### PR TITLE
feat(telegram): session-scope /model overrides (consume-once, revert on restart)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1130,23 +1130,28 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   unset sr_ll_key sr_ll_ok sr_ll_unreachable
 fi
 
-# --- Session model resolution (durable .session-model + .relaunch-model-intent) ---
+# --- Session model resolution (consume-once .session-model carrier) ---
 #
-# Contract: reference/rfcs/session-model-stickiness.md (#3039 revision). A
-# positively-confirmed `/model X` switch persists as
-# `{{agentDir}}/.session-model` (one-line JSON written by the gateway) and is
-# honored on EVERY boot — deploy, watchdog bounce, raw `docker restart`,
-# host reboot, crash. It is cleared only by:
+# Contract: reference/rfcs/session-model-stickiness.md §0.1 (rev 4, operator
+# decision 2026-07-12 — SESSION-SCOPED, superseding rev 3 keep-by-default). A
+# `/model` override lasts only for the current session:
 #
-#   - explicit user action (`/model default` deletes it live; a fresh
-#     (<10 min) explicit "revert" `.relaunch-model-intent` reverts at boot)
-#   - invalidation: corrupt/malformed file, or the configured yaml `model:`
-#     changed since the switch
+#   - Claude switches apply LIVE in-session (claude's native picker) and write
+#     NO carrier — the explicit `claude --model {{{modelQ}}}` this script execs
+#     reverts them for free on the next boot.
+#   - sr-* / sr→Claude switches and a queued /model persisted at shutdown need
+#     a relaunch to take effect, so the gateway writes `{{agentDir}}/.session-model`
+#     (one-line JSON) IMMEDIATELY before that relaunch. This block APPLIES the
+#     carrier on the single boot that reads it and then DELETES it (consume-once).
+#     Any SUBSEQUENT restart — deploy, `/restart`, `/new`, watchdog recovery,
+#     crash, raw `docker restart`, host reboot — finds no carrier and boots the
+#     configured default. That deletion is the marker distinguishing the
+#     model-apply relaunch from every later restart.
 #
-# Every clearing path writes `.session-model-alert`, which the gateway
-# relays to the operator chat once at boot — an override is never dropped
-# silently. Default (no intent / stale / corrupt intent) is KEEP (operator
-# decision 2026-07-11, superseding the earlier revert-by-default).
+# `/model default` deletes the carrier live. Invalidation paths (corrupt file,
+# configured yaml `model:` changed) also delete + write `.session-model-alert`,
+# which the gateway relays to the operator chat once at boot. The normal apply
+# path is silent here — the gateway already acked the `/model` in chat.
 #
 # NB {{{modelQ}}} is already shell-single-quoted by the scaffold (it renders as
 # a quoted token, e.g. 'claude-sonnet-5'), so it is assigned BARE here — never
@@ -1154,63 +1159,36 @@ fi
 # the value and break `claude --model`.
 _EFFECTIVE_MODEL={{{modelQ}}}
 # Record the RESOLVED configured default (raw, unquoted) every boot, before
-# override resolution. The gateway copies this into the override's
+# override resolution. The gateway copies this into the carrier's
 # `configuredDefaultAtWrite`, so both sides of the invalidation compare below
 # come from the same resolver. Overwrite, not consumed.
 printf '%s\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.configured-default-model" 2>/dev/null || true
 
-# Migration shim (one release, RFC §7): a leftover one-shot
-# `.session-model-override` carrier means an OLD gateway wrote it immediately
-# before this very bounce — it is the newest user intent and WINS over any
-# `.session-model` on disk. Convert (overwrite) + consume, and apply THIS
-# boot (the carrier's presence is itself the keep signal).
-_sm_keep=""
+# Migration shim (one release): a leftover one-shot `.session-model-override`
+# carrier from a pre-consume-once gateway means an OLD gateway wrote it
+# immediately before this very bounce — convert it to `.session-model` so the
+# block below applies + consumes it this boot (same one-shot semantics).
 if [ -f "{{agentDir}}/.session-model-override" ]; then
   _mig="$(tr -d '[:space:]' < "{{agentDir}}/.session-model-override" 2>/dev/null || true)"
   rm -f "{{agentDir}}/.session-model-override"
   if printf '%s' "$_mig" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
     printf '{"model":"%s","configuredDefaultAtWrite":"%s","ts":%s}\n' "$_mig" "$_EFFECTIVE_MODEL" "$(( $(date +%s) * 1000 ))" > "{{agentDir}}/.session-model" 2>/dev/null || true
-    _sm_keep="1"
-    echo "session-model: migrated legacy one-shot carrier '$_mig' to durable .session-model (applying this boot)" >&2
+    echo "session-model: migrated legacy one-shot carrier '$_mig' to .session-model (applying + consuming this boot)" >&2
   else
     echo "session-model: ignoring malformed legacy .session-model-override (failed shape gate)" >&2
   fi
   unset _mig
 fi
 
-# One-shot intent: consume unconditionally, honor only a fresh "keep".
-# Freshness clock is the EMBEDDED ts (ms), never file mtime — same clock the
-# gateway writes with.
-_sm_reason=""
-_sm_revert=""
-if [ -f "{{agentDir}}/.relaunch-model-intent" ]; then
-  _int_raw="$(cat "{{agentDir}}/.relaunch-model-intent" 2>/dev/null || true)"
-  rm -f "{{agentDir}}/.relaunch-model-intent"
-  _int="$(printf '%s' "$_int_raw" | sed -n 's/.*"intent"[[:space:]]*:[[:space:]]*"\([a-z]*\)".*/\1/p')"
-  _int_ts="$(printf '%s' "$_int_raw" | sed -n 's/.*"ts"[[:space:]]*:[[:space:]]*\([0-9]\{1,\}\).*/\1/p')"
-  _sm_reason="$(printf '%s' "$_int_raw" | sed -n 's/.*"reason"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
-  # #3039: boot default is KEEP. Only a FRESH explicit "revert" intent
-  # (stamped by an explicit user/gateway revert path) clears the override.
-  # A stale or corrupt intent counts as no intent → keep.
-  if [ "$_int" = "revert" ] && [ -n "$_int_ts" ] && [ $(( $(date +%s) * 1000 - _int_ts )) -lt 600000 ]; then
-    _sm_revert="1"
-  fi
-  unset _int_raw _int _int_ts
-fi
-
 if [ -f "{{agentDir}}/.session-model" ]; then
   _smf="$(cat "{{agentDir}}/.session-model" 2>/dev/null || true)"
   _sm_model="$(printf '%s' "$_smf" | sed -n 's/.*"model"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
   _sm_cfg="$(printf '%s' "$_smf" | sed -n 's/.*"configuredDefaultAtWrite"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
-  _sm_ts="$(printf '%s' "$_smf" | sed -n 's/.*"ts"[[:space:]]*:[[:space:]]*\([0-9]\{1,\}\).*/\1/p')"
-  if [ -n "$_sm_revert" ]; then
-    # Explicit fresh revert intent — the ONLY boot path that clears a valid
-    # override by design (#3039). Everything else keeps.
-    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-kept-notified"
-    _sm_why="${_sm_reason:-explicit revert intent}"
-    echo "session-model: reverting to configured default '$_EFFECTIVE_MODEL' — $_sm_why (session override '$_sm_model' cleared)" >&2
-    printf 'Session model override `%s` was cleared as requested (%s) — this relaunch booted the configured default `%s`. Re-issue /model %s to switch back.\n' "$_sm_model" "$_sm_why" "$_EFFECTIVE_MODEL" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
-    unset _sm_why
+  # CONSUME-ONCE: delete the carrier now, before any apply/exec. The carrier
+  # governs exactly this one boot; a bad token can therefore crash at most one
+  # boot (the next boot has no carrier and reverts), so no crashloop self-heal
+  # is needed. Every branch below has already removed the file.
+  rm -f "{{agentDir}}/.session-model"
   # Shape gate — kept BYTE-IDENTICAL with MODEL_ARG_RE in
   # telegram-plugin/gateway/model-command.ts. `/` is allowed for
   # OpenRouter-style `sr-vendor/model` ids; it is not a shell metachar inside
@@ -1219,87 +1197,32 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   # extraction above emits one match per matching LINE, and `grep -Eq`
   # passes if ANY line matches — a multiline value must never reach
   # `claude --model` (parity with parseSessionModel's single-string check).
-  elif [ "$(printf '%s' "$_sm_model" | wc -c)" -eq 0 ] || [ "$(printf '%s' "$_sm_model" | wc -l)" -ne 0 ] || ! printf '%s' "$_sm_model" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
-    # Invalid carrier (#3039): fall back to the configured default AND tell
-    # the operator once — never a silent stderr-only drop.
-    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-kept-notified"
+  if [ "$(printf '%s' "$_sm_model" | wc -c)" -eq 0 ] || [ "$(printf '%s' "$_sm_model" | wc -l)" -ne 0 ] || ! printf '%s' "$_sm_model" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
+    # Invalid carrier: fall back to the configured default AND tell the
+    # operator once — never a silent stderr-only drop.
     echo "session-model: ignoring malformed .session-model (failed shape gate) — using configured default '$_EFFECTIVE_MODEL'" >&2
     printf 'Your saved session model override could not be read (invalid or corrupt), so the agent booted on its configured default `%s`. Re-issue /model <name> if you want a different model.\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   elif [ "$_sm_cfg" != "$_EFFECTIVE_MODEL" ]; then
-    # switchroom.yaml `model:` changed since the switch → the override is
-    # against a default that no longer exists (it may name a retired model).
-    # Invalidate + announce once (#3039 invalid-carrier fallback).
-    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-kept-notified"
-    echo "session-model: configured default changed ('$_sm_cfg' → '$_EFFECTIVE_MODEL') — clearing session override '$_sm_model'" >&2
-    printf 'The configured default model changed (`%s` → `%s`), so your session override to `%s` was cleared — the agent booted on the new configured default. Re-issue /model %s if you still want it.\n' "$_sm_cfg" "$_EFFECTIVE_MODEL" "$_sm_model" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+    # switchroom.yaml `model:` changed between the switch and this apply-boot →
+    # the carrier is against a default that no longer exists. Invalidate +
+    # announce once.
+    echo "session-model: configured default changed ('$_sm_cfg' → '$_EFFECTIVE_MODEL') — dropping session override '$_sm_model'" >&2
+    printf 'The configured default model changed (`%s` → `%s`), so your session override to `%s` was not applied — the agent booted on the new configured default. Re-issue /model %s if you still want it.\n' "$_sm_cfg" "$_EFFECTIVE_MODEL" "$_sm_model" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+  elif [ "${_sm_model#sr-}" != "$_sm_model" ] && [ -z "$_LITELLM_OK" ]; then
+    # sr-* + LiteLLM unreachable at the apply-boot: booting the override would
+    # 4xx against Anthropic, and consume-once means we can't retain it for a
+    # later relaunch. Boot the configured default and tell the operator to
+    # re-issue once the proxy is back.
+    echo "session-model: LiteLLM proxy unreachable at boot — NOT applying sr-* override '$_sm_model'; booting configured default '$_EFFECTIVE_MODEL' (re-issue /model when the proxy is back)" >&2
+    printf 'LiteLLM proxy was unreachable at boot, so the session model override `%s` was not applied — the agent booted on its configured default `%s`. Re-issue /model %s once the proxy is reachable.\n' "$_sm_model" "$_EFFECTIVE_MODEL" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   else
-    case "$_sm_model" in
-      sr-*)
-        if [ -z "$_LITELLM_OK" ]; then
-          # sr-* + LiteLLM unreachable: booting the override would 4xx against
-          # Anthropic. Boot the configured default but RETAIN the durable file
-          # — it re-applies on the next keep relaunch once the proxy is back.
-          echo "session-model: LiteLLM proxy unreachable at boot — NOT applying sr-* override '$_sm_model' this boot; booting configured default '$_EFFECTIVE_MODEL' (override retained, re-applies next relaunch)" >&2
-          printf 'LiteLLM proxy was unreachable at boot, so the session model override `%s` was not applied — the agent booted on its configured default `%s`. The override is retained and will re-apply on the next switchroom-managed relaunch once LiteLLM is reachable; /model default drops it.\n' "$_sm_model" "$_EFFECTIVE_MODEL" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
-        else
-          _EFFECTIVE_MODEL="$_sm_model"
-        fi
-        ;;
-      *)
-        _EFFECTIVE_MODEL="$_sm_model"
-        ;;
-    esac
-    if [ "$_EFFECTIVE_MODEL" = "$_sm_model" ]; then
-      echo "session-model: keeping session override '$_sm_model' across this relaunch${_sm_reason:+ ($_sm_reason)}" >&2
-      # #3042 item 4: notify the chat ONCE per kept value — a watchdog bounce
-      # loop must not storm the operator with identical "kept" alerts. The
-      # sentinel is cleared on every path that clears the override.
-      if [ "$(cat "{{agentDir}}/.session-model-kept-notified" 2>/dev/null || true)" != "$_sm_model" ]; then
-        printf 'Session model override `%s` kept across this relaunch%s. It persists across restarts and deploys; /model default clears it.\n' "$_sm_model" "${_sm_reason:+ ($_sm_reason)}" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
-        printf '%s\n' "$_sm_model" > "{{agentDir}}/.session-model-kept-notified" 2>/dev/null || true
-      fi
-    fi
+    # Apply the carrier for THIS session. No boot alert — the gateway already
+    # acked the /model switch in chat, and the override reverts on next restart.
+    _EFFECTIVE_MODEL="$_sm_model"
+    echo "session-model: applying session override '$_sm_model' this boot (consume-once — reverts on next restart)" >&2
   fi
-  unset _smf _sm_model _sm_cfg _sm_ts
+  unset _smf _sm_model _sm_cfg
 fi
