### PR TITLE
fix(worker-feed): reap ghost worker rows on the watcher's terminal sweep + TTL backstop

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -723,6 +723,7 @@ import { redact } from '../secret-detect/redact.js'
 import { classifyAdminGate } from '../admin-commands/index.js'
 import {
   startSubagentWatcher,
+  resolveInflightTerminalCapMs,
   type SubagentWatcherHandle,
 } from '../subagent-watcher.js'
 import { listRecords as listWorktreeRecords, touchHeartbeat as touchWorktreeHeartbeat } from '../../src/worktree/registry.js'
@@ -2025,6 +2026,14 @@ function resolveSubagentOriginChat(
  * hits the fallback). A gateway restart clears it.
  */
 const WORKER_FEED_FALLBACK_LOG_CAP = 256
+/**
+ * Margin added to the watcher's in-flight terminal cap to form the worker-feed
+ * backstop TTL (`staleWorkerTtlMs`). The feed reaps a row only once it has been
+ * silent for cap + this margin — comfortably past the watcher's own terminal-
+ * transition latency, so the backstop can only ever bite a genuinely ghosted
+ * slot, never a live-but-quiet worker. 5 min.
+ */
+const WORKER_FEED_STALE_TTL_MARGIN_MS = 5 * 60_000
 const workerFeedOwnerDmFallbackLogged = new Set<string>()
 
 /**
@@ -29700,6 +29709,18 @@ void (async () => {
               // channels.telegram.worker_feed.max_rows via the config cascade
               // (scaffold emits SWITCHROOM_TG_WORKER_FEED_MAX_ROWS); unset → 8.
               maxRows: workerFeedMaxRows,
+              // Backstop TTL for the feed's stale-row reaper, DERIVED in code
+              // from the watcher's effective in-flight terminal cap (same env /
+              // default the watcher itself resolves) plus a margin — NOT a
+              // hardcoded assumption about that cap's value. This keeps the
+              // invariant "the feed must never reap a row the watcher still
+              // considers live" enforced even if an operator raises the cap via
+              // SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_CAP_MS: a worker mid-very-
+              // long tool can go silent up to the cap before the watcher
+              // declares it terminal, so the feed waits cap + margin before
+              // force-collapsing a row the terminal signals somehow never
+              // removed.
+              staleWorkerTtlMs: resolveInflightTerminalCapMs() + WORKER_FEED_STALE_TTL_MARGIN_MS,
               // #3207 review: GROUP-level status pin. Workers now coalesce into
               // ONE shared message, so the pin must follow the GROUP lifecycle,
               // not a single worker's — otherwise a sibling's finish unpins a

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -29865,6 +29865,23 @@ void (async () => {
                   `telegram gateway: worker ${agentId} NAMED AS LOST — falsely finalised twice, resurrection chain bound reached (issue #3023)\n`,
                 )
               },
+              // Worker-feed ghost-leak fix: the watcher's AUTHORITATIVE terminal
+              // sweep (`cleanupTerminalAgent`) fires for EVERY terminal agent,
+              // including the JSONL-vanished and boot-orphan paths that never
+              // reach `onFinish`. Wire feed removal here so cleanup and feed-
+              // remove can't diverge: `terminate` is idempotent (a no-op once
+              // `onFinish` already removed the row) and, when this was the last
+              // live worker, collapses the shared card to its terminal summary
+              // and unpins it — closing the immortal/unpinned/buried-card leak.
+              onTerminalCleanup: (agentId) => {
+                try {
+                  void workerActivityFeed?.terminate(agentId)
+                } catch (err) {
+                  process.stderr.write(
+                    `telegram gateway: worker terminal-cleanup feed removal error agent=${agentId}: ${(err as Error).message}\n`,
+                  )
+                }
+              },
               onFinish: ({ agentId, outcome, description, resultText, toolCount, durationMs, background: entryBackground }) => {
                 // Reaction promotion: if the parent turn already ended
                 // with this (or another) worker still running, its 👍 was

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -655,6 +655,21 @@ const DEFAULT_SILENT_STALL_TERMINAL_MS = 300_000
 // reaper TTL, so the watcher — not the reaper — still owns the terminal
 // transition for a worker that died mid-tool.
 const DEFAULT_INFLIGHT_TERMINAL_CAP_MS = 45 * 60_000
+/**
+ * Resolve the effective in-flight terminal-synthesis cap — the maximum wall-
+ * clock a genuinely-live worker can go with ZERO JSONL writes before the
+ * watcher declares it terminal (a worker mid-very-long `Bash`). This is the
+ * SAME resolution `startSubagentWatcher` uses internally (explicit config →
+ * `SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_CAP_MS` env → default), exported so
+ * downstream liveness surfaces (the worker-activity feed's backstop TTL) can
+ * DERIVE their bound from it in code rather than hardcoding an assumption about
+ * its value. Keeps the "TTL must exceed the watcher's terminal-transition
+ * latency" invariant code-enforced: if an operator raises the cap via env, any
+ * derived TTL moves with it instead of falsely reaping a still-live worker.
+ */
+export function resolveInflightTerminalCapMs(configVal?: number): number {
+  return configVal ?? parseEnvMs('SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_CAP_MS') ?? DEFAULT_INFLIGHT_TERMINAL_CAP_MS
+}
 // Minimum wall-clock gap between two "terminal synthesis deferred" log lines
 // for the SAME worker (#3092). `checkStalls` runs on the ~1s rescan tick, and
 // the deferral is re-evaluated (and, before this gate, re-logged) on every one
