### PR TITLE
feat(litellm-pacer): cooldown-hold + hard-wait backstop (throughput safety L1)

### DIFF
--- a/docker/litellm-pacer/README.md
+++ b/docker/litellm-pacer/README.md
@@ -81,16 +81,22 @@ regimes, plus one absolute backstop:
   `PACE_COOLDOWN_HOLD_CEILING_S`. **Gated OFF by default** so merge + redeploy is
   behaviour-neutral until the env is set at rollout.
 - **Absolute backstop**: `PACE_HARD_MAX_WAIT_S` caps *any* wait in *either*
-  regime, enforced on every iteration of the wait loop, so a bug in the hold
-  logic can never wedge a request longer than this. **Active by default** — it
-  only ever shortens a pathological wait (default 45 > `MAX_WAIT_S`, so it never
-  fires during normal burst-smoothing).
+  regime, checked on every iteration of the wait loop, so a bug in the hold
+  logic can't wedge a request meaningfully past it. The true worst-case wait is
+  `PACE_HARD_MAX_WAIT_S` + at most one backoff interval + the final admit-check
+  latency (≈46s for the default 45s), since the loop only notices the deadline
+  between admit attempts — not a to-the-millisecond ceiling. **Active by
+  default** — it only ever shortens a pathological wait (default 45 >
+  `MAX_WAIT_S`, so it never fires during normal burst-smoothing). The value is
+  also clamped at config load into `[PACE_MAX_WAIT_S, 280]` (280 < the 300s
+  gateway silence watchdog), so an env misconfig can't drop it below the
+  smoothing ceiling or push it into hang-looks-like territory.
 
 | Knob                          | Code default | Active by default? | Rollout value | Meaning |
 |-------------------------------|:------------:|:------------------:|:-------------:|---------|
-| `PACE_HARD_MAX_WAIT_S`        |      45      | yes (only shortens) |      45       | Absolute cap on any pacer wait, every regime, every iteration. Keep `< 300` (gateway silence watchdog) and `>= PACE_MAX_WAIT_S`. |
+| `PACE_HARD_MAX_WAIT_S`        |      45      | yes (only shortens) |      45       | Absolute cap on any pacer wait, every regime, checked every iteration. Clamped at load into `[PACE_MAX_WAIT_S, 280]` (280 < the 300s gateway silence watchdog), so an out-of-range env value is corrected automatically. |
 | `PACE_COOLDOWN_HOLD`          |    `false`   |  no (gate)          |    `true`     | Enables the cooldown-HOLD regime. Off = pre-L1 behaviour (fail open at `MAX_WAIT_S` even during a cooldown). |