-unset _sm_keep _sm_reason _sm_revert
-
-# --- Override crashloop self-heal (#3042 review blocker 2b) ---
-#
-# Under keep-by-default an invalid-but-shape-valid persisted model (a typo
-# persisted at shutdown, or a confirmed model later retired) would make every
-# boot exec `claude --model <bad>` and die with the gateway dead — recovery
-# would need a host shell. Detect the loop from inside: when an override is
-# ACTIVE, stamp a boot-attempt counter just before exec; a healthy run makes
-# the next boot arrive much later (stamp stale → counter resets), while a
-# fast crashloop re-enters here within seconds (docker backoff caps ≈1 min).
-# Three consecutive fast boots with the same override → clear the carrier,
-# boot the configured default, and alert the chat once.
-_SM_CFG_RECORDED="$(cat "{{agentDir}}/.configured-default-model" 2>/dev/null | tr -d '[:space:]' || true)"
-if [ -n "$_SM_CFG_RECORDED" ] && [ "$_EFFECTIVE_MODEL" != "$_SM_CFG_RECORDED" ] && [ -f "{{agentDir}}/.session-model" ]; then
-  _bl_now="$(date +%s)"
-  _bl_cnt=0
-  _bl_prev=0
-  if [ -f "{{agentDir}}/.session-model-boot-attempts" ]; then
-    read -r _bl_cnt _bl_prev < "{{agentDir}}/.session-model-boot-attempts" 2>/dev/null || true
-  fi
-  case "$_bl_cnt" in (''|*[!0-9]*) _bl_cnt=0;; esac
-  case "$_bl_prev" in (''|*[!0-9]*) _bl_prev=0;; esac
-  if [ $(( _bl_now - _bl_prev )) -lt 150 ]; then _bl_cnt=$(( _bl_cnt + 1 )); else _bl_cnt=1; fi
-  if [ "$_bl_cnt" -ge 3 ]; then
-    echo "session-model: override '$_EFFECTIVE_MODEL' appears to be crashlooping the session ($_bl_cnt fast boots) — clearing it, booting configured default '$_SM_CFG_RECORDED'" >&2
-    printf 'Session model override `%s` was cleared automatically: the agent failed to stay up %s boots in a row with it active (the model may be invalid or retired). Booting the configured default `%s`. Re-issue /model <name> if you want a different model.\n' "$_EFFECTIVE_MODEL" "$_bl_cnt" "$_SM_CFG_RECORDED" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
-    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-boot-attempts" "{{agentDir}}/.session-model-kept-notified"
-    _EFFECTIVE_MODEL="$_SM_CFG_RECORDED"
-  else
-    printf '%s %s\n' "$_bl_cnt" "$_bl_now" > "{{agentDir}}/.session-model-boot-attempts" 2>/dev/null || true
-  fi
-  unset _bl_now _bl_cnt _bl_prev
-else
-  # No active override this boot — a stale counter must not bite a future one.
-  rm -f "{{agentDir}}/.session-model-boot-attempts"
-fi
-unset _SM_CFG_RECORDED
 
 # --- Session effort resolution (durable .session-effort, #3039) ---
 #

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1164,6 +1164,12 @@ _EFFECTIVE_MODEL={{{modelQ}}}
 # come from the same resolver. Overwrite, not consumed.
 printf '%s\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.configured-default-model" 2>/dev/null || true
 
+# Rev-4 hygiene (#3184 review LOW-2): remove the files retired with the
+# keep/revert intent subsystem and the crashloop self-heal. Nothing reads them
+# anymore; without this rm they would linger in the bind-mounted state dir
+# forever after rollout. Idempotent — a cheap no-op once clean.
+rm -f "{{agentDir}}/.relaunch-model-intent" "{{agentDir}}/.session-model-boot-attempts" "{{agentDir}}/.session-model-kept-notified"
+
 # Migration shim (one release): a leftover one-shot `.session-model-override`
 # carrier from a pre-consume-once gateway means an OLD gateway wrote it
 # immediately before this very bounce — convert it to `.session-model` so the