@@ -1530,10 +1545,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     config.silentStallTerminalMs
     ?? parseEnvMs('SWITCHROOM_SUBAGENT_STALL_TERMINAL_MS')
     ?? DEFAULT_SILENT_STALL_TERMINAL_MS
-  const inflightTerminalCapMs =
-    config.inflightTerminalCapMs
-    ?? parseEnvMs('SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_CAP_MS')
-    ?? DEFAULT_INFLIGHT_TERMINAL_CAP_MS
+  const inflightTerminalCapMs = resolveInflightTerminalCapMs(config.inflightTerminalCapMs)
   const deferralLogIntervalMs =
     config.deferralLogIntervalMs
     ?? parseEnvMs('SWITCHROOM_SUBAGENT_DEFERRAL_LOG_INTERVAL_MS')

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -539,6 +539,26 @@ export interface SubagentWatcherConfig {
     background: boolean | undefined
   }) => void
   /**
+   * Fires EXACTLY when a sub-agent is swept out of the watcher's registry by
+   * `cleanupTerminalAgent` — the single, authoritative "this agent is terminal
+   * and being forgotten" signal that EVERY terminal path funnels through
+   * (real `turn_end`, silent-stall synthesis, failed, boot done-at-boot orphan,
+   * AND the JSONL-vanished path — where Claude Code reaped the parent session's
+   * `subagents/` dir, `onFileVanished` → `cleanupTerminalAgent` runs DIRECTLY,
+   * bypassing `onFinish`).
+   *
+   * Why this exists (worker-feed ghost leak): the live worker-activity feed
+   * removes a worker's row ONLY from the gateway's `onFinish` handler. The
+   * JSONL-vanished and boot-orphan terminal paths never fire `onFinish`, so a
+   * worker that was live in the feed leaks there forever — the shared card never
+   * empties, so it never collapses/unpins and heartbeat-edits indefinitely
+   * while buried up-chat. Wiring feed removal to THIS callback (the same sweep
+   * the watcher already performs) makes cleanup and feed-remove impossible to
+   * diverge. Best-effort; idempotent on the feed side (a no-op once the worker
+   * was already removed by `onFinish`).
+   */
+  onTerminalCleanup?: (agentId: string) => void
+  /**
    * #1720: fires on every `sub_agent_text` event for a running
    * sub-agent. The gateway decides whether to materialise a
    * `subagent_progress` envelope via `decideSubagentProgress` (pure,
@@ -2012,6 +2032,18 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     }
     terminatedAgentIds.add(agentId)
     log?.(`subagent-watcher: cleaned up terminal agent ${agentId}`)
+    // Authoritative terminal sweep → notify the worker-activity feed so its row
+    // for this agent is removed even on the paths that never fire `onFinish`
+    // (JSONL vanished, boot done-at-boot orphan). Without this the feed row
+    // leaks and the shared card goes immortal/unpinned (worker-feed ghost leak).
+    // Best-effort: a callback throw must never wedge the watcher's cleanup.
+    if (config.onTerminalCleanup) {
+      try {
+        config.onTerminalCleanup(agentId)
+      } catch (cbErr) {
+        log?.(`subagent-watcher: onTerminalCleanup callback error ${agentId}: ${(cbErr as Error).message}`)
+      }
+    }
   }
 
   // ─── Card resurrection (issue #3023) ─────────────────────────────────────

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -559,3 +559,151 @@ describe('renderCombinedWorkerFeed (pure)', () => {
     expect(combinedHistoryDepth(8)).toBe(1)
   })
 })
+
+/**
+ * Worker-feed ghost-leak (immortal/unpinned/buried card) — outcome tests.
+ *
+ * Root cause: the feed removed a worker's row ONLY from the gateway's
+ * `onFinish` handler. Terminal paths that never fire `onFinish` (the watcher's
+ * JSONL-vanished `onFileVanished` → `cleanupTerminalAgent`, and boot done-at-
+ * boot orphans) left the row in the feed forever — the shared card never
+ * emptied, so it never collapsed/unpinned and heartbeat-edited indefinitely
+ * while buried up-chat. The fix wires feed removal to the watcher's
+ * authoritative terminal sweep (`terminate`, driven by `onTerminalCleanup`)
+ * PLUS a backstop TTL sweep. These assert the OUTCOMES, not the code paths.
+ */
+function ghostHarness(opts: { staleWorkerTtlMs?: number; now: () => number }) {
+  const edits: { messageId: number; text: string }[] = []
+  const sends: { text: string }[] = []
+  const pins: { messageId: number | null }[] = []
+  let seq = 500
+  const bot: BotApiForWorkerFeed = {
+    sendMessage: async (_chatId, text) => {
+      sends.push({ text })
+      return { message_id: seq++ }
+    },
+    editMessageText: async (_chatId, messageId, text) => {
+      edits.push({ messageId, text })
+      return true
+    },
+  }
+  const feed = createWorkerActivityFeed({
+    bot,
+    now: opts.now,
+    minEditIntervalMs: 0,
+    heartbeatTickMs: 1000,
+    firstPaintMinMs: 0,
+    setInterval: () => 0,
+    clearInterval: () => {},
+    staleWorkerTtlMs: opts.staleWorkerTtlMs,
+    reconcilePin: ({ messageId }) => pins.push({ messageId }),
+  })
+  return { feed, edits, sends, pins }
+}
+async function drain(): Promise<void> {
+  for (let i = 0; i < 10; i++) await new Promise((r) => setImmediate(r))
+}
+
+describe('worker-feed ghost-leak — deterministic terminal removal + backstop', () => {
+  it('finish() on the LAST worker removes its row, collapses to the terminal summary, and UNPINS', async () => {
+    let t = 0
+    const { feed, sends, edits, pins } = ghostHarness({ now: () => t })
+    await feed.update('a', 'chat', view('task a', 'reading files', 0))
+    await drain()
+    expect(sends.length).toBe(1)
+    expect(feed.size).toBe(1)
+    // Painting the group pins the shared message.
+    expect(pins.at(-1)?.messageId).not.toBeNull()
+
+    t = 5000
+    await feed.finish('a', {
+      description: 'task a',
+      lastTool: null,
+      toolCount: 3,
+      latestSummary: 'all done',
+      elapsedMs: 5000,
+      state: 'done',
+    })
+    await drain()
+    // Row gone → the active set empties.
+    expect(feed.size).toBe(0)
+    // Collapsed to a terminal summary (a distinct edit landed, showing 'done').
+    expect(edits.length).toBeGreaterThan(0)
+    expect(edits.at(-1)?.text).toContain('done')
+    // And UNPINNED (group empty → reconcilePin messageId null).
+    expect(pins.at(-1)?.messageId).toBeNull()
+  })
+
+  it('terminate() (authoritative onTerminalCleanup sweep) reaps a worker whose onFinish NEVER fired — collapses + unpins', async () => {
+    let t = 0
+    const { feed, edits, pins } = ghostHarness({ now: () => t })
+    await feed.update('b', 'chat', view('task b', 'running a command', 0))
+    await drain()
+    expect(feed.size).toBe(1)
+    expect(pins.at(-1)?.messageId).not.toBeNull()
+
+    // Simulate the watcher's JSONL-vanished sweep: cleanupTerminalAgent → this,
+    // with NO onFinish ever delivered.
+    t = 3000
+    await feed.terminate('b')
+    await drain()
+    expect(feed.size).toBe(0)
+    expect(pins.at(-1)?.messageId).toBeNull()
+    // The card stopped editing: no further heartbeat edits after termination.
+    const after = edits.length
+    t = 20000
+    feed.heartbeatTick()
+    await drain()
+    expect(edits.length).toBe(after)
+  })
+
+  it('backstop TTL sweep force-reaps a leaked slot (terminal signal never delivered), then the card collapses + unpins', async () => {
+    let t = 0
+    const { feed, edits, pins } = ghostHarness({ staleWorkerTtlMs: 1000, now: () => t })
+    await feed.update('c', 'chat', view('task c', 'thinking', 0))
+    await drain()
+    expect(feed.size).toBe(1)
+
+    // No finish, no terminate — the worker is a pure leak. Advance past the TTL.
+    t = 2500
+    feed.heartbeatTick()
+    await drain()
+    expect(feed.size).toBe(0)
+    expect(pins.at(-1)?.messageId).toBeNull()
+
+    // Immortality closed: subsequent heartbeats produce no further edits.
+    const after = edits.length
+    t = 10000
+    feed.heartbeatTick()
+    await drain()
+    expect(edits.length).toBe(after)
+  })
+
+  it('a still-live worker (fresh update within the TTL) is NOT reaped by the backstop sweep', async () => {
+    let t = 0
+    const { feed } = ghostHarness({ staleWorkerTtlMs: 1000, now: () => t })
+    await feed.update('d', 'chat', view('task d', 's0', 0))
+    await drain()
+    // A fresh cue just before the sweep keeps it live.
+    t = 900
+    await feed.update('d', 'chat', view('task d', 's1', 900))
+    await drain()
+    t = 1500
+    feed.heartbeatTick()
+    await drain()
+    // Still tracked — the sweep only reaps rows silent PAST the TTL.
+    expect(feed.size).toBe(1)
+  })
+
+  it('no-op re-render is skipped (byte-identical body → no redundant edit)', async () => {
+    let t = 0
+    const { feed, edits } = ghostHarness({ now: () => t })
+    await feed.update('e', 'chat', view('task e', 'same step', 0))
+    await drain()
+    const afterPaint = edits.length // first paint is a send, not an edit
+    // Identical view (same elapsed → byte-identical rendered body): dedup skips.
+    await feed.update('e', 'chat', view('task e', 'same step', 0))
+    await drain()
+    expect(edits.length).toBe(afterPaint)
+  })
+})

