### PR TITLE
feat(gateway): show original request reason on vault-grant approval card

### DIFF
--- a/telegram-plugin/gateway/callback-query-handlers.ts
+++ b/telegram-plugin/gateway/callback-query-handlers.ts
@@ -52,6 +52,7 @@ import {
 import {
   buildVaultGrantApprovedInbound,
   buildVaultGrantApprovedCardText,
+  normalizeGrantReason,
   buildVaultGrantDeniedInbound,
   buildVaultSaveCompletedInbound,
   buildVaultSaveFailedInbound,
@@ -786,6 +787,10 @@ async function performVaultAccessApproval(
   pendingCardStore.remove(stageId)
   if (pending.card_message_id != null) {
     const days = Math.round(pending.ttl_seconds / 86400)
+    // Normalize + cap the agent-supplied reason to a single line BEFORE
+    // escaping, so the value passed into the card builder is already
+    // safe to render inside the `_Reason: …_` italic clause.
+    const reasonNormalized = normalizeGrantReason(pending.reason)
     const footer =
       getVaultApprovalAuthMode() === 'telegram-id'
         ? `\n_Approver verified by Telegram identity — broker auto-unlocked at startup._`
@@ -802,9 +807,7 @@ async function performVaultAccessApproval(
             days,
             grantId: id,
             reasonEscaped:
-              pending.reason != null && pending.reason.length > 0
-                ? escapeHtmlForTg(pending.reason)
-                : undefined,
+              reasonNormalized.length > 0 ? escapeHtmlForTg(reasonNormalized) : undefined,
             footer,
           }),
         ),

--- a/telegram-plugin/gateway/callback-query-handlers.ts
+++ b/telegram-plugin/gateway/callback-query-handlers.ts
@@ -801,6 +801,10 @@ async function performVaultAccessApproval(
             key: pending.key,
             days,
             grantId: id,
+            reasonEscaped:
+              pending.reason != null && pending.reason.length > 0
+                ? escapeHtmlForTg(pending.reason)
+                : undefined,
             footer,
           }),
         ),

