### PR TITLE
fix(telegram): ~1s answer-ready flush — deliver composed replies immediately, not via the ~3min backstop (PR 2/2 silent-turn)

### DIFF
--- a/telegram-plugin/answer-ready-flush.ts
+++ b/telegram-plugin/answer-ready-flush.ts
@@ -1,0 +1,87 @@
+/**
+ * Answer-ready quiescence flush (PR A — "late-delivery" fix).
+ *
+ * A "silent no-op" turn ends by emitting its final answer as plain transcript
+ * `text` (never calling the reply tool). Today that answer is only delivered
+ * when claude's `turn_duration`/`turn_end` signal lands — a signal that is
+ * KNOWN-UNRELIABLE for terminal-text turns (gateway.ts:13616-13618,
+ * 12992-12993). When it doesn't land, delivery falls to the orphaned-reply
+ * backstop, whose fuse is itself re-armed by the very answer text it is waiting
+ * on (the terminal text stamps `lastStreamEventAt`, so `recentlyStreaming`
+ * keeps deferring the ~30 s fuse across the full ~120 s window). Net: a fully
+ * composed answer sits ~150-196 s of dead wait AFTER it was ready.
+ *
+ * This module provides the DETERMINISTIC positive signal that closes that gap:
+ * once a turn has a genuine composed terminal answer AND goes quiescent (no
+ * in-flight tool, no pending async/background dispatch, no new stream event)
+ * for a short debounce (~1 s), a per-turn timer fires and routes the answer
+ * into the SAME existing turn-flush send path immediately — instead of waiting
+ * on the unreliable turn_end or the multi-minute backstop.
+ *
+ * The arm/fire decision is factored here as a pure, injectable predicate so the
+ * oracle asserts real behavior (mirrors `turn-record-status.ts` /
+ * `context-exhaustion.ts`). The gateway feeds it the SAME `decideTurnFlush`
+ * classifier the turn-flush branch uses, so a working-preamble, an ack, a tool
+ * preamble, or a genuine NO_REPLY turn never arms a spurious flush.
+ */
+
+import { decideTurnFlush, type FlushDecisionInput } from './turn-flush-safety.js'
+
+/** Default answer-ready quiescence debounce (ms). Ken approved ~1 s as
+ *  "immediate". Env-tunable via SWITCHROOM_ANSWER_READY_FLUSH_MS; 0 (or any
+ *  non-positive value) is the kill-switch that disables the flush entirely,
+ *  matching the repo's env-flag convention. */
+export const ANSWER_READY_FLUSH_MS = 1000
+
+/**
+ * Resolve the debounce window from the environment. Returns a positive integer
+ * ms, or 0 when disabled (kill-switch) / unparseable / non-positive. The
+ * gateway treats 0 as "never arm", so a bad env value fails safe to the default
+ * rather than to a hot-loop.
+ */
+export function resolveAnswerReadyFlushMs(
+  env: Record<string, string | undefined>,
+): number {
+  const raw = env.SWITCHROOM_ANSWER_READY_FLUSH_MS
+  if (raw == null || raw.trim() === '') return ANSWER_READY_FLUSH_MS
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return ANSWER_READY_FLUSH_MS
+  // Explicit 0 (or negative) = operator kill-switch → disabled.
+  if (n <= 0) return 0
+  return Math.floor(n)
+}
+
+export interface AnswerReadyArmInput {
+  /** The exact `decideTurnFlush` inputs the turn-flush branch resolves at
+   *  turn_end. Reusing the classifier is what guarantees the debounce only
+   *  fires on a genuine composed final answer — never a silent marker, an
+   *  empty turn, a reply-already-served turn, or a sub-agent turn. */
+  flush: FlushDecisionInput
+  /** `toolFlightTracker.inFlightCount()` — a live surface tool means the model
+   *  is still working, not quiescent. */
+  inFlightToolCount: number
+  /** `pendingProgress.hasPendingAsyncDispatch(key)` — a detached background
+   *  dispatch (Bash run_in_background, async tool) means work is still pending
+   *  even though `inFlightCount` is 0. */
+  hasPendingAsyncDispatch: boolean
+  /** The resolved debounce window; 0 disables (kill-switch). */
+  flushWindowMs: number
+}
+
+/**
+ * Should the answer-ready quiescence timer be armed / fired right now?
+ *
+ * True iff the kill-switch is off AND the turn has a genuine flushable answer
+ * (`decideTurnFlush` → `flush`) AND the turn is genuinely quiescent (no
+ * in-flight surface tool, no pending async/background dispatch). This same
+ * predicate gates BOTH the arm (in the `text` handler) AND the fire-time
+ * re-verification (in the timer callback) — so a tool that started after the
+ * arm, or a reply that landed in the interim, deterministically cancels the
+ * flush at fire time even if the explicit disarm was somehow missed.
+ */
+export function shouldArmAnswerReadyFlush(input: AnswerReadyArmInput): boolean {
+  if (input.flushWindowMs <= 0) return false
+  if (input.inFlightToolCount > 0) return false
+  if (input.hasPendingAsyncDispatch) return false
+  return decideTurnFlush(input.flush).kind === 'flush'
+}

--- a/telegram-plugin/answer-ready-flush.ts
+++ b/telegram-plugin/answer-ready-flush.ts
@@ -85,3 +85,103 @@ export function shouldArmAnswerReadyFlush(input: AnswerReadyArmInput): boolean {
   if (input.hasPendingAsyncDispatch) return false
   return decideTurnFlush(input.flush).kind === 'flush'
 }
