### PR TITLE
feat(telegram): adaptive-density combined worker card — per-worker rolling history within a line budget

### DIFF
--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -4,7 +4,7 @@ import {
   type BotApiForWorkerFeed,
   type WorkerActivityView,
 } from '../worker-activity-feed.js'
-import { renderCombinedWorkerFeed } from '../tool-activity-summary.js'
+import { renderCombinedWorkerFeed, combinedHistoryDepth } from '../tool-activity-summary.js'
 import { STATUS_CARD_CHAR_BUDGET } from '../status-no-truncate.js'
 import { createSendGate, isSendGateShed, type Clock } from '../send-gate.js'
 
@@ -488,5 +488,74 @@ describe('renderCombinedWorkerFeed (pure)', () => {
 
   it('returns null for an empty worker set', () => {
     expect(renderCombinedWorkerFeed([], { maxRows: 8 })).toBeNull()
+  })
+
+  // ── Adaptive density: per-worker rolling history within a line budget ──────
+  const rowH = (i: number, history: string[]) => ({
+    description: `task number ${i}`,
+    elapsedMs: 12_000 + i * 1000,
+    toolCount: i,
+    currentStep: history[history.length - 1] ?? '',
+    historyLines: history,
+  })
+
+  // A history line rendered as a PRIOR (done) step in the single-worker idiom.
+  const struck = (s: string) => `~~_✓ ${s}_~~`
+  // A history line rendered as the NEWEST in-progress step.
+  const current = (s: string) => `**→ ${s}**`
+
+  it('with 2 workers paints each worker MULTIPLE history lines with the ✓/→ strikethrough idiom', () => {
+    const body = renderCombinedWorkerFeed(
+      [
+        rowH(1, ['a first', 'a second', 'a third']),
+        rowH(2, ['b first', 'b second', 'b third']),
+      ],
+      { maxRows: 8 },
+    )!
+    // Prior steps struck-through, newest bold — same idiom as the single card.
+    expect(body).toContain(struck('a first'))
+    expect(body).toContain(struck('a second'))
+    expect(body).toContain(current('a third'))
+    expect(body).toContain(struck('b first'))
+    expect(body).toContain(struck('b second'))
+    expect(body).toContain(current('b third'))
+    // This is the regression assertion: the OLD single-line-only render would
+    // have shown only 'a third'/'b third' as `→ _step_`, never the earlier
+    // struck lines. Prove the trail is restored.
+    expect(body).toContain('a first')
+    expect(body).toContain('b first')
+  })
+
+  it('degrades to ONE history line per worker at a large fan-out and stays within the body budget', () => {
+    const rows = Array.from({ length: 6 }, (_, i) =>
+      rowH(i, [`w${i} oldest`, `w${i} middle`, `w${i} newest`]),
+    )
+    const body = renderCombinedWorkerFeed(rows, { maxRows: 8 })!
+    // Only the newest step of each worker survives — the earlier lines are
+    // dropped by the per-worker depth clamp (floor((13-6)/6)=1).
+    for (let i = 0; i < 6; i++) {
+      expect(body).toContain(current(`w${i} newest`))
+      expect(body).not.toContain(`w${i} oldest`)
+      expect(body).not.toContain(`w${i} middle`)
+    }
+    // Total body lines (worker headers + history) stay within the budget: 6
+    // header lines + 6 history lines = 12 ≤ MAX_COMBINED_BODY_LINES (13). Count
+    // only the per-worker body lines (exclude the top count line + any spill).
+    const bodyLines = body
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+    const headerAndHistory = bodyLines.filter(
+      (l) => !l.startsWith('🛠') && !l.includes('more working'),
+    )
+    expect(headerAndHistory.length).toBeLessThanOrEqual(13)
+  })
+
+  it('exposes the deterministic depth formula (2→5, 3→3, 4→2, 6→1)', () => {
+    expect(combinedHistoryDepth(2)).toBe(5)
+    expect(combinedHistoryDepth(3)).toBe(3)
+    expect(combinedHistoryDepth(4)).toBe(2)
+    expect(combinedHistoryDepth(6)).toBe(1)
+    expect(combinedHistoryDepth(8)).toBe(1)
   })
 })

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -582,6 +582,16 @@ export interface CombinedWorkerRow {
   toolCount: number
   /** The worker's latest step line (raw prose or friendly tool label). */
   currentStep: string
+  /**
+   * The worker's accumulated narrative history (oldest→newest, raw/unescaped),
+   * already deduped + rolling-window capped upstream (STATUS_ROLLING_LINES).
+   * When present + non-empty, the combined feed paints the worker's last-K
+   * lines as a `✓`/`→` step trail (prior steps struck, newest in-progress) —
+   * the same idiom as the single-worker card — with K set by the adaptive
+   * per-worker line budget. Absent/empty → falls back to the single
+   * `currentStep` line (back-compat for direct callers).
+   */
+  historyLines?: string[]
   /** Live model id (raw, e.g. `claude-opus-4-8`); omitted when unknown. */
   model?: string
 }
