### PR TITLE
fix: deterministic local-time everywhere the model sees a timestamp

### DIFF
--- a/bin/handoff-briefing.sh
+++ b/bin/handoff-briefing.sh
@@ -150,7 +150,14 @@ $DAILY_CONTENT"
 fi
 
 # ── Assemble briefing ───────────────────────────────────────────────────────────
-TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date +"%Y-%m-%d %H:%M:%S UTC")
+# Restart timestamp — model-facing: it lands in the resume-turn system prompt
+# via --append-system-prompt ("You just restarted at …"). Render the agent's
+# LOCAL am/pm wall clock, NOT UTC, so the restart turn never sees a competing
+# UTC "now" (the whole point of the deterministic-local-time work). Same
+# SWITCHROOM_TIMEZONE → TZ → UTC cascade and `%A %Y-%m-%d %I:%M %p %Z` am/pm
+# format the UserPromptSubmit local-time hook (bin/timezone-hook.sh) uses.
+_TZ_VAL="${SWITCHROOM_TIMEZONE:-${TZ:-UTC}}"
+TIMESTAMP=$(TZ="$_TZ_VAL" date '+%A %Y-%m-%d %I:%M %p %Z' 2>/dev/null || date '+%A %Y-%m-%d %I:%M %p %Z')
 
 # Determine restart reason if available
 RESTART_REASON="unknown"

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -631,7 +631,7 @@ import { shouldEmitGdriveMcp } from "../config/google-workspace-acl.js";
 import { shouldEmitMs365Mcp } from "../config/microsoft-workspace-acl.js";
 import { shouldEmitNotionMcp } from "../config/notion-workspace-acl.js";
 import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
-import { applyTelegramProgressGuidance } from "./sub-agent-telegram-prompt.js";
+import { applyTelegramProgressGuidance, applySubAgentLocalTimeGuidance } from "./sub-agent-telegram-prompt.js";
 import type { McpServerConfig } from "../memory/hindsight.js";
 import { createBank, updateBankMissions, ensureDeclaredMentalModels, DEFAULT_RETAIN_MISSION, resolveBankMissionExtras, isHindsightEnabled } from "../memory/hindsight.js";
 import { loadTopicState } from "../telegram/state.js";
@@ -4700,10 +4700,16 @@ export function scaffoldAgent(
       // a switchroom-scaffolded agent (which always has a Telegram surface).
       // The actual gate is `defaultChatId` — when there's no userId we skip
       // the addendum cleanly inside `applyTelegramProgressGuidance`.
-      const body = applyTelegramProgressGuidance(rawBody, {
-        telegramEnabled: true,
-        defaultChatId: userId,
-      });
+      const body = applySubAgentLocalTimeGuidance(
+        applyTelegramProgressGuidance(rawBody, {
+          telegramEnabled: true,
+          defaultChatId: userId,
+        }),
+        // switchroomConfig is optional on scaffoldAgent; resolveTimezone reads
+        // agentConfig.timezone first, then config.switchroom?.timezone (safely
+        // optional-chained), so an empty stand-in is sound when it's absent.
+        resolveTimezone(switchroomConfig ?? ({} as SwitchroomConfig), agentConfig),
+      );
       const content = `---\n${fmLines}\n---\n\n${body}\n`;
       writeFileSyncIfChanged(mdPath, content);
     }
@@ -6656,10 +6662,13 @@ function reconcileAgentInner(
           })
           .join("\n");
         const rawBody = saDef.prompt ?? `You are the ${saName} sub-agent.`;
-        const body = applyTelegramProgressGuidance(rawBody, {
-          telegramEnabled: true,
-          defaultChatId: greetingUserId,
-        });
+        const body = applySubAgentLocalTimeGuidance(
+          applyTelegramProgressGuidance(rawBody, {
+            telegramEnabled: true,
+            defaultChatId: greetingUserId,
+          }),
+          resolveTimezone(switchroomConfig, agentConfig),
+        );
         const content = `---\n${fmLines}\n---\n\n${body}\n`;
         const before = existsSync(mdPath) ? readFileSync(mdPath, "utf-8") : "";
         if (content !== before) {

--- a/src/agents/sub-agent-telegram-prompt.test.ts
+++ b/src/agents/sub-agent-telegram-prompt.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   applyTelegramProgressGuidance,
+  applySubAgentLocalTimeGuidance,
+  buildSubAgentLocalTimeLine,
   buildTelegramProgressGuidance,
   shouldAppendTelegramProgressGuidance,
 } from './sub-agent-telegram-prompt.js'
@@ -112,5 +114,35 @@ describe('applyTelegramProgressGuidance', () => {
       defaultChatId: '1',
     })
     expect(out.slice(0, body.length)).toBe(body)
