### PR TITLE
fix(gateway): TTL-bounded background-work suppressor for idle-clear (#3117)

### DIFF
--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -919,3 +919,98 @@ describe("#2566 — /model and /memory allowlist treatment", () => {
     expect(result.outcome).toBe("ok");
   });
 });
+
+// ─── #3116 — check-to-send race guard (precondition re-eval at write) ──────
+describe("injectSlashCommandWith — precondition (#3116)", () => {
+  it("precondition false → command is NEVER typed into the pane (outcome=skipped)", async () => {
+    // The race: idle-clear decided /clear, but an inbound arrived before the
+    // tmux write. The precondition re-reads the idle gate at write time and
+    // returns false, so nothing is sent.
+    const sent: string[][] = [];
+    const runner = makeFake({
+      hasSession: true,
+      captures: ["before\n"],
+      onSend: (args) => sent.push(args),
+    });
+
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 50,
+      timeoutMs: 100,
+      precondition: () => false,
+    });
+
+    // The load-bearing assertion — no keys were ever sent into the pane.
+    // On current main (no precondition param) the write always fires and
+    // `sent` would contain the send-keys calls → this FAILS, proving the bug.
+    expect(sent).toEqual([]);
+    expect(r.outcome).toBe("skipped");
+    expect(r.errorCode).toBe("precondition_failed");
+    expect(r.command).toBe("/clear");
+  });
+
+  it("precondition true → command IS sent (still-idle at write time)", async () => {
+    const sent: string[][] = [];
+    const runner = makeFake({
+      hasSession: true,
+      captures: ["before\n", "before\n"],
+      onSend: (args) => sent.push(args),
+    });
+
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 20,
+      timeoutMs: 60,
+      precondition: () => true,
+    });
+
+    expect(sent[0]).toEqual(["send-keys", "-l", "/clear"]);
+    expect(sent[1]).toEqual(["send-keys", "Enter"]);
+    // /clear renders no output → ok_no_output, but it WAS dispatched.
+    expect(r.outcome).toBe("ok_no_output");
+  });
+
+  it("no precondition → unchanged behaviour (always sends)", async () => {
+    const sent: string[][] = [];
+    const runner = makeFake({
+      hasSession: true,
+      captures: ["before\n", "before\n"],
+      onSend: (args) => sent.push(args),
+    });
+
+    await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 20,
+      timeoutMs: 60,
+    });
+
+    expect(sent[0]).toEqual(["send-keys", "-l", "/clear"]);
+  });
+
+  it("precondition is evaluated BEFORE has-session pane capture, once", async () => {
+    // The precondition must gate the write, and must not be re-invoked per poll.
+    let calls = 0;
+    const runner = makeFake({
+      hasSession: true,
+      captures: ["before\n", "before\n"],
+    });
+    await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 20,
+      timeoutMs: 60,
+      precondition: () => {
+        calls += 1;
+        return true;
+      },
+    });
+    expect(calls).toBe(1);
+  });
+});

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -223,7 +223,8 @@ export type InjectErrorCode =
   | "session_missing"
   | "invalid"
   | "timeout"
-  | "tmux_failed";
+  | "tmux_failed"
+  | "precondition_failed";
 
 export class InjectError extends Error {
   code: InjectErrorCode;
@@ -249,6 +250,24 @@ export interface InjectOpts {
   settleMs?: number;
   /** Hard upper bound on total wait (ms). Default 5000ms. */
   timeoutMs?: number;
+  /**
+   * Check-to-send race guard (#3116). Re-evaluated by
+   * `injectSlashCommandWith` IMMEDIATELY before the first `send-keys` write.
+   * If it returns false the command is NOT typed into the pane and the call
+   * returns `outcome: 'skipped'` (`errorCode: 'precondition_failed'`).
+   *
+   * Why: idle-clear / proactive-compact decide to inject `/clear` (or
+   * `/compact`) against a session judged idle, then dispatch asynchronously.
+   * An inbound arriving in the gap between the decision and the tmux write
+   * would otherwise land the slash command in claude's prompt buffer, where
+   * it runs at the NEXT idle prompt — against a session that is no longer
+   * idle, destroying live context (overlord, 2026-07-11). Passing a
+   * precondition that re-reads the idle gate at write time closes the gap:
+   * dispatch only if still idle when the keys are actually sent.
+   *
+   * Omitted by every interactive/operator caller → unchanged behaviour.
+   */
+  precondition?: () => boolean;
 }
 
 /**
@@ -258,11 +277,14 @@ export interface InjectOpts {
  *    expected (e.g. `/clear`) or suspicious (`/cost` with no output).
  *  - `failed` — validation rejected, session missing, or send-keys
  *    threw. `errorCode` and `errorMessage` carry the reason.
+ *  - `skipped` — a caller `precondition` returned false at write time
+ *    (#3116); nothing was typed into the pane. `errorCode` is
+ *    `precondition_failed`.
  *
  * Classification is derived from runtime capture, not from
  * `expectsOutput` — that field is a UX hint only.
  */
-export type InjectOutcome = "ok" | "ok_no_output" | "failed";
+export type InjectOutcome = "ok" | "ok_no_output" | "failed" | "skipped";
 
 export type InjectDiagnostic =
   | "anchor_missing"
@@ -593,6 +615,7 @@ export async function injectSlashCommand(
       command: command.trim(),
       settleMs,
       timeoutMs,
+      precondition: opts.precondition,
     }),
   );
 }
