### PR TITLE
feat(gateway): close sub-agent-handback dead-air gap with an adopted pre-turn signal (#3268)

### DIFF
--- a/telegram-plugin/gateway/derive-turn-id.ts
+++ b/telegram-plugin/gateway/derive-turn-id.ts
@@ -1,0 +1,32 @@
+/**
+ * derive-turn-id.ts — the stable per-turn identity, extracted from the gateway
+ * monolith so BOTH the enqueue seam and out-of-gateway tests use the SAME
+ * function (no mirror-drift between production and the round-trip test).
+ *
+ * Component 3 — derive the stable per-turn identity from the chat, thread, and
+ * originating message id. Stamped into the inbound meta at build time
+ * (`origin_turn_id`) AND reconstructed at enqueue time from the same three
+ * values, so the id stamped on the message the model reads matches the id on
+ * the turn the gateway started for it. Using the message id (not the
+ * not-yet-known startedAt) is what lets the two sites agree. Returns null when
+ * there is no message id (synthetic / cron turns with no originating inbound —
+ * they never need origin routing, the live turn IS the origin).
+ *
+ * NOTE (#3268): a subagent-handback IS a synthetic inbound, but it MUST still
+ * derive a stable non-null id so the dead-air pre-turn card can be adopted by
+ * identity at enqueue. The handback inbound builder therefore rounds-trips its
+ * fabricated `ts` through `meta.message_id` (mirroring resume-inbound-builder),
+ * so `ev.messageId` is populated at enqueue and this function yields the SAME
+ * `chatKey#ts` the pre-turn seam recorded at release.
+ */
+
+import { chatKey } from './chat-key.js'
+
+export function deriveTurnId(
+  chatId: string,
+  threadId: number | null | undefined,
+  messageId: string | number | null | undefined,
+): string | null {
+  if (messageId == null || messageId === '' || String(messageId) === '0') return null
+  return `${chatKey(chatId, threadId ?? null)}#${messageId}`
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -198,6 +198,10 @@ import { NarrativeFlushController, PENDING_NARRATIVE_FLUSH_MS } from '../narrati
 import { toolLabel } from '../tool-labels.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { createTurnTypingLoop } from './turn-typing-loop.js'
+import {
+  createHandbackPreturnSignal,
+  type PreTurnCardRecord,
+} from './handback-preturn-signal.js'
 import { createTypingEmitter, TYPING_REFRESH_MS } from '../typing-emitter.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
 import { handlePtyPartialPure, type PtyHandlerState } from '../pty-partial-handler.js'
@@ -8964,11 +8968,20 @@ async function runMidSessionCardReaper(): Promise<void> {
       const { finalized, vanished, total } = await runActivityCardMidSessionReaper({
         path: ACTIVITY_CARD_STORE_PATH,
         fs: activityCardStoreFs,
+        // A synthetic pre-turn record's key is never a live topic key, so it is
+        // correctly seen as ownerless here (the seam's own age-based self-reap is
+        // the fast path; this is the crash / long-lived backstop).
         isLive: (record) => topicKeys.has(record.turnKey),
         ttlMs: MID_SESSION_CARD_REAPER_TTL_MS,
         now,
-        finalizeCard: (record) =>
-          robustApiCall(
+        finalizeCard: (record) => {
+          // Reap hook (design lever 4): a never-adopted pre-turn card being
+          // finalized here must also stop its forever-running typing loop and
+          // drop the seam's in-memory entry.
+          if (handbackPreturnSignal.isPreTurnRecord(record.turnKey)) {
+            handbackPreturnSignal.handleReaped(record.turnKey)
+          }
+          return robustApiCall(
             () =>
               lockedBot.api.editMessageText(
                 record.chatId,
@@ -8981,7 +8994,8 @@ async function runMidSessionCardReaper(): Promise<void> {
               ...(record.threadId != null ? { threadId: record.threadId } : {}),
               verb: 'activity-card.mid-session-reap-finalize',
             },
-          ),
+          )
+        },
         // #3001: route through reconcileStatusPin when the pin is a live
         // in-memory claim, so the claim AND the durable status-pins.json row
         // clear together (the raw-API unpin left both behind — the boot sweep
@@ -10083,6 +10097,15 @@ _deliveryMachineTick.unref?.()
 // synthetic-source/empty, which never produce an `enqueue` and would otherwise
 // re-deliver forever.
 function trackRedeliveredInbound(merged: InboundMessage): void {
+  // Dead-air pre-turn signal: this is the shared CONFIRMED-release chokepoint
+  // (buffer drain, idle-drain tick, bridge re-register). A released
+  // subagent-handback gets a `typing…` + pre-turn card the imminent turn
+  // adopts; a no-op for every non-handback inbound (guarded inside the seam).
+  // Emitted BEFORE the delivery-confirm early-return so it fires regardless of
+  // that feature flag. Design lever 1: emit at release, do NOT gate on
+  // turn-in-flight (the common case is a worker finishing while the parent is
+  // mid-turn on another topic).
+  if (HANDBACK_PRETURN_ENABLED) handbackPreturnSignal.noteHandbackRelease(merged)
   if (!DELIVERY_CONFIRM_ENABLED) return
   // The boot-resume synthetic ('resume_interrupted') is the ONE synthetic we DO
   // enrol: a restart can drop it into a not-ready session exactly like a user
@@ -17077,6 +17100,90 @@ function clearActivitySummary(turn: CurrentTurn, finalHtmlOverride?: string | nu
   })
 }
 
+// ─── Sub-agent handback dead-air pre-turn signal ─────────────────────────────
+// Closes the gap between a background sub-agent's handback being RELEASED for
+// delivery (the buffer drain) and the parent turn that consumes it minting +
+// rendering its first tool/narration. On release we emit a `typing…` loop + a
+// "reading the worker's results…" card; the imminent turn ADOPTS that exact
+// card (by inbound identity) so it's one continuous card lifecycle finalized by
+// the turn's normal `clearActivitySummary`, never a second card. See
+// handback-preturn-signal.ts for the design + the red-team holes each lever
+// closes. Kill switch: SWITCHROOM_HANDBACK_PRETURN=0.
+const HANDBACK_PRETURN_ENABLED = !STATIC && process.env.SWITCHROOM_HANDBACK_PRETURN !== '0'
+const HANDBACK_PRETURN_HTML = '🤝 Reading the worker’s results…'
+const HANDBACK_PRETURN_ORPHAN_HTML =
+  '🤝 A background worker finished, but the handback never started — it may need a nudge.'
+
+async function openHandbackPreTurnCard(
+  chatId: string,
+  threadId: number | null,
+): Promise<number | null> {
+  if (STATIC) return null
+  try {
+    const sent = await robustApiCall(
+      // allow-raw-bot-api: sendRichMessage routed through robustApiCall (not in the THREAD_NOT_FOUND blast pattern)
+      () =>
+        bot.api.sendRichMessage(chatId, richMessage(HANDBACK_PRETURN_HTML), {
+          ...(threadId != null ? { message_thread_id: threadId } : {}),
+          disable_notification: true,
+        }),
+      {
+        chat_id: chatId,
+        ...(threadId != null ? { threadId } : {}),
+        verb: 'handback-preturn.send',
+      },
+    )
+    return sent?.message_id ?? null
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: handback pre-turn card send failed: ${(err as Error).message}\n`,
+    )
+    return null
+  }
+}
+
+function finalizeHandbackPreTurnCard(record: PreTurnCardRecord): Promise<void> {
+  return robustApiCall(
+    () =>
+      bot.api.editMessageText(
+        record.chatId,
+        record.activityMessageId,
+        richMessage(HANDBACK_PRETURN_ORPHAN_HTML),
+        {},
+      ),
+    {
+      chat_id: record.chatId,
+      ...(record.threadId != null ? { threadId: record.threadId } : {}),
+      verb: 'handback-preturn.orphan-finalize',
+    },
+  )
+    .then(() => undefined)
+    .catch(() => undefined)
+}
+
+const handbackPreturnSignal = createHandbackPreturnSignal({
+  chatKey: (chatId, threadId) => chatKey(chatId, threadId) as string,
+  deriveTurnId: (chatId, threadId, messageId) => deriveTurnId(chatId, threadId, messageId),
+  startTypingLoop: (chatId, threadId) => startTurnTypingLoop(chatId, threadId),
+  stopTypingLoop: (chatId, threadId) => stopTurnTypingLoop(chatId, threadId),
+  openCard: openHandbackPreTurnCard,
+  finalizeCard: finalizeHandbackPreTurnCard,
+  writeCardRecord: (record) => {
+    if (!activityCardPersistEnabled) return
+    writeActivityCardRecord(ACTIVITY_CARD_STORE_PATH, activityCardStoreFs, record)
+  },
+  clearCardRecord: (turnKey, activityMessageId) => {
+    if (!activityCardPersistEnabled) return
+    clearActivityCardRecord(ACTIVITY_CARD_STORE_PATH, activityCardStoreFs, turnKey, activityMessageId)
+  },
+  // Lever 5: never paint a pre-turn card beneath a turn that already delivered
+  // its answer / ended by the time the debounce fires.
+  isTurnSettled: (key) => {
+    const live = currentTurnMap.get(key)
+    return live != null && (live.finalAnswerDelivered || live.endedAt != null)
+  },
+})
+
 /**
  * #2849 hindsight Phase 4 — sparse chat-legible memory.
  *
@@ -17430,6 +17537,27 @@ function handleSessionEvent(ev: SessionEvent): void {
         // Wire the per-turn narrative gate now that `next` exists (its SHOW/RETRACT
         // effects close over the turn). Born with this turn, torn down at turn end.
         next.narrativeGate = makeNarrativeGate(next)
+        // Dead-air pre-turn signal — ADOPT by inbound identity (design lever 2).
+        // If a subagent-handback pre-turn signal was emitted for THIS exact turn
+        // (matched on `turnId`, not the bare topic key, so a racing user inbound
+        // can't mis-adopt), consume it. A card-bearing adoption seeds
+        // `activityMessageId` + `activityEverOpened` so `renderActivityFeed`
+        // EDITS the existing card instead of opening a second one, and so the
+        // turn's own end-of-turn `clearActivitySummary` finalizes it (lever 3).
+        // The handback turn also gets the turn-long typing loop it never had —
+        // whether or not a card was painted (the debounce may not have fired) —
+        // stopped by the canonical turn-end (`purgeReactionTracking →
+        // stopTurnTypingLoop`).
+        if (HANDBACK_PRETURN_ENABLED) {
+          const handbackAdoption = handbackPreturnSignal.tryAdopt(turnId)
+          if (handbackAdoption != null) {
+            if (handbackAdoption.activityMessageId != null) {
+              next.activityMessageId = handbackAdoption.activityMessageId
+              next.activityEverOpened = true
+            }
+            startTurnTypingLoop(ev.chatId, enqThreadIdNum ?? null)
+          }
+        }
         // PR-4e — route the turn-SET through the keyed accessor: flag-OFF assigns
         // the singleton (byte-identical to `currentTurn = next`); flag-ON sets the
         // per-topic `byKey[statusKey]` entry AND the most-recent mirror. The key is

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -202,6 +202,7 @@ import {
   createHandbackPreturnSignal,
   type PreTurnCardRecord,
 } from './handback-preturn-signal.js'
+import { deriveTurnId } from './derive-turn-id.js'
 import { createTypingEmitter, TYPING_REFRESH_MS } from '../typing-emitter.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
 import { handlePtyPartialPure, type PtyHandlerState } from '../pty-partial-handler.js'
@@ -3759,25 +3760,10 @@ function findTurnByQuotedMessageId(chatId: string, replyTo: unknown): CurrentTur
   if (turn == null || turn.sessionChatId !== chatId) return null
   return turn
 }
-/**
- * Component 3 — derive the stable per-turn identity from the chat, thread,
- * and originating message id. Stamped into the inbound meta at build time
- * (`origin_turn_id`) AND reconstructed at enqueue time from the same three
- * values, so the id stamped on the message the model reads matches the id
- * on the turn the gateway started for it. Using the message id (not the
- * not-yet-known startedAt) is what lets the two sites agree. Returns null
- * when there is no message id (synthetic / cron / handback turns have no
- * originating inbound — they never need origin routing, the live turn IS
- * the origin).
- */
-function deriveTurnId(
-  chatId: string,
-  threadId: number | null | undefined,
-  messageId: string | number | null | undefined,
-): string | null {
-  if (messageId == null || messageId === '' || String(messageId) === '0') return null
-  return `${chatKey(chatId, threadId ?? null)}#${messageId}`
-}
+// Component 3 — the stable per-turn identity. Extracted to `derive-turn-id.ts`
+// (#3268) so the enqueue seam and the handback round-trip test share ONE
+// function. Re-exported into scope under the original name so every existing
+// callsite is unchanged.
 
 /**
  * Component 3 — resolve the turn that OWNS a reply by its `origin_turn_id`

--- a/telegram-plugin/gateway/handback-preturn-signal.ts
+++ b/telegram-plugin/gateway/handback-preturn-signal.ts
@@ -161,6 +161,12 @@ export interface HandbackPreturnSignalDeps {
   /** Age after emit at which a never-adopted card self-reaps. Independent of
    *  topic liveness. */
   adoptTimeoutMs?: number
+  /** Injected scheduler (mirrors bridge-dead-watchdog.ts): defaults to
+   *  setTimeout/clearTimeout. Injected so a runner-agnostic test can drive the
+   *  debounce + self-reap deterministically WITHOUT any vitest-only fake-timer
+   *  API (bun's test runner lacks `vi.advanceTimersByTimeAsync`). */
+  setTimer?: (fn: () => void, ms: number) => unknown
+  clearTimer?: (handle: unknown) => void
   log?: (line: string) => void
 }
 
@@ -173,8 +179,8 @@ interface PreTurnEntry {
   syntheticTurnKey: string
   startedAt: number
   pinned: boolean
-  debounceTimer: ReturnType<typeof setTimeout> | null
-  reapTimer: ReturnType<typeof setTimeout> | null
+  debounceTimer: unknown | null
+  reapTimer: unknown | null
   /** Set once the debounce fired and the card was painted. */
   activityMessageId: number | null
   emitted: boolean
@@ -212,6 +218,14 @@ export function createHandbackPreturnSignal(
   const now = deps.now ?? (() => Date.now())
   const debounceMs = deps.debounceMs ?? 700
   const adoptTimeoutMs = deps.adoptTimeoutMs ?? 30_000
+  const setTimer =
+    deps.setTimer ??
+    ((fn: () => void, ms: number) => {
+      const t = setTimeout(fn, ms)
+      ;(t as { unref?: () => void }).unref?.()
+      return t
+    })
+  const clearTimer = deps.clearTimer ?? ((h: unknown) => clearTimeout(h as ReturnType<typeof setTimeout>))
   const log = deps.log ?? ((l: string) => process.stderr.write(l))
 
   // Keyed by statusKey — one live pre-turn entry per topic (dedupe).
@@ -221,11 +235,11 @@ export function createHandbackPreturnSignal(
 
   function clearTimers(entry: PreTurnEntry): void {
     if (entry.debounceTimer != null) {
-      clearTimeout(entry.debounceTimer)
+      clearTimer(entry.debounceTimer)
       entry.debounceTimer = null
     }
     if (entry.reapTimer != null) {
-      clearTimeout(entry.reapTimer)
+      clearTimer(entry.reapTimer)
       entry.reapTimer = null
     }
   }
@@ -282,8 +296,7 @@ export function createHandbackPreturnSignal(
         // adoption lets the boot reaper finalize this orphan.
         deps.writeCardRecord(record)
         // Age-based self-reap, independent of topic liveness.
-        entry.reapTimer = setTimeout(() => reap(entry), adoptTimeoutMs)
-        entry.reapTimer.unref?.()
+        entry.reapTimer = setTimer(() => reap(entry), adoptTimeoutMs)
       })
       .catch((err) => {
         log(
@@ -351,8 +364,7 @@ export function createHandbackPreturnSignal(
       }
       byKey.set(statusKey, entry)
       bySyntheticKey.set(syntheticTurnKey, statusKey)
-      entry.debounceTimer = setTimeout(() => emit(entry), debounceMs)
-      entry.debounceTimer.unref?.()
+      entry.debounceTimer = setTimer(() => emit(entry), debounceMs)
     },
 
     tryAdopt(turnId) {

--- a/telegram-plugin/gateway/handback-preturn-signal.ts
+++ b/telegram-plugin/gateway/handback-preturn-signal.ts
@@ -1,0 +1,424 @@
+/**
+ * handback-preturn-signal.ts — close the sub-agent-handback "dead-air" gap.
+ *
+ * THE GAP. When a *background* sub-agent (worker / researcher) finishes, the
+ * gateway synthesises a `subagent_handback` inbound and buffers it
+ * (`pendingInboundBuffer`). That inbound is RELEASED for delivery only at an
+ * idle prompt (the buffer drain), travels bridge → claude, and eventually
+ * mints a fresh turn at the `enqueue` session-event. Between the RELEASE and
+ * the turn's first tool/narration render there is a stretch of dead air: no
+ * `typing…` indicator and no activity card. The user — who dispatched the work
+ * and is waiting — sees nothing until the turn is well underway. Worse, a
+ * handback turn historically never even got a turn-long typing loop
+ * (`startTurnTypingLoop` has a single caller on the real-inbound path), so the
+ * dark stretch extended past turn start.
+ *
+ * THE FIX (one continuous card lifecycle, NOT an orphan). The moment the
+ * buffered handback is RELEASED, emit a pre-turn signal for its topic:
+ *
+ *   1. a turn-long `typing…` loop (the same mechanism the real-inbound path
+ *      starts), and
+ *   2. a "reading the worker's results…" activity CARD.
+ *
+ * When the handback's turn later mints at `enqueue`, it ADOPTS that exact card
+ * (its `activityMessageId` is seeded onto the new turn, `activityEverOpened`
+ * set) so the turn EDITS the existing card instead of opening a second one —
+ * one card, one lifecycle, finalized by the turn's normal end-of-turn
+ * `clearActivitySummary`. The typing loop keeps running across the seam (no
+ * zero-gap), stopped by the canonical turn-end (`purgeReactionTracking →
+ * stopTurnTypingLoop`).
+ *
+ * WHY THIS SHAPE (each decision closes a red-team hole in the naive
+ * "single emit at the enqueue seam" design):
+ *
+ *   • EMIT AT THE DRAIN/RELEASE SITE, not the enqueue seam, and DO NOT gate on
+ *     global turn-in-flight. The common case is a worker finishing WHILE the
+ *     parent is mid-turn on another topic; a turn-in-flight guard would suppress
+ *     exactly that case. The release is the earliest deterministic signal that a
+ *     handback turn is imminent.
+ *
+ *   • ADOPT BY INBOUND IDENTITY, not by bare topic key. A racing user inbound
+ *     on the same topic would mis-adopt a bare-key entry. Each pre-turn entry
+ *     records the `turnId` its handback will derive at enqueue
+ *     (`deriveTurnId(chat, thread, messageId)` — the handback carries a
+ *     synthetic `messageId`, so the id is stable and unique). Only the enqueue
+ *     whose `turnId` matches consumes it. This mirrors the `pendingCrossTurnGate`
+ *     consume-by-turnId pattern in gateway.ts.
+ *
+ *   • ADOPTION SEEDS `activityMessageId` so the turn's own end-of-turn
+ *     `clearActivitySummary` is the durable-teardown owner (it clears the
+ *     durable card record keyed on `statusKey(chat,thread)` + that exact id).
+ *     On adoption the durable record is re-keyed from its synthetic pre-turn key
+ *     to the real `statusKey` so that teardown matches.
+ *
+ *   • NEVER-ADOPTED ORPHAN REAP. A degenerate case (bridge death after release,
+ *     no enqueue ever arrives) would leave a frozen card + a forever `typing…`
+ *     loop. The pre-turn card is persisted as a COMPLETE `ActivityCardRecord`
+ *     under a SYNTHETIC `turnKey` (`preturn:<statusKey>:<startedAt>`) — synthetic
+ *     so a sibling REAL turn on the same topic key can neither upsert-clobber it
+ *     nor keep it "live" (the mid-session reaper's `isLive` keys on live topic
+ *     keys, which never contain a synthetic key). An AGE-BASED self-reap timer
+ *     (independent of topic liveness) finalizes the frozen card, stops the
+ *     typing loop, clears the record, and drops the in-memory entry; the
+ *     gateway's mid-session + boot reapers are the crash backstop (the complete
+ *     record lets them finalize an orphan across a restart), and a reap hook
+ *     lets them stop the typing loop + drop the map entry too.
+ *
+ *   • DEBOUNCE (~700ms) kills sub-second-worker flicker: a worker that finishes
+ *     and whose turn mints within the debounce window never paints a pre-turn
+ *     card at all — the enqueue arrives first, cancels the debounce, and the
+ *     turn's own early-liveness card takes over. The typing loop is still
+ *     started for that turn (adoption returns a result even with no card).
+ *
+ * PURE, IMPORTABLE SEAM. The gateway monolith is not importable by tests; this
+ * factory (mirroring `turn-typing-loop.ts` / the `idleDrainTick` extraction)
+ * takes every effect as an injected dep, so the emit→adopt→reap contract is
+ * driven deterministically by a vitest contract test with fake timers and spy
+ * transports (`tests/handback-preturn-signal.test.ts`).
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+
+/** Prefix marking a durable card record as a pre-turn (not-yet-adopted) card.
+ *  The gateway uses this to route mid-session/boot-reaped records back through
+ *  the seam's `handleReaped` hook (stop typing loop + drop map entry). */
+export const PRETURN_TURNKEY_PREFIX = 'preturn:'
+
+/** True IFF `source` is the load-bearing subagent-handback source string. Kept
+ *  here next to the seam so a source-string regression is caught by this
+ *  module's own test, not only the inbound-builder's. */
+export function isHandbackInbound(msg: InboundMessage): boolean {
+  return msg.type === 'inbound' && msg.meta?.source === 'subagent_handback'
+}
+
+/** A COMPLETE durable card handle for a pre-turn card — enough for the gateway's
+ *  mid-session / boot reapers to finalize an orphan across a restart. Shape is a
+ *  structural subset of `ActivityCardRecord` (activity-card-store.ts) so the
+ *  gateway can persist it through the existing `writeActivityCardRecord`. */
+export interface PreTurnCardRecord {
+  /** Synthetic `preturn:<statusKey>:<startedAt>` — decoupled from the real
+   *  topic key so a sibling real turn can't clobber or keep it alive. */
+  turnKey: string
+  chatId: string
+  threadId: number | null
+  activityMessageId: number
+  startedAt: number
+  pinned: boolean
+}
+
+/** What `tryAdopt` returns to the gateway's `enqueue` seam. `activityMessageId`
+ *  is non-null when a pre-turn CARD had already been painted (adopt it by
+ *  seeding); null when the debounce had not yet fired (no card to adopt, but the
+ *  turn is still a released handback so it must get a typing loop). */
+export interface HandbackAdoption {
+  statusKey: string
+  chatId: string
+  threadId: number | null
+  activityMessageId: number | null
+  startedAt: number
+  pinned: boolean
+}
+
+export interface HandbackPreturnSignalDeps {
+  /** Canonical `statusKey`/`chatKey` (null/0/undefined thread → `_`). */
+  chatKey: (chatId: string, threadId: number | null) => string
+  /** The gateway's `deriveTurnId(chat, thread, messageId)` — the SAME function
+   *  the `enqueue` seam uses, so the identity computed at release matches the
+   *  turnId minted at enqueue. Returns null for a message with no usable id. */
+  deriveTurnId: (
+    chatId: string,
+    threadId: number | null,
+    messageId: string | number | null | undefined,
+  ) => string | null
+  /** Turn-long `typing…` loop — the gateway's shared `turnTypingLoop`. `start`
+   *  fires one action immediately and refreshes on the loop's own cadence;
+   *  `stop` clears it. Started at pre-turn emit, kept running across adoption,
+   *  stopped by the gateway's canonical turn-end (or by this seam on orphan
+   *  reap). */
+  startTypingLoop: (chatId: string, threadId: number | null) => void
+  stopTypingLoop: (chatId: string, threadId: number | null) => void
+  /** Open the pre-turn activity card. Resolves to the sent message id, or null
+   *  when the send failed / was suppressed (best-effort — a null just means no
+   *  card was painted, so nothing to adopt or reap). */
+  openCard: (chatId: string, threadId: number | null) => Promise<number | null>
+  /** Finalize (single honest edit) a frozen never-adopted pre-turn card on
+   *  orphan self-reap. Best-effort; failures swallowed by the caller. */
+  finalizeCard: (record: PreTurnCardRecord) => void | Promise<void>
+  /** Persist the durable card record (the gateway's `writeActivityCardRecord`,
+   *  scoped by `turnKey`). */
+  writeCardRecord: (record: PreTurnCardRecord) => void
+  /** Clear a durable card record scoped to `turnKey` + exact `activityMessageId`
+   *  (the gateway's `clearActivityCardRecord`). */
+  clearCardRecord: (turnKey: string, activityMessageId: number) => void
+  /** True IFF the topic's adopting turn has ALREADY delivered a final answer or
+   *  ended by the time the debounce fires — in which case skip the emit
+   *  entirely (design lever 5: never paint beneath a settled turn). Optional;
+   *  defaults to "not settled". */
+  isTurnSettled?: (statusKey: string) => boolean
+  now?: () => number
+  /** Debounce before painting the pre-turn card (kills sub-second flicker). */
+  debounceMs?: number
+  /** Age after emit at which a never-adopted card self-reaps. Independent of
+   *  topic liveness. */
+  adoptTimeoutMs?: number
+  log?: (line: string) => void
+}
+
+interface PreTurnEntry {
+  statusKey: string
+  chatId: string
+  threadId: number | null
+  /** The turnId the handback will derive at enqueue — the adoption identity. */
+  adoptTurnId: string
+  syntheticTurnKey: string
+  startedAt: number
+  pinned: boolean
+  debounceTimer: ReturnType<typeof setTimeout> | null
+  reapTimer: ReturnType<typeof setTimeout> | null
+  /** Set once the debounce fired and the card was painted. */
+  activityMessageId: number | null
+  emitted: boolean
+  consumed: boolean
+}
+
+export interface HandbackPreturnSignal {
+  /** Called once per handback inbound at the point it is RELEASED for delivery
+   *  (the buffer drain). Dedupes per topic key. Arms the debounce; on fire it
+   *  starts the typing loop, paints the card, persists the durable record, and
+   *  arms the orphan self-reap. No-op for a non-handback inbound, an inbound
+   *  with no derivable turnId, or a topic key that already has a live entry. */
+  noteHandbackRelease: (inbound: InboundMessage) => void
+  /** Called from the `enqueue` seam with the freshly minted `turnId`. Returns an
+   *  adoption when this turn corresponds to a released handback (consuming the
+   *  entry), else null. On a card-bearing adoption the durable record is
+   *  re-keyed to the real `statusKey` so the turn's end-of-turn
+   *  `clearActivitySummary` finalizes it. Cancels the debounce/self-reap. */
+  tryAdopt: (turnId: string) => HandbackAdoption | null
+  /** True IFF `turnKey` is a synthetic pre-turn record key. */
+  isPreTurnRecord: (turnKey: string) => boolean
+  /** Reap hook for the gateway's mid-session / boot card reapers: stop the
+   *  typing loop and drop the in-memory entry for a reaped synthetic key. */
+  handleReaped: (turnKey: string) => void
+  /** Test/observability: number of live (un-consumed) pre-turn entries. */
+  pendingCount: () => number
+  /** Shutdown-drain cleanup: clear every timer + entry (does not stop typing
+   *  loops — the gateway's `turnTypingLoop.stopAll` owns that). */
+  stopAll: () => void
+}
+
+export function createHandbackPreturnSignal(
+  deps: HandbackPreturnSignalDeps,
+): HandbackPreturnSignal {
+  const now = deps.now ?? (() => Date.now())
+  const debounceMs = deps.debounceMs ?? 700
+  const adoptTimeoutMs = deps.adoptTimeoutMs ?? 30_000
+  const log = deps.log ?? ((l: string) => process.stderr.write(l))
+
+  // Keyed by statusKey — one live pre-turn entry per topic (dedupe).
+  const byKey = new Map<string, PreTurnEntry>()
+  // Reverse index synthetic turnKey → statusKey, so a reaped record routes back.
+  const bySyntheticKey = new Map<string, string>()
+
+  function clearTimers(entry: PreTurnEntry): void {
+    if (entry.debounceTimer != null) {
+      clearTimeout(entry.debounceTimer)
+      entry.debounceTimer = null
+    }
+    if (entry.reapTimer != null) {
+      clearTimeout(entry.reapTimer)
+      entry.reapTimer = null
+    }
+  }
+
+  function dropEntry(entry: PreTurnEntry): void {
+    clearTimers(entry)
+    byKey.delete(entry.statusKey)
+    bySyntheticKey.delete(entry.syntheticTurnKey)
+  }
+
+  function emit(entry: PreTurnEntry): void {
+    entry.debounceTimer = null
+    if (entry.consumed) return // adopted or reaped in the debounce window
+    if (deps.isTurnSettled?.(entry.statusKey)) {
+      // The adopting turn already delivered/ended — a pre-turn card would
+      // narrate beneath a finished turn. Skip the emit and drop the entry.
+      dropEntry(entry)
+      return
+    }
+    // Start the turn-long typing loop NOW so the chat lights up the instant the
+    // handback is released; it keeps running across adoption into the turn.
+    deps.startTypingLoop(entry.chatId, entry.threadId)
+    // Paint the card. Async: the entry may be consumed (adopted) before the send
+    // resolves — guard on that so we never orphan a card the turn already owns.
+    void Promise.resolve()
+      .then(() => deps.openCard(entry.chatId, entry.threadId))
+      .then((messageId) => {
+        if (messageId == null) return
+        if (entry.consumed) {
+          // Adopted/reaped while the send was in flight: the card is now the
+          // turn's (adoption seeds a null id it can't use) — finalize+clear so
+          // it never dangles. Rare; the debounce makes it unlikely.
+          void deps.finalizeCard({
+            turnKey: entry.syntheticTurnKey,
+            chatId: entry.chatId,
+            threadId: entry.threadId,
+            activityMessageId: messageId,
+            startedAt: entry.startedAt,
+            pinned: entry.pinned,
+          })
+          return
+        }
+        entry.activityMessageId = messageId
+        entry.emitted = true
+        const record: PreTurnCardRecord = {
+          turnKey: entry.syntheticTurnKey,
+          chatId: entry.chatId,
+          threadId: entry.threadId,
+          activityMessageId: messageId,
+          startedAt: entry.startedAt,
+          pinned: entry.pinned,
+        }
+        // COMPLETE durable record — the crash backstop: a gateway restart before
+        // adoption lets the boot reaper finalize this orphan.
+        deps.writeCardRecord(record)
+        // Age-based self-reap, independent of topic liveness.
+        entry.reapTimer = setTimeout(() => reap(entry), adoptTimeoutMs)
+        entry.reapTimer.unref?.()
+      })
+      .catch((err) => {
+        log(
+          `handback-preturn-signal: openCard failed key=${entry.statusKey}: ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        )
+      })
+  }
+
+  function reap(entry: PreTurnEntry): void {
+    entry.reapTimer = null
+    if (entry.consumed) return
+    entry.consumed = true
+    // Stop the forever-running typing loop and finalize the frozen card.
+    deps.stopTypingLoop(entry.chatId, entry.threadId)
+    if (entry.activityMessageId != null) {
+      const record: PreTurnCardRecord = {
+        turnKey: entry.syntheticTurnKey,
+        chatId: entry.chatId,
+        threadId: entry.threadId,
+        activityMessageId: entry.activityMessageId,
+        startedAt: entry.startedAt,
+        pinned: entry.pinned,
+      }
+      // Clear the durable record BEFORE the finalizing edit (at-most-once
+      // idempotency guard, mirroring the activity-card-store reapers).
+      deps.clearCardRecord(entry.syntheticTurnKey, entry.activityMessageId)
+      void Promise.resolve(deps.finalizeCard(record)).catch((err) => {
+        log(
+          `handback-preturn-signal: orphan finalize failed key=${entry.statusKey}: ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        )
+      })
+    }
+    dropEntry(entry)
+  }
+
+  return {
+    noteHandbackRelease(inbound) {
+      if (!isHandbackInbound(inbound)) return
+      const chatId = inbound.chatId
+      if (chatId == null || chatId === '') return
+      const threadId = inbound.threadId ?? null
+      const adoptTurnId = deps.deriveTurnId(chatId, threadId, inbound.messageId)
+      if (adoptTurnId == null) return // no stable identity → can't be adopted
+      const statusKey = deps.chatKey(chatId, threadId)
+      // Dedupe: a live entry already covers this topic (e.g. two handbacks for
+      // the same topic released together — the first owns the pre-turn signal).
+      if (byKey.has(statusKey)) return
+      const startedAt = now()
+      const syntheticTurnKey = `${PRETURN_TURNKEY_PREFIX}${statusKey}:${startedAt}`
+      const entry: PreTurnEntry = {
+        statusKey,
+        chatId,
+        threadId,
+        adoptTurnId,
+        syntheticTurnKey,
+        startedAt,
+        pinned: false,
+        debounceTimer: null,
+        reapTimer: null,
+        activityMessageId: null,
+        emitted: false,
+        consumed: false,
+      }
+      byKey.set(statusKey, entry)
+      bySyntheticKey.set(syntheticTurnKey, statusKey)
+      entry.debounceTimer = setTimeout(() => emit(entry), debounceMs)
+      entry.debounceTimer.unref?.()
+    },
+
+    tryAdopt(turnId) {
+      // Match by inbound identity, not bare key — a racing user inbound on the
+      // same topic derives a DIFFERENT turnId and cannot consume this entry.
+      let entry: PreTurnEntry | undefined
+      for (const e of byKey.values()) {
+        if (e.adoptTurnId === turnId && !e.consumed) {
+          entry = e
+          break
+        }
+      }
+      if (entry == null) return null
+      entry.consumed = true
+      clearTimers(entry)
+      const adoption: HandbackAdoption = {
+        statusKey: entry.statusKey,
+        chatId: entry.chatId,
+        threadId: entry.threadId,
+        activityMessageId: entry.activityMessageId,
+        startedAt: entry.startedAt,
+        pinned: entry.pinned,
+      }
+      if (entry.activityMessageId != null) {
+        // Re-key the durable record from the synthetic pre-turn key to the real
+        // topic key so the adopting turn's end-of-turn `clearActivitySummary`
+        // (which clears on `statusKey` + this exact id) finalizes it — one
+        // continuous card lifecycle, torn down by the real owner.
+        deps.clearCardRecord(entry.syntheticTurnKey, entry.activityMessageId)
+        deps.writeCardRecord({
+          turnKey: entry.statusKey,
+          chatId: entry.chatId,
+          threadId: entry.threadId,
+          activityMessageId: entry.activityMessageId,
+          startedAt: entry.startedAt,
+          pinned: entry.pinned,
+        })
+      }
+      dropEntry(entry)
+      return adoption
+    },
+
+    isPreTurnRecord(turnKey) {
+      return turnKey.startsWith(PRETURN_TURNKEY_PREFIX)
+    },
+
+    handleReaped(turnKey) {
+      const statusKey = bySyntheticKey.get(turnKey)
+      if (statusKey == null) return
+      const entry = byKey.get(statusKey)
+      if (entry == null) return
+      entry.consumed = true
+      deps.stopTypingLoop(entry.chatId, entry.threadId)
+      dropEntry(entry)
+    },
+
+    pendingCount() {
+      let n = 0
+      for (const e of byKey.values()) if (!e.consumed) n++
+      return n
+    },
+
+    stopAll() {
+      for (const e of [...byKey.values()]) clearTimers(e)
+      byKey.clear()
+      bySyntheticKey.clear()
+    },
+  }
+}

--- a/telegram-plugin/gateway/handback-preturn-signal.ts
+++ b/telegram-plugin/gateway/handback-preturn-signal.ts
@@ -262,12 +262,20 @@ export function createHandbackPreturnSignal(
     // Start the turn-long typing loop NOW so the chat lights up the instant the
     // handback is released; it keeps running across adoption into the turn.
     deps.startTypingLoop(entry.chatId, entry.threadId)
+    entry.emitted = true
+    // Age-based self-reap armed HERE — before (and independent of) the async
+    // card open — so a card send that returns null / fails, OR an enqueue that
+    // never arrives, can never leak the entry + a forever-running typing loop.
+    // A reap with `activityMessageId == null` just stops the typing loop and
+    // drops the entry (no card to finalize). Cancelled by `tryAdopt` on
+    // adoption. (Reaping is independent of topic liveness — lever 4.)
+    entry.reapTimer = setTimer(() => reap(entry), adoptTimeoutMs)
     // Paint the card. Async: the entry may be consumed (adopted) before the send
     // resolves — guard on that so we never orphan a card the turn already owns.
     void Promise.resolve()
       .then(() => deps.openCard(entry.chatId, entry.threadId))
       .then((messageId) => {
-        if (messageId == null) return
+        if (messageId == null) return // no card painted; the reap timer cleans up
         if (entry.consumed) {
           // Adopted/reaped while the send was in flight: the card is now the
           // turn's (adoption seeds a null id it can't use) — finalize+clear so
@@ -283,7 +291,6 @@ export function createHandbackPreturnSignal(
           return
         }
         entry.activityMessageId = messageId
-        entry.emitted = true
         const record: PreTurnCardRecord = {
           turnKey: entry.syntheticTurnKey,
           chatId: entry.chatId,
@@ -293,10 +300,9 @@ export function createHandbackPreturnSignal(
           pinned: entry.pinned,
         }
         // COMPLETE durable record — the crash backstop: a gateway restart before
-        // adoption lets the boot reaper finalize this orphan.
+        // adoption lets the boot reaper finalize this orphan. (The self-reap
+        // timer was armed synchronously above.)
         deps.writeCardRecord(record)
-        // Age-based self-reap, independent of topic liveness.
-        entry.reapTimer = setTimer(() => reap(entry), adoptTimeoutMs)
       })
       .catch((err) => {
         log(

--- a/telegram-plugin/gateway/subagent-handback-inbound-builder.ts
+++ b/telegram-plugin/gateway/subagent-handback-inbound-builder.ts
@@ -115,6 +115,18 @@ export function buildSubagentHandbackInbound(opts: {
     meta: {
       source: 'subagent_handback',
       outcome: opts.ctx.outcome,
+      // #3268 — round-trip the fabricated `ts` through `meta.message_id` so it
+      // survives to enqueue. `ev.messageId` at enqueue is parsed from the
+      // channel envelope's `message_id` attribute, which is rendered ONLY from
+      // `meta.message_id` — the top-level `messageId` field does NOT survive the
+      // bridge. Without this, enqueue's `deriveTurnId` returns null → the
+      // dead-air pre-turn card's identity-based adoption never matches (the card
+      // is orphaned + a false "handback never started" reap message fires on
+      // every SUCCESSFUL handback). Mirrors resume-inbound-builder.ts's
+      // `message_id: String(ts)` for the identical enqueue-round-trip reason. It
+      // is NEVER used as a Telegram reply anchor: `parseSourceMessageId` gates
+      // the 13-digit synthetic ts out of the reply-anchor path at enqueue.
+      message_id: String(ts),
       // meta.message_thread_id is the model-visible channel attribute
       // (mirrors the real-inbound shape) so the model's reply targets
       // the dispatching topic. Mirrors gateway.ts:10557.

--- a/telegram-plugin/tests/activity-ever-opened-sticky.test.ts
+++ b/telegram-plugin/tests/activity-ever-opened-sticky.test.ts
@@ -10,8 +10,14 @@
  * resume-400 signature) from "feed opened + finalized".
  *
  * Load-bearing constraints:
- *   1. `activityEverOpened = true` is set exactly ONCE in gateway.ts (at the
- *      send-message success site in drainActivitySummary).
+ *   1. `activityEverOpened = true` is set only at legitimate feed-OPEN signal
+ *      sites in gateway.ts — the send-message success site in
+ *      drainActivitySummary, AND the sub-agent-handback pre-turn ADOPTION site
+ *      (#3268): an adopted turn inherits an already-open pre-turn card via a
+ *      seeded `activityMessageId`, so it only ever EDITs the feed (never hits
+ *      the open branch), and must stamp the flag itself so the turn-end
+ *      DEGRADED check doesn't false-flag it as "feed never opened". Both are
+ *      set-TRUE (never a reset), preserving the sticky-true invariant.
  *   2. `turn.activityEverOpened = false` NEVER appears in gateway.ts (it is only
  *      initialised to `false` in the turn-initialiser object literal, never reset
  *      via a standalone assignment).
@@ -28,9 +34,13 @@ const gatewaySrc = readFileSync(
 )
 
 describe('M-2: activityEverOpened sticky-true invariant', () => {
-  it('activityEverOpened = true appears exactly once (set at send-message success)', () => {
+  it('activityEverOpened = true appears only at the two feed-OPEN signal sites', () => {
+    // Site 1: drainActivitySummary send-message success. Site 2: the #3268
+    // handback pre-turn ADOPTION seed (an adopted turn only edits, so it stamps
+    // the flag itself). Both are set-TRUE; the sticky invariant (no reset to
+    // false) is enforced by the next test.
     const setTrueMatches = [...gatewaySrc.matchAll(/activityEverOpened\s*=\s*true/g)]
-    expect(setTrueMatches).toHaveLength(1)
+    expect(setTrueMatches).toHaveLength(2)
   })
 
   it('turn.activityEverOpened = false never appears (no standalone reset)', () => {

--- a/telegram-plugin/tests/handback-preturn-adoption-roundtrip.test.ts
+++ b/telegram-plugin/tests/handback-preturn-adoption-roundtrip.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createHandbackPreturnSignal } from '../gateway/handback-preturn-signal.js'
+import { createTurnTypingLoop } from '../gateway/turn-typing-loop.js'
+import { buildSubagentHandbackInbound } from '../gateway/subagent-handback-inbound-builder.js'
+import { deriveTurnId } from '../gateway/derive-turn-id.js'
+import { chatKey } from '../gateway/chat-key.js'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
+import type { PreTurnCardRecord } from '../gateway/handback-preturn-signal.js'
+
+/**
+ * #3268 IDENTITY ROUND-TRIP (the anti-masking integration test).
+ *
+ * The unit contract test hand-feeds a matching `messageId` to BOTH the seam's
+ * release side and the enqueue's adopt side, so it CANNOT catch a builder that
+ * fails to round-trip the identity across the bridge. This test closes that gap:
+ * it runs the REAL `buildSubagentHandbackInbound` and the REAL `deriveTurnId`,
+ * and models the enqueue exactly as the gateway does —
+ *
+ *   ev.messageId  ← the channel envelope's `message_id` attribute, which is
+ *                   rendered ONLY from `meta.message_id` (the top-level
+ *                   `messageId` field does NOT survive the bridge; see
+ *                   resume-inbound-builder.ts's identical round-trip).
+ *   turnId        ← deriveTurnId(ev.chatId, enqThreadId, ev.messageId)
+ *                   ?? `${chatKey}#synthetic-${startedAt}`  (gateway.ts enqueue)
+ *
+ * and asserts the enqueue-derived `turnId` EQUALS the id the seam recorded at
+ * release — so `tryAdopt` actually fires end-to-end.
+ *
+ * This FAILS on a builder that omits `meta.message_id` (ev.messageId → null →
+ * deriveTurnId → null → synthetic fallback → adoption never matches → the
+ * pre-turn card is orphaned + the false "handback never started" reap message
+ * fires on every SUCCESSFUL handback), and PASSES once the builder rounds-trips
+ * the identity.
+ */
+
+// The gateway's enqueue turn-id, reconstructed with the SAME primitives the
+// gateway uses (real deriveTurnId; synthetic fallback for a null message id).
+function enqueueTurnIdFor(inbound: InboundMessage, startedAt: number): string {
+  // ev.messageId at enqueue comes from meta.message_id (channel-rendered), NOT
+  // the top-level messageId field.
+  const evMessageId = inbound.meta.message_id ?? null
+  // ev.threadId at enqueue comes from meta.message_thread_id.
+  const enqThreadId =
+    inbound.meta.message_thread_id != null ? Number(inbound.meta.message_thread_id) : null
+  return (
+    deriveTurnId(inbound.chatId, enqThreadId, evMessageId) ??
+    `${chatKey(inbound.chatId, enqThreadId)}#synthetic-${startedAt}`
+  )
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 12; i++) await Promise.resolve()
+}
+
+function makeScheduler() {
+  let seq = 0
+  let currentTime = 0
+  const timers = new Map<number, { fn: () => void; at: number }>()
+  return {
+    now: () => currentTime,
+    setTimer: (fn: () => void, ms: number): unknown => {
+      const id = ++seq
+      timers.set(id, { fn, at: currentTime + ms })
+      return id
+    },
+    clearTimer: (h: unknown): void => {
+      timers.delete(h as number)
+    },
+    async advance(ms: number): Promise<void> {
+      const target = currentTime + ms
+      for (;;) {
+        let nextId: number | null = null
+        let nextAt = Infinity
+        for (const [id, t] of timers) {
+          if (t.at <= target && t.at < nextAt) {
+            nextId = id
+            nextAt = t.at
+          }
+        }
+        if (nextId == null) break
+        const t = timers.get(nextId)!
+        timers.delete(nextId)
+        currentTime = t.at
+        t.fn()
+        await flushMicrotasks()
+      }
+      currentTime = target
+      await flushMicrotasks()
+    },
+  }
+}
+
+function makeSeam(sched: ReturnType<typeof makeScheduler>) {
+  const sendChatAction = vi.fn<(c: string, t: number | null) => void>()
+  const typing = createTurnTypingLoop({
+    sendChatAction,
+    chatKey: (c, t) => chatKey(c, t) as string,
+    refreshMs: 4000,
+  })
+  let msgSeq = 5000
+  const openCard = vi.fn<(c: string, t: number | null) => Promise<number | null>>(async () => ++msgSeq)
+  const records = new Map<string, PreTurnCardRecord>()
+  const signal = createHandbackPreturnSignal({
+    // The gateway wires these to the SAME real chatKey / deriveTurnId.
+    chatKey: (c, t) => chatKey(c, t) as string,
+    deriveTurnId,
+    startTypingLoop: (c, t) => typing.start(c, t),
+    stopTypingLoop: (c, t) => typing.stop(c, t),
+    openCard,
+    finalizeCard: () => {},
+    writeCardRecord: (r) => records.set(r.turnKey, r),
+    clearCardRecord: (turnKey, id) => {
+      const cur = records.get(turnKey)
+      if (cur != null && cur.activityMessageId === id) records.delete(turnKey)
+    },
+    now: sched.now,
+    setTimer: sched.setTimer,
+    clearTimer: sched.clearTimer,
+    debounceMs: 700,
+    adoptTimeoutMs: 30_000,
+  })
+  return { signal, typing, openCard, records }
+}
+
+const teardown: Array<() => void> = []
+afterEach(() => {
+  for (const fn of teardown.splice(0)) fn()
+})
+
+describe('#3268 handback identity round-trip — adoption fires end-to-end', () => {
+  it('the REAL builder + REAL deriveTurnId yield the SAME turnId at release and enqueue (DM)', async () => {
+    const sched = makeScheduler()
+    const seam = makeSeam(sched)
+    teardown.push(() => seam.typing.stopAll())
+
+    const inbound = buildSubagentHandbackInbound({
+      ctx: {
+        chatId: '12345',
+        taskDescription: 'Refactor the auth module',
+        resultText: 'Done.',
+        outcome: 'completed',
+      },
+      nowMs: 1_700_000_000_000,
+    })
+
+    // Release-side identity, computed exactly as the seam does internally.
+    const releaseTurnId = deriveTurnId('12345', null, inbound.messageId)
+    // Enqueue-side identity, computed exactly as the gateway does.
+    const enqueueTurnId = enqueueTurnIdFor(inbound, /* startedAt */ 1_700_000_000_500)
+
+    // THE round-trip: the two independently-derived ids must be equal AND
+    // non-null (a synthetic fallback would be non-equal).
+    expect(releaseTurnId).not.toBeNull()
+    expect(enqueueTurnId).toBe(releaseTurnId)
+
+    // And end-to-end: release into the real seam, then adopt with the
+    // enqueue-derived id — adoption must fire (card seeded).
+    seam.signal.noteHandbackRelease(inbound)
+    await sched.advance(700)
+    expect(seam.openCard).toHaveBeenCalledTimes(1)
+    const adoption = seam.signal.tryAdopt(enqueueTurnId)
+    expect(adoption).not.toBeNull()
+    expect(adoption!.activityMessageId).not.toBeNull()
+    expect(seam.signal.pendingCount()).toBe(0)
+  })
+
+  it('round-trips identity through a supergroup topic (threadId survives via meta.message_thread_id)', async () => {
+    const sched = makeScheduler()
+    const seam = makeSeam(sched)
+    teardown.push(() => seam.typing.stopAll())
+
+    const inbound = buildSubagentHandbackInbound({
+      ctx: {
+        chatId: '-100999',
+        threadId: 42,
+        taskDescription: 'Migrate DB',
+        resultText: 'Done.',
+        outcome: 'completed',
+      },
+      nowMs: 1_700_000_111_111,
+    })
+
+    const releaseTurnId = deriveTurnId('-100999', 42, inbound.messageId)
+    const enqueueTurnId = enqueueTurnIdFor(inbound, 1_700_000_111_500)
+    expect(releaseTurnId).not.toBeNull()
+    expect(enqueueTurnId).toBe(releaseTurnId)
+
+    seam.signal.noteHandbackRelease(inbound)
+    await sched.advance(700)
+    const adoption = seam.signal.tryAdopt(enqueueTurnId)
+    expect(adoption).not.toBeNull()
+    expect(adoption!.statusKey).toBe(chatKey('-100999', 42) as string)
+  })
+
+  it('the enqueue message id comes from meta.message_id, not the top-level messageId field', () => {
+    // Guards the exact bridge-survival fact the bug hinged on: the identity must
+    // live in meta (channel-rendered), not only on the top-level field.
+    const inbound = buildSubagentHandbackInbound({
+      ctx: { chatId: '7', taskDescription: 't', resultText: 'r', outcome: 'completed' },
+      nowMs: 1_700_000_222_222,
+    })
+    expect(inbound.meta.message_id).toBe(String(1_700_000_222_222))
+    // The synthetic fallback (what enqueue would use if meta.message_id were
+    // absent) must NOT equal the real release id — proving the round-trip is
+    // load-bearing.
+    const releaseTurnId = deriveTurnId('7', null, inbound.messageId)
+    const syntheticFallback = `${chatKey('7', null)}#synthetic-999`
+    expect(syntheticFallback).not.toBe(releaseTurnId)
+  })
+})

--- a/telegram-plugin/tests/handback-preturn-signal.test.ts
+++ b/telegram-plugin/tests/handback-preturn-signal.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createHandbackPreturnSignal,
+  isHandbackInbound,
+  PRETURN_TURNKEY_PREFIX,
+  type HandbackPreturnSignalDeps,
+  type PreTurnCardRecord,
+} from '../gateway/handback-preturn-signal.js'
+import { createTurnTypingLoop } from '../gateway/turn-typing-loop.js'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
+
+/**
+ * Contract test for the sub-agent-handback dead-air fix (the extracted
+ * emit→adopt→reap seam). Drives the pure seam with fake timers + spy
+ * transports so the whole card lifecycle is asserted without the gateway or
+ * the Telegram bot API:
+ *
+ *   - drain-site emit within the debounce window (typing action + card)
+ *   - adoption across the enqueue boundary is an EDIT (no second card send)
+ *     and the typing loop never samples zero
+ *   - turn-end hands off cleanly (record migrated, typing stopped once)
+ *   - a never-adopted handback self-reaps its frozen card past the TTL
+ *   - an identity race (user inbound adopts first) never mis-adopts the
+ *     handback and never double-sends
+ *
+ * The first two assertions describe behaviour that DOES NOT EXIST on
+ * pre-feature `main` (no pre-turn emit at all, and a handback turn never even
+ * got a turn-long typing loop) — the seam is what makes them true.
+ */
+
+// Mirror the gateway's chatKey (null/0/undefined thread → '_').
+const chatKey = (chatId: string, threadId: number | null) =>
+  `${chatId}:${threadId == null || threadId === 0 ? '_' : threadId}`
+
+// Mirror the gateway's deriveTurnId (`${chatKey}#${messageId}`, null for no id).
+const deriveTurnId = (
+  chatId: string,
+  threadId: number | null,
+  messageId: string | number | null | undefined,
+): string | null => {
+  if (messageId == null || messageId === '' || String(messageId) === '0') return null
+  return `${chatKey(chatId, threadId)}#${messageId}`
+}
+
+function handbackInbound(opts: {
+  chatId: string
+  threadId?: number
+  messageId: number
+}): InboundMessage {
+  return {
+    type: 'inbound',
+    chatId: opts.chatId,
+    ...(opts.threadId != null ? { threadId: opts.threadId } : {}),
+    messageId: opts.messageId,
+    user: 'subagent-watcher',
+    userId: 0,
+    ts: opts.messageId,
+    text: '🤝 A background worker you dispatched has finished.',
+    meta: { source: 'subagent_handback', outcome: 'completed' },
+  }
+}
+
+function userInbound(opts: {
+  chatId: string
+  threadId?: number
+  messageId: number
+}): InboundMessage {
+  return {
+    type: 'inbound',
+    chatId: opts.chatId,
+    ...(opts.threadId != null ? { threadId: opts.threadId } : {}),
+    messageId: opts.messageId,
+    user: 'ken',
+    userId: 42,
+    ts: opts.messageId,
+    text: 'hi',
+    meta: {},
+  }
+}
+
+interface Harness {
+  signal: ReturnType<typeof createHandbackPreturnSignal>
+  typing: ReturnType<typeof createTurnTypingLoop>
+  sendChatAction: ReturnType<typeof vi.fn>
+  openCard: ReturnType<typeof vi.fn>
+  finalizeCard: ReturnType<typeof vi.fn>
+  records: Map<string, PreTurnCardRecord>
+  finalizedIds: number[]
+  nextMessageId: () => number
+}
+
+function makeHarness(overrides: Partial<HandbackPreturnSignalDeps> = {}): Harness {
+  const sendChatAction = vi.fn<(c: string, t: number | null) => void>()
+  const typing = createTurnTypingLoop({
+    sendChatAction,
+    chatKey: (c, t) => chatKey(c, t),
+    refreshMs: 4000,
+  })
+
+  let msgSeq = 1000
+  const nextMessageId = () => ++msgSeq
+  const openCard = vi.fn<(c: string, t: number | null) => Promise<number | null>>(
+    async () => nextMessageId(),
+  )
+
+  // In-memory durable record store keyed by turnKey (mirrors the activity card
+  // store's per-turnKey upsert semantics).
+  const records = new Map<string, PreTurnCardRecord>()
+  const writeCardRecord = (r: PreTurnCardRecord) => {
+    records.set(r.turnKey, r)
+  }
+  const clearCardRecord = (turnKey: string, activityMessageId: number) => {
+    const cur = records.get(turnKey)
+    if (cur != null && cur.activityMessageId === activityMessageId) records.delete(turnKey)
+  }
+
+  const finalizedIds: number[] = []
+  const finalizeCard = vi.fn<(r: PreTurnCardRecord) => void>((r) => {
+    finalizedIds.push(r.activityMessageId)
+  })
+
+  const signal = createHandbackPreturnSignal({
+    chatKey: (c, t) => chatKey(c, t),
+    deriveTurnId,
+    startTypingLoop: (c, t) => typing.start(c, t),
+    stopTypingLoop: (c, t) => typing.stop(c, t),
+    openCard,
+    finalizeCard,
+    writeCardRecord,
+    clearCardRecord,
+    now: () => Date.now(),
+    debounceMs: 700,
+    adoptTimeoutMs: 30_000,
+    ...overrides,
+  })
+
+  return { signal, typing, sendChatAction, openCard, finalizeCard, records, finalizedIds, nextMessageId }
+}
+
+describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('isHandbackInbound only matches the load-bearing source string', () => {
+    expect(isHandbackInbound(handbackInbound({ chatId: 'c', messageId: 1 }))).toBe(true)
+    expect(isHandbackInbound(userInbound({ chatId: 'c', messageId: 1 }))).toBe(false)
+  })
+
+  it('emits a typing action + a pre-turn card within the debounce window on drain release', async () => {
+    const h = makeHarness()
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatA', threadId: 7, messageId: 555 }))
+
+    // Nothing paints before the debounce elapses (flicker guard).
+    await vi.advanceTimersByTimeAsync(699)
+    expect(h.sendChatAction).not.toHaveBeenCalled()
+    expect(h.openCard).not.toHaveBeenCalled()
+
+    // At the debounce boundary: typing loop lights up AND the card opens.
+    await vi.advanceTimersByTimeAsync(1)
+    expect(h.sendChatAction).toHaveBeenCalledWith('chatA', 7)
+    expect(h.typing.activeCount()).toBe(1)
+    expect(h.openCard).toHaveBeenCalledTimes(1)
+    expect(h.openCard).toHaveBeenCalledWith('chatA', 7)
+
+    // A COMPLETE durable record was persisted under a synthetic pre-turn key.
+    expect(h.records.size).toBe(1)
+    const rec = [...h.records.values()][0]!
+    expect(rec.turnKey.startsWith(PRETURN_TURNKEY_PREFIX)).toBe(true)
+    expect(rec.chatId).toBe('chatA')
+    expect(rec.threadId).toBe(7)
+    expect(typeof rec.activityMessageId).toBe('number')
+    expect(typeof rec.startedAt).toBe('number')
+  })
+
+  it('adoption across the enqueue boundary edits (no second card) and keeps typing ≥1 continuously', async () => {
+    const h = makeHarness()
+    const inbound = handbackInbound({ chatId: 'chatB', messageId: 900 })
+    h.signal.noteHandbackRelease(inbound)
+    await vi.advanceTimersByTimeAsync(700)
+    expect(h.openCard).toHaveBeenCalledTimes(1)
+    const cardId = h.openCard.mock.results[0]!.value // Promise<number>
+    const resolvedId = await cardId
+
+    // Typing is already lit before the turn mints — sample it: never zero.
+    expect(h.typing.activeCount()).toBe(1)
+
+    // The enqueue seam mints the SAME turnId deriveTurnId would compute.
+    const turnId = deriveTurnId('chatB', null, 900)!
+    const adoption = h.signal.tryAdopt(turnId)
+    expect(adoption).not.toBeNull()
+    expect(adoption!.activityMessageId).toBe(resolvedId)
+    expect(adoption!.statusKey).toBe('chatB:_')
+
+    // Adoption is an EDIT: no second card send across the boundary.
+    expect(h.openCard).toHaveBeenCalledTimes(1)
+    // Typing loop never sampled zero across the seam.
+    expect(h.typing.activeCount()).toBe(1)
+
+    // Durable record migrated from the synthetic key to the real topic key so
+    // the turn's own end-of-turn clearActivitySummary owns the teardown.
+    expect([...h.records.keys()]).toEqual(['chatB:_'])
+    expect(h.records.get('chatB:_')!.activityMessageId).toBe(resolvedId)
+
+    // Entry consumed — no lingering pre-turn state.
+    expect(h.signal.pendingCount()).toBe(0)
+  })
+
+  it('turn-end hands off cleanly: typing stops exactly once, durable record cleared, map empty', async () => {
+    const h = makeHarness()
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatC', threadId: 3, messageId: 12 }))
+    await vi.advanceTimersByTimeAsync(700)
+    const resolvedId = await h.openCard.mock.results[0]!.value
+    const turnId = deriveTurnId('chatC', 3, 12)!
+    const adoption = h.signal.tryAdopt(turnId)!
+    expect(adoption.activityMessageId).toBe(resolvedId)
+
+    // Simulate the gateway's canonical turn-end: clearActivitySummary clears the
+    // durable record (statusKey + exact id) and stopTurnTypingLoop stops once.
+    h.records.delete('chatC:3') // clearActivityCardRecord(statusKey, id)
+    h.typing.stop('chatC', 3)
+
+    expect(h.typing.activeCount()).toBe(0)
+    expect(h.records.size).toBe(0)
+    expect(h.signal.pendingCount()).toBe(0)
+  })
+
+  it('never-adopted handback self-reaps its frozen card past the TTL', async () => {
+    const h = makeHarness()
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatD', messageId: 77 }))
+    await vi.advanceTimersByTimeAsync(700)
+    const resolvedId = await h.openCard.mock.results[0]!.value
+    expect(h.typing.activeCount()).toBe(1)
+    expect(h.records.size).toBe(1)
+
+    // No enqueue ever arrives. Past the adopt TTL the orphan self-reaps.
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(h.finalizedIds).toEqual([resolvedId]) // finalized exactly THAT card
+    expect(h.typing.activeCount()).toBe(0) // typing stopped
+    expect(h.records.size).toBe(0) // durable record cleared (at-most-once)
+    expect(h.signal.pendingCount()).toBe(0) // map empty
+  })
+
+  it('identity race: a user inbound on the same topic never mis-adopts the handback, no double-send', async () => {
+    const h = makeHarness()
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatE', messageId: 200 }))
+    await vi.advanceTimersByTimeAsync(700)
+    expect(h.openCard).toHaveBeenCalledTimes(1)
+
+    // A racing user inbound on the SAME topic key mints a DIFFERENT turnId.
+    const userTurnId = deriveTurnId('chatE', null, 201)! // user's message id
+    expect(h.signal.tryAdopt(userTurnId)).toBeNull() // must NOT mis-adopt
+    expect(h.signal.pendingCount()).toBe(1) // handback entry still live
+
+    // The handback's own enqueue adopts correctly — still exactly one send.
+    const handbackTurnId = deriveTurnId('chatE', null, 200)!
+    const adoption = h.signal.tryAdopt(handbackTurnId)
+    expect(adoption).not.toBeNull()
+    expect(h.openCard).toHaveBeenCalledTimes(1) // no double-send
+    expect(h.signal.pendingCount()).toBe(0)
+  })
+
+  it('dedupes a second handback release for the same topic; ignores non-handback inbounds', async () => {
+    const h = makeHarness()
+    // Non-handback → no-op.
+    h.signal.noteHandbackRelease(userInbound({ chatId: 'chatF', messageId: 1 }))
+    expect(h.signal.pendingCount()).toBe(0)
+
+    // Two handbacks for the same topic → the first owns the pre-turn signal.
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatF', messageId: 10 }))
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatF', messageId: 11 }))
+    expect(h.signal.pendingCount()).toBe(1)
+    await vi.advanceTimersByTimeAsync(700)
+    expect(h.openCard).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the emit when the adopting turn already settled before the debounce fires', async () => {
+    const settled = new Set<string>()
+    const h = makeHarness({ isTurnSettled: (k) => settled.has(k) })
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatG', messageId: 5 }))
+    settled.add('chatG:_') // the turn delivered its answer during the debounce
+    await vi.advanceTimersByTimeAsync(700)
+    expect(h.openCard).not.toHaveBeenCalled()
+    expect(h.typing.activeCount()).toBe(0)
+    expect(h.signal.pendingCount()).toBe(0)
+  })
+})

--- a/telegram-plugin/tests/handback-preturn-signal.test.ts
+++ b/telegram-plugin/tests/handback-preturn-signal.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   createHandbackPreturnSignal,
@@ -12,9 +12,11 @@ import type { InboundMessage } from '../gateway/ipc-protocol.js'
 
 /**
  * Contract test for the sub-agent-handback dead-air fix (the extracted
- * emit→adopt→reap seam). Drives the pure seam with fake timers + spy
- * transports so the whole card lifecycle is asserted without the gateway or
- * the Telegram bot API:
+ * emit→adopt→reap seam). Drives the pure seam through an INJECTED clock +
+ * INJECTED scheduler (NOT vitest's `vi.useFakeTimers` / `advanceTimersByTimeAsync`,
+ * which bun's test runner does not implement) so it passes identically under
+ * BOTH runners (the telegram-plugin dual-run rule). Asserts the whole card
+ * lifecycle without the gateway or the Telegram bot API:
  *
  *   - drain-site emit within the debounce window (typing action + card)
  *   - adoption across the enqueue boundary is an EDIT (no second card send)
@@ -79,18 +81,70 @@ function userInbound(opts: {
   }
 }
 
+/** Flush the microtask queue so the seam's async openCard promise chain settles
+ *  between scheduler ticks. Runner-agnostic (no fake-timer API): a handful of
+ *  `await` turns drains the fixed-depth chain the seam builds. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 12; i++) await Promise.resolve()
+}
+
+/** Manual injected scheduler + clock — the runner-agnostic replacement for
+ *  vitest fake timers. Fires due timers in chronological order, allowing a
+ *  fired timer to schedule another, and flushes microtasks after each fire so
+ *  the async card-open chain completes deterministically. */
+function makeScheduler() {
+  let seq = 0
+  let currentTime = 0
+  const timers = new Map<number, { fn: () => void; at: number }>()
+  return {
+    now: () => currentTime,
+    setTimer: (fn: () => void, ms: number): unknown => {
+      const id = ++seq
+      timers.set(id, { fn, at: currentTime + ms })
+      return id
+    },
+    clearTimer: (handle: unknown): void => {
+      timers.delete(handle as number)
+    },
+    async advance(ms: number): Promise<void> {
+      const target = currentTime + ms
+      for (;;) {
+        let nextId: number | null = null
+        let nextAt = Infinity
+        for (const [id, t] of timers) {
+          if (t.at <= target && t.at < nextAt) {
+            nextId = id
+            nextAt = t.at
+          }
+        }
+        if (nextId == null) break
+        const t = timers.get(nextId)!
+        timers.delete(nextId)
+        currentTime = t.at
+        t.fn()
+        await flushMicrotasks()
+      }
+      currentTime = target
+      await flushMicrotasks()
+    },
+  }
+}
+
 interface Harness {
   signal: ReturnType<typeof createHandbackPreturnSignal>
   typing: ReturnType<typeof createTurnTypingLoop>
+  sched: ReturnType<typeof makeScheduler>
   sendChatAction: ReturnType<typeof vi.fn>
   openCard: ReturnType<typeof vi.fn>
   finalizeCard: ReturnType<typeof vi.fn>
   records: Map<string, PreTurnCardRecord>
   finalizedIds: number[]
-  nextMessageId: () => number
 }
 
+const harnesses: Harness[] = []
+
 function makeHarness(overrides: Partial<HandbackPreturnSignalDeps> = {}): Harness {
+  const sched = makeScheduler()
   const sendChatAction = vi.fn<(c: string, t: number | null) => void>()
   const typing = createTurnTypingLoop({
     sendChatAction,
@@ -99,9 +153,8 @@ function makeHarness(overrides: Partial<HandbackPreturnSignalDeps> = {}): Harnes
   })
 
   let msgSeq = 1000
-  const nextMessageId = () => ++msgSeq
   const openCard = vi.fn<(c: string, t: number | null) => Promise<number | null>>(
-    async () => nextMessageId(),
+    async () => ++msgSeq,
   )
 
   // In-memory durable record store keyed by turnKey (mirrors the activity card
@@ -129,21 +182,24 @@ function makeHarness(overrides: Partial<HandbackPreturnSignalDeps> = {}): Harnes
     finalizeCard,
     writeCardRecord,
     clearCardRecord,
-    now: () => Date.now(),
+    now: sched.now,
+    setTimer: sched.setTimer,
+    clearTimer: sched.clearTimer,
     debounceMs: 700,
     adoptTimeoutMs: 30_000,
     ...overrides,
   })
 
-  return { signal, typing, sendChatAction, openCard, finalizeCard, records, finalizedIds, nextMessageId }
+  const h: Harness = { signal, typing, sched, sendChatAction, openCard, finalizeCard, records, finalizedIds }
+  harnesses.push(h)
+  return h
 }
 
 describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
   afterEach(() => {
-    vi.useRealTimers()
+    // Real setInterval-backed typing loops in the harnesses are unref'd, but
+    // clear them so no interval leaks across the runner's test files.
+    for (const h of harnesses.splice(0)) h.typing.stopAll()
   })
 
   it('isHandbackInbound only matches the load-bearing source string', () => {
@@ -156,12 +212,12 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
     h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatA', threadId: 7, messageId: 555 }))
 
     // Nothing paints before the debounce elapses (flicker guard).
-    await vi.advanceTimersByTimeAsync(699)
+    await h.sched.advance(699)
     expect(h.sendChatAction).not.toHaveBeenCalled()
     expect(h.openCard).not.toHaveBeenCalled()
 
     // At the debounce boundary: typing loop lights up AND the card opens.
-    await vi.advanceTimersByTimeAsync(1)
+    await h.sched.advance(1)
     expect(h.sendChatAction).toHaveBeenCalledWith('chatA', 7)
     expect(h.typing.activeCount()).toBe(1)
     expect(h.openCard).toHaveBeenCalledTimes(1)
@@ -179,12 +235,10 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
 
   it('adoption across the enqueue boundary edits (no second card) and keeps typing ≥1 continuously', async () => {
     const h = makeHarness()
-    const inbound = handbackInbound({ chatId: 'chatB', messageId: 900 })
-    h.signal.noteHandbackRelease(inbound)
-    await vi.advanceTimersByTimeAsync(700)
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatB', messageId: 900 }))
+    await h.sched.advance(700)
     expect(h.openCard).toHaveBeenCalledTimes(1)
-    const cardId = h.openCard.mock.results[0]!.value // Promise<number>
-    const resolvedId = await cardId
+    const resolvedId = await h.openCard.mock.results[0]!.value
 
     // Typing is already lit before the turn mints — sample it: never zero.
     expect(h.typing.activeCount()).toBe(1)
@@ -213,7 +267,7 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
   it('turn-end hands off cleanly: typing stops exactly once, durable record cleared, map empty', async () => {
     const h = makeHarness()
     h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatC', threadId: 3, messageId: 12 }))
-    await vi.advanceTimersByTimeAsync(700)
+    await h.sched.advance(700)
     const resolvedId = await h.openCard.mock.results[0]!.value
     const turnId = deriveTurnId('chatC', 3, 12)!
     const adoption = h.signal.tryAdopt(turnId)!
@@ -232,13 +286,13 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
   it('never-adopted handback self-reaps its frozen card past the TTL', async () => {
     const h = makeHarness()
     h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatD', messageId: 77 }))
-    await vi.advanceTimersByTimeAsync(700)
+    await h.sched.advance(700)
     const resolvedId = await h.openCard.mock.results[0]!.value
     expect(h.typing.activeCount()).toBe(1)
     expect(h.records.size).toBe(1)
 
     // No enqueue ever arrives. Past the adopt TTL the orphan self-reaps.
-    await vi.advanceTimersByTimeAsync(30_000)
+    await h.sched.advance(30_000)
 
     expect(h.finalizedIds).toEqual([resolvedId]) // finalized exactly THAT card
     expect(h.typing.activeCount()).toBe(0) // typing stopped
@@ -249,7 +303,7 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
   it('identity race: a user inbound on the same topic never mis-adopts the handback, no double-send', async () => {
     const h = makeHarness()
     h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatE', messageId: 200 }))
-    await vi.advanceTimersByTimeAsync(700)
+    await h.sched.advance(700)
     expect(h.openCard).toHaveBeenCalledTimes(1)
 
     // A racing user inbound on the SAME topic key mints a DIFFERENT turnId.
@@ -275,7 +329,7 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
     h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatF', messageId: 10 }))
     h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatF', messageId: 11 }))
     expect(h.signal.pendingCount()).toBe(1)
-    await vi.advanceTimersByTimeAsync(700)
+    await h.sched.advance(700)
     expect(h.openCard).toHaveBeenCalledTimes(1)
   })
 
@@ -284,7 +338,7 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
     const h = makeHarness({ isTurnSettled: (k) => settled.has(k) })
     h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatG', messageId: 5 }))
     settled.add('chatG:_') // the turn delivered its answer during the debounce
-    await vi.advanceTimersByTimeAsync(700)
+    await h.sched.advance(700)
     expect(h.openCard).not.toHaveBeenCalled()
     expect(h.typing.activeCount()).toBe(0)
     expect(h.signal.pendingCount()).toBe(0)

--- a/telegram-plugin/tests/multitopic-routing-wiring.test.ts
+++ b/telegram-plugin/tests/multitopic-routing-wiring.test.ts
@@ -20,6 +20,13 @@ const bridgeSrc = readFileSync(
   resolve(__dirname, '..', 'bridge', 'bridge.ts'),
   'utf-8',
 )
+// #3268 — deriveTurnId was extracted from the gateway monolith into its own
+// importable module so the enqueue seam and the handback round-trip test share
+// ONE function. The body-shape assertion below now reads it from there.
+const deriveTurnIdSrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'derive-turn-id.ts'),
+  'utf-8',
+)
 
 describe('component 3 — turn-origin reply routing', () => {
   it('CurrentTurn carries a turnId, and the enqueue handler initialises it', () => {
@@ -35,10 +42,15 @@ describe('component 3 — turn-origin reply routing', () => {
 
   it('deriveTurnId is stable across inbound-build and enqueue (message-id based)', () => {
     // The id must be derivable identically at both sites — keyed on
-    // chat/thread/messageId, NOT the not-yet-known startedAt.
-    const fn = gatewaySrc.split('function deriveTurnId')[1]?.split('\nfunction ')[0] ?? ''
+    // chat/thread/messageId, NOT the not-yet-known startedAt. Lives in the
+    // extracted derive-turn-id.ts module (#3268); the gateway imports it under
+    // the same name (asserted below), so every enqueue callsite is unchanged.
+    const fn = deriveTurnIdSrc.split('export function deriveTurnId')[1]?.split('\nexport function ')[0] ?? ''
     expect(fn).toMatch(/chatKey\(chatId, threadId \?\? null\)/)
     expect(fn).toMatch(/messageId/)
+    // The gateway must import the shared function, not redefine it — so the
+    // enqueue seam and the round-trip test provably use the same identity.
+    expect(gatewaySrc).toMatch(/import \{ deriveTurnId \} from '\.\/derive-turn-id\.js'/)
   })
 
   it('executeReply resolves the answer thread via the origin turn, not the live currentTurn', () => {

--- a/telegram-plugin/tests/subagent-handback-inbound-builder.test.ts
+++ b/telegram-plugin/tests/subagent-handback-inbound-builder.test.ts
@@ -37,6 +37,11 @@ describe('buildSubagentHandbackInbound', () => {
     // The wake-up contract: bridge renders <channel source="subagent_handback">.
     expect(inbound.meta.source).toBe('subagent_handback')
     expect(inbound.meta.outcome).toBe('completed')
+    // #3268 — the fabricated ts rounds-trips through meta.message_id (the only
+    // channel-rendered id) so enqueue's deriveTurnId matches the pre-turn seam's
+    // adopt id. Must equal the top-level messageId as a string.
+    expect(inbound.meta.message_id).toBe(String(FIXED_NOW))
+    expect(inbound.meta.message_id).toBe(String(inbound.messageId))
     // Text carries the task, the result, and the beat-4 steer.
     expect(inbound.text).toContain('Refactor the auth module')
     expect(inbound.text).toContain('4 tests added, all green')


### PR DESCRIPTION
Closes #3268.

## What

Closes the dead-air gap after a background sub-agent (worker / researcher) finishes: between the handback being **released** for delivery (buffer drain) and the parent turn's first tool/narration render, the chat went dark — no `typing…`, no activity card. Handback turns also never got a turn-long typing loop at all.

Now, at the confirmed-release chokepoint we emit a pre-turn signal (typing loop + a "reading the worker's results…" card); the imminent turn **adopts** that exact card so it's one continuous card lifecycle, finalized by the turn's normal `clearActivitySummary`.

## Design (red-team-hardened — supersedes the naive single-emit at the enqueue seam)

1. **Emit at the release site, not the enqueue seam; no turn-in-flight gate.** The common case is a worker finishing *while the parent is mid-turn on another topic* — a turn-in-flight guard would suppress exactly that. Hooked into `trackRedeliveredInbound` (the shared CONFIRMED-release chokepoint: `performBufferDrain`, `idleDrainTick`, bridge re-register), before the delivery-confirm early-return.
2. **Adopt by inbound identity, not bare topic key.** Each pre-turn entry records the `turnId` its handback derives at enqueue; only the matching enqueue consumes it (mirrors the `pendingCrossTurnGate` consume-by-`turnId` pattern). A racing user inbound on the same topic derives a different `turnId` and cannot mis-adopt.
3. **Adoption seeds `activityMessageId` + `activityEverOpened`** so `renderActivityFeed` EDITS the existing card (no second card) and the turn's own end-of-turn `clearActivitySummary` finalizes it. On adoption the durable record is re-keyed from the synthetic pre-turn key to the real `statusKey` so that teardown matches.
4. **Never-adopted orphan reap.** The pre-turn card is persisted as a COMPLETE `ActivityCardRecord` under a *synthetic* `turnKey` (`preturn:<statusKey>:<startedAt>`) — synthetic so a sibling real turn on the same topic can neither upsert-clobber it nor keep it "live" for the mid-session reaper. An age-based self-reap (independent of topic liveness) finalizes the frozen card, stops the typing loop, and clears the record; the gateway's mid-session + boot reapers are the crash backstop, and a reap hook stops the typing loop + drops the in-memory entry for reaped pre-turn records.
5. **~700ms debounce** kills sub-second-worker flicker (a turn that mints within the window cancels the emit; the turn's own early-liveness card takes over — but it still gets the typing loop).
6. **Testability extraction.** The emit→adopt→reap wiring is an importable pure seam (`handback-preturn-signal.ts`, mirroring `turn-typing-loop.ts` / the `idleDrainTick` extraction), driven deterministically by a vitest contract test.

Kill switch: `SWITCHROOM_HANDBACK_PRETURN=0`.

## Files

- **`telegram-plugin/gateway/handback-preturn-signal.ts`** (new) — the extracted seam: `createHandbackPreturnSignal({ ...deps })` with `noteHandbackRelease` / `tryAdopt` / `handleReaped` / `isPreTurnRecord` / `pendingCount` / `stopAll`.
- **`telegram-plugin/tests/handback-preturn-signal.test.ts`** (new) — contract test (fake timers, spy transports, real `createTurnTypingLoop`).
- **`telegram-plugin/gateway/gateway.ts`** — instantiate the seam (`openHandbackPreTurnCard` / `finalizeHandbackPreTurnCard` deps); emit at `trackRedeliveredInbound`; adopt at the `enqueue` seam; reap hook in the mid-session card reaper.

## Contract test (all green)

- Drain release: within the debounce window a typing action + a pre-turn card open for (chat,thread).
- Enqueue boundary: adoption EDITS (no second card send) and the typing loop never samples zero.
- Turn-end: typing stopped once, durable record cleared, pre-turn map empty.
- Negative-drop: a handback that never enqueues self-reaps past the TTL — finalizes exactly that card id, stops typing, empties the map.
- Identity race: a user inbound on the same topic never mis-adopts the handback; no double-send.
- Dedupe + non-handback no-op; settled-turn skip.

## Test / lint

- `vitest run` — new suite 8/8; related suites (turn-typing-loop, activity-card-store, pending-inbound-buffer, no-reply-bounded-drain, subagent-handback-inbound-builder) 113/113 green.
- `check-bot-api-wrapping`, `check-plugin-references` (tsc), `check-bun-test-imports`, `check-no-pii-secrets`, `check-stale-tool-descriptions` — clean.
- `bun build telegram-plugin/gateway/gateway.ts` — bundles cleanly (864 modules). CI is the full-suite authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)