### PR TITLE
fix(narration): time-box the opening-narration early paint on the progress card

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -16521,6 +16521,13 @@ function handleSessionEvent(ev: SessionEvent): void {
           clearTimeout(prior.orphanedReplyTimeoutId)
           prior.orphanedReplyTimeoutId = null
         }
+        // Same bounded-leak class (early-paint 250ms setTimeout): the prior
+        // turn may have armed its narrative gate's early-paint timer before
+        // being superseded. Left untorn, ~250ms later it fires showNarrativeStep
+        // on the dead turn and can paint a stale narration card below the new
+        // turn's surface. Teardown is guard-safe and idempotent (no-op when never
+        // armed / already fired / already disarmed by the prior turn's turn_end).
+        prior?.narrativeGate?.teardown()
         // #1067: swap the entire turn atom in one assignment. Every
         // handler captures `const turn = currentTurn` at entry, so a
         // captured-then-awaited read can't reattribute to the new turn.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -192,7 +192,8 @@ import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, forma
 import { formatModelLabel } from '../model-label.js'
 import { createSessionModelSource } from './session-model-source.js'
 import { runSilentTurnHeartbeatTick } from '../feed-heartbeat-climb.js'
-import { REPLY_TOOLS, isDraftOfReply } from '../narrative-dedup.js'
+import { REPLY_TOOLS } from '../narrative-dedup.js'
+import { NarrativeFlushController } from '../narrative-flush.js'
 import { toolLabel } from '../tool-labels.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { createTurnTypingLoop } from './turn-typing-loop.js'
