### PR TITLE
harden auth OAuth + credential-store writes; scope host-control idempotency cache

### DIFF
--- a/src/auth/account-store-hardening.test.ts
+++ b/src/auth/account-store-hardening.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Security-hardening pins for the Anthropic account store (2026-07-11 review).
+ *
+ *   - F2: credential/meta writes MUST route through the shared hardened atomic
+ *     primitive (`../util/atomic.js:atomicWriteJsonSync`) — fsync +
+ *     O_NOFOLLOW|O_EXCL tempfile open — instead of the old local
+ *     `writeFileSync('w') + rename` (no fsync, followed symlinks, no O_EXCL).
+ *   - F5: account dirs MUST be created 0700 (not the default ~0755), so a
+ *     co-resident local UID can't traverse to the OAuth-secret inodes.
+ *
+ * The atomic primitive's own no-symlink-follow guarantee is proven in
+ * `src/util/atomic.test.ts`; here we prove the account store ROUTES through it
+ * (bites a revert of F2) and that the dir mode is 0700 (bites a revert of F5).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Wrap the hardened primitive so we can assert the account store calls it,
+// while still delegating to the REAL implementation (so file contents, mode,
+// and symlink-safety behaviour are exercised for real).
+vi.mock("../util/atomic.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../util/atomic.js")>();
+  return { ...actual, atomicWriteJsonSync: vi.fn(actual.atomicWriteJsonSync) };
+});
+
+import { atomicWriteJsonSync } from "../util/atomic.js";
+import {
+  writeAccountCredentials,
+  writeAccountMeta,
+  accountDir,
+  accountCredentialsPath,
+} from "./account-store.js";
+
+const CREDS = {
+  claudeAiOauth: {
+    accessToken: "at",
+    refreshToken: "rt",
+    expiresAt: Date.now() + 3_600_000,
+  },
+};
+
+describe("account-store hardening (sec F2/F5)", () => {
+  let home: string;
+  beforeEach(() => {
+    home = fs.mkdtempSync(join(tmpdir(), "acct-store-hardening-"));
+    vi.mocked(atomicWriteJsonSync).mockClear();
+  });
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("F5: account dir is created 0700 on credential write", () => {
+    writeAccountCredentials("acct@example.com", CREDS, home);
+    const mode = fs.statSync(accountDir("acct@example.com", home)).mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+
+  it("F5: account dir is created 0700 on meta write", () => {
+    writeAccountMeta("m@example.com", { createdAt: Date.now() }, home);
+    const mode = fs.statSync(accountDir("m@example.com", home)).mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+
+  it("F2: credential write routes through the hardened atomicWriteJsonSync", () => {
+    writeAccountCredentials("s@example.com", CREDS, home);
+    expect(vi.mocked(atomicWriteJsonSync)).toHaveBeenCalled();
+    expect(vi.mocked(atomicWriteJsonSync).mock.calls[0]![0]).toBe(
+      accountCredentialsPath("s@example.com", home),
+    );
+  });
+
+  it("F2: meta write routes through the hardened atomicWriteJsonSync", () => {
+    writeAccountMeta("m2@example.com", { createdAt: Date.now() }, home);
+    expect(vi.mocked(atomicWriteJsonSync)).toHaveBeenCalled();
+  });
+
+  it("F2: credentials.json lands at 0600, a real file, no tempfile leak", () => {
+    writeAccountCredentials("f@example.com", CREDS, home);
+    const p = accountCredentialsPath("f@example.com", home);
+    expect(fs.statSync(p).mode & 0o777).toBe(0o600);
+    expect(fs.lstatSync(p).isSymbolicLink()).toBe(false);
+    const leaks = fs
+      .readdirSync(accountDir("f@example.com", home))
+      .filter((n) => n.includes(".tmp-"));
+    expect(leaks).toHaveLength(0);
+  });
+
+  it("F2: a symlink pre-planted at credentials.json is NOT written through", () => {
+    const dir = accountDir("v@example.com", home);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const victim = join(home, "victim-secret");
+    fs.writeFileSync(victim, "UNTOUCHED");
+    const dest = accountCredentialsPath("v@example.com", home);
+    fs.symlinkSync(victim, dest);
+
+    writeAccountCredentials("v@example.com", CREDS, home);
+
+    // rename(2) replaced the symlink with a real file; the victim the symlink
+    // pointed at was never written through.
+    expect(fs.readFileSync(victim, "utf8")).toBe("UNTOUCHED");
+    expect(fs.lstatSync(dest).isSymbolicLink()).toBe(false);
+    expect(JSON.parse(fs.readFileSync(dest, "utf8")).claudeAiOauth.accessToken).toBe("at");
+  });
+});

--- a/src/auth/account-store.ts
+++ b/src/auth/account-store.ts
@@ -36,11 +36,10 @@ import {
   renameSync,
   rmSync,
   statSync,
-  writeFileSync,
 } from "node:fs";
-import { randomBytes } from "node:crypto";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { atomicWriteJsonSync } from "../util/atomic.js";
 
 const LABEL_MAX = 64;
 // Account labels accept email-friendly characters so operators can
@@ -268,8 +267,14 @@ export function writeAccountCredentials(
   home: string = homedir(),
 ): void {
   validateAccountLabel(label);
-  mkdirSync(accountDir(label, home), { recursive: true });
-  atomicWriteJson(accountCredentialsPath(label, home), enrichClaudeCreds(value));
+  // 0o700 — account dirs hold OAuth secrets and must not be world-traversable
+  // (sec F5; matches the Google/MS storage dirs). The broker runs as root, so
+  // a 0o755 dir would let any local UID traverse to the credentials inode.
+  mkdirSync(accountDir(label, home), { recursive: true, mode: 0o700 });
+  // atomicWriteJsonSync: fsync + O_NOFOLLOW|O_EXCL tempfile open (sec F2) so a
+  // pre-planted symlink at the tempfile path can't redirect the root broker's
+  // credential write through it.
+  atomicWriteJsonSync(accountCredentialsPath(label, home), enrichClaudeCreds(value));
 }
 
 /**
@@ -322,8 +327,11 @@ export function writeAccountMeta(
   home: string = homedir(),
 ): void {
   validateAccountLabel(label);
-  mkdirSync(accountDir(label, home), { recursive: true });
-  atomicWriteJson(accountMetaPath(label, home), value);
+  // 0o700 + hardened atomic write — same rationale as writeAccountCredentials
+  // (sec F2/F5). meta.json carries account identity/quota state alongside the
+  // creds and must get the same symlink-resistant, fsync'd write.
+  mkdirSync(accountDir(label, home), { recursive: true, mode: 0o700 });
+  atomicWriteJsonSync(accountMetaPath(label, home), value);
 }
 
 /** Update a single meta field, preserving the rest. Creates if absent. */
@@ -438,23 +446,10 @@ export function renameAccount(
 
 /* ── Atomic write helper ─────────────────────────────────────────────── */
 
-/**
- * Write a JSON value atomically: tempfile in the same directory + rename.
- * Same-directory rename keeps it on a single filesystem (rename(2) is
- * only atomic intra-fs). Cleans the tempfile on failure so a crash
- * mid-write doesn't leave a sibling turd.
- */
-function atomicWriteJson(destPath: string, value: unknown, mode = 0o600): void {
-  const tmp = `${destPath}.tmp-${process.pid}-${randomBytes(4).toString("hex")}`;
-  try {
-    writeFileSync(tmp, JSON.stringify(value, null, 2) + "\n", { mode });
-    renameSync(tmp, destPath);
-  } catch (err) {
-    try {
-      rmSync(tmp, { force: true });
-    } catch {
-      /* already gone */
-    }
-    throw err;
-  }
-}
+// The local `atomicWriteJson` (tempfile + rename, no fsync, `'w'` open that
+// followed symlinks and lacked O_EXCL) was replaced by the shared
+// `atomicWriteJsonSync` from `../util/atomic.js` (sec F2): it fsyncs the
+// tempfile and opens it O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW, so a pre-planted
+// symlink at the tempfile path fails the open (EEXIST/ELOOP) instead of
+// letting the root broker write a secret through it. Output is byte-identical
+// (`JSON.stringify(value, null, 2) + "\n"`, mode 0o600).

--- a/src/drive/oauth.test.ts
+++ b/src/drive/oauth.test.ts
@@ -17,7 +17,10 @@ import {
   buildLoopbackAuthUrl,
   requestDeviceCode,
   OAuthTierRejected,
+  generatePkcePair,
+  exchangeAuthCode,
 } from "./oauth.js";
+import { createHash } from "node:crypto";
 
 const cfg = {
   client_id: "cid",
@@ -345,21 +348,74 @@ describe("revokeRefreshToken", () => {
   });
 });
 
+describe("PKCE (sec F1 — Google loopback parity with Microsoft)", () => {
+  it("generatePkcePair returns a verifier and its S256 challenge", () => {
+    const { verifier, challenge } = generatePkcePair();
+    // Verifier is base64url of 32 random bytes → 43 chars, unreserved set.
+    expect(verifier).toMatch(/^[A-Za-z0-9\-_]{43}$/);
+    expect(challenge).toMatch(/^[A-Za-z0-9\-_]+$/);
+    // Challenge MUST be base64url(SHA-256(verifier)).
+    const expected = createHash("sha256").update(verifier).digest("base64url");
+    expect(challenge).toBe(expected);
+  });
+
+  it("generatePkcePair is non-deterministic across calls", () => {
+    expect(generatePkcePair().verifier).not.toBe(generatePkcePair().verifier);
+  });
+
+  it("buildLoopbackAuthUrl carries code_challenge + code_challenge_method=S256", () => {
+    const url = buildLoopbackAuthUrl(cfg, "http://127.0.0.1:54321", "abc123", "chal-xyz");
+    const u = new URL(url);
+    expect(u.searchParams.get("code_challenge")).toBe("chal-xyz");
+    expect(u.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("exchangeAuthCode sends code_verifier when provided", async () => {
+    let sentBody = "";
+    const fakeFetch = mock(async (_url: string, init?: RequestInit) => {
+      sentBody = String(init?.body ?? "");
+      return new Response(
+        JSON.stringify({ access_token: "at", expires_in: 3600, token_type: "Bearer" }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+    await exchangeAuthCode(cfg, "code-1", "http://127.0.0.1:9/", "verifier-abc", fakeFetch);
+    const params = new URLSearchParams(sentBody);
+    expect(params.get("code_verifier")).toBe("verifier-abc");
+    expect(params.get("grant_type")).toBe("authorization_code");
+  });
+
+  it("exchangeAuthCode omits code_verifier when not provided (OOB path)", async () => {
+    let sentBody = "";
+    const fakeFetch = mock(async (_url: string, init?: RequestInit) => {
+      sentBody = String(init?.body ?? "");
+      return new Response(
+        JSON.stringify({ access_token: "at", expires_in: 3600, token_type: "Bearer" }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+    await exchangeAuthCode(cfg, "code-1", "urn:ietf:wg:oauth:2.0:oob", undefined, fakeFetch);
+    expect(new URLSearchParams(sentBody).has("code_verifier")).toBe(false);
+  });
+});
+
 describe("desktop-loopback flow", () => {
   it("buildLoopbackAuthUrl includes redirect_uri, state, code response_type", () => {
-    const url = buildLoopbackAuthUrl(cfg, "http://127.0.0.1:54321", "abc123");
+    const url = buildLoopbackAuthUrl(cfg, "http://127.0.0.1:54321", "abc123", "chal");
     expect(url).toContain("redirect_uri=http%3A%2F%2F127.0.0.1%3A54321");
     expect(url).toContain("state=abc123");
     expect(url).toContain("response_type=code");
     expect(url).toContain("access_type=offline");
   });
 
-  it("happy path: simulates Google redirect with valid state and exchanges code", async () => {
+  it("happy path: simulates Google redirect with valid state and exchanges code with a code_verifier", async () => {
     const fakeFetch = mock(async (_url: string, init?: RequestInit) => {
       const body = String(init?.body ?? "");
       expect(body).toContain("grant_type=authorization_code");
       expect(body).toContain("code=auth-code-xyz");
       expect(body).toContain("redirect_uri=http");
+      // sec F1: the loopback exchange MUST carry a PKCE verifier.
+      expect(new URLSearchParams(body).get("code_verifier")).toBeTruthy();
       return new Response(
         JSON.stringify({
           access_token: "at-loop",
@@ -396,6 +452,10 @@ describe("desktop-loopback flow", () => {
     expect(tok.access_token).toBe("at-loop");
     expect(tok.refresh_token).toBe("rt-loop");
     expect(capturedAuthUrl).toContain("state=");
+    // sec F1: the consent URL the browser opened MUST carry the S256 challenge.
+    const authU = new URL(capturedAuthUrl);
+    expect(authU.searchParams.get("code_challenge")).toBeTruthy();
+    expect(authU.searchParams.get("code_challenge_method")).toBe("S256");
   });
 
   it("rejects callback with mismatched state and never exchanges", async () => {

--- a/src/drive/oauth.ts
+++ b/src/drive/oauth.ts
@@ -297,17 +297,25 @@ export async function exchangeOobCode(
   code: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<TokenResponse> {
-  return exchangeAuthCode(cfg, code, "urn:ietf:wg:oauth:2.0:oob", fetchImpl);
+  // OOB is a paste flow with no loopback interception surface, so it
+  // carries no PKCE verifier (pass `undefined`).
+  return exchangeAuthCode(cfg, code, "urn:ietf:wg:oauth:2.0:oob", undefined, fetchImpl);
 }
 
 /**
  * Shared authorization_code → token exchange. Used by both OOB-paste and
  * desktop-loopback flows; only the redirect_uri differs.
+ *
+ * `codeVerifier` is the PKCE verifier (sec F1). The desktop-loopback flow
+ * passes it so Google can bind the exchange to the `code_challenge` it saw
+ * on the auth URL; the OOB flow passes `undefined` (no PKCE). When set, it
+ * is sent as `code_verifier` on the token request.
  */
 export async function exchangeAuthCode(
   cfg: OAuthClientConfig,
   code: string,
   redirectUri: string,
+  codeVerifier?: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<TokenResponse> {
   const body = new URLSearchParams({
@@ -317,6 +325,9 @@ export async function exchangeAuthCode(
     grant_type: "authorization_code",
     redirect_uri: redirectUri,
   });
+  if (codeVerifier !== undefined && codeVerifier.length > 0) {
+    body.set("code_verifier", codeVerifier);
+  }
   const res = await fetchImpl("https://oauth2.googleapis.com/token", {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
@@ -336,12 +347,36 @@ import * as crypto from "node:crypto";
 import { spawn } from "node:child_process";
 
 /**
- * Build the loopback consent URL targeting an ephemeral local redirect_uri.
+ * Generate a PKCE code verifier + S256 challenge pair for the OAuth code
+ * flow. RFC 7636: verifier is 43-128 chars unreserved set
+ * (`[A-Z][a-z][0-9]-._~`); challenge is base64url(SHA-256(verifier)).
+ *
+ * Mirrors `src/microsoft/oauth.ts:generatePkcePair` exactly — the two
+ * OAuth modules keep the same PKCE primitive rather than cross-importing
+ * (avoids a drive↔microsoft dep). Used by the desktop-loopback flow to
+ * close the Google-vs-Microsoft asymmetry (sec F1): the loopback redirect
+ * lands on `127.0.0.1`, so an authorization code intercepted on the
+ * loopback interface (a co-resident local process racing the callback)
+ * is useless without the verifier held only in this process's memory.
+ */
+export function generatePkcePair(): { verifier: string; challenge: string } {
+  const verifier = crypto.randomBytes(32).toString("base64url");
+  const challenge = crypto
+    .createHash("sha256")
+    .update(verifier)
+    .digest("base64url");
+  return { verifier, challenge };
+}
+
+/**
+ * Build the loopback consent URL targeting an ephemeral local redirect_uri,
+ * carrying the PKCE `code_challenge` (S256).
  */
 export function buildLoopbackAuthUrl(
   cfg: OAuthClientConfig,
   redirectUri: string,
   state: string,
+  codeChallenge: string,
 ): string {
   const u = new URL("https://accounts.google.com/o/oauth2/auth");
   u.searchParams.set("client_id", cfg.client_id);
@@ -351,6 +386,8 @@ export function buildLoopbackAuthUrl(
   u.searchParams.set("access_type", "offline");
   u.searchParams.set("prompt", "consent");
   u.searchParams.set("state", state);
+  u.searchParams.set("code_challenge", codeChallenge);
+  u.searchParams.set("code_challenge_method", "S256");
   return u.toString();
 }
 
@@ -424,6 +461,10 @@ export async function runLoopbackOAuth(
   const fetchImpl = opts.fetchImpl ?? fetch;
   const openImpl = opts.openImpl ?? openBrowser;
   const state = crypto.randomBytes(16).toString("hex");
+  // PKCE (sec F1): bind the loopback code exchange to a per-flow verifier so
+  // an intercepted authorization code on 127.0.0.1 can't be redeemed without
+  // the verifier held only in this process's memory.
+  const { verifier, challenge } = generatePkcePair();
 
   // Capture the callback via a single-shot promise.
   let server: http.Server | null = null;
@@ -518,7 +559,7 @@ export async function runLoopbackOAuth(
           return;
         }
         const redirectUri = `http://${host}:${addr.port}`;
-        const authUrl = buildLoopbackAuthUrl(cfg, redirectUri, state);
+        const authUrl = buildLoopbackAuthUrl(cfg, redirectUri, state, challenge);
         // Fire-and-forget the browser open; if it fails the user has the URL.
         openImpl(authUrl)
           .then((opened) => opts.onAuthUrl?.(authUrl, opened))
@@ -537,7 +578,7 @@ export async function runLoopbackOAuth(
     if (timer) clearTimeout(timer);
     await closeServer();
 
-    return await exchangeAuthCode(cfg, code, redirectUri, fetchImpl);
+    return await exchangeAuthCode(cfg, code, redirectUri, verifier, fetchImpl);
   } finally {
     if (timer) clearTimeout(timer);
     await closeServer();

--- a/src/host-control/idempotency-caller-scope.test.ts
+++ b/src/host-control/idempotency-caller-scope.test.ts
@@ -1,0 +1,154 @@
+/**
+ * sec host-control-F1 — the 15s idempotency cache must (a) never be consulted
+ * BEFORE the authz gate, and (b) be scoped by caller identity so one caller can
+ * never be served — or collide with — another caller's cached mutation result.
+ *
+ * Pre-fix, `handleLine` consulted the cache first and keyed it on the bare
+ * `idempotency_key ?? request_id` (no caller scope). So caller B replaying
+ * caller A's idempotency_key would be handed A's cached result BEFORE
+ * `checkGate` ran — an unauthorized, unaudited cross-caller leak.
+ *
+ * We drive the private `handleLine` directly (same private-method-via-cast
+ * pattern as `reconcile-rollback-output.test.ts`) with a fake socket that
+ * captures the response frame. `agent_restart` records its status entry and
+ * returns `started` synchronously (the child is fire-and-forget), so no real
+ * fleet mutation is needed; `switchroomBin` points at `/bin/true` so the
+ * detached child exits cleanly.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HostdServer, type ServerOptions } from "./server.js";
+import { decodeResponse, type HostdRequest, type HostdResponse } from "./protocol.js";
+import type { SocketIdentity } from "./peercred.js";
+
+/** Minimal fake Socket capturing what the daemon writes back. */
+function fakeSocket() {
+  const frames: string[] = [];
+  return {
+    frames,
+    write: (buf: string | Buffer) => {
+      frames.push(buf.toString());
+      return true;
+    },
+    end: () => undefined,
+    response(): HostdResponse {
+      // Last written frame is the response (denials & cache-serves both write one).
+      const last = frames[frames.length - 1]!;
+      return decodeResponse(last.replace(/\n$/, ""));
+    },
+  };
+}
+
+function restartReq(
+  request_id: string,
+  targetName: string,
+  idempotency_key: string,
+): HostdRequest {
+  return {
+    v: 1,
+    request_id,
+    op: "agent_restart",
+    args: { name: targetName },
+    idempotency_key,
+  } as HostdRequest;
+}
+
+type ServerInternals = {
+  handleLine: (
+    line: string,
+    caller: SocketIdentity,
+    socket: ReturnType<typeof fakeSocket>,
+  ) => Promise<void>;
+  statusByRequestId: Map<string, unknown>;
+};
+
+describe("idempotency cache — caller-scoped & gate-first (sec F1)", () => {
+  let home: string;
+  let server: HostdServer;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "hostd-idem-"));
+    const opts: ServerOptions = {
+      homeDir: home,
+      agentUids: {},
+      config: {
+        agents: {
+          alpha: { admin: true },
+          beta: { admin: true },
+          gamma: { admin: false },
+        },
+      },
+      switchroomBin: "/bin/true",
+      auditLogPath: join(home, "audit.log"),
+      allowNonLinux: true,
+    };
+    server = new HostdServer(opts);
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  const internals = () => server as unknown as ServerInternals;
+
+  it("does NOT serve caller A's cached result to a DIFFERENT admin caller sharing the idempotency_key", async () => {
+    const alpha: SocketIdentity = { kind: "agent", name: "alpha" };
+    const beta: SocketIdentity = { kind: "agent", name: "beta" };
+
+    // Caller A (alpha, admin) restarts "svc" with a shared idempotency_key.
+    const sockA = fakeSocket();
+    await internals().handleLine(
+      JSON.stringify(restartReq("reqA", "svc", "SHARED")),
+      alpha,
+      sockA,
+    );
+    expect(sockA.response().result).toBe("started");
+    expect(internals().statusByRequestId.has("reqA")).toBe(true);
+
+    // Caller B (beta, admin) sends the SAME idempotency_key. With caller
+    // scoping, B must run its OWN dispatch (record reqB), NOT be short-
+    // circuited onto A's cached entry.
+    const sockB = fakeSocket();
+    await internals().handleLine(
+      JSON.stringify(restartReq("reqB", "svc", "SHARED")),
+      beta,
+      sockB,
+    );
+    expect(sockB.response().result).toBe("started");
+    // The bite: pre-fix, B is served A's cache and never dispatches, so reqB
+    // is never recorded. Post-fix, B dispatches and records its own entry.
+    expect(internals().statusByRequestId.has("reqB")).toBe(true);
+  });
+
+  it("runs the authz gate BEFORE the cache — an unauthorized caller is denied, not served the cache", async () => {
+    const alpha: SocketIdentity = { kind: "agent", name: "alpha" };
+    const gamma: SocketIdentity = { kind: "agent", name: "gamma" };
+
+    // Caller A (alpha, admin) caches a cross-agent restart of "svc".
+    const sockA = fakeSocket();
+    await internals().handleLine(
+      JSON.stringify(restartReq("reqA", "svc", "SHARED2")),
+      alpha,
+      sockA,
+    );
+    expect(sockA.response().result).toBe("started");
+
+    // Caller B (gamma, NON-admin) replays the shared idempotency_key on a
+    // cross-agent restart (not self-targeting → requires admin).
+    const sockB = fakeSocket();
+    await internals().handleLine(
+      JSON.stringify(restartReq("reqB", "svc", "SHARED2")),
+      gamma,
+      sockB,
+    );
+    const resp = sockB.response();
+    // The bite: pre-fix, gamma is handed alpha's cached "started" ahead of the
+    // gate. Post-fix, the gate denies gamma before the cache is ever consulted.
+    expect(resp.result).toBe("denied");
+    expect(String(resp.error ?? "")).toMatch(/admin/i);
+    expect(internals().statusByRequestId.has("reqB")).toBe(false);
+  });
+});

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -479,6 +479,21 @@ function defaultApprovalId(): string {
 }
 
 /**
+ * Caller-identity scope prefix for the idempotency cache key (sec
+ * host-control-F1). Two different callers must never share an idempotency
+ * bucket — otherwise caller B replaying caller A's idempotency_key (or a
+ * request_id collision) could be served A's cached mutation result. The
+ * agent-name / operator distinction is authoritative because it's derived
+ * from the daemon's own bind path (`socketPathToIdentity`), which a caller
+ * cannot influence. The scope prefix (`operator` / `agent:<slug>`) contains
+ * no space, and agent slugs contain no space, so the single-space separator
+ * makes the scoped key unambiguous across distinct callers.
+ */
+function idempotencyScope(caller: SocketIdentity): string {
+  return caller.kind === "agent" ? `agent:${caller.name}` : "operator";
+}
+
+/**
  * Map a deny `ApprovalResult` to the appropriate error string for
  * the config_propose_edit response. (#1762)
  *
@@ -964,9 +979,29 @@ export class HostdServer {
       return;
     }
 
-    const idempotencyKey = req.idempotency_key ?? req.request_id;
     const now = Date.now();
     this.evictExpiredIdempotency(now);
+
+    // sec host-control-F1: the authz gate MUST run BEFORE any idempotency
+    // short-circuit. Previously the cache was consulted first, so a cached
+    // result could be handed back before `checkGate` ever ran — and the
+    // cache key was NOT scoped by caller, so caller B replaying caller A's
+    // idempotency_key could be served A's mutation result, unaudited and
+    // unauthorized. Gating first closes both halves: an unauthorized caller
+    // is denied (and the denial is audited) before the cache is touched.
+    const denied = this.checkGate(req, caller);
+    if (denied) {
+      const resp = deniedResponse(req.request_id, denied);
+      await this.writeAudit({ caller, req, resp });
+      socket.write(encodeResponse(resp));
+      socket.end();
+      return;
+    }
+
+    // Idempotency key is scoped by caller identity (sec host-control-F1) so
+    // one caller's bucket can never collide with — or surface — another
+    // caller's cached result. Consulted only after the gate above passes.
+    const idempotencyKey = `${idempotencyScope(caller)} ${req.idempotency_key ?? req.request_id}`;
     const prior = this.idempotencyKeys.get(idempotencyKey);
     if (prior && now - prior.ts < IDEMPOTENCY_WINDOW_MS) {
       // Reuse the prior response if available. Note: only mutating
@@ -983,15 +1018,6 @@ export class HostdServer {
       }
     }
     this.idempotencyKeys.set(idempotencyKey, { request_id: req.request_id, ts: now });
-
-    const denied = this.checkGate(req, caller);
-    if (denied) {
-      const resp = deniedResponse(req.request_id, denied);
-      await this.writeAudit({ caller, req, resp });
-      socket.write(encodeResponse(resp));
-      socket.end();
-      return;
-    }
 
     // ── #1841 operator-attest 2nd factor (RFC §5.4) ──────────────────
     // Runs AFTER the admin/allowlist gate: attestation is an additional

--- a/src/util/atomic.test.ts
+++ b/src/util/atomic.test.ts
@@ -84,6 +84,29 @@ describe("atomicWriteFileSync", () => {
     const p = join(dir, "nope", "deep", "x");
     expect(() => atomicWriteFileSync(p, "data")).toThrow();
   });
+
+  // Deterministic guard for the flagship symlink-safety property (#1410):
+  // the tempfile open MUST carry O_EXCL (refuse a pre-existing path) and
+  // O_NOFOLLOW (refuse a symlink at the final component). The destination-
+  // symlink test above passes even on pre-fix code because rename(2) defeats a
+  // dest symlink regardless of open flags — so it does NOT pin these flags. If
+  // someone stripped O_NOFOLLOW|O_EXCL from TMP_OPEN_FLAGS, only this test fails.
+  it("opens the tempfile with O_EXCL and O_NOFOLLOW (symlink-proof create)", () => {
+    const openSpy = vi.spyOn(fs, "openSync");
+    try {
+      atomicWriteFileSync(join(dir, "x"), "data");
+      const tmpOpen = openSpy.mock.calls.find((c) => String(c[0]).includes(".tmp-"));
+      expect(tmpOpen).toBeDefined();
+      const flags = tmpOpen![1] as number;
+      expect(flags & fs.constants.O_EXCL).toBe(fs.constants.O_EXCL);
+      // O_NOFOLLOW is Linux/macOS-only; TMP_OPEN_FLAGS uses `?? 0` where absent.
+      if (fs.constants.O_NOFOLLOW) {
+        expect(flags & fs.constants.O_NOFOLLOW).toBe(fs.constants.O_NOFOLLOW);
+      }
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
 });
 
 describe("writeConfigFileSync (#2457 — EBUSY bind-mount fallback)", () => {


### PR DESCRIPTION
Security-hardening batch from the 2026-07-11 review. Single-concern: the highest-value secret (OAuth creds) written by a root broker. Scoped tests + lint local; CI is the merge authority.

## Findings fixed

**auth F1 (MEDIUM) — Google loopback OAuth had NO PKCE** (asymmetric with Microsoft, which already does S256). `src/drive/oauth.ts`: added `generatePkcePair()` (mirrors `src/microsoft/oauth.ts` exactly), `buildLoopbackAuthUrl` now sends `code_challenge` + `code_challenge_method=S256`, `exchangeAuthCode` sends `code_verifier`, and `runLoopbackOAuth` generates the pair and threads it through. The OOB paste flow (no loopback interception surface) stays PKCE-free (`exchangeOobCode` passes `undefined`).

**auth F2 (MEDIUM) — Anthropic credential/meta writes skipped fsync + O_NOFOLLOW|O_EXCL.** `src/auth/account-store.ts`'s local `atomicWriteJson` used `writeFileSync('w') + rename` — no fsync, and the `'w'` open followed symlinks / lacked `O_EXCL` (pre-planted symlink at the tmp path → root broker writes creds through it). Now routed through the shared `src/util/atomic.ts:atomicWriteJsonSync` (fsync + `O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW`). Output byte-identical.

**auth F5 (LOW) — Anthropic account dirs created ~0755 (world-traversable).** Now created `0700`, matching the Google/MS storage dirs.

**host-control F1 (LOW) — idempotency short-circuit ran BEFORE the gate and was not caller-scoped.** `src/host-control/server.ts`: `checkGate` now runs first; the 15s idempotency cache key is scoped by caller identity (`operator` / `agent:<slug>`). A caller can no longer be served — or collide with — another caller's cached mutation result ahead of authz.

## Deferred (assessed, not clean/self-contained — dedicated PRs)

- **auth F3** (refresh-lease has no real `flock`): Node core lacks `flock`; a durable fix needs a native addon or an `O_EXCL` lockfile + PID/staleness reclamation protocol. The current code documents this as best-effort for the v1 single-instance broker. Materially expands diff + dependency surface → defer.
- **auth F4** (mirror-fanout lstat-then-act TOCTOU): needs `openat` / `O_DIRECTORY|O_NOFOLLOW` per-component resolution from a trusted root fd, which Node core doesn't expose. Mitigating: the final credential write already goes through `atomicWriteFileSync`, so the secret itself can't be written through a swapped symlink; residual exposure is the `mkdirSync(claudeDir,{recursive})` after the lstat sweep. Deep change with its own concurrency test surface → defer.

## Tests (assert outcomes; each proven to bite via `git show`-based revert)

- `src/drive/oauth.test.ts` (bun): auth URL carries `code_challenge`+`S256`; `exchangeAuthCode` sends `code_verifier` (and omits it on the OOB path); loopback happy-path carries both. 42 pass. Bite: neutralizing the PKCE emission → 3 fail.
- `src/auth/account-store-hardening.test.ts` (vitest): dir `0700`; writes route through `atomicWriteJsonSync`; `0600` real file, no tempfile leak; pre-planted dest symlink not written through. 6 pass. Bite: `git show HEAD` revert of account-store → 4 fail.
- `src/host-control/idempotency-caller-scope.test.ts` (vitest): cache not shared across two admin callers; gate runs before cache (unauthorized caller denied, not served). 2 pass. Bite: `git show HEAD` revert of server → 2 fail.

Commands: `bun test src/drive/oauth.test.ts src/microsoft/oauth.test.ts` (88 pass); `./node_modules/.bin/vitest run src/auth src/host-control` (631 pass) + the two new files; `npx tsc --noEmit` clean; `npm run lint` clean (incl. `check-plugin-references`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)