### PR TITLE
fix(config): atomic writes for switchroom.yaml and scaffold state

### DIFF
--- a/src/agents/reconcile-default-mcps.test.ts
+++ b/src/agents/reconcile-default-mcps.test.ts
@@ -10,15 +10,30 @@
  *   (f) reconcileAllAgentDefaultMcps iterates over agent directories correctly
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { BuiltinMcpEntry } from "../memory/scaffold-integration.js";
+
+// Mock node:fs so the M5 atomicity block can force renameSync(2) to fail
+// (simulating a crash between the tmp write and the atomic swap) while every
+// other fs call keeps its real implementation. atomicWriteFileSync (which
+// reconcile-default-mcps.ts now routes through) imports renameSync from
+// node:fs, so this mock reaches it. Mirrors src/util/atomic.test.ts.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    renameSync: vi.fn().mockImplementation(actual.renameSync),
+  };
+});
+
 import {
   reconcileAgentDefaultMcps,
   reconcileAllAgentDefaultMcps,
 } from "./reconcile-default-mcps.js";
-import type { BuiltinMcpEntry } from "../memory/scaffold-integration.js";
 
 // Minimal fixture defaults — tests don't need real npx commands
 const FIXTURE_DEFAULTS: BuiltinMcpEntry[] = [
@@ -257,5 +272,78 @@ describe("reconcileAllAgentDefaultMcps", () => {
     const results = reconcileAllAgentDefaultMcps(agentsDir, {}, FIXTURE_DEFAULTS);
     expect(results).toHaveLength(1);
     expect(results[0]!.name).toBe("realagent");
+  });
+});
+
+describe("reconcileAgentDefaultMcps — atomic write (M5 crash-safety)", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "sr-reconcile-atomic-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  // BITE: a crash / ENOSPC after the tmp write but before the atomic swap
+  // must leave the ORIGINAL settings.json fully intact — never a torn or
+  // truncated file (which the JSON.parse read at reconcile-default-mcps.ts:~76
+  // would then fail on, silently wiping the agent's MCP servers). Pre-fix this
+  // used a bare writeFileSync (truncate-in-place, no rename), so it never
+  // touched renameSync: the mocked failure never fired, the write "succeeded",
+  // and both assertions below fail.
+  it("leaves the original settings.json intact when rename(2) fails mid-write", () => {
+    const agentDir = makeAgentDir(tmpRoot, "atomic", {
+      mcpServers: { switchroom: { command: "bun", args: ["run", "server.ts"] } },
+    });
+    const settingsPath = join(agentDir, ".claude", "settings.json");
+    const originalRaw = readFileSync(settingsPath, "utf-8");
+
+    // Simulate a hard failure (EIO — NOT one of the bind-mount fallback codes)
+    // at the atomic swap. atomicWriteFileSync must clean its tmp and rethrow,
+    // leaving the destination untouched.
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EIO: i/o error"), { code: "EIO" });
+    });
+
+    expect(() =>
+      reconcileAgentDefaultMcps(agentDir, {}, FIXTURE_DEFAULTS),
+    ).toThrow(/EIO/);
+
+    // The original file is byte-for-byte unchanged — the write was atomic.
+    expect(readFileSync(settingsPath, "utf-8")).toBe(originalRaw);
+    // No orphaned tempfile left in the .claude dir.
+    const claudeDir = join(agentDir, ".claude");
+    expect(fs.readdirSync(claudeDir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  it("round-trips: on success the new entry is present and valid JSON", () => {
+    const agentDir = makeAgentDir(tmpRoot, "roundtrip", {
+      mcpServers: { switchroom: {} },
+    });
+    const settingsPath = join(agentDir, ".claude", "settings.json");
+
+    const result = reconcileAgentDefaultMcps(agentDir, {}, FIXTURE_DEFAULTS);
+    expect(result.changed).toBe(true);
+
+    // renameSync (real impl) was used — the atomic path, not a truncate.
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalled();
+    const parsed = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+    const servers = parsed.mcpServers as Record<string, unknown>;
+    expect(servers["playwright"]).toEqual(FIXTURE_DEFAULTS[0]!.value);
+    // Trailing newline + pretty format preserved (no format change).
+    expect(readFileSync(settingsPath, "utf-8").endsWith("\n")).toBe(true);
+  });
+
+  it("preserves the settings.json mode across the atomic swap", () => {
+    const agentDir = makeAgentDir(tmpRoot, "modekeep", { mcpServers: {} });
+    const settingsPath = join(agentDir, ".claude", "settings.json");
+    fs.chmodSync(settingsPath, 0o600);
+
+    reconcileAgentDefaultMcps(agentDir, {}, FIXTURE_DEFAULTS);
+
+    expect(fs.statSync(settingsPath).mode & 0o777).toBe(0o600);
   });
 });

--- a/src/agents/reconcile-default-mcps.ts
+++ b/src/agents/reconcile-default-mcps.ts
@@ -10,9 +10,10 @@
  * and add only what's absent. Idempotent — running twice produces no changes.
  */
 
-import { existsSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { getBuiltinDefaultMcpEntries, type BuiltinMcpEntry } from "../memory/scaffold-integration.js";
+import { atomicWriteFileSync } from "../util/atomic.js";
 
 /**
  * Result for a single agent processed by reconcileDefaultMcps.
@@ -100,7 +101,20 @@ export function reconcileAgentDefaultMcps(
 
   if (result.added.length > 0) {
     settings.mcpServers = mcpServers;
-    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+    // Atomic tmp+fsync+rename so a crash/ENOSPC mid-write can never leave a
+    // torn or truncated settings.json (which the read at line ~76 would then
+    // fail to JSON.parse, silently disabling the agent's MCP servers). Preserve
+    // the existing file's inode mode across the swap — the plain writeFileSync
+    // this replaced kept the mode of the already-existing file, whereas
+    // atomicWriteFileSync creates a fresh tmp inode, so we carry the mode over
+    // explicitly (default 0o600 to match the scaffold's settings.json mode).
+    let mode = 0o600;
+    try {
+      mode = statSync(settingsPath).mode & 0o777;
+    } catch {
+      /* fall back to 0o600 */
+    }
+    atomicWriteFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", mode);
     result.changed = true;
   }
 

