### PR TITLE
fix(gateway): re-eval idle decision at /clear write time to narrow the check-to-send race (#3116)

### DIFF
--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -22,6 +22,7 @@ import {
   validateInjectCommand,
   type TmuxRunner,
 } from "./inject.js";
+import { decideIdleClear } from "../../telegram-plugin/gateway/idle-clear.js";
 
 describe("validateInjectCommand", () => {
   it("accepts every command in the allowlist", () => {
@@ -917,5 +918,114 @@ describe("#2566 — /model and /memory allowlist treatment", () => {
     expect(sent[1]).toEqual(["send-keys", "Enter"]);
     expect(sent[sent.length - 1]).toEqual(["send-keys", "Escape"]);
     expect(result.outcome).toBe("ok");
+  });
+});
+
+// ─── #3116 — write-time precondition (idle-clear check-to-send race) ─────────
+//
+// The idle-clear path decides "idle" then fires `/clear` into the tmux pane.
+// Between that decision and the send-keys write there is a gap: an inbound can
+// arrive and the session is no longer idle, but the buffered `/clear` still
+// clobbers it (inject.ts FUTURE-GAP). The fix is an opt-in `precondition`
+// re-evaluated INSIDE the pane lock, immediately before send-keys. These tests
+// assert the OUTCOME — no keys are sent when the precondition fails — and are
+// written so they FAIL against pre-fix main (which has no precondition and
+// always sends).
+describe("injectSlashCommandWith — #3116 write-time precondition", () => {
+  it("precondition true → send-keys fires (behaviour unchanged)", async () => {
+    const before = "$ \n";
+    const after = "$ \n"; // /clear leaves fresh prompt → ok_no_output
+    const sent: string[][] = [];
+    const runner: TmuxRunner = {
+      hasSession: () => true,
+      capture: () => before === after ? before : after,
+      send: (_s, _n, args) => sent.push(args),
+    };
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 20,
+      timeoutMs: 60,
+      precondition: () => true,
+    });
+    expect(sent).toContainEqual(["send-keys", "-l", "/clear"]);
+    expect(sent).toContainEqual(["send-keys", "Enter"]);
+    expect(r.outcome).not.toBe("skipped");
+  });
+
+  it("precondition false → NO keys sent, outcome=skipped, pane untouched", async () => {
+    const sent: string[][] = [];
+    let captured = 0;
+    const runner: TmuxRunner = {
+      hasSession: () => true,
+      capture: () => { captured += 1; return "$ \n"; },
+      send: (_s, _n, args) => sent.push(args),
+    };
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 20,
+      timeoutMs: 60,
+      precondition: () => false,
+    });
+    // The load-bearing assertion: send-keys was NEVER called, so the buffered
+    // /clear cannot clobber a no-longer-idle session. On pre-fix main there is
+    // no precondition param, the send always fires, and this fails.
+    expect(sent).toEqual([]);
+    expect(captured).toBe(0); // aborted before any tmux I/O
+    expect(r.outcome).toBe("skipped");
+    expect(r.errorCode).toBe("precondition_failed");
+    expect(r.command).toBe("/clear");
+  });
+
+  // End-to-end race semantics driven through the REAL idle decider
+  // (decideIdleClear), the same function maybeIdleClear's precondition re-runs
+  // at write time. An inbound (markIdleActivity) that lands in the check→send
+  // gap must SUPPRESS the /clear.
+  it("inbound in the check→send gap suppresses /clear (via real decideIdleClear)", async () => {
+    let now = 1_000_000;
+    const idleClearMs = 10_000;
+    // Idle clocks, mutated to simulate an inbound arriving in the gap.
+    const state = {
+      lastActivityAt: now - idleClearMs - 1, // idle at decision time
+      lastTurnEndedAt: null as number | null,
+    };
+    // Gate decision (as maybeIdleClear does before dispatch): idle → clear.
+    const gateDecision = decideIdleClear(
+      { ...state, idleClearMs, alreadyCleared: false, turnInFlight: false },
+      now,
+    );
+    expect(gateDecision.clear).toBe(true);
+
+    const sent: string[][] = [];
+    const runner: TmuxRunner = {
+      hasSession: () => true,
+      capture: () => "$ \n",
+      send: (_s, _n, args) => sent.push(args),
+    };
+
+    // The write-time precondition re-runs the FULL decision on the LIVE clocks.
+    const stillIdleAtWrite = (): boolean => {
+      // Simulate: an inbound landed in the gap right before the write.
+      state.lastActivityAt = now;
+      return decideIdleClear(
+        { ...state, idleClearMs, alreadyCleared: false, turnInFlight: false },
+        now,
+      ).clear;
+    };
+
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 20,
+      timeoutMs: 60,
+      precondition: stillIdleAtWrite,
+    });
+
+    expect(sent).toEqual([]); // /clear suppressed — session preserved
+    expect(r.outcome).toBe("skipped");
   });
 });

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -223,7 +223,8 @@ export type InjectErrorCode =
   | "session_missing"
   | "invalid"
   | "timeout"
