### PR TITLE
fix(telegram): classify transient burst 429 as rate-limited, not quota-exhausted

### DIFF
--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -41,6 +41,44 @@ export interface ModelUnavailableDetection {
   raw: string
 }
 
+// ─── Transient-burst signals (canonical, single source of truth) ─────────────
+
+/**
+ * Explicit markers of a TRANSIENT per-account burst / server-side throttle —
+ * a short-term RPM/burst 429 that Claude Code retries internally with backoff,
+ * NOT the 5h/7d subscription usage-limit wall. Anthropic emits these with a
+ * `rate_limit_error` whose wording explicitly NEGATES the account-quota reading
+ * ("not your usage limit" / "would exceed your account's rate limit … try again
+ * later"). Keyed on the explicit negation so a genuine wall that merely contains
+ * the word "limit" is never down-classified.
+ *
+ * Exported so `session-tail.ts` classifies a 429 by wording against THIS list
+ * rather than hand-rolling its own copy (keeps the two in sync — issue #2922).
+ */
+export const transientUpstreamSignals = [
+  'not your usage limit',
+  'not your account',
+  "not your account's",
+  'temporarily limiting requests',
+  'temporarily rate',
+  'server is temporarily',
+  'would exceed your account’s rate limit',
+  "would exceed your account's rate limit",
+]
+
+/**
+ * True when `text` carries an EXPLICIT transient-burst marker (see
+ * `transientUpstreamSignals`). Never throws on weird input. Used to keep the
+ * calm rate-limit path and the model-unavailable detector reading the same
+ * canonical signal list.
+ */
+export function isTransientUpstreamSignal(text: string): boolean {
+  if (typeof text !== 'string' || text.length === 0) return false
+  const sample = text.length > 16_384 ? text.slice(0, 16_384) : text
+  const lower = sample.toLowerCase()
+  return transientUpstreamSignals.some(s => lower.includes(s))
+}
+
 // ─── Detection ───────────────────────────────────────────────────────────────
 
 /**
@@ -77,17 +115,9 @@ export function detectModelUnavailable(
   // failover that self-cancels and leaves the turn dead. These are upstream
   // throttles Claude Code retries internally with backoff — classify them as
   // `overload` (the calm rate-limit path) BEFORE the quota substrings run, so
-  // the negation is honoured and no failover is announced.
-  const transientUpstreamSignals = [
-    'not your usage limit',
-    'not your account',
-    "not your account's",
-    'temporarily limiting requests',
-    'temporarily rate',
-    'server is temporarily',
-    'would exceed your account’s rate limit',
-    "would exceed your account's rate limit",
-  ]
+  // the negation is honoured and no failover is announced. The signal list is
+  // module-level (`transientUpstreamSignals`) so session-tail.ts classifies a
+  // 429 against the SAME canonical wording.
   if (transientUpstreamSignals.some(s => lower.includes(s))) {
     const resetAt = parseResetTime(sample)
     return resetAt !== undefined

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -41,6 +41,7 @@ function isMultiAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return env.PROGRESS_CARD_MULTI_AGENT !== '0'
 }
 import { classifyClaudeError, type OperatorEventKind } from './operator-events.js'
+import { isTransientUpstreamSignal } from './model-unavailable.js'
 import { createToolLabelSidecar, type ToolLabelSidecar, type SidecarOptions } from './tool-label-sidecar.js'
 import { isModelSentinel } from './model-label.js'
 
@@ -668,13 +669,26 @@ export function detectErrorInTranscriptLine(
       typeof obj.apiErrorStatus === 'number' ? obj.apiErrorStatus : null
     const errStr = typeof obj.error === 'string' ? obj.error : ''
     const text = extractAssistantText(obj)
-    // A 429 in this shape is a subscription usage-limit hit (it carries
-    // a reset time) — classify it quota-exhausted so the operator event
-    // resolves to an auto-fallback-eligible kind. Other statuses fall
+    // A 429 in this shape is USUALLY a subscription usage-limit wall (it
+    // carries a reset time) — classify it quota-exhausted so the operator
+    // event resolves to an auto-fallback-eligible kind that always shows the
+    // "model unavailable" card. BUT Anthropic also emits a 429 for a TRANSIENT
+    // per-account burst / RPM throttle whose wording explicitly negates the
+    // account-quota reading ("This request would exceed your account's rate
+    // limit … not your usage limit"). That is a self-healing few-second throttle
+    // Claude Code retries internally — blanket-labeling it quota-exhausted fired
+    // a false scary card on the fleet (carrie incident, 2026-07-12). So a 429 is
+    // only quota-exhausted when it LACKS an explicit transient-burst marker;
+    // with one, classify it rate-limited so it takes the calm path (no card, no
+    // failover). Keyed on the explicit transient NEGATION (canonical list in
+    // model-unavailable.ts) — an ambiguous 429 that merely says "limit" stays
+    // quota-exhausted, biasing toward surfacing a real wall. Other statuses fall
     // through to the shared classifier.
     const kind: OperatorEventKind =
       status === 429
-        ? 'quota-exhausted'
+        ? isTransientUpstreamSignal(`${text}\n${errStr}`)
+          ? 'rate-limited'
+          : 'quota-exhausted'
         : classifyClaudeError({ type: errStr, status, message: text })
     // An `isApiErrorMessage` line is Claude surfacing the failure to the
     // user — terminal by construction (Claude writes this shape only

--- a/telegram-plugin/tests/operator-events-session-tail.test.ts
+++ b/telegram-plugin/tests/operator-events-session-tail.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { detectErrorInTranscriptLine, startSessionTail } from '../session-tail.js'
 import { resetAllCooldowns } from '../operator-events.js'
+import { resolveModelUnavailableFromOperatorEvent } from '../model-unavailable.js'
 
 // ─── detectErrorInTranscriptLine unit tests ───────────────────────────────────
 
@@ -153,6 +154,79 @@ describe('detectErrorInTranscriptLine — error detection', () => {
     // The user-facing text must survive into `detail` (the model-
     // unavailable card + the text-pattern path both rely on it).
     expect(result!.detail).toContain('hit your limit')
+  })
+
+  // Regression — the carrie incident (2026-07-12). Anthropic also emits a
+  // 429 for a TRANSIENT per-account burst / RPM throttle whose wording
+  // explicitly negates the account-quota reading ("would exceed your
+  // account's rate limit … not your usage limit"). That is a self-healing
+  // few-second throttle Claude Code retries internally — it must NOT be
+  // labeled quota-exhausted (which always shows the scary "model
+  // unavailable" card + drives failover). It must take the calm
+  // rate-limited path.
+  it('classifies a TRANSIENT burst 429 (explicit negation) as rate-limited, NOT quota-exhausted', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        model: '<synthetic>',
+        content: [
+          {
+            type: 'text',
+            text:
+              'API Error: 429 rate_limit_error This request would exceed ' +
+              "your account's rate limit. Please try again later. This is a " +
+              'short-term burst limit, not your usage limit.',
+          },
+        ],
+      },
+      error: 'rate_limit',
+      isApiErrorMessage: true,
+      apiErrorStatus: 429,
+    })
+    const result = detectErrorInTranscriptLine(line)
+    expect(result).not.toBeNull()
+    // Wording-based classification: explicit transient negation → calm path.
+    expect(result!.kind).toBe('rate-limited')
+    expect(result!.transient).toBe(true)
+    // End-to-end: the resolver must NOT produce a model-unavailable card for
+    // this kind (the calm rate-limited branch returns null on a bare burst).
+    const detection = resolveModelUnavailableFromOperatorEvent({
+      kind: result!.kind,
+      detail: result!.detail,
+    })
+    expect(detection).toBeNull()
+  })
+
+  // Guard against over-correcting: a GENUINE quota wall (no transient marker)
+  // must STILL be quota-exhausted AND still resolve to a card.
+  it('a genuine quota-wall 429 still produces the quota-exhausted card', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        model: '<synthetic>',
+        content: [
+          {
+            type: 'text',
+            text: "You've hit your limit · resets 8:50am (Australia/Melbourne)",
+          },
+        ],
+      },
+      error: 'rate_limit',
+      isApiErrorMessage: true,
+      apiErrorStatus: 429,
+    })
+    const result = detectErrorInTranscriptLine(line)
+    expect(result).not.toBeNull()
+    expect(result!.kind).toBe('quota-exhausted')
+    // The quota-exhausted branch ALWAYS returns a detection (the card).
+    const detection = resolveModelUnavailableFromOperatorEvent({
+      kind: result!.kind,
+      detail: result!.detail,
+    })
+    expect(detection).not.toBeNull()
+    expect(detection!.kind).toBe('quota_exhausted')
   })
 
   it('still returns null for a normal (non-error) assistant message', () => {


### PR DESCRIPTION
## Summary

A **transient per-account burst 429** (Anthropic `rate_limit_error`, message contains "This request would exceed your account's rate limit … not your usage limit" — a short-term RPM/burst throttle, NOT the 5h/7d quota wall) was being **mislabeled as hard quota exhaustion**, so switchroom posted a scary "⚠️ Model unavailable … Reason: model overloaded … What to try: /auth use" card to the operator for what is actually a self-healing few-second throttle Claude Code retries internally.

**The carrie incident (2026-07-12):** a transient burst 429 on the fleet-consolidated `pixsoul` account surfaced a false "model unavailable / quota exhausted" card.

## Why

`session-tail.ts:detectErrorInTranscriptLine` blanket-labeled **every** `isApiErrorMessage` line with `apiErrorStatus === 429` as `kind: 'quota-exhausted'`, unconditionally, regardless of wording. That `quota-exhausted` kind routes into `resolveModelUnavailableFromOperatorEvent` (`model-unavailable.ts`), whose `quota-exhausted` branch **always** returns a card (never null) and drives failover — while its `rate-limited` branch returns null for a bare overload (the calm path, no card). So the transient burst took the always-card branch.

## The fix

Classify the 429 by **error wording**, not blanket `quota-exhausted`:

- **Transient burst** (detail carries an explicit transient-negation marker) → `rate-limited` → the existing **calm path** (`resolveModelUnavailableFromOperatorEvent` returns null → no "model unavailable" card, no fleet auto-fallback).
- **Genuine quota wall** ("You've hit your limit · resets…", `out_of_credits`, no transient marker) → **unchanged** `quota-exhausted` (card + failover eligibility).

The transient-signal list is the **canonical** one: `transientUpstreamSignals` (previously a local const inside `detectModelUnavailable`) is hoisted to module scope in `model-unavailable.ts` and exposed via a new `isTransientUpstreamSignal(text)` predicate. `session-tail.ts` reuses that predicate — no hand-rolled second list, so the two stay in sync (issue #2922).

### Disambiguation rule

Down-classify to `rate-limited` **only** when the 429 detail matches an **explicit transient negation** ("not your usage limit" / "would exceed your account's rate limit" / "temporarily limiting requests" …). An **ambiguous** 429 that merely contains the word "limit" **stays `quota-exhausted`** — biasing toward surfacing a real wall, since under-surfacing a genuine wall is worse than an occasional extra calm card.

## Scope / safety

Only the **classification** of a 429 at the session-tail source changes. The **failover engine, the broker, the card formatting, and the calm-path rendering are untouched** — the transient burst now simply reaches the already-existing calm branch instead of the always-card branch.

## Test plan

Added two load-bearing tests to `telegram-plugin/tests/operator-events-session-tail.test.ts`:

1. A transient burst 429 (`isApiErrorMessage` / `apiErrorStatus:429`, text = "…would exceed your account's rate limit … not your usage limit") → `kind === 'rate-limited'`, `transient === true`, and `resolveModelUnavailableFromOperatorEvent` returns `null` (no card).
2. A genuine quota-wall 429 ("You've hit your limit · resets 8:50am") → still `kind === 'quota-exhausted'` and the resolver still returns a `quota_exhausted` detection (the card) — guards against over-correcting.

**Load-bearing proof:** with the fix reverted, test #1 fails — the burst gets `quota-exhausted` (the scary card).

- `vitest run` on the touched files (`operator-events-session-tail`, `model-unavailable`, `operator-events`): **142 passed**.
- Bun CI command `bun test admin-commands gateway registry secret-detect tests channel-envelope-safety.test.ts`: **7580 pass, 5 skip, 1 fail** — the single fail is the known pre-existing `blocked-approval record` root-uid chmod artifact (root can write anywhere, so the "not writable" fallback can't trigger); no NEW failures.
- `npm run lint`: **clean**.

## Risk

Low. Narrow, conservative classification change guarded on explicit transient negation; genuine walls provably still show the card + drive failover.