### PR TITLE
Fixes #3111: scope-precise onFloodWait to avoid global over-suppression

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5494,15 +5494,20 @@ const sendGate = createSendGate({
 const probeFloodWaitRemainingMs = makeFloodWaitProbe(FLOOD_STATE_PATH)
 const rawRobustApiCall = createRetryApiCall({
   log: (line) => process.stderr.write(line),
-  onFloodWait: (retryAfterSec) => {
+  onFloodWait: (retryAfterSec, opts) => {
     // #2923/#3094 — persist the single-object global window (probe reads this).
     makeFloodWaitRecorder(FLOOD_STATE_PATH)(retryAfterSec)
-    // #3084 PR 2 — also open a GLOBAL send-gate window so cosmetic traffic sheds
-    // for the ban's duration even on a SHORT (slept-and-retried) 429 that never
-    // throws FLOOD_WAIT_ACTIVE. Scope-precise windows are opened by the gate's
-    // own FLOOD_WAIT_ACTIVE catch (which has the call's opts).
+    // #3084 PR 2 / #3111 — also open SCOPE-PRECISE send-gate window(s) so cosmetic
+    // traffic sheds for the ban's duration even on a SHORT (slept-and-retried)
+    // 429 that never throws FLOOD_WAIT_ACTIVE. The retry policy now passes the
+    // call's `opts` (#3111) so this opens the FINEST scope the 429 implies —
+    // `chat:`/`group:`/`msg-edit:` for a chat-bound call, `global` only when the
+    // call carries no chat scope (genuinely global) — instead of a blanket
+    // `global` window that would suppress unrelated chats. This mirrors the
+    // gate's own FLOOD_WAIT_ACTIVE catch, which uses the same scope-precise
+    // opener for LONG bans.
     try {
-      sendGate.openFloodWindow('global', Date.now() + Math.max(0, retryAfterSec) * 1000)
+      sendGate.openScopedFloodWindows(opts, Date.now() + Math.max(0, retryAfterSec) * 1000)
     } catch {
       /* best-effort — never let the window hook break the retry path */
     }

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -121,8 +121,14 @@ export interface RetryApiCallConfig {
    * a container restart during an active ban can suppress non-essential
    * sends (boot cards) instead of feeding the same per-bot-token flood
    * counter and prolonging the ban. Best-effort; a throw here is swallowed.
+   *
+   * The call's `opts` are passed through (#3111) so the hook can open a
+   * SCOPE-PRECISE send-gate window: this fires even for a SHORT slept-and-retried
+   * 429 that never throws `FLOOD_WAIT_ACTIVE`, so without the opts the gateway
+   * could only open a blanket `global` window for those. Existing callers that
+   * ignore the second argument are unaffected.
    */
-  onFloodWait?: (retryAfterSec: number) => void
+  onFloodWait?: (retryAfterSec: number, opts?: RetryCallOpts) => void
 }
 
 /**
@@ -353,7 +359,7 @@ export function createRetryApiCall(
           // Persist the flood window so a restart during the ban can suppress
           // non-essential sends instead of extending it (#2923 circuit breaker).
           try {
-            onFloodWait?.(retryAfter)
+            onFloodWait?.(retryAfter, opts)
           } catch {
             /* best-effort — never let the breaker hook break the retry path */
           }

--- a/telegram-plugin/send-gate-degraded.test.ts
+++ b/telegram-plugin/send-gate-degraded.test.ts
@@ -566,11 +566,162 @@ describe('send-gate PR2: opening a window from a 429, and persistence hook', () 
     ).rejects.toBe(floodErr)
 
     const scopes = opened.map((o) => o.scopeKey).sort()
+    // #3111: a chat-bound 429 opens ONLY the chat/group/msg-edit scopes — NOT a
+    // coincident `global` window (which would suppress unrelated chats).
     // H1: msg-edit scope carries the chat_id (msg-edit:7:3), not the bare id.
-    expect(scopes).toEqual(['chat:7', 'global', 'group:7', 'msg-edit:7:3'])
+    expect(scopes).toEqual(['chat:7', 'group:7', 'msg-edit:7:3'])
     // After the window opens, a later cosmetic on the same chat sheds.
     const shed = await gate.gate(async () => 'x', { chat_id: '7', priorityClass: 'cosmetic' })
     expect(shed).toBe(SEND_GATE_SHED)
     expect(gate.stats().global.shed).toBe(1)
+  })
+})
+
+describe('send-gate #3111: scope-precise flood windows', () => {
+  // A structured FLOOD_WAIT_ACTIVE the wrapped `fn` throws to simulate a 429
+  // whose remaining window (`untilTs`) exceeds the fail-fast ceiling.
+  function floodErrUntil(untilTs: number) {
+    const sec = Math.ceil(untilTs / 1000)
+    return Object.assign(new Error('FLOOD_WAIT_ACTIVE'), {
+      retryAfterSec: sec,
+      untilTs,
+      error_code: 429 as const,
+      parameters: { retry_after: sec },
+      original: null,
+    })
+  }
+
+  it('a chat:A 429 suppresses only chat:A — an unrelated chat:B critical still sends', async () => {
+    const clock = new FakeClock()
+    const opened: string[] = []
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      criticalFailFastMs: 60_000,
+      onWindowOpen: (scopeKey) => opened.push(scopeKey),
+    })
+
+    // A LONG (10-min) 429 on chat:A opens the flood window via the gate's catch.
+    const floodErr = floodErrUntil(600_000)
+    await expect(
+      gate.gate(
+        async () => {
+          throw floodErr
+        },
+        { chat_id: 'A', priorityClass: 'critical' },
+      ),
+    ).rejects.toBe(floodErr)
+
+    // Only chat:A was suppressed — pre-#3111 this ALSO opened `global`.
+    expect(opened.sort()).toEqual(['chat:A'])
+    // The 429 came from `fn`, not a fail-fast admission.
+    expect(gate.stats().global.failedFast).toBe(0)
+
+    // An unrelated chat:B critical is NOT fail-fasted — it sends. Pre-#3111 the
+    // coincident global window would have fail-fasted this critical too.
+    const bResult = await gate.gate(async () => 'B-sent', {
+      chat_id: 'B',
+      priorityClass: 'critical',
+    })
+    expect(bResult).toBe('B-sent')
+    expect(gate.stats().global.failedFast).toBe(0)
+    expect(gate.stats().global.sent).toBe(1)
+
+    // A chat:A critical IS fail-fasted — its window exceeds the ceiling.
+    let caught: unknown
+    await gate
+      .gate(async () => 'A-sent', { chat_id: 'A', priorityClass: 'critical' })
+      .catch((e) => {
+        caught = e
+      })
+    expect(isFloodWaitActiveError(caught)).toBe(true)
+    expect(gate.stats().global.failedFast).toBe(1)
+    // chat:B's critical really was the only additional send.
+    expect(gate.stats().global.sent).toBe(1)
+  })
+
+  it('a global 429 (no chat scope) still opens the global window and suppresses everywhere', async () => {
+    const clock = new FakeClock()
+    const opened: string[] = []
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      onWindowOpen: (scopeKey) => opened.push(scopeKey),
+    })
+
+    // A 429 on a call with NO chat_id → the evidence IS global.
+    const floodErr = floodErrUntil(HOUR)
+    await expect(
+      gate.gate(
+        async () => {
+          throw floodErr
+        },
+        { priorityClass: 'critical' },
+      ),
+    ).rejects.toBe(floodErr)
+
+    expect(opened).toEqual(['global'])
+    // An unrelated chat's cosmetic sheds — global covers every scope.
+    const shed = await gate.gate(async () => 'x', { chat_id: 'Z', priorityClass: 'cosmetic' })
+    expect(shed).toBe(SEND_GATE_SHED)
+    expect(gate.stats().global.shed).toBe(1)
+  })
+
+  it('conservativeGlobalFloodScope restores the pre-#3111 always-open-global posture', async () => {
+    const clock = new FakeClock()
+    const opened: string[] = []
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      conservativeGlobalFloodScope: true,
+      onWindowOpen: (scopeKey) => opened.push(scopeKey),
+    })
+
+    const floodErr = floodErrUntil(HOUR)
+    await expect(
+      gate.gate(
+        async () => {
+          throw floodErr
+        },
+        { chat_id: 'A', priorityClass: 'critical' },
+      ),
+    ).rejects.toBe(floodErr)
+
+    // Conservative posture: a chat-bound 429 ALSO opens the global window.
+    expect(opened.sort()).toEqual(['chat:A', 'global'])
+  })
+
+  it('openScopedFloodWindows (the gateway onFloodWait seam) opens scope-precise windows', async () => {
+    const clock = new FakeClock()
+    const opened: string[] = []
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      onWindowOpen: (scopeKey) => opened.push(scopeKey),
+    })
+
+    // Simulates the gateway's onFloodWait hook for a SHORT slept-and-retried 429
+    // on a supergroup chat — the gate's own FLOOD_WAIT_ACTIVE catch never fires
+    // for those, so this seam must carry the scope precision.
+    gate.openScopedFloodWindows({ chat_id: '9', chatType: 'supergroup' }, HOUR)
+    expect(opened.sort()).toEqual(['chat:9', 'group:9'])
+
+    // A no-chat-scope 429 opens global.
+    opened.length = 0
+    gate.openScopedFloodWindows(undefined, HOUR)
+    expect(opened).toEqual(['global'])
+  })
+
+  it('openScopedFloodWindows is a pure no-op when the gate is disabled', async () => {
+    const clock = new FakeClock()
+    const opened: string[] = []
+    const gate = createSendGate({
+      enabled: false,
+      clock,
+      onWindowOpen: (scopeKey) => opened.push(scopeKey),
+    })
+    gate.openScopedFloodWindows({ chat_id: 'A' }, HOUR)
+    gate.openScopedFloodWindows(undefined, HOUR)
+    expect(opened).toEqual([])
   })
 })