-  | "tmux_failed";
+  | "tmux_failed"
+  | "precondition_failed";
 
 export class InjectError extends Error {
   code: InjectErrorCode;
@@ -249,6 +250,19 @@ export interface InjectOpts {
   settleMs?: number;
   /** Hard upper bound on total wait (ms). Default 5000ms. */
   timeoutMs?: number;
+  /**
+   * Opt-in write-time guard (#3116). Re-evaluated INSIDE the pane lock,
+   * IMMEDIATELY BEFORE the send-keys write — i.e. after the check-to-send
+   * gap that a plain caller cannot guard. If provided and it returns
+   * `false`, the send is aborted with `outcome:'skipped'` /
+   * `errorCode:'precondition_failed'` and NO keys are sent.
+   *
+   * The idle-clear caller passes a predicate that re-runs the FULL idle
+   * decision against the live clocks, so an inbound/activity that landed in
+   * the gap suppresses the `/clear` instead of clobbering the session.
+   * Callers that omit it get identical behaviour to before (never checked).
+   */
+  precondition?: () => boolean;
 }
 
 /**
@@ -258,11 +272,14 @@ export interface InjectOpts {
  *    expected (e.g. `/clear`) or suspicious (`/cost` with no output).
  *  - `failed` — validation rejected, session missing, or send-keys
  *    threw. `errorCode` and `errorMessage` carry the reason.
+ *  - `skipped` — an opt-in write-time `precondition` returned false, so
+ *    the send was aborted before any keys were sent (#3116). No pane
+ *    mutation happened; `errorCode` is `precondition_failed`.
  *
  * Classification is derived from runtime capture, not from
  * `expectsOutput` — that field is a UX hint only.
  */
-export type InjectOutcome = "ok" | "ok_no_output" | "failed";
+export type InjectOutcome = "ok" | "ok_no_output" | "failed" | "skipped";
 
 export type InjectDiagnostic =
   | "anchor_missing"
@@ -593,6 +610,7 @@ export async function injectSlashCommand(
       command: command.trim(),
       settleMs,
       timeoutMs,
+      precondition: opts.precondition,
     }),
   );
 }
@@ -614,9 +632,10 @@ export async function injectSlashCommandWith(
     command: string;
     settleMs: number;
     timeoutMs: number;
+    precondition?: () => boolean;
   },
 ): Promise<InjectResult> {
-  const { socket, session, command, settleMs, timeoutMs } = args;
+  const { socket, session, command, settleMs, timeoutMs, precondition } = args;
 
   // Re-validate so the seam itself enforces the contract. The bare
   // verb is what we'll surface in `result.command` / lookup metadata.
@@ -651,6 +670,26 @@ export async function injectSlashCommandWith(
         `tmux session "${session}" on socket "${socket}" not found. ` +
         `Is the agent running under the tmux supervisor (the default)? ` +
         `If experimental.legacy_pty=true is set, inject is unsupported.`,
+    };
+  }
+
+  // #3116 — write-time precondition. Re-evaluated HERE, inside the pane lock
+  // and as late as possible before the send, to close the check-to-send gap
+  // the caller cannot guard from outside. The idle-clear caller re-runs the
+  // full idle decision; if an inbound/activity landed in the gap the session
+  // is no longer idle and we abort WITHOUT sending any keys — the pane is left
+  // untouched. Runs before `capture` so a false precondition does no tmux I/O.
+  if (precondition && !precondition()) {
+    return {
+      outcome: "skipped",
+      output: "",
+      truncated: false,
+      command: bareVerb,
+      meta,
+      errorCode: "precondition_failed",
+      errorMessage:
+        "inject precondition returned false at write time; send aborted " +
+        "(no keys sent).",
     };
   }
 

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1622,6 +1622,16 @@ export function registerAgentCommand(program: Command): void {
             }
             return;
           }
