### PR TITLE
Fixes #3128: share the on-delivery startedAt reset instead of mirroring it

### DIFF
--- a/telegram-plugin/gateway/approval-hold.ts
+++ b/telegram-plugin/gateway/approval-hold.ts
@@ -516,6 +516,55 @@ export function isHeldUndeliverable(
   return pend.undeliverable != null
 }
 
+/** The fields the on-delivery reset reads and mutates. */
+export interface DeliveredPermissionEntry {
+  undeliverable?: UndeliverableMark | null
+  redeliveryFailures?: number
+  /** When the operator's decision window began — the TTL is measured from here. */
+  startedAt: number
+}
+
+/**
+ * A HELD card just LANDED — the operator can finally see and tap it. Clear the
+ * hold marks and RESTART the TTL clock, as ONE shared decision used by BOTH
+ * gateway.ts and the outcome test's harness.
+ *
+ * WHY THIS IS SHARED CODE AND NOT AN INLINE BLOCK (#3128):
+ *
+ * The harness used to carry a PRIVATE copy of this reset (its own
+ * `live.startedAt = clock.now()`), so the behavioural test that proves the
+ * operator gets a FULL window after re-delivery drove the double, not the real
+ * gateway. Deleting `startedAt = Date.now()` from gateway.ts would have left that
+ * test GREEN — only a source-text grep noticed, and greps drift. Same placebo-pin
+ * class as the leash (#3123) and the never-auto-approve pin (#3126). Now the reset
+ * lives here, in one importable place, and both callers drive it: delete
+ * `entry.startedAt = now` below and the `(d2)` outcome test goes RED, because there
+ * is only one implementation to delete.
+ *
+ * RESET THE TTL CLOCK is load-bearing, not cosmetic. `startedAt` is when the
+ * agent asked; the TTL measures how long the operator had to answer. Until the
+ * card lands they have NOTHING to answer — it did not exist in any chat. Without
+ * the reset, a card held through a 4.6h ban lands already-expired against a 60-min
+ * TTL and the very next reaper tick auto-denies it: the silent denial would be
+ * MOVED, not removed.
+ *
+ * Returns true when this was a HELD-card recovery — the caller should reconcile
+ * the off-Telegram surface and log the re-delivery. Returns false for a normal
+ * first delivery (the entry was never held), where there is nothing to reset.
+ *
+ * @see reference/invariants.md § no-self-escalation, § on-leash
+ */
+export function applyDeliveredHoldReset(
+  entry: DeliveredPermissionEntry,
+  now: number,
+): boolean {
+  if (entry.undeliverable == null) return false
+  entry.undeliverable = null
+  entry.redeliveryFailures = 0
+  entry.startedAt = now
+  return true
+}
+
 /**
  * Per-tick re-delivery cap (PR 2).
  *

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -184,6 +184,7 @@ import {
   selectHeldForRedelivery,
   holdReasonFor,
   heldRetryBackoffMs,
+  applyDeliveredHoldReset,
   type UndeliverableMark,
 } from './approval-hold.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
@@ -7085,20 +7086,13 @@ function postPermissionCard(
         const landedThreadId = sent.message_thread_id ?? undefined
         live.cards.push({ chatId, messageId: sent.message_id, threadId: landedThreadId })
         // The card LANDED — the operator can see and tap it, so the block is over.
-        // Drop the hold mark and reconcile the off-Telegram surface. (PR 3 also
-        // resets `startedAt` here: the TTL measures how long the operator had to
-        // answer, and until this moment they had nothing to answer.)
-        if (live.undeliverable != null) {
-          live.undeliverable = null
-          live.redeliveryFailures = 0
-          // RESET THE TTL CLOCK. Load-bearing, not cosmetic. `startedAt` is when
-          // the agent asked; the TTL measures how long the operator had to
-          // answer. Until this instant they had NOTHING to answer — the card did
-          // not exist in any chat. Without the reset, a card held through a 4.6h
-          // ban lands already-expired against a 60-min TTL and the very next
-          // reaper tick auto-denies it: we would have MOVED the silent denial,
-          // not removed it.
-          live.startedAt = Date.now()
+        // Drop the hold mark, reset the TTL clock, and reconcile the off-Telegram
+        // surface — as ONE shared decision (`applyDeliveredHoldReset`, #3128) that
+        // the outcome test's harness ALSO drives, so deleting the `startedAt` reset
+        // turns the behavioural `(d2)` test red instead of only a fragile grep.
+        // PR 3: the reset is load-bearing — the TTL measures how long the operator
+        // had to answer, and until this moment they had nothing to answer.
+        if (applyDeliveredHoldReset(live, Date.now())) {
           reconcileBlockedApprovals()
           process.stderr.write(
             `telegram gateway: permission-card RE-DELIVERED request=${requestId} ` +

--- a/telegram-plugin/tests/approval-hold-harness.ts
+++ b/telegram-plugin/tests/approval-hold-harness.ts
@@ -42,6 +42,7 @@ import {
   safeActionForRecord,
   holdReasonFor,
   heldRetryBackoffMs,
+  applyDeliveredHoldReset,
   type UndeliverableMark,
   type BlockedApprovalStore,
 } from '../gateway/approval-hold.js'
@@ -280,12 +281,11 @@ export function createHarness(opts: { cap?: number; targets?: string[] } = {}): 
         const live = pending.get(requestId)
         if (live && sent) {
           live.cards.push({ chatId, messageId: sent.message_id })
-          if (live.undeliverable != null) {
-            live.undeliverable = null
-            live.redeliveryFailures = 0
-            // PR 3: the operator's decision window starts NOW — until this
-            // moment they had nothing to answer.
-            live.startedAt = clock.now()
+          // Drive the SAME reset the gateway drives (#3128) — no private copy.
+          // Deleting `startedAt = now` from `applyDeliveredHoldReset` turns the
+          // `(d2)` full-window outcome test RED, because there is one shared
+          // implementation, not a mirror the harness silently compensates with.
+          if (applyDeliveredHoldReset(live, clock.now())) {
             reconcile()
           }
         }

--- a/telegram-plugin/tests/approval-hold-outcome.test.ts
+++ b/telegram-plugin/tests/approval-hold-outcome.test.ts
@@ -289,8 +289,16 @@ describe('gateway wiring — the leash', () => {
     expect(sweep).not.toContain('if (now - v.startedAt > ttl)')
   })
 
-  it('successful (re)delivery resets startedAt', () => {
-    expect(GATEWAY_SRC).toContain('live.startedAt = Date.now()')
+  it('successful (re)delivery resets startedAt through the SHARED reset (#3128)', () => {
+    // This pin is no longer the safety net for the reset — the behavioural `(d2)`
+    // test above is, and it now drives the same `applyDeliveredHoldReset` the
+    // gateway does, so deleting `startedAt = now` from that one shared function
+    // turns `(d2)` RED. This only guards the WIRING: that the gateway routes
+    // delivery through the shared reset and can't regrow a private inline copy
+    // that drifts from what the harness exercises.
+    expect(GATEWAY_SRC).toContain('applyDeliveredHoldReset(live, Date.now())')
+    // …and must NOT carry its own inline copy of the reset.
+    expect(GATEWAY_SRC).not.toContain('live.startedAt = Date.now()')
   })
 
   it('the missed-approvals re-offer no longer drops a card that never landed', () => {


### PR DESCRIPTION
## Problem

`telegram-plugin/tests/approval-hold-harness.ts` **mirrored** the gateway's on-delivery `startedAt` reset rather than calling the same code. The behavioural outcome test `(d2)` — "the TTL clock RESTARTS on delivery — the operator gets a full window" — therefore drove the harness's *private copy*, not production. Deleting `live.startedAt = Date.now()` from `gateway.ts` would have left `(d2)` **green**; only a fragile source-text grep (`GATEWAY_SRC.toContain('live.startedAt = Date.now()')`) would have caught it, and greps drift.

Same placebo-pin class as the two already fixed:
- the leash / never-auto-deny — #3123
- never-auto-approve — #3126

## Why it matters

The `startedAt` reset on (re)delivery is what gives the operator a FULL TTL window once the card finally lands. Without it, a card held through a 4.6h ban lands already-expired against a 60-min TTL and the very next reaper tick auto-denies it — moving the silent denial, not removing it. That guard was a mirror.

## Fix

Extract the "card landed → clear `undeliverable` + reset `startedAt`" logic into one importable function — `applyDeliveredHoldReset` in `gateway/approval-hold.ts` — and drive it from **both** `gateway.ts` and the harness (the `sweepPermissionTtl` / `shouldExpirePermission` extraction pattern from #3123). There is now a single implementation to delete.

The old source-grep pin is reframed to guard only the WIRING (gateway routes through the shared reset, carries no inline copy), exactly as #3123 reframed the `shouldExpirePermission` pin.

## Proof it is no longer a placebo

Deleting `entry.startedAt = now` from the single shared `applyDeliveredHoldReset`:

```
(fail) ... the whole run dispatches exactly ONE verdict, and it is the operator's
  Expected: [{ behavior: "allow", requestId: "req-overlord-1" }]
  Received: [{ behavior: "deny", message: "timed out", requestId: "req-overlord-1" }]
 10 pass, 3 fail
```

The held card auto-denies "timed out" — the exact incident behaviour. Before this change that same deletion left all 13 tests green. Restored → 49 pass / 0 fail across the two approval-hold test files.

## Verdict rule

- **Vision outcome:** always-on + subscription-honest — the leash never fabricates a verdict for a human who was never shown the ask.
- **Job spec:** `reference/jobs/approve-what-my-agent-can-touch.md`.
- **Invariants:** `no-self-escalation`, `on-leash` — this is the test *for* those invariants, now genuinely able to fail.

## Tests
- `npm run lint` — clean (tsc + all check-* scripts).
- `bun test telegram-plugin/tests/approval-hold-outcome.test.ts telegram-plugin/tests/approval-hold-redeliver.test.ts` — 49 pass / 0 fail.
- Deliberate-regression proof above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)