### PR TITLE
feat(telegram): coalesce worker activity feed into one message per chat (bot-wide edit liveness)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1992,6 +1992,13 @@ function channelsToEnv(agent: AgentConfig): Record<string, string> {
       out.SWITCHROOM_TG_SEND_GATE_EDIT_FLOOR_MS = String(sg.edit_floor_ms);
     }
   }
+  // Coalesced worker-activity feed tuning (channels.telegram.worker_feed.*).
+  // Only emitted when explicitly set so the feed's built-in default (8) owns
+  // the unset case — omitting the block reproduces today's behaviour.
+  const wf = (tg as { worker_feed?: { max_rows?: number } } | undefined)?.worker_feed;
+  if (wf?.max_rows !== undefined) {
+    out.SWITCHROOM_TG_WORKER_FEED_MAX_ROWS = String(wf.max_rows);
+  }
   // Whether to DELETE the activity/status feed when the final answer lands.
   // Default (unset) = keep it as a record; only emit the env when explicitly
   // set so the gateway's default-off parse owns the unset case.

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -130,6 +130,30 @@ describe("TelegramChannelSchema — send_gate rate limits (#3084)", () => {
   });
 });
 
+describe("TelegramChannelSchema — worker_feed.max_rows (coalesced feed)", () => {
+  it("accepts a positive integer max_rows", () => {
+    const r = TelegramChannelSchema.parse({ worker_feed: { max_rows: 10 } });
+    expect(r?.worker_feed).toEqual({ max_rows: 10 });
+  });
+
+  it("omitting worker_feed leaves it undefined (built-in default of 8 owns the unset case)", () => {
+    const r = TelegramChannelSchema.parse({ format: "html" });
+    expect(r?.worker_feed).toBeUndefined();
+  });
+
+  it("rejects a zero max_rows LOUDLY (a 0-row feed would render no live workers)", () => {
+    expect(() =>
+      TelegramChannelSchema.parse({ worker_feed: { max_rows: 0 } }),
+    ).toThrow();
+  });
+
+  it("rejects a non-integer max_rows LOUDLY", () => {
+    expect(() =>
+      TelegramChannelSchema.parse({ worker_feed: { max_rows: 8.5 } }),
+    ).toThrow();
+  });
+});
+
 describe("TelegramChannelSchema — voice_out (PR-C2)", () => {
   it("applies engine/reply_mode defaults when only enabled is set", () => {
     const r = TelegramChannelSchema.parse({ voice_out: { enabled: true } });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1231,6 +1231,29 @@ export const TelegramChannelSchema = z
         "today's exact behaviour — this is pure operator tuning, no default is " +
         "changed. Cascades from defaults.channels.telegram.send_gate."
       ),
+    worker_feed: z
+      .object({
+        max_rows: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            "Max live-worker rows rendered in the COMBINED worker-activity feed " +
+            "(2+ background workers in one chat/thread coalesce into ONE message; " +
+            "telegram-plugin/worker-activity-feed.ts) before a compact " +
+            "'+M more working…' spill line — keeps the coalesced body compact and " +
+            "legible (and under the rich-message wire ceiling). Default 8. A " +
+            "single-worker chat renders the full 🛠 Worker card and ignores this. " +
+            "Must be an integer >= 1. Omit to keep 8."
+          ),
+      })
+      .optional()
+      .describe(
+        "Tuning for the coalesced worker-activity feed " +
+        "(telegram-plugin/worker-activity-feed.ts). Cascades from " +
+        "defaults.channels.telegram.worker_feed."
+      ),
     // progress_card block removed in #1122 PR3 (the pinned progress card
     // was replaced by conversational pacing + silence-poke). Existing
     // YAML files with a stale progress_card key will be silently

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8601,6 +8601,17 @@ async function runMidSessionCardReaper(): Promise<void> {
       const reaps = decideWorkerPinReaps({
         pins: candidates,
         statusOf: (agentId) => {
+          // #3207: coalesced feed pins are GROUP-level (`wk:group:<feedKey>`),
+          // so `workerAgentIdOfPinKey` yields `group:<feedKey>`, not a real
+          // jsonl agent id. Vouch for these off the live feed instead of the
+          // registry: a group the feed still tracks is 'running' (exempt from
+          // the TTL); a lingering group pin the feed no longer knows about is a
+          // missed unpin → 'terminal' (reap now). The feed's own group-empty
+          // unpin is the primary path; this is the missed-unpin backstop.
+          if (agentId.startsWith('group:')) {
+            const feedKey = agentId.slice('group:'.length)
+            return workerActivityFeed?.hasRunningInFeed(feedKey) ? 'running' : 'terminal'
+          }
           if (turnsDb == null) return 'unknown'
           try {
             const row = getSubagentByJsonlId(turnsDb, agentId)
@@ -8759,34 +8770,14 @@ async function reconcileStatusPinInner(
   }
 }
 
-/**
- * Background-worker desired-pin, driven off the live `🛠 Worker` message.
- * Reads the worker feed's current message_id (the EXISTING message — we pin
- * what the feed already rendered, never a new send) and reconciles a silent
- * pin while it's running / an unpin on completion. No-op until the feed has
- * actually painted a message for this worker (trivial sub-second workers stay
- * silent and are never pinned). Keyed `wk:<agentId>`.
- */
-function reconcileWorkerPin(
-  agentId: string,
-  chatId: string | null,
-  running: boolean,
-): void {
-  if (!PIN_STATUS_WHILE_WORKING) return
-  const key = `wk:${agentId}`
-  if (!running) {
-    // Unpin: recover the chat we pinned in (caller may not have it at
-    // completion). No-op when nothing was pinned for this worker.
-    const unpinChat = chatId ?? statusPinChatIds.get(key)
-    if (unpinChat == null) return
-    void reconcileStatusPin(key, unpinChat, { pinned: false })
-    return
-  }
-  if (chatId == null) return
-  const messageId = workerActivityFeed?.messageIdOf(agentId) ?? null
-  if (messageId == null) return // no message painted yet — nothing to pin
-  void reconcileStatusPin(key, chatId, { pinned: true, messageId })
-}
+// #3207: the per-worker `reconcileWorkerPin(agentId, …)` (keyed `wk:<agentId>`)
+// was removed. Now that background workers COALESCE into one shared message per
+// chat/thread, the pin is driven at the GROUP level by the feed itself
+// (`reconcilePin` → `wk:group:<feedKey>`, wired at createWorkerActivityFeed):
+// it pins when the group's first worker paints and unpins only when the group
+// empties. A per-worker unpin used to physically unpin a message a sibling
+// still needed, after which the survivor's re-pin NO-OP'd (its claim still
+// named that id) — leaving live work unpinned (review blocker).
 
 /** Unpin every owned status pin — used by the pre-restart sweep so a
  *  crash / interrupt never leaves a permanent pin behind. Best-effort;
@@ -29404,6 +29395,25 @@ void (async () => {
               // channels.telegram.worker_feed.max_rows via the config cascade
               // (scaffold emits SWITCHROOM_TG_WORKER_FEED_MAX_ROWS); unset → 8.
               maxRows: workerFeedMaxRows,
+              // #3207 review: GROUP-level status pin. Workers now coalesce into
+              // ONE shared message, so the pin must follow the GROUP lifecycle,
+              // not a single worker's — otherwise a sibling's finish unpins a
+              // message the survivors still need and the survivor's re-pin NOOPs
+              // (its claim still names that id), leaving live work unpinned. The
+              // feed drives this: pin `wk:group:<feedKey>` when the group first
+              // paints, unpin only when the group empties (messageId === null).
+              reconcilePin: ({ feedKey, chatId, messageId }) => {
+                if (!PIN_STATUS_WHILE_WORKING) return
+                const key = `wk:group:${feedKey}`
+                if (messageId != null) {
+                  void reconcileStatusPin(key, chatId, { pinned: true, messageId })
+                } else {
+                  const unpinChat = chatId || statusPinChatIds.get(key)
+                  if (unpinChat != null && unpinChat.length > 0) {
+                    void reconcileStatusPin(key, unpinChat, { pinned: false })
+                  }
+                }
+              },
               log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
             })
             subagentWatcher = startSubagentWatcher({
@@ -29520,9 +29530,9 @@ void (async () => {
               // anything. The actual repaint + re-pin happen DOWNSTREAM on the
               // next replayed `running` cue: the watcher's re-registration
               // replays `onProgress`, which calls `workerActivityFeed.update()`
-              // (now un-gated) to first-paint a FRESH `🛠 Worker` message, and
-              // its `.then(reconcileWorkerPin(agentId, wkChat, true))` pins that
-              // new message via the `wk:<agentId>` status-pin. Clearing the gate
+              // (now un-gated) to first-paint a FRESH message, and the feed's
+              // own `reconcilePin` (#3207) re-pins that message at the GROUP
+              // level (`wk:group:<feedKey>`). Clearing the gate
               // here FIRST is the ordering requirement — without it those first
               // replayed ticks would be swallowed by the finalized gate and no
               // new card would ever paint. Net effect restores the operator
@@ -29628,7 +29638,7 @@ void (async () => {
                       // card keeps the model tag even with no live entry.
                       model: dispatch.feedModel ?? undefined,
                     })
-                    reconcileWorkerPin(agentId, null, false)
+                    // #3207: group-level pin dropped by the feed on group-empty.
                   }
                   return
                 }
@@ -29706,8 +29716,9 @@ void (async () => {
                       state: outcome === 'failed' ? 'failed' : 'done',
                       model: dispatch.feedModel ?? undefined,
                     })
-                    // Status-pin: worker done — drop its pin.
-                    reconcileWorkerPin(agentId, null, false)
+                    // #3207: the group-level pin is dropped by the feed itself
+                    // when this group's LAST worker finishes (reconcilePin →
+                    // `wk:group:<feedKey>`); no per-worker unpin here.
                   }
                   return
                 }
@@ -29726,8 +29737,8 @@ void (async () => {
                     state: outcome === 'failed' ? 'failed' : 'done',
                     model: dispatch.feedModel ?? undefined,
                   })
-                  // Status-pin: worker done — drop its pin.
-                  reconcileWorkerPin(agentId, null, false)
+                  // #3207: the group-level pin is dropped by the feed itself
+                  // when this group's LAST worker finishes; no per-worker unpin.
                 }
 
                 const handbackOrigin = resolveSubagentOriginChat(agentId)
@@ -29894,7 +29905,10 @@ void (async () => {
                         model: feedModel,
                       },
                       wk.threadId,
-                    )?.then(() => reconcileWorkerPin(agentId, wkChat, true))
+                    )
+                  // #3207: the feed pins the group's shared message itself when
+                  // it first paints (reconcilePin → `wk:group:<feedKey>`); no
+                  // per-worker pin chained here.
                     return
                   }
                   if (surface !== 'nest') return // 'skip' — orphan-status off
@@ -30036,7 +30050,10 @@ void (async () => {
                       model: feedModel,
                     },
                     wk.threadId,
-                  )?.then(() => reconcileWorkerPin(agentId, wkChat, true))
+                  )
+                  // #3207: the feed pins the group's shared message itself when
+                  // it first paints (reconcilePin → `wk:group:<feedKey>`); no
+                  // per-worker pin chained here.
                   return
                 }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6747,10 +6747,19 @@ function isAutoFallbackCooldownActive(_agentName: string, now: number): boolean 
 
 async function editCardExpired(chatId: string, messageId: number | undefined, body: string): Promise<void> {
   if (messageId == null) return
-  await lockedBot.api
-    // allow-raw-bot-api: message-id-targeted edit (no thread to lose); best-effort card-expiry strip from the reaper (no grammy ctx). Dropping reply_markup strips the stale keyboard atomically with the text edit.
-    .editMessageText(chatId, messageId, richMessage(body), { reply_markup: { inline_keyboard: [] } })
-    .catch(() => {})
+  // #3084 bypass audit: this best-effort card-expiry strip (reaper + lazy
+  // sweeps, no grammy ctx) previously fired a RAW `lockedBot.api.editMessageText`
+  // OUTSIDE the send gate — a residual flood vector (a 429 here never reached
+  // `onFloodWait`, so the breaker stayed blind). Routed through `robustApiCall`
+  // (chat-lock → send-gate → retry/breaker) as a `cosmetic` edit carrying
+  // messageId+editPayload so it paces/sheds under pressure and its 429 records
+  // the flood window. Dropping reply_markup strips the stale keyboard atomically
+  // with the text edit; message-id-targeted so no thread to lose.
+  const text = richMessage(body)
+  await robustApiCall(
+    () => lockedBot.api.editMessageText(chatId, messageId, text, { reply_markup: { inline_keyboard: [] } }),
+    { chat_id: chatId, verb: 'card-expired.strip', priorityClass: 'cosmetic', messageId, editPayload: body },
+  ).catch(() => {})
 }
 
 function recordMissedApproval(opts: {
@@ -29325,6 +29334,12 @@ void (async () => {
             // supersedes the coarse 5-min bucket relay below to avoid
             // double-surfacing the same progress beat.
             const workerFeedEnabled = isWorkerActivityFeedEnabled(process.env.SWITCHROOM_WORKER_ACTIVITY_FEED)
+            // Combined-feed row cap (channels.telegram.worker_feed.max_rows).
+            // Unset / non-positive → the feed's built-in default (8).
+            const workerFeedMaxRows = (() => {
+              const raw = Number(process.env.SWITCHROOM_TG_WORKER_FEED_MAX_ROWS)
+              return Number.isInteger(raw) && raw > 0 ? raw : undefined
+            })()
             // Model A — foreground sub-agent nesting in the parent's live
             // activity draft. ON by default; this edits the SAME activity-
             // summary message the tool_label feed already owns (not the
@@ -29382,6 +29397,13 @@ void (async () => {
               // every ~6s for the whole ban (the worker-feed shed-contract bug:
               // 565 `sent.message_id` crashes in one 6h ban).
               floodWaitRemainingMs: probeFloodWaitRemainingMs,
+              // #3084 follow-up: 2+ background workers in one chat/thread coalesce
+              // into ONE combined feed message. `maxRows` caps the visible rows
+              // (compact `+M more working…` spill) so the body stays under the
+              // rich-message wire ceiling (STATUS_CARD_CHAR_BUDGET). Sourced from
+              // channels.telegram.worker_feed.max_rows via the config cascade
+              // (scaffold emits SWITCHROOM_TG_WORKER_FEED_MAX_ROWS); unset → 8.
+              maxRows: workerFeedMaxRows,
               log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
             })
             subagentWatcher = startSubagentWatcher({

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -533,17 +533,20 @@ describe('createWorkerActivityFeed — log sink', () => {
     const edit = logs.find((l) => l.startsWith('worker-feed: edit'))
     const finish = logs.find((l) => l.startsWith('worker-feed: finish'))
 
+    // The feed message is per-(chat,thread) now (workers coalesce), so the
+    // paint/edit lines are feed-scoped; the terminal `finish` line still names
+    // the finishing worker + its state.
     expect(paint).toBeDefined()
-    expect(paint).toContain('agent=w-research')
     expect(paint).toContain('chat=chat-9')
     expect(paint).toContain('thread=7')
     expect(paint).toMatch(/msgId=\d+/)
     expect(paint).toMatch(/bytes=\d+/)
 
     expect(edit).toBeDefined()
-    expect(edit).toContain('agent=w-research')
+    expect(edit).toContain('chat=chat-9')
 
     expect(finish).toBeDefined()
+    expect(finish).toContain('agent=w-research')
     expect(finish).toContain('state=done')
   })
 

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createWorkerActivityFeed,
+  type BotApiForWorkerFeed,
+  type WorkerActivityView,
+} from '../worker-activity-feed.js'
+import { renderCombinedWorkerFeed } from '../tool-activity-summary.js'
+import { STATUS_CARD_CHAR_BUDGET } from '../status-no-truncate.js'
+import { createSendGate, isSendGateShed, type Clock } from '../send-gate.js'
+
+/**
+ * Outcome tests for the coalesced worker-activity feed (#3084 follow-up).
+ *
+ * These drive the REAL send gate (perChatPerSec=1, burst 3, editFloorMs=1500 —
+ * the shipped defaults) with the feed's real send/edit adapters wired exactly
+ * as the gateway wires them (`useful` sends, `cosmetic` edits carrying
+ * messageId+editPayload). The assertions prove the coalescing win that the
+ * per-worker-message model cannot achieve:
+ *
+ *   - N=15 workers in one chat produce exactly ONE combined message (not 15).
+ *   - Every worker's latest state refreshes TOGETHER in that one message within
+ *     one ~1.5s edit cycle (the per-worker model refreshes each card only once
+ *     per ~N·(1/perChatPerSec) seconds — liveness collapse).
+ *   - The gate SHEDS ~nothing under the coalesced stream (the per-worker model
+ *     sheds ~14/15 of every second's cosmetic edits — a real ban happened).
+ *   - A `critical` reply mid-storm is admitted, never shed/starved.
+ *   - Redundant identical renders don't produce redundant landed edits.
+ */
+
+/**
+ * Deterministic fake clock shared by BOTH the send gate (Clock.now/sleep) and
+ * the feed (`now: () => clock.now()`). Mirrors send-gate.test.ts's FakeClock.
+ */
+class FakeClock implements Clock {
+  private cur = 0
+  private seq = 0
+  private timers: { at: number; id: number; resolve: () => void }[] = []
+  now(): number {
+    return this.cur
+  }
+  sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.timers.push({ at: this.cur + ms, id: this.seq++, resolve })
+    })
+  }
+  async advance(ms: number): Promise<void> {
+    const target = this.cur + ms
+    for (;;) {
+      const due = this.timers.filter((t) => t.at <= target).sort((a, b) => a.at - b.at || a.id - b.id)
+      if (due.length === 0) break
+      const t = due[0]
+      this.timers = this.timers.filter((x) => x !== t)
+      this.cur = t.at
+      t.resolve()
+      await flush()
+    }
+    this.cur = target
+  }
+}
+function flush(): Promise<void> {
+  return new Promise((r) => setImmediate(r))
+}
+/** Flush the promise-chain a few times so feed chains + gate drivers settle. */
+async function settle(clock: FakeClock, ms = 0): Promise<void> {
+  await clock.advance(ms)
+  for (let i = 0; i < 6; i++) await flush()
+}
+
+interface LandedEdit {
+  chatId: string
+  messageId: number
+  text: string
+  at: number
+}
+
+/**
+ * Build the feed + a bot adapter routed through a REAL send gate, exactly like
+ * the gateway (worker-feed sends are `useful`, edits are `cosmetic` carrying
+ * messageId + editPayload for the gate's floor/coalesce/no-op logic).
+ */
+function harness(clock: FakeClock, opts: { maxRows?: number } = {}) {
+  const gate = createSendGate({
+    enabled: true,
+    clock,
+    globalPerSec: 1000, // global is not the limiter under test
+    globalBurst: 1000,
+    perChatPerSec: 1,
+    perChatBurst: 3,
+    editFloorMs: 1500,
+  })
+  const sends: { chatId: string; messageId: number; at: number }[] = []
+  const edits: LandedEdit[] = []
+  let seq = 1000
+  const bot: BotApiForWorkerFeed = {
+    sendMessage: (chatId, _text, o) =>
+      gate.gate(
+        async () => {
+          const messageId = seq++
+          sends.push({ chatId, messageId, at: clock.now() })
+          return { message_id: messageId }
+        },
+        { chat_id: chatId, priorityClass: 'useful', verb: 'worker-feed' },
+      ) as Promise<{ message_id: number }>,
+    editMessageText: (chatId, messageId, text, o) =>
+      gate.gate(
+        async () => {
+          edits.push({ chatId, messageId, text, at: clock.now() })
+          return true
+        },
+        {
+          chat_id: chatId,
+          priorityClass: 'cosmetic',
+          messageId,
+          editPayload: text,
+          verb: 'worker-feed',
+        },
+      ),
+  }
+  const feed = createWorkerActivityFeed({
+    bot,
+    now: () => clock.now(),
+    // Let the send gate's editFloorMs (1500) be the pacing authority: the feed's
+    // own proactive throttle matches it so the coalesced stream never outruns
+    // the per-chat bucket (which is what would shed it).
+    minEditIntervalMs: 1500,
+    heartbeatTickMs: 1500,
+    firstPaintMinMs: 0,
+    // No auto-timer: the test drives heartbeatTick() deterministically.
+    setInterval: () => 0,
+    clearInterval: () => {},
+    maxRows: opts.maxRows ?? 8,
+  })
+  return { gate, feed, sends, edits }
+}
+
+function view(desc: string, step: string, elapsedMs: number): WorkerActivityView {
+  return {
+    description: desc,
+    lastTool: null,
+    toolCount: 3,
+    latestSummary: step,
+    elapsedMs,
+    state: 'running',
+  }
+}
+
+describe('coalesced worker feed — one message per chat under load', () => {
+  it('N=15 workers over 60s produce ONE message with a bounded, non-shedding edit stream', async () => {
+    const clock = new FakeClock()
+    const CHAT = 'chat-storm'
+    const N = 15
+    const { gate, feed, sends, edits } = harness(clock, { maxRows: N })
+    const ids = Array.from({ length: N }, (_, i) => `w${i}`)
+
+    // Latest step each worker last emitted (unique per cycle so we can prove
+    // freshness in the rendered body).
+    const latest: Record<string, string> = {}
+
+    const CYCLE = 1500
+    const CYCLES = 40 // 40 * 1.5s = 60s
+    for (let c = 0; c < CYCLES; c++) {
+      await clock.advance(CYCLE)
+      for (const id of ids) {
+        latest[id] = `${id}-step-${c}`
+        void feed.update(id, CHAT, view(`task ${id}`, latest[id], clock.now()))
+      }
+      await settle(clock)
+      feed.heartbeatTick() // flush the accumulated combined render
+      await settle(clock)
+    }
+    await settle(clock, 3000)
+
+    // ONE combined message — not one per worker. This is the structural
+    // distinction from the per-worker-message model (which sends N).
+    expect(sends.length).toBe(1)
+    expect(feed.size).toBe(N)
+
+    // Bounded edit stream: at most perChatPerSec·T + burst landed edits.
+    const seconds = (CYCLES * CYCLE) / 1000
+    const bound = Math.ceil(1 * seconds + 3)
+    expect(edits.length).toBeLessThanOrEqual(bound)
+    // And it actually stayed live (edited many times, not frozen).
+    expect(edits.length).toBeGreaterThan(CYCLES / 3)
+
+    // Shed pin: the coalesced single stream sheds ~nothing. The per-worker model
+    // would shed ~ (N-1)/N of every second's cosmetic edits.
+    expect(gate.stats().global.shed).toBeLessThanOrEqual(3)
+
+    // Liveness: the LAST landed edit carries EVERY worker's latest step — all
+    // rows refreshed together in the one message within one edit cycle.
+    const lastBody = edits[edits.length - 1].text
+    for (const id of ids) {
+      expect(lastBody).toContain(latest[id])
+    }
+  })
+
+  it('admits a critical reply mid-storm (never shed or starved by the cosmetic feed)', async () => {
+    const clock = new FakeClock()
+    const CHAT = 'chat-crit'
+    const { gate, feed } = harness(clock, { maxRows: 15 })
+    const ids = Array.from({ length: 12 }, (_, i) => `k${i}`)
+
+    // Warm the storm.
+    for (let c = 0; c < 4; c++) {
+      await clock.advance(1500)
+      for (const id of ids) void feed.update(id, CHAT, view(`task ${id}`, `${id}-s${c}`, clock.now()))
+      await settle(clock)
+      feed.heartbeatTick()
+      await settle(clock)
+    }
+
+    // A critical reply to the SAME chat, mid-storm. `critical` is never shed and
+    // never blocks behind the cosmetic feed edits.
+    const CRIT = { ok: true, id: 'crit-reply' }
+    const p = gate.gate(async () => CRIT, {
+      chat_id: CHAT,
+      priorityClass: 'critical',
+      verb: 'reply',
+    })
+    await settle(clock, 2000)
+    const res = await p
+    expect(isSendGateShed(res)).toBe(false)
+    expect(res).toEqual(CRIT)
+  })
+
+  it('does not produce redundant landed edits for redundant renders (coalesce/no-op)', async () => {
+    const clock = new FakeClock()
+    const CHAT = 'chat-dedupe'
+    const { gate, feed, edits } = harness(clock)
+
+    // First paint + one edit with a real state change.
+    await clock.advance(1500)
+    void feed.update('w', CHAT, view('task w', 'step-A', clock.now()))
+    await settle(clock)
+    feed.heartbeatTick()
+    await settle(clock, 2000)
+    const afterFirst = edits.length
+
+    // Re-drive the SAME state many times over several cycles. No new step, no new
+    // state → the feed dedups (body === lastBody) and/or the gate drops the no-op;
+    // either way, NO new landed edit and NO shed.
+    const shedBefore = gate.stats().global.shed
+    for (let c = 0; c < 5; c++) {
+      await clock.advance(1500)
+      void feed.update('w', CHAT, view('task w', 'step-A', clock.now()))
+      await settle(clock)
+      feed.heartbeatTick()
+      await settle(clock, 2000)
+    }
+    // The header elapsed climbs on heartbeat, so a redundant *content* update
+    // must not multiply landed edits beyond the heartbeat's own climb cadence.
+    expect(edits.length - afterFirst).toBeLessThanOrEqual(5)
+    // Crucially: redundant identical narrative never sheds.
+    expect(gate.stats().global.shed).toBe(shedBefore)
+  })
+})
+
+/**
+ * Deterministic lifecycle transitions with a DIRECT fake bot (no gate) so we
+ * can assert the exact rendered body at each step.
+ */
+function directBot() {
+  const sent: { chatId: string; text: string; messageId: number }[] = []
+  const edits: { messageId: number; text: string }[] = []
+  let seq = 500
+  const bot: BotApiForWorkerFeed = {
+    sendMessage: async (chatId, text) => {
+      const messageId = seq++
+      sent.push({ chatId, text, messageId })
+      return { message_id: messageId }
+    },
+    editMessageText: async (_chatId, messageId, text) => {
+      edits.push({ messageId, text })
+      return true
+    },
+  }
+  return { bot, sent, edits }
+}
+
+describe('coalesced worker feed — lifecycle transitions', () => {
+  it('two workers in one chat share ONE message that becomes a combined body', async () => {
+    let clock = 0
+    const { bot, sent } = directBot()
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 0,
+      firstPaintMinMs: 0,
+      setInterval: () => 0,
+      clearInterval: () => {},
+    })
+    clock = 1000
+    await feed.update('a', 'chat', view('task A', 'a-doing', 1000))
+    clock = 1100
+    await feed.update('b', 'chat', view('task B', 'b-doing', 1100))
+
+    // ONE message for the chat (both workers share it), and its id is the same.
+    expect(sent.length).toBe(1)
+    expect(feed.messageIdOf('a')).toBe(feed.messageIdOf('b'))
+    expect(feed.size).toBe(2)
+  })
+
+  it('finishing one of two drops its row (result NOT in the feed edit); the survivor stays live', async () => {
+    let clock = 0
+    const { bot, edits } = directBot()
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 0,
+      firstPaintMinMs: 0,
+      setInterval: () => 0,
+      clearInterval: () => {},
+    })
+    clock = 1000
+    await feed.update('a', 'chat', view('task A', 'a-doing', 1000))
+    await feed.update('b', 'chat', view('task B', 'b-doing', 1000))
+    clock = 2000
+    await feed.finish('a', {
+      description: 'task A',
+      lastTool: null,
+      toolCount: 3,
+      latestSummary: 'SECRET-RESULT-A should reach the user via handback only',
+      elapsedMs: 2000,
+      state: 'done',
+    })
+
+    const last = edits[edits.length - 1].text
+    // The finished worker's RESULT is never folded into the cosmetic feed edit.
+    expect(last).not.toContain('SECRET-RESULT-A')
+    // The survivor's live step is still shown.
+    expect(last).toContain('b-doing')
+    expect(feed.size).toBe(1)
+    expect(feed.has('a')).toBe(false)
+    expect(feed.has('b')).toBe(true)
+  })
+
+  it('finishing the LAST worker finalizes the shared message to its terminal recap', async () => {
+    let clock = 0
+    const { bot, edits } = directBot()
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 0,
+      firstPaintMinMs: 0,
+      setInterval: () => 0,
+      clearInterval: () => {},
+    })
+    clock = 1000
+    await feed.update('solo', 'chat', view('task solo', 'working', 1000))
+    clock = 2000
+    await feed.finish('solo', {
+      description: 'task solo',
+      lastTool: null,
+      toolCount: 5,
+      latestSummary: 'the final recap paragraph',
+      elapsedMs: 2000,
+      state: 'done',
+    })
+    const last = edits[edits.length - 1].text
+    // Terminal recap: the single 🛠 Worker card carries the done state + result.
+    expect(last).toContain('the final recap paragraph')
+    expect(feed.size).toBe(0)
+    // The finalized worker is gated against a late resurrecting cue.
+    await feed.update('solo', 'chat', view('task solo', 'late tick', 3000))
+    expect(feed.size).toBe(0)
+  })
+})
+
+describe('renderCombinedWorkerFeed (pure)', () => {
+  const row = (i: number, step: string) => ({
+    description: `task number ${i}`,
+    elapsedMs: 12_000 + i * 1000,
+    toolCount: i,
+    currentStep: step,
+  })
+
+  it('renders one row-block per worker with a running count header', () => {
+    const body = renderCombinedWorkerFeed([row(1, 'alpha step'), row(2, 'beta step')], { maxRows: 8 })!
+    expect(body).toContain('Workers')
+    expect(body).toContain('2 running')
+    expect(body).toContain('task number 1')
+    expect(body).toContain('task number 2')
+    expect(body).toContain('alpha step')
+    expect(body).toContain('beta step')
+  })
+
+  it('caps at maxRows and spills the remainder to a compact +M more working line', () => {
+    const rows = Array.from({ length: 15 }, (_, i) => row(i, `s${i}`))
+    const body = renderCombinedWorkerFeed(rows, { maxRows: 8 })!
+    expect(body).toContain('15 running')
+    expect(body).toContain('+7 more working')
+    // The 8th row is shown, the 9th is spilled.
+    expect(body).toContain('s7')
+    expect(body).not.toContain('s8')
+  })
+
+  it('stays under the rich-message wire budget even with many long rows (backstop drops rows)', () => {
+    // 120 rows of ~700 raw chars each would be ~84k > the 32768 rich-message
+    // cap; the char-budget backstop must shrink the visible set until it fits.
+    const rows = Array.from({ length: 120 }, () => ({
+      description: 'x'.repeat(300),
+      elapsedMs: 60_000,
+      toolCount: 40,
+      currentStep: 'y'.repeat(400),
+    }))
+    const body = renderCombinedWorkerFeed(rows, { maxRows: 120 })!
+    expect(body.length).toBeLessThanOrEqual(STATUS_CARD_CHAR_BUDGET)
+    // The backstop grew the spill line rather than overflowing the wire.
+    expect(body).toContain('more working')
+  })
+
+  it('returns null for an empty worker set', () => {
+    expect(renderCombinedWorkerFeed([], { maxRows: 8 })).toBeNull()
+  })
+})

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -366,6 +366,83 @@ describe('coalesced worker feed — lifecycle transitions', () => {
   })
 })
 
