### PR TITLE
feat(auth-broker): per-account, per-model-tier usage ledger (#3185)

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -200,6 +200,12 @@ export interface AccountState {
   premium_wall_bucket?: string;
   /** #3176 — latest flagship-tier canary snapshot, for the dashboard/card. */
   last_tier_quota?: LastTierQuotaSnapshot | null;
+  /**
+   * #3185 — rolling per-tier usage summary (standard 5h/7d + premium `7d_oi`),
+   * refill-normalized by the broker. Answers "how much Fable/standard headroom
+   * is left, and the recent trend". Absent on pre-#3185 brokers.
+   */
+  usage_ledger?: UsageAccountSummary | null;
 }
 
 /**
@@ -214,6 +220,16 @@ export interface LastTierQuotaSnapshot {
   sevenDayOiResetAt: string | null;
   capturedAt: number;
 }
+
+/**
+ * #3185 — rolling per-tier usage summary attached to each `AccountState`. The
+ * broker computes it (refill-normalized) from its durable usage ledger, so the
+ * dashboard / `switchroom auth usage` can answer "how much Fable is left" with
+ * no live probe. Re-exported from the ledger module's summary type so the wire
+ * shape has a single source of truth. Absent on pre-#3185 brokers.
+ */
+export type { UsageAccountSummary, UsageTierSummary } from "./usage-ledger.js";
+import type { UsageAccountSummary } from "./usage-ledger.js";
 
 export interface AgentState {
   name: string;

--- a/src/auth/broker/server-usage-ledger.test.ts
+++ b/src/auth/broker/server-usage-ledger.test.ts
@@ -1,0 +1,283 @@
+/**
+ * #3185 — end-to-end: the rate-limit headers the broker ALREADY receives each
+ * fleet tick (haiku standard probe + #3176 flagship canary) must land in a
+ * durable per-(account, tier) usage ledger, surface via `list-state`, survive a
+ * restart, and feed the premium-failover selector as a headroom PREFERENCE —
+ * all WITHOUT adding any request (the harness fetcher is the only traffic; the
+ * ledger is pure harvest).
+ *
+ * Asserts OUTCOMES (headers in → ledger state → list-state / selection out),
+ * not code paths. Tmpdir-isolated.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AuthBroker } from "./server.js";
+import { AuthBrokerClient } from "./client.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import { writeAccountCredentials } from "../account-store.js";
+import type { FetchQuotaOptions, QuotaResult } from "../quota.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-usage-ledger-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try { rmSync(h.tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness, active: string, fallback: string[]): SwitchroomConfig {
+  return ({
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents: { rider: {} },
+    auth: { active, fallback_order: fallback },
+  } as unknown) as SwitchroomConfig;
+}
+
+function seedAccount(h: Harness, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: `at-${label}`,
+        refreshToken: `rt-${label}`,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    },
+    h.home,
+  );
+}
+
+const HAIKU_MODEL = "claude-haiku-4-5-20251001";
+
+/** haiku standard probe: 5h/7d utilization, healthy. */
+function haiku(five: number, seven: number): QuotaResult {
+  return { ok: true, data: {
+    fiveHourUtilizationPct: five,
+    sevenDayUtilizationPct: seven,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    representativeClaim: null,
+    overageStatus: null,
+    overageDisabledReason: null,
+  } };
+}
+
+/** flagship canary 200: allowed, with a given 7d_oi utilization. */
+function fableAllowed(oiUtil: number): QuotaResult {
+  return { ok: true, data: {
+    fiveHourUtilizationPct: 1,
+    sevenDayUtilizationPct: 5,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    representativeClaim: null,
+    overageStatus: null,
+    overageDisabledReason: null,
+    unifiedStatus: "allowed",
+    sevenDayOiStatus: "allowed",
+    sevenDayOiUtilizationPct: oiUtil,
+    sevenDayOiResetAt: null,
+    sevenDayOiPresent: true,
+  } };
+}
+
+/** flagship canary 429: 7d_oi rejected (a wall). */
+function fableWalled(resetMs: number): QuotaResult {
+  return { ok: true, data: {
+    fiveHourUtilizationPct: 0,
+    sevenDayUtilizationPct: 0,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    representativeClaim: "seven_day_overage_included",
+    overageStatus: null,
+    overageDisabledReason: null,
+    unifiedStatus: "rejected",
+    sevenDayOiStatus: "rejected",
+    sevenDayOiUtilizationPct: 100,
+    sevenDayOiResetAt: new Date(resetMs),
+    sevenDayOiPresent: true,
+  } };
+}
+
+/** Build a fetcher: haiku for the default probe, per-account flagship result. */
+function fetcher(
+  haikuByAccount: Record<string, () => QuotaResult>,
+  tierByAccount: Record<string, () => QuotaResult>,
+): (opts: FetchQuotaOptions) => Promise<QuotaResult> {
+  return async ({ accessToken, model }: FetchQuotaOptions) => {
+    const label = accessToken.replace(/^at-/, "");
+    if (model && model !== HAIKU_MODEL) {
+      return (tierByAccount[label] ?? (() => fableAllowed(10)))();
+    }
+    return (haikuByAccount[label] ?? (() => haiku(1, 5)))();
+  };
+}
+
+describe("#3185 usage ledger — harvest, surface, persist", () => {
+  it("records standard + premium samples for every probed account and surfaces them in list-state", async () => {
+    const h = makeHarness();
+    seedAccount(h, "acct");
+    seedAccount(h, "spare");
+    const broker = new AuthBroker(makeConfig(h, "acct", ["acct", "spare"]), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: fetcher(
+        { acct: () => haiku(2, 40), spare: () => haiku(1, 10) },
+        { acct: () => fableAllowed(30), spare: () => fableAllowed(15) },
+      ),
+    });
+    await broker.start();
+    await broker.fleetQuotaProbeTick();
+
+    const st = broker._state();
+    // Standard tier harvested from the haiku probe (binding = 7d = 40).
+    expect(st.usageLedger["acct"]?.standard?.samples.at(-1)?.utilizationPct).toBe(40);
+    // Premium tier harvested from the flagship canary (7d_oi = 30).
+    expect(st.usageLedger["acct"]?.premium?.samples.at(-1)?.utilizationPct).toBe(30);
+    expect(st.usageLedger["spare"]?.premium?.samples.at(-1)?.utilizationPct).toBe(15);
+
+    // list-state (over the real UDS wire) carries the refill-normalized
+    // per-tier summary — the operator/dashboard surface.
+    const client = new AuthBrokerClient({ socket: join(h.socketRoot, "rider", "sock") });
+    try {
+      const state = await client.listState();
+      const acct = state.accounts.find((a) => a.label === "acct")!;
+      expect(acct.usage_ledger?.premium?.headroomPct).toBe(70); // 100 - 30
+      expect(acct.usage_ledger?.standard?.headroomPct).toBe(60); // 100 - 40
+      expect(acct.usage_ledger?.premium?.observations).toBe(1);
+    } finally {
+      await client.close();
+    }
+    broker.stop();
+  });
+
+  it("persists the ledger to usage-ledger.json and reloads it across a restart", async () => {
+    const h = makeHarness();
+    seedAccount(h, "acct");
+    const opts = {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: fetcher({ acct: () => haiku(3, 22) }, { acct: () => fableAllowed(44) }),
+    };
+    const b1 = new AuthBroker(makeConfig(h, "acct", ["acct"]), opts);
+    await b1.start();
+    await b1.fleetQuotaProbeTick();
+    b1.stop();
+
+    // The durable file exists.
+    expect(existsSync(join(h.stateDir, "usage-ledger.json"))).toBe(true);
+    const onDisk = JSON.parse(readFileSync(join(h.stateDir, "usage-ledger.json"), "utf-8"));
+    expect(onDisk["acct"].premium.samples.at(-1).utilizationPct).toBe(44);
+
+    // A fresh broker reloads it — history is not lost.
+    const b2 = new AuthBroker(makeConfig(h, "acct", ["acct"]), opts);
+    await b2.start();
+    const reloaded = b2._state().usageLedger["acct"];
+    expect(reloaded?.premium?.samples.at(-1)?.utilizationPct).toBe(44);
+    expect(reloaded?.standard?.samples.at(-1)?.utilizationPct).toBe(22);
+    b2.stop();
+  });
+
+  it("does NOT record a premium sample for an account outside the canary set (no fabricated tier data)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "active");
+    // 'lonely' exists on disk but is NOT active / fallback / pinned → no canary.
+    seedAccount(h, "lonely");
+    const broker = new AuthBroker(makeConfig(h, "active", ["active"]), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: fetcher({}, {}),
+    });
+    await broker.start();
+    await broker.fleetQuotaProbeTick();
+    const st = broker._state();
+    // Standard tier IS probed for every account (the haiku fleet probe).
+    expect(st.usageLedger["lonely"]?.standard).toBeTruthy();
+    // Premium tier is NOT — the canary only hits the serving set.
+    expect(st.usageLedger["lonely"]?.premium).toBeUndefined();
+    broker.stop();
+  });
+});
+
+describe("#3185 usage ledger — feeds the premium-failover selector", () => {
+  it("rolls a flagship-walled active to the eligible fallback with the MOST premium headroom (not just ring order)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "walled");
+    seedAccount(h, "low");   // first in ring order after walled, but LESS headroom
+    seedAccount(h, "high");  // later in ring order, but MORE headroom
+    const resetMs = Date.now() + 2 * 60 * 60 * 1000;
+    const broker = new AuthBroker(makeConfig(h, "walled", ["walled", "low", "high"]), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: fetcher(
+        {},
+        {
+          walled: () => fableWalled(resetMs),
+          low: () => fableAllowed(90),  // 10% headroom
+          high: () => fableAllowed(20), // 80% headroom
+        },
+      ),
+    });
+    await broker.start();
+    await broker.fleetQuotaProbeTick();
+
+    const st = broker._state();
+    // The walled active rolled — and it rolled to `high`, the higher-headroom
+    // fallback, NOT `low` (which ring order would have picked first). This is
+    // the ledger driving the selection.
+    expect(st.quota["walled"]?.premium_walled_until).toBe(resetMs);
+    expect(st.activeAccount).toBe("high");
+    broker.stop();
+  });
+
+  it("on EQUAL premium headroom, selection is order-stable — first eligible in ring order (unchanged behavior)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "walled");
+    seedAccount(h, "first");
+    seedAccount(h, "second");
+    const resetMs = Date.now() + 60 * 60 * 1000;
+    // Equal headroom on both fallbacks → the ledger preference has no opinion,
+    // so ring order governs (the pre-#3185 behavior). This guards that the
+    // headroom preference NEVER reorders when it lacks a distinguishing signal.
+    const broker = new AuthBroker(makeConfig(h, "walled", ["walled", "first", "second"]), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: fetcher(
+        {},
+        {
+          walled: () => fableWalled(resetMs),
+          first: () => fableAllowed(50),  // equal headroom
+          second: () => fableAllowed(50), // equal headroom → ring order wins
+        },
+      ),
+    });
+    await broker.start();
+    await broker.fleetQuotaProbeTick();
+    // Equal headroom → order-stable → first eligible in ring order.
+    expect(broker._state().activeAccount).toBe("first");
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -60,6 +60,15 @@ import {
   type ModelTierWallMark,
 } from "./model-tier-quota.js";
 import {
+  recordUsageSample,
+  standardSampleFromResult,
+  premiumSampleFromResult,
+  summarizeAccountUsage,
+  bestPremiumHeadroomAccount,
+  resolveUsageRingCap,
+  type UsageLedger,
+} from "./usage-ledger.js";
+import {
   isAccountBlocked as evalAccountBlocked,
   accountEligibility,
   snapshotShouldClearMark,
@@ -574,6 +583,19 @@ export class AuthBroker {
   private lastTierQuotaCache: LastTierQuotaCache = {};
   /** #3176 — resolved model-tier canary probe model (env-overridable). */
   private readonly modelTierProbeModel: string = resolveModelTierProbeModel();
+  /**
+   * #3185 — per-account, per-tier rolling usage ledger. Harvested PASSIVELY
+   * from the rate-limit headers the broker already receives each fleet tick
+   * (standard tier at `cacheQuotaSnapshot`, premium/`7d_oi` tier at
+   * `recordTierProbe`) — zero added requests. Persisted to `usage-ledger.json`,
+   * reloaded on boot, surfaced via `list-state` and consumed as a headroom
+   * PREFERENCE by the premium-failover selector.
+   */
+  private usageLedger: UsageLedger = {};
+  /** #3185 — rolling-ring cap per (account, tier); env-overridable. */
+  private readonly usageRingCap: number = resolveUsageRingCap(
+    process.env.SWITCHROOM_USAGE_LEDGER_RING_CAP,
+  );
   /** Last `expiresAt` the broker wrote per label — drives threshold-violation. */
   private lastWrittenExpiresAt = new Map<string, number | undefined>();
   /** Refresh leases held while a POST is in flight (in-process). */
@@ -1407,6 +1429,10 @@ export class AuthBroker {
         capturedAt: this.now(),
       };
       this.persistLastTierQuotaCache();
+      // #3185 — harvest a PREMIUM-tier (7d_oi) usage sample from the SAME canary
+      // headers (zero added requests). A result carrying no tier signal (rotted
+      // canary id / non-flagship response) yields null → no-op.
+      this.recordUsage(label, "premium", premiumSampleFromResult(result, this.now()));
     }
     // Self-heal: a fresh canary that positively reads the tier allowed clears
     // any lingering tier-wall mark so the account rejoins flagship serving.
@@ -1429,11 +1455,20 @@ export class AuthBroker {
   }
 
   /**
-   * First flagship-eligible failover target for `from` (#3176): the first
-   * `fallback_order` account, starting after `from`, that exists, has stored
-   * credentials, and is NEITHER exhausted NOR premium-walled. Null when every
-   * candidate is walled on the flagship tier (or exhausted) — the honest
-   * all-walled path, which the caller surfaces with the earliest reset.
+   * Flagship-eligible failover target for `from` (#3176): a `fallback_order`
+   * account, starting after `from`, that exists, has stored credentials, and is
+   * NEITHER exhausted NOR premium-walled. Null when every candidate is walled on
+   * the flagship tier (or exhausted) — the honest all-walled path, which the
+   * caller surfaces with the earliest reset.
+   *
+   * #3185 — among the ELIGIBLE candidates, prefer the one with the most premium
+   * (`7d_oi`) HEADROOM from the usage ledger, so a proactive roll lands on the
+   * account that can serve the most Fable before walling again. This is a
+   * PREFERENCE, not a gate: eligibility is still owned entirely by the #3176
+   * `premium_walled_until` marks above. When the ledger has no premium data for
+   * any candidate, `bestPremiumHeadroomAccount` returns null and we fall back to
+   * the first eligible candidate in ring order — i.e. behavior is UNCHANGED
+   * whenever the ledger is empty (pre-existing #3176 failover tests unaffected).
    */
   private nextPremiumEligibleAccount(from: string): string | null {
     const order = this.config.auth?.fallback_order ?? [];
@@ -1442,15 +1477,18 @@ export class AuthBroker {
       start === -1
         ? [...order]
         : order.map((_, i) => order[(start + 1 + i) % order.length]);
+    const eligible: string[] = [];
     for (const cand of ring) {
       if (!cand || cand === from) continue;
       if (this.isAccountExhausted(cand)) continue;
       if (this.isAccountPremiumWalled(cand)) continue;
       if (!accountExists(cand, this.home)) continue;
       if (!readAccountCredentials(cand, this.home)) continue;
-      return cand;
+      eligible.push(cand);
     }
-    return null;
+    if (eligible.length === 0) return null;
+    // Headroom-preferred pick (order-stable on ties / empty ledger).
+    return bestPremiumHeadroomAccount(this.usageLedger, eligible, this.now()) ?? eligible[0];
   }
 
   /**
@@ -1921,6 +1959,9 @@ export class AuthBroker {
         premium_walled_until: q?.premium_walled_until,
         premium_wall_bucket: q?.premium_wall_bucket,
         last_tier_quota: this.lastTierQuotaCache[label] ?? null,
+        // #3185 — rolling per-tier usage summary (refill-normalized) so the
+        // operator/dashboard can answer "how much Fable is left" instantly.
+        usage_ledger: summarizeAccountUsage(this.usageLedger, label, this.now()),
       };
     });
     const agents = Object.entries(this.config.agents ?? {}).map(([name, agent]) => {
@@ -2133,6 +2174,9 @@ export class AuthBroker {
     // #2495 Change 1 — persist the cache so a broker restart serves this
     // last-known snapshot (age-stamped via capturedAt) instead of blank.
     this.persistLastQuotaCache();
+    // #3185 — harvest a STANDARD-tier usage sample from the SAME probe headers
+    // (zero added requests). A thin probe yields null → no-op.
+    this.recordUsage(label, "standard", standardSampleFromResult(result, this.now()));
     // Self-heal: a fresh, clearly-healthy probe (both windows well under the
     // wall) that is newer than the mark CLEARS the persisted mark — so a
     // misfired/expired exhaustion can't linger on disk and survive restarts
@@ -4065,6 +4109,9 @@ export class AuthBroker {
     // #3176 — reload the durable flagship-tier canary cache + all-walled alert.
     this.lastTierQuotaCache = this.readJson<LastTierQuotaCache>("last-tier-quota.json") ?? {};
     this.premiumTierAllWalled = this.readJson<PremiumTierAllWalled>("premium-tier-all-walled.json") ?? null;
+    // #3185 — reload the durable per-(account, tier) usage ledger so a restart
+    // keeps the rolling history instead of starting the trend from scratch.
+    this.usageLedger = this.readJson<UsageLedger>("usage-ledger.json") ?? {};
     this.applyActiveOverride();
   }
 
@@ -4131,6 +4178,29 @@ export class AuthBroker {
   private persistLastQuotaCache(): void { atomicWriteJsonSync(join(this.stateDir, "last-quota.json"), this.lastQuotaCache, 0o600); }
   /** #3176 — mirror the flagship-tier canary cache to disk. */
   private persistLastTierQuotaCache(): void { atomicWriteJsonSync(join(this.stateDir, "last-tier-quota.json"), this.lastTierQuotaCache, 0o600); }
+  /** #3185 — mirror the per-(account, tier) usage ledger to disk so the rolling
+   *  history survives a broker restart. */
+  private persistUsageLedger(): void { atomicWriteJsonSync(join(this.stateDir, "usage-ledger.json"), this.usageLedger, 0o600); }
+
+  /**
+   * #3185 — append a usage sample to the rolling ledger and persist. A null
+   * sample (failed / thin / no-tier-signal probe) is a no-op and does NOT
+   * re-write the file — so a run of empty probes costs nothing. Never throws
+   * into the probe path: a ledger/persist failure is logged, never fatal.
+   */
+  private recordUsage(
+    label: string,
+    tier: "standard" | "premium",
+    sample: ReturnType<typeof standardSampleFromResult>,
+  ): void {
+    if (sample == null) return;
+    try {
+      recordUsageSample(this.usageLedger, label, tier, sample, this.usageRingCap);
+      this.persistUsageLedger();
+    } catch (err) {
+      this.logErr(`usage-ledger ${label}/${tier}: ${(err as Error).message}`);
+    }
+  }
   private persistNotificationClaims(): void { atomicWriteJsonSync(join(this.stateDir, "notification-claims.json"), this.notificationClaims, 0o600); }
   private persistLastFleetRoll(): void { if (this.lastFleetRoll) atomicWriteJsonSync(join(this.stateDir, "last-fleet-roll.json"), this.lastFleetRoll, 0o600); }
   private persistShaIndex(): void { atomicWriteJsonSync(join(this.stateDir, "sha-index.json"), this.shaIndex, 0o600); }
@@ -4364,6 +4434,8 @@ export class AuthBroker {
     /** #3176 — flagship-tier canary cache + all-walled alert + live active. */
     lastTierQuotaCache: LastTierQuotaCache;
     premiumTierAllWalled: PremiumTierAllWalled | null;
+    /** #3185 — per-(account, tier) rolling usage ledger (in-memory view). */
+    usageLedger: UsageLedger;
     activeAccount: string | undefined;
   } {
     return {
@@ -4373,6 +4445,7 @@ export class AuthBroker {
       listeners: [...this.listeners.keys()],
       lastQuotaCache: structuredClone(this.lastQuotaCache),
       lastTierQuotaCache: structuredClone(this.lastTierQuotaCache),
+      usageLedger: structuredClone(this.usageLedger),
       premiumTierAllWalled: this.premiumTierAllWalled
         ? { ...this.premiumTierAllWalled }
         : null,

--- a/src/auth/broker/usage-ledger.test.ts
+++ b/src/auth/broker/usage-ledger.test.ts
@@ -1,0 +1,278 @@
+/**
+ * #3185 — pure usage-ledger unit tests. Assert OUTCOMES: given probe/canary
+ * header shapes in, the ledger records the right per-tier samples, trims the
+ * ring, refill-normalizes at read time, and the headroom selector is
+ * deterministic + order-stable. No I/O; the server wires persistence.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { QuotaResult } from "../quota.js";
+import {
+  standardSampleFromResult,
+  premiumSampleFromResult,
+  recordUsageSample,
+  summarizeAccountUsage,
+  premiumHeadroomPct,
+  bestPremiumHeadroomAccount,
+  resolveUsageRingCap,
+  USAGE_RING_CAP_DEFAULT,
+  STANDARD_WALL_PCT,
+  type UsageLedger,
+} from "./usage-ledger.js";
+
+const NOW = 1_700_000_000_000;
+
+function standardResult(
+  five: number,
+  seven: number,
+  opts: {
+    fiveReset?: number | null;
+    sevenReset?: number | null;
+    fivePresent?: boolean;
+    sevenPresent?: boolean;
+    unifiedStatus?: string | null;
+  } = {},
+): QuotaResult {
+  return {
+    ok: true,
+    data: {
+      fiveHourUtilizationPct: five,
+      sevenDayUtilizationPct: seven,
+      fiveHourResetAt: opts.fiveReset != null ? new Date(opts.fiveReset) : null,
+      sevenDayResetAt: opts.sevenReset != null ? new Date(opts.sevenReset) : null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+      fiveHourUtilPresent: opts.fivePresent,
+      sevenDayUtilPresent: opts.sevenPresent,
+      unifiedStatus: opts.unifiedStatus ?? null,
+    },
+  };
+}
+
+function premiumResult(
+  opts: {
+    oiUtil?: number | null;
+    oiStatus?: string | null;
+    unifiedStatus?: string | null;
+    oiReset?: number | null;
+    signalPresent?: boolean;
+  },
+): QuotaResult {
+  const hasSignal = opts.signalPresent ?? true;
+  return {
+    ok: true,
+    data: {
+      fiveHourUtilizationPct: 0,
+      sevenDayUtilizationPct: 0,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+      unifiedStatus: hasSignal ? opts.unifiedStatus ?? null : null,
+      sevenDayOiStatus: hasSignal ? opts.oiStatus ?? null : null,
+      sevenDayOiUtilizationPct: hasSignal ? opts.oiUtil ?? null : null,
+      sevenDayOiResetAt: opts.oiReset != null ? new Date(opts.oiReset) : null,
+      sevenDayOiPresent: hasSignal,
+    },
+  };
+}
+
+describe("standardSampleFromResult", () => {
+  it("binds to the HIGHER-utilized window and carries its reset", () => {
+    const r = standardResult(20, 60, { fiveReset: NOW + 3600_000, sevenReset: NOW + 7 * 86400_000 });
+    const s = standardSampleFromResult(r, NOW);
+    expect(s).not.toBeNull();
+    expect(s!.utilizationPct).toBe(60); // 7d binds
+    expect(s!.resetAt).toBe(NOW + 7 * 86400_000);
+    expect(s!.walled).toBe(false);
+  });
+
+  it("flags a wall when the binding window is at/above the standard wall", () => {
+    const s = standardSampleFromResult(standardResult(99.9, 10), NOW);
+    expect(s!.utilizationPct).toBe(99.9);
+    expect(s!.walled).toBe(true);
+    expect(STANDARD_WALL_PCT).toBe(99.5);
+  });
+
+  it("returns null for a thin probe (both windows explicitly absent)", () => {
+    const s = standardSampleFromResult(
+      standardResult(0, 0, { fivePresent: false, sevenPresent: false }),
+      NOW,
+    );
+    expect(s).toBeNull();
+  });
+
+  it("uses only the PRESENT window when one is absent", () => {
+    const s = standardSampleFromResult(
+      standardResult(0, 70, { fivePresent: false, sevenPresent: true, sevenReset: NOW + 100 }),
+      NOW,
+    );
+    expect(s!.utilizationPct).toBe(70);
+    expect(s!.resetAt).toBe(NOW + 100);
+  });
+
+  it("returns null for a failed probe (never fabricates a sample)", () => {
+    expect(standardSampleFromResult({ ok: false, reason: "boom" }, NOW)).toBeNull();
+  });
+});
+
+describe("premiumSampleFromResult", () => {
+  it("records a rejected 7d_oi wall with util + reset", () => {
+    const s = premiumSampleFromResult(
+      premiumResult({ oiUtil: 100, oiStatus: "rejected", unifiedStatus: "rejected", oiReset: NOW + 9999 }),
+      NOW,
+    );
+    expect(s!.utilizationPct).toBe(100);
+    expect(s!.status).toBe("rejected");
+    expect(s!.walled).toBe(true);
+    expect(s!.resetAt).toBe(NOW + 9999);
+  });
+
+  it("records an allowed tier as not walled", () => {
+    const s = premiumSampleFromResult(premiumResult({ oiUtil: 40, oiStatus: "allowed", unifiedStatus: "allowed" }), NOW);
+    expect(s!.utilizationPct).toBe(40);
+    expect(s!.walled).toBe(false);
+  });
+
+  it("walls on util >= wall even without a rejected status", () => {
+    const s = premiumSampleFromResult(premiumResult({ oiUtil: 99.6, oiStatus: "allowed" }), NOW);
+    expect(s!.walled).toBe(true);
+  });
+
+  it("falls back to the unified status when the per-bucket status is absent", () => {
+    const s = premiumSampleFromResult(premiumResult({ oiUtil: 10, oiStatus: null, unifiedStatus: "allowed" }), NOW);
+    expect(s!.status).toBe("allowed");
+  });
+
+  it("returns null when the result carries NO tier signal (haiku / rotted canary)", () => {
+    const s = premiumSampleFromResult(premiumResult({ signalPresent: false }), NOW);
+    expect(s).toBeNull();
+  });
+});
+
+describe("recordUsageSample + ring", () => {
+  it("appends and increments observations; null is a no-op", () => {
+    const ledger: UsageLedger = {};
+    recordUsageSample(ledger, "acct", "premium", premiumSampleFromResult(premiumResult({ oiUtil: 30, oiStatus: "allowed" }), NOW));
+    recordUsageSample(ledger, "acct", "premium", null); // no-op
+    const tl = ledger["acct"]!.premium!;
+    expect(tl.samples.length).toBe(1);
+    expect(tl.observations).toBe(1);
+    expect(tl.firstObservedAt).toBe(NOW);
+    expect(tl.lastObservedAt).toBe(NOW);
+  });
+
+  it("trims to the ring cap but keeps observations monotonic", () => {
+    const ledger: UsageLedger = {};
+    for (let i = 0; i < 10; i++) {
+      const s = premiumSampleFromResult(premiumResult({ oiUtil: i, oiStatus: "allowed" }), NOW + i);
+      recordUsageSample(ledger, "acct", "premium", s, 3);
+    }
+    const tl = ledger["acct"]!.premium!;
+    expect(tl.samples.length).toBe(3); // trimmed to cap
+    expect(tl.observations).toBe(10); // but the honest count survives trimming
+    // The retained samples are the NEWEST three (util 7,8,9).
+    expect(tl.samples.map((x) => x.utilizationPct)).toEqual([7, 8, 9]);
+  });
+
+  it("resolveUsageRingCap falls back to the default on garbage", () => {
+    expect(resolveUsageRingCap(undefined)).toBe(USAGE_RING_CAP_DEFAULT);
+    expect(resolveUsageRingCap("")).toBe(USAGE_RING_CAP_DEFAULT);
+    expect(resolveUsageRingCap("0")).toBe(USAGE_RING_CAP_DEFAULT);
+    expect(resolveUsageRingCap("nope")).toBe(USAGE_RING_CAP_DEFAULT);
+    expect(resolveUsageRingCap("50")).toBe(50);
+  });
+});
+
+describe("summarizeAccountUsage — refill-aware", () => {
+  it("computes headroom from the latest sample", () => {
+    const ledger: UsageLedger = {};
+    recordUsageSample(ledger, "a", "premium", premiumSampleFromResult(premiumResult({ oiUtil: 30, oiStatus: "allowed", oiReset: NOW + 86400_000 }), NOW));
+    const sum = summarizeAccountUsage(ledger, "a", NOW);
+    expect(sum.premium!.currentUtilizationPct).toBe(30);
+    expect(sum.premium!.headroomPct).toBe(70);
+    expect(sum.premium!.refilled).toBe(false);
+    expect(sum.premium!.walled).toBe(false);
+  });
+
+  it("treats a passed reset as REFILLED — 0% used / 100% headroom, no probe", () => {
+    const ledger: UsageLedger = {};
+    // Latest sample was walled with a reset in the past relative to `now`.
+    recordUsageSample(ledger, "a", "premium", premiumSampleFromResult(premiumResult({ oiUtil: 100, oiStatus: "rejected", oiReset: NOW - 1 }), NOW - 10));
+    const sum = summarizeAccountUsage(ledger, "a", NOW);
+    expect(sum.premium!.refilled).toBe(true);
+    expect(sum.premium!.currentUtilizationPct).toBe(0);
+    expect(sum.premium!.headroomPct).toBe(100);
+    expect(sum.premium!.walled).toBe(false); // refill overrides the stale wall
+  });
+
+  it("reports the peak across the retained ring", () => {
+    const ledger: UsageLedger = {};
+    for (const u of [20, 80, 55]) {
+      recordUsageSample(ledger, "a", "premium", premiumSampleFromResult(premiumResult({ oiUtil: u, oiStatus: "allowed" }), NOW));
+    }
+    const sum = summarizeAccountUsage(ledger, "a", NOW);
+    expect(sum.premium!.peakUtilizationPct).toBe(80);
+    expect(sum.premium!.observations).toBe(3);
+  });
+
+  it("returns null tiers for an unknown account", () => {
+    const sum = summarizeAccountUsage({}, "ghost", NOW);
+    expect(sum.premium).toBeNull();
+    expect(sum.standard).toBeNull();
+  });
+});
+
+describe("premiumHeadroomPct + bestPremiumHeadroomAccount", () => {
+  function seed(ledger: UsageLedger, acct: string, oiUtil: number, reset?: number): void {
+    recordUsageSample(
+      ledger,
+      acct,
+      "premium",
+      premiumSampleFromResult(premiumResult({ oiUtil, oiStatus: "allowed", oiReset: reset ?? null }), NOW),
+    );
+  }
+
+  it("premiumHeadroomPct is null when unobserved, else 100-util", () => {
+    const ledger: UsageLedger = {};
+    seed(ledger, "a", 25);
+    expect(premiumHeadroomPct(ledger, "a", NOW)).toBe(75);
+    expect(premiumHeadroomPct(ledger, "b", NOW)).toBeNull();
+  });
+
+  it("picks the candidate with the MOST premium headroom", () => {
+    const ledger: UsageLedger = {};
+    seed(ledger, "a", 90); // 10 headroom
+    seed(ledger, "b", 20); // 80 headroom
+    seed(ledger, "c", 55); // 45 headroom
+    expect(bestPremiumHeadroomAccount(ledger, ["a", "b", "c"], NOW)).toBe("b");
+  });
+
+  it("returns null when NO candidate has premium data (caller keeps its order)", () => {
+    expect(bestPremiumHeadroomAccount({}, ["a", "b"], NOW)).toBeNull();
+  });
+
+  it("is order-stable on ties — first candidate wins", () => {
+    const ledger: UsageLedger = {};
+    seed(ledger, "a", 40);
+    seed(ledger, "b", 40);
+    expect(bestPremiumHeadroomAccount(ledger, ["a", "b"], NOW)).toBe("a");
+    expect(bestPremiumHeadroomAccount(ledger, ["b", "a"], NOW)).toBe("b");
+  });
+
+  it("prefers a known-headroom candidate over an unobserved one", () => {
+    const ledger: UsageLedger = {};
+    seed(ledger, "b", 10);
+    // a is unobserved (headroom null → skipped); b is the only known one.
+    expect(bestPremiumHeadroomAccount(ledger, ["a", "b"], NOW)).toBe("b");
+  });
+
+  it("counts a refilled candidate as full (100) headroom", () => {
+    const ledger: UsageLedger = {};
+    seed(ledger, "a", 30); // 70 headroom
+    seed(ledger, "b", 100, NOW - 1); // walled but reset passed → refilled → 100
+    expect(bestPremiumHeadroomAccount(ledger, ["a", "b"], NOW)).toBe("b");
+  });
+});

--- a/src/auth/broker/usage-ledger.ts
+++ b/src/auth/broker/usage-ledger.ts
@@ -267,6 +267,12 @@ function summarizeTier(
     rawUtil == null ? null : refilled ? 0 : rawUtil;
   const headroomPct =
     currentUtilizationPct == null ? null : Math.max(0, 100 - currentUtilizationPct);
+  // DELIBERATELY refill-AGNOSTIC (unlike currentUtilizationPct above): the peak
+  // is a trend statistic over the retained ring (~48h at the default cadence),
+  // so it can read e.g. 99% for up to the ring's span AFTER a weekly refill.
+  // That is honest history ("how hard was this account driven recently"), not
+  // current state — renderers must label it "peak", and it is NEVER used in
+  // selection or headroom (PR #3187 review, note 2).
   const utilSamples = tl.samples
     .map((s) => s.utilizationPct)
     .filter((u): u is number => u != null);
@@ -325,6 +331,18 @@ export function premiumHeadroomPct(
  * Deterministic + order-stable: ties (equal headroom, incl. the empty-ledger
  * case where all are unknown) resolve to the earliest candidate in the input
  * order, so behavior is unchanged whenever the ledger carries no data. PURE.
+ *
+ * KNOWN-DATA-WINS (deliberate — PR #3187 review, note 1): a candidate with
+ * KNOWN-low headroom beats an UNOBSERVED one. An unobserved eligible account
+ * carries zero information — the premium canary only covers the serving set,
+ * so "no ledger data" can mean near-wall-but-never-canaried just as easily as
+ * fresh; #3176 walls are only marked for accounts that have been canaried (or
+ * 429'd). A known-low account is POSITIVELY verified serviceable right now:
+ * worst case is a sooner honest re-roll (eligibility already excludes walled
+ * targets). Preferring the unknown instead could land the whole fleet's
+ * flagship traffic on an effectively-walled account and reproduce the 429
+ * storm #3176 exists to prevent. Self-correcting: a promoted account joins the
+ * canary set, so its ledger entry appears within one fleet tick.
  */
 export function bestPremiumHeadroomAccount(
   ledger: UsageLedger,
@@ -335,6 +353,7 @@ export function bestPremiumHeadroomAccount(
   let bestHeadroom = -Infinity;
   for (const cand of candidates) {
     const h = premiumHeadroomPct(ledger, cand, now);
+    // Unobserved → skipped, never guessed-as-full (known-data-wins; see above).
     if (h == null) continue;
     // Strictly-greater keeps the FIRST candidate on ties → order-stable.
     if (h > bestHeadroom) {

--- a/src/auth/broker/usage-ledger.ts
+++ b/src/auth/broker/usage-ledger.ts
@@ -1,0 +1,346 @@
+/**
+ * Per-account, per-model-tier usage ledger (pure decision + data layer).
+ *
+ * THE ASK (Ken, 2026-07-12): "Let's make sure switchroom tracks model usage
+ * per account for premium models like fable." The broker already probes every
+ * account each fleet tick and reads Anthropic's unified rate-limit headers —
+ * the standard-tier `5h`/`7d` windows off a 1-token haiku probe, and (since
+ * #3176/#3179) the premium-tier `7d_oi` (`seven_day_overage_included`) bucket
+ * off a 1-token flagship canary. Until now the broker kept only the LATEST
+ * snapshot per account (`last-quota.json` / `last-tier-quota.json`), throwing
+ * away everything else. This module turns those already-received headers into a
+ * durable, rolling per-(account, tier) usage ledger — WITHOUT issuing a single
+ * extra request (the samples are harvested at the existing probe/canary capture
+ * points; the #3176 canary is unchanged).
+ *
+ * WHY BROKER-SIDE / IN-REPO: the broker is in-repo, unit-tested and shipped via
+ * normal releases; the staged LiteLLM pacing callback (`custom_pacing.py`) is
+ * host-managed proxy config, out of this repo and off CI. Harvesting from the
+ * headers the broker ALREADY receives is the in-repo, zero-added-cost path and
+ * gives continuous per-tier utilization/reset — the exact "how much Fable is
+ * left" signal the operator asked for.
+ *
+ * TOKENS: the unified rate-limit headers carry utilization %, reset times and
+ * an allowed/rejected status — NOT token counts. This ledger records those
+ * (Anthropic's own accounting) plus an observation count; true per-request
+ * token accounting would need the proxy callback (real traffic, out of repo)
+ * and is deliberately out of scope here rather than fabricated.
+ *
+ * PURE: no I/O, no clock except the injected `now`. The server owns
+ * persistence (`usage-ledger.json`) and calls into this module at its existing
+ * `cacheQuotaSnapshot` (standard) and `recordTierProbe` (premium) capture
+ * points. Fully unit-tested.
+ */
+
+import type { QuotaResult } from "../quota.js";
+import { MODEL_TIER_WALL_PCT } from "./model-tier-quota.js";
+
+/** The two tiers we ledger. `standard` = the 5h/7d windows a haiku probe sees;
+ *  `premium` = the flagship `7d_oi` bucket a flagship canary sees (#3176). */
+export type UsageTier = "standard" | "premium";
+
+/** Standard-tier hard wall — matches `consumer-quota-sensor` EXHAUSTION_PCT and
+ *  `account-eligibility` WALL_PCT so "walled" means the same across the codebase. */
+export const STANDARD_WALL_PCT = 99.5;
+
+/**
+ * Rolling-ring cap per (account, tier). At the ~10-min fleet-probe cadence
+ * (`DEFAULT_CONSUMER_PROBE_INTERVAL_MS`) 288 samples ≈ 48h of history — enough
+ * to show a trend without the ledger growing unbounded. Overridable so the
+ * server can size it from env; a bad value falls back to the default.
+ */
+export const USAGE_RING_CAP_DEFAULT = 288;
+
+/** Resolve the ring cap from an env value, else the default. Exported for the
+ *  server + tests; a non-finite / non-positive value is ignored. */
+export function resolveUsageRingCap(raw: string | undefined): number {
+  if (raw == null || raw.trim().length === 0) return USAGE_RING_CAP_DEFAULT;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : USAGE_RING_CAP_DEFAULT;
+}
+
+/**
+ * One observed usage sample for a (account, tier), harvested from a probe/canary
+ * response's rate-limit headers. `utilizationPct` is the tier's BINDING window
+ * utilization (0-100); `resetAt` is when that window rolls; `status` is the
+ * allowed/rejected verdict when the headers carried one (premium tier), else
+ * null; `walled` is whether this sample was at/above the tier wall.
+ */
+export interface UsageSample {
+  /** Capture time, unix ms. */
+  at: number;
+  /** Binding-window utilization (0-100), or null when the header was absent. */
+  utilizationPct: number | null;
+  /** Unix ms when the binding window resets, or null. */
+  resetAt: number | null;
+  /** allowed/rejected verdict (premium tier), or null (standard probe). */
+  status: string | null;
+  /** True when this sample was at/above the tier's wall. */
+  walled: boolean;
+}
+
+/** Rolling ledger for one (account, tier). */
+export interface UsageTierLedger {
+  tier: UsageTier;
+  /** Bounded rolling ring, OLDEST first / NEWEST last. Length ≤ ring cap. */
+  samples: UsageSample[];
+  /** Monotonic count of samples EVER recorded — survives ring trimming, so it
+   *  is an honest observation count even after old samples age out. */
+  observations: number;
+  /** Unix ms of the first sample ever recorded. */
+  firstObservedAt: number;
+  /** Unix ms of the most recent sample. */
+  lastObservedAt: number;
+}
+
+export interface UsageAccountLedger {
+  standard?: UsageTierLedger;
+  premium?: UsageTierLedger;
+}
+
+/** The whole ledger, keyed by account label. Persisted to `usage-ledger.json`. */
+export interface UsageLedger {
+  [account: string]: UsageAccountLedger;
+}
+
+/**
+ * Build the STANDARD-tier sample from a haiku-probe result, or null when the
+ * probe carried no usable window (a "thin" probe — both windows absent). The
+ * binding window is the HIGHER-utilized of the present windows (that is the one
+ * that walls the account); its reset is the sample reset. PURE.
+ */
+export function standardSampleFromResult(
+  result: QuotaResult,
+  now: number,
+): UsageSample | null {
+  if (!result.ok) return null;
+  const d = result.data;
+  // Default-present semantics: the flags are only `false` when #2494 explicitly
+  // marked a window absent; unset (legacy/cached) reads as present.
+  const fivePresent = d.fiveHourUtilPresent !== false;
+  const sevenPresent = d.sevenDayUtilPresent !== false;
+  if (!fivePresent && !sevenPresent) return null; // thin probe → no signal
+  type Win = { util: number; reset: number | null };
+  const wins: Win[] = [];
+  if (fivePresent) {
+    wins.push({
+      util: d.fiveHourUtilizationPct,
+      reset: d.fiveHourResetAt?.getTime() ?? null,
+    });
+  }
+  if (sevenPresent) {
+    wins.push({
+      util: d.sevenDayUtilizationPct,
+      reset: d.sevenDayResetAt?.getTime() ?? null,
+    });
+  }
+  // Binding = highest utilization; that window's reset is what governs.
+  const binding = wins.reduce((a, b) => (b.util > a.util ? b : a));
+  return {
+    at: now,
+    utilizationPct: binding.util,
+    resetAt: binding.reset,
+    status: d.unifiedStatus ?? null,
+    walled: binding.util >= STANDARD_WALL_PCT,
+  };
+}
+
+/**
+ * Build the PREMIUM-tier (`7d_oi`) sample from a flagship-canary result, or null
+ * when the result carried NO tier signal (a non-flagship probe, or a rotted
+ * canary id that 4xx'd without `7d_oi` headers — "no tier observed", never a
+ * fabricated 0%). Mirrors #3176's classifier: a tier signal exists when any of
+ * `unifiedStatus` / `sevenDayOiStatus` / `sevenDayOiUtilizationPct` is present.
+ * `walled` reuses the #3176 wall definition (rejected status, or util ≥ wall).
+ * PURE.
+ */
+export function premiumSampleFromResult(
+  result: QuotaResult,
+  now: number,
+): UsageSample | null {
+  if (!result.ok) return null;
+  const d = result.data;
+  const hasSignal =
+    d.unifiedStatus != null ||
+    d.sevenDayOiStatus != null ||
+    d.sevenDayOiUtilizationPct != null;
+  if (!hasSignal) return null; // no tier signal → not a premium observation
+  const util = d.sevenDayOiUtilizationPct ?? null;
+  // Prefer the per-bucket status; fall back to the overall unified verdict.
+  const status = d.sevenDayOiStatus ?? d.unifiedStatus ?? null;
+  const walled =
+    d.sevenDayOiStatus === "rejected" ||
+    (util != null && util >= MODEL_TIER_WALL_PCT);
+  return {
+    at: now,
+    utilizationPct: util,
+    resetAt: d.sevenDayOiResetAt?.getTime() ?? null,
+    status,
+    walled,
+  };
+}
+
+/**
+ * Append a sample to `ledger[account][tier]`, trimming the ring to `ringCap`.
+ * MUTATES and returns `ledger` (the server holds a single live ref; tests pass
+ * a fresh object). A null `sample` is a no-op — a failed/thin/no-signal probe
+ * never pollutes the ledger (same discipline as the exhaustion classifiers).
+ */
+export function recordUsageSample(
+  ledger: UsageLedger,
+  account: string,
+  tier: UsageTier,
+  sample: UsageSample | null,
+  ringCap: number = USAGE_RING_CAP_DEFAULT,
+): UsageLedger {
+  if (sample == null) return ledger;
+  const cap = ringCap >= 1 ? Math.floor(ringCap) : USAGE_RING_CAP_DEFAULT;
+  const acct = (ledger[account] ??= {});
+  let tl = acct[tier];
+  if (tl == null) {
+    tl = {
+      tier,
+      samples: [],
+      observations: 0,
+      firstObservedAt: sample.at,
+      lastObservedAt: sample.at,
+    };
+    acct[tier] = tl;
+  }
+  tl.samples.push(sample);
+  // Trim oldest-first to the cap.
+  if (tl.samples.length > cap) {
+    tl.samples.splice(0, tl.samples.length - cap);
+  }
+  tl.observations += 1;
+  tl.lastObservedAt = sample.at;
+  // firstObservedAt is monotone (never moves once set).
+  if (sample.at < tl.firstObservedAt) tl.firstObservedAt = sample.at;
+  return ledger;
+}
+
+/** A rendering-friendly rollup of one tier's ledger, refill-normalized. */
+export interface UsageTierSummary {
+  tier: UsageTier;
+  /** Monotonic count of samples ever recorded. */
+  observations: number;
+  /** Number of samples currently retained in the ring. */
+  retained: number;
+  /** Latest utilization %, refill-normalized (reset passed → 0). Null when the
+   *  latest sample carried no utilization header. */
+  currentUtilizationPct: number | null;
+  /** Remaining headroom (100 - util), refill-normalized. Null when unknown. */
+  headroomPct: number | null;
+  /** Latest binding-window reset, unix ms, or null. */
+  resetAt: number | null;
+  /** Latest allowed/rejected status, or null. */
+  status: string | null;
+  /** True when the latest sample was at/above the tier wall AND not refilled. */
+  walled: boolean;
+  /** True when the latest sample's reset has passed (window rolled since). */
+  refilled: boolean;
+  /** Unix ms of the most recent sample, or null when empty. */
+  lastObservedAt: number | null;
+  /** Peak utilization across the retained ring (trend), refill-agnostic. Null
+   *  when no sample carried a utilization header. */
+  peakUtilizationPct: number | null;
+}
+
+export interface UsageAccountSummary {
+  account: string;
+  standard: UsageTierSummary | null;
+  premium: UsageTierSummary | null;
+}
+
+function summarizeTier(
+  tl: UsageTierLedger | undefined,
+  now: number,
+): UsageTierSummary | null {
+  if (tl == null || tl.samples.length === 0) return null;
+  const latest = tl.samples[tl.samples.length - 1];
+  // Refill-normalize: a latest sample whose reset has already passed means the
+  // window rolled since capture — treat it as refilled (0% used / full headroom)
+  // with zero extra probes, same discipline as `refillNormalizedUtils`.
+  const refilled = latest.resetAt != null && latest.resetAt <= now;
+  const rawUtil = latest.utilizationPct;
+  const currentUtilizationPct =
+    rawUtil == null ? null : refilled ? 0 : rawUtil;
+  const headroomPct =
+    currentUtilizationPct == null ? null : Math.max(0, 100 - currentUtilizationPct);
+  const utilSamples = tl.samples
+    .map((s) => s.utilizationPct)
+    .filter((u): u is number => u != null);
+  const peakUtilizationPct =
+    utilSamples.length > 0 ? Math.max(...utilSamples) : null;
+  return {
+    tier: tl.tier,
+    observations: tl.observations,
+    retained: tl.samples.length,
+    currentUtilizationPct,
+    headroomPct,
+    resetAt: latest.resetAt,
+    status: latest.status,
+    walled: latest.walled && !refilled,
+    refilled,
+    lastObservedAt: tl.lastObservedAt,
+    peakUtilizationPct,
+  };
+}
+
+/** Summarize one account's usage across both tiers, refill-normalized. PURE. */
+export function summarizeAccountUsage(
+  ledger: UsageLedger,
+  account: string,
+  now: number,
+): UsageAccountSummary {
+  const acct = ledger[account];
+  return {
+    account,
+    standard: summarizeTier(acct?.standard, now),
+    premium: summarizeTier(acct?.premium, now),
+  };
+}
+
+/**
+ * Premium (flagship / Fable) headroom % for `account` right now, refill-aware.
+ * Null when the ledger has no premium observation for the account (never
+ * probed the flagship tier, or only "no signal" results). Convenience over
+ * {@link summarizeAccountUsage}. PURE.
+ */
+export function premiumHeadroomPct(
+  ledger: UsageLedger,
+  account: string,
+  now: number,
+): number | null {
+  return summarizeAccountUsage(ledger, account, now).premium?.headroomPct ?? null;
+}
+
+/**
+ * Among `candidates` (already-eligible accounts, in caller preference order),
+ * pick the one with the MOST premium headroom from the ledger. Returns null
+ * when NO candidate has a known premium headroom — the caller then keeps its
+ * existing order (this is a PREFERENCE among eligible accounts, never a new
+ * gate; #3176's `premium_walled_until` marks remain the eligibility authority).
+ *
+ * Deterministic + order-stable: ties (equal headroom, incl. the empty-ledger
+ * case where all are unknown) resolve to the earliest candidate in the input
+ * order, so behavior is unchanged whenever the ledger carries no data. PURE.
+ */
+export function bestPremiumHeadroomAccount(
+  ledger: UsageLedger,
+  candidates: string[],
+  now: number,
+): string | null {
+  let best: string | null = null;
+  let bestHeadroom = -Infinity;
+  for (const cand of candidates) {
+    const h = premiumHeadroomPct(ledger, cand, now);
+    if (h == null) continue;
+    // Strictly-greater keeps the FIRST candidate on ties → order-stable.
+    if (h > bestHeadroom) {
+      bestHeadroom = h;
+      best = cand;
+    }
+  }
+  return best;
+}

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -342,6 +342,62 @@ function printConsumersTable(state: ListStateData): void {
   }
 }
 
+/**
+ * #3185 — render the per-account usage ledger, foregrounding PREMIUM (flagship /
+ * Fable) headroom — the operator's "how much Fable is left on each account"
+ * question — with the standard tier alongside. Refill-normalized by the broker;
+ * `no data` when a tier hasn't been observed (e.g. premium is only probed for
+ * the serving set). Purely from the durable ledger — no live probe.
+ */
+interface UsageCell {
+  /** Plain (uncolored) text — pad on THIS, then color, so ANSI escapes never
+   *  throw the column width off. */
+  plain: string;
+  /** Apply the tier's status color to a (possibly padded) string. */
+  color: (s: string) => string;
+}
+
+function usageHeadroomCell(
+  t:
+    | {
+        headroomPct: number | null;
+        walled: boolean;
+        refilled: boolean;
+        peakUtilizationPct: number | null;
+        observations: number;
+      }
+    | null,
+): UsageCell {
+  const noColor = (s: string) => s;
+  if (t == null) return { plain: "no data", color: chalk.gray };
+  if (t.headroomPct == null) return { plain: "unknown", color: chalk.gray };
+  const left = Math.round(t.headroomPct);
+  const peak = t.peakUtilizationPct == null ? "?" : `${Math.round(t.peakUtilizationPct)}`;
+  const base = `${left}% left (peak ${peak}%, n=${t.observations})`;
+  if (t.walled) return { plain: `WALLED - ${base}`, color: chalk.red };
+  if (t.refilled) return { plain: `refilled - ${base}`, color: chalk.green };
+  if (left <= 10) return { plain: base, color: chalk.yellow };
+  return { plain: base, color: noColor };
+}
+
+function printUsageTable(state: ListStateData): void {
+  console.log(
+    chalk.bold("  ACCOUNT                           PREMIUM (Fable) HEADROOM                    STANDARD HEADROOM"),
+  );
+  const WIDTH = 44;
+  for (const a of state.accounts) {
+    const marker = a.label === state.active ? chalk.green("*") : " ";
+    const label = a.label.padEnd(32);
+    const premium = usageHeadroomCell(a.usage_ledger?.premium ?? null);
+    const standard = usageHeadroomCell(a.usage_ledger?.standard ?? null);
+    // Pad the PLAIN text to a fixed column, THEN color — ANSI escapes can never
+    // distort the width this way.
+    const premiumCol = premium.color(premium.plain.padEnd(WIDTH));
+    const standardCol = standard.color(standard.plain);
+    console.log(`  ${marker} ${label} ${premiumCol} ${standardCol}`);
+  }
+}
+
 function printAgentDetail(state: ListStateData, agent: AgentState): void {
   console.log();
   console.log(chalk.bold(`  ${agent.name}`));
@@ -655,6 +711,39 @@ export function registerAuthCommand(program: Command): void {
         }
         console.log();
         printAccountsTable(state);
+        console.log();
+      }),
+    );
+
+  // ── auth usage ────────────────────────────────────────────────────────
+  // #3185 — "how much Fable is left on each account?" answered instantly from
+  // the broker's durable per-tier usage ledger (no live probe). Premium
+  // (flagship/Fable) headroom is foregrounded; standard tier alongside.
+  auth
+    .command("usage")
+    .description("Per-account premium (Fable) + standard usage headroom, from the durable ledger")
+    .option("--json", "Output the raw per-account usage_ledger summaries as JSON")
+    .action(
+      withConfigError(async (opts: { json?: boolean }) => {
+        const state = await brokerCall((client) => client.listState());
+        if (opts.json) {
+          console.log(
+            JSON.stringify(
+              state.accounts.map((a) => ({ label: a.label, usage_ledger: a.usage_ledger ?? null })),
+              null,
+              2,
+            ),
+          );
+          return;
+        }
+        console.log();
+        printUsageTable(state);
+        console.log();
+        console.log(
+          chalk.gray(
+            "  Premium = flagship (Fable) 7d_oi tier; standard = 5h/7d. Passive: harvested from probe headers, no extra requests.",
+          ),
+        );
         console.log();
       }),
     );

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -744,6 +744,11 @@ export function registerAuthCommand(program: Command): void {
             "  Premium = flagship (Fable) 7d_oi tier; standard = 5h/7d. Passive: harvested from probe headers, no extra requests.",
           ),
         );
+        console.log(
+          chalk.gray(
+            "  'X% left' is current (refill-aware); 'peak' is the max over retained history (~48h) and may predate the latest reset.",
+          ),
+        );
         console.log();
       }),
     );


### PR DESCRIPTION
Closes #3185.

## The ask (Ken, 2026-07-12)

> "Let's make sure switchroom tracks model usage per account for premium models like fable."

## Where tracking lives, and why

**Broker-side, in-repo, harvested passively — zero added requests.**

The auth-broker already probes every account each fleet tick and reads Anthropic's unified rate-limit headers: the standard-tier `5h`/`7d` windows off the 1-token haiku probe (`cacheQuotaSnapshot`), and — since #3179 — the premium-tier `7d_oi` (`seven_day_overage_included`) bucket off the 1-token flagship canary (`recordTierProbe`). Until now it kept only the **latest** snapshot per account and threw the rest away.

This PR turns those already-received headers into a durable, rolling per-(account, tier) usage ledger. It adds **no** request volume (requirement 5) — samples are harvested at the existing capture points, and the #3179 canary is untouched. Broker-side because the broker is in-repo, unit-tested and shipped via normal releases; the staged LiteLLM pacing callback (`custom_pacing.py`) is host-managed proxy config, out of this repo and off CI, so a proxy-side ledger would be un-tested and out-of-band.

## What changed

- **`src/auth/broker/usage-ledger.ts`** (new, pure): per-tier sample extraction from probe/canary headers; a bounded rolling ring (`USAGE_RING_CAP_DEFAULT` = 288 ≈ 48h at the ~10-min cadence, env-overridable) with a **monotonic observation count** that survives trimming; **refill-aware** summaries (a sample whose reset has passed reads as refilled → 0% used / full headroom, no extra probe — same discipline as `refillNormalizedUtils`); and a **deterministic, order-stable** `bestPremiumHeadroomAccount` selector.
- **`server.ts`**: load/persist `usage-ledger.json` (survives restart); append a standard sample at `cacheQuotaSnapshot` and a premium sample at `recordTierProbe`; expose a refill-normalized `usage_ledger` summary per account in `list-state`; and — **extending #3179, not duplicating it** — make `nextPremiumEligibleAccount` prefer the eligible fallback with the most premium headroom. Eligibility is still owned entirely by the #3179 `premium_walled_until` marks; the ledger is only a *preference among already-eligible accounts*, and it is ring-order-stable whenever the ledger has no distinguishing data, so existing #3179 failover tests are unaffected.
- **`client.ts`**: `usage_ledger` on `AccountState`; the wire types are re-exported from the ledger module so the shape has one source of truth.
- **`cli/auth.ts`**: `switchroom auth usage` renders per-account **premium (Fable)** + standard headroom, peak utilization and observation count straight from the durable ledger — the operator's instant "how much Fable is left on each account" answer, no live probe. `--json` for machine use.

## Honesty note on "tokens"

The unified rate-limit headers carry utilization %, reset times and an allowed/rejected status — **not** token counts. The ledger records those (Anthropic's own accounting of everything the fleet spent on the account) plus an observation count; it does not fabricate a token figure. True per-request token accounting would need the proxy callback (real traffic, out of repo) and is a documented follow-up, not part of this PR.

The operator-facing Telegram rendering (a pushed "Fable left per account" card) is likewise deferred: `list-state.usage_ledger` + the CLI are the surface here; the Telegram layer can consume the same field in a follow-up if wanted.

## Tests (assert outcomes, not code paths)

- `usage-ledger.test.ts` — 23 pure unit tests: per-tier extraction, thin/no-signal → null (never fabricated), ring trim with monotonic count, refill normalization, headroom + peak, selector max-headroom / order-stability / unknown-skip / refilled-as-full.
- `server-usage-ledger.test.ts` — 5 e2e: headers in → ledger state → `list-state` (over the real UDS wire) out; persistence across a broker restart; no premium sample for accounts outside the canary set; and the discriminating one — a flagship-walled active rolls to the **higher-headroom** fallback, not the ring-order-first one, proving selection consumes the ledger; plus the equal-headroom case staying order-stable.

Local: scoped vitest (28 new + 35 adjacent #3176/quota/throttle tests green), `npm run lint` clean, `npm run build` clean. CI is the full-suite authority.

## Risk

- Selection change is a *preference within eligible candidates*, gated behind #3179's marks and only exercised at a wall-triggered roll — no flapping (once rolled, the new active isn't walled, so no re-roll), and a no-op whenever the ledger lacks data.
- Everything fails safe: a ledger/persist error is logged, never fatal to the probe path; a failed/thin/no-signal probe records nothing.
- One extra small atomic write per observed sample per tick (consistent with the existing per-snapshot persistence). Ledger file is bounded by the ring cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