@@ -594,15 +604,51 @@ export interface CombinedWorkerFeedOpts {
 }
 
 /**
+ * Total per-worker BODY line budget for the combined feed — the sum, across all
+ * visible workers, of (one header line + that worker's history lines). The top
+ * `🛠 Workers · N running` line and the `+M more working…` spill are OUTSIDE
+ * this budget (fixed chrome). 13 is chosen so the card stays a compact glance,
+ * not a wall: at 2 workers it yields the full 5-line history each (2·1 header +
+ * 2·5 history = 12 ≤ 13), and it degrades to a single history line each by ~6
+ * workers — matching the pre-adaptive one-line-per-worker floor while never
+ * letting a 2–3 worker fan-out lose its narrative trail.
+ */
+const MAX_COMBINED_BODY_LINES = 13
+/** Each visible worker costs one header line before any history. */
+const PER_WORKER_HEADER_COST = 1
+
+/**
+ * Deterministic per-worker history depth for `w` visible workers:
+ *   clamp( floor( (BUDGET − headerCost·w) / w ), 1, STATUS_ROLLING_LINES )
+ * So 2 workers → 5 lines each, 3 → 3, 4 → 2, ≥6 → 1 (today's single-line floor
+ * is the graceful-degradation floor, never below it). Pure function of the
+ * visible worker count — no model input, consistent with deterministic controls.
+ */
+export function combinedHistoryDepth(w: number): number {
+  if (w <= 0) return 1
+  const raw = Math.floor((MAX_COMBINED_BODY_LINES - PER_WORKER_HEADER_COST * w) / w)
+  return Math.max(1, Math.min(STATUS_ROLLING_LINES, raw))
+}
+
+/**
  * Render N≥1 live workers into ONE combined feed body (ready Telegram
  * markdown; callers send verbatim — do NOT re-escape). Layout:
  *
  *   🛠 **Workers** · _N running_
  *   **{desc1}** _· {elapsed} · {n} tools_
- *   → _{step1}_
+ *   ~~_✓ {earlier step}_~~
+ *   **→ {newest step}**
  *   **{desc2}** _· {elapsed} · {n} tools_
- *   → _{step2}_
+ *   **→ {newest step}**
  *   _+M more working…_
+ *
+ * ADAPTIVE DENSITY: each visible worker renders its last-K narrative lines as a
+ * `✓`/`→` trail (prior steps struck, newest bold in-progress) — the single-
+ * worker card's idiom — where K = `combinedHistoryDepth(visibleCount)` splits a
+ * fixed body-line budget across the running workers. So 2 workers each show
+ * their full recent history and a 6-way fan-out degrades to one line each, the
+ * card staying bounded regardless of fan-out. When a worker has no history yet
+ * it falls back to a single `→ starting…`/currentStep line.
  *
  * Pure. Rows are rendered in the order supplied (the manager passes them
  * dispatch-order, oldest first). `maxRows` caps the visible rows; the hidden
@@ -618,29 +664,43 @@ export function renderCombinedWorkerFeed(
   if (rows.length === 0) return null
   const maxRows = Math.max(1, Math.floor(opts.maxRows))
 
-  const rowLines = (r: CombinedWorkerRow): [string, string] => {
+  const rowHeader = (r: CombinedWorkerRow): string => {
     const desc = escapeMarkdown(
       truncate(stripMarkdown(r.description).replace(/\s+/g, ' ').trim() || 'background task', COMBINED_ROW_DESC_MAX),
     )
     const toolWord = r.toolCount === 1 ? 'tool' : 'tools'
     const modelLabel = formatModelLabel(r.model)
     const modelPart = modelLabel != null ? ` · ${escapeMarkdown(modelLabel)}` : ''
-    const header = `**${desc}** _· ${formatFeedElapsed(r.elapsedMs)} · ${r.toolCount} ${toolWord}${modelPart}_`
-    const stepClean = stripMarkdown(r.currentStep).replace(/\s+/g, ' ').trim()
-    const step =
-      stepClean.length > 0
-        ? `→ _${escapeMarkdown(truncate(stepClean, STATUS_LINE_MAX))}_`
-        : `→ _starting…_`
-    return [header, step]
+    return `**${desc}** _· ${formatFeedElapsed(r.elapsedMs)} · ${r.toolCount} ${toolWord}${modelPart}_`
+  }
+
+  // Raw (unescaped) history for a worker, oldest→newest, empty lines stripped.
+  // Falls back to the single currentStep when no history was supplied.
+  const rowHistory = (r: CombinedWorkerRow): string[] => {
+    const src = r.historyLines != null && r.historyLines.length > 0 ? r.historyLines : [r.currentStep]
+    return src.filter((s) => s != null && stripMarkdown(s).replace(/\s+/g, ' ').trim().length > 0)
   }
 
   const compose = (visibleCount: number): string => {
     const shown = rows.slice(0, visibleCount)
     const hidden = rows.length - shown.length
+    // Adaptive depth: split the fixed body-line budget across the VISIBLE
+    // workers so the card stays bounded regardless of fan-out.
+    const depth = combinedHistoryDepth(shown.length)
     const out: string[] = [`🛠 **Workers** · _${rows.length} running_`]
     for (const r of shown) {
-      const [h, s] = rowLines(r)
-      out.push(h, s)
+      out.push(rowHeader(r))
+      const hist = rowHistory(r)
+      if (hist.length === 0) {
+        out.push('→ _starting…_')
+        continue
+      }
+      // Paint the last-K history lines with the SAME `✓`/`→` idiom as the
+      // single-worker card: escape each raw line through the shared per-line
+      // pipeline (escapeStepLine), then renderStepFeed strikes the prior steps
+      // and bolds the newest in-progress step.
+      const esc = hist.slice(-depth).map(escapeStepLine)
+      renderStepFeed(out, esc, false)
     }
     if (hidden > 0) out.push(`_+${hidden} more working…_`)
     return stackCardLines(out)

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -616,6 +616,11 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         elapsedMs: elapsedFor(r),
         toolCount: v.toolCount,
         currentStep,
+        // Full per-worker rolling history (oldest→newest) so the combined feed
+        // can paint an adaptive-depth ✓/→ trail, not just the latest line. The
+        // renderer clamps depth to the shared body-line budget; when a worker
+        // has no narrative yet this is empty and it falls back to currentStep.
+        historyLines: r.narrative.length > 0 ? [...r.narrative] : undefined,
         model: v.model,
       }
     })


### PR DESCRIPTION
## Problem

The single-worker 🛠 card shows the rolling last-N narrative trail (`~~_✓ prior_~~` struck + `**→ current**` bold). But the **combined** multi-worker card (`renderCombinedWorkerFeed`) collapsed each worker to only its latest line (`worker-activity-feed.ts` — `currentStep = narrative[last]`), discarding the trail. The full per-worker history was already retained in `row.narrative` (capped at `STATUS_ROLLING_LINES`); the combined layout just never painted it.

## Change — adaptive density

A fixed **total body-line budget** is split across the visible workers, so the card stays bounded regardless of fan-out:

- `MAX_COMBINED_BODY_LINES = 13` — the sum, across visible workers, of (1 header line + that worker's history lines). The top `🛠 Workers · N running` line and the `+M more working…` spill are fixed chrome, outside the budget. 13 keeps the card a compact glance while giving a 2–3 worker fan-out its full trail.
- Per-worker depth = `clamp(floor((13 − 1·W)/W), 1, STATUS_ROLLING_LINES)`, W = visible workers:
  - 2 → 5 lines each · 3 → 3 · 4 → 2 · ≥6 → 1 (the old single-line render is the graceful floor, never below it).
- Deterministic — pure function of the visible worker count, no model input (consistent with the deterministic-controls rule).
- Each worker's last-K lines render with the **same idiom** as the single-worker card (prior struck `~~_✓ step_~~`, newest bold `**→ step**`) by reusing the shared `escapeStepLine → renderStepFeed` pipeline — no hand-rolled escaping.
- `maxRows` spill, header/metrics lines (elapsed · tools · model), and the **single-worker path** are all preserved unchanged.

## Tests

Added to `worker-feed-coalesce.test.ts` (pure `renderCombinedWorkerFeed`):
- 2 workers → each paints multiple history lines with the ✓/→ strikethrough idiom (asserts the struck earlier lines the old single-line render never emitted — the regression proof).
- 6 workers → degrades to 1 history line each and the per-worker body lines stay ≤ 13.
- The `combinedHistoryDepth` formula (2→5, 3→3, 4→2, 6→1, 8→1).

All 3 new tests **fail on `origin/main`'s render** and pass with the diff. Scoped suites green (`worker-feed-coalesce`, `tool-activity-summary`, `worker-activity-feed`, `worker-feed-dispatch`, `worker-pin-reaper` — 218 tests), `tsc --noEmit` + `npm run lint` clean. Do NOT merge — awaiting review + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)