### PR TITLE
fix(idle): gate idle-clear on in-flight background sub-agents, TTL-bounded (#3117)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5073,6 +5073,14 @@ function maybeIdleClear(): void {
       idleClearMs,
       alreadyCleared: idleAutoCleared,
       turnInFlight: turnInFlightForGate(),
+      // #3117 — TTL-bounded background-work suppressor. A detached sub-agent
+      // (Agent/Task dispatched, main turn ended before it returned) is invisible
+      // to turnInFlightForGate(); consult the pending-dispatch flag directly so a
+      // silent long-running worker isn't /clear'ed out from under its handback.
+      // The TTL keeps a leaked flag from disabling idle-clear forever.
+      backgroundWorkInFlight: pendingProgress.anyPendingAsyncDispatchWithin(
+        pendingProgress.BACKGROUND_WORK_SUPPRESS_TTL_MS,
+      ),
     },
     Date.now(),
   );
@@ -5107,6 +5115,13 @@ function maybeIdleClear(): void {
         // re-eval must judge idleness on the live clocks only, so force false.
         alreadyCleared: false,
         turnInFlight: turnInFlightForGate(),
+        // #3117 — re-sample the background-work suppressor at write time too, so
+        // a sub-agent dispatched in the check-to-send gap (or still fresh within
+        // its TTL) suppresses the buffered /clear. This composes with #3116's
+        // write-time re-eval automatically — same decider, live inputs.
+        backgroundWorkInFlight: pendingProgress.anyPendingAsyncDispatchWithin(
+          pendingProgress.BACKGROUND_WORK_SUPPRESS_TTL_MS,
+        ),
       },
       Date.now(),
     ).clear;

