### PR TITLE
chore(litellm-pacer): vendor fleet LLM pacer into repo with tests (P0)

### DIFF
--- a/.github/workflows/ci-tests-python.yml
+++ b/.github/workflows/ci-tests-python.yml
@@ -43,6 +43,7 @@ jobs:
             relevant:
               - 'vendor/hindsight-memory/scripts/**'
               - 'docker/voice-sidecar/**'
+              - 'docker/litellm-pacer/**'
               - '.github/workflows/ci-tests-python.yml'
 
   unittest:
@@ -62,4 +63,11 @@ jobs:
       # kokoro lazily, so no ONNX runtime / model is needed here.
       - name: Run voice-sidecar unittests
         working-directory: docker/voice-sidecar
+        run: python3 -m unittest discover -s . -p 'test_*.py'
+
+      # Fleet LLM pacer's pure-logic tests (admit / cooldown / fail-open /
+      # Retry-After). The test stubs the top-level `litellm` imports via
+      # sys.modules, so no litellm / redis pip install is needed here.
+      - name: Run litellm-pacer unittests
+        working-directory: docker/litellm-pacer
         run: python3 -m unittest discover -s . -p 'test_*.py'

--- a/docker/litellm-pacer/README.md
+++ b/docker/litellm-pacer/README.md
@@ -1,0 +1,101 @@
+# Fleet LLM pacer (`custom_pacing.py`)
+
+Fleet-wide request pacer for LiteLLM's Anthropic **passthrough** path. It runs
+as a LiteLLM `CustomLogger` callback and smooths the burst that hits a single
+Anthropic OAuth account when the switchroom auth-broker flips the whole fleet
+onto it. Full mechanism is in the module docstring at the top of
+`custom_pacing.py`.
+
+## This directory is now the source of truth
+
+Until 2026-07-13 this file lived **only** as a bind-mounted file on the Coolify
+host, with no repo tracking, no tests, and no CI. That was a durability defect
+(a fleet-critical hot-path module with no reviewable source of truth). This
+directory fixes that:
+
+- `custom_pacing.py` — the vendored module, **byte-for-byte identical** to the
+  live deployed copy at vendor time.
+- `test_custom_pacing.py` — stdlib `unittest` coverage of the pure decision
+  logic (admit / cooldown / fail-open / Retry-After). Wired into the
+  `ci-tests-python` GitHub Actions lane.
+
+**The repo copy is authoritative.** Changes to the pacer belong here first
+(reviewed + tested), then get synced to the host — never edited on the host and
+back-ported.
+
+## Deploy path on the host
+
+The live copy is bind-mounted into the LiteLLM proxy container:
+
+```
+host:  /host/data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/custom_pacing.py
+       (Coolify service dir; from inside this repo's root agent it is
+        /host/data/... , on the raw host /data/coolify/services/...)
+container: /app/custom_pacing.py   (the config dir is on the proxy's sys.path)
+```
+
+Wire-up in the sibling `litellm-config.yaml`:
+
+```yaml
+litellm_settings:
+  callbacks: ["custom_pacing.pacer_instance"]
+```
+
+Bind mount in the sibling `docker-compose.yml`:
+
+```yaml
+volumes:
+  - '/data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/custom_pacing.py:/app/custom_pacing.py'
+```
+
+## Code defaults vs. live env overrides
+
+The module's **code defaults** (in `_Cfg`) are the conservative baseline and are
+preserved here unchanged:
+
+| Knob                   | Code default | Live deployment override (`docker-compose.yml`) |
+|------------------------|:------------:|:-----------------------------------------------:|
+| `PACE_MAX_CONCURRENCY` |      8       |                       16                        |
+| `PACE_MAX_RPM`         |      60      |                       90                        |
+| `PACE_MAX_RPS`         |      4       |                        6                        |
+| `PACE_MAX_WAIT_S`      |      20      |                       12                        |
+| `PACE_MAX_COOLDOWN_S`  |      60      |                       60                        |
+| `PACE_LEASE_TTL_S`     |     300      |                       300                       |
+
+**Tuning the running fleet is the deployment's job, via env** — set/adjust the
+`PACE_*` vars in `docker-compose.yml` (or live via the same Redis keys). Do NOT
+change the code defaults here to chase a live value; the repo copy stays the
+safe baseline and the deployment layer owns the operating point.
+
+## Sync / redeploy step
+
+After changing `custom_pacing.py` here (and getting it merged):
+
+1. Copy the vendored file to the host deploy path:
+   ```
+   cp docker/litellm-pacer/custom_pacing.py \
+      /data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/custom_pacing.py
+   ```
+   (Keep a timestamped `.bak` first, matching the existing host convention.)
+2. **Redeploy / restart the LiteLLM service** so the proxy re-imports the
+   callback module — a running proxy holds the old module in memory; the pacer
+   is only reloaded on container (re)start. Redeploy the Coolify `litellm`
+   service, or restart its container.
+3. Verify the callback loaded (proxy logs mention `custom_pacing`) and that a
+   passthrough request is being paced.
+
+Changing only env knobs (`PACE_*`) also requires a container restart to re-read
+env — unless you set the equivalent live Redis keys, which take effect
+immediately.
+
+> Full one-command deploy automation (copy + redeploy + verify) is a follow-up.
+> P0 scope is: get the file in-repo, under test, with the sync documented.
+
+## Running the tests locally
+
+```
+python3 -m unittest discover -s docker/litellm-pacer -p 'test_*.py'
+```
+
+Pure stdlib — no `pip install`. The test stubs the top-level `litellm` imports
+via `sys.modules`, so neither `litellm` nor `redis` needs to be installed.

