### PR TITLE
feat(auth): 429 throttle tier — retry in place under 5 min, else failover

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -208,6 +208,32 @@ When `exhausted_until` passes, the broker clears the mark. Agents
 that *prefer* the cleared account (it's first in their effective
 preference order) drift back on next idle.
 
+### 429 throttle tier — short throttles stay put
+
+Not every 429 is a wall. Anthropic also emits transient per-account
+burst throttles whose wording explicitly negates the quota reading
+("not your usage limit") and usually names a reset minutes away.
+Failing the whole fleet over for a 3-minute throttle is churn, so
+those take a lighter tier:
+
+- Reset within the retry-in-place threshold (default **5 minutes**,
+  override with `SWITCHROOM_THROTTLE_RETRY_IN_PLACE_MAX_MS`): the
+  gateway calls the broker's `mark-throttled` verb — the ledger entry
+  gains `throttled_until`, nothing rolls, the account stays fully
+  eligible. One lightweight notice (per account, cooldown-deduped)
+  tells you it's a throttle, not a wall, and when it resets; the dead
+  turn is retried automatically after the reset. No parseable reset →
+  a conservative 60-second wait.
+- Reset beyond the threshold, or genuine wall wording: the normal
+  mark-exhausted + fleet failover path, unchanged.
+- Escalation guard: 3 transient 429s on the same account inside 10
+  minutes trigger one live quota probe; only a probe that corroborates
+  a real wall converts the throttle into mark-exhausted + roll.
+
+Cron fires are throttle-aware: the scheduler's quota preflight
+soft-defers a fire while the agent's effective account is throttled
+and retries just past `throttled_until`.
+
 ### Soft-avoid tier — proactive preference before the wall
 
 `auth.proactive_failover_pct` (optional, e.g. `95`) adds a third
@@ -258,6 +284,7 @@ Recovery procedure: see
 | `get-credentials`     | any agent / consumer (own account only) |
 | `list-state`          | any agent / consumer                    |
 | `mark-exhausted`      | any agent / consumer (own account only) |
+| `mark-throttled`      | any agent / consumer (own account only) |
 | `set-active`          | admin                                   |
 | `refresh-account`     | admin                                   |
 | `add-account`         | admin                                   |

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -210,25 +210,39 @@ preference order) drift back on next idle.
 
 ### 429 throttle tier — short throttles stay put
 
-Not every 429 is a wall. Anthropic also emits transient per-account
-burst throttles whose wording explicitly negates the quota reading
-("not your usage limit") and usually names a reset minutes away.
-Failing the whole fleet over for a 3-minute throttle is churn, so
-those take a lighter tier:
+Not every 429 is a wall. Anthropic also emits transient burst
+throttles whose wording affirms the ACCOUNT's own rate limit ("would
+exceed your account's rate limit") and usually names a reset minutes
+away. Failing the whole fleet over for a 3-minute throttle is churn,
+so those take a lighter tier. Server-side transient wordings ("Server
+is temporarily limiting requests", 529 overload) are deliberately
+excluded — they stay on the calm rate-limited path, since an
+account-scoped mark would bench the wrong thing for a server-wide
+condition.
 
 - Reset within the retry-in-place threshold (default **5 minutes**,
   override with `SWITCHROOM_THROTTLE_RETRY_IN_PLACE_MAX_MS`): the
   gateway calls the broker's `mark-throttled` verb — the ledger entry
   gains `throttled_until`, nothing rolls, the account stays fully
-  eligible. One lightweight notice (per account, cooldown-deduped)
-  tells you it's a throttle, not a wall, and when it resets; the dead
-  turn is retried automatically after the reset. No parseable reset →
-  a conservative 60-second wait.
-- Reset beyond the threshold, or genuine wall wording: the normal
-  mark-exhausted + fleet failover path, unchanged.
+  eligible. One lightweight notice (per account, cooldown-deduped
+  locally AND fleet-wide via the broker's claim verb) tells you it's a
+  throttle, not a wall, and when it resets; the dead turn is retried
+  automatically after the reset (jittered so agents sharing the
+  account don't stampede, and never while a newer live turn is
+  running). No parseable reset → a conservative 60-second wait.
+- Reset beyond the threshold: the same mark-exhausted + fleet
+  failover mechanics as a wall, with the parsed reset as the mark
+  expiry and an honest "rate limit" headline. The rate-limit trigger
+  is trusted over the utilization probe here — a rate-limited account
+  typically probes healthy, which must not self-cancel the swap.
+- Genuine wall wording: the normal quota-exhausted path, unchanged.
 - Escalation guard: 3 transient 429s on the same account inside 10
   minutes trigger one live quota probe; only a probe that corroborates
-  a real wall converts the throttle into mark-exhausted + roll.
+  a real wall converts the throttle into mark-exhausted + roll. The
+  raising gateway announces that roll (covers pinned accounts too).
+  Re-marks within 5 seconds of the previous hit only refresh
+  `throttled_until` — they add no escalation hit and can trigger no
+  probe, so a simultaneous multi-agent burst counts once.
 
 Cron fires are throttle-aware: the scheduler's quota preflight
 soft-defers a fire while the agent's effective account is throttled

--- a/src/agent-scheduler/index.test.ts
+++ b/src/agent-scheduler/index.test.ts
@@ -20,6 +20,7 @@ import {
   registerAgentSchedule,
   resolveChannelTarget,
   resolveEntryThreadId,
+  resolveQuotaDeferDelayMs,
   type CronLib,
 } from "./index.js";
 
@@ -466,5 +467,69 @@ describe("registerAgentSchedule — quota preflight", () => {
     expect(r.pending).toHaveLength(1);
     tasks[0]!.task.stop();
     expect(r.pending[0]!.cancelled).toBe(true);
+  });
+
+  it("aims the retry at a throttle soft-defer's retryAtMs (429 throttle tier)", async () => {
+    const cron = fakeCron();
+    const sink = new InMemoryAuditSink();
+    const dispatcher = captureDispatcher({ delivered: true });
+    const NOW = 1_700_000_000_000;
+    const delays: number[] = [];
+    registerAgentSchedule({
+      entries: oneEntry, channel: chan, sink, cronLib: cron, dispatcher,
+      now: () => NOW,
+      quotaGate: async () => ({
+        defer: true,
+        reason: "account 'alice' rate-throttled (clears in 90s)",
+        retryAtMs: NOW + 90_000,
+      }),
+      scheduleRetry: (fn, ms) => {
+        delays.push(ms);
+        return { cancel: () => {} };
+      },
+    });
+
+    await cron.fire(0);
+
+    expect(dispatcher.calls).toHaveLength(0);
+    expect(sink.fires[0]!.exitCode).toBe(-2);
+    expect(sink.fires[0]!.outputSummary).toContain("rate-throttled");
+    // Aimed just past the throttle clear (90s + 2s slack), NOT the 60s ladder.
+    expect(delays).toEqual([92_000]);
+  });
+});
+
+describe("resolveQuotaDeferDelayMs — throttle-aimed retry delay", () => {
+  const NOW = 1_700_000_000_000;
+
+  it("keeps the backoff ladder when no retryAtMs is present (all-blocked defer)", () => {
+    expect(resolveQuotaDeferDelayMs({ defer: true, reason: "all" }, 60_000, NOW)).toBe(60_000);
+  });
+
+  it("aims 2s past retryAtMs", () => {
+    expect(
+      resolveQuotaDeferDelayMs(
+        { defer: true, reason: "throttled", retryAtMs: NOW + 90_000 },
+        60_000,
+        NOW,
+      ),
+    ).toBe(92_000);
+  });
+
+  it("bounds the aim: never sooner than 5s, never later than 10m", () => {
+    expect(
+      resolveQuotaDeferDelayMs(
+        { defer: true, reason: "throttled", retryAtMs: NOW - 1 },
+        60_000,
+        NOW,
+      ),
+    ).toBe(5_000);
+    expect(
+      resolveQuotaDeferDelayMs(
+        { defer: true, reason: "throttled", retryAtMs: NOW + 60 * 60_000 },
+        60_000,
+        NOW,
+      ),
+    ).toBe(10 * 60_000);
   });
 });

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -220,6 +220,23 @@ function defaultQuotaDeferBackoffMs(attempt: number): number {
   return [60_000, 180_000, 300_000][attempt] ?? 300_000;
 }
 
+/**
+ * Delay before a deferred fire's retry. A throttle soft-defer (429 throttle
+ * tier) carries `retryAtMs` — the throttled account's clear time — so the
+ * retry is aimed just past it (2s slack, bounded to 5s..10m) instead of the
+ * blind backoff ladder; every other defer keeps the default 1/3/5m backoff.
+ * Exported for tests.
+ */
+export function resolveQuotaDeferDelayMs(
+  decision: QuotaPreflightDecision,
+  fallbackMs: number,
+  nowMs: number,
+): number {
+  if (decision.retryAtMs === undefined) return fallbackMs;
+  const target = decision.retryAtMs - nowMs + 2_000;
+  return Math.min(Math.max(target, 5_000), 10 * 60_000);
+}
+
 export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
   const tasks: RegisteredTask[] = [];
   const now = opts.now ?? Date.now;
@@ -286,7 +303,7 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
             handle = scheduleRetry(() => {
               pendingRetries.delete(handle);
               void attemptFire(attempt + 1);
-            }, backoff(attempt));
+            }, resolveQuotaDeferDelayMs(decision, backoff(attempt), now()));
             pendingRetries.add(handle);
           }
           return;
