### PR TITLE
fix(gateway): dedup DM double-reply on the late-reply supersede path

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -88,7 +88,7 @@ import {
   type TelegraphAccount,
 } from '../telegraph.js'
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
-import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
+import { FlushedTurnSupersedeRegistry, DEFAULT_SUPERSEDE_TTL_MS } from '../flushed-turn-supersede.js'
 import { createInboundCoalescer, inboundCoalesceKey } from './inbound-coalesce.js'
 import {
   splitCoalescedAttachments,
@@ -3143,6 +3143,15 @@ type CurrentTurn = {
   // 1's supersede cannot reach. Scoped to the substantive floor so an interim
   // sub-floor ack NEITHER sets nor trips it. Reset false at turn start.
   answerDelivered: boolean
+  // 2026-07 double-reply-on-DM fix (F2 — recency bound). Wall-clock ms the turn
+  // ENDED (stamped once by `endCurrentTurnAtomic`), or null while still live.
+  // The `findLatestEndedTurnForChat` supersede tier carries DESTRUCTIVE
+  // authority (it drives message deletion), so `resolveReplyOwnerTurn` only
+  // honours a latest-ended turn whose `endedAt` is within the supersede TTL —
+  // otherwise a late reply belonging to an OLDER turn could resolve its owner to
+  // a NEWER turn sitting at the registry tail and delete that newer turn's legit
+  // answer. Unbounded routing use of `findLatestEndedTurnForChat` is unaffected.
+  endedAt: number | null
   // #1675 (over-ping safety net): wall-clock ms of the first reply
   // this turn that landed with `disable_notification: false` (a real
   // device ping). The conversational-pacing contract
@@ -3678,11 +3687,20 @@ function resolveReplyOwnerTurn(
   for (const t of [latestEnded, quoted, origin, liveTurn]) {
     if (t != null) byId.set(t.turnId, t)
   }
+  // F2 — bound the DESTRUCTIVE latest-ended tier to the supersede TTL so a stale
+  // latest-ended turn can't inherit deletion authority over a newer turn's flush
+  // record. `endedAt` is null only for a turn still resolvable but not yet ended
+  // (not a supersede risk); leave the age unset then (unbounded) rather than
+  // fabricate one.
+  const latestEndedAgeMs =
+    latestEnded?.endedAt != null ? Date.now() - latestEnded.endedAt : null
   const winnerId = resolveReplyOwnerTurnId({
     liveTurnId: liveTurn?.turnId ?? null,
     originTurnId: origin?.turnId ?? null,
     quotedTurnId: quoted?.turnId ?? null,
     latestEndedTurnId: latestEnded?.turnId ?? null,
+    latestEndedAgeMs,
+    latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
   })
   return winnerId != null ? (byId.get(winnerId) ?? null) : null
 }
@@ -4921,6 +4939,12 @@ function endCurrentTurnAtomic(
   // the turn got), plus a DEGRADED warning when the turn did tool work but the
   // live feed never opened because its sends failed (the resume-400 signature).
   const turnEndedAt = Date.now()
+  // 2026-07 double-reply-on-DM fix (F2) — stamp the turn's end time so the
+  // `findLatestEndedTurnForChat` supersede tier can be recency-bounded to the
+  // supersede TTL (a stale latest-ended turn must not inherit deletion
+  // authority over a newer turn's flush record). Set once; idempotent on the
+  // deferRecord flush path (which calls this synchronously before its send).
+  turn.endedAt = turnEndedAt
   process.stderr.write(
     `telegram gateway: ${formatTurnLifecycle('clear', 'turn_end', turn, turnEndedAt)}\n`,
   )
@@ -17006,6 +17030,8 @@ function handleSessionEvent(ev: SessionEvent): void {
           // 2026-07 double-reply-on-DM fix (Part 2) — answer-delivered race
           // latch, reset at turn start alongside the other answer flags.
           answerDelivered: false,
+          // 2026-07 double-reply-on-DM fix (F2) — stamped at turn end.
+          endedAt: null,
           firstPingAt: null,
           // Notification ownership (R8 / PR-2): no slot claimed yet, so the
           // "claimer was substantive" flag starts false. Set atomically with
@@ -18492,6 +18518,22 @@ function handleSessionEvent(ev: SessionEvent): void {
           } catch (err) {
             sendThrew = true
             process.stderr.write(`telegram gateway: turn-flush send failed: ${(err as Error).message}\n`)
+            // 2026-07 double-reply-on-DM fix (F1) — the flush armed
+            // `answerDelivered` synchronously at FIRE time, but the send just
+            // FAILED. When nothing was delivered the supersede record was NOT
+            // written (gated on `sentIds.length > 0` above), so Part 1 can never
+            // fire for this turn — leaving the latch armed would make a genuine
+            // late reply suppress itself and the user would get ZERO messages
+            // (silent answer loss; on main that path still delivers the reply).
+            // Reset the latch so the late reply is NOT suppressed. On a PARTIAL
+            // send (sentIds > 0) the record WAS written, so Part 1's supersede
+            // deletes the partial message A and the reply delivers cleanly —
+            // resetting here is harmless in that case too.
+            // FOLLOW-UP (coordinator to file an issue): a reply suppressed
+            // synchronously DURING the in-flight send that then fails is not
+            // fully closable with a boolean latch — a residual micro-window the
+            // supersede+latch pair cannot eliminate. Not addressed in this PR.
+            turn.answerDelivered = false
             // #1713: backstop send failed — finalize as error so the
             // turn ends cleanly with 😱 rather than leaving it open.
             if (backstopCtrl) backstopCtrl.finalize('error')

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -400,7 +400,12 @@ import {
 import {
   decideTurnFlush,
   isTurnFlushSafetyEnabled,
+  FLUSH_SUBSTANTIVE_MIN_CHARS,
 } from '../turn-flush-safety.js'
+import {
+  resolveReplyOwnerTurnId,
+  decideAnswerLatchSuppression,
+} from '../reply-owner-resolve.js'
 // PR A — deterministic answer-ready quiescence flush (late-delivery fix).
 import {
   AnswerReadyFlushController,
@@ -3126,6 +3131,18 @@ type CurrentTurn = {
   // false ONLY at turn start, mirroring `activityEverOpened`'s sticky-true
   // contract.
   finalAnswerEverDelivered: boolean
+  // 2026-07 double-reply-on-DM fix (Part 2 — race backstop). Set true
+  // SYNCHRONOUSLY at turn-flush FIRE time (before the ~500 ms async send and
+  // before `flushedTurnSupersede.record`) when the flush delivers a SUBSTANTIVE
+  // (≥`FLUSH_SUBSTANTIVE_MIN_CHARS`) terminal answer, and also set when a
+  // substantive `reply` sends. It persists on the ended turn in
+  // `recentTurnsById`, so a LATE reply landing in the flush's post-fire
+  // pre-record race window (where `flushedTurnSupersede` finds no record to
+  // delete yet) resolves this turn via the unified owner resolver, sees the
+  // latch already set, and suppresses itself — closing the residual window Part
+  // 1's supersede cannot reach. Scoped to the substantive floor so an interim
+  // sub-floor ack NEITHER sets nor trips it. Reset false at turn start.
+  answerDelivered: boolean
   // #1675 (over-ping safety net): wall-clock ms of the first reply
   // this turn that landed with `disable_notification: false` (a real
   // device ping). The conversational-pacing contract
@@ -3628,6 +3645,46 @@ function findLatestEndedTurnForChat(chatId: string): CurrentTurn | null {
     if (t.sessionChatId === chatId) latest = t
   }
   return latest
+}
+
+/**
+ * 2026-07 double-reply-on-DM fix (Part 1). Resolve the turn that OWNS a landing
+ * reply using the SAME full chain the thread-router uses, so the supersede
+ * resolver can never again diverge from routing (the exact bug: supersede
+ * omitted the quoted-message and latest-ended recoveries, so a DM late reply —
+ * no live turn, no `origin_turn_id` — resolved to a null owner and its flush
+ * message was never superseded → duplicate).
+ *
+ * Precedence (first non-null wins), delegated to the pure
+ * `resolveReplyOwnerTurnId` so the exact precedence is unit-tested:
+ *   1. the live `currentTurn` passed in (null once the flush nulled the atom);
+ *   2. `findTurnByOriginId(origin_turn_id)` — the model echo;
+ *   3. `findTurnByQuotedMessageId(chat_id, reply_to)` — framework-owned quote;
+ *   4. `findLatestEndedTurnForChat(chat_id)` — the chat's last-ended turn.
+ * Returns the CurrentTurn for the winning id (so callers can read its
+ * `answerDelivered` latch), or null when every lookup missed.
+ */
+function resolveReplyOwnerTurn(
+  liveTurn: CurrentTurn | null,
+  chatId: string,
+  args: Record<string, unknown>,
+): CurrentTurn | null {
+  const origin = findTurnByOriginId(args.origin_turn_id as string | undefined)
+  const quoted = findTurnByQuotedMessageId(chatId, args.reply_to)
+  const latestEnded = findLatestEndedTurnForChat(chatId)
+  const byId = new Map<string, CurrentTurn>()
+  // Populate lowest-precedence first so a higher tier's turn wins the id slot
+  // when two lookups resolve the same turn (they carry the same turnId anyway).
+  for (const t of [latestEnded, quoted, origin, liveTurn]) {
+    if (t != null) byId.set(t.turnId, t)
+  }
+  const winnerId = resolveReplyOwnerTurnId({
+    liveTurnId: liveTurn?.turnId ?? null,
+    originTurnId: origin?.turnId ?? null,
+    quotedTurnId: quoted?.turnId ?? null,
+    latestEndedTurnId: latestEnded?.turnId ?? null,
+  })
+  return winnerId != null ? (byId.get(winnerId) ?? null) : null
 }
 
 /**
@@ -12947,17 +13004,21 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // so a fresh turn's answer is never clobbered.
   {
     const replyThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
-    // Resolve the turnId this reply belongs to by IDENTITY, not just the live
-    // `currentTurn`. A late reply lands with `currentTurn == null` (silence poke
-    // cleared it — Bug D) or with a transiently-cleared currentTurn while its own
-    // turn is really still the owner (LOW-1); in both cases the turn is still
-    // resolvable from the `origin_turn_id` nonce the model echoes back (Tier 2 —
-    // the same last-known-turn resolver the chat-routing / obligation code uses).
-    // Passing this resolved turnId means supersede matches the flushed record by
-    // identity instead of falling back to a null-liveTurnId branch that would
-    // otherwise be free to delete a DIFFERENT turn's legitimate message.
-    const resolvedTurnId =
-      turn?.turnId ?? findTurnByOriginId(args.origin_turn_id as string | undefined)?.turnId ?? null
+    // 2026-07 double-reply-on-DM fix (Part 1) — resolve the turn this reply
+    // belongs to by IDENTITY, via the SAME full chain the thread-router uses
+    // (`resolveReplyOwnerTurn`): live `currentTurn`, then the model-echoed
+    // `origin_turn_id`, then the framework-owned quoted message id, then the
+    // chat's most-recently-ended turn. The prior chain stopped at
+    // `currentTurn ?? findTurnByOriginId`, so a DM late reply — `currentTurn`
+    // nulled by the flush's synthetic turn_end AND no `origin_turn_id` (a
+    // supergroup-only field) — resolved to a null owner. `decideSupersede`
+    // deliberately never lets a null live turn supersede a turnId-bearing flush
+    // record, so message A survived AND the reply shipped message B (the exact
+    // double-send). The quoted / latest-ended recoveries are precisely what the
+    // router already did for the same reply, so unifying here makes the two
+    // resolvers agree and the late-reply supersede fires by identity.
+    const ownerTurn = resolveReplyOwnerTurn(turn, chat_id, args)
+    const resolvedTurnId = ownerTurn?.turnId ?? null
     const decision = flushedTurnSupersede.take(
       chat_id,
       replyThreadId,
@@ -12973,6 +13034,46 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
           () => lockedBot.api.deleteMessage(chat_id, id),
           { chat_id, verb: 'reply.supersedeFlushed' },
         )
+      }
+    } else {
+      // 2026-07 double-reply-on-DM fix (Part 2) — answer-delivered race latch.
+      // Supersede found no record. Either there was no flush (normal reply), or
+      // the flush FIRED but has not yet recorded its message ids (the residual
+      // pre-record race Part 1's supersede cannot reach). The flush sets
+      // `answerDelivered = true` synchronously at fire time (before its async
+      // send AND before `record`), and it persists on the ended turn — so when
+      // this LATE, substantive reply resolves its owner turn and sees the latch
+      // already set, the flush's message A is already on its way out and this
+      // reply would ship a duplicate. Suppress it. Scoped to the substantive
+      // ≥`FLUSH_SUBSTANTIVE_MIN_CHARS` floor and the late-reply case so an
+      // interim sub-floor ack, a chunked multi-part answer, or a legitimate
+      // second in-turn substantive reply (live `currentTurn`) is never
+      // suppressed. `isSubstantiveFinalReply` reduces to the ≥200-char test on
+      // the `reply` path (no `done`); pass the model's original notification
+      // intent to mirror the #2533 decoupling call shape.
+      const replySubstantive = isSubstantiveFinalReply({
+        text: rawText,
+        disableNotification: args.disable_notification === true,
+      })
+      const suppressByLatch = decideAnswerLatchSuppression({
+        superseded: false,
+        replySubstantive,
+        isLateReply: turn == null,
+        ownerAnswerDelivered: ownerTurn?.answerDelivered ?? false,
+      })
+      if (suppressByLatch) {
+        process.stderr.write(
+          `telegram gateway: reply: suppressed by answer-delivered latch ` +
+          `(flush already delivered this turn's answer) chatId=${chat_id} ` +
+          `ownerTurnId=${JSON.stringify(resolvedTurnId)}\n`,
+        )
+        return { content: [{ type: 'text', text: 'sent (deduped — answer already delivered via turn-flush)' }] }
+      }
+      // A substantive answer is going out via this reply — set the latch on its
+      // owner turn so a later bridge-replayed / reworded duplicate of the same
+      // answer is caught by the branch above.
+      if (replySubstantive && ownerTurn != null) {
+        ownerTurn.answerDelivered = true
       }
     }
   }
@@ -16902,6 +17003,9 @@ function handleSessionEvent(ev: SessionEvent): void {
           finalAnswerSubstantive: false,
           // Sticky latch — reset ONLY here (turn start), never by reopen.
           finalAnswerEverDelivered: false,
+          // 2026-07 double-reply-on-DM fix (Part 2) — answer-delivered race
+          // latch, reset at turn start alongside the other answer flags.
+          answerDelivered: false,
           firstPingAt: null,
           // Notification ownership (R8 / PR-2): no slot claimed yet, so the
           // "claimer was substantive" flag starts false. Set atomically with
@@ -18135,6 +18239,20 @@ function handleSessionEvent(ev: SessionEvent): void {
         // the silent-end re-prompt. (Belt-and-braces, like the set above —
         // this branch returns before any further tool_label can arrive.)
         turn.finalAnswerSubstantive = true
+        // 2026-07 double-reply-on-DM fix (Part 2) — arm the answer-delivered
+        // race latch NOW, synchronously, BEFORE the ~500 ms async send below and
+        // BEFORE `flushedTurnSupersede.record`. A late reply that lands in the
+        // post-fire pre-record window resolves this turn (via the unified owner
+        // resolver, reading the atom preserved in `recentTurnsById`) and
+        // suppresses itself against this latch — closing the residual race Part
+        // 1's supersede cannot reach. Scoped to a SUBSTANTIVE terminal answer
+        // (the same ≥`FLUSH_SUBSTANTIVE_MIN_CHARS` floor the codebase uses to
+        // recognise a real answer) so a short flush never latches against a
+        // legitimate substantive reply. `capturedText` here is the selected,
+        // normalized flush delivery text.
+        if (capturedText.trim().length >= FLUSH_SUBSTANTIVE_MIN_CHARS) {
+          turn.answerDelivered = true
+        }
 
         // #654 deterministic double-message fix. Hand off the pinned
         // progress card BEFORE state reset so the driver doesn't keep

--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -1,0 +1,137 @@
+/**
+ * Reply owner-turn resolution + answer-delivered latch decision
+ * (2026-07 double-reply-on-DM fix — completes the #3236 turnId-keyed dedup for
+ * the late-reply / DM path).
+ *
+ * ## The bug this closes
+ *
+ * On a DM agent a turn double-sent: the answer-ready quiescence flush posted the
+ * composed terminal answer as message A (no quote), then the model's REAL `reply`
+ * tool call landed a moment later and sent message B (quoted). The user should
+ * have received exactly ONE message (the quoted reply).
+ *
+ * #3236 shipped `flushed-turn-supersede.ts` — a turnId-identity-keyed dedup that
+ * is text-agnostic BY DESIGN. It missed here not because of the text rewording
+ * but because the reply's owner turn resolved to `null` on the late path:
+ *
+ *   - At reply consumption the gateway resolved the owner turn as
+ *     `currentTurn ?? findTurnByOriginId(origin_turn_id) ?? null`.
+ *   - `currentTurn` was already nulled by the flush's synthetic turn_end.
+ *   - `origin_turn_id` is a forum-supergroup field, ABSENT in DMs, so
+ *     `findTurnByOriginId` returned null.
+ *   - ⇒ the resolved live turnId was `null`, and `decideSupersede` deliberately
+ *     never lets a null live turn supersede a turnId-bearing flush record. No
+ *     supersede fired → message A survived AND the reply sent message B.
+ *
+ * The DECISIVE divergence: the gateway's *thread-routing* path DID recover the
+ * owner turn for the same late reply — via `findTurnByQuotedMessageId` (the
+ * framework-owned default quote target) and `findLatestEndedTurnForChat` (the
+ * chat's most-recently-ended turn). The supersede resolver chain omitted BOTH
+ * recoveries, so the two resolvers disagreed on who owned the reply. This module
+ * unifies them onto ONE precedence so they can never diverge again.
+ *
+ * ## Why a pure module
+ *
+ * `gateway.ts` is not importable in tests (heavy top-level side effects), so the
+ * repo's convention — `decideTurnFlush`, `decideSupersede`,
+ * `decideCapturedProseDelivery` — is to extract the decision core into a pure,
+ * unit-testable function and have the gateway run the EXACT code the regression
+ * tests exercise. The gateway performs the four turn lookups (currentTurn,
+ * findTurnByOriginId, findTurnByQuotedMessageId, findLatestEndedTurnForChat) and
+ * feeds their resolved turnIds here; the precedence lives in one place.
+ */
+
+/**
+ * The four owner-turn candidate ids, in the gateway's resolution precedence.
+ * Each is the `turnId` of the turn a given lookup resolved, or null when that
+ * lookup found nothing.
+ */
+export interface ReplyOwnerCandidates {
+  /** The LIVE `currentTurn` at reply-consumption time (null once the flush's
+   *  synthetic turn_end has torn the atom down — the late-reply case). */
+  liveTurnId: string | null
+  /** `findTurnByOriginId(origin_turn_id)` — the turn the model echoed back.
+   *  Null in DMs (no `origin_turn_id`) and when the model omitted the echo. */
+  originTurnId: string | null
+  /** `findTurnByQuotedMessageId(chat_id, reply_to)` — the framework-owned
+   *  quoted message id, resolved with NO model thread assertion. */
+  quotedTurnId: string | null
+  /** `findLatestEndedTurnForChat(chat_id)` — the chat's most-recently-ended
+   *  turn. The deterministic late-reply fallback (the DM path's recovery). */
+  latestEndedTurnId: string | null
+}
+
+/**
+ * Resolve the turnId that OWNS a landing reply, using the SAME full chain the
+ * thread-router uses. Precedence, first non-null wins:
+ *
+ *   1. the live `currentTurn`;
+ *   2. the model-echoed `origin_turn_id` turn;
+ *   3. the framework-owned quoted-message turn;
+ *   4. the chat's most-recently-ended turn.
+ *
+ * Returns null only when EVERY lookup missed (a genuinely unattributable reply),
+ * in which case `decideSupersede` keeps its null-safety semantics and declines
+ * to delete any turnId-bearing flush record.
+ */
+export function resolveReplyOwnerTurnId(candidates: ReplyOwnerCandidates): string | null {
+  return (
+    candidates.liveTurnId ??
+    candidates.originTurnId ??
+    candidates.quotedTurnId ??
+    candidates.latestEndedTurnId ??
+    null
+  )
+}
+
+/**
+ * The answer-delivered latch inputs (Part 2 — the race backstop).
+ *
+ * The unified resolver (Part 1) closes the common late-reply case where the
+ * flush fully COMPLETED (recorded its supersede entry) before the reply landed:
+ * supersede then deletes message A and the reply delivers as the single clean
+ * message B. But a residual race remains — a reply whose supersede `take()` runs
+ * in the window AFTER the flush FIRED but BEFORE it recorded its message ids.
+ * There `flushed-turn-supersede` finds no record (nothing to delete yet) and the
+ * reply would ship message B as a duplicate of the flush's message A.
+ *
+ * The latch closes that window: the gateway sets `answerDelivered = true` on the
+ * turn atom SYNCHRONOUSLY at flush-fire time — before the ~500 ms async send and
+ * before the record — and the flag persists on the ended turn (readable via the
+ * unified resolver after `currentTurn` is null). A reply landing in the race
+ * window then sees the latch already set and suppresses itself.
+ */
+export interface AnswerLatchSuppressInput {
+  /** True when Part 1's supersede already fired for THIS reply (message A was
+   *  deleted and this reply IS the sanctioned replacement). The latch must NOT
+   *  then also suppress — that would leave the turn with ZERO messages. */
+  superseded: boolean
+  /** True when the landing reply is a substantive terminal answer (the same
+   *  ≥200-char `FINAL_ANSWER_MIN_CHARS` floor the flush latch is scoped to).
+   *  A sub-floor interim ack (short, `disable_notification`) is never a final
+   *  answer, so it neither sets nor trips the latch. */
+  replySubstantive: boolean
+  /** True when this is a LATE reply — `currentTurn` was already null at
+   *  consumption. The flush-duplicate ALWAYS lands late (the flush's synthetic
+   *  turn_end nulled the atom); scoping suppression to the late path leaves a
+   *  legitimate second in-turn substantive reply (a genuine multi-message
+   *  answer, live currentTurn) untouched. */
+  isLateReply: boolean
+  /** The resolved owner turn's `answerDelivered` latch. */
+  ownerAnswerDelivered: boolean
+}
+
+/**
+ * Decide whether the answer-delivered latch suppresses a landing reply.
+ *
+ * Suppress IFF: Part 1 did NOT already supersede, the reply is a substantive
+ * final answer, it is a late reply (no live turn), AND the owner turn's latch is
+ * already set (the flush delivered the same substantive answer as message A in
+ * the pre-record race window). Otherwise the reply sends.
+ */
+export function decideAnswerLatchSuppression(input: AnswerLatchSuppressInput): boolean {
+  if (input.superseded) return false
+  if (!input.replySubstantive) return false
+  if (!input.isLateReply) return false
+  return input.ownerAnswerDelivered
+}

--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -59,6 +59,29 @@ export interface ReplyOwnerCandidates {
   /** `findLatestEndedTurnForChat(chat_id)` — the chat's most-recently-ended
    *  turn. The deterministic late-reply fallback (the DM path's recovery). */
   latestEndedTurnId: string | null
+  /** Age (ms) of the latest-ended turn — `now - turn.endedAt`. The latest-ended
+   *  tier carries DESTRUCTIVE authority (it drives supersede deletion), so it is
+   *  honoured ONLY when the turn ended within `latestEndedTtlMs` (the supersede
+   *  TTL). Without the bound, a late reply belonging to an OLDER turn could
+   *  resolve its owner to a NEWER turn now sitting at the registry tail and
+   *  delete THAT turn's legit answer. Undefined/null ⇒ unbounded (back-compat:
+   *  callers that don't supply an age keep the pre-F2 behaviour). */
+  latestEndedAgeMs?: number | null
+  /** The supersede TTL bound applied to `latestEndedAgeMs`. Undefined ⇒
+   *  unbounded. */
+  latestEndedTtlMs?: number
+}
+
+/**
+ * Whether the latest-ended candidate is fresh enough to carry supersede
+ * (deletion) authority. A missing age or TTL means unbounded (back-compat).
+ */
+function latestEndedAccepted(candidates: ReplyOwnerCandidates): boolean {
+  if (candidates.latestEndedTurnId == null) return false
+  const age = candidates.latestEndedAgeMs
+  const ttl = candidates.latestEndedTtlMs
+  if (age == null || ttl == null) return true
+  return age <= ttl
 }
 
 /**
@@ -79,7 +102,7 @@ export function resolveReplyOwnerTurnId(candidates: ReplyOwnerCandidates): strin
     candidates.liveTurnId ??
     candidates.originTurnId ??
     candidates.quotedTurnId ??
-    candidates.latestEndedTurnId ??
+    (latestEndedAccepted(candidates) ? candidates.latestEndedTurnId : null) ??
     null
   )
 }

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -35,7 +35,7 @@ import {
   decideAnswerLatchSuppression,
   type ReplyOwnerCandidates,
 } from '../reply-owner-resolve.js'
-import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
+import { FlushedTurnSupersedeRegistry, DEFAULT_SUPERSEDE_TTL_MS } from '../flushed-turn-supersede.js'
 
 const NONE: ReplyOwnerCandidates = {
   liveTurnId: null,
@@ -185,5 +185,95 @@ describe('decideAnswerLatchSuppression — race backstop (Part 2)', () => {
         ownerAnswerDelivered: false,
       }),
     ).toBe(false)
+  })
+})
+
+describe('F1 — flush send failure must NOT suppress the late reply (zero-message guard)', () => {
+  // The flush arms `answerDelivered` synchronously at FIRE time, BEFORE the async
+  // send. If the send then throws and NOTHING was delivered, the supersede record
+  // is never written (gated on sentIds>0), so Part 1 cannot fire. Leaving the
+  // latch armed would make a genuine late reply suppress itself → the user gets
+  // ZERO messages. The gateway's send-failure catch resets `answerDelivered =
+  // false`; these assert the resulting coordination outcome at the pure core.
+  const lateSubstantiveReply = (ownerAnswerDelivered: boolean) =>
+    decideAnswerLatchSuppression({
+      superseded: false,
+      replySubstantive: true,
+      isLateReply: true,
+      ownerAnswerDelivered,
+    })
+
+  it('WITHOUT the catch-reset (latch still armed) the late reply is suppressed ' +
+    '— the zero-message bug', () => {
+    // Models the buggy state: flush armed the latch, send failed, latch left true.
+    expect(lateSubstantiveReply(true)).toBe(true)
+  })
+
+  it('WITH the catch-reset (answerDelivered=false) the late reply DELIVERS', () => {
+    // Models the fixed state: catch reset the latch, so the genuine late reply
+    // is not suppressed and the user still receives the answer.
+    expect(lateSubstantiveReply(false)).toBe(false)
+  })
+})
+
+describe('F2 — recency-bound the destructive latest-ended supersede tier', () => {
+  const CHAT = '515151'
+  const base: ReplyOwnerCandidates = {
+    liveTurnId: null,
+    originTurnId: null,
+    quotedTurnId: null,
+    latestEndedTurnId: null,
+  }
+
+  it('accepts a latest-ended turn that ended within the supersede TTL', () => {
+    expect(
+      resolveReplyOwnerTurnId({
+        ...base,
+        latestEndedTurnId: 'turn-T',
+        latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS - 1,
+        latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+      }),
+    ).toBe('turn-T')
+  })
+
+  it('REJECTS a STALE latest-ended turn (ended past the supersede TTL) so it ' +
+    'cannot inherit deletion authority — resolver returns null', () => {
+    expect(
+      resolveReplyOwnerTurnId({
+        ...base,
+        latestEndedTurnId: 'turn-STALE',
+        latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS + 5_000,
+        latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+      }),
+    ).toBeNull()
+  })
+
+  it('end-to-end: a stale latest-ended turn does NOT delete a live flush ' +
+    "record it doesn't own", () => {
+    const reg = new FlushedTurnSupersedeRegistry()
+    const now = 1_000_000
+    // A fresh flush record for the newer turn T2 (its owner, well within TTL).
+    reg.record(CHAT, undefined, { turnId: 'turn-T2', messageIds: [9001], text: 'A2' }, now)
+    // A late reply whose only recoverable owner is a STALE turn (ended long ago).
+    // Without the recency bound the resolver would hand back the stale turn id
+    // and a take() keyed on it could mis-target; with the bound it resolves null,
+    // so no deletion authority is granted and T2's record survives untouched.
+    const ownerId = resolveReplyOwnerTurnId({
+      ...base,
+      latestEndedTurnId: 'turn-STALE',
+      latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS + 5_000,
+      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+    })
+    expect(ownerId).toBeNull()
+    const decision = reg.take(CHAT, undefined, { liveTurnId: ownerId, now: now + 10 })
+    expect(decision.supersede).toBe(false)
+    // T2's record is intact (a null owner never reaches its turnId-keyed lane).
+    expect(reg.peek(CHAT, undefined, { liveTurnId: 'turn-T2', now: now + 10 }).supersede).toBe(true)
+  })
+
+  it('unbounded when no age is supplied (back-compat: pre-F2 precedence intact)', () => {
+    expect(
+      resolveReplyOwnerTurnId({ ...base, latestEndedTurnId: 'turn-T' }),
+    ).toBe('turn-T')
   })
 })

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression coverage for the 2026-07 double-reply-on-DM fix — completes the
+ * #3236 turnId-keyed dedup (`flushed-turn-supersede.ts`) for the late-reply / DM
+ * path.
+ *
+ * ## The incident these tests pin
+ *
+ * On a DM agent a turn DOUBLE-SENT: the answer-ready quiescence flush posted the
+ * composed terminal answer as message A (no quote), then the model's REAL
+ * `reply` tool call landed and sent message B (quoted). The user should have
+ * received exactly ONE message (the quoted reply).
+ *
+ * #3236's supersede is turnId-identity-keyed and text-agnostic BY DESIGN, so the
+ * 275-vs-249-char rewording is NOT why it missed. It missed because the reply's
+ * owner turn resolved to `null` on the late path: `currentTurn` was nulled by the
+ * flush's synthetic turn_end, and `origin_turn_id` (a forum-supergroup field) is
+ * absent in DMs — so the OLD 2-tier chain `currentTurn ?? findTurnByOriginId`
+ * yielded null, and `decideSupersede` never lets a null live turn supersede a
+ * turnId-bearing record.
+ *
+ * The router recovered the SAME reply's owner via `findTurnByQuotedMessageId` and
+ * `findLatestEndedTurnForChat`; the supersede chain omitted BOTH. The fix
+ * (`resolveReplyOwnerTurnId`) unifies the two onto one precedence.
+ *
+ * These tests exercise the extracted pure cores — the exact precedence and latch
+ * decision the gateway runs (`gateway.ts` is not importable in tests; the repo's
+ * `decideTurnFlush` / `decideSupersede` pattern). The core test also asserts the
+ * OLD 2-tier chain FAILS to recover the owner (the red-on-main contrast) while
+ * the unified chain recovers it and the supersede fires.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  resolveReplyOwnerTurnId,
+  decideAnswerLatchSuppression,
+  type ReplyOwnerCandidates,
+} from '../reply-owner-resolve.js'
+import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
+
+const NONE: ReplyOwnerCandidates = {
+  liveTurnId: null,
+  originTurnId: null,
+  quotedTurnId: null,
+  latestEndedTurnId: null,
+}
+
+/** The OLD (pre-fix) resolver chain the gateway ran on main — the 2-tier
+ *  `currentTurn ?? findTurnByOriginId` — reproduced here to prove the incident
+ *  went unrecovered before the fix (red-on-main contrast). */
+function oldTwoTierResolve(c: ReplyOwnerCandidates): string | null {
+  return c.liveTurnId ?? c.originTurnId ?? null
+}
+
+describe('resolveReplyOwnerTurnId — unified owner-turn precedence (Part 1)', () => {
+  it('prefers the live currentTurn when present', () => {
+    expect(
+      resolveReplyOwnerTurnId({ ...NONE, liveTurnId: 'live', originTurnId: 'origin', latestEndedTurnId: 'ended' }),
+    ).toBe('live')
+  })
+
+  it('falls to the model-echoed origin turn when no live turn', () => {
+    expect(
+      resolveReplyOwnerTurnId({ ...NONE, originTurnId: 'origin', quotedTurnId: 'quoted', latestEndedTurnId: 'ended' }),
+    ).toBe('origin')
+  })
+
+  it('falls to the framework-owned quoted-message turn when no live/origin', () => {
+    expect(
+      resolveReplyOwnerTurnId({ ...NONE, quotedTurnId: 'quoted', latestEndedTurnId: 'ended' }),
+    ).toBe('quoted')
+  })
+
+  it('falls to the chat latest-ended turn as the final tier — the DM recovery', () => {
+    expect(resolveReplyOwnerTurnId({ ...NONE, latestEndedTurnId: 'ended' })).toBe('ended')
+  })
+
+  it('returns null only when every lookup missed', () => {
+    expect(resolveReplyOwnerTurnId(NONE)).toBeNull()
+  })
+
+  it('RED-ON-MAIN CONTRAST: the DM late reply (no live turn, no origin) is ' +
+    'unrecovered by the old 2-tier chain but recovered by the unified chain', () => {
+    // The exact incident inputs: flush nulled currentTurn (liveTurnId=null),
+    // DM has no origin_turn_id (originTurnId=null); the owner survives only in
+    // the latest-ended registry (latestEndedTurnId).
+    const incident: ReplyOwnerCandidates = { ...NONE, latestEndedTurnId: 'turn-T' }
+    // Old behaviour (what shipped on main): null → no supersede → duplicate.
+    expect(oldTwoTierResolve(incident)).toBeNull()
+    // Fixed behaviour: recovers the owning turn T.
+    expect(resolveReplyOwnerTurnId(incident)).toBe('turn-T')
+  })
+})
+
+describe('Part 1 end-to-end: unified resolver drives the flush supersede', () => {
+  const CHAT = '424242'
+
+  it('CORE INCIDENT: flush records message A for turn T, then a late DM reply ' +
+    '(currentTurn=null, no origin_turn_id) SUPERSEDES via the recovered owner', () => {
+    const reg = new FlushedTurnSupersedeRegistry()
+    const now = 1_000
+    // Flush commits message A for turn T.
+    reg.record(CHAT, undefined, { turnId: 'turn-T', messageIds: [5001], text: 'A' }, now)
+
+    // Late DM reply: no live turn, no origin echo; owner survives in the
+    // latest-ended registry as turn-T.
+    const incident: ReplyOwnerCandidates = { ...NONE, latestEndedTurnId: 'turn-T' }
+
+    // Old 2-tier chain → null → supersede DECLINES (the duplicate ships).
+    const oldId = oldTwoTierResolve(incident)
+    expect(reg.peek(CHAT, undefined, { liveTurnId: oldId, now: now + 10 }).supersede).toBe(false)
+
+    // Unified chain → turn-T → supersede FIRES and deletes message A, so the
+    // reply below delivers as the single clean message.
+    const newId = resolveReplyOwnerTurnId(incident)
+    const decision = reg.take(CHAT, undefined, { liveTurnId: newId, now: now + 10 })
+    expect(decision.supersede).toBe(true)
+    expect(decision.deleteMessageIds).toEqual([5001])
+  })
+
+  it('a DIFFERENT newer turn recovered as owner does NOT supersede turn T', () => {
+    const reg = new FlushedTurnSupersedeRegistry()
+    const now = 2_000
+    reg.record(CHAT, undefined, { turnId: 'turn-T', messageIds: [7001], text: 'A' }, now)
+    // Owner recovers to a newer turn (its own flush isn't recorded here).
+    const id = resolveReplyOwnerTurnId({ ...NONE, latestEndedTurnId: 'turn-NEWER' })
+    expect(reg.take(CHAT, undefined, { liveTurnId: id, now: now + 10 }).supersede).toBe(false)
+  })
+})
+
+describe('decideAnswerLatchSuppression — race backstop (Part 2)', () => {
+  it('RACE: a late substantive reply lands in the flush post-fire pre-record ' +
+    'window (no supersede record yet) → SUPPRESSED by the latch', () => {
+    expect(
+      decideAnswerLatchSuppression({
+        superseded: false,
+        replySubstantive: true,
+        isLateReply: true,
+        ownerAnswerDelivered: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('does NOT double-suppress when Part 1 already superseded (else the turn ' +
+    'ends with ZERO messages)', () => {
+    expect(
+      decideAnswerLatchSuppression({
+        superseded: true,
+        replySubstantive: true,
+        isLateReply: true,
+        ownerAnswerDelivered: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('NEGATIVE: an interim sub-floor ack (not substantive) is never suppressed ' +
+    '— so interim-ack-then-final both send', () => {
+    expect(
+      decideAnswerLatchSuppression({
+        superseded: false,
+        replySubstantive: false,
+        isLateReply: true,
+        ownerAnswerDelivered: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('NEGATIVE: a normal in-turn reply with a live currentTurn is never ' +
+    'suppressed (a legitimate second substantive reply still sends)', () => {
+    expect(
+      decideAnswerLatchSuppression({
+        superseded: false,
+        replySubstantive: true,
+        isLateReply: false,
+        ownerAnswerDelivered: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not suppress when the owner latch is unset (a normal answer)', () => {
+    expect(
+      decideAnswerLatchSuppression({
+        superseded: false,
+        replySubstantive: true,
+        isLateReply: true,
+        ownerAnswerDelivered: false,
+      }),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

On DM agents a turn double-sent to Telegram: the answer-ready quiescence flush posted the composed terminal answer as **message A** (no quote), then the model's late `reply` tool call sent **message B** (quoted). The user should get exactly **one** message (the quoted reply). This completes the #3236 turnId-keyed dedup for the late-reply / DM path.

## Why it missed (resolver divergence — root cause)

#3236's supersede (`flushed-turn-supersede.ts`) is turnId-identity-keyed and **text-agnostic by design**, so the char-count rewording between the flush blob and the clean reply is *not* why it missed. It missed because the reply's **owner turn resolved to `null`** on the late path:

- At supersede consumption the gateway resolved the owner as `currentTurn ?? findTurnByOriginId(origin_turn_id)?.turnId ?? null`.
- `currentTurn` was already nulled by the flush's synthetic turn_end (`endCurrentTurnAtomic`).
- `origin_turn_id` is a **forum-supergroup field, absent in DMs**, so `findTurnByOriginId` → null.
- ⇒ resolved live turnId `null`; `decideSupersede` deliberately **never** lets a null live turn supersede a turnId-bearing record. No supersede → message A survived **and** the reply shipped message B.

The **thread-router recovered the same reply's owner** for the identical reply — via `findTurnByQuotedMessageId(chat_id, reply_to)` and `findLatestEndedTurnForChat(chat_id)` (this is why the reply routed `via=recovered`). The supersede resolver chain omitted **both** recoveries. The two resolvers disagreed.

## The fix (two parts, deterministic)

**Part 1 (primary) — unify the reply owner-turn resolver.** New pure `resolveReplyOwnerTurnId` (precedence: live → origin → quoted → latest-ended), wired through the gateway `resolveReplyOwnerTurn` helper at the supersede consumption site (and reusing the same lookups the router uses). The DM late reply now recovers its owner turn, so the supersede fires by identity and deletes message A while the reply delivers as the single clean message.

**Part 2 (backstop) — `answerDelivered` latch on the CurrentTurn atom.** Set **synchronously at flush FIRE time** (before the ~500 ms async send and before `flushedTurnSupersede.record`), persisted in `recentTurnsById` so it is readable after `currentTurn` is null. A reply landing in the flush **post-fire pre-record race window** — which Part 1's supersede cannot reach (no record yet) — resolves its owner turn, sees the latch, and suppresses itself. Scoped to the `>=200`-char `FLUSH_SUBSTANTIVE_MIN_CHARS` floor and the late-reply case:

- an interim sub-floor ack neither sets nor trips it (interim-ack-then-final both send);
- a chunked multi-part answer (one `reply` call) is untouched;
- a legitimate second in-turn substantive reply (live `currentTurn`) is untouched;
- it never fires when Part 1 already superseded (that would leave the turn with **zero** messages).

## Test plan

Pure decision cores are extracted (repo convention — `gateway.ts` isn't importable in tests) and the gateway runs the exact code the tests exercise.

- `telegram-plugin/tests/reply-owner-resolve.test.ts` (13): unified precedence; the **red-on-main contrast** (the incident inputs — no live turn, no `origin_turn_id` — are unrecovered by the old 2-tier chain, recovered by the unified chain); the **core incident end-to-end** (flush records message A for turn T, late DM reply supersedes via the recovered owner; old chain declines → duplicate); the race backstop and the negative guards (ack, live-turn second reply, superseded-no-double-suppress).
- `telegram-plugin/tests/flushed-turn-supersede.test.ts` (15): unchanged, green.
- `tsc --noEmit` and `npm run lint` (all 8 guards incl. `check-bot-api-wrapping`) clean.

## Risk

Low. Part 1 only widens owner-turn resolution to the two recoveries the router already performed for the same reply; the null-safety semantics of `decideSupersede` are intact. Part 2's latch is scoped to the substantive floor + late-reply case + not-superseded, so it cannot suppress a legitimate ack, chunk, or second in-turn answer. Kill path unchanged (no new flags).

Job spec: `reference/jobs/` — conversational pacing / exactly-one-final-answer delivery (`reference/rfcs/conversational-pacing.md` beat 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)