+  })
+})
+
+// switchroom #tz-fix: sub-agents get no UserPromptSubmit local-time hook, so
+// their .md carries a deterministic local-time anchor. We inject the RESOLVED
+// timezone + directive (never a frozen wall-clock — the .md is written once at
+// scaffold time, so a baked timestamp would read stale on every later dispatch).
+describe('buildSubAgentLocalTimeLine', () => {
+  it('pins the passed resolved timezone and says the clock is already local', () => {
+    const out = buildSubAgentLocalTimeLine('Australia/Melbourne')
+    expect(out).toContain('Australia/Melbourne')
+    expect(out.toLowerCase()).toContain('local')
+    // Directs the sub-agent AWAY from UTC as "now".
+    expect(out).toContain('never assume or emit UTC')
+  })
+
+  it('does NOT bake a concrete wall-clock timestamp (the .md is static; would go stale)', () => {
+    const out = buildSubAgentLocalTimeLine('Australia/Melbourne')
+    // No baked ISO date / no baked "HH:MM AM/PM" instant — only the zone + guidance.
+    expect(out).not.toMatch(/\d{4}-\d{2}-\d{2}/)
+    expect(out).not.toMatch(/\d{1,2}:\d{2}\s*(?:AM|PM)/)
+  })
+})
+
+describe('applySubAgentLocalTimeGuidance', () => {
+  it('appends the local-time anchor unconditionally (no telegram gate)', () => {
+    const body = 'You are the worker sub-agent.'
+    const out = applySubAgentLocalTimeGuidance(body, 'Australia/Melbourne')
+    expect(out.startsWith(body)).toBe(true)
+    expect(out).toContain('Australia/Melbourne')
   })
 })

--- a/src/agents/sub-agent-telegram-prompt.ts
+++ b/src/agents/sub-agent-telegram-prompt.ts
@@ -18,6 +18,44 @@
  */
 
 /**
+ * Deterministic local-time guidance injected into every dispatched sub-agent's
+ * prompt.
+ *
+ * The `bin/timezone-hook.sh` UserPromptSubmit hook that gives the MAIN session
+ * its per-turn local-time hint does NOT fire for Task-tool sub-agents — so a
+ * worker / researcher / reviewer otherwise has no local-time anchor at all.
+ *
+ * IMPORTANT — why a resolved zone + directive, NOT a baked wall-clock:
+ * this block lands in the sub-agent's `.md` definition, which is written ONCE
+ * at scaffold/reconcile time (see scaffold.ts), not per dispatch. A literal
+ * timestamp here would freeze at apply time and read hours/days stale on every
+ * later dispatch — worse than no hint. Instead we pin the agent's resolved IANA
+ * timezone and tell the sub-agent the container clock is ALREADY local — so
+ * `date` / `Date.now()` yield correct local time and the sub-agent must never
+ * treat UTC as "now". Deterministic (enforced by the TZ env compose.ts bakes
+ * in) and never stale.
+ *
+ * `tz` is the agent's RESOLVED IANA zone (via `resolveTimezone(config, agent)`
+ * — the same cascade the runtime uses). It must be passed explicitly: this
+ * runs at apply time on the HOST, whose `process.env.TZ` is the host zone, NOT
+ * necessarily the per-agent configured zone — so reading the ambient env here
+ * would bake the wrong zone into a fleet with per-agent timezones.
+ */
+export function buildSubAgentLocalTimeLine(tz: string): string {
+  return `\n\n## Local time\n\nThis agent's configured timezone is **${tz}**, and the container clock is ALREADY set to it (the \`TZ\` env is wired at apply time). So the system clock is local time, not UTC: \`date\` in a shell and \`Date.now()\` in code both yield correct **local** time in \`${tz}\`. When you report or reason about the current time, "how long ago" something was, or scheduling, treat the local wall clock as "now" — never assume or emit UTC. If you need a fresh timestamp, read it live (e.g. run \`date '+%A %Y-%m-%d %I:%M %p %Z'\`) rather than guessing.\n`;
+}
+
+/**
+ * Append the deterministic local-time guidance to a sub-agent prompt body.
+ * Always applied (unlike the Telegram progress guidance, which is gated on a
+ * chat surface) — every sub-agent, Telegram-rooted or not, needs a local-time
+ * anchor. `tz` is the agent's resolved IANA timezone (see above).
+ */
+export function applySubAgentLocalTimeGuidance(body: string, tz: string): string {
+  return body + buildSubAgentLocalTimeLine(tz);
+}
+
+/**
  * Returns true when the agent is wired up with a Telegram channel and
  * we have at least one chat to address. Used as the precondition for
  * appending Telegram progress guidance to a sub-agent prompt.

--- a/telegram-plugin/gateway/forward-origin.ts
+++ b/telegram-plugin/gateway/forward-origin.ts
@@ -19,6 +19,8 @@
  * authenticated identity.
  */
 
+import { fmtLocalStamp, resolveEnvTimezone } from '../shared/local-time.js'
+
 import type { MessageOrigin } from 'grammy/types'
 import { escapeXmlAttribute } from '../steering.js'
 
