### PR TITLE
fix(worker-feed): absolute row-lifetime cap for immortal-but-updating pinned card

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2043,13 +2043,21 @@ const WORKER_FEED_STALE_TTL_MARGIN_MS = 5 * 60_000
  * row's immutable creation time, so it reaps an immortal card even when the row
  * keeps receiving `update()` cues that reset `lastUpdateAt` every heartbeat
  * (the Carrie 5h zombie-pin leak, re-edited 3000+ times, that the silence sweep
- * could never match). At the 45-min default cap this yields a 6-hour absolute
- * ceiling — far above any legitimate single worker's lifetime, so it can only
- * ever bite a genuine leak, while still bounding a ghost card to hours not days.
- * Derived from the same base as `staleWorkerTtlMs` (never a bare magic number)
- * so it tracks any operator override of the terminal cap.
+ * could never match). At the 45-min default cap this yields a 3-hour absolute
+ * ceiling — comfortably above any legitimate single worker's lifetime, so it
+ * can only ever bite a genuine leak, while bounding a ghost card well UNDER the
+ * ~5h symptom Ken hit (the initial 8x/6h was too loose). Derived from the same
+ * base as `staleWorkerTtlMs` — the watcher's effective in-flight terminal cap
+ * (`resolveInflightTerminalCapMs()`: the `SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_
+ * CAP_MS` env override, else the 45-min default) — never a bare magic number, so
+ * it tracks the env-level terminal-cap override in lockstep with the silence
+ * backstop. (Both this and `staleWorkerTtlMs` call `resolveInflightTerminalCapMs()`
+ * with NO arg, matching the watcher's OWN effective value here: the gateway does
+ * not pass a config-file `inflightTerminalCapMs` to `startSubagentWatcher`, so
+ * there is no config-file override to thread through — env + default is the
+ * complete override surface on this path.)
  */
-const WORKER_FEED_ABSOLUTE_ROW_LIFETIME_CAP_MULTIPLE = 8
+const WORKER_FEED_ABSOLUTE_ROW_LIFETIME_CAP_MULTIPLE = 4
 const workerFeedOwnerDmFallbackLogged = new Set<string>()
 
 /**
@@ -30116,7 +30124,16 @@ void (async () => {
             // or the turn ended while it kept running — extended autonomous
             // work) is surfaced via the worker feed instead of vanishing.
             const orphanStatusEnabled = isOrphanSubagentStatusEnabled(process.env.SWITCHROOM_ORPHAN_SUBAGENT_STATUS)
-            workerActivityFeed?.stop()
+            // Boot/reconnect purge (Ken, PR #3239 review): every row in the
+            // OUTGOING feed is a dead child sub-agent, and its `wk:group:` pins
+            // would otherwise be orphaned — the replacement feed is empty and
+            // never knew those groups, so it can never unpin them, and no full-
+            // boot pin sweep runs on a bare bridge reconnect. Reconcile the old
+            // feed to empty and release all its group pins BEFORE stopping it.
+            if (workerActivityFeed != null) {
+              workerActivityFeed.purgeAllOnBoot()
+              workerActivityFeed.stop()
+            }
             workerActivityFeed = createWorkerActivityFeed({
               // #2669: worker-feed body is raw GFM markdown — send via rich.
               bot: {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -30202,7 +30202,7 @@ void (async () => {
               // to the `lastUpdateAt` reset that lets an immortal-but-updating
               // row dodge `staleWorkerTtlMs` forever (Carrie 5h zombie pin).
               // Derived from the same terminal cap so it tracks operator
-              // overrides; 8× → 6h at the 45-min default.
+              // overrides; 4× → ~3h at the 45-min default.
               absoluteRowLifetimeCapMs: resolveInflightTerminalCapMs() * WORKER_FEED_ABSOLUTE_ROW_LIFETIME_CAP_MULTIPLE,
               // #3207 review: GROUP-level status pin. Workers now coalesce into
               // ONE shared message, so the pin must follow the GROUP lifecycle,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2036,6 +2036,20 @@ const WORKER_FEED_FALLBACK_LOG_CAP = 256
  * slot, never a live-but-quiet worker. 5 min.
  */
 const WORKER_FEED_STALE_TTL_MARGIN_MS = 5 * 60_000
