### PR TITLE
Fixes #3167: synthesize honest card context when the caller supplies no reason

### DIFF
--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -20,7 +20,7 @@
 import { basename } from "node:path";
 import { escapeMarkdown } from "./card-format.js";
 import { prettyMcpServer, type ScopeOption } from "./permission-rule.js";
-import { redact } from "./secret-detect/redact.js";
+import { redact, REDACTED_MARKER } from "./secret-detect/redact.js";
 
 const COMMAND_TITLE_MAX = 48;
 const DESCRIPTION_LINE_MAX = 240;
@@ -64,6 +64,25 @@ const CONTEXT_NOISE_KEYS = new Set([
   "inline_keyboard",
   "file_id",
 ]);
+
+/**
+ * Input keys whose VALUE is credential-shaped by name — hard-masked whole,
+ * never partially revealed (#3167 review). The token-shape detectors in
+ * `redact()` need a random-looking value to fire, so a low-entropy password
+ * or a short secret under one of these keys would otherwise slip through the
+ * synthesized `context:` line. Matching the key is the reliable signal.
+ */
+const SENSITIVE_VALUE_KEY_RE =
+  /token|secret|password|passwd|key|auth|dsn|conn|url|credential|cookie|session/i;
+
+/**
+ * Credential-bearing DSN schemes that `redactUrls()` (inside `redact()`) does
+ * NOT cover — it only handles http(s)/ws(s)/ftp. A `postgres://user:pass@host`
+ * DATABASE_URL is a real vault-key shape here, so mask the whole DSN when its
+ * authority carries a `user:pass@` credential (#3167 review).
+ */
+const NON_HTTP_DSN_RE =
+  /\b(?:postgres(?:ql)?|mysql|mariadb|redis|rediss|mongodb(?:\+srv)?|amqp|amqps):\/\/\S*@\S+/gi;
 
 /**
  * Human verb-phrases for switchroom-managed MCP tools. The raw
@@ -656,7 +675,20 @@ export function synthesizeContext(
   // target) — the substance the title's verb-phrase does NOT already carry.
   // When the input exposes nothing meaningful, fall back to the natural
   // action so the line still names the tool rather than reading empty.
-  return summary ?? naturalAction(toolName, inputPreview);
+  const base = summary ?? naturalAction(toolName, inputPreview);
+  // Acceptance criteria (#3167) call for "tool + summarized input +
+  // originating turn". When the call carries a forum-topic origin turn,
+  // append a compact reference so the operator can tie the card to the turn
+  // that spawned it. Kept short — it's a routing id, not prose.
+  const turnRef = input ? readString(input, "origin_turn_id") : null;
+  return turnRef ? `${base} · turn ${shortTurnRef(turnRef)}` : base;
+}
+
+/** Compact display form of an origin-turn id — the tail is the distinguishing
+ *  part; a full opaque id would swamp the line. */
+function shortTurnRef(turnId: string): string {
+  const t = turnId.trim();
+  return t.length <= 10 ? t : `…${t.slice(-8)}`;
 }
 
 /**
@@ -668,6 +700,14 @@ export function synthesizeContext(
  * value dump — avoids leaking PII/secrets and oversized blobs). Returns null
  * when nothing meaningful remains, so the caller falls back to the bare
  * action phrase.
+ *
+ * Free-text fields (e.g. a reply `text`) surface as content — a conscious
+ * choice (#3167 review, LOW-1): the operator NEEDS to see *what* is being
+ * sent to judge the card. Exposure is bounded to {@link ARG_VALUE_MAX} chars
+ * and every value is redaction-passed via {@link redactSalientValue}, so a
+ * card can never leak more than the outbound reply already does in history
+ * (both use the same `redact()` chokepoint). We do not mask free text to a
+ * placeholder, which would gut the card's usefulness.
  */
 function salientInputSummary(input: Record<string, unknown>): string | null {
   const parts: string[] = [];
@@ -682,7 +722,7 @@ function salientInputSummary(input: Record<string, unknown>): string | null {
       parts.push(key); // nested object/array → key name only, never dumped
       continue;
     }
-    const shown = truncate(redact(String(value)), ARG_VALUE_MAX);
+    const shown = truncate(redactSalientValue(key, String(value)), ARG_VALUE_MAX);
     if (shown.length === 0) continue;
     parts.push(`${key}: ${shown}`);
   }
