### PR TITLE
feat(agents): foreground turn-hog PreToolUse gate for Bash

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -244,6 +244,17 @@ RUN chmod 0755 /opt/switchroom/hooks/skill-validate-pretool.mjs
 COPY dist/cli/hindsight-mental-model-pretool.mjs /opt/switchroom/hooks/hindsight-mental-model-pretool.mjs
 RUN chmod 0755 /opt/switchroom/hooks/hindsight-mental-model-pretool.mjs
 
+# Foreground turn-hog gate. A PreToolUse hook scoped to `^Bash$` that DENIES
+# effectively-unbounded FOREGROUND command shapes (tail -f, watch, sleep > 30s,
+# sleep-loops, gh --watch, docker/kubectl/journalctl followers) with an
+# instructive "re-run with run_in_background: true" message, so the turn is
+# never wedged behind an open-ended command. Backgrounded calls
+# (run_in_background: true) always pass. Not in the security-plugin: it's
+# turn-hygiene (responsiveness), not a load-bearing safety control. Kill
+# switch SWITCHROOM_FOREGROUND_HOG_GATE=0.
+COPY dist/cli/foreground-hog-pretool.mjs /opt/switchroom/hooks/foreground-hog-pretool.mjs
+RUN chmod 0755 /opt/switchroom/hooks/foreground-hog-pretool.mjs
+
 # Agent self-improvement Stop gate (RFC reference/rfcs/agent-self-improvement.md
 # slice 1). A cheap deterministic per-turn triage; on a learning signal
 # it injects a forked review turn via the gateway socket (inject_inbound,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -308,6 +308,24 @@ if (mmHookEscape.changed) {
   console.log(`[build] ASCII-escaped ${mmHookEscape.nonAsciiCount} non-ASCII code units in dist/cli/hindsight-mental-model-pretool.mjs`);
 }
 
+// Bundle the foreground-hog-pretool hook — deterministic gate that denies
+// effectively-unbounded FOREGROUND Bash shapes (tail -f, watch, long sleeps,
+// sleep-loops, gh --watch, docker/kubectl/journalctl followers) with an
+// instructive "re-run with run_in_background: true" message. Same pattern
+// as hindsight-mental-model-pretool: no src/ imports (a pure tool_input
+// gate), bundled for consistency so it ships to /opt/switchroom/hooks/.
+console.log("[build] bundling src/cli/foreground-hog-pretool.ts -> dist/cli/foreground-hog-pretool.mjs");
+execSync(
+  `bun build ${JSON.stringify(resolve(root, "src/cli/foreground-hog-pretool.ts"))} --outfile ${JSON.stringify(resolve(outDir, "foreground-hog-pretool.mjs"))} --target node`,
+  { stdio: "inherit", cwd: root }
+);
+const fgHogHookOutFile = resolve(outDir, "foreground-hog-pretool.mjs");
+chmodSync(fgHogHookOutFile, 0o755);
+const fgHogHookEscape = escapeBundleNonAscii(fgHogHookOutFile);
+if (fgHogHookEscape.changed) {
+  console.log(`[build] ASCII-escaped ${fgHogHookEscape.nonAsciiCount} non-ASCII code units in dist/cli/foreground-hog-pretool.mjs`);
+}
+
 // Bundle the self-improve-stop hook — RFC reference/rfcs/agent-self-improvement.md
 // slice 1. Turn-end GATE: a self-contained .mjs the agent container runs
 // via node from the bundled-hooks path. It imports the src/self-improve/*

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -5342,6 +5342,36 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           ],
         },
         {
+          // Foreground turn-hog gate — deterministic safety net in the
+          // #3150 family (fail-closed deny on known-bad shapes, not a
+          // heuristic classifier). A foreground Bash call holds the whole
+          // session until it returns; this hook DENIES effectively-
+          // unbounded foreground shapes (tail -f/--follow, watch,
+          // sleep > 30s, sleep-in-a-loop, gh pr checks --watch / gh run
+          // watch, docker/kubectl logs -f, journalctl -f) with an
+          // instructive message: re-run with run_in_background: true or
+          // use a bounded alternative. run_in_background: true always
+          // passes; conservative by design so real build/test runs are
+          // never blocked. Default ON; kill switch
+          // SWITCHROOM_FOREGROUND_HOG_GATE=0 (send-gate convention).
+          // Matcher scoped to Bash so the stdin parse only lands there.
+          //
+          // DOCKER_BUNDLED_HOOKS_PATH: bundled via scripts/build.mjs from
+          // src/cli/foreground-hog-pretool.ts, mirroring
+          // hindsight-mental-model-pretool.
+          matcher: "^Bash$",
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:foreground-hog-pretool",
+                `node "${join(DOCKER_BUNDLED_HOOKS_PATH, "foreground-hog-pretool.mjs")}"`,
+              ),
+              timeout: 10,
+            },
+          ],
+        },
+        {
           // Agent self-improvement APPLY-GUARD — RFC
           // reference/rfcs/agent-self-improvement.md slice 2. The
           // DETERMINISTIC T1 gate: when a self-improve review is pending

--- a/src/cli/foreground-hog-pretool.ts
+++ b/src/cli/foreground-hog-pretool.ts
@@ -48,6 +48,12 @@
  * Fail-OPEN on any stdin parse error / unknown shape: a turn-hygiene gate
  * must never be the reason a legitimate tool call fails. The only non-allow
  * outcome is the explicit deterministic block on a matched shape.
+ *
+ * Quote/heredoc discipline: before any matching, quoted spans and heredoc
+ * bodies are blanked (see blankQuotedAndHeredocs) so string DATA — commit
+ * messages, PR bodies, files being written — can never be mistaken for
+ * commands. When the blanking pass can't parse confidently (unterminated
+ * quote, weird heredoc) the whole command ALLOWS, same fail-open rule.
  */
 
 import { readFileSync } from "node:fs";
