### PR TITLE
fix(config): remove dead channels.telegram.rate_limit_ms knob

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,6 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `session.idle_clear_after` | override | Auto-run `/clear` (wipe working context) after this much idle. Default `3h` (on by default); `0s` disables. Long-term memory stays in Hindsight. |
 | `channels.telegram.plugin` | override | `switchroom` (default, enhanced) or `official` |
 | `channels.telegram.format` | override | Reply format (`html`, `markdownv2`, `text`) |
-| `channels.telegram.rate_limit_ms` | override | Min delay between outgoing messages |
 | `channels.telegram.orphan_promotion_ms` | override | Progress-card: ms before an unmatched spawn is promoted to a running row (default 5000) |
 | `channels.telegram.cold_sub_agent_threshold_ms` | override | Progress-card: ms of JSONL silence before a sub-agent is synthesised as finished (default 30000) |
 | `channels.telegram.deferred_completion_timeout_ms` | override | Progress-card: force-close timeout (ms) after parent `turn_end` while sub-agents are still running (default 180000) |

--- a/docs/telegram-plugin.md
+++ b/docs/telegram-plugin.md
@@ -226,7 +226,6 @@ The switchroom fork reads additional env vars from `start.sh`:
 | Env var | Source | Purpose |
 |---------|--------|---------|
 | `SWITCHROOM_TG_FORMAT` | `channels.telegram.format` | Default reply format (`html`, `markdownv2`, `text`) |
-| `SWITCHROOM_TG_RATE_LIMIT_MS` | `channels.telegram.rate_limit_ms` | Min delay between outgoing messages |
 | `SWITCHROOM_TG_STREAM_MODE` | `channels.telegram.stream_mode` | `checklist` (default) or `pty`. See "Streaming modes" above |
 | `TELEGRAM_STATE_DIR` | Auto-set by scaffold | Path to `telegram/` dir (history.db, access.json) |
 | `SWITCHROOM_AGENT_NAME` | Auto-set by scaffold | Agent name for self-restart detection |

--- a/skills/switchroom-architecture/telegram.md
+++ b/skills/switchroom-architecture/telegram.md
@@ -81,7 +81,6 @@ agents:
 | Var | Source | Purpose |
 |-----|--------|---------|
 | `SWITCHROOM_TG_FORMAT` | `channels.telegram.format` | Default reply format |
