### PR TITLE
fix(telegram): wire draft-stream edits through the send gate's per-message edit floor

### DIFF
--- a/telegram-plugin/draft-stream.ts
+++ b/telegram-plugin/draft-stream.ts
@@ -26,6 +26,40 @@
 
 const TELEGRAM_MAX_CHARS = 32768
 
+/**
+ * Error a transport layer (stream-controller.ts) throws from its edit
+ * callback when the send gate SHED the edit — it did NOT land, and the
+ * stream must not record the snapshot as on-screen (#3110). Marked with a
+ * property (not a message pattern) so the classification is exact.
+ *
+ * `flush()` recognizes this and PRESERVES the snapshot in `shedText` so a
+ * later `finalize()` — including the argument-less finalize the gateway's
+ * cleanup paths use — re-flushes it as the stream's final state instead of
+ * silently losing the content (review F2). It deliberately does NOT restore
+ * `pendingText`: `flushLoop` drains while `pendingText != null`, and a
+ * restore there would busy-spin the loop against an open flood window.
+ */
+export interface DraftEditShedError extends Error {
+  draftEditShed: true
+}
+
+/** Build the marker error a transport throws for a gate-shed edit. */
+export function makeDraftEditShedError(messageId: number | null): DraftEditShedError {
+  return Object.assign(
+    new Error(
+      `draft edit shed by send gate (id=${messageId ?? 'unknown'}); snapshot preserved for re-flush`,
+    ),
+    { draftEditShed: true as const },
+  )
+}
+
+/** True when `err` is the shed marker thrown by a stream transport. */
+export function isDraftEditShedError(err: unknown): err is DraftEditShedError {
+  return (
+    err instanceof Error && (err as Partial<DraftEditShedError>).draftEditShed === true
+  )
+}
+
 // Throttle defaults for the in-place engine.
 //   DM chats: 400 ms — slightly more responsive than groups while staying
 //     well under Telegram's practical ~1 edit/sec/message ceiling. This