--- a/src/agents/rename-orchestrator-atomic.test.ts
+++ b/src/agents/rename-orchestrator-atomic.test.ts
@@ -1,0 +1,100 @@
+/**
+ * F1 atomicity test for renameAgentInConfig (src/agents/rename-orchestrator.ts).
+ *
+ * `switchroom agent rename <old> <new>` rewrites the operator's canonical
+ * switchroom.yaml to move an agent block under its new slug. The prior
+ * implementation wrote it with a bare in-place `writeFileSync` — a crash /
+ * ENOSPC between truncate and write left the operator's fleet config torn
+ * or empty. renameAgentInConfig now routes through writeConfigFileSync
+ * (tmp + fsync + rename, bind-mount-aware); a failed rename leaves the
+ * PRIOR file byte-for-byte intact and no tempfile behind.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Mock node:fs so we can force renameSync(2) to fail while every other fs
+// call stays real. writeConfigFileSync → atomicWriteFileSync imports
+// renameSync from node:fs, so the mock reaches it. Mirrors
+// src/agents/scaffold-write-atomic.test.ts.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    renameSync: vi.fn().mockImplementation(actual.renameSync),
+  };
+});
+
+import { renameAgentInConfig } from "./rename-orchestrator.js";
+
+// Full block mapping (not flow) so renameAgentInConfig's YAML round-trip
+// preserves fields verbatim and the assertions read cleanly.
+const FIXTURE = `agents:
+  oldbot:
+    bot_token: vault:oldbot.bot_token
+    memory:
+      collection: oldbot
+    model: sonnet
+  keepbot:
+    bot_token: vault:keepbot.bot_token
+`;
+
+describe("renameAgentInConfig — atomic switchroom.yaml write (F1)", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-rename-atomic-"));
+    configPath = join(dir, "switchroom.yaml");
+    writeFileSync(configPath, FIXTURE, { mode: 0o644 });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("round-trips: renames the agent block atomically and preserves mode", () => {
+    renameAgentInConfig(configPath, "oldbot", "newbot");
+
+    const after = readFileSync(configPath, "utf-8");
+    // New slug present, old gone, sibling untouched.
+    expect(after).toContain("newbot:");
+    expect(after).not.toMatch(/^  oldbot:/m);
+    expect(after).toContain("keepbot:");
+    // Slug-prefixed vault ref + default memory.collection rewritten.
+    expect(after).toContain("vault:newbot.bot_token");
+    expect(after).toContain("collection: newbot");
+    // Went through the atomic swap.
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalled();
+    // Mode preserved, no tempfile leaked.
+    expect(statSync(configPath).mode & 0o777).toBe(0o644);
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  // BITE: a hard rename(2) failure (ENOSPC — NOT one of the
+  // EBUSY/EXDEV/EINVAL codes writeConfigFileSync falls back on) must leave
+  // the PRIOR switchroom.yaml byte-for-byte intact and throw. The pre-fix
+  // bare writeFileSync never called rename, so the mock never fired: it
+  // truncated + rewrote the file in place with no throw. Both the throw and
+  // the byte-intact assertion fail on the old code.
+  it("leaves the prior config byte-intact when rename(2) fails mid-write", () => {
+    const before = readFileSync(configPath, "utf-8");
+    const beforeMode = statSync(configPath).mode & 0o777;
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("ENOSPC: no space left on device"), { code: "ENOSPC" });
+    });
+
+    expect(() => renameAgentInConfig(configPath, "oldbot", "newbot")).toThrow(/ENOSPC/);
+
+    // Prior file untouched — not torn, not empty, not renamed.
+    expect(readFileSync(configPath, "utf-8")).toBe(before);
+    expect(statSync(configPath).mode & 0o777).toBe(beforeMode);
+    // Tempfile cleaned up.
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+});

--- a/src/agents/rename-orchestrator.ts
+++ b/src/agents/rename-orchestrator.ts
@@ -46,7 +46,8 @@ import { usesSwitchroomTelegramPlugin, resolveAgentConfig } from "../config/merg
 import { resolveTimezone } from "../config/timezone.js";
 import { isVaultReference, parseVaultReference } from "../vault/resolver.js";
 import YAML from "yaml";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
+import { writeConfigFileSync } from "../util/atomic.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -188,7 +189,17 @@ export function renameAgentInConfig(
   agents.delete(oldName);
   agents.set(newName, oldEntry);
 
-  writeFileSync(configPath, doc.toString(), "utf-8");
+  // Atomic (tmp + fsync + rename, bind-mount-aware) so a crash / ENOSPC
+  // mid-rename can never truncate the operator's switchroom.yaml — the
+  // prior in-place writeFileSync could leave a torn / empty config on a
+  // failed write (2026-07 review, F1). Preserve the file's existing mode.
+  let mode = 0o644;
+  try {
+    mode = statSync(configPath).mode & 0o777;
+  } catch {
+    /* default 0o644 */
+  }
+  writeConfigFileSync(configPath, doc.toString(), mode);
 }
 
 /**

--- a/src/agents/scaffold-reconcile-atomic.test.ts
+++ b/src/agents/scaffold-reconcile-atomic.test.ts
@@ -1,0 +1,100 @@
+/**
+ * F3 atomicity coverage for reconcileAgent's settings.json + .mcp.json
+ * writers (src/agents/scaffold.ts).
+ *
+ * reconcileAgent read-modify-writes each agent's `.claude/settings.json`
+ * and `.mcp.json` on every `switchroom agent reconcile`. Both were bare
+ * in-place `writeFileSync(..., { mode: 0o600 })` calls — the same torn-JSON
+ * risk M5 already fixed elsewhere: a crash / ENOSPC mid-write leaves a
+ * truncated file that Claude Code then fails to parse. Both sites now route
+ * through atomicWriteFileSync (tmp + fsync + rename), preserving mode 0600.
+ *
+ * reconcileAgent itself needs a fully-scaffolded agent directory (a heavy
+ * integration fixture with no precedent in this suite), so F3 is covered
+ * two ways:
+ *   1. A source-integrity guard that BITES if either reconcile writer is
+ *      reverted to a truncating writeFileSync (deterministic regression
+ *      fence, not prompt discipline).
+ *   2. A functional round-trip + crash-bite of the exact mechanism the two
+ *      sites invoke — atomicWriteFileSync(path, json, 0o600).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    renameSync: vi.fn().mockImplementation(actual.renameSync),
+  };
+});
+
+import { atomicWriteFileSync } from "../util/atomic.js";
+
+const SCAFFOLD_SRC = fileURLToPath(new URL("./scaffold.ts", import.meta.url));
+
+describe("reconcileAgent settings.json + .mcp.json — atomic writers (F3)", () => {
+  // GUARD: both reconcile write sites must go through atomicWriteFileSync
+  // with mode 0600, and neither may use a truncating writeFileSync on its
+  // path variable. Reverting either to writeFileSync fails this test.
+  it("routes both reconcile JSON writers through atomicWriteFileSync (source guard)", () => {
+    const src = readFileSync(SCAFFOLD_SRC, "utf-8");
+
+    // settings.json reconcile writer
+    expect(src).toContain("atomicWriteFileSync(settingsPath, after, 0o600)");
+    expect(src).not.toContain("writeFileSync(settingsPath, after");
+    // .mcp.json reconcile writer
+    expect(src).toContain("atomicWriteFileSync(mcpJsonPath, after, 0o600)");
+    expect(src).not.toContain("writeFileSync(mcpJsonPath, after");
+  });
+
+  describe("mechanism — atomicWriteFileSync at 0o600 (settings.json / .mcp.json)", () => {
+    let dir: string;
+    let p: string;
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), "sr-reconcile-atomic-"));
+      p = join(dir, "settings.json");
+    });
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+      vi.clearAllMocks();
+    });
+
+    it("round-trips JSON content and preserves mode 0600", () => {
+      const json = JSON.stringify({ mcpServers: {}, model: "sonnet" }, null, 2) + "\n";
+      atomicWriteFileSync(p, json, 0o600);
+
+      expect(readFileSync(p, "utf-8")).toBe(json);
+      expect(JSON.parse(readFileSync(p, "utf-8"))).toEqual({ mcpServers: {}, model: "sonnet" });
+      expect(vi.mocked(fs.renameSync)).toHaveBeenCalled();
+      expect(statSync(p).mode & 0o777).toBe(0o600);
+      expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+    });
+
+    // BITE: crash at the atomic swap leaves the PRIOR settings.json
+    // byte-intact — never torn — so the JSON.parse the reconcile flow does
+    // on the next run sees valid old content, not corruption.
+    it("leaves the prior JSON byte-intact when rename(2) fails mid-write", () => {
+      const original = JSON.stringify({ mcpServers: { old: {} } }, null, 2) + "\n";
+      writeFileSync(p, original, { mode: 0o600 });
+
+      vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+        throw Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" });
+      });
+
+      const next = JSON.stringify({ mcpServers: { new: {} } }, null, 2) + "\n";
+      expect(() => atomicWriteFileSync(p, next, 0o600)).toThrow(/EPERM/);
+
+      expect(readFileSync(p, "utf-8")).toBe(original);
+      expect(statSync(p).mode & 0o777).toBe(0o600);
+      expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+    });
+  });
+});

--- a/src/agents/scaffold-write-atomic.test.ts
+++ b/src/agents/scaffold-write-atomic.test.ts
@@ -1,0 +1,98 @@
+/**
+ * M1 atomicity test for writeIfMissing (src/agents/scaffold.ts).
+ *
+ * The 2026-07-11 durability review flagged that a scaffold interrupted mid-write
+ * (crash / ENOSPC / SIGKILL) left a torn settings.json — written non-atomically
+ * via a bare writeFileSync and then read back + JSON.parse'd a few dozen lines
+ * later, aborting the scaffold with a corrupt agent on disk. writeIfMissing now
+ * routes through atomicWriteFileSync (tmp + fsync + rename); a failed write
+ * leaves NO file at the destination rather than a partial one.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Mock node:fs so we can force renameSync(2) to fail while leaving every other
+// fs call real. atomicWriteFileSync imports renameSync from node:fs, so the
+// mock reaches it. Mirrors src/util/atomic.test.ts.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    renameSync: vi.fn().mockImplementation(actual.renameSync),
+  };
+});
+
+import { writeIfMissing } from "./scaffold.js";
+
+describe("writeIfMissing — atomic scaffold write (M1)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-scaffold-atomic-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("round-trips: writes the file and records it as created", () => {
+    const created: string[] = [];
+    const skipped: string[] = [];
+    const p = join(dir, ".claude", "settings.json");
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+
+    writeIfMissing(p, () => '{\n  "mcpServers": {}\n}\n', created, skipped, 0o600);
+
+    expect(readFileSync(p, "utf-8")).toBe('{\n  "mcpServers": {}\n}\n');
+    expect(created).toEqual([p]);
+    expect(skipped).toEqual([]);
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalled();
+    // Mode honoured, no tempfile leaked.
+    expect(fs.statSync(p).mode & 0o777).toBe(0o600);
+    expect(fs.readdirSync(join(dir, ".claude")).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  it("skips when the file already exists (unchanged)", () => {
+    const created: string[] = [];
+    const skipped: string[] = [];
+    const p = join(dir, "existing");
+    writeFileSync(p, "ORIGINAL");
+
+    writeIfMissing(p, () => "SHOULD-NOT-WRITE", created, skipped);
+
+    expect(readFileSync(p, "utf-8")).toBe("ORIGINAL");
+    expect(created).toEqual([]);
+    expect(skipped).toEqual([p]);
+  });
+
+  // BITE: a crash at the atomic swap must leave NO file at the destination —
+  // never a torn/partial one. Pre-fix writeIfMissing used a bare writeFileSync
+  // (no rename), so the mocked failure never fired: no throw, and the file was
+  // fully created. Both assertions below fail on the old code.
+  it("creates no file at the destination when rename(2) fails mid-write", () => {
+    const created: string[] = [];
+    const skipped: string[] = [];
+    const p = join(dir, ".claude", "settings.json");
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("ENOSPC: no space left on device"), { code: "ENOSPC" });
+    });
+
+    expect(() =>
+      writeIfMissing(p, () => '{\n  "mcpServers": {}\n}\n', created, skipped),
+    ).toThrow(/ENOSPC/);
+
+    // No torn file left behind — the JSON.parse read that follows in the real
+    // scaffold would therefore see "missing", not "corrupt".
+    expect(existsSync(p)).toBe(false);
+    expect(created).toEqual([]);
+    // Tempfile cleaned up.
+    expect(fs.readdirSync(join(dir, ".claude")).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+});

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -22,6 +22,7 @@ import { createHash } from "node:crypto";
 import chalk from "chalk";
 import type { AgentConfig, QuotaConfig, SwitchroomConfig, TelegramConfig } from "../config/schema.js";
 import { CRON_SCRIPT_BASENAME_RE, LEGACY_CRON_SCRIPT_BASENAME_RE } from "./cron-unit-name.js";
+import { atomicWriteFileSync } from "../util/atomic.js";
 
 // Repo root for referencing bin/ scripts in hooks
 const REPO_ROOT = resolve(import.meta.dirname, "../..");
@@ -6537,7 +6538,12 @@ export function reconcileAgent(
 
     const after = JSON.stringify(mergedSettings, null, 2) + "\n";
     if (after !== before) {
-      writeFileSync(settingsPath, after, { encoding: "utf-8", mode: 0o600 });
+      // Atomic (tmp + fsync + rename) so a crash / ENOSPC mid-write can
+      // never leave a torn / truncated settings.json that Claude Code
+      // then fails to parse — same guarantee as the M5 fix. Mode 0600
+      // preserved (settings.json is not secret-bearing but the prior
+      // write pinned it; keep it identical).
+      atomicWriteFileSync(settingsPath, after, 0o600);
       changes.push(settingsPath);
     }
   }
@@ -6747,7 +6753,11 @@ export function reconcileAgent(
       ? readFileSync(mcpJsonPath, "utf-8")
       : "";
     if (after !== before) {
-      writeFileSync(mcpJsonPath, after, { encoding: "utf-8", mode: 0o600 });
+      // Atomic (tmp + fsync + rename) so a crash / ENOSPC mid-write can
+      // never leave a torn / truncated .mcp.json that Claude Code then
+      // fails to parse — same guarantee as the M5 fix. Mode 0600
+      // preserved from the prior write.
+      atomicWriteFileSync(mcpJsonPath, after, 0o600);
       changes.push(mcpJsonPath);
     }
     // Cheap-cron Tier-1 (#2307): keep the cron .mcp.json (full set + cron-only
@@ -6993,8 +7003,10 @@ export function reconcileAgent(
 /**
  * Write a file only if it doesn't already exist.
  * Tracks what was created vs skipped for reporting.
+ *
+ * Exported for tests (M1 atomicity — see scaffold-write-atomic.test.ts).
  */