+
+/** Opaque timer handle. Real code passes Node's `setTimeout` return; tests can
+ *  inject fake-timer handles. */
+export type FlushTimerHandle = ReturnType<typeof setTimeout>
+
+/**
+ * Injectable dependencies for {@link AnswerReadyFlushController}. Everything the
+ * orchestration needs from the gateway is threaded through here so the REAL
+ * arm / debounce / rollover-guard / fire-time-re-verify / disarm logic is
+ * unit-testable without importing the 30k-line gateway module (which has a
+ * top-level startup IIFE and cannot be imported). `Turn` is the gateway's
+ * `CurrentTurn`; the controller only touches it through these accessors.
+ */
+export interface AnswerReadyFlushDeps<Turn> {
+  /** The live turn atom (gateway `currentTurn`). Read at arm time and re-read at
+   *  fire time so a superseded turn's timer never fires against a fresh atom. */
+  getCurrentTurn(): Turn | null
+  /** Resolve the `shouldArmAnswerReadyFlush` inputs for a turn (chat/reply/
+   *  captured-text + live tool-flight + pending-async + the window). */
+  getArmInput(turn: Turn): AnswerReadyArmInput
+  /** Read / write the per-turn timer handle (stored on the `CurrentTurn`). */
+  getTimerHandle(turn: Turn): FlushTimerHandle | null
+  setTimerHandle(turn: Turn, handle: FlushTimerHandle | null): void
+  /**
+   * Deliver the composed answer — dispatch the positive `answer-ready-quiescence`
+   * synthetic turn_end that routes through the EXISTING turn-flush send path
+   * (endCurrentTurnAtomic → send-gated IIFE → PR-B honest record). The controller
+   * calls this AT MOST ONCE per turn (guarded by the rollover + timer-cleared
+   * checks). endCurrentTurnAtomic then nulls the atom, so a later real turn_end
+   * short-circuits — the exactly-once guarantee.
+   */
+  onFlush(turn: Turn): void
+  /** Injectable timer primitives (default to the globals). */
+  setTimeoutFn?: (fn: () => void, ms: number) => FlushTimerHandle
+  clearTimeoutFn?: (handle: FlushTimerHandle) => void
+  log?: (msg: string) => void
+}
+
+/**
+ * The deterministic answer-ready quiescence flush orchestration, extracted from
+ * the gateway so it is testable as a unit (mirrors `withTurnEndGateBackstop`).
+ *
+ * - `reset()` — called from `case 'text'`: clear any pending timer, then (re)arm
+ *   iff the turn currently classifies as a genuine flushable answer AND is
+ *   quiescent. Each text chunk re-arms → the debounce.
+ * - `clear(turn)` — the DISARM: called on any tool activity and from
+ *   `endCurrentTurnAtomic`. A real turn_end that lands first cancels a pending
+ *   flush (exactly-once), and a resumed turn (tool started) cancels a stale one.
+ *
+ * On fire the controller re-pins `getCurrentTurn() === turn` (rollover guard),
+ * clears the handle, RE-VERIFIES quiescence (a tool that started / a reply that
+ * landed since the arm cancels the flush deterministically), then dispatches
+ * exactly one `onFlush`.
+ */
+export class AnswerReadyFlushController<Turn> {
+  constructor(private readonly deps: AnswerReadyFlushDeps<Turn>) {}
+
+  private get setTimeoutFn(): (fn: () => void, ms: number) => FlushTimerHandle {
+    return this.deps.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms))
+  }
+
+  private get clearTimeoutFn(): (handle: FlushTimerHandle) => void {
+    return this.deps.clearTimeoutFn ?? ((h) => clearTimeout(h))
+  }
+
+  /** Disarm the flush timer for a turn (idempotent). */
+  clear(turn: Turn | null): void {
+    if (turn == null) return
+    const handle = this.deps.getTimerHandle(turn)
+    if (handle != null) {
+      this.clearTimeoutFn(handle)
+      this.deps.setTimerHandle(turn, null)
+    }
+  }
+
+  /** (Re)arm the flush timer for the current turn — the debounce. */
+  reset(): void {
+    const turn = this.deps.getCurrentTurn()
+    this.clear(turn)
+    if (turn == null) return
+    const armInput = this.deps.getArmInput(turn)
+    if (!shouldArmAnswerReadyFlush(armInput)) return
+    const handle = this.setTimeoutFn(() => this.onExpiry(turn), armInput.flushWindowMs)
+    this.deps.setTimerHandle(turn, handle)
+  }
+
+  /** Timer-expiry callback. Re-pins the turn, re-verifies quiescence, fires once. */
+  private onExpiry(armedTurn: Turn): void {
+    const live = this.deps.getCurrentTurn()
+    // Rollover guard: a superseded turn's timer must not fire against a fresh atom.
+    if (live == null || live !== armedTurn) return
+    this.deps.setTimerHandle(live, null)
+    // Fire-time re-verification: a tool that started (or a reply that landed)
+    // since the arm deterministically cancels the flush even if the explicit
+    // disarm was somehow missed.
+    if (!shouldArmAnswerReadyFlush(this.deps.getArmInput(live))) return
+    this.deps.log?.('answer-ready quiescence flush — delivering composed terminal answer')
+    this.deps.onFlush(live)
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -401,7 +401,7 @@ import {
 } from '../turn-flush-safety.js'
 // PR A — deterministic answer-ready quiescence flush (late-delivery fix).
 import {
-  shouldArmAnswerReadyFlush,
+  AnswerReadyFlushController,
   resolveAnswerReadyFlushMs,
 } from '../answer-ready-flush.js'
 // #1667 — pure decision core for the turn_end answer-delivery gate (#1664).
@@ -15368,43 +15368,36 @@ function resetOrphanedReplyTimeout(): void {
 }
 
 /**
- * PR A — clear the answer-ready quiescence flush timer for a turn. Called from
- * every disarm point (tool activity, reply, `endCurrentTurnAtomic`) so a resumed
- * turn or an already-delivered answer never fires a stale flush.
- */
-function clearAnswerReadyFlushTimeout(turn: CurrentTurn | null): void {
-  if (turn?.answerReadyFlushTimeoutId != null) {
-    clearTimeout(turn.answerReadyFlushTimeoutId)
-    turn.answerReadyFlushTimeoutId = null
-  }
-}
-
-/**
- * PR A — DETERMINISTIC answer-ready quiescence flush.
+ * PR A — DETERMINISTIC answer-ready quiescence flush controller.
  *
- * (Re)arm a short per-turn timer whenever the current turn has a genuine
- * composed terminal answer (the SAME `decideTurnFlush` classifier the turn-flush
- * branch uses) AND is quiescent (no in-flight surface tool, no pending async
- * dispatch). Each new `text` chunk re-arms it (the debounce), so the timer only
- * fires after ~1 s of NO new stream events and NO tool activity — i.e. once the
- * answer has settled. On fire it re-verifies the SAME predicate and, if still
- * quiescent, dispatches a positive `answer-ready-quiescence` synthetic turn_end
- * that routes through the identical turn-flush send path (endCurrentTurnAtomic
- * → send-gated IIFE → honest PR-B record). This replaces the ~150 s dead wait
- * with ~1 s, deterministically and in code.
+ * The orchestration (arm / debounce / rollover-guard / fire-time re-verify /
+ * disarm) lives in the extracted, unit-tested `AnswerReadyFlushController`
+ * (answer-ready-flush.ts) — the gateway only supplies the thin deps below and
+ * calls `.reset()` / `.clear(turn)`. Behaviour:
  *
- * Exactly-once: the synthetic turn_end's `endCurrentTurnAtomic` nulls the turn
- * atom, so a later REAL turn_end (or the orphaned backstop) short-circuits at
- * its `turn != null` guard; `outboundDedup` is the second layer. The fire
- * callback also re-pins `currentTurn === turn` (rollover guard) and clears its
- * own id before dispatch.
+ * - `reset()` (from `case 'text'`): (re)arm iff the turn has a genuine composed
+ *   terminal answer (the SAME `decideTurnFlush` classifier the turn-flush branch
+ *   uses) AND is quiescent. Each text chunk re-arms → the debounce.
+ * - `clear(turn)` (from tool activity + `endCurrentTurnAtomic`): the DISARM.
+ * - on fire: re-pin `currentTurn === turn`, re-verify quiescence, then dispatch
+ *   a positive `answer-ready-quiescence` synthetic turn_end that routes through
+ *   the IDENTICAL turn-flush send path (endCurrentTurnAtomic → send-gated IIFE →
+ *   honest PR-B record). Replaces the ~150 s dead wait with ~1 s, in code.
+ *
+ * Exactly-once: the synthetic turn_end's `endCurrentTurnAtomic` nulls the atom,
+ * so a later REAL turn_end (or the orphaned backstop) short-circuits at its
+ * `turn != null` guard; `endCurrentTurnAtomic` also calls `.clear(turn)` so a
+ * real turn_end that lands FIRST cancels a pending flush. `outboundDedup` is the
+ * second layer.
+ *
+ * The `answer-ready-quiescence` reason bypasses the `durationMs===-1`
+ * recently-streaming SUPPRESSION guard (the terminal answer text itself stamps
+ * recentlyStreaming): quiescence IS the positive "streaming has settled" signal,
+ * the opposite of the hung-turn backstop that guard protects.
  */
-function resetAnswerReadyFlushTimeout(): void {
-  const turn = currentTurn
-  clearAnswerReadyFlushTimeout(turn)
-  if (turn == null) return
-  const key = statusKey(turn.sessionChatId, turn.sessionThreadId)
-  const armInput = {
+const answerReadyFlush = new AnswerReadyFlushController<CurrentTurn>({
+  getCurrentTurn: () => currentTurn,
+  getArmInput: (turn) => ({
     flush: {
       chatId: turn.sessionChatId,
       replyCalled: turn.replyCalled,
@@ -15412,46 +15405,28 @@ function resetAnswerReadyFlushTimeout(): void {
       flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
     },
     inFlightToolCount: toolFlightTracker.inFlightCount(),
-    hasPendingAsyncDispatch: pendingProgress.hasPendingAsyncDispatch(key),
+    hasPendingAsyncDispatch: pendingProgress.hasPendingAsyncDispatch(
+      statusKey(turn.sessionChatId, turn.sessionThreadId),
+    ),
     flushWindowMs: ANSWER_READY_FLUSH_MS,
-  }
-  if (!shouldArmAnswerReadyFlush(armInput)) return
-  turn.answerReadyFlushTimeoutId = setTimeout(() => {
-    // Rollover guard (mirrors the orphaned-reply timer): re-read currentTurn so
-    // a superseded turn's timer never fires against a fresh atom.
-    const t = currentTurn
-    if (t == null || t !== turn) return
-    t.answerReadyFlushTimeoutId = null
-    // Re-verify quiescence at FIRE time: a tool that started, or a reply that
-    // landed, since the arm deterministically cancels the flush here even if the
-    // explicit disarm was missed.
-    const fireKey = statusKey(t.sessionChatId, t.sessionThreadId)
-    const stillQuiescent = shouldArmAnswerReadyFlush({
-      flush: {
-        chatId: t.sessionChatId,
-        replyCalled: t.replyCalled,
-        capturedText: t.capturedText,
-        flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
-      },
-      inFlightToolCount: toolFlightTracker.inFlightCount(),
-      hasPendingAsyncDispatch: pendingProgress.hasPendingAsyncDispatch(fireKey),
-      flushWindowMs: ANSWER_READY_FLUSH_MS,
-    })
-    if (!stillQuiescent) return
-    process.stderr.write(
-      `telegram gateway: answer-ready quiescence flush (${ANSWER_READY_FLUSH_MS}ms) —` +
-      ` delivering composed terminal answer` +
-      ` (in_flight=${toolFlightTracker.inFlightCount()},` +
-      ` bg_work=${pendingProgress.hasPendingAsyncDispatch(fireKey)})\n`,
-    )
-    // Route through the identical turn-flush path. A positive
-    // `answer-ready-quiescence` reason bypasses the `durationMs===-1`
-    // recently-streaming SUPPRESSION guard (which would otherwise defer this —
-    // the terminal answer text itself stamps recentlyStreaming): quiescence IS
-    // the positive "streaming has settled" signal, the opposite of the hung-turn
-    // backstop that guard protects.
-    handleSessionEvent({ kind: 'turn_end', durationMs: -1, reason: 'answer-ready-quiescence' })
-  }, ANSWER_READY_FLUSH_MS)
+  }),
+  getTimerHandle: (turn) => turn.answerReadyFlushTimeoutId,
+  setTimerHandle: (turn, handle) => {
+    turn.answerReadyFlushTimeoutId = handle
+  },
+  onFlush: () =>
+    handleSessionEvent({ kind: 'turn_end', durationMs: -1, reason: 'answer-ready-quiescence' }),
+  log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
+})
+
+/** PR A — disarm the answer-ready flush timer for a turn (thin adapter). */
+function clearAnswerReadyFlushTimeout(turn: CurrentTurn | null): void {
+  answerReadyFlush.clear(turn)
+}
+
+/** PR A — (re)arm the answer-ready flush timer for the current turn (debounce). */
+function resetAnswerReadyFlushTimeout(): void {
+  answerReadyFlush.reset()
 }
 
 function closeActivityLane(chatId: string, threadId: number | undefined): void {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -399,6 +399,11 @@ import {
   decideTurnFlush,
   isTurnFlushSafetyEnabled,
 } from '../turn-flush-safety.js'
+// PR A — deterministic answer-ready quiescence flush (late-delivery fix).
+import {
+  shouldArmAnswerReadyFlush,
+  resolveAnswerReadyFlushMs,
+} from '../answer-ready-flush.js'
 // #1667 — pure decision core for the turn_end answer-delivery gate (#1664).
 import { decideTurnEndGate } from './turn-end-gate.js'
 // #1122 PR3: turn-flush-prose-recovery removed with the progress card.
@@ -3115,6 +3120,14 @@ type CurrentTurn = {
   silentAnchorText: string
   capturedText: string[]
   orphanedReplyTimeoutId: ReturnType<typeof setTimeout> | null
+  // PR A — answer-ready quiescence flush timer. Armed in `case 'text'` once the
+  // turn has a genuine composed terminal answer and is quiescent; fires a
+  // positive `answer-ready-quiescence` synthetic turn_end after the ~1 s
+  // debounce so the answer is delivered deterministically instead of waiting on
+  // the unreliable turn_duration signal or the ~150 s orphaned-reply backstop.
+  // Cleared on any tool activity, on `endCurrentTurnAtomic`, and re-armed on
+  // each subsequent text chunk (the debounce).
+  answerReadyFlushTimeoutId: ReturnType<typeof setTimeout> | null
   // Per-turn liveness tracker for the orphaned-reply backstop. Owns
   // `lastStreamEventAt` (stamped on ANY genuine stream event so a model
   // reasoning pause keeps the turn "recently streaming" and re-arms the fuse
@@ -4798,6 +4811,11 @@ function endCurrentTurnAtomic(
   // longer matches — the same early-return semantics as the old `!== turn` guard.
   const key = statusKey(turn.sessionChatId, turn.sessionThreadId)
   if (!turnLiveForItsTopic(turn)) return null
+  // PR A — the turn is ending (this is the ONE place every turn-end path funnels
+  // through, incl. the answer-ready flush's own synthetic turn_end). Clear the
+  // quiescence timer so a real turn_end that lands first cancels a pending flush,
+  // guaranteeing exactly-once delivery.
+  clearAnswerReadyFlushTimeout(turn)
   endCurrentTurnForKey(turn, key) // currentTurnByKey.delete(key) + mirror clear
   // Status-surface observability: one line at every turn CLEAR (with how far
   // the turn got), plus a DEGRADED warning when the turn did tool work but the
@@ -8156,6 +8174,10 @@ const STREAM_THROTTLE_MS_OVERRIDE: number | undefined = (() => {
   return Number.isFinite(n) && n >= 0 ? n : undefined
 })()
 const TURN_FLUSH_SAFETY_ENABLED = isTurnFlushSafetyEnabled()
+
+// PR A — answer-ready quiescence flush debounce (ms). 0 = kill-switch (never
+// arm). Resolved once at boot; env-tunable via SWITCHROOM_ANSWER_READY_FLUSH_MS.
+const ANSWER_READY_FLUSH_MS = resolveAnswerReadyFlushMs(process.env)
 
 // When SET, the answer-lane stream (telegram-plugin/answer-stream.ts) renders
 // the model's transcript text as a USER-VISIBLE edit-in-place message. Default
@@ -15345,6 +15367,93 @@ function resetOrphanedReplyTimeout(): void {
   }
 }
 
+/**
+ * PR A — clear the answer-ready quiescence flush timer for a turn. Called from
+ * every disarm point (tool activity, reply, `endCurrentTurnAtomic`) so a resumed
+ * turn or an already-delivered answer never fires a stale flush.
+ */
+function clearAnswerReadyFlushTimeout(turn: CurrentTurn | null): void {
+  if (turn?.answerReadyFlushTimeoutId != null) {
+    clearTimeout(turn.answerReadyFlushTimeoutId)
+    turn.answerReadyFlushTimeoutId = null
+  }
+}
+
+/**
+ * PR A — DETERMINISTIC answer-ready quiescence flush.
+ *
+ * (Re)arm a short per-turn timer whenever the current turn has a genuine
+ * composed terminal answer (the SAME `decideTurnFlush` classifier the turn-flush
+ * branch uses) AND is quiescent (no in-flight surface tool, no pending async
+ * dispatch). Each new `text` chunk re-arms it (the debounce), so the timer only
+ * fires after ~1 s of NO new stream events and NO tool activity — i.e. once the
+ * answer has settled. On fire it re-verifies the SAME predicate and, if still
+ * quiescent, dispatches a positive `answer-ready-quiescence` synthetic turn_end
+ * that routes through the identical turn-flush send path (endCurrentTurnAtomic
+ * → send-gated IIFE → honest PR-B record). This replaces the ~150 s dead wait
+ * with ~1 s, deterministically and in code.
+ *
+ * Exactly-once: the synthetic turn_end's `endCurrentTurnAtomic` nulls the turn
+ * atom, so a later REAL turn_end (or the orphaned backstop) short-circuits at
+ * its `turn != null` guard; `outboundDedup` is the second layer. The fire
+ * callback also re-pins `currentTurn === turn` (rollover guard) and clears its
+ * own id before dispatch.
+ */
+function resetAnswerReadyFlushTimeout(): void {
+  const turn = currentTurn
+  clearAnswerReadyFlushTimeout(turn)
+  if (turn == null) return
+  const key = statusKey(turn.sessionChatId, turn.sessionThreadId)
+  const armInput = {
+    flush: {
+      chatId: turn.sessionChatId,
+      replyCalled: turn.replyCalled,
+      capturedText: turn.capturedText,
+      flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
+    },
+    inFlightToolCount: toolFlightTracker.inFlightCount(),
+    hasPendingAsyncDispatch: pendingProgress.hasPendingAsyncDispatch(key),
+    flushWindowMs: ANSWER_READY_FLUSH_MS,
+  }
+  if (!shouldArmAnswerReadyFlush(armInput)) return
+  turn.answerReadyFlushTimeoutId = setTimeout(() => {
+    // Rollover guard (mirrors the orphaned-reply timer): re-read currentTurn so
+    // a superseded turn's timer never fires against a fresh atom.
+    const t = currentTurn
+    if (t == null || t !== turn) return
+    t.answerReadyFlushTimeoutId = null
+    // Re-verify quiescence at FIRE time: a tool that started, or a reply that
+    // landed, since the arm deterministically cancels the flush here even if the
+    // explicit disarm was missed.
+    const fireKey = statusKey(t.sessionChatId, t.sessionThreadId)
+    const stillQuiescent = shouldArmAnswerReadyFlush({
+      flush: {
+        chatId: t.sessionChatId,
+        replyCalled: t.replyCalled,
+        capturedText: t.capturedText,
+        flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
+      },
+      inFlightToolCount: toolFlightTracker.inFlightCount(),
+      hasPendingAsyncDispatch: pendingProgress.hasPendingAsyncDispatch(fireKey),
+      flushWindowMs: ANSWER_READY_FLUSH_MS,
+    })
+    if (!stillQuiescent) return
+    process.stderr.write(
+      `telegram gateway: answer-ready quiescence flush (${ANSWER_READY_FLUSH_MS}ms) —` +
+      ` delivering composed terminal answer` +
+      ` (in_flight=${toolFlightTracker.inFlightCount()},` +
+      ` bg_work=${pendingProgress.hasPendingAsyncDispatch(fireKey)})\n`,
+    )
+    // Route through the identical turn-flush path. A positive
+    // `answer-ready-quiescence` reason bypasses the `durationMs===-1`
+    // recently-streaming SUPPRESSION guard (which would otherwise defer this —
+    // the terminal answer text itself stamps recentlyStreaming): quiescence IS
+    // the positive "streaming has settled" signal, the opposite of the hung-turn
+    // backstop that guard protects.
+    handleSessionEvent({ kind: 'turn_end', durationMs: -1, reason: 'answer-ready-quiescence' })
+  }, ANSWER_READY_FLUSH_MS)
+}
+
 function closeActivityLane(chatId: string, threadId: number | undefined): void {
   const key = chatKeyWithSuffix(chatId, threadId, 'activity')
   const stream = activeDraftStreams.get(key)
@@ -16378,6 +16487,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           silentAnchorText: '',
           capturedText: [],
           orphanedReplyTimeoutId: null,
+          answerReadyFlushTimeoutId: null,
           // Fresh liveness tracker: lastStreamEventAt seeded to the turn start
           // so a turn that never streams still trips the fuse after windowMs.
           liveness: new LivenessTracker(startedAt),
@@ -16576,6 +16686,11 @@ function handleSessionEvent(ev: SessionEvent): void {
     case 'tool_use': {
       const turn = currentTurn
       if (turn == null) return
+      // PR A — the model resumed work (surface or otherwise). Cancel any pending
+      // answer-ready quiescence flush: the turn is no longer quiescent. (Fire-time
+      // re-verification would also catch this, but disarming here avoids a wasted
+      // wakeup and matches the design's disarm-on-tool requirement.)
+      clearAnswerReadyFlushTimeout(turn)
       // Narrative-dedup gate step 2 (JSONL-text-narrative primitive): a
       // narrative block was pending; this tool_use is the lookahead event
       // that decides it. reply/stream_reply with near-identical text ⇒
@@ -16662,6 +16777,11 @@ function handleSessionEvent(ev: SessionEvent): void {
       // where the JSONL tool_use rows arrive too late.
       const turn = currentTurn
       if (turn == null) return
+      // PR A — a tool_label (real-time, ~250 ms) means the model is producing
+      // work right now: cancel any pending answer-ready quiescence flush (the
+      // turn is not quiescent). Fires ahead of the JSONL tool_use, so it disarms
+      // the timer at the earliest deterministic point.
+      clearAnswerReadyFlushTimeout(turn)
       // SECONDARY FIX: an active tool_label means the model is producing work
       // right now — re-arm the orphaned-reply fuse so a multi-phase tool turn
       // (write → compile → test → fix) that regularly emits labels doesn't let
@@ -16984,6 +17104,11 @@ function handleSessionEvent(ev: SessionEvent): void {
         preambleSuppressor.onText(ev.text)
       }
       resetOrphanedReplyTimeout()
+      // PR A — (re)arm the deterministic answer-ready quiescence flush. Each
+      // text chunk debounces the timer; it fires only after ~1 s of no new
+      // stream events, delivering a composed toolless answer without waiting on
+      // the unreliable turn_duration signal or the ~150 s orphaned backstop.
+      resetAnswerReadyFlushTimeout()
 
       if (isContextExhaustionText(ev.text) && turn != null) {
         const chatId = turn.sessionChatId
@@ -17073,7 +17198,14 @@ function handleSessionEvent(ev: SessionEvent): void {
       // check to the full isLegitimatelyWorking predicate so detached background
       // work and human-wait tools (ask_user) are also protected.
       // INVARIANT: a REAL turn_end (durationMs >= 0) is NEVER suppressed.
-      if (ev.durationMs === -1) {
+      // PR A carve-out: the answer-ready quiescence flush also uses
+      // `durationMs:-1`, but it is a POSITIVE "streaming has settled" signal
+      // fired only after ~1 s of no stream events AND no in-flight tool — the
+      // exact opposite of a hung turn. It must NOT be suppressed by
+      // recentlyStreaming (the terminal answer text itself stamps that window,
+      // which is the whole bug). Its own arm/fire predicate already re-verified
+      // quiescence, so let it through to deliver.
+      if (ev.durationMs === -1 && ev.reason !== 'answer-ready-quiescence') {
         const turn = currentTurn
         const key = turn != null ? statusKey(turn.sessionChatId, turn.sessionThreadId) : ''
         // Widened to also suppress while the turn is RECENTLY STREAMING — a

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -119,7 +119,12 @@ export type SessionEvent =
   // gate keys on it.
   | { kind: 'text'; text: string; blockIndex: number; lastInMessage: boolean }
   | { kind: 'tool_result'; toolUseId: string; toolName: string | null; isError?: boolean; errorText?: string }
-  | { kind: 'turn_end'; durationMs: number }
+  // `reason` is set ONLY by an internal gateway-synthesized turn_end (never by
+  // the JSONL projection). `answer-ready-quiescence` (PR A) marks the positive
+  // deterministic quiescence-flush signal, which — unlike the orphaned-reply
+  // backstop's bare `durationMs:-1` — deliberately bypasses the recently-
+  // streaming suppression guard (quiescence IS the "streaming settled" signal).
+  | { kind: 'turn_end'; durationMs: number; reason?: 'answer-ready-quiescence' }
   // Multi-agent: sub-agent-scoped events. agentId is the sub-agent JSONL
   // filename stem (e.g. "aac6f1…"). Routed through the same ingest path
   // as parent events; the reducer fans them out to per-sub-agent state.

--- a/telegram-plugin/tests/answer-ready-flush.test.ts
+++ b/telegram-plugin/tests/answer-ready-flush.test.ts
@@ -6,14 +6,24 @@
  * orphaned-reply backstop, which the answer text itself keeps re-arming across
  * a ~150 s window. PR A adds a DETERMINISTIC ~1 s quiescence flush.
  *
- * These tests exercise the REAL seam (`shouldArmAnswerReadyFlush`, which calls
- * the REAL `decideTurnFlush` classifier + a REAL `ToolFlightTracker`) and a
- * fake-timer harness that models the gateway's arm/fire/disarm orchestration
- * (`resetAnswerReadyFlushTimeout`) using that same predicate — mirroring how
- * `orphaned-reply-rearm.test.ts` tests the inline orphaned timer via the real
- * `LivenessTracker`. The oracle asserts OUTCOMES: the flush fires at the ~1 s
- * debounce (not ~150 s), it re-arms per text chunk, and after it fires a later
- * turn_end delivers NOTHING more (exactly-once).
+ * Two layers of coverage:
+ *   1. The pure predicate `shouldArmAnswerReadyFlush` (which calls the REAL
+ *      `decideTurnFlush` classifier + a REAL `ToolFlightTracker`).
+ *   2. An INTEGRATION harness that drives the REAL orchestration —
+ *      `AnswerReadyFlushController` (the exact arm / debounce / rollover-guard /
+ *      fire-time-re-verify / disarm code the gateway runs, extracted so it is
+ *      testable, mirroring how `turn-end-gate-backstop.test.ts` drives the real
+ *      `withTurnEndGateBackstop`). The harness supplies a faithful gateway world
+ *      (a mutable `currentTurn`, a real `ToolFlightTracker`, and an
+ *      `endCurrentTurnAtomic` that — like the real one — disarms via
+ *      `controller.clear(turn)` and NULLS the atom) plus a send-sink that models
+ *      `handleSessionEvent({turn_end})` short-circuiting on a null atom.
+ *
+ * The oracle asserts OUTCOMES on real code: the flush fires at the ~1 s debounce
+ * (not ~150 s), re-arms per text chunk, and delivers EXACTLY ONCE across both
+ * turn_end race orderings. It is designed to go RED if the controller's
+ * rollover guard, fire-time re-verify, or disarm were removed (see the
+ * red-when-removed proofs in the handback).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -21,7 +31,9 @@ import {
   shouldArmAnswerReadyFlush,
   resolveAnswerReadyFlushMs,
   ANSWER_READY_FLUSH_MS,
+  AnswerReadyFlushController,
   type AnswerReadyArmInput,
+  type FlushTimerHandle,
 } from '../answer-ready-flush.js'
 import { ToolFlightTracker } from '../gateway/interrupt-defer.js'
 
@@ -132,75 +144,82 @@ describe('resolveAnswerReadyFlushMs', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Timer harness — models the gateway's resetAnswerReadyFlushTimeout +
-// exactly-once teardown, driven by the REAL predicate. Asserts OUTCOMES.
+// Integration harness — drives the REAL AnswerReadyFlushController. Only the
+// gateway world (currentTurn storage, the send sink, endCurrentTurnAtomic) is
+// modeled; the arm / debounce / rollover-guard / fire-time-re-verify / disarm
+// is the controller's REAL code. Mirrors turn-end-gate-backstop.test.ts driving
+// the real withTurnEndGateBackstop.
 // ---------------------------------------------------------------------------
 
+interface FakeTurn {
+  capturedText: string[]
+  replyCalled: boolean
+  answerReadyFlushTimeoutId: FlushTimerHandle | null
+}
+
 /**
- * Faithful in-test model of the gateway seam. Everything load-bearing (the
- * arm/fire DECISION) delegates to the real `shouldArmAnswerReadyFlush`; the
- * orchestration (per-turn timer id, rollover guard, atom-null teardown) is the
- * same 5 lines the gateway runs. `sends` counts delivered flushes; `dispatch`
- * models `handleSessionEvent({turn_end})` → `endCurrentTurnAtomic` nulling the
- * atom, which is exactly what makes delivery exactly-once.
+ * A faithful gateway world around the REAL controller. `sends` / `records`
+ * count what actually reached the user / turns.jsonl. `endCurrentTurnAtomic`
+ * mirrors the real one: it DISARMS via `controller.clear(turn)` and NULLS the
+ * atom. `dispatchTurnEnd` mirrors `handleSessionEvent({turn_end})`: it
+ * short-circuits when the atom is already gone (the exactly-once guarantee),
+ * else delivers once and runs `endCurrentTurnAtomic`.
  */
-class FlushHarness {
-  turn: { capturedText: string[]; replyCalled: boolean; timerId: ReturnType<typeof setTimeout> | null } | null
+class GatewayWorld {
+  currentTurn: FakeTurn | null
   flight = new ToolFlightTracker()
   pendingAsync = false
   sends = 0
+  records = 0
   window = WINDOW
+  readonly controller: AnswerReadyFlushController<FakeTurn>
 
   constructor() {
-    this.turn = { capturedText: [], replyCalled: false, timerId: null }
+    this.currentTurn = { capturedText: [], replyCalled: false, answerReadyFlushTimeoutId: null }
+    this.controller = new AnswerReadyFlushController<FakeTurn>({
+      getCurrentTurn: () => this.currentTurn,
+      getArmInput: (turn) => ({
+        flush: { chatId: CHAT, replyCalled: turn.replyCalled, capturedText: turn.capturedText, flushEnabled: true },
+        inFlightToolCount: this.flight.inFlightCount(),
+        hasPendingAsyncDispatch: this.pendingAsync,
+        flushWindowMs: this.window,
+      }),
+      getTimerHandle: (turn) => turn.answerReadyFlushTimeoutId,
+      setTimerHandle: (turn, handle) => {
+        turn.answerReadyFlushTimeoutId = handle
+      },
+      // The controller's single delivery action routes into the world's
+      // turn_end dispatch — exactly as the gateway's onFlush dispatches a
+      // synthetic turn_end into handleSessionEvent.
+      onFlush: () => this.dispatchTurnEnd(),
+    })
   }
 
-  private armInputFor(t: NonNullable<FlushHarness['turn']>): AnswerReadyArmInput {
-    return {
-      flush: { chatId: CHAT, replyCalled: t.replyCalled, capturedText: t.capturedText, flushEnabled: true },
-      inFlightToolCount: this.flight.inFlightCount(),
-      hasPendingAsyncDispatch: this.pendingAsync,
-      flushWindowMs: this.window,
-    }
+  /** = endCurrentTurnAtomic: DISARM (real controller.clear) + NULL the atom. */
+  private endCurrentTurnAtomic(turn: FakeTurn): void {
+    this.controller.clear(turn) // ← the load-bearing disarm (gateway.ts:~4818)
+    this.records++
+    this.currentTurn = null // ← the load-bearing atom-null (#1067)
   }
 
-  /** = endCurrentTurnAtomic: clear the timer for a turn. */
-  clear(t: FlushHarness['turn']): void {
-    if (t?.timerId != null) {
-      clearTimeout(t.timerId)
-      t.timerId = null
-    }
-  }
-
-  /** = the synthetic turn_end dispatch. Short-circuits when the atom is gone
-   *  (currentTurn === null), the mechanism that guarantees exactly-once. On the
-   *  first live dispatch it delivers and tears the atom down (atom-null). */
+  /** = handleSessionEvent({turn_end}). A null atom short-circuits (no second
+   *  send); otherwise deliver once and tear the turn down. */
   dispatchTurnEnd(): void {
-    if (this.turn == null) return // atom already torn down → no second send
-    this.clear(this.turn)
+    const turn = this.currentTurn
+    if (turn == null) return // atom already gone → exactly-once
     this.sends++
-    this.turn = null // endCurrentTurnAtomic: null the atom
+    this.endCurrentTurnAtomic(turn)
   }
 
-  /** = resetAnswerReadyFlushTimeout, called from `case 'text'`. */
+  /** = case 'text': push the chunk, then (re)arm via the REAL controller. */
   onText(chunk: string): void {
-    const turn = this.turn
-    this.clear(turn) // clear-before-rearm (debounce)
-    if (turn == null) return
-    turn.capturedText.push(chunk)
-    if (!shouldArmAnswerReadyFlush(this.armInputFor(turn))) return
-    turn.timerId = setTimeout(() => {
-      const t = this.turn
-      if (t == null || t !== turn) return // rollover guard
-      t.timerId = null
-      if (!shouldArmAnswerReadyFlush(this.armInputFor(t))) return // fire-time re-verify
-      this.dispatchTurnEnd()
-    }, this.window)
+    if (this.currentTurn != null) this.currentTurn.capturedText.push(chunk)
+    this.controller.reset()
   }
 
-  /** = case 'tool_use' / 'tool_label': disarm on tool activity. */
+  /** = case 'tool_use' / 'tool_label': disarm (real controller.clear) then track. */
   onToolUse(id: string): void {
-    if (this.turn != null) this.clear(this.turn)
+    this.controller.clear(this.currentTurn)
     this.flight.onEvent({ kind: 'tool_use', toolUseId: id })
   }
 
@@ -209,96 +228,116 @@ class FlushHarness {
   }
 }
 
-describe('answer-ready quiescence flush — timer outcomes', () => {
+describe('answer-ready quiescence flush — real controller integration', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
   it('flushes the composed answer at the ~1 s debounce, NOT at the ~150 s backstop', () => {
-    const h = new FlushHarness()
-    h.onText('The composed final answer.')
+    const w = new GatewayWorld()
+    w.onText('The composed final answer.')
     // Nothing before the debounce elapses.
     vi.advanceTimersByTime(WINDOW - 1)
-    expect(h.sends).toBe(0)
+    expect(w.sends).toBe(0)
     // Fires deterministically at the debounce.
     vi.advanceTimersByTime(1)
-    expect(h.sends).toBe(1)
+    expect(w.sends).toBe(1)
+    expect(w.records).toBe(1) // exactly one turns.jsonl record
     // And it did NOT wait for the multi-minute backstop.
     expect(vi.getTimerCount()).toBe(0)
     vi.advanceTimersByTime(BACKSTOP_MS)
-    expect(h.sends).toBe(1) // still exactly one — proves it beat ~150 s
+    expect(w.sends).toBe(1) // still exactly one — proves it beat ~150 s
   })
 
   it('each text chunk re-arms the debounce (only fires 1 s after the LAST chunk)', () => {
-    const h = new FlushHarness()
-    h.onText('Part one. ')
+    const w = new GatewayWorld()
+    w.onText('Part one. ')
     vi.advanceTimersByTime(500)
-    expect(h.sends).toBe(0)
-    h.onText('Part two — the rest of the answer.') // re-arms
+    expect(w.sends).toBe(0)
+    w.onText('Part two — the rest of the answer.') // re-arms
     vi.advanceTimersByTime(999)
-    expect(h.sends).toBe(0) // debounce reset by the 2nd chunk
+    expect(w.sends).toBe(0) // debounce reset by the 2nd chunk
     vi.advanceTimersByTime(1)
-    expect(h.sends).toBe(1)
+    expect(w.sends).toBe(1)
   })
 
-  it('EXACTLY-ONCE: a later turn_end after a quiescence flush sends nothing more', () => {
-    const h = new FlushHarness()
-    h.onText('Answer text.')
+  it('EXACTLY-ONCE (a): quiescence flush, THEN a real turn_end → still one send', () => {
+    const w = new GatewayWorld()
+    w.onText('Answer text.')
     vi.advanceTimersByTime(WINDOW)
-    expect(h.sends).toBe(1) // quiescence flushed + nulled the atom
-    // The real turn_end finally lands — it must short-circuit (atom gone).
-    h.dispatchTurnEnd()
-    expect(h.sends).toBe(1)
+    expect(w.sends).toBe(1) // quiescence flushed + nulled the atom
+    // The real turn_end finally lands — it must short-circuit on the null atom.
+    // (Goes red if the atom-null in endCurrentTurnAtomic were removed.)
+    w.dispatchTurnEnd()
+    expect(w.sends).toBe(1)
+    expect(w.records).toBe(1)
   })
 
-  it('EXACTLY-ONCE: a real turn_end BEFORE the debounce disarms the pending flush', () => {
-    const h = new FlushHarness()
-    h.onText('Answer text.')
+  it('EXACTLY-ONCE (b): a real turn_end BEFORE the debounce disarms the pending flush', () => {
+    const w = new GatewayWorld()
+    w.onText('Answer text.')
     vi.advanceTimersByTime(WINDOW - 100)
-    // turn_end arrives first → delivers once and clears the pending timer.
-    h.dispatchTurnEnd()
-    expect(h.sends).toBe(1)
-    expect(vi.getTimerCount()).toBe(0) // pending quiescence timer was cleared
+    // turn_end arrives first → delivers once and (via controller.clear in
+    // endCurrentTurnAtomic) cancels the pending flush timer.
+    // (Goes red if controller.clear no longer cleared the timer.)
+    w.dispatchTurnEnd()
+    expect(w.sends).toBe(1)
+    expect(vi.getTimerCount()).toBe(0) // the pending quiescence timer was cleared
     vi.advanceTimersByTime(BACKSTOP_MS)
-    expect(h.sends).toBe(1) // the stale timer never fired a second send
+    expect(w.sends).toBe(1) // the stale timer never fired a second send
+    expect(w.records).toBe(1)
   })
 
   it('does NOT flush while a tool call is in flight (only on genuine quiescence)', () => {
-    const h = new FlushHarness()
-    h.onText('Interim thought before a tool.')
+    const w = new GatewayWorld()
+    w.onText('Interim thought before a tool.')
     // A tool starts within the window → disarm.
     vi.advanceTimersByTime(400)
-    h.onToolUse('bash_1')
+    w.onToolUse('bash_1')
     vi.advanceTimersByTime(BACKSTOP_MS)
-    expect(h.sends).toBe(0) // never fired while (and after) the tool was open
+    expect(w.sends).toBe(0) // never fired while (and after) the tool was open
     expect(vi.getTimerCount()).toBe(0)
   })
 
   it('re-arms and flushes once the tool completes and new answer text settles', () => {
-    const h = new FlushHarness()
-    h.onText('Working on it.')
-    h.onToolUse('bash_1') // disarm
+    const w = new GatewayWorld()
+    w.onText('Working on it.')
+    w.onToolUse('bash_1') // disarm
     vi.advanceTimersByTime(2000)
-    expect(h.sends).toBe(0)
-    h.onToolResult('bash_1') // tool done → quiescent again
-    h.onText(' Here is the final composed answer.') // new text re-arms
+    expect(w.sends).toBe(0)
+    w.onToolResult('bash_1') // tool done → quiescent again
+    w.onText(' Here is the final composed answer.') // new text re-arms
     vi.advanceTimersByTime(WINDOW)
-    expect(h.sends).toBe(1)
+    expect(w.sends).toBe(1)
   })
 
-  it('a fire-time tool in flight cancels the flush even if disarm was missed', () => {
-    const h = new FlushHarness()
-    h.onText('Answer text.')
-    // Simulate a missed explicit disarm: a tool becomes in-flight directly.
-    h.flight.onEvent({ kind: 'tool_use', toolUseId: 'sneaky' })
+  it('fire-time re-verify: a tool in flight at expiry cancels the flush even if disarm was missed', () => {
+    const w = new GatewayWorld()
+    w.onText('Answer text.')
+    // Simulate a missed explicit disarm: a tool becomes in-flight directly,
+    // WITHOUT going through onToolUse (which would clear the timer).
+    w.flight.onEvent({ kind: 'tool_use', toolUseId: 'sneaky' })
     vi.advanceTimersByTime(WINDOW)
-    expect(h.sends).toBe(0) // fire-time re-verification saw inFlight > 0 → no send
+    // (Goes red if the controller's fire-time re-verification were removed.)
+    expect(w.sends).toBe(0)
+  })
+
+  it('rollover guard: a superseded turn does not fire against a fresh atom', () => {
+    const w = new GatewayWorld()
+    const armed = w.currentTurn!
+    w.onText('Answer for turn A.') // arms A's timer
+    // A new turn swaps in before the debounce (turn rollover).
+    w.currentTurn = { capturedText: ['Turn B is still working'], replyCalled: false, answerReadyFlushTimeoutId: null }
+    expect(w.currentTurn).not.toBe(armed)
+    vi.advanceTimersByTime(WINDOW)
+    // (Goes red if the controller's rollover guard `live !== armedTurn` were removed.)
+    expect(w.sends).toBe(0)
   })
 
   it('a NO_REPLY turn never arms, so it flushes nothing (records no_reply upstream)', () => {
-    const h = new FlushHarness()
-    h.onText('NO_REPLY')
+    const w = new GatewayWorld()
+    w.onText('NO_REPLY')
     vi.advanceTimersByTime(BACKSTOP_MS)
-    expect(h.sends).toBe(0)
+    expect(w.sends).toBe(0)
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/telegram-plugin/tests/answer-ready-flush.test.ts
+++ b/telegram-plugin/tests/answer-ready-flush.test.ts
@@ -1,0 +1,304 @@
+/**
+ * PR A — answer-ready quiescence flush (late-delivery fix).
+ *
+ * The gateway delivers a toolless terminal-text answer either on claude's
+ * (unreliable) `turn_duration`/turn_end, or — when that never lands — on the
+ * orphaned-reply backstop, which the answer text itself keeps re-arming across
+ * a ~150 s window. PR A adds a DETERMINISTIC ~1 s quiescence flush.
+ *
+ * These tests exercise the REAL seam (`shouldArmAnswerReadyFlush`, which calls
+ * the REAL `decideTurnFlush` classifier + a REAL `ToolFlightTracker`) and a
+ * fake-timer harness that models the gateway's arm/fire/disarm orchestration
+ * (`resetAnswerReadyFlushTimeout`) using that same predicate — mirroring how
+ * `orphaned-reply-rearm.test.ts` tests the inline orphaned timer via the real
+ * `LivenessTracker`. The oracle asserts OUTCOMES: the flush fires at the ~1 s
+ * debounce (not ~150 s), it re-arms per text chunk, and after it fires a later
+ * turn_end delivers NOTHING more (exactly-once).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  shouldArmAnswerReadyFlush,
+  resolveAnswerReadyFlushMs,
+  ANSWER_READY_FLUSH_MS,
+  type AnswerReadyArmInput,
+} from '../answer-ready-flush.js'
+import { ToolFlightTracker } from '../gateway/interrupt-defer.js'
+
+const CHAT = '12345'
+const WINDOW = 1000
+// The orphaned-reply backstop's real dead-wait ceiling — the wall-clock the
+// flush must beat. Used to prove the flush fires ~1 s, not ~150 s.
+const BACKSTOP_MS = 150_000
+
+function armInput(over: Partial<AnswerReadyArmInput> = {}): AnswerReadyArmInput {
+  return {
+    flush: {
+      chatId: CHAT,
+      replyCalled: false,
+      capturedText: ['Here is the composed final answer to your question.'],
+      flushEnabled: true,
+    },
+    inFlightToolCount: 0,
+    hasPendingAsyncDispatch: false,
+    flushWindowMs: WINDOW,
+    ...over,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure predicate: shouldArmAnswerReadyFlush (real decideTurnFlush classifier)
+// ---------------------------------------------------------------------------
+
+describe('shouldArmAnswerReadyFlush (arm/fire predicate)', () => {
+  it('arms on a genuine composed terminal answer that is quiescent', () => {
+    expect(shouldArmAnswerReadyFlush(armInput())).toBe(true)
+  })
+
+  it('does NOT arm while a tool is in flight (not quiescent)', () => {
+    expect(shouldArmAnswerReadyFlush(armInput({ inFlightToolCount: 1 }))).toBe(false)
+  })
+
+  it('does NOT arm while a background/async dispatch is pending', () => {
+    expect(shouldArmAnswerReadyFlush(armInput({ hasPendingAsyncDispatch: true }))).toBe(false)
+  })
+
+  it('does NOT arm once the reply tool has served the turn (reply-called)', () => {
+    expect(
+      shouldArmAnswerReadyFlush(armInput({ flush: { chatId: CHAT, replyCalled: true, capturedText: ['x'], flushEnabled: true } })),
+    ).toBe(false)
+  })
+
+  it('does NOT arm on a genuine NO_REPLY turn (silent marker → no spurious flush)', () => {
+    expect(
+      shouldArmAnswerReadyFlush(armInput({ flush: { chatId: CHAT, replyCalled: false, capturedText: ['NO_REPLY'], flushEnabled: true } })),
+    ).toBe(false)
+  })
+
+  it('does NOT arm on an empty terminal turn (nothing to send)', () => {
+    expect(
+      shouldArmAnswerReadyFlush(armInput({ flush: { chatId: CHAT, replyCalled: false, capturedText: [], flushEnabled: true } })),
+    ).toBe(false)
+  })
+
+  it('does NOT arm on prose that ends with a trailing silent marker', () => {
+    expect(
+      shouldArmAnswerReadyFlush(
+        armInput({ flush: { chatId: CHAT, replyCalled: false, capturedText: ['Some prose the model wrote.', 'NO_REPLY'], flushEnabled: true } }),
+      ),
+    ).toBe(false)
+  })
+
+  it('does NOT arm for a system/sub-agent turn (no inbound chat)', () => {
+    expect(
+      shouldArmAnswerReadyFlush(armInput({ flush: { chatId: null, replyCalled: false, capturedText: ['answer'], flushEnabled: true } })),
+    ).toBe(false)
+  })
+
+  it('does NOT arm when the kill-switch disables the flush (window <= 0)', () => {
+    expect(shouldArmAnswerReadyFlush(armInput({ flushWindowMs: 0 }))).toBe(false)
+    expect(shouldArmAnswerReadyFlush(armInput({ flushWindowMs: -1 }))).toBe(false)
+  })
+
+  it('does NOT arm when the turn-flush safety flag is off', () => {
+    expect(
+      shouldArmAnswerReadyFlush(armInput({ flush: { chatId: CHAT, replyCalled: false, capturedText: ['answer'], flushEnabled: false } })),
+    ).toBe(false)
+  })
+})
+
+describe('resolveAnswerReadyFlushMs', () => {
+  it('defaults to ANSWER_READY_FLUSH_MS when unset', () => {
+    expect(resolveAnswerReadyFlushMs({})).toBe(ANSWER_READY_FLUSH_MS)
+    expect(resolveAnswerReadyFlushMs({ SWITCHROOM_ANSWER_READY_FLUSH_MS: '' })).toBe(ANSWER_READY_FLUSH_MS)
+  })
+
+  it('parses a positive override', () => {
+    expect(resolveAnswerReadyFlushMs({ SWITCHROOM_ANSWER_READY_FLUSH_MS: '1500' })).toBe(1500)
+  })
+
+  it('treats 0 (and negatives) as the kill-switch → disabled (0)', () => {
+    expect(resolveAnswerReadyFlushMs({ SWITCHROOM_ANSWER_READY_FLUSH_MS: '0' })).toBe(0)
+    expect(resolveAnswerReadyFlushMs({ SWITCHROOM_ANSWER_READY_FLUSH_MS: '-5' })).toBe(0)
+  })
+
+  it('fails safe to the default on an unparseable value', () => {
+    expect(resolveAnswerReadyFlushMs({ SWITCHROOM_ANSWER_READY_FLUSH_MS: 'nonsense' })).toBe(ANSWER_READY_FLUSH_MS)
+  })
+
+  it('ANSWER_READY_FLUSH_MS is ~1 s ("immediate")', () => {
+    expect(ANSWER_READY_FLUSH_MS).toBe(1000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Timer harness — models the gateway's resetAnswerReadyFlushTimeout +
+// exactly-once teardown, driven by the REAL predicate. Asserts OUTCOMES.
+// ---------------------------------------------------------------------------
+
+/**
+ * Faithful in-test model of the gateway seam. Everything load-bearing (the
+ * arm/fire DECISION) delegates to the real `shouldArmAnswerReadyFlush`; the
+ * orchestration (per-turn timer id, rollover guard, atom-null teardown) is the
+ * same 5 lines the gateway runs. `sends` counts delivered flushes; `dispatch`
+ * models `handleSessionEvent({turn_end})` → `endCurrentTurnAtomic` nulling the
+ * atom, which is exactly what makes delivery exactly-once.
+ */
+class FlushHarness {
+  turn: { capturedText: string[]; replyCalled: boolean; timerId: ReturnType<typeof setTimeout> | null } | null
+  flight = new ToolFlightTracker()
+  pendingAsync = false
+  sends = 0
+  window = WINDOW
+
+  constructor() {
+    this.turn = { capturedText: [], replyCalled: false, timerId: null }
+  }
+
+  private armInputFor(t: NonNullable<FlushHarness['turn']>): AnswerReadyArmInput {
+    return {
+      flush: { chatId: CHAT, replyCalled: t.replyCalled, capturedText: t.capturedText, flushEnabled: true },
+      inFlightToolCount: this.flight.inFlightCount(),
+      hasPendingAsyncDispatch: this.pendingAsync,
+      flushWindowMs: this.window,
+    }
+  }
+
+  /** = endCurrentTurnAtomic: clear the timer for a turn. */
+  clear(t: FlushHarness['turn']): void {
+    if (t?.timerId != null) {
+      clearTimeout(t.timerId)
+      t.timerId = null
+    }
+  }
+
+  /** = the synthetic turn_end dispatch. Short-circuits when the atom is gone
+   *  (currentTurn === null), the mechanism that guarantees exactly-once. On the
+   *  first live dispatch it delivers and tears the atom down (atom-null). */
+  dispatchTurnEnd(): void {
+    if (this.turn == null) return // atom already torn down → no second send
+    this.clear(this.turn)
+    this.sends++
+    this.turn = null // endCurrentTurnAtomic: null the atom
+  }
+
+  /** = resetAnswerReadyFlushTimeout, called from `case 'text'`. */
+  onText(chunk: string): void {
+    const turn = this.turn
+    this.clear(turn) // clear-before-rearm (debounce)
+    if (turn == null) return
+    turn.capturedText.push(chunk)
+    if (!shouldArmAnswerReadyFlush(this.armInputFor(turn))) return
+    turn.timerId = setTimeout(() => {
+      const t = this.turn
+      if (t == null || t !== turn) return // rollover guard
+      t.timerId = null
+      if (!shouldArmAnswerReadyFlush(this.armInputFor(t))) return // fire-time re-verify
+      this.dispatchTurnEnd()
+    }, this.window)
+  }
+
+  /** = case 'tool_use' / 'tool_label': disarm on tool activity. */
+  onToolUse(id: string): void {
+    if (this.turn != null) this.clear(this.turn)
+    this.flight.onEvent({ kind: 'tool_use', toolUseId: id })
+  }
+
+  onToolResult(id: string): void {
+    this.flight.onEvent({ kind: 'tool_result', toolUseId: id })
+  }
+}
+
+describe('answer-ready quiescence flush — timer outcomes', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('flushes the composed answer at the ~1 s debounce, NOT at the ~150 s backstop', () => {
+    const h = new FlushHarness()
+    h.onText('The composed final answer.')
+    // Nothing before the debounce elapses.
+    vi.advanceTimersByTime(WINDOW - 1)
+    expect(h.sends).toBe(0)
+    // Fires deterministically at the debounce.
+    vi.advanceTimersByTime(1)
+    expect(h.sends).toBe(1)
+    // And it did NOT wait for the multi-minute backstop.
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(BACKSTOP_MS)
+    expect(h.sends).toBe(1) // still exactly one — proves it beat ~150 s
+  })
+
+  it('each text chunk re-arms the debounce (only fires 1 s after the LAST chunk)', () => {
+    const h = new FlushHarness()
+    h.onText('Part one. ')
+    vi.advanceTimersByTime(500)
+    expect(h.sends).toBe(0)
+    h.onText('Part two — the rest of the answer.') // re-arms
+    vi.advanceTimersByTime(999)
+    expect(h.sends).toBe(0) // debounce reset by the 2nd chunk
+    vi.advanceTimersByTime(1)
+    expect(h.sends).toBe(1)
+  })
+
+  it('EXACTLY-ONCE: a later turn_end after a quiescence flush sends nothing more', () => {
+    const h = new FlushHarness()
+    h.onText('Answer text.')
+    vi.advanceTimersByTime(WINDOW)
+    expect(h.sends).toBe(1) // quiescence flushed + nulled the atom
+    // The real turn_end finally lands — it must short-circuit (atom gone).
+    h.dispatchTurnEnd()
+    expect(h.sends).toBe(1)
+  })
+
+  it('EXACTLY-ONCE: a real turn_end BEFORE the debounce disarms the pending flush', () => {
+    const h = new FlushHarness()
+    h.onText('Answer text.')
+    vi.advanceTimersByTime(WINDOW - 100)
+    // turn_end arrives first → delivers once and clears the pending timer.
+    h.dispatchTurnEnd()
+    expect(h.sends).toBe(1)
+    expect(vi.getTimerCount()).toBe(0) // pending quiescence timer was cleared
+    vi.advanceTimersByTime(BACKSTOP_MS)
+    expect(h.sends).toBe(1) // the stale timer never fired a second send
+  })
+
+  it('does NOT flush while a tool call is in flight (only on genuine quiescence)', () => {
+    const h = new FlushHarness()
+    h.onText('Interim thought before a tool.')
+    // A tool starts within the window → disarm.
+    vi.advanceTimersByTime(400)
+    h.onToolUse('bash_1')
+    vi.advanceTimersByTime(BACKSTOP_MS)
+    expect(h.sends).toBe(0) // never fired while (and after) the tool was open
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('re-arms and flushes once the tool completes and new answer text settles', () => {
+    const h = new FlushHarness()
+    h.onText('Working on it.')
+    h.onToolUse('bash_1') // disarm
+    vi.advanceTimersByTime(2000)
+    expect(h.sends).toBe(0)
+    h.onToolResult('bash_1') // tool done → quiescent again
+    h.onText(' Here is the final composed answer.') // new text re-arms
+    vi.advanceTimersByTime(WINDOW)
+    expect(h.sends).toBe(1)
+  })
+
+  it('a fire-time tool in flight cancels the flush even if disarm was missed', () => {
+    const h = new FlushHarness()
+    h.onText('Answer text.')
+    // Simulate a missed explicit disarm: a tool becomes in-flight directly.
+    h.flight.onEvent({ kind: 'tool_use', toolUseId: 'sneaky' })
+    vi.advanceTimersByTime(WINDOW)
+    expect(h.sends).toBe(0) // fire-time re-verification saw inFlight > 0 → no send
+  })
+
+  it('a NO_REPLY turn never arms, so it flushes nothing (records no_reply upstream)', () => {
+    const h = new FlushHarness()
+    h.onText('NO_REPLY')
+    vi.advanceTimersByTime(BACKSTOP_MS)
+    expect(h.sends).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})


### PR DESCRIPTION
## What
PR 2 of 2 for the fleet-wide "silent turn" pattern. The **latency** fix; follows #3213 (send-honesty), now merged to main.

## Problem
Measured: ~24 of 50 flagged turns wait ~196s (~3.3 min) before delivery. When an agent ends a turn with its answer as plain terminal text (no reply-tool call), delivery falls to an orphaned-reply backstop whose fuse the answer text itself keeps re-arming → multi-minute dead wait for a reply that was already composed.

## Fix
Deterministic ~1s **answer-ready quiescence** flush: once the turn has a composed terminal answer and goes quiescent (no in-flight tool, no new stream events) for a short debounce (default 1000ms, `SWITCHROOM_ANSWER_READY_FLUSH_MS`, 0 = kill-switch), it fires a synthetic `turn_end` into the **same** send-gated turn-flush path — immediate delivery instead of the backstop. New `AnswerReadyFlushController`; gateway is a thin adapter. Reuses #3213's honest `deliveryOutcome` record; no new send site (P0 never-storm preserved).

## Exactly-once
Fire→atom-null path is fully synchronous (no `await` between reading `currentTurn` and nulling it), so a real `turn_end` can't interleave; every teardown disarms the timer; a queued callback re-verifies `currentTurn === turn`. Adversarially reviewed across every interleaving — no double-send, no truncated answer.

## Tests
`answer-ready-flush.test.ts` (24), incl. a real-controller integration oracle asserting send-count == 1 across both race orderings, with a verified red-when-guard-removed proof. Lint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)