### PR TITLE
feat(telegram): session-scope /effort overrides (consume-once, revert on restart)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1230,34 +1230,42 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   unset _smf _sm_model _sm_cfg
 fi
 
-# --- Session effort resolution (durable .session-effort, #3039) ---
+# --- Session effort resolution (consume-once .session-effort carrier, #3186) ---
 #
-# The `/effort` sibling of the block above. A positively-confirmed `/effort`
-# apply persists `{{agentDir}}/.session-effort` (one-line JSON
-# {"level","configuredDefaultAtWrite","ts"} written by the gateway). It is
-# honored on every boot and cleared only by `/effort default` (live delete)
-# or invalidation here (corrupt file / configured `thinking_effort:` changed)
-# — each invalidation appends to `.session-model-alert` so the gateway's
-# boot relay tells the operator once.
+# The `/effort` sibling of the block above, session-scoped like /model
+# (rev 4). A live `/effort <level>` applies in-session via the applyEffort
+# driver and writes NO carrier — the explicit `--effort <configured>` below
+# reverts it on the next boot. The ONLY boot-applied case is a queued
+# mid-turn `/effort` the gateway persisted at shutdown: this block APPLIES
+# that carrier on the single boot that reads it and then DELETES it
+# (consume-once), so any subsequent restart reverts to the configured
+# `thinking_effort`. Invalidation (corrupt file / configured default
+# changed) appends to `.session-model-alert` so the gateway's boot relay
+# tells the operator once.
+#
+# NB: the CONFIGURED default resolution is untouched (#3186 constraint) —
+# the fleet `thinking_effort: low` pin (see #1978 /
+# src/config/thinking-effort-risk.ts) resolves exactly as before.
 _EFFECTIVE_EFFORT={{#if thinkingEffort}}'{{thinkingEffort}}'{{else}}''{{/if}}
 if [ -f "{{agentDir}}/.session-effort" ]; then
   _sef="$(cat "{{agentDir}}/.session-effort" 2>/dev/null || true)"
   _se_level="$(printf '%s' "$_sef" | sed -n 's/.*"level"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
   _se_cfg="$(printf '%s' "$_sef" | sed -n 's/.*"configuredDefaultAtWrite"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  # CONSUME-ONCE: delete the carrier now, before any apply/exec — it governs
+  # exactly this one boot (parity with the .session-model block above).
+  rm -f "{{agentDir}}/.session-effort"
   # Allowlist gate — kept in sync with EFFORT_LEVELS in
   # telegram-plugin/gateway/effort-command.ts. The level is passed verbatim
   # to `claude --effort`.
   if [ "$(printf '%s' "$_se_level" | wc -l)" -ne 0 ] || ! printf '%s' "$_se_level" | grep -Eq '^(low|medium|high|xhigh|max)$'; then
-    rm -f "{{agentDir}}/.session-effort"
     echo "session-effort: ignoring malformed .session-effort (failed allowlist gate) — using configured default '${_EFFECTIVE_EFFORT:-<unset>}'" >&2
     printf 'Your saved session effort override could not be read (invalid or corrupt), so the agent booted on its configured default effort. Re-issue /effort <level> if you want a different one.\n' >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   elif [ "$_se_cfg" != "$_EFFECTIVE_EFFORT" ]; then
-    rm -f "{{agentDir}}/.session-effort"
-    echo "session-effort: configured thinking_effort changed ('$_se_cfg' → '${_EFFECTIVE_EFFORT:-<unset>}') — clearing session override '$_se_level'" >&2
-    printf 'The configured default effort changed (`%s` → `%s`), so your session effort override `%s` was cleared — the agent booted on the new configured default. Re-issue /effort %s if you still want it.\n' "${_se_cfg:-<unset>}" "${_EFFECTIVE_EFFORT:-<unset>}" "$_se_level" "$_se_level" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+    echo "session-effort: configured thinking_effort changed ('$_se_cfg' → '${_EFFECTIVE_EFFORT:-<unset>}') — dropping session override '$_se_level'" >&2
+    printf 'The configured default effort changed (`%s` → `%s`), so your session effort override `%s` was not applied — the agent booted on the new configured default. Re-issue /effort %s if you still want it.\n' "${_se_cfg:-<unset>}" "${_EFFECTIVE_EFFORT:-<unset>}" "$_se_level" "$_se_level" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   else
     _EFFECTIVE_EFFORT="$_se_level"
-    echo "session-effort: keeping session effort override '$_se_level' across this relaunch" >&2
+    echo "session-effort: applying session effort override '$_se_level' this boot (consume-once — reverts on next restart)" >&2
   fi
   unset _sef _se_level _se_cfg
 fi
@@ -1266,6 +1274,11 @@ if [ -n "$_EFFECTIVE_EFFORT" ]; then
 else
   _EFFORT_ARG=""
 fi
+# Record the EFFECTIVE launched effort so the gateway can re-hydrate its
+# in-memory session-effort state after a queued-apply boot, keeping the
+# /effort menu highlight honest. Overwrite (not consumed) — the effort
+# sibling of `.active-session-model` below.
+printf '%s\n' "$_EFFECTIVE_EFFORT" > "{{agentDir}}/.active-session-effort" 2>/dev/null || true
 
 # sr-* passthrough→router repoint — ONE post-resolution gate covering BOTH the
 # /model override path AND the configured-default path (`model: sr-*` in

--- a/reference/rfcs/session-model-stickiness.md
+++ b/reference/rfcs/session-model-stickiness.md
@@ -56,9 +56,18 @@ Mechanism — **consume-once carrier** (no intent file):
 - **sr-* + LiteLLM-down at the apply-boot:** the carrier cannot apply and
   consume-once forbids retaining it for a later relaunch, so start.sh boots the
   configured default and alerts the operator to re-issue once the proxy is back.
-- **`/effort` is unchanged** — `.session-effort` remains keep-across-restarts
-  (rev 3). Whether `/effort` should also become session-scoped is deferred to
-  the operator (#3183 open question).
+- **`/effort` is session-scoped too** (#3186, operator decision 2026-07-12,
+  resolving the #3183 open question). A live `/effort <level>` applies
+  in-session via the applyEffort driver and records in gateway memory only —
+  no carrier — so start.sh's explicit `--effort <configured>` reverts it on
+  the next boot. `.session-effort` remains solely as the queued-command
+  shutdown carrier and is consume-once at boot, with the same LOW-3-style
+  crash-recovery exception as `/model`. start.sh records the effective
+  launched effort to `.active-session-effort` (sibling of
+  `.active-session-model`) so the gateway re-hydrates the menu's live level
+  after a queued-apply boot. The CONFIGURED `thinking_effort` resolution is
+  untouched — the fleet `low` pin (#1978, `thinking-effort-risk.ts`; see
+  Appendix A) resolves exactly as before.
 - **#3178 preserved.** Instant ack, the durable receipt log + history row, the
   mid-turn queue-and-apply, and explicit failures are untouched; the queued
   apply persists a consume-once carrier at shutdown so it still applies as the

--- a/telegram-plugin/gateway/effort-command.ts
+++ b/telegram-plugin/gateway/effort-command.ts
@@ -65,8 +65,9 @@ export function parseEffortCommand(text: string): ParsedEffortCommand | null {
   }
   const arg = parts[0]
   if (arg.toLowerCase() === 'help') return { kind: 'help' }
-  // `/effort default` — explicit user action that clears the durable
-  // `.session-effort` override and restores the configured default (#3039).
+  // `/effort default` — explicit user action that clears the session
+  // override (in-memory + any leftover queued-command carrier) and restores
+  // the configured default (#3186, session-scoped).
   if (arg.toLowerCase() === 'default') return { kind: 'default' }
   if (!isValidEffortArg(arg)) {
     return { kind: 'help', reason: `not a valid effort level: ${arg}` }
@@ -91,14 +92,15 @@ export interface EffortCommandDeps {
    */
   getConfiguredEffort: () => string | null
   /**
-   * Delete the durable `.session-effort` override (#3039). Optional so
+   * Clear the session effort override (#3186: the in-memory live level plus
+   * any leftover queued-command `.session-effort` carrier). Optional so
    * gateway-agnostic tests can omit it; the gateway always wires it.
    */
   clearSessionEffort?: () => void
   /**
-   * The active durable `.session-effort` override level, or null when none
-   * (#3039). Optional; used to mark the LIVE level in the menu and the show
-   * text honestly after a restart re-applied the override.
+   * The active session effort override level, or null when none (#3186:
+   * in-memory, session-scoped — reverts on restart). Optional; used to mark
+   * the LIVE level in the menu and the show text honestly.
    */
   getSessionEffort?: () => string | null
   escapeHtml: (s: string) => string
@@ -110,7 +112,7 @@ export interface EffortCommandReply {
 }
 
 const PERSIST_NOTE =
-  '_Sticky — persists across restarts and deploys until \`/effort default\` clears it. To change the configured default, set \`thinking_effort:\` in switchroom.yaml._'
+  '_Session-only — this override lasts until the agent’s next restart, then reverts to the configured \`thinking_effort:\`. \`/effort default\` clears it now. To change the default permanently, set \`thinking_effort:\` in switchroom.yaml._'
 
 const LEVELS_INLINE = EFFORT_LEVELS.map(l => `\`${l}\``).join(' · ')
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -468,7 +468,6 @@ import {
   readConfiguredDefaultModel,
   writeSessionEffortFile,
   clearSessionEffortFile,
-  readSessionEffortFile,
 } from './session-model-file.js'
 import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
 import { resolveMainModel, SWITCHROOM_DEFAULT_THINKING_EFFORT } from '../../src/agents/scaffold.js'
@@ -22331,39 +22330,38 @@ bot.command('model', async ctx => {
 // is blocklisted for `/effort` since #2471), session-scoped — boot re-pins
 // the configured default via start.sh's `--effort`. Implementation in
 // effort-command.ts so it's unit-testable without booting the bot.
+
+// The live session-effort override, in memory only (#3186, session-scoped
+// like /model rev 4). A confirmed live apply records here — NOT to the
+// `.session-effort` carrier — so it lasts exactly until the next restart
+// (start.sh's explicit `--effort <configured>` reverts it for free). Seeded
+// at boot from `.active-session-effort` (the effort sibling of
+// `.active-session-model`) so a queued-carrier apply-boot still shows the
+// honest live level on the /effort menu.
+let sessionEffortOverride: string | null = null
+
 function buildEffortDeps(): EffortCommandDeps {
   return {
-    // #3039: single persistence choke point — EVERY positively-confirmed
-    // effort apply (typed, menu tap, queued drain) durably records the level
-    // to `.session-effort`, which start.sh resolves into `--effort` on every
-    // boot. `/effort default` clears it via clearSessionEffort (the handler
-    // clears AFTER its restore-apply, so the wrapper's write is undone).
+    // Session-scoped (#3186): a positively-confirmed live apply records the
+    // level IN MEMORY only — no durable carrier. The `.session-effort`
+    // carrier is written solely by persistQueuedCommandForRestart (a queued
+    // mid-turn /effort carried across the bounce) and is consume-once at
+    // boot. `/effort default` clears via clearSessionEffort below.
     applyEffort: async (agent, level) => {
       const result = await applyEffort(agent, level)
-      if (result.ok) {
-        const agentDir = resolveAgentDirFromEnv()
-        if (agentDir) {
-          try {
-            writeSessionEffortFile(agentDir, level, getConfiguredEffortForPersist())
-          } catch (err) {
-            process.stderr.write(
-              `telegram gateway: session-effort persist failed level=${level}: ${(err as Error)?.message ?? String(err)}\n`,
-            )
-          }
-        }
-      }
+      if (result.ok) sessionEffortOverride = level
       return result
     },
     getAgentName: getMyAgentName,
     getConfiguredEffort: () => getConfiguredEffortForPersist(),
     clearSessionEffort: () => {
+      sessionEffortOverride = null
+      // Also drop any leftover queued-command carrier so the next boot can't
+      // consume a stale level the user just cleared.
       const agentDir = resolveAgentDirFromEnv()
       if (agentDir) clearSessionEffortFile(agentDir)
     },
-    getSessionEffort: () => {
-      const agentDir = resolveAgentDirFromEnv()
-      return agentDir ? (readSessionEffortFile(agentDir)?.level ?? null) : null
-    },
+    getSessionEffort: () => sessionEffortOverride,
     escapeHtml: escapeHtmlForTg,
   }
 }
@@ -28906,6 +28904,23 @@ void (async () => {
                 sessionModelSource.setOverride(
                   launched.length > 0 && launched !== configured ? launched : null,
                 )
+              } catch { /* leave override as-is on a bad read */ }
+            }
+
+            // Effort sibling (#3186): start.sh records the EFFECTIVE launched
+            // effort to `.active-session-effort` every boot. Re-hydrate the
+            // in-memory session-effort override so the /effort menu highlight
+            // stays honest after a queued-carrier apply-boot. Only an effort
+            // differing from the configured default counts as an override.
+            const activeEffortPath = join(smAgentDir, '.active-session-effort')
+            if (existsSync(activeEffortPath)) {
+              try {
+                const launchedEffort = readFileSync(activeEffortPath, 'utf8').trim()
+                const configuredEffort = getConfiguredEffortForPersist()
+                sessionEffortOverride =
+                  launchedEffort.length > 0 && launchedEffort !== configuredEffort
+                    ? launchedEffort
+                    : null
               } catch { /* leave override as-is on a bad read */ }
             }
 

--- a/telegram-plugin/gateway/session-model-file.ts
+++ b/telegram-plugin/gateway/session-model-file.ts
@@ -18,13 +18,14 @@
  *     configured yaml default changed at the apply-boot) drops it and notifies
  *     the operator chat via `.session-model-alert`.
  *
- *   - `.session-effort` — the DURABLE effort override (#3039), still
- *     keep-across-restarts (NOT changed by rev 4). Same shape as
- *     `.session-model` with `level` in place of `model`:
- *     `{"level","configuredDefaultAtWrite","ts"}`. Written on every
- *     positively-confirmed `/effort` apply, resolved by start.sh into the
- *     relaunch's `--effort`, cleared only by `/effort default` or
- *     invalidation (with a boot alert).
+ *   - `.session-effort` — the CONSUME-ONCE effort carrier (#3186, session-
+ *     scoped like `.session-model`). Same shape with `level` in place of
+ *     `model`: `{"level","configuredDefaultAtWrite","ts"}`. Written ONLY by
+ *     the queued-command shutdown persist (a mid-turn `/effort` carried
+ *     across the bounce); start.sh resolves it into the apply-boot's
+ *     `--effort` and deletes it, so any subsequent restart reverts to the
+ *     configured `thinking_effort`. Live `/effort` applies record in memory
+ *     only. Cleared live by `/effort default`; invalidation alerts at boot.
  *
  * The `model` token is always a canonical `claude --model` token (alias,
  * `claude-*` id, or `sr-*` id) — NEVER a display label like "Opus 4.8".
@@ -82,8 +83,8 @@ export function parseSessionModel(text: string): SessionModelRecord | null {
 }
 
 /**
- * Write the durable session override. Throws on a non-canonical token —
- * callers must pass a `claude --model` token, never a display label
+ * Write the consume-once session-model carrier. Throws on a non-canonical
+ * token — callers must pass a `claude --model` token, never a display label
  * (regression guard for the "Opus 4.5 persisted" class).
  */
 export function writeSessionModelFile(
@@ -151,12 +152,13 @@ export function readConfiguredDefaultModel(agentDir: string): string | null {
   }
 }
 
-// ─── Durable session-effort override (#3039) ────────────────────────────────
+// ─── Consume-once session-effort carrier (#3186) ────────────────────────────
 //
-// The `/effort` sibling of `.session-model`. Same lifecycle: written on every
-// positively-confirmed effort apply, honored by start.sh on every boot
-// (`--effort <level>`), cleared only by `/effort default` or invalidation
-// (configured `thinking_effort:` changed / corrupt file — both alert once).
+// The `/effort` sibling of `.session-model`, session-scoped. Written ONLY by
+// the queued-command shutdown persist (a mid-turn /effort carried across the
+// bounce); start.sh applies it on the single boot that reads it (`--effort
+// <level>`) and deletes it. Cleared live by `/effort default`; invalidation
+// (configured `thinking_effort:` changed / corrupt file) alerts once at boot.
 
 export const SESSION_EFFORT_FILE = '.session-effort'
 
@@ -193,8 +195,9 @@ export function parseSessionEffort(text: string): SessionEffortRecord | null {
 }
 
 /**
- * Write the durable effort override. Throws on a non-allowlisted level —
- * the value is passed verbatim to `claude --effort` at the next boot.
+ * Write the consume-once effort carrier. Throws on a non-allowlisted level —
+ * the value is passed verbatim to `claude --effort` at the next boot (the
+ * apply-boot, which consumes the file).
  */
 export function writeSessionEffortFile(
   agentDir: string,
@@ -210,7 +213,7 @@ export function writeSessionEffortFile(
   )
 }
 
-/** Parsed durable effort override, or null when absent/corrupt. */
+/** Parsed effort carrier, or null when absent/corrupt. */
 export function readSessionEffortFile(agentDir: string): SessionEffortRecord | null {
   try {
     return parseSessionEffort(readFileSync(join(agentDir, SESSION_EFFORT_FILE), 'utf8'))
@@ -219,7 +222,7 @@ export function readSessionEffortFile(agentDir: string): SessionEffortRecord | n
   }
 }
 
-/** Delete the durable effort override (`/effort default`). Best-effort. */
+/** Delete the effort carrier (`/effort default`, leftover hygiene). Best-effort. */
 export function clearSessionEffortFile(agentDir: string): void {
   try {
     rmSync(join(agentDir, SESSION_EFFORT_FILE), { force: true })

--- a/telegram-plugin/tests/effort-command.test.ts
+++ b/telegram-plugin/tests/effort-command.test.ts
@@ -107,7 +107,7 @@ describe("effort-command: handler", () => {
     const { deps } = makeDeps({ getConfiguredEffort: () => "medium" });
     const r = await handleEffortCommand({ kind: "show" }, deps);
     expect(r.text).toContain("medium");
-    expect(r.text).toMatch(/persists across restarts and deploys/);
+    expect(r.text).toMatch(/lasts until the agent’s next restart/);
   });
 
   it("show falls back to low when effort is unreadable", async () => {
@@ -121,7 +121,7 @@ describe("effort-command: handler", () => {
     const r = await handleEffortCommand({ kind: "set", level: "high" }, deps);
     expect(calls).toEqual([{ agent: "carrie", level: "high" }]);
     expect(r.text).toContain("Set effort level to high");
-    expect(r.text).toMatch(/persists across restarts and deploys/);
+    expect(r.text).toMatch(/lasts until the agent’s next restart/);
   });
 
   it("set notes the re-read cost when a confirmation was needed", async () => {
@@ -249,9 +249,9 @@ describe("effort-command: /effort default (#3039)", () => {
     expect(marked?.text).toBe("✅ max");
   });
 
-  it("help text advertises /effort default and the sticky contract", async () => {
+  it("help text advertises /effort default and the session-only contract", async () => {
     const r = await handleEffortCommand({ kind: "help" }, makeDeps().deps);
     expect(r.text).toContain("/effort default");
-    expect(r.text).toContain("persists across restarts and deploys");
+    expect(r.text).toContain("lasts until the agent’s next restart");
   });
 });

--- a/telegram-plugin/tests/gateway-pending-command-wiring.test.ts
+++ b/telegram-plugin/tests/gateway-pending-command-wiring.test.ts
@@ -95,14 +95,33 @@ describe('gateway: /restart reverts the session-model override (rev 4, session-s
   })
 })
 
-describe('gateway: /effort persistence choke point (#3039)', () => {
-  it('buildEffortDeps persists a confirmed apply to .session-effort and wires clearSessionEffort', () => {
+describe('gateway: /effort is session-scoped (#3186)', () => {
+  it('buildEffortDeps records a confirmed live apply IN MEMORY only — no durable carrier write', () => {
     const fnIdx = GATEWAY_SRC.indexOf('function buildEffortDeps(')
     expect(fnIdx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(fnIdx, fnIdx + 2500)
-    expect(win).toContain('writeSessionEffortFile(')
+    expect(win).not.toContain('writeSessionEffortFile(')
+    expect(win).toContain('sessionEffortOverride = level')
+    // /effort default clears the in-memory level AND any leftover carrier.
+    expect(win).toContain('sessionEffortOverride = null')
     expect(win).toContain('clearSessionEffortFile(')
-    expect(win).toContain('readSessionEffortFile(')
+  })
+
+  it('the queued-command shutdown persist is the ONLY .session-effort writer', () => {
+    const writes = [...GATEWAY_SRC.matchAll(/writeSessionEffortFile\(/g)]
+    expect(writes.length).toBe(1)
+    const fnIdx = GATEWAY_SRC.indexOf('function persistQueuedCommandForRestart(')
+    expect(fnIdx).toBeGreaterThan(0)
+    expect(writes[0].index).toBeGreaterThan(fnIdx)
+    expect(writes[0].index).toBeLessThan(fnIdx + 3000)
+  })
+
+  it('boot re-hydrates the in-memory effort override from .active-session-effort', () => {
+    const idx = GATEWAY_SRC.indexOf("join(smAgentDir, '.active-session-effort')")
+    expect(idx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(idx, idx + 800)
+    expect(win).toContain('getConfiguredEffortForPersist()')
+    expect(win).toContain('sessionEffortOverride =')
   })
 })
 

--- a/telegram-plugin/tests/session-model-file.test.ts
+++ b/telegram-plugin/tests/session-model-file.test.ts
@@ -94,9 +94,9 @@ describe('readConfiguredDefaultModel', () => {
   })
 })
 
-// ─── #3039: durable session-effort carrier ───────────────────────────────────
+// ─── #3186: consume-once session-effort carrier (queued-command boot apply) ──
 
-describe('session-effort file helpers (#3039)', () => {
+describe('session-effort file helpers (#3186)', () => {
   let dir: string
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'sr-session-effort-'))

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -307,7 +307,7 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
   });
 
-  // ── session-effort resolver (#3039 — UNCHANGED by rev 4) ──────────────────
+  // ── session-effort resolver (#3186 — consume-once, session-scoped) ────────
   function effortJson(level: string, cfg = "low", ts = Date.now()): string {
     return `${JSON.stringify({ level, configuredDefaultAtWrite: cfg, ts })}\n`;
   }
@@ -320,14 +320,23 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     };
   }
 
-  it("no .session-effort → --effort uses the configured default", () => {
+  it("no .session-effort → --effort uses the configured default; effective effort recorded", () => {
     expect(runBlockEffort().effortArg).toBe("--effort low");
+    // The configured-default resolution itself is untouched (#3186 constraint)
+    // and the effective launched effort is recorded for gateway re-hydration.
+    expect(readFileSync(join(agentDir, ".active-session-effort"), "utf-8").trim()).toBe("low");
   });
 
-  it(".session-effort override survives the boot and is applied to --effort (still keep-across-restarts)", () => {
+  it("effort carrier → APPLIES this boot and is CONSUMED; the next boot reverts to configured (a/b)", () => {
     writeFileSync(join(agentDir, ".session-effort"), effortJson("xhigh"));
-    expect(runBlockEffort().effortArg).toBe("--effort xhigh");
-    expect(existsSync(join(agentDir, ".session-effort"))).toBe(true);
+    expect(runBlockEffort().effortArg).toBe("--effort xhigh"); // apply-boot
+    expect(existsSync(join(agentDir, ".session-effort"))).toBe(false); // consume-once
+    expect(readFileSync(join(agentDir, ".active-session-effort"), "utf-8").trim()).toBe("xhigh");
+    // No boot alert on a clean apply — the gateway already acked the /effort.
+    expect(existsSync(join(agentDir, ".session-model-alert"))).toBe(false);
+    // Any SUBSEQUENT restart reverts to the configured default.
+    expect(runBlockEffort().effortArg).toBe("--effort low");
+    expect(readFileSync(join(agentDir, ".active-session-effort"), "utf-8").trim()).toBe("low");
   });
 
   it("corrupt/non-allowlisted .session-effort → falls back to configured default AND notifies", () => {
@@ -337,7 +346,7 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     expect(alertText()).toContain("effort override could not be read");
   });
 
-  it("configured thinking_effort changed since the effort switch → cleared + notifies", () => {
+  it("configured thinking_effort changed since the effort switch → NOT applied + notifies + consumed", () => {
     writeFileSync(join(agentDir, ".session-effort"), effortJson("xhigh", "medium"));
     expect(runBlockEffort().effortArg).toBe("--effort low");
     expect(existsSync(join(agentDir, ".session-effort"))).toBe(false);


### PR DESCRIPTION
## Summary

Make `/effort` overrides **session-scoped**, mirroring #3184's `/model` semantics exactly, per operator decision 2026-07-12. An `/effort` override lasts until the agent's next restart, then reverts to the `switchroom.yaml`-resolved `thinking_effort`.

**STACKED ON #3184** (`feat/model-override-session-scope`) — base branch is that PR's branch, one commit on top (`70fe82a2`). Merge #3184 first; after its squash-merge this branch should be rebased onto main and this PR retargeted (I can do that on request). Do NOT merge this PR before #3184.

**CI note:** every CI workflow triggers on `pull_request: branches: [main]` only, so NO checks run while this PR targets the stack base. CI becomes the merge authority the moment it is retargeted to main post-#3184; until then the evidence is the local run below (tsc clean, all 8 lint guards clean, 240 scoped vitest tests green including every #3184 suite).

Job spec: `reference/jobs/operate-the-fleet-from-telegram.md`. Design record: `reference/rfcs/session-model-stickiness.md` §0.1 (the `/effort` bullet, updated here).

## Why

#3184 session-scoped `/model` but explicitly left `.session-effort` on the rev-3 keep-across-restarts contract as an open question. The operator has now decided `/effort` gets the same semantics.

## Design (same consume-once pattern as #3184)

- **Live applies write no carrier.** `/effort <level>` already applies in-session via the `applyEffort` tmux driver (no relaunch ever needed); the gateway now records the confirmed level in memory (`sessionEffortOverride`) instead of persisting `.session-effort`. start.sh's explicit `--effort <configured>` reverts it on the next boot for free.
- **`.session-effort` remains solely as the queued-command shutdown carrier** (a mid-turn `/effort` the gateway persisted while dying) and is now **consume-once**: start.sh applies it on the single boot that reads it, then deletes it. Any subsequent restart reverts. Same deliberate crash-recovery exception as `/model` (RFC §0.1 LOW-3 note): the acked queued choice applies on its one apply-boot, bounded by consume-once.
- **Menu honesty:** start.sh records the effective launched effort to `.active-session-effort` (sibling of `.active-session-model`); the gateway boot re-hydrates the in-memory override from it so the `/effort` menu ✅ highlight is truthful after a queued-carrier apply-boot.
- `/effort default` clears immediately (in-memory + any leftover carrier). Invalidation branches (corrupt / configured `thinking_effort:` changed) keep their one-shot boot alerts.
- Copy: `/effort` PERSIST_NOTE now reads "Session-only — lasts until the agent's next restart…".

## Constraints honored

- **Configured-default resolution untouched.** `_EFFECTIVE_EFFORT={{thinkingEffort}}` and the cascade are byte-identical; the fleet `thinking_effort: low` pin resolves exactly as before. (Rationale note: the pin guards the upstream claude CLI concurrent-streaming merge bug — #1978, `src/config/thinking-effort-risk.ts`; RFC Appendix A corrects the older "scrubber/signature invalidation" attribution.) Test asserts the no-carrier boot still renders `--effort low`.
- **#3180 (typed /effort mid-turn swallow, the #3177 sibling): neither fixed nor worsened.** This PR only changes how long a confirmed override persists; the missing durable receipt and the narrower busy gate described in #3180 are untouched and remain open. Stated in #3186 as well.

## Test plan

- `tests/scaffold.session-model.test.ts` (effort section, rendered start.sh executed via bash): (a) carrier applies on the apply-boot + is consumed + `.active-session-effort` records it; (b) the next boot reverts to `--effort low`; corrupt / config-changed drop + alert + consume; no-carrier boot unchanged (`--effort low`, constraint pin).
- `telegram-plugin/tests/gateway-pending-command-wiring.test.ts`: buildEffortDeps writes no carrier (in-memory only); the queued-command shutdown persist is the ONLY `.session-effort` writer; boot re-hydration pinned.
- `telegram-plugin/tests/effort-command.test.ts`: ack/help copy asserts "lasts until the agent's next restart".
- Local: `tsc --noEmit` clean, `npm run lint` clean (all 8 guards), scoped vitest **240 passed** across 7 suites (incl. all #3184 suites — no regression to the model work or #3178 guarantees).

## Risk / open questions

- Known minor limitation: after a **gateway-only** bounce (container not restarted), the in-memory live level re-hydrates from boot-time `.active-session-effort`, so a live switch made since boot drops off the menu ✅ highlight (display only; the session's actual effort is unaffected). The model side has the same shape, mitigated by transcript events; effort has no transcript source. Accepted as cosmetic.
- Rollout: an existing rev-3 durable `.session-effort` on disk gets one final apply-boot (consumed), then reverts — same gentle migration as the model carrier in #3184.

Do NOT merge — review and merge happen separately, and only after #3184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #3186