@@ -172,6 +206,14 @@ export function createDraftStream(
   let messageId: number | null = config.initialMessageId ?? null
   let pendingText: string | null = null
   let lastSentText: string | null = null
+  /**
+   * Snapshot of the newest text the transport reported as SHED (thrown
+   * `DraftEditShedError`) — content that never landed. Cleared on any
+   * successful flush (a newer snapshot superseded it) and consumed by
+   * `finalize()` so the stream's last state is re-delivered once the
+   * pressure clears instead of being lost (review F2).
+   */
+  let shedText: string | null = null
   let lastSentAt = 0
   let inFlight: Promise<void> | null = null
   // Observability — per-stream fire counters for the stream-end trace.
@@ -225,11 +267,21 @@ export function createDraftStream(
       await sendViaMessage(textToSend)
       lastSentText = textToSend
       lastSentAt = Date.now()
+      shedText = null // a newer snapshot landed — drop any older shed one
     } catch (err) {
       const msg = (err as Error).message ?? String(err)
-      if (/\bmessage is not modified\b/i.test(msg)) {
+      if (isDraftEditShedError(err)) {
+        // #3110 review F2: the send gate shed this edit — it did NOT land.
+        // Preserve the snapshot for finalize()'s re-flush (as the stream's
+        // final state, sent critical) instead of silently losing it. Do NOT
+        // restore pendingText: flushLoop drains while pendingText != null
+        // and would busy-spin against an open flood window.
+        shedText = textToSend
+        log?.(`stream → shed by send gate (id: ${messageId}); snapshot preserved for re-flush`)
+      } else if (/\bmessage is not modified\b/i.test(msg)) {
         lastSentText = textToSend
         lastSentAt = Date.now()
+        shedText = null // on-screen text == this snapshot; nothing to recover
         log?.(`stream → not modified (id: ${messageId})`)
       } else if (
         /\bmessage to edit not found\b/i.test(msg)
@@ -352,6 +404,15 @@ export function createDraftStream(
       if (inFlight) {
         await inFlight
       }
+      // #3110 review F2: if the newest snapshot was SHED by the send gate
+      // (never landed) and nothing newer is pending, re-flush it as the
+      // stream's final state. Checked AFTER awaiting inFlight so a flush
+      // that sheds mid-finalize is recovered too. A provided finalText and
+      // any pending draft both outrank the shed snapshot (they are newer).
+      if (pendingText == null && shedText != null && !stopped) {
+        pendingText = shedText
+      }
+      shedText = null
       if (pendingText != null && !stopped) {
         await flush()
       }

--- a/telegram-plugin/draft-stream.ts
+++ b/telegram-plugin/draft-stream.ts
@@ -116,8 +116,17 @@ export interface DraftStreamHandle {
    * Mark the stream as final. Flushes any pending text and rejects all
    * future update() calls. Returns a promise that resolves once the final
    * edit has landed (or the initial send if no edits ever fired).
+   *
+   * When `finalText` is provided, it becomes the pending snapshot for the
+   * final flush (superseding any older pending draft — last-write-wins).
+   * Callers that know a text is the LAST one (e.g. `stream_reply`
+   * `done=true`) MUST pass it here instead of `update(text)` +
+   * `finalize()`: the flush then runs with the stream already final, so
+   * the transport layer (stream-controller) classifies the edit that
+   * renders the completed answer as `critical` for the send gate — never
+   * shed as a cosmetic draft under flood pressure (#3110).
    */
-  finalize(): Promise<void>
+  finalize(finalText?: string): Promise<void>
 
   /** Returns the captured Telegram message_id, or null if nothing has sent yet. */
   getMessageId(): number | null
@@ -327,9 +336,14 @@ export function createDraftStream(
       return waitPromise
     },
 
-    async finalize(): Promise<void> {
+    async finalize(finalText?: string): Promise<void> {
       if (final) return
       final = true
+      // A caller-supplied final snapshot supersedes any pending draft
+      // (last-write-wins) and is flushed below with `final` already set,
+      // so the transport classifies this edit as the answer's final
+      // render, not a sheddable draft (#3110).
+      if (finalText != null && !stopped) pendingText = finalText
       // Drain any pending updates
       if (scheduledTimer != null) {
         clearTimeout(scheduledTimer)

--- a/telegram-plugin/send-gate-degraded.test.ts
+++ b/telegram-plugin/send-gate-degraded.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createSendGate, type Clock } from './send-gate.js'
+import { createSendGate, SEND_GATE_SHED, type Clock } from './send-gate.js'
 import { isFloodWaitActiveError } from './retry-api-call.js'
 
 /**
@@ -73,8 +73,10 @@ describe('send-gate PR2: cosmetic shedding', () => {
 
     const res = await gate.gate(fn('cosmetic'), { priorityClass: 'cosmetic' })
 
-    // Shed resolves undefined; fn never ran; the shed counter moved.
-    expect(res).toBeUndefined()
+    // Shed resolves the distinguishable sentinel (#3110 F1 — never a bare
+    // undefined, which is reserved for benign no-op drops); fn never ran;
+    // the shed counter moved.
+    expect(res).toBe(SEND_GATE_SHED)
     expect(calls).toHaveLength(0)
     expect(gate.stats().global.shed).toBe(1)
     expect(gate.stats().global.sent).toBe(0)
@@ -95,7 +97,7 @@ describe('send-gate PR2: cosmetic shedding', () => {
     const shed = await gate.gate(fn('b'), { chat_id: '5', priorityClass: 'cosmetic' })
 
     expect(calls.map((c) => c.label)).toEqual(['a'])
-    expect(shed).toBeUndefined()
+    expect(shed).toBe(SEND_GATE_SHED)
     expect(gate.stats().global.shed).toBe(1)
   })
 
@@ -128,7 +130,7 @@ describe('send-gate PR2: cosmetic shedding', () => {
       priorityClass: 'cosmetic',
     })
 
-    expect(res).toBeUndefined()
+    expect(res).toBe(SEND_GATE_SHED)
     expect(calls).toHaveLength(0)
     expect(gate.stats().global.shed).toBe(1)
   })
@@ -366,7 +368,7 @@ describe('send-gate PR2: H1 cross-chat message_id isolation', () => {
       priorityClass: 'cosmetic',
     })
 
-    expect(rA).toBeUndefined() // A shed
+    expect(rA).toBe(SEND_GATE_SHED) // A shed
     expect(rB).toBe('B-edit') // B sent
     expect(calls.map((c) => c.label)).toEqual(['B-edit'])
     expect(gate.stats().global.shed).toBe(1)
@@ -568,7 +570,7 @@ describe('send-gate PR2: opening a window from a 429, and persistence hook', () 
     expect(scopes).toEqual(['chat:7', 'global', 'group:7', 'msg-edit:7:3'])
     // After the window opens, a later cosmetic on the same chat sheds.
     const shed = await gate.gate(async () => 'x', { chat_id: '7', priorityClass: 'cosmetic' })
-    expect(shed).toBeUndefined()
+    expect(shed).toBe(SEND_GATE_SHED)
     expect(gate.stats().global.shed).toBe(1)
   })
 })

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -119,6 +119,32 @@ export type PriorityClass = 'critical' | 'useful' | 'cosmetic'
 export const UNTAGGED_SEND_CLASS: PriorityClass = 'critical'
 
 /**
+ * Distinguishable resolution value for a SHED call (#3110 review F1).
+ *
+ * `undefined` was overloaded three ways at the robustApiCall seam: a gate
+ * SHED (cosmetic call dropped under pressure — did NOT land), a gate no-op
+ * drop (identical payload already on screen — benign), and the retry
+ * policy's swallowed benign 400s ("message is not modified" — also benign).
+ * A caller that needs to know "did my edit land?" (the draft stream's
+ * shed-honesty handling in stream-controller.ts) could not tell these
+ * apart, and treating every `undefined` as a shed froze multi-piece
+ * streams on perfectly healthy chats.
+ *
+ * A shed now resolves THIS sentinel instead. `Symbol.for` keys it in the
+ * global symbol registry so duplicated module instances (server + gateway
+ * builds) agree on identity. The no-op drop and coalesced-revert drop keep
+ * resolving `undefined` — for those the payload IS on screen. Callers that
+ * ignore the result (reactions, typing, fire-and-forget card edits) are
+ * unaffected either way.
+ */
+export const SEND_GATE_SHED: unique symbol = Symbol.for('switchroom.send-gate.shed')
+
+/** True when a gate result is the {@link SEND_GATE_SHED} sentinel. */
+export function isSendGateShed(value: unknown): value is typeof SEND_GATE_SHED {
+  return value === SEND_GATE_SHED
+}
+
+/**
  * Extra metadata a call site can attach so the gate can key the right buckets.
  * All fields optional — a call with none still passes the global bucket. These
  * mirror (a superset of) `RetryCallOpts` so the gate can wrap `robustApiCall`
@@ -159,8 +185,9 @@ export interface BucketCounters {
   dropped: number
   /**
    * Cosmetic calls shed under pressure — no token free OR a flood window open
-   * (part3-design §2). A shed resolves as `undefined`; the next send carries
-   * full state.
+   * (part3-design §2). A shed resolves the SEND_GATE_SHED sentinel (F1 —
+   * distinguishable from a benign no-op drop's `undefined`); the next send
+   * carries full state.
    */
   shed: number
   /** Useful calls dropped because they exceeded their queue TTL (part3-design §2). */
@@ -913,7 +940,9 @@ export function createSendGate(config: SendGateConfig): SendGate {
       const msgWait = state.suppressedUntilMs > now ? state.suppressedUntilMs - now : 0
       if (wait > 0 || msgWait > 0) {
         counters.shed++
-        return Promise.resolve(undefined as unknown as T)
+        // Distinguishable from the no-op drop below (undefined): a shed did
+        // NOT land, and edit-driving callers must be able to tell (F1).
+        return Promise.resolve(SEND_GATE_SHED as unknown as T)
       }
     }
 
@@ -991,7 +1020,8 @@ export function createSendGate(config: SendGateConfig): SendGate {
     const outcome = await admitPriority(bucketsFor(opts), priority)
     if (outcome.result === 'shed') {
       counters.shed++
-      return undefined as unknown as T
+      // See SEND_GATE_SHED: distinguishable "did not land" resolution (F1).
+      return SEND_GATE_SHED as unknown as T
     }
     if (outcome.result === 'expired') {
       counters.expired++

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -316,9 +316,14 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
    * draft-stream's own dedupe — the completed answer would never render.
    * The conservative reading costs nothing: a re-flush of a payload that DID
    * land is dropped by the gate's no-op skip before it reaches the API.
+   *
+   * Decides from the CLASS THE CALL WAS SENT WITH (the opts built at call
+   * time), never a re-read of `isFinal()` at result time: finalize() landing
+   * while a cosmetic edit is in flight must not reclassify that edit's shed
+   * as a benign skip.
    */
-  const editWasShed = (result: unknown): boolean =>
-    result === undefined && handleRef?.isFinal() !== true
+  const editWasShed = (result: unknown, sentOpts: RetryPolicyOpts): boolean =>
+    result === undefined && sentOpts.priorityClass === 'cosmetic'
   /** Sentinel thrown so draft-stream's flush does not record a shed edit as sent. */
   const shedError = (id: number) =>
     new Error(`draft edit shed by send gate (id=${id}); next flush carries full state`)
@@ -346,11 +351,9 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     if (existingId != null) {
       if (tailLastText[ti] === piece.text) return // unchanged — skip the API call
       try {
-        const res = await retry(
-          () => editPiece(existingId, piece, baseOpts),
-          editGateOpts(existingId, piecePayload(piece)),
-        )
-        if (editWasShed(res)) {
+        const gateOpts = editGateOpts(existingId, piecePayload(piece))
+        const res = await retry(() => editPiece(existingId, piece, baseOpts), gateOpts)
+        if (editWasShed(res, gateOpts)) {
           // Shed by the gate (flood window / pressure) — leave tailLastText
           // stale so the next flush retries this piece with full state.
           return
@@ -362,11 +365,12 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
           warn?.(
             `stream-controller: tail-piece #${ti + 1} edit parse-entities rejected — retrying same id=${existingId} as plain text (${err instanceof Error ? err.message : String(err)})`,
           )
+          const fallbackOpts = editGateOpts(existingId, piece.text)
           const res = await retry(
             () => bot.api.editMessageText(chatId, existingId, piece.text, baseOpts),
-            editGateOpts(existingId, piece.text),
+            fallbackOpts,
           )
-          if (editWasShed(res)) return // shed — retried with full state next flush
+          if (editWasShed(res, fallbackOpts)) return // shed — retried with full state next flush
           tailLastText[ti] = piece.text
           onEdit?.(existingId, piece.text.length)
         } else {
@@ -461,14 +465,12 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
       const head = pieces[0]
       // Edit the anchor message in place with the FIRST piece.
       try {
-        const res = await retry(
-          () => editPiece(id, head, baseOpts),
-          editGateOpts(id, piecePayload(head)),
-        )
+        const gateOpts = editGateOpts(id, piecePayload(head))
+        const res = await retry(() => editPiece(id, head, baseOpts), gateOpts)
         // Shed by the gate (cosmetic under pressure / an open flood window):
         // throw so draft-stream does NOT record this text as on-screen — a
         // later flush of the same text (e.g. the finalize) must still land.
-        if (editWasShed(res)) throw shedError(id)
+        if (editWasShed(res, gateOpts)) throw shedError(id)
         // C2: report the actual head-piece length, not the full body length.
         onEdit?.(id, head.text.length)
       } catch (err) {
@@ -485,11 +487,12 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
           // contract). For a single-piece stream (common case) this is the
           // whole body; a rare oversize split edits the head piece's body.
           const fallbackBody = pieces.length === 1 ? text : head.text
+          const fallbackOpts = editGateOpts(id, fallbackBody)
           const res = await retry(
             () => bot.api.editMessageText(chatId, id, fallbackBody, baseOpts),
-            editGateOpts(id, fallbackBody),
+            fallbackOpts,
           )
-          if (editWasShed(res)) throw shedError(id)
+          if (editWasShed(res, fallbackOpts)) throw shedError(id)
           onEdit?.(id, head.text.length)
         } else {
           throw err

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -22,6 +22,7 @@
 import { createDraftStream, type DraftStreamHandle } from './draft-stream.js'
 import { richMessage, isParseEntitiesError } from './rich-send.js'
 import { renderOutboundChunks } from './render/rich-render.js'
+import type { SendGateOpts } from './send-gate.js'
 
 /**
  * Minimal bot.api surface the controller needs. Real callers pass grammy's
@@ -77,9 +78,21 @@ export interface StreamSendOpts {
   disable_notification?: boolean
 }
 
+/**
+ * Options a stream-controller call passes to its retry wrapper. A structural
+ * superset of `SendGateOpts` (send-gate.ts) plus the retry policy's own
+ * `threadId`, and assignable to `RetryCallOpts` (retry-api-call.ts) — so the
+ * production wrapper (`robustApiCall` = send gate over `createRetryApiCall`)
+ * receives `messageId` / `editPayload` / `priorityClass` and the gate's
+ * per-message edit floor, last-write-wins coalescing, no-op skip and
+ * cosmetic shedding govern the draft/answer stream (#3110; part3-design §4
+ * names rapid same-message editMessageText as the #1 flood-ban trigger).
+ */
+export type RetryPolicyOpts = SendGateOpts & { threadId?: number }
+
 export type RetryPolicy = <T>(
   fn: () => Promise<T>,
-  opts?: { threadId?: number; chat_id?: string },
+  opts?: RetryPolicyOpts,
 ) => Promise<T>
 
 export interface StreamControllerConfig {
@@ -251,6 +264,65 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     return bot.api.editMessageText(chatId, id, richMessage(piece.text), opts)
   }
 
+  // ---- Send-gate wiring for the edit path (#3110) -------------------------
+  //
+  // Every edit call passes `messageId` / `editPayload` / `priorityClass`
+  // through the retry wrapper so the send gate's per-message edit floor
+  // (>=1.5s), last-write-wins coalescing, and no-op skip govern the draft
+  // stream — previously these edits carried only `{ threadId, chat_id }`,
+  // so the gate treated them as ordinary sends and the stream's own 400 ms
+  // DM throttle drove same-message editMessageText well under the floor
+  // (the #1 documented flood-ban trigger, part3-design §4; production ban
+  // 2026-07-12 on #3110). The local per-surface throttle stays as a cheap
+  // pre-filter; the gate is the authority.
+  //
+  // Priority classes: intermediate draft edits are `cosmetic` (part3-design
+  // §2 lists "stream updates" there) — shed under pressure / an open flood
+  // window; the next flush carries full state. The FINALIZE flush (the edit
+  // that renders the completed answer) is `critical`, mirroring the reply
+  // path's preview-finalize convention (gateway.ts editPreview): never shed,
+  // waits out a short window, fails fast with a structured FLOOD_WAIT_ACTIVE
+  // on a long one. SENDS stay untagged (the gate admits untagged non-edit
+  // sends as `critical`) — a shed send would resolve `undefined` and break
+  // message-id capture, and the anchor/tail sends ARE the answer surface.
+  //
+  // `handleRef.isFinal()` is true from the moment finalize() is entered
+  // (draft-stream sets `final` before its last flush), so the closures below
+  // classify exactly the finalize flush — and anything after it — as
+  // critical. The ref is assigned right after createDraftStream returns,
+  // before any closure can run (closures only fire from update/finalize).
+  let handleRef: DraftStreamHandle | null = null
+  const editGateOpts = (id: number, payload: unknown): RetryPolicyOpts => ({
+    threadId,
+    chat_id: chatId,
+    messageId: id,
+    editPayload: payload,
+    priorityClass: handleRef?.isFinal() === true ? 'critical' : 'cosmetic',
+  })
+  // The rendered payload the gate hashes for the no-op skip / coalescing —
+  // exactly what goes over the wire (rich wrapper included), so a plain
+  // fallback of the same text never hashes equal to its rich form.
+  const piecePayload = (piece: { text: string; rich: boolean }): unknown =>
+    piece.rich ? richMessage(piece.text) : piece.text
+  /**
+   * True when a gated edit did NOT land on screen: the gate SHED it as
+   * cosmetic (resolves `undefined` by contract — "the next send carries full
+   * state"). A critical (finalize) edit is never shed, so an `undefined`
+   * there is a benign skip (gate no-op drop / robustApiCall's swallowed
+   * "message is not modified") — the text is already on screen. Treating a
+   * cosmetic `undefined` as not-landed keeps draft-stream's `lastSentText`
+   * honest: without this, a shed draft would be recorded as delivered and a
+   * later flush of the SAME text (e.g. the finalize) would be skipped by
+   * draft-stream's own dedupe — the completed answer would never render.
+   * The conservative reading costs nothing: a re-flush of a payload that DID
+   * land is dropped by the gate's no-op skip before it reaches the API.
+   */
+  const editWasShed = (result: unknown): boolean =>
+    result === undefined && handleRef?.isFinal() !== true
+  /** Sentinel thrown so draft-stream's flush does not record a shed edit as sent. */
+  const shedError = (id: number) =>
+    new Error(`draft edit shed by send gate (id=${id}); next flush carries full state`)
+
   // Overflow-tail bookkeeping, shared across the send + edit closures for the
   // whole stream lifetime. A body large enough to split into several
   // wire-cap pieces anchors on piece[0] (edited in place by draft-stream) and
@@ -274,7 +346,15 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     if (existingId != null) {
       if (tailLastText[ti] === piece.text) return // unchanged — skip the API call
       try {
-        await retry(() => editPiece(existingId, piece, baseOpts), { threadId, chat_id: chatId })
+        const res = await retry(
+          () => editPiece(existingId, piece, baseOpts),
+          editGateOpts(existingId, piecePayload(piece)),
+        )
+        if (editWasShed(res)) {
+          // Shed by the gate (flood window / pressure) — leave tailLastText
+          // stale so the next flush retries this piece with full state.
+          return
+        }
         tailLastText[ti] = piece.text
         onEdit?.(existingId, piece.text.length)
       } catch (err) {
@@ -282,10 +362,11 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
           warn?.(
             `stream-controller: tail-piece #${ti + 1} edit parse-entities rejected — retrying same id=${existingId} as plain text (${err instanceof Error ? err.message : String(err)})`,
           )
-          await retry(
+          const res = await retry(
             () => bot.api.editMessageText(chatId, existingId, piece.text, baseOpts),
-            { threadId, chat_id: chatId },
+            editGateOpts(existingId, piece.text),
           )
+          if (editWasShed(res)) return // shed — retried with full state next flush
           tailLastText[ti] = piece.text
           onEdit?.(existingId, piece.text.length)
         } else {
@@ -326,7 +407,7 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     }
   }
 
-  return createDraftStream(
+  const handle = createDraftStream(
     async (text) => {
       // Render → 1+ cap-respecting pieces. The FIRST piece's message_id anchors
       // the stream (later edits target it); any overflow pieces are parked as
@@ -380,10 +461,14 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
       const head = pieces[0]
       // Edit the anchor message in place with the FIRST piece.
       try {
-        await retry(
+        const res = await retry(
           () => editPiece(id, head, baseOpts),
-          { threadId, chat_id: chatId },
+          editGateOpts(id, piecePayload(head)),
         )
+        // Shed by the gate (cosmetic under pressure / an open flood window):
+        // throw so draft-stream does NOT record this text as on-screen — a
+        // later flush of the same text (e.g. the finalize) must still land.
+        if (editWasShed(res)) throw shedError(id)
         // C2: report the actual head-piece length, not the full body length.
         onEdit?.(id, head.text.length)
       } catch (err) {
@@ -400,10 +485,11 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
           // contract). For a single-piece stream (common case) this is the
           // whole body; a rare oversize split edits the head piece's body.
           const fallbackBody = pieces.length === 1 ? text : head.text
-          await retry(
+          const res = await retry(
             () => bot.api.editMessageText(chatId, id, fallbackBody, baseOpts),
-            { threadId, chat_id: chatId },
+            editGateOpts(id, fallbackBody),
           )
+          if (editWasShed(res)) throw shedError(id)
           onEdit?.(id, head.text.length)
         } else {
           throw err
@@ -429,4 +515,6 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
       chatId,
     },
   )
+  handleRef = handle
+  return handle
 }

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -19,10 +19,14 @@
  * entire server.ts top-level initialization.
  */
 
-import { createDraftStream, type DraftStreamHandle } from './draft-stream.js'
+import {
+  createDraftStream,
+  makeDraftEditShedError,
+  type DraftStreamHandle,
+} from './draft-stream.js'
 import { richMessage, isParseEntitiesError } from './rich-send.js'
 import { renderOutboundChunks } from './render/rich-render.js'
-import type { SendGateOpts } from './send-gate.js'
+import { isSendGateShed, type SendGateOpts } from './send-gate.js'
 
 /**
  * Minimal bot.api surface the controller needs. Real callers pass grammy's
@@ -283,14 +287,27 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
   // path's preview-finalize convention (gateway.ts editPreview): never shed,
   // waits out a short window, fails fast with a structured FLOOD_WAIT_ACTIVE
   // on a long one. SENDS stay untagged (the gate admits untagged non-edit
-  // sends as `critical`) — a shed send would resolve `undefined` and break
-  // message-id capture, and the anchor/tail sends ARE the answer surface.
+  // sends as `critical`) — a shed send would resolve the gate's shed
+  // sentinel instead of `{ message_id }` and break message-id capture, and
+  // the anchor/tail sends ARE the answer surface.
   //
   // `handleRef.isFinal()` is true from the moment finalize() is entered
   // (draft-stream sets `final` before its last flush), so the closures below
   // classify exactly the finalize flush — and anything after it — as
   // critical. The ref is assigned right after createDraftStream returns,
   // before any closure can run (closures only fire from update/finalize).
+  //
+  // KNOWN MISSED BENEFIT (review F5, deliberate): the gate's last-write-wins
+  // coalescing never engages for THIS surface, because draft-stream
+  // serializes its flushes — it awaits each edit before issuing the next, so
+  // at most one edit per message is ever inside the gate. Consequence: a
+  // stale draft sleeping on the gate's floor still lands (one API call the
+  // coalescer would have replaced) before the newer snapshot, and a finalize
+  // issued mid-floor can trail by up to ~2x editFloorMs (floor wait for the
+  // stale draft, then floor wait for the final). Correctness is unaffected —
+  // the latest state always lands, floor-paced — and the gate coalescing
+  // remains live protection for CONCURRENT writers to one message (e.g. a
+  // re-attached #626 controller racing its predecessor).
   let handleRef: DraftStreamHandle | null = null
   const editGateOpts = (id: number, payload: unknown): RetryPolicyOpts => ({
     threadId,
@@ -304,29 +321,16 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
   // fallback of the same text never hashes equal to its rich form.
   const piecePayload = (piece: { text: string; rich: boolean }): unknown =>
     piece.rich ? richMessage(piece.text) : piece.text
-  /**
-   * True when a gated edit did NOT land on screen: the gate SHED it as
-   * cosmetic (resolves `undefined` by contract — "the next send carries full
-   * state"). A critical (finalize) edit is never shed, so an `undefined`
-   * there is a benign skip (gate no-op drop / robustApiCall's swallowed
-   * "message is not modified") — the text is already on screen. Treating a
-   * cosmetic `undefined` as not-landed keeps draft-stream's `lastSentText`
-   * honest: without this, a shed draft would be recorded as delivered and a
-   * later flush of the SAME text (e.g. the finalize) would be skipped by
-   * draft-stream's own dedupe — the completed answer would never render.
-   * The conservative reading costs nothing: a re-flush of a payload that DID
-   * land is dropped by the gate's no-op skip before it reaches the API.
-   *
-   * Decides from the CLASS THE CALL WAS SENT WITH (the opts built at call
-   * time), never a re-read of `isFinal()` at result time: finalize() landing
-   * while a cosmetic edit is in flight must not reclassify that edit's shed
-   * as a benign skip.
-   */
-  const editWasShed = (result: unknown, sentOpts: RetryPolicyOpts): boolean =>
-    result === undefined && sentOpts.priorityClass === 'cosmetic'
-  /** Sentinel thrown so draft-stream's flush does not record a shed edit as sent. */
-  const shedError = (id: number) =>
-    new Error(`draft edit shed by send gate (id=${id}); next flush carries full state`)
+  // Shed detection (#3110 review F1): keyed EXACTLY off the gate's
+  // SEND_GATE_SHED sentinel — never off `undefined`, which is overloaded
+  // (gate no-op drop; robustApiCall's swallowed benign 400s like "message is
+  // not modified"). Those benign cases mean the payload is ALREADY on screen
+  // and are treated as delivered, exactly as before this wiring existed. A
+  // true shed means the edit did NOT land: draft-stream must not record the
+  // snapshot as on-screen (its dedupe would skip a later flush of the same
+  // text — the completed answer would never render), so the edit closure
+  // throws the marker error draft-stream recognizes and recovers from
+  // (`makeDraftEditShedError` → snapshot preserved for finalize, review F2).
 
   // Overflow-tail bookkeeping, shared across the send + edit closures for the
   // whole stream lifetime. A body large enough to split into several
@@ -346,18 +350,25 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
   // text) thereafter. A non-parse failure is logged as a partial-delivery
   // warning and swallowed so the remaining tail pieces still get a chance to
   // land — never a silent drop, never an abort of pieces K..N (concern C1).
-  const upsertTail = async (ti: number, piece: { text: string; rich: boolean }): Promise<void> => {
+  //
+  // Returns TRUE when this piece's edit was SHED by the send gate (did not
+  // land): the caller must then report the whole flush as shed so
+  // draft-stream does not record the full body as delivered while a tail is
+  // stale (review F3). The piece's own tailLastText stays stale too, so the
+  // recovery flush re-attempts exactly the shed piece.
+  const upsertTail = async (
+    ti: number,
+    piece: { text: string; rich: boolean },
+  ): Promise<boolean> => {
     const existingId = tailIds[ti]
     if (existingId != null) {
-      if (tailLastText[ti] === piece.text) return // unchanged — skip the API call
+      if (tailLastText[ti] === piece.text) return false // unchanged — skip the API call
       try {
-        const gateOpts = editGateOpts(existingId, piecePayload(piece))
-        const res = await retry(() => editPiece(existingId, piece, baseOpts), gateOpts)
-        if (editWasShed(res, gateOpts)) {
-          // Shed by the gate (flood window / pressure) — leave tailLastText
-          // stale so the next flush retries this piece with full state.
-          return
-        }
+        const res = await retry(
+          () => editPiece(existingId, piece, baseOpts),
+          editGateOpts(existingId, piecePayload(piece)),
+        )
+        if (isSendGateShed(res)) return true // shed — stale; retried by the recovery flush
         tailLastText[ti] = piece.text
         onEdit?.(existingId, piece.text.length)
       } catch (err) {
@@ -365,12 +376,11 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
           warn?.(
             `stream-controller: tail-piece #${ti + 1} edit parse-entities rejected — retrying same id=${existingId} as plain text (${err instanceof Error ? err.message : String(err)})`,
           )
-          const fallbackOpts = editGateOpts(existingId, piece.text)
           const res = await retry(
             () => bot.api.editMessageText(chatId, existingId, piece.text, baseOpts),
-            fallbackOpts,
+            editGateOpts(existingId, piece.text),
           )
-          if (editWasShed(res, fallbackOpts)) return // shed — retried with full state next flush
+          if (isSendGateShed(res)) return true // shed — stale; retried by the recovery flush
           tailLastText[ti] = piece.text
           onEdit?.(existingId, piece.text.length)
         } else {
@@ -381,7 +391,7 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
           )
         }
       }
-      return
+      return false
     }
     // First emission of this tail piece → a fresh follow-up message.
     try {
@@ -409,6 +419,9 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
         )
       }
     }
+    // First-emission SENDS are untagged (critical) — the gate never sheds
+    // them, so this path can only land or fail (handled above).
+    return false
   }
 
   const handle = createDraftStream(
@@ -463,16 +476,26 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     async (id, text) => {
       const pieces = renderPieces(text)
       const head = pieces[0]
+      // Whether any piece of THIS flush was shed by the gate (did not land).
+      // Decided at the very end — AFTER the tail loop — so a benign anchor
+      // outcome (or even a shed anchor) never starves the tail pieces of
+      // their own upsert attempt (review F1: an anchor whose payload stopped
+      // changing resolves benignly every flush while only the tail grows).
+      let anchorShed = false
       // Edit the anchor message in place with the FIRST piece.
       try {
-        const gateOpts = editGateOpts(id, piecePayload(head))
-        const res = await retry(() => editPiece(id, head, baseOpts), gateOpts)
-        // Shed by the gate (cosmetic under pressure / an open flood window):
-        // throw so draft-stream does NOT record this text as on-screen — a
-        // later flush of the same text (e.g. the finalize) must still land.
-        if (editWasShed(res, gateOpts)) throw shedError(id)
-        // C2: report the actual head-piece length, not the full body length.
-        onEdit?.(id, head.text.length)
+        const res = await retry(() => editPiece(id, head, baseOpts), editGateOpts(id, piecePayload(head)))
+        if (isSendGateShed(res)) {
+          // Shed by the gate (cosmetic under pressure / an open flood
+          // window) — did NOT land. Benign `undefined` resolutions (gate
+          // no-op drop, robustApiCall's swallowed "message is not modified")
+          // deliberately do NOT take this branch: the payload is already on
+          // screen and the flush proceeds as delivered.
+          anchorShed = true
+        } else {
+          // C2: report the actual head-piece length, not the full body length.
+          onEdit?.(id, head.text.length)
+        }
       } catch (err) {
         if (!literalText && head.rich && isParseEntitiesError(err)) {
           // Edit rejected because the markdown couldn't be parsed — DO NOT
@@ -487,13 +510,12 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
           // contract). For a single-piece stream (common case) this is the
           // whole body; a rare oversize split edits the head piece's body.
           const fallbackBody = pieces.length === 1 ? text : head.text
-          const fallbackOpts = editGateOpts(id, fallbackBody)
           const res = await retry(
             () => bot.api.editMessageText(chatId, id, fallbackBody, baseOpts),
-            fallbackOpts,
+            editGateOpts(id, fallbackBody),
           )
-          if (editWasShed(res, fallbackOpts)) throw shedError(id)
-          onEdit?.(id, head.text.length)
+          if (isSendGateShed(res)) anchorShed = true
+          else onEdit?.(id, head.text.length)
         } else {
           throw err
         }
@@ -503,10 +525,20 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
       // that only just came into existence) — we never re-send tails already
       // emitted on a prior flush. This is the fix for the duplicate-flood
       // blocker: the previous code re-sent pieces[1..n] as brand-new messages
-      // on each throttled edit tick.
+      // on each throttled edit tick. Runs BEFORE the shed decision below so a
+      // shed (or benign) anchor never starves the tails (review F1).
+      let anyTailShed = false
       for (let pi = 1; pi < pieces.length; pi++) {
-        await upsertTail(pi - 1, pieces[pi])
+        if (await upsertTail(pi - 1, pieces[pi])) anyTailShed = true
       }
+      // Review F3: ANY shed piece — anchor or tail — means this flush did not
+      // fully land. Throw the marker error so draft-stream does not record
+      // the body as delivered (its dedupe would freeze the shed piece
+      // forever) and instead preserves the snapshot for the finalize
+      // re-flush. Pieces that DID land are unaffected on that re-flush: the
+      // gate's no-op skip drops their identical payloads before the API, and
+      // landed tails short-circuit on tailLastText.
+      if (anchorShed || anyTailShed) throw makeDraftEditShedError(id)
     },
     {
       ...(throttleMs != null ? { throttleMs } : {}),

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -516,10 +516,20 @@ export async function handleStreamReply(
     state.activeDraftStreams.set(sKey, stream)
   }
 
-  await stream.update(effectiveText)
+  if (!done) {
+    // Intermediate snapshot — an ordinary throttled draft update.
+    await stream.update(effectiveText)
+  }
 
   if (done) {
-    await stream.finalize()
+    // #3110: route the FINAL text through finalize(text) so the flush that
+    // renders the completed answer runs with the stream already final —
+    // stream-controller then classifies that edit `critical` for the send
+    // gate (never shed; fails fast with a structured FLOOD_WAIT_ACTIVE on a
+    // long flood window) while intermediate draft edits stay `cosmetic`
+    // (sheddable). The previous update()-then-finalize() pair flushed the
+    // final text inside update(), i.e. as an ordinary sheddable draft edit.
+    await stream.finalize(effectiveText)
     state.activeDraftStreams.delete(sKey)
     // #1713: stream_reply done=true is a NON-EVENT for the status
     // reaction. The reaction reflects current turn activity, not

--- a/telegram-plugin/tests/bot-api.harness.ts
+++ b/telegram-plugin/tests/bot-api.harness.ts
@@ -84,7 +84,11 @@ export function createMockBot(startMessageId = 500): MockBot {
   const api: MockBotApi = {
     sendMessage: vi.fn(async () => ({ message_id: state.nextMessageId++ })),
     sendRichMessage: vi.fn(async () => ({ message_id: state.nextMessageId++ })),
-    editMessageText: vi.fn(async () => undefined),
+    // Faithful to grammy: editMessageText resolves `Message | true`, NEVER
+    // undefined. An `undefined` from the production retry stack means the
+    // send gate shed/skipped the call (#3110) — stream-controller treats it
+    // as not-landed — so the mock default must not be undefined.
+    editMessageText: vi.fn(async () => true as const),
     deleteMessage: vi.fn(async () => true as const),
     setMessageReaction: vi.fn(async () => true as const),
     editMessageReplyMarkup: vi.fn(async () => undefined),
@@ -122,7 +126,8 @@ export function installBotResetHook(bot: MockBot): void {
     bot.api.sendRichMessage.mockImplementation(async () => ({
       message_id: bot.nextMessageId++,
     }))
-    bot.api.editMessageText.mockImplementation(async () => undefined)
+    // Faithful to grammy: `Message | true`, never undefined (see above).
+    bot.api.editMessageText.mockImplementation(async () => true as const)
     bot.api.deleteMessage.mockImplementation(async () => true as const)
     bot.api.setMessageReaction.mockImplementation(async () => true as const)
     bot.api.editMessageReplyMarkup.mockImplementation(async () => undefined)

--- a/telegram-plugin/tests/draft-stream.test.ts
+++ b/telegram-plugin/tests/draft-stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { createDraftStream } from '../draft-stream.js'
+import { createDraftStream, makeDraftEditShedError } from '../draft-stream.js'
 
 interface MockTelegram {
   send: (text: string) => Promise<number>
@@ -165,6 +165,72 @@ describe('createDraftStream', () => {
     expect(m.editCalls[0].text).toBe('the completed answer')
     expect(finalAtEdit).toEqual([true])
     expect(stream.isFinal()).toBe(true)
+  })
+
+  it('a shed flush preserves the snapshot; argument-less finalize() re-delivers it (#3110 F2)', async () => {
+    const m = makeMock()
+    let shedNext = true
+    const stream = createDraftStream(
+      m.send,
+      async (id, text) => {
+        if (shedNext) {
+          shedNext = false
+          throw makeDraftEditShedError(id)
+        }
+        await m.edit(id, text)
+      },
+      { throttleMs: 1000 },
+    )
+
+    void stream.update('v1')
+    await microtaskFlush()
+    expect(m.sendCalls.length).toBe(1)
+
+    void stream.update('v2 — shed by the gate')
+    vi.advanceTimersByTime(1000)
+    await microtaskFlush()
+    // The edit was shed: nothing landed, and the snapshot must NOT be
+    // recorded as sent.
+    expect(m.editCalls.length).toBe(0)
+
+    // The gateway's cleanup paths finalize with NO argument — the shed
+    // snapshot must be re-flushed as the stream's final state, not lost.
+    await stream.finalize()
+    expect(m.editCalls.length).toBe(1)
+    expect(m.editCalls[0].text).toBe('v2 — shed by the gate')
+  })
+
+  it('a newer landed flush supersedes an earlier shed snapshot (no stale resurrect)', async () => {
+    const m = makeMock()
+    let shedNext = true
+    const stream = createDraftStream(
+      m.send,
+      async (id, text) => {
+        if (shedNext) {
+          shedNext = false
+          throw makeDraftEditShedError(id)
+        }
+        await m.edit(id, text)
+      },
+      { throttleMs: 1000 },
+    )
+
+    void stream.update('v1')
+    await microtaskFlush()
+    void stream.update('v2 — shed')
+    vi.advanceTimersByTime(1000)
+    await microtaskFlush()
+    expect(m.editCalls.length).toBe(0)
+
+    // A NEWER snapshot lands normally — the shed one is now stale.
+    void stream.update('v3 — landed')
+    vi.advanceTimersByTime(1000)
+    await microtaskFlush()
+    expect(m.editCalls.map((c) => c.text)).toEqual(['v3 — landed'])
+
+    // finalize() must NOT resurrect the superseded shed snapshot.
+    await stream.finalize()
+    expect(m.editCalls.map((c) => c.text)).toEqual(['v3 — landed'])
   })
 
   it('finalize(finalText) still dedupes against text that actually landed', async () => {

--- a/telegram-plugin/tests/draft-stream.test.ts
+++ b/telegram-plugin/tests/draft-stream.test.ts
@@ -137,6 +137,49 @@ describe('createDraftStream', () => {
     expect(stream.isFinal()).toBe(true)
   })
 
+  it('finalize(finalText) flushes the supplied snapshot with the stream already final (#3110)', async () => {
+    const m = makeMock()
+    // Capture what isFinal() reads AT EDIT TIME — the transport layer
+    // (stream-controller) classifies the send-gate priority from exactly
+    // this signal, so the final snapshot MUST flush with final=true.
+    const finalAtEdit: boolean[] = []
+    const stream = createDraftStream(
+      m.send,
+      async (id, text) => {
+        finalAtEdit.push(stream.isFinal())
+        await m.edit(id, text)
+      },
+      { throttleMs: 1000 },
+    )
+
+    void stream.update('initial')
+    await microtaskFlush()
+    expect(m.sendCalls.length).toBe(1)
+
+    // A stale draft is pending; finalize(text) supersedes it (last-write-wins).
+    void stream.update('stale draft')
+    await microtaskFlush()
+    await stream.finalize('the completed answer')
+
+    expect(m.editCalls.length).toBe(1)
+    expect(m.editCalls[0].text).toBe('the completed answer')
+    expect(finalAtEdit).toEqual([true])
+    expect(stream.isFinal()).toBe(true)
+  })
+
+  it('finalize(finalText) still dedupes against text that actually landed', async () => {
+    const m = makeMock()
+    const stream = createDraftStream(m.send, m.edit, { throttleMs: 1000 })
+
+    void stream.update('the answer')
+    await microtaskFlush()
+    expect(m.sendCalls.length).toBe(1)
+
+    // Same text again as the final snapshot → already on screen, no edit.
+    await stream.finalize('the answer')
+    expect(m.editCalls.length).toBe(0)
+  })
+
   it('updates after finalize are silently dropped', async () => {
     const m = makeMock()
     const stream = createDraftStream(m.send, m.edit, { throttleMs: 1000 })

--- a/telegram-plugin/tests/flood-windows-persistence.test.ts
+++ b/telegram-plugin/tests/flood-windows-persistence.test.ts
@@ -14,7 +14,7 @@ import {
   FLOOD_STATE_MODE,
   FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS,
 } from '../flood-circuit-breaker.js'
-import { createSendGate, type Clock } from '../send-gate.js'
+import { createSendGate, SEND_GATE_SHED, type Clock } from '../send-gate.js'
 
 /**
  * #3084 PR 2 — restart-proof SCOPED flood windows (part3-design §7). Verifies
@@ -119,7 +119,7 @@ describe('#3084 scoped flood-window persistence', () => {
       chat_id: '7',
       priorityClass: 'cosmetic',
     })
-    expect(res).toBeUndefined()
+    expect(res).toBe(SEND_GATE_SHED) // shed sentinel (#3110 F1)
     expect(gate2.stats().global.shed).toBe(1)
 
     // And a critical into the still-long window fails fast — restart did not

--- a/telegram-plugin/tests/reaction-gate-routing.test.ts
+++ b/telegram-plugin/tests/reaction-gate-routing.test.ts
@@ -29,7 +29,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { createSendGate, type Clock } from '../send-gate.js'
+import { createSendGate, SEND_GATE_SHED, type Clock } from '../send-gate.js'
 import { createRetryApiCall } from '../retry-api-call.js'
 import { errors } from './fake-bot-api.js'
 
@@ -95,7 +95,7 @@ describe('#3155 reactions route through the send gate (cosmetic)', () => {
     // resolves undefined (fire-and-forget callers .catch nothing), and the gate
     // counts the shed.
     expect(setMessageReaction).not.toHaveBeenCalled()
-    expect(result).toBeUndefined()
+    expect(result).toBe(SEND_GATE_SHED) // shed sentinel (#3110 F1)
     expect(sendGate.stats().global.shed).toBe(1)
   })
 

--- a/telegram-plugin/tests/stream-controller-send-gate.test.ts
+++ b/telegram-plugin/tests/stream-controller-send-gate.test.ts
@@ -192,10 +192,10 @@ describe('stream-controller × send gate (#3110)', () => {
     expect(bot.api.editMessageText).toHaveBeenCalledTimes(1)
 
     await clock.advance(1500) // clear the floor — isolate the no-op skip
-    const second = createStreamController({
-      bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777,
-    })
     const onEdit = vi.fn()
+    const second = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777, onEdit,
+    })
     void second.update('**status: done**')
     await flush()
 

--- a/telegram-plugin/tests/stream-controller-send-gate.test.ts
+++ b/telegram-plugin/tests/stream-controller-send-gate.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Integration tests: `createStreamController` driven through a REAL
+ * `createSendGate` (#3110).
+ *
+ * Production wires stream-controller's `retry` to the gateway's
+ * `robustApiCall`, which is the send gate wrapped over the retry policy —
+ * so what the gate does to the opts a call site passes IS the production
+ * behavior. Before #3110 the controller passed only `{ threadId, chat_id }`,
+ * the gate saw ordinary sends, and the draft stream's own 400 ms DM throttle
+ * drove same-message editMessageText straight past the >=1.5s per-message
+ * edit floor — the #1 documented flood-ban trigger (part3-design §4;
+ * production ~6h ban 2026-07-12).
+ *
+ * These tests pin the wiring end to end:
+ *   - draft edits inside the floor never reach the API; intermediates
+ *     collapse; the latest snapshot lands floor-paced
+ *   - the floor is per-message (stream A does not delay stream B)
+ *   - the gate's no-op skip drops a repeat payload for the same message
+ *   - an open flood window sheds draft edits with ZERO API calls, and the
+ *     stream recovers with full state after the window closes
+ *   - a shed draft is NOT recorded as delivered — a later flush of the
+ *     SAME text (the completed answer) still lands
+ *   - the finalize flush is `critical`: never shed; waits out a short
+ *     window; fails fast (structured, logged) on a long one
+ *   - regression pin: the controller passes messageId / editPayload /
+ *     priorityClass through the retry policy on every edit
+ *
+ * Two clocks, deliberately separate: vitest fake timers drive draft-stream's
+ * internal `setTimeout` throttle (only `setTimeout`/`clearTimeout` are faked
+ * so the gate's microtask pump below stays real); the gate runs on the same
+ * injectable fake `Clock` used by send-gate.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createStreamController, type RetryPolicy } from '../stream-controller.js'
+import { createSendGate, type Clock, type SendGateConfig } from '../send-gate.js'
+import { isFloodWaitActiveError } from '../retry-api-call.js'
+import { createMockBot, installBotResetHook } from './bot-api.harness.js'
+
+/** Deterministic fake clock — same contract as send-gate.test.ts's. */
+class FakeClock implements Clock {
+  private cur = 0
+  private seq = 0
+  private timers: { at: number; id: number; resolve: () => void }[] = []
+
+  now(): number {
+    return this.cur
+  }
+
+  sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.timers.push({ at: this.cur + ms, id: this.seq++, resolve })
+    })
+  }
+
+  async advance(ms: number): Promise<void> {
+    const target = this.cur + ms
+    for (;;) {
+      const due = this.timers
+        .filter((t) => t.at <= target)
+        .sort((a, b) => a.at - b.at || a.id - b.id)
+      if (due.length === 0) break
+      const t = due[0]
+      this.timers = this.timers.filter((x) => x !== t)
+      this.cur = t.at
+      t.resolve()
+      await flush()
+    }
+    this.cur = target
+  }
+}
+
+/** Flush pending microtasks via a REAL macrotask hop (setImmediate is not faked). */
+function flush(): Promise<void> {
+  return new Promise<void>((r) => setImmediate(r))
+}
+
+/** A real send gate on a fake clock, exposed as a stream-controller RetryPolicy. */
+function makeGatedRetry(cfg: Partial<SendGateConfig> = {}) {
+  const clock = new FakeClock()
+  const gate = createSendGate({ enabled: true, clock, jitter: () => 0, ...cfg })
+  const retry: RetryPolicy = (fn, opts) => gate.gate(fn, opts)
+  return { clock, gate, retry }
+}
+
+describe('stream-controller × send gate (#3110)', () => {
+  const bot = createMockBot()
+  installBotResetHook(bot)
+
+  // Fake ONLY draft-stream's throttle timers. The gate's fake clock is
+  // driven explicitly; its microtask pump (setImmediate) must stay real.
+  beforeEach(() => vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] }))
+  afterEach(() => vi.useRealTimers())
+
+  /** Release draft-stream's local throttle, then settle microtasks. */
+  async function tick(throttleMs = 250): Promise<void> {
+    vi.advanceTimersByTime(throttleMs)
+    await flush()
+  }
+
+  const editBodies = () =>
+    bot.api.editMessageText.mock.calls.map(([, , text]) =>
+      typeof text === 'object' && text != null ? text.markdown : text,
+    )
+
+  it('draft edits inside the floor never hit the API; intermediates collapse; latest lands floor-paced', async () => {
+    const { clock, retry } = makeGatedRetry({ editFloorMs: 1500 })
+    // Record the FAKE-clock time of every editMessageText that reaches the API.
+    const editTimes: number[] = []
+    bot.api.editMessageText.mockImplementation(async () => {
+      editTimes.push(clock.now())
+      return true as const
+    })
+    const stream = createStreamController({ bot, chatId: '1', throttleMs: 250, retry })
+
+    // Anchor send, then the first edit — no prior edit on the message, so the
+    // gate admits it immediately.
+    void stream.update('draft 1')
+    await flush()
+    expect(bot.api.sendRichMessage).toHaveBeenCalledTimes(1)
+    void stream.update('draft 2')
+    await tick()
+    expect(editBodies()).toEqual(['draft 2'])
+
+    // Three rapid snapshots inside the 1.5s floor: d3 reaches the gate (edit
+    // floor holds it); d4 and d5 arrive while that edit is in flight, so
+    // draft-stream's own last-write-wins collapses d4 — it must NEVER reach
+    // the API.
+    void stream.update('draft 3')
+    await tick()
+    void stream.update('draft 4')
+    void stream.update('draft 5')
+    await flush()
+    // Still inside the floor: nothing new hit the API.
+    expect(editBodies()).toEqual(['draft 2'])
+
+    await clock.advance(1500) // floor clears → d3 lands; d5 flushes into the gate
+    await clock.advance(1500) // next floor clears → d5 lands
+    expect(editBodies()).toEqual(['draft 2', 'draft 3', 'draft 5'])
+    // Wire spacing is the gate floor, not the 250 ms local throttle.
+    expect(editTimes).toEqual([0, 1500, 3000])
+  })
+
+  it('the edit floor is per-message: stream B is not delayed by stream A holding its floor', async () => {
+    const { clock, retry } = makeGatedRetry({ editFloorMs: 1500 })
+    const editTimes = new Map<number, number[]>()
+    bot.api.editMessageText.mockImplementation(async (_chat, id) => {
+      const arr = editTimes.get(id) ?? []
+      arr.push(clock.now())
+      editTimes.set(id, arr)
+      return true as const
+    })
+    // Two chats → independent per-chat buckets; ONE shared gate (as in the
+    // gateway, where every surface transits the same robustApiCall).
+    const a = createStreamController({ bot, chatId: '100', throttleMs: 250, retry })
+    const b = createStreamController({ bot, chatId: '200', throttleMs: 250, retry })
+
+    void a.update('a1')
+    void b.update('b1')
+    await flush()
+    void a.update('a2')
+    void b.update('b2')
+    await tick()
+    // First edit per message admits immediately on each message's own floor.
+    const idA = a.getMessageId() as number
+    const idB = b.getMessageId() as number
+    expect(editTimes.get(idA)).toEqual([0])
+    expect(editTimes.get(idB)).toEqual([0])
+
+    // Refill the global bucket a little so the cosmetic shed check (token
+    // pressure) doesn't fire — this test isolates the FLOOR.
+    await clock.advance(400)
+    void a.update('a3')
+    void b.update('b3')
+    await tick()
+    expect(editTimes.get(idA)).toEqual([0]) // held by A's floor…
+    expect(editTimes.get(idB)).toEqual([0]) // …and B by B's own, not A's.
+
+    await clock.advance(1100) // 400 + 1100 = 1500 → BOTH floors clear together
+    expect(editTimes.get(idA)).toEqual([0, 1500])
+    expect(editTimes.get(idB)).toEqual([0, 1500])
+  })
+
+  it('gate no-op skip: a second surface repeating the on-screen payload never reaches the API', async () => {
+    const { clock, gate, retry } = makeGatedRetry({ editFloorMs: 1500 })
+    // Two controllers re-attached to the SAME anchor message (the #626
+    // initialMessageId path — e.g. a stream re-created after a restart).
+    const first = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777,
+    })
+    void first.update('**status: done**')
+    await flush()
+    expect(bot.api.editMessageText).toHaveBeenCalledTimes(1)
+
+    await clock.advance(1500) // clear the floor — isolate the no-op skip
+    const second = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777,
+    })
+    const onEdit = vi.fn()
+    void second.update('**status: done**')
+    await flush()
+
+    // Identical rendered payload for the same chat+message → dropped by the
+    // gate before the API.
+    expect(bot.api.editMessageText).toHaveBeenCalledTimes(1)
+    expect(gate.stats().global.dropped).toBe(1)
+    expect(onEdit).not.toHaveBeenCalled()
+  })
+
+  it('open flood window: draft edits shed with ZERO API calls; full state lands after it closes', async () => {
+    const { clock, gate, retry } = makeGatedRetry({ editFloorMs: 1500 })
+    const stream = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777,
+    })
+
+    gate.openFloodWindow('global', clock.now() + 30_000)
+
+    void stream.update('draft a')
+    await flush()
+    void stream.update('draft b')
+    await tick()
+    // Both drafts shed as cosmetic — nothing reached the API.
+    expect(bot.api.editMessageText).not.toHaveBeenCalled()
+    expect(gate.stats().global.shed).toBe(2)
+
+    await clock.advance(30_000) // window closes
+    void stream.update('draft c — full state')
+    await tick()
+    expect(editBodies()).toEqual(['draft c — full state'])
+  })
+
+  it('a shed draft is NOT recorded as delivered: a later finalize of the SAME text still lands', async () => {
+    const { clock, gate, retry } = makeGatedRetry({ editFloorMs: 1500 })
+    const stream = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777,
+    })
+
+    gate.openFloodWindow('global', clock.now() + 30_000)
+    void stream.update('the completed answer')
+    await flush()
+    expect(bot.api.editMessageText).not.toHaveBeenCalled()
+    expect(gate.stats().global.shed).toBe(1)
+
+    await clock.advance(30_000)
+    // stream_reply done=true with the same text → finalize(text). If the shed
+    // draft had been recorded as on-screen, draft-stream's dedupe would skip
+    // this flush and the completed answer would never render.
+    await stream.finalize('the completed answer')
+    expect(editBodies()).toEqual(['the completed answer'])
+  })
+
+  it('finalize is critical: not shed by an open short window — waits it out, then lands', async () => {
+    const { clock, gate, retry } = makeGatedRetry({ editFloorMs: 1500 })
+    const editTimes: number[] = []
+    bot.api.editMessageText.mockImplementation(async () => {
+      editTimes.push(clock.now())
+      return true as const
+    })
+    const stream = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777,
+    })
+
+    gate.openFloodWindow('global', clock.now() + 30_000) // short: <= 60s fail-fast ceiling
+    void stream.update('draft while banned')
+    await flush()
+    expect(bot.api.editMessageText).not.toHaveBeenCalled() // draft shed
+
+    const fin = stream.finalize('the answer')
+    await flush()
+    // Critical: NOT shed — queued against the window, still zero API calls.
+    expect(bot.api.editMessageText).not.toHaveBeenCalled()
+
+    await clock.advance(30_000)
+    await fin
+    expect(editBodies()).toEqual(['the answer'])
+    expect(editTimes).toEqual([30_000])
+    expect(gate.stats().global.shed).toBe(1) // only the draft
+  })
+
+  it('finalize under a LONG window fails fast (structured FLOOD_WAIT_ACTIVE, logged) — no API call, no hang', async () => {
+    const { clock, gate, retry } = makeGatedRetry({ editFloorMs: 1500 })
+    const logs: string[] = []
+    const stream = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777,
+      log: (m) => logs.push(m),
+    })
+
+    gate.openFloodWindow('global', clock.now() + 21_397_000) // the 2026-07-12 ban: ~5.9h
+    const fin = stream.finalize('the answer')
+    await flush()
+    await fin // resolves — draft-stream surfaces the failure via log, not a hang
+
+    expect(bot.api.editMessageText).not.toHaveBeenCalled()
+    expect(gate.stats().global.failedFast).toBe(1)
+    expect(logs.some((m) => m.includes('FLOOD_WAIT_ACTIVE'))).toBe(true)
+    // Sanity: the gate's structured error shape is what the reply path keys on.
+    try {
+      await retry(async () => true, { chat_id: '1', priorityClass: 'critical' })
+      expect.unreachable('critical send during a long window must fail fast')
+    } catch (err) {
+      expect(isFloodWaitActiveError(err)).toBe(true)
+    }
+  })
+
+  it('REGRESSION PIN: every edit passes messageId / editPayload / priorityClass to the retry policy', async () => {
+    // Spy retry with NO gate — pins exactly what the controller hands to
+    // robustApiCall (the #3110 bypass was these fields being absent).
+    const seen: Array<Record<string, unknown> | undefined> = []
+    const retry: RetryPolicy = (fn, opts) => {
+      seen.push(opts as Record<string, unknown> | undefined)
+      return fn()
+    }
+    const stream = createStreamController({ bot, chatId: '9', threadId: 3, throttleMs: 250, retry })
+
+    void stream.update('draft')
+    await flush()
+    // The anchor SEND stays untagged: the gate admits untagged non-edit
+    // sends as critical, and a shed send would break message-id capture.
+    expect(seen[0]).toEqual({ threadId: 3, chat_id: '9' })
+
+    void stream.update('draft v2')
+    await tick()
+    const id = stream.getMessageId() as number
+    expect(seen[1]).toEqual({
+      threadId: 3,
+      chat_id: '9',
+      messageId: id,
+      editPayload: { markdown: 'draft v2' },
+      priorityClass: 'cosmetic',
+    })
+
+    await stream.finalize('the final answer')
+    expect(seen[2]).toEqual({
+      threadId: 3,
+      chat_id: '9',
+      messageId: id,
+      editPayload: { markdown: 'the final answer' },
+      priorityClass: 'critical',
+    })
+  })
+
+  it('REGRESSION PIN: the plain parse-entities fallback edit carries the gate fields too', async () => {
+    const seen: Array<Record<string, unknown> | undefined> = []
+    const retry: RetryPolicy = (fn, opts) => {
+      seen.push(opts as Record<string, unknown> | undefined)
+      return fn()
+    }
+    const stream = createStreamController({ bot, chatId: '9', throttleMs: 250, retry })
+    void stream.update('draft')
+    await flush()
+    const id = stream.getMessageId() as number
+
+    // Rich edit 400s with a parse-entities rejection → same-id plain fallback.
+    const { GrammyError } = await import('grammy')
+    bot.api.editMessageText.mockRejectedValueOnce(
+      new GrammyError(
+        "Bad Request: can't parse entities",
+        { ok: false, error_code: 400, description: "Bad Request: can't parse entities" },
+        'editMessageText',
+        {},
+      ),
+    )
+    void stream.update('draft *broken')
+    await tick()
+
+    expect(bot.api.editMessageText).toHaveBeenCalledTimes(2)
+    // The fallback is an EDIT of the same message: gate fields present, and
+    // the payload is the PLAIN body (hashes differently from the rich form,
+    // so the gate never no-op-drops the recovery edit).
+    expect(seen[2]).toEqual({
+      threadId: undefined,
+      chat_id: '9',
+      messageId: id,
+      editPayload: 'draft *broken',
+      priorityClass: 'cosmetic',
+    })
+  })
+})

--- a/telegram-plugin/tests/stream-controller-send-gate.test.ts
+++ b/telegram-plugin/tests/stream-controller-send-gate.test.ts
@@ -34,6 +34,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createStreamController, type RetryPolicy } from '../stream-controller.js'
 import { createSendGate, type Clock, type SendGateConfig } from '../send-gate.js'
 import { isFloodWaitActiveError } from '../retry-api-call.js'
+import { renderOutboundChunks } from '../render/rich-render.js'
 import { createMockBot, installBotResetHook } from './bot-api.harness.js'
 
 /** Deterministic fake clock — same contract as send-gate.test.ts's. */
@@ -180,7 +181,7 @@ describe('stream-controller × send gate (#3110)', () => {
     expect(editTimes.get(idB)).toEqual([0, 1500])
   })
 
-  it('gate no-op skip: a second surface repeating the on-screen payload never reaches the API', async () => {
+  it('gate no-op skip: a repeated payload is dropped BENIGNLY — no API call, treated as delivered (F4)', async () => {
     const { clock, gate, retry } = makeGatedRetry({ editFloorMs: 1500 })
     // Two controllers re-attached to the SAME anchor message (the #626
     // initialMessageId path — e.g. a stream re-created after a restart).
@@ -193,17 +194,31 @@ describe('stream-controller × send gate (#3110)', () => {
 
     await clock.advance(1500) // clear the floor — isolate the no-op skip
     const onEdit = vi.fn()
+    const logs: string[] = []
     const second = createStreamController({
       bot, chatId: '1', throttleMs: 250, retry, initialMessageId: 7777, onEdit,
+      log: (m) => logs.push(m),
     })
     void second.update('**status: done**')
     await flush()
 
     // Identical rendered payload for the same chat+message → dropped by the
-    // gate before the API.
+    // gate before the API…
     expect(bot.api.editMessageText).toHaveBeenCalledTimes(1)
     expect(gate.stats().global.dropped).toBe(1)
-    expect(onEdit).not.toHaveBeenCalled()
+    // …and the drop is BENIGN (the payload IS on screen): the controller
+    // reports it as delivered — onEdit fires, no shed marker, no failure log
+    // (F4: pre-sentinel this test passed via the wrong mechanism — the
+    // drop's `undefined` was misread as a shed and onEdit stayed silent).
+    expect(onEdit).toHaveBeenCalledTimes(1)
+    expect(logs.filter((m) => m.includes('shed') || m.includes('edit failed'))).toEqual([])
+
+    // Because the drop was recorded as delivered, a THIRD identical update
+    // dedupes inside draft-stream itself — it never even reaches the gate.
+    void second.update('**status: done**')
+    await tick() // release the local throttle so the dedupe check runs
+    expect(gate.stats().global.dropped).toBe(1) // unchanged — gate never consulted
+    expect(bot.api.editMessageText).toHaveBeenCalledTimes(1)
   })
 
   it('open flood window: draft edits shed with ZERO API calls; full state lands after it closes', async () => {
@@ -373,5 +388,134 @@ describe('stream-controller × send gate (#3110)', () => {
       editPayload: 'draft *broken',
       priorityClass: 'cosmetic',
     })
+  })
+
+  /**
+   * The reviewer's F1 production-faithful probe: a multi-piece body (the
+   * escaped-markdown expansion splits it across several wire-cap pieces)
+   * where only the TAIL grows across flushes. The anchor piece stops
+   * changing, so on a perfectly healthy chat its edit resolves `undefined`
+   * every flush — first via robustApiCall's swallowed "message is not
+   * modified" 400, then via the gate's no-op drop. Pre-sentinel, that
+   * `undefined` was misread as a shed and thrown BEFORE the tail loop: no
+   * tail edit ever landed (screen frozen at "tail v1") and a false "shed"
+   * line hit stderr every flush.
+   */
+  it('multi-piece body: a benign anchor outcome never starves the tail edits (F1)', async () => {
+    const { clock, gate, retry } = makeGatedRetry({
+      editFloorMs: 1500,
+      // Generous buckets: this test isolates the benign-undefined path, not
+      // token pressure.
+      globalPerSec: 1000, globalBurst: 100, perChatPerSec: 1000, perChatBurst: 100,
+    })
+    const base = ('a_b_c_d_e ').repeat(3000)
+    const b1 = `${base}tail v1`
+    const b2 = `${base}tail v2`
+    const b3 = `${base}tail v3`
+    // Sanity-pin the repro geometry: several pieces, prefix-stable chunking,
+    // only the LAST piece changes as the tail grows.
+    const p1 = renderOutboundChunks(b1)
+    const p2 = renderOutboundChunks(b2)
+    expect(p1.length).toBeGreaterThan(1)
+    expect(p2.length).toBe(p1.length)
+    for (let i = 0; i < p1.length - 1; i++) expect(p2[i].text).toBe(p1[i].text)
+    expect(p2[p1.length - 1].text).not.toBe(p1[p1.length - 1].text)
+
+    // Faithful edit mock: repeating a message's current text 400s with
+    // "message is not modified", which the production retry policy swallows
+    // to `undefined` — simulate the post-swallow result directly.
+    const currentText = new Map<number, string>()
+    bot.api.sendMessage.mockImplementation(async (_c, text) => {
+      const id = bot.nextMessageId++
+      currentText.set(id, text)
+      return { message_id: id }
+    })
+    bot.api.editMessageText.mockImplementation(async (_c, id, text) => {
+      const body = typeof text === 'object' && text != null ? text.markdown : text
+      if (currentText.get(id) === body) return undefined // swallowed not-modified
+      currentText.set(id, body)
+      return true as const
+    })
+
+    const logs: string[] = []
+    const stream = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry,
+      log: (m) => logs.push(m), warn: (m) => logs.push(m),
+    })
+
+    void stream.update(b1)
+    await flush()
+    const anchorId = stream.getMessageId() as number
+    const lastTailId = anchorId + p1.length - 1
+    expect(bot.api.sendMessage).toHaveBeenCalledTimes(p1.length)
+    expect(currentText.get(lastTailId)).toContain('tail v1')
+
+    // Flush 2: anchor unchanged → its edit resolves undefined via the
+    // not-modified swallow. The tail edit MUST still land.
+    void stream.update(b2)
+    await tick()
+    expect(currentText.get(lastTailId)).toContain('tail v2')
+
+    // Flush 3: anchor unchanged again → this time the GATE no-op-drops it
+    // (its hash is recorded from flush 2). The tail edit MUST still land.
+    await clock.advance(1600) // clear the tail message's own edit floor
+    void stream.update(b3)
+    await tick()
+    expect(currentText.get(lastTailId)).toContain('tail v3')
+    expect(gate.stats().global.dropped).toBeGreaterThanOrEqual(1)
+
+    // The whole run was healthy: no shed marker, no failure lines.
+    expect(logs.filter((m) => m.includes('shed') || m.includes('FAILED') || m.includes('edit failed'))).toEqual([])
+
+    // And the flushes were recorded as delivered: an identical finalize
+    // dedupes inside draft-stream — zero further API calls.
+    const editCalls = bot.api.editMessageText.mock.calls.length
+    await stream.finalize(b3)
+    expect(bot.api.editMessageText.mock.calls.length).toBe(editCalls)
+  })
+
+  it('a shed TAIL is not recorded as delivered: argument-less finalize() re-flushes and lands it (F2+F3)', async () => {
+    const { clock, gate, retry } = makeGatedRetry({
+      editFloorMs: 1500,
+      globalPerSec: 1000, globalBurst: 100, perChatPerSec: 1000, perChatBurst: 100,
+    })
+    const base = ('a_b_c_d_e ').repeat(3000)
+    const b1 = `${base}tail v1`
+    const b2 = `${base}tail v2 — the completed answer`
+    const pieceCount = renderOutboundChunks(b1).length
+    expect(pieceCount).toBeGreaterThan(1)
+
+    const logs: string[] = []
+    const stream = createStreamController({
+      bot, chatId: '1', throttleMs: 250, retry, log: (m) => logs.push(m),
+    })
+    void stream.update(b1)
+    await flush()
+    const anchorId = stream.getMessageId() as number
+    const lastTailId = anchorId + pieceCount - 1
+
+    // Flood window scoped to the LAST tail message only (H1 msg-edit scope):
+    // its edit sheds; the anchor and other pieces are unaffected.
+    gate.openFloodWindow(`msg-edit:1:${lastTailId}`, clock.now() + 30_000)
+
+    void stream.update(b2)
+    await tick()
+    // The changed piece is the suppressed tail → shed, zero edits landed on
+    // it; the flush is reported shed and the snapshot preserved (F2), NOT
+    // recorded as delivered (F3).
+    const tailEdits = () =>
+      bot.api.editMessageText.mock.calls.filter(([, id]) => id === lastTailId)
+    expect(tailEdits()).toHaveLength(0)
+    expect(gate.stats().global.shed).toBe(1)
+    expect(logs.some((m) => m.includes('shed by send gate'))).toBe(true)
+
+    // Window closes; the gateway-style ARGUMENT-LESS finalize (the
+    // disconnect-flush / turn-end cleanup path) must re-deliver the shed
+    // snapshot — pre-F2 the content was silently lost here.
+    await clock.advance(31_000)
+    await stream.finalize()
+    expect(tailEdits()).toHaveLength(1)
+    const [, , tailBody] = tailEdits()[0]
+    expect(String(tailBody)).toContain('tail v2')
   })
 })

--- a/telegram-plugin/tests/stream-reply-handler.test.ts
+++ b/telegram-plugin/tests/stream-reply-handler.test.ts
@@ -207,6 +207,50 @@ describe('handleStreamReply', () => {
     expect(state.activeDraftStreams.size).toBe(0)
   })
 
+  it('done=true routes the final text through finalize(text) — the answer edit is CRITICAL for the send gate, drafts cosmetic (#3110)', async () => {
+    const state = makeState()
+    // Spy retry: pins exactly what reaches robustApiCall (= the send gate).
+    const seen: Array<Record<string, unknown> | undefined> = []
+    const retry = (<T,>(fn: () => Promise<T>, opts?: unknown) => {
+      seen.push(opts as Record<string, unknown> | undefined)
+      return fn()
+    }) as StreamReplyDeps['retry']
+    const deps = makeDeps(bot, { retry })
+
+    // Turn start → anchor send.
+    let pending = handleStreamReply({ chat_id: '1', text: 'thinking…' }, state, deps)
+    await microtaskFlush()
+    await pending
+
+    // Intermediate snapshot → a sheddable (cosmetic) draft edit.
+    pending = handleStreamReply({ chat_id: '1', text: 'half the answer' }, state, deps)
+    await microtaskFlush()
+    vi.advanceTimersByTime(600) // release the local throttle
+    await microtaskFlush()
+    await pending
+
+    // done=true → the completed answer flushes via finalize(text): the edit
+    // runs with the stream already final and is tagged critical — never shed
+    // as a draft under flood pressure.
+    pending = handleStreamReply(
+      { chat_id: '1', text: 'the full answer', done: true },
+      state,
+      deps,
+    )
+    await microtaskFlush()
+    const result = await pending
+
+    expect(result.status).toBe('finalized')
+    expect(richEditMarkdown(bot, 1)).toBe('the full answer')
+    expect(seen[0]).toEqual({ threadId: undefined, chat_id: '1' }) // anchor send: untagged
+    expect(seen[1]).toMatchObject({ messageId: 500, priorityClass: 'cosmetic' })
+    expect(seen[2]).toMatchObject({
+      messageId: 500,
+      priorityClass: 'critical',
+      editPayload: { markdown: 'the full answer' },
+    })
+  })
+
   it('done=true on a named lane does NOT fire terminal 👍', async () => {
     const state = makeState()
     const deps = makeDeps(bot)


### PR DESCRIPTION
## Summary

`stream-controller.ts` drove rapid same-message `editMessageText` through its own 400 ms DM / 1000 ms group throttle and called `robustApiCall` with only `{ threadId, chat_id }` — omitting `messageId` / `editPayload` / `priorityClass` — so the send gate treated the draft/answer stream as ordinary sends and its per-message edit floor (>=1.5 s), last-write-wins coalescing, no-op skip, and cosmetic shedding never applied. part3-design §4 names rapid same-message edits as the #1 documented flood-ban trigger, and this exact bypass produced a production 429 with `retry_after=21397s` (~6 h) on 2026-07-12: draft edits 472 ms apart, consistent with the 400 ms DM throttle (evidence on #3110).

Fixes #3110 (carried follow-up from #3084 PR 2 review L3).

## What changed

- **`stream-controller.ts`** — `RetryPolicy` opts widened to `SendGateOpts & { threadId?: number }` (structural superset, assignable to `RetryCallOpts`; type-only import). All four edit call sites (anchor edit, anchor plain parse-fallback, tail edit, tail plain parse-fallback) now pass `messageId` + `editPayload` (the exact wire payload, rich wrapper included) + `priorityClass`. The local throttle stays as a cheap pre-filter; the gate is the authority.
- **Priority classes** — intermediate draft edits are `cosmetic` (part3-design §2 lists "stream updates" there): shed under pressure / an open flood window; the next flush carries full state. The finalize flush is `critical`, mirroring the reply path's preview-finalize convention (`gateway.ts` `editPreview`): never shed, waits out a short window, fails fast with a structured `FLOOD_WAIT_ACTIVE` on a long one. Sends stay untagged (gate admits untagged non-edit sends as `critical`) — a shed send resolves `undefined` and would break message-id capture.
- **Shed honesty (reworked per review F1–F3)** — the gate's shed paths now resolve a distinguishable exported `SEND_GATE_SHED` sentinel (`Symbol.for`-keyed) instead of `undefined`, which was overloaded (gate no-op drop and robustApiCall's swallowed benign 400s also resolved `undefined`). stream-controller keys shed detection off `isSendGateShed()` exactly; benign `undefined` resolutions are treated as delivered. The anchor's shed outcome is decided AFTER the tail-upsert loop (a benign or shed anchor never starves tails), and ANY shed piece marks the flush not-delivered. draft-stream recognizes the property-tagged `DraftEditShedError`, preserves the shed snapshot in `shedText` (not `pendingText` — avoids a flushLoop busy-spin against an open window), and `finalize()` — with or without `finalText` — re-flushes it as the stream's final critical state, so argument-less cleanup finalizes (disconnect-flush, turn-end, PTY previews) no longer lose content.
- **`draft-stream.ts`** — `finalize(finalText?)`: an optional final snapshot that supersedes any pending draft (last-write-wins) and flushes with `final` already set. Needed because `stream_reply done=true` used to flush the final text inside `update()` — i.e. before the stream was final — which would have classified the completed answer as a sheddable draft.
- **`stream-reply-handler.ts`** — `done=true` routes the text through `stream.finalize(effectiveText)` instead of `update()` + `finalize()`. Side effect: the final flush no longer waits out the local throttle window.
- **`tests/bot-api.harness.ts`** — mock `editMessageText` now resolves `true` (faithful to grammy's `Message | true`; `undefined` from the production retry stack now specifically means gate-shed/skip).

## Test plan

New `telegram-plugin/tests/stream-controller-send-gate.test.ts` — `createStreamController` driven through a REAL `createSendGate` on the same fake clock as `send-gate.test.ts` (vitest fake timers restricted to `setTimeout`/`clearTimeout` for the local throttle; the gate clock advanced explicitly):

- draft edits inside the floor never hit the API; intermediates collapse; latest snapshot lands floor-paced (wire spacing 0/1500/3000 ms)
- the floor is per-message (stream B not delayed by stream A's floor)
- gate no-op skip engages for stream edits (second surface repeating the on-screen payload → zero API calls)
- open flood window: drafts shed with ZERO API calls; full state lands after close
- a shed draft is NOT recorded as delivered — a later finalize of the SAME text still lands
- finalize is critical: not shed; waits out a short (<= fail-fast ceiling) window then lands; fails fast (structured, logged, `failedFast` counted) on a long window with zero API calls and no hang
- regression pins: every edit passes `messageId`/`editPayload`/`priorityClass` through the retry policy (anchor, finalize, and the plain parse-fallback), sends stay untagged

Plus draft-stream unit pins (`finalize(text)` flushes final-tagged, supersedes pending, still dedupes text that actually landed) and a handler-level pin (`done=true` edit reaches `robustApiCall` as `critical`, intermediates `cosmetic`).

**Sabotage-verified**: with the gate fields stripped from stream-controller, 8/9 of the new integration tests fail.

Local: 302 tests across the 20 files touching send-gate/stream/draft/handler modules pass under vitest; `bun test telegram-plugin/tests/draft-stream.test.ts` (dual-run file) passes; `npm run lint` fully green (tsc + all 8 guards).

## Risk

Medium-low, flag-gated like the rest of #3084: with `SWITCHROOM_TELEGRAM_SEND_GATE=0` the gate is a pure passthrough and the only behavior deltas are (a) `done=true` flushes via `finalize(text)` (fewer edits, no throttle wait — same final state) and (b) the harness mock return value. With the gate on, draft edits now pace at >=1.5 s/message instead of 400 ms/1000 ms — slightly less "live" draft streaming, which is exactly the design's intent (the 400 ms cadence is the documented ban trigger).

Known missed benefit (review F5, documented in-code): draft-stream serializes flushes, so the gate's last-write-wins coalescing engages only for CONCURRENT writers to one message; a stale draft sleeping on the floor lands before the final, and finalize can trail by up to ~2x floor. Correctness unaffected. Known limitation (pre-existing, unchanged): draft-stream swallows edit failures, so a `stream_reply done=true` during a >60 s ban still returns `finalized` while the fail-fast is only logged — surfacing that as a structured MCP error is a candidate follow-up. Also deferred: the post-flood cooldown multiplier suggested in the #3110 evidence comment.

Job spec: `reference/jobs/talk-to-agents-from-anywhere.md` — advances the **always-available** outcome; outbound edit pacing is what keeps an agent from flood-banning itself off Telegram for hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