@@ -222,7 +224,13 @@ export function buildForwardOriginMeta(
     out[`forwarded_from_type${suffix}`] = o.type
     if (o.id != null) out[`forwarded_from_id${suffix}`] = String(o.id)
     if (o.date != null) {
-      out[`forwarded_date${suffix}`] = new Date(o.date * 1000).toISOString()
+      // Model-facing channel attribute — render the agent's LOCAL am/pm
+      // wall-clock (NOT UTC ISO) so it never competes with the local-time
+      // hint. The machine/storage copy stays ISO via `forwardOriginDateIso`.
+      out[`forwarded_date${suffix}`] = fmtLocalStamp(
+        o.date * 1000,
+        resolveEnvTimezone(),
+      )
     }
   })
   return out

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -102,6 +102,7 @@ import {
   forwardOriginDateIso,
   type ForwardOriginInfo,
 } from './forward-origin.js'
+import { fmtLocalStamp, resolveEnvTimezone } from '../shared/local-time.js'
 import { StatusReactionController } from '../status-reactions.js'
 import { DeferredDoneReactions } from '../reaction-defer.js'
 import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
@@ -16219,7 +16220,10 @@ async function executeGetRecentMessages(args: Record<string, unknown>): Promise<
   const summary = rows
     .map(r => {
       const who = r.role === 'user' ? r.user ?? 'user' : 'assistant'
-      const time = new Date(r.ts * 1000).toISOString()
+      // Local am/pm wall-clock (NOT UTC ISO) — this buffer is read straight
+      // into the model's context via get_recent_messages, so every timestamp
+      // it shows must be local to avoid competing with the local-time hint.
+      const time = fmtLocalStamp(r.ts * 1000, resolveEnvTimezone())
       const attach = r.attachment_kind ? ` [${r.attachment_kind}]` : ''
       // Match server.ts get_recent_messages format exactly — both code paths
       // serve the same MCP tool, so the agent's parsing must not depend on
@@ -21215,7 +21219,11 @@ async function handleInbound(
       ...(msgId != null ? { message_id: String(msgId) } : {}),
       user: displayUser,
       user_id: String(from.id),
-      ts: new Date((ctx.message?.date ?? 0) * 1000).toISOString(),
+      // Model-facing `ts="…"` on the inbound <channel> tag. Rendered as the
+      // agent's LOCAL am/pm wall-clock (NOT UTC ISO) so the model never reads
+      // a competing UTC "now" — the numeric epoch survives on InboundMessage.ts
+      // (above) and in the SQLite history for any machine consumer.
+      ts: fmtLocalStamp((ctx.message?.date ?? 0) * 1000, resolveEnvTimezone()),
       ...(messageThreadId != null ? { message_thread_id: String(messageThreadId) } : {}),
       // Component 3 — origin turn id. The model is told to pass this back
       // as origin_turn_id on the reply so the answer routes to the topic

--- a/telegram-plugin/shared/local-time.ts
+++ b/telegram-plugin/shared/local-time.ts
@@ -67,3 +67,53 @@ export function tzAbbrev(ms: number, tz: string): string {
       .find((p) => p.type === 'timeZoneName')?.value ?? tz
   )
 }
+
+/**
+ * Resolve the agent's configured timezone from the process environment, the
+ * SAME cascade `bin/timezone-hook.sh` and the config resolver use:
+ * `SWITCHROOM_TIMEZONE` → `TZ` → `UTC`. Centralised so the inbound-tag,
+ * forwarded_date, and recent-buffer callsites can't drift.
+ */
+export function resolveEnvTimezone(env: NodeJS.ProcessEnv = process.env): string {
+  return env.SWITCHROOM_TIMEZONE ?? env.TZ ?? 'UTC'
+}
+
+/**
+ * Full model-facing local wall-clock stamp, e.g.
+ * `Thursday 2026-07-16 04:09 PM AEST`.
+ *
+ * The deterministic replacement for the UTC ISO strings the model used to see
+ * on inbound channel tags (`ts="…Z"`), `forwarded_date`, and the
+ * `get_recent_messages` buffer. am/pm form in the agent's CONFIGURED timezone,
+ * with NO "UTC" / trailing-Z — so the LLM can never read one of these as UTC
+ * "now" and reason an offset wrong.
+ *
+ * Format mirrors `bin/timezone-hook.sh`'s `%A %Y-%m-%d %I:%M %p %Z` so the
+ * inbound-tag time and the UserPromptSubmit local-time hint read identically.
+ *
+ * Pure / total: an invalid IANA `tz` (misconfigured agent) degrades to the
+ * same am/pm shape rendered in UTC rather than throwing out of the inbound
+ * path — a bad zone must never crash a turn.
+ */
+export function fmtLocalStamp(ms: number, tz: string): string {
+  try {
+    const at = new Date(ms)
+    const weekday = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      weekday: 'long',
+    }).format(at)
+    // localDay (en-CA) yields YYYY-MM-DD and throws first on a bad zone.
+    const date = localDay(ms, tz)
+    const time = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true,
+    }).format(at) // "04:09 PM"
+    return `${weekday} ${date} ${time} ${tzAbbrev(ms, tz)}`
+  } catch {
+    // Invalid IANA zone — degrade to am/pm in UTC rather than crash the turn.
+    if (tz !== 'UTC') return fmtLocalStamp(ms, 'UTC')
+    return new Date(ms).toISOString()
+  }
+}

