### PR TITLE
fix(telegram): close session/sub-agent FSWatchers at runtime to stop FD leak

### DIFF
--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -781,6 +781,13 @@ export interface SessionTailConfig {
   claudeHome?: string
   /** How often to re-scan for a new active session file (ms). Default 500. */
   rescanIntervalMs?: number
+  /**
+   * Idle window before an inactive sub-agent FSWatcher (and its PreToolUse
+   * sidecar) is reaped, in ms. Defaults to 5 minutes — well past the 99th-
+   * percentile sub-agent completion time. Exposed only so tests can drive the
+   * reap deterministically without a 5-minute wall-clock wait.
+   */
+  subTailIdleReapMs?: number
   /** Optional logger. */
   log?: (msg: string) => void
   /** Called for each parsed event. */
@@ -913,6 +920,22 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
       return null
     }
   }
+  /**
+   * M1 FD-leak fix: stop and forget the PreToolUse sidecar for a session that
+   * has ended (a rotated-away parent session, or a reaped sub-agent). Each
+   * sidecar holds its own stat-poll timer (and, on real fs, a file handle);
+   * pre-fix they were only reaped in `stop()`, so every session rotation
+   * (`/clear`, compaction → new sessionId) and every finished sub-agent leaked
+   * one for the gateway's life. Idempotent — a no-op when the key is absent.
+   */
+  function stopSidecar(sessionId: string | null): void {
+    if (!sessionId) return
+    const s = sidecars.get(sessionId)
+    if (!s) return
+    try { s.stop() } catch { /* ignore */ }
+    sidecars.delete(sessionId)
+  }
+
   function decorate(ev: SessionEvent, sessionId: string | null): SessionEvent {
     if (!sessionId) return ev
     if (ev.kind !== 'tool_use' && ev.kind !== 'sub_agent_tool_use') return ev
@@ -1024,6 +1047,19 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
       try { watcher.close() } catch { /* ignore */ }
       watcher = null
     }
+    // M1 FD-leak fix: we are rotating the PARENT tail off `currentFile`; its
+    // PreToolUse sidecar is no longer needed (its watcher just closed). Reap it
+    // so `/clear`- and compaction-driven session rotations don't accumulate one
+    // idle sidecar poll-timer per rotation. Parent session ids are the JSONL
+    // stem (`<uuid>`); sub-agent sidecars are keyed by `agent-<id>` stems and
+    // owned by their sub-tail (reaped in `reapIdleSubTails`), so this never
+    // stops a sidecar a live sub-tail still depends on. A later re-attach to
+    // this same file transparently recreates the sidecar via `ensureSidecar`.
+    const rotatedAwaySid = sessionIdForFile(currentFile)
+    const nextSid = sessionIdForFile(file)
+    if (rotatedAwaySid != null && rotatedAwaySid !== nextSid) {
+      stopSidecar(rotatedAwaySid)
+    }
     currentFile = file
     const prior = fileCursors.get(file)
     if (prior != null) {
@@ -1113,7 +1149,7 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
    * very-long task (rescanSubagents picks the file back up on the
    * next tick if it grows).
    */
-  const IDLE_FSWATCH_TTL_MS = 5 * 60 * 1000
+  const IDLE_FSWATCH_TTL_MS = config.subTailIdleReapMs ?? 5 * 60 * 1000
 
   function readSub(t: SubTail): void {
     if (stopped) return
@@ -1254,6 +1290,13 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
           try { t.watcher.close() } catch { /* ignore */ }
           t.watcher = null
         }
+        // M1 FD-leak fix: reap the sub-agent's PreToolUse sidecar alongside its
+        // file watcher. Sub-agent sidecars are keyed by the sub file's stem
+        // (`agent-<id>`), created lazily by `decorate` while reading the sub
+        // JSONL. Pre-fix `reapIdleSubTails` closed the sub-tail watcher but left
+        // the sidecar (and its poll timer) alive until `stop()`, so a long-lived
+        // agent leaked one sidecar per finished sub-agent.
+        stopSidecar(sessionIdForFile(t.file))
         subTails.delete(file)
         log?.(`session-tail: reaped idle sub ${t.agentId} (${file})`)
       }

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -41,7 +41,7 @@ function isMultiAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return env.PROGRESS_CARD_MULTI_AGENT !== '0'
 }
 import { classifyClaudeError, type OperatorEventKind } from './operator-events.js'
-import { createToolLabelSidecar, type ToolLabelSidecar } from './tool-label-sidecar.js'
+import { createToolLabelSidecar, type ToolLabelSidecar, type SidecarOptions } from './tool-label-sidecar.js'
 import { isModelSentinel } from './model-label.js'
 
 /** Match Claude Code's cli.js VX() function. */