-| `SWITCHROOM_TG_RATE_LIMIT_MS` | `channels.telegram.rate_limit_ms` | Min delay between outgoing messages |
 | `TELEGRAM_STATE_DIR` | Auto-set by scaffold | Path to `telegram/` dir |
 | `SWITCHROOM_AGENT_NAME` | Auto-set by scaffold | Agent name (used for self-restart detection) |
 | `SWITCHROOM_CONFIG` | Auto-set by scaffold | Path to switchroom.yaml |

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1906,7 +1906,7 @@ export function installSwitchroomSkills(
 
 /**
  * Translate per-channel YAML fields into env vars the telegram-plugin
- * will read at startup. Today: SWITCHROOM_TG_FORMAT, SWITCHROOM_TG_RATE_LIMIT_MS,
+ * will read at startup. Today: SWITCHROOM_TG_FORMAT,
  * SWITCHROOM_TG_STREAM_MODE, and the progress-card threshold knobs.
  *
  * Returns an object that can be merged into the user env. User-declared
@@ -1919,9 +1919,9 @@ function channelsToEnv(agent: AgentConfig): Record<string, string> {
   const tg = agent.channels?.telegram;
   if (!tg) return out;
   if (tg.format !== undefined) out.SWITCHROOM_TG_FORMAT = tg.format;
-  if (tg.rate_limit_ms !== undefined) {
-    out.SWITCHROOM_TG_RATE_LIMIT_MS = String(tg.rate_limit_ms);
-  }
+  // SWITCHROOM_TG_RATE_LIMIT_MS removed in #3161 — nothing in
+  // telegram-plugin ever read it; the send gate (on by default since
+  // #3153) is the real outbound throttle.
   if (tg.stream_mode !== undefined) {
     out.SWITCHROOM_TG_STREAM_MODE = tg.stream_mode;
   }

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -45,6 +45,19 @@ describe("TelegramChannelSchema — supergroup smart defaults", () => {
   });
 });
 
+describe("TelegramChannelSchema — removed rate_limit_ms knob (#3161)", () => {
+  it("a stale rate_limit_ms key is accepted-and-ignored, never a validation failure", () => {
+    // The knob was removed (documented + scaffold-exported but read by
+    // nothing; the send gate is the real throttle). Existing YAML that
+    // still sets it must keep parsing — Zod's default strip mode drops
+    // the unknown key, same pattern as the progress_card removal
+    // (#1122 PR3).
+    const r = TelegramChannelSchema.parse({ format: "html", rate_limit_ms: 500 });
+    expect(r?.format).toBe("html");
+    expect((r as Record<string, unknown> | undefined)?.rate_limit_ms).toBeUndefined();
+  });
+});
+
 describe("TelegramChannelSchema — voice_out (PR-C2)", () => {
   it("applies engine/reply_mode defaults when only enabled is set", () => {
     const r = TelegramChannelSchema.parse({ voice_out: { enabled: true } });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -927,11 +927,9 @@ export const SessionContinuitySchema = z
  *    plugin (basic send/receive only).
  *  - format: default reply format for the channel. Passed to the
  *    plugin via env var. "html" (default) auto-converts markdown.
- *  - rate_limit_ms: minimum delay between outgoing messages.
  *
- * format and rate_limit_ms are pass-through — the plugin reads them
- * from env vars at startup but may not act on every field yet. We
- * define them in the schema so users can start setting them now.
+ * format is pass-through — the plugin reads it from an env var at
+ * startup.
  */
 
 /**
@@ -990,10 +988,13 @@ export const TelegramChannelSchema = z
       .enum(["html", "markdownv2", "text"])
       .optional()
       .describe("Default reply format passed to the plugin"),
-    rate_limit_ms: z
-      .number()
-      .optional()
-      .describe("Minimum delay between outgoing messages in ms"),
+    // rate_limit_ms removed in #3161 — it was documented and scaffold-
+    // exported (SWITCHROOM_TG_RATE_LIMIT_MS) but read by NOTHING; the
+    // send gate (telegram-plugin/send-gate.ts, on by default since
+    // #3153) is the real outbound throttle. Existing YAML files with a
+    // stale rate_limit_ms key are silently ignored by Zod's default
+    // strip mode — intentional, same pattern as the progress_card
+    // removal (#1122 PR3): operators don't need to clean their YAML.
     stream_mode: z
       .enum(["pty", "checklist"])
       .optional()

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -623,16 +623,16 @@ describe("mergeAgentConfig channels block", () => {
 
   it("per-field merges channels.telegram with agent winning", () => {
     const defaults: AgentDefaults = {
-      channels: { telegram: { plugin: "switchroom", format: "html", rate_limit_ms: 1000 } },
+      channels: { telegram: { plugin: "switchroom", format: "html", stream_throttle_ms: 1000 } },
     };
     const agent = baseAgent({
       channels: { telegram: { format: "markdownv2" } },
     });
     const result = mergeAgentConfig(defaults, agent);
-    // plugin and rate_limit flow from defaults; format is overridden
+    // plugin and stream_throttle flow from defaults; format is overridden
     expect(result.channels?.telegram?.plugin).toBe("switchroom");
     expect(result.channels?.telegram?.format).toBe("markdownv2");
-    expect(result.channels?.telegram?.rate_limit_ms).toBe(1000);
+    expect(result.channels?.telegram?.stream_throttle_ms).toBe(1000);
   });
 
   it("leaves channels undefined when neither side sets it", () => {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -3516,9 +3516,9 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(startSh).toContain('--plugin-dir "/opt/switchroom/security-plugin"');
   });
 
-  it("channels.telegram.format and rate_limit_ms become env vars in start.sh", () => {
+  it("channels.telegram.format and stream_throttle_ms become env vars in start.sh", () => {
     const agentConfig = makeAgentConfig({
-      channels: { telegram: { format: "markdownv2", rate_limit_ms: 500 } },
+      channels: { telegram: { format: "markdownv2", stream_throttle_ms: 500 } },
     });
     const result = scaffoldAgent(
       "chan-env-agent",
@@ -3529,7 +3529,7 @@ describe("scaffoldAgent with global defaults cascade", () => {
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
 
     expect(startSh).toContain("export SWITCHROOM_TG_FORMAT='markdownv2'");
-    expect(startSh).toContain("export SWITCHROOM_TG_RATE_LIMIT_MS='500'");
+    expect(startSh).toContain("export SWITCHROOM_TG_STREAM_THROTTLE_MS='500'");
   });
 
   it("user env entry wins over channel-derived env default on key conflict", () => {


### PR DESCRIPTION
## Summary

Closes #3161. `channels.telegram.rate_limit_ms` / `SWITCHROOM_TG_RATE_LIMIT_MS` was documented (`docs/configuration.md`, `docs/telegram-plugin.md`), schema-defined (`src/config/schema.ts`), and scaffold-exported into every agent's `start.sh` (`src/agents/scaffold.ts` `channelsToEnv`) — but **read by nothing** in telegram-plugin. An operator setting it got no throttling and no error: a documented dead knob. This takes the issue's preferred option 1 (remove) — the send gate (`telegram-plugin/send-gate.ts` token buckets, **on by default since #3153**, escape hatch `SWITCHROOM_TELEGRAM_SEND_GATE=0`) is the real outbound throttle, so a second documented throttle knob would be a lie twice over.

## What changed

- `src/config/schema.ts` — `rate_limit_ms` field removed from `TelegramChannelSchema`, replaced by an explanatory comment; the block docstring no longer mentions it.
- `src/agents/scaffold.ts` — the `SWITCHROOM_TG_RATE_LIMIT_MS` export in `channelsToEnv` removed (comment left in place); docstring updated.
- Docs rows removed: `docs/configuration.md`, `docs/telegram-plugin.md`, and the mirrored table in `skills/switchroom-architecture/telegram.md` (caught by the full-repo straggler grep). Old CHANGELOG entries untouched.
- `tests/merge.test.ts` / `tests/scaffold.test.ts` — the two tests that used `rate_limit_ms` as their example field now use the live `stream_throttle_ms` field, so the cascade-flow and channel→env coverage they provided is preserved, not deleted.

## Deprecation safety (checked, not assumed)

`TelegramChannelSchema` is a plain Zod object — NOT `.strict()` (the only `.strict()` in schema.ts is `ReleaseBlock`), so unknown keys are silently stripped at parse, never rejected. An existing `switchroom.yaml` that still sets `rate_limit_ms` keeps validating; the key is accepted-and-ignored. This follows the repo's established removed-field precedent verbatim — the `progress_card` removal (#1122 PR3, see the comment at its old schema location). A new regression test in `src/config/schema.test.ts` pins the guarantee: parsing `{ format: "html", rate_limit_ms: 500 }` succeeds and the stale key is stripped.

## Test plan

- `./node_modules/.bin/vitest run tests/merge.test.ts tests/scaffold.test.ts src/config/schema.test.ts tests/config.test.ts` → **4 files / 453 tests passed** (before the tsc nit fix; schema.test.ts re-run after → 138 passed).
- `npm run lint` → clean (tsc + all 8 guards).
- Full-repo grep for `rate_limit_ms` / `RATE_LIMIT_MS` (excluding CHANGELOG and the unrelated `SWITCHROOM_RATE_LIMIT_OVERAGE`) → only the intentional removal comments + the new regression test remain.

## Risk

Minimal: removes code that was provably dead (nothing read the env var) plus its documentation. The only observable change is that a stale YAML key stops appearing in the parsed config object — which nothing consumed.

Job spec: `reference/jobs/extend-without-forking.md` — config the product actually honors; a documented knob that does nothing fails the docs test (`reference/principles.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)