### PR TITLE
feat(turn-card): show the parent agent's own token count on its turn card

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3322,6 +3322,20 @@ type CurrentTurn = {
   // sync_retain are suppressed at the hook (computeLabel returns null) and
   // never arrive as tool_label events — excluded automatically.
   labeledToolCount: number
+  // Running total of the PARENT agent's OWN token usage this turn, summed from
+  // the main-tier session-tail `usage` events (input + output + cache_read +
+  // cache_creation per assistant message, via sumUsageTokens). Rendered on the
+  // 🤖 turn-activity card's metrics line (`… · N tok · model`). This is the
+  // parent alone — sub-agent tokens are NOT folded in here (they report on
+  // their own worker-feed rows; summing them would double-count). 0 until the
+  // turn's first assistant line carries a usage block.
+  totalTokens: number
+  // Dedup guard for `totalTokens`: Claude Code persists one logical assistant
+  // message as MULTIPLE JSONL lines sharing one `message.id`, each stamped with
+  // the SAME `usage` block. We fold a given `message.id` exactly once (same
+  // idempotency as the sub-agent watcher's `seenUsageMessageIds`). A null/absent
+  // messageId is un-dedupable and always counted.
+  seenUsageMessageIds: Set<string>
   // Tool-activity summary — mirrors Claude Code's native chat-UI
   // rendering ("Ran 5 commands, read a file"). Counters are
   // incremented in `case 'tool_use'`; `activityMessageId` holds the
@@ -16246,6 +16260,9 @@ function composeTurnActivity(turn: CurrentTurn, final = false, liveSuffix = ''):
     toolCount: turn.labeledToolCount,
     state: final ? 'done' : 'running',
     model: turn.currentModel,
+    // The parent's OWN running token total → `· N tok` on the metrics line.
+    // 0 → tokenSegment omits it (clean, same as the worker feed).
+    totalTokens: turn.totalTokens,
   }
   return renderActivityFeedWithNested(turn.mirrorLines, childLines, final, liveSuffix, stepCount, header)
 }
@@ -17303,6 +17320,8 @@ function handleSessionEvent(ev: SessionEvent): void {
           lastAssistantDone: false,
           toolCallCount: 0,
           labeledToolCount: 0,
+          totalTokens: 0,
+          seenUsageMessageIds: new Set<string>(),
           activityMessageId: null,
           activityInFlight: null,
           activityPendingRender: null,
@@ -17482,6 +17501,22 @@ function handleSessionEvent(ev: SessionEvent): void {
         turn.currentModel = ev.model
       }
       sessionModelSource.noteTranscriptModel(ev.model)
+      return
+    }
+    case 'usage': {
+      // Fold the parent agent's OWN per-message token usage into the turn's
+      // running total, deduped by message.id (one logical assistant message can
+      // land as several JSONL lines sharing one id + usage block). Rendered on
+      // the 🤖 turn-activity card's metrics line. Sub-agent tokens are NOT
+      // folded here — they surface on their own worker-feed rows; summing them
+      // would double-count. A null messageId is un-dedupable → always counted.
+      const turn = currentTurn
+      if (turn == null) return
+      if (ev.messageId != null) {
+        if (turn.seenUsageMessageIds.has(ev.messageId)) return
+        turn.seenUsageMessageIds.add(ev.messageId)
+      }
+      turn.totalTokens += ev.totalTokens
       return
     }
     case 'thinking': {

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -118,6 +118,16 @@ export type SessionEvent =
   // and reserved for a future staging-skip optimization; do not assume the
   // gate keys on it.
   | { kind: 'text'; text: string; blockIndex: number; lastInMessage: boolean }
+  // Per-assistant-message token usage for the MAIN agent, extracted from
+  // `message.usage` on each `type:"assistant"` transcript line. `totalTokens`
+  // is the summed delta for THIS message (input + output + cache_read +
+  // cache_creation, via sumUsageTokens). `messageId` is `message.id` —
+  // REQUIRED for dedup: Claude Code persists one logical assistant message as
+  // MULTIPLE JSONL lines sharing one `message.id`, each stamped with the SAME
+  // `usage` block, so the accumulator must count a given `messageId` only once
+  // (naive summing across lines over-counts). Null messageId → un-dedupable,
+  // counted as-is. Mirrors `sub_agent_usage` but for the parent's OWN tokens.
+  | { kind: 'usage'; messageId: string | null; totalTokens: number }
   | { kind: 'tool_result'; toolUseId: string; toolName: string | null; isError?: boolean; errorText?: string }
   // `reason` is set ONLY by an internal gateway-synthesized turn_end (never by
   // the JSONL projection). `answer-ready-quiescence` (PR A) marks the positive
@@ -499,6 +509,23 @@ export function projectTranscriptLine(line: string): SessionEvent[] {
     const mainModel = message?.model
     if (typeof mainModel === 'string' && !isModelSentinel(mainModel)) {
       events.push({ kind: 'model', model: mainModel })
+    }
+    // Per-message token usage (MAIN tier): surface the summed delta so the
+    // gateway can accumulate the parent's OWN running total for the turn card's
+    // metrics line. `messageId` (message.id) rides along so the accumulator
+    // dedups the multi-line split-message shape (one logical message → many
+    // JSONL lines, one shared `usage`). Emitted only when a usage object with a
+    // non-zero total exists — a no-usage line contributes nothing and is
+    // skipped. Mirrors the sub-agent emit below; this counts the parent alone
+    // (sub-agents report their own tokens on their worker-feed rows).
+    const mainUsageTotal = sumUsageTokens(message?.usage)
+    if (mainUsageTotal > 0) {
+      const mainMsgId = message?.id
+      events.push({
+        kind: 'usage',
+        messageId: typeof mainMsgId === 'string' ? mainMsgId : null,
+        totalTokens: mainUsageTotal,
+      })
     }
     // Text→narrative projection comes from the ONE shared kernel
     // (projectAssistantTextBlocks): it owns the empty-drop + blockIndex +

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -420,6 +420,49 @@ describe('projectTranscriptLine', () => {
     })
     expect(projectTranscriptLine(line)).toEqual([{ kind: 'thinking' }])
   })
