### PR TITLE
fix(cards): uniform instant-narration + truthful terminal state across all nesting levels

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -193,7 +193,7 @@ import { formatModelLabel } from '../model-label.js'
 import { createSessionModelSource } from './session-model-source.js'
 import { runSilentTurnHeartbeatTick } from '../feed-heartbeat-climb.js'
 import { REPLY_TOOLS } from '../narrative-dedup.js'
-import { NarrativeFlushController } from '../narrative-flush.js'
+import { NarrativeFlushController, PENDING_NARRATIVE_FLUSH_MS } from '../narrative-flush.js'
 import { toolLabel } from '../tool-labels.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { createTurnTypingLoop } from './turn-typing-loop.js'
@@ -15545,18 +15545,13 @@ function composeTurnActivity(turn: CurrentTurn, final = false, liveSuffix = ''):
   return renderActivityFeedWithNested(turn.mirrorLines, childLines, final, liveSuffix, stepCount, header)
 }
 
-/**
- * Time-box for the parked-narrative early-paint (see `narrative-flush.ts`).
- * If a parked opening narration gets no lookahead event (tool_use / next text /
- * turn_end) within this window — the "narrate, then think before the first tool"
- * case that produced the visible gap — the flush timer paints it via the SAME
- * `showNarrativeStep` path a lookahead would. Chosen so a normal draft-then-send
- * `reply` (emitted right after the text block) lands FIRST and cancels the timer;
- * but correctness does NOT depend on that race — a timer-painted block that later
- * proves to be the reply is deterministically retracted (see the RETRACT effect
- * wired into the controller below). Named const so a test can pin it.
- */
-const PENDING_NARRATIVE_FLUSH_MS = 250
+// PENDING_NARRATIVE_FLUSH_MS is now defined in and imported from
+// `narrative-flush.ts` (the kernel's home) so the main-agent gateway path and
+// the worker/sub-agent watcher share ONE source of truth for the time-box.
+// The main path paints a parked block via the SAME `showNarrativeStep` path a
+// lookahead would, and a timer-painted block that later proves to be the reply
+// is deterministically retracted (the RETRACT effect wired into the controller
+// below).
 
 /**
  * Retract a narration step the flush timer painted EARLY that turned out to draft

--- a/telegram-plugin/narrative-flush.ts
+++ b/telegram-plugin/narrative-flush.ts
@@ -41,6 +41,26 @@
 
 import { REPLY_TOOLS, isDraftOfReply } from './narrative-dedup.js'
 
+/**
+ * Time-box for the parked-narrative early-paint (the kernel's home for the
+ * constant so BOTH callers share ONE source of truth):
+ *   - the main-agent gateway path drives the kernel with a real `setTimeout`
+ *     scheduler (`makeNarrativeGate`, gateway.ts);
+ *   - the worker / sub-agent watcher drives the SAME kernel with a POLL-driven
+ *     scheduler (stamp `deadline = nowFn()+flushMs`; flush on the next poll
+ *     tick once `nowFn() >= deadline`) — see `subagent-watcher.ts`.
+ * If a parked opening narration gets no lookahead event (tool_use / next text /
+ * turn_end) within this window — the "narrate, then think before the first
+ * tool" gap — it is painted EARLY instead of waiting for the first tool. Chosen
+ * so a normal draft-then-send `reply` (emitted right after the text block)
+ * resolves the block FIRST; correctness does NOT depend on that race — a
+ * timer-painted block that later proves to be the reply is deterministically
+ * retracted (main path) or is structurally harmless (worker path: the reply is
+ * a Telegram-surface tool that never renders on the card). Named const so a
+ * test can pin it.
+ */
+export const PENDING_NARRATIVE_FLUSH_MS = 250
+
 /** Side effects the kernel drives. The caller owns rendering + retraction. */
 export interface NarrativeFlushEffects {
   /** Paint a narrative block as a transient liveness step (SHOW). */

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -92,9 +92,9 @@ export type WorkerState = 'running' | 'done' | 'failed'
  * applies uniformly at every nesting level.
  */
 export interface WorkerNarrativeGate {
-  /** Refresh the injected clock to this poll's `now`. */
-  setNow(now: number): void
-  /** Fire the early-paint if a parked block's flush window has elapsed. */
+  /** Fire the early-paint if a parked block's flush window has elapsed.
+   *  Also refreshes the injected clock to this poll's `now`, so a separate
+   *  clock-refresh entrypoint is unnecessary. */
   tick(now: number): void
   /** Gate step 1: park a new `sub_agent_text` block (SHOW any prior pending). */
   stage(text: string): void
@@ -1215,7 +1215,7 @@ export function readSubTail(
       // narrative-dedup.ts, timer + retract in narrative-flush.ts).
       const buildNarrativeGate = (): WorkerNarrativeGate => {
         // Injected clock the kernel's scheduler reads. Refreshed each poll via
-        // setNow/tick so `deadline = nowRef.value + flushMs` uses the CURRENT
+        // tick(now) so `deadline = nowRef.value + flushMs` uses the CURRENT
         // poll's `now` even though the kernel persists across polls.
         const nowRef = { value: now }
         // Whether the LAST kernel effect painted a narrative cue — read back by
@@ -1283,9 +1283,6 @@ export function readSubTail(
           PENDING_NARRATIVE_FLUSH_MS,
         )
         return {
-          setNow: (n) => {
-            nowRef.value = n
-          },
           tick: (n) => {
             nowRef.value = n
             if (scheduler.armedFn != null && n >= scheduler.deadline) {

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -46,7 +46,8 @@ import { homedir } from 'os'
 import { projectSubagentLine, sanitizeCwdToProjectName, detectErrorInTranscriptLine } from './session-tail.js'
 import { sanitiseToolArg } from './fleet-state.js'
 import { clipNarrative, describeToolUse } from './tool-activity-summary.js'
-import { REPLY_TOOLS, isDraftOfReply } from './narrative-dedup.js'
+import { REPLY_TOOLS } from './narrative-dedup.js'
+import { NarrativeFlushController, PENDING_NARRATIVE_FLUSH_MS } from './narrative-flush.js'
 import { truncate } from './card-format.js'
 import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows, countRunningBackgroundSubagents, recordNestedSubagentDispatch, recordSubagentModel } from './registry/subagents-schema.js'
 import { touchTurnActiveMarker } from './gateway/turn-active-marker.js'
@@ -72,6 +73,38 @@ export interface SubagentLivenessDb {
 }
 
 export type WorkerState = 'running' | 'done' | 'failed'
+
+/**
+ * Per-entry narrative gate: the SAME `NarrativeFlushController` kernel the
+ * main-agent gateway path uses, driven by a POLL-driven scheduler instead of a
+ * real `setTimeout`. Constructed lazily on the first `sub_agent_text` block.
+ *
+ * Time-box parity with the main path (Residual A): the kernel's injected
+ * scheduler stamps `deadline = nowFn()+PENDING_NARRATIVE_FLUSH_MS` when a block
+ * is parked; `tick(now)` — called at the top of every `readSubTail` (which runs
+ * every ~1s poll for a running entry, regardless of file growth) — fires the
+ * parked block EARLY once `now >= deadline`, WITHOUT waiting for the worker's
+ * first tool. So a worker's opening narration surfaces ~the next poll tick
+ * after the flush window rather than gating on its first jsonl tool event.
+ *
+ * Depth-generic: one gate per `WorkerEntry`, and every sub-agent / worker /
+ * nested sub-worker at any depth is a `WorkerEntry` — so the early-paint
+ * applies uniformly at every nesting level.
+ */
+export interface WorkerNarrativeGate {
+  /** Refresh the injected clock to this poll's `now`. */
+  setNow(now: number): void
+  /** Fire the early-paint if a parked block's flush window has elapsed. */
+  tick(now: number): void
+  /** Gate step 1: park a new `sub_agent_text` block (SHOW any prior pending). */
+  stage(text: string): void
+  /** Gate step 2: a tool_use lookahead. Returns whether a narrative cue fired. */
+  resolveOnTool(toolName: string | null, input: Record<string, unknown> | undefined): boolean
+  /** Gate step 3: turn_end lookahead. Returns whether a narrative cue fired. */
+  resolveAtTurnEnd(lastReplyText: string): boolean
+  /** Cancel the timer + drop pending state (resurrection / teardown). */
+  reset(): void
+}
 
 export interface WorkerEntry {
   /** Sub-agent JSONL file stem, e.g. "a75d4757a81e7b1f8". */
@@ -197,15 +230,18 @@ export interface WorkerEntry {
    *  worker left no narrative result of its own. */
   errorDetail?: string
   /**
-   * Narrative-dedup gate state (JSONL-text-narrative primitive). A
-   * `sub_agent_text` block is held here for ONE lookahead step so the next
-   * `sub_agent_tool_use` / `sub_agent_turn_end` can decide draft-then-send
-   * (SUPPRESS — it duplicates the worker's reply) vs working-narration (SHOW
-   * — fire `onProgress({latestSummary})`). Null when nothing is pending. The
-   * pure decision lives in narrative-dedup.ts; this slot is the per-entry
-   * cursor. Mirrors the gateway's `turn.pendingNarrative`.
+   * Narrative-dedup + early-paint gate (JSONL-text-narrative primitive). A
+   * `sub_agent_text` block is parked in the kernel for ONE lookahead step so
+   * the next `sub_agent_tool_use` / `sub_agent_turn_end` can decide
+   * draft-then-send (SUPPRESS — it duplicates the worker's reply) vs
+   * working-narration (SHOW — fire `onProgress({latestSummary})`), AND
+   * time-boxed so an opening narration paints EARLY if no lookahead arrives
+   * within `PENDING_NARRATIVE_FLUSH_MS`. Reuses the SAME
+   * `NarrativeFlushController` kernel as the main-agent gateway path
+   * (`makeNarrativeGate`), driven by a poll scheduler. Constructed lazily on
+   * the first `sub_agent_text`; null before then. Reset on resurrection.
    */
-  pendingNarrative?: { text: string } | null
+  narrativeGate?: WorkerNarrativeGate | null
   /**
    * NIT 3 (sub-agent turn_end symmetry). Most-recently-seen
    * reply/stream_reply `input.text` for this sub-agent — the actual answer a
@@ -1055,6 +1091,13 @@ export function readSubTail(
   }) => void,
 ): void {
   try {
+    // Early-paint tick (Residual A): fire a parked opening narration whose
+    // flush window has elapsed, WITHOUT waiting for a tool. Runs BEFORE the
+    // `size === cursor` no-growth early-return below, so it fires on a quiet
+    // poll (the "narrate, then think" gap) — the whole point of the time-box.
+    // This function is the per-poll defensive read for every running entry, so
+    // the deadline is observed within one poll tick of PENDING_NARRATIVE_FLUSH_MS.
+    if (entry.narrativeGate != null) entry.narrativeGate.tick(now)
     const stat = fs.statSync(entry.filePath)
     if (stat.size < tail.cursor) {
       tail.cursor = 0
@@ -1161,70 +1204,145 @@ export function readSubTail(
         if (errInfo.detail) entry.errorDetail = errInfo.detail.slice(0, SUBAGENT_RESULT_TEXT_MAX)
       }
       const events = projectSubagentLine(line, entry.agentId, startState)
-      // Narrative-dedup gate (JSONL-text-narrative primitive) — fire the
-      // narrative progress cue for a SHOWN sub_agent_text block. Identical
-      // shape to the inline #1720 onProgress below; factored out so the gate
-      // (stage-on-text, resolve-on-tool/turn_end) can replay a previously
-      // pending block exactly once. `latestSummary` carries the worker's
-      // narrative result (entry.lastResultText), never tool labels.
-      const fireNarrativeProgress = (): boolean => {
-        if (onProgress == null || entry.state !== 'running' || entry.historical) return false
-        try {
-          onProgress({
-            agentId: entry.agentId,
-            description: entry.description,
-            latestSummary: entry.lastResultText,
-            elapsedMs: now - entry.dispatchedAt,
-            prevBucketIdx: entry.lastProgressBucketIdx,
-            setBucketIdx: (b: number) => {
-              entry.lastProgressBucketIdx = b
+      // Narrative gate (JSONL-text-narrative primitive) — the SAME
+      // `NarrativeFlushController` kernel the main-agent gateway path uses,
+      // driven here by a POLL-driven scheduler so a worker's opening narration
+      // paints EARLY (~the next poll after PENDING_NARRATIVE_FLUSH_MS) instead
+      // of gating on its first tool. `show` fires the narrative onProgress cue
+      // for a SHOWN block (`latestSummary` = entry.lastResultText, never tool
+      // labels — matching the historical wire shape); the kernel owns the
+      // SHOW/SUPPRESS/early-paint/retract decisions (dedup lives in
+      // narrative-dedup.ts, timer + retract in narrative-flush.ts).
+      const buildNarrativeGate = (): WorkerNarrativeGate => {
+        // Injected clock the kernel's scheduler reads. Refreshed each poll via
+        // setNow/tick so `deadline = nowRef.value + flushMs` uses the CURRENT
+        // poll's `now` even though the kernel persists across polls.
+        const nowRef = { value: now }
+        // Whether the LAST kernel effect painted a narrative cue — read back by
+        // resolveOnTool/resolveAtTurnEnd for the tool-label clobber guard.
+        let cueFired = false
+        const fireCue = (): boolean => {
+          if (onProgress == null || entry.state !== 'running' || entry.historical) return false
+          try {
+            onProgress({
+              agentId: entry.agentId,
+              description: entry.description,
+              latestSummary: entry.lastResultText,
+              elapsedMs: nowRef.value - entry.dispatchedAt,
+              prevBucketIdx: entry.lastProgressBucketIdx,
+              setBucketIdx: (b: number) => {
+                entry.lastProgressBucketIdx = b
+              },
+              lastTool: entry.lastTool,
+              toolCount: entry.toolCount,
+              model: entry.currentModel,
+            })
+            return true
+          } catch (cbErr) {
+            log?.(`subagent-watcher: onProgress callback error ${entry.agentId}: ${(cbErr as Error).message}`)
+            return false
+          }
+        }
+        // Poll-driven scheduler: `arm` stamps a deadline off the injected clock;
+        // the watcher's `tick` fires it once the poll clock reaches it — the
+        // deterministic, clock-injected equivalent of the gateway's setTimeout.
+        const scheduler = {
+          armedFn: null as (() => void) | null,
+          deadline: 0,
+        }
+        const controller = new NarrativeFlushController(
+          {
+            show: () => {
+              cueFired = fireCue()
             },
-            lastTool: entry.lastTool,
-            toolCount: entry.toolCount,
-            model: entry.currentModel,
-          })
-          return true
-        } catch (cbErr) {
-          log?.(`subagent-watcher: onProgress callback error ${entry.agentId}: ${(cbErr as Error).message}`)
-          return false
+            // Retract on the worker path is a documented near-no-op: unlike the
+            // gateway (which splices a persisted narration mirror), the worker
+            // card is replace-on-write and the worker's reply is a
+            // Telegram-surface tool that `describeToolUse` never renders — so a
+            // timer-painted block can never be DOUBLE-printed as both a card
+            // step and the reply (the gateway's catastrophe is structurally
+            // impossible here). The transient trail line self-heals via the
+            // rolling window; the worker's true result rides
+            // lastResultText/onFinish regardless of the gate. See DESIGN.md
+            // "COVERAGE LIMIT" for the narrow >250ms-gap draft edge.
+            retractShown: () => {
+              log?.(
+                `subagent-watcher: narrative early-paint retract (no-op on replace-on-write worker card) ${entry.agentId}`,
+              )
+            },
+          },
+          {
+            arm: (fn, ms) => {
+              scheduler.armedFn = fn
+              scheduler.deadline = nowRef.value + ms
+            },
+            disarm: () => {
+              scheduler.armedFn = null
+            },
+          },
+          PENDING_NARRATIVE_FLUSH_MS,
+        )
+        return {
+          setNow: (n) => {
+            nowRef.value = n
+          },
+          tick: (n) => {
+            nowRef.value = n
+            if (scheduler.armedFn != null && n >= scheduler.deadline) {
+              const fn = scheduler.armedFn
+              scheduler.armedFn = null
+              fn() // → onTimerFire → show → fireCue (EARLY paint, no tool needed)
+            }
+          },
+          // stage/resolve run synchronously within a readSubTail call whose
+          // clock was already refreshed onto nowRef by the top-of-function
+          // `tick(now)` (or by buildNarrativeGate on the first block), so they
+          // must NOT re-stamp nowRef with a captured (stale) `now`.
+          stage: (text) => {
+            controller.stage(text)
+          },
+          resolveOnTool: (toolName, input) => {
+            cueFired = false
+            // NIT 3 (turn_end symmetry) lives inside the kernel: it compares the
+            // pending block against a REPLY_TOOL's input.text (tool path) and,
+            // at turn_end, against the delivered reply text passed by
+            // resolveAtTurnEnd. Here we only forward the tool lookahead.
+            controller.resolveOnTool(toolName ?? '', input)
+            return cueFired
+          },
+          resolveAtTurnEnd: (lastReplyText) => {
+            cueFired = false
+            controller.flushAtTurnEnd(lastReplyText)
+            return cueFired
+          },
+          reset: () => {
+            controller.teardown()
+            scheduler.armedFn = null
+          },
         }
       }
       // Resolve a pending sub-agent narrative against a lookahead event.
-      // SUPPRESS only when the pending block drafts a reply/stream_reply
-      // tool's text; otherwise SHOW (fire the cue). See narrative-dedup.ts §2b.
-      //
-      // Two lookahead shapes:
-      //   - sub_agent_tool_use: `toolName`/`toolInput` are the tool — suppress
-      //     a draft of THIS tool's reply text.
-      //   - sub_agent_turn_end: `toolName` is null. NIT 3 (turn_end symmetry):
-      //     a FOREGROUND sub-agent that called stream_reply/reply as its final
-      //     tool then emitted a trailing text block would, under the old
-      //     unconditional SHOW, surface a draft of the delivered answer. So at
-      //     turn_end we apply the SAME conservative dedup as main-agent step 3:
-      //     compare the trailing block against the worker's last reply text
-      //     (`entry.lastReplyText`) and suppress a draft. Background workers
-      //     never set lastReplyText, so their trailing narration still SHOWs.
-      // Returns true iff a narrative onProgress cue actually fired this
-      // call — callers use this to skip a redundant/clobbering tool-label
-      // onProgress cue for the SAME tick (see #1042 below: without this,
-      // the tool-description onProgress unconditionally fires right after
-      // and its replace-on-write onProgress always wins, so the narration
-      // shown here is never actually visible on the pinned card).
+      // SUPPRESS only when the pending block drafts a reply/stream_reply tool's
+      // text; otherwise SHOW (fire the cue). Two lookahead shapes:
+      //   - sub_agent_tool_use: forward the tool — the kernel suppresses a draft
+      //     of THIS tool's reply text (REPLY_TOOLS only).
+      //   - sub_agent_turn_end: `toolName` is null → resolveAtTurnEnd with
+      //     entry.lastReplyText, so a FOREGROUND sub-agent's trailing draft of
+      //     its delivered answer is suppressed (background workers never set
+      //     lastReplyText, so their trailing narration still SHOWs).
+      // Returns true iff a narrative onProgress cue actually fired — callers use
+      // this to skip a redundant/clobbering tool-label onProgress cue for the
+      // SAME tick (the tool-description onProgress's replace-on-write always
+      // wins, so firing both back-to-back hides the narration).
       const resolvePendingSubNarrative = (
         toolName: string | null,
         toolInput: Record<string, unknown> | undefined,
       ): boolean => {
-        if (entry.pendingNarrative == null) return false
-        const pending = entry.pendingNarrative
-        entry.pendingNarrative = null
-        if (toolName != null && REPLY_TOOLS.has(toolName)) {
-          const replyText = typeof toolInput?.text === 'string' ? (toolInput.text as string) : ''
-          if (isDraftOfReply(pending.text, replyText)) return false // draft of the reply → SUPPRESS
-        } else if (toolName == null && entry.lastReplyText != null && entry.lastReplyText.length > 0) {
-          // turn_end path: suppress a trailing draft of the delivered answer.
-          if (isDraftOfReply(pending.text, entry.lastReplyText)) return false
+        if (entry.narrativeGate == null) return false
+        if (toolName == null) {
+          return entry.narrativeGate.resolveAtTurnEnd(entry.lastReplyText ?? '')
         }
-        return fireNarrativeProgress()
+        return entry.narrativeGate.resolveOnTool(toolName, toolInput)
       }
       for (const ev of events) {
         const idleSecBeforeBump = Math.round((now - entry.lastActivityAt) / 1000)
@@ -1431,18 +1549,18 @@ export function readSubTail(
           // args or file content — consistent with the watcher's
           // "descriptions only" privacy posture.
           entry.lastResultText = ev.text.trim().slice(0, SUBAGENT_RESULT_TEXT_MAX)
-          // #1720 + JSONL-text-narrative gate step 1: stage this block for
-          // one lookahead step instead of firing the progress cue
-          // immediately. A previously-pending block had nothing reply-shaped
-          // after it (pure narration) → flush it as SHOWN now; then stage
-          // THIS block. Its eventual SHOW/SUPPRESS is decided by the next
-          // sub_agent_tool_use / sub_agent_turn_end. `lastResultText` /
-          // `lastSummaryLine` above already updated unconditionally — the
-          // handback payload is independent of the progress-cue decision.
-          if (entry.pendingNarrative != null) {
-            fireNarrativeProgress() // prior pending was pure narration → SHOW
-          }
-          entry.pendingNarrative = { text: ev.text }
+          // #1720 + JSONL-text-narrative gate step 1: stage this block for one
+          // lookahead step (AND arm the early-paint timer) instead of firing
+          // the progress cue immediately. The kernel's `stage` SHOWs any prior
+          // pending block (it had nothing reply-shaped after it → pure
+          // narration) then parks THIS one; its eventual SHOW/SUPPRESS is
+          // decided by the next sub_agent_tool_use / sub_agent_turn_end, or by
+          // the early-paint timer if neither arrives within the flush window.
+          // `lastResultText` / `lastSummaryLine` above already updated
+          // unconditionally — the handback payload is independent of the
+          // progress-cue decision. Gate is built lazily on the first block.
+          if (entry.narrativeGate == null) entry.narrativeGate = buildNarrativeGate()
+          entry.narrativeGate.stage(ev.text)
         } else if (ev.kind === 'sub_agent_tool_result') {
           // The tool call completed — clear it from the in-flight set so
           // the terminal-synthesis gate re-opens. Idempotent: a result
@@ -1894,7 +2012,11 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       // worker's card reaches real activity instead of a frozen stub.
       entry.toolCount = 0
       entry.lastTool = null
-      entry.pendingNarrative = null
+      // Cancel any armed early-paint timer + drop pending state before the
+      // from-scratch replay so a stale parked block can't fire against the
+      // rebuilt cursor. Rebuilt lazily on the first replayed sub_agent_text.
+      entry.narrativeGate?.reset()
+      entry.narrativeGate = null
       tail.cursor = 0
       tail.pendingPartial = ''
       tail.hasEmittedStart = false

--- a/telegram-plugin/tests/subagent-watcher-narrative-early-paint.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-narrative-early-paint.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Residual A regression: a worker / sub-agent's OPENING narration must paint
+ * EARLY on its card (~the next poll after PENDING_NARRATIVE_FLUSH_MS) WITHOUT
+ * waiting for the worker's first tool — the same time-box the main-agent card
+ * got in #3227, applied uniformly to the poll-driven worker/sub-agent path via
+ * the SHARED NarrativeFlushController kernel driven by the injected poll clock.
+ *
+ * These assert OUTCOMES on the onProgress cue stream (the worker card is
+ * replace-on-write via onProgress), driven by an INJECTED clock so the timing
+ * is deterministic:
+ *   - a parked opening narration fires a narrative cue after the flush window
+ *     with NO tool event (RED if the early-paint tick is removed);
+ *   - it fires at more than one entry (depth-generic — the registry is flat, so
+ *     every sub-agent/worker/nested sub-worker is a WorkerEntry and the gate is
+ *     per-entry);
+ *   - the early-painted block is NOT re-fired (no double-print) and does not
+ *     leave a stale duplicate when the first real tool step lands after it;
+ *   - a tool arriving WITHIN the window still resolves the block exactly once
+ *     (no early-paint + resolve double).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+import { PENDING_NARRATIVE_FLUSH_MS } from '../narrative-flush.js'
+
+function buildJSONL(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+}
+function subAgentUserMsg(promptText: string) {
+  return { type: 'user', message: { content: [{ type: 'text', text: promptText }] } }
+}
+function subAgentAssistantText(text: string) {
+  return { type: 'assistant', message: { content: [{ type: 'text', text }] } }
+}
+function subAgentToolUse(name: string, id: string) {
+  return { type: 'assistant', message: { content: [{ type: 'tool_use', name, id, input: {} }] } }
+}
+
+interface Cue { progressLine?: string; latestSummary: string }
+
+describe('worker/sub-agent opening-narration early paint (Residual A)', () => {
+  let tmpRoot = ''
+  const started: Array<ReturnType<typeof startSubagentWatcher>> = []
+
+  afterEach(() => {
+    while (started.length) {
+      try { started.pop()?.stop() } catch { /* ignore */ }
+    }
+    if (tmpRoot) {
+      try { rmSync(tmpRoot, { recursive: true, force: true }) } catch { /* ignore */ }
+      tmpRoot = ''
+    }
+  })
+
+  /** Watcher over a real tmpdir with an INJECTED, manually-advanced clock. */
+  function startWatcher(agentDir: string) {
+    let currentTime = 100_000
+    const cues: Array<{ agentId: string } & Cue> = []
+    const intervals: Array<{ fn: () => void; ref: number }> = []
+    let nextRef = 1
+    const watcher = startSubagentWatcher({
+      agentDir,
+      onFinish: () => {},
+      onProgress: ({ agentId, progressLine, latestSummary }) => {
+        cues.push({ agentId, progressLine, latestSummary })
+      },
+      stallThresholdMs: 600_000,
+      silentSynthesisStallThresholdMs: 600_000,
+      rescanMs: 1000,
+      now: () => currentTime,
+      setInterval: (fn) => { const ref = nextRef++; intervals.push({ fn, ref }); return { ref } },
+      clearInterval: (handle) => {
+        const { ref } = handle as { ref: number }
+        const idx = intervals.findIndex((i) => i.ref === ref)
+        if (idx !== -1) intervals.splice(idx, 1)
+      },
+      setTimeout: () => ({ ref: nextRef++ }),
+      clearTimeout: () => {},
+      log: () => {},
+    })
+    started.push(watcher)
+    return {
+      watcher,
+      cues,
+      poll: () => intervals[0]?.fn(),
+      advance: (ms: number) => { currentTime += ms },
+    }
+  }
+
+  function narrativeCues(cues: Cue[]): string[] {
+    // Narrative cues carry NO progressLine; tool-label cues do.
+    return cues.filter((c) => c.progressLine == null).map((c) => c.latestSummary)
+  }
+
+  it('paints a parked opening narration after the flush window with NO tool event', () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'sr-early-paint-'))
+    const agentDir = join(tmpRoot, 'agent')
+    const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+    mkdirSync(subagentsDir, { recursive: true })
+    const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+
+    writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Do the task')))
+    const h = startWatcher(agentDir)
+    h.poll() // register + promote to live
+
+    // Opening narration arrives; the worker then "thinks" (no tool yet).
+    appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText('On it — pulling the logs first.')))
+    h.poll() // parks the block, arms the early-paint timer — NO cue yet
+    expect(narrativeCues(h.cues), 'parked block must not paint before the window').toHaveLength(0)
+
+    // Advance past the flush window and poll again — STILL no new jsonl event.
+    h.advance(PENDING_NARRATIVE_FLUSH_MS + 50)
+    h.poll()
+
+    const narr = narrativeCues(h.cues)
+    expect(narr, 'opening narration must early-paint without a tool').toHaveLength(1)
+    expect(narr[0]).toContain('pulling the logs')
+  })
+
+  it('does NOT paint before the flush window elapses', () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'sr-early-paint-nofire-'))
+    const agentDir = join(tmpRoot, 'agent')
+    const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+    mkdirSync(subagentsDir, { recursive: true })
+    const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+
+    writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Do the task')))
+    const h = startWatcher(agentDir)
+    h.poll()
+    appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText('On it — pulling the logs first.')))
+    h.poll()
+
+    // Advance LESS than the window — the tick must not fire yet.
+    h.advance(PENDING_NARRATIVE_FLUSH_MS - 50)
+    h.poll()
+    expect(narrativeCues(h.cues), 'must not paint before the window').toHaveLength(0)
+  })
+
+  it('is depth-generic: two independent entries each early-paint their opening narration', () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'sr-early-paint-depth-'))
+    const agentDir = join(tmpRoot, 'agent')
+    const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+    mkdirSync(subagentsDir, { recursive: true })
+    // Two entries stand in for two nesting levels: the registry is FLAT, so a
+    // top worker and a nested depth-2 sub-worker are both plain WorkerEntry
+    // rows and take the identical per-entry gate — this proves the mechanism
+    // is depth-generic (it operates on the generic node, not a fixed level).
+    const aPath = join(subagentsDir, 'agent-aaaa0000.jsonl')
+    const bPath = join(subagentsDir, 'agent-bbbb1111.jsonl')
+    writeFileSync(aPath, buildJSONL(subAgentUserMsg('Level 1 task')))
+    writeFileSync(bPath, buildJSONL(subAgentUserMsg('Level 2 task')))
+    const h = startWatcher(agentDir)
+    h.poll()
+    appendFileSync(aPath, buildJSONL(subAgentAssistantText('Worker A: reading the config.')))
+    appendFileSync(bPath, buildJSONL(subAgentAssistantText('Worker B: cloning the repo.')))
+    h.poll()
+    expect(narrativeCues(h.cues)).toHaveLength(0)
+
+    h.advance(PENDING_NARRATIVE_FLUSH_MS + 50)
+    h.poll()
+
+    const aCues = h.cues.filter((c) => c.agentId === 'aaaa0000' && c.progressLine == null)
+    const bCues = h.cues.filter((c) => c.agentId === 'bbbb1111' && c.progressLine == null)
+    expect(aCues.map((c) => c.latestSummary).join(' ')).toContain('reading the config')
+    expect(bCues.map((c) => c.latestSummary).join(' ')).toContain('cloning the repo')
+  })
+
+  it('does not double-print: an early-painted block is not re-shown when the first real tool lands', () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'sr-early-paint-nodup-'))
+    const agentDir = join(tmpRoot, 'agent')
+    const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+    mkdirSync(subagentsDir, { recursive: true })
+    const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+    writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Do the task')))
+    const h = startWatcher(agentDir)
+    h.poll()
+    appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText('On it — pulling the logs first.')))
+    h.poll()
+    h.advance(PENDING_NARRATIVE_FLUSH_MS + 50)
+    h.poll() // early-paint fires (1 narrative cue)
+    expect(narrativeCues(h.cues)).toHaveLength(1)
+
+    // Now the worker's first real tool lands. The parked block was already
+    // consumed by the timer → it must NOT re-fire as a narrative cue, and the
+    // tool-label cue is a SEPARATE step (no stale duplicate narration).
+    appendFileSync(jsonlPath, buildJSONL(subAgentToolUse('Bash', 'b1')))
+    h.advance(10)
+    h.poll()
+
+    expect(narrativeCues(h.cues), 'narration must not be re-shown').toHaveLength(1)
+    const toolCues = h.cues.filter((c) => c.progressLine != null)
+    expect(toolCues.length, 'the tool step fires as its own cue').toBeGreaterThanOrEqual(1)
+  })
+
+  it('a tool arriving WITHIN the window resolves the block exactly once (no early-paint + resolve double)', () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'sr-early-paint-within-'))
+    const agentDir = join(tmpRoot, 'agent')
+    const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+    mkdirSync(subagentsDir, { recursive: true })
+    const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+    writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Do the task')))
+    const h = startWatcher(agentDir)
+    h.poll()
+    appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText('On it — let me find the repo.')))
+    h.poll()
+    // Tool lands well within the window → resolve shows it once; timer never fires.
+    h.advance(50)
+    appendFileSync(jsonlPath, buildJSONL(subAgentToolUse('Bash', 'b1')))
+    h.poll()
+    // Advance past the window: the (already-consumed) block must not re-paint.
+    h.advance(PENDING_NARRATIVE_FLUSH_MS + 50)
+    h.poll()
+    expect(narrativeCues(h.cues), 'resolved narration shows exactly once').toHaveLength(1)
+  })
+})

