### PR TITLE
fix(telegram): route setMessageReaction through the send gate + flood breaker

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5530,6 +5530,65 @@ const swallowingApiCall = createSwallowingRetryApiCall(
 )
 
 /**
+ * The ONE seam every `setMessageReaction` in this gateway goes through (#3155).
+ *
+ * Reactions are cosmetic outbound traffic. Before this seam, ~13 raw
+ * `bot.api.setMessageReaction(...)` / `lockedBot.api.setMessageReaction(...)`
+ * call sites fired reactions OUTSIDE the send gate AND the flood circuit
+ * breaker, so:
+ *
+ *   (a) reaction spam was never PACED/SHED by the gate when it's on — a busy
+ *       turn's status-reaction churn added straight onto the per-bot flood
+ *       budget the REPLIES need; and
+ *   (b) a 429 from a reaction was INVISIBLE to the breaker — the flood window
+ *       is only learned through the retry module's `onFloodWait` hook, which a
+ *       raw `bot.api` call never reaches. Reactions were a residual flood
+ *       vector even with the gate ON.
+ *
+ * Routing through `robustApiCall` (= chat-lock → send-gate → retry/breaker,
+ * the SAME path every other outbound call takes) with
+ * `priorityClass: 'cosmetic'` fixes both: the gate paces/sheds reactions under
+ * pressure, and a 429 runs `onFloodWait` so the window is recorded. Callers
+ * keep their own fire-and-forget / `.catch(() => {})` / `await` semantics —
+ * this returns the promise and does NOT swallow.
+ */
+const gatedSetMessageReaction = (
+  chatId: string,
+  messageId: number,
+  reaction: ReactionTypeEmoji[],
+): Promise<unknown> =>
+  robustApiCall(() => lockedBot.api.setMessageReaction(chatId, messageId, reaction), {
+    chat_id: chatId,
+    verb: 'set-message-reaction',
+    priorityClass: 'cosmetic',
+  })
+
+/** React with a single emoji through the gate (cosmetic). Wraps {@link gatedSetMessageReaction}. */
+const sendReaction = (
+  chatId: string,
+  messageId: number,
+  emoji: ReactionTypeEmoji['emoji'],
+): Promise<unknown> => gatedSetMessageReaction(chatId, messageId, [{ type: 'emoji', emoji }])
+
+/**
+ * Bot-API surface handed to `redactAuthCodeMessage` (#488) so its 🔑 reaction
+ * routes through the send gate + flood breaker like every other reaction
+ * (#3155). The OAuth-code DELETE stays raw/best-effort exactly as before — its
+ * own `.then(onOk, onErr)` logging (the "token may still be visible" breadcrumb)
+ * must keep firing, which a swallowing wrapper would suppress.
+ */
+const redactAuthCodeApi = {
+  deleteMessage: (chatId: string, messageId: number) =>
+    // allow-raw-bot-api: auth-code redact delete stays raw/best-effort (behavior unchanged, #488); #3155 gates only the reaction.
+    bot.api.deleteMessage(chatId, messageId),
+  setMessageReaction: (
+    chatId: string,
+    messageId: number,
+    reaction: Array<{ type: 'emoji'; emoji: string }>,
+  ) => gatedSetMessageReaction(chatId, messageId, reaction as ReactionTypeEmoji[]),
+}
+
+/**
  * The wrapper for NON-ESSENTIAL sends that must NEVER retry (#3084).
  *
  * A typing indicator is disposable: if it fails, the correct answer is to drop
@@ -14659,9 +14718,11 @@ async function executeReact(args: Record<string, unknown>): Promise<unknown> {
   if (!args.message_id) throw new Error('react: message_id is required')
   if (!args.emoji) throw new Error('react: emoji is required')
   assertAllowedChat(String(args.chat_id ?? ''))
-  await lockedBot.api.setMessageReaction(String(args.chat_id ?? ''), Number(args.message_id), [
-    { type: 'emoji', emoji: args.emoji as ReactionTypeEmoji['emoji'] },
-  ])
+  await sendReaction(
+    String(args.chat_id ?? ''),
+    Number(args.message_id),
+    args.emoji as ReactionTypeEmoji['emoji'],
+  )
   return { content: [{ type: 'text', text: 'reacted' }] }
 }
 
@@ -18044,9 +18105,7 @@ function maybeEarlyAckReaction(ctx: Context, from: NonNullable<Context['from']>)
   if (activeTurnStartedAt.has(statusKey(chatId, threadId))) return
   const access = loadAccess()
   if (!access.allowFrom.includes(String(from.id))) return
-  void bot.api.setMessageReaction(chatId, msgId, [
-    { type: 'emoji', emoji: '👀' as ReactionTypeEmoji['emoji'] },
-  ]).catch(() => {})
+  void sendReaction(chatId, msgId, '👀' as ReactionTypeEmoji['emoji']).catch(() => {})
   // #2527: log the early-ack fire so operators can see how often the
   // fast pre-coalesce DM path triggers vs. the controller path.
   logStreamingEvent({ kind: 'early_ack_reaction', chatId, messageId: msgId, emoji: '👀' })
@@ -18287,9 +18346,7 @@ async function handleInbound(
     )
     if (inFlight) {
       if (msgId != null) {
-        void bot.api.setMessageReaction(chat_id, msgId, [
-          { type: 'emoji', emoji: '⚡' as ReactionTypeEmoji['emoji'] },
-        ]).catch(() => {})
+        void sendReaction(chat_id, msgId, '⚡' as ReactionTypeEmoji['emoji']).catch(() => {})
       }
       await executeHaltNow('stop-keyword')
     }
@@ -18334,9 +18391,7 @@ async function handleInbound(
       `in_flight=${toolFlightTracker.inFlightCount()}\n`,
     )
     if (msgId != null) {
-      void bot.api.setMessageReaction(chat_id, msgId, [
-        { type: 'emoji', emoji: '⚡' as ReactionTypeEmoji['emoji'] },
-      ]).catch(() => {})
+      void sendReaction(chat_id, msgId, '⚡' as ReactionTypeEmoji['emoji']).catch(() => {})
     }
     if (interrupt.emptyBody) {
       // #3020: empty `!` is a pure halt (no replacement body) — same shared
@@ -18470,9 +18525,7 @@ async function handleInbound(
     })
     if (msgId != null) {
       const emoji = behavior === 'allow' ? '✅' : '❌'
-      void bot.api.setMessageReaction(chat_id, msgId, [
-        { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] },
-      ]).catch(() => {})
+      void sendReaction(chat_id, msgId, emoji as ReactionTypeEmoji['emoji']).catch(() => {})
     }
     return
   }
@@ -18528,7 +18581,7 @@ async function handleInbound(
         )
       }
       // Redact the OAuth code paste from chat history (#488).
-      redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+      redactAuthCodeMessage(redactAuthCodeApi as never, chat_id, msgId ?? null, line => process.stderr.write(line))
       return
     }
     // Stale — drop the pending entry but let the message fall through
@@ -18560,7 +18613,7 @@ async function handleInbound(
           '_Still finishing the previous paste — one moment._',
           { html: true },
         )
-        redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+        redactAuthCodeMessage(redactAuthCodeApi as never, chat_id, msgId ?? null, line => process.stderr.write(line))
         return
       }
       const result = await submitLoopbackRedirect(pendingLoop, text.trim())
@@ -18573,7 +18626,7 @@ async function handleInbound(
           { html: true },
         )
         // Redact the pasted redirect (carries the OAuth code) from history.
-        redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+        redactAuthCodeMessage(redactAuthCodeApi as never, chat_id, msgId ?? null, line => process.stderr.write(line))
         return
       }
       if (result.retryable) {
@@ -18586,7 +18639,7 @@ async function handleInbound(
           { html: true },
         )
         // Redact even a rejected paste — it may still carry a live code.
-        redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+        redactAuthCodeMessage(redactAuthCodeApi as never, chat_id, msgId ?? null, line => process.stderr.write(line))
         return
       }
       // Non-retryable — the flow is spent. Kill the CLI child before
@@ -18601,7 +18654,7 @@ async function handleInbound(
         `**/auth ${pendingLoop.provider} add failed:** ${escapeHtmlForTg(result.reason)}`,
         { html: true },
       )
-      redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+      redactAuthCodeMessage(redactAuthCodeApi as never, chat_id, msgId ?? null, line => process.stderr.write(line))
       return
     }
     // Stale — the intercept window has closed. Kill the child and drop the
@@ -18621,7 +18674,7 @@ async function handleInbound(
   // reference AND a code/error param), so ordinary chatter mentioning
   // localhost flows through untouched. Redact and drop rather than forward.
   if (shouldConsumeLoopbackPaste(text)) {
-    redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+    redactAuthCodeMessage(redactAuthCodeApi as never, chat_id, msgId ?? null, line => process.stderr.write(line))
     await switchroomReply(
       ctx,
       '_That looked like an OAuth redirect/code, so I removed it from chat and did not forward it. ' +
@@ -18656,7 +18709,7 @@ async function handleInbound(
       // Single-use code so a third party can't replay it after exchange,
       // but plaintext OAuth tokens in chat history are still poor
       // hygiene. The helper handles delete + 🔑 reaction silently.
-      redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+      redactAuthCodeMessage(redactAuthCodeApi as never, chat_id, msgId ?? null, line => process.stderr.write(line))
       return
     }
     pendingReauthFlows.delete(interceptKey)
@@ -19119,12 +19172,12 @@ async function handleInbound(
       if (isSteering) {
         // Explicit steer: mark with 🤝 on the inbound message; leave the
         // existing StatusReactionController running for the in-flight turn.
-        void bot.api.setMessageReaction(chat_id, msgId, [{ type: 'emoji', emoji: '🤝' }]).catch(() => {})
+        void sendReaction(chat_id, msgId, '🤝').catch(() => {})
       } else if (priorTurnInFlight) {
         // Queued mid-turn message (new default): don't touch the existing
         // controller; just ack the inbound message with 👀 so the user
         // knows we received it, without disrupting the in-flight reaction.
-        void bot.api.setMessageReaction(chat_id, msgId, [{ type: 'emoji', emoji: '👀' }]).catch(() => {})
+        void sendReaction(chat_id, msgId, '👀').catch(() => {})
         // #203: time-to-ack metric — measure gateway-receive → ack-post delta.
         logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
       } else {
@@ -19167,9 +19220,7 @@ async function handleInbound(
         // msgId here and use it as the reaction-session token in log events.
         const ctrlTurnToken = `${chat_id}:${msgId}`
         const ctrl = new StatusReactionController(async (emoji) => {
-          await bot.api.setMessageReaction(chat_id, msgId, [
-            { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] },
-          ])
+          await sendReaction(chat_id, msgId, emoji as ReactionTypeEmoji['emoji'])
           // #203: every status-reaction transition is a user-visible signal.
           signalTracker.noteSignal(key, Date.now())
         }, allowedReactions, {
@@ -19252,9 +19303,7 @@ async function handleInbound(
         }
       }
     } else if (access.ackReaction) {
-      void bot.api.setMessageReaction(chat_id, msgId, [
-        { type: 'emoji', emoji: access.ackReaction as ReactionTypeEmoji['emoji'] },
-      ]).catch(() => {})
+      void sendReaction(chat_id, msgId, access.ackReaction as ReactionTypeEmoji['emoji']).catch(() => {})
       // #203: time-to-ack metric for the custom-ack-reaction path.
       logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
     }
@@ -20597,7 +20646,7 @@ async function sweepBeforeSelfRestart(): Promise<void> {
   try {
     await sweepActiveReactions(
       agentDir,
-      (chatId, messageId) => lockedBot.api.setMessageReaction(chatId, messageId, [{ type: 'emoji', emoji: '👍' as ReactionTypeEmoji['emoji'] }]),
+      (chatId, messageId) => sendReaction(chatId, messageId, '👍' as ReactionTypeEmoji['emoji']),
       { log: (msg) => process.stderr.write(`telegram gateway: pre-restart reaction sweep — ${msg}\n`) },
     )
   } catch (err) {
@@ -26826,9 +26875,7 @@ async function handleAckOnly(
     const chat_id = String(ctx.chat!.id)
     const msgId = ctx.message?.message_id
     if (msgId != null) {
-      void bot.api.setMessageReaction(chat_id, msgId, [
-        { type: 'emoji', emoji: (opts.emoji ?? '👀') as ReactionTypeEmoji['emoji'] },
-      ]).catch(() => {})
+      void sendReaction(chat_id, msgId, (opts.emoji ?? '👀') as ReactionTypeEmoji['emoji']).catch(() => {})
     }
     const prefix = opts.warn ? 'WARN ' : ''
     process.stderr.write(`telegram gateway: ${prefix}inbound ${kind} ack-only chat_id=${chat_id} from=${ctx.from?.id ?? '?'}\n`)
@@ -26861,9 +26908,7 @@ async function handleRefusal(
     const msgId = ctx.message?.message_id
     const messageThreadId = ctx.message?.message_thread_id
     if (msgId != null) {
-      void bot.api.setMessageReaction(chat_id, msgId, [
-        { type: 'emoji', emoji: '🚫' as ReactionTypeEmoji['emoji'] },
-      ]).catch(() => {})
+      void sendReaction(chat_id, msgId, '🚫' as ReactionTypeEmoji['emoji']).catch(() => {})
     }
     // #1075: thread-id-bearing — swallow on THREAD_NOT_FOUND so a
     // deleted topic doesn't crash the refusal handler.
@@ -27922,7 +27967,7 @@ process.on('SIGINT', () => void shutdown('SIGINT'))
   if (startupAgentDir != null) {
     void sweepActiveReactions(
       startupAgentDir,
-      (chatId, messageId) => lockedBot.api.setMessageReaction(chatId, messageId, [{ type: 'emoji', emoji: '👍' as ReactionTypeEmoji['emoji'] }]),
+      (chatId, messageId) => sendReaction(chatId, messageId, '👍' as ReactionTypeEmoji['emoji']),
       { log: (msg) => process.stderr.write(`telegram gateway: startup reaction sweep — ${msg}\n`) },
     )
   }

--- a/telegram-plugin/tests/inbound-message-types.test.ts
+++ b/telegram-plugin/tests/inbound-message-types.test.ts
@@ -206,7 +206,11 @@ describe('inbound message-type helpers: handleAckOnly + handleRefusal', () => {
     const fnStart = SRC.indexOf('async function handleAckOnly(')
     const fnSlice = SRC.slice(fnStart, fnStart + 2000)
     expect(fnSlice).toContain('gate(ctx)')
-    expect(fnSlice).toContain('setMessageReaction')
+    // #3155: the reaction now routes through the gated `sendReaction` helper
+    // (send gate + flood breaker, cosmetic) instead of a raw
+    // `bot.api.setMessageReaction`. The invariant is unchanged: it gates, THEN
+    // reacts.
+    expect(fnSlice).toContain('sendReaction(')
   })
 
   it('handleAckOnly drops non-allowlisted senders silently', () => {

--- a/telegram-plugin/tests/reaction-gate-routing.test.ts
+++ b/telegram-plugin/tests/reaction-gate-routing.test.ts
@@ -1,0 +1,173 @@
+/**
+ * #3155 — `setMessageReaction` must route through the send gate + flood breaker.
+ *
+ * Before this change ~13 raw `bot.api.setMessageReaction(...)` /
+ * `lockedBot.api.setMessageReaction(...)` call sites (early-ack 👀, status
+ * reactions, stop/interrupt ⚡, permission verdict ✅/❌, refusal 🚫, ack-only,
+ * the MCP `react` tool, the crash-recovery sweeps, the auth-code 🔑 redact)
+ * fired reactions OUTSIDE both:
+ *
+ *   (a) the send gate — so reaction churn was never paced/shed under flood
+ *       pressure even with the gate ON; and
+ *   (b) the flood circuit breaker — a 429 from a reaction never reached the
+ *       retry module's `onFloodWait` hook, so the ban went unrecorded.
+ *
+ * Reactions were therefore a residual flood vector even when the gate is on.
+ * The gateway now funnels every reaction through ONE seam,
+ * `robustApiCall(() => lockedBot.api.setMessageReaction(...), { priorityClass:
+ * 'cosmetic', verb: 'set-message-reaction' })`.
+ *
+ * Two levels of coverage:
+ *   1. BEHAVIOURAL — compose the real `send-gate` + `retry-api-call` modules the
+ *      same way `gateway.ts` wires `robustApiCall`, and prove a cosmetic
+ *      reaction is (a) shed when a flood window is open and (b) visible to
+ *      `onFloodWait` on a 429.
+ *   2. LOAD-BEARING SOURCE SCAN — assert the gateway has exactly ONE runtime
+ *      `setMessageReaction` call and that it is the cosmetic seam. This FAILS if
+ *      any future change re-introduces a raw (ungated, breaker-blind) reaction.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { createSendGate, type Clock } from '../send-gate.js'
+import { createRetryApiCall } from '../retry-api-call.js'
+import { errors } from './fake-bot-api.js'
+
+const GATEWAY_SRC = fileURLToPath(new URL('../gateway/gateway.ts', import.meta.url))
+
+/** Fixed-time clock; `sleep` is a no-op so nothing actually waits under test. */
+function fixedClock(now: number): Clock {
+  return { now: () => now, sleep: () => Promise.resolve() }
+}
+
+/**
+ * Reconstruct the gateway's outbound wiring for reactions: `robustApiCall =
+ * gate(rawRetry)`, and a `sendReaction` closure that tags the call `cosmetic`
+ * exactly like `gatedSetMessageReaction` in gateway.ts.
+ */
+function wireReactionPath(opts: {
+  clock: Clock
+  enabled: boolean
+  windowUntilTs?: number
+  onFloodWait?: (retryAfterSec: number) => void
+}) {
+  const setMessageReaction = vi.fn(async () => true as const)
+  const sendGate = createSendGate({
+    enabled: opts.enabled,
+    clock: opts.clock,
+    ...(opts.windowUntilTs != null
+      ? { initialWindows: [{ scopeKey: 'global', untilTs: opts.windowUntilTs }] }
+      : {}),
+  })
+  const rawRetry = createRetryApiCall({
+    maxRetries: 2,
+    sleep: async () => {},
+    ...(opts.onFloodWait ? { onFloodWait: opts.onFloodWait } : {}),
+  })
+  const robustApiCall = <T>(
+    fn: () => Promise<T>,
+    o?: Parameters<typeof rawRetry<T>>[1],
+  ): Promise<T> => sendGate.gate(() => rawRetry(fn, o), o)
+
+  // Mirrors gateway.ts `gatedSetMessageReaction` / `sendReaction`.
+  const sendReaction = (chatId: string, messageId: number, emoji: string): Promise<unknown> =>
+    robustApiCall(() => setMessageReaction(chatId, messageId, [{ type: 'emoji', emoji }]), {
+      chat_id: chatId,
+      verb: 'set-message-reaction',
+      priorityClass: 'cosmetic',
+    })
+
+  return { sendReaction, setMessageReaction, sendGate }
+}
+
+describe('#3155 reactions route through the send gate (cosmetic)', () => {
+  it('SHEDS a reaction while a flood window is open (paced/shed by the gate)', async () => {
+    const now = 1_000_000
+    const { sendReaction, setMessageReaction, sendGate } = wireReactionPath({
+      clock: fixedClock(now),
+      enabled: true,
+      windowUntilTs: now + 60_000, // an open global ban window
+    })
+
+    const result = await sendReaction('chatA', 42, '👀')
+
+    // Cosmetic + a covering window ⇒ shed: the API is NEVER hit, the promise
+    // resolves undefined (fire-and-forget callers .catch nothing), and the gate
+    // counts the shed.
+    expect(setMessageReaction).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+    expect(sendGate.stats().global.shed).toBe(1)
+  })
+
+  it('does NOT shed when the gate is OFF (proves the gate is what sheds)', async () => {
+    const now = 1_000_000
+    const { sendReaction, setMessageReaction } = wireReactionPath({
+      clock: fixedClock(now),
+      enabled: false, // gate disabled ⇒ pure passthrough
+      windowUntilTs: now + 60_000,
+    })
+
+    await sendReaction('chatA', 42, '👀')
+
+    // Flag OFF ⇒ the reaction still fires (the window only bites when enabled).
+    expect(setMessageReaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('records a 429 on a reaction to the flood breaker via onFloodWait', async () => {
+    const now = 1_000_000
+    const onFloodWait = vi.fn()
+    const { sendReaction, setMessageReaction } = wireReactionPath({
+      clock: fixedClock(now),
+      enabled: true, // gate on, no open window ⇒ the cosmetic call is admitted
+      onFloodWait,
+    })
+    // The reaction send hits a Telegram 429 flood-wait.
+    setMessageReaction.mockRejectedValue(errors.floodWait(7, 'setMessageReaction'))
+
+    // Fire-and-forget semantics: callers swallow. The point is the SIDE EFFECT.
+    await sendReaction('chatA', 42, '🤝').catch(() => {})
+
+    // The reaction actually reached the API (was admitted, not shed)...
+    expect(setMessageReaction).toHaveBeenCalled()
+    // ...and its 429 was recorded by the breaker — the whole gap this closes.
+    expect(onFloodWait).toHaveBeenCalledWith(7)
+  })
+})
+
+describe('#3155 load-bearing: gateway.ts sends no reaction raw', () => {
+  const src = readFileSync(GATEWAY_SRC, 'utf-8')
+  const lines = src.split('\n')
+
+  /** Non-comment source lines that call `(bot|lockedBot).api.setMessageReaction`. */
+  const rawReactionLines = lines
+    .map((text, i) => ({ text, n: i + 1 }))
+    .filter(({ text }) => {
+      const t = text.trim()
+      if (t.startsWith('*') || t.startsWith('//') || t.startsWith('/*')) return false
+      return /\b(bot|lockedBot)\.api\.setMessageReaction\b/.test(text)
+    })
+
+  it('has EXACTLY ONE runtime setMessageReaction callsite (the shared seam)', () => {
+    // If this fails with >1, a raw reaction was re-introduced somewhere —
+    // ungated and invisible to the flood breaker. Route it through
+    // `sendReaction` / `gatedSetMessageReaction` instead.
+    expect(rawReactionLines).toHaveLength(1)
+  })
+
+  it('the sole seam is tagged cosmetic and routed through robustApiCall', () => {
+    const seamLine = rawReactionLines[0]!.n
+    // Look at the seam line + a small window for its opts object.
+    const window = lines.slice(seamLine - 2, seamLine + 6).join('\n')
+    expect(window).toContain('robustApiCall(')
+    expect(window).toContain("priorityClass: 'cosmetic'")
+    expect(window).toContain("verb: 'set-message-reaction'")
+  })
+
+  it('no reaction is fired as a raw fire-and-forget bot.api call', () => {
+    // Belt-and-braces: the old `bot.api.setMessageReaction(...).catch(() => {})`
+    // shape must be gone entirely.
+    expect(src).not.toMatch(/bot\.api\.setMessageReaction\([^)]*\)\s*\.catch/)
+    // And the fire-and-forget callers now go through the helper.
+    expect(src).toContain('void sendReaction(')
+  })
+})

--- a/telegram-plugin/tests/secret-detect-oauth-code.test.ts
+++ b/telegram-plugin/tests/secret-detect-oauth-code.test.ts
@@ -210,10 +210,11 @@ describe('pendingReauthFlows intercept — deleteMessage sequencing (Blocker 1)'
     const window = src.slice(interceptIdx, interceptIdx + 2000)
     // Allow the optional 4th `log` argument added in #561 (diagnostic
     // sink for redaction failures) — required is the first three args.
-    // `bot.api` may be cast (e.g. `bot.api as never`) for the local
-    // BotApi-vs-grammy-Api type mismatch cleanup in #623; `msgId` may
-    // be narrowed (`msgId ?? null`).
-    expect(window).toMatch(/redactAuthCodeMessage\(bot\.api(?:\s+as\s+\w+)?,\s*chat_id,\s*msgId(?:\s*\?\?\s*null)?(?:,\s*[^)]+)?\)/)
+    // The first arg is the injected BotApi surface: historically `bot.api`
+    // (optionally cast, #623), now the gated `redactAuthCodeApi` adapter whose
+    // reaction routes through the send gate + flood breaker (#3155). `msgId`
+    // may be narrowed (`msgId ?? null`).
+    expect(window).toMatch(/redactAuthCodeMessage\((?:bot\.api|redactAuthCodeApi)(?:\s+as\s+\w+)?,\s*chat_id,\s*msgId(?:\s*\?\?\s*null)?(?:,\s*[^)]+)?\)/)
   })
 
   it('redaction lands AFTER the success/error reply renders', () => {


### PR DESCRIPTION
## Summary

Reactions were the last outbound Telegram surface bypassing the #3084 send gate. ~13 raw `bot.api.setMessageReaction(...)` / `lockedBot.api.setMessageReaction(...)` call sites — the early-ack 👀, the `StatusReactionController` emitter, stop/interrupt ⚡, the permission verdict ✅/❌, the refusal 🚫, ack-only handlers, the MCP `react` tool, both crash-recovery sweeps — plus the auth-code 🔑 redact (`redactAuthCodeMessage`) fired reactions **outside both the send gate and the flood circuit breaker**.

This routes all of them through one shared seam, classified `cosmetic`.

## Why

Even with the send gate **on**, reactions bypassed it entirely:

- **Not paced/shed under pressure.** A busy turn's status-reaction churn (👀 → ✍ → ⚡ → 👍, per transition) went straight onto the per-bot flood budget the *replies* need. The gate's cosmetic class exists precisely to shed this under load; reactions never entered it.
- **Invisible to the flood breaker.** The #2923/#3084 breaker only learns about a 429 through the retry module's `onFloodWait` hook. A raw `bot.api.*` call never reaches it, so a 429 *from a reaction* was never recorded — the window wasn't opened, later sends didn't suppress, and the ban could be prolonged.

So reactions were a residual flood vector even after the gate is turned on. **This pairs with `fix/send-gate-default-on`** — flipping the gate default is only fully effective once reactions actually go through it.

## Approach — one shared helper (DRY, no callsite missed)

Rather than edit 14 call sites ad hoc, a single seam funnels every reaction through the canonical outbound path:

```ts
const gatedSetMessageReaction = (chatId, messageId, reaction) =>
  robustApiCall(() => lockedBot.api.setMessageReaction(chatId, messageId, reaction),
    { chat_id: chatId, verb: 'set-message-reaction', priorityClass: 'cosmetic' })

