### PR TITLE
Ship crash-survival redelivery (live) + silent-no-op detector windowing

### DIFF
--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -5,6 +5,7 @@ import {
   detectTurnFindings,
   detectGatewayFindings,
   HANG_MS,
+  SILENT_NOOP_FLOOR_TS,
 } from "./detect.js";
 
 /**
@@ -37,7 +38,28 @@ describe("parseTurns", () => {
 
 describe("detectTurnFindings", () => {
   it("flags a silent no-op (complete, zero tools, real turn)", () => {
+    // Fixture base ts (1_782_600_000 ≈ 2026-06-27) is BELOW the default
+    // SILENT_NOOP_FLOOR_TS (2026-07-13), so pass floor:0 to assert the detector
+    // LOGIC independent of the calendar window.
     const turns = parseTurns(turn(10, { tools: 0 }));
+    const f = detectTurnFindings("alpha", turns, { silentNoopFloorTs: 0 });
+    expect(f.map((x) => x.signal)).toContain("silent-no-op-candidate");
+  });
+
+  it("windows OUT a silent no-op whose ts is below the floor (Fix 2)", () => {
+    // Same complete/zero-tool turn, but under the default floor its 2026-06-27
+    // ts is pre-fix backlog → it must NOT be flagged.
+    const turns = parseTurns(turn(10, { tools: 0 }));
+    const f = detectTurnFindings("alpha", turns);
+    expect(f.map((x) => x.signal)).not.toContain("silent-no-op-candidate");
+  });
+
+  it("flags a silent no-op whose ts is AT/ABOVE the default floor (Fix 2)", () => {
+    // A post-fix turn (ts at the 2026-07-13 floor) is still a real signal — the
+    // windowing must not swallow go-forward silent no-ops.
+    const turns = parseTurns(
+      turn(10, { tools: 0, ts: SILENT_NOOP_FLOOR_TS + 100 }),
+    );
     const f = detectTurnFindings("alpha", turns);
     expect(f.map((x) => x.signal)).toContain("silent-no-op-candidate");
   });

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -20,6 +20,29 @@ export const HANG_MS = 360_000;
  *  tool calls is deep work. Load-bearing. */
 export const HANG_MAXTOOLS = 2;
 