-function writeIfMissing(
+export function writeIfMissing(
   filePath: string,
   contentFn: () => string,
   created: string[],
@@ -7005,7 +7017,14 @@ function writeIfMissing(
     skipped.push(filePath);
     return;
   }
-  writeFileSync(filePath, contentFn(), mode !== undefined ? { encoding: "utf-8", mode } : "utf-8");
+  // Atomic tmp+fsync+rename: an interrupted scaffold (crash / ENOSPC / SIGKILL
+  // mid-write) must never leave a torn or truncated file behind. This matters
+  // most for settings.json — a partial write here is read back and JSON.parse'd
+  // a few dozen lines later (the MCP-merge pass), so a half-written file would
+  // throw and abort the scaffold with a corrupt agent on disk. When `mode` is
+  // omitted we pass 0o666 to mirror plain writeFileSync's default (the process
+  // umask is applied by the O_CREAT open, so the on-disk mode is unchanged).
+  atomicWriteFileSync(filePath, contentFn(), mode ?? 0o666);
   created.push(filePath);
 }
 

--- a/src/cli/agent-config-atomic.test.ts
+++ b/src/cli/agent-config-atomic.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Atomicity tests for the switchroom.yaml writers in src/cli/agent.ts.
+ *
+ * The 2026-07-11 durability review flagged the bare readFileSync → writeFileSync
+ * (truncate-in-place) rewrites in `switchroom agent` subcommands: a crash /
+ * ENOSPC mid-write truncates the fleet-wide config. The writes now route through
+ * the bind-mount-aware writeConfigFileSync (tmp + fsync + rename). This pins the
+ * atomic outcome for the exported YAML-mutation helpers.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import YAML from "yaml";
+
+// Mock node:fs so we can force renameSync(2) to fail while leaving every other
+// fs call real. writeConfigFileSync → atomicWriteFileSync imports renameSync
+// from node:fs, so the mock reaches it. Mirrors src/util/atomic.test.ts.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    renameSync: vi.fn().mockImplementation(actual.renameSync),
+  };
+});
+
+import { writeAgentEntryToConfig, updateAgentExtendsInConfig } from "./agent.js";
+
+const SAMPLE = [
+  "telegram:",
+  "  bot_token: vault:telegram/bot_token",
+  "agents:",
+  "  alpha:",
+  "    extends: default",
+  "",
+].join("\n");
+
+describe("agent.ts switchroom.yaml writers — atomic write", () => {
+  let dir: string;
+  let cfg: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-agent-cfg-"));
+    cfg = join(dir, "switchroom.yaml");
+    writeFileSync(cfg, SAMPLE, { mode: 0o644 });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("round-trips: writeAgentEntryToConfig adds an agent and stays parseable", () => {
+    writeAgentEntryToConfig(cfg, "bravo", "default");
+    const doc = YAML.parse(readFileSync(cfg, "utf-8"));
+    expect(doc.agents.bravo.extends).toBe("default");
+    expect(doc.agents.alpha.extends).toBe("default");
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalled();
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  // BITE: a hard failure at the atomic swap (EPERM) must rethrow and leave
+  // switchroom.yaml intact. Pre-fix the bare writeFileSync never called
+  // renameSync, so the mocked failure never fired — no throw, file rewritten.
+  it("leaves switchroom.yaml intact when rename(2) fails writing a new agent", () => {
+    const before = readFileSync(cfg, "utf-8");
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" });
+    });
+
+    expect(() => writeAgentEntryToConfig(cfg, "bravo", "default")).toThrow(/EPERM/);
+
+    expect(readFileSync(cfg, "utf-8")).toBe(before);
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  it("leaves switchroom.yaml intact when rename(2) fails updating extends", () => {
+    const before = readFileSync(cfg, "utf-8");
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" });
+    });
+
+    expect(() => updateAgentExtendsInConfig(cfg, "alpha", "worker")).toThrow(/EPERM/);
+    expect(readFileSync(cfg, "utf-8")).toBe(before);
+  });
+
+  it("preserves the file mode across the write", () => {
+    fs.chmodSync(cfg, 0o600);
+    writeAgentEntryToConfig(cfg, "charlie", "default");
+    expect(fs.statSync(cfg).mode & 0o777).toBe(0o600);
+  });
+});

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1,7 +1,7 @@
 import { Option, type Command } from "commander";
 import chalk from "chalk";
 import { join, resolve } from "node:path";