@@ -65,10 +71,130 @@ function gateEnabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 /**
+ * Blank quoted spans and heredoc bodies to SPACES (length-preserving)
+ * before any segmentation or shape matching, so string DATA can never be
+ * mistaken for commands: separators inside quotes must not create phantom
+ * segments (`git commit -m "retry; sleep 60"`), heredoc bodies are file
+ * CONTENT being written, not commands being run (`cat > x.sh <<'EOF' ...`),
+ * and quoted prose must not trip the loop/gh matchers.
+ *
+ * Returns null when the command can't be parsed confidently — unterminated
+ * quote (including a prose apostrophe), unterminated heredoc, or an
+ * un-parseable heredoc tag. The caller ALLOWS on null: false negatives are
+ * acceptable, false positives are not.
+ *
+ * Handled: '…' (no escapes), "…" (backslash escapes), backslash escapes in
+ * normal state (`\;` is not a separator, `\'` does not open a quote),
+ * `<<TAG` / `<<'TAG'` / `<<"TAG"` / `<<-TAG` heredocs (bodies blanked
+ * through the terminator line; multiple heredocs on one line queue in
+ * order), `<<<` here-strings (skipped — a single word, no body). NOT a
+ * shell parser: `$(…)` and backtick substitution stay unparsed, as before.
+ */
+function blankQuotedAndHeredocs(src: string): string | null {
+  const out = src.split("");
+  const n = src.length;
+  const pending: Array<{ tag: string; stripTabs: boolean }> = [];
+  let i = 0;
+  while (i < n) {
+    const ch = src[i];
+    if (ch === "\\") {
+      // Escape in normal state: neutralize both chars so an escaped
+      // separator/quote is never treated as structure.
+      out[i] = " ";
+      if (i + 1 < n) out[i + 1] = " ";
+      i += 2;
+      continue;
+    }
+    if (ch === "'") {
+      let j = i + 1;
+      while (j < n && src[j] !== "'") j++;
+      if (j >= n) return null; // unterminated (or a prose apostrophe)
+      for (let k = i; k <= j; k++) out[k] = " ";
+      i = j + 1;
+      continue;
+    }
+    if (ch === '"') {
+      let j = i + 1;
+      while (j < n && src[j] !== '"') {
+        j += src[j] === "\\" ? 2 : 1;
+      }
+      if (j >= n) return null; // unterminated
+      for (let k = i; k <= j && k < n; k++) out[k] = " ";
+      i = j + 1;
+      continue;
+    }
+    if (ch === "<" && src[i + 1] === "<") {
+      if (src[i + 2] === "<") {
+        i += 3; // here-string: a single word follows, no body to blank
+        continue;
+      }
+      let j = i + 2;
+      let stripTabs = false;
+      if (src[j] === "-") {
+        stripTabs = true;
+        j++;
+      }
+      while (j < n && (src[j] === " " || src[j] === "\t")) j++;
+      let quote = "";
+      if (src[j] === "'" || src[j] === '"') {
+        quote = src[j]!;
+        j++;
+      }
+      let tag = "";
+      while (j < n && /[A-Za-z0-9_]/.test(src[j]!)) {
+        tag += src[j];
+        j++;
+      }
+      if (quote) {
+        if (src[j] !== quote) return null; // weird opener → fail open
+        j++;
+      }
+      if (!tag) return null; // `<<$(…)` and friends → fail open
+      pending.push({ tag, stripTabs });
+      i = j;
+      continue;
+    }
+    if (ch === "\n" && pending.length > 0) {
+      // Heredoc bodies start after this newline; blank each queued body
+      // through (but not including) its terminator line, in order. The
+      // terminator line itself survives as a harmless bare token.
+      let j = i + 1;
+      while (pending.length > 0) {
+        const { tag, stripTabs } = pending.shift()!;
+        let found = false;
+        while (j <= n) {
+          let eol = src.indexOf("\n", j);
+          if (eol === -1) eol = n;
+          const line = src.slice(j, eol);
+          const cmp = stripTabs ? line.replace(/^\t+/, "") : line;
+          if (cmp === tag) {
+            found = true;
+            j = eol + 1;
+            break;
+          }
+          for (let k = j; k < eol; k++) out[k] = " ";
+          if (eol === n) {
+            j = n + 1;
+            break;
+          }
+          j = eol + 1;
+        }
+        if (!found) return null; // unterminated heredoc → fail open
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+  return out.join("");
+}
+
+/**
  * Sleep-in-a-loop across the WHOLE command: a `sleep` between `do` and
  * `done` of a while/until/for loop is a poll loop regardless of the
  * per-tick duration. Ordered match keeps it conservative (`... done &&
- * sleep 5` does not trip it — no `done` after the sleep).
+ * sleep 5` does not trip it — no `done` after the sleep). Runs on the
+ * BLANKED command, so quoted prose / quoted script literals never match.
  */
 const LOOP_SLEEP =
   /\b(?:while|until|for)\b[\s\S]*?\bdo\b[\s\S]*?\bsleep\b[\s\S]*?\bdone\b/;
@@ -162,10 +288,13 @@ function matchSegment(segment: string): string | null {
   }
 
   if (cmd === "gh") {
-    const joined = args.join(" ");
-    if (/\bpr\s+checks\b/.test(joined) && args.includes("--watch"))
+    // Only UNQUOTED positional tokens name the gh verb — flag values
+    // (`--body "run watch locally"`) are data, already blanked upstream,
+    // and flag tokens themselves (`-R`, `--body=x`) are never positional.
+    const positionals = args.filter((a) => !a.startsWith("-"));
+    if (positionals[0] === "pr" && positionals[1] === "checks" && args.includes("--watch"))
       return "gh pr checks --watch";
-    if (/\brun\s+watch\b/.test(joined)) return "gh run watch";
+    if (positionals[0] === "run" && positionals[1] === "watch") return "gh run watch";
   }
 
   if (cmd === "docker" && args[0] === "logs" && hasFollowFlag(args.slice(1), false))
@@ -179,10 +308,14 @@ function matchSegment(segment: string): string | null {
   return null;
 }
 
-/** The full detector. Returns the matched pattern label or null. */
+/** The full detector. Returns the matched pattern label or null. Every
+ *  matcher sees only the BLANKED command — quoted data and heredoc bodies
+ *  can never be mistaken for commands; an un-blankable command allows. */
 function detectForegroundHog(command: string): string | null {
-  if (LOOP_SLEEP.test(command)) return "sleep in a while/until/for loop";
-  for (const segment of foregroundSegments(command)) {
+  const blanked = blankQuotedAndHeredocs(command);
+  if (blanked === null) return null; // can't parse confidently → fail open
+  if (LOOP_SLEEP.test(blanked)) return "sleep in a while/until/for loop";
+  for (const segment of foregroundSegments(blanked)) {
     const hit = matchSegment(segment);
     if (hit) return hit;
   }

--- a/src/cli/foreground-hog-pretool.ts
+++ b/src/cli/foreground-hog-pretool.ts
@@ -1,0 +1,246 @@
+/**
+ * PreToolUse hook — deterministic foreground turn-hog gate for Bash.
+ *
+ * A foreground Bash call holds the WHOLE session for its full duration: the
+ * agent cannot reply, steer, or take the next queued message until the
+ * command returns (reference/jobs/steer-or-queue-mid-flight.md). The fleet
+ * dev protocol already forbids foreground watches over 30s as prompt
+ * discipline — this hook makes that guarantee MECHANICAL, in the same family
+ * as the destructive-git detector (#3150): a conservative, deterministic
+ * deny on KNOWN-BAD shapes, not a heuristic classifier. False negatives are
+ * acceptable; false positives are not — a legitimate medium-length build or
+ * test run must never be blocked, so nothing here matches generic
+ * build/test commands.
+ *
+ * Gated shapes (each effectively unbounded — or pure dead time — in the
+ * foreground):
+ *   - `tail -f` / `tail -F` / `tail --follow`
+ *   - `watch <cmd>`
+ *   - `sleep N` with N > 30 seconds (bare or as a segment of a compound
+ *     command, e.g. `npm run build && sleep 300`)
+ *   - sleep-in-a-loop (`while ...; do ...; sleep ...; done`, also until/for)
+ *   - `gh pr checks --watch`, `gh run watch`
+ *   - `docker logs -f/--follow`, `kubectl logs -f/--follow`, `journalctl -f`
+ *
+ * The deny message is instructive (reference/principles.md #1): it names the
+ * matched pattern and tells the model exactly what to do next — re-run the
+ * same command with `run_in_background: true`, or use a bounded alternative.
+ *
+ * Kill-switch (reference/principles.md #2 — default ON, escape hatch, not
+ * opt-in; mirrors `sendGateEnabledFromEnv` in telegram-plugin/send-gate.ts):
+ * `SWITCHROOM_FOREGROUND_HOG_GATE=0|false|off|no` disables the gate; unset
+ * or any other value keeps it enabled.
+ *
+ * Session scoping: Claude Code fires PreToolUse hooks for MAIN-session and
+ * sub-agent (Task) tool calls alike, with the parent's session_id and no
+ * sidechain marker in the payload (see tool-label-pretool.mjs — "Claude Code
+ * does not pass sub-agent agent_id directly to the hook"). Main-session-only
+ * scoping is therefore NOT expressible at this layer. The pattern list is
+ * deliberately limited to shapes that are wrong even inside a worker: an
+ * unbounded follower or a >30s dead sleep should be backgrounded or bounded
+ * there too (fleet dev protocol: no foreground watches over 30s, anywhere).
+ *
+ * Claude Code PreToolUse protocol (v1), mirrors hindsight-mental-model-pretool:
+ *   Input:  JSON on stdin — { session_id, tool_name, tool_input, ... }
+ *   Output: exit 0 + empty stdout                       → allow.
+ *           exit 0 + {"decision":"block","reason":...}  → block (deny).
+ *
+ * Fail-OPEN on any stdin parse error / unknown shape: a turn-hygiene gate
+ * must never be the reason a legitimate tool call fails. The only non-allow
+ * outcome is the explicit deterministic block on a matched shape.
+ */
+
+import { readFileSync } from "node:fs";
+
+/**
+ * Default-on kill-switch, repo convention (send-gate.ts, midTurnFloorEnabled):
+ * enabled unless SWITCHROOM_FOREGROUND_HOG_GATE is explicitly set to a
+ * falsey/off value (`0`/`false`/`off`/`no`, case-insensitive, trimmed).
+ */
+function gateEnabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env.SWITCHROOM_FOREGROUND_HOG_GATE;
+  if (v == null) return true;
+  const t = v.trim().toLowerCase();
+  return !(t === "0" || t === "false" || t === "off" || t === "no");
+}
+
+/**
+ * Sleep-in-a-loop across the WHOLE command: a `sleep` between `do` and
+ * `done` of a while/until/for loop is a poll loop regardless of the
+ * per-tick duration. Ordered match keeps it conservative (`... done &&
+ * sleep 5` does not trip it — no `done` after the sleep).
+ */
+const LOOP_SLEEP =
+  /\b(?:while|until|for)\b[\s\S]*?\bdo\b[\s\S]*?\bsleep\b[\s\S]*?\bdone\b/;
+
+/** `sleep` durations: bare seconds or GNU suffixes s/m/h/d. Unparseable
+ *  (e.g. `sleep $N`) → null → allow (false negatives are acceptable). */
+function sleepSeconds(token: string): number | null {
+  const m = /^(\d+(?:\.\d+)?)([smhd]?)$/.exec(token);
+  if (!m) return null;
+  const mult = { "": 1, s: 1, m: 60, h: 3600, d: 86400 }[m[2] as "" | "s" | "m" | "h" | "d"];
+  return Number(m[1]) * mult;
+}
+
+/** A short/combined flag or `--follow` that means "follow" for the follower
+ *  commands gated below (tail/docker logs/kubectl logs/journalctl — for all
+ *  of them a combined short group containing `f`, e.g. `-xef`, follows). */
+function hasFollowFlag(args: readonly string[], allowCapitalF: boolean): boolean {
+  return args.some(
+    (a) =>
+      a === "--follow" ||
+      a.startsWith("--follow=") ||
+      (/^-[a-zA-Z0-9]+$/.test(a) &&
+        (a.includes("f") || (allowCapitalF && a.includes("F")))),
+  );
+}
+
+/**
+ * Split a compound command into its FOREGROUND segments. `&&`/`||`/`;`/`|`/
+ * newline separate sequential segments (each holds the turn in sequence); a
+ * segment terminated by a single `&` is shell-backgrounded and dropped — it
+ * does not hold the turn. Quotes/subshells are not parsed: this is the
+ * conservative tokenizer-lite the shape list needs, not a shell parser.
+ */
+function foregroundSegments(command: string): string[] {
+  // fd-duplication redirects (`2>&1`, `>&2`) contain `&` but are not
+  // backgrounding — blank them before splitting.
+  const cleaned = command.replace(/\d*>&\d*/g, " ");
+  const out: string[] = [];
+  const sep = /&&|\|\||[;|\n&]/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  const push = (seg: string, backgrounded: boolean) => {
+    const t = seg.trim();
+    if (t && !backgrounded) out.push(t);
+  };
+  while ((m = sep.exec(cleaned)) !== null) {
+    push(cleaned.slice(last, m.index), m[0] === "&");
+    last = m.index + m[0].length;
+  }
+  push(cleaned.slice(last), false);
+  return out;
+}
+
+/** Tokenize one segment down to the actual command + args: strip leading
+ *  env assignments, shell keywords, and transparent wrappers. */
+function commandTokens(segment: string): string[] {
+  const SKIP = new Set([
+    "if", "elif", "then", "else", "do", "time", "nohup", "sudo", "command", "exec",
+  ]);
+  const tokens = segment.split(/\s+/);
+  const out: string[] = [];
+  let started = false;
+  for (const rawTok of tokens) {
+    const tok = rawTok.replace(/^[({]+/, "");
+    if (!tok) continue;
+    if (!started) {
+      if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tok)) continue; // FOO=bar prefix
+      if (SKIP.has(tok)) continue;
+      started = true;
+    }
+    out.push(tok);
+  }
+  return out;
+}
+
+/** Match ONE foreground segment against the known-bad shapes. Returns a
+ *  human-readable pattern label, or null when the segment is fine. */
+function matchSegment(segment: string): string | null {
+  const tokens = commandTokens(segment);
+  const cmd = tokens[0];
+  if (!cmd) return null;
+  const args = tokens.slice(1);
+
+  if (cmd === "tail" && hasFollowFlag(args, true)) return "tail -f/--follow";
+
+  if (cmd === "watch") return "watch";
+
+  if (cmd === "sleep") {
+    const secs = sleepSeconds(args[0] ?? "");
+    if (secs !== null && secs > 30) return `sleep ${args[0]} (> 30s foreground)`;
+  }
+
+  if (cmd === "gh") {
+    const joined = args.join(" ");
+    if (/\bpr\s+checks\b/.test(joined) && args.includes("--watch"))
+      return "gh pr checks --watch";
+    if (/\brun\s+watch\b/.test(joined)) return "gh run watch";
+  }
+
+  if (cmd === "docker" && args[0] === "logs" && hasFollowFlag(args.slice(1), false))
+    return "docker logs -f/--follow";
+
+  if (cmd === "kubectl" && args[0] === "logs" && hasFollowFlag(args.slice(1), false))
+    return "kubectl logs -f/--follow";
+
+  if (cmd === "journalctl" && hasFollowFlag(args, false)) return "journalctl -f";
+
+  return null;
+}
+
+/** The full detector. Returns the matched pattern label or null. */
+function detectForegroundHog(command: string): string | null {
+  if (LOOP_SLEEP.test(command)) return "sleep in a while/until/for loop";
+  for (const segment of foregroundSegments(command)) {
+    const hit = matchSegment(segment);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function denyMessage(pattern: string): string {
+  return (
+    `Foreground-hog gate: \`${pattern}\` would hold the session foreground for its full duration. ` +
+    "Re-run this exact command with `run_in_background: true` and act on the completion notification, " +
+    "or use a bounded alternative (e.g. `tail -n 200` instead of `tail -f`)."
+  );
+}
+
+function readStdin(): string {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function allow(): never {
+  process.exit(0);
+}
+
+function block(reason: string): never {
+  process.stdout.write(JSON.stringify({ decision: "block", reason }));
+  process.exit(0);
+}
+
+function main(): void {
+  if (!gateEnabledFromEnv()) allow();
+
+  const raw = readStdin().trim();
+  if (!raw) allow();
+
+  let event: { tool_name?: unknown; tool_input?: unknown };
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    allow(); // Claude protocol error — not ours to police.
+  }
+
+  if (event.tool_name !== "Bash") allow();
+  const input = event.tool_input;
+  if (!input || typeof input !== "object") allow();
+  const { run_in_background: runInBackground, command } = input as {
+    run_in_background?: unknown;
+    command?: unknown;
+  };
+  if (runInBackground === true) allow(); // backgrounded → never a turn hog
+  if (typeof command !== "string" || command.length === 0) allow();
+
+  const pattern = detectForegroundHog(command);
+  if (pattern) block(denyMessage(pattern));
+
+  allow();
+}
+
+main();

--- a/tests/bundled-hooks-parity.test.ts
+++ b/tests/bundled-hooks-parity.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildSettingsHooksBlock,
+  DOCKER_BUNDLED_HOOKS_PATH,
+} from "../src/agents/scaffold.js";
+import type { AgentConfig } from "../src/config/schema.js";
+
+/**
+ * Registration parity for BUNDLED hooks (PR #3159 review, pre-existing gap).
+ *
+ * A hook registered in the scaffold's settings.json from the bundled-hooks
+ * path (/opt/switchroom/hooks) only exists at runtime when BOTH:
+ *   (a) scripts/build.mjs bundles src/cli/<name>.ts -> dist/cli/<name>.mjs
+ *   (b) docker/Dockerfile.agent COPYs dist/cli/<name>.mjs into the image
+ * A missing leg means settings.json points at a file that isn't there and
+ * Claude Code silently never fires the hook — the exact #1811 failure class.
+ * This test derives the list from the scaffold (the single source of truth
+ * for what agents load) and string-scans the other two files, so adding a
+ * bundled hook without all three legs fails here instead of in production.
+ */
+describe("bundled hooks parity (scaffold ⇄ build.mjs ⇄ Dockerfile.agent)", () => {
+  const agentConfig = {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+  } as unknown as AgentConfig;
+
+  const hooksBlock = buildSettingsHooksBlock({
+    agentName: "parity-agent",
+    agentConfig,
+    hindsightEnabled: true,
+    useSwitchroomPlugin: true,
+  });
+
+  // Every command string across every hook event.
+  const commands: string[] = Object.values(hooksBlock).flatMap((entries) =>
+    (entries as Array<{ hooks: Array<{ command: string }> }>).flatMap((e) =>
+      e.hooks.map((h) => h.command),
+    ),
+  );
+
+  // Bundled-hook filenames referenced from settings.json.
+  const bundledRe = new RegExp(
+    `${DOCKER_BUNDLED_HOOKS_PATH.replace(/\//g, "\\/")}\\/([a-z0-9-]+\\.mjs)`,
+    "g",
+  );
+  const bundledNames = [
+    ...new Set(
+      commands.flatMap((c) => [...c.matchAll(bundledRe)].map((m) => m[1]!)),
+    ),
+  ];
+
+  const buildMjs = readFileSync(join(process.cwd(), "scripts", "build.mjs"), "utf-8");
+  const dockerfile = readFileSync(
+    join(process.cwd(), "docker", "Dockerfile.agent"),
+    "utf-8",
+  );
+
+  it("finds a non-trivial set of bundled hooks in the scaffold output", () => {
+    // Guard against the scan going vacuous after a refactor: as of #3159
+    // there are 6+ (drive-write, ms-365-write, notion-write, skill-validate,
+    // hindsight-mental-model, self-improve-stop, self-improve-apply-guard,
+    // foreground-hog).
+    expect(bundledNames.length).toBeGreaterThanOrEqual(6);
+    expect(bundledNames).toContain("foreground-hog-pretool.mjs");
+  });
+
+  it("every scaffold-registered bundled hook is bundled by scripts/build.mjs", () => {
+    for (const name of bundledNames) {
+      const src = `src/cli/${name.replace(/\.mjs$/, ".ts")}`;
+      expect(buildMjs, `build.mjs must bundle ${src}`).toContain(src);
+      expect(buildMjs, `build.mjs must emit ${name}`).toContain(name);
+    }
+  });
+
+  it("every scaffold-registered bundled hook is COPY'd by Dockerfile.agent", () => {
+    for (const name of bundledNames) {
+      expect(
+        dockerfile,
+        `Dockerfile.agent must ship ${name} to ${DOCKER_BUNDLED_HOOKS_PATH}`,
+      ).toContain(`COPY dist/cli/${name} ${DOCKER_BUNDLED_HOOKS_PATH}/${name}`);
+    }
+  });
+});

--- a/tests/foreground-hog-pretool.test.ts
+++ b/tests/foreground-hog-pretool.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+// The hook is a .ts that bundles to .mjs at build time; drive it through
+// `bun` against source so the test doesn't depend on build order (mirrors
+// hindsight-mental-model-pretool.test.ts). Skip cleanly if bun absent.
+const bunOk = spawnSync("which", ["bun"], { encoding: "utf-8" }).status === 0;
+const HOOK = join(process.cwd(), "src", "cli", "foreground-hog-pretool.ts");
+
+function run(
+  payload: unknown,
+  env: Record<string, string> = {},
+): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync("bun", [HOOK], {
+    input: typeof payload === "string" ? payload : JSON.stringify(payload),
+    encoding: "utf-8",
+    timeout: 30000,
+    env: { ...process.env, SWITCHROOM_FOREGROUND_HOG_GATE: "", ...env },
+  });
+  return {
+    status: r.status ?? 1,
+    stdout: (r.stdout ?? "").trim(),
+    stderr: r.stderr ?? "",
+  };
+}
+
+function bash(command: string, extra: Record<string, unknown> = {}) {
+  return { tool_name: "Bash", tool_input: { command, ...extra } };
+}
+
+function expectDeny(command: string, patternFragment: string) {
+  const r = run(bash(command));
+  expect(r.status).toBe(0);
+  expect(r.stdout, `expected DENY for: ${command}`).not.toBe("");
+  const out = JSON.parse(r.stdout);
+  expect(out.decision).toBe("block");
+  // Instructive message: names the matched pattern AND the recovery.
+  expect(out.reason).toContain(patternFragment);
+  expect(out.reason).toContain("run_in_background: true");
+  expect(out.reason).toContain("bounded alternative");
+}
+
+function expectAllow(command: string) {
+  const r = run(bash(command));
+  expect(r.status).toBe(0);
+  expect(r.stdout, `expected ALLOW for: ${command}`).toBe("");
+}
+
+describe("foreground-hog-pretool hook", () => {
+  it("DENIES tail follow shapes with the instructive message", () => {
+    if (!bunOk) return;
+    expectDeny("tail -f /var/log/syslog", "tail -f/--follow");
+    expectDeny("tail -F /var/log/syslog", "tail -f/--follow");
+    expectDeny("tail --follow /var/log/syslog", "tail -f/--follow");
+    expectDeny("tail --follow=name /var/log/syslog", "tail -f/--follow");
+    expectDeny("tail -fn200 /var/log/syslog", "tail -f/--follow");
+    // In a compound command / pipeline the follower still holds the turn.
+    expectDeny("cd /var/log && tail -f syslog", "tail -f/--follow");
+    expectDeny("tail -f app.log | grep ERROR", "tail -f/--follow");
+  });
+
+  it("DENIES watch as a command", () => {
+    if (!bunOk) return;
+    expectDeny("watch docker ps", "watch");
+    expectDeny("watch -n 5 'kubectl get pods'", "watch");
+  });
+
+  it("DENIES sleep > 30s, bare and inside a compound command", () => {
+    if (!bunOk) return;
+    expectDeny("sleep 300", "sleep 300");
+    expectDeny("sleep 31", "sleep 31");
+    expectDeny("sleep 5m", "sleep 5m");
+    expectDeny("sleep 1h", "sleep 1h");
+    expectDeny("npm run build && sleep 300", "sleep 300");
+    expectDeny("sleep 120; gh pr checks 42", "sleep 120");
+  });
+
+  it("DENIES sleep-in-a-loop regardless of per-tick duration", () => {
+    if (!bunOk) return;
+    expectDeny("while true; do gh pr checks 42; sleep 5; done", "loop");
+    expectDeny("until curl -sf localhost:8080; do sleep 2; done", "loop");
+    expectDeny("for i in 1 2 3; do date; sleep 10; done", "loop");
+  });
+
+  it("DENIES gh watch verbs", () => {
+    if (!bunOk) return;
+    expectDeny("gh pr checks 3141 --watch", "gh pr checks --watch");
+    expectDeny("gh pr checks --watch 3141", "gh pr checks --watch");
+    expectDeny("gh run watch 123456", "gh run watch");
+  });
+
+  it("DENIES unbounded log followers (docker/kubectl/journalctl)", () => {
+    if (!bunOk) return;
+    expectDeny("docker logs -f switchroom-overlord", "docker logs");
+    expectDeny("docker logs --follow switchroom-overlord", "docker logs");
+    expectDeny("kubectl logs -f pod/web-0", "kubectl logs");
+    expectDeny("kubectl logs --follow deployment/api", "kubectl logs");
+    expectDeny("journalctl -f", "journalctl -f");
+    expectDeny("journalctl -xef -u nginx", "journalctl -f");
+  });
+
+  it("ALLOWS bounded near-misses (false positives are not acceptable)", () => {
+    if (!bunOk) return;
+    expectAllow("tail -n 100 /var/log/syslog");
+    expectAllow("tail -n 200 app.log | grep ERROR");
+    expectAllow("sleep 5");
+    expectAllow("sleep 30"); // threshold is strictly > 30
+    expectAllow("npm run build && sleep 10");
+    // `watch`/followers as substrings of other words or as arguments,
+    // never as the command itself.
+    expectAllow("watchman version");
+    expectAllow("git log --follow -- src/cli/foreground-hog-pretool.ts");
+    expectAllow("cat stopwatch.ts");
+    expectAllow("echo 'watch this: tail -f is banned'");
+    expectAllow("gh pr checks 3141"); // no --watch → single bounded poll
+    expectAllow("gh run view 123456");
+    expectAllow("docker logs --tail 200 switchroom-overlord");
+    expectAllow("kubectl logs --tail=100 pod/web-0");
+    expectAllow("journalctl -u nginx -n 200");
+    // Loop without a sleep, and a sleep after the loop closed.
+    expectAllow("for f in *.ts; do wc -l $f; done");
+    expectAllow("for f in *.ts; do wc -l $f; done && sleep 5");
+  });
+
+  it("ALLOWS generic build/test/deploy commands untouched", () => {
+    if (!bunOk) return;
+    expectAllow("npm test");
+    expectAllow("npm run lint");
+    expectAllow("cargo build --release");
+    expectAllow("./node_modules/.bin/vitest run tests/foo.test.ts");
+    expectAllow("docker build -t app . && docker push app");
+    expectAllow("bun install");
+  });
+
+  it("ALLOWS shell-backgrounded segments (single & is not a turn hog)", () => {
+    if (!bunOk) return;
+    expectAllow("tail -f app.log &");
+    expectAllow("sleep 300 & echo started");
+    // fd-duplication redirects are not backgrounding and must not confuse
+    // the splitter into false negatives for the surrounding foreground cmd.
+    expectAllow("npm test 2>&1");
+  });
+
+  it("still DENIES a foreground hog that also uses fd redirects", () => {
+    if (!bunOk) return;
+    expectDeny("tail -f app.log 2>&1", "tail -f/--follow");
+  });
+
+  it("ALLOWS any matched shape when run_in_background is true", () => {
+    if (!bunOk) return;
+    for (const cmd of [
+      "tail -f /var/log/syslog",
+      "sleep 300",
+      "gh run watch 123456",
+      "while true; do date; sleep 5; done",
+    ]) {
+      const r = run(bash(cmd, { run_in_background: true }));
+      expect(r.status).toBe(0);
+      expect(r.stdout, `expected ALLOW (backgrounded) for: ${cmd}`).toBe("");
+    }
+  });
+
+  it("kill-switch env disables the gate (default-on, escape hatch)", () => {
+    if (!bunOk) return;
+    for (const off of ["0", "false", "off", "no", " OFF ", "False"]) {
+      const r = run(bash("tail -f /var/log/syslog"), {
+        SWITCHROOM_FOREGROUND_HOG_GATE: off,
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout, `expected ALLOW with kill-switch=${off}`).toBe("");
+    }
+    // Any other value (including junk) keeps the gate ON.
+    for (const on of ["1", "true", "yes", "banana"]) {
+      const r = run(bash("tail -f /var/log/syslog"), {
+        SWITCHROOM_FOREGROUND_HOG_GATE: on,
+      });
+      expect(r.status).toBe(0);
+      expect(JSON.parse(r.stdout).decision).toBe("block");
+    }
+  });
+
+  it("ALLOWS non-Bash tools untouched", () => {
+    if (!bunOk) return;
+    for (const tool of ["Read", "Write", "Task", "mcp__switchroom-telegram__reply"]) {
+      const r = run({ tool_name: tool, tool_input: { command: "tail -f x" } });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe("");
+    }
+  });
+
+  it("fails open on empty / non-JSON / unknown-shape stdin", () => {
+    if (!bunOk) return;
+    for (const bad of ["", "not-json", "{}", '{"tool_name":123}', '{"tool_name":"Bash"}', '{"tool_name":"Bash","tool_input":{"command":42}}']) {
+      const r = run(bad);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe("");
+    }
+  });
+});

--- a/tests/foreground-hog-pretool.test.ts
+++ b/tests/foreground-hog-pretool.test.ts
@@ -180,6 +180,77 @@ describe("foreground-hog-pretool hook", () => {
     }
   });
 
+  // ── Quote/heredoc blindness regressions (PR #3159 review, FP-1..FP-4) ──
+  // String DATA — commit messages, PR bodies, files being written — must
+  // never be mistaken for commands. Each case below was a confirmed false
+  // positive before the blanking pre-pass.
+
+  it("FP-1: separators inside quoted strings never create phantom segments", () => {
+    if (!bunOk) return;
+    expectAllow('git commit -m "retry logic; sleep 60 between attempts"');
+    expectAllow('echo "step one; watch the dashboard"');
+    expectAllow("echo 'first; tail -f is what we avoid; second'");
+    // Multi-line quoted commit body whose lines start with gated words.
+    expectAllow(
+      'git commit -m "fix poller\n\nwatch the dashboard after deploy\nsleep 60 between retries"',
+    );
+    expectAllow('git commit -am "feat: add watch mode; sleep 300 default" && git push');
+  });
+
+  it("FP-2: heredoc bodies are file content, not commands", () => {
+    if (!bunOk) return;
+    expectAllow("cat > /tmp/wait.sh <<'EOF'\nsleep 300\necho done\nEOF");
+    expectAllow("cat > /tmp/wait.sh <<EOF\nsleep 300\necho done\nEOF");
+    expectAllow(
+      "cat > /tmp/monitor.sh <<'EOF'\nwhile true; do\n  check_health\n  sleep 60\ndone\nEOF",
+    );
+    expectAllow("cat <<-EOF > /tmp/x.sh\n\ttail -f /var/log/syslog\n\tEOF");
+    // Command AFTER the heredoc terminator is still live (and harmless here).
+    expectAllow("cat > x.sh <<'EOF'\nsleep 300\nEOF\necho written");
+  });
+
+  it("FP-3: LOOP_SLEEP never matches quoted prose or quoted script literals", () => {
+    if (!bunOk) return;
+    expectAllow(
+      'git commit -m "while the queue is empty we do a short sleep until work is done"',
+    );
+    expectAllow("printf 'while true; do sleep 5; done\\n' > poll.sh");
+    expectAllow('echo "while x; do sleep 99; done" >> notes.md');
+  });
+
+  it("FP-4: gh matcher ignores flag values and quoted data", () => {
+    if (!bunOk) return;
+    expectAllow('gh pr comment 3159 --body "then run watch locally to verify"');
+    expectAllow('gh pr create --title "run watch fix" --body "adds gh run watch docs"');
+    expectAllow('gh issue create --title "sleep 300 hangs" --body "repro: tail -f x"');
+  });
+
+  it("fails open (ALLOW) when quoting can't be parsed confidently", () => {
+    if (!bunOk) return;
+    // Prose apostrophe = unterminated single quote → allow, even alongside
+    // a would-be hog (false negatives are acceptable, false positives not).
+    expectAllow("echo don't wait && sleep 300");
+    expectAllow('echo "unterminated sleep 300');
+    expectAllow("cat > x.sh <<'EOF'\nsleep 300\n"); // heredoc never terminated
+  });
+
+  it("still DENIES true positives around quotes and heredocs", () => {
+    if (!bunOk) return;
+    // A quoted arg does not launder the live command around it.
+    expectDeny("watch -n 5 'kubectl get pods'", "watch");
+    expectDeny('sleep 300 && git commit -m "waited"', "sleep 300");
+    // A live hog after a properly terminated heredoc still denies.
+    expectDeny(
+      "cat > x.sh <<'EOF'\necho hi\nEOF\ntail -f /var/log/syslog",
+      "tail -f/--follow",
+    );
+    // gh watch verbs still deny with flags after the positionals. (A
+    // value-taking global flag BEFORE the verb — `gh --repo o/r run watch`
+    // — is a known, accepted false negative of the positional matcher.)
+    expectDeny("gh pr checks 3141 --watch", "gh pr checks --watch");
+    expectDeny("gh run watch 123456 --exit-status", "gh run watch");
+  });
+
   it("ALLOWS non-Bash tools untouched", () => {
     if (!bunOk) return;
     for (const tool of ["Read", "Write", "Task", "mcp__switchroom-telegram__reply"]) {

--- a/tests/reconcile-hooks-drift.test.ts
+++ b/tests/reconcile-hooks-drift.test.ts
@@ -151,6 +151,16 @@ describe("buildSettingsHooksBlock", () => {
       e.hooks.some(h => h.command.includes("hindsight-mental-model-pretool.mjs")),
     );
     expect(mmEntry?.matcher).toBe("^mcp__hindsight__");
+
+    // Foreground turn-hog gate: registered and scoped to Bash; it denies
+    // effectively-unbounded foreground shapes (tail -f, watch, sleep > 30s,
+    // sleep-loops, gh --watch, log followers) with an instructive
+    // "re-run with run_in_background: true" message.
+    expect(preCmds.some(c => c.includes("foreground-hog-pretool.mjs"))).toBe(true);
+    const fgHogEntry = preHooks.find(e =>
+      e.hooks.some(h => h.command.includes("foreground-hog-pretool.mjs")),
+    );
+    expect(fgHogEntry?.matcher).toBe("^Bash$");
   });
 
   it("with user hooks declared merges them with switchroom-owned hooks", () => {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -4566,6 +4566,39 @@ describe("secret-detect hook wiring", () => {
     expect(hook.timeout).toBe(10);
   });
 
+  it("wires foreground-hog-pretool.mjs scoped to ^Bash$", () => {
+    const agentConfig = makeAgentConfig();
+    const result = scaffoldAgent(
+      "sd-fghog-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+      makeConfig("sd-fghog-agent", agentConfig),
+    );
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const pre = settings.hooks.PreToolUse as Array<{
+      matcher?: string;
+      hooks: Array<{ command: string; timeout?: number }>;
+    }>;
+    const entry = pre.find((e) =>
+      e.hooks.some((h) => h.command.includes("foreground-hog-pretool.mjs")),
+    );
+    expect(entry).toBeDefined();
+    // Scoped so the stdin parse cost only lands on Bash calls.
+    expect(entry!.matcher).toBe("^Bash$");
+    const hook = entry!.hooks.find((h) =>
+      h.command.includes("foreground-hog-pretool.mjs"),
+    )!;
+    // Bundled hook path + node invocation, wrapped via run-hook.sh.
+    expect(hook.command).toMatch(/run-hook\.sh/);
+    expect(hook.command).toContain("node ");
+    expect(hook.command).toContain("/opt/switchroom/hooks/");
+    // Explicit short timeout — a pure tool_input gate never needs long.
+    expect(hook.timeout).toBe(10);
+  });
+
   it("preserves user-declared PreToolUse hooks alongside secret-guard", () => {
     const agentConfig = makeAgentConfig({
       hooks: { PreToolUse: [{ command: "/opt/audit.sh", timeout: 5 }] },


### PR DESCRIPTION
## Summary

Deterministic PreToolUse gate that DENIES effectively-unbounded **foreground** Bash commands with an instructive message: re-run the exact command with `run_in_background: true` (and act on the completion notification), or use a bounded alternative. Same family as the destructive-git detector (#3150): a conservative deny on known-bad shapes, not a heuristic classifier.

**What it gates** (foreground only — `run_in_background: true` always passes):
- `tail -f` / `tail -F` / `--follow` (incl. combined short flags like `-fn200`)
- `watch <cmd>`
- `sleep N` with N > 30s — bare or as a segment of a compound command (`npm run build && sleep 300`)
- sleep-in-a-loop (`while|until|for ... do ... sleep ... done`)
- `gh pr checks --watch`, `gh run watch`
- `docker logs -f/--follow`, `kubectl logs -f/--follow`, `journalctl -f` (incl. `-xef`)

**Deny message** (principles.md #1 — tells the model exactly what to do next, one line, no doc links):

> Foreground-hog gate: `tail -f/--follow` would hold the session foreground for its full duration. Re-run this exact command with `run_in_background: true` and act on the completion notification, or use a bounded alternative (e.g. `tail -n 200` instead of `tail -f`).

## Why conservative

False negatives are acceptable; false positives are not. Every rule is anchored on the command token of each foreground segment — generic build/test/deploy commands (`npm test`, `cargo build`, `vitest run`, `docker build && docker push`) are never matched, `--follow`/`-f` only counts for the four follower commands (so `git log --follow` passes), `watch` only as a command (so `watchman`, `stopwatch.ts`, quoted text pass), and shell-backgrounded segments (`tail -f x &`) pass because they don't hold the turn. Wrappers (`bash -c "..."`, `timeout 600 tail -f`) are deliberate false negatives, not parsed.

## Kill-switch (principles.md #2 — default ON, escape hatch not opt-in)

`SWITCHROOM_FOREGROUND_HOG_GATE=0|false|off|no` disables (trimmed, case-insensitive); unset or any other value keeps it enabled. Follows the repo's default-on kill-switch convention (`sendGateEnabledFromEnv`, #3153 shape).

## Sub-agent scoping decision

Main-session-only scoping is **not expressible at the hook layer**: Claude Code fires PreToolUse for sub-agent (Task) tool calls with the parent's session_id and no sidechain marker in the payload (documented at `telegram-plugin/hooks/tool-label-pretool.mjs` — "Claude Code does not pass sub-agent agent_id directly to the hook"), and sub-agents inherit the same settings.json hooks. Trade-off, made explicit: the gate applies inside workers too. The pattern list is therefore limited to shapes that are wrong even inside a worker — an unbounded follower, a `--watch` poll, or a > 30s dead foreground sleep should be backgrounded or bounded there as well (fleet dev protocol: no foreground watches over 30s, anywhere), and every gated shape has a trivial compliant alternative (`run_in_background: true` or a bounded flag).

## Registration (one more hook in the existing shape, no new mechanism)

- `src/cli/foreground-hog-pretool.ts` — the hook (deny = exit 0 + `{"decision":"block","reason"}`, fail-OPEN on protocol errors; exact template: `hindsight-mental-model-pretool`)
- `scripts/build.mjs` — bundled to `dist/cli/foreground-hog-pretool.mjs`
- `docker/Dockerfile.agent` — shipped to `/opt/switchroom/hooks/`
- `src/agents/scaffold.ts` — `switchroomPreToolUse` entry, matcher `^Bash$`, `run-hook.sh`-wrapped, timeout 10

## Test plan

- `tests/foreground-hog-pretool.test.ts` — full decision matrix (14 tests, spawn-driven against source like the hindsight hook test): every gated pattern → deny with the instructive message; near-misses (`tail -n 100`, `sleep 5`, `sleep 30`, `watchman`, `git log --follow`, `gh pr checks` without `--watch`, `docker logs --tail`, loop-without-sleep, `2>&1` fd redirects) → allow; shell-backgrounded segments → allow; `run_in_background: true` → allow; kill-switch off values → allow / junk values stay ON; non-Bash tools and malformed stdin → allow.
- `tests/scaffold.test.ts` — settings.json wiring (matcher, bundled path, run-hook.sh wrap, timeout).
- `tests/reconcile-hooks-drift.test.ts` — registration parity assertion.

Local: 14/14 new hook tests green; `tests/scaffold.test.ts` + `tests/reconcile-hooks-drift.test.ts` 224/224 green; `npm run lint` clean; `npm run build` bundles and the dist artifact was smoke-tested under `node` (deny + allow paths).

## Risk

Low. Fail-open on protocol errors; deny only on the explicit shape list; kill-switch requires no rebuild. Hook only fires on Bash (scoped matcher). Live in agents only after image rebuild + restart.

## Job spec

`reference/jobs/steer-or-queue-mid-flight.md` — a turn wedged behind an unbounded foreground command can't be steered, and the user can't tell why the agent went dark; also serves `feel-like-a-colleague`'s "no foreground watches over 30s" protocol by making it deterministic instead of prompt-dependent (dev protocol: deterministic mechanisms over model-dependent behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)