### PR TITLE
fix(skills): self-heal legacy switchroom-ai/skills symlinks on reconcile

### DIFF
--- a/src/agents/reconcile-default-skills.test.ts
+++ b/src/agents/reconcile-default-skills.test.ts
@@ -267,6 +267,51 @@ describe("reconcileAgentDefaultSkills — legacy-prefix migration (#1164)", () =
     expect(result.added).toContain("skill-a");
     expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(join(poolDir, "skill-a"));
   });
+
+  it("repoints a symlink whose target was the retired bun-global switchroom-ai/skills path (carrie RCA)", () => {
+    const agentDir = makeAgentDir(tmpRoot, "ag1");
+    const skillsDir = join(agentDir, ".claude", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    // Exact retired legacy shape that left carrie with 7 dangling links:
+    // .../node_modules/switchroom-ai/skills/<key> (NOT .../switchroom/skills/).
+    // Dangling on purpose — lstat only needs to see a symlink.
+    symlinkSync(
+      "/home/agent/.bun/install/global/node_modules/switchroom-ai/skills/skill-a",
+      join(skillsDir, "skill-a"),
+    );
+
+    const result = reconcileAgentDefaultSkills(
+      agentDir,
+      {},
+      [{ key: "skill-a", optOutKey: "skill-a", source: "anthropic" }],
+      poolDir,
+    );
+    // Owned-stale: link is deleted and recreated pointing into the current pool.
+    expect(result.added).toContain("skill-a");
+    expect(result.conflicts).not.toContain("skill-a");
+    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(join(poolDir, "skill-a"));
+  });
+
+  it("leaves a genuinely foreign switchroom-ai-like path alone (no over-match)", () => {
+    const agentDir = makeAgentDir(tmpRoot, "ag1");
+    const skillsDir = join(agentDir, ".claude", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    // Operator-custom location — resembles nothing switchroom owns; must be
+    // preserved as a conflict, proving the legacy matcher isn't a blanket match.
+    const foreignTarget = join(tmpRoot, "custom", "skills", "skill-a");
+    mkdirSync(foreignTarget, { recursive: true });
+    symlinkSync(foreignTarget, join(skillsDir, "skill-a"));
+
+    const result = reconcileAgentDefaultSkills(
+      agentDir,
+      {},
+      [{ key: "skill-a", optOutKey: "skill-a", source: "anthropic" }],
+      poolDir,
+    );
+    expect(result.conflicts).toContain("skill-a");
+    expect(result.added).not.toContain("skill-a");
+    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(foreignTarget);
+  });
 });
 
 describe("getBuiltinDefaultSkillEntries", () => {

--- a/src/agents/reconcile-default-skills.ts
+++ b/src/agents/reconcile-default-skills.ts
@@ -75,12 +75,15 @@ export function getBundledSkillsPoolDir(): string {
  * under a previous resolver — and therefore safe to delete and
  * recreate? Matches the current pool dir AND legacy prefixes (any
  * path containing `/switchroom/skills/` — dev-checkout or packaged —
- * plus the `/opt/skills/` baked-image path used by pre-fix containers).
+ * the `/opt/skills/` baked-image path used by pre-fix containers, plus
+ * the retired bun-global install path `.../node_modules/switchroom-ai/
+ * skills/` (RCA: carrie's 7 permanently-dangling links, #1164)).
  */
 function isOwnedStaleLink(target: string, poolDir: string): boolean {
   if (target.startsWith(poolDir)) return true;
   if (target.includes("/switchroom/skills/")) return true;
   if (target.startsWith("/opt/skills/")) return true;
+  if (target.includes("/switchroom-ai/skills/")) return true;
   return false;
 }
 


### PR DESCRIPTION
## RCA
Agent `carrie` had 7 bundled-skill symlinks under `.claude/skills/<name>` that were **permanently dangling** — no restart could heal them. The links pointed at the **retired bun-global install path** `.../node_modules/switchroom-ai/skills/<name>` (note: `switchroom-ai/skills`, NOT `switchroom/skills`), an old bun-global install location.

`isOwnedStaleLink(target, poolDir)` in `src/agents/reconcile-default-skills.ts` recognized three switchroom-owned shapes: the current pool dir, any `/switchroom/skills/` path, and `/opt/skills/`. It did **not** recognize the `switchroom-ai/skills` legacy shape, so reconcile classified those dangling links as foreign (operator-owned) and left them untouched forever instead of repointing them to the current pool.

## Fix
Add a `/switchroom-ai/skills/` substring recognizer to `isOwnedStaleLink`. Specific enough to avoid catching operator-custom links (e.g. `/home/x/custom/skills/foo`). Doc-comment updated to mention the legacy path.

## Tests
- New test asserts the retired legacy path is treated as owned-stale: reconcile **deletes and recreates** the link pointing into the current pool dir (asserts `readlinkSync === poolDir/<key>`).
- New test asserts a genuinely foreign custom path still returns a conflict and is left alone (no over-match).

## Validation
- Scoped: `vitest run src/agents/reconcile-default-skills.test.ts` — 16 passed.
- `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)