### PR TITLE
fix(ms-365): resolve calendar approval-card context + guard mid-batch grant lapse (#3267)

### DIFF
--- a/src/cli/ms-365-write-pretool.test.ts
+++ b/src/cli/ms-365-write-pretool.test.ts
@@ -26,6 +26,10 @@ import {
   GATED_MS365_WRITE_TOOLS,
   KNOWN_SAFE_MS365_READ_TOOLS,
   isGatedMs365Tool,
+  isCalendarEventTool,
+  extractEventId,
+  buildCalendarChanges,
+  enrichCalendarPreview,
   loadAllowFrom,
 } from "./ms-365-write-pretool.js";
 
@@ -292,5 +296,128 @@ describe("extractMs365Preview", () => {
     expect(extractMs365Preview("x", null).itemId).toBe("(new)");
     expect(extractMs365Preview("x", "not-an-object").itemId).toBe("(new)");
     expect(extractMs365Preview("x", undefined).itemDisplayName).toBe("(unknown)");
+  });
+});
+
+// ── #3267 Problem 1: Graph-resolved calendar context + diff ────────────────
+
+describe("isCalendarEventTool / extractEventId", () => {
+  it("detects calendar-event tools", () => {
+    expect(isCalendarEventTool("mcp__ms-365__update-calendar-event")).toBe(true);
+    expect(isCalendarEventTool("mcp__ms-365__create-specific-calendar-event")).toBe(true);
+    expect(isCalendarEventTool("mcp__ms-365__cancel-calendar-event")).toBe(true);
+  });
+  it("does not flag non-event calendar / mail / drive tools", () => {
+    expect(isCalendarEventTool("mcp__ms-365__create-calendar")).toBe(false);
+    expect(isCalendarEventTool("mcp__ms-365__update-mail-message")).toBe(false);
+    expect(isCalendarEventTool("mcp__ms-365__upload-file-content")).toBe(false);
+    expect(isCalendarEventTool("Edit")).toBe(false);
+  });
+  it("extracts the event id from common shapes", () => {
+    expect(extractEventId({ eventId: "AQ==" })).toBe("AQ==");
+    expect(extractEventId({ id: "xyz" })).toBe("xyz");
+    expect(extractEventId({})).toBeNull();
+    expect(extractEventId(null)).toBeNull();
+  });
+});
+
+describe("buildCalendarChanges", () => {
+  const current = {
+    subject: "Standup",
+    start: "2026-07-20T09:00:00",
+    end: "2026-07-20T09:30:00",
+    location: "Room A",
+    bodyPreview: "old notes",
+  };
+
+  it("diffs only the fields the mutation actually changes (body-only edit)", () => {
+    const changes = buildCalendarChanges(
+      { eventId: "AQ==", body: { contentType: "HTML", content: "<p>new notes</p>" } },
+      current,
+    );
+    expect(changes).toEqual([
+      { field: "body", before: "old notes", after: "new notes" },
+    ]);
+  });
+
+  it("emits before→after for a location change", () => {
+    const changes = buildCalendarChanges({ location: "Room B" }, current);
+    expect(changes).toEqual([{ field: "location", before: "Room A", after: "Room B" }]);
+  });
+
+  it("skips no-op changes where after === before", () => {
+    expect(buildCalendarChanges({ location: "Room A" }, current)).toEqual([]);
+  });
+
+  it("works with no current context (before undefined)", () => {
+    const changes = buildCalendarChanges({ start: { dateTime: "2026-07-20T10:00:00" } }, null);
+    expect(changes).toEqual([{ field: "start", after: "2026-07-20T10:00:00" }]);
+  });
+});
+
+describe("enrichCalendarPreview — resolves subject + account for a body-only edit", () => {
+  it("returns a real subject + account instead of '(unknown)' when Graph resolves", async () => {
+    const enrichment = await enrichCalendarPreview(
+      "mcp__ms-365__update-calendar-event",
+      { eventId: "AQMkADAw==", body: { content: "<p>new</p>" } },
+      {
+        loadHandle: async () => ({
+          access_token: "at-1",
+          expires_at: Date.now() + 3_600_000,
+          account_email: "ken@example.com",
+        }),
+        fetchEvent: async () => ({
+          subject: "Dentist appointment",
+          start: "2026-07-20T09:00:00",
+          end: "2026-07-20T09:30:00",
+          bodyPreview: "old",
+        }),
+      },
+    );
+    // The exact bug: a body-only edit used to fall through to "(unknown)".
+    expect(enrichment.itemDisplayName).toBe("Dentist appointment");
+    expect(enrichment.accountEmail).toBe("ken@example.com");
+    expect(enrichment.eventWhen).toBe("2026-07-20T09:00:00 → 2026-07-20T09:30:00");
+    expect(enrichment.changes).toEqual([{ field: "body", before: "old", after: "new" }]);
+    expect(enrichment.resolveAttemptedButFailed).toBeUndefined();
+  });
+
+  it("is a no-op for non-calendar tools", async () => {
+    const e = await enrichCalendarPreview("mcp__ms-365__upload-file-content", {}, {
+      loadHandle: async () => {
+        throw new Error("should not be called");
+      },
+    });
+    expect(e).toEqual({});
+  });
+
+  it("degrades to resolveAttemptedButFailed when the broker is unreachable (never throws)", async () => {
+    const e = await enrichCalendarPreview(
+      "mcp__ms-365__update-calendar-event",
+      { eventId: "AQ==" },
+      { loadHandle: async () => null },
+    );
+    expect(e.resolveAttemptedButFailed).toBe(true);
+    expect(e.itemDisplayName).toBeUndefined();
+  });
+
+  it("does not throw when the Graph fetch itself rejects", async () => {
+    const e = await enrichCalendarPreview(
+      "mcp__ms-365__update-calendar-event",
+      { eventId: "AQ==", location: "New" },
+      {
+        loadHandle: async () => ({
+          access_token: "at",
+          expires_at: Date.now() + 3_600_000,
+          account_email: "ken@example.com",
+        }),
+        fetchEvent: async () => {
+          throw new Error("network");
+        },
+      },
+    );
+    // Still resolves the account (from the token identity) and the after-value.
+    expect(e.accountEmail).toBe("ken@example.com");
+    expect(e.changes).toEqual([{ field: "location", after: "New" }]);
   });
 });

--- a/src/cli/ms-365-write-pretool.ts
+++ b/src/cli/ms-365-write-pretool.ts
@@ -59,6 +59,7 @@ import {
   readLedger,
   recordOutcome,
   evaluateBatchAdmission,
+  countCurrentBatchApplied,
   buildBatchAbortReason,
 } from "../ms365/batch-ledger.js";
 
