### PR TITLE
docs(diagrams): comprehension-first diagram playbook + HTML render pipeline

### DIFF
--- a/docs/diagrams/DESIGN.md
+++ b/docs/diagrams/DESIGN.md
@@ -88,7 +88,7 @@ human, not the reverse.
 # Part 2 — Production pipeline
 
 Two sanctioned ways to author a diagram. Both produce a diffable text source
-and a raster build artifact; both obey the Part 2 visual recipe below.
+and a raster build artifact; both obey the Part 3 visual recipe below.
 
 ## Method A — HTML/CSS → 2x PNG (narrative diagrams)
 

--- a/docs/diagrams/scripts/render.sh
+++ b/docs/diagrams/scripts/render.sh
@@ -7,12 +7,12 @@
 # Renders the HTML at a 2x device scale into <name>.png next to the source.
 # The HTML is the source of truth; the PNG is a build artifact — re-render,
 # never hand-edit the PNG. A 2x screenshot of a ~1200-wide canvas produces a
-# ~2400px-wide PNG. Default canvas is 1200x800; pass WxH to override to match
+# ~2400px-wide PNG. Default canvas is 1200x760; pass WxH to override to match
 # the diagram's .stage dimensions.
 set -euo pipefail
 
 html="${1:-}"
-size="${2:-1200x800}"
+size="${2:-1200x760}"
 if [[ -z "$html" || ! -f "$html" ]]; then
   echo "usage: render.sh <diagram.html> [WxH]  (e.g. 1200x760)" >&2
   exit 2


### PR DESCRIPTION
## Summary

Extends the diagram design system (`docs/diagrams/DESIGN.md`) with the two
things that actually made the just-approved `approval-grant-flow` exemplar
land — and that v3 did not document.

**1. Comprehension-first principles (new Part 1, before the visual recipe).**
The old diagrams were visually coherent but "didn't make sense to a human"
because nobody wrote down the reader's job. Adds:
- the **one-idea rule** (state the single sentence a newcomer walks away with,
  at the top of the spec, before drawing);
- read-as-a-story discipline (one direction, numbered beats, concrete example
  over abstract placeholder);
- put the **human at the emotional centre** (the phone + approval card);
- cut implementation jargon out of the primary read;
- text rules: ≤5-word labels, sentence case on all text (one letterspaced
  kicker allowed), no em-dashes, one accent role-colour meaning, icons carry
  meaning.

**2. Production pipeline (new Part 2).** Documents **HTML/CSS → 2x PNG via
headless chromium** as a first-class authoring method alongside Eraser/hand-SVG,
with the working chromium invocation, the self-contained-HTML + system-font
constraint (no network for web fonts), and a when-to-use-which table. Adds a
reusable helper at `docs/diagrams/scripts/render.sh` (auto-discovers chromium,
renders `<name>.png` at 2x next to the source).

**Exemplar promoted to canonical.** Moves the approved diagram out of `_wip`:
`approval-grant-flow.html` (source of truth) + `approval-grant-flow.png` (2x,
2400×1520), and updates `approval-grant-flow.spec.md` with the one-idea line
and the HTML-authored note. DESIGN.md cites it as the reference implementation.

## Why

The visual recipe was already solid; the comprehension half and the actual
production method were tribal knowledge. This makes the guide strong enough
that any agent can reproduce the validated result.

## Scope / follow-up

Deliberately NOT in this PR: the legacy `.svg`/`.jpg` are kept, and README
image references are unchanged. The README image swap to the new 2x PNGs and
the rebuild of the remaining five diagrams to the comprehension-first bar land
in a **subsequent PR**.

## Test plan

Docs + one shell script; no source touched. `render.sh` validated (`bash -n`,
and it produced the committed 2400×1520 PNG). Relevant lint guards run clean
(`check-no-pii-secrets`, `check-stale-tool-descriptions`,
`check-no-unpinned-npx-playwright`). tsc is unaffected (zero TS changed).
CI is the authority.

## Risk

Low — documentation and a build helper. No runtime, no CLI, no invariant
touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)