### PR TITLE
fix(setup): write operator choices to the canonical config, stop silent no-ops

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -45,6 +45,7 @@ import {
 import { getViaBrokerStructured } from "../vault/broker/client.js";
 import {
   ask,
+  askHidden,
   askYesNo,
   askChoice,
   waitForAction,
@@ -53,6 +54,7 @@ import {
 } from "../setup/prompt.js";
 import { captureEvent, captureException } from "../analytics/posthog.js";
 import { insertVaultBrokerApprovalAuth } from "./setup-posture-rewrite.js";
+import type { PostureRewriteResult } from "./setup-posture-rewrite.js";
 import {
   isValidSupergroupChatId,
   setAgentSupergroupChatId,
@@ -150,7 +152,7 @@ export function registerSetupCommand(program: Command): void {
         await stepAutoUnlock(config, switchroomConfigPath, nonInteractive);
 
         // ── Step 10: Dangerous mode ─────────────────────────────
-        await stepDangerousMode(config, nonInteractive);
+        await stepDangerousMode(config, switchroomConfigPath, nonInteractive);
 
         // ── Step 11: Agent onboarding guidance ───────────────────
         await stepOnboardingGuidance(config, nonInteractive);
@@ -612,7 +614,7 @@ async function storeTokenInVault(
     console.log(chalk.gray("  Creating encrypted vault..."));
     let passphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
     if (!passphrase) {
-      passphrase = await ask("  Vault passphrase (for encrypting secrets)");
+      passphrase = await askHidden("  Vault passphrase (for encrypting secrets)");
       if (!passphrase) throw new Error("Vault passphrase is required");
     }
     createVault(passphrase, vaultPath);
@@ -623,7 +625,7 @@ async function storeTokenInVault(
   } else {
     let passphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
     if (!passphrase) {
-      passphrase = await ask("  Vault passphrase");
+      passphrase = await askHidden("  Vault passphrase");
     }
     if (passphrase) {
       try {
@@ -1554,35 +1556,24 @@ async function stepAutoUnlock(
   const TELEGRAM_ID_CHOICE = "telegram-id — Approve tap mints immediately, no passphrase prompt (single-factor)";
   const choice = await askChoice("  Approval posture", [PASSPHRASE_CHOICE, TELEGRAM_ID_CHOICE]);
   if (choice === TELEGRAM_ID_CHOICE) {
-    try {
-      const yamlPath = existsSync(resolve(process.cwd(), "switchroom.yaml"))
-        ? resolve(process.cwd(), "switchroom.yaml")
-        : resolve(process.cwd(), "switchroom.yml");
-      if (existsSync(yamlPath)) {
-        const content = readFileSync(yamlPath, "utf-8");
-        // Use a YAML-aware rewrite scoped to vault.broker — the previous
-        // regex matched any top-level `broker:` and could land the
-        // posture key under the wrong block.
-        const result = insertVaultBrokerApprovalAuth(content, "telegram-id");
-        if (result.kind === "rewritten") {
-          writeFileSync(yamlPath, result.content, "utf-8");
-          console.log(
-            chalk.green(`  ${STEP_DONE} Set vault.broker.approvalAuth: telegram-id in ${yamlPath}`),
-          );
-        } else if (result.kind === "already-set") {
-          console.log(chalk.gray("  approvalAuth already set — leaving it alone."));
-        } else {
-          console.log(
-            chalk.yellow(
-              "  Could not locate vault.broker block — add `approvalAuth: telegram-id` under `vault.broker:` manually.",
-            ),
-          );
-        }
-      }
-    } catch (err) {
+    // Persist to the canonical config path that stepConfigFile resolved
+    // (~/.switchroom/switchroom.yaml, or an explicit --config) — the same
+    // file every other setup step writes. The previous code resolved the
+    // path from process.cwd(), so running setup from any directory other
+    // than the config dir silently dropped this single-factor posture
+    // choice with no error (2026-07-11 review, HIGH). Fail loud if the
+    // canonical config is missing or unwritable rather than no-op.
+    const kind = persistApprovalAuthTelegramId(switchroomConfigPath);
+    if (kind === "rewritten") {
+      console.log(
+        chalk.green(`  ${STEP_DONE} Set vault.broker.approvalAuth: telegram-id in ${switchroomConfigPath}`),
+      );
+    } else if (kind === "already-set") {
+      console.log(chalk.gray("  approvalAuth already set — leaving it alone."));
+    } else {
       console.log(
         chalk.yellow(
-          `  Could not write approvalAuth: ${err instanceof Error ? err.message : String(err)}`,
+          "  Could not locate vault.broker block — add `approvalAuth: telegram-id` under `vault.broker:` manually.",
         ),
       );
     }
@@ -1593,8 +1584,91 @@ async function stepAutoUnlock(
 
 // ─── Step 9: Dangerous Mode ─────────────────────────────────────────────────
 
+/**
+ * Insert `vault.broker.approvalAuth: telegram-id` into the canonical
+ * config at `configPath`, failing loud if that file is missing/unwritable.
+ *
+ * Extracted from stepAutoUnlock so the persistence (and its fail-loud
+ * contract) can be exercised in unit tests without the interactive vault
+ * flow. Returns the underlying rewrite kind so the caller can render the
+ * right message (`not-found` is a loud manual-edit hint, not a silent
+ * no-op). A missing config throws — the operator's posture choice must
+ * never be silently discarded (2026-07-11 review, HIGH).
+ */
+export function persistApprovalAuthTelegramId(
+  configPath: string,
+): PostureRewriteResult["kind"] {
+  if (!existsSync(configPath)) {
+    throw new ConfigError(
+      `Cannot persist vault.broker.approvalAuth: config not found at ${configPath}`,
+    );
+  }
+  const content = readFileSync(configPath, "utf-8");
+  // YAML-aware rewrite scoped to vault.broker — a plain regex could land
+  // the posture key under an unrelated top-level `broker:` block.
+  const result = insertVaultBrokerApprovalAuth(content, "telegram-id");
+  if (result.kind === "rewritten") {
+    writeFileSync(configPath, result.content, "utf-8");
+  }
+  return result.kind;
+}
+
+/**
+ * Write `dangerous_mode: true` into every agent block of the canonical
+ * config at `configPath` (and mirror it into the in-memory `config`).
+ *
+ * Extracted from stepDangerousMode for the same reason: the write must
+ * target the SAME canonical config the rest of setup resolves, not
+ * process.cwd(), and must fail loud rather than no-op when that file is
+ * missing (2026-07-11 review, HIGH). Throws if `configPath` doesn't exist.
+ */
+export function persistDangerousMode(
+  config: SwitchroomConfig,
+  configPath: string,
+): void {
+  if (!existsSync(configPath)) {
+    throw new ConfigError(
+      `Cannot persist dangerous_mode: config not found at ${configPath}`,
+    );
+  }
+  let content = readFileSync(configPath, "utf-8");
+  const agentNames = Object.keys(config.agents);
+
+  for (const name of agentNames) {
+    // Add dangerous_mode to each agent block. (Prior versions also added
+    // skip_permission_prompt: true here — dropped as of the dead-settings
+    // cleanup since it's now a no-op; autoaccept handles the boot prompt.)
+    const agentPattern = new RegExp(`(^  ${name}:\\s*\\n)`, "m");
+    if (agentPattern.test(content)) {
+      // Match this agent's block up to the next 2-space top-level key OR
+      // end of input. The end-of-input arm was `\Z`, which in JS regex is
+      // a literal `Z` (JS has no `\Z` anchor) — so the LAST agent's block
+      // never matched and its dangerous_mode was silently dropped from the
+      // file (2026-07-11 review, LOW). `(?![\s\S])` is a true end-of-string
+      // assertion that works under the `m` flag.
+      const blockPattern = new RegExp(
+        `^  ${name}:[\\s\\S]*?(?=^  [a-z]|(?![\\s\\S]))`,
+        "m",
+      );
+      const blockMatch = content.match(blockPattern);
+      if (blockMatch && !blockMatch[0].includes("dangerous_mode")) {
+        content = content.replace(
+          agentPattern,
+          `$1    dangerous_mode: true\n`,
+        );
+      }
+    }
+
+    // Also update the in-memory config
+    config.agents[name].dangerous_mode = true;
+  }
+
+  writeFileSync(configPath, content, "utf-8");
+}
+
 async function stepDangerousMode(
   config: SwitchroomConfig,
+  switchroomConfigPath: string,
   nonInteractive: boolean,
 ): Promise<void> {
   stepHeader(10, "Auto-approve mode", STEP_ACTIVE);
@@ -1613,41 +1687,13 @@ async function stepDangerousMode(
   }
 
   if (enableDangerous) {
-    const configPaths = [
-      resolve(process.cwd(), "switchroom.yaml"),
-      resolve(process.cwd(), "switchroom.yml"),
-    ];
-
-    for (const configPath of configPaths) {
-      if (existsSync(configPath)) {
-        let content = readFileSync(configPath, "utf-8");
-        const agentNames = Object.keys(config.agents);
-
-        for (const name of agentNames) {
-          // Add dangerous_mode to each agent block. (Prior versions also added
-          // skip_permission_prompt: true here — dropped as of the dead-settings
-          // cleanup since it's now a no-op; autoaccept handles the boot prompt.)
-          const agentPattern = new RegExp(`(^  ${name}:\\s*\\n)`, "m");
-          if (agentPattern.test(content)) {
-            const blockPattern = new RegExp(`^  ${name}:[\\s\\S]*?(?=^  [a-z]|\\Z)`, "m");
-            const blockMatch = content.match(blockPattern);
-            if (blockMatch && !blockMatch[0].includes("dangerous_mode")) {
-              content = content.replace(
-                agentPattern,
-                `$1    dangerous_mode: true\n`,
-              );
-            }
-          }
-
-          // Also update the in-memory config
-          config.agents[name].dangerous_mode = true;
-        }
-
-        writeFileSync(configPath, content, "utf-8");
-        console.log(chalk.green(`  ${STEP_DONE} Enabled dangerous_mode for all agents in ${configPath}`));
-        break;
-      }
-    }
+    // Persist to the canonical config stepConfigFile resolved, NOT
+    // process.cwd(). Running setup outside the config dir previously
+    // wrote this choice to a stray cwd file — or nowhere — with no error
+    // (2026-07-11 review, HIGH). persistDangerousMode fails loud if the
+    // canonical config is missing/unwritable.
+    persistDangerousMode(config, switchroomConfigPath);
+    console.log(chalk.green(`  ${STEP_DONE} Enabled dangerous_mode for all agents in ${switchroomConfigPath}`));
   } else {
     console.log(chalk.gray("  Skipped. Agents will prompt for tool approval."));
     console.log(chalk.green(`  ${STEP_DONE} Skipped`));

--- a/src/setup/prompt.ts
+++ b/src/setup/prompt.ts
@@ -38,6 +38,72 @@ export async function ask(
 }
 
 /**
+ * Prompt for a secret (e.g. a vault passphrase) WITHOUT echoing input
+ * to the terminal. Mirrors {@link ask}'s interactive/non-interactive
+ * contract: in non-interactive mode it returns `defaultValue` or throws.
+ *
+ * On a TTY it reads in raw mode so keystrokes are never rendered — the
+ * passphrase must never appear in the terminal or scrollback. This is
+ * the no-echo replacement for `ask()` on secret prompts (2026-07-11
+ * review, MEDIUM: `switchroom setup` echoed the vault passphrase in
+ * cleartext because it prompted via the echoing `ask()`).
+ *
+ * Ctrl-C rejects (aborts the prompt); backspace/delete edit the buffer.
+ */
+export async function askHidden(
+  question: string,
+  defaultValue?: string,
+): Promise<string> {
+  if (!isInteractive()) {
+    if (defaultValue !== undefined) return defaultValue;
+    throw new Error(`Non-interactive mode: no default for "${question}"`);
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    const stdin = process.stdin;
+    process.stdout.write(`${question}: `);
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
+
+    let input = "";
+    const cleanup = () => {
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdin.removeListener("data", onData);
+    };
+
+    const onData = (chunk: string) => {
+      // A single data event can carry several characters (fast typing or
+      // a paste that includes the terminating newline), so iterate.
+      for (const char of chunk) {
+        if (char === "\n" || char === "\r" || char === "\u0004") {
+          // Enter / EOF — accept. Emit the newline WE suppressed so the
+          // cursor moves on, but never the typed characters themselves.
+          cleanup();
+          process.stdout.write("\n");
+          resolve(input.trim() || defaultValue || "");
+          return;
+        } else if (char === "\u0003") {
+          // Ctrl-C — abort the prompt.
+          cleanup();
+          process.stdout.write("\n");
+          reject(new Error("Aborted"));
+          return;
+        } else if (char === "\u007f" || char === "\b") {
+          // Backspace / Delete.
+          if (input.length > 0) input = input.slice(0, -1);
+        } else {
+          input += char;
+        }
+      }
+    };
+
+    stdin.on("data", onData);
+  });
+}
+
+/**
  * Ask a yes/no question. Returns true for yes.
  * In non-interactive mode, returns the default.
  */

--- a/tests/prompt-hidden.test.ts
+++ b/tests/prompt-hidden.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+import { askHidden } from "../src/setup/prompt.js";
+
+// A fake stdin standing in for a TTY. askHidden reads via raw-mode data
+// events (never readline), so we drive it by emitting "data".
+function makeFakeStdin(isTTY: boolean) {
+  const s = new EventEmitter() as EventEmitter & {
+    isTTY: boolean;
+    setRawMode: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    pause: ReturnType<typeof vi.fn>;
+    setEncoding: ReturnType<typeof vi.fn>;
+  };
+  s.isTTY = isTTY;
+  s.setRawMode = vi.fn();
+  s.resume = vi.fn();
+  s.pause = vi.fn();
+  s.setEncoding = vi.fn();
+  return s;
+}
+
+const origStdin = process.stdin;
+const origWrite = process.stdout.write;
+
+function installStdin(fake: EventEmitter & { isTTY: boolean }) {
+  Object.defineProperty(process, "stdin", { value: fake, configurable: true });
+}
+
+afterEach(() => {
+  Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
+  process.stdout.write = origWrite;
+  vi.restoreAllMocks();
+});
+
+describe("askHidden", () => {
+  it("reads a secret in raw mode WITHOUT echoing it to the terminal", async () => {
+    const fake = makeFakeStdin(true);
+    installStdin(fake);
+
+    const writes: string[] = [];
+    process.stdout.write = ((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    const pending = askHidden("  Vault passphrase");
+    // Let askHidden register its data listener before we feed input.
+    await Promise.resolve();
+
+    // Typed across multiple data events, including a paste-style chunk
+    // that carries the terminating newline.
+    fake.emit("data", "hun");
+    fake.emit("data", "ter2\n");
+
+    const result = await pending;
+    expect(result).toBe("hunter2");
+
+    // Raw mode was engaged (no-echo) and then released.
+    expect(fake.setRawMode).toHaveBeenCalledWith(true);
+    expect(fake.setRawMode).toHaveBeenCalledWith(false);
+
+    // The secret must NEVER appear in anything written to stdout — only
+    // the prompt label and the suppressed newline are echoed.
+    const echoed = writes.join("");
+    expect(echoed).not.toContain("hunter2");
+    expect(echoed).not.toContain("hunter");
+    expect(echoed).toContain("Vault passphrase");
+  });
+
+  it("handles backspace without echoing", async () => {
+    const fake = makeFakeStdin(true);
+    installStdin(fake);
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+
+    const pending = askHidden("  Passphrase");
+    await Promise.resolve();
+    fake.emit("data", "abc");
+    fake.emit("data", "\u007f"); // delete -> drops 'c'
+    fake.emit("data", "\n");
+    expect(await pending).toBe("ab");
+  });
+
+  it("returns the default in non-interactive mode (mirrors ask)", async () => {
+    const fake = makeFakeStdin(false);
+    installStdin(fake);
+    expect(await askHidden("x", "fallback")).toBe("fallback");
+  });
+
+  it("throws in non-interactive mode with no default (mirrors ask)", async () => {
+    const fake = makeFakeStdin(false);
+    installStdin(fake);
+    await expect(askHidden("x")).rejects.toThrow(/Non-interactive/);
+  });
+});

--- a/tests/setup-persist-choices.test.ts
+++ b/tests/setup-persist-choices.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Importing setup.ts transitively loads vault-broker.js → broker/server.ts
+// → grants-db.ts → bun:sqlite, which vitest can't resolve. Mock the same
+// modules the existing setup.test.ts mocks so the import graph is safe.
+vi.mock("../src/vault/vault.js", () => ({
+  openVault: vi.fn(),
+  createVault: vi.fn(),
+  setStringSecret: vi.fn(),
+  getStringSecret: vi.fn(),
+}));
+vi.mock("../src/vault/grants-db.ts", () => ({}));
+vi.mock("../src/vault/broker/server.js", () => ({
+  VaultBroker: vi.fn(),
+  registerShutdownHandlers: vi.fn(),
+}));
+
+import {
+  persistDangerousMode,
+  persistApprovalAuthTelegramId,
+} from "../src/cli/setup.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+// A canonical config with agents nested under `agents:`. `omega` is LAST
+// so it exercises the end-of-block boundary that the `\Z` bug broke.
+const CANONICAL_YAML = `switchroom:
+  version: 1
+
+vault:
+  path: ~/.switchroom/vault/vault.enc
+  broker:
+    socket: ~/.switchroom/vault/broker.sock
+
+agents:
+  alpha:
+    model: claude-sonnet-5
+  omega:
+    model: claude-sonnet-5
+`;
+
+describe("persistDangerousMode", () => {
+  let dir: string;
+  let canonicalPath: string;
+  let cwdDir: string;
+  let decoyPath: string;
+  const origCwd = process.cwd();
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-canonical-"));
+    canonicalPath = join(dir, "switchroom.yaml");
+    writeFileSync(canonicalPath, CANONICAL_YAML, "utf-8");
+
+    // A DIFFERENT directory that we chdir into — with a decoy config the
+    // buggy cwd-resolving code would have written to instead.
+    cwdDir = mkdtempSync(join(tmpdir(), "sr-cwd-"));
+    decoyPath = join(cwdDir, "switchroom.yaml");
+    writeFileSync(decoyPath, CANONICAL_YAML, "utf-8");
+    process.chdir(cwdDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(cwdDir, { recursive: true, force: true });
+  });
+
+  it("writes dangerous_mode to the canonical config, not cwd", () => {
+    const config = {
+      agents: { alpha: {}, omega: {} },
+    } as unknown as SwitchroomConfig;
+
+    persistDangerousMode(config, canonicalPath);
+
+    const canonical = readFileSync(canonicalPath, "utf-8");
+    // BOTH agents get it — including `omega`, the last block, which the
+    // literal-`\Z` regex previously failed to match (silent drop).
+    expect(canonical).toMatch(/alpha:\n    dangerous_mode: true/);
+    expect(canonical).toMatch(/omega:\n    dangerous_mode: true/);
+
+    // The decoy in cwd is untouched — the choice landed canonically.
+    const decoy = readFileSync(decoyPath, "utf-8");
+    expect(decoy).not.toContain("dangerous_mode");
+
+    // In-memory config mirrors the write.
+    expect(config.agents.alpha.dangerous_mode).toBe(true);
+    expect(config.agents.omega.dangerous_mode).toBe(true);
+  });
+
+  it("is idempotent — does not double-insert on a second run", () => {
+    const config = { agents: { alpha: {}, omega: {} } } as unknown as SwitchroomConfig;
+    persistDangerousMode(config, canonicalPath);
+    persistDangerousMode(config, canonicalPath);
+    const canonical = readFileSync(canonicalPath, "utf-8");
+    expect(canonical.match(/dangerous_mode: true/g)?.length).toBe(2);
+  });
+
+  it("fails loud when the canonical config does not exist", () => {
+    const config = { agents: { alpha: {} } } as unknown as SwitchroomConfig;
+    expect(() =>
+      persistDangerousMode(config, join(dir, "does-not-exist.yaml")),
+    ).toThrow(/config not found/);
+  });
+});
+
+describe("persistApprovalAuthTelegramId", () => {
+  let dir: string;
+  let canonicalPath: string;
+  let cwdDir: string;
+  let decoyPath: string;
+  const origCwd = process.cwd();
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-canonical-"));
+    canonicalPath = join(dir, "switchroom.yaml");
+    writeFileSync(canonicalPath, CANONICAL_YAML, "utf-8");
+
+    cwdDir = mkdtempSync(join(tmpdir(), "sr-cwd-"));
+    decoyPath = join(cwdDir, "switchroom.yaml");
+    writeFileSync(decoyPath, CANONICAL_YAML, "utf-8");
+    process.chdir(cwdDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(cwdDir, { recursive: true, force: true });
+  });
+
+  it("writes approvalAuth to the canonical config, not cwd", () => {
+    const kind = persistApprovalAuthTelegramId(canonicalPath);
+    expect(kind).toBe("rewritten");
+
+    const canonical = readFileSync(canonicalPath, "utf-8");
+    expect(canonical).toContain("approvalAuth: telegram-id");
+
+    const decoy = readFileSync(decoyPath, "utf-8");
+    expect(decoy).not.toContain("approvalAuth");
+  });
+
+  it("returns already-set on a second run without duplicating", () => {
+    expect(persistApprovalAuthTelegramId(canonicalPath)).toBe("rewritten");
+    expect(persistApprovalAuthTelegramId(canonicalPath)).toBe("already-set");
+    const canonical = readFileSync(canonicalPath, "utf-8");
+    expect(canonical.match(/approvalAuth/g)?.length).toBe(1);
+  });
+
+  it("returns not-found when there is no vault.broker block", () => {
+    const noBroker = join(dir, "no-broker.yaml");
+    writeFileSync(noBroker, "switchroom:\n  version: 1\nagents:\n  a:\n    model: x\n", "utf-8");
+    expect(persistApprovalAuthTelegramId(noBroker)).toBe("not-found");
+  });
+
+  it("fails loud when the canonical config does not exist", () => {
+    expect(() =>
+      persistApprovalAuthTelegramId(join(dir, "does-not-exist.yaml")),
+    ).toThrow(/config not found/);
+  });
+});


### PR DESCRIPTION
Fixes four findings from the 2026-07-11 `src/cli/setup.ts` review. Single concern: setup must persist the operator's choices to the **canonical** config (`~/.switchroom/switchroom.yaml` / `--config`) that every other step resolves, and fail loud instead of silently no-op'ing.

## Findings fixed

**HIGH — `stepDangerousMode` wrote the auto-approve choice to the WRONG file and silently no-op'd.** It resolved the yaml path from `process.cwd()` and only searched there. Run setup from any other directory and the `dangerous_mode` choice was written to a stray cwd file — or nowhere — with no error. Now persisted via the extracted `persistDangerousMode(config, switchroomConfigPath)` to the same canonical path `stepConfigFile` resolved, threaded through from the call site.

**HIGH — the `approvalAuth: telegram-id` posture rewrite had the identical cwd bug.** `yamlPath` came from `process.cwd()`; the single-factor-auth posture choice was silently dropped when cwd wasn't the config dir, and its `try/catch` swallowed write failures into a yellow warning. Now persisted via `persistApprovalAuthTelegramId(switchroomConfigPath)`; a missing/unwritable canonical config throws `ConfigError` → the setup command exits non-zero.

**LOW — `\Z` in the dangerous_mode block regex was a literal `Z`.** JS regex has no `\Z` anchor, so the lookahead `(?=^  [a-z]|\Z)` never terminated on the LAST agent's block → that agent's `dangerous_mode` was dropped from the file. Replaced with `(?![\s\S])`, a true end-of-string assertion under the `m` flag.

**MEDIUM — vault master passphrase echoed to the terminal in cleartext.** Both passphrase prompts called the echoing `ask()`. Added `askHidden()` to `src/setup/prompt.ts` (raw-mode, no-echo, mirrors `ask()`'s interactive/non-interactive contract) and routed both prompts through it.

## Tests (outcomes, not code paths)

- `tests/setup-persist-choices.test.ts` (7) — drives the persistence with **cwd != config dir** and asserts the canonical file changed while a decoy cwd file did NOT; last-agent (`omega`) gets `dangerous_mode` (regex bite); idempotency; `not-found` / `already-set`; unresolvable target throws.
- `tests/prompt-hidden.test.ts` (4) — `askHidden` engages raw mode and the typed secret never appears in anything written to stdout; backspace; non-interactive default/throw.

## Proof of bite (git-checkout reverts against the committed fix)

- Regex `(?![\s\S])` → `\Z`: `omega` + idempotency assertions fail.
- `persistDangerousMode` guard removed: fail-loud test fails.
- `persistApprovalAuthTelegramId` guard removed: fail-loud test fails.
- `askHidden` re-echoes the char: no-echo test fails.

`npx tsc --noEmit` clean; full `npm run lint` green (incl. check-plugin-references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)