### PR TITLE
fix(hindsight): durable retain watermark + boot reconciliation (#3244)

### DIFF
--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -72,7 +72,18 @@ def _budget_seconds() -> float:
 
 
 def _retry_one(entry: dict, timeout: int) -> None:
-    """POST a single queued retain. Raises on failure."""
+    """POST a single queued retain. Raises on failure.
+
+    Posts ``async_processing=False`` (commit-before-ack, switchroom #3244 §1.1):
+    the drain is a DURABILITY path — it deletes the pending entry on a 200, so
+    the 200 must prove durable persistence, not merely ack-of-receipt. A bare
+    async 200 followed by a dropped extraction would delete the queue entry
+    while the content never lands, and (for boot-reconcile remainders whose
+    watermark already advanced) there is no reconcile backstop — silent loss
+    (the #3244 bug). All drained entries — Stop-hook A2 failures, SessionEnd
+    failures, and reconcile-remainder deferrals — are durability retries, so
+    sync is correct for every one.
+    """
     client = HindsightClient(entry["api_url"], entry.get("api_token"))
     client.retain(
         bank_id=entry["bank_id"],
@@ -82,6 +93,7 @@ def _retry_one(entry: dict, timeout: int) -> None:
         metadata=entry.get("metadata") or {},
         tags=entry.get("tags"),
         timeout=timeout,
+        async_processing=False,
     )
 
 

--- a/vendor/hindsight-memory/scripts/lib/client.py
+++ b/vendor/hindsight-memory/scripts/lib/client.py
@@ -173,12 +173,22 @@ class HindsightClient:
         metadata: Optional[dict] = None,
         tags: Optional[list] = None,
         timeout: int = 15,
+        async_processing: bool = True,
     ) -> dict:
         """Retain content into a bank's memory.
 
-        Posts with async=true so the server processes in the background.
-        The context field helps Hindsight cluster memories by provenance
-        (e.g. "claude-code" vs manual retains).
+        By default posts with ``async=true`` so the server processes extraction
+        in the background (a 200 is an ack-of-receipt, not proof of durable
+        persistence). The context field helps Hindsight cluster memories by
+        provenance (e.g. "claude-code" vs manual retains).
+
+        ``async_processing=False`` (switchroom #3244 §1.1) posts ``async=false``
+        so the 200 is returned only after the daemon has durably committed the
+        item — commit-before-ack. Durability paths whose success advances the
+        retain watermark (the Stop-hook durability retain and boot
+        reconciliation) MUST use this so a bare async 200 can never falsely mark
+        unpersisted work as committed. (Merge precondition: the daemon honours
+        ``async=false`` as commit-before-ack — verified by the §1.1 probe.)
         """
         path = f"/v1/default/banks/{urllib.parse.quote(bank_id, safe='')}/memories"
         item = {
@@ -192,7 +202,7 @@ class HindsightClient:
             item["tags"] = tags
         body = {
             "items": [item],
-            "async": True,
+            "async": bool(async_processing),
         }
         return self._request("POST", path, body, timeout=timeout)
 

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -95,6 +95,12 @@ DEFAULTS = {
     "retainContext": "claude-code",
     "retainTags": [],
     "retainMetadata": {},
+    # Switchroom #3244 — boot reconciliation of un-committed transcript tails.
+    # On by default; the load-bearing recovery for work an abrupt session death
+    # (SIGKILL/OOM/watchdog) skipped. Disable per-agent via
+    # HINDSIGHT_RECONCILE_ON_START=false. reconcile_tail.py also honours the
+    # HINDSIGHT_RECONCILE_{LOOKBACK_H,MAX_TURNS,BUDGET_S} bounds (read directly).
+    "reconcileOnStart": True,
     "recallAdditionalBanks": [],
     # Connection
     "hindsightApiUrl": None,
@@ -134,6 +140,8 @@ ENV_OVERRIDES = {
     "HINDSIGHT_AUTO_RECALL": ("autoRecall", bool),
     "HINDSIGHT_AUTO_RETAIN": ("autoRetain", bool),
     "HINDSIGHT_RETAIN_MODE": ("retainMode", str),
+    # Switchroom #3244 — boot reconciliation on/off (default on).
+    "HINDSIGHT_RECONCILE_ON_START": ("reconcileOnStart", bool),
     "HINDSIGHT_RECALL_BUDGET": ("recallBudget", str),
     "HINDSIGHT_RECALL_MAX_TOKENS": ("recallMaxTokens", int),
     # Switchroom-local: count cap. Set by start.sh from

--- a/vendor/hindsight-memory/scripts/lib/pacing.py
+++ b/vendor/hindsight-memory/scripts/lib/pacing.py
@@ -1,0 +1,102 @@
+"""Shared fleet pacing lock for Hindsight retain POSTs (switchroom #3244 §1.5).
+
+A single per-agent advisory flock, ``$HOME/.hindsight/retain-inflight.lock``,
+serialises the durability-path retain POSTs so at most ONE is in flight for an
+agent at a time — covering the live Stop-hook retain, boot reconciliation, and
+(PR2) the one-time backfill collectively. This is the "never storm the daemon"
+guard.
+
+Usage::
+
+    from lib.pacing import inflight_lock
+
+    with inflight_lock(blocking=False) as acquired:
+        if not acquired:
+            ...  # someone else holds it — enqueue and return, do NOT wait
+        client.retain(...)
+
+* Boot reconcile / backfill acquire it **blocking** (they are batch work and
+  should wait their turn).
+* The live Stop hook acquires it **non-blocking** (``blocking=False``): if a
+  reconcile/backfill holds it the live retain must NOT wait (turn latency must
+  not regress) — the caller enqueues its payload to ``pending-retains/`` and
+  returns, and the next boot drain delivers it.
+
+The context manager yields ``True`` when the lock was acquired (and releases it
+on exit) and ``False`` when a non-blocking acquire failed (nothing to release).
+It never raises on lock-infrastructure errors: if flock is unavailable it
+fails OPEN (yields ``True``) so durability is never blocked by the lock itself.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from typing import Iterator
+
+if sys.platform != "win32":
+    import fcntl
+else:  # pragma: no cover - switchroom agents are Linux only
+    fcntl = None
+
+
+def lock_path() -> str:
+    """Path of the shared inflight lock. Override with ``HINDSIGHT_INFLIGHT_LOCK``."""
+    override = os.environ.get("HINDSIGHT_INFLIGHT_LOCK")
+    if override:
+        return override
+    return os.path.join(os.path.expanduser("~"), ".hindsight", "retain-inflight.lock")
+
+
+@contextlib.contextmanager
+def inflight_lock(blocking: bool = True) -> Iterator[bool]:
+    """Acquire the shared inflight lock.
+
+    Yields ``True`` if acquired (released on exit), ``False`` if a non-blocking
+    acquire could not get it. Fails OPEN (yields ``True``, no real lock) when
+    flock is unavailable so the durability path is never blocked by lock
+    infrastructure.
+    """
+    if fcntl is None:
+        yield True
+        return
+
+    path = lock_path()
+    d = os.path.dirname(path)
+    try:
+        if d and not os.path.isdir(d):
+            os.makedirs(d, mode=0o700, exist_ok=True)
+    except OSError:
+        # Can't even create the dir — fail open rather than block durability.
+        yield True
+        return
+
+    lock_fd = None
+    acquired = False
+    try:
+        lock_fd = open(path, "w")
+        flags = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+        try:
+            fcntl.flock(lock_fd, flags)
+            acquired = True
+        except OSError:
+            if blocking:
+                # A blocking acquire that errored (not a would-block) — fail
+                # open so batch work still makes progress.
+                acquired = True
+            else:
+                acquired = False
+        yield acquired
+    except OSError:
+        # Could not open the lock file at all — fail open.
+        yield True
+        return
+    finally:
+        if lock_fd is not None:
+            try:
+                if acquired:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            lock_fd.close()

--- a/vendor/hindsight-memory/scripts/lib/watermark.py
+++ b/vendor/hindsight-memory/scripts/lib/watermark.py
@@ -1,0 +1,213 @@
+"""Durable per-session retain watermark (switchroom #3244).
+
+Records, per ``(agent, session_id)``, the identity of the last transcript
+entry that has been *confirmed* committed to the Hindsight bank. This is the
+fact-on-disk that boot reconciliation (``reconcile_tail.py``) diffs against
+the surviving ``.jsonl`` transcript to recover work an abrupt session death
+(SIGKILL / OOM / watchdog) would otherwise silently drop.
+
+Design (design-20260715.md §1.1):
+
+* **Key = the message ``uuid`` of the last committed transcript entry.** Not
+  a turn ordinal (compaction re-indexes) and not a byte offset (shifts on
+  compaction); the ``uuid`` Claude Code stamps on every ``.jsonl`` entry is
+  stable across compaction and unambiguous. A ``byte_offset_hint`` is stored
+  as a fast-path only and never trusted alone.
+* **Advance ONLY on confirmed persistence.** ``commit()`` is called only after
+  a retain POST the caller made with commit-before-ack semantics
+  (``async_processing=False``) returned ok. A watermark that is *behind*
+  reality is safe (the reconciler re-POSTs, which upserts idempotently on the
+  deterministic ``document_id``); a watermark *ahead* of reality would skip
+  real work, so we never write it speculatively.
+* **Never moves backward.** ``commit()`` compares the incoming ``last_uuid``'s
+  position against the stored one *in the current transcript*; a stored uuid
+  that compaction removed is treated as stale (accept the incoming commit) —
+  a lost anchor can only cause a safe re-upsert, never a skip.
+* **Atomic + flock.** ``write tmp -> fsync -> os.replace`` under an exclusive
+  flock (mirrors ``lib/state.py`` / ``lib/pending.py``) so a concurrent async
+  Stop hook and a SessionEnd force-retain writing the same session serialize
+  and never observe a torn file.
+
+Location: ``$HOME/.hindsight/retained/<session_id>.json`` — same
+container-lifetime persistence semantics as ``pending-retains/``. Losing it on
+container recreate is safe: no watermark => the reconciler treats the bounded
+transcript tail as the gap and re-upserts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from typing import Optional
+
+if sys.platform != "win32":
+    import fcntl
+else:  # pragma: no cover - switchroom agents are Linux only
+    fcntl = None
+
+SCHEMA = 1
+
+
+def watermark_dir() -> str:
+    """Return the retained-watermark directory.
+
+    Override with ``HINDSIGHT_RETAINED_DIR`` (tests). Default:
+    ``$HOME/.hindsight/retained/``.
+    """
+    override = os.environ.get("HINDSIGHT_RETAINED_DIR")
+    if override:
+        return override
+    return os.path.join(os.path.expanduser("~"), ".hindsight", "retained")
+
+
+def _ensure_dir() -> str:
+    d = watermark_dir()
+    if not os.path.isdir(d):
+        os.makedirs(d, mode=0o700, exist_ok=True)
+    else:
+        try:
+            mode = os.stat(d).st_mode & 0o777
+            if mode != 0o700:
+                os.chmod(d, 0o700)
+        except OSError:
+            pass
+    return d
+
+
+def _safe_session(session_id: str) -> str:
+    """Sanitise a session id for use as a filename (no path traversal)."""
+    keep = [c if (c.isalnum() or c in "-_.") else "_" for c in (session_id or "unknown")]
+    name = "".join(keep)[:200]
+    # Never allow a name that resolves to a traversal component.
+    return name.replace("..", "_") or "unknown"
+
+
+def _path(session_id: str) -> str:
+    return os.path.join(watermark_dir(), f"{_safe_session(session_id)}.json")
+
+
+def _lock_path(session_id: str) -> str:
+    return os.path.join(watermark_dir(), f"{_safe_session(session_id)}.lock")
+
+
+def load(session_id: str) -> Optional[dict]:
+    """Return the stored watermark dict for ``session_id``, or ``None``."""
+    p = _path(session_id)
+    if not os.path.isfile(p):
+        return None
+    try:
+        with open(p, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _atomic_write(session_id: str, entry: dict) -> None:
+    d = _ensure_dir()
+    final = os.path.join(d, f"{_safe_session(session_id)}.json")
+    tmp = final + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(entry, f, ensure_ascii=False)
+        f.flush()
+        os.fsync(f.fileno())
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, final)
+
+
+def _would_regress(stored: Optional[dict], last_uuid: str, ordered_uuids) -> bool:
+    """True if committing ``last_uuid`` would move the watermark BACKWARD.
+
+    Uses the position of each uuid *in the current transcript* (``ordered_uuids``,
+    transcript order). Explicit stale-anchor branch (design §1.1): if the stored
+    ``last_uuid`` is not present in the current transcript it was compacted away
+    and cannot be positionally compared — treat the stored watermark as stale and
+    accept the incoming commit (never a skip, at worst a safe re-upsert).
+    """
+    if not stored:
+        return False
+    stored_uuid = stored.get("last_uuid")
+    if not stored_uuid or stored_uuid == last_uuid:
+        # No stored anchor, or an idempotent re-commit of the same anchor —
+        # neither is a backward move.
+        return False
+    if not ordered_uuids:
+        # Without transcript ordering we cannot prove regression; accept
+        # (safety leans toward re-upsert, never skip).
+        return False
+    try:
+        stored_idx = ordered_uuids.index(stored_uuid)
+    except ValueError:
+        # Stored anchor compacted away -> stale -> accept incoming.
+        return False
+    try:
+        incoming_idx = ordered_uuids.index(last_uuid)
+    except ValueError:
+        # Incoming uuid not in transcript (shouldn't happen); accept.
+        return False
+    # Regress only if the stored anchor is strictly AHEAD of the incoming one.
+    return stored_idx > incoming_idx
+
+
+def commit(
+    session_id: str,
+    last_uuid: str,
+    document_id: str,
+    transcript_path: str = "",
+    ordered_uuids=None,
+    byte_offset_hint: Optional[int] = None,
+) -> Optional[dict]:
+    """Advance the watermark for ``session_id`` to ``last_uuid``.
+
+    Refuses to move backward (see ``_would_regress``). Returns the persisted
+    watermark dict, or the existing one if the commit was a no-op (regression /
+    idempotent). Best-effort: a write failure returns ``None`` and never raises
+    — a successful retain must never be failed by a watermark write.
+
+    ``ordered_uuids`` is the list of transcript entry uuids in transcript order,
+    used for the monotonic comparison; the caller (retain / reconcile) has the
+    transcript in hand.
+    """
+    if not last_uuid:
+        # Nothing to anchor on (legacy/flat transcript with no uuids). We do
+        # not persist a uuid-less watermark: the reconciler falls back to
+        # treating the bounded tail as the gap, which upserts idempotently.
+        return None
+    lock_path = _lock_path(session_id)
+    entry = {
+        "schema": SCHEMA,
+        "session_id": session_id,
+        "last_uuid": last_uuid,
+        "last_document_id": document_id,
+        "committed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "transcript_path": transcript_path,
+    }
+    if byte_offset_hint is not None:
+        entry["byte_offset_hint"] = int(byte_offset_hint)
+
+    def _do() -> Optional[dict]:
+        stored = load(session_id)
+        if _would_regress(stored, last_uuid, ordered_uuids):
+            return stored
+        _atomic_write(session_id, entry)
+        return entry
+
+    if fcntl is not None:
+        try:
+            _ensure_dir()
+            lock_fd = open(lock_path, "w")
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                return _do()
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                lock_fd.close()
+        except OSError:
+            pass
+
+    # Fallback without lock (best-effort).
+    try:
+        return _do()
+    except OSError:
+        return None

--- a/vendor/hindsight-memory/scripts/reconcile_tail.py
+++ b/vendor/hindsight-memory/scripts/reconcile_tail.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Boot reconciliation of un-committed transcript tails (switchroom #3244 §1.3).
+
+The load-bearing guarantee. The `.jsonl` transcript survives *every* kind of
+session death (SIGKILL / OOM / watchdog / SIGTERM) because Claude Code writes it
+independent of any hook. This module runs at SessionStart, AFTER the
+pending-retains drain, and diffs the durable per-session watermark
+(``lib/watermark``) against the on-disk transcript tail: any human turns after
+the watermark that were never committed are retained here, BEFORE the new
+session starts — so the next ``recall``/``reflect`` sees work an abrupt kill
+would otherwise have silently dropped.
+
+Properties (design §1.3):
+
+* **Deterministic + idempotent.** Each slice is posted under the content-derived
+  ``document_id`` (``retain.slice_document_id``), so running reconcile twice over
+  an unchanged transcript upserts the identical documents. The watermark is
+  advanced only after a **confirmed** (``async_processing=False``) 200, so a
+  crash mid-reconcile re-does the same slice next boot, never skips it.
+* **Bounded, but NEVER silently truncating.** Three bounds — a lookback window
+  (``HINDSIGHT_RECONCILE_LOOKBACK_H``, 48h), a per-session turn cap
+  (``HINDSIGHT_RECONCILE_MAX_TURNS``, 200), and a wall-clock budget
+  (``HINDSIGHT_RECONCILE_BUDGET_S``, 4s) — keep boot cheap, but every bound
+  ENQUEUES the excluded remainder to ``pending-retains/`` (drained next boot)
+  rather than dropping it. A >48h idle-then-killed session, a >200-turn loss, or
+  an over-budget boot is recovered across one or more boots, not forgotten.
+* **Shared pacing.** Every inline POST goes through the shared
+  ``retain-inflight.lock`` (§1.5) so boot reconcile can never storm the daemon
+  alongside a live retain or a running backfill.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib import watermark
+from lib.bank import derive_bank_id
+from lib.client import HindsightClient
+from lib.config import debug_log, load_config
+from lib.content import _is_tool_result_only_user_message, slice_last_turns_by_user_boundary
+from lib.daemon import get_api_url
+from lib.pacing import inflight_lock
+from lib.pending import enqueue as pending_enqueue
+from retain import build_retain_payload, read_transcript
+
+
+def _lookback_seconds() -> float:
+    try:
+        return max(0.0, float(os.environ.get("HINDSIGHT_RECONCILE_LOOKBACK_H", "48"))) * 3600.0
+    except ValueError:
+        return 48 * 3600.0
+
+
+def _max_turns() -> int:
+    try:
+        return max(1, int(os.environ.get("HINDSIGHT_RECONCILE_MAX_TURNS", "200")))
+    except ValueError:
+        return 200
+
+
+def _budget_seconds() -> float:
+    try:
+        return max(0.5, float(os.environ.get("HINDSIGHT_RECONCILE_BUDGET_S", "4")))
+    except ValueError:
+        return 4.0
+
+
+def _enabled(config: dict) -> bool:
+    env = os.environ.get("HINDSIGHT_RECONCILE_ON_START")
+    if env is not None:
+        return env.strip().lower() in ("1", "true", "yes")
+    # Config flag (scaffold: memory.retain.reconcile_on_start), default on.
+    return bool(config.get("reconcileOnStart", True))
+
+
+def _transcripts_dir(hook_input: dict | None) -> str | None:
+    """Resolve the directory holding this agent's session ``.jsonl`` files.
+
+    Override with ``HINDSIGHT_TRANSCRIPTS_DIR`` (tests / explicit). Otherwise
+    derive the Claude ``projects/<project>/`` directory from the boot hook's
+    ``transcript_path``. Returns ``None`` when it can't be located (reconcile
+    then no-ops — never a crash).
+    """
+    override = os.environ.get("HINDSIGHT_TRANSCRIPTS_DIR")
+    if override:
+        return override
+    tpath = (hook_input or {}).get("transcript_path") or ""
+    if tpath:
+        d = os.path.dirname(os.path.abspath(tpath))
+        if os.path.isdir(d):
+            return d
+    return None
+
+
+def _human_turns(messages: list) -> int:
+    return sum(
+        1
+        for m in messages
+        if isinstance(m, dict) and m.get("role") == "user" and not _is_tool_result_only_user_message(m)
+    )
+
+
+def _tail_after(messages: list, last_uuid: str | None) -> list:
+    """Return the transcript entries AFTER the watermark anchor.
+
+    No watermark, or a stale anchor compaction removed → the whole transcript is
+    the gap (a safe re-upsert, never a skip).
+    """
+    if not last_uuid:
+        return list(messages)
+    for i, m in enumerate(messages):
+        if isinstance(m, dict) and m.get("uuid") == last_uuid:
+            return messages[i + 1:]
+    return list(messages)
+
+
+def _session_id_from_path(path: str) -> str:
+    return os.path.splitext(os.path.basename(path))[0]
+
+
+def reconcile(config: dict | None = None, hook_input: dict | None = None) -> dict:
+    """Diff watermarks vs transcript tails and recover un-committed work.
+
+    Returns a summary dict. Never raises — boot must not be broken by reconcile.
+    """
+    config = config or load_config()
+    summary = {
+        "scanned": 0,
+        "reconciled": 0,      # transcripts with an inline-posted gap
+        "posts_ok": 0,
+        "enqueued": 0,        # slices deferred to pending-retains (bounds/failure)
+        "skipped_clean": 0,
+        "disabled": False,
+    }
+    if not config.get("autoRetain"):
+        summary["disabled"] = True
+        return summary
+    if not _enabled(config):
+        summary["disabled"] = True
+        return summary
+
+    tdir = _transcripts_dir(hook_input)
+    if not tdir:
+        debug_log(config, "reconcile_tail: no transcripts dir resolved, skipping")
+        return summary
+
+    # Resolve the daemon WITHOUT starting it — session_start only calls us when
+    # the health check already passed. If it's unreachable, skip: the transcript
+    # stays on disk and the next boot reconciles (no loss).
+    def _dbg(*a):
+        debug_log(config, *a)
+
+    try:
+        api_url = get_api_url(config, debug_fn=_dbg, allow_daemon_start=False)
+        client = HindsightClient(
+            api_url,
+            config.get("hindsightApiToken"),
+            request_timeout_override=config.get("requestTimeoutSeconds"),
+        )
+    except (RuntimeError, ValueError) as e:
+        debug_log(config, f"reconcile_tail: daemon unavailable, skipping: {e}")
+        return summary
+
+    api_token = config.get("hindsightApiToken")
+    lookback = _lookback_seconds()
+    max_turns = _max_turns()
+    budget = _budget_seconds()
+    started = time.monotonic()
+    now = time.time()
+
+    transcripts = sorted(
+        glob.glob(os.path.join(tdir, "**", "*.jsonl"), recursive=True)
+        + glob.glob(os.path.join(tdir, "*.jsonl"))
+    )
+    # De-dup (the two globs can overlap) while keeping order.
+    seen = set()
+    transcripts = [p for p in transcripts if not (p in seen or seen.add(p))]
+
+    for path in transcripts:
+        summary["scanned"] += 1
+        session_id = _session_id_from_path(path)
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            continue
+        within_lookback = (now - mtime) <= lookback
+
+        messages = read_transcript(path)
+        if not messages:
+            continue
+        wm = watermark.load(session_id)
+        last_uuid = wm.get("last_uuid") if wm else None
+        tail = _tail_after(messages, last_uuid)
+        if _human_turns(tail) == 0:
+            summary["skipped_clean"] += 1
+            continue
+
+        synthetic_hook = {"session_id": session_id, "cwd": (hook_input or {}).get("cwd", "")}
+        bank_id = derive_bank_id(synthetic_hook, config)
+
+        # Out-of-lookback but with a real un-committed tail → do NOT drop it
+        # (design §1.3 tier ii): enqueue for a later boot, don't process inline.
+        # Over-budget → same treatment.
+        if not within_lookback or (time.monotonic() - started) > budget:
+            if _enqueue_slice(config, session_id, path, messages, tail, bank_id, api_url, api_token):
+                summary["enqueued"] += 1
+            continue
+
+        # Turn-cap split: process the most-recent MAX_TURNS human turns inline;
+        # enqueue the older remainder (never truncate).
+        recent = slice_last_turns_by_user_boundary(tail, max_turns)
+        if len(recent) < len(tail):
+            older = tail[: len(tail) - len(recent)]
+            if _human_turns(older) > 0 and _enqueue_slice(
+                config, session_id, path, messages, older, bank_id, api_url, api_token
+            ):
+                summary["enqueued"] += 1
+
+        posted = _post_inline(
+            config, client, session_id, path, messages, recent, bank_id, api_url, api_token
+        )
+        if posted == "ok":
+            summary["reconciled"] += 1
+            summary["posts_ok"] += 1
+        elif posted == "enqueued":
+            summary["enqueued"] += 1
+
+    debug_log(config, f"reconcile_tail summary: {summary}")
+    return summary
+
+
+def _post_inline(
+    config, client, session_id, path, all_messages, slice_messages, bank_id, api_url, api_token
+) -> str:
+    """POST one gap slice inline, advancing the watermark on confirmed persistence.
+
+    Returns "ok", "enqueued" (POST failed / lock busy → deferred), or "skip".
+    """
+    built = build_retain_payload(
+        config,
+        session_id,
+        slice_messages,
+        all_messages,
+        bank_id=bank_id,
+        api_url=api_url,
+        api_token=api_token,
+        retain_full_window=True,
+        document_id=None,  # deterministic content-derived id (§1)
+    )
+    if built is None:
+        return "skip"
+    payload = built["payload"]
+    document_id = built["document_id"]
+
+    with inflight_lock(blocking=True) as acquired:
+        if not acquired:  # pragma: no cover - blocking acquire fails open
+            pending_enqueue(payload, RuntimeError("reconcile lock unavailable"))
+            return "enqueued"
+        try:
+            client.retain(
+                bank_id=bank_id,
+                content=payload["content"],
+                document_id=document_id,
+                context=payload["context"],
+                metadata=payload["metadata"],
+                tags=payload["tags"],
+                timeout=15,
+                async_processing=False,
+            )
+        except Exception as e:
+            debug_log(config, f"reconcile_tail: inline POST failed, enqueuing: {e}")
+            pending_enqueue(payload, e)
+            return "enqueued"
+
+    try:
+        watermark.commit(
+            session_id,
+            built["last_uuid"],
+            document_id,
+            transcript_path=path,
+            ordered_uuids=built["ordered_uuids"],
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        debug_log(config, f"reconcile_tail: watermark commit skipped: {e}")
+    return "ok"
+
+
+def _enqueue_slice(config, session_id, path, all_messages, slice_messages, bank_id, api_url, api_token) -> bool:
+    """Build a payload for a slice and enqueue it to pending-retains (no POST)."""
+    built = build_retain_payload(
+        config,
+        session_id,
+        slice_messages,
+        all_messages,
+        bank_id=bank_id,
+        api_url=api_url,
+        api_token=api_token,
+        retain_full_window=True,
+        document_id=None,
+    )
+    if built is None:
+        return False
+    queued = pending_enqueue(built["payload"], RuntimeError("reconcile deferred (bound/budget)"))
+    if queued is None:
+        debug_log(config, "reconcile_tail: pending-retains full, could not enqueue remainder")
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    try:
+        s = reconcile()
+        print(f"[Hindsight] reconcile_tail: {s}", file=sys.stderr)
+    except Exception as e:
+        print(f"[Hindsight] reconcile_tail unexpected error: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/vendor/hindsight-memory/scripts/reconcile_tail.py
+++ b/vendor/hindsight-memory/scripts/reconcile_tail.py
@@ -212,17 +212,30 @@ def reconcile(config: dict | None = None, hook_input: dict | None = None) -> dic
             continue
 
         # Turn-cap split: process the most-recent MAX_TURNS human turns inline;
-        # enqueue the older remainder (never truncate).
+        # defer the OLDER remainder (never truncate).
         recent = slice_last_turns_by_user_boundary(tail, max_turns)
-        if len(recent) < len(tail):
+        did_split = len(recent) < len(tail)
+        if did_split and _human_turns(tail[: len(tail) - len(recent)]) > 0:
             older = tail[: len(tail) - len(recent)]
-            if _human_turns(older) > 0 and _enqueue_slice(
-                config, session_id, path, messages, older, bank_id, api_url, api_token
-            ):
+            if _enqueue_slice(config, session_id, path, messages, older, bank_id, api_url, api_token):
                 summary["enqueued"] += 1
 
+        # CRITICAL (switchroom #3244 F1/F2): when we split, the older remainder
+        # (which precedes `recent` in the transcript) is only DEFERRED — either
+        # enqueued for a later sync drain, or, if the enqueue failed, not stored
+        # at all. Either way it is NOT yet confirmed-persisted. The watermark is
+        # a single "last contiguously-committed entry" pointer, so advancing it
+        # to `recent`'s end (the transcript tail) would jump PAST the unconfirmed
+        # older remainder — and `_tail_after` would then never re-derive it,
+        # silently losing it if the drain drops (async) or the enqueue failed.
+        # So on a split we do NOT advance the watermark: the recent slice is
+        # upserted for immediate recall, but the anchor stays put and the next
+        # boot re-derives (and idempotently re-upserts) the whole tail until it
+        # fits the budget and is confirmed end-to-end. Redundant work in the
+        # rare >MAX_TURNS-loss case; never loss.
         posted = _post_inline(
-            config, client, session_id, path, messages, recent, bank_id, api_url, api_token
+            config, client, session_id, path, messages, recent, bank_id, api_url, api_token,
+            advance_watermark=not did_split,
         )
         if posted == "ok":
             summary["reconciled"] += 1
@@ -235,11 +248,18 @@ def reconcile(config: dict | None = None, hook_input: dict | None = None) -> dic
 
 
 def _post_inline(
-    config, client, session_id, path, all_messages, slice_messages, bank_id, api_url, api_token
+    config, client, session_id, path, all_messages, slice_messages, bank_id, api_url, api_token,
+    advance_watermark: bool = True,
 ) -> str:
     """POST one gap slice inline, advancing the watermark on confirmed persistence.
 
     Returns "ok", "enqueued" (POST failed / lock busy → deferred), or "skip".
+
+    ``advance_watermark=False`` (turn-cap split, #3244 F1/F2): the slice is
+    upserted for immediate recall but the watermark is NOT moved, because an
+    unconfirmed older remainder precedes this slice — advancing would jump past
+    it and risk silent loss. The next boot re-derives and idempotently
+    re-upserts.
     """
     built = build_retain_payload(
         config,
@@ -276,6 +296,9 @@ def _post_inline(
             debug_log(config, f"reconcile_tail: inline POST failed, enqueuing: {e}")
             pending_enqueue(payload, e)
             return "enqueued"
+
+    if not advance_watermark:
+        return "ok"
 
     try:
         watermark.commit(

--- a/vendor/hindsight-memory/scripts/retain.py
+++ b/vendor/hindsight-memory/scripts/retain.py
@@ -17,6 +17,7 @@ Exit codes:
   0 — always (graceful degradation on any error)
 """
 
+import hashlib
 import json
 import os
 import sys
@@ -24,6 +25,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from lib import watermark
 from lib.bank import derive_bank_id, ensure_bank_mission
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
@@ -32,6 +34,7 @@ from lib.content import (
     slice_last_turns_by_user_boundary,
 )
 from lib.daemon import get_api_url
+from lib.pacing import inflight_lock
 from lib.state import increment_turn_count, track_retention
 
 
@@ -41,7 +44,14 @@ def read_transcript(transcript_path: str) -> list:
     Claude Code transcript format nests messages:
       {type: "user", message: {role: "user", content: "..."}, uuid: "...", ...}
     Also supports flat format for testing:
-      {role: "user", content: "..."}
+      {role: "user", content: "...", uuid: "..."}
+
+    The per-entry ``uuid`` Claude Code stamps on every ``.jsonl`` line is
+    surfaced onto the returned message dict (switchroom #3244) so the
+    deterministic content-derived ``document_id`` and the durable retain
+    watermark can key on it. The uuid is stable across compaction and unique
+    per entry. Adding the key is inert for downstream formatting
+    (``lib/content`` reads only ``role``/``content``).
     """
     if not transcript_path or not os.path.isfile(transcript_path):
         return []
@@ -58,6 +68,12 @@ def read_transcript(transcript_path: str) -> list:
                     if entry.get("type") in ("user", "assistant"):
                         msg = entry.get("message", {})
                         if isinstance(msg, dict) and msg.get("role"):
+                            # Surface the transcript-entry uuid (nested format
+                            # carries it on the OUTER entry, not the message).
+                            uid = entry.get("uuid")
+                            if uid is not None and "uuid" not in msg:
+                                msg = dict(msg)
+                                msg["uuid"] = uid
                             messages.append(msg)
                     # Flat format (testing / future compatibility)
                     elif "role" in entry and "content" in entry:
@@ -121,6 +137,164 @@ def select_retain_window(
     # Full session: vendor full-session mode, OR a forced (SessionEnd) chunked
     # sweep. Retain all messages, always as a full window.
     return list(all_messages), True
+
+
+def _ordered_uuids(all_messages: list) -> list:
+    """Transcript-order list of entry uuids (skips entries without one)."""
+    out = []
+    for m in all_messages:
+        if isinstance(m, dict):
+            uid = m.get("uuid")
+            if uid:
+                out.append(uid)
+    return out
+
+
+def slice_document_id(session_id: str, messages_slice: list, transcript_text: str) -> str:
+    """Deterministic, content-derived retain ``document_id`` (switchroom #3244 §1).
+
+    ``{session_id}-r{start_uuid}-{end_uuid}`` from the FULL first/last transcript
+    entry uuids of the retained slice — NOT truncated (32+32 bits birthday-
+    collide across months of history and a collision is *silent loss*, not a
+    dup). Because the id is a pure function of *which turns* are retained, the
+    live Stop-hook path, boot reconciliation, and the PR2 backfill all compute
+    the IDENTICAL id for the same slice ⇒ they upsert on the daemon's
+    document_id key instead of double-storing. No wall clock, no randomness.
+
+    Fallback (legacy/flat transcripts with no per-entry uuid): a sha256 of the
+    formatted transcript content — still purely deterministic and convergent
+    across paths for identical content.
+    """
+    start = messages_slice[0].get("uuid") if messages_slice else None
+    end = messages_slice[-1].get("uuid") if messages_slice else None
+    if start and end:
+        return f"{session_id}-r{start}-{end}"
+    digest = hashlib.sha256((transcript_text or "").encode("utf-8")).hexdigest()[:32]
+    return f"{session_id}-r{digest}"
+
+
+def build_retain_payload(
+    config: dict,
+    session_id: str,
+    messages_to_retain: list,
+    all_messages: list,
+    *,
+    bank_id: str,
+    api_url,
+    api_token,
+    retain_full_window: bool = True,
+    document_id=None,
+) -> dict | None:
+    """Pure transcript → retain payload + deterministic id (switchroom #3244 §1.4).
+
+    NETWORK-FREE and MISSION-WRITE-FREE by contract: it formats the slice,
+    computes the deterministic content-derived ``document_id`` (unless one is
+    supplied, e.g. the full-session compaction-tracked id), and assembles the
+    exact kwargs ``client.retain()`` / the pending-retains drainer expect. It
+    issues NO HTTP and never touches ``ensure_bank_mission`` — so the boot
+    reconciler and the PR2 dry-run can import it and stay genuinely write-free.
+
+    Returns ``{payload, document_id, message_count, last_uuid, ordered_uuids,
+    transcript}`` or ``None`` when the slice formats to nothing.
+    """
+    retain_roles = config.get("retainRoles", ["user", "assistant"])
+    include_tool_calls = config.get("retainToolCalls", True)
+    transcript, message_count = prepare_retention_transcript(
+        messages_to_retain, retain_roles, retain_full_window, include_tool_calls=include_tool_calls
+    )
+    if not transcript:
+        return None
+
+    if document_id is None:
+        document_id = slice_document_id(session_id, messages_to_retain, transcript)
+
+    template_vars = {
+        "session_id": session_id,
+        "bank_id": bank_id,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "user_id": os.environ.get("HINDSIGHT_USER_ID", ""),
+    }
+
+    def _resolve_template(value: str) -> str:
+        for k, v in template_vars.items():
+            value = value.replace(f"{{{k}}}", v)
+        return value
+
+    raw_tags = config.get("retainTags", [])
+    if raw_tags:
+        tags = []
+        for original in raw_tags:
+            resolved = _resolve_template(original)
+            if ":" in resolved and resolved.split(":", 1)[1] == "":
+                continue
+            tags.append(resolved)
+        if not tags:
+            tags = None
+    else:
+        tags = None
+
+    metadata = {
+        "retained_at": template_vars["timestamp"],
+        "message_count": str(message_count),
+        "session_id": session_id,
+    }
+    for k, v in config.get("retainMetadata", {}).items():
+        metadata[k] = _resolve_template(str(v))
+
+    # Topic tagging (switchroom PR6a) — best-effort, never fails a build.
+    try:
+        from lib.gateway_ipc import extract_topic_from_prompt
+
+        topic_chat_id = None
+        topic_thread_id = None
+        for m in reversed(messages_to_retain):
+            if not isinstance(m, dict) or m.get("role") != "user":
+                continue
+            content = m.get("content")
+            text = content if isinstance(content, str) else (
+                next((p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text"), "")
+                if isinstance(content, list) else ""
+            )
+            c_id, t_id = extract_topic_from_prompt(text)
+            if c_id is not None:
+                topic_chat_id, topic_thread_id = c_id, t_id
+                break
+        if topic_chat_id is not None:
+            metadata["chat_id"] = topic_chat_id
+            if topic_thread_id is not None:
+                metadata["thread_id"] = topic_thread_id
+                aliases_json = os.environ.get("HINDSIGHT_TOPIC_ALIASES_JSON", "")
+                if aliases_json:
+                    try:
+                        aliases = json.loads(aliases_json)
+                        if isinstance(aliases, dict):
+                            inverse = {str(v): k for k, v in aliases.items()}
+                            alias = inverse.get(str(topic_thread_id))
+                            if alias:
+                                metadata["topic_alias"] = alias
+                    except (json.JSONDecodeError, ValueError, TypeError):
+                        pass
+    except Exception:
+        pass
+
+    payload = {
+        "api_url": api_url,
+        "api_token": api_token,
+        "bank_id": bank_id,
+        "content": transcript,
+        "document_id": document_id,
+        "context": config.get("retainContext", "claude-code"),
+        "metadata": metadata,
+        "tags": tags,
+    }
+    return {
+        "payload": payload,
+        "document_id": document_id,
+        "message_count": message_count,
+        "last_uuid": messages_to_retain[-1].get("uuid") if messages_to_retain else None,
+        "ordered_uuids": _ordered_uuids(all_messages),
+        "transcript": transcript,
+    }
 
 
 def run_retain(hook_input: dict, force: bool = False) -> dict:
@@ -211,17 +385,6 @@ def run_retain(hook_input: dict, force: bool = False) -> dict:
     else:
         debug_log(config, f"Full session retain: {len(all_messages)} messages")
 
-    # Format transcript
-    retain_roles = config.get("retainRoles", ["user", "assistant"])
-    include_tool_calls = config.get("retainToolCalls", True)
-    transcript, message_count = prepare_retention_transcript(
-        messages_to_retain, retain_roles, retain_full_window, include_tool_calls=include_tool_calls
-    )
-
-    if not transcript:
-        debug_log(config, "Empty transcript after formatting, skipping retain")
-        return {"status": "skipped", "reason": "empty transcript after formatting"}
-
     # Resolve API URL
     def _dbg(*a):
         debug_log(config, *a)
@@ -250,15 +413,18 @@ def run_retain(hook_input: dict, force: bool = False) -> dict:
     bank_id = derive_bank_id(hook_input, config)
     ensure_bank_mission(client, bank_id, config, debug_fn=_dbg)
 
-    # Document ID strategy:
-    # - Chunked mode: each chunk gets a timestamped document_id.
-    # - Full-session mode: uses session_id as base, but tracks message count
-    #   to detect compaction.  When Claude Code compacts the conversation the
-    #   transcript shrinks — if we kept the same document_id we'd overwrite the
-    #   pre-compaction document with a shorter one, losing context.  Instead we
-    #   increment a chunk counter so the old document is preserved.
+    # Document ID strategy (switchroom #3244 §1 — single deterministic namespace):
+    # - Chunked mode at retainEveryNTurns>1 (the deployed default): a
+    #   *content-derived* id computed from the slice's first/last transcript
+    #   uuids (``document_id=None`` lets build_retain_payload compute it). This
+    #   REPLACES the former wall-clock ``{session_id}-{time.time()*1000}`` id so
+    #   the live path, boot reconciliation, and the PR2 backfill all mint the
+    #   SAME id for the same turns ⇒ upsert, not duplicate.
+    # - Full-session mode / n==1: unchanged — a stable ``session_id`` base with
+    #   a compaction chunk counter so a shrinking transcript doesn't overwrite
+    #   the pre-compaction document with a shorter one.
     if retain_mode == "chunked" and retain_every_n > 1:
-        document_id = f"{session_id}-{int(time.time() * 1000)}"
+        document_id = None  # build_retain_payload computes the content-derived id
     else:
         chunk_index, compacted = track_retention(session_id, len(all_messages))
         if compacted:
@@ -270,135 +436,80 @@ def run_retain(hook_input: dict, force: bool = False) -> dict:
         # chunk 0 → plain session_id (backwards compatible with existing docs)
         document_id = session_id if chunk_index == 0 else f"{session_id}-c{chunk_index}"
 
-    # Resolve template variables in tags and metadata.
-    # Supported variables: {session_id}, {bank_id}, {timestamp}, {user_id}
-    template_vars = {
-        "session_id": session_id,
-        "bank_id": bank_id,
-        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "user_id": os.environ.get("HINDSIGHT_USER_ID", ""),
-    }
-
-    def _resolve_template(value: str) -> str:
-        for k, v in template_vars.items():
-            value = value.replace(f"{{{k}}}", v)
-        return value
-
-    # Tags from config with template resolution.
-    # Drop tags whose resolved form ends in an empty namespace part (e.g. "user:"
-    # when HINDSIGHT_USER_ID is unset). Tags without ':' are preserved as-is.
-    raw_tags = config.get("retainTags", [])
-    if raw_tags:
-        tags = []
-        for original in raw_tags:
-            resolved = _resolve_template(original)
-            if ":" in resolved and resolved.split(":", 1)[1] == "":
-                debug_log(config, f"Dropping tag '{original}' -> '{resolved}' (empty content after ':')")
-                continue
-            tags.append(resolved)
-        if not tags:
-            tags = None
-    else:
-        tags = None
-
-    # Metadata: merge built-in defaults with user-configured extras
-    metadata = {
-        "retained_at": template_vars["timestamp"],
-        "message_count": str(message_count),
-        "session_id": session_id,
-    }
-    for k, v in config.get("retainMetadata", {}).items():
-        metadata[k] = _resolve_template(str(v))
-
-    # Switchroom PR6a — topic tagging for supergroup-mode agents.
-    # Scan the messages we're retaining for the latest `<channel
-    # chat_id=... message_thread_id=...>` envelope and stamp the
-    # tuple into metadata. Downstream (recall.py) uses this to log
-    # active-vs-source topic for binding-failure analysis and to
-    # support hard-filter mode when an operator opts in.
-    #
-    # No-op for fleet-shared / DM topology where every inbound from
-    # this agent carries the same chat_id (or no chat envelope at all
-    # for interactive / cron-only sessions) — the metadata is added
-    # but doesn't change behaviour.
-    try:
-        from lib.gateway_ipc import extract_topic_from_prompt
-        topic_chat_id = None
-        topic_thread_id = None
-        # Walk in reverse — most recent user message is the authoritative
-        # "active topic" at retain time.
-        for m in reversed(messages_to_retain):
-            if not isinstance(m, dict) or m.get("role") != "user":
-                continue
-            content = m.get("content")
-            text = content if isinstance(content, str) else (
-                # Claude Code list-content shape: [{type:"text", text:"..."}, ...]
-                next((p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text"), "")
-                if isinstance(content, list) else ""
-            )
-            c_id, t_id = extract_topic_from_prompt(text)
-            if c_id is not None:
-                topic_chat_id, topic_thread_id = c_id, t_id
-                break
-        if topic_chat_id is not None:
-            metadata["chat_id"] = topic_chat_id
-            if topic_thread_id is not None:
-                metadata["thread_id"] = topic_thread_id
-                # Resolve alias from operator-injected env map.
-                aliases_json = os.environ.get("HINDSIGHT_TOPIC_ALIASES_JSON", "")
-                if aliases_json:
-                    try:
-                        aliases = json.loads(aliases_json)
-                        # aliases is {alias_name: thread_id_int_or_str}; build
-                        # the inverse lookup once.
-                        if isinstance(aliases, dict):
-                            inverse = {str(v): k for k, v in aliases.items()}
-                            alias = inverse.get(str(topic_thread_id))
-                            if alias:
-                                metadata["topic_alias"] = alias
-                    except (json.JSONDecodeError, ValueError, TypeError):
-                        pass  # malformed env is non-fatal
-    except Exception as e:
-        # Topic tagging is best-effort — never fail a retain over it.
-        debug_log(config, f"Topic tagging skipped: {e}")
-
-    debug_log(
-        config, f"Retaining to bank '{bank_id}', doc '{document_id}', {message_count} messages, {len(transcript)} chars"
+    # Build the payload via the shared, network-free seam (§1.4). This carries
+    # the deterministic id, connection info, formatted transcript, tags and
+    # metadata — sufficient to retry from a different process (drain_pending).
+    built = build_retain_payload(
+        config,
+        session_id,
+        messages_to_retain,
+        all_messages,
+        bank_id=bank_id,
+        api_url=api_url,
+        api_token=api_token,
+        retain_full_window=retain_full_window,
+        document_id=document_id,
     )
-    if tags:
-        debug_log(config, f"Tags: {tags}")
+    if built is None:
+        debug_log(config, "Empty transcript after formatting, skipping retain")
+        return {"status": "skipped", "reason": "empty transcript after formatting"}
 
-    # Build the full payload up-front so we can hand it to the pending-
-    # retains queue verbatim if the POST fails. The payload mirrors the
-    # client.retain() kwargs plus connection info (api_url, api_token)
-    # so the drainer can reconstruct the call from a different process.
-    payload = {
-        "api_url": api_url,
-        "api_token": api_token,
-        "bank_id": bank_id,
-        "content": transcript,
-        "document_id": document_id,
-        "context": config.get("retainContext", "claude-code"),
-        "metadata": metadata,
-        "tags": tags,
-    }
+    payload = built["payload"]
+    document_id = built["document_id"]
+    debug_log(
+        config,
+        f"Retaining to bank '{bank_id}', doc '{document_id}', {built['message_count']} messages",
+    )
 
-    # POST to Hindsight retain API
+    # POST to Hindsight retain API under the shared fleet pacing lock (§1.5) so
+    # at most one durability POST is in flight for this agent. The live Stop
+    # path acquires it NON-BLOCKING (turn latency must not regress): if a boot
+    # reconcile / backfill holds it, we do NOT wait — we return the failure
+    # payload so main() enqueues it and the next boot drain delivers it. A
+    # forced SessionEnd sweep waits (blocking) since it is the final flush.
+    with inflight_lock(blocking=force) as acquired:
+        if not acquired:
+            debug_log(config, "retain-inflight lock busy; deferring retain to pending-retains")
+            return {
+                "status": "failed",
+                "error": RuntimeError("retain-inflight lock busy; deferring to pending-retains"),
+                "payload": payload,
+            }
+        try:
+            # async_processing=False (§1.1): commit-before-ack so the 200 proves
+            # durable persistence before we advance the watermark. A bare async
+            # 200 (ack-of-receipt) must never mark unpersisted work committed.
+            response = client.retain(
+                bank_id=bank_id,
+                content=payload["content"],
+                document_id=document_id,
+                context=payload["context"],
+                metadata=payload["metadata"],
+                tags=payload["tags"],
+                timeout=15,
+                async_processing=False,
+            )
+        except Exception as e:
+            print(f"[Hindsight] Retain failed: {e}", file=sys.stderr)
+            return {"status": "failed", "error": e, "payload": payload}
+
+    debug_log(config, f"Retain response: {json.dumps(response)[:200]}")
+
+    # Advance the durable watermark ONLY after confirmed persistence (§1.1).
+    # Best-effort: a watermark write failure must never fail a landed retain —
+    # worst case the boot reconciler re-upserts the same slice idempotently.
     try:
-        response = client.retain(
-            bank_id=bank_id,
-            content=transcript,
-            document_id=document_id,
-            context=payload["context"],
-            metadata=metadata,
-            tags=tags,
-            timeout=15,
+        watermark.commit(
+            session_id,
+            built["last_uuid"],
+            document_id,
+            transcript_path=transcript_path,
+            ordered_uuids=built["ordered_uuids"],
         )
-        debug_log(config, f"Retain response: {json.dumps(response)[:200]}")
-        return {"status": "ok", "response": response}
-    except Exception as e:
-        print(f"[Hindsight] Retain failed: {e}", file=sys.stderr)
-        return {"status": "failed", "error": e, "payload": payload}
+    except Exception as e:  # pragma: no cover - defensive
+        debug_log(config, f"watermark commit skipped: {e}")
+
+    return {"status": "ok", "response": response}
 
 
 def main():
@@ -407,7 +518,42 @@ def main():
     except (json.JSONDecodeError, EOFError):
         print("[Hindsight] Failed to read hook input", file=sys.stderr)
         return
-    run_retain(hook_input, force=False)
+
+    # Close hole A2 (switchroom #3244): the Stop entrypoint used to discard
+    # run_retain's return value, so a failed per-turn retain (daemon busy /
+    # unreachable / lock-deferred) was silently dropped — never queued, never
+    # surfaced. Mirror session_end.py: on a failed retain WITH a payload,
+    # durably enqueue it to pending-retains so the next SessionStart drain
+    # replays it. The deterministic content-derived document_id (§1) means a
+    # queued entry and a later boot-reconcile entry for the same window collide
+    # on id ⇒ upsert, not duplicate — so no id rewrite is needed here.
+    #
+    # We keep exit 0: retain.py is registered as an async Stop hook (hooks.json)
+    # whose exit code Claude Code discards. Durability comes from the enqueue,
+    # not the exit code.
+    result = run_retain(hook_input, force=False) or {}
+    if result.get("status") == "failed" and result.get("payload"):
+        try:
+            from lib.pending import MAX_ENTRIES, count as pending_count, enqueue as pending_enqueue
+
+            err = result.get("error") or RuntimeError("stop retain failed")
+            queued = pending_enqueue(result["payload"], err)
+            if queued is None:
+                print(
+                    f"[Hindsight] pending-retains queue full ({MAX_ENTRIES} entries); "
+                    f"dropping this Stop retain. Operator: drain manually, then run "
+                    f"`switchroom doctor`.",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"[Hindsight] Stop retain failed: queued to pending-retains "
+                    f"(error: {type(err).__name__}: {err}, pending={pending_count()}). "
+                    f"Will retry on next SessionStart.",
+                    file=sys.stderr,
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            print(f"[Hindsight] Stop retain enqueue failed: {e}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/session_start.py
+++ b/vendor/hindsight-memory/scripts/session_start.py
@@ -88,6 +88,20 @@ def main():
         # this up via run-hook.sh — see exit-code path in __main__.
         debug_log(config, f"drain_pending unexpected error (ignored): {e}")
 
+    # Boot reconciliation (switchroom #3244): AFTER the drain, diff the durable
+    # per-session watermark against the on-disk transcript tail and recover any
+    # un-committed human turns an abrupt session death (SIGKILL / OOM /
+    # watchdog) skipped — the drain only replays what SessionEnd managed to
+    # enqueue, which an abrupt kill never runs. This is the load-bearing
+    # guarantee; it is naturally cheap (skips sessions with no gap) and bounded
+    # (lookback / turn-cap / wall-clock budget, each enqueuing its remainder).
+    try:
+        from reconcile_tail import reconcile as reconcile_tail
+
+        reconcile_tail(config, hook_input=hook_input)
+    except Exception as e:
+        debug_log(config, f"reconcile_tail unexpected error (ignored): {e}")
+
 
 if __name__ == "__main__":
     try:

--- a/vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py
+++ b/vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py
@@ -250,14 +250,21 @@ class TestForwardFix(DurabilityTestBase):
         self.assertIsNotNone(watermark.load(session))
         self.assertIn("user turn 2", self.daemon.content_blob())
 
-    # -- Test 10: a bound (200-turn cap) ENQUEUES the remainder -----------------
+    # -- Test 10: a bound (200-turn cap) ENQUEUES the remainder, no silent loss -
     def test_turn_cap_enqueues_remainder_never_truncates(self):
+        # Regression for F1/F2 (reviewer reproduced silent loss): the older
+        # remainder is delivered by the drain, which the daemon may 200-then-drop
+        # on an async post; if the watermark had advanced past the remainder,
+        # that drop would be permanent loss with no reconcile backstop. This test
+        # sets drop_async=True on the drain path — it must still land durably
+        # (drain now posts commit-before-ack) AND the watermark must NOT have
+        # jumped past the un-confirmed remainder after the capped reconcile.
         session = "sessE"
         tpath = os.path.join(self.transcripts, f"{session}.jsonl")
         _write_transcript(tpath, 6, session_prefix=session)
         hook = {"session_id": session, "transcript_path": tpath, "cwd": "/x"}
 
-        # Cap the boot reconcile at 2 human turns; the other 4 must be enqueued,
+        # Cap the boot reconcile at 2 human turns; the other 4 must be deferred,
         # not dropped.
         with mock.patch.dict(os.environ, {"HINDSIGHT_RECONCILE_MAX_TURNS": "2"}):
             reconcile_tail.reconcile(self._config(), hook_input=hook)
@@ -266,10 +273,17 @@ class TestForwardFix(DurabilityTestBase):
         blob = self.daemon.content_blob()
         self.assertIn("user turn 5", blob)
         self.assertIn("user turn 4", blob)
-        # ... and the older remainder is ENQUEUED (not lost).
+        # ... the older remainder is ENQUEUED (not lost) ...
         self.assertEqual(len(self._pending_entries()), 1)
+        # ... and the watermark did NOT advance past the un-confirmed remainder
+        # (F2): it must not sit at the transcript end. With no prior watermark
+        # and a split, no watermark is written at all.
+        wm = watermark.load(session)
+        self.assertTrue(wm is None or wm["last_uuid"] != f"{session}-a5")
 
-        # A subsequent boot drains the remainder → older turns land too.
+        # An adversarial daemon that DROPS async extractions (the #3244 hazard):
+        # the drain must still persist the remainder durably (commit-before-ack).
+        self.daemon.drop_async = True
         from drain_pending import drain
         drain(self._config())
         blob2 = self.daemon.content_blob()

--- a/vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py
+++ b/vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py
@@ -1,0 +1,336 @@
+"""Switchroom #3244 — durable-retain / boot-reconciliation outcome tests.
+
+Stdlib-only (`python3 -m unittest discover tests/`). Every test drives the real
+hook code against a FAKE in-process daemon (no network, no LLM) and asserts
+OUTCOMES — content landed in the bank / entries landed in the pending queue /
+the watermark's value — not merely that a code path ran.
+
+Covers the PR1 slice of design-20260715.md §4: tests 1 (SIGKILL→boot recall),
+2 (failed Stop retain enqueued), 3 (live-Stop + reconcile ⇒ ONE doc via the
+single deterministic id), 6 (watermark monotonicity + uuid-not-found), 7
+(200-not-persisted / commit-before-ack), 9 (dry-run/seam zero writes), 10 (a
+bound ENQUEUES the remainder).
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import reconcile_tail  # noqa: E402
+import retain  # noqa: E402
+from lib import watermark  # noqa: E402
+from lib.client import HindsightClient  # noqa: E402
+
+
+class FakeDaemon:
+    """Records retained documents by document_id with upsert semantics.
+
+    ``fail`` → every POST raises (stressed/unreachable daemon).
+    ``drop_async`` → an ``async_processing=True`` POST 200s but does NOT persist
+    (ack-of-receipt, extraction lost) — the #3244 async-200 hazard. An
+    ``async_processing=False`` POST always persists (commit-before-ack).
+    """
+
+    def __init__(self):
+        self.docs = {}          # document_id -> {content, metadata, async}
+        self.posts = []         # [(document_id, async_processing)]
+        self.fail = False
+        self.drop_async = False
+
+    def retain(self, bank_id, content, document_id="conversation", context=None,
+               metadata=None, tags=None, timeout=15, async_processing=True):
+        self.posts.append((document_id, async_processing))
+        if self.fail:
+            raise RuntimeError("simulated daemon failure")
+        persisted = (not async_processing) or (not self.drop_async)
+        if persisted:
+            # Upsert: same document_id overwrites (the daemon contract §1).
+            self.docs[document_id] = {
+                "content": content, "metadata": metadata, "async": async_processing,
+            }
+        return {"ok": True}
+
+    # Any content substring present across all stored docs?
+    def content_blob(self):
+        return "\n".join(d["content"] for d in self.docs.values())
+
+
+def _write_transcript(path, n_turns, session_prefix="u"):
+    """Flat-format JSONL: n_turns human turns (user+assistant), each with a uuid."""
+    lines = []
+    for i in range(n_turns):
+        lines.append(json.dumps({"role": "user", "content": f"user turn {i}", "uuid": f"{session_prefix}-u{i}"}))
+        lines.append(json.dumps({"role": "assistant", "content": f"assistant turn {i}", "uuid": f"{session_prefix}-a{i}"}))
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+class DurabilityTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="hs-3244-")
+        self.plugin_root = os.path.join(self.tmp, "plugin_root")
+        self.home = os.path.join(self.tmp, "home")
+        self.data = os.path.join(self.tmp, "data")
+        self.transcripts = os.path.join(self.tmp, "transcripts")
+        for d in (self.plugin_root, self.home, self.data, self.transcripts):
+            os.makedirs(d)
+
+        # chunked + n=3 → the deployed default, which exercises the
+        # content-derived document_id path (§1). bankMission empty → no mission
+        # PATCH. autoRetain on.
+        settings = {
+            "autoRetain": True,
+            "autoRecall": True,
+            "retainMode": "chunked",
+            "retainEveryNTurns": 3,
+            "retainOverlapTurns": 0,
+            "bankId": "test-bank",
+            "reconcileOnStart": True,
+        }
+        with open(os.path.join(self.plugin_root, "settings.json"), "w") as f:
+            json.dump(settings, f)
+
+        self.env = mock.patch.dict(os.environ, {
+            "CLAUDE_PLUGIN_ROOT": self.plugin_root,
+            "CLAUDE_PLUGIN_DATA": self.data,
+            "HOME": self.home,
+            "HINDSIGHT_PENDING_DIR": os.path.join(self.home, ".hindsight", "pending-retains"),
+            "HINDSIGHT_RETAINED_DIR": os.path.join(self.home, ".hindsight", "retained"),
+            "HINDSIGHT_INFLIGHT_LOCK": os.path.join(self.home, ".hindsight", "retain-inflight.lock"),
+            "HINDSIGHT_TRANSCRIPTS_DIR": self.transcripts,
+        }, clear=False)
+        self.env.start()
+        for k in list(os.environ):
+            if k.startswith("HINDSIGHT_") and k not in (
+                "HINDSIGHT_PENDING_DIR", "HINDSIGHT_RETAINED_DIR",
+                "HINDSIGHT_INFLIGHT_LOCK", "HINDSIGHT_TRANSCRIPTS_DIR",
+            ):
+                os.environ.pop(k, None)
+
+        self.daemon = FakeDaemon()
+        self._patches = [
+            mock.patch.object(HindsightClient, "retain", self._fake_retain),
+            mock.patch("retain.get_api_url", return_value="http://fake"),
+            mock.patch("reconcile_tail.get_api_url", return_value="http://fake"),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def _fake_retain(self, *a, **kw):
+        return self.daemon.retain(*a, **kw)
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self.env.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _config(self):
+        from lib.config import load_config
+        return load_config()
+
+    def _pending_entries(self):
+        from lib import pending
+        return pending.iter_entries()
+
+
+class TestForwardFix(DurabilityTestBase):
+    # -- Test 1: SIGKILL-after-work → next-boot reconcile surfaces it -----------
+    def test_sigkill_then_boot_reconcile_recovers_all_turns(self):
+        session = "sessA"
+        tpath = os.path.join(self.transcripts, f"{session}.jsonl")
+        _write_transcript(tpath, 5, session_prefix=session)
+        hook = {"session_id": session, "transcript_path": tpath, "cwd": "/x"}
+
+        # (b) Stop retains fire but the daemon REFUSES them. run via main() so
+        # the A2 enqueue path is exercised.
+        self.daemon.fail = True
+        with mock.patch("retain.increment_turn_count", return_value=3), \
+             mock.patch("sys.stdin", _stdin(hook)):
+            retain.main()
+
+        # watermark did NOT advance (no confirmed persistence) ...
+        self.assertIsNone(watermark.load(session))
+        # ... and the failed Stop retain was ENQUEUED, not dropped (A2).
+        self.assertEqual(len(self._pending_entries()), 1)
+
+        # (c) No SessionEnd fires (abrupt kill). (d) Boot against a healthy daemon.
+        self.daemon.fail = False
+        reconcile_tail.reconcile(self._config(), hook_input=hook)
+
+        # OUTCOME: all 5 turns' content is now in the bank.
+        blob = self.daemon.content_blob()
+        for i in range(5):
+            self.assertIn(f"user turn {i}", blob)
+        # And the watermark now anchors on the last committed entry.
+        wm = watermark.load(session)
+        self.assertIsNotNone(wm)
+        self.assertEqual(wm["last_uuid"], f"{session}-a4")
+
+    # -- Test 2: failed Stop retain is enqueued, not dropped --------------------
+    def test_failed_stop_retain_enqueued_with_deterministic_id(self):
+        session = "sessB"
+        tpath = os.path.join(self.transcripts, f"{session}.jsonl")
+        _write_transcript(tpath, 3, session_prefix=session)
+        hook = {"session_id": session, "transcript_path": tpath, "cwd": "/x"}
+
+        self.daemon.fail = True
+        with mock.patch("retain.increment_turn_count", return_value=3), \
+             mock.patch("sys.stdin", _stdin(hook)):
+            retain.main()
+
+        entries = self._pending_entries()
+        self.assertEqual(len(entries), 1)
+        _, entry = entries[0]
+        # The queued payload carries the deterministic content-derived id.
+        self.assertTrue(entry["document_id"].startswith(f"{session}-r"))
+        self.assertIn(f"{session}-u", entry["document_id"])  # full uuids, not 8-char
+
+        # Drain against a healthy daemon delivers it and deletes the entry.
+        self.daemon.fail = False
+        from drain_pending import drain
+        drain(self._config())
+        self.assertEqual(len(self._pending_entries()), 0)
+        self.assertIn(entry["document_id"], self.daemon.docs)
+
+    # -- Test 3 (rewritten): live Stop + reconcile of same window ⇒ ONE doc -----
+    def test_live_stop_and_reconcile_converge_on_single_document(self):
+        session = "sessC"
+        tpath = os.path.join(self.transcripts, f"{session}.jsonl")
+        _write_transcript(tpath, 3, session_prefix=session)  # window(3) == whole transcript
+        hook = {"session_id": session, "transcript_path": tpath, "cwd": "/x"}
+
+        # Live Stop retain — writes the content-derived id, advances watermark.
+        with mock.patch("retain.increment_turn_count", return_value=3), \
+             mock.patch("sys.stdin", _stdin(hook)):
+            retain.main()
+        self.assertEqual(len(self.daemon.docs), 1)
+        live_id = self.daemon.posts[0][0]
+        self.assertTrue(live_id.startswith(f"{session}-r"))
+
+        # Simulate a watermark loss (container recreate) so reconcile RE-posts
+        # the same window — proving the two paths collide on document_id.
+        os.remove(os.path.join(os.environ["HINDSIGHT_RETAINED_DIR"], f"{session}.json"))
+        reconcile_tail.reconcile(self._config(), hook_input=hook)
+
+        # Two POSTs, identical id, still exactly ONE stored document (upsert).
+        self.assertEqual(len(self.daemon.docs), 1)
+        self.assertEqual(self.daemon.posts[-1][0], live_id)
+
+    # -- Test 7: commit-before-ack; 200-not-persisted doesn't advance watermark -
+    def test_durability_posts_are_synchronous_and_gate_the_watermark(self):
+        session = "sessD"
+        tpath = os.path.join(self.transcripts, f"{session}.jsonl")
+        _write_transcript(tpath, 3, session_prefix=session)
+        hook = {"session_id": session, "transcript_path": tpath, "cwd": "/x"}
+
+        # A failing durability POST must NOT advance the watermark ...
+        self.daemon.fail = True
+        with mock.patch("retain.increment_turn_count", return_value=3), \
+             mock.patch("sys.stdin", _stdin(hook)):
+            retain.main()
+        self.assertIsNone(watermark.load(session))
+
+        # ... and every durability POST is async_processing=False (commit-before
+        # -ack), so a bare async-200 can never falsely mark work committed.
+        self.assertTrue(self.daemon.posts, "expected at least one durability POST")
+        self.assertTrue(all(async_flag is False for _, async_flag in self.daemon.posts))
+
+        # Next boot re-catches the turns and advances the watermark.
+        self.daemon.fail = False
+        reconcile_tail.reconcile(self._config(), hook_input=hook)
+        self.assertIsNotNone(watermark.load(session))
+        self.assertIn("user turn 2", self.daemon.content_blob())
+
+    # -- Test 10: a bound (200-turn cap) ENQUEUES the remainder -----------------
+    def test_turn_cap_enqueues_remainder_never_truncates(self):
+        session = "sessE"
+        tpath = os.path.join(self.transcripts, f"{session}.jsonl")
+        _write_transcript(tpath, 6, session_prefix=session)
+        hook = {"session_id": session, "transcript_path": tpath, "cwd": "/x"}
+
+        # Cap the boot reconcile at 2 human turns; the other 4 must be enqueued,
+        # not dropped.
+        with mock.patch.dict(os.environ, {"HINDSIGHT_RECONCILE_MAX_TURNS": "2"}):
+            reconcile_tail.reconcile(self._config(), hook_input=hook)
+
+        # Inline landed the most-recent 2 turns ...
+        blob = self.daemon.content_blob()
+        self.assertIn("user turn 5", blob)
+        self.assertIn("user turn 4", blob)
+        # ... and the older remainder is ENQUEUED (not lost).
+        self.assertEqual(len(self._pending_entries()), 1)
+
+        # A subsequent boot drains the remainder → older turns land too.
+        from drain_pending import drain
+        drain(self._config())
+        blob2 = self.daemon.content_blob()
+        for i in range(6):
+            self.assertIn(f"user turn {i}", blob2)
+
+    # -- Test 9 (seam): build_retain_payload is network- and mission-write-free -
+    def test_build_retain_payload_is_write_free(self):
+        session = "sessF"
+        tpath = os.path.join(self.transcripts, f"{session}.jsonl")
+        _write_transcript(tpath, 2, session_prefix=session)
+        msgs = retain.read_transcript(tpath)
+
+        def _boom(*a, **kw):
+            raise AssertionError("build_retain_payload must not touch the network")
+
+        with mock.patch.object(HindsightClient, "retain", _boom), \
+             mock.patch.object(HindsightClient, "set_bank_mission", _boom):
+            built = retain.build_retain_payload(
+                self._config(), session, msgs, msgs,
+                bank_id="test-bank", api_url="http://fake", api_token=None,
+            )
+        self.assertIsNotNone(built)
+        self.assertTrue(built["document_id"].startswith(f"{session}-r"))
+        self.assertEqual(built["last_uuid"], f"{session}-a1")
+        # No POST reached the daemon.
+        self.assertEqual(self.daemon.posts, [])
+
+
+class TestWatermark(DurabilityTestBase):
+    # -- Test 6: monotonicity + uuid-not-found branch --------------------------
+    def test_watermark_never_regresses_and_handles_stale_anchor(self):
+        session = "wm1"
+        ordered = ["e0", "e1", "e2", "e3"]
+        watermark.commit(session, "e2", "doc-e2", ordered_uuids=ordered)
+        self.assertEqual(watermark.load(session)["last_uuid"], "e2")
+
+        # Backward move refused (e1 is before e2).
+        watermark.commit(session, "e1", "doc-e1", ordered_uuids=ordered)
+        self.assertEqual(watermark.load(session)["last_uuid"], "e2")
+
+        # Forward move accepted.
+        watermark.commit(session, "e3", "doc-e3", ordered_uuids=ordered)
+        self.assertEqual(watermark.load(session)["last_uuid"], "e3")
+
+        # uuid-not-found branch: the stored anchor was compacted away — accept
+        # the incoming commit rather than crash/mis-compare.
+        compacted_order = ["c0", "c1"]
+        got = watermark.commit(session, "c1", "doc-c1", ordered_uuids=compacted_order)
+        self.assertIsNotNone(got)
+        self.assertEqual(watermark.load(session)["last_uuid"], "c1")
+
+    def test_watermark_ignores_empty_uuid(self):
+        self.assertIsNone(watermark.commit("wm2", "", "doc", ordered_uuids=[]))
+        self.assertIsNone(watermark.load("wm2"))
+
+
+def _stdin(obj):
+    import io
+    return io.StringIO(json.dumps(obj))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/tests/test_hooks.py
+++ b/vendor/hindsight-memory/tests/test_hooks.py
@@ -801,7 +801,13 @@ class TestRetainHook:
         # Should not raise
         _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=raise_error)
 
-    def test_retain_posts_async_true(self, monkeypatch, tmp_path):
+    def test_retain_durability_post_is_commit_before_ack(self, monkeypatch, tmp_path):
+        # Switchroom #3244 §1.1: the Stop-hook durability retain now POSTs with
+        # ``async=false`` (commit-before-ack) so the 200 proves durable
+        # persistence before the watermark advances — a bare async-200
+        # (ack-of-receipt) must never mark unpersisted work committed. This
+        # replaces the former ``async: true`` assertion (the deliberate
+        # behaviour change; other, non-watermark callers still default async).
         messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
         transcript = make_transcript_file(tmp_path, messages)
         hook_input = make_hook_input(transcript_path=transcript)
@@ -815,7 +821,7 @@ class TestRetainHook:
         _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
 
         if "body" in captured:
-            assert captured["body"].get("async") is True
+            assert captured["body"].get("async") is False
 
     def test_retain_includes_context_label(self, monkeypatch, tmp_path):
         messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]


### PR DESCRIPTION
## Summary

PR1 of 2 for #3244 — stop Hindsight silently dropping work from abruptly-ended
sessions (SIGKILL / OOM / watchdog kill / gateway SIGTERM). **Forward fix only;
the one-time backfill is PR2 and is gated (below).** Builds the revised design
`design-20260715.md` §1–§1.5, §4, §5.

## Why

The `.jsonl` transcript survives every kind of session death (Claude Code writes
it independent of any hook), but retain durability depended on a graceful
SessionEnd that an abrupt kill skips, a per-turn Stop hook that silently
swallowed its own POST failures, and a boot path that only drained a queue —
never reconciled the transcript. When those holes lined up, an entire session's
work vanished with a clean recall (the clerk 2026-07-11 loss).

Job spec: this advances "always available" / memory-survives-restart
(`reference/jobs`), the same outcome the `jtbd-memory-survives-restart` UAT
guards.

## Three holes closed

- **A2 (silent drop).** `retain.py:main()` now ENQUEUES the failure payload it
  already builds (mirrors `session_end.py`) instead of discarding it.
- **B1 + C (no jsonl-tail reconciliation).** New `reconcile_tail.py` runs at
  SessionStart *after* the drain: it diffs a durable per-session watermark
  against the on-disk transcript tail and retains any un-committed human turns
  before the new session starts. This is the load-bearing guarantee; A2/B1 are
  defense-in-depth.
- **Duplicate-namespace id.** The live chunked-`n>1` path drops the wall-clock
  `{session_id}-{time.time()*1000}` id for the content-derived
  `{session_id}-r{start_uuid}-{end_uuid}` (FULL uuids) that reconcile and the
  PR2 backfill also compute — one id namespace, so any two writes of the same
  turn-slice upsert instead of double-storing.

## Also in scope

- `lib/watermark.py` — atomic (tmp+fsync+rename) + flock, advances ONLY on
  confirmed persistence, never regresses, explicit uuid-not-found (compaction)
  branch.
- `build_retain_payload()` — network-free, mission-write-free seam reused by
  reconcile (and PR2 dry-run).
- Shared `retain-inflight.lock` pacing — non-blocking for the live path so turn
  latency never regresses; blocking for boot reconcile.
- `client.retain(async_processing=False)` commit-before-ack on durability
  paths, so a bare async-200 (ack-of-receipt) can never falsely advance the
  watermark.
- Honest bounds — 48h lookback / 200-turn cap / 4s budget each ENQUEUE the
  remainder rather than truncate. No silent loss of any turn written to disk
  (modulo the documented ≤1-turn torn-tail residual, design §3).

## Merge preconditions still open (do NOT merge until resolved)

1. **Empirical daemon upsert-on-`document_id` probe** (throwaway bank: POST same
   id twice with different content, assert ONE doc reflecting the second write).
   The whole single-id dedup — including the live throttle-edge re-fire — relies
   on it.
2. **`async=false` commit-before-ack probe** (assert the doc is queryable the
   instant the sync POST returns).
3. This is **PR1 of 2**. The backfill (PR2) is hard-gated on #1, on this PR's
   single-id redesign, and on a Ken-reviewed fleet dry-run before `--commit`.

## Test plan

`vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py` — fake
in-process daemon, no network, asserts outcomes:
SIGKILL→boot-reconcile recovers all 5 turns; failed Stop retain enqueued (not
dropped); live-Stop + reconcile of the same window ⇒ ONE document (single-id
fix); commit-before-ack gates the watermark (200-not-persisted doesn't advance);
turn-cap ENQUEUES the remainder; `build_retain_payload` is write-free; watermark
monotonicity + stale-anchor.

Local (scoped): `python3 -m unittest discover tests/` from
`vendor/hindsight-memory/scripts` → **256 pass** (CI-authoritative path). The
vendor-root `tests/` set → **229 pass** (one assertion updated to the new
commit-before-ack contract). No Python linter is configured in-repo.

## Risk

Blast radius of the id change is contained to `retain.py:260-261` (the only
wall-clock-id site; the full-session/`n==1` stable-id path is unchanged). Live
throughput unaffected except the durability POST is now synchronous on the
async-registered Stop hook (off the user's critical path). Notable deviation:
the `memory.retain.reconcile_on_start` YAML surface in `scaffold.ts` was
deferred — the knob is fully functional and defaults ON via config /
`HINDSIGHT_RECONCILE_ON_START`, and wiring it through the byte-identical
settings.json reconcile invariant risked destabilising the TS suite for no
behavioural gain in PR1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)