### PR TITLE
feat(worker-feed): show running total token count on the activity card

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -30816,7 +30816,7 @@ void (async () => {
                   )
                 }
               },
-              onFinish: ({ agentId, outcome, description, resultText, toolCount, durationMs, background: entryBackground }) => {
+              onFinish: ({ agentId, outcome, description, resultText, toolCount, totalTokens, durationMs, background: entryBackground }) => {
                 // Reaction promotion: if the parent turn already ended
                 // with this (or another) worker still running, its 👍 was
                 // deferred (held on ✍️/⚡). Now that a worker finished,
@@ -30886,6 +30886,7 @@ void (async () => {
                       description: dispatch.feedDescription,
                       lastTool: null,
                       toolCount,
+                      totalTokens,
                       latestSummary: resultText,
                       elapsedMs: durationMs,
                       state: outcome === 'failed' ? 'failed' : 'done',
@@ -30967,6 +30968,7 @@ void (async () => {
                       description: dispatch.feedDescription,
                       lastTool: null,
                       toolCount,
+                      totalTokens,
                       latestSummary: resultText,
                       elapsedMs: durationMs,
                       state: outcome === 'failed' ? 'failed' : 'done',
@@ -30988,6 +30990,7 @@ void (async () => {
                     description: dispatch.feedDescription,
                     lastTool: null,
                     toolCount,
+                    totalTokens,
                     latestSummary: resultText,
                     elapsedMs: durationMs,
                     state: outcome === 'failed' ? 'failed' : 'done',
@@ -31078,7 +31081,7 @@ void (async () => {
               // suppresses stale-after-restart delivery (a 4-h-old
               // "still working (5m)" would be a lie). Sweep on handback
               // lives in the `onFinish` block just above.
-              onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx, lastTool, toolCount, progressLine, model, skeleton }) => {
+              onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx, lastTool, toolCount, totalTokens, progressLine, model, skeleton }) => {
                 let fleetChatId = ''
                 try {
                   const fleets = progressDriver?.peekAllFleets() ?? []
@@ -31159,6 +31162,7 @@ void (async () => {
                         elapsedMs,
                         state: 'running',
                         model: feedModel,
+                        totalTokens,
                       },
                       wk.threadId,
                     )
@@ -31313,6 +31317,7 @@ void (async () => {
                       elapsedMs,
                       state: 'running',
                       model: feedModel,
+                      totalTokens,
                     },
                     wk.threadId,
                   )

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -134,6 +134,16 @@ export type SessionEvent =
   // `model` kind (sentinel-filtered, emitted first) but agent-scoped so the
   // watcher can track it per WorkerEntry and thread it onto the worker card.
   | { kind: 'sub_agent_model'; agentId: string; model: string }
+  // Per-assistant-message token usage for a SUB-AGENT, extracted from
+  // `message.usage` on each `type:"assistant"` transcript line. `totalTokens`
+  // is the summed delta for THIS message (input + output + cache_read +
+  // cache_creation). `messageId` is `message.id` — REQUIRED for dedup: Claude
+  // Code ≥2.1.x persists one logical assistant message as MULTIPLE JSONL lines
+  // sharing one `message.id`, each stamped with the SAME `usage` block, so the
+  // watcher must count a given `messageId` only once (naive summing across
+  // lines 2-3x over-counts; verified against live worker jsonl — 131 usage
+  // lines / 59 unique ids). Null messageId → un-dedupable, counted as-is.
+  | { kind: 'sub_agent_usage'; agentId: string; messageId: string | null; totalTokens: number }
   | { kind: 'sub_agent_tool_use'; agentId: string; toolUseId: string | null; toolName: string; input?: Record<string, unknown>; precomputedLabel?: string }
   // Same shared contract as the main-agent `text` kind — see its doc above
   // (including the `lastInMessage` projection-artifact note). The wire-kind
@@ -283,6 +293,30 @@ export function projectAssistantTextBlocks(
  * projectSubagentLine). A thinking-only or empty line returns false; the real
  * terminal rides the following content line, which also carries `end_turn`.
  */
+/**
+ * Sum the total token delta carried by a single assistant message's `usage`
+ * object: `input_tokens + output_tokens + cache_read_input_tokens +
+ * cache_creation_input_tokens`. Every field is guarded with `?? 0` — Claude
+ * Code omits fields that are zero/absent on some messages. A non-object (or
+ * missing) usage returns 0 so the caller can skip a no-usage line.
+ *
+ * These four fields ARE the whole per-message token cost (the nested
+ * `iterations` / `cache_creation` breakdowns are subsets already reflected in
+ * the top-level fields — never add them, that double-counts). Verified against
+ * live worker jsonl.
+ */
+export function sumUsageTokens(usage: unknown): number {
+  if (usage == null || typeof usage !== 'object') return 0
+  const u = usage as Record<string, unknown>
+  const n = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0)
+  return (
+    n(u.input_tokens) +
+    n(u.output_tokens) +
+    n(u.cache_read_input_tokens) +
+    n(u.cache_creation_input_tokens)
+  )
+}
+
 export function assistantLineCarriesAnswerSurface(
   content: Array<Record<string, unknown>> | undefined,
 ): boolean {
@@ -619,6 +653,22 @@ export function projectSubagentLine(
     const subModel = message?.model
     if (typeof subModel === 'string' && !isModelSentinel(subModel)) {
       events.push({ kind: 'sub_agent_model', agentId, model: subModel })
+    }
+    // Per-message token usage: surface the summed delta so the watcher can
+    // accumulate a running total for the worker-activity card's metrics line.
+    // `messageId` (message.id) rides along so the watcher dedups the multi-line
+    // split-message shape (one logical message → many JSONL lines, one shared
+    // `usage`). Emitted only when a usage object with a non-zero total exists —
+    // a no-usage line contributes nothing and is skipped here.
+    const subUsageTotal = sumUsageTokens(message?.usage)
+    if (subUsageTotal > 0) {
+      const subMsgId = message?.id
+      events.push({
+        kind: 'sub_agent_usage',
+        agentId,
+        messageId: typeof subMsgId === 'string' ? subMsgId : null,
+        totalTokens: subUsageTotal,
+      })
     }
     // Text→narrative projection comes from the SAME shared kernel as the
     // main agent (projectAssistantTextBlocks): one source for the empty-drop

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -125,6 +125,18 @@ export interface WorkerEntry {
   lastActivityAt: number
   /** Number of tool calls seen so far. */
   toolCount: number
+  /**
+   * Running TOTAL tokens across every assistant message the worker has emitted
+   * (input + output + cache_read + cache_creation, summed via sumUsageTokens).
+   * Accumulated from `sub_agent_usage` events, deduped by `seenUsageMessageIds`
+   * so the multi-line split-message shape (one logical message persisted as
+   * several JSONL lines sharing one `message.id` + identical `usage`) counts
+   * once. Rendered on the worker card's metrics line. 0 for a worker that never
+   * emitted a usage block (e.g. a non-Claude/litellm transcript).
+   */
+  totalTokens: number
+  /** message.id set already folded into `totalTokens` (usage dedup). */
+  seenUsageMessageIds: Set<string>
   /** True once a stall notification has been sent (suppresses repeat). */
   stallNotified: boolean
   /**
@@ -557,6 +569,9 @@ export interface SubagentWatcherConfig {
     state: WorkerState
     outcome: 'completed' | 'failed' | 'orphan'
     toolCount: number
+    /** Final running TOTAL tokens across the worker's whole life
+     *  (`WorkerEntry.totalTokens`). For the terminal worker-feed card. */
+    totalTokens: number
     durationMs: number
     /** Dispatch-time task description, for the handback envelope. */
     description: string
@@ -615,6 +630,10 @@ export interface SubagentWatcherConfig {
     lastTool: { name: string; sanitisedArg: string } | null
     /** Tool-use count observed so far. */
     toolCount: number
+    /** Running TOTAL tokens across the worker's assistant messages so far
+     *  (`WorkerEntry.totalTokens`). Threaded onto the worker/nested card's
+     *  metrics line. 0 for a worker that has emitted no usage yet / ever. */
+    totalTokens: number
     /** Friendly display line for THIS tick. Set on `sub_agent_tool_use`
      *  events to a `describeToolUse` label ("Reading X", "Running a
      *  command") so a foreground sub-agent that runs tools without
@@ -1089,6 +1108,8 @@ export function readSubTail(
     lastTool: { name: string; sanitisedArg: string } | null
     /** Tool-use count observed so far. */
     toolCount: number
+    /** Running total tokens so far (see SubagentWatcherConfig.onProgress). */
+    totalTokens: number
     /** Friendly display line for THIS tick (set on tool ticks; see the
      *  SubagentWatcherConfig.onProgress doc). */
     progressLine?: string
@@ -1179,6 +1200,7 @@ export function readSubTail(
               },
               lastTool: entry.lastTool,
               toolCount: entry.toolCount,
+              totalTokens: entry.totalTokens,
               model: entry.currentModel,
               skeleton: true,
             })
@@ -1320,6 +1342,7 @@ export function readSubTail(
               },
               lastTool: entry.lastTool,
               toolCount: entry.toolCount,
+              totalTokens: entry.totalTokens,
               model: entry.currentModel,
             })
             return true
@@ -1502,6 +1525,22 @@ export function readSubTail(
           }
           continue
         }
+        if (ev.kind === 'sub_agent_usage') {
+          // Accumulate the worker's running total tokens, deduped by
+          // message.id: the ≥2.1.x split-message shape stamps the SAME `usage`
+          // block on every JSONL line of one logical assistant message, so
+          // counting each line would 2-3x over-count. A null messageId is
+          // un-dedupable (older/edge shapes) — count it as-is (its usage is
+          // real). No card render here; the total rides the next onProgress
+          // tick's payload like the model does.
+          if (ev.messageId == null) {
+            entry.totalTokens += ev.totalTokens
+          } else if (!entry.seenUsageMessageIds.has(ev.messageId)) {
+            entry.seenUsageMessageIds.add(ev.messageId)
+            entry.totalTokens += ev.totalTokens
+          }
+          continue
+        }
         if (ev.kind === 'sub_agent_tool_use') {
           // Narrative-dedup gate step 2: a sub_agent_text block was pending;
           // this tool is the lookahead that decides it (SHOW unless it drafts
@@ -1567,6 +1606,7 @@ export function readSubTail(
                   },
                   lastTool: entry.lastTool,
                   toolCount: entry.toolCount,
+                  totalTokens: entry.totalTokens,
                   progressLine: toolLine,
                   model: entry.currentModel,
                 })
@@ -1892,6 +1932,8 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       dispatchedAt: n,
       lastActivityAt: n,
       toolCount: 0,
+      totalTokens: 0,
+      seenUsageMessageIds: new Set<string>(),
       stallNotified: false,
       stalledAt: null,
       completionNotified: false,
@@ -2157,6 +2199,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
             // registerAgent's short-circuit + Gap 1 promotion).
             outcome: entry.errored ? 'failed' : entry.historical ? 'orphan' : 'completed',
             toolCount: entry.toolCount,
+            totalTokens: entry.totalTokens,
             durationMs: nowFn() - entry.dispatchedAt,
             description: entry.description,
             // For a failure, fall back to the error detail when the worker
@@ -2184,6 +2227,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
             state: entry.state,
             outcome: 'failed',
             toolCount: entry.toolCount,
+            totalTokens: entry.totalTokens,
             durationMs: nowFn() - entry.dispatchedAt,
             description: entry.description,
             resultText: entry.lastResultText,

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -6,11 +6,50 @@ import {
   projectTranscriptLine,
   projectSubagentLine,
   projectAssistantTextBlocks,
+  sumUsageTokens,
   sanitizeCwdToProjectName,
   getProjectsDirForCwd,
   startSessionTail,
   type SessionEvent,
 } from '../session-tail.js'
+
+describe('sumUsageTokens', () => {
+  it('sums input + output + cache_read + cache_creation', () => {
+    expect(
+      sumUsageTokens({
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 1000,
+        cache_creation_input_tokens: 200,
+      }),
+    ).toBe(1350)
+  })
+
+  it('guards missing fields with 0', () => {
+    expect(sumUsageTokens({ output_tokens: 42 })).toBe(42)
+    expect(sumUsageTokens({})).toBe(0)
+  })
+
+  it('ignores the nested iterations / cache_creation breakdown (no double count)', () => {
+    expect(
+      sumUsageTokens({
+        input_tokens: 2,
+        output_tokens: 3,
+        cache_read_input_tokens: 4,
+        cache_creation_input_tokens: 5,
+        cache_creation: { ephemeral_1h_input_tokens: 5, ephemeral_5m_input_tokens: 0 },
+        iterations: [{ input_tokens: 2, output_tokens: 3 }],
+      }),
+    ).toBe(14)
+  })
+
+  it('returns 0 for null / non-object / non-numeric fields', () => {
+    expect(sumUsageTokens(null)).toBe(0)
+    expect(sumUsageTokens(undefined)).toBe(0)
+    expect(sumUsageTokens('nope')).toBe(0)
+    expect(sumUsageTokens({ input_tokens: 'x', output_tokens: null })).toBe(0)
+  })
+})
 
 describe('sanitizeCwdToProjectName', () => {
   it('replaces non-alphanumeric chars with hyphens', () => {
@@ -552,6 +591,55 @@ describe('projectSubagentLine', () => {
     const events = projectSubagentLine(line, 'X', st)
     expect(events.some((e) => e.kind === 'sub_agent_model')).toBe(false)
     expect(events[0].kind).toBe('sub_agent_tool_use')
+  })
+
+  it('emits sub_agent_usage with the summed per-message token delta + message.id', () => {
+    const st = { hasEmittedStart: true }
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_1',
+        model: 'claude-opus-4-8',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_input_tokens: 1000,
+          cache_creation_input_tokens: 200,
+        },
+        content: [{ type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } }],
+      },
+    })
+    const events = projectSubagentLine(line, 'X', st)
+    const usage = events.find((e) => e.kind === 'sub_agent_usage')
+    expect(usage).toEqual({ kind: 'sub_agent_usage', agentId: 'X', messageId: 'msg_1', totalTokens: 1350 })
+  })
+
+  it('emits no sub_agent_usage when the assistant line carries no usage', () => {
+    const st = { hasEmittedStart: true }
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_2',
+        model: 'claude-opus-4-8',
+        content: [{ type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } }],
+      },
+    })
+    const events = projectSubagentLine(line, 'X', st)
+    expect(events.some((e) => e.kind === 'sub_agent_usage')).toBe(false)
+  })
+
+  it('carries a null messageId when message.id is absent', () => {
+    const st = { hasEmittedStart: true }
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        usage: { input_tokens: 5, output_tokens: 5 },
+        content: [{ type: 'text', text: 'working' }],
+      },
+    })
+    const events = projectSubagentLine(line, 'X', st)
+    const usage = events.find((e) => e.kind === 'sub_agent_usage')
+    expect(usage).toEqual({ kind: 'sub_agent_usage', agentId: 'X', messageId: null, totalTokens: 10 })
   })
 
   it('emits sub_agent_tool_use for regular tools; nested Agent fires ONLY nested_spawn', () => {

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -550,6 +550,55 @@ describe('startSubagentWatcher', () => {
       expect(modelled?.model).toBe('claude-opus-4-8')
     })
 
+    it('accumulates total tokens across assistant messages, deduped by message.id', () => {
+      const progress: Array<{ totalTokens: number }> = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ totalTokens }) => { progress.push({ totalTokens }) },
+      })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Research the competitors')))
+      h.poll()
+
+      // Message 1 persisted as TWO JSONL lines sharing one message.id + the
+      // SAME usage block (the ≥2.1.x split-message shape). Must count ONCE.
+      const usage1 = {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 1000,
+        cache_creation_input_tokens: 200,
+      }
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { id: 'msg_1', model: 'claude-opus-4-8', usage: usage1, content: [{ type: 'text', text: 'thinking about it' }] },
+      }))
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { id: 'msg_1', model: 'claude-opus-4-8', usage: usage1, content: [{ type: 'tool_use', name: 'Read', id: 'r1', input: { file_path: '/x/a.ts' } }] },
+      }))
+      h.poll()
+
+      // A DISTINCT message adds on top; a line with NO usage contributes nothing.
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { id: 'msg_2', model: 'claude-opus-4-8', usage: { input_tokens: 2, output_tokens: 40 }, content: [{ type: 'tool_use', name: 'Bash', id: 'r2', input: {} }] },
+      }))
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { id: 'msg_3', model: 'claude-opus-4-8', content: [{ type: 'tool_use', name: 'Edit', id: 'r3', input: {} }] },
+      }))
+      h.poll()
+
+      // msg_1 (1350, counted once despite two lines) + msg_2 (42) = 1392.
+      expect(h.watcher.getRegistry().get('deadbeef')?.totalTokens).toBe(1392)
+      const last = progress[progress.length - 1]
+      expect(last.totalTokens).toBe(1392)
+    })
+
     it('ignores a synthetic model sentinel, keeping the last real model', () => {
       const agentDir = join(tmpRoot, 'agent')
       const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -7,7 +7,9 @@ import {
   renderActivityFeed,
   renderActivityFeedWithNested,
   renderActivityHeader,
+  renderCombinedWorkerFeed,
   formatFeedElapsed,
+  formatTokenCount,
   formatStepSuffix,
   STEP_TIMER_MIN_MS,
   type SessionActivityHeader,
@@ -744,6 +746,71 @@ describe("renderActivityHeader — two-line header builder", () => {
     expect(h2none).toBe("_15s · 7 tools_");
     const [, h2synth] = renderActivityHeader("🤖", "Agent", "", 15_000, 7, "running", "<synthetic>");
     expect(h2synth).toBe("_15s · 7 tools_");
+  });
+
+  it("inserts the token segment between tool count and model (running)", () => {
+    const [, h2] = renderActivityHeader("🛠", "Worker", "run tests", 120_000, 14, "running", "claude-opus-4-8", 12_400);
+    expect(h2).toBe("_2m00s · 14 tools · 12.4k tok · opus 4.8_");
+  });
+
+  it("inserts the token segment before elapsed on the done line", () => {
+    const [, h2] = renderActivityHeader("🛠", "Worker", "run tests", 65_000, 3, "done", undefined, 940);
+    expect(h2).toBe("_done · 3 tools · 940 tok · 1m05s_");
+  });
+
+  it("omits the token segment when total is 0 / undefined (both variants consistent)", () => {
+    const [, running] = renderActivityHeader("🛠", "Worker", "", 15_000, 7, "running", undefined, 0);
+    expect(running).toBe("_15s · 7 tools_");
+    const [, undef] = renderActivityHeader("🛠", "Worker", "", 15_000, 7, "running");
+    expect(undef).toBe("_15s · 7 tools_");
+    const [, doneZero] = renderActivityHeader("🛠", "Worker", "", 65_000, 3, "done", undefined, 0);
+    expect(doneZero).toBe("_done · 3 tools · 1m05s_");
+  });
+
+  it("renders tokens and model together, in order", () => {
+    const [, h2] = renderActivityHeader("🛠", "Worker", "", 10_000, 2, "running", "sr-glm-5", 1_200_000);
+    expect(h2).toBe("_10s · 2 tools · 1.2M tok · sr-glm-5_");
+  });
+});
+
+describe("formatTokenCount — compact token formatter", () => {
+  it("renders sub-1000 as a raw integer", () => {
+    expect(formatTokenCount(0)).toBe("0");
+    expect(formatTokenCount(1)).toBe("1");
+    expect(formatTokenCount(999)).toBe("999");
+  });
+
+  it("renders >=1000 as one-decimal k at the boundary", () => {
+    expect(formatTokenCount(1000)).toBe("1.0k");
+    expect(formatTokenCount(12_400)).toBe("12.4k");
+    expect(formatTokenCount(999_499)).toBe("999.5k");
+  });
+
+  it("renders >=1e6 as one-decimal M at the boundary", () => {
+    expect(formatTokenCount(1_000_000)).toBe("1.0M");
+    expect(formatTokenCount(1_200_000)).toBe("1.2M");
+  });
+
+  it("clamps negatives / non-finite to 0", () => {
+    expect(formatTokenCount(-5)).toBe("0");
+    expect(formatTokenCount(Number.NaN)).toBe("0");
+    expect(formatTokenCount(Number.POSITIVE_INFINITY)).toBe("0");
+  });
+});
+
+describe("renderCombinedWorkerFeed — token segment on the row header", () => {
+  it("shows `· N tok` per worker row and omits it at 0", () => {
+    const body = renderCombinedWorkerFeed(
+      [
+        { description: "alpha", elapsedMs: 15_000, toolCount: 3, currentStep: "Reading a.ts", totalTokens: 12_400 },
+        { description: "beta", elapsedMs: 20_000, toolCount: 5, currentStep: "Running tests", totalTokens: 0 },
+      ],
+      { maxRows: 5 },
+    );
+    expect(body).not.toBeNull();
+    expect(body!).toContain("**alpha** _· 15s · 3 tools · 12.4k tok_");
+    expect(body!).toContain("**beta** _· 20s · 5 tools_");
+    expect(body!).not.toContain("beta** _· 20s · 5 tools · 0 tok");
   });
 });
 

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -791,6 +791,15 @@ describe("formatTokenCount — compact token formatter", () => {
     expect(formatTokenCount(1_200_000)).toBe("1.2M");
   });
 
+  it("promotes the k→M rounding boundary (never renders 1000.0k)", () => {
+    // 999_949 rounds down to 999.9k; from 999_950 the 1-decimal k rounds to
+    // 1000.0 which must roll into the M branch as 1.0M.
+    expect(formatTokenCount(999_949)).toBe("999.9k");
+    expect(formatTokenCount(999_950)).toBe("1.0M");
+    expect(formatTokenCount(999_999)).toBe("1.0M");
+    expect(formatTokenCount(1_000_000)).toBe("1.0M");
+  });
+
   it("clamps negatives / non-finite to 0", () => {
     expect(formatTokenCount(-5)).toBe("0");
     expect(formatTokenCount(Number.NaN)).toBe("0");

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -185,19 +185,49 @@ export function renderActivityHeader(
   toolCount: number,
   state: 'running' | 'done' | 'failed' | 'incomplete',
   model?: string,
+  totalTokens?: number,
 ): [string, string] {
   const toolWord = toolCount === 1 ? 'tool' : 'tools'
   const elapsed = formatFeedElapsed(elapsedMs)
   const descPart = description.length > 0 ? ` · _${escapeMarkdown(description)}_` : ''
   const line1 = `${emoji} **${escapeMarkdown(label)}**${descPart}`
+  // Running total tokens: joins the dot-separated metrics between the tool
+  // count and the model tag. Omitted (empty) when the total is 0/unknown.
+  const tokPart = tokenSegment(totalTokens)
   // Subtle live-model tag: joins the existing dot-separated metrics (never a new
   // line). formatModelLabel returns null for absent/sentinel values → no suffix.
   const modelLabel = formatModelLabel(model)
   const modelPart = modelLabel != null ? ` · ${escapeMarkdown(modelLabel)}` : ''
   const line2 = state === 'running'
-    ? `_${elapsed} · ${toolCount} ${toolWord}${modelPart}_`
-    : `_${state} · ${toolCount} ${toolWord} · ${elapsed}${modelPart}_`
+    ? `_${elapsed} · ${toolCount} ${toolWord}${tokPart}${modelPart}_`
+    : `_${state} · ${toolCount} ${toolWord}${tokPart} · ${elapsed}${modelPart}_`
   return [line1, line2]
+}
+
+/**
+ * Compact token-count formatter for the activity card's metrics line:
+ *   <1000        → raw          ("940")
+ *   ≥1000, <1e6  → one-decimal k ("12.4k", "1.0k")
+ *   ≥1e6         → one-decimal M ("1.2M")
+ * Negative / non-finite inputs clamp to "0". The caller appends " tok".
+ */
+export function formatTokenCount(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '0'
+  if (n < 1000) return String(Math.floor(n))
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`
+  return `${(n / 1_000_000).toFixed(1)}M`
+}
+
+/**
+ * The ` · {N} tok` metrics segment, or '' when there are no tokens to show.
+ * A 0 / undefined total (a worker that emitted no usage — e.g. a non-Claude
+ * transcript) OMITS the segment entirely so the line stays clean; the same
+ * predicate is used by BOTH render variants (single-worker header + combined
+ * row) so they never diverge.
+ */
+function tokenSegment(totalTokens: number | undefined): string {
+  if (totalTokens == null || totalTokens <= 0) return ''
+  return ` · ${formatTokenCount(totalTokens)} tok`
 }
 
 /** Format elapsed milliseconds for display in the activity header (e.g. "12s", "2m05s"). */
@@ -289,6 +319,9 @@ export interface StatusCardHeader {
   /** Live model id (raw, e.g. `claude-opus-4-8`) — rendered as a short friendly
    *  tag on the metrics line via `formatModelLabel`. Omitted when unknown. */
   model?: string
+  /** Running total tokens for the worker/turn — rendered as `· {N} tok` on the
+   *  metrics line. Omitted (0/undefined) → no token segment. */
+  totalTokens?: number
 }
 
 /** Inputs to the unified status-card renderer. */
@@ -341,6 +374,7 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
         // 'failed', so only the worker card is affected.
         header.state,
         header.model,
+        header.totalTokens,
       )
     : []
 
@@ -596,6 +630,9 @@ export interface CombinedWorkerRow {
   historyLines?: string[]
   /** Live model id (raw, e.g. `claude-opus-4-8`); omitted when unknown. */
   model?: string
+  /** Running total tokens for this worker — rendered as `· {N} tok` on the row
+   *  header. Omitted (0/undefined) → no token segment. */
+  totalTokens?: number
 }
 
 export interface CombinedWorkerFeedOpts {
@@ -671,9 +708,10 @@ export function renderCombinedWorkerFeed(
       truncate(stripMarkdown(r.description).replace(/\s+/g, ' ').trim() || 'background task', COMBINED_ROW_DESC_MAX),
     )
     const toolWord = r.toolCount === 1 ? 'tool' : 'tools'
+    const tokPart = tokenSegment(r.totalTokens)
     const modelLabel = formatModelLabel(r.model)
     const modelPart = modelLabel != null ? ` · ${escapeMarkdown(modelLabel)}` : ''
-    return `**${desc}** _· ${formatFeedElapsed(r.elapsedMs)} · ${r.toolCount} ${toolWord}${modelPart}_`
+    return `**${desc}** _· ${formatFeedElapsed(r.elapsedMs)} · ${r.toolCount} ${toolWord}${tokPart}${modelPart}_`
   }
 
   // Raw (unescaped) history for a worker, oldest→newest, empty lines stripped.

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -214,7 +214,13 @@ export function renderActivityHeader(
 export function formatTokenCount(n: number): string {
   if (!Number.isFinite(n) || n <= 0) return '0'
   if (n < 1000) return String(Math.floor(n))
-  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`
+  if (n < 1_000_000) {
+    // Round to the displayed 1-decimal k FIRST: inputs in [999_950, 999_999]
+    // round to "1000.0k", which must promote into the M branch rather than
+    // render a nonsense "1000.0k". Fall through when the rounded k reaches 1000.
+    const k = Number((n / 1000).toFixed(1))
+    if (k < 1000) return `${k.toFixed(1)}k`
+  }
   return `${(n / 1_000_000).toFixed(1)}M`
 }
 

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -92,6 +92,13 @@ export interface WorkerActivityView {
   lastTool: { name: string; sanitisedArg: string } | null
   /** Number of tool calls observed so far. */
   toolCount: number
+  /**
+   * Running TOTAL tokens across the worker's assistant messages so far
+   * (input + output + cache_read + cache_creation, deduped by message.id in the
+   * watcher). Rendered as `· {N} tok` on the card's metrics line. Omitted /
+   * 0 → no token segment (a worker that emitted no usage).
+   */
+  totalTokens?: number
   /** The worker's latest narrative line, if any (already capped upstream). */
   latestSummary: string
   /**
@@ -178,6 +185,7 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     toolCount: v.toolCount,
     state: v.state,
     model: v.model,
+    totalTokens: v.totalTokens,
   }
 
   // Terminal: latestSummary carries the worker's final result text (gateway
@@ -798,6 +806,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         description: v.description,
         elapsedMs: elapsedFor(r),
         toolCount: v.toolCount,
+        totalTokens: v.totalTokens,
         currentStep,
         // Full per-worker rolling history (oldest→newest) so the combined feed
         // can paint an adaptive-depth ✓/→ trail, not just the latest line. The
@@ -1112,6 +1121,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       description: lv?.description ?? 'background task',
       lastTool: null,
       toolCount: lv?.toolCount ?? 0,
+      totalTokens: lv?.totalTokens,
       // No fabricated result paragraph — an authoritative sweep can't know what
       // the worker returned; the terminal card shows the header struck-through
       // as `incomplete`, and the handback (if it ran) carries the actual result.


### PR DESCRIPTION
## Summary
Adds a running **TOTAL token count** to the live 🛠 Worker activity feed's metrics line, for all agent types. The card now reads `elapsed · N tools · 12.4k tok · model`.

**Before:** `_2m00s · 14 tools · opus 4.8_`
**After (live):** `_2m00s · 14 tools · 12.4k tok · opus 4.8_`
**After (zero/unavailable usage):** `_2m00s · 14 tools · opus 4.8_` (segment omitted)

## Why
The card already surfaces elapsed, tool count, and model but gave no sense of token spend while a background sub-agent runs. Tokens are the operator's cost/scope signal.

## How
- **session-tail.ts**: new `sub_agent_usage` event + exported `sumUsageTokens` helper (input + output + cache_read + cache_creation, each `?? 0`).
- **subagent-watcher.ts**: accumulate `entry.totalTokens`, **deduped by `message.id`**, and thread through `onProgress` + `onFinish`.
- **tool-activity-summary.ts**: `formatTokenCount` (compact `<1000` raw / `k` / `M`) + a shared `tokenSegment` rendered on BOTH variants (single-worker header and combined-feed row).
- **gateway.ts / worker-activity-feed.ts**: thread `totalTokens` onto the views.

## The jsonl semantics I verified (contradicts the naive-sum premise)
Claude Code ≥2.1.x persists one logical assistant message as **multiple JSONL lines sharing one `message.id`**, each stamped with the **same** `usage` block. In a live worker transcript: **131 usage-carrying lines / 59 unique message ids** — naive per-line summing over-counts ~2.2x. So the event carries `messageId` and the watcher dedups via a `seenUsageMessageIds` set. Null messageId (edge shapes) is counted as-is.

## Design choice: 0/unavailable
The token segment is **omitted entirely** when the total is 0/undefined (a non-Claude/litellm worker that emits no usage). Same predicate on both render variants so they never diverge; the 🤖 agent card also omits it (it passes no token field).

## Applies to all agent types
worker/researcher/reviewer/general all flow through the same watcher + `renderStatusCard` / `renderCombinedWorkerFeed`; no agent-type branch bypasses it.

## Test plan
- New unit tests: `sumUsageTokens` (field guards, no-double-count of nested breakdown, non-object), `sub_agent_usage` projection (dedup id, no-usage skip, null id), watcher accumulation **deduped across split-message lines**, `formatTokenCount` boundaries (999/1000/12400/1.2M/0), `renderActivityHeader` + `renderCombinedWorkerFeed` token segment (running/done/omit).
- Scoped vitest green: tool-activity-summary (101), subagent-watcher (34), session-tail (57), worker-activity-feed (77), worker-feed-coalesce (28), terminal-truthful (5), budget-parity (5).
- `npm run lint` clean (tsc + all 8 guards).

## Risk
Low. Additive optional field; existing metrics-line assertions unchanged (segment omitted when no tokens). CI is the full-suite authority.

Job: `know-what-my-agent-is-doing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)