--- a/reference/rfcs/session-model-stickiness.md
+++ b/reference/rfcs/session-model-stickiness.md
@@ -8,10 +8,65 @@ status: Accepted — revised per adversarial review + operator decision (default
 
 # RFC — Session-scoped `/model` stickiness
 
-**Status:** Accepted (rev 3 — #3039 keep-by-default amendment; rev 2 semantics below are superseded where §0 says so)
+**Status:** Accepted (rev 4 — session-scoped consume-once, #3183; rev 3 keep-by-default and rev 2 revert-by-default are superseded where §0.1 says so)
 **Author:** (agent-authored, operator-directed; semantics decided by the operator 2026-07)
 **Targets:** `origin/main` @ v0.18.7
-**Builds on:** #2982 (in-memory `sessionModelSource` + one-shot `.session-model-override` carrier), #2983 (live model on progress cards)
+**Builds on:** #2982 (in-memory `sessionModelSource` + one-shot `.session-model-override` carrier), #2983 (live model on progress cards), #3178 (durable /model ack/trace/queue)
+
+---
+
+## 0.1 Rev 4 amendment (#3183, operator decision 2026-07-12) — session-scoped, consume-once
+
+The operator requirement (verbatim): *"/model overrides should only last until
+that agent is restarted; on restart the agent should default back to switchroom
+config."* This **supersedes** the rev-3 §0 keep-by-default contract (and the
+rev-2 revert-by-default rows). A `/model` override is now **session-scoped**:
+it lives for the current session and any restart drops it back to the
+`switchroom.yaml` `model:`.
+
+Mechanism — **consume-once carrier** (no intent file):
+
+- **Live Claude switches write NO carrier.** A typed `/model <claude>` or a
+  Claude menu tap applies in-session via claude's native picker; the explicit
+  `claude --model <configured>` flag start.sh always execs reverts it on the
+  next boot for free. `sessionModelSource.setOverride` still records it live so
+  `/status` and progress cards stay truthful for the running session.
+- **Relaunch-requiring switches write a consume-once `.session-model`.** The
+  sr-* and sr→Claude paths (`scheduleModelRelaunch` / the menu sr→Claude
+  transition) and a queued /model persisted at graceful shutdown write the
+  carrier **immediately before the relaunch that applies it**. start.sh applies
+  the carrier on the single boot that reads it and then **deletes it**. That
+  deletion is the marker that distinguishes the model-apply relaunch from any
+  later restart.
+- **Every SUBSEQUENT restart reverts** — deploy, `/restart`, `/new`/`/reset`,
+  inline restart button, hostd/CLI restart, watchdog recovery, crash, raw
+  `docker restart`, host reboot. The carrier was consumed on the apply-boot, so
+  these boots find no carrier and launch the configured default.
+- **The `.relaunch-model-intent` keep/revert subsystem is retired** (writers,
+  readers, `intentForRestartReason`, `clearStaleGatewayShutdownIntent`,
+  `GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX`) and so is the **crashloop self-heal
+  counter** (`.session-model-boot-attempts`): a consume-once carrier can crash
+  at most one boot before it is gone, so no self-heal is needed.
+- **Clearing / invalidation.** `/model default` deletes the carrier and clears
+  the in-memory override live. start.sh drops (without applying) a corrupt
+  carrier or one whose `configuredDefaultAtWrite` no longer matches the current
+  configured default, and writes a `.session-model-alert` the gateway relays.
+  The normal apply-boot is silent — the gateway already acked the `/model` in
+  chat. The 7-day staleness bound is moot (a carrier never survives one boot).
+- **sr-* + LiteLLM-down at the apply-boot:** the carrier cannot apply and
+  consume-once forbids retaining it for a later relaunch, so start.sh boots the
+  configured default and alerts the operator to re-issue once the proxy is back.
+- **`/effort` is unchanged** — `.session-effort` remains keep-across-restarts
+  (rev 3). Whether `/effort` should also become session-scoped is deferred to
+  the operator (#3183 open question).
+- **#3178 preserved.** Instant ack, the durable receipt log + history row, the
+  mid-turn queue-and-apply, and explicit failures are untouched; the queued
+  apply persists a consume-once carrier at shutdown so it still applies as the
+  agent boots (its apply-relaunch), then reverts on the next restart.
+
+The rev-2/rev-3 §0 and §§2-6 below are the historical design record; where they
+describe keep-by-default, intent files, the crashloop counter, or the 7-day
+expiry they are **superseded by this §0.1**.
 
 ---
 

--- a/reference/rfcs/session-model-stickiness.md
+++ b/reference/rfcs/session-model-stickiness.md
@@ -63,6 +63,12 @@ Mechanism — **consume-once carrier** (no intent file):
   mid-turn queue-and-apply, and explicit failures are untouched; the queued
   apply persists a consume-once carrier at shutdown so it still applies as the
   agent boots (its apply-relaunch), then reverts on the next restart.
+  **Deliberate exception (#3184 review LOW-3):** that persist runs on every
+  shutdown path INCLUDING crashes, so a mid-turn queued `/model` + crash
+  applies on the crash-recovery boot — honoring the acked pending request
+  ("a queued /model never silently vanishes") rather than the literal
+  crash-reverts reading; gated to offline-trusted tokens and bounded by
+  consume-once to that single recovery boot, after which any restart reverts.
 
 The rev-2/rev-3 §0 and §§2-6 below are the historical design record; where they
 describe keep-by-default, intent files, the crashloop counter, or the 7-day

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3172,15 +3172,14 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     // (e.g. tests with no HOME) the template's {{#if hostHomeQ}} guard renders
     // the symlink block as a no-op.
     hostHomeQ: hostHomeQForBake(),
-    // modelQ is the CONFIGURED default only. It is NOT the last word on the
-    // launched model: start.sh applies the durable `.session-model` override
-    // at boot when a fresh keep `.relaunch-model-intent` accompanies it
-    // (Telegram `/model` switches; contract in
-    // reference/rfcs/session-model-stickiness.md). The override reverts to
-    // modelQ on deliberate restarts / crashes / external container restarts
-    // and is never persisted here or to switchroom.yaml. See
-    // profiles/_base/start.sh.hbs (Session model resolution) and
-    // telegram-plugin/gateway/model-command.ts.
+    // modelQ is the CONFIGURED default only. A Telegram `/model` switch is
+    // session-scoped (reference/rfcs/session-model-stickiness.md §0.1): a
+    // relaunch-requiring switch writes a CONSUME-ONCE `.session-model` carrier
+    // that start.sh applies on its single apply-relaunch and then deletes, so
+    // EVERY subsequent restart boots modelQ. Live Claude switches write no
+    // carrier at all. The override is never persisted here or to
+    // switchroom.yaml. See profiles/_base/start.sh.hbs (Session model
+    // resolution) and telegram-plugin/gateway/model-command.ts.
     modelQ: shellSingleQuote(resolveMainModel(agentConfig.model)),
     ...buildCronSessionContext(agentConfig),
     thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,

--- a/telegram-plugin/gateway/bridge-dead-watchdog.ts
+++ b/telegram-plugin/gateway/bridge-dead-watchdog.ts
@@ -60,10 +60,9 @@ import { readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs'
 import { isCronIdentity } from './cron-session.js'
 import type { InboundMessage } from './ipc-protocol.js'
 
-/** The distinct triggerSelfRestart reason for this escalation. Classified
- *  as intent 'keep' by intentForRestartReason (recovery bounce — session
- *  model stickiness preserved), like every other switchroom-managed
- *  relaunch. */
+/** The distinct triggerSelfRestart reason for this escalation. Like every
+ *  other switchroom-managed relaunch it reverts any session `/model` override
+ *  to the configured default (session-scoped, rev 4). */
 export const BRIDGE_DEAD_RESTART_REASON = 'bridge-dead-resume'
 
 /** Default grace window before a missing bridge is treated as dead.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -465,15 +465,7 @@ import {
   readSessionModelFileRaw,
   restoreSessionModelFileRaw,
   clearSessionModelFile,
-  clearSessionModelBootAttempts,
   readConfiguredDefaultModel,
-  writeRelaunchModelIntent,
-  clearRelaunchModelIntent,
-  intentForRestartReason,
-  readSessionModelFile,
-  RELAUNCH_MODEL_INTENT_FILE,
-  GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX,
-  clearStaleGatewayShutdownIntent,
   writeSessionEffortFile,
   clearSessionEffortFile,
   readSessionEffortFile,
@@ -1101,16 +1093,10 @@ function triggerSelfRestart(
       )
       return false
     }
-    // Session-model stickiness (reference/rfcs/session-model-stickiness.md):
-    // boot default is REVERT, so every switchroom-managed bounce must stamp
-    // its intent BEFORE the SIGTERM is even scheduled (write-before-kill
-    // invariant — pinned by gateway-session-model-relaunch.test.ts). The
-    // per-reason table classifies recovery/model-switch bounces as "keep"
-    // and the deliberate inline restart button as "revert".
-    {
-      const smDir = resolveAgentDirFromEnv()
-      if (smDir) writeRelaunchModelIntent(smDir, intentForRestartReason(reason), reason)
-    }
+    // Session-scoped /model (reference/rfcs/session-model-stickiness.md §0.1):
+    // a `.session-model` carrier is consume-once — start.sh applies it on the
+    // apply-relaunch and deletes it, so no boot needs a keep/revert intent. A
+    // switchroom-managed bounce simply reverts to the configured default.
     process.stderr.write(
       `telegram gateway: restart-via-SIGTERM-PID1 agent=${targetAgent} reason=${reason} (docker)\n`,
     )
@@ -1122,10 +1108,6 @@ function triggerSelfRestart(
     return true
   }
   // Legacy systemd path.
-  if (targetAgent === selfAgent) {
-    const smDir = resolveAgentDirFromEnv()
-    if (smDir) writeRelaunchModelIntent(smDir, intentForRestartReason(reason), reason)
-  }
   process.stderr.write(
     `telegram gateway: restart-via-systemctl agent=${targetAgent} reason=${reason}\n`,
   )
@@ -1142,24 +1124,6 @@ function triggerSelfRestart(
   } catch (err) {
     process.stderr.write(`telegram gateway: restart spawn failed for ${targetAgent}: ${err}\n`)
     return false
-  }
-}
-
-// #3018 finding 4: a gateway-only bounce (supervisor relaunch, bare gateway
-// unit restart) leaves the shutdown handler's deploy-survival keep-intent
-// stamp on disk UNCONSUMED — start.sh only runs on a container-level boot.
-// If this gateway boot still sees a gateway-shutdown-stamped intent, the
-// preceding bounce was gateway-only: clear it so a genuine crash inside the
-// 10-min freshness window can't be converted into a "keep" (crash-reverts
-// policy intact). A real container stop/deploy consumes the file in start.sh
-// before any gateway boots, so a legitimate deploy stamp is never touched;
-// triggerSelfRestart / user-slash stamps use un-prefixed reasons.
-{
-  const bootSmDir = resolveAgentDirFromEnv()
-  if (bootSmDir != null && clearStaleGatewayShutdownIntent(bootSmDir)) {
-    process.stderr.write(
-      'telegram gateway: cleared stale gateway-shutdown relaunch-model intent (previous bounce was gateway-only — container never restarted)\n',
-    )
   }
 }
 
@@ -10428,16 +10392,6 @@ const ipcServer: IpcServer = createIpcServer({
     // this call is safe wherever it sits relative to the cron early-return
     // above (#3038 review finding 5).
     bridgeDeadWatchdog.noteBridgeRegistered(client.agentName)
-    // #3043 item 2: a REAL bridge registering is proof the boot came all the
-    // way up healthy — clear start.sh's crashloop boot-attempts counter so only
-    // boots that genuinely fail BEFORE the bridge registers accumulate toward
-    // the 3-strike override clear. Without this, three quick operator
-    // hand-bounces of a healthy agent (each <150s apart) spuriously wipe a
-    // working model override. Best-effort; no-op when the file is absent.
-    if (client.agentName != null) {
-      const smBootDir = resolveAgentDirFromEnv()
-      if (smBootDir != null) clearSessionModelBootAttempts(smBootDir)
-    }
     client.send({ type: 'status', status: 'agent_connected' })
 
     // Phase 2b PR 3a — bridgeUp cutover. The state machine's `bridgeUp`
@@ -21871,15 +21825,10 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
         })
       }
       stampUserRestartReason(reason)
-      // Model-switch restarts are switchroom-managed relaunches: the session
-      // override (written by the caller before this dispatch) must survive
-      // the bounce, so stamp keep-intent BEFORE dispatch (boot default is
-      // revert). hostd shells through `switchroom agent restart`, which
-      // deliberately writes no intent of its own.
-      {
-        const smDir = resolveAgentDirFromEnv()
-        if (smDir) writeRelaunchModelIntent(smDir, 'keep', reason)
-      }
+      // Model-switch restarts are the APPLY-relaunch for a `.session-model`
+      // carrier the caller wrote immediately above: start.sh consumes it on
+      // the very next boot (this dispatch's boot), then reverts thereafter.
+      // No keep/revert intent is needed — the carrier is consume-once.
       await sweepBeforeSelfRestart()
       const hostdResp = await tryHostdDispatch(name, {
         v: 1,
@@ -21900,14 +21849,11 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
         return
       }
       // hostd is configured but returned an error/denied result. No restart
-      // is coming, so the keep-intent stamped above must not linger — a
-      // crash within its 10-min freshness window would wrongly KEEP.
+      // is coming, so the carrier the caller wrote must not linger to be
+      // consumed by an unrelated later boot — scheduleModelRelaunch's catch
+      // rolls it back on this throw.
       if (hostdResp.result !== 'started' && hostdResp.result !== 'completed') {
         clearRestartMarker()
-        {
-          const smDir = resolveAgentDirFromEnv()
-          if (smDir) clearRelaunchModelIntent(smDir)
-        }
         throw new Error(
           `hostd restart failed (result=${hostdResp.result}): ${hostdResp.error ?? '(no details)'}`,
         )
@@ -21916,11 +21862,11 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
     /**
      * Switch TO a model that needs a relaunch (sr-* LiteLLM/OpenRouter ids,
      * which claude's native `/model` picker rejects, and the sr-to-claude
-     * direction). Write the DURABLE `.session-model` override (start.sh
-     * applies it on every keep-relaunch boot and launches `claude --model
-     * <token>`), set the in-memory session-model so /status stays honest
-     * across the restart window, then run the SAME restart dispatch as
-     * scheduleRestart above — which stamps the keep-intent this boot needs.
+     * direction). Write the CONSUME-ONCE `.session-model` carrier (start.sh
+     * applies it on the very next boot — this dispatch's apply-relaunch — and
+     * deletes it, so it reverts on any subsequent restart), set the in-memory
+     * session-model so /status stays honest across the restart window, then
+     * run the SAME restart dispatch as scheduleRestart above.
      */
     scheduleModelRelaunch: async (model: string, reason: string) => {
       const agentDir = resolveAgentDirFromEnv()
@@ -21937,20 +21883,15 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
       try {
         await deps.scheduleRestart(reason)
       } catch (err) {
-        // A restart already in flight OWNS the override we just wrote — its
-        // boot (stamped keep by the in-flight path's own intent, last-writer-
-        // wins) will apply our token, so the switch is queued, not lost: keep
-        // the file + override and let the caller tell the operator "~15s".
-        // Any OTHER dispatch failure means no restart is coming, so roll BOTH
-        // back — a lingering file/override would lie to /status and
-        // mis-launch the NEXT relaunch. The keep-intent goes with them
-        // (belt-and-braces: scheduleRestart's failure branch clears it too):
-        // a fresh keep on disk with no restart coming would wrongly KEEP
-        // across a crash inside its 10-min window.
+        // A restart already in flight OWNS the carrier we just wrote — its
+        // boot will consume+apply our token, so the switch is queued, not
+        // lost: keep the file + override and let the caller tell the operator
+        // "~15s". Any OTHER dispatch failure means no restart is coming, so
+        // roll BOTH back — a lingering carrier would lie to /status and be
+        // consumed (mis-applied) by an unrelated later boot.
         if ((err as { code?: string })?.code !== 'restart_in_flight') {
           restoreSessionModelFileRaw(agentDir, prevFileRaw)
           sessionModelSource.setOverride(prevOverride)
-          clearRelaunchModelIntent(agentDir)
         }
         throw err
       }
@@ -21971,19 +21912,24 @@ function modelMenuReplyMarkup(reply: ModelMenuReply): InlineKeyboard | undefined
 
 /**
  * Record a POSITIVELY-CONFIRMED typed `/model` switch: set the in-memory
- * override so `/status` reflects the live model and persist the sticky
- * `.session-model` carrier. Shared by the live `bot.command('model')` handler
- * and the deferred (queued mid-turn) apply so both record identically. Returns
- * a persist-warning suffix to append to the reply body (empty when clean).
+ * override so `/status` reflects the live model. Shared by the live
+ * `bot.command('model')` handler and the deferred (queued mid-turn) apply so
+ * both record identically. Returns a warning suffix to append to the reply
+ * body (currently always empty — kept for a stable signature).
  *
- * The `/status` honesty invariant lives here: only `reply.selectedModel`
- * (present only on a confirmed switch) records; an unverified inject records
- * nothing. `/model default` clears the carrier idempotently.
+ * Session-scoped (rev 4): a live Claude `/model` switch writes NO
+ * `.session-model` carrier — it applies in-session and the explicit
+ * `claude --model <configured>` flag reverts it on the next boot, so it lasts
+ * exactly until the next restart with no durable state. (sr-* switches never
+ * reach here — they go through scheduleModelRelaunch, which owns the
+ * consume-once carrier.) The `/status` honesty invariant lives here: only
+ * `reply.selectedModel` records; an unverified inject records nothing.
+ * `/model default` clears any in-memory override and any leftover carrier.
  */
 function recordTypedModelSwitch(
   reply: { text: string; selectedModel?: string },
   requestedModelArg: string | null,
-  deps: ModelCommandDeps,
+  _deps: ModelCommandDeps,
 ): string {
   const requested = requestedModelArg != null ? expandSrAlias(requestedModelArg) : null
   if (requested?.toLowerCase() === 'default') {
@@ -21994,28 +21940,14 @@ function recordTypedModelSwitch(
   }
   if (!reply.selectedModel) return ''
   sessionModelSource.setOverride(reply.selectedModel)
-  const smDir = resolveAgentDirFromEnv()
-  if (smDir && requested && isValidModelArg(requested) && !isSrModel(requested)) {
-    try {
-      writeSessionModelFile(
-        smDir,
-        requested,
-        readConfiguredDefaultModel(smDir) ??
-          resolveMainModel(deps.getConfiguredModel() ?? undefined),
-      )
-    } catch (err) {
-      process.stderr.write(
-        `telegram gateway: session-model persist failed (typed /model): ${(err as Error)?.message ?? String(err)}\n`,
-      )
-      return '\n⚠️ Couldn’t persist the sticky override — the switch is live now but won’t survive a relaunch.'
-    }
-  }
   return ''
 }
 
 /**
- * Record a model-MENU callback outcome (persist/clear sticky override) and
- * drive an sr-*→Claude graceful restart when the tap crosses that boundary.
+ * Record a model-MENU callback outcome (set the live in-memory override, clear
+ * a leftover carrier on a Default tap) and drive an sr-*→Claude graceful
+ * restart when the tap crosses that boundary — the only menu path that writes a
+ * consume-once `.session-model` carrier (a live Claude tap writes none, rev 4).
  * Extracted from the live `mdl:*` dispatcher so the deferred (queued mid-turn)
  * apply records + restarts identically. Does NOT edit any Telegram message —
  * callers own the card edit. Returns a restart notice when a session restart
@@ -22029,29 +21961,13 @@ function recordModelMenuSideEffects(
   prevSessionModel: string | null,
 ): { restartNotice?: string } {
   // Record a successful session switch so /status reflects what's actually
-  // running, and persist the STICKY override
-  // (reference/rfcs/session-model-stickiness.md): the canonical token (never
-  // the display label) goes to the durable `.session-model`; a confirmed
-  // "Default (recommended)" selection clears it instead.
+  // running. Session-scoped (rev 4): a live Claude menu tap writes NO
+  // `.session-model` carrier — it applies in-session (native picker) and
+  // reverts on the next boot. Only the sr→Claude transition below (which
+  // relaunches) writes the consume-once carrier. A confirmed "Default
+  // (recommended)" selection clears any leftover carrier.
   if (outcome.selectedModel) {
     sessionModelSource.setOverride(outcome.selectedModel)
-    const smDir = resolveAgentDirFromEnv()
-    if (smDir && outcome.selectedModelToken) {
-      try {
-        writeSessionModelFile(
-          smDir,
-          outcome.selectedModelToken,
-          readConfiguredDefaultModel(smDir) ??
-            resolveMainModel(modelDeps.getConfiguredModel() ?? undefined),
-        )
-      } catch (err) {
-        outcome.reply.text +=
-          '\n⚠️ Couldn’t persist the sticky override — the switch is live now but won’t survive a relaunch.'
-        process.stderr.write(
-          `telegram gateway: session-model persist failed (menu): ${(err as Error)?.message ?? String(err)}\n`,
-        )
-      }
-    }
   }
   if (outcome.clearedDefault) {
     const smDir = resolveAgentDirFromEnv()
@@ -22228,20 +22144,19 @@ function persistQueuedCommandForRestart(action: ShutdownResolutionAction): strin
     switch (action.persist) {
       case 'model': {
         // #3042 blocker 2a: this token was QUEUED, never confirmed by claude.
-        // Under the keep-by-default boot a garbage-but-shape-valid token
-        // persisted here would crashloop `claude --model <garbage>` with the
-        // gateway dead. Only offline-trustable tokens (static Claude aliases,
-        // curated sr-* alias targets) may be persisted unconfirmed; anything
-        // else gets the honest "couldn't verify — re-issue" card instead.
+        // The carrier is written immediately before the bounce, so the next
+        // boot IS its apply-relaunch: consume-once means a garbage token can
+        // crash at most one boot before it reverts, but we still gate on
+        // offline-trustable tokens (static Claude aliases, curated sr-* alias
+        // targets) to avoid even that one crash-boot; anything else gets the
+        // honest "couldn't verify — re-issue" card instead.
         if (!isOfflineTrustedModelToken(action.arg)) {
           return `↩️ Couldn’t verify \`${escapeHtmlForTg(action.cmd.targetLabel || action.arg)}\` as a known model without the live session — it was NOT saved. Re-issue \`/model ${escapeHtmlForTg(action.arg)}\` once the agent is back.`
         }
         const configured =
           readConfiguredDefaultModel(agentDir) ?? resolveMainModel(undefined)
+        // Consume-once carrier: applied by the next boot, then reverts.
         writeSessionModelFile(agentDir, expandSrAlias(action.arg), configured)
-        // Boot default is keep (#3039), but stamp explicit keep-intent for
-        // reason-honesty in the boot notice.
-        writeRelaunchModelIntent(agentDir, 'keep', 'queued /model carried across restart')
         break
       }
       case 'clear-model':
@@ -22591,14 +22506,10 @@ bot.command('restart', async ctx => {
     // greeting card shows "Restarted  user: /restart from chat" instead
     // of whatever reason the downstream CLI would default to.
     stampUserRestartReason('user: /restart from chat')
-    // #3039: /restart is "bounce the session", NOT "clear my model" — the
-    // durable override survives every restart and is cleared only by
-    // `/model default`. Stamp keep for reason-honesty in the boot notice
-    // (absence of intent keeps anyway under the keep-by-default boot).
-    {
-      const smDir = resolveAgentDirFromEnv()
-      if (smDir) writeRelaunchModelIntent(smDir, 'keep', 'user: /restart from chat')
-    }
+    // Session-scoped (rev 4): /restart reverts any live /model override to the
+    // configured default. A consume-once `.session-model` carrier (if one was
+    // in flight) was already consumed by its own apply-relaunch, so nothing to
+    // do here — start.sh boots the configured default.
     await sweepBeforeSelfRestart()
     const hostdResp = await tryHostdDispatch(getMyAgentName(), {
       v: 1,
@@ -22757,12 +22668,8 @@ async function handleNewCommand(ctx: Context): Promise<void> {
   // Stamp user attribution so the next greeting shows "Restarted  user:
   // /new" / "user: /reset" rather than the downstream CLI default.
   stampUserRestartReason(`user: /${kind} from chat`)
-  // /new and /reset start a fresh CONVERSATION, not a fresh model choice:
-  // the sticky session-model override KEEPS across them (contract row 7).
-  // Boot default is revert, so the keep-intent must land before dispatch.
-  if (agentDir != null) {
-    writeRelaunchModelIntent(agentDir, 'keep', `user: /${kind} from chat`)
-  }
+  // Session-scoped (rev 4): /new and /reset are restarts, so they revert any
+  // live /model override to the configured default — no carrier to preserve.
   await sweepBeforeSelfRestart()
   const hostdResp = await tryHostdDispatch(getMyAgentName(), {
     v: 1,
@@ -28129,35 +28036,12 @@ async function shutdown(signal: string): Promise<void> {
     } catch (err) {
       process.stderr.write(`telegram gateway: shutdown.clean_marker_write_failed err=${(err as Error).message}\n`)
     }
-    // #3017 — persist a Telegram-set model across a GRACEFUL deploy/restart.
-    // Boot default is REVERT, and an EXTERNAL deploy (SIGTERM to PID 1 from
-    // `switchroom apply` / `docker compose up`) never routes through
-    // triggerSelfRestart, so it stamps no `.relaunch-model-intent` and start.sh
-    // drops the user's `/model` choice (the overlord `fable`→`opus` revert on
-    // the v0.18.9 roll). A graceful OS-signal shutdown IS a clean, planned
-    // bounce — stamp keep-intent for an active `.session-model` override so the
-    // chosen model survives and start.sh re-confirms it via `.session-model-alert`
-    // on boot. Respect an intent an initiator already stamped (a /restart stamps
-    // 'revert' before SIGTERM): only stamp when none exists. A crash routes
-    // through the non-OS-signal branch and still reverts (safe side preserved).
-    try {
-      const smDir = resolveAgentDirFromEnv()
-      if (smDir != null) {
-        const hasOverride = readSessionModelFile(smDir) != null
-        const intentAlreadyStamped = existsSync(join(smDir, RELAUNCH_MODEL_INTENT_FILE))
-        if (hasOverride && !intentAlreadyStamped) {
-          // The GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX makes this stamp
-          // recognisable at the next GATEWAY boot: a gateway-only bounce never
-          // runs start.sh, so a leftover stamp with this prefix is cleared at
-          // boot (clearStaleGatewayShutdownIntent) instead of lingering to
-          // convert a later genuine crash into a "keep" (#3018 finding 4).
-          writeRelaunchModelIntent(smDir, 'keep', `${GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX} graceful ${signal} shutdown (deploy/rolling restart) — preserving user-chosen session model`)
-          process.stderr.write(`telegram gateway: shutdown.session_model_keep_stamped signal=${signal}\n`)
-        }
-      }
-    } catch (err) {
-      process.stderr.write(`telegram gateway: shutdown.session_model_keep_stamp_failed err=${(err as Error).message}\n`)
-    }
+    // Session-scoped (rev 4): a graceful deploy/restart REVERTS a live /model
+    // override to the configured default — there is no keep-intent to stamp.
+    // (A live Claude override never had a `.session-model` carrier; an in-flight
+    // sr-* carrier was already consumed by its own apply-relaunch.) A queued —
+    // not-yet-applied — /model IS still persisted just below so it applies as
+    // the agent boots (its apply-relaunch), then reverts on the next restart.
   } else {
     process.stderr.write(`telegram gateway: shutdown.clean_marker_skipped signal=${signal} (crash path — banner will fire on next boot)\n`)
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -21979,9 +21979,11 @@ function recordModelMenuSideEffects(
   // torn down — a graceful restart (same mechanism as /restart) is required.
   if (outcome.selectedModel && isSrToClaudeTransition(prevSessionModel, outcome.selectedModel)) {
     const agentName = getMyAgentName()
-    // Carry the requested Claude model across the restart via the SAME durable
-    // `.session-model` override a Claude → sr-* switch uses — otherwise boot
-    // launches the CONFIGURED default and the tapped model is silently dropped.
+    // Carry the requested Claude model across the restart via the SAME
+    // consume-once `.session-model` carrier a Claude → sr-* switch uses —
+    // otherwise this transition's apply-relaunch boots the CONFIGURED default
+    // and the tapped model is silently dropped. Applied on that one boot,
+    // then reverts on the next restart (rev 4).
     const agentDir = resolveAgentDirFromEnv()
     const token = outcome.selectedModelToken
     if (agentDir && token) {
@@ -25627,7 +25629,7 @@ bot.on('callback_query:data', async ctx => {
     // sr-* TARGET tap: switch TO a non-Claude (LiteLLM/OpenRouter) model.
     // Parity with the text `/model sr-*` path — claude's native picker rejects
     // unknown sr-* ids, so an in-place inject can't set them. Carry the token
-    // across a graceful restart (the durable `.session-model` override) and
+    // across a graceful restart (the consume-once `.session-model` carrier) and
     // relaunch `claude --model sr-*`. Session-only; reverts to the configured
     // default on the next restart. The sr-* → Claude direction is handled below
     // via the SELECT/alias outcome + isSrToClaudeTransition.
@@ -28048,11 +28050,21 @@ async function shutdown(signal: string): Promise<void> {
 
   // #3018 finding 3 + #3039: resolve any queued /model|/effort ack cards. The
   // gateway (and with it the in-memory queue) is going away — persist each
-  // typed choice to the durable boot carriers (`.session-model` /
-  // `.session-effort`) so it still deterministically applies as the agent
-  // boots, and edit the ack card to say so. Only an unresolvable menu-tag
-  // selection falls back to a re-issue note. Best-effort and time-bounded so
-  // a wedged Telegram API can't block shutdown.
+  // typed choice to the boot carriers (the consume-once `.session-model` /
+  // the durable `.session-effort`) so it still deterministically applies as
+  // the agent boots, and edit the ack card to say so. Only an unresolvable
+  // menu-tag selection falls back to a re-issue note. Best-effort and
+  // time-bounded so a wedged Telegram API can't block shutdown.
+  //
+  // DELIBERATE (rev 4, #3184 review LOW-3): this runs on EVERY shutdown path,
+  // including crashes (uncaughtException/unhandledRejection route here), not
+  // just the isOsSignal branch above. So a mid-turn queued /model + crash can
+  // apply on the crash-recovery boot — technically at odds with a literal
+  // "crash reverts" reading of the session-scoped contract. Intended: it
+  // preserves #3178's "a queued /model never silently vanishes" guarantee
+  // (the ack card promised the switch), it is gated to offline-trusted
+  // tokens, and the consume-once carrier bounds it to exactly that one
+  // recovery boot — the following restart reverts to config.
   const orphanedCmdActions = pendingCmdShutdownResolutionActions(pendingSessionCommand, escapeHtmlForTg)
   const orphanedCmdEdits = orphanedCmdActions.map(a => ({
     chatId: a.cmd.ackChatId,

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -251,7 +251,7 @@ export interface ModelCommandReply {
 }
 
 const PERSIST_NOTE =
-  '_Sticky — persists across restarts, deploys, and crashes until \`/model default\` clears it (or the configured \`model:\` in switchroom.yaml changes, which resets it and notifies you). To change the default, set \`model:\` in switchroom.yaml._'
+  '_Session-only — this override lasts until the agent’s next restart, then reverts to the configured \`model:\`. \`/model default\` clears it now. To change the default permanently, set \`model:\` in switchroom.yaml._'
 
 function helpText(deps: ModelCommandDeps, reason?: string): ModelCommandReply {
   const srAliasExamples = Object.keys(SR_MODEL_ALIASES).map(a => `\`${a}\``).join(' · ')
@@ -583,18 +583,19 @@ export const SR_MODEL_ALIASES: Record<string, string> = {
 
 /** Expand a short alias (case-insensitive) to its full sr-* id, or return the original. */
 /**
- * #3042 review blocker 2a: can `token` be trusted for a DURABLE, boot-applied
- * `.session-model` persist WITHOUT a live confirmation from claude?
+ * #3042 review blocker 2a: can `token` be trusted for a boot-applied
+ * `.session-model` carrier persist WITHOUT a live confirmation from claude?
  *
  * A queued typed `/model <arg>` that is persisted at shutdown was never
- * validated by claude's picker — and under the keep-by-default boot (#3039)
- * a garbage-but-shape-valid token (e.g. `claude-nonexistnet-9`) would make
- * every boot run `claude --model <garbage>` with the gateway dead. Only
- * tokens with a switchroom-known meaning are offline-trustable: the static
- * Claude aliases (claude resolves them itself) and the curated sr-* alias
- * TARGETS (present in the LiteLLM config by construction). Full `claude-*` /
- * arbitrary `sr-*` ids typed by hand are refused — they need the live
- * session to verify, so the operator is asked to re-issue after boot.
+ * validated by claude's picker. Under the consume-once carrier (rev 4) a
+ * garbage-but-shape-valid token (e.g. `claude-nonexistnet-9`) can crash at
+ * most ONE boot before the carrier is gone and the agent reverts — but we
+ * still avoid even that crash-boot. Only tokens with a switchroom-known
+ * meaning are offline-trustable: the static Claude aliases (claude resolves
+ * them itself) and the curated sr-* alias TARGETS (present in the LiteLLM
+ * config by construction). Full `claude-*` / arbitrary `sr-*` ids typed by
+ * hand are refused — they need the live session to verify, so the operator is
+ * asked to re-issue after boot.
  */
 export function isOfflineTrustedModelToken(token: string): boolean {
   // #3043 item 1: the live accept path normalizes case (isClaudeModel /

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -910,18 +910,19 @@ export interface ModelCallbackOutcome {
   /**
    * The canonical `claude --model` token (alias or full `claude-*` id) for a
    * Claude selection, when derivable — distinct from `selectedModel` (a display
-   * name for /status). The gateway persists this to the durable
-   * `.session-model` override so the confirmed switch survives
-   * switchroom-managed relaunches (and, on an sr-* → Claude transition, its own
+   * name for /status). Session-scoped (rev 4): a live Claude selection persists
+   * NO carrier (the switch applies in-session and reverts on the next boot);
+   * the gateway uses this token ONLY on an sr-* → Claude transition, writing it
+   * to the consume-once `.session-model` carrier so that transition's own
+   * apply-relaunch boots the tapped model (then reverts on the following
    * restart). Absent when the target has no derivable token.
    */
   selectedModelToken?: string
   /**
    * True when the confirmed selection was the "Default (recommended)" row —
-   * i.e. the session is now on the configured default and any sticky
-   * `.session-model` override must be CLEARED (there is no token to persist;
-   * persisting nothing while leaving a stale override would re-apply the old
-   * model on the next keep-relaunch).
+   * i.e. the session is now on the configured default and any leftover
+   * `.session-model` carrier must be CLEARED (a stale carrier would be
+   * consumed — mis-applied — by the next boot).
    */
   clearedDefault?: boolean
   /** Short toast for answerCallbackQuery. */

--- a/telegram-plugin/gateway/session-model-file.ts
+++ b/telegram-plugin/gateway/session-model-file.ts
@@ -1,28 +1,26 @@
 /**
- * Durable session-model stickiness — file helpers shared by the gateway.
+ * Session-scoped `/model` carrier — file helpers shared by the gateway.
  *
- * Two files in the bind-mounted agent state dir carry the contract
- * (reference/rfcs/session-model-stickiness.md):
+ * Contract: reference/rfcs/session-model-stickiness.md §0.1 (rev 4, operator
+ * decision 2026-07-12 — SESSION-SCOPED, superseding the rev-3 keep-by-default).
+ * Files in the bind-mounted agent state dir:
  *
- *   - `.session-model` — the DURABLE session override written on every
- *     positively-confirmed `/model` switch. One-line JSON
- *     `{"model","configuredDefaultAtWrite","ts"}`. It is NOT consumed by a
- *     keep-path boot; it survives every restart/deploy/crash and is cleared
- *     only by explicit user action (`/model default`) or invalidation
- *     (corruption / the configured yaml default changed) — every clearing
- *     path notifies the operator chat via `.session-model-alert` (#3039).
+ *   - `.session-model` — a CONSUME-ONCE carrier written ONLY immediately
+ *     before a relaunch that applies the switch (the sr-* / sr→Claude paths
+ *     and a queued /model persisted at graceful shutdown). One-line JSON
+ *     `{"model","configuredDefaultAtWrite","ts"}`. start.sh applies it on the
+ *     single boot that reads it and then deletes it; every SUBSEQUENT restart
+ *     (deploy, /restart, /new, watchdog recovery, crash, raw docker restart)
+ *     finds no carrier and boots the configured default. Live Claude switches
+ *     do NOT write a carrier — they apply in-session and the explicit
+ *     `claude --model <configured>` flag reverts them on the next boot.
+ *     Cleared live by `/model default`; invalidation (corruption / the
+ *     configured yaml default changed at the apply-boot) drops it and notifies
+ *     the operator chat via `.session-model-alert`.
  *
- *   - `.relaunch-model-intent` — the ONE-SHOT intent bit for the next boot.
- *     One-line JSON `{"intent":"keep"|"revert","reason","ts"}`, atomic
- *     write, last-writer-wins. Boot default is KEEP (#3039 — operator
- *     decision 2026-07-11, superseding the earlier revert-by-default): a
- *     raw `docker restart` / host reboot / deploy / crash keeps a valid
- *     override. Only an explicit fresh "revert" intent reverts. start.sh
- *     consumes the file (rm -f) every boot; a stale (>10 min by the
- *     embedded ts) or corrupt intent counts as no intent (→ keep).
- *
- *   - `.session-effort` — the DURABLE effort override (#3039), same shape
- *     and lifecycle as `.session-model` with `level` in place of `model`:
+ *   - `.session-effort` — the DURABLE effort override (#3039), still
+ *     keep-across-restarts (NOT changed by rev 4). Same shape as
+ *     `.session-model` with `level` in place of `model`:
  *     `{"level","configuredDefaultAtWrite","ts"}`. Written on every
  *     positively-confirmed `/effort` apply, resolved by start.sh into the
  *     relaunch's `--effort`, cleared only by `/effort default` or
@@ -38,32 +36,12 @@ import { join } from 'node:path'
 import { isValidModelArg } from './model-command.js'
 
 export const SESSION_MODEL_FILE = '.session-model'
-export const RELAUNCH_MODEL_INTENT_FILE = '.relaunch-model-intent'
 export const CONFIGURED_DEFAULT_MODEL_FILE = '.configured-default-model'
-/** Crashloop self-heal counter (start.sh stamps `<count> <epoch>` per fast boot). */
-export const SESSION_MODEL_BOOT_ATTEMPTS_FILE = '.session-model-boot-attempts'
-
-export type RelaunchModelIntent = 'keep' | 'revert'
 
 export interface SessionModelRecord {
   model: string
   configuredDefaultAtWrite: string
   ts: number
-}
-
-/**
- * Classify a triggerSelfRestart reason into the intent the boot should honor.
- *
- * Since #3039 (operator contract 2026-07-11) EVERY restart reason keeps the
- * override: a restart — user-tapped, watchdog, deploy, or crash — is not
- * "clear my model". The override is cleared only by explicit user action
- * (`/model default`) or invalidation at boot, both of which run their own
- * paths. The 'revert' intent value remains recognised by start.sh (and this
- * classifier's signature keeps it) so an older gateway's stamp still parses,
- * but current code never emits it.
- */
-export function intentForRestartReason(_reason: string): RelaunchModelIntent {
-  return 'keep'
 }
 
 function atomicWrite(path: string, content: string): void {
@@ -137,37 +115,10 @@ export function readSessionModelFile(agentDir: string): SessionModelRecord | nul
   return raw == null ? null : parseSessionModel(raw)
 }
 
-/** Delete the durable override (`/model default`, rollback). Best-effort. */
+/** Delete the session-model carrier (`/model default`, rollback). Best-effort. */
 export function clearSessionModelFile(agentDir: string): void {
   try {
     rmSync(join(agentDir, SESSION_MODEL_FILE), { force: true })
-    // #3042 item 4: also drop the kept-alert dedup sentinel so a future
-    // override of the same name re-alerts on its first kept boot.
-    rmSync(join(agentDir, '.session-model-kept-notified'), { force: true })
-    rmSync(join(agentDir, SESSION_MODEL_BOOT_ATTEMPTS_FILE), { force: true })
-  } catch {
-    /* best-effort */
-  }
-}
-
-/**
- * #3043 item 2: clear ONLY the crashloop boot-attempts counter — a positive
- * health signal from the gateway, not a carrier change.
- *
- * start.sh's self-heal (start.sh.hbs "Override crashloop self-heal") increments
- * the counter on every boot that re-enters within 150s with the override still
- * active, and clears a healthy override after 3 fast boots. That window can't
- * tell a genuine crashloop from three quick OPERATOR hand-bounces of a healthy
- * agent — both look like fast successive boots — so three deliberate restarts
- * would spuriously wipe a working override. A boot that reaches bridge
- * registration is proven healthy (the session came all the way up and the
- * bridge connected), so the gateway deletes the counter there. Only boots that
- * genuinely FAIL before the bridge registers now accumulate toward the 3-strike
- * clear. Best-effort; absent file is fine.
- */
-export function clearSessionModelBootAttempts(agentDir: string): void {
-  try {
-    rmSync(join(agentDir, SESSION_MODEL_BOOT_ATTEMPTS_FILE), { force: true })
   } catch {
     /* best-effort */
   }
@@ -181,94 +132,6 @@ export function restoreSessionModelFileRaw(agentDir: string, raw: string | null)
   }
   try {
     atomicWrite(join(agentDir, SESSION_MODEL_FILE), raw)
-  } catch {
-    /* best-effort */
-  }
-}
-
-/**
- * Stamp the one-shot relaunch intent. MUST be called synchronously BEFORE
- * the restart signal/dispatch it describes (write-before-kill invariant —
- * the next start.sh boot reads this to decide keep vs revert). Best-effort:
- * a failed write means the boot falls back to the default (keep, #3039) —
- * the user's choice is preserved either way.
- */
-export function writeRelaunchModelIntent(
-  agentDir: string,
-  intent: RelaunchModelIntent,
-  reason: string,
-): void {
-  try {
-    atomicWrite(
-      join(agentDir, RELAUNCH_MODEL_INTENT_FILE),
-      `${JSON.stringify({ intent, reason, ts: Date.now() })}\n`,
-    )
-  } catch (err) {
-    process.stderr.write(
-      `telegram gateway: relaunch-model-intent write failed (boot will revert): ${(err as Error)?.message ?? String(err)}\n`,
-    )
-  }
-}
-
-/**
- * Reason prefix the gateway's SIGTERM/SIGINT shutdown handler stamps on its
- * deploy-survival keep-intent (#3017/#3018). Distinguishable on purpose:
- * a gateway-only bounce (supervisor relaunch, bare gateway-unit restart)
- * leaves that stamp UNCONSUMED on disk — start.sh only runs on a container
- * boot — and the next gateway boot uses this prefix to recognise and clear
- * the stale stamp (see clearStaleGatewayShutdownIntent).
- */
-export const GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX = 'gateway-shutdown:'
-
-export interface RelaunchModelIntentRecord {
-  intent: RelaunchModelIntent
-  reason: string
-  ts: number
-}
-
-/** Parsed `.relaunch-model-intent`, or null when absent / corrupt / malformed. */
-export function readRelaunchModelIntent(agentDir: string): RelaunchModelIntentRecord | null {
-  try {
-    const raw = readFileSync(join(agentDir, RELAUNCH_MODEL_INTENT_FILE), 'utf8')
-    const parsed = JSON.parse(raw) as Partial<RelaunchModelIntentRecord>
-    if (
-      (parsed.intent !== 'keep' && parsed.intent !== 'revert') ||
-      typeof parsed.reason !== 'string' ||
-      typeof parsed.ts !== 'number'
-    ) {
-      return null
-    }
-    return { intent: parsed.intent, reason: parsed.reason, ts: parsed.ts }
-  } catch {
-    return null
-  }
-}
-
-/**
- * Boot-time cleanup for the gateway-only-bounce hole (#3018 finding 4).
- *
- * A container-level stop/deploy consumes `.relaunch-model-intent` in start.sh
- * BEFORE any gateway boots. So if a freshly-booting GATEWAY still sees an
- * intent that a gateway shutdown handler stamped (reason carries
- * GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX), the preceding bounce was
- * gateway-only — the container never restarted and the stamp is stale.
- * Left in place, it could convert a genuine crash within the 10-min
- * freshness window into a "keep", breaking the crash-reverts policy.
- * Clear it. Never touches a triggerSelfRestart / user-slash stamp (those
- * use their own un-prefixed reasons and precede a container bounce).
- * Returns true when a stale stamp was cleared.
- */
-export function clearStaleGatewayShutdownIntent(agentDir: string): boolean {
-  const rec = readRelaunchModelIntent(agentDir)
-  if (rec == null || !rec.reason.startsWith(GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX)) return false
-  clearRelaunchModelIntent(agentDir)
-  return true
-}
-
-/** Remove a stamped intent (rollback of a failed dispatch). Best-effort. */
-export function clearRelaunchModelIntent(agentDir: string): void {
-  try {
-    rmSync(join(agentDir, RELAUNCH_MODEL_INTENT_FILE), { force: true })
   } catch {
     /* best-effort */
   }

--- a/telegram-plugin/tests/gateway-pending-command-wiring.test.ts
+++ b/telegram-plugin/tests/gateway-pending-command-wiring.test.ts
@@ -89,10 +89,9 @@ describe('gateway: unconfirmed queued model tokens are gated before durable pers
   })
 })
 
-describe('gateway: /restart keeps the session-model override (#3039)', () => {
-  it('the /restart chat command stamps keep, never revert', () => {
-    expect(GATEWAY_SRC).toContain("writeRelaunchModelIntent(smDir, 'keep', 'user: /restart from chat')")
-    expect(GATEWAY_SRC).not.toContain("writeRelaunchModelIntent(smDir, 'revert'")
+describe('gateway: /restart reverts the session-model override (rev 4, session-scoped)', () => {
+  it('no restart verb stamps a relaunch-model intent (the subsystem is retired)', () => {
+    expect(GATEWAY_SRC).not.toContain('writeRelaunchModelIntent')
   })
 })
 
@@ -107,18 +106,14 @@ describe('gateway: /effort persistence choke point (#3039)', () => {
   })
 })
 
-describe('gateway: keep-intent stamp narrowing (#3018 finding 4)', () => {
-  it('the shutdown keep-intent stamp carries the gateway-shutdown reason prefix', () => {
-    expect(GATEWAY_SRC).toContain(
-      "writeRelaunchModelIntent(smDir, 'keep', `${GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX} graceful ${signal} shutdown",
-    )
-  })
-
-  it('boot clears a stale gateway-shutdown-stamped intent (gateway-only bounce never runs start.sh)', () => {
-    const idx = GATEWAY_SRC.indexOf('clearStaleGatewayShutdownIntent(bootSmDir)')
+describe('gateway: graceful shutdown no longer preserves a session model (rev 4)', () => {
+  it('the shutdown handler stamps no keep-intent — a deploy reverts to config', () => {
+    const idx = GATEWAY_SRC.indexOf('async function shutdown(signal: string)')
     expect(idx).toBeGreaterThan(0)
-    // The cleanup runs at module top-level (gateway boot), BEFORE the shutdown
-    // handler could stamp a fresh one for THIS process's own exit.
-    expect(idx).toBeLessThan(GATEWAY_SRC.indexOf('async function shutdown(signal: string)'))
+    const win = GATEWAY_SRC.slice(idx, idx + 6000)
+    expect(win).not.toContain('writeRelaunchModelIntent')
+    expect(win).not.toContain('GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX')
+    // The queued-command persist at shutdown still writes a consume-once carrier.
+    expect(win).toContain('persistQueuedCommandForRestart')
   })
 })

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -1,15 +1,14 @@
 /**
- * Structural pins for the session-model stickiness wiring in gateway.ts
- * (reference/rfcs/session-model-stickiness.md).
+ * Structural pins for the session-scoped /model wiring in gateway.ts
+ * (reference/rfcs/session-model-stickiness.md §0.1, rev 4 — consume-once).
  *
  * The behaviour lives in un-exported inline closures (buildModelDeps's
- * scheduleModelRelaunch/scheduleRestart, triggerSelfRestart, the /restart and
- * /new handlers, the model-menu callback branches, and the boot re-hydration
- * block inside the startup IIFE), so — mirroring the other gateway-*.test.ts
- * source-pins — we assert on the source structure. The end-to-end behaviour
- * of the boot resolver is exercised in tests/scaffold.session-model.test.ts
- * (rendered start.sh), the file helpers in session-model-file.test.ts, and
- * the handler contract in model-command.test.ts.
+ * scheduleModelRelaunch/scheduleRestart, the typed/menu recorders, and the
+ * boot re-hydration block inside the startup IIFE), so — mirroring the other
+ * gateway-*.test.ts source-pins — we assert on the source structure. The
+ * end-to-end boot behaviour is exercised in tests/scaffold.session-model.test.ts
+ * (rendered start.sh), the file helpers in session-model-file.test.ts, and the
+ * handler contract in model-command.test.ts.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -20,35 +19,27 @@ import { dirname, resolve } from 'node:path'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const GATEWAY_SRC = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf8')
 
-describe('gateway: triggerSelfRestart stamps relaunch-model intent BEFORE the kill', () => {
-  it('docker branch: writeRelaunchModelIntent(intentForRestartReason(reason)) precedes the SIGTERM scheduling', () => {
+describe('gateway: the .relaunch-model-intent subsystem is retired (rev 4)', () => {
+  it('gateway.ts no longer writes/clears/imports any relaunch-model intent', () => {
+    expect(GATEWAY_SRC).not.toContain('writeRelaunchModelIntent')
+    expect(GATEWAY_SRC).not.toContain('clearRelaunchModelIntent')
+    expect(GATEWAY_SRC).not.toContain('intentForRestartReason')
+    expect(GATEWAY_SRC).not.toContain('clearStaleGatewayShutdownIntent')
+    expect(GATEWAY_SRC).not.toContain('GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX')
+    expect(GATEWAY_SRC).not.toContain('.relaunch-model-intent')
+  })
+
+  it('triggerSelfRestart just signals — no intent stamp before the kill', () => {
     const fnIdx = GATEWAY_SRC.indexOf('function triggerSelfRestart(')
     expect(fnIdx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(fnIdx, fnIdx + 3000)
-    const writeIdx = win.indexOf('writeRelaunchModelIntent(smDir, intentForRestartReason(reason), reason)')
-    const killIdx = win.indexOf("process.kill(1, 'SIGTERM')")
-    // Write-before-kill invariant: boot default is REVERT, so the intent must
-    // be on disk synchronously before the SIGTERM is even scheduled.
-    expect(writeIdx).toBeGreaterThan(0)
-    expect(killIdx).toBeGreaterThan(writeIdx)
-    // And before the setTimeout that schedules it.
-    const timeoutIdx = win.indexOf('setTimeout(')
-    expect(timeoutIdx).toBeGreaterThan(writeIdx)
-  })
-
-  it('legacy systemd branch stamps intent too (self-target only)', () => {
-    const fnIdx = GATEWAY_SRC.indexOf('function triggerSelfRestart(')
-    const win = GATEWAY_SRC.slice(fnIdx, fnIdx + 4200)
-    const legacyIdx = win.indexOf('// Legacy systemd path.')
-    expect(legacyIdx).toBeGreaterThan(0)
-    const legacyWin = win.slice(legacyIdx)
-    expect(legacyWin).toContain('writeRelaunchModelIntent(smDir, intentForRestartReason(reason), reason)')
-    expect(legacyWin.indexOf('writeRelaunchModelIntent')).toBeLessThan(legacyWin.indexOf('spawn('))
+    expect(win).toContain("process.kill(1, 'SIGTERM')")
+    expect(win).not.toContain('writeRelaunchModelIntent')
   })
 })
 
-describe('gateway: scheduleModelRelaunch dep (durable .session-model)', () => {
-  it('writes the durable file via writeSessionModelFile before dispatching the restart', () => {
+describe('gateway: scheduleModelRelaunch dep (consume-once .session-model carrier)', () => {
+  it('writes the carrier via writeSessionModelFile before dispatching the restart', () => {
     const idx = GATEWAY_SRC.indexOf('scheduleModelRelaunch: async')
     expect(idx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(idx, idx + 1800)
@@ -67,21 +58,12 @@ describe('gateway: scheduleModelRelaunch dep (durable .session-model)', () => {
     expect(restartIdx).toBeGreaterThan(setIdx)
   })
 
-  it('rolls back the prior file content (not just deletion) on a non-in-flight dispatch failure', () => {
+  it('rolls back the prior carrier content (not just deletion) on a non-in-flight dispatch failure', () => {
     const idx = GATEWAY_SRC.indexOf('scheduleModelRelaunch: async')
     const win = GATEWAY_SRC.slice(idx, idx + 1800)
     expect(win).toContain('const prevFileRaw = readSessionModelFileRaw(agentDir)')
     expect(win).toContain('restoreSessionModelFileRaw(agentDir, prevFileRaw)')
     expect(win).toContain("!== 'restart_in_flight'")
-  })
-
-  it('the non-in-flight rollback ALSO clears the keep-intent (a live intent with no restart coming would wrongly KEEP across a crash)', () => {
-    const idx = GATEWAY_SRC.indexOf('scheduleModelRelaunch: async')
-    const win = GATEWAY_SRC.slice(idx, idx + 2400)
-    const inFlightIdx = win.indexOf("!== 'restart_in_flight'")
-    const clearIdx = win.indexOf('clearRelaunchModelIntent(agentDir)')
-    expect(inFlightIdx).toBeGreaterThan(0)
-    expect(clearIdx).toBeGreaterThan(inFlightIdx)
   })
 
   it('reuses the same scheduleRestart dispatch (not a bespoke restart path)', () => {
@@ -91,63 +73,20 @@ describe('gateway: scheduleModelRelaunch dep (durable .session-model)', () => {
   })
 })
 
-describe('gateway: intent writers on the restart verbs', () => {
-  it('model-switch scheduleRestart stamps keep-intent before the hostd dispatch', () => {
-    const idx = GATEWAY_SRC.indexOf('scheduleRestart: async (reason: string)')
-    expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 3200)
-    const keepIdx = win.indexOf("writeRelaunchModelIntent(smDir, 'keep', reason)")
-    const dispatchIdx = win.indexOf("op: 'agent_restart'")
-    expect(keepIdx).toBeGreaterThan(0)
-    expect(dispatchIdx).toBeGreaterThan(keepIdx)
-  })
-
-  it('scheduleRestart clears the keep-intent when hostd refuses (failed dispatch → no live intent on disk)', () => {
-    const idx = GATEWAY_SRC.indexOf('scheduleRestart: async (reason: string)')
-    const win = GATEWAY_SRC.slice(idx, idx + 3200)
-    const failIdx = win.indexOf('hostd restart failed')
-    const clearIdx = win.indexOf('clearRelaunchModelIntent(smDir)')
-    expect(clearIdx).toBeGreaterThan(0)
-    expect(failIdx).toBeGreaterThan(clearIdx) // cleared before the throw's message
-    // And it sits in the same error branch as clearRestartMarker.
-    const markerIdx = win.indexOf('clearRestartMarker()')
-    expect(clearIdx).toBeGreaterThan(markerIdx)
-  })
-
-  it('/restart stamps a KEEP intent before dispatch (#3039: a restart is not "clear my model")', () => {
-    const idx = GATEWAY_SRC.indexOf("stampUserRestartReason('user: /restart from chat')")
-    expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 900)
-    const keepIdx = win.indexOf("writeRelaunchModelIntent(smDir, 'keep', 'user: /restart from chat')")
-    const dispatchIdx = win.indexOf("hostdRequestId('gw-restart')")
-    expect(keepIdx).toBeGreaterThan(0)
-    expect(dispatchIdx).toBeGreaterThan(keepIdx)
-  })
-
-  it('/new and /reset stamp keep-intent (fresh conversation, same model — contract row 7)', () => {
-    const idx = GATEWAY_SRC.indexOf('stampUserRestartReason(`user: /${kind} from chat`)')
-    expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 700)
-    const keepIdx = win.indexOf("writeRelaunchModelIntent(agentDir, 'keep', `user: /${kind} from chat`)")
-    const dispatchIdx = win.indexOf('tryHostdDispatch')
-    expect(keepIdx).toBeGreaterThan(0)
-    expect(dispatchIdx).toBeGreaterThan(keepIdx)
-  })
-})
-
-describe('gateway: model-menu callback persists the sticky override', () => {
-  it('a confirmed selection persists the canonical token (selectedModelToken), never the display label', () => {
-    // Recording extracted into recordModelMenuSideEffects (#3017) — shared by the
-    // live dispatcher and the deferred (queued mid-turn) apply so both record
-    // identically.
+describe('gateway: menu callback carrier handling (session-scoped)', () => {
+  it('a live Claude selection records the in-memory override but writes NO carrier', () => {
     const idx = GATEWAY_SRC.indexOf('function recordModelMenuSideEffects')
     expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 2400)
-    expect(win).toContain('outcome.selectedModelToken')
-    expect(win).toMatch(/writeSessionModelFile\(\s*smDir,\s*outcome\.selectedModelToken/)
+    const win = GATEWAY_SRC.slice(idx, idx + 900)
+    // The first (live-switch) block sets the override but no longer persists.
+    expect(win).toContain('sessionModelSource.setOverride(outcome.selectedModel)')
+    const overrideIdx = win.indexOf('sessionModelSource.setOverride(outcome.selectedModel)')
+    const nextClearIdx = win.indexOf('outcome.clearedDefault')
+    const writeBetween = win.slice(overrideIdx, nextClearIdx)
+    expect(writeBetween).not.toContain('writeSessionModelFile(')
   })
 
-  it('a confirmed "Default" selection CLEARS the sticky file', () => {
+  it('a confirmed "Default" selection CLEARS the carrier', () => {
     const idx = GATEWAY_SRC.indexOf('function recordModelMenuSideEffects')
     const win = GATEWAY_SRC.slice(idx, idx + 2400)
     expect(win).toContain('outcome.clearedDefault')
@@ -155,9 +94,6 @@ describe('gateway: model-menu callback persists the sticky override', () => {
   })
 
   it('the sr-* callback branch calls scheduleModelRelaunch, not inject', () => {
-    // Anchor on the sr-* TARGET dispatcher branch specifically (a mid-turn
-    // busy-gate #3017 also matches `if (data.startsWith(MODEL_CALLBACK_SR))`, so
-    // anchor on the relaunch call that is unique to the idle apply branch).
     const idx = GATEWAY_SRC.indexOf('const srLabel = escapeHtmlForTg(srFriendlyLabel(srName))')
     expect(idx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(idx, idx + 1400)
@@ -165,53 +101,37 @@ describe('gateway: model-menu callback persists the sticky override', () => {
     expect(win).toMatch(/scheduleModelRelaunch[\s\S]*?\n\s*return\n/)
   })
 
-  it('the sr-to-claude transition writes the durable file (and clears it on a Default tap)', () => {
+  it('the sr-to-claude transition (a relaunch) writes the carrier, and clears it on a Default tap', () => {
     const idx = GATEWAY_SRC.indexOf('isSrToClaudeTransition(prevSessionModel, outcome.selectedModel)')
     expect(idx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(idx, idx + 3600)
     expect(win).toMatch(/writeSessionModelFile\(\s*agentDir,\s*token/)
     expect(win).toContain('clearSessionModelFile(agentDir)')
-    // Restart rides triggerSelfRestart with a keep-classified reason.
     expect(win).toContain("triggerSelfRestart(agentName, 'sr-to-claude-model-switch'")
   })
 })
 
-describe('gateway: typed /model persists the REQUESTED canonical token', () => {
-  it('persists expandSrAlias(parsed.model), and `/model default` clears file + in-memory override', () => {
-    // Recording extracted into recordTypedModelSwitch (#3017) — shared by the
-    // live `bot.command('model')` handler and the deferred (queued mid-turn) apply.
+describe('gateway: typed /model is session-scoped (live Claude switch writes no carrier)', () => {
+  it('the Claude path sets the in-memory override but never persists a carrier', () => {
     const idx = GATEWAY_SRC.indexOf('function recordTypedModelSwitch')
     expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 2400)
-    expect(win).toContain("requested?.toLowerCase() === 'default'")
-    expect(win).toContain('sessionModelSource.setOverride(null)')
-    expect(win).toContain('clearSessionModelFile(smDir)')
-    // Non-default: the requested token (shape-gated, non-sr) is what persists.
-    expect(win).toContain('isValidModelArg(requested) && !isSrModel(requested)')
-    expect(win).toMatch(/writeSessionModelFile\(\s*smDir,\s*requested/)
+    const win = GATEWAY_SRC.slice(idx, idx + 1400)
+    expect(win).toContain('sessionModelSource.setOverride(reply.selectedModel)')
+    // No durable carrier write on the live-switch path.
+    expect(win).not.toContain('writeSessionModelFile(')
   })
 
-  it('`/model default` file-clear is NOT gated on a positive confirmation (silent-switch path must not resurrect)', () => {
+  it('`/model default` clears the carrier + in-memory override (silent-switch path must not resurrect)', () => {
     const idx = GATEWAY_SRC.indexOf('function recordTypedModelSwitch')
-    const win = GATEWAY_SRC.slice(idx, idx + 2400)
-    // The default branch clears the file unconditionally, and only the
-    // in-memory override change is confirmation-gated inside it.
+    const win = GATEWAY_SRC.slice(idx, idx + 1400)
+    expect(win).toContain("requested?.toLowerCase() === 'default'")
+    expect(win).toContain('clearSessionModelFile(smDir)')
+    expect(win).toContain('sessionModelSource.setOverride(null)')
+    // The file-clear is not gated on a positive confirmation.
     const clearIdx = win.indexOf('if (smDir) clearSessionModelFile(smDir)')
     const gatedOverrideIdx = win.indexOf('if (reply.selectedModel) sessionModelSource.setOverride(null)')
     expect(clearIdx).toBeGreaterThan(0)
     expect(gatedOverrideIdx).toBeGreaterThan(clearIdx)
-    // And the whole default branch is not nested in an `if (reply.selectedModel)` block:
-    const between = win.slice(0, clearIdx)
-    expect(between).not.toContain('if (reply.selectedModel) {')
-  })
-
-  it('a persist failure is surfaced ON THE REPLY, not just stderr (typed + menu paths)', () => {
-    expect(GATEWAY_SRC.match(/won’t survive a relaunch/g)?.length ?? 0).toBeGreaterThanOrEqual(2)
-    const typedIdx = GATEWAY_SRC.indexOf('persistWarning =')
-    expect(typedIdx).toBeGreaterThan(0)
-    expect(GATEWAY_SRC).toContain('reply.text + persistWarning')
-    // Menu path appends onto the outgoing card text.
-    expect(GATEWAY_SRC).toContain('outcome.reply.text +=')
   })
 })
 

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -206,7 +206,7 @@ describe("handleModelCommand — set", () => {
     const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
     expect(calls).toEqual([{ agent: "klanker", command: "/model opus" }]);
     expect(reply.text).toContain("<pre>⏺ Set model to sonnet</pre>");
-    expect(reply.text).toContain("persists across restarts, deploys, and crashes");
+    expect(reply.text).toContain("lasts until the agent’s next restart");
     expect(reply.html).toBe(true);
     // A verified confirmation records the live model so /status stays honest
     // (bug 1: the typed path never recorded the switch before).

--- a/telegram-plugin/tests/session-model-file.test.ts
+++ b/telegram-plugin/tests/session-model-file.test.ts
@@ -1,10 +1,12 @@
 /**
- * Durable session-model file helpers (session-model-file.ts) — the gateway
- * side of the stickiness contract (reference/rfcs/session-model-stickiness.md).
+ * Session-model file helpers (session-model-file.ts) — the gateway side of the
+ * session-scoped /model contract (reference/rfcs/session-model-stickiness.md
+ * §0.1, rev 4 — consume-once). The `.relaunch-model-intent` subsystem and the
+ * crashloop counter were retired with rev 4; their tests are gone.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
@@ -15,17 +17,8 @@ import {
   readSessionModelFileRaw,
   restoreSessionModelFileRaw,
   clearSessionModelFile,
-  clearSessionModelBootAttempts,
-  SESSION_MODEL_BOOT_ATTEMPTS_FILE,
-  writeRelaunchModelIntent,
-  clearRelaunchModelIntent,
   readConfiguredDefaultModel,
-  intentForRestartReason,
-  readRelaunchModelIntent,
-  clearStaleGatewayShutdownIntent,
-  GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX,
   SESSION_MODEL_FILE,
-  RELAUNCH_MODEL_INTENT_FILE,
   CONFIGURED_DEFAULT_MODEL_FILE,
   parseSessionEffort,
   writeSessionEffortFile,
@@ -87,86 +80,6 @@ describe('rollback snapshot (scheduleModelRelaunch dispatch failure)', () => {
   })
 })
 
-describe('relaunch intent', () => {
-  it('writes one-line JSON with intent, reason, and embedded ts (the freshness clock)', () => {
-    writeRelaunchModelIntent(dir, 'keep', 'user: /new from chat')
-    const raw = readFileSync(join(dir, RELAUNCH_MODEL_INTENT_FILE), 'utf8')
-    const parsed = JSON.parse(raw)
-    expect(parsed.intent).toBe('keep')
-    expect(parsed.reason).toBe('user: /new from chat')
-    expect(Math.abs(Date.now() - parsed.ts)).toBeLessThan(5000)
-  })
-
-  it('last-writer-wins and clearable', () => {
-    writeRelaunchModelIntent(dir, 'keep', 'a')
-    writeRelaunchModelIntent(dir, 'revert', 'b')
-    expect(JSON.parse(readFileSync(join(dir, RELAUNCH_MODEL_INTENT_FILE), 'utf8')).intent).toBe('revert')
-    clearRelaunchModelIntent(dir)
-    expect(existsSync(join(dir, RELAUNCH_MODEL_INTENT_FILE))).toBe(false)
-  })
-})
-
-describe('intentForRestartReason — the triggerSelfRestart per-reason table (RFC §3)', () => {
-  it.each([
-    'schedule-restart-immediate',
-    'restart-drain-cap-forced',
-    'turn-complete-pending-restart',
-    'fleet-fallback-resume',
-    'sr-to-claude-model-switch',
-  ])('switchroom-managed relaunch %s → keep', (reason) => {
-    expect(intentForRestartReason(reason)).toBe('keep')
-  })
-
-  it('inline-button-restart → keep (#3039: a restart is not "clear my model")', () => {
-    expect(intentForRestartReason('inline-button-restart')).toBe('keep')
-  })
-
-  it('unknown gateway reasons default to keep (only gateway code calls triggerSelfRestart; crashes never do)', () => {
-    expect(intentForRestartReason('some-future-recovery-path')).toBe('keep')
-  })
-})
-
-describe('readRelaunchModelIntent', () => {
-  it('round-trips a stamped intent; null when absent / corrupt / malformed', () => {
-    expect(readRelaunchModelIntent(dir)).toBeNull()
-    writeRelaunchModelIntent(dir, 'keep', 'watchdog recovery')
-    const rec = readRelaunchModelIntent(dir)!
-    expect(rec.intent).toBe('keep')
-    expect(rec.reason).toBe('watchdog recovery')
-    expect(Math.abs(Date.now() - rec.ts)).toBeLessThan(5000)
-    writeFileSync(join(dir, RELAUNCH_MODEL_INTENT_FILE), '{broken')
-    expect(readRelaunchModelIntent(dir)).toBeNull()
-    writeFileSync(join(dir, RELAUNCH_MODEL_INTENT_FILE), '{"intent":"maybe","reason":"x","ts":1}\n')
-    expect(readRelaunchModelIntent(dir)).toBeNull()
-  })
-})
-
-describe('clearStaleGatewayShutdownIntent (#3018 finding 4 — a gateway-only bounce must not leave a keep stamp)', () => {
-  it('clears ONLY a gateway-shutdown-stamped intent and reports it', () => {
-    writeRelaunchModelIntent(
-      dir,
-      'keep',
-      `${GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX} graceful SIGTERM shutdown (deploy/rolling restart) — preserving user-chosen session model`,
-    )
-    expect(clearStaleGatewayShutdownIntent(dir)).toBe(true)
-    expect(existsSync(join(dir, RELAUNCH_MODEL_INTENT_FILE))).toBe(false)
-    // Idempotent: a second call finds nothing.
-    expect(clearStaleGatewayShutdownIntent(dir)).toBe(false)
-  })
-
-  it('never touches a triggerSelfRestart / user-slash stamp (un-prefixed reason)', () => {
-    writeRelaunchModelIntent(dir, 'keep', 'sr-to-claude-model-switch')
-    expect(clearStaleGatewayShutdownIntent(dir)).toBe(false)
-    expect(readRelaunchModelIntent(dir)!.reason).toBe('sr-to-claude-model-switch')
-  })
-
-  it('is a safe no-op on an absent or corrupt intent file', () => {
-    expect(clearStaleGatewayShutdownIntent(dir)).toBe(false)
-    writeFileSync(join(dir, RELAUNCH_MODEL_INTENT_FILE), 'not json')
-    expect(clearStaleGatewayShutdownIntent(dir)).toBe(false)
-  })
-})
-
 describe('readConfiguredDefaultModel', () => {
   it('reads the trimmed value; null when absent or empty', () => {
     expect(readConfiguredDefaultModel(dir)).toBeNull()
@@ -216,66 +129,5 @@ describe('session-effort file helpers (#3039)', () => {
     writeSessionEffortFile(dir, 'high', '')
     clearSessionEffortFile(dir)
     expect(readSessionEffortFile(dir)).toBeNull()
-  })
-})
-
-describe('intentForRestartReason is keep-for-everything (#3039)', () => {
-  it('every reason keeps — restarts never clear a user model choice', () => {
-    for (const reason of [
-      'inline-button-restart',
-      'user: /restart from chat',
-      'schedule-restart-immediate',
-      'anything-else',
-    ]) {
-      expect(intentForRestartReason(reason)).toBe('keep')
-    }
-  })
-})
-
-describe('clearSessionModelBootAttempts (#3043 item 2: bridge-register clears the crashloop counter)', () => {
-  const bootAttemptsPath = () => join(dir, SESSION_MODEL_BOOT_ATTEMPTS_FILE)
-
-  // Faithful model of start.sh.hbs "Override crashloop self-heal": each boot
-  // within 150s of the previous stamp bumps the count; a stale stamp resets to
-  // 1. Reproduced here so the accumulate-vs-reset OUTCOME is asserted, not just
-  // the delete call.
-  function simulateBootStamp(nowSec: number): number {
-    let count = 0
-    let prev = 0
-    if (existsSync(bootAttemptsPath())) {
-      const [c, p] = readFileSync(bootAttemptsPath(), 'utf8').trim().split(/\s+/)
-      count = Number(c) || 0
-      prev = Number(p) || 0
-    }
-    count = nowSec - prev < 150 ? count + 1 : 1
-    writeFileSync(bootAttemptsPath(), `${count} ${nowSec}\n`)
-    return count
-  }
-
-  it('WITHOUT a bridge register, three fast boots accumulate toward the 3-strike clear', () => {
-    // Three operator hand-bounces, each <150s apart, with no register between.
-    expect(simulateBootStamp(1000)).toBe(1)
-    expect(simulateBootStamp(1010)).toBe(2)
-    expect(simulateBootStamp(1020)).toBe(3) // start.sh would now clear a HEALTHY override — the false positive
-  })
-
-  it('a bridge register between boots resets the counter, so a healthy agent never reaches 3', () => {
-    expect(simulateBootStamp(1000)).toBe(1)
-    // Boot 1 came all the way up and the bridge registered → gateway clears it.
-    clearSessionModelBootAttempts(dir)
-    expect(existsSync(bootAttemptsPath())).toBe(false)
-
-    // Next fast boot starts fresh at 1 (no accumulation), and register clears again.
-    expect(simulateBootStamp(1010)).toBe(1)
-    clearSessionModelBootAttempts(dir)
-    expect(simulateBootStamp(1020)).toBe(1)
-    // The healthy agent's counter never climbs to the 3-strike clear.
-    const [count] = readFileSync(bootAttemptsPath(), 'utf8').trim().split(/\s+/)
-    expect(Number(count)).toBeLessThan(3)
-  })
-
-  it('is best-effort — no throw when the counter file is absent', () => {
-    expect(existsSync(bootAttemptsPath())).toBe(false)
-    expect(() => clearSessionModelBootAttempts(dir)).not.toThrow()
   })
 })

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -7,17 +7,17 @@ import { scaffoldAgent } from "../src/agents/scaffold.js";
 import { isValidModelArg } from "../telegram-plugin/gateway/model-command.js";
 import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
 
-// Session-scoped /model stickiness — the rendered start.sh boot resolver
-// (reference/rfcs/session-model-stickiness.md). Successor to
-// scaffold.session-model-override.test.ts (one-shot carrier, retired).
+// Session-scoped /model — the rendered start.sh boot resolver
+// (reference/rfcs/session-model-stickiness.md §0.1, rev 4). Driven as
+// sh-harness fixtures against the RENDERED block.
 //
-// Contract under test (#3039 rev 3, keep-by-default), driven as sh-harness
-// fixtures against the RENDERED block: the durable `.session-model` override
-// is applied on EVERY boot — crash, deploy, raw `docker restart`, stale or
-// corrupt intent all KEEP it. Only a FRESH (<10 min, embedded ts) explicit
-// "revert" `.relaunch-model-intent`, corruption, or a configured-default
-// change clears it — and every clearing path writes a `.session-model-alert`
-// notice the gateway relays to chat.
+// Contract under test (CONSUME-ONCE): a `.session-model` carrier is applied on
+// the single boot that reads it and then DELETED, so the model-apply relaunch
+// picks it up and EVERY subsequent restart reverts to the configured default.
+// There is no `.relaunch-model-intent`, no crashloop counter, and no
+// kept-notified sentinel. Invalidation (corrupt / configured-default changed /
+// sr-*+LiteLLM-down) drops the carrier and writes a `.session-model-alert` the
+// gateway relays.
 
 const telegramConfig: TelegramConfig = {
   bot_token: "123456:ABC-DEF",
@@ -60,17 +60,12 @@ function extractBlock(startSh: string): string {
   return startSh.slice(start, end);
 }
 
-/** One-line durable override JSON, same shape the gateway writes. */
+/** One-line carrier JSON, same shape the gateway writes. */
 function sessionModelJson(model: string, cfg = DEFAULT_MODEL, ts = Date.now()): string {
   return `${JSON.stringify({ model, configuredDefaultAtWrite: cfg, ts })}\n`;
 }
 
-/** One-line intent JSON, same shape the gateway writes. */
-function intentJson(intent: string, ts = Date.now(), reason = "test"): string {
-  return `${JSON.stringify({ intent, reason, ts })}\n`;
-}
-
-describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () => {
+describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", () => {
   let tmpDir: string;
   let agentDir: string;
   let block: string;
@@ -118,13 +113,16 @@ describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () 
     return readFileSync(join(agentDir, ".session-model-alert"), "utf-8");
   }
 
-  it("renders the durable-override + intent wiring in start.sh", () => {
+  it("renders the consume-once carrier wiring in start.sh (no intent file)", () => {
     expect(block).toContain(".session-model");
-    expect(block).toContain(".relaunch-model-intent");
     expect(block).toContain(".configured-default-model");
     expect(block).toContain(".session-model-alert");
     // Migration shim still consumes the legacy one-shot carrier.
     expect(block).toContain(".session-model-override");
+    // The retired keep/revert intent + crashloop machinery is gone.
+    expect(block).not.toContain(".relaunch-model-intent");
+    expect(block).not.toContain(".session-model-boot-attempts");
+    expect(block).not.toContain(".session-model-kept-notified");
     // modelQ is assigned BARE (already shell-quoted by the scaffold).
     expect(block).toContain("_EFFECTIVE_MODEL='claude-sonnet-5'");
     const startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
@@ -133,17 +131,11 @@ describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () 
   });
 
   // ── MODEL_ARG_RE byte-parity against the RENDERED start.sh ────────────────
-  // The sh shape gate and the gateway's MODEL_ARG_RE must accept/reject the
-  // same tokens, or a gateway-persisted override could be dropped (or worse,
-  // an sh-accepted string the gateway never validated could launch). Extract
-  // the grep -Eq pattern from the RENDERED script and drive BOTH gates over
-  // one fixture list.
   it("shape gate is byte-parity with MODEL_ARG_RE (rendered start.sh vs gateway)", () => {
     const startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
     const patterns = [...startSh.matchAll(/grep -Eq '([^']+)'/g)].map((m) => m[1]);
     const shapePatterns = patterns.filter((p) => p.includes("{0,99}"));
-    expect(shapePatterns.length).toBeGreaterThanOrEqual(2); // durable gate + migration gate
-    // All rendered shape gates are the same bytes.
+    expect(shapePatterns.length).toBeGreaterThanOrEqual(2); // carrier gate + migration gate
     for (const p of shapePatterns) expect(p).toBe(shapePatterns[0]);
     const shPattern = shapePatterns[0];
     const fixtures: Array<[string, boolean]> = [
@@ -170,109 +162,33 @@ describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () 
     }
   });
 
-  it("no override, no intent → boots default, records .configured-default-model + .active-session-model", () => {
+  it("no carrier → boots default, records .configured-default-model + no alert", () => {
     expect(runBlock("1")).toBe(DEFAULT_MODEL);
     expect(readFileSync(join(agentDir, ".configured-default-model"), "utf-8").trim()).toBe(DEFAULT_MODEL);
-    expect(readFileSync(join(agentDir, ".active-session-model"), "utf-8").trim()).toBe(DEFAULT_MODEL);
     expect(existsSync(join(agentDir, ".session-model-alert"))).toBe(false);
   });
 
-  // ── keep path (row 11: watchdog / recovery bounce) ────────────────────────
-  it("override + fresh keep intent → applies the override, RETAINS the file, consumes the intent, announces", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep", Date.now(), "schedule-restart-immediate"));
-    expect(runBlock("1")).toBe("claude-opus-4-8");
-    // Durable: NOT consumed on a keep boot.
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(true);
-    // Intent is one-shot.
-    expect(existsSync(join(agentDir, ".relaunch-model-intent"))).toBe(false);
-    // Rendered notice: an involuntary bounce never SILENTLY continues on a
-    // non-default model.
-    expect(alertText()).toContain("`claude-opus-4-8` kept across this relaunch");
-    expect(alertText()).toContain("/model default");
-  });
-
-  // ── keep-by-default paths (#3039) ────────────────────────────────────────
-  it("override + NO intent (crash / raw docker restart / deploy) → KEEPS the override and announces", () => {
+  // ── requirement (a): the apply-relaunch picks up the carrier ─────────────
+  it("valid carrier → APPLIES the override this boot and CONSUMES the carrier (no boot alert)", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
     expect(runBlock("1")).toBe("claude-opus-4-8");
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(true);
-    const alert = alertText();
-    expect(alert).toContain("`claude-opus-4-8` kept across this relaunch");
-    expect(alert).toContain("/model default");
-  });
-
-  it("override + revert intent → reverts and the notice carries the intent's reason", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("sr-glm-5"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("revert", Date.now(), "user: /restart from chat"));
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    // Consume-once: the carrier is deleted on the apply boot.
     expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
-    expect(existsSync(join(agentDir, ".relaunch-model-intent"))).toBe(false);
-    expect(alertText()).toContain("user: /restart from chat");
+    // The gateway already acked the /model in chat — no boot alert on apply.
+    expect(existsSync(join(agentDir, ".session-model-alert"))).toBe(false);
   });
 
-  it("override + STALE revert intent (>10 min by embedded ts) → treated as no intent, KEEPS", () => {
+  // ── requirement (b): the next restart reverts to the configured default ──
+  it("SUBSEQUENT restart (carrier already consumed) → reverts to the configured default", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("revert", Date.now() - 11 * 60_000));
-    expect(runBlock("1")).toBe("claude-opus-4-8");
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(true);
-  });
-
-  it("override + corrupt intent → treated as no intent, KEEPS; intent consumed", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), "not json at all\n");
-    expect(runBlock("1")).toBe("claude-opus-4-8");
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(true);
-    expect(existsSync(join(agentDir, ".relaunch-model-intent"))).toBe(false);
-  });
-
-  // ── keep-gated hygiene branches ──────────────────────────────────────────
-  it("keep + corrupt .session-model → deletes it, boots default", () => {
-    writeFileSync(join(agentDir, ".session-model"), "{broken\n");
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep"));
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    expect(runBlock("1")).toBe("claude-opus-4-8"); // apply-relaunch
+    expect(runBlock("1")).toBe(DEFAULT_MODEL); // any later restart
+    expect(runBlock("1")).toBe(DEFAULT_MODEL); // and every one after
     expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
   });
 
-  it("keep + shape-gate-failing model → deletes it, boots default (injection surface closed)", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("bad name; rm -rf /"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep"));
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
-  });
-
-  it("keep + MULTILINE .session-model (two model fields on two lines) → rejected, boots default", () => {
-    // The sed extraction emits one match per matching LINE and `grep -Eq`
-    // passes if ANY line matches — without the newline check a multiline
-    // value (each line individually shape-valid) would reach `claude
-    // --model`. Parity with parseSessionModel's single-string strictness.
-    writeFileSync(
-      join(agentDir, ".session-model"),
-      `${sessionModelJson("sr-glm-5")}${sessionModelJson("sr-evil-2")}`,
-    );
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep"));
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
-  });
-
-  it("keep + configuredDefaultAtWrite mismatch (yaml model changed) → INVALIDATES + announces", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8", "claude-old-model"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep"));
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
-    const alert = alertText();
-    expect(alert).toContain("configured default model changed");
-    expect(alert).toContain("`claude-old-model` → `claude-sonnet-5`");
-    expect(alert).toContain("override to `claude-opus-4-8` was cleared");
-  });
-
-  it("override older than 7 days → NO expiry (#3039: only explicit user action clears it)", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8", DEFAULT_MODEL, Date.now() - 8 * 24 * 3600_000));
-    expect(runBlock("1")).toBe("claude-opus-4-8");
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(true);
-  });
-
-  it("corrupt .session-model → falls back to default AND notifies (never a silent drop)", () => {
+  // ── invalidation branches (all consume + alert) ──────────────────────────
+  it("corrupt .session-model → deletes it, boots default, notifies (never a silent drop)", () => {
     writeFileSync(join(agentDir, ".session-model"), "{broken\n");
     expect(runBlock("1")).toBe(DEFAULT_MODEL);
     expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
@@ -281,40 +197,94 @@ describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () 
     expect(alert).toContain("configured default");
   });
 
-  // ── crashloop self-heal (#3042 blocker 2b) ───────────────────────────────
-  it("three consecutive fast boots with an override active → carrier cleared, default booted, alert once", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
-    expect(runBlock("1")).toBe("claude-opus-4-8"); // boot 1 (cnt=1)
-    expect(runBlock("1")).toBe("claude-opus-4-8"); // boot 2 (cnt=2)
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);     // boot 3 → self-heal
+  it("shape-gate-failing model → deletes it, boots default (injection surface closed)", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("bad name; rm -rf /"));
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
     expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
-    expect(existsSync(join(agentDir, ".session-model-boot-attempts"))).toBe(false);
+  });
+
+  it("MULTILINE .session-model (two model fields on two lines) → rejected, boots default", () => {
+    writeFileSync(
+      join(agentDir, ".session-model"),
+      `${sessionModelJson("sr-glm-5")}${sessionModelJson("sr-evil-2")}`,
+    );
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+  });
+
+  it("configuredDefaultAtWrite mismatch (yaml model changed) → NOT applied + announces + consumed", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8", "claude-old-model"));
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
     const alert = alertText();
-    expect(alert).toContain("cleared automatically");
-    expect(alert).toContain("`claude-sonnet-5`");
-    // …and the NEXT boot is a clean default boot (no stale counter).
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    expect(alert).toContain("configured default model changed");
+    expect(alert).toContain("`claude-old-model` → `claude-sonnet-5`");
+    expect(alert).toContain("override to `claude-opus-4-8` was not applied");
   });
 
-  it("a boot without an override clears any stale boot-attempt counter", () => {
-    writeFileSync(join(agentDir, ".session-model-boot-attempts"), "2 " + Math.floor(Date.now() / 1000) + "\n");
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
-    expect(existsSync(join(agentDir, ".session-model-boot-attempts"))).toBe(false);
+  // ── sr-* + LiteLLM guard ─────────────────────────────────────────────────
+  it("sr-* carrier + LiteLLM DOWN → boots default, CONSUMES the carrier, tells the operator to re-issue", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("sr-glm-5"));
+    expect(runBlock("")).toBe(DEFAULT_MODEL);
+    // Consume-once forbids retaining it for a later relaunch.
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    const alert = alertText();
+    expect(alert).toContain("sr-glm-5");
+    expect(alert).toContain("LiteLLM");
+    expect(alert).toContain("Re-issue /model");
   });
 
-  // ── kept-alert dedup (#3042 item 4) ──────────────────────────────────────
-  it("the 'kept' chat alert fires once per kept value — a bounce loop can't storm the chat", () => {
+  it("Claude carrier does NOT require LiteLLM (applies with proxy down, consumed)", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
-    expect(runBlock("1")).toBe("claude-opus-4-8");
-    expect(alertText()).toContain("kept across this relaunch");
-    rmSync(join(agentDir, ".session-model-alert"));
-    // Second boot, same kept value → no new alert; sentinel remembers.
-    expect(runBlock("1")).toBe("claude-opus-4-8");
-    expect(existsSync(join(agentDir, ".session-model-alert"))).toBe(false);
-    expect(readFileSync(join(agentDir, ".session-model-kept-notified"), "utf-8").trim()).toBe("claude-opus-4-8");
+    expect(runBlock("")).toBe("claude-opus-4-8");
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
   });
 
-  // ── session-effort resolver (#3039) ───────────────────────────────────────
+  it("sr-* carrier + LiteLLM up → applies once + repoints ANTHROPIC_BASE_URL + consumed", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("sr-glm-5"));
+    const { effective, baseUrl } = runBlockRouting("1");
+    expect(effective).toBe("sr-glm-5");
+    expect(baseUrl).toBe(ROUTER_ROOT);
+    expect(baseUrl.endsWith("/anthropic")).toBe(false);
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+  });
+
+  it("no carrier (Claude default) → KEEPS the /anthropic passthrough (guards the Opus SSE fix)", () => {
+    const { effective, baseUrl } = runBlockRouting("1");
+    expect(effective).toBe(DEFAULT_MODEL);
+    expect(baseUrl).toBe(PASSTHROUGH);
+  });
+
+  it("claude-* carrier → KEEPS the /anthropic passthrough (only sr-* repoints)", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
+    const { effective, baseUrl } = runBlockRouting("1");
+    expect(effective).toBe("claude-opus-4-8");
+    expect(baseUrl).toBe(PASSTHROUGH);
+  });
+
+  // ── migration from the one-shot carrier ──────────────────────────────────
+  it("legacy .session-model-override carrier → converted, applied + consumed THIS boot", () => {
+    writeFileSync(join(agentDir, ".session-model-override"), "sr-glm-5\n");
+    expect(runBlock("1")).toBe("sr-glm-5");
+    expect(existsSync(join(agentDir, ".session-model-override"))).toBe(false);
+    // Consume-once: the converted carrier is also gone after the apply boot.
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+  });
+
+  it("legacy carrier WINS over an existing .session-model (newer intent)", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
+    writeFileSync(join(agentDir, ".session-model-override"), "sr-glm-5\n");
+    expect(runBlock("1")).toBe("sr-glm-5");
+  });
+
+  it("malformed legacy carrier → ignored (no conversion), reverts to default", () => {
+    writeFileSync(join(agentDir, ".session-model-override"), "bad name; rm -rf /\n");
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    expect(existsSync(join(agentDir, ".session-model-override"))).toBe(false);
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+  });
+
+  // ── session-effort resolver (#3039 — UNCHANGED by rev 4) ──────────────────
   function effortJson(level: string, cfg = "low", ts = Date.now()): string {
     return `${JSON.stringify({ level, configuredDefaultAtWrite: cfg, ts })}\n`;
   }
@@ -331,14 +301,13 @@ describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () 
     expect(runBlockEffort().effortArg).toBe("--effort low");
   });
 
-  it(".session-effort override survives the boot and is applied to --effort", () => {
+  it(".session-effort override survives the boot and is applied to --effort (still keep-across-restarts)", () => {
     writeFileSync(join(agentDir, ".session-effort"), effortJson("xhigh"));
     expect(runBlockEffort().effortArg).toBe("--effort xhigh");
     expect(existsSync(join(agentDir, ".session-effort"))).toBe(true);
   });
 
   it("corrupt/non-allowlisted .session-effort → falls back to configured default AND notifies", () => {
-    writeFileSync(join(agentDir, ".session-effort"), effortJson("mega; rm -rf /".replace(/;.*/, "mega")));
     writeFileSync(join(agentDir, ".session-effort"), `${JSON.stringify({ level: "mega", configuredDefaultAtWrite: "low", ts: Date.now() })}\n`);
     expect(runBlockEffort().effortArg).toBe("--effort low");
     expect(existsSync(join(agentDir, ".session-effort"))).toBe(false);
@@ -350,75 +319,6 @@ describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () 
     expect(runBlockEffort().effortArg).toBe("--effort low");
     expect(existsSync(join(agentDir, ".session-effort"))).toBe(false);
     expect(alertText()).toContain("configured default effort changed");
-  });
-
-  // ── sr-* + LiteLLM guard (row 18) ─────────────────────────────────────────
-  it("keep + sr-* override + LiteLLM DOWN → boots default, RETAINS the file, announces retention", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("sr-glm-5"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep"));
-    expect(runBlock("")).toBe(DEFAULT_MODEL);
-    // Retained — re-applies on the next keep relaunch (NOT the one-shot drop
-    // semantics of the retired carrier).
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(true);
-    const alert = alertText();
-    expect(alert).toContain("sr-glm-5");
-    expect(alert).toContain("retained");
-    expect(alert).toContain("LiteLLM");
-  });
-
-  it("keep + Claude override does NOT require LiteLLM (applies with proxy down)", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep"));
-    expect(runBlock("")).toBe("claude-opus-4-8");
-  });
-
-  // ── migration from the one-shot carrier (RFC §7) ──────────────────────────
-  it("legacy .session-model-override carrier → converted to .session-model and applied THIS boot", () => {
-    writeFileSync(join(agentDir, ".session-model-override"), "sr-glm-5\n");
-    expect(runBlock("1")).toBe("sr-glm-5");
-    expect(existsSync(join(agentDir, ".session-model-override"))).toBe(false);
-    const converted = JSON.parse(readFileSync(join(agentDir, ".session-model"), "utf-8"));
-    expect(converted.model).toBe("sr-glm-5");
-    expect(converted.configuredDefaultAtWrite).toBe(DEFAULT_MODEL);
-  });
-
-  it("legacy carrier WINS over an existing .session-model (newer intent)", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
-    writeFileSync(join(agentDir, ".session-model-override"), "sr-glm-5\n");
-    expect(runBlock("1")).toBe("sr-glm-5");
-    const converted = JSON.parse(readFileSync(join(agentDir, ".session-model"), "utf-8"));
-    expect(converted.model).toBe("sr-glm-5");
-  });
-
-  it("malformed legacy carrier → ignored (no conversion), reverts as no-intent", () => {
-    writeFileSync(join(agentDir, ".session-model-override"), "bad name; rm -rf /\n");
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
-    expect(existsSync(join(agentDir, ".session-model-override"))).toBe(false);
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
-  });
-
-  // ── sr-* passthrough→router repoint (carried over from the carrier suite) ──
-  it("keep + sr-* override + LiteLLM up → repoints ANTHROPIC_BASE_URL onto the router root", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("sr-glm-5"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep"));
-    const { effective, baseUrl } = runBlockRouting("1");
-    expect(effective).toBe("sr-glm-5");
-    expect(baseUrl).toBe(ROUTER_ROOT);
-    expect(baseUrl.endsWith("/anthropic")).toBe(false);
-  });
-
-  it("no override (Claude default) → KEEPS the /anthropic passthrough (guards the Opus SSE fix)", () => {
-    const { effective, baseUrl } = runBlockRouting("1");
-    expect(effective).toBe(DEFAULT_MODEL);
-    expect(baseUrl).toBe(PASSTHROUGH);
-  });
-
-  it("keep + claude-* override → KEEPS the /anthropic passthrough (only sr-* repoints)", () => {
-    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep"));
-    const { effective, baseUrl } = runBlockRouting("1");
-    expect(effective).toBe("claude-opus-4-8");
-    expect(baseUrl).toBe(PASSTHROUGH);
   });
 });
 

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -113,21 +113,44 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     return readFileSync(join(agentDir, ".session-model-alert"), "utf-8");
   }
 
