### PR TITLE
scaffold: correct bot-token resolution + placeholder refresh

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -811,9 +811,38 @@ export function alignAgentUid(
 }
 
 /**
- * Resolve a bot token value. If it's a vault reference, try to resolve it
- * via SWITCHROOM_VAULT_PASSPHRASE or fall back to TELEGRAM_BOT_TOKEN env var.
- * Returns the resolved token or undefined if unresolvable.
+ * Placeholder written to `telegram/.env` when this agent's bot token cannot
+ * be resolved at scaffold time (e.g. an as-yet-ungranted `vault:` reference).
+ * Deliberately carries NO active `TELEGRAM_BOT_TOKEN=` assignment — only the
+ * commented hint — so `isTelegramEnvPlaceholder` can tell it apart from a real
+ * operator-set token and `refreshTelegramBotTokenEnv` may safely overwrite it
+ * once a later reconcile resolves the vault grant.
+ */
+const TELEGRAM_ENV_PLACEHOLDER = `# Set your bot token: TELEGRAM_BOT_TOKEN=your-token-here\n`;
+
+/**
+ * True when a `telegram/.env` body still holds only the placeholder — i.e. it
+ * has no active (uncommented, non-empty) `TELEGRAM_BOT_TOKEN=` line. A real
+ * operator- or vault-set token has such a line and must never be clobbered.
+ */
+function isTelegramEnvPlaceholder(content: string): boolean {
+  return !/^\s*TELEGRAM_BOT_TOKEN=\S/m.test(content);
+}
+
+/**
+ * Resolve a bot token value. If it's a vault reference, resolve it ONLY via
+ * the vault (SWITCHROOM_VAULT_PASSPHRASE). Returns the resolved token, or
+ * undefined if it cannot be resolved for THIS agent.
+ *
+ * IMPORTANT — no ambient env fallback for vault references (M2, review
+ * 2026-07-11): a `vault:` bot-token that can't be resolved must NOT fall back
+ * to `$TELEGRAM_BOT_TOKEN`. On a multi-agent `apply` that ambient value is
+ * whatever the outer process exported — commonly a DIFFERENT agent's token —
+ * so falling back silently wrote agent B's bot token into agent A's
+ * `telegram/.env`. When resolution fails we return undefined; callers write
+ * the placeholder (see TELEGRAM_ENV_PLACEHOLDER) and a later reconcile picks
+ * up the real token once the vault grant lands. The vault is the sole source
+ * of truth for a vault-referenced token — never a cross-agent env var.
  */
 function resolveBotToken(rawToken: string): string | undefined {
   if (!isVaultReference(rawToken)) {
@@ -835,19 +864,45 @@ function resolveBotToken(rawToken: string): string | undefined {
       }
     } catch (err) {
       // Known "vault missing / wrong passphrase" outcomes are expected when
-      // callers haven't set one up — fall through to env-var fallback. Any
-      // other error is a real problem and should bubble up so the user sees
-      // it instead of silently using a stale token from the environment.
+      // callers haven't set one up — treat the token as unresolvable and let
+      // the caller write the placeholder. Any other error is a real problem
+      // and should bubble up so the user sees it.
       if (!(err instanceof VaultError)) throw err;
     }
   }
 
-  // Fall back to TELEGRAM_BOT_TOKEN env var
-  if (process.env.TELEGRAM_BOT_TOKEN) {
-    return process.env.TELEGRAM_BOT_TOKEN;
-  }
-
+  // Unresolvable for THIS agent. Return undefined — do NOT fall back to
+  // $TELEGRAM_BOT_TOKEN (may belong to another agent on a multi-agent apply).
   return undefined;