@@ -3249,17 +3250,19 @@ type CurrentTurn = {
   // (via `renderActivityFeed`) as a capped chronological list into the
   // in-place edited activity message and clears on reply. Reset per turn.
   mirrorLines: string[]
-  // Narrative-dedup gate state (JSONL-text-narrative primitive). A `text`
-  // block is held here for ONE lookahead step so the next event (a tool_use
-  // or turn_end) can decide draft-then-send (SUPPRESS, it duplicates the
-  // reply) vs working-narration (SHOW it as a transient mirrorLines step).
-  // Null when nothing is pending. The pure decision lives in
-  // narrative-dedup.ts; this slot is the per-turn cursor. Reset per turn.
-  // Invariant `chat-is-the-single-source-of-truth`: a SHOWN narrative is
-  // rendered through the SAME appendActivityLabel→renderStepFeed path as a
-  // tool step — a transient, clipped, rolling-window line replaced by the
-  // next event, never a persisted parallel mirror.
-  pendingNarrative: { text: string } | null
+  // Narrative-dedup gate state (JSONL-text-narrative primitive). A `text` block
+  // is parked for ONE lookahead step so the next event (a tool_use or turn_end)
+  // can decide draft-then-send (SUPPRESS, it duplicates the reply) vs
+  // working-narration (SHOW it as a transient mirrorLines step). The pure park /
+  // timer / retract state machine lives in `narrative-flush.ts`; this controller
+  // is the per-turn instance, wired with the SHOW effect (`showNarrativeStep`),
+  // the RETRACT effect (splice the timer-painted line out of `mirrorLines`), and
+  // a real `unref`'d `setTimeout` scheduler for the ~`PENDING_NARRATIVE_FLUSH_MS`
+  // early paint. Reset per turn. Invariant `chat-is-the-single-source-of-truth`:
+  // a SHOWN narrative renders through the SAME appendActivityLabel→renderStepFeed
+  // path as a tool step — transient, clipped, rolling-window, never a persisted
+  // parallel mirror.
+  narrativeGate: NarrativeFlushController
   // Most-recently-seen reply/stream_reply `input.text` for this turn — the
   // ACTUAL delivered answer surface. Set wherever a REPLY_TOOL tool_use is
   // handled in the reducer. `flushPendingNarrativeAtTurnEnd` compares a
@@ -4889,6 +4892,11 @@ function endCurrentTurnAtomic(
     clearTimeout(turn.noReplyDrainTimer)
     turn.noReplyDrainTimer = null
   }
+  // Teardown the narrative gate's early-paint timer so it can neither leak past
+  // the turn nor fire against a torn-down turn. (Idempotent — no-op when never
+  // armed / already fired. `flushPendingNarrativeAtTurnEnd` on the turn_end event
+  // normally disarms it first; this is the belt-and-braces teardown net.)
+  turn.narrativeGate?.teardown()
   // Pass `turn` so purgeReactionTracking sees the authoritative
   // replyCalled flag even though we just nulled module-scope
   // currentTurn. Without this, the shadow trace's outboundEmitted
@@ -15538,6 +15546,80 @@ function composeTurnActivity(turn: CurrentTurn, final = false, liveSuffix = ''):
 }
 
 /**
+ * Time-box for the parked-narrative early-paint (see `narrative-flush.ts`).
+ * If a parked opening narration gets no lookahead event (tool_use / next text /
+ * turn_end) within this window — the "narrate, then think before the first tool"
+ * case that produced the visible gap — the flush timer paints it via the SAME
+ * `showNarrativeStep` path a lookahead would. Chosen so a normal draft-then-send
+ * `reply` (emitted right after the text block) lands FIRST and cancels the timer;
+ * but correctness does NOT depend on that race — a timer-painted block that later
+ * proves to be the reply is deterministically retracted (see the RETRACT effect
+ * wired into the controller below). Named const so a test can pin it.
+ */
+const PENDING_NARRATIVE_FLUSH_MS = 250
+
+/**
+ * Retract a narration step the flush timer painted EARLY that turned out to draft
+ * the outgoing reply — the effect half of the anti-double-print guarantee's timer
+ * path. Splice the line out of `mirrorLines` and re-render, so neither the live
+ * nor the finalized card surfaces the answer as a narration step. The splice runs
+ * synchronously BEFORE the reply's `clearActivitySummary` finalize reads
+ * `mirrorLines`, so the persisted card is clean regardless of the re-render.
+ */
+function retractNarrativeLine(turn: CurrentTurn, text: string): void {
+  const clipped = clipNarrative(text)
+  const idx = turn.mirrorLines.lastIndexOf(clipped)
+  if (idx === -1) return // rolled out of the window already — nothing to retract
+  turn.mirrorLines.splice(idx, 1)
+  // Live re-render without the retracted line (the finalize path reads the same
+  // spliced array; this only matters for the interim-ack case where finalize
+  // isn't called on this reply). Guarded on a non-null render so an emptied feed
+  // doesn't blank the card.
+  const rerender = composeTurnActivity(turn)
+  if (rerender == null) return
+  turn.activityPendingRender = rerender
+  const ea = emissionAuthorityFor(turn)
+  cardDrainGate(turn, ea, () => {
+    if (ea.mayDrain(turn)) {
+      ea.openOrEditCard('narrative', () => {
+        turn.activityInFlight = drainActivitySummary(turn, 'narrative')
+      })
+    }
+  })
+}
+
+/**
+ * Build a per-turn narrative gate: the pure park/timer/retract state machine
+ * (`narrative-flush.ts`) wired to THIS turn's SHOW effect (`showNarrativeStep`),
+ * RETRACT effect (`retractNarrativeLine`), and a real `unref`'d `setTimeout`
+ * scheduler. The scheduler captures the turn's own timer handle so a turn swap
+ * can't mis-target it — mirrors the `noReplyDrainTimer` discipline.
+ */
+function makeNarrativeGate(turn: CurrentTurn): NarrativeFlushController {
+  let handle: ReturnType<typeof setTimeout> | null = null
+  return new NarrativeFlushController(
+    {
+      show: (text) => showNarrativeStep(turn, text),
+      retractShown: (text) => retractNarrativeLine(turn, text),
+    },
+    {
+      arm: (fn, ms) => {
+        if (handle != null) clearTimeout(handle)
+        handle = setTimeout(fn, ms)
+        handle.unref?.()
+      },
+      disarm: () => {
+        if (handle != null) {
+          clearTimeout(handle)
+          handle = null
+        }
+      },
+    },
+    PENDING_NARRATIVE_FLUSH_MS,
+  )
+}
+
+/**
  * Render a SHOWN narrative text block as a transient liveness step — the
  * same path a tool label takes (appendActivityLabel → renderStepFeed), so
  * the narrative line is rolling-window-clipped and replaced by the next
@@ -15582,27 +15664,20 @@ function resolvePendingNarrativeOnTool(
   toolName: string,
   input: Record<string, unknown> | undefined,
 ): void {
-  const pending = turn.pendingNarrative
-  if (pending == null) return
-  turn.pendingNarrative = null
-  if (REPLY_TOOLS.has(toolName)) {
-    const replyText = typeof input?.text === 'string' ? (input.text as string) : ''
-    if (isDraftOfReply(pending.text, replyText)) return // draft of the answer → SUPPRESS
-  }
-  showNarrativeStep(turn, pending.text) // working preamble / post-action narration → SHOW
+  // Delegate to the pure park/timer/retract kernel: it cancels the early-paint
+  // timer, retracts a timer-painted block that THIS reply drafts (anti-double-
+  // print), then SHOWs / SUPPRESSes the parked block. See narrative-flush.ts §2.
+  turn.narrativeGate.resolveOnTool(toolName, input)
 }
 
 /**
  * Narrative-dedup gate, step 1 (reducer-side): a new narrative block
  * arrived. A previously-pending block had nothing reply-shaped immediately
  * after it (pure narration) → flush it as SHOWN, then stage the new one for
- * one lookahead step. See narrative-dedup.ts §2b.
+ * one lookahead step AND arm the time-boxed early paint. See narrative-flush.ts.
  */
 function stagePendingNarrative(turn: CurrentTurn, text: string): void {
-  if (turn.pendingNarrative != null) {
-    showNarrativeStep(turn, turn.pendingNarrative.text)
-  }
-  turn.pendingNarrative = { text }
+  turn.narrativeGate.stage(text)
 }
 
 /**
@@ -15610,14 +15685,11 @@ function stagePendingNarrative(turn: CurrentTurn, text: string): void {
  * trailing narrative block and nothing after it. SUPPRESS only when the turn
  * already delivered its answer via reply/stream_reply and the trailing text
  * is a draft of that answer; otherwise SHOW (genuine trailing narration like
- * "Done — all green."). See narrative-dedup.ts §2b.
+ * "Done — all green."). Also cancels the early-paint timer and retracts a
+ * timer-painted draft of the delivered answer. See narrative-flush.ts §3.
  */
 function flushPendingNarrativeAtTurnEnd(turn: CurrentTurn, lastReplyText: string): void {
-  const pending = turn.pendingNarrative
-  if (pending == null) return
-  turn.pendingNarrative = null
-  if (lastReplyText.length > 0 && isDraftOfReply(pending.text, lastReplyText)) return // trailing duplicate of the answer
-  showNarrativeStep(turn, pending.text)
+  turn.narrativeGate.flushAtTurnEnd(lastReplyText)
 }
 
 /**
@@ -16526,7 +16598,10 @@ function handleSessionEvent(ev: SessionEvent): void {
           activityEverOpened: false,
           activityDrainFailures: 0,
           mirrorLines: [],
-          pendingNarrative: null,
+          // Assigned immediately after this literal via makeNarrativeGate(next) —
+          // the controller's SHOW/RETRACT effects close over the turn object, which
+          // can't reference itself inside its own initializer.
+          narrativeGate: undefined as unknown as NarrativeFlushController,
           lastReplyText: '',
           foregroundSubAgents: new Map(),
           answerStream: null,
@@ -16539,6 +16614,9 @@ function handleSessionEvent(ev: SessionEvent): void {
             statusKey(ev.chatId, enqThreadIdNum),
           ),
         }
+        // Wire the per-turn narrative gate now that `next` exists (its SHOW/RETRACT
+        // effects close over the turn). Born with this turn, torn down at turn end.
+        next.narrativeGate = makeNarrativeGate(next)
         // PR-4e — route the turn-SET through the keyed accessor: flag-OFF assigns
         // the singleton (byte-identical to `currentTurn = next`); flag-ON sets the
         // per-topic `byKey[statusKey]` entry AND the most-recent mirror. The key is
@@ -17294,8 +17372,8 @@ function handleSessionEvent(ev: SessionEvent): void {
       // delivered reply text and SUPPRESS the duplicate; otherwise SHOW
       // genuine trailing narration ("Done — all green."). Must run BEFORE
       // clearActivitySummary so a SHOWN line lands in the feed's final
-      // render. Always clears turn.pendingNarrative so it can't leak across
-      // turns.
+      // render. Always clears the gate's parked block (and disarms its
+      // early-paint timer) so nothing can leak across turns.
       //
       // NIT 2 (reply-proxy precision): use `turn.lastReplyText` (the
       // most-recent reply/stream_reply input.text) rather than

--- a/telegram-plugin/narrative-flush.ts
+++ b/telegram-plugin/narrative-flush.ts
@@ -1,0 +1,161 @@
+/**
+ * Time-boxed narrative early-paint — the TIMER half of the JSONL-text-narrative
+ * primitive, and the pure, fully-unit-testable kernel of it (companion to
+ * `narrative-dedup.ts`, which owns the SHOW-vs-SUPPRESS decision).
+ *
+ * ## Why this exists
+ * A `text` / `sub_agent_text` block is parked for ONE lookahead step so the
+ * reducer can tell DRAFT-THEN-SEND (suppress — it duplicates the reply) from
+ * WORKING NARRATION (show). On a normal turn the lookahead is the FIRST real
+ * `tool_use`, so the opening narration ("On it, pulling the logs…") only painted
+ * when that tool landed — a visible gap while the agent thinks before its first
+ * tool.
+ *
+ * This kernel adds a deterministic timer: when a block is parked, arm a short
+ * timer. If a lookahead event (tool_use / next text / turn_end) arrives first,
+ * the normal path resolves the block and the timer is CANCELLED. If the timer
+ * fires first, the parked narration is painted EARLY — so it surfaces
+ * ~`flushMs` into the turn instead of waiting for the first tool.
+ *
+ * ## Anti-double-print guarantee (the correctness core)
+ * The whole reason the decision is deferred is that a parked block might turn out
+ * to be the outgoing reply, which must NEVER surface as a card narration step AND
+ * as the canonical reply. The timer introduces a window where a block is painted
+ * BEFORE its lookahead reply arrives. This kernel keeps the guarantee
+ * deterministically, NOT by hoping the window hides the race:
+ *   - A block painted by the timer is remembered (`timerShown`).
+ *   - When the reply/stream_reply lookahead finally arrives (on a tool or at
+ *     turn_end), if it is a draft-then-send of the timer-painted block
+ *     (`isDraftOfReply`), the kernel emits a RETRACT effect so the caller removes
+ *     the prematurely-shown step. Correctness therefore does not depend on the
+ *     250ms window winning the race — the retract is the guarantee; the timer is
+ *     only the early-paint trigger.
+ *
+ * ## Purity
+ * No I/O, no real timers, no state of its own beyond the two explicit slots. All
+ * effects (paint a step, retract a step, arm/disarm a real timer) are injected,
+ * so the kernel is driven deterministically in tests with fake timers. The caller
+ * (gateway reducer for the main agent, subagent-watcher for sub/worker) owns the
+ * effects and the per-turn lifetime.
+ */
+
+import { REPLY_TOOLS, isDraftOfReply } from './narrative-dedup.js'
+
+/** Side effects the kernel drives. The caller owns rendering + retraction. */
+export interface NarrativeFlushEffects {
+  /** Paint a narrative block as a transient liveness step (SHOW). */
+  show(text: string): void
+  /**
+   * Retract a previously-SHOWN narration step (it turned out to draft the reply).
+   * Caller removes it from the feed. No-op-safe if already gone.
+   */
+  retractShown(text: string): void
+}
+
+/** Arms / disarms the real early-paint timer. Injected so tests can fake it. */
+export interface NarrativeFlushScheduler {
+  /** Arm the timer; MUST cancel any prior armed callback first (at-most-one). */
+  arm(fn: () => void, ms: number): void
+  /** Cancel the armed callback if any. Idempotent. */
+  disarm(): void
+}
+
+/**
+ * Pure park/timer/retract state machine for one turn (or one sub-agent entry).
+ * Construct once per turn with the effect + scheduler wiring; discard at teardown.
+ */
+export class NarrativeFlushController {
+  /** Block parked awaiting its lookahead event. Null when nothing pending. */
+  private pending: string | null = null
+  /** Block the timer painted EARLY, retained for possible retract. */
+  private timerShown: string | null = null
+
+  constructor(
+    private readonly effects: NarrativeFlushEffects,
+    private readonly scheduler: NarrativeFlushScheduler,
+    private readonly flushMs: number,
+  ) {}
+
+  /** Test/inspection accessors (no behaviour). */
+  get pendingText(): string | null {
+    return this.pending
+  }
+  get timerShownText(): string | null {
+    return this.timerShown
+  }
+
+  /**
+   * Gate step 1: a new narrative block arrived. It is itself the lookahead for
+   * the previously-parked block (pure narration — a draft is followed by a reply,
+   * not more text) → SHOW the old one, then park the new one and arm the timer.
+   */
+  stage(text: string): void {
+    this.scheduler.disarm()
+    if (this.pending != null) {
+      this.effects.show(this.pending)
+    }
+    this.pending = text
+    this.scheduler.arm(() => this.onTimerFire(), this.flushMs)
+  }
+
+  /**
+   * The early-paint timer fired: no lookahead arrived within the window. If the
+   * block is still parked, SHOW it now and remember it so a later draft-then-send
+   * reply can retract it.
+   */
+  private onTimerFire(): void {
+    if (this.pending == null) return // a lookahead already consumed it
+    const text = this.pending
+    this.pending = null
+    this.timerShown = text
+    this.effects.show(text)
+  }
+
+  /**
+   * Gate step 2: a tool_use lookahead arrived. Cancel the timer, retract a
+   * timer-painted block if THIS reply drafts it, then resolve the parked block:
+   * SUPPRESS a reply-draft, else SHOW.
+   */
+  resolveOnTool(toolName: string, input: Record<string, unknown> | undefined): void {
+    this.scheduler.disarm()
+    const replyText =
+      REPLY_TOOLS.has(toolName) && typeof input?.text === 'string' ? (input.text as string) : null
+    if (replyText != null) this.maybeRetract(replyText)
+    const pending = this.pending
+    if (pending == null) return
+    this.pending = null
+    if (replyText != null && isDraftOfReply(pending, replyText)) return // draft → SUPPRESS
+    this.effects.show(pending)
+  }
+
+  /**
+   * Gate step 3: turn_end — the terminal lookahead. Cancel the timer, retract a
+   * timer-painted block if the delivered reply drafts it, then SHOW a genuine
+   * trailing narration (or SUPPRESS a trailing draft of the answer).
+   */
+  flushAtTurnEnd(lastReplyText: string): void {
+    this.scheduler.disarm()
+    if (lastReplyText.length > 0) this.maybeRetract(lastReplyText)
+    const pending = this.pending
+    if (pending == null) return
+    this.pending = null
+    if (lastReplyText.length > 0 && isDraftOfReply(pending, lastReplyText)) return // trailing draft
+    this.effects.show(pending)
+  }
+
+  /** Turn teardown: cancel the timer so it can neither leak nor fire late. */
+  teardown(): void {
+    this.scheduler.disarm()
+    this.pending = null
+    this.timerShown = null
+  }
+
+  /** Retract the timer-painted block iff this reply is its draft-then-send. */
+  private maybeRetract(replyText: string): void {
+    const shown = this.timerShown
+    if (shown == null) return
+    if (!isDraftOfReply(shown, replyText)) return
+    this.timerShown = null
+    this.effects.retractShown(shown)
+  }
+}