@@ -614,9 +637,10 @@ export async function injectSlashCommandWith(
     command: string;
     settleMs: number;
     timeoutMs: number;
+    precondition?: () => boolean;
   },
 ): Promise<InjectResult> {
-  const { socket, session, command, settleMs, timeoutMs } = args;
+  const { socket, session, command, settleMs, timeoutMs, precondition } = args;
 
   // Re-validate so the seam itself enforces the contract. The bare
   // verb is what we'll surface in `result.command` / lookup metadata.
@@ -651,6 +675,25 @@ export async function injectSlashCommandWith(
         `tmux session "${session}" on socket "${socket}" not found. ` +
         `Is the agent running under the tmux supervisor (the default)? ` +
         `If experimental.legacy_pty=true is set, inject is unsupported.`,
+    };
+  }
+
+  // #3116 — check-to-send race guard. Re-evaluate the caller's precondition
+  // IMMEDIATELY before the tmux write (after the pane lock is held and the
+  // session confirmed present), so a state change between the caller's
+  // decision and this write cancels the send rather than typing a stale
+  // command into the pane. Nothing has been sent yet, so a false verdict is a
+  // clean no-op.
+  if (precondition && !precondition()) {
+    return {
+      outcome: "skipped",
+      output: "",
+      truncated: false,
+      command: bareVerb,
+      meta,
+      errorCode: "precondition_failed",
+      errorMessage:
+        "inject precondition no longer held at write time — command not sent",
     };
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -519,7 +519,7 @@ import { resolveOutboundTopic as resolveOutboundTopicHelper, topicForRecipient, 
 import { readTurnUsages } from '../../src/agents/perf.js'
 import { buildContextOccupancy, writeContextOccupancySnapshot } from './context-occupancy.js'
 import { decideProactiveCompact, initialCompactState, type CompactState } from './proactive-compact.js'
-import { decideIdleClear, classifyIdleEvent, idleDurationToMs, DEFAULT_IDLE_CLEAR_MS } from './idle-clear.js'
+import { decideIdleClear, classifyIdleEvent, idleDurationToMs, DEFAULT_IDLE_CLEAR_MS, decideBackgroundSuppression, DEFAULT_IDLE_BG_SUPPRESS_TTL_MS } from './idle-clear.js'
 import { nextCompactNotify, idleCompactNotifyState, type CompactNotifyState } from './compact-notify.js'
 import {
   tryHostdDispatch,
@@ -5022,11 +5022,30 @@ let lastIdleActivityAt = Date.now();
 let lastIdleTurnEndAt: number | null = null;
 let idleAutoCleared = false;
 let idleClearDispatching = false;
+// #3117 — TTL-bounded background-work suppressor. Epoch ms when the idle clear
+// first observed detached background work in flight (subagent / bg bash) while
+// otherwise clearable, or null when not suppressing. Bounds how long a stuck
+// pending flag may hold the clear off (see decideBackgroundSuppression).
+let idleBgSuppressSince: number | null = null;
+
+/** Idle background-suppressor TTL: env override → 30m default. */
+function resolveIdleBgSuppressTtlMs(): number {
+  const env = process.env.SWITCHROOM_IDLE_BG_SUPPRESS_TTL_MS;
+  if (env != null && env !== '') {
+    const n = Number(env);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return DEFAULT_IDLE_BG_SUPPRESS_TTL_MS;
+}
 
 /** Reset the idle timer + re-arm auto-clear. Call on ANY activity. */
 function markIdleActivity(): void {
   lastIdleActivityAt = Date.now();
   idleAutoCleared = false;
+  // Fresh activity re-arms the whole gate — drop any background-suppression
+  // clock so a later silent worker gets a fresh TTL rather than inheriting a
+  // stale (possibly already-expired) `since`.
+  idleBgSuppressSince = null;
 }
 
 /**
@@ -5066,6 +5085,7 @@ function maybeIdleClear(): void {
   const agentName = process.env.SWITCHROOM_AGENT_NAME;
   if (!agentName) return;
   const idleClearMs = resolveIdleClearMs();
+  const now = Date.now();
   const decision = decideIdleClear(
     {
       lastActivityAt: lastIdleActivityAt,
@@ -5074,9 +5094,30 @@ function maybeIdleClear(): void {
       alreadyCleared: idleAutoCleared,
       turnInFlight: turnInFlightForGate(),
     },
-    Date.now(),
+    now,
   );
-  if (!decision.clear) return;
+  if (!decision.clear) {
+    // Not at the would-be-clear point (window not elapsed, mid-turn, or already
+    // cleared). The background suppressor only measures grace PAST that point,
+    // so reset its clock here — a fresh silent worker gets a full TTL once the
+    // window actually elapses.
+    idleBgSuppressSince = null;
+    return;
+  }
+  // #3117 — TTL-bounded background-work suppressor. The idle window has elapsed
+  // and we WOULD clear. #3113 keeps the window warm via activity events for a
+  // worker that is EMITTING; this covers the residual hole — a background worker
+  // alive but SILENT for a full window. Hold the clear while background work is
+  // in flight, but only for a TTL bound measured from this would-be-clear point,
+  // so a stuck pending flag cannot disable idle-clear forever (self-heals).
+  const bg = decideBackgroundSuppression({
+    backgroundInFlight: pendingProgress.anyPendingAsyncDispatch(),
+    suppressingSince: idleBgSuppressSince,
+    now,
+    ttlMs: resolveIdleBgSuppressTtlMs(),
+  });
+  idleBgSuppressSince = bg.suppressingSince;
+  if (bg.suppress) return;
   // Fire once per idle period — set BEFORE the await so the next tick can't
   // double-dispatch. markIdleActivity() re-arms on the next real activity.
   idleAutoCleared = true;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5085,10 +5085,20 @@ function maybeIdleClear(): void {
     `telegram gateway: idle auto-/clear for ${agentName} ` +
       `(idle >= ${Math.round(idleClearMs / 60_000)}m)\n`,
   );
-  // Accepted check-to-send race (same as maybeProactiveCompact): a new inbound
-  // could arrive between the gate check and the tmux send; /clear then lands in
-  // claude's prompt buffer and runs at the next idle prompt (inject.ts FUTURE-GAP).
-  void injectSlashCommandImpl(agentName, '/clear')
+  // #3116 — close the check-to-send race. A new inbound can arrive between
+  // this gate check and the tmux send; without a guard, `/clear` lands in
+  // claude's prompt buffer and runs at the NEXT idle prompt against a session
+  // that is no longer idle, destroying live context (overlord, 2026-07-11).
+  // `injectSlashCommandImpl` re-evaluates this precondition IMMEDIATELY before
+  // the tmux write and skips the send if the session is no longer idle. An
+  // inbound in the gap calls markIdleActivity() (bumps lastIdleActivityAt and
+  // resets idleAutoCleared), so `stillIdle` reads false and the gate re-arms.
+  const stillIdle = (): boolean => {
+    if (turnInFlightForGate()) return false;
+    const evAt = Math.max(lastIdleActivityAt, lastIdleTurnEndAt ?? 0);
+    return Date.now() - evAt >= idleClearMs;
+  };
+  void injectSlashCommandImpl(agentName, '/clear', { precondition: stillIdle })
     .catch((err: unknown) => {
       process.stderr.write(
         `telegram gateway: idle /clear inject failed for ` +

--- a/telegram-plugin/gateway/idle-clear.ts
+++ b/telegram-plugin/gateway/idle-clear.ts
@@ -99,6 +99,64 @@ export function decideIdleClear(
   return { clear: true };
 }
 
+/** Default TTL for the background-work idle suppressor (#3117): 30 min. */
+export const DEFAULT_IDLE_BG_SUPPRESS_TTL_MS = 30 * 60 * 1000;
+
+export interface BackgroundSuppressionInput {
+  /** Is detached background work (subagent / bg bash) in flight right now? */
+  backgroundInFlight: boolean;
+  /**
+   * Epoch ms when suppression started (the first evaluation that observed
+   * background work in flight), or null if not currently suppressing.
+   */
+  suppressingSince: number | null;
+  now: number;
+  /** Bound on how long a background flag may suppress the clear. */
+  ttlMs: number;
+}
+
+export interface BackgroundSuppressionDecision {
+  /** Suppress the idle clear this evaluation? */
+  suppress: boolean;
+  /** New `suppressingSince` to carry to the next evaluation. */
+  suppressingSince: number | null;
+}
+
+/**
+ * TTL-bounded background-work suppressor (#3117).
+ *
+ * #3113 already stamps the activity clock on every `sub_agent_*` event, so a
+ * background worker that is EMITTING keeps the idle window warm on its own. The
+ * residual hole: a worker that is alive but SILENT for a full window (one long
+ * tool call, no events) could be `/clear`ed out from under itself. This gates
+ * the clear while background work is in flight — but only for `ttlMs` after
+ * suppression first engaged, so a stuck pending flag (worker actually dead, flag
+ * never cleared) cannot disable idle-clear permanently. Bounded and
+ * self-healing, exactly the trade #3117 asks for.
+ *
+ * Pure: the gateway owns the `suppressingSince` cell and passes it back in.
+ *   - no background work  → not suppressing, clock reset to null.
+ *   - background in flight, first seen → start the clock, suppress.
+ *   - background in flight, within TTL → keep suppressing.
+ *   - background in flight, past TTL → STOP suppressing (self-heal); the clock
+ *     is retained so it stays expired until the work drains and re-arms it.
+ */
+export function decideBackgroundSuppression(
+  input: BackgroundSuppressionInput,
+): BackgroundSuppressionDecision {
+  const { backgroundInFlight, suppressingSince, now, ttlMs } = input;
+  if (!backgroundInFlight) {
+    return { suppress: false, suppressingSince: null };
+  }
+  const since = suppressingSince ?? now;
+  if (now - since >= ttlMs) {
+    // Past the bound — self-heal. Keep `since` so we don't re-arm a fresh TTL
+    // on the next tick while the same stuck flag is still set.
+    return { suppress: false, suppressingSince: since };
+  }
+  return { suppress: true, suppressingSince: since };
+}
+
 /** What a claude session-stream event means for the idle clocks. */
 export interface IdleEventSignal {
   /** Genuine agent activity → stamp `lastActivityAt` (and re-arm). */

--- a/telegram-plugin/pending-work-progress.ts
+++ b/telegram-plugin/pending-work-progress.ts
@@ -297,6 +297,22 @@ export function hasPendingAsyncDispatch(key: string): boolean {
 }
 
 /**
+ * True when ANY chat key currently has detached background work in flight
+ * (Agent / Task / Bash run_in_background:true dispatched, turn not yet ended
+ * with a cleared pending flag). Keyless variant of {@link hasPendingAsyncDispatch}
+ * for the idle-clear gate (#3117): the gateway runs a single claude session, so
+ * the idle auto-clear must not fire while a background worker is alive but
+ * silent for a full idle window — but only up to a TTL bound, enforced by the
+ * caller (a stuck pending flag must not disable idle-clear forever).
+ */
+export function anyPendingAsyncDispatch(): boolean {
+  for (const s of stateByKey.values()) {
+    if (s.pending === true) return true
+  }
+  return false
+}
+
+/**
  * Clear pending-progress for a chat — reasons:
  *   'inbound'   — user sent a new message, they're re-engaged
  *   'handback'  — switchroom injected a subagent_handback channel turn

--- a/telegram-plugin/tests/idle-clear.test.ts
+++ b/telegram-plugin/tests/idle-clear.test.ts
@@ -25,6 +25,8 @@ import {
   classifyIdleEvent,
   idleDurationToMs,
   DEFAULT_IDLE_CLEAR_MS,
+  decideBackgroundSuppression,
+  DEFAULT_IDLE_BG_SUPPRESS_TTL_MS,
   type IdleClearState,
 } from '../gateway/idle-clear.js'
 
@@ -270,6 +272,137 @@ describe('decideIdleClear (pure gate)', () => {
     const reArmed = state({ lastActivityAt: now, alreadyCleared: false })
     expect(decideIdleClear(reArmed, now + 3 * H - 1).clear).toBe(false) // not yet
     expect(decideIdleClear(reArmed, now + 3 * H).clear).toBe(true) // again, one window later
+  })
+})
+
+describe('decideBackgroundSuppression (#3117 — TTL-bounded suppressor)', () => {
+  const TTL = 30 * M
+
+  it('no background work → not suppressing, clock reset', () => {
+    const d = decideBackgroundSuppression({
+      backgroundInFlight: false,
+      suppressingSince: 5 * H,
+      now: 6 * H,
+      ttlMs: TTL,
+    })
+    expect(d).toEqual({ suppress: false, suppressingSince: null })
+  })
+
+  it('first observation of in-flight work → start the clock and suppress', () => {
+    const now = 100 * H
+    const d = decideBackgroundSuppression({
+      backgroundInFlight: true,
+      suppressingSince: null,
+      now,
+      ttlMs: TTL,
+    })
+    expect(d).toEqual({ suppress: true, suppressingSince: now })
+  })
+
+  it('in-flight and within TTL → keeps suppressing from the original since', () => {
+    const since = 100 * H
+    const d = decideBackgroundSuppression({
+      backgroundInFlight: true,
+      suppressingSince: since,
+      now: since + TTL - 1,
+      ttlMs: TTL,
+    })
+    expect(d).toEqual({ suppress: true, suppressingSince: since })
+  })
+
+  it('in-flight but past TTL → STOPS suppressing (self-heals), retains since', () => {
+    const since = 100 * H
+    const d = decideBackgroundSuppression({
+      backgroundInFlight: true,
+      suppressingSince: since,
+      now: since + TTL,
+      ttlMs: TTL,
+    })
+    expect(d).toEqual({ suppress: false, suppressingSince: since })
+  })
+
+  it('default TTL is 30m', () => {
+    expect(DEFAULT_IDLE_BG_SUPPRESS_TTL_MS).toBe(30 * M)
+  })
+})
+
+describe('idle-clear + background suppressor — end-to-end outcomes (#3117)', () => {
+  const TTL = 30 * M
+  // Mirror the gateway's maybeIdleClear loop EXACTLY: run the base decider
+  // first; if it would NOT clear, reset the suppression clock and stop; if it
+  // WOULD clear, apply the TTL-bounded background suppressor (whose clock is
+  // measured from this would-be-clear point).
+  function run(opts: {
+    idleClearMs: number
+    ttlMs: number
+    /** returns whether background work is in flight at time `now` */
+    bgInFlight: (now: number) => boolean
+    lastActivityAt: number
+    from: number
+    to: number
+  }): number[] {
+    let since: number | null = null
+    let alreadyCleared = false
+    const clears: number[] = []
+    for (let now = opts.from; now <= opts.to; now += TICK) {
+      const { clear: wouldClear } = decideIdleClear(
+        {
+          lastActivityAt: opts.lastActivityAt,
+          lastTurnEndedAt: null,
+          idleClearMs: opts.idleClearMs,
+          alreadyCleared,
+          turnInFlight: false,
+        },
+        now,
+      )
+      if (!wouldClear) {
+        since = null
+        continue
+      }
+      const bg = decideBackgroundSuppression({
+        backgroundInFlight: opts.bgInFlight(now),
+        suppressingSince: since,
+        now,
+        ttlMs: opts.ttlMs,
+      })
+      since = bg.suppressingSince
+      if (bg.suppress) continue
+      alreadyCleared = true
+      clears.push(now)
+    }
+    return clears
+  }
+
+  it('a silent background worker in flight past the window (within TTL) is NOT cleared', () => {
+    const T = 100 * H
+    // Worker in flight the whole time, emits nothing. Idle window 3h.
+    const clears = run({
+      idleClearMs: 3 * H,
+      ttlMs: TTL,
+      bgInFlight: () => true,
+      lastActivityAt: T,
+      from: T,
+      // window elapses at T+3h; suppression starts then and holds for TTL.
+      to: T + 3 * H + TTL - TICK,
+    })
+    expect(clears).toEqual([])
+  })
+
+  it('a background flag stuck past window+TTL → clear STILL eventually fires (not disabled forever)', () => {
+    const T = 100 * H
+    const clears = run({
+      idleClearMs: 3 * H,
+      ttlMs: TTL,
+      bgInFlight: () => true, // stuck flag: never clears
+      lastActivityAt: T,
+      from: T,
+      to: T + 3 * H + TTL + 5 * TICK,
+    })
+    // Suppression engages when the window elapses (~T+3h) and self-heals TTL
+    // later, so the clear fires once, near T + 3h + TTL.
+    expect(clears).toHaveLength(1)
+    expect(clears[0]).toBeGreaterThanOrEqual(T + 3 * H + TTL)
+    expect(clears[0]).toBeLessThan(T + 3 * H + TTL + 2 * TICK)
   })
 })
 

--- a/telegram-plugin/tests/pending-work-progress.test.ts
+++ b/telegram-plugin/tests/pending-work-progress.test.ts
@@ -16,7 +16,9 @@ import {
   __resetAllForTests,
   __setDepsForTests,
   __tickForTests,
+  anyPendingAsyncDispatch,
   clearPending,
+  hasPendingAsyncDispatch,
   noteAsyncDispatch,
   noteOutbound,
   noteTurnEnd,
@@ -670,5 +672,40 @@ describe('pending-work-progress', () => {
     } finally {
       process.stderr.write = origStderr
     }
+  })
+})
+
+// #3117 — keyless variant used by the idle-clear background suppressor.
+describe('anyPendingAsyncDispatch (#3117)', () => {
+  beforeEach(() => {
+    __resetAllForTests()
+  })
+
+  it('false when nothing is pending', () => {
+    expect(anyPendingAsyncDispatch()).toBe(false)
+  })
+
+  it('true while ANY key has a detached background dispatch in flight', () => {
+    startTurn(KEY)
+    noteAsyncDispatch(KEY)
+    expect(hasPendingAsyncDispatch(KEY)).toBe(true)
+    expect(anyPendingAsyncDispatch()).toBe(true)
+  })
+
+  it('detects background work under a key other than the queried one', () => {
+    const OTHER = '99999:_'
+    startTurn(OTHER)
+    noteAsyncDispatch(OTHER)
+    // hasPendingAsyncDispatch(KEY) is false, but the keyless scan sees OTHER.
+    expect(hasPendingAsyncDispatch(KEY)).toBe(false)
+    expect(anyPendingAsyncDispatch()).toBe(true)
+  })
+
+  it('false again once the pending flag is cleared', () => {
+    startTurn(KEY)
+    noteAsyncDispatch(KEY)
+    expect(anyPendingAsyncDispatch()).toBe(true)
+    clearPending(KEY, 'manual')
+    expect(anyPendingAsyncDispatch()).toBe(false)
   })
 })


