### PR TITLE
fix(gateway): close idle-clear check-to-send race with a write-time precondition (#3116)

### DIFF
--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -919,3 +919,98 @@ describe("#2566 — /model and /memory allowlist treatment", () => {
     expect(result.outcome).toBe("ok");
   });
 });
+
+// ─── #3116 — check-to-send race guard (precondition re-eval at write) ──────
+describe("injectSlashCommandWith — precondition (#3116)", () => {
+  it("precondition false → command is NEVER typed into the pane (outcome=skipped)", async () => {
+    // The race: idle-clear decided /clear, but an inbound arrived before the
+    // tmux write. The precondition re-reads the idle gate at write time and
+    // returns false, so nothing is sent.
+    const sent: string[][] = [];
+    const runner = makeFake({
+      hasSession: true,
+      captures: ["before\n"],
+      onSend: (args) => sent.push(args),
+    });
+
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 50,
+      timeoutMs: 100,
+      precondition: () => false,
+    });
+
+    // The load-bearing assertion — no keys were ever sent into the pane.
+    // On current main (no precondition param) the write always fires and
+    // `sent` would contain the send-keys calls → this FAILS, proving the bug.
+    expect(sent).toEqual([]);
+    expect(r.outcome).toBe("skipped");
+    expect(r.errorCode).toBe("precondition_failed");
+    expect(r.command).toBe("/clear");
+  });
+
+  it("precondition true → command IS sent (still-idle at write time)", async () => {
+    const sent: string[][] = [];
+    const runner = makeFake({
+      hasSession: true,
+      captures: ["before\n", "before\n"],
+      onSend: (args) => sent.push(args),
+    });
+
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 20,
+      timeoutMs: 60,
+      precondition: () => true,
+    });
+
+    expect(sent[0]).toEqual(["send-keys", "-l", "/clear"]);
+    expect(sent[1]).toEqual(["send-keys", "Enter"]);
+    // /clear renders no output → ok_no_output, but it WAS dispatched.
+    expect(r.outcome).toBe("ok_no_output");
+  });
+
+  it("no precondition → unchanged behaviour (always sends)", async () => {
+    const sent: string[][] = [];
+    const runner = makeFake({
+      hasSession: true,
+      captures: ["before\n", "before\n"],
+      onSend: (args) => sent.push(args),
+    });
+
+    await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 20,
+      timeoutMs: 60,
+    });
+
+    expect(sent[0]).toEqual(["send-keys", "-l", "/clear"]);
+  });
+
+  it("precondition is evaluated BEFORE has-session pane capture, once", async () => {
+    // The precondition must gate the write, and must not be re-invoked per poll.
+    let calls = 0;
+    const runner = makeFake({
+      hasSession: true,
+      captures: ["before\n", "before\n"],
+    });
+    await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 20,
+      timeoutMs: 60,
+      precondition: () => {
+        calls += 1;
+        return true;
+      },
+    });
+    expect(calls).toBe(1);
+  });
+});

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -223,7 +223,8 @@ export type InjectErrorCode =
   | "session_missing"
   | "invalid"
   | "timeout"
-  | "tmux_failed";
+  | "tmux_failed"
+  | "precondition_failed";
 
 export class InjectError extends Error {
   code: InjectErrorCode;
@@ -249,6 +250,24 @@ export interface InjectOpts {
   settleMs?: number;
   /** Hard upper bound on total wait (ms). Default 5000ms. */
   timeoutMs?: number;
+  /**
+   * Check-to-send race guard (#3116). Re-evaluated by
+   * `injectSlashCommandWith` IMMEDIATELY before the first `send-keys` write.
+   * If it returns false the command is NOT typed into the pane and the call
+   * returns `outcome: 'skipped'` (`errorCode: 'precondition_failed'`).
+   *
+   * Why: idle-clear / proactive-compact decide to inject `/clear` (or
+   * `/compact`) against a session judged idle, then dispatch asynchronously.
+   * An inbound arriving in the gap between the decision and the tmux write
+   * would otherwise land the slash command in claude's prompt buffer, where
+   * it runs at the NEXT idle prompt — against a session that is no longer
+   * idle, destroying live context (overlord, 2026-07-11). Passing a
+   * precondition that re-reads the idle gate at write time closes the gap:
+   * dispatch only if still idle when the keys are actually sent.
+   *
+   * Omitted by every interactive/operator caller → unchanged behaviour.
+   */
+  precondition?: () => boolean;
 }
 
 /**
@@ -258,11 +277,14 @@ export interface InjectOpts {
  *    expected (e.g. `/clear`) or suspicious (`/cost` with no output).
  *  - `failed` — validation rejected, session missing, or send-keys
  *    threw. `errorCode` and `errorMessage` carry the reason.
+ *  - `skipped` — a caller `precondition` returned false at write time
+ *    (#3116); nothing was typed into the pane. `errorCode` is
+ *    `precondition_failed`.
  *
  * Classification is derived from runtime capture, not from
  * `expectsOutput` — that field is a UX hint only.
  */
-export type InjectOutcome = "ok" | "ok_no_output" | "failed";
+export type InjectOutcome = "ok" | "ok_no_output" | "failed" | "skipped";
 
 export type InjectDiagnostic =
   | "anchor_missing"
@@ -593,6 +615,7 @@ export async function injectSlashCommand(
       command: command.trim(),
       settleMs,
       timeoutMs,
+      precondition: opts.precondition,
     }),
   );
 }
