### PR TITLE
Fixes #3157: doctor pre-flight scan for agent-unreadable dotfiles + reconcile ownership (core already landed in #3169)

### DIFF
--- a/src/agents/agent-owned-tree.ts
+++ b/src/agents/agent-owned-tree.ts
@@ -123,21 +123,35 @@ export function alignAgentTreeOwnershipIfRoot(
  * bundled-skills pool). Group-readability is deliberately ignored — agent
  * containers run with a single supplementary-group-free uid:gid, so
  * owner-or-other is the honest readability predicate.
+ *
+ * The `fs` seam is injectable so the SAME readability predicate can be
+ * reused off the reconcile hot-path — the `switchroom doctor` pre-flight
+ * (#3157 direction 2, `doctor-agent-dotfile-ownership.ts`) drives it with a
+ * synthetic stat table to assert a root:root 0600 settings.json is flagged
+ * for the agent's ACTUAL runtime uid (0 for a `root:` agent, the
+ * deterministic 10001+ uid otherwise) without needing a real chown. Defaults
+ * to node:fs so every existing caller (the reconcile assert) is unchanged.
  */
+export interface UnreadableScanFs {
+  lstatSync: (p: string) => { isSymbolicLink(): boolean };
+  statSync: (p: string) => { uid: number; mode: number; isDirectory(): boolean };
+}
+
 export function findAgentUnreadablePaths(
   candidates: string[],
   agentUid: number,
+  fs: UnreadableScanFs = { lstatSync, statSync },
 ): string[] {
   const bad: string[] = [];
   for (const p of candidates) {
     let ls;
     try {
-      ls = lstatSync(p);
+      ls = fs.lstatSync(p);
     } catch {
       continue; // deleted / never created — nothing to read
     }
     if (ls.isSymbolicLink()) continue;
-    const st = statSync(p);
+    const st = fs.statSync(p);
     if (st.uid === agentUid) continue;
     const otherReadable = st.isDirectory()
       ? (st.mode & 0o005) === 0o005 // need r+x to read through a dir

--- a/src/cli/doctor-agent-dotfile-ownership.test.ts
+++ b/src/cli/doctor-agent-dotfile-ownership.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the agent dotfile-ownership doctor probe (#3157 direction 2).
+ *
+ * The 2026-07-12 incident: rollout reconcile left non-root agents'
+ * `.claude/settings.json` as `root:root 0600`, so the agent (running as its
+ * deterministic 10001+ uid) could not read its own permission allowlist and
+ * stormed the operator with approval cards. This probe is the operator-facing
+ * pre-flight for an ALREADY-poisoned tree; the tests below pin the outcomes
+ * that matter:
+ *
+ *   - a root:root 0600 settings.json under a NON-root agent → `fail`
+ *     (this is the bug; the check exists to surface it)
+ *   - the SAME root-owned file under a `root:` agent (runs as uid 0) → `ok`
+ *     (benign — the klanker caveat from the issue)
+ *   - correctly agent-owned files → `ok`
+ *   - other-readable (0644) files → `ok` even when not agent-owned
+ *
+ * All ownership is simulated via an injected stat table so no real chown
+ * (which needs CAP_CHOWN) is required in CI.
+ */
+
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  runAgentDotfileOwnershipChecks,
+  agentDotfileCandidates,
+} from "./doctor-agent-dotfile-ownership.js";
+import { allocateAgentUid } from "../agents/agent-uid.js";
+import type { UnreadableScanFs } from "../agents/agent-owned-tree.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const AGENTS_DIR = "/tmp/agents";
+
+interface FakeStat {
+  uid: number;
+  mode: number;
+  dir?: boolean;
+  symlink?: boolean;
+}
+
+/** Build an injected stat seam from a { path -> FakeStat } table. A path
+ *  absent from the table throws ENOENT (i.e. the file does not exist). */
+function fakeScanFs(table: Record<string, FakeStat>): UnreadableScanFs {
+  const get = (p: string): FakeStat => {
+    const s = table[p];
+    if (s === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    return s;
+  };
+  return {
+    lstatSync: (p: string) => {
+      const s = get(p);
+      return { isSymbolicLink: () => s.symlink === true };
+    },
+    statSync: (p: string) => {
+      const s = get(p);
+      return { uid: s.uid, mode: s.mode, isDirectory: () => s.dir === true };
+    },
+  };
+}
+
+function cfg(agents: Record<string, { root?: boolean }>): SwitchroomConfig {
+  return { agents } as unknown as SwitchroomConfig;
+}
+
+const NON_ROOT_AGENT = "clerk";
+const ROOT_AGENT = "klanker";
+
+describe("runAgentDotfileOwnershipChecks", () => {
+  it("returns no results when there are no agents", () => {
+    const r = runAgentDotfileOwnershipChecks(cfg({}), { agentsDir: AGENTS_DIR });
+    expect(r).toEqual([]);
+  });
+
+  it("FAILS a non-root agent whose settings.json is root:root 0600 (the incident)", () => {
+    const agentDir = join(AGENTS_DIR, NON_ROOT_AGENT);
+    const settings = join(agentDir, ".claude", "settings.json");
+    const r = runAgentDotfileOwnershipChecks(cfg({ [NON_ROOT_AGENT]: {} }), {
+      agentsDir: AGENTS_DIR,
+      existsSync: (p) => p === agentDir,
+      // root:root 0600 — owner root (uid 0), no other-read bit.
+      scanFs: fakeScanFs({ [settings]: { uid: 0, mode: 0o600 } }),
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0]!.status).toBe("fail");
+    expect(r[0]!.detail).toContain(settings);
+    // Remediation targets the agent's REAL uid, not root.
+    const uid = allocateAgentUid(NON_ROOT_AGENT);
+    expect(r[0]!.fix).toContain(`${uid}:${uid}`);
+  });
+
+  it("PASSES the same root-owned file under a root: agent (runs as uid 0 — benign)", () => {
+    const agentDir = join(AGENTS_DIR, ROOT_AGENT);
+    const settings = join(agentDir, ".claude", "settings.json");
+    const r = runAgentDotfileOwnershipChecks(cfg({ [ROOT_AGENT]: { root: true } }), {
+      agentsDir: AGENTS_DIR,
+      existsSync: (p) => p === agentDir,
+      scanFs: fakeScanFs({ [settings]: { uid: 0, mode: 0o600 } }),
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0]!.status).toBe("ok");
+    expect(r[0]!.detail).toContain("uid 0");
+  });
+
+  it("PASSES a non-root agent whose settings.json is correctly agent-owned 0600", () => {
+    const agentDir = join(AGENTS_DIR, NON_ROOT_AGENT);
+    const settings = join(agentDir, ".claude", "settings.json");
+    const uid = allocateAgentUid(NON_ROOT_AGENT);
+    const r = runAgentDotfileOwnershipChecks(cfg({ [NON_ROOT_AGENT]: {} }), {
+      agentsDir: AGENTS_DIR,
+      existsSync: (p) => p === agentDir,
+      scanFs: fakeScanFs({ [settings]: { uid, mode: 0o600 } }),
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0]!.status).toBe("ok");
+    expect(r[0]!.detail).toContain(`uid ${uid}`);
+  });
+
+  it("PASSES a root-owned but other-readable (0644) file — the agent can still read it", () => {
+    const agentDir = join(AGENTS_DIR, NON_ROOT_AGENT);
+    const settings = join(agentDir, ".claude", "settings.json");
+    const r = runAgentDotfileOwnershipChecks(cfg({ [NON_ROOT_AGENT]: {} }), {
+      agentsDir: AGENTS_DIR,
+      existsSync: (p) => p === agentDir,
+      scanFs: fakeScanFs({ [settings]: { uid: 0, mode: 0o644 } }),
+    });
+    expect(r[0]!.status).toBe("ok");
+  });
+
+  it("skips (no result) an agent that is not scaffolded yet", () => {
+    const r = runAgentDotfileOwnershipChecks(cfg({ [NON_ROOT_AGENT]: {} }), {
+      agentsDir: AGENTS_DIR,
+      existsSync: () => false,
+      scanFs: fakeScanFs({}),
+    });
+    expect(r).toEqual([]);
+  });
+
+  it("flags a poisoned .mcp.json even when settings.json is fine", () => {
+    const agentDir = join(AGENTS_DIR, NON_ROOT_AGENT);
+    const uid = allocateAgentUid(NON_ROOT_AGENT);
+    const settings = join(agentDir, ".claude", "settings.json");
+    const mcp = join(agentDir, ".mcp.json");
+    const r = runAgentDotfileOwnershipChecks(cfg({ [NON_ROOT_AGENT]: {} }), {
+      agentsDir: AGENTS_DIR,
+      existsSync: (p) => p === agentDir,
+      scanFs: fakeScanFs({
+        [settings]: { uid, mode: 0o600 }, // fine
+        [mcp]: { uid: 0, mode: 0o600 }, // root-owned
+      }),
+    });
+    expect(r[0]!.status).toBe("fail");
+    expect(r[0]!.detail).toContain(mcp);
+  });
+
+  it("warns when the agents directory cannot be resolved", () => {
+    // No agentsDir passed and no switchroom block → resolveAgentsDir throws
+    // (config.switchroom is undefined). Guard against a container-set
+    // SWITCHROOM_AGENTS_DIR override, which would otherwise resolve a path.
+    const prev = process.env.SWITCHROOM_AGENTS_DIR;
+    delete process.env.SWITCHROOM_AGENTS_DIR;
+    try {
+      const r = runAgentDotfileOwnershipChecks(cfg({ [NON_ROOT_AGENT]: {} }));
+      expect(r).toHaveLength(1);
+      expect(r[0]!.status).toBe("warn");
+    } finally {
+      if (prev !== undefined) process.env.SWITCHROOM_AGENTS_DIR = prev;
+    }
+  });
+
+  it("agentDotfileCandidates covers settings.json, .claude.json and both .mcp.json", () => {
+    const c = agentDotfileCandidates("/x");
+    expect(c).toContain("/x/.claude/settings.json");
+    expect(c.some((p) => p.endsWith(".claude.json"))).toBe(true);
+    expect(c).toContain("/x/.mcp.json");
+    expect(c).toContain("/x/.claude-cron/.mcp.json");
+  });
+});

--- a/src/cli/doctor-agent-dotfile-ownership.ts
+++ b/src/cli/doctor-agent-dotfile-ownership.ts
@@ -1,0 +1,168 @@
+/**
+ * Agent dotfile-ownership doctor probe (#3157 direction 2).
+ *
+ * ## Why this exists
+ *
+ * The rollout restart-reconcile once rewrote per-agent
+ * `.claude/settings.json` as `root:root 0600` (the 2026-07-12 v0.18.13→14
+ * incident). A non-root agent then could not read its own settings.json,
+ * so Claude Code loaded NO permission allowlist and every tool call threw
+ * an operator approval card — a fleet-wide "approve everything" storm.
+ *
+ * The recurrence is now blocked at the source: `reconcileAgent` ends with
+ * the `alignAgentTreeOwnershipIfRoot` sweep + `findAgentUnreadablePaths`
+ * assert (#3169, `agent-owned-tree.ts`). This probe is the OPERATOR-facing
+ * twin of that runtime assert — a cheap standing `switchroom doctor` check
+ * that catches a tree ALREADY poisoned (by the historical incident, a
+ * writer that ran OUTSIDE reconcile, or a stopgap host-side edit that
+ * flipped ownership) BEFORE the agent boots into a card storm.
+ *
+ * Issue #3157 fix-direction 2 asked precisely for this: the ownership
+ * pre-flight already caught a root-owned `switchroom.yaml`, but NOT the
+ * per-agent `.claude/settings.json` / `.claude.json`. This closes that gap.
+ *
+ * ## Runtime-uid correctness (the klanker caveat)
+ *
+ * The check compares each dotfile against the agent's ACTUAL runtime uid,
+ * not a blanket "must be 10001+". A `root:` agent (e.g. klanker) runs its
+ * `claude` as uid 0 (`compose.ts`: `user: "0:0"`), so root-owned files are
+ * BENIGN there and must not be flagged — exactly the note in #3157. So the
+ * expected uid is `0` for a `root:` agent and the deterministic
+ * `allocateAgentUid(name)` (10001+) otherwise, matching what compose writes
+ * into the container's `user:` field.
+ *
+ * ## Predicate reuse
+ *
+ * Readability is decided by the SAME `findAgentUnreadablePaths` predicate
+ * the reconcile assert uses (owner-or-other-readable, symlinks skipped) so
+ * the doctor verdict can never drift from what actually wedges the agent.
+ */
+
+import { existsSync, lstatSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { resolveAgentsDir } from "../config/loader.js";
+import { allocateAgentUid } from "../agents/agent-uid.js";
+import {
+  findAgentUnreadablePaths,
+  type UnreadableScanFs,
+} from "../agents/agent-owned-tree.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+export interface AgentDotfileOwnershipDeps {
+  /** Defaults to `resolveAgentsDir(config)`, resolved lazily + guarded. */
+  agentsDir?: string;
+  /** Existence probe — injected in tests. */
+  existsSync?: (p: string) => boolean;
+  /** Stat seam handed to `findAgentUnreadablePaths` — injected in tests so a
+   *  root:root 0600 file can be simulated without a real chown. */
+  scanFs?: UnreadableScanFs;
+}
+
+/**
+ * The per-agent dotfiles whose ownership determines whether the agent can
+ * load its own Claude Code state. `.claude/settings.json` carries the
+ * permission allowlist + defaultMode (the incident file); `.claude.json`
+ * holds the MCP trust list; `.mcp.json` and the cron `.mcp.json` carry the
+ * agent's MCP server wiring. All are atomic-rewrite (new-inode) targets on
+ * the reconcile path, i.e. exactly the class that flips to root-owned.
+ */
+export function agentDotfileCandidates(agentDir: string): string[] {
+  return [
+    join(agentDir, ".claude", "settings.json"),
+    join(agentDir, ".claude.json"),
+    join(agentDir, ".claude", ".claude.json"),
+    join(agentDir, ".mcp.json"),
+    join(agentDir, ".claude-cron", ".mcp.json"),
+  ];
+}
+
+/**
+ * For each configured agent, assert its critical dotfiles are readable by
+ * the agent's actual runtime uid. A root-owned 0600 settings.json under a
+ * non-root agent fails with a `chown` remediation; a `root:` agent whose
+ * files are root-owned passes (benign — it runs as uid 0).
+ */
+export function runAgentDotfileOwnershipChecks(
+  config: SwitchroomConfig,
+  deps: AgentDotfileOwnershipDeps = {},
+): CheckResult[] {
+  const results: CheckResult[] = [];
+  const agents = Object.keys(config.agents ?? {});
+  if (agents.length === 0) return results;
+
+  const exists = deps.existsSync ?? existsSync;
+  const scanFs = deps.scanFs ?? { lstatSync, statSync };
+
+  let agentsDir = deps.agentsDir;
+  if (agentsDir === undefined) {
+    try {
+      agentsDir = resolveAgentsDir(config);
+    } catch {
+      agentsDir = undefined;
+    }
+  }
+  if (agentsDir === undefined) {
+    return [
+      {
+        name: "agent dotfile ownership",
+        status: "warn",
+        detail:
+          "could not resolve the agents directory (no switchroom block) — skipped dotfile-ownership check",
+      },
+    ];
+  }
+
+  for (const name of agents) {
+    const agentDir = join(agentsDir, name);
+    if (!exists(agentDir)) {
+      // Not scaffolded yet — nothing to own. Silent (no result) mirrors
+      // other scaffold probes' "run apply first" posture without noise.
+      continue;
+    }
+
+    // Actual runtime uid: 0 for a root-tier agent (runs `user: "0:0"`),
+    // the deterministic non-root uid otherwise. This is the exact value
+    // compose.ts stamps into the container, so a root-owned file is only
+    // ever flagged when the agent CANNOT read it at runtime. `root:` is a
+    // per-agent-only flag (never cascaded), so read it from the raw agent
+    // config exactly as compose.ts does (`agent.root === true`).
+    const isRoot = config.agents[name]?.root === true;
+    const runtimeUid = isRoot ? 0 : allocateAgentUid(name);
+
+    const candidates = agentDotfileCandidates(agentDir);
+    const unreadable = findAgentUnreadablePaths(candidates, runtimeUid, scanFs);
+
+    if (unreadable.length === 0) {
+      results.push({
+        name: `dotfile ownership: ${name}`,
+        status: "ok",
+        detail: isRoot
+          ? `runs as uid 0 (root-tier) — dotfiles readable`
+          : `dotfiles readable by agent uid ${runtimeUid}`,
+      });
+      continue;
+    }
+
+    results.push({
+      name: `dotfile ownership: ${name}`,
+      status: "fail",
+      detail:
+        `${unreadable.length} dotfile(s) not readable by the agent's runtime ` +
+        `uid ${runtimeUid}: ${unreadable.join(", ")}. Claude Code loads no ` +
+        `permission allowlist from an unreadable settings.json → the agent ` +
+        `prompts the operator to approve every tool call (card storm).`,
+      fix: `sudo chown -h -R ${runtimeUid}:${runtimeUid} ${agentDir}  # then \`switchroom agent restart ${name}\``,
+    });
+  }
+
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -44,6 +44,7 @@ import { runMcpSecretChecks } from "./doctor-mcp-secrets.js";
 import { runContextChecks } from "./doctor-context.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
 import { runSecretAccessChecks } from "./doctor-secret-access.js";
+import { runAgentDotfileOwnershipChecks } from "./doctor-agent-dotfile-ownership.js";
 import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
 import {
   loadLiveAllowFromAccessFiles,
@@ -3047,6 +3048,10 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Memory (Hindsight)", results: await checkHindsight(config) },
           { title: "Telegram", results: await checkTelegram(config) },
           { title: "Agents", results: checkAgents(config, configPath) },
+          {
+            title: "Agent dotfile ownership (#3157)",
+            results: runAgentDotfileOwnershipChecks(config),
+          },
           { title: "Credentials", results: runCredentialsMigrationChecks(config) },
           { title: "Audit integrity (WS10-F4)", results: runAuditIntegrityChecks() },
           {


### PR DESCRIPTION
## Scope decision (read first)

While root-causing #3157 I found its **core** — rollout restart-reconcile writing per-agent `.claude/settings.json` as `root:root 0600` — **was already fixed on `main` by PR #3169** (commit `82b8ee88`, merged 2026-07-12, which closed the twin issue #3168). `reconcileAgent` now ends with the `alignAgentTreeOwnershipIfRoot` chown sweep + a `findAgentUnreadablePaths` runtime assert (`src/agents/agent-owned-tree.ts`), covering #3157 fix-directions **1** (writer lands agent-owned) and **3** (post-reconcile readability assert, fail-loud).

What #3169 did **not** land — and what keeps #3157 open — is **fix-direction 2**: the ownership pre-flight already caught a root-owned `switchroom.yaml`, but not the per-agent `.claude/settings.json` / `.claude.json`. This PR closes that gap with an operator-facing `switchroom doctor` check. I did **not** duplicate the already-landed core fix.

The maintainer's related **SIGTERM graceful-marker** comment is a genuinely **separate subsystem** (container init / signal forwarding), so per the "don't bloat the PR" guidance it is **deferred to a follow-up** — root cause documented below.

## Root cause

- Rollout reconcile runs as **root** (hostd spawns `switchroom agent restart` per agent; `src/cli/rollout.ts`). `atomicWriteFileSync` (tmp + rename) replaces the inode, so `settings.json`/`.mcp.json` land owned by the writer's euid: root. Non-root agent (uid 10001+) → EACCES on its own `settings.json` → Claude Code loads no permission allowlist → approval-card storm. **Already fixed by #3169.**
- The `switchroom doctor` ownership pre-flight never stat'd the per-agent dotfiles against the agent's runtime uid, so an already-poisoned tree (historical incident, an out-of-reconcile writer, or a host-side stopgap edit) was invisible until the agent booted into the storm.

## This change

New doctor section **"Agent dotfile ownership (#3157)"** (`src/cli/doctor-agent-dotfile-ownership.ts`, wired in `src/cli/doctor.ts`). For each configured agent it asserts `.claude/settings.json`, `.claude.json`, `.mcp.json` and the cron `.mcp.json` are readable by the agent's **actual runtime uid**:

- **`root:` agent** (e.g. klanker) runs `user: "0:0"` → expected uid `0`; root-owned files are **benign** and pass — exactly the caveat #3157 called out.
- **non-root agent** → deterministic `allocateAgentUid(name)` (10001+), matching what `compose.ts` stamps into the container.

A poisoned file `fail`s with a `sudo chown -h -R <uid>:<uid> <agentDir>` remediation. Readability uses the **same** `findAgentUnreadablePaths` predicate the reconcile assert uses (refactored with an injectable `fs` seam, defaulting to `node:fs` so the existing reconcile caller is unchanged) — the doctor verdict can never drift from what actually wedges the agent.

## Tests

`src/cli/doctor-agent-dotfile-ownership.test.ts` (9 tests, outcome-asserting; ownership simulated via an injected stat table so no real chown/CAP_CHOWN in CI):

- `FAILS a non-root agent whose settings.json is root:root 0600 (the incident)` — the core outcome; remediation targets the agent's real uid.
- `PASSES the same root-owned file under a root: agent (runs as uid 0 — benign)` — the klanker caveat.
- `PASSES a non-root agent whose settings.json is correctly agent-owned 0600`.
- `PASSES a root-owned but other-readable (0644) file`.
- `flags a poisoned .mcp.json even when settings.json is fine`.
- `skips (no result) an agent that is not scaffolded yet`.
- `warns when the agents directory cannot be resolved`.
- `returns no results when there are no agents` + candidate-set coverage.

Existing `tests/reconcile.agent-ownership.test.ts` (17 tests, #3169) stays green with the `findAgentUnreadablePaths` signature change. `npm run lint` clean.

## Follow-up (deferred, separate subsystem): SIGTERM graceful marker

The maintainer noted a plain `docker restart` posts a boot card with `reason=crash` / `kind=agent-crashed` (`boot.lock_stale_recovered_boot_mismatch`). Root cause: the gateway's SIGTERM handler already writes the clean-shutdown marker **and** releases the startup lock (`telegram-plugin/gateway/gateway.ts` `shutdown()` + `process.on('SIGTERM', …)`), so if SIGTERM reached the gateway the boot would classify `graceful`. But the gateway is a **backgrounded sidecar** under tmux/tini (`profiles/_base/start.sh.hbs`), not PID 1 — on a plain `docker restart` (SIGTERM → PID 1) the signal never reaches the gateway, so neither the marker nor the lock release happens → next boot logs `lock_stale_recovered_boot_mismatch` and `determineRestartReason` falls through to `crash`. The durable fix lives in container-init signal forwarding (tini `-g` / a `start.sh` trap forwarding SIGTERM to the gateway pid), a different subsystem from this ownership fix and one that needs container-level (not vitest/bun) verification. Filing separately rather than bloating this PR.

## Verdict rule
- **Vision:** always-on (an update rollout no longer silently wedges the fleet on permission prompts).
- **JTBD:** `fleet-stays-healthy` (surface a fleet failure ranked by impact before it storms the operator); incident context `idempotent-update-and-restart`.
- **Principles:** docs/defaults/consistency — reuses the existing doctor check shape + the single shared ownership predicate.
- **Invariants:** none crossed (read-only diagnostic; no self-escalation, on-leash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)