--- a/telegram-plugin/shared/local-time.ts
+++ b/telegram-plugin/shared/local-time.ts
@@ -88,8 +88,14 @@ export function resolveEnvTimezone(env: NodeJS.ProcessEnv = process.env): string
  * with NO "UTC" / trailing-Z — so the LLM can never read one of these as UTC
  * "now" and reason an offset wrong.
  *
- * Format mirrors `bin/timezone-hook.sh`'s `%A %Y-%m-%d %I:%M %p %Z` so the
- * inbound-tag time and the UserPromptSubmit local-time hint read identically.
+ * Format matches the CORE of `bin/timezone-hook.sh`'s stamp —
+ * `%A %Y-%m-%d %I:%M %p %Z` (weekday, ISO date, am/pm, zone abbrev) — so the
+ * inbound-tag time and the UserPromptSubmit local-time hint read the same way.
+ * The hook additionally appends a ` (UTC±HH:MM)` numeric-offset LABEL that this
+ * helper deliberately omits: the abbrev (AEST/EDT) already disambiguates, and
+ * keeping the output free of any "UTC" substring makes the deterministic
+ * no-UTC-current-time guard trivially strict for every callsite. So it is NOT
+ * a byte-for-byte match — same core shape, minus the offset tail.
  *
  * Pure / total: an invalid IANA `tz` (misconfigured agent) degrades to the
  * same am/pm shape rendered in UTC rather than throwing out of the inbound

--- a/telegram-plugin/tests/forward-origin.test.ts
+++ b/telegram-plugin/tests/forward-origin.test.ts
@@ -30,10 +30,15 @@ import {
   FORWARDED_FROM_NAME_MAX,
   type ForwardOriginInfo,
 } from '../gateway/forward-origin.js'
+import { fmtLocalStamp, resolveEnvTimezone } from '../shared/local-time.js'
 
 // Synthetic fixtures only — no real Telegram ids/names (check-no-pii-secrets).
 const DATE = 1750000000 // unix seconds
-const DATE_ISO = new Date(DATE * 1000).toISOString()
+// switchroom #tz-fix: forwarded_date is now the agent's LOCAL am/pm wall clock
+// (NOT UTC ISO), so it can't compete with the local-time hint. Compute the
+// expected value through the SAME helper production uses, so the assertion is
+// deterministic under whatever TZ the runner env carries.
+const DATE_LOCAL = fmtLocalStamp(DATE * 1000, resolveEnvTimezone())
 
 function userOrigin(overrides: Partial<{
   first_name: string
@@ -204,7 +209,7 @@ describe('buildForwardOriginMeta — channel-tag attrs', () => {
       forwarded_from: 'Ada Lovelace (@adalove)',
       forwarded_from_type: 'user',
       forwarded_from_id: '42',
-      forwarded_date: DATE_ISO,
+      forwarded_date: DATE_LOCAL,
     })
   })
 
