### PR TITLE
feat(telegram): humanized, deduped LLM error surfacing (no raw JSON passthrough)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -21,6 +21,7 @@ import { homedir } from 'os'
 
 import { installPluginLogger } from '../plugin-logger.js'
 import { startSessionTail, type SessionEvent, type SessionTailHandle } from '../session-tail.js'
+import { truncateDetailPreservingRequestId } from '../raw-error-scrub.js'
 import {
   startPtyTail,
   V1ToolActivityExtractor,
@@ -851,7 +852,12 @@ if (sessionTailEnabled) {
             type: 'operator_event',
             kind: ev.kind,
             agent: AGENT_NAME,
-            detail: ev.detail.slice(0, 1000),
+            // Preserve the Anthropic request_id through the 1000-char cap: it
+            // sits in the trailing byte-blob (often past char 1000), and it is
+            // the reliable EXACT key for the cross-surface dedup gate. A naive
+            // slice would drop it → the gate degrades to the coarse per-kind key
+            // and wrongly collapses two distinct same-kind errors within 60s.
+            detail: truncateDetailPreservingRequestId(ev.detail, 1000),
             chatId: '',
           })
         } catch (err) {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -316,6 +316,11 @@ import {
 } from '../operator-events.js'
 import { recordOperatorEvent } from '../operator-events-history.js'
 import {
+  parseLlmError,
+  renderLlmError,
+  decideErrorSurface,
+} from '../llm-error-present.js'
+import {
   formatModelUnavailableCard,
   resolveModelUnavailableFromOperatorEvent,
   type ModelUnavailableDetection,
@@ -7924,6 +7929,28 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
       // the old account fails — honest reset messaging on the enriched card.
       void fireFleetAutoFallback(agent, untilMs, modelUnavailable.resetAt)
     }
+  } else if (kind === 'rate-limited' || kind === 'unknown-5xx') {
+    // #llm-error-surfacing — surface #2 (the "🚦 Rate limited" operator card).
+    // The transient rate-limit / overload family used to render the raw
+    // synthetic-error `detail` (bytes and all) via renderOperatorEvent. Route
+    // it through the humanized card instead: JSON-stripped coreText + reset in
+    // LOCAL time. The ErrorPresenceGate is the cross-surface dedup authority —
+    // the reply/done-card surfaces are already suppressed at the transcript
+    // source (session-tail), so the operator card is the sole renderer and
+    // wins the claim; a redundant burst within the collapse window is
+    // suppressed here in addition to the existing 5-min per-kind cooldown.
+    const parsed = parseLlmError(event.detail)
+    const now = Date.now()
+    if (decideErrorSurface(parsed, agent, { claim: true, now }) === 'suppress') {
+      process.stderr.write(
+        `telegram gateway: operator-event collapsed (error-presence-gate) agent=${agent} kind=${kind}\n`,
+      )
+      return
+    }
+    const tz = process.env.SWITCHROOM_TIMEZONE ?? process.env.TZ ?? 'UTC'
+    const r = renderLlmError(parsed, agent, tz, new Date(now))
+    renderedText = r.text
+    renderedKeyboard = r.keyboard
   } else {
     try {
       const r = renderOperatorEvent(event)

--- a/telegram-plugin/llm-error-present.ts
+++ b/telegram-plugin/llm-error-present.ts
@@ -1,0 +1,459 @@
+/**
+ * llm-error-present.ts — humanized, cross-surface-deduped presentation of an
+ * LLM/API error, so a raw `b'{"type":"error",…}'` line never reaches a user.
+ *
+ * THE PROBLEM this closes
+ * -----------------------
+ * One Anthropic error JSONL line fans out to THREE independent render surfaces,
+ * none consulting each other, each historically printing the raw `detail`
+ * string with its `b'{…}'` byte-blob attached:
+ *   1. the agent turn-end "done" card (tool-activity-summary result block),
+ *   2. the operator-event "🚦 Rate limited" card (raw `detail`), and
+ *   3. the reply/answer passthrough (the synthetic-assistant error text relayed
+ *      as the turn's answer).
+ *
+ * This module owns the ONE clean rendering + the ONE dedup authority the three
+ * surfaces consult, so a fan-out produces EXACTLY ONE user-facing message with
+ * NO raw JSON. It reuses the existing classifiers rather than re-deriving them:
+ * `classify429Detail` (throttle-tier.ts), `detectModelUnavailable` /
+ * `parseResetTime` (model-unavailable.ts), `isLitellmProxyLocal429` /
+ * `isTransientUpstreamSignal` (model-unavailable.ts), `classifyClaudeError`
+ * (operator-events.ts). `coreText` is ALWAYS built from a per-kind template —
+ * never from the raw `detail` — and `stripRawErrorBytes` is the belt-and-braces
+ * scrub so even the enrichment `reason` can carry no JSON.
+ *
+ * Pure module: no IPC, no bot, no FS. The only mutable state is the
+ * `ErrorPresenceGate` singleton (an in-memory dedup ledger), driven by an
+ * injectable `now`.
+ */
+
+import {
+  detectModelUnavailable,
+  isLitellmProxyLocal429,
+  parseResetTime,
+} from './model-unavailable.js'
+import { classify429Detail } from './throttle-tier.js'
+import { classifyClaudeError } from './operator-events.js'
+import type { InlineKeyboardMarkup } from './operator-events.js'
+import { looksLikeRawApiError } from './pty-partial-handler.js'
+import { stripRawErrorBytes } from './raw-error-scrub.js'
+import { fmtLocalClock, tzAbbrev } from './shared/local-time.js'
+
+export { stripRawErrorBytes } from './raw-error-scrub.js'
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type LlmErrorKind =
+  | 'rate_limit'
+  | 'overload_529'
+  | 'quota_wall'
+  | 'auth'
+  | 'model_unavailable'
+  | 'transient'
+  | 'unknown'
+
+export type LlmErrorSource = 'anthropic' | 'litellm-local' | 'network'
+
+export interface ParsedLlmError {
+  kind: LlmErrorKind
+  /** Human, JSON-STRIPPED one-liner built from a per-kind template. Never raw. */
+  coreText: string
+  /** Optional extra human context (also JSON-stripped). */
+  reason?: string
+  /** Parsed reset instant, when the source carried one. */
+  resetAt?: Date
+  /** Parsed retry-after window in ms, when the source carried one. */
+  retryAfterMs?: number
+  /** Resolved model id, when the source named one. */
+  model?: string
+  /** Anthropic `request_id`, when present — the strongest dedup key. */
+  requestId?: string
+  source: LlmErrorSource
+  /** True when the harness is still retrying this error internally (mid-retry). */
+  autoRetrying: boolean
+  /** True when the failure is final (NOT an in-flight retry). */
+  terminal: boolean
+}
+
+/** Optional retry-state annotations Claude Code stamps on a retried error line. */
+export interface LlmErrorRetryState {
+  retryAttempt: number | null
+  maxRetries: number | null
+}
+
+// ─── request_id extraction ───────────────────────────────────────────────────
+
+/** Pull an Anthropic `request_id` out of a raw string, or undefined. */
+export function extractRequestId(raw: string): string | undefined {
+  if (typeof raw !== 'string' || raw.length === 0) return undefined
+  const m =
+    raw.match(/["']request[_-]?id["']\s*:\s*["']([A-Za-z0-9._-]+)["']/i) ??
+    raw.match(/\brequest[_-]?id[=:]\s*([A-Za-z0-9._-]+)/i)
+  return m ? m[1] : undefined
+}
+
+/** Pull a resolved model id (`claude-…`, `sr-…`) out of a raw string, or undefined. */
+function extractModel(raw: string): string | undefined {
+  const m = raw.match(/["']?model["']?\s*[=:]\s*["']?((?:claude|sr)[A-Za-z0-9._-]+)/i)
+  return m ? m[1] : undefined
+}
+
+// ─── Parser ──────────────────────────────────────────────────────────────────
+
+const TRANSIENT_KINDS: ReadonlySet<LlmErrorKind> = new Set<LlmErrorKind>([
+  'rate_limit',
+  'overload_529',
+  'transient',
+])
+
+/** The always-actionable kinds — NEVER silenced, even inside a collapse window. */
+export function isActionableKind(kind: LlmErrorKind): boolean {
+  return kind === 'auth' || kind === 'quota_wall'
+}
+
+/**
+ * Parse a raw error string (a session-tail `detail`, an isApiErrorMessage
+ * text, or a raw stderr line) into a structured, JSON-free ParsedLlmError.
+ * Reuses the existing wording classifiers; maps their kinds into this union.
+ */
+export function parseLlmError(
+  raw: string,
+  retryState?: LlmErrorRetryState,
+): ParsedLlmError {
+  const text = typeof raw === 'string' ? raw : ''
+  const requestId = extractRequestId(text)
+  const model = extractModel(text)
+
+  // Reset / retry-after best-effort (Anthropic + relative wordings).
+  const resetAt = parseResetTime(text)
+  const retryAfterMs =
+    resetAt != null ? Math.max(0, resetAt.getTime() - Date.now()) : undefined
+
+  const { kind, source } = classifyKindAndSource(text)
+
+  // Retry / terminal semantics. Only the transient family can be mid-retry;
+  // auth / quota_wall / model_unavailable are terminal by construction.
+  let autoRetrying = false
+  let terminal = true
+  if (TRANSIENT_KINDS.has(kind)) {
+    const { retryAttempt, maxRetries } = retryState ?? { retryAttempt: null, maxRetries: null }
+    if (retryAttempt != null && maxRetries != null) {
+      autoRetrying = retryAttempt < maxRetries
+      terminal = retryAttempt >= maxRetries
+    } else {
+      // No retry annotation: treat as a surfaced (terminal) failure — Claude
+      // writes the user-facing error shape only after its own retries are done.
+      autoRetrying = false
+      terminal = true
+    }
+  }
+
+  const reasonRaw = stripRawErrorBytes(text)
+  const reason = reasonRaw.length > 0 && reasonRaw.length <= 200 ? reasonRaw : undefined
+
+  return {
+    kind,
+    coreText: buildCoreText(kind, source),
+    ...(reason != null ? { reason } : {}),
+    ...(resetAt != null ? { resetAt } : {}),
+    ...(retryAfterMs != null ? { retryAfterMs } : {}),
+    ...(model != null ? { model } : {}),
+    ...(requestId != null ? { requestId } : {}),
+    source,
+    autoRetrying,
+    terminal,
+  }
+}
+
+function classifyKindAndSource(text: string): { kind: LlmErrorKind; source: LlmErrorSource } {
+  const lower = text.toLowerCase()
+
+  // 1. Auth — always terminal, always actionable.
+  const claudeKind = classifyClaudeError({ message: text, type: text })
+  if (claudeKind === 'credentials-expired' || claudeKind === 'credentials-invalid') {
+    return { kind: 'auth', source: 'anthropic' }
+  }
+
+  // 2. LiteLLM-proxy-LOCAL 429 — the proxy's own limiter, never Anthropic.
+  //    Checked before the generic quota/overload matchers because some LiteLLM
+  //    bodies contain the word "limit" that a quota matcher could seize on.
+  if (isLitellmProxyLocal429(text)) {
+    return { kind: 'rate_limit', source: 'litellm-local' }
+  }
+
+  // 3. Model-unavailable detector owns quota-wall / overload / network wording.
+  const mu = detectModelUnavailable(text)
+  if (mu != null) {
+    if (mu.kind === 'quota_exhausted') return { kind: 'quota_wall', source: 'anthropic' }
+    if (mu.kind === 'network') return { kind: 'transient', source: 'network' }
+    // mu.kind === 'overload' | 'rate_limited' — split 529 overload from a 429.
+    if (
+      lower.includes('529') ||
+      lower.includes('overloaded')
+    ) {
+      return { kind: 'overload_529', source: 'anthropic' }
+    }
+    // A 429-family transient. Three-way classify picks the source nuance; all
+    // land on the calm rate_limit kind here.
+    const c = classify429Detail(text)
+    return {
+      kind: 'rate_limit',
+      source: c === 'litellm-local' ? 'litellm-local' : 'anthropic',
+    }
+  }
+
+  // 4. Credit balance is a quota-family wall (actionable).
+  if (claudeKind === 'credit-exhausted') {
+    return { kind: 'quota_wall', source: 'anthropic' }
+  }
+
+  // 5. Bare rate-limit classification from the operator taxonomy.
+  if (claudeKind === 'rate-limited') {
+    return { kind: 'rate_limit', source: 'anthropic' }
+  }
+  if (claudeKind === 'unknown-5xx') {
+    return { kind: 'overload_529', source: 'anthropic' }
+  }
+
+  return { kind: 'unknown', source: 'anthropic' }
+}
+
+function buildCoreText(kind: LlmErrorKind, source: LlmErrorSource): string {
+  switch (kind) {
+    case 'rate_limit':
+      return source === 'litellm-local'
+        ? 'Hit the local proxy rate limit — retrying automatically.'
+        : 'Rate limited by Anthropic — retrying automatically.'
+    case 'overload_529':
+      return 'Anthropic is overloaded (529) — retrying automatically.'
+    case 'quota_wall':
+      return 'Usage limit reached on this Claude subscription.'
+    case 'auth':
+      return 'Claude login needs re-authentication.'
+    case 'model_unavailable':
+      return 'The model is temporarily unavailable.'
+    case 'transient':
+      return source === 'network'
+        ? "Couldn't reach Anthropic (network) — retrying automatically."
+        : 'A temporary upstream hiccup — retrying automatically.'
+    case 'unknown':
+      return 'The model returned an error.'
+  }
+}
+
+// ─── Rendering ───────────────────────────────────────────────────────────────
+
+export interface RenderedLlmError {
+  text: string
+  keyboard?: InlineKeyboardMarkup
+}
+
+/**
+ * Format a reset instant in the operator's local tz plus a relative tail, e.g.
+ * `clears ~4:52pm AEST (~in 38m)`. Returns '' when there is no reset to show.
+ */
+export function formatResetLocal(resetAt: Date | undefined, tz: string, now: Date = new Date()): string {
+  if (resetAt == null) return ''
+  const ms = resetAt.getTime()
+  if (!Number.isFinite(ms)) return ''
+  const clock = fmtLocalClock(ms, tz)
+  const abbrev = tzAbbrev(ms, tz)
+  const rel = formatRelativeTail(ms - now.getTime())
+  return rel ? `clears ~${clock} ${abbrev} (${rel})` : `clears ~${clock} ${abbrev}`
+}
+
+function formatRelativeTail(deltaMs: number): string {
+  if (deltaMs <= 0) return '~now'
+  const totalMin = Math.round(deltaMs / 60_000)
+  if (totalMin < 1) return '~in <1m'
+  if (totalMin < 60) return `~in ${totalMin}m`
+  const hours = Math.floor(totalMin / 60)
+  const mins = totalMin % 60
+  if (hours < 24) return mins > 0 ? `~in ${hours}h ${mins}m` : `~in ${hours}h`
+  const days = Math.floor(hours / 24)
+  const remH = hours % 24
+  return remH > 0 ? `~in ${days}d ${remH}h` : `~in ${days}d`
+}
+
+/**
+ * Render ONE clean card for a parsed LLM error. Action buttons for the
+ * actionable kinds (auth → Reauth, quota_wall → Wait/switch). `agent` is used
+ * in the callback_data (URL-encoded) and the headline; `tz` localizes the reset.
+ */
+export function renderLlmError(
+  parsed: ParsedLlmError,
+  agent: string,
+  tz: string,
+  now: Date = new Date(),
+): RenderedLlmError {
+  const safeAgent = escapeAgent(agent)
+  const emoji = kindEmoji(parsed.kind)
+  const lines: string[] = [`${emoji} ${parsed.coreText} (**${safeAgent}**)`]
+
+  const resetLine = formatResetLocal(parsed.resetAt, tz, now)
+  if (resetLine) lines.push(`_${resetLine}_`)
+
+  if (parsed.model) lines.push(`_model: ${escapeAgent(parsed.model)}_`)
+
+  const text = lines.join('\n')
+
+  switch (parsed.kind) {
+    case 'auth':
+      return {
+        text,
+        keyboard: {
+          inline_keyboard: [
+            [
+              { text: '🔐 Reauth now', callback_data: `op:reauth:${encodeURIComponent(agent)}` },
+              { text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(agent)}` },
+            ],
+          ],
+        },
+      }
+    case 'quota_wall':
+      return {
+        text,
+        keyboard: {
+          inline_keyboard: [
+            [{ text: '⏳ Wait', callback_data: `op:dismiss:${encodeURIComponent(agent)}` }],
+          ],
+        },
+      }
+    default:
+      return { text }
+  }
+}
+
+function kindEmoji(kind: LlmErrorKind): string {
+  switch (kind) {
+    case 'rate_limit':
+      return '🚦'
+    case 'overload_529':
+      return '🔥'
+    case 'quota_wall':
+      return '⚠️'
+    case 'auth':
+      return '🔑'
+    case 'model_unavailable':
+      return '🚧'
+    case 'transient':
+      return '🌐'
+    case 'unknown':
+      return '⚠️'
+  }
+}
+
+/** Minimal markdown-safe agent rendering (mirrors operator-events escapeMarkdown intent). */
+function escapeAgent(s: string): string {
+  return s.replace(/([_*`\[\]])/g, '\\$1')
+}
+
+// ─── Cross-surface dedup: ErrorPresenceGate ──────────────────────────────────
+
+/**
+ * How long ONE terminal error owns the "already surfaced" claim across all
+ * three surfaces. Distinct from — and additional to — the 5-minute per-kind
+ * `shouldEmitOperatorEvent` cooldown (operator-events.ts): that debounces an
+ * error STORM on one surface; this collapses ONE error's FAN-OUT across
+ * surfaces within a single turn.
+ */
+export const ERROR_COLLAPSE_WINDOW_MS = 60_000
+
+/**
+ * A tiny in-memory dedup ledger. The FIRST surface to `claim(key)` within the
+ * collapse window wins (returns true) and renders; every later surface loses
+ * (returns false) and suppresses. Key preference: the Anthropic `request_id`
+ * when present (exact), else a `${kind}:${agent}:${windowBucket}` coarse key so
+ * two distinct-but-unlabelled errors of the same kind within 60s still collapse.
+ */
+export class ErrorPresenceGate {
+  private readonly claims = new Map<string, number>()
+
+  /** Build the dedup key for a parsed error + agent. */
+  keyFor(parsed: Pick<ParsedLlmError, 'kind' | 'requestId'>, agent: string, now: number): string {
+    if (parsed.requestId) return `rid:${parsed.requestId}`
+    const bucket = Math.floor(now / ERROR_COLLAPSE_WINDOW_MS)
+    return `${parsed.kind}:${agent}:${bucket}`
+  }
+
+  /**
+   * Attempt to claim ownership of `key`. Returns true for the first caller
+   * within the window, false for every subsequent caller. Expired claims are
+   * pruned lazily on each call.
+   */
+  claim(key: string, now: number = Date.now()): boolean {
+    this.prune(now)
+    const existing = this.claims.get(key)
+    if (existing != null && now - existing < ERROR_COLLAPSE_WINDOW_MS) {
+      return false
+    }
+    this.claims.set(key, now)
+    return true
+  }
+
+  /** True when `key` is currently claimed (does NOT claim). */
+  isClaimed(key: string, now: number = Date.now()): boolean {
+    const existing = this.claims.get(key)
+    return existing != null && now - existing < ERROR_COLLAPSE_WINDOW_MS
+  }
+
+  private prune(now: number): void {
+    for (const [k, at] of this.claims) {
+      if (now - at >= ERROR_COLLAPSE_WINDOW_MS) this.claims.delete(k)
+    }
+  }
+
+  /** Test-only: forget every claim. */
+  reset(): void {
+    this.claims.clear()
+  }
+}
+
+/** The process-wide gate the three surfaces consult. */
+export const errorPresenceGate = new ErrorPresenceGate()
+
+/**
+ * The single decision a surface makes before rendering a parsed LLM error.
+ * Returns:
+ *   - 'render'   — this surface owns the humanized card, render it.
+ *   - 'suppress' — another surface already owns it (dedup) OR it is a
+ *     transient error the harness is still auto-retrying — stay silent.
+ *
+ * ACTIONABLE kinds (auth / quota_wall) ALWAYS return 'render' — they are never
+ * deduped away and never silenced mid-retry, because the operator must always
+ * see (and be able to act on) a login/quota wall.
+ */
+export function decideErrorSurface(
+  parsed: ParsedLlmError,
+  agent: string,
+  opts: { claim: boolean; now?: number; gate?: ErrorPresenceGate } = { claim: true },
+): 'render' | 'suppress' {
+  const now = opts.now ?? Date.now()
+  const gate = opts.gate ?? errorPresenceGate
+
+  if (isActionableKind(parsed.kind)) {
+    // Always render — but still record the claim so a redundant transient
+    // surface for the same key stays collapsed.
+    if (opts.claim) gate.claim(gate.keyFor(parsed, agent, now), now)
+    return 'render'
+  }
+
+  // Auto-retry silence: a transient error still being retried internally is
+  // NOT surfaced on ANY surface until it goes terminal.
+  if (parsed.autoRetrying && !parsed.terminal) return 'suppress'
+
+  const key = gate.keyFor(parsed, agent, now)
+  if (opts.claim) {
+    return gate.claim(key, now) ? 'render' : 'suppress'
+  }
+  return gate.isClaimed(key, now) ? 'suppress' : 'render'
+}
+
+/**
+ * True when `text` is a raw LLM-error line that a non-card surface (reply /
+ * done-card recap) must NOT relay as the turn's answer. Thin re-export of the
+ * `looksLikeRawApiError` anchors so the reply/recap paths share ONE detector.
+ */
+export function isRawLlmErrorText(text: string): boolean {
+  return looksLikeRawApiError(text)
+}

--- a/telegram-plugin/llm-error-present.ts
+++ b/telegram-plugin/llm-error-present.ts
@@ -35,11 +35,10 @@ import {
 import { classify429Detail } from './throttle-tier.js'
 import { classifyClaudeError } from './operator-events.js'
 import type { InlineKeyboardMarkup } from './operator-events.js'
-import { looksLikeRawApiError } from './pty-partial-handler.js'
-import { stripRawErrorBytes } from './raw-error-scrub.js'
+import { stripRawErrorBytes, extractRequestId } from './raw-error-scrub.js'
 import { fmtLocalClock, tzAbbrev } from './shared/local-time.js'
 
-export { stripRawErrorBytes } from './raw-error-scrub.js'
+export { stripRawErrorBytes, extractRequestId } from './raw-error-scrub.js'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -48,7 +47,6 @@ export type LlmErrorKind =
   | 'overload_529'
   | 'quota_wall'
   | 'auth'
-  | 'model_unavailable'
   | 'transient'
   | 'unknown'
 
@@ -58,8 +56,6 @@ export interface ParsedLlmError {
   kind: LlmErrorKind
   /** Human, JSON-STRIPPED one-liner built from a per-kind template. Never raw. */
   coreText: string
-  /** Optional extra human context (also JSON-stripped). */
-  reason?: string
   /** Parsed reset instant, when the source carried one. */
   resetAt?: Date
   /** Parsed retry-after window in ms, when the source carried one. */
@@ -81,16 +77,7 @@ export interface LlmErrorRetryState {
   maxRetries: number | null
 }
 
-// ─── request_id extraction ───────────────────────────────────────────────────
-
-/** Pull an Anthropic `request_id` out of a raw string, or undefined. */
-export function extractRequestId(raw: string): string | undefined {
-  if (typeof raw !== 'string' || raw.length === 0) return undefined
-  const m =
-    raw.match(/["']request[_-]?id["']\s*:\s*["']([A-Za-z0-9._-]+)["']/i) ??
-    raw.match(/\brequest[_-]?id[=:]\s*([A-Za-z0-9._-]+)/i)
-  return m ? m[1] : undefined
-}
+// ─── model extraction ────────────────────────────────────────────────────────
 
 /** Pull a resolved model id (`claude-…`, `sr-…`) out of a raw string, or undefined. */
 function extractModel(raw: string): string | undefined {
@@ -148,13 +135,9 @@ export function parseLlmError(
     }
   }
 
-  const reasonRaw = stripRawErrorBytes(text)
-  const reason = reasonRaw.length > 0 && reasonRaw.length <= 200 ? reasonRaw : undefined
-
   return {
     kind,
     coreText: buildCoreText(kind, source),
-    ...(reason != null ? { reason } : {}),
     ...(resetAt != null ? { resetAt } : {}),
     ...(retryAfterMs != null ? { retryAfterMs } : {}),
     ...(model != null ? { model } : {}),
@@ -230,8 +213,6 @@ function buildCoreText(kind: LlmErrorKind, source: LlmErrorSource): string {
       return 'Usage limit reached on this Claude subscription.'
     case 'auth':
       return 'Claude login needs re-authentication.'
-    case 'model_unavailable':
-      return 'The model is temporarily unavailable.'
     case 'transient':
       return source === 'network'
         ? "Couldn't reach Anthropic (network) — retrying automatically."
@@ -334,8 +315,6 @@ function kindEmoji(kind: LlmErrorKind): string {
       return '⚠️'
     case 'auth':
       return '🔑'
-    case 'model_unavailable':
-      return '🚧'
     case 'transient':
       return '🌐'
     case 'unknown':
@@ -439,7 +418,14 @@ export function decideErrorSurface(
   }
 
   // Auto-retry silence: a transient error still being retried internally is
-  // NOT surfaced on ANY surface until it goes terminal.
+  // NOT surfaced on ANY surface until it goes terminal. NOTE: in the current
+  // production wiring the operator surface reaches here only AFTER session-tail
+  // (readNew → `errEvent.terminal || !errEvent.transient`) has already dropped
+  // in-flight transients, and the gateway calls `parseLlmError(detail)` with no
+  // retryState (the raw retry annotations don't survive the IPC hop) — so a
+  // production `parsed.autoRetrying` is always false here. This branch is the
+  // module's own guarantee for ANY caller that DOES pass retryState (unit-tested
+  // as such); prod silence is owned upstream at session-tail, not re-derived here.
   if (parsed.autoRetrying && !parsed.terminal) return 'suppress'
 
   const key = gate.keyFor(parsed, agent, now)
@@ -447,13 +433,4 @@ export function decideErrorSurface(
     return gate.claim(key, now) ? 'render' : 'suppress'
   }
   return gate.isClaimed(key, now) ? 'suppress' : 'render'
-}
-
-/**
- * True when `text` is a raw LLM-error line that a non-card surface (reply /
- * done-card recap) must NOT relay as the turn's answer. Thin re-export of the
- * `looksLikeRawApiError` anchors so the reply/recap paths share ONE detector.
- */
-export function isRawLlmErrorText(text: string): boolean {
-  return looksLikeRawApiError(text)
 }

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -13,6 +13,7 @@
  */
 
 import { escapeMarkdown } from './format.js'
+import { stripRawErrorBytes } from './raw-error-scrub.js'
 
 // ─── Taxonomy ────────────────────────────────────────────────────────────────
 
@@ -216,7 +217,12 @@ export interface RenderResult {
  */
 export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
   const agent = escapeMarkdown(ev.agent)
-  const detail = escapeMarkdown(ev.detail)
+  // #llm-error-surfacing: NEVER let a raw API-error byte-blob (`· b'{…}'`,
+  // trailing `{"type":"error"…}` JSON, `API Error:` prefix) reach a user. A
+  // clean human detail passes through unchanged; only smuggled raw bytes are
+  // stripped. This is the belt-and-braces scrub for every card kind — the
+  // rate-limited card in particular used to relay the raw synthetic-error text.
+  const detail = escapeMarkdown(stripRawErrorBytes(ev.detail))
 
   switch (ev.kind) {
     case 'credentials-expired':

--- a/telegram-plugin/raw-error-scrub.ts
+++ b/telegram-plugin/raw-error-scrub.ts
@@ -33,3 +33,41 @@ export function stripRawErrorBytes(raw: string): string {
   s = s.replace(/\s+/g, ' ').replace(/[·:\-\s]+$/g, '').replace(/^[·:\-\s]+/g, '').trim()
   return s
 }
+
+/**
+ * Pull an Anthropic `request_id` out of a raw error string, or undefined. The
+ * id lives in the trailing byte-blob (`…,"request_id":"req_abc"}'`) and can sit
+ * far into a long body — see `truncateDetailPreservingRequestId`. Total.
+ */
+export function extractRequestId(raw: string): string | undefined {
+  if (typeof raw !== 'string' || raw.length === 0) return undefined
+  const m =
+    raw.match(/["']request[_-]?id["']\s*:\s*["']([A-Za-z0-9._-]+)["']/i) ??
+    raw.match(/\brequest[_-]?id[=:]\s*([A-Za-z0-9._-]+)/i)
+  return m ? m[1] : undefined
+}
+
+/**
+ * Truncate an error `detail` to `max` chars WITHOUT losing the `request_id`.
+ *
+ * Why this exists: the bridge forwards operator-event detail truncated to 1000
+ * chars (OPERATOR_EVENT_DETAIL_MAX), but the Anthropic `request_id` lives in the
+ * trailing byte-blob, which can sit PAST char 1000. A naive `slice(0, 1000)`
+ * drops it, so the cross-surface dedup gate silently degrades from the reliable
+ * `rid:` EXACT key to the coarse `${kind}:${agent}:${bucket}` key — collapsing
+ * two genuinely-distinct same-kind errors within 60s into one card.
+ *
+ * Fix: extract the id from the FULL body first; if the plain head would drop it,
+ * append `request_id=<id>` in the freed tail budget (`extractRequestId` matches
+ * that form), keeping the result ≤ `max`. Total — never throws.
+ */
+export function truncateDetailPreservingRequestId(detail: string, max: number): string {
+  if (typeof detail !== 'string') return ''
+  if (detail.length <= max) return detail
+  const rid = extractRequestId(detail)
+  const head = detail.slice(0, max)
+  if (rid == null || head.includes(rid)) return head
+  const suffix = ` request_id=${rid}`
+  const headBudget = Math.max(0, max - suffix.length)
+  return `${detail.slice(0, headBudget)}${suffix}`
+}

--- a/telegram-plugin/raw-error-scrub.ts
+++ b/telegram-plugin/raw-error-scrub.ts
@@ -1,0 +1,35 @@
+/**
+ * raw-error-scrub.ts — the ONE scrubber that removes raw-API-error bytes from a
+ * string before it reaches a user, shared by every surface that might print an
+ * error `detail`.
+ *
+ * Zero dependencies (a leaf module) so both the pure `operator-events.ts`
+ * renderer AND `llm-error-present.ts` can import it without a cycle. Anchored on
+ * the same markers as `looksLikeRawApiError` (pty-partial-handler.ts): the CLI's
+ * Python `· b'{…}'` byte-blob, a trailing `{"type":"error"…}` JSON object, and an
+ * `API Error:` prefix.
+ */
+
+/**
+ * Strip the raw-API-error bytes a source can smuggle into an otherwise-human
+ * string. Total — never throws; a clean human string passes through unchanged
+ * (modulo whitespace tidy-up).
+ */
+export function stripRawErrorBytes(raw: string): string {
+  if (typeof raw !== 'string' || raw.length === 0) return ''
+  let s = raw
+  // 1. `API Error:` / `API Error 429:` prefix anywhere.
+  s = s.replace(/API Error:?\s*\d*\s*/gi, ' ')
+  // 2. Python byte-blob render: ` b'{…}'` or ` b"{…}"` (the CLI's raw-body echo).
+  s = s.replace(/\bb'[^']*'/g, ' ')
+  s = s.replace(/\bb"[^"]*"/g, ' ')
+  // 3. A JSON error object `{"type":"error"…}` (or `'type': 'error'`) and
+  //    everything after it — these blobs are always trailing on the real lines,
+  //    and brace-balanced stripping is not worth the fragility.
+  s = s.replace(/[·\-\s]*\{[\s\S]*?["']type["']\s*:\s*["']error["'][\s\S]*$/i, ' ')
+  // 4. A bare leading/trailing JSON object with no human text around it.
+  s = s.replace(/^\s*\{[\s\S]*\}\s*$/g, ' ')
+  // 5. Tidy: collapse whitespace, drop dangling separators.
+  s = s.replace(/\s+/g, ' ').replace(/[·:\-\s]+$/g, '').replace(/^[·:\-\s]+/g, '').trim()
+  return s
+}

--- a/telegram-plugin/send-gate-observability.ts
+++ b/telegram-plugin/send-gate-observability.ts
@@ -54,6 +54,7 @@
 
 import type { Clock, SendGateStats } from './send-gate.js'
 import type { FloodWindowRecord } from './flood-circuit-breaker.js'
+import { fmtLocalClock, fmtLocalDate, localDay, tzAbbrev } from './shared/local-time.js'
 
 /** One-line, human-scannable summary of the gate counters + global fill. */
 export function formatStatsLine(stats: SendGateStats): string {
@@ -175,59 +176,11 @@ export interface FloodWindowObserver {
 // AEST" reads at a glance where a raw `2026-07-12T23:39:24Z UTC` does not. The
 // machine-facing snapshot LOG lines (config.log → gateway-supervisor.log) keep
 // their epoch/ISO wording; only the chat/card text is localized.
-
-/** Lowercased wall-clock time in `tz`, e.g. `9:39am`. */
-function fmtLocalClock(ms: number, tz: string): string {
-  return new Intl.DateTimeFormat('en-US', {
-    timeZone: tz,
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  })
-    .format(new Date(ms))
-    .replace(/\s([AP])M$/, (_m, p: string) => `${p.toLowerCase()}m`)
-}
-
-/** Compact local date, e.g. `12 Jul` — used only to disambiguate day-spanning windows. */
-function fmtLocalDate(ms: number, tz: string): string {
-  return new Intl.DateTimeFormat('en-GB', {
-    timeZone: tz,
-    day: 'numeric',
-    month: 'short',
-  }).format(new Date(ms))
-}
-
-/** Calendar day (`YYYY-MM-DD`) in `tz`, for a timezone-correct "same day?" test. */
-function localDay(ms: number, tz: string): string {
-  return new Intl.DateTimeFormat('en-CA', {
-    timeZone: tz,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(new Date(ms))
-}
-
-/**
- * Short tz abbreviation for `tz` at `ms`, e.g. `AEST`, `EDT`, `BST`. ICU only
- * surfaces the common alpha abbreviation for a locale whose region matches the
- * zone, so we try a small locale list and take the first genuine abbreviation;
- * zones with no common abbreviation (e.g. Asia/Kolkata) fall back to the offset
- * form (`GMT+5:30`), and `UTC` stays `UTC`.
- */
-function tzAbbrev(ms: number, tz: string): string {
-  const at = new Date(ms)
-  for (const loc of ['en-US', 'en-AU', 'en-GB']) {
-    const v = new Intl.DateTimeFormat(loc, { timeZone: tz, timeZoneName: 'short' })
-      .formatToParts(at)
-      .find((p) => p.type === 'timeZoneName')?.value
-    if (v && !/^(?:GMT|UTC)/i.test(v)) return v
-  }
-  return (
-    new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'short' })
-      .formatToParts(at)
-      .find((p) => p.type === 'timeZoneName')?.value ?? tz
-  )
-}
+//
+// The four wall-clock primitives (fmtLocalClock / fmtLocalDate / localDay /
+// tzAbbrev) now live in shared/local-time.ts so the humanized LLM-error card
+// renders timestamps through the SAME source of truth. The two composers below
+// (fmtLocalStamp / fmtLocalRange) stay here — they are this module's own wording.
 
 /**
  * A single operator-facing local timestamp with tz suffix, e.g. `9:46am AEST`.

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -333,6 +333,22 @@ export function projectTranscriptLine(line: string): SessionEvent[] {
     const message = obj.message as Record<string, unknown> | undefined
     const content = message?.content as Array<Record<string, unknown>> | undefined
     if (!Array.isArray(content)) return []
+    // #llm-error-surfacing — DETERMINISTIC TERMINAL SOURCE. Claude Code writes a
+    // usage-limit / API error as a SYNTHETIC ASSISTANT MESSAGE
+    // (`isApiErrorMessage: true`) whose `content[].text` is the raw error string
+    // ("You've hit your limit · resets … b'{\"type\":\"error\"…}'"). That text
+    // used to fan out to the reply/answer passthrough AND the turn-end "done"
+    // card as if it were the model's answer. It is NOT an answer — it is an
+    // error the operator-event pipeline (detectErrorInTranscriptLine →
+    // humanized card) owns. Suppress the text/thinking events here at the ONE
+    // authoritative source so neither downstream surface can relay the raw
+    // bytes; the humanized card is rendered independently from the same line.
+    if (obj.isApiErrorMessage === true) {
+      const mainModel = message?.model
+      return typeof mainModel === 'string' && !isModelSentinel(mainModel)
+        ? [{ kind: 'model', model: mainModel }]
+        : []
+    }
     const events: SessionEvent[] = []
     // Live model capture: `message.model` is the exact resolved model that
     // served THIS assistant API call. Emit it FIRST (before the content events)

--- a/telegram-plugin/shared/local-time.ts
+++ b/telegram-plugin/shared/local-time.ts
@@ -1,0 +1,69 @@
+/**
+ * shared/local-time.ts — operator-facing local wall-clock formatting.
+ *
+ * These four primitives render an epoch-ms instant in an operator's CONFIGURED
+ * IANA timezone (e.g. `Australia/Melbourne`) instead of UTC, so a card reading
+ * "clears ~4:52pm AEST" is legible at a glance where a raw `…T04:52:00Z UTC`
+ * is not. They were originally file-private in `send-gate-observability.ts`
+ * (#3084 / PR 3205); extracted here so BOTH the flood-window observer and the
+ * humanized LLM-error card (`llm-error-present.ts`) render timestamps through
+ * ONE source of truth rather than two drifting copies.
+ *
+ * Pure — no I/O, no clock, no env. Every function is total (never throws) and
+ * degrades gracefully: an unknown tz falls back to the offset form or the tz
+ * string itself. `tz='UTC'` reproduces the pre-extraction behaviour exactly, so
+ * `send-gate-observability`'s snapshot-locked output is byte-identical.
+ */
+
+/** Lowercased wall-clock time in `tz`, e.g. `9:39am`. */
+export function fmtLocalClock(ms: number, tz: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+    .format(new Date(ms))
+    .replace(/\s([AP])M$/, (_m, p: string) => `${p.toLowerCase()}m`)
+}
+
+/** Compact local date, e.g. `12 Jul` — used only to disambiguate day-spanning windows. */
+export function fmtLocalDate(ms: number, tz: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: tz,
+    day: 'numeric',
+    month: 'short',
+  }).format(new Date(ms))
+}
+
+/** Calendar day (`YYYY-MM-DD`) in `tz`, for a timezone-correct "same day?" test. */
+export function localDay(ms: number, tz: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date(ms))
+}
+
+/**
+ * Short tz abbreviation for `tz` at `ms`, e.g. `AEST`, `EDT`, `BST`. ICU only
+ * surfaces the common alpha abbreviation for a locale whose region matches the
+ * zone, so we try a small locale list and take the first genuine abbreviation;
+ * zones with no common abbreviation (e.g. Asia/Kolkata) fall back to the offset
+ * form (`GMT+5:30`), and `UTC` stays `UTC`.
+ */
+export function tzAbbrev(ms: number, tz: string): string {
+  const at = new Date(ms)
+  for (const loc of ['en-US', 'en-AU', 'en-GB']) {
+    const v = new Intl.DateTimeFormat(loc, { timeZone: tz, timeZoneName: 'short' })
+      .formatToParts(at)
+      .find((p) => p.type === 'timeZoneName')?.value
+    if (v && !/^(?:GMT|UTC)/i.test(v)) return v
+  }
+  return (
+    new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'short' })
+      .formatToParts(at)
+      .find((p) => p.type === 'timeZoneName')?.value ?? tz
+  )
+}

--- a/telegram-plugin/tests/llm-error-present.test.ts
+++ b/telegram-plugin/tests/llm-error-present.test.ts
@@ -22,9 +22,9 @@ import {
   ErrorPresenceGate,
   errorPresenceGate,
   ERROR_COLLAPSE_WINDOW_MS,
-  isRawLlmErrorText,
   type LlmErrorRetryState,
 } from '../llm-error-present.js'
+import { truncateDetailPreservingRequestId } from '../raw-error-scrub.js'
 import { projectTranscriptLine, detectErrorInTranscriptLine } from '../session-tail.js'
 import { renderOperatorEvent, type OperatorEvent } from '../operator-events.js'
 
@@ -132,7 +132,6 @@ describe('parseLlmError — classification table', () => {
     expect(p.model).toBe('claude-opus-4-8')
     expect(p.requestId).toBe('req_abc123')
     assertNoRawBytes(p.coreText)
-    if (p.reason) assertNoRawBytes(p.reason)
   })
 })
 
@@ -211,8 +210,15 @@ describe('ErrorPresenceGate — dedup key semantics', () => {
 })
 
 // ─── auto-retry silence ──────────────────────────────────────────────────────
+//
+// UNIT test of the module's own auto-retry-silence CONTRACT: given a retryState
+// with attempt<max, a transient error is suppressed. This is NOT exercised by
+// the production gateway wiring (it calls `parseLlmError(detail)` without a
+// retryState, and session-tail already drops in-flight transients upstream — see
+// the note in decideErrorSurface). These cases pin the module guarantee for any
+// caller that DOES thread retryState; they do not imply the gateway does.
 
-describe('decideErrorSurface — auto-retry silence', () => {
+describe('decideErrorSurface — auto-retry silence (module contract, retryState-driven)', () => {
   beforeEach(() => errorPresenceGate.reset())
 
   it('a transient 529 mid-retry (attempt<max) is silenced on all surfaces', () => {
@@ -290,13 +296,14 @@ describe('golden fan-out — one 429 line → exactly one JSON-free user message
     expect(projected.some((e) => e.kind === 'text')).toBe(false)
 
     // Surface #2 (operator card): the SAME line is independently classified and
-    // rendered as the ONE humanized card.
+    // rendered as the ONE humanized card. This mirrors the production gateway
+    // call exactly — `parseLlmError(detail)` with NO retryState (session-tail
+    // has already dropped any in-flight transient before forwarding, so the
+    // event that reaches the gateway is terminal by construction).
     const detected = detectErrorInTranscriptLine(line)
     expect(detected).not.toBeNull()
-    const parsed = parseLlmError(detected!.detail, {
-      retryAttempt: detected!.terminal ? 5 : 1,
-      maxRetries: 5,
-    })
+    expect(detected!.terminal).toBe(true)
+    const parsed = parseLlmError(detected!.detail)
     if (decideErrorSurface(parsed, 'gymbro', { claim: true }) === 'render') {
       userMessages.push(renderLlmError(parsed, 'gymbro', 'Australia/Melbourne').text)
     }
@@ -331,11 +338,43 @@ describe('renderOperatorEvent — never relays raw error bytes', () => {
   })
 })
 
-// ─── isRawLlmErrorText passthrough guard ─────────────────────────────────────
+// ─── request_id survives the 1000-char bridge truncation (MEDIUM) ─────────────
 
-describe('isRawLlmErrorText', () => {
-  it('flags raw error lines and passes clean prose', () => {
-    expect(isRawLlmErrorText(`chatter · ${RAW_BYTES}`)).toBe(true)
-    expect(isRawLlmErrorText('here is my normal answer about errors in general')).toBe(false)
+describe('truncateDetailPreservingRequestId — exact dedup key survives truncation', () => {
+  beforeEach(() => errorPresenceGate.reset())
+
+  // A realistic long Anthropic rate-limit body whose request_id sits PAST char
+  // 1000 (the bridge's OPERATOR_EVENT_DETAIL_MAX). `filler` pads the human part.
+  function longRateLimitLine(requestId: string): string {
+    const filler = 'Server is temporarily limiting requests (not your usage limit). '.repeat(30)
+    return `${filler} b'{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"},"request_id":"${requestId}"}'`
+  }
+
+  it('preserves the request_id that a naive slice(0,1000) would drop', () => {
+    const line = longRateLimitLine('req_deadbeef01')
+    expect(line.length).toBeGreaterThan(1000)
+    // A naive slice loses the trailing id...
+    expect(extractRequestId(line.slice(0, 1000))).toBeUndefined()
+    // ...but the preserving truncation keeps it, within budget.
+    const truncated = truncateDetailPreservingRequestId(line, 1000)
+    expect(truncated.length).toBeLessThanOrEqual(1000)
+    expect(extractRequestId(truncated)).toBe('req_deadbeef01')
+  })
+
+  it('two DISTINCT request_ids past char 1000 render TWO messages (exact key still fires)', () => {
+    const now = 9_000_000
+    const messages: string[] = []
+    for (const rid of ['req_aaaaaaaa', 'req_bbbbbbbb']) {
+      // Simulate the bridge hop: truncate-preserving, THEN parse gateway-side.
+      const detail = truncateDetailPreservingRequestId(longRateLimitLine(rid), 1000)
+      const parsed = parseLlmError(detail)
+      expect(parsed.requestId).toBe(rid) // exact key preserved, not coarse fallback
+      if (decideErrorSurface(parsed, 'gymbro', { claim: true, now }) === 'render') {
+        messages.push(renderLlmError(parsed, 'gymbro', 'UTC', new Date(now)).text)
+      }
+    }
+    // Pre-fix (id truncated away) both fall to the SAME `${kind}:${agent}:${bucket}`
+    // key and collapse to ONE. With the id preserved, the exact keys differ → TWO.
+    expect(messages).toHaveLength(2)
   })
 })

--- a/telegram-plugin/tests/llm-error-present.test.ts
+++ b/telegram-plugin/tests/llm-error-present.test.ts
@@ -1,0 +1,341 @@
+/**
+ * llm-error-present.test.ts — outcome-asserting tests for the humanized,
+ * cross-surface-deduped LLM-error surfacing (no raw JSON passthrough).
+ *
+ * Each block is written to FAIL against pre-fix behaviour:
+ *   - golden fan-out: pre-fix, the raw synthetic-error text fanned out to the
+ *     reply + done-card surfaces (≥2 messages, raw bytes) — this asserts EXACTLY
+ *     ONE JSON-free message across all three.
+ *   - operator-card sanitize: pre-fix, renderOperatorEvent embedded the raw
+ *     detail verbatim — this asserts the bytes are gone.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  parseLlmError,
+  renderLlmError,
+  stripRawErrorBytes,
+  extractRequestId,
+  formatResetLocal,
+  decideErrorSurface,
+  isActionableKind,
+  ErrorPresenceGate,
+  errorPresenceGate,
+  ERROR_COLLAPSE_WINDOW_MS,
+  isRawLlmErrorText,
+  type LlmErrorRetryState,
+} from '../llm-error-present.js'
+import { projectTranscriptLine, detectErrorInTranscriptLine } from '../session-tail.js'
+import { renderOperatorEvent, type OperatorEvent } from '../operator-events.js'
+
+// A raw byte-blob every surface must scrub.
+const RAW_BYTES = `b'{"type":"error","error":{"type":"rate_limit_error","message":"rate limit"},"request_id":"req_abc123"}'`
+
+function assertNoRawBytes(text: string): void {
+  expect(text).not.toContain("b'{")
+  expect(text).not.toContain('{"type":"error"')
+  expect(text.toLowerCase()).not.toContain('api error:')
+}
+
+// ─── stripRawErrorBytes ──────────────────────────────────────────────────────
+
+describe('stripRawErrorBytes', () => {
+  it('removes the Python byte-blob, JSON error object, and API Error prefix', () => {
+    const raw = `API Error: 429 Server is temporarily limiting requests · ${RAW_BYTES}`
+    const out = stripRawErrorBytes(raw)
+    assertNoRawBytes(out)
+    expect(out).toContain('Server is temporarily limiting requests')
+  })
+
+  it('passes a clean human string through unchanged (modulo whitespace)', () => {
+    expect(stripRawErrorBytes('Invalid API key')).toBe('Invalid API key')
+    expect(stripRawErrorBytes('Rate limit exceeded')).toBe('Rate limit exceeded')
+    expect(stripRawErrorBytes('')).toBe('')
+  })
+
+  it('strips a bare JSON blob down to empty', () => {
+    expect(stripRawErrorBytes('{"type":"error","error":{"type":"overloaded_error"}}')).toBe('')
+  })
+})
+
+// ─── extractRequestId ────────────────────────────────────────────────────────
+
+describe('extractRequestId', () => {
+  it('pulls an Anthropic request_id from a raw JSON string', () => {
+    expect(extractRequestId(RAW_BYTES)).toBe('req_abc123')
+    expect(extractRequestId('no id here')).toBeUndefined()
+  })
+})
+
+// ─── parser table ────────────────────────────────────────────────────────────
+
+describe('parseLlmError — classification table', () => {
+  it('rate_limit (Anthropic account throttle)', () => {
+    const p = parseLlmError(
+      "This request would exceed your account's rate limit. Please try again later.",
+    )
+    expect(p.kind).toBe('rate_limit')
+    expect(p.source).toBe('anthropic')
+    assertNoRawBytes(p.coreText)
+  })
+
+  it('overload_529', () => {
+    const p = parseLlmError('overloaded_error: Anthropic 529 overloaded')
+    expect(p.kind).toBe('overload_529')
+    expect(p.source).toBe('anthropic')
+    assertNoRawBytes(p.coreText)
+  })
+
+  it('quota_wall with a parsed reset', () => {
+    const p = parseLlmError("You've hit your limit · resets 8:50am (Australia/Melbourne)")
+    expect(p.kind).toBe('quota_wall')
+    expect(p.source).toBe('anthropic')
+    expect(p.resetAt).toBeInstanceOf(Date)
+    expect(p.terminal).toBe(true)
+    assertNoRawBytes(p.coreText)
+  })
+
+  it('litellm-local proxy 429', () => {
+    const p = parseLlmError(
+      'litellm.RateLimitError: Deployment over user-defined ratelimit. tpm limit=8000. current usage=8241',
+    )
+    expect(p.kind).toBe('rate_limit')
+    expect(p.source).toBe('litellm-local')
+    assertNoRawBytes(p.coreText)
+  })
+
+  it('auth (credentials expired)', () => {
+    const p = parseLlmError('authentication_error: OAuth token expired, please refresh')
+    expect(p.kind).toBe('auth')
+    expect(p.source).toBe('anthropic')
+    expect(p.terminal).toBe(true)
+    expect(p.autoRetrying).toBe(false)
+  })
+
+  it('network', () => {
+    const p = parseLlmError('fetch failed: ECONNREFUSED getaddrinfo ENOTFOUND api.anthropic.com')
+    expect(p.kind).toBe('transient')
+    expect(p.source).toBe('network')
+    assertNoRawBytes(p.coreText)
+  })
+
+  it('unknown falls through cleanly', () => {
+    const p = parseLlmError('something entirely unrecognizable happened')
+    expect(p.kind).toBe('unknown')
+    assertNoRawBytes(p.coreText)
+  })
+
+  it('extracts model + requestId, and coreText is JSON-free even from a raw line', () => {
+    const raw = `Server is temporarily limiting requests · model=claude-opus-4-8 · ${RAW_BYTES}`
+    const p = parseLlmError(raw)
+    expect(p.kind).toBe('rate_limit')
+    expect(p.model).toBe('claude-opus-4-8')
+    expect(p.requestId).toBe('req_abc123')
+    assertNoRawBytes(p.coreText)
+    if (p.reason) assertNoRawBytes(p.reason)
+  })
+})
+
+// ─── local-time render ───────────────────────────────────────────────────────
+
+describe('renderLlmError / formatResetLocal — local-time rendering', () => {
+  const tz = 'Australia/Melbourne'
+  // Pin now to a fixed instant. 2026-07-13T06:14:00Z = 4:14pm AEST (winter, +10).
+  const now = new Date('2026-07-13T06:14:00Z')
+
+  it('renders the reset in local wall-clock + relative tail, DST-correct', () => {
+    // resetAt = 2026-07-13T06:52:00Z = 4:52pm AEST, ~38m out.
+    const reset = new Date('2026-07-13T06:52:00Z')
+    const line = formatResetLocal(reset, tz, now)
+    expect(line).toContain('4:52pm')
+    expect(line).toContain('AEST')
+    expect(line).toContain('~in 38m')
+  })
+
+  it('renderLlmError produces a JSON-free card with the local reset', () => {
+    const parsed = parseLlmError(
+      `Server is temporarily limiting requests · resets 4:52pm (Australia/Melbourne) · ${RAW_BYTES}`,
+    )
+    const { text } = renderLlmError(parsed, 'gymbro', tz, now)
+    assertNoRawBytes(text)
+    expect(text).toContain('gymbro')
+    expect(text).toContain('AEST')
+  })
+
+  it('auth + quota_wall cards carry action buttons', () => {
+    const auth = renderLlmError(parseLlmError('authentication_error: token expired'), 'a', tz, now)
+    expect(auth.keyboard?.inline_keyboard.flat().some((b) => b.callback_data?.includes('reauth'))).toBe(true)
+    const quota = renderLlmError(
+      parseLlmError("You've hit your limit · resets 5pm"),
+      'a',
+      tz,
+      now,
+    )
+    expect(quota.keyboard?.inline_keyboard.flat().length).toBeGreaterThan(0)
+  })
+})
+
+// ─── dedup key ───────────────────────────────────────────────────────────────
+
+describe('ErrorPresenceGate — dedup key semantics', () => {
+  let gate: ErrorPresenceGate
+  beforeEach(() => {
+    gate = new ErrorPresenceGate()
+  })
+
+  it('same requestId → collapses to 1', () => {
+    const p = { kind: 'rate_limit' as const, requestId: 'req_x' }
+    const now = 1_000_000
+    const k = gate.keyFor(p, 'agent', now)
+    expect(gate.claim(k, now)).toBe(true)
+    expect(gate.claim(gate.keyFor(p, 'agent', now + 5_000), now + 5_000)).toBe(false)
+  })
+
+  it('different requestId, same kind → 2 distinct claims', () => {
+    const now = 1_000_000
+    expect(gate.claim(gate.keyFor({ kind: 'rate_limit', requestId: 'a' }, 'g', now), now)).toBe(true)
+    expect(gate.claim(gate.keyFor({ kind: 'rate_limit', requestId: 'b' }, 'g', now), now)).toBe(true)
+  })
+
+  it('no requestId, same kind: <window → 1, >window → 2', () => {
+    const now = 5 * ERROR_COLLAPSE_WINDOW_MS
+    const p = { kind: 'rate_limit' as const }
+    expect(gate.claim(gate.keyFor(p, 'g', now), now)).toBe(true)
+    // Within window (same bucket) → suppressed.
+    const within = now + ERROR_COLLAPSE_WINDOW_MS - 1
+    expect(gate.claim(gate.keyFor(p, 'g', within), within)).toBe(false)
+    // Past window (next bucket) → new claim.
+    const past = now + ERROR_COLLAPSE_WINDOW_MS + 1
+    expect(gate.claim(gate.keyFor(p, 'g', past), past)).toBe(true)
+  })
+})
+
+// ─── auto-retry silence ──────────────────────────────────────────────────────
+
+describe('decideErrorSurface — auto-retry silence', () => {
+  beforeEach(() => errorPresenceGate.reset())
+
+  it('a transient 529 mid-retry (attempt<max) is silenced on all surfaces', () => {
+    const retry: LlmErrorRetryState = { retryAttempt: 1, maxRetries: 5 }
+    const p = parseLlmError('overloaded_error 529 overloaded', retry)
+    expect(p.autoRetrying).toBe(true)
+    expect(p.terminal).toBe(false)
+    expect(decideErrorSurface(p, 'g', { claim: true })).toBe('suppress')
+  })
+
+  it('the same 529 at attempt>=max renders exactly one card', () => {
+    const retry: LlmErrorRetryState = { retryAttempt: 5, maxRetries: 5 }
+    const p = parseLlmError('overloaded_error 529 overloaded', retry)
+    expect(p.autoRetrying).toBe(false)
+    expect(p.terminal).toBe(true)
+    expect(decideErrorSurface(p, 'g', { claim: true })).toBe('render')
+    // A second surface for the same terminal error collapses.
+    expect(decideErrorSurface(p, 'g', { claim: true })).toBe('suppress')
+  })
+})
+
+// ─── actionable never suppressed ─────────────────────────────────────────────
+
+describe('decideErrorSurface — actionable kinds never suppressed', () => {
+  beforeEach(() => errorPresenceGate.reset())
+
+  it('auth + quota_wall always render even inside an active collapse window', () => {
+    const auth = parseLlmError('authentication_error: credentials expired')
+    const quota = parseLlmError("You've hit your limit · resets 5pm")
+    expect(isActionableKind(auth.kind)).toBe(true)
+    expect(isActionableKind(quota.kind)).toBe(true)
+    // Pre-claim the same-kind window key to simulate a busy collapse window.
+    const now = 2_000_000
+    errorPresenceGate.claim(errorPresenceGate.keyFor(auth, 'g', now), now)
+    errorPresenceGate.claim(errorPresenceGate.keyFor(quota, 'g', now), now)
+    expect(decideErrorSurface(auth, 'g', { claim: true, now })).toBe('render')
+    expect(decideErrorSurface(quota, 'g', { claim: true, now })).toBe('render')
+  })
+})
+
+// ─── golden fan-out ──────────────────────────────────────────────────────────
+
+describe('golden fan-out — one 429 line → exactly one JSON-free user message', () => {
+  beforeEach(() => errorPresenceGate.reset())
+
+  // The v2.1.x synthetic-assistant usage/rate-limit shape: the raw error text
+  // lives inside message.content[].text, with the byte-blob attached.
+  const line = JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [
+        {
+          type: 'text',
+          text: `Server is temporarily limiting requests (not your usage limit) · resets 4:52pm (Australia/Melbourne) · ${RAW_BYTES}`,
+        },
+      ],
+    },
+    error: 'rate_limit',
+    isApiErrorMessage: true,
+    apiErrorStatus: 429,
+  })
+
+  it('starves the reply + done-card surfaces and renders one operator card', () => {
+    const userMessages: string[] = []
+
+    // Surfaces #1 (done-card recap) and #3 (reply passthrough) both derive from
+    // the projected transcript `text` events. Post-fix: NO text/thinking event
+    // is projected for an isApiErrorMessage line, so neither surface can relay
+    // the raw bytes as the turn's answer.
+    const projected = projectTranscriptLine(line)
+    for (const ev of projected) {
+      if (ev.kind === 'text') userMessages.push(`reply:${ev.text}`)
+    }
+    expect(projected.some((e) => e.kind === 'text')).toBe(false)
+
+    // Surface #2 (operator card): the SAME line is independently classified and
+    // rendered as the ONE humanized card.
+    const detected = detectErrorInTranscriptLine(line)
+    expect(detected).not.toBeNull()
+    const parsed = parseLlmError(detected!.detail, {
+      retryAttempt: detected!.terminal ? 5 : 1,
+      maxRetries: 5,
+    })
+    if (decideErrorSurface(parsed, 'gymbro', { claim: true }) === 'render') {
+      userMessages.push(renderLlmError(parsed, 'gymbro', 'Australia/Melbourne').text)
+    }
+
+    // EXACTLY ONE user-facing message, and it carries no raw bytes.
+    expect(userMessages).toHaveLength(1)
+    assertNoRawBytes(userMessages[0])
+  })
+})
+
+// ─── operator-card sanitize (surface #2 regression) ──────────────────────────
+
+describe('renderOperatorEvent — never relays raw error bytes', () => {
+  function ev(kind: OperatorEvent['kind'], detail: string): OperatorEvent {
+    return { kind, agent: 'g', detail, suggestedActions: [], firstSeenAt: new Date() }
+  }
+
+  it('strips raw bytes from a rate-limited detail', () => {
+    const { text } = renderOperatorEvent(ev('rate-limited', `Rate limited · ${RAW_BYTES}`))
+    assertNoRawBytes(text)
+    expect(text).toContain('Rate limited')
+  })
+
+  it('strips raw bytes from an unknown-4xx detail', () => {
+    const { text } = renderOperatorEvent(ev('unknown-4xx', `API Error: 400 bad · ${RAW_BYTES}`))
+    assertNoRawBytes(text)
+  })
+
+  it('leaves a clean detail intact', () => {
+    const { text } = renderOperatorEvent(ev('credentials-expired', 'token expired 2026-04-01'))
+    expect(text).toContain('token expired 2026-04-01')
+  })
+})
+
+// ─── isRawLlmErrorText passthrough guard ─────────────────────────────────────
+
+describe('isRawLlmErrorText', () => {
+  it('flags raw error lines and passes clean prose', () => {
+    expect(isRawLlmErrorText(`chatter · ${RAW_BYTES}`)).toBe(true)
+    expect(isRawLlmErrorText('here is my normal answer about errors in general')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

One Anthropic error JSONL line fans out to **three** independent render surfaces, none consulting each other, each printing the raw `detail` string with `b'{\"type\":\"error\",…}'` attached:

1. Agent turn-end **"done" card** — `tool-activity-summary.ts` result block (the error text becomes the "answer").
2. Operator-event **"🚦 Rate limited"** — `operator-events.ts` rate-limited case (raw `detail`).
3. **Reply/answer passthrough** — the reply path relays the synthetic-assistant error text as the turn's answer.

Shared origin: `session-tail.ts` `detectErrorInTranscriptLine()` sets `detail` verbatim. The PTY-tail leak was already fixed (`looksLikeRawApiError`); this closes the surviving reply/card passthrough.

## What lands

- **`llm-error-present.ts`** (new pure module): `parseLlmError` (reuses `classify429Detail`, `detectModelUnavailable`/`parseResetTime`, `isLitellmProxyLocal429`, `classifyClaudeError`; adds `request_id` + `model` extraction), `renderLlmError` (one clean card, reset in **local time** + relative tail e.g. `clears ~4:52pm AEST (~in 38m)`, action buttons for auth/quota), and the **`ErrorPresenceGate`** singleton (`claim(key, now)` — `request_id` key when present, else `${kind}:${agent}:${bucket}`; `ERROR_COLLAPSE_WINDOW_MS=60_000`, distinct from + additional to the 5-min per-kind cooldown). `coreText` is always template-built, never raw.
- **`raw-error-scrub.ts`** (new leaf): `stripRawErrorBytes` — removes ` b'{…}'`, trailing `{\"type\":\"error\"…}` JSON, `API Error:` prefix. Shared by the pure operator renderer and the new module without an import cycle.
- **`shared/local-time.ts`** (new): `fmtLocalClock`/`fmtLocalDate`/`tzAbbrev`/`localDay` extracted + exported from `send-gate-observability.ts`, re-imported there — output **snapshot-locked unchanged** (its 21 tests stay green).

## Dedup mechanism (deterministic, not a race)

- **session-tail `projectTranscriptLine`**: the `isApiErrorMessage` synthetic-assistant line no longer emits its raw error text — the authoritative terminal source — so the reply passthrough **and** the done-card recap are starved at the root.
- **gateway `emitGatewayOperatorEvent`**: the rate-limited / unknown-5xx card renders via `renderLlmError` (JSON-stripped, local-time reset) and consults the `ErrorPresenceGate`.
- **`renderOperatorEvent`**: belt-and-braces `stripRawErrorBytes` on every card's detail.

**Auto-retry silence**: `autoRetrying && !terminal` transients are suppressed on all surfaces; `auth`/`quota_wall` are never silenced and always render with buttons, even inside an active collapse window.

## Tests (outcome-asserting, fail pre-fix)

`telegram-plugin/tests/llm-error-present.test.ts` — golden fan-out (one 429 line → exactly one JSON-free message across all 3 surfaces), parser table, local-time render (DST-correct AEST), dedup-key semantics, auto-retry silence, actionable-never-suppressed, operator-card sanitize regression. 26 tests.

Scoped vitest for the touched files + `npm run lint` (tsc --noEmit + all repo checks) pass locally. CI is the merge authority.

## JTBD / verdict

Serves **visibility** (a user never sees a raw byte-blob as their answer) under `reference/jobs/know-what-my-agent-is-doing`. Crosses no invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)