### PR TITLE
fix(worker-feed): stop leaked finished rows from pinning the coalesced feed forever (#3207)

### DIFF
--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -1513,7 +1513,7 @@ describe('worker-feed send-gate shed contract', () => {
     expect(bot.edits[0].text).toContain('2 tools')
   })
 
-  it('does not falsely finalize on a shed terminal edit — re-drives the finalize once the gate clears', async () => {
+  it('a shed terminal edit drops the finished row immediately but stages the recap for a heartbeat re-drive (#3207)', async () => {
     let clock = 10_000
     const bot = makeGateBot(() => 0)
     const feed = createWorkerActivityFeed({
@@ -1522,25 +1522,30 @@ describe('worker-feed send-gate shed contract', () => {
       firstPaintMinMs: 0,
       minEditIntervalMs: 0,
       floodWaitRemainingMs: () => 0,
+      setInterval: () => 1,
+      clearInterval: () => {},
     })
 
     await feed.update('w1', 'chat', view({ toolCount: 1 }))
     expect(bot.sent).toHaveLength(1)
 
-    // Gate sheds the terminal edit (undefined).
+    // Gate sheds the terminal edit (SEND_GATE_SHED sentinel).
     clock = 20_000
     bot.shedNextEdit = true
     await feed.finish('w1', view({ state: 'done', toolCount: 5 }))
     expect(bot.editCalls).toBe(1)
     expect(bot.edits).toHaveLength(0)
-    // NOT finalized: the handle survives (pendingFinish staged) rather than
-    // being torn down with the card frozen on its last running render.
-    expect(feed.has('w1')).toBe(true)
+    // #3207: the finished row is dropped RIGHT AWAY — it is NOT kept alive to
+    // leak the group/pin when the terminal edit fails. The recap is staged for
+    // the heartbeat re-drive instead (a second finish() would be a no-op: the
+    // agent is already finalized + removed).
+    expect(feed.has('w1')).toBe(false)
+    expect(feed.size).toBe(0)
 
-    // Re-drive with the gate clear: the terminal recap lands and the handle
-    // finalizes.
+    // A heartbeat with the gate clear re-drives the staged recap → it lands.
     clock = 30_000
-    await feed.finish('w1', view({ state: 'done', toolCount: 5 }))
+    feed.heartbeatTick()
+    await new Promise((r) => setTimeout(r, 0))
     expect(bot.edits).toHaveLength(1)
     expect(bot.edits[0].text).toContain('_done · 5 tools')
     expect(feed.has('w1')).toBe(false)

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -546,7 +546,7 @@ describe('coalesced worker feed — leaked finished-row fix (#3207)', () => {
 
   it('TWO workers finishing in the same flood window are BOTH reaped (no single-slot overwrite)', async () => {
     let flooding = true
-    const { feed, pins, sent, setClock } = leakHarness({
+    const { feed, pins, sent, edits, setClock } = leakHarness({
       failEdits: () => (flooding ? { error_code: 429, parameters: { retry_after: 2 } } : null),
     })
     setClock(1000)
@@ -574,6 +574,17 @@ describe('coalesced worker feed — leaked finished-row fix (#3207)', () => {
     setClock(5000)
     feed.heartbeatTick()
     await drain()
+
+    // BOTH staged terminal recaps must actually repaint — not just one. This is
+    // the contract the per-agent `pendingFinalize` map exists to hold: a single-
+    // slot `pendingFinalize` would have let worker B's stage overwrite worker A's,
+    // so only ONE recap edit would land and this assertion would FAIL. The
+    // decoupled row-removal (fix 1) alone would pass size===0 + unpin above WITHOUT
+    // repainting either recap, so those assertions do not pin this contract — these
+    // do. Each recap carries its own worker's description ('task A' / 'task B').
+    const doneEdits = edits.filter((e) => e.text.includes('_done ·'))
+    expect(doneEdits.some((e) => e.text.includes('task A'))).toBe(true)
+    expect(doneEdits.some((e) => e.text.includes('task B'))).toBe(true)
 
     // The group is gone: a later worker paints a FRESH message, never editing a
     // terminated sibling's message.

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -443,6 +443,191 @@ describe('coalesced worker feed — GROUP-level pin lifecycle (#3207 review)', (
   })
 })
 
+// ─── #3207 leaked-finished-row fix ────────────────────────────────────────────
+//
+// Root cause of the "progress card never unpins; later workers append to a
+// stale pinned message" incident (a card observed pinned + edited for 2h12m):
+// a finished worker row whose terminal edit hit a 429/flood window was left in
+// `g.workers`, so the group never emptied → never deleted → never unpinned, and
+// a later worker inherited the stale message. These outcome tests pin the fix:
+// group emptiness / deletion / unpin are decoupled from terminal-edit success,
+// the finalize staging is per-agent (no single-slot overwrite), and a later
+// worker never reuses a terminated group's message.
+
+describe('coalesced worker feed — leaked finished-row fix (#3207)', () => {
+  interface PinCall {
+    feedKey: string
+    chatId: string
+    messageId: number | null
+  }
+  function leakHarness(opts: { failEdits?: () => unknown } = {}) {
+    const pins: PinCall[] = []
+    const sent: { chatId: string; text: string; messageId: number }[] = []
+    const edits: { messageId: number; text: string }[] = []
+    let seq = 700
+    let clock = 0
+    const bot: BotApiForWorkerFeed = {
+      sendMessage: async (chatId, text) => {
+        const messageId = seq++
+        sent.push({ chatId, text, messageId })
+        return { message_id: messageId }
+      },
+      editMessageText: async (_chatId, messageId, text) => {
+        const err = opts.failEdits?.()
+        if (err != null) throw err
+        edits.push({ messageId, text })
+        return true
+      },
+    }
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 0,
+      firstPaintMinMs: 0,
+      heartbeatTickMs: 6000,
+      setInterval: () => 0,
+      clearInterval: () => {},
+      reconcilePin: ({ feedKey, chatId, messageId }) => pins.push({ feedKey, chatId, messageId }),
+    })
+    return { feed, pins, sent, edits, setClock: (t: number) => (clock = t) }
+  }
+  const done = (desc: string, elapsedMs: number): WorkerActivityView => ({
+    description: desc,
+    lastTool: null,
+    toolCount: 3,
+    latestSummary: `${desc} result`,
+    elapsedMs,
+    state: 'done',
+  })
+  const drain = () => new Promise((r) => setTimeout(r, 0))
+
+  it('drops the finished row + requests unpin even when the last terminal edit floods (429)', async () => {
+    let flooding = true
+    const { feed, pins, sent, edits, setClock } = leakHarness({
+      failEdits: () => (flooding ? { error_code: 429, parameters: { retry_after: 2 } } : null),
+    })
+    setClock(1000)
+    await feed.update('w1', 'chat', view('task 1', 'doing', 1000))
+    expect(sent).toHaveLength(1)
+    const feedKey = pins[pins.length - 1].feedKey
+
+    // The LAST worker finishes but the terminal recap edit 429s.
+    setClock(2000)
+    await feed.finish('w1', done('task 1', 2000))
+    await drain()
+
+    // Outcome: the finished row is gone and the pin is RELEASED immediately —
+    // neither is blocked by the failed terminal edit.
+    expect(feed.has('w1')).toBe(false)
+    expect(feed.size).toBe(0)
+    // Pin-reaper backstop: no running rows remain → the group is not "running".
+    expect(feed.hasRunningInFeed(feedKey)).toBe(false)
+    expect(pins[pins.length - 1].messageId).toBeNull()
+    // The terminal recap has NOT landed yet (still flooding) — proves the unpin
+    // did not wait on it.
+    expect(edits.some((e) => e.text.includes('_done ·'))).toBe(false)
+
+    // Flood clears; a heartbeat past the cooldown re-drives the staged recap.
+    flooding = false
+    setClock(5000)
+    feed.heartbeatTick()
+    await drain()
+    expect(edits.some((e) => e.text.includes('_done ·'))).toBe(true)
+
+    // The group is fully reaped: a later worker in the SAME chat paints a FRESH
+    // message — it does NOT reuse/edit the terminated group's message id.
+    setClock(6000)
+    await feed.update('w2', 'chat', view('task 2', 'doing2', 6000))
+    await drain()
+    expect(sent).toHaveLength(2)
+    expect(feed.messageIdOf('w2')).toBe(sent[1].messageId)
+    expect(feed.messageIdOf('w2')).not.toBe(sent[0].messageId)
+  })
+
+  it('TWO workers finishing in the same flood window are BOTH reaped (no single-slot overwrite)', async () => {
+    let flooding = true
+    const { feed, pins, sent, setClock } = leakHarness({
+      failEdits: () => (flooding ? { error_code: 429, parameters: { retry_after: 2 } } : null),
+    })
+    setClock(1000)
+    await feed.update('a', 'chat', view('task A', 'a-doing', 1000))
+    await feed.update('b', 'chat', view('task B', 'b-doing', 1000))
+    expect(feed.size).toBe(2)
+    const feedKey = pins[pins.length - 1].feedKey
+
+    // Both finish before either finalize chain drains, so both latch terminal in
+    // the SAME cooldown window. The old single `pendingFinalize` slot dropped all
+    // but one → the other row leaked forever. The per-agent map keeps both.
+    setClock(2000)
+    const f1 = feed.finish('a', done('task A', 2000))
+    const f2 = feed.finish('b', done('task B', 2000))
+    await Promise.all([f1, f2])
+    await drain()
+
+    // NEITHER finished row leaks — the group is empty and unpinned.
+    expect(feed.size).toBe(0)
+    expect(feed.hasRunningInFeed(feedKey)).toBe(false)
+    expect(pins[pins.length - 1].messageId).toBeNull()
+
+    // Flood clears; one heartbeat drains ALL staged recaps and reaps the group.
+    flooding = false
+    setClock(5000)
+    feed.heartbeatTick()
+    await drain()
+
+    // The group is gone: a later worker paints a FRESH message, never editing a
+    // terminated sibling's message.
+    setClock(6000)
+    await feed.update('c', 'chat', view('task C', 'c-doing', 6000))
+    await drain()
+    const firstMsgId = sent[0].messageId
+    expect(feed.messageIdOf('c')).toBe(sent[sent.length - 1].messageId)
+    expect(feed.messageIdOf('c')).not.toBe(firstMsgId)
+  })
+
+  it('a later worker after all prior workers finished does NOT reuse the prior message id', async () => {
+    const { feed, sent, setClock } = leakHarness()
+    setClock(1000)
+    await feed.update('w1', 'chat', view('task 1', 'doing', 1000))
+    setClock(2000)
+    await feed.finish('w1', done('task 1', 2000))
+    await drain()
+    expect(feed.size).toBe(0)
+
+    // A brand-new worker in the same chat gets its OWN fresh message.
+    setClock(3000)
+    await feed.update('w2', 'chat', view('task 2', 'doing2', 3000))
+    await drain()
+    expect(sent).toHaveLength(2)
+    expect(feed.messageIdOf('w2')).toBe(sent[1].messageId)
+    expect(feed.messageIdOf('w2')).not.toBe(sent[0].messageId)
+  })
+
+  it('hasRunningInFeed is false once only finished rows remain (pin-reaper backstop fires)', async () => {
+    // A sibling keeps the group running; when the LAST running worker finishes,
+    // no running row remains → hasRunningInFeed flips to false so the gateway's
+    // wk:group: reaper is free to unpin (finished rows never count as running).
+    const { feed, pins, setClock } = leakHarness()
+    setClock(1000)
+    await feed.update('a', 'chat', view('task A', 'a-doing', 1000))
+    await feed.update('b', 'chat', view('task B', 'b-doing', 1000))
+    const feedKey = pins[pins.length - 1].feedKey
+    expect(feed.hasRunningInFeed(feedKey)).toBe(true)
+
+    setClock(2000)
+    await feed.finish('a', done('task A', 2000))
+    await drain()
+    // One still runs → still counts.
+    expect(feed.hasRunningInFeed(feedKey)).toBe(true)
+
+    setClock(3000)
+    await feed.finish('b', done('task B', 3000))
+    await drain()
+    // Only finished work remains → NOT running.
+    expect(feed.hasRunningInFeed(feedKey)).toBe(false)
+  })
+})
+
 describe('renderCombinedWorkerFeed (pure)', () => {
   const row = (i: number, step: string) => ({
     description: `task number ${i}`,

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -788,7 +788,15 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       if (finishingAgentId != null && g.workers.has(finishingAgentId)) {
         removeWorker(g, finishingAgentId)
       }
-      g.terminalPainted = true
+      // Only latch terminalPainted when NO live worker remains at paint time.
+      // Race: this finalize was the last live worker when the chain latched, but
+      // a fresh worker B may have called update() and joined g.workers before
+      // this body runs — in which case renderGroupBody paints B's RUNNING card,
+      // not a terminal recap. Setting the flag true unconditionally would
+      // mislabel that running paint as terminal (a spurious group-reuse fresh-
+      // paint on B's next update). Reflect reality: the group only went terminal
+      // if it's actually empty of live workers.
+      g.terminalPainted = !hasLiveWorker(g)
       syncPin(g)
     }
 

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -390,12 +390,29 @@ interface FeedGroup {
   /** Live workers in this group, keyed by agentId (insertion ≈ dispatch order). */
   workers: Map<string, WorkerRow>
   /**
-   * A terminal render (the last worker's recap) staged because a 429 cooldown /
-   * flood window blocked the edit. The heartbeat re-drives it once the cooldown
-   * expires so a finished feed can't get stuck on its last running render.
-   * Null when no finalize is pending.
+   * Terminal renders (per finishing worker's recap) staged because a 429
+   * cooldown / flood window blocked the edit. Keyed by agentId so a SECOND
+   * worker finishing in the same window can't overwrite the first's staged
+   * recap (the single-slot bug: two near-simultaneous last-worker finishes
+   * leaked the earlier finished row forever). The heartbeat drains EVERY entry
+   * once the cooldown expires so a finished feed can't get stuck on its last
+   * running render. Empty when no finalize is pending.
+   *
+   * Note: the finishing row is dropped from `workers` immediately at finalize
+   * time (decoupled from edit success — #3207 leaked-finished-row fix), so a
+   * staged entry here is purely the best-effort terminal REPAINT; group
+   * emptiness / deletion / unpin never wait on it.
    */
-  pendingFinalize: WorkerActivityView | null
+  pendingFinalize: Map<string, WorkerActivityView>
+  /**
+   * True once this group's shared message last rendered a TERMINAL recap (a
+   * finished worker's done/failed/incomplete card), and no live worker has
+   * repainted since. A later worker joining the group must NOT edit that
+   * terminal message — it forces a fresh first-paint (new message) instead, so
+   * a new dispatch never appends to a stale "done" card. Reset to false on any
+   * fresh first-paint.
+   */
+  terminalPainted: boolean
 }
 
 const COOLDOWN_JITTER_MS = 500
@@ -693,7 +710,24 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   function removeWorker(g: FeedGroup, agentId: string): void {
     g.workers.delete(agentId)
     agentIndex.delete(agentId)
-    if (g.workers.size === 0) groups.delete(g.feedKey)
+    maybeDeleteGroup(g)
+  }
+
+  /**
+   * Delete an empty group. A group is gone only when it has NO tracked workers
+   * AND no staged terminal repaints pending — the latter keeps the group object
+   * reachable for the heartbeat re-drive after a flood/429 deferred the recap,
+   * without keeping it "alive" for the pin (syncPin / hasRunningInFeed count
+   * only live workers, so an emptied-but-pending group is already unpinned).
+   */
+  function maybeDeleteGroup(g: FeedGroup): void {
+    if (g.workers.size === 0 && g.pendingFinalize.size === 0) groups.delete(g.feedKey)
+  }
+
+  /** Live (not-yet-finished) workers still tracked in a group. */
+  function hasLiveWorker(g: FeedGroup): boolean {
+    for (const w of g.workers.values()) if (!w.finished) return true
+    return false
   }
 
   /**
@@ -704,7 +738,10 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
    * still needs — the survivors keep the pin until the LAST worker is done.
    */
   function syncPin(g: FeedGroup): void {
-    const messageId = g.messageId != null && g.workers.size > 0 ? g.messageId : null
+    // Pin follows LIVE membership, not row count: a finished-but-not-yet-swept
+    // row (or a staged terminal repaint) must NOT keep the pin. Unpin the
+    // instant the last running worker is gone.
+    const messageId = g.messageId != null && hasLiveWorker(g) ? g.messageId : null
     reconcilePinFn({ feedKey: g.feedKey, chatId: g.chatId, threadId: g.threadId, messageId })
   }
 
@@ -721,45 +758,70 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   ): Promise<void> {
     const now = nowFn()
     const isTerminal = opts2.terminalRecap != null
-    // Terminal edit RESOLVED (landed / not-modified / gone): clear the staged
-    // re-drive unconditionally so a heartbeat re-drive can never loop, and drop
-    // the finished row when its id is known (the last-worker finalize path).
-    const settleTerminal = (): void => {
-      g.pendingFinalize = null
-      if (opts2.finishingAgentId != null) removeWorker(g, opts2.finishingAgentId)
-      // Group-level pin follows membership: unpin once this drops the last
-      // worker; a NOOP-pin (siblings remain) keeps the shared message pinned.
+    const finishingAgentId = opts2.finishingAgentId
+
+    // Stage the terminal recap for the heartbeat re-drive, keyed by the
+    // FINISHING agent so a second worker finishing in the same cooldown/flood
+    // window can't overwrite an earlier staged recap (#3207: the single-slot
+    // overwrite that orphaned finished rows). Best-effort repaint only — the
+    // row is dropped and the pin released independently, below.
+    const stageRecap = (): void => {
+      if (isTerminal && finishingAgentId != null && opts2.terminalRecap != null) {
+        g.pendingFinalize.set(finishingAgentId, opts2.terminalRecap)
+      }
+    }
+    // Terminal repaint no longer pending (landed / not-modified / gone / never
+    // had a message): stop re-driving it and reap the group if now fully empty.
+    const clearStaged = (): void => {
+      if (finishingAgentId != null) g.pendingFinalize.delete(finishingAgentId)
+      maybeDeleteGroup(g)
       syncPin(g)
     }
+
+    // #3207 leaked-finished-row fix — decouple row removal + unpin from the
+    // terminal edit's SUCCESS. The instant a worker finalizes we drop its row
+    // and release the group pin; a 429 / flood / transport failure on the
+    // cosmetic recap edit must NEVER keep the group, its message, or its pin
+    // alive. The recap is staged (above) purely as a best-effort repaint.
+    if (isTerminal) {
+      stageRecap()
+      if (finishingAgentId != null && g.workers.has(finishingAgentId)) {
+        removeWorker(g, finishingAgentId)
+      }
+      g.terminalPainted = true
+      syncPin(g)
+    }
+
     if (now < g.cooldownUntil) {
-      if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
+      // Row already dropped + unpinned above; the recap stays staged so the
+      // heartbeat re-drives the repaint once the cooldown expires.
       return
     }
     // A flood window is open: the gate would SHED every call. Park in cooldown
     // and make ZERO api calls until it closes; the heartbeat re-drives.
     if (parkIfFloodWindowOpen(g)) {
-      if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
       return
     }
 
     const body = renderGroupBody(g, now, opts2.terminalRecap ?? null, opts2.heartbeat ?? false)
     if (body == null) {
-      // Nothing to show. On a terminal finalize with no message ever posted,
-      // just drop the finished row (the handback carries the result).
-      if (isTerminal) settleTerminal()
+      // Nothing to show. On a terminal finalize the row is already dropped;
+      // clear the staged repaint (the handback carries the result).
+      if (isTerminal) clearStaged()
       return
     }
 
     // First paint: hold until some worker in the group has run long enough.
     if (g.messageId == null) {
-      const maxElapsed = Math.max(0, ...runningRows(g).map((r) => liveElapsed(r, now)))
       // A terminal recap for a group that never painted → nothing to finalize;
       // never first-paint a terminal card (trivial workers stay silent, the
       // handback carries the result — matches the pre-coalesce doFinish guard).
+      // The finished row is already dropped; just clear the staged repaint.
       if (isTerminal) {
-        settleTerminal()
+        clearStaged()
         return
       }
+      const maxElapsed = Math.max(0, ...runningRows(g).map((r) => liveElapsed(r, now)))
       if (maxElapsed < firstPaintMin) return
       try {
         const sent = await opts.bot.sendMessage(g.chatId, body, sendOptsFor(g))
@@ -775,6 +837,8 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         g.messageId = sent.message_id
         g.lastBody = body
         g.lastEditAt = now
+        // A fresh message is a live running paint, never a terminal recap.
+        g.terminalPainted = false
         // Group's first (or re-established) message is up → pin it for the group.
         syncPin(g)
         log(
@@ -790,7 +854,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
 
     // Dedup + proactive throttle (finish/terminal edits force through).
     if (body === g.lastBody) {
-      if (isTerminal) settleTerminal()
+      if (isTerminal) clearStaged()
       return
     }
     if (!opts2.force && now - g.lastEditAt < minEditInterval) return
@@ -803,7 +867,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       // The shed payload is NOT on screen, so do not record it as `lastBody`.
       if (isSendGateShed(res)) {
         parkIfFloodWindowOpen(g)
-        if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
+        // Recap stays staged (above); row already dropped + unpinned.
         return
       }
       g.lastBody = body
@@ -811,7 +875,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       if (isTerminal) {
         log(
           `worker-feed: finish feed=${g.feedKey} chat=${g.chatId} thread=${g.threadId ?? '-'} ` +
-            `msgId=${g.messageId} agent=${opts2.finishingAgentId ?? '-'} ` +
+            `msgId=${g.messageId} agent=${finishingAgentId ?? '-'} ` +
             `state=${opts2.terminalRecap?.state ?? 'done'} bytes=${body.length}`,
         )
       } else {
@@ -820,34 +884,34 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
             `thread=${g.threadId ?? '-'} msgId=${g.messageId} workers=${g.workers.size} bytes=${body.length}`,
         )
       }
-      if (isTerminal) settleTerminal()
+      if (isTerminal) clearStaged()
     } catch (err) {
       const outcome = classifyEditError(err)
       if (outcome === 'rate_limited') {
         noteRateLimited(g, err, isTerminal ? 'finish' : 'edit')
-        if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
+        // Recap stays staged; the heartbeat re-drives after the cooldown.
         return
       }
       if (outcome === 'not_modified') {
         g.lastBody = body
         g.lastEditAt = now
-        if (isTerminal) settleTerminal()
+        if (isTerminal) clearStaged()
         return
       }
       if (outcome === 'gone') {
         // Message/chat gone or edit window closed — no card to update. Drop the
         // stale message id; a fresh first-paint re-establishes one if workers
-        // are still live. On a terminal finalize, also drop the finished row.
+        // are still live. On a terminal finalize, clear the staged repaint.
         g.messageId = null
         g.lastBody = null
         // The pinned message no longer exists → release the group pin claim
-        // (settleTerminal already re-syncs on the terminal path).
-        if (isTerminal) settleTerminal()
+        // (clearStaged already re-syncs on the terminal path).
+        if (isTerminal) clearStaged()
         else syncPin(g)
         return
       }
       // 'transient' — leave the message intact; the heartbeat re-attempts.
-      if (isTerminal && opts2.terminalRecap != null) g.pendingFinalize = opts2.terminalRecap
+      // Recap stays staged for the terminal path.
       log(`worker-feed: edit transient error feed=${g.feedKey}: ${(err as Error).message}`)
     }
   }
@@ -945,12 +1009,26 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     // mutates the group's worker map), then terminate each through its chain so
     // the render/unpin happens under the normal cooldown/flood guards.
     const staleAgentIds: string[] = []
+    const staleFinished: Array<{ g: FeedGroup; agentId: string }> = []
     for (const g of groups.values()) {
       for (const row of g.workers.values()) {
-        if (!row.finished && now - row.lastUpdateAt >= staleWorkerTtlMs) {
-          staleAgentIds.push(row.agentId)
+        if (now - row.lastUpdateAt >= staleWorkerTtlMs) {
+          if (row.finished) staleFinished.push({ g, agentId: row.agentId })
+          else staleAgentIds.push(row.agentId)
         }
       }
+    }
+    // GC any FINISHED row still lingering past the TTL (#3207: finished rows
+    // were exempt from the sweep — `if (!row.finished …)` — so a stuck finished
+    // row could keep a group, its message, and its pin alive forever). The
+    // normal finalize path drops the row immediately now, but reap directly
+    // here as a durable backstop: `terminate()` no-ops on a finished row, so
+    // remove it and release the pin without routing through it.
+    for (const { g, agentId } of staleFinished) {
+      log(`worker-feed: TTL GC finished row agent=${agentId} feed=${g.feedKey} — reaping leaked finished row`)
+      g.pendingFinalize.delete(agentId)
+      removeWorker(g, agentId)
+      syncPin(g)
     }
     for (const agentId of staleAgentIds) {
       log(`worker-feed: TTL reap agent=${agentId} — no update in ${Math.floor((now - (groupOfAgent(agentId)?.workers.get(agentId)?.lastUpdateAt ?? now)) / 1000)}s (>= ${Math.floor(staleWorkerTtlMs / 1000)}s); force-terminating leaked row`)
@@ -960,15 +1038,19 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       // Deferred-finalize re-drive: a terminal edit that hit a cooldown/flood
       // window was staged on `pendingFinalize`. Re-drive it once the cooldown
       // expires so a finished feed can't get stuck on its last running render.
-      if (g.pendingFinalize != null && now >= g.cooldownUntil) {
-        const recap = g.pendingFinalize
-        // The finishing agent is whatever finished row remains (state terminal).
-        const finishingAgentId = [...g.workers.values()].find((w) => w.finished)?.agentId
-        g.chain = g.chain
-          .then(() => doRender(g, { force: true, terminalRecap: recap, finishingAgentId }))
-          .catch((err) => {
-            log(`worker-feed: heartbeat finalize re-drive error feed=${g.feedKey}: ${(err as Error).message}`)
-          })
+      if (g.pendingFinalize.size > 0 && now >= g.cooldownUntil) {
+        // Drain EVERY staged terminal recap, keyed by its finishing agent
+        // (#3207: the single `pendingFinalize` slot dropped all but one when
+        // multiple workers finished inside the same cooldown/flood window, so
+        // the earlier finished rows leaked). Each re-drive removes its own
+        // staged entry on success and reaps the group once fully empty.
+        for (const [agentId, recap] of [...g.pendingFinalize]) {
+          g.chain = g.chain
+            .then(() => doRender(g, { force: true, terminalRecap: recap, finishingAgentId: agentId }))
+            .catch((err) => {
+              log(`worker-feed: heartbeat finalize re-drive error feed=${g.feedKey}: ${(err as Error).message}`)
+            })
+        }
         continue
       }
 
@@ -1013,7 +1095,11 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     },
     hasRunningInFeed(feedKey) {
       const g = groups.get(feedKey)
-      return g != null && g.workers.size > 0
+      // Count only RUNNING (not-yet-finished) rows (#3207): a finished row
+      // lingering pre-sweep — or a group kept alive solely for a staged
+      // terminal repaint — is NOT running, so the gateway's `wk:group:` pin
+      // reaper must be free to unpin it.
+      return g != null && hasLiveWorker(g)
     },
     get size() {
       let n = 0
@@ -1043,9 +1129,25 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           cooldownUntil: 0,
           chain: Promise.resolve(),
           workers: new Map(),
-          pendingFinalize: null,
+          pendingFinalize: new Map(),
+          terminalPainted: false,
         }
         groups.set(feedKey, g)
+      }
+      // Group-reuse-after-terminal (#3207): a later worker landing in a group
+      // whose shared message last rendered a TERMINAL recap (its prior workers
+      // all finished, but the group lingered — e.g. a staged repaint, or a
+      // finished row not yet swept) must NOT inherit that message id and edit
+      // the "done" card. Force a fresh first-paint (new message) so the new
+      // dispatch never appends to a stale terminal card. Only triggers when no
+      // live worker remains AND the group last went terminal.
+      if (!g.workers.has(agentId) && g.terminalPainted && !hasLiveWorker(g)) {
+        g.messageId = null
+        g.lastBody = null
+        g.pendingFinalize.clear()
+        g.terminalPainted = false
+        // The stale terminal message is no longer this group's pinned surface.
+        syncPin(g)
       }
       let row = g.workers.get(agentId)
       if (row == null) {


### PR DESCRIPTION
## Summary

A background sub-agent progress card (the coalesced per-chat worker feed from #3207) was observed **pinned and edited for 2h12m and never unpinned**, with later unrelated workers appending to the stale pinned message. This fixes the leaked-finished-row root cause.

## Why (root cause)

All in `telegram-plugin/worker-activity-feed.ts`. A **finished worker row whose terminal edit hit a 429/flood window was left in the group's `workers` map**, so the group never emptied → was never deleted → its pin was never released. Five interacting defects kept it alive:

1. **Row removal coupled to edit success** — `settleTerminal` (which removed the finished row) only ran when the terminal edit *landed*. A 429/flood on the recap left the row alive.
2. **Finished rows immortal** — the TTL sweep guard was `if (!row.finished && ...)` and `terminate()` no-ops on finished rows, so a stuck finished row was never reaped; `g.workers.size` never reached 0, so the delete-on-empty (`removeWorker`) never fired.
3. **Single `pendingFinalize` slot + wrong-agent removal** — a second worker finishing in the same cooldown window overwrote the first's staged recap, and the heartbeat re-drive removed only ONE row (`[...workers.values()].find(w => w.finished)` picked the wrong/first row). Other finished rows orphaned.
4. **`hasRunningInFeed` counted finished rows** — it returned `g.workers.size > 0`, so the gateway `wk:group:` pin reaper treated a dead group as running and never unpinned (backstop defeated).
5. **Group reuse edited the stale terminal message** — a later worker found the still-alive group, inherited `g.messageId`, skipped first-paint, and edited the STALE "done" message.

## What changed

- **Decouple row removal + unpin from edit success.** The finishing row is dropped and the pin released the *instant* a worker finalizes; the terminal recap is a best-effort repaint staged for the heartbeat. Group emptiness → deletion → unpin can no longer be blocked by a transport failure.
- **Per-agent finalize staging.** `pendingFinalize` is now a `Map<agentId, recap>`; the heartbeat drains EVERY staged entry (no overwrite, no wrong-agent removal).
- **GC finished rows.** The TTL sweep reaps lingering finished rows directly (removed the `!row.finished` exemption via a dedicated finished-row GC — `terminate()` no-ops on them).
- **`hasRunningInFeed` counts only running (not-finished) rows**, so the pin-reaper backstop actually fires.
- **Group-reuse-after-terminal forces a fresh first-paint** (new message) instead of editing a terminated group's message.

## Test plan

Scoped, outcome-asserting tests (not just path coverage):

- `telegram-plugin/tests/worker-feed-coalesce.test.ts` (new `#3207` block):
  - finished row dropped + unpin requested **even when the last terminal edit floods (429)**; recap re-drives on a later heartbeat.
  - **two workers finishing in the same flood window are BOTH reaped** (no single-slot overwrite leak).
  - a later worker after all prior workers finished paints a **fresh** message (no messageId reuse).
  - `hasRunningInFeed` is **false once only finished rows remain**.
- `telegram-plugin/tests/worker-activity-feed.test.ts`: updated the shed-terminal-edit test to the new no-leak contract (row dropped immediately, recap staged, heartbeat re-drives).

`./node_modules/.bin/vitest run` on both files: **101 passed**. `tsc --noEmit` clean; all lint guard scripts clean. (`check-plugin-references` reports 18 pre-existing `error TS` from missing optional deps `mdast-*`/`@mtcute` in this worktree's node_modules — identical with my changes stashed; CI has full deps.)

## Risk

Behavior change is confined to the worker-feed finalize/heartbeat/pin paths. The terminal recap becomes best-effort (unpin no longer waits on it) — a deliberate trade to guarantee the pin is always released.

Job spec: `reference/jobs/` — surfaces live sub-agent work in chat without leaving a stale pinned status widget ("Chat is the artifact").

🤖 Generated with [Claude Code](https://claude.com/claude-code)