### PR TITLE
fix(ms-365): make write-approval functional — real tool names + non-empty approver set (P1)

### DIFF
--- a/src/cli/ms-365-write-pretool.test.ts
+++ b/src/cli/ms-365-write-pretool.test.ts
@@ -1,39 +1,88 @@
 /**
- * Tests for ms-365-write-pretool — RFC #1873 §8 PR 4.
+ * Tests for ms-365-write-pretool — RFC #1873 §8 PR 4, P1 hotfix (2026-07-13).
  *
  * Pure-function tests for the testable surface. The async main() flow
- * (stdin parse, gateway IPC, kernel poll) is not unit-tested here —
- * it's tested in the gateway handler tests + UAT scenarios in PR 5.
+ * (stdin parse, gateway IPC, kernel poll) is not unit-tested here — it's
+ * tested in the gateway handler tests + UAT scenarios.
+ *
+ * These tests pin the AUTHORITATIVE softeria tool names (harvested from real
+ * `mcp__ms-365__*` invocations across the fleet). The prior version pinned
+ * conjectured names (`create-event`, `list-files`, …) that never existed
+ * upstream; those assertions passed only because `isGatedMs365Tool`
+ * fail-closes ANY unknown name, so they actively MASKED Bug 1 (every real
+ * read misclassified as a write). The read assertions below use real names
+ * and would FAIL against the pre-fix allowlists.
  */
 
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { canonicalizeApproverSet } from "../vault/approvals/canonical.js";
 import {
   extractMs365Preview,
   GATED_MS365_WRITE_TOOLS,
   KNOWN_SAFE_MS365_READ_TOOLS,
   isGatedMs365Tool,
+  loadAllowFrom,
 } from "./ms-365-write-pretool.js";
 
-describe("isGatedMs365Tool", () => {
-  it("returns true for known gated tools", () => {
+describe("isGatedMs365Tool — real softeria write names (Bug 1: gate)", () => {
+  it("GATES real calendar writes", () => {
+    expect(isGatedMs365Tool("mcp__ms-365__create-calendar-event")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__update-calendar-event")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__delete-calendar-event")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__cancel-calendar-event")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__accept-calendar-event")).toBe(true);
+  });
+
+  it("GATES real mail writes", () => {
+    expect(isGatedMs365Tool("mcp__ms-365__update-mail-message")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__delete-mail-message")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__move-mail-message")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__create-draft-email")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__reply-mail-message")).toBe(true);
+  });
+
+  it("GATES real OneDrive writes", () => {
     expect(isGatedMs365Tool("mcp__ms-365__upload-file-content")).toBe(true);
     expect(isGatedMs365Tool("mcp__ms-365__create-upload-session")).toBe(true);
-    expect(isGatedMs365Tool("mcp__ms-365__create-event")).toBe(true);
-    expect(isGatedMs365Tool("mcp__ms-365__update-event")).toBe(true);
-    expect(isGatedMs365Tool("mcp__ms-365__delete-event")).toBe(true);
-    expect(isGatedMs365Tool("mcp__ms-365__update-message")).toBe(true);
-    expect(isGatedMs365Tool("mcp__ms-365__delete-message")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__delete-onedrive-file")).toBe(true);
+  });
+});
+
+describe("isGatedMs365Tool — real softeria read names (Bug 1: pass through)", () => {
+  // These are the highest-traffic REAL reads. Pre-fix, none were on the
+  // allowlist, so every one posted an approval card and then hit Bug 2 →
+  // drift_revoked. Post-fix they must pass through WITHOUT a card. Each of
+  // these assertions FAILS against the pre-fix (conjectured-name) allowlist.
+  it("passes real calendar reads through without a card", () => {
+    expect(isGatedMs365Tool("mcp__ms-365__get-calendar-view")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__list-calendars")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__list-calendar-events")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__get-calendar-event")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__list-calendar-view-delta")).toBe(false);
   });
 
-  it("returns false for VERIFIED read tools (no gating overhead)", () => {
-    expect(isGatedMs365Tool("mcp__ms-365__list-files")).toBe(false);
+  it("passes real mail reads through without a card", () => {
+    expect(isGatedMs365Tool("mcp__ms-365__list-mail-messages")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__get-mail-message")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__list-mail-folders")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__list-mail-attachments")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__get-mailbox-settings")).toBe(false);
+  });
+
+  it("passes real OneDrive reads + identity control-plane through", () => {
     expect(isGatedMs365Tool("mcp__ms-365__get-drive-item")).toBe(false);
-    expect(isGatedMs365Tool("mcp__ms-365__list-events")).toBe(false);
-    expect(isGatedMs365Tool("mcp__ms-365__search-mail")).toBe(false);
     expect(isGatedMs365Tool("mcp__ms-365__download-bytes")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__verify-login")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__list-accounts")).toBe(false);
   });
