### PR TITLE
fix(litellm): bind generated keys to team via team_id for per-team cost tracking

### DIFF
--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -591,8 +591,9 @@ export async function provisionLiteLLMKeys(
         continue;
       }
 
-      // Provision: ensure team, then generate the per-agent key.
-      await ensureTeam(baseUrl, masterKey, team);
+      // Provision: ensure team (capturing its team_id so the key binds to it
+      // for per-team cost/spend tracking), then generate the per-agent key.
+      const teamId = await ensureTeam(baseUrl, masterKey, team);
       const metadata: Record<string, string> = {
         agent: name,
         env: "fleet",
@@ -608,7 +609,7 @@ export async function provisionLiteLLMKeys(
         baseUrl,
         masterKey,
         alias,
-        team,
+        teamId,
         metadata,
         // Surface the orphaned-alias self-heal steps (delete + regenerate) so the
         // operator sees the recovery instead of a silent extra round-trip.
@@ -696,12 +697,12 @@ export async function provisionLiteLLMKeys(
             }
           }
           const team = topLevel?.team ?? "switchroom";
-          await ensureTeam(baseUrl, masterKey, team);
+          const teamId = await ensureTeam(baseUrl, masterKey, team);
           const { key } = await ensureKey({
             baseUrl,
             masterKey,
             alias: "service:hindsight",
-            team,
+            teamId,
             metadata: { service: "hindsight", env: "fleet", ...(oauthAccount ? { oauth_account: oauthAccount } : {}) },
             log: (m) => ctx.writeErr(chalk.gray(`  ~ litellm/hindsight: ${m}\n`)),
           });

--- a/src/litellm/provision-apply-e2e.test.ts
+++ b/src/litellm/provision-apply-e2e.test.ts
@@ -78,6 +78,10 @@ describe("provisionLiteLLMKeys — real broker e2e (blocker-1 seam)", () => {
   let prevSock: string | undefined;
   let prevPass: string | undefined;
   let realFetch: typeof fetch;
+  // Captures the /key/generate request body so a test can assert the key was
+  // bound to the team via team_id (the cost-tracking fix), end-to-end through
+  // the real provisionLiteLLMKeys → ensureTeam → ensureKey path.
+  let keyGenBodies: Array<Record<string, unknown>>;
 
   beforeEach(async () => {
     prevNonLinux = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
@@ -116,13 +120,15 @@ describe("provisionLiteLLMKeys — real broker e2e (blocker-1 seam)", () => {
     process.env.SWITCHROOM_VAULT_PASSPHRASE = TEST_PASSPHRASE;
 
     // Stub global fetch so ensureTeam/ensureKey never hit the network.
+    keyGenBodies = [];
     realFetch = globalThis.fetch;
-    globalThis.fetch = (async (url: string | URL | Request) => {
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
       if (u.endsWith("/team/new")) {
         return new Response(JSON.stringify({ team_id: "t1" }), { status: 200 });
       }
       if (u.includes("/key/generate")) {
+        if (init?.body) keyGenBodies.push(JSON.parse(String(init.body)));
         return new Response(JSON.stringify({ key: "sk-virtual-clerk-xyz" }), {
           status: 200,
         });
@@ -191,6 +197,13 @@ describe("provisionLiteLLMKeys — real broker e2e (blocker-1 seam)", () => {
     expect(stored).toBe("sk-virtual-clerk-xyz");
 
     expect(out.join("")).toContain("provisioned virtual key");
+
+    // Cost-tracking fix, end-to-end: the team_id from /team/new ("t1") is
+    // threaded into the /key/generate payload so the key is BOUND to the team.
+    // The buggy path sent team_alias (ignored by LiteLLM) and never bound it.
+    expect(keyGenBodies).toHaveLength(1);
+    expect(keyGenBodies[0]!.team_id).toBe("t1");
+    expect(keyGenBodies[0]).not.toHaveProperty("team_alias");
   });
 
   it("control: a passphrase-LESS put of a new key IS denied (proves the seam)", async () => {

--- a/src/litellm/provision.test.ts
+++ b/src/litellm/provision.test.ts
@@ -28,13 +28,19 @@ function mockResponse(opts: {
 }
 
 describe("ensureTeam", () => {
-  it("POSTs team_alias to /team/new and resolves on success", async () => {
+  it("POSTs team_alias to /team/new and RETURNS the team_id from the response", async () => {
+    // /team/new's request body carries team_alias (that IS the NewTeamRequest
+    // field), but its RESPONSE (a LiteLLM_TeamTable) carries the team_id — the
+    // UUID that keys must be bound to. ensureTeam must surface that id so
+    // ensureKey can pass it as team_id on /key/generate (the pre-fix code
+    // returned void and threw the id away → keys landed unbound).
     const calls: { url: string; init: RequestInit | undefined }[] = [];
     const fetchFn: FetchFn = async (url, init) => {
       calls.push({ url: String(url), init });
       return mockResponse({ ok: true, status: 200, json: { team_id: "t1" } });
     };
-    await ensureTeam("http://127.0.0.1:4010", "sk-master", "switchroom", fetchFn);
+    const teamId = await ensureTeam("http://127.0.0.1:4010", "sk-master", "switchroom", fetchFn);
+    expect(teamId).toBe("t1");
     expect(calls).toHaveLength(1);
     expect(calls[0]!.url).toBe("http://127.0.0.1:4010/team/new");
     expect(calls[0]!.init?.method).toBe("POST");
@@ -42,6 +48,54 @@ describe("ensureTeam", () => {
     expect(body).toEqual({ team_alias: "switchroom" });
     const headers = calls[0]!.init?.headers as Record<string, string>;
     expect(headers.authorization).toBe("Bearer sk-master");
+  });
+
+  it("resolves the team_id via /team/list when the team already exists", async () => {
+    // On the idempotent already-exists path /team/new hands back an error, not
+    // the team object — so ensureTeam must resolve the id by alias via
+    // /team/list (each entry carries team_id + team_alias) so a re-apply still
+    // binds keys to the existing team.
+    const calls: { url: string; method: string }[] = [];
+    const fetchFn: FetchFn = async (url, init) => {
+      const u = String(url);
+      calls.push({ url: u, method: init?.method ?? "GET" });
+      if (u.endsWith("/team/new")) {
+        return mockResponse({
+          ok: false,
+          status: 400,
+          text: "Team alias switchroom already exists in DB",
+        });
+      }
+      if (u.endsWith("/team/list")) {
+        return mockResponse({
+          ok: true,
+          status: 200,
+          json: [
+            { team_id: "other-id", team_alias: "other" },
+            { team_id: "switchroom-uuid", team_alias: "switchroom" },
+          ],
+        });
+      }
+      return mockResponse({ ok: false, status: 404, text: "not found" });
+    };
+    const teamId = await ensureTeam("http://127.0.0.1:4010", "sk-master", "switchroom", fetchFn);
+    expect(teamId).toBe("switchroom-uuid");
+    // It fell through to /team/list after the already-exists /team/new.
+    expect(calls.map((c) => `${c.method} ${c.url.replace("http://127.0.0.1:4010", "")}`)).toEqual([
+      "POST /team/new",
+      "GET /team/list",
+    ]);
+  });
+
+  it("returns undefined (non-fatal) when the already-exists team can't be resolved", async () => {
+    // Best-effort: if /team/list is unavailable, degrade to undefined rather
+    // than failing the whole apply — the key falls back to unbound.
+    const fetchFn: FetchFn = async (url) =>
+      String(url).endsWith("/team/new")
+        ? mockResponse({ ok: false, status: 409, text: "conflict" })
+        : mockResponse({ ok: false, status: 500, text: "list unavailable" });
+    const teamId = await ensureTeam("http://h", "k", "switchroom", fetchFn);
+    expect(teamId).toBeUndefined();
   });
 
   it("strips a trailing slash from base_url", async () => {
@@ -93,7 +147,14 @@ describe("ensureTeam", () => {
 });
 
 describe("ensureKey", () => {
-  it("POSTs the key spec to /key/generate and returns the new key", async () => {
+  it("POSTs the key spec to /key/generate and binds it to the team via team_id", async () => {
+    // Regression pin for the cost-tracking bug: the key MUST carry team_id (the
+    // UUID from /team/new), NOT team_alias. LiteLLM's GenerateKeyRequest
+    // (v1.91 litellm/proxy/_types.py: GenerateRequestBase) has a `team_id`
+    // field and NO `team_alias` field, so a key generated with team_alias is
+    // never attached to the team → per-team budget/spend tracking silently
+    // doesn't apply. The prior test asserted team_alias: "switchroom", pinning
+    // exactly that unbound-key bug.
     const calls: { url: string; init: RequestInit | undefined }[] = [];
     const fetchFn: FetchFn = async (url, init) => {
       calls.push({ url: String(url), init });
@@ -104,7 +165,7 @@ describe("ensureKey", () => {
         baseUrl: "http://127.0.0.1:4010",
         masterKey: "sk-master",
         alias: "agent:clerk",
-        team: "switchroom",
+        teamId: "switchroom-team-uuid",
         models: ["claude-haiku-4-5-20251001"],
         metadata: { agent: "clerk", env: "fleet" },
       },
@@ -116,9 +177,11 @@ describe("ensureKey", () => {
     expect(body).toEqual({
       key_alias: "agent:clerk",
       models: ["claude-haiku-4-5-20251001"],
-      team_alias: "switchroom",
+      team_id: "switchroom-team-uuid",
       metadata: { agent: "clerk", env: "fleet" },
     });
+    // Explicitly assert the buggy field is gone.
+    expect(body).not.toHaveProperty("team_alias");
   });
 
   it("omits models/team/metadata when not provided", async () => {
@@ -207,7 +270,7 @@ describe("ensureKey — orphaned-alias self-heal", () => {
       calls,
     );
     const result = await ensureKey(
-      { baseUrl: "http://h", masterKey: "m", alias: "agent:clerk", team: "switchroom" },
+      { baseUrl: "http://h", masterKey: "m", alias: "agent:clerk", teamId: "t1" },
       fetchFn,
     );
     expect(result).toEqual({ key: "sk-clean" });
@@ -245,7 +308,7 @@ describe("ensureKey — orphaned-alias self-heal", () => {
     );
 
     const result = await ensureKey(
-      { baseUrl: "http://h", masterKey: "m", alias: "agent:clerk", team: "switchroom", log: (m) => logs.push(m) },
+      { baseUrl: "http://h", masterKey: "m", alias: "agent:clerk", teamId: "t1", log: (m) => logs.push(m) },
       fetchFn,
     );
 

--- a/src/litellm/provision.ts
+++ b/src/litellm/provision.ts
@@ -9,7 +9,9 @@
  *
  * The operations:
  *   - ensureTeam: create the "switchroom" LiteLLM team (idempotent — an
- *     "already exists" response is treated as success).
+ *     "already exists" response is treated as success). Returns the team's
+ *     `team_id` (the UUID `/team/new` hands back, or resolved via `/team/list`
+ *     on the already-exists path) so keys can be bound to the team.
  *   - ensureKey: generate a per-agent virtual key under the team. Self-heals an
  *     ORPHANED key alias: LiteLLM enforces unique key aliases (upstream
  *     issue #9730), so if a prior apply generated the alias but crashed before
@@ -19,8 +21,10 @@
  *   - validateKey: probe a stored virtual key against the proxy (GET /key/info)
  *     to detect DB drift (proxy DB reset / restore without the vault).
  *
- * LiteLLM admin API reference (v1.91 shapes): POST {base}/team/new,
- * POST {base}/key/generate, GET {base}/key/info?key=..., GET {base}/key/list,
+ * LiteLLM admin API reference (v1.91 shapes): POST {base}/team/new (returns a
+ * LiteLLM_TeamTable carrying `team_id`), GET {base}/team/list (each entry
+ * carries `team_id` + `team_alias`), POST {base}/key/generate (binds to a team
+ * via `team_id`), GET {base}/key/info?key=..., GET {base}/key/list,
  * POST {base}/key/delete — authenticated with the master key as a Bearer token.
  */
 
@@ -59,8 +63,15 @@ export interface EnsureKeyOpts {
   alias: string;
   /** Optional model allowlist for the key. Omit ⇒ team/all models. */
   models?: string[];
-  /** Team alias the key is created under (e.g. "switchroom"). */
-  team?: string;
+  /**
+   * Team id (the UUID `/team/new` returns) the key is bound under. LiteLLM's
+   * `/key/generate` associates a key with a team via `team_id` — NOT via
+   * `team_alias`, which is not a `GenerateKeyRequest` field and is silently
+   * ignored (LiteLLM v1.91 `litellm/proxy/_types.py`: `GenerateRequestBase`
+   * carries `team_id`, no `team_alias`). Per-team spend/budget tracking only
+   * applies when `team_id` is sent — omit ⇒ the key lands UNBOUND to any team.
+   */
+  teamId?: string;
   /** Arbitrary metadata tags attached to the key. */
   metadata?: Record<string, string>;
   /**
@@ -119,16 +130,24 @@ function looksLikeUnknownKey(status: number, body: string): boolean {
 }
 
 /**
- * Create the LiteLLM team if it doesn't already exist. Idempotent: an
- * "already exists" response (or 409) is treated as success.
+ * Create the LiteLLM team if it doesn't already exist, and return its
+ * `team_id`. Idempotent: an "already exists" response (or 409) is treated as
+ * success and the id is resolved by alias via `/team/list`.
+ *
+ * The returned `team_id` is what binds generated keys to the team
+ * (`ensureKey`'s `teamId`). It is best-effort: if the id cannot be read from
+ * the create response or resolved on the already-exists path, `undefined` is
+ * returned rather than throwing — the provision still succeeds, the key just
+ * falls back to unbound (the pre-fix behavior) instead of failing the apply.
  */
 export async function ensureTeam(
   baseUrl: string,
   masterKey: string,
   teamName: string,
   fetchFn: FetchFn = fetch,
-): Promise<void> {
-  const url = `${normalizeBase(baseUrl)}/team/new`;
+): Promise<string | undefined> {
+  const base = normalizeBase(baseUrl);
+  const url = `${base}/team/new`;
   let resp: Response;
   try {
     resp = await fetchFn(url, {
@@ -141,14 +160,83 @@ export async function ensureTeam(
       `LiteLLM /team/new request failed: ${(err as Error).message}`,
     );
   }
-  if (resp.ok) return;
+  if (resp.ok) {
+    // Fresh create: the response is a LiteLLM_TeamTable carrying the new
+    // team_id (the UUID keys must be bound to).
+    return await readTeamId(resp);
+  }
   const body = await safeText(resp);
-  if (looksLikeAlreadyExists(resp.status, body)) return; // idempotent
+  if (looksLikeAlreadyExists(resp.status, body)) {
+    // Idempotent: the team already exists, so /team/new did NOT hand back the
+    // id — resolve it by alias via /team/list so keys can still be bound.
+    return await resolveTeamIdByAlias(base, masterKey, teamName, fetchFn);
+  }
   throw new LiteLLMProvisionError(
     `LiteLLM /team/new returned ${resp.status}`,
     resp.status,
     body,
   );
+}
+
+/**
+ * Best-effort: pull `team_id` out of a `/team/new` (LiteLLM_TeamTable) body. A
+ * missing / unparseable id is non-fatal — it just means the caller can't bind
+ * the key to the team (the pre-fix behavior), so we degrade rather than throw.
+ */
+async function readTeamId(resp: Response): Promise<string | undefined> {
+  let json: unknown;
+  try {
+    json = await resp.json();
+  } catch {
+    return undefined;
+  }
+  const id = (json as { team_id?: unknown } | null)?.team_id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+/**
+ * Resolve an existing team's `team_id` from its `team_alias` via GET
+ * /team/list (each entry is a LiteLLM_TeamTable carrying both `team_id` and
+ * `team_alias`; some versions wrap the array as `{teams:[...]}`). Best-effort:
+ * any failure returns undefined so an idempotent re-apply still succeeds.
+ */
+async function resolveTeamIdByAlias(
+  base: string,
+  masterKey: string,
+  teamName: string,
+  fetchFn: FetchFn,
+): Promise<string | undefined> {
+  let resp: Response;
+  try {
+    resp = await fetchFn(`${base}/team/list`, {
+      method: "GET",
+      headers: authHeaders(masterKey),
+    });
+  } catch {
+    return undefined;
+  }
+  if (!resp.ok) return undefined;
+  let json: unknown;
+  try {
+    json = await resp.json();
+  } catch {
+    return undefined;
+  }
+  const teams: unknown[] = Array.isArray(json)
+    ? json
+    : Array.isArray((json as { teams?: unknown } | null)?.teams)
+      ? (json as { teams: unknown[] }).teams
+      : [];
+  for (const t of teams) {
+    if (t && typeof t === "object") {
+      const alias = (t as { team_alias?: unknown }).team_alias;
+      const id = (t as { team_id?: unknown }).team_id;
+      if (alias === teamName && typeof id === "string" && id.length > 0) {
+        return id;
+      }
+    }
+  }
+  return undefined;
 }
 
 /** Internal outcome of a single /key/generate POST. */
@@ -164,7 +252,8 @@ async function generateKeyOnce(opts: EnsureKeyOpts, fetchFn: FetchFn): Promise<G
     key_alias: opts.alias,
   };
   if (opts.models && opts.models.length > 0) payload.models = opts.models;
-  if (opts.team) payload.team_alias = opts.team;
+  // Bind the key to the team via team_id — LiteLLM ignores team_alias here.
+  if (opts.teamId) payload.team_id = opts.teamId;
   if (opts.metadata && Object.keys(opts.metadata).length > 0) {
     payload.metadata = opts.metadata;
   }


### PR DESCRIPTION
## Problem

The standing invariant is that all agent traffic routes through LiteLLM so per-team cost/token spend rolls up accurately. Provisioning silently defeated it.

`src/litellm/provision.ts` generated per-agent virtual keys with `team_alias` on `POST /key/generate`, but **LiteLLM binds a key to a team via `team_id`, not `team_alias`**. `ensureTeam` returned `void`, discarding the `team_id` that `POST /team/new` returns — so it was never available to `ensureKey`. Net effect: every per-agent (and the hindsight service) key landed **UNBOUND** to the `switchroom` team, so team-level budget caps and spend aggregation never applied to agent traffic.

Confirmed by review F2 (`small-subsystems.md`) and re-verified against fresh `main`/`c4ab171` (`stale-tree-verify.md` Claim B).

## API grounding

Field contract verified against **LiteLLM v1.91.0 source** (the pinned version — `CHANGELOG.md` "LiteLLM proxy bump to v1.91.0"; `provision.ts` docstring "v1.91 shapes"). No vendored client exists in-repo (pure HTTP client), so grounded against `litellm/proxy/_types.py` @ `v1.91.0`:

- `GenerateRequestBase` (base of `KeyRequestBase` → `GenerateKeyRequest`) carries `team_id: Optional[str]` and has **no `team_alias` field** → `/key/generate` binds via `team_id`; a `team_alias` is silently ignored.
- `POST /team/new` has `response_model=LiteLLM_TeamTable`, and `LiteLLM_TeamTable` has `team_id: str` → the create response carries the id.
- `GET /team/list` returns team objects each carrying `team_id` + `team_alias` → the resolve-by-alias path for the idempotent already-exists case.

## Fix

- `ensureTeam` now returns the `team_id`: reads it from the `/team/new` response on create, and resolves it by alias via `GET /team/list` on the idempotent already-exists path. Best-effort (returns `undefined`, never throws) so a re-apply degrades to the prior unbound behavior rather than failing the whole apply.
- `EnsureKeyOpts.team` (alias) → `teamId`; `/key/generate` now sends `team_id`.
- `src/cli/apply.ts` threads the captured `team_id` into `ensureKey` at both callsites (per-agent key + hindsight service key).

## Tests (assert outcomes; >=1 fails without the fix)

- `provision.test.ts`: `/key/generate` payload carries `team_id` and **not** `team_alias`; `ensureTeam` returns the id from `/team/new` and resolves it via `/team/list` on already-exists; non-fatal `undefined` when unresolvable.
- `provision-apply-e2e.test.ts`: asserts the `team_id` from `/team/new` (`"t1"`) flows end-to-end into the `/key/generate` payload.
- Verified all three fail against pre-fix code (reverted the one source line): unit `team_id`/`team_alias` mismatch and e2e `team_id === undefined`.

## Test + lint results

- `vitest run src/litellm/provision.test.ts src/cli/apply-litellm-provision.test.ts` -> **37 passed**
- `bun test src/litellm/provision-apply-e2e.test.ts` -> **4 passed**
- `tsc --noEmit` (root) -> **clean**. The `check-plugin-references` guard fails on `telegram-plugin/*` module-resolution errors (`@mtcute/node`, `mdast-util-*`) — a pre-existing worktree artifact (plugin subpackage deps not installed here), identical with these changes stashed, and untouched by this PR. CI (with plugin deps installed) is the lint authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)