--- a/telegram-plugin/tests/worker-feed-terminal-state-truthful.test.ts
+++ b/telegram-plugin/tests/worker-feed-terminal-state-truthful.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Residual B regression: a worker cleaned up by the TTL / authoritative
+ * `terminate` sweep — i.e. reaped / vanished / crashed WITHOUT ever delivering
+ * a clean `onFinish` result — must render a TRUTHFUL terminal state, NOT "done".
+ *
+ * `terminateWorker` synthesises the recap when NO clean finish arrived (a clean
+ * `onFinish` removes the row first, making `terminate` a no-op; an errored
+ * worker goes through `onFinish(outcome:'failed')`). So a row still present at
+ * terminate time genuinely ended without a result → it must render as the
+ * `incomplete` terminal ("incomplete · …"), never "done".
+ *
+ * OUTCOME assertions on the finalized card body (RED if `terminate` reverts to
+ * `state:'done'`), applied to the generic worker row so the guarantee holds at
+ * every nesting level (the feed keys rows by agentId, depth-agnostic):
+ *   - a solo reaped worker's terminal card reads `incomplete`, never `done`;
+ *   - a genuinely-`finish`ed worker still reads `done` with its result.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  createWorkerActivityFeed,
+  renderWorkerActivity,
+  type BotApiForWorkerFeed,
+  type WorkerActivityView,
+} from '../worker-activity-feed.js'
+
+function makeFeed(now: () => number) {
+  const sends: { text: string }[] = []
+  const edits: { messageId: number; text: string }[] = []
+  let seq = 900
+  const bot: BotApiForWorkerFeed = {
+    sendMessage: async (_c, text) => { sends.push({ text }); return { message_id: seq++ } },
+    editMessageText: async (_c, messageId, text) => { edits.push({ messageId, text }); return true },
+  }
+  const feed = createWorkerActivityFeed({
+    bot,
+    now,
+    minEditIntervalMs: 0,
+    firstPaintMinMs: 0,
+    setInterval: () => 0,
+    clearInterval: () => {},
+  })
+  return { feed, sends, edits }
+}
+const runningView = (desc: string, step: string, elapsedMs: number): WorkerActivityView => ({
+  description: desc, lastTool: null, toolCount: 3, latestSummary: step, elapsedMs, state: 'running',
+})
+async function drain(): Promise<void> {
+  for (let i = 0; i < 12; i++) await new Promise((r) => setImmediate(r))
+}
+
+describe('worker terminal state is truthful for reaped workers (Residual B)', () => {
+  it('a reaped/vanished worker (terminate, no clean finish) renders `incomplete`, never `done`', async () => {
+    let clock = 1000
+    const { feed, edits } = makeFeed(() => clock)
+    clock = 1000
+    await feed.update('w', 'chat', runningView('background job', 'doing work', 1000))
+    await drain()
+    clock = 5000
+    // Authoritative sweep / TTL backstop: no onFinish ever arrived.
+    await feed.terminate('w')
+    await drain()
+
+    const last = edits[edits.length - 1].text
+    expect(last, 'reaped worker must NOT read as done').not.toMatch(/\bdone\b/)
+    expect(last, 'reaped worker reads the truthful incomplete terminal').toContain('incomplete')
+    expect(feed.size).toBe(0)
+  })
+
+  it('a genuinely finished worker still renders `done` with its result', async () => {
+    let clock = 1000
+    const { feed, edits } = makeFeed(() => clock)
+    await feed.update('w', 'chat', runningView('background job', 'doing work', 1000))
+    await drain()
+    clock = 2000
+    await feed.finish('w', {
+      description: 'background job',
+      lastTool: null,
+      toolCount: 5,
+      latestSummary: 'the delivered result paragraph',
+      elapsedMs: 2000,
+      state: 'done',
+    })
+    await drain()
+    const last = edits[edits.length - 1].text
+    expect(last).toContain('done')
+    expect(last).toContain('the delivered result paragraph')
+    expect(last).not.toContain('incomplete')
+  })
+
+  it('renderWorkerActivity renders the `incomplete` state as a finished card without a fabricated result', () => {
+    const card = renderWorkerActivity({
+      description: 'background job',
+      lastTool: null,
+      toolCount: 3,
+      latestSummary: '', // reaped: no result text
+      elapsedMs: 4000,
+      state: 'incomplete',
+    })
+    expect(card).toContain('incomplete')
+    expect(card).not.toMatch(/\bdone\b/)
+    // No fabricated result paragraph (latestSummary empty) → no ✅ result block.
+    expect(card).not.toContain('✅')
+  })
+})

