### PR TITLE
feat(telegram): rich render on-by-default escape hatch (=0 to disable)

### DIFF
--- a/reference/rfcs/telegram-native-formatting.md
+++ b/reference/rfcs/telegram-native-formatting.md
@@ -250,6 +250,15 @@ Telegram entity on the live wire.
 - **No streaming assumptions.** Rollout changes only which agents render rich;
   the whole-reply/chunked send model (§2) is unchanged.
 
+**Rollout completed (2026-07-12).** After the §6a live-wire verification, the
+canary/staggered rollout above ran its course and `SWITCHROOM_RICH_RENDER`
+flipped to **ON by default** — an escape hatch, not an opt-in feature,
+following the repo's default-on kill-switch convention (same shape as the
+send gate's `SWITCHROOM_TELEGRAM_SEND_GATE`, #3153). `SWITCHROOM_RICH_RENDER=0`
+(or `false`/`off`/`no`) per agent disables it without a rebuild. The
+degrade-to-plain safety path (`renderSafe`) is unchanged and remains the
+failure fallback.
+
 ---
 
 ## 8. Out of scope

--- a/telegram-plugin/render/rich-render.ts
+++ b/telegram-plugin/render/rich-render.ts
@@ -1,21 +1,24 @@
-// Flag-gated wiring for the Bot API 10.1 rich renderer (parse.ts + render.ts)
-// into the live outbound send path.
+// Wiring for the Bot API 10.1 rich renderer (parse.ts + render.ts) into the
+// live outbound send path.
 //
 // The renderer (`render/render.ts`, PR #2930) and parser (`render/parse.ts`)
 // have full unit coverage but were, until this module, wired into NOTHING —
-// no outbound message ever flowed through them. This module is the single,
-// feature-flagged bridge: the gateway's rich send path (stream-controller.ts)
-// runs the assistant's raw markdown through `parse → renderSafe` before it
-// reaches `sendRichMessage`, but ONLY when the flag is on.
+// no outbound message ever flowed through them. This module is the single
+// bridge: the gateway's rich send path (stream-controller.ts) runs the
+// assistant's raw markdown through `parse → renderSafe` before it reaches
+// `sendRichMessage`, unless the escape hatch below disables it.
 //
-// Feature flag — `SWITCHROOM_RICH_RENDER`, default OFF:
-//   Mirrors the `SWITCHROOM_VISIBLE_ANSWER_STREAM` convention
-//   (`answer-stream-flag.ts`): an env var read at runtime, default off, opted
-//   in PER AGENT via the `env:` block in `switchroom.yaml` (propagated into
-//   the container `environment:` by `src/agents/compose.ts`). When off,
-//   `maybeRenderOutbound` returns the input untouched, so the live send path
-//   is byte-for-byte unchanged — no agent's behaviour moves until an operator
-//   explicitly flips the flag for a specific agent. Accepts `1/true/on/yes`.
+// Escape hatch — `SWITCHROOM_RICH_RENDER`, default ON:
+//   ON BY DEFAULT in every install — an escape hatch, not an opt-in feature,
+//   mirroring the send gate's convention (`sendGateEnabledFromEnv` in
+//   `send-gate.ts`, default-on since #3153; also `midTurnFloorEnabled`,
+//   `SWITCHROOM_RATE_LIMIT_OVERAGE=0`). Enabled unless the var is explicitly
+//   set to a falsey/off value (`0`/`false`/`off`/`no`, case-insensitive,
+//   trimmed) — per agent via the `env:` block in `switchroom.yaml`
+//   (propagated into the container `environment:` by
+//   `src/agents/compose.ts`). When disabled, `maybeRenderOutbound` returns
+//   the input untouched, so the live send path is byte-for-byte the
+//   pre-renderer behaviour (raw transcript markdown to `sendRichMessage`).
 //
 // Why route through `renderSafe` and not bare `render`:
 //   `renderSafe` guarantees the returned body is never a rich-markdown string