--- a/telegram-plugin/send-gate-observability.ts
+++ b/telegram-plugin/send-gate-observability.ts
@@ -29,14 +29,15 @@
  *     "was banned from X to Y" alert when the window CLOSES (or as soon as the
  *     operator chat becomes reachable again).
  *
- * STATUS OF THE IMMEDIATE PATH (today vs. after #3111)
- * ----------------------------------------------------
- * The immediate-delivery branch is present and unit-tested, but it does NOT
- * fire in production yet: `openScopedWindowsForOpts` opens a coincident `global`
- * window on every 429, so the operator chat is always "covered" while any ban is
- * active and every alert defers to close. It becomes live once #3111 makes
- * `onFloodWait` scope-precise. Until then the operator is alerted at window
- * CLOSE — once per incident, all scopes coalesced into one card (M1, #3112).
+ * STATUS OF THE IMMEDIATE PATH (live since #3111)
+ * -----------------------------------------------
+ * The immediate-delivery branch is present, unit-tested, AND now fires in
+ * production: as of #3111 a chat-scoped 429 opens ONLY that chat's window (no
+ * coincident `global`), so when a ban covers `chat:<other>` while the operator's
+ * own chat is clear, the alert is delivered IMMEDIATELY rather than deferred to
+ * close. A genuinely global 429 still opens `global`, so the operator chat is
+ * "covered" and the alert defers to close — once per incident, all scopes
+ * coalesced into one card (M1, #3112).
  *
  * At-most-once is anchored by the persisted `alertedAt` (survives restart). The
  * deferred close-alert is best-effort at-least-once: if the gateway is down for
@@ -312,11 +313,12 @@ export function createFloodWindowObserver(
       if (w.alertedAt != null) continue
       if (now - w.observedAt < alertThresholdMs) continue
       if (operatorReachable && !coversOperator(w, operatorChatId)) {
-        // NOTE (M1, #3112): this immediate-delivery branch is currently
-        // UNREACHABLE for recorder-produced state — `openScopedWindowsForOpts`
-        // opens a coincident `global` window on every 429, so `operatorReachable`
-        // is always false while any ban is active. It goes live once #3111 makes
-        // `onFloodWait` scope-precise. Kept + unit-tested as forward-looking.
+        // NOTE (M1, #3112 / #3111): this immediate-delivery branch is now LIVE
+        // for recorder-produced state. Since #3111 a chat-scoped 429 opens only
+        // that chat's window (no coincident `global`), so when a ban covers a
+        // chat OTHER than the operator's, `operatorReachable` is true and the
+        // alert is delivered here rather than deferred to close. A genuinely
+        // global 429 still opens `global`, keeping the operator "covered".
         // NOTE (L1, #3112): send-first, then persist `alertedAt`. A crash between
         // the delivered card and the disk write re-alerts on restart — a benign
         // duplicate. Deliberate: send-first guarantees an alert is never LOST,

--- a/telegram-plugin/send-gate.test.ts
+++ b/telegram-plugin/send-gate.test.ts
@@ -207,6 +207,30 @@ describe('send-gate: sendGateConfigFromEnv (yaml → env → createSendGate)', (
     ).toBeUndefined()
   })
 
+  it('maps the #3111 conservative-global flood-scope break-glass flag', () => {
+    // Unset ⇒ absent (scope-precise default; createSendGate falls back to false).
+    expect(
+      sendGateConfigFromEnv(E({})).conservativeGlobalFloodScope,
+    ).toBeUndefined()
+    // On-values ⇒ true (restore pre-#3111 always-open-global posture).
+    for (const on of ['1', 'true', 'on', 'yes']) {
+      expect(
+        sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_CONSERVATIVE_GLOBAL: on }))
+          .conservativeGlobalFloodScope,
+      ).toBe(true)
+    }
+    // Off-values ⇒ explicit false.
+    expect(
+      sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_CONSERVATIVE_GLOBAL: '0' }))
+        .conservativeGlobalFloodScope,
+    ).toBe(false)
+    // Unrecognised ⇒ absent (defensive net).
+    expect(
+      sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_CONSERVATIVE_GLOBAL: 'nonsense' }))
+        .conservativeGlobalFloodScope,
+    ).toBeUndefined()
+  })
+
   describe('enabled precedence: break-glass valve > config > default-on', () => {
     it('config send_gate.enabled decides when the env valve is unset', () => {
       expect(sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_ENABLED: '0' })).enabled).toBe(false)

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -304,6 +304,21 @@ export interface SendGateConfig {
    * `initialWindows` applied at construction (those already came from disk).
    */
   onWindowOpen?: (scopeKey: string, untilTs: number) => void
+  /**
+   * Conservative flood-scope posture (#3111). When `false` (the DEFAULT), a 429
+   * on a call bound to a specific chat opens ONLY that chat's (and, for groups,
+   * that group's) flood window — NOT a blanket `global` window — so a genuinely
+   * chat-scoped 429 (e.g. a per-group 20/min limit) cannot fail-fast CRITICAL
+   * sends to every other chat. `global` is opened only when the 429 carries no
+   * finer scope (no `chat_id`), i.e. the evidence is genuinely global.
+   *
+   * When `true`, the pre-#3111 posture is restored: EVERY 429 additionally opens
+   * the `global` window. Telegram 429s are per-bot-token, so a flood often IS
+   * global; an operator who prefers to over-suppress rather than risk a missed
+   * global ban can opt back in via
+   * `SWITCHROOM_TG_SEND_GATE_CONSERVATIVE_GLOBAL=1`.
+   */
+  conservativeGlobalFloodScope?: boolean
 }
 
 /**
@@ -462,6 +477,15 @@ export interface SendGate {
    * by PR 2 on a 429 and at boot from the persisted `flood-wait.json`.
    */
   openFloodWindow(scopeKey: string, untilTs: number): void
+  /**
+   * Open the SCOPE-PRECISE flood windows a 429 on a call with these `opts`
+   * implies (#3111). Used by the gateway's `onFloodWait` hook, which sees a
+   * SHORT slept-and-retried 429 the gate's own `FLOOD_WAIT_ACTIVE` catch never
+   * observes. Opens `global` only when `opts` carries no `chat_id` (genuinely
+   * global evidence) or the conservative posture is on — so a chat-scoped 429
+   * does not suppress unrelated chats. A pure no-op when the gate is disabled.
+   */
+  openScopedFloodWindows(opts: SendGateOpts | undefined, untilTs: number): void
   /** Snapshot of counters + current bucket fill. */
   stats(): SendGateStats
 }