-  it("renders the consume-once carrier wiring in start.sh (no intent file)", () => {
+  it("renders the consume-once carrier wiring in start.sh (no intent resolution)", () => {
     expect(block).toContain(".session-model");
     expect(block).toContain(".configured-default-model");
     expect(block).toContain(".session-model-alert");
     // Migration shim still consumes the legacy one-shot carrier.
     expect(block).toContain(".session-model-override");
-    // The retired keep/revert intent + crashloop machinery is gone.
-    expect(block).not.toContain(".relaunch-model-intent");
-    expect(block).not.toContain(".session-model-boot-attempts");
-    expect(block).not.toContain(".session-model-kept-notified");
+    // The retired keep/revert intent + crashloop machinery is no longer
+    // RESOLVED — the retired filenames appear only in the one-line hygiene
+    // `rm -f` (#3184 LOW-2), never in a read/parse/stamp.
+    expect(block).not.toContain('"intent"');
+    expect(block).not.toContain("_sm_revert");
+    expect(block).not.toMatch(/(cat|read -r|<)[^\n]*\.relaunch-model-intent/);
+    expect(block).not.toMatch(/(cat|read -r|<)[^\n]*\.session-model-boot-attempts/);
+    expect(block).not.toMatch(/(cat|read -r|<)[^\n]*\.session-model-kept-notified/);
     // modelQ is assigned BARE (already shell-quoted by the scaffold).
     expect(block).toContain("_EFFECTIVE_MODEL='claude-sonnet-5'");
     const startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
     expect(startSh).toContain('--model "$_EFFECTIVE_MODEL"');
     expect(startSh).not.toContain("--model {{{modelQ}}}");
+  });
+
+  it("cleans up the retired rev-3 files on boot (#3184 LOW-2 hygiene)", () => {
+    // Simulate a fleet rollout onto an agent dir that still carries the
+    // retired intent/crashloop/dedup files from the keep-by-default era.
+    writeFileSync(join(agentDir, ".relaunch-model-intent"), `${JSON.stringify({ intent: "keep", reason: "old", ts: Date.now() })}\n`);
+    writeFileSync(join(agentDir, ".session-model-boot-attempts"), "2 12345\n");
+    writeFileSync(join(agentDir, ".session-model-kept-notified"), "claude-opus-4-8\n");
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    expect(existsSync(join(agentDir, ".relaunch-model-intent"))).toBe(false);
+    expect(existsSync(join(agentDir, ".session-model-boot-attempts"))).toBe(false);
+    expect(existsSync(join(agentDir, ".session-model-kept-notified"))).toBe(false);
+    // A stale intent file has NO effect on carrier resolution: a carrier still
+    // applies + consumes regardless of any leftover intent content.
+    writeFileSync(join(agentDir, ".relaunch-model-intent"), `${JSON.stringify({ intent: "revert", reason: "old", ts: Date.now() })}\n`);
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    expect(existsSync(join(agentDir, ".relaunch-model-intent"))).toBe(false);
   });
 
   // ── MODEL_ARG_RE byte-parity against the RENDERED start.sh ────────────────


### PR DESCRIPTION
## Summary

Make Telegram `/model` overrides **session-scoped**: an override lasts only for
the current session and reverts to the configured `switchroom.yaml` `model:` on
any restart. Operator decision 2026-07-12 (verbatim: *"/model overrides should
only last until that agent is restarted; on restart the agent should default
back to switchroom config."*), reversing the rev-3 keep-by-default contract
(#3039).

Job spec: `reference/jobs/operate-the-fleet-from-telegram.md` (a `/model` switch
must be truthful and predictable; the operator decides how long it lives).
Design record: `reference/rfcs/session-model-stickiness.md` §0.1 (new rev-4
amendment).

## Why

The durable `.session-model` override honoured on every boot meant a `/model`
switch outlived restarts/deploys/crashes indefinitely and silently masked the
yaml `model:` until the user ran `/model default`. The operator wants the
opposite: session-scoped, reverting on restart.

## Design — consume-once carrier

- `.session-model` becomes a **consume-once** carrier: start.sh applies it on
  the single boot that reads it and **deletes it**. The apply-relaunch picks it
  up; every subsequent restart (deploy, `/restart`, `/new`, watchdog recovery,
  crash, raw `docker restart`, host reboot) finds no carrier and boots the
  configured default. That deletion is the marker distinguishing the model-apply
  relaunch from any later restart.
- The carrier is written **only immediately before a relaunch that applies it**
  — the sr-* / sr→Claude paths (`scheduleModelRelaunch`, the menu sr→Claude
  transition) and a queued `/model` persisted at graceful shutdown. **Live
  Claude switches write no carrier**: they apply in-session via claude's native
  picker and the explicit `claude --model <configured>` flag reverts them on the
  next boot for free. `sessionModelSource.setOverride` still records the live
  choice so `/status` and progress cards stay truthful for the running session.
- **Retired** the now-moot machinery: the `.relaunch-model-intent` keep/revert
  subsystem (writers/readers, `intentForRestartReason`,
  `clearStaleGatewayShutdownIntent`, `GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX`,
  the graceful-shutdown keep stamp) and the `.session-model-boot-attempts`
  crashloop self-heal (a consume-once carrier can crash at most one boot before
  it is gone).
- `/model default` still clears live. Invalidation (corrupt carrier /
  configured default changed at the apply-boot / sr-*+LiteLLM-down) drops the
  carrier and writes a `.session-model-alert` the gateway relays. The ack/footer
  copy now says the override lasts until the next restart.
- **#3178 preserved**: instant ack, durable receipt log + history row, mid-turn
  queue-and-apply, explicit failure. The queued apply persists a consume-once
  carrier at shutdown so it still applies as the agent boots (its
  apply-relaunch), then reverts on the next restart.

## Test plan

- `tests/scaffold.session-model.test.ts` — rewritten for consume-once against
  the RENDERED start.sh: (a) valid carrier applies + is consumed; (b) a second
  restart reverts to the configured default; corrupt / config-changed /
  sr-*+LiteLLM-down all drop + alert + consume; sr-* routing repoint; migration
  from the legacy one-shot carrier; MODEL_ARG_RE byte-parity. `/effort` rows
  unchanged.
- `telegram-plugin/tests/gateway-session-model-relaunch.test.ts` — rewritten to
  pin the new wiring (no intent stamps anywhere; live Claude paths write no
  carrier; sr→Claude relaunch writes the carrier; boot re-hydration + alert
  relay intact).
- `session-model-file.test.ts`, `gateway-pending-command-wiring.test.ts`,
  `model-command.test.ts` updated for the retired subsystem + new copy.
- Local: `tsc --noEmit` clean, `npm run lint` clean (all 8 guards), scoped
  vitest **208 passed** (model-command, effort-command, session-model-file,
  gateway-session-model-relaunch, gateway-pending-command-wiring,
  scaffold.session-model).

## Risk / open questions

- **`/effort` is left unchanged** (`.session-effort` still keeps across
  restarts). The operator's ask was `/model` only. **Open question: should
  `/effort` also become session-scoped for symmetry?**
- sr-* + LiteLLM-down at the apply-boot now **drops** the override (re-issue
  after the proxy returns) rather than retaining it for a later relaunch —
  consume-once forbids retention. Rare edge (sr-* is OpenRouter-via-LiteLLM),
  clearly alerted.
- A queued `/model` (typed mid-turn, persisted at shutdown) applies on the
  post-restart boot — its apply-relaunch — then reverts on the next restart.
  This is the intended "apply-relaunch picks up the model" behavior, not a
  regression of #3178.
- Migration shim for the legacy `.session-model-override` carrier is retained
  one release; retire next cleanup.

Do NOT merge — review + merge happen separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Fixes #3183