--- a/telegram-plugin/tests/worker-feed-terminal-cleanup.test.ts
+++ b/telegram-plugin/tests/worker-feed-terminal-cleanup.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Integration guard for the worker-feed ghost-leak fix (PR #3226 review,
+ * Finding 1). The unit tests in `worker-feed-coalesce.test.ts` call
+ * `feed.terminate()` DIRECTLY — they prove the feed collapses/unpins when
+ * asked, but they do NOT prove the two halves of the actual wire that was
+ * broken:
+ *
+ *   (a) the subagent-watcher FIRES `onTerminalCleanup` from its authoritative
+ *       `cleanupTerminalAgent` sweep — on BOTH the JSONL-vanished path
+ *       (`onFileVanished` → `cleanupTerminalAgent`) AND the boot done-at-boot
+ *       orphan path — the exact paths that never fire `onFinish`; and
+ *   (b) wiring that callback to `workerActivityFeed.terminate` removes the row
+ *       and collapses/unpins the shared card end-to-end.
+ *
+ * These drive the REAL `startSubagentWatcher` (with a mock fs) wired to a REAL
+ * `createWorkerActivityFeed` exactly as the gateway wires them
+ * (`onTerminalCleanup: (id) => feed.terminate(id)`). If a future refactor drops
+ * the `config.onTerminalCleanup(agentId)` call in `cleanupTerminalAgent`, the
+ * callback never fires, the feed row survives, and these go RED — the
+ * regression the divergence-based leak represented.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import * as fs from 'fs'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+import {
+  createWorkerActivityFeed,
+  type BotApiForWorkerFeed,
+  type WorkerActivityView,
+} from '../worker-activity-feed.js'
+
+function buildJSONL(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+}
+const subAgentUserMsg = (t: string) => ({ type: 'user', message: { content: [{ type: 'text', text: t }] } })
+const subAgentTurnEnd = () => ({ type: 'system', subtype: 'turn_duration', duration_ms: 100 })
+
+function view(desc: string, step: string, elapsedMs: number): WorkerActivityView {
+  return { description: desc, lastTool: null, toolCount: 2, latestSummary: step, elapsedMs, state: 'running' }
+}
+
+/** A real feed with a fake bot + reconcilePin capture, driven off `now`. */
+function makeFeed(now: () => number) {
+  const sends: { text: string }[] = []
+  const edits: { messageId: number; text: string }[] = []
+  const pins: { messageId: number | null }[] = []
+  let seq = 700
+  const bot: BotApiForWorkerFeed = {
+    sendMessage: async (_c, text) => {
+      sends.push({ text })
+      return { message_id: seq++ }
+    },
+    editMessageText: async (_c, messageId, text) => {
+      edits.push({ messageId, text })
+      return true
+    },
+  }
+  const feed = createWorkerActivityFeed({
+    bot,
+    now,
+    minEditIntervalMs: 0,
+    heartbeatTickMs: 1000,
+    firstPaintMinMs: 0,
+    setInterval: () => 0,
+    clearInterval: () => {},
+    reconcilePin: ({ messageId }) => pins.push({ messageId }),
+  })
+  return { feed, sends, edits, pins }
+}
+async function drain(): Promise<void> {
+  for (let i = 0; i < 12; i++) await new Promise((r) => setImmediate(r))
+}
+
+/**
+ * A mock fs over a single subagents dir with one worker JSONL. `vanished`
+ * flips the file-read calls to throw ENOENT (Claude Code reaped the parent
+ * session's `subagents/` dir) to exercise the vanished terminal path.
+ */
+function mockWatcherFs(opts: {
+  agentDir: string
+  fileName: string
+  content: Buffer
+  vanished: () => boolean
+}) {
+  const projectsRoot = `${opts.agentDir}/.claude/projects`
+  const projectDir = `${projectsRoot}/mock-cwd`
+  const sessionDir = `${projectDir}/sess`
+  const subagentsDir = `${sessionDir}/subagents`
+  const filePath = `${subagentsDir}/${opts.fileName}`
+  let lastOpened: string | null = null
+  const enoent = (): never => {
+    const e = new Error('ENOENT') as NodeJS.ErrnoException
+    e.code = 'ENOENT'
+    throw e
+  }
+  const mock = {
+    existsSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (ps === projectsRoot || ps === projectDir || ps === sessionDir || ps === subagentsDir) return true
+      return ps === filePath && !opts.vanished()
+    }) as typeof fs.existsSync,
+    readdirSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (ps === projectsRoot) return ['mock-cwd']
+      if (ps === projectDir) return ['sess']
+      if (ps === sessionDir) return ['subagents']
+      if (ps === subagentsDir) return opts.vanished() ? [] : [opts.fileName]
+      return []
+    }) as unknown as typeof fs.readdirSync,
+    statSync: ((p: fs.PathLike) => {
+      if (opts.vanished()) return enoent()
+      return { size: opts.content.length, mtimeMs: 0 } as fs.Stats
+    }) as typeof fs.statSync,
+    openSync: ((p: fs.PathLike) => {
+      if (opts.vanished()) return enoent()
+      lastOpened = String(p)
+      return 7
+    }) as unknown as typeof fs.openSync,
+    closeSync: (() => { lastOpened = null }) as typeof fs.closeSync,
+    readSync: ((_fd: number, buf: NodeJS.ArrayBufferView, offset: number, length: number, position: number | null): number => {
+      if (opts.vanished() || lastOpened == null) return 0
+      const src = opts.content.slice(position ?? 0, (position ?? 0) + length)
+      src.copy(buf as Buffer, offset)
+      return src.length
+    }) as unknown as typeof fs.readSync,
+    watch: (() => ({ close: vi.fn() }) as unknown as fs.FSWatcher) as unknown as typeof fs.watch,
+  }
+  return { mock, filePath }
+}
+
+/** Deterministic clock + injectable timers shared by watcher + feed. */
+function makeClock() {
+  let currentTime = 1_000_000
+  const intervals: Array<{ fn: () => void; ms: number; fireAt: number }> = []
+  const timeouts: Array<{ fn: () => void; fireAt: number; ref: number }> = []
+  let nextRef = 1
+  const now = () => currentTime
+  const advance = (ms: number): void => {
+    currentTime += ms
+    for (;;) {
+      timeouts.sort((a, b) => a.fireAt - b.fireAt)
+      const next = timeouts[0]
+      if (!next || next.fireAt > currentTime) break
+      timeouts.shift()
+      next.fn()
+    }
+    for (const iv of intervals) {
+      while (iv.fireAt <= currentTime) {
+        iv.fn()
+        iv.fireAt += iv.ms
+      }
+    }
+  }
+  const timers = {
+    setInterval: (fn: () => void, ms: number) => {
+      intervals.push({ fn, ms, fireAt: currentTime + ms })
+      return { ref: 0 }
+    },
+    clearInterval: () => {},
+    setTimeout: (fn: () => void, ms: number) => {
+      const ref = nextRef++
+      timeouts.push({ fn, fireAt: currentTime + ms, ref })
+      return { ref }
+    },
+    clearTimeout: (handle: { ref: number }) => {
+      const idx = timeouts.findIndex((t) => t.ref === handle.ref)
+      if (idx !== -1) timeouts.splice(idx, 1)
+    },
+  }
+  return { now, advance, timers }
+}
+
+describe('worker-feed ghost-leak — watcher terminal sweep → feed removal (integration)', () => {
+  it('boot done-at-boot orphan: cleanupTerminalAgent fires onTerminalCleanup → feed row removed, card collapsed + unpinned', async () => {
+    const agentDir = '/home/user/.switchroom/agents/x'
+    const { now, advance, timers } = makeClock()
+    const { feed, pins } = makeFeed(now)
+
+    // The worker was live in the feed (its progress had surfaced there).
+    await feed.update('boot1', 'chat', view('task boot1', 'reading', 0))
+    await drain()
+    expect(feed.size).toBe(1)
+    expect(pins.at(-1)?.messageId).not.toBeNull() // pinned
+
+    const { mock } = mockWatcherFs({
+      agentDir,
+      fileName: 'agent-boot1.jsonl',
+      // Already `done` at boot (turn_end present) → registerAgent schedules a
+      // terminal cleanup with NO onFinish (the boot-orphan bypass path).
+      content: Buffer.from(buildJSONL(subAgentUserMsg('done task'), subAgentTurnEnd()), 'utf-8'),
+      vanished: () => false,
+    })
+    const watcher = startSubagentWatcher({
+      agentDir,
+      fs: mock,
+      now,
+      // Wire EXACTLY as the gateway does.
+      onTerminalCleanup: (agentId) => { void feed.terminate(agentId) },
+      ...timers,
+    })
+    expect(watcher.getRegistry().has('boot1')).toBe(true)
+
+    // Fire the scheduled terminal cleanup (30s grace) → onTerminalCleanup.
+    advance(30_000)
+    await drain()
+
+    expect(feed.size).toBe(0)                        // row removed by the sweep
+    expect(pins.at(-1)?.messageId).toBeNull()        // card collapsed + UNPINNED
+    watcher.stop()
+  })
+
+  it('JSONL-vanished path: onFileVanished → cleanupTerminalAgent → onTerminalCleanup → feed row removed + unpinned', async () => {
+    const agentDir = '/home/user/.switchroom/agents/y'
+    const { now, advance, timers } = makeClock()
+    const { feed, pins } = makeFeed(now)
+
+    await feed.update('van1', 'chat', view('task van1', 'running a command', 0))
+    await drain()
+    expect(feed.size).toBe(1)
+
+    let vanished = false
+    const { mock } = mockWatcherFs({
+      agentDir,
+      fileName: 'agent-van1.jsonl',
+      // Running at boot (no turn_end) — stays registered; the poll loop reads
+      // it defensively, so when the file vanishes the read throws ENOENT and
+      // the watcher takes onFileVanished → cleanupTerminalAgent.
+      content: Buffer.from(buildJSONL(subAgentUserMsg('long task')), 'utf-8'),
+      vanished: () => vanished,
+    })
+    const captured: string[] = []
+    const watcher = startSubagentWatcher({
+      agentDir,
+      fs: mock,
+      now,
+      onTerminalCleanup: (agentId) => {
+        captured.push(agentId)
+        void feed.terminate(agentId)
+      },
+      ...timers,
+    })
+    expect(watcher.getRegistry().has('van1')).toBe(true)
+
+    // The parent session ends → Claude Code reaps subagents/ → next poll read
+    // hits ENOENT.
+    vanished = true
+    advance(2_000) // drive the rescan/poll interval
+    await drain()
+
+    expect(captured).toContain('van1')               // vanished path funnels here
+    expect(feed.size).toBe(0)                         // wired removal happened
+    expect(pins.at(-1)?.messageId).toBeNull()         // unpinned
+    watcher.stop()
+  })
+})

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -258,6 +258,24 @@ export interface WorkerActivityFeedOpts {
    */
   maxRows?: number
   /**
+   * Backstop TTL (ms): a worker row that has received no `update()` cue for
+   * longer than this AND is not already finished is force-terminated by the
+   * heartbeat sweep — its row is removed, and when it was the last live worker
+   * the shared card collapses to its terminal summary and unpins. This is the
+   * durable guard against an immortal card if BOTH terminal signals are missed
+   * (the gateway's `onFinish` AND the watcher's `onTerminalCleanup` sweep).
+   *
+   * Default 50 min. Chosen deliberately ABOVE the subagent-watcher's maximum
+   * terminal-transition latency: the watcher owns the terminal transition up to
+   * its 45-min in-flight tool cap (a worker mid-very-long `Bash` legitimately
+   * emits nothing for up to that long before the watcher declares it terminal).
+   * A shorter bound would falsely reap a genuinely-live-but-quiet worker's card.
+   * At 50 min, any row still present is a definitive leak — the watcher would
+   * already have swept a live worker — so this only ever bites a truly ghosted
+   * slot, never a working one. Tests inject a small value.
+   */
+  staleWorkerTtlMs?: number
+  /**
    * Group-level status-pin reconcile hook (#3207 review). Because workers now
    * COALESCE into one shared message, the pin MUST follow the GROUP lifecycle,
    * not a single worker's: pin the shared message when a group's first worker
@@ -309,6 +327,15 @@ interface WorkerRow {
    * stable sort order within the combined feed.
    */
   dispatchAtMs: number | null
+  /**
+   * Wall-clock ms of the most recent `update()` cue for this worker (its last
+   * observed liveness). The heartbeat's backstop TTL sweep force-terminates a
+   * row whose `lastUpdateAt` is older than `staleWorkerTtlMs` — the durable
+   * guard that no card can go immortal even if every terminal signal (onFinish
+   * AND the onTerminalCleanup sweep) is somehow missed. Stamped on row creation
+   * and on every `update()`.
+   */
+  lastUpdateAt: number
   /**
    * Wall-clock ms the CURRENT step started — stamped whenever a NEW narrative
    * line lands (the `→` line changes). The heartbeat's step suffix shows the
@@ -432,6 +459,17 @@ export interface WorkerActivityFeed {
    *  in the group — force the terminal recap edit. No-op if the worker was
    *  never tracked. */
   finish(agentId: string, view: WorkerActivityView): Promise<void>
+  /**
+   * Force a worker terminal from an AUTHORITATIVE watcher sweep
+   * (`onTerminalCleanup`) or the backstop TTL, WITHOUT an external result view:
+   * the terminal recap is synthesised from the worker's own last-known row
+   * state (state → `done`, no fabricated result text — the real result reaches
+   * the user via the separate handback, if one ran). When it was the last live
+   * worker the shared card collapses to its terminal summary and unpins; with
+   * siblings, its row is dropped and the combined body re-renders. Idempotent —
+   * a no-op if the worker was already removed (e.g. `onFinish` fired first).
+   */
+  terminate(agentId: string): Promise<void>
   /** Forget a worker's state without a recap edit (e.g. error path); re-renders
    *  the group so the dropped worker disappears from the combined body. */
   drop(agentId: string): void
@@ -461,6 +499,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   const firstPaintMin = opts.firstPaintMinMs ?? 8000
   const heartbeatTickMs = opts.heartbeatTickMs ?? 6000
   const maxRows = Math.max(1, Math.floor(opts.maxRows ?? 8))
+  const staleWorkerTtlMs = Math.max(1, Math.floor(opts.staleWorkerTtlMs ?? 50 * 60_000))
   const reconcilePinFn = opts.reconcilePin ?? (() => {})
   const setIntervalFn =
     opts.setInterval ??
@@ -790,10 +829,99 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     }
   }
 