@@ -614,9 +637,10 @@ export async function injectSlashCommandWith(
     command: string;
     settleMs: number;
     timeoutMs: number;
+    precondition?: () => boolean;
   },
 ): Promise<InjectResult> {
-  const { socket, session, command, settleMs, timeoutMs } = args;
+  const { socket, session, command, settleMs, timeoutMs, precondition } = args;
 
   // Re-validate so the seam itself enforces the contract. The bare
   // verb is what we'll surface in `result.command` / lookup metadata.
@@ -651,6 +675,25 @@ export async function injectSlashCommandWith(
         `tmux session "${session}" on socket "${socket}" not found. ` +
         `Is the agent running under the tmux supervisor (the default)? ` +
         `If experimental.legacy_pty=true is set, inject is unsupported.`,
+    };
+  }
+
+  // #3116 — check-to-send race guard. Re-evaluate the caller's precondition
+  // IMMEDIATELY before the tmux write (after the pane lock is held and the
+  // session confirmed present), so a state change between the caller's
+  // decision and this write cancels the send rather than typing a stale
+  // command into the pane. Nothing has been sent yet, so a false verdict is a
+  // clean no-op.
+  if (precondition && !precondition()) {
+    return {
+      outcome: "skipped",
+      output: "",
+      truncated: false,
+      command: bareVerb,
+      meta,
+      errorCode: "precondition_failed",
+      errorMessage:
+        "inject precondition no longer held at write time — command not sent",
     };
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5085,10 +5085,20 @@ function maybeIdleClear(): void {
     `telegram gateway: idle auto-/clear for ${agentName} ` +
       `(idle >= ${Math.round(idleClearMs / 60_000)}m)\n`,
   );
-  // Accepted check-to-send race (same as maybeProactiveCompact): a new inbound
-  // could arrive between the gate check and the tmux send; /clear then lands in
-  // claude's prompt buffer and runs at the next idle prompt (inject.ts FUTURE-GAP).
-  void injectSlashCommandImpl(agentName, '/clear')
+  // #3116 — close the check-to-send race. A new inbound can arrive between
+  // this gate check and the tmux send; without a guard, `/clear` lands in
+  // claude's prompt buffer and runs at the NEXT idle prompt against a session
+  // that is no longer idle, destroying live context (overlord, 2026-07-11).
+  // `injectSlashCommandImpl` re-evaluates this precondition IMMEDIATELY before
+  // the tmux write and skips the send if the session is no longer idle. An
+  // inbound in the gap calls markIdleActivity() (bumps lastIdleActivityAt and
+  // resets idleAutoCleared), so `stillIdle` reads false and the gate re-arms.
+  const stillIdle = (): boolean => {
+    if (turnInFlightForGate()) return false;
+    const evAt = Math.max(lastIdleActivityAt, lastIdleTurnEndAt ?? 0);
+    return Date.now() - evAt >= idleClearMs;
+  };
+  void injectSlashCommandImpl(agentName, '/clear', { precondition: stillIdle })
     .catch((err: unknown) => {
       process.stderr.write(
         `telegram gateway: idle /clear inject failed for ` +


### PR DESCRIPTION
Closes #3116.

## Problem
`maybeIdleClear()` evaluated the idle gate, then dispatched `/clear` into the agent's tmux asynchronously. An inbound arriving between the gate check and the tmux send landed `/clear` in claude's prompt buffer, where it ran at the *next* idle prompt — against a session that was **no longer idle**, destroying live context. Observed 2026-07-11 (overlord stray injected text). Narrowed but not closed by #3113.

## Fix
The inject primitive is shared with proactive-compact, so the guard lives in the primitive:

- `injectSlashCommand`/`injectSlashCommandWith` take an optional `precondition: () => boolean`, re-evaluated **immediately before** the first `send-keys` write (after the pane lock is held and the session confirmed). False → nothing is typed; returns the new `outcome: 'skipped'` (`errorCode: 'precondition_failed'`). Every interactive/operator caller omits it → unchanged behaviour.
- `maybeIdleClear` passes `stillIdle`: `!turnInFlightForGate() && Date.now() - max(lastActivityAt, lastTurnEndedAt) >= idleClearMs`. An inbound in the gap calls `markIdleActivity()` (bumps the clock, resets `idleAutoCleared`), so the precondition reads false and the gate re-arms cleanly.

## Test (fails on main)
`src/agents/inject.test.ts` — precondition false → `runner.send` **never** called + `outcome==='skipped'`; precondition true → sent. The "send never called" assertion **fails on current main** (no precondition → the write always fires). Verified via mutation check (source stashed → 2 RED).

Scoped tests green (99/99 in `inject.test.ts`); `npm run lint` clean.

## Stacking
First of the idle-clear cluster (#3116 → #3117 → #3114 → #3115). Based on main; independent of the others at the file level except a shared touch of `maybeIdleClear`. Later PRs in the stack branch off this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)