+describe('coalesced worker feed — GROUP-level pin lifecycle (#3207 review)', () => {
+  interface PinCall {
+    feedKey: string
+    chatId: string
+    messageId: number | null
+  }
+  function pinHarness() {
+    const pins: PinCall[] = []
+    const { bot } = directBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 0,
+      firstPaintMinMs: 0,
+      setInterval: () => 0,
+      clearInterval: () => {},
+      reconcilePin: ({ feedKey, chatId, messageId }) => pins.push({ feedKey, chatId, messageId }),
+    })
+    return { feed, pins, setClock: (t: number) => (clock = t) }
+  }
+  const done = (desc: string, elapsedMs: number): WorkerActivityView => ({
+    description: desc,
+    lastTool: null,
+    toolCount: 3,
+    latestSummary: `${desc} result`,
+    elapsedMs,
+    state: 'done',
+  })
+
+  it('a mid-group sibling finish does NOT unpin the shared message while a worker still runs', async () => {
+    const { feed, pins, setClock } = pinHarness()
+    setClock(1000)
+    await feed.update('a', 'chat', view('task A', 'a-doing', 1000))
+    await feed.update('b', 'chat', view('task B', 'b-doing', 1000))
+
+    // The group's shared message is pinned (messageId non-null).
+    const pinnedAfterPaint = pins.filter((p) => p.messageId != null)
+    expect(pinnedAfterPaint.length).toBeGreaterThan(0)
+    const sharedMsgId = pinnedAfterPaint[pinnedAfterPaint.length - 1].messageId
+    expect(feed.messageIdOf('a')).toBe(sharedMsgId)
+    expect(feed.messageIdOf('b')).toBe(sharedMsgId)
+
+    // A finishes while B still runs — the pin MUST stay (B needs the message).
+    setClock(2000)
+    await feed.finish('a', done('task A', 2000))
+
+    // Every reconcilePin emitted through A's finish keeps the message pinned —
+    // there is NO unpin (messageId === null) while B is live. This is the exact
+    // regression the review flagged: a per-worker unpin here strands B unpinned.
+    const last = pins[pins.length - 1]
+    expect(last.messageId).toBe(sharedMsgId)
+    expect(pins.some((p) => p.messageId === null)).toBe(false)
+    // The feed still vouches for the group (reaper exemption stays live).
+    const feedKey = last.feedKey
+    expect(feed.hasRunningInFeed(feedKey)).toBe(true)
+  })
+
+  it('unpins the shared message only when the LAST worker finishes (group empties)', async () => {
+    const { feed, pins, setClock } = pinHarness()
+    setClock(1000)
+    await feed.update('a', 'chat', view('task A', 'a-doing', 1000))
+    await feed.update('b', 'chat', view('task B', 'b-doing', 1000))
+    setClock(2000)
+    await feed.finish('a', done('task A', 2000))
+    expect(pins.some((p) => p.messageId === null)).toBe(false) // B still runs
+
+    // Now the last worker finishes → the group empties → unpin fires.
+    setClock(3000)
+    await feed.finish('b', done('task B', 3000))
+    const last = pins[pins.length - 1]
+    expect(last.messageId).toBeNull()
+    const feedKey = last.feedKey
+    expect(feed.hasRunningInFeed(feedKey)).toBe(false) // reaper may now reap it
+  })
+})
+
 describe('renderCombinedWorkerFeed (pure)', () => {
   const row = (i: number, step: string) => ({
     description: `task number ${i}`,

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -557,6 +557,105 @@ export function renderActivityFeedWithNested(
   })
 }
 
+// ─── Combined multi-worker feed (coalesced one-message-per-chat) ────────────
+//
+// When 2+ background workers are live in the SAME chat/thread, they render into
+// ONE shared message rather than one message each — so their edits form a
+// single per-message edit stream under the send gate's 1/sec per-chat ceiling
+// instead of N streams that contend and shed (#3084 per-chat bucket). Each
+// worker is a compact two-line row (header + live → step); the body is capped
+// at `maxRows` with a `+M more working…` spill so it stays compact/legible and
+// under the rich-message wire ceiling (STATUS_CARD_CHAR_BUDGET). A single-worker
+// chat still renders through
+// `renderStatusCard` (the 🛠 Worker card) — this primitive owns the N≥2 case.
+
+/** Dispatch-time task description cap for a combined-feed worker row. */
+const COMBINED_ROW_DESC_MAX = 72
+
+/** One live worker's render-relevant snapshot for the combined feed. */
+export interface CombinedWorkerRow {
+  /** Dispatch-time task description (raw, unescaped). */
+  description: string
+  /** Wall-clock since dispatch, ms — climbs on every heartbeat re-render. */
+  elapsedMs: number
+  /** Tool calls observed so far. */
+  toolCount: number
+  /** The worker's latest step line (raw prose or friendly tool label). */
+  currentStep: string
+  /** Live model id (raw, e.g. `claude-opus-4-8`); omitted when unknown. */
+  model?: string
+}
+
+export interface CombinedWorkerFeedOpts {
+  /** Max worker rows rendered before the `+M more working…` spill line.
+   *  The overflow is ordered oldest-hidden-first (the newest/most-recently
+   *  active workers stay visible). */
+  maxRows: number
+}
+
+/**
+ * Render N≥1 live workers into ONE combined feed body (ready Telegram
+ * markdown; callers send verbatim — do NOT re-escape). Layout:
+ *
+ *   🛠 **Workers** · _N running_
+ *   **{desc1}** _· {elapsed} · {n} tools_
+ *   → _{step1}_
+ *   **{desc2}** _· {elapsed} · {n} tools_
+ *   → _{step2}_
+ *   _+M more working…_
+ *
+ * Pure. Rows are rendered in the order supplied (the manager passes them
+ * dispatch-order, oldest first). `maxRows` caps the visible rows; the hidden
+ * remainder collapses to a single `+M more working…` line. A total-budget
+ * backstop drops the OLDEST visible rows one at a time (growing the spill)
+ * until the body fits STATUS_CARD_CHAR_BUDGET, so a burst of long descriptions
+ * can never overflow the wire limit. Returns null only when `rows` is empty.
+ */
+export function renderCombinedWorkerFeed(
+  rows: CombinedWorkerRow[],
+  opts: CombinedWorkerFeedOpts,
+): string | null {
+  if (rows.length === 0) return null
+  const maxRows = Math.max(1, Math.floor(opts.maxRows))
+
+  const rowLines = (r: CombinedWorkerRow): [string, string] => {
+    const desc = escapeMarkdown(
+      truncate(stripMarkdown(r.description).replace(/\s+/g, ' ').trim() || 'background task', COMBINED_ROW_DESC_MAX),
+    )
+    const toolWord = r.toolCount === 1 ? 'tool' : 'tools'
+    const modelLabel = formatModelLabel(r.model)
+    const modelPart = modelLabel != null ? ` · ${escapeMarkdown(modelLabel)}` : ''
+    const header = `**${desc}** _· ${formatFeedElapsed(r.elapsedMs)} · ${r.toolCount} ${toolWord}${modelPart}_`
+    const stepClean = stripMarkdown(r.currentStep).replace(/\s+/g, ' ').trim()
+    const step =
+      stepClean.length > 0
+        ? `→ _${escapeMarkdown(truncate(stepClean, STATUS_LINE_MAX))}_`
+        : `→ _starting…_`
+    return [header, step]
+  }
+
+  const compose = (visibleCount: number): string => {
+    const shown = rows.slice(0, visibleCount)
+    const hidden = rows.length - shown.length
+    const out: string[] = [`🛠 **Workers** · _${rows.length} running_`]
+    for (const r of shown) {
+      const [h, s] = rowLines(r)
+      out.push(h, s)
+    }
+    if (hidden > 0) out.push(`_+${hidden} more working…_`)
+    return stackCardLines(out)
+  }
+
+  // Cap to maxRows first, then shrink further only if the char budget demands.
+  let visible = Math.min(rows.length, maxRows)
+  let body = compose(visible)
+  while (body.length > STATUS_CARD_CHAR_BUDGET && visible > 1) {
+    visible -= 1
+    body = compose(visible)
+  }
+  return body
+}
+
 /**
  * Like appendActivityLine, but for a pre-computed label (from the
  * real-time PreToolUse sidecar / `tool_label` event) — the hook already

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -13,17 +13,34 @@
  * that grows/edits as work happens — indistinguishable from "the agent
  * is typing live", not a status widget.
  *
- * Pure render (`renderWorkerActivity`) + an injected bot API
- * (`BotApiForWorkerFeed`), mirroring `issues-card.ts` so the gateway
- * reuses the same wiring. The manager (`createWorkerActivityFeed`) owns
- * one edit-in-place message per worker, keyed by jsonl agent id, with:
+ * COALESCED (#3084 follow-up): all live workers dispatched to the SAME
+ * chat/thread render into ONE shared message (a {@link FeedGroup}), not one
+ * message each. With N workers, N separate messages each coalesce their own
+ * edit stream but ALL draw from the send gate's 1/sec per-chat bucket — so
+ * ~N-1 of every second's edits SHED and every card refreshes only ~once per N
+ * seconds (liveness collapse). One combined message = ONE per-message edit
+ * stream: it coalesces (last-write-wins) and never contends with siblings, so
+ * every worker's row refreshes together within the ~1.5s edit floor. A single-
+ * worker chat still renders the full 🛠 Worker card (identical to before); a
+ * 2+ worker chat renders `renderCombinedWorkerFeed`.
+ *
+ * Pure render (`renderWorkerActivity` / `renderCombinedWorkerFeed`) + an
+ * injected bot API (`BotApiForWorkerFeed`). The manager
+ * (`createWorkerActivityFeed`) owns one edit-in-place message per (chat,thread)
+ * with:
  *   - a first-paint delay so trivial sub-second workers never post a
  *     message (their result still lands via the handback reply),
  *   - a proactive min-edit-interval throttle (worker jsonl ticks ~1/s;
  *     Telegram rate-limits edits) plus body-dedup,
- *   - per-worker serialization so two rapid ticks can't double-send,
+ *   - per-message serialization so two rapid ticks can't double-send,
  *   - 429 cooldown + message_id drift resilience (re-post on stale edit),
- *   - a forced terminal edit on `finish` regardless of throttle.
+ *   - a forced terminal edit on the LAST worker's `finish`.
+ *
+ * The completed-worker RESULT is NOT folded into this cosmetic feed — it
+ * reaches the user as its own `useful` handback reply (gateway onFinish). The
+ * feed shows only *live* work; a finished worker's row is dropped from the
+ * combined body (or, when it is the last worker, the message finalizes to its
+ * terminal recap).
  *
  * The feed is gated to BACKGROUND workers and is ON by default; set
  * `SWITCHROOM_WORKER_ACTIVITY_FEED=0` to disable it — see the gateway
@@ -38,7 +55,12 @@ import {
   truncate,
 } from './card-format.js'
 import { STATUS_ROLLING_LINES } from './status-no-truncate.js'
-import { renderStatusCard, formatStepSuffix } from './tool-activity-summary.js'
+import {
+  renderStatusCard,
+  formatStepSuffix,
+  renderCombinedWorkerFeed,
+  type CombinedWorkerRow,
+} from './tool-activity-summary.js'
 import { isSendGateShed } from './send-gate.js'
 
 /** Worker-activity feed is ON by default; an operator opts out with
@@ -208,7 +230,7 @@ export interface WorkerActivityFeedOpts {
    * shed send every `heartbeatTickMs` (~6s) for the WHOLE ban — thousands of
    * gate admissions, and (pre-fix) a `sent.message_id` crash on the `undefined`
    * every tick. With it, a running/first-paint tick that sees an open window
-   * parks the handle in cooldown for the window's remaining and makes ZERO api
+   * parks the group in cooldown for the window's remaining and makes ZERO api
    * calls until it closes, mirroring the held-card sweep's pre-send probe.
    * Defaults to `() => 0` (no window) so tests and non-gateway callers are
    * unchanged.
@@ -222,67 +244,90 @@ export interface WorkerActivityFeedOpts {
   /** Heartbeat timer disposer. Injectable for tests. Defaults to `clearInterval`. */
   clearInterval?: (handle: unknown) => void
   /**
-   * Heartbeat tick cadence in ms. On each tick a stale, running worker is
-   * re-rendered with a climbing `· Ns` suffix so a worker that emits no new
-   * narrative still visibly advances. Default 6000ms.
+   * Heartbeat tick cadence in ms. On each tick a stale, running feed is
+   * re-rendered with climbing elapsed so a worker that emits no new narrative
+   * still visibly advances. Default 6000ms.
    */
   heartbeatTickMs?: number
+  /**
+   * Max worker rows rendered in a COMBINED feed (2+ workers in one chat/thread)
+   * before the `+M more working…` spill line. Keeps the coalesced body compact
+   * and legible (and under the rich-message wire ceiling). Default 8. A single-
+   * worker chat renders the full 🛠 Worker card and ignores this. Sourced from
+   * `channels.telegram.worker_feed.max_rows` via the config cascade.
+   */
+  maxRows?: number
 }
 
-interface WorkerHandle {
+/**
+ * One live worker's per-row state inside a chat/thread feed group. The row
+ * carries everything the render needs for THIS worker; the shared message
+ * (id, cooldown, chain) lives on the enclosing {@link FeedGroup}.
+ */
+interface WorkerRow {
   /** jsonl agent id — carried so success/failure log lines can name the worker. */
   agentId: string
+  /**
+   * Accumulated narrative lines (oldest→newest), deduped within the whole
+   * rolling window. Rolling-window capped to STATUS_ROLLING_LINES. Grows the
+   * live render so the feed reads like the main agent's answer.
+   */
+  narrative: string[]
+  /** Last view for this worker (drives the heartbeat re-render + combined row). */
+  lastView: WorkerActivityView | null
+  /** Latest state observed for this worker; excluded from the running set once
+   *  terminal (its result reaches the user via the separate handback reply). */
+  state: WorkerActivityState
+  /**
+   * Latched in `finish` before the terminal edit. A late watcher `onProgress`
+   * tick that arrives after `finish()` queued its chain must NOT resurrect the
+   * row and paint a fresh `running` state on an already-finalized worker.
+   */
+  finished: boolean
+  /**
+   * Wall-clock ms the worker was dispatched, derived from `now - view.elapsedMs`
+   * on the first update. The heartbeat computes a live elapsed from this so the
+   * elapsed climbs even when no fresh view arrives, and it fixes the worker's
+   * stable sort order within the combined feed.
+   */
+  dispatchAtMs: number | null
+  /**
+   * Wall-clock ms the CURRENT step started — stamped whenever a NEW narrative
+   * line lands (the `→` line changes). The heartbeat's step suffix shows the
+   * step's OWN elapsed from this anchor (single-worker card only), and only
+   * once past STEP_TIMER_MIN_MS.
+   */
+  stepStartedAtMs: number | null
+}
+
+/**
+ * One shared feed message per (chatId, threadId). ALL live workers dispatched
+ * to the same chat/thread render into this one message — so their edits form a
+ * single per-message edit stream under the send gate's 1/sec per-chat ceiling
+ * (last-write-wins coalescing + no-op skip) instead of N contending streams
+ * that shed (#3084). A single-worker group renders the full 🛠 Worker card;
+ * a 2+ worker group renders the combined `renderCombinedWorkerFeed` body.
+ */
+interface FeedGroup {
+  /** Stable key `${chatId} ${threadId ?? ''}`. */
+  feedKey: string
   chatId: string
   threadId?: number
   messageId: number | null
   lastBody: string | null
   lastEditAt: number
   cooldownUntil: number
-  /**
-   * Accumulated narrative lines (oldest→newest), deduped against the
-   * immediately-preceding line. Rolling-window capped to STATUS_ROLLING_LINES.
-   * Grows the live render so the feed reads like the main agent's answer.
-   */
-  narrative: string[]
-  /** Per-worker serialization chain so ticks can't interleave sends. */
+  /** Single serialization chain for the shared message — ticks can't interleave sends. */
   chain: Promise<void>
-  /** Last view rendered into the message (drives the heartbeat re-render). */
-  lastView: WorkerActivityView | null
+  /** Live workers in this group, keyed by agentId (insertion ≈ dispatch order). */
+  workers: Map<string, WorkerRow>
   /**
-   * A terminal (`finish`) view whose edit could not land yet — most often
-   * because a 429 cooldown was in effect when `doFinish` ran. The heartbeat
-   * re-drives `doFinish` with this view once the cooldown expires so a
-   * transport hiccup can't leave the card stuck on its last running render
-   * ("worker done, card says running"). Cleared on a successful terminal
-   * edit, on a permanent failure (message gone), or when the handle is
-   * deleted. Null when no finalize is pending.
+   * A terminal render (the last worker's recap) staged because a 429 cooldown /
+   * flood window blocked the edit. The heartbeat re-drives it once the cooldown
+   * expires so a finished feed can't get stuck on its last running render.
+   * Null when no finalize is pending.
    */
-  pendingFinish: WorkerActivityView | null
-  /**
-   * Latched in `doFinish` before the terminal edit. A late watcher
-   * `onProgress` tick that arrives after `finish()` queued its chain (but
-   * before the `.finally(handles.delete)` microtask drains) must NOT
-   * resurrect the handle and paint a fresh `running` message on an
-   * already-finalized worker. The heartbeat's orphan-paint guard
-   * (`if (!handles.has(h.agentId)) continue`) only covers the heartbeat
-   * tick — this flag covers the `update` entry point. Set synchronously
-   * inside `doFinish` (runs on the chain), checked synchronously in
-   * `update` before handle creation.
-   */
-  finished: boolean
-  /**
-   * Wall-clock ms the worker was dispatched, derived from `now - view.elapsedMs`
-   * on the first update. The heartbeat computes a live elapsed from this so the
-   * `· Ns` suffix climbs even when no fresh view arrives.
-   */
-  dispatchAtMs: number | null
-  /**
-   * Wall-clock ms the CURRENT step started — stamped whenever a NEW narrative
-   * line lands (the `→` line changes). The heartbeat's step suffix shows the
-   * step's OWN elapsed from this anchor (not the worker total, which the
-   * header already carries), and only once past STEP_TIMER_MIN_MS.
-   */
-  stepStartedAtMs: number | null
+  pendingFinalize: WorkerActivityView | null
 }
 
 const COOLDOWN_JITTER_MS = 500
@@ -307,7 +352,7 @@ function extractRetryAfterSecs(err: unknown): number | null {
  *   'rate_limited' — 429 with retry_after. Back off; the heartbeat re-drives
  *     the edit after cooldown (running renders + deferred terminal edits).
  *   'gone'         — message/chat deleted or edit window expired. Nothing to
- *     update; drop the handle silently (no warning — there is no card).
+ *     update; drop the message silently (no warning — there is no card).
  *   'transient'    — anything else (network blip, 5xx). Retry on the next
  *     heartbeat tick; don't spam stderr.
  */
@@ -338,17 +383,20 @@ function classifyEditError(err: unknown): EditOutcome {
 }
 
 /**
- * Manager owning one live message per background worker. Keyed by jsonl
- * agent id. The gateway calls `update` on each watcher activity cue and
- * `finish` on terminal; `drop` discards a worker's state without a final
- * edit (error / supersession paths).
+ * Manager owning one live message per (chat,thread) into which all live
+ * workers there coalesce. Public methods stay keyed by jsonl agent id (the
+ * gateway wiring is unchanged): the manager resolves the enclosing feed group
+ * internally. The gateway calls `update` on each watcher activity cue and
+ * `finish` on terminal; `drop` discards a worker's state without a final edit
+ * (error / supersession paths).
  */
 export interface WorkerActivityFeed {
-  /** True if a message is currently posted for this worker. */
+  /** True if a message is currently posted for this worker's feed group. */
   has(agentId: string): boolean
-  /** The Telegram message_id currently posted for this worker, or null if
-   *  none is posted (never painted, or dropped after a stale-edit re-post).
-   *  Lets the gateway pin the EXISTING `🛠 Worker` message (status-pin). */
+  /** The Telegram message_id currently posted for this worker's feed group, or
+   *  null if none is posted (never painted, or dropped after a stale-edit
+   *  re-post). Lets the gateway pin the EXISTING `🛠 Worker` message. Note:
+   *  siblings sharing the chat/thread return the SAME id (one message). */
   messageIdOf(agentId: string): number | null
   /** Push a running-state cue. Returns the serialized op for tests. */
   update(
@@ -357,13 +405,17 @@ export interface WorkerActivityFeed {
     view: WorkerActivityView,
     threadId?: number,
   ): Promise<void>
-  /** Force the terminal recap edit. No-op if no message was ever posted. */
+  /** Finalize a worker: drop its row from the combined feed (its result reaches
+   *  the user via the separate handback), or — when it is the last live worker
+   *  in the group — force the terminal recap edit. No-op if the worker was
+   *  never tracked. */
   finish(agentId: string, view: WorkerActivityView): Promise<void>
-  /** Forget a worker's state without editing (e.g. error path). */
+  /** Forget a worker's state without a recap edit (e.g. error path); re-renders
+   *  the group so the dropped worker disappears from the combined body. */
   drop(agentId: string): void
   /**
    * Issue #3023 (card resurrection). Undo a finalization: clear the durable
-   * `finalized` gate (and any lingering per-handle `finished` latch) so a
+   * `finalized` gate (and any lingering per-row `finished` latch) so a
    * worker whose card was FALSELY finalized can be painted/edited again. The
    * watcher calls this (via the gateway's `onResurrect` wiring) when a
    * falsely-finalized worker's JSONL resumes growing. A fresh `running` cue
@@ -375,7 +427,7 @@ export interface WorkerActivityFeed {
   stop(): void
   /** Manually fire one heartbeat tick (test hook). */
   heartbeatTick(): void
-  /** Number of tracked workers (test/inspection hook). */
+  /** Number of tracked workers across all feed groups (test/inspection hook). */
   readonly size: number
 }
 
@@ -386,6 +438,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   const minEditInterval = opts.minEditIntervalMs ?? 2500
   const firstPaintMin = opts.firstPaintMinMs ?? 8000
   const heartbeatTickMs = opts.heartbeatTickMs ?? 6000
+  const maxRows = Math.max(1, Math.floor(opts.maxRows ?? 8))
   const setIntervalFn =
     opts.setInterval ??
     ((cb: () => void, ms: number): unknown => {
@@ -395,17 +448,21 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       return t
     })
   const clearIntervalFn = opts.clearInterval ?? ((handle: unknown) => clearInterval(handle as ReturnType<typeof setInterval>))
-  const handles = new Map<string, WorkerHandle>()
+
+  /** Feed groups keyed by `${chatId} ${threadId ?? ''}`. */
+  const groups = new Map<string, FeedGroup>()
+  /** Reverse index agentId → feedKey, so the agentId-keyed public API resolves
+   *  its group in O(1). Cleared when a worker's row is removed. */
+  const agentIndex = new Map<string, string>()
+
   /**
-   * Agent ids that have been finalized (`doFinish` latched). Survives handle
+   * Agent ids that have been finalized (`finish` latched). Survives row/group
    * deletion so a LATE watcher `onProgress` tick — which can arrive after
-   * `finish()`'s chain has fully settled and the handle was deleted — cannot
-   * resurrect a fresh handle and paint a running card on a worker that is
-   * already done. The per-handle `finished` flag only covers the narrow
-   * window between latch and delete; this set is the durable gate. A late
-   * tick arrives within seconds of finish (watcher poll cadence), so the set
-   * only needs to cover recent finalizations — capped at FINALIZED_CAP and
-   * trimmed FIFO to stay bounded across a long gateway lifetime.
+   * `finish()`'s chain has fully settled — cannot resurrect a fresh row and
+   * paint a running card on a worker that is already done. A late tick arrives
+   * within seconds of finish (watcher poll cadence), so the set only needs to
+   * cover recent finalizations — capped at FINALIZED_CAP and trimmed FIFO to
+   * stay bounded across a long gateway lifetime.
    */
   const finalized = new Set<string>()
   const FINALIZED_CAP = 256
@@ -413,469 +470,466 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     if (finalized.has(agentId)) return
     finalized.add(agentId)
     if (finalized.size > FINALIZED_CAP) {
-      // Map-free FIFO trim: Set iterates in insertion order; drop the oldest.
       const oldest = finalized.values().next().value
       if (oldest != null) finalized.delete(oldest)
     }
   }
   let heartbeatTimer: unknown = null
 
-  function sendOptsFor(h: WorkerHandle): Record<string, unknown> {
+  function feedKeyOf(chatId: string, threadId?: number): string {
+    return `${chatId} ${threadId ?? ''}`
+  }
+  function groupOfAgent(agentId: string): FeedGroup | undefined {
+    const key = agentIndex.get(agentId)
+    return key != null ? groups.get(key) : undefined
+  }
+
+  function sendOptsFor(g: FeedGroup): Record<string, unknown> {
     return {
       disable_web_page_preview: true,
-      // Sub-agent progress card is a status surface, never the user's
-      // answer — silence the open ping. (editMessageText ignores
-      // disable_notification, so this is a no-op on the in-place edits
-      // that share these opts.)
+      // Sub-agent progress feed is a status surface, never the user's answer —
+      // silence the open ping. (editMessageText ignores disable_notification,
+      // so this is a no-op on the in-place edits that share these opts.)
       disable_notification: true,
-      ...(h.threadId != null ? { message_thread_id: h.threadId } : {}),
+      ...(g.threadId != null ? { message_thread_id: g.threadId } : {}),
     }
   }
 
-  function noteRateLimited(h: WorkerHandle, err: unknown, label: string): void {
+  function noteRateLimited(g: FeedGroup, err: unknown, label: string): void {
     const retryAfter = extractRetryAfterSecs(err)
     if (retryAfter == null) return
-    h.cooldownUntil = nowFn() + retryAfter * 1000 + COOLDOWN_JITTER_MS
+    g.cooldownUntil = nowFn() + retryAfter * 1000 + COOLDOWN_JITTER_MS
     log(`worker-feed: ${label} 429 — backing off ${retryAfter}s`)
   }
 
   /**
-   * Park a handle in cooldown for the remaining of an open flood window (if
-   * any), so the heartbeat's `nowFn() < h.cooldownUntil` guard suppresses every
+   * Park a group in cooldown for the remaining of an open flood window (if
+   * any), so the heartbeat's `nowFn() < g.cooldownUntil` guard suppresses every
    * further send/edit until the ban closes. Returns true when a window was open
    * (caller should abandon the current attempt). Two reads of the SAME on-disk
    * marker `robustApiCall` gates on — never a second notion of "channel open".
    */
-  function parkIfFloodWindowOpen(h: WorkerHandle): boolean {
+  function parkIfFloodWindowOpen(g: FeedGroup): boolean {
     const remaining = floodWaitRemainingMs()
     if (remaining <= 0) return false
-    // Only extend the cooldown — never shorten one a 429 already set longer.
     const until = nowFn() + remaining + COOLDOWN_JITTER_MS
-    if (until > h.cooldownUntil) h.cooldownUntil = until
+    if (until > g.cooldownUntil) g.cooldownUntil = until
     return true
   }
 
-  function accumulateNarrative(h: WorkerHandle, view: WorkerActivityView): void {
+  function accumulateNarrative(row: WorkerRow, view: WorkerActivityView): void {
     const line = view.latestSummary.trim()
     if (line.length === 0) return
-    // Dedup within the whole rolling window, not just the immediately-
-    // preceding line. The watcher re-emits the same narrative across ticks
-    // while a tool runs (adjacent repeats), AND one logical step can surface
-    // twice non-adjacently — e.g. a "Look for X" preamble followed later by
-    // the Task tool whose describeToolUse label is the same "Look for X"
-    // description, interleaved with another step (the A,B,A duplication the
-    // operator observed on live cards). A legitimate later re-visit of the
-    // same step re-appears once the earlier copy scrolls out of the window.
-    if (h.narrative.includes(line)) return
-    h.narrative.push(line)
-    // The `→` current-step line just CHANGED — reset the per-step timer so the
-    // heartbeat's `· Ns` suffix measures THIS step, not the whole worker run.
-    h.stepStartedAtMs = nowFn()
-    // Rolling window — keep only the last STATUS_ROLLING_LINES in memory. The
-    // render shows exactly those lines (clipped per-line by the unified pipeline);
-    // fitCardToBudget is the wire-limit backstop.
-    if (h.narrative.length > STATUS_ROLLING_LINES) {
-      h.narrative.splice(0, h.narrative.length - STATUS_ROLLING_LINES)
+    // Dedup within the whole rolling window (the watcher re-emits the same
+    // narrative across ticks, and a preamble + its tool label can repeat
+    // non-adjacently — the A,B,A duplication observed on live cards).
+    if (row.narrative.includes(line)) return
+    row.narrative.push(line)
+    // The `→` current-step line just CHANGED — reset the per-step timer.
+    row.stepStartedAtMs = nowFn()
+    if (row.narrative.length > STATUS_ROLLING_LINES) {
+      row.narrative.splice(0, row.narrative.length - STATUS_ROLLING_LINES)
     }
   }
 
-  async function doUpdate(h: WorkerHandle, view: WorkerActivityView, liveSuffix = ''): Promise<void> {
-    // Accumulate before any gate so a throttled/cooled-down tick still grows
-    // the narrative — the line surfaces on the next edit that does fire.
-    accumulateNarrative(h, view)
-    // Stamp the dispatch wall-clock once so the heartbeat can climb a live
-    // elapsed even between fresh views. lastView feeds the heartbeat re-render.
-    const merged: WorkerActivityView = { ...view, narrativeLines: [...h.narrative] }
-    h.lastView = merged
-    if (h.dispatchAtMs == null) h.dispatchAtMs = nowFn() - view.elapsedMs
-    if (nowFn() < h.cooldownUntil) return
-    // A flood window is open: the send gate would SHED every call made now
-    // (resolving `undefined`). Park in cooldown for the window's remaining and
-    // make ZERO api calls until it closes — the heartbeat re-drives the paint
-    // with full state on the first tick past the window. Same source of truth
-    // as robustApiCall's own pre-call probe.
-    if (parkIfFloodWindowOpen(h)) return
-    const body = renderWorkerActivity(merged, liveSuffix)
+  /** Live wall-clock elapsed for a worker (climbs between fresh views). */
+  function liveElapsed(row: WorkerRow, now: number): number {
+    const base = row.dispatchAtMs != null ? now - row.dispatchAtMs : row.lastView?.elapsedMs ?? 0
+    return Math.max(base, row.lastView?.elapsedMs ?? 0)
+  }
 
-    // First paint: hold off until the worker has run long enough to be
-    // worth a message; trivial workers stay silent (handback covers them).
-    if (h.messageId == null) {
-      if (view.elapsedMs < firstPaintMin) return
+  /** The running rows of a group, dispatch-ordered (oldest first, stable). */
+  function runningRows(g: FeedGroup): WorkerRow[] {
+    return [...g.workers.values()]
+      .filter((w) => w.state === 'running' && w.lastView != null)
+      .sort((a, b) => (a.dispatchAtMs ?? 0) - (b.dispatchAtMs ?? 0))
+  }
+
+  /**
+   * Render a group's shared message body at `now`.
+   *   - `terminalRecap` set + zero running → the last worker's terminal recap
+   *     (single 🛠 Worker card, done/failed).
+   *   - exactly one running → the full 🛠 Worker card (single-worker parity).
+   *   - 2+ running → the combined `renderCombinedWorkerFeed` body.
+   *   - zero running, no recap → null (nothing to show).
+   * `heartbeat` toggles the single-worker climbing `· Ns` step suffix.
+   */
+  function renderGroupBody(
+    g: FeedGroup,
+    now: number,
+    terminalRecap: WorkerActivityView | null,
+    heartbeat: boolean,
+  ): string | null {
+    const running = runningRows(g)
+    if (running.length === 0) {
+      if (terminalRecap == null) return null
+      return renderWorkerActivity(terminalRecap)
+    }
+    // On a normal update/finish the header shows the worker's LAST-REPORTED
+    // elapsed (byte-stable for the dedup / no-op skip). Only the heartbeat —
+    // which fires when no fresh view arrived — climbs a live wall-clock elapsed
+    // so a silent worker still visibly advances.
+    const elapsedFor = (r: WorkerRow): number =>
+      heartbeat ? liveElapsed(r, now) : r.lastView?.elapsedMs ?? liveElapsed(r, now)
+    if (running.length === 1) {
+      const r = running[0]
+      const view: WorkerActivityView = {
+        ...(r.lastView as WorkerActivityView),
+        elapsedMs: elapsedFor(r),
+        narrativeLines: [...r.narrative],
+      }
+      let liveSuffix = ''
+      if (heartbeat) {
+        const stepElapsed = r.stepStartedAtMs != null ? now - r.stepStartedAtMs : liveElapsed(r, now)
+        liveSuffix = formatStepSuffix(stepElapsed)
+      }
+      return renderWorkerActivity(view, liveSuffix)
+    }
+    const rows: CombinedWorkerRow[] = running.map((r) => {
+      const v = r.lastView as WorkerActivityView
+      const currentStep = r.narrative.length > 0 ? r.narrative[r.narrative.length - 1] : v.latestSummary
+      return {
+        description: v.description,
+        elapsedMs: elapsedFor(r),
+        toolCount: v.toolCount,
+        currentStep,
+        model: v.model,
+      }
+    })
+    return renderCombinedWorkerFeed(rows, { maxRows })
+  }
+
+  /** Remove a worker's row + index entry; delete the group if it is now empty. */
+  function removeWorker(g: FeedGroup, agentId: string): void {
+    g.workers.delete(agentId)
+    agentIndex.delete(agentId)
+    if (g.workers.size === 0) groups.delete(g.feedKey)
+  }
+
+  /**
+   * Drive the group's shared message to the current combined body. Handles
+   * first-paint gating, the proactive throttle (bypassed by `force`), the
+   * dedup/no-op skip, the send-gate SHED contract, and 429/flood cooldown.
+   * `terminalRecap` (set on the last worker's finish) renders + finalizes the
+   * message, then removes the finished row.
+   */
+  async function doRender(
+    g: FeedGroup,
+    opts2: { force?: boolean; heartbeat?: boolean; terminalRecap?: WorkerActivityView; finishingAgentId?: string } = {},
+  ): Promise<void> {
+    const now = nowFn()
+    const isTerminal = opts2.terminalRecap != null
+    if (now < g.cooldownUntil) {
+      if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
+      return
+    }
+    // A flood window is open: the gate would SHED every call. Park in cooldown
+    // and make ZERO api calls until it closes; the heartbeat re-drives.
+    if (parkIfFloodWindowOpen(g)) {
+      if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
+      return
+    }
+
+    const body = renderGroupBody(g, now, opts2.terminalRecap ?? null, opts2.heartbeat ?? false)
+    if (body == null) {
+      // Nothing to show. On a terminal finalize with no message ever posted,
+      // just drop the finished row (the handback carries the result).
+      if (isTerminal && opts2.finishingAgentId != null) {
+        g.pendingFinalize = null
+        removeWorker(g, opts2.finishingAgentId)
+      }
+      return
+    }
+
+    // First paint: hold until some worker in the group has run long enough.
+    if (g.messageId == null) {
+      const maxElapsed = Math.max(0, ...runningRows(g).map((r) => liveElapsed(r, now)))
+      // A terminal recap for a group that never painted → nothing to finalize.
+      if (isTerminal && opts2.finishingAgentId != null) {
+        g.pendingFinalize = null
+        removeWorker(g, opts2.finishingAgentId)
+        return
+      }
+      if (maxElapsed < firstPaintMin) return
       try {
-        const sent = await opts.bot.sendMessage(h.chatId, body, sendOptsFor(h))
-        // Shed contract (#3084): the gate resolves `undefined` for a send it
-        // shed (open flood window) or dropped as stale (`useful` TTL). That is
-        // NOT a delivered message — dereferencing `sent.message_id` here was
-        // the `undefined is not an object` crash that fired every ~6s for a
-        // whole 6h ban. Treat it as not-delivered: record no message_id, park
-        // on any open window, and let the heartbeat re-drive the paint.
+        const sent = await opts.bot.sendMessage(g.chatId, body, sendOptsFor(g))
+        // Shed contract (#3084): the gate resolves `undefined`/non-object for a
+        // shed send (open flood window) or dropped-stale `useful` TTL. That is
+        // NOT a delivered message — record no id, park on any window, let the
+        // heartbeat re-drive.
         if (sent == null || typeof sent.message_id !== 'number') {
-          parkIfFloodWindowOpen(h)
-          log(`worker-feed: first paint shed by send gate agent=${h.agentId} — not delivered`)
+          parkIfFloodWindowOpen(g)
+          log(`worker-feed: first paint shed by send gate feed=${g.feedKey} — not delivered`)
           return
         }
-        h.messageId = sent.message_id
-        h.lastBody = body
-        h.lastEditAt = nowFn()
+        g.messageId = sent.message_id
+        g.lastBody = body
+        g.lastEditAt = now
         log(
-          `worker-feed: paint agent=${h.agentId} chat=${h.chatId} ` +
-            `thread=${h.threadId ?? '-'} msgId=${h.messageId} bytes=${body.length}`,
+          `worker-feed: paint feed=${g.feedKey} chat=${g.chatId} ` +
+            `thread=${g.threadId ?? '-'} msgId=${g.messageId} workers=${g.workers.size} bytes=${body.length}`,
         )
       } catch (err) {
-        noteRateLimited(h, err, 'send')
+        noteRateLimited(g, err, 'send')
         log(`worker-feed: send failed: ${(err as Error).message}`)
       }
       return
     }
 
-    // Dedup + proactive throttle.
-    if (body === h.lastBody) return
-    if (nowFn() - h.lastEditAt < minEditInterval) return
+    // Dedup + proactive throttle (finish/terminal edits force through).
+    if (body === g.lastBody) {
+      if (isTerminal && opts2.finishingAgentId != null) {
+        g.pendingFinalize = null
+        removeWorker(g, opts2.finishingAgentId)
+      }
+      return
+    }
+    if (!opts2.force && now - g.lastEditAt < minEditInterval) return
 
     try {
-      const res = await opts.bot.editMessageText(h.chatId, h.messageId, body, sendOptsFor(h))
-      // Shed honesty (#3084, mirrors #3173): a cosmetic edit the gate shed
-      // resolves the distinguishable SEND_GATE_SHED sentinel (#3110 F1 — NOT a
-      // bare `undefined`, which the gate reserves for a benign no-op drop whose
-      // payload IS already on screen). The shed payload is NOT on screen, so do
-      // not record it as `lastBody`, or the next tick's dedup would skip
-      // re-sending the very update the gate dropped. Park on any open window and
-      // let the heartbeat re-drive once it closes. A benign `undefined`/`true`
-      // falls through below and is correctly recorded as delivered.
+      const res = await opts.bot.editMessageText(g.chatId, g.messageId, body, sendOptsFor(g))
+      // Shed honesty (#3084): a cosmetic edit the gate shed resolves the
+      // distinguishable SEND_GATE_SHED sentinel (NOT a bare `undefined`, which
+      // the gate reserves for a benign no-op drop whose payload IS on screen).
+      // The shed payload is NOT on screen, so do not record it as `lastBody`.
       if (isSendGateShed(res)) {
-        parkIfFloodWindowOpen(h)
+        parkIfFloodWindowOpen(g)
+        if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
         return
       }
-      h.lastBody = body
-      h.lastEditAt = nowFn()
-      log(
-        `worker-feed: edit agent=${h.agentId} chat=${h.chatId} ` +
-          `thread=${h.threadId ?? '-'} msgId=${h.messageId} bytes=${body.length}`,
-      )
+      g.lastBody = body
+      g.lastEditAt = now
+      if (isTerminal) {
+        log(
+          `worker-feed: finish feed=${g.feedKey} chat=${g.chatId} thread=${g.threadId ?? '-'} ` +
+            `msgId=${g.messageId} agent=${opts2.finishingAgentId ?? '-'} ` +
+            `state=${opts2.terminalRecap?.state ?? 'done'} bytes=${body.length}`,
+        )
+      } else {
+        log(
+          `worker-feed: edit feed=${g.feedKey} chat=${g.chatId} ` +
+            `thread=${g.threadId ?? '-'} msgId=${g.messageId} workers=${g.workers.size} bytes=${body.length}`,
+        )
+      }
+      if (isTerminal && opts2.finishingAgentId != null) {
+        g.pendingFinalize = null
+        removeWorker(g, opts2.finishingAgentId)
+      }
     } catch (err) {
       const outcome = classifyEditError(err)
       if (outcome === 'rate_limited') {
-        noteRateLimited(h, err, 'edit')
+        noteRateLimited(g, err, isTerminal ? 'finish' : 'edit')
+        if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
         return
       }
       if (outcome === 'not_modified') {
-        // Card already shows this body — record it as landed and move on.
-        h.lastBody = body
-        h.lastEditAt = nowFn()
+        g.lastBody = body
+        g.lastEditAt = now
+        if (isTerminal && opts2.finishingAgentId != null) {
+          g.pendingFinalize = null
+          removeWorker(g, opts2.finishingAgentId)
+        }
         return
       }
       if (outcome === 'gone') {
-        // Message/chat deleted or edit window closed — there is no card to
-        // update. Drop the handle silently; a fresh first-paint on the next
-        // running tick re-establishes one if the worker is still active. No
-        // warning: "no card" is not a liveness-logic error.
-        h.messageId = null
-        h.lastBody = null
+        // Message/chat gone or edit window closed — no card to update. Drop the
+        // stale message id; a fresh first-paint re-establishes one if workers
+        // are still live. On a terminal finalize, also drop the finished row.
+        g.messageId = null
+        g.lastBody = null
+        if (isTerminal && opts2.finishingAgentId != null) {
+          g.pendingFinalize = null
+          removeWorker(g, opts2.finishingAgentId)
+        }
         return
       }
-      // 'transient' — network blip / 5xx. Leave the handle intact; the
-      // heartbeat re-attempts on its next tick. Log at debug, not stderr-warn:
-      // a transport hiccup on a best-effort card is not "shit code", it's a
-      // retryable blip the framework rides out deterministically.
-      log(`worker-feed: edit transient error agent=${h.agentId}: ${(err as Error).message}`)
-    }
-  }
-
-  async function doFinish(h: WorkerHandle, view: WorkerActivityView): Promise<void> {
-    // Latch FIRST, before any early return. A `running`-cue tick arriving
-    // after `finish()` queued this chain (but before its `.finally(delete)`
-    // drains) would otherwise resurrect a handle via `update()` and paint a
-    // fresh running message on a finalized worker. Setting this synchronously
-    // on the chain — ahead of the cooldown/no-message guards — makes the
-    // gate in `update()` authoritative regardless of which guard path runs.
-    // The durable `finalized` set survives the subsequent handle deletion so
-    // a tick arriving AFTER the full settle still can't resurrect.
-    h.finished = true
-    markFinalized(h.agentId)
-    // No message ever posted → nothing to finalize. The worker's result
-    // reaches the user via the handback reply; a bare "done" recap with
-    // no preceding activity would be noise.
-    if (h.messageId == null) {
-      h.pendingFinish = null
-      return
-    }
-    // A flood window is open (or a prior 429 set a cooldown): honour it — a
-    // terminal edit isn't worth extending a ban. STAGE the terminal view so the
-    // heartbeat re-drives the finalize the instant the window/cooldown expires,
-    // so a finished worker's card can't get stuck on its last running render.
-    if (parkIfFloodWindowOpen(h) || nowFn() < h.cooldownUntil) {
-      h.pendingFinish = view
-      return
-    }
-    const body = renderWorkerActivity({ ...view, narrativeLines: h.narrative })
-    if (body === h.lastBody) {
-      h.pendingFinish = null
-      return
-    }
-    try {
-      const res = await opts.bot.editMessageText(h.chatId, h.messageId, body, sendOptsFor(h))
-      // Shed honesty (#3084): a shed terminal edit resolves the distinguishable
-      // SEND_GATE_SHED sentinel (#3110 F1 — NOT a bare `undefined`, which is the
-      // gate's benign no-op drop) — it did NOT land. Keep `pendingFinish` staged
-      // so the heartbeat re-drives it once the window closes; do NOT clear it or
-      // record `lastBody` (that would be a false finalization — card frozen on
-      // its running render while we believe it's done). Park on any open window.
-      if (isSendGateShed(res)) {
-        parkIfFloodWindowOpen(h)
-        h.pendingFinish = view
-        return
-      }
-      h.lastBody = body
-      h.lastEditAt = nowFn()
-      h.pendingFinish = null
-      log(
-        `worker-feed: finish agent=${h.agentId} chat=${h.chatId} ` +
-          `thread=${h.threadId ?? '-'} msgId=${h.messageId} state=${view.state} bytes=${body.length}`,
-      )
-    } catch (err) {
-      const outcome = classifyEditError(err)
-      if (outcome === 'rate_limited') {
-        noteRateLimited(h, err, 'finish')
-        // Re-stage for the heartbeat to re-drive after cooldown.
-        h.pendingFinish = view
-        return
-      }
-      if (outcome === 'not_modified') {
-        // Card already shows the finalized body — terminal edit succeeded.
-        h.lastBody = body
-        h.lastEditAt = nowFn()
-        h.pendingFinish = null
-        return
-      }
-      if (outcome === 'gone') {
-        // Message/chat gone — no card to finalize. Drop silently; the
-        // handback reply carries the result regardless.
-        h.pendingFinish = null
-        return
-      }
-      // 'transient' — re-stage for a heartbeat retry; log at debug.
-      h.pendingFinish = view
-      log(`worker-feed: finish transient error agent=${h.agentId}: ${(err as Error).message}`)
-    }
-  }
-
-  /**
-   * Heartbeat — keeps a running worker's message alive AND performs the
-   * FIRST paint for a prose-silent worker whose only tick arrived before
-   * `firstPaintMin`.
-   *
-   * Why the first-paint branch exists: a background worker that dives
-   * straight into quiet work (e.g. a long `Bash` / `npm test`) emits a
-   * single `sub_agent_tool_use` event when the command is invoked, then no
-   * further JSONL lines for the whole run. That one tick drives `update`
-   * once — but if it lands before `firstPaintMin` the paint is held, and
-   * with no subsequent tick nothing ever re-drives it, so the worker shows
-   * NOTHING for its entire run (the "I can't see the worker" gap). The
-   * heartbeat closes it: once such a handle is past `firstPaintMin`, drive a
-   * paint here through the same chain → doUpdate path. After first paint the
-   * suffix-only maintenance branch keeps it advancing.
-   *
-   * For handles that already have a posted message, this is the original
-   * option-(a), suffix-only re-render (never editMessageText directly). Skips:
-   *   - handles inside a 429 cooldown,
-   *   - handles with no `lastView` (no update ever arrived) or non-running,
-   *   - for the maintenance branch: handles edited within minEditInterval
-   *     (no stampede) or whose current step isn't yet stale.
-   * The `· Ns` liveSuffix is applied ONLY when the worker's current step is
-   * stale (now - lastEditAt >= heartbeatTickMs) so a normally-ticking worker is
-   * untouched and its body stays byte-stable for the dedup.
-   */
-  function heartbeatTick(): void {
-    const now = nowFn()
-    for (const h of handles.values()) {
-      // Orphan-paint guard: `finish()` deletes the handle in a `.finally` that
-      // may not have drained if a tick fires in the same synchronous stretch.
-      // Skip any handle no longer in the map so the first-paint branch below
-      // can never send a fresh `running` message on an already-finished worker
-      // (which would orphan a card that never finalizes). Restores the
-      // structural safety the pre-first-paint `messageId == null` skip gave.
-      if (!handles.has(h.agentId)) continue
-
-      // Deferred-finalize re-drive: a terminal edit that hit a 429 cooldown
-      // (or a transient error) was staged on `pendingFinish` by `doFinish`.
-      // Re-drive it once the cooldown has expired so a finished worker's card
-      // can't get stuck on its last running render. This is the deterministic
-      // backstop that replaces the old "stale but harmless" surrender — the
-      // framework owns ALIVE-and-done, wall-clock driven, no model in the loop.
-      // (The handle is still in the map because `finish()`'s `.finally(delete)`
-      // is chained AFTER `doFinish` and won't drain while a re-drive keeps the
-      // chain busy; once the terminal edit lands, `pendingFinish` is cleared
-      // and the `.finally` runs on the next chain settle.)
-      if (h.pendingFinish != null && now >= h.cooldownUntil) {
-        const view = h.pendingFinish
-        h.chain = h.chain
-          .then(() => doFinish(h, view))
-          .catch((err) => {
-            log(`worker-feed: heartbeat finalize re-drive error ${h.agentId}: ${(err as Error).message}`)
-          })
-          .finally(() => {
-            // Mirror `finish()`'s teardown: once the re-driven `doFinish`
-            // clears `pendingFinish` (terminal edit landed OR permanently
-            // failed), drop the handle. If it re-staged (another 429), the
-            // handle survives for the next heartbeat tick to retry.
-            if (handles.get(h.agentId)?.pendingFinish == null) {
-              handles.delete(h.agentId)
-            }
-          })
-        continue
-      }
-
-      if (h.lastView == null) continue
-      if (h.lastView.state !== 'running') continue
-      if (now < h.cooldownUntil) continue
-
-      const liveElapsed = h.dispatchAtMs != null ? now - h.dispatchAtMs : h.lastView.elapsedMs
-
-      // First-paint path: a prose-silent worker's single early tick was held
-      // (elapsed < firstPaintMin) and no further tick re-drove it. Once it is
-      // past firstPaintMin, drive the paint. doUpdate's send branch re-checks
-      // firstPaintMin against the refreshed elapsed, so this is exact.
-      if (h.messageId == null) {
-        if (liveElapsed < firstPaintMin) continue
-        const view = { ...h.lastView, elapsedMs: Math.max(h.lastView.elapsedMs, liveElapsed) }
-        h.chain = h.chain
-          .then(() => doUpdate(h, view))
-          .catch((err) => {
-            log(`worker-feed: heartbeat first-paint chain error ${h.agentId}: ${(err as Error).message}`)
-          })
-        continue
-      }
-
-      if (now - h.lastEditAt < minEditInterval) continue
-      const stale = now - h.lastEditAt >= heartbeatTickMs
-      if (!stale) continue
-      // Per-step suffix: the CURRENT step's own elapsed (since the `→` line
-      // last changed), never the worker total — the header already shows the
-      // total, and repeating it on the step line was the Ken-observed dupe.
-      // Under STEP_TIMER_MIN_MS formatStepSuffix returns '' (no timer yet);
-      // the header elapsed still climbs via the refreshed view below.
-      const stepElapsed = h.stepStartedAtMs != null ? now - h.stepStartedAtMs : liveElapsed
-      const liveSuffix = formatStepSuffix(stepElapsed)
-      // Re-render THROUGH the chain + doUpdate path — never editMessageText directly.
-      //
-      // CLOCK-ANCHOR PARITY: refresh the view's elapsedMs to the same `now`
-      // anchor the step suffix uses. The header renders
-      // `view.elapsedMs`; passing the stale lastView froze the header at the
-      // last watcher event while the `· Ns` suffix kept ticking, so the
-      // current step's timer could read MORE than the card's master elapsed
-      // (Ken-observed defect). Both numbers now derive from one anchor
-      // (dispatchAtMs) at one `now`, so header elapsed >= step suffix always.
-      const view = { ...h.lastView, elapsedMs: Math.max(h.lastView.elapsedMs, liveElapsed) }
-      h.chain = h.chain
-        .then(() => doUpdate(h, view, liveSuffix))
-        .catch((err) => {
-          log(`worker-feed: heartbeat chain error ${h.agentId}: ${(err as Error).message}`)
-        })
+      // 'transient' — leave the message intact; the heartbeat re-attempts.
+      if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
+      log(`worker-feed: edit transient error feed=${g.feedKey}: ${(err as Error).message}`)
     }
   }
 
   // Arm the heartbeat once at construction. The real timer is `.unref()`'d so
   // it never keeps the process alive; tests inject setInterval/clearInterval.
+  function heartbeatTick(): void {
+    const now = nowFn()
+    for (const g of [...groups.values()]) {
+      // Deferred-finalize re-drive: a terminal edit that hit a cooldown/flood
+      // window was staged on `pendingFinalize`. Re-drive it once the cooldown
+      // expires so a finished feed can't get stuck on its last running render.
+      if (g.pendingFinalize != null && now >= g.cooldownUntil) {
+        const recap = g.pendingFinalize
+        // The finishing agent is whatever finished row remains (state terminal).
+        const finishingAgentId = [...g.workers.values()].find((w) => w.finished)?.agentId
+        g.chain = g.chain
+          .then(() => doRender(g, { force: true, terminalRecap: recap, finishingAgentId }))
+          .catch((err) => {
+            log(`worker-feed: heartbeat finalize re-drive error feed=${g.feedKey}: ${(err as Error).message}`)
+          })
+        continue
+      }
+
+      if (now < g.cooldownUntil) continue
+      const running = runningRows(g)
+      if (running.length === 0) continue
+
+      // First-paint path: no message yet and some worker has now crossed
+      // firstPaintMin (a prose-silent worker's single early tick was held).
+      if (g.messageId == null) {
+        const maxElapsed = Math.max(0, ...running.map((r) => liveElapsed(r, now)))
+        if (maxElapsed < firstPaintMin) continue
+        g.chain = g.chain
+          .then(() => doRender(g, {}))
+          .catch((err) => {
+            log(`worker-feed: heartbeat first-paint chain error feed=${g.feedKey}: ${(err as Error).message}`)
+          })
+        continue
+      }
+
+      if (now - g.lastEditAt < minEditInterval) continue
+      const stale = now - g.lastEditAt >= heartbeatTickMs
+      if (!stale) continue
+      // Re-render THROUGH the chain → doRender path with climbing elapsed.
+      g.chain = g.chain
+        .then(() => doRender(g, { heartbeat: true }))
+        .catch((err) => {
+          log(`worker-feed: heartbeat chain error feed=${g.feedKey}: ${(err as Error).message}`)
+        })
+    }
+  }
+
   heartbeatTimer = setIntervalFn(heartbeatTick, heartbeatTickMs)
 
   return {
     has(agentId) {
-      return handles.get(agentId)?.messageId != null
+      const g = groupOfAgent(agentId)
+      return g != null && g.messageId != null && g.workers.has(agentId)
     },
     messageIdOf(agentId) {
-      return handles.get(agentId)?.messageId ?? null
+      return groupOfAgent(agentId)?.messageId ?? null
     },
     get size() {
-      return handles.size
+      let n = 0
+      for (const g of groups.values()) n += g.workers.size
+      return n
     },
     update(agentId, chatId, view, threadId) {
-      // No chat to post to (owner DM unconfigured) — don't create a
-      // handle that would retry a failing send('') every tick.
+      // No chat to post to (owner DM unconfigured) — don't create state that
+      // would retry a failing send('') every tick.
       if (chatId.length === 0) return Promise.resolve()
-      // Resurrection guard: a worker that has already been finalized
-      // (`doFinish` latched `finalized`) must not get a fresh running cue.
-      // A late watcher `onProgress` tick can arrive after `finish()`'s chain
-      // has fully settled and the handle was deleted — without this durable
-      // gate the tick would create a brand-new handle and paint a fresh
-      // `running` message on an already-done worker (the card lies). The
-      // heartbeat's orphan-paint guard covers the heartbeat tick only; the
-      // per-handle `finished` flag covers the pre-delete window; this set
-      // covers the post-delete window.
+      // Resurrection guard: a worker already finalized must not get a fresh
+      // running cue (a late watcher tick would repaint a done worker as live).
       if (finalized.has(agentId)) return Promise.resolve()
-      const existing = handles.get(agentId)
-      if (existing?.finished === true) return Promise.resolve()
-      let h = existing
-      if (h == null) {
-        h = {
-          agentId,
+      const existingRow = groupOfAgent(agentId)?.workers.get(agentId)
+      if (existingRow?.finished === true) return Promise.resolve()
+
+      const feedKey = feedKeyOf(chatId, threadId)
+      let g = groups.get(feedKey)
+      if (g == null) {
+        g = {
+          feedKey,
           chatId,
           threadId,
           messageId: null,
           lastBody: null,
           lastEditAt: 0,
           cooldownUntil: 0,
-          narrative: [],
           chain: Promise.resolve(),
+          workers: new Map(),
+          pendingFinalize: null,
+        }
+        groups.set(feedKey, g)
+      }
+      let row = g.workers.get(agentId)
+      if (row == null) {
+        row = {
+          agentId,
+          narrative: [],
           lastView: null,
+          state: 'running',
+          finished: false,
           dispatchAtMs: null,
           stepStartedAtMs: null,
-          finished: false,
-          pendingFinish: null,
         }
-        handles.set(agentId, h)
+        g.workers.set(agentId, row)
+        agentIndex.set(agentId, feedKey)
       }
-      const handle = h
-      handle.chain = handle.chain.then(() => doUpdate(handle, view)).catch((err) => {
+      // Accumulate before the gate so a throttled tick still grows the
+      // narrative — it surfaces on the next edit that does fire.
+      accumulateNarrative(row, view)
+      row.state = 'running'
+      row.lastView = { ...view, narrativeLines: [...row.narrative] }
+      if (row.dispatchAtMs == null) row.dispatchAtMs = nowFn() - view.elapsedMs
+
+      const group = g
+      group.chain = group.chain.then(() => doRender(group)).catch((err) => {
         log(`worker-feed: update chain error ${agentId}: ${(err as Error).message}`)
       })
-      return handle.chain
+      return group.chain
     },
     finish(agentId, view) {
-      const h = handles.get(agentId)
-      if (h == null) return Promise.resolve()
-      h.chain = h.chain
-        .then(() => doFinish(h, view))
+      const g = groupOfAgent(agentId)
+      const row = g?.workers.get(agentId)
+      if (g == null || row == null) {
+        // Never tracked (trivial worker) — mark finalized so a late tick can't
+        // resurrect, and let the handback carry the result.
+        markFinalized(agentId)
+        return Promise.resolve()
+      }
+      // Latch synchronously so a late `running` cue on the chain can't resurrect.
+      row.finished = true
+      row.state = view.state === 'failed' ? 'failed' : 'done'
+      markFinalized(agentId)
+
+      const group = g
+      group.chain = group.chain
+        .then(() => {
+          const others = runningRows(group).filter((w) => w.agentId !== agentId)
+          if (others.length > 0) {
+            // Siblings still live → drop this row from the combined body and
+            // re-render the running set. The result reaches the user via the
+            // separate handback, never folded into this cosmetic edit.
+            removeWorker(group, agentId)
+            return doRender(group, { force: true })
+          }
+          // Last live worker → finalize the shared message to its terminal recap.
+          const recap: WorkerActivityView = { ...view, narrativeLines: [...row.narrative] }
+          return doRender(group, { force: true, terminalRecap: recap, finishingAgentId: agentId })
+        })
         .catch((err) => {
           log(`worker-feed: finish chain error ${agentId}: ${(err as Error).message}`)
         })
-        .finally(() => {
-          // Only tear down the handle once the terminal edit has actually
-          // landed (or permanently failed). If `doFinish` staged the edit on
-          // `pendingFinish` (a 429 cooldown / transient error was in effect),
-          // the handle must survive so the heartbeat can re-drive the
-          // finalize after cooldown. The heartbeat's re-drive chain ends by
-          // re-entering `doFinish`, which clears `pendingFinish` on success
-          // or permanent-failure — so this `.finally` deletes on the NEXT
-          // chain settle once there is nothing left to finalize. Without this
-          // guard, the `.finally` would delete the handle (and its staged
-          // pendingFinish) immediately after the first staged doFinish,
-          // stranding the card on its last running render.
-          if (handles.get(agentId)?.pendingFinish == null) {
-            handles.delete(agentId)
-          }
-        })
-      return h.chain
+      return group.chain
     },
     drop(agentId) {
-      // A dropped worker is also done — mark finalized so a late watcher
-      // tick can't resurrect a running card on it (same gate as `finish`).
+      // A dropped worker is also done — mark finalized so a late tick can't
+      // resurrect a running card on it (same gate as `finish`).
       markFinalized(agentId)
-      handles.delete(agentId)
+      const g = groupOfAgent(agentId)
+      if (g == null) return
+      const hadMessage = g.messageId != null
+      removeWorker(g, agentId)
+      // Re-render so the dropped worker disappears from a combined body. Skip
+      // when the group is gone (removeWorker deleted it) or never painted.
+      if (hadMessage && groups.has(g.feedKey) && runningRows(g).length > 0) {
+        g.chain = g.chain
+          .then(() => doRender(g, { force: true }))
+          .catch((err) => {
+            log(`worker-feed: drop re-render error ${agentId}: ${(err as Error).message}`)
+          })
+      }
     },
     resurrect(agentId) {
       // Issue #3023: the worker's card was falsely finalized and its JSONL has
-      // resumed. Re-open the paint path: drop the durable finalized gate so a
-      // fresh `running` cue creates a new handle and first-paints a live card
-      // again, and un-latch any surviving handle (finish deleted it in the
-      // common case, but a staged pendingFinish could keep it alive). The next
-      // `update` tick from the watcher's replayed progress does the repaint.
+      // resumed. Re-open the paint path: drop the durable finalized gate + any
+      // surviving per-row latch so a fresh `running` cue repaints a live card.
       const wasFinalized = finalized.delete(agentId)
-      const h = handles.get(agentId)
-      if (h != null) {
-        h.finished = false
-        h.pendingFinish = null
+      const row = groupOfAgent(agentId)?.workers.get(agentId)
+      if (row != null) {
+        row.finished = false
+        row.state = 'running'
       }
-      if (wasFinalized || h != null) {
+      if (wasFinalized || row != null) {
         log(`worker-feed: resurrect agent=${agentId} — cleared finalized gate; card will repaint on next running cue`)
       }
     },

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -257,6 +257,24 @@ export interface WorkerActivityFeedOpts {
    * `channels.telegram.worker_feed.max_rows` via the config cascade.
    */
   maxRows?: number
+  /**
+   * Group-level status-pin reconcile hook (#3207 review). Because workers now
+   * COALESCE into one shared message, the pin MUST follow the GROUP lifecycle,
+   * not a single worker's: pin the shared message when a group's first worker
+   * paints, and unpin ONLY when the group empties (its LAST worker finishes / is
+   * dropped). The feed alone knows group membership + running-count, so it owns
+   * the pin. `messageId: null` means "unpin this group". A per-worker unpin would
+   * physically unpin a message a SIBLING still needs, and the survivor's next
+   * pin request NO-OPs (its claim still names that id) — so it would run
+   * unpinned for the rest of its life (the shared-message NOOP trap). Best-
+   * effort; defaults to a noop for tests / non-gateway callers.
+   */
+  reconcilePin?: (args: {
+    feedKey: string
+    chatId: string
+    threadId?: number
+    messageId: number | null
+  }) => void
 }
 
 /**
@@ -398,6 +416,10 @@ export interface WorkerActivityFeed {
    *  re-post). Lets the gateway pin the EXISTING `🛠 Worker` message. Note:
    *  siblings sharing the chat/thread return the SAME id (one message). */
   messageIdOf(agentId: string): number | null
+  /** True while the feed group `feedKey` (`${chatId} ${threadId ?? ''}`) still
+   *  tracks live work — used by the gateway's `wk:group:` pin reaper to exempt
+   *  a live group's pin from the stale-TTL sweep (#3207). */
+  hasRunningInFeed(feedKey: string): boolean
   /** Push a running-state cue. Returns the serialized op for tests. */
   update(
     agentId: string,
@@ -439,6 +461,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   const firstPaintMin = opts.firstPaintMinMs ?? 8000
   const heartbeatTickMs = opts.heartbeatTickMs ?? 6000
   const maxRows = Math.max(1, Math.floor(opts.maxRows ?? 8))
+  const reconcilePinFn = opts.reconcilePin ?? (() => {})
   const setIntervalFn =
     opts.setInterval ??
     ((cb: () => void, ms: number): unknown => {
@@ -607,6 +630,18 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   }
 
   /**
+   * Reconcile the GROUP-level status pin (#3207 review). Pin the shared message
+   * while the group has a posted message AND at least one tracked worker;
+   * unpin the instant the group empties. Because it is keyed by the whole group
+   * (not a single worker), a per-worker finish never unpins a message a sibling
+   * still needs — the survivors keep the pin until the LAST worker is done.
+   */
+  function syncPin(g: FeedGroup): void {
+    const messageId = g.messageId != null && g.workers.size > 0 ? g.messageId : null
+    reconcilePinFn({ feedKey: g.feedKey, chatId: g.chatId, threadId: g.threadId, messageId })
+  }
+
+  /**
    * Drive the group's shared message to the current combined body. Handles
    * first-paint gating, the proactive throttle (bypassed by `force`), the
    * dedup/no-op skip, the send-gate SHED contract, and 429/flood cooldown.
@@ -625,6 +660,9 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     const settleTerminal = (): void => {
       g.pendingFinalize = null
       if (opts2.finishingAgentId != null) removeWorker(g, opts2.finishingAgentId)
+      // Group-level pin follows membership: unpin once this drops the last
+      // worker; a NOOP-pin (siblings remain) keeps the shared message pinned.
+      syncPin(g)
     }
     if (now < g.cooldownUntil) {
       if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
@@ -670,6 +708,8 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         g.messageId = sent.message_id
         g.lastBody = body
         g.lastEditAt = now
+        // Group's first (or re-established) message is up → pin it for the group.
+        syncPin(g)
         log(
           `worker-feed: paint feed=${g.feedKey} chat=${g.chatId} ` +
             `thread=${g.threadId ?? '-'} msgId=${g.messageId} workers=${g.workers.size} bytes=${body.length}`,
@@ -733,7 +773,10 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         // are still live. On a terminal finalize, also drop the finished row.
         g.messageId = null
         g.lastBody = null
+        // The pinned message no longer exists → release the group pin claim
+        // (settleTerminal already re-syncs on the terminal path).
         if (isTerminal) settleTerminal()
+        else syncPin(g)
         return
       }
       // 'transient' — leave the message intact; the heartbeat re-attempts.
@@ -800,6 +843,10 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     },
     messageIdOf(agentId) {
       return groupOfAgent(agentId)?.messageId ?? null
+    },
+    hasRunningInFeed(feedKey) {
+      const g = groups.get(feedKey)
+      return g != null && g.workers.size > 0
     },
     get size() {
       let n = 0
@@ -881,8 +928,11 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           if (others.length > 0) {
             // Siblings still live → drop this row from the combined body and
             // re-render the running set. The result reaches the user via the
-            // separate handback, never folded into this cosmetic edit.
+            // separate handback, never folded into this cosmetic edit. The
+            // group pin STAYS (siblings still need the shared message) — a
+            // per-worker unpin here was the #3207 review blocker.
             removeWorker(group, agentId)
+            syncPin(group)
             return doRender(group, { force: true })
           }
           // Last live worker → finalize the shared message to its terminal recap.
@@ -902,6 +952,9 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       if (g == null) return
       const hadMessage = g.messageId != null
       removeWorker(g, agentId)
+      // Group pin follows membership: unpin if this emptied the group, else
+      // keep it (siblings still need the shared message).
+      if (hadMessage) syncPin(g)
       // Re-render so the dropped worker disappears from a combined body. Skip
       // when the group is gone (removeWorker deleted it) or never painted.
       if (hadMessage && groups.has(g.feedKey) && runningRows(g).length > 0) {

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -619,6 +619,13 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   ): Promise<void> {
     const now = nowFn()
     const isTerminal = opts2.terminalRecap != null
+    // Terminal edit RESOLVED (landed / not-modified / gone): clear the staged
+    // re-drive unconditionally so a heartbeat re-drive can never loop, and drop
+    // the finished row when its id is known (the last-worker finalize path).
+    const settleTerminal = (): void => {
+      g.pendingFinalize = null
+      if (opts2.finishingAgentId != null) removeWorker(g, opts2.finishingAgentId)
+    }
     if (now < g.cooldownUntil) {
       if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
       return
@@ -634,20 +641,18 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     if (body == null) {
       // Nothing to show. On a terminal finalize with no message ever posted,
       // just drop the finished row (the handback carries the result).
-      if (isTerminal && opts2.finishingAgentId != null) {
-        g.pendingFinalize = null
-        removeWorker(g, opts2.finishingAgentId)
-      }
+      if (isTerminal) settleTerminal()
       return
     }
 
     // First paint: hold until some worker in the group has run long enough.
     if (g.messageId == null) {
       const maxElapsed = Math.max(0, ...runningRows(g).map((r) => liveElapsed(r, now)))
-      // A terminal recap for a group that never painted → nothing to finalize.
-      if (isTerminal && opts2.finishingAgentId != null) {
-        g.pendingFinalize = null
-        removeWorker(g, opts2.finishingAgentId)
+      // A terminal recap for a group that never painted → nothing to finalize;
+      // never first-paint a terminal card (trivial workers stay silent, the
+      // handback carries the result — matches the pre-coalesce doFinish guard).
+      if (isTerminal) {
+        settleTerminal()
         return
       }
       if (maxElapsed < firstPaintMin) return
@@ -678,10 +683,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
 
     // Dedup + proactive throttle (finish/terminal edits force through).
     if (body === g.lastBody) {
-      if (isTerminal && opts2.finishingAgentId != null) {
-        g.pendingFinalize = null
-        removeWorker(g, opts2.finishingAgentId)
-      }
+      if (isTerminal) settleTerminal()
       return
     }
     if (!opts2.force && now - g.lastEditAt < minEditInterval) return
@@ -711,10 +713,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
             `thread=${g.threadId ?? '-'} msgId=${g.messageId} workers=${g.workers.size} bytes=${body.length}`,
         )
       }
-      if (isTerminal && opts2.finishingAgentId != null) {
-        g.pendingFinalize = null
-        removeWorker(g, opts2.finishingAgentId)
-      }
+      if (isTerminal) settleTerminal()
     } catch (err) {
       const outcome = classifyEditError(err)
       if (outcome === 'rate_limited') {
@@ -725,10 +724,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       if (outcome === 'not_modified') {
         g.lastBody = body
         g.lastEditAt = now
-        if (isTerminal && opts2.finishingAgentId != null) {
-          g.pendingFinalize = null
-          removeWorker(g, opts2.finishingAgentId)
-        }
+        if (isTerminal) settleTerminal()
         return
       }
       if (outcome === 'gone') {
@@ -737,10 +733,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         // are still live. On a terminal finalize, also drop the finished row.
         g.messageId = null
         g.lastBody = null
-        if (isTerminal && opts2.finishingAgentId != null) {
-          g.pendingFinalize = null
-          removeWorker(g, opts2.finishingAgentId)
-        }
+        if (isTerminal) settleTerminal()
         return
       }
       // 'transient' — leave the message intact; the heartbeat re-attempts.


### PR DESCRIPTION
## What & why

Background workers dispatched to the **same chat/thread** now render into **ONE shared feed message** instead of one message each.

The send gate (#3084) composes all edits to a chat through a **1/sec per-chat bucket (burst 3)** with per-message last-write-wins coalescing + a 1.5s edit floor. Today's feed owns **one edit-in-place message per worker** (`telegram-plugin/worker-activity-feed.ts`, `Map<agentId, WorkerHandle>`). With N live workers = N cosmetic edit streams all drawing from the single 1/sec bucket, ~(N-1)/N of every second's edits **SHED** (`send-gate.ts` cosmetic-shed) and each card refreshes only ~once per N seconds — a bot-wide liveness collapse (and a real flood ban).

**Fix:** one combined message = **one** per-message edit stream. It coalesces (last-write-wins) and never contends with siblings, so every worker's row refreshes **together** within the ~1.5s edit floor, and the gate sheds ~nothing.

## Design as-built

- **Primary — `telegram-plugin/worker-activity-feed.ts`:** the manager now owns one `FeedGroup` (shared `messageId`, cooldown, serialization chain, `pendingFinalize`) per `(chatId, threadId)`, with a `WorkerRow` per live worker. The **public API is unchanged** (`update`/`finish`/`drop`/`resurrect`/`has`/`messageIdOf`, all keyed by `agentId`) — so the gateway wiring is untouched and the separate `useful` completed-worker **handback** is never folded into the cosmetic feed edit.
- **Rendering:** a **single-worker** chat still renders the exact 🛠 Worker card as before (`renderWorkerActivity`). **2+ workers** render a new compact `renderCombinedWorkerFeed` (`tool-activity-summary.ts`) — a per-worker header + live `→` step row — capped at `worker_feed.max_rows` (default 8) with a `+M more working…` spill and a char-budget backstop under the rich-message wire ceiling.
- **finish():** drops the finished worker's row from the combined body (its result reaches the user via the handback); when it's the **last** live worker, the message finalizes to its terminal recap. All edge cases preserved at the group level: first-paint delay, flood-window parking, send-gate SHED contract, 429 cooldown + deferred-finalize re-drive, resurrection gate, drop.
- **Config:** new `channels.telegram.worker_feed.max_rows` (schema + scaffold env `SWITCHROOM_TG_WORKER_FEED_MAX_ROWS` + gateway wiring). **No new rate knob;** `perChatPerSec=1` / `editFloorMs=1500` unchanged.

### Pins (group-level — corrected after review)
The status pin is now driven at the **group level** by the feed itself (`reconcilePin` hook → `wk:group:<feedKey>`): it pins the shared message when a group's first worker paints and unpins **only when the group empties** (its last worker finishes/drops). The 5 per-worker `reconcileWorkerPin(wk:<agentId>)` calls + the dead function were removed, and the `wk:` reaper's `statusOf` now vouches for a live group (`hasRunningInFeed`).

**Correction to the original description:** an earlier revision kept the per-worker pin and claimed a mid-group finish "self-heals on the next progress tick." That was **false** — a sibling's finish physically unpinned the shared message and the survivor's re-pin NO-OP'd (`decidePinAction` returns noop when `prev.messageId === desired.messageId`, `status-pin.ts:69`), so every survivor ran unpinned for the rest of its life. The group-level fix closes this; a new test asserts a mid-group sibling finish does not unpin while a worker still runs.

## Bypass audit (#3084 belt-and-braces)
Verified the 8 candidate raw-edit sites. `robustApiCall` **and** `swallowingApiCall` both funnel through `sendGate.gate` — so `3825`, `4146`, `5152`, `9776` (swallowing) and `8363`, `8526` (robust) are all **gated**. `6135` is a grammy **ctx** callback-query response to a human button tap (not a programmatic flood vector). **`6749` (`editCardExpired`) was a genuine raw bypass** (`lockedBot.api.editMessageText` outside the gate, reaper-driven) — **routed through `robustApiCall`** as a `cosmetic` edit so it paces/sheds under pressure and its 429 records the flood window.

## Design-landmark corrections (grounded against real source)
- Gateway is `telegram-plugin/gateway/gateway.ts` (not `gateway/gateway.ts`).
- Body-composition landmark files `consolidation-legibility.ts` / `feed-heartbeat-climb.ts` are **unrelated** to the worker feed (hindsight memory webhook + the main-turn silent climb). The real primitive is `tool-activity-summary.ts` (`renderStatusCard`) — where `renderCombinedWorkerFeed` was added.
- The worker-feed wire cap is the **rich-message** budget `RICH_MESSAGE_MAX_CHARS` (32768), not the legacy 4096 plain-text cap (post-#2669 the feed sends via `sendRichMessage`).

## Tests
New `telegram-plugin/tests/worker-feed-coalesce.test.ts` (outcome-asserting, **real** send gate + fake clock):
- **Aggregate/liveness:** N=15 workers × 60s → exactly **1** message, bounded non-shedding landed-edit stream, and the last edit carries **every** worker's latest step (all rows refresh together).
- **Shed pin:** `stats().global.shed ≈ 0` under load.
- **Critical not starved:** a `critical` reply mid-storm is admitted (not shed).
- **Coalesce/no-op:** redundant renders produce no redundant landed edits and never shed.
- **Lifecycle:** single→combined, finish-one-of-two drops the row (result NOT in the feed edit), finish-last finalizes to the terminal recap, resurrection gate holds.
- `renderCombinedWorkerFeed` pure: header/rows, `maxRows` spill, char-budget backstop, empty→null.

Existing **77** `worker-activity-feed.test.ts` tests kept green (single-worker parity), plus `worker-feed-dispatch`, `worker-pin-reaper`, `tool-activity-summary`, `schema`, visibility integration/harness suites. `npm run lint` clean (incl. `check-bot-api-wrapping`).

**JTBD:** `know-what-my-agent-is-doing` — active work must stay visible; this restores per-worker liveness under multi-worker load. **Vision:** visibility + always-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
