### PR TITLE
Fixes #3127: compose.ts no longer mkdirSync's into the real $HOME during tests

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -347,6 +347,29 @@ export interface ComposeGeneratorOptions {
    */
   probeHomeDir?: string;
   /**
+   * Whether to pre-create the host-side per-agent directories (audit dir,
+   * blocked-approvals, schedule.d, personal-skills) that docker would
+   * otherwise auto-create as root:root — trapping the agent uid out of
+   * writing them (#3084 / #1163). These are FILESYSTEM SIDE EFFECTS, not
+   * part of the returned compose string.
+   *
+   * Defaults to `true` ONLY when the caller has explicitly supplied a home
+   * (`homeDir` or `probeHomeDir`). When neither is passed, `probeHome`
+   * silently falls back to the ambient `process.env.HOME` — the operator's
+   * REAL production state tree — and blindly `mkdirSync`-ing there is the
+   * bug in #3127: a full test-suite run created `~/.switchroom/blocked-
+   * approvals` (and chmod 1777'd it) in the operator's real `$HOME`.
+   * Reads (`existsSync`) against the ambient home are harmless; writes are
+   * not. So the pre-create is gated on the caller having told us WHERE the
+   * host home actually is. Every production caller (write-compose,
+   * docker-fleet) passes `homeDir`, so production behaviour is unchanged;
+   * pure compose-string tests that omit it get no writes.
+   *
+   * Explicit override wins over the default in both directions (a test can
+   * force it off even with a tmp homeDir; a caller can force it on).
+   */
+  precreateHostDirs?: boolean;
+  /**
    * Absolute host path to the switchroom.yaml the operator wants the
    * containerised broker / kernel / scheduler to load. Bind-mounted
    * read-only into each of those services at /state/config/switchroom.yaml,
@@ -1207,6 +1230,16 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // conditional mount. probeHome is the container-real home. Defaults to
   // hostHomeForChecks (identical on the host). See GenerateComposeOpts.probeHomeDir.
   const probeHome = opts.probeHomeDir ?? hostHomeForChecks;
+  // Gate the host-side directory pre-create (mkdirSync side effects below) on
+  // the caller having explicitly told us where the host home is. When neither
+  // `homeDir` nor `probeHomeDir` is passed, `probeHome` falls back to the
+  // ambient `process.env.HOME` — the operator's REAL production state tree —
+  // and pre-creating dirs there corrupts a running fleet (#3127). Reads stay
+  // ambient (harmless); only writes are gated. Explicit `precreateHostDirs`
+  // overrides the default in either direction.
+  const precreateHostDirs =
+    opts.precreateHostDirs ??
+    (opts.homeDir !== undefined || opts.probeHomeDir !== undefined);
   // The config mount SOURCE must be a HOST path — docker bind-mounts it off the
   // host filesystem. `opts.switchroomConfigPath` is where the RUNNING generator
   // reads ITS config, which is the in-CONTAINER path `/state/config/
@@ -1765,6 +1798,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
       hostControlEnabled,
       opts.operatorUid,
       voiceEngine,
+      precreateHostDirs,
     );
   }
 
@@ -1869,6 +1903,7 @@ function emitAgentService(
   hostControlEnabled: boolean,
   operatorUid: number | undefined,
   voiceEngine: VoiceEngine,
+  precreateHostDirs: boolean,
 ): void {
   lines.push(`  agent-${a.name}:`);
   emitImageOrBuild(lines, "agent", imageTag, buildMode, buildContext);
@@ -2519,9 +2554,11 @@ function emitAgentService(
   // compose tries to bind-mount it (docker auto-creates as root, which
   // then traps the agent uid out of writing — pre-creating with the
   // operator's umask sidesteps that).
-  try {
-    mkdirSync(`${probeHome}/.switchroom/audit/${a.name}`, { recursive: true });
-  } catch { /* best-effort */ }
+  if (precreateHostDirs) {
+    try {
+      mkdirSync(`${probeHome}/.switchroom/audit/${a.name}`, { recursive: true });
+    } catch { /* best-effort */ }
+  }
   // Same trap, shared dir (#3084 follow-up): the blocked-approval surface is
   // ONE directory written by EVERY agent, and agents run as per-agent non-root
   // uids (AGENT_UID_MIN = 10001). If docker auto-creates this bind source it is
