### PR TITLE
fix(idle): cron fires no longer warm the MAIN idle clock at inject time (#3114)

### DIFF
--- a/telegram-plugin/gateway/cron-session.ts
+++ b/telegram-plugin/gateway/cron-session.ts
@@ -36,6 +36,38 @@ export function baseAgent(name: string): string {
 }
 
 /**
+ * True iff an inject_inbound fire is a scheduled cron fire — Tier-1 cheap-cron
+ * (`meta.session='cron'`, routed to the derived `<agent>-cron` bridge) OR a
+ * Tier-2 full-session cron (`meta.source='cron'`, lands on the main bridge).
+ *
+ * #3114 — such a fire must NOT stamp the MAIN session's idle-clear clock at
+ * inject time. Before #3113, `onInjectInbound` stamped unconditionally so a
+ * "working scheduled agent isn't wiped after 3h of no inbound". That is now
+ * redundant AND harmful: a cron cadence shorter than `idle_clear_after`
+ * re-arms the timer on every fire and keeps idle-clear permanently suppressed
+ * for that agent. After #3113 a cron fire that does REAL work already stamps
+ * the main clock through `handleSessionEvent` on every genuine session event,
+ * so the blanket inject-time stamp buys nothing for main-bridge fires — and a
+ * cheap-cron fire (whose session events are dropped for the cron identity in
+ * `onSessionEvent`) correctly stops warming the main clock once it is gone.
+ *
+ * Only cron fires are gated: other synthetic-source injects (reaction, vault
+ * grant, resume) reflect genuine operator/session presence and still stamp.
+ *
+ * DOCUMENTED RESIDUAL (#3114, operator-approved): a Tier-2 cron pinned to the
+ * MAIN session (`context:'agent'`) that replies NO_REPLY still runs a real
+ * turn on the main bridge, which emits session events → stamps via
+ * `handleSessionEvent`. So "a NO_REPLY poll isn't presence" is fully closed
+ * only for cheap/derived-bridge crons; an expensive main-session poll still
+ * warms the clock because the model genuinely ran. This predicate governs only
+ * the inject-time stamp, not the session-event stamp — closing the main-
+ * session-poll case would need a separate weaker clock, out of scope here.
+ */
+export function isCronInjectFire(meta: Record<string, string> | undefined): boolean {
+  return meta?.source === "cron" || meta?.session === "cron";
+}
+
+/**
  * Resolve the IPC routing target for an inject_inbound. When the fire
  * carries `meta.session='cron'` it goes to the derived cron bridge; every
  * other fire (and all of today's callers) goes to the agent unchanged.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -550,7 +550,7 @@ import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { handleRequestMs365Approval } from './ms365-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
-import { isCronIdentity, deliverInjectWithFallback } from './cron-session.js'
+import { isCronIdentity, isCronInjectFire, deliverInjectWithFallback } from './cron-session.js'
 import {
   ObligationLedger,
   buildObligationRepresentInbound,
@@ -11562,10 +11562,18 @@ const ipcServer: IpcServer = createIpcServer({
   },
 
   onInjectInbound(_client: IpcClient, msg: InjectInboundMessage) {
-    // Cron fires (incl. cheap-cron, whose session events are dropped before
-    // currentTurn is set) are real activity — re-arm idle auto-clear so a
-    // working scheduled agent isn't wiped after 3h of "no inbound".
-    markIdleActivity()
+    // #3114 — do NOT unconditionally stamp the MAIN idle clock here. A cron
+    // fire (Tier-1 cheap-cron routed to `<agent>-cron`, or a Tier-2 main-
+    // session cron) whose cadence is shorter than `idle_clear_after` would
+    // otherwise re-arm the timer on every fire and suppress idle-clear
+    // permanently. After #3113 a cron that does real work already stamps the
+    // main clock via handleSessionEvent, so the blanket fire-time stamp is
+    // redundant for main-bridge fires and wrong for cheap-cron (whose session
+    // events are dropped for the cron identity). Only non-cron injects
+    // (reaction, vault grant, resume — genuine operator/session presence) stamp
+    // at inject time. See isCronInjectFire for the documented main-session-poll
+    // residual (a Tier-2 NO_REPLY poll still warms the clock via its real turn).
+    if (!isCronInjectFire(msg.inbound.meta)) markIdleActivity()
     const promptKey = typeof msg.inbound.meta?.prompt_key === 'string'
       ? msg.inbound.meta.prompt_key
       : 'unknown'

--- a/telegram-plugin/tests/cron-inject-idle-clock.test.ts
+++ b/telegram-plugin/tests/cron-inject-idle-clock.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #3114 — a cron fire must NOT warm the MAIN session's idle-clear clock.
+ *
+ * Root cause (confirmed live): `onInjectInbound` stamped the main idle clock
+ * UNCONDITIONALLY at inject time. A cron cadence shorter than
+ * `idle_clear_after` re-armed the timer on every fire, so idle-clear was
+ * permanently suppressed for any agent with a frequent scheduled task —
+ * including cheap-cron fires routed to the derived `<agent>-cron` bridge,
+ * whose session events never reach the main clock at all.
+ *
+ * Two layers of guarantee, both of which FAIL against pre-fix main:
+ *
+ *   1. The pure identity predicate `isCronInjectFire` — classifies which
+ *      inject fires warm the main clock. Did not exist on main → import fails.
+ *
+ *   2. A wiring pin over gateway.ts source — the inject-time stamp is now
+ *      GATED on `!isCronInjectFire(...)`, while the genuine-human inbound path
+ *      (`handleInbound`) still stamps unconditionally. On main the inject-time
+ *      stamp was unconditional, so the "cron does not stamp, human does"
+ *      assertion fails there.
+ *
+ * The wiring pin mirrors the established pattern for un-exported inline
+ * gateway closures (see gateway-pending-command-wiring.test.ts): gateway.ts is
+ * ~30k lines with import-time side effects, so nothing imports it directly —
+ * the durable structural extraction of the idle bookkeeping is #3115's job,
+ * explicitly out of scope here.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { isCronInjectFire } from '../gateway/cron-session.js'
+
+describe('#3114 isCronInjectFire — which inject fires warm the main idle clock', () => {
+  it('a cheap-cron fire (routed to the derived <agent>-cron bridge) does NOT warm the clock', () => {
+    // Tier-1: scheduler tags meta.session='cron' → resolveInjectTarget sends it
+    // to `<agent>-cron`; its session events are dropped for the cron identity.
+    expect(isCronInjectFire({ session: 'cron', source: 'cron' })).toBe(true)
+    expect(isCronInjectFire({ session: 'cron' })).toBe(true)
+  })
+
+  it('a Tier-2 (main-session) cron fire does NOT warm the clock at inject time', () => {
+    // Tier-2 lands on the main bridge but is still a scheduled fire — the
+    // inject-time stamp is suppressed (its real turn stamps via session events;
+    // that is the documented residual, not the inject-time path).
+    expect(isCronInjectFire({ source: 'cron' })).toBe(true)
+  })
+
+  it('a genuine operator/session inject (reaction, vault grant, resume) DOES warm the clock', () => {
+    expect(isCronInjectFire({ source: 'reaction' })).toBe(false)
+    expect(isCronInjectFire({ source: 'vault_grant_approved' })).toBe(false)
+    expect(isCronInjectFire({ source: 'resume' })).toBe(false)
+  })
+
+  it('a bare / manual inject with no cron marker DOES warm the clock', () => {
+    expect(isCronInjectFire(undefined)).toBe(false)
+    expect(isCronInjectFire({})).toBe(false)
+    expect(isCronInjectFire({ prompt_key: 'x' })).toBe(false)
+  })
+})
+
+describe('#3114 gateway wiring — cron inject does not stamp, human inbound does', () => {
+  const __dirname = dirname(fileURLToPath(import.meta.url))
+  const GATEWAY_SRC = readFileSync(
+    resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+    'utf8',
+  )
+
+  it('onInjectInbound gates the idle stamp on !isCronInjectFire (was unconditional on main)', () => {
+    const handlerIdx = GATEWAY_SRC.indexOf('onInjectInbound(_client: IpcClient, msg: InjectInboundMessage)')
+    expect(handlerIdx).toBeGreaterThan(0)
+    // Scope to the handler head — up to the promptKey extraction that follows
+    // the stamp decision.
+    const win = GATEWAY_SRC.slice(handlerIdx, handlerIdx + 1600)
+    const promptKeyIdx = win.indexOf('const promptKey')
+    expect(promptKeyIdx).toBeGreaterThan(0)
+    const head = win.slice(0, promptKeyIdx)
+    // The stamp is present but GUARDED by the cron-identity predicate…
+    expect(head).toContain('isCronInjectFire(msg.inbound.meta)')
+    expect(head).toContain('markIdleActivity()')
+    // …and there is NO unconditional markIdleActivity() before the guard
+    // (the pre-fix bug). The only occurrence sits behind the guard on one line.
+    expect(head).toContain('if (!isCronInjectFire(msg.inbound.meta)) markIdleActivity()')
+    const stampCount = (head.match(/markIdleActivity\(\)/g) ?? []).length
+    expect(stampCount).toBe(1)
+  })
+
+  it('the genuine-human inbound path (handleInbound) still stamps unconditionally', () => {
+    const fnIdx = GATEWAY_SRC.indexOf('async function handleInbound(')
+    expect(fnIdx).toBeGreaterThan(0)
+    const bodyStart = GATEWAY_SRC.indexOf('): Promise<void> {', fnIdx)
+    expect(bodyStart).toBeGreaterThan(0)
+    const head = GATEWAY_SRC.slice(bodyStart, bodyStart + 200)
+    // Unconditional — not gated by any cron predicate: real human presence.
+    expect(head).toContain('markIdleActivity()')
+    expect(head).not.toContain('isCronInjectFire')
+  })
+})


### PR DESCRIPTION
Closes part of #3114 (staged PR 3/4 of the idle-clear / session-loss cluster: 3116 → 3117 → **3114** → 3115). Builds on merged #3116 (`c3a665fa`) and #3117 (`747dc653`).

## Problem
`onInjectInbound` stamped `markIdleActivity()` **unconditionally** at inject time (the issue cites `gateway.ts:10788`, but that line is unrelated `onSessionEvent` — the real stamp is in the `onInjectInbound` handler; line numbers shifted after the 3116/3117 merges). A cron cadence shorter than `idle_clear_after` re-armed the idle timer on every fire, so idle-clear was suppressed permanently for any agent with a frequent scheduled task. Cheap-cron fires are routed to the derived `<agent>-cron` bridge and their session events are already dropped for the cron identity in `onSessionEvent` — yet the blanket inject-time stamp still warmed the main clock.

## Fix
Gate the inject-time stamp on `!isCronInjectFire(meta)` (new pure predicate in `cron-session.ts`, alongside the existing cron-identity helpers). Identity signal: `meta.source === 'cron' || meta.session === 'cron'` — the codebase's own stable cron discriminators (`src/scheduler/dispatch.ts:292`).

Why this is safe: after #3113 a cron that does real work already stamps the main clock through `handleSessionEvent` on every genuine session event, so the fire-time stamp is redundant for main-bridge fires and wrong for cheap-cron. Non-cron injects (reaction / vault grant / resume — genuine operator/session presence) and the human inbound path (`handleInbound`) still stamp unconditionally.

- `telegram-plugin/gateway/cron-session.ts` — new `isCronInjectFire(meta)` predicate + doc.
- `telegram-plugin/gateway/gateway.ts` — import it; `onInjectInbound` stamp now `if (!isCronInjectFire(msg.inbound.meta)) markIdleActivity()`.

## Documented residual (operator-approved — not full closure)
A Tier-2 cron pinned to the MAIN session (`context:'agent'`) that replies `NO_REPLY` **still runs a real turn** on the main bridge, which emits session events → stamps via `handleSessionEvent`. So "a NO_REPLY poll isn't presence" is fully solved only for cheap/derived-bridge crons; an expensive main-session poll still warms the clock because the model genuinely ran. This PR governs only the inject-time stamp — closing the main-session-poll case would need a separate weaker clock, out of scope here. Called out in code comments and here rather than implying full closure.

## Test (`telegram-plugin/tests/cron-inject-idle-clock.test.ts`)
1. Pure `isCronInjectFire` classification — cheap-cron (`session:'cron'`) and Tier-2 cron (`source:'cron'`) → do not warm; reaction / vault / resume / bare / manual injects → do warm.
2. Gateway wiring pin — `onInjectInbound` gates the stamp on `!isCronInjectFire(...)` with exactly one stamp occurrence, while `handleInbound` (human) still stamps unconditionally. **This fails against pre-fix main** (verified: reverting the guard to an unconditional `markIdleActivity()` makes the wiring pin fail), asserting the outcome "cron inject does not stamp, human inbound does". The source-text wiring pin mirrors the established precedent for un-exported inline gateway closures (`gateway-pending-command-wiring.test.ts`); the durable IdleTracker extraction is #3115's scope, not this PR.

## Local checks
- `npx vitest run` scoped to `cron-inject-idle-clock` + `cron-session`: 13 passed.
- `npm run lint` (incl. `tsc --noEmit`): clean.
- Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)