### PR TITLE
Fixes #3086: scope bridge-dead-watchdog to the gateway's own primary bridge

### DIFF
--- a/telegram-plugin/gateway/bridge-dead-watchdog.ts
+++ b/telegram-plugin/gateway/bridge-dead-watchdog.ts
@@ -32,11 +32,15 @@
  *     claude itself down — where a bounce is either premature or
  *     futile); the timer re-arms so a slow-booting claude gets the full
  *     grace window again once it appears;
- *   - cron-session bridges (`<agent>-cron`) and anonymous IPC clients
- *     (recall.py one-shots, pre-handshake connects) neither satisfy nor
- *     re-arm the watchdog — the gating lives INSIDE noteBridge* so a
- *     gateway handler refactor can't silently reintroduce the
- *     bounce-after-cron-fire false positive;
+ *   - cron-session bridges (`<agent>-cron`), anonymous IPC clients
+ *     (recall.py one-shots, pre-handshake connects), AND secondary/relay
+ *     clients that register a DIFFERENT agent name than this gateway serves
+ *     (e.g. an `overlord-relay` connecting into another agent's gateway
+ *     socket — #3086) neither satisfy nor re-arm the watchdog: only the
+ *     gateway's OWN primary bridge (agentName === $SWITCHROOM_AGENT_NAME)
+ *     counts. The gating lives INSIDE noteBridge* so a gateway handler
+ *     refactor can't silently reintroduce the bounce-after-cron-fire or the
+ *     bounce-after-relay-disconnect false positive;
  *   - loud, structured escalation log line including a fresh
  *     bridge-crash.log tail (PR #3037 breadcrumbs) so the operator sees
  *     WHY from the supervisor log alone.
@@ -352,6 +356,16 @@ export interface BridgeDeadWatchdogOpts {
    *  unref (the watchdog must never keep the gateway process alive). */
   setTimer?: (fn: () => void, ms: number) => unknown
   clearTimer?: (handle: unknown) => void
+  /** The agent identity THIS gateway serves ($SWITCHROOM_AGENT_NAME).
+   *  Only a bridge client registering under this exact name is the
+   *  primary bridge whose presence/absence drives the watchdog. Secondary
+   *  or relay clients (a different named identity connecting into this
+   *  gateway's socket — e.g. `overlord-relay`, #3086) are ignored on both
+   *  the register and disconnect paths. When unset/empty (a misconfigured
+   *  gateway with no agent name), the watchdog falls back to the pre-#3086
+   *  test — any named non-cron client counts — so a genuine bridge death is
+   *  still caught rather than silently un-guarded. */
+  selfAgentName?: string
   /** Injectable clock (marker ts + crash-log freshness). */
   nowMs?: () => number
   /** Injectable marker writer (tests avoid real fs). */
@@ -365,15 +379,18 @@ export interface BridgeDeadWatchdog {
    *  when the cross-boot streak cap is already reached (stands down with
    *  an audit line instead). */
   arm: () => void
-  /** A bridge client registered. Only a REAL bridge (named, non-cron)
-   *  satisfies the watchdog — cron sessions (`<agent>-cron`) and
-   *  anonymous clients (agentName null) are ignored HERE so a gateway
-   *  handler refactor can't reorder the gating away (review finding 5). */
+  /** A bridge client registered. Only THIS gateway's OWN primary bridge
+   *  (agentName === selfAgentName, named, non-cron) satisfies the watchdog
+   *  — cron sessions (`<agent>-cron`), anonymous clients (agentName null),
+   *  and secondary/relay clients registering a different name (#3086) are
+   *  ignored HERE so a gateway handler refactor can't reorder the gating
+   *  away (review finding 5). */
   noteBridgeRegistered: (agentName: string | null | undefined) => void
-  /** A bridge client disconnected. Re-arms the grace window only for the
-   *  real bridge (same internal gating), so a bridge that dies AFTER boot
-   *  and never reconnects also escalates. Still capped by the
-   *  once-per-boot fuse. */
+  /** A bridge client disconnected. Re-arms the grace window only for THIS
+   *  gateway's own primary bridge (same internal gating), so a bridge that
+   *  dies AFTER boot and never reconnects also escalates — while a
+   *  transient relay/secondary client's disconnect (#3086) is a no-op.
+   *  Still capped by the once-per-boot fuse. */
   noteBridgeDisconnected: (agentName: string | null | undefined) => void
   /** Evaluate now (the timer body — exposed for tests). Returns the
    *  decision taken. */
@@ -384,9 +401,34 @@ export interface BridgeDeadWatchdog {
   hasEscalated: () => boolean
 }
 
-/** Is this client identity the REAL main-agent bridge (named, non-cron)? */
-function isRealBridgeIdentity(agentName: string | null | undefined): boolean {
-  return agentName != null && agentName.length > 0 && !isCronIdentity(agentName)
+/**
+ * Is this client identity THIS gateway's OWN primary main-agent bridge?
+ *
+ * A named, non-cron client whose name matches the gateway's own agent
+ * identity (`selfAgentName` = $SWITCHROOM_AGENT_NAME). A switchroom gateway
+ * serves exactly one agent, and its real bridge registers under exactly that
+ * name (see bridge/bridge.ts — `agentName: AGENT_NAME`). Secondary or relay
+ * clients (e.g. an `overlord-relay` that connects into another agent's
+ * gateway socket, #3086) register a DIFFERENT name; they are named and
+ * non-cron but are NOT this gateway's primary bridge, so their register /
+ * disconnect must neither satisfy nor re-arm the watchdog — otherwise a
+ * transient relay disconnect marks the (still-alive) primary bridge dead and
+ * bounces a healthy container.
+ *
+ * When `selfAgentName` is unset/empty (misconfigured gateway) we cannot
+ * identity-match, so fall back to the pre-#3086 test — any named non-cron
+ * client counts — keeping the watchdog protective rather than un-guarded.
+ */
+function isRealBridgeIdentity(
+  agentName: string | null | undefined,
+  selfAgentName: string | null | undefined,
+): boolean {
+  if (agentName == null || agentName.length === 0) return false
+  if (isCronIdentity(agentName)) return false
+  if (selfAgentName != null && selfAgentName.length > 0) {
+    return agentName === selfAgentName
+  }
+  return true
 }
 
 export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDeadWatchdog {
@@ -404,6 +446,7 @@ export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDe
     opts.readCrashTail ?? ((p: string, t: number) => readFreshCrashLogTail(p, { nowMs: t }))
   const priorStreak = opts.priorStreak ?? 0
   const maxConsecutive = opts.maxConsecutive ?? MAX_CONSECUTIVE_ESCALATIONS
+  const selfAgentName = opts.selfAgentName
 
   let timer: unknown = null
   let bridgeRegistered = false
@@ -528,13 +571,13 @@ export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDe
   return {
     arm: armInternal,
     noteBridgeRegistered: (agentName) => {
-      if (!isRealBridgeIdentity(agentName)) return
+      if (!isRealBridgeIdentity(agentName, selfAgentName)) return
       bridgeRegistered = true
       bridgeEverRegistered = true
       cancel()
     },
     noteBridgeDisconnected: (agentName) => {
-      if (!isRealBridgeIdentity(agentName)) return
+      if (!isRealBridgeIdentity(agentName, selfAgentName)) return
       bridgeRegistered = false
       armInternal()
     },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10359,6 +10359,13 @@ const bridgeDeadWatchdog = createBridgeDeadWatchdog({
   // consecutive-escalation count. At the cap, arm() stands down loudly
   // instead of restart-looping a deterministically-failing bridge.
   priorStreak: bridgeDeadPriorStreak,
+  // #3086 — only THIS gateway's own primary bridge (registering under
+  // $SWITCHROOM_AGENT_NAME) drives the watchdog. A secondary/relay client
+  // (e.g. `overlord-relay`) registering a different name into this socket
+  // is named + non-cron but must NOT mark the (still-alive) primary bridge
+  // dead when it disconnects. Empty string ⟹ fall back to the pre-#3086
+  // "any named non-cron client" test inside the watchdog.
+  selfAgentName: process.env.SWITCHROOM_AGENT_NAME ?? '',
 })
 if (BRIDGE_DEAD_ESCALATION_ENABLED) {
   bridgeDeadWatchdog.arm()
@@ -10398,10 +10405,11 @@ const ipcServer: IpcServer = createIpcServer({
       : []
     // #3038 — a REAL (named, non-cron) bridge registered: stand the
     // bridge-dead watchdog down. Anonymous clients (recall.py, mcp
-    // handshakes) and cron-session bridges must NOT satisfy it — the
-    // watchdog gates on the identity INTERNALLY (isRealBridgeIdentity), so
-    // this call is safe wherever it sits relative to the cron early-return
-    // above (#3038 review finding 5).
+    // handshakes), cron-session bridges, and secondary/relay clients
+    // registering a name other than this gateway's own agent (#3086) must
+    // NOT satisfy it — the watchdog gates on the identity INTERNALLY
+    // (isRealBridgeIdentity vs selfAgentName), so this call is safe wherever
+    // it sits relative to the cron early-return above (#3038 review finding 5).
     bridgeDeadWatchdog.noteBridgeRegistered(client.agentName)
     client.send({ type: 'status', status: 'agent_connected' })
 
@@ -10595,8 +10603,10 @@ const ipcServer: IpcServer = createIpcServer({
       // #3038 — the real bridge went away mid-life. Re-arm the grace
       // window: a normal claude restart re-registers within seconds and
       // stands it down; a bridge that died for good escalates once (the
-      // once-per-boot fuse inside the watchdog caps it). Cron/anonymous
-      // identities are ignored inside the watchdog itself (finding 5).
+      // once-per-boot fuse inside the watchdog caps it). Cron/anonymous and
+      // secondary/relay identities (a name other than this gateway's own
+      // agent, #3086) are ignored inside the watchdog itself (finding 5) —
+      // so a transient relay disconnect never bounces a healthy container.
       if (BRIDGE_DEAD_ESCALATION_ENABLED) bridgeDeadWatchdog.noteBridgeDisconnected(client.agentName)
     }
 

--- a/telegram-plugin/tests/bridge-dead-watchdog.test.ts
+++ b/telegram-plugin/tests/bridge-dead-watchdog.test.ts
@@ -99,6 +99,9 @@ function makeWatchdog(overrides: Partial<BridgeDeadWatchdogOpts> = {}) {
   const state = { sessionAlive: true, shuttingDown: false, escalateResult: true }
   const wd = createBridgeDeadWatchdog({
     graceMs: 90_000,
+    // The gateway serves AGENT — only AGENT's own bridge drives the
+    // watchdog (#3086). Overridable per-test.
+    selfAgentName: AGENT,
     isSessionAlive: () => state.sessionAlive,
     isShuttingDown: () => state.shuttingDown,
     escalate: (reason) => {
@@ -383,6 +386,64 @@ describe('cron / anonymous identity gating', () => {
     expect(harness.liveCount()).toBe(0)
     wd.noteBridgeDisconnected(null) // recall.py one-shot closing
     expect(harness.liveCount()).toBe(0) // did not re-arm
+  })
+})
+
+// ─── #3086: secondary/relay identity gating ──────────────────────────────────
+//
+// Repro of the klanker incident: a short-lived `overlord-relay` IPC client
+// registers and disconnects against klanker's gateway socket while klanker's
+// OWN bridge is registered and actively replying. Pre-fix, isRealBridgeIdentity
+// treated the relay (named, non-cron) as the real bridge, so its disconnect
+// flipped bridgeRegistered=false, re-armed the grace window, and 90s later the
+// watchdog SIGTERM'd a healthy container — killing the in-flight claude session.
+describe('#3086 secondary/relay identity gating', () => {
+  const RELAY = 'overlord-relay' // a DIFFERENT agent name than AGENT
+
+  it('a relay disconnecting while the primary bridge is alive does NOT re-arm or escalate', () => {
+    const { wd, harness, escalations } = makeWatchdog() // selfAgentName === AGENT
+    wd.arm()
+    wd.noteBridgeRegistered(AGENT) // klanker's own bridge — healthy
+    expect(harness.liveCount()).toBe(0) // grace timer stood down
+    // The relay connects then disconnects (flood-ban workaround churn).
+    wd.noteBridgeRegistered(RELAY)
+    wd.noteBridgeDisconnected(RELAY)
+    // Must NOT re-arm: the primary bridge never went away.
+    expect(harness.liveCount()).toBe(0)
+    expect(escalations).toEqual([])
+    expect(wd.hasEscalated()).toBe(false)
+  })
+
+  it('a relay register does NOT satisfy the watchdog (only the primary bridge does)', () => {
+    const { wd, harness, escalations } = makeWatchdog()
+    wd.arm()
+    wd.noteBridgeRegistered(RELAY) // relay is not THIS gateway's bridge
+    expect(harness.liveCount()).toBe(1) // still armed — primary still missing
+    harness.fireLatest()
+    // Primary bridge genuinely absent → the real failure still escalates.
+    expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
+  })
+
+  it('a genuine PRIMARY bridge death still escalates (fix does not over-suppress)', () => {
+    const { wd, harness, escalations } = makeWatchdog()
+    wd.arm()
+    wd.noteBridgeRegistered(AGENT) // primary registers
+    expect(harness.liveCount()).toBe(0)
+    wd.noteBridgeDisconnected(AGENT) // primary dies for good, never reconnects
+    expect(harness.liveCount()).toBe(1) // re-armed
+    harness.fireLatest()
+    expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
+  })
+
+  it('fallback: with no selfAgentName, any named non-cron client still counts (pre-#3086)', () => {
+    const { wd, harness, escalations } = makeWatchdog({ selfAgentName: '' })
+    wd.arm()
+    wd.noteBridgeRegistered(RELAY) // no identity to match against → treated as real
+    expect(harness.liveCount()).toBe(0) // satisfied the watchdog
+    wd.noteBridgeDisconnected(RELAY)
+    expect(harness.liveCount()).toBe(1) // re-armed
+    harness.fireLatest()
+    expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
   })
 })
 


### PR DESCRIPTION
## Problem

The gateway `bridge-dead-watchdog` (#3038) treated **any** named, non-cron IPC client as "the real bridge" — `isRealBridgeIdentity(agentName)` returned true for any non-empty name that didn't end in `-cron`. It keeps a single `bridgeRegistered` boolean, so `noteBridgeDisconnected(agentName)` flipped it false and armed the 90s escalation timer for **any** such identity, without checking whether the gateway's own primary bridge was still registered.

A switchroom gateway serves exactly one agent, and its real bridge registers under `$SWITCHROOM_AGENT_NAME` (`bridge/bridge.ts` → `agentName: AGENT_NAME`). But a short-lived **secondary/relay** client — e.g. an `overlord-relay` connecting into another agent's gateway socket (the #3084 flood-ban workaround) — registers a *different* name and still passed the test. Its disconnect marked the (still-alive) primary bridge dead and, 90s later, SIGTERM'd a healthy PID 1 with `reason=bridge-dead-resume`, killing the live claude session and its in-flight background workers.

Reproduced live on klanker 2026-07-11: two container bounces, each ~90s after an `overlord-relay` disconnect, while klanker's own bridge was registered and actively sending replies.

## Fix

Issue direction #1, deterministic: **identity-scope the watchdog to the gateway's own agent.** `isRealBridgeIdentity` now takes `selfAgentName` (= `$SWITCHROOM_AGENT_NAME`, injected via `BridgeDeadWatchdogOpts`) and counts a client only when `agentName === selfAgentName`. Cron (`<agent>-cron`) and anonymous (null/empty) identities are still gated exactly as before; secondary/relay names no longer satisfy **or** re-arm the watchdog. The gating stays **inside** `noteBridge*` so a gateway-handler refactor can't reorder it away (#3038 finding 5).

Safe fallback: when `selfAgentName` is unset/empty (a misconfigured gateway with no agent name), the watchdog reverts to the pre-#3086 test — any named non-cron client counts — so a genuine bridge death is still caught rather than silently un-guarded.

## Tests

`telegram-plugin/tests/bridge-dead-watchdog.test.ts` — new `#3086` describe block:
- a relay register+disconnect while the primary bridge is alive does **not** re-arm or escalate
- a relay register alone does **not** satisfy the watchdog (primary still missing → still escalates on real absence)
- a genuine **primary** bridge death still escalates (no over-suppression)
- the no-`selfAgentName` fallback still counts any named non-cron client

The two behavioral assertions **fail pre-fix** (verified by neutering the identity match), pass post-fix. Full watchdog suite: 44 pass. `gateway-bridge` + `ipc-server-client`: 39 pass. `npm run lint` clean.

## Verdict

- **Vision outcome:** always-on — a healthy gateway + live claude session must not be bounced by a transient sibling disconnect.
- **Invariants:** on-leash / single-tenant preserved (one gateway == one agent identity).

Related: #3084 (flood-ban degraded mode — the relay that triggered this).

Fixes #3086

🤖 Generated with [Claude Code](https://claude.com/claude-code)