### PR TITLE
fix(litellm): loud team-binding degradation + re-bind unbound keys on apply (#3140 review follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## Unreleased
 
+### LiteLLM per-agent keys bind to their team — and unbound keys self-heal on upgrade
+
+Standing invariant: all agent traffic routes through LiteLLM so per-team
+cost/token spend rolls up accurately. Provisioning silently defeated it —
+`ensureKey` sent `team_alias` on `/key/generate`, but LiteLLM binds a key to a
+team via `team_id` (v1.91.0 `GenerateRequestBase`; `team_alias` is not a
+`GenerateKeyRequest` field and is ignored), and `ensureTeam` discarded the
+`team_id`. Every per-agent key was generated UNBOUND, so team budget caps and
+spend aggregation never applied.
+
+Fix (this branch):
+
+- `ensureTeam` resolves + returns the `team_id` (from `/team/new`, or by alias
+  via `GET /team/list`), and `/key/generate` sends `team_id`.
+- **No more silent degradation (F3).** When a `team_id` can't be resolved, the
+  key is still provisioned (agents keep routing env), but apply now emits a
+  LOUD warning naming the reason and stating cost tracking will NOT aggregate —
+  instead of the old green `(team 'switchroom')` success line, which printed the
+  config *name* (always truthy) and falsely claimed a binding. The honest
+  team-clause success line prints only when the key is genuinely bound.
+- **Upgrade behavior — existing unbound keys are re-bound on the next apply
+  (F1).** The steady-state re-apply path used to skip any key that passed
+  `GET /key/info`, blind to its team binding — so every key provisioned before
+  this fix (or via the degraded path) stayed UNBOUND forever. `validateKey` now
+  also reports the key's current `team_id` (from `info.team_id`), and when a
+  valid key is unbound (or bound to a different team) apply issues a bind-only
+  `POST /key/update {key, team_id}` to re-bind it IN PLACE — no key deletion or
+  regeneration, no vault churn. Verified against LiteLLM v1.91.0
+  (`update_key_fn` / `UpdateKeyRequest`, whose `is_different_team` guard rebinds
+  null→team and team→team). If the team can't be resolved, apply stays LOUD on
+  every run for the unbound key rather than degrading silently; a failed
+  `/key/update` is surfaced as a warning naming the manual remediation, and the
+  key is never deleted/regenerated automatically.
+- **Deterministic duplicate-alias handling.** LiteLLM does not enforce unique
+  `team_alias`, so `/team/list` can return several teams sharing our alias.
+  Resolution now picks the lexicographically smallest `team_id` (stable across
+  applies) and warns naming every duplicate, instead of returning the first
+  array-order match nondeterministically.
+
+Operators upgrading: no action required — the first `switchroom apply` after
+upgrade re-binds each agent's existing key to the team and per-team cost
+tracking begins aggregating. Watch the apply output for any
+`! litellm/<agent>: ... WITHOUT team binding` / `re-bind ... FAILED` warnings,
+which name the exact manual `/key/update` remediation for the rare case the
+proxy rejects the automatic re-bind.
+
 ## v0.18.12 — Approvals hold the leash, config edits survive the window
 
 ### Undeliverable approval cards are held, never auto-denied (#3107, #3108, #3109)

--- a/src/cli/apply-litellm-provision.test.ts
+++ b/src/cli/apply-litellm-provision.test.ts
@@ -31,10 +31,12 @@ vi.mock("../vault/broker/client.js", () => ({
 const ensureTeam = vi.fn();
 const ensureKey = vi.fn();
 const validateKey = vi.fn();
+const bindKeyToTeam = vi.fn();
 vi.mock("../litellm/provision.js", () => ({
   ensureTeam: (...a: unknown[]) => ensureTeam(...a),
   ensureKey: (...a: unknown[]) => ensureKey(...a),
   validateKey: (...a: unknown[]) => validateKey(...a),
+  bindKeyToTeam: (...a: unknown[]) => bindKeyToTeam(...a),
 }));
 
 function makeConfig(): SwitchroomConfig {
@@ -170,12 +172,15 @@ describe("provisionLiteLLMKeys — stored-key validation against the proxy (DB d
     else process.env.SWITCHROOM_VAULT_PASSPHRASE = prevPass;
   });
 
-  it("stored key VALID on the proxy → skip, no re-provision", async () => {
+  it("stored key VALID and ALREADY bound to the desired team → skip, no re-provision, NO re-bind", async () => {
     getViaBrokerStructured.mockResolvedValue({
       kind: "ok",
       entry: { kind: "string", value: "sk-stored" },
     });
-    validateKey.mockResolvedValue({ kind: "valid" });
+    // Key is valid AND already bound to team "t1", which is what ensureTeam
+    // resolves → nothing to do.
+    validateKey.mockResolvedValue({ kind: "valid", teamId: "t1" });
+    ensureTeam.mockResolvedValue({ kind: "bound", teamId: "t1" });
 
     const { ctx, failures, out } = makeSinks();
     await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
@@ -183,7 +188,72 @@ describe("provisionLiteLLMKeys — stored-key validation against the proxy (DB d
     expect(failures).toEqual([]);
     expect(ensureKey).not.toHaveBeenCalled();
     expect(putViaBroker).not.toHaveBeenCalled();
+    // F1: a correctly-bound key must NOT trigger a spurious /key/update.
+    expect(bindKeyToTeam).not.toHaveBeenCalled();
     expect(out.join("")).toMatch(/already provisioned \+ validated/);
+  });
+
+  it("F1: stored key VALID but UNBOUND → re-bound in place via /key/update (not re-provisioned)", async () => {
+    // The steady-state re-apply path used to skip a valid key blind to its team
+    // binding, so every key provisioned before the fix stayed UNBOUND forever
+    // and per-team cost tracking never aggregated. It must now re-bind.
+    getViaBrokerStructured.mockResolvedValue({
+      kind: "ok",
+      entry: { kind: "string", value: "sk-stored" },
+    });
+    validateKey.mockResolvedValue({ kind: "valid", teamId: null }); // UNBOUND
+    ensureTeam.mockResolvedValue({ kind: "bound", teamId: "t1" });
+    bindKeyToTeam.mockResolvedValue({ kind: "ok" });
+
+    const { ctx, failures, out } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
+
+    expect(failures).toEqual([]);
+    // Re-bound in place — NO key deletion/regeneration, NO vault churn.
+    expect(ensureKey).not.toHaveBeenCalled();
+    expect(putViaBroker).not.toHaveBeenCalled();
+    // The bind-only /key/update carried the stored key + the resolved team_id.
+    expect(bindKeyToTeam).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "sk-stored", teamId: "t1" }),
+    );
+    expect(out.join("")).toMatch(/re-bound existing key to team 'switchroom'/);
+    expect(out.join("")).toMatch(/was UNBOUND/);
+  });
+
+  it("F1: valid UNBOUND key but /key/update FAILS → LOUD warning, key kept, apply not failed", async () => {
+    getViaBrokerStructured.mockResolvedValue({
+      kind: "ok",
+      entry: { kind: "string", value: "sk-stored" },
+    });
+    validateKey.mockResolvedValue({ kind: "valid", teamId: null });
+    ensureTeam.mockResolvedValue({ kind: "bound", teamId: "t1" });
+    bindKeyToTeam.mockResolvedValue({ kind: "error", detail: "HTTP 500: boom" });
+
+    const { ctx, failures, errs } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
+
+    // Best-effort: a failed re-bind never fails the apply, but it IS loud.
+    expect(failures).toEqual([]);
+    expect(errs.join("")).toMatch(/re-bind to team 'switchroom' FAILED/);
+    expect(errs.join("")).toMatch(/will NOT aggregate/);
+  });
+
+  it("F1: valid UNBOUND key + team_id unresolvable → persistent LOUD warning every apply", async () => {
+    getViaBrokerStructured.mockResolvedValue({
+      kind: "ok",
+      entry: { kind: "string", value: "sk-stored" },
+    });
+    validateKey.mockResolvedValue({ kind: "valid", teamId: null });
+    ensureTeam.mockResolvedValue({ kind: "unbound", reason: "team_id could not be resolved" });
+
+    const { ctx, failures, errs } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
+
+    expect(failures).toEqual([]);
+    // No /key/update attempted (no team_id to bind to), but stays LOUD.
+    expect(bindKeyToTeam).not.toHaveBeenCalled();
+    expect(errs.join("")).toMatch(/UNBOUND to any team/);
+    expect(errs.join("")).toMatch(/will NOT aggregate/);
   });
 
   it("stored key UNKNOWN on the proxy (DB drift) → re-provision + rewrite vault", async () => {
@@ -224,6 +294,71 @@ describe("provisionLiteLLMKeys — stored-key validation against the proxy (DB d
     expect(putViaBroker).not.toHaveBeenCalled();
     expect(errs.join("")).toMatch(/proxy unreachable during key validation/);
     expect(errs.join("")).toMatch(/keeping the stored key unverified/);
+  });
+});
+
+describe("provisionLiteLLMKeys — F3: ensureTeam-fails degrades LOUDLY, honest success line", () => {
+  let prevPass: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prevPass = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    process.env.SWITCHROOM_VAULT_PASSPHRASE = "test-passphrase";
+  });
+
+  afterEach(() => {
+    if (prevPass === undefined) delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    else process.env.SWITCHROOM_VAULT_PASSPHRASE = prevPass;
+  });
+
+  it("new agent, ensureTeam returns unbound → key STILL provisioned, WARNING emitted, NO false '(team ...)' claim", async () => {
+    // Genuinely-new agent: no vault key yet → provisioning path.
+    getViaBrokerStructured.mockResolvedValue({ kind: "not_found" });
+    // ensureTeam cannot resolve a team_id → the key will be generated UNBOUND.
+    ensureTeam.mockResolvedValue({
+      kind: "unbound",
+      reason: "team 'switchroom' already exists but its team_id could not be resolved via /team/list",
+    });
+    ensureKey.mockResolvedValue({ key: "sk-fresh" });
+    putViaBroker.mockResolvedValue({ kind: "ok" });
+
+    const { ctx, failures, out, errs } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
+
+    // Outcome 1: the key was STILL provisioned + written (invariant: an agent
+    // must get its routing env even when team binding degrades).
+    expect(failures).toEqual([]);
+    expect(ensureKey).toHaveBeenCalledTimes(1);
+    expect(putViaBroker).toHaveBeenCalledWith(
+      "litellm/clerk/api-key",
+      { kind: "string", value: "sk-fresh" },
+      expect.objectContaining({ passphrase: "test-passphrase" }),
+    );
+    // Outcome 2: a LOUD warning names the degradation + the reason.
+    expect(errs.join("")).toMatch(/provisioned virtual key WITHOUT team binding/);
+    expect(errs.join("")).toMatch(/will NOT aggregate/);
+    expect(errs.join("")).toMatch(/could not be resolved via \/team\/list/);
+    // Outcome 3: NO false green "(team 'switchroom')" success claim.
+    expect(out.join("")).not.toMatch(/provisioned virtual key \(team/);
+  });
+
+  it("new agent, ensureTeam BOUND → honest green success line WITH the team clause", async () => {
+    getViaBrokerStructured.mockResolvedValue({ kind: "not_found" });
+    ensureTeam.mockResolvedValue({ kind: "bound", teamId: "t1" });
+    ensureKey.mockResolvedValue({ key: "sk-fresh" });
+    putViaBroker.mockResolvedValue({ kind: "ok" });
+
+    const { ctx, failures, out, errs } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
+
+    expect(failures).toEqual([]);
+    // The team clause is printed ONLY because the key is genuinely bound.
+    expect(out.join("")).toMatch(/provisioned virtual key \(team 'switchroom'\)/);
+    expect(errs.join("")).not.toMatch(/WITHOUT team binding/);
+    // And ensureKey received the resolved team_id (bound at generate time).
+    expect(ensureKey).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: "t1" }),
+    );
   });
 });
 

