### PR TITLE
feat(model): deterministic /model switch — retire inject/scrape, relaunch every switch (rev 5)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1148,18 +1148,19 @@ fi
 
 # --- Session model resolution (consume-once .session-model carrier) ---
 #
-# Contract: reference/rfcs/session-model-stickiness.md §0.1 (rev 4, operator
-# decision 2026-07-12 — SESSION-SCOPED, superseding rev 3 keep-by-default). A
-# `/model` override lasts only for the current session:
+# Contract: reference/rfcs/session-model-stickiness.md §0.05 (rev 5, operator
+# decision 2026-07-16 — DETERMINISTIC SWITCH, superseding rev 4 §0.1's "live
+# Claude switches write no carrier"). A `/model` override lasts only for the
+# current session:
 #
-#   - Claude switches apply LIVE in-session (claude's native picker) and write
-#     NO carrier — the explicit `claude --model {{{modelQ}}}` this script execs
-#     reverts them for free on the next boot.
-#   - sr-* / sr→Claude switches and a queued /model persisted at shutdown need
-#     a relaunch to take effect, so the gateway writes `{{agentDir}}/.session-model`
-#     (one-line JSON) IMMEDIATELY before that relaunch. This block APPLIES the
-#     carrier on the single boot that reads it and then DELETES it (consume-once).
-#     Any SUBSEQUENT restart — deploy, `/restart`, `/new`, watchdog recovery,
+#   - EVERY `/model` switch — Claude→Claude, Claude→sr-*, sr-*→Claude, the
+#     Fable/alias button, and the picker SELECT — writes `{{agentDir}}/.session-model`
+#     (one-line JSON) IMMEDIATELY before the relaunch that applies it. The
+#     inject-into-tmux + terminal-scrape path is RETIRED: it silently no-op'd
+#     then optimistically lied to /status. This block APPLIES the carrier on the
+#     single boot that reads it and then DELETES it (consume-once), and the
+#     `exec claude --model <token>` below cannot silently no-op.
+#   - Any SUBSEQUENT restart — deploy, `/restart`, `/new`, watchdog recovery,
 #     crash, raw `docker restart`, host reboot — finds no carrier and boots the
 #     configured default. That deletion is the marker distinguishing the
 #     model-apply relaunch from every later restart.
@@ -1230,12 +1231,16 @@ if [ -f "{{agentDir}}/.session-model" ]; then
     # announce once.
     echo "session-model: configured default changed ('$_sm_cfg' → '$_EFFECTIVE_MODEL') — dropping session override '$_sm_model'" >&2
     printf 'The configured default model changed (`%s` → `%s`), so your session override to `%s` was not applied — the agent booted on the new configured default. Re-issue /model %s if you still want it.\n' "$_sm_cfg" "$_EFFECTIVE_MODEL" "$_sm_model" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
-  elif [ "${_sm_model#sr-}" != "$_sm_model" ] && [ -z "$_LITELLM_OK" ]; then
-    # sr-* + LiteLLM unreachable at the apply-boot: booting the override would
-    # 4xx against Anthropic, and consume-once means we can't retain it for a
-    # later relaunch. Boot the configured default and tell the operator to
-    # re-issue once the proxy is back.
-    echo "session-model: LiteLLM proxy unreachable at boot — NOT applying sr-* override '$_sm_model'; booting configured default '$_EFFECTIVE_MODEL' (re-issue /model when the proxy is back)" >&2
+  elif { [ "${_sm_model#sr-}" != "$_sm_model" ] || [ "$_sm_model" = fable ] || [ "$_sm_model" = claude-fable-5 ]; } && [ -z "$_LITELLM_OK" ]; then
+    # Proxy-only override + LiteLLM unreachable at the apply-boot: booting the
+    # override would 4xx (sr-* against Anthropic; `fable`/`claude-fable-5` is a
+    # retired codename direct-to-Anthropic and ONLY resolves via the LiteLLM
+    # router — see the repoint case below). Consume-once means we can't retain it
+    # for a later relaunch, so boot the configured default and tell the operator
+    # to re-issue once the proxy is back. (Rev 5: Fable is now reachable via the
+    # carrier relaunch — the old live-inject path never launched it — so it needs
+    # the same down-guard as sr-*.)
+    echo "session-model: LiteLLM proxy unreachable at boot — NOT applying proxy-only override '$_sm_model'; booting configured default '$_EFFECTIVE_MODEL' (re-issue /model when the proxy is back)" >&2
     printf 'LiteLLM proxy was unreachable at boot, so the session model override `%s` was not applied — the agent booted on its configured default `%s`. Re-issue /model %s once the proxy is reachable.\n' "$_sm_model" "$_EFFECTIVE_MODEL" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   else
     # Apply the carrier for THIS session. No boot alert — the gateway already
@@ -1312,11 +1317,24 @@ printf '%s\n' "$_EFFECTIVE_EFFORT" > "{{agentDir}}/.active-session-effort" 2>/de
 # non-Claude default at the router root) and run degraded until litellm returns —
 # there is NO Claude default to fall back to for a persistent sr-* agent, and
 # that (loud-warned, non-fatal) degraded state is the correct behavior.
+#
+# Rev 5 (F2): `fable`/`claude-fable-5` ALSO needs the router root, not the
+# passthrough. The `fable` alias resolves in the CLI to `claude-fable-5`
+# (ANTHROPIC_DEFAULT_FABLE_MODEL above), a RETIRED codename that 4xxs
+# direct-to-Anthropic; it ONLY resolves via the LiteLLM router (maps
+# fable/claude-fable-5 -> anthropic/claude-fable-5, forwarding the OAuth). The
+# old Fable path was a live inject that silently no-op'd, so Fable never actually
+# launched via `--model`; routing the Fable button through the carrier relaunch
+# newly exposes this, so the repoint case must include it or a fable carrier
+# 4xxs even with LiteLLM UP. Verified against the live litellm config + router
+# /v1/models (both `fable` and `claude-fable-5` served). Other Claude sessions
+# (opus/sonnet/haiku/default) keep the passthrough — it dodges the Opus SSE
+# re-chunk stall; Fable trades that for being routable at all.
 case "$_EFFECTIVE_MODEL" in
-  sr-*)
+  sr-*|fable|claude-fable-5)
     if [ -n "$_LITELLM_OK" ] && [ -n "$SWITCHROOM_LITELLM_BASE" ]; then
       export ANTHROPIC_BASE_URL="$SWITCHROOM_LITELLM_BASE"
-      echo "session-model: effective model '$_EFFECTIVE_MODEL' is sr-* — routing via LiteLLM model router '$SWITCHROOM_LITELLM_BASE' (off /anthropic passthrough) so it reaches OpenRouter" >&2
+      echo "session-model: effective model '$_EFFECTIVE_MODEL' is proxy-only (sr-*/fable) — routing via LiteLLM model router '$SWITCHROOM_LITELLM_BASE' (off /anthropic passthrough)" >&2
     fi
     ;;
 esac

--- a/reference/rfcs/session-model-stickiness.md
+++ b/reference/rfcs/session-model-stickiness.md
@@ -8,10 +8,84 @@ status: Accepted — revised per adversarial review + operator decision (default
 
 # RFC — Session-scoped `/model` stickiness
 
-**Status:** Accepted (rev 4 — session-scoped consume-once, #3183; rev 3 keep-by-default and rev 2 revert-by-default are superseded where §0.1 says so)
+**Status:** Accepted (rev 5 — deterministic switch, §0.05, operator decision 2026-07-16; rev 4 session-scoped consume-once §0.1 stands EXCEPT its "live Claude switches write no carrier" bullet, now superseded by §0.05; rev 3 keep-by-default and rev 2 revert-by-default superseded where §0.1 says so)
 **Author:** (agent-authored, operator-directed; semantics decided by the operator 2026-07)
 **Targets:** `origin/main` @ v0.18.7
 **Builds on:** #2982 (in-memory `sessionModelSource` + one-shot `.session-model-override` carrier), #2983 (live model on progress cards), #3178 (durable /model ack/trace/queue)
+
+---
+
+## 0.05 Rev 5 amendment (operator decision 2026-07-16) — DETERMINISTIC switch (reverses §0.1's "live Claude switches write no carrier")
+
+**Decision:** ALL `/model` switches — Claude→Claude, Claude→sr-*, sr-*→Claude,
+the Fable/alias button, and the picker SELECT — go through the consume-once
+`.session-model` carrier relaunch (`scheduleModelRelaunch` /
+`scheduleModelDefaultRelaunch`). The typed-inject-into-tmux + terminal-scrape
+switch path is **RETIRED**. This **supersedes §0.1 bullet 1** ("Live Claude
+switches write NO carrier … apply in-session via claude's native picker").
+Everything else in §0.1 (session-scoped revert on the next restart, consume-once,
+`/effort` unchanged, the invalidation/down-guard branches) still holds.
+
+- **Rationale.** The inject path silently no-op'd — keystrokes were swallowed
+  when the pane was not idle (and, per operator report, on idle panes too) — then
+  **optimistically recorded** the requested model as a success, an unverifiable
+  lie to `/status`. The carrier relaunch is deterministic: start.sh's
+  `exec claude --model <token>` cannot silently no-op, and `.active-session-model`
+  is a real post-boot signal. Success is reported ONLY from that signal (the
+  in-memory override is re-hydrated from `.active-session-model` at boot; the
+  transcript's `message.model` reclaims it on the first assistant line), never
+  from a scraped pane.
+
+- **Trade-off accepted.** A Claude→Claude switch now costs a fresh session
+  (~30s) and loses live in-session scrollback. Acceptable per operator: Hindsight
+  memory + the handoff briefing carry context. No `--continue`/`--resume`.
+
+- **Determinism scope (honest).** `.active-session-model` records the token
+  start.sh wrote *before* `exec claude` (the REQUESTED token), not a post-launch
+  confirmation. If a shape-valid but UNKNOWN Claude id is requested,
+  `--fallback-model` can mask it — claude serves the fallback while
+  `.active-session-model` holds the requested token. This is NOT a persistent
+  lie: the transcript's `message.model` reclaims the source on the first
+  assistant line, correcting `/status` to the model actually serving calls. The
+  pre-first-assistant window is the only optimistic window (bounded,
+  self-healing); it is documented here, not silently asserted as success. The
+  honest-FAILURE surface is scoped to the three modes start.sh's
+  `.session-model-alert` can report (corrupt carrier / configured-default changed
+  / proxy-only + LiteLLM-down); other divergence is corrected by the transcript,
+  not announced.
+
+- **`default` reverts via relaunch.** With inject retired, `/model default`
+  clears the carrier + in-memory override and RELAUNCHES so the live session
+  actually reverts to the configured `model:` (rather than a live no-op clear).
+
+- **Fable via the router (F2).** Routing the Fable BUTTON through the carrier
+  newly exposes that `fable`/`claude-fable-5` needs the LiteLLM **router root**,
+  not the `/anthropic` passthrough: `claude-fable-5` is a retired codename that
+  4xxs direct-to-Anthropic and only resolves via the router
+  (maps `fable`/`claude-fable-5` → `anthropic/claude-fable-5`, forwarding the
+  OAuth). start.sh's passthrough→router repoint `case` and its LiteLLM-down guard
+  are extended from `sr-*` to also cover `fable`/`claude-fable-5`. Verified live
+  against the litellm config + router `/v1/models`. Other Claude sessions
+  (opus/sonnet/haiku/default) keep the passthrough (it dodges the Opus SSE
+  re-chunk stall); Fable trades that for being routable at all.
+
+- **No restart storm.** Unchanged: the 15s `scheduleRestart` debounce (one
+  relaunch per switch; a second `/model` inside the window surfaces "~15s"),
+  consume-once (`rm -f` before apply), and last-write-wins on the carrier.
+
+- **Retired code.** `recordTypedModelSwitch`, `recordModelMenuSideEffects`, the
+  `isSrToClaudeTransition` wiring, the `inject`/`select` model-deps, and the
+  scrape helpers (`modelSwitchConfirmationLine`, `modelSwitchErrorLine`,
+  `isKeptModelConfirmation`, `sessionModelFromConfirmation`,
+  `optimisticModelRecordLabel`, `MODEL_SWITCH_*` regexes) are deleted; the
+  `optimistic` / scrape-derived `selectedModel` reply fields are removed.
+
+- **Copy.** All user-facing strings that claimed Claude switches are
+  instant/in-session are corrected to: *"A `/model` switch relaunches the session
+  (~30s) on the chosen model; session-only, reverts to the configured `model:` on
+  the next restart. Live scrollback is replaced by a fresh session — memory and
+  the handoff briefing carry the context."* §4.5's "applies in-session via
+  claude's native picker" copy is superseded accordingly.
 
 ---
 
@@ -26,11 +100,13 @@ it lives for the current session and any restart drops it back to the
 
 Mechanism — **consume-once carrier** (no intent file):
 
-- **Live Claude switches write NO carrier.** A typed `/model <claude>` or a
-  Claude menu tap applies in-session via claude's native picker; the explicit
-  `claude --model <configured>` flag start.sh always execs reverts it on the
-  next boot for free. `sessionModelSource.setOverride` still records it live so
-  `/status` and progress cards stay truthful for the running session.
+- **Live Claude switches write NO carrier.** _[SUPERSEDED by §0.05 (rev 5).]_
+  This bullet described the retired inject-into-tmux path (a typed `/model
+  <claude>` or Claude menu tap applied in-session via claude's native picker,
+  writing no carrier). Rev 5 routes EVERY switch — including Claude→Claude and
+  the picker/Fable buttons — through the consume-once `.session-model` carrier
+  relaunch, because the inject path silently no-op'd then optimistically lied to
+  `/status`. See §0.05.
 - **Relaunch-requiring switches write a consume-once `.session-model`.** The
   sr-* and sr→Claude paths (`scheduleModelRelaunch` / the menu sr→Claude
   transition) and a queued /model persisted at graceful shutdown write the

--- a/src/agents/model-picker.ts
+++ b/src/agents/model-picker.ts
@@ -8,10 +8,11 @@
  *
  *   discoverModels()  open picker → parse the rendered option rows →
  *                     ALWAYS Esc out (verified) → return the options.
- *   selectModel()     open picker → parse → arrow-key the cursor to the
- *                     target row (matched by label, never by stale
- *                     index) → press `s` (session-only apply) → capture
- *                     claude's confirmation. Esc + bail on any mismatch.
+ *
+ * NB (rev 5): the terminal-DRIVING `selectModel()` / `extractConfirmation()`
+ * were removed — the `/model` switch path no longer drives the picker to APPLY a
+ * switch (every switch is a deterministic carrier relaunch, see
+ * reference/rfcs/session-model-stickiness.md §0.05). Discovery here is RENDER-only.
  *
  * Validated against claude 2.1.170's picker (2026-06-10, test-harness):
  *
@@ -171,10 +172,6 @@ export type DiscoverResult =
       dismissFailed?: true;
     }
   | { ok: false; reason: string; dismissFailed?: true };
-
-export type SelectResult =
-  | { ok: true; confirmation: string }
-  | { ok: false; reason: string };
 
 const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -360,89 +357,3 @@ export async function discoverModels(
   });
 }
 
-/**
- * Select a model by LABEL via the picker, applying session-only (`s`).
- * Re-opens and re-parses the picker fresh — never trusts a previously
- * rendered index. Any mismatch aborts via Escape.
- */
-export async function selectModel(
-  agentName: string,
-  targetLabel: string,
-  opts: PickerOpts = {},
-): Promise<SelectResult> {
-  const io = makeIo(agentName, opts);
-  if (!io.runner.hasSession(io.socket, io.session)) {
-    return { ok: false, reason: "tmux session not found" };
-  }
-
-  // Same per-pane serialization as discoverModels — see that comment.
-  return withPaneLock(`${io.socket}:${io.session}`, async () => {
-    io.startedAt = Date.now(); // budget starts when the lock is held
-    let selected = false;
-    try {
-      const parsed = await openPickerWithRetry(io);
-      if (!parsed || !parsed.footerSeen) {
-        return { ok: false, reason: "picker did not render — agent may be mid-turn" };
-      }
-      const target = parsed.options.find((o) => o.label === targetLabel);
-      if (!target) {
-        const have = parsed.options.map((o) => o.label).join(", ");
-        return { ok: false, reason: `option "${targetLabel}" not offered (have: ${have})` };
-      }
-      if (parsed.cursorIndex < 0) {
-        return { ok: false, reason: "cursor marker not visible — refusing blind navigation" };
-      }
-
-      // Walk the cursor to the target row one keypress at a time,
-      // verifying position after the walk. Option indices are the
-      // picker's own contiguous numbering.
-      const delta = target.index - parsed.cursorIndex;
-      const key = delta > 0 ? "Down" : "Up";
-      for (let i = 0; i < Math.abs(delta); i++) {
-        if (expired(io)) return { ok: false, reason: "timed out navigating picker" };
-        sendKey(io, key);
-        await io.sleep(Math.min(io.stepMs, 250));
-      }
-      await io.sleep(io.stepMs);
-      const verifyPane = io.runner.capture(io.socket, io.session) ?? "";
-      const verify = parseModelPicker(verifyPane);
-      const atRow = verify?.options.find((o) => o.index === verify.cursorIndex);
-      if (!verify || !atRow || atRow.label !== targetLabel) {
-        return {
-          ok: false,
-          reason: `cursor verification failed (on "${atRow?.label ?? "?"}", wanted "${targetLabel}")`,
-        };
-      }
-
-      // `s` = apply for this session only — the keypress dismisses the
-      // modal itself, so no Escape on this path.
-      sendLiteral(io, "s");
-      selected = true;
-      await io.sleep(io.stepMs);
-      const after = io.runner.capture(io.socket, io.session) ?? "";
-      const confirmation = extractConfirmation(after) ?? `Switched to ${targetLabel} (session)`;
-      return { ok: true, confirmation };
-    } catch (err) {
-      return { ok: false, reason: err instanceof Error ? err.message : String(err) };
-    } finally {
-      if (!selected) {
-        // Failure is reported loudly inside dismissOrWarn (gateway log).
-        await dismissOrWarn(io, "select");
-      }
-    }
-  });
-}
-
-/**
- * Pull claude's post-selection confirmation line from the pane tail —
- * e.g. "Set model to Haiku 4.5 for this session" / "Kept model as …".
- * Returns null when no recognizable line is present.
- */
-export function extractConfirmation(pane: string): string | null {
-  const lines = pane.split("\n");
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const t = lines[i].replace(/^\s*⎿\s*/, "").trim();
-    if (/^(Set model to|Kept model as|Switched to)/i.test(t)) return t;
-  }
-  return null;
-}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -474,7 +474,6 @@ import {
   handleModelCommand,
   buildModelMenu,
   handleModelMenuCallback,
-  isSrToClaudeTransition,
   isValidModelArg,
   MODEL_CALLBACK_PREFIX,
   MODEL_CALLBACK_HEADER,
@@ -506,7 +505,7 @@ import {
 import { runTierDowngrade } from './tier-downgrade-wiring.js'
 import { runPremiumRecoveryPing } from './premium-recovery-wiring.js'
 import { decidePremiumRecovery } from '../premium-recovery.js'
-import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
+import { discoverModels } from '../../src/agents/model-picker.js'
 import { resolveMainModel, SWITCHROOM_DEFAULT_THINKING_EFFORT } from '../../src/agents/scaffold.js'
 import {
   parseEffortCommand,
@@ -23324,7 +23323,6 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
         return []
       }
     },
-    select: (a, label) => selectModel(a, label),
     isBusy: () => currentTurn !== null,
     getAgentName: getMyAgentName,
     getQuotaBrief: async () => {
@@ -23343,7 +23341,6 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
       } catch { /* quota is garnish — never block the menu on it */ }
       return null
     },
-    inject: injectSlashCommandImpl,
     getConfiguredModel: () => {
       type AgentListResp = { agents: Array<{ name: string; model?: string | null }> }
       const data = switchroomExecJson<AgentListResp>(['agent', 'list'])
@@ -23437,6 +23434,18 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
           resolveMainModel(deps.getConfiguredModel() ?? undefined),
       )
       sessionModelSource.setOverride(model)
+      // Diagnosability (rev 5): the applied-model is now always greppable at the
+      // relaunch boundary — `grep 'gw /model relaunch scheduled'` — closing the
+      // gap the debug worker flagged (the retired inject path logged nothing).
+      process.stderr.write(
+        `telegram gateway: gw /model relaunch scheduled agent=${getMyAgentName()} token=${model} reason=${JSON.stringify(reason)}\n`,
+      )
+      // A manual /model switch clears any pending premium-recovery marker so the
+      // "available again" ping can't still fire after the operator switched away
+      // themselves. Rev 5: this moves here (from the deleted recordTypedModelSwitch /
+      // recordModelMenuSideEffects) so it fires for EVERY switch path uniformly —
+      // both R5 sites collapse to this single call.
+      clearPremiumRecoveryOnManualSwitch(model)
       try {
         await deps.scheduleRestart(reason)
       } catch (err) {
@@ -23446,6 +23455,36 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
         // "~15s". Any OTHER dispatch failure means no restart is coming, so
         // roll BOTH back — a lingering carrier would lie to /status and be
         // consumed (mis-applied) by an unrelated later boot.
+        if ((err as { code?: string })?.code !== 'restart_in_flight') {
+          restoreSessionModelFileRaw(agentDir, prevFileRaw)
+          sessionModelSource.setOverride(prevOverride)
+        }
+        throw err
+      }
+    },
+    /**
+     * `/model default` (rev 5): CLEAR the consume-once carrier + the in-memory
+     * override, then relaunch so the LIVE session reverts to the configured
+     * default. Mirrors scheduleModelRelaunch's rollback discipline (G1): on a
+     * `restart_in_flight` throw keep the cleared state (the in-flight boot has no
+     * carrier and reverts anyway); on any other dispatch failure restore the
+     * prior carrier + override so a failed default-revert doesn't strand the
+     * session in a half-cleared state.
+     */
+    scheduleModelDefaultRelaunch: async (reason: string) => {
+      const agentDir = resolveAgentDirFromEnv()
+      if (!agentDir) throw new Error('agent dir unresolvable — cannot clear session-model file')
+      const prevOverride = sessionModelSource.getOverride()
+      const prevFileRaw = readSessionModelFileRaw(agentDir)
+      clearSessionModelFile(agentDir)
+      sessionModelSource.setOverride(null)
+      process.stderr.write(
+        `telegram gateway: gw /model relaunch scheduled agent=${getMyAgentName()} token=(default) reason=${JSON.stringify(reason)}\n`,
+      )
+      clearPremiumRecoveryOnManualSwitch(null)
+      try {
+        await deps.scheduleRestart(reason)
+      } catch (err) {
         if ((err as { code?: string })?.code !== 'restart_in_flight') {
           restoreSessionModelFileRaw(agentDir, prevFileRaw)
           sessionModelSource.setOverride(prevOverride)
@@ -23467,125 +23506,14 @@ function modelMenuReplyMarkup(reply: ModelMenuReply): InlineKeyboard | undefined
   return kb
 }
 
-/**
- * Record a POSITIVELY-CONFIRMED typed `/model` switch: set the in-memory
- * override so `/status` reflects the live model. Shared by the live
- * `bot.command('model')` handler and the deferred (queued mid-turn) apply so
- * both record identically. Returns a warning suffix to append to the reply
- * body (currently always empty — kept for a stable signature).
- *
- * Session-scoped (rev 4): a live Claude `/model` switch writes NO
- * `.session-model` carrier — it applies in-session and the explicit
- * `claude --model <configured>` flag reverts it on the next boot, so it lasts
- * exactly until the next restart with no durable state. (sr-* switches never
- * reach here — they go through scheduleModelRelaunch, which owns the
- * consume-once carrier.) The `/status` honesty invariant lives here: only
- * `reply.selectedModel` records; an unverified inject records nothing.
- * `/model default` clears any in-memory override and any leftover carrier.
- */
-function recordTypedModelSwitch(
-  reply: { text: string; selectedModel?: string },
-  requestedModelArg: string | null,
-  _deps: ModelCommandDeps,
-): string {
-  const requested = requestedModelArg != null ? expandSrAlias(requestedModelArg) : null
-  if (requested?.toLowerCase() === 'default') {
-    const smDir = resolveAgentDirFromEnv()
-    if (smDir) clearSessionModelFile(smDir)
-    if (reply.selectedModel) sessionModelSource.setOverride(null)
-    return ''
-  }
-  if (!reply.selectedModel) return ''
-  sessionModelSource.setOverride(reply.selectedModel)
-  // A manual /model apply to the dropped premium clears any pending recovery
-  // marker so the "available again" ping can't still fire after the user has
-  // already switched back themselves.
-  clearPremiumRecoveryOnManualSwitch(reply.selectedModel)
-  return ''
-}
-
-/**
- * Record a model-MENU callback outcome (set the live in-memory override, clear
- * a leftover carrier on a Default tap) and drive an sr-*→Claude graceful
- * restart when the tap crosses that boundary — the only menu path that writes a
- * consume-once `.session-model` carrier (a live Claude tap writes none, rev 4).
- * Extracted from the live `mdl:*` dispatcher so the deferred (queued mid-turn)
- * apply records + restarts identically. Does NOT edit any Telegram message —
- * callers own the card edit. Returns a restart notice when a session restart
- * was scheduled (the card should then drop its keyboard).
- */
-function recordModelMenuSideEffects(
-  outcome: Awaited<ReturnType<typeof handleModelMenuCallback>>,
-  modelDeps: ModelCommandDeps,
-  cbChatId: string,
-  cbThreadId: number | undefined,
-  prevSessionModel: string | null,
-): { restartNotice?: string } {
-  // Record a successful session switch so /status reflects what's actually
-  // running. Session-scoped (rev 4): a live Claude menu tap writes NO
-  // `.session-model` carrier — it applies in-session (native picker) and
-  // reverts on the next boot. Only the sr→Claude transition below (which
-  // relaunches) writes the consume-once carrier. A confirmed "Default
-  // (recommended)" selection clears any leftover carrier.
-  if (outcome.selectedModel) {
-    sessionModelSource.setOverride(outcome.selectedModel)
-    // Clear a pending premium-recovery marker when the tap re-selects the
-    // dropped premium (menu OR the recovery ping's own switch-back button):
-    // no stale "available again" ping once we're back on it. Idempotent — the
-    // ping-send path already consumed the marker, so this is a no-op there.
-    clearPremiumRecoveryOnManualSwitch(outcome.selectedModel)
-  }
-  if (outcome.clearedDefault) {
-    const smDir = resolveAgentDirFromEnv()
-    if (smDir) clearSessionModelFile(smDir)
-  }
-
-  // sr-* → Claude transition: the picker-select only changes the session model
-  // label, but the sr-* LiteLLM routing context persists until the session is
-  // torn down — a graceful restart (same mechanism as /restart) is required.
-  if (outcome.selectedModel && isSrToClaudeTransition(prevSessionModel, outcome.selectedModel)) {
-    const agentName = getMyAgentName()
-    // Carry the requested Claude model across the restart via the SAME
-    // consume-once `.session-model` carrier a Claude → sr-* switch uses —
-    // otherwise this transition's apply-relaunch boots the CONFIGURED default
-    // and the tapped model is silently dropped. Applied on that one boot,
-    // then reverts on the next restart (rev 4).
-    const agentDir = resolveAgentDirFromEnv()
-    const token = outcome.selectedModelToken
-    if (agentDir && token) {
-      try {
-        writeSessionModelFile(
-          agentDir,
-          token,
-          readConfiguredDefaultModel(agentDir) ??
-            resolveMainModel(modelDeps.getConfiguredModel() ?? undefined),
-        )
-        sessionModelSource.setOverride(token)
-      } catch (e) {
-        process.stderr.write(`telegram gateway: sr-to-claude session-model write failed: ${(e as Error)?.message ?? String(e)}\n`)
-      }
-    } else if (agentDir) {
-      // Default-row tap while on sr-*: the restart must land on the configured
-      // default — a stale sticky override would resurrect the old model.
-      clearSessionModelFile(agentDir)
-    }
-    // Write the restart marker so the post-restart boot card edits into this chat.
-    writeRestartMarker({ chat_id: cbChatId, thread_id: cbThreadId ?? null, ack_message_id: null, ts: Date.now() })
-    stampUserRestartReason('user: sr-to-claude model switch (menu)')
-    if (turnInFlightForGate()) {
-      // Defer restart until the in-flight turn completes (same gate as /restart).
-      pendingRestarts.set(agentName, Date.now())
-    } else {
-      void sweepBeforeSelfRestart().finally(() =>
-        triggerSelfRestart(agentName, 'sr-to-claude-model-switch', 1500),
-      )
-    }
-    return {
-      restartNotice: `🔄 Switching from **${escapeHtmlForTg(prevSessionModel!)}** back to Claude — restarting session cleanly. Claude will be ready in ~30s.`,
-    }
-  }
-  return {}
-}
+// Rev 5 (deterministic switch): `recordTypedModelSwitch` and
+// `recordModelMenuSideEffects` are RETIRED. Every switch now routes through
+// `scheduleModelRelaunch` / `scheduleModelDefaultRelaunch` inside the handlers,
+// which own the carrier + in-memory override writes and the premium-recovery
+// clear. The sr-*→Claude special case is gone: because EVERY switch relaunches,
+// the sr-* LiteLLM routing is always torn down cleanly by the boot, so there is
+// no distinct transition to detect. The ACTUAL running model is reconciled at
+// boot from `.active-session-model` (never from a scraped `selectedModel`).
 
 // ─── Mid-turn ack-queue-apply-confirm for /model + /effort (#3017) ──────────
 //
@@ -23644,24 +23572,17 @@ function enqueueSessionCommand(cmd: PendingSessionCommand): void {
 async function applyQueuedModelCommand(cmd: PendingSessionCommand): Promise<string> {
   const deps = buildModelDeps({ chatId: cmd.chatId, threadId: cmd.threadId })
   if (cmd.origin === 'menu') {
-    // Menu SELECT (mdl:s:<tag>) — replay the callback handler (discovery is
-    // idle-safe now) and record via the shared side-effects helper.
-    const prevSessionModel = sessionModelSource.getOverride()
+    // Menu SELECT (mdl:s:<token>) — replay the callback handler, which now
+    // relaunches through the carrier itself (rev 5: no side-effects helper, no
+    // scrape). The relaunch writes its own restart marker so the post-boot card
+    // lands in this chat.
     const outcome = await handleModelMenuCallback(cmd.arg, deps)
-    const { restartNotice } = recordModelMenuSideEffects(
-      outcome,
-      deps,
-      cmd.chatId,
-      cmd.threadId,
-      prevSessionModel,
-    )
-    return restartNotice ?? outcome.reply.text
+    return outcome.reply.text
   }
   // Typed (and alias/sr menu taps converted to typed at enqueue): run the real
-  // handler + shared recording.
+  // handler, which relaunches through the carrier and owns all side effects.
   const reply = await handleModelCommand({ kind: 'set', model: cmd.arg }, deps)
-  const warning = recordTypedModelSwitch(reply, cmd.arg, deps)
-  return reply.text + warning
+  return reply.text
 }
 
 /** Apply a queued typed/menu effort command at idle; return the reply body. */
@@ -23880,17 +23801,12 @@ bot.command('model', async ctx => {
     })
     return
   }
+  // Rev 5: the handler relaunches through the carrier and owns every side effect
+  // (override write, carrier, premium-recovery clear). There is no post-hoc
+  // recording — /status is reconciled at boot from `.active-session-model`, so
+  // an unapplied switch can never be optimistically recorded here.
   const reply = await handleModelCommand(parsed, deps)
-  // Record a POSITIVELY-CONFIRMED typed switch so /status reflects what's
-  // actually running (shared with the deferred/menu paths). The sr-*/relaunch
-  // paths already set the override inside scheduleModelRelaunch; an unverified
-  // switch carries no selectedModel so /status is never lied to.
-  const persistWarning = recordTypedModelSwitch(
-    reply,
-    parsed.kind === 'set' ? parsed.model : null,
-    deps,
-  )
-  await switchroomReply(ctx, reply.text + persistWarning, { html: reply.html })
+  await switchroomReply(ctx, reply.text, { html: reply.html })
 })
 
 // `/effort` — show or switch the reasoning effort for the live session.