+}
+
+/**
+ * Refresh an agent's `telegram/.env` when it still holds the placeholder and a
+ * real bot token is now resolvable (M3, review 2026-07-11). Runs on the
+ * reconcile/apply path so a `vault:` bot-token that was ungranted at first
+ * scaffold — and therefore wrote the placeholder — is picked up once the grant
+ * lands, without a rescaffold. Deterministic and safe:
+ *
+ *   - No-op when the token still can't be resolved (a later grant re-triggers).
+ *   - No-op when the `.env` is absent (scaffold owns first creation).
+ *   - Overwrites ONLY when the current body is still the placeholder
+ *     (`isTelegramEnvPlaceholder`) — a real operator-set token is never
+ *     clobbered.
+ */
+function refreshTelegramBotTokenEnv(
+  agentDir: string,
+  resolvedBotToken: string | undefined,
+  changes: string[],
+): void {
+  if (!resolvedBotToken) return;
+  const envPath = join(agentDir, "telegram", ".env");
+  if (!existsSync(envPath)) return;
+  const current = readFileSync(envPath, "utf-8");
+  if (!isTelegramEnvPlaceholder(current)) return;
+  const next = `TELEGRAM_BOT_TOKEN=${resolvedBotToken}\n`;
+  if (next === current) return;
+  writeFileSync(envPath, next, { encoding: "utf-8", mode: 0o600 });
+  changes.push(envPath);
 }
 
 /**
@@ -4486,7 +4541,7 @@ export function scaffoldAgent(
       if (resolvedBotToken) {
         return `TELEGRAM_BOT_TOKEN=${resolvedBotToken}\n`;
       }
-      return `# Set your bot token: TELEGRAM_BOT_TOKEN=your-token-here\n`;
+      return TELEGRAM_ENV_PLACEHOLDER;
     },
     created,
     skipped,
@@ -6512,6 +6567,18 @@ export function reconcileAgent(
       }
     }
   }
+
+  // --- Refresh telegram/.env bot token once a vault grant lands (M3) ---
+  //
+  // scaffold's `.env` write is writeIfMissing, so a token that was an
+  // unresolvable `vault:` reference at first scaffold froze the placeholder
+  // forever — a later `vault set` + `apply` never picked it up. Re-resolve
+  // here and overwrite ONLY when the file is still the placeholder, so a real
+  // operator-set token is never clobbered. resolvedBotToken is keyed strictly
+  // by THIS agent's config (agentConfig.bot_token ?? telegramConfig.bot_token),
+  // so the interrupt window (vault has <new>.bot_token while agents.<old> lingers
+  // in config) can't mis-attribute another agent's token here.
+  refreshTelegramBotTokenEnv(agentDir, resolvedBotToken, changes);
 
   // --- Reconcile global skills pool symlinks ---
   //

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -824,9 +824,12 @@ const TELEGRAM_ENV_PLACEHOLDER = `# Set your bot token: TELEGRAM_BOT_TOKEN=your-
  * True when a `telegram/.env` body still holds only the placeholder — i.e. it
  * has no active (uncommented, non-empty) `TELEGRAM_BOT_TOKEN=` line. A real
  * operator- or vault-set token has such a line and must never be clobbered.
+ * The optional `export ` prefix is tolerated so a hand-edited
+ * `export TELEGRAM_BOT_TOKEN=<real>` is never mistaken for the placeholder
+ * and overwritten.
  */
 function isTelegramEnvPlaceholder(content: string): boolean {
-  return !/^\s*TELEGRAM_BOT_TOKEN=\S/m.test(content);
+  return !/^\s*(?:export\s+)?TELEGRAM_BOT_TOKEN=\S/m.test(content);
 }
 
 /**

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1241,6 +1241,51 @@ describe("scaffoldAgent", () => {
     }
   });
 
+  it("never clobbers an `export TELEGRAM_BOT_TOKEN=` hand-edit on reconcile (M3)", () => {
+    const vaultTelegramConfig: TelegramConfig = {
+      bot_token: "vault:telegram-bot-token",
+      forum_chat_id: "-1001234567890",
+    };
+    const config = makeAgentConfig();
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: vaultTelegramConfig,
+      agents: { "m3-export-agent": config },
+    } as SwitchroomConfig;
+
+    const origPassphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    const origVaultPath = process.env.SWITCHROOM_VAULT_PATH;
+    const origToken = process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    delete process.env.SWITCHROOM_VAULT_PATH;
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    try {
+      const result = scaffoldAgent("m3-export-agent", config, tmpDir, vaultTelegramConfig, switchroomConfig);
+      const envPath = join(result.agentDir, "telegram", ".env");
+      // Operator hand-edits with shell `export` syntax.
+      const operatorLine = "export TELEGRAM_BOT_TOKEN=111222:OPERATOR-EXPORT\n";
+      writeFileSync(envPath, operatorLine, { mode: 0o600 });
+
+      const vaultPath = join(tmpDir, "vault.enc");
+      const passphrase = "test-passphrase";
+      createVault(passphrase, vaultPath);
+      setStringSecret(passphrase, vaultPath, "telegram-bot-token", "999999:VAULT-DIFFERENT");
+      process.env.SWITCHROOM_VAULT_PATH = vaultPath;
+      process.env.SWITCHROOM_VAULT_PASSPHRASE = passphrase;
+
+      reconcileAgent("m3-export-agent", config, tmpDir, vaultTelegramConfig, switchroomConfig);
+      // The `export`-prefixed real token is a real token, not the placeholder.
+      expect(readFileSync(envPath, "utf-8")).toBe(operatorLine);
+    } finally {
+      if (origPassphrase !== undefined) process.env.SWITCHROOM_VAULT_PASSPHRASE = origPassphrase;
+      else delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+      if (origVaultPath !== undefined) process.env.SWITCHROOM_VAULT_PATH = origVaultPath;
+      else delete process.env.SWITCHROOM_VAULT_PATH;
+      if (origToken !== undefined) process.env.TELEGRAM_BOT_TOKEN = origToken;
+      else delete process.env.TELEGRAM_BOT_TOKEN;
+    }
+  });
+
   it("uses per-agent bot token when provided", () => {
     const config = makeAgentConfig({ bot_token: "999888:AGENT-SPECIFIC" });
     const result = scaffoldAgent("agent-token", config, tmpDir, telegramConfig);

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { scaffoldAgent, reconcileAgent, installHindsightPlugin, installSwitchroomSkills, renderFleetInvariants } from "../src/agents/scaffold.js";
+import { createVault, setStringSecret } from "../src/vault/vault.js";
 import { renderTemplate, renderProfileClaudeTemplate } from "../src/agents/profiles.js";
 import { cronScriptFilename, cronUnitName } from "../src/agents/cron-unit-name.js";
 import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
@@ -1105,6 +1106,138 @@ describe("scaffoldAgent", () => {
     } finally {
       if (origPassphrase !== undefined) process.env.SWITCHROOM_VAULT_PASSPHRASE = origPassphrase;
       if (origToken !== undefined) process.env.TELEGRAM_BOT_TOKEN = origToken;
+    }
+  });
+
+  // --- M2: unresolvable vault bot-token must NOT fall back to the ambient
+  //     $TELEGRAM_BOT_TOKEN, which on a multi-agent apply is another agent's
+  //     token. Prior behaviour wrote agent B's token into agent A's .env.
+  it("does NOT write ambient $TELEGRAM_BOT_TOKEN when a vault bot-token is unresolvable (M2)", () => {
+    const vaultTelegramConfig: TelegramConfig = {
+      bot_token: "vault:telegram-bot-token",
+      forum_chat_id: "-1001234567890",
+    };
+    const origPassphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    const origToken = process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    // Simulate a multi-agent apply where the outer process exported a
+    // DIFFERENT agent's bot token into the environment.
+    const otherAgentToken = "555000:OTHER-AGENT-TOKEN";
+    process.env.TELEGRAM_BOT_TOKEN = otherAgentToken;
+    try {
+      const config = makeAgentConfig();
+      const result = scaffoldAgent("m2-agent", config, tmpDir, vaultTelegramConfig);
+      const envContent = readFileSync(join(result.agentDir, "telegram", ".env"), "utf-8");
+
+      // Never the cross-agent ambient token…
+      expect(envContent).not.toContain(otherAgentToken);
+      // …and never any active token assignment at all — just the placeholder.
+      expect(envContent).not.toMatch(/^\s*TELEGRAM_BOT_TOKEN=\S/m);
+      expect(envContent).toContain("# Set your bot token");
+    } finally {
+      if (origPassphrase !== undefined) process.env.SWITCHROOM_VAULT_PASSPHRASE = origPassphrase;
+      else delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+      if (origToken !== undefined) process.env.TELEGRAM_BOT_TOKEN = origToken;
+      else delete process.env.TELEGRAM_BOT_TOKEN;
+    }
+  });
+
+  // --- M3: a placeholder .env is refreshed to the real token once the vault
+  //     grant lands on a later reconcile (writeIfMissing froze it before).
+  it("refreshes a placeholder .env to the real token once the vault ref resolves on reconcile (M3)", () => {
+    const vaultTelegramConfig: TelegramConfig = {
+      bot_token: "vault:telegram-bot-token",
+      forum_chat_id: "-1001234567890",
+    };
+    const config = makeAgentConfig();
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: vaultTelegramConfig,
+      agents: { "m3-agent": config },
+    } as SwitchroomConfig;
+
+    const origPassphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    const origVaultPath = process.env.SWITCHROOM_VAULT_PATH;
+    const origToken = process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    delete process.env.SWITCHROOM_VAULT_PATH;
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    try {
+      // First scaffold: vault ungranted → placeholder frozen on disk.
+      const result = scaffoldAgent("m3-agent", config, tmpDir, vaultTelegramConfig, switchroomConfig);
+      const envPath = join(result.agentDir, "telegram", ".env");
+      expect(readFileSync(envPath, "utf-8")).toContain("# Set your bot token");
+      expect(readFileSync(envPath, "utf-8")).not.toMatch(/^\s*TELEGRAM_BOT_TOKEN=\S/m);
+
+      // Grant lands: the operator sets the secret in the vault.
+      const vaultPath = join(tmpDir, "vault.enc");
+      const passphrase = "test-passphrase";
+      createVault(passphrase, vaultPath);
+      const realToken = "777333:VAULT-RESOLVED-TOKEN";
+      setStringSecret(passphrase, vaultPath, "telegram-bot-token", realToken);
+      process.env.SWITCHROOM_VAULT_PATH = vaultPath;
+      process.env.SWITCHROOM_VAULT_PASSPHRASE = passphrase;
+
+      // Later reconcile picks it up.
+      reconcileAgent("m3-agent", config, tmpDir, vaultTelegramConfig, switchroomConfig);
+      const refreshed = readFileSync(envPath, "utf-8");
+      expect(refreshed).toBe(`TELEGRAM_BOT_TOKEN=${realToken}\n`);
+    } finally {
+      if (origPassphrase !== undefined) process.env.SWITCHROOM_VAULT_PASSPHRASE = origPassphrase;
+      else delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+      if (origVaultPath !== undefined) process.env.SWITCHROOM_VAULT_PATH = origVaultPath;
+      else delete process.env.SWITCHROOM_VAULT_PATH;
+      if (origToken !== undefined) process.env.TELEGRAM_BOT_TOKEN = origToken;
+      else delete process.env.TELEGRAM_BOT_TOKEN;
+    }
+  });
+
+  // --- M3 safety: a real operator-set token must never be clobbered by the
+  //     reconcile refresh, even when the vault ref now resolves to something
+  //     else.
+  it("never clobbers a real operator-set .env token on reconcile (M3)", () => {
+    const vaultTelegramConfig: TelegramConfig = {
+      bot_token: "vault:telegram-bot-token",
+      forum_chat_id: "-1001234567890",
+    };
+    const config = makeAgentConfig();
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: vaultTelegramConfig,
+      agents: { "m3-safe-agent": config },
+    } as SwitchroomConfig;
+
+    const origPassphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    const origVaultPath = process.env.SWITCHROOM_VAULT_PATH;
+    const origToken = process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    delete process.env.SWITCHROOM_VAULT_PATH;
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    try {
+      const result = scaffoldAgent("m3-safe-agent", config, tmpDir, vaultTelegramConfig, switchroomConfig);
+      const envPath = join(result.agentDir, "telegram", ".env");
+      // Operator hand-sets a real token into the placeholder .env.
+      const operatorToken = "111222:OPERATOR-SET";
+      writeFileSync(envPath, `TELEGRAM_BOT_TOKEN=${operatorToken}\n`, { mode: 0o600 });
+
+      // Vault now resolves the ref to a DIFFERENT value.
+      const vaultPath = join(tmpDir, "vault.enc");
+      const passphrase = "test-passphrase";
+      createVault(passphrase, vaultPath);
+      setStringSecret(passphrase, vaultPath, "telegram-bot-token", "999999:VAULT-DIFFERENT");
+      process.env.SWITCHROOM_VAULT_PATH = vaultPath;
+      process.env.SWITCHROOM_VAULT_PASSPHRASE = passphrase;
+
+      reconcileAgent("m3-safe-agent", config, tmpDir, vaultTelegramConfig, switchroomConfig);
+      // Operator's token is preserved — reconcile did not overwrite it.
+      expect(readFileSync(envPath, "utf-8")).toBe(`TELEGRAM_BOT_TOKEN=${operatorToken}\n`);
+    } finally {
+      if (origPassphrase !== undefined) process.env.SWITCHROOM_VAULT_PASSPHRASE = origPassphrase;
+      else delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+      if (origVaultPath !== undefined) process.env.SWITCHROOM_VAULT_PATH = origVaultPath;
+      else delete process.env.SWITCHROOM_VAULT_PATH;
+      if (origToken !== undefined) process.env.TELEGRAM_BOT_TOKEN = origToken;
+      else delete process.env.TELEGRAM_BOT_TOKEN;
     }
   });
 


### PR DESCRIPTION
Fixes two bot-token findings from the 2026-07-11 review (single-concern PR).

## M2 (MEDIUM) — wrong bot-token fallback wrote ANOTHER agent's token
`resolveBotToken` fell back to the ambient `$TELEGRAM_BOT_TOKEN` when a `vault:` bot-token couldn't be resolved. On a multi-agent `apply` that env value is whatever the outer process exported — commonly a **different** agent's token — so agent A's `telegram/.env` got agent B's bot token.

**Fix:** cut the ambient-env fallback branch. The vault is the sole source of truth for a vault-referenced token; when it can't be resolved for THIS agent, `resolveBotToken` returns `undefined` and the caller writes the placeholder. No cross-agent env token is ever written.

## M3 (MEDIUM) — placeholder `.env` frozen after first scaffold
scaffold's `.env` write is `writeIfMissing`, so a token that was an unresolvable `vault:` reference at first scaffold froze the `# Set your bot token…` placeholder forever — a later vault grant + `apply`/reconcile never picked it up.

**Fix:** `refreshTelegramBotTokenEnv` runs on the reconcile/apply path, re-resolves the token, and overwrites `telegram/.env` **only** when the body is still the placeholder (deterministic `isTelegramEnvPlaceholder` check — no active `TELEGRAM_BOT_TOKEN=` assignment). A real operator-set token is never clobbered. Keyed strictly by THIS agent's config (`agentConfig.bot_token ?? telegramConfig.bot_token`), so the interrupt window (vault has `<new>.bot_token` while `agents.<old>` lingers in config) can't mis-attribute.

## Tests (outcome-asserting, `tests/scaffold.test.ts`)
- M2: unresolvable vault bot-token **with an ambient `$TELEGRAM_BOT_TOKEN` set to another agent's token** writes the placeholder, never the cross-agent token.
- M3: a placeholder `.env` is refreshed to the real token once the vault ref resolves on a later reconcile (uses a real temp vault).
- M3 safety: a real operator-set `.env` token is never clobbered on reconcile, even when the vault ref now resolves to a different value.

**Proof of bite** (`git show HEAD~1:...` revert): with the pre-fix source, the M2 test fails (writes the ambient token) and the M3 refresh test fails (placeholder stays frozen). Restored fix → all green.

## Verification
- `./node_modules/.bin/vitest run tests/scaffold.test.ts` → **206 passed** (incl. 3 new)
- `npx tsc --noEmit` → clean
- All `npm run lint` check scripts clean except `check-plugin-references` (known worktree env gap; CI authority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)