+
+  it('emits a main-tier usage event with the summed per-message token delta + message.id', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_main_1',
+        model: 'claude-opus-4-8',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_input_tokens: 1000,
+          cache_creation_input_tokens: 200,
+        },
+        content: [{ type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } }],
+      },
+    })
+    const usage = projectTranscriptLine(line).find((e) => e.kind === 'usage')
+    expect(usage).toEqual({ kind: 'usage', messageId: 'msg_main_1', totalTokens: 1350 })
+  })
+
+  it('emits no main-tier usage event when the assistant line carries no usage', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_main_2',
+        model: 'claude-opus-4-8',
+        content: [{ type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } }],
+      },
+    })
+    expect(projectTranscriptLine(line).some((e) => e.kind === 'usage')).toBe(false)
+  })
+
+  it('carries a null messageId on the main-tier usage event when message.id is absent', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        usage: { input_tokens: 5, output_tokens: 5 },
+        content: [{ type: 'text', text: 'working' }],
+      },
+    })
+    const usage = projectTranscriptLine(line).find((e) => e.kind === 'usage')
+    expect(usage).toEqual({ kind: 'usage', messageId: null, totalTokens: 10 })
+  })
 })
 
 // ─── Bug 1 regression: per-file cursor state survives re-attachment ────

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -928,6 +928,39 @@ describe("renderActivityFeed — header param (main-session card fix)", () => {
     expect(nested).toContain("· opus 4.8_");
   });
 
