### PR TITLE
fix(telegram): make history upsert idempotent for null-thread rows

### DIFF
--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -178,7 +178,7 @@ export function initHistory(stateDir: string, retentionDays = 30): void {
     }
   }
 
-  // Migration (H3): make INSERT OR REPLACE idempotent for thread-less rows.
+  // Migration (review finding H5): make INSERT OR REPLACE idempotent for thread-less rows.
   //
   // The table's PRIMARY KEY is (chat_id, thread_id, message_id), but thread_id
   // is nullable and SQLite treats NULL as DISTINCT from NULL in a PK/UNIQUE

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -178,6 +178,57 @@ export function initHistory(stateDir: string, retentionDays = 30): void {
     }
   }
 
+  // Migration (H3): make INSERT OR REPLACE idempotent for thread-less rows.
+  //
+  // The table's PRIMARY KEY is (chat_id, thread_id, message_id), but thread_id
+  // is nullable and SQLite treats NULL as DISTINCT from NULL in a PK/UNIQUE
+  // index. Every DM and every non-topic group message has thread_id = NULL, so
+  // two inserts of the same (chat_id, message_id) with NULL thread do NOT
+  // conflict — `INSERT OR REPLACE` APPENDS a duplicate row instead of replacing
+  // it. On the documented at-least-once boot replay / synthesized-resume
+  // re-record, an already-stored message is duplicated, inflating
+  // get_recent_messages and the getRecentOutboundCount / hasOutboundDeliveredSince
+  // counters that feed the silence / over-ping detectors.
+  //
+  // Fix: a UNIQUE index over COALESCE(thread_id, '') gives every logical
+  // (chat, thread-or-general, message_id) key a NON-null uniqueness value, so
+  // REPLACE conflict-resolves and dedupes thread-less rows too. INSERT OR
+  // REPLACE resolves against ANY unique index, so no writer change is needed.
+  // A forum-topic row (non-null thread) and a general row (NULL thread) that
+  // share a message_id keep DISTINCT keys (the topic id vs ''), so they stay
+  // separate. Stored thread_id values remain real NULLs, so every read path
+  // (`thread_id IS NULL` / `thread_id = ?`) is unchanged.
+  const LOGICAL_KEY_INDEX = 'idx_messages_logical_key'
+  const logicalKeyIndexExists =
+    db
+      .prepare(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?`)
+      .get(LOGICAL_KEY_INDEX) != null
+  if (!logicalKeyIndexExists) {
+    // De-dupe rows an earlier (pre-fix) build already appended, keeping the
+    // NEWEST row per logical key (highest ts, then highest rowid = the last
+    // write, which is what INSERT OR REPLACE would have left). This MUST run
+    // before the UNIQUE index is created, or CREATE UNIQUE INDEX would fail on
+    // the existing duplicates. On a fresh/empty DB it is a harmless no-op.
+    db.exec(`
+      DELETE FROM messages
+      WHERE rowid NOT IN (
+        SELECT keep_rowid FROM (
+          SELECT rowid AS keep_rowid,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY chat_id, COALESCE(thread_id, ''), message_id
+                   ORDER BY ts DESC, rowid DESC
+                 ) AS rn
+          FROM messages
+        )
+        WHERE rn = 1
+      )
+    `)
+    db.exec(
+      `CREATE UNIQUE INDEX IF NOT EXISTS ${LOGICAL_KEY_INDEX} ` +
+        `ON messages (chat_id, COALESCE(thread_id, ''), message_id)`,
+    )
+  }
+
   // Readable by owner and others so the web dashboard (different uid than the
   // agent) can stream replies back to Hermes Desktop. The WAL sidecar files
   // (-shm/-wal) are also chmod'd so SQLite readonly opens succeed for uid=1000.

--- a/telegram-plugin/tests/history.test.ts
+++ b/telegram-plugin/tests/history.test.ts
@@ -542,14 +542,14 @@ describe('hasOutboundDeliveredSince', () => {
   })
 })
 
-// H3 regression: the original PRIMARY KEY (chat_id, thread_id, message_id) does
+// Review finding H5 regression: the original PRIMARY KEY (chat_id, thread_id, message_id) does
 // NOT dedupe thread-less rows because SQLite treats NULL as distinct from NULL
 // in a UNIQUE/PK index. The documented at-least-once boot replay re-records an
 // already-stored DM/non-topic message, so `INSERT OR REPLACE` appended a
 // DUPLICATE row instead of replacing — over-counting the silence / over-ping
 // detectors. The COALESCE(thread_id,'') unique index makes the upsert
 // idempotent. These tests fail (duplicate rows) without the fix.
-describe('idempotent upsert for null-thread rows (H3)', () => {
+describe('idempotent upsert for null-thread rows (H5)', () => {
   beforeEach(() => initHistory(stateDir, 30))
 
   it('re-recording the same null-thread inbound yields exactly ONE row', () => {
@@ -642,7 +642,7 @@ describe('idempotent upsert for null-thread rows (H3)', () => {
     ).run('-100', 7, now, 'topic row')
     raw.close()
 
-    // Re-open through initHistory → runs the H3 migration (dedupe + index).
+    // Re-open through initHistory → runs the H5 migration (dedupe + index).
     initHistory(stateDir, 30)
     const general = query({ chat_id: '-100', thread_id: null })
     expect(general).toHaveLength(1)

--- a/telegram-plugin/tests/history.test.ts
+++ b/telegram-plugin/tests/history.test.ts
@@ -542,6 +542,121 @@ describe('hasOutboundDeliveredSince', () => {
   })
 })
 
+// H3 regression: the original PRIMARY KEY (chat_id, thread_id, message_id) does
+// NOT dedupe thread-less rows because SQLite treats NULL as distinct from NULL
+// in a UNIQUE/PK index. The documented at-least-once boot replay re-records an
+// already-stored DM/non-topic message, so `INSERT OR REPLACE` appended a
+// DUPLICATE row instead of replacing — over-counting the silence / over-ping
+// detectors. The COALESCE(thread_id,'') unique index makes the upsert
+// idempotent. These tests fail (duplicate rows) without the fix.
+describe('idempotent upsert for null-thread rows (H3)', () => {
+  beforeEach(() => initHistory(stateDir, 30))
+
+  it('re-recording the same null-thread inbound yields exactly ONE row', () => {
+    const msg = {
+      chat_id: '-100',
+      thread_id: null,
+      message_id: 7,
+      user: 'alice',
+      user_id: '111',
+      ts: 1000,
+      text: 'hello',
+    }
+    // Simulate the at-least-once replay: record the same message twice.
+    recordInbound(msg)
+    recordInbound(msg)
+    const rows = query({ chat_id: '-100' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ message_id: 7, role: 'user', text: 'hello' })
+    // The over-count surface the finding calls out must stay accurate.
+    expect(getRecentOutboundCount('-100', 999_999)).toBe(0)
+  })
+
+  it('re-recording the same null-thread outbound yields exactly ONE row', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const send = {
+      chat_id: '-100',
+      thread_id: null,
+      message_ids: [42],
+      texts: ['the answer'],
+      ts: now,
+    }
+    recordOutbound(send)
+    recordOutbound(send)
+    const rows = query({ chat_id: '-100' })
+    expect(rows).toHaveLength(1)
+    // hasOutboundDeliveredSince / getRecentOutboundCount read this table; a
+    // duplicate here would double-count and over-ping.
+    expect(getRecentOutboundCount('-100', 60)).toBe(1)
+  })
+
+  it('a re-record REPLACES rather than appends (newest text wins)', () => {
+    recordInbound({ chat_id: '-100', thread_id: null, message_id: 7, user: 'a', user_id: '1', ts: 1000, text: 'first version' })
+    recordInbound({ chat_id: '-100', thread_id: null, message_id: 7, user: 'a', user_id: '1', ts: 1000, text: 'second version' })
+    const rows = query({ chat_id: '-100' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.text).toBe('second version')
+  })
+
+  it('a topic row and a general row with the SAME message_id stay DISTINCT', () => {
+    // Same chat_id + message_id, but one is in a forum topic (thread 5) and one
+    // is the general/DM row (null thread). These are different logical messages
+    // and must both survive — the COALESCE sentinel keeps them separate.
+    recordInbound({ chat_id: '-100', thread_id: 5, message_id: 9, user: 'a', user_id: '1', ts: 100, text: 'in topic 5' })
+    recordInbound({ chat_id: '-100', thread_id: null, message_id: 9, user: 'a', user_id: '1', ts: 100, text: 'in general' })
+    expect(query({ chat_id: '-100' })).toHaveLength(2)
+    expect(query({ chat_id: '-100', thread_id: 5 }).map(r => r.text)).toEqual(['in topic 5'])
+    expect(query({ chat_id: '-100', thread_id: null }).map(r => r.text)).toEqual(['in general'])
+  })
+
+  it('two distinct forum topics with the same message_id stay DISTINCT', () => {
+    recordInbound({ chat_id: '-100', thread_id: 5, message_id: 9, user: 'a', user_id: '1', ts: 100, text: 'topic5' })
+    recordInbound({ chat_id: '-100', thread_id: 6, message_id: 9, user: 'a', user_id: '1', ts: 100, text: 'topic6' })
+    expect(query({ chat_id: '-100' })).toHaveLength(2)
+    expect(query({ chat_id: '-100', thread_id: 5 }).map(r => r.text)).toEqual(['topic5'])
+    expect(query({ chat_id: '-100', thread_id: 6 }).map(r => r.text)).toEqual(['topic6'])
+  })
+
+  it('migration de-dupes pre-existing null-thread duplicates from a legacy DB', async () => {
+    // Simulate a DB written by the pre-fix build: insert duplicate null-thread
+    // rows DIRECTLY, bypassing the (now-fixed) upsert, to reproduce the exact
+    // corruption the finding describes. Then re-init to fire the migration.
+    const { Database } = await import('bun:sqlite')
+    const dbPath = join(stateDir, 'history.db')
+    const now = Math.floor(Date.now() / 1000) // recent ts so the retention sweep keeps them
+    _resetForTests()
+    const raw = new Database(dbPath)
+    // Drop the logical-key index so we're back to the legacy, dupe-permitting
+    // schema, then append two rows sharing the same (chat, null-thread, msg).
+    raw.exec('DROP INDEX IF EXISTS idx_messages_logical_key')
+    const insert = raw.prepare(
+      `INSERT INTO messages (chat_id, thread_id, message_id, role, user, user_id, ts, text, group_id)
+       VALUES (?, NULL, ?, 'user', 'a', '1', ?, ?, NULL)`,
+    )
+    insert.run('-100', 7, now, 'stale copy')
+    insert.run('-100', 7, now + 1, 'newest copy')
+    // A distinct topic row with the same message_id must survive the migration.
+    raw.prepare(
+      `INSERT INTO messages (chat_id, thread_id, message_id, role, user, user_id, ts, text, group_id)
+       VALUES (?, 5, ?, 'user', 'a', '1', ?, ?, NULL)`,
+    ).run('-100', 7, now, 'topic row')
+    raw.close()
+
+    // Re-open through initHistory → runs the H3 migration (dedupe + index).
+    initHistory(stateDir, 30)
+    const general = query({ chat_id: '-100', thread_id: null })
+    expect(general).toHaveLength(1)
+    expect(general[0]?.text).toBe('newest copy') // kept the newest (highest ts/rowid)
+    // The topic row with the same message_id is untouched.
+    expect(query({ chat_id: '-100', thread_id: 5 }).map(r => r.text)).toEqual(['topic row'])
+    expect(query({ chat_id: '-100' })).toHaveLength(2)
+
+    // And the upsert is idempotent going forward.
+    recordInbound({ chat_id: '-100', thread_id: null, message_id: 7, user: 'a', user_id: '1', ts: now + 2, text: 'replay' })
+    expect(query({ chat_id: '-100', thread_id: null })).toHaveLength(1)
+  })
+})
+
 describe('secret redaction at persistence (both directions)', () => {
   beforeEach(() => initHistory(stateDir, 30))
 


### PR DESCRIPTION
## Summary

Fixes HIGH correctness finding **H3**: the history table's `INSERT OR REPLACE` is non-idempotent for every DM / non-topic message, so the documented at-least-once boot replay **appends duplicate rows** instead of replacing them.

The `messages` table PK is `(chat_id, thread_id, message_id)`, but `thread_id` is nullable and SQLite treats `NULL` as **distinct** from `NULL` in a PK/UNIQUE index. Every DM and every non-topic group message has `thread_id = NULL`, so two inserts of the same `(chat_id, message_id)` with a null thread never conflict — `INSERT OR REPLACE` appends a second row.

## Why it matters

On the documented at-least-once boot replay / synthesized-resume re-record, an already-stored message is duplicated. Those duplicates show up doubled in `get_recent_messages` and over-count `getRecentOutboundCount` / `hasOutboundDeliveredSince`, which feed the **silence / over-ping** detectors. Forum-topic rows (non-null thread) were unaffected.

## Fix (durable, deterministic)

Add a `UNIQUE` index over `(chat_id, COALESCE(thread_id, ''), message_id)`. `COALESCE` maps the null thread to a non-null `''` sentinel **in the uniqueness key only**, so `INSERT OR REPLACE` conflict-resolves and dedupes thread-less rows. It resolves against any unique index, so **no writer change is needed**.

- A forum-topic row (non-null thread) and a general row (`NULL` thread) sharing a `message_id` keep **distinct** keys (topic id vs `''`) and stay separate.
- Stored `thread_id` values remain real `NULL`s — every read path (`thread_id IS NULL` / `thread_id = ?`) is unchanged.

### Migration

Runs once, guarded on index existence: (1) de-dupe any rows a pre-fix build already appended, keeping the **newest row per logical key** (highest `ts`, then highest `rowid`); (2) create the `UNIQUE` index. New DBs: de-dupe is a no-op. Existing rows are de-duped before the index is created (else `CREATE UNIQUE INDEX` would fail on the dupes).

## Test plan

`bun test telegram-plugin/tests/history.test.ts` — added `describe('idempotent upsert for null-thread rows (H3)')` asserting outcomes: re-recording the same `(chat, null-thread, message_id)` inbound/outbound yields exactly **one** row; a re-record **replaces** rather than appends; a topic row and a general row with the same `message_id` stay **distinct**; two distinct topics with the same `message_id` stay **distinct**; the migration de-dupes a legacy DB while preserving the distinct topic row.

**4 of these fail without the fix** (stashing `history.ts`: `47 pass / 4 fail` → `51 pass / 0 fail`). Full file + `history-reaper.test.ts`: `64 pass / 0 fail`. `tsc --noEmit` clean.

## Risk

Low. Read paths and stored values unchanged; the only behavior change is a re-recorded thread-less message now replaces instead of duplicating (the intended `INSERT OR REPLACE` contract). The one-time migration is idempotent and bounded.

Job spec: always-available / chat-is-source-of-truth — restart-replay history must not corrupt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)