@@ -798,6 +798,18 @@ export interface SessionTailConfig {
    * TODO(Phase 4b): wire this to the gateway's emitOperatorEvent pipeline.
    */
   onOperatorEvent?: (event: TailOperatorEvent) => void
+  /**
+   * PreToolUse sidecar factory. Defaults to the real `createToolLabelSidecar`;
+   * production never sets this. It exists as a dependency-injection seam so the
+   * M1 FD-leak reap test can drive a fake sidecar per session WITHOUT
+   * `vi.mock`-ing the shared `tool-label-sidecar` module: bun's `vi.mock` is
+   * process-global (not file-scoped like vitest), and the CI bun-test shard
+   * runs the whole `tests/` dir in ONE process, so a module-mock here would
+   * leak into the real `tool-label-sidecar.test.ts` suite and break it. This
+   * mirrors the repo's bun-safe injection precedent (`vault-write-posture`'s
+   * optional `deps` param).
+   */
+  createSidecar?: (opts: SidecarOptions) => ToolLabelSidecar
 }
 
 export interface SessionTailHandle {
@@ -894,6 +906,7 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
   // $TELEGRAM_STATE_DIR/tool-labels-<session_id>.jsonl. Each sub-agent
   // has its OWN sessionId (its jsonl filename stem), so we key by that.
   const sidecars = new Map<string, ToolLabelSidecar>()
+  const createSidecar = config.createSidecar ?? createToolLabelSidecar
   const stateDirForSidecar = process.env.TELEGRAM_STATE_DIR ?? null
   function sessionIdForFile(file: string | null): string | null {
     if (!file) return null
@@ -905,7 +918,7 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
     const existing = sidecars.get(sessionId)
     if (existing) return existing
     try {
-      const s = createToolLabelSidecar({ stateDir: stateDirForSidecar, sessionId })
+      const s = createSidecar({ stateDir: stateDirForSidecar, sessionId })
       sidecars.set(sessionId, s)
       // Real-time draft-mirror source: emit a `tool_label` event the moment
       // the hook writes a label (flush-independent), so the gateway can

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -1149,7 +1149,12 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
    * very-long task (rescanSubagents picks the file back up on the
    * next tick if it grows).
    */
-  const IDLE_FSWATCH_TTL_MS = config.subTailIdleReapMs ?? 5 * 60 * 1000
+  // Floor-clamp the reap window: a 0 / negative override would make
+  // `reapIdleSubTails` treat every live sub-tail as instantly idle
+  // (cutoff = Date.now() - 0 ≥ lastActivityAt), reaping every live
+  // sidecar on the first tick. Only tests set this today, but the clamp
+  // makes the footgun unreachable — the smallest sane window is 1s.
+  const IDLE_FSWATCH_TTL_MS = Math.max(1000, config.subTailIdleReapMs ?? 5 * 60 * 1000)
 
   function readSub(t: SubTail): void {
     if (stopped) return

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -1779,21 +1779,39 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       maybySendStateTransition(agentId)
     }
 
-    // Set up FSWatcher
-    try {
-      tail.watcher = fs.watch(filePath, () => {
-        if (stopped) return
-        const entry = registry.get(agentId)
-        const t = tails.get(agentId)
-        if (!entry || !t) return
-        checkBootPromotionGrowth(entry, t, nowFn())
-        readSubTail(entry, t, nowFn(), (desc) => {
-          log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-        }, fs, log, db, parentStateDir, config.onUnstall, cleanupTerminalAgent, config.onProgress)
-        maybySendStateTransition(agentId)
-      })
-    } catch (err) {
-      log?.(`subagent-watcher: fs.watch failed for ${agentId}: ${(err as Error).message}`)
+    // Set up FSWatcher.
+    //
+    // FD-leak fix (H2): only open an inotify watch when it can do real work.
+    // A historical entry that is done-at-boot (already `scheduleTerminalCleanup`d
+    // just above) or a stale `running` entry that will never be promoted (no
+    // `bootPromotionPending`) has NO live transition left to observe —
+    // `checkStalls` skips every historical entry, so such an entry never
+    // reaches a terminal transition and `scheduleTerminalCleanup` never runs
+    // for it. Opening an `fs.watch` for one leaks its inotify FD for the whole
+    // gateway lifetime (the dozens-to-hundreds of dead prior-session
+    // `running` JSONLs a 24/7 agent accumulates). The poll loop still reads
+    // any registered running entry defensively, so dropping the watcher here
+    // costs nothing but the leaked FD. Open the watch only for a live worker
+    // or a historical one still awaiting boot-promotion growth confirmation.
+    const needsWatcher = !entry.historical || entry.bootPromotionPending != null
+    if (needsWatcher) {
+      try {
+        tail.watcher = fs.watch(filePath, () => {
+          if (stopped) return
+          const entry = registry.get(agentId)
+          const t = tails.get(agentId)
+          if (!entry || !t) return
+          checkBootPromotionGrowth(entry, t, nowFn())
+          readSubTail(entry, t, nowFn(), (desc) => {
+            log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
+          }, fs, log, db, parentStateDir, config.onUnstall, cleanupTerminalAgent, config.onProgress)
+          maybySendStateTransition(agentId)
+        })
+      } catch (err) {
+        log?.(`subagent-watcher: fs.watch failed for ${agentId}: ${(err as Error).message}`)
+      }
+    } else {
+      log?.(`subagent-watcher: ${agentId} historical/terminal at registration — not opening an FSWatcher (no live transition to observe)`)
     }
   }
 
@@ -1855,7 +1873,17 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     }
     if (n >= pending.deadlineAt) {
       entry.bootPromotionPending = undefined
-      log?.(`subagent-watcher: ${entry.agentId} never observed post-boot JSONL growth within the window — leaving historical/orphan (not promoting; avoids synthesising a stale 'completed' handback from a worker killed before this restart)`)
+      // FD-leak fix (H2): the boot-promotion window elapsed with no growth,
+      // so this entry is now a permanent historical/orphan that `checkStalls`
+      // skips — it will never reach terminal cleanup. Release the FSWatcher we
+      // opened purely for growth-confirmation now; the poll loop remains the
+      // fallback reader if the file ever resumes (rescan re-registers on a
+      // fresh transition).
+      if (tail.watcher) {
+        try { tail.watcher.close() } catch { /* ignore */ }
+        tail.watcher = null
+      }
+      log?.(`subagent-watcher: ${entry.agentId} never observed post-boot JSONL growth within the window — leaving historical/orphan (not promoting; avoids synthesising a stale 'completed' handback from a worker killed before this restart); released growth-confirmation FSWatcher`)
     }
   }
 
@@ -2386,8 +2414,35 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
    * We walk: <agentDir>/.claude/projects/ → each project dir → each session dir
    * → subagents/ → agent-*.jsonl
    */
+  /**
+   * FD-leak fix (H1): close and forget any directory FSWatcher whose watched
+   * directory no longer exists on disk. Every new Claude session mints a fresh
+   * `<sessionId>/subagents/` dir (and `workflows/wf_<id>` sub-dirs); when Claude
+   * Code reaps a prior session's directory, the scan loop below simply skips
+   * the vanished path (`existsSync` guard) WITHOUT closing the watcher it had
+   * opened for it — Node only frees the inotify FD on `.close()`, so each dead
+   * session leaked one dir watcher for the whole gateway lifetime. Sweeping on
+   * every rescan releases them deterministically the tick after the dir goes
+   * away, and also covers a slug that transitions to "foreign" (skipped by the
+   * allow-list filter below). Deleting the current key while iterating a Map's
+   * entries() is safe in JS.
+   */
+  function pruneVanishedDirWatchers(): void {
+    for (const [dirPath, w] of dirWatchers) {
+      if (!fs.existsSync(dirPath)) {
+        try { w.close() } catch { /* ignore */ }
+        dirWatchers.delete(dirPath)
+        log?.(`subagent-watcher: released dir watcher for vanished ${dirPath}`)
+      }
+    }
+  }
+
   function rescanSubagentDirs(): void {
     if (stopped) return
+    // Release watchers for directories reaped since the last tick BEFORE the
+    // early-returns below, so a projectsRoot that vanishes entirely still frees
+    // every child dir watcher.
+    pruneVanishedDirWatchers()
     const claudeHome = join(agentDir, '.claude')
     const projectsRoot = join(claudeHome, 'projects')
     if (!fs.existsSync(projectsRoot)) return

--- a/telegram-plugin/tests/session-tail-sidecar-reap.test.ts
+++ b/telegram-plugin/tests/session-tail-sidecar-reap.test.ts
@@ -20,27 +20,37 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 
 // ─── Sidecar factory mock: record every instance keyed by sessionId ──────────
-const created = vi.hoisted(() => {
+// The instance registry lives INSIDE the factory and is re-exported as a
+// test-only handle (`__sidecarInstances`) rather than closed over from a
+// `vi.hoisted` binding: bun's vitest-compat layer implements `vi.mock`/`vi.fn`
+// but NOT `vi.hoisted`, so a hoisted-closure mock throws `vi.hoisted is not a
+// function` under `bun test` (CI's bun-test-run shard runs this whole dir).
+// Same pattern as callback-query-handlers.test.ts (#3130).
+vi.mock('../tool-label-sidecar.js', () => {
   const instances: Array<{ sessionId: string; stop: ReturnType<typeof vi.fn> }> = []
-  return { instances }
+  return {
+    __sidecarInstances: instances,
+    createToolLabelSidecar: (opts: { stateDir: string; sessionId: string }) => {
+      const inst = {
+        sessionId: opts.sessionId,
+        stop: vi.fn(),
+        getLabel: () => undefined,
+        onLabel: () => () => {},
+        poll: () => {},
+      }
+      instances.push(inst)
+      return inst
+    },
+  }
 })
 
-vi.mock('../tool-label-sidecar.js', () => ({
-  createToolLabelSidecar: (opts: { stateDir: string; sessionId: string }) => {
-    const inst = {
-      sessionId: opts.sessionId,
-      stop: vi.fn(),
-      getLabel: () => undefined,
-      onLabel: () => () => {},
-      poll: () => {},
-    }
-    created.instances.push(inst)
-    return inst
-  },
-}))
-
-// Import AFTER the mock is registered.
+// Import AFTER the mock is registered. The mocked module namespace carries the
+// test-only instance registry under both runners.
 const { startSessionTail, getProjectsDirForCwd } = await import('../session-tail.js')
+const sidecarMod = (await import('../tool-label-sidecar.js')) as unknown as {
+  __sidecarInstances: Array<{ sessionId: string; stop: ReturnType<typeof vi.fn> }>
+}
+const created = { instances: sidecarMod.__sidecarInstances }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 const tempDirs: string[] = []

--- a/telegram-plugin/tests/session-tail-sidecar-reap.test.ts
+++ b/telegram-plugin/tests/session-tail-sidecar-reap.test.ts
@@ -134,9 +134,11 @@ describe('session-tail sidecar reap (M1) — idle sub-agent', () => {
       cwd,
       claudeHome,
       rescanIntervalMs: 30,
-      // Reap sub-tails idle for >250ms so the test doesn't wait 5 minutes but
-      // still leaves a comfortable window to observe the not-yet-reaped state.
-      subTailIdleReapMs: 250,
+      // Reap sub-tails idle for >1000ms so the test doesn't wait 5 minutes but
+      // still respects the L1 floor clamp (Math.max(1000, …) — a smaller value
+      // is silently lifted to 1s) and leaves a window to observe the
+      // not-yet-reaped state.
+      subTailIdleReapMs: 1000,
       onEvent: () => {},
     })
     try {
@@ -146,8 +148,109 @@ describe('session-tail sidecar reap (M1) — idle sub-agent', () => {
       expect(sub!.stop).not.toHaveBeenCalled()
 
       // Let the sub-tail go idle past the reap window; a rescan tick reaps it.
-      await wait(400)
+      await wait(1300)
       expect(sub!.stop).toHaveBeenCalledTimes(1)
+    } finally {
+      handle.stop()
+    }
+  })
+})
+
+describe('session-tail sidecar reap (L1) — reap window is floor-clamped', () => {
+  it('does NOT instant-reap a live sub-tail under a zero (or negative) idle window', async () => {
+    // A `subTailIdleReapMs` of 0 (or negative) would, without the
+    // Math.max(1000, …) clamp, make `reapIdleSubTails` compute
+    // `cutoff = Date.now() - 0`, which is ALWAYS ≥ a live sub-tail's slightly-
+    // earlier `lastActivityAt` — so every live sub-agent sidecar would be
+    // reaped on the very first rescan tick. The clamp lifts the effective
+    // window to the 1s floor, so a sub-tail active moments ago survives.
+    const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+    const parent = join(projectsDir, 'parent.jsonl')
+    writeFileSync(parent, assistantText('parent'))
+    setMtime(parent, Math.floor(Date.now() / 1000))
+
+    const subDir = join(projectsDir, 'parent', 'subagents')
+    mkdirSync(subDir, { recursive: true })
+    const subFile = join(subDir, 'agent-subzero.jsonl')
+    writeFileSync(subFile, toolUseLine('Bash', 'toolu_z'))
+
+    const handle = startSessionTail({
+      cwd,
+      claudeHome,
+      rescanIntervalMs: 30,
+      subTailIdleReapMs: 0, // pathological: pre-clamp this instant-reaps
+      onEvent: () => {},
+    })
+    try {
+      await wait(100) // attach parent + sub → sidecar 'agent-subzero' created
+      const sub = findSidecar('agent-subzero')
+      expect(sub).toBeDefined()
+      expect(sub!.stop).not.toHaveBeenCalled()
+
+      // Several rescan ticks pass (well under the 1s clamp floor). A live
+      // sub-tail whose activity is <1s old must NOT be reaped — so its sidecar
+      // stays alive. Pre-clamp, the first tick reaps it (sub.stop called once).
+      await wait(200)
+      expect(sub!.stop).not.toHaveBeenCalled()
+    } finally {
+      handle.stop()
+    }
+  })
+})
+
+describe('session-tail sidecar reap (M1) — namespace safety', () => {
+  it('a parent-session rotation does NOT stop a concurrently-live sub-agent sidecar', async () => {
+    // The rotation reap in attachToFile stops the sidecar keyed by the
+    // rotated-away parent's JSONL stem (a UUID). A live sub-agent's sidecar is
+    // keyed by its OWN file stem ('agent-<id>'). Because the two key namespaces
+    // never collide, rotating the parent must leave the sub-agent's sidecar
+    // untouched — otherwise a `/clear` or compaction mid-worker would silently
+    // kill the live worker's label sidecar. Reviewer verified by code-reading
+    // only; this locks it in.
+    const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+    const first = join(projectsDir, 'session-one.jsonl')
+    const second = join(projectsDir, 'session-two.jsonl')
+
+    writeFileSync(first, assistantText('parent one'))
+    setMtime(first, 1_000_000)
+
+    // A live sub-agent under the CURRENT (session-one) parent. Its tool_use
+    // line makes the sub-tail create a sidecar keyed 'agent-subns'.
+    const subDir = join(projectsDir, 'session-one', 'subagents')
+    mkdirSync(subDir, { recursive: true })
+    const subFile = join(subDir, 'agent-subns.jsonl')
+    writeFileSync(subFile, toolUseLine('Bash', 'toolu_ns'))
+
+    const handle = startSessionTail({
+      cwd,
+      claudeHome,
+      rescanIntervalMs: 30,
+      // Large window so the sub-tail is never idle-reaped during the test —
+      // we're isolating the rotation path, not the idle path.
+      subTailIdleReapMs: 60_000,
+      onEvent: () => {},
+    })
+    try {
+      await wait(120) // attach parent + sub → both sidecars created
+      const parentSidecar = findSidecar('session-one')
+      const subSidecar = findSidecar('agent-subns')
+      expect(parentSidecar).toBeDefined()
+      expect(subSidecar).toBeDefined()
+      expect(parentSidecar!.stop).not.toHaveBeenCalled()
+      expect(subSidecar!.stop).not.toHaveBeenCalled()
+
+      // Parent session rotates (compaction / clear → new sessionId).
+      const nowSec = Math.floor(Date.now() / 1000)
+      writeFileSync(second, assistantText('parent two'))
+      setMtime(second, nowSec + 20)
+      setMtime(first, nowSec + 5)
+      await wait(200) // rescan flips active file to session-two
+
+      // The rotated-away PARENT sidecar is reaped …
+      expect(parentSidecar!.stop).toHaveBeenCalledTimes(1)
+      // … but the concurrently-live SUB-agent sidecar is NOT — different stem
+      // namespace, so the rotation reap never targets it.
+      expect(subSidecar!.stop).not.toHaveBeenCalled()
     } finally {
       handle.stop()
     }

--- a/telegram-plugin/tests/session-tail-sidecar-reap.test.ts
+++ b/telegram-plugin/tests/session-tail-sidecar-reap.test.ts
@@ -1,0 +1,155 @@
+/**
+ * FD/timer-leak regression test for the session-tail PreToolUse sidecars
+ * (review finding M1).
+ *
+ * `ToolLabelSidecar`s (each holding a stat-poll timer + file handle) were only
+ * reaped in the global `stop()`. Every session rotation (`/clear`, compaction →
+ * new sessionId) and every finished sub-agent minted a fresh sidecar that then
+ * lived until process exit — hundreds of leaked timers/handles on a long-lived
+ * agent.
+ *
+ * We mock the sidecar factory so each instance is a cheap fake with a `stop`
+ * spy, then drive a real parent-session rotation and a real sub-agent reap and
+ * assert the ended session's sidecar was stopped. Both assertions FAIL on
+ * pre-fix code (stop only in `stop()`).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, rmSync, utimesSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// ─── Sidecar factory mock: record every instance keyed by sessionId ──────────
+const created = vi.hoisted(() => {
+  const instances: Array<{ sessionId: string; stop: ReturnType<typeof vi.fn> }> = []
+  return { instances }
+})
+
+vi.mock('../tool-label-sidecar.js', () => ({
+  createToolLabelSidecar: (opts: { stateDir: string; sessionId: string }) => {
+    const inst = {
+      sessionId: opts.sessionId,
+      stop: vi.fn(),
+      getLabel: () => undefined,
+      onLabel: () => () => {},
+      poll: () => {},
+    }
+    created.instances.push(inst)
+    return inst
+  },
+}))
+
+// Import AFTER the mock is registered.
+const { startSessionTail, getProjectsDirForCwd } = await import('../session-tail.js')
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+const tempDirs: string[] = []
+let prevStateDir: string | undefined
+
+beforeEach(() => {
+  created.instances.length = 0
+  prevStateDir = process.env.TELEGRAM_STATE_DIR
+  const stateDir = mkdtempSync(join(tmpdir(), 'sidecar-state-'))
+  tempDirs.push(stateDir)
+  process.env.TELEGRAM_STATE_DIR = stateDir
+})
+
+afterEach(() => {
+  if (prevStateDir === undefined) delete process.env.TELEGRAM_STATE_DIR
+  else process.env.TELEGRAM_STATE_DIR = prevStateDir
+  for (const d of tempDirs) {
+    try { rmSync(d, { recursive: true, force: true }) } catch { /* ignore */ }
+  }
+  tempDirs.length = 0
+})
+
+function mkProjectsDir(): { claudeHome: string; cwd: string; projectsDir: string } {
+  const base = mkdtempSync(join(tmpdir(), 'session-tail-sidecar-'))
+  tempDirs.push(base)
+  const cwd = join(base, 'agent')
+  const claudeHome = join(base, 'claude-home')
+  const projectsDir = getProjectsDirForCwd(cwd, claudeHome)
+  mkdirSync(projectsDir, { recursive: true })
+  return { claudeHome, cwd, projectsDir }
+}
+
+const setMtime = (path: string, seconds: number): void => utimesSync(path, seconds, seconds)
+const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+const assistantText = (text: string): string =>
+  JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } }) + '\n'
+const toolUseLine = (name: string, id: string): string =>
+  JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name, id, input: {} }] } }) + '\n'
+
+const findSidecar = (sessionId: string) => created.instances.find((i) => i.sessionId === sessionId)
+
+describe('session-tail sidecar reap (M1) — parent session rotation', () => {
+  it('stops the prior session sidecar when the active file rotates', async () => {
+    const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+    const first = join(projectsDir, 'session-one.jsonl')
+    const second = join(projectsDir, 'session-two.jsonl')
+
+    writeFileSync(first, assistantText('parent one'))
+    setMtime(first, 1_000_000)
+
+    const handle = startSessionTail({ cwd, claudeHome, rescanIntervalMs: 30, onEvent: () => {} })
+    try {
+      await wait(120) // initial attach → sidecar 'session-one' created
+      expect(findSidecar('session-one')).toBeDefined()
+      expect(findSidecar('session-one')!.stop).not.toHaveBeenCalled()
+
+      // A newer session file appears (compaction / clear rotation).
+      const nowSec = Math.floor(Date.now() / 1000)
+      writeFileSync(second, assistantText('parent two'))
+      setMtime(second, nowSec + 20)
+      setMtime(first, nowSec + 5)
+      await wait(200) // rescan flips to session-two → session-one must be reaped
+
+      expect(findSidecar('session-two')).toBeDefined()
+      // The rotated-away session's sidecar is stopped at runtime, not left for stop().
+      expect(findSidecar('session-one')!.stop).toHaveBeenCalledTimes(1)
+      // The now-active session's sidecar stays alive.
+      expect(findSidecar('session-two')!.stop).not.toHaveBeenCalled()
+    } finally {
+      handle.stop()
+    }
+  })
+})
+
+describe('session-tail sidecar reap (M1) — idle sub-agent', () => {
+  it('stops a sub-agent sidecar when its idle sub-tail is reaped', async () => {
+    const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+    const parent = join(projectsDir, 'parent.jsonl')
+    writeFileSync(parent, assistantText('parent'))
+    setMtime(parent, Math.floor(Date.now() / 1000))
+
+    // Sub-agents live under <parentSessionId>/subagents/agent-<id>.jsonl.
+    const subDir = join(projectsDir, 'parent', 'subagents')
+    mkdirSync(subDir, { recursive: true })
+    const subFile = join(subDir, 'agent-sub123.jsonl')
+    // A tool_use line makes the sub-tail lazily create its sidecar (keyed by
+    // the file stem 'agent-sub123').
+    writeFileSync(subFile, toolUseLine('Bash', 'toolu_1'))
+
+    const handle = startSessionTail({
+      cwd,
+      claudeHome,
+      rescanIntervalMs: 30,
+      // Reap sub-tails idle for >250ms so the test doesn't wait 5 minutes but
+      // still leaves a comfortable window to observe the not-yet-reaped state.
+      subTailIdleReapMs: 250,
+      onEvent: () => {},
+    })
+    try {
+      await wait(100) // attach parent + sub, read tool_use → sidecar created
+      const sub = findSidecar('agent-sub123')
+      expect(sub).toBeDefined()
+      expect(sub!.stop).not.toHaveBeenCalled()
+
+      // Let the sub-tail go idle past the reap window; a rescan tick reaps it.
+      await wait(400)
+      expect(sub!.stop).toHaveBeenCalledTimes(1)
+    } finally {
+      handle.stop()
+    }
+  })
+})