--- a/telegram-plugin/tests/emission-authority-facade.test.ts
+++ b/telegram-plugin/tests/emission-authority-facade.test.ts
@@ -370,13 +370,15 @@ describe('the drain sites route through the façade with producers preserved ver
 
   it('every routed drain site guards the single-flight via ea.mayDrain(turn), not a bare activityInFlight read', () => {
     const mayDrainGuards = [...gatewaySrc.matchAll(/if \(ea\.mayDrain\(turn\)\)/g)]
-    // narrative + 2 liveness + tool + 2 sub-agent + 1 post-answer bg-liveness
-    // (Fix 2) = 7. The Phase-1 0-label climb (deterministic-turn-liveness.md)
-    // consults the SAME guard, but its `if (deps.mayDrain())` lives in the
-    // extracted tick body (feed-heartbeat-climb.ts) with `() => ea.mayDrain(turn)`
-    // injected at the gateway call site — pinned by
-    // feed-heartbeat-liveness-open.test.ts + silent-turn-climb-transport.test.ts.
-    expect(mayDrainGuards).toHaveLength(7)
+    // narrative SHOW + narrative RETRACT (timer-flush early-paint retract,
+    // narrative-flush.ts) + 2 liveness + tool + 2 sub-agent + 1 post-answer
+    // bg-liveness (Fix 2) = 8. The Phase-1 0-label climb
+    // (deterministic-turn-liveness.md) consults the SAME guard, but its
+    // `if (deps.mayDrain())` lives in the extracted tick body
+    // (feed-heartbeat-climb.ts) with `() => ea.mayDrain(turn)` injected at the
+    // gateway call site — pinned by feed-heartbeat-liveness-open.test.ts +
+    // silent-turn-climb-transport.test.ts.
+    expect(mayDrainGuards).toHaveLength(8)
     expect(gatewaySrc).toMatch(/mayDrain:\s*\(\)\s*=>\s*ea\.mayDrain\(turn\)/)
   })
 })
