### PR TITLE
fix(telegram): operator-facing event timestamps in local time not UTC

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5652,6 +5652,9 @@ const sendGateStatsLogger = createStatsLogger({
 const floodWindowObserver = createFloodWindowObserver({
   clock: { now: () => Date.now(), sleep: (ms) => new Promise((r) => setTimeout(r, ms)) },
   log: (line) => process.stderr.write(line),
+  // Render the operator-facing flood alerts in the configured local timezone
+  // (same env the config cascade bakes into every agent — see timezone.ts).
+  tz: process.env.SWITCHROOM_TIMEZONE ?? process.env.TZ ?? 'UTC',
   stats: () => sendGate.stats(),
   readWindows: (now) => readFloodWindows(FLOOD_WINDOWS_PATH, now),
   markAlerted: (scopeKey, alertedAt) =>

--- a/telegram-plugin/send-gate-observability.test.ts
+++ b/telegram-plugin/send-gate-observability.test.ts
@@ -352,6 +352,146 @@ describe('createFloodWindowObserver — alerting', () => {
     expect(alerts).toHaveLength(1)
   })
 
+  // The operator-facing alert timestamps must render in the CONFIGURED local
+  // timezone, not UTC. The live incident that prompted this: a "flood ban
+  // cleared" card printed `2026-07-12T23:39:24Z to 2026-07-12T23:46:40Z UTC`,
+  // which is 9:39am–9:46am AEST in the fleet's configured zone. These assert
+  // the local rendering and would FAIL on the old `.toISOString()` output.
+  const OBSERVED = Date.parse('2026-07-12T23:39:24Z') // 2026-07-13 09:39 AEST
+  const UNTIL = Date.parse('2026-07-12T23:46:40Z') // 2026-07-13 09:46 AEST
+
+  it('renders the CLEARED card timestamps in the configured local tz (AEST), not UTC', async () => {
+    const clock = new TestClock()
+    const alerts: string[] = []
+    let windows: FloodWindowRecord[] = [
+      { scopeKey: 'global', untilTs: UNTIL, retryAfterSrc: '429', observedAt: OBSERVED },
+    ]
+    const obs = createFloodWindowObserver({
+      clock,
+      log: () => {},
+      stats: () => makeStats(),
+      readWindows: () => windows,
+      markAlerted: () => {},
+      sendAlert: async (t) => {
+        alerts.push(t)
+      },
+      operatorChatId: () => 'op',
+      alertThresholdMs: 60_000,
+      tz: 'Australia/Melbourne',
+    })
+
+    // Past threshold but global → operator unreachable → defer to close.
+    clock.cur = OBSERVED + 61_000
+    await obs.tick()
+    expect(alerts).toHaveLength(0)
+
+    // Window closes → deferred cleared card fires, in LOCAL time.
+    clock.cur = UNTIL + 1_000
+    windows = []
+    await obs.tick()
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toContain('flood ban cleared')
+    // Local-tz rendering: 9:39am to 9:46am AEST.
+    expect(alerts[0]).toContain('was banned from 9:39am to 9:46am AEST')
+    // And explicitly NOT the old UTC ISO output.
+    expect(alerts[0]).not.toContain('2026-07-12T23:39:24Z')
+    expect(alerts[0]).not.toContain('UTC')
+  })
+
+  it('renders the ACTIVE card clear-time in the configured local tz (AEST), not UTC', async () => {
+    const clock = new TestClock()
+    const alerts: string[] = []
+    let windows: FloodWindowRecord[] = [
+      // A far-future untilTs so the window stays open; a non-operator chat so
+      // the immediate-delivery branch fires (openAlertText).
+      { scopeKey: 'chat:other', untilTs: UNTIL, retryAfterSrc: '429', observedAt: OBSERVED },
+    ]
+    const obs = createFloodWindowObserver({
+      clock,
+      log: () => {},
+      stats: () => makeStats(),
+      readWindows: () => windows,
+      markAlerted: (scope, at) => {
+        windows = windows.map((w) => (w.scopeKey === scope ? { ...w, alertedAt: at } : w))
+      },
+      sendAlert: async (t) => {
+        alerts.push(t)
+      },
+      operatorChatId: () => 'op',
+      alertThresholdMs: 60_000,
+      tz: 'Australia/Melbourne',
+    })
+
+    clock.cur = OBSERVED + 61_000
+    await obs.tick()
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toContain('flood ban active')
+    // "expected to clear at 9:46am AEST" — local wall-clock, not UTC ISO.
+    expect(alerts[0]).toContain('expected to clear at 9:46am AEST')
+    expect(alerts[0]).not.toContain('2026-07-12T23:46:40Z')
+    expect(alerts[0]).not.toContain('UTC')
+  })
+
+  it('defaults to UTC wording when no tz is configured (backward compat)', async () => {
+    const clock = new TestClock()
+    const alerts: string[] = []
+    let windows: FloodWindowRecord[] = [
+      { scopeKey: 'global', untilTs: UNTIL, retryAfterSrc: '429', observedAt: OBSERVED },
+    ]
+    const obs = createFloodWindowObserver({
+      clock,
+      log: () => {},
+      stats: () => makeStats(),
+      readWindows: () => windows,
+      markAlerted: () => {},
+      sendAlert: async (t) => {
+        alerts.push(t)
+      },
+      operatorChatId: () => 'op',
+      alertThresholdMs: 60_000,
+      // no tz → UTC
+    })
+    clock.cur = OBSERVED + 61_000
+    await obs.tick()
+    clock.cur = UNTIL + 1_000
+    windows = []
+    await obs.tick()
+    expect(alerts).toHaveLength(1)
+    // UTC fallback: 11:39pm to 11:46pm UTC on 2026-07-12.
+    expect(alerts[0]).toContain('11:39pm to 11:46pm UTC')
+  })
+
+  it('spans the local date when a window crosses local midnight', async () => {
+    const clock = new TestClock()
+    const alerts: string[] = []
+    // 2026-07-13T13:55:00Z .. 2026-07-13T14:05:00Z = 11:55pm 13 Jul .. 12:05am 14 Jul AEST.
+    const obsStart = Date.parse('2026-07-13T13:55:00Z')
+    const obsEnd = Date.parse('2026-07-13T14:05:00Z')
+    let windows: FloodWindowRecord[] = [
+      { scopeKey: 'global', untilTs: obsEnd, retryAfterSrc: '429', observedAt: obsStart },
+    ]
+    const obs = createFloodWindowObserver({
+      clock,
+      log: () => {},
+      stats: () => makeStats(),
+      readWindows: () => windows,
+      markAlerted: () => {},
+      sendAlert: async (t) => {
+        alerts.push(t)
+      },
+      operatorChatId: () => 'op',
+      alertThresholdMs: 60_000,
+      tz: 'Australia/Melbourne',
+    })
+    clock.cur = obsStart + 61_000
+    await obs.tick()
+    clock.cur = obsEnd + 1_000
+    windows = []
+    await obs.tick()
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toContain('13 Jul 11:55pm to 14 Jul 12:05am AEST')
+  })
+
   it('does not alert for msg-edit (cosmetic) scopes', async () => {
     const clock = new TestClock()
     const alerts: string[] = []

--- a/telegram-plugin/send-gate-observability.ts
+++ b/telegram-plugin/send-gate-observability.ts
@@ -154,6 +154,14 @@ export interface FloodWindowObserverConfig {
   operatorChatId?: () => string | undefined
   /** Ms a window must be open before it earns an alert. Default 60_000. */
   alertThresholdMs?: number
+  /**
+   * IANA timezone (e.g. `Australia/Melbourne`) for rendering the operator-facing
+   * alert timestamps in local wall-clock time instead of UTC. The gateway sources
+   * this from `SWITCHROOM_TIMEZONE ?? TZ` (the same env the config cascade bakes
+   * into every agent service — see `src/config/timezone.ts`). Defaults to `'UTC'`
+   * so a missing tz degrades to the previous behaviour rather than throwing.
+   */
+  tz?: string
 }
 
 export interface FloodWindowObserver {
@@ -161,11 +169,92 @@ export interface FloodWindowObserver {
   tick(): Promise<void>
 }
 
-/** Human-readable ISO-ish timestamp (UTC, second precision) for alert wording. */
-function fmtTs(ms: number): string {
-  // Strip the milliseconds (`.\d{3}`) for second precision — this also covers
-  // the `.000` case, so no separate replace is needed.
-  return new Date(ms).toISOString().replace(/\.\d{3}/, '')
+// ─── Operator-facing local-time formatting ──────────────────────────────────
+// Operator alerts (openAlertText / closeAlertText) render timestamps in the
+// operator's CONFIGURED timezone, not UTC — a "was banned from 9:39am to 9:46am
+// AEST" reads at a glance where a raw `2026-07-12T23:39:24Z UTC` does not. The
+// machine-facing snapshot LOG lines (config.log → gateway-supervisor.log) keep
+// their epoch/ISO wording; only the chat/card text is localized.
+
+/** Lowercased wall-clock time in `tz`, e.g. `9:39am`. */
+function fmtLocalClock(ms: number, tz: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+    .format(new Date(ms))
+    .replace(/\s([AP])M$/, (_m, p: string) => `${p.toLowerCase()}m`)
+}
+
+/** Compact local date, e.g. `12 Jul` — used only to disambiguate day-spanning windows. */
+function fmtLocalDate(ms: number, tz: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: tz,
+    day: 'numeric',
+    month: 'short',
+  }).format(new Date(ms))
+}
+
+/** Calendar day (`YYYY-MM-DD`) in `tz`, for a timezone-correct "same day?" test. */
+function localDay(ms: number, tz: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date(ms))
+}
+
+/**
+ * Short tz abbreviation for `tz` at `ms`, e.g. `AEST`, `EDT`, `BST`. ICU only
+ * surfaces the common alpha abbreviation for a locale whose region matches the
+ * zone, so we try a small locale list and take the first genuine abbreviation;
+ * zones with no common abbreviation (e.g. Asia/Kolkata) fall back to the offset
+ * form (`GMT+5:30`), and `UTC` stays `UTC`.
+ */
+function tzAbbrev(ms: number, tz: string): string {
+  const at = new Date(ms)
+  for (const loc of ['en-US', 'en-AU', 'en-GB']) {
+    const v = new Intl.DateTimeFormat(loc, { timeZone: tz, timeZoneName: 'short' })
+      .formatToParts(at)
+      .find((p) => p.type === 'timeZoneName')?.value
+    if (v && !/^(?:GMT|UTC)/i.test(v)) return v
+  }
+  return (
+    new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'short' })
+      .formatToParts(at)
+      .find((p) => p.type === 'timeZoneName')?.value ?? tz
+  )
+}
+
+/**
+ * A single operator-facing local timestamp with tz suffix, e.g. `9:46am AEST`.
+ * When `refMs` is on a different local calendar day (or omitted), the date is
+ * prepended (`12 Jul 11:52pm AEST`) so a day-spanning window is unambiguous.
+ */
+function fmtLocalStamp(ms: number, tz: string, refMs?: number): string {
+  const clock = fmtLocalClock(ms, tz)
+  const sameDay = refMs != null && localDay(ms, tz) === localDay(refMs, tz)
+  const body = sameDay ? clock : `${fmtLocalDate(ms, tz)} ${clock}`
+  return `${body} ${tzAbbrev(ms, tz)}`
+}
+
+/**
+ * A local time RANGE with a single tz suffix, e.g. `9:39am to 9:46am AEST`.
+ * Same-local-day windows drop the redundant start date; day-spanning windows
+ * carry the date on each end (`12 Jul 11:59pm to 13 Jul 12:04am AEST`).
+ */
+function fmtLocalRange(startMs: number, endMs: number, tz: string): string {
+  const sameDay = localDay(startMs, tz) === localDay(endMs, tz)
+  if (sameDay) {
+    return `${fmtLocalClock(startMs, tz)} to ${fmtLocalClock(endMs, tz)} ${tzAbbrev(endMs, tz)}`
+  }
+  return (
+    `${fmtLocalDate(startMs, tz)} ${fmtLocalClock(startMs, tz)} to ` +
+    `${fmtLocalDate(endMs, tz)} ${fmtLocalClock(endMs, tz)} ${tzAbbrev(endMs, tz)}`
+  )
 }
 
 function fmtDur(ms: number): string {
@@ -187,6 +276,7 @@ export function createFloodWindowObserver(
   config: FloodWindowObserverConfig,
 ): FloodWindowObserver {
   const alertThresholdMs = config.alertThresholdMs ?? 60_000
+  const tz = config.tz ?? 'UTC'
   // Full records seen on the previous tick, keyed by scope (close detection).
   let lastSeen = new Map<string, FloodWindowRecord>()
   // First tick after boot: any window already present was loaded from disk
@@ -233,7 +323,7 @@ export function createFloodWindowObserver(
     const openFor = fmtDur(now - w.observedAt)
     return (
       `⚠️ Telegram flood ban active (scope \`${w.scopeKey}\`). ` +
-      `Open for ${openFor}, expected to clear at ${fmtTs(w.untilTs)} UTC. ` +
+      `Open for ${openFor}, expected to clear at ${fmtLocalStamp(w.untilTs, tz, now)}. ` +
       `Outbound to that scope is being suppressed.`
     )
   }
@@ -251,7 +341,7 @@ export function createFloodWindowObserver(
     const plural = recs.length > 1 ? 's' : ''
     return (
       `⚠️ Telegram flood ban cleared (scope${plural} ${scopes}). ` +
-      `The bot was banned from ${fmtTs(observedAt)} to ${fmtTs(untilTs)} UTC ` +
+      `The bot was banned from ${fmtLocalRange(observedAt, untilTs, tz)} ` +
       `(~${fmtDur(untilTs - observedAt)}). Some outbound messages during that ` +
       `window were suppressed.`
     )


### PR DESCRIPTION
## Problem

Operator-facing flood-window alerts printed raw UTC ISO timestamps. The live example that triggered this:

> The bot was banned from `2026-07-12T23:39:24Z` to `2026-07-12T23:46:40Z` UTC (~7m16s).

Unreadable at a glance for an operator whose fleet runs in `Australia/Melbourne`.

## Fix

Render these operator-chat/card timestamps in the operator's **configured** timezone:

> The bot was banned from **9:39am to 9:46am AEST** (~7m16s).

Scope — **operator-facing chat text only**, both alert builders in `telegram-plugin/send-gate-observability.ts`:
- `openAlertText` — "flood ban active … expected to clear at `9:46am AEST`"
- `closeAlertText` — "flood ban cleared … was banned from `9:39am to 9:46am AEST`"

Machine-facing snapshot **log** lines (`config.log` → `gateway-supervisor.log`, epoch `untilTs=`/ISO) are left untouched — they are debugging output, not operator UX. Sibling UTC sites audited and deliberately excluded: `buildButtonConfirmation` already has an operator-chosen `gateway`/`utc` mode; `model-unavailable.ts` *parses* Anthropic's inbound reset strings; rate-limit reset *displays* already localize via `auth-snapshot-format`'s `tz`; `startup-mutex`/`stderr-timestamps`/`secret-detect` are machine logs.

## How the timezone is resolved

`tz` is threaded into `FloodWindowObserverConfig` (defaults to `'UTC'` for back-compat). The gateway wires it from `process.env.SWITCHROOM_TIMEZONE ?? process.env.TZ ?? 'UTC'` — the exact source the rest of the plugin already uses (`gateway.ts`, `callback-query-handlers.ts`), which the config cascade (`src/config/timezone.ts` → `emitAgentServiceEnv`) bakes into every agent service from `agent.timezone` / `profile.timezone` / `switchroom.timezone` / host detection. No hard-coded zone.

The tz abbreviation (`AEST`/`EDT`/`BST`/…) comes from ICU via a small locale-preference list, falling back to the offset form (`GMT+5:30`) for zones with no common abbreviation. A date prefix is added only when a window spans a local calendar day.

## Tests

`telegram-plugin/send-gate-observability.test.ts`:
- cleared card renders `9:39am to 9:46am AEST`, not the UTC ISO
- active card renders `expected to clear at 9:46am AEST`
- back-compat: no `tz` → `11:39pm to 11:46pm UTC`
- day-spanning window → `13 Jul 11:55pm to 14 Jul 12:05am AEST`

Verified the four local-tz assertions **fail** against pre-fix source (guarding against no-op tests). `npm run lint` clean.

## JTBD / verdict

Serves **Visibility** (reference/vision.md) — an operator alert the human can actually read at 2am. Crosses no invariant (telegram-only, single-tenant, chat-is-source-of-truth all intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)