### PR TITLE
fix(telegram): dedup linear_create_issue by exact capture marker, not fuzzy search

### DIFF
--- a/telegram-plugin/gateway/linear-activity.ts
+++ b/telegram-plugin/gateway/linear-activity.ts
@@ -297,11 +297,20 @@ export async function emitLinearAgentActivity(
   return { content: [{ type: 'text', text: `Linear ${type} emitted on session ${sessionId}` }] }
 }
 
+/** The exact HTML-comment carrying a capture's dedup key. Both the embed
+ *  (captureDedupMarker) and the dedup lookup match on this precise string, so a
+ *  re-capture is confirmed by exact-key equality, not fuzzy search relevance.
+ *  The trailing ` -->` and leading `: ` anchor the key so `abc` never matches
+ *  `abcd`. */
+export function captureDedupComment(dedupKey: string): string {
+  return `<!-- switchroom-capture: ${dedupKey} -->`
+}
+
 /** Hidden marker appended to a captured issue's description so a re-capture of
  *  the same Telegram message can be detected (dedup backstop; the gateway-side
  *  seen-set is the primary, race-free guard). */
 export function captureDedupMarker(dedupKey: string): string {
-  return `\n\n<!-- switchroom-capture: ${dedupKey} -->`
+  return `\n\n${captureDedupComment(dedupKey)}`
 }
 
 /**
@@ -390,19 +399,26 @@ export async function createLinearIssue(
   }
 
   // Dedup backstop: search for a prior capture of the same Telegram message.
+  // `searchIssues` is a relevance-ranked full-text search, so its top hit for a
+  // key can be an unrelated issue that merely shares tokens. We therefore only
+  // treat a result as a dedup match when its description carries the EXACT
+  // capture marker for this key, never the raw top hit.
   if (dedupKey) {
+    const marker = captureDedupComment(dedupKey)
     const search = await gql(
-      'query($term: String!) { searchIssues(term: $term) { nodes { id url title } } }',
+      'query($term: String!) { searchIssues(term: $term, first: 25) { nodes { id url title description } } }',
       { term: dedupKey },
     )
     if (search.ok) {
-      const hit = (search.data?.searchIssues?.nodes ?? [])[0] as { url?: string } | undefined
+      const nodes = (search.data?.searchIssues?.nodes ?? []) as Array<{ url?: string; description?: string }>
+      const hit = nodes.find((n) => typeof n.description === 'string' && n.description.includes(marker))
       if (hit?.url) {
         log(`telegram gateway: linear_create_issue: dedup hit key=${dedupKey} agent=${agent}\n`)
         return { content: [{ type: 'text', text: `Already filed: ${hit.url}` }] }
       }
     }
-    // a failed search is non-fatal — fall through to create (gateway seen-set is primary).
+    // a failed search or no exact-marker match is non-fatal — fall through to
+    // create (gateway seen-set is the primary, race-free guard).
   }
 
   // Resolve the team.

--- a/telegram-plugin/tests/linear-create-issue.test.ts
+++ b/telegram-plugin/tests/linear-create-issue.test.ts
@@ -155,9 +155,14 @@ describe('createLinearIssue — behaviour (#2312)', () => {
     expect(r.content[0].text).toMatch(/default_team_id/)
   })
 
-  it('short-circuits to "Already filed" on a dedup hit', async () => {
+  it('short-circuits to "Already filed" only on an EXACT marker match, skipping unrelated top hits', async () => {
     const { fetchImpl, calls } = routingFetch({
-      searchIssues: () => ({ searchIssues: { nodes: [{ id: 'old', url: 'https://linear.app/acme/issue/ENG-7', title: 'prior' }] } }),
+      searchIssues: () => ({ searchIssues: { nodes: [
+        // relevance-ranked top hit that merely shares tokens — must be ignored.
+        { id: 'noise', url: 'https://linear.app/acme/issue/ENG-99', title: 'unrelated', description: 'no capture marker here' },
+        // the real prior capture, carrying the exact marker for this key.
+        { id: 'old', url: 'https://linear.app/acme/issue/ENG-7', title: 'prior', description: `Y${captureDedupMarker('chat:99')}` },
+      ] } }),
       teams: oneTeam,
       issueCreate: issueOk,
     })
@@ -165,10 +170,33 @@ describe('createLinearIssue — behaviour (#2312)', () => {
       { title: 'X', body: 'Y', dedup_key: 'chat:99' },
       { resolveToken: okToken('t'), fetchImpl, log: () => {} },
     )
+    // matched the marker-bearing node, not the higher-ranked noise node.
     expect(r.content[0].text).toBe('Already filed: https://linear.app/acme/issue/ENG-7')
     // only the search ran — no team resolve, no create.
     expect(calls).toHaveLength(1)
     expect(calls[0].query).toMatch(/searchIssues/)
+  })
+
+  it('does NOT dedup when the search returns only unrelated hits (fuzzy false-positive regression)', async () => {
+    // Regression for the searchIssues fuzzy-match bug: a novel dedup_key
+    // returned an unrelated relevance-ranked hit and wrongly suppressed
+    // creation. No node carries this key's marker, so the tool must create.
+    const { fetchImpl, calls } = routingFetch({
+      searchIssues: () => ({ searchIssues: { nodes: [
+        { id: 'x', url: 'https://linear.app/acme/issue/ENG-56', title: 'ProductOS Job Spec', description: 'shares tokens, but no capture marker' },
+      ] } }),
+      teams: oneTeam,
+      issueCreate: issueOk,
+    })
+    const r = await createLinearIssue(
+      { title: 'Series QA tracker', body: 'Y', dedup_key: 'productos-qa-2026-07-13' },
+      { resolveToken: okToken('t'), fetchImpl, log: () => {} },
+    )
+    expect(r.content[0].text).toMatch(/Filed:/)
+    // fell through past the search to team resolve + create, embedding the marker.
+    const create = calls.find((c) => c.query.includes('issueCreate'))!
+    expect(create).toBeTruthy()
+    expect((create.variables.input as Record<string, unknown>).description).toContain(captureDedupMarker('productos-qa-2026-07-13'))
   })
 
   it('falls through to create when the dedup search misses, and embeds the marker', async () => {


### PR DESCRIPTION
## Problem

`linear_create_issue`'s dedup trusted the top `searchIssues(term: dedupKey)` hit unconditionally. `searchIssues` is a relevance-ranked full-text search, so a **novel** `dedup_key` returned an unrelated issue that merely shared tokens and wrongly short-circuited to "Already filed" instead of creating.

Observed live: two fresh captures with distinct new dedup keys each returned unrelated pre-existing issues (a fresh `productos-qa-*` key matched an unrelated "ProductOS Job Spec" issue). No issue was created.

## Root cause

`telegram-plugin/gateway/linear-activity.ts`, `createLinearIssue` dedup block: it took `nodes[0]` from the fuzzy search and treated any non-empty hit as a match. The dedup key is meant to be recognised via the hidden `<!-- switchroom-capture: KEY -->` marker embedded in the issue description, but the code never verified the returned issue actually contained that marker.

## Fix

- Only treat a search result as a dedup match when its `description` contains the **exact** capture marker for this key. Scan all returned nodes, not just the top one.
- Widen the search to `first: 25` so the true prior capture is in range.
- Extract `captureDedupComment` so the embed and the lookup share one exact string (the `: ` prefix and ` -->` suffix anchor the key, so `abc` can't match `abcd`).

## Tests

- New regression: search returns only an unrelated hit (no marker) => tool must create, not dedup. This is the exact bug repro; it fails on the old code.
- Tightened the existing dedup-hit test: the exact-marker node must win over a higher-ranked unrelated node.
- Full file: 15/15 pass. `tsc --noEmit` clean.

## Adjacent scan

Reviewed the rest of `createLinearIssue`; no other unconditional top-hit trust. The only residual (documented) limitation: a true re-capture relies on the marker-bearing issue being within the search's `first: 25`. The gateway seen-set remains the primary race-free dedup guard, so this backstop missing only risks a rare duplicate, never a wrong suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)