@@ -512,6 +536,7 @@ export function createSendGate(config: SendGateConfig): SendGate {
   const criticalJitterMaxMs = config.criticalJitterMaxMs ?? 250
   const jitter = config.jitter ?? Math.random
   const onWindowOpen = config.onWindowOpen
+  const conservativeGlobalFloodScope = config.conservativeGlobalFloodScope ?? false
 
   const counters: BucketCounters = {
     sent: 0,
@@ -624,18 +649,35 @@ export function createSendGate(config: SendGateConfig): SendGate {
   }
 
   /**
-   * Open all scope windows implied by a call's `opts` at `untilTs` — global,
-   * plus per-chat / per-group / per-message where keyed. Called when a wrapped
-   * send surfaces a `FLOOD_WAIT_ACTIVE` (a real 429 or a pre-call
-   * short-circuit) so the ban is remembered at the finest scope we know
-   * (part3-design §7). Global is always opened as the conservative floor.
+   * Open the flood windows a 429 on this call implies at `untilTs`, at the
+   * FINEST scope the evidence supports (#3111). Called when a wrapped send
+   * surfaces a `FLOOD_WAIT_ACTIVE` (a real 429 or a pre-call short-circuit), and
+   * by the gateway's `onFloodWait` hook for a SHORT slept-and-retried 429 (via
+   * the public `openScopedFloodWindows`), so the ban is remembered at the finest
+   * scope we know (part3-design §7).
+   *
+   * SCOPE PRECISION (#3111): a call bound to a specific `chat_id` opens ONLY that
+   * chat's (and, for groups, that group's) window — NOT a blanket `global`
+   * window that would suppress unrelated chats. `global` is opened only when the
+   * call carries NO finer scope (no `chat_id`) — i.e. the evidence is genuinely
+   * global — OR when `conservativeGlobalFloodScope` restores the pre-#3111
+   * always-open-global posture. Telegram 429s are per-bot-token so a flood is
+   * OFTEN global, but a genuinely chat-scoped 429 (e.g. a per-group 20/min
+   * limit) must not fail-fast CRITICAL sends to every other chat. The
+   * per-message (`msg-edit:`) window is additive whenever a `messageId` is
+   * present. Monotonic/idempotent: `applyWindow` only ever extends.
    */
   function openScopedWindowsForOpts(opts: SendGateOpts | undefined, untilTs: number): void {
-    applyWindow('global', untilTs, true)
-    if (opts?.chat_id) {
-      applyWindow(`chat:${opts.chat_id}`, untilTs, true)
-      if (opts.chatType && GROUP_TYPES.has(opts.chatType)) {
-        applyWindow(`group:${opts.chat_id}`, untilTs, true)
+    const hasChatScope = opts?.chat_id != null && opts.chat_id !== ''
+    // Open `global` only when the 429 has no finer scope (genuinely global), or
+    // when the operator opted into the conservative always-global posture.
+    if (!hasChatScope || conservativeGlobalFloodScope) {
+      applyWindow('global', untilTs, true)
+    }
+    if (hasChatScope) {
+      applyWindow(`chat:${opts!.chat_id}`, untilTs, true)
+      if (opts!.chatType && GROUP_TYPES.has(opts!.chatType)) {
+        applyWindow(`group:${opts!.chat_id}`, untilTs, true)
       }
     }
     if (opts?.messageId != null) {
@@ -1094,7 +1136,18 @@ export function createSendGate(config: SendGateConfig): SendGate {
     }
   }
 
-  return { gate, openFloodWindow, stats }
+  /**
+   * Public, scope-precise window opener for the gateway's `onFloodWait` hook
+   * (#3111). Flag-OFF is a pure no-op (mirrors `openFloodWindow`'s M3 guard) so
+   * a 429 never mutates suppression or writes `flood-windows.json` while the gate
+   * is disabled.
+   */
+  function openScopedFloodWindows(opts: SendGateOpts | undefined, untilTs: number): void {
+    if (!enabled) return
+    openScopedWindowsForOpts(opts, untilTs)
+  }
+
+  return { gate, openFloodWindow, openScopedFloodWindows, stats }
 }
 
 /**
@@ -1139,6 +1192,19 @@ function parseNonNegativeInt(raw: string | undefined): number | undefined {
 }
 
 /**
+ * Parse a boolean env flag using the repo's on/off grammar
+ * (`1/true/on/yes` → true, `0/false/off/no` → false). Blank or unrecognised →
+ * undefined so the caller keeps its built-in default (#3111).
+ */
+function parseBoolFlag(raw: string | undefined): boolean | undefined {
+  if (raw == null || raw.trim() === '') return undefined
+  const t = raw.trim().toLowerCase()
+  if (t === '1' || t === 'true' || t === 'on' || t === 'yes') return true
+  if (isOffValue(t)) return false
+  return undefined
+}
+
+/**
  * The resolved rate-limit + enable slice `createSendGate` consumes, sourced
  * from env (which the scaffold populates from `channels.telegram.send_gate.*`).
  * Only fields the operator SET are present; an unset rate field is absent so
@@ -1156,6 +1222,7 @@ export type SendGateEnvConfig = Pick<SendGateConfig, 'enabled'> &
       | 'perGroupPerMin'
       | 'perGroupBurst'
       | 'editFloorMs'
+      | 'conservativeGlobalFloodScope'
     >
   >
 
@@ -1203,6 +1270,10 @@ export function sendGateConfigFromEnv(
   if (perGroupBurst !== undefined) out.perGroupBurst = perGroupBurst
   const editFloorMs = parseNonNegativeInt(env.SWITCHROOM_TG_SEND_GATE_EDIT_FLOOR_MS)
   if (editFloorMs !== undefined) out.editFloorMs = editFloorMs
+  // #3111 break-glass: restore the pre-#3111 always-open-global flood posture.
+  // Unset ⇒ scope-precise default (global opened only on genuinely global 429s).
+  const conservativeGlobal = parseBoolFlag(env.SWITCHROOM_TG_SEND_GATE_CONSERVATIVE_GLOBAL)
+  if (conservativeGlobal !== undefined) out.conservativeGlobalFloodScope = conservativeGlobal
 
   return out
 }

--- a/telegram-plugin/tests/flood-windows-persistence.test.ts
+++ b/telegram-plugin/tests/flood-windows-persistence.test.ts
@@ -103,9 +103,10 @@ describe('#3084 scoped flood-window persistence', () => {
       ),
     ).rejects.toBe(floodErr)
 
-    // The window is on disk.
+    // The window is on disk. #3111: a chat-bound 429 persists ONLY the chat
+    // scope — no coincident `global` window that would suppress unrelated chats.
     const persisted = readFloodWindows(winPath, 0)
-    expect(persisted.map((w) => w.scopeKey).sort()).toEqual(['chat:7', 'global'])
+    expect(persisted.map((w) => w.scopeKey).sort()).toEqual(['chat:7'])
 
     // Gate 2 (simulated restart): built BEFORE any outbound call from the
     // persisted windows. A cosmetic send on chat:7 must still shed.

--- a/telegram-plugin/tests/reaction-gate-routing.test.ts
+++ b/telegram-plugin/tests/reaction-gate-routing.test.ts
@@ -130,7 +130,12 @@ describe('#3155 reactions route through the send gate (cosmetic)', () => {
     // The reaction actually reached the API (was admitted, not shed)...
     expect(setMessageReaction).toHaveBeenCalled()
     // ...and its 429 was recorded by the breaker — the whole gap this closes.
-    expect(onFloodWait).toHaveBeenCalledWith(7)
+    // #3111: the retry policy now also passes the call's opts so the gateway can
+    // open a scope-precise window (a reaction 429 implies only that chat).
+    expect(onFloodWait).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ chat_id: 'chatA', priorityClass: 'cosmetic' }),
+    )
   })
 })
 

--- a/telegram-plugin/tests/retry-api-call.test.ts
+++ b/telegram-plugin/tests/retry-api-call.test.ts
@@ -576,6 +576,27 @@ describe('#2923 — LOCAL resource exhaustion is NOT retried (avoids flood ban)'
     expect(out).toBe('ok')
     expect(seen).toEqual([42])
   })
+
+  it('passes the call opts to onFloodWait so the gateway can open a scope-precise window (#3111)', async () => {
+    const seen: { sec: number; chat_id?: string; chatType?: string }[] = []
+    const sleep = vi.fn(async () => {})
+    let n = 0
+    const retry = createRetryApiCall({
+      maxRetries: 3,
+      sleep,
+      onFloodWait: (sec, opts) => seen.push({ sec, chat_id: opts?.chat_id, chatType: opts?.chatType }),
+    })
+    const out = await retry(
+      async () => {
+        if (n++ === 0) throw errors.floodWait(7)
+        return 'ok'
+      },
+      { chat_id: '42', chatType: 'supergroup' },
+    )
+    expect(out).toBe('ok')
+    // The hook received the same chat scope the send carried — not a bare number.
+    expect(seen).toEqual([{ sec: 7, chat_id: '42', chatType: 'supergroup' }])
+  })
 })
 
 describe('#3084 — a long flood ban fails FAST instead of sleeping for hours', () => {


### PR DESCRIPTION
## Problem

The send gate over-suppressed on every 429. `openScopedWindowsForOpts` (send-gate.ts) ALWAYS opened the `global` window in addition to any chat/group/msg-edit scope, and the gateway's `onFloodWait` hook (gateway.ts) unconditionally called `sendGate.openFloodWindow('global', …)`. So ANY single-chat or single-message 429 fail-fast'd CRITICAL sends across ALL chats and shed cosmetic traffic everywhere — not just on the offending scope. Telegram 429s are per-bot-token so a flood is *often* global, but a genuinely chat-scoped 429 (e.g. a per-group 20/min limit) shouldn't suppress unrelated chats.

Carried follow-up from #3084 PR 2 review (L1), filed per PR 3's scope note.

## Change

- **`openScopedWindowsForOpts` is now scope-precise.** It opens `global` ONLY when the 429 carries no finer scope (no `chat_id`) — i.e. the evidence is genuinely global. A chat-bound 429 opens just `chat:`/`group:`/`msg-edit:` windows. Monotonic/idempotent semantics unchanged (`applyWindow` only extends).
- **New `SendGate.openScopedFloodWindows(opts, untilTs)` seam.** `retryApiCall`'s `onFloodWait` now passes the call's `opts` through (additive; existing callers ignore the 2nd arg), so the gateway hook opens the finest scope even for a SHORT slept-and-retried 429 that never throws `FLOOD_WAIT_ACTIVE` (which the gate's own catch never sees). This mirrors the gate's LONG-ban catch path — both use the same scope-precise opener.
- **Tunable conservative fallback.** `conservativeGlobalFloodScope` config + `SWITCHROOM_TG_SEND_GATE_CONSERVATIVE_GLOBAL=1` break-glass restores the pre-#3111 always-open-global posture.
- **Observability (#3112) notes updated.** The immediate-alert branch — deliver a flood alert when a ban covers a chat OTHER than the operator's — was documented as UNREACHABLE until #3111; it's now LIVE.

## Tests (assert outcomes; fail pre-fix)

- `chat:A` 429 does NOT fail-fast a `chat:B` critical (the headline), while a `chat:A` critical still fails fast. Pre-fix the coincident global window fail-fast'd chat:B too.
- A global 429 (no chat scope) still opens `global` and suppresses everywhere.
- `conservativeGlobalFloodScope: true` re-opens `global` on a chat-bound 429.
- `openScopedFloodWindows` opens scope-precise windows and is a no-op when disabled.
- `onFloodWait` receives the call's opts (retry-api-call).
- Env parse for the new break-glass flag.
- Updated flood-windows-persistence + reaction-gate-routing tests to the scope-precise expectation.

Scoped `bun test` (send-gate, retry, persistence, reaction, observability): 152 pass / 0 fail. `npm run lint` (tsc --noEmit + repo guards): clean.

JTBD: **talk-to-agents-from-anywhere** (always-available) — a per-chat 429 no longer silences the whole fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)