### PR TITLE
feat(telegram): premium-model tier-downgrade failover when walled fleet-wide

### DIFF
--- a/telegram-plugin/fleet-fallback-resume.ts
+++ b/telegram-plugin/fleet-fallback-resume.ts
@@ -81,12 +81,24 @@ export interface FleetFallbackResumeGate {
   /**
    * Decide whether to resume the dead turn after a successful swap. Call ONLY
    * when the swap outcome was `'switched'`. Records the arm time on a 'resume'
-   * verdict so a follow-on swap within `singleFlightMs` is suppressed.
+   * verdict so a follow-on swap within `singleFlightMs` is suppressed. Equivalent
+   * to `peek()` followed by `arm()` on a 'resume' verdict.
    *
    * @param failedTurnStartedAtMs epoch-ms the failed turn began, or null when
    *        unknown (then the staleness guard is deferred to the boot path).
    */
   decide(failedTurnStartedAtMs: number | null): ResumeDecision;
+  /**
+   * Evaluate the resume verdict WITHOUT arming the single-flight latch. Use when
+   * the caller must perform fallible work (e.g. write a consume-once carrier)
+   * BEFORE committing to a restart: peek → do the writes → `arm()` only on
+   * success, so a throwing write can never leave an armed latch with no pending
+   * restart (which would suppress a legitimate later resume for `singleFlightMs`).
+   */
+  peek(failedTurnStartedAtMs: number | null): ResumeDecision;
+  /** Commit the single-flight arm (records "now" as the arm time). Pair with a
+   *  prior `peek()` that returned 'resume'. */
+  arm(): void;
   /** Test seam — reset to fresh state. Production code should not call this. */
   reset(): void;
   /** Test/debug — current internal state. */
@@ -105,7 +117,7 @@ export function createFleetFallbackResumeGate(
   // -Infinity = never resumed. A concrete value arms the single-flight window.
   let lastResumedAtMs = Number.NEGATIVE_INFINITY;
 
-  function decide(failedTurnStartedAtMs: number | null): ResumeDecision {
+  function peek(failedTurnStartedAtMs: number | null): ResumeDecision {
     const now = nowFn();
     // Guard 2 — single-flight. A second swap within the window does not
     // re-arm; the in-flight restart owns the resume.
@@ -115,12 +127,23 @@ export function createFleetFallbackResumeGate(
     if (failedTurnStartedAtMs != null && now - failedTurnStartedAtMs > maxAgeMs) {
       return 'skip-stale';
     }
-    lastResumedAtMs = now;
     return 'resume';
+  }
+
+  function arm(): void {
+    lastResumedAtMs = nowFn();
+  }
+
+  function decide(failedTurnStartedAtMs: number | null): ResumeDecision {
+    const verdict = peek(failedTurnStartedAtMs);
+    if (verdict === 'resume') arm();
+    return verdict;
   }
 
   return {
     decide,
+    peek,
+    arm,
     reset() {
       lastResumedAtMs = Number.NEGATIVE_INFINITY;
     },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -468,8 +468,16 @@ import {
   readConfiguredDefaultModel,
   writeSessionEffortFile,
   clearSessionEffortFile,
+  writePremiumRecoveryFile,
+  readPremiumRecoveryFile,
+  clearPremiumRecoveryFile,
 } from './session-model-file.js'
-import { decideTierDowngrade, planTierDowngrade } from '../tier-downgrade.js'
+import { runTierDowngrade } from './tier-downgrade-wiring.js'
+import {
+  decidePremiumRecovery,
+  renderPremiumRecoveryPing,
+  premiumRecoveryClaimKey,
+} from '../premium-recovery.js'
 import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
 import { resolveMainModel, SWITCHROOM_DEFAULT_THINKING_EFFORT } from '../../src/agents/scaffold.js'
 import {
@@ -21940,6 +21948,10 @@ function recordTypedModelSwitch(
   }
   if (!reply.selectedModel) return ''
   sessionModelSource.setOverride(reply.selectedModel)
+  // A manual /model apply to the dropped premium clears any pending recovery
+  // marker so the "available again" ping can't still fire after the user has
+  // already switched back themselves.
+  clearPremiumRecoveryOnManualSwitch(reply.selectedModel)
   return ''
 }
 
@@ -21968,6 +21980,11 @@ function recordModelMenuSideEffects(
   // (recommended)" selection clears any leftover carrier.
   if (outcome.selectedModel) {
     sessionModelSource.setOverride(outcome.selectedModel)
+    // Clear a pending premium-recovery marker when the tap re-selects the
+    // dropped premium (menu OR the recovery ping's own switch-back button):
+    // no stale "available again" ping once we're back on it. Idempotent — the
+    // ping-send path already consumed the marker, so this is a no-op there.
+    clearPremiumRecoveryOnManualSwitch(outcome.selectedModel)
   }
   if (outcome.clearedDefault) {
     const smDir = resolveAgentDirFromEnv()
@@ -23601,57 +23618,134 @@ function broadcastTierNotice(markdown: string): void {
  *                       falls through to the all-blocked card.
  */
 function maybeTierDowngrade(triggerAgent: string): 'downgraded' | 'restart-pending' | 'skip' {
-  const agentDir = resolveAgentDirFromEnv()
-  if (!agentDir) return 'skip'
-  const configuredDefault = resolveMainModel(readConfiguredDefaultModel(agentDir) ?? undefined)
-  const decision = decideTierDowngrade({
-    sessionOverride: sessionModelSource.getOverride(),
-    configuredDefault,
+  // Thin adapter: the order-sensitive glue lives in runTierDowngrade
+  // (tier-downgrade-wiring.ts) behind injected deps so it is unit-testable
+  // without importing the gateway. This wires the real seams.
+  return runTierDowngrade(triggerAgent, {
+    getAgentDir: () => resolveAgentDirFromEnv() ?? null,
+    getConfiguredDefault: () => {
+      const dir = resolveAgentDirFromEnv()
+      if (!dir) return null
+      return resolveMainModel(readConfiguredDefaultModel(dir) ?? undefined)
+    },
+    getSessionOverride: () => sessionModelSource.getOverride(),
     resolve: (t) => resolveMainModel(t),
+    // PEEK the resume gate WITHOUT arming (single-flight within this process +
+    // 3h staleness), the same gate the account-swap resume path uses.
+    peekResumeGate: () => fleetFallbackResumeGate.peek(newestActiveTurnStartedAtMs()),
+    writeCarrier: (dir, toModel, cfg) => writeSessionModelFile(dir, toModel, cfg),
+    armResumeGate: () => fleetFallbackResumeGate.arm(),
+    // Records the DROPPED premium token + the notice's allowFrom chats; start.sh
+    // never consumes `.premium-recovery`, so it survives the self-restart.
+    writeRecoveryMarker: (dir, premiumModel) => {
+      const chats = loadAccess().allowFrom.map((c) => String(c))
+      if (chats.length > 0) writePremiumRecoveryFile(dir, premiumModel, chats)
+    },
+    broadcastNotice: (md) => broadcastTierNotice(md),
+    selfRestart: (agent) => triggerSelfRestart(agent, 'tier-downgrade-resume'),
+    selfAgent: (t) => process.env.SWITCHROOM_AGENT_NAME ?? t,
+    log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
   })
-  // PEEK the resume gate WITHOUT arming (single-flight within this process + 3h
-  // staleness), the same gate the account-swap resume path uses. Peeking lets us
-  // do the fallible carrier write BEFORE committing the arm (see arm() below).
-  const gateVerdict = fleetFallbackResumeGate.peek(newestActiveTurnStartedAtMs())
-  const plan = planTierDowngrade(decision, gateVerdict, triggerAgent)
-  if (plan.kind === 'skip') {
-    if (decision.action === 'downgrade') {
-      process.stderr.write(
-        `telegram gateway: [tier-downgrade] restart suppressed (${gateVerdict}) agent=${triggerAgent}\n`,
-      )
-    }
-    return 'skip'
-  }
-  if (plan.kind === 'suppress') {
-    // A resume restart is already armed (concurrent turn). Do NOT emit a give-up
-    // card — that restart will replay the latest interrupted turn.
-    process.stderr.write(
-      `telegram gateway: [tier-downgrade] give-up suppressed — a resume restart is already armed agent=${triggerAgent}\n`,
-    )
-    return 'restart-pending'
-  }
-  // plan.kind === 'downgrade'. Write the consume-once carrier for the configured
-  // default BEFORE arming the latch: a throwing write must not leave an armed
-  // latch with no pending restart (which would suppress a legitimate later
-  // account-swap resume for the single-flight window).
-  try {
-    writeSessionModelFile(agentDir, plan.toModel, configuredDefault)
-  } catch (err) {
-    process.stderr.write(
-      `telegram gateway: [tier-downgrade] failed to write session-model carrier — aborting downgrade: ${(err as Error)?.message ?? err}\n`,
-    )
-    return 'skip'
-  }
-  // Carrier is on disk — NOW commit the single-flight arm and fire the restart.
-  fleetFallbackResumeGate.arm()
-  process.stderr.write(
-    `telegram gateway: [tier-downgrade] downgrading ${plan.fromModel} → ${plan.toModel} ` +
-    `and resuming via self-restart agent=${triggerAgent}\n`,
+}
+
+/**
+ * "Premium model recovered" ping (tier-downgrade companion). Consulted from the
+ * gateway's existing `runQuotaWatch` tick (every 15 min, on the cheap
+ * `list-state` IPC read it already does — NO new poller, NO broker change).
+ * When a `.premium-recovery` marker is pending (a downgrade dropped a premium
+ * `/model` selection fleet-wide) AND the broker's live-authoritative per-account
+ * eligibility shows the premium tier servable again — at least one account
+ * neither `exhausted` nor `premium_walled` — fire EXACTLY ONE ping to the
+ * recorded chats with a one-tap "switch back" button, then consume the marker.
+ *
+ * DETERMINISTIC: `exhausted` / `premium_walled` are the broker's own verdicts
+ * (`isAccountExhausted` / `isAccountPremiumWalled` → `isModelTierWalled`, a pure
+ * timestamp compare). No model judgement, no clock of our own.
+ *
+ * AT-MOST-ONCE: a fleet-wide `claim-notification` gates against a bounce or a
+ * concurrent tick, and the marker is cleared BEFORE the send (never-storm). The
+ * button routes through the SAME session-scoped `/model` apply path as the
+ * model menu (`mdl:alias:<premium>` → handleModelMenuCallback +
+ * recordModelMenuSideEffects) — it does not bypass it.
+ */
+async function maybePremiumRecoveryPing(
+  brokerClient: NonNullable<Awaited<ReturnType<typeof getAuthBrokerClient>>>,
+  accounts: ReadonlyArray<{ exhausted: boolean; premium_walled?: boolean }>,
+): Promise<void> {
+  const agentDir = resolveAgentDirFromEnv()
+  if (!agentDir) return
+  const marker = readPremiumRecoveryFile(agentDir)
+  if (marker == null) return
+  const decision = decidePremiumRecovery({
+    hasMarker: true,
+    accounts: accounts.map((a) => ({
+      exhausted: a.exhausted,
+      premiumWalled: a.premium_walled === true,
+    })),
+  })
+  if (!decision.fire) return
+  const agent = getMyAgentName()
+  // Fleet-wide dedup: a fresh gateway boot or a second tick inside the window
+  // must not re-send. Fail-open (claimQuotaNotification returns true on any
+  // broker error) — a convenience ping degrades to at-least-once, never lost.
+  const granted = await claimQuotaNotification(
+    brokerClient,
+    premiumRecoveryClaimKey(agent, marker.premiumModel),
   )
-  broadcastTierNotice(plan.notice)
-  const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? triggerAgent
-  triggerSelfRestart(selfAgent, 'tier-downgrade-resume')
-  return 'downgraded'
+  if (!granted) {
+    // Another gateway already owns this recovery ping — consume our marker so
+    // it can't linger and re-attempt every tick, and bail.
+    clearPremiumRecoveryFile(agentDir)
+    return
+  }
+  // Consume the marker BEFORE sending (never-storm: at-most-once is the hard
+  // requirement for this ping; a transient send fault is covered by
+  // swallowingApiCall's retry policy).
+  clearPremiumRecoveryFile(agentDir)
+  const ping = renderPremiumRecoveryPing(marker.premiumModel)
+  const keyboard = {
+    inline_keyboard: [
+      [{ text: ping.buttonText, callback_data: `${MODEL_CALLBACK_ALIAS}${marker.premiumModel}` }],
+    ],
+  }
+  const chats = marker.chats.length > 0
+    ? marker.chats
+    : loadAccess().allowFrom.map((c) => String(c))
+  for (const chat_id of chats) {
+    void swallowingApiCall(
+      // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy)
+      () =>
+        bot.api.sendRichMessage(chat_id, richMessage(ping.text), {
+          disable_notification: true,
+          reply_markup: keyboard,
+        }),
+      { chat_id: String(chat_id), verb: 'premium-recovery:notify' },
+    )
+  }
+  process.stderr.write(
+    `telegram gateway: [premium-recovery] ${marker.premiumModel} servable again — ping sent agent=${agent} chats=${chats.length}\n`,
+  )
+}
+
+/**
+ * Clear a pending premium-recovery marker when the user MANUALLY re-selects the
+ * dropped premium model before the recovery ping fires — no stale "available
+ * again" ping after they've already switched back. Called from every `/model`
+ * apply chokepoint (typed + menu/callback). Matches on the canonicalized token
+ * so an alias vs resolved-id spelling of the same model still clears it.
+ */
+function clearPremiumRecoveryOnManualSwitch(appliedToken: string | null | undefined): void {
+  if (appliedToken == null || appliedToken.length === 0) return
+  const agentDir = resolveAgentDirFromEnv()
+  if (!agentDir) return
+  const marker = readPremiumRecoveryFile(agentDir)
+  if (marker == null) return
+  if (resolveMainModel(appliedToken) === resolveMainModel(marker.premiumModel)) {
+    clearPremiumRecoveryFile(agentDir)
+    process.stderr.write(
+      `telegram gateway: [premium-recovery] marker cleared — user manually re-issued /model ${marker.premiumModel}\n`,
+    )
+  }
 }
 
 /** Returns true iff the dispatcher actually performed a swap (and the
@@ -23982,6 +24076,16 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
   if (!listStateData.accounts || listStateData.accounts.length === 0) {
     return // No accounts — nothing to watch.
   }
+
+  // Premium-model recovery ping (tier-downgrade companion). Reuses THIS tick's
+  // list-state read (no extra IPC): if a downgrade left a `.premium-recovery`
+  // marker and the broker now shows the premium tier servable again, ping once
+  // with a one-tap switch-back button. At-most-once + fleet-claim-deduped.
+  await maybePremiumRecoveryPing(brokerClient, listStateData.accounts).catch((err) => {
+    process.stderr.write(
+      `telegram gateway: [premium-recovery] ping check failed (non-fatal): ${(err as Error)?.message ?? err}\n`,
+    )
+  })
 
   // Build AccountSnapshot[] from cached broker state only — no live probe.
   // Accounts with null last_quota produce quota=null snapshots; classifyHealth

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -469,12 +469,7 @@ import {
   writeSessionEffortFile,
   clearSessionEffortFile,
 } from './session-model-file.js'
-import {
-  decideTierDowngrade,
-  readTierDowngradeAttempts,
-  writeTierDowngradeAttempts,
-  clearTierDowngradeAttempts,
-} from '../tier-downgrade.js'
+import { decideTierDowngrade, planTierDowngrade } from '../tier-downgrade.js'
 import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
 import { resolveMainModel, SWITCHROOM_DEFAULT_THINKING_EFFORT } from '../../src/agents/scaffold.js'
 import {
@@ -4460,16 +4455,6 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
     ? endingTurn.replyCalled === true
     : currentTurn?.replyCalled === true
   shadowEmit({ kind: 'turnEnd', key: key as _ChatKey, at: Date.now(), outboundEmitted })
-  // Tier-downgrade recovery: a turn that ended WITH an outbound reply is a
-  // successful answer, so any in-progress model-tier downgrade chain is
-  // resolved — clear the restart-surviving `.tier-downgrade-attempts` counter
-  // so a LATER independent overload can downgrade again. (Staleness bounds it
-  // too, but clearing on success avoids wrongly benching a re-selected premium
-  // model inside the staleness window.) Best-effort; a no-op when absent.
-  if (outboundEmitted) {
-    const tdAgentDir = resolveAgentDirFromEnv()
-    if (tdAgentDir) clearTierDowngradeAttempts(tdAgentDir)
-  }
   const msgInfo = activeReactionMsgIds.get(key)
   activeStatusReactions.delete(key)
   activeReactionMsgIds.delete(key)
@@ -23586,26 +23571,36 @@ function broadcastTierNotice(markdown: string): void {
  * (distinct from the configured default), downgrade to the configured default
  * and resume the dead turn via a self-restart, rather than let the turn stall.
  *
- *   - Revert is NATIVE: the consume-once `.session-model` carrier for the
- *     configured default is applied+deleted by start.sh on the resume boot, so
- *     any later restart reverts. The premium override was session-scoped, so the
- *     boot lands on the default regardless; the carrier makes it deterministic.
+ *   - NO automatic return to the premium model. The /model override is
+ *     session-scoped and in-memory only (recordTypedModelSwitch writes no
+ *     carrier), so it dies on the downgrade SIGTERM. The consume-once
+ *     `.session-model` carrier written here targets the CONFIGURED DEFAULT:
+ *     start.sh applies+deletes it on the resume boot, and every later restart
+ *     also boots the default. The premium tier is never restored on its own —
+ *     the user must re-issue `/model <premium>`, which the notice says plainly.
  *   - Effort is NATIVE: no `.session-effort` carrier is written, so the restart
  *     sheds any live /effort override and the downgraded default boots at the
  *     configured `thinking_effort` (the fleet `low` pin, #1978).
- *   - Loop-bounded: the restart-surviving `.tier-downgrade-attempts` counter
- *     caps consecutive downgrades per interruption chain; a second consecutive
- *     downgrade-resume failure is named-as-lost (no restart). Pacing reuses the
- *     fleetFallbackResumeGate single-flight + 3h staleness.
+ *   - Loop-bounded by the NATURAL on-default guard: after the downgrade boot the
+ *     session runs the configured default (override gone), so a re-entry returns
+ *     `skip` ('on-default') and never re-downgrades — even if the default is
+ *     itself walled (then the normal all-blocked card fires, no loop). Pacing
+ *     reuses the fleetFallbackResumeGate single-flight + 3h staleness.
  *
  * Returns:
- *   'downgraded' — carrier written, restart armed; caller must NOT also emit the
- *                  all-blocked give-up card (we are recovering, not giving up).
- *   'exhausted'  — budget spent; name-as-lost already broadcast; caller returns.
- *   'skip'       — not applicable (on the configured default, unresolved default,
- *                  or paced out); caller falls through to the all-blocked card.
+ *   'downgraded'      — carrier written, latch armed, restart fired; caller must
+ *                       NOT also emit the all-blocked give-up card (we are
+ *                       recovering, not giving up).
+ *   'restart-pending' — a resume restart was ALREADY armed in this process (a
+ *                       concurrent turn's downgrade or account-swap); that
+ *                       restart replays the interrupted turn, so caller must NOT
+ *                       emit a give-up card (avoids the contradictory "could not
+ *                       be recovered" race).
+ *   'skip'            — not applicable (on the configured default, unresolved
+ *                       default, or the turn is too stale to resume); caller
+ *                       falls through to the all-blocked card.
  */
-function maybeTierDowngrade(triggerAgent: string): 'downgraded' | 'exhausted' | 'skip' {
+function maybeTierDowngrade(triggerAgent: string): 'downgraded' | 'restart-pending' | 'skip' {
   const agentDir = resolveAgentDirFromEnv()
   if (!agentDir) return 'skip'
   const configuredDefault = resolveMainModel(readConfiguredDefaultModel(agentDir) ?? undefined)
@@ -23613,65 +23608,47 @@ function maybeTierDowngrade(triggerAgent: string): 'downgraded' | 'exhausted' | 
     sessionOverride: sessionModelSource.getOverride(),
     configuredDefault,
     resolve: (t) => resolveMainModel(t),
-    attempts: readTierDowngradeAttempts(agentDir),
-    now: Date.now(),
   })
-  if (decision.action === 'skip') return 'skip'
-  if (decision.action === 'exhausted') {
-    process.stderr.write(
-      `telegram gateway: [tier-downgrade] budget spent — naming turn as lost ` +
-      `agent=${triggerAgent} premium=${decision.premiumModel}\n`,
-    )
-    broadcastTierNotice(
-      `⚠️ **Turn could not be recovered** on agent **${triggerAgent}**\n` +
-      `The premium model \`${decision.premiumModel}\` is walled fleet-wide, and a ` +
-      `downgrade to the default \`${configuredDefault}\` already failed once — ` +
-      `stopping here to avoid a restart loop. Re-send your message once a model frees.`,
-    )
-    return 'exhausted'
-  }
-  // action === 'downgrade'. Pace via the resume gate (single-flight within this
-  // process + 3h staleness), the same gate the account-swap resume path uses.
-  const verdict = fleetFallbackResumeGate.decide(newestActiveTurnStartedAtMs())
-  if (verdict !== 'resume') {
-    process.stderr.write(
-      `telegram gateway: [tier-downgrade] restart suppressed (${verdict}) agent=${triggerAgent}\n`,
-    )
+  // PEEK the resume gate WITHOUT arming (single-flight within this process + 3h
+  // staleness), the same gate the account-swap resume path uses. Peeking lets us
+  // do the fallible carrier write BEFORE committing the arm (see arm() below).
+  const gateVerdict = fleetFallbackResumeGate.peek(newestActiveTurnStartedAtMs())
+  const plan = planTierDowngrade(decision, gateVerdict, triggerAgent)
+  if (plan.kind === 'skip') {
+    if (decision.action === 'downgrade') {
+      process.stderr.write(
+        `telegram gateway: [tier-downgrade] restart suppressed (${gateVerdict}) agent=${triggerAgent}\n`,
+      )
+    }
     return 'skip'
   }
-  // Persist the loop-guard counter BEFORE the restart — it must survive the boot
-  // (start.sh never touches `.tier-downgrade-attempts`).
-  try {
-    writeTierDowngradeAttempts(agentDir, decision.nextAttempts)
-  } catch (err) {
+  if (plan.kind === 'suppress') {
+    // A resume restart is already armed (concurrent turn). Do NOT emit a give-up
+    // card — that restart will replay the latest interrupted turn.
     process.stderr.write(
-      `telegram gateway: [tier-downgrade] failed to persist attempts counter — aborting downgrade: ${(err as Error)?.message ?? err}\n`,
+      `telegram gateway: [tier-downgrade] give-up suppressed — a resume restart is already armed agent=${triggerAgent}\n`,
     )
-    return 'skip'
+    return 'restart-pending'
   }
-  // Consume-once carrier for the configured default → the resume boot runs the
-  // default, replays the dead turn there, and reverts on any later restart.
+  // plan.kind === 'downgrade'. Write the consume-once carrier for the configured
+  // default BEFORE arming the latch: a throwing write must not leave an armed
+  // latch with no pending restart (which would suppress a legitimate later
+  // account-swap resume for the single-flight window).
   try {
-    writeSessionModelFile(agentDir, decision.toModel, configuredDefault)
+    writeSessionModelFile(agentDir, plan.toModel, configuredDefault)
   } catch (err) {
-    // Never arm the restart if the carrier could not be written — a bare
-    // restart would still revert to the default, but keep the two side effects
-    // atomic in intent and surface the failure.
     process.stderr.write(
       `telegram gateway: [tier-downgrade] failed to write session-model carrier — aborting downgrade: ${(err as Error)?.message ?? err}\n`,
     )
     return 'skip'
   }
+  // Carrier is on disk — NOW commit the single-flight arm and fire the restart.
+  fleetFallbackResumeGate.arm()
   process.stderr.write(
-    `telegram gateway: [tier-downgrade] downgrading ${decision.fromModel} → ${decision.toModel} ` +
-    `and resuming via self-restart agent=${triggerAgent} (attempt ${decision.nextAttempts.count})\n`,
+    `telegram gateway: [tier-downgrade] downgrading ${plan.fromModel} → ${plan.toModel} ` +
+    `and resuming via self-restart agent=${triggerAgent}\n`,
   )
-  broadcastTierNotice(
-    `⤵️ **Downgrading model to keep going** on agent **${triggerAgent}**\n` +
-    `\`${decision.fromModel}\` is overloaded across every account, so this turn is ` +
-    `resuming on the default \`${decision.toModel}\`. It reverts to \`${decision.fromModel}\` ` +
-    `on the next restart.`,
-  )
+  broadcastTierNotice(plan.notice)
   const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? triggerAgent
   triggerSelfRestart(selfAgent, 'tier-downgrade-resume')
   return 'downgraded'
@@ -23765,18 +23742,13 @@ async function doFireFleetAutoFallback(
       // downgrade to the configured default and resume the dead turn rather than
       // stall. Only reachable here — a `switched` outcome never enters this
       // branch, so a model throttled on one account is always recovered by
-      // account-swap first, never by a downgrade. Loop-bounded by
-      // `.tier-downgrade-attempts`; effort + revert are native (see
-      // maybeTierDowngrade).
+      // account-swap first, never by a downgrade. Loop-bounded by the natural
+      // on-default guard; effort revert is native (see maybeTierDowngrade).
       const tier = maybeTierDowngrade(triggerAgent)
-      if (tier === 'downgraded') {
-        // Restart armed; the boot-resume path replays the turn on the default.
-        // Do NOT also emit the all-blocked give-up card — we are recovering.
-        return false
-      }
-      if (tier === 'exhausted') {
-        // Turn already named-as-lost to the operator; suppress the generic
-        // all-blocked card to avoid double-messaging.
+      if (tier === 'downgraded' || tier === 'restart-pending') {
+        // Either this turn armed a downgrade restart, or a concurrent turn
+        // already armed a resume restart. Do NOT emit the all-blocked give-up
+        // card — a restart is coming that replays the interrupted turn.
         return false
       }
       const verdict = evaluateAllBlockedNotice(fallbackAllBlockedNoticeState, Date.now())

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -473,11 +473,8 @@ import {
   clearPremiumRecoveryFile,
 } from './session-model-file.js'
 import { runTierDowngrade } from './tier-downgrade-wiring.js'
-import {
-  decidePremiumRecovery,
-  renderPremiumRecoveryPing,
-  premiumRecoveryClaimKey,
-} from '../premium-recovery.js'
+import { runPremiumRecoveryPing } from './premium-recovery-wiring.js'
+import { decidePremiumRecovery } from '../premium-recovery.js'
 import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
 import { resolveMainModel, SWITCHROOM_DEFAULT_THINKING_EFFORT } from '../../src/agents/scaffold.js'
 import {
@@ -23672,59 +23669,42 @@ async function maybePremiumRecoveryPing(
   brokerClient: NonNullable<Awaited<ReturnType<typeof getAuthBrokerClient>>>,
   accounts: ReadonlyArray<{ exhausted: boolean; premium_walled?: boolean }>,
 ): Promise<void> {
-  const agentDir = resolveAgentDirFromEnv()
-  if (!agentDir) return
-  const marker = readPremiumRecoveryFile(agentDir)
-  if (marker == null) return
-  const decision = decidePremiumRecovery({
-    hasMarker: true,
-    accounts: accounts.map((a) => ({
-      exhausted: a.exhausted,
-      premiumWalled: a.premium_walled === true,
-    })),
+  // Thin adapter: the order-sensitive never-storm glue lives in
+  // runPremiumRecoveryPing (premium-recovery-wiring.ts) behind injected deps so
+  // it is unit-testable without importing the gateway. This wires the real seams
+  // (marker FS, fleet claim, send) — behaviour is preserved exactly.
+  return runPremiumRecoveryPing({
+    getAgentDir: () => resolveAgentDirFromEnv() ?? null,
+    readMarker: (dir) => readPremiumRecoveryFile(dir),
+    clearMarker: (dir) => clearPremiumRecoveryFile(dir),
+    getAgent: () => getMyAgentName(),
+    // The pure recovery predicate, bound to THIS tick's live per-account
+    // eligibility (the broker's own verdicts; `premium_walled` may be absent).
+    decide: () =>
+      decidePremiumRecovery({
+        hasMarker: true,
+        accounts: accounts.map((a) => ({
+          exhausted: a.exhausted,
+          premiumWalled: a.premium_walled === true,
+        })),
+      }).fire,
+    // Fail-open (claimQuotaNotification returns true on any broker error) — a
+    // convenience ping degrades to at-least-once, never lost.
+    claimNotification: (key) => claimQuotaNotification(brokerClient, key),
+    fallbackChats: () => loadAccess().allowFrom.map((c) => String(c)),
+    sendToChat: (chat_id, ping, keyboard) => {
+      void swallowingApiCall(
+        // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy)
+        () =>
+          bot.api.sendRichMessage(chat_id, richMessage(ping.text), {
+            disable_notification: true,
+            reply_markup: keyboard,
+          }),
+        { chat_id: String(chat_id), verb: 'premium-recovery:notify' },
+      )
+    },
+    log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
   })
-  if (!decision.fire) return
-  const agent = getMyAgentName()
-  // Fleet-wide dedup: a fresh gateway boot or a second tick inside the window
-  // must not re-send. Fail-open (claimQuotaNotification returns true on any
-  // broker error) — a convenience ping degrades to at-least-once, never lost.
-  const granted = await claimQuotaNotification(
-    brokerClient,
-    premiumRecoveryClaimKey(agent, marker.premiumModel),
-  )
-  if (!granted) {
-    // Another gateway already owns this recovery ping — consume our marker so
-    // it can't linger and re-attempt every tick, and bail.
-    clearPremiumRecoveryFile(agentDir)
-    return
-  }
-  // Consume the marker BEFORE sending (never-storm: at-most-once is the hard
-  // requirement for this ping; a transient send fault is covered by
-  // swallowingApiCall's retry policy).
-  clearPremiumRecoveryFile(agentDir)
-  const ping = renderPremiumRecoveryPing(marker.premiumModel)
-  const keyboard = {
-    inline_keyboard: [
-      [{ text: ping.buttonText, callback_data: `${MODEL_CALLBACK_ALIAS}${marker.premiumModel}` }],
-    ],
-  }
-  const chats = marker.chats.length > 0
-    ? marker.chats
-    : loadAccess().allowFrom.map((c) => String(c))
-  for (const chat_id of chats) {
-    void swallowingApiCall(
-      // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy)
-      () =>
-        bot.api.sendRichMessage(chat_id, richMessage(ping.text), {
-          disable_notification: true,
-          reply_markup: keyboard,
-        }),
-      { chat_id: String(chat_id), verb: 'premium-recovery:notify' },
-    )
-  }
-  process.stderr.write(
-    `telegram gateway: [premium-recovery] ${marker.premiumModel} servable again — ping sent agent=${agent} chats=${chats.length}\n`,
-  )
 }
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -469,6 +469,12 @@ import {
   writeSessionEffortFile,
   clearSessionEffortFile,
 } from './session-model-file.js'
+import {
+  decideTierDowngrade,
+  readTierDowngradeAttempts,
+  writeTierDowngradeAttempts,
+  clearTierDowngradeAttempts,
+} from '../tier-downgrade.js'
 import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
 import { resolveMainModel, SWITCHROOM_DEFAULT_THINKING_EFFORT } from '../../src/agents/scaffold.js'
 import {
@@ -4454,6 +4460,16 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
     ? endingTurn.replyCalled === true
     : currentTurn?.replyCalled === true
   shadowEmit({ kind: 'turnEnd', key: key as _ChatKey, at: Date.now(), outboundEmitted })
+  // Tier-downgrade recovery: a turn that ended WITH an outbound reply is a
+  // successful answer, so any in-progress model-tier downgrade chain is
+  // resolved — clear the restart-surviving `.tier-downgrade-attempts` counter
+  // so a LATER independent overload can downgrade again. (Staleness bounds it
+  // too, but clearing on success avoids wrongly benching a re-selected premium
+  // model inside the staleness window.) Best-effort; a no-op when absent.
+  if (outboundEmitted) {
+    const tdAgentDir = resolveAgentDirFromEnv()
+    if (tdAgentDir) clearTierDowngradeAttempts(tdAgentDir)
+  }
   const msgInfo = activeReactionMsgIds.get(key)
   activeStatusReactions.delete(key)
   activeReactionMsgIds.delete(key)
@@ -23546,6 +23562,121 @@ function broadcastFleetFallbackFailure(triggerAgent: string, reason: string): vo
   }
 }
 
+/**
+ * Broadcast a status notice to every authorized chat (system notice posture:
+ * silenced ping, wrapped send). Shared by the tier-downgrade notices below.
+ */
+function broadcastTierNotice(markdown: string): void {
+  const access = loadAccess()
+  if (access.allowFrom.length === 0) return
+  for (const chat_id of access.allowFrom) {
+    void swallowingApiCall(
+      // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy)
+      () => bot.api.sendRichMessage(chat_id, richMessage(markdown), { disable_notification: true }),
+      { chat_id: String(chat_id), verb: 'tier-downgrade:notify' },
+    )
+  }
+}
+
+/**
+ * MODEL-TIER downgrade failover (second recovery tier). Consulted ONLY from the
+ * `all-blocked` branch of doFireFleetAutoFallback — i.e. AFTER account-swap has
+ * been tried and found no account still serving the walled premium model
+ * (precedence A: account-swap first). When a PREMIUM /model override is active
+ * (distinct from the configured default), downgrade to the configured default
+ * and resume the dead turn via a self-restart, rather than let the turn stall.
+ *
+ *   - Revert is NATIVE: the consume-once `.session-model` carrier for the
+ *     configured default is applied+deleted by start.sh on the resume boot, so
+ *     any later restart reverts. The premium override was session-scoped, so the
+ *     boot lands on the default regardless; the carrier makes it deterministic.
+ *   - Effort is NATIVE: no `.session-effort` carrier is written, so the restart
+ *     sheds any live /effort override and the downgraded default boots at the
+ *     configured `thinking_effort` (the fleet `low` pin, #1978).
+ *   - Loop-bounded: the restart-surviving `.tier-downgrade-attempts` counter
+ *     caps consecutive downgrades per interruption chain; a second consecutive
+ *     downgrade-resume failure is named-as-lost (no restart). Pacing reuses the
+ *     fleetFallbackResumeGate single-flight + 3h staleness.
+ *
+ * Returns:
+ *   'downgraded' — carrier written, restart armed; caller must NOT also emit the
+ *                  all-blocked give-up card (we are recovering, not giving up).
+ *   'exhausted'  — budget spent; name-as-lost already broadcast; caller returns.
+ *   'skip'       — not applicable (on the configured default, unresolved default,
+ *                  or paced out); caller falls through to the all-blocked card.
+ */
+function maybeTierDowngrade(triggerAgent: string): 'downgraded' | 'exhausted' | 'skip' {
+  const agentDir = resolveAgentDirFromEnv()
+  if (!agentDir) return 'skip'
+  const configuredDefault = resolveMainModel(readConfiguredDefaultModel(agentDir) ?? undefined)
+  const decision = decideTierDowngrade({
+    sessionOverride: sessionModelSource.getOverride(),
+    configuredDefault,
+    resolve: (t) => resolveMainModel(t),
+    attempts: readTierDowngradeAttempts(agentDir),
+    now: Date.now(),
+  })
+  if (decision.action === 'skip') return 'skip'
+  if (decision.action === 'exhausted') {
+    process.stderr.write(
+      `telegram gateway: [tier-downgrade] budget spent — naming turn as lost ` +
+      `agent=${triggerAgent} premium=${decision.premiumModel}\n`,
+    )
+    broadcastTierNotice(
+      `⚠️ **Turn could not be recovered** on agent **${triggerAgent}**\n` +
+      `The premium model \`${decision.premiumModel}\` is walled fleet-wide, and a ` +
+      `downgrade to the default \`${configuredDefault}\` already failed once — ` +
+      `stopping here to avoid a restart loop. Re-send your message once a model frees.`,
+    )
+    return 'exhausted'
+  }
+  // action === 'downgrade'. Pace via the resume gate (single-flight within this
+  // process + 3h staleness), the same gate the account-swap resume path uses.
+  const verdict = fleetFallbackResumeGate.decide(newestActiveTurnStartedAtMs())
+  if (verdict !== 'resume') {
+    process.stderr.write(
+      `telegram gateway: [tier-downgrade] restart suppressed (${verdict}) agent=${triggerAgent}\n`,
+    )
+    return 'skip'
+  }
+  // Persist the loop-guard counter BEFORE the restart — it must survive the boot
+  // (start.sh never touches `.tier-downgrade-attempts`).
+  try {
+    writeTierDowngradeAttempts(agentDir, decision.nextAttempts)
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: [tier-downgrade] failed to persist attempts counter — aborting downgrade: ${(err as Error)?.message ?? err}\n`,
+    )
+    return 'skip'
+  }
+  // Consume-once carrier for the configured default → the resume boot runs the
+  // default, replays the dead turn there, and reverts on any later restart.
+  try {
+    writeSessionModelFile(agentDir, decision.toModel, configuredDefault)
+  } catch (err) {
+    // Never arm the restart if the carrier could not be written — a bare
+    // restart would still revert to the default, but keep the two side effects
+    // atomic in intent and surface the failure.
+    process.stderr.write(
+      `telegram gateway: [tier-downgrade] failed to write session-model carrier — aborting downgrade: ${(err as Error)?.message ?? err}\n`,
+    )
+    return 'skip'
+  }
+  process.stderr.write(
+    `telegram gateway: [tier-downgrade] downgrading ${decision.fromModel} → ${decision.toModel} ` +
+    `and resuming via self-restart agent=${triggerAgent} (attempt ${decision.nextAttempts.count})\n`,
+  )
+  broadcastTierNotice(
+    `⤵️ **Downgrading model to keep going** on agent **${triggerAgent}**\n` +
+    `\`${decision.fromModel}\` is overloaded across every account, so this turn is ` +
+    `resuming on the default \`${decision.toModel}\`. It reverts to \`${decision.fromModel}\` ` +
+    `on the next restart.`,
+  )
+  const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? triggerAgent
+  triggerSelfRestart(selfAgent, 'tier-downgrade-resume')
+  return 'downgraded'
+}
+
 /** Returns true iff the dispatcher actually performed a swap (and the
  *  user-visible announcement was broadcast). False on no-op /
  *  error / idempotent-skip — caller uses this to decide whether to
@@ -23628,6 +23759,26 @@ async function doFireFleetAutoFallback(
     if (outcome.kind === 'switched') {
       fallbackAllBlockedNoticeState = { lastSentAtMs: 0 }
     } else if (outcome.kind === 'all-blocked') {
+      // ── Second recovery tier: MODEL-TIER downgrade (precedence A) ──────────
+      // Account-swap just came back all-blocked (no account still serves the
+      // walled model). Before giving up, if a PREMIUM /model override is active,
+      // downgrade to the configured default and resume the dead turn rather than
+      // stall. Only reachable here — a `switched` outcome never enters this
+      // branch, so a model throttled on one account is always recovered by
+      // account-swap first, never by a downgrade. Loop-bounded by
+      // `.tier-downgrade-attempts`; effort + revert are native (see
+      // maybeTierDowngrade).
+      const tier = maybeTierDowngrade(triggerAgent)
+      if (tier === 'downgraded') {
+        // Restart armed; the boot-resume path replays the turn on the default.
+        // Do NOT also emit the all-blocked give-up card — we are recovering.
+        return false
+      }
+      if (tier === 'exhausted') {
+        // Turn already named-as-lost to the operator; suppress the generic
+        // all-blocked card to avoid double-messaging.
+        return false
+      }
       const verdict = evaluateAllBlockedNotice(fallbackAllBlockedNoticeState, Date.now())
       if (!verdict.send) {
         process.stderr.write(

--- a/telegram-plugin/gateway/premium-recovery-wiring.ts
+++ b/telegram-plugin/gateway/premium-recovery-wiring.ts
@@ -1,0 +1,122 @@
+/**
+ * premium-recovery-wiring.ts — the gateway GLUE for the "premium model
+ * recovered" ping, behind injected deps so the never-storm orchestration is
+ * unit-testable without importing the whole gateway (mirrors
+ * tier-downgrade-wiring.ts).
+ *
+ * The pure recovery predicate (`decidePremiumRecovery`), the honest wording +
+ * button (`renderPremiumRecoveryPing`), and the fleet-dedup key
+ * (`premiumRecoveryClaimKey`) all live in premium-recovery.ts. This module owns
+ * the ORDER-SENSITIVE side effects the gateway performs off that verdict — the
+ * P0 at-most-once guarantee a review cares about:
+ *
+ *   - the marker is READ first; a missing/corrupt marker is a no-op (no send);
+ *   - the pure decision gates the send: `fire === false` → NO clear, NO send
+ *     (the marker survives for a later tick once the tier actually recovers);
+ *   - a fleet-wide `claim-notification` gates against a bounce / concurrent
+ *     tick; on `!granted` the marker is cleared (so it can't linger and
+ *     re-attempt every tick) and we bail with NO send;
+ *   - on a GRANTED claim the marker is cleared BEFORE the send (never-storm:
+ *     at-most-once is the hard requirement — a transient send fault is covered
+ *     by the caller's retry policy, a double-send is not recoverable);
+ *   - EXACTLY ONE send per recorded chat, each carrying the session-scoped
+ *     `mdl:alias:<premium>` switch-back button (the SAME apply path as the model
+ *     menu — it does not bypass handleModelMenuCallback).
+ *
+ * Behaviour is a faithful extraction of the former inline
+ * `maybePremiumRecoveryPing`; the ordering above is preserved exactly.
+ */
+
+import {
+  renderPremiumRecoveryPing,
+  premiumRecoveryClaimKey,
+  type PremiumRecoveryPing,
+} from '../premium-recovery.js'
+import { MODEL_CALLBACK_ALIAS } from './model-command.js'
+
+/** The one-tap switch-back keyboard (single callback button). */
+export interface PremiumRecoveryKeyboard {
+  inline_keyboard: Array<Array<{ text: string; callback_data: string }>>
+}
+
+/** The minimal marker view the ping orchestration needs. */
+export interface PremiumRecoveryMarkerView {
+  /** The dropped premium `/model` token to offer switching back to. */
+  premiumModel: string
+  /** Chat ids to ping (the downgrade notice's allowFrom); may be empty → fallback. */
+  chats: string[]
+}
+
+export interface PremiumRecoveryPingDeps {
+  /** Bind-mounted agent state dir, or null when unresolvable (→ no-op). */
+  getAgentDir: () => string | null
+  /** Read the parsed `.premium-recovery` marker, or null when absent/corrupt. */
+  readMarker: (agentDir: string) => PremiumRecoveryMarkerView | null
+  /** Delete the marker (consume-once). Best-effort. */
+  clearMarker: (agentDir: string) => void
+  /** The agent name (for the fleet-dedup claim key). */
+  getAgent: () => string
+  /** The pure recovery predicate, bound to THIS tick's live accounts. Returns
+   *  whether to fire (the marker is already known present when this is called). */
+  decide: () => boolean
+  /** Fleet-wide at-most-once claim for this premium token. Returns granted
+   *  (fail-open: true on any broker error → degrades to at-least-once). */
+  claimNotification: (claimKey: string) => Promise<boolean>
+  /** Fallback chats when the marker records none (parity with the inline path). */
+  fallbackChats: () => string[]
+  /** Send the recovery ping (with the switch-back keyboard) to ONE chat. */
+  sendToChat: (
+    chatId: string,
+    ping: PremiumRecoveryPing,
+    keyboard: PremiumRecoveryKeyboard,
+  ) => void
+  /** Structured logger (stderr in prod, captured in test). */
+  log: (msg: string) => void
+}
+
+/**
+ * Run the premium-recovery ping glue. No-op unless a marker is pending, the
+ * pure decision says fire, and the fleet claim is granted — then clears the
+ * marker BEFORE fanning out exactly one send per chat. Async because the claim
+ * is a broker round-trip; the caller `.catch`es (a convenience ping is never
+ * allowed to throw the quota-watch tick).
+ */
+export async function runPremiumRecoveryPing(deps: PremiumRecoveryPingDeps): Promise<void> {
+  const agentDir = deps.getAgentDir()
+  if (!agentDir) return
+  const marker = deps.readMarker(agentDir)
+  if (marker == null) return
+  // Pure decision gate: on `false` leave the marker in place (a later tick fires
+  // once the tier recovers) — no clear, no claim, no send.
+  if (!deps.decide()) return
+  const agent = deps.getAgent()
+  // Fleet-wide dedup: a fresh gateway boot or a second tick inside the window
+  // must not re-send. Fail-open — a convenience ping degrades to at-least-once,
+  // never lost.
+  const granted = await deps.claimNotification(
+    premiumRecoveryClaimKey(agent, marker.premiumModel),
+  )
+  if (!granted) {
+    // Another gateway already owns this recovery ping — consume our marker so it
+    // can't linger and re-attempt every tick, and bail (NO send).
+    deps.clearMarker(agentDir)
+    return
+  }
+  // Consume the marker BEFORE sending (never-storm: at-most-once is the hard
+  // requirement for this ping; a transient send fault is covered by the
+  // caller's retry policy, whereas a double-send is not recoverable).
+  deps.clearMarker(agentDir)
+  const ping = renderPremiumRecoveryPing(marker.premiumModel)
+  const keyboard: PremiumRecoveryKeyboard = {
+    inline_keyboard: [
+      [{ text: ping.buttonText, callback_data: `${MODEL_CALLBACK_ALIAS}${marker.premiumModel}` }],
+    ],
+  }
+  const chats = marker.chats.length > 0 ? marker.chats : deps.fallbackChats()
+  for (const chatId of chats) {
+    deps.sendToChat(chatId, ping, keyboard)
+  }
+  deps.log(
+    `[premium-recovery] ${marker.premiumModel} servable again — ping sent agent=${agent} chats=${chats.length}`,
+  )
+}

--- a/telegram-plugin/gateway/session-model-file.ts
+++ b/telegram-plugin/gateway/session-model-file.ts
@@ -230,3 +230,91 @@ export function clearSessionEffortFile(agentDir: string): void {
     /* best-effort */
   }
 }
+
+// ─── Consume-once premium-recovery marker (tier-downgrade companion) ─────────
+//
+// A DURABLE marker the tier-downgrade writes when it walls a premium `/model`
+// selection fleet-wide. It records the DROPPED premium token + the chats to
+// notify, and survives the downgrade self-restart (start.sh never touches this
+// name — unlike `.session-model`, which is consumed at boot). The gateway's
+// `runQuotaWatch` tick reads it, and when the broker's `list-state` shows the
+// premium tier servable again (deterministic per-account eligibility), fires
+// EXACTLY ONE "available again" ping with a one-tap switch-back button, then
+// clears the marker (at-most-once). Also cleared the instant the user re-issues
+// `/model <premium>` manually (no stale ping). Shape-gated like the carriers
+// above — the model token passes the same MODEL_ARG_RE gate.
+
+export const PREMIUM_RECOVERY_FILE = '.premium-recovery'
+
+export interface PremiumRecoveryRecord {
+  /** The dropped premium `/model` token (e.g. `fable`) to offer switching back to. */
+  premiumModel: string
+  /** Telegram chat ids to ping on recovery (the downgrade notice's allowFrom). */
+  chats: string[]
+  ts: number
+}
+
+/**
+ * Parse `.premium-recovery` content. Null on corrupt JSON, a missing/wrong-typed
+ * field, a model token that fails the MODEL_ARG_RE shape gate, or a `chats`
+ * array that is not a non-empty list of non-empty strings.
+ */
+export function parsePremiumRecovery(text: string): PremiumRecoveryRecord | null {
+  try {
+    const raw = JSON.parse(text) as Partial<PremiumRecoveryRecord>
+    if (
+      typeof raw.premiumModel !== 'string' ||
+      !isValidModelArg(raw.premiumModel) ||
+      typeof raw.ts !== 'number' ||
+      !Array.isArray(raw.chats) ||
+      raw.chats.length === 0 ||
+      !raw.chats.every((c) => typeof c === 'string' && c.length > 0)
+    ) {
+      return null
+    }
+    return { premiumModel: raw.premiumModel, chats: raw.chats, ts: raw.ts }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Write the premium-recovery marker. Throws on a non-canonical token (parity
+ * with the carriers) or an empty chat list — a marker with nowhere to ping is a
+ * bug, not a silent no-op.
+ */
+export function writePremiumRecoveryFile(
+  agentDir: string,
+  premiumModel: string,
+  chats: string[],
+): void {
+  if (!isValidModelArg(premiumModel)) {
+    throw new Error(`refusing to persist non-canonical premium-recovery token: ${JSON.stringify(premiumModel)}`)
+  }
+  const clean = chats.filter((c) => typeof c === 'string' && c.length > 0)
+  if (clean.length === 0) {
+    throw new Error('refusing to persist premium-recovery marker with no chats to notify')
+  }
+  atomicWrite(
+    join(agentDir, PREMIUM_RECOVERY_FILE),
+    `${JSON.stringify({ premiumModel, chats: clean, ts: Date.now() })}\n`,
+  )
+}
+
+/** Parsed premium-recovery marker, or null when absent/corrupt. */
+export function readPremiumRecoveryFile(agentDir: string): PremiumRecoveryRecord | null {
+  try {
+    return parsePremiumRecovery(readFileSync(join(agentDir, PREMIUM_RECOVERY_FILE), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+/** Delete the premium-recovery marker (consumed on ping / manual re-issue). Best-effort. */
+export function clearPremiumRecoveryFile(agentDir: string): void {
+  try {
+    rmSync(join(agentDir, PREMIUM_RECOVERY_FILE), { force: true })
+  } catch {
+    /* best-effort */
+  }
+}

--- a/telegram-plugin/gateway/session-model-file.ts
+++ b/telegram-plugin/gateway/session-model-file.ts
@@ -301,13 +301,28 @@ export function writePremiumRecoveryFile(
   )
 }
 
-/** Parsed premium-recovery marker, or null when absent/corrupt. */
+/**
+ * Parsed premium-recovery marker, or null when absent/corrupt. A present-but-
+ * corrupt marker (null parse of a file that exists) is SWEPT on read: neither
+ * the ping path nor `clearPremiumRecoveryOnManualSwitch` can act on a null
+ * parse, so a garbled file would otherwise linger forever. Deleting it here is
+ * best-effort hygiene — the read still returns null either way.
+ */
 export function readPremiumRecoveryFile(agentDir: string): PremiumRecoveryRecord | null {
+  let raw: string
   try {
-    return parsePremiumRecovery(readFileSync(join(agentDir, PREMIUM_RECOVERY_FILE), 'utf8'))
+    raw = readFileSync(join(agentDir, PREMIUM_RECOVERY_FILE), 'utf8')
   } catch {
+    return null // absent / unreadable — nothing on disk to sweep.
+  }
+  const parsed = parsePremiumRecovery(raw)
+  if (parsed == null) {
+    // Corrupt marker present on disk — garbage-collect it so it can't wedge the
+    // recovery path (best-effort; a failed unlink still returns null).
+    clearPremiumRecoveryFile(agentDir)
     return null
   }
+  return parsed
 }
 
 /** Delete the premium-recovery marker (consumed on ping / manual re-issue). Best-effort. */

--- a/telegram-plugin/gateway/tier-downgrade-wiring.ts
+++ b/telegram-plugin/gateway/tier-downgrade-wiring.ts
@@ -1,0 +1,121 @@
+/**
+ * tier-downgrade-wiring.ts — the gateway GLUE for the model-tier downgrade,
+ * behind injected deps so the orchestration is unit-testable without importing
+ * the whole gateway (mirrors throttle-tier-wiring.ts).
+ *
+ * The pure decision (`decideTierDowngrade`), the give-up/suppress routing
+ * (`planTierDowngrade`), and the user-facing wording (`renderTierDowngradeNotice`)
+ * all live in tier-downgrade.ts. This module owns the ORDER-SENSITIVE side
+ * effects the gateway performs off those verdicts — and the invariants a review
+ * cares about:
+ *
+ *   - the resume gate is PEEKed (not armed) first, so the fallible carrier write
+ *     happens before the single-flight latch is committed;
+ *   - the consume-once `.session-model` carrier is written BEFORE the arm; a
+ *     throwing write aborts the downgrade and leaves NO armed latch;
+ *   - the latch is armed only AFTER a successful carrier write;
+ *   - the durable premium-recovery marker write is best-effort (a failure never
+ *     aborts the downgrade — the recovery ping simply doesn't arm);
+ *   - the broadcast notice is the HONEST resume-on-default text (never a
+ *     revert-to-premium promise) and is sent only on a real downgrade;
+ *   - a `skip-inflight` resume-gate verdict returns `restart-pending` and emits
+ *     NO notice and NO restart (the concurrent turn's armed restart resumes).
+ */
+
+import {
+  decideTierDowngrade,
+  planTierDowngrade,
+  type ResumeGateVerdict,
+} from '../tier-downgrade.js'
+
+export type TierDowngradeOutcome = 'downgraded' | 'restart-pending' | 'skip'
+
+export interface TierDowngradeRunnerDeps {
+  /** Bind-mounted agent state dir, or null when unresolvable (→ skip). */
+  getAgentDir: () => string | null
+  /** Resolved configured-default token; '' / null → unresolved (never downgrade blind). */
+  getConfiguredDefault: () => string | null
+  /** Live session `/model` override, or null on the plain configured default. */
+  getSessionOverride: () => string | null
+  /** Model canonicalizer (the gateway passes resolveMainModel). */
+  resolve: (token: string) => string
+  /** PEEK the resume gate WITHOUT arming it. */
+  peekResumeGate: () => ResumeGateVerdict
+  /** Write the consume-once `.session-model` carrier for the default. May throw. */
+  writeCarrier: (agentDir: string, toModel: string, configuredDefault: string) => void
+  /** Commit the single-flight arm — called ONLY after a successful carrier write. */
+  armResumeGate: () => void
+  /** Persist the durable premium-recovery marker (best-effort; may throw — caught). */
+  writeRecoveryMarker: (agentDir: string, premiumModel: string) => void
+  /** Broadcast the honest downgrade notice to the operator chats. */
+  broadcastNotice: (markdown: string) => void
+  /** Fire the resume self-restart for `agent`. */
+  selfRestart: (agent: string) => void
+  /** The agent whose session self-restarts (SWITCHROOM_AGENT_NAME ?? triggerAgent). */
+  selfAgent: (triggerAgent: string) => string
+  /** Structured logger (stderr in prod, captured in test). */
+  log: (msg: string) => void
+}
+
+/**
+ * Run the tier-downgrade glue. Returns:
+ *   'downgraded'      — carrier written, latch armed, notice broadcast, restart fired.
+ *   'restart-pending' — a resume restart is already armed (concurrent turn); no
+ *                       notice, no restart (its restart replays the dead turn).
+ *   'skip'            — not applicable / carrier write failed; caller falls
+ *                       through to its all-blocked give-up card.
+ */
+export function runTierDowngrade(
+  triggerAgent: string,
+  deps: TierDowngradeRunnerDeps,
+): TierDowngradeOutcome {
+  const agentDir = deps.getAgentDir()
+  if (!agentDir) return 'skip'
+  const configuredDefault = deps.getConfiguredDefault() ?? ''
+  const decision = decideTierDowngrade({
+    sessionOverride: deps.getSessionOverride(),
+    configuredDefault,
+    resolve: deps.resolve,
+  })
+  // PEEK (no arm): the fallible carrier write must precede the latch commit.
+  const gateVerdict = deps.peekResumeGate()
+  const plan = planTierDowngrade(decision, gateVerdict, triggerAgent)
+  if (plan.kind === 'skip') {
+    if (decision.action === 'downgrade') {
+      deps.log(`[tier-downgrade] restart suppressed (${gateVerdict}) agent=${triggerAgent}`)
+    }
+    return 'skip'
+  }
+  if (plan.kind === 'suppress') {
+    deps.log(
+      `[tier-downgrade] give-up suppressed — a resume restart is already armed agent=${triggerAgent}`,
+    )
+    return 'restart-pending'
+  }
+  // plan.kind === 'downgrade'. Carrier BEFORE arm: a throwing write must not
+  // leave an armed latch with no pending restart.
+  try {
+    deps.writeCarrier(agentDir, plan.toModel, configuredDefault)
+  } catch (err) {
+    deps.log(
+      `[tier-downgrade] failed to write session-model carrier — aborting downgrade: ${(err as Error)?.message ?? err}`,
+    )
+    return 'skip'
+  }
+  deps.armResumeGate()
+  deps.log(
+    `[tier-downgrade] downgrading ${plan.fromModel} → ${plan.toModel} and resuming via self-restart agent=${triggerAgent}`,
+  )
+  // Durable premium-recovery marker — best-effort (survives the restart; the
+  // downgrade is the critical path and must not abort on a marker failure).
+  try {
+    deps.writeRecoveryMarker(agentDir, plan.fromModel)
+  } catch (err) {
+    deps.log(
+      `[tier-downgrade] premium-recovery marker write failed (non-fatal): ${(err as Error)?.message ?? err}`,
+    )
+  }
+  deps.broadcastNotice(plan.notice)
+  deps.selfRestart(deps.selfAgent(triggerAgent))
+  return 'downgraded'
+}

--- a/telegram-plugin/premium-recovery.ts
+++ b/telegram-plugin/premium-recovery.ts
@@ -1,0 +1,101 @@
+/**
+ * premium-recovery.ts — "your premium model is servable again" ping (pure layer).
+ *
+ * Companion to tier-downgrade.ts. When a premium `/model` selection (e.g.
+ * `/model fable`) is walled fleet-wide, the tier-downgrade tier resumes the
+ * turn on the configured default and tells the user to re-issue `/model fable`
+ * once it frees up (there is NO automatic revert — the override is session-
+ * scoped and dies on the downgrade restart). This module closes that loop with
+ * a HEADS-UP: the moment the premium tier can be served again, ping the chat
+ * ONCE with a one-tap "switch back" button.
+ *
+ * DETERMINISTIC recovery signal (P0 deterministic-controls — never model-
+ * decided). The signal is the auth-broker's own per-account eligibility, read
+ * off `list-state` (the SAME state the gateway's `runQuotaWatch` tick already
+ * polls every 15 min — no new poller, no broker change):
+ *   - `account.exhausted`      — live-authoritative `isAccountExhausted` verdict
+ *     (5h/7d wall or an unexpired `exhausted_until` mark).
+ *   - `account.premium_walled` — live-authoritative `isAccountPremiumWalled`
+ *     verdict; `isModelTierWalled` is a pure timestamp compare
+ *     (`premium_walled_until > now`) unless a fresher canary read the flagship
+ *     tier `allowed`. (src/auth/broker/model-tier-quota.ts / account-eligibility.ts.)
+ * The tier-downgrade fires from the account-swap `all-blocked` verdict — i.e.
+ * EVERY account was exhausted or premium-walled. Recovery is the exact
+ * complement: at least ONE account is neither. No clock of our own, no model
+ * judgement — the broker already decided; we read its decision.
+ *
+ * AT-MOST-ONCE. The gateway holds a consume-once `.premium-recovery` marker
+ * (session-model-file.ts) recording the dropped premium token + the chats to
+ * notify. `decidePremiumRecovery` is a pure predicate; the gateway clears the
+ * marker BEFORE sending (never-storm) and additionally takes a fleet-wide
+ * `claim-notification` so a bounce or a second gateway tick can't double-fire.
+ * The marker is also cleared the instant the user manually re-issues
+ * `/model <premium>` (no stale ping).
+ *
+ * PURE — no I/O, no clock. The gateway does the list-state read, the marker
+ * FS, the claim, and the send off these verdicts.
+ */
+
+/** The minimal per-account eligibility view the recovery predicate needs —
+ *  both fields are the broker's live-authoritative verdicts from `list-state`. */
+export interface AccountRecoveryView {
+  /** `isAccountExhausted` — a 5h/7d wall or an unexpired `exhausted_until` mark. */
+  exhausted: boolean
+  /** `isAccountPremiumWalled` — the flagship (`7d_oi`) tier wall verdict. */
+  premiumWalled: boolean
+}
+
+export interface PremiumRecoveryDecision {
+  /** Fire exactly one ping now (a marker is pending AND the premium tier is
+   *  servable again). The gateway clears the marker + claims before sending. */
+  fire: boolean
+  /** Why not, for the log (never surfaced to the user). */
+  reason: 'no-marker' | 'still-walled' | 'recovered'
+}
+
+/**
+ * Decide whether the premium tier has recovered for a pending downgrade.
+ * PURE. Fires iff a marker is pending AND at least one account can serve the
+ * premium tier again (neither exhausted nor premium-walled) — the exact
+ * complement of the `all-blocked` condition that fired the downgrade.
+ */
+export function decidePremiumRecovery(opts: {
+  hasMarker: boolean
+  accounts: ReadonlyArray<AccountRecoveryView>
+}): PremiumRecoveryDecision {
+  if (!opts.hasMarker) return { fire: false, reason: 'no-marker' }
+  const servable = opts.accounts.some((a) => !a.exhausted && !a.premiumWalled)
+  return servable
+    ? { fire: true, reason: 'recovered' }
+    : { fire: false, reason: 'still-walled' }
+}
+
+export interface PremiumRecoveryPing {
+  /** Telegram-formatted (rich-markdown) body. */
+  text: string
+  /** Inline-keyboard button label. */
+  buttonText: string
+}
+
+/**
+ * The user-facing recovery ping. PURE + deterministic so the wording + button
+ * are pinned by a test. Honest: the switch it offers is SESSION-SCOPED (the
+ * same `/model` semantics as everywhere else — it reverts on the next restart),
+ * so it never promises a durable pin.
+ */
+export function renderPremiumRecoveryPing(premiumModel: string): PremiumRecoveryPing {
+  return {
+    text:
+      `✅ \`${premiumModel}\` is available again — tap to switch back to it for this session.`,
+    buttonText: `Switch to ${premiumModel}`,
+  }
+}
+
+/**
+ * The fleet-wide `claim-notification` key for a premium-recovery ping. Keyed on
+ * agent + the specific premium token so two different dropped models never
+ * dedup each other, and a bounce mid-window can't re-send the same one.
+ */
+export function premiumRecoveryClaimKey(agent: string, premiumModel: string): string {
+  return `premium-recovery:${agent}:${premiumModel}`
+}

--- a/telegram-plugin/tests/fleet-fallback-resume.test.ts
+++ b/telegram-plugin/tests/fleet-fallback-resume.test.ts
@@ -122,6 +122,45 @@ describe('createFleetFallbackResumeGate — staleness guard', () => {
   })
 })
 
+describe('createFleetFallbackResumeGate — peek / arm seams (tier-downgrade LOW-3 + LOW-9a)', () => {
+  it('peek() evaluates the verdict WITHOUT arming the single-flight latch', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now })
+    // Peeking 'resume' must not record an arm time — a following peek/decide is
+    // still 'resume'. This is what lets the gateway do a fallible carrier write
+    // between the peek and the arm without leaving a phantom armed latch (LOW-3).
+    expect(gate.peek(clk.now())).toBe('resume')
+    expect(gate.inspect().lastResumedAtMs).toBe(Number.NEGATIVE_INFINITY)
+    expect(gate.peek(clk.now())).toBe('resume')
+    // The real restart never fires (write threw) → nothing armed → a genuine
+    // later swap still resumes.
+    expect(gate.decide(clk.now())).toBe('resume')
+  })
+
+  it('arm() commits the single-flight window so a later peek reports skip-inflight (LOW-9a)', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now, singleFlightMs: 60_000 })
+    // Turn 1: peek 'resume' → do the write → arm.
+    expect(gate.peek(clk.now())).toBe('resume')
+    gate.arm()
+    // Turn 2 (concurrent, same process, 1s later): a resume restart is already
+    // armed, so peek reports skip-inflight → the gateway suppresses the give-up.
+    clk.advance(1_000)
+    expect(gate.peek(clk.now())).toBe('skip-inflight')
+  })
+
+  it('peek(skip-inflight/skip-stale) never arms; only arm() records the window', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now })
+    // A stale peek must not arm (mirrors decide()'s stale behaviour).
+    expect(gate.peek(clk.now() - (DEFAULT_RESUME_MAX_AGE_MS + 1))).toBe('skip-stale')
+    expect(gate.inspect().lastResumedAtMs).toBe(Number.NEGATIVE_INFINITY)
+    // decide() remains equivalent to peek+arm-on-resume.
+    expect(gate.decide(clk.now())).toBe('resume')
+    expect(gate.peek(clk.now())).toBe('skip-inflight')
+  })
+})
+
 describe('createFleetFallbackResumeGate — reset / inspect seams', () => {
   it('reset() clears the single-flight arm', () => {
     const clk = fakeClock()

--- a/telegram-plugin/tests/premium-recovery-wiring.test.ts
+++ b/telegram-plugin/tests/premium-recovery-wiring.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Integration test for the premium-recovery ping GLUE
+ * (`runPremiumRecoveryPing`, premium-recovery-wiring.ts) — the never-storm
+ * orchestration the pure `decidePremiumRecovery` / `renderPremiumRecoveryPing`
+ * tests do NOT cover. This is the P0 at-most-once guarantee (claim-gate → clear-
+ * marker-before-send → per-chat fan-out) that was inline in the gateway and so
+ * had ZERO coverage; the same untested-glue gap the tier-downgrade extraction
+ * closed for the downgrade path.
+ *
+ * It drives the real runner with injected seams and PINS:
+ *   - clear-BEFORE-send ordering (never-storm) + exactly one send per chat;
+ *   - claim !granted → marker cleared, NO send;
+ *   - decision.fire === false → no clear, no claim, no send;
+ *   - no marker / no agent dir → no-op;
+ *   - the button `callback_data` is EXACTLY `mdl:alias:<premium>` (a future edit
+ *     can't silently break the session-scoped switch-back path).
+ * These are outcome assertions that FAIL if the guard logic is reordered/dropped.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  runPremiumRecoveryPing,
+  type PremiumRecoveryPingDeps,
+  type PremiumRecoveryMarkerView,
+  type PremiumRecoveryKeyboard,
+} from '../gateway/premium-recovery-wiring.js'
+import type { PremiumRecoveryPing } from '../premium-recovery.js'
+
+interface Recorder {
+  /** Ordered event log — pins clear-before-send. */
+  events: string[]
+  clears: number
+  claims: string[]
+  sends: Array<{ chatId: string; ping: PremiumRecoveryPing; keyboard: PremiumRecoveryKeyboard }>
+  decides: number
+  logs: string[]
+}
+
+function makeDeps(
+  over: {
+    agentDir?: string | null
+    marker?: PremiumRecoveryMarkerView | null
+    fire?: boolean
+    granted?: boolean
+    fallbackChats?: string[]
+  } = {},
+): { deps: PremiumRecoveryPingDeps; rec: Recorder } {
+  const rec: Recorder = { events: [], clears: 0, claims: [], sends: [], decides: 0, logs: [] }
+  const deps: PremiumRecoveryPingDeps = {
+    getAgentDir: () => (over.agentDir === undefined ? '/tmp/agent' : over.agentDir),
+    readMarker: () =>
+      over.marker === undefined
+        ? { premiumModel: 'fable', chats: ['111', '222'] }
+        : over.marker,
+    clearMarker: () => {
+      rec.clears += 1
+      rec.events.push('clear')
+    },
+    getAgent: () => 'klanker',
+    decide: () => {
+      rec.decides += 1
+      return over.fire === undefined ? true : over.fire
+    },
+    claimNotification: async (key) => {
+      rec.claims.push(key)
+      return over.granted === undefined ? true : over.granted
+    },
+    fallbackChats: () => over.fallbackChats ?? ['999'],
+    sendToChat: (chatId, ping, keyboard) => {
+      rec.sends.push({ chatId, ping, keyboard })
+      rec.events.push(`send:${chatId}`)
+    },
+    log: (msg) => rec.logs.push(msg),
+  }
+  return { deps, rec }
+}
+
+describe('runPremiumRecoveryPing — never-storm at-most-once ordering', () => {
+  it('fire + granted: marker cleared BEFORE any send, exactly one send per chat', async () => {
+    const { deps, rec } = makeDeps({ marker: { premiumModel: 'fable', chats: ['111', '222'] } })
+    await runPremiumRecoveryPing(deps)
+    expect(rec.clears).toBe(1)
+    // One send per recorded chat, in order, no duplicates.
+    expect(rec.sends.map((s) => s.chatId)).toEqual(['111', '222'])
+    // The clear MUST precede the first send (a double-send is unrecoverable).
+    const clearIdx = rec.events.indexOf('clear')
+    const firstSendIdx = rec.events.findIndex((e) => e.startsWith('send:'))
+    expect(clearIdx).toBeGreaterThanOrEqual(0)
+    expect(firstSendIdx).toBeGreaterThanOrEqual(0)
+    expect(clearIdx).toBeLessThan(firstSendIdx)
+    // The fleet claim was keyed on agent + the dropped premium token.
+    expect(rec.claims).toEqual(['premium-recovery:klanker:fable'])
+    expect(rec.logs).toHaveLength(1)
+  })
+
+  it('claim NOT granted: marker cleared (no lingering re-attempt), NO send', async () => {
+    const { deps, rec } = makeDeps({ granted: false })
+    await runPremiumRecoveryPing(deps)
+    expect(rec.claims).toEqual(['premium-recovery:klanker:fable'])
+    expect(rec.clears).toBe(1)
+    expect(rec.sends).toHaveLength(0)
+  })
+
+  it('decision.fire === false: NO clear, NO claim, NO send (marker survives for a later tick)', async () => {
+    const { deps, rec } = makeDeps({ fire: false })
+    await runPremiumRecoveryPing(deps)
+    expect(rec.decides).toBe(1)
+    expect(rec.clears).toBe(0)
+    expect(rec.claims).toHaveLength(0)
+    expect(rec.sends).toHaveLength(0)
+  })
+
+  it('no marker present: no-op — no decide, no claim, no clear, no send', async () => {
+    const { deps, rec } = makeDeps({ marker: null })
+    await runPremiumRecoveryPing(deps)
+    expect(rec.decides).toBe(0)
+    expect(rec.clears).toBe(0)
+    expect(rec.claims).toHaveLength(0)
+    expect(rec.sends).toHaveLength(0)
+  })
+
+  it('no agent dir: immediate no-op (marker is never even read)', async () => {
+    const { deps, rec } = makeDeps({ agentDir: null })
+    await runPremiumRecoveryPing(deps)
+    expect(rec.decides).toBe(0)
+    expect(rec.clears).toBe(0)
+    expect(rec.sends).toHaveLength(0)
+  })
+
+  it('marker with no chats falls back to the access allowFrom chats', async () => {
+    const { deps, rec } = makeDeps({
+      marker: { premiumModel: 'fable', chats: [] },
+      fallbackChats: ['999'],
+    })
+    await runPremiumRecoveryPing(deps)
+    expect(rec.sends.map((s) => s.chatId)).toEqual(['999'])
+  })
+})
+
+describe('runPremiumRecoveryPing — session-scoped switch-back button', () => {
+  it('the button callback_data is EXACTLY mdl:alias:<premium> (routes the model-menu apply path)', async () => {
+    const { deps, rec } = makeDeps({ marker: { premiumModel: 'fable', chats: ['111'] } })
+    await runPremiumRecoveryPing(deps)
+    const button = rec.sends[0].keyboard.inline_keyboard[0][0]
+    // Pin the exact wire format — a change to MODEL_CALLBACK_ALIAS or the button
+    // construction that broke the session-scoped `/model` apply path must fail here.
+    expect(button.callback_data).toBe('mdl:alias:fable')
+    expect(button.text).toBe('Switch to fable')
+  })
+})

--- a/telegram-plugin/tests/premium-recovery.test.ts
+++ b/telegram-plugin/tests/premium-recovery.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the "premium model recovered" ping.
+ *
+ *  - `decidePremiumRecovery` is the PURE recovery predicate: fires iff a marker
+ *    is pending AND the broker shows the premium tier servable again (at least
+ *    one account neither `exhausted` nor `premium_walled`) — the exact
+ *    complement of the `all-blocked` condition that fired the downgrade. This
+ *    IS the deterministic recovery signal: both fields are the broker's live-
+ *    authoritative verdicts, so the ping never depends on model judgement.
+ *  - `renderPremiumRecoveryPing` pins the honest, session-scoped wording +
+ *    button label.
+ *  - `premiumRecoveryClaimKey` keys the fleet-wide dedup on agent + token.
+ *  - the `.premium-recovery` carrier round-trips + is shape-gated (parity with
+ *    the `.session-model` / `.session-effort` carriers).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  decidePremiumRecovery,
+  renderPremiumRecoveryPing,
+  premiumRecoveryClaimKey,
+} from '../premium-recovery.js'
+import {
+  writePremiumRecoveryFile,
+  readPremiumRecoveryFile,
+  clearPremiumRecoveryFile,
+  parsePremiumRecovery,
+  PREMIUM_RECOVERY_FILE,
+} from '../gateway/session-model-file.js'
+
+describe('decidePremiumRecovery — deterministic recovery predicate', () => {
+  it('no marker → never fires', () => {
+    expect(
+      decidePremiumRecovery({ hasMarker: false, accounts: [{ exhausted: false, premiumWalled: false }] }),
+    ).toEqual({ fire: false, reason: 'no-marker' })
+  })
+
+  it('marker pending but EVERY account still walled/exhausted → no fire (still-walled)', () => {
+    const d = decidePremiumRecovery({
+      hasMarker: true,
+      accounts: [
+        { exhausted: true, premiumWalled: false },
+        { exhausted: false, premiumWalled: true },
+        { exhausted: true, premiumWalled: true },
+      ],
+    })
+    expect(d).toEqual({ fire: false, reason: 'still-walled' })
+  })
+
+  it('marker pending AND one account can serve the premium tier again → fire', () => {
+    const d = decidePremiumRecovery({
+      hasMarker: true,
+      accounts: [
+        { exhausted: true, premiumWalled: true },
+        { exhausted: false, premiumWalled: false }, // recovered
+      ],
+    })
+    expect(d).toEqual({ fire: true, reason: 'recovered' })
+  })
+
+  it('an account that is exhausted-but-not-premium-walled does NOT count as recovered', () => {
+    // The premium tier is only servable on an account that is BOTH not
+    // exhausted AND not premium-walled.
+    const d = decidePremiumRecovery({
+      hasMarker: true,
+      accounts: [{ exhausted: true, premiumWalled: false }],
+    })
+    expect(d.fire).toBe(false)
+  })
+
+  it('an account that is premium-walled-but-not-exhausted does NOT count as recovered', () => {
+    const d = decidePremiumRecovery({
+      hasMarker: true,
+      accounts: [{ exhausted: false, premiumWalled: true }],
+    })
+    expect(d.fire).toBe(false)
+  })
+
+  it('empty account list with a pending marker → no fire (nothing servable)', () => {
+    expect(decidePremiumRecovery({ hasMarker: true, accounts: [] }).fire).toBe(false)
+  })
+})
+
+describe('renderPremiumRecoveryPing — honest wording', () => {
+  it('names the model, says available again, and offers a session-scoped switch', () => {
+    const p = renderPremiumRecoveryPing('fable')
+    expect(p.text).toContain('`fable`')
+    expect(p.text.toLowerCase()).toContain('available again')
+    expect(p.text.toLowerCase()).toContain('this session')
+    expect(p.buttonText).toBe('Switch to fable')
+    // Must NOT over-promise a durable pin.
+    expect(p.text.toLowerCase()).not.toContain('permanently')
+    expect(p.text.toLowerCase()).not.toContain('forever')
+  })
+})
+
+describe('premiumRecoveryClaimKey', () => {
+  it('keys the dedup on agent + token so different drops never collide', () => {
+    expect(premiumRecoveryClaimKey('klanker', 'fable')).toBe('premium-recovery:klanker:fable')
+    expect(premiumRecoveryClaimKey('klanker', 'fable')).not.toBe(
+      premiumRecoveryClaimKey('klanker', 'opus'),
+    )
+  })
+})
+
+describe('.premium-recovery carrier — round-trip + shape gate', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'premium-recovery-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('write → read round-trips model + chats', () => {
+    writePremiumRecoveryFile(dir, 'fable', ['12345', '67890'])
+    const rec = readPremiumRecoveryFile(dir)
+    expect(rec?.premiumModel).toBe('fable')
+    expect(rec?.chats).toEqual(['12345', '67890'])
+    expect(typeof rec?.ts).toBe('number')
+  })
+
+  it('clear removes the marker', () => {
+    writePremiumRecoveryFile(dir, 'fable', ['12345'])
+    expect(existsSync(join(dir, PREMIUM_RECOVERY_FILE))).toBe(true)
+    clearPremiumRecoveryFile(dir)
+    expect(existsSync(join(dir, PREMIUM_RECOVERY_FILE))).toBe(false)
+    expect(readPremiumRecoveryFile(dir)).toBeNull()
+  })
+
+  it('refuses a non-canonical model token (shell-injection shape)', () => {
+    expect(() => writePremiumRecoveryFile(dir, 'bad name; rm -rf /', ['12345'])).toThrow()
+  })
+
+  it('refuses an empty chat list (a marker with nowhere to ping is a bug)', () => {
+    expect(() => writePremiumRecoveryFile(dir, 'fable', [])).toThrow()
+  })
+
+  it('parse rejects corrupt JSON / bad shape / bad token / empty chats', () => {
+    expect(parsePremiumRecovery('{broken')).toBeNull()
+    expect(parsePremiumRecovery(JSON.stringify({ premiumModel: 'fable', chats: [], ts: 1 }))).toBeNull()
+    expect(
+      parsePremiumRecovery(JSON.stringify({ premiumModel: 'bad;name', chats: ['1'], ts: 1 })),
+    ).toBeNull()
+    expect(
+      parsePremiumRecovery(JSON.stringify({ premiumModel: 'fable', chats: [1, 2], ts: 1 })),
+    ).toBeNull()
+    expect(parsePremiumRecovery(JSON.stringify({ premiumModel: 'fable', chats: ['1'] }))).toBeNull()
+  })
+
+  it('read returns null on a corrupt on-disk marker (never a half-parsed record)', () => {
+    writeFileSync(join(dir, PREMIUM_RECOVERY_FILE), '{not json\n')
+    expect(readPremiumRecoveryFile(dir)).toBeNull()
+  })
+})

--- a/telegram-plugin/tests/premium-recovery.test.ts
+++ b/telegram-plugin/tests/premium-recovery.test.ts
@@ -115,12 +115,14 @@ describe('.premium-recovery carrier — round-trip + shape gate', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('write → read round-trips model + chats', () => {
+  it('write → read round-trips model + chats (a VALID marker is NOT swept)', () => {
     writePremiumRecoveryFile(dir, 'fable', ['12345', '67890'])
     const rec = readPremiumRecoveryFile(dir)
     expect(rec?.premiumModel).toBe('fable')
     expect(rec?.chats).toEqual(['12345', '67890'])
     expect(typeof rec?.ts).toBe('number')
+    // A well-formed marker must survive a read — only corrupt files are swept.
+    expect(existsSync(join(dir, PREMIUM_RECOVERY_FILE))).toBe(true)
   })
 
   it('clear removes the marker', () => {
@@ -151,8 +153,13 @@ describe('.premium-recovery carrier — round-trip + shape gate', () => {
     expect(parsePremiumRecovery(JSON.stringify({ premiumModel: 'fable', chats: ['1'] }))).toBeNull()
   })
 
-  it('read returns null on a corrupt on-disk marker (never a half-parsed record)', () => {
+  it('read returns null on a corrupt on-disk marker AND sweeps the garbled file', () => {
     writeFileSync(join(dir, PREMIUM_RECOVERY_FILE), '{not json\n')
+    expect(existsSync(join(dir, PREMIUM_RECOVERY_FILE))).toBe(true)
     expect(readPremiumRecoveryFile(dir)).toBeNull()
+    // LOW-1: a corrupt marker is garbage-collected on read so it can't linger
+    // forever (neither the ping path nor the manual-switch clear could ever
+    // delete it — both read null first).
+    expect(existsSync(join(dir, PREMIUM_RECOVERY_FILE))).toBe(false)
   })
 })

--- a/telegram-plugin/tests/tier-downgrade-wiring.test.ts
+++ b/telegram-plugin/tests/tier-downgrade-wiring.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration test for the tier-downgrade GLUE (`runTierDowngrade`,
+ * tier-downgrade-wiring.ts) — the gateway orchestration the pure
+ * `decideTierDowngrade` / `renderTierDowngradeNotice` tests do NOT cover.
+ *
+ * This is the test the @overlord review asked for (the MEDIUM "reverts to
+ * fable" misinform slipped through precisely because the glue that emits the
+ * BROADCAST notice text had no test — only the pure renderer did). It drives
+ * the real runner with injected seams and PINS the broadcast notice:
+ *   - asserts the resume-on-DEFAULT wording + the manual re-issue instruction;
+ *   - FAILS on any revert-to-premium phrasing (the exact regression).
+ * It also covers the resume-gate suppression path and the carrier-before-arm
+ * ordering invariant.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  runTierDowngrade,
+  type TierDowngradeRunnerDeps,
+  type TierDowngradeOutcome,
+} from '../gateway/tier-downgrade-wiring.js'
+
+interface Recorder {
+  carrier: Array<{ dir: string; toModel: string; cfg: string }>
+  arms: number
+  markers: Array<{ dir: string; premiumModel: string }>
+  notices: string[]
+  restarts: string[]
+  logs: string[]
+}
+
+function makeDeps(
+  over: Partial<TierDowngradeRunnerDeps> & {
+    sessionOverride?: string | null
+    configuredDefault?: string | null
+    gateVerdict?: 'resume' | 'skip-inflight' | 'skip-stale'
+    carrierThrows?: boolean
+    markerThrows?: boolean
+    agentDir?: string | null
+  } = {},
+): { deps: TierDowngradeRunnerDeps; rec: Recorder } {
+  const rec: Recorder = { carrier: [], arms: 0, markers: [], notices: [], restarts: [], logs: [] }
+  // A near-identity resolver like the real resolveMainModel: the unset/`default`
+  // sentinel maps to the switchroom default, everything else is itself.
+  const resolve = (t: string): string => (t === '' || t === 'default' ? 'claude-opus-4-8' : t)
+  const deps: TierDowngradeRunnerDeps = {
+    getAgentDir: () => (over.agentDir === undefined ? '/tmp/agent' : over.agentDir),
+    getConfiguredDefault: () => (over.configuredDefault === undefined ? 'opus' : over.configuredDefault),
+    getSessionOverride: () => (over.sessionOverride === undefined ? 'fable' : over.sessionOverride),
+    resolve,
+    peekResumeGate: () => over.gateVerdict ?? 'resume',
+    writeCarrier: (dir, toModel, cfg) => {
+      if (over.carrierThrows) throw new Error('disk full')
+      rec.carrier.push({ dir, toModel, cfg })
+    },
+    armResumeGate: () => {
+      rec.arms += 1
+    },
+    writeRecoveryMarker: (dir, premiumModel) => {
+      if (over.markerThrows) throw new Error('marker write failed')
+      rec.markers.push({ dir, premiumModel })
+    },
+    broadcastNotice: (md) => rec.notices.push(md),
+    selfRestart: (agent) => rec.restarts.push(agent),
+    selfAgent: (t) => `self-${t}`,
+    log: (msg) => rec.logs.push(msg),
+    ...over,
+  }
+  return { deps, rec }
+}
+
+describe('runTierDowngrade — broadcast notice honesty (the pinned regression)', () => {
+  it('downgrade path broadcasts EXACTLY ONE notice with resume-on-default wording', () => {
+    const { deps, rec } = makeDeps({ sessionOverride: 'fable', configuredDefault: 'opus' })
+    const outcome: TierDowngradeOutcome = runTierDowngrade('klanker', deps)
+    expect(outcome).toBe('downgraded')
+    expect(rec.notices).toHaveLength(1)
+    const notice = rec.notices[0]
+    // Resume-on-DEFAULT + the manual re-issue instruction.
+    expect(notice).toContain('`opus`')
+    expect(notice).toContain('/model fable')
+    expect(notice.toLowerCase()).toContain("won't switch back on its own")
+  })
+
+  it('the notice NEVER promises a revert to the premium model (the MEDIUM regression)', () => {
+    const { deps, rec } = makeDeps({ sessionOverride: 'fable', configuredDefault: 'opus' })
+    runTierDowngrade('klanker', deps)
+    const notice = rec.notices[0].toLowerCase()
+    // The exact false phrasing from the pre-5d9bbf44 revision, and its kin.
+    expect(notice).not.toContain('reverts to `fable`')
+    expect(notice).not.toContain('revert to `fable`')
+    expect(notice).not.toMatch(/reverts? to fable/)
+    expect(notice).not.toMatch(/switch(es)? back.*on (the )?next restart/)
+    expect(notice).not.toMatch(/automatically.*(fable|premium)/)
+  })
+})
+
+describe('runTierDowngrade — side-effect ordering + outcomes', () => {
+  it('downgrade: carrier written BEFORE the arm, marker + notice + restart all fire', () => {
+    const { deps, rec } = makeDeps({ sessionOverride: 'fable', configuredDefault: 'opus' })
+    const outcome = runTierDowngrade('klanker', deps)
+    expect(outcome).toBe('downgraded')
+    expect(rec.carrier).toEqual([{ dir: '/tmp/agent', toModel: 'opus', cfg: 'opus' }])
+    expect(rec.arms).toBe(1)
+    expect(rec.markers).toEqual([{ dir: '/tmp/agent', premiumModel: 'fable' }])
+    expect(rec.restarts).toEqual(['self-klanker'])
+  })
+
+  it('carrier write THROWS → abort: NO arm, NO marker, NO notice, NO restart (skip)', () => {
+    const { deps, rec } = makeDeps({ carrierThrows: true })
+    const outcome = runTierDowngrade('klanker', deps)
+    expect(outcome).toBe('skip')
+    expect(rec.arms).toBe(0)
+    expect(rec.markers).toHaveLength(0)
+    expect(rec.notices).toHaveLength(0)
+    expect(rec.restarts).toHaveLength(0)
+  })
+
+  it('marker write THROWS → downgrade still completes (marker is best-effort)', () => {
+    const { deps, rec } = makeDeps({ markerThrows: true })
+    const outcome = runTierDowngrade('klanker', deps)
+    expect(outcome).toBe('downgraded')
+    expect(rec.arms).toBe(1)
+    expect(rec.notices).toHaveLength(1)
+    expect(rec.restarts).toEqual(['self-klanker'])
+    expect(rec.markers).toHaveLength(0)
+  })
+
+  it('resume-gate skip-inflight → restart-pending, NO notice, NO restart, NO carrier', () => {
+    const { deps, rec } = makeDeps({ gateVerdict: 'skip-inflight' })
+    const outcome = runTierDowngrade('klanker', deps)
+    expect(outcome).toBe('restart-pending')
+    expect(rec.carrier).toHaveLength(0)
+    expect(rec.arms).toBe(0)
+    expect(rec.notices).toHaveLength(0)
+    expect(rec.restarts).toHaveLength(0)
+  })
+
+  it('resume-gate skip-stale → skip (give up), NO notice/restart', () => {
+    const { deps, rec } = makeDeps({ gateVerdict: 'skip-stale' })
+    const outcome = runTierDowngrade('klanker', deps)
+    expect(outcome).toBe('skip')
+    expect(rec.notices).toHaveLength(0)
+    expect(rec.restarts).toHaveLength(0)
+  })
+
+  it('session on the configured default (override null) → skip, no downgrade', () => {
+    const { deps, rec } = makeDeps({ sessionOverride: null })
+    const outcome = runTierDowngrade('klanker', deps)
+    expect(outcome).toBe('skip')
+    expect(rec.notices).toHaveLength(0)
+  })
+
+  it('unresolved configured default → skip (never downgrade blind)', () => {
+    const { deps, rec } = makeDeps({ configuredDefault: '' })
+    const outcome = runTierDowngrade('klanker', deps)
+    expect(outcome).toBe('skip')
+    expect(rec.carrier).toHaveLength(0)
+  })
+
+  it('no agent dir → skip immediately', () => {
+    const { deps } = makeDeps({ agentDir: null })
+    expect(runTierDowngrade('klanker', deps)).toBe('skip')
+  })
+})

--- a/telegram-plugin/tests/tier-downgrade.test.ts
+++ b/telegram-plugin/tests/tier-downgrade.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for the MODEL-TIER downgrade failover (second recovery tier).
+ *
+ * The pure `decideTierDowngrade` owns the decision the gateway consults inside
+ * the `all-blocked` branch of doFireFleetAutoFallback — i.e. AFTER account-swap
+ * has been tried and found no account still serving the walled premium model.
+ * The deliverable outcomes it must guarantee:
+ *
+ *   - overload + the session is NOT on a premium model (override null, or the
+ *     override resolves to the configured default) → NO downgrade ('skip'); the
+ *     account-swap path already handled it or there is no lower tier to fall to.
+ *   - overload + a premium model walled across ALL accounts → 'downgrade' to the
+ *     configured default (the carrier target), with the loop-guard counter
+ *     incremented.
+ *   - loop guard: a SECOND consecutive downgrade-resume failure (a fresh
+ *     attempts record already at the cap) → 'exhausted' (name-the-turn-as-lost),
+ *     never a re-downgrade.
+ *   - a stale attempts record (older than staleMs) starts a FRESH chain so a
+ *     later INDEPENDENT interruption can downgrade again.
+ *
+ * The counter file (`.tier-downgrade-attempts`) round-trips via the FS helpers;
+ * it is DELIBERATELY a distinct name from `.session-model-boot-attempts` (which
+ * start.sh rm -f's every boot), so it survives the downgrade restart.
+ *
+ * Pure decision → fake clock, no process restart, no real FS for the decision
+ * cases; the file helpers use an isolated mkdtemp dir.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  decideTierDowngrade,
+  parseTierDowngradeAttempts,
+  serializeTierDowngradeAttempts,
+  readTierDowngradeAttempts,
+  writeTierDowngradeAttempts,
+  clearTierDowngradeAttempts,
+  TIER_DOWNGRADE_ATTEMPTS_FILE,
+  DEFAULT_MAX_TIER_DOWNGRADES,
+  DEFAULT_TIER_DOWNGRADE_STALE_MS,
+  type TierDowngradeAttempts,
+} from '../tier-downgrade.js'
+
+// The gateway passes resolveMainModel; here a near-identity resolver (maps the
+// unset/`default` sentinel to the switchroom default, exactly like the real one)
+// is enough to exercise the canonicalization guard.
+const resolve = (t: string): string =>
+  t === '' || t === 'default' ? 'claude-sonnet-5' : t
+
+const NOW = 1_800_000_000_000
+
+describe('decideTierDowngrade — precedence + downgrade target', () => {
+  it("NO downgrade when the session is on the configured default (override null)", () => {
+    // Overload + account-swap all-blocked, but nothing premium is active — the
+    // account-swap path owns this and there is no lower tier. => skip.
+    const d = decideTierDowngrade({
+      sessionOverride: null,
+      configuredDefault: 'opus',
+      resolve,
+      attempts: null,
+      now: NOW,
+    })
+    expect(d).toEqual({ action: 'skip', reason: 'on-default' })
+  })
+
+  it("NO downgrade when the override resolves to the configured default (alias vs id)", () => {
+    // A premium-looking override that is actually the default in another spelling
+    // must never read as a premium tier (that would loop). Same resolver both
+    // sides → on-default.
+    const d = decideTierDowngrade({
+      sessionOverride: 'default',
+      configuredDefault: 'claude-sonnet-5',
+      resolve,
+      attempts: null,
+      now: NOW,
+    })
+    expect(d).toEqual({ action: 'skip', reason: 'on-default' })
+  })
+
+  it('NO downgrade (and no blind fall) when the configured default is unreadable', () => {
+    const d = decideTierDowngrade({
+      sessionOverride: 'fable',
+      configuredDefault: null,
+      resolve,
+      attempts: null,
+      now: NOW,
+    })
+    expect(d).toEqual({ action: 'skip', reason: 'unresolved' })
+  })
+
+  it('DOWNGRADES a walled premium model to the configured default + arms the counter', () => {
+    const d = decideTierDowngrade({
+      sessionOverride: 'fable',
+      configuredDefault: 'opus',
+      resolve,
+      attempts: null,
+      now: NOW,
+    })
+    expect(d).toEqual({
+      action: 'downgrade',
+      toModel: 'opus',
+      fromModel: 'fable',
+      nextAttempts: { count: 1, premiumModel: 'fable', ts: NOW },
+    })
+  })
+
+  it('downgrade target is GENERAL — any premium model → the agent default (not hardcoded fable→opus)', () => {
+    const d = decideTierDowngrade({
+      sessionOverride: 'sr-x-ai/grok-4',
+      configuredDefault: 'claude-sonnet-5',
+      resolve,
+      attempts: null,
+      now: NOW,
+    })
+    expect(d.action).toBe('downgrade')
+    if (d.action === 'downgrade') {
+      expect(d.toModel).toBe('claude-sonnet-5')
+      expect(d.fromModel).toBe('sr-x-ai/grok-4')
+    }
+  })
+})
+
+describe('decideTierDowngrade — loop guard (names the turn as lost, no loop)', () => {
+  it("SECOND consecutive downgrade-resume failure → 'exhausted', no re-downgrade", () => {
+    // The first downgrade wrote count=1. Its resume died again with the premium
+    // model still walled and active → the budget (default 1) is spent.
+    const attempts: TierDowngradeAttempts = { count: 1, premiumModel: 'fable', ts: NOW - 5_000 }
+    const d = decideTierDowngrade({
+      sessionOverride: 'fable',
+      configuredDefault: 'opus',
+      resolve,
+      attempts,
+      now: NOW,
+    })
+    expect(d).toEqual({ action: 'exhausted', premiumModel: 'fable' })
+  })
+
+  it('a STALE attempts record starts a fresh chain (later independent interruption)', () => {
+    const attempts: TierDowngradeAttempts = {
+      count: DEFAULT_MAX_TIER_DOWNGRADES,
+      premiumModel: 'fable',
+      ts: NOW - DEFAULT_TIER_DOWNGRADE_STALE_MS - 1, // just past the window
+    }
+    const d = decideTierDowngrade({
+      sessionOverride: 'fable',
+      configuredDefault: 'opus',
+      resolve,
+      attempts,
+      now: NOW,
+    })
+    expect(d.action).toBe('downgrade')
+    if (d.action === 'downgrade') expect(d.nextAttempts.count).toBe(1)
+  })
+
+  it('honours a custom maxDowngrades cap', () => {
+    const attempts: TierDowngradeAttempts = { count: 1, premiumModel: 'fable', ts: NOW }
+    const d = decideTierDowngrade({
+      sessionOverride: 'fable',
+      configuredDefault: 'opus',
+      resolve,
+      attempts,
+      now: NOW,
+      maxDowngrades: 2,
+    })
+    expect(d.action).toBe('downgrade')
+    if (d.action === 'downgrade') expect(d.nextAttempts.count).toBe(2)
+  })
+})
+
+describe('.tier-downgrade-attempts counter file', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'switchroom-tier-downgrade-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('is a DISTINCT filename from the retired .session-model-boot-attempts', () => {
+    // The historical loop-guard file is rm -f'd by start.sh every boot, so it
+    // cannot survive a restart — this guard must use its own name.
+    expect(TIER_DOWNGRADE_ATTEMPTS_FILE).toBe('.tier-downgrade-attempts')
+    expect(TIER_DOWNGRADE_ATTEMPTS_FILE).not.toBe('.session-model-boot-attempts')
+  })
+
+  it('write → read round-trips', () => {
+    const rec: TierDowngradeAttempts = { count: 1, premiumModel: 'fable', ts: NOW }
+    writeTierDowngradeAttempts(dir, rec)
+    expect(existsSync(join(dir, TIER_DOWNGRADE_ATTEMPTS_FILE))).toBe(true)
+    expect(readTierDowngradeAttempts(dir)).toEqual(rec)
+    // one line + trailing newline, matching the session-model carrier shape.
+    const onDisk = readFileSync(join(dir, TIER_DOWNGRADE_ATTEMPTS_FILE), 'utf8')
+    expect(onDisk.endsWith('\n')).toBe(true)
+    expect(onDisk.trimEnd().split('\n')).toHaveLength(1)
+  })
+
+  it('read of an absent file → null', () => {
+    expect(readTierDowngradeAttempts(dir)).toBeNull()
+  })
+
+  it('corrupt / bad-shape content → null (never trusted)', () => {
+    writeFileSync(join(dir, TIER_DOWNGRADE_ATTEMPTS_FILE), '{not json\n')
+    expect(readTierDowngradeAttempts(dir)).toBeNull()
+    writeFileSync(
+      join(dir, TIER_DOWNGRADE_ATTEMPTS_FILE),
+      JSON.stringify({ count: 'x', premiumModel: 'fable', ts: NOW }) + '\n',
+    )
+    expect(readTierDowngradeAttempts(dir)).toBeNull()
+    expect(parseTierDowngradeAttempts('{"count":-1,"premiumModel":"f","ts":1}')).toBeNull()
+  })
+
+  it('clear removes the file (best-effort, idempotent)', () => {
+    writeTierDowngradeAttempts(dir, { count: 1, premiumModel: 'fable', ts: NOW })
+    clearTierDowngradeAttempts(dir)
+    expect(existsSync(join(dir, TIER_DOWNGRADE_ATTEMPTS_FILE))).toBe(false)
+    // idempotent — no throw on a second clear
+    expect(() => clearTierDowngradeAttempts(dir)).not.toThrow()
+  })
+
+  it('serialize is stable field order', () => {
+    expect(serializeTierDowngradeAttempts({ count: 2, premiumModel: 'sr-glm-5', ts: 7 })).toBe(
+      '{"count":2,"premiumModel":"sr-glm-5","ts":7}\n',
+    )
+  })
+})

--- a/telegram-plugin/tests/tier-downgrade.test.ts
+++ b/telegram-plugin/tests/tier-downgrade.test.ts
@@ -4,43 +4,33 @@
  * The pure `decideTierDowngrade` owns the decision the gateway consults inside
  * the `all-blocked` branch of doFireFleetAutoFallback — i.e. AFTER account-swap
  * has been tried and found no account still serving the walled premium model.
- * The deliverable outcomes it must guarantee:
+ * `planTierDowngrade` then routes that decision + the resume-gate verdict into
+ * what the gateway should DO (downgrade / suppress the give-up / fall through),
+ * and `renderTierDowngradeNotice` owns the exact user-facing wording. All three
+ * are pure so the decision, the concurrent-turn suppression (LOW-9a), and the
+ * honesty of the broadcast (no "revert to the premium model" promise) are pinned
+ * without a process restart.
  *
+ * Contract (post loop-guard reconciliation, option b — the ceremonial
+ * `.tier-downgrade-attempts` counter was REMOVED):
  *   - overload + the session is NOT on a premium model (override null, or the
  *     override resolves to the configured default) → NO downgrade ('skip'); the
  *     account-swap path already handled it or there is no lower tier to fall to.
+ *     This is also the natural loop bound: after the downgrade boot the override
+ *     is gone, so a re-entry lands on 'on-default' and never re-downgrades.
  *   - overload + a premium model walled across ALL accounts → 'downgrade' to the
- *     configured default (the carrier target), with the loop-guard counter
- *     incremented.
- *   - loop guard: a SECOND consecutive downgrade-resume failure (a fresh
- *     attempts record already at the cap) → 'exhausted' (name-the-turn-as-lost),
- *     never a re-downgrade.
- *   - a stale attempts record (older than staleMs) starts a FRESH chain so a
- *     later INDEPENDENT interruption can downgrade again.
- *
- * The counter file (`.tier-downgrade-attempts`) round-trips via the FS helpers;
- * it is DELIBERATELY a distinct name from `.session-model-boot-attempts` (which
- * start.sh rm -f's every boot), so it survives the downgrade restart.
- *
- * Pure decision → fake clock, no process restart, no real FS for the decision
- * cases; the file helpers use an isolated mkdtemp dir.
+ *     configured default.
+ *   - a resume restart already armed in this process (gate 'skip-inflight') →
+ *     'suppress': no give-up card, no re-downgrade (the armed restart resumes).
+ *   - the downgrade broadcast states resume-on-default + manual re-issue and
+ *     carries NO promise of an automatic revert to the premium model.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
-import { tmpdir } from 'node:os'
+import { describe, it, expect } from 'vitest'
 import {
   decideTierDowngrade,
-  parseTierDowngradeAttempts,
-  serializeTierDowngradeAttempts,
-  readTierDowngradeAttempts,
-  writeTierDowngradeAttempts,
-  clearTierDowngradeAttempts,
-  TIER_DOWNGRADE_ATTEMPTS_FILE,
-  DEFAULT_MAX_TIER_DOWNGRADES,
-  DEFAULT_TIER_DOWNGRADE_STALE_MS,
-  type TierDowngradeAttempts,
+  planTierDowngrade,
+  renderTierDowngradeNotice,
 } from '../tier-downgrade.js'
 
 // The gateway passes resolveMainModel; here a near-identity resolver (maps the
@@ -49,23 +39,15 @@ import {
 const resolve = (t: string): string =>
   t === '' || t === 'default' ? 'claude-sonnet-5' : t
 
-const NOW = 1_800_000_000_000
-
 describe('decideTierDowngrade — precedence + downgrade target', () => {
-  it("NO downgrade when the session is on the configured default (override null)", () => {
+  it('NO downgrade when the session is on the configured default (override null)', () => {
     // Overload + account-swap all-blocked, but nothing premium is active — the
     // account-swap path owns this and there is no lower tier. => skip.
-    const d = decideTierDowngrade({
-      sessionOverride: null,
-      configuredDefault: 'opus',
-      resolve,
-      attempts: null,
-      now: NOW,
-    })
+    const d = decideTierDowngrade({ sessionOverride: null, configuredDefault: 'opus', resolve })
     expect(d).toEqual({ action: 'skip', reason: 'on-default' })
   })
 
-  it("NO downgrade when the override resolves to the configured default (alias vs id)", () => {
+  it('NO downgrade when the override resolves to the configured default (alias vs id)', () => {
     // A premium-looking override that is actually the default in another spelling
     // must never read as a premium tier (that would loop). Same resolver both
     // sides → on-default.
@@ -73,37 +55,18 @@ describe('decideTierDowngrade — precedence + downgrade target', () => {
       sessionOverride: 'default',
       configuredDefault: 'claude-sonnet-5',
       resolve,
-      attempts: null,
-      now: NOW,
     })
     expect(d).toEqual({ action: 'skip', reason: 'on-default' })
   })
 
   it('NO downgrade (and no blind fall) when the configured default is unreadable', () => {
-    const d = decideTierDowngrade({
-      sessionOverride: 'fable',
-      configuredDefault: null,
-      resolve,
-      attempts: null,
-      now: NOW,
-    })
+    const d = decideTierDowngrade({ sessionOverride: 'fable', configuredDefault: null, resolve })
     expect(d).toEqual({ action: 'skip', reason: 'unresolved' })
   })
 
-  it('DOWNGRADES a walled premium model to the configured default + arms the counter', () => {
-    const d = decideTierDowngrade({
-      sessionOverride: 'fable',
-      configuredDefault: 'opus',
-      resolve,
-      attempts: null,
-      now: NOW,
-    })
-    expect(d).toEqual({
-      action: 'downgrade',
-      toModel: 'opus',
-      fromModel: 'fable',
-      nextAttempts: { count: 1, premiumModel: 'fable', ts: NOW },
-    })
+  it('DOWNGRADES a walled premium model to the configured default', () => {
+    const d = decideTierDowngrade({ sessionOverride: 'fable', configuredDefault: 'opus', resolve })
+    expect(d).toEqual({ action: 'downgrade', toModel: 'opus', fromModel: 'fable' })
   })
 
   it('downgrade target is GENERAL — any premium model → the agent default (not hardcoded fable→opus)', () => {
@@ -111,117 +74,68 @@ describe('decideTierDowngrade — precedence + downgrade target', () => {
       sessionOverride: 'sr-x-ai/grok-4',
       configuredDefault: 'claude-sonnet-5',
       resolve,
-      attempts: null,
-      now: NOW,
     })
-    expect(d.action).toBe('downgrade')
-    if (d.action === 'downgrade') {
-      expect(d.toModel).toBe('claude-sonnet-5')
-      expect(d.fromModel).toBe('sr-x-ai/grok-4')
-    }
+    expect(d).toEqual({ action: 'downgrade', toModel: 'claude-sonnet-5', fromModel: 'sr-x-ai/grok-4' })
   })
 })
 
-describe('decideTierDowngrade — loop guard (names the turn as lost, no loop)', () => {
-  it("SECOND consecutive downgrade-resume failure → 'exhausted', no re-downgrade", () => {
-    // The first downgrade wrote count=1. Its resume died again with the premium
-    // model still walled and active → the budget (default 1) is spent.
-    const attempts: TierDowngradeAttempts = { count: 1, premiumModel: 'fable', ts: NOW - 5_000 }
-    const d = decideTierDowngrade({
-      sessionOverride: 'fable',
-      configuredDefault: 'opus',
-      resolve,
-      attempts,
-      now: NOW,
-    })
-    expect(d).toEqual({ action: 'exhausted', premiumModel: 'fable' })
+describe('renderTierDowngradeNotice — HONEST wording (no revert-to-premium promise)', () => {
+  const notice = renderTierDowngradeNotice('fable', 'opus', 'klanker')
+
+  it('states the turn resumes on the DEFAULT to keep working', () => {
+    expect(notice).toContain('opus')
+    expect(notice.toLowerCase()).toContain('resuming on the default')
   })
 
-  it('a STALE attempts record starts a fresh chain (later independent interruption)', () => {
-    const attempts: TierDowngradeAttempts = {
-      count: DEFAULT_MAX_TIER_DOWNGRADES,
-      premiumModel: 'fable',
-      ts: NOW - DEFAULT_TIER_DOWNGRADE_STALE_MS - 1, // just past the window
-    }
-    const d = decideTierDowngrade({
-      sessionOverride: 'fable',
-      configuredDefault: 'opus',
-      resolve,
-      attempts,
-      now: NOW,
-    })
-    expect(d.action).toBe('downgrade')
-    if (d.action === 'downgrade') expect(d.nextAttempts.count).toBe(1)
+  it('tells the user to RE-ISSUE the premium /model themselves', () => {
+    expect(notice).toContain('/model fable')
+    expect(notice.toLowerCase()).toContain("won't switch back on its own")
   })
 
-  it('honours a custom maxDowngrades cap', () => {
-    const attempts: TierDowngradeAttempts = { count: 1, premiumModel: 'fable', ts: NOW }
-    const d = decideTierDowngrade({
-      sessionOverride: 'fable',
-      configuredDefault: 'opus',
-      resolve,
-      attempts,
-      now: NOW,
-      maxDowngrades: 2,
-    })
-    expect(d.action).toBe('downgrade')
-    if (d.action === 'downgrade') expect(d.nextAttempts.count).toBe(2)
+  it("carries NO promise of an automatic revert to the premium/fable model", () => {
+    // The HIGH finding: the prior wording lied ("It reverts to `fable` on the
+    // next restart"). Assert none of those false promises can creep back.
+    const lower = notice.toLowerCase()
+    expect(lower).not.toMatch(/reverts? to `?fable/)
+    expect(lower).not.toContain('reverts to `fable`')
+    expect(lower).not.toContain('on the next restart')
+    expect(lower).not.toMatch(/revert(s|ing)? to the premium/)
+    expect(lower).not.toMatch(/back to `?fable`? (on|at|after)/)
   })
 })
 
-describe('.tier-downgrade-attempts counter file', () => {
-  let dir: string
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), 'switchroom-tier-downgrade-'))
-  })
-  afterEach(() => {
-    rmSync(dir, { recursive: true, force: true })
+describe('planTierDowngrade — routing (downgrade / suppress / skip)', () => {
+  const skipDecision = { action: 'skip', reason: 'on-default' } as const
+  const downgradeDecision = { action: 'downgrade', toModel: 'opus', fromModel: 'fable' } as const
+
+  it("a 'skip' decision routes to 'skip' regardless of the gate verdict", () => {
+    expect(planTierDowngrade(skipDecision, 'resume', 'ag').kind).toBe('skip')
+    expect(planTierDowngrade(skipDecision, 'skip-inflight', 'ag').kind).toBe('skip')
+    expect(planTierDowngrade(skipDecision, 'skip-stale', 'ag').kind).toBe('skip')
   })
 
-  it('is a DISTINCT filename from the retired .session-model-boot-attempts', () => {
-    // The historical loop-guard file is rm -f'd by start.sh every boot, so it
-    // cannot survive a restart — this guard must use its own name.
-    expect(TIER_DOWNGRADE_ATTEMPTS_FILE).toBe('.tier-downgrade-attempts')
-    expect(TIER_DOWNGRADE_ATTEMPTS_FILE).not.toBe('.session-model-boot-attempts')
+  it("downgrade + gate 'resume' → 'downgrade' with the honest notice", () => {
+    const plan = planTierDowngrade(downgradeDecision, 'resume', 'klanker')
+    expect(plan.kind).toBe('downgrade')
+    if (plan.kind === 'downgrade') {
+      expect(plan.toModel).toBe('opus')
+      expect(plan.fromModel).toBe('fable')
+      // The plan carries EXACTLY the honest renderer output — no revert promise.
+      expect(plan.notice).toBe(renderTierDowngradeNotice('fable', 'opus', 'klanker'))
+      expect(plan.notice.toLowerCase()).not.toContain('on the next restart')
+    }
   })
 
-  it('write → read round-trips', () => {
-    const rec: TierDowngradeAttempts = { count: 1, premiumModel: 'fable', ts: NOW }
-    writeTierDowngradeAttempts(dir, rec)
-    expect(existsSync(join(dir, TIER_DOWNGRADE_ATTEMPTS_FILE))).toBe(true)
-    expect(readTierDowngradeAttempts(dir)).toEqual(rec)
-    // one line + trailing newline, matching the session-model carrier shape.
-    const onDisk = readFileSync(join(dir, TIER_DOWNGRADE_ATTEMPTS_FILE), 'utf8')
-    expect(onDisk.endsWith('\n')).toBe(true)
-    expect(onDisk.trimEnd().split('\n')).toHaveLength(1)
+  it("LOW-9a: downgrade + gate 'skip-inflight' → 'suppress' (a resume restart is already armed, no give-up card)", () => {
+    // Two turns hit all-blocked in the same pre-restart process. Turn 1 armed a
+    // downgrade (or account-swap) restart. Turn 2 must NOT broadcast a "could
+    // not be recovered" give-up — the armed restart resumes the interrupted turn.
+    const plan = planTierDowngrade(downgradeDecision, 'skip-inflight', 'klanker')
+    expect(plan.kind).toBe('suppress')
   })
 
-  it('read of an absent file → null', () => {
-    expect(readTierDowngradeAttempts(dir)).toBeNull()
-  })
-
-  it('corrupt / bad-shape content → null (never trusted)', () => {
-    writeFileSync(join(dir, TIER_DOWNGRADE_ATTEMPTS_FILE), '{not json\n')
-    expect(readTierDowngradeAttempts(dir)).toBeNull()
-    writeFileSync(
-      join(dir, TIER_DOWNGRADE_ATTEMPTS_FILE),
-      JSON.stringify({ count: 'x', premiumModel: 'fable', ts: NOW }) + '\n',
-    )
-    expect(readTierDowngradeAttempts(dir)).toBeNull()
-    expect(parseTierDowngradeAttempts('{"count":-1,"premiumModel":"f","ts":1}')).toBeNull()
-  })
-
-  it('clear removes the file (best-effort, idempotent)', () => {
-    writeTierDowngradeAttempts(dir, { count: 1, premiumModel: 'fable', ts: NOW })
-    clearTierDowngradeAttempts(dir)
-    expect(existsSync(join(dir, TIER_DOWNGRADE_ATTEMPTS_FILE))).toBe(false)
-    // idempotent — no throw on a second clear
-    expect(() => clearTierDowngradeAttempts(dir)).not.toThrow()
-  })
-
-  it('serialize is stable field order', () => {
-    expect(serializeTierDowngradeAttempts({ count: 2, premiumModel: 'sr-glm-5', ts: 7 })).toBe(
-      '{"count":2,"premiumModel":"sr-glm-5","ts":7}\n',
-    )
+  it("downgrade + gate 'skip-stale' → 'skip' (turn too old to resume; fall through to the all-blocked card)", () => {
+    const plan = planTierDowngrade(downgradeDecision, 'skip-stale', 'klanker')
+    expect(plan.kind).toBe('skip')
   })
 })

--- a/telegram-plugin/tier-downgrade.ts
+++ b/telegram-plugin/tier-downgrade.ts
@@ -19,83 +19,52 @@
  * so a premium model that is merely throttled on ONE account is recovered by
  * account-swap, never by a downgrade.
  *
- * Revert is NATIVE (do not fight it). The downgrade writes a CONSUME-ONCE
- * `.session-model` carrier for the configured default
- * (reference/rfcs/session-model-stickiness.md §0.1 rev 4): start.sh applies it
- * on the single boot that reads it, deletes it, and every SUBSEQUENT restart
- * reverts to the configured default for free. The premium /model override was
- * itself session-scoped (a live Claude switch writes no carrier), so the
- * downgrade boot naturally lands on the configured default; writing the carrier
- * makes that DETERMINISTIC even if a stray carrier is on disk.
+ * There is NO automatic return to the premium model. The `/model` override is
+ * SESSION-SCOPED and in-memory only (`recordTypedModelSwitch` writes NO carrier
+ * — reference/rfcs/session-model-stickiness.md §0.1 rev 4), so it dies on the
+ * downgrade SIGTERM. The downgrade writes a consume-once `.session-model`
+ * carrier for the CONFIGURED DEFAULT: start.sh applies+deletes it on the resume
+ * boot, and every subsequent restart boots the configured default too. The
+ * premium model is never restored on its own — the user must re-issue
+ * `/model <premium>` once it frees up. The user-facing notice
+ * (`renderTierDowngradeNotice`) says exactly that; it must NOT promise any
+ * revert to the premium tier.
  *
- * Effort is NATIVE too. A live `/effort` override records in gateway memory
- * only (no carrier), so the self-restart sheds it and the downgraded default
- * boots at the configured `thinking_effort` (the fleet `low` pin, #1978 /
+ * Effort is NATIVE. A live `/effort` override records in gateway memory only
+ * (no carrier), so the self-restart sheds it and the downgraded default boots at
+ * the configured `thinking_effort` (the fleet `low` pin, #1978 /
  * src/config/thinking-effort-risk.ts). This module writes NO effort carrier —
  * that is the whole point: the downgraded opus must resolve LOW.
  *
- * Loop guard (survives restart). The gate is bounded so a turn that dies AGAIN
- * during its own downgrade-resume is named-as-lost rather than looped forever:
- *   - The natural guard: after the downgrade boot the session is ON the
- *     configured default (override null), so a second `all-blocked` finds no
- *     premium tier and `decide()` returns `skip` — no re-downgrade.
- *   - The belt-and-suspenders guard: a restart-surviving
- *     `.tier-downgrade-attempts` counter caps consecutive downgrades per
- *     interruption chain (default 1). A record older than `staleMs` starts a
- *     fresh chain, so a later INDEPENDENT interruption can downgrade again.
+ * Loop guard — the natural on-default guard is the real bound. After the
+ * downgrade boot the session runs the configured default (the override is gone
+ * with the restart), so a second `all-blocked` finds no premium tier and
+ * `decide()` returns `skip` ('on-default') — the turn never re-downgrades. If
+ * the DEFAULT is itself walled fleet-wide on the resume boot, `decide()` still
+ * returns `skip` and the gateway falls through to its normal all-blocked card;
+ * there is no restart loop. Cross-restart pacing is additionally bounded by the
+ * broker-side persisted account exhaustion (see fleet-fallback-resume.ts).
  *
- * NB — carrier-name choice. The in-memory single-flight latch in
- * fleet-fallback-resume.ts does NOT survive the restart, and the historical
- * `.session-model-boot-attempts` filename is UNUSABLE as a boot-surviving guard
- * on current main: start.sh unconditionally `rm -f`s it every boot (retired
- * with the rev-3 crashloop self-heal, session-model-stickiness.md §0.1). So the
- * loop guard uses a DISTINCT file, `.tier-downgrade-attempts`, that start.sh
- * never touches — the durable equivalent of the premise's intent.
+ * Concurrent-turn race (single process, pre-restart): if a first turn already
+ * armed a resume restart (a downgrade OR an account-swap), a second turn that
+ * also hits `all-blocked` must NOT emit a give-up card — the armed restart will
+ * replay the latest interrupted turn. `planTierDowngrade` maps a `skip-inflight`
+ * resume-gate verdict to `suppress` for exactly this reason (no re-downgrade, no
+ * contradictory "could not be recovered" message).
  *
- * This module is pure at its core (`decideTierDowngrade`) so the decision is
- * unit-testable without a process restart; the small FS helpers for the counter
- * file live here too (they mirror session-model-file.ts's shape).
+ * This module is pure (`decideTierDowngrade` / `planTierDowngrade` /
+ * `renderTierDowngradeNotice`) so the decision, the give-up suppression, and the
+ * user-facing wording are all unit-testable without a process restart; the
+ * gateway does the FS write, the latch arm, and the restart off these verdicts.
  */
-
-import { readFileSync, writeFileSync, renameSync, rmSync } from 'node:fs'
-import { join } from 'node:path'
-
-export const TIER_DOWNGRADE_ATTEMPTS_FILE = '.tier-downgrade-attempts'
-
-/** Consecutive downgrades allowed per interruption chain. The 2nd consecutive
- *  downgrade-resume failure is named-as-lost, never attempted. */
-export const DEFAULT_MAX_TIER_DOWNGRADES = 1
-
-/** An attempts record older than this is a FRESH chain (a later independent
- *  interruption), not a continuation of a storm. Comfortably longer than a
- *  restart + boot-resume cycle so a genuine loop (which cycles in seconds) is
- *  always caught, while an unrelated overload minutes later can downgrade
- *  again. */
-export const DEFAULT_TIER_DOWNGRADE_STALE_MS = 600_000 // 10 min
-
-export interface TierDowngradeAttempts {
-  /** Number of downgrades fired in the current chain. */
-  count: number
-  /** The premium model that was walled when the chain started (observability). */
-  premiumModel: string
-  /** Wall-clock ms of the most recent downgrade in the chain. */
-  ts: number
-}
 
 export type TierDowngradeDecision =
   | {
-      /** Fire the downgrade: write a consume-once carrier for `toModel`, persist
-       *  `nextAttempts`, and self-restart to resume the dead turn. */
+      /** Fire the downgrade: write a consume-once carrier for `toModel` and
+       *  self-restart to resume the dead turn on the configured default. */
       action: 'downgrade'
       toModel: string
       fromModel: string
-      nextAttempts: TierDowngradeAttempts
-    }
-  | {
-      /** The downgrade budget is spent for this chain — name the turn as lost
-       *  (surface to the operator) and do NOT restart. */
-      action: 'exhausted'
-      premiumModel: string
     }
   | {
       /** No downgrade is warranted. `on-default`: the session is already on the
@@ -120,14 +89,6 @@ export interface TierDowngradeInput {
    *  spuriously reading as a premium tier over a `claude-opus-*`-shaped default
    *  and vice versa, as far as the resolver can. */
   resolve: (token: string) => string
-  /** The parsed `.tier-downgrade-attempts` counter, or null when absent/corrupt. */
-  attempts: TierDowngradeAttempts | null
-  /** Now, epoch ms. */
-  now: number
-  /** Override the staleness window (tests). */
-  staleMs?: number
-  /** Override the per-chain downgrade cap (tests). */
-  maxDowngrades?: number
 }
 
 /**
@@ -136,9 +97,6 @@ export interface TierDowngradeInput {
  * off this verdict.
  */
 export function decideTierDowngrade(input: TierDowngradeInput): TierDowngradeDecision {
-  const staleMs = input.staleMs ?? DEFAULT_TIER_DOWNGRADE_STALE_MS
-  const maxDowngrades = input.maxDowngrades ?? DEFAULT_MAX_TIER_DOWNGRADES
-
   const configured =
     typeof input.configuredDefault === 'string' ? input.configuredDefault.trim() : ''
   if (configured.length === 0) {
@@ -148,7 +106,9 @@ export function decideTierDowngrade(input: TierDowngradeInput): TierDowngradeDec
 
   const override = input.sessionOverride
   if (override == null || override.length === 0) {
-    // On the configured default already — no lower tier to fall to.
+    // On the configured default already — no lower tier to fall to. This is also
+    // the natural loop bound: after the downgrade boot the override is gone, so a
+    // re-entry lands here and never re-downgrades.
     return { action: 'skip', reason: 'on-default' }
   }
 
@@ -158,80 +118,81 @@ export function decideTierDowngrade(input: TierDowngradeInput): TierDowngradeDec
     return { action: 'skip', reason: 'on-default' }
   }
 
-  // A premium model is active AND walled fleet-wide. Consult the loop guard.
-  const fresh = input.attempts != null && input.now - input.attempts.ts <= staleMs
-    ? input.attempts
-    : null
-  const priorCount = fresh?.count ?? 0
-  if (priorCount >= maxDowngrades) {
-    // Already downgraded this chain and it died again → name-as-lost.
-    return { action: 'exhausted', premiumModel: override }
-  }
-
-  return {
-    action: 'downgrade',
-    toModel: configured,
-    fromModel: override,
-    nextAttempts: { count: priorCount + 1, premiumModel: override, ts: input.now },
-  }
+  // A premium model is active AND walled fleet-wide → downgrade to the default.
+  return { action: 'downgrade', toModel: configured, fromModel: override }
 }
 
-// ─── `.tier-downgrade-attempts` counter file (restart-surviving loop guard) ──
-//
-// Deliberately NOT `.session-model-boot-attempts`: start.sh `rm -f`s that name
-// every boot (retired rev-4 hygiene), so it cannot survive a restart. This file
-// is untouched by start.sh — the gateway is its only reader/writer.
+/**
+ * The user-facing broadcast for a fired downgrade. PURE + deterministic so the
+ * wording is pinned by a test.
+ *
+ * HONESTY CONTRACT (do not regress): it states the turn resumes on the DEFAULT
+ * and that the user must RE-ISSUE `/model <premium>` to get the premium tier
+ * back. It must NOT claim any automatic revert to the premium model — there is
+ * none (the override is session-scoped and dies on the downgrade restart).
+ */
+export function renderTierDowngradeNotice(
+  fromModel: string,
+  toModel: string,
+  agent: string,
+): string {
+  return (
+    `⤵️ **Downgrading model to keep going** on agent **${agent}**\n` +
+    `\`${fromModel}\` is overloaded across every account right now, so this turn is ` +
+    `resuming on the default \`${toModel}\` to keep working. ` +
+    `Re-issue \`/model ${fromModel}\` once it frees up — it won't switch back on its own.`
+  )
+}
 
-/** Parse the counter file. Null on corrupt JSON or a bad shape. */
-export function parseTierDowngradeAttempts(text: string): TierDowngradeAttempts | null {
-  try {
-    const raw = JSON.parse(text) as Partial<TierDowngradeAttempts>
-    if (
-      typeof raw.count !== 'number' ||
-      !Number.isFinite(raw.count) ||
-      raw.count < 0 ||
-      typeof raw.premiumModel !== 'string' ||
-      typeof raw.ts !== 'number' ||
-      !Number.isFinite(raw.ts)
-    ) {
-      return null
+/** The resume-gate verdict the gateway feeds `planTierDowngrade` (mirrors
+ *  `ResumeDecision` from fleet-fallback-resume.ts, peeked WITHOUT arming). */
+export type ResumeGateVerdict = 'resume' | 'skip-inflight' | 'skip-stale'
+
+export type TierDowngradePlan =
+  | {
+      /** Fire the downgrade: write the carrier, arm the latch, broadcast
+       *  `notice`, and self-restart. */
+      kind: 'downgrade'
+      toModel: string
+      fromModel: string
+      notice: string
     }
-    return { count: raw.count, premiumModel: raw.premiumModel, ts: raw.ts }
-  } catch {
-    return null
-  }
-}
+  | {
+      /** A resume restart is ALREADY armed in this process (a concurrent turn's
+       *  downgrade or account-swap) — emit NO give-up card; the armed restart
+       *  replays the interrupted turn. */
+      kind: 'suppress'
+    }
+  | {
+      /** No downgrade; caller falls through to its normal all-blocked card. */
+      kind: 'skip'
+    }
 
-export function serializeTierDowngradeAttempts(rec: TierDowngradeAttempts): string {
-  return `${JSON.stringify({ count: rec.count, premiumModel: rec.premiumModel, ts: rec.ts })}\n`
-}
-
-function atomicWrite(path: string, content: string): void {
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`
-  writeFileSync(tmp, content, 'utf8')
-  renameSync(tmp, path)
-}
-
-/** Read + parse the counter for `agentDir`, or null when absent/corrupt. */
-export function readTierDowngradeAttempts(agentDir: string): TierDowngradeAttempts | null {
-  try {
-    const raw = readFileSync(join(agentDir, TIER_DOWNGRADE_ATTEMPTS_FILE), 'utf8')
-    return parseTierDowngradeAttempts(raw)
-  } catch {
-    return null
-  }
-}
-
-/** Persist the counter BEFORE the downgrade restart (it must survive the boot). */
-export function writeTierDowngradeAttempts(agentDir: string, rec: TierDowngradeAttempts): void {
-  atomicWrite(join(agentDir, TIER_DOWNGRADE_ATTEMPTS_FILE), serializeTierDowngradeAttempts(rec))
-}
-
-/** Clear the counter (a fresh chain / recovery). Best-effort. */
-export function clearTierDowngradeAttempts(agentDir: string): void {
-  try {
-    rmSync(join(agentDir, TIER_DOWNGRADE_ATTEMPTS_FILE), { force: true })
-  } catch {
-    /* best-effort */
+/**
+ * Pure orchestration off the (pure) decision + the resume-gate verdict. Keeps
+ * the concurrent-turn suppression (LOW-9a) and the give-up/fall-through routing
+ * testable without a live gateway.
+ *
+ *   - decision `skip`               → `skip` (fall through to the all-blocked card)
+ *   - decision `downgrade`, gate `skip-inflight`
+ *                                   → `suppress` (a restart is already armed)
+ *   - decision `downgrade`, gate `skip-stale`
+ *                                   → `skip` (turn too old to resume; give up)
+ *   - decision `downgrade`, gate `resume`
+ *                                   → `downgrade` (carry the honest notice)
+ */
+export function planTierDowngrade(
+  decision: TierDowngradeDecision,
+  gateVerdict: ResumeGateVerdict,
+  agent: string,
+): TierDowngradePlan {
+  if (decision.action !== 'downgrade') return { kind: 'skip' }
+  if (gateVerdict === 'skip-inflight') return { kind: 'suppress' }
+  if (gateVerdict === 'skip-stale') return { kind: 'skip' }
+  return {
+    kind: 'downgrade',
+    toModel: decision.toModel,
+    fromModel: decision.fromModel,
+    notice: renderTierDowngradeNotice(decision.fromModel, decision.toModel, agent),
   }
 }

--- a/telegram-plugin/tier-downgrade.ts
+++ b/telegram-plugin/tier-downgrade.ts
@@ -1,0 +1,237 @@
+/**
+ * tier-downgrade.ts — MODEL-TIER downgrade failover (second recovery tier).
+ *
+ * The problem this owns:
+ *   A user selects a premium model (e.g. `/model fable`). Mid-turn that model
+ *   is overloaded / throttled fleet-wide (HTTP 529 / 429 / overloaded_error /
+ *   503). The FIRST recovery tier — account-level failover (swap the OAuth
+ *   account, same model) — is tried first and already exists
+ *   (`runFleetAutoFallback` → `doFireFleetAutoFallback`). When that comes back
+ *   `all-blocked` (no account still serves the premium model), the live turn
+ *   would otherwise stall silently. This module adds a SECOND, lower-priority
+ *   tier: DOWNGRADE the session to the agent's configured default model (the
+ *   fleet default is `opus`) and resume, so the turn keeps moving.
+ *
+ * Precedence (HARD): account-swap FIRST. The gateway only consults this module
+ * inside the `all-blocked` branch of `doFireFleetAutoFallback` — i.e. AFTER
+ * account-swap has been tried and found no eligible account. A `switched`
+ * outcome never reaches here (the existing resume-after-swap path handles it),
+ * so a premium model that is merely throttled on ONE account is recovered by
+ * account-swap, never by a downgrade.
+ *
+ * Revert is NATIVE (do not fight it). The downgrade writes a CONSUME-ONCE
+ * `.session-model` carrier for the configured default
+ * (reference/rfcs/session-model-stickiness.md §0.1 rev 4): start.sh applies it
+ * on the single boot that reads it, deletes it, and every SUBSEQUENT restart
+ * reverts to the configured default for free. The premium /model override was
+ * itself session-scoped (a live Claude switch writes no carrier), so the
+ * downgrade boot naturally lands on the configured default; writing the carrier
+ * makes that DETERMINISTIC even if a stray carrier is on disk.
+ *
+ * Effort is NATIVE too. A live `/effort` override records in gateway memory
+ * only (no carrier), so the self-restart sheds it and the downgraded default
+ * boots at the configured `thinking_effort` (the fleet `low` pin, #1978 /
+ * src/config/thinking-effort-risk.ts). This module writes NO effort carrier —
+ * that is the whole point: the downgraded opus must resolve LOW.
+ *
+ * Loop guard (survives restart). The gate is bounded so a turn that dies AGAIN
+ * during its own downgrade-resume is named-as-lost rather than looped forever:
+ *   - The natural guard: after the downgrade boot the session is ON the
+ *     configured default (override null), so a second `all-blocked` finds no
+ *     premium tier and `decide()` returns `skip` — no re-downgrade.
+ *   - The belt-and-suspenders guard: a restart-surviving
+ *     `.tier-downgrade-attempts` counter caps consecutive downgrades per
+ *     interruption chain (default 1). A record older than `staleMs` starts a
+ *     fresh chain, so a later INDEPENDENT interruption can downgrade again.
+ *
+ * NB — carrier-name choice. The in-memory single-flight latch in
+ * fleet-fallback-resume.ts does NOT survive the restart, and the historical
+ * `.session-model-boot-attempts` filename is UNUSABLE as a boot-surviving guard
+ * on current main: start.sh unconditionally `rm -f`s it every boot (retired
+ * with the rev-3 crashloop self-heal, session-model-stickiness.md §0.1). So the
+ * loop guard uses a DISTINCT file, `.tier-downgrade-attempts`, that start.sh
+ * never touches — the durable equivalent of the premise's intent.
+ *
+ * This module is pure at its core (`decideTierDowngrade`) so the decision is
+ * unit-testable without a process restart; the small FS helpers for the counter
+ * file live here too (they mirror session-model-file.ts's shape).
+ */
+
+import { readFileSync, writeFileSync, renameSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const TIER_DOWNGRADE_ATTEMPTS_FILE = '.tier-downgrade-attempts'
+
+/** Consecutive downgrades allowed per interruption chain. The 2nd consecutive
+ *  downgrade-resume failure is named-as-lost, never attempted. */
+export const DEFAULT_MAX_TIER_DOWNGRADES = 1
+
+/** An attempts record older than this is a FRESH chain (a later independent
+ *  interruption), not a continuation of a storm. Comfortably longer than a
+ *  restart + boot-resume cycle so a genuine loop (which cycles in seconds) is
+ *  always caught, while an unrelated overload minutes later can downgrade
+ *  again. */
+export const DEFAULT_TIER_DOWNGRADE_STALE_MS = 600_000 // 10 min
+
+export interface TierDowngradeAttempts {
+  /** Number of downgrades fired in the current chain. */
+  count: number
+  /** The premium model that was walled when the chain started (observability). */
+  premiumModel: string
+  /** Wall-clock ms of the most recent downgrade in the chain. */
+  ts: number
+}
+
+export type TierDowngradeDecision =
+  | {
+      /** Fire the downgrade: write a consume-once carrier for `toModel`, persist
+       *  `nextAttempts`, and self-restart to resume the dead turn. */
+      action: 'downgrade'
+      toModel: string
+      fromModel: string
+      nextAttempts: TierDowngradeAttempts
+    }
+  | {
+      /** The downgrade budget is spent for this chain — name the turn as lost
+       *  (surface to the operator) and do NOT restart. */
+      action: 'exhausted'
+      premiumModel: string
+    }
+  | {
+      /** No downgrade is warranted. `on-default`: the session is already on the
+       *  configured default (nothing lower to fall to). `unresolved`: the
+       *  configured default could not be read (never downgrade blind). */
+      action: 'skip'
+      reason: 'on-default' | 'unresolved'
+    }
+
+export interface TierDowngradeInput {
+  /** The live session model override (`sessionModelSource.getOverride()`), or
+   *  null when the session is running the plain configured default. Null is the
+   *  common "on default" signal (boot seeding leaves it null when the launched
+   *  model equals the configured default). */
+  sessionOverride: string | null
+  /** The resolved configured default model token (from
+   *  `.configured-default-model` / `resolveMainModel`). Empty/undefined => the
+   *  boot record was unreadable and we must not downgrade blind. */
+  configuredDefault: string | null | undefined
+  /** Canonicalizer so `sessionOverride` and `configuredDefault` compare in the
+   *  same dialect (the gateway passes `resolveMainModel`). Keeps `opus` from
+   *  spuriously reading as a premium tier over a `claude-opus-*`-shaped default
+   *  and vice versa, as far as the resolver can. */
+  resolve: (token: string) => string
+  /** The parsed `.tier-downgrade-attempts` counter, or null when absent/corrupt. */
+  attempts: TierDowngradeAttempts | null
+  /** Now, epoch ms. */
+  now: number
+  /** Override the staleness window (tests). */
+  staleMs?: number
+  /** Override the per-chain downgrade cap (tests). */
+  maxDowngrades?: number
+}
+
+/**
+ * Decide whether — and to what — the walled premium session should downgrade.
+ * PURE: no FS, no clock, no restart. The gateway does the I/O and the restart
+ * off this verdict.
+ */
+export function decideTierDowngrade(input: TierDowngradeInput): TierDowngradeDecision {
+  const staleMs = input.staleMs ?? DEFAULT_TIER_DOWNGRADE_STALE_MS
+  const maxDowngrades = input.maxDowngrades ?? DEFAULT_MAX_TIER_DOWNGRADES
+
+  const configured =
+    typeof input.configuredDefault === 'string' ? input.configuredDefault.trim() : ''
+  if (configured.length === 0) {
+    // No configured-default record — never downgrade to an unknown model.
+    return { action: 'skip', reason: 'unresolved' }
+  }
+
+  const override = input.sessionOverride
+  if (override == null || override.length === 0) {
+    // On the configured default already — no lower tier to fall to.
+    return { action: 'skip', reason: 'on-default' }
+  }
+
+  // Canonicalize both sides so an alias vs resolved-id spelling of the SAME
+  // model reads as "on default", never as a premium tier (which would loop).
+  if (input.resolve(override) === input.resolve(configured)) {
+    return { action: 'skip', reason: 'on-default' }
+  }
+
+  // A premium model is active AND walled fleet-wide. Consult the loop guard.
+  const fresh = input.attempts != null && input.now - input.attempts.ts <= staleMs
+    ? input.attempts
+    : null
+  const priorCount = fresh?.count ?? 0
+  if (priorCount >= maxDowngrades) {
+    // Already downgraded this chain and it died again → name-as-lost.
+    return { action: 'exhausted', premiumModel: override }
+  }
+
+  return {
+    action: 'downgrade',
+    toModel: configured,
+    fromModel: override,
+    nextAttempts: { count: priorCount + 1, premiumModel: override, ts: input.now },
+  }
+}
+
+// ─── `.tier-downgrade-attempts` counter file (restart-surviving loop guard) ──
+//
+// Deliberately NOT `.session-model-boot-attempts`: start.sh `rm -f`s that name
+// every boot (retired rev-4 hygiene), so it cannot survive a restart. This file
+// is untouched by start.sh — the gateway is its only reader/writer.
+
+/** Parse the counter file. Null on corrupt JSON or a bad shape. */
+export function parseTierDowngradeAttempts(text: string): TierDowngradeAttempts | null {
+  try {
+    const raw = JSON.parse(text) as Partial<TierDowngradeAttempts>
+    if (
+      typeof raw.count !== 'number' ||
+      !Number.isFinite(raw.count) ||
+      raw.count < 0 ||
+      typeof raw.premiumModel !== 'string' ||
+      typeof raw.ts !== 'number' ||
+      !Number.isFinite(raw.ts)
+    ) {
+      return null
+    }
+    return { count: raw.count, premiumModel: raw.premiumModel, ts: raw.ts }
+  } catch {
+    return null
+  }
+}
+
+export function serializeTierDowngradeAttempts(rec: TierDowngradeAttempts): string {
+  return `${JSON.stringify({ count: rec.count, premiumModel: rec.premiumModel, ts: rec.ts })}\n`
+}
+
+function atomicWrite(path: string, content: string): void {
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`
+  writeFileSync(tmp, content, 'utf8')
+  renameSync(tmp, path)
+}
+
+/** Read + parse the counter for `agentDir`, or null when absent/corrupt. */
+export function readTierDowngradeAttempts(agentDir: string): TierDowngradeAttempts | null {
+  try {
+    const raw = readFileSync(join(agentDir, TIER_DOWNGRADE_ATTEMPTS_FILE), 'utf8')
+    return parseTierDowngradeAttempts(raw)
+  } catch {
+    return null
+  }
+}
+
+/** Persist the counter BEFORE the downgrade restart (it must survive the boot). */
+export function writeTierDowngradeAttempts(agentDir: string, rec: TierDowngradeAttempts): void {
+  atomicWrite(join(agentDir, TIER_DOWNGRADE_ATTEMPTS_FILE), serializeTierDowngradeAttempts(rec))
+}
+
+/** Clear the counter (a fresh chain / recovery). Best-effort. */
+export function clearTierDowngradeAttempts(agentDir: string): void {
+  try {
+    rmSync(join(agentDir, TIER_DOWNGRADE_ATTEMPTS_FILE), { force: true })
+  } catch {
+    /* best-effort */
+  }
+}

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -352,6 +352,36 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     expect(existsSync(join(agentDir, ".session-effort"))).toBe(false);
     expect(alertText()).toContain("configured default effort changed");
   });
+
+  // ── MODEL-TIER downgrade failover — start.sh outcomes ─────────────────────
+  // The gateway's downgrade writes a consume-once `.session-model` carrier whose
+  // model IS the configured default (see maybeTierDowngrade). These assert the
+  // two native guarantees the downgrade relies on at the boot layer: revert is
+  // free (consume-once) and the downgraded default resolves the CONFIGURED
+  // (low) effort because the downgrade writes NO `.session-effort` carrier.
+  it("tier-downgrade carrier (model == configured default) → applies the default, consumes, reverts on next restart", () => {
+    // The gateway writes {model: <configured default>, configuredDefaultAtWrite:
+    // <same>} immediately before the resume restart.
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson(DEFAULT_MODEL, DEFAULT_MODEL));
+    expect(runBlock("1")).toBe(DEFAULT_MODEL); // resume boot runs the default
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false); // consume-once
+    expect(existsSync(join(agentDir, ".session-model-alert"))).toBe(false); // silent apply
+    // Native revert: every subsequent restart is already the default (the
+    // premium override was session-scoped and never wrote a surviving carrier).
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+  });
+
+  it("tier-downgrade boot sheds a prior live /effort → downgraded default resolves configured (low) effort", () => {
+    // A live `/effort high` records in gateway memory only (NO `.session-effort`
+    // carrier, rev 4), so the downgrade self-restart sheds it: the boot has no
+    // effort carrier and the downgraded default lands at the configured low pin
+    // (#1978). Model carrier present (the downgrade); effort carrier absent.
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson(DEFAULT_MODEL, DEFAULT_MODEL));
+    expect(existsSync(join(agentDir, ".session-effort"))).toBe(false);
+    const { model, effortArg } = runBlockEffort();
+    expect(model).toBe(DEFAULT_MODEL);
+    expect(effortArg).toBe("--effort low");
+  });
 });
 
 // ── configured-default sr-* (persistent, NO override) — carried over ─────────


### PR DESCRIPTION
## Summary

Adds a **second, lower-priority recovery tier** to the fleet-fallback machinery. When a user's selected premium model (e.g. `/model fable`) is overloaded / throttled mid-turn (HTTP 529 / 429 / `overloaded_error` / 503) **and** account-level failover finds no other account still serving that model, the live turn no longer stalls: the agent **downgrades to its configured default model** (fleet default `opus`) and resumes so work continues.

Account-level failover (swap OAuth account, same model) already exists and is untouched — this adds a strictly lower-priority tier that only fires when account-swap is exhausted.

Cites job spec: `reference/jobs/steer-or-queue-mid-flight.md` (via `reference/rfcs/session-model-stickiness.md` §0.1 rev 4), advancing the **always-available** outcome.

## What actually happens (no auto-return to the premium model)

A `/model fable` override is **session-scoped and in-memory only** — `recordTypedModelSwitch` writes **no** `.session-model` carrier, so the override dies on the downgrade SIGTERM. The downgrade writes a consume-once carrier for the **configured default** (`opus`), so:

- the resume boot runs `opus`, replays the interrupted turn, and keeps working;
- every subsequent restart also boots `opus`;
- **the premium model is never restored automatically.** The user must re-issue `/model fable` once it frees up.

The user-facing notice says exactly that:

> ⤵️ **Downgrading model to keep going** on agent **klanker**
> `fable` is overloaded across every account right now, so this turn is resuming on the default `opus` to keep working. Re-issue `/model fable` once it frees up — it won't switch back on its own.

(An earlier revision of this PR claimed the agent "reverts to `fable` on the next restart" — that was false and impossible under the session-scoped `/model` rule; it has been corrected in code, comments, and this description. `renderTierDowngradeNotice` is a pure function pinned by a test that fails on any revert-to-premium wording.)

## Design

- **Precedence A — account-swap first.** The downgrade is consulted *only* from the `all-blocked` branch of `doFireFleetAutoFallback`, i.e. after `runFleetAutoFallback` returned no eligible account. A `switched` outcome never reaches it, so a model merely throttled on **one** account is always recovered by account-swap, never a downgrade.
- **Consume-once carrier for the configured default.** `maybeTierDowngrade` writes a consume-once `.session-model` carrier for the configured default; start.sh applies + deletes it on the resume boot. General by construction — **any** premium override → the agent's default, not a hardcoded `fable→opus`.
- **Effort is native.** No `.session-effort` carrier is written, so the self-restart **sheds** any live `/effort` override and the downgraded default boots at the configured `thinking_effort` (the fleet `low` pin, #1978 / `src/config/thinking-effort-risk.ts`).
- **Loop bound is the natural on-default guard.** After the downgrade boot the session runs the configured default (the override is gone), so a re-entry returns `skip` ('on-default') and never re-downgrades — even if the default is itself walled fleet-wide (then the normal all-blocked card fires; no loop). The ceremonial restart-surviving counter from the first revision was **removed**: it was unreachable in the normal single-turn flow and advertised a "name-as-lost after 2nd failure" UX that never fired. Pacing reuses the `fleetFallbackResumeGate` single-flight + 3h staleness.
- **Concurrent-turn race is silent, not contradictory.** If a first turn already armed a resume restart (a downgrade or an account-swap), a second turn that also hits `all-blocked` does **not** broadcast a give-up card — the armed restart replays the interrupted turn. `planTierDowngrade` maps a `skip-inflight` resume-gate verdict to `suppress`.
- **Latch armed only after the carrier write.** The resume gate is split into `peek()` / `arm()`: `maybeTierDowngrade` peeks (no arm), writes the carrier, and arms only on write success — a throwing write can no longer leave an armed latch with no pending restart (which would suppress a legitimate later account-swap resume for the single-flight window).

## Test plan

Scoped vitest only (no full suite run):

- `telegram-plugin/tests/tier-downgrade.test.ts` — `decideTierDowngrade` (skip on-default / unresolved / downgrade-to-default / general target); `renderTierDowngradeNotice` asserts resume-on-default + manual re-issue and **no** revert-to-premium promise; `planTierDowngrade` routing incl. the LOW-9a `suppress` on `skip-inflight`.
- `telegram-plugin/tests/fleet-fallback-resume.test.ts` — new `peek()`/`arm()` seams: `peek` never arms, `arm` commits the single-flight window, `decide` == peek+arm-on-resume.
- `tests/scaffold.session-model.test.ts` — rendered start.sh outcomes: the consume-once carrier applies + reverts to the configured default; a downgrade boot with no effort carrier resolves `--effort low`.

`npm run lint` — clean (tsc + all 8 guards).

## Risk

Behavior change is confined to the `all-blocked` fleet-fallback branch (previously a give-up card). Deterministic and loop-bounded by the natural on-default guard; no new raw `bot.api` calls (notices use `sendRichMessage`). Does not touch account-level failover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up (commit `81c6cf18`) — "premium model recovered" ping

The downgrade above strands the user on the default with no signal for when
their premium selection frees up. This follow-up adds a one-tap heads-up.

- **Durable marker.** `maybeTierDowngrade` persists a consume-once
  `.premium-recovery` marker (shape-gated, parity with the `.session-model` /
  `.session-effort` carriers) recording the **dropped premium token** + the
  chats to notify. `start.sh` never consumes this name, so it survives the
  downgrade self-restart.
- **Deterministic recovery signal — no new poller, no broker change.** The
  signal is the auth-broker's **own per-account eligibility**, read off the
  `list-state` the gateway's existing `runQuotaWatch` tick already polls
  (~15 min). Recovery = at least one account **neither `exhausted` nor
  `premium_walled`** — the exact complement of the `all-blocked` condition that
  fired the downgrade. Both fields are the broker's live-authoritative verdicts
  (`isAccountExhausted` / `isAccountPremiumWalled` → `isModelTierWalled`, a pure
  `premium_walled_until > now` timestamp compare) — **P0 deterministic, never
  model-decided.**
- **Exactly one ping, one button, one apply.** On recovery, fire ONE ping
  (`✅ \`fable\` is available again — tap to switch back…`) with an inline
  **"Switch to fable"** button. Its `callback_data` is `mdl:alias:<premium>`,
  which routes through the **same session-scoped `/model` apply path** as the
  model menu (`handleModelMenuCallback` → `recordModelMenuSideEffects`, PR #3184)
  — it does **not** bypass it. At-most-once: fleet-wide `claim-notification`
  dedup + marker cleared **before** the send (never-storm).
- **No stale ping.** The marker is cleared the instant the user **manually**
  re-issues `/model <premium>` (both `/model` record chokepoints).

### Review close-out (@overlord adversarial review)

- **[MEDIUM] "reverts to fable" misinform** — resolved in `5d9bbf44` (honest
  `renderTierDowngradeNotice`). Confirmed on tip.
- **[LOW] attempts-counter pollution** — the counter was removed entirely in
  `5d9bbf44`; moot (no counter remains).
- **[LOW] `maybeTierDowngrade` glue untested** — **fixed in `81c6cf18`.**
  Extracted the order-sensitive glue into `runTierDowngrade`
  (`tier-downgrade-wiring.ts`, injected-deps runner); the new
  `tier-downgrade-wiring.test.ts` **pins the broadcast notice** (asserts
  resume-on-default + manual re-issue, fails on any revert-to-premium phrasing)
  and covers the `skip-inflight` suppress path + carrier-before-arm ordering.

### Added tests

- `telegram-plugin/tests/premium-recovery.test.ts` — `decidePremiumRecovery`
  (deterministic predicate), `renderPremiumRecoveryPing` (honest wording),
  `premiumRecoveryClaimKey`, `.premium-recovery` carrier round-trip + shape gate.
- `telegram-plugin/tests/tier-downgrade-wiring.test.ts` — the gateway-glue
  integration test (notice-text pin + suppress path + ordering invariant).

Scoped vitest + `npm run lint` (tsc + 8 guards) clean.