--- a/telegram-plugin/tests/session-tail-sidecar-reap.test.ts
+++ b/telegram-plugin/tests/session-tail-sidecar-reap.test.ts
@@ -15,42 +15,38 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, rmSync, utimesSync } from 'fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { startSessionTail, getProjectsDirForCwd } from '../session-tail.js'
+import type { SidecarOptions, ToolLabelSidecar } from '../tool-label-sidecar.js'
 
-// ─── Sidecar factory mock: record every instance keyed by sessionId ──────────
-// The instance registry lives INSIDE the factory and is re-exported as a
-// test-only handle (`__sidecarInstances`) rather than closed over from a
-// `vi.hoisted` binding: bun's vitest-compat layer implements `vi.mock`/`vi.fn`
-// but NOT `vi.hoisted`, so a hoisted-closure mock throws `vi.hoisted is not a
-// function` under `bun test` (CI's bun-test-run shard runs this whole dir).
-// Same pattern as callback-query-handlers.test.ts (#3130).
-vi.mock('../tool-label-sidecar.js', () => {
-  const instances: Array<{ sessionId: string; stop: ReturnType<typeof vi.fn> }> = []
-  return {
-    __sidecarInstances: instances,
-    createToolLabelSidecar: (opts: { stateDir: string; sessionId: string }) => {
-      const inst = {
-        sessionId: opts.sessionId,
-        stop: vi.fn(),
-        getLabel: () => undefined,
-        onLabel: () => () => {},
-        poll: () => {},
-      }
-      instances.push(inst)
-      return inst
-    },
-  }
-})
-
-// Import AFTER the mock is registered. The mocked module namespace carries the
-// test-only instance registry under both runners.
-const { startSessionTail, getProjectsDirForCwd } = await import('../session-tail.js')
-const sidecarMod = (await import('../tool-label-sidecar.js')) as unknown as {
-  __sidecarInstances: Array<{ sessionId: string; stop: ReturnType<typeof vi.fn> }>
+// ─── Sidecar factory injection: record every fake instance keyed by sessionId ─
+// We do NOT `vi.mock('../tool-label-sidecar.js')`. Under bun's vitest-compat
+// layer `vi.mock` is PROCESS-GLOBAL (not file-scoped like vitest), and CI's
+// bun-test-run shard runs this whole `tests/` dir in ONE process — so a module
+// mock here would leak into the real `tool-label-sidecar.test.ts` suite and
+// replace the module under test, failing its 7 assertions. Instead we inject a
+// fake sidecar factory through `startSessionTail`'s `createSidecar` seam (the
+// repo's bun-safe DI precedent — see `vault-write-posture.test.ts`), so the
+// shared module cache is never touched. Sibling `subagent-watcher-fd-leak.test.ts`
+// uses the same injected-fake style.
+interface FakeSidecar extends ToolLabelSidecar {
+  sessionId: string
+  stop: ReturnType<typeof vi.fn>
 }
-const created = { instances: sidecarMod.__sidecarInstances }
+const created = { instances: [] as FakeSidecar[] }
+const fakeSidecarFactory = (opts: SidecarOptions): ToolLabelSidecar => {
+  const inst: FakeSidecar = {
+    sessionId: opts.sessionId,
+    stop: vi.fn(),
+    getLabel: () => undefined,
+    onLabel: () => () => {},
+    poll: () => {},
+  }
+  created.instances.push(inst)
+  return inst
+}
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 const tempDirs: string[] = []
@@ -90,7 +86,8 @@ const assistantText = (text: string): string =>
 const toolUseLine = (name: string, id: string): string =>
   JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name, id, input: {} }] } }) + '\n'
 