@@ -498,11 +500,12 @@ describe('mayDrainCardNow — PR-4d card-drain gate (pure read; gateway holds th
   })
 
   it('the card-drain sites each route their guarded block through cardDrainGate (single-flight gate stays byte-identical)', () => {
-    // Option A: the 7 `if (ea.mayDrain(turn))` guards + drainActivitySummary
+    // Option A: the 8 `if (ea.mayDrain(turn))` guards + drainActivitySummary
     // thunks stay byte-identical, wrapped by the centralized helper.
-    // 6 original + 1 new post-answer background-agent liveness drain (Fix 2).
+    // 6 original + 1 post-answer background-agent liveness drain (Fix 2) + 1
+    // narrative-retract drain (timer-flush early-paint retract, narrative-flush.ts).
     const wraps = [...gatewaySrc.matchAll(/cardDrainGate\(turn, ea, \(\) => \{/g)]
-    expect(wraps).toHaveLength(7)
+    expect(wraps).toHaveLength(8)
     // The Phase-1 0-label climb (deterministic-turn-liveness.md) routes through
     // the SAME helper via an injected thunk — its call lives in the extracted
     // tick body (feed-heartbeat-climb.ts), wired at the gateway call site as

--- a/telegram-plugin/tests/narrative-flush.test.ts
+++ b/telegram-plugin/tests/narrative-flush.test.ts
@@ -1,0 +1,213 @@
+/**
+ * narrative-flush.test.ts — the time-boxed narrative early-paint kernel.
+ *
+ * Pins the deterministic behaviour of NarrativeFlushController (narrative-flush.ts):
+ * the timer half of the JSONL-text-narrative primitive. Drives the REAL kernel with
+ * a fake scheduler + effect spies (no real timers, no gateway I/O) so every
+ * assertion is an outcome, not a code-path.
+ *
+ * Coverage maps 1:1 to the fix's correctness requirements:
+ *   1. Early paint — a parked block SHOWs when the timer fires and NO lookahead
+ *      followed (RED on pre-fix: pre-fix never armed a timer, so `show` only ever
+ *      fired on the next event — here it fires with no lookahead at all).
+ *   2. Fast tool — a tool_use lookahead before the timer fires SHOWs exactly once
+ *      and cancels the timer (no double-paint).
+ *   3. Anti-double-print, deferred path — a parked block that drafts the reply is
+ *      SUPPRESSED (never shown) when the reply lands before the timer.
+ *   4. Anti-double-print, TIMER path — a block the timer already painted that
+ *      later proves to draft the reply is RETRACTED (the guarantee holds even when
+ *      the timer paints ahead of the reply).
+ *   5. Leak safety — turn_end and teardown disarm the timer; a stale fire is inert.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { NarrativeFlushController } from '../narrative-flush.js'
+
+const FLUSH_MS = 250
+
+/** Deterministic stand-in for the real `unref`'d setTimeout wiring. */
+class FakeScheduler {
+  private fn: (() => void) | null = null
+  armCount = 0
+  disarmCount = 0
+  lastMs: number | null = null
+
+  arm(fn: () => void, ms: number): void {
+    // Real scheduler cancels any prior armed callback first (at-most-one).
+    this.fn = fn
+    this.lastMs = ms
+    this.armCount++
+  }
+  disarm(): void {
+    if (this.fn != null) this.disarmCount++
+    this.fn = null
+  }
+  /** Simulate the real timer elapsing. No-op once disarmed (mirrors clearTimeout). */
+  fire(): void {
+    const fn = this.fn
+    this.fn = null // a real one-shot timer is spent after firing
+    fn?.()
+  }
+  get isArmed(): boolean {
+    return this.fn != null
+  }
+}
+
+function makeController() {
+  const show = vi.fn<[string], void>()
+  const retractShown = vi.fn<[string], void>()
+  const scheduler = new FakeScheduler()
+  const ctrl = new NarrativeFlushController({ show, retractShown }, scheduler, FLUSH_MS)
+  return { ctrl, show, retractShown, scheduler }
+}
+
+describe('early paint — parked narration surfaces on the timer with no lookahead', () => {
+  it('does NOT paint on stage alone, then paints exactly once when the timer fires', () => {
+    const { ctrl, show, scheduler } = makeController()
+    ctrl.stage('On it, pulling the logs…')
+
+    // Pre-fix behaviour: nothing shown yet (deferred one lookahead step).
+    expect(show).not.toHaveBeenCalled()
+    // The fix ARMS a timer for exactly this case.
+    expect(scheduler.isArmed).toBe(true)
+    expect(scheduler.lastMs).toBe(FLUSH_MS)
+
+    scheduler.fire() // the agent thought past the window before its first tool
+    expect(show).toHaveBeenCalledTimes(1)
+    expect(show).toHaveBeenCalledWith('On it, pulling the logs…')
+  })
+})
+
+describe('fast tool — a lookahead before the window cancels the timer, paints once', () => {
+  it('SHOWs the working preamble once and disarms; a later stale fire is inert', () => {
+    const { ctrl, show, scheduler } = makeController()
+    ctrl.stage('Let me check the build…')
+    expect(scheduler.isArmed).toBe(true)
+
+    ctrl.resolveOnTool('Bash', { command: 'npm test' }) // real tool → SHOW
+    expect(show).toHaveBeenCalledTimes(1)
+    expect(show).toHaveBeenCalledWith('Let me check the build…')
+    expect(scheduler.isArmed).toBe(false) // timer cancelled
+    expect(scheduler.disarmCount).toBeGreaterThan(0)
+
+    scheduler.fire() // stale — must not double-paint
+    expect(show).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('anti-double-print (deferred path) — a draft-then-send reply is suppressed', () => {
+  it('never SHOWs a parked block that drafts the reply landing before the timer', () => {
+    const { ctrl, show, retractShown, scheduler } = makeController()
+    const answer = 'The build is green — all 412 tests pass.'
+    ctrl.stage(answer) // the model drafting its answer just before reply()
+
+    ctrl.resolveOnTool('reply', { text: answer }) // draft-then-send → SUPPRESS
+    expect(show).not.toHaveBeenCalled()
+    expect(retractShown).not.toHaveBeenCalled() // nothing was shown to retract
+    expect(scheduler.isArmed).toBe(false)
+  })
+
+  it('SHOWs a working preamble whose text DIFFERS from the reply', () => {
+    const { ctrl, show } = makeController()
+    ctrl.stage('Looking into it…')
+    ctrl.resolveOnTool('reply', { text: 'The answer is 42.' })
+    expect(show).toHaveBeenCalledTimes(1)
+    expect(show).toHaveBeenCalledWith('Looking into it…')
+  })
+})
+
+describe('anti-double-print (TIMER path) — a timer-painted draft is retracted', () => {
+  it('RETRACTS a block the timer already painted when the reply proves it a draft', () => {
+    const { ctrl, show, retractShown, scheduler } = makeController()
+    const answer = 'Done — deployed v0.16.51 to production, health checks green.'
+    ctrl.stage(answer)
+
+    scheduler.fire() // timer paints it EARLY (the reply hadn't arrived yet)
+    expect(show).toHaveBeenCalledTimes(1)
+    expect(show).toHaveBeenCalledWith(answer)
+
+    // The reply finally lands and IS that block → must be retracted, not left
+    // on the card to double-print against the canonical reply.
+    ctrl.resolveOnTool('stream_reply', { text: answer })
+    expect(retractShown).toHaveBeenCalledTimes(1)
+    expect(retractShown).toHaveBeenCalledWith(answer)
+    expect(show).toHaveBeenCalledTimes(1) // not re-shown
+  })
+
+  it('does NOT retract a timer-painted block when the reply differs (genuine narration)', () => {
+    const { ctrl, show, retractShown, scheduler } = makeController()
+    ctrl.stage('Still working — compiling the worker…')
+    scheduler.fire()
+    ctrl.resolveOnTool('reply', { text: 'Here are your results: …' })
+    expect(show).toHaveBeenCalledTimes(1)
+    expect(retractShown).not.toHaveBeenCalled()
+  })
+
+  it('retracts a timer-painted draft even when the reply only lands at turn_end', () => {
+    const { ctrl, show, retractShown, scheduler } = makeController()
+    const answer = 'All set — the migration ran cleanly.'
+    ctrl.stage(answer)
+    scheduler.fire()
+    ctrl.flushAtTurnEnd(answer) // reply delivered; trailing block is its draft
+    expect(retractShown).toHaveBeenCalledTimes(1)
+    expect(retractShown).toHaveBeenCalledWith(answer)
+    expect(show).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('turn_end — trailing narration is shown or suppressed, timer disarmed', () => {
+  it('SHOWs genuine trailing narration and disarms the timer', () => {
+    const { ctrl, show, scheduler } = makeController()
+    ctrl.stage('Done — all green.')
+    ctrl.flushAtTurnEnd('') // no reply delivered → genuine trailing narration
+    expect(show).toHaveBeenCalledTimes(1)
+    expect(show).toHaveBeenCalledWith('Done — all green.')
+    expect(scheduler.isArmed).toBe(false)
+  })
+
+  it('SUPPRESSes a trailing block that drafts the delivered answer', () => {
+    const { ctrl, show } = makeController()
+    const answer = 'The total came to $1,240.50 across the three invoices.'
+    ctrl.stage(answer)
+    ctrl.flushAtTurnEnd(answer)
+    expect(show).not.toHaveBeenCalled()
+  })
+})
+
+describe('leak safety — teardown and turn_end can never leave a live timer', () => {
+  it('teardown disarms; a stale fire after teardown is inert', () => {
+    const { ctrl, show, scheduler } = makeController()
+    ctrl.stage('Working…')
+    expect(scheduler.isArmed).toBe(true)
+
+    ctrl.teardown()
+    expect(scheduler.isArmed).toBe(false)
+    expect(scheduler.disarmCount).toBeGreaterThan(0)
+
+    scheduler.fire() // must not paint against a torn-down turn
+    expect(show).not.toHaveBeenCalled()
+  })
+
+  it('flushAtTurnEnd disarms the timer so it cannot fire post-turn', () => {
+    const { ctrl, show, scheduler } = makeController()
+    ctrl.stage('Half-done…')
+    ctrl.flushAtTurnEnd('') // shows it, and disarms
+    show.mockClear()
+    scheduler.fire() // stale
+    expect(show).not.toHaveBeenCalled()
+  })
+
+  it('re-staging cancels the prior block’s timer (at-most-one armed)', () => {
+    const { ctrl, show, scheduler } = makeController()
+    ctrl.stage('first line…')
+    ctrl.stage('second line…') // the new block is the lookahead for the first
+    // The first (pure narration) is shown immediately by the stage lookahead.
+    expect(show).toHaveBeenCalledTimes(1)
+    expect(show).toHaveBeenCalledWith('first line…')
+    // Exactly one live timer remains (for the second block).
+    expect(scheduler.isArmed).toBe(true)
+    scheduler.fire()
+    expect(show).toHaveBeenCalledTimes(2)
+    expect(show).toHaveBeenLastCalledWith('second line…')
+  })
+})

--- a/telegram-plugin/tests/narrative-splice-before-finalize.test.ts
+++ b/telegram-plugin/tests/narrative-splice-before-finalize.test.ts
@@ -1,0 +1,167 @@
+/**
+ * narrative-splice-before-finalize.test.ts — the gateway-level anti-double-print
+ * guarantee for the TIMER early-paint path.
+ *
+ * ## What this proves
+ * The kernel unit tests (narrative-flush.test.ts) prove the controller EMITS a
+ * RETRACT effect. They do NOT prove the load-bearing gateway wiring: that the
+ * RETRACT effect splices `mirrorLines` synchronously BEFORE the finalize render
+ * (`clearActivitySummary` → `composeTurnActivity(final)`) reads that same array,
+ * so a narration the timer painted early and that turned out to draft the reply
+ * appears ZERO times in the finalized card.
+ *
+ * This test reconstructs the gateway's OWN effect wiring 1:1 with
+ * `makeNarrativeGate` (gateway.ts): a shared `mirrorLines` array, a `show`
+ * effect that mirrors `showNarrativeStep`'s core
+ * (`appendActivityLabel(mirrorLines, clipNarrative(text))`), and a `retractShown`
+ * effect that mirrors `retractNarrativeLine`'s core (splice the
+ * `lastIndexOf(clipNarrative(text))` entry). The finalize render reads the SAME
+ * live array. It drives the REAL `NarrativeFlushController`, the REAL render
+ * helpers, and a REAL `setTimeout`-based scheduler under fake timers — every
+ * assertion is an outcome.
+ *
+ * ## Red-on-regression
+ *   - If the RETRACT effect were removed / made a no-op, the timer-painted line
+ *     stays in `mirrorLines` and the finalize render contains it → RED.
+ *   - If the finalize render were reordered to read a snapshot taken BEFORE the
+ *     retract splice (the "splice-after-finalize" reordering), the snapshot still
+ *     holds the line → RED. (Modeled here by taking the finalize snapshot AFTER
+ *     `resolveOnTool`, exactly as the gateway sequences retract-then-finalize.)
+ *
+ * ## Honest limits
+ * gateway.ts does NOT export `showNarrativeStep` / `retractNarrativeLine` /
+ * `composeTurnActivity` / `clearActivitySummary`, so this test cannot invoke
+ * those private functions directly — it reconstructs their effect bodies against
+ * the real shared helpers. It therefore locks the CONTRACT (splice-before-read,
+ * clipped-line matching, retract-empties-cleanly) but would not catch a future
+ * edit that diverges the gateway's private effect bodies from this reconstruction
+ * without also updating this test. The kernel test covers the controller; this
+ * test covers the mirrorLines splice/finalize contract they compose into.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NarrativeFlushController } from '../narrative-flush.js'
+import {
+  clipNarrative,
+  appendActivityLabel,
+  renderActivityFeedWithNested,
+} from '../tool-activity-summary.js'
+
+const FLUSH_MS = 250
+
+/** Count non-overlapping occurrences of `needle` in `haystack`. */
+function occurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0
+  let count = 0
+  let from = 0
+  for (;;) {
+    const at = haystack.indexOf(needle, from)
+    if (at === -1) return count
+    count++
+    from = at + needle.length
+  }
+}
+
+describe('gateway wiring: retract splices mirrorLines BEFORE finalize reads it', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  /**
+   * Build the SAME effect wiring `makeNarrativeGate` builds, over a shared
+   * `mirrorLines` array, with a real setTimeout scheduler (mirrors the gateway's
+   * `unref`'d setTimeout wiring).
+   */
+  function wireGate() {
+    const mirrorLines: string[] = []
+    let handle: ReturnType<typeof setTimeout> | null = null
+    const controller = new NarrativeFlushController(
+      {
+        // showNarrativeStep core: append the clipped narrative as a feed line.
+        show: (text) => {
+          appendActivityLabel(mirrorLines, clipNarrative(text))
+        },
+        // retractNarrativeLine core: splice the clipped line out of mirrorLines.
+        retractShown: (text) => {
+          const clipped = clipNarrative(text)
+          const idx = mirrorLines.lastIndexOf(clipped)
+          if (idx === -1) return
+          mirrorLines.splice(idx, 1)
+        },
+      },
+      {
+        arm: (fn, ms) => {
+          if (handle != null) clearTimeout(handle)
+          handle = setTimeout(fn, ms)
+          handle.unref?.()
+        },
+        disarm: () => {
+          if (handle != null) {
+            clearTimeout(handle)
+            handle = null
+          }
+        },
+      },
+      FLUSH_MS,
+    )
+    // composeTurnActivity(final) core: render the SAME live mirrorLines array.
+    const finalize = () => renderActivityFeedWithNested(mirrorLines, [], true)
+    return { controller, mirrorLines, finalize }
+  }
+
+  it('early-painted narration that drafts the reply appears ZERO times in the finalized card', () => {
+    const { controller, mirrorLines, finalize } = wireGate()
+    const narration = 'The migration completed and all 40 rows were backfilled cleanly.'
+    const reply = 'The migration completed and all 40 rows were backfilled cleanly.'
+    const clipped = clipNarrative(narration)
+
+    // 1. Stage the opening narration (parked, timer armed).
+    controller.stage(narration)
+
+    // 2. Fire the early-paint timer → SHOW paints the line into mirrorLines.
+    vi.advanceTimersByTime(FLUSH_MS)
+    expect(mirrorLines).toContain(clipped)
+    // Sanity: before retract, a finalize WOULD have shown the line (proves the
+    // assertion below is meaningful, not vacuously passing on an empty feed).
+    expect(occurrences(finalize() ?? '', clipped)).toBe(1)
+
+    // 3. Deliver the matching reply (draft-then-send) → RETRACT splices the line.
+    controller.resolveOnTool('reply', { text: reply })
+
+    // 4. Finalize reads the SAME (now-spliced) array → line appears ZERO times.
+    const finalRender = finalize()
+    expect(occurrences(finalRender ?? '', clipped)).toBe(0)
+  })
+
+  it('a genuinely different early-painted narration survives finalize exactly once (no over-retract)', () => {
+    const { controller, mirrorLines, finalize } = wireGate()
+    const narration = 'Running the integration suite against staging'
+    const reply = 'All checks passed — deployed to production.'
+    const clipped = clipNarrative(narration)
+
+    controller.stage(narration)
+    vi.advanceTimersByTime(FLUSH_MS)
+    controller.resolveOnTool('reply', { text: reply })
+
+    // Not a draft of the reply → NOT retracted → present exactly once.
+    expect(mirrorLines).toContain(clipped)
+    expect(occurrences(finalize() ?? '', clipped)).toBe(1)
+  })
+
+  it('retract that empties the feed collapses composeTurnActivity to null (interim-ack anti-blank guard input)', () => {
+    // Documents the LOW cosmetic case: when the ONLY feed line is retracted, the
+    // live re-render collapses to null and the guard leaves the stale line up
+    // until the next event. Here we assert the *finalize* is clean (no double
+    // print) even though the interim live render would be null.
+    const { controller, mirrorLines, finalize } = wireGate()
+    const narration = 'Drafting the summary of the deploy'
+    const reply = 'Drafting the summary of the deploy'
+    controller.stage(narration)
+    vi.advanceTimersByTime(FLUSH_MS)
+    controller.resolveOnTool('reply', { text: reply })
+    expect(mirrorLines).toHaveLength(0)
+    // Empty feed → renderActivityFeedWithNested returns null (the anti-blank
+    // guard's null input). The finalized card carries the narration ZERO times.
+    const finalRender = finalize()
+    expect(finalRender == null || occurrences(finalRender, clipNarrative(narration)) === 0).toBe(true)
+  })
+})


### PR DESCRIPTION
## The gap
The progress card showed the agent's opening narration ("On it, pulling the logs…") only at the **first real `tool_use`**, not at turn start. The narration is the model's own assistant `text` block, surfaced as a transient card step.

**Root cause** — the deliberate one-step-deferred narrative-dedup gate. `stagePendingNarrative` parks the text block in `turn.pendingNarrative` and paints nothing; the parked block flushes only on the NEXT session event (`tool_use` → `resolvePendingNarrativeOnTool`, a later `text`, or `turn_end` → `flushPendingNarrativeAtTurnEnd`). On a normal turn the next event is the first tool, so the opening narration waited for it. The defer exists because a projector sees one line at a time and can't yet know whether the next line is a `reply` that would make this block the outgoing answer (which must NOT surface as a narration step — the anti-double-print guarantee). Side effect: the visible dead-air gap while the agent thinks before its first tool.

## The fix — time-boxed flush
Keep the gate, add a deterministic timer. When a block is parked, arm a short timer (`PENDING_NARRATIVE_FLUSH_MS = 250ms`, a named const). If a lookahead event arrives first, the existing flush path resolves it and the timer is **cancelled**; if the timer fires first, the parked narration paints via the same `showNarrativeStep` path. Narration now surfaces ~250ms into the turn instead of at the first tool.

## How the anti-double-print guarantee is preserved (the key correctness point)
Deterministically, **not** by hoping the 250ms window hides a slow-reply race:

- A block the timer painted early is remembered (`timerShown`).
- When the `reply`/`stream_reply` lookahead finally lands — on a tool_use or at `turn_end` — if it is a draft-then-send of that block (`isDraftOfReply`, the same test the deferred gate uses), the shown step is **RETRACTED**: spliced out of `mirrorLines`. The splice runs synchronously **before** the reply's `clearActivitySummary` finalize reads `mirrorLines`, so the persisted (and live) card never surfaces the outgoing answer as a narration step AND as the canonical reply.

The retract is the guarantee; the timer is only the early-paint trigger — correctness does not depend on the window winning the race.

**Leak safety:** at most one timer per turn (re-stage/`resolveOnTool`/`flushAtTurnEnd` all disarm first), disarmed on `turn_end`, on turn teardown (`endCurrentTurnAtomic`), and every early-return; the real timer is `unref`'d.

## Design — pure, testable kernel
The park/timer/retract state machine is extracted into `telegram-plugin/narrative-flush.ts` (`NarrativeFlushController`), a pure, fully-unit-testable kernel companion to `narrative-dedup.ts`, with injected effects (`show` / `retractShown`) + scheduler. The gateway wires it with real `showNarrativeStep`, the `mirrorLines` splice + re-render, and an `unref`'d `setTimeout`.

## Window const
`PENDING_NARRATIVE_FLUSH_MS = 250` (`telegram-plugin/gateway/gateway.ts`).

## Sub-agent / worker card
The worker card's parking logic is a **NON-shared mirror** (subagent-watcher inlines its own `entry.pendingNarrative`; it does not call `stagePendingNarrative`), it paints via **replace-on-write `onProgress`** (not the append feed), and it is **clock-injected / polling-driven** (`nowFn`). A real-time `setTimeout` early-paint is an architectural mismatch there, and the main-agent double-print class (persistent card step + separate reply message) is structurally absent because the worker card is a replace-on-write status row whose `latestSummary` IS the worker's result. Left as-is; the requirement's "fix both if the parking logic is shared" condition is false.

## Tests (assert outcomes)
`telegram-plugin/tests/narrative-flush.test.ts` — 12 tests on the real kernel with a fake scheduler:
- early paint: no paint on stage alone; paints once when the timer fires with NO lookahead (RED on pre-fix, which never armed a timer)
- fast tool: a lookahead before the window paints once and cancels the timer; a stale fire is inert
- anti-double-print, deferred path: a draft-then-send reply is never shown
- anti-double-print, TIMER path: a timer-painted block that proves to draft the reply (on tool OR at turn_end) is retracted, never re-shown
- leak safety: teardown / turn_end disarm; stale fires inert; at-most-one armed

Updated `emission-authority-facade.test.ts` source-count guards (7→8 `mayDrain` guards / `cardDrainGate` wraps) for the new narrative-retract drain site.

## Scoped results
- `narrative-flush.test.ts`: 12 passed
- narration/emission/liveness/feed/activity sweep (26 files): **516 passed**
- `npm run lint` (tsc --noEmit + 8 guards): clean

CI is the full-suite authority. Do not merge — adversarial review + merge on CI green is the reviewer's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)