@@ -27382,51 +27298,15 @@ bot.on('callback_query:data', async ctx => {
     // rather than the switch-oriented "Switching…".
     const isPageNav = data === MODEL_CALLBACK_PAGE_EXTERNAL || data === MODEL_CALLBACK_PAGE_MAIN
     await ctx.answerCallbackQuery({ text: isPageNav ? 'Loading…' : 'Switching…' }).catch(() => {})
-    // sr-* inject waits for claude to respond (can take 10-30s). Edit the
-    // menu immediately to show a "working on it" state so the operator isn't
-    // left looking at a stale menu with no feedback. The final edit (✅/❌)
-    // replaces this once the inject returns.
-    // NOTE: this await yields the event loop, so a new inbound turn could
-    // start between here and handleModelMenuCallback's inner isBusy() check.
-    // We track whether we applied the interim edit so we can skip the
-    // toastOnly short-circuit if we did — a toastOnly return after the interim
-    // edit would leave the menu stuck button-less.
-    // sr-* TARGET tap: switch TO a non-Claude (LiteLLM/OpenRouter) model.
-    // Parity with the text `/model sr-*` path — claude's native picker rejects
-    // unknown sr-* ids, so an in-place inject can't set them. Carry the token
-    // across a graceful restart (the consume-once `.session-model` carrier) and
-    // relaunch `claude --model sr-*`. Session-only; reverts to the configured
-    // default on the next restart. The sr-* → Claude direction is handled below
-    // via the SELECT/alias outcome + isSrToClaudeTransition.
-    if (data.startsWith(MODEL_CALLBACK_SR)) {
-      const srName = data.slice(MODEL_CALLBACK_SR.length)
-      const srLabel = escapeHtmlForTg(srFriendlyLabel(srName))
-      if (!isValidModelArg(srName)) {
-        await ctx
-          .editMessageText(richMessage('❌ Invalid model name'), { reply_markup: { inline_keyboard: [] } })
-          .catch(() => {})
-        return
-      }
-      await ctx
-        .editMessageText(
-          richMessage(`🔄 Switching session to **${srLabel}** — restarting (~30s). _Session-only; reverts to the configured default on the next restart._`),
-          { reply_markup: { inline_keyboard: [] } },
-        )
-        .catch(() => {})
-      try {
-        await modelDeps.scheduleModelRelaunch(srName, `user: /model ${srName} (session-only relaunch, menu)`)
-      } catch (err) {
-        await ctx
-          .editMessageText(
-            richMessage(`❌ Could not switch to **${srLabel}**: ${escapeHtmlForTg((err as Error)?.message ?? String(err))}`),
-            { reply_markup: { inline_keyboard: [] } },
-          )
-          .catch(() => {})
-      }
-      return
-    }
+    // Rev 5 (deterministic switch): EVERY switch tap — Fable/alias (`mdl:alias:`),
+    // sr-* target (`mdl:sr:`), and picker SELECT (`mdl:s:<token>`) — goes through
+    // the single handler, which relaunches through the consume-once carrier
+    // (`scheduleModelRelaunch` / `scheduleModelDefaultRelaunch`). No inject, no
+    // cursor-nav, no scrape, and no post-hoc `recordModelMenuSideEffects`: the
+    // relaunch owns the override + carrier writes, and `.active-session-model`
+    // reconciles /status at boot. The handler writes its own restart marker so
+    // the post-boot card lands in this chat.
     try {
-      const prevSessionModel = sessionModelSource.getOverride()
       const outcome = await handleModelMenuCallback(data, modelDeps)
       // toastOnly: leave the menu untouched — a mid-turn refusal keeps its
       // buttons so the operator can tap again. (In the enqueue world this
@@ -27434,23 +27314,6 @@ bot.on('callback_query:data', async ctx => {
       // before ever calling the handler — but retained for callers that skip
       // the dispatcher gate.)
       if (outcome.toastOnly) return
-      // Record the switch (persist/clear sticky override) + drive an sr-*→Claude
-      // graceful restart when needed. Shared with the deferred (queued) apply so
-      // both surfaces record identically. Returns a restart notice when a
-      // session restart was scheduled.
-      const { restartNotice } = recordModelMenuSideEffects(
-        outcome,
-        modelDeps,
-        cbChatId,
-        cbThreadId,
-        prevSessionModel,
-      )
-      if (restartNotice) {
-        await ctx
-          .editMessageText(richMessage(restartNotice), { reply_markup: { inline_keyboard: [] } })
-          .catch(() => {})
-        return
-      }
       await ctx
         .editMessageText(richMessage(outcome.reply.text), {
           reply_markup: modelMenuReplyMarkup(outcome.reply) ?? { inline_keyboard: [] },
@@ -30481,6 +30344,13 @@ void (async () => {
           void sweepableIds
         } catch {}
 
+        // Rev 5: capture the restart-marker chat BEFORE the boot-card block
+        // clears it, so the session-model re-hydration block below can send the
+        // switch-confirmation ("✅ Now running X") to the chat that initiated the
+        // switch. Only used when the re-hydration detects a genuine apply-boot
+        // (`launched !== configured`); a non-switch restart leaves it unused.
+        let modelSwitchMarkerChat: { chatId: string; threadId: number | null } | null = null
+
         // Boot card — always post on every gateway start with the restart reason.
         // Gated on session marker so a grammY poll-restart (same process, no
         // actual restart) does NOT re-post.  See session-marker.ts for the
@@ -30542,6 +30412,12 @@ void (async () => {
             const ageMs = nowMs - marker.ts
             const ageSec = Math.max(1, Math.round(ageMs / 1000))
             process.stderr.write(`telegram gateway: boot: restart-marker present, chat_id=${marker.chat_id} age=${ageSec}s within5min=${ageMs < 5 * 60_000}\n`)
+            // Stash the chat for the model-switch confirmation (rev 5) before the
+            // marker is cleared. Bounded to a recent marker (<5min) so a stale
+            // marker can't misdirect a confirmation.
+            if (ageMs < 5 * 60_000) {
+              modelSwitchMarkerChat = { chatId: marker.chat_id, threadId: marker.thread_id }
+            }
             clearRestartMarker()
           }
 
@@ -30684,9 +30560,55 @@ void (async () => {
                   // a phantom session override.
                   return resolveMainModel(raw ?? undefined)
                 })()
-                sessionModelSource.setOverride(
-                  launched.length > 0 && launched !== configured ? launched : null,
+                // `launched !== configured` is the DETERMINISTIC "a model switch
+                // landed" signal (F1): the carrier is consume-once, so a launched
+                // model that differs from the configured default only ever
+                // happens on a genuine apply-boot. Seed the in-memory override
+                // from it — this is the ONLY success reporting, sourced from the
+                // real post-boot signal (`.active-session-model`), never from a
+                // scraped pane or an optimistic record.
+                const isApplyBoot = launched.length > 0 && launched !== configured
+                sessionModelSource.setOverride(isApplyBoot ? launched : null)
+                // Diagnosability (rev 5): the applied model is now always
+                // greppable — `grep 'gw /model relaunch applied'`. F4 note:
+                // `launched` is the REQUESTED token start.sh wrote before `exec
+                // claude` (it is NOT a post-launch confirmation). If a shape-valid
+                // but unknown Claude id was requested, `--fallback-model` may mask
+                // it: claude serves a fallback while this records the requested
+                // token. That divergence is NOT a persistent lie — the transcript's
+                // `message.model` (noteTranscriptModel) reclaims the source from
+                // this override on the first assistant line, correcting /status to
+                // the model actually serving calls. The pre-first-assistant window
+                // is the only optimistic window (G2), and it is bounded and
+                // self-healing; it is documented, not silently asserted as success.
+                process.stderr.write(
+                  `telegram gateway: gw /model relaunch applied agent=${getMyAgentName()} launched=${launched || '(none)'} configured=${configured} override=${isApplyBoot ? 'set' : 'cleared'}\n`,
                 )
+                // Switch-confirmation (F1 / PLAN §4 step 2): on a genuine apply-boot
+                // with a known initiating chat, send ONE confirmation built from the
+                // ACTUAL launched model — never optimistic. G3: this is the only
+                // switch-specific card; the generic boot card is the restart
+                // greeting (it shows configured-model diffs, not a session override),
+                // so the two do not duplicate. Fired only when launched !== configured,
+                // i.e. at most once per switch.
+                if (isApplyBoot && modelSwitchMarkerChat) {
+                  const chat = modelSwitchMarkerChat
+                  // allow-raw-bot-api: one-shot boot confirmation, same shape as the session-model alert relay below
+                  void lockedBot.api
+                    .sendMessage(
+                      chat.chatId,
+                      `✅ Now running \`${launched}\` — session-only, reverts to the configured model on the next restart. Fresh session; memory and the handoff briefing carry the context.`,
+                      {
+                        parse_mode: 'Markdown',
+                        ...(chat.threadId != null ? { message_thread_id: chat.threadId } : {}),
+                      },
+                    )
+                    .catch((err: unknown) =>
+                      process.stderr.write(
+                        `telegram gateway: model-switch confirmation send failed: ${(err as Error)?.message ?? String(err)}\n`,
+                      ),
+                    )
+                }
               } catch { /* leave override as-is on a bad read */ }
             }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -23348,7 +23348,6 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
     },
     escapeHtml: escapeHtmlForTg,
     preBlock,
-    getActiveSessionModel: () => sessionModelSource.getOverride(),
     /**
      * Graceful restart for sr-* → Claude model switch. Same mechanism as
      * the /restart command: writes a restart marker (so the post-restart
@@ -30347,9 +30346,14 @@ void (async () => {
         // Rev 5: capture the restart-marker chat BEFORE the boot-card block
         // clears it, so the session-model re-hydration block below can send the
         // switch-confirmation ("✅ Now running X") to the chat that initiated the
-        // switch. Only used when the re-hydration detects a genuine apply-boot
-        // (`launched !== configured`); a non-switch restart leaves it unused.
+        // switch. A non-`/model` restart leaves these unused.
         let modelSwitchMarkerChat: { chatId: string; threadId: number | null } | null = null
+        // The DETERMINISTIC "this boot was a /model switch" signal: the reason
+        // stampUserRestartReason() wrote to the clean-shutdown marker. Precise
+        // (distinguishes a model-switch relaunch from any other restart) and works
+        // even when launched === configured (a `/model default` / switch-to-default
+        // apply-boot) — that is how N4 (confirm the default case too) is closed.
+        let modelSwitchReason: string | null = null
 
         // Boot card — always post on every gateway start with the restart reason.
         // Gated on session marker so a grammY poll-restart (same process, no
@@ -30414,9 +30418,15 @@ void (async () => {
             process.stderr.write(`telegram gateway: boot: restart-marker present, chat_id=${marker.chat_id} age=${ageSec}s within5min=${ageMs < 5 * 60_000}\n`)
             // Stash the chat for the model-switch confirmation (rev 5) before the
             // marker is cleared. Bounded to a recent marker (<5min) so a stale
-            // marker can't misdirect a confirmation.
+            // marker can't misdirect a confirmation. Pair it with the /model
+            // switch reason (from the clean-shutdown marker) so the confirmation
+            // fires ONLY on a genuine /model relaunch (not a plain /restart that
+            // also wrote a marker chat).
             if (ageMs < 5 * 60_000) {
               modelSwitchMarkerChat = { chatId: marker.chat_id, threadId: marker.thread_id }
+              if (typeof cleanMarker?.reason === 'string' && cleanMarker.reason.startsWith('user: /model')) {
+                modelSwitchReason = cleanMarker.reason
+              }
             }
             clearRestartMarker()
           }
@@ -30454,7 +30464,21 @@ void (async () => {
               })
             }
 
-            if (target) {
+            // N3 (dedup to ONE card per switch): a `/model` apply-boot already
+            // sends the `✅ Now running X` confirmation from the re-hydration block
+            // below (into the same chat). Suppress the generic restart boot card
+            // here so a deliberate switch yields exactly one card — the
+            // confirmation, which carries the operative "here's your model" info.
+            // Only when we KNOW it was a /model switch (reason) AND we will send the
+            // confirmation (marker chat captured); otherwise the boot card fires
+            // normally. Version/quota remain available via /status.
+            const suppressBootCardForModelSwitch =
+              modelSwitchReason != null && modelSwitchMarkerChat != null
+            if (target && suppressBootCardForModelSwitch) {
+              process.stderr.write(
+                `telegram gateway: boot: suppressing generic boot card — /model switch apply-boot (reason=${JSON.stringify(modelSwitchReason)}); the confirmation card replaces it\n`,
+              )
+            } else if (target) {
               const { chatId, threadId, ackMsgId } = target
               // First-write-wins dedupe: if bridge-reconnect already
               // claimed (its IPC client connected before this IIFE
@@ -30584,25 +30608,25 @@ void (async () => {
                 process.stderr.write(
                   `telegram gateway: gw /model relaunch applied agent=${getMyAgentName()} launched=${launched || '(none)'} configured=${configured} override=${isApplyBoot ? 'set' : 'cleared'}\n`,
                 )
-                // Switch-confirmation (F1 / PLAN §4 step 2): on a genuine apply-boot
+                // Switch-confirmation (F1 / PLAN §4 step 2): on a /model apply-boot
                 // with a known initiating chat, send ONE confirmation built from the
-                // ACTUAL launched model — never optimistic. G3: this is the only
-                // switch-specific card; the generic boot card is the restart
-                // greeting (it shows configured-model diffs, not a session override),
-                // so the two do not duplicate. Fired only when launched !== configured,
-                // i.e. at most once per switch.
-                if (isApplyBoot && modelSwitchMarkerChat) {
+                // ACTUAL launched model — never optimistic. Keyed on the DETERMINISTIC
+                // /model switch reason (from the clean-shutdown marker), not on
+                // `launched !== configured`, so it ALSO fires when a switch landed on
+                // the configured default (`/model default`, or `/model <configured>`)
+                // — N4. The generic boot card is suppressed for this boot (N3), so
+                // this is the single card the operator sees for the switch.
+                if (modelSwitchReason != null && modelSwitchMarkerChat) {
                   const chat = modelSwitchMarkerChat
+                  const body = isApplyBoot
+                    ? `✅ Now running \`${launched}\` — session-only, reverts to the configured model on the next restart. Fresh session; memory and the handoff briefing carry the context.`
+                    : `✅ Now running \`${launched || configured}\` (the configured default) — fresh session; memory and the handoff briefing carry the context.`
                   // allow-raw-bot-api: one-shot boot confirmation, same shape as the session-model alert relay below
                   void lockedBot.api
-                    .sendMessage(
-                      chat.chatId,
-                      `✅ Now running \`${launched}\` — session-only, reverts to the configured model on the next restart. Fresh session; memory and the handoff briefing carry the context.`,
-                      {
-                        parse_mode: 'Markdown',
-                        ...(chat.threadId != null ? { message_thread_id: chat.threadId } : {}),
-                      },
-                    )
+                    .sendMessage(chat.chatId, body, {
+                      parse_mode: 'Markdown',
+                      ...(chat.threadId != null ? { message_thread_id: chat.threadId } : {}),
+                    })
                     .catch((err: unknown) =>
                       process.stderr.write(
                         `telegram gateway: model-switch confirmation send failed: ${(err as Error)?.message ?? String(err)}\n`,

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -274,14 +274,6 @@ export interface ModelCommandDeps {
   escapeHtml: (s: string) => string
   preBlock: (s: string) => string
   /**
-   * The active session-model override set by a prior `/model` switch.
-   * Null when no session override is active (using configured/default model).
-   * Used to detect whether the current session is on an sr-* (OpenRouter)
-   * model so a switch back to Claude can trigger a graceful restart instead
-   * of an in-place inject (which would leave stale sr-* routing in place).
-   */
-  getActiveSessionModel: () => string | null
-  /**
    * Schedule a graceful restart of this agent. Called instead of inject
    * when switching from an sr-* model back to Claude — the restart clears
    * the sr-* session context cleanly, whereas an in-place inject would
@@ -653,11 +645,38 @@ export function modelSelectCallbackData(label: string): string {
   // Rev 5: embed the CANONICAL `claude --model` token directly, not a label
   // hash. A tap no longer needs live picker discovery to resolve the row — it
   // goes straight to the carrier relaunch (`mdl:s:<token>`), removing the last
-  // terminal-driving step from the switch path. The "Default (recommended)" row
-  // has no derivable token (`canonicalClaudeToken` → null); it carries the
-  // `default` sentinel so the tap routes to the clear+revert relaunch.
-  const token = canonicalClaudeToken(label) ?? 'default'
-  return `${MODEL_CALLBACK_SELECT}${token}`
+  // terminal-driving step from the switch path.
+  const token = canonicalClaudeToken(label)
+  if (token) return `${MODEL_CALLBACK_SELECT}${token}`
+  // The "Default (recommended)" row has no derivable token (`canonicalClaudeToken`
+  // → null) — it carries the `default` sentinel so the tap routes to the
+  // clear+revert relaunch.
+  if (/^default\b/i.test(label.trim())) return `${MODEL_CALLBACK_SELECT}default`
+  // N2: an UNMAPPED non-default Claude row (a label whose first word is neither a
+  // known alias nor `claude-*`, nor `default`) has no derivable token. Emit an
+  // EMPTY suffix so the tap is REJECTED by the switch-tap gate and re-renders,
+  // rather than collapsing to the `default` sentinel — which would silently
+  // REVERT to the configured default instead of switching to the labelled model.
+  return MODEL_CALLBACK_SELECT
+}
+
+/**
+ * N1: is `token` a switch target we actually recognize? A stale menu rendered by
+ * an OLD gateway carries `mdl:s:<8-hex labelTag>` callback_data, which passes the
+ * loose `MODEL_ARG_RE` shape gate — relaunching onto it would write a garbage
+ * carrier and `--fallback-model` would silently serve a fallback. Constrain
+ * SELECT/alias/sr tokens to a known set before scheduling any relaunch:
+ *   - the `default` sentinel (clear+revert),
+ *   - any sr-* (LiteLLM/OpenRouter) id (accepted raw, never picker-validated),
+ *   - a canonical Claude token (a known alias or a `claude-*` id).
+ * An 8-hex tag, an empty suffix, or any other unmapped string returns false → the
+ * handler re-renders the menu (the old "Model list changed" graceful degrade)
+ * instead of relaunching onto a token claude will silently fall back from.
+ */
+export function isRecognizedSwitchToken(token: string): boolean {
+  if (token.toLowerCase() === 'default') return true
+  if (isSrModel(token)) return true
+  return canonicalClaudeToken(token) !== null
 }
 
 const BUSY_REFUSAL_TEXT =
@@ -982,6 +1001,13 @@ export async function handleModelMenuCallback(
     }
     if (!isValidModelArg(token)) {
       return { answer: 'Invalid model name', reply: await buildModelMenu(deps) }
+    }
+    // N1: reject a token we don't recognize (a stale OLD-gateway `mdl:s:<hex>`
+    // callback, an unmapped SELECT row, or garbage). Relaunching onto it would
+    // write a carrier claude silently falls back from (--fallback-model). Re-render
+    // the fresh menu instead — the graceful degrade the label-tag path used to give.
+    if (!isRecognizedSwitchToken(token)) {
+      return { answer: 'Model list changed — menu refreshed', reply: await buildModelMenu(deps) }
     }
     // Mid-turn: refuse WITHOUT touching the message so the menu keeps its
     // buttons and the operator can tap again once idle. (The gateway dispatcher

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -11,24 +11,26 @@
  * When discovery fails (agent mid-turn, CLI UI changed, kill-switched
  * via SWITCHROOM_MODEL_MENU=0) it falls back to the static v1 text.
  *
- * `/model <alias|full-id>` types claude's own `/model <name>` into the
- * agent's tmux pane via the existing allowlisted inject primitive
- * (`src/agents/inject.ts` — `/model` is already on the allowlist) and
- * relays the captured response. This is the Claude-native mechanism:
- * the unmodified CLI's REPL command, no API, no SDK, no config
- * mutation. The switch is session-scoped — it lasts until the agent
- * restarts; persisting requires `model:` in switchroom.yaml (cascade)
- * and a restart, which the reply spells out.
+ * `/model <alias|full-id>` (and every menu tap) is a DETERMINISTIC carrier
+ * relaunch (rev 5, session-model-stickiness.md §0.05): the requested token is
+ * written to the consume-once `.session-model` carrier and applied by start.sh's
+ * `exec claude --model <token>` on the next boot. The inject-into-tmux +
+ * terminal-scrape path is RETIRED — it silently no-op'd (keystrokes swallowed
+ * on a busy pane) then optimistically recorded success, an unverifiable lie to
+ * `/status`. A relaunch cannot silently no-op, and `.active-session-model` is a
+ * real post-boot signal. Still Claude-native (the unmodified CLI's `--model`
+ * flag, no API/SDK). The switch is session-scoped — it lasts until the next
+ * restart, then reverts to the configured `model:`; persisting requires
+ * `model:` in switchroom.yaml (cascade), which the reply spells out. The cost
+ * is a ~30s fresh session (Hindsight memory + the handoff briefing carry
+ * context); no `--continue`/`--resume`.
  *
  * Split parser/handler shape mirrors `auth-command.ts` so the logic is
  * unit-testable without booting the bot.
  */
 
-import type { InjectResult, InjectOpts } from '../../src/agents/inject.js'
 import {
-  labelTag,
   type DiscoverResult,
-  type SelectResult,
   type ModelPickerOption,
 } from '../../src/agents/model-picker.js'
 
@@ -254,17 +256,6 @@ export function modelCommandReceiptLine(
 
 export interface ModelCommandDeps {
   /**
-   * Inject primitive — wired to injectSlashCommand in the gateway. The optional
-   * third argument forwards the #3241 poll-until-signal opts (successPattern /
-   * errorPattern / settleBeforeSendMs); the set path passes them so the `/model`
-   * confirmation scrape is deterministic instead of racing a fixed window.
-   */
-  inject: (
-    agent: string,
-    command: string,
-    opts?: Pick<InjectOpts, 'successPattern' | 'errorPattern' | 'settleBeforeSendMs'>,
-  ) => Promise<InjectResult>
-  /**
    * True while the agent is mid-turn. A typed `/model <name>` switch drives
    * claude's session (either an inject into the input box, or a carrier-backed
    * restart) — doing either mid-turn is unsafe: an inject queues `/model` as
@@ -308,38 +299,44 @@ export interface ModelCommandDeps {
    * on the following restart. Wired to the same restart dispatch as
    * `scheduleRestart`, plus the carrier write. `model` is the full `sr-*` id
    * (already alias-expanded); `reason` is stamped as the restart reason.
+   *
+   * Rev 5 (deterministic switch): EVERY `/model` switch — Claude→Claude,
+   * Claude→sr-*, sr-*→Claude, the Fable/alias button, and the picker SELECT —
+   * routes through here. The inject-into-tmux + terminal-scrape path is retired,
+   * so a switch can no longer silently no-op or optimistically lie to /status:
+   * start.sh's `exec claude --model <token>` cannot silently no-op, and the
+   * post-boot `.active-session-model` signal is what /status reflects.
    */
   scheduleModelRelaunch: (model: string, reason: string) => Promise<void>
+  /**
+   * Revert TO the configured default (`/model default`) via a relaunch. Clears
+   * the consume-once `.session-model` carrier + the in-memory override, then
+   * relaunches so the LIVE session actually reverts to `switchroom.yaml model:`
+   * (rev 5: with inject retired, a relaunch is the only way to make `default`
+   * take effect live — consistent with "all switches relaunch"). Mirrors
+   * scheduleModelRelaunch's careful rollback: a `restart_in_flight` throw keeps
+   * the cleared state (the in-flight boot reverts anyway); any other dispatch
+   * failure restores the prior carrier + override.
+   */
+  scheduleModelDefaultRelaunch: (reason: string) => Promise<void>
 }
 
 export interface ModelCommandReply {
   text: string
   html: true
   /**
-   * On a POSITIVELY-CONFIRMED typed switch, the model now running this session
-   * (parsed from claude's confirmation, falling back to the requested token).
-   * The gateway records this as the session-model override so `/status` reflects
-   * what's actually running — the SAME code path the menu callback uses via
-   * `ModelCallbackOutcome.selectedModel`. Absent on every unverified / non-switch
-   * outcome (silent capture, error, busy refusal) so an unconfirmed switch never
-   * lies to `/status`.
+   * Rev 5: a `/model` switch NEVER carries a live-model field. The inject +
+   * terminal-scrape path that produced an optimistic `selectedModel` is retired.
+   * Every switch relaunches through `scheduleModelRelaunch`, which owns the
+   * in-memory override write for the restart window; the ACTUAL running model is
+   * reconciled at boot from `.active-session-model` (and by the transcript's
+   * `message.model`), never optimistically asserted from a scraped pane. So
+   * there is no `selectedModel`/`optimistic` here to lie to /status with.
    */
-  selectedModel?: string
-  /**
-   * True when `selectedModel` was recorded OPTIMISTICALLY (#3241 part B): the
-   * inject SEND succeeded and NO explicit error line was scraped, but claude's
-   * confirmation line was not read either. Poll-until-signal already waited the
-   * full window, so a missing line means a silent switch (or a confirmation
-   * that scrolled off) — NOT a failure — and we record the requested model so
-   * `/status` is right. The switch is retracted (no `selectedModel`) only when
-   * an error line IS scraped. Purely a wording hint; the gateway records
-   * `selectedModel` the same way whether confirmed or optimistic.
-   */
-  optimistic?: boolean
 }
 
 const PERSIST_NOTE =
-  '_Session-only — this override lasts until the agent’s next restart, then reverts to the configured \`model:\`. \`/model default\` clears it now. To change the default permanently, set \`model:\` in switchroom.yaml._'
+  '_A `/model` switch relaunches the session (~30s) on the chosen model. Session-only — reverts to the configured \`model:\` on the next restart. \`/model default\` reverts now. Live scrollback is replaced by a fresh session; memory and the handoff briefing carry the context. To change the default permanently, set \`model:\` in switchroom.yaml._'
 
 function helpText(deps: ModelCommandDeps, reason?: string): ModelCommandReply {
   const srAliasExamples = Object.keys(SR_MODEL_ALIASES).map(a => `\`${a}\``).join(' · ')
@@ -350,7 +347,7 @@ function helpText(deps: ModelCommandDeps, reason?: string): ModelCommandReply {
     '\`/model\` — show the configured model',
     `\`/model <name>\` — switch the live session (${MODEL_ALIASES.map(a => `\`${a}\``).join(' · ')} or a full model id)`,
     `_OpenRouter shortcuts:_ ${srAliasExamples}`,
-    '_OpenRouter (sr-\\*) switches restart the session (~30s); Claude switches apply instantly._',
+    '_Every switch relaunches the session (~30s) on the chosen model — Claude and OpenRouter (sr-\\*) alike._',
     PERSIST_NOTE,
   )
   return { text: lines.join('\n'), html: true }
@@ -388,10 +385,10 @@ export async function handleModelCommand(
   // Expand short aliases: `flash` → `sr-gemini-2.5-flash`, `codex` → `sr-codex-5.5`, etc.
   const model = expandSrAlias(parsed.model)
 
-  // Busy gate: a typed switch either injects into claude's input box or triggers
-  // a carrier-backed restart. Both are unsafe mid-turn — an inject queues the
-  // `/model` text instead of switching, and a restart kills the live turn. Refuse
-  // and ask the operator to retry (parity with the menu callback's isBusy check).
+  // Busy gate: a switch RELAUNCHES the session, which is unsafe mid-turn (it
+  // would tear down the live turn). The gateway's mid-turn path ACKs + queues +
+  // applies-on-idle before this handler is reached; this is the belt-and-braces
+  // seam for a caller that skipped it.
   if (deps.isBusy()) {
     return {
       text: '⏳ The agent is mid-turn — a model switch needs an idle session. The switch was not applied.',
@@ -399,182 +396,71 @@ export async function handleModelCommand(
     }
   }
 
-  // sr-* → Claude: an in-place `/model` inject would leave LiteLLM routing
-  // active in the live session because the sr-* model context was set by
-  // the proxy at session start, not by claude's own REPL. A graceful restart
-  // is the only clean path back to the native OAuth route. Route it through the
-  // SAME carrier mechanism as a Claude → sr-* switch (scheduleModelRelaunch)
-  // so the requested Claude model is written to the durable `.session-model` and
-  // survives the restart — otherwise boot launches the configured default and
-  // the operator's choice is silently dropped. start.sh's LiteLLM-down guard
-  // only special-cases `sr-*` overrides, so a Claude token is never dropped.
-  const currentSession = deps.getActiveSessionModel()
-  if (currentSession !== null && isSrModel(currentSession) && isClaudeModel(model)) {
-    try {
-      await deps.scheduleModelRelaunch(model, `user: /model ${model} (sr-to-claude restart)`)
-    } catch (err) {
-      if (isRestartInFlight(err)) {
-        return {
-          text: `⏳ A restart is already in flight — your switch to \`${deps.escapeHtml(model)}\` will apply as it completes (~15s).`,
-          html: true,
-        }
-      }
-      const msg = err instanceof Error ? err.message : String(err)
-      return {
-        text: `❌ Could not schedule restart: ${deps.escapeHtml(msg)}`,
-        html: true,
-      }
-    }
+  // Rev 5 (deterministic switch): route EVERY target through the consume-once
+  // `.session-model` carrier relaunch. `default` clears the carrier + override
+  // and relaunches so the live session reverts to the configured `model:`; any
+  // other token — Claude alias/id, sr-*, Fable — is carried and applied by
+  // start.sh's `exec claude --model <token>`. The inject-into-tmux +
+  // terminal-scrape path is RETIRED: a switch can no longer silently no-op or
+  // optimistically lie to /status (start.sh cannot silently no-op, and the
+  // post-boot `.active-session-model` signal is the source of truth).
+  if (model.toLowerCase() === 'default') {
+    return scheduleDefaultRelaunchReply(deps, 'user: /model default (revert relaunch)')
+  }
+  return scheduleRelaunchReply(deps, model, `user: /model ${model} (session-only relaunch)`)
+}
+
+/** The one-line ack shown while a switch relaunches (~30s). */
+function switchingLine(deps: Pick<ModelCommandDeps, 'escapeHtml'>, model: string): string {
+  const friendly = isSrModel(model) ? srFriendlyLabel(model) : model
+  return `🔄 Switching to \`${deps.escapeHtml(friendly)}\` — relaunching the session (~30s).`
+}
+
+/** Map a relaunch-dispatch error to an honest reply (debounce vs failure). */
+function relaunchErrorReply(
+  deps: Pick<ModelCommandDeps, 'escapeHtml'>,
+  model: string,
+  err: unknown,
+): ModelCommandReply {
+  if (isRestartInFlight(err)) {
     return {
-      text: [
-        `Switching from \`${deps.escapeHtml(currentSession)}\` back to Claude — restarting session cleanly. Claude will be ready in ~30s.`,
-        PERSIST_NOTE,
-      ].join('\n'),
+      text: `⏳ A restart is already in flight — your switch to \`${deps.escapeHtml(model)}\` will apply as it completes (~15s).`,
       html: true,
     }
   }
+  const msg = err instanceof Error ? err.message : String(err)
+  return { text: `❌ Could not schedule model switch: ${deps.escapeHtml(msg)}`, html: true }
+}
 
-  // Claude → sr-*: an in-place inject can't set a non-Anthropic model — claude's
-  // native `/model` picker rejects the unknown `sr-*` id ("Model not found").
-  // Carry the token across a graceful restart and relaunch `claude --model
-  // sr-*` directly (LiteLLM routes it). Session-only: reverts to the configured
-  // default on the next restart. The sr-* → Claude direction is handled above.
-  if (isSrModel(model)) {
-    try {
-      await deps.scheduleModelRelaunch(model, `user: /model ${model} (session-only relaunch)`)
-    } catch (err) {
-      if (isRestartInFlight(err)) {
-        return {
-          text: `⏳ A restart is already in flight — your switch to \`${deps.escapeHtml(model)}\` will apply as it completes (~15s).`,
-          html: true,
-        }
-      }
-      const msg = err instanceof Error ? err.message : String(err)
-      return {
-        text: `❌ Could not schedule model switch: ${deps.escapeHtml(msg)}`,
-        html: true,
-      }
-    }
-    return {
-      text: [
-        `Switching to \`${deps.escapeHtml(model)}\` — restarting session (~30s).`,
-        PERSIST_NOTE,
-      ].join('\n'),
-      html: true,
-    }
-  }
-
-  const verbHtml = `\`/model ${deps.escapeHtml(model)}\``
-  let result: InjectResult
+/** Schedule a carrier relaunch onto `model`, returning the deterministic ack. */
+async function scheduleRelaunchReply(
+  deps: ModelCommandDeps,
+  model: string,
+  reason: string,
+): Promise<ModelCommandReply> {
   try {
-    // #3241 part A — poll-until-signal. Hand the inject primitive the exact
-    // confirmation / error line shapes so its capture loop keeps polling until
-    // claude's "Set model to …" (or an error) actually lands, instead of
-    // breaking at a fixed settle window on the first pane change (which the
-    // async access banner tripped, capturing the banner and missing the
-    // confirmation). settleBeforeSendMs waits for a clean prompt so the keys
-    // aren't typed into a still-animating pane (symptom 2's silent no-op).
-    result = await deps.inject(deps.getAgentName(), `/model ${model}`, {
-      successPattern: MODEL_SWITCH_CONFIRMATION_PREFIX,
-      errorPattern: MODEL_SWITCH_ERROR_RE,
-      settleBeforeSendMs: 1500,
-    })
+    await deps.scheduleModelRelaunch(model, reason)
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return {
-      text: `❌ ${verbHtml} — inject failed: ${deps.escapeHtml(msg)}`,
-      html: true,
-    }
+    return relaunchErrorReply(deps, model, err)
   }
+  return { text: [switchingLine(deps, model), PERSIST_NOTE].join('\n'), html: true }
+}
 
-  if (result.outcome === 'ok' || result.outcome === 'ok_no_output') {
-    // claude's `/model <name>` prints a "Set model to X" acknowledgement, an
-    // error line ("Model not found"), a "Kept model as X" no-op, or (rarely)
-    // switches with the confirmation scrolled off. `result.output` on a silent
-    // path is just pane scrollback (the agent's previous prose) — NEVER a
-    // confirmation, and it must not be dumped back as a code block (screenshot-
-    // confirmed leak on klanker, v0.16.47).
-    //
-    // Honest reporting (#3241 part B inverts the old "record nothing unless
-    // confirmed" to "record optimistically, retract only on a scraped error").
-    // Order matters (#3242 review MEDIUM 1): check the CONFIRMATION line FIRST —
-    // a genuine switch always prints one, so it can never be flipped to a failure
-    // by a stray availability/denial word (the widened MODEL_SWITCH_ERROR_RE) in
-    // the same region. Then:
-    //   (1) "Kept model as X" → genuine no-op; report it, record NOTHING.
-    //   (2) other confirmation → verified switch; relay it, record the display
-    //       name for /status.
-    //   (3) error/denial line scraped (bad id OR access denial) → switch FAILED.
-    //       Report it; record NOTHING (the retract — /status keeps the prior model).
-    //   (4) no line either way → poll-until-signal already waited the full
-    //       window, so this is a SILENT success, not a failure. Record the
-    //       requested model OPTIMISTICALLY (normalized to display form) so
-    //       /status is right, and say so.
-    const confirmation = result.outcome === 'ok' ? modelSwitchConfirmationLine(result.output) : null
-    if (confirmation) {
-      if (isKeptModelConfirmation(confirmation)) {
-        // "Kept model as X" — nothing changed. Relay it, record no override.
-        return {
-          text: [
-            `${verbHtml}`,
-            deps.preBlock(confirmation),
-            ...(result.truncated ? ['_truncated_'] : []),
-            PERSIST_NOTE,
-          ].join('\n'),
-          html: true,
-        }
-      }
-      const confirmed = sessionModelFromConfirmation(confirmation) ?? model
-      return {
-        text: [
-          `${verbHtml}`,
-          deps.preBlock(confirmation),
-          ...(result.truncated ? ['_truncated_'] : []),
-          PERSIST_NOTE,
-        ].join('\n'),
-        html: true,
-        selectedModel: confirmed,
-      }
-    }
-    const errLine = result.outcome === 'ok' ? modelSwitchErrorLine(result.output) : null
-    if (errLine) {
-      return {
-        text: [
-          `❌ ${verbHtml} — the switch did not take:`,
-          deps.preBlock(errLine),
-          'Check \`/model\` for a valid, available model.',
-        ].join('\n'),
-        html: true,
-      }
-    }
-    // No confirmation and no error — optimistic record (#3241 part B). The
-    // Telegram copy stays PROVISIONAL (#3242 review FIX 2): we couldn't read a
-    // confirmation, and if the CLI denied the switch with wording our error
-    // regex misses, an affirmative "recorded X" would be a lie that never
-    // self-corrects. `/status` DOES self-heal (the override is reclaimed by the
-    // next transcript line), so point the user there rather than assert success.
-    const optimisticLabel = optimisticModelRecordLabel(model)
-    return {
-      text: [
-        `${verbHtml} — sent, but couldn't read a confirmation line. \`/status\` will show the live model once it's confirmed.`,
-        PERSIST_NOTE,
-      ].join('\n'),
-      html: true,
-      selectedModel: optimisticLabel,
-      optimistic: true,
-    }
-  }
-
-  // outcome === 'failed'
-  if (result.errorCode === 'session_missing') {
-    return {
-      text:
-        '❌ tmux session not found — the agent must be running under the tmux supervisor (the default). Remove \`experimental.legacy_pty: true\` if set.',
-      html: true,
-    }
+/** Schedule the `/model default` clear + revert relaunch, returning its ack. */
+async function scheduleDefaultRelaunchReply(
+  deps: ModelCommandDeps,
+  reason: string,
+): Promise<ModelCommandReply> {
+  try {
+    await deps.scheduleModelDefaultRelaunch(reason)
+  } catch (err) {
+    return relaunchErrorReply(deps, 'default', err)
   }
   return {
-    text: `❌ ${verbHtml} — ${deps.escapeHtml(result.errorMessage ?? 'inject failed')}`,
+    text: [
+      '🔄 Reverting to the configured default model — relaunching the session (~30s).',
+      PERSIST_NOTE,
+    ].join('\n'),
     html: true,
   }
 }
@@ -584,12 +470,14 @@ export async function handleModelCommand(
 // ---------------------------------------------------------------------------
 
 export interface ModelMenuDeps {
-  /** Live picker discovery — src/agents/model-picker.ts discoverModels. */
-  discover: (agent: string) => Promise<DiscoverResult>
-  /** Live picker selection by label — selectModel (session-only `s`). */
-  select: (agent: string, label: string) => Promise<SelectResult>
   /**
-   * True while the agent is mid-turn. Driving the picker types into
+   * Live picker discovery — src/agents/model-picker.ts discoverModels. Used ONLY
+   * to RENDER the model list (buildModelMenu); rev 5 retired the terminal-driving
+   * `select` from the switch path, so discovery no longer applies a switch.
+   */
+  discover: (agent: string) => Promise<DiscoverResult>
+  /**
+   * True while the agent is mid-turn. Driving the picker (for RENDER) types into
    * claude's input box; doing that mid-turn would queue "/model" as
    * user text instead of opening the modal — refuse instead.
    */
@@ -628,9 +516,9 @@ export const MODEL_CALLBACK_HEADER = 'mdl:h'
 /**
  * Callback prefix for Claude aliases that the CLI picker doesn't render but
  * the CLI resolves natively (e.g. `fable`). Carries the alias verbatim; its
- * handler INJECTS `/model <alias>` — the same mechanism MODEL_CALLBACK_SR
- * uses — because the cursor-nav select path can only pick rows claude's own
- * picker actually renders.
+ * handler routes to the carrier relaunch (`scheduleModelRelaunch`) — the same
+ * deterministic mechanism every switch uses (rev 5). `fable` boots via the
+ * LiteLLM router repoint in start.sh (see the fable case there).
  */
 export const MODEL_CALLBACK_ALIAS = 'mdl:alias:'
 /** Callback: open the nested "External models" keyboard page. */
@@ -644,9 +532,10 @@ export type ModelMenuPage = 'main' | 'external'
 /**
  * Static Claude aliases appended to the scraped Claude group. The claude CLI's
  * own `/model` picker (deps.discover) does NOT list `fable`, but the CLI
- * resolves the alias natively, so we render it as an extra button that selects
- * by injecting `/model fable` (MODEL_CALLBACK_ALIAS). Extend this list to
- * surface further CLI-resolvable aliases the picker omits.
+ * resolves the alias natively, so we render it as an extra button that switches
+ * via the carrier relaunch (MODEL_CALLBACK_ALIAS → scheduleModelRelaunch, rev
+ * 5). Extend this list to surface further CLI-resolvable aliases the picker
+ * omits.
  */
 export const EXTRA_CLAUDE_ALIASES: ReadonlyArray<{ alias: string; label: string }> = [
   { alias: 'fable', label: 'Fable' },
@@ -735,32 +624,6 @@ export function srFriendlyLabel(srName: string): string {
 }
 
 /**
- * #3242 review LOW 4 — display normalization for the OPTIMISTIC `/status` record.
- * The confirmed path records the display name claude printed (e.g. "Fable 5" via
- * `sessionModelFromConfirmation`); the optimistic path only has the requested
- * arg. Without a confirmation we can't know the version suffix, so we normalize
- * a bare Claude alias to the same DISPLAY style — Title-case ("fable" → "Fable")
- * — and leave a full `claude-*` id as-is (already canonical).
- *
- * #3242 review FIX 1 (MEDIUM) — sr-* tokens are returned UNCHANGED (with the
- * `sr-` prefix). The stored `selectedModel` doubles as the sr-*→Claude sentinel:
- * `gateway.ts` `isSrToClaudeTransition` checks `prevModel?.startsWith('sr-')` to
- * decide whether a later Claude switch needs the graceful restart that tears
- * down LiteLLM routing. De-prefixing here (as the earlier LOW-4 pass did via
- * `srFriendlyLabel`) would silently break that restart. So this helper never
- * de-prefixes: the caller normalizes only the DISPLAY text separately (see
- * `srFriendlyLabel`), never the stored token.
- */
-export function optimisticModelRecordLabel(token: string): string {
-  if (isSrModel(token)) return token
-  const lower = token.toLowerCase()
-  if ((MODEL_ALIASES as readonly string[]).includes(lower)) {
-    return lower.charAt(0).toUpperCase() + lower.slice(1)
-  }
-  return token
-}
-
-/**
  * Split picker-discovered options into native Claude options and sr-*
  * (LiteLLM non-Anthropic) options. Options with "/" in the label or
  * other non-native prefixes (e.g., "openrouter/...", "gpt-4") are
@@ -787,11 +650,14 @@ export function classifyDiscoveredOptions(options: ModelPickerOption[]): {
 }
 
 export function modelSelectCallbackData(label: string): string {
-  // Identity is the label's hash, not its index — a tap re-discovers
-  // the picker and matches by tag, so a list that shifted between
-  // render and tap can never select the wrong row. 8 hex chars keeps
-  // callback_data tiny (well under Telegram's 64-byte cap).
-  return `${MODEL_CALLBACK_SELECT}${labelTag(label)}`
+  // Rev 5: embed the CANONICAL `claude --model` token directly, not a label
+  // hash. A tap no longer needs live picker discovery to resolve the row — it
+  // goes straight to the carrier relaunch (`mdl:s:<token>`), removing the last
+  // terminal-driving step from the switch path. The "Default (recommended)" row
+  // has no derivable token (`canonicalClaudeToken` → null); it carries the
+  // `default` sentinel so the tap routes to the clear+revert relaunch.
+  const token = canonicalClaudeToken(label) ?? 'default'
+  return `${MODEL_CALLBACK_SELECT}${token}`
 }
 
 const BUSY_REFUSAL_TEXT =
@@ -1044,30 +910,14 @@ export interface ModelCallbackOutcome {
    */
   busyRefusal?: boolean
   /**
-   * On a successful session switch, the live model name now running (parsed
-   * from claude's confirmation, e.g. "Fable 5"). The gateway records this as
-   * the session-model override so `/status` reflects what's actually running.
-   * Absent on every non-switch outcome.
+   * Rev 5: a menu tap NEVER carries a scrape-derived live-model field. Every
+   * switch (alias/Fable, picker SELECT, sr-*) relaunches through
+   * `scheduleModelRelaunch`/`scheduleModelDefaultRelaunch`, which own the
+   * in-memory override + carrier writes; the ACTUAL running model is reconciled
+   * at boot from `.active-session-model`. So there is no `selectedModel` /
+   * `selectedModelToken` / `clearedDefault` here to record optimistically — the
+   * gateway no longer post-processes the outcome for side effects.
    */
-  selectedModel?: string
-  /**
-   * The canonical `claude --model` token (alias or full `claude-*` id) for a
-   * Claude selection, when derivable — distinct from `selectedModel` (a display
-   * name for /status). Session-scoped (rev 4): a live Claude selection persists
-   * NO carrier (the switch applies in-session and reverts on the next boot);
-   * the gateway uses this token ONLY on an sr-* → Claude transition, writing it
-   * to the consume-once `.session-model` carrier so that transition's own
-   * apply-relaunch boots the tapped model (then reverts on the following
-   * restart). Absent when the target has no derivable token.
-   */
-  selectedModelToken?: string
-  /**
-   * True when the confirmed selection was the "Default (recommended)" row —
-   * i.e. the session is now on the configured default and any leftover
-   * `.session-model` carrier must be CLEARED (a stale carrier would be
-   * consumed — mis-applied — by the next boot).
-   */
-  clearedDefault?: boolean
   /** Short toast for answerCallbackQuery. */
   answer: string
   /** Replacement dashboard (message edit). */
@@ -1098,98 +948,6 @@ export async function handleModelMenuCallback(
     return { answer: 'Back', reply: await buildModelMenu(deps, 'main') }
   }
 
-  // Claude-alias tap (e.g. Fable): the CLI resolves the alias but its picker
-  // doesn't render it, so select by injecting `/model <alias>` — same path as
-  // the sr-* handler below, no cursor-nav.
-  if (data.startsWith(MODEL_CALLBACK_ALIAS)) {
-    const alias = data.slice(MODEL_CALLBACK_ALIAS.length)
-    if (!isValidModelArg(alias)) {
-      return { answer: 'Invalid model name', reply: await buildModelMenu(deps) }
-    }
-    if (deps.isBusy()) {
-      return {
-        answer: '⏳ Agent is mid-turn — tap again when it’s idle',
-        reply: { text: BUSY_REFUSAL_TEXT, html: true },
-        toastOnly: true,
-        busyRefusal: true,
-      }
-    }
-    let aliasResult: InjectResult
-    try {
-      // #3241 part A — same poll-until-signal + clean-prompt opts as the typed
-      // set path so the alias (e.g. Fable) confirmation scrape is deterministic
-      // and immune to the async access banner.
-      aliasResult = await deps.inject(deps.getAgentName(), `/model ${alias}`, {
-        successPattern: MODEL_SWITCH_CONFIRMATION_PREFIX,
-        errorPattern: MODEL_SWITCH_ERROR_RE,
-        settleBeforeSendMs: 1500,
-      })
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      return {
-        answer: 'Switch failed',
-        reply: await menuWithBanner(deps, `❌ Switch to **${deps.escapeHtml(alias)}** failed: ${deps.escapeHtml(msg)}`),
-      }
-    }
-    // #3242 review MEDIUM 2 — the alias BUTTON (the primary Fable UI, the exact
-    // async-banner scenario) must be symmetric with the typed set path: handle
-    // BOTH `ok` and `ok_no_output` with record-on-send / retract-on-scraped-error.
-    // Previously `ok_no_output` fell through to "Switch failed — agent may be
-    // mid-turn" and dropped the override, so a silent successful button-switch
-    // was reported as a failure while the identical typed command recorded.
-    if (aliasResult.outcome === 'ok' || aliasResult.outcome === 'ok_no_output') {
-      // Confirmation first (a genuine switch always prints one) so a stray
-      // availability/denial word can't flip it to a failure.
-      const confirmation = aliasResult.outcome === 'ok'
-        ? modelSwitchConfirmationLine(aliasResult.output)
-        : null
-      if (confirmation) {
-        // "Kept model as X" means no change — don't overwrite the override.
-        const kept = isKeptModelConfirmation(confirmation)
-        return {
-          answer: confirmation,
-          reply: await menuWithBannerStatic(deps, `✅ ${deps.escapeHtml(confirmation)}`),
-          ...(kept ? {} : {
-            selectedModel: sessionModelFromConfirmation(confirmation) ?? optimisticModelRecordLabel(alias),
-            selectedModelToken: alias,
-          }),
-        }
-      }
-      // Scraped error/denial (bad id OR access denial) → genuine failure, record
-      // nothing (retract).
-      const aliasErr = aliasResult.outcome === 'ok' ? modelSwitchErrorLine(aliasResult.output) : null
-      if (aliasErr) {
-        return {
-          answer: 'Switch failed',
-          reply: await menuWithBanner(
-            deps,
-            `❌ Switch to **${deps.escapeHtml(alias)}** did not take: ${deps.escapeHtml(aliasErr)}`,
-          ),
-        }
-      }
-      // Silent success (no confirmation, no error) → optimistic record, same as
-      // the typed path. PROVISIONAL copy (#3242 review FIX 2): don't assert the
-      // switch succeeded — we couldn't read a confirmation, and /status self-heals.
-      const optimisticLabel = optimisticModelRecordLabel(alias)
-      return {
-        answer: `Sent /model ${alias} — check /status`,
-        reply: await menuWithBannerStatic(
-          deps,
-          `Sent \`/model ${deps.escapeHtml(alias)}\` — couldn’t read a confirmation line. \`/status\` will show the live model once it’s confirmed.`,
-        ),
-        selectedModel: optimisticLabel,
-        selectedModelToken: alias,
-      }
-    }
-    return {
-      answer: 'Switch failed',
-      reply: await menuWithBanner(
-        deps,
-        `❌ Switch to **${deps.escapeHtml(alias)}** failed — agent may be mid-turn`,
-      ),
-    }
-  }
-
   if (data === MODEL_CALLBACK_HEADER) {
     // Section-header row — the gateway handles this with a direct answerCallbackQuery
     // before calling this function, so this branch is dead in practice. Guard
@@ -1197,20 +955,38 @@ export async function handleModelMenuCallback(
     return { answer: 'Tap a model in this section to switch', reply: { text: '', html: true }, toastOnly: true }
   }
 
-  // sr-* model tap. In the live gateway this branch is DEAD — the gateway
-  // intercepts `mdl:sr:` at its callback dispatcher (before calling this
-  // function) and routes it straight to scheduleModelRelaunch (carrier + restart).
-  // The old body here text-injected `/model sr-<name>`, which is doubly broken if
-  // ever reached: claude's picker rejects unknown sr-* ids AND the ANTHROPIC_BASE_URL
-  // is never repointed at the LiteLLM router, so the request 4xxs against Anthropic.
-  // Delegate to the SAME carrier mechanism so a direct caller (tests, a future
-  // refactor that drops the gateway intercept) still does the safe thing.
-  if (data.startsWith(MODEL_CALLBACK_SR)) {
-    const srName = data.slice(MODEL_CALLBACK_SR.length)
-    const friendlyName = srFriendlyLabel(srName)
-    if (!isValidModelArg(srName)) {
+  // A model-SWITCH tap — Fable/alias button (`mdl:alias:`), an sr-* target
+  // (`mdl:sr:`), or a picker SELECT row (`mdl:s:<token>`). Rev 5: every one
+  // relaunches through the consume-once `.session-model` carrier. No inject, no
+  // cursor-nav, no terminal scrape — a tap resolves its canonical token and
+  // hands off to `scheduleModelRelaunch` (or the clear+revert path for the
+  // `default` sentinel, which the "Default (recommended)" row and the Default
+  // alias button both carry). This is what makes a tap deterministic: it can no
+  // longer silently no-op or optimistically record a switch that never applied.
+  if (
+    data.startsWith(MODEL_CALLBACK_ALIAS) ||
+    data.startsWith(MODEL_CALLBACK_SR) ||
+    data.startsWith(MODEL_CALLBACK_SELECT)
+  ) {
+    let token: string
+    let label: string
+    if (data.startsWith(MODEL_CALLBACK_ALIAS)) {
+      token = data.slice(MODEL_CALLBACK_ALIAS.length)
+      label = token
+    } else if (data.startsWith(MODEL_CALLBACK_SR)) {
+      token = data.slice(MODEL_CALLBACK_SR.length)
+      label = srFriendlyLabel(token)
+    } else {
+      token = data.slice(MODEL_CALLBACK_SELECT.length)
+      label = token
+    }
+    if (!isValidModelArg(token)) {
       return { answer: 'Invalid model name', reply: await buildModelMenu(deps) }
     }
+    // Mid-turn: refuse WITHOUT touching the message so the menu keeps its
+    // buttons and the operator can tap again once idle. (The gateway dispatcher
+    // already enqueues switch taps mid-turn before calling this handler; this is
+    // the belt-and-braces seam for callers that skip it.)
     if (deps.isBusy()) {
       return {
         answer: '⏳ Agent is mid-turn — tap again when it’s idle',
@@ -1219,195 +995,55 @@ export async function handleModelMenuCallback(
         busyRefusal: true,
       }
     }
-    try {
-      await deps.scheduleModelRelaunch(srName, `user: /model ${srName} (session-only relaunch, menu)`)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+    return menuRelaunchOutcome(deps, token, label)
+  }
+
+  return { answer: 'Unknown action', reply: await buildModelMenu(deps) }
+}
+
+/**
+ * Shared menu-tap relaunch: schedule the carrier relaunch onto `token` (or the
+ * clear+revert relaunch for the `default` sentinel) and return the deterministic
+ * "relaunching (~30s)" card. Uses the STATIC banner (no discover()) because the
+ * pane is about to restart. No `selectedModel` — the actual running model is
+ * reconciled at boot from `.active-session-model`.
+ */
+async function menuRelaunchOutcome(
+  deps: ModelMenuDeps & ModelCommandDeps,
+  token: string,
+  label: string,
+): Promise<ModelCallbackOutcome> {
+  const isDefault = token.toLowerCase() === 'default'
+  try {
+    if (isDefault) {
+      await deps.scheduleModelDefaultRelaunch('user: /model default (revert relaunch, menu)')
+    } else {
+      await deps.scheduleModelRelaunch(token, `user: /model ${token} (session-only relaunch, menu)`)
+    }
+  } catch (err) {
+    if (isRestartInFlight(err)) {
       return {
-        answer: 'Switch failed',
-        reply: await menuWithBannerStatic(deps, `❌ Switch to **${deps.escapeHtml(friendlyName)}** failed: ${deps.escapeHtml(msg)}`),
+        answer: 'A restart is already in flight (~15s)',
+        reply: await menuWithBannerStatic(
+          deps,
+          `⏳ A restart is already in flight — your switch to **${deps.escapeHtml(label)}** will apply as it completes (~15s).`,
+        ),
       }
     }
+    const msg = err instanceof Error ? err.message : String(err)
     return {
-      answer: `Switching to ${friendlyName} — restarting (~30s)`,
-      reply: await menuWithBannerStatic(
-        deps,
-        `🔄 Switching session to **${deps.escapeHtml(friendlyName)}** — restarting (~30s).\n${PERSIST_NOTE}`,
-      ),
-      selectedModel: srName,
+      answer: 'Switch failed',
+      reply: await menuWithBannerStatic(deps, `❌ Switch to **${deps.escapeHtml(label)}** failed: ${deps.escapeHtml(msg)}`),
     }
   }
-
-  if (!data.startsWith(MODEL_CALLBACK_SELECT)) {
-    return { answer: 'Unknown action', reply: await buildModelMenu(deps) }
-  }
-  // Mid-turn: refuse WITHOUT touching the message. Driving the picker types
-  // into claude's input box, which mid-turn would queue "/model" as user
-  // text. toastOnly keeps the menu (and its buttons) exactly as-is so the
-  // operator just taps again when the agent is idle — no button-less
-  // "try again" line that read as a dead menu.
-  if (deps.isBusy()) {
-    return {
-      answer: '⏳ Agent is mid-turn — tap again when it’s idle',
-      reply: { text: BUSY_REFUSAL_TEXT, html: true },
-      toastOnly: true,
-      busyRefusal: true,
-    }
-  }
-
-  const tag = data.slice(MODEL_CALLBACK_SELECT.length)
-  const discovered = await deps.discover(deps.getAgentName())
-  if (!discovered.ok) {
-    // Keep the menu interactive: re-render (falls back to v1 text if even
-    // the show path can't discover) with the failure as a banner.
-    return {
-      answer: 'Picker unavailable',
-      reply: await menuWithBanner(
-        deps,
-        `❌ Could not open the model picker: ${deps.escapeHtml(discovered.reason)}`,
-      ),
-    }
-  }
-  const target = discovered.options.find((o) => labelTag(o.label) === tag)
-  if (!target) {
-    // Options changed since the menu rendered — never guess; re-render.
-    const fresh = await buildModelMenu(deps)
-    return { answer: 'Model list changed — menu refreshed', reply: fresh }
-  }
-  // NOTE: do NOT short-circuit when target.current is set. The picker's ✔
-  // marks claude's DEFAULT FOR NEW SESSIONS, which is a DIFFERENT axis from
-  // the model the live session is running (set by --model at launch). Tapping
-  // the ✔ row to apply that model to the live session is a legitimate switch
-  // — e.g. an agent launched on Fable tapping "Default (Opus)". Skipping it
-  // here was the "tapped Default, nothing happened" bug. Always drive the
-  // selection; claude harmlessly answers "Kept model as X" if it's already
-  // the session model.
-  const result = await deps.select(deps.getAgentName(), target.label)
-  if (!result.ok) {
-    // Switch failed but the agent is reachable — keep the menu so the
-    // operator can retry, with the reason as a banner.
-    return {
-      answer: 'Switch failed — see the menu',
-      reply: await menuWithBanner(
-        deps,
-        `❌ Switch to **${deps.escapeHtml(target.label)}** failed: ${deps.escapeHtml(result.reason)}`,
-      ),
-    }
-  }
-
-  // "Kept model as X" means the tapped model was ALREADY the session model —
-  // nothing changed. Do NOT overwrite the override (and never store the display
-  // label). Tapping the "Default (recommended)" row on the already-default model
-  // previously stored "Default (recommended)" verbatim into /status.
-  if (isKeptModelConfirmation(result.confirmation)) {
-    return {
-      answer: deps.escapeHtml(result.confirmation),
-      reply: await menuWithBanner(deps, `✅ ${deps.escapeHtml(result.confirmation)}`),
-    }
-  }
-  // Normalize what we store: prefer the model name claude confirmed, else a
-  // canonical token derived from the row label — never a pure display label like
-  // "Default (recommended)". If neither resolves, record nothing rather than lie.
-  const token = canonicalClaudeToken(target.label)
-  const selectedModel = sessionModelFromConfirmation(result.confirmation) ?? token ?? undefined
-  // The "Default (recommended)" row has no derivable token BY DESIGN — a
-  // confirmed switch to it means "back on the configured default", which the
-  // gateway must translate into clearing the sticky override.
-  const clearedDefault = token == null && /^default\b/i.test(target.label.trim())
+  const friendly = isDefault ? 'the configured default' : label
   return {
-    answer: deps.escapeHtml(result.confirmation),
-    reply: await menuWithBanner(deps, `✅ ${deps.escapeHtml(result.confirmation)}`),
-    ...(selectedModel ? { selectedModel } : {}),
-    ...(token ? { selectedModelToken: token } : {}),
-    ...(clearedDefault ? { clearedDefault: true } : {}),
+    answer: `Switching to ${isDefault ? 'default' : label} — relaunching (~30s)`,
+    reply: await menuWithBannerStatic(
+      deps,
+      `🔄 Switching session to **${deps.escapeHtml(friendly)}** — relaunching (~30s).\n${PERSIST_NOTE}`,
+    ),
   }
-}
-
-/**
- * True when the transition from `prevModel` to `nextModel` is a switch FROM
- * an sr-* (LiteLLM/OpenRouter) model BACK TO a native Claude model. This
- * signals that a session restart is required — an in-place model-picker select
- * cannot undo the LiteLLM routing that the sr-* switch established in the live
- * session. Null / undefined prev means no prior sr-* session — not a transition.
- */
-export function isSrToClaudeTransition(
-  prevModel: string | null | undefined,
-  nextModel: string,
-): boolean {
-  return !!prevModel?.startsWith('sr-') && !nextModel.startsWith('sr-')
-}
-
-/**
- * Return the single line of a pane capture that actually reads as claude's
- * model-switch acknowledgement ("Set model to X…", "Switched to X", or
- * "Kept model as X"), or null when no such line is present. Used by the
- * direct `/model <name>` path to decide whether `result.output` carries a
- * genuine confirmation worth relaying, versus mere scrollback that must NOT
- * be echoed back to chat. Mirrors the line-scan already used by the picker
- * alias/sr-* callback paths.
- */
-export function modelSwitchConfirmationLine(output: string): string | null {
-  const line = output
-    .split('\n')
-    .map((l) => l.trim())
-    .find((l) => MODEL_SWITCH_CONFIRMATION_PREFIX.test(l))
-  return line && line.length > 0 ? line : null
-}
-
-/**
- * claude's failure output for a bad `/model <name>` — the CLI rejects an
- * unknown id with "Model not found" / "Invalid model" / "Unknown model".
- * Detecting it lets the typed set path report an HONEST failure instead of
- * falsely claiming "switched (session)". Anchored to LINE START (behind the
- * same optional status glyph + optional "Error:" prefix as
- * MODEL_SWITCH_CONFIRMATION_PREFIX) so ordinary scrollback prose that merely
- * CONTAINS the phrase mid-sentence (e.g. "deploy failed: model not found in
- * registry") can never false-positive a successful switch into a reported
- * failure — the false-FAILURE variant of the scrollback-leak class.
- *
- * Empirically verified against claude v2.1.205 (disposable TUI probe,
- * 2026-07-10): `/model claude-bogus-99` prints
- * `⎿  Model 'claude-bogus-99' not found` — glyph prefix `⎿`, quoted model
- * name between "Model" and "not found". Both shapes are covered.
- *
- * #3242 review MEDIUM 1 — ACCESS/ENTITLEMENT DENIAL. A bad-id shape is not the
- * only failure: `/model fable` on a plan that lacks it prints an availability /
- * access-denial line ("Fable is not available on your plan", "access denied",
- * "requires a subscription", "not enabled for your account", "no access to …").
- * Those match neither the bad-id shapes nor the confirmation prefix, so the poll
- * loop would expire and the optimistic branch would falsely record the switch —
- * exactly the Fable-entitlement case this PR is about. The second alternation
- * group covers those phrasings. It allows up to four leading words (a model
- * name + a linking adverb etc.) BEFORE the denial phrase — unlike the bad-id
- * branches, which keep
- * their original tight line-start anchoring so ordinary scrollback that merely
- * says "model not found" mid-sentence still can't false-fail a silent switch.
- * The handler checks the confirmation line FIRST (below), so a genuine switch —
- * which always prints a confirmation — is never flipped to a failure by a stray
- * availability word in the same region.
- */
-const MODEL_SWITCH_ERROR_RE =
-  /^\s*[⏺●•>⎿-]?\s*(?:Error:\s*)?(?:Model(?:\s+'[^']+')?\s+not found|Invalid model|Unknown model|No such model|(?:[\w'’.\-]+\s+){0,4}(?:(?:is |are )?(?:not available|unavailable|not enabled|not supported)|access denied|requires\b[^\n]{0,40}\b(?:subscription|plan)|no access)\b)/i
-
-/** The single capture line that reads as a claude model-switch error, or null. */
-export function modelSwitchErrorLine(output: string): string | null {
-  const line = output
-    .split('\n')
-    .map((l) => l.trim())
-    .find((l) => MODEL_SWITCH_ERROR_RE.test(l))
-  return line && line.length > 0 ? line : null
-}
-
-/**
- * True when a confirmation line is claude's "Kept model as X" — i.e. the model
- * was ALREADY the session model and nothing changed. The caller must NOT record
- * this as a session-override (there is nothing to override), and must not store
- * a display label in its place. See the menu-select bug where tapping the
- * "Default (recommended)" row on the already-default model stored the display
- * label verbatim into /status.
- */
-export function isKeptModelConfirmation(confirmation: string): boolean {
-  return /^\s*[⏺●•>⎿-]?\s*Kept model as\b/i.test(confirmation.trim())
 }
 
 /**
@@ -1435,43 +1071,6 @@ export function canonicalClaudeToken(label: string): string | null {
  */
 export function isRestartInFlight(err: unknown): boolean {
   return !!err && typeof err === 'object' && (err as { code?: unknown }).code === 'restart_in_flight'
-}
-
-/**
- * claude's real model-switch confirmation always begins the line (optionally
- * behind a status glyph like `⏺` or `⎿` + whitespace) with one of these exact
- * phrasings. Anchoring to the line start keeps ordinary scrollback prose that
- * merely *contains* words like "switched" or "set model" (e.g. "I switched the
- * deploy to blue-green") from false-positiving as a confirmation worth
- * relaying. Shared by `modelSwitchConfirmationLine` (does this line qualify?)
- * and `sessionModelFromConfirmation` (pull the name out).
- *
- * Empirically verified against claude v2.1.205 (disposable TUI probe,
- * 2026-07-10): the arg form `/model opus` is NOT silent — it prints
- * `⎿  Set model to Opus 4.8 and saved as your default for new sessions`.
- * The `⎿` glyph survives the inject capture (isTuiChromeLine doesn't strip
- * it), so it must be in the glyph class or every typed switch would fall
- * through to the "couldn't confirm" branch and never record the override.
- */
-const MODEL_SWITCH_CONFIRMATION_PREFIX =
-  /^\s*[⏺●•>⎿-]?\s*(?:Set model to|Switched to|Kept model as)\b/i
-
-/**
- * Pull the model NAME out of claude's session-switch confirmation so it can
- * be shown in `/status` as the live session model. claude phrases it as
- * "Set model to <name> for this session only" / "Switched to <name>" /
- * (v2.1.205 arg form) "Set model to <name> and saved as your default for new
- * sessions" — the "and saved" tail must terminate the name capture or the
- * whole sentence would be stored as the model. Returns null when the
- * confirmation doesn't carry a recognizable name (the caller falls back to
- * the tapped picker label).
- */
-export function sessionModelFromConfirmation(confirmation: string): string | null {
-  const m = /(?:Set model to|Switched to)\s+(.+?)(?:\s+for (?:this|the) session|\s+and saved\b|\s*\(|\s*$)/i.exec(
-    confirmation.trim(),
-  )
-  const name = m?.[1]?.trim()
-  return name && name.length > 0 ? name : null
 }
 
 /**

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -1,10 +1,11 @@
 /**
- * Structural pins for the session-scoped /model wiring in gateway.ts
- * (reference/rfcs/session-model-stickiness.md §0.1, rev 4 — consume-once).
+ * Structural pins for the DETERMINISTIC /model wiring in gateway.ts
+ * (reference/rfcs/session-model-stickiness.md §0.05, rev 5 — every switch
+ * relaunches through the consume-once carrier; the inject/scrape path retired).
  *
  * The behaviour lives in un-exported inline closures (buildModelDeps's
- * scheduleModelRelaunch/scheduleRestart, the typed/menu recorders, and the
- * boot re-hydration block inside the startup IIFE), so — mirroring the other
+ * scheduleModelRelaunch / scheduleModelDefaultRelaunch / scheduleRestart, and
+ * the boot re-hydration block inside the startup IIFE), so — mirroring the other
  * gateway-*.test.ts source-pins — we assert on the source structure. The
  * end-to-end boot behaviour is exercised in tests/scaffold.session-model.test.ts
  * (rendered start.sh), the file helpers in session-model-file.test.ts, and the
@@ -42,7 +43,7 @@ describe('gateway: scheduleModelRelaunch dep (consume-once .session-model carrie
   it('writes the carrier via writeSessionModelFile before dispatching the restart', () => {
     const idx = GATEWAY_SRC.indexOf('scheduleModelRelaunch: async')
     expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 1800)
+    const win = GATEWAY_SRC.slice(idx, idx + 2600)
     const writeIdx = win.indexOf('writeSessionModelFile(')
     const restartIdx = win.indexOf('deps.scheduleRestart(reason)')
     expect(writeIdx).toBeGreaterThan(0)
@@ -51,7 +52,7 @@ describe('gateway: scheduleModelRelaunch dep (consume-once .session-model carrie
 
   it('sets the in-memory session-model override before dispatching the restart', () => {
     const idx = GATEWAY_SRC.indexOf('scheduleModelRelaunch: async')
-    const win = GATEWAY_SRC.slice(idx, idx + 1800)
+    const win = GATEWAY_SRC.slice(idx, idx + 2600)
     const setIdx = win.indexOf('sessionModelSource.setOverride(model)')
     const restartIdx = win.indexOf('deps.scheduleRestart(reason)')
     expect(setIdx).toBeGreaterThan(0)
@@ -60,7 +61,7 @@ describe('gateway: scheduleModelRelaunch dep (consume-once .session-model carrie
 
   it('rolls back the prior carrier content (not just deletion) on a non-in-flight dispatch failure', () => {
     const idx = GATEWAY_SRC.indexOf('scheduleModelRelaunch: async')
-    const win = GATEWAY_SRC.slice(idx, idx + 1800)
+    const win = GATEWAY_SRC.slice(idx, idx + 2600)
     expect(win).toContain('const prevFileRaw = readSessionModelFileRaw(agentDir)')
     expect(win).toContain('restoreSessionModelFileRaw(agentDir, prevFileRaw)')
     expect(win).toContain("!== 'restart_in_flight'")
@@ -68,80 +69,90 @@ describe('gateway: scheduleModelRelaunch dep (consume-once .session-model carrie
 
   it('reuses the same scheduleRestart dispatch (not a bespoke restart path)', () => {
     const idx = GATEWAY_SRC.indexOf('scheduleModelRelaunch: async')
-    const win = GATEWAY_SRC.slice(idx, idx + 1800)
+    const win = GATEWAY_SRC.slice(idx, idx + 2600)
     expect(win).toContain('await deps.scheduleRestart(reason)')
   })
 })
 
-describe('gateway: menu callback carrier handling (session-scoped)', () => {
-  it('a live Claude selection records the in-memory override but writes NO carrier', () => {
-    const idx = GATEWAY_SRC.indexOf('function recordModelMenuSideEffects')
+describe('gateway: the retired scrape-recorders are GONE (rev 5 inversion)', () => {
+  it('recordTypedModelSwitch and recordModelMenuSideEffects no longer exist', () => {
+    // INVERTED from rev 4: these helpers recorded a scrape-derived selectedModel
+    // and drove the sr-to-claude special case. Every switch now relaunches, so
+    // they are deleted — their presence would mean the retired path survived.
+    expect(GATEWAY_SRC).not.toContain('function recordTypedModelSwitch')
+    expect(GATEWAY_SRC).not.toContain('function recordModelMenuSideEffects')
+  })
+
+  it('no isSrToClaudeTransition wiring (every switch relaunches — no distinct transition)', () => {
+    expect(GATEWAY_SRC).not.toContain('isSrToClaudeTransition')
+  })
+
+  it('buildModelDeps wires neither the inject nor the select terminal-driver dep', () => {
+    const idx = GATEWAY_SRC.indexOf('function buildModelDeps')
+    expect(idx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(idx, idx + 4000)
+    expect(win).not.toContain('inject: injectSlashCommandImpl')
+    expect(win).not.toContain('select: (a, label) => selectModel')
+  })
+})
+
+describe('gateway: scheduleModelDefaultRelaunch (G1 — clear + revert relaunch)', () => {
+  it('clears the carrier + override and mirrors scheduleModelRelaunch rollback', () => {
+    const idx = GATEWAY_SRC.indexOf('scheduleModelDefaultRelaunch: async')
     expect(idx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(idx, idx + 900)
-    // The first (live-switch) block sets the override but no longer persists.
-    expect(win).toContain('sessionModelSource.setOverride(outcome.selectedModel)')
-    const overrideIdx = win.indexOf('sessionModelSource.setOverride(outcome.selectedModel)')
-    const nextClearIdx = win.indexOf('outcome.clearedDefault')
-    const writeBetween = win.slice(overrideIdx, nextClearIdx)
-    expect(writeBetween).not.toContain('writeSessionModelFile(')
-  })
-
-  it('a confirmed "Default" selection CLEARS the carrier', () => {
-    const idx = GATEWAY_SRC.indexOf('function recordModelMenuSideEffects')
-    const win = GATEWAY_SRC.slice(idx, idx + 2400)
-    expect(win).toContain('outcome.clearedDefault')
-    expect(win).toContain('clearSessionModelFile(smDir)')
-  })
-
-  it('the sr-* callback branch calls scheduleModelRelaunch, not inject', () => {
-    const idx = GATEWAY_SRC.indexOf('const srLabel = escapeHtmlForTg(srFriendlyLabel(srName))')
-    expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 1400)
-    expect(win).toContain('modelDeps.scheduleModelRelaunch(srName')
-    expect(win).toMatch(/scheduleModelRelaunch[\s\S]*?\n\s*return\n/)
-  })
-
-  it('the sr-to-claude transition (a relaunch) writes the carrier, and clears it on a Default tap', () => {
-    const idx = GATEWAY_SRC.indexOf('isSrToClaudeTransition(prevSessionModel, outcome.selectedModel)')
-    expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 3600)
-    expect(win).toMatch(/writeSessionModelFile\(\s*agentDir,\s*token/)
-    expect(win).toContain('clearSessionModelFile(agentDir)')
-    expect(win).toContain("triggerSelfRestart(agentName, 'sr-to-claude-model-switch'")
-  })
-})
-
-describe('gateway: typed /model is session-scoped (live Claude switch writes no carrier)', () => {
-  it('the Claude path sets the in-memory override but never persists a carrier', () => {
-    const idx = GATEWAY_SRC.indexOf('function recordTypedModelSwitch')
-    expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 1400)
-    expect(win).toContain('sessionModelSource.setOverride(reply.selectedModel)')
-    // No durable carrier write on the live-switch path.
-    expect(win).not.toContain('writeSessionModelFile(')
-  })
-
-  it('`/model default` clears the carrier + in-memory override (silent-switch path must not resurrect)', () => {
-    const idx = GATEWAY_SRC.indexOf('function recordTypedModelSwitch')
-    const win = GATEWAY_SRC.slice(idx, idx + 1400)
-    expect(win).toContain("requested?.toLowerCase() === 'default'")
-    expect(win).toContain('clearSessionModelFile(smDir)')
-    expect(win).toContain('sessionModelSource.setOverride(null)')
-    // The file-clear is not gated on a positive confirmation.
-    const clearIdx = win.indexOf('if (smDir) clearSessionModelFile(smDir)')
-    const gatedOverrideIdx = win.indexOf('if (reply.selectedModel) sessionModelSource.setOverride(null)')
+    const clearIdx = win.indexOf('clearSessionModelFile(agentDir)')
+    const overrideIdx = win.indexOf('sessionModelSource.setOverride(null)')
+    const restartIdx = win.indexOf('deps.scheduleRestart(reason)')
     expect(clearIdx).toBeGreaterThan(0)
-    expect(gatedOverrideIdx).toBeGreaterThan(clearIdx)
+    expect(overrideIdx).toBeGreaterThan(clearIdx)
+    expect(restartIdx).toBeGreaterThan(overrideIdx)
+    // G1 rollback on a non-in-flight dispatch failure.
+    expect(win).toContain('restoreSessionModelFileRaw(agentDir, prevFileRaw)')
+    expect(win).toContain("!== 'restart_in_flight'")
   })
 })
 
-describe('gateway boot: session-model re-hydration + alert relay', () => {
-  it('re-hydrates the override from .active-session-model', () => {
+describe('gateway: the live callback dispatcher routes every switch tap to the handler', () => {
+  it('calls handleModelMenuCallback and no longer post-processes a scrape outcome', () => {
+    const idx = GATEWAY_SRC.indexOf('const outcome = await handleModelMenuCallback(data, modelDeps)')
+    expect(idx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(idx, idx + 600)
+    expect(win).not.toContain('recordModelMenuSideEffects')
+  })
+
+  it('the typed dispatcher relays the handler reply directly (no recordTypedModelSwitch)', () => {
+    const idx = GATEWAY_SRC.indexOf('const reply = await handleModelCommand(parsed, deps)')
+    expect(idx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(idx, idx + 400)
+    expect(win).not.toContain('recordTypedModelSwitch')
+    expect(win).toContain('switchroomReply(ctx, reply.text')
+  })
+})
+
+describe('gateway boot: session-model re-hydration + confirmation + alert relay', () => {
+  it('re-hydrates the override from .active-session-model (launched !== configured)', () => {
     const idx = GATEWAY_SRC.indexOf("join(smAgentDir, '.active-session-model')")
     expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx - 200, idx + 1400)
-    expect(win).toMatch(/launched\.length > 0 && launched !== configured \? launched : null/)
+    const win = GATEWAY_SRC.slice(idx - 200, idx + 3200)
+    // F1: `launched !== configured` is the deterministic apply-boot signal.
+    expect(win).toContain('const isApplyBoot = launched.length > 0 && launched !== configured')
+    expect(win).toContain('sessionModelSource.setOverride(isApplyBoot ? launched : null)')
     expect(win).toContain('resolveMainModel(raw ?? undefined)')
+  })
+
+  it('logs the applied model for diagnosability (F1)', () => {
+    expect(GATEWAY_SRC).toContain('gw /model relaunch applied agent=')
+    expect(GATEWAY_SRC).toContain('gw /model relaunch scheduled agent=')
+  })
+
+  it('sends ONE switch-confirmation from the ACTUAL launched model, keyed on the apply-boot (F1/G3)', () => {
+    const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
+    expect(idx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(idx, idx + 3200)
+    // Success is asserted only from the real launched value, never optimistically.
+    expect(win).toContain('if (isApplyBoot && modelSwitchMarkerChat)')
+    expect(win).toContain('✅ Now running')
   })
 
   it('consumes the .session-model-alert sentinel, notifies ALL operators, and deletes it', () => {

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -146,13 +146,29 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
     expect(GATEWAY_SRC).toContain('gw /model relaunch scheduled agent=')
   })
 
-  it('sends ONE switch-confirmation from the ACTUAL launched model, keyed on the apply-boot (F1/G3)', () => {
+  it('sends ONE switch-confirmation from the ACTUAL launched model, keyed on the /model reason (F1/N4)', () => {
     const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
     expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 3200)
-    // Success is asserted only from the real launched value, never optimistically.
-    expect(win).toContain('if (isApplyBoot && modelSwitchMarkerChat)')
+    const win = GATEWAY_SRC.slice(idx, idx + 3400)
+    // Keyed on the deterministic /model switch reason, so it also fires on a
+    // launched===configured apply-boot (/model default) — N4. Never optimistic.
+    expect(win).toContain('if (modelSwitchReason != null && modelSwitchMarkerChat)')
     expect(win).toContain('✅ Now running')
+    // N4: the launched===configured branch still confirms.
+    expect(win).toContain('(the configured default)')
+  })
+
+  it('N4/reason: the /model switch reason is captured from the clean-shutdown marker', () => {
+    expect(GATEWAY_SRC).toContain("cleanMarker.reason.startsWith('user: /model')")
+    expect(GATEWAY_SRC).toContain('let modelSwitchReason: string | null = null')
+  })
+
+  it('N3: the generic boot card is suppressed on a /model apply-boot (one card per switch)', () => {
+    const idx = GATEWAY_SRC.indexOf('const suppressBootCardForModelSwitch')
+    expect(idx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(idx, idx + 800)
+    expect(win).toContain('modelSwitchReason != null && modelSwitchMarkerChat != null')
+    expect(win).toContain('else if (target)')
   })
 
   it('consumes the .session-model-alert sentinel, notifies ALL operators, and deletes it', () => {

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -1,19 +1,21 @@
 /**
- * `/model` Telegram command — parser + handler coverage.
+ * `/model` Telegram command — parser + handler coverage (rev 5, DETERMINISTIC
+ * SWITCH). This suite encodes the CURRENT contract after the inject-into-tmux +
+ * terminal-scrape path was RETIRED (reference/rfcs/session-model-stickiness.md
+ * §0.05):
  *
- * The headline guarantees:
+ *   1. The bare `/model` form renders the dashboard; it never applies a switch.
+ *   2. The argument is shape-gated before it becomes a `claude --model` token.
+ *   3. EVERY switch — typed Claude→Claude, Claude→sr-*, sr-*→Claude, the
+ *      Fable/alias button, and the picker SELECT — routes through the carrier
+ *      relaunch (`scheduleModelRelaunch` / `scheduleModelDefaultRelaunch`). No
+ *      inject, no cursor-nav select, no scrape, no optimistic `/status` record.
  *
- *   1. The bare `/model` form NEVER reaches the inject primitive —
- *      with no argument claude renders an interactive picker modal
- *      that Telegram can't drive (no arrows, no Esc), so injecting it
- *      would wedge the pane (the /rate-limit-options class of wedge).
- *   2. The argument is shape-gated before it's typed into the tmux
- *      pane: one token, no whitespace, no shell/control smuggling.
- *   3. The set path injects exactly `/model <name>` (claude's own
- *      REPL verb — already on the inject allowlist) and relays the
- *      captured output, with the session-only persistence caveat.
+ * These tests FAIL on the OLD behavior on purpose: a Claude→Claude switch that
+ * called `inject`, a picker tap that called `select`, or any reply carrying an
+ * `optimistic` / scrape-derived `selectedModel` would not satisfy them.
  */
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   parseModelCommand,
   planModelCommand,
@@ -29,27 +31,13 @@ import {
   MODEL_ALIASES,
   type ModelCommandDeps,
 } from "../gateway/model-command.js";
-import type { InjectResult } from "../../src/agents/inject.js";
 
-function okResult(output: string): InjectResult {
-  return {
-    outcome: "ok",
-    output,
-    truncated: false,
-    command: "/model",
-    meta: { description: "Open model picker", expectsOutput: true },
-  };
-}
-
+/** A recorder-backed ModelCommandDeps. The inject/select deps are GONE (rev 5). */
 function makeDeps(overrides: Partial<ModelCommandDeps> = {}) {
-  const calls: Array<{ agent: string; command: string }> = [];
-  const restartCalls: string[] = [];
   const relaunchCalls: Array<{ model: string; reason: string }> = [];
+  const defaultRelaunchCalls: string[] = [];
+  const restartCalls: string[] = [];
   const deps: ModelCommandDeps = {
-    inject: async (agent, command) => {
-      calls.push({ agent, command });
-      return okResult("⏺ Set model to sonnet");
-    },
     getAgentName: () => "klanker",
     getConfiguredModel: () => "claude-sonnet-5",
     escapeHtml: (s) =>
@@ -59,765 +47,194 @@ function makeDeps(overrides: Partial<ModelCommandDeps> = {}) {
     isBusy: () => false,
     scheduleRestart: async (reason) => { restartCalls.push(reason); },
     scheduleModelRelaunch: async (model, reason) => { relaunchCalls.push({ model, reason }); },
+    scheduleModelDefaultRelaunch: async (reason) => { defaultRelaunchCalls.push(reason); },
     ...overrides,
   };
-  return { deps, calls, restartCalls, relaunchCalls };
+  return { deps, relaunchCalls, defaultRelaunchCalls, restartCalls };
+}
+
+/** An error shaped like scheduleRestart's 15s-debounce throw. */
+function restartInFlight(): Error {
+  const e = new Error("a restart is already in flight — try again in ~15s");
+  (e as { code?: string }).code = "restart_in_flight";
+  return e;
 }
 
 describe("parseModelCommand", () => {
-  it("returns null for non-/model text", () => {
-    expect(parseModelCommand("/auth list")).toBeNull();
-    expect(parseModelCommand("model sonnet")).toBeNull();
-    expect(parseModelCommand("/modelx sonnet")).toBeNull();
-  });
-
-  it("bare /model (and @botname form) parses as show", () => {
+  it("bare /model → show", () => {
     expect(parseModelCommand("/model")).toEqual({ kind: "show" });
-    expect(parseModelCommand("/model@klanker_bot")).toEqual({ kind: "show" });
-    expect(parseModelCommand("/model   ")).toEqual({ kind: "show" });
   });
-
-  it("single valid token parses as set", () => {
-    expect(parseModelCommand("/model sonnet")).toEqual({ kind: "set", model: "sonnet" });
-    expect(parseModelCommand("/model@bot claude-opus-4-8")).toEqual({
-      kind: "set",
-      model: "claude-opus-4-8",
-    });
-    // 1m-context variant ids carry brackets
-    expect(parseModelCommand("/model claude-sonnet-5[1m]")).toEqual({
-      kind: "set",
-      model: "claude-sonnet-5[1m]",
-    });
+  it("/model opus → set opus", () => {
+    expect(parseModelCommand("/model opus")).toEqual({ kind: "set", model: "opus" });
   });
-
-  it("/model help parses as help", () => {
+  it("/model help → help", () => {
     expect(parseModelCommand("/model help")).toEqual({ kind: "help" });
   });
-
-  it("rejects multi-token args (no second token can ride into the pane)", () => {
-    const p = parseModelCommand("/model sonnet; rm -rf /");
+  it("two args → help with reason", () => {
+    const p = parseModelCommand("/model opus sonnet");
     expect(p?.kind).toBe("help");
   });
-
-  it("rejects shell/control smuggling shapes", () => {
-    for (const bad of [
-      "/model $(reboot)",
-      "/model `id`",
-      "/model -opus", // leading dash — looks like a flag
-      "/model sonnet\nEnter",
-      "/model ../../etc/passwd",
-      "/model a|b",
-    ]) {
-      const p = parseModelCommand(bad);
-      expect(p?.kind, `should reject: ${bad}`).toBe("help");
-    }
+  it("invalid arg → help with reason", () => {
+    const p = parseModelCommand("/model bad name!");
+    expect(p?.kind).toBe("help");
+  });
+  it("non-/model text → null", () => {
+    expect(parseModelCommand("hello")).toBeNull();
   });
 });
 
 describe("isValidModelArg", () => {
-  it("accepts aliases and full ids", () => {
-    for (const good of [...MODEL_ALIASES, "claude-opus-4-8", "claude-haiku-4-5-20251001", "claude-sonnet-5[1m]"]) {
-      expect(isValidModelArg(good), good).toBe(true);
+  it("accepts aliases + full ids + sr-*", () => {
+    for (const a of ["opus", "sonnet", "haiku", "fable", "claude-opus-4-8", "sr-glm-5", "sr-gpt-5.5"]) {
+      expect(isValidModelArg(a)).toBe(true);
     }
   });
-  it("accepts OpenRouter-style sr-vendor/model ids (embedded slash)", () => {
-    // `/` is a legal char in a model id — needed for OpenRouter-style
-    // `sr-vendor/model` routing. It is NOT a shell metachar inside the
-    // double-quoted `claude --model "$_EFFECTIVE_MODEL"` launch, so it is
-    // safe. Kept aligned with the shell shape gate in profiles/_base/start.sh.hbs.
-    for (const good of ["sr-openrouter/gpt-5", "sr-vendor/model", "sr-mistralai/mixtral-8x7b"]) {
-      expect(isValidModelArg(good), good).toBe(true);
-    }
-  });
-  it("rejects whitespace, metacharacters, and over-long strings", () => {
-    for (const bad of ["", " ", "a b", "a;b", "-x", "a".repeat(120), "a\tb", "a\nb", "/leading"]) {
-      expect(isValidModelArg(bad), JSON.stringify(bad)).toBe(false);
+  it("rejects whitespace / control / shell smuggling", () => {
+    for (const bad of ["a b", "opus\n", "opus;rm", "", " "]) {
+      expect(isValidModelArg(bad)).toBe(false);
     }
   });
 });
 
-// Regression for the 2026-06-13 fleet outage: defaults.model was pinned to
-// the full codename `claude-fable-5`, which Anthropic retired server-side →
-// every agent 4xx'd. The fix is to select models by ALIAS (durable) instead
-// of pinned ids. This locks in that `fable` (and the other aliases) stay
-// selectable, and documents the alias-vs-codename distinction.
-describe("model selection: aliases stay selectable (incl. fable)", () => {
-  it("lists fable as a first-class alias", () => {
-    // `fable` is the latest flagship (Fable 5) and must remain pickable.
-    expect(MODEL_ALIASES).toContain("fable");
-    // The standard set is intact alongside it.
-    for (const a of ["opus", "sonnet", "haiku", "default"]) {
-      expect(MODEL_ALIASES, a).toContain(a);
-    }
-  });
-
-  it("each alias is a valid model arg and parses as a set", () => {
-    for (const alias of MODEL_ALIASES) {
-      expect(isValidModelArg(alias), alias).toBe(true);
-      expect(parseModelCommand(`/model ${alias}`)).toEqual({ kind: "set", model: alias });
-    }
-  });
-
-  it("the help text surfaces the fable alias", async () => {
-    const reply = await handleModelCommand({ kind: "help" }, makeDeps());
-    expect(reply.text).toContain("fable");
-  });
-
-  it("passthrough: a full id (incl. the retired claude-fable-5 codename) is shape-accepted, not allowlisted", () => {
-    // switchroom does NOT allowlist models — the SHAPE gate passes any
-    // well-formed id through to claude, which is the sole validator. So the
-    // retired `claude-fable-5` codename still parses here (it just 4xx's at
-    // claude); selection flexibility (any current/future model) is preserved.
-    expect(parseModelCommand("/model claude-fable-5")).toEqual({
-      kind: "set",
-      model: "claude-fable-5",
-    });
-    expect(isValidModelArg("claude-fable-5")).toBe(true);
-  });
-});
-
-describe("handleModelCommand — show / help never inject (picker-wedge guard)", () => {
-  it("show renders configured model + switch options without injecting", async () => {
-    const { deps, calls } = makeDeps();
-    const reply = await handleModelCommand({ kind: "show" }, deps);
-    expect(calls.length).toBe(0);
-    expect(reply.text).toContain("claude-sonnet-5");
-    expect(reply.text).toContain("/model opus");
-    expect(reply.text).toContain("switchroom.yaml");
-  });
-
-  it("show falls back to 'default' when no model configured", async () => {
-    const { deps, calls } = makeDeps({ getConfiguredModel: () => null });
-    const reply = await handleModelCommand({ kind: "show" }, deps);
-    expect(calls.length).toBe(0);
-    expect(reply.text).toContain("`default`");
-  });
-
-  it("help never injects", async () => {
-    const { deps, calls } = makeDeps();
-    const reply = await handleModelCommand({ kind: "help", reason: "nope" }, deps);
-    expect(calls.length).toBe(0);
-    expect(reply.text).toContain("nope");
-  });
-});
-
-describe("handleModelCommand — set — #3241 poll-until-signal wiring", () => {
-  it("forwards successPattern + errorPattern + settleBeforeSendMs to the inject primitive", async () => {
-    const seen: Array<{ command: string; opts: unknown }> = [];
-    const { deps } = makeDeps({
-      inject: async (_agent, command, opts) => {
-        seen.push({ command, opts });
-        return okResult("⏺ Set model to Sonnet 5 for this session");
-      },
-    });
-    await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
-    expect(seen).toHaveLength(1);
-    const opts = seen[0].opts as {
-      successPattern?: RegExp;
-      errorPattern?: RegExp;
-      settleBeforeSendMs?: number;
-    };
-    // A success pattern that matches claude's confirmation line, an error pattern
-    // that matches the "not found" line, and a clean-prompt pre-send wait.
-    expect(opts.successPattern?.test("⏺ Set model to Sonnet 5")).toBe(true);
-    expect(opts.errorPattern?.test("⎿  Model 'x' not found")).toBe(true);
-    expect(typeof opts.settleBeforeSendMs).toBe("number");
-    expect(opts.settleBeforeSendMs).toBeGreaterThan(0);
-  });
-
-  it("confirmation that lands after a banner → records the live model for /status", async () => {
-    // The inject primitive (poll-until-signal) is responsible for returning the
-    // confirmation and not the banner; here the handler receives that confirmation
-    // and must record it as the session override.
-    const { deps } = makeDeps({
-      inject: async () =>
-        okResult("⠋ extending Claude Fable 5 access…\n⎿  Set model to Fable 5 for this session"),
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
-    expect(reply.selectedModel).toBe("Fable 5");
-    expect(reply.optimistic).toBeUndefined();
-    expect(reply.text).toContain("Set model to Fable 5");
-    // The banner is scrollback and must not leak as prose above the confirmation.
-    expect(reply.text).not.toContain("extending Claude Fable 5 access");
-  });
-
-  it("scraped error line → failure verdict AND no override recorded (retract)", async () => {
-    const { deps } = makeDeps({
-      inject: async () => okResult("⎿  Model 'claude-bogus-99' not found"),
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "claude-bogus-99" }, deps);
-    expect(reply.text).toContain("did not take");
-    expect(reply.selectedModel).toBeUndefined();
-    expect(reply.optimistic).toBeUndefined();
-  });
-
-  // #3242 review MEDIUM 1 — an access/entitlement denial must NOT be recorded
-  // optimistically. Each of these lines matches neither the confirmation prefix
-  // nor the OLD bad-id error regex, so before the widen they slipped into the
-  // optimistic branch and falsely recorded the switch.
-  for (const denial of [
-    "⎿  Fable is not available on your plan",
-    "⎿  access denied",
-    "⎿  Fable requires a Pro subscription",
-    "⎿  This model is not enabled for your account",
-    "⎿  No access to Fable on this tier",
-    "⎿  Fable 5 is currently unavailable",
-  ]) {
-    it(`access-denial line → failure verdict AND no override (retract): ${JSON.stringify(denial)}`, async () => {
-      const { deps } = makeDeps({ inject: async () => okResult(denial) });
-      const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
-      expect(reply.text).toContain("did not take");
-      expect(reply.selectedModel).toBeUndefined();
-      expect(reply.optimistic).toBeUndefined();
-    });
-  }
-
-  it("a genuine confirmation is NEVER flipped to a failure by the widened denial regex", async () => {
-    // Confirmation-first ordering: even if scrollback in the same region says
-    // something "unavailable", a real "Set model to …" line wins.
-    const mixed = [
-      "the metrics endpoint was unavailable earlier",
-      "⎿  Set model to Fable 5 for this session",
-    ].join("\n");
-    const { deps } = makeDeps({ inject: async () => okResult(mixed) });
-    const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
-    expect(reply.text).not.toContain("did not take");
-    expect(reply.selectedModel).toBe("Fable 5");
-  });
-});
-
-describe("handleModelCommand — set", () => {
-  it("injects exactly `/model <name>` once and relays a genuine confirmation + persistence note", async () => {
-    const { deps, calls } = makeDeps();
-    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    expect(calls).toEqual([{ agent: "klanker", command: "/model opus" }]);
-    expect(reply.text).toContain("<pre>⏺ Set model to sonnet</pre>");
-    expect(reply.text).toContain("lasts until the agent’s next restart");
-    expect(reply.html).toBe(true);
-    // A verified confirmation records the live model so /status stays honest
-    // (bug 1: the typed path never recorded the switch before).
-    expect(reply.selectedModel).toBe("sonnet");
-  });
-
-  it("SILENT switch: suppresses raw pane scrollback instead of dumping it as a code block", async () => {
-    // claude switches models silently, so the pane capture below the command
-    // echo is just the agent's previous prose answer. It must NOT be relayed.
-    const scrollback = [
-      "Here's the summary you asked for earlier:",
-      "- point one about the deploy",
-      "- point two about the rollback plan",
-    ].join("\n");
-    const { deps } = makeDeps({ inject: async () => okResult(scrollback) });
-    const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
-    // The leak: none of the scrollback prose reaches the reply, and there is
-    // no <pre> code block echoing the capture.
-    expect(reply.text).not.toContain("summary you asked for");
-    expect(reply.text).not.toContain("rollback plan");
-    expect(reply.text).not.toContain("<pre>");
-    // #3241 part B — poll-until-signal already waited the full window, so a
-    // missing confirmation line with NO scraped error is a SILENT switch, not a
-    // failure. Record the requested model optimistically so /status is right,
-    // and say so honestly (no false "switched (session)", no scrollback leak).
-    expect(reply.text).toContain("/model fable");
-    expect(reply.text).toContain("couldn't read a confirmation");
-    expect(reply.text).toContain("/status");
-    expect(reply.text).not.toContain("Recorded");
-    expect(reply.text).not.toContain("switched (session)");
-    expect(reply.selectedModel).toBe("Fable");
-    expect(reply.optimistic).toBe(true);
-    expect(reply.html).toBe(true);
-  });
-
-  it("relays only the confirmation line when the capture also carries scrollback", async () => {
-    const mixed = [
-      "Some earlier prose that must not leak",
-      "⏺ Set model to Fable 5 for this session",
-    ].join("\n");
-    const { deps } = makeDeps({ inject: async () => okResult(mixed) });
-    const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
-    expect(reply.text).toContain("<pre>⏺ Set model to Fable 5 for this session</pre>");
-    expect(reply.text).not.toContain("earlier prose that must not leak");
-  });
-
-  it("does NOT relay scrollback prose that merely contains 'switched'/'set model' as ordinary words", async () => {
-    // No line begins with claude's real confirmation phrasing — these are just
-    // English sentences that happen to use the words. None must be relayed.
-    const prose = [
-      "I switched the deploy to blue-green as we discussed.",
-      "Then I set model behaviour aside and moved on to the tests.",
-      "The team kept model changes out of this release entirely.",
-    ].join("\n");
-    const { deps } = makeDeps({ inject: async () => okResult(prose) });
-    const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
-    // The anchored regex rejects all three lines, so nothing leaks and there is
-    // no <pre> block. No confirmation AND no scraped error → #3241 optimistic
-    // record: the switch is reported as sent + recorded, never a false
-    // "switched", and no scrollback prose leaks.
-    expect(reply.text).not.toContain("<pre>");
-    expect(reply.text).not.toContain("switched the deploy");
-    expect(reply.text).not.toContain("set model behaviour");
-    expect(reply.text).not.toContain("kept model changes");
-    expect(reply.text).toContain("couldn't read a confirmation");
-    expect(reply.text).not.toContain("switched (session)");
-    expect(reply.selectedModel).toBe("Fable");
-    expect(reply.optimistic).toBe(true);
-    expect(reply.html).toBe(true);
-  });
-
-  it("re-gates the model arg at the seam (caller bypassing the parser)", async () => {
-    const { deps, calls } = makeDeps();
-    const reply = await handleModelCommand({ kind: "set", model: "a b; reboot" }, deps);
-    expect(calls.length).toBe(0);
-    expect(reply.text).toContain("not a valid model name");
-  });
-
-  it("ok_no_output explains the empty capture", async () => {
-    const { deps } = makeDeps({
-      inject: async () => ({
-        outcome: "ok_no_output",
-        output: "",
-        truncated: false,
-        command: "/model",
-        meta: { description: "Open model picker", expectsOutput: true },
-      }),
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
-    // #3241 part B — an empty capture can't carry an error line, so the send is
-    // treated as a silent switch and the requested model is recorded
-    // optimistically (was: "no response captured", recorded nothing).
-    expect(reply.text).toContain("couldn't read a confirmation");
-    expect(reply.text).toContain("/status");
-    expect(reply.selectedModel).toBe("Sonnet");
-    expect(reply.optimistic).toBe(true);
-  });
-
-  it("session_missing failure surfaces the tmux-supervisor hint", async () => {
-    const { deps } = makeDeps({
-      inject: async () => ({
-        outcome: "failed",
-        output: "",
-        truncated: false,
-        command: "/model",
-        meta: null,
-        errorCode: "session_missing",
-        errorMessage: "tmux session not found",
-      }),
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
-    expect(reply.text).toContain("tmux session not found");
-    expect(reply.text).toContain("tmux supervisor");
-  });
-
-  it("inject throwing is surfaced, not propagated", async () => {
-    const { deps } = makeDeps({
-      inject: async () => {
-        throw new Error("boom");
-      },
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
-    expect(reply.text).toContain("boom");
-  });
-});
-
-describe("isSrModel / isClaudeModel helpers", () => {
-  it("isSrModel is true only for sr-* names", () => {
-    expect(isSrModel("sr-gemini-2.5-pro")).toBe(true);
-    expect(isSrModel("sr-deepseek-r1")).toBe(true);
-    expect(isSrModel("claude-sonnet-5")).toBe(false);
-    expect(isSrModel("sonnet")).toBe(false);
-    expect(isSrModel("")).toBe(false);
-  });
-
-  it("isClaudeModel is true for aliases and claude-* ids", () => {
-    for (const alias of MODEL_ALIASES) {
-      expect(isClaudeModel(alias), alias).toBe(true);
-    }
+describe("isSrModel / isClaudeModel", () => {
+  it("classifies", () => {
+    expect(isSrModel("sr-glm-5")).toBe(true);
+    expect(isSrModel("opus")).toBe(false);
+    expect(isClaudeModel("opus")).toBe(true);
     expect(isClaudeModel("claude-opus-4-8")).toBe(true);
-    expect(isClaudeModel("claude-sonnet-5[1m]")).toBe(true);
-    expect(isClaudeModel("sr-gemini-2.5-pro")).toBe(false);
-    expect(isClaudeModel("gpt-4")).toBe(false);
+    expect(isClaudeModel("fable")).toBe(true);
+    expect(isClaudeModel("sr-glm-5")).toBe(false);
   });
 });
 
-describe("handleModelCommand — sr-* → Claude graceful restart", () => {
-  it("carries the requested Claude model across the restart (relaunch carrier), never injects", async () => {
-    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
-      getActiveSessionModel: () => "sr-gemini-2.5-pro",
-    });
+// ─── The headline rev-5 contract: every switch relaunches, nothing injects ───
+
+describe("handleModelCommand — set — deterministic carrier relaunch (rev 5)", () => {
+  it("Claude→Claude `/model opus` (idle) calls scheduleModelRelaunch('opus') EXACTLY ONCE", async () => {
+    // FAILS on old code: Claude→Claude went through the inject+scrape path and
+    // NEVER called scheduleModelRelaunch.
+    const { deps, relaunchCalls, defaultRelaunchCalls } = makeDeps();
     const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    // Must NOT inject
-    expect(calls).toHaveLength(0);
-    // sr→Claude now rides the SAME carrier mechanism as Claude→sr so the
-    // requested Claude model survives the restart (bug 2). The bespoke
-    // scheduleRestart-without-carrier path is gone.
-    expect(restartCalls).toHaveLength(0);
     expect(relaunchCalls).toHaveLength(1);
     expect(relaunchCalls[0].model).toBe("opus");
-    expect(relaunchCalls[0].reason).toContain("sr-to-claude");
-    // Reply mentions the sr-* model and ~30s
-    expect(reply.text).toContain("sr-gemini-2.5-pro");
-    expect(reply.text).toContain("30s");
-    expect(reply.html).toBe(true);
+    expect(defaultRelaunchCalls).toHaveLength(0);
+    expect(reply.text).toContain("relaunching the session");
+    // No optimistic / scrape-derived fields on the reply (the retired-path guard).
+    expect((reply as Record<string, unknown>).selectedModel).toBeUndefined();
+    expect((reply as Record<string, unknown>).optimistic).toBeUndefined();
   });
 
-  it("carries a full claude-* id across the restart when session is on sr-*", async () => {
-    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
-      getActiveSessionModel: () => "sr-deepseek-r1",
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "claude-opus-4-8" }, deps);
-    expect(calls).toHaveLength(0);
-    expect(restartCalls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(1);
-    expect(relaunchCalls[0].model).toBe("claude-opus-4-8");
-    expect(reply.text).toContain("sr-deepseek-r1");
-    expect(reply.text).toContain("30s");
+  it("Claude→Claude with a full id relaunches on that id", async () => {
+    const { deps, relaunchCalls } = makeDeps();
+    await handleModelCommand({ kind: "set", model: "claude-opus-4-8" }, deps);
+    expect(relaunchCalls).toEqual([
+      expect.objectContaining({ model: "claude-opus-4-8" }),
+    ]);
   });
 
-  it("does NOT restart when switching between Claude models (no sr-* session)", async () => {
-    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
-      getActiveSessionModel: () => "Opus 4.8",
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
-    // Normal inject path: still injects, no restart, no relaunch
-    expect(calls).toHaveLength(1);
-    expect(restartCalls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(0);
-    expect(reply.text).toContain("Set model to sonnet");
+  it("sr-* typed `/model sr-glm-5` relaunches once (regression guard)", async () => {
+    const { deps, relaunchCalls } = makeDeps();
+    await handleModelCommand({ kind: "set", model: "sr-glm-5" }, deps);
+    expect(relaunchCalls).toEqual([expect.objectContaining({ model: "sr-glm-5" })]);
   });
 
-  it("surfaces relaunch dispatch failures without propagating the error", async () => {
-    const { deps, calls } = makeDeps({
-      getActiveSessionModel: () => "sr-deepseek-r1",
-      scheduleModelRelaunch: async () => { throw new Error("hostd unreachable"); },
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
-    expect(calls).toHaveLength(0);
-    expect(reply.text).toContain("Could not schedule restart");
-    expect(reply.text).toContain("hostd unreachable");
+  it("non-Claude token passes the RAW token through (accepted, not picker-validated)", async () => {
+    const { deps, relaunchCalls } = makeDeps();
+    await handleModelCommand({ kind: "set", model: "sr-gpt-5.5" }, deps);
+    expect(relaunchCalls[0].model).toBe("sr-gpt-5.5");
   });
 
-  it("reports 'restart already in flight' honestly on a debounced dispatch (no silent no-op)", async () => {
-    const { deps } = makeDeps({
-      getActiveSessionModel: () => "sr-deepseek-r1",
-      scheduleModelRelaunch: async () => {
-        const e = new Error("a restart is already in flight — try again in ~15s");
-        (e as { code?: string }).code = "restart_in_flight";
-        throw e;
-      },
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    expect(reply.text).toContain("restart is already in flight");
-    expect(reply.text).toContain("15s");
-    // Never a false success.
-    expect(reply.text).not.toContain("Set model to");
-  });
-
-  it("null session model (no prior override) still uses normal inject path for Claude target", async () => {
-    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
-      getActiveSessionModel: () => null,
-    });
-    await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    expect(calls).toHaveLength(1);
-    expect(restartCalls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(0);
-  });
-});
-
-describe("handleModelCommand — busy gate + honest unverified reporting", () => {
-  it("refuses a typed switch while the agent is mid-turn (no inject, no relaunch)", async () => {
-    const { deps, calls, relaunchCalls } = makeDeps({ isBusy: () => true });
-    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    expect(calls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(0);
-    expect(reply.text).toContain("mid-turn");
-    expect(reply.selectedModel).toBeUndefined();
-  });
-
-  it("refuses an sr-* switch too while mid-turn", async () => {
-    const { deps, relaunchCalls } = makeDeps({ isBusy: () => true });
-    const reply = await handleModelCommand({ kind: "set", model: "sr-glm-5" }, deps);
-    expect(relaunchCalls).toHaveLength(0);
-    expect(reply.text).toContain("mid-turn");
-  });
-
-  it("reports a claude error output as an HONEST failure, not a switch", async () => {
-    const { deps } = makeDeps({
-      inject: async () => okResult("Error: Model not found"),
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "claude-bogus" }, deps);
-    expect(reply.text).toContain("did not take");
-    expect(reply.text).toContain("Model not found");
-    expect(reply.text).not.toContain("Sticky across switchroom-managed relaunches");
-    expect(reply.selectedModel).toBeUndefined();
-  });
-
-  it("detects claude v2.1.205's real error shape: ⎿  Model 'name' not found (TUI-probe verified)", async () => {
-    // Captured verbatim from a disposable claude v2.1.205 TUI, 2026-07-10.
-    const { deps } = makeDeps({
-      inject: async () => okResult("⎿  Model 'claude-bogus-99' not found"),
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "claude-bogus-99" }, deps);
-    expect(reply.text).toContain("did not take");
-    expect(reply.text).toContain("not found");
-    expect(reply.selectedModel).toBeUndefined();
-  });
-
-  it("scrollback prose CONTAINING 'model not found' mid-sentence is NOT a failure (anchored error scan)", async () => {
-    // The error regex is line-start anchored, like the confirmation prefix —
-    // prose that merely mentions the phrase must not flip a successful switch
-    // into a reported failure (the false-FAILURE variant of the scrollback-leak
-    // class this PR eliminates).
-    const { deps } = makeDeps({
-      inject: async () => okResult("deploy failed: model not found in registry"),
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    expect(reply.text).not.toContain("did not take");
-    expect(reply.text).not.toContain("model not found");
-    // No LINE-ANCHORED error and no confirmation → #3241 optimistic record: the
-    // mid-sentence "model not found" prose does NOT flip the switch to a failure,
-    // and the requested model is recorded (was: "couldn't confirm", nothing).
-    expect(reply.text).toContain("couldn't read a confirmation");
-    expect(reply.selectedModel).toBe("Opus");
-    expect(reply.optimistic).toBe(true);
-  });
-
-  it("recognises claude v2.1.205's real arg-form confirmation (⎿ glyph + 'and saved as your default')", async () => {
-    // Captured verbatim from a disposable claude v2.1.205 TUI, 2026-07-10:
-    // the arg form is NOT silent — it prints this line, and the ⎿ glyph
-    // survives the inject capture. The name extraction must stop at "and
-    // saved", not swallow the whole sentence.
-    const { deps } = makeDeps({
-      inject: async () =>
-        okResult("⎿  Set model to Opus 4.8 and saved as your default for new sessions"),
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    expect(reply.text).toContain("Set model to Opus 4.8");
-    expect(reply.selectedModel).toBe("Opus 4.8");
-  });
-
-  it("does NOT record an override when the confirmation is 'Kept model as' (no change)", async () => {
-    const { deps } = makeDeps({
-      inject: async () => okResult("⏺ Kept model as Opus 4.8 (default)"),
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    // The kept line is still relayed as a confirmation, but nothing is recorded.
-    expect(reply.selectedModel).toBeUndefined();
-  });
-});
-
-describe("handleModelCommand — Claude → sr-* session relaunch", () => {
-  it("schedules a model relaunch (carrier) instead of injecting for an sr-* target", async () => {
-    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
-      getActiveSessionModel: () => null,
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "sr-glm-5" }, deps);
-    // Must NOT inject (claude's picker rejects sr-* ids)
-    expect(calls).toHaveLength(0);
-    // Must NOT use the sr→claude scheduleRestart path
-    expect(restartCalls).toHaveLength(0);
-    // Must schedule the carrier-based relaunch with the full sr-* id
-    expect(relaunchCalls).toHaveLength(1);
-    expect(relaunchCalls[0].model).toBe("sr-glm-5");
-    expect(reply.text).toContain("sr-glm-5");
-    expect(reply.text).toContain("30s");
-    expect(reply.html).toBe(true);
-  });
-
-  it("expands a short sr alias then relaunches on the full id", async () => {
-    const { deps, calls, relaunchCalls } = makeDeps({ getActiveSessionModel: () => null });
-    await handleModelCommand({ kind: "set", model: "glm" }, deps);
-    expect(calls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(1);
-    expect(relaunchCalls[0].model).toBe("sr-glm-5");
-  });
-
-  it("Claude target still uses the instant inject path (no relaunch)", async () => {
-    const { deps, calls, relaunchCalls, restartCalls } = makeDeps({
-      getActiveSessionModel: () => null,
-    });
-    await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
-    expect(calls).toHaveLength(1);
-    expect(relaunchCalls).toHaveLength(0);
-    expect(restartCalls).toHaveLength(0);
-  });
-
-  it("sr-* → Claude rides scheduleModelRelaunch (carrier) so the Claude model survives the restart", async () => {
-    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
-      getActiveSessionModel: () => "sr-glm-5",
-    });
-    await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    expect(calls).toHaveLength(0);
-    expect(restartCalls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(1);
-    expect(relaunchCalls[0].model).toBe("opus");
-  });
-
-  it("surfaces scheduleModelRelaunch failures without propagating the error", async () => {
-    const { deps, calls } = makeDeps({
-      getActiveSessionModel: () => null,
-      scheduleModelRelaunch: async () => { throw new Error("carrier write failed"); },
-    });
-    const reply = await handleModelCommand({ kind: "set", model: "sr-glm-5" }, deps);
-    expect(calls).toHaveLength(0);
-    expect(reply.text).toContain("Could not schedule model switch");
-    expect(reply.text).toContain("carrier write failed");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Manual full-sr-* passthrough (Ken 2026-07-08): the /model MENU stays curated
-// to the main SR_MODEL_ALIASES set, but typing `/model <any registered sr-*>`
-// must switch to that exact model — the set path is a SHAPE gate only, with NO
-// whitelist against SR_MODEL_LABELS / SR_MODEL_ALIASES. These guard that any
-// arbitrary sr-* id passes through verbatim and schedules the relaunch on the
-// exact id (not rejected, not remapped, not injected).
-// ---------------------------------------------------------------------------
-describe("handleModelCommand — arbitrary sr-* passthrough (no whitelist)", () => {
-  // sr-* names that are NOT in SR_MODEL_ALIASES (so not menu-reachable) but ARE
-  // registered in the live litellm config — must still switch when typed.
-  const ARBITRARY_SR = [
-    "sr-gpt-oss-120b",
-    "sr-gpt-oss-20b",
-    "sr-minimax-m3",
-    "sr-gemini-flash-lite",
-    "sr-gpt-5.5",
-    "sr-gpt-5-codex",
-    "sr-gpt-5.2-codex",
-    "sr-deepseek-v4-flash",
-  ];
-
-  it("each arbitrary sr-* passes the shape gate and isSrModel", () => {
-    for (const name of ARBITRARY_SR) {
-      expect(isValidModelArg(name), `${name} must pass MODEL_ARG_RE`).toBe(true);
-      expect(isSrModel(name), `${name} must be recognised as sr-*`).toBe(true);
-      expect(isClaudeModel(name)).toBe(false);
-    }
-  });
-
-  it("relaunches on the exact typed id — not rejected, not remapped", async () => {
-    for (const name of ARBITRARY_SR) {
-      const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
-        getActiveSessionModel: () => null,
-      });
-      const reply = await handleModelCommand({ kind: "set", model: name }, deps);
-      // Never injected (claude's picker rejects sr-* ids).
-      expect(calls, `${name} must not inject`).toHaveLength(0);
-      // Never the sr→claude restart path (source session is Claude here).
-      expect(restartCalls, `${name} must not scheduleRestart`).toHaveLength(0);
-      // Scheduled the carrier relaunch on the EXACT id (no alias remap).
-      expect(relaunchCalls).toHaveLength(1);
-      expect(relaunchCalls[0].model, `${name} must relaunch verbatim`).toBe(name);
-      expect(reply.text).toContain(name);
-    }
-  });
-
-  it("parseModelCommand accepts arbitrary sr-* ids as a set command", () => {
-    for (const name of ARBITRARY_SR) {
-      expect(parseModelCommand(`/model ${name}`)).toEqual({ kind: "set", model: name });
-    }
-  });
-
-  it("switching FROM an arbitrary sr-* back to Claude carries the Claude model via the relaunch carrier", async () => {
-    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
-      getActiveSessionModel: () => "sr-gpt-oss-120b",
-    });
-    await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    expect(calls).toHaveLength(0);
-    expect(restartCalls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(1);
-    expect(relaunchCalls[0].model).toBe("opus");
-  });
-});
-
-describe("inject allowlist contract", () => {
-  it("/model stays on the inject allowlist (the set path depends on it)", async () => {
-    const { INJECT_COMMANDS } = await import("../../src/agents/inject.js");
-    expect(INJECT_COMMANDS.has("/model")).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Picker-driven menu (v2) — buildModelMenu + handleModelMenuCallback
-// ---------------------------------------------------------------------------
-
-describe("SR_MODEL_ALIASES / expandSrAlias", () => {
-  let expandSrAlias: (arg: string) => string;
-  let SR_MODEL_ALIASES: Record<string, string>;
-
-  beforeAll(async () => {
-    const mod = await import("../gateway/model-command.js");
-    expandSrAlias = mod.expandSrAlias;
-    SR_MODEL_ALIASES = mod.SR_MODEL_ALIASES;
-  });
-
-  it("expands known short aliases to full sr-* ids", () => {
-    expect(expandSrAlias("flash")).toBe("sr-gemini-2.5-flash");
-    expect(expandSrAlias("gemini")).toBe("sr-gemini-2.5-pro");
-    expect(expandSrAlias("deepseek")).toBe("sr-deepseek-v3");
-    expect(expandSrAlias("r1")).toBe("sr-deepseek-r1");
-    expect(expandSrAlias("glm")).toBe("sr-glm-5");
-    expect(expandSrAlias("codex")).toBe("sr-codex-5.5");
-  });
-
-  it("is case-insensitive", () => {
-    expect(expandSrAlias("Flash")).toBe("sr-gemini-2.5-flash");
-    expect(expandSrAlias("CODEX")).toBe("sr-codex-5.5");
-  });
-
-  it("passes through unknown names unchanged", () => {
-    expect(expandSrAlias("opus")).toBe("opus");
-    expect(expandSrAlias("sr-gemini-2.5-flash")).toBe("sr-gemini-2.5-flash");
-    expect(expandSrAlias("claude-opus-4-8")).toBe("claude-opus-4-8");
-  });
-
-  it("every alias target is a valid sr-* model arg", () => {
-    for (const [alias, target] of Object.entries(SR_MODEL_ALIASES)) {
-      expect(target.startsWith("sr-"), `${alias} → ${target} must start with sr-`).toBe(true);
-    }
-  });
-
-  it("handleModelCommand relaunches on the expanded sr-* id, not the short alias", async () => {
-    const { deps, calls, relaunchCalls } = makeDeps({ getActiveSessionModel: () => null });
+  it("short alias expands before relaunch (`flash` → `sr-gemini-2.5-flash`)", async () => {
+    const { deps, relaunchCalls } = makeDeps();
     await handleModelCommand({ kind: "set", model: "flash" }, deps);
-    // sr-* targets no longer inject — they carrier-relaunch on the full id.
-    expect(calls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(1);
     expect(relaunchCalls[0].model).toBe("sr-gemini-2.5-flash");
   });
 
-  it("handleModelCommand with a Claude alias relaunches (carrier) when session is on sr-*", async () => {
-    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
-      getActiveSessionModel: () => "sr-deepseek-v3",
-    });
+  it("sr-*→Claude relaunches on the Claude token (no special inject path)", async () => {
+    const { deps, relaunchCalls } = makeDeps({ getActiveSessionModel: () => "sr-deepseek-v3" });
     await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    expect(calls).toHaveLength(0);
-    expect(restartCalls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(1);
-    expect(relaunchCalls[0].model).toBe("opus");
+    expect(relaunchCalls).toEqual([expect.objectContaining({ model: "opus" })]);
+  });
+
+  it("`/model default` calls scheduleModelDefaultRelaunch, NOT scheduleModelRelaunch", async () => {
+    const { deps, relaunchCalls, defaultRelaunchCalls } = makeDeps();
+    const reply = await handleModelCommand({ kind: "set", model: "default" }, deps);
+    expect(defaultRelaunchCalls).toHaveLength(1);
+    expect(relaunchCalls).toHaveLength(0);
+    expect(reply.text).toContain("Reverting to the configured default");
+  });
+
+  it("busy session refuses without scheduling anything", async () => {
+    const { deps, relaunchCalls, defaultRelaunchCalls } = makeDeps({ isBusy: () => true });
+    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(relaunchCalls).toHaveLength(0);
+    expect(defaultRelaunchCalls).toHaveLength(0);
+    expect(reply.text).toContain("mid-turn");
+  });
+
+  it("debounce: a restart_in_flight throw yields the ~15s copy, not a double-dispatch", async () => {
+    let calls = 0;
+    const { deps } = makeDeps({
+      scheduleModelRelaunch: async () => { calls++; throw restartInFlight(); },
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(calls).toBe(1);
+    expect(reply.text).toContain("~15s");
+  });
+
+  it("a generic dispatch failure surfaces an honest error", async () => {
+    const { deps } = makeDeps({
+      scheduleModelRelaunch: async () => { throw new Error("hostd down"); },
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(reply.text).toContain("Could not schedule model switch");
+  });
+
+  it("the reply type carries no optimistic/selectedModel field on ANY set outcome", async () => {
+    // The retired-contract guard (F3): the fields were DELETED from the reply,
+    // so an unapplied switch can no longer be optimistically recorded.
+    const { deps } = makeDeps();
+    for (const model of ["opus", "sr-glm-5", "default", "fable"]) {
+      const reply = await handleModelCommand({ kind: "set", model }, deps);
+      expect(Object.prototype.hasOwnProperty.call(reply, "selectedModel")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(reply, "optimistic")).toBe(false);
+    }
   });
 });
+
+describe("handleModelCommand — show / help never schedule a switch", () => {
+  it("show renders the configured model + options, schedules nothing", async () => {
+    const { deps, relaunchCalls, defaultRelaunchCalls } = makeDeps();
+    const reply = await handleModelCommand({ kind: "show" }, deps);
+    expect(reply.text).toContain("claude-sonnet-5");
+    expect(relaunchCalls).toHaveLength(0);
+    expect(defaultRelaunchCalls).toHaveLength(0);
+  });
+  it("help lists the aliases including fable", async () => {
+    const reply = await handleModelCommand({ kind: "help" }, makeDeps().deps);
+    for (const a of MODEL_ALIASES) expect(reply.text).toContain(a);
+  });
+});
+
+// ─── Menu / callback deterministic relaunch ─────────────────────────────────
 
 import {
   buildModelMenu,
   handleModelMenuCallback,
   modelSelectCallbackData,
-  sessionModelFromConfirmation,
   classifyDiscoveredOptions,
+  canonicalClaudeToken,
   MODEL_CALLBACK_REFRESH,
-  MODEL_CALLBACK_HEADER,
   MODEL_CALLBACK_SR,
   MODEL_CALLBACK_ALIAS,
   MODEL_CALLBACK_PAGE_EXTERNAL,
-  MODEL_CALLBACK_PAGE_MAIN,
   SR_MODEL_LABELS,
   SR_MODEL_ALIASES,
   EXTRA_CLAUDE_ALIASES,
+  expandSrAlias,
   externalModelNames,
-  isSrToClaudeTransition,
-  optimisticModelRecordLabel,
   type ModelMenuDeps,
 } from "../gateway/model-command.js";
-import { labelTag } from "../../src/agents/model-picker.js";
 
 const OPTIONS = [
   { index: 1, label: "Default (recommended)", detail: "Opus 4.8 with 1M context", current: false },
@@ -825,45 +242,125 @@ const OPTIONS = [
   { index: 3, label: "Haiku", detail: "Haiku 4.5 · Fastest", current: false },
 ];
 
-function makeMenuDeps(overrides: Partial<ModelMenuDeps> = {}) {
-  const calls = { discover: 0, select: [] as string[] };
-  const base = makeDeps(); // v1 deps (inject/getConfiguredModel/escapeHtml/preBlock)
-  const deps = {
+function makeMenuDeps(overrides: Partial<ModelMenuDeps & ModelCommandDeps> = {}) {
+  const base = makeDeps();
+  const calls = { discover: 0 };
+  const deps: ModelMenuDeps & ModelCommandDeps = {
     ...base.deps,
     discover: async () => {
       calls.discover++;
       return { ok: true as const, options: OPTIONS, currentLabel: "Sonnet" };
-    },
-    select: async (_a: string, label: string) => {
-      calls.select.push(label);
-      return { ok: true as const, confirmation: `Set model to ${label} for this session` };
     },
     isBusy: () => false,
     getQuotaBrief: async () => "29% / 5h · 33% / 7d",
     discoverSrModels: async () => [],
     ...overrides,
   };
-  return { deps, calls, injectCalls: base.calls };
+  return {
+    deps,
+    calls,
+    relaunchCalls: base.relaunchCalls,
+    defaultRelaunchCalls: base.defaultRelaunchCalls,
+  };
 }
 
-describe("buildModelMenu", () => {
-  it("renders current model, quota brief, and one button per discovered option", async () => {
+describe("modelSelectCallbackData — embeds the canonical token (rev 5)", () => {
+  it("an alias row carries the alias token", () => {
+    expect(modelSelectCallbackData("Haiku")).toBe("mdl:s:haiku");
+  });
+  it("a full-id row carries the id", () => {
+    expect(modelSelectCallbackData("claude-opus-4-8")).toBe("mdl:s:claude-opus-4-8");
+  });
+  it("the Default row carries the `default` sentinel", () => {
+    expect(modelSelectCallbackData("Default (recommended)")).toBe("mdl:s:default");
+  });
+});
+
+describe("handleModelMenuCallback — every switch tap relaunches (rev 5)", () => {
+  it("picker SELECT `mdl:s:haiku` relaunches on 'haiku' and never scrapes/selects", async () => {
+    // FAILS on old code: the SELECT branch called deps.select and re-discovered
+    // the picker; here there is no select dep at all.
+    const { deps, relaunchCalls, calls } = makeMenuDeps();
+    const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
+    expect(relaunchCalls).toEqual([expect.objectContaining({ model: "haiku" })]);
+    // The switch path does NOT drive discovery.
+    expect(calls.discover).toBe(0);
+    expect(out.reply.text).toContain("relaunching");
+    expect(Object.prototype.hasOwnProperty.call(out, "selectedModel")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(out, "selectedModelToken")).toBe(false);
+  });
+
+  it("picker SELECT of the Default row routes to the default relaunch", async () => {
+    const { deps, relaunchCalls, defaultRelaunchCalls } = makeMenuDeps();
+    await handleModelMenuCallback("mdl:s:default", deps);
+    expect(defaultRelaunchCalls).toHaveLength(1);
+    expect(relaunchCalls).toHaveLength(0);
+  });
+
+  it("Fable button `mdl:alias:fable` relaunches on 'fable' (never injects)", async () => {
+    // FAILS on old code: the alias branch injected `/model fable` and scraped.
+    const { deps, relaunchCalls } = makeMenuDeps();
+    await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
+    expect(relaunchCalls).toEqual([expect.objectContaining({ model: "fable" })]);
+  });
+
+  it("Default alias button routes to the default relaunch", async () => {
+    const { deps, relaunchCalls, defaultRelaunchCalls } = makeMenuDeps();
+    await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}default`, deps);
+    expect(defaultRelaunchCalls).toHaveLength(1);
+    expect(relaunchCalls).toHaveLength(0);
+  });
+
+  it("sr-* tap `mdl:sr:sr-glm-5` relaunches on the sr id", async () => {
+    const { deps, relaunchCalls } = makeMenuDeps();
+    await handleModelMenuCallback(`${MODEL_CALLBACK_SR}sr-glm-5`, deps);
+    expect(relaunchCalls).toEqual([expect.objectContaining({ model: "sr-glm-5" })]);
+  });
+
+  it("a switch tap while mid-turn refuses (toastOnly) and schedules nothing", async () => {
+    const { deps, relaunchCalls } = makeMenuDeps({ isBusy: () => true });
+    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}opus`, deps);
+    expect(out.toastOnly).toBe(true);
+    expect(out.busyRefusal).toBe(true);
+    expect(relaunchCalls).toHaveLength(0);
+  });
+
+  it("restart_in_flight on a menu tap yields the ~15s copy, one dispatch", async () => {
+    let calls = 0;
+    const { deps } = makeMenuDeps({
+      scheduleModelRelaunch: async () => { calls++; throw restartInFlight(); },
+    });
+    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
+    expect(calls).toBe(1);
+    expect(out.reply.text).toContain("~15s");
+  });
+
+  it("Refresh re-renders without scheduling", async () => {
+    const { deps, relaunchCalls } = makeMenuDeps();
+    const out = await handleModelMenuCallback(MODEL_CALLBACK_REFRESH, deps);
+    expect(relaunchCalls).toHaveLength(0);
+    expect(out.answer).toBe("Refreshed");
+  });
+
+  it("page-nav swaps the keyboard without scheduling", async () => {
+    const { deps, relaunchCalls } = makeMenuDeps();
+    await handleModelMenuCallback(MODEL_CALLBACK_PAGE_EXTERNAL, deps);
+    expect(relaunchCalls).toHaveLength(0);
+  });
+});
+
+describe("buildModelMenu — render only (discovery is not the switch path)", () => {
+  it("renders current model, quota, and one button per option", async () => {
     const { deps, calls } = makeMenuDeps();
     const menu = await buildModelMenu(deps);
     expect(calls.discover).toBe(1);
     expect(menu.text).toContain("**Sonnet**");
     expect(menu.text).toContain("29% / 5h · 33% / 7d");
     expect(menu.keyboard).toBeDefined();
-    // 3 scraped option rows + static Fable row + refresh row
-    // (no external row here — discoverSrModels returns [] and the default
-    // makeMenuDeps has no SR seed override, but externalModelNames seeds from
-    // SR_MODEL_ALIASES, so the External row IS present — see dedicated tests).
-    expect(menu.keyboard![1][0].text).toBe("✅ Sonnet");
-    expect(menu.keyboard![0][0].text).toBe("Default (recommended)");
-    // Refresh is always the last row.
-    expect(menu.keyboard![menu.keyboard!.length - 1][0].callback_data).toBe(
-      MODEL_CALLBACK_REFRESH,
-    );
+    // SELECT rows now carry canonical tokens, not label hashes.
+    const selectRows = menu.keyboard!.flat().map((b) => b.callback_data).filter((d) => d.startsWith("mdl:s:"));
+    expect(selectRows).toContain("mdl:s:default");
+    expect(selectRows).toContain("mdl:s:haiku");
   });
 
   it("every callback_data fits Telegram's 64-byte cap", async () => {
@@ -876,873 +373,119 @@ describe("buildModelMenu", () => {
     }
   });
 
-  it("busy agent → no discovery, STATIC keyboard whose taps ride the queue (#3039)", async () => {
+  it("busy agent → static keyboard, no discovery", async () => {
     const { deps, calls } = makeMenuDeps({ isBusy: () => true });
     const menu = await buildModelMenu(deps);
-    // Never drives the picker mid-turn…
     expect(calls.discover).toBe(0);
-    expect(menu.text).toContain("mid-turn");
-    // …but no dead-end either: static alias rows are offered so the operator
-    // can still lock in a choice (the tap queues at the gateway busy gate).
-    expect(menu.keyboard).toBeDefined();
-    const data = menu.keyboard!.flat().map(b => b.callback_data);
+    const data = menu.keyboard!.flat().map((b) => b.callback_data);
     expect(data).toContain("mdl:alias:opus");
     expect(data).toContain("mdl:alias:default");
-    expect(menu.text).not.toContain("Try again");
-  });
-
-  it("discovery failure → static v1 fallback with the reason, no keyboard", async () => {
-    const { deps } = makeMenuDeps({
-      discover: async () => ({ ok: false as const, reason: "tmux session not found" }),
-    });
-    const menu = await buildModelMenu(deps);
-    expect(menu.keyboard).toBeUndefined();
-    expect(menu.text).toContain("picker unavailable");
-    expect(menu.text).toContain("Configured:");
-  });
-
-  it("quota failure never blocks the menu", async () => {
-    const { deps } = makeMenuDeps({
-      getQuotaBrief: async () => {
-        throw new Error("broker down");
-      },
-    });
-    const menu = await buildModelMenu(deps);
-    expect(menu.keyboard).toBeDefined();
-    expect(menu.text).not.toContain("Quota:");
   });
 });
 
-describe("handleModelMenuCallback", () => {
-  it("mdl:s:<tag> selects by re-discovered label", async () => {
-    const { deps, calls } = makeMenuDeps();
-    const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
-    expect(calls.select).toEqual(["Haiku"]);
-    expect(out.answer).toContain("Set model to Haiku");
-    expect(out.reply.text).toContain("✅");
-  });
+// ─── Preserved pure-logic helpers ───────────────────────────────────────────
 
-  it("stale tag (options changed) → never selects, re-renders menu", async () => {
-    const { deps, calls } = makeMenuDeps();
-    const staleTag = `mdl:s:${labelTag("Removed Model")}`;
-    const out = await handleModelMenuCallback(staleTag, deps);
-    expect(calls.select).toEqual([]);
-    expect(out.answer).toContain("refreshed");
-    expect(out.reply.keyboard).toBeDefined();
-  });
-
-  it("tapping the ✔ (default) row STILL drives a switch — ✔ is the new-session default, not the live session model", async () => {
-    // OPTIONS marks "Sonnet" current (the ✔). An agent launched on a
-    // different model must still be able to apply the ✔ row to its live
-    // session — skipping it was the "tapped Default, nothing happened" bug.
-    const { deps, calls } = makeMenuDeps();
-    const out = await handleModelMenuCallback(modelSelectCallbackData("Sonnet"), deps);
-    expect(calls.select).toEqual(["Sonnet"]);
-    expect(out.reply.text).toContain("✅");
-    expect(out.reply.keyboard).toBeDefined();
-  });
-
-  it("busy agent → toastOnly refusal that leaves the menu untouched", async () => {
-    const { deps, calls } = makeMenuDeps({ isBusy: () => true });
-    const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
-    expect(calls.select).toEqual([]);
-    expect(out.answer).toContain("mid-turn");
-    // toastOnly tells the gateway to NOT edit the menu — buttons survive.
-    expect(out.toastOnly).toBe(true);
-  });
-
-  it("selection failure surfaces the reason AND keeps the menu so the operator can retry", async () => {
-    const { deps } = makeMenuDeps({
-      select: async () => ({ ok: false as const, reason: "cursor verification failed" }),
-    });
-    const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
-    expect(out.answer).toContain("failed");
-    expect(out.reply.text).toContain("cursor verification failed");
-    // The menu buttons are preserved — a failure no longer collapses the
-    // menu to a button-less error (the "nothing happened" bug).
-    expect(out.reply.keyboard).toBeDefined();
-  });
-
-  it("a successful switch banners the confirmation, keeps the menu, AND reports the live model for /status", async () => {
-    const { deps } = makeMenuDeps({
-      select: async () => ({ ok: true as const, confirmation: "Set model to Haiku 4.5 for this session only" }),
-    });
-    const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
-    expect(out.answer).toContain("Haiku 4.5");
-    expect(out.reply.text).toContain("✅");
-    expect(out.reply.text).toContain("Set model to Haiku 4.5");
-    expect(out.reply.keyboard).toBeDefined();
-    // The gateway records this so /status reflects the live session model.
-    expect(out.selectedModel).toBe("Haiku 4.5");
-  });
-
-  it("tapping the Default row when already on it (Kept model as) records NO override", async () => {
-    // Bug 6: "Kept model as X" is a no-change; the old code fell back to
-    // target.label and stored "Default (recommended)" verbatim into /status.
-    const { deps } = makeMenuDeps({
-      select: async () => ({ ok: true as const, confirmation: "Kept model as Opus 4.8 (default)" }),
-    });
-    const out = await handleModelMenuCallback(modelSelectCallbackData("Default (recommended)"), deps);
-    expect(out.reply.text).toContain("✅");
-    // Crucially, NOTHING is recorded — no display label leaks into the override.
-    expect(out.selectedModel).toBeUndefined();
-    expect(out.reply.text).not.toContain("Default (recommended)");
-  });
-
-  it("a real switch on the Default row stores a canonical token, never the display label", async () => {
-    // The Default row confirms with a real model name; the /status value is that
-    // name (never "Default (recommended)"), and the carrier token is canonical.
-    const { deps } = makeMenuDeps({
-      select: async () => ({ ok: true as const, confirmation: "Set model to Opus 4.8 for this session only" }),
-    });
-    const out = await handleModelMenuCallback(modelSelectCallbackData("Default (recommended)"), deps);
-    expect(out.selectedModel).toBe("Opus 4.8");
-    // "Default (recommended)" yields no --model token → carrier boots the config default.
-    expect(out.selectedModelToken).toBeUndefined();
-  });
-
-  it("selecting an alias row exposes a canonical --model token for the sr→claude carrier", async () => {
-    const { deps } = makeMenuDeps({
-      select: async () => ({ ok: true as const, confirmation: "Set model to Sonnet for this session" }),
-    });
-    const out = await handleModelMenuCallback(modelSelectCallbackData("Sonnet"), deps);
-    expect(out.selectedModel).toBe("Sonnet");
-    expect(out.selectedModelToken).toBe("sonnet");
+describe("canonicalClaudeToken", () => {
+  it("aliases → alias, ids → id, Default → null", () => {
+    expect(canonicalClaudeToken("Opus")).toBe("opus");
+    expect(canonicalClaudeToken("claude-opus-4-8")).toBe("claude-opus-4-8");
+    expect(canonicalClaudeToken("Default (recommended)")).toBeNull();
   });
 });
 
-// #3242 review MEDIUM 2 — the alias BUTTON (mdl:alias:<alias>, e.g. the Fable
-// button) must be symmetric with the typed set path: record-on-send / retract-
-// on-scraped-error, handling BOTH ok and ok_no_output. Before the fix a silent
-// successful button-switch (ok_no_output, or ok with no confirmation line) fell
-// through to "Switch failed" and dropped the override.
-describe("handleModelMenuCallback — alias button symmetry (#3242 MEDIUM 2)", () => {
-  it("ok_no_output (silent switch via the button) → optimistic record, not a failure", async () => {
-    const { deps } = makeMenuDeps({
-      inject: async () => ({
-        outcome: "ok_no_output" as const,
-        output: "",
-        truncated: false,
-        command: "/model",
-        meta: { description: "Open model picker", expectsOutput: true },
-      }),
-    });
-    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
-    expect(out.selectedModel).toBe("Fable"); // normalized display form
-    expect(out.selectedModelToken).toBe("fable");
-    // Provisional copy (#3242 FIX 2): doesn't assert the switch succeeded, points
-    // at /status, and never reads as a failure.
-    expect(out.reply.text).not.toContain("failed");
-    expect(out.reply.text).toContain("/status");
-    expect(out.reply.text).toContain("/model fable");
+describe("SR_MODEL_ALIASES / expandSrAlias", () => {
+  it("expands known aliases, passes others through", () => {
+    expect(expandSrAlias("flash")).toBe("sr-gemini-2.5-flash");
+    expect(expandSrAlias("opus")).toBe("opus");
+    expect(expandSrAlias("sr-glm-5")).toBe("sr-glm-5");
   });
-
-  it("ok with no confirmation line (banner-only) → optimistic record", async () => {
-    const { deps } = makeMenuDeps({
-      inject: async () => okResult("⠋ extending Claude Fable 5 access…"),
-    });
-    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
-    expect(out.selectedModel).toBe("Fable");
-    expect(out.selectedModelToken).toBe("fable");
-    // The banner must not leak as the confirmation.
-    expect(out.reply.text).not.toContain("extending Claude Fable 5 access");
-  });
-
-  it("scraped access-denial line via the button → failure, no override (retract)", async () => {
-    const { deps } = makeMenuDeps({
-      inject: async () => okResult("⎿  Fable is not available on your plan"),
-    });
-    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
-    expect(out.selectedModel).toBeUndefined();
-    expect(out.reply.text).toContain("did not take");
-  });
-
-  it("genuine confirmation via the button still records the display name", async () => {
-    const { deps } = makeMenuDeps({
-      inject: async () => okResult("⎿  Set model to Fable 5 for this session"),
-    });
-    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
-    expect(out.selectedModel).toBe("Fable 5");
-    expect(out.selectedModelToken).toBe("fable");
+  it("every alias target is a sr-* id", () => {
+    for (const target of Object.values(SR_MODEL_ALIASES)) expect(isSrModel(target)).toBe(true);
   });
 });
-
-describe("sessionModelFromConfirmation", () => {
-  it("pulls the model name from claude's session-switch confirmation", () => {
-    expect(sessionModelFromConfirmation("Set model to Fable 5 for this session only")).toBe("Fable 5");
-    expect(sessionModelFromConfirmation("Set model to Opus 4.8 (1M context) for this session only")).toBe("Opus 4.8");
-    expect(sessionModelFromConfirmation("Switched to Haiku 4.5")).toBe("Haiku 4.5");
-  });
-  it("terminates the name at 'and saved' (claude v2.1.205 arg-form phrasing, TUI-probe verified)", () => {
-    expect(
-      sessionModelFromConfirmation("⎿  Set model to Opus 4.8 and saved as your default for new sessions"),
-    ).toBe("Opus 4.8");
-  });
-  it("returns null when no recognizable name is present", () => {
-    expect(sessionModelFromConfirmation("Kept model as Opus 4.8 (default)")).toBeNull();
-    expect(sessionModelFromConfirmation("")).toBeNull();
-  });
-
-  it("mdl:r re-renders the dashboard", async () => {
-    const { deps, calls } = makeMenuDeps();
-    const out = await handleModelMenuCallback(MODEL_CALLBACK_REFRESH, deps);
-    expect(out.answer).toBe("Refreshed");
-    expect(calls.discover).toBe(1);
-    expect(out.reply.keyboard).toBeDefined();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Ship D — sr-* (LiteLLM non-Anthropic) model support
-// ---------------------------------------------------------------------------
-
-const OPTIONS_WITH_SR = [
-  { index: 1, label: "Default (recommended)", detail: "Opus 4.8 with 1M context", current: false },
-  { index: 2, label: "Sonnet", detail: "Sonnet 5", current: true },
-  { index: 3, label: "sr-gemini-2.5-pro", detail: "", current: false },
-  { index: 4, label: "sr-deepseek-r1", detail: "", current: false },
-  // internal path — should be filtered out
-  { index: 5, label: "openrouter/google/gemini-2.5-pro", detail: "", current: false },
-  // bare OpenAI models from GATEWAY_MODEL_DISCOVERY — should also be filtered out
-  { index: 6, label: "gpt-4", detail: "", current: false },
-  { index: 7, label: "gpt-4o", detail: "", current: false },
-  { index: 8, label: "voyage-law-2", detail: "", current: false },
-  // full claude ID — should be in claude bucket
-  { index: 9, label: "claude-opus-4-8", detail: "", current: false },
-];
 
 describe("classifyDiscoveredOptions", () => {
-  it("puts native Claude options in claude, sr-* in sr, drops others", () => {
-    const { claude, sr } = classifyDiscoveredOptions(OPTIONS_WITH_SR);
-    expect(claude.map((o) => o.label)).toEqual([
-      "Default (recommended)", "Sonnet", "claude-opus-4-8",
+  it("splits native Claude rows from sr-* rows and drops routing paths", () => {
+    const { claude, sr } = classifyDiscoveredOptions([
+      { index: 1, label: "Opus", current: false },
+      { index: 2, label: "sr-glm-5", current: false },
+      { index: 3, label: "openrouter/foo", current: false },
+      { index: 4, label: "gpt-4o", current: false },
     ]);
-    expect(sr.map((o) => o.label)).toEqual(["sr-gemini-2.5-pro", "sr-deepseek-r1"]);
-    // openrouter/*, gpt-*, voyage-* not present in either bucket
-    const all = [...claude, ...sr];
-    expect(all.find((o) => o.label.includes("openrouter"))).toBeUndefined();
-    expect(all.find((o) => o.label.startsWith("gpt-"))).toBeUndefined();
-    expect(all.find((o) => o.label.startsWith("voyage-"))).toBeUndefined();
-  });
-
-  it("handles a list with no sr-* models", () => {
-    const { claude, sr } = classifyDiscoveredOptions(OPTIONS);
-    expect(claude).toHaveLength(3);
-    expect(sr).toHaveLength(0);
+    expect(claude.map((o) => o.label)).toEqual(["Opus"]);
+    expect(sr.map((o) => o.label)).toEqual(["sr-glm-5"]);
   });
 });
 
-describe("SR_MODEL_LABELS", () => {
-  it("has friendly names for the standard sr-* models", () => {
-    expect(SR_MODEL_LABELS["sr-gemini-2.5-pro"]).toBe("Gemini 2.5 Pro");
-    expect(SR_MODEL_LABELS["sr-deepseek-r1"]).toBe("DeepSeek R1");
+describe("externalModelNames / SR_MODEL_LABELS / EXTRA_CLAUDE_ALIASES", () => {
+  it("seeds from the curated alias targets and merges discovered sr-*", () => {
+    const names = externalModelNames(["sr-gpt-oss-20b"]);
+    expect(names).toContain("sr-gemini-2.5-flash");
+    expect(names).toContain("sr-gpt-oss-20b");
   });
-
-  it("bumps sr-glm-5 label to GLM-5.2 (now targets glm-5.2 in litellm)", () => {
-    expect(SR_MODEL_LABELS["sr-glm-5"]).toBe("GLM-5.2");
+  it("Fable is offered as an extra Claude alias", () => {
+    expect(EXTRA_CLAUDE_ALIASES.some((a) => a.alias === "fable")).toBe(true);
   });
-
-  it("has friendly names for the new OpenRouter sr-* models (display-only)", () => {
-    expect(SR_MODEL_LABELS["sr-gpt-oss-20b"]).toBe("GPT-OSS 20B");
-    expect(SR_MODEL_LABELS["sr-gpt-oss-120b"]).toBe("GPT-OSS 120B");
-    expect(SR_MODEL_LABELS["sr-gpt-5.5"]).toBe("GPT-5.5");
-    expect(SR_MODEL_LABELS["sr-gpt-5-codex"]).toBe("GPT-5 Codex");
-    expect(SR_MODEL_LABELS["sr-gpt-5.2-codex"]).toBe("GPT-5.2 Codex");
-    expect(SR_MODEL_LABELS["sr-gemini-flash-lite"]).toBe("Gemini 3.1 Flash Lite");
-    expect(SR_MODEL_LABELS["sr-minimax-m3"]).toBe("MiniMax M3");
-    expect(SR_MODEL_LABELS["sr-deepseek-v4-flash"]).toBe("DeepSeek V4 Flash");
+  it("labels are display-only strings", () => {
+    expect(SR_MODEL_LABELS["sr-glm-5"]).toBeTypeOf("string");
   });
 });
-
-describe("menu stays curated — new OpenRouter models are display-only, not in the picker", () => {
-  // The 8 new models are typeable (manual passthrough) but must NOT bloat the
-  // /model keyboard. externalModelNames() seeds the picker from SR_MODEL_ALIASES
-  // values, so these ids must be ABSENT from both the alias table and the picker
-  // list. This locks in Ken's "menu = main models only" decision.
-  const NEW_SR = [
-    "sr-gpt-oss-20b",
-    "sr-gpt-oss-120b",
-    "sr-gpt-5.5",
-    "sr-gpt-5-codex",
-    "sr-gpt-5.2-codex",
-    "sr-gemini-flash-lite",
-    "sr-minimax-m3",
-    "sr-deepseek-v4-flash",
-  ];
-
-  it("SR_MODEL_ALIASES stays the curated 6-entry main set (no new short aliases)", () => {
-    expect(Object.keys(SR_MODEL_ALIASES).sort()).toEqual(
-      ["codex", "deepseek", "flash", "gemini", "glm", "r1"],
-    );
-    // None of the new sr-* ids are an alias target.
-    const targets = new Set(Object.values(SR_MODEL_ALIASES));
-    for (const name of NEW_SR) {
-      expect(targets.has(name), `${name} must NOT be an alias target`).toBe(false);
-    }
-  });
-
-  it("externalModelNames (picker seed) excludes the new models", () => {
-    const picker = externalModelNames([]);
-    for (const name of NEW_SR) {
-      expect(picker.includes(name), `${name} must NOT appear in the picker`).toBe(false);
-    }
-    // The curated main set is still exactly the alias targets.
-    expect(picker.sort()).toEqual([...new Set(Object.values(SR_MODEL_ALIASES))].sort());
-  });
-});
-
-describe("buildModelMenu — with sr-* models", () => {
-  // sr-* models now come from discoverSrModels (LiteLLM), not the claude picker.
-  function makeMenuDepsWithSr(overrides: Partial<ModelMenuDeps> = {}) {
-    return makeMenuDeps({
-      discoverSrModels: async () => ["sr-gemini-2.5-pro", "sr-deepseek-r1"],
-      ...overrides,
-    });
-  }
-
-  // Nested-page design (this PR): sr-* models no longer render inline on the
-  // main page — they live behind the "🌐 External models ▸" button on a second
-  // keyboard page. Live discoverSrModels() results are UNION-ed with the static
-  // SR_MODEL_ALIASES seed, so the external page always has at least the six
-  // curated aliases even when discovery returns [].
-
-  it("live-discovered sr-* models appear on the EXTERNAL page (not inline on main)", async () => {
-    const { deps } = makeMenuDepsWithSr();
-    const main = await buildModelMenu(deps, "main");
-    const mainButtons = main.keyboard!.flat();
-    // Not inline on the main page…
-    expect(mainButtons.find((b) => b.text === "🌐 Gemini 2.5 Pro")).toBeUndefined();
-    // …but the External-open button is present.
-    expect(mainButtons.find((b) => b.callback_data === MODEL_CALLBACK_PAGE_EXTERNAL)).toBeDefined();
-
-    const ext = await buildModelMenu(deps, "external");
-    const extButtons = ext.keyboard!.flat();
-    expect(extButtons.find((b) => b.text === "🌐 Gemini 2.5 Pro")).toBeDefined();
-    expect(extButtons.find((b) => b.text === "🌐 DeepSeek R1")).toBeDefined();
-    // openrouter/* / non-sr-* never shown at all.
-    expect(extButtons.find((b) => b.text.includes("openrouter"))).toBeUndefined();
-  });
-
-  it("external-page sr-* buttons use the mdl:sr: callback prefix", async () => {
-    const { deps } = makeMenuDepsWithSr();
-    const menu = await buildModelMenu(deps, "external");
-    const srButton = menu.keyboard!.flat().find((b) => b.text === "🌐 Gemini 2.5 Pro");
-    expect(srButton?.callback_data).toBe(`${MODEL_CALLBACK_SR}sr-gemini-2.5-pro`);
-  });
-
-  it("external page has exactly one header row (billed-separately)", async () => {
-    const { deps } = makeMenuDepsWithSr();
-    const menu = await buildModelMenu(deps, "external");
-    const headers = menu.keyboard!.flat().filter((b) => b.callback_data === MODEL_CALLBACK_HEADER);
-    expect(headers.length).toBe(1);
-    expect(headers[0].text).toContain("External");
-  });
-
-  it("main page carries NO header rows (headers live on the external page)", async () => {
-    const { deps } = makeMenuDeps();
-    const menu = await buildModelMenu(deps, "main");
-    const headers = (menu.keyboard ?? []).flat().filter((b) => b.callback_data === MODEL_CALLBACK_HEADER);
-    expect(headers.length).toBe(0);
-  });
-
-  it("header-row tap returns toastOnly without inject or model change", async () => {
-    const { deps, injectCalls } = makeMenuDepsWithSr();
-    const out = await handleModelMenuCallback(MODEL_CALLBACK_HEADER, deps);
-    expect(out.toastOnly).toBe(true);
-    expect(out.selectedModel).toBeUndefined();
-    expect(injectCalls).toHaveLength(0);
-  });
-
-  it("main page points at the External page for OpenRouter-billed models", async () => {
-    const { deps } = makeMenuDepsWithSr();
-    const menu = await buildModelMenu(deps, "main");
-    expect(menu.text).toContain("Max/Pro subscription");
-    expect(menu.text).toContain("External models");
-  });
-});
-
-describe("handleModelMenuCallback — sr-* selection", () => {
-  function makeMenuDepsWithSr(overrides: Partial<ModelMenuDeps> = {}) {
-    return makeMenuDeps({
-      discoverSrModels: async () => ["sr-gemini-2.5-pro", "sr-deepseek-r1"],
-      ...overrides,
-    });
-  }
-
-  it("sr-* tap delegates to the carrier relaunch — never a picker-rejecting inject", async () => {
-    // The gateway intercepts mdl:sr: before this function; if a direct caller
-    // reaches it, delegating to scheduleModelRelaunch is the ONLY safe path (an
-    // inject of `/model sr-*` 4xxs — picker rejects the id, base-URL never repointed).
-    const relaunch: Array<{ model: string }> = [];
-    const { deps, calls, injectCalls } = makeMenuDepsWithSr({
-      scheduleModelRelaunch: async (model) => { relaunch.push({ model }); },
-    });
-    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_SR}sr-gemini-2.5-pro`, deps);
-    // No inject, no cursor nav — a carrier relaunch on the exact sr-* id.
-    expect(injectCalls).toHaveLength(0);
-    expect(calls.select).toHaveLength(0);
-    expect(relaunch).toEqual([{ model: "sr-gemini-2.5-pro" }]);
-    expect(out.selectedModel).toBe("sr-gemini-2.5-pro");
-    expect(out.reply.keyboard).toBeUndefined();
-    expect(out.reply.text).toContain('🔄');
-    expect(out.reply.text).not.toContain('picker unavailable');
-  });
-
-  it("sr-* tap while busy returns toast-only with no relaunch", async () => {
-    const relaunch: string[] = [];
-    const { deps, injectCalls } = makeMenuDepsWithSr({
-      isBusy: () => true,
-      scheduleModelRelaunch: async (model) => { relaunch.push(model); },
-    });
-    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_SR}sr-gemini-2.5-pro`, deps);
-    expect(out.toastOnly).toBe(true);
-    expect(injectCalls).toHaveLength(0);
-    expect(relaunch).toHaveLength(0);
-  });
-
-  it("rejects malformed sr-* callback data", async () => {
-    const { deps } = makeMenuDepsWithSr();
-    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_SR}bad name with spaces`, deps);
-    expect(out.answer).toBe("Invalid model name");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// isSrToClaudeTransition helper (used by gateway callback handler)
-// ---------------------------------------------------------------------------
-
-describe("isSrToClaudeTransition", () => {
-  it("true when prev is sr-* and next is not sr-*", () => {
-    expect(isSrToClaudeTransition("sr-gemini-2.5-pro", "Haiku 4.5")).toBe(true);
-    expect(isSrToClaudeTransition("sr-deepseek-r1", "Fable 5")).toBe(true);
-    expect(isSrToClaudeTransition("sr-deepseek-r1", "claude-opus-4-8")).toBe(true);
-  });
-
-  it("false when prev is not sr-* (Claude → Claude)", () => {
-    expect(isSrToClaudeTransition("Opus 4.8", "Haiku 4.5")).toBe(false);
-    expect(isSrToClaudeTransition(null, "Sonnet")).toBe(false);
-    expect(isSrToClaudeTransition(undefined, "Sonnet")).toBe(false);
-  });
-
-  it("false when prev is sr-* but next is also sr-* (sr-* → sr-*)", () => {
-    expect(isSrToClaudeTransition("sr-gemini-2.5-pro", "sr-deepseek-r1")).toBe(false);
-  });
-
-  // #3242 review FIX 1 — optimisticModelRecordLabel must NOT de-prefix an sr-*
-  // token: the stored selectedModel doubles as the sr-*→Claude sentinel that
-  // isSrToClaudeTransition (prevModel.startsWith('sr-')) reads. De-prefixing to
-  // a friendly label ("kimi k2") would silently kill the graceful restart that
-  // tears down LiteLLM routing on a subsequent Claude switch.
-  it("optimisticModelRecordLabel keeps sr-* tokens verbatim so the sentinel survives", () => {
-    const recorded = optimisticModelRecordLabel("sr-kimi-k2");
-    expect(recorded).toBe("sr-kimi-k2"); // NOT "kimi k2"
-    // The recorded value still trips the sr→Claude transition on a later switch.
-    expect(isSrToClaudeTransition(recorded, "opus")).toBe(true);
-    // Regression guard: the de-prefixed form would NOT — that was the bug.
-    expect(isSrToClaudeTransition("kimi k2", "opus")).toBe(false);
-  });
-
-  it("optimisticModelRecordLabel Title-cases a bare Claude alias, leaves full ids as-is", () => {
-    expect(optimisticModelRecordLabel("fable")).toBe("Fable");
-    expect(optimisticModelRecordLabel("opus")).toBe("Opus");
-    expect(optimisticModelRecordLabel("claude-opus-4-8")).toBe("claude-opus-4-8");
-  });
-
-  it("false when switching to sr-* from Claude (Claude → sr-*)", () => {
-    expect(isSrToClaudeTransition("Sonnet", "sr-gemini-2.5-pro")).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Paginated picker — Fable in the Claude group + nested External page.
-// ---------------------------------------------------------------------------
-
-describe("externalModelNames", () => {
-  it("seeds from SR_MODEL_ALIASES values even when discovery is empty", () => {
-    const names = externalModelNames([]);
-    for (const target of Object.values(SR_MODEL_ALIASES)) {
-      expect(names).toContain(target);
-    }
-    // All six curated aliases, deduped.
-    expect(names.length).toBe(new Set(Object.values(SR_MODEL_ALIASES)).size);
-    expect(names).toEqual([...names].sort());
-  });
-
-  it("unions live discovery, dedupes, and drops non-sr-* names", () => {
-    const names = externalModelNames(["sr-brand-new", "sr-glm-5", "gpt-4o", "voyage-law-2"]);
-    expect(names).toContain("sr-brand-new");
-    expect(names).toContain("sr-glm-5");
-    // sr-glm-5 already came from aliases — deduped, not doubled.
-    expect(names.filter((n) => n === "sr-glm-5").length).toBe(1);
-    // Non-sr-* names never surface (subscription-honest).
-    expect(names).not.toContain("gpt-4o");
-    expect(names).not.toContain("voyage-law-2");
-  });
-});
-
-describe("paginated model menu — main page", () => {
-  it("main page includes a Fable button and an External-models-open button", async () => {
-    const { deps } = makeMenuDeps();
-    const menu = await buildModelMenu(deps);
-    const flat = menu.keyboard!.flat();
-    const fable = flat.find((b) => b.text === "Fable");
-    expect(fable).toBeDefined();
-    expect(fable!.callback_data).toBe(`${MODEL_CALLBACK_ALIAS}fable`);
-    const ext = flat.find((b) => b.callback_data === MODEL_CALLBACK_PAGE_EXTERNAL);
-    expect(ext).toBeDefined();
-    expect(ext!.text).toContain("External");
-    // Refresh is last.
-    expect(menu.keyboard![menu.keyboard!.length - 1][0].callback_data).toBe(
-      MODEL_CALLBACK_REFRESH,
-    );
-  });
-
-  it("no External-open button when there are no external models", async () => {
-    // Force externalModelNames to be empty by stubbing SR aliases away is not
-    // possible (static), but a build with an empty alias set is covered by the
-    // externalModelNames unit test. Here we assert the button is gated on the
-    // list being non-empty via the real (non-empty) path: it IS present.
-    const { deps } = makeMenuDeps();
-    const menu = await buildModelMenu(deps);
-    const flat = menu.keyboard!.flat();
-    expect(flat.some((b) => b.callback_data === MODEL_CALLBACK_PAGE_EXTERNAL)).toBe(true);
-  });
-
-  it("dedupes the static Fable row if the scraped options already include Fable", async () => {
-    const { deps } = makeMenuDeps({
-      discover: async () => ({
-        ok: true as const,
-        options: [
-          { index: 1, label: "Sonnet", detail: "", current: true },
-          { index: 2, label: "Fable", detail: "Fable 5", current: false },
-        ],
-        currentLabel: "Sonnet",
-      }),
-    });
-    const menu = await buildModelMenu(deps);
-    const flat = menu.keyboard!.flat();
-    // Exactly one Fable button, and it's the scraped (select) one, not the alias.
-    const fables = flat.filter((b) => b.text === "Fable" || b.text === "✅ Fable");
-    expect(fables.length).toBe(1);
-    expect(fables[0].callback_data.startsWith(MODEL_CALLBACK_ALIAS)).toBe(false);
-  });
-
-  it("every callback_data still fits Telegram's 64-byte cap", async () => {
-    const { deps } = makeMenuDeps();
-    for (const page of ["main", "external"] as const) {
-      const menu = await buildModelMenu(deps, page);
-      for (const btn of menu.keyboard!.flat()) {
-        expect(Buffer.byteLength(btn.callback_data, "utf-8")).toBeLessThanOrEqual(64);
-      }
-    }
-  });
-});
-
-describe("paginated model menu — external page", () => {
-  it("lists all six SR_MODEL_ALIASES models plus a Back button", async () => {
-    const { deps } = makeMenuDeps();
-    const menu = await buildModelMenu(deps, "external");
-    const flat = menu.keyboard!.flat();
-    for (const target of Object.values(SR_MODEL_ALIASES)) {
-      const btn = flat.find((b) => b.callback_data === `${MODEL_CALLBACK_SR}${target}`);
-      expect(btn, `missing external button for ${target}`).toBeDefined();
-      expect(btn!.text.startsWith("🌐")).toBe(true);
-    }
-    expect(flat.some((b) => b.callback_data === MODEL_CALLBACK_PAGE_MAIN)).toBe(true);
-    expect(flat.some((b) => b.callback_data === MODEL_CALLBACK_REFRESH)).toBe(true);
-  });
-
-  it("external page body text makes the billed-separately split explicit", async () => {
-    const { deps } = makeMenuDeps();
-    const menu = await buildModelMenu(deps, "external");
-    expect(menu.text).toContain("billed separately");
-    expect(menu.text).toContain("OpenRouter");
-    expect(menu.text).toContain("subscription");
-  });
-});
-
-describe("page callbacks swap the keyboard without switching model", () => {
-  it("PAGE_EXTERNAL renders the external page and does NOT select/inject", async () => {
-    const { deps, calls, injectCalls } = makeMenuDeps();
-    const out = await handleModelMenuCallback(MODEL_CALLBACK_PAGE_EXTERNAL, deps);
-    expect(calls.select).toEqual([]);
-    expect(injectCalls).toEqual([]);
-    expect(out.selectedModel).toBeUndefined();
-    const flat = out.reply.keyboard!.flat();
-    expect(flat.some((b) => b.callback_data === MODEL_CALLBACK_PAGE_MAIN)).toBe(true);
-    expect(out.reply.text).toContain("billed separately");
-  });
-
-  it("PAGE_MAIN renders the main page and does NOT select/inject", async () => {
-    const { deps, calls, injectCalls } = makeMenuDeps();
-    const out = await handleModelMenuCallback(MODEL_CALLBACK_PAGE_MAIN, deps);
-    expect(calls.select).toEqual([]);
-    expect(injectCalls).toEqual([]);
-    expect(out.selectedModel).toBeUndefined();
-    const flat = out.reply.keyboard!.flat();
-    expect(flat.some((b) => b.callback_data === MODEL_CALLBACK_PAGE_EXTERNAL)).toBe(true);
-    expect(flat.some((b) => b.text === "Fable")).toBe(true);
-  });
-});
-
-describe("Fable alias callback injects /model fable", () => {
-  it("injects exactly '/model fable' and reports the session model", async () => {
-    const { deps, calls, injectCalls } = makeMenuDeps();
-    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}fable`, deps);
-    // Alias path uses inject, never the cursor-nav select path.
-    expect(calls.select).toEqual([]);
-    expect(injectCalls).toHaveLength(1);
-    expect(injectCalls[0].command).toBe("/model fable");
-    expect(out.reply.text).toContain("✅");
-  });
-
-  it("EXTRA_CLAUDE_ALIASES contains fable", () => {
-    expect(EXTRA_CLAUDE_ALIASES.some((a) => a.alias === "fable" && a.label === "Fable")).toBe(true);
-  });
-
-  it("rejects an invalid alias without injecting", async () => {
-    const { deps, injectCalls } = makeMenuDeps();
-    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}bad name`, deps);
-    expect(injectCalls).toEqual([]);
-    expect(out.answer).toContain("Invalid");
-  });
-});
-
-// ─── #3039: busy-refusal detection for the queued-command drain ──────────────
-
-describe("isBusyRefusalText (#3039)", () => {
-  it("matches the typed and menu busy refusals", async () => {
-    const deps = makeDeps({ isBusy: () => true }).deps;
-    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
-    expect(isBusyRefusalText(reply.text)).toBe(true);
-  });
-
-  it("never matches a genuine confirmation or failure", () => {
-    expect(isBusyRefusalText("⏺ Set model to Opus 4.8")).toBe(false);
-    expect(isBusyRefusalText("✅ `/effort high` — Set effort level to high")).toBe(false);
-    expect(isBusyRefusalText("❌ Switch to opus failed: tmux session not found")).toBe(false);
-  });
-});
-
 
 describe("isOfflineTrustedModelToken (#3042 blocker 2a)", () => {
-  it("trusts static Claude aliases and curated sr-* alias names/targets", () => {
-    for (const a of MODEL_ALIASES) expect(isOfflineTrustedModelToken(a)).toBe(true);
-    // Curated sr-* aliases resolve by construction (present in the LiteLLM config).
-    const [alias, target] = Object.entries(SR_MODEL_ALIASES)[0];
-    expect(isOfflineTrustedModelToken(alias)).toBe(true);
-    expect(isOfflineTrustedModelToken(target)).toBe(true);
-  });
-
-  it("refuses hand-typed full ids — shape-valid garbage must never reach a boot carrier unconfirmed", () => {
-    expect(isOfflineTrustedModelToken("claude-nonexistnet-9")).toBe(false);
-    expect(isOfflineTrustedModelToken("claude-opus-4-8")).toBe(false); // real but unverifiable offline
-    expect(isOfflineTrustedModelToken("sr-made-up/model")).toBe(false);
-    expect(isOfflineTrustedModelToken("")).toBe(false);
-  });
-
-  it("#3043 item 1: accepts case-variant aliases the live path already normalizes (OPUS, Sonnet)", () => {
-    // The live accept path lowercases (isClaudeModel / expandSrAlias) so a
-    // queued `/model OPUS` is accepted live — the persist gate must not then
-    // refuse it with the over-conservative "couldn't verify" card.
-    for (const a of MODEL_ALIASES) {
-      expect(isOfflineTrustedModelToken(a.toUpperCase())).toBe(true);
-    }
+  it("trusts static aliases + curated sr targets, refuses arbitrary ids", () => {
+    expect(isOfflineTrustedModelToken("opus")).toBe(true);
     expect(isOfflineTrustedModelToken("OPUS")).toBe(true);
-    expect(isOfflineTrustedModelToken("Sonnet")).toBe(true);
-    // Curated sr-* alias, upper-cased, still resolves.
-    const [alias] = Object.entries(SR_MODEL_ALIASES)[0];
-    expect(isOfflineTrustedModelToken(alias.toUpperCase())).toBe(true);
+    expect(isOfflineTrustedModelToken("flash")).toBe(true);
+    expect(isOfflineTrustedModelToken("sr-gemini-2.5-flash")).toBe(true);
+    expect(isOfflineTrustedModelToken("claude-random-9")).toBe(false);
+    expect(isOfflineTrustedModelToken("sr-obscure-xyz")).toBe(false);
   });
 });
 
-// ---------------------------------------------------------------------------
-// #3177 — a typed /model must NEVER be swallowed without trace when sent
-// mid-turn. The routing decision folds BOTH busy signals, and every parsed
-// shape maps to a visible action (menu / queue / apply — never "do nothing").
-// ---------------------------------------------------------------------------
-describe("#3177 typed /model never silently swallowed mid-turn", () => {
-  describe("isModelCommandBusy folds both busy signals", () => {
-    it("is busy when the turn atom is set", () => {
-      expect(isModelCommandBusy({ currentTurnActive: true, turnInFlight: false })).toBe(true);
-    });
+describe("isBusyRefusalText (#3039)", () => {
+  it("matches the mid-turn refusal copy", () => {
+    expect(isBusyRefusalText("⏳ The agent is mid-turn — …")).toBe(true);
+    expect(isBusyRefusalText("done")).toBe(false);
+  });
+});
 
-    it("is busy when only the authoritative delivery-machine/approval gate is set", () => {
-      // THE SWALLOW REGRESSION: the pre-fix handler gated on `currentTurn !==
-      // null` ALONE. A session busy by the delivery-machine / pending-approval
-      // gate while the turn atom is cleared (the recovered-late / premature-
-      // turn-end window) read as idle, so the switch injected into a busy pane
-      // and was swallowed as literal text. Folding turnInFlight closes it.
-      expect(isModelCommandBusy({ currentTurnActive: false, turnInFlight: true })).toBe(true);
-    });
-
-    it("is idle only when BOTH signals are clear", () => {
-      expect(isModelCommandBusy({ currentTurnActive: false, turnInFlight: false })).toBe(false);
-    });
+describe("#3177 — routing decision helpers", () => {
+  it("isModelCommandBusy folds both signals", () => {
+    expect(isModelCommandBusy({ currentTurnActive: true, turnInFlight: false })).toBe(true);
+    expect(isModelCommandBusy({ currentTurnActive: false, turnInFlight: true })).toBe(true);
+    expect(isModelCommandBusy({ currentTurnActive: false, turnInFlight: false })).toBe(false);
   });
 
-  describe("planModelCommand routes every shape to a visible action", () => {
-    const busyByAtom = { currentTurnActive: true, turnInFlight: false, menuEnabled: true };
-    const busyByGate = { currentTurnActive: false, turnInFlight: true, menuEnabled: true };
+  it("planModelCommand routes each shape", () => {
     const idle = { currentTurnActive: false, turnInFlight: false, menuEnabled: true };
-
-    it("QUEUES a set while busy by the turn atom (ack, not silent inject)", () => {
-      const d = planModelCommand({ kind: "set", model: "opus" }, busyByAtom);
-      expect(d).toEqual({ kind: "queue", target: "opus" });
+    expect(planModelCommand({ kind: "show" }, idle)).toEqual({ kind: "menu" });
+    expect(planModelCommand({ kind: "set", model: "opus" }, idle)).toEqual({
+      kind: "apply",
+      parsed: { kind: "set", model: "opus" },
     });
-
-    it("QUEUES a set while busy by the delivery-machine/approval gate ONLY — the swallow case", () => {
-      // Sabotage-verify: revert the fix (gate on currentTurnActive alone) and
-      // this flips to { kind: 'apply' } → the direct-inject swallow returns.
-      const d = planModelCommand({ kind: "set", model: "opus" }, busyByGate);
-      expect(d).toEqual({ kind: "queue", target: "opus" });
-    });
-
-    it("expands sr-* aliases into the queued target token", () => {
-      const d = planModelCommand({ kind: "set", model: "flash" }, busyByAtom);
-      expect(d).toEqual({ kind: "queue", target: "sr-gemini-2.5-flash" });
-    });
-
-    it("APPLIES a set immediately when idle by both signals", () => {
-      const d = planModelCommand({ kind: "set", model: "opus" }, idle);
-      expect(d).toEqual({ kind: "apply", parsed: { kind: "set", model: "opus" } });
-    });
-
-    it("renders the MENU for bare /model when the picker is enabled (even mid-turn)", () => {
-      expect(planModelCommand({ kind: "show" }, busyByGate)).toEqual({ kind: "menu" });
-    });
-
-    it("APPLIES the text show path when the picker is disabled", () => {
-      const d = planModelCommand({ kind: "show" }, { ...idle, menuEnabled: false });
-      expect(d).toEqual({ kind: "apply", parsed: { kind: "show" } });
-    });
-
-    it("APPLIES help so a bad arg still gets an explicit reply", () => {
-      const parsed = { kind: "help", reason: "not a valid model name: !!" } as const;
-      expect(planModelCommand(parsed, busyByGate)).toEqual({ kind: "apply", parsed });
+    const busy = { currentTurnActive: true, turnInFlight: false, menuEnabled: true };
+    expect(planModelCommand({ kind: "set", model: "flash" }, busy)).toEqual({
+      kind: "queue",
+      target: "sr-gemini-2.5-flash",
     });
   });
 
-  describe("resolveStaleAwareBusy — phantom 'active turn' fix (#3262)", () => {
-    const HARD_TTL = 10 * 60_000;
-
-    it("APPLIES a set when the turn atom is DANGLING (older than the hard TTL)", () => {
-      // A currentTurn atom whose turn_end never fired: non-null but its
-      // liveness marker is far older than the ceiling. Discounted to idle,
-      // and flagged for the gateway to clear.
-      const r = resolveStaleAwareBusy({
-        currentTurnActive: true,
-        turnAgeMs: HARD_TTL + 1,
-        machineInTurn: false,
-        oldestPendingApprovalAgeMs: null,
-        hardTtlMs: HARD_TTL,
-      });
-      expect(r.currentTurnActive).toBe(false);
-      expect(r.turnInFlight).toBe(false);
-      expect(r.clearStaleTurn).toBe(true);
-      // Routing sees "idle" → applies, not queues.
-      const d = planModelCommand(
-        { kind: "set", model: "opus" },
-        { currentTurnActive: r.currentTurnActive, turnInFlight: r.turnInFlight, menuEnabled: true },
-      );
-      expect(d).toEqual({ kind: "apply", parsed: { kind: "set", model: "opus" } });
+  it("resolveStaleAwareBusy discounts a stale turn atom", () => {
+    const out = resolveStaleAwareBusy({
+      currentTurnActive: true,
+      turnAgeMs: 10 * 60_000,
+      machineInTurn: false,
+      oldestPendingApprovalAgeMs: null,
+      hardTtlMs: 5 * 60_000,
     });
-
-    it("QUEUES a set when the turn is FRESH (marker within the TTL) — no regression", () => {
-      const r = resolveStaleAwareBusy({
-        currentTurnActive: true,
-        turnAgeMs: 5_000,
-        machineInTurn: false,
-        oldestPendingApprovalAgeMs: null,
-        hardTtlMs: HARD_TTL,
-      });
-      expect(r.currentTurnActive).toBe(true);
-      expect(r.clearStaleTurn).toBe(false);
-      const d = planModelCommand(
-        { kind: "set", model: "opus" },
-        { currentTurnActive: r.currentTurnActive, turnInFlight: r.turnInFlight, menuEnabled: true },
-      );
-      expect(d).toEqual({ kind: "queue", target: "opus" });
-    });
-
-    it("APPLIES when only a WEDGED approval (older than the TTL) holds the gate on an idle session", () => {
-      const r = resolveStaleAwareBusy({
-        currentTurnActive: false,
-        turnAgeMs: null,
-        machineInTurn: false,
-        oldestPendingApprovalAgeMs: HARD_TTL + 1,
-        hardTtlMs: HARD_TTL,
-      });
-      expect(r.turnInFlight).toBe(false);
-      expect(r.currentTurnActive).toBe(false);
-      const d = planModelCommand(
-        { kind: "set", model: "opus" },
-        { currentTurnActive: r.currentTurnActive, turnInFlight: r.turnInFlight, menuEnabled: true },
-      );
-      expect(d).toEqual({ kind: "apply", parsed: { kind: "set", model: "opus" } });
-    });
-
-    it("QUEUES when a RECENT pending approval holds the gate — a real block is preserved", () => {
-      const r = resolveStaleAwareBusy({
-        currentTurnActive: false,
-        turnAgeMs: null,
-        machineInTurn: false,
-        oldestPendingApprovalAgeMs: 3_000,
-        hardTtlMs: HARD_TTL,
-      });
-      expect(r.turnInFlight).toBe(true);
-      const d = planModelCommand(
-        { kind: "set", model: "opus" },
-        { currentTurnActive: r.currentTurnActive, turnInFlight: r.turnInFlight, menuEnabled: true },
-      );
-      expect(d).toEqual({ kind: "queue", target: "opus" });
-    });
-
-    it("QUEUES when the machine is genuinely in-turn regardless of atom age", () => {
-      const r = resolveStaleAwareBusy({
-        currentTurnActive: false,
-        turnAgeMs: null,
-        machineInTurn: true,
-        oldestPendingApprovalAgeMs: null,
-        hardTtlMs: HARD_TTL,
-      });
-      expect(r.turnInFlight).toBe(true);
-      expect(r.clearStaleTurn).toBe(false);
-    });
-
-    it("does NOT clear or discount when there is no turn atom", () => {
-      const r = resolveStaleAwareBusy({
-        currentTurnActive: false,
-        turnAgeMs: null,
-        machineInTurn: false,
-        oldestPendingApprovalAgeMs: null,
-        hardTtlMs: HARD_TTL,
-      });
-      expect(r).toEqual({ currentTurnActive: false, turnInFlight: false, clearStaleTurn: false });
-    });
-
-    it("keeps a non-null atom busy when its age is exactly at the ceiling (strict >)", () => {
-      const r = resolveStaleAwareBusy({
-        currentTurnActive: true,
-        turnAgeMs: HARD_TTL,
-        machineInTurn: false,
-        oldestPendingApprovalAgeMs: null,
-        hardTtlMs: HARD_TTL,
-      });
-      expect(r.currentTurnActive).toBe(true);
-      expect(r.clearStaleTurn).toBe(false);
-    });
+    expect(out.currentTurnActive).toBe(false);
+    expect(out.clearStaleTurn).toBe(true);
   });
 
-  describe("modelCommandReceiptLine — the durable, greppable entry trace", () => {
-    it("stamps agent, kind, arg, and busy for a typed set", () => {
-      const line = modelCommandReceiptLine("finn", { kind: "set", model: "opus" }, true);
-      expect(line).toBe("telegram gateway: gw /model received agent=finn kind=set arg=opus busy=true");
-    });
-
-    it("marks the show + help forms with placeholder args", () => {
-      expect(modelCommandReceiptLine("finn", { kind: "show" }, false)).toContain("kind=show arg=(show)");
-      expect(modelCommandReceiptLine("finn", { kind: "help" }, false)).toContain("kind=help arg=(help)");
-    });
+  it("modelCommandReceiptLine is stable + greppable", () => {
+    const line = modelCommandReceiptLine("klanker", { kind: "set", model: "opus" }, false);
+    expect(line).toContain("gw /model received");
+    expect(line).toContain("agent=klanker");
+    expect(line).toContain("arg=opus");
   });
 });

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -222,6 +222,7 @@ import {
   buildModelMenu,
   handleModelMenuCallback,
   modelSelectCallbackData,
+  isRecognizedSwitchToken,
   classifyDiscoveredOptions,
   canonicalClaudeToken,
   MODEL_CALLBACK_REFRESH,
@@ -274,6 +275,25 @@ describe("modelSelectCallbackData — embeds the canonical token (rev 5)", () =>
   it("the Default row carries the `default` sentinel", () => {
     expect(modelSelectCallbackData("Default (recommended)")).toBe("mdl:s:default");
   });
+  it("N2: an UNMAPPED Claude row does NOT collapse to the `default` sentinel", () => {
+    // A label whose first word is neither a known alias nor claude-* nor default
+    // must not masquerade as a default-revert; it carries an empty (rejected) suffix.
+    expect(modelSelectCallbackData("Sparkle 9 (preview)")).toBe("mdl:s:");
+    expect(modelSelectCallbackData("Sparkle 9 (preview)")).not.toBe("mdl:s:default");
+  });
+});
+
+describe("isRecognizedSwitchToken (N1 allowlist)", () => {
+  it("accepts default, sr-*, aliases, and claude-* ids", () => {
+    for (const t of ["default", "sr-glm-5", "opus", "fable", "claude-opus-4-8"]) {
+      expect(isRecognizedSwitchToken(t)).toBe(true);
+    }
+  });
+  it("rejects a stale 8-hex labelTag and other garbage", () => {
+    for (const t of ["1a2b3c4d", "", "deadbeef", "Sparkle9"]) {
+      expect(isRecognizedSwitchToken(t)).toBe(false);
+    }
+  });
 });
 
 describe("handleModelMenuCallback — every switch tap relaunches (rev 5)", () => {
@@ -288,6 +308,25 @@ describe("handleModelMenuCallback — every switch tap relaunches (rev 5)", () =
     expect(out.reply.text).toContain("relaunching");
     expect(Object.prototype.hasOwnProperty.call(out, "selectedModel")).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(out, "selectedModelToken")).toBe(false);
+  });
+
+  it("N1: a stale SELECT token (old 8-hex labelTag) does NOT relaunch — re-renders instead", async () => {
+    // A menu rendered by the OLD gateway carries `mdl:s:<hex>`. The hex passes the
+    // loose shape gate but is not a recognized model token; relaunching onto it
+    // would write a garbage carrier that --fallback-model silently masks. The
+    // handler must re-render, not schedule anything.
+    const { deps, relaunchCalls, defaultRelaunchCalls } = makeMenuDeps();
+    const out = await handleModelMenuCallback("mdl:s:1a2b3c4d", deps);
+    expect(relaunchCalls).toHaveLength(0);
+    expect(defaultRelaunchCalls).toHaveLength(0);
+    expect(out.answer).toContain("menu refreshed");
+  });
+
+  it("N1: an empty SELECT suffix (unmapped row) does NOT relaunch", async () => {
+    const { deps, relaunchCalls, defaultRelaunchCalls } = makeMenuDeps();
+    await handleModelMenuCallback("mdl:s:", deps);
+    expect(relaunchCalls).toHaveLength(0);
+    expect(defaultRelaunchCalls).toHaveLength(0);
   });
 
   it("picker SELECT of the Default row routes to the default relaunch", async () => {

--- a/telegram-plugin/tier-downgrade.ts
+++ b/telegram-plugin/tier-downgrade.ts
@@ -20,9 +20,10 @@
  * account-swap, never by a downgrade.
  *
  * There is NO automatic return to the premium model. The `/model` override is
- * SESSION-SCOPED and in-memory only (`recordTypedModelSwitch` writes NO carrier
- * — reference/rfcs/session-model-stickiness.md §0.1 rev 4), so it dies on the
- * downgrade SIGTERM. The downgrade writes a consume-once `.session-model`
+ * SESSION-SCOPED: rev 5 (reference/rfcs/session-model-stickiness.md §0.05) makes
+ * every switch a consume-once `.session-model` carrier relaunch, so the override
+ * dies on the downgrade SIGTERM (the carrier was consumed on its own apply-boot).
+ * The downgrade writes a consume-once `.session-model`
  * carrier for the CONFIGURED DEFAULT: start.sh applies+deletes it on the resume
  * boot, and every subsequent restart boots the configured default too. The
  * premium model is never restored on its own — the user must re-issue

--- a/tests/model-picker.test.ts
+++ b/tests/model-picker.test.ts
@@ -6,21 +6,19 @@
  * picker layout, update the fixture from a fresh capture and the
  * parser together.
  *
- * Headline safety invariants:
- *   1. Esc-always: every discovery path and every failed selection
- *      path sends Escape — the picker is never left open to wedge the
- *      pane (the /rate-limit-options class of wedge).
- *   2. Never select blind: `selectModel` re-verifies the cursor row's
- *      LABEL after navigation; any mismatch aborts via Escape and the
- *      session-only `s` keypress is never sent.
+ * Headline safety invariant:
+ *   Esc-always: every discovery path sends Escape — the picker is never
+ *   left open to wedge the pane (the /rate-limit-options class of wedge).
+ *
+ * NB (rev 5): the terminal-DRIVING selectModel()/extractConfirmation() were
+ * removed (the /model switch is now a deterministic carrier relaunch), so this
+ * suite covers discovery/parse + the shared pane-lock/dismissal invariants only.
  */
 import { describe, it, expect } from "vitest";
 import {
   parseModelPicker,
   labelTag,
-  extractConfirmation,
   discoverModels,
-  selectModel,
 } from "../src/agents/model-picker.js";
 import type { TmuxRunner } from "../src/agents/inject.js";
 
@@ -128,14 +126,6 @@ describe("labelTag", () => {
   });
 });
 
-describe("extractConfirmation", () => {
-  it("pulls the ⎿ confirmation line", () => {
-    expect(extractConfirmation(AFTER_S)).toBe("Set model to Haiku 4.5 for this session");
-    expect(extractConfirmation(AFTER_ESC)).toBe("Kept model as Sonnet 4.6");
-    expect(extractConfirmation(IDLE)).toBeNull();
-  });
-});
-
 /**
  * Scripted fake runner: `frames` is consumed one capture at a time
  * (last frame repeats); every send is recorded for exact-sequence
@@ -226,62 +216,6 @@ describe("#3241 interstitial dismiss-and-retry", () => {
   });
 });
 
-describe("selectModel", () => {
-  it("navigates cursor→target, verifies the label, presses s — no Escape", async () => {
-    // open → PICKER (cursor 2) → after Down: cursor 3 → verify → s → confirmation
-    const { runner, sends } = fakeRunner([PICKER, PICKER_CURSOR_3, AFTER_S]);
-    const res = await selectModel("agentx", "Haiku", { ...fastOpts, _runner: runner });
-    expect(res).toEqual({ ok: true, confirmation: "Set model to Haiku 4.5 for this session" });
-    expect(sentKeys(sends)).toEqual(["/model", "Enter", "Down", "s"]);
-  });
-
-  it("navigates UP when the target is above the cursor", async () => {
-    const cursorOn3 = PICKER_CURSOR_3;
-    const cursorOn2 = PICKER;
-    const { runner, sends } = fakeRunner([cursorOn3, cursorOn2, AFTER_S]);
-    const res = await selectModel("agentx", "Sonnet", { ...fastOpts, _runner: runner });
-    expect(res.ok).toBe(true);
-    expect(sentKeys(sends)).toEqual(["/model", "Enter", "Up", "s"]);
-  });
-
-  it("aborts via Escape when the label is not offered — never presses s", async () => {
-    const { runner, sends } = fakeRunner([PICKER, AFTER_ESC]);
-    const res = await selectModel("agentx", "Nonexistent Model", { ...fastOpts, _runner: runner });
-    expect(res.ok).toBe(false);
-    if (!res.ok) expect(res.reason).toContain("not offered");
-    const keys = sentKeys(sends);
-    expect(keys).toContain("Escape");
-    expect(keys).not.toContain("s");
-  });
-
-  it("aborts via Escape when cursor verification fails — never presses s", async () => {
-    // After the Down keypress the pane unexpectedly still shows cursor
-    // on Sonnet (row 2) — e.g. the pane shifted under us.
-    const { runner, sends } = fakeRunner([PICKER, PICKER, AFTER_ESC]);
-    const res = await selectModel("agentx", "Haiku", { ...fastOpts, _runner: runner });
-    expect(res.ok).toBe(false);
-    if (!res.ok) expect(res.reason).toContain("cursor verification failed");
-    const keys = sentKeys(sends);
-    expect(keys).toContain("Escape");
-    expect(keys).not.toContain("s");
-  });
-
-  it("zero-delta selection (target == cursor row) presses s directly", async () => {
-    const { runner, sends } = fakeRunner([PICKER, PICKER, AFTER_S]);
-    const res = await selectModel("agentx", "Sonnet", { ...fastOpts, _runner: runner });
-    expect(res.ok).toBe(true);
-    expect(sentKeys(sends)).toEqual(["/model", "Enter", "s"]);
-  });
-
-  it("aborts when the picker never renders", async () => {
-    const { runner, sends } = fakeRunner([IDLE]);
-    const res = await selectModel("agentx", "Haiku", { ...fastOpts, _runner: runner, timeoutMs: 20 });
-    expect(res.ok).toBe(false);
-    expect(sentKeys(sends)).not.toContain("s");
-    expect(sentKeys(sends)).toContain("Escape");
-  });
-});
-
 describe("pane-lock serialization (#2263 review blocker 1)", () => {
   it("two concurrent drives on one pane never interleave keys", async () => {
     // A slow runner whose captures resolve through real microtasks;
@@ -312,15 +246,10 @@ describe("pane-lock serialization (#2263 review blocker 1)", () => {
     ]);
   });
 
-  it("a select queued behind a discover runs after its Escape", async () => {
+  it("two discovers on one pane serialize (never interleave)", async () => {
     const sends: string[][] = [];
     let i = 0;
-    const frames = [
-      // discover: open → esc
-      PICKER, AFTER_ESC,
-      // select: open → walk-verify → s-confirm
-      PICKER, PICKER_CURSOR_3, AFTER_S,
-    ];
+    const frames = [PICKER, AFTER_ESC, PICKER, AFTER_ESC];
     const runner: TmuxRunner = {
       capture: () => frames[Math.min(i++, frames.length - 1)],
       send: (_s, _t, args) => {
@@ -329,15 +258,15 @@ describe("pane-lock serialization (#2263 review blocker 1)", () => {
       hasSession: () => true,
     };
     const opts = { ...fastOpts, _runner: runner };
-    const [d, s] = await Promise.all([
+    const [d1, d2] = await Promise.all([
       discoverModels("samepane2", opts),
-      selectModel("samepane2", "Haiku", opts),
+      discoverModels("samepane2", opts),
     ]);
-    expect(d.ok).toBe(true);
-    expect(s).toEqual({ ok: true, confirmation: "Set model to Haiku 4.5 for this session" });
+    expect(d1.ok).toBe(true);
+    expect(d2.ok).toBe(true);
     expect(sentKeys(sends)).toEqual([
       "/model", "Enter", "Escape",
-      "/model", "Enter", "Down", "s",
+      "/model", "Enter", "Escape",
     ]);
   });
 });
@@ -358,15 +287,4 @@ describe("dismissal failure is loud (#2263 review blocker 3)", () => {
     expect(logs.some((l) => l.includes("may still be open"))).toBe(true);
   });
 
-  it("failed select logs the stuck-modal warning too", async () => {
-    const logs: string[] = [];
-    const { runner } = fakeRunner([PICKER]);
-    const res = await selectModel("agentx", "Nonexistent Model", {
-      ...fastOpts,
-      _runner: runner,
-      _log: (l) => logs.push(l),
-    });
-    expect(res.ok).toBe(false);
-    expect(logs.some((l) => l.includes("may still be open"))).toBe(true);
-  });
 });

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -278,11 +278,42 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     expect(baseUrl).toBe(PASSTHROUGH);
   });
 
-  it("claude-* carrier → KEEPS the /anthropic passthrough (only sr-* repoints)", () => {
+  it("claude-* carrier → KEEPS the /anthropic passthrough (only sr-*/fable repoint)", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
     const { effective, baseUrl } = runBlockRouting("1");
     expect(effective).toBe("claude-opus-4-8");
     expect(baseUrl).toBe(PASSTHROUGH);
+  });
+
+  // ── Fable (F2): proxy-only Claude alias — repoints like sr-*, guards like sr-* ──
+  it("fable carrier + LiteLLM up → applies + REPOINTS ANTHROPIC_BASE_URL to the router root", () => {
+    // FAILS on old start.sh: the repoint `case` matched sr-* ONLY, so a fable
+    // carrier kept the /anthropic passthrough and 4xx'd (claude-fable-5 is a
+    // retired codename direct-to-Anthropic; it only resolves via the router).
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("fable"));
+    const { effective, baseUrl } = runBlockRouting("1");
+    expect(effective).toBe("fable");
+    expect(baseUrl).toBe(ROUTER_ROOT);
+    expect(baseUrl.endsWith("/anthropic")).toBe(false);
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+  });
+
+  it("claude-fable-5 carrier + LiteLLM up → also repoints to the router root", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-fable-5"));
+    const { effective, baseUrl } = runBlockRouting("1");
+    expect(effective).toBe("claude-fable-5");
+    expect(baseUrl).toBe(ROUTER_ROOT);
+  });
+
+  it("fable carrier + LiteLLM DOWN → boots default, CONSUMES the carrier, tells the operator to re-issue", () => {
+    // FAILS on old start.sh: the down-guard was sr-* only, so a fable carrier
+    // would APPLY with the proxy down and then 4xx at runtime.
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("fable"));
+    expect(runBlock("")).toBe(DEFAULT_MODEL);
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    const alert = alertText();
+    expect(alert).toContain("fable");
+    expect(alert).toContain("LiteLLM");
   });
 
   // ── migration from the one-shot carrier ──────────────────────────────────


### PR DESCRIPTION
## Summary
Retire the inject-into-tmux + terminal-scrape `/model` switch path and route **every** switch — Claude→Claude, Claude→sr-*, sr-*→Claude, the Fable/alias button, and the picker SELECT — through the consume-once `.session-model` carrier relaunch. Implements RFC rev-5 §0.05 (reverses §0.1's "live Claude switches write no carrier"). Single atomic PR: RFC + code + tests land together so the stated contract never contradicts the code (G4).

## Why
The inject path silently no-op'd (keystrokes swallowed when the pane wasn't idle) then **optimistically recorded** the requested model as success — an unverifiable lie to `/status`. A relaunch cannot silently no-op, and `.active-session-model` is a real post-boot signal. Success is asserted only from that signal (boot re-hydration + the transcript's `message.model`), never from a scraped pane.

## Fable-boot verdict (STEP 0)
**Fixed via the router repoint (F2), not dropped.** Empirically: a Claude agent routes via the `/anthropic` passthrough; `fable` resolves in the CLI to `claude-fable-5`, a retired codename that 4xxs direct-to-Anthropic and only resolves via the LiteLLM **router root** (verified live against the litellm config + router `/v1/models` — both `fable` and `claude-fable-5` served). The old repoint `case` matched `sr-*` only, so a fable carrier would 4xx even with LiteLLM up. Fix extends the repoint `case` **and** the LiteLLM-down guard to cover `fable`/`claude-fable-5`.

## Review findings resolved
- **F1** — switch-confirmation keys off `launched !== configured` (deterministic apply-boot signal; consume-once ⇒ only true on a genuine apply); success reported only from `.active-session-model`; applied-model logged (`gw /model relaunch scheduled/applied`).
- **F2** — router repoint + down-guard extended to fable (above).
- **F3** — retired-contract tests inverted/rewritten, not extended (Claude→Claude calls `scheduleModelRelaunch` not `inject`; picker tap never `select`s; no optimistic/scrape `selectedModel`; scaffold fable repoint + down-guard cases fail on old start.sh).
- **F4** — documented honestly: `.active-session-model` is the requested token; `--fallback-model` masking self-heals via the transcript reclaiming the source on the first assistant line (no persistent lie); honest-failure surface scoped to the three `.session-model-alert` modes.
- **G1** — `scheduleModelDefaultRelaunch` mirrors the relaunch rollback discipline.
- **G2** — the ~30s in-flight override window documented as the only optimistic window (bounded, self-healing).
- **G3** — one switch-confirmation card, keyed on the apply-boot; distinct from the generic boot card (which shows configured-model diffs, not a session override).
- **G4** — RFC + code + tests in one release.
- **R5** — premium-recovery clear moved into the relaunch (covers both sites).

## Invariants preserved
Session-scoped (reverts on next restart, never persisted); everything routes through LiteLLM; `/effort` untouched; #1978 low-on-Opus pin untouched; 15s debounce / consume-once / last-write-wins (no restart storm).

## Test plan
Scoped locally (CI is the authority): `model-command.test.ts` (50), `gateway-session-model-relaunch.test.ts` (17), `scaffold.session-model.test.ts` (29, incl. 3 new fable cases that fail on old start.sh), plus tier-downgrade / premium-recovery / welcome-text / model-unavailable / session-model-file / effort / model-picker / reconcile — all green. `npm run lint` green (incl. plugin tsc via check-plugin-references).

## Risk
Every Claude→Claude switch now costs a ~30s fresh session (accepted trade; memory + handoff carry context). Fable via the router forgoes the passthrough's Opus SSE re-chunk mitigation — the router is the only path where Fable resolves at all. **Do not roll to the live fleet without the operator's canary** — this changes live `/model` UX.

Job spec: reference/jobs/steer-or-queue-mid-flight.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)