### PR TITLE
fix(start.sh): offer Fable 5 in /model behind the litellm provider gate

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -144,6 +144,14 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
 x-litellm-customer-id: $SWITCHROOM_AGENT_NAME
 x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:-default}"
       export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+      # Offer Fable 5 in /model. The CLI's Fable gate only offers Fable when the
+      # firstParty ANTHROPIC_BASE_URL host is api.anthropic.com OR this env is
+      # set; agents route through litellm (non-Anthropic host), so without this
+      # /model fable silently no-ops. Value claude-fable-5 is ONLY valid via the
+      # litellm proxy (maps fable->anthropic/claude-fable-5); it is a RETIRED
+      # codename against direct Anthropic, so it must NEVER be set on the
+      # fail-open (direct OAuth) path below.
+      export ANTHROPIC_DEFAULT_FABLE_MODEL=claude-fable-5
     else
       # Missing-key fail-open: gateway talks direct OAuth, unproxied.
       unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE
@@ -1116,6 +1124,14 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
     # models configured in the proxy appear in the /model picker and can be
     # selected via --model. Without this, the CLI only knows its bundled list.
     export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+    # Offer Fable 5 in /model. The CLI's Fable gate only offers Fable when the
+    # firstParty ANTHROPIC_BASE_URL host is api.anthropic.com OR this env is set;
+    # agents route through litellm (non-Anthropic host), so without this
+    # /model fable silently no-ops. Value claude-fable-5 is ONLY valid via the
+    # litellm proxy (maps fable->anthropic/claude-fable-5); it is a RETIRED
+    # codename against direct Anthropic, so it must NEVER be set on the fail-open
+    # (direct OAuth) path below.
+    export ANTHROPIC_DEFAULT_FABLE_MODEL=claude-fable-5
     if [ -n "$sr_ll_ok" ]; then
       # Probe succeeded: proxy is live, so honor any sr-* session model override
       # below. On unreachable, _LITELLM_OK stays empty so the override is dropped


### PR DESCRIPTION
## Summary

Makes `/model fable` actually switch an agent to Fable 5 when it routes through the litellm custom provider. Today it silently no-ops and the session stays on Opus.

## Why (root cause — availability gate)

The claude CLI's Fable availability gate is:

- if `ANTHROPIC_DEFAULT_FABLE_MODEL` is set → offer Fable; else
- Fable is offered only when the firstParty provider's `ANTHROPIC_BASE_URL` host is `api.anthropic.com`.

Agents route through litellm at `http://127.0.0.1:4010/anthropic` — a non-Anthropic host — so without the env set, the gate does not offer Fable and `/model fable` is a no-op.

## The change

Add `export ANTHROPIC_DEFAULT_FABLE_MODEL=claude-fable-5` immediately after each `export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` in `profiles/_base/start.sh.hbs`. There are two such lines — the outer pre-fork pass and the inner tmux pass — both inside the litellm-key-fetched SUCCESS branch, above the fail-open `else` that unsets `ANTHROPIC_BASE_URL`. The env is added to both, and to nowhere else.

## Two-branch placement / fail-open safety (load-bearing)

`claude-fable-5` is valid **only** through the litellm proxy: the operator's litellm config maps `fable` → `anthropic/claude-fable-5`, and the proxy's `/v1/models` returns id `claude-fable-5`. Against **direct** Anthropic, `claude-fable-5` is a **retired codename** that previously caused a fleet 4xx outage.

So it must be set **only in the litellm-success branch**. On the fail-open path (litellm down → direct Anthropic OAuth), `ANTHROPIC_BASE_URL` is unset so the host is `api.anthropic.com`; the env stays **unset** and Fable resolves natively there (the gate passes on host alone). Result: no regression to the direct path and no reintroduction of the retired-codename outage.

## Test plan

- Scoped vitest: `scaffold.litellm-failopen`, `scaffold.litellm-gateway-outer`, `scaffold.gateway-env-order`, `scaffold.session-model` — all green.
- Grep confirms exactly two `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` occurrences, each followed by the new export.
- `npm run lint` — clean.
- Validated live on test-harness: with the env set + restart, `/model fable` → "Set model to Fable 5".

## Risk

Low. Single env var, scoped to the litellm-success branch only; the fail-open direct-OAuth path is untouched (retired-codename outage cannot recur). Full suite authority is CI.