+/**
+ * Multiple of the watcher's in-flight terminal cap used to derive the worker-
+ * feed ABSOLUTE row-lifetime cap (`absoluteRowLifetimeCapMs`). Unlike the
+ * silence-keyed `staleWorkerTtlMs` backstop, the absolute cap is anchored to a
+ * row's immutable creation time, so it reaps an immortal card even when the row
+ * keeps receiving `update()` cues that reset `lastUpdateAt` every heartbeat
+ * (the Carrie 5h zombie-pin leak, re-edited 3000+ times, that the silence sweep
+ * could never match). At the 45-min default cap this yields a 6-hour absolute
+ * ceiling — far above any legitimate single worker's lifetime, so it can only
+ * ever bite a genuine leak, while still bounding a ghost card to hours not days.
+ * Derived from the same base as `staleWorkerTtlMs` (never a bare magic number)
+ * so it tracks any operator override of the terminal cap.
+ */
+const WORKER_FEED_ABSOLUTE_ROW_LIFETIME_CAP_MULTIPLE = 8
 const workerFeedOwnerDmFallbackLogged = new Set<string>()
 
 /**
@@ -30167,6 +30181,12 @@ void (async () => {
               // force-collapsing a row the terminal signals somehow never
               // removed.
               staleWorkerTtlMs: resolveInflightTerminalCapMs() + WORKER_FEED_STALE_TTL_MARGIN_MS,
+              // ABSOLUTE row-lifetime cap — anchored to a row's creation, immune
+              // to the `lastUpdateAt` reset that lets an immortal-but-updating
+              // row dodge `staleWorkerTtlMs` forever (Carrie 5h zombie pin).
+              // Derived from the same terminal cap so it tracks operator
+              // overrides; 8× → 6h at the 45-min default.
+              absoluteRowLifetimeCapMs: resolveInflightTerminalCapMs() * WORKER_FEED_ABSOLUTE_ROW_LIFETIME_CAP_MULTIPLE,
               // #3207 review: GROUP-level status pin. Workers now coalesce into
               // ONE shared message, so the pin must follow the GROUP lifecycle,
               // not a single worker's — otherwise a sibling's finish unpins a

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -768,7 +768,7 @@ describe('renderCombinedWorkerFeed (pure)', () => {
  * authoritative terminal sweep (`terminate`, driven by `onTerminalCleanup`)
  * PLUS a backstop TTL sweep. These assert the OUTCOMES, not the code paths.
  */