--- a/src/cli/apply-litellm-provision.test.ts
+++ b/src/cli/apply-litellm-provision.test.ts
@@ -220,6 +220,29 @@ describe("provisionLiteLLMKeys — stored-key validation against the proxy (DB d
     expect(out.join("")).toMatch(/was UNBOUND/);
   });
 
+  it("F1: stored key VALID but bound to a DIFFERENT team → re-bound to the config team (config wins)", async () => {
+    // Config is authoritative: an out-of-band binding to another team is
+    // re-bound back to the config-declared team, announced with the prior team.
+    getViaBrokerStructured.mockResolvedValue({
+      kind: "ok",
+      entry: { kind: "string", value: "sk-stored" },
+    });
+    validateKey.mockResolvedValue({ kind: "valid", teamId: "t2" }); // wrong team
+    ensureTeam.mockResolvedValue({ kind: "bound", teamId: "t1" });
+    bindKeyToTeam.mockResolvedValue({ kind: "ok" });
+
+    const { ctx, failures, out } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
+
+    expect(failures).toEqual([]);
+    expect(ensureKey).not.toHaveBeenCalled();
+    expect(bindKeyToTeam).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "sk-stored", teamId: "t1" }),
+    );
+    expect(out.join("")).toMatch(/re-bound existing key to team 'switchroom'/);
+    expect(out.join("")).toMatch(/was team 't2'/);
+  });
+
   it("F1: valid UNBOUND key but /key/update FAILS → LOUD warning, key kept, apply not failed", async () => {
     getViaBrokerStructured.mockResolvedValue({
       kind: "ok",

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -588,6 +588,11 @@ export async function provisionLiteLLMKeys(
               );
             }
 
+            // Config is authoritative for team binding: a key bound out-of-band
+            // to a DIFFERENT team is re-bound back to the config-declared team
+            // on the next apply (announced in the output). One team per cost
+            // bucket is the product invariant; change the config to change the
+            // binding.
             if (desired && desired.kind === "bound" && boundTeamId !== desired.teamId) {
               const bind = await bindKeyToTeam({ baseUrl, masterKey, key: storedKey, teamId: desired.teamId });
               if (bind.kind === "ok") {

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -296,7 +296,7 @@ export async function provisionLiteLLMKeys(
   if (optedIn.length === 0 && !needsHindsight) return; // zero-impact when the feature is off
 
   // Lazy imports — only paid for when at least one agent opts in or hindsight is wired.
-  const [{ getViaBrokerStructured, putViaBroker }, { ensureTeam, ensureKey, validateKey }, { addAgentSecret }] =
+  const [{ getViaBrokerStructured, putViaBroker }, { ensureTeam, ensureKey, validateKey, bindKeyToTeam }, { addAgentSecret }] =
     await Promise.all([
       import("../vault/broker/client.js"),
       import("../litellm/provision.js"),
@@ -560,7 +560,71 @@ export async function provisionLiteLLMKeys(
               ),
             );
           } else {
-            writeOut(chalk.gray(`  ~ litellm/${name}: key already provisioned + validated (skipped)\n`));
+            // validation.kind === "valid": the proxy recognizes the key. F1:
+            // it may still be UNBOUND (provisioned before the team-binding fix,
+            // or via the degraded unbound path) or bound to the WRONG team — so
+            // per-team cost tracking silently never aggregates for it, and the
+            // pre-fix idempotent skip left it that way FOREVER. Resolve the
+            // desired team and re-bind IN PLACE (POST /key/update) — no key
+            // deletion/regeneration. Availability-safe + LOUD on failure.
+            const boundTeamId = validation.teamId; // string | null
+            let desired: Awaited<ReturnType<typeof ensureTeam>> | null = null;
+            try {
+              desired = await ensureTeam(
+                baseUrl,
+                masterKey,
+                team,
+                undefined,
+                (m) => ctx.writeErr(chalk.yellow(`  ! litellm/${name}: ${m}\n`)),
+              );
+            } catch (err) {
+              // #2781 parity: a team-resolution error must NOT turn an
+              // already-good key into a scaffold failure — keep it, warn, move on.
+              ctx.writeErr(
+                chalk.yellow(
+                  `  ! litellm/${name}: could not resolve team '${team}' to check ` +
+                  `key binding (${(err as Error).message}) — keeping the stored key as-is.\n`,
+                ),
+              );
+            }
+
+            if (desired && desired.kind === "bound" && boundTeamId !== desired.teamId) {
+              const bind = await bindKeyToTeam({ baseUrl, masterKey, key: storedKey, teamId: desired.teamId });
+              if (bind.kind === "ok") {
+                writeOut(
+                  chalk.green(
+                    `  + litellm/${name}: re-bound existing key to team '${team}' ` +
+                    `(${boundTeamId === null ? "was UNBOUND" : `was team '${boundTeamId}'`}) ` +
+                    `— per-team cost tracking now applies\n`,
+                  ),
+                );
+              } else {
+                ctx.writeErr(
+                  chalk.yellow(
+                    `  ! litellm/${name}: key is provisioned but re-bind to team ` +
+                    `'${team}' FAILED (${bind.detail}) — per-team cost tracking will ` +
+                    `NOT aggregate for this key until re-bound. Manual: POST ` +
+                    `${baseUrl}/key/update {"key":"<key>","team_id":"${desired.teamId}"}.\n`,
+                  ),
+                );
+              }
+            } else if (desired && desired.kind === "unbound" && boundTeamId === null) {
+              // Key UNBOUND and the team_id could not be resolved → stay LOUD
+              // every apply so the degradation is never silent (F1 loud fallback).
+              ctx.writeErr(
+                chalk.yellow(
+                  `  ! litellm/${name}: key is provisioned but UNBOUND to any team, ` +
+                  `and team '${team}' could not be resolved (${desired.reason}) — ` +
+                  `per-team cost tracking will NOT aggregate for this key. Re-run ` +
+                  `once the LiteLLM team is resolvable.\n`,
+                ),
+              );
+            } else {
+              // Already bound to the desired team, OR bound to some team we
+              // couldn't re-resolve (still tracked), OR the lookup threw
+              // (warned above) — quiet, honest skip.
+              writeOut(chalk.gray(`  ~ litellm/${name}: key already provisioned + validated (skipped)\n`));
+            }
           }
         } else {
           // Can't validate (no admin key in hand, or a non-string entry) — keep
@@ -593,7 +657,14 @@ export async function provisionLiteLLMKeys(
 
       // Provision: ensure team (capturing its team_id so the key binds to it
       // for per-team cost/spend tracking), then generate the per-agent key.
-      const teamId = await ensureTeam(baseUrl, masterKey, team);
+      const teamResult = await ensureTeam(
+        baseUrl,
+        masterKey,
+        team,
+        undefined,
+        (m) => ctx.writeErr(chalk.yellow(`  ! litellm/${name}: ${m}\n`)),
+      );
+      const teamId = teamResult.kind === "bound" ? teamResult.teamId : undefined;
       const metadata: Record<string, string> = {
         agent: name,
         env: "fleet",
@@ -651,7 +722,21 @@ export async function provisionLiteLLMKeys(
         }
       }
 
-      writeOut(chalk.green(`  + litellm/${name}: provisioned virtual key (team '${team}')\n`));
+      if (teamId) {
+        writeOut(chalk.green(`  + litellm/${name}: provisioned virtual key (team '${team}')\n`));
+      } else {
+        // F3: ensureTeam could not resolve a team_id, so the key was generated
+        // UNBOUND. The pre-fix code printed a green "(team 'switchroom')" here —
+        // the config NAME string, always truthy — falsely claiming a binding.
+        // Be honest + LOUD: the key exists, but cost tracking will NOT aggregate.
+        ctx.writeErr(
+          chalk.yellow(
+            `  ! litellm/${name}: provisioned virtual key WITHOUT team binding ` +
+            `(${teamResult.kind === "unbound" ? teamResult.reason : "team_id unresolved"}) ` +
+            `— per-team cost tracking will NOT aggregate for this key.\n`,
+          ),
+        );
+      }
     } catch (err) {
       failures.push({ agent: name, message: `litellm: ${(err as Error).message}` });
     }
@@ -697,7 +782,14 @@ export async function provisionLiteLLMKeys(
             }
           }
           const team = topLevel?.team ?? "switchroom";
-          const teamId = await ensureTeam(baseUrl, masterKey, team);
+          const teamResult = await ensureTeam(
+            baseUrl,
+            masterKey,
+            team,
+            undefined,
+            (m) => ctx.writeErr(chalk.yellow(`  ! litellm/hindsight: ${m}\n`)),
+          );
+          const teamId = teamResult.kind === "bound" ? teamResult.teamId : undefined;
           const { key } = await ensureKey({
             baseUrl,
             masterKey,
@@ -712,7 +804,18 @@ export async function provisionLiteLLMKeys(
             { passphrase: passphrase! },
           );
           if (put.kind === "ok") {
-            writeOut(chalk.green(`  + litellm/hindsight: provisioned virtual key (team '${team}')\n`));
+            if (teamId) {
+              writeOut(chalk.green(`  + litellm/hindsight: provisioned virtual key (team '${team}')\n`));
+            } else {
+              // F3: honest, LOUD degradation instead of a false "(team ...)" claim.
+              ctx.writeErr(
+                chalk.yellow(
+                  `  ! litellm/hindsight: provisioned virtual key WITHOUT team binding ` +
+                  `(${teamResult.kind === "unbound" ? teamResult.reason : "team_id unresolved"}) ` +
+                  `— per-team cost tracking will NOT aggregate for this key.\n`,
+                ),
+              );
+            }
           } else {
             throw new Error(`vault write failed (${put.kind})`);
           }

--- a/src/litellm/provision-apply-e2e.test.ts
+++ b/src/litellm/provision-apply-e2e.test.ts
@@ -82,6 +82,9 @@ describe("provisionLiteLLMKeys — real broker e2e (blocker-1 seam)", () => {
   // bound to the team via team_id (the cost-tracking fix), end-to-end through
   // the real provisionLiteLLMKeys → ensureTeam → ensureKey path.
   let keyGenBodies: Array<Record<string, unknown>>;
+  // Captures /key/update bodies so the idempotent re-apply test can assert the
+  // F1 in-place team re-bind (bind-only {key, team_id}, no regeneration).
+  let keyUpdateBodies: Array<Record<string, unknown>>;
 
   beforeEach(async () => {
     prevNonLinux = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
@@ -121,6 +124,7 @@ describe("provisionLiteLLMKeys — real broker e2e (blocker-1 seam)", () => {
 
     // Stub global fetch so ensureTeam/ensureKey never hit the network.
     keyGenBodies = [];
+    keyUpdateBodies = [];
     realFetch = globalThis.fetch;
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
@@ -136,6 +140,15 @@ describe("provisionLiteLLMKeys — real broker e2e (blocker-1 seam)", () => {
       // Fix-2 validation probe: any stored key we might validate is "valid".
       if (u.includes("/key/info")) {
         return new Response(JSON.stringify({ key: "sk-virtual-clerk-xyz", info: {} }), {
+          status: 200,
+        });
+      }
+      // F1 re-bind: a steady-state re-apply of a valid-but-unbound key issues a
+      // bind-only /key/update {key, team_id}. The /key/info stub above reports
+      // info:{} (UNBOUND), so an idempotent re-run heals it here.
+      if (u.includes("/key/update")) {
+        if (init?.body) keyUpdateBodies.push(JSON.parse(String(init.body)));
+        return new Response(JSON.stringify({ key: "sk-virtual-clerk-xyz", team_id: "t1" }), {
           status: 200,
         });
       }
@@ -290,5 +303,13 @@ describe("provisionLiteLLMKeys — real broker e2e (blocker-1 seam)", () => {
     expect(getStringSecret(TEST_PASSPHRASE, vaultPath, "litellm/clerk/api-key")).toBe(
       "sk-virtual-clerk-xyz",
     );
+    // NOTE: the F1 steady-state re-bind (valid key → /key/update) can't be
+    // exercised through THIS harness: apply connects to the broker as a
+    // non-operator peer on the tmp socket, so getViaBrokerStructured returns
+    // `denied` for any key (peer-identity ACL, see the file-header note), and
+    // the code never reaches the `existing.kind === "ok"` steady-state branch —
+    // the second run re-provisions (upsert) instead. F1's re-bind is pinned at
+    // the unit level in apply-litellm-provision.test.ts, where the broker read
+    // is stubbable. The `/key/update` fetch stub above stays for coherence.
   });
 });

--- a/src/litellm/provision.test.ts
+++ b/src/litellm/provision.test.ts
@@ -3,6 +3,7 @@ import {
   ensureTeam,
   ensureKey,
   validateKey,
+  bindKeyToTeam,
   LiteLLMProvisionError,
   type FetchFn,
 } from "./provision.js";
@@ -40,7 +41,7 @@ describe("ensureTeam", () => {
       return mockResponse({ ok: true, status: 200, json: { team_id: "t1" } });
     };
     const teamId = await ensureTeam("http://127.0.0.1:4010", "sk-master", "switchroom", fetchFn);
-    expect(teamId).toBe("t1");
+    expect(teamId).toEqual({ kind: "bound", teamId: "t1" });
     expect(calls).toHaveLength(1);
     expect(calls[0]!.url).toBe("http://127.0.0.1:4010/team/new");
     expect(calls[0]!.init?.method).toBe("POST");
@@ -79,7 +80,7 @@ describe("ensureTeam", () => {
       return mockResponse({ ok: false, status: 404, text: "not found" });
     };
     const teamId = await ensureTeam("http://127.0.0.1:4010", "sk-master", "switchroom", fetchFn);
-    expect(teamId).toBe("switchroom-uuid");
+    expect(teamId).toEqual({ kind: "bound", teamId: "switchroom-uuid" });
     // It fell through to /team/list after the already-exists /team/new.
     expect(calls.map((c) => `${c.method} ${c.url.replace("http://127.0.0.1:4010", "")}`)).toEqual([
       "POST /team/new",
@@ -87,15 +88,61 @@ describe("ensureTeam", () => {
     ]);
   });
 
-  it("returns undefined (non-fatal) when the already-exists team can't be resolved", async () => {
-    // Best-effort: if /team/list is unavailable, degrade to undefined rather
-    // than failing the whole apply — the key falls back to unbound.
+  it("returns unbound + a reason (non-fatal) when the already-exists team can't be resolved", async () => {
+    // Best-effort: if /team/list is unavailable, degrade to `unbound` (carrying
+    // WHY) rather than failing the whole apply — the caller then warns LOUDLY
+    // and the key falls back to unbound instead of a silent green success.
     const fetchFn: FetchFn = async (url) =>
       String(url).endsWith("/team/new")
         ? mockResponse({ ok: false, status: 409, text: "conflict" })
         : mockResponse({ ok: false, status: 500, text: "list unavailable" });
-    const teamId = await ensureTeam("http://h", "k", "switchroom", fetchFn);
-    expect(teamId).toBeUndefined();
+    const result = await ensureTeam("http://h", "k", "switchroom", fetchFn);
+    expect(result.kind).toBe("unbound");
+    expect((result as { reason: string }).reason).toMatch(/could not be resolved/);
+  });
+
+  it("returns unbound with a reason when /team/new 200s but carries no team_id", async () => {
+    // A fresh-create 200 whose body has no usable team_id must NOT masquerade as
+    // a bound team — it degrades to `unbound` so the caller warns instead of
+    // falsely claiming the key was team-bound.
+    const fetchFn: FetchFn = async () =>
+      mockResponse({ ok: true, status: 200, json: { not_a_team_id: true } });
+    const result = await ensureTeam("http://h", "k", "switchroom", fetchFn);
+    expect(result.kind).toBe("unbound");
+    expect((result as { reason: string }).reason).toMatch(/no usable team_id/);
+  });
+
+  it("duplicate team_alias: picks the lexicographically smallest team_id + WARNS (deterministic)", async () => {
+    // LiteLLM does NOT enforce a unique team_alias, so /team/list can carry
+    // several teams sharing our alias. Returning the first (array-order) match
+    // is nondeterministic — keys could bind to a different team run-to-run,
+    // splitting cost tracking. ensureTeam must pick deterministically (lex-
+    // smallest id) and warn naming every duplicate.
+    const logs: string[] = [];
+    const fetchFn: FetchFn = async (url) => {
+      const u = String(url);
+      if (u.endsWith("/team/new")) {
+        return mockResponse({ ok: false, status: 400, text: "Team alias switchroom already exists in DB" });
+      }
+      // Duplicates deliberately out of lexicographic order to prove the sort.
+      return mockResponse({
+        ok: true,
+        status: 200,
+        json: [
+          { team_id: "zzz-team", team_alias: "switchroom" },
+          { team_id: "aaa-team", team_alias: "switchroom" },
+          { team_id: "mmm-team", team_alias: "other" },
+        ],
+      });
+    };
+    const result = await ensureTeam("http://h", "k", "switchroom", fetchFn, (m) => logs.push(m));
+    // Deterministic: lexicographically smallest of {zzz-team, aaa-team}.
+    expect(result).toEqual({ kind: "bound", teamId: "aaa-team" });
+    // Loud + honest: the warning names BOTH duplicate ids.
+    const warned = logs.join("\n");
+    expect(warned).toMatch(/2 LiteLLM teams share team_alias 'switchroom'/);
+    expect(warned).toMatch(/aaa-team/);
+    expect(warned).toMatch(/zzz-team/);
   });
 
   it("strips a trailing slash from base_url", async () => {
@@ -115,9 +162,11 @@ describe("ensureTeam", () => {
         status: 400,
         text: "Team alias switchroom already exists in DB",
       });
+    // Idempotent already-exists, but no /team/list reachable here → `unbound`
+    // (non-fatal), not a throw.
     await expect(
       ensureTeam("http://h", "k", "switchroom", fetchFn),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ kind: "unbound" });
   });
 
   it("treats a 409 conflict as success (idempotent)", async () => {
@@ -125,7 +174,7 @@ describe("ensureTeam", () => {
       mockResponse({ ok: false, status: 409, text: "conflict" });
     await expect(
       ensureTeam("http://h", "k", "switchroom", fetchFn),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ kind: "unbound" });
   });
 
   it("throws LiteLLMProvisionError on a genuine non-existence error", async () => {
@@ -398,15 +447,30 @@ describe("ensureKey — orphaned-alias self-heal", () => {
 });
 
 describe("validateKey", () => {
-  it("returns valid on a 200 from /key/info", async () => {
+  it("returns valid with teamId=null on a 200 /key/info whose info carries no team_id", async () => {
     const calls: string[] = [];
     const fetchFn: FetchFn = async (url) => {
       calls.push(String(url));
       return mockResponse({ ok: true, status: 200, json: { key: "sk-x", info: {} } });
     };
     const r = await validateKey({ baseUrl: "http://h", masterKey: "m", key: "sk-x" }, fetchFn);
-    expect(r).toEqual({ kind: "valid" });
+    // An UNBOUND key → teamId null (so the caller can re-bind it).
+    expect(r).toEqual({ kind: "valid", teamId: null });
     expect(calls[0]).toContain("/key/info?key=sk-x");
+  });
+
+  it("reports the bound team_id from info.team_id on a 200 /key/info", async () => {
+    // F1: validateKey must surface the key's CURRENT team binding so the apply
+    // path can tell an unbound (or wrong-team) key from a correctly-bound one.
+    // Verified v1.91.0 shape: GET /key/info → { key, info: {...team_id...} }.
+    const fetchFn: FetchFn = async () =>
+      mockResponse({
+        ok: true,
+        status: 200,
+        json: { key: "sk-x", info: { team_id: "team-uuid-42", spend: 0 } },
+      });
+    const r = await validateKey({ baseUrl: "http://h", masterKey: "m", key: "sk-x" }, fetchFn);
+    expect(r).toEqual({ kind: "valid", teamId: "team-uuid-42" });
   });
 
   it("returns unknown on a 400 'not found' (DB drift)", async () => {
@@ -456,5 +520,58 @@ describe("validateKey", () => {
       mockResponse({ ok: false, status: 500, text: "internal server error" });
     const r = await validateKey({ baseUrl: "http://h", masterKey: "m", key: "sk-x" }, fetchFn);
     expect(r.kind).toBe("unreachable");
+  });
+});
+
+describe("bindKeyToTeam", () => {
+  it("POSTs {key, team_id} to /key/update and returns ok on 200", async () => {
+    // F1 re-bind contract (verified v1.91.0 update_key_fn / UpdateKeyRequest):
+    // a bind-only /key/update attaches an existing key to a team WITHOUT
+    // deleting/regenerating it, so per-team cost tracking starts aggregating.
+    const calls: { url: string; init: RequestInit | undefined }[] = [];
+    const fetchFn: FetchFn = async (url, init) => {
+      calls.push({ url: String(url), init });
+      return mockResponse({ ok: true, status: 200, json: { key: "sk-x", team_id: "t1" } });
+    };
+    const r = await bindKeyToTeam(
+      { baseUrl: "http://127.0.0.1:4010", masterKey: "sk-master", key: "sk-x", teamId: "t1" },
+      fetchFn,
+    );
+    expect(r).toEqual({ kind: "ok" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("http://127.0.0.1:4010/key/update");
+    expect(calls[0]!.init?.method).toBe("POST");
+    const body = JSON.parse(String(calls[0]!.init?.body));
+    // Exactly the bind-only payload — no incidental key churn.
+    expect(body).toEqual({ key: "sk-x", team_id: "t1" });
+    const headers = calls[0]!.init?.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer sk-master");
+  });
+
+  it("strips a trailing slash from base_url", async () => {
+    const calls: string[] = [];
+    const fetchFn: FetchFn = async (url) => {
+      calls.push(String(url));
+      return mockResponse({ ok: true, status: 200, json: {} });
+    };
+    await bindKeyToTeam({ baseUrl: "http://h/", masterKey: "m", key: "sk-x", teamId: "t1" }, fetchFn);
+    expect(calls[0]).toBe("http://h/key/update");
+  });
+
+  it("returns a structured error (never throws) on a non-200", async () => {
+    const fetchFn: FetchFn = async () =>
+      mockResponse({ ok: false, status: 403, text: "forbidden" });
+    const r = await bindKeyToTeam({ baseUrl: "http://h", masterKey: "m", key: "sk-x", teamId: "t1" }, fetchFn);
+    expect(r.kind).toBe("error");
+    expect((r as { detail: string }).detail).toMatch(/HTTP 403.*forbidden/);
+  });
+
+  it("returns a structured error (never throws) on a network failure", async () => {
+    const fetchFn: FetchFn = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const r = await bindKeyToTeam({ baseUrl: "http://h", masterKey: "m", key: "sk-x", teamId: "t1" }, fetchFn);
+    expect(r.kind).toBe("error");
+    expect((r as { detail: string }).detail).toMatch(/ECONNREFUSED/);
   });
 });

--- a/src/litellm/provision.ts
+++ b/src/litellm/provision.ts
@@ -9,9 +9,12 @@
  *
  * The operations:
  *   - ensureTeam: create the "switchroom" LiteLLM team (idempotent — an
- *     "already exists" response is treated as success). Returns the team's
- *     `team_id` (the UUID `/team/new` hands back, or resolved via `/team/list`
- *     on the already-exists path) so keys can be bound to the team.
+ *     "already exists" response is treated as success). Returns an
+ *     `EnsureTeamResult`: `{kind:"bound", teamId}` (the UUID `/team/new` hands
+ *     back, or resolved via `/team/list` on the already-exists path) so keys
+ *     can be bound to the team, or `{kind:"unbound", reason}` carrying WHY no
+ *     id could be resolved so the caller can degrade LOUDLY instead of
+ *     silently binding nothing.
  *   - ensureKey: generate a per-agent virtual key under the team. Self-heals an
  *     ORPHANED key alias: LiteLLM enforces unique key aliases (upstream
  *     issue #9730), so if a prior apply generated the alias but crashed before
@@ -19,13 +22,25 @@
  *     — every later /key/generate then hard-fails with 400 "Key with alias ...
  *     already exists". ensureKey recovers by deleting the orphan and regenerating.
  *   - validateKey: probe a stored virtual key against the proxy (GET /key/info)
- *     to detect DB drift (proxy DB reset / restore without the vault).
+ *     to detect DB drift (proxy DB reset / restore without the vault) AND report
+ *     the key's current `team_id` binding so a valid-but-unbound key can be
+ *     re-bound on a steady-state re-apply.
+ *   - bindKeyToTeam: re-bind an EXISTING key to a team in place via
+ *     POST /key/update {key, team_id} — heals keys provisioned before the
+ *     team-binding fix (or via the degraded unbound path) without deleting or
+ *     regenerating them.
  *
- * LiteLLM admin API reference (v1.91 shapes): POST {base}/team/new (returns a
- * LiteLLM_TeamTable carrying `team_id`), GET {base}/team/list (each entry
- * carries `team_id` + `team_alias`), POST {base}/key/generate (binds to a team
- * via `team_id`), GET {base}/key/info?key=..., GET {base}/key/list,
- * POST {base}/key/delete — authenticated with the master key as a Bearer token.
+ * LiteLLM admin API reference (verified against v1.91.0
+ * litellm/proxy/management_endpoints/key_management_endpoints.py + _types.py):
+ * POST {base}/team/new (returns a LiteLLM_TeamTable carrying `team_id`),
+ * GET {base}/team/list (each entry carries `team_id` + `team_alias`),
+ * POST {base}/key/generate (binds to a team via `team_id`),
+ * GET {base}/key/info?key=... (returns `{key, info}` where the binding is at
+ * `info.team_id`, null/absent ⇒ UNBOUND), GET {base}/key/list,
+ * POST {base}/key/delete, POST {base}/key/update (accepts `UpdateKeyRequest`,
+ * which inherits `team_id` from `GenerateRequestBase` via `KeyRequestBase`; the
+ * handler's `is_different_team` guard rebinds null→team and team→team) —
+ * authenticated with the master key as a Bearer token.
  */
 
 /**
@@ -140,12 +155,27 @@ function looksLikeUnknownKey(status: number, body: string): boolean {
  * returned rather than throwing — the provision still succeeds, the key just
  * falls back to unbound (the pre-fix behavior) instead of failing the apply.
  */
+/**
+ * Outcome of `ensureTeam`.
+ *   - `bound`: carries the `team_id` keys must be attached to for per-team
+ *     cost/spend tracking.
+ *   - `unbound`: no id could be resolved (a fresh `/team/new` 200 with no
+ *     parseable id, or an already-exists team whose id `/team/list` didn't
+ *     yield). Carries a human `reason` so the CALLER can log a loud, specific
+ *     warning instead of silently degrading to an unbound key (the pre-fix
+ *     behavior swallowed the reason and provisioned a green "success").
+ */
+export type EnsureTeamResult =
+  | { kind: "bound"; teamId: string }
+  | { kind: "unbound"; reason: string };
+
 export async function ensureTeam(
   baseUrl: string,
   masterKey: string,
   teamName: string,
   fetchFn: FetchFn = fetch,
-): Promise<string | undefined> {
+  log?: (msg: string) => void,
+): Promise<EnsureTeamResult> {
   const base = normalizeBase(baseUrl);
   const url = `${base}/team/new`;
   let resp: Response;
@@ -163,13 +193,28 @@ export async function ensureTeam(
   if (resp.ok) {
     // Fresh create: the response is a LiteLLM_TeamTable carrying the new
     // team_id (the UUID keys must be bound to).
-    return await readTeamId(resp);
+    const id = await readTeamId(resp);
+    if (id) return { kind: "bound", teamId: id };
+    return {
+      kind: "unbound",
+      reason:
+        `/team/new returned 200 for team '${teamName}' but the response ` +
+        `carried no usable team_id`,
+    };
   }
   const body = await safeText(resp);
   if (looksLikeAlreadyExists(resp.status, body)) {
     // Idempotent: the team already exists, so /team/new did NOT hand back the
     // id — resolve it by alias via /team/list so keys can still be bound.
-    return await resolveTeamIdByAlias(base, masterKey, teamName, fetchFn);
+    const id = await resolveTeamIdByAlias(base, masterKey, teamName, fetchFn, log);
+    if (id) return { kind: "bound", teamId: id };
+    return {
+      kind: "unbound",
+      reason:
+        `team '${teamName}' already exists but its team_id could not be ` +
+        `resolved via /team/list (list unavailable, unparseable, or no ` +
+        `entry matching the alias)`,
+    };
   }
   throw new LiteLLMProvisionError(
     `LiteLLM /team/new returned ${resp.status}`,
@@ -205,6 +250,7 @@ async function resolveTeamIdByAlias(
   masterKey: string,
   teamName: string,
   fetchFn: FetchFn,
+  log?: (msg: string) => void,
 ): Promise<string | undefined> {
   let resp: Response;
   try {
@@ -227,16 +273,34 @@ async function resolveTeamIdByAlias(
     : Array.isArray((json as { teams?: unknown } | null)?.teams)
       ? (json as { teams: unknown[] }).teams
       : [];
+  // Collect ALL ids sharing the alias. LiteLLM does NOT enforce a unique
+  // team_alias, so /team/list can legitimately carry several teams with our
+  // alias (e.g. a team recreated after a partial delete). Returning the first
+  // match is array-order — server-defined and NONDETERMINISTIC: keys could
+  // bind to a different team run-to-run, splitting cost tracking silently.
+  const matches: string[] = [];
   for (const t of teams) {
     if (t && typeof t === "object") {
       const alias = (t as { team_alias?: unknown }).team_alias;
       const id = (t as { team_id?: unknown }).team_id;
       if (alias === teamName && typeof id === "string" && id.length > 0) {
-        return id;
+        matches.push(id);
       }
     }
   }
-  return undefined;
+  if (matches.length === 0) return undefined;
+  if (matches.length === 1) return matches[0];
+  // Duplicate aliases: pick DETERMINISTICALLY (the lexicographically smallest
+  // team_id) so binding is stable across applies, and warn naming every
+  // duplicate so the operator can dedupe the team upstream.
+  const sorted = [...matches].sort();
+  log?.(
+    `WARNING: ${matches.length} LiteLLM teams share team_alias '${teamName}' ` +
+    `(team_ids: ${sorted.join(", ")}); binding keys deterministically to the ` +
+    `lexicographically smallest '${sorted[0]}'. Deduplicate the team in ` +
+    `LiteLLM to silence this and guarantee cost tracking lands on one team.`,
+  );
+  return sorted[0];
 }
 
 /** Internal outcome of a single /key/generate POST. */
@@ -476,7 +540,7 @@ export interface ValidateKeyOpts {
  *       Never triggers a destructive re-provision.
  */
 export type ValidateKeyResult =
-  | { kind: "valid" }
+  | { kind: "valid"; teamId: string | null }
   | { kind: "unknown" }
   | { kind: "unreachable"; detail: string };
 
@@ -486,6 +550,11 @@ export type ValidateKeyResult =
  * a stale vault key can be re-provisioned instead of silently 401ing every
  * agent request. Availability-safe: any ambiguous failure degrades to
  * `unreachable` (skip), never to a destructive re-provision.
+ *
+ * On `valid`, also reports the key's current team binding (`teamId`, from
+ * `info.team_id` in the /key/info response — `null` when UNBOUND) so the
+ * caller can re-bind a valid-but-unbound key on a steady-state re-apply
+ * (see `bindKeyToTeam`).
  */
 export async function validateKey(
   opts: ValidateKeyOpts,
@@ -498,12 +567,77 @@ export async function validateKey(
   } catch (err) {
     return { kind: "unreachable", detail: (err as Error).message };
   }
-  if (resp.ok) return { kind: "valid" };
+  if (resp.ok) {
+    // GET /key/info returns { key, info: {...VerificationToken row...} }
+    // (verified v1.91.0 key_management_endpoints.py info_key_fn). The key's
+    // team binding lives at info.team_id — null/absent ⇒ UNBOUND. Surface it
+    // so a valid-but-unbound key can be healed in place (F1). A missing /
+    // unparseable body degrades to `null` (unknown binding), never an error.
+    let teamId: string | null = null;
+    try {
+      const json = (await resp.json()) as { info?: { team_id?: unknown } } | null;
+      const t = json?.info?.team_id;
+      if (typeof t === "string" && t.length > 0) teamId = t;
+    } catch {
+      /* body unreadable/non-JSON — treat binding as unknown (null). */
+    }
+    return { kind: "valid", teamId };
+  }
   const body = await safeText(resp);
   if (looksLikeUnknownKey(resp.status, body)) return { kind: "unknown" };
   // Bare 401/403 (bad master key, no not-found semantic), 5xx, or any other
   // ambiguous error — do NOT re-provision; keep the stored key and warn.
   return { kind: "unreachable", detail: `HTTP ${resp.status}: ${body.slice(0, 200)}` };
+}
+
+/** Options for `bindKeyToTeam`. */
+export interface BindKeyToTeamOpts {
+  baseUrl: string;
+  masterKey: string;
+  /** The existing virtual key string to re-bind. */
+  key: string;
+  /** The team_id to bind the key under. */
+  teamId: string;
+}
+
+/** Outcome of a bind-only /key/update. */
+export type BindKeyToTeamResult =
+  | { kind: "ok" }
+  | { kind: "error"; detail: string };
+
+/**
+ * Re-bind an EXISTING virtual key to a team in place via
+ * POST /key/update {key, team_id}. Heals keys provisioned before the
+ * team-binding fix (or via the degraded unbound path) so per-team cost
+ * tracking starts aggregating — WITHOUT deleting or regenerating the key
+ * (which would churn the vault + break in-flight agents).
+ *
+ * Contract verified against LiteLLM v1.91.0
+ * (litellm/proxy/management_endpoints/key_management_endpoints.py update_key_fn
+ * + _types.py): POST /key/update accepts `UpdateKeyRequest`, which inherits the
+ * optional `team_id` field from `GenerateRequestBase` via `KeyRequestBase`; the
+ * handler's `is_different_team(data, existing_key_row)` guard rebinds a key
+ * from null→team and team→team. Best-effort + LOUD on failure: never throws —
+ * returns a structured error the caller surfaces as a warning.
+ */
+export async function bindKeyToTeam(
+  opts: BindKeyToTeamOpts,
+  fetchFn: FetchFn = fetch,
+): Promise<BindKeyToTeamResult> {
+  const url = `${normalizeBase(opts.baseUrl)}/key/update`;
+  let resp: Response;
+  try {
+    resp = await fetchFn(url, {
+      method: "POST",
+      headers: authHeaders(opts.masterKey),
+      body: JSON.stringify({ key: opts.key, team_id: opts.teamId }),
+    });
+  } catch (err) {
+    return { kind: "error", detail: (err as Error).message };
+  }
+  if (resp.ok) return { kind: "ok" };
+  const body = await safeText(resp);
+  return { kind: "error", detail: `HTTP ${resp.status}: ${body.slice(0, 200)}` };
 }
 
 /** Read a Response body as text, swallowing any read error (best-effort


### PR DESCRIPTION
Adversarial-review follow-ups to #3140 (which was squash-merged before these findings were addressed, so this is a fresh PR onto `main` carrying only the review fixes).

Standing invariant: all agent traffic routes through LiteLLM with per-team cost tracking; degradation must be loud and deterministic, never silent.

## F3 (MEDIUM, blocking) — silent degradation + misleading success log
`ensureTeam` now returns `EnsureTeamResult` (`bound{teamId}` | `unbound{reason}`) instead of `string|undefined`, threading the reason OUT instead of swallowing it. When no `team_id` resolves, apply still provisions the key (agents keep routing env) but emits a LOUD warning naming the reason + "cost tracking will NOT aggregate"; the honest `(team '…')` success clause prints ONLY when the key is genuinely bound — replacing the old green line that printed the config *name* (always truthy) and falsely claimed a binding. Same fix on the hindsight-service callsite.

## F1 (MEDIUM) — existing fleet keys never re-bound
The steady-state re-apply path skipped any key that passed `GET /key/info`, blind to `team_id` — so keys provisioned before the fix (or via the degraded path) stayed UNBOUND forever. `validateKey` now also reports the key's current `team_id` (`info.team_id`); a valid-but-unbound (or wrong-team) key is re-bound IN PLACE via a bind-only `POST /key/update {key, team_id}` — no delete/regenerate, no vault churn. Contract verified against **LiteLLM v1.91.0** source (`update_key_fn` / `UpdateKeyRequest` inherits `team_id` via `KeyRequestBase`→`GenerateRequestBase`; the `is_different_team` guard rebinds null→team and team→team). Best-effort + LOUD: an unresolvable team stays warned every apply; a failed `/key/update` names the manual remediation; keys are never auto-deleted.

## LOW — duplicate `team_alias` resolved nondeterministically
LiteLLM does not enforce unique `team_alias`; resolution now picks the lexicographically smallest `team_id` (stable across applies) and warns naming every duplicate, instead of the first array-order match.

## Upgrade behavior (CHANGELOG)
First `switchroom apply` after upgrade re-binds each agent's existing key to the team; per-team cost tracking begins aggregating. Warnings name the manual `/key/update` remediation for the rare case the proxy rejects the automatic re-bind.

## Tests (assert outcomes, not paths)
- `provision.test.ts`: ensureTeam bound/unbound+reason shapes; deterministic duplicate-alias pick + warning; validateKey surfaces `info.team_id`; bindKeyToTeam POSTs `{key,team_id}` and never throws.
- `apply-litellm-provision.test.ts`: F3 unbound → key provisioned + warning + NO false `(team)` claim; F3 bound → honest green + team_id to ensureKey; F1 unbound → `/key/update` re-bind; F1 bound → no update; F1 update-fail + team-unresolvable → loud, apply not failed.

Proof-of-bite (git-show revert of the pre-fix source, no stash): 5 apply F1/F3 tests + 2 provision tests fail against pre-fix; all 49 vitest + 4 bun e2e green after restore. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)