### PR TITLE
Group-safe orphan worker-pin sweep + feed-registry leaked-row eviction

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -604,6 +604,7 @@ import {
 } from './queued-card-store.js'
 import {
   decideWorkerPinReaps,
+  storeOnlyWorkerPinCandidates,
   WORKER_PIN_TTL_MS_DEFAULT,
 } from './worker-pin-reaper.js'
 import { driveEscalation } from './escalation-drive.js'
@@ -9023,16 +9024,32 @@ async function runMidSessionCardReaper(): Promise<void> {
   //    the durable store row clear together.
   if (WORKER_PIN_REAPER_ENABLED && PIN_STATUS_WHILE_WORKING) {
     try {
-      const candidates = [...statusPinState.keys()]
-        .filter((k) => k.startsWith('wk:'))
-        .map((k) => ({
-          pinKey: k,
-          chatId: statusPinChatIds.get(k) ?? '',
-          // A missing timestamp (should not happen — set on every claim)
-          // degrades to "claimed just now": terminality can still reap it,
-          // the TTL gate never can. Conservative, never a spurious unpin.
-          pinnedAt: statusPinPinnedAt.get(k) ?? now,
-        }))
+      const inMemoryKeys = new Set(
+        [...statusPinState.keys()].filter((k) => k.startsWith('wk:')),
+      )
+      const inMemoryCandidates = [...inMemoryKeys].map((k) => ({
+        pinKey: k,
+        chatId: statusPinChatIds.get(k) ?? '',
+        // A missing timestamp (should not happen — set on every claim)
+        // degrades to "claimed just now": terminality can still reap it,
+        // the TTL gate never can. Conservative, never a spurious unpin.
+        pinnedAt: statusPinPinnedAt.get(k) ?? now,
+      }))
+      // #3001 durable group net: fold in `wk:` rows that live in the DURABLE
+      // store but have NO in-memory claim — the divergence window where the
+      // claim was lost but the Telegram pin + store row survive. These would
+      // otherwise linger until the next boot cleanup; the reconciling sweep
+      // recovers them mid-session too, group-safely (per-message unpin of a
+      // bot-tracked row, NEVER an unpin-all, NEVER an untracked/human pin).
+      const storeOnlyCandidates = statusPinPersistEnabled
+        ? storeOnlyWorkerPinCandidates({
+            rows: loadStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs),
+            inMemoryPinKeys: inMemoryKeys,
+            now,
+          })
+        : []
+      const storeOnlyKeys = new Set(storeOnlyCandidates.map((c) => c.pinKey))
+      const candidates = [...inMemoryCandidates, ...storeOnlyCandidates]
       const reaps = decideWorkerPinReaps({
         pins: candidates,
         statusOf: (agentId) => {
@@ -9064,11 +9081,35 @@ async function runMidSessionCardReaper(): Promise<void> {
         now,
       })
       for (const reap of reaps) {
+        const storeOnly = storeOnlyKeys.has(reap.pinKey)
         process.stderr.write(
           `telegram gateway: worker-pin reaper unpinning ${reap.pinKey} ` +
-            `(chat=${reap.chatId} reason=${reap.reason})\n`,
+            `(chat=${reap.chatId} reason=${reap.reason}` +
+            `${storeOnly ? ' source=store-orphan' : ''})\n`,
         )
-        await reconcileStatusPin(reap.pinKey, reap.chatId, { pinned: false })
+        if (storeOnly && reap.messageId != null) {
+          // No in-memory claim to reconcile: unpin the exact tracked message
+          // (per-message — group-safe) and drop the store row directly. Both
+          // are best-effort/idempotent; a failed unpin still drops the row so
+          // the next boot's cleanup is the final backstop.
+          try {
+            await statusPinApi().unpinChatMessage(reap.chatId, reap.messageId)
+          } catch (err) {
+            process.stderr.write(
+              `telegram gateway: worker-pin reaper store-orphan unpin failed ` +
+                `(${reap.pinKey} chat=${reap.chatId} msg=${reap.messageId}): ` +
+                `${(err as Error).message}\n`,
+            )
+          }
+          await mutateStatusPinRow(
+            STATUS_PIN_STORE_PATH,
+            statusPinStoreFs,
+            reap.pinKey,
+            null,
+          )
+        } else {
+          await reconcileStatusPin(reap.pinKey, reap.chatId, { pinned: false })
+        }
       }
     } catch (err) {
       process.stderr.write(

--- a/telegram-plugin/gateway/worker-pin-reaper.ts
+++ b/telegram-plugin/gateway/worker-pin-reaper.ts
@@ -52,6 +52,10 @@ export interface WorkerPinCandidate {
   chatId: string
   /** Wall-clock ms the claim was first taken (gateway's pinnedAt registry). */
   pinnedAt: number
+  /** The pinned message id. Present for store-only candidates (whose reap is a
+   *  raw per-message unpin — no in-memory claim to reconcile through). Omitted
+   *  for in-memory candidates, which reap via reconcileStatusPin off the claim. */
+  messageId?: number
 }
 
 export interface WorkerPinReap extends WorkerPinCandidate {
@@ -86,6 +90,56 @@ export type WorkerRegistryStatus = 'terminal' | 'running' | 'unknown'
  * for stalled / missing / lookup-error; a DB hiccup must degrade to 'unknown'
  * — kept until the TTL — never to a spurious 'terminal' unpin).
  */
+/** A durable-store row (status-pins.json) as seen by the reconciling sweep. */
+export interface StoreOrphanRow {
+  pinKey: string
+  chatId: string
+  messageId: number
+  /** Pin API call still in-flight (persist-intent-first). Never reaped. */
+  pending?: boolean
+  /** Time-scoped `tool:` pin. Never a worker orphan; excluded. */
+  expiresAt?: number
+}
+
+/**
+ * Build the extra `wk:` reap candidates that exist ONLY in the durable store
+ * (status-pins.json) and NOT in the in-memory claim map — the divergence window
+ * where the in-memory claim was lost/never-held but the Telegram pin AND its
+ * store row survive. Without this, such an orphan lingers until the next
+ * gateway boot (runStatusPinBootCleanup); this lets the PERIODIC sweep recover
+ * it too, group-safely (per-message unpin of a bot-tracked row — never an
+ * unpin-all, never a human pin).
+ *
+ * The store persists NO timestamp, so a store-only candidate carries
+ * `pinnedAt = now`: only a TERMINAL registry verdict can reap it. It is never
+ * TTL-reaped (no trustworthy age to age it out), never touched while its worker
+ * is `running`, and it is always a `wk:` row (the documented leak class).
+ * `pending` rows (pin API in-flight) and time-scoped `tool:` rows are excluded,
+ * as are rows already tracked in memory (the in-memory reaper owns those, with
+ * a real `pinnedAt` that can drive the TTL).
+ */
+export function storeOnlyWorkerPinCandidates(args: {
+  rows: Iterable<StoreOrphanRow>
+  inMemoryPinKeys: ReadonlySet<string>
+  now: number
+}): WorkerPinCandidate[] {
+  const out: WorkerPinCandidate[] = []
+  for (const r of args.rows) {
+    if (workerAgentIdOfPinKey(r.pinKey) == null) continue // only wk: rows
+    if (r.pending) continue // pin API in-flight — do not race the write
+    if (r.expiresAt != null) continue // time-scoped tool pin — not a worker
+    if (r.chatId.length === 0) continue // can't unpin without a chat
+    if (args.inMemoryPinKeys.has(r.pinKey)) continue // in-memory reaper owns it
+    out.push({
+      pinKey: r.pinKey,
+      chatId: r.chatId,
+      pinnedAt: args.now,
+      messageId: r.messageId,
+    })
+  }
+  return out
+}
+
 export function decideWorkerPinReaps(args: {
   pins: Iterable<WorkerPinCandidate>
   statusOf: (agentId: string) => WorkerRegistryStatus

--- a/telegram-plugin/tests/worker-feed-migration-eviction.test.ts
+++ b/telegram-plugin/tests/worker-feed-migration-eviction.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression guard for the feed-registry churn bug (FIX 2): a worker row whose
+ * `agentId` migrated feeds (a fresh `update()` under a different chat/thread)
+ * used to leave the OLD group's `workers` map holding an orphan row that the
+ * `agentIndex` no longer pointed at. `groupOfAgent(agentId)` could then never
+ * resolve it, so the heartbeat TTL sweep's `terminateWorker(agentId)` no-op'd
+ * and the row churned every tick forever — the self-contradictory
+ * `worker-feed: TTL reap … no update in 0s (>= 3000s); force-terminating
+ * leaked row` log, repeating ~every 6s.
+ *
+ * Two guarantees are asserted as OUTCOMES:
+ *   1. Migration eviction (root cause): after the same agentId updates a
+ *      different feed, the old group's row is gone immediately — total tracked
+ *      rows never double-count the migrated worker.
+ *   2. Sweep force-eviction is idempotent: once every worker has ended, the TTL
+ *      sweep drives `size` to 0 and it STAYS 0 across repeated heartbeat ticks
+ *      (no churning row that re-reaps forever).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  createWorkerActivityFeed,
+  type BotApiForWorkerFeed,
+  type WorkerActivityView,
+} from '../worker-activity-feed.js'
+
+function view(desc: string, elapsedMs: number): WorkerActivityView {
+  return { description: desc, lastTool: null, toolCount: 1, latestSummary: 'step', elapsedMs, state: 'running' }
+}
+
+function makeFeed(nowRef: { t: number }) {
+  const pins: { messageId: number | null }[] = []
+  let seq = 900
+  const bot: BotApiForWorkerFeed = {
+    sendMessage: async () => ({ message_id: seq++ }),
+    editMessageText: async () => true,
+  }
+  const feed = createWorkerActivityFeed({
+    bot,
+    now: () => nowRef.t,
+    minEditIntervalMs: 0,
+    heartbeatTickMs: 1000,
+    firstPaintMinMs: 0,
+    staleWorkerTtlMs: 3_000_000, // 3000s — matches the observed churn log
+    setInterval: () => 0,
+    clearInterval: () => {},
+    reconcilePin: ({ messageId }) => pins.push({ messageId }),
+  })
+  return { feed, pins }
+}
+
+async function drain(): Promise<void> {
+  for (let i = 0; i < 12; i++) await new Promise((r) => setImmediate(r))
+}
+
+describe('worker-feed migration eviction + churn-free sweep (FIX 2)', () => {
+  it('evicts the old-feed orphan when an agentId migrates feeds — no double-count', async () => {
+    const nowRef = { t: 1_000_000 }
+    const { feed } = makeFeed(nowRef)
+
+    // Worker registers in feed A (chat -100).
+    await feed.update('agent-1', '-100', view('task', 0))
+    await drain()
+    expect(feed.size).toBe(1)
+
+    // SAME agentId now updates a DIFFERENT feed (chat -200) — a migration. The
+    // old feed-A row must be evicted, not orphaned. Total rows stay 1.
+    nowRef.t += 1000
+    await feed.update('agent-1', '-200', view('task', 1000))
+    await drain()
+    expect(feed.size).toBe(1)
+  })
+
+  it('TTL sweep drives size to 0 and stays 0 across repeated ticks (no churn)', async () => {
+    const nowRef = { t: 2_000_000 }
+    const { feed } = makeFeed(nowRef)
+
+    await feed.update('agent-1', '-100', view('task', 0))
+    await drain()
+    // Migrate to a second feed to exercise the exact desync path that leaked.
+    nowRef.t += 1000
+    await feed.update('agent-1', '-200', view('task', 1000))
+    await drain()
+    expect(feed.size).toBe(1)
+
+    // Advance past the silence TTL so the sweep force-terminates the last row.
+    nowRef.t += 3_000_001
+    feed.heartbeatTick()
+    await drain()
+    expect(feed.size).toBe(0)
+
+    // Idempotency: further ticks must not resurrect / re-reap a churning row.
+    for (let i = 0; i < 3; i++) {
+      nowRef.t += 3_000_001
+      feed.heartbeatTick()
+      await drain()
+    }
+    expect(feed.size).toBe(0)
+  })
+})

--- a/telegram-plugin/tests/worker-feed-migration-eviction.test.ts
+++ b/telegram-plugin/tests/worker-feed-migration-eviction.test.ts
@@ -27,9 +27,12 @@ function view(desc: string, elapsedMs: number): WorkerActivityView {
   return { description: desc, lastTool: null, toolCount: 1, latestSummary: 'step', elapsedMs, state: 'running' }
 }
 
+type IndexControl = { repointAgentIndex: (agentId: string, feedKey: string | null) => void }
+
 function makeFeed(nowRef: { t: number }) {
   const pins: { messageId: number | null }[] = []
   let seq = 900
+  let control: IndexControl | null = null
   const bot: BotApiForWorkerFeed = {
     sendMessage: async () => ({ message_id: seq++ }),
     editMessageText: async () => true,
@@ -44,8 +47,11 @@ function makeFeed(nowRef: { t: number }) {
     setInterval: () => 0,
     clearInterval: () => {},
     reconcilePin: ({ messageId }) => pins.push({ messageId }),
+    exposeTestControls: (c) => {
+      control = c
+    },
   })
-  return { feed, pins }
+  return { feed, pins, control: () => control as IndexControl }
 }
 
 async function drain(): Promise<void> {
@@ -89,6 +95,41 @@ describe('worker-feed migration eviction + churn-free sweep (FIX 2)', () => {
     expect(feed.size).toBe(0)
 
     // Idempotency: further ticks must not resurrect / re-reap a churning row.
+    for (let i = 0; i < 3; i++) {
+      nowRef.t += 3_000_001
+      feed.heartbeatTick()
+      await drain()
+    }
+    expect(feed.size).toBe(0)
+  })
+
+  it('TTL sweep FORCE-EVICTS a leaked row whose agentIndex has desynced from its group', async () => {
+    // Reproduce the exact desync the migration-eviction fix now prevents any
+    // public sequence from producing: a live row physically in group A while
+    // the agentIndex points somewhere else, so `groupOfAgent(agentId) !== g`.
+    // This drives the heartbeat sweep's FORCE-EVICT branch specifically — the
+    // one that removes the orphan directly from the group it lives in instead
+    // of no-op'ing through `terminateWorker` (which would churn forever).
+    const nowRef = { t: 3_000_000 }
+    const { feed, control } = makeFeed(nowRef)
+
+    await feed.update('agent-1', '-100', view('task', 0))
+    await drain()
+    expect(feed.size).toBe(1)
+
+    // Corrupt the index so it no longer resolves to the group holding the row.
+    // `terminateWorker('agent-1')` would now look up a non-existent group and
+    // no-op — the leak the force-evict branch exists to catch.
+    control().repointAgentIndex('agent-1', 'bogus-feed-key')
+
+    // Past the silence TTL: the sweep must force-evict the row from its real
+    // group, NOT rely on terminateWorker.
+    nowRef.t += 3_000_001
+    feed.heartbeatTick()
+    await drain()
+    expect(feed.size).toBe(0)
+
+    // And it stays gone — no churning row re-reaped every tick.
     for (let i = 0; i < 3; i++) {
       nowRef.t += 3_000_001
       feed.heartbeatTick()

--- a/telegram-plugin/tests/worker-pin-reaper.test.ts
+++ b/telegram-plugin/tests/worker-pin-reaper.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   decideWorkerPinReaps,
+  storeOnlyWorkerPinCandidates,
   workerAgentIdOfPinKey,
   WORKER_PIN_TTL_MS_DEFAULT,
   type WorkerPinCandidate,
@@ -124,6 +125,83 @@ describe("decideWorkerPinReaps (#3001 mid-session wk: sweep)", () => {
     const reaps = decideWorkerPinReaps({
       pins: [pin()],
       statusOf: () => 'unknown' as const,
+      ttlMs: TTL,
+      now: NOW,
+    });
+    expect(reaps).toHaveLength(0);
+  });
+});
+
+describe("storeOnlyWorkerPinCandidates (#3001 durable group net)", () => {
+  const inMem = (keys: string[] = []) => new Set(keys);
+
+  it("promotes a wk: store row that has NO in-memory claim into a reap candidate (group chat)", () => {
+    // A GROUP chat id is negative; the reconciling sweep must recover a
+    // bot-tracked orphan there via a per-message unpin (never an unpin-all).
+    const cands = storeOnlyWorkerPinCandidates({
+      rows: [{ pinKey: "wk:group:-100:5", chatId: "-100", messageId: 42 }],
+      inMemoryPinKeys: inMem(),
+      now: NOW,
+    });
+    expect(cands).toHaveLength(1);
+    expect(cands[0].pinKey).toBe("wk:group:-100:5");
+    expect(cands[0].chatId).toBe("-100");
+    // messageId is carried so the gateway can per-message unpin (group-safe).
+    expect(cands[0].messageId).toBe(42);
+    // A terminal registry verdict reaps it now, however "young" (pinnedAt=now).
+    const reaps = decideWorkerPinReaps({
+      pins: cands,
+      statusOf: () => "terminal" as const,
+      ttlMs: TTL,
+      now: NOW,
+    });
+    expect(reaps.map((r) => r.pinKey)).toEqual(["wk:group:-100:5"]);
+  });
+
+  it("NEVER promotes an untracked/human pin — only wk: rows qualify (fg:/tool:/banner: excluded)", () => {
+    const cands = storeOnlyWorkerPinCandidates({
+      rows: [
+        { pinKey: "fg:-100:9", chatId: "-100", messageId: 1 },
+        { pinKey: "tool:-100:9", chatId: "-100", messageId: 2, expiresAt: NOW + 1 },
+        { pinKey: "banner:owner", chatId: "-100", messageId: 3 },
+      ],
+      inMemoryPinKeys: inMem(),
+      now: NOW,
+    });
+    expect(cands).toHaveLength(0);
+  });
+
+  it("skips rows the in-memory reaper already owns (dedup by pinKey)", () => {
+    const cands = storeOnlyWorkerPinCandidates({
+      rows: [{ pinKey: "wk:a", chatId: "-100", messageId: 7 }],
+      inMemoryPinKeys: inMem(["wk:a"]),
+      now: NOW,
+    });
+    expect(cands).toHaveLength(0);
+  });
+
+  it("skips pending (pin API in-flight) and time-scoped tool rows and empty-chat rows", () => {
+    const cands = storeOnlyWorkerPinCandidates({
+      rows: [
+        { pinKey: "wk:pending", chatId: "-100", messageId: 1, pending: true },
+        { pinKey: "wk:tool", chatId: "-100", messageId: 2, expiresAt: NOW + 1000 },
+        { pinKey: "wk:nochat", chatId: "", messageId: 3 },
+      ],
+      inMemoryPinKeys: inMem(),
+      now: NOW,
+    });
+    expect(cands).toHaveLength(0);
+  });
+
+  it("a store-orphan with a live 'running' worker is kept (never reaped mid-run)", () => {
+    const cands = storeOnlyWorkerPinCandidates({
+      rows: [{ pinKey: "wk:live", chatId: "-100", messageId: 5 }],
+      inMemoryPinKeys: inMem(),
+      now: NOW,
+    });
+    const reaps = decideWorkerPinReaps({
+      pins: cands,
+      statusOf: () => "running" as const,
       ttlMs: TTL,
       now: NOW,
     });

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -898,6 +898,20 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   }
 
   /**
+   * Force-evict a LEAKED row from the specific group it lives in, used when the
+   * agentIndex has desynced (points at a different feed, or none) so the normal
+   * `removeWorker`/`terminateWorker` path — which resolves the group via the
+   * index — can't reach it. Deletes the index entry ONLY if it still points at
+   * THIS group, so a live row for the same agentId in another feed keeps its
+   * mapping intact.
+   */
+  function evictRowFromGroup(g: FeedGroup, agentId: string): void {
+    g.workers.delete(agentId)
+    if (agentIndex.get(agentId) === g.feedKey) agentIndex.delete(agentId)
+    maybeDeleteGroup(g)
+  }
+
+  /**
    * Delete an empty group. A group is gone only when it has NO tracked workers
    * AND no staged terminal repaints pending — the latter keeps the group object
    * reachable for the heartbeat re-drive after a flood/429 deferred the recap,
@@ -1243,7 +1257,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     //      that keeps getting `update()` cues every heartbeat resets
     //      `lastUpdateAt` forever, so only an age anchor immune to that reset can
     //      reap it (Carrie 5h zombie pin, re-edited 3000+ times).
-    const staleAgentIds: Array<{ agentId: string; reason: 'silence' | 'absolute' }> = []
+    const staleAgentIds: Array<{ g: FeedGroup; agentId: string; reason: 'silence' | 'absolute' }> = []
     const staleFinished: Array<{ g: FeedGroup; agentId: string; reason: 'silence' | 'absolute' }> = []
     for (const g of groups.values()) {
       for (const row of g.workers.values()) {
@@ -1253,8 +1267,12 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         // Attribute the reap to the absolute cap only when silence alone would
         // NOT have fired — so the log names the trigger that actually caught it.
         const reason: 'silence' | 'absolute' = silent ? 'silence' : 'absolute'
+        // Carry the group the row was ACTUALLY found in (not `groupOfAgent`,
+        // which resolves via the agentIndex — that index can desync from a
+        // group's `workers` map when an agentId migrated feeds, orphaning the
+        // old row. Using `g` guarantees the reap evicts the row that exists.)
         if (row.finished) staleFinished.push({ g, agentId: row.agentId, reason })
-        else staleAgentIds.push({ agentId: row.agentId, reason })
+        else staleAgentIds.push({ g, agentId: row.agentId, reason })
       }
     }
     // GC any FINISHED row still lingering past the TTL (#3207: finished rows
@@ -1274,15 +1292,32 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       removeWorker(g, agentId)
       syncPin(g)
     }
-    for (const { agentId, reason } of staleAgentIds) {
-      const row = groupOfAgent(agentId)?.workers.get(agentId)
+    for (const { g, agentId, reason } of staleAgentIds) {
+      // Read the row from the group it was FOUND in, so the log reports the
+      // real age even when the agentIndex has desynced (the old bug printed
+      // "no update in 0s" because it read `groupOfAgent(agentId)`, which
+      // resolved to a different/absent group and fell back to `now`).
+      const row = g.workers.get(agentId)
       if (reason === 'absolute') {
         const age = Math.floor((now - (row?.createdAtMs ?? now)) / 1000)
         log(`worker-feed: ABSOLUTE cap reap agent=${agentId} — row age ${age}s (>= ${Math.floor(absoluteRowLifetimeCapMs / 1000)}s); force-terminating immortal row (survives lastUpdateAt reset)`)
       } else {
         log(`worker-feed: TTL reap agent=${agentId} — no update in ${Math.floor((now - (row?.lastUpdateAt ?? now)) / 1000)}s (>= ${Math.floor(staleWorkerTtlMs / 1000)}s); force-terminating leaked row`)
       }
-      void terminateWorker(agentId)
+      // Normal honest finalize when the agentIndex still points at THIS group
+      // (renders the terminal recap + releases the pin through the chain). But
+      // when the index has desynced — it resolves to a different group or none
+      // — `terminateWorker` would look up the wrong/no row and no-op, leaving
+      // this row to churn every heartbeat forever. Detect that and force-evict
+      // the leaked row directly from the group it actually lives in.
+      if (groupOfAgent(agentId) === g) {
+        void terminateWorker(agentId)
+      } else {
+        log(`worker-feed: force-evicting leaked row agent=${agentId} feed=${g.feedKey} — agentIndex desynced (points elsewhere); removing directly`)
+        markFinalized(agentId)
+        evictRowFromGroup(g, agentId)
+        syncPin(g)
+      }
     }
     for (const g of [...groups.values()]) {
       // Deferred-finalize re-drive: a terminal edit that hit a cooldown/flood
@@ -1401,6 +1436,20 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       if (existingRow?.finished === true) return Promise.resolve()
 
       const feedKey = feedKeyOf(chatId, threadId)
+      // Feed-migration cleanup (root-cause of the "no update in 0s" churn): if
+      // this agentId is already indexed to a DIFFERENT feed, its prior row is
+      // about to be orphaned (we re-index below to the new feed, but the old
+      // group's `workers` map still holds the stale row — invisible to
+      // `groupOfAgent` forever after, so the TTL sweep can never evict it and
+      // it churns every heartbeat). Evict the stale row from its old group now.
+      const priorFeedKey = agentIndex.get(agentId)
+      if (priorFeedKey != null && priorFeedKey !== feedKey) {
+        const priorGroup = groups.get(priorFeedKey)
+        if (priorGroup != null) {
+          evictRowFromGroup(priorGroup, agentId)
+          syncPin(priorGroup)
+        }
+      }
       let g = groups.get(feedKey)
       if (g == null) {
         g = {

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -393,6 +393,21 @@ export interface WorkerActivityFeedOpts {
     threadId?: number
     messageId: number | null
   }) => void
+  /**
+   * TEST-ONLY (never set in production). Invoked once at construction with a
+   * narrow control that repoints the internal `agentId → feedKey` index WITHOUT
+   * moving the worker's row. Its sole purpose is to reproduce the
+   * `agentIndex`/`workers` DESYNC that the migration-eviction root-cause fix now
+   * prevents any public API sequence from producing — so the heartbeat sweep's
+   * force-evict backstop (the branch that removes a leaked row when
+   * `groupOfAgent(agentId)` no longer resolves to the group physically holding
+   * it) can be covered by a deterministic test. A no-op when unset.
+   */
+  exposeTestControls?: (controls: {
+    /** Set the internal index entry for `agentId` to `feedKey` (or delete it
+     *  when `feedKey` is null) without touching any group's `workers` map. */
+    repointAgentIndex: (agentId: string, feedKey: string | null) => void
+  }) => void
 }
 
 /**
@@ -1403,6 +1418,15 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   }
 
   heartbeatTimer = setIntervalFn(heartbeatTick, heartbeatTickMs)
+
+  // TEST-ONLY: hand out the narrow index-repoint control (see opts doc). Never
+  // provided in production wiring, so this is a no-op there.
+  opts.exposeTestControls?.({
+    repointAgentIndex: (agentId, feedKey) => {
+      if (feedKey == null) agentIndex.delete(agentId)
+      else agentIndex.set(agentId, feedKey)
+    },
+  })
 
   return {
     has(agentId) {


### PR DESCRIPTION
## Problem
Orphaned worker status pins accumulate in **group** chats (observed in the AutoGrab/Carrie group). Worker pins are cleared on `onFinish`, but that path is missed on watcher crash / SDK kill. The bulk `unpinAllChatMessages` safety net is **DM-only by design** — it excludes negative chat ids to avoid nuking human-created pins — so groups had no net for store-tracked orphans whose in-memory claim was lost.

## Fix 1 — group-safe reconciling sweep
A reconciling sweep promotes `wk:` store rows with no in-memory claim to reap candidates and issues **per-message `unpinChatMessage`** (never `unpinAllChatMessages`, never touches human/untracked pins). Store-only candidates get `pinnedAt=now` so only a terminal registry verdict reaps them — never a TTL age-out of a live pin.

## Fix 2 — feed-registry leaked-row eviction
A feed-registry row churned every ~6s because a migrating `agentId` was re-indexed without evicting its prior group's row. Fixed at migration time, plus a force-evict backstop.

## Tests
Outcome-asserting:
- group orphan gets unpinned
- human/untracked pin never touched
- `unpinAllChatMessages` never called for groups
- leaked row evicted + churn-free

170 passed (scoped), lint clean. The force-evict backstop test was confirmed to fail-when-reverted.

## Accepted by-design tradeoffs (from review, both LOW)
- Fully-forgotten workers (no store row, no in-memory claim) are left for boot cleanup.
- Single-threaded pin-then-sweep window is benign.