+          // outcome === 'skipped' (#3116): an opt-in write-time precondition
+          // aborted the send before any keys were sent. No CLI caller opts in
+          // today, so this is unreachable here — but report it honestly (not as
+          // a failure) so a future precondition caller isn't mislabeled.
+          if (result.outcome === "skipped") {
+            console.log(
+              chalk.yellow(`↷ ${result.command} — skipped (precondition not met at send time)`),
+            );
+            return;
+          }
           // outcome === 'failed'
           const code = result.errorCode ?? "tmux_failed";
           const msg = result.errorMessage ?? "unknown error";

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -1221,10 +1221,15 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
           sendResponse(ctx, rpcErr(id, -32603, msg));
           break;
         }
+        // #3116: `skipped` means an opt-in write-time precondition aborted the
+        // send — no keys were sent, so do NOT claim it was "sent". No hermes
+        // caller opts in today (unreachable), but report honestly if one does.
         const output =
           injectResult.outcome === "ok"
             ? injectResult.output ?? ""
-            : `*(${fullCommand} sent)*`;
+            : injectResult.outcome === "skipped"
+              ? `*(${fullCommand} skipped — precondition not met)*`
+              : `*(${fullCommand} sent)*`;
         sendResponse(ctx, rpcOk(id, { ok: true, output }));
         break;
       }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5085,10 +5085,43 @@ function maybeIdleClear(): void {
     `telegram gateway: idle auto-/clear for ${agentName} ` +
       `(idle >= ${Math.round(idleClearMs / 60_000)}m)\n`,
   );
