### PR TITLE
fix(gateway): stop stale turn atom & wedged approval blocking /model & /effort on an idle session (#3262)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -803,6 +803,7 @@ import {
   removeTurnActiveMarker,
   sweepStaleTurnActiveMarker,
   readTurnActiveMarkerAgeMs,
+  effectiveTurnAgeMs,
   TURN_ACTIVE_MARKER_FILE,
   TURN_ACTIVE_HARD_TTL_MS,
   TURN_ACTIVE_IDLE_SWEEP_MS,
@@ -2862,32 +2863,34 @@ function turnInFlightForGate(): boolean {
   // handlers and do not sit behind this gate — and the block is surfaced
   // off-Telegram in blocked-approvals/<agent>.json.
   const hasPendingApproval = pendingPermissions.size > 0
-  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0 || hasPendingApproval
+  // The shared inbound gate stays STRICT: unconditionally busy whenever an
+  // approval card is outstanding (#2841 — a new inbound in that window would
+  // displace the approval context and orphan the pending MCP call). Only the
+  // machine-in-turn leg is factored out (`turnInFlightMachineOnly`); the
+  // `|| hasPendingApproval` composition here is what preserves the contract.
+  return turnInFlightMachineOnly() || hasPendingApproval
+}
+
+/**
+ * The machine-in-turn portion of the gate WITHOUT the `pendingPermissions`
+ * hold — "claude is actively producing a turn right now", ignoring an
+ * outstanding approval card. `turnInFlightForGate()` = this OR a pending
+ * approval, so the shared inbound-hold contract (#2841) is unchanged.
+ *
+ * Factored out so the `/model` & `/effort` busy decision can read THIS
+ * machine-only leg (plus a TTL-bounded approval check in
+ * `resolveModelEffortBusy`) — a wedged / undeliverable approval that "never
+ * expires by design" (#3084) must not hold their switch queued forever on an
+ * idle session (#3262), even though it correctly holds the general inbound gate.
+ */
+function turnInFlightMachineOnly(): boolean {
+  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0
   // Machine is authoritative. Run the log-only drift canary (#2794): the
   // imperative `claudeBusyKeys` shadow is still live in parallel, so a
   // dangerous over-hold divergence (machine holds the gate while the
   // imperative view is idle) is surfaced without changing behaviour. The
   // benign orphan-dangle direction — the wedge the machine self-heals — is
   // NOT flagged. `probeGateParity` returns the machine value unchanged.
-  return probeGateParity(isMachineInTurn(), claudeBusyKeys.size) || hasPendingApproval
-}
-
-/**
- * The machine-in-turn portion of the gate WITHOUT the `pendingPermissions`
- * hold — "claude is actively producing a turn right now", ignoring an
- * outstanding approval card.
- *
- * This is a SEPARATE reader, NOT a refactor of `turnInFlightForGate()`. The
- * shared gate stays strict and UNCONDITIONALLY true whenever a permission card
- * is outstanding (the #2841 inbound-hold contract — a source-inspection test
- * pins its exact body). Only the `/model` & `/effort` busy decision reads THIS
- * machine-only leg (plus a TTL-bounded approval check) so a wedged /
- * undeliverable approval that "never expires by design" (#3084) can't hold
- * their switch queued forever on an idle session (#3262). The two-branch logic
- * is duplicated deliberately to keep the shared gate's body untouched.
- */
-function turnInFlightMachineOnly(): boolean {
-  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0
   return probeGateParity(isMachineInTurn(), claudeBusyKeys.size)
 }
 
@@ -2901,8 +2904,7 @@ function turnInFlightMachineOnly(): boolean {
  */
 function liveTurnAgeMs(now: number): number | null {
   if (currentTurn === null) return null
-  const markerAge = readTurnActiveMarkerAgeMs(STATE_DIR, now)
-  return markerAge ?? (now - currentTurn.startedAt)
+  return effectiveTurnAgeMs(readTurnActiveMarkerAgeMs(STATE_DIR, now), currentTurn.startedAt, now)
 }
 
 /** Age (ms) of the OLDEST outstanding pending approval, or null when none. */

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -463,6 +463,7 @@ import { handleInjectCommand, type InjectDeps } from './inject-handler.js'
 import {
   parseModelCommand,
   planModelCommand,
+  resolveStaleAwareBusy,
   modelCommandReceiptLine,
   handleModelCommand,
   buildModelMenu,
@@ -803,6 +804,8 @@ import {
   sweepStaleTurnActiveMarker,
   readTurnActiveMarkerAgeMs,
   TURN_ACTIVE_MARKER_FILE,
+  TURN_ACTIVE_HARD_TTL_MS,
+  TURN_ACTIVE_IDLE_SWEEP_MS,
 } from './turn-active-marker.js'
 import {
   VERSION,
@@ -2859,14 +2862,83 @@ function turnInFlightForGate(): boolean {
   // handlers and do not sit behind this gate — and the block is surfaced
   // off-Telegram in blocked-approvals/<agent>.json.
   const hasPendingApproval = pendingPermissions.size > 0
-  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0 || hasPendingApproval
+  return turnInFlightMachineOnly() || hasPendingApproval
+}
+
+/**
+ * The machine-in-turn portion of the gate WITHOUT the `pendingPermissions`
+ * hold — "claude is actively producing a turn right now", ignoring an
+ * outstanding approval card. `/model` & `/effort` read THIS (plus a
+ * TTL-bounded approval check) so a wedged / undeliverable approval that "never
+ * expires by design" (#3084) can't hold their switch queued forever on an idle
+ * session (#3262). `turnInFlightForGate()` = this OR a pending approval.
+ */
+function turnInFlightMachineOnly(): boolean {
+  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0
   // Machine is authoritative. Run the log-only drift canary (#2794): the
   // imperative `claudeBusyKeys` shadow is still live in parallel, so a
   // dangerous over-hold divergence (machine holds the gate while the
   // imperative view is idle) is surfaced without changing behaviour. The
   // benign orphan-dangle direction — the wedge the machine self-heals — is
   // NOT flagged. `probeGateParity` returns the machine value unchanged.
-  return probeGateParity(isMachineInTurn(), claudeBusyKeys.size) || hasPendingApproval
+  return probeGateParity(isMachineInTurn(), claudeBusyKeys.size)
+}
+
+/**
+ * Age (ms) of the live turn for the phantom-turn cross-check (#3262): the
+ * turn-active liveness marker's mtime age (touched on every foreground
+ * tool_use AND on sub-agent JSONL growth, so a genuinely long turn keeps it
+ * small), falling back to `now - turn.startedAt` when the marker is absent
+ * (e.g. already swept). Null when no turn atom is set. A large age on a
+ * non-null atom is the dangling-atom signal.
+ */
+function liveTurnAgeMs(now: number): number | null {
+  if (currentTurn === null) return null
+  const markerAge = readTurnActiveMarkerAgeMs(STATE_DIR, now)
+  return markerAge ?? (now - currentTurn.startedAt)
+}
+
+/** Age (ms) of the OLDEST outstanding pending approval, or null when none. */
+function oldestPendingApprovalAgeMs(now: number): number | null {
+  let oldest: number | null = null
+  for (const p of pendingPermissions.values()) {
+    const age = now - p.startedAt
+    if (oldest === null || age > oldest) oldest = age
+  }
+  return oldest
+}
+
+/**
+ * Resolve the apply-vs-queue busy signals for a `/model` or `/effort` command,
+ * sweeping a stale (dangling) turn atom and discounting a wedged (undeliverable)
+ * approval hold — both bounded by the SAME `TURN_ACTIVE_HARD_TTL_MS` ceiling the
+ * marker sweep uses (#3262). A genuinely in-flight turn (fresh marker) and a
+ * recent pending approval still read busy, so the #3017/#3039 apply-or-queue
+ * contract and #3177/#3180 are preserved. Clears the dangling atom as a side
+ * effect so the phantom can't re-block the next command.
+ */
+function resolveModelEffortBusy(now = Date.now()): { currentTurnActive: boolean; turnInFlight: boolean } {
+  const turnAgeMs = liveTurnAgeMs(now)
+  const resolved = resolveStaleAwareBusy({
+    currentTurnActive: currentTurn !== null,
+    turnAgeMs,
+    machineInTurn: turnInFlightMachineOnly(),
+    oldestPendingApprovalAgeMs: oldestPendingApprovalAgeMs(now),
+    hardTtlMs: TURN_ACTIVE_HARD_TTL_MS,
+  })
+  if (resolved.clearStaleTurn && currentTurn !== null) {
+    const ageSec = Math.round((turnAgeMs ?? 0) / 1000)
+    process.stderr.write(
+      `telegram gateway: [phantomturn] cleared stale currentTurn atom age=${ageSec}s ` +
+      `ttl=${Math.round(TURN_ACTIVE_HARD_TTL_MS / 1000)}s for /model|/effort busy-check agent=${getMyAgentName()}\n`,
+    )
+    // Single-tenant / sequential-CLI invariant: the singleton `currentTurn` IS
+    // the only live turn, and a stale atom is a ghost (its `turn_end` never
+    // fired) — clearing every entry is equivalent to clearing it, matching the
+    // bridge-died "every entry is a ghost" semantics.
+    clearAllCurrentTurns()
+  }
+  return { currentTurnActive: resolved.currentTurnActive, turnInFlight: resolved.turnInFlight }
 }
 
 /**
@@ -7767,8 +7839,8 @@ const pendingStateReaper = setInterval(() => {
   try {
     sweepStaleTurnActiveMarker(STATE_DIR, {
       turnInFlight: currentTurn?.registryKey != null,
-      idleSweepMs: 60_000,
-      hardTtlMs: 10 * 60_000,
+      idleSweepMs: TURN_ACTIVE_IDLE_SWEEP_MS,
+      hardTtlMs: TURN_ACTIVE_HARD_TTL_MS,
       now,
       onRemove: ({ ageMs, reason, payload }) => {
         const agent = getMyAgentName()
@@ -23515,8 +23587,13 @@ bot.command('model', async ctx => {
   // command leaves a greppable log line + a history row before any branch. This
   // is the fix for the finn 2026-07-12 zero-trace swallow (no log, no reply, no
   // ack, no deferred apply). `busyNow` folds BOTH busy signals (turn atom AND
-  // the authoritative delivery-machine/approval gate).
-  const busyNow = currentTurn !== null || turnInFlightForGate()
+  // the authoritative delivery-machine/approval gate) — but a STALE atom or a
+  // wedged approval older than the hard TTL is discounted as idle (#3262), so a
+  // phantom "active turn" on an idle session no longer blocks the switch. Resolve
+  // once (it may clear a dangling atom) and reuse for both the receipt log and
+  // the routing disposition.
+  const modelBusy = resolveModelEffortBusy()
+  const busyNow = modelBusy.currentTurnActive || modelBusy.turnInFlight
   process.stderr.write(modelCommandReceiptLine(getMyAgentName(), parsed, busyNow) + '\n')
   if (HISTORY_ENABLED && ctx.message?.message_id != null) {
     try {
@@ -23538,8 +23615,8 @@ bot.command('model', async ctx => {
   // session busy by EITHER measure ack+queues instead of silently injecting
   // into a busy pane. Every branch below produces a visible action.
   const disposition = planModelCommand(parsed, {
-    currentTurnActive: currentTurn !== null,
-    turnInFlight: turnInFlightForGate(),
+    currentTurnActive: modelBusy.currentTurnActive,
+    turnInFlight: modelBusy.turnInFlight,
     menuEnabled: process.env.SWITCHROOM_MODEL_MENU !== '0',
   })
   if (disposition.kind === 'menu') {
@@ -23650,9 +23727,12 @@ bot.command('effort', async ctx => {
   }
   // Mid-turn: ACK + QUEUE + apply-on-idle + confirm (#3017) — parity with
   // /model. `applyEffort` mid-turn silently maybe-failed ("couldn't confirm it
-  // applied") before this gate existed. `currentTurn !== null` is the same
-  // busy signal the model path reads via deps.isBusy().
-  if ((parsed.kind === 'set' || parsed.kind === 'default') && currentTurn !== null) {
+  // applied") before this gate existed. Use the SAME stale-aware busy resolver
+  // as /model (#3262) so a dangling turn atom older than the hard TTL is
+  // discounted as idle and the switch applies instead of queuing forever on an
+  // idle session.
+  const effortBusy = resolveModelEffortBusy()
+  if ((parsed.kind === 'set' || parsed.kind === 'default') && effortBusy.currentTurnActive) {
     const requestedLevel = parsed.kind === 'set' ? parsed.level : 'default'
     const chatId = String(ctx.chat!.id)
     const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2862,25 +2862,32 @@ function turnInFlightForGate(): boolean {
   // handlers and do not sit behind this gate — and the block is surfaced
   // off-Telegram in blocked-approvals/<agent>.json.
   const hasPendingApproval = pendingPermissions.size > 0
-  return turnInFlightMachineOnly() || hasPendingApproval
-}
-
-/**
- * The machine-in-turn portion of the gate WITHOUT the `pendingPermissions`
- * hold — "claude is actively producing a turn right now", ignoring an
- * outstanding approval card. `/model` & `/effort` read THIS (plus a
- * TTL-bounded approval check) so a wedged / undeliverable approval that "never
- * expires by design" (#3084) can't hold their switch queued forever on an idle
- * session (#3262). `turnInFlightForGate()` = this OR a pending approval.
- */
-function turnInFlightMachineOnly(): boolean {
-  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0
+  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0 || hasPendingApproval
   // Machine is authoritative. Run the log-only drift canary (#2794): the
   // imperative `claudeBusyKeys` shadow is still live in parallel, so a
   // dangerous over-hold divergence (machine holds the gate while the
   // imperative view is idle) is surfaced without changing behaviour. The
   // benign orphan-dangle direction — the wedge the machine self-heals — is
   // NOT flagged. `probeGateParity` returns the machine value unchanged.
+  return probeGateParity(isMachineInTurn(), claudeBusyKeys.size) || hasPendingApproval
+}
+
+/**
+ * The machine-in-turn portion of the gate WITHOUT the `pendingPermissions`
+ * hold — "claude is actively producing a turn right now", ignoring an
+ * outstanding approval card.
+ *
+ * This is a SEPARATE reader, NOT a refactor of `turnInFlightForGate()`. The
+ * shared gate stays strict and UNCONDITIONALLY true whenever a permission card
+ * is outstanding (the #2841 inbound-hold contract — a source-inspection test
+ * pins its exact body). Only the `/model` & `/effort` busy decision reads THIS
+ * machine-only leg (plus a TTL-bounded approval check) so a wedged /
+ * undeliverable approval that "never expires by design" (#3084) can't hold
+ * their switch queued forever on an idle session (#3262). The two-branch logic
+ * is duplicated deliberately to keep the shared gate's body untouched.
+ */
+function turnInFlightMachineOnly(): boolean {
+  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0
   return probeGateParity(isMachineInTurn(), claudeBusyKeys.size)
 }
 

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -139,6 +139,74 @@ export function isModelCommandBusy(ctx: Pick<ModelCommandContext, 'currentTurnAc
 }
 
 /**
+ * Raw busy signals for a `/model` or `/effort` command, PLUS the ages needed
+ * to tell a live signal from a stale/dangling one (#3262). Pure + clock-free
+ * (ages are passed in) so the apply-vs-queue outcome is unit-testable with the
+ * same clock-injection pattern as the marker-sweep tests.
+ */
+export interface StaleAwareBusyInput {
+  /** The in-memory turn atom is non-null (`currentTurn !== null`). */
+  currentTurnActive: boolean
+  /**
+   * Age (ms) of the live turn: the turn-active liveness marker's mtime age
+   * (touched on every tool_use / sub-agent activity), falling back to
+   * `now - turn.startedAt` when the marker is absent. Null ONLY when there is
+   * no live turn (`currentTurnActive` false). A large age on a non-null atom
+   * means the `turn_end` that should have cleared it never fired — a phantom.
+   */
+  turnAgeMs: number | null
+  /**
+   * Machine-in-turn signal WITHOUT the pending-approval hold — the authoritative
+   * "claude is actively producing a turn" gate (`turnInFlightForGate()` minus
+   * its `pendingPermissions` leg).
+   */
+  machineInTurn: boolean
+  /**
+   * Age (ms) of the OLDEST outstanding pending approval, or null when there are
+   * none. A wedged / undeliverable approval "never expires by design" (#3084)
+   * and would otherwise hold the gate closed forever on an idle session.
+   */
+  oldestPendingApprovalAgeMs: number | null
+  /** Hard TTL ceiling (ms) — reuse `TURN_ACTIVE_HARD_TTL_MS`, do not invent one. */
+  hardTtlMs: number
+}
+
+export interface StaleAwareBusy {
+  /** The turn atom, with a stale (older-than-TTL) atom discounted to idle. */
+  currentTurnActive: boolean
+  /** The gate: machine-in-turn OR a pending approval still within the TTL. */
+  turnInFlight: boolean
+  /**
+   * True when the atom was judged STALE (non-null but older than the hard TTL).
+   * The gateway caller clears the dangling atom when this is set so the phantom
+   * doesn't re-block the next command either.
+   */
+  clearStaleTurn: boolean
+}
+
+/**
+ * Fold the raw busy signals into an apply-vs-queue decision that treats a turn
+ * atom OR a pending approval older than the hard TTL as STALE — a dangling atom
+ * / wedged approval, not a live turn (#3262). A genuinely fresh turn (recent
+ * marker) and a recent pending approval still read busy, preserving the
+ * #3017/#3039 apply-or-queue contract; only a stale signal is discounted.
+ */
+export function resolveStaleAwareBusy(input: StaleAwareBusyInput): StaleAwareBusy {
+  const turnStale =
+    input.currentTurnActive &&
+    input.turnAgeMs !== null &&
+    input.turnAgeMs > input.hardTtlMs
+  const approvalLive =
+    input.oldestPendingApprovalAgeMs !== null &&
+    input.oldestPendingApprovalAgeMs <= input.hardTtlMs
+  return {
+    currentTurnActive: input.currentTurnActive && !turnStale,
+    turnInFlight: input.machineInTurn || approvalLive,
+    clearStaleTurn: turnStale,
+  }
+}
+
+/**
  * What the gateway should do with a parsed `/model` command. Pure so the
  * routing decision is unit-testable without booting the bot. Every parsed
  * shape maps to exactly one visible action — there is NO branch that silently

--- a/telegram-plugin/gateway/turn-active-marker.ts
+++ b/telegram-plugin/gateway/turn-active-marker.ts
@@ -214,3 +214,20 @@ export function readTurnActiveMarkerAgeMs(stateDir: string, now?: number): numbe
     return null; // ENOENT / unstattable → not working
   }
 }
+
+/**
+ * Effective age (ms) of a live turn for the phantom-turn cross-check (#3262):
+ * prefer the turn-active liveness marker's mtime age (touched on every
+ * tool_use / sub-agent activity, so a genuinely long turn keeps it small),
+ * falling back to `now - turnStartedAt` when the marker is absent (e.g. already
+ * swept away). Pure so the fallback branch is unit-testable with an injected
+ * clock. `markerAgeMs` is the result of `readTurnActiveMarkerAgeMs` (null when
+ * the marker is gone).
+ */
+export function effectiveTurnAgeMs(
+  markerAgeMs: number | null,
+  turnStartedAt: number,
+  now: number,
+): number {
+  return markerAgeMs ?? now - turnStartedAt;
+}

--- a/telegram-plugin/gateway/turn-active-marker.ts
+++ b/telegram-plugin/gateway/turn-active-marker.ts
@@ -38,6 +38,24 @@ import { join } from "node:path";
 
 export const TURN_ACTIVE_MARKER_FILE = "turn-active.json";
 
+/**
+ * Absolute ceiling (ms) beyond which a turn-active signal cannot reflect a
+ * real in-flight turn. This is the marker sweep's `hardTtlMs` (`gateway.ts`
+ * `sweepStaleTurnActiveMarker` callsite). Exported so the `/model` & `/effort`
+ * busy-gate cross-checks the in-memory turn atom and the pending-approval hold
+ * against the SAME ceiling it sweeps the marker file at (#3262) — instead of
+ * the atom leaking past it and reading as a phantom "active turn" on an idle
+ * session.
+ */
+export const TURN_ACTIVE_HARD_TTL_MS = 10 * 60_000;
+
+/**
+ * Idle-sweep threshold (ms): the marker is swept this soon when the caller
+ * asserts no turn is in flight. Exported alongside the hard TTL so both
+ * bounds have a single source of truth.
+ */
+export const TURN_ACTIVE_IDLE_SWEEP_MS = 60_000;
+
 export interface TurnActiveMarker {
   turnKey: string;
   chatId: string;

--- a/telegram-plugin/tests/effort-command.test.ts
+++ b/telegram-plugin/tests/effort-command.test.ts
@@ -21,6 +21,7 @@ import {
   EFFORT_CALLBACK_PREFIX,
   type EffortCommandDeps,
 } from "../gateway/effort-command.js";
+import { resolveStaleAwareBusy } from "../gateway/model-command.js";
 import type { EffortApplyResult } from "../../src/agents/effort-picker.js";
 
 function applyOk(level: string, confirmed = false): EffortApplyResult {
@@ -253,5 +254,51 @@ describe("effort-command: /effort default (#3039)", () => {
     const r = await handleEffortCommand({ kind: "help" }, makeDeps().deps);
     expect(r.text).toContain("/effort default");
     expect(r.text).toContain("lasts until the agent’s next restart");
+  });
+
+  // #3262 parity with /model: the gateway gates the effort apply-vs-queue on
+  // `resolveModelEffortBusy().currentTurnActive` (the turn-atom leg — /effort
+  // does not consult the delivery-machine/approval gate). These pin the SAME
+  // stale-aware decision the gateway feeds that gate: a dangling atom older than
+  // the hard TTL reads idle → APPLY; a fresh atom reads busy → QUEUE.
+  describe("phantom 'active turn' apply-vs-queue (#3262)", () => {
+    const HARD_TTL = 10 * 60_000;
+    // The gateway's effort queue predicate, reduced to the signal it reads.
+    const effortWouldQueue = (currentTurnActive: boolean): boolean => currentTurnActive;
+
+    it("APPLIES a set when the turn atom is DANGLING (older than the hard TTL)", () => {
+      const r = resolveStaleAwareBusy({
+        currentTurnActive: true,
+        turnAgeMs: HARD_TTL + 1,
+        machineInTurn: false,
+        oldestPendingApprovalAgeMs: null,
+        hardTtlMs: HARD_TTL,
+      });
+      expect(r.clearStaleTurn).toBe(true);
+      expect(effortWouldQueue(r.currentTurnActive)).toBe(false); // → applies now
+    });
+
+    it("QUEUES a set when the turn is FRESH (marker within the TTL) — no regression", () => {
+      const r = resolveStaleAwareBusy({
+        currentTurnActive: true,
+        turnAgeMs: 5_000,
+        machineInTurn: false,
+        oldestPendingApprovalAgeMs: null,
+        hardTtlMs: HARD_TTL,
+      });
+      expect(r.clearStaleTurn).toBe(false);
+      expect(effortWouldQueue(r.currentTurnActive)).toBe(true); // → queues
+    });
+
+    it("APPLIES when there is no turn atom at all", () => {
+      const r = resolveStaleAwareBusy({
+        currentTurnActive: false,
+        turnAgeMs: null,
+        machineInTurn: false,
+        oldestPendingApprovalAgeMs: null,
+        hardTtlMs: HARD_TTL,
+      });
+      expect(effortWouldQueue(r.currentTurnActive)).toBe(false);
+    });
   });
 });

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import {
   parseModelCommand,
   planModelCommand,
+  resolveStaleAwareBusy,
   isModelCommandBusy,
   modelCommandReceiptLine,
   handleModelCommand,
@@ -1619,6 +1620,117 @@ describe("#3177 typed /model never silently swallowed mid-turn", () => {
     it("APPLIES help so a bad arg still gets an explicit reply", () => {
       const parsed = { kind: "help", reason: "not a valid model name: !!" } as const;
       expect(planModelCommand(parsed, busyByGate)).toEqual({ kind: "apply", parsed });
+    });
+  });
+
+  describe("resolveStaleAwareBusy — phantom 'active turn' fix (#3262)", () => {
+    const HARD_TTL = 10 * 60_000;
+
+    it("APPLIES a set when the turn atom is DANGLING (older than the hard TTL)", () => {
+      // A currentTurn atom whose turn_end never fired: non-null but its
+      // liveness marker is far older than the ceiling. Discounted to idle,
+      // and flagged for the gateway to clear.
+      const r = resolveStaleAwareBusy({
+        currentTurnActive: true,
+        turnAgeMs: HARD_TTL + 1,
+        machineInTurn: false,
+        oldestPendingApprovalAgeMs: null,
+        hardTtlMs: HARD_TTL,
+      });
+      expect(r.currentTurnActive).toBe(false);
+      expect(r.turnInFlight).toBe(false);
+      expect(r.clearStaleTurn).toBe(true);
+      // Routing sees "idle" → applies, not queues.
+      const d = planModelCommand(
+        { kind: "set", model: "opus" },
+        { currentTurnActive: r.currentTurnActive, turnInFlight: r.turnInFlight, menuEnabled: true },
+      );
+      expect(d).toEqual({ kind: "apply", parsed: { kind: "set", model: "opus" } });
+    });
+
+    it("QUEUES a set when the turn is FRESH (marker within the TTL) — no regression", () => {
+      const r = resolveStaleAwareBusy({
+        currentTurnActive: true,
+        turnAgeMs: 5_000,
+        machineInTurn: false,
+        oldestPendingApprovalAgeMs: null,
+        hardTtlMs: HARD_TTL,
+      });
+      expect(r.currentTurnActive).toBe(true);
+      expect(r.clearStaleTurn).toBe(false);
+      const d = planModelCommand(
+        { kind: "set", model: "opus" },
+        { currentTurnActive: r.currentTurnActive, turnInFlight: r.turnInFlight, menuEnabled: true },
+      );
+      expect(d).toEqual({ kind: "queue", target: "opus" });
+    });
+
+    it("APPLIES when only a WEDGED approval (older than the TTL) holds the gate on an idle session", () => {
+      const r = resolveStaleAwareBusy({
+        currentTurnActive: false,
+        turnAgeMs: null,
+        machineInTurn: false,
+        oldestPendingApprovalAgeMs: HARD_TTL + 1,
+        hardTtlMs: HARD_TTL,
+      });
+      expect(r.turnInFlight).toBe(false);
+      expect(r.currentTurnActive).toBe(false);
+      const d = planModelCommand(
+        { kind: "set", model: "opus" },
+        { currentTurnActive: r.currentTurnActive, turnInFlight: r.turnInFlight, menuEnabled: true },
+      );
+      expect(d).toEqual({ kind: "apply", parsed: { kind: "set", model: "opus" } });
+    });
+
+    it("QUEUES when a RECENT pending approval holds the gate — a real block is preserved", () => {
+      const r = resolveStaleAwareBusy({
+        currentTurnActive: false,
+        turnAgeMs: null,
+        machineInTurn: false,
+        oldestPendingApprovalAgeMs: 3_000,
+        hardTtlMs: HARD_TTL,
+      });
+      expect(r.turnInFlight).toBe(true);
+      const d = planModelCommand(
+        { kind: "set", model: "opus" },
+        { currentTurnActive: r.currentTurnActive, turnInFlight: r.turnInFlight, menuEnabled: true },
+      );
+      expect(d).toEqual({ kind: "queue", target: "opus" });
+    });
+
+    it("QUEUES when the machine is genuinely in-turn regardless of atom age", () => {
+      const r = resolveStaleAwareBusy({
+        currentTurnActive: false,
+        turnAgeMs: null,
+        machineInTurn: true,
+        oldestPendingApprovalAgeMs: null,
+        hardTtlMs: HARD_TTL,
+      });
+      expect(r.turnInFlight).toBe(true);
+      expect(r.clearStaleTurn).toBe(false);
+    });
+
+    it("does NOT clear or discount when there is no turn atom", () => {
+      const r = resolveStaleAwareBusy({
+        currentTurnActive: false,
+        turnAgeMs: null,
+        machineInTurn: false,
+        oldestPendingApprovalAgeMs: null,
+        hardTtlMs: HARD_TTL,
+      });
+      expect(r).toEqual({ currentTurnActive: false, turnInFlight: false, clearStaleTurn: false });
+    });
+
+    it("keeps a non-null atom busy when its age is exactly at the ceiling (strict >)", () => {
+      const r = resolveStaleAwareBusy({
+        currentTurnActive: true,
+        turnAgeMs: HARD_TTL,
+        machineInTurn: false,
+        oldestPendingApprovalAgeMs: null,
+        hardTtlMs: HARD_TTL,
+      });
+      expect(r.currentTurnActive).toBe(true);
+      expect(r.clearStaleTurn).toBe(false);
     });
   });
 

--- a/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
+++ b/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
@@ -90,20 +90,27 @@ describe('inbound gate holds while approval card is outstanding (#2841)', () => 
   // even after releaseTurnBufferGate has cleared claudeBusyKeys/machine on the
   // first interim reply. Without this, a new inbound delivered in that window
   // displaces the approval context and orphans the pending MCP call.
-  it('turnInFlightForGate includes pendingPermissions.size > 0 on the legacy path', () => {
-    // span 2600: the function gained a ~1100-char note (#3084 follow-up) documenting
-    // the one case with no timeout valve — a HELD approval.
-    const fn = slice(GATEWAY, 'function turnInFlightForGate()', 2600)
-    // Both paths (legacy claudeBusyKeys + machine-authoritative) must include the check.
-    expect(fn).toMatch(/claudeBusyKeys\.size\s*>\s*0\s*\|\|\s*hasPendingApproval/)
+  it('turnInFlightForGate STILL composes the pending-approval hold (#2841 contract)', () => {
+    // #3262 factored the machine-in-turn leg into turnInFlightMachineOnly(), but
+    // the shared inbound gate must remain UNCONDITIONALLY busy while an approval
+    // card is outstanding. That contract now lives in the composition here.
+    // span 2800: the function carries a ~1100-char #2841/#3084 note before the
+    // composition line.
+    const fn = slice(GATEWAY, 'function turnInFlightForGate()', 2800)
+    expect(fn).toMatch(/return\s+turnInFlightMachineOnly\(\)\s*\|\|\s*hasPendingApproval/)
+    expect(fn).toMatch(/hasPendingApproval\s*=\s*pendingPermissions\.size\s*>\s*0/)
   })
 
-  it('turnInFlightForGate includes pendingPermissions.size > 0 on the machine path', () => {
-    const fn = slice(GATEWAY, 'function turnInFlightForGate()', 2700)
-    // probeGateParity(...) || hasPendingApproval — the inner arg contains its own
-    // parens (isMachineInTurn()), so match the two tokens independently.
+  it('turnInFlightMachineOnly carries BOTH busy paths (legacy claudeBusyKeys + machine)', () => {
+    // #3262: the machine-in-turn signal moved here (read by the /model & /effort
+    // resolver without the approval hold). Both the legacy claudeBusyKeys path
+    // and the machine-authoritative probeGateParity path must be present — a
+    // dropped branch would silently change the busy read.
+    const fn = slice(GATEWAY, 'function turnInFlightMachineOnly()', 1400)
+    expect(fn).toMatch(/claudeBusyKeys\.size\s*>\s*0/)
     expect(fn).toContain('probeGateParity(')
-    expect(fn).toMatch(/probeGateParity[\s\S]+?\|\|\s*hasPendingApproval/)
+    // NOT gated by the approval hold — that stays in turnInFlightForGate.
+    expect(fn).not.toContain('hasPendingApproval')
   })
 
   it('hasPendingApproval reads pendingPermissions.size', () => {

--- a/telegram-plugin/tests/turn-active-marker.test.ts
+++ b/telegram-plugin/tests/turn-active-marker.test.ts
@@ -15,6 +15,7 @@ import {
   removeTurnActiveMarker,
   sweepStaleTurnActiveMarker,
   readTurnActiveMarkerAgeMs,
+  effectiveTurnAgeMs,
   TURN_ACTIVE_HARD_TTL_MS,
   TURN_ACTIVE_IDLE_SWEEP_MS,
 } from '../gateway/turn-active-marker.js'
@@ -37,6 +38,23 @@ describe('turn-active-marker (#412)', () => {
     expect(TURN_ACTIVE_HARD_TTL_MS).toBe(10 * 60_000)
     expect(TURN_ACTIVE_IDLE_SWEEP_MS).toBe(60_000)
     expect(TURN_ACTIVE_HARD_TTL_MS).toBeGreaterThan(TURN_ACTIVE_IDLE_SWEEP_MS)
+  })
+
+  it('effectiveTurnAgeMs prefers the marker age when present (#3262)', () => {
+    // Marker present (touched on tool_use) → its age wins over the fixed
+    // turn.startedAt, so a legitimately LONG turn that keeps touching the
+    // marker reads fresh and is never mis-swept as a phantom.
+    const now = 1_000_000
+    expect(effectiveTurnAgeMs(5_000, now - 9_999_999, now)).toBe(5_000)
+  })
+
+  it('effectiveTurnAgeMs falls back to now - startedAt when the marker is absent (#3262)', () => {
+    // Marker already swept (null age) → fall back to the turn-start timestamp,
+    // so a dangling atom whose marker was reaped still reports a large age and
+    // is recognised as stale by the /model & /effort cross-check.
+    const now = 1_000_000
+    const startedAt = now - 42_000
+    expect(effectiveTurnAgeMs(null, startedAt, now)).toBe(42_000)
   })
 
   it('writeTurnActiveMarker creates a JSON file with the expected payload', () => {

--- a/telegram-plugin/tests/turn-active-marker.test.ts
+++ b/telegram-plugin/tests/turn-active-marker.test.ts
@@ -15,6 +15,8 @@ import {
   removeTurnActiveMarker,
   sweepStaleTurnActiveMarker,
   readTurnActiveMarkerAgeMs,
+  TURN_ACTIVE_HARD_TTL_MS,
+  TURN_ACTIVE_IDLE_SWEEP_MS,
 } from '../gateway/turn-active-marker.js'
 
 describe('turn-active-marker (#412)', () => {
@@ -26,6 +28,15 @@ describe('turn-active-marker (#412)', () => {
 
   afterEach(() => {
     rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('exports the sweep TTL bounds as shared constants (#3262 single source of truth)', () => {
+    // The /model & /effort phantom-turn cross-check reuses these SAME bounds —
+    // guarding against a drift where the atom ceiling and the marker ceiling
+    // diverge into two different magic numbers.
+    expect(TURN_ACTIVE_HARD_TTL_MS).toBe(10 * 60_000)
+    expect(TURN_ACTIVE_IDLE_SWEEP_MS).toBe(60_000)
+    expect(TURN_ACTIVE_HARD_TTL_MS).toBeGreaterThan(TURN_ACTIVE_IDLE_SWEEP_MS)
   })
 
   it('writeTurnActiveMarker creates a JSON file with the expected payload', () => {


### PR DESCRIPTION
Fixes #3262.

## Summary

`/model` and `/effort` refused to apply on a genuinely **idle** session —
either queuing ("I'll switch the moment this turn finishes") or hard-refusing
("the agent is mid-turn — a model switch needs an idle session") — when there
was NO active turn. Two folded busy signals could dangle past any real turn,
and neither was covered by the deterministic staleness sweep that already
guards the turn-active **marker file**:

1. **Dangling turn atom** — `currentTurn !== null` (`gateway.ts`) is cleared
   ONLY by `endCurrentTurnAtomic` on `turn_end`. An SDK kill / flush /
   interrupt before `turn_end` leaves it non-null; only the silence-poke
   fallback eventually clears it. In that window the switch saw a phantom
   turn. Affects both `/model` and `/effort` (`/effort` gated on the atom
   alone).
2. **Wedged approval gate** — `turnInFlightForGate()` returns true whenever
   `pendingPermissions.size > 0`; an approval whose card could not be
   delivered "never expires, by design" (#3084), holding the gate closed on
   an idle session. Affects `/model`.

## Why this approach

The repo already has a deterministic staleness mechanism for the turn-active
**marker file** (`sweepStaleTurnActiveMarker` / `readTurnActiveMarkerAgeMs`
with `hardTtlMs = 10*60_000`). The in-memory atom that `/model`/`/effort`
read, and the pending-approval hold, were simply not covered by that ceiling.
This PR closes that asymmetry — no new magic number:

- Exported the sweep bounds as `TURN_ACTIVE_HARD_TTL_MS` /
  `TURN_ACTIVE_IDLE_SWEEP_MS` (single source of truth; the sweep callsite now
  reads them too).
- New pure `resolveStaleAwareBusy` (in `model-command.ts`): cross-checks the
  live-turn liveness marker age (touched on every tool_use / sub-agent
  activity, so a legitimately **long** turn stays fresh — this is why we key
  on the marker age, not the fixed `turn.startedAt`) against the hard TTL.
  Older than the ceiling → the atom is stale → discount to idle and flag it
  for clearing. The gateway wrapper `resolveModelEffortBusy` performs the
  clear (`clearAllCurrentTurns`, safe under the single-tenant sequential-CLI
  invariant) and both `/model` and `/effort` route on its result.

### Approval leg: TTL bound, not a blanket exemption

The task suggested preferring a full exemption of `/model`/`/effort` from the
`pendingPermissions` gate (matching `/allow` `/deny` `/pending`). I chose the
**TTL bound** instead, deliberately:

- A pending approval means claude is genuinely **blocked mid-tool** waiting
  for the verdict — the machine gate was released after the first interim
  reply (#2841), so the session is NOT idle. A blanket exemption would let
  `/model` inject into a genuinely-blocked pane and be swallowed — reviving
  the #2841/#1556 stranding class.
- Only a **leaked / undeliverable** approval that outlived the hard ceiling is
  a phantom. Bounding the hold by the same TTL as leg 1 precisely
  distinguishes "phantom" (stale, discounted) from "real" (recent, still
  queues) — a deterministic mechanism, not model-dependent behaviour.

## What is preserved (no regression)

- Fresh turn (recent marker) → still queues. Recent pending approval → still
  queues. Genuine machine-in-turn → still queues. (#3017/#3039 apply-or-queue,
  #3177/#3180 not regressed.)

## Test plan

- `telegram-plugin/tests/model-command.test.ts` — new `resolveStaleAwareBusy`
  block: dangling atom → APPLY; fresh atom → QUEUE; wedged approval → APPLY;
  recent approval → QUEUE; machine-in-turn → QUEUE; exact-ceiling strict-`>`
  boundary; no-turn no-op.
- `telegram-plugin/tests/turn-active-marker.test.ts` — asserts the exported
  TTL constants (single-source-of-truth guard).
- Scoped: `vitest run` model-command + effort-command + turn-active-marker →
  **190 passed**. `npm run lint` (tsc + all 9 guards incl. bot-api-wrapping) →
  clean. Full suite left to CI.

## Job spec

`reference/jobs/steer-or-queue-mid-flight.md` — the apply-or-queue contract:
the operator's `/model`/`/effort` switch lands (applied now when idle, queued
when genuinely busy) and the user knows which happened; a phantom-busy signal
must not make it dead-end on an idle session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)