### PR DESCRIPTION
Closes #3117. **Stacked on #3219 (#3116)** — review/merge that first; this branch contains its commit.

## Problem
`turnInFlightForGate()` sees the main turn only. #3113 fixed in-flight background subagents *as activity* (a worker that EMITS keeps the window warm), but a worker alive yet **silent** for a full idle window can still be `/clear`ed out from under itself.

## Fix — TTL-bounded suppressor (self-healing)
An unbounded `backgroundWorkInFlight` boolean was deliberately rejected in #3113: a stuck pending flag would disable idle-clear forever. The TTL fixes that.

- `pending-work-progress.ts`: `anyPendingAsyncDispatch()` — keyless scan (single-session gateway).
- `idle-clear.ts`: pure `decideBackgroundSuppression({ backgroundInFlight, suppressingSince, now, ttlMs })`. Clock starts at the would-be-clear point; suppresses until `now - since >= ttlMs`; then self-heals. Default 30m (`SWITCHROOM_IDLE_BG_SUPPRESS_TTL_MS`).
- `maybeIdleClear`: base decider first; if it would not clear, reset the clock; if it would, apply the suppressor — so grace is measured from the moment the clear would otherwise fire (not from when the worker appeared).

## Tests (both directions, RED on main)
`idle-clear.test.ts` — silent worker in flight past the window but within TTL → **NOT cleared**; flag stuck past window+TTL → clear **still fires once** (not permanently disabled). `pending-work-progress.test.ts` — `anyPendingAsyncDispatch` sees work under any key. Both files import symbols that don't exist on main → RED.

Scoped tests green (52/52); `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)