### PR TITLE
fix: Telegram outbound formatting — kill NBSP double-gap, protect link hrefs, entity-aware chunking

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -1070,8 +1070,15 @@ function backOffTableRow(text: string, cut: number): number {
  * matched over the full `text`; if the chosen `cut` lands STRICTLY inside a
  * matched span, retreat to that span's start so the whole span moves to the
  * next chunk (mirrors backOffOpenFence / backOffTableRow). Cutting inside a
- * span would strand an unclosed `**` / `` ` `` / `_` / `](` delimiter, which
- * Telegram parse-rejects to plaintext or mis-renders across the boundary.
+ * span would strand an unclosed `***`/`**`/`*` / `` ` `` / `___`/`__`/`_` /
+ * `](` delimiter, which Telegram parse-rejects to plaintext or mis-renders
+ * across the boundary.
+ *
+ * The TRIPLE-marker patterns (`***bold-italic***` / `___…___`) come FIRST so
+ * their whole span wins the earliest-start back-off in backOffOpenInline: the
+ * double-marker pattern would otherwise match the inner `**…**` of a `***…***`
+ * span and retreat only past that, stranding the lone outer `*` (odd asterisk
+ * count → the italic is lost).
  *
  * The `_italic_` pattern is boundary-guarded so snake_case identifiers
  * (`foo_bar_baz`) don't read as emphasis; a stray match there is harmless
@@ -1079,6 +1086,8 @@ function backOffTableRow(text: string, cut: number): number {
  */
 const INLINE_SPAN_PATTERNS: readonly RegExp[] = [
   /`[^`\n]+`/g, // inline code
+  /\*\*\*[^*\n]+\*\*\*/g, // bold-italic (triple) — before the bold pattern
+  /___[^_\n]+___/g, // bold-italic underscore (triple)
   /\*\*[^*\n]+\*\*/g, // bold
   /__[^_\n]+__/g, // underline
   /(?<![\w*])_[^_\n]+_(?![\w*])/g, // italic (snake_case-guarded)

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -534,12 +534,26 @@ export function normalizePunctuation(text: string): string {
     linkMasks.push(href)
     return `${open}${LINK_MASK_PH}${idx}\x00${close}`
   })
+  // Also protect GFM ANGLE-BRACKET AUTOLINK destinations `<scheme:…>` for the
+  // same reason (`<https://x/foo–bar>` → the en-dash would be rewritten to `-`,
+  // corrupting the URL). Only the URI inside the brackets is masked; the `<`/`>`
+  // are untouched. Conservative — requires a scheme-like `xxx:` prefix and no
+  // whitespace/`>` in the body (loosely mirrors the GFM absolute-URI autolink
+  // rule), so arbitrary `<…>` prose is never masked.
+  const maskedAutolinks = maskedLinks.replace(
+    /(<)([a-zA-Z][a-zA-Z0-9+.-]*:[^>\s]*)(>)/g,
+    (_m, lt: string, uri: string, gt: string) => {
+      const idx = linkMasks.length
+      linkMasks.push(uri)
+      return `${lt}${LINK_MASK_PH}${idx}\x00${gt}`
+    },
+  )
   const escNonce = nonce.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   const linkRestoreRe = new RegExp(`\x00RML${escNonce}_(\\d+)\x00`, 'g')
   const restoreLinks = (s: string): string =>
     s.replace(linkRestoreRe, (_m, idx: string) => linkMasks[Number(idx)] ?? _m)
 
-  let out = maskedLinks
+  let out = maskedAutolinks
     // 1. Space-flanked em/en dash. Numeric range keeps a hyphen. The right
     //    flank is a LOOKAHEAD (captured, not consumed) so consecutive spaced
     //    dashes ("a — b — c") all normalize in one pass — a consumed \S would

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -111,6 +111,16 @@ export function escapeLinkHref(href: string): string {
  * the old whole-message heuristic ("bail if any real newline exists") was
  * too broad and prevented repair of mixed messages that had both real
  * newlines and stray literal `\n` escape sequences outside code spans.
+ *
+ * KNOWN ISSUE (accepted tradeoff): a literal backslash sequence `\n`/`\r`/`\t`
+ * that a user genuinely meant as text OUTSIDE a code span is unescaped into a
+ * real newline/tab — e.g. a bare Windows path `C:\new\table` becomes
+ * `C:<newline>ew<tab>able`. This is deliberately not guarded: the fleet is
+ * Linux-only, such paths in prose (rather than inside a `code span`, which is
+ * masked and safe) are vanishingly rare, and the far commoner failure this
+ * repairs is an LLM emitting JSON-escaped `\n\n` as literal text. If a
+ * Windows-path use case ever matters, restrict the unescape to sequences not
+ * flanked by path-like characters rather than removing it.
  */
 export function repairEscapedWhitespace(text: string): string {
   if (!/\\[nrt"\\]/.test(text)) return text
@@ -315,13 +325,14 @@ export function normalizeParagraphBreaks(text: string): string {
   //       as an oversized / ragged gap in the raw text and in some clients, and
   //       it was the "stray blank line" seen in real replies. Collapse it.
   //
-  // Deliberately ASCII-only: a line whose only content is U+00A0 is the
-  // INTENTIONAL, non-collapsible paragraph spacer added later by
-  // addParagraphSpacers (#2692) to force a visible gap on the rich-message
-  // path. This step runs BEFORE that spacer pass and must never eat a U+00A0
-  // line, so the `[ \t\r]` character class here excludes U+00A0 by
-  // construction. Runs on code-masked text, so a blank-ish line inside a
-  // fenced block is parked and never touched.
+  // Deliberately ASCII-only: the `[ \t\r]` character class excludes U+00A0 by
+  // construction, so a line whose only content is a non-breaking space a user
+  // legitimately typed is left intact rather than silently collapsed. (This
+  // used to also protect the NBSP paragraph spacer that addParagraphSpacers
+  // injected downstream; that spacer pass was removed in the #2669 follow-up —
+  // paragraph gaps now rely on plain `\n\n` — but keeping this ASCII-only is
+  // still the conservative choice.) Runs on code-masked text, so a blank-ish
+  // line inside a fenced block is parked and never touched.
   let out = masked
     // Collapse any run of newlines interleaved with ASCII whitespace-only
     // interior lines down to a single clean `\n\n`. Requires at least one
@@ -469,184 +480,14 @@ export function hardenCardBreaks(text: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Paragraph spacers — restore a VISIBLE blank line between prose paragraphs
-// ---------------------------------------------------------------------------
-
-/**
- * The non-collapsible spacer paragraph injected between two prose paragraphs.
- *
- * Telegram's Bot API 10.1 rich-message renderer (the GFM/CommonMark engine
- * behind `sendRichMessage` / `editMessageText({ markdown })`) renders a `\n\n`
- * paragraph break TIGHT — the two paragraphs sit on adjacent lines with no
- * visible empty line between them. The legacy markdown→HTML path (removed in
- * #2669) sent `\n\n` literally with `parse_mode:"HTML"`, where two newlines
- * render as a real blank line. That regression is the operator-confirmed
- * "paragraphs jammed together" symptom.
- *
- * CommonMark discards blank lines made of ASCII whitespace, but a line whose
- * only content is a NON-breaking space (U+00A0) is a genuine, non-empty
- * paragraph — it renders as a visible empty line. So `A\n\n \n\nB`
- * renders as three paragraphs: A, a blank-looking line, then B — the visible
- * gap the HTML path used to produce.
- */
-export const PARAGRAPH_SPACER = ' '
-
-/**
- * Insert a visible blank-line spacer into each genuine `\n\n` paragraph gap so
- * the rich GFM renderer shows a real empty line between paragraphs (matching
- * the pre-#2669 HTML behaviour). See PARAGRAPH_SPACER for why a U+00A0 line is
- * the reliable trick.
- *
- * Uniform-block-spacing contract: a spacer is inserted into EVERY `\n\n` gap
- * that separates two DISTINCT blocks — prose→prose, paragraph→list,
- * list→paragraph, heading→anything, blockquote/table/fence boundaries — so a
- * mixed message renders with one identical visible blank line between blocks.
- * The one exception is a gap INSIDE a block of the same structural kind (two
- * items of a loose list, consecutive table rows/quotes/fences): those stay
- * tight so the block's contiguity survives. Interiors joined by a single `\n`
- * are never gaps at all and are untouched by construction.
- *
- * Runs on code-masked text (so a blank line inside a fenced block is never
- * touched) and is idempotent — a gap that already contains a U+00A0 spacer
- * paragraph is recognised and never doubled.
- *
- * Intended to run in the outbound send path AFTER normalizeParagraphBreaks,
- * which has already collapsed 3+ newline runs to `\n\n`, promoted lone prose
- * breaks, and guaranteed block-boundary blank lines. normalizeParagraphBreaks
- * itself deliberately does NOT do this so its (well-tested) `\n\n`-preserving
- * contract is unchanged.
- */
-export function addParagraphSpacers(text: string): string {
-  if (!text.includes('\n\n')) return text
-
-  const nonce = Math.random().toString(36).slice(2)
-  const { masked, restore, placeholder } = maskCodeRegions(text, nonce)
-
-  if (!masked.includes('\n\n')) return restore(masked)
-
-  // The line we inject for a spacer paragraph (its only content is U+00A0).
-  const spacerLine = PARAGRAPH_SPACER
-
-  // CRITICAL: `String.prototype.trim()` strips U+00A0, so a spacer line would
-  // read as "blank" and the pass would lose idempotency (re-spacing an
-  // already-spaced gap). Detect blank-ness with an ASCII-whitespace-only test
-  // so the U+00A0 spacer line is correctly seen as NON-blank.
-  const isBlankLine = (line: string): boolean => /^[ \t\r\f\v]*$/.test(line)
-  // Trim ASCII-only (preserve U+00A0) so the spacer line is recognisable.
-  const asciiTrim = (line: string): string => line.replace(/^[ \t\r\f\v]+|[ \t\r\f\v]+$/g, '')
-
-  // Classify the block kind of a facing line so the spacer decision can be
-  // made per BLOCK TRANSITION (#uniform-block-spacing). A spacer is inserted
-  // at every `\n\n` gap between two DIFFERENT block kinds (paragraph→list,
-  // list→paragraph, heading→anything, blockquote/table boundaries) and
-  // between two prose paragraphs — but NEVER inside a single block's interior
-  // (between two items of the same loose list, two rows of a table, two
-  // quote lines, two fenced blocks). One visible blank line between distinct
-  // blocks, identical everywhere; list/table interiors stay tight.
-  type BlockKind = 'spacer' | 'list' | 'table' | 'quote' | 'heading' | 'fence' | 'divider' | 'prose'
-  const blockKind = (line: string): BlockKind => {
-    if (asciiTrim(line) === spacerLine) return 'spacer'
-    if (isFenceOpenLine(line, placeholder)) return 'fence'
-    if (isListItemLine(line)) return 'list'
-    if (isTableRowLine(line) || isTableDelimiterLine(line)) return 'table'
-    if (isBlockquoteLine(line)) return 'quote'
-    if (isHeadingLine(line)) return 'heading'
-    if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(line.trimStart())) return 'divider'
-    return 'prose'
-  }
-
-  // Same-kind structural pairs whose `\n\n` gap is a block INTERIOR (a loose
-  // list's item gap, consecutive tables/quotes/fences) — no spacer there.
-  const SAME_KIND_TIGHT: ReadonlySet<BlockKind> = new Set([
-    'list',
-    'table',
-    'quote',
-    'fence',
-    'divider',
-  ])
-
-  const shouldSpaceGap = (above: string, below: string): boolean => {
-    const a = blockKind(above)
-    const b = blockKind(below)
-    // A facing spacer line means the gap is already spaced (idempotency —
-    // also guarded by alreadySpaced at the call site).
-    if (a === 'spacer' || b === 'spacer') return false
-    if (a === b && SAME_KIND_TIGHT.has(a)) return false
-    // Everything else is a genuine block transition (incl. prose→prose,
-    // heading→anything, list↔paragraph, table/quote boundaries) — space it.
-    return true
-  }
-
-  // Split into blank-line-delimited segments, then re-join inserting a spacer
-  // paragraph between two adjacent NON-blank segments whose facing lines are
-  // both prose and which are not already separated by a spacer.
-  // A `\n\n` paragraph gap is a SINGLE blank entry between two content lines
-  // (`"A\n\nB".split('\n')` → `["A", "", "B"]`). normalizeParagraphBreaks has
-  // already collapsed 3+ newline runs to exactly `\n\n`, so we only ever see a
-  // one-blank gap here; a multi-blank run is handled defensively the same way
-  // (the FIRST blank of the run carries the spacer decision).
-  const lines = masked.split('\n')
-  const out: string[] = []
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
-    const isBlank = isBlankLine(line)
-    // The spacer decision is made at the FIRST blank of a gap, i.e. when the
-    // previously emitted line is non-blank prose. Inject the spacer BEFORE the
-    // blank so the result is `above \n\n   \n\n below`.
-    if (isBlank) {
-      const prevEmitted = out.length > 0 ? out[out.length - 1] : null
-      const prevIsBlank = prevEmitted != null && isBlankLine(prevEmitted)
-      if (!prevIsBlank) {
-        const above = lastNonBlank(out, isBlankLine)
-        const below = nextNonBlank(lines, i + 1, isBlankLine)
-        const alreadySpaced =
-          (above != null && asciiTrim(above) === spacerLine) ||
-          (below != null && asciiTrim(below) === spacerLine)
-        if (
-          !alreadySpaced &&
-          above != null &&
-          below != null &&
-          shouldSpaceGap(above, below)
-        ) {
-          // Emit: blank, spacer paragraph, blank — a U+00A0 paragraph wedged
-          // between two real blank lines so CommonMark renders it as a visible
-          // empty line between the two prose paragraphs.
-          out.push('')
-          out.push(spacerLine)
-          out.push('')
-          continue
-        }
-      }
-    }
-    out.push(line)
-  }
-
-  return restore(out.join('\n'))
-}
-
-/**
- * Last non-blank entry already emitted into `arr`, or null. `isBlank` is the
- * caller's blank test (ASCII-only, so a U+00A0 spacer line counts as
- * non-blank — `String.trim()` would wrongly strip it).
- */
-function lastNonBlank(arr: string[], isBlank: (s: string) => boolean): string | null {
-  for (let i = arr.length - 1; i >= 0; i--) {
-    if (!isBlank(arr[i])) return arr[i]
-  }
-  return null
-}
-
-/** First non-blank line at or after index `from` in `lines`, or null. */
-function nextNonBlank(
-  lines: string[],
-  from: number,
-  isBlank: (s: string) => boolean,
-): string | null {
-  for (let i = from; i < lines.length; i++) {
-    if (!isBlank(lines[i])) return lines[i]
-  }
-  return null
-}
+// Paragraph spacing note (#2669 follow-up): the NBSP paragraph-spacer
+// (PARAGRAPH_SPACER / addParagraphSpacers) was REMOVED. Its premise — that the
+// Bot API 10.1 rich (GFM) renderer collapses a `\n\n` gap TIGHT — is false for
+// the live renderer, which shows a `\n\n` gap as a normal single blank line.
+// The old U+00A0 spacer therefore injected a spurious SECOND blank line
+// (`\n\n \n\n`) between every paragraph fleet-wide. Paragraph spacing now
+// relies on the plain `\n\n` that normalizeParagraphBreaks already guarantees
+// at block boundaries — one correct single blank line, no spacer pass.
 
 // ---------------------------------------------------------------------------
 // Punctuation / bullet normalization — fleet-wide consistent typography
@@ -678,7 +519,27 @@ export function normalizePunctuation(text: string): string {
   const nonce = Math.random().toString(36).slice(2)
   const { masked, restore } = maskCodeRegions(text, nonce)
 
-  let out = masked
+  // Mask inline-link DESTINATIONS `](href)` before the dash passes so a dash
+  // inside a URL is never rewritten. maskCodeRegions only masks code spans/
+  // fences, not link hrefs, so without this an en-dash in a path becomes a
+  // silently-wrong URL, and an em-dash becomes `, ` — the injected space
+  // TERMINATES the markdown link and leaks the trailing text as prose
+  // (`[a](https://x/foo—bar)` → `[a](https://x/foo, bar)`). Only the href
+  // inside the parens is masked; the visible link LABEL still normalizes like
+  // ordinary prose (dashes in label text are intended, per existing behaviour).
+  const linkMasks: string[] = []
+  const LINK_MASK_PH = `\x00RML${nonce}_`
+  const maskedLinks = masked.replace(/(\]\()([^)\n]*)(\))/g, (_m, open: string, href: string, close: string) => {
+    const idx = linkMasks.length
+    linkMasks.push(href)
+    return `${open}${LINK_MASK_PH}${idx}\x00${close}`
+  })
+  const escNonce = nonce.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const linkRestoreRe = new RegExp(`\x00RML${escNonce}_(\\d+)\x00`, 'g')
+  const restoreLinks = (s: string): string =>
+    s.replace(linkRestoreRe, (_m, idx: string) => linkMasks[Number(idx)] ?? _m)
+
+  let out = maskedLinks
     // 1. Space-flanked em/en dash. Numeric range keeps a hyphen. The right
     //    flank is a LOOKAHEAD (captured, not consumed) so consecutive spaced
     //    dashes ("a — b — c") all normalize in one pass — a consumed \S would
@@ -693,6 +554,10 @@ export function normalizePunctuation(text: string): string {
     )
     // 3. Bare en-dash between word chars → hyphen (ranges: 2019–2024).
     .replace(/(\w)–(?=\w)/g, '$1-')
+
+  // Restore link hrefs now that the dash passes are done — before the bullet
+  // pass and the code restore.
+  out = restoreLinks(out)
 
   // 4. Leading unicode bullet markers → GFM `- ` (per line, indent kept).
   out = out
@@ -884,9 +749,10 @@ function ensureBlockBoundaries(text: string, placeholder?: string): string {
       const startsHeading = isHeadingLine(line) && !isHeadingLine(prev)
       // List start glued to prose above by a single `\n` (uniform-block-
       // spacing): a `- ` line already interrupts a paragraph in CommonMark,
-      // so the blank line is render-safe — it only lets the spacer pass see
-      // the transition. Never fires between two list items (prev is a list
-      // item) so list interiors stay tight.
+      // so the blank line is render-safe — it makes the prose→list transition
+      // a real `\n\n` block boundary the GFM renderer honours. Never fires
+      // between two list items (prev is a list item) so list interiors stay
+      // tight.
       const startsList = isListItemLine(line) && !isListItemLine(prev)
 
       if (startsTableHere || startsFence || startsQuote || startsHeading || startsList) {
@@ -1096,6 +962,12 @@ export function splitMarkdownChunks(text: string, maxLen = RICH_MESSAGE_MAX_CHAR
     cut = backOffOpenFence(rest, cut)
     // Back off so the cut doesn't bisect a table row (a line with `|`).
     cut = backOffTableRow(rest, cut)
+    // Back off so the cut doesn't bisect an inline entity (`**bold**`,
+    // `` `code` ``, `_italic_`, `[label](href)`), which would leave an unclosed
+    // delimiter in the emitted chunk (Telegram then parse-rejects it to
+    // plaintext, or mis-renders the continuation). Runs LAST so it also cleans
+    // up a boundary the fence/table back-offs landed on.
+    cut = backOffOpenInline(rest, cut)
 
     if (cut <= 0) {
       // Could not find a safe boundary below maxLen — the region is one
@@ -1120,38 +992,26 @@ export function splitMarkdownChunks(text: string, maxLen = RICH_MESSAGE_MAX_CHAR
 }
 
 /**
- * Strip stray paragraph-spacer / blank lines off a chunk boundary so a cut that
- * lands inside an injected spacer gap (`\n\n${PARAGRAPH_SPACER}\n\n`, see
- * addParagraphSpacers) never leaves a continuation chunk that OPENS with a bare
- * U+00A0 spacer line, nor a prior chunk that ENDS with one.
+ * Strip stray blank lines off a chunk boundary so a cut that lands in a `\n\n`
+ * paragraph gap never leaves a continuation chunk that OPENS with a bare blank
+ * line, nor a prior chunk that ENDS with one.
  *
- * A "boundary blank run" is any sequence of newlines and spacer-only lines (a
- * line whose only content is the U+00A0 spacer, optionally surrounded by ASCII
- * spaces/tabs) in ANY interleaving — `\n \n`, ` \n\n`, `\n\n \n`, etc. The
- * legacy behaviour (strip leading ASCII `\n+` only) is a strict subset, so a
- * boundary with NO spacer is unaffected. Idempotent: a chunk already trimmed
- * has nothing left to strip.
+ * (Pre-#2669-follow-up this also peeled the NBSP paragraph spacer that
+ * addParagraphSpacers injected into every gap. That spacer pass was removed —
+ * gaps are now plain `\n\n` — so this reduces to the original behaviour: strip
+ * a run of ASCII-whitespace-only blank lines off the boundary.) Idempotent: a
+ * chunk already trimmed has nothing left to strip.
  *
  *  - `'leading'`  → strip the run from the START (the continuation chunk).
  *  - `'trailing'` → strip the run from the END (the just-emitted prior chunk).
  */
 function stripBoundarySpacers(chunk: string, side: 'leading' | 'trailing'): string {
-  // One blank-or-spacer line: optional ASCII ws, optional one U+00A0, optional
-  // ASCII ws — i.e. a line that renders empty. A run of these (joined by \n,
-  // with leading/trailing \n) is what we peel off the boundary.
-  const sp = PARAGRAPH_SPACER
+  // A boundary blank run is one-or-more lines that render empty (ASCII
+  // whitespace only). Peel it off the requested side.
   if (side === 'leading') {
-    // Leading: one-or-more newlines, optionally with spacer-only lines mixed in.
-    return chunk.replace(
-      new RegExp(`^(?:[ \\t]*${sp}?[ \\t]*\\n+)+`),
-      '',
-    )
+    return chunk.replace(/^(?:[ \t]*\n)+/, '')
   }
-  // Trailing: a newline run, optionally with spacer-only lines, at the very end.
-  return chunk.replace(
-    new RegExp(`(?:\\n+[ \\t]*${sp}?[ \\t]*)+$`),
-    '',
-  )
+  return chunk.replace(/(?:\n[ \t]*)+$/, '')
 }
 
 /**
@@ -1189,4 +1049,45 @@ function backOffTableRow(text: string, cut: number): number {
     return lineStart > 0 ? lineStart - 1 : 0
   }
   return cut
+}
+
+/**
+ * Inline entities that must not be bisected by a chunk cut. Each pattern is
+ * matched over the full `text`; if the chosen `cut` lands STRICTLY inside a
+ * matched span, retreat to that span's start so the whole span moves to the
+ * next chunk (mirrors backOffOpenFence / backOffTableRow). Cutting inside a
+ * span would strand an unclosed `**` / `` ` `` / `_` / `](` delimiter, which
+ * Telegram parse-rejects to plaintext or mis-renders across the boundary.
+ *
+ * The `_italic_` pattern is boundary-guarded so snake_case identifiers
+ * (`foo_bar_baz`) don't read as emphasis; a stray match there is harmless
+ * anyway (it only shifts the cut to a `_` character, still a clean boundary).
+ */
+const INLINE_SPAN_PATTERNS: readonly RegExp[] = [
+  /`[^`\n]+`/g, // inline code
+  /\*\*[^*\n]+\*\*/g, // bold
+  /__[^_\n]+__/g, // underline
+  /(?<![\w*])_[^_\n]+_(?![\w*])/g, // italic (snake_case-guarded)
+  /\[[^\]\n]*\]\([^)\n]*\)/g, // link [label](href)
+]
+
+function backOffOpenInline(text: string, cut: number): number {
+  if (cut <= 0 || cut >= text.length) return cut
+  let earliest = cut
+  for (const re of INLINE_SPAN_PATTERNS) {
+    re.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = re.exec(text)) !== null) {
+      const start = m.index
+      const end = start + m[0].length
+      // Cut strictly inside this span → the span straddles the boundary.
+      if (start < cut && cut < end && start < earliest) earliest = start
+      // Matches arrive in order; once a span starts at/after the cut, no later
+      // span can contain it.
+      if (start >= cut) break
+      // Guard against a zero-width match wedging the loop.
+      if (re.lastIndex === start) re.lastIndex = start + 1
+    }
+  }
+  return earliest
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -343,7 +343,7 @@ const REPLY_TO_TEXT_MAX = 200
 // #1161 silent-end fallback text now lives in ../silent-end.ts
 // (`silentEndFallbackText`, imported above) so the transport-boundary
 // tests exercise the real string — see PR #2892.
-import { splitMarkdownChunks, repairEscapedWhitespace, normalizeParagraphBreaks, addParagraphSpacers, normalizePunctuation, stripExcessBold, escapeMarkdown, hardenCardBreaks, RICH_MESSAGE_MAX_CHARS } from '../format.js'
+import { splitMarkdownChunks, repairEscapedWhitespace, normalizeParagraphBreaks, normalizePunctuation, stripExcessBold, escapeMarkdown, hardenCardBreaks, RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { richMessage } from '../rich-send.js'
 import { scrubVoice } from '../text-voice-scrub.js'
 import {
@@ -14972,9 +14972,11 @@ async function executeEditMessage(args: Record<string, unknown>): Promise<unknow
   // secret into a live bubble or the history row. Mask before scrub/send.
   editRawText = redactOutboundText(editRawText, 'edit_message')
   // Fleet-wide consistent formatting (same order as the reply path: redact
-  // first so secrets are matched literally, then normalize, then spacers on
-  // the rich path only).
-  if (!editLiteralText) editRawText = addParagraphSpacers(stripExcessBold(normalizePunctuation(editRawText)))
+  // first so secrets are matched literally, then normalize). No paragraph
+  // spacer pass — the NBSP spacer was removed in the #2669 follow-up because it
+  // double-gapped every paragraph; the rich renderer already shows `\n\n` as
+  // one blank line.
+  if (!editLiteralText) editRawText = stripExcessBold(normalizePunctuation(editRawText))
   // Voice scrub (#1683): same em-dash scrub as the reply path. Edits
   // are how silent-anchor and progress-update mutate already-sent
   // bubbles, so without this an edit can re-introduce dashes the
@@ -17410,9 +17412,9 @@ function handleSessionEvent(ev: SessionEvent): void {
         // breaks into GFM hard breaks so the Bot API 10.1 rich path doesn't
         // collapse them (lists/tables/code left untouched). Runs BEFORE the
         // redact/scrub below, exactly as reply orders it (repair → normalize →
-        // redact → scrub), so masking sees the repaired text. The matching
-        // addParagraphSpacers pass runs on the send side just before
-        // splitMarkdownChunks (see below).
+        // redact → scrub), so masking sees the repaired text. Paragraph gaps
+        // are the plain `\n\n` normalizeParagraphBreaks guarantees — no spacer
+        // pass runs on the send side any more (removed in the #2669 follow-up).
         capturedText = normalizeParagraphBreaks(repairEscapedWhitespace(capturedText))
         // Component 3 — origin-thread backstop. `chatId`/`threadId` are
         // captured from the turn atom (turn.sessionChatId/sessionThreadId)
@@ -17556,13 +17558,12 @@ function handleSessionEvent(ev: SessionEvent): void {
             link_preview_options: { is_disabled: true },
           }
           const limit = RICH_MESSAGE_MAX_CHARS
-          // #2798 / #2692 — inject visible blank-line spacers into prose `\n\n`
-          // gaps before splitting, exactly as executeReply does. The rich GFM
-          // renderer collapses a bare `\n\n` gap TIGHT, so without this the
-          // paragraph boundaries from the '\n\n' block join (turn-flush-safety
-          // .ts) would still render jammed together. Mirrors reply's
-          // `addParagraphSpacers(text)` on the non-literal path.
-          const renderedText = addParagraphSpacers(capturedText)
+          // The `\n\n` block joins from turn-flush-safety.ts render as normal
+          // single blank lines under the Bot API 10.1 rich GFM path, so no
+          // spacer pass runs before splitting (the NBSP spacer was removed in
+          // the #2669 follow-up — it double-gapped every paragraph). Mirrors
+          // executeReply, which now also sends the normalized text as-is.
+          const renderedText = capturedText
           const htmlChunks = splitMarkdownChunks(renderedText, limit)
           const sentIds: number[] = []
           try {

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -27,7 +27,6 @@ import {
   normalizeParagraphBreaks,
   normalizePunctuation,
   stripExcessBold,
-  addParagraphSpacers,
   splitMarkdownChunks,
   hardSliceToCap,
   RICH_MESSAGE_MAX_CHARS,
@@ -88,13 +87,16 @@ export function normalizeOutboundBody(
 }
 
 /**
- * Effective-text spacing (#2669 rich-message regression fix). The rich GFM
- * renderer collapses `\n\n` gaps tight, so prose paragraphs render jammed.
- * Inject a visible blank-line spacer on the rich path only; the literal
- * (`format:'text'`) path stays byte-exact. Pure.
+ * Effective-text stage. Historically this injected an NBSP paragraph spacer on
+ * the rich path (#2669) to force a visible gap; that pass was removed in the
+ * #2669 follow-up because the live Bot API 10.1 GFM renderer already renders a
+ * `\n\n` gap as one normal blank line — the spacer was double-gapping every
+ * paragraph. Both paths now pass the text through byte-identically; the stage
+ * is retained as the named pipeline seam (and the literal/rich distinction is
+ * kept for callers) so a future rich-only transform has a home. Pure.
  */
-export function computeEffectiveText(text: string, literalText: boolean): string {
-  return literalText ? text : addParagraphSpacers(text)
+export function computeEffectiveText(text: string, _literalText: boolean): string {
+  return text
 }
 
 /**

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -171,14 +171,6 @@ export interface StreamReplyDeps {
    * after normalizePunctuation. Optional for backward compat.
    */
   stripExcessBold?: (text: string) => string
-  /**
-   * Insert a visible blank-line spacer into each prose `\n\n` gap so the rich
-   * GFM renderer shows a real empty line between paragraphs (the rich engine
-   * otherwise renders `\n\n` tight — the post-#2669 paragraph-spacing
-   * regression). Applied only on the rich path (never on `format:'text'`).
-   * Optional for backward compat; omitted → no spacers added.
-   */
-  addParagraphSpacers?: (text: string) => string
   /** Validates the chat id against the access list. Throws on deny. */
   assertAllowedChat: (chatId: string) => void
   /** Resolves the effective thread id (explicit, last-inbound, or undefined). */
@@ -362,12 +354,11 @@ export async function handleStreamReply(
   // markdown→HTML / MarkdownV2 rendering happens here anymore — the raw
   // text IS the wire payload.
   const literalText = format === 'text'
-  // Paragraph-spacing fix (rich-message regression after #2669): inject a
-  // visible blank-line spacer into prose `\n\n` gaps on the rich path so
-  // multi-paragraph answers don't render jammed together. The literal
-  // (`format:'text'`) path must stay byte-exact, so it is left untouched.
-  let effectiveText: string =
-    !literalText && deps.addParagraphSpacers ? deps.addParagraphSpacers(rawText) : rawText
+  // No paragraph-spacer pass: the NBSP spacer (#2669) was removed in the
+  // follow-up because the Bot API 10.1 rich GFM renderer already shows a `\n\n`
+  // gap as one blank line — the spacer double-gapped every paragraph. The raw
+  // text (already normalized upstream) is the effective text on both paths.
+  let effectiveText: string = rawText
 
   // Inline status-accent header (issue #320 fallback). Prepended so it
   // leads the body. Since stream_reply callers pass the full text snapshot

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -211,6 +211,20 @@ describe('normalizePunctuation', () => {
     )
   })
 
+  test('does NOT rewrite a dash inside a `<scheme:…>` autolink (#finding-2 sibling)', () => {
+    // An en-dash in an angle-bracket autolink URL must survive verbatim.
+    expect(normalizePunctuation('<https://x.com/foo–bar>')).toBe('<https://x.com/foo–bar>')
+    // An em-dash in an autolink must NOT become `, `.
+    expect(normalizePunctuation('<https://x.com/foo—bar>')).toBe('<https://x.com/foo—bar>')
+    // Autolink mid-prose: the surrounding prose still normalizes, the URL does not.
+    expect(normalizePunctuation('see <https://x.com/a–b> now — go')).toBe(
+      'see <https://x.com/a–b> now, go',
+    )
+    // Arbitrary `<…>` prose (no scheme) is NOT treated as an autolink: a dash
+    // inside it still normalizes like ordinary text.
+    expect(normalizePunctuation('<not—a—url>')).toBe('<not, a, url>')
+  })
+
   test('idempotent', () => {
     const once = normalizePunctuation('a — b\n• c\nd—e\n1–2')
     expect(normalizePunctuation(once)).toBe(once)

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -1,26 +1,24 @@
 /**
  * Tests for the fleet-wide consistent-formatting bundle:
  *
- *   1. addParagraphSpacers extension — a visible U+00A0 spacer line at EVERY
- *      block transition (paragraph→list, list→paragraph, heading→anything,
- *      blockquote/table boundaries), never inside a list/table interior.
+ *   1. paragraph gap spacing — a plain `\n\n` (one blank line) at EVERY block
+ *      transition (paragraph→list, list→paragraph, heading→anything,
+ *      blockquote/table boundaries), never a double blank line and never an
+ *      NBSP spacer (the old spacer pass was removed in the #2669 follow-up).
  *   2. normalizePunctuation — em/en dashes → comma/hyphen, leading `•`/`·`
- *      list markers → `- `, on code-masked text, idempotent.
+ *      list markers → `- `, on code-masked text, idempotent; link hrefs are
+ *      protected from dash rewriting.
  *   3. stripExcessBold — over-bold tripwire: >30% bold or fully-bolded
  *      paragraphs/lists lose their bold markers; short messages exempt.
  */
 import { describe, test, expect } from 'vitest'
 import {
-  addParagraphSpacers,
   normalizeParagraphBreaks,
   normalizePunctuation,
   stripExcessBold,
   splitMarkdownChunks,
   hardenCardBreaks,
-  PARAGRAPH_SPACER,
 } from '../format.js'
-
-const SP = PARAGRAPH_SPACER // U+00A0
 
 describe('hardenCardBreaks — deterministic card line-break hardener', () => {
   test('promotes lone field breaks to GFM hard breaks (the blob fix)', () => {
@@ -100,74 +98,60 @@ describe('hardenCardBreaks — deterministic card line-break hardener', () => {
   })
 })
 
-describe('addParagraphSpacers — uniform block spacing', () => {
-  test('still spaces prose→prose (existing behaviour)', () => {
-    const out = addParagraphSpacers('Alpha.\n\nBravo.')
-    expect(out).toBe(`Alpha.\n\n${SP}\n\nBravo.`)
+describe('paragraph gap spacing — plain single blank line, no NBSP', () => {
+  const NBSP = String.fromCharCode(0xa0)
+
+  test('prose→prose gap is one blank line, no NBSP', () => {
+    const out = normalizeParagraphBreaks('Alpha.\n\nBravo.')
+    expect(out).toBe('Alpha.\n\nBravo.')
+    expect(out).not.toContain(NBSP)
   })
 
-  test('spaces paragraph→list transition', () => {
-    const out = addParagraphSpacers('Intro.\n\n- one\n- two')
-    expect(out).toBe(`Intro.\n\n${SP}\n\n- one\n- two`)
+  test('paragraph→list transition is a single `\\n\\n` boundary', () => {
+    expect(normalizeParagraphBreaks('Intro.\n\n- one\n- two')).toBe('Intro.\n\n- one\n- two')
   })
 
-  test('spaces list→paragraph transition', () => {
-    const out = addParagraphSpacers('- one\n- two\n\nOutro.')
-    expect(out).toBe(`- one\n- two\n\n${SP}\n\nOutro.`)
+  test('list→paragraph transition is a single `\\n\\n` boundary', () => {
+    expect(normalizeParagraphBreaks('- one\n- two\n\nOutro.')).toBe('- one\n- two\n\nOutro.')
   })
 
-  test('spaces heading→anything', () => {
-    expect(addParagraphSpacers('# Title\n\nBody.')).toBe(`# Title\n\n${SP}\n\nBody.`)
-    expect(addParagraphSpacers('# Title\n\n- a\n- b')).toBe(`# Title\n\n${SP}\n\n- a\n- b`)
+  test('heading→anything is a single `\\n\\n` boundary', () => {
+    expect(normalizeParagraphBreaks('# Title\n\nBody.')).toBe('# Title\n\nBody.')
+    expect(normalizeParagraphBreaks('# Title\n\n- a\n- b')).toBe('# Title\n\n- a\n- b')
   })
 
-  test('spaces blockquote and table boundaries', () => {
-    expect(addParagraphSpacers('> quoted\n\nProse.')).toBe(`> quoted\n\n${SP}\n\nProse.`)
+  test('blockquote and table boundaries are single `\\n\\n`', () => {
+    expect(normalizeParagraphBreaks('> quoted\n\nProse.')).toBe('> quoted\n\nProse.')
     const table = '| a | b |\n| --- | --- |\n| 1 | 2 |'
-    expect(addParagraphSpacers(`Prose.\n\n${table}`)).toBe(`Prose.\n\n${SP}\n\n${table}`)
-    expect(addParagraphSpacers(`${table}\n\nProse.`)).toBe(`${table}\n\n${SP}\n\nProse.`)
-  })
-
-  test('does NOT space between items of the same loose list', () => {
-    const input = '- one\n\n- two\n\n- three'
-    expect(addParagraphSpacers(input)).toBe(input)
-  })
-
-  test('does NOT space inside a tight list or table interior (single \\n)', () => {
-    const list = 'Intro.\n\n- a\n- b\n- c'
-    expect(addParagraphSpacers(list)).toBe(`Intro.\n\n${SP}\n\n- a\n- b\n- c`)
-    const table = '| a |\n| --- |\n| 1 |\n| 2 |'
-    expect(addParagraphSpacers(table)).toBe(table)
-  })
-
-  test('idempotent across every transition kind', () => {
-    const input = '# H\n\nProse one.\n\n- a\n- b\n\nProse two.\n\n> quote'
-    const once = addParagraphSpacers(input)
-    expect(addParagraphSpacers(once)).toBe(once)
+    expect(normalizeParagraphBreaks(`Prose.\n\n${table}`)).toBe(`Prose.\n\n${table}`)
+    expect(normalizeParagraphBreaks(`${table}\n\nProse.`)).toBe(`${table}\n\nProse.`)
   })
 
   test('never touches code fences', () => {
     const input = '```\nA\n\nB\n```\n\n```\nC\n```'
-    expect(addParagraphSpacers(input)).toBe(input)
+    expect(normalizeParagraphBreaks(input)).toBe(input)
   })
 
-  test('full pipeline: mixed prose+list+heading message gets uniform gaps', () => {
-    const raw = 'Summary line.\n- item one\n- item two\nClosing prose.'
-    const out = addParagraphSpacers(normalizeParagraphBreaks(raw))
-    // Every block transition carries exactly one visible spacer line.
-    expect(out).toBe(
-      `Summary line.\n\n${SP}\n\n- item one\n- item two\n\n${SP}\n\nClosing prose.`,
-    )
+  test('full pipeline: mixed prose+list message gets single-blank-line gaps, no NBSP, no double gap', () => {
+    const raw = 'Summary line.\n\n- item one\n- item two\n\nClosing prose.'
+    const out = normalizeParagraphBreaks(raw)
+    expect(out).toBe('Summary line.\n\n- item one\n- item two\n\nClosing prose.')
+    expect(out).not.toContain(NBSP)
+    expect(out).not.toMatch(/\n\n\n/)
   })
 
-  test('chunk-boundary interaction: a cut in a spacer gap strips the spacer', () => {
+  test('chunk-boundary interaction: a cut in a `\\n\\n` gap leaves clean chunks (no stray blank lines)', () => {
     const a = 'A'.repeat(60)
     const b = 'B'.repeat(60)
-    const text = `${a}\n\n${SP}\n\n${b}`
+    const text = `${a}\n\n${b}`
     const chunks = splitMarkdownChunks(text, 80)
     expect(chunks.length).toBe(2)
     expect(chunks[0]).toBe(a)
     expect(chunks[1]).toBe(b)
+    // Neither chunk opens or ends with a stray blank line.
+    for (const c of chunks) {
+      expect(c).toBe(c.replace(/^\n+|\n+$/g, ''))
+    }
   })
 })
 
@@ -208,6 +192,23 @@ describe('normalizePunctuation', () => {
   test('never touches code spans or fences', () => {
     const input = 'run `a — b` now\n\n```\nx — y\n• bullet\n```'
     expect(normalizePunctuation(input)).toBe(input)
+  })
+
+  test('does NOT rewrite a dash inside a markdown link href (#finding-2)', () => {
+    // An en-dash in a URL path must survive verbatim — rewriting it to `-`
+    // silently points at a different URL.
+    expect(normalizePunctuation('[a](https://x.com/foo–bar)')).toBe(
+      '[a](https://x.com/foo–bar)',
+    )
+    // An em-dash in a URL must NOT become `, ` — the injected space would
+    // TERMINATE the markdown link and leak the trailing text as prose.
+    expect(normalizePunctuation('[a](https://x.com/foo—bar)')).toBe(
+      '[a](https://x.com/foo—bar)',
+    )
+    // The visible LABEL still normalizes (dashes in label text are prose).
+    expect(normalizePunctuation('[foo—bar](https://x.com/path)')).toBe(
+      '[foo, bar](https://x.com/path)',
+    )
   })
 
   test('idempotent', () => {

--- a/telegram-plugin/tests/formatting-parse-regression.test.ts
+++ b/telegram-plugin/tests/formatting-parse-regression.test.ts
@@ -17,9 +17,10 @@
  *       fixture intended (bold/italic/code/pre/link at the right inner text).
  *
  * The pipeline mirrors `telegram-plugin/gateway/gateway.ts`:
- *   repairEscapedWhitespace -> normalizeParagraphBreaks -> addParagraphSpacers
- *   -> splitMarkdownChunks. (Card-surface fixtures also apply `normalizeDashes`
- *   first — that is where F1's voice scrub lives.)
+ *   repairEscapedWhitespace -> normalizeParagraphBreaks -> splitMarkdownChunks.
+ *   (No paragraph-spacer pass — the NBSP spacer was removed in the #2669
+ *   follow-up; gaps are plain `\n\n`. Card-surface fixtures also apply
+ *   `normalizeDashes` first — that is where F1's voice scrub lives.)
  *
  * This suite is TEST-ONLY. It changes no production formatting behaviour. If a
  * fixture ever fails signal (a), it means the formatter emits markdown Telegram
@@ -30,7 +31,6 @@ import { describe, test, expect } from 'vitest'
 import {
   repairEscapedWhitespace,
   normalizeParagraphBreaks,
-  addParagraphSpacers,
   splitMarkdownChunks,
   RICH_MESSAGE_MAX_CHARS,
 } from '../format.js'
@@ -57,8 +57,7 @@ function transform(input: string, opts: { cardSurfaceScrub?: boolean; cap?: numb
 } {
   let text = input
   if (opts.cardSurfaceScrub) text = normalizeDashes(text)
-  text = normalizeParagraphBreaks(repairEscapedWhitespace(text))
-  const body = addParagraphSpacers(text)
+  const body = normalizeParagraphBreaks(repairEscapedWhitespace(text))
   const chunks = splitMarkdownChunks(body, opts.cap ?? RICH_MESSAGE_MAX_CHARS)
   return { chunks, body }
 }

--- a/telegram-plugin/tests/formatting-torture-set.ts
+++ b/telegram-plugin/tests/formatting-torture-set.ts
@@ -7,7 +7,7 @@
  * The `input` is the raw text as a model/card surface would author it — the
  * regression test runs it through the SAME outbound transform pipeline the
  * gateway uses (repairEscapedWhitespace -> normalizeParagraphBreaks ->
- * addParagraphSpacers -> splitMarkdownChunks) and then asserts:
+ * splitMarkdownChunks) and then asserts:
  *
  *   (a) every emitted chunk is parse-accept valid (no rich-path 400), and
  *   (b) the concatenated output parses into `expect` (entity structure).

--- a/telegram-plugin/tests/outbound-send-path.test.ts
+++ b/telegram-plugin/tests/outbound-send-path.test.ts
@@ -4,7 +4,6 @@ import {
   normalizeParagraphBreaks,
   normalizePunctuation,
   stripExcessBold,
-  addParagraphSpacers,
   splitMarkdownChunks,
   hardSliceToCap,
   RICH_MESSAGE_MAX_CHARS,
@@ -55,8 +54,10 @@ function referenceNormalize(rawText: string): { text: string; voiceReplaced: num
   return { text, voiceReplaced }
 }
 
-function referenceEffectiveText(text: string, literalText: boolean): string {
-  return literalText ? text : addParagraphSpacers(text)
+function referenceEffectiveText(text: string, _literalText: boolean): string {
+  // The NBSP paragraph-spacer pass was removed in the #2669 follow-up; both
+  // paths now pass the normalized text through unchanged.
+  return text
 }
 
 function referenceChunks(

--- a/telegram-plugin/tests/paragraph-normalizer.test.ts
+++ b/telegram-plugin/tests/paragraph-normalizer.test.ts
@@ -12,8 +12,6 @@ import { describe, test, expect } from 'vitest'
 import {
   normalizeParagraphBreaks,
   splitCollapsedInlineBullets,
-  addParagraphSpacers,
-  PARAGRAPH_SPACER,
 } from '../format.js'
 
 describe('normalizeParagraphBreaks', () => {
@@ -433,96 +431,44 @@ describe('splitCollapsedInlineBullets', () => {
 })
 
 // ---------------------------------------------------------------------------
-// addParagraphSpacers — restore a VISIBLE blank line between prose paragraphs.
+// Paragraph gap spacing — plain \n\n, no NBSP spacer (#2669 follow-up).
 //
-// The rich GFM renderer (post-#2669) collapses a `\n\n` paragraph gap TIGHT, so
-// multi-paragraph replies render jammed together — the operator-confirmed
-// regression vs the old HTML path (`parse_mode:"HTML"`, `\n\n` → real blank
-// line). addParagraphSpacers wedges a U+00A0 spacer paragraph into each prose
-// `\n\n` gap so the rich renderer shows a visible empty line. Conservative:
-// only between two prose blocks, never adjacent to list/table/code/quote/heading.
+// The NBSP paragraph-spacer (addParagraphSpacers / PARAGRAPH_SPACER) was
+// REMOVED: its premise — that the Bot API 10.1 rich GFM renderer collapses a
+// `\n\n` gap TIGHT — is false for the live renderer, which shows a `\n\n` gap
+// as one normal blank line. The spacer therefore injected a spurious SECOND
+// blank line (`\n\n \n\n`) between every paragraph fleet-wide. Paragraph
+// spacing now relies on the plain `\n\n` that normalizeParagraphBreaks already
+// guarantees. These tests pin: multi-paragraph output has exactly one blank
+// line per gap, and no U+00A0 anywhere.
 // ---------------------------------------------------------------------------
 
-describe('addParagraphSpacers', () => {
-  const gap = `\n\n${PARAGRAPH_SPACER}\n\n`
+describe('paragraph gap spacing — single blank line, no NBSP', () => {
+  const NBSP = String.fromCharCode(0xa0)
 
-  test('the spacer is a single non-breaking space (U+00A0), not an ASCII space', () => {
-    expect(PARAGRAPH_SPACER).toBe(' ')
+  test('a two-paragraph prose body has exactly one blank-line gap and no NBSP', () => {
+    const out = normalizeParagraphBreaks('Paragraph one.\n\nParagraph two.')
+    expect(out).toBe('Paragraph one.\n\nParagraph two.')
+    expect(out).not.toContain(NBSP)
+    // Exactly one empty line between the two content lines.
+    expect(out.split('\n')).toEqual(['Paragraph one.', '', 'Paragraph two.'])
   })
 
-  test('inserts a visible spacer paragraph into a prose `\\n\\n` gap', () => {
-    expect(addParagraphSpacers('Paragraph one.\n\nParagraph two.')).toBe(
-      `Paragraph one.${gap}Paragraph two.`,
-    )
+  test('a three-paragraph body keeps single-blank-line gaps, no NBSP', () => {
+    const out = normalizeParagraphBreaks('One.\n\nTwo.\n\nThree.')
+    expect(out).toBe('One.\n\nTwo.\n\nThree.')
+    expect(out).not.toContain(NBSP)
+    // No gap is a DOUBLE blank line (`\n\n\n`), which the old spacer produced.
+    expect(out).not.toMatch(/\n\n\n/)
   })
 
-  test('spaces every gap in a three-paragraph body', () => {
-    expect(addParagraphSpacers('One.\n\nTwo.\n\nThree.')).toBe(
-      `One.${gap}Two.${gap}Three.`,
-    )
+  test('prose->list transition is a single `\n\n` boundary, list interior tight', () => {
+    const out = normalizeParagraphBreaks('Here are the steps.\n\n- first\n- second')
+    expect(out).toBe('Here are the steps.\n\n- first\n- second')
+    expect(out).not.toContain(NBSP)
   })
 
-  test('is idempotent — a spaced gap is not doubled on a second pass', () => {
-    const once = addParagraphSpacers('Alpha.\n\nBravo.')
-    expect(addParagraphSpacers(once)).toBe(once)
-  })
-
-  test('leaves a single-`\\n` separation alone (only `\\n\\n` gaps are spaced)', () => {
-    // normalizeParagraphBreaks owns lone-break promotion; this pass only adds a
-    // visible spacer where a genuine blank-line gap already exists.
-    const input = 'Line one.\nLine two.'
-    expect(addParagraphSpacers(input)).toBe(input)
-  })
-
-  test('spaces prose↔list transitions (uniform block spacing), list interior tight', () => {
-    expect(addParagraphSpacers('Here are the steps.\n\n- first\n- second')).toBe(
-      `Here are the steps.${gap}- first\n- second`,
-    )
-    expect(addParagraphSpacers('- first\n- second\n\nClosing prose after the list.')).toBe(
-      `- first\n- second${gap}Closing prose after the list.`,
-    )
-  })
-
-  test('spaces a prose→table boundary; table rows stay contiguous', () => {
-    const table = '| a | b |\n| --- | --- |\n| 1 | 2 |'
-    expect(addParagraphSpacers(`Intro.\n\n${table}`)).toBe(`Intro.${gap}${table}`)
-  })
-
-  test('spaces prose↔fence boundaries; fence interior untouched', () => {
-    const input = 'Look here.\n\n```js\nconst a = 1;\n```\n\nDone.'
-    expect(addParagraphSpacers(input)).toBe(
-      `Look here.${gap}\`\`\`js\nconst a = 1;\n\`\`\`${gap}Done.`,
-    )
-  })
-
-  test('spaces heading→anything and blockquote boundaries', () => {
-    expect(addParagraphSpacers('Intro prose.\n\n## Section\n\nBody prose.')).toBe(
-      `Intro prose.${gap}## Section${gap}Body prose.`,
-    )
-    expect(addParagraphSpacers('Said.\n\n> a quote\n\nAfter.')).toBe(
-      `Said.${gap}> a quote${gap}After.`,
-    )
-  })
-
-  test('does NOT space between items of the same loose list / same-kind blocks', () => {
-    const looseList = '- first\n\n- second\n\n- third'
-    expect(addParagraphSpacers(looseList)).toBe(looseList)
-    const quotes = '> one\n\n> two'
-    expect(addParagraphSpacers(quotes)).toBe(quotes)
-  })
-
-  test('never reaches inside a fenced block (interior blank line untouched)', () => {
-    const input = 'Before.\n\n```\nline 1\n\nline 2\n```\n\nAfter.'
-    const out = addParagraphSpacers(input)
-    // The fence interior — including its own blank line — is byte-for-byte intact.
-    expect(out).toContain('```\nline 1\n\nline 2\n```')
-  })
-
-  test('a body with no paragraph gap is returned unchanged', () => {
-    expect(addParagraphSpacers('just one paragraph, no gap')).toBe('just one paragraph, no gap')
-  })
-
-  test('composes after normalizeParagraphBreaks: prose gap spaced, list left tight', () => {
+  test('composed prose+list body: one blank line per gap, no NBSP, no double gap', () => {
     const input = [
       'Summary of the change.',
       '',
@@ -531,12 +477,11 @@ describe('addParagraphSpacers', () => {
       '- adds a normalizer',
       '- lifts the cap',
     ].join('\n')
-    const out = addParagraphSpacers(normalizeParagraphBreaks(input))
-    // The two prose paragraphs gain a visible spacer between them.
-    expect(out).toContain(`Summary of the change.${gap}It does two things.`)
-    // The prose→list transition gains a spacer too (uniform block spacing),
-    // but the list INTERIOR stays tight.
-    expect(out).toContain(`It does two things.${gap}- adds a normalizer\n- lifts the cap`)
+    const out = normalizeParagraphBreaks(input)
+    expect(out).toContain('Summary of the change.\n\nIt does two things.')
+    expect(out).toContain('It does two things.\n\n- adds a normalizer\n- lifts the cap')
+    expect(out).not.toContain(NBSP)
+    expect(out).not.toMatch(/\n\n\n/)
   })
 })
 
@@ -577,12 +522,12 @@ describe('normalizeParagraphBreaks — inline bullet split integration', () => {
  * ragged / oversized gap: CommonMark discards it so it buys no visible space,
  * but it reads as noise in the raw text. Step 1 of normalizeParagraphBreaks now
  * collapses any run of blank lines — including whitespace-only interior lines —
- * to exactly one clean `\n\n`, WITHOUT ever eating the deliberate U+00A0
- * paragraph spacer that addParagraphSpacers (#2692) adds later for a visible
- * gap on the rich-message path.
+ * to exactly one clean `\n\n`. The collapse is deliberately ASCII-only, so a
+ * genuine user-typed U+00A0 line survives (the conservative choice; there is no
+ * longer an NBSP paragraph spacer to protect — that pass was removed).
  */
 describe('normalizeParagraphBreaks — whitespace-only blank-line collapse (Bug 2)', () => {
-  const NBSP = ' '
+  const NBSP = String.fromCharCode(0xa0)
 
   test('a lone-space blank line between paragraphs collapses to a clean `\\n\\n` (real string)', () => {
     const input =
@@ -635,14 +580,11 @@ describe('normalizeParagraphBreaks — whitespace-only blank-line collapse (Bug 
     expect(normalizeParagraphBreaks(input)).toBe(input)
   })
 
-  test('the deliberate U+00A0 spacer from addParagraphSpacers is preserved (no #2692 regression)', () => {
-    const normalized = normalizeParagraphBreaks('Alpha para.\n\nBravo para.')
-    const spaced = addParagraphSpacers(normalized)
-    // addParagraphSpacers wedges a U+00A0-only line to force a visible gap.
-    expect(spaced).toContain('\n\n' + PARAGRAPH_SPACER + '\n\n')
-    expect(spaced.split('\n')).toContain(NBSP)
-    // And re-running the normalizer must NOT eat that intentional spacer.
-    expect(normalizeParagraphBreaks(spaced)).toBe(spaced)
+  test('a genuine user-typed U+00A0-only line survives (ASCII-only collapse)', () => {
+    // The blank-line collapse is deliberately ASCII-only, so a non-breaking
+    // space a user actually typed on its own line is not silently eaten.
+    const input = 'Alpha para.\n' + NBSP + '\nBravo para.'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
   })
 
   test('idempotent: collapsing a stray gap twice is stable', () => {

--- a/telegram-plugin/tests/stream-reply-handler.test.ts
+++ b/telegram-plugin/tests/stream-reply-handler.test.ts
@@ -120,13 +120,12 @@ describe('handleStreamReply', () => {
     expect(bot.api.sendMessage.mock.calls[0][2]?.parse_mode).toBeUndefined()
   })
 
-  it('applies addParagraphSpacers on the rich path (multi-paragraph gap spaced)', async () => {
+  it('rich path sends the multi-paragraph `\\n\\n` gap byte-exact (no NBSP spacer)', async () => {
+    // The NBSP paragraph-spacer pass was removed in the #2669 follow-up — the
+    // rich renderer shows a plain `\n\n` gap as one blank line, so the handler
+    // passes the text through unchanged.
     const state = makeState()
-    // Spacer dep replaces every `\n\n` gap with a visible marker so we can
-    // assert the rich path ran it (mirrors the real gateway wiring).
-    const deps = makeDeps(bot, {
-      addParagraphSpacers: (t) => t.replace(/\n\n/g, '\n\nSPACER\n\n'),
-    })
+    const deps = makeDeps(bot)
 
     const pending = handleStreamReply(
       { chat_id: '1', text: 'Para one.\n\nPara two.', done: true },
@@ -137,14 +136,13 @@ describe('handleStreamReply', () => {
     await pending
 
     expect(bot.api.sendRichMessage).toHaveBeenCalledTimes(1)
-    expect(richSendMarkdown(bot)).toBe('Para one.\n\nSPACER\n\nPara two.')
+    expect(richSendMarkdown(bot)).toBe('Para one.\n\nPara two.')
+    expect(richSendMarkdown(bot)).not.toContain(String.fromCharCode(0xa0))
   })
 
-  it('does NOT apply addParagraphSpacers on the literal format=text path', async () => {
+  it('literal format=text path is byte-exact too', async () => {
     const state = makeState()
-    const deps = makeDeps(bot, {
-      addParagraphSpacers: (t) => t.replace(/\n\n/g, '\n\nSPACER\n\n'),
-    })
+    const deps = makeDeps(bot)
 
     const pending = handleStreamReply(
       { chat_id: '1', text: 'Para one.\n\nPara two.', format: 'text', done: true },
@@ -155,7 +153,6 @@ describe('handleStreamReply', () => {
     await pending
 
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
-    // Literal path is byte-exact — no spacer injected.
     expect(bot.api.sendMessage.mock.calls[0][1]).toBe('Para one.\n\nPara two.')
   })
 

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -270,6 +270,34 @@ describe('splitMarkdownChunks', () => {
     }
   })
 
+  test('a `***bold-italic***` / `___…___` span straddling the cap keeps SINGLE-marker balance', () => {
+    // Regression for the triple-marker case: without the `***…***` pattern, the
+    // bold pattern matches only the inner `**…**`, so a cut inside `***x***`
+    // strands the lone outer `*` (odd asterisk count → the italic is lost). A
+    // `**`-PAIR balance check misses that, so assert SINGLE-`*` / SINGLE-`_`
+    // balance in every chunk.
+    const filler = 'x'.repeat(30)
+    const body =
+      `${filler} ***bold italic here*** ` +
+      `${filler} ___under bold here___ ${filler}`
+    for (const cap of [40, 50, 60, 70]) {
+      const chunks = splitMarkdownChunks(body, cap)
+      for (const c of chunks) {
+        // SINGLE-marker balance: an even count of `*` and of `_` in every chunk
+        // (a stranded lone `*`/`_` from a bisected triple span makes it odd).
+        expect((c.match(/\*/g) ?? []).length % 2).toBe(0)
+        expect((c.match(/_/g) ?? []).length % 2).toBe(0)
+      }
+      // Each triple span survives intact in exactly one chunk.
+      const rejoined = chunks.join('\n')
+      expect(rejoined).toContain('***bold italic here***')
+      expect(rejoined).toContain('___under bold here___')
+      // Nothing dropped.
+      const words = (s: string): string[] => s.split(/\s+/).filter((w) => w.length > 0)
+      expect(words(chunks.join(' '))).toEqual(words(body))
+    }
+  })
+
   test('a boundary with NO spacer is unaffected (legacy ^\\n+ behaviour preserved)', () => {
     const text = Array.from({ length: 10 }, (_, i) => `plain line ${i}`).join('\n\n')
     const chunks = splitMarkdownChunks(text, 40)

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -19,8 +19,6 @@ import {
   repairEscapedWhitespace,
   escapeMarkdown,
   splitMarkdownChunks,
-  addParagraphSpacers,
-  PARAGRAPH_SPACER,
   RICH_MESSAGE_MAX_CHARS,
 } from '../format.js'
 
@@ -187,59 +185,88 @@ describe('splitMarkdownChunks', () => {
   })
 
   // -------------------------------------------------------------------------
-  // Chunk-boundary spacer hygiene. addParagraphSpacers injects a
-  // `\n\n${PARAGRAPH_SPACER}\n\n` gap between prose paragraphs. When a cut
-  // lands inside that gap, the boundary must not leave a chunk that opens or
-  // ends with a bare U+00A0 spacer line (a stray blank bubble line).
+  // Chunk-boundary blank-line hygiene. Paragraph gaps are now plain `\n\n`
+  // (the NBSP spacer was removed in the #2669 follow-up). When a cut lands in
+  // a gap, the boundary must not leave a chunk that opens or ends with a bare
+  // blank line, and no visible content may be dropped.
   // -------------------------------------------------------------------------
 
-  test('no chunk starts or ends with a bare U+00A0 spacer line (reviewer repro)', () => {
-    // The exact reviewer repro: a spacer gap straddling a small cap.
+  test('no chunk starts or ends with a bare blank line at a `\\n\\n` gap cut', () => {
     const A = 'Alpha sentence one'
     const B = 'Bravo sentence two'
-    const spaced = addParagraphSpacers(`${A}.\n\n${B}.`)
-    const chunks = splitMarkdownChunks(spaced, 33)
+    const text = `${A}.\n\n${B}.`
+    const chunks = splitMarkdownChunks(text, 33)
     expect(chunks.length).toBeGreaterThan(1)
-    const spacerOnly = new RegExp(`^[ \\t]*${PARAGRAPH_SPACER}[ \\t]*$`)
+    const blankOnly = /^[ \t]*$/
     for (const c of chunks) {
       const lines = c.split('\n')
-      expect(spacerOnly.test(lines[0])).toBe(false)
-      expect(spacerOnly.test(lines[lines.length - 1])).toBe(false)
+      expect(blankOnly.test(lines[0])).toBe(false)
+      expect(blankOnly.test(lines[lines.length - 1])).toBe(false)
     }
   })
 
   test('visible paragraph content survives the boundary (no text dropped)', () => {
     const A = 'Alpha sentence one'
     const B = 'Bravo sentence two'
-    const spaced = addParagraphSpacers(`${A}.\n\n${B}.`)
-    const chunks = splitMarkdownChunks(spaced, 33)
+    const text = `${A}.\n\n${B}.`
+    const chunks = splitMarkdownChunks(text, 33)
     const rejoined = chunks.join('\n')
     expect(rejoined).toContain(`${A}.`)
     expect(rejoined).toContain(`${B}.`)
   })
 
-  test('spacer-boundary strip is robust across several gaps and small caps', () => {
+  test('blank-line-boundary strip is robust across several gaps and small caps', () => {
     const paras = Array.from({ length: 6 }, (_, i) => `Paragraph ${i} body text here.`)
-    const spaced = addParagraphSpacers(paras.join('\n\n'))
-    const spacerOnly = new RegExp(`^[ \\t]*${PARAGRAPH_SPACER}[ \\t]*$`)
+    const text = paras.join('\n\n')
+    const blankOnly = /^[ \t]*$/
     for (const cap of [20, 31, 40, 64]) {
-      const chunks = splitMarkdownChunks(spaced, cap)
+      const chunks = splitMarkdownChunks(text, cap)
       for (const c of chunks) {
         const lines = c.split('\n')
-        expect(spacerOnly.test(lines[0])).toBe(false)
-        expect(spacerOnly.test(lines[lines.length - 1])).toBe(false)
+        expect(blankOnly.test(lines[0])).toBe(false)
+        expect(blankOnly.test(lines[lines.length - 1])).toBe(false)
       }
-      // No visible word is dropped: concatenating the chunks' non-blank,
-      // non-spacer tokens reproduces the original word sequence. (Word-level,
-      // not line-level, because a small cap may split mid-word — that's the
-      // chunker's normal space-boundary behaviour, orthogonal to spacers.)
-      const words = (s: string): string[] =>
-        s.split(/\s+/).filter((w) => w.length > 0 && w !== PARAGRAPH_SPACER)
-      // Join chunks with a space — each chunk is a separate Telegram message,
-      // so inter-chunk whitespace is irrelevant; what matters is no word is
-      // lost or fused. (A small cap may end a chunk mid-sentence at a space
-      // boundary, e.g. "...here." | "Paragraph 1...", which is normal.)
+      // No visible word is dropped: concatenating the chunks' non-blank tokens
+      // reproduces the original word sequence. (Word-level, not line-level,
+      // because a small cap may split mid-word — the chunker's normal
+      // space-boundary behaviour.)
+      const words = (s: string): string[] => s.split(/\s+/).filter((w) => w.length > 0)
       expect(words(chunks.join(' '))).toEqual(words(paras.join(' ')))
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // Entity-aware chunking (#finding-3): a cut must never bisect an inline
+  // span (`**bold**`, `` `code` ``, `_italic_`, `[label](href)`), which would
+  // strand an unclosed delimiter in the emitted chunk.
+  // -------------------------------------------------------------------------
+
+  test('a bold/code/link span straddling the cap is not bisected (balanced delimiters)', () => {
+    // Build a body where each inline span sits right around a small cap so the
+    // naive space/newline cut would land inside it. Every span is shorter than
+    // the smallest cap tried (the longest is the 34-char link), so a straddling
+    // span can always be kept whole — the entity-aware back-off must do so.
+    const filler = 'x'.repeat(30)
+    const body =
+      `${filler} **bold span here** ` +
+      `${filler} \`code span here\` ` +
+      `${filler} [label here](https://ex.com/a-b-c) ` +
+      `${filler} _italic span here_ ${filler}`
+    for (const cap of [40, 50, 60, 70, 80]) {
+      const chunks = splitMarkdownChunks(body, cap)
+      for (const c of chunks) {
+        // Balanced `**` and single-backtick delimiters in every chunk.
+        expect((c.match(/\*\*/g) ?? []).length % 2).toBe(0)
+        expect((c.match(/`/g) ?? []).length % 2).toBe(0)
+        // No chunk ends mid-link (an open `](` with no closing `)`), and no
+        // chunk starts with an orphan link tail.
+        const opens = (c.match(/\]\(/g) ?? []).length
+        const closesAfterOpen = (c.match(/\]\([^)\n]*\)/g) ?? []).length
+        expect(opens).toBe(closesAfterOpen)
+      }
+      // Nothing is dropped.
+      const words = (s: string): string[] => s.split(/\s+/).filter((w) => w.length > 0)
+      expect(words(chunks.join(' '))).toEqual(words(body))
     }
   })
 

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -31,9 +31,7 @@ import {
   normalizeParagraphBreaks,
   normalizePunctuation,
   stripExcessBold,
-  addParagraphSpacers,
   splitMarkdownChunks,
-  PARAGRAPH_SPACER,
   RICH_MESSAGE_MAX_CHARS,
 } from '../format.js'
 
@@ -130,7 +128,9 @@ describe('decideTurnFlush — prose+trailing-sentinel is suppressed, not leaked 
 // the real gateway turn-flush render pipeline (post-#2669 rich-markdown path):
 //   decideTurnFlush -> join('\n\n')
 //   -> repairEscapedWhitespace -> normalizeParagraphBreaks
-//   -> addParagraphSpacers -> splitMarkdownChunks -> sendRichMessage
+//   -> splitMarkdownChunks -> sendRichMessage
+// (no paragraph-spacer pass — the NBSP spacer was removed in the #2669
+//  follow-up; gaps are plain `\n\n`, one visible blank line)
 // so it pins the end-to-end fix, not just the pure decision. The corpus is a
 // REAL captured-transcript shape (three separate content[i].text blocks, one
 // stored UNTRIMMED with a trailing '\n' exactly as session-tail.ts pushes
@@ -156,8 +156,7 @@ describe('#2798 turn-flush block separation — real multi-block transcript shap
     const d = decideTurnFlush({ chatId: '12345', replyCalled: false, capturedText: blocks })
     expect(d.kind).toBe('flush')
     const joined = (d as { kind: 'flush'; text: string }).text
-    const normalized = normalizeParagraphBreaks(repairEscapedWhitespace(joined))
-    return addParagraphSpacers(normalized)
+    return normalizeParagraphBreaks(repairEscapedWhitespace(joined))
   }
 
   it('separates whole blocks with a visible paragraph gap, not a wall-of-text', () => {
@@ -167,32 +166,29 @@ describe('#2798 turn-flush block separation — real multi-block transcript shap
     expect(out).toContain('The `auth` handler looks correct')
     expect(out).toContain('Want me to open a PR')
     // The wall-of-text failure mode glues two blocks one '\n' apart. Assert the
-    // boundary carries a real paragraph break with the injected visible spacer
-    // line (#2692 rich-path spacer), and NOT a single-newline join.
-    expect(out).toContain(`\n\n${PARAGRAPH_SPACER}\n\n`)
+    // boundary carries a real paragraph break (plain `\n\n`, one blank line —
+    // no NBSP spacer), and NOT a single-newline join.
+    expect(out).toContain('flagged.\n\nThe `auth`')
     expect(out).not.toContain('flagged.\nThe `auth`')
-    // A spacer sits specifically between block 1 and block 2.
-    const b1 = out.indexOf('flagged.')
-    const b2 = out.indexOf('The `auth` handler')
-    expect(out.slice(b1, b2)).toContain(PARAGRAPH_SPACER)
+    // No U+00A0 anywhere.
+    expect(out).not.toContain(String.fromCharCode(0xa0))
   })
 
   it('collapses the untrimmed-trailing-newline stack — no 3+ newline run reaches the wire', () => {
     const out = renderLikeTurnFlush(realBlocks)
     // Block 2's trailing '\n' + the '\n\n' join = 3 newlines; normalize
-    // collapses 3+ runs to '\n\n' and addParagraphSpacers wedges exactly one
-    // spacer, so no doubled/stacked blank run survives.
+    // collapses 3+ runs to '\n\n', so no doubled/stacked blank run survives.
     expect(out).not.toMatch(/\n{3,}/)
-    // One spacer per block transition: 3 blocks → 2 gaps → 2 spacers.
-    const spacerCount = out.split(PARAGRAPH_SPACER).length - 1
-    expect(spacerCount).toBe(2)
+    // One blank-line gap per block transition: 3 blocks → 2 gaps.
+    const gapCount = (out.match(/\n\n/g) ?? []).length
+    expect(gapCount).toBe(2)
   })
 
   it('the whole separated answer stays in one rich chunk here (well under 32768)', () => {
     const out = renderLikeTurnFlush(realBlocks)
     const chunks = splitMarkdownChunks(out, RICH_MESSAGE_MAX_CHARS)
     expect(chunks.length).toBe(1)
-    expect(chunks[0]).toContain(PARAGRAPH_SPACER)
+    expect(chunks[0]).toContain('\n\n')
   })
 
   it('still SUPPRESSES a real transcript that deliberately terminates with a bare NO_REPLY (#2053 guard intact)', () => {
@@ -228,9 +224,9 @@ describe('#2798 turn-flush block separation — real multi-block transcript shap
 // runs (gateway executeReply):
 //   repairEscapedWhitespace -> normalizeParagraphBreaks -> redactOutboundText
 //   -> stripExcessBold(normalizePunctuation) -> scrubVoice
-//   -> addParagraphSpacers (send side)
+// (no send-side paragraph-spacer pass — removed in the #2669 follow-up).
 // The original #2798 change gave turn-flush the paragraph steps + redact +
-// scrub + spacers but OMITTED `stripExcessBold(normalizePunctuation(...))`.
+// scrub but OMITTED `stripExcessBold(normalizePunctuation(...))`.
 // This suite reconstructs the deterministic format chain of BOTH paths (the
 // runtime-only redact + voice-scrub steps are literally the same calls on both
 // paths and are out of scope here) and pins that turn-flush now matches reply
@@ -312,7 +308,7 @@ describe('#2798 turn-flush punctuation/bold parity with reply', () => {
   function formatChain(text: string): string {
     let t = normalizeParagraphBreaks(repairEscapedWhitespace(text))
     t = stripExcessBold(normalizePunctuation(t))
-    return addParagraphSpacers(t)
+    return t
   }
 
   const input =

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -197,9 +197,10 @@ export function decideTurnFlush(input: FlushDecisionInput): FlushDecision {
   // lone `\n` collapses adjacent blocks into one run — on the Bot API 10.1
   // rich-markdown path (#2669) a single newline is a soft break, so the blocks
   // render as an undifferentiated wall-of-text. `\n\n` is the GFM paragraph
-  // separator; the gateway send path then wedges visible spacers into those
-  // gaps via addParagraphSpacers (mirroring the reply path, #2692) so the
-  // paragraphs render with real separation.
+  // separator; the Bot API 10.1 rich renderer shows it as one visible blank
+  // line, so the paragraphs render with real separation on their own (the
+  // former NBSP spacer pass was removed in the #2669 follow-up — it added a
+  // spurious second blank line).
   //
   // The silent-marker guards below are unaffected by this change:
   // isSilentFlushMarker length-guards the whole joined string; the composite /


### PR DESCRIPTION
## Summary

Consolidated fix for four findings from the adversarial review of the Telegram outbound formatting pipeline. The send path is **raw GFM markdown** (HTML conversion was removed in #2669); malformed markdown degrades to plaintext via the parse-reject fallback in `outbound-send-path.ts`. This is a **standalone consolidated formatting release — not the pacer work.**

## The four findings

**F1 (P1) — NBSP paragraph-spacer double-gap (the headline fix).**
`addParagraphSpacers` wedged a U+00A0 spacer paragraph (`\n\n \n\n`) into every prose `\n\n` gap, on the premise that the Bot API 10.1 rich (GFM) renderer collapses `\n\n` *tight*. That premise is **false** for the live renderer, which shows `\n\n` as one normal blank line — so the spacer injected a spurious **second** blank line between every paragraph fleet-wide.
- Removed `addParagraphSpacers` + `PARAGRAPH_SPACER` and all four send-path call sites: `computeEffectiveText` (`outbound-send-path.ts`), the edit path and turn-flush render (`gateway.ts`), and the stream handler (`stream-reply-handler.ts`, whose optional dep was never wired in production — the only caller uses `format:'text'`).
- Paragraph spacing now relies on the plain `\n\n` that `normalizeParagraphBreaks` already guarantees at block boundaries.
- `stripBoundarySpacers` reverts to stripping plain ASCII blank-line runs (its legacy subset behaviour); dead helpers `lastNonBlank`/`nextNonBlank` removed.

**F2 (P2) — dash normalization corrupted markdown link hrefs.**
`normalizePunctuation` masked code spans/fences but **not** link destinations, so an en-dash in a URL became a silently-wrong path and an em-dash became `, ` — the injected space *terminated* the markdown link and leaked the trailing text as prose (`[a](https://x/foo—bar)` → `[a](https://x/foo, bar)`). Now masks the `](href)` destination before the dash passes; the visible **label** still normalizes.

**F3 (P2) — `splitMarkdownChunks` bisected inline entities at the cap.**
Added `backOffOpenInline`, mirroring `backOffOpenFence`/`backOffTableRow`: a cut landing strictly inside a `**bold**` / `` `code` `` / `_italic_` / `[label](href)` span retreats to the span start so no chunk strands an unclosed delimiter. The `hardSliceToCap` fallback still bounds an oversized indivisible region (a span longer than the cap itself).

**F4 (P3) — `repairEscapedWhitespace` mangles literal `\n`/`\t` in prose (e.g. Windows paths).**
Irrelevant on the Linux fleet. **Behaviour unchanged** — added a concise known-issue comment documenting the accepted tradeoff so it isn't a silent surprise.

## Tests

The green suite **pinned** the NBSP double-gap, so it had to be rewritten, not just extended.
- **Rewritten** (assert plain single-blank-line `\n\n`, no U+00A0): `paragraph-normalizer.test.ts`, `format-consistency.test.ts`, `telegram-format.test.ts`, `turn-flush-safety.test.ts`, `stream-reply-handler.test.ts`, `outbound-send-path.test.ts`, `formatting-parse-regression.test.ts`, and the `formatting-torture-set.ts` pipeline comment.
- **Added regression tests:** (a) multi-paragraph text now produces exactly single-blank-line gaps with no NBSP and no `\n\n\n`; (b) `[a](https://x.com/foo—bar)` keeps its href intact (dash not rewritten inside a href) while the label still normalizes; (c) a bold/code/link span straddling the cap splits with balanced delimiters (no unclosed span).

## Test plan

- Scoped `vitest run` on the 7 touched suites + adjacent pipeline suites (card-format, gateway-outbound-redact, render-outbound-chunks, streaming-*, etc.): **446 tests green.**
- `npm run lint` (tsc --noEmit + all 8 guard scripts including `check-bot-api-wrapping`): **clean.**
- CI is the full-suite authority.

## Risk

Low-moderate. F1 changes fleet-wide paragraph rendering (removes one blank line per gap — the intended fix). F2/F3 are narrow, guarded additions. No production code path other than the four spacer call sites changes behaviour; the removed stream-handler dep was never wired in production.

## Job spec

`reference/jobs/talk-to-agents-from-anywhere.md` — outbound messages must render cleanly on the phone surface where the user actually is. The double-gap, corrupted link hrefs, and delimiter-bisected chunks were all direct degradations of that render quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