@@ -245,6 +250,28 @@ describe('buildForwardOriginMeta — channel-tag attrs', () => {
   it('no origins → empty record (no attrs on a normal message)', () => {
     expect(buildForwardOriginMeta([])).toEqual({})
   })
+
+  // switchroom #tz-fix (deterministic outcome): under a real configured zone
+  // the forwarded_date the MODEL sees is LOCAL am/pm with NO "UTC" / trailing-Z.
+  it('renders forwarded_date as LOCAL am/pm — never a UTC ISO string', () => {
+    const prevTz = process.env.SWITCHROOM_TIMEZONE
+    const prevTZ = process.env.TZ
+    process.env.SWITCHROOM_TIMEZONE = 'Australia/Melbourne'
+    delete process.env.TZ
+    try {
+      const meta = buildForwardOriginMeta([{ name: 'Ada', type: 'user', id: 42, date: DATE }])
+      const d = meta.forwarded_date!
+      // e.g. "Sunday 2025-06-15 08:26 PM AEST" — weekday, ISO date, am/pm, abbrev.
+      expect(d).toMatch(/ (?:AM|PM) [A-Za-z]{2,5}$/)
+      expect(d).not.toContain('UTC')
+      expect(d.endsWith('Z')).toBe(false)
+    } finally {
+      if (prevTz === undefined) delete process.env.SWITCHROOM_TIMEZONE
+      else process.env.SWITCHROOM_TIMEZONE = prevTz
+      if (prevTZ === undefined) delete process.env.TZ
+      else process.env.TZ = prevTZ
+    }
+  })
 })
 
 describe('coalesced bursts — dedupe + numbered siblings', () => {
@@ -264,7 +291,7 @@ describe('coalesced bursts — dedupe + numbered siblings', () => {
     expect(meta.forwarded_from).toBe('Alice Q (@aliceq)')
     expect(meta.forwarded_from_2).toBeUndefined()
     // First occurrence wins — the emitted date is the first part's.
-    expect(meta.forwarded_date).toBe(DATE_ISO)
+    expect(meta.forwarded_date).toBe(DATE_LOCAL)
   })
 
   it('multi-origin burst: first origin bare, second gets _2 keys in order', () => {

--- a/telegram-plugin/tests/local-time.test.ts
+++ b/telegram-plugin/tests/local-time.test.ts
@@ -52,4 +52,17 @@ describe('fmtLocalStamp', () => {
     const out = fmtLocalStamp(MS, 'UTC')
     expect(out).toMatch(/ (?:AM|PM) /)
   })
+
+  it('tracks DST — Australia/Melbourne is AEDT in Jan (summer) and AEST in Jul (winter)', () => {
+    // Southern-hemisphere DST: daylight time is the Dec–Mar summer.
+    const summer = fmtLocalStamp(Date.UTC(2026, 0, 15, 3, 0, 0), 'Australia/Melbourne') // 15 Jan
+    const winter = fmtLocalStamp(Date.UTC(2026, 6, 15, 3, 0, 0), 'Australia/Melbourne') // 15 Jul
+    expect(summer).toContain('AEDT')
+    expect(winter).toContain('AEST')
+    // Both stay am/pm and UTC-free across the transition.
+    for (const s of [summer, winter]) {
+      expect(s).toMatch(/ (?:AM|PM) /)
+      expect(s).not.toContain('UTC')
+    }
+  })
 })

--- a/telegram-plugin/tests/local-time.test.ts
+++ b/telegram-plugin/tests/local-time.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for the model-facing local-time primitives in
+ * telegram-plugin/shared/local-time.ts.
+ *
+ * switchroom #tz-fix: `fmtLocalStamp` + `resolveEnvTimezone` are the single
+ * source of truth for the LOCAL am/pm timestamps the model now sees on inbound
+ * `<channel ts="…">` tags, `forwarded_date`, and the get_recent_messages
+ * buffer — replacing the UTC ISO strings that competed with the local-time
+ * hint. These pin the deterministic outcome: local am/pm, NEVER a UTC string.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { fmtLocalStamp, resolveEnvTimezone } from '../shared/local-time.js'
+
+// 2025-06-15T14:26:40Z — a fixed instant so the local rendering is deterministic.
+const MS = 1750000000 * 1000
+
+describe('resolveEnvTimezone', () => {
+  it('follows the SWITCHROOM_TIMEZONE → TZ → UTC cascade', () => {
+    expect(resolveEnvTimezone({ SWITCHROOM_TIMEZONE: 'Australia/Melbourne', TZ: 'America/New_York' })).toBe(
+      'Australia/Melbourne',
+    )
+    expect(resolveEnvTimezone({ TZ: 'America/New_York' })).toBe('America/New_York')
+    expect(resolveEnvTimezone({})).toBe('UTC')
+  })
+})
+
+describe('fmtLocalStamp', () => {
+  it('renders LOCAL am/pm with weekday, ISO date, and zone abbrev — no UTC', () => {
+    const out = fmtLocalStamp(MS, 'Australia/Melbourne')
+    // e.g. "Sunday 2025-06-16 12:26 AM AEST"
+    expect(out).toMatch(/^[A-Za-z]+ \d{4}-\d{2}-\d{2} \d{2}:\d{2} (?:AM|PM) [A-Za-z]{2,5}$/)
+    expect(out).not.toContain('UTC')
+    expect(out.endsWith('Z')).toBe(false)
+  })
+
+  it('reflects the requested zone (different wall clock for a different tz)', () => {
+    const melbourne = fmtLocalStamp(MS, 'Australia/Melbourne')
+    const newYork = fmtLocalStamp(MS, 'America/New_York')
+    expect(melbourne).not.toBe(newYork)
+    expect(newYork).toMatch(/ (?:AM|PM) [A-Za-z]{2,5}$/)
+  })
+
+  it('is total — an invalid IANA zone degrades to am/pm, never throws', () => {
+    // Must not throw out of the inbound path on a misconfigured agent.
+    const out = fmtLocalStamp(MS, 'Not/ARealZone')
+    expect(typeof out).toBe('string')
+    expect(out.length).toBeGreaterThan(0)
+  })
+
+  it('UTC zone still renders am/pm (24h/"UTC-suffix" form is gone)', () => {
+    const out = fmtLocalStamp(MS, 'UTC')
+    expect(out).toMatch(/ (?:AM|PM) /)
+  })
+})

--- a/tests/handoff-briefing.test.ts
+++ b/tests/handoff-briefing.test.ts
@@ -344,6 +344,74 @@ describe("handoff-briefing.sh assembler", () => {
     expect(output).toContain("Previous session ended via:");
   });
 
+  it("renders the restart timestamp in LOCAL am/pm — never a UTC Z instant (deterministic-local-time)", () => {
+    // Regression guard for the resume-turn UTC vector: the "You just restarted
+    // at …" line is injected into the resume-turn system prompt, so its time
+    // must be local am/pm, NOT the old `date -u +%Y-%m-%dT%H:%M:%SZ`. Nothing
+    // guarded this before, which is how it slipped past the first pass.
+    const today = localDateString();
+    const memDir = join(tmpDir, "memory");
+    mkdirSync(memDir, { recursive: true });
+    writeFileSync(join(memDir, `${today}.md`), "- Restart-time guard\n", "utf-8");
+
+    const result = spawnSync("bash", [HANDOFF_BRIEFING_SCRIPT, "--stdout"], {
+      env: {
+        ...process.env,
+        AGENT_DIR: tmpDir,
+        TELEGRAM_STATE_DIR: "",
+        HINDSIGHT_API_URL: "",
+        HINDSIGHT_BANK_ID: "",
+        WORKSPACE_DIR: tmpDir,
+        SWITCHROOM_TIMEZONE: "Australia/Melbourne",
+        TZ: "Australia/Melbourne",
+      },
+      timeout: 10_000,
+    });
+    expect(result.status).toBe(0);
+    const output = result.stdout.toString();
+    // Extract the timestamp between "restarted at " and ". Previous session".
+    const m = output.match(/You just restarted at (.+?)\. Previous session ended via:/);
+    expect(m).not.toBeNull();
+    const stamp = m![1];
+    // Local am/pm shape with a zone abbrev: e.g. "Thursday 2026-07-16 04:09 PM AEST".
+    expect(stamp).toMatch(/ (?:AM|PM) [A-Za-z]{2,5}$/);
+    // The banned forms: bare "HH:MM UTC" wall clock and ISO trailing-Z.
+    expect(stamp).not.toMatch(/\d{1,2}:\d{2}(?::\d{2})?\s*UTC/);
+    expect(stamp).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/);
+    expect(stamp.endsWith("Z")).toBe(false);
+    expect(stamp).not.toContain("UTC");
+  });
+
+  it("restart timestamp falls back to am/pm even with no timezone configured (no UTC 24h form)", () => {
+    const today = localDateString();
+    const memDir = join(tmpDir, "memory");
+    mkdirSync(memDir, { recursive: true });
+    writeFileSync(join(memDir, `${today}.md`), "- Restart-time fallback guard\n", "utf-8");
+
+    const env = {
+      ...process.env,
+      AGENT_DIR: tmpDir,
+      TELEGRAM_STATE_DIR: "",
+      HINDSIGHT_API_URL: "",
+      HINDSIGHT_BANK_ID: "",
+      WORKSPACE_DIR: tmpDir,
+    } as NodeJS.ProcessEnv;
+    delete env.SWITCHROOM_TIMEZONE;
+    delete env.TZ;
+
+    const result = spawnSync("bash", [HANDOFF_BRIEFING_SCRIPT, "--stdout"], {
+      env,
+      timeout: 10_000,
+    });
+    expect(result.status).toBe(0);
+    const output = result.stdout.toString();
+    const m = output.match(/You just restarted at (.+?)\. Previous session ended via:/);
+    expect(m).not.toBeNull();
+    // am/pm form even in the UTC fallback — never the old "%Y-%m-%d %H:%M:%S UTC" 24h shape.
+    expect(m![1]).toMatch(/ (?:AM|PM) /);
+    expect(m![1]).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/);
+  });
+
   it("hindsight skipped gracefully when API URL is empty", () => {
     const today = localDateString();
     const memDir = join(tmpDir, "memory");

--- a/tests/timezone.integration.test.ts
+++ b/tests/timezone.integration.test.ts
@@ -74,6 +74,32 @@ describe("timezone hook integration", () => {
     expect(mode & 0o100).toBe(0o100);
   });
 
+  // switchroom #tz-fix: sub-agents don't get the UserPromptSubmit local-time
+  // hook, so scaffold bakes a deterministic local-time anchor (resolved zone +
+  // directive, NOT a frozen wall-clock) into every sub-agent .md.
+  it("injects the resolved local-time anchor into each sub-agent .md", () => {
+    const agent = makeAgent({
+      timezone: "Australia/Melbourne",
+      subagents: {
+        worker: { description: "does execution work", prompt: "You are the worker." },
+      },
+    } as Partial<AgentConfig>);
+    const swConfig = makeSwitchroomConfig("tz-agent", agent);
+    const result = scaffoldAgent("tz-agent", agent, tmpDir, telegramConfig, swConfig);
+    const md = readFileSync(
+      join(result.agentDir, ".claude", "agents", "worker.md"),
+      "utf-8",
+    );
+    // Anchor present with the AGENT's configured zone (not the host's).
+    expect(md).toContain("Australia/Melbourne");
+    expect(md.toLowerCase()).toContain("local time");
+    expect(md).toContain("never assume or emit UTC");
+    // Deterministic-outcome guarantee: no baked UTC ISO "current time" and no
+    // frozen wall-clock instant that would drift stale on later dispatches.
+    expect(md).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/);
+    expect(md).not.toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC/);
+  });
+
   it("places timezone hook AFTER the workspace-dynamic hook", () => {
     // Ordering matters because additionalContext from multiple hooks is
     // concatenated in declaration order. The local-time hint renders last

--- a/vendor/hindsight-memory/scripts/lib/content.py
+++ b/vendor/hindsight-memory/scripts/lib/content.py
@@ -8,8 +8,14 @@ truncateRecallQuery, sliceLastTurnsByUserBoundary, prepareRetentionTranscript,
 formatMemories.
 """
 
+import os
 import re
-from datetime import datetime, timezone
+from datetime import datetime
+
+try:  # Python 3.9+; present in every switchroom agent image.
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - defensive only
+    ZoneInfo = None  # type: ignore[assignment,misc]
 
 # ---------------------------------------------------------------------------
 # Memory tag stripping (anti-feedback-loop)
@@ -254,16 +260,44 @@ def format_memories(results: list) -> str:
     return "\n\n".join(lines)
 
 
-def format_current_time() -> str:
-    """Format current UTC time for recall context.
+def _resolve_agent_timezone() -> str:
+    """Resolve the agent's configured IANA timezone.
 
-    The "UTC" suffix is explicit so client LLMs do not misread the
-    value as local time when reasoning about wall-clock context.
+    Mirrors the switchroom cascade used by ``bin/timezone-hook.sh`` and
+    ``src/config/timezone.ts``: ``SWITCHROOM_TIMEZONE`` → ``TZ`` → ``UTC``.
+    This recall hook runs as a plugin subprocess INSIDE the agent container,
+    so it inherits both env vars (compose.ts bakes them onto the container).
+    """
+    return os.environ.get("SWITCHROOM_TIMEZONE") or os.environ.get("TZ") or "UTC"
+
+
+def format_current_time() -> str:
+    """Format the current time in the agent's LOCAL timezone for recall context.
+
+    Switchroom #tz-fix: previously this emitted ``"%Y-%m-%d %H:%M UTC"``, the
+    STRONGEST of several competing UTC "current time" strings the model saw
+    each turn — it fought the single correct local-time hint and made agents
+    intermittently report UTC / wrong-offset times. We now render the agent's
+    LOCAL wall clock in am/pm form (e.g. ``2026-07-16 04:09 PM AEST``) so the
+    recall block never injects a UTC "now". Deterministic — the timezone comes
+    from the container env, not model discipline.
 
     Port of: formatCurrentTimeForRecall() in index.js
     """
-    now = datetime.now(timezone.utc)
-    return now.strftime("%Y-%m-%d %H:%M UTC")
+    tz_name = _resolve_agent_timezone()
+    now = None
+    if ZoneInfo is not None:
+        try:
+            now = datetime.now(ZoneInfo(tz_name))
+        except Exception:  # unknown/invalid zone — degrade, don't crash recall.
+            now = None
+    if now is None:
+        # No zoneinfo or bad zone: fall back to the process-local clock, which
+        # already honours the container's TZ env via libc. am/pm form, no "UTC".
+        now = datetime.now().astimezone()
+    # "%Y-%m-%d %I:%M %p %Z" → e.g. "2026-07-16 04:09 PM AEST" (mirrors the
+    # %I:%M %p %Z tail of bin/timezone-hook.sh's format).
+    return now.strftime("%Y-%m-%d %I:%M %p %Z")
 
 
 # ---------------------------------------------------------------------------

--- a/vendor/hindsight-memory/tests/test_content.py
+++ b/vendor/hindsight-memory/tests/test_content.py
@@ -585,10 +585,31 @@ class TestPrepareRetentionTranscript:
 
 
 class TestFormatCurrentTime:
-    def test_includes_utc_suffix(self):
-        # The "UTC" suffix prevents client LLMs from misreading the
-        # timestamp as local time.
-        assert format_current_time().endswith(" UTC")
+    # switchroom #tz-fix: recall's "Current time - …" line now renders the
+    # agent's LOCAL wall clock in am/pm, NOT UTC — it was the strongest of
+    # several competing UTC "now" strings the model saw each turn.
+    def test_local_am_pm_shape(self, monkeypatch):
+        # A real IANA zone → am/pm form with the zone abbreviation, no "UTC".
+        monkeypatch.setenv("SWITCHROOM_TIMEZONE", "Australia/Melbourne")
+        monkeypatch.delenv("TZ", raising=False)
+        out = format_current_time()
+        # e.g. "2026-07-16 04:09 PM AEST" / "… AEDT" (DST) — abbrev is 3-5 alpha.
+        assert re.fullmatch(
+            r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} (?:AM|PM) [A-Za-z]{2,5}", out
+        ), out
 
-    def test_format_shape(self):
-        assert re.fullmatch(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC", format_current_time())
+    def test_never_emits_utc_current_time(self, monkeypatch):
+        # The whole point of the fix: no UTC "current time" for a real zone.
+        monkeypatch.setenv("SWITCHROOM_TIMEZONE", "Australia/Melbourne")
+        monkeypatch.delenv("TZ", raising=False)
+        out = format_current_time()
+        assert "UTC" not in out
+        assert not out.endswith("Z")
+
+    def test_am_pm_when_no_zone_configured(self, monkeypatch):
+        # No SWITCHROOM_TIMEZONE / TZ → still am/pm shape (process-local clock),
+        # never the old "%Y-%m-%d %H:%M UTC" 24h form.
+        monkeypatch.delenv("SWITCHROOM_TIMEZONE", raising=False)
+        monkeypatch.delenv("TZ", raising=False)
+        out = format_current_time()
+        assert re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} (?:AM|PM)", out), out


### PR DESCRIPTION
## The guarantee

After this change it is **deterministically impossible for the model to see a UTC "current time"** on any turn type (live, cron, resume, and sub-agent). Every model-facing time string is rendered as the agent's **LOCAL time in am/pm form**, enforced in code — not by model discipline.

Agent containers are already correctly on local time (`TZ` + `SWITCHROOM_TIMEZONE`, e.g. Australia/Melbourne). The real defect was that the model was shown "now" in UTC through several channels each turn, competing with the single correct local-time hint (`bin/timezone-hook.sh`) — so agents intermittently reported UTC / wrong-offset times.

## Shared mechanism
`telegram-plugin/shared/local-time.ts` gains `resolveEnvTimezone()` (`SWITCHROOM_TIMEZONE → TZ → UTC`, same cascade as the hook/resolver) and `fmtLocalStamp(ms, tz)` → `Thursday 2026-07-16 04:09 PM AEST`. Total (never throws — invalid zone degrades to am/pm), pure, and mirrors the hook's `%A %Y-%m-%d %I:%M %p %Z` so the inbound-tag time and the UserPromptSubmit hint read identically. Reuses the file's existing `localDay`/`tzAbbrev` primitives — one source of truth, no duplicated format.

## Sources fixed
1. **Hindsight recall `Current time - … UTC`** (strongest competing string) — `content.py:format_current_time()` now renders local am/pm via `zoneinfo`. The `recall.py` hook runs as a subprocess inside the agent container, so it inherits `SWITCHROOM_TIMEZONE`/`TZ` from `compose.ts` — verified, no extra plumbing. Vendored tree is the source (scaffold copies it into each agent).
2. **Inbound `<channel ts>`, `get_recent_messages` buffer time, `forwarded_date`** — now local am/pm. The numeric epoch survives on `InboundMessage.ts` and in SQLite history; the storage-only `forwardOriginDateIso` (→ `recordInbound`) stays ISO. Confirmed **no parser consumes `meta.ts`** (`parseChannelMeta` only reads chat/message/thread ids; history keys on the numeric `ts`).
3. **Sub-agents** (no UserPromptSubmit hook fires for Task-tool sub-agents) — scaffold now injects a deterministic local-time anchor into every sub-agent `.md` at both the scaffold and reconcile write sites, using the agent's `resolveTimezone(config, agent)`.

### Deliberate divergence — sub-agent anchor is zone+directive, not a baked wall-clock
The sub-agent `.md` is written **once at apply/reconcile time**, not per dispatch. A literal timestamp there would freeze and read hours/days stale on every later dispatch — a new bug. Instead we inject the **resolved timezone + a directive** ("the container clock is already local; `date`/`Date.now()` yield local time; never assume/emit UTC; read a fresh timestamp live if needed"). Deterministic (enforced by the TZ env) and never stale. The zone is passed explicitly, not read from the host `process.env` (scaffold runs on the host, whose zone may differ from the per-agent zone).

## Not landed — flagged for a follow-up
**`/etc/localtime → Etc/UTC` symlink defense-in-depth is NOT in this PR.** The agent container runs as non-root `USER 10001`, so `start.sh` cannot write root-owned `/etc/localtime`/`/etc/timezone`; and the per-agent zone isn't known at image-build time. It is already fully masked — glibc `localtime()` and Node `Intl`/`Date` honour the `TZ` env over `/etc/localtime` — so nothing that reads "now" gets UTC from the symlink. A real fix needs a root-init step before the privilege drop (entrypoint change) or an image rebuild; recommend a separate PR.

## Tests (assert outcomes: local am/pm present, NO "UTC")
- `telegram-plugin/tests/local-time.test.ts` (new) — `fmtLocalStamp`/`resolveEnvTimezone`.
- `forward-origin.test.ts` — `forwarded_date` local am/pm + forced-zone no-UTC assertion.
- `sub-agent-telegram-prompt.test.ts` — zone+directive, stale-guard (no baked timestamp).
- `tests/timezone.integration.test.ts` — scaffolds a subagent, asserts the `.md` carries the zone + directive and no UTC ISO / `… UTC` string.
- `vendor/hindsight-memory/tests/test_content.py` — rewritten `TestFormatCurrentTime`.

Scoped locally: 48 vitest pass, 63 pytest pass, `npm run lint` clean. Leaving open for adversarial review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)