### PR TITLE
fix(auth): treat absent 7d utilization as unknown, preserve exhaustion mark

### DIFF
--- a/src/auth/broker/account-eligibility.test.ts
+++ b/src/auth/broker/account-eligibility.test.ts
@@ -8,6 +8,7 @@ import {
   clampMarkExpiry,
   snapshotFresh,
   snapshotWalled,
+  snapshotComplete,
   snapshotClearlyHealthy,
   overageLiftsWall,
   OVERAGE_EXHAUSTED_REASONS,
@@ -275,7 +276,14 @@ describe("snapshotShouldClearMark — self-heal", () => {
       sevenDayUtilPresent: true,
     };
     expect(snapshotShouldClearMark(real, mark, NOW)).toBe(true);
-    // And a partial probe (5h present, 7d absent) is NOT thin → clears.
+    // F0 (was the unsafe assertion) — a PARTIAL probe (5h present healthy, 7d
+    // ABSENT) must NOT clear the mark. The absent 7d header coalesces to a
+    // filler 0% that reads "clearly healthy", but the probe never measured the
+    // weekly window — so clearing a 7-day exhaustion mark off it durably
+    // re-serves a genuinely weekly-walled account (the F0 inversion). The old
+    // assertion expected `true` ("NOT thin → clears"); that was wrong because
+    // "not thin" (≥1 window) is a weaker bar than "complete" (BOTH windows) —
+    // only a complete probe is evidence of health on the marked window.
     const partial: QuotaSnapshot = {
       fiveHourUtilizationPct: 4,
       sevenDayUtilizationPct: 0,
@@ -283,7 +291,7 @@ describe("snapshotShouldClearMark — self-heal", () => {
       fiveHourUtilPresent: true,
       sevenDayUtilPresent: false,
     };
-    expect(snapshotShouldClearMark(partial, mark, NOW)).toBe(true);
+    expect(snapshotShouldClearMark(partial, mark, NOW)).toBe(false);
   });
   it("out_of_credits at 0% util DOES clear a mark — a healthy low-util probe self-heals normally", () => {
     // THE KEY CHANGE from the 2026-06-20 guard: out_of_credits is informational.
@@ -307,6 +315,92 @@ describe("snapshotShouldClearMark — self-heal", () => {
     expect(
       snapshotShouldClearMark(snap(85, 20, 0, { reason: "out_of_credits" }), mark, NOW),
     ).toBe(false); // 85% >= 80% → not clearly healthy → no clear
+  });
+});
+
+describe("F0/F4b — partial-probe & fresh-wall eligibility safety", () => {
+  // A partial probe: 5h window present & healthy, 7d window ABSENT (the real
+  // "7d missing, 5h present" case). The absent 7d coalesces to a filler 0%.
+  const partial = (fiveHourPct: number, ageMs = 30_000): QuotaSnapshot => ({
+    fiveHourUtilizationPct: fiveHourPct,
+    sevenDayUtilizationPct: 0, // filler — 7d header was absent
+    capturedAt: NOW - ageMs,
+    fiveHourUtilPresent: true,
+    sevenDayUtilPresent: false,
+  });
+
+  it("snapshotComplete — false when either window is absent, true otherwise", () => {
+    expect(snapshotComplete(partial(4))).toBe(false);
+    expect(
+      snapshotComplete({ ...partial(4), fiveHourUtilPresent: false, sevenDayUtilPresent: false }),
+    ).toBe(false);
+    // Both present → complete; unset flags (legacy/cached) → treated as complete.
+    expect(snapshotComplete({ ...partial(4), sevenDayUtilPresent: true })).toBe(true);
+    expect(snapshotComplete(snap(4, 20, 0))).toBe(true);
+  });
+
+  it("F0 — a partial probe (7d absent) PRESERVES an existing weekly-exhaustion mark (does not self-heal)", () => {
+    // The exact F0 incident: account walled its weekly window → +7d mark. Next
+    // probe returns 5h=4% healthy but Anthropic omits the 7d header. The mark
+    // must NOT be cleared — the probe never saw the weekly window.
+    const weeklyMark: ExhaustionMark = {
+      exhausted_until: NOW + 7 * 24 * 60 * 60 * 1000,
+      marked_at: NOW - 60_000,
+    };
+    expect(snapshotShouldClearMark(partial(4), weeklyMark, NOW)).toBe(false);
+    // Sanity: the SAME probe but with 7d actually measured healthy DOES clear.
+    const complete: QuotaSnapshot = { ...partial(4), sevenDayUtilPresent: true };
+    expect(snapshotShouldClearMark(complete, weeklyMark, NOW)).toBe(true);
+  });
+
+  it("F0 — a partial probe (7d absent) does NOT re-serve a weekly-walled account", () => {
+    // With the mark preserved, eligibility must still block: the partial probe
+    // is not a complete health signal, so it cannot override the weekly mark.
+    const weeklyMark: ExhaustionMark = {
+      exhausted_until: NOW + 7 * 24 * 60 * 60 * 1000,
+      marked_at: NOW - 60_000, // OLDER than the probe: partial probe would else "win"
+    };
+    expect(accountEligibility({ mark: weeklyMark, snapshot: partial(4), now: NOW })).toBe("blocked");
+    expect(isAccountBlocked({ mark: weeklyMark, snapshot: partial(4), now: NOW })).toBe(true);
+    // No mark + partial healthy probe → not a confident 'eligible': the missing
+    // window is UNKNOWN, so the account is 'unknown' (force-probe), not served.
+    expect(accountEligibility({ snapshot: partial(4), now: NOW })).toBe("unknown");
+  });
+
+  it("F0 — a partial probe with the PRESENT window walled still blocks (positive evidence survives)", () => {
+    // Safety is symmetric: a measured wall on 5h blocks regardless of the absent
+    // 7d window — the absent window is unknown, the present one is positive.
+    expect(accountEligibility({ snapshot: partial(100), now: NOW })).toBe("blocked");
+  });
+
+  it("F0 — clampMarkExpiry does NOT clamp a +7d mark on a partial (7d-absent) probe", () => {
+    // A legit gateway-parsed weekly reset must hold: a 7d-absent probe cannot
+    // contradict the weekly wall, so the long mark is trusted (not clamped to 5h).
+    const proposed = NOW + 7 * 24 * 60 * 60 * 1000;
+    expect(
+      clampMarkExpiry({ proposedUntil: proposed, now: NOW, shortMs: FIVE_H, snapshot: partial(4) }),
+    ).toBe(proposed);
+    // Contrast: 7d present & healthy DOES clamp (unchanged behavior).
+    const complete: QuotaSnapshot = { ...partial(4), sevenDayUtilPresent: true };
+    expect(
+      clampMarkExpiry({ proposedUntil: proposed, now: NOW, shortMs: FIVE_H, snapshot: complete }),
+    ).toBe(NOW + FIVE_H);
+  });
+
+  it("F4b — a fresh over-wall snapshot is NOT discarded by an expired-but-newer mark", () => {
+    // Wall observed fresh at T1 (99.6%). A shorter mark was written at T2>T1 and
+    // has since expired. Pre-fix: snapshot older than mark → live branch skipped;
+    // expired mark → no block → 'unknown' (servable). A fresh positive wall must
+    // block regardless of the expired mark's newer timestamp.
+    const expiredNewerMark: ExhaustionMark = {
+      exhausted_until: NOW - 1_000, // expired
+      marked_at: NOW - 10_000, // NEWER than the snapshot below
+    };
+    const freshWall = snap(99.6, 27, 60_000); // capturedAt older than marked_at
+    expect(accountEligibility({ mark: expiredNewerMark, snapshot: freshWall, now: NOW })).toBe(
+      "blocked",
+    );
+    expect(isAccountBlocked({ mark: expiredNewerMark, snapshot: freshWall, now: NOW })).toBe(true);
   });
 });
 

--- a/src/auth/broker/account-eligibility.ts
+++ b/src/auth/broker/account-eligibility.ts
@@ -18,8 +18,6 @@
  * PURE — no I/O, no clock except the injected `now`. Fully unit-tested.
  */
 
-import { isProbeThin } from "../quota.js";
-
 /**
  * Utilization at/above this on either window is a hard wall. Matches
  * `EXHAUSTION_PCT` in consumer-quota-sensor.ts and `classifyHealth`'s
@@ -162,6 +160,28 @@ export function snapshotWalled(s: QuotaSnapshot): boolean {
 }
 
 /**
+ * Is this snapshot a COMPLETE utilization signal — did the probe actually
+ * measure BOTH windows?
+ *
+ * `parseQuotaHeaders` (quota.ts) coalesces a MISSING window header to `0%` for
+ * back-compat while recording `*UtilPresent === false`. That coalesced `0` is a
+ * FILLER, not a measurement: it is indistinguishable, on the numeric field
+ * alone, from a genuine 0% reading. An unset `*UtilPresent` flag means the
+ * snapshot predates the flag (cached/legacy fixture) and is treated as a real
+ * probe — so completeness keys strictly on `=== false`.
+ *
+ * A PARTIAL probe (one window absent) must never be trusted to (a) rule an
+ * account eligible/servable or (b) self-heal an exhaustion mark on the window
+ * it never measured. Treating the absent window's filler `0%` as healthy
+ * durably re-serves a genuinely weekly-walled account off a probe that never
+ * saw the weekly (7d) window — the F0 inversion this guard exists to prevent.
+ * The absent window is UNKNOWN, not healthy. PURE — no I/O.
+ */
+export function snapshotComplete(s: QuotaSnapshot): boolean {
+  return s.fiveHourUtilPresent !== false && s.sevenDayUtilPresent !== false;
+}
+
+/**
  * Is this account allowed to be served past the utilization wall via Anthropic
  * overage billing? True when ALL of:
  *   1. The account is in the operator's `allow_overage_accounts` opt-in list.
@@ -238,24 +258,47 @@ export function accountEligibility(opts: {
   allowOverage?: boolean;
 }): AccountEligibility {
   const { mark, snapshot, now, allowOverage = false } = opts;
+
+  // F4b — a FRESH snapshot that POSITIVELY shows a hard wall (and is not
+  // overage-lifted) is the strongest live truth there is. It must NOT be
+  // discarded just because a mark carries a newer timestamp but has since
+  // expired: the most-recent-signal-wins branch below skips an older-than-mark
+  // snapshot, and an expired mark yields no block, so the pre-fix path ruled a
+  // genuinely-walled account `unknown` (→ servable). Block on the live wall
+  // directly. Overage-lifted walls fall through to the most-recent-signal-wins
+  // logic so a NEWER `overageStatus:"allowed"` re-probe can still serve past
+  // the wall (that is what overage exists for).
+  if (
+    snapshotFresh(snapshot, now) &&
+    snapshotWalled(snapshot) &&
+    !overageLiftsWall(snapshot, allowOverage)
+  ) {
+    return "blocked";
+  }
+
   if (snapshotFresh(snapshot, now)) {
     const markedAt = mark?.marked_at ?? 0;
     if (snapshot.capturedAt >= markedAt) {
-      // Live truth is the newer signal → it decides, mark ignored. Walled on
-      // util → blocked, UNLESS overage is active for this account (opt-in).
+      // Live truth is the newer signal → it decides, mark ignored.
       if (snapshotWalled(snapshot)) {
-        if (overageLiftsWall(snapshot, allowOverage)) {
-          // The util wall fires but overage is available — account stays eligible.
-          return "eligible";
-        }
+        // Reachable only when overage lifts the wall (the non-lifted fresh wall
+        // already returned 'blocked' above) — the account stays eligible via
+        // Anthropic overage billing.
+        if (overageLiftsWall(snapshot, allowOverage)) return "eligible";
         return "blocked";
       }
-      return "eligible";
+      // F0 — a PARTIAL probe (a window absent, coalesced to a filler 0%) is not
+      // a COMPLETE health signal: it cannot prove the unmeasured window healthy,
+      // so it must NOT rule the account eligible off a window it never saw (e.g.
+      // clearing a weekly 7d wall on a 7d-absent probe). Defer to the mark
+      // instead. A complete probe rules eligible exactly as before.
+      if (snapshotComplete(snapshot)) return "eligible";
     }
   }
-  // No usable live truth (or the mark is newer) → the mark is the only signal.
-  // Unexpired mark → blocked. No mark (or expired) and no fresh snapshot →
-  // unknown: we have ZERO positive evidence, so this is not a hard block.
+  // No usable live truth (or the mark is newer, or the fresh probe was partial)
+  // → the mark is the only signal. Unexpired mark → blocked. No mark (or
+  // expired) and no usable snapshot → unknown: ZERO positive evidence, not a
+  // hard block.
   if (mark !== undefined && mark.exhausted_until > now) return "blocked";
   return "unknown";
 }
@@ -298,12 +341,16 @@ export function snapshotShouldClearMark(
   if (!mark) return false;
   if (!snapshotFresh(snapshot, now)) return false;
   if (snapshot.capturedAt < (mark.marked_at ?? 0)) return false;
-  // #2495 folded nit B — a THIN probe (no util headers, both windows coalesced
-  // to 0) is NOT evidence of health: `snapshotClearlyHealthy` reads it as 0%/0%
-  // and would clear a real exhaustion mark off a headerless response. Refuse to
-  // self-heal a mark on a thin probe; require a probe that actually measured at
-  // least one window before clearing.
-  if (isProbeThin(snapshot)) return false;
+  // F0 (#2495 folded nit B, widened) — a probe that did not measure a window is
+  // NOT evidence that window is healthy: `parseQuotaHeaders` coalesces an absent
+  // header to a filler 0% and `snapshotClearlyHealthy` reads that as 0% < 80% →
+  // "healthy". A THIN probe (both windows absent) OR a PARTIAL probe (one window
+  // absent, e.g. the real "7d missing, 5h present" case) would therefore clear a
+  // genuine exhaustion mark on the window it never saw — durably re-serving a
+  // weekly-walled account. Require a COMPLETE probe (both windows actually
+  // measured) before self-healing a mark. (Completeness subsumes the old thin
+  // check: both-absent is also not complete.)
+  if (!snapshotComplete(snapshot)) return false;
   // out_of_credits is informational (no overage headroom), NOT a serve-block.
   // A 0%-util account with out_of_credits is healthy from a quota standpoint and
   // SHOULD self-heal a misfired mark. The 2026-06-20 guard here was the defect:
@@ -336,8 +383,16 @@ export function clampMarkExpiry(opts: {
   const { proposedUntil, now, shortMs, snapshot } = opts;
   const shortCeil = now + shortMs;
   if (proposedUntil <= shortCeil) return proposedUntil;
+  // F0 — only a probe that ACTUALLY measured the 7-day window can contradict a
+  // weekly wall. A partial probe with the 7d header absent coalesces to a filler
+  // 0% (< WALL_PCT); trusting that would clamp a legitimate gateway-parsed +7d
+  // weekly mark down to 5h off a probe that never saw the weekly window. Require
+  // the 7d window PRESENT before it may disprove the weekly wall; otherwise the
+  // caller's proposed weekly reset is trusted (the #2218 durability path).
   const liveContradictsWeeklyWall =
-    snapshotFresh(snapshot, now) && snapshot.sevenDayUtilizationPct < WALL_PCT;
+    snapshotFresh(snapshot, now) &&
+    snapshot.sevenDayUtilPresent !== false &&
+    snapshot.sevenDayUtilizationPct < WALL_PCT;
   return liveContradictsWeeklyWall ? shortCeil : proposedUntil;
 }
 


### PR DESCRIPTION
## Summary

Fixes **F0 (HIGH)** and the folded-in **F4b (MEDIUM)** from the `src/auth` security review (`code-review-20260711/auth.md`).

An absent `anthropic-ratelimit-unified-7d-utilization` response header coalesces to a **filler 0%** in `quota.ts::parseQuotaHeaders` while recording `sevenDayUtilPresent: false`. Every decision predicate in `broker/account-eligibility.ts` read the coalesced `0` and **none consulted the presence flag**. The `isProbeThin` guard only tripped when *both* windows were absent (dead for live probes, since both-absent already returns `ok:false` upstream). The reachable case is the *partial* probe the code itself names as real ("7d missing, 5h present").

### F0 failure scenario (verified in code)
1. Account walls its weekly (7d) window -> 429 -> `mark-exhausted` writes `{exhausted_until: now+7d}`.
2. Next probe returns 5h=4% healthy but Anthropic omits the 7d header -> snapshot `{five:4, seven:0 (coalesced), sevenDayUtilPresent:false}`.
3. `snapshotShouldClearMark`: not thin, `snapshotClearlyHealthy(4, 0)=true` -> **deletes the weekly mark and persists**.
4. `accountEligibility`: fresh snapshot newer than the (now-gone) mark, `snapshotWalled(4,0)=false` -> **eligible** -> the genuinely-walled account returns to the serving/failover pool and every routed agent 429s again. `clampMarkExpiry` is defeated identically (a legit +7d mark clamps to 5h because it reads 7d=0 < WALL).

## Fix (durable, fail-safe)

New pure predicate `snapshotComplete(s)`: a probe is a complete health signal only when **both** windows were actually measured (`*UtilPresent !== false`; unset = legacy/cached = present). An absent window is treated as **UNKNOWN, not healthy 0%**.

- **`snapshotShouldClearMark`** — require a COMPLETE probe before self-healing a mark. Widens the #2495 thin-probe guard from "both absent" to "any absent" (thin subset of incomplete), so a partial probe can never clear a mark on the window it never measured.
- **`accountEligibility`** — a partial probe still **blocks** on a *measured* wall (positive evidence survives), but can no longer rule an account `eligible` off a window it never saw; it defers to the mark. A no-mark partial-healthy probe is `unknown` (force-probe), not a confident `eligible`.
- **`clampMarkExpiry`** — only a probe with the 7d window PRESENT may contradict a weekly wall; a 7d-absent probe no longer clamps a legitimate gateway-parsed +7d mark down to 5h (#2218 durability path preserved).

### F4b (same path)
A **fresh, positively-walled** snapshot is now hard block evidence that is never discarded because a mark carries a newer timestamp but an expired `exhausted_until` (previously fell through to `unknown` -> servable). Overage-lifted walls still follow most-recent-signal-wins, so a newer `overageStatus:"allowed"` re-probe can serve past the wall.

The presence flags already round-trip through `server.ts::cacheQuotaSnapshot` and the cache reload (#2494), so this pure-layer fix needs no plumbing changes.

## The changed-test judgment call

`account-eligibility.test.ts` had a green test (**#2495 nit B**) asserting the **UNSAFE** outcome: a 5h-present / 7d-absent probe **clears** the mark ("NOT thin -> clears"). That assertion was wrong — **"not thin" (>=1 window measured) is a strictly weaker bar than "complete" (BOTH windows measured)**, and only a complete probe is evidence of health on the *marked* window. Clearing a weekly mark off a probe that never saw the weekly window is exactly the F0 re-serve. The assertion is **inverted** to expect no-clear, with a comment explaining why the old one was wrong.

Added a `F0/F4b — partial-probe & fresh-wall eligibility safety` block that **asserts outcomes** (not code paths): a partial probe preserves the weekly mark and does not re-serve; a measured wall still blocks; clamp is not applied; a fresh wall survives an expired-newer mark. **5 assertions fail against the pre-fix logic; all pass with the fix.**

## Testing

- Scoped: `vitest run` over `account-eligibility.test.ts` + `server.test.ts` + `server-soft-avoid.test.ts` + `server-quota-durable.test.ts` + `consumer-quota-sensor.test.ts` + `server-override-pin-walled.test.ts` + `telegram-plugin/tests/quota-check.test.ts` -> **221 passed**.
- `tsc --noEmit` -> clean (0 errors).
- Proof the tests bite: reverted the decision logic, kept the tests -> **5 failed** (F0 preserve-mark, F0 no-reserve, F0 no-clamp, F4b fresh-wall, inverted #2495 partial). Restored -> all green.

Full-suite gate is CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)