### PR TITLE
fix(cli): net.Socket doctor TCP check, drop shell interpolation (config→RCE)

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,7 +2,8 @@ import type { Command } from "commander";
 import chalk from "chalk";
 
 import { type CheckStatus, statusGlyph } from "./doctor-status.js";
-import { execSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import { Socket } from "node:net";
 import {
   accessSync,
   constants as fsConstants,
@@ -91,23 +92,45 @@ function findInNvm(bin: string): string | null {
 }
 
 /**
+ * Walk $PATH looking for an executable named `bin`. Returns the first
+ * executable match or null. Pure filesystem lookup — no shell — so a
+ * caller-supplied `bin` can never be interpreted as shell syntax.
+ *
+ * A bare name is resolved against each $PATH entry; a name that already
+ * contains a slash (absolute or relative path) is tested as-is.
+ */
+function whichOnPath(bin: string): string | null {
+  const isX = (candidate: string): boolean => {
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  if (bin.includes("/")) {
+    return isX(bin) ? bin : null;
+  }
+
+  const pathEnv = process.env.PATH ?? "";
+  for (const dir of pathEnv.split(":")) {
+    if (!dir) continue;
+    const candidate = join(dir, bin);
+    if (isX(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
  * Check whether a binary is on PATH. Returns the resolved path or null.
  *
- * Falls back to scanning ~/.nvm/versions/node/* for nvm-installed binaries
- * since doctor runs in a non-login shell.
+ * Uses a pure $PATH walk (no shell) then falls back to scanning
+ * ~/.nvm/versions/node/* for nvm-installed binaries, since doctor runs in
+ * a non-login shell where nvm.sh has not been sourced.
  */
 function which(bin: string): string | null {
-  try {
-    const out = execSync(`command -v ${bin}`, {
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-      .toString()
-      .trim();
-    if (out) return out;
-  } catch { /* not on PATH */ }
-
-  // Fallback: nvm
-  return findInNvm(bin);
+  return whichOnPath(bin) ?? findInNvm(bin);
 }
 
 function checkBinary(
@@ -129,18 +152,41 @@ function checkBinary(
 
 /**
  * Check that a TCP host:port is reachable. Returns ok/fail.
+ *
+ * Opens a raw `net.Socket` connection with a timeout — NO shell. `host`
+ * comes from `memory.config.url` in switchroom.yaml (attacker-influenceable
+ * in switchroom's threat model: agents are prompt-injectable and can mutate
+ * config), so it must never reach a shell. A hostile value like
+ * `` x`touch /tmp/pwned` `` is just handed to `socket.connect` as a literal
+ * hostname; it fails DNS resolution and returns false rather than executing.
+ *
+ * @internal exported for testing
  */
-function checkTcp(host: string, port: number): boolean {
-  try {
-    // Use bash /dev/tcp redirect — no extra deps
-    execSync(
-      `timeout 2 bash -c '</dev/tcp/${host}/${port}'`,
-      { stdio: ["ignore", "ignore", "ignore"] },
-    );
-    return true;
-  } catch {
-    return false;
-  }
+export function checkTcp(
+  host: string,
+  port: number,
+  timeoutMs = 2000,
+): Promise<boolean> {
+  return new Promise((resolvePromise) => {
+    const socket = new Socket();
+    let settled = false;
+    const done = (reachable: boolean): void => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolvePromise(reachable);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => done(true));
+    socket.once("timeout", () => done(false));
+    socket.once("error", () => done(false));
+    try {
+      socket.connect(port, host);
+    } catch {
+      // Synchronous throw (e.g. invalid port) — treat as unreachable.
+      done(false);
+    }
+  });
 }
 
 function checkDependencies(): CheckResult[] {
@@ -218,16 +264,17 @@ function readVersion(
 ): { semver: SemVer | null; raw: string; path: string } | null {
   const path = which(bin);
   if (!path) return null;
-  try {
-    const raw = execSync(`${path} --version 2>&1`, {
-      stdio: ["ignore", "pipe", "pipe"],
-    })
-      .toString()
-      .trim();
-    return { semver: parser(raw), raw, path };
-  } catch {
-    return null;
-  }
+  // Argv exec — no shell — so `path` (a filesystem lookup result) is never
+  // parsed as shell syntax. Merge stdout+stderr to catch tools that print
+  // their --version banner to stderr (the old `2>&1` behaviour).
+  const proc = spawnSync(path, ["--version"], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (proc.error || proc.status !== 0) return null;
+  const raw = (
+    (proc.stdout?.toString() ?? "") + (proc.stderr?.toString() ?? "")
+  ).trim();
+  return { semver: parser(raw), raw, path };
 }
 
 function checkPythonVersion(): CheckResult {
@@ -1214,7 +1261,7 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   const host = match[1];
   const port = match[2] ? parseInt(match[2], 10) : 80;
 
-  if (!checkTcp(host, port)) {
+  if (!(await checkTcp(host, port))) {
     return [
       {
         name: "hindsight reachable",

--- a/tests/doctor.checktcp.test.ts
+++ b/tests/doctor.checktcp.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { createServer, type Server } from "node:net";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { checkTcp } from "../src/cli/doctor.js";
+
+/**
+ * Regression tests for the config→RCE fix in doctor.ts `checkTcp`.
+ *
+ * The old implementation ran
+ *   execSync(`timeout 2 bash -c '</dev/tcp/${host}/${port}'`)
+ * so a `host` sourced from `memory.config.url` in switchroom.yaml was parsed
+ * by /bin/sh — a shell-injection / RCE path at every `switchroom doctor`.
+ * The fix opens a raw net.Socket, so `host` is only ever a literal hostname.
+ */
+describe("checkTcp — no-shell TCP reachability", () => {
+  const servers: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.splice(0).map(
+        (s) =>
+          new Promise<void>((resolve) => {
+            s.close(() => resolve());
+          }),
+      ),
+    );
+  });
+
+  function listen(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const server = createServer();
+      servers.push(server);
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (addr && typeof addr === "object") resolve(addr.port);
+        else reject(new Error("no port"));
+      });
+    });
+  }
+
+  it("returns true for a listening port", async () => {
+    const port = await listen();
+    await expect(checkTcp("127.0.0.1", port)).resolves.toBe(true);
+  });
+
+  it("returns false for a closed port (clean failure, no throw)", async () => {
+    // Bind then immediately release the port so nothing is listening on it.
+    const port = await listen();
+    await new Promise<void>((resolve) => servers.pop()!.close(() => resolve()));
+    await expect(checkTcp("127.0.0.1", port, 1000)).resolves.toBe(false);
+  });
+
+  it("returns false for a connection-refused port without spawning a shell", async () => {
+    // Port 1 is privileged and unbound in test envs → ECONNREFUSED.
+    await expect(checkTcp("127.0.0.1", 1, 1000)).resolves.toBe(false);
+  });
+
+  it("does NOT execute shell metacharacters embedded in host (RCE guard)", async () => {
+    // This test FAILS against the old `bash -c '</dev/tcp/${host}/...'`
+    // implementation: the backtick command substitution would run `touch`
+    // and create the sentinel. With net.Socket the whole string is a literal
+    // hostname that fails DNS resolution → false, and no file is created.
+    const sentinel = join(
+      tmpdir(),
+      `switchroom-checktcp-pwned-${process.pid}-${Date.now()}`,
+    );
+    rmSync(sentinel, { force: true });
+    try {
+      const hostWithBacktick = "127.0.0.1`touch " + sentinel + "`";
+      const hostWithDollar = "127.0.0.1$(touch " + sentinel + ")";
+
+      const r1 = await checkTcp(hostWithBacktick, 80, 1000);
+      const r2 = await checkTcp(hostWithDollar, 80, 1000);
+
+      expect(r1).toBe(false);
+      expect(r2).toBe(false);
+      // The load-bearing assertion: the injected command never ran.
+      expect(existsSync(sentinel)).toBe(false);
+    } finally {
+      rmSync(sentinel, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Finding

MEDIUM — command injection / config→RCE in `src/cli/doctor.ts` `checkTcp()`
(code review F1; stale-tree-verify Claim C, confirmed at fresh `main`).

`checkTcp(host, port)` ran:

```ts
execSync(`timeout 2 bash -c '</dev/tcp/${host}/${port}'`)
```

`host` is extracted from `memory.config.url` in `switchroom.yaml` via
`/^https?:\/\/([^:/]+):?(\d+)?/` — the host char-class excludes only `:`
and `/`, so backticks, `$()`, single quotes and `;` pass straight into
`/bin/sh`. In switchroom's threat model config is attacker-influenceable
(agents are prompt-injectable and can mutate config via `config_propose_edit`
/ `hostd`), so a `memory.config.url` like `` http://x`touch /tmp/pwned` ``
executes as the operator at **every** `switchroom doctor` run.

## Fix (durable, deterministic — no shell, no interpolation)

- **`checkTcp`** — replaced the `bash /dev/tcp` probe with a raw
  `net.Socket` connect + timeout. A hostile `host` is only ever handed to
  `socket.connect` as a literal hostname; it fails DNS resolution and
  returns `false` rather than executing. Now returns a `Promise<boolean>`;
  the sole caller (`checkHindsight`) already `await`s.
- **F5 hardening (same family, cheap + in scope):**
  - `which()` — dropped `execSync("command -v ${bin}")` for a pure `$PATH`
    walk (`whichOnPath`, `accessSync` + `X_OK`); nvm fallback unchanged.
  - `readVersion()` — dropped `execSync("${path} --version 2>&1")` for
    argv-based `spawnSync`, merging stdout+stderr to preserve banner capture.
- The `execSync` import is removed — **no shell-string exec remains in
  `doctor.ts`**.

## Tests

`tests/doctor.checktcp.test.ts`:
- listening port → `true`
- closed / connection-refused port → clean `false` (no throw)
- **RCE guard:** a `host` containing `` `touch <sentinel>` `` / `$(touch <sentinel>)`
  returns `false` and does **not** create the sentinel file.

The RCE guard **fails against the old `bash -c` implementation** (verified
by temporarily restoring it — the backtick ran `touch` and created the
sentinel) and passes on the fix, so it asserts the outcome, not just the
path.

## Validation

- `./node_modules/.bin/vitest run tests/doctor.checktcp.test.ts tests/doctor.test.ts` → 50 passed, 2 skipped.
- `npm run lint:tsc` (`tsc --noEmit`) → clean (exit 0).
- The `check-plugin-references` lint step fails on **pre-existing** missing
  optional plugin deps (`@mtcute/node`, `mdast-util-*`) in this worktree's
  symlinked `node_modules` — reproduced on clean `HEAD` before this change,
  unrelated to `doctor.ts`. CI has those deps installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)