### PR TITLE
Make /model TUI scrape deterministic (poll-until-signal + optimistic record)

### DIFF
--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -617,6 +617,113 @@ describe("injectSlashCommandWith — outcomes", () => {
   });
 });
 
+// ─── #3241 poll-until-signal capture ───────────────────────────────────────
+
+/**
+ * A runner whose capture() walks a scripted list of pane snapshots (one per
+ * poll), holding on the last entry once exhausted — so a test can model the
+ * async banner rendering BEFORE claude's confirmation line lands.
+ */
+function makeScriptedRunner(snapshots: string[]): TmuxRunner & { sent: string[][] } {
+  let i = 0;
+  const sent: string[][] = [];
+  return {
+    hasSession: () => true,
+    capture: () => {
+      const v = snapshots[Math.min(i, snapshots.length - 1)] ?? "";
+      i += 1;
+      return v;
+    },
+    send: (_s, _n, args) => sent.push(args),
+    sent,
+  };
+}
+
+describe("injectSlashCommandWith — #3241 poll-until-signal", () => {
+  const BEFORE = "❯ \n";
+  const ECHO = "❯ /model fable";
+  const BANNER = "⠋ extending Claude Fable 5 access…";
+  const CONFIRM = "⎿  Set model to Fable 5 for this session";
+  const ERRLINE = "⎿  Model 'claude-bogus-99' not found";
+  const successPattern = /^\s*[⏺●•>⎿-]?\s*(?:Set model to|Switched to|Kept model as)\b/i;
+  const errorPattern =
+    /^\s*[⏺●•>⎿-]?\s*(?:Error:\s*)?(?:Model(?:\s+'[^']+')?\s+not found|Invalid model|Unknown model|No such model)\b/i;
+
+  it("captures the confirmation that lands on poll N+2 AFTER a banner on poll N (not the banner)", async () => {
+    // before → (banner) → (banner) → (banner+confirmation). A fixed settle break
+    // on the first change would have captured the banner; poll-until-signal waits
+    // for the success line.
+    const runner = makeScriptedRunner([
+      BEFORE,
+      `${ECHO}\n${BANNER}\n`,
+      `${ECHO}\n${BANNER}\n`,
+      `${ECHO}\n${BANNER}\n${CONFIRM}\n`,
+    ]);
+    const r = await injectSlashCommandWith(runner, {
+      socket: "s", session: "x", command: "/model fable",
+      settleMs: 50, timeoutMs: 2000, successPattern, errorPattern,
+    });
+    expect(r.outcome).toBe("ok");
+    expect(r.output).toContain("Set model to Fable 5");
+  });
+
+  it("breaks early on a scraped error line (outcome carries the error, not a banner)", async () => {
+    const runner = makeScriptedRunner([
+      BEFORE,
+      `${ECHO}\n${BANNER}\n`,
+      `${ECHO}\n${ERRLINE}\n`,
+      `${ECHO}\n${ERRLINE}\n`,
+    ]);
+    const r = await injectSlashCommandWith(runner, {
+      socket: "s", session: "x", command: "/model claude-bogus-99",
+      settleMs: 50, timeoutMs: 2000, successPattern, errorPattern,
+    });
+    expect(r.outcome).toBe("ok");
+    expect(r.output).toContain("not found");
+  });
+
+  it("WITHOUT a successPattern the legacy settle break captures the banner (the bug this fixes)", async () => {
+    // Same script, no pattern → legacy path breaks at settleMs on the first
+    // change and captures the banner, never reaching the confirmation. This
+    // pins the behavioural difference the opt-in param introduces.
+    const runner = makeScriptedRunner([
+      BEFORE,
+      `${ECHO}\n${BANNER}\n`,
+      `${ECHO}\n${BANNER}\n`,
+      `${ECHO}\n${BANNER}\n${CONFIRM}\n`,
+    ]);
+    const r = await injectSlashCommandWith(runner, {
+      socket: "s", session: "x", command: "/model fable",
+      settleMs: 20, timeoutMs: 2000,
+    });
+    expect(r.output).toContain("extending Claude Fable 5 access");
+    expect(r.output).not.toContain("Set model to Fable 5");
+  });
+
+  it("settleBeforeSendMs waits for a still pane before typing (symptom 2 clean-prompt guard)", async () => {
+    // Pane is animating (distinct captures) then settles; keys must be sent only
+    // after two equal captures. We assert the send happened (not skipped) and the
+    // confirmation is still captured afterwards.
+    const runner = makeScriptedRunner([
+      "animating-1\n",
+      "animating-2\n",
+      "❯ \n",       // settle loop: consecutive equal idle frames → break
+      "❯ \n",
+      "❯ \n",       // `before` capture (idle) + first signal poll
+      "❯ \n",
+      `${ECHO}\n${CONFIRM}\n`, // confirmation lands after send
+    ]);
+    const r = await injectSlashCommandWith(runner, {
+      socket: "s", session: "x", command: "/model fable",
+      settleMs: 50, timeoutMs: 2000, successPattern, errorPattern,
+      settleBeforeSendMs: 500,
+    });
+    expect(runner.sent).toContainEqual(["send-keys", "-l", "/model fable"]);
+    expect(runner.sent).toContainEqual(["send-keys", "Enter"]);
+    expect(r.output).toContain("Set model to Fable 5");
+  });
+});
+
 describe("injectSlashCommand (default runner — validation only)", () => {
   it("rejects blocked commands before touching tmux", async () => {
     await expect(injectSlashCommand("any", "/login")).rejects.toMatchObject({

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -263,6 +263,29 @@ export interface InjectOpts {
    * Callers that omit it get identical behaviour to before (never checked).
    */
   precondition?: () => boolean;
+  /**
+   * Opt-in poll-until-signal capture (#3241). When EITHER `successPattern` or
+   * `errorPattern` is supplied the capture loop switches from the fixed
+   * settle-window heuristic to a deterministic wait: it keeps polling the
+   * NEW (diffed) pane region until a line matches `errorPattern` (stop early,
+   * a scraped failure) or `successPattern` (stop early, confirmation landed),
+   * or `timeoutMs` elapses. This makes the `/model` confirmation scrape immune
+   * to Anthropic's async multi-line access banners that render inside the
+   * `/model` region AFTER the pane first changes — the old loop broke at
+   * `settleMs` on that first change and captured the banner, missing the
+   * later "Set model to …" line. When NEITHER is supplied the loop is
+   * byte-identical to the pre-#3241 behaviour (gated strictly on these params).
+   */
+  successPattern?: RegExp;
+  errorPattern?: RegExp;
+  /**
+   * Opt-in clean-prompt precondition (#3241, symptom 2). When > 0, poll the
+   * pane BEFORE typing and wait until two consecutive captures match (the pane
+   * stopped animating) or this bound elapses. Guards against keys landing in a
+   * still-rendering pane, where claude swallows them and no-ops ("Kept model as
+   * …"). Omitted / 0 → no pre-send wait (unchanged for every other caller).
+   */
+  settleBeforeSendMs?: number;
 }
 
 /**
@@ -597,7 +620,11 @@ export async function injectSlashCommand(
   const socket = opts.socketName ?? defaultSocketName(agentName);
   const session = opts.sessionName ?? agentName;
   const settleMs = opts.settleMs ?? 2000;
-  const timeoutMs = opts.timeoutMs ?? 5000;
+  // Poll-until-signal callers get a raised default ceiling (#3241): the async
+  // access banner can push claude's confirmation line a few hundred ms past the
+  // old 5s window. Non-signal callers keep the historical 5s default.
+  const signalMode = !!(opts.successPattern || opts.errorPattern);
+  const timeoutMs = opts.timeoutMs ?? (signalMode ? 8000 : 5000);
 
   // Serialize against every other drive on this pane (other injects,
   // the /model picker driver) — see src/agents/pane-lock.ts. An
@@ -611,6 +638,9 @@ export async function injectSlashCommand(
       settleMs,
       timeoutMs,
       precondition: opts.precondition,
+      successPattern: opts.successPattern,
+      errorPattern: opts.errorPattern,
+      settleBeforeSendMs: opts.settleBeforeSendMs,
     }),
   );
 }
@@ -633,9 +663,22 @@ export async function injectSlashCommandWith(
     settleMs: number;
     timeoutMs: number;
     precondition?: () => boolean;
+    successPattern?: RegExp;
+    errorPattern?: RegExp;
+    settleBeforeSendMs?: number;
   },
 ): Promise<InjectResult> {
-  const { socket, session, command, settleMs, timeoutMs, precondition } = args;
+  const {
+    socket,
+    session,
+    command,
+    settleMs,
+    timeoutMs,
+    precondition,
+    successPattern,
+    errorPattern,
+    settleBeforeSendMs,
+  } = args;
 
   // Re-validate so the seam itself enforces the contract. The bare
   // verb is what we'll surface in `result.command` / lookup metadata.
@@ -693,6 +736,21 @@ export async function injectSlashCommandWith(
     };
   }
 
+  // #3241 symptom 2 — opt-in clean-prompt precondition. Wait for the pane to
+  // stop animating before typing so the first keystroke doesn't land in a
+  // still-rendering pane (which claude swallows → silent "Kept model as …"
+  // no-op). Poll until two consecutive captures match or the bound elapses.
+  if (settleBeforeSendMs && settleBeforeSendMs > 0) {
+    const settleStart = Date.now();
+    let prevSettle = runner.capture(socket, session) ?? "";
+    while (Date.now() - settleStart < settleBeforeSendMs) {
+      await sleep(POLL_INTERVAL_MS);
+      const cur = runner.capture(socket, session) ?? "";
+      if (cur === prevSettle) break;
+      prevSettle = cur;
+    }
+  }
+
   const before = runner.capture(socket, session) ?? "";
 
   // Two-step send-keys: literal command body (so `/` survives without
@@ -720,9 +778,27 @@ export async function injectSlashCommandWith(
   const start = Date.now();
   let last = before;
   let stableSince: number | null = null;
+  const signalMode = !!(successPattern || errorPattern);
   while (Date.now() - start < timeoutMs) {
     await sleep(POLL_INTERVAL_MS);
     const cur = runner.capture(socket, session) ?? "";
+    if (signalMode) {
+      // #3241 poll-until-signal: ignore the settle heuristic entirely and keep
+      // polling until the NEW (diffed) region carries a success/error line, or
+      // the hard timeout fires. This survives async banners that render inside
+      // the region AFTER the first pane change (the old settle break captured
+      // the banner and missed the later confirmation line).
+      last = cur;
+      if (cur !== before) {
+        const { output: region } = diffPane(before, cur, command);
+        const regionLines = region.split("\n").map((l) => l.trim());
+        // Error wins over success when both somehow match — an explicit failure
+        // line must never be reported as a switch.
+        if (errorPattern && regionLines.some((l) => errorPattern.test(l))) break;
+        if (successPattern && regionLines.some((l) => successPattern.test(l))) break;
+      }
+      continue;
+    }
     if (cur === last && cur !== before) {
       if (stableSince === null) {
         stableSince = Date.now();

--- a/src/agents/model-picker.ts
+++ b/src/agents/model-picker.ts
@@ -274,6 +274,23 @@ async function openPickerWithRetry(io: Io): Promise<ParsedModelPicker | null> {
   // where the picker should be. Esc it and re-open once against the settled pane
   // before giving up to the caller's static fallback. dismissPicker is Esc +
   // verify; its return is advisory here.
+  //
+  // #3242 review LOW 3 — ASSUMPTION: dismissPicker's Escape actually returned the
+  // pane to a clean prompt. If BOTH Esc rounds failed (a genuinely stuck modal —
+  // the /rate-limit-options wedge class), the re-open below types `/model` + Enter
+  // into a still-open picker, where the keystrokes act as its filter and Enter
+  // could select an arbitrary row. We accept this residual risk rather than add a
+  // second hard guard because it is caught downstream and never silently wrong:
+  //   - if the re-open still can't parse a footer-complete modal, the caller
+  //     returns ok:false ("picker did not render") and falls back to the static
+  //     list — no wrong selection is surfaced;
+  //   - the caller's own `dismissOrWarn` runs in its finally and LOUDLY logs a
+  //     may-still-be-open pane for wedge forensics (+ dismissFailed:true).
+  // The stuck-modal wedge is pre-existing (any open-picker driver that sends
+  // `/model` + Enter faces it); this one-shot retry only reaches the second open
+  // AFTER two Esc rounds already ran, so it does not meaningfully widen the
+  // window. A stuck modal is the rare exception, surfaced (dismissFailed + log)
+  // not swallowed.
   await dismissPicker(io);
   if (expired(io)) return parsed;
   return openPicker(io);

--- a/src/agents/model-picker.ts
+++ b/src/agents/model-picker.ts
@@ -152,7 +152,9 @@ export interface PickerOpts {
   sessionName?: string;
   /** Per-step settle wait (ms). Default 600. */
   stepMs?: number;
-  /** Hard ceiling on the whole operation (ms). Default 10000. */
+  /** Hard ceiling on the whole operation (ms). Default 12000 (#3241 — raised
+   *  from 10000 to leave room for one dismiss-and-retry when an async access
+   *  banner pushes the picker footer out of the first render window). */
   timeoutMs?: number;
   /** Test seam — injected runner + sleep + logger. */
   _runner?: TmuxRunner;
@@ -193,7 +195,7 @@ function makeIo(agentName: string, opts: PickerOpts): Io {
     socket: opts.socketName ?? `switchroom-${agentName}`,
     session: opts.sessionName ?? agentName,
     stepMs: opts.stepMs ?? 600,
-    timeoutMs: opts.timeoutMs ?? 10_000,
+    timeoutMs: opts.timeoutMs ?? 12_000,
     sleep: opts._sleep ?? realSleep,
     log: opts._log ?? ((line) => process.stderr.write(`${line}\n`)),
     startedAt: Date.now(),
@@ -229,20 +231,52 @@ function sendKey(io: Io, key: string): void {
   io.runner.send(io.socket, io.session, ["send-keys", key]);
 }
 
-/** Open the picker and poll until it parses with a rendered footer. */
-async function openPicker(io: Io): Promise<ParsedModelPicker | null> {
+/**
+ * Open the picker and poll until it parses with a rendered footer. Bounded by
+ * `deadlineMs` (absolute epoch ms) when supplied — used by
+ * {@link openPickerWithRetry} to reserve budget for a second attempt — else by
+ * the overall operation timeout.
+ */
+async function openPicker(io: Io, deadlineMs?: number): Promise<ParsedModelPicker | null> {
   sendLiteral(io, "/model");
   sendKey(io, "Enter");
   // Poll for the fully-rendered modal (footer visible). The picker
   // typically renders in well under a second; the loop is bounded by
-  // the overall timeout.
+  // the per-attempt deadline (if any) and the overall timeout.
   for (;;) {
     await io.sleep(io.stepMs);
     const pane = io.runner.capture(io.socket, io.session) ?? "";
     const parsed = parseModelPicker(pane);
     if (parsed?.footerSeen) return parsed;
-    if (expired(io)) return parsed; // best parse we got (may be null)
+    if ((deadlineMs != null && Date.now() >= deadlineMs) || expired(io)) {
+      return parsed; // best parse we got (may be null)
+    }
   }
+}
+
+/**
+ * Open the picker, and if the first render doesn't produce a footer-complete
+ * modal, dismiss any half-rendered interstitial with Escape and retry ONCE
+ * (#3241 symptom 3). Anthropic's async "extending Claude … access" banner can
+ * render inside the `/model` region and push the "Esc to cancel" footer out of
+ * the initial poll window; the retry re-opens against a settled pane. Bounded
+ * by the same overall timeout — the retry is skipped once the budget is spent.
+ */
+async function openPickerWithRetry(io: Io): Promise<ParsedModelPicker | null> {
+  // Reserve budget for a second attempt: the first open gets HALF the remaining
+  // time (floored at a couple of poll steps) so a dismiss-and-retry has room.
+  const remaining = io.timeoutMs - (Date.now() - io.startedAt);
+  const firstDeadline = Date.now() + Math.max(io.stepMs * 2, Math.floor(remaining / 2));
+  const parsed = await openPicker(io, firstDeadline);
+  if (parsed?.footerSeen) return parsed;
+  if (expired(io)) return parsed;
+  // A non-picker interstitial (async access banner / transient render) is sitting
+  // where the picker should be. Esc it and re-open once against the settled pane
+  // before giving up to the caller's static fallback. dismissPicker is Esc +
+  // verify; its return is advisory here.
+  await dismissPicker(io);
+  if (expired(io)) return parsed;
+  return openPicker(io);
 }
 
 /**
@@ -292,7 +326,7 @@ export async function discoverModels(
     let parsed: ParsedModelPicker | null = null;
     let dismissed = true;
     try {
-      parsed = await openPicker(io);
+      parsed = await openPickerWithRetry(io);
     } finally {
       dismissed = await dismissOrWarn(io, "discover");
     }
@@ -329,7 +363,7 @@ export async function selectModel(
     io.startedAt = Date.now(); // budget starts when the lock is held
     let selected = false;
     try {
-      const parsed = await openPicker(io);
+      const parsed = await openPickerWithRetry(io);
       if (!parsed || !parsed.footerSeen) {
         return { ok: false, reason: "picker did not render — agent may be mid-turn" };
       }

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -24,7 +24,7 @@
  * unit-testable without booting the bot.
  */
 
-import type { InjectResult } from '../../src/agents/inject.js'
+import type { InjectResult, InjectOpts } from '../../src/agents/inject.js'
 import {
   labelTag,
   type DiscoverResult,
@@ -185,8 +185,17 @@ export function modelCommandReceiptLine(
 }
 
 export interface ModelCommandDeps {
-  /** Inject primitive — wired to injectSlashCommand in the gateway. */
-  inject: (agent: string, command: string) => Promise<InjectResult>
+  /**
+   * Inject primitive — wired to injectSlashCommand in the gateway. The optional
+   * third argument forwards the #3241 poll-until-signal opts (successPattern /
+   * errorPattern / settleBeforeSendMs); the set path passes them so the `/model`
+   * confirmation scrape is deterministic instead of racing a fixed window.
+   */
+  inject: (
+    agent: string,
+    command: string,
+    opts?: Pick<InjectOpts, 'successPattern' | 'errorPattern' | 'settleBeforeSendMs'>,
+  ) => Promise<InjectResult>
   /**
    * True while the agent is mid-turn. A typed `/model <name>` switch drives
    * claude's session (either an inject into the input box, or a carrier-backed
@@ -248,6 +257,17 @@ export interface ModelCommandReply {
    * lies to `/status`.
    */
   selectedModel?: string
+  /**
+   * True when `selectedModel` was recorded OPTIMISTICALLY (#3241 part B): the
+   * inject SEND succeeded and NO explicit error line was scraped, but claude's
+   * confirmation line was not read either. Poll-until-signal already waited the
+   * full window, so a missing line means a silent switch (or a confirmation
+   * that scrolled off) — NOT a failure — and we record the requested model so
+   * `/status` is right. The switch is retracted (no `selectedModel`) only when
+   * an error line IS scraped. Purely a wording hint; the gateway records
+   * `selectedModel` the same way whether confirmed or optimistic.
+   */
+  optimistic?: boolean
 }
 
 const PERSIST_NOTE =
@@ -379,7 +399,18 @@ export async function handleModelCommand(
   const verbHtml = `\`/model ${deps.escapeHtml(model)}\``
   let result: InjectResult
   try {
-    result = await deps.inject(deps.getAgentName(), `/model ${model}`)
+    // #3241 part A — poll-until-signal. Hand the inject primitive the exact
+    // confirmation / error line shapes so its capture loop keeps polling until
+    // claude's "Set model to …" (or an error) actually lands, instead of
+    // breaking at a fixed settle window on the first pane change (which the
+    // async access banner tripped, capturing the banner and missing the
+    // confirmation). settleBeforeSendMs waits for a clean prompt so the keys
+    // aren't typed into a still-animating pane (symptom 2's silent no-op).
+    result = await deps.inject(deps.getAgentName(), `/model ${model}`, {
+      successPattern: MODEL_SWITCH_CONFIRMATION_PREFIX,
+      errorPattern: MODEL_SWITCH_ERROR_RE,
+      settleBeforeSendMs: 1500,
+    })
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     return {
@@ -388,21 +419,25 @@ export async function handleModelCommand(
     }
   }
 
-  if (result.outcome === 'ok') {
-    // claude's `/model <name>` either prints a "Set model to X" acknowledgement
-    // or switches SILENTLY (no line). `result.output` on the silent path is just
-    // whatever pane scrollback sat below the command echo (the agent's previous
-    // prose answer) — NOT a confirmation. We MUST NOT claim success on that
-    // scrollback, and we must never dump it back as a code block (screenshot-
+  if (result.outcome === 'ok' || result.outcome === 'ok_no_output') {
+    // claude's `/model <name>` prints a "Set model to X" acknowledgement, an
+    // error line ("Model not found"), a "Kept model as X" no-op, or (rarely)
+    // switches with the confirmation scrolled off. `result.output` on a silent
+    // path is just pane scrollback (the agent's previous prose) — NEVER a
+    // confirmation, and it must not be dumped back as a code block (screenshot-
     // confirmed leak on klanker, v0.16.47).
     //
-    // Honest reporting: (1) if claude printed an error ("Model not found" /
-    // "Invalid model"), the switch FAILED — say so. (2) if an anchored
-    // confirmation line is present, the switch is verified — relay it and record
-    // the live model for /status. (3) otherwise we cannot positively verify the
-    // switch (silent success or nothing) — say "sent, but couldn't confirm" and
-    // record NOTHING, so /status is never lied to.
-    const errLine = modelSwitchErrorLine(result.output)
+    // Honest reporting (#3241 part B inverts the old "record nothing unless
+    // confirmed" to "record optimistically, retract only on a scraped error"):
+    //   (1) error line scraped → switch FAILED. Report it; record NOTHING
+    //       (the retract — /status keeps the prior model).
+    //   (2) "Kept model as X" → genuine no-op; report it, record NOTHING.
+    //   (3) confirmation line present → verified switch; relay it and record
+    //       the live model for /status.
+    //   (4) no line either way → poll-until-signal already waited the full
+    //       window, so this is a SILENT success, not a failure. Record the
+    //       requested model OPTIMISTICALLY so /status is right, and say so.
+    const errLine = result.outcome === 'ok' ? modelSwitchErrorLine(result.output) : null
     if (errLine) {
       return {
         text: [
@@ -413,8 +448,20 @@ export async function handleModelCommand(
         html: true,
       }
     }
-    const confirmation = modelSwitchConfirmationLine(result.output)
+    const confirmation = result.outcome === 'ok' ? modelSwitchConfirmationLine(result.output) : null
     if (confirmation) {
+      if (isKeptModelConfirmation(confirmation)) {
+        // "Kept model as X" — nothing changed. Relay it, record no override.
+        return {
+          text: [
+            `${verbHtml}`,
+            deps.preBlock(confirmation),
+            ...(result.truncated ? ['_truncated_'] : []),
+            PERSIST_NOTE,
+          ].join('\n'),
+          html: true,
+        }
+      }
       const confirmed = sessionModelFromConfirmation(confirmation) ?? model
       return {
         text: [
@@ -424,27 +471,18 @@ export async function handleModelCommand(
           PERSIST_NOTE,
         ].join('\n'),
         html: true,
-        // Only record when the confirmation carries a real switch (Set/Switched);
-        // a "Kept model as" line means no change — don't overwrite the override.
-        ...(isKeptModelConfirmation(confirmation) ? {} : { selectedModel: confirmed }),
+        selectedModel: confirmed,
       }
     }
+    // No confirmation and no error — optimistic record (#3241 part B).
     return {
       text: [
-        `${verbHtml} — sent, but couldn't confirm the switch — check \`/status\`.`,
+        `${verbHtml} — sent. Recorded \`${deps.escapeHtml(model)}\` as the live model, but couldn't read claude's confirmation line — check \`/status\`.`,
         PERSIST_NOTE,
       ].join('\n'),
       html: true,
-    }
-  }
-
-  if (result.outcome === 'ok_no_output') {
-    return {
-      text: [
-        `${verbHtml} — sent, but no response captured. The agent may be mid-turn; check \`/inject /status\` to confirm the active model.`,
-        PERSIST_NOTE,
-      ].join('\n'),
-      html: true,
+      selectedModel: model,
+      optimistic: true,
     }
   }
 
@@ -973,7 +1011,14 @@ export async function handleModelMenuCallback(
     }
     let aliasResult: InjectResult
     try {
-      aliasResult = await deps.inject(deps.getAgentName(), `/model ${alias}`)
+      // #3241 part A — same poll-until-signal + clean-prompt opts as the typed
+      // set path so the alias (e.g. Fable) confirmation scrape is deterministic
+      // and immune to the async access banner.
+      aliasResult = await deps.inject(deps.getAgentName(), `/model ${alias}`, {
+        successPattern: MODEL_SWITCH_CONFIRMATION_PREFIX,
+        errorPattern: MODEL_SWITCH_ERROR_RE,
+        settleBeforeSendMs: 1500,
+      })
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       return {

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -428,26 +428,20 @@ export async function handleModelCommand(
     // confirmed leak on klanker, v0.16.47).
     //
     // Honest reporting (#3241 part B inverts the old "record nothing unless
-    // confirmed" to "record optimistically, retract only on a scraped error"):
-    //   (1) error line scraped → switch FAILED. Report it; record NOTHING
-    //       (the retract — /status keeps the prior model).
-    //   (2) "Kept model as X" → genuine no-op; report it, record NOTHING.
-    //   (3) confirmation line present → verified switch; relay it and record
-    //       the live model for /status.
+    // confirmed" to "record optimistically, retract only on a scraped error").
+    // Order matters (#3242 review MEDIUM 1): check the CONFIRMATION line FIRST —
+    // a genuine switch always prints one, so it can never be flipped to a failure
+    // by a stray availability/denial word (the widened MODEL_SWITCH_ERROR_RE) in
+    // the same region. Then:
+    //   (1) "Kept model as X" → genuine no-op; report it, record NOTHING.
+    //   (2) other confirmation → verified switch; relay it, record the display
+    //       name for /status.
+    //   (3) error/denial line scraped (bad id OR access denial) → switch FAILED.
+    //       Report it; record NOTHING (the retract — /status keeps the prior model).
     //   (4) no line either way → poll-until-signal already waited the full
     //       window, so this is a SILENT success, not a failure. Record the
-    //       requested model OPTIMISTICALLY so /status is right, and say so.
-    const errLine = result.outcome === 'ok' ? modelSwitchErrorLine(result.output) : null
-    if (errLine) {
-      return {
-        text: [
-          `❌ ${verbHtml} — the switch did not take:`,
-          deps.preBlock(errLine),
-          'Check \`/model\` for valid model names.',
-        ].join('\n'),
-        html: true,
-      }
-    }
+    //       requested model OPTIMISTICALLY (normalized to display form) so
+    //       /status is right, and say so.
     const confirmation = result.outcome === 'ok' ? modelSwitchConfirmationLine(result.output) : null
     if (confirmation) {
       if (isKeptModelConfirmation(confirmation)) {
@@ -474,14 +468,26 @@ export async function handleModelCommand(
         selectedModel: confirmed,
       }
     }
+    const errLine = result.outcome === 'ok' ? modelSwitchErrorLine(result.output) : null
+    if (errLine) {
+      return {
+        text: [
+          `❌ ${verbHtml} — the switch did not take:`,
+          deps.preBlock(errLine),
+          'Check \`/model\` for a valid, available model.',
+        ].join('\n'),
+        html: true,
+      }
+    }
     // No confirmation and no error — optimistic record (#3241 part B).
+    const optimisticLabel = optimisticModelRecordLabel(model)
     return {
       text: [
-        `${verbHtml} — sent. Recorded \`${deps.escapeHtml(model)}\` as the live model, but couldn't read claude's confirmation line — check \`/status\`.`,
+        `${verbHtml} — sent. Recorded \`${deps.escapeHtml(optimisticLabel)}\` as the live model, but couldn't read claude's confirmation line — check \`/status\`.`,
         PERSIST_NOTE,
       ].join('\n'),
       html: true,
-      selectedModel: model,
+      selectedModel: optimisticLabel,
       optimistic: true,
     }
   }
@@ -653,6 +659,25 @@ export function expandSrAlias(arg: string): string {
 
 export function srFriendlyLabel(srName: string): string {
   return SR_MODEL_LABELS[srName] ?? srName.replace(/^sr-/, '').replace(/-/g, ' ')
+}
+
+/**
+ * #3242 review LOW 4 — display normalization for the OPTIMISTIC `/status` record.
+ * The confirmed path records the display name claude printed (e.g. "Fable 5" via
+ * `sessionModelFromConfirmation`); the optimistic path only has the requested
+ * arg. Without a confirmation we can't know the version suffix, so we normalize
+ * the token to the same DISPLAY style (a friendly label, not a raw token) so
+ * `/status` reads consistently regardless of which path fired: sr-* → its
+ * friendly label, a bare Claude alias → Title-case ("fable" → "Fable"), and a
+ * full `claude-*` id or anything else is left as-is (already canonical).
+ */
+export function optimisticModelRecordLabel(token: string): string {
+  if (isSrModel(token)) return srFriendlyLabel(token)
+  const lower = token.toLowerCase()
+  if ((MODEL_ALIASES as readonly string[]).includes(lower)) {
+    return lower.charAt(0).toUpperCase() + lower.slice(1)
+  }
+  return token
 }
 
 /**
@@ -1026,20 +1051,53 @@ export async function handleModelMenuCallback(
         reply: await menuWithBanner(deps, `❌ Switch to **${deps.escapeHtml(alias)}** failed: ${deps.escapeHtml(msg)}`),
       }
     }
-    if (aliasResult.outcome === 'ok') {
-      // Anchored confirmation only — a loose /set model|switched/ match false-
-      // positives on ordinary scrollback prose ("I switched the deploy…").
-      const confirmation =
-        modelSwitchConfirmationLine(aliasResult.output) ?? `Switched to ${alias} (session)`
-      // "Kept model as X" means no change — don't overwrite the override.
-      const kept = isKeptModelConfirmation(confirmation)
+    // #3242 review MEDIUM 2 — the alias BUTTON (the primary Fable UI, the exact
+    // async-banner scenario) must be symmetric with the typed set path: handle
+    // BOTH `ok` and `ok_no_output` with record-on-send / retract-on-scraped-error.
+    // Previously `ok_no_output` fell through to "Switch failed — agent may be
+    // mid-turn" and dropped the override, so a silent successful button-switch
+    // was reported as a failure while the identical typed command recorded.
+    if (aliasResult.outcome === 'ok' || aliasResult.outcome === 'ok_no_output') {
+      // Confirmation first (a genuine switch always prints one) so a stray
+      // availability/denial word can't flip it to a failure.
+      const confirmation = aliasResult.outcome === 'ok'
+        ? modelSwitchConfirmationLine(aliasResult.output)
+        : null
+      if (confirmation) {
+        // "Kept model as X" means no change — don't overwrite the override.
+        const kept = isKeptModelConfirmation(confirmation)
+        return {
+          answer: confirmation,
+          reply: await menuWithBannerStatic(deps, `✅ ${deps.escapeHtml(confirmation)}`),
+          ...(kept ? {} : {
+            selectedModel: sessionModelFromConfirmation(confirmation) ?? optimisticModelRecordLabel(alias),
+            selectedModelToken: alias,
+          }),
+        }
+      }
+      // Scraped error/denial (bad id OR access denial) → genuine failure, record
+      // nothing (retract).
+      const aliasErr = aliasResult.outcome === 'ok' ? modelSwitchErrorLine(aliasResult.output) : null
+      if (aliasErr) {
+        return {
+          answer: 'Switch failed',
+          reply: await menuWithBanner(
+            deps,
+            `❌ Switch to **${deps.escapeHtml(alias)}** did not take: ${deps.escapeHtml(aliasErr)}`,
+          ),
+        }
+      }
+      // Silent success (no confirmation, no error) → optimistic record, same as
+      // the typed path.
+      const optimisticLabel = optimisticModelRecordLabel(alias)
       return {
-        answer: confirmation,
-        reply: await menuWithBannerStatic(deps, `✅ ${deps.escapeHtml(confirmation)}`),
-        ...(kept ? {} : {
-          selectedModel: sessionModelFromConfirmation(confirmation) ?? alias,
-          selectedModelToken: alias,
-        }),
+        answer: `Switched to ${optimisticLabel} (session)`,
+        reply: await menuWithBannerStatic(
+          deps,
+          `✅ Switched to **${deps.escapeHtml(optimisticLabel)}** (session) — couldn’t read a confirmation line; check \`/status\`.`,
+        ),
+        selectedModel: optimisticLabel,
+        selectedModelToken: alias,
       }
     }
     return {
@@ -1230,9 +1288,25 @@ export function modelSwitchConfirmationLine(output: string): string | null {
  * 2026-07-10): `/model claude-bogus-99` prints
  * `⎿  Model 'claude-bogus-99' not found` — glyph prefix `⎿`, quoted model
  * name between "Model" and "not found". Both shapes are covered.
+ *
+ * #3242 review MEDIUM 1 — ACCESS/ENTITLEMENT DENIAL. A bad-id shape is not the
+ * only failure: `/model fable` on a plan that lacks it prints an availability /
+ * access-denial line ("Fable is not available on your plan", "access denied",
+ * "requires a subscription", "not enabled for your account", "no access to …").
+ * Those match neither the bad-id shapes nor the confirmation prefix, so the poll
+ * loop would expire and the optimistic branch would falsely record the switch —
+ * exactly the Fable-entitlement case this PR is about. The second alternation
+ * group covers those phrasings. It allows up to four leading words (a model
+ * name + a linking adverb etc.) BEFORE the denial phrase — unlike the bad-id
+ * branches, which keep
+ * their original tight line-start anchoring so ordinary scrollback that merely
+ * says "model not found" mid-sentence still can't false-fail a silent switch.
+ * The handler checks the confirmation line FIRST (below), so a genuine switch —
+ * which always prints a confirmation — is never flipped to a failure by a stray
+ * availability word in the same region.
  */
 const MODEL_SWITCH_ERROR_RE =
-  /^\s*[⏺●•>⎿-]?\s*(?:Error:\s*)?(?:Model(?:\s+'[^']+')?\s+not found|Invalid model|Unknown model|No such model)\b/i
+  /^\s*[⏺●•>⎿-]?\s*(?:Error:\s*)?(?:Model(?:\s+'[^']+')?\s+not found|Invalid model|Unknown model|No such model|(?:[\w'’.\-]+\s+){0,4}(?:(?:is |are )?(?:not available|unavailable|not enabled|not supported)|access denied|requires\b[^\n]{0,40}\b(?:subscription|plan)|no access)\b)/i
 
 /** The single capture line that reads as a claude model-switch error, or null. */
 export function modelSwitchErrorLine(output: string): string | null {

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -479,11 +479,16 @@ export async function handleModelCommand(
         html: true,
       }
     }
-    // No confirmation and no error — optimistic record (#3241 part B).
+    // No confirmation and no error — optimistic record (#3241 part B). The
+    // Telegram copy stays PROVISIONAL (#3242 review FIX 2): we couldn't read a
+    // confirmation, and if the CLI denied the switch with wording our error
+    // regex misses, an affirmative "recorded X" would be a lie that never
+    // self-corrects. `/status` DOES self-heal (the override is reclaimed by the
+    // next transcript line), so point the user there rather than assert success.
     const optimisticLabel = optimisticModelRecordLabel(model)
     return {
       text: [
-        `${verbHtml} — sent. Recorded \`${deps.escapeHtml(optimisticLabel)}\` as the live model, but couldn't read claude's confirmation line — check \`/status\`.`,
+        `${verbHtml} — sent, but couldn't read a confirmation line. \`/status\` will show the live model once it's confirmed.`,
         PERSIST_NOTE,
       ].join('\n'),
       html: true,
@@ -666,13 +671,20 @@ export function srFriendlyLabel(srName: string): string {
  * The confirmed path records the display name claude printed (e.g. "Fable 5" via
  * `sessionModelFromConfirmation`); the optimistic path only has the requested
  * arg. Without a confirmation we can't know the version suffix, so we normalize
- * the token to the same DISPLAY style (a friendly label, not a raw token) so
- * `/status` reads consistently regardless of which path fired: sr-* → its
- * friendly label, a bare Claude alias → Title-case ("fable" → "Fable"), and a
- * full `claude-*` id or anything else is left as-is (already canonical).
+ * a bare Claude alias to the same DISPLAY style — Title-case ("fable" → "Fable")
+ * — and leave a full `claude-*` id as-is (already canonical).
+ *
+ * #3242 review FIX 1 (MEDIUM) — sr-* tokens are returned UNCHANGED (with the
+ * `sr-` prefix). The stored `selectedModel` doubles as the sr-*→Claude sentinel:
+ * `gateway.ts` `isSrToClaudeTransition` checks `prevModel?.startsWith('sr-')` to
+ * decide whether a later Claude switch needs the graceful restart that tears
+ * down LiteLLM routing. De-prefixing here (as the earlier LOW-4 pass did via
+ * `srFriendlyLabel`) would silently break that restart. So this helper never
+ * de-prefixes: the caller normalizes only the DISPLAY text separately (see
+ * `srFriendlyLabel`), never the stored token.
  */
 export function optimisticModelRecordLabel(token: string): string {
-  if (isSrModel(token)) return srFriendlyLabel(token)
+  if (isSrModel(token)) return token
   const lower = token.toLowerCase()
   if ((MODEL_ALIASES as readonly string[]).includes(lower)) {
     return lower.charAt(0).toUpperCase() + lower.slice(1)
@@ -1088,13 +1100,14 @@ export async function handleModelMenuCallback(
         }
       }
       // Silent success (no confirmation, no error) → optimistic record, same as
-      // the typed path.
+      // the typed path. PROVISIONAL copy (#3242 review FIX 2): don't assert the
+      // switch succeeded — we couldn't read a confirmation, and /status self-heals.
       const optimisticLabel = optimisticModelRecordLabel(alias)
       return {
-        answer: `Switched to ${optimisticLabel} (session)`,
+        answer: `Sent /model ${alias} — check /status`,
         reply: await menuWithBannerStatic(
           deps,
-          `✅ Switched to **${deps.escapeHtml(optimisticLabel)}** (session) — couldn’t read a confirmation line; check \`/status\`.`,
+          `Sent \`/model ${deps.escapeHtml(alias)}\` — couldn’t read a confirmation line. \`/status\` will show the live model once it’s confirmed.`,
         ),
         selectedModel: optimisticLabel,
         selectedModelToken: alias,

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -249,6 +249,40 @@ describe("handleModelCommand — set — #3241 poll-until-signal wiring", () => 
     expect(reply.selectedModel).toBeUndefined();
     expect(reply.optimistic).toBeUndefined();
   });
+
+  // #3242 review MEDIUM 1 — an access/entitlement denial must NOT be recorded
+  // optimistically. Each of these lines matches neither the confirmation prefix
+  // nor the OLD bad-id error regex, so before the widen they slipped into the
+  // optimistic branch and falsely recorded the switch.
+  for (const denial of [
+    "⎿  Fable is not available on your plan",
+    "⎿  access denied",
+    "⎿  Fable requires a Pro subscription",
+    "⎿  This model is not enabled for your account",
+    "⎿  No access to Fable on this tier",
+    "⎿  Fable 5 is currently unavailable",
+  ]) {
+    it(`access-denial line → failure verdict AND no override (retract): ${JSON.stringify(denial)}`, async () => {
+      const { deps } = makeDeps({ inject: async () => okResult(denial) });
+      const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
+      expect(reply.text).toContain("did not take");
+      expect(reply.selectedModel).toBeUndefined();
+      expect(reply.optimistic).toBeUndefined();
+    });
+  }
+
+  it("a genuine confirmation is NEVER flipped to a failure by the widened denial regex", async () => {
+    // Confirmation-first ordering: even if scrollback in the same region says
+    // something "unavailable", a real "Set model to …" line wins.
+    const mixed = [
+      "the metrics endpoint was unavailable earlier",
+      "⎿  Set model to Fable 5 for this session",
+    ].join("\n");
+    const { deps } = makeDeps({ inject: async () => okResult(mixed) });
+    const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
+    expect(reply.text).not.toContain("did not take");
+    expect(reply.selectedModel).toBe("Fable 5");
+  });
 });
 
 describe("handleModelCommand — set", () => {
@@ -288,7 +322,7 @@ describe("handleModelCommand — set", () => {
     expect(reply.text).toContain("couldn't read claude");
     expect(reply.text).toContain("/status");
     expect(reply.text).not.toContain("switched (session)");
-    expect(reply.selectedModel).toBe("fable");
+    expect(reply.selectedModel).toBe("Fable");
     expect(reply.optimistic).toBe(true);
     expect(reply.html).toBe(true);
   });
@@ -324,7 +358,7 @@ describe("handleModelCommand — set", () => {
     expect(reply.text).not.toContain("kept model changes");
     expect(reply.text).toContain("Recorded");
     expect(reply.text).not.toContain("switched (session)");
-    expect(reply.selectedModel).toBe("fable");
+    expect(reply.selectedModel).toBe("Fable");
     expect(reply.optimistic).toBe(true);
     expect(reply.html).toBe(true);
   });
@@ -352,7 +386,7 @@ describe("handleModelCommand — set", () => {
     // optimistically (was: "no response captured", recorded nothing).
     expect(reply.text).toContain("Recorded");
     expect(reply.text).toContain("/status");
-    expect(reply.selectedModel).toBe("sonnet");
+    expect(reply.selectedModel).toBe("Sonnet");
     expect(reply.optimistic).toBe(true);
   });
 
@@ -542,7 +576,7 @@ describe("handleModelCommand — busy gate + honest unverified reporting", () =>
     // mid-sentence "model not found" prose does NOT flip the switch to a failure,
     // and the requested model is recorded (was: "couldn't confirm", nothing).
     expect(reply.text).toContain("Recorded");
-    expect(reply.selectedModel).toBe("opus");
+    expect(reply.selectedModel).toBe("Opus");
     expect(reply.optimistic).toBe(true);
   });
 
@@ -972,6 +1006,59 @@ describe("handleModelMenuCallback", () => {
     const out = await handleModelMenuCallback(modelSelectCallbackData("Sonnet"), deps);
     expect(out.selectedModel).toBe("Sonnet");
     expect(out.selectedModelToken).toBe("sonnet");
+  });
+});
+
+// #3242 review MEDIUM 2 — the alias BUTTON (mdl:alias:<alias>, e.g. the Fable
+// button) must be symmetric with the typed set path: record-on-send / retract-
+// on-scraped-error, handling BOTH ok and ok_no_output. Before the fix a silent
+// successful button-switch (ok_no_output, or ok with no confirmation line) fell
+// through to "Switch failed" and dropped the override.
+describe("handleModelMenuCallback — alias button symmetry (#3242 MEDIUM 2)", () => {
+  it("ok_no_output (silent switch via the button) → optimistic record, not a failure", async () => {
+    const { deps } = makeMenuDeps({
+      inject: async () => ({
+        outcome: "ok_no_output" as const,
+        output: "",
+        truncated: false,
+        command: "/model",
+        meta: { description: "Open model picker", expectsOutput: true },
+      }),
+    });
+    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
+    expect(out.selectedModel).toBe("Fable"); // normalized display form
+    expect(out.selectedModelToken).toBe("fable");
+    expect(out.reply.text).not.toContain("failed");
+    expect(out.reply.text).toContain("Fable");
+  });
+
+  it("ok with no confirmation line (banner-only) → optimistic record", async () => {
+    const { deps } = makeMenuDeps({
+      inject: async () => okResult("⠋ extending Claude Fable 5 access…"),
+    });
+    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
+    expect(out.selectedModel).toBe("Fable");
+    expect(out.selectedModelToken).toBe("fable");
+    // The banner must not leak as the confirmation.
+    expect(out.reply.text).not.toContain("extending Claude Fable 5 access");
+  });
+
+  it("scraped access-denial line via the button → failure, no override (retract)", async () => {
+    const { deps } = makeMenuDeps({
+      inject: async () => okResult("⎿  Fable is not available on your plan"),
+    });
+    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
+    expect(out.selectedModel).toBeUndefined();
+    expect(out.reply.text).toContain("did not take");
+  });
+
+  it("genuine confirmation via the button still records the display name", async () => {
+    const { deps } = makeMenuDeps({
+      inject: async () => okResult("⎿  Set model to Fable 5 for this session"),
+    });
+    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
+    expect(out.selectedModel).toBe("Fable 5");
+    expect(out.selectedModelToken).toBe("fable");
   });
 });
 

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -318,9 +318,9 @@ describe("handleModelCommand — set", () => {
     // failure. Record the requested model optimistically so /status is right,
     // and say so honestly (no false "switched (session)", no scrollback leak).
     expect(reply.text).toContain("/model fable");
-    expect(reply.text).toContain("Recorded");
-    expect(reply.text).toContain("couldn't read claude");
+    expect(reply.text).toContain("couldn't read a confirmation");
     expect(reply.text).toContain("/status");
+    expect(reply.text).not.toContain("Recorded");
     expect(reply.text).not.toContain("switched (session)");
     expect(reply.selectedModel).toBe("Fable");
     expect(reply.optimistic).toBe(true);
@@ -356,7 +356,7 @@ describe("handleModelCommand — set", () => {
     expect(reply.text).not.toContain("switched the deploy");
     expect(reply.text).not.toContain("set model behaviour");
     expect(reply.text).not.toContain("kept model changes");
-    expect(reply.text).toContain("Recorded");
+    expect(reply.text).toContain("couldn't read a confirmation");
     expect(reply.text).not.toContain("switched (session)");
     expect(reply.selectedModel).toBe("Fable");
     expect(reply.optimistic).toBe(true);
@@ -384,7 +384,7 @@ describe("handleModelCommand — set", () => {
     // #3241 part B — an empty capture can't carry an error line, so the send is
     // treated as a silent switch and the requested model is recorded
     // optimistically (was: "no response captured", recorded nothing).
-    expect(reply.text).toContain("Recorded");
+    expect(reply.text).toContain("couldn't read a confirmation");
     expect(reply.text).toContain("/status");
     expect(reply.selectedModel).toBe("Sonnet");
     expect(reply.optimistic).toBe(true);
@@ -575,7 +575,7 @@ describe("handleModelCommand — busy gate + honest unverified reporting", () =>
     // No LINE-ANCHORED error and no confirmation → #3241 optimistic record: the
     // mid-sentence "model not found" prose does NOT flip the switch to a failure,
     // and the requested model is recorded (was: "couldn't confirm", nothing).
-    expect(reply.text).toContain("Recorded");
+    expect(reply.text).toContain("couldn't read a confirmation");
     expect(reply.selectedModel).toBe("Opus");
     expect(reply.optimistic).toBe(true);
   });
@@ -813,6 +813,7 @@ import {
   EXTRA_CLAUDE_ALIASES,
   externalModelNames,
   isSrToClaudeTransition,
+  optimisticModelRecordLabel,
   type ModelMenuDeps,
 } from "../gateway/model-command.js";
 import { labelTag } from "../../src/agents/model-picker.js";
@@ -1028,8 +1029,11 @@ describe("handleModelMenuCallback — alias button symmetry (#3242 MEDIUM 2)", (
     const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
     expect(out.selectedModel).toBe("Fable"); // normalized display form
     expect(out.selectedModelToken).toBe("fable");
+    // Provisional copy (#3242 FIX 2): doesn't assert the switch succeeded, points
+    // at /status, and never reads as a failure.
     expect(out.reply.text).not.toContain("failed");
-    expect(out.reply.text).toContain("Fable");
+    expect(out.reply.text).toContain("/status");
+    expect(out.reply.text).toContain("/model fable");
   });
 
   it("ok with no confirmation line (banner-only) → optimistic record", async () => {
@@ -1321,6 +1325,26 @@ describe("isSrToClaudeTransition", () => {
 
   it("false when prev is sr-* but next is also sr-* (sr-* → sr-*)", () => {
     expect(isSrToClaudeTransition("sr-gemini-2.5-pro", "sr-deepseek-r1")).toBe(false);
+  });
+
+  // #3242 review FIX 1 — optimisticModelRecordLabel must NOT de-prefix an sr-*
+  // token: the stored selectedModel doubles as the sr-*→Claude sentinel that
+  // isSrToClaudeTransition (prevModel.startsWith('sr-')) reads. De-prefixing to
+  // a friendly label ("kimi k2") would silently kill the graceful restart that
+  // tears down LiteLLM routing on a subsequent Claude switch.
+  it("optimisticModelRecordLabel keeps sr-* tokens verbatim so the sentinel survives", () => {
+    const recorded = optimisticModelRecordLabel("sr-kimi-k2");
+    expect(recorded).toBe("sr-kimi-k2"); // NOT "kimi k2"
+    // The recorded value still trips the sr→Claude transition on a later switch.
+    expect(isSrToClaudeTransition(recorded, "opus")).toBe(true);
+    // Regression guard: the de-prefixed form would NOT — that was the bug.
+    expect(isSrToClaudeTransition("kimi k2", "opus")).toBe(false);
+  });
+
+  it("optimisticModelRecordLabel Title-cases a bare Claude alias, leaves full ids as-is", () => {
+    expect(optimisticModelRecordLabel("fable")).toBe("Fable");
+    expect(optimisticModelRecordLabel("opus")).toBe("Opus");
+    expect(optimisticModelRecordLabel("claude-opus-4-8")).toBe("claude-opus-4-8");
   });
 
   it("false when switching to sr-* from Claude (Claude → sr-*)", () => {

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -200,6 +200,57 @@ describe("handleModelCommand — show / help never inject (picker-wedge guard)",
   });
 });
 
+describe("handleModelCommand — set — #3241 poll-until-signal wiring", () => {
+  it("forwards successPattern + errorPattern + settleBeforeSendMs to the inject primitive", async () => {
+    const seen: Array<{ command: string; opts: unknown }> = [];
+    const { deps } = makeDeps({
+      inject: async (_agent, command, opts) => {
+        seen.push({ command, opts });
+        return okResult("⏺ Set model to Sonnet 5 for this session");
+      },
+    });
+    await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
+    expect(seen).toHaveLength(1);
+    const opts = seen[0].opts as {
+      successPattern?: RegExp;
+      errorPattern?: RegExp;
+      settleBeforeSendMs?: number;
+    };
+    // A success pattern that matches claude's confirmation line, an error pattern
+    // that matches the "not found" line, and a clean-prompt pre-send wait.
+    expect(opts.successPattern?.test("⏺ Set model to Sonnet 5")).toBe(true);
+    expect(opts.errorPattern?.test("⎿  Model 'x' not found")).toBe(true);
+    expect(typeof opts.settleBeforeSendMs).toBe("number");
+    expect(opts.settleBeforeSendMs).toBeGreaterThan(0);
+  });
+
+  it("confirmation that lands after a banner → records the live model for /status", async () => {
+    // The inject primitive (poll-until-signal) is responsible for returning the
+    // confirmation and not the banner; here the handler receives that confirmation
+    // and must record it as the session override.
+    const { deps } = makeDeps({
+      inject: async () =>
+        okResult("⠋ extending Claude Fable 5 access…\n⎿  Set model to Fable 5 for this session"),
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
+    expect(reply.selectedModel).toBe("Fable 5");
+    expect(reply.optimistic).toBeUndefined();
+    expect(reply.text).toContain("Set model to Fable 5");
+    // The banner is scrollback and must not leak as prose above the confirmation.
+    expect(reply.text).not.toContain("extending Claude Fable 5 access");
+  });
+
+  it("scraped error line → failure verdict AND no override recorded (retract)", async () => {
+    const { deps } = makeDeps({
+      inject: async () => okResult("⎿  Model 'claude-bogus-99' not found"),
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "claude-bogus-99" }, deps);
+    expect(reply.text).toContain("did not take");
+    expect(reply.selectedModel).toBeUndefined();
+    expect(reply.optimistic).toBeUndefined();
+  });
+});
+
 describe("handleModelCommand — set", () => {
   it("injects exactly `/model <name>` once and relays a genuine confirmation + persistence note", async () => {
     const { deps, calls } = makeDeps();
@@ -228,13 +279,17 @@ describe("handleModelCommand — set", () => {
     expect(reply.text).not.toContain("summary you asked for");
     expect(reply.text).not.toContain("rollback plan");
     expect(reply.text).not.toContain("<pre>");
-    // No confirmation line was captured, so the switch is UNVERIFIED — report it
-    // honestly (never a false "switched") and record NO session override.
+    // #3241 part B — poll-until-signal already waited the full window, so a
+    // missing confirmation line with NO scraped error is a SILENT switch, not a
+    // failure. Record the requested model optimistically so /status is right,
+    // and say so honestly (no false "switched (session)", no scrollback leak).
     expect(reply.text).toContain("/model fable");
-    expect(reply.text).toContain("couldn't confirm the switch");
+    expect(reply.text).toContain("Recorded");
+    expect(reply.text).toContain("couldn't read claude");
     expect(reply.text).toContain("/status");
     expect(reply.text).not.toContain("switched (session)");
-    expect(reply.selectedModel).toBeUndefined();
+    expect(reply.selectedModel).toBe("fable");
+    expect(reply.optimistic).toBe(true);
     expect(reply.html).toBe(true);
   });
 
@@ -260,15 +315,17 @@ describe("handleModelCommand — set", () => {
     const { deps } = makeDeps({ inject: async () => okResult(prose) });
     const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
     // The anchored regex rejects all three lines, so nothing leaks and there is
-    // no <pre> block. With no confirmation captured, the switch is UNVERIFIED —
-    // report it honestly, never a false "switched".
+    // no <pre> block. No confirmation AND no scraped error → #3241 optimistic
+    // record: the switch is reported as sent + recorded, never a false
+    // "switched", and no scrollback prose leaks.
     expect(reply.text).not.toContain("<pre>");
     expect(reply.text).not.toContain("switched the deploy");
     expect(reply.text).not.toContain("set model behaviour");
     expect(reply.text).not.toContain("kept model changes");
-    expect(reply.text).toContain("couldn't confirm the switch");
+    expect(reply.text).toContain("Recorded");
     expect(reply.text).not.toContain("switched (session)");
-    expect(reply.selectedModel).toBeUndefined();
+    expect(reply.selectedModel).toBe("fable");
+    expect(reply.optimistic).toBe(true);
     expect(reply.html).toBe(true);
   });
 
@@ -290,7 +347,13 @@ describe("handleModelCommand — set", () => {
       }),
     });
     const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
-    expect(reply.text).toContain("no response captured");
+    // #3241 part B — an empty capture can't carry an error line, so the send is
+    // treated as a silent switch and the requested model is recorded
+    // optimistically (was: "no response captured", recorded nothing).
+    expect(reply.text).toContain("Recorded");
+    expect(reply.text).toContain("/status");
+    expect(reply.selectedModel).toBe("sonnet");
+    expect(reply.optimistic).toBe(true);
   });
 
   it("session_missing failure surfaces the tmux-supervisor hint", async () => {
@@ -475,9 +538,12 @@ describe("handleModelCommand — busy gate + honest unverified reporting", () =>
     const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
     expect(reply.text).not.toContain("did not take");
     expect(reply.text).not.toContain("model not found");
-    // No confirmation either → honest unverified message, nothing recorded.
-    expect(reply.text).toContain("couldn't confirm the switch");
-    expect(reply.selectedModel).toBeUndefined();
+    // No LINE-ANCHORED error and no confirmation → #3241 optimistic record: the
+    // mid-sentence "model not found" prose does NOT flip the switch to a failure,
+    // and the requested model is recorded (was: "couldn't confirm", nothing).
+    expect(reply.text).toContain("Recorded");
+    expect(reply.selectedModel).toBe("opus");
+    expect(reply.optimistic).toBe(true);
   });
 
   it("recognises claude v2.1.205's real arg-form confirmation (⎿ glyph + 'and saved as your default')", async () => {

--- a/telegram-plugin/tests/session-model-source.test.ts
+++ b/telegram-plugin/tests/session-model-source.test.ts
@@ -56,6 +56,17 @@ describe('createSessionModelSource — freshest observation wins', () => {
     expect(s.resolve()).toEqual({ model: 'claude-opus-4-8', source: 'transcript' })
   })
 
+  it('#3241 optimistic override: a silently-switched model recorded without a confirmation still wins /status', () => {
+    // Part B — the typed set path records the REQUESTED model optimistically when
+    // the confirmation line was missed. That override, being the freshest write,
+    // must reclaim /status from the stale transcript line just like a confirmed
+    // switch (symptom 4: "/status shows old model" after an in-place typed switch).
+    const s = createSessionModelSource()
+    s.noteTranscriptModel('claude-opus-4-8') // old model's last assistant line
+    s.setOverride('fable') // optimistic record of the requested model (no confirmation read)
+    expect(s.resolve()).toEqual({ model: 'fable', source: 'override' })
+  })
+
   it('getOverride reports the override independent of freshness', () => {
     const s = createSessionModelSource()
     s.setOverride('sr-glm-5')

--- a/tests/model-picker.test.ts
+++ b/tests/model-picker.test.ts
@@ -193,6 +193,39 @@ describe("discoverModels", () => {
   });
 });
 
+describe("#3241 interstitial dismiss-and-retry", () => {
+  // An async access banner (no "Select model" header, no footer) renders where
+  // the picker should be on the first open; openPickerWithRetry must Esc it and
+  // re-open once, then discover succeeds.
+  const INTERSTITIAL = ["❯ /model", "", "⠋ extending Claude Fable 5 access…"].join("\n");
+
+  it("discover Esc-and-retries past a first-render banner, then parses the picker", async () => {
+    let opens = 0;
+    const sends: string[][] = [];
+    const runner: TmuxRunner = {
+      // Until the SECOND `/model` open, the pane shows only the banner; after it,
+      // the real picker renders.
+      capture: () => (opens >= 2 ? PICKER : INTERSTITIAL),
+      send: (_s, _t, args) => {
+        sends.push(args);
+        if (args[1] === "-l" && args[2] === "/model") opens++;
+      },
+      hasSession: () => true,
+    };
+    const res = await discoverModels("agentx", { ...fastOpts, _runner: runner, timeoutMs: 60 });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.options.map((o) => o.label)).toEqual([
+        "Default (recommended)", "Sonnet", "Haiku",
+      ]);
+    }
+    // Two `/model` opens (initial + one retry) and at least one Escape between them.
+    expect(opens).toBe(2);
+    expect(sentKeys(sends).filter((k) => k === "/model").length).toBe(2);
+    expect(sentKeys(sends)).toContain("Escape");
+  });
+});
+
 describe("selectModel", () => {
   it("navigates cursor→target, verifies the label, presses s — no Escape", async () => {
     // open → PICKER (cursor 2) → after Down: cursor 3 → verify → s → confirmation


### PR DESCRIPTION
## Root cause

Grounded at `origin/main` 3224269. The gateway drives the interactive `claude` `/model` TUI and scrapes ANSI pane output within a **fixed timing window**, then gates **both** the user-facing verdict **and** the persisted `/status` session-model state on that scrape. It is racy and version-fragile: Anthropic currently renders an async multi-line "extending Claude … access" banner **inside** the `/model` region, which trips the fixed settle break — the capture loop exits on the *first* pane change (the banner) and never sees the later `Set model to …` confirmation. Four symptoms, one cause:

1. `/model <name>` → "sent, but couldn't confirm" even though the CLI printed `Set model to …`.
2. First `/model <name>` no-ops ("Kept model as …") — keys typed into a still-animating pane.
3. Bare `/model` → "picker did not render" — the banner pushes the `Esc to cancel` footer out of the render window.
4. `/status` shows the old model — the typed-switch persistence only fired when the scrape succeeded.

Option C (a CLI-native non-interactive set) is ruled out: `claude` 2.1.205 has no `model`/`config` subcommand and `--model` binds only at launch. The live `/model` TUI is the only path — so this PR makes the scrape **deterministic** instead of timing-dependent.

## A. Poll-until-signal capture (opt-in; byte-identical for other callers)

- `src/agents/inject.ts` — `InjectOpts` gains `successPattern` / `errorPattern` / `settleBeforeSendMs`. When a pattern is supplied the capture loop keeps polling the **new (diffed) region** until a success or error line matches, or a raised **8s** timeout fires — surviving banners that render *after* the first pane change. When no pattern is supplied the loop is byte-identical to before (gated strictly on the new params).
- `telegram-plugin/gateway/model-command.ts` — the set-path and the alias callback pass the confirmation-prefix regex as success and the error regex as error, plus a clean-prompt pre-send wait (**symptom 2**: keys no longer land in a still-animating pane).
- `src/agents/model-picker.ts` — `openPickerWithRetry` Esc-dismisses a non-picker interstitial and re-opens **once** (budget-split so the retry has room) before falling back to the static list; overall timeout raised 10s→12s (**symptom 3**).

## B. Decouple persistence from the scrape (optimistic record, retract on error)

`handleModelCommand` now records the requested model **optimistically** on a successful inject SEND when **no error line is scraped**, inverting the old "record nothing unless positively confirmed". A scraped error → failure verdict + **no** override (the retract). `Kept model as X` stays a genuine no-op. This fixes **symptom 4** via the in-memory `setOverride` that `/status` reads.

## Tests (assert outcomes, faked `TmuxRunner`)

- `inject.test.ts` — confirmation on poll N+2 *after* a banner on poll N → confirmation captured, not the banner; scraped error → early break; `settleBeforeSendMs` waits for a still pane; a contrast test pins that the legacy (no-pattern) path still captures the banner.
- `model-command.test.ts` — the poll opts are forwarded to inject; confirmation-after-banner → `selectedModel` recorded; scraped error → failure + no override; the four pre-invert tests updated to the optimistic outcomes.
- `session-model-source.test.ts` — an optimistic override reclaims `/status` from a stale transcript line.
- `model-picker.test.ts` — discover Esc-and-retries past a first-render banner, then parses the picker.

Scoped vitest (all touched files + adjacents) green; `npm run lint` (incl. `tsc --noEmit`) clean.

## Reviewer note — deliberate deviation from the spec

The task also asked to **write the `.session-model` carrier** on every in-place typed switch. I did **not**, and flag it for a decision:

- `/status` in-session reads the **in-memory** `sessionModelSource` override, not the `.session-model` file — so the optimistic `setOverride` already fixes symptom 4. The file write is not needed for the stated goal.
- The `.session-model` carrier is documented (session-model-file.ts, rev-4, operator decision 2026-07-12) as **consume-once, written only immediately before a relaunch**; live Claude switches deliberately write no carrier so they revert on the next boot. Writing it for in-place typed switches would make a typed switch **survive one unrelated restart** — a real semantic change to the rev-4 session-scoped contract.

Per the "contradicting evidence wins" protocol I left rev-4 intact. If restart-durability for typed switches is actually wanted, it's a small, explicit follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)