@@ -419,7 +420,12 @@ function locationField(v: unknown): string | undefined {
 }
 
 function shorten(s: string, n = 120): string {
-  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+  // Collapse control whitespace so Graph-sourced values (subject/location/body)
+  // can't smuggle newlines into the plain-text card as fake labelled lines
+  // (#3267 review Finding 2). Defence in depth — the card renderer's truncate()
+  // sanitises again at render time.
+  const oneLine = s.replace(/[\r\n\t]+/g, " ").trim();
+  return oneLine.length <= n ? oneLine : oneLine.slice(0, n - 1) + "…";
 }
 
 /**
@@ -876,17 +882,20 @@ async function main(): Promise<void> {
     }
     if (state === "expired" || state === "drift_revoked") {
       // Grant lapsed (TTL elapsed / approver drift) — NOT an intentional deny.
-      // If earlier ops in this batch already applied, this is the mid-batch
+      // If earlier ops in THIS batch already applied, this is the mid-batch
       // partial-application case (#3267 Problem 2): mark the batch aborted so
       // the REMAINING identical ops are refused up front, and give the agent a
       // distinct "N of the batch applied — stop and reconcile" signal. A lone
-      // lapse with nothing applied is just a timeout — don't suppress.
+      // lapse with nothing applied in this batch (or only unrelated earlier
+      // writes) is just a timeout — don't suppress.
       const t = Date.now();
-      const applied = readLedger(t).entries.filter(
-        (e) => e.outcome === "applied" && e.ts <= t,
-      ).length;
+      const applied = countCurrentBatchApplied(readLedger(t).entries, t);
       if (applied > 0) {
-        recordOutcome(t, { ...ledgerEntry, outcome: "aborted" });
+        recordOutcome(t, {
+          ...ledgerEntry,
+          outcome: "aborted",
+          appliedInBatch: applied,
+        });
         fail(buildBatchAbortReason(applied));
       }
       fail(`operator ${state}`);

--- a/src/cli/ms-365-write-pretool.ts
+++ b/src/cli/ms-365-write-pretool.ts
@@ -49,6 +49,19 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 
+import {
+  loadMicrosoftFromAuthBroker,
+  fetchCalendarEventContext,
+  type Ms365AccessHandle,
+  type CalendarEventContext,
+} from "../ms365/graph-resolve.js";
+import {
+  readLedger,
+  recordOutcome,
+  evaluateBatchAdmission,
+  buildBatchAbortReason,
+} from "../ms365/batch-ledger.js";
+
 // ────────────────────────────────────────────────────────────────────────
 // Configuration
 // ────────────────────────────────────────────────────────────────────────
@@ -317,6 +330,213 @@ export interface Ms365PreviewExtract {
   sizeBytesAfter?: number;
 }
 
+/** A single before→after change surfaced on the card. */
+export interface Ms365Change {
+  field: string;
+  before?: string;
+  after?: string;
+}
+
+/**
+ * Enrichment produced by resolving a calendar event's opaque Graph id into
+ * human-readable context. All fields optional — a failed/partial resolve
+ * simply omits what it couldn't fetch.
+ */
+export interface Ms365CalendarEnrichment {
+  /** Resolved event subject (overrides the payload-scraped display name). */
+  itemDisplayName?: string;
+  /** "start → end" human string for the card's `When:` line. */
+  eventWhen?: string;
+  /** Authenticated Microsoft account email (from the broker identity). */
+  accountEmail?: string;
+  /** Structural before→after diff for the fields the mutation changes. */
+  changes?: Ms365Change[];
+  /**
+   * True when we attempted Graph resolution but it failed (broker/network) —
+   * lets the caller mark the account as "(unresolved)" rather than
+   * "(unknown)" so the operator can tell "couldn't reach Graph" from
+   * "never tried".
+   */
+  resolveAttemptedButFailed?: boolean;
+}
+
+/**
+ * Is this a calendar-EVENT tool whose opaque id is worth resolving to a
+ * subject + start/end via Graph? (Calendar/permission tools that don't act on
+ * a single event id are excluded — nothing to resolve.)
+ */
+export function isCalendarEventTool(toolName: string): boolean {
+  if (!toolName.startsWith(TOOL_PREFIX)) return false;
+  const bare = toolName.slice(TOOL_PREFIX.length);
+  return bare.includes("calendar-event");
+}
+
+/**
+ * Extract the calendar event id from a tool_input. softeria uses `eventId`
+ * (and, for specific-calendar variants, still `eventId`); we also accept `id`.
+ */
+export function extractEventId(toolInput: unknown): string | null {
+  const o =
+    toolInput && typeof toolInput === "object"
+      ? (toolInput as Record<string, unknown>)
+      : {};
+  for (const k of ["eventId", "id", "event_id"]) {
+    if (typeof o[k] === "string" && (o[k] as string).length > 0) {
+      return o[k] as string;
+    }
+  }
+  return null;
+}
+
+/** Normalise a possibly-HTML/object body field to a short plain-text string. */
+function bodyToText(v: unknown): string | undefined {
+  if (typeof v === "string") {
+    return v.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim() || undefined;
+  }
+  if (v && typeof v === "object") {
+    const content = (v as { content?: unknown }).content;
+    if (typeof content === "string") return bodyToText(content);
+  }
+  return undefined;
+}
+
+function dateTimeField(v: unknown): string | undefined {
+  if (typeof v === "string" && v.length > 0) return v;
+  if (v && typeof v === "object") {
+    const dt = (v as { dateTime?: unknown }).dateTime;
+    if (typeof dt === "string" && dt.length > 0) return dt;
+  }
+  return undefined;
+}
+
+function locationField(v: unknown): string | undefined {
+  if (typeof v === "string" && v.length > 0) return v;
+  if (v && typeof v === "object") {
+    const dn = (v as { displayName?: unknown }).displayName;
+    if (typeof dn === "string" && dn.length > 0) return dn;
+  }
+  return undefined;
+}
+
+function shorten(s: string, n = 120): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+/**
+ * Build the structural before→after diff for a calendar update by comparing
+ * the mutation `tool_input` (the "after" — only changed fields present) against
+ * the event's current Graph state (the "before"). Pure.
+ */
+export function buildCalendarChanges(
+  toolInput: unknown,
+  current: CalendarEventContext | null,
+): Ms365Change[] {
+  const o =
+    toolInput && typeof toolInput === "object"
+      ? (toolInput as Record<string, unknown>)
+      : {};
+  const changes: Ms365Change[] = [];
+
+  const pushIfChanged = (field: string, before?: string, after?: string) => {
+    if (after === undefined) return;
+    if (before !== undefined && before === after) return;
+    changes.push({
+      field,
+      before: before !== undefined ? shorten(before) : undefined,
+      after: shorten(after),
+    });
+  };
+
+  if ("subject" in o || "title" in o) {
+    const after =
+      typeof o.subject === "string"
+        ? o.subject
+        : typeof o.title === "string"
+          ? o.title
+          : undefined;
+    pushIfChanged("subject", current?.subject, after);
+  }
+  if ("start" in o) {
+    pushIfChanged("start", current?.start, dateTimeField(o.start));
+  }
+  if ("end" in o) {
+    pushIfChanged("end", current?.end, dateTimeField(o.end));
+  }
+  if ("location" in o) {
+    pushIfChanged("location", current?.location, locationField(o.location));
+  }
+  if ("body" in o || "bodyPreview" in o) {
+    const after = bodyToText(o.body ?? o.bodyPreview);
+    pushIfChanged("body", current?.bodyPreview, after);
+  }
+  return changes;
+}
+
+export interface EnrichCalendarDeps {
+  loadHandle?: () => Promise<Ms365AccessHandle | null>;
+  fetchEvent?: (args: {
+    accessToken: string;
+    eventId: string;
+  }) => Promise<CalendarEventContext | null>;
+}
+
+/**
+ * Resolve a calendar event's opaque Graph id into human-readable card context
+ * (subject, when, account) and a before→after diff. Best-effort and fail-soft:
+ * NEVER throws — on any failure returns `{ resolveAttemptedButFailed: true }`
+ * (or partial context) so the hook falls back cleanly without blocking.
+ */
+export async function enrichCalendarPreview(
+  toolName: string,
+  toolInput: unknown,
+  deps: EnrichCalendarDeps = {},
+): Promise<Ms365CalendarEnrichment> {
+  if (!isCalendarEventTool(toolName)) return {};
+  const loadHandle = deps.loadHandle ?? (() => loadMicrosoftFromAuthBroker());
+  const fetchEvent =
+    deps.fetchEvent ??
+    ((a: { accessToken: string; eventId: string }) =>
+      fetchCalendarEventContext(a));
+
+  let handle: Ms365AccessHandle | null;
+  try {
+    handle = await loadHandle();
+  } catch {
+    return { resolveAttemptedButFailed: true };
+  }
+  if (!handle) return { resolveAttemptedButFailed: true };
+
+  const out: Ms365CalendarEnrichment = {};
+  if (handle.account_email) out.accountEmail = handle.account_email;
+
+  const eventId = extractEventId(toolInput);
+  let current: CalendarEventContext | null = null;
+  if (eventId) {
+    try {
+      current = await fetchEvent({
+        accessToken: handle.access_token,
+        eventId,
+      });
+    } catch {
+      current = null;
+    }
+  }
+
+  if (current?.subject) out.itemDisplayName = current.subject;
+  if (current?.start || current?.end) {
+    out.eventWhen = `${current.start ?? "?"} → ${current.end ?? "?"}`;
+  }
+
+  const changes = buildCalendarChanges(toolInput, current);
+  if (changes.length > 0) out.changes = changes;
+
+  // Resolution "succeeded" if we got an account or any event context. If we
+  // got a token but Graph gave us nothing (deleted event, permission gap),
+  // mark it as attempted-but-failed for the account marker.
+  if (!out.accountEmail && !current) out.resolveAttemptedButFailed = true;
+  return out;
+}
+
 /**
  * Best-effort extract the preview-shape fields from softeria's
  * tool_input. softeria's exact param names vary per tool — we look for
@@ -555,17 +775,54 @@ async function main(): Promise<void> {
     fail("SWITCHROOM_AGENT_NAME unset — cannot identify agent to gate write");
   }
 
-  const accountEmail = process.env.SWITCHROOM_MICROSOFT_ACCOUNT ?? "(unknown)";
-
   const extract = extractMs365Preview(toolName, input.tool_input);
+
+  // ── Problem 2: batch admission ──────────────────────────────────────────
+  // If an earlier op in this same recent batch already lapsed/aborted, refuse
+  // the remaining ops UP FRONT (before posting a card or mutating) with a
+  // distinct "grant lapsed, N applied — stop and reconcile" signal, instead of
+  // dribbling further partial application + re-prompts. Fail-soft: a
+  // missing/corrupt ledger admits the op (a first write is never blocked by
+  // this).
+  const now = Date.now();
+  const admission = evaluateBatchAdmission({
+    entries: readLedger(now).entries,
+    now,
+  });
+  if (!admission.admit) {
+    fail(buildBatchAbortReason(admission.appliedInBatch));
+  }
+
+  // ── Problem 1: resolve opaque Graph id → human-readable card context ─────
+  // For calendar-event tools, resolve the event's subject + start/end and the
+  // authenticated account from Graph BEFORE rendering the card, rather than
+  // scraping the mutation payload (which omits unchanged fields). Best-effort
+  // and fail-soft — enrichCalendarPreview never throws.
+  let enrichment: Ms365CalendarEnrichment = {};
+  try {
+    enrichment = await enrichCalendarPreview(toolName, input.tool_input);
+  } catch {
+    enrichment = { resolveAttemptedButFailed: true };
+  }
+
+  const accountEmail =
+    enrichment.accountEmail ??
+    process.env.SWITCHROOM_MICROSOFT_ACCOUNT ??
+    (enrichment.resolveAttemptedButFailed ? "(unresolved)" : "(unknown)");
+
+  const itemDisplayName =
+    enrichment.itemDisplayName ?? extract.itemDisplayName;
+
   const preview = {
     agentName,
     toolName,
     itemId: extract.itemId,
-    itemDisplayName: extract.itemDisplayName,
+    itemDisplayName,
     accountEmail,
     deepLink: extract.deepLink,
     sizeBytesAfter: extract.sizeBytesAfter,
+    eventWhen: enrichment.eventWhen,
+    changes: enrichment.changes,
     // No agentRationale yet — softeria doesn't pass one, and we
     // don't have a sidecar channel for the agent to supply it.
   };
@@ -605,14 +862,39 @@ async function main(): Promise<void> {
   // so no Approve ever stuck. Mirror the working Drive pretool and pass the
   // loaded allowFrom.
   const approverSet = loadAllowFrom();
+  const ledgerEntry = { tool: toolName, itemId: extract.itemId };
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, KERNEL_POLL_INTERVAL_MS));
     const lookup = await approvalLookupByRequest(agentName, requestId, approverSet);
     if (!lookup) continue;
     const state = lookup.state;
-    if (state === "granted") allow();
-    if (state === "denied" || state === "drift_revoked" || state === "expired") {
+    if (state === "granted") {
+      // Record the applied write so a later op that lapses can report an
+      // accurate "N of the batch already applied" count.
+      recordOutcome(Date.now(), { ...ledgerEntry, outcome: "applied" });
+      allow();
+    }
+    if (state === "expired" || state === "drift_revoked") {
+      // Grant lapsed (TTL elapsed / approver drift) — NOT an intentional deny.
+      // If earlier ops in this batch already applied, this is the mid-batch
+      // partial-application case (#3267 Problem 2): mark the batch aborted so
+      // the REMAINING identical ops are refused up front, and give the agent a
+      // distinct "N of the batch applied — stop and reconcile" signal. A lone
+      // lapse with nothing applied is just a timeout — don't suppress.
+      const t = Date.now();
+      const applied = readLedger(t).entries.filter(
+        (e) => e.outcome === "applied" && e.ts <= t,
+      ).length;
+      if (applied > 0) {
+        recordOutcome(t, { ...ledgerEntry, outcome: "aborted" });
+        fail(buildBatchAbortReason(applied));
+      }
       fail(`operator ${state}`);
+    }
+    if (state === "denied") {
+      // An explicit Deny is a deliberate per-op decision — it must NOT suppress
+      // later, unrelated writes, so we don't write a batch-abort entry here.
+      fail("operator denied");
     }
   }
   fail("approval timed out");

--- a/src/ms365/batch-ledger.test.ts
+++ b/src/ms365/batch-ledger.test.ts
@@ -8,7 +8,7 @@
  * no ledger and would keep posting cards for every op regardless.
  */
 
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   evaluateBatchAdmission,
+  countCurrentBatchApplied,
   recordOutcome,
   readLedger,
   pruneLedger,