+  /**
+   * Shared terminal-finalize path for a worker whose row is still tracked.
+   * Latches the row terminal synchronously (so a late `running` cue on the
+   * chain can't resurrect it), then on the chain either drops the row + re-
+   * renders the surviving siblings, or — when it was the last live worker —
+   * finalizes the shared message to its terminal recap. Used by `finish` (with
+   * the gateway's onFinish view) AND by `terminate` (authoritative watcher
+   * sweep / TTL backstop, view synthesised from the row's own last state).
+   */
+  function finalizeWorker(group: FeedGroup, agentId: string, row: WorkerRow, view: WorkerActivityView): Promise<void> {
+    row.finished = true
+    row.state = view.state === 'failed' ? 'failed' : 'done'
+    markFinalized(agentId)
+    group.chain = group.chain
+      .then(() => {
+        const others = runningRows(group).filter((w) => w.agentId !== agentId)
+        if (others.length > 0) {
+          // Siblings still live → drop this row from the combined body and re-
+          // render the running set. The group pin STAYS (siblings still need
+          // the shared message).
+          removeWorker(group, agentId)
+          syncPin(group)
+          return doRender(group, { force: true })
+        }
+        // Last live worker → finalize the shared message to its terminal recap.
+        const recap: WorkerActivityView = { ...view, narrativeLines: [...row.narrative] }
+        return doRender(group, { force: true, terminalRecap: recap, finishingAgentId: agentId })
+      })
+      .catch((err) => {
+        log(`worker-feed: finalize chain error ${agentId}: ${(err as Error).message}`)
+      })
+    return group.chain
+  }
+
+  /**
+   * Force a worker terminal without an external result view (authoritative
+   * `onTerminalCleanup` sweep or the TTL backstop). Synthesises the recap from
+   * the row's own last-known state — state `done`, NO fabricated result text
+   * (the real result, if any, reaches the user via the separate handback).
+   * Idempotent: a no-op once the worker was already removed (onFinish first).
+   */
+  function terminateWorker(agentId: string): Promise<void> {
+    const g = groupOfAgent(agentId)
+    const row = g?.workers.get(agentId)
+    if (g == null || row == null) {
+      // Already gone (onFinish removed it) — latch finalized so a late cue can't
+      // resurrect, and no-op.
+      markFinalized(agentId)
+      return Promise.resolve()
+    }
+    if (row.finished) {
+      // Terminal already latched; the chain will settle removal. No-op.
+      return g.chain
+    }
+    const lv = row.lastView
+    const view: WorkerActivityView = {
+      description: lv?.description ?? 'background task',
+      lastTool: null,
+      toolCount: lv?.toolCount ?? 0,
+      // No fabricated result paragraph — an authoritative sweep can't know what
+      // the worker returned; the terminal card shows the header struck-through
+      // done, and the handback (if it ran) carries the actual result.
+      latestSummary: '',
+      elapsedMs: liveElapsed(row, nowFn()),
+      state: 'done',
+      model: lv?.model,
+    }
+    return finalizeWorker(g, agentId, row, view)
+  }
+
   // Arm the heartbeat once at construction. The real timer is `.unref()`'d so
   // it never keeps the process alive; tests inject setInterval/clearInterval.
   function heartbeatTick(): void {
     const now = nowFn()
+    // Backstop TTL sweep: force-terminate any worker row that has gone silent
+    // past `staleWorkerTtlMs` (no `update()` cue AND not already finished). This
+    // is the durable guard against an immortal card if BOTH terminal signals
+    // are missed — the gateway's `onFinish` AND the watcher's authoritative
+    // `onTerminalCleanup` sweep. Collect the stale agent ids first (terminate
+    // mutates the group's worker map), then terminate each through its chain so
+    // the render/unpin happens under the normal cooldown/flood guards.
+    const staleAgentIds: string[] = []
+    for (const g of groups.values()) {
+      for (const row of g.workers.values()) {
+        if (!row.finished && now - row.lastUpdateAt >= staleWorkerTtlMs) {
+          staleAgentIds.push(row.agentId)
+        }
+      }
+    }
+    for (const agentId of staleAgentIds) {
+      log(`worker-feed: TTL reap agent=${agentId} — no update in ${Math.floor((now - (groupOfAgent(agentId)?.workers.get(agentId)?.lastUpdateAt ?? now)) / 1000)}s (>= ${Math.floor(staleWorkerTtlMs / 1000)}s); force-terminating leaked row`)
+      void terminateWorker(agentId)
+    }
     for (const g of [...groups.values()]) {
       // Deferred-finalize re-drive: a terminal edit that hit a cooldown/flood
       // window was staged on `pendingFinalize`. Re-drive it once the cooldown
@@ -893,12 +1021,16 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           lastView: null,
           state: 'running',
           finished: false,
+          lastUpdateAt: nowFn(),
           dispatchAtMs: null,
           stepStartedAtMs: null,
         }
         g.workers.set(agentId, row)
         agentIndex.set(agentId, feedKey)
       }