--- a/telegram-plugin/gateway/idle-clear.ts
+++ b/telegram-plugin/gateway/idle-clear.ts
@@ -67,6 +67,20 @@ export interface IdleClearState {
   alreadyCleared: boolean;
   /** A turn is in flight — never clear mid-turn. */
   turnInFlight: boolean;
+  /**
+   * A background sub-agent (Agent/Task dispatched, turn ended before it
+   * returned) is still in flight AND within its suppression TTL (#3117). The
+   * main-turn gate (`turnInFlight`) is blind to detached background work: a
+   * worker that is alive-but-silent for a full idle window (one long tool call,
+   * no stream events to re-stamp the activity clock) would otherwise be cleared,
+   * destroying the context its handback needs. Suppress the clear while this is
+   * true. It is TTL-bounded by the caller so a leaked/never-cleared pending flag
+   * cannot disable idle-clear forever — past the TTL the caller passes false and
+   * self-healing resumes. Optional/undefined ⇒ treated as false (no background
+   * work), which preserves the pre-#3117 behaviour for callers that don't wire
+   * it (e.g. the pure-decider unit tests that exercise only the wall clock).
+   */
+  backgroundWorkInFlight?: boolean;
 }
 
 export interface IdleClearDecision {
@@ -91,6 +105,14 @@ export function decideIdleClear(
 ): IdleClearDecision {
   if (state.idleClearMs <= 0) return { clear: false }; // disabled
   if (state.turnInFlight) return { clear: false }; // never mid-turn
+  // #3117 — a detached background sub-agent within its suppression TTL keeps the
+  // session alive even when the main-turn gate is open and the activity clock
+  // has gone cold (a silent long-running worker emits no stream events). The
+  // caller (gateway) bounds this by a TTL so a stuck pending flag can't disable
+  // idle-clear forever; here we simply honour it. Because #3116's write-time
+  // re-eval re-runs this whole function against the live state, this suppression
+  // is enforced at BOTH decision time and /clear write time for free.
+  if (state.backgroundWorkInFlight) return { clear: false };
   if (state.alreadyCleared) return { clear: false }; // once per idle period
   // Measured from the LAST thing that happened — activity or a turn ending —
   // never from a turn's start. A turn that ran longer than the window ends with

--- a/telegram-plugin/pending-work-progress.ts
+++ b/telegram-plugin/pending-work-progress.ts
@@ -64,6 +64,19 @@
 export const EDIT_INTERVAL_MS = 60_000
 export const POLL_INTERVAL_MS = 5_000
 export const MAX_LIFETIME_MS = 30 * 60_000
+/**
+ * TTL bounding how long an in-flight background dispatch (Agent/Task) suppresses
+ * the idle auto-/clear gate (#3117). Deliberately tied to `MAX_LIFETIME_MS` (the
+ * cross-turn ambient budget cap): the two express the same "how long do we
+ * believe a background worker is still legitimately running" budget, so keeping
+ * them equal means the idle-suppression window and the ambient-liveness window
+ * agree by construction. A SHORTER idle TTL would risk clobbering a legitimate
+ * ~25-min worker mid-flight; a LONGER one would weaken the self-healing bound
+ * (a leaked `pending=true` that never clears would disable idle-clear for
+ * longer). 30 min is the deliberate midpoint the design settled on. The gate
+ * suppresses only while `dispatch age < this`; past it the suppression lapses so
+ * a stuck flag can never disable idle-clear permanently. */
+export const BACKGROUND_WORK_SUPPRESS_TTL_MS = MAX_LIFETIME_MS
 /** Rich-message wire cap is 32768 (#2669); budget headroom for the
  *  suffix and any escape expansion. If the anchor text plus suffix
  *  would exceed this, we skip the edit (the user still sees the
@@ -142,6 +155,13 @@ interface State {
   /** True after a `tool_use(Agent|Task)` was observed for this key in
    *  the current turn. Cleared on next turn start. */
   pending: boolean
+  /** Epoch ms when `pending` was last set true (#3117). null when not
+   *  pending. Load-bearing for the idle-clear suppression TTL: without a
+   *  timestamp the gate cannot bound how long an in-flight background dispatch
+   *  holds off idle-clear, so a leaked `pending=true` would disable idle-clear
+   *  forever. Re-stamped on each `noteAsyncDispatch` (a fresh dispatch re-arms
+   *  the TTL) and cleared whenever `pending` goes false. */
+  dispatchedAt: number | null
   /** The captured anchor — last outbound reply message_id for this
    *  key. */
   anchorMessageId: number | null
@@ -179,6 +199,7 @@ function ensure(key: string): State {
   if (!s) {
     s = {
       pending: false,
+      dispatchedAt: null,
       anchorMessageId: null,
       anchorOriginalText: '',
       anchorLiteralText: false,
@@ -217,6 +238,7 @@ export function startTurn(key: string): void {
   // Only the per-turn fields reset. activatedAt/lastEditAt belong to
   // the prior turn's pending-progress and are cleared separately.
   s.pending = false
+  s.dispatchedAt = null
   s.anchorMessageId = null
   s.anchorOriginalText = ''
   s.anchorLiteralText = false
@@ -229,7 +251,13 @@ export function startTurn(key: string): void {
  */
 export function noteAsyncDispatch(key: string): void {
   if (!enabled()) return
-  ensure(key).pending = true
+  const s = ensure(key)
+  s.pending = true
+  // Stamp (and re-stamp) the dispatch epoch so the idle-clear suppression TTL
+  // (#3117) can bound how long this holds off /clear. Re-stamping on each
+  // dispatch means a fresh Agent/Task within the same wait re-arms the TTL —
+  // freshest legitimate work wins.
+  s.dispatchedAt = nowMs()
 }
 
 /**
@@ -294,6 +322,41 @@ export function noteTurnEnd(key: string): void {
  */
 export function hasPendingAsyncDispatch(key: string): boolean {
   return stateByKey.get(key)?.pending === true
+}
+
+/**
+ * Age in ms since the current pending async dispatch was stamped for `key`
+ * (#3117), or null if there is no pending dispatch (or, defensively, no
+ * timestamp — a pre-stamp entry from a rolling upgrade). Uses the same clock
+ * override as the rest of the module so tests drive it deterministically.
+ */
+export function asyncDispatchAgeMs(key: string): number | null {
+  const s = stateByKey.get(key)
+  if (s == null || s.pending !== true || s.dispatchedAt == null) return null
+  return nowMs() - s.dispatchedAt
+}
+
+/**
+ * True iff ANY chat key currently has a pending async dispatch whose age is
+ * within `ttlMs` (#3117). The idle auto-/clear gate is agent-wide (not scoped
+ * to a single chat key), so it consults this aggregate: while a background
+ * sub-agent is in flight AND fresh, suppress the clear; once every pending
+ * dispatch has aged past the TTL (a leaked/stuck flag), the suppression lapses
+ * and idle-clear self-heals. A non-positive `ttlMs` disables suppression.
+ */
+export function anyPendingAsyncDispatchWithin(ttlMs: number): boolean {
+  if (ttlMs <= 0) return false
+  const now = nowMs()
+  for (const s of stateByKey.values()) {
+    if (
+      s.pending === true &&
+      s.dispatchedAt != null &&
+      now - s.dispatchedAt < ttlMs
+    ) {
+      return true
+    }
+  }
+  return false
 }
 
 /**

--- a/telegram-plugin/pending-work-progress.ts
+++ b/telegram-plugin/pending-work-progress.ts
@@ -160,7 +160,8 @@ interface State {
    *  timestamp the gate cannot bound how long an in-flight background dispatch
    *  holds off idle-clear, so a leaked `pending=true` would disable idle-clear
    *  forever. Re-stamped on each `noteAsyncDispatch` (a fresh dispatch re-arms
-   *  the TTL) and cleared whenever `pending` goes false. */
+   *  the TTL) and cleared when `pending` is set false (`startTurn`); a full
+   *  `clearPending` drops the whole entry, which is equivalent. */
   dispatchedAt: number | null
   /** The captured anchor — last outbound reply message_id for this
    *  key. */

--- a/telegram-plugin/tests/idle-clear.test.ts
+++ b/telegram-plugin/tests/idle-clear.test.ts
@@ -19,7 +19,7 @@
  * `vitest.config.ts`.)
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import {
   decideIdleClear,
   classifyIdleEvent,
@@ -27,6 +27,7 @@ import {
   DEFAULT_IDLE_CLEAR_MS,
   type IdleClearState,
 } from '../gateway/idle-clear.js'
+import * as pendingProgress from '../pending-work-progress.js'
 
 const H = 3_600_000
 const M = 60_000
@@ -270,6 +271,104 @@ describe('decideIdleClear (pure gate)', () => {
     const reArmed = state({ lastActivityAt: now, alreadyCleared: false })
     expect(decideIdleClear(reArmed, now + 3 * H - 1).clear).toBe(false) // not yet
     expect(decideIdleClear(reArmed, now + 3 * H).clear).toBe(true) // again, one window later
+  })
+})
+
+describe('decideIdleClear: #3117 background-work suppressor', () => {
+  it('suppresses the clear while a background sub-agent is in flight, even past the window', () => {
+    // Window elapsed (10h >> 3h), main-turn gate open (turnInFlight:false), and
+    // the activity clock is cold — yet a detached worker is in flight. On main
+    // (no backgroundWorkInFlight branch) this would clear; the fix must not.
+    const s = state({ lastActivityAt: 0, backgroundWorkInFlight: true })
+    expect(decideIdleClear(s, 10 * H).clear).toBe(false)
+  })
+
+  it('allows the clear once background work is no longer in flight (TTL lapsed or dispatch cleared)', () => {
+    const s = state({ lastActivityAt: 0, backgroundWorkInFlight: false })
+    expect(decideIdleClear(s, 10 * H).clear).toBe(true)
+  })
+
+  it('undefined background flag preserves pre-#3117 behaviour (treated as false)', () => {
+    const s = state({ lastActivityAt: 0 })
+    delete (s as { backgroundWorkInFlight?: boolean }).backgroundWorkInFlight
+    expect(decideIdleClear(s, 10 * H).clear).toBe(true)
+  })
+})
+
+describe('#3117 end-to-end: pending dispatch TTL gates idle-clear', () => {
+  // Drives the REAL pending-work-progress state (the source of
+  // backgroundWorkInFlight) against decideIdleClear with an injected clock, so
+  // the wiring — noteAsyncDispatch stamps, the TTL expires, the flag clears —
+  // is exercised as an outcome, not mirrored.
+  let clock = 0
+  const KEY = 'chat-1:'
+
+  beforeEach(() => {
+    pendingProgress.__resetAllForTests()
+    clock = 100 * H
+    // Install a clock override without starting the real timer.
+    pendingProgress.__setDepsForTests({
+      editMessage: async () => {},
+      nowMs: () => clock,
+    })
+  })
+  afterEach(() => {
+    pendingProgress.__setDepsForTests(null)
+    pendingProgress.__resetAllForTests()
+  })
+
+  function decideNow(now: number): boolean {
+    return decideIdleClear(
+      {
+        lastActivityAt: 0, // cold activity clock — window long elapsed
+        lastTurnEndedAt: null,
+        idleClearMs: 3 * H,
+        alreadyCleared: false,
+        turnInFlight: false,
+        backgroundWorkInFlight: pendingProgress.anyPendingAsyncDispatchWithin(
+          pendingProgress.BACKGROUND_WORK_SUPPRESS_TTL_MS,
+        ),
+      },
+      now,
+    ).clear
+  }
+
+  it('a pending dispatch inside the TTL suppresses the clear; past the TTL it self-heals', () => {
+    // No dispatch yet → idle-clear fires (control).
+    expect(decideNow(clock)).toBe(true)
+
+    // Background worker dispatched. Now within the TTL: suppressed.
+    pendingProgress.noteAsyncDispatch(KEY)
+    expect(pendingProgress.hasPendingAsyncDispatch(KEY)).toBe(true)
+    expect(decideNow(clock)).toBe(false)
+
+    // Still within TTL (just under 30m) → still suppressed.
+    clock += pendingProgress.BACKGROUND_WORK_SUPPRESS_TTL_MS - 1
+    expect(decideNow(clock)).toBe(false)
+
+    // TTL lapses (stuck/leaked flag) → suppression drops, idle-clear self-heals.
+    clock += 2
+    expect(pendingProgress.hasPendingAsyncDispatch(KEY)).toBe(true) // flag still set
+    expect(decideNow(clock)).toBe(true)
+  })
+
+  it('a dispatch that clears (worker returned) re-allows the clear before the TTL', () => {
+    pendingProgress.noteAsyncDispatch(KEY)
+    expect(decideNow(clock)).toBe(false)
+    // Worker handback / user inbound clears the pending flag well before TTL.
+    clock += 5 * M
+    pendingProgress.clearPending(KEY, 'handback')
+    expect(decideNow(clock)).toBe(true)
+  })
+
+  it('a fresh dispatch re-arms the TTL (freshest legitimate work wins)', () => {
+    pendingProgress.noteAsyncDispatch(KEY)
+    // Advance to just before expiry, then a new dispatch re-stamps.
+    clock += pendingProgress.BACKGROUND_WORK_SUPPRESS_TTL_MS - 1
+    pendingProgress.noteAsyncDispatch(KEY)
+    // Now advance past what WOULD have been the first dispatch's expiry.
+    clock += 2
+    expect(decideNow(clock)).toBe(false) // re-armed → still suppressed
   })
 })
 


### PR DESCRIPTION
Reopened as a fresh PR after #3222 auto-closed on a merge race (mergeability was UNKNOWN right after a docs-nit push; the retry hit unreported required checks on the reopened PR). Branch and commits are unchanged (`45e06a48`), already passed all 26 CI checks and independent adversarial review (verdict SHIP).

Fixes #3117 — idle-clear gate was blind to in-flight background subagents, so an idle `/clear` could destroy context a background worker's handback needs.

- Adds `dispatchedAt` stamp to per-key pending-work state (prereq for a TTL).
- TTL-bounded background-work suppressor (`BACKGROUND_WORK_SUPPRESS_TTL_MS = MAX_LIFETIME_MS`, 30 min) so a leaked `pending=true` can never disable idle-clear forever.
- Consulted inside `decideIdleClear` (NOT `turnInFlightForGate`, which stays main-turn-only for fleet inbound buffering), so it composes with #3116's write-time re-eval and is enforced at both decision and `/clear` write time.
- Test asserts outcomes and fails against post-#3116 main.

Built on merged #3116 (`c3a665fa`).