### PR TITLE
feat(telegram): send-gate on-by-default escape hatch (SWITCHROOM_TELEGRAM_SEND_GATE=0 to disable)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5468,9 +5468,10 @@ const recordFloodWindow = makeFloodWindowRecorder(FLOOD_WINDOWS_PATH)
 // edit floor + no-op-edit skip + PRIORITY SHEDDING + DEGRADED MODE). Wrapped
 // HERE at the robustApiCall layer so every Bot API call routed through the
 // standard retry policy also transits one scheduler (no call site can bypass
-// it). Feature-flagged, default OFF: when SWITCHROOM_TELEGRAM_SEND_GATE !== '1'
-// the gate is a pure passthrough and the retry policy behaves exactly as
-// before. Composes with #3094's pre-call flood gate and #3097's non-essential
+// it). ON BY DEFAULT (escape hatch): only when SWITCHROOM_TELEGRAM_SEND_GATE is
+// explicitly set to 0/false/off/no is the gate a pure passthrough and the retry
+// policy behaves exactly as before. Composes with #3094's pre-call flood gate
+// and #3097's non-essential
 // drop policy — those decide whether a call happens at all; this paces the
 // calls that do.
 //

--- a/telegram-plugin/send-gate.test.ts
+++ b/telegram-plugin/send-gate.test.ts
@@ -87,14 +87,33 @@ describe('send-gate: feature flag', () => {
     expect(calls.map((c) => c.label)).toEqual(['v1', 'v2'])
   })
 
-  it('sendGateEnabledFromEnv follows the SWITCHROOM_*=== "1" convention', () => {
-    expect(sendGateEnabledFromEnv({} as NodeJS.ProcessEnv)).toBe(false)
+  it('sendGateEnabledFromEnv is ON BY DEFAULT (escape hatch, not opt-in)', () => {
+    // Unset → enabled. This assertion is load-bearing: it fails if the default
+    // is ever flipped back to off.
+    expect(sendGateEnabledFromEnv({} as NodeJS.ProcessEnv)).toBe(true)
     expect(
-      sendGateEnabledFromEnv({ SWITCHROOM_TELEGRAM_SEND_GATE: '0' } as unknown as NodeJS.ProcessEnv),
-    ).toBe(false)
-    expect(
-      sendGateEnabledFromEnv({ SWITCHROOM_TELEGRAM_SEND_GATE: '1' } as unknown as NodeJS.ProcessEnv),
+      sendGateEnabledFromEnv({ SWITCHROOM_TELEGRAM_SEND_GATE: undefined } as NodeJS.ProcessEnv),
     ).toBe(true)
+  })
+
+  it('sendGateEnabledFromEnv disables only on explicit off values (safety valve)', () => {
+    for (const off of ['0', 'false', 'off', 'no', 'FALSE', 'Off', ' no ', '  0 ']) {
+      expect(
+        sendGateEnabledFromEnv({
+          SWITCHROOM_TELEGRAM_SEND_GATE: off,
+        } as unknown as NodeJS.ProcessEnv),
+      ).toBe(false)
+    }
+  })
+
+  it('sendGateEnabledFromEnv stays enabled for any other value', () => {
+    for (const on of ['1', 'true', 'on', 'yes', 'enabled', '', 'anything']) {
+      expect(
+        sendGateEnabledFromEnv({
+          SWITCHROOM_TELEGRAM_SEND_GATE: on,
+        } as unknown as NodeJS.ProcessEnv),
+      ).toBe(true)
+    }
   })
 })
 

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -50,11 +50,13 @@
  *
  * SAFETY / ROLLOUT
  * ----------------
- * Feature-flagged and default-OFF (`SWITCHROOM_TELEGRAM_SEND_GATE=1` to enable,
- * following the `SWITCHROOM_*=== '1'` gateway flag convention). When disabled,
- * `gate()` is a pure passthrough to the wrapped call — zero behaviour change.
- * This is PR 1 of 3; priority-class shedding + degraded mode (PR 2) and
- * observability + operator alert (PR 3) build on the counters exposed here.
+ * ON BY DEFAULT in every install — an escape hatch, not an opt-in feature.
+ * `SWITCHROOM_TELEGRAM_SEND_GATE=0` (or `false`/`off`/`no`) is the safety valve
+ * that disables it without a rebuild, following the repo's default-on kill-
+ * switch convention (`midTurnFloorEnabled`, `SWITCHROOM_RATE_LIMIT_OVERAGE=0`).
+ * When disabled, `gate()` is a pure passthrough to the wrapped call — zero
+ * behaviour change. Priority-class shedding + degraded mode and observability +
+ * operator alert build on the counters exposed here.
  *
  * DETERMINISM / TESTABILITY
  * -------------------------