+      // Stamp liveness for the backstop TTL sweep (this is the worker's most
+      // recent observed activity cue).
+      row.lastUpdateAt = nowFn()
       // Accumulate before the gate so a throttled tick still grows the
       // narrative — it surfaces on the next edit that does fire.
       accumulateNarrative(row, view)
@@ -921,33 +1053,13 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         markFinalized(agentId)
         return Promise.resolve()
       }
-      // Latch synchronously so a late `running` cue on the chain can't resurrect.
-      row.finished = true
-      row.state = view.state === 'failed' ? 'failed' : 'done'
-      markFinalized(agentId)
-
-      const group = g
-      group.chain = group.chain
-        .then(() => {
-          const others = runningRows(group).filter((w) => w.agentId !== agentId)
-          if (others.length > 0) {
-            // Siblings still live → drop this row from the combined body and
-            // re-render the running set. The result reaches the user via the
-            // separate handback, never folded into this cosmetic edit. The
-            // group pin STAYS (siblings still need the shared message) — a
-            // per-worker unpin here was the #3207 review blocker.
-            removeWorker(group, agentId)
-            syncPin(group)
-            return doRender(group, { force: true })
-          }
-          // Last live worker → finalize the shared message to its terminal recap.
-          const recap: WorkerActivityView = { ...view, narrativeLines: [...row.narrative] }
-          return doRender(group, { force: true, terminalRecap: recap, finishingAgentId: agentId })
-        })
-        .catch((err) => {
-          log(`worker-feed: finish chain error ${agentId}: ${(err as Error).message}`)
-        })
-      return group.chain
+      // Latch + finalize via the shared path (drop-with-siblings / terminal
+      // recap on the last worker). Synchronous latch inside finalizeWorker
+      // stops a late `running` cue on the chain from resurrecting the row.
+      return finalizeWorker(g, agentId, row, view)
+    },
+    terminate(agentId) {
+      return terminateWorker(agentId)
     },
     drop(agentId) {
       // A dropped worker is also done — mark finalized so a late tick can't

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -265,14 +265,17 @@ export interface WorkerActivityFeedOpts {
    * durable guard against an immortal card if BOTH terminal signals are missed
    * (the gateway's `onFinish` AND the watcher's `onTerminalCleanup` sweep).
    *
-   * Default 50 min. Chosen deliberately ABOVE the subagent-watcher's maximum
-   * terminal-transition latency: the watcher owns the terminal transition up to
-   * its 45-min in-flight tool cap (a worker mid-very-long `Bash` legitimately
-   * emits nothing for up to that long before the watcher declares it terminal).
-   * A shorter bound would falsely reap a genuinely-live-but-quiet worker's card.
-   * At 50 min, any row still present is a definitive leak — the watcher would
-   * already have swept a live worker — so this only ever bites a truly ghosted
-   * slot, never a working one. Tests inject a small value.
+   * The gateway DERIVES this in code from the watcher's effective in-flight
+   * terminal cap (`resolveInflightTerminalCapMs()` — the same env/default the
+   * watcher resolves) plus a margin, so the invariant "never reap a row the
+   * watcher still considers live" holds even if an operator raises the cap via
+   * `SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_CAP_MS`. A worker mid-very-long tool
+   * can go silent up to the cap before the watcher declares it terminal, so any
+   * row still present past cap + margin is a definitive leak — the watcher would
+   * already have swept a live worker.
+   *
+   * Fallback default (this module, for direct / non-gateway callers) 50 min.
+   * Tests inject a small value.
    */
   staleWorkerTtlMs?: number
   /**


### PR DESCRIPTION
## The bug

The combined worker-activity card could go **immortal, unpinned, and buried** up-chat. Live evidence (klanker gateway, 2026-07-13): card `msgId=18094` kept logging `worker-feed: edit … workers=2 bytes=246` every 6s indefinitely, long after its sub-agents went terminal. `subagent-watcher: cleaned up terminal agent …` fired but the feed count stayed `workers=2`; the pin got reaped (`status-pins.json` → `{"v":2,"pins":[]}`) while the card still considered itself active — so it edited itself forever, buried ~65 messages up. Ken: *"if old workers etc still going it can be ages back in the chat history — that isn't the UX I want."*

## Root cause (file:line)

The feed removes a worker's row **only** from the gateway's `onFinish` handler (`workerActivityFeed.finish`). But not every terminal path fires `onFinish`:

- The watcher's **JSONL-vanished** branch (`telegram-plugin/subagent-watcher.ts:1470` — Claude Code reaps the parent session's `subagents/` dir on session end) calls `onFileVanished(agentId)`, which is wired **directly** to `cleanupTerminalAgent` (`subagent-watcher.ts:1807` / `:2612`), reaching `cleanupTerminalAgent` (`subagent-watcher.ts:1990`) **without** going through `maybySendStateTransition` → `config.onFinish` (`subagent-watcher.ts:1911`).
- **Boot done-at-boot orphans** (`subagent-watcher.ts:1776`) likewise clean up with no `onFinish`.

The feed (`telegram-plugin/worker-activity-feed.ts`) has no other removal trigger, so the row leaks forever: `runningRows` never empties → the card never collapses to its terminal summary and never unpins, and the heartbeat's climbing-elapsed re-render (`heartbeatTick` → `doRender({heartbeat:true})`) edits it indefinitely. The byte-dedup at `doRender` (`if (body === g.lastBody) return`) does **not** fire because the elapsed value changes each tick — so the endless edits are a **symptom of the leak, not a missing dedup**. The no-op skip already exists and is correct.

## The fix (deterministic — enforced in code)

1. **Wire feed removal to the authoritative terminal sweep.** New `onTerminalCleanup(agentId)` watcher callback, fired at the end of `cleanupTerminalAgent` — the single sweep **every** terminal path funnels through (real turn_end, stall synthesis, failed, boot orphan, JSONL-vanished). The gateway wires it to `workerActivityFeed.terminate`, so cleanup and feed-remove **can't diverge**. Idempotent: a no-op once `onFinish` already removed the row.
2. **New feed `terminate(agentId)`** finalizes from the row's own last-known state (state → `done`, **no fabricated result text** — the real result reaches the user via the separate handback). Last worker → collapse to terminal summary **and unpin**; siblings → drop row + re-render. Shares the finalize path with `finish`.
3. **Backstop TTL sweep** in the heartbeat: a row silent past `staleWorkerTtlMs` (default **50 min**, deliberately above the watcher's 45-min in-flight terminal cap so a genuinely-live-but-quiet worker is never falsely reaped) is force-terminated. Durable guard: no card can go immortal even if both terminal signals are missed.
4. **No-op dedup** confirmed already present (`doRender` body-equality skip) — not re-added.

## Tests (assert outcomes)

Added to `telegram-plugin/tests/worker-feed-coalesce.test.ts`:
- last-worker `finish` removes the row, collapses to the terminal summary, and unpins;
- `terminate` (the `onTerminalCleanup` sweep) reaps a worker whose `onFinish` never fired, and the card stops editing;
- the backstop TTL sweep force-reaps a pure leak, collapses + unpins, and closes immortality (no further edits);
- a fresh-within-TTL worker is **not** reaped;
- no-op re-render is skipped.

## Validation

- Scoped vitest: `worker-feed-coalesce` (20 passed), `worker-activity-feed` / `worker-feed-dispatch` / `subagent-watcher-*` (106 passed). 
- Root `tsc --noEmit`: clean.
- `check-plugin-references` fails identically (161 errors) on pristine `origin/main` in this worktree — an environmental artifact (missing patched plugin deps), **zero** referencing the changed files. CI is the full-suite authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)