### PR TITLE
feat(telegram): make send-gate rate limits configurable via switchroom.yaml

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `channels.telegram.sub_agent_tick_interval_ms` | override | Progress-card: elapsed-counter tick interval (ms) while a sub-agent is running (default 10000) |
 | `channels.telegram.approval_timeout_minutes` | override | Operator approval-card lifetime (minutes) for the tool-use "Allow once" card and the vault grant decision wait. After this long with no tap, the card auto-denies as a TIMEOUT (the agent is told not to retry). Default 60. |
 | `channels.telegram.edit_budget_threshold` | override | Progress-card: card-edit budget per minute before throttled mode (default 18) |
+| `channels.telegram.send_gate.*` | override | Tunable rate limits for the deterministic outbound send gate (token buckets + per-message edit floor). Sub-keys: `enabled`, `global_per_sec` (25), `global_burst` (4), `per_chat_per_sec` (1), `per_chat_burst` (3), `per_group_per_min` (18), `per_group_burst` (2), `edit_floor_ms` (1500). Every key optional and defaults to the built-in value, so omitting the block is today's exact behaviour. Rates must be > 0 and bursts integers ≥ 1 (rejected loudly at config-load). The `SWITCHROOM_TELEGRAM_SEND_GATE=0` break-glass env var still wins on `enabled` when explicitly set. |
 | `channels.telegram.clear_status_on_completion` | override | When `true`, the live activity/status feed (the in-place "what it's doing" message) is **deleted** when the turn's final answer lands, leaving only the reply. Default `false`: the status message **stays** in the chat as a record (finalized to an all-done render) — no post-then-delete flicker. |
 | `channels.telegram.pin_status_while_working` | override | When `true` (default), the framework **silently pins** the already-rendered status message while its work is in-flight and **auto-unpins** it on completion — the per-turn activity/status message (foreground) and the `🛠 Worker` background-worker message. Keeps in-flight work in view when the conversation scrolls past it (fast turns, stacked background workers, long turns). It pins a message the chat **already owns** — no new surface is rendered — and never buzzes the device. The one sanctioned pin under `chat-is-the-single-source-of-truth`. Set `false` to disable. |
 | `channels.telegram.coalesce.window_ms` | override | Sliding-window (ms) for merging consecutive inbound messages from the same sender+topic into ONE Claude turn. A forwarded burst or a long paste that Telegram splits across several messages arrives as a single shared-context turn instead of N rapid-fire turns. Each new message resets the timer. Default `500`. Set `0` to disable coalescing (each message is its own turn). The 👀 acknowledgement still fires immediately, so perceived latency is unchanged. |
@@ -533,6 +534,51 @@ agents:
         stream_mode: checklist
         edit_budget_threshold: 12
         sub_agent_tick_interval_ms: 15000
