### PR TITLE
fix(token-count): exclude cache_read from displayed token totals

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3323,8 +3323,9 @@ type CurrentTurn = {
   // never arrive as tool_label events — excluded automatically.
   labeledToolCount: number
   // Running total of the PARENT agent's OWN token usage this turn, summed from
-  // the main-tier session-tail `usage` events (input + output + cache_read +
-  // cache_creation per assistant message, via sumUsageTokens). Rendered on the
+  // the main-tier session-tail `usage` events (input + output + cache_creation
+  // per assistant message, via sumUsageTokens; cache_read is excluded —
+  // replayed cached context, not new work). Rendered on the
   // 🤖 turn-activity card's metrics line (`… · N tok · model`). This is the
   // parent alone — sub-agent tokens are NOT folded in here (they report on
   // their own worker-feed rows; summing them would double-count). 0 until the

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -120,8 +120,9 @@ export type SessionEvent =
   | { kind: 'text'; text: string; blockIndex: number; lastInMessage: boolean }
   // Per-assistant-message token usage for the MAIN agent, extracted from
   // `message.usage` on each `type:"assistant"` transcript line. `totalTokens`
-  // is the summed delta for THIS message (input + output + cache_read +
-  // cache_creation, via sumUsageTokens). `messageId` is `message.id` —
+  // is the NEW-work delta for THIS message (input + output + cache_creation,
+  // via sumUsageTokens; cache_read is deliberately excluded — replayed cached
+  // context, not new work). `messageId` is `message.id` —
   // REQUIRED for dedup: Claude Code persists one logical assistant message as
   // MULTIPLE JSONL lines sharing one `message.id`, each stamped with the SAME
   // `usage` block, so the accumulator must count a given `messageId` only once
@@ -146,8 +147,9 @@ export type SessionEvent =
   | { kind: 'sub_agent_model'; agentId: string; model: string }
   // Per-assistant-message token usage for a SUB-AGENT, extracted from
   // `message.usage` on each `type:"assistant"` transcript line. `totalTokens`
-  // is the summed delta for THIS message (input + output + cache_read +
-  // cache_creation). `messageId` is `message.id` — REQUIRED for dedup: Claude
+  // is the NEW-work delta for THIS message (input + output + cache_creation;
+  // cache_read is deliberately excluded — replayed cached context, not new
+  // work). `messageId` is `message.id` — REQUIRED for dedup: Claude
   // Code ≥2.1.x persists one logical assistant message as MULTIPLE JSONL lines
   // sharing one `message.id`, each stamped with the SAME `usage` block, so the
   // watcher must count a given `messageId` only once (naive summing across
@@ -304,16 +306,21 @@ export function projectAssistantTextBlocks(
  * terminal rides the following content line, which also carries `end_turn`.
  */
 /**
- * Sum the total token delta carried by a single assistant message's `usage`
- * object: `input_tokens + output_tokens + cache_read_input_tokens +
- * cache_creation_input_tokens`. Every field is guarded with `?? 0` — Claude
- * Code omits fields that are zero/absent on some messages. A non-object (or
- * missing) usage returns 0 so the caller can skip a no-usage line.
+ * Sum the NEW token work carried by a single assistant message's `usage`
+ * object: `input_tokens + output_tokens + cache_creation_input_tokens`. Every
+ * field is guarded with `?? 0` — Claude Code omits fields that are zero/absent
+ * on some messages. A non-object (or missing) usage returns 0 so the caller
+ * can skip a no-usage line.
  *
- * These four fields ARE the whole per-message token cost (the nested
- * `iterations` / `cache_creation` breakdowns are subsets already reflected in
- * the top-level fields — never add them, that double-counts). Verified against
- * live worker jsonl.
+ * `cache_read_input_tokens` is DELIBERATELY EXCLUDED. On a prompt-cached turn
+ * it is replayed context (billed at ~10% and doing no new work), and it
+ * dominates the raw total — including it made the displayed number 2-5x bigger
+ * than the actual work done this turn and misread as a cost/effort figure. The
+ * three fields kept here represent new tokens processed this turn: fresh input,
+ * generated output, and newly-written cache. The nested `iterations` /
+ * `cache_creation` breakdowns are subsets already reflected in the top-level
+ * fields — never add them, that double-counts. Verified against live worker
+ * jsonl.
  */
 export function sumUsageTokens(usage: unknown): number {
   if (usage == null || typeof usage !== 'object') return 0
@@ -322,7 +329,6 @@ export function sumUsageTokens(usage: unknown): number {
   return (
     n(u.input_tokens) +
     n(u.output_tokens) +
-    n(u.cache_read_input_tokens) +
     n(u.cache_creation_input_tokens)
   )
 }

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -127,7 +127,8 @@ export interface WorkerEntry {
   toolCount: number
   /**
    * Running TOTAL tokens across every assistant message the worker has emitted
-   * (input + output + cache_read + cache_creation, summed via sumUsageTokens).
+   * (input + output + cache_creation, summed via sumUsageTokens; cache_read is
+   * excluded — replayed cached context, not new work).
    * Accumulated from `sub_agent_usage` events, deduped by `seenUsageMessageIds`
    * so the multi-line split-message shape (one logical message persisted as
    * several JSONL lines sharing one `message.id` + identical `usage`) counts

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../session-tail.js'
 
 describe('sumUsageTokens', () => {
-  it('sums input + output + cache_read + cache_creation', () => {
+  it('sums input + output + cache_creation (cache_read excluded)', () => {
     expect(
       sumUsageTokens({
         input_tokens: 100,
@@ -22,7 +22,21 @@ describe('sumUsageTokens', () => {
         cache_read_input_tokens: 1000,
         cache_creation_input_tokens: 200,
       }),
-    ).toBe(1350)
+    ).toBe(350)
+  })
+
+  it('excludes a large cache_read_input_tokens from the total', () => {
+    // Locks in the deliberate exclusion: replayed cached context must not
+    // inflate the "new work this turn" figure. A future regression that
+    // re-adds cache_read makes this fail.
+    expect(
+      sumUsageTokens({
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 999_999,
+        cache_creation_input_tokens: 200,
+      }),
+    ).toBe(350)
   })
 
   it('guards missing fields with 0', () => {
@@ -40,7 +54,7 @@ describe('sumUsageTokens', () => {
         cache_creation: { ephemeral_1h_input_tokens: 5, ephemeral_5m_input_tokens: 0 },
         iterations: [{ input_tokens: 2, output_tokens: 3 }],
       }),
-    ).toBe(14)
+    ).toBe(10)
   })
 
   it('returns 0 for null / non-object / non-numeric fields', () => {
@@ -437,7 +451,7 @@ describe('projectTranscriptLine', () => {
       },
     })
     const usage = projectTranscriptLine(line).find((e) => e.kind === 'usage')
-    expect(usage).toEqual({ kind: 'usage', messageId: 'msg_main_1', totalTokens: 1350 })
+    expect(usage).toEqual({ kind: 'usage', messageId: 'msg_main_1', totalTokens: 350 })
   })
 
   it('emits no main-tier usage event when the assistant line carries no usage', () => {
@@ -654,7 +668,7 @@ describe('projectSubagentLine', () => {
     })
     const events = projectSubagentLine(line, 'X', st)
     const usage = events.find((e) => e.kind === 'sub_agent_usage')
-    expect(usage).toEqual({ kind: 'sub_agent_usage', agentId: 'X', messageId: 'msg_1', totalTokens: 1350 })
+    expect(usage).toEqual({ kind: 'sub_agent_usage', agentId: 'X', messageId: 'msg_1', totalTokens: 350 })
   })
 
   it('emits no sub_agent_usage when the assistant line carries no usage', () => {

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -593,10 +593,11 @@ describe('startSubagentWatcher', () => {
       }))
       h.poll()
 
-      // msg_1 (1350, counted once despite two lines) + msg_2 (42) = 1392.
-      expect(h.watcher.getRegistry().get('deadbeef')?.totalTokens).toBe(1392)
+      // msg_1 (350, counted once despite two lines; cache_read excluded)
+      // + msg_2 (42) = 392.
+      expect(h.watcher.getRegistry().get('deadbeef')?.totalTokens).toBe(392)
       const last = progress[progress.length - 1]
-      expect(last.totalTokens).toBe(1392)
+      expect(last.totalTokens).toBe(392)
     })
 
     it('ignores a synthetic model sentinel, keeping the last real model', () => {

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -94,8 +94,9 @@ export interface WorkerActivityView {
   toolCount: number
   /**
    * Running TOTAL tokens across the worker's assistant messages so far
-   * (input + output + cache_read + cache_creation, deduped by message.id in the
-   * watcher). Rendered as `· {N} tok` on the card's metrics line. Omitted /
+   * (input + output + cache_creation, deduped by message.id in the watcher;
+   * cache_read is excluded — replayed cached context, not new work). Rendered
+   * as `· {N} tok` on the card's metrics line. Omitted /
    * 0 → no token segment (a worker that emitted no usage).
    */
   totalTokens?: number


### PR DESCRIPTION
## Summary
Drops `cache_read_input_tokens` from `sumUsageTokens` (`telegram-plugin/session-tail.ts`). The token count shown on worker-feed cards and the turn card now means **new tokens processed this turn** — `input + output + cache_creation` — instead of a total dominated by replayed cached context.

## Why
On a prompt-cached turn `cache_read` dominates the raw sum and is billed at ~10% while doing no new work. Including it made the displayed number 2-5x larger than the actual work done this turn and misread as a cost/effort figure. This is a deliberate, approved behavior change to a just-shipped surface.

**Displayed numbers will drop 2-5x on cached turns.** `sumUsageTokens` is the single function feeding both the sub-agent worker-feed count (#3250, `sub_agent_usage`) and the main-agent turn card (#3253, main-tier `usage`), so every token surface updates consistently — intended.

## Changes
- `sumUsageTokens`: remove the `cache_read_input_tokens` term; keep `input + output + cache_creation` with the finite/`?? 0` guards. Signature and dedup-by-`message.id` untouched.
- Updated the docstring + inline field comments (`session-tail.ts`, `worker-activity-feed.ts`, `subagent-watcher.ts`, `gateway/gateway.ts`) to state cache_read is deliberately excluded and why.

## Test plan
Recomputed every fixture sum that included cache_read, and added a focused test locking in the exclusion:
- `sumUsageTokens` unit: `1350 → 350`; nested-breakdown `14 → 10`; new test asserts `cache_read: 999_999 → 350`.
- main-tier `usage` event: `1350 → 350`.
- `sub_agent_usage` event: `1350 → 350`.
- `subagent-watcher` dedup accumulation: `1392 → 392` (msg_1 350 counted once + msg_2 42).
- `tool-activity-summary` totals are passed as props (not derived from `sumUsageTokens`) — unchanged.

Scoped vitest (session-tail, subagent-watcher, tool-activity-summary): 199 passed. `npm run lint`: clean.

## Risk
Low. Pure display-value semantics; no behavior change beyond the reported token figure. Numbers intentionally drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)