+});
 
+describe("isGatedMs365Tool — structural fail-closed + prefix guards", () => {
   it("returns false for non-ms-365 tools (wrong prefix)", () => {
     expect(isGatedMs365Tool("mcp__google-workspace__upload-file-content")).toBe(false);
     expect(isGatedMs365Tool("Edit")).toBe(false);
@@ -45,62 +94,123 @@ describe("isGatedMs365Tool", () => {
     expect(isGatedMs365Tool("mcp__ms-365__")).toBe(false);
   });
 
-  // ── Fail-closed inversion (review 2026-07-11, W2) ────────────────────
-  // An unrecognized MS-365 tool — a renamed or newly-added upstream write —
-  // must REQUIRE approval, not sail through. The allowlist gap defaults to
-  // "gate", never to "allow".
-  it("GATES an unrecognized ms-365 tool (renamed/new write — fail closed)", () => {
-    // A plausibly-renamed upload tool that isn't in our read allowlist.
-    expect(isGatedMs365Tool("mcp__ms-365__upload-file-content-v2")).toBe(true);
+  // ── Fail-closed inversion ────────────────────────────────────────────
+  // An UNRECOGNIZED ms-365 tool — a renamed or newly-added upstream tool
+  // that isn't on the read allowlist — must REQUIRE approval, not sail
+  // through. The allowlist gap defaults to "gate", never to "allow".
+  it("GATES an unrecognized ms-365 tool (renamed/new — fail closed)", () => {
     expect(isGatedMs365Tool("mcp__ms-365__put-file")).toBe(true);
-    expect(isGatedMs365Tool("mcp__ms-365__patch-event")).toBe(true);
-    // A brand-new write surface softeria might add tomorrow.
-    expect(isGatedMs365Tool("mcp__ms-365__move-message")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__patch-calendar-event")).toBe(true);
     expect(isGatedMs365Tool("mcp__ms-365__totally-unknown-tool")).toBe(true);
   });
 
-  it("GATES Mail.Send — a write tool not on the read allowlist (fail closed)", () => {
-    // Pre-fix this was deliberately allowed through ("agent shouldn't have
-    // the scope at all"), which was exactly the fail-open hole: if the
-    // agent ever DID get send access, it bypassed approval. Fail-closed
-    // now requires a card for any unrecognized write.
+  it("GATES send-mail / send — explicit gate-and-allow (not silent pass)", () => {
+    // send-mail is now on the explicit write set (gate-and-allow): it posts
+    // a card the operator can approve, rather than riding fail-closed
+    // implicitly. Either way it must be gated, never allowed silently.
     expect(isGatedMs365Tool("mcp__ms-365__send-mail")).toBe(true);
-    expect(isGatedMs365Tool("mcp__ms-365__send-message")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__send")).toBe(true);
   });
 });
 
-describe("KNOWN_SAFE_MS365_READ_TOOLS — read allowlist integrity", () => {
-  it("does not overlap with the gated write set", () => {
+describe("tool-set integrity", () => {
+  it("read allowlist never overlaps the gated write set", () => {
     for (const t of KNOWN_SAFE_MS365_READ_TOOLS) {
       expect(GATED_MS365_WRITE_TOOLS.has(t), t).toBe(false);
     }
   });
 
-  it("does not include any send tool (writes never belong on the read allowlist)", () => {
+  it("no send tool is on the read allowlist (writes never read-safe)", () => {
     expect(KNOWN_SAFE_MS365_READ_TOOLS.has("send-mail")).toBe(false);
-    expect(KNOWN_SAFE_MS365_READ_TOOLS.has("send-message")).toBe(false);
+    expect(KNOWN_SAFE_MS365_READ_TOOLS.has("send")).toBe(false);
+  });
+
+  it("write set contains the real calendar/mail write names", () => {
+    for (const t of [
+      "create-calendar-event",
+      "update-calendar-event",
+      "delete-calendar-event",
+      "update-mail-message",
+      "delete-mail-message",
+      "send-mail",
+    ]) {
+      expect(GATED_MS365_WRITE_TOOLS.has(t), t).toBe(true);
+    }
+  });
+
+  it("write set does NOT contain the old conjectured names", () => {
+    // Guard against regressing to the fictional names.
+    for (const t of ["create-event", "update-event", "delete-event", "update-message", "delete-message"]) {
+      expect(GATED_MS365_WRITE_TOOLS.has(t), t).toBe(false);
+    }
   });
 });
 
-describe("GATED_MS365_WRITE_TOOLS — set integrity", () => {
-  it("does not include Mail.Send tools (v1 contract)", () => {
-    expect(GATED_MS365_WRITE_TOOLS.has("send-mail")).toBe(false);
-    expect(GATED_MS365_WRITE_TOOLS.has("send-message")).toBe(false);
+// ── Bug 2 regression: verdict lookup must pass a NON-EMPTY operator set ──
+//
+// The kernel's evaluateDecisionRow drift check (src/vault/approvals/kernel.ts)
+// compares `canonicalizeApproverSet(current_approver_set)` against the
+// decision row's stored canonical. On grant the shared callback records the
+// tapper's uid singleton (`[tapper_uid]`). The pre-fix pretool passed `[]`,
+// so `canonicalize([]) !== canonicalize([tapper_uid])` ALWAYS → drift branch
+// → drift_revoked. Every operator Approve was silently reverted to a deny.
+//
+// The fix loads the real operator allowFrom via loadAllowFrom(); in the
+// single-operator DM case that is `[operator_uid]`, and the tapper IS the
+// operator, so the two canonicalize identically → NO drift → grant sticks.
+// These tests reproduce that outcome with the REAL kernel canonicalizer.
+describe("Bug 2 regression — non-empty approver set makes grant stick", () => {
+  let stateDir: string;
+  const savedStateDir = process.env.TELEGRAM_STATE_DIR;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "ms365-access-"));
+  });
+  afterEach(() => {
+    if (savedStateDir === undefined) delete process.env.TELEGRAM_STATE_DIR;
+    else process.env.TELEGRAM_STATE_DIR = savedStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
   });
 
-  it("includes all expected v1 write tools", () => {
-    const expected = [
-      "upload-file-content",
-      "create-upload-session",
-      "create-event",
-      "update-event",
-      "delete-event",
-      "update-message",
-      "delete-message",
-    ];
-    for (const t of expected) {
-      expect(GATED_MS365_WRITE_TOOLS.has(t)).toBe(true);
-    }
+  function writeAccess(allowFrom: string[]): void {
+    writeFileSync(join(stateDir, "access.json"), JSON.stringify({ allowFrom }));
+    process.env.TELEGRAM_STATE_DIR = stateDir;
+  }
+
+  it("loadAllowFrom returns the operator set from access.json", () => {
+    writeAccess(["555000111"]);
+    expect(loadAllowFrom()).toEqual(["555000111"]);
+  });
+
+  it("single-operator: loaded set canonicalizes == the [tapper_uid] record → NO drift (granted)", () => {
+    const tapperUid = "555000111"; // what approval-callback records on grant
+    writeAccess([tapperUid]);
+
+    const lookupSet = loadAllowFrom(); // what the FIXED pretool passes
+    const recordCanonical = canonicalizeApproverSet([tapperUid]);
+    const lookupCanonical = canonicalizeApproverSet(lookupSet);
+
+    // Fixed behaviour: sets match → kernel keeps the grant.
+    expect(lookupCanonical).toBe(recordCanonical);
+  });
+
+  it("the OLD empty-set behaviour would DRIFT-REVOKE against the same record", () => {
+    const tapperUid = "555000111";
+    // Pre-fix pretool passed [] regardless of access.json.
+    const oldLookupCanonical = canonicalizeApproverSet([]);
+    const recordCanonical = canonicalizeApproverSet([tapperUid]);
+    // Proves the bug: empty set never matches the recorded operator → drift.
+    expect(oldLookupCanonical).not.toBe(recordCanonical);
+  });
+
+  it("loadAllowFrom returns [] when no operator is paired (fails closed, not open)", () => {
+    process.env.TELEGRAM_STATE_DIR = stateDir; // no access.json written
+    expect(loadAllowFrom()).toEqual([]);
+    // An empty loaded set still can't match the [tapper_uid] record, so an
+    // unpaired agent drift-denies — safe, never fail-open.
+    expect(canonicalizeApproverSet([])).not.toBe(
+      canonicalizeApproverSet(["555000111"]),
+    );
   });
 });
 
@@ -115,9 +225,9 @@ describe("extractMs365Preview", () => {
   });
 
   it("falls back through alternate id field names", () => {
-    expect(extractMs365Preview("mcp__ms-365__create-event", { eventId: "ev-1" }).itemId).toBe("ev-1");
-    expect(extractMs365Preview("mcp__ms-365__update-message", { messageId: "msg-1" }).itemId).toBe("msg-1");
-    expect(extractMs365Preview("mcp__ms-365__delete-event", { id: "x" }).itemId).toBe("x");
+    expect(extractMs365Preview("mcp__ms-365__create-calendar-event", { eventId: "ev-1" }).itemId).toBe("ev-1");
+    expect(extractMs365Preview("mcp__ms-365__update-mail-message", { messageId: "msg-1" }).itemId).toBe("msg-1");
+    expect(extractMs365Preview("mcp__ms-365__delete-calendar-event", { id: "x" }).itemId).toBe("x");
   });
 
   it('defaults itemId to "(new)" when no id field is present', () => {

--- a/src/cli/ms-365-write-pretool.test.ts
+++ b/src/cli/ms-365-write-pretool.test.ts
@@ -42,7 +42,6 @@ describe("isGatedMs365Tool — real softeria write names (Bug 1: gate)", () => {
     expect(isGatedMs365Tool("mcp__ms-365__update-mail-message")).toBe(true);
     expect(isGatedMs365Tool("mcp__ms-365__delete-mail-message")).toBe(true);
     expect(isGatedMs365Tool("mcp__ms-365__move-mail-message")).toBe(true);
-    expect(isGatedMs365Tool("mcp__ms-365__create-draft-email")).toBe(true);
     expect(isGatedMs365Tool("mcp__ms-365__reply-mail-message")).toBe(true);
   });
 
@@ -74,9 +73,32 @@ describe("isGatedMs365Tool — real softeria read names (Bug 1: pass through)", 
     expect(isGatedMs365Tool("mcp__ms-365__get-mailbox-settings")).toBe(false);
   });
 
-  it("passes real OneDrive reads + identity control-plane through", () => {
+  it("passes real OneDrive reads + read-only identity ops through", () => {
     expect(isGatedMs365Tool("mcp__ms-365__get-drive-item")).toBe(false);
     expect(isGatedMs365Tool("mcp__ms-365__download-bytes")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__login")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__verify-login")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__list-accounts")).toBe(false);
+  });
+
+  it("passes create-draft-email through (policy: frictionless drafting)", () => {
+    // Operator-approved exception: a draft is unsent/reviewable/deletable.
+    expect(isGatedMs365Tool("mcp__ms-365__create-draft-email")).toBe(false);
+  });
+});
+
+describe("isGatedMs365Tool — mutating identity ops must be gated (F1)", () => {
+  // Reviewer MEDIUM finding F1: identity ops that CHANGE auth/account state
+  // (log out, switch account, remove account) are not read-safe — they must
+  // require a card. Only the read-only identity ops stay no-card.
+  it("GATES mutating identity ops", () => {
+    expect(isGatedMs365Tool("mcp__ms-365__logout")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__select-account")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__remove-account")).toBe(true);
+  });
+
+  it("keeps read-only identity ops no-card", () => {
+    expect(isGatedMs365Tool("mcp__ms-365__login")).toBe(false);
     expect(isGatedMs365Tool("mcp__ms-365__verify-login")).toBe(false);
     expect(isGatedMs365Tool("mcp__ms-365__list-accounts")).toBe(false);
   });

--- a/src/cli/ms-365-write-pretool.ts
+++ b/src/cli/ms-365-write-pretool.ts
@@ -71,30 +71,81 @@ const KERNEL_SOCKET =
 const TOOL_PREFIX = "mcp__ms-365__";
 
 /**
- * Gated softeria write tools — RFC §8.
+ * Gated softeria write tools — AUTHORITATIVE names.
  *
- * **OneDrive writes** — upload-file-content (≤4MB inline),
- * create-upload-session (>4MB chunked).
+ * Names are the ground-truth softeria `mcp__ms-365__*` tool names,
+ * harvested from real invocations across the fleet's agent transcripts
+ * (88 distinct names observed) and reconciled in the MS-365 approval
+ * design review (2026-07-13). They replace the earlier conjectured names
+ * (`create-event`/`update-event`/`update-message`/…) which never existed
+ * upstream — softeria names calendar/mail writes as `*-calendar-event`
+ * and `*-mail-message`.
  *
- * **Calendar writes** — create-event, update-event, delete-event.
+ * This set is primarily documentation + an explicit-gate assertion:
+ * `isGatedMs365Tool` fail-closes ANY unrecognized `mcp__ms-365__` tool to
+ * "require approval" regardless, so a name missing here is still gated.
+ * Its load-bearing job is (a) to keep writes and reads from ever
+ * overlapping and (b) to make `send-mail` / `send` explicitly gate-and-
+ * allow (post a card the operator can approve) rather than riding the
+ * fail-closed path implicitly.
  *
- * **Mail edits** — update-message, delete-message. Mail.Send is NOT in
- * v1 scope (drafts only); the gated set doesn't include send tools to
- * defend against scope creep.
- *
- * Tool-name conjecture: softeria's MCP server publishes tool names as
- * `<verb>-<surface>` (e.g. `upload-file-content`). Claude Code
- * namespaces them as `mcp__<server-key>__<tool-name>`. The exact
- * tool-name list is verified at UAT time in PR 5.
+ * Fleet config currently enables `mail|calendar` only, but the OneDrive
+ * writes are included so the classification stays correct on any agent
+ * that enables the drive surface.
  */
 export const GATED_MS365_WRITE_TOOLS = new Set<string>([
+  // ── Calendar writes ──
+  "create-calendar",
+  "update-calendar",
+  "delete-calendar",
+  "create-calendar-event",
+  "create-specific-calendar-event",
+  "update-calendar-event",
+  "update-specific-calendar-event",
+  "delete-calendar-event",
+  "delete-specific-calendar-event",
+  "accept-calendar-event",
+  "decline-calendar-event",
+  "tentatively-accept-calendar-event",
+  "cancel-calendar-event",
+  "forward-calendar-event",
+  "dismiss-calendar-event-reminder",
+  "snooze-calendar-event-reminder",
+  "create-my-calendar-permission",
+  "update-my-calendar-permission",
+  "delete-my-calendar-permission",
+  // ── Mail writes ──
+  "send-mail",
+  "send",
+  "create-draft-email",
+  "update-mail-message",
+  "delete-mail-message",
+  "move-mail-message",
+  "copy-mail-message",
+  "reply-mail-message",
+  "reply-all-mail-message",
+  "forward-mail-message",
+  "create-mail-attachment-upload-session",
+  "add-mail-attachment",
+  "delete-mail-attachment",
+  "create-mail-folder",
+  "create-mail-child-folder",
+  "update-mail-folder",
+  "delete-mail-folder",
+  "create-mail-rule",
+  "update-mail-rule",
+  "delete-mail-rule",
+  "update-mailbox-settings",
+  // ── OneDrive writes (only reachable on agents that enable the drive surface) ──
   "upload-file-content",
   "create-upload-session",
-  "create-event",
-  "update-event",
-  "delete-event",
-  "update-message",
-  "delete-message",
+  "create-onedrive-folder",
+  "delete-onedrive-file",
+  "move-rename-onedrive-item",
+  "copy-drive-item",
+  "share-drive-item",
+  "create-drive-item-share-link",
+  "delete-drive-item-permission",
 ]);
 
 /**
@@ -104,33 +155,57 @@ export const GATED_MS365_WRITE_TOOLS = new Set<string>([
  * this allowlist — so a renamed or newly-added upstream WRITE tool defaults
  * to "require approval" rather than sailing through unrecognized.
  *
- * Names are sourced from softeria's read surface (docs/microsoft-workspace
- * + RFC #1873): OneDrive reads, calendar reads, mail reads, and identity.
+ * Names are the AUTHORITATIVE softeria read surface (design review
+ * 2026-07-13): calendar reads, mail reads, OneDrive reads, and the
+ * identity/session control-plane. They replace the earlier conjectured
+ * names (`list-files`/`list-events`/`get-message`/`whoami`/… — none of
+ * which exist upstream), which caused every REAL read (`get-calendar-view`,
+ * `list-mail-messages`, `get-mail-message`, …) to be misclassified as an
+ * unrecognized write and posted an approval card (Bug 1).
+ *
  * The cost of an omission here is only an extra approval prompt on a read
- * (annoying, safe) — never an ungated write (unsafe). When UAT (PR 5)
- * confirms softeria's exact read-tool names, add any missing ones here.
+ * (annoying, safe) — never an ungated write (unsafe).
  */
 export const KNOWN_SAFE_MS365_READ_TOOLS = new Set<string>([
-  // OneDrive / Drive reads
-  "list-files",
-  "list-drive-items",
-  "get-drive-item",
-  "download-bytes",
-  "search-files",
-  // Calendar reads
-  "list-events",
-  "get-event",
+  // ── Calendar reads ──
   "list-calendars",
-  "get-calendar",
-  // Mail reads
-  "list-messages",
-  "get-message",
-  "search-mail",
+  "get-calendar-view",
+  "get-specific-calendar-view",
+  "list-calendar-events",
+  "list-specific-calendar-events",
+  "get-calendar-event",
+  "get-specific-calendar-event",
+  "list-calendar-event-instances",
+  "list-calendar-events-delta",
+  "list-calendar-view-delta",
+  "list-my-calendar-permissions",
+  // ── Mail reads ──
+  "list-mail-messages",
+  "get-mail-message",
+  "get-mail-message-mime",
   "list-mail-folders",
-  "get-mail-folder",
-  // Identity / account
-  "whoami",
-  "get-current-user",
+  "list-mail-child-folders",
+  "list-mail-folder-messages",
+  "list-mail-folder-messages-delta",
+  "list-mail-attachments",
+  "list-mail-rules",
+  "get-mail-tips",
+  "get-mailbox-settings",
+  // ── OneDrive reads (present on agents that enable the drive surface) ──
+  "get-drive-item",
+  "get-drive-root-item",
+  "download-bytes",
+  "list-drives",
+  "list-folder-files",
+  "search-onedrive-files",
+  "get-drive-delta",
+  // ── Identity / session (control-plane; no card) ──
+  "login",
+  "logout",
+  "verify-login",
+  "list-accounts",
+  "select-account",
+  "remove-account",
 ]);
 
 /**
@@ -152,6 +227,47 @@ export function isGatedMs365Tool(toolName: string): boolean {
   if (KNOWN_SAFE_MS365_READ_TOOLS.has(bare)) return false;
   // Known write OR unrecognized MS-365 tool → require approval (fail-closed).
   return true;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Operator allowFrom discovery
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Read the operator allowFrom set from `access.json` inside the agent
+ * container. Mirrors `drive-write-pretool.ts:loadAllowFrom()` — the WORKING
+ * Drive path — verbatim in mechanism.
+ *
+ * This is the fix for Bug 2: the verdict lookup previously passed `[]` as the
+ * `current_approver_set`, which the kernel's `evaluateDecisionRow` drift check
+ * compared against the decision row's canonical set (`[tapper_uid]`). `[] ≠
+ * [tapper_uid]` → drift branch → `drift_revoked`, so EVERY operator Approve
+ * was silently reverted to a deny. Passing the real operator set (which, in
+ * the single-operator DM case, canonicalizes identically to `[tapper_uid]`)
+ * makes the grant stick — exactly as it does for Drive.
+ *
+ * `access.json` lives at `<TELEGRAM_STATE_DIR>/access.json` inside the agent
+ * container. The homedir fallback only kicks in for host-side invocations
+ * (tests, debug tools). If no operator is paired the list is empty — the poll
+ * then can't match the `[tapper_uid]` record and fails closed (safe).
+ */
+export function loadAllowFrom(): string[] {
+  const stateDir =
+    process.env.TELEGRAM_STATE_DIR ??
+    join(homedir(), ".claude", "channels", "telegram");
+  const accessPath = join(stateDir, "access.json");
+  try {
+    const raw = readFileSync(accessPath, "utf8");
+    const j = JSON.parse(raw) as { allowFrom?: unknown };
+    if (Array.isArray(j.allowFrom)) {
+      return (j.allowFrom as unknown[]).filter(
+        (s): s is string => typeof s === "string",
+      );
+    }
+  } catch {
+    /* not paired or no access file */
+  }
+  return [];
 }
 
 // ────────────────────────────────────────────────────────────────────────
@@ -476,11 +592,15 @@ async function main(): Promise<void> {
   const deadline = response.expiresAtMs ?? Date.now() + HOOK_TIMEOUT_MS;
   // Correlate strictly by the request_id we just registered — not by scope
   // (concurrent same-scope writes would otherwise cross-attribute verdicts).
-  // We don't know the approver_set in the hook — pass an empty list; the
-  // kernel uses the snapshot taken at register time.
+  // Pass the REAL operator allowFrom set (Bug 2 fix): the kernel's
+  // evaluateDecisionRow drift check compares this against the decision row's
+  // canonical set. Passing `[]` (the old bug) always drifted → drift_revoked,
+  // so no Approve ever stuck. Mirror the working Drive pretool and pass the
+  // loaded allowFrom.
+  const approverSet = loadAllowFrom();
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, KERNEL_POLL_INTERVAL_MS));
-    const lookup = await approvalLookupByRequest(agentName, requestId, []);
+    const lookup = await approvalLookupByRequest(agentName, requestId, approverSet);
     if (!lookup) continue;
     const state = lookup.state;
     if (state === "granted") allow();

--- a/src/cli/ms-365-write-pretool.ts
+++ b/src/cli/ms-365-write-pretool.ts
@@ -117,7 +117,6 @@ export const GATED_MS365_WRITE_TOOLS = new Set<string>([
   // ── Mail writes ──
   "send-mail",
   "send",
-  "create-draft-email",
   "update-mail-message",
   "delete-mail-message",
   "move-mail-message",
@@ -191,6 +190,13 @@ export const KNOWN_SAFE_MS365_READ_TOOLS = new Set<string>([
   "list-mail-rules",
   "get-mail-tips",
   "get-mailbox-settings",
+  // Deliberate policy exception (operator-approved 2026-07-13): creating a
+  // mail DRAFT is no-card. A draft is unsent, reviewable, and deletable —
+  // reversible by nature — so frictionless drafting is the low-friction
+  // default while SENDING stays gated. This is NOT an oversight: only the
+  // send/reply/forward-SEND tools carry irreversible external effect and
+  // remain in GATED_MS365_WRITE_TOOLS.
+  "create-draft-email",
   // ── OneDrive reads (present on agents that enable the drive surface) ──
   "get-drive-item",
   "get-drive-root-item",
@@ -199,13 +205,14 @@ export const KNOWN_SAFE_MS365_READ_TOOLS = new Set<string>([
   "list-folder-files",
   "search-onedrive-files",
   "get-drive-delta",
-  // ── Identity / session (control-plane; no card) ──
+  // ── Identity / session — READ-ONLY ops only (no card) ──
+  // Reviewer finding F1: ops that MUTATE auth/account state (logout,
+  // select-account, remove-account) are NOT read-safe — they fall through
+  // to the fail-closed gate and require a card. Only genuinely read-only
+  // identity ops belong here.
   "login",
-  "logout",
   "verify-login",
   "list-accounts",
-  "select-account",
-  "remove-account",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Makes the MS-365 (softeria) write-approval flow functional again. It was **fully broken in production**: every gated `mcp__ms-365__` call ended in `drift_revoked` even after the operator tapped Approve, and every real read was misclassified as a write and posted a card. Consumer-side P1 hotfix; kernel untouched.

Grounded in `work/ms365-approval-review/DESIGN.md` (§§1–3, 6 P1), which confirmed both bugs against source and live clerk transcripts.

## The two bugs

**Bug 2 — writes/reads can never be approved (`drift_revoked`).** The verdict poll called `approvalLookupByRequest(agent, requestId, [])` — an **empty** `current_approver_set`. The kernel's `evaluateDecisionRow` drift check compares that against the decision row's canonical set, which the shared grant callback records as the tapper's uid singleton (`[tapper_uid]`). `canonicalize([]) !== canonicalize([tapper_uid])` → drift branch → `drift_revoked`, so no Approve ever stuck.
Fix: mirror the **working** Drive pretool (`drive-write-pretool.ts:loadAllowFrom` / `:192`) — add `loadAllowFrom()` reading `access.json` in the agent container and pass the real operator set. Single-operator DM ⇒ canonicalizes identically to `[tapper_uid]` ⇒ grant sticks. Unpaired (`[]`) still fails closed.

**Bug 1 — reads misclassified as writes.** `KNOWN_SAFE_MS365_READ_TOOLS` / `GATED_MS365_WRITE_TOOLS` held conjectured names (only ~4/16 reads real; `create-event`/`update-message`/etc. never existed upstream). Every real read (`get-calendar-view`, `list-mail-messages`, `get-mail-message`, …) missed the allowlist, hit fail-closed, and posted a card (then Bug 2 blocked it).
Fix: replaced both sets with the **authoritative** softeria names (calendar + mail + onedrive reads/writes + identity control-plane) harvested from real fleet transcripts. Fail-closed default preserved — an unknown `mcp__ms-365__` tool still requires approval. `send-mail`/`send` now **explicitly** gate-and-allow rather than riding fail-closed implicitly.

## Tests

Rewrote `ms-365-write-pretool.test.ts` to pin REAL names (the old tests passed only because fail-closed catches unknowns — they actively masked Bug 1). Added a **Bug 2 regression** using the real kernel `canonicalizeApproverSet`: proves the loaded operator set matches the `[tapper_uid]` record (grant sticks) while the old `[]` drifts. 28 tests pass.

## Test plan

- `vitest run src/cli/ms-365-write-pretool.test.ts` → 28 passed
- `tsc --noEmit` → clean (exit 0)
- Full `npm run lint` plugin-references guard trips locally only on missing `mdast-*`/`@mtcute/*` deps in a borrowed node_modules (environment artifact, not this diff) — CI is the authority.

## Risk

Low — changes are data (tool-name sets) + one lookup arg + a Drive-mirrored helper. Multi-operator allowFrom (>1 entry) still drifts against the `[tapper_uid]` singleton record — the same limitation Drive has today; accepted for v1, resolved kernel-side in P3. Drive pretool untouched.

Job spec: `reference/jobs/` — on-the-leash approval gating for Microsoft writes (RFC #1873 §8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)