### PR TITLE
fix(telegram): honest turn-record status — record send outcome, not intent (PR 1/2 silent-turn)

### DIFF
--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -67,6 +67,20 @@ describe("detectTurnFindings", () => {
     expect(f.map((x) => x.signal)).not.toContain("killed-incomplete-turn");
   });
 
+  it("flags send_failed as its own signal, NOT the killed catch-all (Fix 2)", () => {
+    // gateway PR B writes status=send_failed when a turn-flush answer failed to
+    // reach the user. It must surface as `send-failed-delivery` (a delivery
+    // failure), not be miscategorised as `killed-incomplete-turn` (killed
+    // mid-run) — which would corrupt that signal's meaning.
+    const turns = parseTurns(turn(15, { status: "send_failed", tools: 0 }));
+    const signals = detectTurnFindings("alpha", turns).map((x) => x.signal);
+    expect(signals).toContain("send-failed-delivery");
+    expect(signals).not.toContain("killed-incomplete-turn");
+    // and a send_failed turn with tools:0 must NOT be a silent-no-op (it is an
+    // honest delivery failure, not a benign complete-zero-tools turn).
+    expect(signals).not.toContain("silent-no-op-candidate");
+  });
+
   it("flags a hang only when long AND stalled (few tools)", () => {
     const stalled = parseTurns(turn(13, { duration_ms: HANG_MS + 1, tools: 1 }));
     const productive = parseTurns(turn(14, { duration_ms: HANG_MS + 1, tools: 9 }));

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -35,7 +35,12 @@ export interface TurnRecord {
 export type TurnSignal =
   | "killed-incomplete-turn"
   | "hang-long-stalled"
-  | "silent-no-op-candidate";
+  | "silent-no-op-candidate"
+  // A turn-flush/backstop send that failed or only partially delivered
+  // (turns.jsonl status `send_failed`, new in gateway PR B). Distinct from
+  // `killed-incomplete-turn` (process killed mid-run): here the run finished
+  // but the answer never fully reached the user (e.g. flood-dropped).
+  | "send-failed-delivery";
 
 /** The L0 failure-mode signals emitted from precise gateway log signatures. */
 export type GatewaySignal =
@@ -118,7 +123,18 @@ export function detectTurnFindings(agent: string, turns: TurnRecord[]): Finding[
     const synthetic = tid.includes("synthetic-"); // gateway-injected, not a real job
     const ts = isoFromTs(t.ts);
 
-    if (st !== "complete" && st !== "no_reply") {
+    // send_failed (gateway PR B): the run finished but the answer did not fully
+    // reach the user. Its own signal — NOT the process-killed catch-all below
+    // (which would corrupt `killed-incomplete-turn`'s "killed mid-run" meaning).
+    if (st === "send_failed") {
+      findings.push({
+        signal: "send-failed-delivery",
+        agent,
+        turn_id: tid,
+        log_pointer: `turns.jsonl:${tid} status=send_failed`,
+        ts,
+      });
+    } else if (st !== "complete" && st !== "no_reply") {
       findings.push({
         signal: "killed-incomplete-turn",
         agent,
@@ -233,7 +249,8 @@ export function scanAgent(
       (f) =>
         f.signal === "killed-incomplete-turn" ||
         f.signal === "hang-long-stalled" ||
-        f.signal === "silent-no-op-candidate",
+        f.signal === "silent-no-op-candidate" ||
+        f.signal === "send-failed-delivery",
     ) ||
     gw_hits["duplicate-delivery-represent"] > 0 ||
     gw_hits["reply-delivery-failure"] > 0;

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -78,6 +78,15 @@ export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
     job_spec: "steer-or-queue-mid-flight",
     signature: "killed:incomplete-turn",
   },
+  "send-failed-delivery": {
+    // A backstop send that failed/partially delivered — the user asked and the
+    // agent answered, but the answer never fully landed. That is a delivery
+    // failure of the talk-to-agents contract, akin to reply-delivery-failure.
+    failure_mode: "success-theater",
+    severity: 3,
+    job_spec: "talk-to-agents-from-anywhere",
+    signature: "send-failed:turn-flush-backstop",
+  },
   "represent-escalation": {
     failure_mode: "drift",
     severity: 1,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -609,6 +609,11 @@ import { resolveChatIdFallback } from './chat-id-fallback.js'
 import { decideObligationTurnEnd } from './obligation-turn-end.js'
 import { maybeRotate } from './turns-jsonl-rotate.js'
 import {
+  computeTurnStatus,
+  backstopSendOutcome,
+  type DeliveryOutcome,
+} from './turn-record-status.js'
+import {
   createDeliveryQueue,
   trackDelivery,
   ackDelivery,
@@ -3039,6 +3044,16 @@ type CurrentTurn = {
   // even though `replyCalled` is true — the #1664 case where the real answer
   // ended up as plain transcript text rendered into an ephemeral draft.
   finalAnswerDelivered: boolean
+  // PR B (send-honesty). The REAL fate of a backstop (turn-flush) send,
+  // stamped only AFTER the async send resolves inside the IIFE — success →
+  // 'delivered', throw/partial → 'failed', reply-tool-already-sent
+  // short-circuit → 'suppressed'. `emitTurnRecord` derives the recorded
+  // status from THIS (via `computeTurnStatus`) rather than the speculative
+  // `finalAnswerDelivered` flag, so a flood-dropped answer is logged
+  // `send_failed` instead of a false `complete`. Undefined on the synchronous
+  // turn-end paths (reply-tool tail, silent-marker, genuine no-reply), where
+  // the legacy `finalAnswerDelivered` reading still applies unchanged.
+  deliveryOutcome?: DeliveryOutcome
   // Feed-reopen-after-ack refinement — whether the reply that set
   // `finalAnswerDelivered` was a *substantive* final answer (stream
   // `done`, or ≥200 chars) as opposed to a short pinging interim ACK.
@@ -4743,7 +4758,7 @@ function emitTurnRecord(turn: CurrentTurn, endedAt: number): void {
         agent: process.env.SWITCHROOM_AGENT_NAME ?? 'unknown',
         duration_ms: turn.startedAt > 0 ? endedAt - turn.startedAt : 0,
         tools: turn.toolCallCount ?? 0,
-        status: turn.finalAnswerDelivered ? 'complete' : 'no_reply',
+        status: computeTurnStatus(turn),
         turn_id: turn.turnId,
       }) + '\n'
     const turnsPath = '/state/agent/turns.jsonl'
@@ -4765,7 +4780,10 @@ function emitTurnRecord(turn: CurrentTurn, endedAt: number): void {
   }
 }
 
-function endCurrentTurnAtomic(turn: CurrentTurn): void {
+function endCurrentTurnAtomic(
+  turn: CurrentTurn,
+  opts?: { deferRecord?: boolean },
+): number | null {
   // PR-4e — keyed liveness + keyed clear (leak-close-at-origin). Flag-OFF: the
   // guard is `currentTurn === turn` and the clear nulls the singleton, verbatim.
   // Flag-ON: the guard becomes `byKey.get(turn'sKey) === turn` (so a flip to
@@ -4774,7 +4792,7 @@ function endCurrentTurnAtomic(turn: CurrentTurn): void {
   // `turn`. `endCurrentTurnForKey` returns false (no delete) when the entry no
   // longer matches — the same early-return semantics as the old `!== turn` guard.
   const key = statusKey(turn.sessionChatId, turn.sessionThreadId)
-  if (!turnLiveForItsTopic(turn)) return
+  if (!turnLiveForItsTopic(turn)) return null
   endCurrentTurnForKey(turn, key) // currentTurnByKey.delete(key) + mirror clear
   // Status-surface observability: one line at every turn CLEAR (with how far
   // the turn got), plus a DEGRADED warning when the turn did tool work but the
@@ -4783,7 +4801,15 @@ function endCurrentTurnAtomic(turn: CurrentTurn): void {
   process.stderr.write(
     `telegram gateway: ${formatTurnLifecycle('clear', 'turn_end', turn, turnEndedAt)}\n`,
   )
-  emitTurnRecord(turn, turnEndedAt)
+  // PR B — the turn-flush backstop defers the record write to its async send
+  // IIFE (passing `{ deferRecord: true }`) so the recorded `status` reflects the
+  // REAL send outcome (`turn.deliveryOutcome`) rather than the speculative
+  // `finalAnswerDelivered` flag set before the send ran. All synchronous
+  // turn-end paths still emit here, unchanged. `turnEndedAt` is returned so the
+  // deferred caller stamps the same ended-at (stable `duration_ms`).
+  if (opts?.deferRecord !== true) {
+    emitTurnRecord(turn, turnEndedAt)
+  }
   const degraded = detectStatusSurfaceDegraded(turn)
   if (degraded != null) {
     process.stderr.write(
@@ -4846,6 +4872,7 @@ function endCurrentTurnAtomic(turn: CurrentTurn): void {
   // wedging forever. No-op when this turn delivered, when nothing is
   // buffered, or when the serialize feature is off.
   armNoReplyDrainTimer(turn)
+  return turnEndedAt
 }
 
 /**
@@ -17553,7 +17580,15 @@ function handleSessionEvent(ev: SessionEvent): void {
         // sendMessage await for this turn will see currentTurn == null
         // and bail; a new enqueue will swap in a fresh atom. The
         // `backstop*` locals above hold everything the IIFE needs.
-        endCurrentTurnAtomic(turn)
+        //
+        // PR B — defer the turns.jsonl record write to the send IIFE below so
+        // the recorded `status` reflects the REAL send outcome, not the
+        // speculative `finalAnswerDelivered=true` set just above. Everything
+        // else in endCurrentTurnAtomic (atom null, gate release, obligation
+        // bookkeeping, purge) still runs synchronously here for the #1067 /
+        // #1556 wedge-safety reasons. `backstopTurnEndedAt` is null iff the
+        // atom was already torn down elsewhere (no record to emit).
+        const backstopTurnEndedAt = endCurrentTurnAtomic(turn, { deferRecord: true })
         // #549 fix — turn-flush takes ownership of the captured-text
         // backup; reset the preamble buffer (its content is already in
         // the captured `capturedText`, which turn-flush is about to send).
@@ -17593,6 +17628,15 @@ function handleSessionEvent(ev: SessionEvent): void {
                 // async IIFE ran). The old redundant purgeReactionTracking
                 // here re-fired on an already-cleared key WITHOUT `endingTurn`,
                 // emitting an inconsistent shadow trace. Removed.
+                //
+                // PR B — the reply tool already delivered this turn's answer, so
+                // the flush was legitimately suppressed. Emit the deferred record
+                // as 'suppressed' (→ `complete`, since the reply path set
+                // finalAnswerDelivered). Not a failure.
+                if (backstopTurnEndedAt != null) {
+                  turn.deliveryOutcome = 'suppressed'
+                  emitTurnRecord(turn, backstopTurnEndedAt)
+                }
                 return
               }
             } catch {}
@@ -17615,6 +17659,9 @@ function handleSessionEvent(ev: SessionEvent): void {
           const renderedText = capturedText
           const htmlChunks = splitMarkdownChunks(renderedText, limit)
           const sentIds: number[] = []
+          // PR B — track whether the send threw so the deferred record reflects
+          // the real outcome (throw OR partial multi-chunk → send_failed).
+          let sendThrew = false
           try {
             // #654 deterministic double-message fix. If the progress
             // card is on screen (60s timer fired before turn_end), edit
@@ -17723,10 +17770,25 @@ function handleSessionEvent(ev: SessionEvent): void {
               unpinProgressCardForChat?.(backstopChatId, backstopThreadId)
             }
           } catch (err) {
+            sendThrew = true
             process.stderr.write(`telegram gateway: turn-flush send failed: ${(err as Error).message}\n`)
             // #1713: backstop send failed — finalize as error so the
             // turn ends cleanly with 😱 rather than leaving it open.
             if (backstopCtrl) backstopCtrl.finalize('error')
+          }
+          // PR B — the send has now RESOLVED; stamp the real delivery outcome and
+          // emit the deferred turns.jsonl record from it. A throw or a partial
+          // multi-chunk delivery (sentIds < htmlChunks) → 'failed' → status
+          // `send_failed`; a full delivery → 'delivered' → `complete`. This
+          // replaces the false `complete` the old synchronous write produced for
+          // a flood-dropped / errored answer the user never received.
+          if (backstopTurnEndedAt != null) {
+            turn.deliveryOutcome = backstopSendOutcome({
+              threw: sendThrew,
+              sentCount: sentIds.length,
+              chunkCount: htmlChunks.length,
+            })
+            emitTurnRecord(turn, backstopTurnEndedAt)
           }
           // #2094 cosmetic: the trailing `finally { purgeReactionTracking() }`
           // was removed. endCurrentTurnAtomic already ran the canonical purge

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -609,8 +609,8 @@ import { resolveChatIdFallback } from './chat-id-fallback.js'
 import { decideObligationTurnEnd } from './obligation-turn-end.js'
 import { maybeRotate } from './turns-jsonl-rotate.js'
 import {
-  computeTurnStatus,
-  backstopSendOutcome,
+  buildTurnRecord,
+  finalizeBackstopSend,
   type DeliveryOutcome,
 } from './turn-record-status.js'
 import {
@@ -4753,14 +4753,19 @@ function releaseTurnBufferGate(key: string, endingTurn?: CurrentTurn): void {
 function emitTurnRecord(turn: CurrentTurn, endedAt: number): void {
   try {
     const rec =
-      JSON.stringify({
-        ts: Math.floor(endedAt / 1000),
-        agent: process.env.SWITCHROOM_AGENT_NAME ?? 'unknown',
-        duration_ms: turn.startedAt > 0 ? endedAt - turn.startedAt : 0,
-        tools: turn.toolCallCount ?? 0,
-        status: computeTurnStatus(turn),
-        turn_id: turn.turnId,
-      }) + '\n'
+      JSON.stringify(
+        buildTurnRecord(
+          {
+            agent: process.env.SWITCHROOM_AGENT_NAME ?? 'unknown',
+            startedAt: turn.startedAt,
+            toolCallCount: turn.toolCallCount ?? 0,
+            turnId: turn.turnId,
+            finalAnswerDelivered: turn.finalAnswerDelivered,
+            deliveryOutcome: turn.deliveryOutcome,
+          },
+          endedAt,
+        ),
+      ) + '\n'
     const turnsPath = '/state/agent/turns.jsonl'
     // Size-cap rotation: keep at most one rotated generation so the file can't
     // grow unbounded on a long-lived agent. Best-effort (never throws).
@@ -17550,6 +17555,17 @@ function handleSessionEvent(ev: SessionEvent): void {
         // that this branch never reaches, this set is belt-and-braces —
         // it keeps the captured `turn` atom internally consistent for any
         // future reader.)
+        // PR B (Fix 4 — intentional record/ledger inconsistency, out of scope).
+        // We keep setting finalAnswerDelivered=true HERE (before the async send)
+        // so endCurrentTurnAtomic's obligation CLOSE (decideObligationTurnEnd,
+        // ~4818) fires unchanged at turn end. PR B only makes the turns.jsonl
+        // *record* honest (status send_failed when the send later throws) — it
+        // deliberately does NOT change obligation behavior. Consequence: a
+        // send_failed turn still CLOSES its obligation, so a flood-dropped
+        // answer is NOT re-presented — an honest record without honest recovery.
+        // Re-delivery on send_failed (drive obligation close from real send
+        // success, leave it open on failure) is a separate change — see the
+        // PR-B handback FOLLOW-UP note; do NOT touch the ledger in this PR.
         turn.finalAnswerDelivered = true
         // Feed-reopen refinement: turn-flush delivers the model's terminal
         // transcript text as the genuine answer (not an ack). Default to
@@ -17651,18 +17667,24 @@ function handleSessionEvent(ev: SessionEvent): void {
             link_preview_options: { is_disabled: true },
           }
           const limit = RICH_MESSAGE_MAX_CHARS
-          // The `\n\n` block joins from turn-flush-safety.ts render as normal
-          // single blank lines under the Bot API 10.1 rich GFM path, so no
-          // spacer pass runs before splitting (the NBSP spacer was removed in
-          // the #2669 follow-up — it double-gapped every paragraph). Mirrors
-          // executeReply, which now also sends the normalized text as-is.
-          const renderedText = capturedText
-          const htmlChunks = splitMarkdownChunks(renderedText, limit)
+          // PR B (Fix 1) — send accounting is declared OUTSIDE the try so the
+          // single-record `finally` below can read it, and ALL setup (the chunk
+          // split) is pulled INSIDE the try so a throw there still lands in the
+          // finally (→ one honest `send_failed` row) rather than rejecting the
+          // IIFE with zero turns.jsonl rows written / an unhandled rejection.
+          let htmlChunks: string[] = []
           const sentIds: number[] = []
-          // PR B — track whether the send threw so the deferred record reflects
-          // the real outcome (throw OR partial multi-chunk → send_failed).
+          // track whether the send threw so the deferred record reflects the
+          // real outcome (throw OR partial multi-chunk → send_failed).
           let sendThrew = false
           try {
+            // The `\n\n` block joins from turn-flush-safety.ts render as normal
+            // single blank lines under the Bot API 10.1 rich GFM path, so no
+            // spacer pass runs before splitting (the NBSP spacer was removed in
+            // the #2669 follow-up — it double-gapped every paragraph). Mirrors
+            // executeReply, which now also sends the normalized text as-is.
+            const renderedText = capturedText
+            htmlChunks = splitMarkdownChunks(renderedText, limit)
             // #654 deterministic double-message fix. If the progress
             // card is on screen (60s timer fired before turn_end), edit
             // it in place with the first chunk of the answer instead of
@@ -17775,20 +17797,28 @@ function handleSessionEvent(ev: SessionEvent): void {
             // #1713: backstop send failed — finalize as error so the
             // turn ends cleanly with 😱 rather than leaving it open.
             if (backstopCtrl) backstopCtrl.finalize('error')
-          }
-          // PR B — the send has now RESOLVED; stamp the real delivery outcome and
-          // emit the deferred turns.jsonl record from it. A throw or a partial
-          // multi-chunk delivery (sentIds < htmlChunks) → 'failed' → status
-          // `send_failed`; a full delivery → 'delivered' → `complete`. This
-          // replaces the false `complete` the old synchronous write produced for
-          // a flood-dropped / errored answer the user never received.
-          if (backstopTurnEndedAt != null) {
-            turn.deliveryOutcome = backstopSendOutcome({
-              threw: sendThrew,
-              sentCount: sentIds.length,
-              chunkCount: htmlChunks.length,
-            })
-            emitTurnRecord(turn, backstopTurnEndedAt)
+          } finally {
+            // PR B (Fix 1) — SINGLE-RECORD GUARANTEE. The send has now RESOLVED
+            // (or thrown); this finally runs on EVERY in-process exit of the send
+            // block — clean send, throw in setup/split, throw mid-send — so
+            // exactly one turns.jsonl row is written, with the outcome reflecting
+            // what actually happened. A throw or a partial multi-chunk delivery
+            // (sentIds < htmlChunks) or an un-run/empty split → 'failed' → status
+            // `send_failed`; a full delivery → 'delivered' → `complete`. This
+            // replaces the false `complete` the old synchronous write produced
+            // for a flood-dropped / errored answer the user never received, and
+            // restores the old code's one-row-per-turn guarantee (the pre-finally
+            // shape wrote ZERO rows if setup threw). The suppressed-reply branch
+            // above already emitted its record and `return`ed BEFORE reaching
+            // this try, so it can never double-write with this finally.
+            if (backstopTurnEndedAt != null) {
+              finalizeBackstopSend(turn, {
+                threw: sendThrew,
+                sentCount: sentIds.length,
+                chunkCount: htmlChunks.length,
+              })
+              emitTurnRecord(turn, backstopTurnEndedAt)
+            }
           }
           // #2094 cosmetic: the trailing `finally { purgeReactionTracking() }`
           // was removed. endCurrentTurnAtomic already ran the canonical purge

--- a/telegram-plugin/gateway/turn-record-status.ts
+++ b/telegram-plugin/gateway/turn-record-status.ts
@@ -1,0 +1,75 @@
+/**
+ * Honest turn-record status derivation (PR B — "send-honesty" fix).
+ *
+ * `emitTurnRecord` historically wrote `status: finalAnswerDelivered ? 'complete'
+ * : 'no_reply'`. On the turn-flush / backstop paths `finalAnswerDelivered` is set
+ * BEFORE the async send actually runs, so a send that then throws (e.g.
+ * `FLOOD_WAIT_ACTIVE` during a flood ban) was still recorded `complete` — a turn
+ * where the user received NOTHING logged as delivered.
+ *
+ * The fix threads a per-turn `deliveryOutcome`, set only AFTER the send resolves,
+ * and derives the recorded status from that real outcome. These helpers are pure
+ * and injectable so the outcome ↔ status mapping is unit-testable without the
+ * 30k-line gateway module (mirrors `turns-jsonl-rotate.ts`).
+ */
+
+/**
+ * The resolved fate of a backstop (turn-flush) send, stamped on the turn only
+ * once the send has actually resolved:
+ * - `delivered`  — every chunk reached Telegram.
+ * - `failed`     — the send threw, OR a partial multi-chunk delivery (chunk 1 ok,
+ *                  a later chunk failed): the answer did not fully reach the user.
+ * - `suppressed` — the flush short-circuited because the reply tool already
+ *                  delivered this turn's answer (the 2s recent-outbound guard).
+ */
+export type DeliveryOutcome = 'delivered' | 'failed' | 'suppressed'
+
+/** The status strings written to turns.jsonl. `send_failed` is new in PR B. */
+export type TurnStatus = 'complete' | 'no_reply' | 'send_failed'
+
+/**
+ * Derive the recorded turn status from the turn's flags.
+ *
+ * `deliveryOutcome` (when present) is authoritative — it reflects the REAL send
+ * resolution on the backstop paths. When it is absent (the synchronous
+ * reply-tool tail, silent-marker, and genuine no-reply paths) we fall back to the
+ * legacy `finalAnswerDelivered` reading, preserving existing semantics exactly.
+ *
+ *   delivered            → complete
+ *   failed / partial     → send_failed   (NOT complete, NOT silently no_reply)
+ *   suppressed           → complete iff the reply path delivered, else no_reply
+ *   undefined (legacy)   → complete iff finalAnswerDelivered, else no_reply
+ *                          (fail-safe: an IIFE that dies before stamping an
+ *                          outcome never fabricates `complete`)
+ */
+export function computeTurnStatus(turn: {
+  finalAnswerDelivered: boolean
+  deliveryOutcome?: DeliveryOutcome
+}): TurnStatus {
+  switch (turn.deliveryOutcome) {
+    case 'failed':
+      return 'send_failed'
+    case 'delivered':
+      return 'complete'
+    case 'suppressed':
+      return turn.finalAnswerDelivered ? 'complete' : 'no_reply'
+    default:
+      return turn.finalAnswerDelivered ? 'complete' : 'no_reply'
+  }
+}
+
+/**
+ * Resolve a backstop send's outcome from what actually happened on the wire.
+ * A throw is a failure; a no-throw send that delivered fewer chunks than it
+ * split into is a partial delivery and is treated as `failed` (the user did not
+ * receive the whole answer) — never silently `delivered`/`complete`.
+ */
+export function backstopSendOutcome(args: {
+  threw: boolean
+  sentCount: number
+  chunkCount: number
+}): DeliveryOutcome {
+  if (args.threw) return 'failed'
+  if (args.sentCount < args.chunkCount) return 'failed'
+  return 'delivered'
+}

--- a/telegram-plugin/gateway/turn-record-status.ts
+++ b/telegram-plugin/gateway/turn-record-status.ts
@@ -70,6 +70,65 @@ export function backstopSendOutcome(args: {
   chunkCount: number
 }): DeliveryOutcome {
   if (args.threw) return 'failed'
+  // Defense (Fix 5): a "send" that split into zero chunks delivered nothing —
+  // do NOT let sentCount(0) < chunkCount(0) === false slip through to
+  // 'delivered'/'complete' (which would trip the silent-no-op-candidate
+  // detector on a tools:0 turn). Nothing sent → failed.
+  if (args.chunkCount === 0) return 'failed'
   if (args.sentCount < args.chunkCount) return 'failed'
   return 'delivered'
+}
+
+/**
+ * Stamp a turn's `deliveryOutcome` from a resolved backstop send. This is the
+ * exact accounting the turn-flush IIFE's `finally` performs — factored here so
+ * the gateway and the tests run the SAME mapping (a real send that throws or
+ * partially delivers must produce `send_failed`, never `complete`). Mutates and
+ * returns the resolved outcome.
+ */
+export function finalizeBackstopSend(
+  turn: { deliveryOutcome?: DeliveryOutcome },
+  send: { threw: boolean; sentCount: number; chunkCount: number },
+): DeliveryOutcome {
+  const outcome = backstopSendOutcome(send)
+  turn.deliveryOutcome = outcome
+  return outcome
+}
+
+/** The parsed shape of one turns.jsonl row. */
+export interface TurnRecordRow {
+  ts: number
+  agent: string
+  duration_ms: number
+  tools: number
+  status: TurnStatus
+  turn_id: string
+}
+
+/**
+ * Build the turns.jsonl row for a turn. The single source of truth for the
+ * `status` field — `emitTurnRecord` serializes exactly this, so a test that
+ * asserts on `buildTurnRecord(...).status` is asserting the value the gateway
+ * actually writes (proving `emitTurnRecord` derives status from the resolved
+ * `deliveryOutcome` via `computeTurnStatus`, not the speculative flag).
+ */
+export function buildTurnRecord(
+  turn: {
+    agent: string
+    startedAt: number
+    toolCallCount: number
+    turnId: string
+    finalAnswerDelivered: boolean
+    deliveryOutcome?: DeliveryOutcome
+  },
+  endedAt: number,
+): TurnRecordRow {
+  return {
+    ts: Math.floor(endedAt / 1000),
+    agent: turn.agent,
+    duration_ms: turn.startedAt > 0 ? endedAt - turn.startedAt : 0,
+    tools: turn.toolCallCount ?? 0,
+    status: computeTurnStatus(turn),
+    turn_id: turn.turnId,
+  }
 }

--- a/telegram-plugin/tests/per-topic-current-turn.test.ts
+++ b/telegram-plugin/tests/per-topic-current-turn.test.ts
@@ -60,8 +60,11 @@ describe('PR-4e source-read oracle — the wiring the per-topic map depends on',
   })
 
   it('endCurrentTurnAtomic closes the leak AT ORIGIN — keyed liveness guard + keyed delete', () => {
+    // Anchor on the `function ` prefix only — the signature is multi-line
+    // (gained an `opts?` param + `number | null` return in the send-honesty
+    // work), and `function ` disambiguates the definition from its call sites.
     const body = gatewaySrc
-      .split('function endCurrentTurnAtomic(turn: CurrentTurn): void {')[1]
+      .split('function endCurrentTurnAtomic(')[1]
       ?.split('\n}')[0] ?? ''
     expect(body.length).toBeGreaterThan(50)
     // Guard is the keyed liveness check (NOT a bare singleton ===).

--- a/telegram-plugin/tests/turn-record-status.test.ts
+++ b/telegram-plugin/tests/turn-record-status.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeTurnStatus,
+  backstopSendOutcome,
+  type DeliveryOutcome,
+} from '../gateway/turn-record-status.js'
+
+/**
+ * PR B — send-honesty. The turns.jsonl `status` must reflect the REAL send
+ * outcome, not the speculative `finalAnswerDelivered` flag the turn-flush
+ * backstop sets before its async send runs.
+ *
+ * These assert the recorded status OUTCOME for each turn shape — the exact
+ * string `emitTurnRecord` writes via `computeTurnStatus` — not merely that a
+ * code path ran. The turn-flush IIFE stamps `deliveryOutcome` from
+ * `backstopSendOutcome` once the send resolves, so the two helpers together are
+ * the whole decision the gateway makes.
+ */
+
+// Model the turn-flush send exactly as the gateway IIFE does: resolve the send,
+// stamp deliveryOutcome from what happened on the wire, then read the status.
+function recordedStatusForFlush(args: {
+  finalAnswerDelivered: boolean
+  threw: boolean
+  sentCount: number
+  chunkCount: number
+}) {
+  const deliveryOutcome: DeliveryOutcome = backstopSendOutcome({
+    threw: args.threw,
+    sentCount: args.sentCount,
+    chunkCount: args.chunkCount,
+  })
+  return computeTurnStatus({
+    finalAnswerDelivered: args.finalAnswerDelivered,
+    deliveryOutcome,
+  })
+}
+
+describe('computeTurnStatus — recorded turn status reflects real outcome', () => {
+  it('genuine no-reply turn → no_reply', () => {
+    // No backstop send happened; legacy flag path. Unchanged semantics.
+    expect(computeTurnStatus({ finalAnswerDelivered: false })).toBe('no_reply')
+  })
+
+  it('synchronous reply-tool delivery (no deliveryOutcome) → complete', () => {
+    // Reply-tool tail sets finalAnswerDelivered after its send loop and never
+    // stamps deliveryOutcome; the legacy reading still yields complete.
+    expect(computeTurnStatus({ finalAnswerDelivered: true })).toBe('complete')
+  })
+
+  it('reply-tool short-circuit suppressed the flush → complete (reply delivered)', () => {
+    expect(
+      computeTurnStatus({ finalAnswerDelivered: true, deliveryOutcome: 'suppressed' }),
+    ).toBe('complete')
+  })
+
+  it('fail-safe: undefined outcome + finalAnswerDelivered false never fabricates complete', () => {
+    expect(computeTurnStatus({ finalAnswerDelivered: false, deliveryOutcome: undefined })).toBe(
+      'no_reply',
+    )
+  })
+})
+
+describe('turn-flush send outcome → recorded status', () => {
+  it('send SUCCEEDS (all chunks delivered) → complete', () => {
+    expect(
+      recordedStatusForFlush({
+        finalAnswerDelivered: true,
+        threw: false,
+        sentCount: 2,
+        chunkCount: 2,
+      }),
+    ).toBe('complete')
+  })
+
+  it('send THROWS (simulated FLOOD_WAIT_ACTIVE) → send_failed', () => {
+    // BUG ORACLE: on the pre-fix code, `finalAnswerDelivered=true` was written
+    // BEFORE the send ran and the record read that flag → status 'complete'
+    // even though the send threw and the user received nothing. Assert the fix:
+    // the resolved outcome makes the record honest.
+    const status = recordedStatusForFlush({
+      finalAnswerDelivered: true, // speculatively set at gateway.ts:17526
+      threw: true, // FLOOD_WAIT_ACTIVE caught at the send catch
+      sentCount: 0,
+      chunkCount: 1,
+    })
+    expect(status).toBe('send_failed')
+    expect(status).not.toBe('complete') // the false-delivered defect must be gone
+  })
+
+  it('PARTIAL multi-chunk (chunk 1 ok, chunk 2 fails) → send_failed, not complete', () => {
+    // No throw is even required to be dishonest — a truncated answer is not a
+    // delivered answer.
+    const status = recordedStatusForFlush({
+      finalAnswerDelivered: true,
+      threw: true, // the loop threw on chunk 2 after chunk 1 landed
+      sentCount: 1,
+      chunkCount: 3,
+    })
+    expect(status).toBe('send_failed')
+  })
+
+  it('backstopSendOutcome: no throw but short delivery is still failed (partial)', () => {
+    expect(backstopSendOutcome({ threw: false, sentCount: 1, chunkCount: 2 })).toBe('failed')
+  })
+
+  it('backstopSendOutcome: full delivery is delivered', () => {
+    expect(backstopSendOutcome({ threw: false, sentCount: 3, chunkCount: 3 })).toBe('delivered')
+  })
+})

--- a/telegram-plugin/tests/turn-record-status.test.ts
+++ b/telegram-plugin/tests/turn-record-status.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest'
 import {
   computeTurnStatus,
   backstopSendOutcome,
+  finalizeBackstopSend,
+  buildTurnRecord,
   type DeliveryOutcome,
 } from '../gateway/turn-record-status.js'
 
@@ -12,40 +14,15 @@ import {
  * backstop sets before its async send runs.
  *
  * These assert the recorded status OUTCOME for each turn shape — the exact
- * string `emitTurnRecord` writes via `computeTurnStatus` — not merely that a
- * code path ran. The turn-flush IIFE stamps `deliveryOutcome` from
- * `backstopSendOutcome` once the send resolves, so the two helpers together are
- * the whole decision the gateway makes.
+ * string `emitTurnRecord` writes — not merely that a code path ran.
  */
-
-// Model the turn-flush send exactly as the gateway IIFE does: resolve the send,
-// stamp deliveryOutcome from what happened on the wire, then read the status.
-function recordedStatusForFlush(args: {
-  finalAnswerDelivered: boolean
-  threw: boolean
-  sentCount: number
-  chunkCount: number
-}) {
-  const deliveryOutcome: DeliveryOutcome = backstopSendOutcome({
-    threw: args.threw,
-    sentCount: args.sentCount,
-    chunkCount: args.chunkCount,
-  })
-  return computeTurnStatus({
-    finalAnswerDelivered: args.finalAnswerDelivered,
-    deliveryOutcome,
-  })
-}
 
 describe('computeTurnStatus — recorded turn status reflects real outcome', () => {
   it('genuine no-reply turn → no_reply', () => {
-    // No backstop send happened; legacy flag path. Unchanged semantics.
     expect(computeTurnStatus({ finalAnswerDelivered: false })).toBe('no_reply')
   })
 
   it('synchronous reply-tool delivery (no deliveryOutcome) → complete', () => {
-    // Reply-tool tail sets finalAnswerDelivered after its send loop and never
-    // stamps deliveryOutcome; the legacy reading still yields complete.
     expect(computeTurnStatus({ finalAnswerDelivered: true })).toBe('complete')
   })
 
@@ -62,50 +39,81 @@ describe('computeTurnStatus — recorded turn status reflects real outcome', () 
   })
 })
 
-describe('turn-flush send outcome → recorded status', () => {
-  it('send SUCCEEDS (all chunks delivered) → complete', () => {
-    expect(
-      recordedStatusForFlush({
-        finalAnswerDelivered: true,
-        threw: false,
-        sentCount: 2,
-        chunkCount: 2,
-      }),
-    ).toBe('complete')
+describe('backstopSendOutcome — resolve outcome from what happened on the wire', () => {
+  it('throw → failed', () => {
+    expect(backstopSendOutcome({ threw: true, sentCount: 0, chunkCount: 1 })).toBe('failed')
   })
 
-  it('send THROWS (simulated FLOOD_WAIT_ACTIVE) → send_failed', () => {
-    // BUG ORACLE: on the pre-fix code, `finalAnswerDelivered=true` was written
-    // BEFORE the send ran and the record read that flag → status 'complete'
-    // even though the send threw and the user received nothing. Assert the fix:
-    // the resolved outcome makes the record honest.
-    const status = recordedStatusForFlush({
-      finalAnswerDelivered: true, // speculatively set at gateway.ts:17526
-      threw: true, // FLOOD_WAIT_ACTIVE caught at the send catch
-      sentCount: 0,
-      chunkCount: 1,
-    })
-    expect(status).toBe('send_failed')
-    expect(status).not.toBe('complete') // the false-delivered defect must be gone
-  })
-
-  it('PARTIAL multi-chunk (chunk 1 ok, chunk 2 fails) → send_failed, not complete', () => {
-    // No throw is even required to be dishonest — a truncated answer is not a
-    // delivered answer.
-    const status = recordedStatusForFlush({
-      finalAnswerDelivered: true,
-      threw: true, // the loop threw on chunk 2 after chunk 1 landed
-      sentCount: 1,
-      chunkCount: 3,
-    })
-    expect(status).toBe('send_failed')
-  })
-
-  it('backstopSendOutcome: no throw but short delivery is still failed (partial)', () => {
+  it('partial (no throw, short delivery) → failed', () => {
     expect(backstopSendOutcome({ threw: false, sentCount: 1, chunkCount: 2 })).toBe('failed')
   })
 
-  it('backstopSendOutcome: full delivery is delivered', () => {
+  it('full delivery → delivered', () => {
     expect(backstopSendOutcome({ threw: false, sentCount: 3, chunkCount: 3 })).toBe('delivered')
+  })
+
+  it('Fix 5 — empty split (0 chunks, no throw) → failed, not delivered', () => {
+    expect(backstopSendOutcome({ threw: false, sentCount: 0, chunkCount: 0 })).toBe('failed')
+  })
+})
+
+/**
+ * Fix 3 — WIRING integration. These drive the SAME seams the gateway
+ * turn-flush IIFE runs — `finalizeBackstopSend` (the stamp) feeding
+ * `buildTurnRecord` (which `emitTurnRecord` serializes verbatim) — and assert
+ * the RECORDED status string. If the accounting stamps the wrong branch, or the
+ * record builder ever reverted to the speculative `finalAnswerDelivered`
+ * ternary, these fail — not just if the pure predicate is wrong.
+ */
+describe('turn-flush wiring → recorded turns.jsonl status', () => {
+  const ENDED_AT = 1_700_000_500_000
+  const mkTurn = () => ({
+    agent: 'test-agent',
+    startedAt: ENDED_AT - 5_000,
+    toolCallCount: 0,
+    turnId: 'turn-abc',
+    // speculatively set at gateway.ts flush site BEFORE the send runs:
+    finalAnswerDelivered: true,
+    deliveryOutcome: undefined as DeliveryOutcome | undefined,
+  })
+
+  const recordAfterSend = (send: { threw: boolean; sentCount: number; chunkCount: number }) => {
+    const turn = mkTurn()
+    finalizeBackstopSend(turn, send) // mutates turn.deliveryOutcome — as the IIFE does
+    return buildTurnRecord(turn, ENDED_AT)
+  }
+
+  it('send SUCCEEDS (all chunks delivered) → complete', () => {
+    expect(recordAfterSend({ threw: false, sentCount: 2, chunkCount: 2 }).status).toBe('complete')
+  })
+
+  it('send THROWS (simulated FLOOD_WAIT_ACTIVE) → send_failed, never complete', () => {
+    // BUG ORACLE: pre-fix, `finalAnswerDelivered=true` was written BEFORE the
+    // send ran and the record read that flag → 'complete' even though the send
+    // threw and the user got nothing. Assert the wired outcome is honest.
+    const rec = recordAfterSend({ threw: true, sentCount: 0, chunkCount: 1 })
+    expect(rec.status).toBe('send_failed')
+    expect(rec.status).not.toBe('complete')
+  })
+
+  it('PARTIAL multi-chunk (chunk 1 ok, chunk 2 throws) → send_failed', () => {
+    expect(recordAfterSend({ threw: true, sentCount: 1, chunkCount: 3 }).status).toBe('send_failed')
+  })
+
+  it('reply-tool suppressed the flush → complete (reply delivered), via the stamp', () => {
+    const turn = mkTurn()
+    turn.deliveryOutcome = 'suppressed' // the IIFE's suppressed-branch stamp
+    expect(buildTurnRecord(turn, ENDED_AT).status).toBe('complete')
+  })
+
+  it('record carries the honest tuple (tools + duration) alongside status', () => {
+    const rec = recordAfterSend({ threw: true, sentCount: 0, chunkCount: 1 })
+    expect(rec).toMatchObject({
+      status: 'send_failed',
+      tools: 0,
+      duration_ms: 5_000,
+      turn_id: 'turn-abc',
+      agent: 'test-agent',
+    })
   })
 })


### PR DESCRIPTION
## What

PR 1 of 2 fixing the fleet-wide "silent turn" pattern (fleet-health `silent-no-op-candidate`, 8/11 agents). This is the **send-honesty** fix; the latency fix follows in PR 2.

## Problem

The turn record was written from a **speculative pre-send flag**. In the turn-flush backstop, `turn.finalAnswerDelivered = true` is set *before* the async send runs, and `emitTurnRecord` wrote `status: finalAnswerDelivered ? 'complete' : 'no_reply'` synchronously. So a send that then throws (e.g. `FLOOD_WAIT_ACTIVE` during a flood ban) was still recorded `complete` = delivered, while the user received nothing. The health data lied about dropped messages.

## Fix

- New per-turn `deliveryOutcome`, stamped only **after** the send resolves.
- New pure module `turn-record-status.ts` (`computeTurnStatus` / `backstopSendOutcome` / `finalizeBackstopSend` / `buildTurnRecord`) — the single source of the recorded status string.
- New `send_failed` status (distinct from `complete` and `no_reply`); a throw **or** a partial multi-chunk send resolves to `send_failed`.
- Record write deferred to a `finally` in the turn-flush IIFE → exactly one row on every in-process exit path (clean / setup-throw / mid-send-throw / empty), never a false `complete`.
- fleet-health `detect.ts`: explicit `send-failed-delivery` signal so a failed send is surfaced honestly, not mislabeled as `killed-incomplete-turn`.

Observation-only: no send call, retry, or send-gate behavior changed (P0 never-storm preserved).

## Tests

Scoped vitest: `turn-record-status.test.ts` (13, incl. real-wiring integration + throw→`send_failed` bug oracle), `detect.test.ts` (12). Lint clean.

## Follow-ups (filed, out of scope)

- A `send_failed` turn still closes its obligation → answer logged as failed but not re-presented (honest record without honest recovery). Candidate for a re-delivery PR.
- Sibling stream-finalized backstop has the same intent-before-outcome shape; identical treatment as a follow-up.
- SIGKILL during the deferred window writes no row (covered by the gateway-log killed-process detector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)