### PR TITLE
fix(worktree): refresh heartbeat + fail-safe reaper to prevent live-worktree deletion

### DIFF
--- a/src/cli/worktree.ts
+++ b/src/cli/worktree.ts
@@ -15,7 +15,7 @@ import chalk from "chalk";
 import { claimWorktree } from "../worktree/claim.js";
 import { releaseWorktree } from "../worktree/release.js";
 import { listWorktrees } from "../worktree/list.js";
-import { runReaper } from "../worktree/reaper.js";
+import { runReaper, planReaper, reapSkipReasonText } from "../worktree/reaper.js";
 import {
   planGc,
   applyGc,
@@ -108,11 +108,18 @@ export function registerWorktreeCommand(program: Command): void {
         return;
       }
       console.log(chalk.bold(`${worktrees.length} active worktree(s):\n`));
+      // Stale = heartbeat older than the reaper's threshold (a live claim
+      // refreshes its heartbeat from the gateway watch loop, so a stale one is
+      // reap-eligible — subject to the reaper's dirty/in-use fail-safes).
+      const STALE_MS = 10 * 60 * 1000;
       for (const wt of worktrees) {
         const hbAge = Math.round(wt.heartbeatAgeSeconds / 60);
+        const isStale = wt.heartbeatAgeSeconds * 1000 > STALE_MS;
         const fresh = wt.heartbeatAgeSeconds < 120
           ? chalk.green("fresh")
-          : chalk.yellow(`${hbAge}m ago`);
+          : isStale
+            ? chalk.red(`${hbAge}m ago — STALE (reap-eligible; kept if dirty/in-use)`)
+            : chalk.yellow(`${hbAge}m ago`);
         console.log(`  ${chalk.bold(wt.id)}`);
         console.log(`    repo:    ${wt.repoName} (${wt.repo})`);
         console.log(`    branch:  ${wt.branch}`);
@@ -127,26 +134,63 @@ export function registerWorktreeCommand(program: Command): void {
 
   worktree
     .command("reap")
-    .description("Run the reaper — remove stale/orphaned worktrees")
+    .description(
+      "Run the reaper — remove stale/orphaned worktrees.\n" +
+        "A stale worktree with UNCOMMITTED changes is NEVER auto-deleted; it is\n" +
+        "reported as skipped. Clear it manually: inspect, commit/salvage, then\n" +
+        "`switchroom worktree release <id>` (or `git worktree remove <path>`).",
+    )
     .option("--dry-run", "Show what would be reaped without acting")
     .option("--json", "Output raw JSON")
     .action((opts: { dryRun?: boolean; json?: boolean }) => {
       if (opts.dryRun) {
-        // Show stale records without acting
-        const { worktrees } = listWorktrees();
-        const STALE_MS = 10 * 60 * 1000;
-        const stale = worktrees.filter(
-          w => w.heartbeatAgeSeconds * 1000 > STALE_MS,
+        // L1 fix: route the dry-run through the SAME predicate as the real
+        // reaper (planReaper) so its output matches what a real run would do —
+        // the dirty + probe guards are applied here too, not just heartbeat
+        // age (which used to over-report dirty/in-use worktrees as reapable).
+        const plan = planReaper();
+        const wouldReap = plan.filter(
+          e => e.action === "reap" || e.action === "reap-orphan",
         );
+        const wouldSkip = plan.filter(e => e.action.startsWith("skip-"));
         if (opts.json) {
-          console.log(JSON.stringify({ would_reap: stale.map(w => w.id) }));
+          console.log(
+            JSON.stringify({
+              would_reap: wouldReap.map(e => e.record.id),
+              would_skip: wouldSkip.map(e => ({
+                id: e.record.id,
+                reason: e.action,
+              })),
+            }),
+          );
+        } else if (wouldReap.length === 0 && wouldSkip.length === 0) {
+          console.log("No stale worktrees found.");
         } else {
-          if (stale.length === 0) {
-            console.log("No stale worktrees found.");
-          } else {
-            console.log(chalk.yellow(`Would reap ${stale.length} worktree(s):`));
-            for (const w of stale) {
-              console.log(`  ${w.id} — ${w.branch}`);
+          if (wouldReap.length > 0) {
+            console.log(chalk.yellow(`Would reap ${wouldReap.length} worktree(s):`));
+            for (const e of wouldReap) {
+              console.log(`  ${e.record.id} — ${e.record.branch}`);
+            }
+          }
+          if (wouldSkip.length > 0) {
+            console.log(
+              chalk.yellow(
+                `${wouldReap.length > 0 ? "\n" : ""}Would SKIP ${wouldSkip.length} stale worktree(s) (kept for safety):`,
+              ),
+            );
+            for (const e of wouldSkip) {
+              console.log(
+                `  ${e.record.id} — ${e.record.branch} — would skip (${reapSkipReasonText(e.action)})`,
+              );
+            }
+            if (wouldSkip.some(e => e.action === "skip-dirty")) {
+              console.log(
+                chalk.dim(
+                  "\n  Dirty worktrees are never auto-removed. Clear one manually:\n" +
+                    "  inspect, commit/salvage, then `switchroom worktree release <id>`\n" +
+                    "  (or `git worktree remove <path>`).",
+                ),
+              );
             }
           }
         }
@@ -162,8 +206,27 @@ export function registerWorktreeCommand(program: Command): void {
         } else {
           console.log(chalk.green(`Reaped ${result.reaped.length} worktree(s): ${result.reaped.join(", ")}`));
         }
-        for (const w of result.warnings) {
-          console.warn(chalk.yellow(w));
+        // M2: surface stale-but-kept worktrees so the never-auto-delete-dirty
+        // policy doesn't let them accumulate invisibly.
+        if (result.skipped.length > 0) {
+          console.log(
+            chalk.yellow(`\nSkipped ${result.skipped.length} stale worktree(s) (kept for safety):`),
+          );
+          for (const s of result.skipped) {
+            console.log(
+              chalk.yellow(`  ${s.record.id} — ${reapSkipReasonText(s.action)} — ${s.record.path}`),
+            );
+          }
+          const dirty = result.skipped.filter(s => s.action === "skip-dirty");
+          if (dirty.length > 0) {
+            console.log(
+              chalk.dim(
+                `\n  ${dirty.length} worktree(s) have UNCOMMITTED changes and will NOT be\n` +
+                  "  auto-removed. Inspect, commit/salvage, then\n" +
+                  "  `switchroom worktree release <id>` (or `git worktree remove <path>`).",
+              ),
+            );
+          }
         }
       }
     });

--- a/src/worktree/reaper.ts
+++ b/src/worktree/reaper.ts
@@ -3,24 +3,51 @@
  *
  * Reaper logic (liveness-based, NOT age-based):
  *   - A claim is stale when heartbeatAt is older than STALE_THRESHOLD_MS
- *     AND no process holds the worktree path open (fuser check).
+ *     AND we can PROVE the worktree path is not held by any live process.
  *   - A claim is an orphan when the registry record exists but the
- *     filesystem worktree doesn't, or vice versa.
+ *     filesystem worktree doesn't (a dangling record).
  *
- * On reap:
- *   1. Run git worktree remove --force.
- *   2. Delete the registry record.
- *   3. If the worktree had uncommitted changes, emit a warning to stderr
- *      (callers can forward this to Telegram).
+ * FAIL-SAFE by construction (data-loss prevention, F1/H3):
+ *   The reaper's whole job is to remove a *dead* claim's worktree with
+ *   `git worktree remove --force`, which discards any working-tree state.
+ *   That force-remove is only ever run when EVERY one of these holds:
+ *     1. the heartbeat is stale (> STALE_THRESHOLD_MS), AND
+ *     2. the worktree has NO uncommitted changes (a hard skip — never a
+ *        mere warning: we do not destroy in-flight work), AND
+ *     3. an in-use probe can DEFINITIVELY report the path as free.
+ *   If the in-use probe is unavailable (neither `fuser` nor `lsof` is
+ *   installed) we treat the path as live and keep it — "can't prove it's
+ *   idle" must never license a force-remove. A live claim advances its own
+ *   heartbeat (see registry.touchHeartbeat, refreshed from the gateway's
+ *   watch loop), so a genuinely-abandoned claim is the only thing that
+ *   reaches the stale branch in the first place.
  */
 
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { listRecords, deleteRecord } from "./registry.js";
-import type { WorktreeRecord } from "./types.js";
 
 /** Heartbeat age threshold in ms. Claims older than this are stale. */
 export const STALE_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Result of probing whether a path is held open by a live process.
+ *   - "in-use"      — a probe positively found a holder → keep the claim.
+ *   - "free"        — a probe ran and found NO holder → safe to consider reap.
+ *   - "unavailable" — NO probe tool is installed → we cannot tell, so the
+ *                     reaper treats the path as live (fail-safe) and keeps it.
+ */
+export type PathUseState = "in-use" | "free" | "unavailable";
+
+/** Injectable dependencies for `runReaper` (defaults use the real probes). */
+export interface ReaperDeps {
+  /** Probe whether the worktree path is held open by a live process. */
+  probeInUse?: (path: string) => PathUseState;
+  /** Detect uncommitted (staged or unstaged) changes in the worktree. */
+  hasUncommittedChanges?: (repoPath: string, worktreePath: string) => boolean;
+  /** Force-remove the worktree (defaults to `git worktree remove --force`). */
+  removeWorktree?: (repoPath: string, worktreePath: string) => void;
+}
 
 export interface ReapResult {
   reaped: string[];
@@ -28,44 +55,60 @@ export interface ReapResult {
 }
 
 /**
- * Check whether any process holds the worktree path open.
+ * Probe whether any process holds the worktree path open.
  *
- * Tries `fuser` (Linux/procps) first, then `lsof` (macOS/BSD). Returns
- * false if neither probe finds a holder OR if neither tool is installed.
+ * Tries `fuser` (Linux/procps) first, then `lsof` (macOS/BSD).
  *
- * Note: a false negative (returns false but a process actually has files
- * open) means the reaper can fall through to heartbeat-only stale logic.
- * That's acceptable — the spec allows reaping on stale heartbeat alone
- * for hosts where process-liveness can't be probed.
+ * Crucially, this distinguishes "the probe RAN and found nothing" (→ "free")
+ * from "the probe tool is not installed" (→ "unavailable"). A missing binary
+ * surfaces as a spawn `ENOENT`; a real "path not in use" surfaces as a
+ * non-zero *exit* (no `ENOENT`). The reaper must never force-remove on the
+ * strength of an "unavailable" result — that was the F1 data-loss hole where
+ * a host without fuser/lsof reaped live worktrees.
  */
-function isPathInUse(path: string): boolean {
-  // fuser: Linux. Exits 0 when the path is in use; non-zero (or ENOENT
-  // if not installed) otherwise.
+export function probePathInUse(path: string): PathUseState {
+  let probeRan = false;
+
+  // fuser: exits 0 when the path is in use; non-zero when not; ENOENT when
+  // the binary itself is missing.
   try {
     execFileSync("fuser", [path], { stdio: "pipe" });
-    return true;
-  } catch {
-    /* fuser missing or path not in use — fall through to lsof */
+    return "in-use";
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      // fuser ran and exited non-zero → path not in use (per fuser).
+      probeRan = true;
+    }
   }
-  // lsof: macOS / BSD. Exits 0 with PID output when in use.
+
+  // lsof: exits 0 with PID output when in use; exits 1 (non-ENOENT) when not.
   try {
     const out = execFileSync("lsof", ["-t", path], {
       stdio: ["ignore", "pipe", "ignore"],
     })
       .toString()
       .trim();
-    if (out.length > 0) return true;
-  } catch {
-    /* lsof missing or path not in use */
+    probeRan = true;
+    if (out.length > 0) return "in-use";
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      // lsof ran and found nothing (exit 1) → not in use (per lsof).
+      probeRan = true;
+    }
   }
-  return false;
+
+  return probeRan ? "free" : "unavailable";
 }
 
 /**
  * Check if a worktree has uncommitted changes.
  * Returns true if there are staged or unstaged changes.
+ *
+ * On ANY error running git (path is not a git worktree, git missing, etc.)
+ * we return `true` — "can't tell" must fail toward preservation, never toward
+ * a force-remove.
  */
-function hasUncommittedChanges(repoPath: string, worktreePath: string): boolean {
+function hasUncommittedChanges(_repoPath: string, worktreePath: string): boolean {
   try {
     const out = execFileSync(
       "git",
@@ -74,49 +117,37 @@ function hasUncommittedChanges(repoPath: string, worktreePath: string): boolean 
     ).toString();
     return out.trim().length > 0;
   } catch {
-    return false;
+    // Can't determine cleanliness → assume dirty so we never force-remove
+    // work we failed to inspect.
+    return true;
   }
 }
 
-/**
- * Reap a single stale/orphan record.
- * Returns a warning string if there were uncommitted changes, otherwise null.
- */
-function reapRecord(record: WorktreeRecord): string | null {
-  const { id, path, repo, branch, ownerAgent } = record;
-
-  let warning: string | null = null;
-
-  if (existsSync(path)) {
-    // Check for uncommitted changes before removing
-    if (hasUncommittedChanges(repo, path)) {
-      warning =
-        `[worktree-reaper] Reaped worktree with uncommitted changes: ` +
-        `id=${id} branch=${branch} agent=${ownerAgent ?? "unknown"} path=${path}`;
-    }
-
-    try {
-      execFileSync("git", ["worktree", "remove", "--force", path], {
-        cwd: repo,
-        stdio: "pipe",
-      });
-    } catch {
-      // If git remove fails, still clean up the record.
-      // The path may have been manually deleted.
-    }
+/** Default force-remove: `git worktree remove --force <path>` from the repo. */
+function defaultRemoveWorktree(repoPath: string, worktreePath: string): void {
+  try {
+    execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
+      cwd: repoPath,
+      stdio: "pipe",
+    });
+  } catch {
+    // If git remove fails, the caller still deletes the record. The path may
+    // have been manually deleted or the repo moved.
   }
-
-  deleteRecord(id);
-  return warning;
 }
 
 /**
  * Run the reaper pass.
  *
  * @param nowMs Optional override for "now" (for testing).
+ * @param deps  Optional injectable probes (for testing / host portability).
  */
-export function runReaper(nowMs?: number): ReapResult {
+export function runReaper(nowMs?: number, deps: ReaperDeps = {}): ReapResult {
   const now = nowMs ?? Date.now();
+  const probeInUse = deps.probeInUse ?? probePathInUse;
+  const uncommitted = deps.hasUncommittedChanges ?? hasUncommittedChanges;
+  const removeWorktree = deps.removeWorktree ?? defaultRemoveWorktree;
+
   const records = listRecords();
 
   const reaped: string[] = [];
@@ -127,20 +158,50 @@ export function runReaper(nowMs?: number): ReapResult {
     const worktreeExists = existsSync(record.path);
 
     // Case 1: Orphan — registry record exists but filesystem worktree doesn't.
-    // Clean up the dangling record.
+    // Nothing to force-remove; just drop the dangling record.
     if (!worktreeExists) {
       deleteRecord(record.id);
       reaped.push(record.id);
       continue;
     }
 
-    // Case 2: Stale heartbeat AND path not in use → reap.
-    if (heartbeatAge > STALE_THRESHOLD_MS && !isPathInUse(record.path)) {
-      const warning = reapRecord(record);
-      if (warning) warnings.push(warning);
-      reaped.push(record.id);
+    // Not stale yet → live claim, keep it.
+    if (heartbeatAge <= STALE_THRESHOLD_MS) continue;
+
+    // ── Stale + worktree present: run the fail-safe gauntlet before any
+    //    `git worktree remove --force`. Only reap when ALL guards clear. ──
+
+    // Fail-safe 1: NEVER destroy uncommitted work. Hard skip (not a warning
+    // that proceeds to remove — that was the F1/H3 data-loss bug).
+    if (uncommitted(record.repo, record.path)) {
+      warnings.push(
+        `[worktree-reaper] SKIPPED stale worktree with UNCOMMITTED changes ` +
+          `(not removed — preserving in-flight work): id=${record.id} ` +
+          `branch=${record.branch} agent=${record.ownerAgent ?? "unknown"} ` +
+          `path=${record.path}`,
+      );
       continue;
     }
+
+    // Fail-safe 2: only reap when the path is DEFINITIVELY free. Both
+    // "in-use" and "unavailable" (no fuser/lsof to prove idleness) mean we
+    // cannot show the worktree is dead → keep it.
+    const use = probeInUse(record.path);
+    if (use !== "free") {
+      if (use === "unavailable") {
+        warnings.push(
+          `[worktree-reaper] SKIPPED stale worktree — in-use probe ` +
+            `unavailable (neither fuser nor lsof installed); treating as ` +
+            `live: id=${record.id} path=${record.path}`,
+        );
+      }
+      continue;
+    }
+
+    // All guards cleared: stale, clean, and provably not in use → reap.
+    removeWorktree(record.repo, record.path);
+    deleteRecord(record.id);
+    reaped.push(record.id);
   }
 
   return { reaped, warnings };

--- a/src/worktree/reaper.ts
+++ b/src/worktree/reaper.ts
@@ -21,11 +21,26 @@
  *   heartbeat (see registry.touchHeartbeat, refreshed from the gateway's
  *   watch loop), so a genuinely-abandoned claim is the only thing that
  *   reaches the stale branch in the first place.
+ *
+ * OPERATIONAL NOTE — dead-but-dirty worktrees are KEPT, not auto-deleted.
+ *   Because fail-safe 2 hard-skips any stale worktree with uncommitted
+ *   changes, a truly-abandoned claim whose tree is dirty is never reaped
+ *   automatically — by design, so in-flight work is never destroyed. The
+ *   trade-off is that such worktrees accumulate until a human clears them.
+ *   The reaper therefore makes the skip VISIBLE: `runReaper` returns them in
+ *   `ReapResult.skipped` (and `switchroom worktree reap` / `reap --dry-run`
+ *   print them with a reason). The manual remediation for a dirty skip is:
+ *     1. inspect the worktree (`git -C <path> status`),
+ *     2. commit or salvage the work,
+ *     3. release it: `switchroom worktree release <id>`  (or, if the record
+ *        is already gone, `git worktree remove <path>`).
+ *   There is deliberately NO auto-delete of a dirty tree.
  */
 
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { listRecords, deleteRecord } from "./registry.js";
+import type { WorktreeRecord } from "./types.js";
 
 /** Heartbeat age threshold in ms. Claims older than this are stale. */
 export const STALE_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
@@ -52,6 +67,55 @@ export interface ReaperDeps {
 export interface ReapResult {
   reaped: string[];
   warnings: string[];
+  /**
+   * Stale worktrees that were KEPT (not reaped) because a fail-safe guard
+   * fired — dirty tree, in-use, or an unavailable probe. Surfaced so the
+   * consequence of the never-auto-delete-dirty policy is visible instead of
+   * silently accumulating. (M2.)
+   */
+  skipped: ReapPlanEntry[];
+}
+
+/**
+ * The decision the reaper reaches for a single record. Both `runReaper` (the
+ * real pass) and `switchroom worktree reap --dry-run` route through the SAME
+ * predicate (`planReaper`) so a dry-run reports EXACTLY what a real run would
+ * do — the dirty / probe guards are applied in both, not just the real run
+ * (L1: dry-run used to over-report by looking at heartbeat age alone).
+ */
+export type ReapAction =
+  /** Registry record with no filesystem worktree → drop the dangling record. */
+  | "reap-orphan"
+  /** Stale + clean + provably free → force-remove the worktree. */
+  | "reap"
+  /** Heartbeat still fresh → live claim, untouched. */
+  | "keep-fresh"
+  /** Stale but has uncommitted changes → preserve (never auto-delete dirty). */
+  | "skip-dirty"
+  /** Stale + clean but no fuser/lsof to prove it idle → treat as live. */
+  | "skip-probe-unavailable"
+  /** Stale + clean but the probe positively found a holder → keep. */
+  | "skip-in-use";
+
+export interface ReapPlanEntry {
+  record: WorktreeRecord;
+  action: ReapAction;
+  /** Human-readable line (used for warnings and dry-run output). */
+  message: string;
+}
+
+/** Short, user-facing reason for a `skip-*` action (CLI + dry-run output). */
+export function reapSkipReasonText(action: ReapAction): string {
+  switch (action) {
+    case "skip-dirty":
+      return "uncommitted changes";
+    case "skip-probe-unavailable":
+      return "cannot verify not in use";
+    case "skip-in-use":
+      return "in use by a live process";
+    default:
+      return action;
+  }
 }
 
 /**
@@ -137,49 +201,60 @@ function defaultRemoveWorktree(repoPath: string, worktreePath: string): void {
 }
 
 /**
- * Run the reaper pass.
+ * Classify every registry record into the action the reaper would take,
+ * WITHOUT mutating anything. This is the single source of truth for the
+ * reaper's decision — `runReaper` executes the plan and the CLI dry-run
+ * merely reports it, so the two can never diverge (L1).
  *
  * @param nowMs Optional override for "now" (for testing).
  * @param deps  Optional injectable probes (for testing / host portability).
  */
-export function runReaper(nowMs?: number, deps: ReaperDeps = {}): ReapResult {
+export function planReaper(nowMs?: number, deps: ReaperDeps = {}): ReapPlanEntry[] {
   const now = nowMs ?? Date.now();
   const probeInUse = deps.probeInUse ?? probePathInUse;
   const uncommitted = deps.hasUncommittedChanges ?? hasUncommittedChanges;
-  const removeWorktree = deps.removeWorktree ?? defaultRemoveWorktree;
 
-  const records = listRecords();
+  const plan: ReapPlanEntry[] = [];
 
-  const reaped: string[] = [];
-  const warnings: string[] = [];
-
-  for (const record of records) {
+  for (const record of listRecords()) {
     const heartbeatAge = now - new Date(record.heartbeatAt).getTime();
     const worktreeExists = existsSync(record.path);
 
     // Case 1: Orphan — registry record exists but filesystem worktree doesn't.
     // Nothing to force-remove; just drop the dangling record.
     if (!worktreeExists) {
-      deleteRecord(record.id);
-      reaped.push(record.id);
+      plan.push({
+        record,
+        action: "reap-orphan",
+        message: `[worktree-reaper] orphan record (no worktree on disk): id=${record.id} path=${record.path}`,
+      });
       continue;
     }
 
     // Not stale yet → live claim, keep it.
-    if (heartbeatAge <= STALE_THRESHOLD_MS) continue;
+    if (heartbeatAge <= STALE_THRESHOLD_MS) {
+      plan.push({ record, action: "keep-fresh", message: "" });
+      continue;
+    }
 
     // ── Stale + worktree present: run the fail-safe gauntlet before any
     //    `git worktree remove --force`. Only reap when ALL guards clear. ──
 
     // Fail-safe 1: NEVER destroy uncommitted work. Hard skip (not a warning
-    // that proceeds to remove — that was the F1/H3 data-loss bug).
+    // that proceeds to remove — that was the F1/H3 data-loss bug). The skip is
+    // surfaced with the manual remediation path (M2) so dirty worktrees don't
+    // silently accumulate.
     if (uncommitted(record.repo, record.path)) {
-      warnings.push(
-        `[worktree-reaper] SKIPPED stale worktree with UNCOMMITTED changes ` +
+      plan.push({
+        record,
+        action: "skip-dirty",
+        message:
+          `[worktree-reaper] SKIPPED stale worktree with UNCOMMITTED changes ` +
           `(not removed — preserving in-flight work): id=${record.id} ` +
           `branch=${record.branch} agent=${record.ownerAgent ?? "unknown"} ` +
-          `path=${record.path}`,
-      );
+          `path=${record.path} — remediation: inspect, commit/salvage, then ` +
+          `\`switchroom worktree release ${record.id}\` (or \`git worktree remove ${record.path}\`)`,
+      });
       continue;
     }
 
@@ -187,22 +262,79 @@ export function runReaper(nowMs?: number, deps: ReaperDeps = {}): ReapResult {
     // "in-use" and "unavailable" (no fuser/lsof to prove idleness) mean we
     // cannot show the worktree is dead → keep it.
     const use = probeInUse(record.path);
-    if (use !== "free") {
-      if (use === "unavailable") {
-        warnings.push(
+    if (use === "unavailable") {
+      plan.push({
+        record,
+        action: "skip-probe-unavailable",
+        message:
           `[worktree-reaper] SKIPPED stale worktree — in-use probe ` +
-            `unavailable (neither fuser nor lsof installed); treating as ` +
-            `live: id=${record.id} path=${record.path}`,
-        );
-      }
+          `unavailable (neither fuser nor lsof installed); treating as ` +
+          `live: id=${record.id} path=${record.path}`,
+      });
+      continue;
+    }
+    if (use === "in-use") {
+      plan.push({
+        record,
+        action: "skip-in-use",
+        message:
+          `[worktree-reaper] kept stale worktree held open by a live process: ` +
+          `id=${record.id} path=${record.path}`,
+      });
       continue;
     }
 
     // All guards cleared: stale, clean, and provably not in use → reap.
-    removeWorktree(record.repo, record.path);
-    deleteRecord(record.id);
-    reaped.push(record.id);
+    plan.push({
+      record,
+      action: "reap",
+      message: `[worktree-reaper] reaping stale worktree: id=${record.id} path=${record.path}`,
+    });
   }
 
-  return { reaped, warnings };
+  return plan;
+}
+
+/**
+ * Run the reaper pass — execute the plan from `planReaper`.
+ *
+ * @param nowMs Optional override for "now" (for testing).
+ * @param deps  Optional injectable probes (for testing / host portability).
+ */
+export function runReaper(nowMs?: number, deps: ReaperDeps = {}): ReapResult {
+  const removeWorktree = deps.removeWorktree ?? defaultRemoveWorktree;
+  const plan = planReaper(nowMs, deps);
+
+  const reaped: string[] = [];
+  const warnings: string[] = [];
+  const skipped: ReapPlanEntry[] = [];
+
+  for (const entry of plan) {
+    switch (entry.action) {
+      case "reap-orphan":
+        deleteRecord(entry.record.id);
+        reaped.push(entry.record.id);
+        break;
+      case "reap":
+        removeWorktree(entry.record.repo, entry.record.path);
+        deleteRecord(entry.record.id);
+        reaped.push(entry.record.id);
+        break;
+      case "keep-fresh":
+        break;
+      case "skip-dirty":
+      case "skip-probe-unavailable":
+        // These two carry an operator-facing warning (backward-compatible with
+        // the pre-M2 behaviour); an in-use skip is expected/benign and is only
+        // reported via `skipped`, not `warnings`.
+        warnings.push(entry.message);
+        skipped.push(entry);
+        break;
+      case "skip-in-use":
+        skipped.push(entry);
+        break;
+    }
+  }
+
+  return { reaped, warnings, skipped };
 }

--- a/src/worktree/registry.ts
+++ b/src/worktree/registry.ts
@@ -92,10 +92,31 @@ export function listRecords(): WorktreeRecord[] {
 /**
  * Update the heartbeat timestamp for a claim.
  * No-op if the record doesn't exist.
+ *
+ * Concurrency (L2): this is a read-modify-write, and it now has a production
+ * caller (the gateway's watch loop) that can run concurrently with a CLI
+ * `worktree release` (which calls `deleteRecord`). If a `deleteRecord` lands
+ * between our read and our write, a naive write would RESURRECT the just-
+ * released record as a zombie claim. To close that common window we re-verify
+ * the record file still exists immediately before writing, and skip the write
+ * if it's gone.
+ *
+ * A tiny TOCTOU window remains between the `recordExists` check and the
+ * `renameSync` inside `writeRecord`; fully closing it would require file
+ * locking, which is out of scope here. This check eliminates the realistic
+ * race (a release completing during a heartbeat refresh) at near-zero cost.
+ *
+ * `onAfterRead` is a test seam: it fires after the record is read but before
+ * the existence re-check, so a test can deterministically simulate a delete
+ * landing in the race window. Production callers never pass it.
  */
-export function touchHeartbeat(id: string): void {
+export function touchHeartbeat(id: string, onAfterRead?: () => void): void {
   const rec = readRecord(id);
   if (!rec) return;
+  onAfterRead?.();
+  // Re-verify the record still exists just before writing — a concurrent
+  // deleteRecord must not be undone by resurrecting the file below.
+  if (!recordExists(id)) return;
   writeRecord({ ...rec, heartbeatAt: new Date().toISOString() });
 }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -691,8 +691,8 @@ import {
   startSubagentWatcher,
   type SubagentWatcherHandle,
 } from '../subagent-watcher.js'
-import { listRecords as listWorktreeRecords } from '../../src/worktree/registry.js'
-import { ownedWorktreeCwds } from '../worktree-watch-cwds.js'
+import { listRecords as listWorktreeRecords, touchHeartbeat as touchWorktreeHeartbeat } from '../../src/worktree/registry.js'
+import { ownedWorktreeCwds, refreshOwnedWorktreeHeartbeats } from '../worktree-watch-cwds.js'
 import {
   startBootCard,
   resolvePersonaName,
@@ -28740,13 +28740,34 @@ void (async () => {
               // Best-effort: a registry read failure (e.g. no worktree dir
               // on an agent that never claims one) must not affect the
               // primary agentCwd watch.
-              extraWatchCwdsProvider: () =>
+              extraWatchCwdsProvider: () => {
+                // F1/H3 fix: on the SAME rescan tick that re-derives the
+                // watched worktree cwds, advance the heartbeat of every
+                // worktree THIS agent owns. This is the production driver
+                // that keeps `touchHeartbeat` alive (it had ZERO callers, so
+                // every claim read "stale" 10 min after creation and the
+                // reaper's staleness guarantee collapsed). A claim held by a
+                // live gateway now stays fresh; when the gateway dies the
+                // ticks stop and the heartbeat ages out for the reaper.
+                // Throttled internally (≤ every 2 min per record) and fully
+                // best-effort — it never throws out of the provider.
+                refreshOwnedWorktreeHeartbeats({
+                  self: process.env.SWITCHROOM_AGENT_NAME,
+                  agentDir:
+                    process.env.SWITCHROOM_WORKTREE_IDENTITY_FALLBACK === '0'
+                      ? undefined
+                      : watcherAgentDir,
+                  listRecords: listWorktreeRecords,
+                  touchHeartbeat: touchWorktreeHeartbeat,
+                  log: (msg) =>
+                    process.stderr.write(`telegram gateway: ${msg}\n`),
+                });
                 // Fail-CLOSED ownership filter (unset identity ⇒ nothing;
                 // ownerless records excluded; registry throw ⇒ []). Extracted
                 // to telegram-plugin/worktree-watch-cwds.ts so the #1116 /
                 // Gap-2 ownership predicate is under direct unit test — see
                 // telegram-plugin/tests/worktree-watch-cwds.test.ts.
-                ownedWorktreeCwds({
+                return ownedWorktreeCwds({
                   self: process.env.SWITCHROOM_AGENT_NAME,
                   listRecords: listWorktreeRecords,
                   // Durable, non-env identity fallback (#1116 / #2893): when
@@ -28763,7 +28784,8 @@ void (async () => {
                       : watcherAgentDir,
                   log: (msg) =>
                     process.stderr.write(`telegram gateway: ${msg}\n`),
-                }),
+                });
+              },
               // Bug 0 fix: previously omitted, leaving the watcher unable to
               // write liveness/stall/turn_end updates to the registry DB.
               // Liveness writes are now persisted across the gateway lifetime.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -692,7 +692,7 @@ import {
   type SubagentWatcherHandle,
 } from '../subagent-watcher.js'
 import { listRecords as listWorktreeRecords, touchHeartbeat as touchWorktreeHeartbeat } from '../../src/worktree/registry.js'
-import { ownedWorktreeCwds, refreshOwnedWorktreeHeartbeats } from '../worktree-watch-cwds.js'
+import { makeWorktreeWatchProvider } from '../worktree-watch-cwds.js'
 import {
   startBootCard,
   resolvePersonaName,
@@ -28740,52 +28740,41 @@ void (async () => {
               // Best-effort: a registry read failure (e.g. no worktree dir
               // on an agent that never claims one) must not affect the
               // primary agentCwd watch.
-              extraWatchCwdsProvider: () => {
-                // F1/H3 fix: on the SAME rescan tick that re-derives the
-                // watched worktree cwds, advance the heartbeat of every
-                // worktree THIS agent owns. This is the production driver
-                // that keeps `touchHeartbeat` alive (it had ZERO callers, so
-                // every claim read "stale" 10 min after creation and the
-                // reaper's staleness guarantee collapsed). A claim held by a
-                // live gateway now stays fresh; when the gateway dies the
-                // ticks stop and the heartbeat ages out for the reaper.
-                // Throttled internally (≤ every 2 min per record) and fully
-                // best-effort — it never throws out of the provider.
-                refreshOwnedWorktreeHeartbeats({
-                  self: process.env.SWITCHROOM_AGENT_NAME,
-                  agentDir:
-                    process.env.SWITCHROOM_WORKTREE_IDENTITY_FALLBACK === '0'
-                      ? undefined
-                      : watcherAgentDir,
-                  listRecords: listWorktreeRecords,
-                  touchHeartbeat: touchWorktreeHeartbeat,
-                  log: (msg) =>
-                    process.stderr.write(`telegram gateway: ${msg}\n`),
-                });
-                // Fail-CLOSED ownership filter (unset identity ⇒ nothing;
-                // ownerless records excluded; registry throw ⇒ []). Extracted
-                // to telegram-plugin/worktree-watch-cwds.ts so the #1116 /
-                // Gap-2 ownership predicate is under direct unit test — see
-                // telegram-plugin/tests/worktree-watch-cwds.test.ts.
-                return ownedWorktreeCwds({
-                  self: process.env.SWITCHROOM_AGENT_NAME,
-                  listRecords: listWorktreeRecords,
-                  // Durable, non-env identity fallback (#1116 / #2893): when
-                  // SWITCHROOM_AGENT_NAME is somehow unset, derive this
-                  // agent's own identity from its own directory so worktree
-                  // ownership still resolves (env is only the fast path).
-                  // `watcherAgentDir` is guaranteed non-null in this branch
-                  // (the whole watcher is gated on it above). Kill-switch
-                  // SWITCHROOM_WORKTREE_IDENTITY_FALLBACK=0 restores the
-                  // pre-fix env-only behaviour.
-                  agentDir:
-                    process.env.SWITCHROOM_WORKTREE_IDENTITY_FALLBACK === '0'
-                      ? undefined
-                      : watcherAgentDir,
-                  log: (msg) =>
-                    process.stderr.write(`telegram gateway: ${msg}\n`),
-                });
-              },
+              // On every ~1s rescan tick the provider does BOTH:
+              //   1. advances the heartbeat of every worktree THIS agent owns
+              //      — the F1/H3 production driver that keeps `touchHeartbeat`
+              //      alive (it had ZERO callers, so every claim read "stale"
+              //      10 min after creation and the reaper's staleness
+              //      guarantee collapsed); throttled to ≤1 write / 2 min per
+              //      record, and
+              //   2. returns the fail-CLOSED set of owned worktree cwds for the
+              //      watcher to also watch (#1116 / Gap-2 ownership predicate).
+              // Extracted to telegram-plugin/worktree-watch-cwds.ts as
+              // `makeWorktreeWatchProvider` so the wiring — specifically that
+              // the provider ACTUALLY drives heartbeats, not just cwds — is
+              // under direct unit test (see the provider behaviour test in
+              // telegram-plugin/tests/worktree-watch-cwds.test.ts). Fully
+              // best-effort: it never throws out of the provider.
+              extraWatchCwdsProvider: makeWorktreeWatchProvider({
+                self: process.env.SWITCHROOM_AGENT_NAME,
+                // Durable, non-env identity fallback (#1116 / #2893): when
+                // SWITCHROOM_AGENT_NAME is somehow unset, derive this agent's
+                // own identity from its own directory so worktree ownership
+                // still resolves (env is only the fast path). `watcherAgentDir`
+                // is guaranteed non-null in this branch (the whole watcher is
+                // gated on it above). Kill-switch
+                // SWITCHROOM_WORKTREE_IDENTITY_FALLBACK=0 restores the pre-fix
+                // env-only behaviour. One `agentDir` governs BOTH the heartbeat
+                // refresh and the cwd derivation.
+                agentDir:
+                  process.env.SWITCHROOM_WORKTREE_IDENTITY_FALLBACK === '0'
+                    ? undefined
+                    : watcherAgentDir,
+                listRecords: listWorktreeRecords,
+                touchHeartbeat: touchWorktreeHeartbeat,
+                log: (msg) =>
+                  process.stderr.write(`telegram gateway: ${msg}\n`),
+              }),
               // Bug 0 fix: previously omitted, leaving the watcher unable to
               // write liveness/stall/turn_end updates to the registry DB.
               // Liveness writes are now persisted across the gateway lifetime.

--- a/telegram-plugin/tests/worktree-watch-cwds.test.ts
+++ b/telegram-plugin/tests/worktree-watch-cwds.test.ts
@@ -9,14 +9,26 @@
  * Run with:
  *   bun test telegram-plugin/tests/worktree-watch-cwds.test.ts
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 import {
   ownedWorktreeCwds,
   refreshOwnedWorktreeHeartbeats,
+  makeWorktreeWatchProvider,
   __resetIdentityEscalationForTests,
   type WorktreeOwnershipRecord,
   type WorktreeHeartbeatRecord,
 } from "../worktree-watch-cwds.js";
+import {
+  writeRecord,
+  readRecord,
+  listRecords as registryListRecords,
+  touchHeartbeat as registryTouchHeartbeat,
+} from "../../src/worktree/registry.js";
+import type { WorktreeRecord } from "../../src/worktree/types.js";
 
 const idPath = (p: string) => p; // identity realpath for deterministic tests
 
@@ -290,5 +302,111 @@ describe("refreshOwnedWorktreeHeartbeats", () => {
     // mine-2 still touched despite mine-1 throwing.
     expect(touched).toEqual(["mine-2"]);
     expect(n).toBe(1);
+  });
+});
+
+// ─── M1: the gateway's extraWatchCwds provider ──────────────────────────────
+//
+// The gateway wires a single closure (`makeWorktreeWatchProvider`) as the
+// subagent-watcher's extraWatchCwdsProvider. The whole point of this PR is
+// that that closure ALSO advances heartbeats on every tick — deleting the
+// refresh call would leave the cwd behaviour (and every ownership test above)
+// green while silently reintroducing the zero-caller `touchHeartbeat` bug.
+// These tests are the deterministic guard: they assert the provider returns
+// owned cwds AND advances a real registry record's heartbeatAt on the same
+// call, and that the gateway actually installs it.
+describe("makeWorktreeWatchProvider (gateway wiring)", () => {
+  const idPathLocal = (p: string) => p; // deterministic realpath
+
+  it("both returns owned cwds AND advances the claim's heartbeat (in-memory)", () => {
+    const now = 10_000_000;
+    const before = new Date(now - 60 * 60_000).toISOString(); // 1h ago (stale)
+    const store: (WorktreeOwnershipRecord & WorktreeHeartbeatRecord)[] = [
+      { id: "mine", path: "/wt/mine", ownerAgent: "klanker", heartbeatAt: before },
+      { id: "theirs", path: "/wt/theirs", ownerAgent: "reggie", heartbeatAt: before },
+    ];
+    const touched: string[] = [];
+    const provider = makeWorktreeWatchProvider({
+      self: "klanker",
+      listRecords: () => store,
+      touchHeartbeat: (id) => touched.push(id),
+      realpath: idPathLocal,
+      minRefreshIntervalMs: 0,
+      now: () => now,
+    });
+
+    const cwds = provider();
+
+    // (1) returns exactly this agent's owned cwds
+    expect(cwds).toEqual(["/wt/mine"]);
+    // (2) AND advanced the heartbeat of the owned record only — never foreign
+    expect(touched).toEqual(["mine"]);
+  });
+
+  describe("against a real temp registry", () => {
+    let tmpDir: string;
+    const origEnv = process.env.SWITCHROOM_WORKTREE_DIR;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "sw-provider-test-"));
+      process.env.SWITCHROOM_WORKTREE_DIR = tmpDir;
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+      if (origEnv === undefined) delete process.env.SWITCHROOM_WORKTREE_DIR;
+      else process.env.SWITCHROOM_WORKTREE_DIR = origEnv;
+    });
+
+    function makeRecord(overrides: Partial<WorktreeRecord> = {}): WorktreeRecord {
+      const iso = new Date().toISOString();
+      return {
+        id: "prov001",
+        repo: "/fake/repo",
+        repoName: "fake",
+        branch: "task/prov001",
+        path: "/wt/prov001",
+        createdAt: iso,
+        heartbeatAt: iso,
+        ownerAgent: "klanker",
+        ...overrides,
+      };
+    }
+
+    it("provider drives the REAL registry: returns cwd AND advances heartbeatAt on disk", async () => {
+      const past = new Date(Date.now() - 5 * 60_000).toISOString(); // 5min ago
+      writeRecord(makeRecord({ heartbeatAt: past }));
+      const before = new Date(readRecord("prov001")!.heartbeatAt).getTime();
+
+      const provider = makeWorktreeWatchProvider({
+        self: "klanker",
+        listRecords: registryListRecords,
+        touchHeartbeat: registryTouchHeartbeat,
+        realpath: idPathLocal,
+        minRefreshIntervalMs: 0, // always touch
+      });
+
+      await new Promise((r) => setTimeout(r, 5)); // ensure a strictly newer ts
+      const cwds = provider();
+
+      // (1) returns the owned cwd from the real registry
+      expect(cwds).toEqual(["/wt/prov001"]);
+      // (2) AND the on-disk heartbeat actually advanced (the zero-caller guard)
+      const after = new Date(readRecord("prov001")!.heartbeatAt).getTime();
+      expect(after).toBeGreaterThan(before);
+    });
+  });
+
+  it("gateway.ts installs makeWorktreeWatchProvider as extraWatchCwdsProvider", () => {
+    // Grep-pin (anchor MUST resolve so it can never pass vacuously — repo test
+    // convention, PR #3126): proves the gateway actually wires the extracted
+    // provider, so a behaviour test on the provider is not testing dead code.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const gatewaySrc = readFileSync(
+      join(here, "..", "gateway", "gateway.ts"),
+      "utf8",
+    );
+    const anchor = "extraWatchCwdsProvider: makeWorktreeWatchProvider(";
+    expect(gatewaySrc.indexOf(anchor)).toBeGreaterThan(-1);
   });
 });

--- a/telegram-plugin/tests/worktree-watch-cwds.test.ts
+++ b/telegram-plugin/tests/worktree-watch-cwds.test.ts
@@ -12,8 +12,10 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   ownedWorktreeCwds,
+  refreshOwnedWorktreeHeartbeats,
   __resetIdentityEscalationForTests,
   type WorktreeOwnershipRecord,
+  type WorktreeHeartbeatRecord,
 } from "../worktree-watch-cwds.js";
 
 const idPath = (p: string) => p; // identity realpath for deterministic tests
@@ -194,5 +196,99 @@ describe("ownedWorktreeCwds", () => {
     live = [{ path: "/wt/b", ownerAgent: "klanker" }];
     // Tick 3: reflects the release.
     expect(provider()).toEqual(["/wt/b"]);
+  });
+});
+
+describe("refreshOwnedWorktreeHeartbeats", () => {
+  const records: WorktreeHeartbeatRecord[] = [
+    { id: "mine-1", ownerAgent: "klanker" },
+    { id: "mine-2", ownerAgent: "klanker" },
+    { id: "theirs", ownerAgent: "reggie" },
+    { id: "ownerless" }, // ownerAgent undefined
+  ];
+
+  it("touches ONLY this agent's records, never ownerless or foreign ones", () => {
+    const touched: string[] = [];
+    const n = refreshOwnedWorktreeHeartbeats({
+      self: "klanker",
+      listRecords: () => records,
+      touchHeartbeat: (id) => touched.push(id),
+      minRefreshIntervalMs: 0, // always touch
+    });
+    expect(touched.sort()).toEqual(["mine-1", "mine-2"]);
+    expect(touched).not.toContain("theirs");
+    expect(touched).not.toContain("ownerless");
+    expect(n).toBe(2);
+  });
+
+  it("fail-closed: unresolved identity touches NOTHING (no #1116 leak)", () => {
+    const touched: string[] = [];
+    const n = refreshOwnedWorktreeHeartbeats({
+      self: undefined,
+      listRecords: () => records,
+      touchHeartbeat: (id) => touched.push(id),
+      minRefreshIntervalMs: 0,
+    });
+    expect(touched).toEqual([]);
+    expect(n).toBe(0);
+  });
+
+  it("resolves identity from agentDir when env is unset (durable fallback)", () => {
+    const touched: string[] = [];
+    refreshOwnedWorktreeHeartbeats({
+      self: undefined,
+      agentDir: "/home/x/.switchroom/agents/klanker",
+      listRecords: () => records,
+      touchHeartbeat: (id) => touched.push(id),
+      minRefreshIntervalMs: 0,
+    });
+    expect(touched.sort()).toEqual(["mine-1", "mine-2"]);
+  });
+
+  it("throttles: skips a record whose heartbeat is younger than the interval", () => {
+    const now = 1_000_000;
+    const fresh = new Date(now - 30_000).toISOString(); // 30s ago
+    const aged = new Date(now - 5 * 60_000).toISOString(); // 5min ago
+    const touched: string[] = [];
+    refreshOwnedWorktreeHeartbeats({
+      self: "klanker",
+      listRecords: () => [
+        { id: "fresh", ownerAgent: "klanker", heartbeatAt: fresh },
+        { id: "aged", ownerAgent: "klanker", heartbeatAt: aged },
+      ],
+      touchHeartbeat: (id) => touched.push(id),
+      minRefreshIntervalMs: 2 * 60_000, // 2 min
+      now: () => now,
+    });
+    // Only the aged one crosses the throttle window.
+    expect(touched).toEqual(["aged"]);
+  });
+
+  it("a registry read failure is swallowed (never throws on the hot loop)", () => {
+    expect(() =>
+      refreshOwnedWorktreeHeartbeats({
+        self: "klanker",
+        listRecords: () => {
+          throw new Error("registry gone");
+        },
+        touchHeartbeat: () => {},
+      }),
+    ).not.toThrow();
+  });
+
+  it("a per-record touch failure does not abort the remaining records", () => {
+    const touched: string[] = [];
+    const n = refreshOwnedWorktreeHeartbeats({
+      self: "klanker",
+      listRecords: () => records,
+      touchHeartbeat: (id) => {
+        if (id === "mine-1") throw new Error("write failed");
+        touched.push(id);
+      },
+      minRefreshIntervalMs: 0,
+    });
+    // mine-2 still touched despite mine-1 throwing.
+    expect(touched).toEqual(["mine-2"]);
+    expect(n).toBe(1);
   });
 });

--- a/telegram-plugin/worktree-watch-cwds.ts
+++ b/telegram-plugin/worktree-watch-cwds.ts
@@ -90,13 +90,30 @@ function defaultDeriveName(agentDir: string): string {
   return leaf;
 }
 
+/**
+ * Two-tier owner-identity resolution shared by `ownedWorktreeCwds` and
+ * `refreshOwnedWorktreeHeartbeats`:
+ *   Tier 1 — env fast path (`SWITCHROOM_AGENT_NAME`).
+ *   Tier 2 — durable fallback derived from the agent's OWN directory basename.
+ * Returns "" when neither source yields a usable identity — callers MUST treat
+ * "" as fail-closed (never guess ownership).
+ */
+export function resolveOwnerIdentity(
+  self: string | undefined,
+  agentDir: string | null | undefined,
+  deriveName?: (agentDir: string) => string,
+): string {
+  let resolved: string = self != null ? self : "";
+  if (resolved === "" && agentDir != null && agentDir !== "") {
+    const derive = deriveName ?? defaultDeriveName;
+    resolved = derive(agentDir) || "";
+  }
+  return resolved;
+}
+
 export function ownedWorktreeCwds(opts: OwnedWorktreeCwdsOptions): string[] {
   // Tier 1: env fast path. Tier 2: durable agentDir-derived fallback.
-  let resolved: string = opts.self != null ? opts.self : "";
-  if (resolved === "" && opts.agentDir != null && opts.agentDir !== "") {
-    const derive = opts.deriveName ?? defaultDeriveName;
-    resolved = derive(opts.agentDir) || "";
-  }
+  const resolved = resolveOwnerIdentity(opts.self, opts.agentDir, opts.deriveName);
 
   if (resolved === "") {
     // Both env and durable config unavailable. Keep the historical
@@ -132,4 +149,103 @@ export function ownedWorktreeCwds(opts: OwnedWorktreeCwdsOptions): string[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * Default minimum interval (ms) between heartbeat writes for the same
+ * worktree record. The gateway invokes the refresh on every ~1s rescan tick;
+ * writing every tick would be needless churn. Refreshing at most every 2 min
+ * keeps every live claim's heartbeat FAR fresher than the reaper's 10-min
+ * `STALE_THRESHOLD_MS`, so a live claim never reads as stale, while a dead
+ * gateway (no ticks) lets the heartbeat age out and become reap-eligible.
+ */
+export const DEFAULT_HEARTBEAT_REFRESH_INTERVAL_MS = 2 * 60_000;
+
+/** Minimal record shape needed to refresh a worktree heartbeat. */
+export interface WorktreeHeartbeatRecord {
+  id: string;
+  ownerAgent?: string;
+  /** ISO 8601 timestamp of the record's current heartbeat (for throttling). */
+  heartbeatAt?: string;
+}
+
+export interface RefreshOwnedHeartbeatsOptions {
+  /** The agent's identity — `process.env.SWITCHROOM_AGENT_NAME` (fast path). */
+  self: string | undefined;
+  /** Durable, non-env identity fallback: the agent's OWN directory. */
+  agentDir?: string | null;
+  /** Host-global registry read (`listRecords` from src/worktree/registry). */
+  listRecords: () => WorktreeHeartbeatRecord[];
+  /** Advance one record's heartbeat (`touchHeartbeat` from the registry). */
+  touchHeartbeat: (id: string) => void;
+  /**
+   * Skip a touch while the record's heartbeat is younger than this (ms).
+   * Defaults to `DEFAULT_HEARTBEAT_REFRESH_INTERVAL_MS`. Set to 0 to always
+   * touch (used by tests).
+   */
+  minRefreshIntervalMs?: number;
+  /** `Date.now` override for tests. */
+  now?: () => number;
+  /** Injectable name derivation (defaults to `path.basename`). */
+  deriveName?: (agentDir: string) => string;
+  /** Best-effort error sink. */
+  log?: (msg: string) => void;
+}
+
+/**
+ * Refresh the heartbeat of every worktree THIS agent owns.
+ *
+ * This is the production driver that keeps `touchHeartbeat` (previously dead —
+ * F1/H3) alive: the gateway calls it on the same rescan tick that re-derives
+ * the watched worktree cwds, so a claim held by a LIVE agent has its heartbeat
+ * advanced continuously and never trips the reaper's staleness gate. When the
+ * owning gateway dies, the ticks stop, the heartbeat ages past
+ * `STALE_THRESHOLD_MS`, and the (now fail-safe) reaper can reclaim the truly
+ * abandoned claim.
+ *
+ * Fail-CLOSED, mirroring `ownedWorktreeCwds`:
+ *   - Unresolved identity ⇒ touch nothing (never guess ownership).
+ *   - Ownerless records (`ownerAgent` undefined) are NEVER matched — we must
+ *     not advance another agent's / an unattributable claim's heartbeat.
+ *   - A registry read failure ⇒ touch nothing.
+ *   - A per-record touch failure is swallowed (logged) — one bad record must
+ *     not abort the rest, and this runs on the hot watch loop.
+ *
+ * @returns the number of heartbeats actually advanced this call.
+ */
+export function refreshOwnedWorktreeHeartbeats(
+  opts: RefreshOwnedHeartbeatsOptions,
+): number {
+  const identity = resolveOwnerIdentity(opts.self, opts.agentDir, opts.deriveName);
+  if (identity === "") return 0; // fail-closed: never guess ownership
+
+  const nowMs = (opts.now ?? Date.now)();
+  const minInterval =
+    opts.minRefreshIntervalMs ?? DEFAULT_HEARTBEAT_REFRESH_INTERVAL_MS;
+
+  let records: WorktreeHeartbeatRecord[];
+  try {
+    records = opts.listRecords();
+  } catch {
+    return 0;
+  }
+
+  let touched = 0;
+  for (const r of records) {
+    if (r.ownerAgent !== identity) continue; // ownerless never matched
+    // Throttle: skip if the heartbeat is still comfortably fresh.
+    if (minInterval > 0 && r.heartbeatAt != null) {
+      const age = nowMs - new Date(r.heartbeatAt).getTime();
+      if (Number.isFinite(age) && age >= 0 && age < minInterval) continue;
+    }
+    try {
+      opts.touchHeartbeat(r.id);
+      touched++;
+    } catch (err) {
+      opts.log?.(
+        `worktree heartbeat refresh failed for ${r.id}: ${(err as Error).message}`,
+      );
+    }
+  }
+  return touched;
 }

--- a/telegram-plugin/worktree-watch-cwds.ts
+++ b/telegram-plugin/worktree-watch-cwds.ts
@@ -249,3 +249,76 @@ export function refreshOwnedWorktreeHeartbeats(
   }
   return touched;
 }
+
+/** A registry record carrying everything both watch operations need. */
+export type WorktreeWatchRecord = WorktreeOwnershipRecord & WorktreeHeartbeatRecord;
+
+export interface WorktreeWatchProviderOptions {
+  /** The agent's identity — `process.env.SWITCHROOM_AGENT_NAME` (fast path). */
+  self: string | undefined;
+  /** Durable, non-env identity fallback: the agent's OWN directory. */
+  agentDir?: string | null;
+  /** Host-global registry read (`listRecords` from src/worktree/registry). */
+  listRecords: () => WorktreeWatchRecord[];
+  /** Advance one record's heartbeat (`touchHeartbeat` from the registry). */
+  touchHeartbeat: (id: string) => void;
+  /** Injectable realpath for the cwd derivation (defaults to fs.realpathSync). */
+  realpath?: (p: string) => string;
+  /** Injectable name derivation from `agentDir` (defaults to path.basename). */
+  deriveName?: (agentDir: string) => string;
+  /** Heartbeat throttle window (ms); see refreshOwnedWorktreeHeartbeats. */
+  minRefreshIntervalMs?: number;
+  /** `Date.now` override for tests. */
+  now?: () => number;
+  /** Best-effort log sink shared by both operations. */
+  log?: (msg: string) => void;
+}
+
+/**
+ * Build the `extraWatchCwdsProvider` closure the gateway installs on the
+ * subagent watcher.
+ *
+ * The provider is invoked on every ~1s rescan tick and does TWO things on that
+ * single tick:
+ *   1. advances the heartbeat of every worktree THIS agent owns
+ *      (`refreshOwnedWorktreeHeartbeats` — the production driver that keeps
+ *      `touchHeartbeat` alive; without it every claim reads "stale" 10 min
+ *      after creation and the reaper's staleness guarantee collapses), AND
+ *   2. returns the set of owned worktree cwds for the watcher to also watch
+ *      (`ownedWorktreeCwds`).
+ *
+ * It is extracted from the gateway (rather than inlined) SO THAT the wiring —
+ * specifically that the provider actually DRIVES heartbeats, not merely returns
+ * cwds — is under direct unit test. Deleting the heartbeat refresh here is
+ * caught by the provider's behaviour test (it would return cwds but stop
+ * advancing heartbeats), which the pre-extraction inline closure could not
+ * assert against.
+ *
+ * Both operations use the SAME two-tier identity (env fast path + agentDir
+ * fallback), so a single `agentDir` kill-switch on the caller governs both.
+ * Fully best-effort: neither operation throws out of the returned closure.
+ */
+export function makeWorktreeWatchProvider(
+  opts: WorktreeWatchProviderOptions,
+): () => string[] {
+  return () => {
+    refreshOwnedWorktreeHeartbeats({
+      self: opts.self,
+      agentDir: opts.agentDir,
+      listRecords: opts.listRecords,
+      touchHeartbeat: opts.touchHeartbeat,
+      minRefreshIntervalMs: opts.minRefreshIntervalMs,
+      now: opts.now,
+      deriveName: opts.deriveName,
+      log: opts.log,
+    });
+    return ownedWorktreeCwds({
+      self: opts.self,
+      agentDir: opts.agentDir,
+      listRecords: opts.listRecords,
+      realpath: opts.realpath,
+      deriveName: opts.deriveName,
+      log: opts.log,
+    });
+  };
+}

--- a/tests/worktree.reaper.test.ts
+++ b/tests/worktree.reaper.test.ts
@@ -6,12 +6,31 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { writeRecord, readRecord, listRecords } from "../src/worktree/registry.js";
-import { runReaper, STALE_THRESHOLD_MS } from "../src/worktree/reaper.js";
+import {
+  runReaper,
+  probePathInUse,
+  STALE_THRESHOLD_MS,
+  type ReaperDeps,
+} from "../src/worktree/reaper.js";
 import type { WorktreeRecord } from "../src/worktree/types.js";
+
+/**
+ * Deterministic default deps for the stale-reap path: the probe reports the
+ * path as free and the tree is clean, so the reaper's ONLY remaining gate is
+ * staleness. Individual fail-safe tests override one field to exercise a guard.
+ * (Without this, the reaper would shell out to the host's real fuser/lsof/git,
+ * making the outcome depend on which tools the CI box happens to have.)
+ */
+const REAP_ALLOWED: ReaperDeps = {
+  probeInUse: () => "free",
+  hasUncommittedChanges: () => false,
+  removeWorktree: () => {},
+};
 
 describe("worktree reaper", () => {
   let tmpDir: string;
@@ -74,16 +93,14 @@ describe("worktree reaper", () => {
     expect(listRecords()).toHaveLength(1);
   });
 
-  it("reaps a record with stale heartbeat (path exists, no fuser)", () => {
+  it("reaps a record with stale heartbeat (path free, tree clean)", () => {
     // Heartbeat is 11 minutes ago — over the 10-min threshold
     const staleAge = STALE_THRESHOLD_MS + 60_000;
     const rec = makeRecord("stale01", staleAge, true);
     writeRecord(rec);
 
-    // The reaper will try `git worktree remove --force` which will fail
-    // on a fake path, but it should still delete the registry record.
-    // It also tries `fuser` which will return false for our tmp dir.
-    const result = runReaper();
+    // Probe reports free + no uncommitted changes → the reaper removes it.
+    const result = runReaper(undefined, REAP_ALLOWED);
 
     expect(result.reaped).toContain("stale01");
     expect(listRecords()).toHaveLength(0);
@@ -96,7 +113,7 @@ describe("worktree reaper", () => {
     writeRecord(fresh);
     writeRecord(stale);
 
-    const result = runReaper();
+    const result = runReaper(undefined, REAP_ALLOWED);
 
     expect(result.reaped).toContain("reaped");
     expect(result.reaped).not.toContain("keepme");
@@ -121,5 +138,77 @@ describe("worktree reaper", () => {
 
     expect(result.reaped.sort()).toEqual(["orphan-a", "orphan-b", "orphan-c"]);
     expect(listRecords()).toHaveLength(0);
+  });
+
+  // ── Fail-safe: data-loss prevention (F1 / H3) ────────────────────────────
+
+  it("does NOT force-remove a stale worktree that has UNCOMMITTED changes (real git)", () => {
+    // Anchor test — uses the REAL hasUncommittedChanges + real git so it
+    // fails at runtime against the pre-fix reaper (which only warned, then
+    // force-removed anyway). The worktree path is a real git repo with an
+    // untracked file, so `git status --porcelain` reports a dirty tree.
+    const staleAge = STALE_THRESHOLD_MS + 60_000;
+    const rec = makeRecord("dirty01", staleAge, true);
+    // Turn the (already-existing) worktree dir into a git repo with a change.
+    execFileSync("git", ["-C", rec.path, "init", "-q"], { stdio: "pipe" });
+    writeFileSync(join(rec.path, "WIP.txt"), "uncommitted work\n");
+    writeRecord(rec);
+
+    // Real probe (fuser/lsof or "unavailable") — either way the dirty guard
+    // fires FIRST and hard-skips, so the record must survive untouched.
+    const result = runReaper();
+
+    expect(result.reaped).not.toContain("dirty01");
+    expect(listRecords().map((r) => r.id)).toContain("dirty01");
+    // The skip is surfaced as a warning (not a silent drop).
+    expect(result.warnings.some((w) => w.includes("UNCOMMITTED"))).toBe(true);
+  });
+
+  it("does NOT force-remove a stale worktree when the in-use probe is UNAVAILABLE (no fuser/lsof)", () => {
+    const staleAge = STALE_THRESHOLD_MS + 60_000;
+    const rec = makeRecord("noprobe01", staleAge, true);
+    writeRecord(rec);
+
+    // Simulate a host with neither fuser nor lsof installed. Tree is clean,
+    // so the probe is the only remaining gate — and "unavailable" must be
+    // treated as live (fail-safe), never reaped.
+    const result = runReaper(undefined, {
+      hasUncommittedChanges: () => false,
+      probeInUse: () => "unavailable",
+      removeWorktree: () => {
+        throw new Error("must not force-remove when probe is unavailable");
+      },
+    });
+
+    expect(result.reaped).not.toContain("noprobe01");
+    expect(listRecords().map((r) => r.id)).toContain("noprobe01");
+    expect(result.warnings.some((w) => w.includes("probe"))).toBe(true);
+  });
+
+  it("does NOT reap a stale worktree the probe reports as in-use", () => {
+    const staleAge = STALE_THRESHOLD_MS + 60_000;
+    const rec = makeRecord("inuse01", staleAge, true);
+    writeRecord(rec);
+
+    const result = runReaper(undefined, {
+      hasUncommittedChanges: () => false,
+      probeInUse: () => "in-use",
+      removeWorktree: () => {
+        throw new Error("must not force-remove a worktree that is in use");
+      },
+    });
+
+    expect(result.reaped).not.toContain("inuse01");
+    expect(listRecords().map((r) => r.id)).toContain("inuse01");
+  });
+
+  it("probePathInUse never reports an unheld dir as 'in-use' (host-independent)", () => {
+    // Nothing holds an empty temp dir open, so the probe must be 'free' (a
+    // probe ran and found no holder) or 'unavailable' (no probe installed) —
+    // never a false 'in-use'. This pins the ENOENT-vs-nonzero-exit
+    // distinction without depending on which tools the host has.
+    const dir = join(checkoutsDir, "probe-free");
+    mkdirSync(dir, { recursive: true });
+    expect(["free", "unavailable"]).toContain(probePathInUse(dir));
   });
 });

--- a/tests/worktree.reaper.test.ts
+++ b/tests/worktree.reaper.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { writeRecord, readRecord, listRecords } from "../src/worktree/registry.js";
 import {
   runReaper,
+  planReaper,
   probePathInUse,
   STALE_THRESHOLD_MS,
   type ReaperDeps,
@@ -200,6 +201,74 @@ describe("worktree reaper", () => {
 
     expect(result.reaped).not.toContain("inuse01");
     expect(listRecords().map((r) => r.id)).toContain("inuse01");
+  });
+
+  // ── L1: dry-run parity — planReaper is the single decision predicate ─────
+
+  it("L1: planReaper marks a stale DIRTY worktree skip-dirty, NOT reap (dry-run parity)", () => {
+    // The pre-fix dry-run computed would-reap from heartbeat age alone, so it
+    // over-reported this record as reapable even though a real run hard-skips
+    // it. planReaper (shared by both the real run and the dry-run) must
+    // classify it as skip-dirty so the two agree.
+    const staleAge = STALE_THRESHOLD_MS + 60_000;
+    const rec = makeRecord("drydirty01", staleAge, true);
+    writeRecord(rec);
+
+    const plan = planReaper(undefined, {
+      hasUncommittedChanges: () => true,
+      probeInUse: () => "free",
+    });
+    const entry = plan.find((e) => e.record.id === "drydirty01");
+    expect(entry?.action).toBe("skip-dirty");
+    // The exact same predicate drives a real run → it is NOT reaped.
+    const result = runReaper(undefined, {
+      hasUncommittedChanges: () => true,
+      probeInUse: () => "free",
+      removeWorktree: () => {
+        throw new Error("must not remove a dirty worktree");
+      },
+    });
+    expect(result.reaped).not.toContain("drydirty01");
+  });
+
+  it("L1: planReaper marks a stale worktree with an UNAVAILABLE probe skip-probe-unavailable, not reap", () => {
+    const staleAge = STALE_THRESHOLD_MS + 60_000;
+    writeRecord(makeRecord("dryprobe01", staleAge, true));
+
+    const plan = planReaper(undefined, {
+      hasUncommittedChanges: () => false,
+      probeInUse: () => "unavailable",
+    });
+    const entry = plan.find((e) => e.record.id === "dryprobe01");
+    expect(entry?.action).toBe("skip-probe-unavailable");
+  });
+
+  it("L1: planReaper still marks a stale, clean, free worktree as reap (would-reap parity)", () => {
+    const staleAge = STALE_THRESHOLD_MS + 60_000;
+    writeRecord(makeRecord("dryreap01", staleAge, true));
+
+    const plan = planReaper(undefined, REAP_ALLOWED);
+    const entry = plan.find((e) => e.record.id === "dryreap01");
+    expect(entry?.action).toBe("reap");
+  });
+
+  // ── M2: stale-but-kept worktrees are surfaced, not silently dropped ──────
+
+  it("M2: runReaper reports a kept dirty worktree in result.skipped with remediation", () => {
+    const staleAge = STALE_THRESHOLD_MS + 60_000;
+    writeRecord(makeRecord("keptdirty01", staleAge, true));
+
+    const result = runReaper(undefined, {
+      hasUncommittedChanges: () => true,
+      probeInUse: () => "free",
+      removeWorktree: () => {},
+    });
+
+    const skip = result.skipped.find((s) => s.record.id === "keptdirty01");
+    expect(skip?.action).toBe("skip-dirty");
+    // The remediation path is spelled out in the message (M2).
+    expect(skip?.message).toContain("worktree release");
+    expect(result.reaped).not.toContain("keptdirty01");
   });
 
   it("probePathInUse never reports an unheld dir as 'in-use' (host-independent)", () => {

--- a/tests/worktree.registry.test.ts
+++ b/tests/worktree.registry.test.ts
@@ -106,6 +106,25 @@ describe("worktree registry", () => {
     expect(() => touchHeartbeat("missing999")).not.toThrow();
   });
 
+  it("L2: does NOT resurrect a record deleted between its read and write", () => {
+    // Race window: touchHeartbeat reads the record, then a concurrent
+    // `worktree release` (deleteRecord) lands, then touchHeartbeat writes. A
+    // naive write would recreate the just-released record as a zombie claim.
+    // The onAfterRead seam simulates the delete landing in that window.
+    const rec = makeRecord({ id: "race001" });
+    writeRecord(rec);
+    expect(recordExists("race001")).toBe(true);
+
+    touchHeartbeat("race001", () => {
+      // Simulate the concurrent release firing after the read but before write.
+      deleteRecord("race001");
+    });
+
+    // The record must stay deleted — touchHeartbeat must not resurrect it.
+    expect(recordExists("race001")).toBe(false);
+    expect(readRecord("race001")).toBeNull();
+  });
+
   it("countByRepo counts correctly", () => {
     writeRecord(makeRecord({ id: "c1", repo: "/repo/a" }));
     writeRecord(makeRecord({ id: "c2", repo: "/repo/a" }));


### PR DESCRIPTION
## Problem (H3 — data-loss, CONFIRMED)

`src/worktree/registry.ts` `touchHeartbeat()` had **zero production callers**. A claim's `heartbeatAt` was written once at claim time (`src/worktree/claim.ts:194`) and never advanced, so every claim read **stale** `STALE_THRESHOLD_MS` (10 min) after creation — regardless of whether an agent was actively working in it.

With the heartbeat permanently stale, the reaper's liveness guarantee (`reaper.ts` — "stale heartbeat AND no process holds the path open") collapsed to a best-effort `fuser`/`lsof` probe that returned "not in use" both when nothing held the path **and** when neither probe tool was installed. `hasUncommittedChanges` only emitted a stderr *warning*, so `git worktree remove --force` could destroy a **live worktree with uncommitted work**.

Refs: `code-review-20260711/small-subsystems.md` F1; `stale-tree-verify.md` Claim A (CONFIRMED at c4ab171).

## Fix (durable + deterministic — both parts)

**1. Refresh the heartbeat while a claim is held.** The gateway's subagent-watcher already re-derives the owned-worktree cwds on every ~1s rescan tick; on that same tick it now calls `refreshOwnedWorktreeHeartbeats()`, advancing `touchHeartbeat` for every worktree **this** agent owns (throttled to <=1 write / 2 min per record — far under the 10-min stale threshold). A claim held by a live gateway stays fresh; when the gateway dies the ticks stop and the heartbeat ages out. Ownership uses the same fail-closed, two-tier (env + `agentDir`) predicate as the cwd provider — ownerless and foreign records are never touched.

**2. Fail-safe reaper.** A stale worktree is force-removed only when **all** guards clear:
- **Uncommitted changes => HARD SKIP** (with a warning) — never warn-then-remove.
- `probePathInUse` is now tri-state and distinguishes *"probe ran, found nothing"* (`free`) from *"no fuser/lsof installed"* (`unavailable`). Both `unavailable` and `in-use` are treated as **live** and kept.

## Tests (assert outcomes; >=1 fails against the unpatched reaper at runtime)

- reaper does **not** force-remove a stale worktree with uncommitted changes (real `git` repo — anchor test; the pre-fix reaper force-removed it).
- reaper does **not** reap when the in-use probe is `unavailable` (no fuser/lsof) or reports `in-use`.
- `probePathInUse` never reports an unheld dir as `in-use` (host-independent).
- `refreshOwnedWorktreeHeartbeats` touches only owned records (never ownerless/foreign), honours the throttle window, resolves identity via the durable `agentDir` fallback, and is fully best-effort (swallows registry / per-record failures).

Reverting only `src/worktree/reaper.ts` makes 4 reaper tests fail at runtime (incl. the uncommitted-changes anchor).

**Scoped tests:** `npx vitest run tests/worktree.reaper.test.ts tests/worktree.registry.test.ts telegram-plugin/tests/worktree-watch-cwds.test.ts` -> 39 passed.
**Lint:** `tsc --noEmit` clean. (The `check-plugin-references.mjs` step reports pre-existing `@mtcute/node` / `mdast-*` missing-module errors in files this PR does not touch — reproduced on a clean tree; an env dep gap, not from this change. CI is the full-suite authority.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)