### PR TITLE
fix(telegram): restore idempotent paragraph spacer — \n\n renders tight, not blank (revert #3208 F1)

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -480,14 +480,167 @@ export function hardenCardBreaks(text: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Paragraph spacing note (#2669 follow-up): the NBSP paragraph-spacer
-// (PARAGRAPH_SPACER / addParagraphSpacers) was REMOVED. Its premise — that the
-// Bot API 10.1 rich (GFM) renderer collapses a `\n\n` gap TIGHT — is false for
-// the live renderer, which shows a `\n\n` gap as a normal single blank line.
-// The old U+00A0 spacer therefore injected a spurious SECOND blank line
-// (`\n\n \n\n`) between every paragraph fleet-wide. Paragraph spacing now
-// relies on the plain `\n\n` that normalizeParagraphBreaks already guarantees
-// at block boundaries — one correct single blank line, no spacer pass.
+// Paragraph spacers — restore a VISIBLE blank line between prose paragraphs
+// ---------------------------------------------------------------------------
+
+/**
+ * The non-collapsible spacer paragraph injected between two prose paragraphs.
+ *
+ * Telegram's Bot API 10.1 rich-message renderer (the GFM/CommonMark engine
+ * behind `sendRichMessage` / `editMessageText({ markdown })`, and the in-repo
+ * IR renderer in `render/` that feeds it) renders a `\n\n` paragraph break
+ * TIGHT — the two paragraphs sit on adjacent lines with no visible empty line
+ * between them (live-confirmed: an outbound message with real `\n\n` gaps
+ * renders jammed; only list/table BLOCK boundaries produce a visible gap). The
+ * legacy markdown→HTML path (removed in #2669) sent `\n\n` literally with
+ * `parse_mode:"HTML"`, where two newlines render as a real blank line. That
+ * regression is the operator-confirmed "paragraphs jammed together" symptom
+ * (#2692).
+ *
+ * CommonMark discards blank lines made of ASCII whitespace, but a line whose
+ * only content is a NON-breaking space (U+00A0) is a genuine, non-empty
+ * paragraph — it renders as a visible empty line. So `A\n\n \n\nB` renders as
+ * three paragraphs: A, a blank-looking line, then B — the visible gap the HTML
+ * path used to produce. This survives the in-repo IR renderer's re-parse /
+ * re-render (verified: a U+00A0-only line round-trips intact, while an
+ * ASCII-space-only line is collapsed to a tight `\n\n`), so it reaches the wire
+ * whether `SWITCHROOM_RICH_RENDER` is on (default) or off.
+ */
+export const PARAGRAPH_SPACER = ' '
+
+/**
+ * Insert a visible blank-line spacer into each genuine `\n\n` paragraph gap so
+ * the rich GFM renderer shows a real empty line between paragraphs (matching
+ * the pre-#2669 HTML behaviour). See PARAGRAPH_SPACER for why a U+00A0 line is
+ * the reliable trick.
+ *
+ * Uniform-block-spacing contract: a spacer is inserted into EVERY `\n\n` gap
+ * that separates two DISTINCT blocks — prose→prose, paragraph→list,
+ * list→paragraph, heading→anything, blockquote/table/fence boundaries — so a
+ * mixed message renders with one identical visible blank line between blocks.
+ * The one exception is a gap INSIDE a block of the same structural kind (two
+ * items of a loose list, consecutive table rows/quotes/fences): those stay
+ * tight so the block's contiguity survives. Interiors joined by a single `\n`
+ * are never gaps at all and are untouched by construction.
+ *
+ * Runs on code-masked text (so a blank line inside a fenced block is never
+ * touched).
+ *
+ * IDEMPOTENT & DOUBLE-GAP-PROOF (the #3208 regression this restores fixes):
+ * each inter-block gap — whatever it originally holds (a bare `\n\n`, a
+ * pre-existing U+00A0 spacer `\n\n \n\n`, a stray extra blank line `\n\n\n`, an
+ * ASCII-space-only line) — is CANONICALISED to exactly one form: `\n\n`
+ * (tight) or `\n\n${PARAGRAPH_SPACER}\n\n` (spaced). It therefore inserts
+ * EXACTLY ONE spacer per spaced gap and can never stack a second, and running
+ * the pass twice yields the same output as running it once. #3208 removed the
+ * whole mechanism to kill a double-gap; the correct fix was to make the gap
+ * canonical (this), not to delete the spacer and reintroduce the jammed-
+ * paragraph symptom fleet-wide.
+ *
+ * Intended to run in the outbound send path AFTER normalizeParagraphBreaks
+ * (which has already collapsed 3+ newline runs to `\n\n` and guaranteed
+ * block-boundary blank lines) — but the canonicalisation above means it is
+ * safe on un-normalized text too (e.g. the edit path).
+ */
+export function addParagraphSpacers(text: string): string {
+  if (!text.includes('\n\n')) return text
+
+  const nonce = Math.random().toString(36).slice(2)
+  const { masked, restore, placeholder } = maskCodeRegions(text, nonce)
+
+  if (!masked.includes('\n\n')) return restore(masked)
+
+  const SP = PARAGRAPH_SPACER
+
+  // ASCII-only trim (preserve U+00A0): `String.prototype.trim()` strips U+00A0,
+  // so a spacer line would read as "blank"; trimming ASCII whitespace only
+  // keeps the spacer line recognisable as content.
+  const asciiTrim = (line: string): string =>
+    line.replace(/^[ \t\r\f\v]+|[ \t\r\f\v]+$/g, '')
+
+  // "Blank-ish" = a line that renders as an empty paragraph: ASCII-whitespace-
+  // only, OR a line whose only non-ASCII-whitespace content is the U+00A0
+  // spacer. Coalescing BOTH kinds into one gap is what makes the pass
+  // idempotent and double-gap-proof — a pre-existing spacer or extra blank line
+  // is absorbed into the gap and re-emitted canonically, never stacked.
+  const isBlankish = (line: string): boolean => {
+    const t = asciiTrim(line)
+    return t === '' || t === SP
+  }
+
+  // Classify the block kind of a facing content line so the spacer decision can
+  // be made per BLOCK TRANSITION (#uniform-block-spacing). A spacer is inserted
+  // at every gap between two DIFFERENT block kinds and between two prose
+  // paragraphs, but NEVER inside a single block's interior (two items of the
+  // same loose list, two rows of a table, consecutive quotes/fences/dividers).
+  type BlockKind = 'list' | 'table' | 'quote' | 'heading' | 'fence' | 'divider' | 'prose'
+  const blockKind = (line: string): BlockKind => {
+    if (isFenceOpenLine(line, placeholder)) return 'fence'
+    if (isListItemLine(line)) return 'list'
+    if (isTableRowLine(line) || isTableDelimiterLine(line)) return 'table'
+    if (isBlockquoteLine(line)) return 'quote'
+    if (isHeadingLine(line)) return 'heading'
+    if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(line.trimStart())) return 'divider'
+    return 'prose'
+  }
+
+  // Same-kind structural pairs whose gap is a block INTERIOR — no spacer there.
+  const SAME_KIND_TIGHT: ReadonlySet<BlockKind> = new Set([
+    'list',
+    'table',
+    'quote',
+    'fence',
+    'divider',
+  ])
+
+  const shouldSpaceGap = (above: string, below: string): boolean => {
+    const a = blockKind(above)
+    const b = blockKind(below)
+    if (a === b && SAME_KIND_TIGHT.has(a)) return false
+    // Everything else is a genuine block transition (incl. prose→prose,
+    // heading→anything, list↔paragraph, table/quote boundaries) — space it.
+    return true
+  }
+
+  // Tokenize into CONTENT runs (consecutive non-blank-ish lines, joined by a
+  // single `\n` — soft breaks stay inside a content block) and GAP runs
+  // (consecutive blank-ish lines). Tokens strictly alternate by construction.
+  type Tok = { kind: 'content' | 'gap'; lines: string[] }
+  const toks: Tok[] = []
+  for (const line of masked.split('\n')) {
+    const kind = isBlankish(line) ? 'gap' : 'content'
+    const last = toks[toks.length - 1]
+    if (last && last.kind === kind) last.lines.push(line)
+    else toks.push({ kind, lines: [line] })
+  }
+
+  // Rebuild. A CONTENT token re-emits its lines verbatim. An INTER-content GAP
+  // (a gap flanked by content on BOTH sides) is re-emitted in canonical form —
+  // one blank line (`''` → `\n\n`) for a tight gap, or `['', SP, '']`
+  // (→ `\n\n${SP}\n\n`) for a spaced gap — discarding whatever it held. A
+  // leading/trailing gap (no content on one side, only possible before the
+  // first / after the last content block) is preserved verbatim.
+  const out: string[] = []
+  for (let i = 0; i < toks.length; i++) {
+    const tok = toks[i]
+    if (tok.kind === 'content') {
+      out.push(...tok.lines)
+      continue
+    }
+    const prev = toks[i - 1]
+    const next = toks[i + 1]
+    if (prev?.kind === 'content' && next?.kind === 'content') {
+      const above = prev.lines[prev.lines.length - 1]
+      const below = next.lines[0]
+      if (shouldSpaceGap(above, below)) out.push('', SP, '')
+      else out.push('')
+    } else {
+      out.push(...tok.lines)
+    }
+  }
+
+  return restore(out.join('\n'))
+}
 
 // ---------------------------------------------------------------------------
 // Punctuation / bullet normalization — fleet-wide consistent typography
@@ -1006,26 +1159,32 @@ export function splitMarkdownChunks(text: string, maxLen = RICH_MESSAGE_MAX_CHAR
 }
 
 /**
- * Strip stray blank lines off a chunk boundary so a cut that lands in a `\n\n`
- * paragraph gap never leaves a continuation chunk that OPENS with a bare blank
- * line, nor a prior chunk that ENDS with one.
+ * Strip stray paragraph-spacer / blank lines off a chunk boundary so a cut that
+ * lands inside an injected spacer gap (`\n\n${PARAGRAPH_SPACER}\n\n`, see
+ * addParagraphSpacers) never leaves a continuation chunk that OPENS with a bare
+ * U+00A0 spacer line, nor a prior chunk that ENDS with one.
  *
- * (Pre-#2669-follow-up this also peeled the NBSP paragraph spacer that
- * addParagraphSpacers injected into every gap. That spacer pass was removed —
- * gaps are now plain `\n\n` — so this reduces to the original behaviour: strip
- * a run of ASCII-whitespace-only blank lines off the boundary.) Idempotent: a
- * chunk already trimmed has nothing left to strip.
+ * A "boundary blank run" is any sequence of newlines and spacer-only lines (a
+ * line whose only content is the U+00A0 spacer, optionally surrounded by ASCII
+ * spaces/tabs) in ANY interleaving — `\n \n`, ` \n\n`, `\n\n \n`, etc. The
+ * legacy behaviour (strip leading ASCII `\n+` only) is a strict subset, so a
+ * boundary with NO spacer is unaffected. Idempotent: a chunk already trimmed
+ * has nothing left to strip.
  *
  *  - `'leading'`  → strip the run from the START (the continuation chunk).
  *  - `'trailing'` → strip the run from the END (the just-emitted prior chunk).
  */
 function stripBoundarySpacers(chunk: string, side: 'leading' | 'trailing'): string {
-  // A boundary blank run is one-or-more lines that render empty (ASCII
-  // whitespace only). Peel it off the requested side.
+  // One blank-or-spacer line: optional ASCII ws, optional one U+00A0, optional
+  // ASCII ws — i.e. a line that renders empty. A run of these (joined by \n,
+  // with leading/trailing \n) is what we peel off the boundary.
+  const sp = PARAGRAPH_SPACER
   if (side === 'leading') {
-    return chunk.replace(/^(?:[ \t]*\n)+/, '')
+    // Leading: one-or-more newlines, optionally with spacer-only lines mixed in.
+    return chunk.replace(new RegExp(`^(?:[ \\t]*${sp}?[ \\t]*\\n+)+`), '')
   }
-  return chunk.replace(/(?:\n[ \t]*)+$/, '')
+  // Trailing: a newline run, optionally with spacer-only lines, at the very end.
+  return chunk.replace(new RegExp(`(?:\\n+[ \\t]*${sp}?[ \\t]*)+$`), '')
 }
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -349,7 +349,7 @@ const REPLY_TO_TEXT_MAX = 200
 // #1161 silent-end fallback text now lives in ../silent-end.ts
 // (`silentEndFallbackText`, imported above) so the transport-boundary
 // tests exercise the real string — see PR #2892.
-import { splitMarkdownChunks, repairEscapedWhitespace, normalizeParagraphBreaks, normalizePunctuation, stripExcessBold, escapeMarkdown, hardenCardBreaks, RICH_MESSAGE_MAX_CHARS } from '../format.js'
+import { splitMarkdownChunks, repairEscapedWhitespace, normalizeParagraphBreaks, addParagraphSpacers, normalizePunctuation, stripExcessBold, escapeMarkdown, hardenCardBreaks, RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { richMessage } from '../rich-send.js'
 import { scrubVoice } from '../text-voice-scrub.js'
 import {
@@ -15131,11 +15131,10 @@ async function executeEditMessage(args: Record<string, unknown>): Promise<unknow
   // secret into a live bubble or the history row. Mask before scrub/send.
   editRawText = redactOutboundText(editRawText, 'edit_message')
   // Fleet-wide consistent formatting (same order as the reply path: redact
-  // first so secrets are matched literally, then normalize). No paragraph
-  // spacer pass — the NBSP spacer was removed in the #2669 follow-up because it
-  // double-gapped every paragraph; the rich renderer already shows `\n\n` as
-  // one blank line.
-  if (!editLiteralText) editRawText = stripExcessBold(normalizePunctuation(editRawText))
+  // first so secrets are matched literally, then normalize, then spacers on
+  // the rich path only — the rich GFM renderer renders `\n\n` tight, so the
+  // idempotent U+00A0 spacer restores a visible gap without double-spacing).
+  if (!editLiteralText) editRawText = addParagraphSpacers(stripExcessBold(normalizePunctuation(editRawText)))
   // Voice scrub (#1683): same em-dash scrub as the reply path. Edits
   // are how silent-anchor and progress-update mutate already-sent
   // bubbles, so without this an edit can re-introduce dashes the
@@ -17916,12 +17915,14 @@ function handleSessionEvent(ev: SessionEvent): void {
           // real outcome (throw OR partial multi-chunk → send_failed).
           let sendThrew = false
           try {
-            // The `\n\n` block joins from turn-flush-safety.ts render as normal
-            // single blank lines under the Bot API 10.1 rich GFM path, so no
-            // spacer pass runs before splitting (the NBSP spacer was removed in
-            // the #2669 follow-up — it double-gapped every paragraph). Mirrors
-            // executeReply, which now also sends the normalized text as-is.
-            const renderedText = capturedText
+            // #2798 / #2692 — inject visible blank-line spacers into prose `\n\n`
+            // gaps before splitting, exactly as executeReply does. The rich GFM
+            // renderer collapses a bare `\n\n` gap TIGHT, so without this the
+            // paragraph boundaries from the '\n\n' block join (turn-flush-safety
+            // .ts) would still render jammed together. Mirrors reply's
+            // `addParagraphSpacers(text)` on the non-literal path (idempotent —
+            // exactly one U+00A0 spacer per gap, never doubled).
+            const renderedText = addParagraphSpacers(capturedText)
             htmlChunks = splitMarkdownChunks(renderedText, limit)
             // #654 deterministic double-message fix. If the progress
             // card is on screen (60s timer fired before turn_end), edit

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -27,6 +27,7 @@ import {
   normalizeParagraphBreaks,
   normalizePunctuation,
   stripExcessBold,
+  addParagraphSpacers,
   splitMarkdownChunks,
   hardSliceToCap,
   RICH_MESSAGE_MAX_CHARS,
@@ -87,16 +88,15 @@ export function normalizeOutboundBody(
 }
 
 /**
- * Effective-text stage. Historically this injected an NBSP paragraph spacer on
- * the rich path (#2669) to force a visible gap; that pass was removed in the
- * #2669 follow-up because the live Bot API 10.1 GFM renderer already renders a
- * `\n\n` gap as one normal blank line — the spacer was double-gapping every
- * paragraph. Both paths now pass the text through byte-identically; the stage
- * is retained as the named pipeline seam (and the literal/rich distinction is
- * kept for callers) so a future rich-only transform has a home. Pure.
+ * Effective-text spacing (#2669 rich-message regression fix, restored after the
+ * #3208 F1 misfire). The Bot API 10.1 rich GFM renderer (and the in-repo IR
+ * renderer that feeds it) renders a prose `\n\n` gap TIGHT, so paragraphs render
+ * jammed together. Inject a visible U+00A0 blank-line spacer into each block
+ * gap on the rich path only (idempotent — see addParagraphSpacers); the literal
+ * (`format:'text'`) path stays byte-exact. Pure.
  */
-export function computeEffectiveText(text: string, _literalText: boolean): string {
-  return text
+export function computeEffectiveText(text: string, literalText: boolean): string {
+  return literalText ? text : addParagraphSpacers(text)
 }
 
 /**

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -171,6 +171,14 @@ export interface StreamReplyDeps {
    * after normalizePunctuation. Optional for backward compat.
    */
   stripExcessBold?: (text: string) => string
+  /**
+   * Insert a visible blank-line spacer into each prose `\n\n` gap so the rich
+   * GFM renderer shows a real empty line between paragraphs (the rich engine
+   * otherwise renders `\n\n` tight — the post-#2669 paragraph-spacing
+   * regression). Applied only on the rich path (never on `format:'text'`).
+   * Optional for backward compat; omitted → no spacers added.
+   */
+  addParagraphSpacers?: (text: string) => string
   /** Validates the chat id against the access list. Throws on deny. */
   assertAllowedChat: (chatId: string) => void
   /** Resolves the effective thread id (explicit, last-inbound, or undefined). */
@@ -354,11 +362,12 @@ export async function handleStreamReply(
   // markdown→HTML / MarkdownV2 rendering happens here anymore — the raw
   // text IS the wire payload.
   const literalText = format === 'text'
-  // No paragraph-spacer pass: the NBSP spacer (#2669) was removed in the
-  // follow-up because the Bot API 10.1 rich GFM renderer already shows a `\n\n`
-  // gap as one blank line — the spacer double-gapped every paragraph. The raw
-  // text (already normalized upstream) is the effective text on both paths.
-  let effectiveText: string = rawText
+  // Paragraph-spacing fix (rich-message regression after #2669): inject a
+  // visible blank-line spacer into prose `\n\n` gaps on the rich path so
+  // multi-paragraph answers don't render jammed together. The literal
+  // (`format:'text'`) path must stay byte-exact, so it is left untouched.
+  let effectiveText: string =
+    !literalText && deps.addParagraphSpacers ? deps.addParagraphSpacers(rawText) : rawText
 
   // Inline status-accent header (issue #320 fallback). Prepended so it
   // leads the body. Since stream_reply callers pass the full text snapshot

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -1,10 +1,12 @@
 /**
  * Tests for the fleet-wide consistent-formatting bundle:
  *
- *   1. paragraph gap spacing — a plain `\n\n` (one blank line) at EVERY block
+ *   1. addParagraphSpacers — a visible U+00A0 spacer line at EVERY block
  *      transition (paragraph→list, list→paragraph, heading→anything,
- *      blockquote/table boundaries), never a double blank line and never an
- *      NBSP spacer (the old spacer pass was removed in the #2669 follow-up).
+ *      blockquote/table boundaries), idempotent and double-gap-proof; list/
+ *      table interiors stay tight. Restored after the #3208 F1 misfire — the
+ *      rich GFM renderer renders a bare `\n\n` gap TIGHT, so the spacer is what
+ *      produces the visible paragraph gap.
  *   2. normalizePunctuation — em/en dashes → comma/hyphen, leading `•`/`·`
  *      list markers → `- `, on code-masked text, idempotent; link hrefs are
  *      protected from dash rewriting.
@@ -13,12 +15,16 @@
  */
 import { describe, test, expect } from 'vitest'
 import {
+  addParagraphSpacers,
   normalizeParagraphBreaks,
   normalizePunctuation,
   stripExcessBold,
   splitMarkdownChunks,
   hardenCardBreaks,
+  PARAGRAPH_SPACER,
 } from '../format.js'
+
+const SP = PARAGRAPH_SPACER // U+00A0
 
 describe('hardenCardBreaks — deterministic card line-break hardener', () => {
   test('promotes lone field breaks to GFM hard breaks (the blob fix)', () => {
@@ -98,60 +104,74 @@ describe('hardenCardBreaks — deterministic card line-break hardener', () => {
   })
 })
 
-describe('paragraph gap spacing — plain single blank line, no NBSP', () => {
-  const NBSP = String.fromCharCode(0xa0)
-
-  test('prose→prose gap is one blank line, no NBSP', () => {
-    const out = normalizeParagraphBreaks('Alpha.\n\nBravo.')
-    expect(out).toBe('Alpha.\n\nBravo.')
-    expect(out).not.toContain(NBSP)
+describe('addParagraphSpacers — uniform block spacing', () => {
+  test('still spaces prose→prose (existing behaviour)', () => {
+    const out = addParagraphSpacers('Alpha.\n\nBravo.')
+    expect(out).toBe(`Alpha.\n\n${SP}\n\nBravo.`)
   })
 
-  test('paragraph→list transition is a single `\\n\\n` boundary', () => {
-    expect(normalizeParagraphBreaks('Intro.\n\n- one\n- two')).toBe('Intro.\n\n- one\n- two')
+  test('spaces paragraph→list transition', () => {
+    const out = addParagraphSpacers('Intro.\n\n- one\n- two')
+    expect(out).toBe(`Intro.\n\n${SP}\n\n- one\n- two`)
   })
 
-  test('list→paragraph transition is a single `\\n\\n` boundary', () => {
-    expect(normalizeParagraphBreaks('- one\n- two\n\nOutro.')).toBe('- one\n- two\n\nOutro.')
+  test('spaces list→paragraph transition', () => {
+    const out = addParagraphSpacers('- one\n- two\n\nOutro.')
+    expect(out).toBe(`- one\n- two\n\n${SP}\n\nOutro.`)
   })
 
-  test('heading→anything is a single `\\n\\n` boundary', () => {
-    expect(normalizeParagraphBreaks('# Title\n\nBody.')).toBe('# Title\n\nBody.')
-    expect(normalizeParagraphBreaks('# Title\n\n- a\n- b')).toBe('# Title\n\n- a\n- b')
+  test('spaces heading→anything', () => {
+    expect(addParagraphSpacers('# Title\n\nBody.')).toBe(`# Title\n\n${SP}\n\nBody.`)
+    expect(addParagraphSpacers('# Title\n\n- a\n- b')).toBe(`# Title\n\n${SP}\n\n- a\n- b`)
   })
 
-  test('blockquote and table boundaries are single `\\n\\n`', () => {
-    expect(normalizeParagraphBreaks('> quoted\n\nProse.')).toBe('> quoted\n\nProse.')
+  test('spaces blockquote and table boundaries', () => {
+    expect(addParagraphSpacers('> quoted\n\nProse.')).toBe(`> quoted\n\n${SP}\n\nProse.`)
     const table = '| a | b |\n| --- | --- |\n| 1 | 2 |'
-    expect(normalizeParagraphBreaks(`Prose.\n\n${table}`)).toBe(`Prose.\n\n${table}`)
-    expect(normalizeParagraphBreaks(`${table}\n\nProse.`)).toBe(`${table}\n\nProse.`)
+    expect(addParagraphSpacers(`Prose.\n\n${table}`)).toBe(`Prose.\n\n${SP}\n\n${table}`)
+    expect(addParagraphSpacers(`${table}\n\nProse.`)).toBe(`${table}\n\n${SP}\n\nProse.`)
+  })
+
+  test('does NOT space between items of the same loose list', () => {
+    const input = '- one\n\n- two\n\n- three'
+    expect(addParagraphSpacers(input)).toBe(input)
+  })
+
+  test('does NOT space inside a tight list or table interior (single \\n)', () => {
+    const list = 'Intro.\n\n- a\n- b\n- c'
+    expect(addParagraphSpacers(list)).toBe(`Intro.\n\n${SP}\n\n- a\n- b\n- c`)
+    const table = '| a |\n| --- |\n| 1 |\n| 2 |'
+    expect(addParagraphSpacers(table)).toBe(table)
+  })
+
+  test('idempotent across every transition kind', () => {
+    const input = '# H\n\nProse one.\n\n- a\n- b\n\nProse two.\n\n> quote'
+    const once = addParagraphSpacers(input)
+    expect(addParagraphSpacers(once)).toBe(once)
   })
 
   test('never touches code fences', () => {
     const input = '```\nA\n\nB\n```\n\n```\nC\n```'
-    expect(normalizeParagraphBreaks(input)).toBe(input)
+    expect(addParagraphSpacers(input)).toBe(input)
   })
 
-  test('full pipeline: mixed prose+list message gets single-blank-line gaps, no NBSP, no double gap', () => {
-    const raw = 'Summary line.\n\n- item one\n- item two\n\nClosing prose.'
-    const out = normalizeParagraphBreaks(raw)
-    expect(out).toBe('Summary line.\n\n- item one\n- item two\n\nClosing prose.')
-    expect(out).not.toContain(NBSP)
-    expect(out).not.toMatch(/\n\n\n/)
+  test('full pipeline: mixed prose+list+heading message gets uniform gaps', () => {
+    const raw = 'Summary line.\n- item one\n- item two\nClosing prose.'
+    const out = addParagraphSpacers(normalizeParagraphBreaks(raw))
+    // Every block transition carries exactly one visible spacer line.
+    expect(out).toBe(
+      `Summary line.\n\n${SP}\n\n- item one\n- item two\n\n${SP}\n\nClosing prose.`,
+    )
   })
 
-  test('chunk-boundary interaction: a cut in a `\\n\\n` gap leaves clean chunks (no stray blank lines)', () => {
+  test('chunk-boundary interaction: a cut in a spacer gap strips the spacer', () => {
     const a = 'A'.repeat(60)
     const b = 'B'.repeat(60)
-    const text = `${a}\n\n${b}`
+    const text = `${a}\n\n${SP}\n\n${b}`
     const chunks = splitMarkdownChunks(text, 80)
     expect(chunks.length).toBe(2)
     expect(chunks[0]).toBe(a)
     expect(chunks[1]).toBe(b)
-    // Neither chunk opens or ends with a stray blank line.
-    for (const c of chunks) {
-      expect(c).toBe(c.replace(/^\n+|\n+$/g, ''))
-    }
   })
 })
 

--- a/telegram-plugin/tests/formatting-parse-regression.test.ts
+++ b/telegram-plugin/tests/formatting-parse-regression.test.ts
@@ -17,10 +17,9 @@
  *       fixture intended (bold/italic/code/pre/link at the right inner text).
  *
  * The pipeline mirrors `telegram-plugin/gateway/gateway.ts`:
- *   repairEscapedWhitespace -> normalizeParagraphBreaks -> splitMarkdownChunks.
- *   (No paragraph-spacer pass — the NBSP spacer was removed in the #2669
- *   follow-up; gaps are plain `\n\n`. Card-surface fixtures also apply
- *   `normalizeDashes` first — that is where F1's voice scrub lives.)
+ *   repairEscapedWhitespace -> normalizeParagraphBreaks -> addParagraphSpacers
+ *   -> splitMarkdownChunks. (Card-surface fixtures also apply `normalizeDashes`
+ *   first — that is where F1's voice scrub lives.)
  *
  * This suite is TEST-ONLY. It changes no production formatting behaviour. If a
  * fixture ever fails signal (a), it means the formatter emits markdown Telegram
@@ -31,6 +30,7 @@ import { describe, test, expect } from 'vitest'
 import {
   repairEscapedWhitespace,
   normalizeParagraphBreaks,
+  addParagraphSpacers,
   splitMarkdownChunks,
   RICH_MESSAGE_MAX_CHARS,
 } from '../format.js'
@@ -57,7 +57,8 @@ function transform(input: string, opts: { cardSurfaceScrub?: boolean; cap?: numb
 } {
   let text = input
   if (opts.cardSurfaceScrub) text = normalizeDashes(text)
-  const body = normalizeParagraphBreaks(repairEscapedWhitespace(text))
+  text = normalizeParagraphBreaks(repairEscapedWhitespace(text))
+  const body = addParagraphSpacers(text)
   const chunks = splitMarkdownChunks(body, opts.cap ?? RICH_MESSAGE_MAX_CHARS)
   return { chunks, body }
 }

--- a/telegram-plugin/tests/formatting-torture-set.ts
+++ b/telegram-plugin/tests/formatting-torture-set.ts
@@ -7,7 +7,7 @@
  * The `input` is the raw text as a model/card surface would author it — the
  * regression test runs it through the SAME outbound transform pipeline the
  * gateway uses (repairEscapedWhitespace -> normalizeParagraphBreaks ->
- * splitMarkdownChunks) and then asserts:
+ * addParagraphSpacers -> splitMarkdownChunks) and then asserts:
  *
  *   (a) every emitted chunk is parse-accept valid (no rich-path 400), and
  *   (b) the concatenated output parses into `expect` (entity structure).

--- a/telegram-plugin/tests/outbound-send-path.test.ts
+++ b/telegram-plugin/tests/outbound-send-path.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeParagraphBreaks,
   normalizePunctuation,
   stripExcessBold,
+  addParagraphSpacers,
   splitMarkdownChunks,
   hardSliceToCap,
   RICH_MESSAGE_MAX_CHARS,
@@ -54,10 +55,10 @@ function referenceNormalize(rawText: string): { text: string; voiceReplaced: num
   return { text, voiceReplaced }
 }
 
-function referenceEffectiveText(text: string, _literalText: boolean): string {
-  // The NBSP paragraph-spacer pass was removed in the #2669 follow-up; both
-  // paths now pass the normalized text through unchanged.
-  return text
+function referenceEffectiveText(text: string, literalText: boolean): string {
+  // Rich path injects the idempotent U+00A0 paragraph spacer (#2692, restored
+  // after the #3208 F1 misfire); the literal path stays byte-exact.
+  return literalText ? text : addParagraphSpacers(text)
 }
 
 function referenceChunks(

--- a/telegram-plugin/tests/paragraph-normalizer.test.ts
+++ b/telegram-plugin/tests/paragraph-normalizer.test.ts
@@ -12,6 +12,8 @@ import { describe, test, expect } from 'vitest'
 import {
   normalizeParagraphBreaks,
   splitCollapsedInlineBullets,
+  addParagraphSpacers,
+  PARAGRAPH_SPACER,
 } from '../format.js'
 
 describe('normalizeParagraphBreaks', () => {
@@ -431,44 +433,96 @@ describe('splitCollapsedInlineBullets', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Paragraph gap spacing — plain \n\n, no NBSP spacer (#2669 follow-up).
+// addParagraphSpacers — restore a VISIBLE blank line between prose paragraphs.
 //
-// The NBSP paragraph-spacer (addParagraphSpacers / PARAGRAPH_SPACER) was
-// REMOVED: its premise — that the Bot API 10.1 rich GFM renderer collapses a
-// `\n\n` gap TIGHT — is false for the live renderer, which shows a `\n\n` gap
-// as one normal blank line. The spacer therefore injected a spurious SECOND
-// blank line (`\n\n \n\n`) between every paragraph fleet-wide. Paragraph
-// spacing now relies on the plain `\n\n` that normalizeParagraphBreaks already
-// guarantees. These tests pin: multi-paragraph output has exactly one blank
-// line per gap, and no U+00A0 anywhere.
+// The rich GFM renderer (post-#2669) collapses a `\n\n` paragraph gap TIGHT, so
+// multi-paragraph replies render jammed together — the operator-confirmed
+// regression vs the old HTML path (`parse_mode:"HTML"`, `\n\n` → real blank
+// line). addParagraphSpacers wedges a U+00A0 spacer paragraph into each prose
+// `\n\n` gap so the rich renderer shows a visible empty line. Conservative:
+// only between two prose blocks, never adjacent to list/table/code/quote/heading.
 // ---------------------------------------------------------------------------
 
-describe('paragraph gap spacing — single blank line, no NBSP', () => {
-  const NBSP = String.fromCharCode(0xa0)
+describe('addParagraphSpacers', () => {
+  const gap = `\n\n${PARAGRAPH_SPACER}\n\n`
 
-  test('a two-paragraph prose body has exactly one blank-line gap and no NBSP', () => {
-    const out = normalizeParagraphBreaks('Paragraph one.\n\nParagraph two.')
-    expect(out).toBe('Paragraph one.\n\nParagraph two.')
-    expect(out).not.toContain(NBSP)
-    // Exactly one empty line between the two content lines.
-    expect(out.split('\n')).toEqual(['Paragraph one.', '', 'Paragraph two.'])
+  test('the spacer is a single non-breaking space (U+00A0), not an ASCII space', () => {
+    expect(PARAGRAPH_SPACER).toBe(' ')
   })
 
-  test('a three-paragraph body keeps single-blank-line gaps, no NBSP', () => {
-    const out = normalizeParagraphBreaks('One.\n\nTwo.\n\nThree.')
-    expect(out).toBe('One.\n\nTwo.\n\nThree.')
-    expect(out).not.toContain(NBSP)
-    // No gap is a DOUBLE blank line (`\n\n\n`), which the old spacer produced.
-    expect(out).not.toMatch(/\n\n\n/)
+  test('inserts a visible spacer paragraph into a prose `\\n\\n` gap', () => {
+    expect(addParagraphSpacers('Paragraph one.\n\nParagraph two.')).toBe(
+      `Paragraph one.${gap}Paragraph two.`,
+    )
   })
 
-  test('prose->list transition is a single `\n\n` boundary, list interior tight', () => {
-    const out = normalizeParagraphBreaks('Here are the steps.\n\n- first\n- second')
-    expect(out).toBe('Here are the steps.\n\n- first\n- second')
-    expect(out).not.toContain(NBSP)
+  test('spaces every gap in a three-paragraph body', () => {
+    expect(addParagraphSpacers('One.\n\nTwo.\n\nThree.')).toBe(
+      `One.${gap}Two.${gap}Three.`,
+    )
   })
 
-  test('composed prose+list body: one blank line per gap, no NBSP, no double gap', () => {
+  test('is idempotent — a spaced gap is not doubled on a second pass', () => {
+    const once = addParagraphSpacers('Alpha.\n\nBravo.')
+    expect(addParagraphSpacers(once)).toBe(once)
+  })
+
+  test('leaves a single-`\\n` separation alone (only `\\n\\n` gaps are spaced)', () => {
+    // normalizeParagraphBreaks owns lone-break promotion; this pass only adds a
+    // visible spacer where a genuine blank-line gap already exists.
+    const input = 'Line one.\nLine two.'
+    expect(addParagraphSpacers(input)).toBe(input)
+  })
+
+  test('spaces prose↔list transitions (uniform block spacing), list interior tight', () => {
+    expect(addParagraphSpacers('Here are the steps.\n\n- first\n- second')).toBe(
+      `Here are the steps.${gap}- first\n- second`,
+    )
+    expect(addParagraphSpacers('- first\n- second\n\nClosing prose after the list.')).toBe(
+      `- first\n- second${gap}Closing prose after the list.`,
+    )
+  })
+
+  test('spaces a prose→table boundary; table rows stay contiguous', () => {
+    const table = '| a | b |\n| --- | --- |\n| 1 | 2 |'
+    expect(addParagraphSpacers(`Intro.\n\n${table}`)).toBe(`Intro.${gap}${table}`)
+  })
+
+  test('spaces prose↔fence boundaries; fence interior untouched', () => {
+    const input = 'Look here.\n\n```js\nconst a = 1;\n```\n\nDone.'
+    expect(addParagraphSpacers(input)).toBe(
+      `Look here.${gap}\`\`\`js\nconst a = 1;\n\`\`\`${gap}Done.`,
+    )
+  })
+
+  test('spaces heading→anything and blockquote boundaries', () => {
+    expect(addParagraphSpacers('Intro prose.\n\n## Section\n\nBody prose.')).toBe(
+      `Intro prose.${gap}## Section${gap}Body prose.`,
+    )
+    expect(addParagraphSpacers('Said.\n\n> a quote\n\nAfter.')).toBe(
+      `Said.${gap}> a quote${gap}After.`,
+    )
+  })
+
+  test('does NOT space between items of the same loose list / same-kind blocks', () => {
+    const looseList = '- first\n\n- second\n\n- third'
+    expect(addParagraphSpacers(looseList)).toBe(looseList)
+    const quotes = '> one\n\n> two'
+    expect(addParagraphSpacers(quotes)).toBe(quotes)
+  })
+
+  test('never reaches inside a fenced block (interior blank line untouched)', () => {
+    const input = 'Before.\n\n```\nline 1\n\nline 2\n```\n\nAfter.'
+    const out = addParagraphSpacers(input)
+    // The fence interior — including its own blank line — is byte-for-byte intact.
+    expect(out).toContain('```\nline 1\n\nline 2\n```')
+  })
+
+  test('a body with no paragraph gap is returned unchanged', () => {
+    expect(addParagraphSpacers('just one paragraph, no gap')).toBe('just one paragraph, no gap')
+  })
+
+  test('composes after normalizeParagraphBreaks: prose gap spaced, list left tight', () => {
     const input = [
       'Summary of the change.',
       '',
@@ -477,11 +531,12 @@ describe('paragraph gap spacing — single blank line, no NBSP', () => {
       '- adds a normalizer',
       '- lifts the cap',
     ].join('\n')
-    const out = normalizeParagraphBreaks(input)
-    expect(out).toContain('Summary of the change.\n\nIt does two things.')
-    expect(out).toContain('It does two things.\n\n- adds a normalizer\n- lifts the cap')
-    expect(out).not.toContain(NBSP)
-    expect(out).not.toMatch(/\n\n\n/)
+    const out = addParagraphSpacers(normalizeParagraphBreaks(input))
+    // The two prose paragraphs gain a visible spacer between them.
+    expect(out).toContain(`Summary of the change.${gap}It does two things.`)
+    // The prose→list transition gains a spacer too (uniform block spacing),
+    // but the list INTERIOR stays tight.
+    expect(out).toContain(`It does two things.${gap}- adds a normalizer\n- lifts the cap`)
   })
 })
 
@@ -522,12 +577,12 @@ describe('normalizeParagraphBreaks — inline bullet split integration', () => {
  * ragged / oversized gap: CommonMark discards it so it buys no visible space,
  * but it reads as noise in the raw text. Step 1 of normalizeParagraphBreaks now
  * collapses any run of blank lines — including whitespace-only interior lines —
- * to exactly one clean `\n\n`. The collapse is deliberately ASCII-only, so a
- * genuine user-typed U+00A0 line survives (the conservative choice; there is no
- * longer an NBSP paragraph spacer to protect — that pass was removed).
+ * to exactly one clean `\n\n`, WITHOUT ever eating the deliberate U+00A0
+ * paragraph spacer that addParagraphSpacers (#2692) adds later for a visible
+ * gap on the rich-message path.
  */
 describe('normalizeParagraphBreaks — whitespace-only blank-line collapse (Bug 2)', () => {
-  const NBSP = String.fromCharCode(0xa0)
+  const NBSP = ' '
 
   test('a lone-space blank line between paragraphs collapses to a clean `\\n\\n` (real string)', () => {
     const input =
@@ -580,11 +635,14 @@ describe('normalizeParagraphBreaks — whitespace-only blank-line collapse (Bug 
     expect(normalizeParagraphBreaks(input)).toBe(input)
   })
 
-  test('a genuine user-typed U+00A0-only line survives (ASCII-only collapse)', () => {
-    // The blank-line collapse is deliberately ASCII-only, so a non-breaking
-    // space a user actually typed on its own line is not silently eaten.
-    const input = 'Alpha para.\n' + NBSP + '\nBravo para.'
-    expect(normalizeParagraphBreaks(input)).toBe(input)
+  test('the deliberate U+00A0 spacer from addParagraphSpacers is preserved (no #2692 regression)', () => {
+    const normalized = normalizeParagraphBreaks('Alpha para.\n\nBravo para.')
+    const spaced = addParagraphSpacers(normalized)
+    // addParagraphSpacers wedges a U+00A0-only line to force a visible gap.
+    expect(spaced).toContain('\n\n' + PARAGRAPH_SPACER + '\n\n')
+    expect(spaced.split('\n')).toContain(NBSP)
+    // And re-running the normalizer must NOT eat that intentional spacer.
+    expect(normalizeParagraphBreaks(spaced)).toBe(spaced)
   })
 
   test('idempotent: collapsing a stray gap twice is stable', () => {

--- a/telegram-plugin/tests/paragraph-spacer-golden.test.ts
+++ b/telegram-plugin/tests/paragraph-spacer-golden.test.ts
@@ -35,7 +35,7 @@ import {
   normalizeParagraphBreaks,
   PARAGRAPH_SPACER,
 } from '../format.js'
-import { renderOutbound } from '../render/rich-render.js'
+import { renderOutbound, renderOutboundChunks } from '../render/rich-render.js'
 
 const SP = PARAGRAPH_SPACER // U+00A0
 
@@ -77,13 +77,38 @@ describe('paragraph spacer — golden outbound byte string', () => {
     expect(eff).toBe(GOLDEN)
   })
 
-  test('the golden survives the live IR renderer byte-for-byte (reaches the wire)', () => {
+  test('the golden survives the single-piece IR renderer byte-for-byte', () => {
     // The renderer (default-on) re-parses and re-renders; a U+00A0-only line is
     // a genuine paragraph that round-trips intact, so the visible gap reaches
     // Telegram. (An ASCII-space-only line, by contrast, would be collapsed.)
+    // This is the sub-cap single-piece case (`renderOutbound`); the live-path
+    // assertion below proves the same through the ACTUAL send transform.
     const wire = renderOutbound(GOLDEN).text
     expect(wire).toBe(GOLDEN)
   })
+
+  test('the golden reaches the wire through the LIVE send path (renderOutboundChunks) byte-for-byte', () => {
+    // The live send path (stream-controller.ts) uses `renderOutboundChunks`, not
+    // the single-piece `renderOutbound`. For a sub-cap body it returns exactly
+    // one `markdown` piece; the joined piece text must preserve the U+00A0
+    // spacer byte-for-byte, so the visible paragraph gaps reach Telegram on the
+    // real path — not merely in the single-piece renderer. This is the load-
+    // bearing anchor against a third flip of the paragraph-spacing behaviour.
+    const pieces = renderOutboundChunks(GOLDEN)
+    expect(pieces).toHaveLength(1) // sub-cap → single deliverable piece
+    expect(pieces[0].mode).toBe('markdown')
+    const joined = pieces.map((p) => p.text).join('')
+    expect(joined).toBe(GOLDEN)
+    // The U+00A0 spacer is present and never doubled at any boundary.
+    expect(joined).toContain(`\n\n${SP}\n\n`)
+    expect(joined).not.toContain(`${SP}\n\n${SP}`)
+  })
+
+  // Multi-chunk boundary safety (a body that exceeds the cap and splits, with no
+  // spacer stranded or duplicated at a chunk boundary) is covered by
+  // telegram-format.test.ts → 'no chunk starts or ends with a bare U+00A0
+  // spacer line (reviewer repro)' and 'spacer-boundary strip is robust across
+  // several gaps and small caps'. Not duplicated here.
 })
 
 describe('paragraph spacer — idempotency guard', () => {

--- a/telegram-plugin/tests/paragraph-spacer-golden.test.ts
+++ b/telegram-plugin/tests/paragraph-spacer-golden.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Durable anchor for the restored idempotent paragraph spacer (revert of
+ * #3208 F1). Two guarantees the fleet depends on:
+ *
+ *   1. GOLDEN — the EXACT outbound byte string for a representative message
+ *      (bold header + two prose paragraphs + a `- ` list + a fenced code
+ *      block + closing prose) is pinned, BOTH after the `addParagraphSpacers`
+ *      pass AND after the in-repo IR renderer (`render/`) re-parses and
+ *      re-renders it. Any future change to paragraph spacing must CONSCIOUSLY
+ *      update this fixture — it can't drift silently. The wire byte string is
+ *      byte-identical to the spacer-pass output, proving the U+00A0 spacer
+ *      survives the live rich-render path (`SWITCHROOM_RICH_RENDER` default-on).
+ *
+ *   2. IDEMPOTENCY — the pass inserts EXACTLY ONE spacer per prose gap and can
+ *      never stack a second: running it twice equals running it once, and a
+ *      gap that already carries a spacer (or an extra blank line, or an
+ *      ASCII-space-only line) is normalised to the single canonical spacer,
+ *      not doubled. The "naive re-add" control below shows WHY the guard is
+ *      load-bearing: a non-canonicalising spacer pass (insert on every `\n\n`)
+ *      double-gaps on the second run — exactly the #3208 symptom. That control
+ *      asserts the naive output DIVERGES, so this test would fail if the real
+ *      pass ever lost its idempotency guard.
+ *
+ * Context: #3208 F1 deleted the spacer wholesale on the false premise that the
+ * Bot API 10.1 rich GFM renderer shows a bare `\n\n` gap as a visible blank
+ * line. Live evidence says the opposite — `\n\n` renders TIGHT, only the
+ * U+00A0 spacer produces a visible gap — so removal reintroduced the
+ * "paragraphs jammed together" symptom #2692 originally fixed. The correct fix
+ * for F1's real-but-narrow double-gap was to make the spacer idempotent (this),
+ * not to delete it.
+ */
+import { describe, test, expect } from 'vitest'
+import {
+  addParagraphSpacers,
+  normalizeParagraphBreaks,
+  PARAGRAPH_SPACER,
+} from '../format.js'
+import { renderOutbound } from '../render/rich-render.js'
+
+const SP = PARAGRAPH_SPACER // U+00A0
+
+// A representative multi-construct message: a **bold** header, two prose
+// paragraphs, a `- ` list, a fenced code block, and closing prose.
+const REPRESENTATIVE = [
+  '**Status report**',
+  '',
+  'First paragraph of prose explaining the situation in some detail.',
+  '',
+  'Second paragraph that continues the explanation across a gap.',
+  '',
+  '- first bullet item',
+  '- second bullet item',
+  '',
+  '```js',
+  'const x = 1',
+  '```',
+  '',
+  'Closing prose after the code block.',
+].join('\n')
+
+// The EXACT expected outbound byte string. Every DISTINCT-block boundary
+// carries exactly one U+00A0 spacer line; the list interior stays tight and the
+// fenced block is byte-for-byte verbatim. Update this fixture ONLY with a
+// conscious decision to change paragraph spacing.
+const GOLDEN =
+  `**Status report**\n\n${SP}\n\n` +
+  `First paragraph of prose explaining the situation in some detail.\n\n${SP}\n\n` +
+  `Second paragraph that continues the explanation across a gap.\n\n${SP}\n\n` +
+  `- first bullet item\n- second bullet item\n\n${SP}\n\n` +
+  '```js\nconst x = 1\n```' +
+  `\n\n${SP}\n\n` +
+  'Closing prose after the code block.'
+
+describe('paragraph spacer — golden outbound byte string', () => {
+  test('addParagraphSpacers output matches the golden fixture exactly', () => {
+    const eff = addParagraphSpacers(normalizeParagraphBreaks(REPRESENTATIVE))
+    expect(eff).toBe(GOLDEN)
+  })
+
+  test('the golden survives the live IR renderer byte-for-byte (reaches the wire)', () => {
+    // The renderer (default-on) re-parses and re-renders; a U+00A0-only line is
+    // a genuine paragraph that round-trips intact, so the visible gap reaches
+    // Telegram. (An ASCII-space-only line, by contrast, would be collapsed.)
+    const wire = renderOutbound(GOLDEN).text
+    expect(wire).toBe(GOLDEN)
+  })
+})
+
+describe('paragraph spacer — idempotency guard', () => {
+  test('running the pass twice equals running it once', () => {
+    const once = addParagraphSpacers(normalizeParagraphBreaks(REPRESENTATIVE))
+    const twice = addParagraphSpacers(once)
+    expect(twice).toBe(once)
+  })
+
+  test('a gap that already carries a spacer is not double-spaced', () => {
+    const already = `Alpha.\n\n${SP}\n\nBravo.`
+    expect(addParagraphSpacers(already)).toBe(already)
+    // No gap ever grows a SECOND spacer line.
+    expect(addParagraphSpacers(already)).not.toContain(`${SP}\n\n${SP}`)
+  })
+
+  test('a stray extra blank line / ASCII-space line is normalised, never stacked', () => {
+    // Triple newline, and an ASCII-space-only spacer line, both canonicalise to
+    // the single U+00A0 spacer — not to a spacer PLUS an extra blank.
+    expect(addParagraphSpacers('Alpha.\n\n\nBravo.')).toBe(`Alpha.\n\n${SP}\n\nBravo.`)
+    expect(addParagraphSpacers('Alpha.\n\n \n\nBravo.')).toBe(`Alpha.\n\n${SP}\n\nBravo.`)
+  })
+
+  test('CONTROL: a naive non-canonicalising spacer pass double-gaps on re-run (proves the guard is load-bearing)', () => {
+    // A naive implementation inserts a spacer at EVERY `\n\n` with no guard.
+    // First run is fine; the SECOND run sees the spacer's own `\n\n` gaps and
+    // wedges more spacers, stacking blank lines — the #3208 double-gap. This
+    // control asserts the naive pass DIVERGES from idempotency, so if the real
+    // addParagraphSpacers ever regressed to naive behaviour the idempotency
+    // test above would start failing rather than silently passing.
+    const naive = (t: string): string => t.replace(/\n\n/g, `\n\n${SP}\n\n`)
+    const once = naive('Alpha.\n\nBravo.')
+    const twice = naive(once)
+    expect(twice).not.toBe(once)
+    // And the real pass does NOT behave like the naive one on re-run.
+    const realOnce = addParagraphSpacers('Alpha.\n\nBravo.')
+    expect(addParagraphSpacers(realOnce)).toBe(realOnce)
+  })
+})

--- a/telegram-plugin/tests/stream-reply-handler.test.ts
+++ b/telegram-plugin/tests/stream-reply-handler.test.ts
@@ -120,12 +120,13 @@ describe('handleStreamReply', () => {
     expect(bot.api.sendMessage.mock.calls[0][2]?.parse_mode).toBeUndefined()
   })
 
-  it('rich path sends the multi-paragraph `\\n\\n` gap byte-exact (no NBSP spacer)', async () => {
-    // The NBSP paragraph-spacer pass was removed in the #2669 follow-up — the
-    // rich renderer shows a plain `\n\n` gap as one blank line, so the handler
-    // passes the text through unchanged.
+  it('applies addParagraphSpacers on the rich path (multi-paragraph gap spaced)', async () => {
     const state = makeState()
-    const deps = makeDeps(bot)
+    // Spacer dep replaces every `\n\n` gap with a visible marker so we can
+    // assert the rich path ran it (mirrors the real gateway wiring).
+    const deps = makeDeps(bot, {
+      addParagraphSpacers: (t) => t.replace(/\n\n/g, '\n\nSPACER\n\n'),
+    })
 
     const pending = handleStreamReply(
       { chat_id: '1', text: 'Para one.\n\nPara two.', done: true },
@@ -136,13 +137,14 @@ describe('handleStreamReply', () => {
     await pending
 
     expect(bot.api.sendRichMessage).toHaveBeenCalledTimes(1)
-    expect(richSendMarkdown(bot)).toBe('Para one.\n\nPara two.')
-    expect(richSendMarkdown(bot)).not.toContain(String.fromCharCode(0xa0))
+    expect(richSendMarkdown(bot)).toBe('Para one.\n\nSPACER\n\nPara two.')
   })
 
-  it('literal format=text path is byte-exact too', async () => {
+  it('does NOT apply addParagraphSpacers on the literal format=text path', async () => {
     const state = makeState()
-    const deps = makeDeps(bot)
+    const deps = makeDeps(bot, {
+      addParagraphSpacers: (t) => t.replace(/\n\n/g, '\n\nSPACER\n\n'),
+    })
 
     const pending = handleStreamReply(
       { chat_id: '1', text: 'Para one.\n\nPara two.', format: 'text', done: true },
@@ -153,6 +155,7 @@ describe('handleStreamReply', () => {
     await pending
 
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
+    // Literal path is byte-exact — no spacer injected.
     expect(bot.api.sendMessage.mock.calls[0][1]).toBe('Para one.\n\nPara two.')
   })
 

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -19,6 +19,8 @@ import {
   repairEscapedWhitespace,
   escapeMarkdown,
   splitMarkdownChunks,
+  addParagraphSpacers,
+  PARAGRAPH_SPACER,
   RICH_MESSAGE_MAX_CHARS,
 } from '../format.js'
 
@@ -185,54 +187,65 @@ describe('splitMarkdownChunks', () => {
   })
 
   // -------------------------------------------------------------------------
-  // Chunk-boundary blank-line hygiene. Paragraph gaps are now plain `\n\n`
-  // (the NBSP spacer was removed in the #2669 follow-up). When a cut lands in
-  // a gap, the boundary must not leave a chunk that opens or ends with a bare
-  // blank line, and no visible content may be dropped.
+  // Chunk-boundary spacer hygiene. addParagraphSpacers injects a
+  // `\n\n${PARAGRAPH_SPACER}\n\n` gap between prose paragraphs. When a cut
+  // lands inside that gap, the boundary must not leave a chunk that opens or
+  // ends with a bare U+00A0 spacer line (a stray blank bubble line).
   // -------------------------------------------------------------------------
 
-  test('no chunk starts or ends with a bare blank line at a `\\n\\n` gap cut', () => {
+  test('no chunk starts or ends with a bare U+00A0 spacer line (reviewer repro)', () => {
+    // The exact reviewer repro: a spacer gap straddling a small cap.
     const A = 'Alpha sentence one'
     const B = 'Bravo sentence two'
-    const text = `${A}.\n\n${B}.`
-    const chunks = splitMarkdownChunks(text, 33)
+    const spaced = addParagraphSpacers(`${A}.\n\n${B}.`)
+    const chunks = splitMarkdownChunks(spaced, 33)
     expect(chunks.length).toBeGreaterThan(1)
-    const blankOnly = /^[ \t]*$/
+    const spacerOnly = new RegExp(`^[ \\t]*${PARAGRAPH_SPACER}[ \\t]*$`)
     for (const c of chunks) {
       const lines = c.split('\n')
-      expect(blankOnly.test(lines[0])).toBe(false)
-      expect(blankOnly.test(lines[lines.length - 1])).toBe(false)
+      expect(spacerOnly.test(lines[0])).toBe(false)
+      expect(spacerOnly.test(lines[lines.length - 1])).toBe(false)
     }
   })
 
   test('visible paragraph content survives the boundary (no text dropped)', () => {
     const A = 'Alpha sentence one'
     const B = 'Bravo sentence two'
-    const text = `${A}.\n\n${B}.`
-    const chunks = splitMarkdownChunks(text, 33)
+    const spaced = addParagraphSpacers(`${A}.\n\n${B}.`)
+    const chunks = splitMarkdownChunks(spaced, 33)
     const rejoined = chunks.join('\n')
     expect(rejoined).toContain(`${A}.`)
     expect(rejoined).toContain(`${B}.`)
   })
 
-  test('blank-line-boundary strip is robust across several gaps and small caps', () => {
+  test('spacer-boundary strip is robust across several gaps and small caps', () => {
     const paras = Array.from({ length: 6 }, (_, i) => `Paragraph ${i} body text here.`)
-    const text = paras.join('\n\n')
-    const blankOnly = /^[ \t]*$/
+    const spaced = addParagraphSpacers(paras.join('\n\n'))
+    const spacerOnly = new RegExp(`^[ \\t]*${PARAGRAPH_SPACER}[ \\t]*$`)
     for (const cap of [20, 31, 40, 64]) {
-      const chunks = splitMarkdownChunks(text, cap)
+      const chunks = splitMarkdownChunks(spaced, cap)
       for (const c of chunks) {
         const lines = c.split('\n')
-        expect(blankOnly.test(lines[0])).toBe(false)
-        expect(blankOnly.test(lines[lines.length - 1])).toBe(false)
+        expect(spacerOnly.test(lines[0])).toBe(false)
+        expect(spacerOnly.test(lines[lines.length - 1])).toBe(false)
       }
-      // No visible word is dropped: concatenating the chunks' non-blank tokens
-      // reproduces the original word sequence. (Word-level, not line-level,
-      // because a small cap may split mid-word — the chunker's normal
-      // space-boundary behaviour.)
-      const words = (s: string): string[] => s.split(/\s+/).filter((w) => w.length > 0)
+      // No visible word is dropped: concatenating the chunks' non-blank,
+      // non-spacer tokens reproduces the original word sequence. (Word-level,
+      // not line-level, because a small cap may split mid-word — that's the
+      // chunker's normal space-boundary behaviour, orthogonal to spacers.)
+      const words = (s: string): string[] =>
+        s.split(/\s+/).filter((w) => w.length > 0 && w !== PARAGRAPH_SPACER)
       expect(words(chunks.join(' '))).toEqual(words(paras.join(' ')))
     }
+  })
+
+  test('a boundary with NO spacer is unaffected (legacy ^\\n+ behaviour preserved)', () => {
+    const text = Array.from({ length: 10 }, (_, i) => `plain line ${i}`).join('\n\n')
+    const chunks = splitMarkdownChunks(text, 40)
+    // No spacer was ever present, so no chunk gains/loses anything beyond the
+    // normal leading-newline strip; content is preserved.
+    const rejoined = chunks.join('\n').replace(/\n+/g, '\n')
+    expect(rejoined).toBe(text.replace(/\n+/g, '\n'))
   })
 
   // -------------------------------------------------------------------------

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -31,7 +31,9 @@ import {
   normalizeParagraphBreaks,
   normalizePunctuation,
   stripExcessBold,
+  addParagraphSpacers,
   splitMarkdownChunks,
+  PARAGRAPH_SPACER,
   RICH_MESSAGE_MAX_CHARS,
 } from '../format.js'
 
@@ -128,9 +130,7 @@ describe('decideTurnFlush — prose+trailing-sentinel is suppressed, not leaked 
 // the real gateway turn-flush render pipeline (post-#2669 rich-markdown path):
 //   decideTurnFlush -> join('\n\n')
 //   -> repairEscapedWhitespace -> normalizeParagraphBreaks
-//   -> splitMarkdownChunks -> sendRichMessage
-// (no paragraph-spacer pass — the NBSP spacer was removed in the #2669
-//  follow-up; gaps are plain `\n\n`, one visible blank line)
+//   -> addParagraphSpacers -> splitMarkdownChunks -> sendRichMessage
 // so it pins the end-to-end fix, not just the pure decision. The corpus is a
 // REAL captured-transcript shape (three separate content[i].text blocks, one
 // stored UNTRIMMED with a trailing '\n' exactly as session-tail.ts pushes
@@ -156,7 +156,8 @@ describe('#2798 turn-flush block separation — real multi-block transcript shap
     const d = decideTurnFlush({ chatId: '12345', replyCalled: false, capturedText: blocks })
     expect(d.kind).toBe('flush')
     const joined = (d as { kind: 'flush'; text: string }).text
-    return normalizeParagraphBreaks(repairEscapedWhitespace(joined))
+    const normalized = normalizeParagraphBreaks(repairEscapedWhitespace(joined))
+    return addParagraphSpacers(normalized)
   }
 
   it('separates whole blocks with a visible paragraph gap, not a wall-of-text', () => {
@@ -166,29 +167,32 @@ describe('#2798 turn-flush block separation — real multi-block transcript shap
     expect(out).toContain('The `auth` handler looks correct')
     expect(out).toContain('Want me to open a PR')
     // The wall-of-text failure mode glues two blocks one '\n' apart. Assert the
-    // boundary carries a real paragraph break (plain `\n\n`, one blank line —
-    // no NBSP spacer), and NOT a single-newline join.
-    expect(out).toContain('flagged.\n\nThe `auth`')
+    // boundary carries a real paragraph break with the injected visible spacer
+    // line (#2692 rich-path spacer), and NOT a single-newline join.
+    expect(out).toContain(`\n\n${PARAGRAPH_SPACER}\n\n`)
     expect(out).not.toContain('flagged.\nThe `auth`')
-    // No U+00A0 anywhere.
-    expect(out).not.toContain(String.fromCharCode(0xa0))
+    // A spacer sits specifically between block 1 and block 2.
+    const b1 = out.indexOf('flagged.')
+    const b2 = out.indexOf('The `auth` handler')
+    expect(out.slice(b1, b2)).toContain(PARAGRAPH_SPACER)
   })
 
   it('collapses the untrimmed-trailing-newline stack — no 3+ newline run reaches the wire', () => {
     const out = renderLikeTurnFlush(realBlocks)
     // Block 2's trailing '\n' + the '\n\n' join = 3 newlines; normalize
-    // collapses 3+ runs to '\n\n', so no doubled/stacked blank run survives.
+    // collapses 3+ runs to '\n\n' and addParagraphSpacers wedges exactly one
+    // spacer, so no doubled/stacked blank run survives.
     expect(out).not.toMatch(/\n{3,}/)
-    // One blank-line gap per block transition: 3 blocks → 2 gaps.
-    const gapCount = (out.match(/\n\n/g) ?? []).length
-    expect(gapCount).toBe(2)
+    // One spacer per block transition: 3 blocks → 2 gaps → 2 spacers.
+    const spacerCount = out.split(PARAGRAPH_SPACER).length - 1
+    expect(spacerCount).toBe(2)
   })
 
   it('the whole separated answer stays in one rich chunk here (well under 32768)', () => {
     const out = renderLikeTurnFlush(realBlocks)
     const chunks = splitMarkdownChunks(out, RICH_MESSAGE_MAX_CHARS)
     expect(chunks.length).toBe(1)
-    expect(chunks[0]).toContain('\n\n')
+    expect(chunks[0]).toContain(PARAGRAPH_SPACER)
   })
 
   it('still SUPPRESSES a real transcript that deliberately terminates with a bare NO_REPLY (#2053 guard intact)', () => {
@@ -224,9 +228,9 @@ describe('#2798 turn-flush block separation — real multi-block transcript shap
 // runs (gateway executeReply):
 //   repairEscapedWhitespace -> normalizeParagraphBreaks -> redactOutboundText
 //   -> stripExcessBold(normalizePunctuation) -> scrubVoice
-// (no send-side paragraph-spacer pass — removed in the #2669 follow-up).
+//   -> addParagraphSpacers (send side)
 // The original #2798 change gave turn-flush the paragraph steps + redact +
-// scrub but OMITTED `stripExcessBold(normalizePunctuation(...))`.
+// scrub + spacers but OMITTED `stripExcessBold(normalizePunctuation(...))`.
 // This suite reconstructs the deterministic format chain of BOTH paths (the
 // runtime-only redact + voice-scrub steps are literally the same calls on both
 // paths and are out of scope here) and pins that turn-flush now matches reply
@@ -308,7 +312,7 @@ describe('#2798 turn-flush punctuation/bold parity with reply', () => {
   function formatChain(text: string): string {
     let t = normalizeParagraphBreaks(repairEscapedWhitespace(text))
     t = stripExcessBold(normalizePunctuation(t))
-    return t
+    return addParagraphSpacers(t)
   }
 
   const input =

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -197,10 +197,10 @@ export function decideTurnFlush(input: FlushDecisionInput): FlushDecision {
   // lone `\n` collapses adjacent blocks into one run — on the Bot API 10.1
   // rich-markdown path (#2669) a single newline is a soft break, so the blocks
   // render as an undifferentiated wall-of-text. `\n\n` is the GFM paragraph
-  // separator; the Bot API 10.1 rich renderer shows it as one visible blank
-  // line, so the paragraphs render with real separation on their own (the
-  // former NBSP spacer pass was removed in the #2669 follow-up — it added a
-  // spurious second blank line).
+  // separator; the gateway send path then wedges visible spacers into those
+  // gaps via addParagraphSpacers (mirroring the reply path, #2692) so the
+  // paragraphs render with real separation (the rich GFM renderer otherwise
+  // shows a bare `\n\n` gap TIGHT).
   //
   // The silent-marker guards below are unaffected by this change:
   // isSilentFlushMarker length-guards the whole joined string; the composite /


### PR DESCRIPTION
## The false premise

PR #3208 (F1) deleted `addParagraphSpacers` / `PARAGRAPH_SPACER` from `telegram-plugin/format.ts` on the premise that the Bot API 10.1 rich (GFM) renderer shows a bare `\n\n` prose gap as a normal single blank line.

That premise is **false**. Live evidence: outbound messages with real `\n\n` between prose paragraphs render **TIGHT** (no visible blank line) on the live path — only list/table BLOCK boundaries produce a gap. So removing the spacer reintroduced the "paragraphs jammed together" symptom #2692 originally fixed by adding it, fleet-wide.

## Why idempotency, not deletion

The double-gap #3208 observed was real but narrow: the old spacer was not fully canonical, so a gap that already carried a spacer (or an extra blank line) could stack a **second** blank. The correct fix is to make the spacer idempotent — not to delete the mechanism and reintroduce the jammed-paragraph regression.

This PR restores the spacer and makes it **double-gap-proof by canonicalising every inter-block gap** to exactly one form — `\n\n` (tight) or `\n\n${SP}\n\n` (spaced) — regardless of what the gap originally held (bare `\n\n`, a pre-existing U+00A0 spacer, a stray extra blank line, or an ASCII-space-only line). It inserts exactly one spacer per spaced gap, never stacks, and running the pass twice equals running it once.

## IR-renderer interaction (grounded, not assumed)

The in-repo rich renderer (`render/`, gated by `SWITCHROOM_RICH_RENDER`, **default ON**) is LIVE on the send path and runs AFTER the spacer pass (in `stream-controller.ts`). Verified against the real `parse → renderSafe`:
- a **U+00A0**-only spacer line is a genuine paragraph that round-trips the re-parse/re-render **byte-for-byte**, so the visible gap reaches the wire;
- an **ASCII-space**-only line is collapsed to a tight `\n\n`.

So the U+00A0 spacer reaches Telegram whether the renderer is on (default) or off — the restore at the pre-render call sites covers both paths.

## What changed

Restored at all send-path call sites F1 removed it from:
- `computeEffectiveText` (`outbound-send-path.ts`, rich path)
- `executeEditMessage` edit path (`gateway.ts`)
- `handleSessionEvent` turn-flush send path (`gateway.ts`)
- `StreamReplyDeps.addParagraphSpacers` hook (`stream-reply-handler.ts`)
- spacer-aware `stripBoundarySpacers`, and the `turn-flush-safety.ts` comment.

**#3208's other findings are preserved** — F2 (link-href / `<scheme:…>` autolink dash mask), F3 (entity-aware chunk back-off incl. triple `***`/`___`), F4 (repairEscapedWhitespace comment). Only F1's spacer removal was wrong.

## Tests — the durable anchor

#3208 rewrote 8 test files to assert the spacer is ABSENT; those assertions encoded the wrong behaviour and are re-pointed to the correct rendered intent (one spacer per prose gap, tight lists, verbatim code fences). New `paragraph-spacer-golden.test.ts`:
- **Golden**: pins the EXACT outbound byte string for a representative message (`**bold**` header + two prose paragraphs + a `- ` list + a fenced code block + closing prose), both after the spacer pass AND after the live IR render (byte-identical) — any future spacing change must consciously update the fixture.
- **Idempotency**: twice == once, pre-existing spacer not doubled, stray blank / ASCII-space normalised — with a **naive-re-add CONTROL** that diverges, so a regression to a non-idempotent spacer fails the suite rather than passing silently.

Scoped `vitest run` (format-consistency, paragraph-normalizer, telegram-format, formatting-parse-regression, turn-flush-safety, stream-reply-handler, outbound-send-path, paragraph-spacer-golden, render/, stream-controller-chunk-cap) and `npm run lint` (incl. `tsc --noEmit`) both green locally. CI is the full-suite authority.

Refs #3208, #2692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