-  // Accepted check-to-send race (same as maybeProactiveCompact): a new inbound
-  // could arrive between the gate check and the tmux send; /clear then lands in
-  // claude's prompt buffer and runs at the next idle prompt (inject.ts FUTURE-GAP).
-  void injectSlashCommandImpl(agentName, '/clear')
+  // #3116 — write-time precondition closes (most of) the check-to-send race.
+  // A new inbound could arrive between the gate decision above and the tmux
+  // send; without a guard /clear lands in claude's prompt buffer and runs at
+  // the next idle prompt (inject.ts FUTURE-GAP), clobbering that inbound's
+  // session. The precondition below is re-evaluated INSIDE the pane lock,
+  // immediately before send-keys, and RE-RUNS THE FULL idle decision against
+  // the live clocks + turnInFlightForGate() — not a bespoke "activity
+  // unchanged" check — so any new activity in the gap suppresses the /clear
+  // (and so a future background-work input to decideIdleClear is honoured at
+  // write time for free). Residual: an inbound landing AFTER send-keys but
+  // before claude submits the buffered /clear is still clobbered — full
+  // closure needs buffer-cancel (tracked as a follow-up issue).
+  const stillIdleAtWrite = (): boolean =>
+    decideIdleClear(
+      {
+        lastActivityAt: lastIdleActivityAt,
+        lastTurnEndedAt: lastIdleTurnEndAt,
+        idleClearMs: resolveIdleClearMs(),
+        // alreadyCleared is latched true above for re-entrancy; the write-time
+        // re-eval must judge idleness on the live clocks only, so force false.
+        alreadyCleared: false,
+        turnInFlight: turnInFlightForGate(),
+      },
+      Date.now(),
+    ).clear;
+  void injectSlashCommandImpl(agentName, '/clear', { precondition: stillIdleAtWrite })
+    .then((result) => {
+      if (result.outcome === 'skipped') {
+        // Activity arrived in the check-to-send gap; re-arm so the next idle
+        // period can clear again rather than staying latched.
+        idleAutoCleared = false;
+        process.stderr.write(
+          `telegram gateway: idle /clear suppressed for ${agentName} ` +
+            `(activity in check-to-send gap)\n`,
+        );
+      }
+    })
     .catch((err: unknown) => {
       process.stderr.write(
         `telegram gateway: idle /clear inject failed for ` +

--- a/telegram-plugin/gateway/inject-handler.ts
+++ b/telegram-plugin/gateway/inject-handler.ts
@@ -86,6 +86,17 @@ function shapeReply(
     return { body: verbHtml, accent: 'done' }
   }
 
+  // outcome === 'skipped' (#3116): an opt-in write-time precondition aborted
+  // the send before any keys were sent. No inject-map caller opts in today, so
+  // this is unreachable via this surface — but handle it explicitly so a future
+  // precondition caller gets an honest "skipped" ack instead of a failure card.
+  if (result.outcome === 'skipped') {
+    return {
+      body: `${verbHtml} — skipped (precondition not met at send time)`,
+      accent: 'issue',
+    }
+  }
+
   // outcome === 'failed'
   const code = result.errorCode ?? 'tmux_failed'
   const msg = result.errorMessage ?? 'unknown error'


### PR DESCRIPTION
Closes part of #3116 (staged PR 1/4 of the idle-clear / session-loss cluster). Follow-up residual tracked in #3216.

## Problem (#3116)
`maybeIdleClear()` decided "idle", latched the fire-once flag, then fired `injectSlashCommandImpl(agentName, '/clear')` into the tmux pane with the **check-to-send gap unguarded**. An inbound arriving between the gate decision and the tmux send still got its session `/clear`ed — the buffered command lands in claude's prompt buffer and runs at the next idle prompt (the `inject.ts` FUTURE-GAP). The code's own comment admitted the race.

## Fix
- **`src/agents/inject.ts`** — add an **opt-in** `precondition?: () => boolean` to `InjectOpts`, threaded through `injectSlashCommand` → `injectSlashCommandWith`. Re-evaluated **inside the pane lock, immediately before send-keys** (before any tmux I/O). If it returns `false`, abort with a new `outcome: 'skipped'` / `errorCode: 'precondition_failed'` and send **no keys**. New `skipped` member added to `InjectOutcome` / `InjectErrorCode`.
- **`telegram-plugin/gateway/gateway.ts`** (`maybeIdleClear`, ~5088) — pass a precondition that **re-runs the full `decideIdleClear` decision** against the live clocks + `turnInFlightForGate()` (per the design red-team: a re-run of the decision, NOT a bespoke "activity unchanged" check, so #3117's future `backgroundWorkInFlight` input composes at write time for free). On `skipped`, the fire-once latch is re-armed.
- **`telegram-plugin/gateway/inject-handler.ts`** — defensive `skipped` branch in `shapeReply` (unreachable today; no inject-map/MCP caller opts in) so a future opt-in caller gets an honest ack instead of a failure card.

## Opt-in guarantee
`/compact` (gateway.ts:4996) and the inject-map / MCP callers (21970, 22061) pass no `precondition`; the guard is `if (precondition && !precondition())`, so their behaviour is byte-for-byte identical. `tsc` passes with the widened union.

## Tests (`src/agents/inject.test.ts`)
Three new tests under `#3116 write-time precondition`, asserting OUTCOMES:
1. precondition `true` → send-keys fires (behaviour unchanged).
2. precondition `false` → **no keys sent**, no tmux I/O, `outcome==='skipped'`, `errorCode==='precondition_failed'`.
3. End-to-end gap semantics driven through the **real `decideIdleClear`**: gate decides clear → an inbound (`markIdleActivity`) lands in the check→send gap → the write-time re-eval returns not-idle → `/clear` suppressed (no keys sent).

Verified genuinely failing on the bug: removing only the write-time guard (types intact) makes tests 2 and 3 fail because send-keys fires. `npm run lint` clean; scoped `inject.test.ts`, `idle-clear.test.ts`, `inject-handler.test.ts` all green.

## Residual (follow-up #3216)
Re-eval narrows but does not fully close the race: an inbound landing **after** send-keys but before claude submits the buffered `/clear` is still clobbered. Full closure needs buffer-cancel. Do not read this PR as eliminating the race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)