--- a/docker/litellm-pacer/custom_pacing.py
+++ b/docker/litellm-pacer/custom_pacing.py
@@ -1,0 +1,343 @@
+"""
+custom_pacing.py — fleet-wide LLM request pacer for LiteLLM's Anthropic
+passthrough path.
+
+Ken's standing rule (2026-07-12): "never storm, always pace." When the
+switchroom auth-broker flips the whole fleet onto a new Anthropic OAuth
+account, every agent's in-flight + queued turn hits that account at once.
+A cold / low-burst-ceiling account 429s ("This request would exceed your
+account's rate limit") even when the 5h quota is at ~1% — its per-minute
+BURST ceiling is below fleet burst demand. This module smooths that burst.
+
+Mechanism (deterministic, version-independent, config-only-impossible under
+LiteLLM v3's per-key reject-based limiter):
+
+  * Runs as a LiteLLM CustomLogger callback. Its async_pre_call_hook is
+    invoked on the /anthropic passthrough path (call_type ==
+    "pass_through_endpoint") — verified against litellm v1.91
+    proxy/utils.py::pre_call_hook + pass_through_endpoints.py:845.
+  * Bounded global CONCURRENCY: at most PACE_MAX_CONCURRENCY upstream
+    requests in flight across all 8 proxy workers, coordinated in Redis
+    via a self-healing sorted-set lease (missed releases age out after
+    PACE_LEASE_TTL_S — no leaked permanent slots).
+  * Bounded global RATE: rolling 60s cap (PACE_MAX_RPM) + rolling 1s burst
+    smoother (PACE_MAX_RPS).
+  * ADAPTIVE 429 cooldown: async_post_call_failure_hook watches for upstream
+    429s carrying Retry-After and parks a fleet-wide `pace:cooldown_until`
+    in Redis. While cooling, pre_call paces harder — honoring Anthropic's
+    own retry-after signal instead of hammering.
+  * QUEUES, does not reject: over-limit requests AWAIT (bounded jittered
+    sleep up to PACE_MAX_WAIT_S) rather than 429. If the wait ceiling is
+    hit the request FAILS OPEN (proceeds) — the pacer can never make the
+    fleet worse than no pacer at all.
+
+Everything FAILS OPEN: any Redis / logic error is swallowed and the request
+proceeds. A bug in this hot-path module degrades to today's behavior, never
+to a fleet outage.
+
+All knobs are env-overridable (see _cfg) so tuning needs no code change and
+no image rebuild — only a container restart to re-read env, OR set them live
+via the same Redis keys.
+
+Wire-up (litellm-config.yaml):
+    litellm_settings:
+      callbacks: ["custom_pacing.pacer_instance"]
+
+Deploy: bind-mount this file to /app/custom_pacing.py (the config dir is on
+the proxy's sys.path). See PLAN.md for exact compose + apply steps.
+"""
+
+import asyncio
+import os
+import time
+import uuid
+from typing import Any, Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm.integrations.custom_logger import CustomLogger
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except Exception:
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except Exception:
+        return default
+
+
+class _Cfg:
+    # Max simultaneous upstream Anthropic requests across the whole fleet.
+    MAX_CONCURRENCY = _int_env("PACE_MAX_CONCURRENCY", 8)
+    # Rolling 60s request ceiling (fleet-wide).
+    MAX_RPM = _int_env("PACE_MAX_RPM", 60)
+    # Rolling 1s burst smoother (fleet-wide).
+    MAX_RPS = _int_env("PACE_MAX_RPS", 4)
+    # Hard ceiling on how long a single request will wait in the pacer
+    # before failing open and proceeding regardless.
+    MAX_WAIT_S = _float_env("PACE_MAX_WAIT_S", 20.0)
+    # A concurrency lease auto-expires after this many seconds so a missed
+    # release (crash / streaming edge) cannot permanently consume a slot.
+    LEASE_TTL_S = _int_env("PACE_LEASE_TTL_S", 300)
+    # Cap on how long a Retry-After-driven cooldown can park the fleet.
+    MAX_COOLDOWN_S = _float_env("PACE_MAX_COOLDOWN_S", 60.0)
+    # Poll interval + jitter while waiting for a slot / rate window.
+    POLL_MIN_S = _float_env("PACE_POLL_MIN_S", 0.10)
+    POLL_MAX_S = _float_env("PACE_POLL_MAX_S", 0.40)
+    # Master on/off. Set PACE_ENABLED=false to make the hook a pure no-op
+    # without touching config wiring.
+    ENABLED = os.getenv("PACE_ENABLED", "true").lower() != "false"
+    # Only pace these call types. Passthrough is what agents use.
+    CALL_TYPES = {"pass_through_endpoint"}
+
+    REDIS_HOST = os.getenv("REDIS_HOST", "redis")
+    REDIS_PORT = _int_env("REDIS_PORT", 6379)
+    REDIS_PASSWORD = os.getenv("REDIS_PASSWORD") or None
+    KEY_PREFIX = os.getenv("PACE_KEY_PREFIX", "litellm_pace")
+
+
+_INFLIGHT_KEY = f"{_Cfg.KEY_PREFIX}:inflight"      # ZSET member=pace_id score=deadline
+_RECENT_KEY = f"{_Cfg.KEY_PREFIX}:recent"          # ZSET member=uuid score=ts (rolling window)
+_COOLDOWN_KEY = f"{_Cfg.KEY_PREFIX}:cooldown_until"  # STRING epoch seconds
+
+# Atomic admission. Redis runs a script to completion single-threaded, so the
+# trim -> count -> conditional-add sequence is race-free across all 8 proxy
+# workers (a plain check-then-act leaks the cap under exactly the burst we
+# defend against). Returns 1 = admitted (lease taken), 0 = must wait.
+_ADMIT_LUA = """
+local inflight = KEYS[1]
+local recent = KEYS[2]
+local cd = KEYS[3]
+local now = tonumber(ARGV[1])
+local maxc = tonumber(ARGV[2])
+local maxrpm = tonumber(ARGV[3])
+local maxrps = tonumber(ARGV[4])
+local lease = tonumber(ARGV[5])
+local pid = ARGV[6]
+local ruid = ARGV[7]
+local until_ = redis.call('GET', cd)
+if until_ and tonumber(until_) > now then return 0 end
+redis.call('ZREMRANGEBYSCORE', inflight, '-inf', now)
+if redis.call('ZCARD', inflight) >= maxc then return 0 end
+redis.call('ZREMRANGEBYSCORE', recent, '-inf', now - 60)
+if redis.call('ZCARD', recent) >= maxrpm then return 0 end
+if tonumber(redis.call('ZCOUNT', recent, now - 1, '+inf')) >= maxrps then return 0 end
+redis.call('ZADD', inflight, now + lease, pid)
+redis.call('EXPIRE', inflight, lease + 60)
+redis.call('ZADD', recent, now, ruid)
+redis.call('EXPIRE', recent, 120)
+return 1
+"""
+
+
+class FleetPacer(CustomLogger):
+    def __init__(self) -> None:
+        super().__init__()
+        self._redis = None
+        self._redis_init_failed = False
+
+    # ----- redis -------------------------------------------------------
+    async def _get_redis(self):
+        if self._redis is not None:
+            return self._redis
+        if self._redis_init_failed:
+            return None
+        try:
+            import redis.asyncio as aioredis  # type: ignore
+
+            self._redis = aioredis.Redis(
+                host=_Cfg.REDIS_HOST,
+                port=_Cfg.REDIS_PORT,
+                password=_Cfg.REDIS_PASSWORD,
+                socket_connect_timeout=1.0,
+                socket_timeout=1.0,
+                decode_responses=True,
+            )
+            # Cheap liveness probe; if it fails we fail open forever after.
+            await self._redis.ping()
+            return self._redis
+        except Exception as e:  # pragma: no cover - defensive
+            verbose_proxy_logger.warning(
+                "custom_pacing: redis unavailable, pacer fails OPEN (no pacing): %s", e
+            )
+            self._redis_init_failed = True
+            self._redis = None
+            return None
+
+    # ----- helpers -----------------------------------------------------
+    async def _cooldown_remaining(self, r) -> float:
+        try:
+            raw = await r.get(_COOLDOWN_KEY)
+            if not raw:
+                return 0.0
+            remaining = float(raw) - time.time()
+            return max(0.0, min(remaining, _Cfg.MAX_COOLDOWN_S))
+        except Exception:
+            return 0.0
+
+    async def _try_admit(self, r, pace_id: str) -> bool:
+        """One ATOMIC admission attempt via Lua. Returns True if a
+        concurrency slot + rate window was granted (and the request
+        recorded). Never raises — on any Redis error it fails OPEN
+        (returns True) so the pacer can never wedge the fleet."""
+        now = time.time()
+        try:
+            result = await r.eval(
+                _ADMIT_LUA,
+                3,
+                _INFLIGHT_KEY,
+                _RECENT_KEY,
+                _COOLDOWN_KEY,
+                repr(now),
+                str(_Cfg.MAX_CONCURRENCY),
+                str(_Cfg.MAX_RPM),
+                str(_Cfg.MAX_RPS),
+                str(_Cfg.LEASE_TTL_S),
+                pace_id,
+                uuid.uuid4().hex,
+            )
+            return int(result) == 1
+        except Exception as e:
+            verbose_proxy_logger.debug("custom_pacing: admit check error (fail open): %s", e)
+            # On redis error, fail open by claiming admission.
+            return True
+
+    async def _release(self, pace_id: Optional[str]) -> None:
+        if not pace_id:
+            return
+        r = await self._get_redis()
+        if r is None:
+            return
+        try:
+            await r.zrem(_INFLIGHT_KEY, pace_id)
+        except Exception:
+            pass
+
+    # ----- LiteLLM hooks ----------------------------------------------
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: Any,
+        cache: Any,
+        data: dict,
+        call_type: str,
+    ):
+        # Fast bail: disabled, wrong call type, or bad payload -> no-op.
+        if not _Cfg.ENABLED or call_type not in _Cfg.CALL_TYPES or not isinstance(data, dict):
+            return data
+
+        r = await self._get_redis()
+        if r is None:
+            return data  # fail open
+
+        pace_id = uuid.uuid4().hex
+        deadline = time.time() + _Cfg.MAX_WAIT_S
+        admitted = False
+        try:
+            while True:
+                if await self._try_admit(r, pace_id):
+                    admitted = True
+                    break
+                if time.time() >= deadline:
+                    # Fail open: never reject, just proceed after the ceiling.
+                    verbose_proxy_logger.warning(
+                        "custom_pacing: wait ceiling %.1fs hit, admitting unpaced (fail open)",
+                        _Cfg.MAX_WAIT_S,
+                    )
+                    break
+                # Bounded jittered backoff; jitter de-synchronizes the fleet
+                # so releases don't thunder.
+                import random
+
+                await asyncio.sleep(random.uniform(_Cfg.POLL_MIN_S, _Cfg.POLL_MAX_S))
+        except Exception as e:
+            verbose_proxy_logger.debug("custom_pacing: pre_call error (fail open): %s", e)
+
+        # Stash id so post hooks can release the concurrency lease. Even if
+        # this is lost, the lease self-heals via LEASE_TTL_S.
+        if admitted:
+            try:
+                meta = data.setdefault("metadata", {})
+                if isinstance(meta, dict):
+                    meta["_pace_id"] = pace_id
+            except Exception:
+                pass
+        return data
+
+    def _extract_pace_id(self, data: Any) -> Optional[str]:
+        try:
+            if isinstance(data, dict):
+                meta = data.get("metadata")
+                if isinstance(meta, dict):
+                    return meta.get("_pace_id")
+        except Exception:
+            pass
+        return None
+
+    async def async_post_call_success_hook(self, data, user_api_key_dict, response):
+        await self._release(self._extract_pace_id(data))
+        return response
+
+    async def async_post_call_failure_hook(
+        self, request_data, original_exception, user_api_key_dict, traceback_str: Optional[str] = None
+    ):
+        # Release the slot first.
+        await self._release(self._extract_pace_id(request_data))
+
+        # Adaptive cooldown on upstream 429: park the fleet for Retry-After.
+        try:
+            status = getattr(original_exception, "status_code", None) or getattr(
+                original_exception, "code", None
+            )
+            msg = str(getattr(original_exception, "message", "") or original_exception)
+            is_429 = str(status) == "429" or "rate_limit_error" in msg or "would exceed your account" in msg
+            if not is_429:
+                return
+            retry_after = self._parse_retry_after(original_exception)
+            cooldown = retry_after if retry_after and retry_after > 0 else 5.0
+            cooldown = min(cooldown, _Cfg.MAX_COOLDOWN_S)
+            r = await self._get_redis()
+            if r is None:
+                return
+            until = time.time() + cooldown
+            # Only extend, never shorten, an existing cooldown.
+            existing = await r.get(_COOLDOWN_KEY)
+            if not existing or float(existing) < until:
+                await r.set(_COOLDOWN_KEY, str(until), ex=int(_Cfg.MAX_COOLDOWN_S) + 5)
+                verbose_proxy_logger.warning(
+                    "custom_pacing: upstream 429 -> fleet cooldown %.1fs (honoring retry-after)",
+                    cooldown,
+                )
+        except Exception as e:
+            verbose_proxy_logger.debug("custom_pacing: failure hook error: %s", e)
+
+    @staticmethod
+    def _parse_retry_after(exc: Any) -> Optional[float]:
+        # Try common shapes: exc.headers['retry-after'], exc.response.headers,
+        # or a numeric in the message. Best-effort, never raises.
+        try:
+            for attr in ("headers",):
+                h = getattr(exc, attr, None)
+                if h and hasattr(h, "get"):
+                    v = h.get("retry-after") or h.get("Retry-After")
+                    if v is not None:
+                        return float(v)
+            resp = getattr(exc, "response", None)
+            if resp is not None:
+                h = getattr(resp, "headers", None)
+                if h and hasattr(h, "get"):
+                    v = h.get("retry-after") or h.get("Retry-After")
+                    if v is not None:
+                        return float(v)
+        except Exception:
+            pass
+        return None
+
+
+# LiteLLM loads the callback by importing this module and resolving the
+# dotted path "custom_pacing.pacer_instance" to this singleton.
+pacer_instance = FleetPacer()