@@ -63,6 +64,90 @@ describe("evaluateBatchAdmission (pure)", () => {
   });
 });
 
+describe("countCurrentBatchApplied — batch identity (Finding 1)", () => {
+  const now = 10_000_000;
+
+  it("counts a contiguous run of close-together applied writes", () => {
+    const entries: BatchEntry[] = [
+      { ts: now - 20_000, tool: "t", itemId: "a", outcome: "applied" },
+      { ts: now - 15_000, tool: "t", itemId: "b", outcome: "applied" },
+      { ts: now - 10_000, tool: "t", itemId: "c", outcome: "applied" },
+    ];
+    expect(countCurrentBatchApplied(entries, now)).toBe(3);
+  });
+
+  it("does NOT count an unrelated earlier applied write once the batch is cold", () => {
+    // Single applied at T-4min; the batch window is 2min, so at `now` it's cold.
+    const entries: BatchEntry[] = [
+      { ts: now - 4 * 60_000, tool: "t", itemId: "solo", outcome: "applied" },
+    ];
+    expect(countCurrentBatchApplied(entries, now)).toBe(0);
+  });
+
+  it("excludes applied writes separated from the current run by a gap > window", () => {
+    const entries: BatchEntry[] = [
+      { ts: now - 5 * 60_000, tool: "t", itemId: "old", outcome: "applied" }, // different batch
+      { ts: now - 20_000, tool: "t", itemId: "a", outcome: "applied" },
+      { ts: now - 10_000, tool: "t", itemId: "b", outcome: "applied" },
+    ];
+    expect(countCurrentBatchApplied(entries, now)).toBe(2);
+  });
+});
+
+// ── Finding 1 regression: prior UNRELATED applied write + later lone timeout ──
+// must NOT be treated as a mid-batch abort, and must NOT trigger a cooldown
+// block on subsequent writes.
+describe("Finding 1 — a stale applied entry never false-blocks a later lone timeout", () => {
+  it("lone timeout minutes after an unrelated single write → no abort, no block", () => {
+    const t0 = 20_000_000;
+    // 10:00 — one unrelated calendar edit applied.
+    const afterFirstEdit: BatchEntry[] = [
+      { ts: t0, tool: "u", itemId: "edit-1", outcome: "applied" },
+    ];
+
+    // 10:04 — a DIFFERENT single edit hits a timeout. The hook computes the
+    // current-batch applied count as of the lapse; the 10:00 entry is cold.
+    const lapseAt = t0 + 4 * 60_000;
+    const appliedInThisBatch = countCurrentBatchApplied(afterFirstEdit, lapseAt);
+    expect(appliedInThisBatch).toBe(0); // → hook does NOT record an abort
+
+    // Because no abort was recorded, admission for the next write is clean.
+    const nextWriteAt = lapseAt + 5_000;
+    const admission = evaluateBatchAdmission({
+      entries: afterFirstEdit, // still just the lone applied entry
+      now: nextWriteAt,
+    });
+    expect(admission.admit).toBe(true);
+    expect(admission.appliedInBatch).toBe(0);
+  });
+
+  it("a genuine mid-batch lapse still blocks, and reports THIS batch's count only", () => {
+    const t0 = 21_000_000;
+    // Unrelated old write far in the past (same retention window, different batch).
+    const entries: BatchEntry[] = [
+      { ts: t0, tool: "u", itemId: "unrelated", outcome: "applied" },
+      // Real batch, seconds apart, starting ~5min later:
+      { ts: t0 + 5 * 60_000, tool: "u", itemId: "b1", outcome: "applied" },
+      { ts: t0 + 5 * 60_000 + 8_000, tool: "u", itemId: "b2", outcome: "applied" },
+    ];
+    const lapseAt = t0 + 5 * 60_000 + 20_000;
+    const applied = countCurrentBatchApplied(entries, lapseAt);
+    expect(applied).toBe(2); // NOT 3 — the unrelated write is excluded
+
+    // Simulate the hook recording the abort with the batch-scoped count.
+    entries.push({
+      ts: lapseAt,
+      tool: "u",
+      itemId: "b3",
+      outcome: "aborted",
+      appliedInBatch: applied,
+    });
+    const admission = evaluateBatchAdmission({ entries, now: lapseAt + 2_000 });
+    expect(admission.admit).toBe(false);
+    expect(admission.appliedInBatch).toBe(2);
+  });
+});
+
 describe("buildBatchAbortReason", () => {
   it("is a distinct, actionable signal (not a bare 'operator expired')", () => {
     const reason = buildBatchAbortReason(2);
@@ -100,14 +185,30 @@ describe("ledger persistence (fail-soft I/O)", () => {
     const t0 = 2_000_000;
     recordOutcome(t0, { tool: "u", itemId: "a", outcome: "applied" }, path);
     recordOutcome(t0 + 1000, { tool: "u", itemId: "b", outcome: "applied" }, path);
-    recordOutcome(t0 + 2000, { tool: "u", itemId: "c", outcome: "aborted" }, path);
+    recordOutcome(
+      t0 + 2000,
+      { tool: "u", itemId: "c", outcome: "aborted", appliedInBatch: 2 },
+      path,
+    );
 
     expect(existsSync(path)).toBe(true);
     const now = t0 + 2500;
     const ledger = readLedger(now, path);
+    // appliedInBatch survives the round-trip on aborted entries.
+    const aborted = ledger.entries.find((e) => e.outcome === "aborted");
+    expect(aborted?.appliedInBatch).toBe(2);
     const admission = evaluateBatchAdmission({ entries: ledger.entries, now });
     expect(admission.admit).toBe(false);
     expect(admission.appliedInBatch).toBe(2);
+  });
+
+  it("leaves no leftover .tmp files after atomic writes (Finding 3)", () => {
+    const path = join(dir, "batch.json");
+    const t0 = 3_000_000;
+    recordOutcome(t0, { tool: "u", itemId: "a", outcome: "applied" }, path);
+    recordOutcome(t0 + 100, { tool: "u", itemId: "b", outcome: "applied" }, path);
+    const stray = readdirSync(dir).filter((f) => f.includes(".tmp."));
+    expect(stray).toEqual([]);
   });
 
   it("returns an empty ledger for a missing/corrupt file (never throws)", () => {

--- a/src/ms365/batch-ledger.test.ts
+++ b/src/ms365/batch-ledger.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the MS-365 write batch ledger — issue #3267 (Problem 2).
+ *
+ * The load-bearing outcome: once a batch has aborted (grant lapsed/denied for
+ * one op), the REMAINING identical ops are refused UP FRONT rather than
+ * continuing to half-apply — and the agent gets an accurate "N of the batch
+ * already applied" count. These tests fail against the pre-fix code, which had
+ * no ledger and would keep posting cards for every op regardless.
+ */
+
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  evaluateBatchAdmission,
+  recordOutcome,
+  readLedger,
+  pruneLedger,
+  buildBatchAbortReason,
+  batchLedgerPath,
+  BATCH_COOLDOWN_MS,
+  type BatchEntry,
+} from "./batch-ledger.js";
+
+describe("evaluateBatchAdmission (pure)", () => {
+  const now = 1_000_000;
+
+  it("admits when the ledger is empty (a first write is never blocked)", () => {
+    const r = evaluateBatchAdmission({ entries: [], now });
+    expect(r.admit).toBe(true);
+    expect(r.appliedInBatch).toBe(0);
+  });
+
+  it("admits when only applied entries exist (no abort yet)", () => {
+    const entries: BatchEntry[] = [
+      { ts: now - 1000, tool: "t", itemId: "a", outcome: "applied" },
+      { ts: now - 500, tool: "t", itemId: "b", outcome: "applied" },
+    ];
+    expect(evaluateBatchAdmission({ entries, now }).admit).toBe(true);
+  });
+
+  it("REFUSES up front after an abort within the cooldown, counting prior applied ops", () => {
+    // Batch: op1 applied, op2 applied, op3 aborted (grant lapsed). op4 now asks.
+    const entries: BatchEntry[] = [
+      { ts: now - 3000, tool: "t", itemId: "a", outcome: "applied" },
+      { ts: now - 2000, tool: "t", itemId: "b", outcome: "applied" },
+      { ts: now - 1000, tool: "t", itemId: "c", outcome: "aborted" },
+    ];
+    const r = evaluateBatchAdmission({ entries, now });
+    expect(r.admit).toBe(false);
+    expect(r.appliedInBatch).toBe(2);
+    expect(r.abortedAt).toBe(now - 1000);
+  });
+
+  it("re-admits once the abort is older than the cooldown window", () => {
+    const entries: BatchEntry[] = [
+      { ts: now - (BATCH_COOLDOWN_MS + 5000), tool: "t", itemId: "c", outcome: "aborted" },
+    ];
+    expect(evaluateBatchAdmission({ entries, now }).admit).toBe(true);
+  });
+});
+
+describe("buildBatchAbortReason", () => {
+  it("is a distinct, actionable signal (not a bare 'operator expired')", () => {
+    const reason = buildBatchAbortReason(2);
+    expect(reason).toContain("2 MS-365 writes already applied");
+    expect(reason).toContain("STOP");
+    expect(reason).not.toBe("operator expired");
+  });
+  it("singularises for one applied write", () => {
+    expect(buildBatchAbortReason(1)).toContain("1 MS-365 write already applied");
+  });
+});
+
+describe("pruneLedger", () => {
+  it("drops entries older than retention and future-dated entries", () => {
+    const now = 1_000_000;
+    const entries: BatchEntry[] = [
+      { ts: now - 1000, tool: "t", itemId: "a", outcome: "applied" }, // keep
+      { ts: now - 60 * 60 * 1000, tool: "t", itemId: "b", outcome: "applied" }, // too old
+      { ts: now + 5000, tool: "t", itemId: "c", outcome: "applied" }, // future
+    ];
+    const kept = pruneLedger(entries, now);
+    expect(kept.map((e) => e.itemId)).toEqual(["a"]);
+  });
+});
+
+describe("ledger persistence (fail-soft I/O)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ms365-ledger-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("round-trips applied/aborted outcomes and drives an up-front refusal", () => {
+    const path = join(dir, "batch.json");
+    const t0 = 2_000_000;
+    recordOutcome(t0, { tool: "u", itemId: "a", outcome: "applied" }, path);
+    recordOutcome(t0 + 1000, { tool: "u", itemId: "b", outcome: "applied" }, path);
+    recordOutcome(t0 + 2000, { tool: "u", itemId: "c", outcome: "aborted" }, path);
+
+    expect(existsSync(path)).toBe(true);
+    const now = t0 + 2500;
+    const ledger = readLedger(now, path);
+    const admission = evaluateBatchAdmission({ entries: ledger.entries, now });
+    expect(admission.admit).toBe(false);
+    expect(admission.appliedInBatch).toBe(2);
+  });
+
+  it("returns an empty ledger for a missing/corrupt file (never throws)", () => {
+    expect(readLedger(1, join(dir, "nope.json")).entries).toEqual([]);
+  });
+
+  it("resolves a default path under TELEGRAM_STATE_DIR", () => {
+    const saved = process.env.TELEGRAM_STATE_DIR;
+    process.env.TELEGRAM_STATE_DIR = dir;
+    try {
+      expect(batchLedgerPath()).toBe(join(dir, "ms365-write-batch.json"));
+    } finally {
+      if (saved === undefined) delete process.env.TELEGRAM_STATE_DIR;
+      else process.env.TELEGRAM_STATE_DIR = saved;
+    }
+  });
+});

--- a/src/ms365/batch-ledger.ts
+++ b/src/ms365/batch-ledger.ts
@@ -31,14 +31,23 @@
  * never crash the hook or wrongly block a legitimate first write.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { randomBytes } from "node:crypto";
 
 /** How long an abort suppresses the rest of a batch. */
 export const BATCH_COOLDOWN_MS = 90 * 1000;
 /** Entries older than this are pruned on every read/write. */
 export const BATCH_LEDGER_RETENTION_MS = 10 * 60 * 1000;
+/**
+ * Max gap between two consecutive ops for them to count as the SAME batch.
+ * A batch is a run of writes issued close together (the incident's four
+ * `update-calendar-event` calls were seconds apart). Applied writes separated
+ * by more than this — e.g. an unrelated edit minutes earlier — are a DIFFERENT
+ * batch and must not inflate the current batch's applied count (Finding 1).
+ */
+export const BATCH_WINDOW_MS = 2 * 60 * 1000;
 
 export type BatchOutcome = "applied" | "aborted";
 
@@ -50,6 +59,13 @@ export interface BatchEntry {
   /** Item/event id the op targeted. */
   itemId: string;
   outcome: BatchOutcome;
+  /**
+   * For `aborted` entries only: how many writes had already applied in THIS
+   * batch at abort time. Captured at write time (batch-scoped, see
+   * `countCurrentBatchApplied`) so admission doesn't have to recount against a
+   * window that may include unrelated writes.
+   */
+  appliedInBatch?: number;
 }
 
 export interface BatchLedger {
@@ -91,14 +107,32 @@ export function readLedger(now: number, path?: string): BatchLedger {
     const raw = readFileSync(p, "utf8");
     const parsed = JSON.parse(raw) as { entries?: unknown };
     const entries = Array.isArray(parsed.entries)
-      ? (parsed.entries as BatchEntry[]).filter(
-          (e): e is BatchEntry =>
-            !!e &&
-            typeof e === "object" &&
-            typeof (e as BatchEntry).ts === "number" &&
-            ((e as BatchEntry).outcome === "applied" ||
-              (e as BatchEntry).outcome === "aborted"),
-        )
+      ? (parsed.entries as BatchEntry[])
+          .filter(
+            (e): e is BatchEntry =>
+              !!e &&
+              typeof e === "object" &&
+              typeof (e as BatchEntry).ts === "number" &&
+              ((e as BatchEntry).outcome === "applied" ||
+                (e as BatchEntry).outcome === "aborted"),
+          )
+          .map((e) => {
+            // Keep only the fields we trust; preserve the batch-scoped count on
+            // aborts so admission can reflect "N of THIS batch" verbatim.
+            const out: BatchEntry = {
+              ts: e.ts,
+              tool: typeof e.tool === "string" ? e.tool : "",
+              itemId: typeof e.itemId === "string" ? e.itemId : "",
+              outcome: e.outcome,
+            };
+            if (
+              e.outcome === "aborted" &&
+              typeof e.appliedInBatch === "number"
+            ) {
+              out.appliedInBatch = e.appliedInBatch;
+            }
+            return out;
+          })
       : [];
     return { entries: pruneLedger(entries, now) };
   } catch {
@@ -107,9 +141,46 @@ export function readLedger(now: number, path?: string): BatchLedger {
 }
 
 /**
- * Append an outcome and persist. Fail-soft: a write failure is swallowed (the
- * ledger is an advisory safety net, not a correctness gate for the single op).
- * Returns the in-memory ledger regardless so callers can reason about it.
+ * Count the writes that have applied in the CURRENT batch as of `asOf`. Pure.
+ *
+ * A batch is the maximal run of `applied` entries ending at the most recent
+ * applied entry, where consecutive entries are ≤ `batchWindowMs` apart AND the
+ * most recent applied entry is itself ≤ `batchWindowMs` before `asOf`. Applied
+ * writes that fall outside that window (an unrelated edit minutes earlier)
+ * belong to a DIFFERENT, already-cold batch and are NOT counted — so a lone
+ * later timeout does not inherit their count (Finding 1).
+ *
+ * Returns 0 when there is no active batch (empty, or the last applied write is
+ * already colder than the window) — i.e. "nothing applied in THIS batch".
+ */
+export function countCurrentBatchApplied(
+  entries: BatchEntry[],
+  asOf: number,
+  batchWindowMs = BATCH_WINDOW_MS,
+): number {
+  const applied = entries
+    .filter((e) => e.outcome === "applied")
+    .sort((a, b) => a.ts - b.ts);
+  if (applied.length === 0) return 0;
+  const last = applied[applied.length - 1];
+  if (asOf - last.ts > batchWindowMs) return 0; // batch already cold
+  let count = 1;
+  for (let i = applied.length - 1; i > 0; i--) {
+    if (applied[i].ts - applied[i - 1].ts <= batchWindowMs) count++;
+    else break;
+  }
+  return count;
+}
+
+/**
+ * Append an outcome and persist ATOMICALLY. Fail-soft: a write failure is
+ * swallowed (the ledger is an advisory safety net, not a correctness gate for
+ * the single op). Returns the in-memory ledger regardless.
+ *
+ * Concurrency (Finding 3): the per-op hook processes can race, so the write is
+ * temp-file + atomic `rename` — a concurrent reader sees either the old or the
+ * new complete file, never a torn half-write, and the fail-soft empty-ledger
+ * recovery on `readLedger` still covers any residual corruption.
  */
 export function recordOutcome(
   now: number,
@@ -120,7 +191,9 @@ export function recordOutcome(
   const ledger = readLedger(now, p);
   ledger.entries.push({ ...entry, ts: now });
   try {
-    writeFileSync(p, JSON.stringify(ledger), "utf8");
+    const tmp = `${p}.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
+    writeFileSync(tmp, JSON.stringify(ledger), "utf8");
+    renameSync(tmp, p);
   } catch {
     /* advisory — never block on a ledger write failure */
   }
@@ -130,7 +203,7 @@ export function recordOutcome(
 export interface BatchAdmission {
   /** Whether this op may proceed to post a card / apply. */
   admit: boolean;
-  /** Count of writes already applied in the current (aborted) batch window. */
+  /** Count of writes already applied in the current (aborted) batch. */
   appliedInBatch: number;
   /** Unix-ms of the abort that is suppressing this op, when admit=false. */
   abortedAt?: number;
@@ -140,10 +213,10 @@ export interface BatchAdmission {
  * Decide whether a new op may start, given the current ledger. Pure.
  *
  * Refuse UP FRONT when the batch was aborted within `cooldownMs`: the grant
- * lapsed (or was denied) for an earlier op, so the remaining identical ops
- * must not keep half-applying. `appliedInBatch` counts the `applied` entries
- * that precede the most recent abort within the retention window — i.e. "N of
- * the batch already landed".
+ * lapsed for an earlier op, so the remaining identical ops must not keep
+ * half-applying. `appliedInBatch` is read from the abort entry itself (the
+ * batch-scoped count captured at abort time), so it reflects "N of THIS batch
+ * already landed" — never an unrelated earlier write (Finding 1).
  */
 export function evaluateBatchAdmission(args: {
   entries: BatchEntry[];
@@ -153,19 +226,22 @@ export function evaluateBatchAdmission(args: {
   const { entries, now } = args;
   const cooldownMs = args.cooldownMs ?? BATCH_COOLDOWN_MS;
 
-  let lastAbortTs: number | undefined;
+  let lastAbort: BatchEntry | undefined;
   for (const e of entries) {
-    if (e.outcome === "aborted" && (lastAbortTs === undefined || e.ts > lastAbortTs)) {
-      lastAbortTs = e.ts;
+    if (e.outcome === "aborted" && (lastAbort === undefined || e.ts > lastAbort.ts)) {
+      lastAbort = e;
     }
   }
-  if (lastAbortTs === undefined || now - lastAbortTs > cooldownMs) {
+  if (lastAbort === undefined || now - lastAbort.ts > cooldownMs) {
     return { admit: true, appliedInBatch: 0 };
   }
-  const appliedInBatch = entries.filter(
-    (e) => e.outcome === "applied" && e.ts <= lastAbortTs!,
-  ).length;
-  return { admit: false, appliedInBatch, abortedAt: lastAbortTs };
+  // Prefer the count captured at abort time; fall back to a batch-scoped
+  // recount anchored at the abort instant for older/hand-written entries.
+  const appliedInBatch =
+    typeof lastAbort.appliedInBatch === "number"
+      ? lastAbort.appliedInBatch
+      : countCurrentBatchApplied(entries, lastAbort.ts);
+  return { admit: false, appliedInBatch, abortedAt: lastAbort.ts };
 }
 
 /**

--- a/src/ms365/batch-ledger.ts
+++ b/src/ms365/batch-ledger.ts
@@ -1,0 +1,183 @@
+/**
+ * MS-365 write batch ledger — fix for issue #3267 (Problem 2).
+ *
+ * The `ms-365-write-pretool` hook runs as a FRESH PROCESS per tool call, so a
+ * run of identical writes (e.g. four `update-calendar-event` calls) is really
+ * four independent approvals. Previously, when a grant/TTL lapsed between the
+ * 2nd and 3rd op, ops 1–2 had already mutated Graph and op 3 hard-blocked with
+ * a bare `operator expired` — leaving the calendar half-applied with no
+ * coherent "the batch is aborted, stop" signal to the agent.
+ *
+ * True cross-process rollback of external Graph writes is impossible from a
+ * pretool hook. What IS deterministic and achievable is a small on-disk ledger
+ * shared across the per-op processes:
+ *
+ *   1. Every APPLIED write appends an `applied` entry.
+ *   2. A GRANT LAPSE (expired / approver drift) that occurs when earlier ops
+ *      have already applied appends an `aborted` entry. An explicit Deny, and a
+ *      lone lapse with nothing applied, do NOT — those must not suppress later
+ *      unrelated writes.
+ *   3. Before starting a new op, the hook consults the ledger: if the batch
+ *      was aborted within a short cooldown window, the remaining ops are
+ *      REFUSED UP FRONT (no card, no mutation) with a distinct
+ *      "grant lapsed, N of the batch already applied — STOP and reconcile"
+ *      signal, instead of dribbling further partial application + re-prompts.
+ *
+ * This turns the failure mode from "silently keep half-applying and re-prompt"
+ * into "abort the rest of the batch up front and tell the agent exactly how
+ * many ops already landed" — the coherent stop signal the issue asks for.
+ *
+ * All I/O here is BEST-EFFORT and fail-soft: a missing/corrupt ledger must
+ * never crash the hook or wrongly block a legitimate first write.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** How long an abort suppresses the rest of a batch. */
+export const BATCH_COOLDOWN_MS = 90 * 1000;
+/** Entries older than this are pruned on every read/write. */
+export const BATCH_LEDGER_RETENTION_MS = 10 * 60 * 1000;
+
+export type BatchOutcome = "applied" | "aborted";
+
+export interface BatchEntry {
+  /** Unix-ms when the outcome was recorded. */
+  ts: number;
+  /** Full tool name (`mcp__ms-365__…`). */
+  tool: string;
+  /** Item/event id the op targeted. */
+  itemId: string;
+  outcome: BatchOutcome;
+}
+
+export interface BatchLedger {
+  entries: BatchEntry[];
+}
+
+/**
+ * Resolve the ledger path inside the agent container. Mirrors the pretool's
+ * own state-dir resolution (`TELEGRAM_STATE_DIR`, homedir fallback for
+ * host-side tests).
+ */
+export function batchLedgerPath(stateDir?: string): string {
+  const dir =
+    stateDir ??
+    process.env.TELEGRAM_STATE_DIR ??
+    join(homedir(), ".claude", "channels", "telegram");
+  return join(dir, "ms365-write-batch.json");
+}
+
+/** Drop entries older than the retention window. Pure. */
+export function pruneLedger(
+  entries: BatchEntry[],
+  now: number,
+  retentionMs = BATCH_LEDGER_RETENTION_MS,
+): BatchEntry[] {
+  return entries.filter(
+    (e) =>
+      e &&
+      typeof e.ts === "number" &&
+      now - e.ts <= retentionMs &&
+      now - e.ts >= 0,
+  );
+}
+
+/** Read + prune the ledger. Fail-soft: returns empty on any error. */
+export function readLedger(now: number, path?: string): BatchLedger {
+  const p = path ?? batchLedgerPath();
+  try {
+    const raw = readFileSync(p, "utf8");
+    const parsed = JSON.parse(raw) as { entries?: unknown };
+    const entries = Array.isArray(parsed.entries)
+      ? (parsed.entries as BatchEntry[]).filter(
+          (e): e is BatchEntry =>
+            !!e &&
+            typeof e === "object" &&
+            typeof (e as BatchEntry).ts === "number" &&
+            ((e as BatchEntry).outcome === "applied" ||
+              (e as BatchEntry).outcome === "aborted"),
+        )
+      : [];
+    return { entries: pruneLedger(entries, now) };
+  } catch {
+    return { entries: [] };
+  }
+}
+
+/**
+ * Append an outcome and persist. Fail-soft: a write failure is swallowed (the
+ * ledger is an advisory safety net, not a correctness gate for the single op).
+ * Returns the in-memory ledger regardless so callers can reason about it.
+ */
+export function recordOutcome(
+  now: number,
+  entry: Omit<BatchEntry, "ts">,
+  path?: string,
+): BatchLedger {
+  const p = path ?? batchLedgerPath();
+  const ledger = readLedger(now, p);
+  ledger.entries.push({ ...entry, ts: now });
+  try {
+    writeFileSync(p, JSON.stringify(ledger), "utf8");
+  } catch {
+    /* advisory — never block on a ledger write failure */
+  }
+  return ledger;
+}
+
+export interface BatchAdmission {
+  /** Whether this op may proceed to post a card / apply. */
+  admit: boolean;
+  /** Count of writes already applied in the current (aborted) batch window. */
+  appliedInBatch: number;
+  /** Unix-ms of the abort that is suppressing this op, when admit=false. */
+  abortedAt?: number;
+}
+
+/**
+ * Decide whether a new op may start, given the current ledger. Pure.
+ *
+ * Refuse UP FRONT when the batch was aborted within `cooldownMs`: the grant
+ * lapsed (or was denied) for an earlier op, so the remaining identical ops
+ * must not keep half-applying. `appliedInBatch` counts the `applied` entries
+ * that precede the most recent abort within the retention window — i.e. "N of
+ * the batch already landed".
+ */
+export function evaluateBatchAdmission(args: {
+  entries: BatchEntry[];
+  now: number;
+  cooldownMs?: number;
+}): BatchAdmission {
+  const { entries, now } = args;
+  const cooldownMs = args.cooldownMs ?? BATCH_COOLDOWN_MS;
+
+  let lastAbortTs: number | undefined;
+  for (const e of entries) {
+    if (e.outcome === "aborted" && (lastAbortTs === undefined || e.ts > lastAbortTs)) {
+      lastAbortTs = e.ts;
+    }
+  }
+  if (lastAbortTs === undefined || now - lastAbortTs > cooldownMs) {
+    return { admit: true, appliedInBatch: 0 };
+  }
+  const appliedInBatch = entries.filter(
+    (e) => e.outcome === "applied" && e.ts <= lastAbortTs!,
+  ).length;
+  return { admit: false, appliedInBatch, abortedAt: lastAbortTs };
+}
+
+/**
+ * Build the distinct agent-facing block reason for a lapsed/aborted batch.
+ * Deliberately NOT the bare `operator expired` string — it tells the agent the
+ * batch is partially applied and must be reconciled, not blindly retried.
+ */
+export function buildBatchAbortReason(appliedInBatch: number): string {
+  const n = appliedInBatch;
+  return (
+    `grant lapsed mid-batch — ${n} MS-365 write${n === 1 ? "" : "s"} already ` +
+    `applied in this batch; remaining ops aborted. STOP: do not retry blindly — ` +
+    `reconcile what landed before re-issuing.`
+  );
+}

--- a/src/ms365/graph-resolve.ts
+++ b/src/ms365/graph-resolve.ts
@@ -1,0 +1,224 @@
+/**
+ * Microsoft Graph resolution helpers for the MS-365 write-approval hook —
+ * fix for issue #3267 (Problem 1).
+ *
+ * The `ms-365-write-pretool` hook previously rendered the approval card
+ * purely from the mutation `tool_input`. For an `update-calendar-event`
+ * that edits only body/location, softeria does NOT resend `subject`/`title`,
+ * so the card showed `Item: (unknown)`, only the raw opaque Graph id, no
+ * account (an unset env var), and no diff — an unverifiable "blind write".
+ *
+ * This module resolves that opaque id into human-readable context BEFORE the
+ * card is rendered: it fetches the event's subject + start/end (and the
+ * authenticated account email) from Microsoft Graph, using the SAME
+ * auth-broker access-token path the softeria launcher uses
+ * (`getCredentials("microsoft")`). It mirrors `src/drive/wrapper-broker.ts` +
+ * `src/drive/docs-get.ts` — the working Drive-write precedent.
+ *
+ * Everything here is BEST-EFFORT and fail-soft: the hook must never crash or
+ * wrongly block the write path because Graph was unreachable. Every function
+ * returns `null` (or throws a caught error) on failure, and the hook falls
+ * back to the prior payload-scrape behaviour with a clear "(unresolved)"
+ * marker.
+ */
+
+// ────────────────────────────────────────────────────────────────────────
+// Auth-broker Microsoft access token
+// ────────────────────────────────────────────────────────────────────────
+
+export interface Ms365AccessHandle {
+  /** Bearer token for `Authorization: Bearer <token>`. */
+  access_token: string;
+  /** Unix-ms when this access token expires. */
+  expires_at: number;
+  /**
+   * The authenticated Microsoft account email, as persisted by the broker
+   * from the OAuth identity. This is the "Graph identity" the issue asks the
+   * card to show instead of the unset `SWITCHROOM_MICROSOFT_ACCOUNT` env var.
+   */
+  account_email?: string;
+}
+
+export interface LoadMicrosoftFromAuthBrokerOptions {
+  /** Override the broker socket path (tests pass a tmp socket). */
+  socketPath?: string;
+  /**
+   * If the broker's credentials expire within this many ms, treat them as
+   * unusable and return null (caller degrades gracefully). Default 60_000.
+   */
+  refreshWindowMs?: number;
+  /** Injectable clock for tests. Defaults to Date.now. */
+  now?: () => number;
+}
+
+/**
+ * Pull a Microsoft Graph access token (+ authenticated account email) from the
+ * auth-broker. Mirrors `loadFromAuthBroker` (Google) but for the `microsoft`
+ * provider and the `microsoftOauth` credentials shape.
+ *
+ * Fail-soft: returns `null` when the broker is unreachable, denies access, is
+ * missing credentials, or the token is expired/near-expiry. NEVER throws for
+ * the "can't resolve" cases — the caller must degrade gracefully, not block.
+ */
+export async function loadMicrosoftFromAuthBroker(
+  options: LoadMicrosoftFromAuthBrokerOptions = {},
+): Promise<Ms365AccessHandle | null> {
+  const now = (options.now ?? Date.now)();
+  const refreshWindowMs = options.refreshWindowMs ?? 60_000;
+
+  // Lazy-import so this module (and the bundled hook) only drags the broker
+  // client in when the Graph-resolution path actually runs.
+  const { withAuthBrokerClient, AuthBrokerUnreachableError, AuthBrokerError } =
+    await import("../auth/broker/client.js");
+
+  let result: { account: string; credentials: unknown; expiresAt?: number };
+  try {
+    result = await withAuthBrokerClient(
+      async (client) => {
+        return (await client.getCredentials("microsoft")) as {
+          account: string;
+          credentials: unknown;
+          expiresAt?: number;
+        };
+      },
+      options.socketPath !== undefined ? { socket: options.socketPath } : undefined,
+    );
+  } catch (err) {
+    // Broker unreachable, ACL-denied, or any other broker error → degrade.
+    // We do NOT distinguish here: for card enrichment, "couldn't resolve" is
+    // the only outcome that matters, and it must never block the write.
+    if (
+      err instanceof AuthBrokerUnreachableError ||
+      err instanceof AuthBrokerError
+    ) {
+      return null;
+    }
+    return null;
+  }
+
+  const creds = result.credentials as {
+    microsoftOauth?: {
+      accessToken?: string;
+      expiresAt?: number;
+      accountEmail?: string;
+    };
+  };
+  const accessToken = creds.microsoftOauth?.accessToken;
+  const expiresAt = result.expiresAt ?? creds.microsoftOauth?.expiresAt;
+  if (typeof accessToken !== "string" || accessToken.length === 0) return null;
+  if (typeof expiresAt !== "number") return null;
+  if (expiresAt <= now + refreshWindowMs) return null;
+
+  return {
+    access_token: accessToken,
+    expires_at: expiresAt,
+    account_email: creds.microsoftOauth?.accountEmail,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Microsoft Graph — calendar event context
+// ────────────────────────────────────────────────────────────────────────
+
+export type FetchImpl = (
+  url: string,
+  init: { headers: Record<string, string>; signal?: AbortSignal },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+const GRAPH_BASE = "https://graph.microsoft.com/v1.0";
+const GRAPH_TIMEOUT_MS = 4000;
+
+export interface CalendarEventContext {
+  /** Event subject/title — the human-readable name for the card. */
+  subject?: string;
+  /** ISO 8601 start dateTime (Graph `start.dateTime`). */
+  start?: string;
+  /** ISO 8601 end dateTime (Graph `end.dateTime`). */
+  end?: string;
+  /** Free-text location display name. */
+  location?: string;
+  /** Short text preview of the current body — used for the before→after diff. */
+  bodyPreview?: string;
+}
+
+function defaultFetch(): FetchImpl | null {
+  const f = (globalThis as { fetch?: unknown }).fetch;
+  return typeof f === "function" ? (f as FetchImpl) : null;
+}
+
+async function graphGet(
+  path: string,
+  accessToken: string,
+  fetchImpl?: FetchImpl,
+): Promise<unknown | null> {
+  const doFetch = fetchImpl ?? defaultFetch();
+  if (!doFetch) return null;
+  const controller =
+    typeof AbortController === "function" ? new AbortController() : null;
+  const timer = controller
+    ? setTimeout(() => controller.abort(), GRAPH_TIMEOUT_MS)
+    : null;
+  try {
+    const res = await doFetch(`${GRAPH_BASE}${path}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+      signal: controller?.signal,
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve a calendar event's human-readable context from Graph. Best-effort:
+ * returns `null` on any failure (no token, network error, non-2xx, missing
+ * fetch). NEVER throws.
+ *
+ * `$select` is scoped to the fields the card needs so the request stays cheap
+ * and doesn't pull the full event body.
+ */
+export async function fetchCalendarEventContext(args: {
+  accessToken: string;
+  eventId: string;
+  fetchImpl?: FetchImpl;
+}): Promise<CalendarEventContext | null> {
+  const { accessToken, eventId, fetchImpl } = args;
+  if (!eventId) return null;
+  const path = `/me/events/${encodeURIComponent(
+    eventId,
+  )}?$select=subject,start,end,location,bodyPreview`;
+  const body = (await graphGet(path, accessToken, fetchImpl)) as {
+    subject?: unknown;
+    start?: { dateTime?: unknown };
+    end?: { dateTime?: unknown };
+    location?: { displayName?: unknown };
+    bodyPreview?: unknown;
+  } | null;
+  if (!body || typeof body !== "object") return null;
+
+  const out: CalendarEventContext = {};
+  if (typeof body.subject === "string" && body.subject.length > 0) {
+    out.subject = body.subject;
+  }
+  if (typeof body.start?.dateTime === "string") out.start = body.start.dateTime;
+  if (typeof body.end?.dateTime === "string") out.end = body.end.dateTime;
+  if (
+    typeof body.location?.displayName === "string" &&
+    body.location.displayName.length > 0
+  ) {
+    out.location = body.location.displayName;
+  }
+  if (typeof body.bodyPreview === "string" && body.bodyPreview.length > 0) {
+    out.bodyPreview = body.bodyPreview;
+  }
+  // If Graph returned an event with none of the fields we care about, treat
+  // it as an unresolved miss rather than an empty "success".
+  if (Object.keys(out).length === 0) return null;
+  return out;
+}

--- a/telegram-plugin/gateway/ms365-write-approval.test.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.test.ts
@@ -193,6 +193,35 @@ describe("buildMs365CardText", () => {
     const text = buildMs365CardText(base);
     expect(text).toContain("Weak attestation (RFC §8 v1)");
   });
+
+  // ── #3267 review Finding 2: line-spoofing defence ────────────────────────
+  it("collapses newlines in a Graph-sourced subject so it can't inject fake card lines", () => {
+    const text = buildMs365CardText({
+      ...base,
+      itemDisplayName: "Team sync\nAccount: attacker@x\nWhen: (spoofed)",
+      accountEmail: "real@example.com",
+    });
+    // The whole malicious subject lands on ONE line, prefixed by the real
+    // Item: label — no injected Account:/When: lines.
+    const itemLine = text.split("\n").find((l) => l.startsWith("Item:"));
+    expect(itemLine).toContain("Team sync Account: attacker@x When: (spoofed)");
+    // The genuine account is the only Account: line.
+    const accountLines = text
+      .split("\n")
+      .filter((l) => l.replace(/\s+$/, "").startsWith("Account:"));
+    expect(accountLines).toHaveLength(1);
+    expect(accountLines[0]).toContain("real@example.com");
+  });
+
+  it("collapses newlines/tabs inside change before/after values", () => {
+    const text = buildMs365CardText({
+      ...base,
+      changes: [{ field: "location", before: "Room A", after: "Room B\nAccount: evil" }],
+    });
+    const changeLine = text.split("\n").find((l) => l.includes("location:"));
+    expect(changeLine).toContain("Room B Account: evil");
+    expect(text.split("\n").filter((l) => l.replace(/\s+$/, "").startsWith("Account:"))).toHaveLength(1);
+  });
 });
 
 describe("validateMs365Preview — #3267 diff fields", () => {

--- a/telegram-plugin/gateway/ms365-write-approval.test.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.test.ts
@@ -152,6 +152,78 @@ describe("buildMs365CardText", () => {
     const text = buildMs365CardText({ ...base, itemDisplayName: "x".repeat(500) });
     expect(text).toContain("…");
   });
+
+  // ── #3267 Problem 1: calendar context + structural diff ──────────────────
+  it("renders a resolved event subject + account (not '(unknown)') for a body-only calendar edit", () => {
+    const text = buildMs365CardText({
+      agentName: "clerk",
+      toolName: "mcp__ms-365__update-calendar-event",
+      itemId: "AQMkADAw==",
+      itemDisplayName: "Dentist appointment", // resolved from Graph, not payload
+      accountEmail: "ken@example.com", // from Graph identity, not env
+      eventWhen: "2026-07-20T09:00:00 → 2026-07-20T09:30:00",
+      changes: [{ field: "location", before: "Old Rd", after: "New St" }],
+    });
+    expect(text).toContain("Dentist appointment");
+    expect(text).toContain("ken@example.com");
+    expect(text).not.toContain("(unknown)");
+    expect(text).toContain("When:");
+    expect(text).toContain("Changes:");
+    expect(text).toContain("location: Old Rd → New St");
+  });
+
+  it("shows '(cleared)' when a change removes a field's value", () => {
+    const text = buildMs365CardText({
+      ...base,
+      changes: [{ field: "location", before: "Somewhere" }],
+    });
+    expect(text).toContain("location: Somewhere → (cleared)");
+  });
+
+  it("softens the attestation warning when a structural diff is present", () => {
+    const text = buildMs365CardText({
+      ...base,
+      changes: [{ field: "body", before: "old", after: "new" }],
+    });
+    expect(text).toContain("RFC §8 v1.5");
+    expect(text).not.toContain("Weak attestation");
+  });
+
+  it("keeps the weak-attestation warning when no diff is present", () => {
+    const text = buildMs365CardText(base);
+    expect(text).toContain("Weak attestation (RFC §8 v1)");
+  });
+});
+
+describe("validateMs365Preview — #3267 diff fields", () => {
+  const validPreview = {
+    agentName: "clerk",
+    toolName: "mcp__ms-365__update-calendar-event",
+    itemId: "AQ==",
+    itemDisplayName: "Standup",
+    accountEmail: "ken@example.com",
+  };
+
+  it("carries eventWhen + well-formed changes through", () => {
+    const r = validateMs365Preview({
+      ...validPreview,
+      eventWhen: "a → b",
+      changes: [{ field: "start", before: "9am", after: "10am" }],
+    });
+    expect(r).not.toBeNull();
+    expect(r!.eventWhen).toBe("a → b");
+    expect(r!.changes).toEqual([{ field: "start", before: "9am", after: "10am" }]);
+  });
+
+  it("drops malformed change entries and a non-array changes field", () => {
+    const r = validateMs365Preview({
+      ...validPreview,
+      changes: [{ field: "" }, { after: "x" }, 42, { field: "ok", after: "y" }],
+    });
+    expect(r!.changes).toEqual([{ field: "ok", after: "y" }]);
+    const r2 = validateMs365Preview({ ...validPreview, changes: "nope" });
+    expect(r2!.changes).toBeUndefined();
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────

--- a/telegram-plugin/gateway/ms365-write-approval.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.ts
@@ -251,8 +251,15 @@ export function buildMs365CardText(p: Ms365WritePreview): string {
 }
 
 function truncate(s: string, n: number): string {
-  if (s.length <= n) return s;
-  return s.slice(0, n - 1) + "…";
+  // Collapse control whitespace (newline / carriage-return / tab) to a single
+  // space FIRST — every field on this card is single-line, and this card is a
+  // security decision surface. A Graph-sourced value like an event subject of
+  // `Team sync\nAccount: attacker@x` would otherwise inject a fake-looking
+  // labelled line onto the card (#3267 review Finding 2). Length-truncation
+  // alone does not defend against this.
+  const oneLine = s.replace(/[\r\n\t]+/g, " ");
+  if (oneLine.length <= n) return oneLine;
+  return oneLine.slice(0, n - 1) + "…";
 }
 
 function humanBytes(bytes: number): string {

--- a/telegram-plugin/gateway/ms365-write-approval.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.ts
@@ -57,8 +57,25 @@ export interface Ms365WritePreview {
   /** Byte delta — present only for OneDrive uploads with known sizes. */
   sizeBytesBefore?: number;
   sizeBytesAfter?: number;
+  /**
+   * "start → end" human string for calendar events, resolved from Graph.
+   * Present only when the opaque event id resolved successfully (#3267).
+   */
+  eventWhen?: string;
+  /**
+   * Structural before→after diff for the fields the mutation changes
+   * (calendar body/location/time). Present only when resolved (#3267).
+   */
+  changes?: Ms365PreviewChange[];
   /** 1-line agent rationale — advisory; operator should not over-trust. */
   agentRationale?: string;
+}
+
+/** A single before→after change rendered on the card. */
+export interface Ms365PreviewChange {
+  field: string;
+  before?: string;
+  after?: string;
 }
 
 /**
@@ -84,8 +101,30 @@ export function validateMs365Preview(input: unknown): Ms365WritePreview | null {
   if (typeof o.deepLink === "string") out.deepLink = o.deepLink;
   if (typeof o.sizeBytesBefore === "number") out.sizeBytesBefore = o.sizeBytesBefore;
   if (typeof o.sizeBytesAfter === "number") out.sizeBytesAfter = o.sizeBytesAfter;
+  if (typeof o.eventWhen === "string") out.eventWhen = o.eventWhen;
+  const changes = sanitizeChanges(o.changes);
+  if (changes) out.changes = changes;
   if (typeof o.agentRationale === "string") out.agentRationale = o.agentRationale;
   return out;
+}
+
+/**
+ * Validate the wire `changes` array into typed before→after entries. Drops
+ * malformed entries defensively; returns undefined when nothing usable.
+ */
+function sanitizeChanges(input: unknown): Ms365PreviewChange[] | undefined {
+  if (!Array.isArray(input)) return undefined;
+  const out: Ms365PreviewChange[] = [];
+  for (const raw of input) {
+    if (!raw || typeof raw !== "object") continue;
+    const c = raw as Record<string, unknown>;
+    if (typeof c.field !== "string" || c.field.length === 0) continue;
+    const entry: Ms365PreviewChange = { field: c.field };
+    if (typeof c.before === "string") entry.before = c.before;
+    if (typeof c.after === "string") entry.after = c.after;
+    out.push(entry);
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 // ────────────────────────────────────────────────────────────────────────
@@ -168,6 +207,9 @@ export function buildMs365CardText(p: Ms365WritePreview): string {
     lines.push(`ID:   ${truncate(p.itemId, 96)}`);
   }
   lines.push(`Account: ${truncate(p.accountEmail, 96)}`);
+  if (p.eventWhen) {
+    lines.push(`When: ${truncate(p.eventWhen, 96)}`);
+  }
   if (
     typeof p.sizeBytesBefore === "number" ||
     typeof p.sizeBytesAfter === "number"
@@ -181,13 +223,26 @@ export function buildMs365CardText(p: Ms365WritePreview): string {
   if (p.deepLink) {
     lines.push(`Link: ${truncate(p.deepLink, 256)}`);
   }
+  if (p.changes && p.changes.length > 0) {
+    lines.push("");
+    lines.push("Changes:");
+    for (const c of p.changes.slice(0, 8)) {
+      const before = c.before !== undefined ? truncate(c.before, 96) : "(none)";
+      const after = c.after !== undefined ? truncate(c.after, 96) : "(cleared)";
+      lines.push(`• ${c.field}: ${before} → ${after}`);
+    }
+  }
   if (p.agentRationale) {
     lines.push("");
     lines.push(`💬 ${truncate(p.agentRationale, 512)}`);
   }
   lines.push("");
+  // With a resolved structural diff present the operator is no longer
+  // approving a blind write; soften the attestation warning accordingly.
   lines.push(
-    "⚠️ Weak attestation (RFC §8 v1): operator should click through to verify the actual change before approving. Structural diff coming v1.5.",
+    p.changes && p.changes.length > 0
+      ? "⚠️ Attestation (RFC §8 v1.5): the diff above is derived from live Graph state + the mutation payload. Verify before approving."
+      : "⚠️ Weak attestation (RFC §8 v1): operator should click through to verify the actual change before approving. Structural diff coming v1.5.",
   );
   // hardenCardBreaks: labelled field lines (Agent:/Tool:/Item:/Account:/Size:…)
   // would soft-collapse into one blob under the GFM rich renderer; this card is


### PR DESCRIPTION
Fixes the two defects in the MS-365 write-approval path reported in #3267.

## Problem 1 — card renders `Item: (unknown)` / `Account: (unknown)`, no diff

An `update-calendar-event` that edits only body/location does not resend
`subject`/`title`, so the previous payload-scrape rendered `Item: (unknown)`,
only the raw opaque Graph id, `Account: (unknown)` (from the unset
`SWITCHROOM_MICROSOFT_ACCOUNT` env var), and no diff — the operator approved a
blind write.

**Fix** (`src/ms365/graph-resolve.ts`, wired into `src/cli/ms-365-write-pretool.ts`):
for calendar-event tools, resolve the opaque Graph event id into human-readable
context **before** rendering the card —
- fetch the event `subject` + `start`/`end` via Microsoft Graph
  (`/me/events/{id}?$select=…`), using the auth-broker Microsoft access token
  (`getCredentials("microsoft")`, the same path the softeria launcher uses);
- populate `Account` from the authenticated Graph identity (broker
  `microsoftOauth.accountEmail`), not the env var;
- surface a structural before→after diff of the changed fields (body / location
  / start / end / subject), computed from live Graph state vs the mutation
  payload.

The card now shows a real `Item:`, `Account:`, a `When:` line, and a `Changes:`
block; the attestation warning softens when a diff is present.

All resolution is **best-effort and fail-soft**: broker unreachable / ACL-denied
/ network error / non-2xx / deleted event all degrade to the prior payload
behaviour with a clear `(unresolved)` account marker. It never throws and never
wrongly blocks the write path.

## Problem 2 — grant can lapse mid-batch, partial application

The hook runs as a fresh process per op, so a run of identical writes is really
N independent approvals. When a grant/TTL lapsed between ops, earlier ops had
already mutated Graph and the Nth hard-blocked with a bare `operator expired` —
no coherent stop signal.

**Fix** (`src/ms365/batch-ledger.ts`): a small on-disk ledger shared across the
per-op processes. Each applied write is recorded; when a grant **lapses**
(expired / approver drift) after earlier ops already applied, the batch is
marked aborted and the remaining identical ops are **refused up front** — no
card, no mutation — with a distinct `grant lapsed mid-batch — N MS-365 writes
already applied … STOP: do not retry blindly` signal. Cross-process rollback of
external Graph writes is impossible from a pretool hook, so this converts
"silently keep half-applying + re-prompt" into "abort the rest up front and tell
the agent exactly how many landed".

An explicit **Deny** is a deliberate per-op decision and a **lone lapse with
nothing applied** is just a timeout — neither writes a suppressing entry, so
later unrelated writes are not blocked. The suppression is bounded by a 90s
cooldown and a 10-min retention prune.

## Tests / lint

- 84 scoped tests passing across `src/cli/ms-365-write-pretool.test.ts`,
  `src/ms365/batch-ledger.test.ts`,
  `telegram-plugin/gateway/ms365-write-approval.test.ts` — including: a
  calendar body-only edit now renders a real subject + account (not
  `(unknown)`); the batch is refused up front after a mid-batch lapse; and
  every Graph-failure path degrades without throwing.
- `npm run lint` clean (tsc + all guard scripts).
- Hook re-bundles cleanly (`bun build` → 15 modules, `node --check` OK).

## Assumptions / notes for review

- Account resolution is scoped to **calendar-event** tools (the incident
  surface). Mail/OneDrive writes still show the env-var/`(unknown)` account —
  extending the broker-identity lookup to those is a cheap follow-up but out of
  scope here to keep the change single-concern.
- Problem 2 is a *forward guard*, not a rollback: it cannot un-apply ops that
  already landed (external Graph writes) — it stops the rest of the batch and
  hands the agent an accurate count to reconcile.
- The 90s cooldown / 10-min retention are tunable constants in
  `batch-ledger.ts`.

Closes #3267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)