### PR TITLE
fix(gateway): LOCAL_RESOURCE_EXHAUSTED marker must not crash the gateway (Fixes #3099)

### DIFF
--- a/telegram-plugin/gateway/unhandled-rejection-policy.ts
+++ b/telegram-plugin/gateway/unhandled-rejection-policy.ts
@@ -12,7 +12,7 @@
 
 import { GrammyError, HttpError } from 'grammy'
 
-import { FLOOD_WAIT_ACTIVE } from '../retry-api-call.js'
+import { FLOOD_WAIT_ACTIVE, LOCAL_RESOURCE_EXHAUSTED } from '../retry-api-call.js'
 
 export type RejectionAction = 'shutdown' | 'log_only'
 
@@ -77,6 +77,19 @@ export function classifyRejection(
   // fires MORE sends into the open window and extends the ban, which is the
   // exact amplification the #2923 circuit breaker exists to stop.
   if (err instanceof Error && err.message === FLOOD_WAIT_ACTIVE) return 'log_only'
+
+  // LOCAL_RESOURCE_EXHAUSTED (#3099, sibling of FLOOD_WAIT_ACTIVE above):
+  // retry-api-call throws this plain Error marker when a send fails on a LOCAL
+  // disk/memory exhaustion (ENOSPC/EDQUOT/EIO/ENOMEM) rather than retrying it
+  // (#2923) — retrying a local-resource failure in a tight loop is what tripped
+  // the per-bot flood ban in the first place. A leaked one (a fire-and-forget
+  // send that wasn't wrapped in swallowingApiCall) must NOT crash the gateway:
+  // the box is ALREADY out of disk/memory, and a crash→restart drives a fresh
+  // round of boot-time sends and staging writes at a resource that is already
+  // exhausted — the exact amplification the #2923 marker exists to avoid. The
+  // degraded-state marker already carries this signal; a crash loop is the
+  // wrong way to surface a full disk. Same log_only posture as its sibling.
+  if (err instanceof Error && err.message === LOCAL_RESOURCE_EXHAUSTED) return 'log_only'
 
   if (!isGrammy) return 'shutdown'
 

--- a/telegram-plugin/tests/unhandled-rejection-policy.test.ts
+++ b/telegram-plugin/tests/unhandled-rejection-policy.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'bun:test'
 import { GrammyError } from 'grammy'
 import { classifyRejection } from '../gateway/unhandled-rejection-policy.js'
-import { FLOOD_WAIT_ACTIVE } from '../retry-api-call.js'
+import { FLOOD_WAIT_ACTIVE, LOCAL_RESOURCE_EXHAUSTED } from '../retry-api-call.js'
 
 // ── Real GrammyError fixtures ──────────────────────────────────────────────
 
@@ -239,5 +239,31 @@ describe('classifyRejection — FLOOD_WAIT_ACTIVE marker (#3084)', () => {
 
   it('still returns "shutdown" for an unrelated plain Error', () => {
     expect(classifyRejection(new Error('FLOOD_WAIT_ACTIVE-ish but not it'))).toBe('shutdown')
+  })
+})
+
+describe('classifyRejection — LOCAL_RESOURCE_EXHAUSTED marker (#3099)', () => {
+  // retry-api-call throws this plain Error marker (retry-api-call.ts:344) when a
+  // send fails on LOCAL disk/memory exhaustion (ENOSPC/EDQUOT/EIO/ENOMEM) rather
+  // than retrying it (#2923). Like its sibling FLOOD_WAIT_ACTIVE it is a plain
+  // Error, not a GrammyError, so without an explicit entry it fell into the
+  // `!isGrammy → shutdown` branch — crashing the gateway when the box is ALREADY
+  // out of disk, which drives a fresh round of boot-time sends/staging writes at
+  // an exhausted resource (the amplification the #2923 marker exists to avoid).
+  it('returns "log_only" for a leaked LOCAL_RESOURCE_EXHAUSTED marker', () => {
+    // Mirror the real throw shape from retry-api-call.ts:344 —
+    // `Object.assign(new Error(LOCAL_RESOURCE_EXHAUSTED), { original: err })`.
+    const err = Object.assign(new Error(LOCAL_RESOURCE_EXHAUSTED), {
+      original: Object.assign(new Error('ENOSPC: no space left on device'), {
+        code: 'ENOSPC',
+      }),
+    })
+    expect(classifyRejection(err)).toBe('log_only')
+  })
+
+  it('still returns "shutdown" for an unrelated plain Error', () => {
+    expect(
+      classifyRejection(new Error('LOCAL_RESOURCE_EXHAUSTED-ish but not it')),
+    ).toBe('shutdown')
   })
 })


### PR DESCRIPTION
## Root cause

`retry-api-call.ts:344` throws `LOCAL_RESOURCE_EXHAUSTED` as a **plain `Error`** when a Telegram send fails on a LOCAL disk/memory exhaustion (`ENOSPC`/`EDQUOT`/`EIO`/`ENOMEM`). This is deliberately non-retryable (#2923): retrying a local-resource failure in a tight loop is what tripped the per-bot flood ban in the first place.

`classifyRejection` (`telegram-plugin/gateway/unhandled-rejection-policy.ts`) had **no entry** for this marker. Its sibling marker `FLOOD_WAIT_ACTIVE` (#3084) gets `log_only` at line 79, but `LOCAL_RESOURCE_EXHAUSTED` fell straight through to `if (!isGrammy) return 'shutdown'` (line 81).

### Leak path

A fire-and-forget send (`void sendX(...)` not wrapped in `swallowingApiCall`) that hits a full disk → `retryApiCall` throws `new Error(LOCAL_RESOURCE_EXHAUSTED)` → rejection is unhandled → gateway's `process.on('unhandledRejection')` calls `classifyRejection` → `shutdown` → the whole gateway crashes.

That is the wrong posture for the same reason the flood case is: the box is **already** out of disk, and a crash→restart drives a fresh round of boot-time sends and staging writes at an exhausted resource — the exact amplification the #2923 degraded-state marker exists to avoid. A full disk should surface via the degraded-state signal, not a crash loop.

## Fix

Give `LOCAL_RESOURCE_EXHAUSTED` a `log_only` entry alongside `FLOOD_WAIT_ACTIVE` — a deterministic exact-message guard, same shape as the sibling marker. The gateway logs the leak (so the full-disk condition is visible) and stays up.

## Test

`telegram-plugin/tests/unhandled-rejection-policy.test.ts`:
- **`returns "log_only" for a leaked LOCAL_RESOURCE_EXHAUSTED marker`** — asserts the outcome, mirroring the real `Object.assign(new Error(LOCAL_RESOURCE_EXHAUSTED), { original })` throw shape. Verified it **fails on the pre-fix policy** (returns `shutdown`).
- **`still returns "shutdown" for an unrelated plain Error`** — guards the narrowness (exact-message match, not substring).

Scoped `bun test telegram-plugin/tests/unhandled-rejection-policy.test.ts`: 26 pass, 0 fail.

## Design contract

- **JTBD:** always-on / gateway resilience — a single leaked marker must never take down the whole gateway for every agent/chat.
- **Vision outcome:** always-on (pillar 4).
- **Invariants:** none crossed; narrow deterministic guard, genuine bugs still crash → `shutdown`.

Fixes #3099

🤖 Generated with [Claude Code](https://claude.com/claude-code)