+```
+
+## Send-Gate Rate Limits
+
+The deterministic outbound send gate (`telegram-plugin/send-gate.ts`, on by
+default since v0.18.17) is the single token-bucket scheduler every Bot API call
+transits, so the many per-surface throttles (reply chunks, stream edits, typing,
+worker-feed edits, reactions, cards) can't add up past a per-bot-token flood
+ceiling. Its rate limits are compile-time defaults; `channels.telegram.send_gate.*`
+makes them tunable per agent. **Every key is optional and defaults to the built-in
+value — omit the whole block to reproduce today's exact behaviour. Setting a knob
+is pure operator tuning; no default changes.**
+
+Rates must be `> 0` and bursts must be integers `>= 1` (a zero rate or zero-capacity
+bucket would never admit a token and wedge all sends). Out-of-range values are
+**rejected loudly at config-load** with a clear error — never silently clamped.
+
+| Field | Default | Description | When to tune |
+|---|---|---|---|
+| `enabled` | `true` | Master switch for the send gate. When `false`, `gate()` is a straight passthrough (the retry policy behaves exactly as before the gate existed). | Leave on. Turn off only to isolate a suspected gate-induced regression — prefer the env valve below for a runtime kill. |
+| `global_per_sec` | 25 | Global bucket sustained rate: Bot API calls/sec across ALL chats (headroom under Telegram's ~30/s). | Lower if a single bot fans out to many chats and you want a tighter global ceiling; raising above ~25 risks the per-token flood ban. |
+| `global_burst` | 4 | Global bucket burst capacity. Worst-case 1 s window admits `global_burst + global_per_sec` = 29 < 30. | Rarely tuned. Keep the `burst + per_sec < 30` margin in mind. |
+| `per_chat_per_sec` | 1 | Per-chat sustained rate: calls/sec to a single chat (Telegram's ~1 msg/sec/chat practical ceiling). | Fractional values allowed (e.g. `0.5` for one send every 2 s). Lower for a quieter cadence. |
+| `per_chat_burst` | 3 | Per-chat burst capacity. | Increase if legitimate rapid multi-chunk replies to one chat get paced too aggressively. |
+| `per_group_per_min` | 18 | Per-group sustained rate: calls/min to a single group/supergroup (headroom under Telegram's ~20/min group ceiling). | Lower for very chatty groups; keep under 20. |
+| `per_group_burst` | 2 | Per-group burst capacity. | Rarely tuned. |
+| `edit_floor_ms` | 1500 | Minimum ms between successive edits of the SAME `message_id` (last-write-wins coalescing enforces the floor). `0` disables the floor. | Raise to further slow card/stream edit churn; lower (or `0`) only if you understand the ~1 edit/sec/message ceiling. |
+
+**Precedence — config vs the break-glass env valve.** The `SWITCHROOM_TELEGRAM_SEND_GATE`
+env var is the operator's runtime kill-switch (`0`/`false`/`off`/`no` disables the
+gate without a config edit or rebuild). It is **distinct** from `send_gate.enabled`
+and, when **explicitly set, always wins** — on or off — regardless of config, so an
+operator disabling the gate mid-incident is never overridden by YAML. When the env
+valve is unset, `send_gate.enabled` decides; when both are unset, the gate is ON.
+The rate knobs come only from config (there was never an env override for them).
+
+```yaml
+agents:
+  worker:
+    channels:
+      telegram:
+        send_gate:
+          per_chat_per_sec: 0.5   # one send every 2 s to any single chat
+          per_chat_burst: 2
+          edit_floor_ms: 2000     # slow same-message edit churn
 ```
 
 ### Advanced env: orphaned-reply liveness window

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1957,6 +1957,41 @@ function channelsToEnv(agent: AgentConfig): Record<string, string> {
   if (tg.edit_budget_threshold !== undefined) {
     out.SWITCHROOM_TG_EDIT_BUDGET_THRESHOLD = String(tg.edit_budget_threshold);
   }
+  // Deterministic send-gate rate limits (channels.telegram.send_gate.*).
+  // Each knob is emitted only when explicitly set so the send gate's built-in
+  // compile-time default (send-gate.ts SEND_GATE_DEFAULTS) owns the unset case
+  // — omitting the whole block reproduces today's exact behaviour. The gateway
+  // resolves these via sendGateConfigFromEnv(). NOTE: `enabled` here is DISTINCT
+  // from the operator break-glass valve SWITCHROOM_TELEGRAM_SEND_GATE, which is
+  // never written by scaffold and always wins when explicitly set (see
+  // sendGateConfigFromEnv precedence).
+  const sg = tg.send_gate;
+  if (sg) {
+    if (sg.enabled !== undefined) {
+      out.SWITCHROOM_TG_SEND_GATE_ENABLED = sg.enabled ? "1" : "0";
+    }
+    if (sg.global_per_sec !== undefined) {
+      out.SWITCHROOM_TG_SEND_GATE_GLOBAL_PER_SEC = String(sg.global_per_sec);
+    }
+    if (sg.global_burst !== undefined) {
+      out.SWITCHROOM_TG_SEND_GATE_GLOBAL_BURST = String(sg.global_burst);
+    }
+    if (sg.per_chat_per_sec !== undefined) {
+      out.SWITCHROOM_TG_SEND_GATE_PER_CHAT_PER_SEC = String(sg.per_chat_per_sec);
+    }
+    if (sg.per_chat_burst !== undefined) {
+      out.SWITCHROOM_TG_SEND_GATE_PER_CHAT_BURST = String(sg.per_chat_burst);
+    }
+    if (sg.per_group_per_min !== undefined) {
+      out.SWITCHROOM_TG_SEND_GATE_PER_GROUP_PER_MIN = String(sg.per_group_per_min);
+    }
+    if (sg.per_group_burst !== undefined) {
+      out.SWITCHROOM_TG_SEND_GATE_PER_GROUP_BURST = String(sg.per_group_burst);
+    }
+    if (sg.edit_floor_ms !== undefined) {
+      out.SWITCHROOM_TG_SEND_GATE_EDIT_FLOOR_MS = String(sg.edit_floor_ms);
+    }
+  }
   // Whether to DELETE the activity/status feed when the final answer lands.
   // Default (unset) = keep it as a record; only emit the env when explicitly
   // set so the gateway's default-off parse owns the unset case.

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -58,6 +58,78 @@ describe("TelegramChannelSchema — removed rate_limit_ms knob (#3161)", () => {
   });
 });
 
+describe("TelegramChannelSchema — send_gate rate limits (#3084)", () => {
+  it("accepts a full send_gate block and preserves every knob", () => {
+    const r = TelegramChannelSchema.parse({
+      send_gate: {
+        enabled: true,
+        global_per_sec: 40,
+        global_burst: 6,
+        per_chat_per_sec: 2,
+        per_chat_burst: 5,
+        per_group_per_min: 30,
+        per_group_burst: 4,
+        edit_floor_ms: 2000,
+      },
+    });
+    expect(r?.send_gate).toEqual({
+      enabled: true,
+      global_per_sec: 40,
+      global_burst: 6,
+      per_chat_per_sec: 2,
+      per_chat_burst: 5,
+      per_group_per_min: 30,
+      per_group_burst: 4,
+      edit_floor_ms: 2000,
+    });
+  });
+
+  it("omitting send_gate leaves it undefined (built-in defaults own the unset case)", () => {
+    const r = TelegramChannelSchema.parse({ format: "html" });
+    expect(r?.send_gate).toBeUndefined();
+  });
+
+  it("accepts a fractional per-sec rate (rates need not be integers)", () => {
+    const r = TelegramChannelSchema.parse({ send_gate: { per_chat_per_sec: 0.5 } });
+    expect(r?.send_gate?.per_chat_per_sec).toBe(0.5);
+  });
+
+  it("edit_floor_ms may be 0 (disables the floor)", () => {
+    const r = TelegramChannelSchema.parse({ send_gate: { edit_floor_ms: 0 } });
+    expect(r?.send_gate?.edit_floor_ms).toBe(0);
+  });
+
+  it("rejects a zero per-chat rate LOUDLY at config-load (would wedge sends)", () => {
+    expect(() =>
+      TelegramChannelSchema.parse({ send_gate: { per_chat_per_sec: 0 } }),
+    ).toThrow();
+  });
+
+  it("rejects a negative global rate LOUDLY at config-load", () => {
+    expect(() =>
+      TelegramChannelSchema.parse({ send_gate: { global_per_sec: -5 } }),
+    ).toThrow();
+  });
+
+  it("rejects a zero burst LOUDLY (a 0-capacity bucket never admits a token)", () => {
+    expect(() =>
+      TelegramChannelSchema.parse({ send_gate: { per_group_burst: 0 } }),
+    ).toThrow();
+  });
+
+  it("rejects a non-integer burst LOUDLY", () => {
+    expect(() =>
+      TelegramChannelSchema.parse({ send_gate: { global_burst: 2.5 } }),
+    ).toThrow();
+  });
+
+  it("rejects a negative edit_floor_ms LOUDLY", () => {
+    expect(() =>
+      TelegramChannelSchema.parse({ send_gate: { edit_floor_ms: -1 } }),
+    ).toThrow();
+  });
+});
+
 describe("TelegramChannelSchema — voice_out (PR-C2)", () => {
   it("applies engine/reply_mode defaults when only enabled is set", () => {
     const r = TelegramChannelSchema.parse({ voice_out: { enabled: true } });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1142,6 +1142,95 @@ export const TelegramChannelSchema = z
         "Increase if your gateway frequently bumps the Telegram edit-rate ceiling " +
         "with many parallel sub-agents; decrease for a more conservative buffer."
       ),
+    send_gate: z
+      .object({
+        enabled: z
+          .boolean()
+          .optional()
+          .describe(
+            "Master switch for the deterministic outbound send gate " +
+            "(telegram-plugin/send-gate.ts) — the token-bucket scheduler every " +
+            "Bot API call transits so per-surface throttles can't add up past a " +
+            "flood ceiling. ON by default. Precedence: the operator break-glass " +
+            "env var SWITCHROOM_TELEGRAM_SEND_GATE (0/false/off/no) ALWAYS wins " +
+            "when explicitly set; this key only decides when that env var is " +
+            "unset. Omit to keep the gate on."
+          ),
+        global_per_sec: z
+          .number()
+          .positive()
+          .optional()
+          .describe(
+            "Global bucket sustained rate (Bot API calls/sec across ALL chats). " +
+            "Default 25 (headroom under Telegram's ~30/s). Must be > 0 — a zero " +
+            "or negative rate would wedge all outbound sends. Omit to keep 25."
+          ),
+        global_burst: z
+          .number()
+          .int()
+          .positive()
+          .describe(
+            "Global bucket burst capacity. Default 4; worst-case 1s window " +
+            "admits global_burst + global_per_sec = 29 < 30, a real margin under " +
+            "the ceiling. Must be an integer >= 1 (a 0 capacity never admits a " +
+            "token and wedges sends). Omit to keep 4."
+          )
+          .optional(),
+        per_chat_per_sec: z
+          .number()
+          .positive()
+          .optional()
+          .describe(
+            "Per-chat sustained rate (calls/sec to a single chat). Default 1. " +
+            "Must be > 0 (zero/negative wedges that chat). Omit to keep 1."
+          ),
+        per_chat_burst: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            "Per-chat burst capacity. Default 3. Must be an integer >= 1 " +
+            "(0 wedges the chat's bucket). Omit to keep 3."
+          ),
+        per_group_per_min: z
+          .number()
+          .positive()
+          .optional()
+          .describe(
+            "Per-group sustained rate (calls/min to a single group/supergroup). " +
+            "Default 18 (headroom under Telegram's ~20/min group ceiling). Must " +
+            "be > 0. Omit to keep 18."
+          ),
+        per_group_burst: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            "Per-group burst capacity. Default 2. Must be an integer >= 1 " +
+            "(0 wedges the group's bucket). Omit to keep 2."
+          ),
+        edit_floor_ms: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe(
+            "Minimum ms between successive edits of the SAME message_id " +
+            "(last-write-wins coalescing enforces this floor). Default 1500 " +
+            "(Telegram's ~1 edit/sec/message practical ceiling). 0 disables the " +
+            "floor. Must be an integer >= 0. Omit to keep 1500."
+          ),
+      })
+      .optional()
+      .describe(
+        "Tunable rate limits for the deterministic outbound send gate " +
+        "(telegram-plugin/send-gate.ts). Every key is optional and defaults to " +
+        "the send gate's built-in value, so omitting the whole block reproduces " +
+        "today's exact behaviour — this is pure operator tuning, no default is " +
+        "changed. Cascades from defaults.channels.telegram.send_gate."
+      ),
     // progress_card block removed in #1122 PR3 (the pinned progress card
     // was replaced by conversational pacing + silence-poke). Existing
     // YAML files with a stale progress_card key will be silently

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -207,7 +207,7 @@ import {
   isPhotoDimensionRejectError,
   isFloodWaitActiveError,
 } from '../retry-api-call.js'
-import { createSendGate, sendGateEnabledFromEnv } from '../send-gate.js'
+import { createSendGate, sendGateConfigFromEnv } from '../send-gate.js'
 import { createStatsLogger, createFloodWindowObserver } from '../send-gate-observability.js'
 import { classifyPhotoFile, rerouteResultSuffix } from '../photo-precheck.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
@@ -5468,8 +5468,14 @@ const recordFloodWindow = makeFloodWindowRecorder(FLOOD_WINDOWS_PATH)
 // ban never resends into an open window. onWindowOpen write-throughs every
 // runtime-opened window to FLOOD_WINDOWS_PATH; bootRamp starts the global
 // bucket at half capacity for 10s to absorb the boot-card burst.
+// Resolve enabled + the tunable rate limits (channels.telegram.send_gate.* →
+// SWITCHROOM_TG_SEND_GATE_* env) ONCE at boot. Unset knobs are absent, so
+// createSendGate applies SEND_GATE_DEFAULTS — omitting config = today's exact
+// behaviour. The SWITCHROOM_TELEGRAM_SEND_GATE break-glass valve still wins on
+// `enabled` when explicitly set (see sendGateConfigFromEnv precedence).
+const sendGateConfig = sendGateConfigFromEnv()
 const sendGate = createSendGate({
-  enabled: sendGateEnabledFromEnv(),
+  ...sendGateConfig,
   initialWindows: loadInitialFloodWindows(FLOOD_STATE_PATH, FLOOD_WINDOWS_PATH, Date.now()),
   bootRamp: {},
   onWindowOpen: (scopeKey, untilTs) => recordFloodWindow(scopeKey, untilTs),
@@ -5654,7 +5660,7 @@ const floodWindowObserver = createFloodWindowObserver({
     )
   },
 })
-if (sendGateEnabledFromEnv()) {
+if (sendGateConfig.enabled) {
   const observeTimer = setInterval(() => {
     try {
       sendGateStatsLogger.tick()

--- a/telegram-plugin/send-gate.test.ts
+++ b/telegram-plugin/send-gate.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { createSendGate, sendGateEnabledFromEnv, type Clock } from './send-gate.js'
+import {
+  createSendGate,
+  sendGateEnabledFromEnv,
+  sendGateConfigFromEnv,
+  SEND_GATE_DEFAULTS,
+  type Clock,
+} from './send-gate.js'
 
 /**
  * Deterministic fake clock. `sleep()` registers a wake at `now + ms`;
@@ -114,6 +120,118 @@ describe('send-gate: feature flag', () => {
         } as unknown as NodeJS.ProcessEnv),
       ).toBe(true)
     }
+  })
+})
+
+describe('send-gate: SEND_GATE_DEFAULTS (compile-time default PIN)', () => {
+  it('pins the exact default rate limits — a drive-by change fails here', () => {
+    // Load-bearing PIN: these are the values createSendGate falls back to when a
+    // knob is unset, i.e. today's shipped behaviour. If any of these numbers
+    // changes, that is a real behaviour change and must be a deliberate,
+    // reviewed edit — not a silent drift. (#3084 send-gate config PR.)
+    expect(SEND_GATE_DEFAULTS).toEqual({
+      globalPerSec: 25,
+      globalBurst: 4,
+      perChatPerSec: 1,
+      perChatBurst: 3,
+      perGroupPerMin: 18,
+      perGroupBurst: 2,
+      editFloorMs: 1500,
+    })
+  })
+})
+
+describe('send-gate: sendGateConfigFromEnv (yaml → env → createSendGate)', () => {
+  const E = (o: Record<string, string | undefined>) => o as unknown as NodeJS.ProcessEnv
+
+  it('maps every SWITCHROOM_TG_SEND_GATE_* env to the exact createSendGate field', () => {
+    // The gateway spreads this object straight into createSendGate({...}), so
+    // asserting the returned slice IS asserting what createSendGate receives.
+    const cfg = sendGateConfigFromEnv(
+      E({
+        SWITCHROOM_TG_SEND_GATE_ENABLED: '1',
+        SWITCHROOM_TG_SEND_GATE_GLOBAL_PER_SEC: '40',
+        SWITCHROOM_TG_SEND_GATE_GLOBAL_BURST: '6',
+        SWITCHROOM_TG_SEND_GATE_PER_CHAT_PER_SEC: '2',
+        SWITCHROOM_TG_SEND_GATE_PER_CHAT_BURST: '5',
+        SWITCHROOM_TG_SEND_GATE_PER_GROUP_PER_MIN: '30',
+        SWITCHROOM_TG_SEND_GATE_PER_GROUP_BURST: '4',
+        SWITCHROOM_TG_SEND_GATE_EDIT_FLOOR_MS: '2000',
+      }),
+    )
+    expect(cfg).toEqual({
+      enabled: true,
+      globalPerSec: 40,
+      globalBurst: 6,
+      perChatPerSec: 2,
+      perChatBurst: 5,
+      perGroupPerMin: 30,
+      perGroupBurst: 4,
+      editFloorMs: 2000,
+    })
+  })
+
+  it('accepts a fractional per-sec rate (rates are not integers)', () => {
+    const cfg = sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_PER_CHAT_PER_SEC: '0.5' }))
+    expect(cfg.perChatPerSec).toBe(0.5)
+  })
+
+  it('unset knobs are ABSENT so createSendGate applies SEND_GATE_DEFAULTS (no behaviour change)', () => {
+    const cfg = sendGateConfigFromEnv(E({}))
+    // Only enabled is present; every rate field is omitted → default fallback.
+    expect(cfg).toEqual({ enabled: true })
+    // And the gate built from it actually pours in the pinned defaults.
+    const gate = createSendGate({ ...cfg, clock: new FakeClock() })
+    // enabled default is ON (escape hatch, not opt-in).
+    expect(gate.stats().enabled).toBe(true)
+  })
+
+  it('drops malformed / wedge-inducing env values back to the default (defensive net)', () => {
+    // The LOUD rejection lives in the Zod config schema; a hand-set bad env must
+    // never wedge sends, so it falls back to undefined → compile-time default.
+    const cfg = sendGateConfigFromEnv(
+      E({
+        SWITCHROOM_TG_SEND_GATE_GLOBAL_PER_SEC: '0', // ≤0 → dropped
+        SWITCHROOM_TG_SEND_GATE_PER_CHAT_BURST: '-3', // negative → dropped
+        SWITCHROOM_TG_SEND_GATE_PER_GROUP_BURST: '2.5', // non-int → dropped
+        SWITCHROOM_TG_SEND_GATE_GLOBAL_BURST: 'nonsense', // NaN → dropped
+      }),
+    )
+    expect(cfg).toEqual({ enabled: true })
+  })
+
+  it('edit_floor_ms accepts 0 (disables the floor) but not negatives', () => {
+    expect(sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_EDIT_FLOOR_MS: '0' })).editFloorMs).toBe(0)
+    expect(
+      sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_EDIT_FLOOR_MS: '-1' })).editFloorMs,
+    ).toBeUndefined()
+  })
+
+  describe('enabled precedence: break-glass valve > config > default-on', () => {
+    it('config send_gate.enabled decides when the env valve is unset', () => {
+      expect(sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_ENABLED: '0' })).enabled).toBe(false)
+      expect(sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_ENABLED: '1' })).enabled).toBe(true)
+      expect(sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_ENABLED: 'off' })).enabled).toBe(false)
+    })
+
+    it('the SWITCHROOM_TELEGRAM_SEND_GATE valve ALWAYS wins when explicitly set', () => {
+      // valve off beats config on
+      expect(
+        sendGateConfigFromEnv(
+          E({ SWITCHROOM_TELEGRAM_SEND_GATE: '0', SWITCHROOM_TG_SEND_GATE_ENABLED: '1' }),
+        ).enabled,
+      ).toBe(false)
+      // valve on beats config off
+      expect(
+        sendGateConfigFromEnv(
+          E({ SWITCHROOM_TELEGRAM_SEND_GATE: '1', SWITCHROOM_TG_SEND_GATE_ENABLED: '0' }),
+        ).enabled,
+      ).toBe(true)
+    })
+
+    it('both unset ⇒ enabled (ON by default, unchanged)', () => {
+      expect(sendGateConfigFromEnv(E({})).enabled).toBe(true)
+    })
   })
 })
 

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -468,16 +468,43 @@ export interface SendGate {
 
 const GROUP_TYPES = new Set<ChatType>(['group', 'supergroup'])
 
+/**
+ * Compile-time default rate limits for the send gate's token buckets and edit
+ * floor — the values `createSendGate` falls back to when a field is omitted.
+ *
+ * Exposed so the config plumbing (`channels.telegram.send_gate.*` →
+ * `SWITCHROOM_TG_SEND_GATE_*` env → `sendGateConfigFromEnv`) defaults to the
+ * SAME numbers, and so a test can PIN them: a future accidental change to any
+ * default fails that pin. Changing a value here is a real behaviour change for
+ * every install — do it deliberately, never as a drive-by edit.
+ */
+export const SEND_GATE_DEFAULTS = {
+  /** Global bucket sustained rate (tokens/sec). */
+  globalPerSec: 25,
+  /** Global burst capacity (headroom under Telegram's ~30/s). */
+  globalBurst: 4,
+  /** Per-chat sustained rate (tokens/sec). */
+  perChatPerSec: 1,
+  /** Per-chat burst capacity. */
+  perChatBurst: 3,
+  /** Per-group sustained rate (tokens/min). */
+  perGroupPerMin: 18,
+  /** Per-group burst capacity (headroom under 20/min). */
+  perGroupBurst: 2,
+  /** Minimum ms between edits of the same message_id. */
+  editFloorMs: 1500,
+} as const
+
 export function createSendGate(config: SendGateConfig): SendGate {
   const enabled = config.enabled
   const clock = config.clock ?? systemClock
-  const globalPerSec = config.globalPerSec ?? 25
-  const globalBurst = config.globalBurst ?? 4
-  const perChatPerSec = config.perChatPerSec ?? 1
-  const perChatBurst = config.perChatBurst ?? 3
-  const perGroupPerMin = config.perGroupPerMin ?? 18
-  const perGroupBurst = config.perGroupBurst ?? 2
-  const editFloorMs = config.editFloorMs ?? 1500
+  const globalPerSec = config.globalPerSec ?? SEND_GATE_DEFAULTS.globalPerSec
+  const globalBurst = config.globalBurst ?? SEND_GATE_DEFAULTS.globalBurst
+  const perChatPerSec = config.perChatPerSec ?? SEND_GATE_DEFAULTS.perChatPerSec
+  const perChatBurst = config.perChatBurst ?? SEND_GATE_DEFAULTS.perChatBurst
+  const perGroupPerMin = config.perGroupPerMin ?? SEND_GATE_DEFAULTS.perGroupPerMin
+  const perGroupBurst = config.perGroupBurst ?? SEND_GATE_DEFAULTS.perGroupBurst
+  const editFloorMs = config.editFloorMs ?? SEND_GATE_DEFAULTS.editFloorMs
   const messageStateTtlMs = config.messageStateTtlMs ?? 60_000
   const maxMessageStates = config.maxMessageStates ?? 5_000
   const usefulTtlMs = config.usefulTtlMs ?? 120_000
@@ -1081,6 +1108,101 @@ export function createSendGate(config: SendGateConfig): SendGate {
 export function sendGateEnabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
   const v = env.SWITCHROOM_TELEGRAM_SEND_GATE
   if (v == null) return true
+  return !isOffValue(v)
+}
+
+/** Shared parse for the default-on kill-switch grammar: `0/false/off/no`. */
+function isOffValue(v: string): boolean {
   const t = v.trim().toLowerCase()
-  return !(t === '0' || t === 'false' || t === 'off' || t === 'no')
+  return t === '0' || t === 'false' || t === 'off' || t === 'no'
+}
+
+/** Parse a strictly-positive finite number env var; blank/NaN/≤0 → undefined. */
+function parsePositiveNumber(raw: string | undefined): number | undefined {
+  if (raw == null || raw.trim() === '') return undefined
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+/** Parse a positive integer env var; blank/NaN/non-int/≤0 → undefined. */
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  if (raw == null || raw.trim() === '') return undefined
+  const n = Number(raw)
+  return Number.isInteger(n) && n > 0 ? n : undefined
+}
+
+/** Parse a non-negative integer env var; blank/NaN/non-int/<0 → undefined. */
+function parseNonNegativeInt(raw: string | undefined): number | undefined {
+  if (raw == null || raw.trim() === '') return undefined
+  const n = Number(raw)
+  return Number.isInteger(n) && n >= 0 ? n : undefined
+}
+
+/**
+ * The resolved rate-limit + enable slice `createSendGate` consumes, sourced
+ * from env (which the scaffold populates from `channels.telegram.send_gate.*`).
+ * Only fields the operator SET are present; an unset rate field is absent so
+ * `createSendGate` applies its `SEND_GATE_DEFAULTS` fallback (unset ⇒ today's
+ * exact behaviour).
+ */
+export type SendGateEnvConfig = Pick<SendGateConfig, 'enabled'> &
+  Partial<
+    Pick<
+      SendGateConfig,
+      | 'globalPerSec'
+      | 'globalBurst'
+      | 'perChatPerSec'
+      | 'perChatBurst'
+      | 'perGroupPerMin'
+      | 'perGroupBurst'
+      | 'editFloorMs'
+    >
+  >
+
+/**
+ * Resolve the send gate's `enabled` flag + tunable rate limits from env.
+ *
+ * ENABLED PRECEDENCE (least-surprising, documented):
+ *   1. `SWITCHROOM_TELEGRAM_SEND_GATE` — the operator break-glass valve. When
+ *      EXPLICITLY set it ALWAYS wins (unchanged kill-switch semantics), on or
+ *      off, regardless of config. An operator disabling the gate in an incident
+ *      must not be overridden by YAML.
+ *   2. `SWITCHROOM_TG_SEND_GATE_ENABLED` — from `channels.telegram.send_gate.
+ *      enabled`. Decides only when the valve above is unset.
+ *   3. Both unset ⇒ `true` (the gate is ON by default, unchanged).
+ *
+ * The rate knobs come solely from config (there was never an env override for
+ * them). Config values are validated LOUDLY at load by the Zod schema; this
+ * parse is a defensive net — a hand-set malformed env falls back to undefined
+ * so `createSendGate` uses its built-in default rather than wedging sends.
+ */
+export function sendGateConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): SendGateEnvConfig {
+  const killSwitch = env.SWITCHROOM_TELEGRAM_SEND_GATE
+  let enabled: boolean
+  if (killSwitch != null && killSwitch.trim() !== '') {
+    enabled = !isOffValue(killSwitch)
+  } else {
+    const cfg = env.SWITCHROOM_TG_SEND_GATE_ENABLED
+    enabled = cfg != null && cfg.trim() !== '' ? !isOffValue(cfg) : true
+  }
+
+  const out: SendGateEnvConfig = { enabled }
+  const globalPerSec = parsePositiveNumber(env.SWITCHROOM_TG_SEND_GATE_GLOBAL_PER_SEC)
+  if (globalPerSec !== undefined) out.globalPerSec = globalPerSec
+  const globalBurst = parsePositiveInt(env.SWITCHROOM_TG_SEND_GATE_GLOBAL_BURST)
+  if (globalBurst !== undefined) out.globalBurst = globalBurst
+  const perChatPerSec = parsePositiveNumber(env.SWITCHROOM_TG_SEND_GATE_PER_CHAT_PER_SEC)
+  if (perChatPerSec !== undefined) out.perChatPerSec = perChatPerSec
+  const perChatBurst = parsePositiveInt(env.SWITCHROOM_TG_SEND_GATE_PER_CHAT_BURST)
+  if (perChatBurst !== undefined) out.perChatBurst = perChatBurst
+  const perGroupPerMin = parsePositiveNumber(env.SWITCHROOM_TG_SEND_GATE_PER_GROUP_PER_MIN)
+  if (perGroupPerMin !== undefined) out.perGroupPerMin = perGroupPerMin
+  const perGroupBurst = parsePositiveInt(env.SWITCHROOM_TG_SEND_GATE_PER_GROUP_BURST)
+  if (perGroupBurst !== undefined) out.perGroupBurst = perGroupBurst
+  const editFloorMs = parseNonNegativeInt(env.SWITCHROOM_TG_SEND_GATE_EDIT_FLOOR_MS)
+  if (editFloorMs !== undefined) out.editFloorMs = editFloorMs
+
+  return out
 }

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -3552,6 +3552,56 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(startSh).toContain("export SWITCHROOM_TG_STREAM_THROTTLE_MS='500'");
   });
 
+  it("channels.telegram.send_gate.* become SWITCHROOM_TG_SEND_GATE_* env vars", () => {
+    const agentConfig = makeAgentConfig({
+      channels: {
+        telegram: {
+          send_gate: {
+            enabled: false,
+            global_per_sec: 40,
+            global_burst: 6,
+            per_chat_per_sec: 2,
+            per_chat_burst: 5,
+            per_group_per_min: 30,
+            per_group_burst: 4,
+            edit_floor_ms: 2000,
+          },
+        },
+      },
+    });
+    const result = scaffoldAgent(
+      "send-gate-env-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+
+    expect(startSh).toContain("export SWITCHROOM_TG_SEND_GATE_ENABLED='0'");
+    expect(startSh).toContain("export SWITCHROOM_TG_SEND_GATE_GLOBAL_PER_SEC='40'");
+    expect(startSh).toContain("export SWITCHROOM_TG_SEND_GATE_GLOBAL_BURST='6'");
+    expect(startSh).toContain("export SWITCHROOM_TG_SEND_GATE_PER_CHAT_PER_SEC='2'");
+    expect(startSh).toContain("export SWITCHROOM_TG_SEND_GATE_PER_CHAT_BURST='5'");
+    expect(startSh).toContain("export SWITCHROOM_TG_SEND_GATE_PER_GROUP_PER_MIN='30'");
+    expect(startSh).toContain("export SWITCHROOM_TG_SEND_GATE_PER_GROUP_BURST='4'");
+    expect(startSh).toContain("export SWITCHROOM_TG_SEND_GATE_EDIT_FLOOR_MS='2000'");
+  });
+
+  it("an unset send_gate emits NO send-gate env vars (built-in defaults own it)", () => {
+    const agentConfig = makeAgentConfig({
+      channels: { telegram: { format: "html" } },
+    });
+    const result = scaffoldAgent(
+      "no-send-gate-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+
+    expect(startSh).not.toContain("SWITCHROOM_TG_SEND_GATE_");
+  });
+
   it("user env entry wins over channel-derived env default on key conflict", () => {
     const agentConfig = makeAgentConfig({
       channels: { telegram: { format: "markdownv2" } },


### PR DESCRIPTION
## Summary

The deterministic outbound send gate (`telegram-plugin/send-gate.ts`, on by default since v0.18.17) shipped with its token-bucket rate limits as **compile-time constants**. Operators could only kill the whole gate via the `SWITCHROOM_TELEGRAM_SEND_GATE` env valve — there was no way to tune a single per-chat / per-group / global rate for a chatty agent.

This PR is **pure plumbing + schema**: it exposes the existing knobs through `channels.telegram.send_gate.*`. **No default value is changed** and the send gate's runtime logic is untouched.

## Why

`reference/jobs` — *always available*: a per-bot-token flood ban (429 retry_after ~hours) silences the agent. The send gate is the flood-safety ceiling; making its rates operator-tunable lets a fleet dial the ceiling per agent without a rebuild, instead of the all-or-nothing kill-switch.

## New config keys (all optional; default = current compile-time value)

Nested under `channels.telegram.send_gate`:

| Key | Default | Meaning |
|---|---|---|
| `enabled` | `true` | Master switch (passthrough when false) |
| `global_per_sec` | `25` | Global bucket sustained rate (calls/sec, all chats) |
| `global_burst` | `4` | Global burst capacity (int ≥ 1) |
| `per_chat_per_sec` | `1` | Per-chat sustained rate (calls/sec) |
| `per_chat_burst` | `3` | Per-chat burst capacity (int ≥ 1) |
| `per_group_per_min` | `18` | Per-group sustained rate (calls/min) |
| `per_group_burst` | `2` | Per-group burst capacity (int ≥ 1) |
| `edit_floor_ms` | `1500` | Min ms between edits of the same message_id (0 = no floor) |

Rates must be `> 0` and bursts integers `>= 1` (a zero rate / zero-capacity bucket never admits a token and would wedge sends). **Invalid values are rejected LOUDLY at config-load** (Zod), never silently clamped.

Threaded to the gateway as `SWITCHROOM_TG_SEND_GATE_*` env vars (scaffold `channelsToEnv`), resolved by the new `sendGateConfigFromEnv()`, and fed to `createSendGate({...})`. `SEND_GATE_DEFAULTS` (new export) pins the compile-time defaults and is now referenced by `createSendGate`, so a drive-by default change fails a test.

## Config ↔ env precedence (decision)

`SWITCHROOM_TELEGRAM_SEND_GATE` is the operator **break-glass valve** and is **distinct** from `send_gate.enabled`:

1. The valve, **when explicitly set, ALWAYS wins** on `enabled` (on or off) — unchanged kill-switch semantics; an operator disabling the gate mid-incident is never overridden by YAML.
2. When the valve is unset, `send_gate.enabled` decides.
3. Both unset ⇒ gate is ON (unchanged default).

Rate knobs come **only** from config (there was never an env override for them). A malformed hand-set env falls back to the compile-time default rather than wedging sends — the loud rejection lives at config-load.

## No behaviour change when unset

Omitting the whole `send_gate` block emits no env vars, so `sendGateConfigFromEnv()` returns `{ enabled: true }` only and `createSendGate` applies `SEND_GATE_DEFAULTS` — **today's exact behaviour. No default value is changed.**

## Test plan

Scoped `vitest` + `npm run lint` locally (CI is the full-suite authority):

- `sendGateConfigFromEnv`: all knobs set → exact values (the object spread into `createSendGate`); unset → `{ enabled: true }` only → defaults apply; fractional per-sec accepted; malformed/≤0/non-int env dropped to default; `edit_floor_ms` 0 ok, negative dropped.
- `SEND_GATE_DEFAULTS` pinned to a literal (future accidental default change fails).
- Enabled precedence: valve beats config both directions; config decides when valve unset; both unset → on.
- Schema: full `send_gate` block round-trips; `per_chat_per_sec: 0`, negative `global_per_sec`, `per_group_burst: 0`, non-int `global_burst: 2.5`, negative `edit_floor_ms` all `.toThrow()`.
- Scaffold: `send_gate.*` → `SWITCHROOM_TG_SEND_GATE_*` exports in start.sh; unset → no send-gate env vars.

`tsc --noEmit` clean; `npm run lint` clean (incl. `check-bot-api-wrapping` — gateway.ts uses inline `// allow-raw-bot-api` markers, not line-keyed ranges, so the insertion is safe).

## Risk

Low — additive optional schema + env plumbing. Send-gate runtime logic untouched. Handing back for adversarial review before merge (auto-merge NOT enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)