@@ -691,6 +731,32 @@ function salientInputSummary(input: Record<string, unknown>): string | null {
   return joined.length > ARG_SUMMARY_LINE_MAX
     ? joined.slice(0, ARG_SUMMARY_LINE_MAX - 1) + "…"
     : joined;
+}
+
+/**
+ * Redact a single salient value for display on the synthesized `context:`
+ * line, given its input KEY (#3167 review). Three layers, defense-in-depth:
+ *
+ *   1. Hard-mask whole when the key is credential-shaped
+ *      ({@link SENSITIVE_VALUE_KEY_RE}) — the token-shape detectors need a
+ *      random-looking value, so a low-entropy password / short secret under a
+ *      `token`/`password`/`api_key` key would otherwise leak. The key name is
+ *      the reliable signal.
+ *   2. Mask non-http DSN credentials ({@link NON_HTTP_DSN_RE}) that
+ *      `redactUrls()` misses (postgres://user:pass@host, mysql://, redis://…).
+ *   3. Run `redact()` WITH the key restored as `key=value` context, so the
+ *      contextual detectors (`kv_entropy` / `env_key_value`) that require the
+ *      `key[:=]value` shape in one string can fire — then strip the synthetic
+ *      `key=` prefix. Redacting the BARE value (the pre-review bug) blinded
+ *      those detectors, since `redact()` deliberately excludes the
+ *      low-precision `generic_high_entropy` fallback.
+ */
+function redactSalientValue(key: string, value: string): string {
+  if (SENSITIVE_VALUE_KEY_RE.test(key)) return REDACTED_MARKER;
+  const dsnScrubbed = value.replace(NON_HTTP_DSN_RE, REDACTED_MARKER);
+  const scrubbed = redact(`${key}=${dsnScrubbed}`);
+  const prefix = `${key}=`;
+  return scrubbed.startsWith(prefix) ? scrubbed.slice(prefix.length) : scrubbed;
 }
 
 /**

--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -36,6 +36,36 @@ const ARG_VALUE_MAX = 40; // per-value truncation in the arg-summary line
 const ARG_SUMMARY_LINE_MAX = 180; // total cap for the arg-summary line
 
 /**
+ * Input keys that are routing / formatting / id noise, never operator-
+ * meaningful context. Stripped when synthesizing the fallback `context:`
+ * line (#3167) so it surfaces the substance (the reply text, the command,
+ * the query) and not `chat_id` / `format` / `disable_notification` chrome.
+ * `reason`/`why` are here too because their presence takes the `why:` path —
+ * they never reach the synthesizer.
+ */
+const CONTEXT_NOISE_KEYS = new Set([
+  "reason",
+  "why",
+  "chat_id",
+  "message_id",
+  "message_thread_id",
+  "thread_id",
+  "origin_turn_id",
+  "reply_to",
+  "quote",
+  "quote_text",
+  "format",
+  "parse_mode",
+  "disable_web_page_preview",
+  "disable_notification",
+  "protect_content",
+  "single_use",
+  "ack_text",
+  "inline_keyboard",
+  "file_id",
+]);
+
+/**
  * Human verb-phrases for switchroom-managed MCP tools. The raw
  * `mcp__<server>__<tool>` name is operator-hostile. Phrases are written
  * to slot in after "wants to" / "can now" — e.g. "read its own merged
@@ -141,15 +171,23 @@ export function formatPermissionCardBody(opts: {
   // static schema description (#2469).
   const callerReason = callerSuppliedReason(opts.inputPreview);
   const rawWhy = (callerReason ?? "").replace(/\s+/g, " ").trim();
-  const truncatedWhy =
-    rawWhy.length > DESCRIPTION_LINE_MAX
-      ? rawWhy.slice(0, DESCRIPTION_LINE_MAX - 1) + "…"
-      : rawWhy;
-  lines.push(
-    truncatedWhy.length > 0
-      ? `why: _${escapeTgHtml(truncatedWhy)}_`
-      : `why: _not provided_`,
-  );
+  if (rawWhy.length > 0) {
+    const truncatedWhy =
+      rawWhy.length > DESCRIPTION_LINE_MAX
+        ? rawWhy.slice(0, DESCRIPTION_LINE_MAX - 1) + "…"
+        : rawWhy;
+    lines.push(`why: _${escapeTgHtml(truncatedWhy)}_`);
+  } else {
+    // No caller reason. Many tools (reply, react, edit_message, …) carry no
+    // `reason`/`why` argument at all, so a bare "why: not provided" gives the
+    // operator nothing to decide on — the post-rollout permission storm filled
+    // the chat with contentless cards (#3167). Fall back to an honest,
+    // redaction-safe `context:` line synthesized from the tool + its salient
+    // input, so the card always carries something meaningful. The distinct
+    // label keeps the agent's omission of a rationale visible (it is NOT a
+    // fabricated "why"), while still surfacing what the tool is about to do.
+    lines.push(`context: _${escapeTgHtml(synthesizeContext(opts.toolName, opts.inputPreview))}_`);
+  }
 
   // Third line (REST-wrapper MCP writes only): a redaction-safe summary of
   // the payload so the operator can see WHAT is being sent, not just the
@@ -595,6 +633,64 @@ function callerSuppliedReason(inputPreview: string | undefined): string | null {
     if (r) return r;
   }
   return null;
+}
+
+/**
+ * Honest, redaction-safe fallback for the card's rationale line when the
+ * caller supplied no `reason`/`why` (#3167). Synthesizes context from a
+ * summary of the tool's salient input fields — the reply text, the command,
+ * the search query — so the operator always has something to decide on
+ * instead of a contentless "not provided". Every value passes through
+ * `redact()`; ids / routing / formatting keys are stripped. Falls back to
+ * the natural action phrase when the input exposes nothing salient.
+ * Deterministic (no model in the loop): same input → same line. Exported
+ * for unit testing.
+ */
+export function synthesizeContext(
+  toolName: string,
+  inputPreview: string | undefined,
+): string {
+  const input = parseInput(inputPreview);
+  const summary = input ? salientInputSummary(input) : null;
+  // Prefer the salient input summary (the reply text, the query, the diff
+  // target) — the substance the title's verb-phrase does NOT already carry.
+  // When the input exposes nothing meaningful, fall back to the natural
+  // action so the line still names the tool rather than reading empty.
+  return summary ?? naturalAction(toolName, inputPreview);
+}
+
+/**
+ * A compact, redaction-safe summary of the operator-meaningful scalar fields
+ * of a tool input — used to build the synthesized `context:` line (#3167).
+ * Skips {@link CONTEXT_NOISE_KEYS} (ids/routing/formatting), surfaces up to
+ * {@link ARG_SUMMARY_MAX_KEYS} scalar `key: value` pairs (each redacted +
+ * truncated), and renders nested objects/arrays as the bare key name (no
+ * value dump — avoids leaking PII/secrets and oversized blobs). Returns null
+ * when nothing meaningful remains, so the caller falls back to the bare
+ * action phrase.
+ */
+function salientInputSummary(input: Record<string, unknown>): string | null {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(input)) {
+    if (CONTEXT_NOISE_KEYS.has(key)) continue;
+    if (value == null) continue;
+    if (parts.length >= ARG_SUMMARY_MAX_KEYS) {
+      parts.push("…");
+      break;
+    }
+    if (typeof value === "object") {
+      parts.push(key); // nested object/array → key name only, never dumped
+      continue;
+    }
+    const shown = truncate(redact(String(value)), ARG_VALUE_MAX);
+    if (shown.length === 0) continue;
+    parts.push(`${key}: ${shown}`);
+  }
+  if (parts.length === 0) return null;
+  const joined = parts.join(", ");
+  return joined.length > ARG_SUMMARY_LINE_MAX
+    ? joined.slice(0, ARG_SUMMARY_LINE_MAX - 1) + "…"
+    : joined;
 }
 
 /**

--- a/telegram-plugin/tests/permission-title.test.ts
+++ b/telegram-plugin/tests/permission-title.test.ts
@@ -156,25 +156,96 @@ describe('formatPermissionCardBody', () => {
     expect(body).toContain('why: _listing temp files_')
   })
 
-  test('shows "not provided" when no caller reason is present (never the description)', () => {
+  // #3167: no caller reason → an honest synthesized `context:` line built
+  // from the tool's salient input, NEVER a bare "why: not provided" and never
+  // the static schema description. The distinct `context:` label keeps the
+  // agent's omission of a rationale visible.
+  test('synthesizes a context line when no caller reason is present (never "not provided" / the description)', () => {
     const body = formatPermissionCardBody({
       toolName: 'Bash',
       inputPreview: JSON.stringify({ command: 'ls /tmp' }),
       description: 'Run a shell command on the host.',
       agentName: 'gymbro',
     })
-    expect(body).toContain('why: _not provided_')
+    expect(body).not.toContain('not provided')
     expect(body).not.toContain('Run a shell command')
+    expect(body).toContain('context: _command: ls /tmp_')
   })
 
-  test('shows "not provided" when caller reason is whitespace only', () => {
+  test('synthesizes context when the caller reason is whitespace only', () => {
     const body = formatPermissionCardBody({
       toolName: 'Bash',
       inputPreview: JSON.stringify({ command: 'ls /tmp', reason: '   \n ' }),
       description: 'Run a shell command.',
       agentName: 'gymbro',
     })
-    expect(body).toContain('why: _not provided_')
+    expect(body).not.toContain('not provided')
+    expect(body).toContain('context: _command: ls /tmp_')
+  })
+
+  // #3167 root case: the `reply` tool (and react/edit_message/…) carries NO
+  // `reason` argument, so its cards used to render a contentless
+  // "🔐 Clerk wants to reply / why: not provided". Now the reply text is
+  // synthesized onto a `context:` line so the operator has something to judge.
+  test('reply (no reason arg) synthesizes the reply text as context, not "not provided"', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__switchroom-telegram__reply',
+      inputPreview: JSON.stringify({
+        chat_id: '12345',
+        text: "On it — pulling yesterday's GitHub activity now.",
+        format: 'html',
+        disable_notification: true,
+      }),
+      description: 'Reply on Telegram.',
+      agentName: 'clerk',
+    })
+    const lines = body.split('\n')
+    expect(lines[0]).toBe('🔐 **Clerk** wants to reply')
+    expect(body).not.toContain('not provided')
+    // Salient field surfaced (truncated); id/routing/formatting noise stripped.
+    expect(body).toContain('context: _text: On it — pulling')
+    expect(body).toMatch(/context: _text: On it — pulling[^_]*…_/)
+    expect(body).not.toContain('chat_id')
+    expect(body).not.toContain('disable_notification')
+    expect(body).not.toContain('format')
+  })
+
+  test('a reason ON a reply card still renders as why:, not context: (#3167)', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__switchroom-telegram__reply',
+      inputPreview: JSON.stringify({
+        chat_id: '12345',
+        text: 'done',
+        reason: 'answering the operator’s status question',
+      }),
+      description: 'Reply on Telegram.',
+      agentName: 'clerk',
+    })
+    expect(body).toContain('why: _answering the operator’s status question_')
+    expect(body).not.toContain('context:')
+  })
+
+  test('synthesized context redacts secrets in the salient input (#3167)', () => {
+    const fakeToken = 'sk-ant-' + 'api03-' + 'B'.repeat(48)
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__switchroom-telegram__reply',
+      inputPreview: JSON.stringify({ chat_id: '1', text: `here is the key: ${fakeToken}` }),
+      description: 'Reply on Telegram.',
+      agentName: 'clerk',
+    })
+    expect(body).toContain('context:')
+    expect(body).not.toContain(fakeToken)
+  })
+
+  test('falls back to the natural action when the input exposes nothing salient (#3167)', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'ExitPlanMode',
+      inputPreview: undefined,
+      description: 'Exit plan mode.',
+      agentName: 'clerk',
+    })
+    expect(body).not.toContain('not provided')
+    expect(body).toContain('context: _exit plan mode_')
   })
 
   test('drops the agent prefix when agentName is null (early-boot edge)', () => {

--- a/telegram-plugin/tests/permission-title.test.ts
+++ b/telegram-plugin/tests/permission-title.test.ts
@@ -248,6 +248,98 @@ describe('formatPermissionCardBody', () => {
     expect(body).toContain('context: _exit plan mode_')
   })
 
+  // #3167 review (HIGH/MEDIUM): the salient-value redactor must catch secrets
+  // the bare-value path missed. redact() excludes generic_high_entropy and the
+  // contextual kv detectors need a `key=value` shape — so a prefixless token
+  // under a credential-shaped key leaked verbatim. These FAIL pre-fix.
+  test('hard-masks a prefixless high-entropy value under a `token` key (#3167)', () => {
+    // No sk-/ghp-/JWT prefix — shape detection alone cannot catch it; only the
+    // key-name signal ("token") does.
+    const bare = 'Zx8Kq2Lm9Rn4Tv6Wb1Yc3Hd5Jf7Ug0Pe'
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__acme__do',
+      inputPreview: JSON.stringify({ token: bare, note: 'ping' }),
+      description: 'do a thing',
+      agentName: 'clerk',
+    })
+    expect(body).not.toContain(bare)
+    // `token` value is hard-masked; the benign `note` still surfaces.
+    expect(body).toContain('token:')
+    expect(body).toContain('REDACTED')
+    expect(body).toContain('note: ping')
+  })
+
+  test('hard-masks a 40-hex secret under a `secret`-shaped key (#3167)', () => {
+    const hex = 'a3f1'.repeat(10) // 40 hex chars, no prefix
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__acme__do',
+      inputPreview: JSON.stringify({ webhook_secret: hex }),
+      description: 'do a thing',
+      agentName: 'clerk',
+    })
+    expect(body).not.toContain(hex)
+    expect(body).toContain('REDACTED')
+  })
+
+  test('masks a non-http DSN credential embedded in free text (redactUrls misses it) (#3167)', () => {
+    // Under a benign key (`text`) so the hard-mask key path does NOT fire —
+    // this exercises the NON_HTTP_DSN_RE scheme coverage specifically.
+    const dsn = 'postgres://user:S3cretPass99@db.host:5432/app'
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__switchroom-telegram__reply',
+      inputPreview: JSON.stringify({ chat_id: '1', text: `connect via ${dsn} then run` }),
+      description: 'Reply on Telegram.',
+      agentName: 'clerk',
+    })
+    expect(body).not.toContain('S3cretPass99')
+    expect(body).not.toContain(dsn)
+    expect(body).toContain('REDACTED')
+  })
+
+  test('hard-masks a DATABASE_URL under a url-shaped key (#3167)', () => {
+    const dsn = 'postgres://admin:hunter2pass@10.0.0.5/prod'
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__acme__migrate',
+      inputPreview: JSON.stringify({ database_url: dsn }),
+      description: 'run a migration',
+      agentName: 'clerk',
+    })
+    expect(body).not.toContain('hunter2pass')
+    expect(body).not.toContain(dsn)
+    expect(body).toContain('REDACTED')
+  })
+
+  // #3167 review (LOW-2): acceptance asks for "tool + summarized input +
+  // originating turn" — surface a compact origin-turn reference when present.
+  test('appends a compact originating-turn reference when origin_turn_id is present (#3167)', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__switchroom-telegram__reply',
+      inputPreview: JSON.stringify({ chat_id: '1', text: 'hi', origin_turn_id: 'turn-abcdef123456' }),
+      description: 'Reply on Telegram.',
+      agentName: 'clerk',
+    })
+    expect(body).toContain('· turn …ef123456')
+    // The raw routing id is NOT dumped as its own kv pair.
+    expect(body).not.toContain('origin_turn_id:')
+  })
+
+  // #3167 review (LOW-3): raw commands/text now reach the context line, so a
+  // markdown metachar in the value must be escaped or it can spoof/break the
+  // card's own `_italic_` / `code` formatting.
+  test('escapes markdown metachars in the synthesized context value (#3167)', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'Bash',
+      inputPreview: JSON.stringify({ command: 'echo _a_ *b* `c`' }),
+      description: 'run a shell command',
+      agentName: 'clerk',
+    })
+    // The metachars are backslash-escaped so they can't open emphasis/code.
+    expect(body).toContain('\\_a\\_')
+    expect(body).toContain('\\*b\\*')
+    expect(body).toContain('\\`c\\`')
+    expect(body).not.toContain('echo _a_ *b* `c`')
+  })
+
   test('drops the agent prefix when agentName is null (early-boot edge)', () => {
     const body = formatPermissionCardBody({
       toolName: 'Skill',


### PR DESCRIPTION
## What & why

Approval cards rendered a bare `why: not provided` whenever the calling tool carried no `reason`/`why` argument. Many tools do — `reply`, `react`, `edit_message` have **no reason field in their schema** (`telegram-plugin/bridge/bridge.ts:102`). During the v0.18.14 rollout permission storm (settings.json ownership bug prompting everything) the operator's chat filled with contentless cards like `Clerk wants to reply / why: not provided`, giving nothing to decide on.

## Root cause (traced end-to-end)

- `input_preview` flows from Claude Code's `permission_request` notification → bridge (`bridge.ts:713`) → gateway IPC → `formatPermissionCardBody` (`gateway.ts:10847`).
- The renderer (`permission-title.ts`) **already threads a caller-supplied reason correctly** via `callerSuppliedReason` (`#2469`), including the truncation-recovery regex path. The reason is *not* dropped in the pipeline.
- The actual gap is the **fallback**: when no reason exists (the tool has no reason arg), the renderer emitted a bare `why: _not provided_` instead of synthesizing context. That is the exact card the operator saw.

This matches the issue's own diagnosis (option 2) and its acceptance criteria, which choose *synthesize honest context* over making a reason mandatory on every tool.

## The fix

The no-reason branch of `formatPermissionCardBody` now renders a distinct `context:` line built **deterministically** from the tool's salient input — the reply text, the command, the query — via a new `synthesizeContext` helper:

- ids / routing / formatting keys stripped (`CONTEXT_NOISE_KEYS`: `chat_id`, `format`, `disable_notification`, …)
- every value passed through `redact()` (secrets never surface)
- nested objects/arrays shown as bare key names (no PII/blob dump)
- falls back to the natural-action phrase when the input exposes nothing salient

The separate `context:` label (vs `why:`) keeps the agent's omission of a rationale **visible** — it is honest synthesized context, not a fabricated "why" — while still giving the operator something to judge. Reason-present cards are unchanged (still `why:`).

Example — before:
```
🔐 Clerk wants to reply
why: not provided
```
after:
```
🔐 Clerk wants to reply
context: text: On it — pulling yesterday's GitHub…
```

## Tests

`telegram-plugin/tests/permission-title.test.ts` (all would fail on the old bare fallback):
- reply with no reason surfaces its `text` on `context:`, with `chat_id`/`format`/`disable_notification` stripped
- a reason ON a reply card still renders as `why:`, not `context:`
- secrets in salient input are redacted
- empty/undefined input falls back to the natural-action phrase
- Bash-no-reason renders `context: command: ls /tmp`, never `not provided`

Scoped `vitest run` green (57 tests in the file), `npm run lint` clean.

## JTBD / verdict rule

Serves **visibility** (`reference/vision.md` outcome 1) — every approval step is legible in chat. Passes the docs/defaults/consistency principle checks; crosses no invariant (no self-escalation, chat-is-single-source-of-truth). Deterministic mechanism (no model in the loop): same input → same line.

Fixes #3167

🤖 Generated with [Claude Code](https://claude.com/claude-code)