### PR TITLE
fix(approvals): close fail-open holes in MS-365 + scoped-approval gates

### DIFF
--- a/src/cli/ms-365-write-pretool.test.ts
+++ b/src/cli/ms-365-write-pretool.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractMs365Preview,
   GATED_MS365_WRITE_TOOLS,
+  KNOWN_SAFE_MS365_READ_TOOLS,
   isGatedMs365Tool,
 } from "./ms-365-write-pretool.js";
 
@@ -25,10 +26,12 @@ describe("isGatedMs365Tool", () => {
     expect(isGatedMs365Tool("mcp__ms-365__delete-message")).toBe(true);
   });
 
-  it("returns false for read tools (no gating overhead)", () => {
+  it("returns false for VERIFIED read tools (no gating overhead)", () => {
     expect(isGatedMs365Tool("mcp__ms-365__list-files")).toBe(false);
     expect(isGatedMs365Tool("mcp__ms-365__get-drive-item")).toBe(false);
     expect(isGatedMs365Tool("mcp__ms-365__list-events")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__search-mail")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__download-bytes")).toBe(false);
   });
 
   it("returns false for non-ms-365 tools (wrong prefix)", () => {
@@ -42,11 +45,40 @@ describe("isGatedMs365Tool", () => {
     expect(isGatedMs365Tool("mcp__ms-365__")).toBe(false);
   });
 
-  it("explicitly does NOT gate Mail.Send (RFC §4.3 — drafts only v1)", () => {
-    expect(isGatedMs365Tool("mcp__ms-365__send-mail")).toBe(false);
-    // Mail.Send is not in v1 scope; the agent shouldn't have access at
-    // all. If a future PR ever adds the scope, this test will need
-    // updating along with GATED_MS365_WRITE_TOOLS.
+  // ── Fail-closed inversion (review 2026-07-11, W2) ────────────────────
+  // An unrecognized MS-365 tool — a renamed or newly-added upstream write —
+  // must REQUIRE approval, not sail through. The allowlist gap defaults to
+  // "gate", never to "allow".
+  it("GATES an unrecognized ms-365 tool (renamed/new write — fail closed)", () => {
+    // A plausibly-renamed upload tool that isn't in our read allowlist.
+    expect(isGatedMs365Tool("mcp__ms-365__upload-file-content-v2")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__put-file")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__patch-event")).toBe(true);
+    // A brand-new write surface softeria might add tomorrow.
+    expect(isGatedMs365Tool("mcp__ms-365__move-message")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__totally-unknown-tool")).toBe(true);
+  });
+
+  it("GATES Mail.Send — a write tool not on the read allowlist (fail closed)", () => {
+    // Pre-fix this was deliberately allowed through ("agent shouldn't have
+    // the scope at all"), which was exactly the fail-open hole: if the
+    // agent ever DID get send access, it bypassed approval. Fail-closed
+    // now requires a card for any unrecognized write.
+    expect(isGatedMs365Tool("mcp__ms-365__send-mail")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__send-message")).toBe(true);
+  });
+});
+
+describe("KNOWN_SAFE_MS365_READ_TOOLS — read allowlist integrity", () => {
+  it("does not overlap with the gated write set", () => {
+    for (const t of KNOWN_SAFE_MS365_READ_TOOLS) {
+      expect(GATED_MS365_WRITE_TOOLS.has(t), t).toBe(false);
+    }
+  });
+
+  it("does not include any send tool (writes never belong on the read allowlist)", () => {
+    expect(KNOWN_SAFE_MS365_READ_TOOLS.has("send-mail")).toBe(false);
+    expect(KNOWN_SAFE_MS365_READ_TOOLS.has("send-message")).toBe(false);
   });
 });
 

--- a/src/cli/ms-365-write-pretool.ts
+++ b/src/cli/ms-365-write-pretool.ts
@@ -30,8 +30,17 @@
  *   - Timeout / no decision → block
  *
  * Fail-open ONLY when:
- *   - Tool isn't in the gated set (unknown / non-write upstream tools)
- *   - SWITCHROOM_AGENT_NAME missing (we don't know which agent we're gating)
+ *   - Tool isn't an MS-365 tool at all (wrong `mcp__ms-365__` prefix), or
+ *     it's a VERIFIED read-only MS-365 tool (KNOWN_SAFE_MS365_READ_TOOLS).
+ *
+ * Fail-CLOSED (require approval) — deterministic, not prompt-dependent:
+ *   - Any known write tool (GATED_MS365_WRITE_TOOLS).
+ *   - Any UNRECOGNIZED `mcp__ms-365__` tool. A renamed or newly-added
+ *     softeria write tool that isn't yet in our read allowlist must NOT
+ *     sail through — an allowlist gap defaults to "require approval",
+ *     never to "allow" (review 2026-07-11, W2 fail-open finding).
+ *   - SWITCHROOM_AGENT_NAME missing → block (we can't identify the agent
+ *     to gate, so we can't prove the operator approved this write).
  */
 
 import { readFileSync } from "node:fs";
@@ -88,9 +97,61 @@ export const GATED_MS365_WRITE_TOOLS = new Set<string>([
   "delete-message",
 ]);
 
+/**
+ * VERIFIED read-only softeria tools that are safe to pass through WITHOUT
+ * an approval card. This is the fail-closed pivot: `isGatedMs365Tool`
+ * gates (requires approval) for any `mcp__ms-365__` tool that is NOT on
+ * this allowlist — so a renamed or newly-added upstream WRITE tool defaults
+ * to "require approval" rather than sailing through unrecognized.
+ *
+ * Names are sourced from softeria's read surface (docs/microsoft-workspace
+ * + RFC #1873): OneDrive reads, calendar reads, mail reads, and identity.
+ * The cost of an omission here is only an extra approval prompt on a read
+ * (annoying, safe) — never an ungated write (unsafe). When UAT (PR 5)
+ * confirms softeria's exact read-tool names, add any missing ones here.
+ */
+export const KNOWN_SAFE_MS365_READ_TOOLS = new Set<string>([
+  // OneDrive / Drive reads
+  "list-files",
+  "list-drive-items",
+  "get-drive-item",
+  "download-bytes",
+  "search-files",
+  // Calendar reads
+  "list-events",
+  "get-event",
+  "list-calendars",
+  "get-calendar",
+  // Mail reads
+  "list-messages",
+  "get-message",
+  "search-mail",
+  "list-mail-folders",
+  "get-mail-folder",
+  // Identity / account
+  "whoami",
+  "get-current-user",
+]);
+
+/**
+ * Should this tool require an operator approval card before it runs?
+ *
+ * Fail-CLOSED classification:
+ *   - Not an `mcp__ms-365__` tool → false (not our surface; another hook
+ *     or the base permission system owns it).
+ *   - A verified read-only tool (KNOWN_SAFE_MS365_READ_TOOLS) → false.
+ *   - Everything else on the `mcp__ms-365__` surface (known writes AND any
+ *     unrecognized / renamed tool) → true (gate).
+ */
 export function isGatedMs365Tool(toolName: string): boolean {
   if (!toolName.startsWith(TOOL_PREFIX)) return false;
-  return GATED_MS365_WRITE_TOOLS.has(toolName.slice(TOOL_PREFIX.length));
+  const bare = toolName.slice(TOOL_PREFIX.length);
+  // Degenerate prefix-only name — not a real tool invocation.
+  if (bare.length === 0) return false;
+  // Verified read-only tools pass through without a card.
+  if (KNOWN_SAFE_MS365_READ_TOOLS.has(bare)) return false;
+  // Known write OR unrecognized MS-365 tool → require approval (fail-closed).
+  return true;
 }
 
 // ────────────────────────────────────────────────────────────────────────
@@ -308,17 +369,26 @@ async function rpcKernel(payload: Record<string, unknown>): Promise<IpcResult> {
   });
 }
 
-async function approvalLookup(
+/**
+ * Poll the verdict for the SPECIFIC request_id this hook registered.
+ *
+ * We correlate by request_id, NOT by scope: two concurrent MS-365 writes
+ * can share a scope (e.g. `ms-365:write:(new)` for two new-file uploads),
+ * and a scope-keyed lookup would let one write's approval satisfy the
+ * other's gate — a fail-open mis-attribution. `approval_lookup_by_request`
+ * resolves the nonce by request_id and returns only that request's own
+ * decision. (review 2026-07-11, W2 verdict-correlation finding.)
+ */
+async function approvalLookupByRequest(
   agentUnit: string,
-  scope: string,
+  requestId: string,
   approverSet: string[],
 ): Promise<{ state?: string } | null> {
   const res = await rpcKernel({
     v: 1,
-    op: "approval_lookup",
+    op: "approval_lookup_by_request",
     agent_unit: agentUnit,
-    scope,
-    action: "write",
+    request_id: requestId,
     current_approver_set: approverSet,
   });
   if (!res.ok) return null;
@@ -355,9 +425,11 @@ async function main(): Promise<void> {
 
   const agentName = process.env.SWITCHROOM_AGENT_NAME;
   if (!agentName) {
-    // No agent identity — can't gate. Fail open per the docstring
-    // contract (Claude Code protocol error, not our concern).
-    allow();
+    // No agent identity — we can't register/correlate an approval for a
+    // known-write path, so we can't prove the operator authorized it.
+    // Fail CLOSED (review 2026-07-11, W2). The write is already confirmed
+    // gated at this point (isGatedMs365Tool returned true above).
+    fail("SWITCHROOM_AGENT_NAME unset — cannot identify agent to gate write");
   }
 
   const accountEmail = process.env.SWITCHROOM_MICROSOFT_ACCOUNT ?? "(unknown)";
@@ -400,13 +472,15 @@ async function main(): Promise<void> {
     fail(response.reason ?? "gateway returned ok=false");
   }
 
+  const requestId = response.requestId;
   const deadline = response.expiresAtMs ?? Date.now() + HOOK_TIMEOUT_MS;
-  const scope = `ms-365:write:${preview.itemId}`;
-  // We don't know the approver_set in the hook — pass an empty list;
-  // the kernel uses the snapshot taken at register time.
+  // Correlate strictly by the request_id we just registered — not by scope
+  // (concurrent same-scope writes would otherwise cross-attribute verdicts).
+  // We don't know the approver_set in the hook — pass an empty list; the
+  // kernel uses the snapshot taken at register time.
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, KERNEL_POLL_INTERVAL_MS));
-    const lookup = await approvalLookup(agentName, scope, []);
+    const lookup = await approvalLookupByRequest(agentName, requestId, []);
     if (!lookup) continue;
     const state = lookup.state;
     if (state === "granted") allow();

--- a/src/vault/approvals/kernel-server.ts
+++ b/src/vault/approvals/kernel-server.ts
@@ -49,6 +49,7 @@ import {
 import {
   requestApproval,
   lookupDecision,
+  lookupDecisionByRequestId,
   consumeNonce,
   consumeAndRecord,
   revokeDecision,
@@ -395,6 +396,35 @@ function handleRequest(
       agent_unit: req.agent_unit,
       scope: req.scope,
       action: req.action,
+      current_approver_set: req.current_approver_set,
+    });
+    const decision = r.state === "granted" || r.state === "denied"
+      ? {
+          id: r.decision.id,
+          agent_unit: r.decision.agent_unit,
+          scope: r.decision.scope,
+          action: r.decision.action,
+          decision: r.decision.decision,
+          granted_at: r.decision.granted_at,
+          granted_by_user_id: r.decision.granted_by_user_id,
+          ttl_expires_at: r.decision.ttl_expires_at,
+          last_used_at: r.decision.last_used_at,
+          revoked_at: r.decision.revoked_at,
+          revoke_reason: r.decision.revoke_reason,
+        }
+      : null;
+    socket.write(encodeResponse({ ok: true, state: r.state, decision }));
+    return;
+  }
+  if (req.op === "approval_lookup_by_request") {
+    const acl = checkApprovalAclByAgent(agent, req.agent_unit);
+    if (!acl.allow) {
+      socket.write(encodeResponse(errorResponse("DENIED", acl.reason)));
+      return;
+    }
+    const r = lookupDecisionByRequestId(db, {
+      agent_unit: req.agent_unit,
+      request_id: req.request_id,
       current_approver_set: req.current_approver_set,
     });
     const decision = r.state === "granted" || r.state === "denied"

--- a/src/vault/approvals/kernel.test.ts
+++ b/src/vault/approvals/kernel.test.ts
@@ -13,6 +13,7 @@ import {
   consumeAndRecord,
   recordDecision,
   lookupDecision,
+  lookupDecisionByRequestId,
   revokeDecision,
   listDecisions,
   getNonce,
@@ -203,6 +204,137 @@ describe("approval kernel — request/consume/record/lookup", () => {
     expect(getNonce(db, r.request_id)?.consumed_at).toBeNull();
     consumeNonce(db, r.request_id);
     expect(getNonce(db, r.request_id)?.consumed_at).not.toBeNull();
+  });
+});
+
+describe("approval kernel — lookupDecisionByRequestId (verdict correlation, W2)", () => {
+  let db: Database;
+  beforeEach(() => { db = newDb(); });
+
+  const AGENT = "switchroom-klanker.service";
+  const SCOPE = "ms-365:write:(new)"; // the collision-prone shared scope
+
+  it("unknown request_id → no_decision", () => {
+    expect(
+      lookupDecisionByRequestId(db, {
+        agent_unit: AGENT,
+        request_id: "0".repeat(32),
+        current_approver_set: ["1"],
+      }).state,
+    ).toBe("no_decision");
+  });
+
+  it("registered but undecided → pending", () => {
+    const r = requestApproval(db, {
+      agent_unit: AGENT, scope: SCOPE, action: "write", approver_set: ["1"],
+    });
+    expect(
+      lookupDecisionByRequestId(db, {
+        agent_unit: AGENT, request_id: r.request_id, current_approver_set: ["1"],
+      }).state,
+    ).toBe("pending");
+  });
+
+  it("does NOT cross-attribute a same-scope concurrent request's verdict", () => {
+    // Two concurrent writes share the scope `ms-365:write:(new)`.
+    const reqA = requestApproval(db, {
+      agent_unit: AGENT, scope: SCOPE, action: "write", approver_set: ["1"],
+    });
+    const reqB = requestApproval(db, {
+      agent_unit: AGENT, scope: SCOPE, action: "write", approver_set: ["1"],
+    });
+
+    // Operator approves ONLY request A.
+    const resA = consumeAndRecord(db, {
+      request_id: reqA.request_id,
+      decision: "allow_once",
+      approver_set: ["1"],
+      granted_by_user_id: 1,
+    });
+    expect(resA.consumed).toBe(true);
+
+    // Request A's own verdict → granted.
+    expect(
+      lookupDecisionByRequestId(db, {
+        agent_unit: AGENT, request_id: reqA.request_id, current_approver_set: ["1"],
+      }).state,
+    ).toBe("granted");
+
+    // Request B must NOT inherit A's grant — it's still pending (its own
+    // card hasn't been tapped). The old scope-keyed lookup returned
+    // "granted" here, which was the fail-open mis-attribution.
+    expect(
+      lookupDecisionByRequestId(db, {
+        agent_unit: AGENT, request_id: reqB.request_id, current_approver_set: ["1"],
+      }).state,
+    ).toBe("pending");
+
+    // Contrast: the scope-keyed lookup DOES see the leaked grant — this is
+    // exactly why the hook must correlate by request_id, not scope.
+    expect(
+      lookupDecision(db, {
+        agent_unit: AGENT, scope: SCOPE, action: "write", current_approver_set: ["1"],
+      }).state,
+    ).toBe("granted");
+  });
+
+  it("independently reflects deny for the specific request", () => {
+    const reqA = requestApproval(db, {
+      agent_unit: AGENT, scope: SCOPE, action: "write", approver_set: ["1"],
+    });
+    const reqB = requestApproval(db, {
+      agent_unit: AGENT, scope: SCOPE, action: "write", approver_set: ["1"],
+    });
+    consumeAndRecord(db, {
+      request_id: reqB.request_id, decision: "deny",
+      approver_set: ["1"], granted_by_user_id: 1,
+    });
+    expect(
+      lookupDecisionByRequestId(db, {
+        agent_unit: AGENT, request_id: reqB.request_id, current_approver_set: ["1"],
+      }).state,
+    ).toBe("denied");
+    // A is untouched.
+    expect(
+      lookupDecisionByRequestId(db, {
+        agent_unit: AGENT, request_id: reqA.request_id, current_approver_set: ["1"],
+      }).state,
+    ).toBe("pending");
+  });
+
+  it("enforces cross-agent isolation — a foreign agent_unit gets no_decision", () => {
+    const r = requestApproval(db, {
+      agent_unit: AGENT, scope: SCOPE, action: "write", approver_set: ["1"],
+    });
+    consumeAndRecord(db, {
+      request_id: r.request_id, decision: "allow_once",
+      approver_set: ["1"], granted_by_user_id: 1,
+    });
+    // Same request_id, different (attacker) agent_unit → no verdict oracle.
+    expect(
+      lookupDecisionByRequestId(db, {
+        agent_unit: "switchroom-evil.service",
+        request_id: r.request_id,
+        current_approver_set: ["1"],
+      }).state,
+    ).toBe("no_decision");
+  });
+
+  it("a revoked decision is terminal-not-granted for its request", () => {
+    const r = requestApproval(db, {
+      agent_unit: AGENT, scope: SCOPE, action: "write", approver_set: ["1"],
+    });
+    const res = consumeAndRecord(db, {
+      request_id: r.request_id, decision: "allow_once",
+      approver_set: ["1"], granted_by_user_id: 1,
+    });
+    expect(res.consumed).toBe(true);
+    revokeDecision(db, (res as { decision_id: string }).decision_id, "operator", "test");
+    expect(
+      lookupDecisionByRequestId(db, {
+        agent_unit: AGENT, request_id: r.request_id, current_approver_set: ["1"],
+      }).state,
+    ).toBe("denied");
   });
 });
 

--- a/src/vault/approvals/kernel.ts
+++ b/src/vault/approvals/kernel.ts
@@ -280,6 +280,90 @@ export function lookupDecision(
 
   if (!row) return { state: "no_decision" };
 
+  return evaluateDecisionRow(db, row, currentCanonical, opts, now);
+}
+
+/**
+ * Correlate a verdict to the SPECIFIC request_id the caller registered —
+ * NOT to the (agent, scope, action) triple. Two concurrent requests can
+ * share a scope (e.g. `ms-365:write:(new)` for two different new-file
+ * uploads); a scope-keyed `lookupDecision` would let one request's
+ * approval be mis-attributed to the other. This resolves the nonce by
+ * request_id, follows its `decision_id` link (set atomically at
+ * consume+record time), and evaluates only that request's own decision
+ * row. (review 2026-07-11, W2 verdict-correlation finding.)
+ *
+ * States:
+ *   - unknown request_id                       → no_decision
+ *   - nonce pending, not yet decided, unexpired → pending
+ *   - nonce pending, past its TTL               → expired
+ *   - decision recorded but revoked             → denied
+ *   - otherwise → evaluate the linked decision row (granted/denied/…)
+ */
+export function lookupDecisionByRequestId(
+  db: Database,
+  query: {
+    agent_unit: string;
+    request_id: string;
+    current_approver_set: string[];
+  },
+  opts: { max_ttl_lifetime_ms?: number } = {},
+  now: number = Date.now(),
+): LookupResult {
+  const currentCanonical = canonicalizeApproverSet(query.current_approver_set);
+
+  const nonceRow = db
+    .query<Record<string, unknown>, [string]>(
+      `SELECT * FROM approval_nonces WHERE request_id = ?`,
+    )
+    .get(query.request_id);
+  if (!nonceRow) return { state: "no_decision" };
+
+  const nonce = nonceFromRow(nonceRow);
+
+  // Cross-agent isolation (#1399 pattern): a request_id is only readable
+  // by the agent that owns it. A mismatch returns the same non-committal
+  // no_decision as an unknown id — no cross-agent existence/verdict oracle.
+  if (nonce.agent_unit !== query.agent_unit) return { state: "no_decision" };
+
+  if (nonce.decision_id === null) {
+    // No verdict recorded yet. Distinguish "still waiting" from "the
+    // prompt timed out" so the caller can fail closed promptly rather
+    // than spin to its own deadline.
+    if (nonce.expires_at < now) return { state: "expired" };
+    return { state: "pending", request_id: nonce.request_id };
+  }
+
+  const decRow = db
+    .query<Record<string, unknown>, [string]>(
+      `SELECT * FROM approval_decisions WHERE id = ?`,
+    )
+    .get(nonce.decision_id);
+  // Linked decision vanished (can't happen — decisions are never deleted,
+  // only revoked). Defensive terminal fail-closed rather than a hang.
+  if (!decRow) return { state: "expired" };
+
+  // A revoked decision is terminal-not-granted for THIS request.
+  if ((decRow.revoked_at as number | null) != null) {
+    return { state: "denied", decision: rowToDecision(decRow) };
+  }
+
+  return evaluateDecisionRow(db, decRow, currentCanonical, opts, now);
+}
+
+/**
+ * Shared decision-row evaluator: deny_perm short-circuit, TTL expiry,
+ * approver-set drift auto-revoke, single-shot deny, and §7 sliding-window
+ * TTL renewal. Factored out of `lookupDecision` so the request-id-keyed
+ * path (`lookupDecisionByRequestId`) applies the identical policy.
+ */
+function evaluateDecisionRow(
+  db: Database,
+  row: Record<string, unknown>,
+  currentCanonical: string,
+  opts: { max_ttl_lifetime_ms?: number },
+  now: number,
+): LookupResult {
   const decision = rowToDecision(row);
 
   // deny_perm short-circuits before drift / TTL — it's a permanent reject.

--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -30,12 +30,13 @@ import { chainRow, seedChain, type ChainState } from "../../util/audit-hashchain
 import { safeAuditLogPath } from "./test-isolation-guard.js";
 
 /** Operations the broker can perform. (PR-6: `approval_consume_record`
- *  is an additive member of the shared broker/kernel request union, so
- *  the broker's grant-mgmt `writeAudit({ op: req.op })` callsites now
- *  see it in `req.op`'s static type even though the broker never
- *  dispatches it — including it here keeps the audit-op vocabulary a
+ *  and `approval_lookup_by_request` are additive members of the shared
+ *  broker/kernel request union, so the broker's grant-mgmt
+ *  `writeAudit({ op: req.op })` callsites now see them in `req.op`'s
+ *  static type even though the broker never dispatches them (they are
+ *  kernel-only ops) — including them here keeps the audit-op vocabulary a
  *  superset of the wire ops and satisfies tsc with no runtime change.) */
-export type AuditOp = "get" | "put" | "set" | "delete" | "list" | "unlock" | "lock" | "mint_grant" | "list_grants" | "revoke_grant" | "preflight_access" | "approval_consume_record";
+export type AuditOp = "get" | "put" | "set" | "delete" | "list" | "unlock" | "lock" | "mint_grant" | "list_grants" | "revoke_grant" | "preflight_access" | "approval_consume_record" | "approval_lookup_by_request";
 
 /**
  * One audit log entry.

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -311,6 +311,19 @@ export const ApprovalLookupRequestSchema = z.object({
   current_approver_set: z.array(z.string()),
 });
 
+// Correlate a verdict strictly by the request_id the caller registered,
+// NOT by (agent_unit, scope, action). Concurrent requests can share a
+// scope (e.g. two `ms-365:write:(new)` uploads); scope-keyed
+// approval_lookup would mis-attribute one request's approval to another.
+// agent_unit is carried for the same per-agent ACL gate as approval_lookup.
+export const ApprovalLookupByRequestRequestSchema = z.object({
+  v: z.literal(1),
+  op: z.literal("approval_lookup_by_request"),
+  agent_unit: z.string().min(1),
+  request_id: z.string().regex(/^[0-9a-f]{32}$/),
+  current_approver_set: z.array(z.string()),
+});
+
 export const ApprovalConsumeRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("approval_consume"),
@@ -379,6 +392,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   RevokeGrantRequestSchema,
   ApprovalRequestRequestSchema,
   ApprovalLookupRequestSchema,
+  ApprovalLookupByRequestRequestSchema,
   ApprovalConsumeRequestSchema,
   ApprovalRevokeRequestSchema,
   ApprovalListRequestSchema,
@@ -398,6 +412,7 @@ export type ListGrantsRequest = z.infer<typeof ListGrantsRequestSchema>;
 export type RevokeGrantRequest = z.infer<typeof RevokeGrantRequestSchema>;
 export type ApprovalRequestRequest = z.infer<typeof ApprovalRequestRequestSchema>;
 export type ApprovalLookupRequest = z.infer<typeof ApprovalLookupRequestSchema>;
+export type ApprovalLookupByRequestRequest = z.infer<typeof ApprovalLookupByRequestRequestSchema>;
 export type ApprovalConsumeRequest = z.infer<typeof ApprovalConsumeRequestSchema>;
 export type ApprovalRevokeRequest = z.infer<typeof ApprovalRevokeRequestSchema>;
 export type ApprovalListRequest = z.infer<typeof ApprovalListRequestSchema>;

--- a/telegram-plugin/scoped-approval.ts
+++ b/telegram-plugin/scoped-approval.ts
@@ -307,9 +307,15 @@ export function isDestructiveBashCommand(command: string): boolean {
   if (/\b(chmod|chown|chgrp)\b[^|;&]*(\s-(-recursive|[a-z]*r[a-z]*)\b)/.test(c)) return true;
   // redirection clobbering devices or system dirs
   if (/>\s*\/(dev|etc|boot|sys|proc)\b/.test(c)) return true;
-  // destructive git
+  // destructive git — discards or rewrites history / working-tree state.
+  //   checkout: `-f`/`--force` (force-overwrite), `git checkout .`
+  //     (path-restore of the whole tree) and `checkout … -- <path>` all
+  //     discard uncommitted work. A plain `git checkout <branch>` (branch
+  //     switch, reversible) is deliberately NOT flagged.
+  //   stash: `drop`/`clear`/`pop` remove stash state irreversibly
+  //     (`stash`/`list`/`show`/`apply` keep it and stay unflagged).
   if (/\bgit\b/.test(c) &&
-      /(push\b[^|;&]*(--force|-f\b|--force-with-lease)|push\s+[^\s]*\s+\+|reset\s+--hard|clean\s+-[a-z]*[fd]|filter-branch|reflog\s+expire|update-ref\s+-d|branch\s+-d{1,2}\b|checkout\s+--\s|restore\b)/.test(c)) return true;
+      /(push\b[^|;&]*(--force|-f\b|--force-with-lease)|push\s+[^\s]*\s+\+|reset\s+--hard|clean\s+-[a-z]*[fd]|filter-branch|reflog\s+expire|update-ref\s+-d|branch\s+-d{1,2}\b|checkout\b[^|;&]*(\s-f\b|\s--force\b|\s--(\s|$)|\s\.(\s|$))|stash\s+(drop|clear|pop)\b|restore\b)/.test(c)) return true;
   // power / process control
   if (/(^|\s|;|&&|\|\||\()(shutdown|reboot|halt|poweroff|kill|killall|pkill)\b/.test(c)) return true;
   if (/(^|\s)init\s+0\b/.test(c)) return true;

--- a/telegram-plugin/scoped-approval.ts
+++ b/telegram-plugin/scoped-approval.ts
@@ -308,14 +308,17 @@ export function isDestructiveBashCommand(command: string): boolean {
   // redirection clobbering devices or system dirs
   if (/>\s*\/(dev|etc|boot|sys|proc)\b/.test(c)) return true;
   // destructive git — discards or rewrites history / working-tree state.
-  //   checkout: `-f`/`--force` (force-overwrite), `git checkout .`
-  //     (path-restore of the whole tree) and `checkout … -- <path>` all
-  //     discard uncommitted work. A plain `git checkout <branch>` (branch
-  //     switch, reversible) is deliberately NOT flagged.
+  //   checkout: `-f`/`--force` (force-overwrite), `git checkout .` / `./`
+  //     / `./<path>` (path-restore of the whole tree or a subtree) and
+  //     `checkout … -- <path>` all discard uncommitted work. A plain
+  //     `git checkout <branch>` (branch switch, reversible) is deliberately
+  //     NOT flagged. NOTE: a bare single-path discard without `--`
+  //     (`git checkout src/x.ts`) is syntactically ambiguous with a branch
+  //     name and is a known uncaught form — not full coverage.
   //   stash: `drop`/`clear`/`pop` remove stash state irreversibly
   //     (`stash`/`list`/`show`/`apply` keep it and stay unflagged).
   if (/\bgit\b/.test(c) &&
-      /(push\b[^|;&]*(--force|-f\b|--force-with-lease)|push\s+[^\s]*\s+\+|reset\s+--hard|clean\s+-[a-z]*[fd]|filter-branch|reflog\s+expire|update-ref\s+-d|branch\s+-d{1,2}\b|checkout\b[^|;&]*(\s-f\b|\s--force\b|\s--(\s|$)|\s\.(\s|$))|stash\s+(drop|clear|pop)\b|restore\b)/.test(c)) return true;
+      /(push\b[^|;&]*(--force|-f\b|--force-with-lease)|push\s+[^\s]*\s+\+|reset\s+--hard|clean\s+-[a-z]*[fd]|filter-branch|reflog\s+expire|update-ref\s+-d|branch\s+-d{1,2}\b|checkout\b[^|;&]*(\s-f\b|\s--force\b|\s--(\s|$)|\s\.(\s|$|\/))|stash\s+(drop|clear|pop)\b|restore\b)/.test(c)) return true;
   // power / process control
   if (/(^|\s|;|&&|\|\||\()(shutdown|reboot|halt|poweroff|kill|killall|pkill)\b/.test(c)) return true;
   if (/(^|\s)init\s+0\b/.test(c)) return true;

--- a/telegram-plugin/tests/scoped-approval.test.ts
+++ b/telegram-plugin/tests/scoped-approval.test.ts
@@ -270,6 +270,29 @@ describe('isDestructiveBashCommand — fail-closed denylist', () => {
     expect(timeBoxRule('Bash', bashInput('git status `rm -rf x`'))).toBeNull()
   })
 
+  it('flags destructive git checkout / stash forms that discard work (fail-closed)', () => {
+    for (const cmd of [
+      // checkout that discards uncommitted working-tree changes
+      'git checkout .', 'git checkout -f', 'git checkout -f main', 'git checkout --force',
+      'git checkout -- file.ts', 'git checkout HEAD -- .', 'git checkout HEAD~1 -- src/x.ts',
+      // stash forms that irreversibly remove stash state
+      'git stash drop', 'git stash drop stash@{2}', 'git stash clear', 'git stash pop',
+    ]) {
+      expect(isDestructiveBashCommand(cmd), cmd).toBe(true)
+    }
+  })
+
+  it('does NOT flag safe git checkout / stash forms (no over-broadening)', () => {
+    for (const cmd of [
+      // branch switches / creation are reversible
+      'git checkout main', 'git checkout -b feature', 'git checkout feature.branch',
+      // stash inspection / non-removing forms keep the stash
+      'git stash', 'git stash list', 'git stash show', 'git stash apply',
+    ]) {
+      expect(isDestructiveBashCommand(cmd), cmd).toBe(false)
+    }
+  })
+
   it('does NOT flag ordinary safe commands', () => {
     for (const cmd of [
       'git status', 'git log --oneline -5', 'git diff', 'npm test', 'npm run build',

--- a/telegram-plugin/tests/scoped-approval.test.ts
+++ b/telegram-plugin/tests/scoped-approval.test.ts
@@ -275,6 +275,10 @@ describe('isDestructiveBashCommand — fail-closed denylist', () => {
       // checkout that discards uncommitted working-tree changes
       'git checkout .', 'git checkout -f', 'git checkout -f main', 'git checkout --force',
       'git checkout -- file.ts', 'git checkout HEAD -- .', 'git checkout HEAD~1 -- src/x.ts',
+      // `./` and `./<path>` are common spellings of `.` — same whole-tree /
+      // subtree discard; git refnames forbid a branch starting with `./`,
+      // so gating these carries no false-positive risk.
+      'git checkout ./', 'git checkout ./src',
       // stash forms that irreversibly remove stash state
       'git stash drop', 'git stash drop stash@{2}', 'git stash clear', 'git stash pop',
     ]) {


### PR DESCRIPTION
## Summary

Closes four fail-open safety-gate holes from the 2026-07-11 W2 review. Safety controls must be **deterministic and fail CLOSED**, never fail-open or prompt-dependent.

### Fixes

**1. MEDIUM/HIGH — `ms-365-write-pretool.ts` gate failed OPEN on tool-name drift.**
`isGatedMs365Tool` gated only an unverified write allowlist, so a renamed or newly-added MS-365 write tool bypassed approval entirely. Inverted to fail-closed: added an explicit `KNOWN_SAFE_MS365_READ_TOOLS` read allowlist; any unrecognized `mcp__ms-365__` tool (known write **or** renamed/new) now **requires approval**. A missing read-tool name only costs an extra prompt on a read (safe) — never an ungated write.

**2. MEDIUM — verdict poll correlated by scope, not `requestId`.**
Concurrent same-scope writes (e.g. two `ms-365:write:(new)` uploads) could cross-attribute one write's approval to another. Added `lookupDecisionByRequestId` in the kernel (resolves nonce → `decision_id` link, evaluates only that request's own decision, with cross-agent isolation) plus the `approval_lookup_by_request` IPC op, and switched the hook's poll to correlate strictly by `request_id`.

**3. LOW — hook failed OPEN on missing `SWITCHROOM_AGENT_NAME`.**
Now fails closed (block): a gated write with no agent identity can't be proven approved.

**4. MEDIUM — destructive-git detector failed open and was untested.**
`git checkout .`, `git checkout -f`, `git stash drop|clear|pop` slipped through and re-enabled auto-allow. Tightened the checkout/stash patterns (plain branch switches like `git checkout main` / `-b feature` stay unflagged) and added tests.

## Tests
- `src/vault/approvals/kernel.test.ts` (bun) — verdict correlation, cross-agent isolation, revoke.
- `src/cli/ms-365-write-pretool.test.ts` (vitest) — fail-closed inversion, read-allowlist integrity.
- `telegram-plugin/tests/scoped-approval.test.ts` (vitest) — destructive git checkout/stash + no over-broadening.

Every new test was proven to bite via a source revert. `tsc --noEmit` clean; scoped lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)