const sendReaction = (chatId, messageId, emoji) =>
  gatedSetMessageReaction(chatId, messageId, [{ type: 'emoji', emoji }])
```

`robustApiCall` = chat-lock → send-gate → retry/breaker — the *same* path every other outbound call already takes. Reactions now (a) shed under an open flood window and (b) record their 429s via `onFloodWait`.

Preserved behavior:
- Fire-and-forget / `.catch(() => {})` / `await` semantics kept at every callsite (the helper returns the promise, does not swallow).
- The `status-reactions.ts` per-message ~3.5s debounce is untouched — it composes on top of the gate.
- Reaction semantics (which emoji, when) unchanged; only the transport path changed.
- The auth-code redact's `deleteMessage` stays raw/best-effort so its "token may still be visible in chat" breadcrumb log keeps firing (a swallowing wrapper would suppress it); only its 🔑 reaction is gated.

`setMessageReaction` is **not** in `check-bot-api-wrapping`'s policed pattern (reactions carry no `message_thread_id`, so they're outside the THREAD_NOT_FOUND blast radius) — no allowlist churn.

## Test plan

New `telegram-plugin/tests/reaction-gate-routing.test.ts`:
- **Behavioural** (real `send-gate` + `retry-api-call` wired as the gateway wires `robustApiCall`): a cosmetic reaction is **shed** while a flood window is open (API never hit, `stats().shed` increments), does **not** shed when the gate is off, and a **429 on a reaction reaches `onFloodWait`** (breaker visibility).
- **Load-bearing source scan**: asserts `gateway.ts` has **exactly one** runtime `setMessageReaction` callsite and that it is the cosmetic seam. **Fails if a raw reaction is ever re-introduced** — verified by temporarily injecting a raw `bot.api.setMessageReaction(...).catch()` (2 assertions failed), then reverting.

Updated two pre-existing structural tests to the new call shape (intent unchanged): `inbound-message-types` (gate-then-react) and `secret-detect-oauth-code` (redaction-helper-called in the intercept).

Verification (scoped, per the two-runner rule):
- `npm run lint` — clean (incl. `check-bot-api-wrapping`, `tsc --noEmit`).
- Full bun CI command `bun test admin-commands gateway registry secret-detect tests channel-envelope-safety.test.ts` — **7578 pass, 5 skip, 1 fail**. The single failure (`approval-hold-record` "falls back … when the shared dir is not writable") is a pre-existing **root-DAC-bypass** artifact: it chmods a dir `0o555` to simulate non-writability, but the harness runs as uid 0 here so the write succeeds and the fallback path isn't taken. The test's own comment assumes a non-root agent uid (10001+); CI runs non-root. This PR touches nothing in the approval-hold path.

## Risk

Low. Transport-only change; no reaction semantics altered. Reactions now participate in per-chat FIFO ordering (via `lockedBot`) and cosmetic shedding — the intended, more-correct behavior. Under an open flood window a reaction resolves `undefined` (shed) instead of firing, which is exactly the desired posture during a ban.

Job spec: `reference/jobs/` — always-available / on-the-leash (the gateway must stay deliverable under flood pressure; reactions must not feed a ban).

🤖 Generated with [Claude Code](https://claude.com/claude-code)