-function ghostHarness(opts: { staleWorkerTtlMs?: number; now: () => number }) {
+function ghostHarness(opts: { staleWorkerTtlMs?: number; absoluteRowLifetimeCapMs?: number; now: () => number }) {
   const edits: { messageId: number; text: string }[] = []
   const sends: { text: string }[] = []
   const pins: { messageId: number | null }[] = []
@@ -792,6 +792,7 @@ function ghostHarness(opts: { staleWorkerTtlMs?: number; now: () => number }) {
     setInterval: () => 0,
     clearInterval: () => {},
     staleWorkerTtlMs: opts.staleWorkerTtlMs,
+    absoluteRowLifetimeCapMs: opts.absoluteRowLifetimeCapMs,
     reconcilePin: ({ messageId }) => pins.push({ messageId }),
   })
   return { feed, edits, sends, pins }
@@ -889,6 +890,72 @@ describe('worker-feed ghost-leak — deterministic terminal removal + backstop',
     await drain()
     // Still tracked — the sweep only reaps rows silent PAST the TTL.
     expect(feed.size).toBe(1)
+  })
+
+  // ── ABSOLUTE row-lifetime cap (Carrie 5h zombie pin, v0.18.23) ──────────────
+  // The silence-keyed `staleWorkerTtlMs` backstop is defeated by a leaked row
+  // that never finishes AND keeps receiving `update()` cues every heartbeat:
+  // each cue resets `lastUpdateAt`, so the silence sweep can NEVER match and the
+  // pinned card lives forever (observed: 5h, re-edited 3000+ times). The
+  // absolute cap is anchored to the row's IMMUTABLE creation time, so it reaps
+  // the row regardless of how recently it updated.
+  it('ABSOLUTE cap reaps an immortal-but-UPDATING row that resets lastUpdateAt every tick, then unpins', async () => {
+    let t = 0
+    // Silence TTL huge (would never fire); absolute cap small. The row keeps
+    // updating just under the silence TTL each step, so ONLY the absolute cap
+    // (immune to the lastUpdateAt reset) can catch it.
+    const { feed, edits, pins } = ghostHarness({
+      staleWorkerTtlMs: 1_000_000,
+      absoluteRowLifetimeCapMs: 5000,
+      now: () => t,
+    })
+    await feed.update('z', 'chat', view('zombie task', 's0', 0))
+    await drain()
+    expect(feed.size).toBe(1)
+    expect(pins.at(-1)?.messageId).not.toBeNull()
+
+    // Drive continuous updates past the absolute cap — each resets lastUpdateAt,
+    // so the silence sweep stays defeated (exactly the Carrie failure mode).
+    for (let step = 1; step <= 8; step++) {
+      t = step * 1000
+      await feed.update('z', 'chat', view('zombie task', `s${step}`, t))
+      await drain()
+      feed.heartbeatTick()
+      await drain()
+    }
+    // The absolute cap (5s) has been crossed while the row kept updating →
+    // reaped despite the fresh cues, and the shared card UNPINNED.
+    expect(feed.size).toBe(0)
+    expect(pins.at(-1)?.messageId).toBeNull()
+
+    // Immortality closed for good: the finalized gate blocks a late cue from
+    // resurrecting the row, and further heartbeats produce no edits.
+    await feed.update('z', 'chat', view('zombie task', 's-late', t))
+    await drain()
+    expect(feed.size).toBe(0)
+    const after = edits.length
+    t += 10000
+    feed.heartbeatTick()
+    await drain()
+    expect(edits.length).toBe(after)
+  })
+
+  it('ABSOLUTE cap reaps a row past the cap even when the silence TTL would never fire', async () => {
+    let t = 0
+    const { feed, pins } = ghostHarness({
+      staleWorkerTtlMs: 1_000_000,
+      absoluteRowLifetimeCapMs: 5000,
+      now: () => t,
+    })
+    await feed.update('f', 'chat', view('task f', 's0', 0))
+    await drain()
+    expect(pins.at(-1)?.messageId).not.toBeNull()
+    // Past the absolute cap with no update at all — the age anchor alone reaps.
+    t = 6000
+    feed.heartbeatTick()
+    await drain()
+    expect(feed.size).toBe(0)
+    expect(pins.at(-1)?.messageId).toBeNull()
   })
 
   it('no-op re-render is skipped (byte-identical body → no redundant edit)', async () => {

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -958,6 +958,55 @@ describe('worker-feed ghost-leak — deterministic terminal removal + backstop',
     expect(pins.at(-1)?.messageId).toBeNull()
   })
 
+  // ── Boot/reconnect purge (Ken's key ask) ───────────────────────────────────
+  // Every tracked row is a dead child sub-agent after a restart/reconnect. On a
+  // bare bridge reconnect the OLD feed's `wk:group:` pins are orphaned — the new
+  // empty feed never knew those groups, so it can never unpin them, and no full-
+  // boot pin sweep runs. `purgeAllOnBoot()` must reconcile the feed to empty AND
+  // release the pin unconditionally.
+  it('purgeAllOnBoot empties a restored running row + pinned card and UNPINS', async () => {
+    let t = 0
+    const { feed, pins } = ghostHarness({ now: () => t })
+    // A running worker with a live pinned card (the "restored at startup" state).
+    await feed.update('p', 'chat', view('task p', 'working', 0))
+    await drain()
+    expect(feed.size).toBe(1)
+    expect(pins.at(-1)?.messageId).not.toBeNull()
+
+    feed.purgeAllOnBoot()
+
+    // Feed reconciled to empty AND the coalesced card unpinned (messageId null).
+    expect(feed.size).toBe(0)
+    expect(pins.at(-1)?.messageId).toBeNull()
+
+    // A late cue on the torn-down feed must NOT resurrect a row (finalized gate).
+    t = 100
+    await feed.update('p', 'chat', view('task p', 'zombie tick', 100))
+    await drain()
+    expect(feed.size).toBe(0)
+  })
+
+  it('purgeAllOnBoot unpins EVERY group (multiple chats) and is a no-op when already empty', async () => {
+    let t = 0
+    const { feed, pins } = ghostHarness({ now: () => t })
+    await feed.update('g1', 'chatA', view('a', 's', 0))
+    await feed.update('g2', 'chatB', view('b', 's', 0))
+    await drain()
+    expect(feed.size).toBe(2)
+
+    const pinsBefore = pins.length
+    feed.purgeAllOnBoot()
+    expect(feed.size).toBe(0)
+    // Both groups emitted a final unpin (messageId null).
+    const unpinsAfter = pins.slice(pinsBefore).filter((p) => p.messageId === null)
+    expect(unpinsAfter.length).toBe(2)
+
+    // Idempotent: a second purge on an empty feed emits no further pin calls.
+    const afterFirst = pins.length
+    feed.purgeAllOnBoot()
+    expect(pins.length).toBe(afterFirst)
+  })
+
   it('no-op re-render is skipped (byte-identical body → no redundant edit)', async () => {
     let t = 0
     const { feed, edits } = ghostHarness({ now: () => t })

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -566,6 +566,22 @@ export interface WorkerActivityFeed {
    * stays visible. Idempotent; a no-op if the worker was never finalized.
    */
   resurrect(agentId: string): void
+  /**
+   * Boot / reconnect purge — reconcile the ENTIRE feed to empty and release
+   * EVERY group's pin, unconditionally.
+   *
+   * Why this is a hard invariant, not a TTL: every tracked worker row is a live
+   * sub-agent that was a CHILD PROCESS of the gateway. It cannot outlive a
+   * gateway restart, and it cannot survive a bridge reconnect that reconstructs
+   * the feed either — so any row still present when the feed is (re)initialised
+   * is definitionally dead. Left alone, the OLD feed instance's `wk:group:` pins
+   * are orphaned: the replacement feed is empty and never knew those groups, so
+   * it never unpins them (the reconnect-orphaned-pin leak — no full-boot pin
+   * sweep runs on a bare reconnect). This finalizes+removes every row and drives
+   * `reconcilePin(messageId: null)` for every group so the coalesced card is
+   * unpinned at once. Idempotent; a no-op on an already-empty feed.
+   */
+  purgeAllOnBoot(): void
   /** Clear the heartbeat interval (gateway shutdown). Idempotent. */
   stop(): void
   /** Manually fire one heartbeat tick (test hook). */
@@ -1310,6 +1326,27 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       if (wasFinalized || row != null) {
         log(`worker-feed: resurrect agent=${agentId} — cleared finalized gate; card will repaint on next running cue`)
       }
+    },
+    purgeAllOnBoot(): void {
+      for (const g of [...groups.values()]) {
+        // Release the group pin unconditionally: the shared card is orphaned
+        // after a restart/reconnect (its workers are dead child processes), so
+        // it must be unpinned regardless of `hasLiveWorker` — NOT gated like
+        // `syncPin`, which would keep the pin for a row we are about to drop.
+        if (g.messageId != null) {
+          reconcilePinFn({ feedKey: g.feedKey, chatId: g.chatId, threadId: g.threadId, messageId: null })
+        }
+        for (const agentId of [...g.workers.keys()]) {
+          // Latch finalized so a late/inflight cue on the OLD chain can't
+          // resurrect a row on a feed we are tearing down.
+          markFinalized(agentId)
+          agentIndex.delete(agentId)
+        }
+        g.workers.clear()
+        g.pendingFinalize.clear()
+        groups.delete(g.feedKey)
+      }
+      log('worker-feed: purgeAllOnBoot — reconciled feed to empty and released all group pins')
     },
     heartbeatTick,
     stop() {

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -299,6 +299,36 @@ export interface WorkerActivityFeedOpts {
    */
   staleWorkerTtlMs?: number
   /**
+   * ABSOLUTE row-lifetime cap (ms), measured from a row's creation — NOT from
+   * its last `update()`. The heartbeat force-terminates (and, when it was the
+   * last live worker, unpins) ANY row this old, whether or not it is marked
+   * finished and no matter how recently it updated.
+   *
+   * Why this exists AND is distinct from `staleWorkerTtlMs` (Carrie 5h zombie
+   * pin, v0.18.23): the `staleWorkerTtlMs` backstop is keyed off `lastUpdateAt`,
+   * so it only bites a row that goes SILENT. A leaked row that never transitions
+   * to finished AND keeps receiving `update()` cues every heartbeat (~6s) resets
+   * `lastUpdateAt` on every tick, so the silence sweep can NEVER match — the row
+   * (and its group pin) lives forever. This cap is immune to that reset: it is
+   * anchored to `createdAtMs` (immutable), so an immortal-but-updating row is
+   * still reaped past an absolute age. The primary fix (the watcher's
+   * `onTerminalCleanup` → `terminate` wiring) drives the clean path; this is the
+   * deterministic last-resort guarantee that no card can outlive the cap even if
+   * that signal is missed or the row is spuriously re-driven.
+   *
+   * The gateway DERIVES this from the watcher's effective in-flight terminal cap
+   * (`resolveInflightTerminalCapMs()`) times a multiple, matching the
+   * `staleWorkerTtlMs` derivation pattern (never a bare magic number). It is set
+   * comfortably above any legitimate single worker's lifetime so it can only
+   * bite a genuine leak; if a real long worker ever hit it, its cosmetic feed
+   * card collapses to `incomplete` and unpins — its actual result still reaches
+   * the user via the separate handback reply.
+   *
+   * Fallback default (this module, for direct / non-gateway callers) 6 h.
+   * Tests inject a small value.
+   */
+  absoluteRowLifetimeCapMs?: number
+  /**
    * Group-level status-pin reconcile hook (#3207 review). Because workers now
    * COALESCE into one shared message, the pin MUST follow the GROUP lifecycle,
    * not a single worker's: pin the shared message when a group's first worker
@@ -359,6 +389,19 @@ interface WorkerRow {
    * and on every `update()`.
    */
   lastUpdateAt: number
+  /**
+   * Wall-clock ms this row was first CREATED (its first `update()` cue).
+   * IMMUTABLE after creation — unlike `lastUpdateAt`, it is NEVER re-stamped by
+   * later updates. The heartbeat's ABSOLUTE row-lifetime cap force-terminates a
+   * row whose `createdAtMs` is older than `absoluteRowLifetimeCapMs` regardless
+   * of how recently it updated. This closes the immortal-card leak the
+   * `lastUpdateAt` backstop cannot: a row that keeps receiving `update()` cues
+   * (a zombie whose watcher entry re-registers, or any spurious re-drive) resets
+   * `lastUpdateAt` every tick, so the silence-TTL sweep NEVER fires — but the
+   * absolute cap is immune to that reset (Carrie 5h zombie pin, re-edited 3000+
+   * times, only cleared by the restart-time dm-pin-sweep).
+   */
+  createdAtMs: number
   /**
    * Wall-clock ms the CURRENT step started — stamped whenever a NEW narrative
    * line lands (the `→` line changes). The heartbeat's step suffix shows the
@@ -540,6 +583,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   const heartbeatTickMs = opts.heartbeatTickMs ?? 6000
   const maxRows = Math.max(1, Math.floor(opts.maxRows ?? 8))
   const staleWorkerTtlMs = Math.max(1, Math.floor(opts.staleWorkerTtlMs ?? 50 * 60_000))
+  const absoluteRowLifetimeCapMs = Math.max(1, Math.floor(opts.absoluteRowLifetimeCapMs ?? 6 * 60 * 60_000))
   const reconcilePinFn = opts.reconcilePin ?? (() => {})
   const setIntervalFn =
     opts.setInterval ??
@@ -1016,14 +1060,29 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     // `onTerminalCleanup` sweep. Collect the stale agent ids first (terminate
     // mutates the group's worker map), then terminate each through its chain so
     // the render/unpin happens under the normal cooldown/flood guards.
-    const staleAgentIds: string[] = []
-    const staleFinished: Array<{ g: FeedGroup; agentId: string }> = []
+    //
+    // TWO independent triggers, OR'd per row:
+    //   1. SILENCE TTL (`staleWorkerTtlMs`, keyed off `lastUpdateAt`) — a row
+    //      that stopped receiving cues.
+    //   2. ABSOLUTE row-lifetime cap (`absoluteRowLifetimeCapMs`, keyed off the
+    //      IMMUTABLE `createdAtMs`) — a row past an absolute age NO MATTER how
+    //      recently it updated. This is the durable guard against the immortal-
+    //      but-updating card the silence sweep can never catch: a leaked row
+    //      that keeps getting `update()` cues every heartbeat resets
+    //      `lastUpdateAt` forever, so only an age anchor immune to that reset can
+    //      reap it (Carrie 5h zombie pin, re-edited 3000+ times).
+    const staleAgentIds: Array<{ agentId: string; reason: 'silence' | 'absolute' }> = []
+    const staleFinished: Array<{ g: FeedGroup; agentId: string; reason: 'silence' | 'absolute' }> = []
     for (const g of groups.values()) {
       for (const row of g.workers.values()) {
-        if (now - row.lastUpdateAt >= staleWorkerTtlMs) {
-          if (row.finished) staleFinished.push({ g, agentId: row.agentId })
-          else staleAgentIds.push(row.agentId)
-        }
+        const silent = now - row.lastUpdateAt >= staleWorkerTtlMs
+        const tooOld = now - row.createdAtMs >= absoluteRowLifetimeCapMs
+        if (!silent && !tooOld) continue
+        // Attribute the reap to the absolute cap only when silence alone would
+        // NOT have fired — so the log names the trigger that actually caught it.
+        const reason: 'silence' | 'absolute' = silent ? 'silence' : 'absolute'
+        if (row.finished) staleFinished.push({ g, agentId: row.agentId, reason })
+        else staleAgentIds.push({ agentId: row.agentId, reason })
       }
     }
     // GC any FINISHED row still lingering past the TTL (#3207: finished rows
@@ -1032,14 +1091,25 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     // normal finalize path drops the row immediately now, but reap directly
     // here as a durable backstop: `terminate()` no-ops on a finished row, so
     // remove it and release the pin without routing through it.
-    for (const { g, agentId } of staleFinished) {
-      log(`worker-feed: TTL GC finished row agent=${agentId} feed=${g.feedKey} — reaping leaked finished row`)
+    for (const { g, agentId, reason } of staleFinished) {
+      if (reason === 'absolute') {
+        const age = Math.floor((now - (g.workers.get(agentId)?.createdAtMs ?? now)) / 1000)
+        log(`worker-feed: ABSOLUTE cap GC finished row agent=${agentId} feed=${g.feedKey} — age ${age}s (>= ${Math.floor(absoluteRowLifetimeCapMs / 1000)}s); reaping immortal finished row`)
+      } else {
+        log(`worker-feed: TTL GC finished row agent=${agentId} feed=${g.feedKey} — reaping leaked finished row`)
+      }
       g.pendingFinalize.delete(agentId)
       removeWorker(g, agentId)
       syncPin(g)
     }
-    for (const agentId of staleAgentIds) {
-      log(`worker-feed: TTL reap agent=${agentId} — no update in ${Math.floor((now - (groupOfAgent(agentId)?.workers.get(agentId)?.lastUpdateAt ?? now)) / 1000)}s (>= ${Math.floor(staleWorkerTtlMs / 1000)}s); force-terminating leaked row`)
+    for (const { agentId, reason } of staleAgentIds) {
+      const row = groupOfAgent(agentId)?.workers.get(agentId)
+      if (reason === 'absolute') {
+        const age = Math.floor((now - (row?.createdAtMs ?? now)) / 1000)
+        log(`worker-feed: ABSOLUTE cap reap agent=${agentId} — row age ${age}s (>= ${Math.floor(absoluteRowLifetimeCapMs / 1000)}s); force-terminating immortal row (survives lastUpdateAt reset)`)
+      } else {
+        log(`worker-feed: TTL reap agent=${agentId} — no update in ${Math.floor((now - (row?.lastUpdateAt ?? now)) / 1000)}s (>= ${Math.floor(staleWorkerTtlMs / 1000)}s); force-terminating leaked row`)
+      }
       void terminateWorker(agentId)
     }
     for (const g of [...groups.values()]) {
@@ -1166,6 +1236,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           state: 'running',
           finished: false,
           lastUpdateAt: nowFn(),
+          createdAtMs: nowFn(),
           dispatchAtMs: null,
           stepStartedAtMs: null,
         }


### PR DESCRIPTION
## The bug (evidenced on live agent Carrie, v0.18.23)

A coalesced worker-feed card gets pinned when a sub-agent registers. When the sub-agent finishes, `subagent-watcher` logs `cleaned up terminal agent <id>`, but the worker-feed **row** never transitions to finished — it stays `state=running, finished=false`. Meanwhile something keeps calling the feed row's `update()` every ~6s. The `#3226` TTL reaper in `heartbeatTick` is keyed off `row.lastUpdateAt`, so **each update resets the staleness clock and the silence sweep NEVER fires**.

Observed: a pinned zombie card lived **5 hours**, re-edited **3000+ times**, only cleared by the restart-time dm-pin-sweep.

`#3226` shipped two mitigations that both fail to bite Carrie's row:
1. `onTerminalCleanup` → `workerActivityFeed.terminate()` wiring (gateway.ts:30343 → subagent-watcher.ts:2258) — the terminal signal is wired, but the row keeps being re-driven, so it is either never actually terminated or immediately re-created/kept alive.
2. the `heartbeatTick` silence reaper — both its branches (`finished` GC and `lastUpdateAt >= staleWorkerTtlMs` reap) require either `finished=true` or silence. Carrie's row is **neither** finished **nor** silent, so neither can ever match.

> Note on the dispatch premise: the requested "Part 1" (drive `terminate` from the watcher's terminal-cleanup path) was **already shipped in #3226** and is present in v0.18.23 — verified via `git log -S`. The genuinely-missing durable guarantee is the absolute cap below.

## The fix — absolute row-lifetime cap

Add an **absolute** row-lifetime cap, anchored to a new immutable `createdAtMs` stamped once at row creation and **never** re-stamped by later updates. The heartbeat sweep now reaps any row past `absoluteRowLifetimeCapMs` **regardless of `lastUpdateAt` or finished state** — force-terminating + unpinning it. Once reaped, the existing `finalized` gate blocks a late/spurious cue from resurrecting the row, so the card is dead for good.

The gateway derives the cap from the watcher's effective in-flight terminal cap (`resolveInflightTerminalCapMs() * 8` → 6h at the 45-min default), matching the existing `staleWorkerTtlMs` derivation pattern — it tracks operator overrides and is never a bare magic number. It sits far above any legitimate single worker's lifetime, so it can only bite a genuine leak; a real long worker that ever hit it collapses its cosmetic card to `incomplete` and unpins — its actual result still reaches the user via the separate handback reply.

## Tests (assert outcomes, RED without the fix)

- A row that **keeps updating** past the absolute cap (resetting `lastUpdateAt` every tick — the exact Carrie failure mode) is still reaped + unpinned.
- A row past the cap is reaped even when the silence TTL would never fire.

Both assert outcomes (`feed.size === 0`, pin `messageId === null`), not that a function was called. Verified they go RED with the source change stashed.

## Files changed
- `telegram-plugin/worker-activity-feed.ts` — `createdAtMs` field + `absoluteRowLifetimeCapMs` option + absolute-age branch in `heartbeatTick`.
- `telegram-plugin/gateway/gateway.ts` — derive + pass `absoluteRowLifetimeCapMs`.
- `telegram-plugin/tests/worker-feed-coalesce.test.ts` — 2 new regression tests.

## Local checks
- `vitest run` worker-feed-coalesce (26→28 tests) + worker-feed-terminal-cleanup: **28 passed**.
- `npm run lint` (tsc --noEmit + repo checks): **clean**.

Completes #3207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)