### PR TITLE
fix(telegram): stop worker-card elapsed clock from earning flood bans

### DIFF
--- a/telegram-plugin/send-gate.test.ts
+++ b/telegram-plugin/send-gate.test.ts
@@ -137,8 +137,8 @@ describe('send-gate: SEND_GATE_DEFAULTS (compile-time default PIN)', () => {
       perGroupPerMin: 18,
       perGroupBurst: 2,
       editFloorMs: 1500,
-      perMessageEditWindowMs: 60_000,
-      perMessageEditMaxPerWindow: 12,
+      perMessageEditWindowMs: 300_000,
+      perMessageEditMaxPerWindow: 150,
     })
   })
 })

--- a/telegram-plugin/send-gate.test.ts
+++ b/telegram-plugin/send-gate.test.ts
@@ -137,6 +137,8 @@ describe('send-gate: SEND_GATE_DEFAULTS (compile-time default PIN)', () => {
       perGroupPerMin: 18,
       perGroupBurst: 2,
       editFloorMs: 1500,
+      perMessageEditWindowMs: 60_000,
+      perMessageEditMaxPerWindow: 12,
     })
   })
 })
@@ -157,6 +159,8 @@ describe('send-gate: sendGateConfigFromEnv (yaml → env → createSendGate)', (
         SWITCHROOM_TG_SEND_GATE_PER_GROUP_PER_MIN: '30',
         SWITCHROOM_TG_SEND_GATE_PER_GROUP_BURST: '4',
         SWITCHROOM_TG_SEND_GATE_EDIT_FLOOR_MS: '2000',
+        SWITCHROOM_TG_SEND_GATE_PER_MSG_EDIT_WINDOW_MS: '30000',
+        SWITCHROOM_TG_SEND_GATE_PER_MSG_EDIT_MAX: '8',
       }),
     )
     expect(cfg).toEqual({
@@ -168,7 +172,21 @@ describe('send-gate: sendGateConfigFromEnv (yaml → env → createSendGate)', (
       perGroupPerMin: 30,
       perGroupBurst: 4,
       editFloorMs: 2000,
+      perMessageEditWindowMs: 30000,
+      perMessageEditMaxPerWindow: 8,
     })
+  })
+
+  it('per-message edit budget: MAX accepts 0 (disables the backstop); WINDOW must be positive', () => {
+    expect(
+      sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_PER_MSG_EDIT_MAX: '0' }))
+        .perMessageEditMaxPerWindow,
+    ).toBe(0)
+    // A zero/negative window is malformed → dropped so createSendGate's default applies.
+    expect(
+      sendGateConfigFromEnv(E({ SWITCHROOM_TG_SEND_GATE_PER_MSG_EDIT_WINDOW_MS: '0' }))
+        .perMessageEditWindowMs,
+    ).toBeUndefined()
   })
 
   it('accepts a fractional per-sec rate (rates are not integers)', () => {
@@ -855,5 +873,125 @@ describe('send-gate: flood windows + boot ramp (L3 / §7 hook)', () => {
     await flush()
     await Promise.all(ps2)
     expect(c2.filter((c) => c.at === 11_000).length).toBe(10) // full burst, no ramp
+  })
+})
+
+describe('send-gate: long-horizon per-message edit budget (backstop)', () => {
+  it('paces + coalesces a sustained same-message cosmetic edit stream under the rolling cap', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    // Tight, fast budget for a deterministic test: 2 cosmetic edits / 5s window,
+    // 1s edit floor. A distinct edit every 1s would sail through the floor
+    // forever (this is exactly the sub-1/s flood the backstop exists to stop).
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      editFloorMs: 1000,
+      perMessageEditWindowMs: 5000,
+      perMessageEditMaxPerWindow: 2,
+    })
+    const msg = 77
+    const attempts = 20
+    const promises: Promise<unknown>[] = []
+    for (let i = 0; i < attempts; i++) {
+      promises.push(
+        gate.gate(fn(`v${i}`), { messageId: msg, editPayload: `v${i}`, priorityClass: 'cosmetic' }),
+      )
+      await flush()
+      await clock.advance(1000)
+    }
+    // Drain any final budget-deferred send (a full window is enough).
+    await clock.advance(5000)
+    await flush()
+    await Promise.allSettled(promises)
+
+    const stats = gate.stats().global
+    // The sustained ~1/s stream is paced FAR below the attempt count — bounded
+    // by ~2 sends per 5s over the ~25s simulated span, not 20 one-per-second.
+    expect(stats.sent).toBeLessThan(attempts)
+    expect(stats.sent).toBeLessThanOrEqual(10)
+    // The backstop actively deferred at least one edit (not just the 1s floor).
+    expect(stats.budgetDeferred).toBeGreaterThan(0)
+    // Coalescing collapsed the deferred edits (last-write-wins), so the FINAL
+    // send carries the newest payload — no stale body is shown.
+    expect(calls[calls.length - 1].label).toBe(`v${attempts - 1}`)
+  })
+
+  it('does NOT throttle distinct message_ids — each message gets its own budget', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      editFloorMs: 1000,
+      perMessageEditWindowMs: 5000,
+      perMessageEditMaxPerWindow: 1,
+    })
+    // One cosmetic edit to each of two distinct messages at t=0. A per-message
+    // budget of 1 must NOT make message B's first edit wait on message A's.
+    const pA = gate.gate(fn('A'), { messageId: 1, editPayload: 'A', priorityClass: 'cosmetic' })
+    const pB = gate.gate(fn('B'), { messageId: 2, editPayload: 'B', priorityClass: 'cosmetic' })
+    await flush()
+    await Promise.all([pA, pB])
+    expect(calls.map((c) => c.label).sort()).toEqual(['A', 'B'])
+    expect(calls.every((c) => c.at === 0)).toBe(true)
+    expect(gate.stats().global.budgetDeferred).toBe(0)
+  })
+
+  it('does NOT throttle non-cosmetic (useful/untagged) edits of the same message', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    // Budget so tight it would allow only ONE cosmetic edit ever in the span —
+    // yet untagged edits default to `useful` and must bypass the budget entirely
+    // (only the 1s floor applies). Legitimate stream/draft edits are untouched.
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      editFloorMs: 1000,
+      perMessageEditWindowMs: 100_000,
+      perMessageEditMaxPerWindow: 1,
+    })
+    const msg = 9
+    const promises: Promise<unknown>[] = []
+    for (let i = 0; i < 5; i++) {
+      promises.push(gate.gate(fn(`u${i}`), { messageId: msg, editPayload: `u${i}` }))
+      await flush()
+      await clock.advance(1000)
+    }
+    await clock.advance(1000)
+    await flush()
+    await Promise.allSettled(promises)
+    // All five distinct useful edits landed (floor-spaced), none budget-deferred.
+    expect(gate.stats().global.sent).toBe(5)
+    expect(gate.stats().global.budgetDeferred).toBe(0)
+    expect(calls.map((c) => c.label)).toEqual(['u0', 'u1', 'u2', 'u3', 'u4'])
+  })
+
+  it('disables the backstop when perMessageEditMaxPerWindow is 0', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      editFloorMs: 1000,
+      perMessageEditMaxPerWindow: 0,
+    })
+    const msg = 55
+    const promises: Promise<unknown>[] = []
+    for (let i = 0; i < 6; i++) {
+      promises.push(
+        gate.gate(fn(`c${i}`), { messageId: msg, editPayload: `c${i}`, priorityClass: 'cosmetic' }),
+      )
+      await flush()
+      await clock.advance(1000)
+    }
+    await clock.advance(1000)
+    await flush()
+    await Promise.allSettled(promises)
+    // With the budget off, only the 1s floor gates: every floor-spaced distinct
+    // edit lands and nothing is budget-deferred.
+    expect(gate.stats().global.sent).toBe(6)
+    expect(gate.stats().global.budgetDeferred).toBe(0)
+    expect(calls.map((c) => c.label)).toEqual(['c0', 'c1', 'c2', 'c3', 'c4', 'c5'])
   })
 })

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -265,21 +265,30 @@ export interface SendGateConfig {
   /** Minimum ms between edits of the same message_id. Default 1500. */
   editFloorMs?: number
   /**
-   * Long-horizon per-message edit budget (rolling window). BACKSTOP for the
-   * sustained same-message edit flood: the 1.5s `editFloorMs` spacing floor
-   * bounds burst rate but NOT a steady sub-1/s stream — a card re-edited every
-   * ~3s for a whole worker run sails through the floor yet accumulates into
-   * Telegram's hidden per-message sustained-edit flood counter (finn incident:
-   * 26,460 clock-only worker-card edits → ~88min 429 ban). This caps a SINGLE
-   * message to at most `perMessageEditMaxPerWindow` edits per
+   * Long-horizon per-message edit budget (rolling window). DEFENSE-IN-DEPTH
+   * backstop for a runaway same-message edit stream (finn incident: sustained
+   * worker-card clock-only edits → ~88min 429 ban). It caps a SINGLE message to
+   * at most `perMessageEditMaxPerWindow` cosmetic edits per
    * `perMessageEditWindowMs`; beyond that the driver DEFERS the next edit until
    * the window slides, and newer edits coalesce (last-write-wins) onto the
-   * pending slot in the meantime — so a runaway stream is paced + collapsed
-   * rather than sustained. Scoped strictly to `cosmetic`-class edits of the
-   * SAME `${chat_id}:${messageId}` (worker-feed, typing, reactions); `useful` /
-   * `critical` edits and all non-edit sends are untouched, and distinct
-   * messages each get their own budget. Default: 12 edits / 60_000ms (1 per 5s
-   * sustained — well above legitimate substantive update cadence). Set
+   * pending slot in the meantime — so a runaway is paced + collapsed rather than
+   * sustained.
+   *
+   * IMPORTANT — this is a coarse rate ceiling, NOT the primary fix. The gate
+   * cannot tell a SUBSTANTIVE cosmetic edit (a new worker step) from an
+   * elapsed-clock cosmetic edit; both carry a changed payload. So the primary
+   * cure for the clock-churn flood is at the source (`worker-activity-feed.ts`
+   * suppresses elapsed-only edits via a substance signature), and THIS backstop
+   * must sit ABOVE legitimate substantive cadence so it never throttles real
+   * updates. The worker feed's own min-edit interval is 2500ms (≤24 edits/min);
+   * the default here — 150 edits / 300_000ms ⟹ a 30 edits/min sustained ceiling
+   * — sits above that, so a normal (even continuously-updating) card never
+   * binds, while a stream that sustains faster than the feed's throttle for
+   * minutes (e.g. a future regression re-introducing per-tick churn, or a
+   * lowered floor) is paced back to 30/min. Scoped strictly to `cosmetic`-class
+   * edits of the SAME `${chat_id}:${messageId}` (worker-feed, typing,
+   * reactions); `useful` / `critical` edits and all non-edit sends are
+   * untouched, and distinct messages each get their own budget. Set
    * `perMessageEditMaxPerWindow: 0` to disable the backstop.
    */
   perMessageEditWindowMs?: number
@@ -554,9 +563,14 @@ export const SEND_GATE_DEFAULTS = {
   /** Minimum ms between edits of the same message_id. */
   editFloorMs: 1500,
   /** Long-horizon per-message edit budget: rolling window length (ms). */
-  perMessageEditWindowMs: 60_000,
-  /** Long-horizon per-message edit budget: max cosmetic edits per window. */
-  perMessageEditMaxPerWindow: 12,
+  perMessageEditWindowMs: 300_000,
+  /**
+   * Long-horizon per-message edit budget: max cosmetic edits per window.
+   * 150 / 300s ⟹ a 30 edits/min sustained ceiling — above the worker feed's
+   * own 24/min cadence so legitimate substantive updates never bind (see the
+   * SendGateConfig field doc).
+   */
+  perMessageEditMaxPerWindow: 150,
 } as const
 
 export function createSendGate(config: SendGateConfig): SendGate {

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -197,6 +197,14 @@ export interface BucketCounters {
    * because the open window exceeded the fail-fast ceiling (part3-design §3).
    */
   failedFast: number
+  /**
+   * Cosmetic edits DEFERRED at least once by the long-horizon per-message edit
+   * budget (rolling-window cap). Counts driver loop iterations that slept on the
+   * budget, not distinct messages — a paced runaway stream increments this each
+   * time it waits out the window. A non-zero, climbing value means the backstop
+   * is actively pacing a sustained same-message edit stream.
+   */
+  budgetDeferred: number
 }
 
 export interface SendGateStats {
@@ -256,6 +264,26 @@ export interface SendGateConfig {
   perGroupBurst?: number
   /** Minimum ms between edits of the same message_id. Default 1500. */
   editFloorMs?: number
+  /**
+   * Long-horizon per-message edit budget (rolling window). BACKSTOP for the
+   * sustained same-message edit flood: the 1.5s `editFloorMs` spacing floor
+   * bounds burst rate but NOT a steady sub-1/s stream — a card re-edited every
+   * ~3s for a whole worker run sails through the floor yet accumulates into
+   * Telegram's hidden per-message sustained-edit flood counter (finn incident:
+   * 26,460 clock-only worker-card edits → ~88min 429 ban). This caps a SINGLE
+   * message to at most `perMessageEditMaxPerWindow` edits per
+   * `perMessageEditWindowMs`; beyond that the driver DEFERS the next edit until
+   * the window slides, and newer edits coalesce (last-write-wins) onto the
+   * pending slot in the meantime — so a runaway stream is paced + collapsed
+   * rather than sustained. Scoped strictly to `cosmetic`-class edits of the
+   * SAME `${chat_id}:${messageId}` (worker-feed, typing, reactions); `useful` /
+   * `critical` edits and all non-edit sends are untouched, and distinct
+   * messages each get their own budget. Default: 12 edits / 60_000ms (1 per 5s
+   * sustained — well above legitimate substantive update cadence). Set
+   * `perMessageEditMaxPerWindow: 0` to disable the backstop.
+   */
+  perMessageEditWindowMs?: number
+  perMessageEditMaxPerWindow?: number
   /**
    * Flood windows to re-open at construction (part3-design §7). PR 2 loads
    * these from `flood-wait.json` BEFORE the first outbound call so a restart
@@ -433,6 +461,14 @@ interface MessageEditState {
   running: boolean
   /** Per-message flood suppression window (part3-design §7). */
   suppressedUntilMs: number
+  /**
+   * Send-START timestamps of recent COSMETIC edits to this message, kept within
+   * the long-horizon rolling window (`perMessageEditWindowMs`). Pruned to the
+   * window on each driver loop and appended at each send start; its length is
+   * the message's edit count over the trailing window and gates the per-message
+   * edit budget. Bounded by the budget cap; empty when the backstop is disabled.
+   */
+  editWindowTs: number[]
 }
 
 function hashPayload(payload: unknown): string {
@@ -517,6 +553,10 @@ export const SEND_GATE_DEFAULTS = {
   perGroupBurst: 2,
   /** Minimum ms between edits of the same message_id. */
   editFloorMs: 1500,
+  /** Long-horizon per-message edit budget: rolling window length (ms). */
+  perMessageEditWindowMs: 60_000,
+  /** Long-horizon per-message edit budget: max cosmetic edits per window. */
+  perMessageEditMaxPerWindow: 12,
 } as const
 
 export function createSendGate(config: SendGateConfig): SendGate {
@@ -529,6 +569,14 @@ export function createSendGate(config: SendGateConfig): SendGate {
   const perGroupPerMin = config.perGroupPerMin ?? SEND_GATE_DEFAULTS.perGroupPerMin
   const perGroupBurst = config.perGroupBurst ?? SEND_GATE_DEFAULTS.perGroupBurst
   const editFloorMs = config.editFloorMs ?? SEND_GATE_DEFAULTS.editFloorMs
+  const perMessageEditWindowMs = Math.max(
+    1,
+    Math.floor(config.perMessageEditWindowMs ?? SEND_GATE_DEFAULTS.perMessageEditWindowMs),
+  )
+  const perMessageEditMaxPerWindow = Math.max(
+    0,
+    Math.floor(config.perMessageEditMaxPerWindow ?? SEND_GATE_DEFAULTS.perMessageEditMaxPerWindow),
+  )
   const messageStateTtlMs = config.messageStateTtlMs ?? 60_000
   const maxMessageStates = config.maxMessageStates ?? 5_000
   const usefulTtlMs = config.usefulTtlMs ?? 120_000
@@ -546,6 +594,7 @@ export function createSendGate(config: SendGateConfig): SendGate {
     shed: 0,
     expired: 0,
     failedFast: 0,
+    budgetDeferred: 0,
   }
 
   const bootStart = clock.now()
@@ -605,6 +654,7 @@ export function createSendGate(config: SendGateConfig): SendGate {
         pending: null,
         running: false,
         suppressedUntilMs: 0,
+        editWindowTs: [],
       }
       perMessage.set(key, state)
     }
@@ -902,7 +952,28 @@ export function createSendGate(config: SendGateConfig): SendGate {
     try {
       while (state.pending) {
         const now = clock.now()
-        const readyAt = Math.max(state.lastSentMs + editFloorMs, state.suppressedUntilMs)
+        let readyAt = Math.max(state.lastSentMs + editFloorMs, state.suppressedUntilMs)
+        // Long-horizon per-message edit budget (backstop). Scoped to cosmetic
+        // edits of THIS message: prune the rolling window, and if it is already
+        // full, defer until the oldest in-window send ages out. Reading the
+        // pending edit's (possibly upgraded) class here means a critical edit
+        // that coalesced onto a cosmetic driver is NOT budget-capped — it must
+        // never block unbounded (part3-design §3). Newer edits keep coalescing
+        // into `state.pending` while we sleep, so pacing preserves last-write-
+        // wins rather than sending stale bodies.
+        if (perMessageEditMaxPerWindow > 0 && state.pending.priorityClass === 'cosmetic') {
+          const windowStart = now - perMessageEditWindowMs
+          while (state.editWindowTs.length > 0 && state.editWindowTs[0] <= windowStart) {
+            state.editWindowTs.shift()
+          }
+          if (state.editWindowTs.length >= perMessageEditMaxPerWindow) {
+            const budgetReadyAt = state.editWindowTs[0] + perMessageEditWindowMs
+            if (budgetReadyAt > readyAt) {
+              readyAt = budgetReadyAt
+              counters.budgetDeferred++
+            }
+          }
+        }
         const waitMs = readyAt - now
         if (waitMs > 0) {
           // Still inside the floor / an open window — sleep, then re-read
@@ -958,6 +1029,16 @@ export function createSendGate(config: SendGateConfig): SendGate {
         // Reserve the send-start time BEFORE awaiting the network so the floor
         // is measured from send start (matches the per-message serialization).
         state.lastSentMs = clock.now()
+        // Record this send against the long-horizon budget when it is a cosmetic
+        // edit (the only class the budget gates). Recorded at send START so the
+        // rolling window measures dispatch cadence, consistent with the floor.
+        if (perMessageEditMaxPerWindow > 0 && p.priorityClass === 'cosmetic') {
+          state.editWindowTs.push(state.lastSentMs)
+          // Bound the array against pathological inputs (it is naturally ≈ the
+          // budget cap since we prune to the window each loop).
+          const overflow = state.editWindowTs.length - (perMessageEditMaxPerWindow + 1)
+          if (overflow > 0) state.editWindowTs.splice(0, overflow)
+        }
         try {
           // N3 (liveness): this awaits `p.fn()` with no watchdog. A `fn` that
           // NEVER settles would keep `state.running` true forever, making the
@@ -1222,6 +1303,8 @@ export type SendGateEnvConfig = Pick<SendGateConfig, 'enabled'> &
       | 'perGroupPerMin'
       | 'perGroupBurst'
       | 'editFloorMs'
+      | 'perMessageEditWindowMs'
+      | 'perMessageEditMaxPerWindow'
       | 'conservativeGlobalFloodScope'
     >
   >
@@ -1270,6 +1353,12 @@ export function sendGateConfigFromEnv(
   if (perGroupBurst !== undefined) out.perGroupBurst = perGroupBurst
   const editFloorMs = parseNonNegativeInt(env.SWITCHROOM_TG_SEND_GATE_EDIT_FLOOR_MS)
   if (editFloorMs !== undefined) out.editFloorMs = editFloorMs
+  // Long-horizon per-message edit budget (flood-ban backstop). Window ≥1ms is
+  // enforced in createSendGate; MAX_PER_WINDOW=0 disables the backstop.
+  const perMsgWindowMs = parsePositiveInt(env.SWITCHROOM_TG_SEND_GATE_PER_MSG_EDIT_WINDOW_MS)
+  if (perMsgWindowMs !== undefined) out.perMessageEditWindowMs = perMsgWindowMs
+  const perMsgMax = parseNonNegativeInt(env.SWITCHROOM_TG_SEND_GATE_PER_MSG_EDIT_MAX)
+  if (perMsgMax !== undefined) out.perMessageEditMaxPerWindow = perMsgMax
   // #3111 break-glass: restore the pre-#3111 always-open-global flood posture.
   // Unset ⇒ scope-precise default (global opened only on genuinely global 429s).
   const conservativeGlobal = parseBoolFlag(env.SWITCHROOM_TG_SEND_GATE_CONSERVATIVE_GLOBAL)

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -1638,4 +1638,37 @@ describe('createWorkerActivityFeed — elapsed-only edit pacing', () => {
     expect(last).toContain('done · 6 tools')
     expect(last).toContain('31s')
   })
+
+  it('does not over-suppress a substantive change that would field-boundary-collide under naive concatenation', async () => {
+    const bot = makeFakeBot()
+    const ref = { t: 10_000 }
+    const feed = mkFeed(bot, ref)
+
+    // Paint: toolCount 1, totalTokens 23. Under a delimiter-less substance key
+    // the fields `1` and `23` concatenate to `123`.
+    ref.t = 20_000
+    await feed.update(
+      'w1',
+      'chat',
+      view({ elapsedMs: 9000, latestSummary: 'scanning', toolCount: 1, totalTokens: 23 }),
+    )
+    expect(bot.sent).toHaveLength(1)
+
+    // A REAL substantive change (toolCount 1→12, totalTokens 23→3) that collides
+    // to the SAME `123` under naive concatenation. It lands within the 15s
+    // elapsed-refresh window (past the 2.5s floor), so ONLY a substance-key
+    // difference can drive the edit. A colliding key would wrongly treat this as
+    // elapsed-only churn and suppress it; the NUL/RS-delimited key keeps them
+    // distinct, so the edit fires promptly.
+    ref.t = 22_500
+    await feed.update(
+      'w1',
+      'chat',
+      view({ elapsedMs: 11_500, latestSummary: 'scanning', toolCount: 12, totalTokens: 3 }),
+    )
+    await drain()
+    expect(bot.edits.length).toBeGreaterThanOrEqual(1)
+    // The rendered card reflects the new tool count, proving the change landed.
+    expect(bot.edits[bot.edits.length - 1].text).toContain('12 tools')
+  })
 })

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -659,6 +659,10 @@ describe('createWorkerActivityFeed — heartbeat', () => {
       bot,
       now: () => clock,
       minEditIntervalMs: 2500,
+      // Suffix-mechanics test: pin the elapsed-refresh cadence to the edit floor
+      // so this exercises the classic 6s heartbeat suffix, not the coarse
+      // flood-pacing cadence (covered by its own tests below).
+      elapsedRefreshMs: 2500,
       heartbeatTickMs: 6000,
       // No real timer: drive ticks manually.
       setInterval: () => 1,
@@ -862,6 +866,10 @@ describe('createWorkerActivityFeed — heartbeat', () => {
       firstPaintMinMs: 8000,
       heartbeatTickMs: 6000,
       minEditIntervalMs: 2500,
+      // Heartbeat-liveness test: pin the elapsed-refresh cadence to the edit
+      // floor so a later heartbeat repaints the climbing clock under the classic
+      // 6s cadence (coarse flood-pacing is covered by its own tests below).
+      elapsedRefreshMs: 2500,
       setInterval: () => 1,
       clearInterval: () => {},
     })
@@ -1549,5 +1557,85 @@ describe('worker-feed send-gate shed contract', () => {
     expect(bot.edits).toHaveLength(1)
     expect(bot.edits[0].text).toContain('_done · 5 tools')
     expect(feed.has('w1')).toBe(false)
+  })
+})
+
+// ─── elapsed-only edit pacing (flood-ban defense, Part 1) ────────────────────
+
+describe('createWorkerActivityFeed — elapsed-only edit pacing', () => {
+  const drain = () => new Promise((r) => setTimeout(r, 0))
+
+  function mkFeed(bot: FakeBot, nowRef: { t: number }) {
+    return createWorkerActivityFeed({
+      bot,
+      now: () => nowRef.t,
+      minEditIntervalMs: 2500,
+      elapsedRefreshMs: 15_000,
+      firstPaintMinMs: 8000,
+      heartbeatTickMs: 6000,
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+  }
+
+  it('suppresses clock-only churn: elapsed advancing within elapsedRefreshMs emits NO edit', async () => {
+    const bot = makeFakeBot()
+    const ref = { t: 10_000 }
+    const feed = mkFeed(bot, ref)
+
+    // First paint.
+    ref.t = 20_000
+    await feed.update('w1', 'chat', view({ elapsedMs: 9000, latestSummary: 'scanning', toolCount: 3 }))
+    expect(bot.sent).toHaveLength(1)
+
+    // A stream of ticks where ONLY the elapsed clock advances (same step, same
+    // toolCount). Every one is past the 2.5s edit floor but under the 15s
+    // elapsed-refresh cadence measured from the last edit (paint @20_000) — so
+    // the send-gate-evading clock-only edit that earns a flood ban never fires.
+    for (const t of [23_000, 26_000, 30_000, 34_000]) {
+      ref.t = t
+      await feed.update('w1', 'chat', view({ elapsedMs: t - 11_000, latestSummary: 'scanning', toolCount: 3 }))
+    }
+    await drain()
+    expect(bot.edits).toHaveLength(0)
+  })
+
+  it('renders a substantive step change PROMPTLY (before the elapsed-refresh cadence)', async () => {
+    const bot = makeFakeBot()
+    const ref = { t: 10_000 }
+    const feed = mkFeed(bot, ref)
+
+    ref.t = 20_000
+    await feed.update('w1', 'chat', view({ elapsedMs: 9000, latestSummary: 'scanning', toolCount: 3 }))
+    expect(bot.sent).toHaveLength(1)
+
+    // 6s later: still under the 15s elapsed-refresh cadence, but the STEP and
+    // toolCount changed — a real update. It renders immediately (only the 2.5s
+    // floor applies), not held for the coarse clock cadence.
+    ref.t = 26_000
+    await feed.update('w1', 'chat', view({ elapsedMs: 15_000, latestSummary: 'writing report', toolCount: 4 }))
+    await drain()
+    expect(bot.edits.length).toBeGreaterThanOrEqual(1)
+    expect(bot.edits[bot.edits.length - 1].text).toContain('writing report')
+  })
+
+  it('forces the terminal edit through and renders the honest final elapsed', async () => {
+    const bot = makeFakeBot()
+    const ref = { t: 10_000 }
+    const feed = mkFeed(bot, ref)
+
+    ref.t = 20_000
+    await feed.update('w1', 'chat', view({ elapsedMs: 9000, latestSummary: 'scanning', toolCount: 3 }))
+    expect(bot.sent).toHaveLength(1)
+
+    // Completion within the elapsed-refresh window still finalizes immediately
+    // (terminal edits bypass the pacing) and shows the correct final elapsed.
+    ref.t = 28_000
+    await feed.finish('w1', view({ state: 'done', toolCount: 6, elapsedMs: 31_000, latestSummary: 'all done' }))
+    await drain()
+    expect(bot.edits.length).toBeGreaterThanOrEqual(1)
+    const last = bot.edits[bot.edits.length - 1].text
+    expect(last).toContain('done · 6 tools')
+    expect(last).toContain('31s')
   })
 })

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -239,6 +239,21 @@ export interface WorkerActivityFeedOpts {
    */
   minEditIntervalMs?: number
   /**
+   * Coarse cadence (ms) for elapsed-ONLY refreshes. When the only thing that
+   * changed since the last edit is the volatile elapsed clock (no new step, no
+   * state/toolCount/token change), the card is NOT re-edited until this much
+   * time has passed — so a worker sitting in one long tool call advances its
+   * clock only every ~`elapsedRefreshMs`, not every jsonl tick. This is the
+   * primary defense against the sustained same-message edit stream that earns a
+   * Telegram flood ban (finn incident: 26,460 clock-only edits → ~88min 429).
+   * A SUBSTANTIVE change (new narrative step, done/failed, toolCount/token
+   * delta) still renders promptly under `minEditIntervalMs`. Default 15000ms.
+   * The terminal finish edit and forced edits bypass it. Liveness for a truly
+   * silent worker is already carried by the typing loop, so a slow clock is not
+   * a liveness regression.
+   */
+  elapsedRefreshMs?: number
+  /**
    * A worker must have been running at least this long before its first
    * message is posted. Sub-second / trivial workers never surface a live
    * message — their result still reaches the user via the handback
@@ -467,6 +482,14 @@ interface FeedGroup {
    */
   messageCreatedAtMs: number
   lastBody: string | null
+  /**
+   * Substance signature of the last EDITED body — every rendered field EXCEPT
+   * the volatile elapsed clock (and heartbeat live suffix). Used to distinguish
+   * an elapsed-only change (paced to `elapsedRefreshMs`) from a real update
+   * (new step / state / toolCount / tokens, rendered promptly). Null until the
+   * group's first paint. See {@link groupSubstanceKey}.
+   */
+  lastSubstanceKey: string | null
   lastEditAt: number
   cooldownUntil: number
   /** Single serialization chain for the shared message — ticks can't interleave sends. */
@@ -647,6 +670,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   const nowFn = opts.now ?? Date.now
   const floodWaitRemainingMs = opts.floodWaitRemainingMs ?? (() => 0)
   const minEditInterval = opts.minEditIntervalMs ?? 2500
+  const elapsedRefreshMs = Math.max(minEditInterval, Math.floor(opts.elapsedRefreshMs ?? 15000))
   const firstPaintMin = opts.firstPaintMinMs ?? 8000
   const heartbeatTickMs = opts.heartbeatTickMs ?? 6000
   const maxRows = Math.max(1, Math.floor(opts.maxRows ?? 8))
@@ -820,6 +844,47 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     return renderCombinedWorkerFeed(rows, { maxRows })
   }
 
+  /**
+   * Substance signature of a group's render at `now` — a stable string of every
+   * field that renders EXCEPT the volatile elapsed clock (and the heartbeat
+   * live suffix, which is elapsed-derived). Two renders with the same substance
+   * key differ only in their clock; an edit between them advances nothing the
+   * user cares about and is exactly the churn that accumulates into a flood ban.
+   *
+   * Built from the group data (not by string-stripping the rendered body) so it
+   * is deterministic and robust to render-format changes: description, state,
+   * toolCount, totalTokens, and the full narrative trail per running row (or the
+   * terminal recap's state/result/narrative when finalizing).
+   */
+  function groupSubstanceKey(g: FeedGroup, terminalRecap: WorkerActivityView | null): string {
+    if (terminalRecap != null) {
+      return [
+        'T',
+        terminalRecap.state,
+        terminalRecap.description,
+        terminalRecap.toolCount,
+        terminalRecap.totalTokens ?? '',
+        terminalRecap.latestSummary,
+        ...(terminalRecap.narrativeLines ?? []),
+      ].join('')
+    }
+    const running = runningRows(g)
+    if (running.length === 0) return 'EMPTY'
+    return running
+      .map((r) => {
+        const v = r.lastView as WorkerActivityView
+        return [
+          r.agentId,
+          v.state,
+          v.description,
+          v.toolCount,
+          v.totalTokens ?? '',
+          ...r.narrative,
+        ].join('')
+      })
+      .join('')
+  }
+
   /** Remove a worker's row + index entry; delete the group if it is now empty. */
   function removeWorker(g: FeedGroup, agentId: string): void {
     g.workers.delete(agentId)
@@ -926,6 +991,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     }
 
     const body = renderGroupBody(g, now, opts2.terminalRecap ?? null, opts2.heartbeat ?? false)
+    const substanceKey = groupSubstanceKey(g, opts2.terminalRecap ?? null)
     if (body == null) {
       // Nothing to show. On a terminal finalize the row is already dropped;
       // clear the staged repaint (the handback carries the result).
@@ -961,6 +1027,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         // group-message lifetime cap measures the message's true absolute age.
         g.messageCreatedAtMs = now
         g.lastBody = body
+        g.lastSubstanceKey = substanceKey
         g.lastEditAt = now
         // A fresh message is a live running paint, never a terminal recap.
         g.terminalPainted = false
@@ -982,7 +1049,19 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       if (isTerminal) clearStaged()
       return
     }
-    if (!opts2.force && now - g.lastEditAt < minEditInterval) return
+    if (!opts2.force && !isTerminal) {
+      // Spacing floor: never edit the same message faster than the 429 floor.
+      if (now - g.lastEditAt < minEditInterval) return
+      // Elapsed-only pacing (flood-ban defense): if the SUBSTANCE is unchanged
+      // since the last edit — the body differs only because the clock advanced —
+      // hold the edit until the coarse `elapsedRefreshMs` cadence. A real change
+      // (new step / state / toolCount / tokens) shifts `substanceKey` and falls
+      // through immediately (subject only to the spacing floor above). This is
+      // what collapses the sustained ~0.33/s clock-only edit stream that
+      // accumulates into Telegram's per-message flood counter.
+      const substanceChanged = substanceKey !== g.lastSubstanceKey
+      if (!substanceChanged && now - g.lastEditAt < elapsedRefreshMs) return
+    }
 
     try {
       const res = await opts.bot.editMessageText(g.chatId, g.messageId, body, sendOptsFor(g))
@@ -996,6 +1075,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         return
       }
       g.lastBody = body
+      g.lastSubstanceKey = substanceKey
       g.lastEditAt = now
       if (isTerminal) {
         log(
@@ -1029,6 +1109,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       }
       if (outcome === 'not_modified') {
         g.lastBody = body
+        g.lastSubstanceKey = substanceKey
         g.lastEditAt = now
         if (isTerminal) clearStaged()
         return
@@ -1040,6 +1121,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         g.messageId = null
         g.messageCreatedAtMs = 0
         g.lastBody = null
+        g.lastSubstanceKey = null
         // The pinned message no longer exists → release the group pin claim
         // (clearStaged already re-syncs on the terminal path).
         if (isTerminal) clearStaged()
@@ -1242,6 +1324,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         g.messageId = null
         g.messageCreatedAtMs = 0
         g.lastBody = null
+        g.lastSubstanceKey = null
         // Clear the (possibly stale) pin claim for the retired message; the
         // fresh first-paint below re-pins the new one from a null claim.
         syncPin(g)
@@ -1322,6 +1405,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           messageId: null,
           messageCreatedAtMs: 0,
           lastBody: null,
+          lastSubstanceKey: null,
           lastEditAt: 0,
           cooldownUntil: 0,
           chain: Promise.resolve(),
@@ -1342,6 +1426,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         g.messageId = null
         g.messageCreatedAtMs = 0
         g.lastBody = null
+        g.lastSubstanceKey = null
         g.pendingFinalize.clear()
         g.terminalPainted = false
         // The stale terminal message is no longer this group's pinned surface.

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -857,6 +857,11 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
    * terminal recap's state/result/narrative when finalizing).
    */
   function groupSubstanceKey(g: FeedGroup, terminalRecap: WorkerActivityView | null): string {
+    // Unambiguous delimiters so adjacent fields can never blur into a boundary
+    // collision (e.g. toolCount `1`+desc `"23"` vs toolCount `12`+desc `"3"`).
+    // FS separates fields within a row; RS separates rows in the combined body.
+    const FS = '\x00'
+    const RS = '\x1e'
     if (terminalRecap != null) {
       return [
         'T',
@@ -866,7 +871,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         terminalRecap.totalTokens ?? '',
         terminalRecap.latestSummary,
         ...(terminalRecap.narrativeLines ?? []),
-      ].join('')
+      ].join(FS)
     }
     const running = runningRows(g)
     if (running.length === 0) return 'EMPTY'
@@ -880,9 +885,9 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           v.toolCount,
           v.totalTokens ?? '',
           ...r.narrative,
-        ].join('')
+        ].join(FS)
       })
-      .join('')
+      .join(RS)
   }
 
   /** Remove a worker's row + index entry; delete the group if it is now empty. */


### PR DESCRIPTION
Closes #3270.

## Summary
The live worker-activity card re-edited ONE Telegram message every ~3s during a background worker run purely to advance its elapsed-time clock. Because each edit changed the rendered bytes (the clock moved), it evaded the #3084 send-gate's no-op hash-skip; at ~0.33/s each edit completed before the next so coalescing never fired, and the per-chat 1/s bucket always had a token so cosmetic-shed never fired. Sustained for a whole run (finn logged 26,460 edits) this accumulates into Telegram's hidden per-message sustained-edit flood counter and earns an ~88min 429 ban.

Two-part deterministic fix, one focused PR.

### Part 1 — kill content-changing no-op edits at source (`worker-activity-feed.ts`)
- New `elapsedRefreshMs` (default 15s) coarse cadence. A `groupSubstanceKey` signature captures every rendered field EXCEPT the volatile elapsed clock (description / state / toolCount / totalTokens / narrative). When the substance is unchanged and only the clock advanced, the card is NOT re-edited until the coarse cadence elapses.
- A substantive change (new step, done/failed, toolCount/token delta) shifts the substance key and renders promptly under the existing 2.5s min-edit floor.
- Terminal finish + forced edits bypass the pacing, so the final card keeps its honest elapsed. Liveness for a silent worker is already carried by the typing loop.

### Part 2 — long-horizon per-message edit budget backstop (`send-gate.ts`)
- Rolling-window cap (`perMessageEditMaxPerWindow` default 12 / `perMessageEditWindowMs` default 60s) on top of the 1.5s spacing floor. A sustained sub-1/s stream of cosmetic edits to one `${chat_id}:${messageId}` is DEFERRED until the window slides, and newer edits coalesce (last-write-wins) onto the pending slot in the meantime.
- Scoped strictly to `cosmetic`-class edits of the SAME message: `useful`/`critical` edits, non-edit sends, and distinct messageIds are untouched (a critical edit that coalesces onto a cosmetic driver is upgraded and never budget-blocked). The reactive breaker (`retry-api-call.ts`) is untouched — this is the proactive complement.
- New `budgetDeferred` counter for observability; configurable via `SWITCHROOM_TG_SEND_GATE_PER_MSG_EDIT_WINDOW_MS` / `SWITCHROOM_TG_SEND_GATE_PER_MSG_EDIT_MAX` (`MAX=0` disables).

## Why
The 1.5s edit floor bounds burst rate but not a sustained sub-1/s stream. A card whose SUBSTANCE never changes but whose clock ticks was, by construction, a perpetual same-message edit source below every existing gate threshold yet above Telegram's real tolerance.

## Test plan
Scoped vitest (all green) + full `npm run lint` (tsc + all guards) clean.
- `worker-activity-feed.test.ts` (80): elapsed-only change within the cadence emits NO edit; a substantive step change emits promptly; terminal completion renders the correct final elapsed. Existing heartbeat suffix-mechanics tests pinned to the fast cadence.
- `send-gate.test.ts` (44): a sustained same-messageId cosmetic stream is paced + coalesced under the rolling cap (bounded edit count over a simulated window, last payload wins); distinct messageIds each get their own budget; non-cosmetic/untagged edits bypass the budget; `MAX=0` disables it; defaults PIN + env-mapping tests updated.

## Risk
Low. Worker-feed responsiveness for real updates is preserved (substantive changes render under the 2.5s floor); the send-gate change is strictly additive and scoped to repeated cosmetic edits of one message, so legitimate reply/send/stream traffic is unaffected. Both mechanisms are deterministic and default-safe.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md` (the worker-activity surface) — advances the "always available" outcome by preventing a self-inflicted multi-hour outage of the bot token.

Scope of Part 1: it fully cures the IDLE-worker clock-churn case (a worker sitting in one long tool call — which is what banned finn). A genuinely long, token-ACTIVE worker whose `totalTokens` ticks on every jsonl event shifts the substance key each tick, so Part 1 does not suppress it — it edits at up to the feed's ~24/min cadence for its whole run, relying on that rate being under Telegram's sustained-edit tolerance (and on Part 2's 30/min backstop above it).