### PR TITLE
fix(vault): correct expired-token list() test assertion (#3102)

### DIFF
--- a/src/vault/broker/client-token.test.ts
+++ b/src/vault/broker/client-token.test.ts
@@ -401,10 +401,23 @@ describe("createBrokerClient — token rejected (grant-expired / grant-revoked)"
     try {
       const client = createBrokerClient(slug, { socket: socketPath });
 
-      const keys = await client.list();
-      // Falls through to the no-token ACL-filtered list — empty in this
-      // harness (config.agents = {}), never a thrown error.
-      expect(Array.isArray(keys)).toBe(true);
+      // Expired token falls through to the standing no-token path and must
+      // NOT throw (only grant-revoked hard-denies). Awaiting here proves the
+      // no-throw contract — a VaultTokenRejectedError would fail the test.
+      const expiredKeys = await client.list();
+
+      // #1496 invariant, asserted directly: an expired (unusable) token must
+      // be no MORE restrictive than presenting no token at all. So an
+      // expired-token list must resolve to EXACTLY the same value a bare
+      // no-token list from this same caller resolves to. In this harness the
+      // caller has no per-agent socket identity, so on Linux the standing-ACL
+      // fall-through denies (#1192) and client.list() collapses that to null;
+      // on non-Linux it is the empty ACL-filtered array. Comparing to the
+      // no-token result asserts the real semantic outcome without baking in a
+      // platform-specific shape (the old `Array.isArray` check wrongly assumed
+      // the fall-through always returns an array — issue #3102).
+      const noTokenKeys = await createBrokerClient({ socket: socketPath }).list();
+      expect(expiredKeys).toEqual(noTokenKeys);
     } finally {
       try { fs.rmSync(path.dirname(tokenPath), { recursive: true, force: true }); } catch { /* ignore */ }
     }


### PR DESCRIPTION
Fixes #3102

## Was it actually red?
Yes. Reproduced on fresh canonical `main`:

```
$ bun test src/vault/broker/client-token.test.ts
13 pass, 1 fail
(fail) list() with EXPIRED token → falls through to standing ACL (does NOT throw)
  expect(Array.isArray(keys)).toBe(true)  →  Received: false
```

## Root cause (test bug, not a behavior bug)
The test asserted `Array.isArray(await client.list())` on an expired-token
list. That assumption is wrong on Linux:

- An expired (non-revoked) token falls through **server-side** to the
  standing no-token path (`server.ts:1158`).
- For an **unidentified** caller (no per-agent socket identity), that path
  **denies** on Linux by the #1192 hardening (`server.ts:1184`).
- `client.list()` collapses a denied response to `null` (`client.ts:321-338`),
  so `keys` is `null` — not an array.

So `list()` correctly returns *exactly what a no-token list from the same
caller returns*. That is the **#1496 invariant**: an unusable token is never
*more* restrictive than presenting no token. The sibling `get()` test already
asserts the matching `kind === "denied"`; only the `list()` assertion was
written on the false premise that the fall-through always yields `[]`.

Empirically confirmed on Linux: expired-token `list()` → `null`, no-token
`list()` → `null` (identical).

## Fix
Assert the #1496 invariant directly and platform-independently: the
expired-token list result must `.toEqual()` the bare no-token list result
from the same caller (`null` on Linux, `[]` on non-Linux). This asserts the
real semantic outcome instead of a brittle array-shape check, and still
proves the no-throw contract (a `VaultTokenRejectedError` would fail the
await). No production code changed — the broker behavior is correct and
secure as-is.

## Verification
- `bun test src/vault/broker/client-token.test.ts` → **14 pass / 0 fail** (was 13/1)
- `npm run lint` (tsc --noEmit + repo guards) → clean

## Design contract
- **Vision outcome:** subscription-honest / always-on reliability — green `main`
  keeps CI trustworthy so the fleet ships without false reds.
- **Job spec:** `reference/jobs/` vault broker capability-token read path.
- **Invariants:** no change to the claude-native / on-leash / single-tenant
  invariants; the #1192 deny-unidentified-caller and #1496 expired-fall-through
  security behaviors are preserved and now asserted directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)