-const findSidecar = (sessionId: string) => created.instances.find((i) => i.sessionId === sessionId)
+const findSidecar = (sessionId: string): FakeSidecar | undefined =>
+  created.instances.find((i) => i.sessionId === sessionId)
 
 describe('session-tail sidecar reap (M1) — parent session rotation', () => {
   it('stops the prior session sidecar when the active file rotates', async () => {
@@ -101,7 +98,7 @@ describe('session-tail sidecar reap (M1) — parent session rotation', () => {
     writeFileSync(first, assistantText('parent one'))
     setMtime(first, 1_000_000)
 
-    const handle = startSessionTail({ cwd, claudeHome, rescanIntervalMs: 30, onEvent: () => {} })
+    const handle = startSessionTail({ cwd, claudeHome, rescanIntervalMs: 30, onEvent: () => {}, createSidecar: fakeSidecarFactory })
     try {
       await wait(120) // initial attach → sidecar 'session-one' created
       expect(findSidecar('session-one')).toBeDefined()
@@ -150,6 +147,7 @@ describe('session-tail sidecar reap (M1) — idle sub-agent', () => {
       // not-yet-reaped state.
       subTailIdleReapMs: 1000,
       onEvent: () => {},
+      createSidecar: fakeSidecarFactory,
     })
     try {
       await wait(100) // attach parent + sub, read tool_use → sidecar created
@@ -190,6 +188,7 @@ describe('session-tail sidecar reap (L1) — reap window is floor-clamped', () =
       rescanIntervalMs: 30,
       subTailIdleReapMs: 0, // pathological: pre-clamp this instant-reaps
       onEvent: () => {},
+      createSidecar: fakeSidecarFactory,
     })
     try {
       await wait(100) // attach parent + sub → sidecar 'agent-subzero' created
@@ -239,6 +238,7 @@ describe('session-tail sidecar reap (M1) — namespace safety', () => {
       // we're isolating the rotation path, not the idle path.
       subTailIdleReapMs: 60_000,
       onEvent: () => {},
+      createSidecar: fakeSidecarFactory,
     })
     try {
       await wait(120) // attach parent + sub → both sidecars created

--- a/telegram-plugin/tests/subagent-watcher-fd-leak.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-fd-leak.test.ts
@@ -189,4 +189,87 @@ describe('subagent-watcher FD-leak (H2): no per-file watcher for stale historica
 
     h.watcher.stop()
   })
+
+  // Positive direction of the H2 gate: the open-guard is `!entry.historical ||
+  // entry.bootPromotionPending != null`, so the negative test above (no watcher
+  // for a stale boot entry) must be balanced by proof the guard does NOT
+  // over-prune a genuinely LIVE worker. A file that first appears AFTER the boot
+  // scan is non-historical (`bootScanInProgress` is already false), so it is a
+  // live worker the user is awaiting and MUST get its own per-file FSWatcher —
+  // otherwise its tool-call / turn_end transitions would be invisible until the
+  // 1s defensive poll happened to catch them. Reviewer verified this by code-
+  // reading only; this test locks it in.
+  it('opens a per-file FSWatcher for a live (post-boot, non-historical) worker JSONL', () => {
+    const projectDir = `${PROJECTS}/myproject`
+    const sessionDir = `${projectDir}/session-A`
+    const subagentsDir = `${sessionDir}/subagents`
+    const liveFile = `${subagentsDir}/agent-live01.jsonl`
+
+    const h = makeHarness({
+      dirs: {
+        [PROJECTS]: ['myproject'],
+        [projectDir]: ['session-A'],
+        [sessionDir]: ['subagents'],
+        [subagentsDir]: [], // empty at boot → nothing marked historical
+      },
+    })
+
+    // Boot scan already ran (constructor) over the empty dir; poll once so the
+    // dir watcher for the subagents dir is definitely established.
+    h.poll()
+    expect(h.fileWatchers()).toHaveLength(0) // nothing to watch yet
+
+    // A brand-new worker dispatches AFTER boot: its JSONL appears now. Because
+    // bootScanInProgress is already false, scanSubagentsDir does NOT mark it
+    // historical → it registers as a live running entry.
+    h.dirs.set(subagentsDir, ['agent-live01.jsonl'])
+    h.fileSizes.set(liveFile, 24)
+
+    h.poll()
+
+    const fileWatchersForLive = h.fileWatchers().filter((w) => w.path === liveFile)
+    expect(fileWatchersForLive).toHaveLength(1)
+    expect(fileWatchersForLive[0].closed).toBe(false)
+
+    h.watcher.stop()
+    // stop() must close the live watcher it opened (no leak on shutdown).
+    expect(fileWatchersForLive[0].closed).toBe(true)
+  })
+})
+
+describe('subagent-watcher FD-leak (H1): a still-present session dir keeps its watcher across rescans', () => {
+  it('does NOT prune the dir watcher for a directory that is still present', () => {
+    const projectDir = `${PROJECTS}/myproject`
+    const sessionDir = `${projectDir}/session-A`
+    const subagentsDir = `${sessionDir}/subagents`
+
+    const h = makeHarness({
+      dirs: {
+        [PROJECTS]: ['myproject'],
+        [projectDir]: ['session-A'],
+        [sessionDir]: ['subagents'],
+        [subagentsDir]: [], // present + empty — gets a dir watcher, stays present
+      },
+    })
+
+    h.poll()
+    const dw = h.dirWatchersFor(subagentsDir)
+    expect(dw).toHaveLength(1)
+    expect(dw[0].closed).toBe(false)
+
+    // The session dir never vanishes. Several rescan ticks pass. The complement
+    // of the H1 close-on-vanish test: pruneVanishedDirWatchers must leave a
+    // still-existing dir's watcher untouched, and the `if (!dirWatchers.has(...))`
+    // guard must NOT open a duplicate watcher for the same dir on each rescan.
+    h.poll()
+    h.poll()
+    h.poll()
+
+    expect(dw[0].close).not.toHaveBeenCalled()
+    expect(dw[0].closed).toBe(false)
+    // Exactly one dir watcher for this path across all the rescans — no churn.
+    expect(h.dirWatchersFor(subagentsDir)).toHaveLength(1)
+
+    h.watcher.stop()
+  })
 })

--- a/telegram-plugin/tests/subagent-watcher-fd-leak.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-fd-leak.test.ts
@@ -1,0 +1,192 @@
+/**
+ * FD-leak regression tests for the subagent-watcher (review findings H1 + H2).
+ *
+ * H1 — directory FSWatchers were only ever closed in the global stop(). When a
+ *      Claude session's `subagents/` dir was reaped, the rescan loop skipped
+ *      the vanished path without closing its watcher, so every session leaked
+ *      one inotify FD for the gateway's lifetime.
+ *
+ * H2 — every boot-scanned file opened a per-file FSWatcher unconditionally,
+ *      including stale historical `running` entries that `checkStalls` skips
+ *      and that therefore never reach terminal cleanup — leaking their FD until
+ *      the file happened to vanish.
+ *
+ * Each test FAILS on pre-fix code (an unclosed / never-opened-guarded watcher)
+ * and PASSES with the runtime-close / open-gating fix.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type * as fs from 'fs'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+
+interface FakeWatcher {
+  path: string
+  close: ReturnType<typeof vi.fn>
+  closed: boolean
+}
+
+/**
+ * Minimal watcher harness with a MUTABLE fake filesystem (so a test can make a
+ * directory or file vanish mid-run) and per-watcher path tracking (so we can
+ * assert exactly which watchers were opened / closed).
+ */
+function makeHarness(opts: {
+  agentDir?: string
+  dirs: Record<string, string[]>
+  fileSizes?: Record<string, number>
+  rescanMs?: number
+}) {
+  const agentDir = opts.agentDir ?? '/home/user/.switchroom/agents/myagent'
+  const rescanMs = opts.rescanMs ?? 500
+  const dirs = new Map<string, string[]>(Object.entries(opts.dirs))
+  const fileSizes = new Map<string, number>(Object.entries(opts.fileSizes ?? {}))
+  const logs: string[] = []
+  const watchers: FakeWatcher[] = []
+  let currentTime = 1_000_000
+
+  const existsSync = ((p: fs.PathLike) => {
+    const ps = String(p)
+    return dirs.has(ps) || fileSizes.has(ps)
+  }) as typeof fs.existsSync
+
+  const mockFs = {
+    existsSync,
+    readdirSync: ((p: fs.PathLike) => dirs.get(String(p)) ?? []) as unknown as typeof fs.readdirSync,
+    // No mtimeMs → boot-promotion freshness gate treats a running file as
+    // stale (dead prior-session worker), so it stays historical + unpromoted.
+    statSync: ((p: fs.PathLike) => ({ size: fileSizes.get(String(p)) ?? 0 }) as fs.Stats) as typeof fs.statSync,
+    openSync: (() => 42) as unknown as typeof fs.openSync,
+    closeSync: (() => undefined) as typeof fs.closeSync,
+    readSync: (() => 0) as unknown as typeof fs.readSync,
+    watch: ((p: fs.PathLike) => {
+      const w: FakeWatcher = {
+        path: String(p),
+        closed: false,
+        close: vi.fn(() => { w.closed = true }),
+      }
+      watchers.push(w)
+      return w as unknown as fs.FSWatcher
+    }) as unknown as typeof fs.watch,
+  }
+
+  const intervals: Array<{ fn: () => void; ms: number; ref: number; fireAt: number }> = []
+  const timeouts: Array<{ fn: () => void; ref: number; fireAt: number }> = []
+  let nextRef = 1
+
+  const watcher = startSubagentWatcher({
+    agentDir,
+    onFinish: () => {},
+    stallThresholdMs: 60_000,
+    silentSynthesisStallThresholdMs: 60_000,
+    rescanMs,
+    now: () => currentTime,
+    setInterval: (fn, ms) => {
+      const ref = nextRef++
+      intervals.push({ fn, ms, ref, fireAt: currentTime + ms })
+      return { ref }
+    },
+    clearInterval: (handle) => {
+      const { ref } = handle as { ref: number }
+      const idx = intervals.findIndex((i) => i.ref === ref)
+      if (idx !== -1) intervals.splice(idx, 1)
+    },
+    setTimeout: (fn, ms) => {
+      const ref = nextRef++
+      timeouts.push({ fn, ref, fireAt: currentTime + ms })
+      return { ref }
+    },
+    clearTimeout: (handle) => {
+      const { ref } = handle as { ref: number }
+      const idx = timeouts.findIndex((t) => t.ref === ref)
+      if (idx !== -1) timeouts.splice(idx, 1)
+    },
+    fs: mockFs,
+    log: (msg: string) => { logs.push(msg) },
+  })
+
+  const poll = (): void => {
+    // intervals[0] is the poll loop (registered first — see startSubagentWatcher).
+    intervals[0]?.fn()
+  }
+
+  return {
+    watcher,
+    watchers,
+    logs,
+    dirs,
+    fileSizes,
+    poll,
+    fileWatchers: () => watchers.filter((w) => w.path.endsWith('.jsonl')),
+    dirWatchersFor: (p: string) => watchers.filter((w) => w.path === p),
+  }
+}
+
+const PROJECTS = '/home/user/.switchroom/agents/myagent/.claude/projects'
+
+describe('subagent-watcher FD-leak (H1): dir watchers close when their session dir vanishes', () => {
+  it('closes and forgets the subagents-dir FSWatcher after the session dir is reaped', () => {
+    const projectDir = `${PROJECTS}/myproject`
+    const sessionDir = `${projectDir}/session-A`
+    const subagentsDir = `${sessionDir}/subagents`
+
+    const h = makeHarness({
+      dirs: {
+        [PROJECTS]: ['myproject'],
+        [projectDir]: ['session-A'],
+        [sessionDir]: ['subagents'],
+        [subagentsDir]: [], // empty subagents dir — still gets a dir watcher
+      },
+    })
+
+    // Boot scan already ran in the constructor; poll once to be certain the
+    // dir watcher for the subagents dir has been opened.
+    h.poll()
+    const dw = h.dirWatchersFor(subagentsDir)
+    expect(dw).toHaveLength(1)
+    expect(dw[0].closed).toBe(false)
+
+    // Claude Code reaps the whole session directory (session rotation).
+    h.dirs.delete(sessionDir)
+    h.dirs.delete(subagentsDir)
+    h.dirs.set(projectDir, []) // session-A gone from the project listing
+
+    // Next rescan tick must release the now-dangling dir watcher.
+    h.poll()
+
+    expect(dw[0].close).toHaveBeenCalledTimes(1)
+    expect(dw[0].closed).toBe(true)
+
+    h.watcher.stop()
+  })
+})
+
+describe('subagent-watcher FD-leak (H2): no per-file watcher for stale historical running entries', () => {
+  it('does not open an FSWatcher for a boot-discovered stale running JSONL', () => {
+    const projectDir = `${PROJECTS}/myproject`
+    const sessionDir = `${projectDir}/session-A`
+    const subagentsDir = `${sessionDir}/subagents`
+    const staleFile = `${subagentsDir}/agent-deadbeef.jsonl`
+
+    const h = makeHarness({
+      dirs: {
+        [PROJECTS]: ['myproject'],
+        [projectDir]: ['session-A'],
+        [sessionDir]: ['subagents'],
+        [subagentsDir]: ['agent-deadbeef.jsonl'],
+      },
+      // size 0 + no mtimeMs → registers as a stale historical `running` entry
+      // that will never be promoted and never reach terminal cleanup.
+      fileSizes: { [staleFile]: 0 },
+    })
+
+    h.poll()
+
+    // A dir watcher for the subagents dir is fine. What must NOT happen is a
+    // per-file (.jsonl) watcher for a stale historical running entry that
+    // would leak forever.
+    const fileWatchersForStale = h.fileWatchers().filter((w) => w.path === staleFile)
+    expect(fileWatchersForStale).toHaveLength(0)
+
+    h.watcher.stop()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes three watcher-lifecycle FD leaks (code-review findings **H1, H2, M1** in `code-review-20260711/tp-root.md`) that would eventually take down all session/sub-agent tailing on a 24/7 gateway. Every leaked `FSWatcher`/sidecar is now paired with a guaranteed runtime `close()`/`stop()` tied to the event that ends the owning session or sub-agent — not only the global `stop()`.

## Why

Directory and per-file `FSWatcher`s (and `ToolLabelSidecar` poll timers) were created per Claude session/sub-agent but released only in the module's `stop()`. Node frees an inotify FD only on `.close()`, so each session/sub-agent leaked one or more FDs for the whole process lifetime. Once a long-lived gateway crossed `ulimit -n` (1024), every subsequent `fs.watch`/`openSync` threw and the progress-card / worker-feed tailing subsystem broke.

## What changed

**`telegram-plugin/subagent-watcher.ts`**
- **H1** — directory watchers (`subagents/` + `workflows/wf_<id>/`) were skipped by the `existsSync` guard when their session dir was reaped, without closing the watcher. New `pruneVanishedDirWatchers()` sweeps on each rescan tick and closes+forgets any watcher whose directory no longer exists (also covers slugs going foreign and a vanished `projectsRoot`).
- **H2** — every boot-scanned file opened a per-file watcher unconditionally, including stale historical `running` entries that `checkStalls` skips and that never reach terminal cleanup. The watch now opens only for a live worker or a historical one still awaiting boot-promotion growth, and the growth-confirmation watcher is released when the promotion window expires with no growth.

**`telegram-plugin/session-tail.ts`**
- **M1** — `ToolLabelSidecar`s were reaped only in `stop()`. New `stopSidecar()` reaps the rotated-away parent sidecar in `attachToFile` (every `/clear`/compaction rotation) and the sub-agent sidecar in `reapIdleSubTails` (every finished sub-agent). Added `subTailIdleReapMs` config to drive the idle reap deterministically in tests.

## Test plan

Two new outcome tests; each **fails on pre-fix source** (verified via `git stash`):

- `telegram-plugin/tests/subagent-watcher-fd-leak.test.ts` — asserts the dir watcher's `close()` fires after its session dir vanishes (H1); asserts no per-file watcher is opened for a stale historical running entry (H2).
- `telegram-plugin/tests/session-tail-sidecar-reap.test.ts` — asserts the prior session's sidecar `stop()` fires on session rotation and on idle sub-agent reap (M1).

Scoped local runs (green):
- vitest: all `subagent-watcher*` + `session-tail*` suites — 192 passed.
- bun test: `subagent-watcher-parent-turn-key`, `subagent-nested-dispatch`, `subagent-watcher-workflow-visibility`, `subagent-tracker-hooks`, `registry/subagents` — 102 passed.
- `tsc --noEmit` clean; all lint guard scripts clean except `check-plugin-references`, which fails identically on pristine `main` in this worktree (missing optional `mdast`/`@mtcute` deps in the symlinked `node_modules`) — an environment artifact, not this diff. CI has the full deps.

## Risk

Low. Behavior change is limited to releasing watchers/sidecars earlier; the poll loop remains the fallback reader for any registered running entry, and `ensureSidecar` transparently recreates a sidecar on re-attach. No change to event emission, handback classification, or stall detection.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md` — the progress-card / worker-activity-feed tailing subsystem these watchers power stays alive on a 24/7 gateway instead of FD-exhausting itself dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)