### PR TITLE
fix(hostd): restrict agent_exec/agent_logs targets to configured agents (singleton-container read)

### DIFF
--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -2232,6 +2232,47 @@ export class HostdServer {
   }
 
   /**
+   * Target guard for the two docker-shell verbs (agent_logs /
+   * agent_exec). Both build the target as `switchroom-${name}` and run
+   * `docker logs`/`docker exec` on it, so `name` MUST be a CONFIGURED
+   * AGENT. Without this an admin caller (checkGate lets an admin target
+   * any name) could pass a SINGLETON service name — `vault-broker`,
+   * `approval-kernel`, `hostd`, `web` — each of which runs as root with
+   * the vault store + /etc/machine-id mounted, and read vault key
+   * material via `docker exec`/`docker logs`. There is no legitimate
+   * agent_exec/agent_logs use case for the singleton containers; the
+   * trust model assumes the target is a peer AGENT container.
+   *
+   * `this.opts.agentUids` is the daemon's configured-agent registry
+   * (name → UID), built at startup from `Object.keys(config.agents)`
+   * (see main.ts) and binding one socket per configured agent — it does
+   * NOT contain any singleton service name. Self-target still passes (a
+   * caller's own name is always in the set); a real peer agent still
+   * passes; only unconfigured names (singletons, typos) are rejected.
+   * Returns a `denied` response to short-circuit the handler, or null
+   * when the target is a configured agent.
+   */
+  private rejectUnconfiguredTarget(
+    name: string,
+    request_id: string,
+    op: string,
+    started: number,
+  ): HostdResponse | null {
+    if (Object.prototype.hasOwnProperty.call(this.opts.agentUids, name)) {
+      return null;
+    }
+    return deniedResponse(
+      request_id,
+      `${op}: "${name}" is not a configured agent. ` +
+        `${op} targets only peer agent containers (switchroom-<agent>); ` +
+        `singleton service containers (vault-broker, approval-kernel, ` +
+        `hostd, web) and unknown names are rejected. Configured agents: ` +
+        `${Object.keys(this.opts.agentUids).sort().join(", ")}.`,
+      Date.now() - started,
+    );
+  }
+
+  /**
    * `docker logs --tail <n> <container>` — synchronous read of a peer
    * container's combined stdout/stderr. The default container name in
    * the switchroom compose project is `switchroom-<agent>`; we shell
@@ -2246,6 +2287,13 @@ export class HostdServer {
     started: number,
   ): Promise<HostdResponse> {
     const tailLines = req.args.tail ?? 100;
+    const rejected = this.rejectUnconfiguredTarget(
+      req.args.name,
+      req.request_id,
+      "agent_logs",
+      started,
+    );
+    if (rejected) return rejected;
     const container = `switchroom-${req.args.name}`;
     const res = await this.runDocker([
       "logs",
@@ -2303,6 +2351,13 @@ export class HostdServer {
         Date.now() - started,
       );
     }
+    const rejected = this.rejectUnconfiguredTarget(
+      req.args.name,
+      req.request_id,
+      "agent_exec",
+      started,
+    );
+    if (rejected) return rejected;
     const container = `switchroom-${req.args.name}`;
     // No `--`. Unlike `docker run`, `docker exec` stops parsing its
     // OWN options at CONTAINER: every token after the container name

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -506,6 +506,116 @@ describe("hostd server — doctor (read-only, admin-gated)", () => {
   });
 });
 
+describe("hostd server — agent_exec/agent_logs target must be a configured agent", () => {
+  // Security-review finding: handleAgentExec/handleAgentLogs build the
+  // docker target as `switchroom-${name}` and shell out to it. checkGate
+  // lets an admin caller target ANY name, so without a membership check
+  // an admin could exec/log into a SINGLETON service container
+  // (vault-broker / approval-kernel / hostd / web) — each root, with the
+  // vault store + /etc/machine-id mounted — and read vault key material.
+  // The guard rejects any name not in the configured-agent registry
+  // (this.opts.agentUids), while self-target and real peers still pass.
+
+  // A docker stub that RECORDS every invocation, so the test can assert
+  // the guard short-circuited BEFORE any `docker exec`/`docker logs` ran.
+  async function withRecordingDocker(): Promise<string> {
+    const invokedLog = join(tmp, `docker-inv-${Math.random().toString(36).slice(2)}.log`);
+    const dockerStub = join(tmp, `docker-tgt-${Math.random().toString(36).slice(2)}.sh`);
+    writeFileSync(dockerStub, `#!/bin/sh\necho "$@" >> ${invokedLog}\nexit 0\n`);
+    chmodSync(dockerStub, 0o755);
+    await server.stop();
+    server = new (await import("../../src/host-control/server.js")).HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: stubBin,
+      dockerBin: dockerStub,
+      auditLogPath: join(tmp, "audit.log"),
+      allowNonLinux: true,
+    });
+    await server.start();
+    // Stash the invocation-log path on the stub name so tests can read it.
+    (withRecordingDocker as unknown as { invokedLog: string }).invokedLog = invokedLog;
+    return dockerStub;
+  }
+
+  it("agent_exec: admin caller targeting the vault-broker singleton is DENIED and never shells out", async () => {
+    await withRecordingDocker();
+    const invokedLog = (withRecordingDocker as unknown as { invokedLog: string }).invokedLog;
+    // klanker IS admin — so this passes checkGate; only the new
+    // configured-agent membership guard can stop it.
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "agent_exec",
+        request_id: "exec-singleton",
+        args: { name: "vault-broker", argv: ["cat", "/etc/machine-id"] },
+      },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/not a configured agent/);
+    // Hard proof no `docker exec` ran against the singleton.
+    expect(existsSync(invokedLog)).toBe(false);
+  });
+
+  it("agent_logs: admin caller targeting the vault-broker singleton is DENIED and never shells out", async () => {
+    await withRecordingDocker();
+    const invokedLog = (withRecordingDocker as unknown as { invokedLog: string }).invokedLog;
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "agent_logs",
+        request_id: "logs-singleton",
+        args: { name: "vault-broker" },
+      },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/not a configured agent/);
+    expect(existsSync(invokedLog)).toBe(false);
+  });
+
+  it("agent_exec: self-target (bob→bob, non-admin) still passes the guard and shells out", async () => {
+    await withRecordingDocker();
+    const invokedLog = (withRecordingDocker as unknown as { invokedLog: string }).invokedLog;
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/bob/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "agent_exec",
+        request_id: "exec-self",
+        args: { name: "bob", argv: ["cat", "/state/agent/start.sh"] },
+      },
+    );
+    expect(resp.result).toBe("completed");
+    // The guard let it through to the docker shell-out.
+    expect(existsSync(invokedLog)).toBe(true);
+    expect(readFileSync(invokedLog, "utf8")).toContain("switchroom-bob");
+  });
+
+  it("agent_logs: admin targeting a real peer agent (klanker→bob) still passes the guard and shells out", async () => {
+    await withRecordingDocker();
+    const invokedLog = (withRecordingDocker as unknown as { invokedLog: string }).invokedLog;
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "agent_logs",
+        request_id: "logs-peer",
+        args: { name: "bob" },
+      },
+    );
+    expect(resp.result).toBe("completed");
+    expect(existsSync(invokedLog)).toBe(true);
+    expect(readFileSync(invokedLog, "utf8")).toContain("switchroom-bob");
+  });
+});
+
 describe("hostd server — agent_smoke (read-only in-agent battery)", () => {
   async function withDocker(stubBody: string): Promise<string> {
     const dockerStub = join(tmp, `docker-smoke-${Math.random().toString(36).slice(2)}.sh`);


### PR DESCRIPTION
## Summary

Security-hardening fix: `hostd`'s `agent_exec` and `agent_logs` verbs build their docker target as `switchroom-${req.args.name}` and shell out to `docker exec` / `docker logs`, but neither validated that `name` is a **configured agent**. `checkGate` (`src/host-control/server.ts` ~1297-1311) lets an admin caller cross-agent-target any name, so an admin agent could target a **singleton service container** — `vault-broker`, `approval-kernel`, `hostd`, `web` — each of which runs as root with the vault store + `/etc/machine-id` mounted, and read vault key material through the docker shell-out. There is no legitimate `agent_exec`/`agent_logs` use case for the singletons; the trust model assumes the target is a peer AGENT container.

## Why

Found in a hostd security-hardening review as the cheap, deterministic close on the accepted admin-tier residual: an admin agent is trusted to inspect *peer agents*, not to reach into the singleton containers that hold vault key material. This is a membership check the code can enforce, so it should not be left to prompt discipline.

## Fix

- New `rejectUnconfiguredTarget(name, request_id, op, started)` guard applied to **both** handlers, before the `switchroom-${name}` container string is constructed.
- It checks `name` against `this.opts.agentUids` — the daemon's configured-agent registry (name → UID), built at startup from `Object.keys(config.agents)` (`main.ts:144-146`) and containing no singleton service name.
- **Self-target still passes** (a caller's own name is always in the set); a real peer agent still passes; only unconfigured names (singletons, typos) are rejected with a clear `denied` response.
- Scope is deliberately just the membership check — no change to `RESERVED_AGENT_NAMES` or the deferred approval-kernel `host_os.exec` scope.

## Test plan

- `tests/host-control/server.test.ts` — new describe block asserting the **outcome**:
  - admin caller (`klanker`) targeting `name="vault-broker"` is **DENIED** for both `agent_exec` and `agent_logs`, and a recording docker stub proves it **never shells out**;
  - self-target (`bob`→`bob`, non-admin) and real peer (`klanker`→`bob`, admin) still pass the guard and reach the docker shell-out.
- Verified the deny tests **fail without the guard** (the singleton targeting is not denied on the un-patched handler).
- Scoped: `vitest run tests/host-control/server.test.ts -t "target must be a configured agent"` → 4 passed.
- `npm run lint` → clean (tsc + all 8 guard scripts).

## Risk

Low. Read-only-verb hardening; the only behaviour change is rejecting targets that were never a legitimate use case. No change to self-target or peer-agent targeting.

Job spec: `reference/jobs/operate-the-fleet-from-telegram.md`
Invariants: no-self-escalation, single-tenant

Found-in: hostd security-hardening review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)