### PR TITLE
fix(telegram): typed /model always leaves a durable trace + acks mid-turn (#3177)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -438,6 +438,8 @@ import { injectSlashCommand as injectSlashCommandImpl } from '../../src/agents/i
 import { handleInjectCommand, type InjectDeps } from './inject-handler.js'
 import {
   parseModelCommand,
+  planModelCommand,
+  modelCommandReceiptLine,
   handleModelCommand,
   buildModelMenu,
   handleModelMenuCallback,
@@ -22329,17 +22331,50 @@ bot.command('model', async ctx => {
   const parsed = parseModelCommand(text) ?? { kind: 'show' as const }
   const chatId = String(ctx.chat!.id)
   const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
+  // #3177 — durable receipt FIRST. A typed /model must NEVER be invisible: even
+  // if every downstream reply is shed/dropped, or the session is in a
+  // phantom-idle window (turn atom cleared while claude is still busy), the
+  // command leaves a greppable log line + a history row before any branch. This
+  // is the fix for the finn 2026-07-12 zero-trace swallow (no log, no reply, no
+  // ack, no deferred apply). `busyNow` folds BOTH busy signals (turn atom AND
+  // the authoritative delivery-machine/approval gate).
+  const busyNow = currentTurn !== null || turnInFlightForGate()
+  process.stderr.write(modelCommandReceiptLine(getMyAgentName(), parsed, busyNow) + '\n')
+  if (HISTORY_ENABLED && ctx.message?.message_id != null) {
+    try {
+      recordInbound({
+        chat_id: chatId,
+        thread_id: threadId ?? null,
+        message_id: ctx.message.message_id,
+        user: ctx.from?.username ?? (ctx.from?.id != null ? String(ctx.from.id) : null),
+        user_id: ctx.from?.id != null ? String(ctx.from.id) : null,
+        ts: ctx.message.date ?? Math.floor(Date.now() / 1000),
+        text,
+      })
+    } catch (err) {
+      process.stderr.write(`telegram gateway: /model recordInbound failed: ${(err as Error)?.message ?? String(err)}\n`)
+    }
+  }
   const deps = buildModelDeps({ chatId, threadId })
-  if (parsed.kind === 'show' && process.env.SWITCHROOM_MODEL_MENU !== '0') {
+  // Route on a pure disposition (#3177) that folds BOTH busy signals so a
+  // session busy by EITHER measure ack+queues instead of silently injecting
+  // into a busy pane. Every branch below produces a visible action.
+  const disposition = planModelCommand(parsed, {
+    currentTurnActive: currentTurn !== null,
+    turnInFlight: turnInFlightForGate(),
+    menuEnabled: process.env.SWITCHROOM_MODEL_MENU !== '0',
+  })
+  if (disposition.kind === 'menu') {
     const menu = await buildModelMenu(deps)
     await switchroomReply(ctx, menu.text, { html: true, reply_markup: modelMenuReplyMarkup(menu) })
     return
   }
-  // Mid-turn: instead of dead-ending ("Try again in a moment"), ACK + QUEUE +
-  // apply-on-idle + confirm (#3017). The typed set path either injects into
-  // claude's input box or triggers a carrier restart — both unsafe mid-turn.
-  if (parsed.kind === 'set' && deps.isBusy()) {
-    const target = expandSrAlias(parsed.model)
+  // Mid-turn (by either busy signal): instead of dead-ending ("Try again in a
+  // moment") or silently injecting into a busy pane, ACK + QUEUE + apply-on-idle
+  // + confirm (#3017/#3177). The typed set path either injects into claude's
+  // input box or triggers a carrier restart — both unsafe while busy.
+  if (disposition.kind === 'queue') {
+    const target = disposition.target
     const sent = await ctx.replyWithRichMessage(
       richMessage(hardenCardBreaks(pendingCmdAckText('model', target, escapeHtmlForTg))),
       threadId != null ? { message_thread_id: threadId } : {},

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -108,6 +108,82 @@ export function parseModelCommand(text: string): ParsedModelCommand | null {
   return { kind: 'set', model: arg }
 }
 
+/**
+ * The busy state a typed `/model` disposition is decided against. Two
+ * independent signals are folded here (#3177): `currentTurnActive` is the
+ * gateway's per-turn atom (`currentTurn !== null`), which is NULLED at
+ * `turn_end`; `turnInFlight` is the authoritative delivery-machine +
+ * pending-approval gate (`turnInFlightForGate()`). The atom can read idle
+ * while the session is still busy (the "recovered-late" / premature-turn-end
+ * window seen in finn's 2026-07-12 log), so a switch decided on the atom ALONE
+ * takes the direct-inject path and types `/model <name>` into a still-busy
+ * pane, where claude swallows it as literal text — a silent no-op. Folding
+ * BOTH signals means a session busy by EITHER measure ack+queues instead.
+ */
+export interface ModelCommandContext {
+  /** Gateway per-turn atom is non-null (`currentTurn !== null`). */
+  currentTurnActive: boolean
+  /** Authoritative busy gate (`turnInFlightForGate()`): machine-in-turn OR a pending approval. */
+  turnInFlight: boolean
+  /** Interactive picker menu is enabled (`SWITCHROOM_MODEL_MENU !== '0'`). */
+  menuEnabled: boolean
+}
+
+/**
+ * True when the session is busy by EITHER busy signal. A typed `/model` set
+ * MUST NOT take the direct-inject path while this holds — it would type into a
+ * busy pane and be swallowed as text. See ModelCommandContext.
+ */
+export function isModelCommandBusy(ctx: Pick<ModelCommandContext, 'currentTurnActive' | 'turnInFlight'>): boolean {
+  return ctx.currentTurnActive || ctx.turnInFlight
+}
+
+/**
+ * What the gateway should do with a parsed `/model` command. Pure so the
+ * routing decision is unit-testable without booting the bot. Every parsed
+ * shape maps to exactly one visible action — there is NO branch that silently
+ * does nothing (the #3177 swallow):
+ *
+ *  - `menu`  — bare `/model` with the picker enabled → render the dashboard.
+ *  - `queue` — a `set` while busy (by EITHER signal) → ack + enqueue for
+ *              apply-on-idle. `target` is the alias-expanded token.
+ *  - `apply` — run the handler now (idle `set`, or `show`/`help` text paths).
+ */
+export type ModelCommandDisposition =
+  | { kind: 'menu' }
+  | { kind: 'queue'; target: string }
+  | { kind: 'apply'; parsed: ParsedModelCommand }
+
+export function planModelCommand(
+  parsed: ParsedModelCommand,
+  ctx: ModelCommandContext,
+): ModelCommandDisposition {
+  if (parsed.kind === 'show' && ctx.menuEnabled) return { kind: 'menu' }
+  if (parsed.kind === 'set' && isModelCommandBusy(ctx)) {
+    return { kind: 'queue', target: expandSrAlias(parsed.model) }
+  }
+  return { kind: 'apply', parsed }
+}
+
+/**
+ * The unconditional durable log line the gateway writes at `/model` entry,
+ * BEFORE any branch or reply attempt (#3177 guarantee (b)). Even if every
+ * downstream reply is shed/dropped, this line — plus the paired history row —
+ * guarantees a typed `/model` is never invisible. Kept pure + shape-stable so
+ * the format is testable and greppable (`grep 'gw /model received'`).
+ */
+export function modelCommandReceiptLine(
+  agent: string,
+  parsed: ParsedModelCommand,
+  busy: boolean,
+): string {
+  const arg =
+    parsed.kind === 'set' ? parsed.model
+      : parsed.kind === 'show' ? '(show)'
+        : '(help)'
+  return `telegram gateway: gw /model received agent=${agent} kind=${parsed.kind} arg=${arg} busy=${busy}`
+}
+
 export interface ModelCommandDeps {
   /** Inject primitive — wired to injectSlashCommand in the gateway. */
   inject: (agent: string, command: string) => Promise<InjectResult>

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -16,6 +16,9 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import {
   parseModelCommand,
+  planModelCommand,
+  isModelCommandBusy,
+  modelCommandReceiptLine,
   handleModelCommand,
   isValidModelArg,
   isSrModel,
@@ -1372,5 +1375,85 @@ describe("isOfflineTrustedModelToken (#3042 blocker 2a)", () => {
     // Curated sr-* alias, upper-cased, still resolves.
     const [alias] = Object.entries(SR_MODEL_ALIASES)[0];
     expect(isOfflineTrustedModelToken(alias.toUpperCase())).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3177 — a typed /model must NEVER be swallowed without trace when sent
+// mid-turn. The routing decision folds BOTH busy signals, and every parsed
+// shape maps to a visible action (menu / queue / apply — never "do nothing").
+// ---------------------------------------------------------------------------
+describe("#3177 typed /model never silently swallowed mid-turn", () => {
+  describe("isModelCommandBusy folds both busy signals", () => {
+    it("is busy when the turn atom is set", () => {
+      expect(isModelCommandBusy({ currentTurnActive: true, turnInFlight: false })).toBe(true);
+    });
+
+    it("is busy when only the authoritative delivery-machine/approval gate is set", () => {
+      // THE SWALLOW REGRESSION: the pre-fix handler gated on `currentTurn !==
+      // null` ALONE. A session busy by the delivery-machine / pending-approval
+      // gate while the turn atom is cleared (the recovered-late / premature-
+      // turn-end window) read as idle, so the switch injected into a busy pane
+      // and was swallowed as literal text. Folding turnInFlight closes it.
+      expect(isModelCommandBusy({ currentTurnActive: false, turnInFlight: true })).toBe(true);
+    });
+
+    it("is idle only when BOTH signals are clear", () => {
+      expect(isModelCommandBusy({ currentTurnActive: false, turnInFlight: false })).toBe(false);
+    });
+  });
+
+  describe("planModelCommand routes every shape to a visible action", () => {
+    const busyByAtom = { currentTurnActive: true, turnInFlight: false, menuEnabled: true };
+    const busyByGate = { currentTurnActive: false, turnInFlight: true, menuEnabled: true };
+    const idle = { currentTurnActive: false, turnInFlight: false, menuEnabled: true };
+
+    it("QUEUES a set while busy by the turn atom (ack, not silent inject)", () => {
+      const d = planModelCommand({ kind: "set", model: "opus" }, busyByAtom);
+      expect(d).toEqual({ kind: "queue", target: "opus" });
+    });
+
+    it("QUEUES a set while busy by the delivery-machine/approval gate ONLY — the swallow case", () => {
+      // Sabotage-verify: revert the fix (gate on currentTurnActive alone) and
+      // this flips to { kind: 'apply' } → the direct-inject swallow returns.
+      const d = planModelCommand({ kind: "set", model: "opus" }, busyByGate);
+      expect(d).toEqual({ kind: "queue", target: "opus" });
+    });
+
+    it("expands sr-* aliases into the queued target token", () => {
+      const d = planModelCommand({ kind: "set", model: "flash" }, busyByAtom);
+      expect(d).toEqual({ kind: "queue", target: "sr-gemini-2.5-flash" });
+    });
+
+    it("APPLIES a set immediately when idle by both signals", () => {
+      const d = planModelCommand({ kind: "set", model: "opus" }, idle);
+      expect(d).toEqual({ kind: "apply", parsed: { kind: "set", model: "opus" } });
+    });
+
+    it("renders the MENU for bare /model when the picker is enabled (even mid-turn)", () => {
+      expect(planModelCommand({ kind: "show" }, busyByGate)).toEqual({ kind: "menu" });
+    });
+
+    it("APPLIES the text show path when the picker is disabled", () => {
+      const d = planModelCommand({ kind: "show" }, { ...idle, menuEnabled: false });
+      expect(d).toEqual({ kind: "apply", parsed: { kind: "show" } });
+    });
+
+    it("APPLIES help so a bad arg still gets an explicit reply", () => {
+      const parsed = { kind: "help", reason: "not a valid model name: !!" } as const;
+      expect(planModelCommand(parsed, busyByGate)).toEqual({ kind: "apply", parsed });
+    });
+  });
+
+  describe("modelCommandReceiptLine — the durable, greppable entry trace", () => {
+    it("stamps agent, kind, arg, and busy for a typed set", () => {
+      const line = modelCommandReceiptLine("finn", { kind: "set", model: "opus" }, true);
+      expect(line).toBe("telegram gateway: gw /model received agent=finn kind=set arg=opus busy=true");
+    });
+
+    it("marks the show + help forms with placeholder args", () => {
+      expect(modelCommandReceiptLine("finn", { kind: "show" }, false)).toContain("kind=show arg=(show)");
+      expect(modelCommandReceiptLine("finn", { kind: "help" }, false)).toContain("kind=help arg=(help)");
+    });
   });
 });


### PR DESCRIPTION
Fixes #3177.

## Problem

A typed `/model opus` DM sent while an agent is finishing a turn can vanish completely — **no effect, no reply, no ack, no log line, no history row, no deferred apply** — violating the P8 invariant "/model must always work and stick".

Live incident (agent `finn`, image v0.18.15, 2026-07-12, chat 8248703757, UTC), reconstructed from `gateway-supervisor.log`:

```
07:16:14.818  turnEnd ... global=bridge_alive_idle   (currentTurn nulled)
07:16:20      worker-feed paint 3593                  (sub-agent STILL running)
07:18:01.837  worker-feed finish 3593 state=done
07:18:50.685  reply-route ... via=recovered late=true originTurn=...#3589 RECOVERED
07:18:51.192  outbound reply msg_id=3596
07:20:17      next real inbound msg=3597 (unrelated turn)
```

Between the `turnEnd` at 07:16:14 and the next inbound at 07:20:17 there is **zero inbound trace of any kind** — the `/model` produced nothing. The turn was declared ended at 07:16:14 while claude was still busy (it produced a `via=recovered late=true` reply at 07:18:50): a **phantom-idle** window where the gateway's busy signals read idle while the session is mid-work.

## Root cause (v0.18.15 source)

`bot.command('model')` in `telegram-plugin/gateway/gateway.ts`:

1. **No durable receipt** — the handler logged nothing and never called `recordInbound`; the only evidence a `/model` happened was a Telegram reply reaching the user. Command handlers are terminal (`bot.command`, no `next()`) so they bypass the `bot.on('message')` `recordInbound`, meaning even a *successful* `/model` never appears in history and a *failed* one is completely untraceable.
2. **Busy gate read only `currentTurn !== null`** (`isBusy`, gateway.ts), which is nulled at `turn_end` — diverging from the authoritative `turnInFlightForGate()` (delivery-machine + pending-approval) signal. In the phantom-idle window a typed `/model` took the direct-inject path and typed `/model opus` into a still-busy pane, where claude queued it as literal text — a silent no-op.

## Fix

A typed `/model` now deterministically produces all three guarantees the moment the handler runs:

- **(b) durable record** — a greppable `gw /model received ...` log line + a history row are written FIRST, before any branch or reply attempt, so a swallowed switch is never invisible.
- **(a) immediate ack** — the disposition is routed through the new pure `planModelCommand`, folding BOTH busy signals (`isModelCommandBusy = currentTurnActive || turnInFlight`) so a session busy by EITHER measure ack+queues (the #3017 mid-turn card) instead of silently injecting.
- **(c) apply-or-explicit-failure** — apply / queue / menu each yield a visible outcome (unchanged handler bodies).

Pure helpers (`planModelCommand`, `isModelCommandBusy`, `modelCommandReceiptLine`) live in `model-command.ts` and are unit-tested. **Sabotage-verified:** reverting the busy-union to `currentTurn`-only makes exactly the two "delivery-machine/approval gate ONLY" swallow tests fail.

## Scope / not addressed here

`/effort` shares the same `currentTurn !== null` mid-turn gate (gateway.ts) — same-shaped exposure; left for a focused follow-up to keep this diff minimal. `/status` and `/restart` don't switch the live session and aren't swallowed the same way, though they share the "command handlers leave no history row / entry log" gap.

## Job spec

Advances the *always available* + *on the leash* outcomes: an operator's live-control command must never silently disappear.

## Testing

- `vitest run telegram-plugin/tests/model-command.test.ts` — 123 passed (12 new #3177 cases).
- Adjacent: `pending-session-command`, `effort-command`, `gateway-session-model-relaunch`, `session-model-source` — 84 passed.
- `npm run lint` — clean (tsc + all 8 guards, including `check-bot-api-wrapping`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)