--- a/telegram-plugin/tests/worker-feed-terminal-state-truthful.test.ts
+++ b/telegram-plugin/tests/worker-feed-terminal-state-truthful.test.ts
@@ -101,4 +101,25 @@ describe('worker terminal state is truthful for reaped workers (Residual B)', ()
     // No fabricated result paragraph (latestSummary empty) → no ✅ result block.
     expect(card).not.toContain('✅')
   })
+
+  it('renderWorkerActivity NEVER renders a result/⚠️ block for `incomplete`, even with a non-empty latestSummary (deterministic guard, not caller-discipline)', () => {
+    // Latent-trap regression guard: the live call site (terminateWorker) always
+    // passes latestSummary:'' for a reaped worker, but a future/direct caller
+    // could pass stray text. The truthful-no-result invariant must be enforced
+    // in the renderer — an `incomplete` worker produced no result, so it must
+    // never fabricate a ⚠️-prefixed result paragraph regardless of the summary.
+    const card = renderWorkerActivity({
+      description: 'background job',
+      lastTool: null,
+      toolCount: 3,
+      latestSummary: 'this looks like a real result but the worker never finished',
+      elapsedMs: 4000,
+      state: 'incomplete',
+    })
+    expect(card).toContain('incomplete')
+    // The renderer maps a non-`done` finished result to the ⚠️ emoji; the guard
+    // must suppress that block entirely for `incomplete`.
+    expect(card).not.toContain('⚠️')
+    expect(card).not.toContain('this looks like a real result')
+  })
 })

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -170,8 +170,10 @@ export function clipNarrative(s: string): string {
  * `description` — italicised task description (optional)
  * `elapsedMs`   — wall-clock elapsed, rendered via `formatFeedElapsed`
  * `toolCount`   — labeled tool calls this turn
- * `state`       — 'running' | 'done' | 'failed' (controls the status line wording;
- *                 'failed' renders `failed · …` so a failed worker never reads as done)
+ * `state`       — 'running' | 'done' | 'failed' | 'incomplete' (controls the
+ *                 status line wording; 'failed'/'incomplete' render
+ *                 `failed · …` / `incomplete · …` so a failed or reaped worker
+ *                 never reads as done)
  *
  * Returns a two-element array of ready Telegram HTML lines (no trailing newline).
  */
@@ -181,7 +183,7 @@ export function renderActivityHeader(
   description: string,
   elapsedMs: number,
   toolCount: number,
-  state: 'running' | 'done' | 'failed',
+  state: 'running' | 'done' | 'failed' | 'incomplete',
   model?: string,
 ): [string, string] {
   const toolWord = toolCount === 1 ? 'tool' : 'tools'
@@ -283,7 +285,7 @@ export interface StatusCardHeader {
   description?: string
   elapsedMs: number
   toolCount: number
-  state: 'running' | 'done' | 'failed'
+  state: 'running' | 'done' | 'failed' | 'incomplete'
   /** Live model id (raw, e.g. `claude-opus-4-8`) — rendered as a short friendly
    *  tag on the metrics line via `formatModelLabel`. Omitted when unknown. */
   model?: string

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -69,7 +69,20 @@ export function isWorkerActivityFeedEnabled(envVal: string | undefined): boolean
   return envVal !== '0'
 }
 
-export type WorkerActivityState = 'running' | 'done' | 'failed'
+/**
+ * Terminal states a worker card can render.
+ *   - 'running'    — live.
+ *   - 'done'       — clean finish WITH a result (✅).
+ *   - 'failed'     — clean finish reporting a failure / crash observed in the
+ *                    transcript (⚠️).
+ *   - 'incomplete' — force-reaped / vanished / crashed WITHOUT any clean finish
+ *                    (the TTL sweep or the watcher's authoritative
+ *                    `onTerminalCleanup` synthesised the terminal because
+ *                    neither `onFinish` nor a turn_end ever delivered a result).
+ *                    Renders `incomplete · …` so a reaped worker NEVER reads as
+ *                    "done" — the truthful "ended without result" terminal.
+ */
+export type WorkerActivityState = 'running' | 'done' | 'failed' | 'incomplete'
 
 /** The render-relevant snapshot of a worker at one instant. */
 export interface WorkerActivityView {
@@ -141,7 +154,7 @@ const DESC_MAX = 80
  */
 export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): string {
   const desc = truncate(stripMarkdown(v.description).trim() || 'background task', DESC_MAX)
-  const finished = v.state === 'done' || v.state === 'failed'
+  const finished = v.state === 'done' || v.state === 'failed' || v.state === 'incomplete'
 
   // Raw narrative steps (unstripped/unescaped) — the unified renderer runs the
   // full per-line pipeline (stripMarkdown → collapse ws → clip → escape).
@@ -843,7 +856,11 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
    */
   function finalizeWorker(group: FeedGroup, agentId: string, row: WorkerRow, view: WorkerActivityView): Promise<void> {
     row.finished = true
-    row.state = view.state === 'failed' ? 'failed' : 'done'
+    // Preserve the truthful terminal state through to the row (done / failed /
+    // incomplete) — never collapse a reaped 'incomplete' into 'done'. view.state
+    // is always terminal on this path (finalize is only reached for a finishing
+    // worker), so threading it verbatim is correct.
+    row.state = view.state
     markFinalized(agentId)
     group.chain = group.chain
       .then(() => {
@@ -869,9 +886,16 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   /**
    * Force a worker terminal without an external result view (authoritative
    * `onTerminalCleanup` sweep or the TTL backstop). Synthesises the recap from
-   * the row's own last-known state — state `done`, NO fabricated result text
-   * (the real result, if any, reaches the user via the separate handback).
-   * Idempotent: a no-op once the worker was already removed (onFinish first).
+   * the row's own last-known state — state `incomplete` (NOT `done`), NO
+   * fabricated result text (the real result, if any, reaches the user via the
+   * separate handback). Reaching here means NO clean finish arrived: a clean
+   * `onFinish` removes the row FIRST (this call is then a no-op), and an
+   * errored worker goes through `onFinish(outcome:'failed')` → `finish` — so a
+   * row still present at terminate time genuinely ended WITHOUT a result. It
+   * must therefore render `incomplete · …`, never "done" (a crash/vanish read
+   * as "done" was the residual this fixes). Idempotent: a no-op once the worker
+   * was already removed (onFinish first). Depth-generic: operates on the
+   * generic worker row by agentId, identical at every nesting level.
    */
   function terminateWorker(agentId: string): Promise<void> {
     const g = groupOfAgent(agentId)
@@ -893,10 +917,10 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       toolCount: lv?.toolCount ?? 0,
       // No fabricated result paragraph — an authoritative sweep can't know what
       // the worker returned; the terminal card shows the header struck-through
-      // done, and the handback (if it ran) carries the actual result.
+      // as `incomplete`, and the handback (if it ran) carries the actual result.
       latestSummary: '',
       elapsedMs: liveElapsed(row, nowFn()),
-      state: 'done',
+      state: 'incomplete',
       model: lv?.model,
     }
     return finalizeWorker(g, agentId, row, view)

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -182,8 +182,15 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
 
   // Terminal: latestSummary carries the worker's final result text (gateway
   // onFinish), distinct from the running narrative steps. Pass it as `result`.
+  //
+  // Truthful-no-result invariant (deterministic control, not caller-discipline):
+  // an `incomplete` worker produced NO result, so it must NEVER render a result
+  // block regardless of whatever `latestSummary` happens to carry. The current
+  // call site (terminateWorker) always sets latestSummary:'' for incomplete, but
+  // enforce the invariant HERE so any future/direct caller can't fabricate a
+  // `⚠️`-prefixed result paragraph out of stray summary text.
   let result: { emoji: string; text: string } | undefined
-  if (finished) {
+  if (finished && v.state !== 'incomplete') {
     const text = cleanWorkerResultParagraph(v.latestSummary)
     if (text.length > 0) result = { emoji: v.state === 'done' ? '✅' : '⚠️', text }
   }


### PR DESCRIPTION
## Summary
Two residuals from the just-merged progress-card batch (#3220/#3226/#3227), fixed **uniformly across every card-rendering / terminal path at every nesting level**. The registry is flat — every sub-agent / worker / nested sub-worker is a `WorkerEntry` (watcher) and a worker-feed row keyed by `agentId` — so a fix on the generic node is depth-generic by construction.

### Residual A — opening narration now paints early on worker/sub-agent cards too
#3227 time-boxed the early-paint only on the MAIN session card (real `setTimeout`). The poll-driven worker/sub-agent path in `subagent-watcher.ts` kept its inlined one-step defer with **no** time-box, so a worker's opening narration waited for its first tool.

Now **reuses the SAME `NarrativeFlushController` kernel** (one source of truth) driven by a **poll-driven scheduler**: `arm` stamps `deadline = nowFn()+PENDING_NARRATIVE_FLUSH_MS`; a per-poll `tick(now)` (run before the no-growth early-return in `readSubTail`) fires the parked block once the window elapses, without waiting for a tool. Deterministic under the injected clock. `PENDING_NARRATIVE_FLUSH_MS` moved to `narrative-flush.ts` so the gateway and the watcher share ONE constant.

Anti-double-print: the worker card is replace-on-write and its reply is a Telegram-surface tool that `describeToolUse` never renders on the card, so the gateway's double-print catastrophe (answer as both a step and the pinned reply) is **structurally impossible** here — the kernel's `retractShown` effect is a documented near-no-op. See DESIGN "COVERAGE LIMIT" for the narrow >250 ms-gap draft edge.

### Residual B — sweep-reaped/crashed workers render the truthful terminal state
`worker-activity-feed.ts terminateWorker` (TTL sweep + authoritative `onTerminalCleanup`) synthesised `state:'done'` for a worker reaped / vanished / crashed **without a clean finish**, so a FAILURE read as "done". It now renders a new truthful terminal state **`incomplete`** (`incomplete · N tools · elapsed`, no fabricated result). A clean `onFinish` (done/failed) removes the row first, and an errored worker goes through `onFinish(outcome:'failed')` — so a row reaching `terminate` genuinely ended without a result. `incomplete` threaded through `WorkerActivityState`, `renderActivityHeader`, `StatusCardHeader.state`, `renderWorkerActivity` (finished), and `finalizeWorker` (row.state preserved).

Product decision flagged for review: label `incomplete` (open to `terminated`/`ended`).

## Tests (assert outcomes; verified RED on revert)
- `subagent-watcher-narrative-early-paint.test.ts` — parked opening narration early-paints with no tool after the window; two entries (depth-generic); no double-print when the first tool lands; no early-paint+resolve double.
- `worker-feed-terminal-state-truthful.test.ts` — a reaped worker renders `incomplete` not `done`; a genuinely-finished worker still renders `done`.

## Validation
- Scoped suites: **318 passed** across 14 files (subagent-watcher, worker-activity-feed, worker-feed-coalesce/terminal-cleanup, tool-activity-summary, narrative-flush/dedup/render, emission-authority-facade, nested-worker-visibility) + 55 more in progress/prose/boot-promotion suites.
- Both fixes empirically **RED on revert** (neutered the tick → 3 A-tests fail; reverted terminate→'done' → the reaped B-test fails).
- Root `tsc --noEmit`: clean. Scoped tsc over the 4 changed source files: 0 errors.
- `check-plugin-references` reports 161 pre-existing grammy rich-message type-augmentation errors that are **identical on the pristine base** (`origin/main` HEAD fails the same way in this environment; only line numbers shift with my const removal) — none introduced by this change. This check is the full-suite / CI authority.
- No emission-authority drain/guard site added or removed → the facade source-count guard is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)