@@ -1038,7 +1040,17 @@ export function createSendGate(config: SendGateConfig): SendGate {
   return { gate, openFloodWindow, stats }
 }
 
-/** Read the feature flag using the standard `SWITCHROOM_*=== '1'` convention. */
+/**
+ * The send gate is an ESCAPE HATCH, not an opt-in feature: it is ON BY DEFAULT
+ * in every install and can be disabled as a safety valve. Mirrors the repo's
+ * default-on kill-switch convention (`midTurnFloorEnabled`, `PIN_STATUS_WHILE_
+ * WORKING`, `SWITCHROOM_RATE_LIMIT_OVERAGE`): enabled unless
+ * `SWITCHROOM_TELEGRAM_SEND_GATE` is explicitly set to a falsey/off value
+ * (`0`/`false`/`off`/`no`, case-insensitive, trimmed). Unset → enabled.
+ */
 export function sendGateEnabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env.SWITCHROOM_TELEGRAM_SEND_GATE === '1'
+  const v = env.SWITCHROOM_TELEGRAM_SEND_GATE
+  if (v == null) return true
+  const t = v.trim().toLowerCase()
+  return !(t === '0' || t === 'false' || t === 'off' || t === 'no')
 }


### PR DESCRIPTION
## Summary

Inverts the Telegram outbound send gate from **default-OFF opt-in** to **ON BY DEFAULT escape hatch**, per Ken (2026-07-12). The gate is now enabled in every install and can be disabled as a safety valve with `SWITCHROOM_TELEGRAM_SEND_GATE=0`.

## Why

The send gate (`telegram-plugin/send-gate.ts`) is the one global token-bucket scheduler that every Bot API call transits at the `robustApiCall` layer — the only thing that composes all the per-surface throttles into a global/per-chat ceiling. It shipped **default-OFF** (opt-in via `=1`) as a deliberate staged rollout, which meant **no outbound throttle actually ran** in production. On 2026-07-11 `klanker` was flood-banned (429 retry_after ~hours) precisely because the per-surface throttles added up with no global cap and tripped a per-bot-token flood ban — the exact failure mode the gate exists to prevent (#3084).

The blocking correctness defects that justified keeping it off were fixed this morning in **#3147** (`7677e8e0`), so it is now safe to default on. A throttle you have to opt into is not a throttle; it should be an escape hatch you opt *out* of.

## What changed

- `sendGateEnabledFromEnv` now returns **true unless explicitly disabled**, mirroring the repo's existing default-on kill-switch convention (`midTurnFloorEnabled`, `PIN_STATUS_WHILE_WORKING`, `SWITCHROOM_RATE_LIMIT_OVERAGE=0`):
  ```ts
  const v = env.SWITCHROOM_TELEGRAM_SEND_GATE
  if (v == null) return true
  const t = v.trim().toLowerCase()
  return !(t === '0' || t === 'false' || t === 'off' || t === 'no')
  ```
  Off values (case-insensitive, trimmed): `0`, `false`, `off`, `no`. Anything else — including unset, `1`, `true` — is ON.
- Doc comments in `send-gate.ts` (SAFETY/ROLLOUT + the predicate) and the wiring comment in `gateway/gateway.ts` rewritten to describe the escape-hatch semantics.
- `send-gate.test.ts`: the flag test rewritten to assert the new contract — unset → enabled, explicit off values → disabled, any other value → enabled. The "unset → enabled" assertion is **load-bearing** (verified: reverting the predicate to `=== '1'` fails exactly those 2 assertions).

**Not touched:** throttle rates, token buckets, priority classes, shedding, degraded mode. Only the enablement default + docs/tests.

## Test plan

- `./node_modules/.bin/vitest run telegram-plugin/send-gate.test.ts` → **29 passed** (vitest runner; the file imports `vitest`).
- `npm run lint` → **clean** (tsc + all 8 guard scripts, including `check-bot-api-wrapping`).
- Load-bearing proof: temporarily reverted predicate to `v === '1'` → the "ON BY DEFAULT" test failed (2 assertions, `expected false to be true`); restored → green.

## Risk

Low. The gate's behaviour when enabled was hardened in #3147. The safety valve (`=0`/`false`/`off`/`no`) lets any operator disable it without a rebuild if a regression surfaces. Job spec: this advances the "always available" outcome — outbound throttling is what keeps an agent from flood-banning itself off Telegram.

## Note

Reactions are handled in a **separate PR** (`fix/send-gate-reactions`); this PR is scoped to the enablement default only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)