### PR TITLE
Fixes #3136: apply configured-agent target guard to handleAgentSmoke

### DIFF
--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -3178,6 +3178,20 @@ export class HostdServer {
     // req.args.name is AgentNameSchema-validated at decode and passed
     // as its own argv element; docker exec stops parsing its options
     // at CONTAINER so nothing after it is read as a docker flag.
+    // #3136: mirror handleAgentExec/handleAgentLogs — reject any target
+    // that is not a configured peer agent BEFORE constructing the
+    // container name, so smoke's docker exec / inspect can't be aimed at
+    // a singleton service container (vault-broker, approval-kernel, …).
+    // Defense-in-depth: smoke runs fixed literal probes and returns
+    // exit-code-only, but the guard keeps this sink consistent with its
+    // siblings and closes the boolean-existence-probe gap.
+    const rejected = this.rejectUnconfiguredTarget(
+      req.args.name,
+      req.request_id,
+      "agent_smoke",
+      started,
+    );
+    if (rejected) return rejected;
     const container = `switchroom-${req.args.name}`;
     type Probe = { name: string; state: "ok" | "fail" | "skip"; detail: string };
     const respond = (

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -716,6 +716,31 @@ describe("hostd server — agent_smoke (read-only in-agent battery)", () => {
     expect(JSON.parse(resp.stdout_tail!).container).toBe("running");
   });
 
+  it("admin caller targeting the vault-broker singleton is DENIED and never shells out (#3136)", async () => {
+    // #3136 defense-in-depth: handleAgentSmoke builds `switchroom-${name}`
+    // and shells `docker inspect` / `docker exec` at it. klanker IS admin,
+    // so checkGate lets it target ANY name; only the configured-agent
+    // membership guard (mirrored from agent_exec/agent_logs) can stop a
+    // singleton service container (vault-broker / approval-kernel / …).
+    // A recording stub proves the guard short-circuits BEFORE any docker.
+    const invokedLog = join(tmp, `smoke-inv-${Math.random().toString(36).slice(2)}.log`);
+    await withDocker(`#!/bin/sh\necho "$@" >> ${invokedLog}\nexit 0\n`);
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "agent_smoke",
+        request_id: "sm-singleton",
+        args: { name: "vault-broker" },
+      },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/not a configured agent/);
+    // Hard proof: no `docker inspect`/`docker exec` ran against the singleton.
+    expect(existsSync(invokedLog)).toBe(false);
+  });
+
   it("down container → completed, exit 0, every probe skip (never fail)", async () => {
     await withDocker(
       '#!/bin/sh\ncase "$1" in\n  inspect) echo "false"; exit 0 ;;\nesac\nexit 0\n',


### PR DESCRIPTION
## What

Applies the existing `rejectUnconfiguredTarget` configured-agent membership guard to `handleAgentSmoke`, mirroring `handleAgentExec` / `handleAgentLogs` (added in #3133).

## Why

Follow-up from the adversarial re-review of #3133. `handleAgentExec` and `handleAgentLogs` call `rejectUnconfiguredTarget(name, request_id, op, started)` before building `switchroom-${name}` and shelling out, so an admin caller can't aim a docker sink at a singleton service container (vault-broker, approval-kernel, hostd, web). `handleAgentSmoke` builds the same container name and runs `docker inspect` / `docker exec sh -lc <probe>` against it, but lacked the guard.

**Severity: LOW / defense-in-depth.** Smoke runs fixed literal probe commands and returns exit-code-only (stdout is explicitly never surfaced — `server.ts` comment near the probe loop), so it cannot exfiltrate secret material. Worst case is a boolean existence probe against a singleton. This closes the consistency gap the reviewer flagged.

## Change

- `src/host-control/server.ts`: `handleAgentSmoke` now calls `rejectUnconfiguredTarget(req.args.name, req.request_id, "agent_smoke", started)` and returns early on rejection, **before** constructing `container` — same placement as its guarded siblings.
- `tests/host-control/server.test.ts`: new test — an admin caller (`klanker`) targeting the `vault-broker` singleton is `denied` with `/not a configured agent/`, and a recording docker stub proves no `docker inspect`/`exec` ran. Fails pre-fix, passes post-fix.

## JTBD / invariants

Serves the fleet-admin observability job (`hostd` agent verbs) while tightening the **no-self-escalation** invariant — admin agents stay confined to peer agent containers, never singleton service containers holding key material. Docs/defaults/consistency: this is precisely the consistency fix (smoke now matches exec/logs).

## Verification

- `npm run lint` — clean (tsc + all custom checks).
- New guard test passes with the fix, fails when the guard is reverted.
- The 4 pre-existing `agent_smoke` probe-behavior test failures in the sandbox are environment-specific (docker-stub `sh -lc` under this runner) and reproduce identically on unmodified `main`; they are unrelated to this change. CI is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)