@@ -2531,20 +2568,24 @@ function emitAgentService(
   // Pre-create it sticky-world-writable (1777, the /tmp model): each agent
   // creates and owns its own 0644 <agent>.json, so no agent can modify or
   // delete another's. mkdirSync's `mode` is masked by umask, so chmod explicitly.
-  try {
-    const blockedDir = `${probeHome}/.switchroom/blocked-approvals`;
-    mkdirSync(blockedDir, { recursive: true });
-    chmodSync(blockedDir, 0o1777);
-  } catch { /* best-effort */ }
+  if (precreateHostDirs) {
+    try {
+      const blockedDir = `${probeHome}/.switchroom/blocked-approvals`;
+      mkdirSync(blockedDir, { recursive: true });
+      chmodSync(blockedDir, 0o1777);
+    } catch { /* best-effort */ }
+  }
   // Phase B (switchroom #1163): pre-create the per-agent overlay
   // directory so the agent-config write tools (Phase C) have a writable
   // landing zone. The whole ~/.switchroom/agents/<name>/ tree is already
   // bind-mounted rw at lines above (the dual-mount), so no separate
   // volume entry is needed — just the host-side dir, owned by the
   // operator umask before docker auto-creates it as root.
-  try {
-    mkdirSync(`${probeHome}/.switchroom/agents/${a.name}/schedule.d`, { recursive: true });
-  } catch { /* best-effort */ }
+  if (precreateHostDirs) {
+    try {
+      mkdirSync(`${probeHome}/.switchroom/agents/${a.name}/schedule.d`, { recursive: true });
+    } catch { /* best-effort */ }
+  }
   // Agent-config audit log (rw) — the read-only agent-config MCP broker
   // (src/mcp/agent-config/server.ts) appends one JSONL row per tool call
   // to ~/.switchroom/audit/<agent>/agent-config.jsonl. PER-AGENT mount:
@@ -2570,12 +2611,14 @@ function emitAgentService(
   // subdir under operator umask so docker doesn't auto-create as root
   // (the chown sweep in alignAgentUid will fix ownership on next apply).
   if (conditionalMountPresent(`${probeHome}/.switchroom-config`, hostHomeForChecks, probeHome)) {
-    try {
-      mkdirSync(
-        `${probeHome}/.switchroom-config/agents/${a.name}/personal-skills`,
-        { recursive: true },
-      );
-    } catch { /* best-effort */ }
+    if (precreateHostDirs) {
+      try {
+        mkdirSync(
+          `${probeHome}/.switchroom-config/agents/${a.name}/personal-skills`,
+          { recursive: true },
+        );
+      } catch { /* best-effort */ }
+    }
     lines.push(
       `      - ${homePrefix}/.switchroom-config/agents/${a.name}/personal-skills:${homePrefix}/.switchroom-config/agents/${a.name}/personal-skills:rw`,
     );

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -3351,5 +3351,63 @@ describe("generateCompose — LiteLLM ANTHROPIC_BASE_URL model-class routing", (
     // keyConfirmed false ⇒ the whole routing block is skipped, so the proxy URL
     // never appears for this agent (no unauthenticated proxy calls).
     expect(out).not.toContain(ROOT);
+  });
+});
+
+describe("generateCompose is HOME-hermetic — no writes to the real \$HOME under test (#3127)", () => {
+  // #3127: `generateCompose` pre-creates host-side per-agent dirs (audit,
+  // blocked-approvals, schedule.d) via mkdirSync. When a caller omits both
+  // `homeDir` and `probeHomeDir`, `probeHome` silently fell back to the
+  // ambient `process.env.HOME` — the operator's REAL production state tree —
+  // so a full test-suite run created `~/.switchroom/blocked-approvals` (and
+  // chmod 1777'd it) in the operator's home (real incident 2026-05-22 class).
+  //
+  // These tests scope `$HOME` to a mkdtemp dir so they are hermetic even on
+  // the buggy code, and then assert generateCompose creates NOTHING under it
+  // when no home is supplied. Against pre-fix main the assertions FAIL (the
+  // dirs get created); with the pre-create gated on an explicit home they pass.
+  let realHome: string | undefined;
+  let scopedHome: string;
+
+  beforeEach(() => {
+    realHome = process.env.HOME;
+    scopedHome = mkdtempSync(join(tmpdir(), "compose-home-hermeticity-"));
+    process.env.HOME = scopedHome;
+  });
+
+  afterEach(() => {
+    if (realHome === undefined) delete process.env.HOME;
+    else process.env.HOME = realHome;
+    rmSync(scopedHome, { recursive: true, force: true });
+  });
+
+  it("creates no ~/.switchroom side-effect dirs when no home is supplied", () => {
+    const out = generateCompose({ config: makeConfig({ klanker: {}, bob: {} }) });
+    // The compose string is still produced normally…
+    expect(out).toContain("klanker");
+    expect(out).toContain("bob");
+    // …but nothing is written under the ambient (scoped) HOME.
+    expect(existsSync(join(scopedHome, ".switchroom"))).toBe(false);
+    expect(existsSync(join(scopedHome, ".switchroom", "blocked-approvals"))).toBe(false);
+    expect(existsSync(join(scopedHome, ".switchroom", "audit", "klanker"))).toBe(false);
+    expect(existsSync(join(scopedHome, ".switchroom", "agents", "klanker", "schedule.d"))).toBe(false);
+  });
+
+  it("explicit precreateHostDirs:false suppresses the writes even when a home IS supplied", () => {
+    const out = generateCompose({
+      config: makeConfig({ klanker: {} }),
+      homeDir: scopedHome,
+      precreateHostDirs: false,
+    });
+    expect(out).toContain("klanker");
+    expect(existsSync(join(scopedHome, ".switchroom", "blocked-approvals"))).toBe(false);
+  });
+
+  it("pre-creates the dirs in the SCOPED home (never the real \$HOME) when a home IS supplied", () => {
+    generateCompose({ config: makeConfig({ klanker: {} }), homeDir: scopedHome });
+    // The production side effects land in the scoped home, proving the writes
+    // are addressed by the injected home rather than the ambient one.
+    expect(existsSync(join(scopedHome, ".switchroom", "blocked-approvals"))).toBe(true);
+    expect(existsSync(join(scopedHome, ".switchroom", "audit", "klanker"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

`generateCompose` (`src/agents/compose.ts`) pre-creates the host-side per-agent directories — `audit/<agent>`, `blocked-approvals`, `agents/<agent>/schedule.d`, and `.switchroom-config/.../personal-skills` — so docker's bind-mount auto-create doesn't make them `root:root` and trap the agent uid out of writing (the #3084 / #1163 pre-create pattern). Those `mkdirSync` calls target `probeHome`, which resolves via:

```
const hostHomeForChecks = opts.homeDir ?? process.env.HOME ?? "";
const probeHome = opts.probeHomeDir ?? hostHomeForChecks;
```

Every **pure compose-string test** calls `generateCompose({ config })` without a `homeDir`/`probeHomeDir`, so `probeHome` silently falls back to the ambient `process.env.HOME` — the operator's **real production state tree**. A full-suite run therefore created `~/.switchroom/blocked-approvals` (and `chmod 1777`'d it) plus `~/.switchroom/audit/<agent>` in the operator's home. That is exactly the write the "shared-state test discipline" HARD RULE forbids (real incident 2026-05-22). The `check-vault-test-hermeticity` guard doesn't catch it — it's scoped to vault paths.

## Root cause

A filesystem **WRITE** side effect keyed off a **silent ambient-`$HOME` fallback**. Reads (`existsSync`) against ambient HOME are harmless; writes are not.

## Fix

Gate the directory pre-create on the caller having explicitly told us where the host home is (`homeDir` or `probeHomeDir` supplied), exposed as an injectable `precreateHostDirs?: boolean` option (default = "a home was supplied"). This is structural, not opt-in-per-test discipline:

- Every production caller passes `homeDir` — `write-compose.ts` (`homeDir` + `probeHomeDir`) and `docker-fleet.ts` (`homeDir`) — so **production behaviour is unchanged**.
- The returned compose **YAML is byte-identical** either way; only the filesystem side effects are gated.
- Tests that omit the home get **no writes** to the ambient `$HOME`.

`emitAgentService` takes the flag as a new parameter threaded from `generateCompose`.

## Test

Three cases added to `tests/docker/compose-generator.test.ts` (scope `$HOME` to a `mkdtemp` dir so they are hermetic even on the buggy code):

1. `creates no ~/.switchroom side-effect dirs when no home is supplied` — asserts nothing is written under the scoped HOME. **Fails against pre-fix main.**
2. `explicit precreateHostDirs:false suppresses the writes even when a home IS supplied` — the injectable override. **Fails against pre-fix main.**
3. `pre-creates the dirs in the SCOPED home (never the real $HOME) when a home IS supplied` — positive control: the production side effect still lands, but in the injected home.

Scoped run: `204 passed`. Lint (`tsc --noEmit` + all `scripts/check-*`): clean.

## JTBD / contract

Serves the **always-on** outcome (a running fleet's production state must not be corrupted by a test run) and upholds the shared-state test-discipline HARD RULE. No invariant crossed; compose output unchanged.

Follow-up worth considering (out of scope here): a sibling structural guard to `check-vault-test-hermeticity` that forbids any test-reachable `mkdirSync`/write rooted at the real `~/.switchroom/`.

Fixes #3127

🤖 Generated with [Claude Code](https://claude.com/claude-code)