--- a/telegram-plugin/gateway/vault-grant-inbound-builders.ts
+++ b/telegram-plugin/gateway/vault-grant-inbound-builders.ts
@@ -159,6 +159,35 @@ export function buildVaultGrantDeniedInbound(opts: {
  * @param footer        Optional trailing footer (e.g. the telegram-id
  *                      auth-mode note). Empty string when absent.
  */
+/** Max characters of agent-supplied reason rendered on the grant card.
+ *  Keeps the edited card well under Telegram's 4096-char editMessageText
+ *  limit — the edit is fire-and-forget (`.catch(() => {})`), so an
+ *  over-long reason would silently fail the edit and leave the pending
+ *  approve/deny buttons showing even though the grant already succeeded. */
+export const MAX_GRANT_REASON_CHARS = 300
+
+/**
+ * Normalize an agent-supplied grant reason for single-line rendering
+ * inside the GFM italic clause `_Reason: …_`:
+ *   - collapse ALL whitespace runs to a single space (a newline breaks
+ *     the `_…_` emphasis — the opening `_` renders literal),
+ *   - trim, so a whitespace-only reason cleanly no-ops (returns ''),
+ *   - cap length with a trailing ellipsis so the card edit can't blow
+ *     past Telegram's message-length limit.
+ *
+ * Returns UNescaped text — the caller MUST HTML-escape the result before
+ * rendering (it is agent-supplied free text). Returns '' for
+ * empty/whitespace-only/undefined input so the caller can skip the clause.
+ */
+export function normalizeGrantReason(raw: string | undefined | null): string {
+  if (raw == null) return ''
+  const collapsed = raw.replace(/\s+/g, ' ').trim()
+  if (collapsed.length === 0) return ''
+  return collapsed.length > MAX_GRANT_REASON_CHARS
+    ? collapsed.slice(0, MAX_GRANT_REASON_CHARS - 1) + '…'
+    : collapsed
+}
+
 export function buildVaultGrantApprovedCardText(opts: {
   agentEscaped: string
   scope: 'read' | 'write'

--- a/telegram-plugin/gateway/vault-grant-inbound-builders.ts
+++ b/telegram-plugin/gateway/vault-grant-inbound-builders.ts
@@ -149,6 +149,13 @@ export function buildVaultGrantDeniedInbound(opts: {
  * @param key           Vault key (rendered inline-code).
  * @param days          Grant TTL in whole days.
  * @param grantId       Broker-returned grant id.
+ * @param reasonEscaped Optional original request reason the agent gave,
+ *                      already run through `escapeHtmlForTg` (it is
+ *                      agent-supplied free text). Rendered as a trailing
+ *                      italic clause for audit visibility. Omitted when
+ *                      absent/empty so no dangling "Reason:" label shows.
+ *                      Placed BEFORE the footer so the auth-mode note
+ *                      stays last.
  * @param footer        Optional trailing footer (e.g. the telegram-id
  *                      auth-mode note). Empty string when absent.
  */
@@ -158,12 +165,17 @@ export function buildVaultGrantApprovedCardText(opts: {
   key: string
   days: number
   grantId: string
+  reasonEscaped?: string
   footer?: string
 }): string {
+  const reasonClause =
+    opts.reasonEscaped != null && opts.reasonEscaped.length > 0
+      ? ` _Reason: ${opts.reasonEscaped}_`
+      : ''
   return (
     `✅ Granted **${opts.agentEscaped}** ${opts.scope} access to ` +
     `\`${opts.key}\` for ${opts.days}d. ` +
-    `(grant \`${opts.grantId}\`)` + (opts.footer ?? '')
+    `(grant \`${opts.grantId}\`)` + reasonClause + (opts.footer ?? '')
   )
 }
 

--- a/telegram-plugin/tests/vault-grant-inbound-builders.test.ts
+++ b/telegram-plugin/tests/vault-grant-inbound-builders.test.ts
@@ -16,6 +16,8 @@ import { describe, it, expect } from 'vitest'
 import {
   buildVaultGrantApprovedInbound,
   buildVaultGrantApprovedCardText,
+  normalizeGrantReason,
+  MAX_GRANT_REASON_CHARS,
   buildVaultGrantDeniedInbound,
   buildVaultSaveCompletedInbound,
   buildVaultSaveFailedInbound,
@@ -140,6 +142,80 @@ describe('buildVaultGrantApprovedCardText — the [object Object] regression gua
     // contains the literal "[object Object]". The helper above avoids it.
     const buggy = '✅ Granted access. ' + (richMessage('(grant `vg_x`)') as unknown as string)
     expect(buggy).toContain('[object Object]')
+  })
+})
+
+describe('normalizeGrantReason — single-line, trimmed, length-capped', () => {
+  it('returns "" for undefined, null, empty, or whitespace-only input (clean no-op)', () => {
+    expect(normalizeGrantReason(undefined)).toBe('')
+    expect(normalizeGrantReason(null)).toBe('')
+    expect(normalizeGrantReason('')).toBe('')
+    expect(normalizeGrantReason('   ')).toBe('')
+    expect(normalizeGrantReason('\n\t  \n')).toBe('')
+  })
+
+  it('collapses newlines and whitespace runs to a single space (protects the _…_ emphasis)', () => {
+    expect(normalizeGrantReason('deploy\nthe   staging\tbuild')).toBe('deploy the staging build')
+    // no newline survives to break the italic clause
+    expect(normalizeGrantReason('a\nb')).not.toContain('\n')
+  })
+
+  it('trims leading/trailing whitespace', () => {
+    expect(normalizeGrantReason('  clone the repo  ')).toBe('clone the repo')
+  })
+
+  it('caps over-long input with a trailing ellipsis, at MAX_GRANT_REASON_CHARS', () => {
+    const long = 'x'.repeat(MAX_GRANT_REASON_CHARS + 50)
+    const out = normalizeGrantReason(long)
+    expect(out.length).toBe(MAX_GRANT_REASON_CHARS)
+    expect(out.endsWith('…')).toBe(true)
+    expect(out.slice(0, -1)).toBe('x'.repeat(MAX_GRANT_REASON_CHARS - 1))
+  })
+
+  it('leaves an at-limit reason untouched (no spurious ellipsis)', () => {
+    const exact = 'y'.repeat(MAX_GRANT_REASON_CHARS)
+    const out = normalizeGrantReason(exact)
+    expect(out).toBe(exact)
+    expect(out.endsWith('…')).toBe(false)
+  })
+
+  it('feeds cleanly through the card builder: whitespace-only → no clause, newline → single-line clause', () => {
+    // whitespace-only normalizes to '' → builder omits the clause
+    const wsCard = buildVaultGrantApprovedCardText({
+      agentEscaped: 'gymbro',
+      scope: 'read',
+      key: 'k',
+      days: 30,
+      grantId: 'vg_x',
+      reasonEscaped: normalizeGrantReason('   ') || undefined,
+    })
+    expect(wsCard).not.toContain('Reason:')
+
+    // newline reason renders as a single-line italic clause, no broken emphasis
+    const nlCard = buildVaultGrantApprovedCardText({
+      agentEscaped: 'gymbro',
+      scope: 'read',
+      key: 'k',
+      days: 30,
+      grantId: 'vg_x',
+      reasonEscaped: normalizeGrantReason('line one\nline two') || undefined,
+    })
+    expect(nlCard).toContain('_Reason: line one line two_')
+    expect(nlCard).not.toContain('\nline two')
+  })
+
+  it('over-long reason renders truncated with ellipsis inside the clause', () => {
+    const reason = normalizeGrantReason('z'.repeat(MAX_GRANT_REASON_CHARS + 100)) || undefined
+    const card = buildVaultGrantApprovedCardText({
+      agentEscaped: 'gymbro',
+      scope: 'read',
+      key: 'k',
+      days: 30,
+      grantId: 'vg_x',
+      reasonEscaped: reason,
+    })
+    expect(card).toContain('…_')
+    expect(card).toContain(`_Reason: ${'z'.repeat(MAX_GRANT_REASON_CHARS - 1)}…_`)
   })
 })
 

--- a/telegram-plugin/tests/vault-grant-inbound-builders.test.ts
+++ b/telegram-plugin/tests/vault-grant-inbound-builders.test.ts
@@ -85,6 +85,55 @@ describe('buildVaultGrantApprovedCardText — the [object Object] regression gua
     expect(noFooter.endsWith('(grant `vg_a1b2c3`)')).toBe(true)
   })
 
+  it('renders the reason as a trailing italic clause when provided, before the footer', () => {
+    const text = buildVaultGrantApprovedCardText({
+      ...BASE,
+      reasonEscaped: 'deploy the staging build',
+      footer: '\n_Approver verified by Telegram identity._',
+    })
+    expect(text).toContain('_Reason: deploy the staging build_')
+    // reason clause sits BEFORE the footer (auth-mode note stays last)
+    expect(text.indexOf('_Reason:')).toBeLessThan(text.indexOf('_Approver verified'))
+    // still one clean string
+    const rich = richMessage(text)
+    expect(rich.markdown).toBe(text)
+    expect(rich.markdown).not.toContain('[object Object]')
+  })
+
+  it('omits the reason clause when reason is undefined or empty — no dangling "Reason:" label', () => {
+    const none = buildVaultGrantApprovedCardText(BASE)
+    expect(none).not.toContain('Reason:')
+    expect(none.endsWith('(grant `vg_a1b2c3`)')).toBe(true)
+
+    const empty = buildVaultGrantApprovedCardText({ ...BASE, reasonEscaped: '' })
+    expect(empty).not.toContain('Reason:')
+    expect(empty.endsWith('(grant `vg_a1b2c3`)')).toBe(true)
+  })
+
+  it('reason clause + reason-less both stay clean when combined with a footer', () => {
+    const footer = '\n_Approver verified by Telegram identity._'
+    const withReason = buildVaultGrantApprovedCardText({ ...BASE, reasonEscaped: 'x', footer })
+    expect(withReason.endsWith(footer)).toBe(true)
+    const noReason = buildVaultGrantApprovedCardText({ ...BASE, footer })
+    expect(noReason.endsWith(footer)).toBe(true)
+    expect(noReason).not.toContain('Reason:')
+  })
+
+  it('carries an already-escaped reason verbatim — HTML-special chars stay escaped, no corruption', () => {
+    // The callsite escapes agent-supplied free text with escapeHtmlForTg
+    // BEFORE passing it (same contract as agentEscaped). Simulate that:
+    // `<b> & "co" *_` → escaped form. The builder must not re-corrupt it,
+    // and the single-richMessage wrap must still hold.
+    const escaped = '&lt;b&gt; &amp; drop &amp;&amp; run *_'
+    const text = buildVaultGrantApprovedCardText({ ...BASE, reasonEscaped: escaped })
+    expect(text).toContain(`_Reason: ${escaped}_`)
+    // No raw unescaped angle brackets leaked into the card text.
+    expect(text).not.toContain('<b>')
+    const rich = richMessage(text)
+    expect(rich.markdown).toBe(text)
+    expect(rich.markdown).not.toContain('[object Object]')
+  })
+
   it('DOCUMENTS the original bug: bare-string + richMessage() coerces to [object Object]', () => {
     // Demonstrates why the fix matters — if a future edit reintroduces the
     // "concatenate a string onto the richMessage object" pattern, the result


### PR DESCRIPTION
## Summary
After an operator taps **Approve** on a `vault_request_access` card, the confirmation the card edits into now includes the **original reason** the requesting agent gave. Before, the card only showed agent/scope/key/ttl/grant-id — no record of *why* the credential was requested.

## Why
Audit visibility. When reviewing the chat history of vault grants, the operator (or a later audit) can now see both *what* was requested and *why*, on the persisted approval card itself, without cross-referencing the original request.

## What changed
- `buildVaultGrantApprovedCardText` gains an optional `reasonEscaped?: string` param. When present and non-empty it renders as a trailing italic clause ` _Reason: <reason>_`, placed **before** the auth-mode footer so that note stays last. Empty/undefined → no clause (no dangling "Reason:" label).
- The Approve callsite (`callback-query-handlers.ts`) wires `pending.reason` through, HTML-escaped via `escapeHtmlForTg` (agent-supplied free text, same escaping contract as `agentEscaped`).
- The whole message remains a single `richMessage()` wrap — the `[object Object]` guard is preserved.

### Rendered example
Without a reason (unchanged):
> ✅ Granted **finn** read access to `pixsoul/ssh-key` for 30d. (grant `vg_26a43e`)

With a reason:
> ✅ Granted **finn** read access to `pixsoul/ssh-key` for 30d. (grant `vg_26a43e`) _Reason: clone the deploy repo over SSH_

(when the telegram-id auth footer is present, the reason clause sits before it.)

## Test plan
- Extended `telegram-plugin/tests/vault-grant-inbound-builders.test.ts`: reason clause present when passed, absent when omitted/empty, ordering before footer, an already-escaped HTML-special reason stays escaped and does not corrupt the single-wrap, `[object Object]` guard still holds. Scoped run: 31 passed.
- `npm run lint` clean (tsc + all 8 guards).

## Risk
Low. Additive optional param; behavior with no reason is byte-identical to before. No wire/meta-shape change (touches only the card display text, not the synthetic inbound builders).

## Job spec
Touches the vault grant approval UX surface (`vault_request_access` flow, #1052/#1150 lineage). Advances the "on the leash" outcome — operator visibility into what agents requested and why.