-| `PACE_COOLDOWN_HOLD_CEILING_S`|      60      |  only when hold on  |      60       | Max hold duration during an active cooldown. Keep `<= PACE_MAX_COOLDOWN_S`. |
+| `PACE_COOLDOWN_HOLD_CEILING_S`|      60      |  only when hold on  |      60       | Max hold duration during an active cooldown. Clamped at load to `<= PACE_MAX_COOLDOWN_S`. |
 | `PACE_RELEASE_JITTER_S`       |      1.0     |  only when holding  |     1.0       | Extra jitter window added to the backoff while holding, so held requests re-admit spread across this window when the cooldown elapses (thundering-herd guard) instead of stampeding one 1s window and re-tripping the 429. |
 
 **Rollout env** (set alongside the existing live overrides in the deployed
@@ -105,7 +111,7 @@ separate from this repo change):
 ```
 
 Until `PACE_COOLDOWN_HOLD=true` is set, the only active change vs. today is the
-45s absolute cap, which can only ever shorten a pathological (>45s) wait.
+absolute cap, which can only ever shorten a pathological (roughly >45s) wait.
 
 ## Sync / redeploy step
 

--- a/docker/litellm-pacer/README.md
+++ b/docker/litellm-pacer/README.md
@@ -67,6 +67,46 @@ preserved here unchanged:
 change the code defaults here to chase a live value; the repo copy stays the
 safe baseline and the deployment layer owns the operating point.
 
+## Layer 1 — cooldown-hold + hard-wait backstop (throughput safety)
+
+Splits the single fail-open wait ceiling in `async_pre_call_hook` into two
+regimes, plus one absolute backstop:
+
+- **Burst-smoothing regime** (admission blocked only by concurrency/RPM/RPS, no
+  active cooldown): unchanged — wait up to `PACE_MAX_WAIT_S` then fail open.
+  Leaking here is benign smoothing.
+- **Cooldown-HOLD regime** (Redis `cooldown_until` is in the future — Anthropic
+  has *signalled* a throttle): instead of leaking at the ~12s burst ceiling,
+  keep holding until the cooldown elapses, bounded by
+  `PACE_COOLDOWN_HOLD_CEILING_S`. **Gated OFF by default** so merge + redeploy is
+  behaviour-neutral until the env is set at rollout.
+- **Absolute backstop**: `PACE_HARD_MAX_WAIT_S` caps *any* wait in *either*
+  regime, enforced on every iteration of the wait loop, so a bug in the hold
+  logic can never wedge a request longer than this. **Active by default** — it
+  only ever shortens a pathological wait (default 45 > `MAX_WAIT_S`, so it never
+  fires during normal burst-smoothing).
+
+| Knob                          | Code default | Active by default? | Rollout value | Meaning |
+|-------------------------------|:------------:|:------------------:|:-------------:|---------|
+| `PACE_HARD_MAX_WAIT_S`        |      45      | yes (only shortens) |      45       | Absolute cap on any pacer wait, every regime, every iteration. Keep `< 300` (gateway silence watchdog) and `>= PACE_MAX_WAIT_S`. |
+| `PACE_COOLDOWN_HOLD`          |    `false`   |  no (gate)          |    `true`     | Enables the cooldown-HOLD regime. Off = pre-L1 behaviour (fail open at `MAX_WAIT_S` even during a cooldown). |
+| `PACE_COOLDOWN_HOLD_CEILING_S`|      60      |  only when hold on  |      60       | Max hold duration during an active cooldown. Keep `<= PACE_MAX_COOLDOWN_S`. |
+| `PACE_RELEASE_JITTER_S`       |      1.0     |  only when holding  |     1.0       | Extra jitter window added to the backoff while holding, so held requests re-admit spread across this window when the cooldown elapses (thundering-herd guard) instead of stampeding one 1s window and re-tripping the 429. |
+
+**Rollout env** (set alongside the existing live overrides in the deployed
+`docker-compose.yml`, then redeploy litellm — this is the gated ROLLOUT step,
+separate from this repo change):
+
+```yaml
+- 'PACE_HARD_MAX_WAIT_S=45'
+- 'PACE_COOLDOWN_HOLD=true'
+- 'PACE_COOLDOWN_HOLD_CEILING_S=60'
+- 'PACE_RELEASE_JITTER_S=1.0'
+```
+
+Until `PACE_COOLDOWN_HOLD=true` is set, the only active change vs. today is the
+45s absolute cap, which can only ever shorten a pathological (>45s) wait.
+
 ## Sync / redeploy step
 
 After changing `custom_pacing.py` here (and getting it merged):

--- a/docker/litellm-pacer/custom_pacing.py
+++ b/docker/litellm-pacer/custom_pacing.py
@@ -49,6 +49,7 @@ the proxy's sys.path). See PLAN.md for exact compose + apply steps.
 
 import asyncio
 import os
+import random
 import time
 import uuid
 from typing import Any, Optional
@@ -89,6 +90,32 @@ class _Cfg:
     # Poll interval + jitter while waiting for a slot / rate window.
     POLL_MIN_S = _float_env("PACE_POLL_MIN_S", 0.10)
     POLL_MAX_S = _float_env("PACE_POLL_MAX_S", 0.40)
+
+    # --- Layer 1: cooldown-hold + hard-wait backstop (throughput safety) ------
+    # ABSOLUTE backstop on ANY wait in the pacer, in EITHER regime. Enforced on
+    # every iteration of the wait loop (see async_pre_call_hook) so a bug in the
+    # cooldown-hold logic can never wedge a request longer than this. Must stay
+    # strictly below the gateway's 300s silence watchdog and below claude's own
+    # retry budget. ACTIVE BY DEFAULT: it only ever SHORTENS a pathological wait,
+    # and with the default 45 (> MAX_WAIT_S's 12/20) it never fires during normal
+    # burst-smoothing, so turning it on is behaviour-neutral. Keep >= MAX_WAIT_S.
+    HARD_MAX_WAIT_S = _float_env("PACE_HARD_MAX_WAIT_S", 45.0)
+    # Gate for the cooldown-HOLD regime. OFF by default => behaviour is identical
+    # to pre-L1 (fail open at MAX_WAIT_S even during a signalled cooldown). Set
+    # PACE_COOLDOWN_HOLD=true at rollout to hold the line through a cooldown.
+    COOLDOWN_HOLD = os.getenv("PACE_COOLDOWN_HOLD", "false").lower() == "true"
+    # Ceiling on how long the cooldown-HOLD regime will queue a request while a
+    # fleet cooldown is active. Naturally bounded by MAX_COOLDOWN_S too; keep
+    # <= MAX_COOLDOWN_S. Only consulted when COOLDOWN_HOLD is on, and always
+    # dominated by HARD_MAX_WAIT_S.
+    COOLDOWN_HOLD_CEILING_S = _float_env("PACE_COOLDOWN_HOLD_CEILING_S", 60.0)
+    # Extra jitter window (seconds) added to the backoff WHILE HOLDING during a
+    # cooldown, so that when the cooldown elapses the queued fleet re-admits
+    # spread across this window instead of stampeding the same 1s and instantly
+    # re-tripping the 429 that set the cooldown. Only applied in the hold regime
+    # (which is off by default), so it is behaviour-neutral until hold is on.
+    RELEASE_JITTER_S = _float_env("PACE_RELEASE_JITTER_S", 1.0)
+
     # Master on/off. Set PACE_ENABLED=false to make the hook a pure no-op
     # without touching config wiring.
     ENABLED = os.getenv("PACE_ENABLED", "true").lower() != "false"
@@ -180,6 +207,20 @@ class FleetPacer(CustomLogger):
         except Exception:
             return 0.0
 
+    def _backoff_sleep_s(self, holding: bool) -> float:
+        """Jittered backoff between admit attempts. The base poll jitter already
+        de-synchronizes the fleet during ordinary polling. In the cooldown-HOLD
+        regime we add an extra bounded release-jitter term (RELEASE_JITTER_S) so
+        that when the cooldown elapses the queued requests re-admit spread across
+        that window instead of stampeding the same 1s window and immediately
+        re-tripping the 429 that set the cooldown (thundering-herd guard). Only
+        widened while holding; the burst-smoothing regime keeps the original
+        POLL_MIN..POLL_MAX behaviour."""
+        base = random.uniform(_Cfg.POLL_MIN_S, _Cfg.POLL_MAX_S)
+        if holding and _Cfg.RELEASE_JITTER_S > 0:
+            base += random.uniform(0.0, _Cfg.RELEASE_JITTER_S)
+        return base
+
     async def _try_admit(self, r, pace_id: str) -> bool:
         """One ATOMIC admission attempt via Lua. Returns True if a
         concurrency slot + rate window was granted (and the request
@@ -235,25 +276,55 @@ class FleetPacer(CustomLogger):
             return data  # fail open
 
         pace_id = uuid.uuid4().hex
-        deadline = time.time() + _Cfg.MAX_WAIT_S
+        start = time.time()
+        # ABSOLUTE backstop: no wait in EITHER regime may exceed this. Computed
+        # once, checked first on every iteration below — unbypassable by the
+        # regime logic. This is the load-bearing safety invariant.
+        hard_deadline = start + _Cfg.HARD_MAX_WAIT_S
         admitted = False
         try:
             while True:
                 if await self._try_admit(r, pace_id):
                     admitted = True
                     break
-                if time.time() >= deadline:
-                    # Fail open: never reject, just proceed after the ceiling.
+                now = time.time()
+                # (1) ABSOLUTE BACKSTOP — enforced FIRST, on every iteration, so
+                # a bug in the cooldown-hold branch below can never wedge a
+                # request past HARD_MAX_WAIT_S. Do NOT move this inside a
+                # conditional or below the regime logic.
+                if now >= hard_deadline:
                     verbose_proxy_logger.warning(
-                        "custom_pacing: wait ceiling %.1fs hit, admitting unpaced (fail open)",
-                        _Cfg.MAX_WAIT_S,
+                        "custom_pacing: HARD wait cap %.1fs hit, admitting unpaced (fail open)",
+                        _Cfg.HARD_MAX_WAIT_S,
                     )
                     break
-                # Bounded jittered backoff; jitter de-synchronizes the fleet
-                # so releases don't thunder.
-                import random
-
-                await asyncio.sleep(random.uniform(_Cfg.POLL_MIN_S, _Cfg.POLL_MAX_S))
+                # (2) Pick this iteration's regime ceiling:
+                #   * burst-smoothing (no active cooldown): the short MAX_WAIT_S
+                #     ceiling then benign fail-open — leaking here is fine.
+                #   * cooldown-HOLD (a fleet cooldown is in the future: Anthropic
+                #     has SIGNALLED a throttle): do NOT fail open at MAX_WAIT_S;
+                #     keep holding until the cooldown elapses, bounded by
+                #     COOLDOWN_HOLD_CEILING_S (and, above, by the hard cap).
+                # The hold regime is gated OFF by default, so with default config
+                # this reduces exactly to the pre-L1 MAX_WAIT_S ceiling.
+                ceiling = _Cfg.MAX_WAIT_S
+                holding = False
+                if _Cfg.COOLDOWN_HOLD:
+                    remaining = await self._cooldown_remaining(r)
+                    if remaining > 0:
+                        holding = True
+                        ceiling = _Cfg.COOLDOWN_HOLD_CEILING_S
+                if now - start >= ceiling:
+                    # Fail open: never reject, just proceed after the ceiling.
+                    verbose_proxy_logger.warning(
+                        "custom_pacing: %s wait ceiling %.1fs hit, admitting unpaced (fail open)",
+                        "cooldown-hold" if holding else "burst",
+                        ceiling,
+                    )
+                    break
+                # (3) Bounded jittered backoff; jitter de-synchronizes the fleet
+                # so releases don't thunder (extra release jitter while holding).
+                await asyncio.sleep(self._backoff_sleep_s(holding))
         except Exception as e:
             verbose_proxy_logger.debug("custom_pacing: pre_call error (fail open): %s", e)
 

--- a/docker/litellm-pacer/custom_pacing.py
+++ b/docker/litellm-pacer/custom_pacing.py
@@ -72,6 +72,33 @@ def _float_env(name: str, default: float) -> float:
         return default
 
 
+# The gateway nulls a silent turn at SILENCE_FALLBACK_MS (default 300000ms /
+# 300s). A pacer hold that approached that would look like a hang, so the hard
+# cap is clamped strictly below it with margin. Named so the invariant is one
+# obvious constant, not a magic number buried in an expression.
+_PACE_WATCHDOG_SAFE_CEILING_S = 280.0
+
+
+def _clamp_hard_max_wait(
+    hard: float, max_wait: float, watchdog_ceiling: float = _PACE_WATCHDOG_SAFE_CEILING_S
+) -> float:
+    """Runtime-enforce the absolute-cap invariants regardless of env overrides,
+    so a deploy-time misconfig can't silently defeat them:
+      * never BELOW the burst-smoothing ceiling (a hard cap under MAX_WAIT_S
+        would shorten a normal, benign wait), and
+      * never AT/ABOVE the gateway silence watchdog (a hold that long looks
+        like a hang to the watchdog).
+    Deterministic control, not a test-only assertion."""
+    return min(max(hard, max_wait), watchdog_ceiling)
+
+
+def _clamp_hold_ceiling(ceiling: float, max_cooldown: float) -> float:
+    """A cooldown-hold can never usefully queue longer than the cooldown itself
+    can be parked (MAX_COOLDOWN_S), so clamp the hold ceiling down to it
+    regardless of env override."""
+    return min(ceiling, max_cooldown)
+
+
 class _Cfg:
     # Max simultaneous upstream Anthropic requests across the whole fleet.
     MAX_CONCURRENCY = _int_env("PACE_MAX_CONCURRENCY", 8)
@@ -92,23 +119,31 @@ class _Cfg:
     POLL_MAX_S = _float_env("PACE_POLL_MAX_S", 0.40)
 
     # --- Layer 1: cooldown-hold + hard-wait backstop (throughput safety) ------
-    # ABSOLUTE backstop on ANY wait in the pacer, in EITHER regime. Enforced on
+    # ABSOLUTE backstop on ANY wait in the pacer, in EITHER regime. Checked on
     # every iteration of the wait loop (see async_pre_call_hook) so a bug in the
-    # cooldown-hold logic can never wedge a request longer than this. Must stay
-    # strictly below the gateway's 300s silence watchdog and below claude's own
-    # retry budget. ACTIVE BY DEFAULT: it only ever SHORTENS a pathological wait,
-    # and with the default 45 (> MAX_WAIT_S's 12/20) it never fires during normal
-    # burst-smoothing, so turning it on is behaviour-neutral. Keep >= MAX_WAIT_S.
-    HARD_MAX_WAIT_S = _float_env("PACE_HARD_MAX_WAIT_S", 45.0)
+    # cooldown-hold logic can never wedge a request meaningfully past it — the
+    # true worst case is HARD_MAX_WAIT_S + at most one backoff interval + the
+    # admit-check latency (~a second), not a hard ceiling to the millisecond.
+    # ACTIVE BY DEFAULT: it only ever SHORTENS a pathological wait, and with the
+    # default 45 (> MAX_WAIT_S's 12/20) it never fires during normal burst-
+    # smoothing, so it is behaviour-neutral. Clamped at load into
+    # [MAX_WAIT_S, _PACE_WATCHDOG_SAFE_CEILING_S] so an env misconfig can't put
+    # it below the smoothing ceiling or above the silence watchdog.
+    HARD_MAX_WAIT_S = _clamp_hard_max_wait(
+        _float_env("PACE_HARD_MAX_WAIT_S", 45.0), MAX_WAIT_S
+    )
     # Gate for the cooldown-HOLD regime. OFF by default => behaviour is identical
     # to pre-L1 (fail open at MAX_WAIT_S even during a signalled cooldown). Set
     # PACE_COOLDOWN_HOLD=true at rollout to hold the line through a cooldown.
     COOLDOWN_HOLD = os.getenv("PACE_COOLDOWN_HOLD", "false").lower() == "true"
     # Ceiling on how long the cooldown-HOLD regime will queue a request while a
-    # fleet cooldown is active. Naturally bounded by MAX_COOLDOWN_S too; keep
-    # <= MAX_COOLDOWN_S. Only consulted when COOLDOWN_HOLD is on, and always
-    # dominated by HARD_MAX_WAIT_S.
-    COOLDOWN_HOLD_CEILING_S = _float_env("PACE_COOLDOWN_HOLD_CEILING_S", 60.0)
+    # fleet cooldown is active. Clamped at load to <= MAX_COOLDOWN_S (a hold can
+    # never usefully outlast the cooldown that can be parked) regardless of env
+    # override. Only consulted when COOLDOWN_HOLD is on, and always dominated by
+    # HARD_MAX_WAIT_S.
+    COOLDOWN_HOLD_CEILING_S = _clamp_hold_ceiling(
+        _float_env("PACE_COOLDOWN_HOLD_CEILING_S", 60.0), MAX_COOLDOWN_S
+    )
     # Extra jitter window (seconds) added to the backoff WHILE HOLDING during a
     # cooldown, so that when the cooldown elapses the queued fleet re-admits
     # spread across this window instead of stampeding the same 1s and instantly
@@ -276,10 +311,15 @@ class FleetPacer(CustomLogger):
             return data  # fail open
 
         pace_id = uuid.uuid4().hex
-        start = time.time()
-        # ABSOLUTE backstop: no wait in EITHER regime may exceed this. Computed
-        # once, checked first on every iteration below — unbypassable by the
-        # regime logic. This is the load-bearing safety invariant.
+        # Loop deadline math uses a MONOTONIC clock so a backward wall-clock/NTP
+        # step can never extend a hold. (Redis cooldown_until stays wall-clock —
+        # see _cooldown_remaining — and is never compared against these values.)
+        start = time.monotonic()
+        # ABSOLUTE backstop: computed once, checked FIRST on every iteration
+        # below. It bounds the wait to HARD_MAX_WAIT_S plus at most one more
+        # backoff interval and the final admit-check latency (the loop can only
+        # notice the deadline between attempts) — the load-bearing safety bound,
+        # not a to-the-millisecond ceiling.
         hard_deadline = start + _Cfg.HARD_MAX_WAIT_S
         admitted = False
         try:
@@ -287,11 +327,11 @@ class FleetPacer(CustomLogger):
                 if await self._try_admit(r, pace_id):
                     admitted = True
                     break
-                now = time.time()
-                # (1) ABSOLUTE BACKSTOP — enforced FIRST, on every iteration, so
-                # a bug in the cooldown-hold branch below can never wedge a
-                # request past HARD_MAX_WAIT_S. Do NOT move this inside a
-                # conditional or below the regime logic.
+                now = time.monotonic()
+                # (1) ABSOLUTE BACKSTOP — checked FIRST, on every iteration, so a
+                # bug in the cooldown-hold branch below can't wedge a request
+                # more than ~one backoff interval past HARD_MAX_WAIT_S. Do NOT
+                # move this inside a conditional or below the regime logic.
                 if now >= hard_deadline:
                     verbose_proxy_logger.warning(
                         "custom_pacing: HARD wait cap %.1fs hit, admitting unpaced (fail open)",

--- a/docker/litellm-pacer/test_custom_pacing.py
+++ b/docker/litellm-pacer/test_custom_pacing.py
@@ -188,9 +188,17 @@ class CodeDefaultTests(unittest.TestCase):
             if isinstance(node, ast.Assign):
                 for t in node.targets:
                     if isinstance(t, ast.Name) and t.id == arg_name:
-                        call = node.value
-                        if isinstance(call, ast.Call) and len(call.args) >= 2:
-                            return ast.literal_eval(call.args[1])
+                        # Walk the whole RHS so we still find the inner
+                        # _int_env/_float_env default even when it is wrapped in a
+                        # clamp call (e.g. _clamp_hard_max_wait(_float_env(...))).
+                        for sub in ast.walk(node.value):
+                            if (
+                                isinstance(sub, ast.Call)
+                                and isinstance(sub.func, ast.Name)
+                                and sub.func.id == func_name
+                                and len(sub.args) >= 2
+                            ):
+                                return ast.literal_eval(sub.args[1])
         raise AssertionError(f"{arg_name} default not found")
 
     def test_code_defaults_unchanged(self):
@@ -227,6 +235,82 @@ class CodeDefaultTests(unittest.TestCase):
         with open(src, "r", encoding="utf-8") as fh:
             source = fh.read()
         self.assertIn('os.getenv("PACE_COOLDOWN_HOLD", "false")', source)
+
+
+# --- Runtime config clamps (deterministic controls) --------------------------
+class ConfigClampTests(unittest.TestCase):
+    """The two guard invariants are enforced at config LOAD by runtime clamps in
+    _Cfg, not merely asserted in tests — so a deploy-time env misconfig can't
+    silently defeat them. These drive REAL env overrides + module reload and
+    assert the RESOLVED _Cfg values, so each would fail if its clamp were removed.
+    """
+
+    _ENV = (
+        "PACE_MAX_WAIT_S",
+        "PACE_HARD_MAX_WAIT_S",
+        "PACE_MAX_COOLDOWN_S",
+        "PACE_COOLDOWN_HOLD_CEILING_S",
+    )
+
+    def _reload_with(self, **env):
+        for k in self._ENV:
+            os.environ.pop(k, None)
+        for k, v in env.items():
+            os.environ[k] = str(v)
+        importlib.reload(custom_pacing)
+        return custom_pacing._Cfg
+
+    def tearDown(self):
+        # Restore clean code defaults for every downstream test.
+        for k in self._ENV:
+            os.environ.pop(k, None)
+        importlib.reload(custom_pacing)
+
+    def test_hard_cap_raised_to_max_wait_on_misconfig(self):
+        # Misconfig: hard cap set BELOW the burst-smoothing ceiling. The clamp
+        # raises it so the hard cap can never shorten a normal, benign wait.
+        cfg = self._reload_with(PACE_MAX_WAIT_S=30, PACE_HARD_MAX_WAIT_S=10)
+        self.assertGreaterEqual(cfg.HARD_MAX_WAIT_S, cfg.MAX_WAIT_S)
+        self.assertEqual(cfg.HARD_MAX_WAIT_S, 30.0)
+
+    def test_hard_cap_capped_below_watchdog_on_misconfig(self):
+        # Misconfig: hard cap set ABOVE the 300s silence watchdog. The clamp caps
+        # it under the watchdog so a hold can never look like a hang.
+        cfg = self._reload_with(PACE_HARD_MAX_WAIT_S=400)
+        self.assertLessEqual(
+            cfg.HARD_MAX_WAIT_S, custom_pacing._PACE_WATCHDOG_SAFE_CEILING_S
+        )
+        self.assertEqual(cfg.HARD_MAX_WAIT_S, 280.0)
+        self.assertLess(cfg.HARD_MAX_WAIT_S, 300.0)
+
+    def test_hold_ceiling_capped_to_max_cooldown_on_misconfig(self):
+        # Misconfig: hold ceiling set ABOVE the max cooldown that can be parked.
+        # The clamp lowers it to MAX_COOLDOWN_S.
+        cfg = self._reload_with(
+            PACE_COOLDOWN_HOLD_CEILING_S=120, PACE_MAX_COOLDOWN_S=60
+        )
+        self.assertLessEqual(cfg.COOLDOWN_HOLD_CEILING_S, cfg.MAX_COOLDOWN_S)
+        self.assertEqual(cfg.COOLDOWN_HOLD_CEILING_S, 60.0)
+
+    def test_sane_config_passes_through_unclamped(self):
+        # A valid operating point is untouched by the clamps (no false positives).
+        cfg = self._reload_with(
+            PACE_MAX_WAIT_S=12,
+            PACE_HARD_MAX_WAIT_S=45,
+            PACE_MAX_COOLDOWN_S=60,
+            PACE_COOLDOWN_HOLD_CEILING_S=60,
+        )
+        self.assertEqual(cfg.HARD_MAX_WAIT_S, 45.0)
+        self.assertEqual(cfg.COOLDOWN_HOLD_CEILING_S, 60.0)
+
+    def test_clamp_helpers_are_pure(self):
+        # Direct unit coverage of the clamp functions (deterministic; fails if the
+        # min/max bounds are dropped).
+        self.assertEqual(custom_pacing._clamp_hard_max_wait(10, 30, 280), 30)
+        self.assertEqual(custom_pacing._clamp_hard_max_wait(400, 20, 280), 280)
+        self.assertEqual(custom_pacing._clamp_hard_max_wait(45, 20, 280), 45)
+        self.assertEqual(custom_pacing._clamp_hold_ceiling(120, 60), 60)
+        self.assertEqual(custom_pacing._clamp_hold_ceiling(30, 60), 30)
 
 
 # --- Admission + fail-open ----------------------------------------------------

--- a/docker/litellm-pacer/test_custom_pacing.py
+++ b/docker/litellm-pacer/test_custom_pacing.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import random
 import sys
 import time
 import types
@@ -91,6 +92,7 @@ class FakeRedis:
         self.eval_result = eval_result
         self.eval_raises = eval_raises
         self.set_calls: list = []
+        self.eval_calls = 0
 
     async def ping(self):
         return True
@@ -104,6 +106,7 @@ class FakeRedis:
         return True
 
     async def eval(self, *args, **kwargs):
+        self.eval_calls += 1
         if self.eval_raises is not None:
             raise self.eval_raises
         return self.eval_result
@@ -197,6 +200,33 @@ class CodeDefaultTests(unittest.TestCase):
         self.assertEqual(self._default_of("_float_env", "MAX_WAIT_S"), 20.0)
         self.assertEqual(self._default_of("_float_env", "MAX_COOLDOWN_S"), 60.0)
         self.assertEqual(self._default_of("_int_env", "LEASE_TTL_S"), 300)
+
+    def test_l1_knob_defaults(self):
+        # The absolute hard cap ships ACTIVE (45s), but with 45 > MAX_WAIT_S it
+        # never fires in normal burst-smoothing => behaviour-neutral by default.
+        self.assertEqual(self._default_of("_float_env", "HARD_MAX_WAIT_S"), 45.0)
+        self.assertEqual(self._default_of("_float_env", "COOLDOWN_HOLD_CEILING_S"), 60.0)
+        self.assertEqual(self._default_of("_float_env", "RELEASE_JITTER_S"), 1.0)
+        # Hard cap must be >= MAX_WAIT_S so it can only ever shorten a pathological
+        # wait, never a normal one (the neutrality invariant).
+        self.assertGreaterEqual(
+            self._default_of("_float_env", "HARD_MAX_WAIT_S"),
+            self._default_of("_float_env", "MAX_WAIT_S"),
+        )
+        # The hold-ceiling stays within MAX_COOLDOWN_S (design constraint).
+        self.assertLessEqual(
+            self._default_of("_float_env", "COOLDOWN_HOLD_CEILING_S"),
+            self._default_of("_float_env", "MAX_COOLDOWN_S"),
+        )
+
+    def test_cooldown_hold_gate_defaults_off(self):
+        # The load-bearing neutrality guard: the cooldown-HOLD regime MUST default
+        # OFF so merging + redeploy is behaviour-neutral until we set the env at
+        # rollout. Read straight from source so a runner env can't mask a change.
+        src = os.path.join(os.path.dirname(__file__), "custom_pacing.py")
+        with open(src, "r", encoding="utf-8") as fh:
+            source = fh.read()
+        self.assertIn('os.getenv("PACE_COOLDOWN_HOLD", "false")', source)
 
 
 # --- Admission + fail-open ----------------------------------------------------
@@ -305,6 +335,179 @@ class FailureHookCooldownTests(unittest.IsolatedAsyncioTestCase):
         await pacer.async_post_call_failure_hook({}, exc, None)
         parked = float(r.store[custom_pacing._COOLDOWN_KEY])
         self.assertEqual(parked, long_until)  # unchanged — never shortened
+
+
+# --- Layer 1: cooldown-hold + hard-wait backstop wait-loop behaviour ---------
+# These are the load-bearing behavioural tests for the two-regime wait ceiling
+# (custom_pacing.py async_pre_call_hook). They drive the real hook with a fake
+# Redis that NEVER admits (eval_result=0) and a cooldown parked far in the
+# future, then assert the wait terminates in the right regime and — above all —
+# that the absolute hard cap can never be exceeded.
+_CFG_KNOBS = (
+    "ENABLED",
+    "MAX_WAIT_S",
+    "HARD_MAX_WAIT_S",
+    "COOLDOWN_HOLD",
+    "COOLDOWN_HOLD_CEILING_S",
+    "RELEASE_JITTER_S",
+    "POLL_MIN_S",
+    "POLL_MAX_S",
+)
+
+
+class _CfgPatchMixin:
+    """Snapshot + restore the _Cfg class attributes each test mutates, so the
+    live/import-time config is never leaked between tests."""
+
+    def setUp(self):
+        super().setUp()
+        self._saved_cfg = {k: getattr(custom_pacing._Cfg, k) for k in _CFG_KNOBS}
+        # Sane, fast baseline; individual tests override what they exercise.
+        custom_pacing._Cfg.ENABLED = True
+        custom_pacing._Cfg.POLL_MIN_S = 0.02
+        custom_pacing._Cfg.POLL_MAX_S = 0.04
+        custom_pacing._Cfg.RELEASE_JITTER_S = 0.05
+
+    def tearDown(self):
+        for k, v in self._saved_cfg.items():
+            setattr(custom_pacing._Cfg, k, v)
+        super().tearDown()
+
+    def _denying_redis_with_future_cooldown(self):
+        r = FakeRedis(eval_result=0)  # _try_admit -> always "wait"
+        r.store[custom_pacing._COOLDOWN_KEY] = str(time.time() + 999)
+        return r
+
+    async def _run_hook(self, pacer, r):
+        pacer._redis = r  # bypass _get_redis (no real redis import)
+        return await pacer.async_pre_call_hook(None, None, {}, "pass_through_endpoint")
+
+
+class HardCapInvariantTests(_CfgPatchMixin, unittest.IsolatedAsyncioTestCase):
+    async def test_hard_cap_dominates_cooldown_hold(self):
+        """LOAD-BEARING: with cooldown-HOLD enabled and a cooldown parked far in
+        the future (so the hold branch is fully engaged), the wait MUST fail open
+        within HARD_MAX_WAIT_S and NEVER hold to the (much larger) hold ceiling.
+        Verified across MANY iterations. If someone bypasses the hard-cap check
+        in the hold branch, the loop runs to COOLDOWN_HOLD_CEILING_S instead and
+        elapsed blows past the assertion -> this test fails."""
+        custom_pacing._Cfg.COOLDOWN_HOLD = True
+        custom_pacing._Cfg.HARD_MAX_WAIT_S = 0.5
+        custom_pacing._Cfg.COOLDOWN_HOLD_CEILING_S = 3.0  # >> hard cap on purpose
+        custom_pacing._Cfg.MAX_WAIT_S = 0.3
+
+        pacer = custom_pacing.FleetPacer()
+        r = self._denying_redis_with_future_cooldown()
+        t0 = time.time()
+        await self._run_hook(pacer, r)
+        elapsed = time.time() - t0
+
+        # Bounded by the hard cap (with slack for one final backoff), and clearly
+        # BELOW the 3.0s hold ceiling — proving the hard cap, not the ceiling,
+        # stopped the wait.
+        self.assertLessEqual(elapsed, custom_pacing._Cfg.HARD_MAX_WAIT_S + 0.4)
+        self.assertLess(elapsed, custom_pacing._Cfg.COOLDOWN_HOLD_CEILING_S)
+        # It actually held (didn't leak at MAX_WAIT_S) and looped many times, so
+        # the cap is enforced on EVERY iteration, not just once.
+        self.assertGreaterEqual(elapsed, custom_pacing._Cfg.MAX_WAIT_S)
+        self.assertGreaterEqual(r.eval_calls, 3)
+
+    async def test_hard_cap_enforced_every_iteration_probe(self):
+        """Explicitly assert the cap is re-checked each loop: shrink the hard cap
+        below MAX_WAIT_S and confirm the wait ends at the hard cap even though the
+        (burst) regime ceiling is larger — only possible if the hard-cap check
+        runs first, every iteration."""
+        custom_pacing._Cfg.COOLDOWN_HOLD = False
+        custom_pacing._Cfg.HARD_MAX_WAIT_S = 0.3
+        custom_pacing._Cfg.MAX_WAIT_S = 5.0  # regime ceiling >> hard cap
+
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis(eval_result=0)
+        t0 = time.time()
+        await self._run_hook(pacer, r)
+        elapsed = time.time() - t0
+        self.assertLessEqual(elapsed, custom_pacing._Cfg.HARD_MAX_WAIT_S + 0.4)
+        self.assertLess(elapsed, custom_pacing._Cfg.MAX_WAIT_S)
+        self.assertGreaterEqual(r.eval_calls, 2)
+
+
+class CooldownHoldRegimeTests(_CfgPatchMixin, unittest.IsolatedAsyncioTestCase):
+    async def test_hold_queues_past_burst_ceiling_when_enabled(self):
+        """With cooldown-HOLD ON and a signalled cooldown active, the wait must
+        HOLD past the short MAX_WAIT_S burst ceiling (not leak at 12s), bounded by
+        COOLDOWN_HOLD_CEILING_S."""
+        custom_pacing._Cfg.COOLDOWN_HOLD = True
+        custom_pacing._Cfg.MAX_WAIT_S = 0.3
+        custom_pacing._Cfg.COOLDOWN_HOLD_CEILING_S = 1.0
+        custom_pacing._Cfg.HARD_MAX_WAIT_S = 5.0
+
+        pacer = custom_pacing.FleetPacer()
+        r = self._denying_redis_with_future_cooldown()
+        t0 = time.time()
+        data = await self._run_hook(pacer, r)
+        elapsed = time.time() - t0
+
+        # Held well past the 0.3s burst ceiling ...
+        self.assertGreater(elapsed, custom_pacing._Cfg.MAX_WAIT_S + 0.2)
+        # ... but bounded by the hold ceiling (and the hard cap).
+        self.assertLessEqual(elapsed, custom_pacing._Cfg.COOLDOWN_HOLD_CEILING_S + 0.4)
+        self.assertLess(elapsed, custom_pacing._Cfg.HARD_MAX_WAIT_S)
+        # Fail-open contract preserved: the request still proceeds (data back).
+        self.assertIsInstance(data, dict)
+
+    async def test_default_off_leaks_at_burst_ceiling_regression(self):
+        """REGRESSION GUARD: with cooldown-HOLD at its default (OFF), behaviour is
+        unchanged from today — even during an active cooldown the wait fails open
+        at the short MAX_WAIT_S burst ceiling, exactly as pre-L1."""
+        custom_pacing._Cfg.COOLDOWN_HOLD = False
+        custom_pacing._Cfg.MAX_WAIT_S = 0.3
+        custom_pacing._Cfg.COOLDOWN_HOLD_CEILING_S = 60.0
+        custom_pacing._Cfg.HARD_MAX_WAIT_S = 45.0
+
+        pacer = custom_pacing.FleetPacer()
+        r = self._denying_redis_with_future_cooldown()
+        t0 = time.time()
+        await self._run_hook(pacer, r)
+        elapsed = time.time() - t0
+
+        # Leaks at the burst ceiling, NOT the hold ceiling — i.e. hold is off.
+        self.assertLessEqual(elapsed, custom_pacing._Cfg.MAX_WAIT_S + 0.3)
+
+
+class ReleaseJitterTests(_CfgPatchMixin, unittest.TestCase):
+    def test_release_jitter_spreads_admissions(self):
+        """Thundering-herd guard: while HOLDING, the backoff adds a bounded
+        release-jitter term so queued requests re-admit spread across a window
+        instead of stampeding one instant. The burst-smoothing regime keeps the
+        original POLL_MIN..POLL_MAX behaviour unchanged."""
+        custom_pacing._Cfg.POLL_MIN_S = 0.10
+        custom_pacing._Cfg.POLL_MAX_S = 0.40
+        custom_pacing._Cfg.RELEASE_JITTER_S = 1.0
+        pacer = custom_pacing.FleetPacer()
+
+        random.seed(20260713)
+        holding = [pacer._backoff_sleep_s(True) for _ in range(300)]
+        burst = [pacer._backoff_sleep_s(False) for _ in range(300)]
+
+        # Burst regime unchanged: strictly within the poll window.
+        self.assertTrue(all(0.10 <= x <= 0.40 for x in burst))
+        # Hold regime: release jitter pushes some waits beyond the poll ceiling
+        # and spreads them across a wide window (no synchronized re-admit).
+        self.assertGreater(max(holding), 0.40)
+        self.assertGreater(max(holding) - min(holding), 0.40)
+        # Not a stampede: the released attempts land on many distinct delays.
+        self.assertGreater(len({round(x, 4) for x in holding}), 200)
+
+    def test_release_jitter_zero_is_pure_poll(self):
+        """RELEASE_JITTER_S=0 disables the extra term: holding backoff collapses
+        back to the plain poll window (escape hatch / neutrality)."""
+        custom_pacing._Cfg.POLL_MIN_S = 0.10
+        custom_pacing._Cfg.POLL_MAX_S = 0.40
+        custom_pacing._Cfg.RELEASE_JITTER_S = 0.0
+        pacer = custom_pacing.FleetPacer()
+        random.seed(7)
+        holding = [pacer._backoff_sleep_s(True) for _ in range(200)]
+        self.assertTrue(all(0.10 <= x <= 0.40 for x in holding))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Path A / **Layer 1** of the fleet throughput-safety plan. Splits the pacer's single fail-open wait ceiling in `async_pre_call_hook` (`docker/litellm-pacer/custom_pacing.py`) into **two regimes plus one absolute backstop**, so a signalled throttle is *held through* instead of leaked every ~12s — without ever letting a bug wedge the fleet.

Depends on P0 (#3204, the vendored pacer). Co-ships with P2 (L2 broker rotation) at rollout per the plan — this PR is repo-only and behaviour-neutral by default.

## The two-regime wait

- **Burst-smoothing** (admission blocked only by concurrency/RPM/RPS, no active cooldown): **unchanged** — wait up to `PACE_MAX_WAIT_S` (~12s live) then benign fail-open. Leaking here is fine.
- **Cooldown-HOLD** (Redis `cooldown_until` is in the future — Anthropic has *signalled* a throttle): do **not** fail open at 12s. Hold/queue until the cooldown elapses (reusing the existing `_cooldown_remaining` helper), bounded by `PACE_COOLDOWN_HOLD_CEILING_S` (≤ `MAX_COOLDOWN_S`, itself capped at 60s).

## The hard-cap invariant (load-bearing)

`PACE_HARD_MAX_WAIT_S` (default **45**) caps **any** wait in **either** regime. It is enforced **first, on every iteration** of the wait loop — structurally above the regime logic — so a bug in the hold branch can never wedge a request past it. 45s is strictly `< 300s` (gateway silence watchdog) and below claude's own retry budget.

## Jittered release (thundering-herd guard)

When holding, the backoff adds a bounded `PACE_RELEASE_JITTER_S` term so that when a cooldown elapses the queued fleet re-admits **spread across a window** rather than stampeding the same 1s window and instantly re-tripping the 429 that set the cooldown.

## Behaviour-neutral by default

All new knobs flow through the existing `_int_env`/`_float_env` pattern (live-settable, no rebuild). Defaults preserve **current live behaviour**:

| Knob | Default | Active by default? |
|---|:---:|:---:|
| `PACE_HARD_MAX_WAIT_S` | 45 | yes — only ever shortens a >45s pathological wait (45 > `MAX_WAIT_S`, never fires in normal smoothing) |
| `PACE_COOLDOWN_HOLD` | `false` | **no** — hold regime gated OFF; off = pre-L1 behaviour exactly |
| `PACE_COOLDOWN_HOLD_CEILING_S` | 60 | only when hold on |
| `PACE_RELEASE_JITTER_S` | 1.0 | only when holding |

So merging + a redeploy changes nothing except the 45s absolute cap, until we explicitly set `PACE_COOLDOWN_HOLD=true` at rollout.

## Env to set at rollout (gated, separate step — NOT in this PR)

```yaml
- 'PACE_HARD_MAX_WAIT_S=45'
- 'PACE_COOLDOWN_HOLD=true'
- 'PACE_COOLDOWN_HOLD_CEILING_S=60'
- 'PACE_RELEASE_JITTER_S=1.0'
```

Set in the deployed `docker-compose.yml` + redeploy litellm. Documented in `docker/litellm-pacer/README.md`. This PR does **not** touch the live deployed file, the live compose, or redeploy anything.

## Tests (stdlib `unittest`, `ci-tests-python` lane)

- **Hard-cap invariant** (load-bearing): with hold enabled and a cooldown parked far in the future, `async_pre_call_hook` fails open in ≤ `PACE_HARD_MAX_WAIT_S`, verified across many iterations, and clearly below the (much larger) hold ceiling. **Confirmed it FAILS if the cap check is bypassed** (neutering the check → 5.0s vs the 0.7s bound).
- **Hold-past-burst-ceiling** when enabled (queues during a signalled cooldown instead of leaking at the burst ceiling).
- **Default-off regression guard** (hold off → leaks at `MAX_WAIT_S`, unchanged from today).
- **Jittered-release no-stampede** (`_backoff_sleep_s(holding=True)` spreads across the release window; burst regime unchanged).
- **Code-default / gate-default guards** (new knob defaults + `PACE_COOLDOWN_HOLD` defaults `"false"`).

31 tests pass locally (`python3 -m unittest discover -s docker/litellm-pacer -p 'test_*.py'`).

Do not merge — goes to adversarial review next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)