--- a/docker/litellm-pacer/test_custom_pacing.py
+++ b/docker/litellm-pacer/test_custom_pacing.py
@@ -1,0 +1,311 @@
+"""Unit tests for the fleet LLM pacer's pure decision logic (custom_pacing.py).
+
+These pin the *behaviour-neutral* contract of the vendored pacer without a live
+LiteLLM proxy or a real Redis. They cover the four decision surfaces called out
+for P0 of the pacer-durable-fix:
+
+  * ADMIT      — _try_admit maps the atomic Lua verdict (1/0) to admit/wait.
+  * FAIL-OPEN  — any Redis error on the admit path proceeds (returns True), so
+                 the pacer can never wedge the fleet.
+  * COOLDOWN   — the adaptive 429 cooldown is extend-only, capped at
+                 MAX_COOLDOWN_S, and fires only on a real 429 signal.
+  * RETRY-AFTER — _parse_retry_after reads the header off the common exception
+                 shapes and degrades to None (never raises).
+
+custom_pacing.py imports `litellm` at module top (it is a LiteLLM CustomLogger
+callback). To keep this test pure-stdlib — no pip install, matching the
+ci-tests-python lane — we inject lightweight stubs for the two litellm imports
+into sys.modules BEFORE importing the module under test. The vendored file is
+NOT modified in any way; these stubs only satisfy its import statements.
+
+Run: python3 -m unittest discover -s docker/litellm-pacer -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+import types
+import unittest
+
+
+# --- Stub the top-level `litellm` imports so the module imports cleanly -------
+# custom_pacing.py does:
+#   from litellm._logging import verbose_proxy_logger
+#   from litellm.integrations.custom_logger import CustomLogger
+# Neither is exercised by the pure-logic paths under test; a no-op logger and a
+# trivial base class are enough. We only install stubs if litellm is absent, so
+# a CI image that happens to have real litellm still uses it.
+def _install_litellm_stubs() -> None:
+    if "litellm" in sys.modules:  # real litellm present — leave it be
+        return
+
+    litellm = types.ModuleType("litellm")
+
+    logging_mod = types.ModuleType("litellm._logging")
+
+    class _SilentLogger:
+        def warning(self, *a, **k):  # noqa: D401 - stub
+            pass
+
+        def debug(self, *a, **k):
+            pass
+
+    logging_mod.verbose_proxy_logger = _SilentLogger()
+
+    integrations_mod = types.ModuleType("litellm.integrations")
+    custom_logger_mod = types.ModuleType("litellm.integrations.custom_logger")
+
+    class CustomLogger:  # minimal stand-in for the ABC the pacer subclasses
+        def __init__(self, *a, **k):
+            pass
+
+    custom_logger_mod.CustomLogger = CustomLogger
+
+    litellm._logging = logging_mod
+    litellm.integrations = integrations_mod
+    integrations_mod.custom_logger = custom_logger_mod
+
+    sys.modules["litellm"] = litellm
+    sys.modules["litellm._logging"] = logging_mod
+    sys.modules["litellm.integrations"] = integrations_mod
+    sys.modules["litellm.integrations.custom_logger"] = custom_logger_mod
+
+
+_install_litellm_stubs()
+
+# Import the module under test (same directory; ci runs with -s on this dir).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+custom_pacing = importlib.import_module("custom_pacing")
+
+
+# --- Async fake Redis --------------------------------------------------------
+class FakeRedis:
+    """Minimal async Redis double. Backs a plain dict; `eval` returns a preset
+    verdict or raises a preset error to exercise the fail-open path."""
+
+    def __init__(self, eval_result=1, eval_raises=None):
+        self.store: dict = {}
+        self.eval_result = eval_result
+        self.eval_raises = eval_raises
+        self.set_calls: list = []
+
+    async def ping(self):
+        return True
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+        self.set_calls.append((key, value, ex))
+        return True
+
+    async def eval(self, *args, **kwargs):
+        if self.eval_raises is not None:
+            raise self.eval_raises
+        return self.eval_result
+
+    async def zrem(self, *args, **kwargs):
+        return 0
+
+
+# --- Retry-After parsing (pure static method) --------------------------------
+class ParseRetryAfterTests(unittest.TestCase):
+    def _exc(self, **attrs):
+        e = types.SimpleNamespace()
+        for k, v in attrs.items():
+            setattr(e, k, v)
+        return e
+
+    def test_headers_lowercase(self):
+        exc = self._exc(headers={"retry-after": "7"})
+        self.assertEqual(custom_pacing.FleetPacer._parse_retry_after(exc), 7.0)
+
+    def test_headers_titlecase(self):
+        exc = self._exc(headers={"Retry-After": "3"})
+        self.assertEqual(custom_pacing.FleetPacer._parse_retry_after(exc), 3.0)
+
+    def test_response_headers_fallback(self):
+        exc = self._exc(response=types.SimpleNamespace(headers={"retry-after": "9"}))
+        self.assertEqual(custom_pacing.FleetPacer._parse_retry_after(exc), 9.0)
+
+    def test_missing_returns_none(self):
+        self.assertIsNone(custom_pacing.FleetPacer._parse_retry_after(self._exc()))
+
+    def test_non_numeric_degrades_to_none(self):
+        exc = self._exc(headers={"retry-after": "soon"})
+        self.assertIsNone(custom_pacing.FleetPacer._parse_retry_after(exc))
+
+
+# --- Env parsing helpers (pure, fail-safe) -----------------------------------
+class EnvHelperTests(unittest.TestCase):
+    ENV_KEY = "PACE_TEST_ENV_HELPER"
+
+    def tearDown(self):
+        os.environ.pop(self.ENV_KEY, None)
+
+    def test_int_valid(self):
+        os.environ[self.ENV_KEY] = "42"
+        self.assertEqual(custom_pacing._int_env(self.ENV_KEY, 8), 42)
+
+    def test_int_invalid_falls_back(self):
+        os.environ[self.ENV_KEY] = "not-an-int"
+        self.assertEqual(custom_pacing._int_env(self.ENV_KEY, 8), 8)
+
+    def test_int_missing_uses_default(self):
+        self.assertEqual(custom_pacing._int_env(self.ENV_KEY, 8), 8)
+
+    def test_float_valid(self):
+        os.environ[self.ENV_KEY] = "1.5"
+        self.assertEqual(custom_pacing._float_env(self.ENV_KEY, 20.0), 1.5)
+
+    def test_float_invalid_falls_back(self):
+        os.environ[self.ENV_KEY] = "nope"
+        self.assertEqual(custom_pacing._float_env(self.ENV_KEY, 20.0), 20.0)
+
+
+# --- Code-default invariant (P0 must not change defaults) ---------------------
+class CodeDefaultTests(unittest.TestCase):
+    """P0 is behaviour-neutral: the vendored file must keep its 8/60/4/20 code
+    defaults. Live deployments override these via env (16/90/6/12) — that stays
+    the deployment's job, not the repo copy's. This test fails loudly if a
+    future edit silently changes a code default. It reads defaults straight from
+    the source so it is unaffected by any PACE_* env set in the test runner."""
+
+    def _default_of(self, func_name, arg_name):
+        import ast
+
+        src = os.path.join(os.path.dirname(__file__), "custom_pacing.py")
+        with open(src, "r", encoding="utf-8") as fh:
+            tree = ast.parse(fh.read())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for t in node.targets:
+                    if isinstance(t, ast.Name) and t.id == arg_name:
+                        call = node.value
+                        if isinstance(call, ast.Call) and len(call.args) >= 2:
+                            return ast.literal_eval(call.args[1])
+        raise AssertionError(f"{arg_name} default not found")
+
+    def test_code_defaults_unchanged(self):
+        self.assertEqual(self._default_of("_int_env", "MAX_CONCURRENCY"), 8)
+        self.assertEqual(self._default_of("_int_env", "MAX_RPM"), 60)
+        self.assertEqual(self._default_of("_int_env", "MAX_RPS"), 4)
+        self.assertEqual(self._default_of("_float_env", "MAX_WAIT_S"), 20.0)
+        self.assertEqual(self._default_of("_float_env", "MAX_COOLDOWN_S"), 60.0)
+        self.assertEqual(self._default_of("_int_env", "LEASE_TTL_S"), 300)
+
+
+# --- Admission + fail-open ----------------------------------------------------
+class AdmitTests(unittest.IsolatedAsyncioTestCase):
+    async def test_admit_when_lua_grants(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis(eval_result=1)
+        self.assertTrue(await pacer._try_admit(r, "pace-1"))
+
+    async def test_wait_when_lua_denies(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis(eval_result=0)
+        self.assertFalse(await pacer._try_admit(r, "pace-1"))
+
+    async def test_fail_open_on_redis_error(self):
+        # A Redis error on the admit path must ADMIT (fail open) so the pacer
+        # can never make the fleet worse than no pacer at all.
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis(eval_raises=RuntimeError("redis down"))
+        self.assertTrue(await pacer._try_admit(r, "pace-1"))
+
+
+# --- Cooldown remaining (clamp math) -----------------------------------------
+class CooldownRemainingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_future_cooldown_reported(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        r.store[custom_pacing._COOLDOWN_KEY] = str(time.time() + 30)
+        remaining = await pacer._cooldown_remaining(r)
+        self.assertTrue(25 <= remaining <= 30)
+
+    async def test_clamped_to_max_cooldown(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        r.store[custom_pacing._COOLDOWN_KEY] = str(time.time() + 999)
+        remaining = await pacer._cooldown_remaining(r)
+        self.assertEqual(remaining, custom_pacing._Cfg.MAX_COOLDOWN_S)
+
+    async def test_absent_key_is_zero(self):
+        pacer = custom_pacing.FleetPacer()
+        self.assertEqual(await pacer._cooldown_remaining(FakeRedis()), 0.0)
+
+    async def test_past_cooldown_is_zero(self):
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis()
+        r.store[custom_pacing._COOLDOWN_KEY] = str(time.time() - 10)
+        self.assertEqual(await pacer._cooldown_remaining(r), 0.0)
+
+
+# --- Adaptive 429 cooldown (extend-only, capped, 429-gated) -------------------
+class FailureHookCooldownTests(unittest.IsolatedAsyncioTestCase):
+    def _pacer_with(self, fake):
+        pacer = custom_pacing.FleetPacer()
+        pacer._redis = fake  # bypass _get_redis (no real redis import)
+        return pacer
+
+    async def test_429_by_status_sets_default_cooldown(self):
+        r = FakeRedis()
+        pacer = self._pacer_with(r)
+        exc = types.SimpleNamespace(status_code=429, message="slow down")
+        before = time.time()
+        await pacer.async_post_call_failure_hook({}, exc, None)
+        self.assertIn(custom_pacing._COOLDOWN_KEY, r.store)
+        parked = float(r.store[custom_pacing._COOLDOWN_KEY])
+        # default cooldown is 5s when no Retry-After present
+        self.assertTrue(before + 4 <= parked <= before + 6.5)
+
+    async def test_429_by_message_sets_cooldown(self):
+        r = FakeRedis()
+        pacer = self._pacer_with(r)
+        exc = types.SimpleNamespace(
+            status_code=None, message="would exceed your account rate limit"
+        )
+        await pacer.async_post_call_failure_hook({}, exc, None)
+        self.assertIn(custom_pacing._COOLDOWN_KEY, r.store)
+
+    async def test_non_429_sets_no_cooldown(self):
+        r = FakeRedis()
+        pacer = self._pacer_with(r)
+        exc = types.SimpleNamespace(status_code=500, message="internal error")
+        await pacer.async_post_call_failure_hook({}, exc, None)
+        self.assertNotIn(custom_pacing._COOLDOWN_KEY, r.store)
+
+    async def test_retry_after_capped_at_max_cooldown(self):
+        r = FakeRedis()
+        pacer = self._pacer_with(r)
+        # Retry-After far above MAX_COOLDOWN_S must be clamped to the cap.
+        exc = types.SimpleNamespace(
+            status_code=429, message="rate_limit_error", headers={"retry-after": "999"}
+        )
+        before = time.time()
+        await pacer.async_post_call_failure_hook({}, exc, None)
+        parked = float(r.store[custom_pacing._COOLDOWN_KEY])
+        cap = custom_pacing._Cfg.MAX_COOLDOWN_S
+        self.assertTrue(before + cap - 1 <= parked <= before + cap + 1)
+
+    async def test_cooldown_is_extend_only(self):
+        # A shorter incoming cooldown must NOT shorten an existing longer one.
+        r = FakeRedis()
+        pacer = self._pacer_with(r)
+        long_until = time.time() + 50
+        r.store[custom_pacing._COOLDOWN_KEY] = str(long_until)
+        exc = types.SimpleNamespace(
+            status_code=429, message="rate_limit_error", headers={"retry-after": "5"}
+        )
+        await pacer.async_post_call_failure_hook({}, exc, None)
+        parked = float(r.store[custom_pacing._COOLDOWN_KEY])
+        self.assertEqual(parked, long_until)  # unchanged — never shortened
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

Brings the fleet-wide LiteLLM pacer (`custom_pacing.py`) under source control **with tests and CI**. Until now this fleet-critical hot-path module lived **only** as a bind-mounted file on the Coolify host — no repo tracking, no tests, no review history, off CI (called out explicitly in `src/auth/broker/usage-ledger.ts:17` prose and the pacer-durable-fix design). That is a durability defect: the running pacer had no reviewable source of truth.

This is **behaviour-neutral governance/hardening only**:
- The vendored `custom_pacing.py` is **byte-for-byte identical** to the live deployed copy (`sha256` verified at vendor time: `823c67a9…b037`).
- **No pacer logic changes. No code-default changes** — the file keeps its conservative code defaults `8/60/4/20` (`MAX_CONCURRENCY/RPM/RPS/WAIT_S`). The live deployment's env overrides (`16/90/6/12` in the host `docker-compose.yml`) remain the deployment layer's job, unchanged.

## Where it landed & why

`docker/litellm-pacer/` — mirrors the existing `docker/voice-sidecar/` precedent: a deployed Python artifact plus a stdlib `test_*.py`, already the exact shape the `ci-tests-python` lane knows how to discover and run. Keeps the deployment asset distinct from the TypeScript app source in `src/litellm/` (which is the provisioning client, compiled/tested as TS).

## Python-test approach

Pure-stdlib `unittest` (+ `IsolatedAsyncioTestCase` for the async hooks) — **no `pip install`, no new CI lane**. The repo already has a Python CI lane (`ci-tests-python.yml`) that runs `python3 -m unittest discover` with zero external deps; this PR extends it rather than standing up new infra.

`custom_pacing.py` imports `litellm` at module top (it is a LiteLLM `CustomLogger` callback), so the test injects lightweight stubs for the two `litellm` imports via `sys.modules` **before** importing the module under test. This keeps the vendored file **completely unmodified** and the test dependency-free. 23 tests, all asserting outcomes:
- **admit** — `_try_admit` maps the atomic Lua verdict (1→admit / 0→wait);
- **fail-open** — a Redis error on the admit path returns `True` (proceeds), the core "never worse than no pacer" guarantee;
- **cooldown** — the adaptive 429 cooldown is extend-only, capped at `MAX_COOLDOWN_S`, and fires **only** on a real 429 signal (status `429` or the rate-limit message strings), not on a 500;
- **Retry-After** — header parsed off both `.headers` and `.response.headers`, degrades to `None` on missing/non-numeric (never raises);
- plus env-parse fail-safe and an AST-based **code-default guard** that fails loudly if a future edit silently changes `8/60/4/20`.

## CI config touched (called out explicitly)

`.github/workflows/ci-tests-python.yml` — added `docker/litellm-pacer/**` to the path filter and a run step (`python3 -m unittest discover -s docker/litellm-pacer -p 'test_*.py'`) so these tests gate PRs. No other CI config needed.

## Sync / deploy note

`docker/litellm-pacer/README.md` documents: the host deploy path (`/data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/custom_pacing.py` → bind-mounted to `/app/custom_pacing.py`), that **the repo copy is now source-of-truth**, the code-default-vs-env table, and the sync step (copy to host, then **redeploy the litellm service to reload the callback**). Full copy+redeploy+verify automation is a documented follow-up — P0 scope is get-it-in-repo-with-tests + documented sync.

## Scope / release

Part of the **consolidated pacer-durable-fix release** (P0 of P0–P4). **Do not roll to the fleet and do not merge on its own** — leave for review; ships together with the later layers. No live change results from merging this (it only adds repo files + a CI step).

## Local verification
- `python3 -m unittest discover -s docker/litellm-pacer -p 'test_*.py'` → **23 passed** (0.03s).
- `npm run lint` → **clean** (tsc + all 8 guard scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)