### PR TITLE
fix(telegram): humanized LLM-error surfacing — drop dead buttons, redact operator cards, crash-guard tz (follow-up to #3209)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -317,7 +317,7 @@ import {
 import { recordOperatorEvent } from '../operator-events-history.js'
 import {
   parseLlmError,
-  renderLlmError,
+  renderLlmErrorSafe,
   decideErrorSurface,
 } from '../llm-error-present.js'
 import {
@@ -7690,6 +7690,21 @@ const inboundCoalescer = createInboundCoalescer<CoalescePayload>({
 function emitGatewayOperatorEvent(event: OperatorEvent): void {
   const { agent, kind } = event
 
+  // #llm-error-surfacing FIX 2 (secret leak): the operator-event cards are sent
+  // via a raw bot.api.sendRichMessage that BYPASSES the normal outbound redact
+  // chokepoint (normalizeOutboundBody → redact, outbound-send-path.ts). The only
+  // scrub the renderers apply is stripRawErrorBytes — a JSON-SHAPE scrub, NOT a
+  // secret scrubber — so a bearer token / `sk-…` key / url-embedded credential
+  // smuggled in an error `detail` would reach the operator card verbatim on the
+  // credentials-expired / credit-exhausted / unknown-4xx paths. Redact the detail
+  // ONCE here, up front, through the SAME redact() the reply path uses — and
+  // crucially BEFORE renderOperatorEvent runs escapeMarkdown on it (redacting the
+  // already-escaped text would let url-query-param secrets slip past url-redact,
+  // exactly the order the outbound pipeline documents: redact before markdown).
+  // Doing it at the top also scrubs the recorded operator-event history and the
+  // 429 metrics — defense in depth, no secret survives in ANY downstream sink.
+  event = { ...event, detail: redactOutboundText(event.detail, 'operator_event') }
+
   // ── 429 throttle tier (operator spec: "retry in place under 5 min, else
   // mark + failover, honest reset messaging") ────────────────────────────
   // A terminal TRANSIENT ACCOUNT-scoped 429 — kind `rate-limited` carrying
@@ -7957,9 +7972,16 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
       return
     }
     const tz = process.env.SWITCHROOM_TIMEZONE ?? process.env.TZ ?? 'UTC'
-    const r = renderLlmError(parsed, agent, tz, new Date(now))
+    // #llm-error-surfacing FIX 3 (crash guard): renderLlmErrorSafe wraps the
+    // tz-formatting render — an invalid IANA `SWITCHROOM_TIMEZONE`/`TZ` throws a
+    // RangeError out of Intl.DateTimeFormat (local-time.ts's "never throws" claim
+    // does NOT hold for construction-time zone validation). Pre-fix this branch
+    // had no guard, so a bad tz crashed the whole operator-event turn; now it
+    // degrades to a minimal tz-free line. There are no action buttons on this
+    // card (FIX 1) — the humanized text carries any recommendation inline.
+    const r = renderLlmErrorSafe(parsed, agent, tz, new Date(now))
     renderedText = r.text
-    renderedKeyboard = r.keyboard
+    renderedKeyboard = undefined
   } else {
     try {
       const r = renderOperatorEvent(event)

--- a/telegram-plugin/llm-error-present.ts
+++ b/telegram-plugin/llm-error-present.ts
@@ -34,7 +34,6 @@ import {
 } from './model-unavailable.js'
 import { classify429Detail } from './throttle-tier.js'
 import { classifyClaudeError } from './operator-events.js'
-import type { InlineKeyboardMarkup } from './operator-events.js'
 import { stripRawErrorBytes, extractRequestId } from './raw-error-scrub.js'
 import { fmtLocalClock, tzAbbrev } from './shared/local-time.js'
 
@@ -226,7 +225,6 @@ function buildCoreText(kind: LlmErrorKind, source: LlmErrorSource): string {
 
 export interface RenderedLlmError {
   text: string
-  keyboard?: InlineKeyboardMarkup
 }
 
 /**
@@ -257,9 +255,49 @@ function formatRelativeTail(deltaMs: number): string {
 }
 
 /**
- * Render ONE clean card for a parsed LLM error. Action buttons for the
- * actionable kinds (auth → Reauth, quota_wall → Wait/switch). `agent` is used
- * in the callback_data (URL-encoded) and the headline; `tz` localizes the reset.
+ * A short local-tz clock+abbrev for a reset instant (`4:52pm AEST`), or '' when
+ * there is no finite reset to name. Used to embed the reset in the recommendation
+ * line. Shares the same tz-formatting primitives as {@link formatResetLocal}, so
+ * an invalid IANA tz throws here too (guarded by {@link renderLlmErrorSafe}).
+ */
+function formatResetClock(resetAt: Date | undefined, tz: string): string {
+  if (resetAt == null) return ''
+  const ms = resetAt.getTime()
+  if (!Number.isFinite(ms)) return ''
+  return `${fmtLocalClock(ms, tz)} ${tzAbbrev(ms, tz)}`
+}
+
+/**
+ * The plain-text "what to DO" line for the actionable error classes. Replaces
+ * the former dead action buttons (auth → Reauth, quota_wall → Wait): those
+ * inline_keyboard callbacks were only ever exercised in tests — the gateway
+ * wiring routes renderLlmError solely for the transient rate_limit/overload_529
+ * kinds, so the auth/quota buttons were unreachable in production (Ken, CPO,
+ * 2026-07: drop the buttons, recommend in text). Transient kinds return undefined
+ * — their coreText already says "retrying automatically", no operator action.
+ */
+function buildRecommendation(parsed: ParsedLlmError, tz: string): string | undefined {
+  switch (parsed.kind) {
+    case 'auth':
+      return '→ Re-authenticate this account to continue.'
+    case 'quota_wall': {
+      const reset = formatResetClock(parsed.resetAt, tz)
+      return reset
+        ? `→ Switch to another account, or wait for the quota to reset at ${reset}.`
+        : '→ Switch to another account, or wait for the quota to reset.'
+    }
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Render ONE clean card for a parsed LLM error. No action buttons — the
+ * actionable kinds (auth, quota_wall) carry a plain-text recommendation line
+ * instead (see {@link buildRecommendation}). `agent` is the headline label; `tz`
+ * localizes the reset. Throws if `tz` is an invalid IANA zone AND a reset is
+ * present (Intl.DateTimeFormat rejects the zone at construction) — call
+ * {@link renderLlmErrorSafe} from any crash-sensitive surface.
  */
 export function renderLlmError(
   parsed: ParsedLlmError,
@@ -276,32 +314,32 @@ export function renderLlmError(
 
   if (parsed.model) lines.push(`_model: ${escapeAgent(parsed.model)}_`)
 
-  const text = lines.join('\n')
+  const recommendation = buildRecommendation(parsed, tz)
+  if (recommendation) lines.push(recommendation)
 
-  switch (parsed.kind) {
-    case 'auth':
-      return {
-        text,
-        keyboard: {
-          inline_keyboard: [
-            [
-              { text: '🔐 Reauth now', callback_data: `op:reauth:${encodeURIComponent(agent)}` },
-              { text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(agent)}` },
-            ],
-          ],
-        },
-      }
-    case 'quota_wall':
-      return {
-        text,
-        keyboard: {
-          inline_keyboard: [
-            [{ text: '⏳ Wait', callback_data: `op:dismiss:${encodeURIComponent(agent)}` }],
-          ],
-        },
-      }
-    default:
-      return { text }
+  return { text: lines.join('\n') }
+}
+
+/**
+ * Crash-guarded wrapper around {@link renderLlmError}. An invalid IANA timezone
+ * makes Intl.DateTimeFormat throw a RangeError at construction time — the
+ * local-time.ts "never throws" contract does NOT cover construction-time zone
+ * validation, so a bad `SWITCHROOM_TIMEZONE`/`TZ` would otherwise crash the
+ * operator-event turn. On ANY formatting failure, degrade to a minimal, tz-free
+ * safe line built only from the JSON-stripped coreText + agent. Total — never
+ * throws.
+ */
+export function renderLlmErrorSafe(
+  parsed: ParsedLlmError,
+  agent: string,
+  tz: string,
+  now: Date = new Date(),
+): RenderedLlmError {
+  try {
+    return renderLlmError(parsed, agent, tz, now)
+  } catch {
+    const safeAgent = escapeAgent(agent)
+    return { text: `${kindEmoji(parsed.kind)} ${parsed.coreText} (**${safeAgent}**)` }
   }
 }
 

--- a/telegram-plugin/tests/gateway-outbound-redact.test.ts
+++ b/telegram-plugin/tests/gateway-outbound-redact.test.ts
@@ -134,6 +134,32 @@ describe('gateway outbound secret-scrub — structural wiring', () => {
     expect(streamIdx).toBeGreaterThan(redactIdx) // mask BEFORE the stream
   })
 
+  it('operator_event: scrubs event.detail at the top of emitGatewayOperatorEvent, BEFORE render/send', () => {
+    // #llm-error-surfacing FIX 2 — operator-event cards are sent via a raw
+    // bot.api.sendRichMessage that BYPASSES the normal outbound chokepoint, so a
+    // secret in an error `detail` (credentials-expired / credit-exhausted /
+    // unknown-4xx) could reach the card verbatim. The detail is redacted ONCE at
+    // the top of the function, through the shared redactOutboundText, and MUST
+    // run before the renderers escapeMarkdown it (redacting the already-escaped
+    // text lets url-query-param secrets slip past url-redact) and before the
+    // send. This is the sole regression guard for that wiring line — deleting it
+    // must turn this red.
+    const start = src.indexOf('function emitGatewayOperatorEvent(')
+    const redactIdx = src.indexOf(
+      `event = { ...event, detail: redactOutboundText(event.detail, 'operator_event') }`,
+      start,
+    )
+    // The two render surfaces + the wire send this must precede.
+    const renderOpIdx = src.indexOf('renderOperatorEvent(event)', start)
+    const renderLlmIdx = src.indexOf('renderLlmErrorSafe(parsed', start)
+    const sendIdx = src.indexOf('bot.api.sendRichMessage(chat_id, richMessage(renderedText)', start)
+    expect(start).toBeGreaterThan(0)
+    expect(redactIdx).toBeGreaterThan(start)
+    expect(renderOpIdx).toBeGreaterThan(redactIdx) // mask BEFORE the escapeMarkdown render
+    expect(renderLlmIdx).toBeGreaterThan(redactIdx) // mask BEFORE the humanized render
+    expect(sendIdx).toBeGreaterThan(redactIdx) // mask BEFORE the card hits the wire
+  })
+
   it('does not log the secret value when a mask fires', () => {
     const idx = src.indexOf('function redactOutboundText(')
     const body = src.slice(idx, idx + 400)

--- a/telegram-plugin/tests/llm-error-present.test.ts
+++ b/telegram-plugin/tests/llm-error-present.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import {
   parseLlmError,
   renderLlmError,
+  renderLlmErrorSafe,
   stripRawErrorBytes,
   extractRequestId,
   formatResetLocal,
@@ -27,6 +28,7 @@ import {
 import { truncateDetailPreservingRequestId } from '../raw-error-scrub.js'
 import { projectTranscriptLine, detectErrorInTranscriptLine } from '../session-tail.js'
 import { renderOperatorEvent, type OperatorEvent } from '../operator-events.js'
+import { redact } from '../secret-detect/redact.js'
 
 // A raw byte-blob every surface must scrub.
 const RAW_BYTES = `b'{"type":"error","error":{"type":"rate_limit_error","message":"rate limit"},"request_id":"req_abc123"}'`
@@ -161,16 +163,115 @@ describe('renderLlmError / formatResetLocal — local-time rendering', () => {
     expect(text).toContain('AEST')
   })
 
-  it('auth + quota_wall cards carry action buttons', () => {
+  // FIX 1 (Ken, CPO, 2026-07): the dead auth/quota action buttons are GONE —
+  // renderLlmError never returns an inline_keyboard; the actionable classes
+  // carry a plain-text recommendation line instead.
+  it('auth card recommends re-authentication in text, with NO action buttons', () => {
     const auth = renderLlmError(parseLlmError('authentication_error: token expired'), 'a', tz, now)
-    expect(auth.keyboard?.inline_keyboard.flat().some((b) => b.callback_data?.includes('reauth'))).toBe(true)
-    const quota = renderLlmError(
-      parseLlmError("You've hit your limit · resets 5pm"),
-      'a',
-      tz,
-      now,
-    )
-    expect(quota.keyboard?.inline_keyboard.flat().length).toBeGreaterThan(0)
+    expect((auth as { keyboard?: unknown }).keyboard).toBeUndefined()
+    expect(auth.text.toLowerCase()).toContain('re-authenticate')
+  })
+
+  it('quota_wall card recommends switch/wait in text (naming the reset), NO buttons', () => {
+    const quota = renderLlmError(parseLlmError("You've hit your limit · resets 5pm"), 'a', tz, now)
+    expect((quota as { keyboard?: unknown }).keyboard).toBeUndefined()
+    const lower = quota.text.toLowerCase()
+    expect(lower).toContain('switch to another account')
+    expect(lower).toContain('wait for the quota to reset')
+    // The reset instant is named in the recommendation line.
+    expect(quota.text).toContain('AEST')
+  })
+
+  it('transient (rate_limit) card has neither buttons nor an action recommendation', () => {
+    const rl = renderLlmError(parseLlmError('rate_limit_error: slow down'), 'a', tz, now)
+    expect((rl as { keyboard?: unknown }).keyboard).toBeUndefined()
+    expect(rl.text.toLowerCase()).not.toContain('re-authenticate')
+    expect(rl.text).not.toContain('→')
+  })
+
+  // FIX 3 (crash guard): an invalid IANA timezone throws a RangeError out of the
+  // raw renderer (local-time.ts's "never throws" claim is false for tz
+  // construction). renderLlmErrorSafe MUST swallow it and degrade — asserting the
+  // OUTCOME (no throw + a usable message), not just that the branch ran.
+  it('renderLlmError DOES throw on an invalid tz with a reset present (documents the hazard)', () => {
+    const parsed = parseLlmError("You've hit your limit · resets 5pm")
+    expect(parsed.resetAt).toBeDefined()
+    expect(() => renderLlmError(parsed, 'gymbro', 'Not/AZone', now)).toThrow()
+  })
+
+  it('renderLlmErrorSafe does NOT throw on an invalid tz and returns a usable line', () => {
+    const parsed = parseLlmError("You've hit your limit · resets 5pm")
+    let out: { text: string } | undefined
+    expect(() => {
+      out = renderLlmErrorSafe(parsed, 'gymbro', 'Not/AZone', now)
+    }).not.toThrow()
+    expect(out?.text).toContain('gymbro')
+    assertNoRawBytes(out!.text)
+  })
+})
+
+// ─── FIX 2: operator-card text is scrubbed by the REAL redactor ───────────────
+//
+// The gateway sends operator-event cards via a raw bot.api call that bypasses
+// the normal outbound redact chokepoint; it now routes the rendered text through
+// the same redact() the reply path uses. These tests assert the OUTCOME: a
+// synthetic bearer token / sk- key / url-embedded credential planted in an error
+// detail does NOT survive into the redacted card text. stripRawErrorBytes alone
+// (a JSON-shape scrub) does NOT catch these — redact() is required.
+describe('operator-card secret redaction (FIX 2)', () => {
+  const now = new Date('2026-07-13T06:14:00Z')
+  // Runtime-assembled so no contiguous Anthropic-token literal lands in source
+  // (check-no-pii-secrets discipline). Resolves to a real sk-ant-shaped key that
+  // redact()'s anthropic_api_key pattern masks.
+  const BEARER = ['sk', 'ant', 'api03-ABCDEF1234567890abcdefGHIJKLMN'].join('-')
+  const URL_SECRET = 'https://user:hunter2pass@api.anthropic.com/v1/x?api_key=abc123secretval456'
+
+  const mkEvent = (kind: OperatorEvent['kind'], detail: string): OperatorEvent => ({
+    agent: 'gymbro',
+    kind,
+    detail,
+    suggestedActions: [],
+    firstSeenAt: now,
+  })
+
+  // Mirrors emitGatewayOperatorEvent's transform: redact the DETAIL first (via
+  // the real redact()), THEN render — so the scrub happens BEFORE the renderer's
+  // escapeMarkdown, exactly as production now does. Redacting the already-escaped
+  // final text would let url-query-param secrets (`api_key=…`) slip past.
+  const renderCardAsSent = (ev: OperatorEvent): string =>
+    renderOperatorEvent({ ...ev, detail: redact(ev.detail) }).text
+
+  it('stripRawErrorBytes alone LEAKS a bearer/api-key (proves redact is needed)', () => {
+    // Guard test: the shape-scrub inside the renderer is JSON-shape-only. If this
+    // ever stops leaking, the shape-scrub grew secret awareness.
+    expect(stripRawErrorBytes(`auth failed: Bearer ${BEARER}`)).toContain(BEARER)
+  })
+
+  it('pre-fix render (no redact) LEAKS the bearer; the production transform scrubs it', () => {
+    const ev = mkEvent('credentials-expired', `token rejected: Bearer ${BEARER}`)
+    // Renderer alone (pre-fix path): secret survives.
+    expect(renderOperatorEvent(ev).text).toContain(BEARER)
+    // Production transform (redact detail → render): secret is gone.
+    expect(renderCardAsSent(ev)).not.toContain(BEARER)
+  })
+
+  it('masks a url-embedded credential in a credit-exhausted card', () => {
+    const ev = mkEvent('credit-exhausted', `billing check: ${URL_SECRET}`)
+    const sent = renderCardAsSent(ev)
+    expect(sent).not.toContain('hunter2pass')
+    expect(sent).not.toContain('abc123secretval456')
+  })
+
+  it('masks a bearer key in an unknown-4xx card', () => {
+    const ev = mkEvent('unknown-4xx', `API Error: 400 · x-api-key ${BEARER}`)
+    expect(renderCardAsSent(ev)).not.toContain(BEARER)
+  })
+
+  it('the humanized (renderLlmError) card never relays raw detail — no secret to leak', () => {
+    // The humanized card's coreText is a per-kind TEMPLATE, never the raw detail,
+    // so a secret in the detail cannot reach it even before redaction.
+    const parsed = parseLlmError(`rate_limit_error · Bearer ${BEARER}`)
+    expect(renderLlmError(parsed, 'gymbro', 'Australia/Melbourne', now).text).not.toContain(BEARER)
   })
 })
 


### PR DESCRIPTION
Follow-up hardening for the humanized LLM-error surfacing that merged in #3209 (already on `main`, not yet rolled to the fleet). Fixes three adversarial-review findings. Core behaviour (one clean, deduped, JSON-free error message, reset in local time) is unchanged.

## FIX 1 — drop the dead action buttons, recommend in text (Ken, CPO)
`renderLlmError` returned `auth`→Reauth/Dismiss and `quota_wall`→Wait inline keyboards, but the gateway only routes `renderLlmError` for the transient `rate_limit`/`overload_529` kinds — those buttons were **unreachable in production**, asserted only in tests. Removed the keyboards entirely (`renderLlmError` no longer returns a keyboard) and added a per-class plain-text recommendation:
- auth → `→ Re-authenticate this account to continue.`
- quota_wall → `→ Switch to another account, or wait for the quota to reset at <local reset time>.`

`renderOperatorEvent`'s `op:reauth`/`dismiss`/`restart` buttons are **left intact** — those are wired to live callback handlers (`callback-query-handlers.ts`), not dead.

## FIX 2 (P0, secret leak) — route operator-card detail through the real `redact()`
Operator-event cards send via a raw `bot.api.sendRichMessage` that **bypasses** the normal outbound redact chokepoint (`normalizeOutboundBody → redact`, `outbound-send-path.ts`). The renderers only apply `stripRawErrorBytes`, a **JSON-shape** scrub — not a secret scrubber — so a bearer token / `sk-…` key / url-embedded credential in an error `detail` could reach the operator card verbatim (credentials-expired / credit-exhausted / unknown-4xx).

Fix: redact `event.detail` once at the top of `emitGatewayOperatorEvent`, through the **same** `redact()` the reply path uses (`redactOutboundText`), **before** `renderOperatorEvent` runs `escapeMarkdown` on it. Ordering matters — redacting the already-escaped text lets url-query-param secrets (`api_key=…`) slip past `url-redact`, which is exactly why the reply pipeline redacts before markdown. Redacting up front also scrubs the recorded operator-event history and 429 metrics (defense in depth).

## FIX 3 (crash guard) — invalid tz must not throw out of the humanized branch
An invalid IANA `SWITCHROOM_TIMEZONE`/`TZ` makes `Intl.DateTimeFormat` throw a `RangeError` at construction (`local-time.ts`'s "never throws" doc-claim does **not** cover zone validation). The humanized-error branch had no `try/catch`, so a bad tz crashed the whole operator-event turn. New `renderLlmErrorSafe` wraps `renderLlmError` and degrades to a minimal, tz-free line on any failure; the gateway branch calls it.

## Tests (outcome-asserting)
- Synthetic bearer / `sk-…` key / url credential is **absent** from the rendered+redacted operator card (credentials-expired, credit-exhausted, unknown-4xx); the humanized card never relays raw detail.
- `renderLlmErrorSafe` does **not** throw on an invalid tz (and `renderLlmError` **does**, documenting the hazard).
- auth/quota recommendation text is present; **no** `inline_keyboard` on any `renderLlmError` card.

Scoped: `llm-error-present.test.ts` (36) + `operator-events.test.ts` (72) green; `tsc --noEmit` clean. CI is the full-suite authority.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)