+/**
+ * Silent-no-op windowing floor (unix SECONDS) = 2026-07-13T00:00:00Z, the
+ * fast-path ship epoch. The silent-no-op detector was over-counting a stale
+ * pre-fix backlog (2026-07-02..07-06). We window the `silent-no-op-candidate`
+ * finding — and ONLY that finding — to turns whose `ts` is at/after this floor,
+ * so the ledger reflects current reality instead of pre-fix inflation.
+ *
+ * FIXED epoch, not a rolling window: a rolling window would hide a genuine
+ * ongoing rate. This is param-injected into the detectors (never read from
+ * `Date.now()` internally) to keep the module a pure function over its inputs.
+ *
+ * Verify: `date -u -d @1783900800` → Mon Jul 13 00:00:00 UTC 2026.
+ */
+export const SILENT_NOOP_FLOOR_TS = 1_783_900_800;
+
+/** Options threaded into the turn detectors. Pure inputs only — no clock. */
+export interface DetectOptions {
+  /** Unix-seconds floor for the silent-no-op finding. Turns with `ts` below
+   *  this are NOT flagged as silent-no-ops. Defaults to `SILENT_NOOP_FLOOR_TS`.
+   *  Tests pass `0` to assert detector LOGIC independent of the calendar. */
+  silentNoopFloorTs?: number;
+}
+
 /** One row of `turns.jsonl` — the structured per-turn oracle. */
 export interface TurnRecord {
   ts?: number;
@@ -113,8 +136,13 @@ function isoFromTs(ts: number | undefined): string | null {
  * Run the turns.jsonl detectors over one agent's parsed turns. Pure — returns
  * the flagged findings. Mirrors the reference detector's three turn checks.
  */
-export function detectTurnFindings(agent: string, turns: TurnRecord[]): Finding[] {
+export function detectTurnFindings(
+  agent: string,
+  turns: TurnRecord[],
+  opts: DetectOptions = {},
+): Finding[] {
   const findings: Finding[] = [];
+  const silentNoopFloorTs = opts.silentNoopFloorTs ?? SILENT_NOOP_FLOOR_TS;
   for (const t of turns) {
     const tid = t.turn_id ?? "?";
     const st = t.status;
@@ -153,8 +181,17 @@ export function detectTurnFindings(agent: string, turns: TurnRecord[]): Finding[
         ts,
       });
     }
-    // silent no-op: completed, zero tools, real (non-synthetic).
-    if (st === "complete" && tl === 0 && !synthetic) {
+    // silent no-op: completed, zero tools, real (non-synthetic). Windowed to
+    // turns at/after the fixed floor so stale pre-fix backlog stops scoring.
+    // Rows lacking a `ts` are dropped from this finding (real gateway rows
+    // always carry `ts` — turn-record-status.ts writes it unconditionally).
+    if (
+      st === "complete" &&
+      tl === 0 &&
+      !synthetic &&
+      t.ts != null &&
+      t.ts >= silentNoopFloorTs
+    ) {
       findings.push({
         signal: "silent-no-op-candidate",
         agent,
@@ -230,6 +267,7 @@ export function scanAgent(
   agent: string,
   turnsText: string,
   gatewayText: string,
+  opts: DetectOptions = {},
 ): AgentScanResult {
   const turns = parseTurns(turnsText);
   const status_mix: Record<string, number> = {};
@@ -237,7 +275,7 @@ export function scanAgent(
     const st = t.status ?? "unknown";
     status_mix[st] = (status_mix[st] ?? 0) + 1;
   }
-  const turnFindings = detectTurnFindings(agent, turns);
+  const turnFindings = detectTurnFindings(agent, turns, opts);
   const { findings: gwFindings, gw_hits } = detectGatewayFindings(
     agent,
     gatewayText,

--- a/src/fleet-health/ledger.test.ts
+++ b/src/fleet-health/ledger.test.ts
@@ -101,6 +101,10 @@ describe("runScan (I/O) — defensive over a synthetic fleet tree", () => {
           turn_id: `${CHAT}:_#1`,
           status: "complete",
           tools: 0,
+          // Real gateway rows always carry `ts`; the silent-no-op guard now
+          // requires it (detect.ts). ~2026-07-02, matching the gw log line and
+          // the scenario clock (below the fixed floor — see silentNoopFloorTs:0).
+          ts: 1_783_032_000,
         }) + "\n",
       );
       writeFileSync(
@@ -119,6 +123,12 @@ describe("runScan (I/O) — defensive over a synthetic fleet tree", () => {
         ownerAgent: "klanker",
         log: (m) => warnings.push(m),
         now: new Date("2026-07-03T00:00:00Z"),
+        // Neutralize the silent-no-op floor for this fixture: the fixture turn
+        // carries no `ts` and the scenario clock (2026-07-03) predates the
+        // fixed floor, so without this override the silent-no-op finding is
+        // dropped. Mirrors how detect.test.ts neutralizes the floor for
+        // sub-floor fixtures. (prod CLI keeps the real floor — see fleet-health.ts)
+        silentNoopFloorTs: 0,
       });
       expect(res.agentsSkipped).toContain("ghost");
       // clerk contributed a silent no-op + a duplicate delivery

--- a/src/fleet-health/scan.ts
+++ b/src/fleet-health/scan.ts
@@ -43,6 +43,9 @@ export interface ScanOptions {
   now?: Date;
   windowDays?: number;
   log?: (msg: string) => void;
+  /** Override the silent-no-op windowing floor (unix seconds). Defaults to
+   *  `SILENT_NOOP_FLOOR_TS`. Exposed for tests / future re-baselining. */
+  silentNoopFloorTs?: number;
 }
 
 export interface ScanResult {
@@ -123,7 +126,9 @@ export function runScan(opts: ScanOptions = {}): ScanResult {
       continue;
     }
     try {
-      const res = scanAgent(agent, turnsText, gwText);
+      const res = scanAgent(agent, turnsText, gwText, {
+        silentNoopFloorTs: opts.silentNoopFloorTs,
+      });
       perAgent.push(res);
       findings.push(...res.findings);
       scanned++;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -357,7 +357,7 @@ const REPLY_TO_TEXT_MAX = 200
 // tests exercise the real string — see PR #2892.
 import { splitMarkdownChunks, repairEscapedWhitespace, normalizeParagraphBreaks, addParagraphSpacers, normalizePunctuation, stripExcessBold, escapeMarkdown, hardenCardBreaks, RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { richMessage } from '../rich-send.js'
-import { decideRedeliver } from './redelivery-decision.js'
+import { decideRedeliver, decideRedeliverCapture } from './redelivery-decision.js'
 import { scrubVoice } from '../text-voice-scrub.js'
 import {
   normalizeOutboundBody,
@@ -1833,25 +1833,6 @@ try {
       return Number.isFinite(v) && v > 0 ? v : 10_800_000 // 3h
     })()
 
-    // Crash-survival redelivery (deterministic, zero-token): capture THIS
-    // interrupted turn as a redelivery candidate. The actual re-project + framed
-    // send happens later, AFTER the Telegram client connects (see
-    // `maybeRedeliverUndeliveredAnswer`, fired from the one-time-setup block).
-    // Gated on the same `pending` as the resume synthetic but a SEPARATE concern:
-    // resume re-runs the model on unfinished work; redelivery just re-sends the
-    // finished answer the model already produced and the crash swallowed. Only a
-    // turn with a durably-stamped `session_id` (pinned live via the session-event
-    // path) is eligible — without it we cannot resolve the EXACT transcript, and
-    // a most-recent-mtime heuristic could shadow a fresh boot session's file.
-    if (pending.session_id) {
-      pendingRedelivery = { turn: pending, maxAgeMs: RESUME_MAX_AGE_MS }
-    } else {
-      process.stderr.write(
-        `telegram gateway: crash-redelivery skipped — interrupted turnKey=${pending.turn_key} has no ` +
-        `pinned session_id (pre-feature turn or no session event seen); cannot resolve exact transcript\n`,
-      )
-    }
-
     // Decide the inbound kind (pure — see decideBootResumeKind). Precedence:
     //   1. loop-guard  → 'defer-loop'       (never a second resume of a resume)
     //   2. suppressed  → 'defer-suppressed' (boot_resume: never; notice, not silence)
@@ -1862,6 +1843,50 @@ try {
       ageMs: Math.max(0, Date.now() - pending.started_at),
       maxAgeMs: RESUME_MAX_AGE_MS,
     })
+
+    // Crash-survival redelivery (deterministic, zero-token): capture THIS
+    // interrupted turn as a redelivery candidate. The actual re-project + framed
+    // send happens later, AFTER the Telegram client connects (see
+    // `maybeRedeliverUndeliveredAnswer`, fired from the one-time-setup block).
+    // Gated on the same `pending` as the resume synthetic but a SEPARATE concern:
+    // resume re-runs the model on unfinished work; redelivery just re-sends the
+    // finished answer the model already produced and the crash swallowed.
+    //
+    // MUTUAL EXCLUSION with resume (double-send guard): redelivery is captured
+    // ONLY when this turn will NOT be re-run by the resume path — i.e.
+    // `bootResumeKind !== 'resume'`. When the kind IS 'resume', the model re-runs
+    // the interrupted work and emits a FRESH answer that supersedes the recovered
+    // draft; redelivering as well would send the same answer twice (once framed
+    // "Recovered from an interrupted turn:", once fresh). The other kinds do NOT
+    // auto-re-answer, so redelivery is the correct (and only) send there:
+    //   - 'report'          (watchdog-timeout): synthetic only ASKS retry — no auto re-answer
+    //   - 'defer-suppressed' (boot_resume: never): no synthetic re-run at all
+    //   - 'defer-loop'       (resume-of-a-resume guard): no re-run
+    //   - 'none'             (nothing queued): redelivery is the sole recovery
+    // This gate is deterministic in code, not prompt-dependent.
+    //
+    // Eligibility floor: only a turn with a durably-stamped `session_id` (pinned
+    // live via the session-event path) qualifies — without it we cannot resolve
+    // the EXACT transcript, and a most-recent-mtime heuristic could shadow a
+    // fresh boot session's file. The mutual-exclusion-with-resume rule and this
+    // floor live together in the pure `decideRedeliverCapture` predicate.
+    const redeliverCapture = decideRedeliverCapture({
+      willBeResumed: bootResumeKind === 'resume',
+      hasSessionId: Boolean(pending.session_id),
+    })
+    if (redeliverCapture.capture) {
+      pendingRedelivery = { turn: pending, maxAgeMs: RESUME_MAX_AGE_MS }
+    } else if (redeliverCapture.skipReason === 'will-be-resumed') {
+      process.stderr.write(
+        `telegram gateway: crash-redelivery suppressed — interrupted turnKey=${pending.turn_key} will be ` +
+        `RESUMED (bootResumeKind=resume); the fresh re-answer supersedes the recovered draft (no double-send)\n`,
+      )
+    } else {
+      process.stderr.write(
+        `telegram gateway: crash-redelivery skipped — interrupted turnKey=${pending.turn_key} has no ` +
+        `pinned session_id (pre-feature turn or no session event seen); cannot resolve exact transcript\n`,
+      )
+    }
 
     // Sub-agents that were still in flight (running / stalled — non-terminal)
     // when the turn was killed. Read HERE, at module top, BEFORE the

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -833,6 +833,7 @@ import {
   findRecentTurnsForChat,
   getTurnByKey,
   markTurnResumed,
+  stampTurnSessionId,
   reapStaleOpenTurns,
 } from '../registry/turns-schema.js'
 import {
@@ -2977,6 +2978,10 @@ const PENDING_CMD_DRAIN_CAP_MS = 60_000
 // forwarded by the bridge on every session_event — we read occupancy from
 // exactly that file (never an independent findActiveSessionFile re-scan).
 let lastSessionActiveFile: string | null = null
+// Crash-survival redelivery (#session-id pin): the last turn_key whose
+// `session_id` we durably stamped, so the hot session-event path stamps once
+// per turn instead of issuing a guarded UPDATE on every event.
+let lastSessionStampedTurnKey: string | null = null
 // Anti-spam state machine lives in ./proactive-compact (pure, unit
 // tested). `compactDispatching` is a synchronous re-entrancy guard for
 // the async tmux send — purgeReactionTracking can run several times per
@@ -11211,6 +11216,29 @@ const ipcServer: IpcServer = createIpcServer({
     // Track the session-tail's attached file for the proactive-
     // compaction occupancy read (see maybeProactiveCompact).
     if (msg.activeFile) lastSessionActiveFile = msg.activeFile
+    // Crash-survival redelivery: durably pin the claude session id onto the
+    // current turn's row the first time we see a session event for it, WHILE
+    // the turn is live (so a later crash preserves it). Boot redelivery then
+    // resolves the EXACT `<sessionId>.jsonl` for the interrupted turn rather
+    // than a most-recent-mtime heuristic that a fresh boot session shadows.
+    // First-write-wins in SQL (`session_id IS NULL`); the in-memory guard just
+    // avoids a redundant UPDATE on every event of the same turn.
+    if (turnsDb != null && msg.activeFile != null) {
+      const stampKey = currentTurn?.registryKey ?? null
+      if (stampKey != null && stampKey !== lastSessionStampedTurnKey) {
+        const sessionId = basename(msg.activeFile).replace(/\.jsonl$/, '')
+        if (sessionId) {
+          try {
+            stampTurnSessionId(turnsDb, stampKey, sessionId)
+            lastSessionStampedTurnKey = stampKey
+          } catch (err) {
+            process.stderr.write(
+              `telegram gateway: stampTurnSessionId failed turnKey=${stampKey}: ${(err as Error).message}\n`,
+            )
+          }
+        }
+      }
+    }
     const ev = msg.event as unknown as SessionEvent
     // #1122/#1126: session events used to be ingested into the pinned progress
     // card here (`progressDriver.ingest`). The card is retired and the driver

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -243,7 +243,11 @@ import { isFinalAnswerReply, isSubstantiveFinalReply, FINAL_ANSWER_MIN_CHARS } f
 import { deriveTurnRole, decideTerminalReason, parsePostAnswerLivenessMs, evaluatePostAnswerLiveness, type LoopRole } from '../turn-liveness-floor.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
 import { parseVisibleAnswerStreamEnabled, resolveAnswerLaneConfig } from '../answer-stream-flag.js'
-import { type SessionEvent } from '../session-tail.js'
+import {
+  type SessionEvent,
+  projectTrailingAnswerFromTranscript,
+  getProjectsDirForCwd,
+} from '../session-tail.js'
 import {
   shouldSuppressToolActivity,
 } from '../pty-tail.js'
@@ -303,6 +307,7 @@ import {
   checkpointWal as checkpointHistoryWal,
   pruneMessagesOlderThanDays,
   hasOutboundDeliveredSince,
+  hasOutboundWithText,
 } from '../history.js'
 import {
   runRegistryReaper,
@@ -352,6 +357,7 @@ const REPLY_TO_TEXT_MAX = 200
 // tests exercise the real string — see PR #2892.
 import { splitMarkdownChunks, repairEscapedWhitespace, normalizeParagraphBreaks, addParagraphSpacers, normalizePunctuation, stripExcessBold, escapeMarkdown, hardenCardBreaks, RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { richMessage } from '../rich-send.js'
+import { decideRedeliver } from './redelivery-decision.js'
 import { scrubVoice } from '../text-voice-scrub.js'
 import {
   normalizeOutboundBody,
@@ -833,8 +839,10 @@ import {
   findRecentTurnsForChat,
   getTurnByKey,
   markTurnResumed,
+  markAnswerRedelivered,
   stampTurnSessionId,
   reapStaleOpenTurns,
+  type Turn,
 } from '../registry/turns-schema.js'
 import {
   buildResumeInterruptedInbound,
@@ -1695,6 +1703,13 @@ let turnsDb: ReturnType<typeof openTurnsDb> | null = null
 // Stashed here; pushed to the spool once it's constructed below. The spool's
 // turn_key-keyed dedup makes a re-stash across multiple restarts a no-op.
 let bootResumeInbound: { agent: string; msg: InboundMessage } | null = null
+// Crash-survival redelivery candidate, captured during the boot-resume block
+// (module init, BEFORE the Telegram client connects) and consumed by
+// `maybeRedeliverUndeliveredAnswer` in the one-time-setup block AFTER
+// `bot.api.getMe()` succeeds — so the framed recovered-answer send is sequenced
+// after the client is ready, never fired mid module-init. `null` when there is
+// no interrupted turn to consider.
+let pendingRedelivery: { turn: Turn; maxAgeMs: number } | null = null
 // #3038 cross-boot damper: consecutive bridge-dead escalations by PRIOR
 // boots (the consumed marker's `count`; 0 when no fresh marker). Set in
 // the boot block below, consumed by the watchdog constructor further down.
@@ -1817,6 +1832,25 @@ try {
       const v = Number(process.env.SWITCHROOM_RESUME_MAX_AGE_MS)
       return Number.isFinite(v) && v > 0 ? v : 10_800_000 // 3h
     })()
+
+    // Crash-survival redelivery (deterministic, zero-token): capture THIS
+    // interrupted turn as a redelivery candidate. The actual re-project + framed
+    // send happens later, AFTER the Telegram client connects (see
+    // `maybeRedeliverUndeliveredAnswer`, fired from the one-time-setup block).
+    // Gated on the same `pending` as the resume synthetic but a SEPARATE concern:
+    // resume re-runs the model on unfinished work; redelivery just re-sends the
+    // finished answer the model already produced and the crash swallowed. Only a
+    // turn with a durably-stamped `session_id` (pinned live via the session-event
+    // path) is eligible — without it we cannot resolve the EXACT transcript, and
+    // a most-recent-mtime heuristic could shadow a fresh boot session's file.
+    if (pending.session_id) {
+      pendingRedelivery = { turn: pending, maxAgeMs: RESUME_MAX_AGE_MS }
+    } else {
+      process.stderr.write(
+        `telegram gateway: crash-redelivery skipped — interrupted turnKey=${pending.turn_key} has no ` +
+        `pinned session_id (pre-feature turn or no session event seen); cannot resolve exact transcript\n`,
+      )
+    }
 
     // Decide the inbound kind (pure — see decideBootResumeKind). Precedence:
     //   1. loop-guard  → 'defer-loop'       (never a second resume of a resume)
@@ -10460,6 +10494,150 @@ async function deliverCapturedProse(args: {
         )
       })
     }
+  }
+}
+
+/**
+ * Crash-survival redelivery — the LIVE boot send (deterministic, zero model
+ * tokens). Consumes the `pendingRedelivery` candidate captured during module
+ * init and, if the interrupted turn's finished answer never reached the user,
+ * re-projects it from the durable transcript and sends it FRAMED as a recovered
+ * draft.
+ *
+ * ── Ordering guarantee (why this is NOT called during module init) ───────────
+ * The Telegram raw send (`bot.api.sendRichMessage`) requires a CONNECTED client.
+ * The boot-resume block that computes `pendingRedelivery` runs at module top,
+ * BEFORE `bot.api.getMe()` and the grammy runner start — sending there would
+ * fire against an unconnected client (or block the connect). So the candidate is
+ * only STASHED at module init; this function is invoked exactly once from the
+ * `didOneTimeSetup` block AFTER `getMe()` resolves — i.e. after the client is
+ * connected and ready. This sequencing is a code-path guarantee, not prompt
+ * discipline: the call site is unreachable until the poll loop has authenticated.
+ *
+ * ── Invariants honored ──────────────────────────────────────────────────────
+ * - at-most-once per interruption: the durable text-identity oracle
+ *   (`hasOutboundWithText`, scoped to this turn's `started_at`) skips when the
+ *   answer already went out, and `markAnswerRedelivered` is stamped SYNCHRONOUSLY
+ *   after the send resolves (first-write-wins). The send also writes its own
+ *   `role='assistant'` history row, so a re-restart before the marker commits is
+ *   still caught by the oracle (residual send→row race documented on the marker).
+ * - RESUME_MAX_AGE_MS (3h) staleness, empty-text, trailing-not-text, and
+ *   already-delivered/already-redelivered are all enforced by `decideRedeliver`.
+ * - isApiErrorMessage lines are suppressed at the projector (never resurfaced).
+ * - only trailing TEXT after the last tool_use is redelivered (mid-tool preamble
+ *   is refused by `trailingIsText`).
+ */
+async function maybeRedeliverUndeliveredAnswer(): Promise<void> {
+  const candidate = pendingRedelivery
+  pendingRedelivery = null // consume once, regardless of outcome
+  if (candidate == null || turnsDb == null) return
+  const { turn, maxAgeMs } = candidate
+  const sessionId = turn.session_id
+  if (!sessionId) return
+
+  // Resolve the EXACT transcript from the pinned session id (never a
+  // most-recent-mtime scan, which a fresh boot session's file could shadow).
+  let transcriptText: string
+  try {
+    const projectsDir = getProjectsDirForCwd()
+    const path = join(projectsDir, `${sessionId}.jsonl`)
+    if (!existsSync(path)) {
+      process.stderr.write(
+        `telegram gateway: crash-redelivery — transcript not found for turnKey=${turn.turn_key} ` +
+        `session=${sessionId} (${path}); skipping\n`,
+      )
+      return
+    }
+    transcriptText = readFileSync(path, 'utf8')
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: crash-redelivery — transcript read failed turnKey=${turn.turn_key}: ${(err as Error).message}\n`,
+    )
+    return
+  }
+
+  const projected = projectTrailingAnswerFromTranscript(transcriptText)
+  const threadIdNum =
+    turn.thread_id != null && turn.thread_id !== '' ? Number(turn.thread_id) : undefined
+  const threadIdForOracle: number | null = threadIdNum != null && Number.isFinite(threadIdNum) ? threadIdNum : null
+
+  const decision = decideRedeliver({
+    capturedText: projected.text,
+    trailingIsText: projected.trailingIsText,
+    // Durable text-identity oracle, scoped to THIS turn's window (`started_at`)
+    // so an unrelated earlier turn's message can never false-positive-suppress.
+    hasDeliveredText: HISTORY_ENABLED
+      ? hasOutboundWithText(turn.chat_id, projected.text, threadIdForOracle, turn.started_at)
+      : false,
+    alreadyRedelivered: turn.answer_redelivered_at != null,
+    ageMs: Math.max(0, Date.now() - turn.started_at),
+    maxAgeMs,
+  })
+
+  if (!decision.redeliver || decision.framedText == null) {
+    process.stderr.write(
+      `telegram gateway: crash-redelivery skipped turnKey=${turn.turn_key} reason=${decision.skipReason ?? 'unknown'}\n`,
+    )
+    return
+  }
+
+  const chatId = turn.chat_id
+  const out = redactOutboundText(decision.framedText, 'crash_redelivery')
+  const chunks = splitMarkdownChunks(out, RICH_MESSAGE_MAX_CHARS)
+  const sentIds: number[] = []
+  try {
+    let liveThreadId: number | undefined = threadIdNum != null && Number.isFinite(threadIdNum) ? threadIdNum : undefined
+    for (const c of chunks) {
+      const sent = await retryWithThreadFallback(
+        robustApiCall,
+        (tid) => {
+          // Built as a variable (not an inline literal) so excess-property
+          // checks don't reject `link_preview_options` on sendRichMessage's
+          // narrow Other<> type — mirrors the captured-prose / turn-flush sites.
+          const opts = {
+            link_preview_options: { is_disabled: true },
+            ...(tid != null ? { message_thread_id: tid } : {}),
+          }
+          return bot.api.sendRichMessage(chatId, richMessage(c), opts)
+        },
+        { threadId: liveThreadId, chat_id: chatId, verb: 'crash-redelivery.sendMessage' },
+      )
+      if (liveThreadId != null && (sent as { message_thread_id?: number }).message_thread_id == null) {
+        liveThreadId = undefined
+      }
+      sentIds.push(sent.message_id)
+    }
+    // Record the send as a real assistant delivery so the durable oracle catches
+    // a duplicate if we crash before the marker commits (self-idempotent).
+    if (HISTORY_ENABLED && sentIds.length > 0) {
+      try {
+        recordOutbound({
+          chat_id: chatId,
+          thread_id: threadIdForOracle,
+          message_ids: sentIds,
+          texts: chunks,
+        })
+      } catch {}
+    }
+    // Stamp the at-most-once marker SYNCHRONOUSLY after the send resolves.
+    try {
+      markAnswerRedelivered(turnsDb, turn.turn_key)
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: crash-redelivery markAnswerRedelivered failed turnKey=${turn.turn_key}: ${(err as Error).message}\n`,
+      )
+    }
+    process.stderr.write(
+      `telegram gateway: crash-redelivery — delivered recovered answer (${out.length} chars, ` +
+      `${chunks.length} chunk(s)) for turnKey=${turn.turn_key} chat=${chatId}\n`,
+    )
+  } catch (err) {
+    // Send failed — leave the marker UNSTAMPED so a later restart retries rather
+    // than silently dropping the recovered answer.
+    process.stderr.write(
+      `telegram gateway: crash-redelivery send failed turnKey=${turn.turn_key}: ${(err as Error).message} ` +
+      `— left un-stamped for a later retry\n`,
+    )
   }
 }
 
@@ -29868,6 +30046,19 @@ void (async () => {
             `telegram gateway: blocked-approval boot reconcile failed: ${(err as Error).message}\n`,
           )
         }
+
+        // Crash-survival redelivery — LIVE boot send. Now that `bot.api.getMe()`
+        // has resolved (the Telegram client is connected and authenticated), it
+        // is safe to fire the framed recovered-answer send for an interrupted
+        // turn whose finished answer the crash swallowed. Fire-and-forget: it is
+        // self-contained, must not block the rest of one-time setup, and is a
+        // no-op when there is no eligible candidate. See
+        // `maybeRedeliverUndeliveredAnswer` for the ordering guarantee + invariants.
+        void maybeRedeliverUndeliveredAnswer().catch((err) => {
+          process.stderr.write(
+            `telegram gateway: crash-redelivery boot send errored: ${(err as Error).message}\n`,
+          )
+        })
 
         // Boot-time pin sweep
         try {

--- a/telegram-plugin/gateway/redelivery-decision.ts
+++ b/telegram-plugin/gateway/redelivery-decision.ts
@@ -69,6 +69,49 @@ export interface RedeliverDecision {
 }
 
 /**
+ * Whether to CAPTURE an interrupted turn as a redelivery candidate at boot.
+ * This is the mutual-exclusion gate against the resume synthetic — decided
+ * BEFORE any transcript projection, purely from the boot-resume outcome.
+ */
+export interface RedeliverCaptureInput {
+  /**
+   * True iff the boot-resume path will RE-RUN this turn's work in a fresh
+   * session (bootResumeKind === 'resume'). A resumed turn emits a fresh answer
+   * that supersedes any recovered draft, so redelivering as well is a
+   * double-send. Every non-resume outcome (watchdog report, defer-suppressed,
+   * defer-loop, none) does NOT auto-re-answer, so redelivery is the correct and
+   * only recovery send there.
+   */
+  willBeResumed: boolean
+  /**
+   * True iff the interrupted turn has a durably-pinned `session_id`. Without it
+   * we cannot resolve the exact transcript to re-project, so we cannot redeliver.
+   */
+  hasSessionId: boolean
+}
+
+export type RedeliverCaptureSkip = 'will-be-resumed' | 'no-session-id'
+
+export interface RedeliverCaptureDecision {
+  capture: boolean
+  /** Present iff `capture` is false — why we declined to stage redelivery. */
+  skipReason?: RedeliverCaptureSkip
+}
+
+/**
+ * Decide whether to stage an interrupted turn for crash-survival redelivery.
+ * Pure: the mutual-exclusion rule with resume lives here so it is testable
+ * without booting a gateway. `will-be-resumed` takes precedence over the
+ * session-id check because a to-be-resumed turn must never redeliver even if it
+ * has a session_id — the fresh re-answer is the send.
+ */
+export function decideRedeliverCapture(input: RedeliverCaptureInput): RedeliverCaptureDecision {
+  if (input.willBeResumed) return { capture: false, skipReason: 'will-be-resumed' }
+  if (!input.hasSessionId) return { capture: false, skipReason: 'no-session-id' }
+  return { capture: true }
+}
+
+/**
  * Frame a captured draft for redelivery — a short recovered-draft preamble
  * above the model's own words. Pure; exported for the boot wiring + tests.
  */

--- a/telegram-plugin/gateway/redelivery-decision.ts
+++ b/telegram-plugin/gateway/redelivery-decision.ts
@@ -1,0 +1,96 @@
+/**
+ * Crash-survival redelivery — the PURE decision predicate.
+ *
+ * When the gateway process crashes (or the hang-watchdog kills it) BEFORE the
+ * in-memory flush timer fires, the model's completed final answer — captured
+ * only in the in-memory buffer — is lost, and the user gets permanent silence.
+ * The answer text is, however, still durable on disk in the claude session
+ * transcript. On the next boot we can re-project that trailing text and re-send
+ * it. This module owns the "should we re-send, and how" decision so it is
+ * unit-testable without booting a gateway (the boot block only wires I/O to it).
+ *
+ * The delivery oracle is DURABLE TEXT-IDENTITY, not a chat+time window: we
+ * redeliver only if the PROJECTED final-answer text was NOT already delivered
+ * (matched against delivered `messages` rows — see `hasOutboundWithText`). A
+ * time-windowed "any assistant row since started_at" oracle is UNSOUND here:
+ * an interim `progress_update` or a streamed partial chunk lands a mid-turn
+ * `role='assistant'` row and would false-positive "delivered", suppressing a
+ * genuinely-undelivered final answer (the exact MISS this fix exists to close).
+ *
+ * The redelivered text is FRAMED as a recovered/interrupted draft rather than
+ * presented as a clean final answer: the transcript cannot durably distinguish
+ * "final answer complete" from "answer-so-far, more tools intended", so we never
+ * assert it is the finished answer.
+ */
+
+/** The short preamble that frames a redelivered draft. */
+export const REDELIVERY_PREFIX = 'Recovered from an interrupted turn:'
+
+export interface RedeliverDecisionInput {
+  /**
+   * The trailing assistant text re-projected from the interrupted turn's own
+   * transcript (after the last tool_use). Empty string when the transcript had
+   * no trailing text to redeliver.
+   */
+  capturedText: string
+  /**
+   * True when the trailing transcript content AFTER the last tool_use is text
+   * (not a dangling tool_use). Bounds the preamble-vs-final ambiguity (R2): a
+   * turn whose last on-disk event was a tool_use is mid-stream, not a finished
+   * answer, so we do not redeliver it.
+   */
+  trailingIsText: boolean
+  /**
+   * Result of the DURABLE text-identity oracle: true iff the projected answer
+   * text was already delivered to this chat/thread (`hasOutboundWithText`).
+   */
+  hasDeliveredText: boolean
+  /** True iff `answer_redelivered_at` is already stamped (at-most-once ledger). */
+  alreadyRedelivered: boolean
+  /** Age of the interrupted turn in ms (`now - started_at`). */
+  ageMs: number
+  /** Staleness failsafe (`RESUME_MAX_AGE_MS`, default 3h). */
+  maxAgeMs: number
+}
+
+export type RedeliverSkipReason =
+  | 'empty-text'
+  | 'trailing-not-text'
+  | 'already-delivered'
+  | 'already-redelivered'
+  | 'stale'
+
+export interface RedeliverDecision {
+  redeliver: boolean
+  /** Present iff `redeliver` is true — the framed text to send. */
+  framedText?: string
+  /** Present iff `redeliver` is false — why we declined. */
+  skipReason?: RedeliverSkipReason
+}
+
+/**
+ * Frame a captured draft for redelivery — a short recovered-draft preamble
+ * above the model's own words. Pure; exported for the boot wiring + tests.
+ */
+export function frameRedelivery(capturedText: string): string {
+  return `${REDELIVERY_PREFIX}\n\n${capturedText.trim()}`
+}
+
+/**
+ * Decide whether — and with what framed text — to redeliver an interrupted
+ * turn's captured-but-undelivered final answer. Pure: no clock, no I/O.
+ *
+ * Precedence of skip reasons is deliberate (most-specific first): a turn with
+ * no trailing text can never redeliver regardless of delivery/age; a delivered
+ * or already-redelivered answer is skipped before the age failsafe so the
+ * at-most-once guarantee never depends on staleness.
+ */
+export function decideRedeliver(input: RedeliverDecisionInput): RedeliverDecision {
+  const text = input.capturedText.trim()
+  if (text.length === 0) return { redeliver: false, skipReason: 'empty-text' }
+  if (!input.trailingIsText) return { redeliver: false, skipReason: 'trailing-not-text' }
+  if (input.alreadyRedelivered) return { redeliver: false, skipReason: 'already-redelivered' }
+  if (input.hasDeliveredText) return { redeliver: false, skipReason: 'already-delivered' }
+  if (input.ageMs > input.maxAgeMs) return { redeliver: false, skipReason: 'stale' }
+  return { redeliver: true, framedText: frameRedelivery(text) }
+}

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -740,6 +740,81 @@ export function hasOutboundDeliveredSince(
   }
 }
 
+/**
+ * DURABLE text-identity delivery oracle for crash-survival redelivery.
+ *
+ * Returns true iff a substantive outbound (`role='assistant'`) row whose text
+ * matches `text` has been delivered to `chatId` (and optionally `threadId`).
+ * Unlike `hasOutboundDeliveredSince`, this keys on the ANSWER TEXT itself, not
+ * a chat+time window — so an interim `progress_update` ("on it…") or a streamed
+ * partial chunk sent earlier in the same turn does NOT false-positive as "the
+ * final answer was delivered" (the exact MISS bug that would otherwise suppress
+ * a genuinely-undelivered final answer and re-open the permanent-silence hole).
+ *
+ * Matching is on the NORMALIZED first chunk (see `normalizeDeliveryText`): a
+ * multi-chunk answer's chunk-1 is compared against delivered rows so a crash
+ * after chunk-1 is detected as delivered (avoids double-sending chunk-1). Both
+ * sides are normalized identically. Empty/whitespace text never matches.
+ *
+ * Durable (reads committed SQLite), survives restart — unlike the in-memory
+ * `outboundDedup` ring, whose window is destroyed by the crash.
+ *
+ * Falls back to false (safe: never suppresses a needed redelivery) if history
+ * is not initialised or the query fails — the `answer_redelivered_at` marker is
+ * the second guard against a double-send in that degraded case.
+ */
+export function hasOutboundWithText(
+  chatId: string,
+  text: string,
+  threadId?: number | null,
+): boolean {
+  const needle = normalizeDeliveryText(text)
+  if (needle.length === 0) return false
+  try {
+    // Compare on the normalized prefix so trailing-whitespace / spacer
+    // differences between the rendered outbound and the re-projected answer do
+    // not defeat the match. We fetch candidate assistant rows and normalize in
+    // JS (SQLite lacks the same normalize) — bounded by chat/thread scope.
+    const params: unknown[] = [chatId]
+    let sql = "SELECT text FROM messages WHERE chat_id = ? AND role = 'assistant'"
+    if (threadId !== undefined) {
+      if (threadId === null) {
+        sql += ' AND thread_id IS NULL'
+      } else {
+        sql += ' AND thread_id = ?'
+        params.push(threadId)
+      }
+    }
+    // Newest first: a redelivery candidate's match is almost always recent.
+    sql += ' ORDER BY ts DESC LIMIT 500'
+    const rows = requireDb()
+      .prepare(sql)
+      .all(...(params as [unknown, ...unknown[]])) as { text: string | null }[]
+    for (const r of rows) {
+      const hay = normalizeDeliveryText(r.text ?? '')
+      if (hay.length === 0) continue
+      // Match when the delivered row starts with the projected first chunk (or
+      // vice-versa) — a chunk-1 row satisfies a multi-chunk projected answer.
+      if (hay === needle || hay.startsWith(needle) || needle.startsWith(hay)) {
+        return true
+      }
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Normalize outbound text for durable text-identity delivery matching. Collapses
+ * all whitespace runs to single spaces and trims — so paragraph-spacer / render
+ * differences between a stored outbound and a re-projected transcript answer do
+ * not defeat an otherwise-identical match. Pure; shared by the redelivery path.
+ */
+export function normalizeDeliveryText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
 export function query(opts: QueryOptions): RecordedMessage[] {
   const limit = Math.min(MAX_LIMIT, Math.max(1, opts.limit ?? DEFAULT_LIMIT))
   const params: unknown[] = [opts.chat_id]

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -759,6 +759,22 @@ export function hasOutboundDeliveredSince(
  * Durable (reads committed SQLite), survives restart — unlike the in-memory
  * `outboundDedup` ring, whose window is destroyed by the crash.
  *
+ * SCOPING (crash-redelivery diff-review defect #1). Two guards keep a match from
+ * being over-broad and suppressing a genuine redelivery (a MISS = permanent
+ * silence):
+ *   1. `sinceMs` — when provided (the interrupted turn's `started_at`), only
+ *      rows delivered AT/AFTER that instant are considered, so an UNRELATED
+ *      earlier turn's message can never satisfy the match. This is the primary
+ *      scope: a redelivery candidate only cares whether THIS turn's own answer
+ *      already went out.
+ *   2. Short-text exactness — the bidirectional-prefix rule (which lets a
+ *      delivered multi-chunk chunk-1 satisfy a longer projected answer) is only
+ *      applied when the shorter side is at least `MIN_PREFIX_MATCH_CHARS`. For a
+ *      SHORT final answer (e.g. "Done.") a prefix match against a longer row
+ *      ("Done, deploying now.") would false-positive; short texts therefore
+ *      require full normalized EQUALITY. Real answer chunks are far longer than
+ *      the floor, so multi-chunk detection is unaffected.
+ *
  * Falls back to false (safe: never suppresses a needed redelivery) if history
  * is not initialised or the query fails — the `answer_redelivered_at` marker is
  * the second guard against a double-send in that degraded case.
@@ -767,6 +783,7 @@ export function hasOutboundWithText(
   chatId: string,
   text: string,
   threadId?: number | null,
+  sinceMs?: number,
 ): boolean {
   const needle = normalizeDeliveryText(text)
   if (needle.length === 0) return false
@@ -785,6 +802,13 @@ export function hasOutboundWithText(
         params.push(threadId)
       }
     }
+    if (sinceMs != null && Number.isFinite(sinceMs)) {
+      // history `ts` is unix SECONDS (recordOutbound); started_at is wall-clock
+      // ms. Scope out any prior turn's rows so an unrelated earlier message can
+      // never satisfy the match.
+      sql += ' AND ts >= ?'
+      params.push(Math.floor(sinceMs / 1000))
+    }
     // Newest first: a redelivery candidate's match is almost always recent.
     sql += ' ORDER BY ts DESC LIMIT 500'
     const rows = requireDb()
@@ -793,11 +817,7 @@ export function hasOutboundWithText(
     for (const r of rows) {
       const hay = normalizeDeliveryText(r.text ?? '')
       if (hay.length === 0) continue
-      // Match when the delivered row starts with the projected first chunk (or
-      // vice-versa) — a chunk-1 row satisfies a multi-chunk projected answer.
-      if (hay === needle || hay.startsWith(needle) || needle.startsWith(hay)) {
-        return true
-      }
+      if (deliveryTextMatch(hay, needle)) return true
     }
     return false
   } catch {
@@ -813,6 +833,29 @@ export function hasOutboundWithText(
  */
 export function normalizeDeliveryText(text: string): string {
   return text.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Minimum length (of the SHORTER side) at which the bidirectional-prefix rule is
+ * allowed. Below this, a delivery match requires full normalized equality — so a
+ * short final answer can't be falsely suppressed by an unrelated longer row that
+ * merely shares a prefix. Real answer chunks (chunk-1 of a multi-chunk send) are
+ * far longer than this floor, so multi-chunk detection is unaffected.
+ */
+export const MIN_PREFIX_MATCH_CHARS = 40
+
+/**
+ * Text-identity match for the delivery oracle. Exact normalized equality always
+ * matches. The bidirectional-prefix relaxation (which lets a delivered chunk-1
+ * satisfy a longer projected answer, and vice-versa) applies ONLY when the
+ * shorter side is at least `MIN_PREFIX_MATCH_CHARS` — otherwise a short answer
+ * would false-positive against any longer row sharing its prefix. Pure.
+ */
+export function deliveryTextMatch(hay: string, needle: string): boolean {
+  if (hay === needle) return true
+  const shorter = Math.min(hay.length, needle.length)
+  if (shorter < MIN_PREFIX_MATCH_CHARS) return false
+  return hay.startsWith(needle) || needle.startsWith(hay)
 }
 
 export function query(opts: QueryOptions): RecordedMessage[] {

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -120,6 +120,26 @@ export interface Turn {
    * Null for turns that were never resumed.
    */
   resumed_at: number | null
+  /**
+   * The claude session id (the `<sessionId>.jsonl` transcript stem) that
+   * produced this turn's assistant output, stamped DURING the turn as soon as
+   * the first session event is observed (see `stampTurnSessionId`). Crash-
+   * survival redelivery uses this to resolve the EXACT transcript file for an
+   * interrupted turn, instead of `findActiveSessionFile`'s most-recent-mtime
+   * heuristic — which can shadow the new boot session's own transcript. Null
+   * until the turn produces its first session event (or for pre-migration rows).
+   */
+  session_id: string | null
+  /**
+   * Ms epoch at which the interrupted turn's captured-but-undelivered final
+   * answer was re-sent to the user at boot (crash-survival redelivery). This is
+   * the at-most-once ledger for redelivery — first-write-wins via
+   * `WHERE answer_redelivered_at IS NULL` (see `markAnswerRedelivered`). Kept on
+   * a SEPARATE marker from `resumed_at` because the two concerns have different
+   * correctness contracts (resume = at-most-once side-effect replay; redelivery
+   * = at-most-once answer send) and a turn can be both. Null until redelivered.
+   */
+  answer_redelivered_at: number | null
   created_at: number
   updated_at: number
 }
@@ -190,6 +210,15 @@ const PHASE3_MIGRATIONS = [
   `ALTER TABLE turns ADD COLUMN resumed_at INTEGER`,
 ]
 
+// Columns added for crash-survival redelivery. `session_id` pins the exact
+// transcript file for an interrupted turn (so redelivery never resolves the
+// wrong session via a most-recent-file heuristic); `answer_redelivered_at` is
+// the at-most-once redelivery ledger (stamped synchronously with the re-send).
+const PHASE4_MIGRATIONS = [
+  `ALTER TABLE turns ADD COLUMN session_id TEXT`,
+  `ALTER TABLE turns ADD COLUMN answer_redelivered_at INTEGER`,
+]
+
 function applySchema(db: SqliteDatabase): void {
   db.exec('PRAGMA journal_mode = WAL')
   db.exec('PRAGMA synchronous = NORMAL')
@@ -206,7 +235,7 @@ function applySchema(db: SqliteDatabase): void {
   // Run migrations. SQLite doesn't support "ADD COLUMN IF NOT EXISTS", so
   // we swallow the "duplicate column" error to stay idempotent on
   // pre-existing registry.db files.
-  for (const sql of [...PHASE1_MIGRATIONS, ...PHASE2_MIGRATIONS, ...PHASE3_MIGRATIONS]) {
+  for (const sql of [...PHASE1_MIGRATIONS, ...PHASE2_MIGRATIONS, ...PHASE3_MIGRATIONS, ...PHASE4_MIGRATIONS]) {
     try {
       db.exec(sql)
     } catch (err) {
@@ -283,6 +312,8 @@ interface RawTurnRow {
   tool_call_count: number | null
   interrupt_reason: string | null
   resumed_at: number | null
+  session_id: string | null
+  answer_redelivered_at: number | null
   created_at: number
   updated_at: number
 }
@@ -304,6 +335,8 @@ function mapRow(row: RawTurnRow): Turn {
     tool_call_count: row.tool_call_count,
     interrupt_reason: row.interrupt_reason,
     resumed_at: row.resumed_at,
+    session_id: row.session_id ?? null,
+    answer_redelivered_at: row.answer_redelivered_at ?? null,
     created_at: row.created_at,
     updated_at: row.updated_at,
   }
@@ -689,6 +722,61 @@ export function markTurnResumed(
     SET resumed_at = ?,
         updated_at = ?
     WHERE turn_key = ? AND resumed_at IS NULL
+  `).run(now, now, turnKey)
+}
+
+/**
+ * Stamp the claude `session_id` (the `<sessionId>.jsonl` transcript stem) on a
+ * turn the FIRST time it is observed, DURING the turn. First-write-wins via
+ * `WHERE session_id IS NULL` so the hot session-event path can call this on
+ * every event cheaply and idempotently. This must run while the turn is live
+ * (before any crash) so crash-survival redelivery can resolve the exact
+ * transcript file for an interrupted turn — never the most-recent-mtime file,
+ * which a fresh boot session would shadow. No-ops if `turnKey` is not found.
+ */
+export function stampTurnSessionId(
+  db: SqliteDatabase,
+  turnKey: string,
+  sessionId: string,
+  now: number = Date.now(),
+): void {
+  if (!sessionId) return
+  db.prepare(`
+    UPDATE turns
+    SET session_id = ?,
+        updated_at = ?
+    WHERE turn_key = ? AND session_id IS NULL
+  `).run(sessionId, now, turnKey)
+}
+
+/**
+ * Stamp `answer_redelivered_at` on an interrupted turn at the moment its
+ * captured-but-undelivered final answer has been re-sent at boot (crash-
+ * survival redelivery). This is the at-most-once ledger for redelivery: once
+ * stamped, the redelivery decision skips the turn on any later restart.
+ *
+ * Ordering: the caller stamps SYNCHRONOUSLY with the send (immediately after
+ * the send resolves), the same discipline as `markTurnResumed`. A residual
+ * race remains — the window between the Telegram send completing and this row
+ * (plus the send's own `role='assistant'` history row) becoming durable. A
+ * crash landing in that window could re-send on the next boot; the durable
+ * text-identity delivery oracle (matching the projected answer text against
+ * delivered `messages` rows) is what CATCHES that duplicate, so redelivery is
+ * at-most-once modulo detection, never a silent double-send of a fresh answer.
+ *
+ * Idempotent and first-write-wins (`WHERE answer_redelivered_at IS NULL`).
+ * No-ops if `turnKey` is not found.
+ */
+export function markAnswerRedelivered(
+  db: SqliteDatabase,
+  turnKey: string,
+  now: number = Date.now(),
+): void {
+  db.prepare(`
+    UPDATE turns
+    SET answer_redelivered_at = ?,
+        updated_at            = ?
+    WHERE turn_key = ? AND answer_redelivered_at IS NULL
   `).run(now, now, turnKey)
 }
 

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -303,6 +303,59 @@ export function assistantLineCarriesAnswerSurface(
   return false
 }
 
+export interface TrailingAnswer {
+  /** Concatenated trailing assistant text of the last turn (after the last
+   *  tool_use / turn boundary). Empty when there is none to redeliver. */
+  text: string
+  /** True iff the last content-bearing event of the transcript was text — i.e.
+   *  the turn ended on an answer, not a dangling tool_use (mid-stream). Bounds
+   *  the preamble-vs-final ambiguity for crash-survival redelivery. */
+  trailingIsText: boolean
+}
+
+/**
+ * Re-project the TRAILING assistant answer of the last turn from a claude
+ * session transcript's full text. Pure — reuses the same `projectTranscriptLine`
+ * kernel the live tail uses, so it inherits the `isApiErrorMessage` suppression
+ * (a usage-limit error line is NEVER resurfaced as an answer) and the empty-block
+ * drop. Used by crash-survival redelivery to recover the finished-but-never-sent
+ * answer from disk after a pre-flush crash.
+ *
+ * Semantics: walk the event stream in order; the "answer buffer" accumulates
+ * `text` events and is RESET by any `tool_use` (the answer-so-far was a preamble
+ * to a tool call) or by an `enqueue` (a new inbound turn boundary). What remains
+ * at end-of-file is the trailing answer of the last turn. `trailingIsText` is
+ * true only when the final content-bearing event was that text (not a tool_use),
+ * so a turn killed mid-tool never redelivers a stale preamble as an answer.
+ */
+export function projectTrailingAnswerFromTranscript(transcriptText: string): TrailingAnswer {
+  const buf: string[] = []
+  let lastMeaningful: 'text' | 'tool_use' | null = null
+  for (const rawLine of transcriptText.split('\n')) {
+    const line = rawLine.trim()
+    if (!line) continue
+    for (const ev of projectTranscriptLine(line)) {
+      if (ev.kind === 'enqueue') {
+        // New inbound turn — any prior turn's trailing text is not this turn's.
+        buf.length = 0
+        lastMeaningful = null
+      } else if (ev.kind === 'tool_use') {
+        buf.length = 0
+        lastMeaningful = 'tool_use'
+      } else if (ev.kind === 'text') {
+        const t = (ev as { text?: string }).text ?? ''
+        if (t.trim().length > 0) {
+          buf.push(t)
+          lastMeaningful = 'text'
+        }
+      }
+      // thinking / model / dequeue / tool_result etc. do not affect the answer.
+    }
+  }
+  const text = buf.join('').trim()
+  return { text, trailingIsText: lastMeaningful === 'text' && text.length > 0 }
+}
+
 /**
  * Project a single transcript line into a SessionEvent (or null if it's
  * uninteresting noise). Caller is responsible for the JSON parse — if a

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -323,10 +323,18 @@ export interface TrailingAnswer {
  *
  * Semantics: walk the event stream in order; the "answer buffer" accumulates
  * `text` events and is RESET by any `tool_use` (the answer-so-far was a preamble
- * to a tool call) or by an `enqueue` (a new inbound turn boundary). What remains
- * at end-of-file is the trailing answer of the last turn. `trailingIsText` is
- * true only when the final content-bearing event was that text (not a tool_use),
- * so a turn killed mid-tool never redelivers a stale preamble as an answer.
+ * to a tool call) or by a turn boundary. What remains at end-of-file is the
+ * trailing answer of the last turn. `trailingIsText` is true only when the final
+ * content-bearing event was that text (not a tool_use), so a turn killed mid-tool
+ * never redelivers a stale preamble as an answer.
+ *
+ * TURN BOUNDARY (diff-review defect #2). A boundary is BOTH an `enqueue`
+ * queue-operation AND a real `type:"user"` message line. The kernel
+ * (`projectTranscriptLine`) emits nothing for a plain user text line — it only
+ * projects `tool_result` blocks out of `type:"user"` — so relying on `enqueue`
+ * alone would let two turns separated by a plain user line (no intervening
+ * tool_use) CONCATENATE. `isRealUserTurnBoundary` detects that separator
+ * directly so only the LAST turn's trailing text is projected.
  */
 export function projectTrailingAnswerFromTranscript(transcriptText: string): TrailingAnswer {
   const buf: string[] = []
@@ -334,6 +342,12 @@ export function projectTrailingAnswerFromTranscript(transcriptText: string): Tra
   for (const rawLine of transcriptText.split('\n')) {
     const line = rawLine.trim()
     if (!line) continue
+    if (isRealUserTurnBoundary(line)) {
+      // A real user message opens a new turn — discard any prior turn's tail.
+      buf.length = 0
+      lastMeaningful = null
+      continue
+    }
     for (const ev of projectTranscriptLine(line)) {
       if (ev.kind === 'enqueue') {
         // New inbound turn — any prior turn's trailing text is not this turn's.
@@ -354,6 +368,41 @@ export function projectTrailingAnswerFromTranscript(transcriptText: string): Tra
   }
   const text = buf.join('').trim()
   return { text, trailingIsText: lastMeaningful === 'text' && text.length > 0 }
+}
+
+/**
+ * Detect a real inbound-user turn separator in a claude session JSONL.
+ *
+ * A `type:"user"` line is EITHER a genuine user message (its `message.content`
+ * is a string, or an array carrying a `{type:"text"}` block) OR a tool_result
+ * carrier (`message.content` is an array of `{type:"tool_result"}` blocks only).
+ * Only the former opens a new turn. The main projection kernel emits NO event
+ * for a genuine user text line (it projects tool_result blocks only), so the
+ * trailing-answer projector needs this to break turns that are separated by a
+ * plain user line rather than an interleaved `enqueue` queue-operation. Pure.
+ */
+export function isRealUserTurnBoundary(line: string): boolean {
+  let obj: Record<string, unknown>
+  try {
+    obj = JSON.parse(line)
+  } catch {
+    return false
+  }
+  if (obj.type !== 'user') return false
+  const message = obj.message as Record<string, unknown> | undefined
+  const content = message?.content
+  if (typeof content === 'string') return content.trim().length > 0
+  if (Array.isArray(content)) {
+    // A genuine user message carries a text block; a tool_result carrier does
+    // not. Presence of any text block ⇒ real user turn.
+    for (const c of content) {
+      if (typeof c === 'object' && c != null && (c as Record<string, unknown>).type === 'text') {
+        const t = String((c as Record<string, unknown>).text ?? '')
+        if (t.trim().length > 0) return true
+      }
+    }
+  }
+  return false
 }
 
 /**

--- a/telegram-plugin/tests/crash-redelivery-resume-exclusion.test.ts
+++ b/telegram-plugin/tests/crash-redelivery-resume-exclusion.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { decideRedeliverCapture } from '../gateway/redelivery-decision.js'
+import {
+  decideBootResumeKind,
+  RESUME_SYNTHETIC_PROMPT_PREFIX,
+} from '../gateway/resume-inbound-builder.js'
+import type { Turn, TurnEndedVia } from '../registry/turns-schema.js'
+
+/**
+ * Pins the MUTUAL EXCLUSION between crash-survival redelivery and the resume
+ * synthetic — the double-send guard. The gateway boot block composes exactly
+ * these two pure predicates: `decideBootResumeKind` classifies the interrupted
+ * turn, then `decideRedeliverCapture({ willBeResumed: kind === 'resume', ... })`
+ * decides whether to ALSO stage a redelivery.
+ *
+ * The load-bearing outcome: an interrupted turn that WILL be resumed (the model
+ * re-runs and emits a fresh answer) must NOT also redeliver its recovered draft
+ * — otherwise the same answer reaches the user twice. Conversely, a turn that
+ * will NOT be resumed (watchdog report, boot_resume:never suppression,
+ * resume-of-a-resume loop-guard) MUST redeliver, because nothing else re-answers.
+ *
+ * This mirrors the gateway wiring exactly, so it asserts the real composed
+ * outcome, not an isolated code path.
+ */
+
+const RESUME_MAX_AGE_MS = 10_800_000 // 3h, gateway default
+
+function makeTurn(over: Partial<Turn> = {}): Turn {
+  return {
+    turn_key: '900001:_#7',
+    chat_id: '900001',
+    thread_id: null,
+    started_at: Date.now() - 60_000, // 1 min ago — well within maxAge
+    ended_at: null,
+    ended_via: null,
+    last_assistant_msg_id: null,
+    last_assistant_done: null,
+    last_user_msg_id: null,
+    user_prompt_preview: 'deploy the staging stack',
+    assistant_reply_preview: null,
+    tool_call_count: 2,
+    interrupt_reason: null,
+    resumed_at: null,
+    session_id: 'sess-abcd', // durably pinned → redelivery is eligible on the floor
+    ...over,
+  } as Turn
+}
+
+/** Compose the two predicates exactly as the gateway boot block does. */
+function composeGate(turn: Turn, suppressed: boolean) {
+  const bootResumeKind = decideBootResumeKind({
+    pending: turn,
+    suppressed,
+    ageMs: Math.max(0, Date.now() - turn.started_at),
+    maxAgeMs: RESUME_MAX_AGE_MS,
+  })
+  const capture = decideRedeliverCapture({
+    willBeResumed: bootResumeKind === 'resume',
+    hasSessionId: Boolean(turn.session_id),
+  })
+  return { bootResumeKind, capture }
+}
+
+describe('crash-redelivery ↔ resume mutual exclusion (no double-send)', () => {
+  it('(a) an interrupted turn that WILL be resumed does NOT also redeliver', () => {
+    // ended_via 'restart' → decideBootResumeKind returns 'resume': the model
+    // re-runs and emits a fresh answer that supersedes any recovered draft.
+    const turn = makeTurn({ ended_via: 'restart' as TurnEndedVia })
+    const { bootResumeKind, capture } = composeGate(turn, /* suppressed */ false)
+    expect(bootResumeKind).toBe('resume')
+    expect(capture.capture).toBe(false)
+    expect(capture.skipReason).toBe('will-be-resumed')
+  })
+
+  it('(a2) a still-open (ended_via=null) killed-mid-flight turn is resumed, not redelivered', () => {
+    const turn = makeTurn({ ended_via: null })
+    const { bootResumeKind, capture } = composeGate(turn, false)
+    expect(bootResumeKind).toBe('resume')
+    expect(capture.capture).toBe(false)
+  })
+
+  it('(b) a watchdog-timeout turn (report, no auto re-answer) DOES redeliver', () => {
+    // ended_via 'timeout' → 'report': the synthetic only ASKS the user whether
+    // to retry — it does not auto-re-answer. Redelivery is the correct recovery.
+    const turn = makeTurn({ ended_via: 'timeout' as TurnEndedVia })
+    const { bootResumeKind, capture } = composeGate(turn, false)
+    expect(bootResumeKind).toBe('report')
+    expect(capture.capture).toBe(true)
+    expect(capture.skipReason).toBeUndefined()
+  })
+
+  it('(b2) a boot_resume:never-suppressed turn (defer-suppressed) DOES redeliver', () => {
+    // suppressed=true → 'defer-suppressed': no synthetic re-run, so redelivery
+    // is the ONLY recovery send.
+    const turn = makeTurn({ ended_via: 'restart' as TurnEndedVia })
+    const { bootResumeKind, capture } = composeGate(turn, /* suppressed */ true)
+    expect(bootResumeKind).toBe('defer-suppressed')
+    expect(capture.capture).toBe(true)
+  })
+
+  it('(b3) a resume-of-a-resume (loop-guard → defer-loop) turn DOES redeliver', () => {
+    // A turn whose prompt is itself a resume synthetic → 'defer-loop': the chain
+    // is capped, no re-run happens, so redelivery must still recover the answer.
+    const turn = makeTurn({
+      ended_via: 'restart' as TurnEndedVia,
+      user_prompt_preview: `${RESUME_SYNTHETIC_PROMPT_PREFIX} Continue the interrupted deploy.`,
+    })
+    const { bootResumeKind, capture } = composeGate(turn, false)
+    expect(bootResumeKind).toBe('defer-loop')
+    expect(capture.capture).toBe(true)
+  })
+
+  it('(b4) a STALE resume downgraded to report DOES redeliver (not suppressed)', () => {
+    // A 'restart' turn older than maxAge downgrades resume→report in
+    // selectResumeBuilder. Because the final kind is 'report' (no re-run),
+    // redelivery must fire — the gate keys on the FINAL kind, not the raw
+    // ended_via.
+    const turn = makeTurn({
+      ended_via: 'restart' as TurnEndedVia,
+      started_at: Date.now() - (RESUME_MAX_AGE_MS + 60_000),
+    })
+    const { bootResumeKind, capture } = composeGate(turn, false)
+    expect(bootResumeKind).toBe('report')
+    expect(capture.capture).toBe(true)
+  })
+
+  it('eligibility floor still applies: no session_id → no redelivery even when not resumed', () => {
+    const turn = makeTurn({ ended_via: 'timeout' as TurnEndedVia, session_id: null })
+    const { capture } = composeGate(turn, false)
+    expect(capture.capture).toBe(false)
+    expect(capture.skipReason).toBe('no-session-id')
+  })
+})

--- a/telegram-plugin/tests/crash-redelivery-wiring.test.ts
+++ b/telegram-plugin/tests/crash-redelivery-wiring.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { projectTrailingAnswerFromTranscript } from '../session-tail.js'
+import { decideRedeliver, REDELIVERY_PREFIX } from '../gateway/redelivery-decision.js'
+
+/**
+ * Pins the crash-survival redelivery WIRING GLUE — the composition
+ * `maybeRedeliverUndeliveredAnswer` performs in the boot send: project the
+ * interrupted turn's trailing answer from its transcript, then feed
+ * (`text`, `trailingIsText`) plus the durable oracle result into
+ * `decideRedeliver`. The oracle (`hasOutboundWithText`) and the projector are
+ * unit-tested in their own suites (history.test.ts / trailing-answer-projector
+ * .test.ts); this asserts the two ends plumb together — the projected answer is
+ * what gets framed, and a dangling mid-tool turn is refused before any send.
+ *
+ * The raw Telegram socket send and the post-`getMe()` connect sequencing are NOT
+ * unit-testable here (they require a connected grammy client); the ordering
+ * guarantee is documented on `maybeRedeliverUndeliveredAnswer` and enforced by
+ * its single call site inside the `didOneTimeSetup` block, which is unreachable
+ * until `bot.api.getMe()` resolves.
+ */
+
+const FINAL_ANSWER = 'The deploy finished — all three services are green and healthy.'
+
+function compose(transcript: string, hasDeliveredText: boolean) {
+  const projected = projectTrailingAnswerFromTranscript(transcript)
+  return decideRedeliver({
+    capturedText: projected.text,
+    trailingIsText: projected.trailingIsText,
+    hasDeliveredText,
+    alreadyRedelivered: false,
+    ageMs: 60_000,
+    maxAgeMs: 10_800_000,
+  })
+}
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj)
+}
+const completedTurn = [
+  line({ type: 'user', message: { role: 'user', content: 'deploy status?' } }),
+  line({ type: 'assistant', message: { content: [{ type: 'text', text: 'Checking.' }] } }),
+  line({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', id: 'toolu_x', input: {} }] } }),
+  line({ type: 'assistant', message: { content: [{ type: 'text', text: FINAL_ANSWER }] } }),
+].join('\n')
+const danglingToolTurn = [
+  line({ type: 'user', message: { role: 'user', content: 'run the migration' } }),
+  line({ type: 'assistant', message: { content: [{ type: 'text', text: 'On it.' }] } }),
+  line({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', id: 'toolu_y', input: {} }] } }),
+].join('\n')
+
+describe('crash-redelivery wiring glue (project → decide)', () => {
+  it('frames the PROJECTED trailing answer when the oracle says it was not delivered', () => {
+    const d = compose(completedTurn, /* hasDeliveredText */ false)
+    expect(d.redeliver).toBe(true)
+    expect(d.framedText?.startsWith(REDELIVERY_PREFIX)).toBe(true)
+    expect(d.framedText).toContain(FINAL_ANSWER)
+  })
+
+  it('skips when the oracle reports the projected answer was already delivered', () => {
+    expect(compose(completedTurn, /* hasDeliveredText */ true).skipReason).toBe('already-delivered')
+  })
+
+  it('refuses a turn killed mid-tool before any send', () => {
+    // The projector RESETS the buffer on the trailing tool_use, so the recovered
+    // text is empty AND trailingIsText is false — either guard refuses. The
+    // decision reports 'empty-text' (checked first); the load-bearing property is
+    // simply that no send happens for a dangling mid-tool turn.
+    const d = compose(danglingToolTurn, false)
+    expect(d.redeliver).toBe(false)
+    expect(d.skipReason).toBe('empty-text')
+  })
+})

--- a/telegram-plugin/tests/history.test.ts
+++ b/telegram-plugin/tests/history.test.ts
@@ -14,6 +14,8 @@ import {
   getRecentOutboundCount,
   getLatestInboundMessageId,
   hasOutboundDeliveredSince,
+  hasOutboundWithText,
+  normalizeDeliveryText,
   _resetForTests,
 } from '../history.js'
 
@@ -870,5 +872,64 @@ describe('forwarded-message origin columns', () => {
     expect(stored).not.toContain(GH_PAT)
     expect(stored).toContain('[REDACTED')
     expect(stored).toContain('Bob') // surrounding name preserved
+  })
+})
+
+// ---------------------------------------------------------------------------
+// hasOutboundWithText — durable text-identity delivery oracle (crash-survival
+// redelivery). Keys on the ANSWER TEXT, not a chat+time window, so an interim
+// progress_update earlier in the same turn does NOT false-positive "delivered".
+// ---------------------------------------------------------------------------
+
+describe('hasOutboundWithText (durable text-identity oracle)', () => {
+  it('does NOT match an interim progress message against the (undelivered) final answer', () => {
+    initHistory(stateDir, 30)
+    // The turn sent only an interim progress_update; the real final answer was
+    // lost in the crash and never recorded. The time-windowed oracle would say
+    // "delivered" off the progress row — the text-identity oracle must not.
+    recordOutbound({
+      chat_id: '1', thread_id: null, message_ids: [10],
+      texts: ['on it — pulling yesterday’s GitHub activity'], ts: 200,
+    })
+    const finalAnswer = 'The deploy finished — all three services are green.'
+    expect(hasOutboundWithText('1', finalAnswer, null)).toBe(false)
+    // sanity: the coarse time-window oracle DOES false-positive here (this is
+    // exactly why we cannot use it as the redelivery gate).
+    expect(hasOutboundDeliveredSince('1', 100 * 1000, null, 1)).toBe(true)
+  })
+
+  it('matches when the final answer text was actually delivered', () => {
+    initHistory(stateDir, 30)
+    const finalAnswer = 'The deploy finished — all three services are green.'
+    recordOutbound({ chat_id: '1', thread_id: null, message_ids: [11], texts: [finalAnswer], ts: 300 })
+    expect(hasOutboundWithText('1', finalAnswer, null)).toBe(true)
+  })
+
+  it('matches a delivered chunk-1 against a longer projected answer (multi-chunk, no double-send)', () => {
+    initHistory(stateDir, 30)
+    const chunk1 = 'Part one of a long answer that was split across chunks.'
+    recordOutbound({ chat_id: '1', thread_id: null, message_ids: [12], texts: [chunk1], ts: 300 })
+    // The re-projected full answer starts with chunk-1 → treated as delivered.
+    expect(hasOutboundWithText('1', chunk1 + ' Part two continues here.', null)).toBe(true)
+  })
+
+  it('ignores whitespace/spacer differences via normalization', () => {
+    initHistory(stateDir, 30)
+    recordOutbound({ chat_id: '1', thread_id: null, message_ids: [13], texts: ['hello   world'], ts: 300 })
+    expect(hasOutboundWithText('1', 'hello world', null)).toBe(true)
+    expect(normalizeDeliveryText('hello   world')).toBe('hello world')
+  })
+
+  it('empty/whitespace text never matches', () => {
+    initHistory(stateDir, 30)
+    recordOutbound({ chat_id: '1', thread_id: null, message_ids: [14], texts: ['real'], ts: 300 })
+    expect(hasOutboundWithText('1', '   ', null)).toBe(false)
+  })
+
+  it('scopes by chat (a different chat does not satisfy the match)', () => {
+    initHistory(stateDir, 30)
+    recordOutbound({ chat_id: '1', thread_id: null, message_ids: [15], texts: ['scoped answer'], ts: 300 })
+    expect(hasOutboundWithText('2', 'scoped answer', null)).toBe(false)
+    expect(hasOutboundWithText('1', 'scoped answer', null)).toBe(true)
   })
 })

--- a/telegram-plugin/tests/history.test.ts
+++ b/telegram-plugin/tests/history.test.ts
@@ -932,4 +932,34 @@ describe('hasOutboundWithText (durable text-identity oracle)', () => {
     expect(hasOutboundWithText('2', 'scoped answer', null)).toBe(false)
     expect(hasOutboundWithText('1', 'scoped answer', null)).toBe(true)
   })
+
+  // diff-review defect #1 — a SHORT final answer must not false-positive-match an
+  // unrelated earlier row via the bidirectional-prefix rule (that would suppress a
+  // genuine redelivery = permanent silence). Short texts require full equality.
+  it('does NOT suppress a short answer that merely shares a prefix with an unrelated row', () => {
+    initHistory(stateDir, 30)
+    // An earlier turn delivered a longer line that starts with the short answer.
+    recordOutbound({ chat_id: '1', thread_id: null, message_ids: [20], texts: ['Done, deploying now.'], ts: 300 })
+    // The interrupted turn's real final answer was the short "Done." — never sent.
+    expect(hasOutboundWithText('1', 'Done.', null)).toBe(false)
+  })
+
+  it('still suppresses a short answer that was genuinely delivered (exact match)', () => {
+    initHistory(stateDir, 30)
+    recordOutbound({ chat_id: '1', thread_id: null, message_ids: [21], texts: ['Done.'], ts: 300 })
+    expect(hasOutboundWithText('1', 'Done.', null)).toBe(true)
+  })
+
+  // sinceMs scope: only rows delivered at/after the interrupted turn's started_at
+  // count, so an unrelated PRIOR turn's identical text can never suppress.
+  it('scopes by sinceMs (a prior-turn row before the floor does not match)', () => {
+    initHistory(stateDir, 30)
+    // Prior turn delivered this exact text at ts=200s.
+    recordOutbound({ chat_id: '1', thread_id: null, message_ids: [22], texts: ['repeated answer'], ts: 200 })
+    // Interrupted turn started at 250s (250_000 ms) — the prior row is out of scope.
+    expect(hasOutboundWithText('1', 'repeated answer', null, 250_000)).toBe(false)
+    // A row delivered within the turn window (ts=300s) does match.
+    recordOutbound({ chat_id: '1', thread_id: null, message_ids: [23], texts: ['repeated answer'], ts: 300 })
+    expect(hasOutboundWithText('1', 'repeated answer', null, 250_000)).toBe(true)
+  })
 })

--- a/telegram-plugin/tests/redelivery-decision.test.ts
+++ b/telegram-plugin/tests/redelivery-decision.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decideRedeliver,
+  frameRedelivery,
+  REDELIVERY_PREFIX,
+  type RedeliverDecisionInput,
+} from '../gateway/redelivery-decision.js'
+
+/**
+ * Pins the crash-survival redelivery decision predicate. The load-bearing
+ * property is the DURABLE TEXT-IDENTITY oracle: an interim `progress_update`
+ * earlier in the same turn must NOT suppress a genuinely-undelivered final
+ * answer (the exact MISS = permanent-silence bug this fix closes), while an
+ * already-delivered final answer MUST be suppressed.
+ */
+
+const base: RedeliverDecisionInput = {
+  capturedText: 'The deploy finished — all three services are green.',
+  trailingIsText: true,
+  hasDeliveredText: false,
+  alreadyRedelivered: false,
+  ageMs: 60_000,
+  maxAgeMs: 10_800_000, // 3h
+}
+
+describe('decideRedeliver — text-identity oracle', () => {
+  it('REDELIVERS an undelivered final answer even when an interim message was sent (the MISS bug)', () => {
+    // The MISS scenario: a progress_update landed a role=assistant row earlier
+    // in the turn, so a chat+time-window oracle would say "delivered" and skip.
+    // The text-identity oracle keys on the ANSWER text — which was never sent —
+    // so hasDeliveredText is false and redelivery fires.
+    const d = decideRedeliver({ ...base, hasDeliveredText: false })
+    expect(d.redeliver).toBe(true)
+    expect(d.framedText).toContain(base.capturedText)
+    expect(d.framedText?.startsWith(REDELIVERY_PREFIX)).toBe(true)
+  })
+
+  it('SUPPRESSES when the final answer text was already delivered', () => {
+    const d = decideRedeliver({ ...base, hasDeliveredText: true })
+    expect(d.redeliver).toBe(false)
+    expect(d.skipReason).toBe('already-delivered')
+  })
+})
+
+describe('decideRedeliver — other skip reasons', () => {
+  it('skips empty / whitespace text', () => {
+    expect(decideRedeliver({ ...base, capturedText: '   ' }).skipReason).toBe('empty-text')
+  })
+
+  it('skips when trailing content is a dangling tool_use (mid-stream, not an answer)', () => {
+    expect(decideRedeliver({ ...base, trailingIsText: false }).skipReason).toBe('trailing-not-text')
+  })
+
+  it('skips an already-redelivered turn (at-most-once ledger)', () => {
+    expect(decideRedeliver({ ...base, alreadyRedelivered: true }).skipReason).toBe('already-redelivered')
+  })
+
+  it('skips a stale turn beyond maxAgeMs', () => {
+    expect(decideRedeliver({ ...base, ageMs: 4 * 3_600_000 }).skipReason).toBe('stale')
+  })
+
+  it('precedence: empty-text wins over delivered/redelivered/stale', () => {
+    const d = decideRedeliver({
+      ...base,
+      capturedText: '',
+      hasDeliveredText: true,
+      alreadyRedelivered: true,
+      ageMs: 999_999_999,
+    })
+    expect(d.skipReason).toBe('empty-text')
+  })
+
+  it('precedence: already-redelivered is checked before the age failsafe', () => {
+    const d = decideRedeliver({ ...base, alreadyRedelivered: true, ageMs: 999_999_999 })
+    expect(d.skipReason).toBe('already-redelivered')
+  })
+})
+
+describe('frameRedelivery', () => {
+  it('frames as a recovered draft, never a clean final answer', () => {
+    const framed = frameRedelivery('  hello world  ')
+    expect(framed).toBe(`${REDELIVERY_PREFIX}\n\nhello world`)
+  })
+})

--- a/telegram-plugin/tests/registry-turns.test.ts
+++ b/telegram-plugin/tests/registry-turns.test.ts
@@ -20,6 +20,8 @@ import {
   markOrphanedWithTimeoutClassification,
   findLatestTurnIfInterrupted,
   markTurnResumed,
+  markAnswerRedelivered,
+  stampTurnSessionId,
   getTurnByKey,
 } from '../registry/turns-schema.js'
 
@@ -571,6 +573,55 @@ describe('markTurnResumed', () => {
   it('no-ops for an unknown turn_key', () => {
     const db = openTurnsDbInMemory()
     expect(() => markTurnResumed(db, 'nope:1')).not.toThrow()
+    db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stampTurnSessionId + markAnswerRedelivered — crash-survival redelivery
+// ---------------------------------------------------------------------------
+
+describe('stampTurnSessionId', () => {
+  it('pins the session id on the turn (first-write-wins) and defaults null', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'sx:1', chatId: 'sx' })
+    expect(getTurnByKey(db, 'sx:1')!.session_id).toBeNull()
+    stampTurnSessionId(db, 'sx:1', 'sess-abc')
+    expect(getTurnByKey(db, 'sx:1')!.session_id).toBe('sess-abc')
+    // first-write-wins: a later different session id does not overwrite
+    stampTurnSessionId(db, 'sx:1', 'sess-def')
+    expect(getTurnByKey(db, 'sx:1')!.session_id).toBe('sess-abc')
+    db.close()
+  })
+
+  it('ignores an empty session id and no-ops on unknown key', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'sx:2', chatId: 'sx' })
+    stampTurnSessionId(db, 'sx:2', '')
+    expect(getTurnByKey(db, 'sx:2')!.session_id).toBeNull()
+    expect(() => stampTurnSessionId(db, 'nope', 'x')).not.toThrow()
+    db.close()
+  })
+})
+
+describe('markAnswerRedelivered', () => {
+  it('stamps answer_redelivered_at (first-write-wins) on a SEPARATE marker from resumed_at', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'rd:1', chatId: 'rd' })
+    recordTurnEnd(db, { turnKey: 'rd:1', endedVia: 'restart' })
+    expect(getTurnByKey(db, 'rd:1')!.answer_redelivered_at).toBeNull()
+    markAnswerRedelivered(db, 'rd:1', 1_700_000_000_000)
+    expect(getTurnByKey(db, 'rd:1')!.answer_redelivered_at).toBe(1_700_000_000_000)
+    // does not touch resumed_at — the two ledgers are independent
+    expect(getTurnByKey(db, 'rd:1')!.resumed_at).toBeNull()
+    markAnswerRedelivered(db, 'rd:1', 1_800_000_000_000)
+    expect(getTurnByKey(db, 'rd:1')!.answer_redelivered_at).toBe(1_700_000_000_000)
+    db.close()
+  })
+
+  it('no-ops for an unknown turn_key', () => {
+    const db = openTurnsDbInMemory()
+    expect(() => markAnswerRedelivered(db, 'nope:1')).not.toThrow()
     db.close()
   })
 })

--- a/telegram-plugin/tests/trailing-answer-projector.test.ts
+++ b/telegram-plugin/tests/trailing-answer-projector.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { projectTrailingAnswerFromTranscript } from '../session-tail.js'
+
+/**
+ * Pins the crash-survival redelivery transcript projector: recovering the
+ * finished-but-never-sent trailing answer from a session JSONL after a
+ * pre-flush crash, and refusing to redeliver a dangling mid-tool preamble.
+ */
+
+function assistantText(text: string): string {
+  return JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } })
+}
+function assistantToolUse(name: string): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', name, id: 'toolu_x', input: {} }] },
+  })
+}
+function enqueue(text: string): string {
+  return JSON.stringify({ type: 'queue-operation', operation: 'enqueue', content: text })
+}
+
+describe('projectTrailingAnswerFromTranscript', () => {
+  it('recovers the trailing answer text after the last tool_use', () => {
+    const transcript = [
+      enqueue('what is the deploy status?'),
+      assistantText('Let me check.'),
+      assistantToolUse('Bash'),
+      assistantText('The deploy finished — all three services are green.'),
+    ].join('\n')
+    const r = projectTrailingAnswerFromTranscript(transcript)
+    expect(r.trailingIsText).toBe(true)
+    expect(r.text).toBe('The deploy finished — all three services are green.')
+  })
+
+  it('does NOT treat a dangling tool_use as a redeliverable answer', () => {
+    const transcript = [
+      enqueue('run the migration'),
+      assistantText('On it — running the migration now.'),
+      assistantToolUse('Bash'),
+    ].join('\n')
+    const r = projectTrailingAnswerFromTranscript(transcript)
+    expect(r.trailingIsText).toBe(false)
+    // the preamble was reset by the tool_use; nothing trailing to send
+    expect(r.text).toBe('')
+  })
+
+  it('scopes to the LAST turn only (a prior turn answer is not resurfaced)', () => {
+    const transcript = [
+      enqueue('first question'),
+      assistantText('First answer.'),
+      enqueue('second question'),
+      assistantText('Second answer.'),
+    ].join('\n')
+    const r = projectTrailingAnswerFromTranscript(transcript)
+    expect(r.text).toBe('Second answer.')
+  })
+
+  it('suppresses an isApiErrorMessage synthetic line (never redeliver an error string)', () => {
+    const transcript = [
+      enqueue('do the thing'),
+      JSON.stringify({
+        type: 'assistant',
+        isApiErrorMessage: true,
+        message: { content: [{ type: 'text', text: "You've hit your limit · resets 5pm" }] },
+      }),
+    ].join('\n')
+    const r = projectTrailingAnswerFromTranscript(transcript)
+    expect(r.text).toBe('')
+    expect(r.trailingIsText).toBe(false)
+  })
+
+  it('concatenates multiple trailing text blocks of the final answer', () => {
+    const transcript = [
+      enqueue('q'),
+      assistantToolUse('Read'),
+      assistantText('Part one. '),
+      assistantText('Part two.'),
+    ].join('\n')
+    const r = projectTrailingAnswerFromTranscript(transcript)
+    expect(r.text).toBe('Part one. Part two.')
+    expect(r.trailingIsText).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/trailing-answer-projector.test.ts
+++ b/telegram-plugin/tests/trailing-answer-projector.test.ts
@@ -19,6 +19,18 @@ function assistantToolUse(name: string): string {
 function enqueue(text: string): string {
   return JSON.stringify({ type: 'queue-operation', operation: 'enqueue', content: text })
 }
+/** A real inbound user message line (string content) — a turn separator the
+ *  projection kernel emits NO event for, unlike an `enqueue`. */
+function userMessage(text: string): string {
+  return JSON.stringify({ type: 'user', message: { role: 'user', content: text } })
+}
+/** A tool_result carrier user line — NOT a turn boundary. */
+function toolResult(toolUseId: string): string {
+  return JSON.stringify({
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUseId, content: 'ok' }] },
+  })
+}
 
 describe('projectTrailingAnswerFromTranscript', () => {
   it('recovers the trailing answer text after the last tool_use', () => {
@@ -68,6 +80,34 @@ describe('projectTrailingAnswerFromTranscript', () => {
     const r = projectTrailingAnswerFromTranscript(transcript)
     expect(r.text).toBe('')
     expect(r.trailingIsText).toBe(false)
+  })
+
+  // diff-review defect #2 — a real claude .jsonl separates turns with a plain
+  // `type:"user"` message line the kernel ignores, NOT always an interleaved
+  // enqueue queue-operation. Two turns with no intervening tool_use must not
+  // concatenate; only the LAST turn's trailing text is projected.
+  it('breaks turns on a plain user-message separator (no enqueue, no tool_use)', () => {
+    const transcript = [
+      userMessage('first question'),
+      assistantText('First answer.'),
+      userMessage('second question'),
+      assistantText('Second answer.'),
+    ].join('\n')
+    const r = projectTrailingAnswerFromTranscript(transcript)
+    expect(r.text).toBe('Second answer.')
+    expect(r.trailingIsText).toBe(true)
+  })
+
+  it('does NOT treat a tool_result user line as a turn boundary (answer still accretes)', () => {
+    const transcript = [
+      userMessage('do the thing'),
+      assistantToolUse('Bash'),
+      toolResult('toolu_x'),
+      assistantText('All done — the thing is done.'),
+    ].join('\n')
+    const r = projectTrailingAnswerFromTranscript(transcript)
+    expect(r.text).toBe('All done — the thing is done.')
+    expect(r.trailingIsText).toBe(true)
   })
 
   it('concatenates multiple trailing text blocks of the final answer', () => {


### PR DESCRIPTION
Ships two fixes together (Ken approved shipping both, including the previously-deferred live boot send).

## Fix 1 — crash-survival redelivery, now LIVE
When the gateway crashes / the hang-watchdog kills a turn BEFORE the in-memory flush timer fires, the model's finished answer (only in the in-memory buffer) was lost = permanent silence. The answer is still durable in the claude session transcript on disk. On the next boot we now re-project that trailing answer and re-send it, framed as a recovered draft. Deterministic, zero model tokens.

Prior commits `7c7bc266` (foundation) + `013f1423` (Fix 2) landed the durable/pure layer but the redelivery was **inert** — no boot-block ever re-sent. This PR closes the two diff-review BLOCKERS and wires the live send:

- **Oracle scope (BLOCKER #1)** — `hasOutboundWithText` was bidirectional-prefix over the 500 newest rows with no turn scoping, so a SHORT final answer could false-positive-match an unrelated earlier row → re-opened the MISS. Now scoped by `sinceMs` (the turn's `started_at`) AND short texts require full normalized equality (`MIN_PREFIX_MATCH_CHARS`), with prefix-relaxation reserved for real multi-chunk chunk-1 rows.
- **Turn boundary (BLOCKER #2)** — `projectTrailingAnswerFromTranscript` reset only on `enqueue` events; a real `.jsonl` separates turns with plain `type:"user"` lines the kernel ignores → two turns could concatenate. Now breaks on `isRealUserTurnBoundary` too.
- **Live wiring** — the boot-resume block captures the interrupted turn (eligible only with a durably-pinned `session_id`, so the EXACT transcript is resolved). `maybeRedeliverUndeliveredAnswer` fires from the `didOneTimeSetup` block AFTER `bot.api.getMe()` resolves — the raw send is sequenced after the Telegram client is connected, never during module init. It projects, runs the durable oracle, sends the framed text via the same retry-wrapped rich-send path replies use, records the outbound row (self-idempotent), then stamps `answer_redelivered_at` synchronously.

Honors: at-most-once per interruption, RESUME_MAX_AGE_MS (3h) staleness, zero tokens, isApiErrorMessage suppression, trailing-TEXT-only.

Independence note: the resume synthetic is committed during module init (pre-connect) while redelivery runs post-connect, so redelivery does not suppress the resume synthetic — sequencing that would need a larger startup refactor, out of scope here.

## Fix 2 — silent-no-op detector windowing (already reviewed GO, `013f1423`)
Fixed floor `SILENT_NOOP_FLOOR_TS = 1_783_900_800` (2026-07-13Z), param-injected, scoped to the silent-no-op branch only.

## Tests (scoped, local)
- `vitest run` redelivery-decision / trailing-answer-projector / crash-redelivery-wiring / fleet-health detect — 33 passed
- `bun test` history / registry-turns / turns-schema — 122 passed
- `npm run lint` (tsc --noEmit + 8 guards) — clean

CI runs the full suite. Do NOT merge — a final adversarial review of the wiring diff precedes merge-on-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)