+  it("threads the parent's OWN totalTokens through the flat and nested turn-card paths", () => {
+    const header: SessionActivityHeader = {
+      label: "Agent",
+      elapsedMs: 120_000,
+      toolCount: 14,
+      state: "running",
+      model: "claude-opus-4-8",
+      totalTokens: 12_400,
+    };
+    // Flat path (no foreground sub-agent).
+    const flat = renderActivityFeed(["Searching memory"], false, "", undefined, header)!;
+    expect(flat).toContain("_2m00s · 14 tools · 12.4k tok · opus 4.8_");
+    // Nested path (with a child line) carries the same token segment.
+    const nested = renderActivityFeedWithNested(["Reading"], ["nested step"], false, "", undefined, header)!;
+    expect(nested).toContain("· 12.4k tok ·");
+  });
+
+  it("omits the token segment on the turn card when totalTokens is 0 / undefined", () => {
+    const zero: SessionActivityHeader = {
+      label: "Agent",
+      elapsedMs: 15_000,
+      toolCount: 7,
+      state: "running",
+      totalTokens: 0,
+    };
+    const outZero = renderActivityFeed(["Searching memory"], false, "", undefined, zero)!;
+    expect(outZero).toContain("_15s · 7 tools_");
+    expect(outZero).not.toContain("tok");
+    // undefined behaves identically.
+    const undef: SessionActivityHeader = { label: "Agent", elapsedMs: 15_000, toolCount: 7, state: "running" };
+    expect(renderActivityFeed(["Searching memory"], false, "", undefined, undef)).toBe(outZero);
+  });
+
   it("prepends the done header when final=true", () => {
     const header: SessionActivityHeader = {
       label: "Agent",

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -115,6 +115,11 @@ export interface SessionActivityHeader {
    * `formatModelLabel` (model-label.ts).
    */
   model?: string
+  /** Running total tokens for THIS turn (the parent agent's OWN per-message
+   *  usage, summed + deduped upstream) — rendered as `· {N} tok` on the metrics
+   *  line via `tokenSegment`. Omitted (0/undefined) → no token segment, same
+   *  clean-omit behavior as the worker feed. */
+  totalTokens?: number
 }
 
 /**
@@ -537,6 +542,7 @@ export function renderActivityFeed(
           toolCount: header.toolCount,
           state: header.state,
           model: header.model,
+          totalTokens: header.totalTokens,
         }
       : undefined,
     steps: lines,
@@ -589,6 +595,7 @@ export function renderActivityFeedWithNested(
           toolCount: header.toolCount,
           state: header.state,
           model: header.model,
+          totalTokens: header.totalTokens,
         }
       : undefined,
     steps: lines,


### PR DESCRIPTION
## Summary
Adds the running token total for the TOP-LEVEL (parent) agent's OWN turn to the 🤖 turn-activity card metrics line, mirroring the worker-feed token segment shipped in #3250 for sub-agents. Sourced from the main agent's own jsonl per-message `usage` — NOT by summing sub-agents (which already report on their own worker-feed rows, so summing would double-count).

Before: `2m · 14 tools · opus 4.8`
After:  `2m · 14 tools · 12.4k tok · opus 4.8`

## Why
The parent agent's own token usage previously appeared on no card. The worker feed (#3250) covers sub-agents only; the turn card (`composeTurnActivity` / `SessionActivityHeader`) had no token field.

## How
- **session-tail.ts**: emit a new main-tier `usage` event (`message.id` + summed `totalTokens` via `sumUsageTokens`) in the main-agent assistant branch, only when the total > 0. Mirrors the existing `sub_agent_usage` emit.
- **gateway.ts**: accumulate onto `CurrentTurn.totalTokens`, deduped by `message.id` via a `seenUsageMessageIds` Set (same idempotency as the watcher — a message split across jsonl lines counts once). Thread it into the `SessionActivityHeader` built by `composeTurnActivity`.
- **tool-activity-summary.ts**: add `totalTokens` to `SessionActivityHeader` and thread it through both the flat and nested render paths (`renderActivityHeader` / `tokenSegment` already exist and clean-omit at 0).

Verified the main-agent (top-level, not `subagents/`) session jsonl carries per-message `usage` blocks with the same shape as sub-agent jsonl (input/output/cache_read/cache_creation).

## Test plan
- session-tail: main-tier usage emitted with right total + `message.id`; no-usage line emits nothing; null `message.id` carried through.
- tool-activity-summary: token segment renders on the turn card when > 0 and is omitted at 0/undefined, across flat + nested paths.
- Scoped vitest (164 tests) green; `npm run lint` clean.

Note: the gateway fold+dedup is inline in the unexported `handleSessionEvent` (no lightweight harness — consistent with the sibling `labeledToolCount`/`currentModel` folds, also untested at that layer); its dedup is identical to the watcher's already-tested `seenUsageMessageIds` path.

## Risk
Low — additive event kind + render field; 0/unavailable cleanly omits the segment. Parent-only accounting avoids double-counting sub-agent tokens.

Job spec: on-the-leash visibility (live progress card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)