-import { rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { rmSync, existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { getSchedulerState, formatSchedulerState } from "../agents/scheduler-state.js";
 import YAML from "yaml";
@@ -48,6 +48,27 @@ import {
 import { createAgent, completeCreation } from "../agents/create-orchestrator.js";
 import { addAgent, type AgentTopology } from "../agents/add-orchestrator.js";
 import { bringUpAgentService } from "../agents/docker-fleet.js";
+import { writeConfigFileSync } from "../util/atomic.js";
+
+/**
+ * Atomically persist a mutated switchroom.yaml document.
+ *
+ * Every `switchroom agent` subcommand that edits the fleet config (add /
+ * update-extends / remove / grant tool / dangerous-mode) routes its write
+ * through here so a crash or ENOSPC mid-write can never truncate the
+ * fleet-wide config. Uses the bind-mount-aware writeConfigFileSync (falls
+ * back to an in-place fsync'd rewrite when a single-file bind mount rejects
+ * rename(2) with EBUSY) and preserves the file's existing mode bits.
+ */
+function writeSwitchroomConfig(configPath: string, text: string): void {
+  let mode = 0o644;
+  try {
+    mode = statSync(configPath).mode & 0o777;
+  } catch {
+    /* default 0o644 */
+  }
+  writeConfigFileSync(configPath, text, mode);
+}
 
 /**
  * Summarise a reconcile batch run. Returns `null` when there is
@@ -449,7 +470,7 @@ export function writeAgentEntryToConfig(
   entry.set("topic_name", synthesizeTopicName(name));
   agents.set(name, entry);
 
-  writeFileSync(configPath, doc.toString(), "utf-8");
+  writeSwitchroomConfig(configPath, doc.toString());
 }
 
 /**
@@ -477,7 +498,7 @@ export function updateAgentExtendsInConfig(
   }
   const agentNode = agents.get(name) as YAML.YAMLMap;
   agentNode.set("extends", profile);
-  writeFileSync(configPath, doc.toString(), "utf-8");
+  writeSwitchroomConfig(configPath, doc.toString());
 }
 
 /**
@@ -494,7 +515,7 @@ export function removeAgentFromConfig(configPath: string, name: string): void {
   const agents = doc.get("agents") as YAML.YAMLMap | null;
   if (!agents || !agents.has(name)) return;
   agents.delete(name);
-  writeFileSync(configPath, doc.toString(), "utf-8");
+  writeSwitchroomConfig(configPath, doc.toString());
 }
 
 /**
@@ -1906,7 +1927,7 @@ export function registerAgentCommand(program: Command): void {
           console.log(chalk.gray(`  ${name}: ${tool} already allowed`));
         } else {
           allow.add(tool);
-          writeFileSync(configPath, doc.toString(), "utf-8");
+          writeSwitchroomConfig(configPath, doc.toString());
           console.log(chalk.green(`  ${name}: granted ${tool}`));
         }
 
@@ -1967,7 +1988,7 @@ export function registerAgentCommand(program: Command): void {
           const tools = agentNode.get("tools") as YAML.YAMLMap | null;
           if (tools && tools.has("allow")) {
             tools.set("allow", new YAML.YAMLSeq());
-            writeFileSync(configPath, doc.toString(), "utf-8");
+            writeSwitchroomConfig(configPath, doc.toString());
             console.log(chalk.yellow(`  ${name}: dangerous mode OFF (tools.allow cleared)`));
           } else {
             console.log(chalk.gray(`  ${name}: dangerous mode was already off`));
@@ -1981,7 +2002,7 @@ export function registerAgentCommand(program: Command): void {
           const allowSeq = new YAML.YAMLSeq();
           allowSeq.add("all");
           tools.set("allow", allowSeq);
-          writeFileSync(configPath, doc.toString(), "utf-8");
+          writeSwitchroomConfig(configPath, doc.toString());
           console.log(chalk.red(`  ${name}: dangerous mode ON — every built-in tool pre-approved`));
           console.log(chalk.gray(`    (tools.allow: [all] expands to Bash, Read, Write, Edit, WebFetch, ...)`));
         }

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -17,7 +17,8 @@
  */
 import { Option, type Command } from "commander";
 import chalk from "chalk";
-import { accessSync, chownSync, constants as fsConstants, copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { accessSync, chownSync, constants as fsConstants, copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { writeConfigFileSync } from "../util/atomic.js";
 import { mkdir } from "node:fs/promises";
 import { spawnSync as childSpawnSync } from "node:child_process";
 import readline from "node:readline";
@@ -750,7 +751,16 @@ export async function provisionLiteLLMKeys(
   // Flush batched config edits (ACL grants) once.
   if (pendingConfigEdits && configText !== null && switchroomConfigPath) {
     try {
-      writeFileSync(switchroomConfigPath, configText, "utf-8");
+      // Atomic tmp+fsync+rename so a crash/ENOSPC mid-write can never truncate
+      // switchroom.yaml when flushing the batched litellm ACL grants. Bind-mount
+      // aware (in-place fsync'd fallback on EBUSY); preserves the file's mode.
+      let cfgMode = 0o644;
+      try {
+        cfgMode = statSync(switchroomConfigPath).mode & 0o777;
+      } catch {
+        /* default 0o644 */
+      }
+      writeConfigFileSync(switchroomConfigPath, configText, cfgMode);
       writeOut(chalk.gray(`  ~ litellm: granted read-ACL on per-agent keys (updated ${switchroomConfigPath})\n`));
     } catch (err) {
       ctx.writeErr(

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -33,7 +33,7 @@
 
 import type { Command } from "commander";
 import chalk from "chalk";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 
 import {
   disableAgentsOnGoogleAccount,
@@ -44,6 +44,22 @@ import {
 import type { PutResult, GetResult } from "../vault/broker/client.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import type { SwitchroomConfig } from "../config/schema.js";
+import { writeConfigFileSync } from "../util/atomic.js";
+
+/**
+ * Atomically persist a mutated switchroom.yaml (google enable/disable ACL
+ * edits). Crash/ENOSPC mid-write must never truncate the fleet config.
+ * Bind-mount aware (in-place fsync'd fallback on EBUSY); preserves mode.
+ */
+function writeGoogleYaml(configPath: string, text: string): void {
+  let mode = 0o644;
+  try {
+    mode = statSync(configPath).mode & 0o777;
+  } catch {
+    /* default 0o644 */
+  }
+  writeConfigFileSync(configPath, text, mode);
+}
 
 export function registerAuthGoogleSubcommands(
   program: Command,
@@ -365,7 +381,7 @@ function registerEnable(googleParent: Command, program: Command): void {
         const after = enableAgentsOnGoogleAccount(before, normalizedAccount, agents);
         const noop = after === before;
         if (!noop) {
-          writeFileSync(yamlPath, after);
+          writeGoogleYaml(yamlPath, after);
         }
 
         const enabledAfter = getEnabledAgentsForGoogleAccount(after, normalizedAccount) ?? [];
@@ -425,7 +441,7 @@ function registerDisable(googleParent: Command, program: Command): void {
         const after = disableAgentsOnGoogleAccount(before, normalizedAccount, agents);
         const noop = after === before;
         if (!noop) {
-          writeFileSync(yamlPath, after);
+          writeGoogleYaml(yamlPath, after);
         }
 
         const enabledAfter = getEnabledAgentsForGoogleAccount(after, normalizedAccount) ?? [];

--- a/src/cli/auth-microsoft.ts
+++ b/src/cli/auth-microsoft.ts
@@ -21,13 +21,14 @@
 
 import type { Command } from "commander";
 import chalk from "chalk";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 
 import {
   getEnabledAgentsForMicrosoftAccount,
   listMicrosoftAccounts,
   removeMicrosoftAccountEntry,
 } from "./microsoft-accounts-yaml.js";
+import { writeConfigFileSync } from "../util/atomic.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import {
   planMicrosoftEnable,
@@ -42,6 +43,21 @@ import { selectMicrosoftScopes } from "../microsoft/scopes.js";
 import { buildMicrosoftCredentials as buildMicrosoftCredentialsCore } from "../microsoft/credentials.js";
 import type { MicrosoftCredentialsShape } from "../auth/broker/protocol.js";
 import type { SwitchroomConfig } from "../config/schema.js";
+
+/**
+ * Atomically persist a mutated switchroom.yaml (microsoft enable/disable/
+ * remove ACL edits). Crash/ENOSPC mid-write must never truncate the fleet
+ * config. Bind-mount aware (in-place fsync'd fallback on EBUSY); preserves mode.
+ */
+function writeMicrosoftYaml(configPath: string, text: string): void {
+  let mode = 0o644;
+  try {
+    mode = statSync(configPath).mode & 0o777;
+  } catch {
+    /* default 0o644 */
+  }
+  writeConfigFileSync(configPath, text, mode);
+}
 
 export function registerAuthMicrosoftSubcommands(
   program: Command,
@@ -91,7 +107,7 @@ function registerEnable(microsoftParent: Command, program: Command): void {
         // to write only the ACL. See microsoft-enable-plan.ts.
         const { text, newlyEnabled, enabledAfter, selectorSet, selectorConflict } =
           planMicrosoftEnable(before, normalizedAccount, agents);
-        if (text !== before) writeFileSync(yamlPath, text);
+        if (text !== before) writeMicrosoftYaml(yamlPath, text);
 
         console.log();
         if (newlyEnabled.length === 0) {
@@ -176,7 +192,7 @@ function registerDisable(microsoftParent: Command, program: Command): void {
         // selector (symmetry with enable). See microsoft-enable-plan.ts.
         const { text, removed, enabledAfter, selectorCleared } =
           planMicrosoftDisable(before, normalizedAccount, agents);
-        if (text !== before) writeFileSync(yamlPath, text);
+        if (text !== before) writeMicrosoftYaml(yamlPath, text);
 
         console.log();
         if (removed.length === 0) {
@@ -569,7 +585,7 @@ function registerAccountRemove(accountParent: Command): void {
       // Prune the dormant YAML entry now that the broker creds are gone.
       // Idempotent — if the entry was already absent, returns input verbatim.
       const after = removeMicrosoftAccountEntry(before, normalizedAccount);
-      if (after !== before) writeFileSync(yamlPath, after);
+      if (after !== before) writeMicrosoftYaml(yamlPath, after);
 
       console.log();
       console.log(

--- a/src/cli/linear-agent.ts
+++ b/src/cli/linear-agent.ts
@@ -22,8 +22,24 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { getConfigPath, withConfigError } from "./helpers.js";
+import { writeConfigFileSync } from "../util/atomic.js";
+
+/**
+ * Write the fleet's switchroom.yaml atomically (tmp + fsync + rename,
+ * bind-mount-aware) so a crash / ENOSPC mid-write can never truncate it
+ * (2026-07 review, #3149 follow-up). Preserves the file's existing mode.
+ */
+function writeConfigAtomic(path: string, after: string): void {
+  let mode = 0o644;
+  try {
+    mode = statSync(path).mode & 0o777;
+  } catch {
+    /* default 0o644 */
+  }
+  writeConfigFileSync(path, after, mode);
+}
 import { setLinearAgent, setLinearDefaultTeam, addAgentSecret } from "./telegram-yaml.js";
 import { vaultPut, vaultPutQuiet, vaultGet } from "./telegram.js";
 import { performLinearRefresh, serializeBundle } from "../linear/oauth-refresh.js";
@@ -161,7 +177,7 @@ export function registerLinearAgentCommand(program: Command): void {
           console.log(chalk.bold(`[dry-run] would edit ${path}`));
           console.log(makeUnifiedDiff(before, after));
         } else {
-          writeFileSync(path, after, "utf-8");
+          writeConfigAtomic(path, after);
           console.log(chalk.green(`✓ Enabled linear-agent for agent '${opts.agent}'`));
           console.log(chalk.gray(`  Vault key: ${vaultKey}`));
           if (canRefresh) {
@@ -259,7 +275,7 @@ export function registerLinearAgentCommand(program: Command): void {
         } catch (err) {
           fail((err as Error).message);
         }
-        writeFileSync(path, after, "utf-8");
+        writeConfigAtomic(path, after);
         if (opts.clear) {
           console.log(chalk.green(`✓ Cleared default Linear team for '${opts.agent}' (auto-resolve).`));
         } else {

--- a/src/cli/memory-atomic.test.ts
+++ b/src/cli/memory-atomic.test.ts
@@ -1,0 +1,109 @@
+/**
+ * F2 atomicity test for persistMemoryConfigUrl (src/cli/memory.ts).
+ *
+ * `switchroom memory setup` rewrites the operator's canonical
+ * switchroom.yaml to record the freshly-started Hindsight endpoint under
+ * memory.config.url. The prior implementation wrote it with a bare in-place
+ * `writeFileSync` — a crash / ENOSPC between truncate and write left the
+ * fleet config torn or empty. persistMemoryConfigUrl now routes through
+ * writeConfigFileSync (tmp + fsync + rename, bind-mount-aware); a failed
+ * rename leaves the PRIOR file byte-for-byte intact and no tempfile behind.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Mock node:fs so we can force renameSync(2) to fail while every other fs
+// call stays real. writeConfigFileSync → atomicWriteFileSync imports
+// renameSync from node:fs, so the mock reaches it.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    renameSync: vi.fn().mockImplementation(actual.renameSync),
+  };
+});
+
+import { persistMemoryConfigUrl } from "./memory.js";
+
+const URL = "http://127.0.0.1:6207/mcp/";
+const PROVIDER = "claude-code";
+
+describe("persistMemoryConfigUrl — atomic switchroom.yaml write (F2)", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-memory-atomic-"));
+    configPath = join(dir, "switchroom.yaml");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("returns false and writes nothing when the config is missing", () => {
+    expect(persistMemoryConfigUrl(configPath, PROVIDER, URL)).toBe(false);
+    expect(fs.existsSync(configPath)).toBe(false);
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  it("round-trips: adds a full memory block atomically and preserves mode", () => {
+    writeFileSync(configPath, "agents:\n  bot: {}\n", { mode: 0o644 });
+
+    expect(persistMemoryConfigUrl(configPath, PROVIDER, URL)).toBe(true);
+
+    const after = readFileSync(configPath, "utf-8");
+    expect(after).toContain("memory:");
+    expect(after).toContain(`url: ${URL}`);
+    expect(after).toContain(`provider: ${PROVIDER}`);
+    expect(after).toContain("backend: hindsight");
+    // Sibling content preserved.
+    expect(after).toContain("agents:");
+    // Went through the atomic swap; mode preserved; no tempfile leaked.
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalled();
+    expect(statSync(configPath).mode & 0o777).toBe(0o644);
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  it("updates only the url when memory.config already exists", () => {
+    writeFileSync(
+      configPath,
+      "memory:\n  backend: hindsight\n  config:\n    provider: claude-code\n    url: http://old/mcp/\n",
+      { mode: 0o644 },
+    );
+
+    persistMemoryConfigUrl(configPath, PROVIDER, URL);
+
+    const after = readFileSync(configPath, "utf-8");
+    expect(after).toContain(`url: ${URL}`);
+    expect(after).not.toContain("http://old/mcp/");
+  });
+
+  // BITE: a hard rename(2) failure (ENOSPC — NOT one of the
+  // EBUSY/EXDEV/EINVAL codes writeConfigFileSync falls back on) must leave
+  // the PRIOR switchroom.yaml byte-for-byte intact and throw. The pre-fix
+  // bare writeFileSync never called rename, so the mock never fired: it
+  // truncated + rewrote in place with no throw. Both assertions fail on the
+  // old code.
+  it("leaves the prior config byte-intact when rename(2) fails mid-write", () => {
+    const original = "agents:\n  bot: {}\nmemory:\n  backend: hindsight\n";
+    writeFileSync(configPath, original, { mode: 0o644 });
+    const beforeMode = statSync(configPath).mode & 0o777;
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("ENOSPC: no space left on device"), { code: "ENOSPC" });
+    });
+
+    expect(() => persistMemoryConfigUrl(configPath, PROVIDER, URL)).toThrow(/ENOSPC/);
+
+    // Prior file untouched — not torn, not empty.
+    expect(readFileSync(configPath, "utf-8")).toBe(original);
+    expect(statSync(configPath).mode & 0o777).toBe(beforeMode);
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+});

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -27,12 +27,61 @@ import {
   type LiteLLMHindsightConfig,
 } from "../setup/hindsight.js";
 import { getViaBrokerStructured } from "../vault/broker/client.js";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { writeConfigFileSync } from "../util/atomic.js";
 import { join } from "node:path";
 import { resolveAgentsDir } from "../config/loader.js";
 import YAML from "yaml";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { normalizeHindsightVersionTag } from "../setup/hindsight.js";
+
+/**
+ * Read-modify-write switchroom.yaml to set `memory.config.url` (and
+ * `provider` when absent) so agents pick up the freshly-started Hindsight
+ * endpoint. Extracted from the `memory setup` action so the persistence —
+ * and its atomicity contract — can be unit-tested without starting a
+ * container.
+ *
+ * Atomic (tmp + fsync + rename, bind-mount-aware via writeConfigFileSync)
+ * so a crash / ENOSPC mid-write can never truncate the operator's config —
+ * the prior in-place writeFileSync could leave a torn / empty switchroom.yaml
+ * (2026-07 review, F2). Preserves the file's existing mode.
+ *
+ * Returns true when the config was updated, false when `configPath` does
+ * not exist (the caller treats a missing config as a soft skip). Any I/O
+ * error propagates to the caller, which renders a manual-edit hint.
+ */
+export function persistMemoryConfigUrl(
+  configPath: string,
+  provider: string,
+  url: string,
+): boolean {
+  if (!existsSync(configPath)) return false;
+  const raw = readFileSync(configPath, "utf-8");
+  const doc = YAML.parseDocument(raw);
+  if (!doc.has("memory")) {
+    doc.set("memory", { backend: "hindsight", shared_collection: "shared", config: { provider, url } });
+  } else {
+    const memNode = doc.get("memory") as YAML.YAMLMap;
+    if (!memNode.has("config")) {
+      memNode.set("config", { provider, url });
+    } else {
+      const configNode = memNode.get("config") as YAML.YAMLMap;
+      configNode.set("url", url);
+      if (!configNode.has("provider")) {
+        configNode.set("provider", provider);
+      }
+    }
+  }
+  let mode = 0o644;
+  try {
+    mode = statSync(configPath).mode & 0o777;
+  } catch {
+    /* default 0o644 */
+  }
+  writeConfigFileSync(configPath, doc.toString(), mode);
+  return true;
+}
 
 /**
  * Decide which hindsight image tag `memory setup` should pull + run, and
@@ -580,24 +629,7 @@ export function registerMemoryCommand(program: Command): void {
       const url = `http://127.0.0.1:${ports.apiPort}/mcp/`;
       const configPath = getConfigPath(program);
       try {
-        if (existsSync(configPath)) {
-          const raw = readFileSync(configPath, "utf-8");
-          const doc = YAML.parseDocument(raw);
-          if (!doc.has("memory")) {
-            doc.set("memory", { backend: "hindsight", shared_collection: "shared", config: { provider, url } });
-          } else {
-            const memNode = doc.get("memory") as YAML.YAMLMap;
-            if (!memNode.has("config")) {
-              memNode.set("config", { provider, url });
-            } else {
-              const configNode = memNode.get("config") as YAML.YAMLMap;
-              configNode.set("url", url);
-              if (!configNode.has("provider")) {
-                configNode.set("provider", provider);
-              }
-            }
-          }
-          writeFileSync(configPath, doc.toString(), "utf-8");
+        if (persistMemoryConfigUrl(configPath, provider, url)) {
           console.log(chalk.gray(`  Updated ${configPath} with memory.config.url = ${url}`));
           console.log(
             chalk.gray(

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import chalk from "chalk";
-import { existsSync, copyFileSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, copyFileSync, readFileSync, mkdirSync, statSync } from "node:fs";
+import { writeConfigFileSync } from "../util/atomic.js";
 import { resolve, dirname } from "node:path";
 import { loadConfig, resolveAgentsDir, resolvePath, findConfigFile, ConfigError } from "../config/loader.js";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
@@ -69,6 +70,24 @@ const STEP_DONE = chalk.green("OK");
 
 function stepHeader(num: number, title: string, status: string): void {
   console.log(`\n${status} ${chalk.bold(`Step ${num}:`)} ${title}`);
+}
+
+/**
+ * Atomically persist a mutated switchroom.yaml during the setup wizard.
+ *
+ * A crash / ENOSPC mid-write must never truncate the operator's config.
+ * Uses the bind-mount-aware writeConfigFileSync (falls back to an in-place
+ * fsync'd rewrite when a single-file bind mount rejects rename(2) with
+ * EBUSY) and preserves the file's existing mode bits.
+ */
+function writeSwitchroomYaml(configPath: string, text: string): void {
+  let mode = 0o644;
+  try {
+    mode = statSync(configPath).mode & 0o777;
+  } catch {
+    /* default 0o644 */
+  }
+  writeConfigFileSync(configPath, text, mode);
 }
 
 export function registerSetupCommand(program: Command): void {
@@ -346,7 +365,7 @@ export async function writeDetectedTimezone(
     // A confidently-real host zone — persist it verbatim, visible/editable.
     const before = readFileSync(destFile, "utf-8");
     const after = setSwitchroomTimezone(before, detected);
-    if (after !== before) writeFileSync(destFile, after);
+    if (after !== before) writeSwitchroomYaml(destFile, after);
     console.log(
       chalk.green(`  Detected timezone ${detected} — wrote switchroom.timezone.`),
     );
@@ -391,7 +410,7 @@ export async function writeDetectedTimezone(
   }
   const before = readFileSync(destFile, "utf-8");
   const after = setSwitchroomTimezone(before, zone);
-  if (after !== before) writeFileSync(destFile, after);
+  if (after !== before) writeSwitchroomYaml(destFile, after);
   console.log(chalk.green(`  Wrote switchroom.timezone: ${zone}.`));
 }
 
@@ -1608,7 +1627,9 @@ export function persistApprovalAuthTelegramId(
   // the posture key under an unrelated top-level `broker:` block.
   const result = insertVaultBrokerApprovalAuth(content, "telegram-id");
   if (result.kind === "rewritten") {
-    writeFileSync(configPath, result.content, "utf-8");
+    // Atomic (tmp + rename, bind-mount-aware) so a crash / ENOSPC
+    // mid-write can never truncate the operator's canonical config.
+    writeSwitchroomYaml(configPath, result.content);
   }
   return result.kind;
 }
@@ -1663,7 +1684,9 @@ export function persistDangerousMode(
     config.agents[name].dangerous_mode = true;
   }
 
-  writeFileSync(configPath, content, "utf-8");
+  // Atomic (tmp + rename, bind-mount-aware) so a crash / ENOSPC
+  // mid-write can never truncate the operator's canonical config.
+  writeSwitchroomYaml(configPath, content);
 }
 
 async function stepDangerousMode(

--- a/src/cli/telegram-atomic.test.ts
+++ b/src/cli/telegram-atomic.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Atomicity test for emitDiffOrWrite (src/cli/telegram.ts) — #3149 follow-up.
+ *
+ * `switchroom telegram enable/disable <feature> <agent>` rewrites the
+ * operator's canonical switchroom.yaml via emitDiffOrWrite. The prior
+ * implementation used a bare in-place `writeFileSync` — a crash / ENOSPC
+ * between truncate and write left the fleet config torn or empty. It now
+ * routes through writeConfigFileSync (tmp + fsync + rename, bind-mount-aware);
+ * a failed rename leaves the PRIOR file byte-for-byte intact and no tempfile
+ * behind. (linear-agent.ts's writeConfigAtomic uses the identical primitive.)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Mock node:fs so we can force renameSync(2) to fail while every other fs call
+// stays real. writeConfigFileSync → atomicWriteFileSync imports renameSync from
+// node:fs, so the mock reaches it.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    renameSync: vi.fn().mockImplementation(actual.renameSync),
+  };
+});
+
+import { emitDiffOrWrite } from "./telegram.js";
+
+const BEFORE = "agents:\n  bot: {}\n";
+const AFTER = "agents:\n  bot:\n    telegram:\n      voice: true\n";
+
+describe("emitDiffOrWrite — atomic switchroom.yaml write (#3149 follow-up)", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-telegram-atomic-"));
+    configPath = join(dir, "switchroom.yaml");
+    writeFileSync(configPath, BEFORE, { mode: 0o644 });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("dry-run writes nothing", () => {
+    emitDiffOrWrite(configPath, BEFORE, AFTER, true);
+    expect(readFileSync(configPath, "utf-8")).toBe(BEFORE);
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  it("round-trips the new content atomically and preserves mode", () => {
+    emitDiffOrWrite(configPath, BEFORE, AFTER, false);
+    expect(readFileSync(configPath, "utf-8")).toBe(AFTER);
+    expect(statSync(configPath).mode & 0o777).toBe(0o644);
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  it("a failed rename leaves the prior config byte-intact and no tempfile (bite)", () => {
+    // The bite: against the pre-fix in-place writeFileSync there is no rename,
+    // so this mock never fires and the file is silently rewritten/truncated.
+    (fs.renameSync as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      const e = new Error("ENOSPC: no space left on device") as NodeJS.ErrnoException;
+      e.code = "ENOSPC";
+      throw e;
+    });
+    expect(() => emitDiffOrWrite(configPath, BEFORE, AFTER, false)).toThrow(/ENOSPC/);
+    // Prior file untouched, no torn/empty write, no leaked tempfile.
+    expect(readFileSync(configPath, "utf-8")).toBe(BEFORE);
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+});

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -12,7 +12,8 @@
 
 import type { Command } from "commander";
 import chalk from "chalk";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { writeConfigFileSync } from "../util/atomic.js";
 import { join } from "node:path";
 import {
   matchesRule,
@@ -507,13 +508,22 @@ async function applyYamlRemove(
   }
 }
 
-function emitDiffOrWrite(path: string, before: string, after: string, dryRun: boolean): void {
+export function emitDiffOrWrite(path: string, before: string, after: string, dryRun: boolean): void {
   if (dryRun) {
     console.log(chalk.bold(`[dry-run] would edit ${path}`));
     console.log(makeUnifiedDiff(before, after));
     return;
   }
-  writeFileSync(path, after, "utf-8");
+  // Atomic (tmp + fsync + rename, bind-mount-aware) so a crash / ENOSPC
+  // mid-write can never truncate the fleet's switchroom.yaml (2026-07 review,
+  // #3149 follow-up). Preserve the file's existing mode.
+  let mode = 0o644;
+  try {
+    mode = statSync(path).mode & 0o777;
+  } catch {
+    /* default 0o644 */
+  }
+  writeConfigFileSync(path, after, mode);
 }
 
 function makeUnifiedDiff(before: string, after: string): string {

--- a/src/cli/vault-auto-unlock.test.ts
+++ b/src/cli/vault-auto-unlock.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Atomicity tests for setVaultBrokerAutoUnlock (src/cli/vault-auto-unlock.ts).
+ *
+ * The 2026-07-11 durability review flagged the bare readFileSync → writeFileSync
+ * (truncate-in-place) rewrite of switchroom.yaml: a crash / ENOSPC mid-write
+ * truncates the fleet-wide config. The write now routes through the bind-mount-
+ * aware writeConfigFileSync (tmp + fsync + rename, in-place fsync'd fallback
+ * only on EBUSY/EXDEV/EINVAL). These tests assert the atomic outcome.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import YAML from "yaml";
+
+// Mock node:fs so we can force renameSync(2) to fail (crash between the tmp
+// write and the atomic swap) while leaving every other fs call real.
+// writeConfigFileSync → atomicWriteFileSync imports renameSync from node:fs,
+// so this mock reaches it. Mirrors src/util/atomic.test.ts.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    renameSync: vi.fn().mockImplementation(actual.renameSync),
+  };
+});
+
+import { setVaultBrokerAutoUnlock } from "./vault-auto-unlock.js";
+
+const SAMPLE = [
+  "telegram:",
+  "  bot_token: vault:telegram/bot_token",
+  "agents:",
+  "  klanker:",
+  "    extends: default",
+  "vault:",
+  "  broker:",
+  "    autoUnlock: false",
+  "",
+].join("\n");
+
+describe("setVaultBrokerAutoUnlock — atomic switchroom.yaml write", () => {
+  let dir: string;
+  let cfg: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-autounlock-"));
+    cfg = join(dir, "switchroom.yaml");
+    writeFileSync(cfg, SAMPLE, { mode: 0o644 });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("round-trips: sets vault.broker.autoUnlock and stays parseable", () => {
+    setVaultBrokerAutoUnlock(cfg, true);
+    const doc = YAML.parse(readFileSync(cfg, "utf-8"));
+    expect(doc.vault.broker.autoUnlock).toBe(true);
+    // Unrelated keys preserved.
+    expect(doc.agents.klanker.extends).toBe("default");
+    // Used the atomic rename path.
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalled();
+    // No tempfile leaked alongside the config.
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  // BITE: a hard failure at the atomic swap (EPERM — NOT a bind-mount fallback
+  // code) must rethrow and leave switchroom.yaml byte-for-byte intact. The
+  // pre-fix bare writeFileSync truncated in place and never called renameSync,
+  // so the mocked failure never fired: no throw, and the file was rewritten —
+  // both assertions below fail on the old code.
+  it("leaves switchroom.yaml intact when rename(2) fails mid-write", () => {
+    const before = readFileSync(cfg, "utf-8");
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" });
+    });
+
+    expect(() => setVaultBrokerAutoUnlock(cfg, true)).toThrow(/EPERM/);
+
+    // Fleet config unharmed — never truncated.
+    expect(readFileSync(cfg, "utf-8")).toBe(before);
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  it("preserves the file mode across the write", () => {
+    fs.chmodSync(cfg, 0o600);
+    setVaultBrokerAutoUnlock(cfg, true);
+    expect(fs.statSync(cfg).mode & 0o777).toBe(0o600);
+  });
+});

--- a/src/cli/vault-auto-unlock.ts
+++ b/src/cli/vault-auto-unlock.ts
@@ -21,10 +21,11 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import YAML from "yaml";
+import { writeConfigFileSync } from "../util/atomic.js";
 
 import { findConfigFile, loadConfig, resolvePath } from "../config/loader.js";
 import { statusViaBroker, resolveBrokerSocketPath } from "../vault/broker/client.js";
@@ -89,7 +90,18 @@ export function setVaultBrokerAutoUnlock(configPath: string, value: boolean): vo
   const raw = readFileSync(configPath, "utf-8");
   const doc = YAML.parseDocument(raw);
   doc.setIn(["vault", "broker", "autoUnlock"], value);
-  writeFileSync(configPath, doc.toString(), "utf-8");
+  // Atomic tmp+fsync+rename so a crash/ENOSPC mid-write can never truncate
+  // switchroom.yaml (which would take the whole fleet's config with it).
+  // writeConfigFileSync is the bind-mount-aware variant: a single-file bind
+  // mount of switchroom.yaml rejects rename(2) with EBUSY, in which case it
+  // falls back to an in-place fsync'd rewrite. Preserve the file's mode.
+  let mode = 0o644;
+  try {
+    mode = statSync(configPath).mode & 0o777;
+  } catch {
+    /* default 0o644 */
+  }
+  writeConfigFileSync(configPath, doc.toString(), mode);
 }
 
 export interface ApplyOptions {


### PR DESCRIPTION
## Problem

A crash / ENOSPC mid-write currently **truncates fleet-wide config** (`switchroom.yaml`) or an agent's scaffolded `settings.json`. Those files were rewritten with a bare `readFileSync` → `writeFileSync` (truncate-in-place, no tmp+rename), so an interrupted write leaves a zero-length or torn file. The 2026-07-11 durability review flagged both classes (plus scaffold M1 / M5).

## Fix

Route every non-atomic writer through the hardened helpers in `src/util/atomic.ts` (tmp write + `fsync` + `rename(2)`, `O_NOFOLLOW|O_EXCL`). Only the **write mechanism** changed — file contents/format are untouched, mode bits preserved via `statSync`.

### `switchroom.yaml` writers → `writeConfigFileSync`
The bind-mount-aware variant purpose-built for `switchroom.yaml` (falls back to an in-place fsync'd rewrite only when a single-file bind mount rejects `rename(2)` with EBUSY/EXDEV/EINVAL). Already the precedent in `update.ts` / `rollout.ts`.

- `src/cli/setup.ts` — timezone (x2), vault approval posture, dangerous_mode
- `src/cli/apply.ts` — litellm ACL grant flush
- `src/cli/agent.ts` — add / update-extends / remove / grant-tool / dangerous (6 sites, via a shared `writeSwitchroomConfig` helper)
- `src/cli/auth-google.ts` — enable / disable
- `src/cli/auth-microsoft.ts` — enable / disable / account remove
- `src/cli/vault-auto-unlock.ts` — `setVaultBrokerAutoUnlock`

### Scaffold state → `atomicWriteFileSync`
- **M1** `scaffold.ts` `writeIfMissing` — an interrupted scaffold no longer leaves a torn `settings.json` that the subsequent `JSON.parse` (MCP-merge pass) aborts on. Omitted mode → `0o666` to match `writeFileSync`'s umask default.
- **M5** `reconcile-default-mcps.ts` — the read-modify-write of `settings.json` is now atomic; existing inode mode carried across the swap.

## Tests

New/extended tests assert the atomic **outcome**, not just "helper is used": forcing `rename(2)` to fail with a hard code (EIO/EPERM/ENOSPC — deliberately *not* a bind-mount fallback code) must rethrow and leave the prior file byte-for-byte intact (or, for the create case, leave **no** file), with no leaked tempfile and mode preserved.

- `src/agents/reconcile-default-mcps.test.ts` (M5, +3)
- `src/agents/scaffold-write-atomic.test.ts` (M1, new)
- `src/cli/vault-auto-unlock.test.ts` (new)
- `src/cli/agent-config-atomic.test.ts` (new)

**Proof of bite:** reverting each converted write back to the old `writeFileSync` fails these tests (7 for the yaml/M5 writers, 2 for M1) — `renameSync` is never called, so no throw and the file is silently rewritten.

`npx tsc --noEmit` clean; scoped vitest green (66 tests incl. neighbors); relevant lint checks pass (`check-plugin-references` skipped — known worktree env gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)