@@ -894,10 +911,12 @@ export async function main(): Promise<void> {
   const quotaPreflightEnabled =
     process.env.SWITCHROOM_DISABLE_CRON_QUOTA_PREFLIGHT !== "1";
   const quotaGate = quotaPreflightEnabled
-    ? async (): Promise<QuotaPreflightDecision> => {
+    ? async (agent: string): Promise<QuotaPreflightDecision> => {
         const client = new AuthBrokerClient();
         try {
-          return decideQuotaPreflight(await client.listState());
+          // `agent` scopes the 429-throttle soft-defer to the agent's own
+          // EFFECTIVE account (its override, else the fleet active).
+          return decideQuotaPreflight(await client.listState(), { agent });
         } finally {
           await client.close().catch(() => {});
         }

--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -169,6 +169,14 @@ export interface AccountState {
   expiresAt?: number;
   exhausted: boolean;
   exhausted_until?: number;
+  /**
+   * 429 throttle tier — unix ms until which the account is transiently
+   * rate-limited (recorded by `mark-throttled`). Informational only: it never
+   * gates serving or failover eligibility. Cron quota-preflight soft-defers a
+   * fire while the agent's effective account carries a future value here.
+   * Absent on pre-throttle-tier brokers.
+   */
+  throttled_until?: number;
   threshold_violations?: number;
   last_refreshed_at?: number;
   /**
@@ -284,6 +292,18 @@ export interface MarkExhaustedData {
   /** The account the fleet rolled TO (next non-exhausted in fallback_order),
    *  or null when every fallback is also exhausted. Added so a non-admin
    *  caller can announce an accurate swap target without an admin set-active. */
+  rolledTo?: string | null;
+}
+
+export interface MarkThrottledData {
+  account: string;
+  /** The recorded (server-clamped) throttle expiry, unix ms. */
+  throttled_until: number;
+  /** True when the escalation guard fired: repeated transient 429s were
+   *  corroborated by a live probe as a genuine wall, so the broker marked
+   *  the account exhausted and rolled the fleet. */
+  escalated: boolean;
+  /** Set only when `escalated` — the roll target (null = all blocked). */
   rolledTo?: string | null;
 }
 
@@ -529,6 +549,24 @@ export class AuthBrokerClient {
       : { v: PROTOCOL_VERSION, id: randomUUID(), op: "mark-exhausted" };
     const data = await this.send(req);
     return data as MarkExhaustedData;
+  }
+
+  /**
+   * 429 throttle tier — record a transient per-account rate limit on the
+   * caller's bound account (`throttled_until` in the quota ledger). Never
+   * rolls the fleet and never blocks eligibility; the broker's escalation
+   * guard may corroborate repeated hits into a real mark-exhausted (see
+   * `MarkThrottledData.escalated`). Non-admin, same posture as
+   * `markExhausted`.
+   */
+  async markThrottled(until: number): Promise<MarkThrottledData> {
+    const data = await this.send({
+      v: PROTOCOL_VERSION,
+      id: randomUUID(),
+      op: "mark-throttled",
+      until,
+    });
+    return data as MarkThrottledData;
   }
 
   /**

--- a/src/auth/broker/protocol.test.ts
+++ b/src/auth/broker/protocol.test.ts
@@ -24,6 +24,7 @@ describe("protocol encode/decode", () => {
       { v: 1, id: "c", op: "set-active", account: "default" },
       { v: 1, id: "d", op: "mark-exhausted", until: 123 },
       { v: 1, id: "d2", op: "mark-exhausted" },
+      { v: 1, id: "d3", op: "mark-throttled", until: 456 },
       { v: 1, id: "e", op: "refresh-account", account: "default" },
       {
         v: 1,
@@ -51,6 +52,11 @@ describe("protocol encode/decode", () => {
 
   it("rejects unknown verbs", () => {
     const bad = JSON.stringify({ v: 1, id: "x", op: "wat" });
+    expect(() => decodeRequest(bad)).toThrow();
+  });
+
+  it("rejects mark-throttled without an until (required, unlike mark-exhausted)", () => {
+    const bad = JSON.stringify({ v: 1, id: "x", op: "mark-throttled" });
     expect(() => decodeRequest(bad)).toThrow();
   });
 

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -17,15 +17,17 @@
  *   - `list-state`      — fleet snapshot (accounts, agents, consumers).
  *   - `set-active`      — fleet-wide active-account swap (admin).
  *   - `mark-exhausted`  — quota event on caller's bound account.
+ *   - `mark-throttled`  — transient-429 throttle on caller's bound account
+ *                         (429 throttle tier; no roll, no ineligibility).
  *   - `refresh-account` — force a refresh tick (admin).
  *   - `add-account`     — register a new account (admin).
  *   - `rm-account`      — remove an account (admin).
  *   - `set-override`    — per-agent override (admin).
  *
- * `mark-exhausted` takes ONLY an `until` argument; the account it
- * affects is derived from path-identity. This closes the
- * fleet-wide spurious-deauth abuse path the round-1 review
- * flagged.
+ * `mark-exhausted` (and `mark-throttled`) take ONLY an `until`
+ * argument; the account they affect is derived from path-identity.
+ * This closes the fleet-wide spurious-deauth abuse path the round-1
+ * review flagged.
  *
  * **Provider field (RFC G Phase 3b.1):** Per-account verbs accept an
  * optional `provider:` field. When absent or `"anthropic"`, behavior
@@ -118,6 +120,27 @@ export const MarkExhaustedRequestSchema = z.object({
   id: z.string().min(1),
   /** Unix ms when the exhaustion clears. Defaults to now + 5h if omitted. */
   until: z.number().int().positive().optional(),
+});
+
+/**
+ * 429 throttle tier — a TRANSIENT per-account rate limit whose reset is near
+ * (retry-in-place, default ≤5 min). Records `throttled_until` in the quota
+ * ledger WITHOUT rolling the fleet and WITHOUT making the account ineligible
+ * for live sessions — eligibility (account-eligibility.ts) keys only on
+ * exhaustion marks and live snapshots. Consumers of `list-state` (cron
+ * quota-preflight) read `throttled_until` to soft-defer scheduled fires until
+ * the throttle clears.
+ *
+ * Same posture as `mark-exhausted`: non-admin, the affected account is
+ * derived from path-identity, never from the wire.
+ */
+export const MarkThrottledRequestSchema = z.object({
+  v: z.literal(PROTOCOL_VERSION),
+  op: z.literal("mark-throttled"),
+  id: z.string().min(1),
+  /** Unix ms when the throttle clears. Server-side clamped to a short
+   *  ceiling (throttles are minutes, never days). */
+  until: z.number().int().positive(),
 });
 
 export const RefreshAccountRequestSchema = z.object({
@@ -385,6 +408,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   ListStateRequestSchema,
   SetActiveRequestSchema,
   MarkExhaustedRequestSchema,
+  MarkThrottledRequestSchema,
   RefreshAccountRequestSchema,
   AddAccountRequestSchema,
   RmAccountRequestSchema,
@@ -410,6 +434,10 @@ export const AccountStateSchema = z.object({
   expiresAt: z.number().optional(),
   exhausted: z.boolean(),
   exhausted_until: z.number().optional(),
+  /** 429 throttle tier — unix ms until which the account is transiently
+   *  rate-limited (`mark-throttled`). Informational: never gates serving
+   *  or failover eligibility; cron quota-preflight soft-defers on it. */
+  throttled_until: z.number().optional(),
   threshold_violations: z.number().int().nonnegative().optional(),
   last_refreshed_at: z.number().optional(),
 });
@@ -455,6 +483,22 @@ export const MarkExhaustedDataSchema = z.object({
   // The account the fleet rolled TO (next non-exhausted in fallback_order),
   // or null when every fallback is also exhausted. Lets a non-admin caller
   // (auto-fallback) announce an accurate target without an admin set-active.
+  rolledTo: z.string().nullable().optional(),
+});
+
+export const MarkThrottledDataSchema = z.object({
+  account: z.string(),
+  /** The recorded (clamped) throttle expiry, unix ms. */
+  throttled_until: z.number(),
+  /**
+   * Escalation guard: true when this hit was the Nth transient 429 on the
+   * account inside the escalation window, the broker ran a live quota probe,
+   * and the probe CORROBORATED a genuine wall — so the broker marked the
+   * account exhausted and rolled the fleet (standard markExhaustedAndRoll).
+   */
+  escalated: z.boolean(),
+  /** Set only when `escalated` — the account the fleet rolled to (null when
+   *  every fallback was also exhausted). */
   rolledTo: z.string().nullable().optional(),
 });
 

--- a/src/auth/broker/server-mark-throttled.test.ts
+++ b/src/auth/broker/server-mark-throttled.test.ts
@@ -13,8 +13,12 @@
  *  - the escalation guard: 3 hits inside the window trigger ONE live probe;
  *    a probe that corroborates a wall converts to the standard
  *    mark-exhausted + fleet roll (mirror fanout, durable promote, audit
- *    reason "throttle-escalation", `last_fleet_roll` recorded); a healthy
- *    probe leaves the account merely throttled and re-arms the counter;
+ *    reason "throttle-escalation") — announced by the RAISING gateway from
+ *    the response, NOT via `last_fleet_roll` (reactive-path doctrine, which
+ *    also covers pinned-account rolls); a healthy probe leaves the account
+ *    merely throttled and re-arms the counter;
+ *  - the re-mark dedup: a mark within 5s of the previous hit refreshes the
+ *    expiry but adds NO hit and can trigger NO probe (probe-flood bound);
  *  - a later mark-exhausted PRESERVES the throttle fields in the entry.
  */
 
@@ -30,6 +34,8 @@ import { writeAccountCredentials } from "../account-store.js";
 import type { QuotaResult } from "../quota.js";
 
 const NOW = 1_800_000_000_000;
+/** Comfortably past the 5s re-mark dedup, well inside the 10-min window. */
+const HIT_SPACING_MS = 30_000;
 const AGENT: Identity = { kind: "agent", name: "ziggy", admin: false };
 
 interface Harness {
@@ -91,7 +97,7 @@ function quotaFor(table: QuotaTable, accessToken: string): QuotaResult {
 function makeBroker(opts: {
   accounts: string[];
   quotas: QuotaTable;
-}): { broker: AuthBroker; b: any; h: Harness } {
+}): { broker: AuthBroker; b: any; h: Harness; clock: { set(ms: number): void } } {
   const tmp = mkdtempSync(join(tmpdir(), "auth-broker-mark-throttled-"));
   const home = join(tmp, "home");
   const agentsDir = join(home, ".switchroom", "agents");
@@ -108,15 +114,16 @@ function makeBroker(opts: {
     agents: { ziggy: {} },
     auth: { active: "alice", fallback_order: ["alice", "bob"] },
   } as unknown as SwitchroomConfig;
+  let nowMs = NOW;
   const broker = new AuthBroker(config, {
     home,
     stateDir,
-    now: () => NOW,
+    now: () => nowMs,
     disableRefreshLoop: true,
     skipHealthyMarker: true,
     _testFetchQuota: async ({ accessToken }) => quotaFor(opts.quotas, accessToken),
   });
-  return { broker, b: broker as any, h };
+  return { broker, b: broker as any, h, clock: { set: (ms) => { nowMs = ms; } } };
 }
 
 /** Drive an op handler with a captured fake socket; parse the one response. */
@@ -218,20 +225,57 @@ describe("mark-throttled — ledger round-trip, no roll, no ineligibility", () =
   });
 });
 
+describe("mark-throttled — re-mark dedup (probe-flood bound)", () => {
+  it("a re-mark within 5s refreshes the expiry but adds NO escalation hit", async () => {
+    const { b } = makeBroker({
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 10, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    const r1 = await markThrottled(b, NOW + 60_000, "1");
+    expect(r1.data.throttled_until).toBe(NOW + 60_000);
+    // Simultaneous second agent marks a slightly later reset.
+    const r2 = await markThrottled(b, NOW + 90_000, "2");
+    expect(r2.data.escalated).toBe(false);
+    // Expiry keeps the LATER value; hit count stays 1.
+    expect(r2.data.throttled_until).toBe(NOW + 90_000);
+    expect(b.quota["alice"].throttle_hits).toEqual([NOW]);
+  });
+
+  it("a simultaneous 3-agent burst counts once and cannot trigger the probe", async () => {
+    let probes = 0;
+    const { b } = makeBroker({
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 10, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    (b as any).fetchQuotaImpl = async () => {
+      probes += 1;
+      return { ok: false as const, reason: "should not be probed" };
+    };
+    await markThrottled(b, NOW + 60_000, "1");
+    await markThrottled(b, NOW + 60_000, "2");
+    const r3 = await markThrottled(b, NOW + 60_000, "3");
+    expect(r3.data.escalated).toBe(false);
+    expect(probes).toBe(0);
+    expect(b.quota["alice"].throttle_hits).toEqual([NOW]);
+  });
+});
+
 describe("mark-throttled — escalation guard (3 hits / 10 min)", () => {
   it("escalates to mark-exhausted + fleet roll when the live probe corroborates a wall", async () => {
-    const { b, h } = makeBroker({
+    const { b, h, clock } = makeBroker({
       accounts: ["alice", "bob"],
       // alice is genuinely weekly-walled — the probe corroborates.
       quotas: { alice: { fiveHour: 10, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
     });
     const r1 = await markThrottled(b, NOW + 60_000, "1");
+    clock.set(NOW + HIT_SPACING_MS);
     const r2 = await markThrottled(b, NOW + 60_000, "2");
     expect(r1.data.escalated).toBe(false);
     expect(r2.data.escalated).toBe(false);
     expect(mirrorToken(h, "ziggy")).toBe(null); // still no roll after 2 hits
 
-    const r3 = await markThrottled(b, NOW + 60_000, "3");
+    clock.set(NOW + 2 * HIT_SPACING_MS);
+    const r3 = await markThrottled(b, NOW + 60_000 + 2 * HIT_SPACING_MS, "3");
     expect(r3.data.escalated).toBe(true);
     expect(r3.data.rolledTo).toBe("bob");
 
@@ -242,52 +286,58 @@ describe("mark-throttled — escalation guard (3 hits / 10 min)", () => {
     expect(b.config.auth?.active).toBe("bob");
     expect(b.isAccountExhausted("alice")).toBe(true);
 
-    // Escalation is attributed in the audit, and the broker-initiated roll
-    // rides the last_fleet_roll announcement channel.
+    // Escalation is attributed in the audit.
     expect(
       auditRows(h).some(
         (r) => r.op === "mark-exhausted" && r.reason === "throttle-escalation",
       ),
     ).toBe(true);
-    expect(b.lastFleetRoll).toMatchObject({ from: "alice", to: "bob" });
+
+    // Reactive-path doctrine: NO last_fleet_roll record — the RAISING gateway
+    // announces from this op's response ({escalated, rolledTo}), which also
+    // covers pinned (non-fleet-active) rolls the fleet channel would skip.
+    expect(b.lastFleetRoll).toBe(null);
 
     // Counter cleared after the escalation probe.
     expect(b.quota["alice"].throttle_hits).toEqual([]);
   });
 
   it("does NOT escalate when the live probe shows the account healthy — counter re-arms", async () => {
-    const { b, h } = makeBroker({
+    const { b, h, clock } = makeBroker({
       accounts: ["alice", "bob"],
       quotas: { alice: { fiveHour: 40, sevenDay: 30 }, bob: { fiveHour: 5, sevenDay: 10 } },
     });
     await markThrottled(b, NOW + 60_000, "1");
+    clock.set(NOW + HIT_SPACING_MS);
     await markThrottled(b, NOW + 60_000, "2");
-    const r3 = await markThrottled(b, NOW + 60_000, "3");
+    clock.set(NOW + 2 * HIT_SPACING_MS);
+    const until3 = NOW + 60_000 + 2 * HIT_SPACING_MS;
+    const r3 = await markThrottled(b, until3, "3");
     expect(r3.data.escalated).toBe(false);
     expect(r3.data.rolledTo).toBe(null);
 
     // Still merely throttled: no mark, no roll, counter cleared (one probe
     // per burst, not one per subsequent hit).
     expect(b.quota["alice"].exhausted_until).toBeUndefined();
-    expect(b.quota["alice"].throttled_until).toBe(NOW + 60_000);
+    expect(b.quota["alice"].throttled_until).toBe(until3);
     expect(b.quota["alice"].throttle_hits).toEqual([]);
     expect(mirrorToken(h, "ziggy")).toBe(null);
     expect(auditRows(h).some((r) => r.op === "mark-exhausted")).toBe(false);
   });
 
   it("hits OUTSIDE the 10-min window do not count toward escalation", async () => {
-    const { broker, b } = makeBroker({
+    const { b, clock } = makeBroker({
       accounts: ["alice", "bob"],
       quotas: { alice: { fiveHour: 10, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
     });
-    // Two old hits, aged past the window.
-    let clock = NOW;
-    (broker as any).now = () => clock;
-    await markThrottled(b, clock + 60_000, "1");
-    await markThrottled(b, clock + 60_000, "2");
-    clock = NOW + 11 * 60_000; // both prior hits now outside the window
-    const r3 = await markThrottled(b, clock + 60_000, "3");
+    // Two old hits, spaced past the dedup, then aged past the window.
+    await markThrottled(b, NOW + 60_000, "1");
+    clock.set(NOW + HIT_SPACING_MS);
+    await markThrottled(b, NOW + 60_000, "2");
+    const late = NOW + 12 * 60_000; // both prior hits now outside the window
+    clock.set(late);
+    const r3 = await markThrottled(b, late + 60_000, "3");
     expect(r3.data.escalated).toBe(false);
-    expect(b.quota["alice"].throttle_hits).toEqual([clock]);
+    expect(b.quota["alice"].throttle_hits).toEqual([late]);
   });
 });

--- a/src/auth/broker/server-mark-throttled.test.ts
+++ b/src/auth/broker/server-mark-throttled.test.ts
@@ -1,0 +1,293 @@
+/**
+ * mark-throttled — the 429 throttle tier's broker verb.
+ *
+ * Drives `opMarkThrottled` on a real AuthBroker (tmpdir home/state,
+ * `_testFetchQuota` seam, fake socket — no listeners) and pins the
+ * OUTCOMES the tier promises:
+ *
+ *  - the ledger round-trip: `throttled_until` recorded + persisted to
+ *    quota.json, response carries {account, throttled_until, escalated};
+ *  - NO roll and NO ineligibility: agent mirrors untouched, `auth.active`
+ *    untouched, the account still reads eligible / not exhausted;
+ *  - the clamp: a bogus long throttle is bounded to the short ceiling;
+ *  - the escalation guard: 3 hits inside the window trigger ONE live probe;
+ *    a probe that corroborates a wall converts to the standard
+ *    mark-exhausted + fleet roll (mirror fanout, durable promote, audit
+ *    reason "throttle-escalation", `last_fleet_roll` recorded); a healthy
+ *    probe leaves the account merely throttled and re-arms the counter;
+ *  - a later mark-exhausted PRESERVES the throttle fields in the entry.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AuthBroker } from "./server.js";
+import type { Identity } from "./peercred.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import { writeAccountCredentials } from "../account-store.js";
+import type { QuotaResult } from "../quota.js";
+
+const NOW = 1_800_000_000_000;
+const AGENT: Identity = { kind: "agent", name: "ziggy", admin: false };
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+}
+
+let harnesses: Harness[] = [];
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try {
+      rmSync(h.tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  harnesses = [];
+});
+
+function seedAccount(home: string, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: "at-" + label,
+        refreshToken: "rt-" + label,
+        expiresAt: NOW + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    },
+    home,
+  );
+}
+
+type QuotaTable = Record<string, { fiveHour: number; sevenDay: number }>;
+
+function quotaFor(table: QuotaTable, accessToken: string): QuotaResult {
+  const label = accessToken.replace(/^at-/, "");
+  const q = table[label];
+  if (!q) return { ok: false, reason: "no fixture for " + label };
+  return {
+    ok: true,
+    data: {
+      fiveHourUtilizationPct: q.fiveHour,
+      sevenDayUtilizationPct: q.sevenDay,
+      fiveHourResetAt: null,
+      sevenDayResetAt: q.sevenDay >= 99.5 ? new Date(NOW + 3 * 86_400_000) : null,
+      representativeClaim: q.sevenDay >= 99.5 ? "seven_day" : null,
+      overageStatus: null,
+      overageDisabledReason: null,
+    },
+  };
+}
+
+function makeBroker(opts: {
+  accounts: string[];
+  quotas: QuotaTable;
+}): { broker: AuthBroker; b: any; h: Harness } {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-mark-throttled-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  mkdirSync(agentsDir, { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+  mkdirSync(join(agentsDir, "ziggy"), { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir };
+  harnesses.push(h);
+  for (const label of opts.accounts) seedAccount(home, label);
+  const config = {
+    switchroom: { version: 1, agents_dir: agentsDir },
+    telegram: {},
+    agents: { ziggy: {} },
+    auth: { active: "alice", fallback_order: ["alice", "bob"] },
+  } as unknown as SwitchroomConfig;
+  const broker = new AuthBroker(config, {
+    home,
+    stateDir,
+    now: () => NOW,
+    disableRefreshLoop: true,
+    skipHealthyMarker: true,
+    _testFetchQuota: async ({ accessToken }) => quotaFor(opts.quotas, accessToken),
+  });
+  return { broker, b: broker as any, h };
+}
+
+/** Drive an op handler with a captured fake socket; parse the one response. */
+async function markThrottled(
+  b: any,
+  until: number,
+  id = "1",
+): Promise<{ ok: boolean; data?: any; error?: any }> {
+  const frames: string[] = [];
+  const socket = { write: (s: string) => frames.push(s) };
+  await b.opMarkThrottled(socket, id, AGENT, until);
+  expect(frames).toHaveLength(1);
+  return JSON.parse(frames[0]);
+}
+
+async function listState(b: any): Promise<any> {
+  const frames: string[] = [];
+  const socket = { write: (s: string) => frames.push(s) };
+  await b.opListState(socket, "ls", AGENT);
+  return JSON.parse(frames[0]).data;
+}
+
+function auditRows(h: Harness): Array<{ op: string; account?: string; reason?: string }> {
+  const p = join(h.stateDir, "audit.jsonl");
+  if (!existsSync(p)) return [];
+  return readFileSync(p, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+function mirrorToken(h: Harness, agent: string): string | null {
+  const p = join(h.agentsDir, agent, ".claude", ".credentials.json");
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, "utf-8")).claudeAiOauth?.accessToken ?? null;
+}
+
+describe("mark-throttled — ledger round-trip, no roll, no ineligibility", () => {
+  it("records throttled_until, persists it, and does NOT roll or block the account", async () => {
+    const { b, h } = makeBroker({
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 10, sevenDay: 20 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    const until = NOW + 90_000;
+    const resp = await markThrottled(b, until);
+    expect(resp.ok).toBe(true);
+    expect(resp.data).toMatchObject({
+      account: "alice",
+      throttled_until: until,
+      escalated: false,
+      rolledTo: null,
+    });
+
+    // Ledger: throttle recorded WITHOUT an exhaustion mark, and persisted.
+    expect(b.quota["alice"]).toMatchObject({ throttled_until: until });
+    expect(b.quota["alice"].exhausted_until).toBeUndefined();
+    const onDisk = JSON.parse(readFileSync(join(h.stateDir, "quota.json"), "utf-8"));
+    expect(onDisk["alice"]).toMatchObject({ throttled_until: until });
+
+    // NO roll: no mirror fanout, active untouched, no override persisted.
+    expect(mirrorToken(h, "ziggy")).toBe(null);
+    expect(b.config.auth?.active).toBe("alice");
+    expect(existsSync(join(h.stateDir, "active-override.json"))).toBe(false);
+
+    // NO ineligibility: the account still serves and reads healthy.
+    expect(b.isAccountExhausted("alice")).toBe(false);
+    const state = await listState(b);
+    const alice = state.accounts.find((a: any) => a.label === "alice");
+    expect(alice.exhausted).toBe(false);
+    expect(alice.throttled_until).toBe(until);
+
+    // Audited under its own op name; no mark-exhausted row.
+    expect(auditRows(h).some((r) => r.op === "mark-throttled" && r.account === "alice")).toBe(true);
+    expect(auditRows(h).some((r) => r.op === "mark-exhausted")).toBe(false);
+  });
+
+  it("clamps a bogus long throttle to the short ceiling (30 min)", async () => {
+    const { b } = makeBroker({
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 10, sevenDay: 20 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    const resp = await markThrottled(b, NOW + 7 * 24 * 60 * 60 * 1000);
+    expect(resp.data.throttled_until).toBe(NOW + 30 * 60 * 1000);
+  });
+
+  it("a later mark-exhausted PRESERVES the throttle fields in the same entry", async () => {
+    const { b } = makeBroker({
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 10, sevenDay: 20 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    const until = NOW + 90_000;
+    await markThrottled(b, until);
+    await b.markExhaustedAndRoll("alice", NOW + 60 * 60 * 1000, AGENT);
+    expect(b.quota["alice"]).toMatchObject({
+      throttled_until: until,
+      exhausted_until: NOW + 60 * 60 * 1000,
+      marked_at: NOW,
+    });
+  });
+});
+
+describe("mark-throttled — escalation guard (3 hits / 10 min)", () => {
+  it("escalates to mark-exhausted + fleet roll when the live probe corroborates a wall", async () => {
+    const { b, h } = makeBroker({
+      accounts: ["alice", "bob"],
+      // alice is genuinely weekly-walled — the probe corroborates.
+      quotas: { alice: { fiveHour: 10, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    const r1 = await markThrottled(b, NOW + 60_000, "1");
+    const r2 = await markThrottled(b, NOW + 60_000, "2");
+    expect(r1.data.escalated).toBe(false);
+    expect(r2.data.escalated).toBe(false);
+    expect(mirrorToken(h, "ziggy")).toBe(null); // still no roll after 2 hits
+
+    const r3 = await markThrottled(b, NOW + 60_000, "3");
+    expect(r3.data.escalated).toBe(true);
+    expect(r3.data.rolledTo).toBe("bob");
+
+    // Standard exhaustion mechanics ran: mark with the probe's weekly reset,
+    // fleet mirror fanout, durable promote.
+    expect(b.quota["alice"].exhausted_until).toBe(NOW + 3 * 86_400_000);
+    expect(mirrorToken(h, "ziggy")).toBe("at-bob");
+    expect(b.config.auth?.active).toBe("bob");
+    expect(b.isAccountExhausted("alice")).toBe(true);
+
+    // Escalation is attributed in the audit, and the broker-initiated roll
+    // rides the last_fleet_roll announcement channel.
+    expect(
+      auditRows(h).some(
+        (r) => r.op === "mark-exhausted" && r.reason === "throttle-escalation",
+      ),
+    ).toBe(true);
+    expect(b.lastFleetRoll).toMatchObject({ from: "alice", to: "bob" });
+
+    // Counter cleared after the escalation probe.
+    expect(b.quota["alice"].throttle_hits).toEqual([]);
+  });
+
+  it("does NOT escalate when the live probe shows the account healthy — counter re-arms", async () => {
+    const { b, h } = makeBroker({
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 40, sevenDay: 30 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    await markThrottled(b, NOW + 60_000, "1");
+    await markThrottled(b, NOW + 60_000, "2");
+    const r3 = await markThrottled(b, NOW + 60_000, "3");
+    expect(r3.data.escalated).toBe(false);
+    expect(r3.data.rolledTo).toBe(null);
+
+    // Still merely throttled: no mark, no roll, counter cleared (one probe
+    // per burst, not one per subsequent hit).
+    expect(b.quota["alice"].exhausted_until).toBeUndefined();
+    expect(b.quota["alice"].throttled_until).toBe(NOW + 60_000);
+    expect(b.quota["alice"].throttle_hits).toEqual([]);
+    expect(mirrorToken(h, "ziggy")).toBe(null);
+    expect(auditRows(h).some((r) => r.op === "mark-exhausted")).toBe(false);
+  });
+
+  it("hits OUTSIDE the 10-min window do not count toward escalation", async () => {
+    const { broker, b } = makeBroker({
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 10, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    // Two old hits, aged past the window.
+    let clock = NOW;
+    (broker as any).now = () => clock;
+    await markThrottled(b, clock + 60_000, "1");
+    await markThrottled(b, clock + 60_000, "2");
+    clock = NOW + 11 * 60_000; // both prior hits now outside the window
+    const r3 = await markThrottled(b, clock + 60_000, "3");
+    expect(r3.data.escalated).toBe(false);
+    expect(b.quota["alice"].throttle_hits).toEqual([clock]);
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -16,7 +16,8 @@
  *   - NDJSON over UDS, 64 KiB frame cap, identity derived from bind path.
  *
  * Verbs (RFC H §4.3): get-credentials, list-state, set-active,
- * mark-exhausted, refresh-account, add-account, rm-account, set-override.
+ * mark-exhausted, mark-throttled, refresh-account, add-account,
+ * rm-account, set-override.
  */
 
 import * as net from "node:net";
@@ -132,6 +133,19 @@ const REFRESH_TICK_INTERVAL_MS = 60 * 1000;
  * the legacy quota-store default and Anthropic's typical 429 reset window. */
 const MARK_EXHAUSTED_DEFAULT_MS = 5 * 60 * 60 * 1000;
 
+/** Ceiling on a `mark-throttled.until` (429 throttle tier). Transient burst /
+ * RPM throttles clear in seconds-to-minutes; anything longer is the failover
+ * path's business (the gateway escalates long resets to mark-exhausted), so a
+ * bogus long throttle is clamped rather than lingering in the ledger. */
+const MARK_THROTTLED_MAX_MS = 30 * 60 * 1000;
+
+/** Escalation guard (429 throttle tier): this many transient-429 hits on the
+ * same account inside the window trigger a live quota probe; a probe that
+ * corroborates a genuine wall converts the throttle into the standard
+ * mark-exhausted + fleet roll. */
+const THROTTLE_ESCALATION_HITS = 3;
+const THROTTLE_ESCALATION_WINDOW_MS = 10 * 60 * 1000;
+
 /** Audit-log size cap before rotation (10 MB, per RFC §4.4). */
 const AUDIT_ROTATE_BYTES = 10 * 1024 * 1024;
 const AUDIT_KEEP = 5;
@@ -149,13 +163,25 @@ interface ThresholdViolations {
 }
 
 interface QuotaEntry {
-  exhausted_until: number;
+  /** Unix ms until which the account is exhausted (a real quota wall).
+   *  Optional since the 429 throttle tier: a throttle-only entry carries
+   *  `throttled_until` with no exhaustion mark. */
+  exhausted_until?: number;
   /** Unix ms when this mark was written. Lets eligibility compare the mark's
    *  recency against a live snapshot (most-recent-signal-wins). Optional for
    *  backward-compat with marks persisted before 2026-06-10 — a legacy mark
    *  with no `marked_at` is treated as older than any fresh probe, so live
    *  truth overrides it (the safe direction). */
   marked_at?: number;
+  /** 429 throttle tier — unix ms until which the account is transiently
+   *  rate-limited (`mark-throttled`). NEVER consulted by eligibility
+   *  (account-eligibility.ts keys on exhaustion marks + live snapshots
+   *  only); read by list-state consumers (cron quota-preflight soft-defer). */
+  throttled_until?: number;
+  /** Unix ms timestamps of recent `mark-throttled` hits — the escalation
+   *  counter. Pruned to THROTTLE_ESCALATION_WINDOW_MS on every hit; cleared
+   *  after an escalation probe runs (corroborated or not). */
+  throttle_hits?: number[];
 }
 interface QuotaState {
   [label: string]: QuotaEntry;
@@ -946,6 +972,9 @@ export class AuthBroker {
         case "mark-exhausted":
           await this.opMarkExhausted(socket, reqId, identity, req.until);
           break;
+        case "mark-throttled":
+          await this.opMarkThrottled(socket, reqId, identity, req.until);
+          break;
         case "refresh-account": {
           const provider: ProviderName = req.provider ?? "anthropic";
           // Phase 3b.1b: gate via registry.has() — when 3b.2 registers
@@ -1213,9 +1242,23 @@ export class AuthBroker {
     return (this.config.auth?.allow_overage_accounts ?? []).includes(account);
   }
 
+  /**
+   * View a quota-ledger entry as an eligibility `ExhaustionMark` — only when
+   * it actually carries an exhaustion mark. A throttle-only entry (429
+   * throttle tier: `throttled_until` with no `exhausted_until`) is NOT a
+   * mark: it must never gate serving or failover eligibility.
+   */
+  private exhaustionMarkOf(
+    account: string,
+  ): { exhausted_until: number; marked_at?: number } | undefined {
+    const q = this.quota[account];
+    if (!q || q.exhausted_until === undefined) return undefined;
+    return { exhausted_until: q.exhausted_until, marked_at: q.marked_at };
+  }
+
   private isAccountExhausted(account: string): boolean {
     return evalAccountBlocked({
-      mark: this.quota[account],
+      mark: this.exhaustionMarkOf(account),
       snapshot: this.lastQuotaCache[account],
       now: this.now(),
       allowOverage: this.isOverageAllowed(account),
@@ -1334,7 +1377,7 @@ export class AuthBroker {
     // last probe still blocks (a fresh refusal wins).
     return (
       accountEligibility({
-        mark: this.quota[account],
+        mark: this.exhaustionMarkOf(account),
         snapshot,
         now,
         allowOverage: true,
@@ -1354,7 +1397,7 @@ export class AuthBroker {
     const snapshot = this.lastQuotaCache[account];
     const allowOverage = this.isOverageAllowed(account);
     const verdict = accountEligibility({
-      mark: this.quota[account],
+      mark: this.exhaustionMarkOf(account),
       snapshot,
       now: this.now(),
       allowOverage,
@@ -1613,6 +1656,9 @@ export class AuthBroker {
         expiresAt: creds?.claudeAiOauth?.expiresAt,
         exhausted,
         exhausted_until: q?.exhausted_until,
+        // 429 throttle tier — raw ledger value for transparency (consumers
+        // compare against their own clock). Never feeds `exhausted`.
+        throttled_until: q?.throttled_until,
         threshold_violations: this.thresholdViolations[label] ?? 0,
         last_refreshed_at: meta?.lastRefreshedAt,
         // Cached utilization snapshot from the most recent probeQuota call.
@@ -1832,7 +1878,7 @@ export class AuthBroker {
     // misfired/expired exhaustion can't linger on disk and survive restarts
     // (the sticky-bogus-+7d-mark that outlasted recreate on 2026-06-10). A
     // genuine weekly wall (7d≥99.5%) is never "clearly healthy" → never cleared.
-    if (snapshotShouldClearMark(snapshot, this.quota[label], this.now())) {
+    if (snapshotShouldClearMark(snapshot, this.exhaustionMarkOf(label), this.now())) {
       delete this.quota[label];
       this.persistQuota();
       process.stdout.write(
@@ -2109,7 +2155,9 @@ export class AuthBroker {
       // Idempotent: skip the write/persist if already marked at/past this reset.
       const existing = this.quota[label]?.exhausted_until;
       if (existing !== undefined && existing >= exhaustedUntil) continue;
-      this.quota[label] = { exhausted_until: exhaustedUntil, marked_at: now };
+      // Spread preserves throttle-tier fields (throttled_until/throttle_hits)
+      // living beside the exhaustion mark in the same ledger entry.
+      this.quota[label] = { ...this.quota[label], exhausted_until: exhaustedUntil, marked_at: now };
       this.persistQuota();
       this.audit({ op: "mark-exhausted", identity: { kind: "operator" }, account: label, accountKind: "claude", ok: true });
       process.stdout.write(
@@ -2181,6 +2229,127 @@ export class AuthBroker {
   }
 
   /**
+   * 429 throttle tier — record a TRANSIENT per-account rate limit on the
+   * caller's bound account. Unlike `mark-exhausted` this:
+   *   - rolls NOTHING (no fanout, no promote — the fleet stays put), and
+   *   - blocks NOTHING (eligibility keys only on exhaustion marks + live
+   *     snapshots; `throttled_until` is invisible to it by construction —
+   *     see `exhaustionMarkOf`).
+   * Consumers of `list-state` (cron quota-preflight) read `throttled_until`
+   * to soft-defer scheduled fires until the throttle clears.
+   *
+   * Escalation guard: THROTTLE_ESCALATION_HITS transient 429s on the same
+   * account inside THROTTLE_ESCALATION_WINDOW_MS smell like a genuine wall
+   * hiding behind transient wording. Run ONE live quota probe; only a probe
+   * that CORROBORATES exhaustion (same overage-aware test every other trigger
+   * uses) converts the throttle into the standard mark-exhausted + fleet roll.
+   * The hit counter is cleared after any escalation probe — corroborated or
+   * not — so a persistent burst re-arms over a fresh window instead of
+   * probing on every subsequent hit.
+   */
+  private async opMarkThrottled(
+    socket: net.Socket,
+    id: string,
+    identity: Identity,
+    until: number,
+  ): Promise<void> {
+    const account = this.callerAccount(identity);
+    if (!account) {
+      this.audit({ op: "mark-throttled", identity, accountKind: "claude", ok: false, error: "no-active-account" });
+      socket.write(encodeError(id, "ACCOUNT_NOT_FOUND", "no active account configured"));
+      return;
+    }
+    const now = this.now();
+    // Clamp: a throttle is minutes, never days. Past/short values still get
+    // a floor of now+1s so the entry is observably "throttled right now".
+    const throttledUntil = Math.min(
+      Math.max(until, now + 1000),
+      now + MARK_THROTTLED_MAX_MS,
+    );
+    const entry = this.quota[account] ?? {};
+    const hits = (entry.throttle_hits ?? []).filter(
+      (t) => now - t < THROTTLE_ESCALATION_WINDOW_MS,
+    );
+    hits.push(now);
+    const escalate = hits.length >= THROTTLE_ESCALATION_HITS;
+    this.quota[account] = {
+      ...entry,
+      throttled_until: throttledUntil,
+      // Clear the counter when the escalation probe runs (below); otherwise
+      // carry the pruned window forward.
+      throttle_hits: escalate ? [] : hits,
+    };
+    this.persistQuota();
+    this.audit({ op: "mark-throttled", identity, account, accountKind: "claude", ok: true });
+    process.stdout.write(
+      `auth-broker: mark-throttled ${account} until ${new Date(throttledUntil).toISOString()} ` +
+        `(hit ${hits.length}/${THROTTLE_ESCALATION_HITS} in window)\n`,
+    );
+
+    let escalated = false;
+    let rolledTo: string | null = null;
+    if (escalate) {
+      const probe = await this.probeThrottleEscalation(account);
+      if (probe.exhausted) {
+        escalated = true;
+        process.stdout.write(
+          `auth-broker: throttle-escalation probe corroborates wall on ${account} — mark-exhausted + roll\n`,
+        );
+        this.audit({ op: "mark-exhausted", identity, account, accountKind: "claude", ok: true, reason: "throttle-escalation" });
+        // Capture the fleet active BEFORE the roll — a corroborated roll
+        // auto-promotes the target, so reading it afterwards would compare
+        // against the NEW active and never record the announcement.
+        const wasFleetActive = account === this.config.auth?.active;
+        const roll = await this.markExhaustedAndRoll(account, probe.until ?? undefined, identity);
+        rolledTo = roll.rolledTo;
+        // Broker-initiated roll with no announcing gateway (the throttle path
+        // posts only the lightweight notice) → record it on the same
+        // `last_fleet_roll` channel the proactive probe uses, so the
+        // quota-watch announcement (dedup'd fleet-wide) reaches the operator.
+        if (rolledTo && wasFleetActive) {
+          this.recordFleetRoll(account, rolledTo, "hard-exhaustion", probe.until ?? undefined);
+        }
+      } else {
+        process.stdout.write(
+          `auth-broker: throttle-escalation probe on ${account} did NOT corroborate a wall — staying throttled\n`,
+        );
+      }
+    }
+    socket.write(
+      encodeSuccess(id, {
+        account,
+        throttled_until: throttledUntil,
+        escalated,
+        rolledTo: escalated ? rolledTo : null,
+      }),
+    );
+  }
+
+  /**
+   * Live-probe `account` for the throttle escalation guard. Returns the
+   * overage-aware exhaustion decision; a failed probe (no creds, network
+   * error) is `exhausted:false` — never escalate on missing evidence.
+   * Caches a successful probe so the dashboard / eligibility see the fresh
+   * snapshot (and so markExhaustedAndRoll's corroboration gate can act on it).
+   */
+  private async probeThrottleEscalation(
+    account: string,
+  ): Promise<{ exhausted: boolean; until: number | null }> {
+    const creds = readAccountCredentials(account, this.home);
+    const token = creds?.claudeAiOauth?.accessToken;
+    if (!token) return { exhausted: false, until: null };
+    let result: QuotaResult;
+    try {
+      result = await this.fetchQuotaImpl({ accessToken: token });
+    } catch (err) {
+      this.logErr(`throttle-escalation probe ${account}: ${(err as Error).message}`);
+      return { exhausted: false, until: null };
+    }
+    this.cacheQuotaSnapshot(account, result);
+    return quotaIndicatesExhaustion(result, this.isOverageAllowed(account));
+  }
+
+  /**
    * Mark `account` exhausted, roll the fleet off it, and — when the walled
    * account was the fleet active — promote the roll target to nominal
    * `auth.active` (persisted). Shared core of the `mark-exhausted` op (the
@@ -2205,7 +2374,9 @@ export class AuthBroker {
       shortMs: MARK_EXHAUSTED_DEFAULT_MS,
       snapshot: this.lastQuotaCache[account],
     });
-    this.quota[account] = { exhausted_until: exhaustedUntil, marked_at: now };
+    // Spread preserves throttle-tier fields (throttled_until/throttle_hits)
+    // living beside the exhaustion mark in the same ledger entry.
+    this.quota[account] = { ...this.quota[account], exhausted_until: exhaustedUntil, marked_at: now };
     this.persistQuota();
     // Fan out next-fallback creds to every agent whose active account is
     // `account`. Uses the LIVE selector (Bug 1): force-probe an `unknown`
@@ -3620,11 +3791,13 @@ export class AuthBroker {
     replace?: boolean;
     /**
      * Trigger attribution for probe-driven failover rolls (#3031 PR 2):
-     *   "soft-avoid"       — serving-preference roll off the soft-avoid tier
-     *   "hard-exhaustion"  — the probe saw a genuine quota wall
+     *   "soft-avoid"          — serving-preference roll off the soft-avoid tier
+     *   "hard-exhaustion"     — the probe saw a genuine quota wall
+     *   "throttle-escalation" — repeated transient 429s corroborated by a live
+     *                           probe (429 throttle tier escalation guard)
      * Omitted for every other op.
      */
-    reason?: "soft-avoid" | "hard-exhaustion";
+    reason?: "soft-avoid" | "hard-exhaustion" | "throttle-escalation";
   }): void {
     const peer =
       entry.identity.kind === "operator"

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -146,6 +146,13 @@ const MARK_THROTTLED_MAX_MS = 30 * 60 * 1000;
 const THROTTLE_ESCALATION_HITS = 3;
 const THROTTLE_ESCALATION_WINDOW_MS = 10 * 60 * 1000;
 
+/** Re-mark dedup (429 throttle tier): a mark landing within this interval of
+ * the account's previous hit only refreshes `throttled_until` (keeping the
+ * later expiry) — it adds no escalation hit and can trigger no probe. Bounds
+ * the probe-flood when many agents sharing one account 429 simultaneously
+ * (one burst counts as one hit). */
+const MARK_THROTTLED_MIN_INTERVAL_MS = 5 * 1000;
+
 /** Audit-log size cap before rotation (10 MB, per RFC §4.4). */
 const AUDIT_ROTATE_BYTES = 10 * 1024 * 1024;
 const AUDIT_KEEP = 5;
@@ -2245,7 +2252,16 @@ export class AuthBroker {
    * uses) converts the throttle into the standard mark-exhausted + fleet roll.
    * The hit counter is cleared after any escalation probe — corroborated or
    * not — so a persistent burst re-arms over a fresh window instead of
-   * probing on every subsequent hit.
+   * probing on every subsequent hit. Marks within
+   * MARK_THROTTLED_MIN_INTERVAL_MS of the previous hit only refresh
+   * `throttled_until` (no hit, no probe) — a simultaneous multi-agent burst
+   * counts once and cannot flood probes.
+   *
+   * Announcement doctrine: an escalated roll is NOT recorded in
+   * `last_fleet_roll` — this is a REACTIVE path (see the LastFleetRoll
+   * docstring), so the RAISING gateway announces from this op's response
+   * (`escalated` + `rolledTo`), which also covers rolls of PINNED
+   * (non-fleet-active) override accounts that the fleet channel would skip.
    */
   private async opMarkThrottled(
     socket: net.Socket,
@@ -2267,9 +2283,32 @@ export class AuthBroker {
       now + MARK_THROTTLED_MAX_MS,
     );
     const entry = this.quota[account] ?? {};
-    const hits = (entry.throttle_hits ?? []).filter(
-      (t) => now - t < THROTTLE_ESCALATION_WINDOW_MS,
-    );
+    const priorHits = entry.throttle_hits ?? [];
+    const lastHit = priorHits.length > 0 ? priorHits[priorHits.length - 1] : undefined;
+
+    // Re-mark dedup: a burst of near-simultaneous marks (N agents sharing the
+    // throttled account) refreshes the expiry but counts as ONE hit and can
+    // trigger no probe — the probe-flood bound.
+    if (lastHit !== undefined && now - lastHit < MARK_THROTTLED_MIN_INTERVAL_MS) {
+      const refreshed = Math.max(entry.throttled_until ?? 0, throttledUntil);
+      this.quota[account] = { ...entry, throttled_until: refreshed };
+      this.persistQuota();
+      this.audit({ op: "mark-throttled", identity, account, accountKind: "claude", ok: true });
+      process.stdout.write(
+        `auth-broker: mark-throttled ${account} deduped (re-mark within ${MARK_THROTTLED_MIN_INTERVAL_MS / 1000}s) — expiry refreshed, no new hit\n`,
+      );
+      socket.write(
+        encodeSuccess(id, {
+          account,
+          throttled_until: refreshed,
+          escalated: false,
+          rolledTo: null,
+        }),
+      );
+      return;
+    }
+
+    const hits = priorHits.filter((t) => now - t < THROTTLE_ESCALATION_WINDOW_MS);
     hits.push(now);
     const escalate = hits.length >= THROTTLE_ESCALATION_HITS;
     this.quota[account] = {
@@ -2296,19 +2335,12 @@ export class AuthBroker {
           `auth-broker: throttle-escalation probe corroborates wall on ${account} — mark-exhausted + roll\n`,
         );
         this.audit({ op: "mark-exhausted", identity, account, accountKind: "claude", ok: true, reason: "throttle-escalation" });
-        // Capture the fleet active BEFORE the roll — a corroborated roll
-        // auto-promotes the target, so reading it afterwards would compare
-        // against the NEW active and never record the announcement.
-        const wasFleetActive = account === this.config.auth?.active;
         const roll = await this.markExhaustedAndRoll(account, probe.until ?? undefined, identity);
         rolledTo = roll.rolledTo;
-        // Broker-initiated roll with no announcing gateway (the throttle path
-        // posts only the lightweight notice) → record it on the same
-        // `last_fleet_roll` channel the proactive probe uses, so the
-        // quota-watch announcement (dedup'd fleet-wide) reaches the operator.
-        if (rolledTo && wasFleetActive) {
-          this.recordFleetRoll(account, rolledTo, "hard-exhaustion", probe.until ?? undefined);
-        }
+        // Deliberately NO recordFleetRoll here — reactive-path doctrine (see
+        // op docstring): the raising gateway announces from this response,
+        // covering pinned-account rolls the fleet channel would skip and
+        // avoiding a double announcement for fleet-active rolls.
       } else {
         process.stdout.write(
           `auth-broker: throttle-escalation probe on ${account} did NOT corroborate a wall — staying throttled\n`,

--- a/src/scheduler/quota-preflight.test.ts
+++ b/src/scheduler/quota-preflight.test.ts
@@ -7,12 +7,15 @@ import { describe, it, expect } from "vitest";
 import { decideQuotaPreflight } from "./quota-preflight.js";
 import type { ListStateData } from "../auth/broker/client.js";
 
-function state(accounts: Array<{ label: string; exhausted: boolean }>): ListStateData {
+function state(
+  accounts: Array<{ label: string; exhausted: boolean; throttled_until?: number }>,
+  opts: { agents?: Array<{ name: string; account: string; override: string | null }> } = {},
+): ListStateData {
   return {
     active: accounts[0]?.label ?? "",
     fallback_order: accounts.map((a) => a.label),
     accounts,
-    agents: [],
+    agents: opts.agents ?? [],
     consumers: [],
   };
 }
@@ -42,5 +45,86 @@ describe("decideQuotaPreflight", () => {
 
   it("does NOT defer when there are no accounts (never block on emptiness)", () => {
     expect(decideQuotaPreflight(state([])).defer).toBe(false);
+  });
+});
+
+describe("decideQuotaPreflight — 429 throttle-tier soft-defer", () => {
+  const NOW = 1_750_000_000_000;
+
+  it("soft-defers while the ACTIVE account is throttled, carrying retryAtMs", () => {
+    const until = NOW + 90_000;
+    const d = decideQuotaPreflight(
+      state([
+        { label: "a", exhausted: false, throttled_until: until },
+        { label: "b", exhausted: false },
+      ]),
+      { now: NOW },
+    );
+    expect(d.defer).toBe(true);
+    expect(d.reason).toContain("'a' rate-throttled");
+    expect(d.retryAtMs).toBe(until);
+  });
+
+  it("uses the AGENT's effective (override) account, not the fleet active", () => {
+    const until = NOW + 60_000;
+    const s = state(
+      [
+        { label: "a", exhausted: false },
+        { label: "pinned", exhausted: false, throttled_until: until },
+      ],
+      { agents: [{ name: "ziggy", account: "pinned", override: "pinned" }] },
+    );
+    // ziggy rides the throttled pinned account → defer…
+    const dz = decideQuotaPreflight(s, { agent: "ziggy", now: NOW });
+    expect(dz.defer).toBe(true);
+    expect(dz.retryAtMs).toBe(until);
+    // …but an agent on the (healthy) fleet active dispatches.
+    const da = decideQuotaPreflight(s, { agent: "other", now: NOW });
+    expect(da.defer).toBe(false);
+  });
+
+  it("does NOT defer once the throttle has expired", () => {
+    const d = decideQuotaPreflight(
+      state([{ label: "a", exhausted: false, throttled_until: NOW - 1 }]),
+      { now: NOW },
+    );
+    expect(d.defer).toBe(false);
+  });
+
+  it("does NOT throttle-defer on a NON-effective account's throttle", () => {
+    const d = decideQuotaPreflight(
+      state([
+        { label: "a", exhausted: false },
+        { label: "b", exhausted: false, throttled_until: NOW + 60_000 },
+      ]),
+      { now: NOW },
+    );
+    expect(d.defer).toBe(false);
+  });
+
+  it("all-exhausted still wins over throttle (harder condition first)", () => {
+    const d = decideQuotaPreflight(
+      state([
+        { label: "a", exhausted: true, throttled_until: NOW + 60_000 },
+        { label: "b", exhausted: true },
+      ]),
+      { now: NOW },
+    );
+    expect(d.defer).toBe(true);
+    expect(d.reason).toContain("all 2");
+    expect(d.retryAtMs).toBeUndefined();
+  });
+
+  it("an exhausted effective account with a stale throttle does not double-flag", () => {
+    // Effective account exhausted (mark) but another healthy → no defer via
+    // throttle rule (rule 2 requires !exhausted).
+    const d = decideQuotaPreflight(
+      state([
+        { label: "a", exhausted: true, throttled_until: NOW + 60_000 },
+        { label: "b", exhausted: false },
+      ]),
+      { now: NOW },
+    );
+    expect(d.defer).toBe(false);
   });
 });

--- a/src/scheduler/quota-preflight.ts
+++ b/src/scheduler/quota-preflight.ts
@@ -10,15 +10,24 @@
  * residual risk is the brief total-wall window.
  *
  * This decides whether to DEFER a fire rather than throw it at a wall. It
- * defers ONLY when EVERY account is exhausted (dispatching is definitely
- * futile). When at least one account is healthy it does NOT defer: the fleet
- * serves the agent a healthy account via failover, and we never hold a
- * dispatch on a maybe — holding risks nothing, but we keep the gate narrow and
- * reliable. A single lag-window run may still be lost in the partial case;
- * recurring crons recover on their next occurrence, and the operator has no
- * hard deadlines (by design decision).
+ * defers in two cases:
  *
- * PURE — no I/O. Fail-open is the caller's job (broker unreachable → dispatch).
+ *   1. EVERY account is exhausted (dispatching is definitely futile). When at
+ *      least one account is healthy it does NOT defer on this rule: the fleet
+ *      serves the agent a healthy account via failover.
+ *   2. 429 throttle tier — the agent's EFFECTIVE account (its override, else
+ *      the fleet active) carries a future `throttled_until`. A throttled
+ *      account is NOT rolled off (that's the whole point of the tier), so the
+ *      fire would 429 against the same account; soft-defer until the throttle
+ *      clears. `retryAtMs` carries the clear time so the caller can align the
+ *      retry with it instead of blind backoff.
+ *
+ * A single lag-window run may still be lost in the partial case; recurring
+ * crons recover on their next occurrence, and the operator has no hard
+ * deadlines (by design decision).
+ *
+ * PURE — no I/O, no clock except the injected `now`. Fail-open is the
+ * caller's job (broker unreachable → dispatch).
  */
 
 import type { ListStateData } from "../auth/broker/client.js";
@@ -26,20 +35,51 @@ import type { ListStateData } from "../auth/broker/client.js";
 export interface QuotaPreflightDecision {
   defer: boolean;
   reason: string;
+  /** When set (throttle soft-defer), the unix ms at/after which a retry is
+   *  expected to succeed — the throttled account's `throttled_until`. The
+   *  caller aligns the retry timer with it (bounded) instead of the default
+   *  backoff ladder. */
+  retryAtMs?: number;
 }
 
-export function decideQuotaPreflight(state: ListStateData): QuotaPreflightDecision {
+export function decideQuotaPreflight(
+  state: ListStateData,
+  opts: { agent?: string; now?: number } = {},
+): QuotaPreflightDecision {
+  const now = opts.now ?? Date.now();
   const accounts = state.accounts ?? [];
   if (accounts.length === 0) {
     // No accounts to reason about — never block a fire on this.
     return { defer: false, reason: "no accounts in broker state" };
   }
   const healthy = accounts.filter((a) => !a.exhausted);
-  if (healthy.length > 0) {
+  if (healthy.length === 0) {
+    return { defer: true, reason: `all ${accounts.length} account(s) exhausted` };
+  }
+  // 429 throttle tier — soft-defer while the agent's effective account is
+  // transiently rate-limited. The throttle deliberately does NOT roll the
+  // fleet, so "some other account is healthy" doesn't help: this agent's
+  // next turn still runs on the throttled account.
+  const effectiveLabel =
+    (opts.agent !== undefined
+      ? (state.agents ?? []).find((a) => a.name === opts.agent)?.account
+      : undefined) ?? state.active;
+  const effective = accounts.find((a) => a.label === effectiveLabel);
+  if (
+    effective !== undefined &&
+    !effective.exhausted &&
+    effective.throttled_until !== undefined &&
+    effective.throttled_until > now
+  ) {
+    const inS = Math.ceil((effective.throttled_until - now) / 1000);
     return {
-      defer: false,
-      reason: `${healthy.length}/${accounts.length} account(s) healthy`,
+      defer: true,
+      reason: `account '${effective.label}' rate-throttled (clears in ${inS}s)`,
+      retryAtMs: effective.throttled_until,
     };
   }
-  return { defer: true, reason: `all ${accounts.length} account(s) exhausted` };
+  return {
+    defer: false,
+    reason: `${healthy.length}/${accounts.length} account(s) healthy`,
+  };
 }

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -713,6 +713,13 @@ export interface FallbackAnnouncementInput {
    * present — it is the fresher, server-authoritative signal.
    */
   parsedResetAt?: Date | null;
+  /**
+   * 429 throttle tier escalation — the trigger was a long-reset transient
+   * RATE LIMIT, not a quota wall. Names the headline honestly ("rate limit
+   * on X" instead of a utilization-derived "5-hour limit on X", which would
+   * be wrong: a rate-limited account's utilization is typically LOW).
+   */
+  cause?: 'rate-limit';
   tz?: string;
   now?: Date;
 }
@@ -737,7 +744,12 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
   const lines: string[] = [];
 
   const limitWord = input.oldQuota ? limitWordFor(input.oldQuota) : 'quota';
-  const headerLimit = limitWord === 'quota' ? 'quota cap' : `${limitWord} limit`;
+  const headerLimit =
+    input.cause === 'rate-limit'
+      ? 'rate limit'
+      : limitWord === 'quota'
+        ? 'quota cap'
+        : `${limitWord} limit`;
 
   if (!input.newLabel) {
     // All-blocked path — no swap occurred. Tell user what's broken and, so they

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -704,6 +704,15 @@ export interface FallbackAnnouncementInput {
    * shows the target's headroom and is unchanged.
    */
   fleetSnapshots?: AccountSnapshot[];
+  /**
+   * 429 throttle tier enrichment — the reset time PARSED from the error
+   * prose ("resets 8:50am (TZ)" / "retry after 60s") that triggered the
+   * fallback. Fallback for the recovery line when the old account's probe
+   * carried no reset (probe failed / thin headers), so the announcement
+   * still names when the account frees. A probe-derived reset wins when
+   * present — it is the fresher, server-authoritative signal.
+   */
+  parsedResetAt?: Date | null;
   tz?: string;
   now?: Date;
 }
@@ -765,9 +774,14 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
             `${formatAbsolute(earliest.at, tz)} (in ${formatRelative(earliest.at, now)})`,
         );
       }
-    } else if (input.oldQuota) {
+    } else {
       // Back-compat: no fleet snapshot supplied → old single-account shape.
-      const recovery = recoveryAtFor(input.oldQuota);
+      // Probe-derived reset first; the prose-parsed reset (429 throttle tier
+      // enrichment) covers the probe-failed case.
+      const recovery =
+        (input.oldQuota ? recoveryAtFor(input.oldQuota) : null) ??
+        input.parsedResetAt ??
+        null;
       if (recovery) {
         lines.push(
           `${escapeMarkdown(input.oldLabel)} recovers ${formatAbsolute(recovery, tz)} ` +
@@ -794,8 +808,14 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
   lines.push(`Triggered by: agent **${escapeMarkdown(input.triggerAgent)}**`);
   lines.push('');
 
-  if (input.oldQuota) {
-    const recovery = recoveryAtFor(input.oldQuota);
+  {
+    // Probe-derived reset first; the prose-parsed reset (429 throttle tier
+    // enrichment) keeps the recovery line honest when the old account's
+    // probe failed at the moment of the wall.
+    const recovery =
+      (input.oldQuota ? recoveryAtFor(input.oldQuota) : null) ??
+      input.parsedResetAt ??
+      null;
     if (recovery) {
       lines.push(
         `\`${codeSpanSafe(input.oldLabel)}\` recovers ` +

--- a/telegram-plugin/auto-fallback-fleet.ts
+++ b/telegram-plugin/auto-fallback-fleet.ts
@@ -189,6 +189,20 @@ export interface FleetFallbackDeps {
    * fallback when the old account's live probe carried no reset.
    */
   parsedResetAt?: Date;
+  /**
+   * 429 throttle tier escalation: the trigger is a TERMINAL transient 429
+   * whose parsed reset lies beyond the retry-in-place threshold. Its wording
+   * explicitly NEGATES the usage-limit reading, so the old account's
+   * UTILIZATION probe typically classifies healthy — the healthy-idempotency
+   * guard would self-cancel the swap ("probed healthy / Stale event?"),
+   * silently dropping the spec's ">threshold → mark + fail over" leg. When
+   * set, the terminal parsed-reset signal is trusted over the utilization
+   * probe: the guard is bypassed and the swap proceeds (the broker mark
+   * honors the caller-passed `until` — the parsed reset). Staleness safety
+   * holds upstream: the flag is only set for a terminal error line the
+   * session-tail just read, never for replayed/late events.
+   */
+  rateLimitTrigger?: boolean;
 }
 
 /**
@@ -223,8 +237,12 @@ export async function runFleetAutoFallback(
   // normalization uses the same clock as the rest of the decision (a default
   // `new Date()` would diverge from `deps.now` and could mis-zero a window
   // whose reset is still future relative to the event's clock).
+  // 429 throttle tier: a rate-limit trigger's wording NEGATES the usage-limit
+  // reading, so healthy utilization is the EXPECTED state, not evidence of a
+  // stale event — the guard must not self-cancel that swap (see
+  // FleetFallbackDeps.rateLimitTrigger).
   const oldHealth = classifyHealth(oldSnap, now);
-  if (oldHealth === 'healthy') {
+  if (oldHealth === 'healthy' && !deps.rateLimitTrigger) {
     return {
       kind: 'no-eligible-target',
       oldLabel: oldSnap.label,
@@ -262,6 +280,7 @@ export async function runFleetAutoFallback(
         // user verify the fleet is truly exhausted, not just the trigger account.
         fleetSnapshots: snapshots,
         parsedResetAt: deps.parsedResetAt ?? null,
+        cause: deps.rateLimitTrigger ? 'rate-limit' : undefined,
         tz,
         now,
       }),
@@ -286,6 +305,7 @@ export async function runFleetAutoFallback(
       newQuota,
       triggerAgent: deps.triggerAgent,
       parsedResetAt: deps.parsedResetAt ?? null,
+      cause: deps.rateLimitTrigger ? 'rate-limit' : undefined,
       tz,
       now,
     }),

--- a/telegram-plugin/auto-fallback-fleet.ts
+++ b/telegram-plugin/auto-fallback-fleet.ts
@@ -183,6 +183,12 @@ export interface FleetFallbackDeps {
   /** Operator timezone for absolute reset times in the announcement. */
   tz?: string;
   now?: Date;
+  /**
+   * The reset time PARSED from the triggering error prose (429 throttle tier
+   * enrichment) — threaded into the announcement as the recovery-line
+   * fallback when the old account's live probe carried no reset.
+   */
+  parsedResetAt?: Date;
 }
 
 /**
@@ -255,6 +261,7 @@ export async function runFleetAutoFallback(
         // card enumerates EVERY account (5h%/7d% + recovery ETA), letting the
         // user verify the fleet is truly exhausted, not just the trigger account.
         fleetSnapshots: snapshots,
+        parsedResetAt: deps.parsedResetAt ?? null,
         tz,
         now,
       }),
@@ -278,6 +285,7 @@ export async function runFleetAutoFallback(
       newLabel: rolledTo,
       newQuota,
       triggerAgent: deps.triggerAgent,
+      parsedResetAt: deps.parsedResetAt ?? null,
       tz,
       now,
     }),

--- a/telegram-plugin/gateway/auth-broker-client.ts
+++ b/telegram-plugin/gateway/auth-broker-client.ts
@@ -28,6 +28,7 @@ export function createAuthBrokerClient(): {
     listState: () => broker.listState(),
     setActive: (label: string) => broker.setActive(label),
     markExhausted: (until?: number) => broker.markExhausted(until),
+    markThrottled: (until: number) => broker.markThrottled(until),
     rmAccount: (label: string) => broker.rmAccount(label),
     refreshAccount: (label: string) => broker.refreshAccount(label),
     setOverride: (agent: string, account: string | null) =>

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -301,6 +301,20 @@ export interface AuthBrokerClient {
    * identity — so auto-fallback works from any agent.
    */
   markExhausted(until?: number): Promise<{ account: string; rolled: string[]; rolledTo?: string | null }>
+  /**
+   * 429 throttle tier (broker `mark-throttled`). Records a transient
+   * per-account rate limit on the CALLER's own account — `throttled_until`
+   * in the quota ledger — WITHOUT rolling the fleet and WITHOUT touching
+   * eligibility. `escalated` is true when the broker's escalation guard
+   * (repeated hits corroborated by a live probe) converted it into the
+   * standard mark-exhausted + roll; `rolledTo` names the roll target then.
+   */
+  markThrottled(until: number): Promise<{
+    account: string
+    throttled_until: number
+    escalated: boolean
+    rolledTo?: string | null
+  }>
   rmAccount(label: string): Promise<{ label: string }>
   refreshAccount(label: string): Promise<{ account: string; expiresAt?: number }>
   setOverride(

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -309,17 +309,15 @@ import {
 import { recordOperatorEvent } from '../operator-events-history.js'
 import {
   formatModelUnavailableCard,
-  isTransientUpstreamSignal,
   resolveModelUnavailableFromOperatorEvent,
   type ModelUnavailableDetection,
 } from '../model-unavailable.js'
 import {
   decideThrottleTier,
-  evaluateThrottleNotice,
-  renderThrottleNotice,
+  isAccountScopedThrottle,
   throttleRetryInPlaceMaxMs,
-  type ThrottleNoticeState,
 } from '../throttle-tier.js'
+import { createThrottleTierRunner } from './throttle-tier-wiring.js'
 import { runFleetAutoFallback, renderFallbackFailureNotice, evaluateFallbackFailureNotice, evaluateAllBlockedNotice, type FallbackFailureNoticeState, type FallbackAllBlockedNoticeState } from '../auto-fallback-fleet.js'
 import { startRestartWatchdog } from './restart-watchdog.js'
 import { validateStringArray } from './access-validator.js'
@@ -7670,15 +7668,19 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
 
   // ── 429 throttle tier (operator spec: "retry in place under 5 min, else
   // mark + failover, honest reset messaging") ────────────────────────────
-  // A terminal TRANSIENT per-account 429 — kind `rate-limited` carrying the
-  // explicit transient-negation wording — is decided BEFORE the per-kind
-  // cooldown gate: every hit must reach the broker's mark-throttled
-  // escalation counter even when the user-facing notice is cooldown-
-  // suppressed (the counter is what corroborates a wall hiding behind
-  // transient wording). Generic overloads / 529s (no negation wording) fall
-  // through to the existing calm rate-limited card unchanged.
+  // A terminal TRANSIENT ACCOUNT-scoped 429 — kind `rate-limited` carrying
+  // wording that affirms the account's own rate limit ("would exceed your
+  // account's rate limit") — is decided BEFORE the per-kind cooldown gate:
+  // every hit must reach the broker's mark-throttled escalation counter, and
+  // the >threshold failover ACTION must fire, even when the user-facing card
+  // is cooldown-suppressed (a calm 529 card two minutes earlier arms that
+  // cooldown). Server-side transients (529 / "server is temporarily…") fall
+  // through to the existing calm rate-limited card unchanged — an
+  // account-scoped throttle would be the wrong action for a server-wide
+  // condition.
   let throttleEscalation: ModelUnavailableDetection | null = null
-  if (kind === 'rate-limited' && isTransientUpstreamSignal(event.detail)) {
+  let escalationFired = false
+  if (kind === 'rate-limited' && isAccountScopedThrottle(event.detail)) {
     const throttleDecision = decideThrottleTier({
       detail: event.detail,
       now: Date.now(),
@@ -7687,7 +7689,8 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     if (throttleDecision.action === 'throttle') {
       // Reset is near (≤ threshold) or unparseable (60s default): DO NOT
       // fail over. Record throttled_until broker-side, post ONE lightweight
-      // notice (per-account cooldown), nudge a retry after the reset.
+      // notice (per-account + fleet-wide dedup), nudge a retry after the
+      // reset. The runner owns the sequencing (throttle-tier-wiring.ts).
       process.stderr.write(
         `telegram gateway: throttle-tier staying-put agent=${agent} ` +
           `until=${new Date(throttleDecision.throttledUntilMs).toISOString()} ` +
@@ -7696,7 +7699,7 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
       try {
         recordOperatorEvent(event)
       } catch { /* history is best-effort */ }
-      void fireThrottleTier(
+      void throttleTierRunner.fire(
         agent,
         throttleDecision.throttledUntilMs,
         throttleDecision.resetParsed,
@@ -7706,12 +7709,25 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     if (throttleDecision.action === 'failover') {
       // Reset beyond the retry-in-place threshold: the account is benched
       // until then anyway, so escalate to the standard mark-exhausted +
-      // fleet-failover machinery below — with the honest 'rate_limited'
-      // wording and the parsed reset as the mark expiry.
-      throttleEscalation = {
-        kind: 'rate_limited',
-        resetAt: new Date(throttleDecision.resetAtMs),
-        raw: event.detail,
+      // fleet-failover machinery — honest 'rate_limited' wording, parsed
+      // reset as the mark expiry. The ACTION fires HERE, before the
+      // per-kind card cooldown below can swallow it (the fleetFallbackGate
+      // provides the action-level dedup); only the card stays
+      // cooldown-bounded. The 'rate-limit' trigger tells the dispatcher to
+      // trust this terminal parsed-reset signal over the utilization probe
+      // (a transient 429 negates the usage-limit reading, so utilization
+      // typically looks healthy — the idempotency guard would self-cancel
+      // the swap).
+      const resetAt = new Date(throttleDecision.resetAtMs)
+      throttleEscalation = { kind: 'rate_limited', resetAt, raw: event.detail }
+      if (wouldFireFleetAutoFallback()) {
+        escalationFired = true
+        void fireFleetAutoFallback(
+          agent,
+          resolveExhaustUntil(resetAt.getTime()),
+          resetAt,
+          'rate-limit',
+        )
       }
     }
   }
@@ -7771,11 +7787,16 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     // internal retry, not by switching accounts.
     // 'rate_limited' is the throttle-tier escalation (transient 429 whose
     // reset exceeds the retry-in-place threshold) — same failover mechanics
-    // as a quota wall, honest wording on the card.
+    // as a quota wall, honest wording on the card. Its fire already happened
+    // ABOVE the cooldown gate (escalationFired) so the action can't be
+    // swallowed by the per-kind card cooldown; the card here only reports it.
     const isAutoKind =
       modelUnavailable.kind === 'quota_exhausted' ||
       modelUnavailable.kind === 'rate_limited'
-    const willActuallyFire = isAutoKind && wouldFireFleetAutoFallback()
+    const willActuallyFire =
+      throttleEscalation != null
+        ? escalationFired
+        : isAutoKind && wouldFireFleetAutoFallback()
     process.stderr.write(
       `telegram gateway: operator-event suppressing-raw-stderr-for-model-unavailable agent=${agent} kind=${kind} detected=${modelUnavailable.kind} autoKind=${isAutoKind} willFire=${willActuallyFire}\n`,
     )
@@ -7799,7 +7820,9 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     // Pre-fix this called fireFleetAutoFallback(agent) with no until, so a
     // weekly wall that surfaced as a 429 got markExhausted's ~5h default and
     // the broker re-mirrored the still-walled account onto the fleet after 5h.
-    if (willActuallyFire) {
+    // Throttle-tier escalations (throttleEscalation != null) already fired
+    // above the cooldown gate — don't double-fire here.
+    if (willActuallyFire && throttleEscalation == null) {
       const untilMs = resolveExhaustUntil(modelUnavailable.resetAt?.getTime())
       // Thread the RAW parsed reset (distinct from the floor-applied untilMs)
       // so the fallback announcement can name it even when the live probe of
@@ -23281,9 +23304,10 @@ async function fireFleetAutoFallback(
   triggerAgent: string,
   untilMs?: number,
   parsedResetAt?: Date,
+  trigger?: 'rate-limit',
 ): Promise<void> {
   return fleetFallbackGate.fire(
-    () => doFireFleetAutoFallback(triggerAgent, untilMs, parsedResetAt),
+    () => doFireFleetAutoFallback(triggerAgent, untilMs, parsedResetAt, trigger),
     (err) => {
       process.stderr.write(
         `telegram gateway: [fleet-fallback] error agent=${triggerAgent}: ${(err as Error)?.message ?? err}\n`,
@@ -23293,154 +23317,43 @@ async function fireFleetAutoFallback(
 }
 
 // ─── 429 throttle tier — side-effect wiring ─────────────────────────────────
-// Decision + notice text live in throttle-tier.ts (pure); this owns the broker
-// write, the ONE lightweight notice, and the delayed retry nudge.
-
-/** Per-account cooldown state for the throttle notice (one per account per
- *  window — a terminal-429 burst produces exactly one message). */
-let throttleNoticeState: ThrottleNoticeState = { lastSentAtMsByAccount: {} }
-
-/** Pending retry-nudge timer. The LATEST throttle owns the nudge — a newer
- *  hit (longer reset) replaces an armed timer instead of stacking restarts. */
-let throttleRetryTimer: NodeJS.Timeout | null = null
-
-/** Slack past throttled_until before the retry nudge fires. */
-const THROTTLE_RETRY_NUDGE_SLACK_MS = 5_000
-
-/**
- * Throttle path (429 throttle tier): the account is transiently rate-limited
- * with a reset near enough to wait out in place. NO failover.
- *
- *  1. Report the broker's non-admin `mark-throttled` verb — records
- *     throttled_until in the quota ledger (cron preflight soft-defers on it)
- *     WITHOUT rolling the fleet and WITHOUT touching eligibility. The broker
- *     also runs the escalation guard there (3+ hits/10min → live probe →
- *     mark-exhausted when corroborated).
- *  2. Post ONE lightweight operator notice: account, that it's rate-limited
- *     not quota-exhausted, when it resets, that the agent stays put.
- *     Cooldown-deduped per account.
- *  3. Nudge a retry after throttled_until via the existing resume lever
- *     (fleetFallbackResumeGate → triggerSelfRestart → boot-resume replays the
- *     turn the 429 killed). Same guards as the fleet-fallback resume:
- *     single-flight + staleness; a needless restart replays nothing (the
- *     boot-resume path only re-injects a genuinely interrupted turn).
- *
- * Fire-and-forget: never throws into the caller's flow.
- */
-async function fireThrottleTier(
-  triggerAgent: string,
-  throttledUntilMs: number,
-  resetParsed: boolean,
-): Promise<void> {
-  let account: string | null = null
-  let escalated = false
-  let rolledTo: string | null = null
-  try {
-    const client = await getAuthBrokerClient(triggerAgent)
-    if (client) {
-      const r = await client.markThrottled(throttledUntilMs)
-      account = r.account
-      escalated = r.escalated
-      rolledTo = r.rolledTo ?? null
-    } else {
-      process.stderr.write(
-        `telegram gateway: [throttle-tier] broker unreachable — notice only, no ledger record agent=${triggerAgent}\n`,
-      )
-    }
-  } catch (err) {
-    process.stderr.write(
-      `telegram gateway: [throttle-tier] markThrottled failed agent=${triggerAgent}: ${(err as Error)?.message ?? err}\n`,
-    )
-  }
-
-  if (escalated) {
-    // The broker's escalation guard corroborated a genuine wall via a live
-    // probe and already ran the standard mark-exhausted + fleet roll. The
-    // roll announcement rides the existing broker-roll channel (list-state
-    // `last_fleet_roll` → quota-watch, fleet-deduped) — no duplicate send
-    // here. Nudge the dead-turn resume now: the fleet just swapped accounts.
-    process.stderr.write(
-      `telegram gateway: [throttle-tier] escalated to wall account=${account ?? '?'} ` +
-        `rolledTo=${rolledTo ?? 'none (all blocked)'}\n`,
-    )
-    if (rolledTo) {
-      const verdict = fleetFallbackResumeGate.decide(newestActiveTurnStartedAtMs())
-      if (verdict === 'resume') {
-        triggerSelfRestart(
-          process.env.SWITCHROOM_AGENT_NAME ?? triggerAgent,
-          'throttle-escalation-resume',
-        )
-      } else {
-        process.stderr.write(
-          `telegram gateway: [throttle-tier] escalation resume suppressed (${verdict})\n`,
-        )
-      }
-    }
-    return
-  }
-
-  // ONE lightweight notice, cooldown-deduped per account. When the broker was
-  // unreachable the account is unknown — key the cooldown on the agent so the
-  // degraded path still can't spam.
-  const cooldownKey = account ?? `agent:${triggerAgent}`
-  const verdict = evaluateThrottleNotice(throttleNoticeState, cooldownKey, Date.now())
-  if (verdict.send) {
-    throttleNoticeState = verdict.next
-    const access = loadAccess()
-    const html = renderThrottleNotice({
-      account,
-      agent: triggerAgent,
-      throttledUntilMs,
-      resetParsed,
-    })
+// Decision + notice text live in throttle-tier.ts (pure); the SEQUENCING
+// (broker mark → fleet-deduped notice → jittered retry nudge with the
+// live-turn safety guards) lives in throttle-tier-wiring.ts so it is
+// unit-testable with injected deps. This block only binds the real gateway
+// dependencies.
+const throttleTierRunner = createThrottleTierRunner({
+  agentName: process.env.SWITCHROOM_AGENT_NAME ?? '',
+  getBrokerClient: () =>
+    getAuthBrokerClient(process.env.SWITCHROOM_AGENT_NAME ?? ''),
+  listNoticeChats: () => loadAccess().allowFrom,
+  sendNotice: (chat_id, markdown) => {
     // Status notice, not the user's answer — silence the ping (same posture
     // as the fleet-fallback announcement).
-    const noticeOpts = { disable_notification: true }
-    for (const chat_id of access.allowFrom) {
-      void swallowingApiCall(
-        // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy)
-        () => bot.api.sendRichMessage(chat_id, richMessage(html), noticeOpts),
-        { chat_id, verb: 'throttle-tier:notify' },
-      )
-    }
-  } else {
-    process.stderr.write(
-      `telegram gateway: [throttle-tier] notice suppressed (cooldown) key=${cooldownKey}\n`,
+    void swallowingApiCall(
+      // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy)
+      () => bot.api.sendRichMessage(chat_id, richMessage(markdown), { disable_notification: true }),
+      { chat_id: String(chat_id), verb: 'throttle-tier:notify' },
     )
-  }
-
-  scheduleThrottleRetryNudge(triggerAgent, throttledUntilMs)
-}
-
-/**
- * Arm (or re-arm) the post-throttle retry nudge. After throttled_until the
- * turn the 429 killed is replayed via the SAME lever the fleet-fallback
- * resume uses — triggerSelfRestart + boot-resume — guarded by the shared
- * fleetFallbackResumeGate (single-flight across throttle AND fallback
- * resumes; staleness failsafe). The gate is consulted at FIRE time, not arm
- * time, so a fallback-driven restart inside the wait window wins and the
- * nudge no-ops.
- */
-function scheduleThrottleRetryNudge(triggerAgent: string, throttledUntilMs: number): void {
-  const delayMs = Math.max(throttledUntilMs - Date.now(), 0) + THROTTLE_RETRY_NUDGE_SLACK_MS
-  if (throttleRetryTimer) clearTimeout(throttleRetryTimer)
-  throttleRetryTimer = setTimeout(() => {
-    throttleRetryTimer = null
-    const verdict = fleetFallbackResumeGate.decide(newestActiveTurnStartedAtMs())
-    if (verdict === 'resume') {
-      const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? triggerAgent
-      process.stderr.write(
-        `telegram gateway: [throttle-tier] throttle cleared — resuming dead turn via self-restart agent=${selfAgent}\n`,
-      )
-      triggerSelfRestart(selfAgent, 'throttle-retry-resume')
-    } else {
-      process.stderr.write(
-        `telegram gateway: [throttle-tier] retry nudge suppressed (${verdict}) agent=${triggerAgent}\n`,
-      )
-    }
-  }, delayMs)
-  throttleRetryTimer.unref()
-}
+  },
+  resumeDecide: (ts) => fleetFallbackResumeGate.decide(ts),
+  newestActiveTurnStartedAtMs,
+  turnInFlight: () => turnInFlightForGate(),
+  deferRestartToTurnComplete: (agentName, reason) => {
+    // Same lever the schedule_restart IPC uses: the restart drains at the
+    // turn-complete gate (never SIGTERM-now under a live turn). Note the
+    // pending-restart drain cap (PENDING_RESTART_DRAIN_CAP_MS) still bounds
+    // a never-idling session — deliberate, matching scheduled restarts.
+    process.stderr.write(
+      `telegram gateway: [throttle-tier] restart deferred to turn-complete agent=${agentName} reason=${reason}\n`,
+    )
+    pendingRestarts.set(agentName, Date.now())
+  },
+  restartNow: (agentName, reason) => {
+    triggerSelfRestart(agentName, reason)
+  },
+  log: (m) => process.stderr.write(`telegram gateway: ${m}\n`),
+})
 
 /**
  * Broadcast a fleet-fallback FAILURE notice to every authorized chat.
@@ -23507,6 +23420,7 @@ async function doFireFleetAutoFallback(
   triggerAgent: string,
   untilMs?: number,
   parsedResetAt?: Date,
+  trigger?: 'rate-limit',
 ): Promise<boolean> {
   try {
     const client = await getAuthBrokerClient(triggerAgent)
@@ -23560,6 +23474,12 @@ async function doFireFleetAutoFallback(
       // error prose, so the announcement names when the old account frees
       // even when its live probe returned nothing.
       parsedResetAt,
+      // Throttle-tier escalation: a terminal transient 429 with a long
+      // parsed reset NEGATES the usage-limit reading, so the old account's
+      // utilization probe typically classifies healthy — the idempotency
+      // guard would self-cancel the swap ("probed healthy / Stale event?").
+      // Trust the terminal parsed-reset signal over the utilization probe.
+      rateLimitTrigger: trigger === 'rate-limit',
     })
     process.stderr.write(
       `telegram gateway: [fleet-fallback] outcome=${outcome.kind} agent=${triggerAgent}` +

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -309,8 +309,17 @@ import {
 import { recordOperatorEvent } from '../operator-events-history.js'
 import {
   formatModelUnavailableCard,
+  isTransientUpstreamSignal,
   resolveModelUnavailableFromOperatorEvent,
+  type ModelUnavailableDetection,
 } from '../model-unavailable.js'
+import {
+  decideThrottleTier,
+  evaluateThrottleNotice,
+  renderThrottleNotice,
+  throttleRetryInPlaceMaxMs,
+  type ThrottleNoticeState,
+} from '../throttle-tier.js'
 import { runFleetAutoFallback, renderFallbackFailureNotice, evaluateFallbackFailureNotice, evaluateAllBlockedNotice, type FallbackFailureNoticeState, type FallbackAllBlockedNoticeState } from '../auto-fallback-fleet.js'
 import { startRestartWatchdog } from './restart-watchdog.js'
 import { validateStringArray } from './access-validator.js'
@@ -7659,6 +7668,54 @@ const inboundCoalescer = createInboundCoalescer<CoalescePayload>({
 function emitGatewayOperatorEvent(event: OperatorEvent): void {
   const { agent, kind } = event
 
+  // ── 429 throttle tier (operator spec: "retry in place under 5 min, else
+  // mark + failover, honest reset messaging") ────────────────────────────
+  // A terminal TRANSIENT per-account 429 — kind `rate-limited` carrying the
+  // explicit transient-negation wording — is decided BEFORE the per-kind
+  // cooldown gate: every hit must reach the broker's mark-throttled
+  // escalation counter even when the user-facing notice is cooldown-
+  // suppressed (the counter is what corroborates a wall hiding behind
+  // transient wording). Generic overloads / 529s (no negation wording) fall
+  // through to the existing calm rate-limited card unchanged.
+  let throttleEscalation: ModelUnavailableDetection | null = null
+  if (kind === 'rate-limited' && isTransientUpstreamSignal(event.detail)) {
+    const throttleDecision = decideThrottleTier({
+      detail: event.detail,
+      now: Date.now(),
+      thresholdMs: throttleRetryInPlaceMaxMs(),
+    })
+    if (throttleDecision.action === 'throttle') {
+      // Reset is near (≤ threshold) or unparseable (60s default): DO NOT
+      // fail over. Record throttled_until broker-side, post ONE lightweight
+      // notice (per-account cooldown), nudge a retry after the reset.
+      process.stderr.write(
+        `telegram gateway: throttle-tier staying-put agent=${agent} ` +
+          `until=${new Date(throttleDecision.throttledUntilMs).toISOString()} ` +
+          `parsedReset=${throttleDecision.resetParsed}\n`,
+      )
+      try {
+        recordOperatorEvent(event)
+      } catch { /* history is best-effort */ }
+      void fireThrottleTier(
+        agent,
+        throttleDecision.throttledUntilMs,
+        throttleDecision.resetParsed,
+      )
+      return
+    }
+    if (throttleDecision.action === 'failover') {
+      // Reset beyond the retry-in-place threshold: the account is benched
+      // until then anyway, so escalate to the standard mark-exhausted +
+      // fleet-failover machinery below — with the honest 'rate_limited'
+      // wording and the parsed reset as the mark expiry.
+      throttleEscalation = {
+        kind: 'rate_limited',
+        resetAt: new Date(throttleDecision.resetAtMs),
+        raw: event.detail,
+      }
+    }
+  }
+
   if (!shouldEmitOperatorEvent(agent, kind)) {
     process.stderr.write(
       `telegram gateway: operator-event suppressed (cooldown) agent=${agent} kind=${kind}\n`,
@@ -7687,7 +7744,10 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
   //     by the upstream classifier
   //   - detail string contains one of the model-unavailable text patterns
   //     (covers raw stderr that slipped past structured classification)
-  const modelUnavailable = resolveModelUnavailableFromOperatorEvent(event)
+  // Throttle-tier escalation (long-reset transient 429) takes precedence:
+  // resolveModelUnavailableFromOperatorEvent deliberately returns null for a
+  // bare rate-limited event, but this one is auto-fallback-eligible.
+  const modelUnavailable = throttleEscalation ?? resolveModelUnavailableFromOperatorEvent(event)
   let renderedText: string
   let renderedKeyboard: ReturnType<typeof renderOperatorEvent>['keyboard'] | undefined
   // #3031 PR 3 — when the card promises an in-flight auto-failover, record
@@ -7709,7 +7769,12 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     // it just produces a self-cancelling "probed healthy / Stale event?"
     // loop on every 529. Overload is handled by Claude Code's own
     // internal retry, not by switching accounts.
-    const isAutoKind = modelUnavailable.kind === 'quota_exhausted'
+    // 'rate_limited' is the throttle-tier escalation (transient 429 whose
+    // reset exceeds the retry-in-place threshold) — same failover mechanics
+    // as a quota wall, honest wording on the card.
+    const isAutoKind =
+      modelUnavailable.kind === 'quota_exhausted' ||
+      modelUnavailable.kind === 'rate_limited'
     const willActuallyFire = isAutoKind && wouldFireFleetAutoFallback()
     process.stderr.write(
       `telegram gateway: operator-event suppressing-raw-stderr-for-model-unavailable agent=${agent} kind=${kind} detected=${modelUnavailable.kind} autoKind=${isAutoKind} willFire=${willActuallyFire}\n`,
@@ -7736,7 +7801,10 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     // the broker re-mirrored the still-walled account onto the fleet after 5h.
     if (willActuallyFire) {
       const untilMs = resolveExhaustUntil(modelUnavailable.resetAt?.getTime())
-      void fireFleetAutoFallback(agent, untilMs)
+      // Thread the RAW parsed reset (distinct from the floor-applied untilMs)
+      // so the fallback announcement can name it even when the live probe of
+      // the old account fails — honest reset messaging on the enriched card.
+      void fireFleetAutoFallback(agent, untilMs, modelUnavailable.resetAt)
     }
   } else {
     try {
@@ -11374,7 +11442,13 @@ const ipcServer: IpcServer = createIpcServer({
         (msg.resetAt == null ? ' (reset unparsed → +7d default)' : '') +
         ' — triggering fleet auto-fallback\n',
     )
-    void fireFleetAutoFallback(msg.agentName, untilMs)
+    void fireFleetAutoFallback(
+      msg.agentName,
+      untilMs,
+      // Enriched announcement: the sidecar-parsed reset (when present) keeps
+      // the recovery line honest even when the old account's probe fails.
+      msg.resetAt != null ? new Date(msg.resetAt) : undefined,
+    )
   },
 
   // Issue #2971 — read-only wedge-watchdog probe: is there a live pending
@@ -23203,15 +23277,169 @@ function wouldFireFleetAutoFallback(): boolean {
  * so the user sees the outcome inline with the original "Model
  * unavailable" card.
  */
-async function fireFleetAutoFallback(triggerAgent: string, untilMs?: number): Promise<void> {
+async function fireFleetAutoFallback(
+  triggerAgent: string,
+  untilMs?: number,
+  parsedResetAt?: Date,
+): Promise<void> {
   return fleetFallbackGate.fire(
-    () => doFireFleetAutoFallback(triggerAgent, untilMs),
+    () => doFireFleetAutoFallback(triggerAgent, untilMs, parsedResetAt),
     (err) => {
       process.stderr.write(
         `telegram gateway: [fleet-fallback] error agent=${triggerAgent}: ${(err as Error)?.message ?? err}\n`,
       )
     },
   )
+}
+
+// ─── 429 throttle tier — side-effect wiring ─────────────────────────────────
+// Decision + notice text live in throttle-tier.ts (pure); this owns the broker
+// write, the ONE lightweight notice, and the delayed retry nudge.
+
+/** Per-account cooldown state for the throttle notice (one per account per
+ *  window — a terminal-429 burst produces exactly one message). */
+let throttleNoticeState: ThrottleNoticeState = { lastSentAtMsByAccount: {} }
+
+/** Pending retry-nudge timer. The LATEST throttle owns the nudge — a newer
+ *  hit (longer reset) replaces an armed timer instead of stacking restarts. */
+let throttleRetryTimer: NodeJS.Timeout | null = null
+
+/** Slack past throttled_until before the retry nudge fires. */
+const THROTTLE_RETRY_NUDGE_SLACK_MS = 5_000
+
+/**
+ * Throttle path (429 throttle tier): the account is transiently rate-limited
+ * with a reset near enough to wait out in place. NO failover.
+ *
+ *  1. Report the broker's non-admin `mark-throttled` verb — records
+ *     throttled_until in the quota ledger (cron preflight soft-defers on it)
+ *     WITHOUT rolling the fleet and WITHOUT touching eligibility. The broker
+ *     also runs the escalation guard there (3+ hits/10min → live probe →
+ *     mark-exhausted when corroborated).
+ *  2. Post ONE lightweight operator notice: account, that it's rate-limited
+ *     not quota-exhausted, when it resets, that the agent stays put.
+ *     Cooldown-deduped per account.
+ *  3. Nudge a retry after throttled_until via the existing resume lever
+ *     (fleetFallbackResumeGate → triggerSelfRestart → boot-resume replays the
+ *     turn the 429 killed). Same guards as the fleet-fallback resume:
+ *     single-flight + staleness; a needless restart replays nothing (the
+ *     boot-resume path only re-injects a genuinely interrupted turn).
+ *
+ * Fire-and-forget: never throws into the caller's flow.
+ */
+async function fireThrottleTier(
+  triggerAgent: string,
+  throttledUntilMs: number,
+  resetParsed: boolean,
+): Promise<void> {
+  let account: string | null = null
+  let escalated = false
+  let rolledTo: string | null = null
+  try {
+    const client = await getAuthBrokerClient(triggerAgent)
+    if (client) {
+      const r = await client.markThrottled(throttledUntilMs)
+      account = r.account
+      escalated = r.escalated
+      rolledTo = r.rolledTo ?? null
+    } else {
+      process.stderr.write(
+        `telegram gateway: [throttle-tier] broker unreachable — notice only, no ledger record agent=${triggerAgent}\n`,
+      )
+    }
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: [throttle-tier] markThrottled failed agent=${triggerAgent}: ${(err as Error)?.message ?? err}\n`,
+    )
+  }
+
+  if (escalated) {
+    // The broker's escalation guard corroborated a genuine wall via a live
+    // probe and already ran the standard mark-exhausted + fleet roll. The
+    // roll announcement rides the existing broker-roll channel (list-state
+    // `last_fleet_roll` → quota-watch, fleet-deduped) — no duplicate send
+    // here. Nudge the dead-turn resume now: the fleet just swapped accounts.
+    process.stderr.write(
+      `telegram gateway: [throttle-tier] escalated to wall account=${account ?? '?'} ` +
+        `rolledTo=${rolledTo ?? 'none (all blocked)'}\n`,
+    )
+    if (rolledTo) {
+      const verdict = fleetFallbackResumeGate.decide(newestActiveTurnStartedAtMs())
+      if (verdict === 'resume') {
+        triggerSelfRestart(
+          process.env.SWITCHROOM_AGENT_NAME ?? triggerAgent,
+          'throttle-escalation-resume',
+        )
+      } else {
+        process.stderr.write(
+          `telegram gateway: [throttle-tier] escalation resume suppressed (${verdict})\n`,
+        )
+      }
+    }
+    return
+  }
+
+  // ONE lightweight notice, cooldown-deduped per account. When the broker was
+  // unreachable the account is unknown — key the cooldown on the agent so the
+  // degraded path still can't spam.
+  const cooldownKey = account ?? `agent:${triggerAgent}`
+  const verdict = evaluateThrottleNotice(throttleNoticeState, cooldownKey, Date.now())
+  if (verdict.send) {
+    throttleNoticeState = verdict.next
+    const access = loadAccess()
+    const html = renderThrottleNotice({
+      account,
+      agent: triggerAgent,
+      throttledUntilMs,
+      resetParsed,
+    })
+    // Status notice, not the user's answer — silence the ping (same posture
+    // as the fleet-fallback announcement).
+    const noticeOpts = { disable_notification: true }
+    for (const chat_id of access.allowFrom) {
+      void swallowingApiCall(
+        // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy)
+        () => bot.api.sendRichMessage(chat_id, richMessage(html), noticeOpts),
+        { chat_id, verb: 'throttle-tier:notify' },
+      )
+    }
+  } else {
+    process.stderr.write(
+      `telegram gateway: [throttle-tier] notice suppressed (cooldown) key=${cooldownKey}\n`,
+    )
+  }
+
+  scheduleThrottleRetryNudge(triggerAgent, throttledUntilMs)
+}
+
+/**
+ * Arm (or re-arm) the post-throttle retry nudge. After throttled_until the
+ * turn the 429 killed is replayed via the SAME lever the fleet-fallback
+ * resume uses — triggerSelfRestart + boot-resume — guarded by the shared
+ * fleetFallbackResumeGate (single-flight across throttle AND fallback
+ * resumes; staleness failsafe). The gate is consulted at FIRE time, not arm
+ * time, so a fallback-driven restart inside the wait window wins and the
+ * nudge no-ops.
+ */
+function scheduleThrottleRetryNudge(triggerAgent: string, throttledUntilMs: number): void {
+  const delayMs = Math.max(throttledUntilMs - Date.now(), 0) + THROTTLE_RETRY_NUDGE_SLACK_MS
+  if (throttleRetryTimer) clearTimeout(throttleRetryTimer)
+  throttleRetryTimer = setTimeout(() => {
+    throttleRetryTimer = null
+    const verdict = fleetFallbackResumeGate.decide(newestActiveTurnStartedAtMs())
+    if (verdict === 'resume') {
+      const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? triggerAgent
+      process.stderr.write(
+        `telegram gateway: [throttle-tier] throttle cleared — resuming dead turn via self-restart agent=${selfAgent}\n`,
+      )
+      triggerSelfRestart(selfAgent, 'throttle-retry-resume')
+    } else {
+      process.stderr.write(
+        `telegram gateway: [throttle-tier] retry nudge suppressed (${verdict}) agent=${triggerAgent}\n`,
+      )
+    }
+  }, delayMs)
+  throttleRetryTimer.unref()
 }
 
 /**
@@ -23275,7 +23503,11 @@ function broadcastFleetFallbackFailure(triggerAgent: string, reason: string): vo
  *  user-visible announcement was broadcast). False on no-op /
  *  error / idempotent-skip — caller uses this to decide whether to
  *  arm the post-fire suppression window. */
-async function doFireFleetAutoFallback(triggerAgent: string, untilMs?: number): Promise<boolean> {
+async function doFireFleetAutoFallback(
+  triggerAgent: string,
+  untilMs?: number,
+  parsedResetAt?: Date,
+): Promise<boolean> {
   try {
     const client = await getAuthBrokerClient(triggerAgent)
     if (!client) {
@@ -23324,6 +23556,10 @@ async function doFireFleetAutoFallback(triggerAgent: string, untilMs?: number): 
       },
       triggerAgent,
       tz,
+      // Enriched card (429 throttle tier): the RAW reset parsed from the
+      // error prose, so the announcement names when the old account frees
+      // even when its live probe returned nothing.
+      parsedResetAt,
     })
     process.stderr.write(
       `telegram gateway: [fleet-fallback] outcome=${outcome.kind} agent=${triggerAgent}` +

--- a/telegram-plugin/gateway/throttle-tier-wiring.ts
+++ b/telegram-plugin/gateway/throttle-tier-wiring.ts
@@ -1,0 +1,268 @@
+/**
+ * throttle-tier-wiring.ts — side-effect runner for the 429 throttle tier.
+ *
+ * The DECISION and notice text live in ../throttle-tier.ts (pure). This
+ * module owns the sequenced side effects, with every dependency injected so
+ * the wiring is unit-testable without importing gateway.ts:
+ *
+ *   1. Broker `mark-throttled` — records `throttled_until` in the quota
+ *      ledger (no roll, no eligibility change) and runs the broker-side
+ *      escalation guard (3 hits / 10 min → live probe → mark-exhausted when
+ *      corroborated). EVERY fire reaches the broker — the notice cooldown
+ *      below never suppresses the ledger write, because the escalation
+ *      counter is what corroborates a wall hiding behind transient wording.
+ *   2. ONE lightweight operator notice — deduped per account BOTH locally
+ *      (cooldown window) and FLEET-WIDE via the broker's claim-notification
+ *      verb (N agents sharing a throttled account produce one copy per chat,
+ *      not N). Claim failures FAIL OPEN (send anyway) per the claim
+ *      contract.
+ *   3. A delayed retry nudge — after `throttled_until` (+slack +jitter so N
+ *      agents don't restart-and-replay simultaneously into the just-cleared
+ *      account), replay the turn the 429 killed via the existing resume
+ *      lever (triggerSelfRestart → boot-resume). Guards, in order:
+ *        - a LIVE turn that started AFTER the throttle was armed supersedes
+ *          the dead turn — skip entirely (restarting would kill live work
+ *          and boot-resume would replay the WRONG turn);
+ *        - a live turn that started BEFORE the arm is the dead turn itself
+ *          still holding the in-flight gate — defer the restart to the
+ *          turn-complete drain (`pendingRestarts`) instead of SIGTERM-now;
+ *        - otherwise consult the SHARED fleet-fallback resume gate
+ *          (single-flight across throttle AND fallback resumes + staleness)
+ *          and restart on a 'resume' verdict.
+ *
+ * The escalated outcome (broker corroborated a wall and already rolled)
+ * posts its own announcement — gateway-side, per the reactive-path doctrine
+ * (`LastFleetRoll` docstring in src/auth/broker/server.ts), which also
+ * covers PINNED (non-fleet-active) account rolls — then nudges the resume
+ * immediately through the same turn-safety guards.
+ */
+
+import {
+  evaluateThrottleNotice,
+  renderThrottleEscalationNotice,
+  renderThrottleNotice,
+  THROTTLE_NOTICE_COOLDOWN_MS,
+  type ThrottleNoticeState,
+} from '../throttle-tier.js'
+
+/** Slack past throttled_until before the retry nudge fires. */
+export const THROTTLE_RETRY_NUDGE_SLACK_MS = 5_000
+
+/** Max random jitter added to the nudge so agents sharing the throttled
+ *  account stagger their restart-and-replay instead of stampeding the
+ *  just-cleared account. */
+export const THROTTLE_RETRY_NUDGE_JITTER_MAX_MS = 30_000
+
+/** The narrow broker surface the runner needs (structurally satisfied by
+ *  the gateway's AuthBrokerClient). */
+export interface ThrottleBrokerClient {
+  markThrottled(until: number): Promise<{
+    account: string
+    throttled_until: number
+    escalated: boolean
+    rolledTo?: string | null
+  }>
+  claimNotification(key: string, windowMs: number): Promise<{ granted: boolean }>
+}
+
+export interface ThrottleTierRunnerDeps {
+  /** This gateway's own agent (SWITCHROOM_AGENT_NAME). */
+  agentName: string
+  getBrokerClient(): Promise<ThrottleBrokerClient | null>
+  /** Chats the notice broadcasts to (access.allowFrom, resolved per call). */
+  listNoticeChats(): Array<string | number>
+  /** Fire-and-forget rich send (gateway wraps swallowingApiCall). */
+  sendNotice(chatId: string | number, markdown: string): void
+  /** THE shared fleet-fallback resume gate (single-flight + staleness). */
+  resumeDecide(failedTurnStartedAtMs: number | null): 'resume' | 'skip-inflight' | 'skip-stale'
+  newestActiveTurnStartedAtMs(): number | null
+  /** True while a turn is in flight (gateway turnInFlightForGate()). */
+  turnInFlight(): boolean
+  /** Defer the restart to the turn-complete drain (pendingRestarts). */
+  deferRestartToTurnComplete(agentName: string, reason: string): void
+  /** Restart now (gateway triggerSelfRestart). */
+  restartNow(agentName: string, reason: string): void
+  log(msg: string): void
+  now?: () => number
+  /** Timer seam (tests drive synchronously). Default setTimeout+unref. */
+  schedule?: (fn: () => void, ms: number) => { cancel(): void }
+  /** Jitter source (tests pin it). Default uniform 0..JITTER_MAX. */
+  jitterMs?: () => number
+}
+
+export interface ThrottleTierRunner {
+  /**
+   * Run the throttle path for one terminal transient 429. Fire-and-forget
+   * from the caller's perspective — never throws.
+   */
+  fire(triggerAgent: string, throttledUntilMs: number, resetParsed: boolean): Promise<void>
+  /** Test/debug view of internal state. */
+  inspect(): { noticeState: ThrottleNoticeState; nudgePending: boolean }
+}
+
+export function createThrottleTierRunner(deps: ThrottleTierRunnerDeps): ThrottleTierRunner {
+  const now = deps.now ?? (() => Date.now())
+  const schedule =
+    deps.schedule ??
+    ((fn: () => void, ms: number) => {
+      const t = setTimeout(fn, ms)
+      if (typeof t.unref === 'function') t.unref()
+      return { cancel: () => clearTimeout(t) }
+    })
+  const jitterMs =
+    deps.jitterMs ?? (() => Math.floor(Math.random() * THROTTLE_RETRY_NUDGE_JITTER_MAX_MS))
+
+  let noticeState: ThrottleNoticeState = { lastSentAtMsByAccount: {} }
+  /** The LATEST throttle owns the nudge — a newer hit replaces an armed
+   *  timer instead of stacking restarts. */
+  let pendingNudge: { cancel(): void } | null = null
+
+  /**
+   * Post `markdown` to every authorized chat, fleet-deduped per chat via the
+   * broker claim verb when a client + account are available. Fail-open: a
+   * claim error or missing broker never drops the notice.
+   */
+  async function broadcastDeduped(
+    client: ThrottleBrokerClient | null,
+    keyPrefix: string,
+    account: string | null,
+    markdown: string,
+  ): Promise<void> {
+    for (const chatId of deps.listNoticeChats()) {
+      let granted = true
+      if (client && account) {
+        try {
+          granted = (
+            await client.claimNotification(
+              `${keyPrefix}:${account}:${chatId}`,
+              THROTTLE_NOTICE_COOLDOWN_MS,
+            )
+          ).granted
+        } catch {
+          granted = true // fail open — a duplicated notice beats a dropped one
+        }
+      }
+      if (granted) {
+        deps.sendNotice(chatId, markdown)
+      } else {
+        deps.log(`[throttle-tier] notice suppressed (fleet claim) chat=${chatId}`)
+      }
+    }
+  }
+
+  /**
+   * Replay the dead turn via restart, with the turn-safety guards (see
+   * module docstring). `armedAtMs` anchors the "newer turn supersedes"
+   * check: a turn that started after the throttle was armed is live user
+   * work, never to be killed for a replay.
+   */
+  function nudgeResume(reason: string, armedAtMs: number): void {
+    const newest = deps.newestActiveTurnStartedAtMs()
+    if (deps.turnInFlight()) {
+      if (newest != null && newest > armedAtMs) {
+        deps.log(
+          `[throttle-tier] resume skipped (superseded by a live newer turn) reason=${reason}`,
+        )
+        return
+      }
+      // The in-flight gate is held by the dead throttled turn itself —
+      // defer to the turn-complete drain instead of SIGTERM-ing now.
+      deps.log(`[throttle-tier] resume deferred to turn-complete reason=${reason}`)
+      deps.deferRestartToTurnComplete(deps.agentName, reason)
+      return
+    }
+    const verdict = deps.resumeDecide(newest)
+    if (verdict === 'resume') {
+      deps.log(`[throttle-tier] resuming dead turn via self-restart reason=${reason}`)
+      deps.restartNow(deps.agentName, reason)
+    } else {
+      deps.log(`[throttle-tier] resume suppressed (${verdict}) reason=${reason}`)
+    }
+  }
+
+  async function fire(
+    triggerAgent: string,
+    throttledUntilMs: number,
+    resetParsed: boolean,
+  ): Promise<void> {
+    const armedAtMs = now()
+    let client: ThrottleBrokerClient | null = null
+    let account: string | null = null
+    let escalated = false
+    let rolledTo: string | null = null
+    try {
+      client = await deps.getBrokerClient()
+      if (client) {
+        const r = await client.markThrottled(throttledUntilMs)
+        account = r.account
+        escalated = r.escalated
+        rolledTo = r.rolledTo ?? null
+      } else {
+        deps.log(
+          `[throttle-tier] broker unreachable — notice only, no ledger record agent=${triggerAgent}`,
+        )
+      }
+    } catch (err) {
+      deps.log(
+        `[throttle-tier] markThrottled failed agent=${triggerAgent}: ${(err as Error)?.message ?? err}`,
+      )
+    }
+
+    if (escalated) {
+      // The broker corroborated a genuine wall via a live probe and already
+      // ran mark-exhausted + roll (fleet active AND pinned accounts alike).
+      // The RAISING gateway announces — reactive-path doctrine — fleet-
+      // deduped so N gateways sharing the account produce one copy per chat.
+      deps.log(
+        `[throttle-tier] escalated to wall account=${account ?? '?'} ` +
+          `rolledTo=${rolledTo ?? 'none (all blocked)'}`,
+      )
+      await broadcastDeduped(
+        client,
+        'throttle-escalation',
+        account,
+        renderThrottleEscalationNotice({ account, agent: triggerAgent, rolledTo }),
+      )
+      if (rolledTo) nudgeResume('throttle-escalation-resume', armedAtMs)
+      return
+    }
+
+    // ONE lightweight notice, deduped per account: locally by cooldown, then
+    // fleet-wide by broker claim. Unknown account (broker down) keys the
+    // local cooldown on the agent so the degraded path still can't spam.
+    const cooldownKey = account ?? `agent:${triggerAgent}`
+    const verdict = evaluateThrottleNotice(noticeState, cooldownKey, now())
+    if (verdict.send) {
+      noticeState = verdict.next
+      await broadcastDeduped(
+        client,
+        'throttle-notice',
+        account,
+        renderThrottleNotice({
+          account,
+          agent: triggerAgent,
+          throttledUntilMs,
+          resetParsed,
+          now: new Date(now()),
+        }),
+      )
+    } else {
+      deps.log(`[throttle-tier] notice suppressed (cooldown) key=${cooldownKey}`)
+    }
+
+    // Arm (or re-arm) the retry nudge: slack past the reset + jitter so
+    // agents sharing the account stagger their replays.
+    const delayMs =
+      Math.max(throttledUntilMs - now(), 0) + THROTTLE_RETRY_NUDGE_SLACK_MS + jitterMs()
+    if (pendingNudge) pendingNudge.cancel()
+    pendingNudge = schedule(() => {
+      pendingNudge = null
+      nudgeResume('throttle-retry-resume', armedAtMs)
+    }, delayMs)
+  }
+
+  return {
+    fire,
+    inspect: () => ({ noticeState, nudgePending: pendingNudge != null }),
+  }
+}

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -31,7 +31,20 @@ import { escapeMarkdown } from './card-format.js'
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
-export type ModelUnavailableKind = 'overload' | 'quota_exhausted' | 'network'
+export type ModelUnavailableKind =
+  | 'overload'
+  | 'quota_exhausted'
+  | 'network'
+  /**
+   * 429 throttle tier — a TRANSIENT per-account 429 (explicit
+   * `transientUpstreamSignals` negation wording) whose parsed reset lies
+   * BEYOND the retry-in-place threshold, so the gateway escalates it to the
+   * standard mark-exhausted + fleet-failover machinery. Never produced by
+   * `detectModelUnavailable` (a transient-negation string classifies as
+   * `overload` there); constructed only by the gateway's throttle-tier
+   * branch so the card names the true cause instead of "quota exhausted".
+   */
+  | 'rate_limited'
 
 export interface ModelUnavailableDetection {
   kind: ModelUnavailableKind
@@ -212,7 +225,7 @@ export function detectModelUnavailable(
  * arg lets tests pin the relative-clock anchor; production callers omit
  * it to use Date.now().
  */
-function parseResetTime(text: string, parseTimeNow: Date = new Date()): Date | undefined {
+export function parseResetTime(text: string, parseTimeNow: Date = new Date()): Date | undefined {
   const lower = text.toLowerCase()
 
   // "retry after 60 seconds" / "retry-after: 60"
@@ -459,6 +472,11 @@ function formatReason(d: ModelUnavailableDetection, now: Date): string {
       return `quota exhausted${reset}`
     case 'overload':
       return `model overloaded${reset}`
+    case 'rate_limited':
+      // Throttle-tier escalation (429 with transient wording but a reset too
+      // far out to wait in place). Honest cause: the account is rate-limited,
+      // not quota-exhausted — the reset names when it frees.
+      return `account rate-limited${reset}`
     case 'network':
       return 'network unreachable'
   }

--- a/telegram-plugin/tests/auto-fallback-fleet.test.ts
+++ b/telegram-plugin/tests/auto-fallback-fleet.test.ts
@@ -143,6 +143,53 @@ describe('runFleetAutoFallback', () => {
     }
   });
 
+  it('rateLimitTrigger: swaps even when the old account probes HEALTHY (the >threshold leg must execute)', async () => {
+    // A terminal transient 429 NEGATES the usage-limit reading, so healthy
+    // utilization is the EXPECTED state for the rate-limited account. The
+    // healthy-idempotency guard must not self-cancel this swap into a
+    // "probed healthy / Stale event?" no-op.
+    const failover = vi.fn(async () => ({ rolledTo: 'you@x', rolled: ['ken@x'] }));
+    const out = await runFleetAutoFallback({
+      state: state('ken@x', ['ken@x', 'you@x']),
+      quotas: [
+        qOk({ fiveHourUtilizationPct: 12, sevenDayUtilizationPct: 30 }), // healthy!
+        qOk({ fiveHourUtilizationPct: 8, sevenDayUtilizationPct: 20 }),
+      ],
+      failover,
+      triggerAgent: 'carrie',
+      now: NOW,
+      tz: 'UTC',
+      parsedResetAt: new Date('2026-05-15T02:53:00Z'),
+      rateLimitTrigger: true,
+    });
+
+    expect(out.kind).toBe('switched');
+    expect(failover).toHaveBeenCalledTimes(1);
+    if (out.kind === 'switched') {
+      // Honest headline: a rate limit, not a utilization-derived window cap.
+      expect(out.announcement).toContain('rate limit on ken@x');
+      expect(out.announcement).not.toContain('5-hour limit');
+      // Recovery line carries the parsed reset (no window was maxed).
+      expect(out.announcement).toContain('recovers');
+      expect(out.announcement).toContain('in 2h');
+    }
+  });
+
+  it('rateLimitTrigger stays subject to the broker outcome (all-blocked passes through)', async () => {
+    const failover = vi.fn(async () => ({ rolledTo: null, rolled: [] }));
+    const out = await runFleetAutoFallback({
+      state: state('ken@x', ['ken@x']),
+      quotas: [qOk({ fiveHourUtilizationPct: 12, sevenDayUtilizationPct: 30 })],
+      failover,
+      triggerAgent: 'carrie',
+      now: NOW,
+      tz: 'UTC',
+      rateLimitTrigger: true,
+    });
+    expect(out.kind).toBe('all-blocked');
+    expect(failover).toHaveBeenCalledTimes(1);
+  });
+
   it('idempotency: skips the swap WITHOUT calling failover when active probes healthy', async () => {
     const failover = vi.fn();
     const out = await runFleetAutoFallback({

--- a/telegram-plugin/tests/auto-fallback-fleet.test.ts
+++ b/telegram-plugin/tests/auto-fallback-fleet.test.ts
@@ -118,6 +118,31 @@ describe('runFleetAutoFallback', () => {
     }
   });
 
+  it('parsedResetAt (429 throttle tier) names the recovery when the old probe carried no reset', async () => {
+    const failover = vi.fn(async () => ({ rolledTo: 'you@x', rolled: ['ken@x'] }));
+    const out = await runFleetAutoFallback({
+      state: state('ken@x', ['ken@x', 'you@x']),
+      quotas: [
+        // ken: walled, but the probe carried NO reset time — pre-fix the
+        // announcement's recovery line was silently dropped.
+        qOk({ fiveHourUtilizationPct: 100, representativeClaim: 'five_hour' }),
+        qOk({ fiveHourUtilizationPct: 8, sevenDayUtilizationPct: 20 }),
+      ],
+      failover,
+      triggerAgent: 'carrie',
+      now: NOW,
+      tz: 'UTC',
+      // Parsed from the error prose ("resets 5:50am") by the gateway.
+      parsedResetAt: new Date('2026-05-15T05:50:00Z'),
+    });
+
+    expect(out.kind).toBe('switched');
+    if (out.kind === 'switched') {
+      expect(out.announcement).toContain('recovers');
+      expect(out.announcement).toContain('in 4h 57m');
+    }
+  });
+
   it('idempotency: skips the swap WITHOUT calling failover when active probes healthy', async () => {
     const failover = vi.fn();
     const out = await runFleetAutoFallback({

--- a/telegram-plugin/tests/throttle-tier-wiring.test.ts
+++ b/telegram-plugin/tests/throttle-tier-wiring.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for gateway/throttle-tier-wiring.ts — the 429 throttle tier's
+ * side-effect runner, driven with fully injected deps (no gateway import).
+ *
+ * Pins the OUTCOMES the wiring promises:
+ *  - EVERY fire reaches the broker's mark-throttled (the escalation counter),
+ *    even when the user-facing notice is cooldown-suppressed;
+ *  - ONE notice per account per window, deduped locally AND fleet-wide via
+ *    the broker claim verb (denied claim → no send; claim error → fail open);
+ *  - the retry nudge is armed at throttled_until + slack + jitter, replaced
+ *    (not stacked) by a newer throttle, and at FIRE time:
+ *      - restarts when idle and the resume gate says 'resume';
+ *      - DEFERS to the turn-complete drain when the in-flight gate is held
+ *        by the dead throttled turn (never SIGTERM-now under a live turn);
+ *      - SKIPS entirely when a NEWER turn (started after the throttle was
+ *        armed) is live — restarting would kill live work and boot-resume
+ *        would replay the WRONG turn;
+ *  - the escalated outcome posts the corroborated-wall announcement (fleet-
+ *    deduped) and nudges the resume immediately through the same guards;
+ *  - a broker-unreachable fire degrades to notice-only without throwing.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createThrottleTierRunner,
+  THROTTLE_RETRY_NUDGE_SLACK_MS,
+  type ThrottleBrokerClient,
+  type ThrottleTierRunnerDeps,
+} from '../gateway/throttle-tier-wiring.js'
+
+const NOW = Date.UTC(2026, 6, 12, 8, 0, 0)
+
+interface Harness {
+  deps: ThrottleTierRunnerDeps
+  calls: {
+    markThrottled: number[]
+    claims: string[]
+    notices: Array<{ chatId: string | number; markdown: string }>
+    deferrals: string[]
+    restarts: string[]
+    logs: string[]
+    timers: Array<{ ms: number; fn: () => void; cancelled: boolean }>
+  }
+  clock: { set(ms: number): void }
+  fireTimer(idx: number): void
+}
+
+function makeHarness(opts: {
+  markThrottledResult?:
+    | { account: string; throttled_until: number; escalated: boolean; rolledTo?: string | null }
+    | 'unreachable'
+    | 'throw'
+  claimGranted?: (key: string) => boolean | 'throw'
+  resumeVerdict?: 'resume' | 'skip-inflight' | 'skip-stale'
+  turnInFlight?: () => boolean
+  newestTurnStartedAt?: () => number | null
+  jitterMs?: number
+} = {}): Harness {
+  let nowMs = NOW
+  const calls: Harness['calls'] = {
+    markThrottled: [],
+    claims: [],
+    notices: [],
+    deferrals: [],
+    restarts: [],
+    logs: [],
+    timers: [],
+  }
+  const client: ThrottleBrokerClient = {
+    async markThrottled(until: number) {
+      calls.markThrottled.push(until)
+      if (opts.markThrottledResult === 'throw') throw new Error('boom')
+      const r = opts.markThrottledResult
+      if (r && r !== 'unreachable') return r
+      return { account: 'alice', throttled_until: until, escalated: false, rolledTo: null }
+    },
+    async claimNotification(key: string) {
+      calls.claims.push(key)
+      const g = opts.claimGranted?.(key) ?? true
+      if (g === 'throw') throw new Error('claim boom')
+      return { granted: g }
+    },
+  }
+  const deps: ThrottleTierRunnerDeps = {
+    agentName: 'carrie',
+    getBrokerClient: async () =>
+      opts.markThrottledResult === 'unreachable' ? null : client,
+    listNoticeChats: () => ['111', '222'],
+    sendNotice: (chatId, markdown) => calls.notices.push({ chatId, markdown }),
+    resumeDecide: () => opts.resumeVerdict ?? 'resume',
+    newestActiveTurnStartedAtMs: opts.newestTurnStartedAt ?? (() => null),
+    turnInFlight: opts.turnInFlight ?? (() => false),
+    deferRestartToTurnComplete: (_agent, reason) => calls.deferrals.push(reason),
+    restartNow: (_agent, reason) => calls.restarts.push(reason),
+    log: (m) => calls.logs.push(m),
+    now: () => nowMs,
+    schedule: (fn, ms) => {
+      const t = { ms, fn, cancelled: false }
+      calls.timers.push(t)
+      return { cancel: () => { t.cancelled = true } }
+    },
+    jitterMs: () => opts.jitterMs ?? 0,
+  }
+  return {
+    deps,
+    calls,
+    clock: { set: (ms) => { nowMs = ms } },
+    fireTimer(idx: number) {
+      const t = calls.timers[idx]
+      if (!t || t.cancelled) throw new Error('no live timer at idx ' + idx)
+      t.fn()
+    },
+  }
+}
+
+describe('throttle-tier runner — broker mark + notice dedup', () => {
+  it('every fire reaches markThrottled; the notice is sent ONCE per cooldown window', async () => {
+    const h = makeHarness()
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, true)
+    h.clock.set(NOW + 30_000) // same window
+    await runner.fire('carrie', NOW + 90_000, true)
+
+    // Both hits reached the broker (the escalation counter needs them)…
+    expect(h.calls.markThrottled).toEqual([NOW + 60_000, NOW + 90_000])
+    // …but only ONE notice per chat went out.
+    expect(h.calls.notices).toHaveLength(2) // 2 chats × 1 notice
+    expect(h.calls.notices.map((n) => n.chatId)).toEqual(['111', '222'])
+    expect(h.calls.notices[0].markdown).toContain('alice')
+    expect(h.calls.notices[0].markdown).toContain('Rate-limited, staying put')
+  })
+
+  it('fleet-wide claim dedup: a denied claim suppresses that chat, an error fails open', async () => {
+    const h = makeHarness({
+      claimGranted: (key) => (key.endsWith(':111') ? false : 'throw'),
+    })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, true)
+
+    // chat 111 denied (another gateway won the claim), chat 222 errored → open.
+    expect(h.calls.claims).toEqual([
+      `throttle-notice:alice:111`,
+      `throttle-notice:alice:222`,
+    ])
+    expect(h.calls.notices.map((n) => n.chatId)).toEqual(['222'])
+  })
+
+  it('degrades to notice-only when the broker is unreachable (no throw, no claim)', async () => {
+    const h = makeHarness({ markThrottledResult: 'unreachable' })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, false)
+    expect(h.calls.markThrottled).toHaveLength(0)
+    expect(h.calls.claims).toHaveLength(0) // no account → no claim key
+    expect(h.calls.notices).toHaveLength(2)
+    expect(h.calls.notices[0].markdown).toContain('the active account')
+  })
+
+  it('a markThrottled throw is swallowed and the notice still goes out', async () => {
+    const h = makeHarness({ markThrottledResult: 'throw' })
+    const runner = createThrottleTierRunner(h.deps)
+    await expect(runner.fire('carrie', NOW + 60_000, true)).resolves.toBeUndefined()
+    expect(h.calls.notices).toHaveLength(2)
+  })
+})
+
+describe('throttle-tier runner — retry nudge scheduling + turn safety', () => {
+  it('arms the nudge at reset + slack + jitter and restarts when idle', async () => {
+    const h = makeHarness({ jitterMs: 7_000 })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, true)
+
+    expect(h.calls.timers).toHaveLength(1)
+    expect(h.calls.timers[0].ms).toBe(60_000 + THROTTLE_RETRY_NUDGE_SLACK_MS + 7_000)
+    expect(runner.inspect().nudgePending).toBe(true)
+
+    h.fireTimer(0)
+    expect(h.calls.restarts).toEqual(['throttle-retry-resume'])
+    expect(h.calls.deferrals).toHaveLength(0)
+    expect(runner.inspect().nudgePending).toBe(false)
+  })
+
+  it('a newer throttle REPLACES the pending nudge instead of stacking restarts', async () => {
+    const h = makeHarness()
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, true)
+    await runner.fire('carrie', NOW + 120_000, true)
+    expect(h.calls.timers).toHaveLength(2)
+    expect(h.calls.timers[0].cancelled).toBe(true)
+    expect(h.calls.timers[1].cancelled).toBe(false)
+  })
+
+  it('DEFERS to the turn-complete drain when the dead throttled turn still holds the gate', async () => {
+    const h = makeHarness({
+      turnInFlight: () => true,
+      // The in-flight turn started BEFORE the throttle was armed — it IS the
+      // dead turn (a 429-killed turn never writes its turn-end marker).
+      newestTurnStartedAt: () => NOW - 60_000,
+    })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, true)
+    h.fireTimer(0)
+    expect(h.calls.restarts).toHaveLength(0) // never SIGTERM-now under a live gate
+    expect(h.calls.deferrals).toEqual(['throttle-retry-resume'])
+  })
+
+  it('SKIPS entirely when a NEWER live turn supersedes the dead one', async () => {
+    let nowAtNudge = NOW
+    const h = makeHarness({
+      turnInFlight: () => true,
+      // Started AFTER the throttle was armed — live user work.
+      newestTurnStartedAt: () => nowAtNudge + 30_000,
+    })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, true)
+    nowAtNudge = NOW // armedAt == NOW; newest = NOW+30s > armedAt
+    h.fireTimer(0)
+    expect(h.calls.restarts).toHaveLength(0)
+    expect(h.calls.deferrals).toHaveLength(0)
+    expect(h.calls.logs.some((l) => l.includes('superseded'))).toBe(true)
+  })
+
+  it('honours the shared resume gate verdict (skip-inflight → no restart)', async () => {
+    const h = makeHarness({ resumeVerdict: 'skip-inflight' })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, true)
+    h.fireTimer(0)
+    expect(h.calls.restarts).toHaveLength(0)
+    expect(h.calls.logs.some((l) => l.includes('skip-inflight'))).toBe(true)
+  })
+})
+
+describe('throttle-tier runner — escalated outcome (corroborated wall)', () => {
+  it('posts the fleet-deduped escalation announcement and resumes immediately', async () => {
+    const h = makeHarness({
+      markThrottledResult: {
+        account: 'alice',
+        throttled_until: NOW + 60_000,
+        escalated: true,
+        rolledTo: 'bob',
+      },
+    })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, true)
+
+    // Announcement (not the staying-put notice), per chat, claim-deduped.
+    expect(h.calls.claims).toEqual([
+      `throttle-escalation:alice:111`,
+      `throttle-escalation:alice:222`,
+    ])
+    expect(h.calls.notices).toHaveLength(2)
+    expect(h.calls.notices[0].markdown).toContain('actually a wall')
+    expect(h.calls.notices[0].markdown).toContain('bob')
+
+    // Immediate resume (fleet just swapped accounts) — no delayed nudge armed.
+    expect(h.calls.restarts).toEqual(['throttle-escalation-resume'])
+    expect(h.calls.timers).toHaveLength(0)
+  })
+
+  it('escalated with rolledTo=null (all blocked) announces but does NOT restart', async () => {
+    const h = makeHarness({
+      markThrottledResult: {
+        account: 'alice',
+        throttled_until: NOW + 60_000,
+        escalated: true,
+        rolledTo: null,
+      },
+    })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, true)
+    expect(h.calls.notices[0].markdown).toContain('all blocked')
+    expect(h.calls.restarts).toHaveLength(0)
+  })
+
+  it('escalated resume respects the live-turn guards too', async () => {
+    const h = makeHarness({
+      markThrottledResult: {
+        account: 'alice',
+        throttled_until: NOW + 60_000,
+        escalated: true,
+        rolledTo: 'bob',
+      },
+      turnInFlight: () => true,
+      newestTurnStartedAt: () => NOW - 60_000, // the dead turn holds the gate
+    })
+    const runner = createThrottleTierRunner(h.deps)
+    await runner.fire('carrie', NOW + 60_000, true)
+    expect(h.calls.restarts).toHaveLength(0)
+    expect(h.calls.deferrals).toEqual(['throttle-escalation-resume'])
+  })
+})

--- a/telegram-plugin/tests/throttle-tier.test.ts
+++ b/telegram-plugin/tests/throttle-tier.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for telegram-plugin/throttle-tier.ts — the 429 throttle tier.
+ *
+ * Pins the operator-approved decision matrix ("retry in place under 5 min,
+ * else mark + failover, honest reset messaging"):
+ *   - transient wording + reset ≤ threshold  → throttle (stay put)
+ *   - transient wording + reset > threshold  → failover (escalate)
+ *   - transient wording + unparseable reset  → throttle, now+60s default
+ *   - non-transient (wall) wording           → none (caller's existing path)
+ * plus the per-account notice cooldown and the notice text itself.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  decideThrottleTier,
+  evaluateThrottleNotice,
+  renderThrottleNotice,
+  throttleRetryInPlaceMaxMs,
+  THROTTLE_DEFAULT_WAIT_MS,
+  THROTTLE_NOTICE_COOLDOWN_MS,
+  THROTTLE_RETRY_IN_PLACE_MAX_MS_DEFAULT,
+  type ThrottleNoticeState,
+} from '../throttle-tier.js'
+import { formatModelUnavailableCard, parseResetTime } from '../model-unavailable.js'
+
+const NOW = Date.UTC(2026, 6, 12, 8, 0, 0) // 2026-07-12T08:00:00Z
+const THRESHOLD = THROTTLE_RETRY_IN_PLACE_MAX_MS_DEFAULT // 5 min
+
+// The canonical transient-negation wording (Anthropic burst-429 shape).
+const TRANSIENT = (suffix: string): string =>
+  `This request would exceed your account's rate limit (not your usage limit). ${suffix}`
+
+describe('decideThrottleTier — decision matrix', () => {
+  it('transient wording + reset within threshold → throttle at the parsed reset', () => {
+    const d = decideThrottleTier({
+      detail: TRANSIENT('Please retry after 90 seconds.'),
+      now: NOW,
+      thresholdMs: THRESHOLD,
+    })
+    expect(d).toEqual({
+      action: 'throttle',
+      throttledUntilMs: NOW + 90_000,
+      resetParsed: true,
+    })
+  })
+
+  it('transient wording + "resets in 3m" → throttle (≤ 5 min)', () => {
+    const d = decideThrottleTier({
+      detail: TRANSIENT('resets in 3m'),
+      now: NOW,
+      thresholdMs: THRESHOLD,
+    })
+    expect(d).toEqual({
+      action: 'throttle',
+      throttledUntilMs: NOW + 3 * 60_000,
+      resetParsed: true,
+    })
+  })
+
+  it('transient wording + reset beyond threshold → failover with the parsed reset', () => {
+    const d = decideThrottleTier({
+      detail: TRANSIENT('resets in 2h 15m'),
+      now: NOW,
+      thresholdMs: THRESHOLD,
+    })
+    expect(d).toEqual({
+      action: 'failover',
+      resetAtMs: NOW + (2 * 60 + 15) * 60_000,
+    })
+  })
+
+  it('transient wording + NO parseable reset → throttle for the 60s default', () => {
+    const d = decideThrottleTier({
+      detail: TRANSIENT('try again later.'),
+      now: NOW,
+      thresholdMs: THRESHOLD,
+    })
+    expect(d).toEqual({
+      action: 'throttle',
+      throttledUntilMs: NOW + THROTTLE_DEFAULT_WAIT_MS,
+      resetParsed: false,
+    })
+  })
+
+  it('transient wording + reset in the PAST → throttle for the 60s default', () => {
+    const past = new Date(NOW - 60_000).toISOString()
+    const d = decideThrottleTier({
+      detail: TRANSIENT(`resets ${past}`),
+      now: NOW,
+      thresholdMs: THRESHOLD,
+    })
+    expect(d).toEqual({
+      action: 'throttle',
+      throttledUntilMs: NOW + THROTTLE_DEFAULT_WAIT_MS,
+      resetParsed: false,
+    })
+  })
+
+  it('genuine wall wording (no transient negation) → none (existing quota path owns it)', () => {
+    const d = decideThrottleTier({
+      detail: "You've hit your limit · resets 8:50am (Australia/Melbourne)",
+      now: NOW,
+      thresholdMs: THRESHOLD,
+    })
+    expect(d).toEqual({ action: 'none' })
+  })
+
+  it('honours a custom threshold (boundary: exactly at threshold stays in place)', () => {
+    const atThreshold = decideThrottleTier({
+      detail: TRANSIENT('retry after 300 seconds'),
+      now: NOW,
+      thresholdMs: 5 * 60_000,
+    })
+    expect(atThreshold.action).toBe('throttle')
+    const beyond = decideThrottleTier({
+      detail: TRANSIENT('retry after 301 seconds'),
+      now: NOW,
+      thresholdMs: 5 * 60_000,
+    })
+    expect(beyond.action).toBe('failover')
+  })
+})
+
+describe('throttleRetryInPlaceMaxMs — env resolution', () => {
+  it('defaults to 5 minutes', () => {
+    expect(throttleRetryInPlaceMaxMs({})).toBe(5 * 60_000)
+  })
+
+  it('reads SWITCHROOM_THROTTLE_RETRY_IN_PLACE_MAX_MS', () => {
+    expect(
+      throttleRetryInPlaceMaxMs({ SWITCHROOM_THROTTLE_RETRY_IN_PLACE_MAX_MS: '120000' }),
+    ).toBe(120_000)
+  })
+
+  it('falls back to the default on junk / non-positive values', () => {
+    expect(
+      throttleRetryInPlaceMaxMs({ SWITCHROOM_THROTTLE_RETRY_IN_PLACE_MAX_MS: 'soon' }),
+    ).toBe(THROTTLE_RETRY_IN_PLACE_MAX_MS_DEFAULT)
+    expect(
+      throttleRetryInPlaceMaxMs({ SWITCHROOM_THROTTLE_RETRY_IN_PLACE_MAX_MS: '-5' }),
+    ).toBe(THROTTLE_RETRY_IN_PLACE_MAX_MS_DEFAULT)
+  })
+})
+
+describe('evaluateThrottleNotice — per-account cooldown', () => {
+  it('sends the first notice and suppresses a repeat inside the window', () => {
+    let state: ThrottleNoticeState = { lastSentAtMsByAccount: {} }
+    const first = evaluateThrottleNotice(state, 'acct-a', NOW)
+    expect(first.send).toBe(true)
+    state = first.next
+    const repeat = evaluateThrottleNotice(state, 'acct-a', NOW + 60_000)
+    expect(repeat.send).toBe(false)
+  })
+
+  it('a DIFFERENT account is not suppressed by the first account\'s window', () => {
+    const first = evaluateThrottleNotice({ lastSentAtMsByAccount: {} }, 'acct-a', NOW)
+    const other = evaluateThrottleNotice(first.next, 'acct-b', NOW + 1)
+    expect(other.send).toBe(true)
+  })
+
+  it('sends again once the cooldown window has elapsed', () => {
+    const first = evaluateThrottleNotice({ lastSentAtMsByAccount: {} }, 'acct-a', NOW)
+    const later = evaluateThrottleNotice(
+      first.next,
+      'acct-a',
+      NOW + THROTTLE_NOTICE_COOLDOWN_MS,
+    )
+    expect(later.send).toBe(true)
+  })
+})
+
+describe('renderThrottleNotice — honest reset messaging', () => {
+  it('names the account, the agent, the reset, and that it is NOT a quota wall', () => {
+    const text = renderThrottleNotice({
+      account: 'alice',
+      agent: 'carrie',
+      throttledUntilMs: NOW + 3 * 60_000,
+      resetParsed: true,
+      now: new Date(NOW),
+    })
+    expect(text).toContain('alice')
+    expect(text).toContain('carrie')
+    expect(text).toContain('resets in 3m')
+    expect(text).toContain('not a quota wall')
+    expect(text).toContain('Staying on')
+    expect(text).toContain('no failover')
+  })
+
+  it('degrades honestly when the account is unknown (broker unreachable)', () => {
+    const text = renderThrottleNotice({
+      account: null,
+      agent: 'carrie',
+      throttledUntilMs: NOW + THROTTLE_DEFAULT_WAIT_MS,
+      resetParsed: false,
+      now: new Date(NOW),
+    })
+    expect(text).toContain('the active account')
+    expect(text).toContain('retrying in ~60s')
+  })
+})
+
+describe('rate_limited escalation card wording (model-unavailable integration)', () => {
+  it('formatModelUnavailableCard names the rate limit, not quota exhaustion', () => {
+    const card = formatModelUnavailableCard(
+      { kind: 'rate_limited', resetAt: new Date(NOW + 30 * 60_000), raw: 'x' },
+      'carrie',
+      { now: new Date(NOW), autoFallbackInFlight: true },
+    )
+    expect(card).toContain('account rate-limited')
+    expect(card).toContain('resets in 30m')
+    expect(card).not.toContain('quota exhausted')
+  })
+})
+
+describe('parseResetTime (exported for the throttle tier)', () => {
+  it('parses "retry after N seconds" relative to the injected clock', () => {
+    const d = parseResetTime('retry after 45 seconds', new Date(NOW))
+    expect(d?.getTime()).toBe(NOW + 45_000)
+  })
+
+  it('returns undefined for prose with no reset hint', () => {
+    expect(parseResetTime('temporarily limiting requests', new Date(NOW))).toBeUndefined()
+  })
+})

--- a/telegram-plugin/tests/throttle-tier.test.ts
+++ b/telegram-plugin/tests/throttle-tier.test.ts
@@ -14,6 +14,8 @@ import { describe, it, expect } from 'vitest'
 import {
   decideThrottleTier,
   evaluateThrottleNotice,
+  isAccountScopedThrottle,
+  renderThrottleEscalationNotice,
   renderThrottleNotice,
   throttleRetryInPlaceMaxMs,
   THROTTLE_DEFAULT_WAIT_MS,
@@ -105,6 +107,19 @@ describe('decideThrottleTier — decision matrix', () => {
     expect(d).toEqual({ action: 'none' })
   })
 
+  it('SERVER-side transient wording (529 shape) → none — never account-throttled', () => {
+    // This carries the transient NEGATION ("not your usage limit") but does
+    // NOT affirm the account's own rate limit — it is a server-wide
+    // condition; an account-scoped throttle + restart nudge would be the
+    // wrong action. It stays on the existing calm rate-limited path.
+    const d = decideThrottleTier({
+      detail: 'Server is temporarily limiting requests (not your usage limit). retry after 60 seconds',
+      now: NOW,
+      thresholdMs: THRESHOLD,
+    })
+    expect(d).toEqual({ action: 'none' })
+  })
+
   it('honours a custom threshold (boundary: exactly at threshold stays in place)', () => {
     const atThreshold = decideThrottleTier({
       detail: TRANSIENT('retry after 300 seconds'),
@@ -118,6 +133,21 @@ describe('decideThrottleTier — decision matrix', () => {
       thresholdMs: 5 * 60_000,
     })
     expect(beyond.action).toBe('failover')
+  })
+})
+
+describe('isAccountScopedThrottle — the tier gate', () => {
+  it("matches account-affirming wording (both apostrophe variants + 'not your account')", () => {
+    expect(isAccountScopedThrottle("would exceed your account's rate limit")).toBe(true)
+    expect(isAccountScopedThrottle('would exceed your account’s rate limit')).toBe(true)
+    expect(isAccountScopedThrottle("this is not your account's limit")).toBe(true)
+  })
+
+  it('rejects server-side transient / 529 wordings and walls', () => {
+    expect(isAccountScopedThrottle('Server is temporarily limiting requests (not your usage limit)')).toBe(false)
+    expect(isAccountScopedThrottle('temporarily rate limited, overloaded_error 529')).toBe(false)
+    expect(isAccountScopedThrottle("You've hit your limit · resets 8:50am")).toBe(false)
+    expect(isAccountScopedThrottle('')).toBe(false)
   })
 })
 
@@ -196,6 +226,30 @@ describe('renderThrottleNotice — honest reset messaging', () => {
     })
     expect(text).toContain('the active account')
     expect(text).toContain('retrying in ~60s')
+  })
+})
+
+describe('renderThrottleEscalationNotice — corroborated-wall announcement', () => {
+  it('names the account, the trigger agent, and the roll target', () => {
+    const text = renderThrottleEscalationNotice({
+      account: 'alice',
+      agent: 'carrie',
+      rolledTo: 'bob',
+    })
+    expect(text).toContain('alice')
+    expect(text).toContain('carrie')
+    expect(text).toContain('bob')
+    expect(text).toContain('actually a wall')
+  })
+
+  it('renders the all-blocked variant when no fallback had quota', () => {
+    const text = renderThrottleEscalationNotice({
+      account: 'alice',
+      agent: 'carrie',
+      rolledTo: null,
+    })
+    expect(text).toContain('all blocked')
+    expect(text).toContain('/auth add')
   })
 })
 

--- a/telegram-plugin/throttle-tier.ts
+++ b/telegram-plugin/throttle-tier.ts
@@ -1,0 +1,168 @@
+/**
+ * throttle-tier.ts — the 429 throttle tier (pure decision + notice rendering).
+ *
+ * Operator-approved behavior spec: "retry in place under 5 min, else mark +
+ * failover, honest reset messaging."
+ *
+ * A terminal TRANSIENT 429 (a `rate_limit_error` whose wording explicitly
+ * negates the account-quota reading — see `transientUpstreamSignals` in
+ * model-unavailable.ts) used to take the fully calm path: no broker state, no
+ * account attribution, a generic "🚦 Rate limited" card. That is right for a
+ * few-second burst but wrong for the minutes-long per-account throttles
+ * Anthropic emits with a "resets 8:50am (TZ)" hint: the fleet has no memory
+ * that the account is throttled (cron fires walk straight into the same 429)
+ * and the operator can't tell a throttle from a wall.
+ *
+ * This module owns the DECISION and the NOTICE TEXT; the gateway wires the
+ * side effects (broker `mark-throttled`, the Telegram send, the delayed
+ * retry nudge):
+ *
+ *   - reset parseable and ≤ threshold (default 5 min) → `throttle`: stay on
+ *     the account, record `throttled_until` broker-side, notify once.
+ *   - reset parseable and > threshold → `failover`: escalate to the existing
+ *     mark-exhausted + fleet-failover machinery with the parsed reset as the
+ *     mark expiry.
+ *   - reset unparseable → `throttle` with a conservative now+60s wait.
+ *
+ * Wall wording ("You've hit your limit", out_of_credits) never reaches this
+ * module — session-tail classifies those `quota-exhausted` and the gateway's
+ * existing failover path handles them unchanged.
+ *
+ * PURE — no IPC, no bot, no clock except the injected `now`.
+ */
+
+import { escapeMarkdown } from './card-format.js'
+import { formatResetRelative } from './quota-check.js'
+import { isTransientUpstreamSignal, parseResetTime } from './model-unavailable.js'
+
+/**
+ * Default retry-in-place ceiling: a transient 429 whose reset is within this
+ * window waits on the account instead of failing the fleet over. Override
+ * with SWITCHROOM_THROTTLE_RETRY_IN_PLACE_MAX_MS.
+ */
+export const THROTTLE_RETRY_IN_PLACE_MAX_MS_DEFAULT = 5 * 60_000
+
+/**
+ * Wait applied when a transient 429 carries NO parseable reset. Anthropic's
+ * burst throttles clear in seconds; 60s is comfortably past the common case
+ * without benching the account for long on a misread.
+ */
+export const THROTTLE_DEFAULT_WAIT_MS = 60_000
+
+/** Resolve the retry-in-place threshold from env (ms), else the default. */
+export function throttleRetryInPlaceMaxMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.SWITCHROOM_THROTTLE_RETRY_IN_PLACE_MAX_MS
+  if (raw == null || raw === '') return THROTTLE_RETRY_IN_PLACE_MAX_MS_DEFAULT
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : THROTTLE_RETRY_IN_PLACE_MAX_MS_DEFAULT
+}
+
+export type ThrottleTierDecision =
+  /** Not a transient per-account 429 — caller falls through to its
+   *  existing handling (calm card / quota path). */
+  | { action: 'none' }
+  /** Stay on the account; record throttled_until broker-side; notify once. */
+  | { action: 'throttle'; throttledUntilMs: number; resetParsed: boolean }
+  /** Reset is beyond the retry-in-place threshold — escalate to the
+   *  existing mark-exhausted + fleet-failover machinery. */
+  | { action: 'failover'; resetAtMs: number }
+
+/**
+ * THE throttle-tier decision for a terminal `rate-limited` operator event.
+ * `detail` is the user-facing error text from the transcript (the source of
+ * both the transient-negation wording and the "resets …" prose).
+ */
+export function decideThrottleTier(opts: {
+  detail: string
+  now: number
+  /** Retry-in-place ceiling (ms). Callers pass throttleRetryInPlaceMaxMs(). */
+  thresholdMs: number
+}): ThrottleTierDecision {
+  const { detail, now, thresholdMs } = opts
+  if (!isTransientUpstreamSignal(detail)) return { action: 'none' }
+  const resetAt = parseResetTime(detail, new Date(now))
+  const resetAtMs = resetAt?.getTime()
+  if (resetAtMs == null || !Number.isFinite(resetAtMs) || resetAtMs <= now) {
+    // No usable reset — wait the conservative default in place.
+    return {
+      action: 'throttle',
+      throttledUntilMs: now + THROTTLE_DEFAULT_WAIT_MS,
+      resetParsed: false,
+    }
+  }
+  if (resetAtMs - now <= thresholdMs) {
+    return { action: 'throttle', throttledUntilMs: resetAtMs, resetParsed: true }
+  }
+  return { action: 'failover', resetAtMs }
+}
+
+// ─── Per-account notice cooldown ─────────────────────────────────────────────
+
+/**
+ * Cooldown for the lightweight throttle notice, PER ACCOUNT. A burst of
+ * transient 429s (session-tail forwards every terminal error line) must
+ * produce ONE notice, not a stream — same shape and rationale as the
+ * failure-notice / all-blocked cooldowns in auto-fallback-fleet.ts. Keyed by
+ * account (not agent): the throttle is account-scoped, so every agent riding
+ * the same throttled account shares one window.
+ */
+export const THROTTLE_NOTICE_COOLDOWN_MS = 10 * 60_000
+
+export interface ThrottleNoticeState {
+  /** account label → unix ms of the last notice sent for it. */
+  lastSentAtMsByAccount: Record<string, number>
+}
+
+export function evaluateThrottleNotice(
+  prev: ThrottleNoticeState,
+  account: string,
+  now: number,
+  cooldownMs: number = THROTTLE_NOTICE_COOLDOWN_MS,
+): { send: boolean; next: ThrottleNoticeState } {
+  const last = prev.lastSentAtMsByAccount[account] ?? 0
+  if (now - last >= cooldownMs) {
+    return {
+      send: true,
+      next: {
+        lastSentAtMsByAccount: {
+          ...prev.lastSentAtMsByAccount,
+          [account]: now,
+        },
+      },
+    }
+  }
+  return { send: false, next: prev }
+}
+
+// ─── Notice rendering ────────────────────────────────────────────────────────
+
+/**
+ * The ONE lightweight operator notice for the throttle path. Deliberately not
+ * the ⚠️ model-unavailable card: nothing is exhausted and nothing failed
+ * over — the point is to say so, name the account, and name the reset.
+ */
+export function renderThrottleNotice(opts: {
+  /** Account label from the broker's mark-throttled response; null when the
+   *  broker was unreachable and the account could not be attributed. */
+  account: string | null
+  agent: string
+  throttledUntilMs: number
+  /** True when the reset came from parsed "resets …" prose (vs the 60s default). */
+  resetParsed: boolean
+  now?: Date
+}): string {
+  const now = opts.now ?? new Date()
+  // "resets in 3m" — same countdown dialect /usage speaks.
+  const resetStr = formatResetRelative(new Date(opts.throttledUntilMs), now)
+  const acct = opts.account ? `\`${escapeMarkdown(opts.account)}\`` : 'the active account'
+  const lines = [
+    `🚦 **Rate-limited, staying put** — ${acct} hit a transient rate limit on **${escapeMarkdown(opts.agent)}**.`,
+    `This is a short throttle, not a quota wall — ${
+      opts.resetParsed ? resetStr : `no reset given, retrying in ~60s`
+    }.`,
+    `_Staying on ${acct}; no failover needed. The turn retries automatically after the reset._`,
+  ]
+  return lines.join('\n')
+}

--- a/telegram-plugin/throttle-tier.ts
+++ b/telegram-plugin/throttle-tier.ts
@@ -33,7 +33,37 @@
 
 import { escapeMarkdown } from './card-format.js'
 import { formatResetRelative } from './quota-check.js'
-import { isTransientUpstreamSignal, parseResetTime } from './model-unavailable.js'
+import { parseResetTime } from './model-unavailable.js'
+
+// ─── Account-scoped throttle wording ─────────────────────────────────────────
+
+/**
+ * ACCOUNT-AFFIRMING subset of `transientUpstreamSignals` (model-unavailable.ts).
+ * The throttle tier takes ACCOUNT-level actions — broker `mark-throttled`,
+ * per-account notice, retry nudge — so it must key on wording that affirms the
+ * account's OWN rate limit ("would exceed your account's rate limit",
+ * "not your account…"), NOT the server-side phrasings ("Server is temporarily
+ * limiting requests (not your usage limit)", 529 overload wording). A
+ * server-wide condition recorded as an account throttle would bench the wrong
+ * thing and restart-nudge an agent straight back into the same server-side
+ * wall. Server-side transients keep the existing calm rate-limited path
+ * (Claude Code's internal retry) untouched.
+ */
+export const accountScopedThrottleSignals = [
+  "would exceed your account's rate limit",
+  'would exceed your account’s rate limit',
+  // Covers both "not your account" and "not your account's" (substring).
+  'not your account',
+]
+
+/** True when `text` carries an EXPLICIT account-affirming throttle marker.
+ *  Never throws on weird input. */
+export function isAccountScopedThrottle(text: string): boolean {
+  if (typeof text !== 'string' || text.length === 0) return false
+  const sample = text.length > 16_384 ? text.slice(0, 16_384) : text
+  const lower = sample.toLowerCase()
+  return accountScopedThrottleSignals.some((s) => lower.includes(s))
+}
 
 /**
  * Default retry-in-place ceiling: a transient 429 whose reset is within this
@@ -81,7 +111,10 @@ export function decideThrottleTier(opts: {
   thresholdMs: number
 }): ThrottleTierDecision {
   const { detail, now, thresholdMs } = opts
-  if (!isTransientUpstreamSignal(detail)) return { action: 'none' }
+  // Account-affirming wording ONLY — the wider transient list includes
+  // server-side phrasings (529 / "server is temporarily limiting requests")
+  // for which an account-scoped throttle would be the wrong action.
+  if (!isAccountScopedThrottle(detail)) return { action: 'none' }
   const resetAt = parseResetTime(detail, new Date(now))
   const resetAtMs = resetAt?.getTime()
   if (resetAtMs == null || !Number.isFinite(resetAtMs) || resetAtMs <= now) {
@@ -165,4 +198,29 @@ export function renderThrottleNotice(opts: {
     `_Staying on ${acct}; no failover needed. The turn retries automatically after the reset._`,
   ]
   return lines.join('\n')
+}
+
+/**
+ * Notice for the broker's ESCALATION outcome: repeated transient 429s on one
+ * account were corroborated by a live probe as a genuine wall, so the broker
+ * ran the standard mark-exhausted + roll. The gateway that raised the
+ * mark-throttled announces it (the reactive-path doctrine — same reason the
+ * plain mark-exhausted path announces gateway-side rather than via
+ * `last_fleet_roll`), which also covers PINNED (non-fleet-active) accounts.
+ */
+export function renderThrottleEscalationNotice(opts: {
+  account: string | null
+  agent: string
+  /** The account the fleet/agents rolled to; null = every fallback blocked. */
+  rolledTo: string | null
+}): string {
+  const acct = opts.account ? `\`${escapeMarkdown(opts.account)}\`` : 'the active account'
+  const head =
+    `⛔️ **Rate limit was actually a wall** — repeated 429s on ${acct} ` +
+    `(trigger: **${escapeMarkdown(opts.agent)}**) were corroborated by a live quota probe.`
+  const tail = opts.rolledTo
+    ? `Marked exhausted and rolled to \`${escapeMarkdown(opts.rolledTo)}\`.`
+    : `Marked exhausted — no fallback account had quota (all blocked). ` +
+      `Use \`/auth add <label>\` to attach another subscription.`
+  return `${head}\n${tail}`
 }


### PR DESCRIPTION
## Summary

Implements the **429 throttle tier** (operator-approved spec: *"retry in place under 5 min, else mark + failover, honest reset messaging"*). A terminal transient per-account 429 — the `rate_limit_error` whose wording explicitly negates the quota reading (`transientUpstreamSignals`, #3155) — previously took the fully calm path: no broker state, no account attribution, a generic 🚦 card. Cron fires walked straight into the same 429 and the operator couldn't tell a 3-minute throttle from a quota wall.

## Behavior matrix

| Signal | Decision | Mechanics |
|---|---|---|
| Transient negation wording, parsed reset **≤ threshold** (default 5 min, `SWITCHROOM_THROTTLE_RETRY_IN_PLACE_MAX_MS`) | **Throttle — stay put, NO failover** | Broker `mark-throttled` records `throttled_until` in the quota ledger (no roll, no eligibility change); ONE lightweight notice (per-account 10-min cooldown) names the account, that it's *rate-limited, not quota-exhausted*, and the reset ("resets in 3m"); retry nudged after the reset |
| Transient wording, parsed reset **> threshold** | **Escalate to standard failover** | Existing mark-exhausted + fleet-roll machinery, parsed reset as the mark expiry, honest card reason `account rate-limited (resets …)` (new `rate_limited` detection kind) |
| Transient wording, **no parseable reset** | Throttle for **now+60s** | Same throttle path, notice says "no reset given, retrying in ~60s" |
| Wall wording ("You've hit your limit", `out_of_credits`) / any non-transient 429 | **Unchanged** | Existing quota-exhausted classification → mark-exhausted + fleet failover |
| 3+ transient 429s on one account within 10 min | **Escalation guard** | Broker runs ONE live quota probe; only a probe that corroborates a wall (same overage-aware test as every other trigger) converts into mark-exhausted + roll (audit reason `throttle-escalation`, announced via the existing `last_fleet_roll` channel) |

## What changed

- **`telegram-plugin/throttle-tier.ts`** (new, pure): decision matrix, env threshold resolution, per-account notice cooldown, notice rendering.
- **Gateway** (`emitGatewayOperatorEvent`): throttle branch runs BEFORE the per-kind cooldown gate so every hit reaches the broker's escalation counter; side-effect wiring in `fireThrottleTier` (broker write → notice → `scheduleThrottleRetryNudge`).
- **Broker**: new non-admin `mark-throttled` verb (account from path-identity, `until` clamped to 30 min). `QuotaEntry` gains `throttled_until` + `throttle_hits` beside the exhaustion mark; `exhaustionMarkOf()` guarantees a throttle-only entry can never gate serving/failover eligibility. `list-state` exposes `throttled_until`.
- **Cron quota-preflight**: soft-defers while the agent's **effective** account (override ?? active) is throttled; new `retryAtMs` aims the scheduler retry just past `throttled_until` (bounded 5s–10m) instead of the blind backoff ladder.
- **Enriched failover messaging** (spec item 3): `parsedResetAt` (prose-parsed reset) threads gateway → `runFleetAutoFallback` → `renderFallbackAnnouncement`, so the recovery line ("`old` recovers … (in 4h 57m)") survives a failed live probe. The announcement (which edits/folds into the model-unavailable card per #3031 PR 3) already names old account, new account, and trigger agent.

## Retry-in-place mechanics (spec item 6 — investigation result)

The gateway already has a clean re-engage lever: `triggerSelfRestart` + boot-resume replays the LATEST interrupted turn (the auth-failover-stall fix, `fleet-fallback-resume.ts`). The throttle path reuses it verbatim: a timer armed at `throttled_until + 5s` consults the **shared** `fleetFallbackResumeGate` (single-flight across throttle AND fallback resumes, 3h staleness) and restarts only on a `resume` verdict; the boot-resume path replays only genuinely interrupted turns, so a spurious nudge replays nothing. No new session-injection mechanism was invented. Broker ledger + preflight soft-defer cover scheduled work.

## Contradictions found vs. the investigation premise

- *"rate-limited → calm path: no card"* — not quite: a **terminal** transient 429 DOES post the generic "🚦 Rate limited" card today via `renderOperatorEvent` (session-tail suppresses only non-terminal in-flight retries). This PR replaces that generic card with the account-attributed throttle notice on the transient path.
- Cited line anchors had drifted slightly (e.g. `transientUpstreamSignals` at `model-unavailable.ts:58-67`, `markExhaustedAndRoll` at `server.ts:2191+`); mechanisms matched.

## Test plan

- `telegram-plugin/tests/throttle-tier.test.ts` — full decision matrix (transient ≤/>/unparseable/past reset, wall wording, threshold boundary), env resolution, notice cooldown (per-account), notice text, `rate_limited` card wording, exported `parseResetTime`.
- `src/auth/broker/server-mark-throttled.test.ts` — ledger round-trip (recorded + persisted, response shape), NO roll / NO promote / NO eligibility change, 30-min clamp, mark-exhausted preserves throttle fields, escalation corroborated (mark + roll + promote + audit reason + `last_fleet_roll`), escalation NOT corroborated (stays throttled, counter re-arms), window pruning.
- `src/scheduler/quota-preflight.test.ts` — throttled active defers with `retryAtMs`, per-agent override account, expired throttle, non-effective account, all-exhausted precedence.
- `src/agent-scheduler/index.test.ts` — retry aimed at `retryAtMs` (+2s slack) end-to-end through `registerAgentSchedule`; `resolveQuotaDeferDelayMs` bounds.
- `telegram-plugin/tests/auto-fallback-fleet.test.ts` — `parsedResetAt` recovery-line fallback.
- `src/auth/broker/protocol.test.ts` — `mark-throttled` round-trip; `until` required.
- Locally: `npm run lint` fully green; scoped vitest 339 tests green plus the full `src/auth/broker/` + adjacent fallback/session-tail suites (657 tests) green.

## Risk

- Additive protocol verb + optional wire fields — old brokers reject `mark-throttled` at the protocol layer (gateway logs and degrades to notice-only); old gateways never send it.
- `QuotaEntry.exhausted_until` became optional; every eligibility consumer routes through `exhaustionMarkOf()` which filters throttle-only entries, and all external readers were already null-guarded (verified by grep + tsc).
- The retry nudge reuses the existing single-flight resume gate, so a 429 storm cannot loop-restart; broker-side persisted exhaustion bounds cross-restart loops exactly as before.

## Job spec

`reference/jobs/share-auth-across-the-fleet.md` — *"Refresh, quota state, and fallback all live at the account level"*: the throttle becomes account-level broker state instead of a per-agent blind spot. Also serves `reference/jobs/survive-reboots-and-real-life.md` (*"Work resumes. The user is told when something went wrong, never left in silence"*) — the throttle notice + automatic post-reset retry are exactly that contract for the transient-429 failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
