### PR TITLE
fix(auth-broker): detect model-tier (7d_oi) quota walls (#3176)

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -186,6 +186,33 @@ export interface AccountState {
    * without triggering a live network call.
    */
   last_quota?: LastQuotaSnapshot | null;
+  /**
+   * #3176 — flagship-tier (`7d_oi` / `seven_day_overage_included`) wall. TRUE
+   * when the account is walled on the premium tier right now (an unexpired
+   * `premium_walled_until` mark not contradicted by a fresher tier-allowed
+   * canary). Tier-scoped: the account still serves opus/haiku. Absent on
+   * pre-#3176 brokers (treat as false).
+   */
+  premium_walled?: boolean;
+  /** #3176 — raw ledger mark: unix ms until which the flagship tier is walled. */
+  premium_walled_until?: number;
+  /** #3176 — the binding bucket claim (seven_day_overage_included). */
+  premium_wall_bucket?: string;
+  /** #3176 — latest flagship-tier canary snapshot, for the dashboard/card. */
+  last_tier_quota?: LastTierQuotaSnapshot | null;
+}
+
+/**
+ * #3176 — the flagship-tier (`7d_oi`) canary snapshot exposed via `list-state`.
+ * Separate from {@link LastQuotaSnapshot} (the haiku probe's 5h/7d windows).
+ */
+export interface LastTierQuotaSnapshot {
+  unifiedStatus: string | null;
+  sevenDayOiStatus: string | null;
+  sevenDayOiUtilizationPct: number | null;
+  /** ISO 8601 string, or null. */
+  sevenDayOiResetAt: string | null;
+  capturedAt: number;
 }
 
 export interface AgentState {
@@ -235,7 +262,21 @@ export interface ListStateData {
      * off an account approaching its limits (no mark, no promote). Absent on
      * pre-PR-2 brokers (render as hard exhaustion).
      */
-    reason?: "soft-avoid" | "hard-exhaustion";
+    reason?: "soft-avoid" | "hard-exhaustion" | "model-tier-wall";
+    /** #3176 — the binding tier bucket, set only when reason is model-tier-wall. */
+    bucket?: string;
+  } | null;
+  /**
+   * #3176 — fleet-wide flagship-tier all-walled alert. Set when EVERY account
+   * is walled on the `7d_oi` bucket with no premium-eligible failover target,
+   * so the gateway can surface an operator card naming the bucket and the
+   * earliest recovery. Null/absent whenever at least one account can serve the
+   * flagship tier.
+   */
+  premium_tier_all_walled?: {
+    bucket: string | null;
+    earliest_reset?: number;
+    at: number;
   } | null;
 }
 

--- a/src/auth/broker/model-tier-quota.test.ts
+++ b/src/auth/broker/model-tier-quota.test.ts
@@ -1,0 +1,172 @@
+/**
+ * #3176 — the pure model-tier (`7d_oi` / `seven_day_overage_included`) wall
+ * decision layer. Uses the exact 2026-07-12 evidence shapes.
+ *
+ * FAILS on pristine main: this module does not exist there, and nothing
+ * classifies a 7d_oi rejection as a tier wall.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { QuotaResult } from "../quota.js";
+import {
+  quotaIndicatesModelTierWall,
+  quotaTierAllowed,
+  isModelTierWalled,
+  MODEL_TIER_WALL_PCT,
+} from "./model-tier-quota.js";
+
+/** The fable-5 429 probe result (walled on the flagship tier). */
+function fableWalled(resetMs: number | null = 1783850400 * 1000): QuotaResult {
+  return {
+    ok: true,
+    data: {
+      fiveHourUtilizationPct: 0,
+      sevenDayUtilizationPct: 0,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: "seven_day_overage_included",
+      overageStatus: null,
+      overageDisabledReason: null,
+      unifiedStatus: "rejected",
+      sevenDayOiStatus: "rejected",
+      sevenDayOiUtilizationPct: 100,
+      sevenDayOiResetAt: resetMs != null ? new Date(resetMs) : null,
+      sevenDayOiPresent: true,
+    },
+  };
+}
+
+/** The opus-4-8 200 probe result (flagship tier allowed). */
+function opusHealthy(): QuotaResult {
+  return {
+    ok: true,
+    data: {
+      fiveHourUtilizationPct: 1,
+      sevenDayUtilizationPct: 58,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+      unifiedStatus: "allowed",
+      sevenDayOiStatus: "allowed",
+      sevenDayOiUtilizationPct: 58,
+      sevenDayOiResetAt: null,
+      sevenDayOiPresent: true,
+    },
+  };
+}
+
+/** A plain haiku 5h/7d probe — no tier headers at all. */
+function haikuHealthy(): QuotaResult {
+  return {
+    ok: true,
+    data: {
+      fiveHourUtilizationPct: 1,
+      sevenDayUtilizationPct: 58,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+    },
+  };
+}
+
+describe("#3176 quotaIndicatesModelTierWall", () => {
+  it("classifies a fable-5 429 (7d_oi rejected) as walled, with the tier reset", () => {
+    const d = quotaIndicatesModelTierWall(fableWalled());
+    expect(d.walled).toBe(true);
+    expect(d.bucket).toBe("seven_day_overage_included");
+    expect(d.until).toBe(1783850400 * 1000);
+  });
+
+  it("classifies rejection-by-representative-claim even without an explicit 7d_oi-status", () => {
+    const res: QuotaResult = {
+      ok: true,
+      data: {
+        fiveHourUtilizationPct: 0,
+        sevenDayUtilizationPct: 0,
+        fiveHourResetAt: null,
+        sevenDayResetAt: null,
+        representativeClaim: "seven_day_overage_included",
+        overageStatus: null,
+        overageDisabledReason: null,
+        unifiedStatus: "rejected",
+        sevenDayOiResetAt: null,
+      },
+    };
+    expect(quotaIndicatesModelTierWall(res).walled).toBe(true);
+  });
+
+  it("classifies a >=wall 7d_oi utilization as walled even if status is absent", () => {
+    const res: QuotaResult = {
+      ok: true,
+      data: {
+        fiveHourUtilizationPct: 0,
+        sevenDayUtilizationPct: 0,
+        fiveHourResetAt: null,
+        sevenDayResetAt: null,
+        representativeClaim: null,
+        overageStatus: null,
+        overageDisabledReason: null,
+        sevenDayOiUtilizationPct: MODEL_TIER_WALL_PCT,
+        sevenDayOiResetAt: null,
+      },
+    };
+    expect(quotaIndicatesModelTierWall(res).walled).toBe(true);
+  });
+
+  it("an opus 200 (tier allowed) is NOT a wall", () => {
+    expect(quotaIndicatesModelTierWall(opusHealthy()).walled).toBe(false);
+  });
+
+  it("a haiku probe with no tier headers is NOT a wall (absence != rejection)", () => {
+    expect(quotaIndicatesModelTierWall(haikuHealthy()).walled).toBe(false);
+  });
+
+  it("a FAILED probe is never a wall (transient error must not bench a tier)", () => {
+    expect(quotaIndicatesModelTierWall({ ok: false, reason: "network" }).walled).toBe(false);
+  });
+});
+
+describe("#3176 quotaTierAllowed", () => {
+  it("true for an opus 200 (positive allowed signal → clears a stale mark)", () => {
+    expect(quotaTierAllowed(opusHealthy())).toBe(true);
+  });
+  it("false for a fable 429 (rejected)", () => {
+    expect(quotaTierAllowed(fableWalled())).toBe(false);
+  });
+  it("false for a haiku probe with no tier verdict (inconclusive, not a clear signal)", () => {
+    expect(quotaTierAllowed(haikuHealthy())).toBe(false);
+  });
+  it("false for a failed probe", () => {
+    expect(quotaTierAllowed({ ok: false, reason: "boom" })).toBe(false);
+  });
+});
+
+describe("#3176 isModelTierWalled", () => {
+  const now = 1_000_000;
+  it("an unexpired mark walls the account", () => {
+    expect(
+      isModelTierWalled({ mark: { premium_walled_until: now + 1000 }, now }),
+    ).toBe(true);
+  });
+  it("an expired mark does not", () => {
+    expect(
+      isModelTierWalled({ mark: { premium_walled_until: now - 1000 }, now }),
+    ).toBe(false);
+  });
+  it("a fresh tier-allowed canary overrides an unexpired mark", () => {
+    expect(
+      isModelTierWalled({
+        mark: { premium_walled_until: now + 1000 },
+        now,
+        snapshotTierAllowed: true,
+      }),
+    ).toBe(false);
+  });
+  it("no mark → not walled", () => {
+    expect(isModelTierWalled({ now })).toBe(false);
+  });
+});

--- a/src/auth/broker/model-tier-quota.test.ts
+++ b/src/auth/broker/model-tier-quota.test.ts
@@ -128,6 +128,37 @@ describe("#3176 quotaIndicatesModelTierWall", () => {
   it("a FAILED probe is never a wall (transient error must not bench a tier)", () => {
     expect(quotaIndicatesModelTierWall({ ok: false, reason: "network" }).walled).toBe(false);
   });
+
+  it("a transient rejection bound on a NON-7d_oi claim is NOT a tier wall (false-wall guard)", () => {
+    // A 429 whose overall verdict is `rejected` but whose binding claim is a
+    // burst/5h throttle — NOT `seven_day_overage_included` — with NO 7d_oi
+    // bucket verdict must never mark the flagship tier walled: the account is
+    // momentarily throttled, not on a weekly tier wall, and benching it for
+    // hours would be a false wall. Only a loosened classifier (e.g. "any
+    // rejected") would trip here — this locks the boundary.
+    const res: QuotaResult = {
+      ok: true,
+      data: {
+        fiveHourUtilizationPct: 100,
+        sevenDayUtilizationPct: 60,
+        fiveHourResetAt: null,
+        sevenDayResetAt: null,
+        representativeClaim: "five_hour",
+        overageStatus: null,
+        overageDisabledReason: null,
+        unifiedStatus: "rejected",
+        sevenDayOiStatus: null,
+        sevenDayOiUtilizationPct: null,
+        sevenDayOiResetAt: null,
+        sevenDayOiPresent: false,
+      },
+    };
+    expect(quotaIndicatesModelTierWall(res).walled).toBe(false);
+    // …and such a probe is not a clear "tier allowed" signal for self-heal
+    // either — the overall verdict is rejected and the 7d_oi bucket gave no
+    // verdict, so a real mark is left untouched (inconclusive, not cleared).
+    expect(quotaTierAllowed(res)).toBe(false);
+  });
 });
 
 describe("#3176 quotaTierAllowed", () => {

--- a/src/auth/broker/model-tier-quota.ts
+++ b/src/auth/broker/model-tier-quota.ts
@@ -1,0 +1,151 @@
+/**
+ * Model-tier quota wall — the pure decision layer for Anthropic's per-tier
+ * `7d_oi` (`seven_day_overage_included`) bucket (#3176).
+ *
+ * THE DEFECT this module exists to fix: the broker's quota probe hits
+ * `POST /v1/messages` with HAIKU and only records the 5h/7d utilization
+ * windows. Anthropic's `7d_oi` bucket is PER-MODEL-TIER — an account can be
+ * `rejected` on the flagship (Fable) tier while `allowed` on opus/haiku
+ * (verified 2026-07-12: same account, same moment, fable=429 / opus=200 /
+ * haiku=200, with `7d_oi-utilization=1.0`, `7d_oi-status=rejected`,
+ * `representative-claim=seven_day_overage_included`, `retry-after≈2.8h`). A
+ * haiku probe therefore reads `5h=1% / 7d=58%` — healthy — so the broker set
+ * the account fleet-active and every flagship agent 429'd (an 86-request
+ * storm over ~5 min until the mark rolled off).
+ *
+ * A model-tier wall is NOT the same as a 5h/7d exhaustion mark:
+ *  - It is TIER-SCOPED: the account still serves opus/haiku fine. A blanket
+ *    exhaustion mark would wrongly bench those tiers.
+ *  - It is NOT transient (not a burst / RPM throttle) and NOT proxy-local
+ *    (LiteLLM never emits Anthropic's unified headers). It is a real weekly
+ *    wall on the flagship tier with a genuine reset.
+ *
+ * PURE — no I/O, no clock except the injected `now`. Fully unit-tested.
+ */
+
+import type { QuotaResult } from "../quota.js";
+import { MODEL_TIER_REPRESENTATIVE_CLAIM } from "../quota.js";
+
+/**
+ * `7d_oi` utilization at/above this counts as a hard tier wall even if the
+ * status header is missing. Matches the 99.5% wall the 5h/7d windows use
+ * (account-eligibility.ts `WALL_PCT`) so "walled" means the same thing across
+ * buckets. In practice the tier wall reports `1.0` (100%) with an explicit
+ * `rejected` status.
+ */
+export const MODEL_TIER_WALL_PCT = 99.5;
+
+/** The tier a model-tier wall applies to (the fleet flagship / premium tier). */
+export const MODEL_TIER = "premium" as const;
+
+export interface ModelTierWallDecision {
+  /** True when the probe result proves the flagship-tier `7d_oi` bucket walled. */
+  walled: boolean;
+  /** Epoch ms when the tier wall lifts, when the probe carried a reset. Null
+   *  otherwise (caller applies a default window). */
+  until: number | null;
+  /** The binding bucket claim, for operator messaging. Null when not walled. */
+  bucket: string | null;
+}
+
+/**
+ * Decide whether a quota probe result indicates the account is walled on the
+ * flagship model tier (the `7d_oi` bucket), and when it resets. PURE.
+ *
+ * A FAILED probe is NOT a wall — a transient network/probe error must never
+ * bench a tier (the all-blocked-from-stale-probe lesson). A NON-429 success
+ * that simply lacks the tier headers (e.g. the default haiku probe, or a
+ * stale/rotted canary model id that 4xx'd as "model not found") is NOT a wall
+ * either — absence of signal is treated as "no wall observed", never a
+ * mismark. Only a POSITIVE signal counts:
+ *   - `sevenDayOiStatus === 'rejected'`, OR
+ *   - `unifiedStatus === 'rejected'` with the binding representative-claim
+ *     being `seven_day_overage_included`, OR
+ *   - a measured `sevenDayOiUtilizationPct >= MODEL_TIER_WALL_PCT`.
+ */
+export function quotaIndicatesModelTierWall(
+  result: QuotaResult,
+): ModelTierWallDecision {
+  const none: ModelTierWallDecision = { walled: false, until: null, bucket: null };
+  if (!result.ok) return none;
+  const d = result.data;
+
+  const statusRejected = d.sevenDayOiStatus === "rejected";
+  const claimRejected =
+    d.unifiedStatus === "rejected" &&
+    d.representativeClaim === MODEL_TIER_REPRESENTATIVE_CLAIM;
+  const utilWalled =
+    d.sevenDayOiUtilizationPct != null &&
+    d.sevenDayOiUtilizationPct >= MODEL_TIER_WALL_PCT;
+
+  if (!statusRejected && !claimRejected && !utilWalled) return none;
+
+  return {
+    walled: true,
+    until: d.sevenDayOiResetAt?.getTime() ?? null,
+    bucket: MODEL_TIER_REPRESENTATIVE_CLAIM,
+  };
+}
+
+/**
+ * Does this probe result POSITIVELY prove the flagship tier is NOT walled — a
+ * clear signal to clear a stale tier-wall mark? True only when the canary came
+ * back OK with an explicit `allowed` verdict AND {@link
+ * quotaIndicatesModelTierWall} does not fire. A failed probe, a result with no
+ * tier headers (the haiku probe, or a rotted canary id that 4xx'd), or any
+ * `rejected` verdict is NOT a clear signal — the mark is left untouched (the
+ * safe direction: never clear a real wall off an inconclusive probe). PURE.
+ */
+export function quotaTierAllowed(result: QuotaResult): boolean {
+  if (!result.ok) return false;
+  if (quotaIndicatesModelTierWall(result).walled) return false;
+  const d = result.data;
+  return d.unifiedStatus === "allowed" || d.sevenDayOiStatus === "allowed";
+}
+
+/**
+ * A persisted model-tier wall mark. Distinct from the blanket `exhausted_until`
+ * mark: it benches the account for FLAGSHIP-tier serving only, and expires at
+ * the tier bucket's own reset. `marked_at` lets live truth override it
+ * (most-recent-signal-wins), same discipline as ExhaustionMark.
+ */
+export interface ModelTierWallMark {
+  /** Epoch ms until which the flagship tier is walled for this account. */
+  premium_walled_until: number;
+  /** The binding bucket, for operator messaging. */
+  premium_wall_bucket?: string;
+  /** Epoch ms when the mark was written. */
+  premium_wall_marked_at?: number;
+}
+
+/**
+ * Is this account currently walled on the flagship tier? Live-truth first: a
+ * fresh probe result that POSITIVELY shows the tier `7d_oi` bucket `allowed`
+ * (a non-walled measurement newer than the mark) clears the wall; otherwise an
+ * unexpired mark governs. `snapshotTierAllowed` is the caller's live signal
+ * ("the newest canary probe measured the tier and it was NOT walled"); when
+ * the caller has no fresh tier measurement it passes undefined and the mark
+ * alone decides.
+ */
+export function isModelTierWalled(opts: {
+  mark?: ModelTierWallMark;
+  now: number;
+  /** True when a fresh canary probe measured the tier as NOT walled (newer
+   *  than the mark). Undefined = no fresh tier truth. */
+  snapshotTierAllowed?: boolean;
+}): boolean {
+  const { mark, now, snapshotTierAllowed } = opts;
+  if (snapshotTierAllowed === true) return false;
+  if (mark !== undefined && mark.premium_walled_until > now) return true;
+  return false;
+}
+
+/**
+ * Default tier-wall window when a canary 429 carried no parseable reset. The
+ * `7d_oi` bucket is a WEEKLY bucket, but we deliberately clamp an
+ * unparseable-reset wall to a short window (the caller re-probes each fleet
+ * tick and re-marks while the wall persists) so a one-off misread self-clears
+ * fast rather than benching the flagship tier for days. Mirrors the
+ * mark-exhausted 5h default discipline.
+ */
+export const MODEL_TIER_WALL_DEFAULT_MS = 5 * 60 * 60 * 1000;

--- a/src/auth/broker/server-model-tier-wall.test.ts
+++ b/src/auth/broker/server-model-tier-wall.test.ts
@@ -1,0 +1,230 @@
+/**
+ * #3176 — the fleet quota probe tick must detect an account walled on the
+ * flagship model tier (`7d_oi` / `seven_day_overage_included`) and fail the
+ * fleet off it, WITHOUT waiting for an 86-request 429 storm.
+ *
+ * The incident: the default haiku probe reads the account 5h=1% / 7d=58% —
+ * healthy — while a flagship (Fable) request 429s with 7d_oi=100% rejected.
+ * The broker set the account fleet-active and every flagship agent stormed.
+ *
+ * These tests drive the fleet tick with a `_testFetchQuota` that returns
+ * DIFFERENT results per requested model — haiku healthy, flagship walled —
+ * exactly reproducing the split. They FAIL on pristine main (no canary, no
+ * tier classification, no tier-scoped mark).
+ *
+ * Tmpdir-isolated (never ~/.switchroom).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AuthBroker } from "./server.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import { writeAccountCredentials } from "../account-store.js";
+import type { FetchQuotaOptions, QuotaResult } from "../quota.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-tier-wall-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try { rmSync(h.tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness, active: string, fallback: string[]): SwitchroomConfig {
+  return ({
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents: { rider: {} },
+    auth: { active, fallback_order: fallback },
+  } as unknown) as SwitchroomConfig;
+}
+
+function seedAccount(h: Harness, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: `at-${label}`,
+        refreshToken: `rt-${label}`,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    },
+    h.home,
+  );
+}
+
+/** haiku 5h/7d healthy — what the default probe (no model) reads. */
+function haikuHealthy(): QuotaResult {
+  return { ok: true, data: {
+    fiveHourUtilizationPct: 1,
+    sevenDayUtilizationPct: 58,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    representativeClaim: null,
+    overageStatus: null,
+    overageDisabledReason: null,
+  } };
+}
+
+/** flagship 429 — 7d_oi rejected (the fable wall the haiku probe cannot see). */
+function fableWalled(resetMs: number): QuotaResult {
+  return { ok: true, data: {
+    fiveHourUtilizationPct: 0,
+    sevenDayUtilizationPct: 0,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    representativeClaim: "seven_day_overage_included",
+    overageStatus: null,
+    overageDisabledReason: null,
+    unifiedStatus: "rejected",
+    sevenDayOiStatus: "rejected",
+    sevenDayOiUtilizationPct: 100,
+    sevenDayOiResetAt: new Date(resetMs),
+    sevenDayOiPresent: true,
+  } };
+}
+
+/** flagship 200 — tier allowed (a healthy canary). */
+function fableAllowed(): QuotaResult {
+  return { ok: true, data: {
+    fiveHourUtilizationPct: 1,
+    sevenDayUtilizationPct: 58,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    representativeClaim: null,
+    overageStatus: null,
+    overageDisabledReason: null,
+    unifiedStatus: "allowed",
+    sevenDayOiStatus: "allowed",
+    sevenDayOiUtilizationPct: 58,
+    sevenDayOiResetAt: null,
+    sevenDayOiPresent: true,
+  } };
+}
+
+/**
+ * Build a `_testFetchQuota` that branches on the requested model AND account.
+ * `tierByAccount` maps account label → flagship-canary result; a request with
+ * no model (the haiku probe) always reads healthy.
+ */
+function fetcher(
+  tierByAccount: Record<string, () => QuotaResult>,
+): (opts: FetchQuotaOptions) => Promise<QuotaResult> {
+  return async ({ accessToken, model }: FetchQuotaOptions) => {
+    const label = accessToken.replace(/^at-/, "");
+    if (model && model !== "claude-haiku-4-5-20251001") {
+      const fn = tierByAccount[label];
+      return fn ? fn() : fableAllowed();
+    }
+    return haikuHealthy();
+  };
+}
+
+describe("#3176 fleet tick — model-tier (7d_oi) wall detection", () => {
+  it("marks the flagship-walled active account and rolls the fleet off it (tier-scoped, not exhausted)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "walled");
+    seedAccount(h, "healthy");
+    const resetMs = Date.now() + 2.8 * 60 * 60 * 1000;
+    const broker = new AuthBroker(makeConfig(h, "walled", ["walled", "healthy"]), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: fetcher({ walled: () => fableWalled(resetMs) }),
+    });
+    await broker.start();
+    await broker.fleetQuotaProbeTick();
+
+    const st = broker._state();
+    // The tier wall was recorded — with the real ~2.8h reset, not invisible.
+    expect(st.quota["walled"]?.premium_walled_until).toBe(resetMs);
+    expect(st.quota["walled"]?.premium_wall_bucket).toBe("seven_day_overage_included");
+    // TIER-SCOPED: it is NOT a blanket exhaustion mark (the account still
+    // serves opus/haiku fine).
+    expect(st.quota["walled"]?.exhausted_until).toBeUndefined();
+    // The fleet rolled off the walled account and durably promoted the target.
+    expect(st.activeAccount).toBe("healthy");
+    // The canary snapshot is persisted for transparency.
+    expect(st.lastTierQuotaCache["walled"]?.sevenDayOiStatus).toBe("rejected");
+    broker.stop();
+  });
+
+  it("does NOT select a flagship-walled fallback as the roll target; all-walled records the alert with earliest reset", async () => {
+    const h = makeHarness();
+    seedAccount(h, "a");
+    seedAccount(h, "b");
+    const resetA = Date.now() + 3 * 60 * 60 * 1000;
+    const resetB = Date.now() + 1 * 60 * 60 * 1000; // earlier
+    const broker = new AuthBroker(makeConfig(h, "a", ["a", "b"]), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: fetcher({
+        a: () => fableWalled(resetA),
+        b: () => fableWalled(resetB),
+      }),
+    });
+    await broker.start();
+    await broker.fleetQuotaProbeTick();
+
+    const st = broker._state();
+    // Both walled → no eligible target → active stays put, all-walled alert set.
+    expect(st.activeAccount).toBe("a");
+    expect(st.premiumTierAllWalled).not.toBeNull();
+    expect(st.premiumTierAllWalled?.earliest_reset).toBe(resetB);
+    expect(st.premiumTierAllWalled?.bucket).toBe("seven_day_overage_included");
+    broker.stop();
+  });
+
+  it("a later canary reading the tier allowed clears a stale wall mark", async () => {
+    const h = makeHarness();
+    seedAccount(h, "acct");
+    seedAccount(h, "spare");
+    const resetMs = Date.now() + 2 * 60 * 60 * 1000;
+    // Tick 1: acct walled → mark set, roll to spare.
+    let walled = true;
+    const broker = new AuthBroker(makeConfig(h, "acct", ["acct", "spare"]), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async ({ accessToken, model }: FetchQuotaOptions) => {
+        const label = accessToken.replace(/^at-/, "");
+        if (model && model !== "claude-haiku-4-5-20251001") {
+          if (label === "acct") return walled ? fableWalled(resetMs) : fableAllowed();
+          return fableAllowed();
+        }
+        return haikuHealthy();
+      },
+    });
+    await broker.start();
+    await broker.fleetQuotaProbeTick();
+    expect(broker._state().quota["acct"]?.premium_walled_until).toBe(resetMs);
+
+    // Tick 2: acct's canary now reads allowed → the mark self-heals.
+    walled = false;
+    await broker.fleetQuotaProbeTick();
+    expect(broker._state().quota["acct"]?.premium_walled_until).toBeUndefined();
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -2259,7 +2259,7 @@ export class AuthBroker {
         this.audit({ op: "mark-exhausted", identity: { kind: "operator" }, account: label, accountKind: "claude", ok: true, reason: "model-tier-wall" });
         const { rolledTo, allWalled, earliestReset } = this.markPremiumWalledAndRoll(label, tw.until, tw.bucket);
         if (rolledTo && label === active) {
-          this.recordFleetRoll(label, rolledTo, "model-tier-wall", tw.until ?? undefined);
+          this.recordFleetRoll(label, rolledTo, "model-tier-wall", tw.until ?? undefined, tw.bucket);
         } else if (allWalled && label === active) {
           this.recordPremiumAllWalled(tw.bucket, earliestReset);
         }

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -42,12 +42,23 @@ import { dirname, join, resolve } from "node:path";
 
 import { allocateAgentUid } from "../../agents/compose.js";
 import { resolveAgentsDir } from "../../config/loader.js";
-import { fetchQuota, type QuotaResult } from "../quota.js";
+import {
+  fetchQuota,
+  resolveModelTierProbeModel,
+  type QuotaResult,
+} from "../quota.js";
 import {
   quotaIndicatesExhaustion,
   resolveConsumerProbeIntervalMs,
   EXHAUSTION_PCT,
 } from "./consumer-quota-sensor.js";
+import {
+  quotaIndicatesModelTierWall,
+  quotaTierAllowed,
+  isModelTierWalled,
+  MODEL_TIER_WALL_DEFAULT_MS,
+  type ModelTierWallMark,
+} from "./model-tier-quota.js";
 import {
   isAccountBlocked as evalAccountBlocked,
   accountEligibility,
@@ -60,6 +71,7 @@ import {
   type SoftAvoidSnapshot,
   snapshotWalled,
   WALL_PCT,
+  SNAPSHOT_STALE_AGE_MS,
 } from "./account-eligibility.js";
 import type { AuthConfig, AuthConsumer, SwitchroomConfig } from "../../config/schema.js";
 import { atomicWriteFileSync, atomicWriteJsonSync } from "../../util/atomic.js";
@@ -189,6 +201,16 @@ interface QuotaEntry {
    *  counter. Pruned to THROTTLE_ESCALATION_WINDOW_MS on every hit; cleared
    *  after an escalation probe runs (corroborated or not). */
   throttle_hits?: number[];
+  /** #3176 — model-tier (7d_oi / seven_day_overage_included) wall. Unix ms
+   *  until which the account is walled on the FLAGSHIP tier only (the account
+   *  still serves opus/haiku fine, so this is NOT an `exhausted_until`
+   *  blanket mark). Set by the fleet tick's premium canary; cleared when a
+   *  fresh canary reports the tier allowed. */
+  premium_walled_until?: number;
+  /** The binding bucket claim at mark time, for operator messaging. */
+  premium_wall_bucket?: string;
+  /** Unix ms when the tier-wall mark was written (most-recent-signal-wins). */
+  premium_wall_marked_at?: number;
 }
 interface QuotaState {
   [label: string]: QuotaEntry;
@@ -259,9 +281,29 @@ export interface LastFleetRoll {
   /**
    * Trigger attribution (#3031 PR 2): "hard-exhaustion" = the probe saw a
    * genuine quota wall (mark + roll, possibly promote); "soft-avoid" = a
-   * serving-preference roll off the soft-avoid tier (no mark, no promote).
+   * serving-preference roll off the soft-avoid tier (no mark, no promote);
+   * "model-tier-wall" = the flagship-tier (7d_oi) canary saw the account
+   * walled on the premium tier (#3176).
    */
-  reason?: "soft-avoid" | "hard-exhaustion";
+  reason?: "soft-avoid" | "hard-exhaustion" | "model-tier-wall";
+  /** #3176 — the binding tier bucket, set only when reason is model-tier-wall. */
+  bucket?: string;
+}
+
+/**
+ * #3176 — the fleet-wide "every account is flagship-tier walled" alert. Set
+ * when a model-tier failover finds no premium-eligible target, so the gateway
+ * can surface an operator card naming the bucket and the earliest recovery.
+ * Persisted as `premium-tier-all-walled.json`; cleared once any account's
+ * canary reads the tier allowed again.
+ */
+export interface PremiumTierAllWalled {
+  /** The binding bucket (seven_day_overage_included). */
+  bucket: string | null;
+  /** Epoch ms of the earliest tier reset across all walled accounts, when known. */
+  earliest_reset?: number;
+  /** Unix ms the all-walled condition was recorded. */
+  at: number;
 }
 
 /**
@@ -320,6 +362,30 @@ interface LastQuotaEntry {
 
 interface LastQuotaCache {
   [label: string]: LastQuotaEntry;
+}
+
+/**
+ * #3176 — flagship-tier (`7d_oi` / `seven_day_overage_included`) canary
+ * snapshot, written after each premium-canary probe in the fleet tick. Kept
+ * separate from {@link LastQuotaEntry} (the haiku probe's 5h/7d snapshot) so
+ * the two probe models never overwrite each other's windows. Persisted to
+ * `last-tier-quota.json` and exposed via `list-state` for transparency.
+ */
+interface LastTierQuotaEntry {
+  /** Overall `anthropic-ratelimit-unified-status` (allowed/rejected). */
+  unifiedStatus: string | null;
+  /** `anthropic-ratelimit-unified-7d_oi-status` (allowed/rejected). */
+  sevenDayOiStatus: string | null;
+  /** `7d_oi` bucket utilization (0-100), when the header was present. */
+  sevenDayOiUtilizationPct: number | null;
+  /** ISO string of the tier-wall reset (7d_oi-reset / unified-reset / retry-after). */
+  sevenDayOiResetAt: string | null;
+  /** Unix ms when this canary snapshot was captured. */
+  capturedAt: number;
+}
+
+interface LastTierQuotaCache {
+  [label: string]: LastTierQuotaEntry;
 }
 
 interface ShaIndex {
@@ -386,6 +452,12 @@ function cachedSnapshotToResult(s: LastQuotaEntry): QuotaResult {
       overageDisabledReason: s.overageDisabledReason,
       fiveHourUtilPresent: s.fiveHourUtilPresent,
       sevenDayUtilPresent: s.sevenDayUtilPresent,
+      // #3176 — the haiku 5h/7d cache carries no flagship-tier signal; the
+      // canary owns those in `lastTierQuotaCache`. Null here by construction.
+      unifiedStatus: null,
+      sevenDayOiStatus: null,
+      sevenDayOiUtilizationPct: null,
+      sevenDayOiResetAt: null,
     },
   };
 }
@@ -495,6 +567,13 @@ export class AuthBroker {
   /** Most recent broker-initiated proactive fleet roll (see LastFleetRoll).
    *  Persisted so a restart doesn't drop a pending announcement. */
   private lastFleetRoll: LastFleetRoll | null = null;
+  /** #3176 — per-account flagship-tier (`7d_oi`) canary snapshot. Kept
+   *  SEPARATE from `lastQuotaCache` (which the haiku probe owns) so the two
+   *  probes never clobber each other's windows. Persisted to
+   *  `last-tier-quota.json`, reloaded on boot. */
+  private lastTierQuotaCache: LastTierQuotaCache = {};
+  /** #3176 — resolved model-tier canary probe model (env-overridable). */
+  private readonly modelTierProbeModel: string = resolveModelTierProbeModel();
   /** Last `expiresAt` the broker wrote per label — drives threshold-violation. */
   private lastWrittenExpiresAt = new Map<string, number | undefined>();
   /** Refresh leases held while a POST is in flight (in-process). */
@@ -1272,6 +1351,171 @@ export class AuthBroker {
     });
   }
 
+  /* ─── Model-tier (7d_oi / seven_day_overage_included) wall (#3176) ─── */
+
+  /** View a quota-ledger entry as a model-tier wall mark — only when it
+   *  carries one. */
+  private premiumWallMarkOf(account: string): ModelTierWallMark | undefined {
+    const q = this.quota[account];
+    if (!q || q.premium_walled_until === undefined) return undefined;
+    return {
+      premium_walled_until: q.premium_walled_until,
+      premium_wall_bucket: q.premium_wall_bucket,
+      premium_wall_marked_at: q.premium_wall_marked_at,
+    };
+  }
+
+  /**
+   * True when `account` is walled on the FLAGSHIP tier right now (#3176).
+   * Live-truth first: a fresh canary snapshot that positively read the tier
+   * `allowed` (newer than the mark) clears it; otherwise an unexpired mark
+   * governs. Consulted ONLY by the fleet-active roll/serving path — a tier
+   * wall benches flagship traffic, never opus/haiku.
+   */
+  private isAccountPremiumWalled(account: string): boolean {
+    const mark = this.premiumWallMarkOf(account);
+    const tier = this.lastTierQuotaCache[account];
+    // A canary that ran AFTER the mark and read the tier allowed is live truth.
+    const tierAllowed =
+      tier != null &&
+      tier.capturedAt >= (mark?.premium_wall_marked_at ?? 0) &&
+      this.now() - tier.capturedAt <= SNAPSHOT_STALE_AGE_MS &&
+      (tier.unifiedStatus === "allowed" || tier.sevenDayOiStatus === "allowed") &&
+      !(tier.sevenDayOiStatus === "rejected");
+    return isModelTierWalled({
+      mark,
+      now: this.now(),
+      snapshotTierAllowed: tierAllowed ? true : undefined,
+    });
+  }
+
+  /**
+   * Cache a premium-canary result and reconcile the tier-wall mark (#3176).
+   * A walled result is left to the caller (it may need to roll the fleet); a
+   * result that positively reads the tier allowed CLEARS a stale mark; an
+   * inconclusive result (failed probe / no tier headers / rotted canary id)
+   * is a no-op — it never clears a real wall.
+   */
+  private recordTierProbe(label: string, result: QuotaResult): void {
+    if (result.ok) {
+      const d = result.data;
+      this.lastTierQuotaCache[label] = {
+        unifiedStatus: d.unifiedStatus ?? null,
+        sevenDayOiStatus: d.sevenDayOiStatus ?? null,
+        sevenDayOiUtilizationPct: d.sevenDayOiUtilizationPct ?? null,
+        sevenDayOiResetAt: d.sevenDayOiResetAt?.toISOString() ?? null,
+        capturedAt: this.now(),
+      };
+      this.persistLastTierQuotaCache();
+    }
+    // Self-heal: a fresh canary that positively reads the tier allowed clears
+    // any lingering tier-wall mark so the account rejoins flagship serving.
+    const entry = this.quota[label];
+    if (quotaTierAllowed(result) && entry?.premium_walled_until !== undefined) {
+      const { premium_walled_until, premium_wall_bucket, premium_wall_marked_at, ...rest } = entry;
+      void premium_walled_until;
+      void premium_wall_bucket;
+      void premium_wall_marked_at;
+      this.quota[label] = rest;
+      this.persistQuota();
+      process.stdout.write(
+        `auth-broker: premium canary shows ${label} flagship-tier allowed — cleared model-tier wall mark\n`,
+      );
+      this.fanoutToAffectedConsumers(label);
+    }
+    // An account that can serve the flagship again lifts a fleet-wide
+    // all-walled alert.
+    if (quotaTierAllowed(result)) this.clearPremiumAllWalled();
+  }
+
+  /**
+   * First flagship-eligible failover target for `from` (#3176): the first
+   * `fallback_order` account, starting after `from`, that exists, has stored
+   * credentials, and is NEITHER exhausted NOR premium-walled. Null when every
+   * candidate is walled on the flagship tier (or exhausted) — the honest
+   * all-walled path, which the caller surfaces with the earliest reset.
+   */
+  private nextPremiumEligibleAccount(from: string): string | null {
+    const order = this.config.auth?.fallback_order ?? [];
+    const start = order.indexOf(from);
+    const ring =
+      start === -1
+        ? [...order]
+        : order.map((_, i) => order[(start + 1 + i) % order.length]);
+    for (const cand of ring) {
+      if (!cand || cand === from) continue;
+      if (this.isAccountExhausted(cand)) continue;
+      if (this.isAccountPremiumWalled(cand)) continue;
+      if (!accountExists(cand, this.home)) continue;
+      if (!readAccountCredentials(cand, this.home)) continue;
+      return cand;
+    }
+    return null;
+  }
+
+  /**
+   * The earliest flagship-tier reset across all walled accounts, for the
+   * all-walled operator card ("recovers at …"). Null when nothing is walled.
+   */
+  private earliestPremiumWallReset(): number | null {
+    let earliest: number | null = null;
+    for (const label of listAccounts(this.home)) {
+      const until = this.quota[label]?.premium_walled_until;
+      if (until != null && (earliest == null || until < earliest)) earliest = until;
+    }
+    return earliest;
+  }
+
+  /**
+   * Mark `account` walled on the flagship tier and roll the fleet off it
+   * (#3176). Unlike `markExhaustedAndRoll` this is TIER-SCOPED: it writes a
+   * `premium_walled_until` mark (not a blanket `exhausted_until`), selects a
+   * flagship-ELIGIBLE target (not merely non-exhausted), and — when `account`
+   * is the fleet active and a target exists — durably promotes the target so
+   * the fleet stops routing flagship agents onto the walled account. The
+   * canary that triggered this IS the fresh corroboration, so the promote is
+   * not gated on a 5h/7d snapshot (which a tier wall never trips).
+   */
+  private markPremiumWalledAndRoll(
+    account: string,
+    until: number | null,
+    bucket: string | null,
+  ): { rolledTo: string | null; allWalled: boolean; earliestReset: number | null } {
+    const now = this.now();
+    const premiumWalledUntil = until ?? now + MODEL_TIER_WALL_DEFAULT_MS;
+    this.quota[account] = {
+      ...this.quota[account],
+      premium_walled_until: premiumWalledUntil,
+      premium_wall_bucket: bucket ?? undefined,
+      premium_wall_marked_at: now,
+    };
+    this.persistQuota();
+    const target = this.nextPremiumEligibleAccount(account);
+    if (!target) {
+      // Every account is flagship-walled (or exhausted). Honest all-walled —
+      // do NOT roll (nowhere better to go); surface the earliest reset.
+      return { rolledTo: null, allWalled: true, earliestReset: this.earliestPremiumWallReset() };
+    }
+    this.fanoutFailoverTo(account, target);
+    this.fanoutToAffectedConsumers(account);
+    // A flagship-eligible target exists → clear any fleet-wide all-walled alert.
+    this.clearPremiumAllWalled();
+    if (this.config.auth?.active === account) {
+      this.config = {
+        ...this.config,
+        auth: { ...(this.config.auth ?? {}), active: target },
+      };
+      this.persistActiveOverride(target);
+      this.fanoutAllConsumers();
+      this.audit({ op: "auto-promote-active", identity: { kind: "operator" }, account: target, accountKind: "claude", ok: true, reason: "model-tier-wall" });
+      process.stdout.write(
+        `auth-broker: auto-promoted auth.active ${account} → ${target} ` +
+          `(${account} flagship-tier walled until ${new Date(premiumWalledUntil).toISOString()}, bucket=${bucket ?? "?"}) — persisted\n`,
+      );
+    }
+    return { rolledTo: target, allWalled: false, earliestReset: null };
+  }
+
   /* ─── Soft-avoid tier (#3031, PR 1/4) ───────────────────────── */
 
   /** Per-account soft-avoid hysteresis (in-memory; re-derived from the next
@@ -1671,6 +1915,12 @@ export class AuthBroker {
         // Cached utilization snapshot from the most recent probeQuota call.
         // null when no probe has been run since broker start.
         last_quota: lq ?? null,
+        // #3176 — flagship-tier (7d_oi) wall: live-authoritative verdict +
+        // raw mark + latest canary snapshot for the dashboard/operator card.
+        premium_walled: this.isAccountPremiumWalled(label),
+        premium_walled_until: q?.premium_walled_until,
+        premium_wall_bucket: q?.premium_wall_bucket,
+        last_tier_quota: this.lastTierQuotaCache[label] ?? null,
       };
     });
     const agents = Object.entries(this.config.agents ?? {}).map(([name, agent]) => {
@@ -1706,6 +1956,9 @@ export class AuthBroker {
         // #3031 — most recent broker-initiated proactive roll, so gateways
         // can announce it (null until the first proactive roll).
         last_fleet_roll: this.lastFleetRoll,
+        // #3176 — fleet-wide flagship-tier all-walled alert (null unless every
+        // account is walled on the 7d_oi bucket with no eligible failover).
+        premium_tier_all_walled: this.premiumTierAllWalled,
       }),
     );
   }
@@ -1927,6 +2180,15 @@ export class AuthBroker {
     // candidates the loop simply hadn't reached yet (stale/absent snapshots)
     // — most visibly on the boot tick, where nothing is cached at all.
     const probed: Array<{ label: string; result: QuotaResult }> = [];
+    // #3176 — accounts whose flagship-tier canary reported a 7d_oi wall this
+    // tick, collected in Phase 1 and acted on in Phase 2 (same probe-all-then-
+    // act discipline the exhaustion path uses).
+    const tierWalled = new Map<string, { until: number | null; bucket: string | null }>();
+    // The set the premium canary probes: the fleet active + fallback candidates
+    // + pinned agent accounts. Probing only the serving set bounds flagship
+    // spend (a 200 canary costs one flagship token; a walled canary 429s free).
+    const canarySet = this.premiumCanarySet();
+    const canaryEnabled = process.env.SWITCHROOM_DISABLE_MODEL_TIER_PROBE !== "1";
     for (const label of listAccounts(this.home)) {
       const creds = readAccountCredentials(label, this.home);
       const token = creds?.claudeAiOauth?.accessToken;
@@ -1940,7 +2202,39 @@ export class AuthBroker {
       }
       this.cacheQuotaSnapshot(label, result);
       probed.push({ label, result });
+      // #3176 — flagship-tier canary. The default haiku probe above CANNOT see
+      // the per-tier 7d_oi wall (haiku is `allowed` while flagship is
+      // `rejected`), so we issue a second 1-token request against the flagship
+      // tier and read its own response headers.
+      if (canaryEnabled && canarySet.has(label)) {
+        let tierResult: QuotaResult;
+        try {
+          tierResult = await this.fetchQuotaImpl({ accessToken: token, model: this.modelTierProbeModel });
+        } catch (err) {
+          this.logErr(`fleet-tier-probe ${label}: ${(err as Error).message}`);
+          continue;
+        }
+        this.recordTierProbe(label, tierResult);
+        const wall = quotaIndicatesModelTierWall(tierResult);
+        if (wall.walled) tierWalled.set(label, { until: wall.until, bucket: wall.bucket });
+      }
     }
+    // #3176 — pre-mark EVERY flagship-walled account before the roll phase.
+    // Without this, Phase 2 marks accounts one at a time, so the first walled
+    // account's roll would pick a second walled account that simply hadn't
+    // been marked yet (same ordering hazard the exhaustion path avoids by
+    // probing all before acting). Marking first makes
+    // `nextPremiumEligibleAccount` see the true fleet-wide state.
+    for (const [label, wall] of tierWalled) {
+      const now = this.now();
+      this.quota[label] = {
+        ...this.quota[label],
+        premium_walled_until: wall.until ?? now + MODEL_TIER_WALL_DEFAULT_MS,
+        premium_wall_bucket: wall.bucket ?? undefined,
+        premium_wall_marked_at: now,
+      };
+    }
+    if (tierWalled.size > 0) this.persistQuota();
     // Phase 2 — act on the fleet ACTIVE and on PINNED agent accounts.
     for (const { label, result } of probed) {
       // Re-read active each iteration: a promote earlier in this loop moves it.
@@ -1952,6 +2246,25 @@ export class AuthBroker {
       // active does. Non-active, non-pinned labels stay probe-only.
       const isPinnedAgentAccount = this.pinnedAgentAccounts().has(label);
       if (label !== active && !isPinnedAgentAccount) continue;
+      // #3176 — flagship-tier (7d_oi) wall acts BEFORE the 5h/7d exhaustion
+      // check: this is exactly the case the haiku probe reads healthy (the
+      // incident). A tier wall is tier-scoped (the account still serves
+      // opus/haiku), so it takes the dedicated tier roll, not mark-exhausted.
+      const tw = tierWalled.get(label);
+      if (tw) {
+        process.stdout.write(
+          `auth-broker: fleet-tier-probe shows ${label === active ? "ACTIVE" : "PINNED"} ${label} ` +
+            `flagship-tier walled (bucket=${tw.bucket ?? "?"}) — model-tier failover\n`,
+        );
+        this.audit({ op: "mark-exhausted", identity: { kind: "operator" }, account: label, accountKind: "claude", ok: true, reason: "model-tier-wall" });
+        const { rolledTo, allWalled, earliestReset } = this.markPremiumWalledAndRoll(label, tw.until, tw.bucket);
+        if (rolledTo && label === active) {
+          this.recordFleetRoll(label, rolledTo, "model-tier-wall", tw.until ?? undefined);
+        } else if (allWalled && label === active) {
+          this.recordPremiumAllWalled(tw.bucket, earliestReset);
+        }
+        continue;
+      }
       const decision = quotaIndicatesExhaustion(result, this.isOverageAllowed(label));
       if (decision.exhausted) {
         process.stdout.write(
@@ -1995,8 +2308,9 @@ export class AuthBroker {
   private recordFleetRoll(
     from: string,
     to: string,
-    reason: "soft-avoid" | "hard-exhaustion",
+    reason: "soft-avoid" | "hard-exhaustion" | "model-tier-wall",
     exhaustedUntil?: number,
+    bucket?: string | null,
   ): void {
     const s = this.lastQuotaCache[from];
     this.lastFleetRoll = {
@@ -2004,8 +2318,12 @@ export class AuthBroker {
       to,
       at: this.now(),
       reason,
+      ...(bucket ? { bucket } : {}),
       ...(exhaustedUntil != null ? { exhausted_until: exhaustedUntil } : {}),
-      ...(s
+      // A model-tier wall does not bind on the 5h/7d windows — those read
+      // healthy (the whole point of the bug). Only stamp window/pct for the
+      // 5h/7d-driven rolls, where they are meaningful.
+      ...(s && reason !== "model-tier-wall"
         ? {
             window:
               s.fiveHourUtilizationPct >= s.sevenDayUtilizationPct
@@ -2016,6 +2334,54 @@ export class AuthBroker {
         : {}),
     };
     this.persistLastFleetRoll();
+  }
+
+  /* ─── Premium-tier all-walled alert (#3176) ─────────────────── */
+
+  /** Fleet-wide "every account is flagship-tier walled" state (see
+   *  {@link PremiumTierAllWalled}). Persisted so a restart doesn't drop the
+   *  operator alert. Null when at least one account can serve the flagship. */
+  private premiumTierAllWalled: PremiumTierAllWalled | null = null;
+
+  /** Record the all-flagship-walled condition for the operator card. */
+  private recordPremiumAllWalled(bucket: string | null, earliestReset: number | null): void {
+    this.premiumTierAllWalled = {
+      bucket,
+      ...(earliestReset != null ? { earliest_reset: earliestReset } : {}),
+      at: this.now(),
+    };
+    atomicWriteJsonSync(
+      join(this.stateDir, "premium-tier-all-walled.json"),
+      this.premiumTierAllWalled,
+      0o600,
+    );
+    process.stdout.write(
+      `auth-broker: ALL accounts flagship-tier walled (bucket=${bucket ?? "?"}` +
+        `${earliestReset != null ? `, earliest reset ${new Date(earliestReset).toISOString()}` : ""}) ` +
+        `— no premium-eligible failover target\n`,
+    );
+  }
+
+  /** Clear the all-walled alert once any account can serve the flagship again. */
+  private clearPremiumAllWalled(): void {
+    if (this.premiumTierAllWalled == null) return;
+    this.premiumTierAllWalled = null;
+    try { unlinkSync(join(this.stateDir, "premium-tier-all-walled.json")); } catch { /* best-effort */ }
+  }
+
+  /**
+   * The set of accounts the flagship-tier canary probes each tick: the fleet
+   * active, every `fallback_order` candidate (so a wall is seen BEFORE the
+   * fleet rolls onto it), and every pinned agent account. Bounds flagship
+   * spend to the serving set.
+   */
+  private premiumCanarySet(): Set<string> {
+    const set = new Set<string>();
+    const active = this.config.auth?.active;
+    if (active) set.add(active);
+    for (const cand of this.config.auth?.fallback_order ?? []) set.add(cand);
+    for (const acct of this.pinnedAgentAccounts()) set.add(acct);
+    return set;
   }
 
   /** Every account some agent is pinned to via per-agent `auth.override`. */
@@ -3696,6 +4062,9 @@ export class AuthBroker {
     // #2495 Change 1 — reload the durable utilization cache so a restart
     // serves last-known (age-stamped) quota, not a blank card.
     this.lastQuotaCache = this.readJson<LastQuotaCache>("last-quota.json") ?? {};
+    // #3176 — reload the durable flagship-tier canary cache + all-walled alert.
+    this.lastTierQuotaCache = this.readJson<LastTierQuotaCache>("last-tier-quota.json") ?? {};
+    this.premiumTierAllWalled = this.readJson<PremiumTierAllWalled>("premium-tier-all-walled.json") ?? null;
     this.applyActiveOverride();
   }
 
@@ -3760,6 +4129,8 @@ export class AuthBroker {
   /** #2495 Change 1 — mirror the utilization cache to disk so it survives
    *  a broker restart. Same atomic-write pattern as the exhaustion ledger. */
   private persistLastQuotaCache(): void { atomicWriteJsonSync(join(this.stateDir, "last-quota.json"), this.lastQuotaCache, 0o600); }
+  /** #3176 — mirror the flagship-tier canary cache to disk. */
+  private persistLastTierQuotaCache(): void { atomicWriteJsonSync(join(this.stateDir, "last-tier-quota.json"), this.lastTierQuotaCache, 0o600); }
   private persistNotificationClaims(): void { atomicWriteJsonSync(join(this.stateDir, "notification-claims.json"), this.notificationClaims, 0o600); }
   private persistLastFleetRoll(): void { if (this.lastFleetRoll) atomicWriteJsonSync(join(this.stateDir, "last-fleet-roll.json"), this.lastFleetRoll, 0o600); }
   private persistShaIndex(): void { atomicWriteJsonSync(join(this.stateDir, "sha-index.json"), this.shaIndex, 0o600); }
@@ -3827,9 +4198,11 @@ export class AuthBroker {
      *   "hard-exhaustion"     — the probe saw a genuine quota wall
      *   "throttle-escalation" — repeated transient 429s corroborated by a live
      *                           probe (429 throttle tier escalation guard)
+     *   "model-tier-wall"     — flagship-tier (7d_oi) canary saw the account
+     *                           walled on the premium tier (#3176)
      * Omitted for every other op.
      */
-    reason?: "soft-avoid" | "hard-exhaustion" | "throttle-escalation";
+    reason?: "soft-avoid" | "hard-exhaustion" | "throttle-escalation" | "model-tier-wall";
   }): void {
     const peer =
       entry.identity.kind === "operator"
@@ -3988,6 +4361,10 @@ export class AuthBroker {
     listeners: string[];
     /** #2495 Change 1 — durable utilization cache (in-memory view). */
     lastQuotaCache: LastQuotaCache;
+    /** #3176 — flagship-tier canary cache + all-walled alert + live active. */
+    lastTierQuotaCache: LastTierQuotaCache;
+    premiumTierAllWalled: PremiumTierAllWalled | null;
+    activeAccount: string | undefined;
   } {
     return {
       quota: { ...this.quota },
@@ -3995,6 +4372,11 @@ export class AuthBroker {
       thresholdViolations: { ...this.thresholdViolations },
       listeners: [...this.listeners.keys()],
       lastQuotaCache: structuredClone(this.lastQuotaCache),
+      lastTierQuotaCache: structuredClone(this.lastTierQuotaCache),
+      premiumTierAllWalled: this.premiumTierAllWalled
+        ? { ...this.premiumTierAllWalled }
+        : null,
+      activeAccount: this.config.auth?.active,
     };
   }
 

--- a/src/auth/quota-model-tier.test.ts
+++ b/src/auth/quota-model-tier.test.ts
@@ -1,0 +1,105 @@
+/**
+ * #3176 — `parseQuotaHeaders` must capture the model-tier (`7d_oi` /
+ * `seven_day_overage_included`) bucket signals, using the EXACT header shapes
+ * observed on 2026-07-12 (direct probe of a single account, same moment):
+ *
+ *   model=claude-fable-5  -> 429, unified-status=rejected, 7d_oi-status=rejected,
+ *                            7d_oi-utilization=1.0,
+ *                            representative-claim=seven_day_overage_included,
+ *                            retry-after=10195, unified-reset=1783850400
+ *   model=claude-opus-4-8 -> 200, unified-status=allowed, 5h util 0.01, 7d 0.58
+ *   model=claude-haiku-4-5 -> 200 (healthy; carries no 7d_oi rejection)
+ *
+ * These tests FAIL on pristine main: `parseQuotaHeaders` there parses only the
+ * 5h/7d/representative-claim/overage headers and returns `ok:false` on a
+ * response that carries ONLY the 7d_oi tier headers (the fable 429).
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseQuotaHeaders } from "./quota.js";
+
+/** The exact fable-5 429 header set from the 2026-07-12 evidence. */
+function fableWalled429(): Headers {
+  return new Headers({
+    "anthropic-ratelimit-unified-status": "rejected",
+    "anthropic-ratelimit-unified-7d_oi-status": "rejected",
+    "anthropic-ratelimit-unified-7d_oi-utilization": "1.0",
+    "anthropic-ratelimit-unified-representative-claim": "seven_day_overage_included",
+    "retry-after": "10195",
+    "anthropic-ratelimit-unified-reset": "1783850400",
+  });
+}
+
+/** The exact opus-4-8 200 header set (healthy) from the same moment. */
+function opusOk200(): Headers {
+  return new Headers({
+    "anthropic-ratelimit-unified-status": "allowed",
+    "anthropic-ratelimit-unified-5h-utilization": "0.01",
+    "anthropic-ratelimit-unified-7d-utilization": "0.58",
+    "anthropic-ratelimit-unified-7d_oi-status": "allowed",
+  });
+}
+
+describe("#3176 parseQuotaHeaders — model-tier (7d_oi) bucket", () => {
+  it("parses a fable-5 429 that carries ONLY the tier headers (ok, not rejected as headerless)", () => {
+    const now = new Date("2026-07-12T06:34:45Z");
+    const res = parseQuotaHeaders(fableWalled429(), now);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.unifiedStatus).toBe("rejected");
+    expect(res.data.sevenDayOiStatus).toBe("rejected");
+    expect(res.data.sevenDayOiUtilizationPct).toBe(100);
+    expect(res.data.representativeClaim).toBe("seven_day_overage_included");
+    expect(res.data.sevenDayOiPresent).toBe(true);
+  });
+
+  it("resolves the tier reset from unified-reset (preferred over retry-after here)", () => {
+    const now = new Date("2026-07-12T06:34:45Z");
+    const res = parseQuotaHeaders(fableWalled429(), now);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    // unified-reset=1783850400 (epoch seconds) wins over retry-after.
+    expect(res.data.sevenDayOiResetAt?.getTime()).toBe(1783850400 * 1000);
+  });
+
+  it("falls back to retry-after when no reset epoch header is present", () => {
+    const now = new Date("2026-07-12T06:34:45Z");
+    const h = new Headers({
+      "anthropic-ratelimit-unified-7d_oi-status": "rejected",
+      "anthropic-ratelimit-unified-7d_oi-utilization": "1.0",
+      "retry-after": "10195",
+    });
+    const res = parseQuotaHeaders(h, now);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.sevenDayOiResetAt?.getTime()).toBe(now.getTime() + 10195 * 1000);
+  });
+
+  it("an opus-4-8 200 reads tier allowed, 5h/7d healthy", () => {
+    const res = parseQuotaHeaders(opusOk200());
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.unifiedStatus).toBe("allowed");
+    expect(res.data.sevenDayOiStatus).toBe("allowed");
+    expect(res.data.fiveHourUtilizationPct).toBeCloseTo(1);
+    expect(res.data.sevenDayUtilizationPct).toBeCloseTo(58);
+  });
+
+  it("a headerless response (no unified headers at all) still returns ok:false", () => {
+    const res = parseQuotaHeaders(new Headers({ "content-type": "application/json" }));
+    expect(res.ok).toBe(false);
+  });
+
+  it("a plain haiku 5h/7d probe leaves the tier fields null/absent (no false wall)", () => {
+    const h = new Headers({
+      "anthropic-ratelimit-unified-5h-utilization": "0.01",
+      "anthropic-ratelimit-unified-7d-utilization": "0.58",
+    });
+    const res = parseQuotaHeaders(h);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.sevenDayOiStatus).toBeNull();
+    expect(res.data.sevenDayOiUtilizationPct).toBeNull();
+    expect(res.data.sevenDayOiPresent).toBe(false);
+  });
+});

--- a/src/auth/quota.ts
+++ b/src/auth/quota.ts
@@ -40,6 +40,43 @@ export const DEFAULT_USER_AGENT = "claude-cli/1.0.0 (external, cli)";
  */
 export const DEFAULT_PROBE_MODEL = "claude-haiku-4-5-20251001";
 
+/**
+ * Model-tier canary probe model (#3176). The `7d_oi`
+ * (`seven_day_overage_included`) quota bucket is PER-MODEL-TIER: an account
+ * can be `rejected` on the flagship (Fable) tier while `allowed` on
+ * opus/haiku (verified 2026-07-12 — same account, same moment, fable=429 /
+ * opus=200 / haiku=200). The default haiku probe therefore CANNOT observe a
+ * Fable-tier wall, so a walled account looked healthy and the fleet stormed
+ * it. This probe issues the 1-token request against the flagship tier so its
+ * OWN 429/200 response carries the tier signal.
+ *
+ * Overridable via `SWITCHROOM_MODEL_TIER_PROBE_MODEL`. Unlike the model
+ * PICKER (where a stale pinned id 4xx's the fleet — the 2026-06-13
+ * `claude-fable-5` incident), a stale id HERE is safe: a non-429 response
+ * (incl. a 4xx "model not found") is classified as "no tier wall observed",
+ * so a rotted id degrades the canary to a benign no-op, never a mismark. Keep
+ * this pointed at the current flagship id; update it here (or via env) when
+ * the flagship id changes.
+ */
+export const DEFAULT_MODEL_TIER_PROBE_MODEL = "claude-fable-5";
+
+/** Resolve the model-tier canary probe model from env, else the default. */
+export function resolveModelTierProbeModel(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const raw = env.SWITCHROOM_MODEL_TIER_PROBE_MODEL;
+  if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
+  return DEFAULT_MODEL_TIER_PROBE_MODEL;
+}
+
+/**
+ * Anthropic's `representative-claim` value naming the model-tier weekly
+ * overage bucket. When the unified status is `rejected` and this is the
+ * binding claim, the account is walled on the flagship (Fable) tier — the
+ * `7d_oi` bucket — regardless of how healthy the 5h/7d windows read.
+ */
+export const MODEL_TIER_REPRESENTATIVE_CLAIM = "seven_day_overage_included";
+
 export type QuotaUtilization = {
   fiveHourUtilizationPct: number;
   sevenDayUtilizationPct: number;
@@ -48,6 +85,27 @@ export type QuotaUtilization = {
   representativeClaim: string | null;
   overageStatus: string | null;
   overageDisabledReason: string | null;
+  /**
+   * #3176 — model-tier (7d_oi / seven_day_overage_included) bucket signals.
+   * These come from a request issued AGAINST the flagship tier (the default
+   * haiku probe leaves them null). `unifiedStatus` is the overall
+   * allowed/rejected verdict; `sevenDayOiStatus` is the per-tier bucket
+   * status; `sevenDayOiUtilizationPct` is that bucket's utilization (0-100);
+   * `sevenDayOiResetAt` is when the tier wall lifts (from the `7d_oi-reset`
+   * header, else the overall `unified-reset`, else `retry-after`).
+   *
+   * Optional (default-null semantics) so hand-built fixtures and cached/legacy
+   * snapshots that predate the field still satisfy the type — an absent field
+   * reads as "the probe carried no tier signal", never a wall.
+   */
+  unifiedStatus?: string | null;
+  sevenDayOiStatus?: string | null;
+  sevenDayOiUtilizationPct?: number | null;
+  sevenDayOiResetAt?: Date | null;
+  /** True when the probe response actually carried a `7d_oi` bucket header —
+   *  lets consumers tell "tier bucket absent (haiku probe)" from "measured
+   *  and healthy". Absent (undefined) on legacy/cached snapshots. */
+  sevenDayOiPresent?: boolean;
   /**
    * #2494 Bug C — header-presence markers. The two utilization fields are
    * always numeric (a missing header coalesces to 0 for back-compat), so on
@@ -107,32 +165,77 @@ function parseEpochHeader(headers: Headers, name: string): Date | null {
   return new Date(n * 1000);
 }
 
-export function parseQuotaHeaders(headers: Headers): QuotaResult {
+/**
+ * #3176 — resolve the tier-bucket reset. Prefer the per-bucket `7d_oi-reset`
+ * header, fall back to the overall `unified-reset`, then to `retry-after`
+ * (seconds from now) which a 429 always carries. `now` is injectable so the
+ * retry-after anchor is testable.
+ */
+function parseTierReset(headers: Headers, now: Date): Date | null {
+  const oi = parseEpochHeader(headers, "anthropic-ratelimit-unified-7d_oi-reset");
+  if (oi != null) return oi;
+  const unified = parseEpochHeader(headers, "anthropic-ratelimit-unified-reset");
+  if (unified != null) return unified;
+  const ra = headers.get("retry-after");
+  if (ra != null) {
+    const secs = Number(ra);
+    if (Number.isFinite(secs) && secs > 0 && secs < 30 * 24 * 3600) {
+      return new Date(now.getTime() + secs * 1000);
+    }
+  }
+  return null;
+}
+
+export function parseQuotaHeaders(
+  headers: Headers,
+  now: Date = new Date(),
+): QuotaResult {
   const fiveHour = parseFloatHeader(headers, "anthropic-ratelimit-unified-5h-utilization");
   const sevenDay = parseFloatHeader(headers, "anthropic-ratelimit-unified-7d-utilization");
-  if (fiveHour == null && sevenDay == null) {
+  // #3176 — model-tier (7d_oi) bucket + overall unified verdict. Present on a
+  // request issued against the flagship tier (a 429 wall carries these even
+  // when the 5h/7d utilization headers are omitted).
+  const unifiedStatus = headers.get("anthropic-ratelimit-unified-status");
+  const sevenDayOiStatus = headers.get("anthropic-ratelimit-unified-7d_oi-status");
+  const sevenDayOiUtil = parseFloatHeader(
+    headers,
+    "anthropic-ratelimit-unified-7d_oi-utilization",
+  );
+  const representativeClaim = headers.get(
+    "anthropic-ratelimit-unified-representative-claim",
+  );
+  const hasTierSignal =
+    unifiedStatus != null || sevenDayOiStatus != null || sevenDayOiUtil != null;
+  if (fiveHour == null && sevenDay == null && !hasTierSignal) {
     return {
       ok: false,
       reason: "no unified rate-limit headers in response (API token, not OAuth?)",
     };
   }
+  const oiPresent = sevenDayOiStatus != null || sevenDayOiUtil != null;
   return {
     ok: true,
     data: {
       // #2494 Bug C — we still coalesce a missing window header to 0 so the
       // numeric fields stay non-null for back-compat, but record which
       // windows were actually present so renderers can tell a real 0% from a
-      // filled-0. (Both-absent already returned ok:false above, so at least
-      // one of these is true here.)
+      // filled-0. (All-absent already returned ok:false above, so at least
+      // one signal is present here.)
       fiveHourUtilizationPct: (fiveHour ?? 0) * 100,
       sevenDayUtilizationPct: (sevenDay ?? 0) * 100,
       fiveHourUtilPresent: fiveHour != null,
       sevenDayUtilPresent: sevenDay != null,
       fiveHourResetAt: parseEpochHeader(headers, "anthropic-ratelimit-unified-5h-reset"),
       sevenDayResetAt: parseEpochHeader(headers, "anthropic-ratelimit-unified-7d-reset"),
-      representativeClaim: headers.get("anthropic-ratelimit-unified-representative-claim"),
+      representativeClaim,
       overageStatus: headers.get("anthropic-ratelimit-unified-overage-status"),
       overageDisabledReason: headers.get("anthropic-ratelimit-unified-overage-disabled-reason"),
+      // #3176 — model-tier bucket signals.
+      unifiedStatus,
+      sevenDayOiStatus,
+      sevenDayOiUtilizationPct: sevenDayOiUtil != null ? sevenDayOiUtil * 100 : null,
+      sevenDayOiResetAt: parseTierReset(headers, now),
+      sevenDayOiPresent: oiPresent,
     },
   };
 }

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -245,9 +245,17 @@ export function buildFleetRollMessage(roll: FleetRollInfo, now: number): string 
       ? ` (resets ${formatRelative(new Date(roll.exhausted_until), new Date(now))})`
       : "";
   const softAvoid = roll.reason === "soft-avoid";
+  // #3176 — a model-tier wall binds on the flagship (premium) 7d_oi bucket, not
+  // the 5h/7d windows (which read healthy — the whole point of the bug), so it
+  // has no window/pct to cite. Name the flagship tier explicitly and reassure
+  // that opus/haiku on the walled account are unaffected (the mark is
+  // tier-scoped), rather than rendering a generic, misleading "quota window".
+  const modelTierWall = roll.reason === "model-tier-wall";
   const causeLine = softAvoid
     ? `Proactive switch — \`${codeSpanSafe(roll.from)}\` is approaching its limits (${winLabel}${pctPart})${resetPart}, so the fleet moved early instead of hitting the wall.`
-    : `${winLabel}${pctPart} on \`${codeSpanSafe(roll.from)}\`${resetPart}.`;
+    : modelTierWall
+      ? `Flagship (premium) tier weekly limit reached on \`${codeSpanSafe(roll.from)}\`${resetPart} — opus/haiku on that account are unaffected.`
+      : `${winLabel}${pctPart} on \`${codeSpanSafe(roll.from)}\`${resetPart}.`;
   return [
     `🔁 **Switched fleet to \`${codeSpanSafe(roll.to)}\`**`,
     ``,

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -192,10 +192,14 @@ export interface FleetRollInfo {
   /**
    * Trigger attribution (#3031 PR 2): "soft-avoid" = proactive
    * serving-preference roll off an account APPROACHING its limits;
-   * "hard-exhaustion" = the probe saw a genuine quota wall. Absent on
-   * pre-PR-2 brokers — rendered as hard exhaustion.
+   * "hard-exhaustion" = the probe saw a genuine quota wall;
+   * "model-tier-wall" = the flagship-tier (7d_oi) canary saw the account
+   * walled on the premium tier (#3176). Absent on pre-PR-2 brokers —
+   * rendered as hard exhaustion.
    */
-  reason?: "soft-avoid" | "hard-exhaustion";
+  reason?: "soft-avoid" | "hard-exhaustion" | "model-tier-wall";
+  /** #3176 — the binding tier bucket, set only when reason is model-tier-wall. */
+  bucket?: string;
 }
 
 export type FleetRollAnnounceDecision =

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -1170,4 +1170,25 @@ describe("buildFleetRollMessage — reason attribution (#3031 PR 2 reason field)
       expect(msg).toContain("7-day window at 96% on");
     }
   });
+
+  it("model-tier-wall (#3176) names the flagship tier and reassures opus/haiku are unaffected — not a generic quota window", () => {
+    // A tier wall binds on the 7d_oi bucket; window/pct are absent (5h/7d read
+    // healthy). exhausted_until carries the tier reset.
+    const roll: FleetRollInfo = {
+      from: "alice@example.com",
+      to: "bob@example.com",
+      at: NOW - 60_000,
+      reason: "model-tier-wall",
+      bucket: "seven_day_overage_included",
+      exhausted_until: NOW + 2.8 * 60 * 60 * 1000,
+    };
+    const msg = buildFleetRollMessage(roll, NOW);
+    expect(msg).toContain("Flagship (premium) tier weekly limit reached");
+    expect(msg).toContain("opus/haiku on that account are unaffected");
+    // Must NOT mislead as a generic 5h/7d window roll.
+    expect(msg).not.toContain("quota window");
+    expect(msg).not.toContain("Proactive switch");
+    // The tier reset is surfaced.
+    expect(msg).toContain("resets");
+  });
 });


### PR DESCRIPTION
Fixes #3176.

## Summary

The auth broker's quota probe is blind to Anthropic's per-model-tier `7d_oi`
(`seven_day_overage_included`) bucket. Because it probes with **haiku** and
records only 5h/7d utilization, an account hard-walled on the flagship (Fable)
tier reads healthy — so the broker sets it fleet-active and every flagship
agent 429-storms it (the 2026-07-12 incident: read `5h=1% / 7d=58%`, was 100%
walled on `7d_oi` with a ~2.8h `retry-after` invisible to us; 86-request storm
over ~5 min).

## Why

- `src/auth/quota.ts` parsed only `-5h-*` / `-7d-*` / `representative-claim` /
  `overage-*` headers, and returned `ok:false` on a response carrying only the
  tier headers (the fable 429).
- The probe model is haiku, so even parsing `7d_oi` off the existing probe
  cannot surface the Fable wall — the tier bucket is per-tier. Detection needs
  a request issued **against the flagship tier**, whose own 429/200 carries the
  signal.

## What changes

- **`quota.ts`** — `parseQuotaHeaders` captures `unified-status`,
  `7d_oi-status/utilization/reset`, widens the ok-gate so a tier-only 429
  parses, and resolves the tier reset from `7d_oi-reset` → `unified-reset` →
  `retry-after`. New fields are optional (fixtures/cached snapshots unaffected).
- **`model-tier-quota.ts`** (new, pure) — `quotaIndicatesModelTierWall`
  classifies a `7d_oi` rejection (or `representative-claim
  seven_day_overage_included`, or `>=wall` 7d_oi util) as an
  account-model-tier wall: **not transient, not proxy-local**.
  `quotaTierAllowed` / `isModelTierWalled` drive clearing + eligibility.
- **`server.ts`** — the fleet tick fires a 1-token **flagship canary** against
  the serving set (active + `fallback_order` + pinned). A walled canary
  records a **tier-scoped** `premium_walled_until` mark (the account still
  serves opus/haiku — never a blanket `exhausted_until`), rolls the fleet off
  it, and durably promotes a flagship-eligible target. All accounts walled →
  no roll, persisted all-walled alert with the earliest reset. A later canary
  reading the tier allowed self-heals the mark. Tier signals persist
  (`last-tier-quota.json`) and surface via `list-state`.
  - Kill-switch `SWITCHROOM_DISABLE_MODEL_TIER_PROBE=1`; canary model
    env-overridable (`SWITCHROOM_MODEL_TIER_PROBE_MODEL`, default
    `claude-fable-5`). A rotted id degrades safely — a non-429 is "no wall
    observed", never a mismark (unlike the model picker, where a stale id
    4xx's the fleet).
- **`client.ts` / `quota-watch.ts`** — list-state + roll-announce types carry
  the new `premium_walled*` fields and `model-tier-wall` reason + bucket.

## Design note / grounding

The repo deliberately keeps concrete flagship ids out of the model **picker**
(the 2026-06-13 `claude-fable-5` retirement 4xx'd the fleet). A probe id is a
different risk class: a stale id yields a benign non-429 that we treat as "no
wall", so the canary can pin `claude-fable-5` (currently the valid flagship, per
today's evidence) behind an env override without the picker's failure mode. The
tier wall is **tier-scoped by design** — a Fable wall must not bench opus/haiku,
which is why it is a separate mark, not `exhausted_until`.

## Test plan

- `src/auth/quota-model-tier.test.ts` — `parseQuotaHeaders` on the exact
  2026-07-12 header shapes (fable-walled 429, opus-ok 200, retry-after fallback,
  haiku no-tier).
- `src/auth/broker/model-tier-quota.test.ts` — classifier / `quotaTierAllowed` /
  `isModelTierWalled`.
- `src/auth/broker/server-model-tier-wall.test.ts` — fleet tick: tier-scoped
  mark + roll + promote, no false `exhausted_until`, all-walled earliest-reset
  alert, self-heal. **Sabotage-verified**: all 3 fail with the canary disabled.
- Scoped: `vitest run src/auth/` (534 pass), `quota-watch.test.ts` (77 pass),
  `npm run lint` clean.

## Risk

Adds ~1 flagship token per serving-account per fleet tick (a walled canary
429s free). Kill-switch + env-overridable model. No changes to telegram-plugin
send paths. Does not merge; CI-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
