### PR TITLE
test(host-control): de-flake config_propose_edit idempotency fuzz loop — Fixes #3170

### DIFF
--- a/tests/host-control/config-propose-edit-idempotency.test.ts
+++ b/tests/host-control/config-propose-edit-idempotency.test.ts
@@ -221,12 +221,24 @@ describe("property — re-fired identical proposals: exactly-once apply, always 
   const verdicts: ApprovalVerdict[] = ["approve", "deny", "timeout"];
   const ITERATIONS = 60;
 
-  it(`holds invariants across ${ITERATIONS} fuzzed schedules`, async () => {
+  it(
+    `holds invariants across ${ITERATIONS} fuzzed schedules`,
+    async () => {
     const rand = lcg(0xc0ffee);
     for (let i = 0; i < ITERATIONS; i++) {
       const verdict = verdicts[Math.floor(rand() * verdicts.length)]!;
       const burst = 2 + Math.floor(rand() * 3); // 2..4 identical re-fires
-      const holdMs = Math.floor(rand() * 60); // 0..59ms tap latency
+      // Simulated operator tap latency. The card only needs to stay open
+      // longer than the burst's sub-ms arrival spread to exercise the
+      // in-flight dedupe overlap — the ABSOLUTE magnitude is irrelevant to
+      // every invariant here, so a wide 0..59ms range was pure sequential
+      // wall-clock cost (~1.9s of setTimeout sleeps summed over 60 schedules,
+      // the dominant term that pushed this loop past the 5s default under CI
+      // fork contention — #3170). Both regimes stay anchored deterministically
+      // by the sibling tests (the dedupe-collapse test pins overlap; the
+      // key-release test pins the sequential/non-overlap path), so shrinking
+      // the range keeps full coverage while cutting the sleep budget ~3x.
+      const holdMs = Math.floor(rand() * 20); // 0..19ms tap latency
       const arrivalJitter = Math.floor(rand() * 12); // stagger re-fires
 
       // Fresh server + file per schedule.
@@ -277,5 +289,15 @@ describe("property — re-fired identical proposals: exactly-once apply, always 
 
       await server.stop();
     }
-  });
+  },
+    // Explicit generous budget (default is 5s). After the holdMs shrink this
+    // loop runs in ~2s locally, but its irreducible floor is 60×(2..4) REAL
+    // `git apply` subprocess spawns (propose-time validation + the under-lock
+    // re-apply) whose wall time is legitimately load-dependent — under CI
+    // shards (`VITEST_MAX_FORKS: 2`, co-scheduled suites contending for CPU +
+    // process spawns) it can stretch several-fold. 30s is ~15x the local
+    // runtime: it leaves ample headroom for shard contention yet still trips
+    // on a genuine hang/deadlock (the failure this suite guards against). #3170
+    30_000,
+  );
 });


### PR DESCRIPTION
## Fixes #3170

`config_propose_edit — idempotency` fuzz case (`holds invariants across 60 fuzzed schedules`) ran at ~60-70% of the 5s vitest default and timed out under CI shard load (`VITEST_MAX_FORKS: 2`, co-scheduled suites).

### Root cause (measured)
Profiled the 60-iteration loop:
- `server.start()` total: **36ms**, `server.stop()` total: **16ms** — negligible.
- Dominant reducible cost: the simulated operator tap-latency `holdMs` sleep — **~1.9s** of `setTimeout` wall-clock, summed sequentially over 60 schedules (send phase ≈ hold phase). That absolute magnitude is irrelevant to every invariant — the approval card only needs to outlast the burst's sub-ms arrival spread to exercise in-flight dedupe.

### Fix (durable, coverage-preserving)
1. **Shrink tap-latency range `0..59ms` → `0..19ms`.** Cuts the sleep budget ~3x (loop body **~2.9s → ~2.0s** local). Proven coverage-neutral: dedupe-collapse schedules `59 → 60/60`, exactly-once apply count `21/21` unchanged; both overlap and sequential regimes stay anchored deterministically by the sibling tests (dedupe-collapse test = overlap; key-release test = non-overlap).
2. **Explicit `30_000ms` budget on the `it`.** The residual ~2s floor is `60×(2..4)` real `git apply` subprocess spawns whose wall time is legitimately load-dependent under fork contention — 30s is ~15x the local runtime (ample shard headroom) yet still trips a genuine hang/deadlock.

No production code touched; the invariants (bounded cards, exactly-once apply, always-terminal, file-mutated-iff-approved) are unchanged.

### Verification
- Target test run 3x locally: fuzz case **~2.0s** (was ~2.9s), all 4 tests pass each run.
- `npm run lint` clean.

**JTBD:** `approve-what-my-agent-can-touch` (guards the `config_propose_edit` approval flow's exactly-once-apply invariant); serves `fleet-stays-healthy` by removing a green-main flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)