### PR TITLE
feat(hindsight): one-time transcript backfill to recover pre-fix misses (#3244)

### DIFF
--- a/vendor/hindsight-memory/scripts/backfill_transcripts.py
+++ b/vendor/hindsight-memory/scripts/backfill_transcripts.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+"""One-time backfill of transcript work already missing from Hindsight banks.
+
+switchroom #3244 Part 2 (design-20260715.md). Recovers work an abrupt session
+death silently dropped BEFORE the forward fix (PR1) shipped — e.g. clerk's
+2026-07-11 planner sessions whose Stop-hook retains were discarded and never
+reconciled. This is a standalone, operator-run CLI, NOT runtime code: it scans
+every agent's on-disk ``.jsonl`` transcripts (which survive every kind of
+death) and re-POSTs anything missing from the bank, paced and resumable.
+
+**Reuse, not fork (design Part 2).** It imports PR1's seams verbatim — the
+deterministic content-derived ``document_id`` (``retain.slice_document_id`` via
+``build_retain_payload``), the durable watermark, the shared inflight pacing
+lock, and the pending-retains layout. The backfill is "run the boot reconciler
+over ALL history for ALL agents, paced, resumable, with a dry-run."
+
+Guarantees, all resting on daemon contracts CONFIRMED against hindsight
+v0.18.24 (daemon-contract-20260715.md):
+
+* **Dedup by deterministic document_id + daemon UPSERT.** Every slice is posted
+  under ``{session_id}-r{start_uuid}-{end_uuid}`` — a pure function of *which
+  turns* it holds. The daemon UPSERTs on ``(id, bank_id)``
+  (``ops_postgresql.py:63-69`` ``ON CONFLICT DO UPDATE``; full-replace of
+  derived memories, ``fact_storage.py:334-360``) and short-circuits an
+  identical re-post on ``content_hash``. So re-deriving ids across history — and
+  colliding with anything the live path already wrote for the SAME slice —
+  upserts to ONE document, never a duplicate. No separate existence query
+  needed for the total-loss case.
+* **Never-storm pacing (HARD).** Strictly serial — one ``client.retain()`` in
+  flight at a time, fleet-wide, via PR1's shared ``retain-inflight.lock``
+  (acquired blocking around every POST) plus a backfill-only ``backfill.lock``
+  "one backfill process at a time" mutex. A deterministic ~1.5s inter-POST
+  delay, exponential backoff (cap 60s) + a circuit-breaker cooldown on repeated
+  failure, and session-granular slicing bound the downstream LLM extractor.
+  Every POST uses ``async_processing=False`` (commit-before-ack) so each write
+  is durably confirmed before the next is issued.
+* **Dry-run is the DEFAULT and is genuinely ZERO-write.** Without ``--commit``
+  the tool calls ONLY ``build_retain_payload`` (network-free, mission-write-
+  free by contract) and reports what it WOULD recover: zero retain POSTs, zero
+  ``set_bank_mission`` PATCHes. An operator reviews the blast radius before
+  committing per agent.
+* **Resumable.** Per-``(agent, session)`` progress in
+  ``~/.hindsight/backfill-progress.json`` (advanced to ``done`` only after ALL
+  of a session's slices are confirmed persisted). Kill it anywhere and re-run:
+  completed sessions are skipped, an in-progress session re-does its current
+  slices (safe upsert), no duplicates.
+
+Classification (design Part 2 dedup redesign):
+
+* **No live watermark for the session** ⇒ true-total-loss (the clerk case) —
+  post it in full.
+* **Has a live watermark** ⇒ partially retained by the live path, whose slice
+  boundaries may differ from the backfill's, so an id-collision is not
+  guaranteed. The vendored client exposes no per-document existence query, so
+  the conservative default is to **SKIP and report for manual review** rather
+  than risk a partial-overlap duplicate. (Total-loss recovery is the backfill's
+  real job; partial sessions are already served by the live path + boot
+  reconcile.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+import time
+from typing import Callable, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib import watermark
+from lib.bank import derive_bank_id
+from lib.client import HindsightClient
+from lib.config import debug_log, load_config
+from lib.content import _is_tool_result_only_user_message
+from lib.daemon import get_api_url
+from lib.pacing import inflight_lock
+from retain import build_retain_payload, read_transcript
+
+# Injectable sleep so tests assert pacing via a fake clock, not wall time.
+_SLEEP: Callable[[float], None] = time.sleep
+
+
+# --------------------------------------------------------------------------- #
+# Config knobs (env-overridable, mirroring the HINDSIGHT_DRAIN_* convention).
+# --------------------------------------------------------------------------- #
+def _delay_ms(override: Optional[int] = None) -> float:
+    if override is not None:
+        return max(0, override)
+    try:
+        return max(0, int(os.environ.get("HINDSIGHT_BACKFILL_DELAY_MS", "1500")))
+    except ValueError:
+        return 1500
+
+
+def _slice_turns(override: Optional[int] = None) -> int:
+    if override is not None:
+        return max(1, override)
+    try:
+        return max(1, int(os.environ.get("HINDSIGHT_BACKFILL_SLICE_TURNS", "40")))
+    except ValueError:
+        return 40
+
+
+def _cooldown_s() -> float:
+    try:
+        return max(1.0, float(os.environ.get("HINDSIGHT_BACKFILL_COOLDOWN_S", "120")))
+    except ValueError:
+        return 120.0
+
+
+_STALL_THRESHOLD = 3          # consecutive failures → circuit-breaker cooldown
+_BACKOFF_CAP_S = 60.0         # exponential backoff ceiling
+
+
+def agents_dir() -> str:
+    """Root holding every agent's scaffold. Override with ``HINDSIGHT_AGENTS_DIR``."""
+    override = os.environ.get("HINDSIGHT_AGENTS_DIR")
+    if override:
+        return override
+    return os.path.join(os.path.expanduser("~"), ".switchroom", "agents")
+
+
+# --------------------------------------------------------------------------- #
+# Resumable per-(agent, session) progress store.
+# --------------------------------------------------------------------------- #
+def progress_path() -> str:
+    """Path of the backfill progress JSON. Override with ``HINDSIGHT_BACKFILL_PROGRESS``."""
+    override = os.environ.get("HINDSIGHT_BACKFILL_PROGRESS")
+    if override:
+        return override
+    return os.path.join(os.path.expanduser("~"), ".hindsight", "backfill-progress.json")
+
+
+class Progress:
+    """Small atomic JSON store: ``{"<agent>/<session>": {"status": ...}}``.
+
+    ``status`` ∈ {``done``, ``skipped_partial``, ``failed``}. Only ``done`` is a
+    resume-skip; a re-run retries ``failed``/``skipped_partial`` sessions.
+    """
+
+    def __init__(self, path: Optional[str] = None):
+        self.path = path or progress_path()
+        self._data: dict = {}
+        self._load()
+
+    @staticmethod
+    def _key(agent: str, session: str) -> str:
+        return f"{agent}/{session}"
+
+    def _load(self) -> None:
+        try:
+            with open(self.path, encoding="utf-8") as f:
+                loaded = json.load(f)
+                if isinstance(loaded, dict):
+                    self._data = loaded
+        except (OSError, json.JSONDecodeError):
+            self._data = {}
+
+    def status(self, agent: str, session: str) -> Optional[str]:
+        entry = self._data.get(self._key(agent, session))
+        return entry.get("status") if isinstance(entry, dict) else None
+
+    def is_done(self, agent: str, session: str) -> bool:
+        return self.status(agent, session) == "done"
+
+    def record(self, agent: str, session: str, status: str, **extra) -> None:
+        self._data[self._key(agent, session)] = {
+            "agent": agent,
+            "session": session,
+            "status": status,
+            "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            **extra,
+        }
+        self._flush()
+
+    def _flush(self) -> None:
+        d = os.path.dirname(self.path)
+        try:
+            if d and not os.path.isdir(d):
+                os.makedirs(d, mode=0o700, exist_ok=True)
+        except OSError:
+            return
+        tmp = self.path + ".tmp"
+        try:
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(self._data, f, ensure_ascii=False)
+                f.flush()
+                os.fsync(f.fileno())
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, self.path)
+        except OSError:
+            pass
+
+
+# --------------------------------------------------------------------------- #
+# Transcript chunking — forward, deterministic, human-turn bounded.
+# --------------------------------------------------------------------------- #
+def _human_turn_indices(messages: list) -> list:
+    return [
+        i
+        for i, m in enumerate(messages)
+        if isinstance(m, dict) and m.get("role") == "user" and not _is_tool_result_only_user_message(m)
+    ]
+
+
+def chunk_by_human_turns(messages: list, turns: int) -> list:
+    """Partition ``messages`` into consecutive slices of up to ``turns`` human
+    turns each, on user-message boundaries.
+
+    Forward (oldest-first) and deterministic: re-running produces identical
+    slices ⇒ identical ``document_id``s ⇒ clean upsert / resume. Leading
+    non-human prelude before the first human turn is dropped (the live path
+    counts human turns too). Each slice runs from its first human turn up to
+    just before the next chunk's first human turn, so trailing assistant/tool
+    messages travel with their turn.
+    """
+    idx = _human_turn_indices(messages)
+    if not idx:
+        return []
+    slices = []
+    for start in range(0, len(idx), turns):
+        s = idx[start]
+        end_h = start + turns
+        e = idx[end_h] if end_h < len(idx) else len(messages)
+        slice_msgs = messages[s:e]
+        if slice_msgs:
+            slices.append(slice_msgs)
+    return slices
+
+
+def _session_id_from_path(path: str) -> str:
+    return os.path.splitext(os.path.basename(path))[0]
+
+
+def _resolve_bank_id(agent: str, session_id: str, config: dict) -> str:
+    synthetic_hook = {"session_id": session_id, "cwd": ""}
+    cfg = dict(config)
+    cfg.setdefault("agentName", agent)
+    if config.get("dynamicBankId"):
+        cfg["agentName"] = agent
+    return derive_bank_id(synthetic_hook, cfg)
+
+
+# --------------------------------------------------------------------------- #
+# The backfill.
+# --------------------------------------------------------------------------- #
+class Backfill:
+    def __init__(
+        self,
+        config: dict,
+        *,
+        commit: bool = False,
+        delay_ms: Optional[int] = None,
+        slice_turns: Optional[int] = None,
+        max_per_min: Optional[int] = None,
+        agents_root: Optional[str] = None,
+        client: Optional[HindsightClient] = None,
+        progress: Optional[Progress] = None,
+    ):
+        self.config = config
+        self.commit = commit
+        self.delay_s = _delay_ms(delay_ms) / 1000.0
+        self.slice_turns = _slice_turns(slice_turns)
+        self.max_per_min = max_per_min
+        self.agents_root = agents_root or agents_dir()
+        self.client = client
+        self.progress = progress or Progress()
+        self._api_url = None
+        self._api_token = config.get("hindsightApiToken")
+        # Pacing / breaker state.
+        self._posted_count = 0
+        self._consecutive_failures = 0
+        self._post_times: list = []  # monotonic timestamps for --max-per-min
+        # Per-agent + rollup report.
+        self.report: dict = {"agents": {}, "rollup": {}}
+
+    # -- daemon wiring ------------------------------------------------------ #
+    def _ensure_client(self) -> Optional[HindsightClient]:
+        if self.client is not None:
+            if self._api_url is None:
+                self._api_url = "http://backfill-client"
+            return self.client
+        if self._api_url is None:
+            try:
+                self._api_url = get_api_url(
+                    self.config, debug_fn=lambda *a: debug_log(self.config, *a),
+                    allow_daemon_start=False,
+                )
+            except (RuntimeError, ValueError) as e:
+                debug_log(self.config, f"backfill: daemon unavailable: {e}")
+                return None
+            self.client = HindsightClient(
+                self._api_url,
+                self._api_token,
+                request_timeout_override=self.config.get("requestTimeoutSeconds"),
+            )
+        return self.client
+
+    # -- pacing ------------------------------------------------------------- #
+    def _pace_before_post(self) -> None:
+        """Deterministic inter-POST delay + optional hard rate cap. First POST
+        of the run is not delayed."""
+        if self._posted_count > 0 and self.delay_s > 0:
+            _SLEEP(self.delay_s)
+        if self.max_per_min:
+            now = time.monotonic()
+            self._post_times = [t for t in self._post_times if now - t < 60.0]
+            if len(self._post_times) >= self.max_per_min:
+                oldest = self._post_times[0]
+                wait = 60.0 - (now - oldest)
+                if wait > 0:
+                    _SLEEP(wait)
+
+    def _on_failure(self) -> None:
+        """Exponential backoff + circuit-breaker cooldown on repeated failure."""
+        self._consecutive_failures += 1
+        backoff = min(self.delay_s * (2 ** self._consecutive_failures), _BACKOFF_CAP_S)
+        _SLEEP(backoff)
+        if self._consecutive_failures >= _STALL_THRESHOLD:
+            debug_log(self.config, "backfill: circuit-breaker tripped, cooling down")
+            _SLEEP(_cooldown_s())
+            self._consecutive_failures = 0
+
+    def _post_slice(self, bank_id: str, built: dict) -> bool:
+        """Serial, paced, confirmed POST of one slice. Returns True on confirmed
+        persistence. NEVER concurrent — one in flight fleet-wide via the shared
+        inflight lock."""
+        client = self._ensure_client()
+        if client is None:
+            return False
+        payload = built["payload"]
+        self._pace_before_post()
+        with inflight_lock(blocking=True) as acquired:
+            if not acquired:  # pragma: no cover - blocking acquire fails open
+                return False
+            try:
+                client.retain(
+                    bank_id=bank_id,
+                    content=payload["content"],
+                    document_id=built["document_id"],
+                    context=payload["context"],
+                    metadata=payload["metadata"],
+                    tags=payload["tags"],
+                    timeout=15,
+                    async_processing=False,  # commit-before-ack (daemon contract 2)
+                )
+            except Exception as e:
+                debug_log(self.config, f"backfill: POST failed for {built['document_id']}: {e}")
+                self._posted_count += 1
+                self._on_failure()
+                return False
+        self._posted_count += 1
+        self._post_times.append(time.monotonic())
+        self._consecutive_failures = 0
+        return True
+
+    # -- scanning ----------------------------------------------------------- #
+    def _list_agents(self, agent_filter: Optional[set]) -> list:
+        try:
+            names = sorted(
+                n for n in os.listdir(self.agents_root)
+                if os.path.isdir(os.path.join(self.agents_root, n))
+            )
+        except OSError:
+            return []
+        if agent_filter:
+            names = [n for n in names if n in agent_filter]
+        return names
+
+    def _agent_transcripts(self, agent: str) -> list:
+        base = os.path.join(self.agents_root, agent, ".claude", "projects")
+        paths = sorted(glob.glob(os.path.join(base, "**", "*.jsonl"), recursive=True))
+        seen = set()
+        return [p for p in paths if not (p in seen or seen.add(p))]
+
+    def _agent_report(self, agent: str) -> dict:
+        return self.report["agents"].setdefault(agent, {
+            "sessions_scanned": 0,
+            "sessions_total_loss": 0,
+            "sessions_partial_skipped": 0,
+            "sessions_already_done": 0,
+            "turns_recovered": 0,
+            "slices": 0,
+            "posts_ok": 0,
+            "posts_failed": 0,
+            "sessions": [],
+        })
+
+    def run(self, agent_filter: Optional[set] = None) -> dict:
+        for agent in self._list_agents(agent_filter):
+            self._backfill_agent(agent)
+        self._finalize_report()
+        return self.report
+
+    def _backfill_agent(self, agent: str) -> None:
+        ar = self._agent_report(agent)
+        for path in self._agent_transcripts(agent):
+            session = _session_id_from_path(path)
+            ar["sessions_scanned"] += 1
+
+            # Resumability: an already-completed session is skipped cheaply.
+            if self.progress.is_done(agent, session):
+                ar["sessions_already_done"] += 1
+                continue
+
+            messages = read_transcript(path)
+            if not messages:
+                continue
+
+            # Classification (design Part 2 dedup redesign).
+            live_wm = watermark.load(session)
+            if live_wm is not None:
+                # Partially retained by the live path — conservative skip
+                # (no existence query available in the vendored client).
+                ar["sessions_partial_skipped"] += 1
+                ar["sessions"].append({"session": session, "class": "partial", "action": "skipped_for_review"})
+                if self.commit:
+                    self.progress.record(agent, session, "skipped_partial")
+                continue
+
+            # True-total-loss — recover in full.
+            slices = chunk_by_human_turns(messages, self.slice_turns)
+            if not slices:
+                continue
+
+            bank_id = _resolve_bank_id(agent, session, self.config)
+            built_slices = []
+            n_turns = 0
+            for sl in slices:
+                built = build_retain_payload(
+                    self.config, session, sl, messages,
+                    bank_id=bank_id, api_url=self._api_url or "http://backfill-client",
+                    api_token=self._api_token, retain_full_window=True, document_id=None,
+                )
+                if built is None:
+                    continue
+                built_slices.append(built)
+                n_turns += len(_human_turn_indices(sl))
+
+            if not built_slices:
+                continue
+            ar["sessions_total_loss"] += 1
+            ar["slices"] += len(built_slices)
+            ar["turns_recovered"] += n_turns
+            ar["sessions"].append({
+                "session": session, "class": "total_loss",
+                "slices": len(built_slices), "turns": n_turns,
+                "document_ids": [b["document_id"] for b in built_slices],
+            })
+
+            if not self.commit:
+                # Dry-run: build-only, ZERO writes. Nothing posted, no mission
+                # PATCH, no progress mutation.
+                continue
+
+            all_ok = True
+            last_built = None
+            for built in built_slices:
+                if self._post_slice(bank_id, built):
+                    ar["posts_ok"] += 1
+                    last_built = built
+                else:
+                    ar["posts_failed"] += 1
+                    all_ok = False
+
+            if all_ok and last_built is not None:
+                # Advance the live watermark so the agent's own boot reconcile
+                # sees the tail as committed, and mark the session done for a
+                # cheap resume.
+                try:
+                    watermark.commit(
+                        session, last_built["last_uuid"], last_built["document_id"],
+                        transcript_path=path, ordered_uuids=last_built["ordered_uuids"],
+                    )
+                except Exception:  # pragma: no cover - defensive
+                    pass
+                self.progress.record(agent, session, "done", slices=len(built_slices), turns=n_turns)
+            else:
+                self.progress.record(agent, session, "failed")
+
+    def _finalize_report(self) -> None:
+        roll = {
+            "agents": len(self.report["agents"]),
+            "sessions_scanned": 0,
+            "sessions_total_loss": 0,
+            "sessions_partial_skipped": 0,
+            "sessions_already_done": 0,
+            "turns_recovered": 0,
+            "slices": 0,
+            "posts_ok": 0,
+            "posts_failed": 0,
+            "committed": self.commit,
+        }
+        for ar in self.report["agents"].values():
+            for k in (
+                "sessions_scanned", "sessions_total_loss", "sessions_partial_skipped",
+                "sessions_already_done", "turns_recovered", "slices", "posts_ok", "posts_failed",
+            ):
+                roll[k] += ar[k]
+        self.report["rollup"] = roll
+
+
+# --------------------------------------------------------------------------- #
+# Reporting / CLI.
+# --------------------------------------------------------------------------- #
+def format_report(report: dict) -> str:
+    roll = report.get("rollup", {})
+    mode = "COMMIT" if roll.get("committed") else "DRY-RUN (no writes)"
+    lines = [f"[Hindsight] backfill report — {mode}", ""]
+    for agent in sorted(report.get("agents", {})):
+        ar = report["agents"][agent]
+        lines.append(
+            f"  {agent}: scanned={ar['sessions_scanned']} "
+            f"total_loss={ar['sessions_total_loss']} "
+            f"partial_skipped={ar['sessions_partial_skipped']} "
+            f"already_done={ar['sessions_already_done']} "
+            f"turns={ar['turns_recovered']} slices={ar['slices']} "
+            f"posts_ok={ar['posts_ok']} posts_failed={ar['posts_failed']}"
+        )
+    lines.append("")
+    lines.append(
+        f"  ROLLUP: agents={roll.get('agents', 0)} "
+        f"total_loss_sessions={roll.get('sessions_total_loss', 0)} "
+        f"partial_skipped={roll.get('sessions_partial_skipped', 0)} "
+        f"turns_would_recover={roll.get('turns_recovered', 0)} "
+        f"slices={roll.get('slices', 0)} "
+        f"posts_ok={roll.get('posts_ok', 0)} posts_failed={roll.get('posts_failed', 0)}"
+    )
+    if not roll.get("committed"):
+        est_posts = roll.get("slices", 0)
+        delay_ms = _delay_ms()
+        est_secs = est_posts * (delay_ms / 1000.0)
+        lines.append(
+            f"  ESTIMATE (at {delay_ms}ms/post): ~{est_posts} POSTs, "
+            f"~{est_secs:.0f}s wall-clock. Re-run with --commit to write."
+        )
+    return "\n".join(lines)
+
+
+def _acquire_process_mutex():
+    """``backfill.lock`` — one backfill process at a time (distinct from the
+    per-POST storm guard). Returns the held fd, or None if flock unavailable /
+    already held."""
+    if sys.platform == "win32":
+        return None
+    import fcntl
+    path = os.environ.get("HINDSIGHT_BACKFILL_LOCK") or os.path.join(
+        os.path.expanduser("~"), ".hindsight", "backfill.lock"
+    )
+    d = os.path.dirname(path)
+    try:
+        if d and not os.path.isdir(d):
+            os.makedirs(d, mode=0o700, exist_ok=True)
+        fd = open(path, "w")
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return fd
+    except OSError:
+        return None
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="One-time backfill of transcript work missing from Hindsight banks (#3244).",
+    )
+    parser.add_argument("--commit", action="store_true",
+                        help="Actually write. WITHOUT this flag the tool is a zero-write dry-run (the default).")
+    parser.add_argument("--agent", action="append", dest="agents", default=None,
+                        help="Restrict to this agent (repeatable). Default: all agents.")
+    parser.add_argument("--agents-dir", default=None, help="Override the agents scaffold root.")
+    parser.add_argument("--delay-ms", type=int, default=None, help="Inter-POST delay (default 1500).")
+    parser.add_argument("--slice-turns", type=int, default=None, help="Human turns per document slice (default 40).")
+    parser.add_argument("--max-per-min", type=int, default=None, help="Optional hard POST rate cap.")
+    parser.add_argument("--json", action="store_true", help="Emit the machine-readable report as JSON.")
+    args = parser.parse_args(argv)
+
+    config = load_config()
+
+    mutex = _acquire_process_mutex()
+    if mutex is None and sys.platform != "win32":
+        print("[Hindsight] backfill: could not take backfill.lock — another backfill may be "
+              "running. Refusing to co-run.", file=sys.stderr)
+        return 2
+
+    try:
+        bf = Backfill(
+            config,
+            commit=args.commit,
+            delay_ms=args.delay_ms,
+            slice_turns=args.slice_turns,
+            max_per_min=args.max_per_min,
+            agents_root=args.agents_dir,
+        )
+        agent_filter = set(args.agents) if args.agents else None
+        report = bf.run(agent_filter)
+    finally:
+        if mutex is not None:
+            try:
+                mutex.close()
+            except OSError:
+                pass
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(format_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vendor/hindsight-memory/scripts/backfill_transcripts.py
+++ b/vendor/hindsight-memory/scripts/backfill_transcripts.py
@@ -17,15 +17,23 @@ over ALL history for ALL agents, paced, resumable, with a dry-run."
 Guarantees, all resting on daemon contracts CONFIRMED against hindsight
 v0.18.24 (daemon-contract-20260715.md):
 
-* **Dedup by deterministic document_id + daemon UPSERT.** Every slice is posted
-  under ``{session_id}-r{start_uuid}-{end_uuid}`` — a pure function of *which
-  turns* it holds. The daemon UPSERTs on ``(id, bank_id)``
-  (``ops_postgresql.py:63-69`` ``ON CONFLICT DO UPDATE``; full-replace of
-  derived memories, ``fact_storage.py:334-360``) and short-circuits an
-  identical re-post on ``content_hash``. So re-deriving ids across history — and
-  colliding with anything the live path already wrote for the SAME slice —
-  upserts to ONE document, never a duplicate. No separate existence query
-  needed for the total-loss case.
+* **Dedup by deterministic document_id + daemon UPSERT — ACROSS BACKFILL
+  RE-RUNS.** Every slice is posted under ``{session_id}-r{start_uuid}-{end_uuid}``
+  — a pure function of *which turns* it holds. The daemon UPSERTs on
+  ``(id, bank_id)`` (``ops_postgresql.py:63-69`` ``ON CONFLICT DO UPDATE``;
+  full-replace of derived memories, ``fact_storage.py:334-360``) and
+  short-circuits an identical re-post on ``content_hash``. So two backfill runs
+  over the same transcript **with the same ``slice_turns``** compute identical
+  ids and upsert to ONE document. NOTE — these ids do **NOT** converge with the
+  live/boot path's ids: the live path slices a *sliding* ``retainEveryNTurns``+
+  overlap window (``retain.py:130-136``) while the backfill slices *non-
+  overlapping* ``slice_turns`` (default 40) chunks, so the boundary uuids differ
+  and the daemon CANNOT upsert one against the other. The backfill is kept
+  duplicate-free **not** by id-convergence with the live path but by the
+  **total-loss gate** (§ classification below — it only ever re-posts sessions
+  the live path wrote *nothing* for) plus advancing the watermark after commit.
+  Do NOT remove the total-loss gate believing upsert will dedup live-vs-backfill
+  — it will not.
 * **Never-storm pacing (HARD).** Strictly serial — one ``client.retain()`` in
   flight at a time, fleet-wide, via PR1's shared ``retain-inflight.lock``
   (acquired blocking around every POST) plus a backfill-only ``backfill.lock``
@@ -45,17 +53,30 @@ v0.18.24 (daemon-contract-20260715.md):
   completed sessions are skipped, an in-progress session re-does its current
   slices (safe upsert), no duplicates.
 
-Classification (design Part 2 dedup redesign):
+Classification & guards (design Part 2 dedup redesign + PR3248 review F1/F3):
 
-* **No live watermark for the session** ⇒ true-total-loss (the clerk case) —
-  post it in full.
+* **Dynamic-bank agent** ⇒ **REFUSED (warn + skip, no writes).** Its bank is
+  composed from ``project``/``channel``/``user`` (bank.py), none recoverable
+  from a transcript scan, so backfilling would write to the WRONG bank. Only
+  static-bank agents are eligible (F1).
+* **Active / recently-written session** (transcript mtime within
+  ``--min-idle-s``, default 1h) ⇒ **SKIPPED.** An in-flight session may have no
+  watermark yet; re-posting non-overlapping slices while the live path writes
+  sliding-window slices would duplicate the same turns under different ids the
+  daemon can't upsert away (F3).
+* **No live watermark, idle session** ⇒ true-total-loss (the clerk case) —
+  post it in full. RESIDUAL (F3, narrow): a *closed* session whose live retain
+  landed but whose best-effort watermark WRITE failed has a bank doc and no
+  watermark; it is indistinguishable from total-loss without a per-document
+  existence query (which the vendored client lacks) and would be re-posted. The
+  ``--min-idle-s`` gate does not close this; it is a rare, documented residual.
 * **Has a live watermark** ⇒ partially retained by the live path, whose slice
-  boundaries may differ from the backfill's, so an id-collision is not
-  guaranteed. The vendored client exposes no per-document existence query, so
-  the conservative default is to **SKIP and report for manual review** rather
-  than risk a partial-overlap duplicate. (Total-loss recovery is the backfill's
-  real job; partial sessions are already served by the live path + boot
-  reconcile.)
+  boundaries differ from the backfill's, so an id-collision is not guaranteed.
+  The vendored client exposes no per-document existence query, so the
+  conservative default is to **SKIP and report for manual review** rather than
+  risk a partial-overlap duplicate. Consequence: a permanently-closed partial
+  session's lost TAIL is not recovered by backfill (only the live path + boot
+  reconcile cover it) — surfaced in the report, not silently dropped.
 """
 
 from __future__ import annotations
@@ -111,6 +132,29 @@ def _cooldown_s() -> float:
         return 120.0
 
 
+def _min_idle_s(override: Optional[int] = None) -> float:
+    """A session whose transcript was modified more recently than this is treated
+    as ACTIVE / in-flight and is NEVER backfilled (F3): an active session may have
+    no watermark yet, so classifying it total-loss and re-posting non-overlapping
+    slices would duplicate turns the live path is concurrently writing. Default
+    1h; override with ``--min-idle-s`` / ``HINDSIGHT_BACKFILL_MIN_IDLE_S``."""
+    if override is not None:
+        return max(0, override)
+    try:
+        return max(0.0, float(os.environ.get("HINDSIGHT_BACKFILL_MIN_IDLE_S", "3600")))
+    except ValueError:
+        return 3600.0
+
+
+def _is_dynamic_bank(config: dict) -> bool:
+    """True when the loaded config resolves banks dynamically (per project /
+    channel / user). A transcript scan cannot reliably reconstruct such a bank
+    (F1): ``cwd`` is unknown at backfill time so ``project`` → ``unknown`` and
+    ``channel``/``user`` fall back to the operator's env — the recovered memory
+    would land in the WRONG bank. Such agents are refused (warn + skip)."""
+    return bool(config.get("dynamicBankId", False))
+
+
 _STALL_THRESHOLD = 3          # consecutive failures → circuit-breaker cooldown
 _BACKOFF_CAP_S = 60.0         # exponential backoff ceiling
 
@@ -146,9 +190,43 @@ class Progress:
         self._data: dict = {}
         self._load()
 
+    # Reserved (non-session) key holding id-affecting run params. Cannot collide
+    # with an "<agent>/<session>" key.
+    PARAMS_KEY = "__backfill_params__"
+
     @staticmethod
     def _key(agent: str, session: str) -> str:
         return f"{agent}/{session}"
+
+    def recorded_slice_turns(self) -> Optional[int]:
+        entry = self._data.get(self.PARAMS_KEY)
+        if isinstance(entry, dict):
+            val = entry.get("slice_turns")
+            return int(val) if isinstance(val, int) else None
+        return None
+
+    def ensure_slice_turns(self, slice_turns: int) -> None:
+        """Persist the run's ``slice_turns`` on first commit, and REFUSE to
+        resume with a different value (F2).
+
+        A different ``slice_turns`` re-slices at new boundaries → new
+        ``document_id``s → the already-committed run-1 slices orphan as
+        duplicates (the daemon can't upsert them away). Raises ``ValueError`` on
+        mismatch so the caller aborts before writing anything new.
+        """
+        recorded = self.recorded_slice_turns()
+        if recorded is None:
+            self._data[self.PARAMS_KEY] = {"slice_turns": int(slice_turns)}
+            self._flush()
+            return
+        if recorded != int(slice_turns):
+            raise ValueError(
+                f"backfill-progress.json was written with slice_turns={recorded}, "
+                f"but this run requested slice_turns={slice_turns}. Resuming with a "
+                f"different slice size would orphan the already-committed slices as "
+                f"duplicates. Re-run with --slice-turns {recorded}, or start a fresh "
+                f"backfill (new --backfill-progress path / clear the progress file)."
+            )
 
     def _load(self) -> None:
         try:
@@ -257,6 +335,7 @@ class Backfill:
         slice_turns: Optional[int] = None,
         max_per_min: Optional[int] = None,
         agents_root: Optional[str] = None,
+        min_idle_s: Optional[int] = None,
         client: Optional[HindsightClient] = None,
         progress: Optional[Progress] = None,
     ):
@@ -266,6 +345,8 @@ class Backfill:
         self.slice_turns = _slice_turns(slice_turns)
         self.max_per_min = max_per_min
         self.agents_root = agents_root or agents_dir()
+        self.min_idle_s = _min_idle_s(min_idle_s)
+        self.dynamic_bank = _is_dynamic_bank(config)
         self.client = client
         self.progress = progress or Progress()
         self._api_url = None
@@ -378,9 +459,12 @@ class Backfill:
 
     def _agent_report(self, agent: str) -> dict:
         return self.report["agents"].setdefault(agent, {
+            "bank_id": None,
+            "dynamic_bank_skipped": False,
             "sessions_scanned": 0,
             "sessions_total_loss": 0,
             "sessions_partial_skipped": 0,
+            "sessions_active_skipped": 0,
             "sessions_already_done": 0,
             "turns_recovered": 0,
             "slices": 0,
@@ -390,6 +474,10 @@ class Backfill:
         })
 
     def run(self, agent_filter: Optional[set] = None) -> dict:
+        # F2: on a commit run, pin the id-affecting slice_turns; refuse to resume
+        # a progress file written with a different value (raises ValueError).
+        if self.commit:
+            self.progress.ensure_slice_turns(self.slice_turns)
         for agent in self._list_agents(agent_filter):
             self._backfill_agent(agent)
         self._finalize_report()
@@ -397,6 +485,21 @@ class Backfill:
 
     def _backfill_agent(self, agent: str) -> None:
         ar = self._agent_report(agent)
+
+        # F1: a dynamic-bank agent's bank cannot be reconstructed from a
+        # transcript scan (cwd/channel/user are unknown at backfill time), so we
+        # REFUSE it entirely rather than write recovered memory to a guessed
+        # WRONG bank. Warn loudly, count, and skip — never post.
+        if self.dynamic_bank:
+            ar["dynamic_bank_skipped"] = True
+            debug_log(self.config,
+                      f"backfill: REFUSING dynamic-bank agent {agent} — bank cannot be "
+                      f"reliably reconstructed from a transcript scan; skipping.")
+            print(f"[Hindsight] backfill: WARNING — {agent} is dynamic-bank; refusing to "
+                  f"guess its bank. Skipped (no writes).", file=sys.stderr)
+            return
+
+        now = time.time()
         for path in self._agent_transcripts(agent):
             session = _session_id_from_path(path)
             ar["sessions_scanned"] += 1
@@ -404,6 +507,19 @@ class Backfill:
             # Resumability: an already-completed session is skipped cheaply.
             if self.progress.is_done(agent, session):
                 ar["sessions_already_done"] += 1
+                continue
+
+            # F3: never touch an ACTIVE / recently-written session — it may have
+            # no watermark yet, and re-posting non-overlapping slices while the
+            # live path writes sliding-window slices duplicates the turns.
+            try:
+                idle = now - os.path.getmtime(path)
+            except OSError:
+                continue
+            if idle < self.min_idle_s:
+                ar["sessions_active_skipped"] += 1
+                ar["sessions"].append({"session": session, "class": "active",
+                                       "action": "skipped_recent", "idle_s": round(idle, 1)})
                 continue
 
             messages = read_transcript(path)
@@ -427,6 +543,8 @@ class Backfill:
                 continue
 
             bank_id = _resolve_bank_id(agent, session, self.config)
+            if ar["bank_id"] is None:
+                ar["bank_id"] = bank_id
             built_slices = []
             n_turns = 0
             for sl in slices:
@@ -447,6 +565,7 @@ class Backfill:
             ar["turns_recovered"] += n_turns
             ar["sessions"].append({
                 "session": session, "class": "total_loss",
+                "bank_id": bank_id,
                 "slices": len(built_slices), "turns": n_turns,
                 "document_ids": [b["document_id"] for b in built_slices],
             })
@@ -484,20 +603,26 @@ class Backfill:
     def _finalize_report(self) -> None:
         roll = {
             "agents": len(self.report["agents"]),
+            "dynamic_bank_agents_skipped": 0,
             "sessions_scanned": 0,
             "sessions_total_loss": 0,
             "sessions_partial_skipped": 0,
+            "sessions_active_skipped": 0,
             "sessions_already_done": 0,
             "turns_recovered": 0,
             "slices": 0,
             "posts_ok": 0,
             "posts_failed": 0,
+            "slice_turns": self.slice_turns,
             "committed": self.commit,
         }
         for ar in self.report["agents"].values():
+            if ar.get("dynamic_bank_skipped"):
+                roll["dynamic_bank_agents_skipped"] += 1
             for k in (
                 "sessions_scanned", "sessions_total_loss", "sessions_partial_skipped",
-                "sessions_already_done", "turns_recovered", "slices", "posts_ok", "posts_failed",
+                "sessions_active_skipped", "sessions_already_done", "turns_recovered",
+                "slices", "posts_ok", "posts_failed",
             ):
                 roll[k] += ar[k]
         self.report["rollup"] = roll
@@ -512,10 +637,14 @@ def format_report(report: dict) -> str:
     lines = [f"[Hindsight] backfill report — {mode}", ""]
     for agent in sorted(report.get("agents", {})):
         ar = report["agents"][agent]
+        if ar.get("dynamic_bank_skipped"):
+            lines.append(f"  {agent}: DYNAMIC-BANK — REFUSED (bank not reconstructable, no writes)")
+            continue
         lines.append(
-            f"  {agent}: scanned={ar['sessions_scanned']} "
+            f"  {agent} [bank={ar.get('bank_id')}]: scanned={ar['sessions_scanned']} "
             f"total_loss={ar['sessions_total_loss']} "
             f"partial_skipped={ar['sessions_partial_skipped']} "
+            f"active_skipped={ar['sessions_active_skipped']} "
             f"already_done={ar['sessions_already_done']} "
             f"turns={ar['turns_recovered']} slices={ar['slices']} "
             f"posts_ok={ar['posts_ok']} posts_failed={ar['posts_failed']}"
@@ -523,10 +652,12 @@ def format_report(report: dict) -> str:
     lines.append("")
     lines.append(
         f"  ROLLUP: agents={roll.get('agents', 0)} "
+        f"dynamic_bank_refused={roll.get('dynamic_bank_agents_skipped', 0)} "
         f"total_loss_sessions={roll.get('sessions_total_loss', 0)} "
         f"partial_skipped={roll.get('sessions_partial_skipped', 0)} "
+        f"active_skipped={roll.get('sessions_active_skipped', 0)} "
         f"turns_would_recover={roll.get('turns_recovered', 0)} "
-        f"slices={roll.get('slices', 0)} "
+        f"slices={roll.get('slices', 0)} slice_turns={roll.get('slice_turns')} "
         f"posts_ok={roll.get('posts_ok', 0)} posts_failed={roll.get('posts_failed', 0)}"
     )
     if not roll.get("committed"):
@@ -573,8 +704,20 @@ def main(argv=None) -> int:
     parser.add_argument("--delay-ms", type=int, default=None, help="Inter-POST delay (default 1500).")
     parser.add_argument("--slice-turns", type=int, default=None, help="Human turns per document slice (default 40).")
     parser.add_argument("--max-per-min", type=int, default=None, help="Optional hard POST rate cap.")
+    parser.add_argument("--min-idle-s", type=int, default=None,
+                        help="Skip sessions whose transcript was modified within this many seconds "
+                             "(treated as active/in-flight). Default 3600.")
     parser.add_argument("--json", action="store_true", help="Emit the machine-readable report as JSON.")
     args = parser.parse_args(argv)
+
+    # F1/F3 footgun guard: a blanket --commit across the whole fleet can write to
+    # a wrong (dynamic) bank or double-post an active session. Require an explicit
+    # per-agent opt-in for any write; dry-run may still scan the whole fleet.
+    if args.commit and not args.agents:
+        print("[Hindsight] backfill: --commit requires an explicit --agent <name> "
+              "(fleet-wide commit is refused; dry-run the fleet first, then commit per agent).",
+              file=sys.stderr)
+        return 2
 
     config = load_config()
 
@@ -592,9 +735,15 @@ def main(argv=None) -> int:
             slice_turns=args.slice_turns,
             max_per_min=args.max_per_min,
             agents_root=args.agents_dir,
+            min_idle_s=args.min_idle_s,
         )
         agent_filter = set(args.agents) if args.agents else None
-        report = bf.run(agent_filter)
+        try:
+            report = bf.run(agent_filter)
+        except ValueError as e:
+            # F2: slice_turns mismatch on resume — refuse before writing.
+            print(f"[Hindsight] backfill: {e}", file=sys.stderr)
+            return 2
     finally:
         if mutex is not None:
             try:

--- a/vendor/hindsight-memory/scripts/retain.py
+++ b/vendor/hindsight-memory/scripts/retain.py
@@ -156,10 +156,20 @@ def slice_document_id(session_id: str, messages_slice: list, transcript_text: st
     ``{session_id}-r{start_uuid}-{end_uuid}`` from the FULL first/last transcript
     entry uuids of the retained slice — NOT truncated (32+32 bits birthday-
     collide across months of history and a collision is *silent loss*, not a
-    dup). Because the id is a pure function of *which turns* are retained, the
-    live Stop-hook path, boot reconciliation, and the PR2 backfill all compute
-    the IDENTICAL id for the same slice ⇒ they upsert on the daemon's
-    document_id key instead of double-storing. No wall clock, no randomness.
+    dup). The id is a pure function of *which turns* (which start/end uuids) are
+    retained, so any two writes of the **identical** slice — the live Stop-hook
+    path re-firing the same window, or boot reconciliation re-posting it —
+    compute the same id and upsert on the daemon's document_id key instead of
+    double-storing. No wall clock, no randomness.
+
+    CAUTION — this convergence is only for the *same slice boundaries*. The live
+    path slices a *sliding* ``retainEveryNTurns``+overlap window (see
+    ``select_retain_window``) while the PR2 backfill slices *non-overlapping*
+    fixed-size chunks; they do NOT produce the same boundaries for the same
+    turns, so their ids do NOT converge and the daemon cannot upsert one against
+    the other. The backfill stays duplicate-free via its total-loss gate (it
+    only re-posts sessions the live path wrote nothing for), NOT via id-identity
+    with the live path — do not conflate the two.
 
     Fallback (legacy/flat transcripts with no per-entry uuid): a sha256 of the
     formatted transcript content — still purely deterministic and convergent

--- a/vendor/hindsight-memory/scripts/tests/test_backfill.py
+++ b/vendor/hindsight-memory/scripts/tests/test_backfill.py
@@ -1,0 +1,289 @@
+"""Switchroom #3244 Part 2 — backfill outcome tests.
+
+Stdlib-only (`python3 -m unittest discover tests/`). Every test drives the real
+``backfill_transcripts`` code against a FAKE in-process daemon (no network, no
+LLM) and asserts OUTCOMES — content landed in the bank / dedup to one document /
+zero writes in dry-run / pacing spacing observed via a fake clock / resume
+skips committed sessions — not merely that a code path ran.
+
+Covers design-20260715.md §4 tests 4 (backfill dedup + pacing), 5
+(resumability), 8 (dedups against pre-existing docs + total-loss posted in
+full), 9 (dry-run ZERO writes incl. no mission PATCH).
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import backfill_transcripts as bf  # noqa: E402
+from lib import watermark  # noqa: E402
+from lib.client import HindsightClient  # noqa: E402
+
+
+class FakeDaemon:
+    """Records retained documents by document_id with UPSERT semantics (the
+    confirmed daemon contract: same document_id ⇒ one row, full-replace)."""
+
+    def __init__(self):
+        self.docs = {}                 # document_id -> {content, ...}
+        self.posts = []                # [(document_id, async_processing)]
+        self.mission_patches = []      # set_bank_mission calls (must stay empty)
+        self.fail = False
+        self.max_inflight_seen = 0
+        self._inflight = 0
+
+    def retain(self, bank_id, content, document_id="conversation", context=None,
+               metadata=None, tags=None, timeout=15, async_processing=True):
+        self._inflight += 1
+        self.max_inflight_seen = max(self.max_inflight_seen, self._inflight)
+        try:
+            self.posts.append((document_id, async_processing))
+            if self.fail:
+                raise RuntimeError("simulated daemon failure")
+            self.docs[document_id] = {"content": content, "metadata": metadata}
+            return {"ok": True}
+        finally:
+            self._inflight -= 1
+
+    def set_bank_mission(self, *a, **kw):
+        self.mission_patches.append((a, kw))
+        return {"ok": True}
+
+    def content_blob(self):
+        return "\n".join(d["content"] for d in self.docs.values())
+
+
+def _write_transcript(path, n_turns, session_prefix="u"):
+    lines = []
+    for i in range(n_turns):
+        lines.append(json.dumps({"role": "user", "content": f"user turn {i}", "uuid": f"{session_prefix}-u{i}"}))
+        lines.append(json.dumps({"role": "assistant", "content": f"assistant turn {i}", "uuid": f"{session_prefix}-a{i}"}))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+class BackfillTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="hs-3244-bf-")
+        self.plugin_root = os.path.join(self.tmp, "plugin_root")
+        self.home = os.path.join(self.tmp, "home")
+        self.data = os.path.join(self.tmp, "data")
+        self.agents_root = os.path.join(self.tmp, "agents")
+        for d in (self.plugin_root, self.home, self.data, self.agents_root):
+            os.makedirs(d)
+
+        settings = {
+            "autoRetain": True,
+            "autoRecall": True,
+            "retainMode": "chunked",
+            "retainEveryNTurns": 3,
+            "retainOverlapTurns": 0,
+            "bankId": "test-bank",
+            "reconcileOnStart": True,
+        }
+        with open(os.path.join(self.plugin_root, "settings.json"), "w") as f:
+            json.dump(settings, f)
+
+        self.env = mock.patch.dict(os.environ, {
+            "CLAUDE_PLUGIN_ROOT": self.plugin_root,
+            "CLAUDE_PLUGIN_DATA": self.data,
+            "HOME": self.home,
+            "HINDSIGHT_PENDING_DIR": os.path.join(self.home, ".hindsight", "pending-retains"),
+            "HINDSIGHT_RETAINED_DIR": os.path.join(self.home, ".hindsight", "retained"),
+            "HINDSIGHT_INFLIGHT_LOCK": os.path.join(self.home, ".hindsight", "retain-inflight.lock"),
+            "HINDSIGHT_BACKFILL_PROGRESS": os.path.join(self.home, ".hindsight", "backfill-progress.json"),
+            "HINDSIGHT_BACKFILL_LOCK": os.path.join(self.home, ".hindsight", "backfill.lock"),
+            "HINDSIGHT_AGENTS_DIR": self.agents_root,
+            "HINDSIGHT_BACKFILL_DELAY_MS": "0",  # tests inject their own delay
+        }, clear=False)
+        self.env.start()
+        for k in list(os.environ):
+            if k.startswith("HINDSIGHT_") and k not in (
+                "HINDSIGHT_PENDING_DIR", "HINDSIGHT_RETAINED_DIR", "HINDSIGHT_INFLIGHT_LOCK",
+                "HINDSIGHT_BACKFILL_PROGRESS", "HINDSIGHT_BACKFILL_LOCK", "HINDSIGHT_AGENTS_DIR",
+                "HINDSIGHT_BACKFILL_DELAY_MS",
+            ):
+                os.environ.pop(k, None)
+
+        self.daemon = FakeDaemon()
+        self.sleeps = []
+        self._patches = [
+            mock.patch.object(HindsightClient, "retain", self._fake_retain),
+            mock.patch.object(HindsightClient, "set_bank_mission", self._fake_mission),
+            mock.patch("backfill_transcripts.get_api_url", return_value="http://fake"),
+            mock.patch("backfill_transcripts._SLEEP", self._fake_sleep),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def _fake_retain(self, *a, **kw):
+        return self.daemon.retain(*a, **kw)
+
+    def _fake_mission(self, *a, **kw):
+        return self.daemon.set_bank_mission(*a, **kw)
+
+    def _fake_sleep(self, secs):
+        self.sleeps.append(secs)
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self.env.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _config(self):
+        from lib.config import load_config
+        return load_config()
+
+    def _transcript(self, agent, session, n_turns):
+        path = os.path.join(self.agents_root, agent, ".claude", "projects", "proj", f"{session}.jsonl")
+        _write_transcript(path, n_turns, session_prefix=session)
+        return path
+
+
+class TestBackfill(BackfillTestBase):
+    # -- Recovers a total-loss session --------------------------------------
+    def test_recovers_total_loss_session(self):
+        self._transcript("clerk", "sess-lost", 4)
+        report = bf.Backfill(self._config(), commit=True, delay_ms=0).run()
+
+        blob = self.daemon.content_blob()
+        for i in range(4):
+            self.assertIn(f"user turn {i}", blob)
+        self.assertEqual(report["rollup"]["sessions_total_loss"], 1)
+        self.assertGreater(report["rollup"]["posts_ok"], 0)
+        # Every durability POST is commit-before-ack.
+        self.assertTrue(self.daemon.posts)
+        self.assertTrue(all(async_flag is False for _, async_flag in self.daemon.posts))
+
+    # -- Dedups against a pre-existing document with the same deterministic id
+    def test_dedups_against_preexisting_document_id(self):
+        path = self._transcript("clerk", "sess-dup", 3)
+        # Pre-seed the daemon with the EXACT deterministic ids the backfill will
+        # derive (as a prior live/backfill run would have written them).
+        from retain import read_transcript
+        msgs = read_transcript(path)
+        slices = bf.chunk_by_human_turns(msgs, bf._slice_turns())
+        seeded_ids = []
+        for sl in slices:
+            built = bf.build_retain_payload(
+                self._config(), "sess-dup", sl, msgs, bank_id="test-bank",
+                api_url="http://fake", api_token=None,
+            )
+            self.daemon.docs[built["document_id"]] = {"content": "STALE", "metadata": {}}
+            seeded_ids.append(built["document_id"])
+        self.assertTrue(seeded_ids)
+        before = len(self.daemon.docs)
+
+        bf.Backfill(self._config(), commit=True, delay_ms=0).run()
+
+        # UPSERT: re-posting the same ids overwrites; document count unchanged
+        # (no duplicates), and content now reflects the recovered turns.
+        self.assertEqual(len(self.daemon.docs), before)
+        for did in seeded_ids:
+            self.assertNotEqual(self.daemon.docs[did]["content"], "STALE")
+
+    # -- Dry-run performs ZERO writes (no retain POST, no mission PATCH) -----
+    def test_dry_run_is_zero_write(self):
+        self._transcript("clerk", "sess-dry", 5)
+        report = bf.Backfill(self._config(), commit=False, delay_ms=0).run()
+
+        # Report still lists the gap it WOULD recover ...
+        self.assertEqual(report["rollup"]["sessions_total_loss"], 1)
+        self.assertGreater(report["rollup"]["turns_recovered"], 0)
+        # ... but not a single write reached the daemon.
+        self.assertEqual(self.daemon.posts, [])
+        self.assertEqual(self.daemon.mission_patches, [])
+        # No progress recorded, no watermark advanced.
+        self.assertFalse(os.path.exists(os.environ["HINDSIGHT_BACKFILL_PROGRESS"]))
+        self.assertIsNone(watermark.load("sess-dry"))
+
+    # -- Pacing: serial (one in flight) and spaced by the configured delay ---
+    def test_pacing_is_serial_and_spaced(self):
+        # Two sessions, several slices each (slice_turns=1 → one POST per turn).
+        self._transcript("clerk", "sess-p1", 3)
+        self._transcript("clerk", "sess-p2", 2)
+        bf.Backfill(self._config(), commit=True, delay_ms=1500, slice_turns=1).run()
+
+        # 5 POSTs total; never more than one in flight (serial worker).
+        self.assertEqual(len(self.daemon.posts), 5)
+        self.assertEqual(self.daemon.max_inflight_seen, 1)
+        # Each POST after the first is preceded by the configured 1.5s delay.
+        spaced = [s for s in self.sleeps if abs(s - 1.5) < 1e-9]
+        self.assertEqual(len(spaced), 4)  # 5 posts → 4 inter-post gaps
+
+    # -- Resumability: interrupt after N sessions, re-run skips committed -----
+    def test_resumes_and_skips_committed_sessions(self):
+        for i in range(4):
+            self._transcript("clerk", f"sess-r{i}", 2)
+
+        # First run: raise after the 2nd session's POST completes.
+        real_post = bf.Backfill._post_slice
+        state = {"posts": 0}
+
+        def _interrupting_post(self, bank_id, built):
+            # Raise at the START of the 3rd POST so sessions 1 and 2 are fully
+            # committed AND recorded done before the interruption.
+            state["posts"] += 1
+            if state["posts"] > 2:
+                raise KeyboardInterrupt("simulated interruption after 2 sessions")
+            return real_post(self, bank_id, built)
+
+        with mock.patch.object(bf.Backfill, "_post_slice", _interrupting_post):
+            with self.assertRaises(KeyboardInterrupt):
+                bf.Backfill(self._config(), commit=True, delay_ms=0, slice_turns=40).run()
+
+        # Two sessions were committed + recorded done before the interruption.
+        prog = bf.Progress(os.environ["HINDSIGHT_BACKFILL_PROGRESS"])
+        done_first = [s for s in ("sess-r0", "sess-r1", "sess-r2", "sess-r3")
+                      if prog.is_done("clerk", s)]
+        self.assertEqual(len(done_first), 2)
+        posts_after_first = len(self.daemon.posts)
+
+        # Re-run to completion: the already-done sessions must be SKIPPED (no
+        # re-POST), the remaining ones completed, zero duplicates.
+        report = bf.Backfill(self._config(), commit=True, delay_ms=0, slice_turns=40).run()
+        self.assertEqual(report["rollup"]["sessions_already_done"], 2)
+
+        prog2 = bf.Progress(os.environ["HINDSIGHT_BACKFILL_PROGRESS"])
+        for s in ("sess-r0", "sess-r1", "sess-r2", "sess-r3"):
+            self.assertTrue(prog2.is_done("clerk", s))
+        # Only the two remaining sessions were posted on the re-run.
+        self.assertEqual(len(self.daemon.posts) - posts_after_first, 2)
+        # All four sessions' content landed, one document per session (no dupes).
+        self.assertEqual(len(self.daemon.docs), 4)
+
+    # -- Partial (live-watermarked) sessions are skipped for review ----------
+    def test_partial_session_skipped_for_review(self):
+        path = self._transcript("clerk", "sess-partial", 3)
+        # A live watermark means the live path already retained part of it.
+        watermark.commit("sess-partial", "sess-partial-a1", "sess-partial-r...",
+                         transcript_path=path, ordered_uuids=["sess-partial-u0"])
+
+        report = bf.Backfill(self._config(), commit=True, delay_ms=0).run()
+
+        self.assertEqual(report["rollup"]["sessions_partial_skipped"], 1)
+        self.assertEqual(report["rollup"]["sessions_total_loss"], 0)
+        # Conservative: nothing posted for the partial session.
+        self.assertEqual(self.daemon.posts, [])
+
+    # -- --agent restricts scope --------------------------------------------
+    def test_agent_filter_restricts_scope(self):
+        self._transcript("clerk", "sess-a", 2)
+        self._transcript("scout", "sess-b", 2)
+        report = bf.Backfill(self._config(), commit=True, delay_ms=0).run(agent_filter={"clerk"})
+        self.assertIn("clerk", report["agents"])
+        self.assertNotIn("scout", report["agents"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_backfill.py
+++ b/vendor/hindsight-memory/scripts/tests/test_backfill.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 import unittest
 from unittest import mock
 
@@ -103,14 +104,15 @@ class BackfillTestBase(unittest.TestCase):
             "HINDSIGHT_BACKFILL_PROGRESS": os.path.join(self.home, ".hindsight", "backfill-progress.json"),
             "HINDSIGHT_BACKFILL_LOCK": os.path.join(self.home, ".hindsight", "backfill.lock"),
             "HINDSIGHT_AGENTS_DIR": self.agents_root,
-            "HINDSIGHT_BACKFILL_DELAY_MS": "0",  # tests inject their own delay
+            "HINDSIGHT_BACKFILL_DELAY_MS": "0",   # tests inject their own delay
+            "HINDSIGHT_BACKFILL_MIN_IDLE_S": "0",  # freshly-written fixtures aren't "active"
         }, clear=False)
         self.env.start()
         for k in list(os.environ):
             if k.startswith("HINDSIGHT_") and k not in (
                 "HINDSIGHT_PENDING_DIR", "HINDSIGHT_RETAINED_DIR", "HINDSIGHT_INFLIGHT_LOCK",
                 "HINDSIGHT_BACKFILL_PROGRESS", "HINDSIGHT_BACKFILL_LOCK", "HINDSIGHT_AGENTS_DIR",
-                "HINDSIGHT_BACKFILL_DELAY_MS",
+                "HINDSIGHT_BACKFILL_DELAY_MS", "HINDSIGHT_BACKFILL_MIN_IDLE_S",
             ):
                 os.environ.pop(k, None)
 
@@ -283,6 +285,77 @@ class TestBackfill(BackfillTestBase):
         report = bf.Backfill(self._config(), commit=True, delay_ms=0).run(agent_filter={"clerk"})
         self.assertIn("clerk", report["agents"])
         self.assertNotIn("scout", report["agents"])
+
+    # -- F3: the total-loss GATE is load-bearing (live doc, no watermark) -----
+    def test_total_loss_gate_prevents_live_vs_backfill_duplication(self):
+        # A session the LIVE path retained (a sliding-window doc in the bank) but
+        # whose watermark IS present. Backfill must NOT re-post it — the ids do
+        # NOT converge with the live path's, so a re-post would DUPLICATE the
+        # turns under different ids the daemon can't upsert away. The guard here
+        # is the classification gate, not id-convergence.
+        path = self._transcript("clerk", "sess-live", 5)
+        # Seed a live-path doc under a DIFFERENT (sliding-window-shaped) id.
+        live_id = "sess-live-r-live-sliding-window"
+        self.daemon.docs[live_id] = {"content": "live user turn 3\nlive user turn 4", "metadata": {}}
+        # The live path also wrote a watermark (the normal, healthy case).
+        watermark.commit("sess-live", "sess-live-a4", live_id,
+                         transcript_path=path, ordered_uuids=["sess-live-u4"])
+        before = len(self.daemon.docs)
+
+        report = bf.Backfill(self._config(), commit=True, delay_ms=0).run()
+
+        # Gate held: classified partial (watermark present) → skipped, zero posts,
+        # no second doc for the same turns.
+        self.assertEqual(report["rollup"]["sessions_partial_skipped"], 1)
+        self.assertEqual(self.daemon.posts, [])
+        self.assertEqual(len(self.daemon.docs), before)
+
+        # Prove the gate is load-bearing: with the watermark REMOVED (the F3
+        # watermark-write-failure shape) the same session WOULD be reclassified
+        # total-loss and re-posted, creating additional docs beyond the live one.
+        os.remove(os.path.join(os.environ["HINDSIGHT_RETAINED_DIR"], "sess-live.json"))
+        bf.Backfill(self._config(), commit=True, delay_ms=0,
+                    progress=bf.Progress(os.path.join(self.home, ".hindsight", "prog2.json"))).run()
+        self.assertGreater(len(self.daemon.docs), before)  # gate removed ⇒ duplication
+
+    # -- F1: a dynamic-bank agent is refused, never written to a guessed bank -
+    def test_dynamic_bank_agent_refused(self):
+        self._transcript("clerk", "sess-dyn", 3)
+        cfg = self._config()
+        cfg["dynamicBankId"] = True
+        cfg["dynamicBankGranularity"] = ["agent", "project"]
+
+        report = bf.Backfill(cfg, commit=True, delay_ms=0).run(agent_filter={"clerk"})
+
+        self.assertTrue(report["agents"]["clerk"]["dynamic_bank_skipped"])
+        self.assertEqual(report["rollup"]["dynamic_bank_agents_skipped"], 1)
+        # Nothing written to any guessed bank.
+        self.assertEqual(self.daemon.posts, [])
+        self.assertEqual(report["rollup"]["posts_ok"], 0)
+
+    # -- F2: resuming with a different --slice-turns is refused --------------
+    def test_slice_turns_mismatch_refused_on_resume(self):
+        self._transcript("clerk", "sess-st", 3)
+        # First commit run pins slice_turns=40.
+        bf.Backfill(self._config(), commit=True, delay_ms=0, slice_turns=40).run()
+        # A resume with a different slice size must refuse (would orphan run-1's
+        # slices as duplicates under new ids).
+        with self.assertRaises(ValueError):
+            bf.Backfill(self._config(), commit=True, delay_ms=0, slice_turns=10).run()
+
+    # -- F3: an active / recently-written session is skipped -----------------
+    def test_active_session_skipped(self):
+        path = self._transcript("clerk", "sess-hot", 3)
+        # Fresh mtime (now) with a 1h idle threshold → classified active.
+        report = bf.Backfill(self._config(), commit=True, delay_ms=0, min_idle_s=3600).run()
+        self.assertEqual(report["rollup"]["sessions_active_skipped"], 1)
+        self.assertEqual(report["rollup"]["sessions_total_loss"], 0)
+        self.assertEqual(self.daemon.posts, [])
+        # Backdate the transcript → now idle → recovered.
+        old = time.time() - 7200
+        os.utime(path, (old, old))
+        report2 = bf.Backfill(self._config(), commit=True, delay_ms=0, min_idle_s=3600).run()
+        self.assertEqual(report2["rollup"]["sessions_total_loss"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
One-time operator-run recovery tool for #3244 — scans on-disk transcripts and restores work missing from agents' Hindsight banks (e.g. clerk's 2026-07-11 total-loss sessions). Rebased onto main after PR #3246 (durable retain) merged; was PR #3248 (auto-closed when its base branch was deleted on PR1 merge).

## Safety (validated: adversarial review + re-review, all findings fixed)
- **Dry-run is the default; zero writes.** Requires explicit `--commit` to write, and `--commit` requires an explicit `--agent` (no fleet-wide blind commit).
- **No duplication:** total-loss classification gate + watermark advance (NOT id-convergence — ids intentionally do not match the live path; the gate is load-bearing and tested as such).
- **Never storms:** strictly serial, async=false commit-before-ack, shared inflight lock, 1.5s pace, backoff + circuit-breaker.
- **Wrong-bank safe:** dynamic-bank agents refused (zero writes); resolved bank surfaced per agent/session in the dry-run report.
- **Active-session safe:** `--min-idle-s` (default 3600s) skips in-flight sessions.
- Not wired to any hook/cron — operator-invoked only.

## Depends on
PR #3246 (durable retain seams: build_retain_payload, slice_document_id, watermark, pacing) — now merged to main.

## Run flow
1. `python3 backfill_transcripts.py` (dry-run, whole fleet, zero writes) → review per-agent report.
2. `python3 backfill_transcripts.py --commit --agent clerk` (static-bank incident target).

267 hindsight tests pass. Do NOT run against real banks without operator go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)