@@ -38,17 +41,19 @@ import { RICH_MESSAGE_MAX_CHARS, splitMarkdownChunks } from "../format.js";
  */
 export const PLAIN_TEXT_MAX_CHARS = 4096;
 
-/** Parse the `SWITCHROOM_RICH_RENDER` flag value. Default OFF; accepts the
- *  same truthy tokens as the other switchroom env flags. Pure so the default
- *  + parsing are unit-testable. */
+/** Parse the `SWITCHROOM_RICH_RENDER` kill-switch value. Default ON; disabled
+ *  only by an explicit falsey/off token (`0`/`false`/`off`/`no`,
+ *  case-insensitive, trimmed) — the same disable vocabulary as
+ *  `sendGateEnabledFromEnv`. Unset, empty, or unrecognised values → ON. Pure
+ *  so the default + parsing are unit-testable. */
 export function parseRichRenderEnabled(raw: string | undefined): boolean {
-  if (raw == null) return false;
+  if (raw == null) return true;
   const v = raw.trim().toLowerCase();
-  return v === "1" || v === "true" || v === "on" || v === "yes";
+  return !(v === "0" || v === "false" || v === "off" || v === "no");
 }
 
 /** Is the rich renderer enabled in this process? Reads the env flag live so a
- *  test can set/unset it per-case; defaults OFF. */
+ *  test can set/unset it per-case; defaults ON (escape hatch, not opt-in). */
 export function richRenderEnabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -65,13 +70,14 @@ export function renderOutbound(
 }
 
 /**
- * Flag-gated transform for the live send path.
+ * Kill-switch-gated transform for the live send path.
  *
- *   - flag OFF (default): returns the input untouched, `mode: "markdown"` —
- *     identical to the pre-existing behaviour (raw transcript markdown sent
- *     straight to `sendRichMessage`). No behavioural change for any agent.
- *   - flag ON: returns `parse → renderSafe` output. `mode: "plain"` signals
- *     the caller to send WITHOUT the rich wrapper (oversized/unsafe content).
+ *   - enabled (default): returns `parse → renderSafe` output. `mode: "plain"`
+ *     signals the caller to send WITHOUT the rich wrapper (oversized/unsafe
+ *     content).
+ *   - disabled (`SWITCHROOM_RICH_RENDER=0`): returns the input untouched,
+ *     `mode: "markdown"` — identical to the pre-renderer behaviour (raw
+ *     transcript markdown sent straight to `sendRichMessage`).
  */
 export function maybeRenderOutbound(
   text: string,
@@ -83,7 +89,7 @@ export function maybeRenderOutbound(
 }
 
 /**
- * Flag-gated, CAP-ENFORCING transform for the live send path.
+ * Kill-switch-gated, CAP-ENFORCING transform for the live send path.
  *
  * `maybeRenderOutbound` returns ONE `RenderResult` and can only ever fit a
  * body into a single wire message. But `renderSafe`'s markdown re-escaping
@@ -104,11 +110,13 @@ export function maybeRenderOutbound(
  * plain degradation would have thrown away: the smaller pieces individually
  * escape under `maxLen` and come back as `markdown`.
  *
- *   - flag OFF (default): `[{ text, mode: "markdown", degradations: [] }]` —
- *     a single passthrough piece, identical to `maybeRenderOutbound`.
- *   - flag ON, body fits: `[renderSafe(...)]` — a single piece, identical to
- *     `maybeRenderOutbound` (byte-for-byte for the common case).
- *   - flag ON, body oversize: 2+ cap-respecting pieces in send order.
+ *   - disabled (`SWITCHROOM_RICH_RENDER=0`):
+ *     `[{ text, mode: "markdown", degradations: [] }]` — a single passthrough
+ *     piece, identical to `maybeRenderOutbound`.
+ *   - enabled (default), body fits: `[renderSafe(...)]` — a single piece,
+ *     identical to `maybeRenderOutbound` (byte-for-byte for the common case).
+ *   - enabled (default), body oversize: 2+ cap-respecting pieces in send
+ *     order.
  */
 export function renderOutboundChunks(
   text: string,

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -228,8 +228,9 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
   // `maybeRenderOutbound` path; a body whose markdown-escaping pushed the
   // rendered form past the cap splits into several pieces, each of which fits
   // its own wire cap and never bisects a fenced block / table row (see
-  // `renderOutboundChunks`). Flag OFF (default) and a literal `format:'text'`
-  // stream both yield a single passthrough piece — no behavioural change.
+  // `renderOutboundChunks`). Rendering disabled (SWITCHROOM_RICH_RENDER=0)
+  // and a literal `format:'text'` stream both yield a single passthrough
+  // piece — byte-for-byte the pre-renderer send path.
   const renderPieces = (text: string): { text: string; rich: boolean }[] => {
     if (literalText) return [{ text, rich: false }]
     // A `plain`-mode piece (oversized/unsafe content renderSafe declined to

--- a/telegram-plugin/tests/render/render-outbound-chunks.test.ts
+++ b/telegram-plugin/tests/render/render-outbound-chunks.test.ts
@@ -17,8 +17,10 @@ import { describe, it, expect } from "vitest";
 import { renderOutboundChunks, PLAIN_TEXT_MAX_CHARS } from "../../render/rich-render.js";
 import { RICH_MESSAGE_MAX_CHARS } from "../../format.js";
 
-const ON = { SWITCHROOM_RICH_RENDER: "1" } as NodeJS.ProcessEnv;
-const OFF = {} as NodeJS.ProcessEnv;
+// Rendering is ON BY DEFAULT (escape hatch, not opt-in — mirrors the send
+// gate): an empty env exercises the real default; "0" is the kill-switch.
+const ON = {} as NodeJS.ProcessEnv;
+const OFF = { SWITCHROOM_RICH_RENDER: "0" } as NodeJS.ProcessEnv;
 
 /** Count fenced-code delimiter lines (```) in a body. A piece that bisects a
  *  fenced block has an ODD count. */
@@ -27,7 +29,7 @@ function fenceCount(s: string): number {
 }
 
 describe("renderOutboundChunks", () => {
-  it("flag OFF is a single passthrough piece (byte-for-byte)", () => {
+  it("disabled (=0) is a single passthrough piece (byte-for-byte)", () => {
     const raw = "**bold** and _italic_ | a | table |";
     const pieces = renderOutboundChunks(raw, OFF);
     expect(pieces).toHaveLength(1);
@@ -35,7 +37,7 @@ describe("renderOutboundChunks", () => {
     expect(pieces[0].mode).toBe("markdown");
   });
 
-  it("flag ON, body that fits is a single piece (common case)", () => {
+  it("default (env unset), body that fits is a single piece (common case)", () => {
     const pieces = renderOutboundChunks("just some plain prose", ON);
     expect(pieces).toHaveLength(1);
     expect(pieces[0].text.length).toBeLessThanOrEqual(RICH_MESSAGE_MAX_CHARS);

--- a/telegram-plugin/tests/render/rich-render.test.ts
+++ b/telegram-plugin/tests/render/rich-render.test.ts
@@ -7,24 +7,32 @@ import {
 } from "../../render/rich-render.js";
 
 describe("parseRichRenderEnabled", () => {
-  it("defaults OFF when unset", () => {
-    expect(parseRichRenderEnabled(undefined)).toBe(false);
+  it("defaults ON when unset (escape hatch, not opt-in)", () => {
+    expect(parseRichRenderEnabled(undefined)).toBe(true);
   });
-  it("accepts the truthy tokens", () => {
+  it("disabled only by the explicit off tokens (case-insensitive, trimmed)", () => {
+    for (const v of ["0", "false", "off", "no", "FALSE", " Off ", "NO"]) {
+      expect(parseRichRenderEnabled(v)).toBe(false);
+    }
+  });
+  it("truthy tokens stay ON", () => {
     for (const v of ["1", "true", "on", "yes", "TRUE", " On "]) {
       expect(parseRichRenderEnabled(v)).toBe(true);
     }
   });
-  it("treats everything else as OFF", () => {
-    for (const v of ["0", "false", "off", "no", "", "maybe"]) {
-      expect(parseRichRenderEnabled(v)).toBe(false);
+  it("empty / unrecognised values stay ON (fail-open to the default)", () => {
+    for (const v of ["", "  ", "maybe", "2", "disable"]) {
+      expect(parseRichRenderEnabled(v)).toBe(true);
     }
   });
 });
 
 describe("richRenderEnabled", () => {
-  it("reads SWITCHROOM_RICH_RENDER, default OFF", () => {
-    expect(richRenderEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+  it("reads SWITCHROOM_RICH_RENDER, default ON", () => {
+    expect(richRenderEnabled({} as NodeJS.ProcessEnv)).toBe(true);
+    expect(
+      richRenderEnabled({ SWITCHROOM_RICH_RENDER: "0" } as NodeJS.ProcessEnv),
+    ).toBe(false);
     expect(
       richRenderEnabled({ SWITCHROOM_RICH_RENDER: "1" } as NodeJS.ProcessEnv),
     ).toBe(true);
@@ -32,40 +40,51 @@ describe("richRenderEnabled", () => {
 });
 
 describe("maybeRenderOutbound", () => {
-  it("flag OFF is a byte-for-byte passthrough (no behavioural change)", () => {
+  it("disabled (=0) is a byte-for-byte passthrough (the escape hatch)", () => {
     const raw = "**bold** and a\n\n**> collapsible quote\n> second line";
-    const r = maybeRenderOutbound(raw, {} as NodeJS.ProcessEnv);
+    const r = maybeRenderOutbound(raw, {
+      SWITCHROOM_RICH_RENDER: "0",
+    } as NodeJS.ProcessEnv);
     expect(r.mode).toBe("markdown");
     expect(r.text).toBe(raw);
   });
 
-  it("flag ON routes through parse -> renderSafe", () => {
-    const r = maybeRenderOutbound("**> collapsible", {
-      SWITCHROOM_RICH_RENDER: "1",
-    } as NodeJS.ProcessEnv);
+  it("default (env unset) routes through parse -> renderSafe", () => {
+    const r = maybeRenderOutbound("**> collapsible", {} as NodeJS.ProcessEnv);
     expect(r.mode).toBe("markdown");
     // The expandable blockquote round-trips back to the `**> ` marker.
     expect(r.text).toContain("**> ");
   });
 
-  it("flag ON preserves plain prose through the round-trip", () => {
-    const r = maybeRenderOutbound("just some plain text", {
-      SWITCHROOM_RICH_RENDER: "1",
-    } as NodeJS.ProcessEnv);
+  it("default preserves plain prose through the round-trip", () => {
+    const r = maybeRenderOutbound(
+      "just some plain text",
+      {} as NodeJS.ProcessEnv,
+    );
     expect(r.text).toContain("just some plain text");
   });
 
-  it("flag ON round-trips underline / spoiler / highlight", () => {
-    const on = { SWITCHROOM_RICH_RENDER: "1" } as NodeJS.ProcessEnv;
+  it("default round-trips underline / spoiler / highlight", () => {
+    const on = {} as NodeJS.ProcessEnv;
     expect(maybeRenderOutbound("__u__", on).text).toBe("__u__");
     expect(maybeRenderOutbound("a ||s|| b", on).text).toBe("a ||s|| b");
     expect(maybeRenderOutbound("a ==m== b", on).text).toBe("a ==m== b");
   });
 
-  it("flag OFF passes new constructs through untouched too", () => {
+  it("disabled (=0) passes new constructs through untouched too", () => {
     const raw = "__u__ and ||s|| and ==m==";
-    const r = maybeRenderOutbound(raw, {} as NodeJS.ProcessEnv);
+    const r = maybeRenderOutbound(raw, {
+      SWITCHROOM_RICH_RENDER: "0",
+    } as NodeJS.ProcessEnv);
     expect(r.text).toBe(raw);
+  });
+
+  it("a junk env value still renders (fail-open to the default)", () => {
+    const r = maybeRenderOutbound("**> collapsible", {
+      SWITCHROOM_RICH_RENDER: "maybe",
+    } as NodeJS.ProcessEnv);
+    expect(r.mode).toBe("markdown");
+    expect(r.text).toContain("**> ");
   });
 });
 

--- a/telegram-plugin/tests/single-mode-stream-reply.test.ts
+++ b/telegram-plugin/tests/single-mode-stream-reply.test.ts
@@ -69,7 +69,7 @@ describe('stream-reply single-mode reuse (#2669)', () => {
     expect(bot.api.editMessageText).toHaveBeenCalled()
   })
 
-  it('the rich path ships raw GFM markdown unescaped via sendRichMessage', async () => {
+  it('the rich path ships GFM markdown unescaped via sendRichMessage', async () => {
     const state = makeState()
     const deps = makeDeps(bot)
 
@@ -77,8 +77,10 @@ describe('stream-reply single-mode reuse (#2669)', () => {
 
     expect(bot.state.sent).toHaveLength(1)
     expect(bot.state.sent[0].rich).toBe(true)
-    // Raw markdown is the wire payload — no HTML, no MarkdownV2 escaping.
-    expect(bot.state.sent[0].text).toBe('**bold** and _italic_')
+    // GFM markdown is the wire payload — no HTML, no MarkdownV2 escaping.
+    // The default-on rich renderer normalises the italic marker
+    // (`_italic_` -> `*italic*`, same wire entity).
+    expect(bot.state.sent[0].text).toBe('**bold** and *italic*')
     expect(bot.state.sent[0].parse_mode).toBeUndefined()
   })
 

--- a/telegram-plugin/tests/status-accent.test.ts
+++ b/telegram-plugin/tests/status-accent.test.ts
@@ -91,8 +91,10 @@ describe('handleStreamReply accent integration', () => {
     await pending
 
     const sent = sentMarkdown(bot)
-    expect(sent).toMatch(/^🔵 _In progress…_\n\n/)
-    expect(sent).toBe('🔵 _In progress…_\n\nStill working...')
+    // The default-on rich renderer normalises the italic marker
+    // (`_In progress…_` -> `*In progress…*`, same wire entity).
+    expect(sent).toMatch(/^🔵 \*In progress…\*\n\n/)
+    expect(sent).toBe('🔵 *In progress…*\n\nStill working...')
   })
 
   it("accent='done' prepends the checkmark markdown header before the body", async () => {
@@ -176,6 +178,6 @@ describe('handleStreamReply accent integration', () => {
     await microtaskFlush()
     await p2
 
-    expect(editedMarkdown(bot)).toBe('🔵 _In progress…_\n\nPart one Part two')
+    expect(editedMarkdown(bot)).toBe('🔵 *In progress…*\n\nPart one Part two')
   })
 })

--- a/telegram-plugin/tests/stream-controller-chunk-cap.test.ts
+++ b/telegram-plugin/tests/stream-controller-chunk-cap.test.ts
@@ -2,7 +2,8 @@
  * Wire-level regression test for the chunk-boundary cap bug
  * (fix/rich-render-chunk-boundary-cap).
  *
- * With `SWITCHROOM_RICH_RENDER` on, a near-cap body full of escapable chars
+ * With the rich renderer enabled (the default — escape hatch, not opt-in), a
+ * near-cap body full of escapable chars
  * (`_ * |`) makes `renderSafe` degrade the whole document to plain (its escaped
  * rich form exceeds RICH_MESSAGE_MAX_CHARS). BEFORE the fix, the stream
  * controller shipped that ~32k plain body through the plain `sendMessage`
@@ -13,7 +14,7 @@
  * emitted send fits its own wire cap: rich pieces <= 32768, plain pieces
  * <= 4096, and no fenced block is bisected.
  */
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { createStreamController } from "../stream-controller.js";
 import { createFakeBotApi } from "./fake-bot-api.js";
 import { RICH_MESSAGE_MAX_CHARS } from "../format.js";
@@ -25,12 +26,7 @@ function fenceCount(s: string): number {
 }
 
 describe("stream-controller enforces the wire cap on the post-escape body", () => {
-  afterEach(() => {
-    delete process.env.SWITCHROOM_RICH_RENDER;
-  });
-
   it("REGRESSION: near-cap escapable first send never exceeds the plain wire cap", async () => {
-    process.env.SWITCHROOM_RICH_RENDER = "1";
     const bot = createFakeBotApi({ startMessageId: 1000 });
     const unit = "a_b*c|d ";
     const body = unit.repeat(Math.floor((RICH_MESSAGE_MAX_CHARS - 20) / unit.length));
@@ -62,7 +58,6 @@ describe("stream-controller enforces the wire cap on the post-escape body", () =
     // callback. The pre-fix code re-sent all (N-1) tails as brand-new messages
     // on each edit tick, so `sent.length` grew by (N-1) every update. After the
     // fix, tails are parked once and edited in place — `sent.length` is flat.
-    process.env.SWITCHROOM_RICH_RENDER = "1";
     const bot = createFakeBotApi({ startMessageId: 3000 });
     const unit = "a_b*c|d ";
     // Near-cap body that degrades to plain and splits into several pieces.
@@ -106,17 +101,22 @@ describe("stream-controller enforces the wire cap on the post-escape body", () =
     }
   }, 30000);
 
-  it("flag OFF leaves the single-send path untouched", async () => {
-    const bot = createFakeBotApi({ startMessageId: 2000 });
-    const stream = createStreamController({
-      bot: bot as unknown as Parameters<typeof createStreamController>[0]["bot"],
-      chatId: "c1",
-      throttleMs: 0,
-    });
-    await stream.update("**hi** _there_");
-    await stream.finalize();
-    expect(bot.state.sent).toHaveLength(1);
-    expect(bot.state.sent[0].rich).toBe(true);
-    expect(bot.state.sent[0].text).toBe("**hi** _there_");
+  it("kill-switch (=0) leaves the single-send path byte-for-byte untouched", async () => {
+    process.env.SWITCHROOM_RICH_RENDER = "0";
+    try {
+      const bot = createFakeBotApi({ startMessageId: 2000 });
+      const stream = createStreamController({
+        bot: bot as unknown as Parameters<typeof createStreamController>[0]["bot"],
+        chatId: "c1",
+        throttleMs: 0,
+      });
+      await stream.update("**hi** _there_");
+      await stream.finalize();
+      expect(bot.state.sent).toHaveLength(1);
+      expect(bot.state.sent[0].rich).toBe(true);
+      expect(bot.state.sent[0].text).toBe("**hi** _there_");
+    } finally {
+      delete process.env.SWITCHROOM_RICH_RENDER;
+    }
   });
 });

--- a/telegram-plugin/tests/stream-reply-handler.test.ts
+++ b/telegram-plugin/tests/stream-reply-handler.test.ts
@@ -81,7 +81,7 @@ describe('handleStreamReply', () => {
     expect(state.activeDraftStreams.size).toBe(1)
   })
 
-  it('a non-text format ships raw GFM markdown unescaped (no parse_mode)', async () => {
+  it('a non-text format ships GFM markdown unescaped (no parse_mode)', async () => {
     const state = makeState()
     const deps = makeDeps(bot)
 
@@ -94,7 +94,10 @@ describe('handleStreamReply', () => {
     await pending
 
     expect(bot.api.sendRichMessage).toHaveBeenCalledTimes(1)
-    expect(richSendMarkdown(bot)).toBe('**hi** _there_')
+    // The default-on rich renderer (parse -> renderSafe) normalises the
+    // italic marker (`_there_` -> `*there*`, same wire entity) but the
+    // payload stays unescaped GFM markdown — no HTML, no MarkdownV2 escaping.
+    expect(richSendMarkdown(bot)).toBe('**hi** *there*')
     // No parse_mode on rich opts.
     expect(bot.api.sendRichMessage.mock.calls[0][2]?.parse_mode).toBeUndefined()
   })

--- a/telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts
@@ -61,13 +61,14 @@ import { richRenderEnabled } from "../../render/rich-render.js";
 const AGENT = "test-harness";
 
 // The rich-render wiring (parse -> IR -> renderSafe -> sendRichMessage) is
-// gated behind `SWITCHROOM_RICH_RENDER` (default OFF). The expandable /
-// collapsible round-trip proof below only runs when BOTH the driver creds AND
-// the flag are present — the flag must be set in the gateway process under
-// test for the renderer to actually shape the outbound message, so gating the
-// scenario on the same flag keeps it honest (no false green when the wiring
-// isn't live). When the flag is off, this scenario self-skips green exactly
-// like the credential-less case.
+// ON BY DEFAULT, with `SWITCHROOM_RICH_RENDER=0` as the escape hatch. The
+// expandable / collapsible round-trip proof below only runs when the driver
+// creds are present AND the renderer hasn't been killed off — the same
+// setting must hold in the gateway process under test for the renderer to
+// actually shape the outbound message, so gating the scenario on the same
+// check keeps it honest (no false green when the wiring isn't live). When
+// the kill-switch is set, this scenario self-skips green exactly like the
+// credential-less case.
 const RICH_RENDER_ON = richRenderEnabled();
 
 // The driver session is the load-bearing credential. Absent it, spinUp()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,16 +16,16 @@ import { defineConfig } from "vitest/config";
 // host's actual processes read the env independently from their own
 // systemd / shell context.
 //
-// SWITCHROOM_RICH_RENDER (#3014) is the same hazard: agents opt into the
-// Bot API rich renderer per-agent via their `env:` block, so `npm test`
-// run inside such a container inherits `SWITCHROOM_RICH_RENDER=1`. That
-// flips `renderOutboundChunks`' default-OFF passthrough ON, round-trips
-// markdown through mdast (`_italic_` → `*italic*`), and breaks the four
-// stream-reply / status-accent tests that pin the raw flag-OFF body —
-// green in CI (flag unset) but red in a flag-on agent container. Scrub it
-// so the default-OFF path is deterministic; the flag-ON tests
-// (render-outbound-chunks, rich-render, stream-controller-chunk-cap) set
-// it explicitly per-case and delete it in cleanup.
+// SWITCHROOM_RICH_RENDER (#3014) is the same hazard: the Bot API rich
+// renderer is ON BY DEFAULT (escape hatch, not opt-in — mirrors the send
+// gate), and an agent that opted OUT via its `env:` block exports
+// `SWITCHROOM_RICH_RENDER=0` into its container. `npm test` run inside
+// such a container would inherit the kill-switch, flip
+// `renderOutboundChunks` to raw passthrough, and break the tests that
+// pin the rendered (mdast round-tripped) body — green in CI (var unset →
+// default ON) but red in an opted-out agent container. Scrub it so every
+// run exercises the real default; the kill-switch tests
+// (render-outbound-chunks, rich-render) set `=0` explicitly per-case.
 for (const k of [
   "SWITCHROOM_RUNTIME",
   "SWITCHROOM_CONTAINER",


### PR DESCRIPTION
## Summary

Flips `SWITCHROOM_RICH_RENDER` from opt-in (on only when `=1`) to **ON BY DEFAULT** with an explicit kill-switch — an escape hatch, not a feature flag — copying the send gate's precedent exactly (`sendGateEnabledFromEnv`, #3153): enabled unless the var is explicitly set to `0`/`false`/`off`/`no` (case-insensitive, trimmed); unset, empty, or unrecognised values stay ON.

The rollout preconditions are already met on `main`: every construct was live-wire verified against the Bot API (`reference/rfcs/telegram-native-formatting.md` §6a, #2937) and the latent flag-gated defects were fixed pre-flip in #3147.

## What changed

- `telegram-plugin/render/rich-render.ts` — `parseRichRenderEnabled` now defaults ON and accepts the send gate's disable vocabulary; header + docblocks updated from "feature flag, default OFF" to "escape hatch, default ON". `renderSafe` and the whole render pipeline are untouched.
- `telegram-plugin/stream-controller.ts` — comment-only (described the old default).
- Tests (`tests/render/rich-render.test.ts`, `tests/render/render-outbound-chunks.test.ts`, `tests/stream-controller-chunk-cap.test.ts`): default (env unset) → renders; each disable token → byte-for-byte passthrough; junk/empty value → renders (fail-open to the default). Coverage of the disabled path is kept — those cases now set `=0` explicitly.
- Four tests pinned the raw flag-OFF wire body (`stream-reply-handler`, `single-mode-stream-reply`, `status-accent` ×2 — exactly the set predicted by the `vitest.config.ts` scrub comment). Updated honestly to assert the new default's rendered output: the renderer normalises the italic marker (`_i_` → `*i*`, the same `italic` wire entity); the tests' original intent (unescaped GFM payload, no `parse_mode`, no HTML/MarkdownV2 escaping) is still asserted.
- `vitest.config.ts` — the env scrub does NOT set `=1` (it deletes the var), so it stays: post-flip it guarantees the suite exercises the real default even inside a container that opted OUT via `=0`. Comment rewritten to match the new semantics.
- `reference/rfcs/telegram-native-formatting.md` — dated rollout-completed note under §7 (the RFC was the only prose describing the flag as opt-in; `docs/` has no references). No old CHANGELOG entries touched.
- `telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts` — comment-only; the `richRenderEnabled()` self-skip gate keeps working (it now skips only when the kill-switch is set in the gateway under test).

## Notes for operators

- Fleet yamls that force `SWITCHROOM_RICH_RENDER: "1"` in `defaults.env` become redundant but harmless.
- The degrade-to-plain safety path (`renderSafe`) is unchanged and remains the failure fallback — oversized/unsafe content still degrades to plain text, never a mid-construct cut.

## Test plan

- `./node_modules/.bin/vitest run telegram-plugin/tests/` → **370 files passed / 6106 tests passed**; the single remaining failure (`approval-hold-record.test.ts` "shared dir not writable") is a proven environment artifact — fails identically on pristine `origin/main` in this sandbox (test runs as uid 0, so the chmod-unwritable fixture doesn't bind); CI is the authority there.
- `npm run lint` → clean (tsc + all 8 guards).
- No bun-run suite touches the render path (checked `test:bun` file list).

## Risk

Low-medium: fleet-wide outbound formatting change on the send path, but the pipeline has been live per-agent since #2932/#2934 with live-wire verification (§6a) and pre-flip hardening (#3147), and `SWITCHROOM_RICH_RENDER=0` disables it per agent without a rebuild.

Job spec: `reference/jobs/talk-to-agents-from-anywhere.md` — readable rich replies on the phone surface by default; also `reference/principles.md` defaults test (finished features default ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)