### PR TITLE
fix(model): honest confirmation when a /model switch silently reverts (#3284)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -30749,23 +30749,38 @@ void (async () => {
                     launched,
                     configured,
                   })
-                  const body =
-                    confirmation.kind === 'applied'
-                      ? `✅ Now running \`${confirmation.launched}\` — session-only, reverts to the configured model on the next restart. Fresh session; memory and the handoff briefing carry the context.`
-                      : confirmation.kind === 'not-applied'
-                        ? `⚠️ Your switch to \`${confirmation.target}\` didn't apply — the agent reverted to \`${confirmation.revertedTo}\` (the apply-boot didn't complete). Re-issue /model ${confirmation.target} to try again.`
-                        : `✅ Now running \`${confirmation.launched}\` (the configured default) — fresh session; memory and the handoff briefing carry the context.`
-                  // allow-raw-bot-api: one-shot boot confirmation, same shape as the session-model alert relay below
-                  void lockedBot.api
-                    .sendMessage(chat.chatId, body, {
-                      parse_mode: 'Markdown',
-                      ...(chat.threadId != null ? { message_thread_id: chat.threadId } : {}),
-                    })
-                    .catch((err: unknown) =>
-                      process.stderr.write(
-                        `telegram gateway: model-switch confirmation send failed: ${(err as Error)?.message ?? String(err)}\n`,
-                      ),
+                  // LOW-2 dedup: the config-default-changed / proxy-down revert
+                  // paths in start.sh write a TAILORED `.session-model-alert`
+                  // (relayed to operators below) that already explains why the
+                  // switch didn't apply and how to re-issue it. Suppress the
+                  // generic not-applied card when such an alert is present for
+                  // this boot so the operator isn't double-warned — the alert is
+                  // the more specific message. The not-applied card still fires
+                  // for the plain wedge/revert case (no alert on disk).
+                  const hasSessionModelAlert = existsSync(join(smAgentDir, '.session-model-alert'))
+                  if (confirmation.kind === 'not-applied' && hasSessionModelAlert) {
+                    process.stderr.write(
+                      `telegram gateway: gw /model relaunch applied — suppressing not-applied confirmation (a .session-model-alert is present and will be relayed) agent=${getMyAgentName()} target=${confirmation.target}\n`,
                     )
+                  } else {
+                    const body =
+                      confirmation.kind === 'applied'
+                        ? `✅ Now running \`${confirmation.launched}\` — session-only, reverts to the configured model on the next restart. Fresh session; memory and the handoff briefing carry the context.`
+                        : confirmation.kind === 'not-applied'
+                          ? `⚠️ Your switch to \`${confirmation.target}\` didn't apply — the agent reverted to \`${confirmation.revertedTo}\` (the apply-boot didn't complete). Re-issue \`/model ${confirmation.target}\` to try again.`
+                          : `✅ Now running \`${confirmation.launched}\` (the configured default) — fresh session; memory and the handoff briefing carry the context.`
+                    // allow-raw-bot-api: one-shot boot confirmation, same shape as the session-model alert relay below
+                    void lockedBot.api
+                      .sendMessage(chat.chatId, body, {
+                        parse_mode: 'Markdown',
+                        ...(chat.threadId != null ? { message_thread_id: chat.threadId } : {}),
+                      })
+                      .catch((err: unknown) =>
+                        process.stderr.write(
+                          `telegram gateway: model-switch confirmation send failed: ${(err as Error)?.message ?? String(err)}\n`,
+                        ),
+                      )
+                  }
                 }
               } catch { /* leave override as-is on a bad read */ }
             }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -472,6 +472,7 @@ import {
   resolveStaleAwareBusy,
   modelCommandReceiptLine,
   handleModelCommand,
+  classifyModelSwitchConfirmation,
   buildModelMenu,
   handleModelMenuCallback,
   isValidModelArg,
@@ -30737,9 +30738,23 @@ void (async () => {
                 // this is the single card the operator sees for the switch.
                 if (modelSwitchReason != null && modelSwitchMarkerChat) {
                   const chat = modelSwitchMarkerChat
-                  const body = isApplyBoot
-                    ? `✅ Now running \`${launched}\` — session-only, reverts to the configured model on the next restart. Fresh session; memory and the handoff briefing carry the context.`
-                    : `✅ Now running \`${launched || configured}\` (the configured default) — fresh session; memory and the handoff briefing carry the context.`
+                  // Derive the confirmation from the DETERMINISTIC post-boot
+                  // signals. A non-default switch that reverted to the configured
+                  // default (a wedged/consumed apply-boot — the silent-revert bug)
+                  // must WARN, not print a misleading green "✅ Now running
+                  // <default>" card. `applied` / `default` keep the honest green
+                  // card (N4: the default/revert case still confirms).
+                  const confirmation = classifyModelSwitchConfirmation({
+                    reason: modelSwitchReason,
+                    launched,
+                    configured,
+                  })
+                  const body =
+                    confirmation.kind === 'applied'
+                      ? `✅ Now running \`${confirmation.launched}\` — session-only, reverts to the configured model on the next restart. Fresh session; memory and the handoff briefing carry the context.`
+                      : confirmation.kind === 'not-applied'
+                        ? `⚠️ Your switch to \`${confirmation.target}\` didn't apply — the agent reverted to \`${confirmation.revertedTo}\` (the apply-boot didn't complete). Re-issue /model ${confirmation.target} to try again.`
+                        : `✅ Now running \`${confirmation.launched}\` (the configured default) — fresh session; memory and the handoff briefing carry the context.`
                   // allow-raw-bot-api: one-shot boot confirmation, same shape as the session-model alert relay below
                   void lockedBot.api
                     .sendMessage(chat.chatId, body, {

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -84,6 +84,76 @@ export function isClaudeModel(name: string): boolean {
   return lower.startsWith('claude-')
 }
 
+/**
+ * The outcome of a `/model` apply-boot, derived purely from the DETERMINISTIC
+ * post-boot signals (never optimistic):
+ *
+ *   - `reason`     — the clean-shutdown marker reason that keyed this boot as a
+ *                    `/model` apply-boot, e.g.
+ *                    `user: /model fable (session-only relaunch, menu)`.
+ *   - `launched`   — the contents of `.active-session-model`: the model start.sh
+ *                    actually passed to `claude --model` this boot.
+ *   - `configured` — the resolved configured default model.
+ *
+ * Three outcomes:
+ *   - `applied`      — the launched model differs from the configured default, so
+ *                      the switch landed (a session-only override).
+ *   - `default`      — the operator asked for the configured default (`/model
+ *                      default`, or `/model <configured>`) and got it.
+ *   - `not-applied`  — the operator asked for a NON-default model, but the boot
+ *                      came back on the configured default: the switch SILENTLY
+ *                      failed to apply. The consume-once carrier was consumed by a
+ *                      boot that never launched the target (e.g. a wedged apply-boot
+ *                      that hit boot.lock_stale_recovered_boot_mismatch and reverted
+ *                      to the default). This is the case that previously emitted a
+ *                      MISLEADING green "✅ Now running <default> (the configured
+ *                      default)" card with no signal that the requested switch was
+ *                      lost. It self-corrects across boots: a later boot that
+ *                      genuinely launches the target reports `applied`.
+ */
+export type ModelSwitchConfirmation =
+  | { kind: 'applied'; launched: string }
+  | { kind: 'default'; launched: string }
+  | { kind: 'not-applied'; target: string; revertedTo: string }
+
+/**
+ * Extract the requested `/model <target>` token from a clean-shutdown reason
+ * (e.g. `user: /model fable (session-only relaunch, menu)` → `fable`). Returns
+ * null when the reason carries no `/model <token>` (a non-switch reason).
+ */
+export function parseModelSwitchTarget(reason: string): string | null {
+  const m = reason.match(/\/model\s+(\S+)/)
+  return m ? m[1] : null
+}
+
+/**
+ * Classify a `/model` apply-boot outcome from the post-boot signals. Pure so the
+ * confirmation-card decision is unit-testable without booting the gateway. The
+ * `not-applied` branch is the fix for the silent-revert bug: a non-default switch
+ * that reverted to the configured default must warn, not print a green ✅.
+ */
+export function classifyModelSwitchConfirmation(input: {
+  reason: string
+  launched: string
+  configured: string
+}): ModelSwitchConfirmation {
+  const { reason, launched, configured } = input
+  const isApplyBoot = launched.length > 0 && launched !== configured
+  if (isApplyBoot) return { kind: 'applied', launched }
+  // launched === configured (or empty): either an intended default/revert, or a
+  // NON-default switch that silently reverted to the configured default.
+  const target = parseModelSwitchTarget(reason)
+  const revertedTo = launched.length > 0 ? launched : configured
+  if (
+    target != null &&
+    target.toLowerCase() !== 'default' &&
+    target.toLowerCase() !== revertedTo.toLowerCase()
+  ) {
+    return { kind: 'not-applied', target, revertedTo }
+  }
+  return { kind: 'default', launched: revertedTo }
+}
+
 export type ParsedModelCommand =
   | { kind: 'show' }
   | { kind: 'set'; model: string }

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -127,6 +127,37 @@ export function parseModelSwitchTarget(reason: string): string | null {
 }
 
 /**
+ * Reduce a model token to a comparable FAMILY key so an alias and its resolved
+ * full id compare equal (`sonnet` ≡ `claude-sonnet-5` ≡ `claude-sonnet-5-<date>`).
+ *
+ * This is the normalization the silent-revert classifier needs: `target` from
+ * the clean-shutdown reason is the RAW user token (an alias like `sonnet`),
+ * while `.active-session-model` / the configured default may be the RESOLVED
+ * full id start.sh wrote on a revert-with-alert path (config-default-changed at
+ * start.sh.hbs:1228, proxy-down at :1234). A naive string compare would flag
+ * `/model sonnet` on a `claude-sonnet-5`-default agent as "didn't apply" even
+ * though sonnet IS the default.
+ *
+ * NB `resolveMainModel` (scaffold.ts:1358) is NOT sufficient here — it only
+ * remaps the `default` alias / unset to the switchroom default; it passes
+ * `sonnet`/`opus`/etc. through unchanged. The alias↔full-id equivalence is a
+ * FAMILY reduction (same rule model-label.ts uses one-way), done here:
+ *   - `claude-<family>-…` → `<family>`  (e.g. `claude-sonnet-5` → `sonnet`)
+ *   - a bare alias / any other token     → itself, lowercased (`sonnet`, `sr-glm-5`)
+ * sr-* ids never carry a `claude-` prefix, so they stay verbatim — correct,
+ * since the reason token and `.active-session-model` both hold the same
+ * already-expanded sr-* id and compare equal directly.
+ */
+export function modelFamilyToken(token: string): string {
+  const t = token.trim().toLowerCase()
+  if (t.startsWith('claude-')) {
+    const family = t.slice('claude-'.length).split('-').filter((p) => p.length > 0)[0]
+    return family ?? t
+  }
+  return t
+}
+
+/**
  * Classify a `/model` apply-boot outcome from the post-boot signals. Pure so the
  * confirmation-card decision is unit-testable without booting the gateway. The
  * `not-applied` branch is the fix for the silent-revert bug: a non-default switch
@@ -144,10 +175,13 @@ export function classifyModelSwitchConfirmation(input: {
   // NON-default switch that silently reverted to the configured default.
   const target = parseModelSwitchTarget(reason)
   const revertedTo = launched.length > 0 ? launched : configured
+  // Family-normalize both sides so an alias target (`sonnet`) matches its
+  // resolved full-id revert (`claude-sonnet-5`) — otherwise a `/model sonnet`
+  // that reverted to the sonnet default would emit a WRONG "didn't apply" card.
   if (
     target != null &&
     target.toLowerCase() !== 'default' &&
-    target.toLowerCase() !== revertedTo.toLowerCase()
+    modelFamilyToken(target) !== modelFamilyToken(revertedTo)
   ) {
     return { kind: 'not-applied', target, revertedTo }
   }

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -149,13 +149,25 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
   it('sends ONE switch-confirmation from the ACTUAL launched model, keyed on the /model reason (F1/N4)', () => {
     const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
     expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 3400)
+    const win = GATEWAY_SRC.slice(idx, idx + 4200)
     // Keyed on the deterministic /model switch reason, so it also fires on a
     // launched===configured apply-boot (/model default) — N4. Never optimistic.
     expect(win).toContain('if (modelSwitchReason != null && modelSwitchMarkerChat)')
     expect(win).toContain('✅ Now running')
     // N4: the launched===configured branch still confirms.
     expect(win).toContain('(the configured default)')
+  })
+
+  it('warns instead of a green ✅ when a non-default switch silently reverted to the default (silent-revert fix)', () => {
+    const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
+    const win = GATEWAY_SRC.slice(idx, idx + 4200)
+    // The confirmation card is derived from the pure classifier, not an inline
+    // isApplyBoot ternary — so a reverted non-default switch yields the ⚠️ card.
+    expect(win).toContain('classifyModelSwitchConfirmation({')
+    expect(win).toContain("confirmation.kind === 'applied'")
+    expect(win).toContain("confirmation.kind === 'not-applied'")
+    expect(win).toContain("⚠️ Your switch to")
+    expect(win).toContain("didn't apply")
   })
 
   it('N4/reason: the /model switch reason is captured from the clean-shutdown marker', () => {

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -149,7 +149,7 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
   it('sends ONE switch-confirmation from the ACTUAL launched model, keyed on the /model reason (F1/N4)', () => {
     const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
     expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 4200)
+    const win = GATEWAY_SRC.slice(idx, idx + 5200)
     // Keyed on the deterministic /model switch reason, so it also fires on a
     // launched===configured apply-boot (/model default) — N4. Never optimistic.
     expect(win).toContain('if (modelSwitchReason != null && modelSwitchMarkerChat)')
@@ -160,7 +160,7 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
 
   it('warns instead of a green ✅ when a non-default switch silently reverted to the default (silent-revert fix)', () => {
     const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
-    const win = GATEWAY_SRC.slice(idx, idx + 4200)
+    const win = GATEWAY_SRC.slice(idx, idx + 5200)
     // The confirmation card is derived from the pure classifier, not an inline
     // isApplyBoot ternary — so a reverted non-default switch yields the ⚠️ card.
     expect(win).toContain('classifyModelSwitchConfirmation({')
@@ -168,6 +168,18 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
     expect(win).toContain("confirmation.kind === 'not-applied'")
     expect(win).toContain("⚠️ Your switch to")
     expect(win).toContain("didn't apply")
+    // LOW-3: the re-issue hint interpolates the target inside backticks so a
+    // token containing Markdown metachars can't italicize / 400 the send.
+    expect(win).toContain('Re-issue \\`/model ${confirmation.target}\\`')
+  })
+
+  it('dedups the not-applied card against a tailored .session-model-alert (LOW-2)', () => {
+    const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
+    const win = GATEWAY_SRC.slice(idx, idx + 5200)
+    // When start.sh wrote a specific alert for this revert, the classifier's
+    // generic not-applied card is suppressed (the alert relay is the message).
+    expect(win).toContain("existsSync(join(smAgentDir, '.session-model-alert'))")
+    expect(win).toContain("confirmation.kind === 'not-applied' && hasSessionModelAlert")
   })
 
   it('N4/reason: the /model switch reason is captured from the clean-shutdown marker', () => {
@@ -184,7 +196,7 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
   })
 
   it('consumes the .session-model-alert sentinel, notifies ALL operators, and deletes it', () => {
-    const idx = GATEWAY_SRC.indexOf("join(smAgentDir, '.session-model-alert')")
+    const idx = GATEWAY_SRC.indexOf("const alertPath = join(smAgentDir, '.session-model-alert')")
     expect(idx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(idx, idx + 1100)
     expect(win).toContain('unlinkSync(alertPath)')

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -30,6 +30,7 @@ import {
   isOfflineTrustedModelToken,
   classifyModelSwitchConfirmation,
   parseModelSwitchTarget,
+  modelFamilyToken,
   MODEL_ALIASES,
   type ModelCommandDeps,
 } from "../gateway/model-command.js";
@@ -609,5 +610,54 @@ describe("classifyModelSwitchConfirmation", () => {
       configured: "opus",
     });
     expect(out).toEqual({ kind: "not-applied", target: "fable", revertedTo: "opus" });
+  });
+
+  // LOW-1: an ALIAS target must family-match its RESOLVED full-id revert, so a
+  // `/model sonnet` on a `claude-sonnet-5`-default agent (start.sh wrote the full
+  // id to .active-session-model on a config-changed / proxy-down revert path) is
+  // NOT falsely reported as "sonnet didn't apply". This is the exact case the
+  // reviewer flagged; a naive string compare returns not-applied here.
+  it("family-matches an alias target to its resolved full-id default (sonnet ≡ claude-sonnet-5)", () => {
+    const out = classifyModelSwitchConfirmation({
+      reason: "user: /model sonnet (session-only relaunch)",
+      launched: "claude-sonnet-5",
+      configured: "claude-sonnet-5",
+    });
+    expect(out).toEqual({ kind: "default", launched: "claude-sonnet-5" });
+  });
+
+  it("still flags a genuinely different-family switch that reverted to the full-id default", () => {
+    // /model opus reverting to a claude-sonnet-5 default is a REAL failed switch.
+    const out = classifyModelSwitchConfirmation({
+      reason: "user: /model opus (session-only relaunch)",
+      launched: "claude-sonnet-5",
+      configured: "claude-sonnet-5",
+    });
+    expect(out).toEqual({ kind: "not-applied", target: "opus", revertedTo: "claude-sonnet-5" });
+  });
+
+  it("family-matches a full-id target to the aliased default (claude-opus-4-8 ≡ opus)", () => {
+    const out = classifyModelSwitchConfirmation({
+      reason: "user: /model claude-opus-4-8 (session-only relaunch)",
+      launched: "opus",
+      configured: "opus",
+    });
+    expect(out).toEqual({ kind: "default", launched: "opus" });
+  });
+});
+
+describe("modelFamilyToken", () => {
+  it("reduces a claude full id to its family, dropping version + date", () => {
+    expect(modelFamilyToken("claude-sonnet-5")).toBe("sonnet");
+    expect(modelFamilyToken("claude-opus-4-8")).toBe("opus");
+    expect(modelFamilyToken("claude-haiku-4-5-20251001")).toBe("haiku");
+  });
+  it("passes a bare alias through, lowercased", () => {
+    expect(modelFamilyToken("Sonnet")).toBe("sonnet");
+    expect(modelFamilyToken("fable")).toBe("fable");
+  });
+  it("keeps sr-* routing ids verbatim (no claude- prefix)", () => {
+    expect(modelFamilyToken("sr-glm-5")).toBe("sr-glm-5");
+    expect(modelFamilyToken("sr-gemini-2.5-flash")).toBe("sr-gemini-2.5-flash");
   });
 });

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -28,6 +28,8 @@ import {
   isClaudeModel,
   isBusyRefusalText,
   isOfflineTrustedModelToken,
+  classifyModelSwitchConfirmation,
+  parseModelSwitchTarget,
   MODEL_ALIASES,
   type ModelCommandDeps,
 } from "../gateway/model-command.js";
@@ -526,5 +528,86 @@ describe("#3177 — routing decision helpers", () => {
     expect(line).toContain("gw /model received");
     expect(line).toContain("agent=klanker");
     expect(line).toContain("arg=opus");
+  });
+});
+
+describe("parseModelSwitchTarget", () => {
+  it("extracts the target from a menu relaunch reason", () => {
+    expect(
+      parseModelSwitchTarget("user: /model fable (session-only relaunch, menu)"),
+    ).toBe("fable");
+  });
+  it("extracts the target from a typed relaunch reason", () => {
+    expect(
+      parseModelSwitchTarget("user: /model sr-gemini-2.5-flash (session-only relaunch)"),
+    ).toBe("sr-gemini-2.5-flash");
+  });
+  it("extracts the default sentinel from a revert reason", () => {
+    expect(parseModelSwitchTarget("user: /model default (revert relaunch)")).toBe("default");
+  });
+  it("returns null for a non-/model reason", () => {
+    expect(parseModelSwitchTarget("cli: restart")).toBeNull();
+  });
+});
+
+describe("classifyModelSwitchConfirmation", () => {
+  // The regression this fix closes: a /model fable apply-boot that reverted to
+  // the configured default (opus) must be reported as NOT-applied (⚠️), not as a
+  // green "✅ Now running opus (the configured default)". Under the OLD inline
+  // logic (isApplyBoot ? applied : green-default) this exact case produced the
+  // misleading green card — this asserts the corrected outcome.
+  it("flags a non-default switch that reverted to the configured default as not-applied", () => {
+    const out = classifyModelSwitchConfirmation({
+      reason: "user: /model fable (session-only relaunch, menu)",
+      launched: "opus",
+      configured: "opus",
+    });
+    expect(out).toEqual({ kind: "not-applied", target: "fable", revertedTo: "opus" });
+  });
+
+  it("reports an applied switch when the launched model differs from the default", () => {
+    const out = classifyModelSwitchConfirmation({
+      reason: "user: /model fable (session-only relaunch, menu)",
+      launched: "fable",
+      configured: "opus",
+    });
+    expect(out).toEqual({ kind: "applied", launched: "fable" });
+  });
+
+  it("reports the default (green) for an intended /model default revert", () => {
+    const out = classifyModelSwitchConfirmation({
+      reason: "user: /model default (revert relaunch)",
+      launched: "opus",
+      configured: "opus",
+    });
+    expect(out).toEqual({ kind: "default", launched: "opus" });
+  });
+
+  it("reports the default (green) when the operator asked for the configured model itself", () => {
+    // /model opus while configured=opus is a SUCCESS, not a silent revert.
+    const out = classifyModelSwitchConfirmation({
+      reason: "user: /model opus (session-only relaunch)",
+      launched: "opus",
+      configured: "opus",
+    });
+    expect(out).toEqual({ kind: "default", launched: "opus" });
+  });
+
+  it("is case-insensitive on the target-vs-launched comparison", () => {
+    const out = classifyModelSwitchConfirmation({
+      reason: "user: /model OPUS (session-only relaunch)",
+      launched: "opus",
+      configured: "opus",
+    });
+    expect(out).toEqual({ kind: "default", launched: "opus" });
+  });
+
+  it("treats an empty launched value (unreadable .active-session-model) as a revert to the default", () => {
+    const out = classifyModelSwitchConfirmation({
+      reason: "user: /model fable (session-only relaunch, menu)",
+      launched: "",
+      configured: "opus",
+    });
+    expect(out).toEqual({ kind: "not-applied", target: "fable", revertedTo: "opus" });
   });
 });


### PR DESCRIPTION
## Problem

A `/model <name>` switch that actually reverted to the configured default (a wedged apply-boot) reported a **misleading green** card: `✅ Now running opus (the configured default)` — with zero signal that the operator's requested switch (e.g. `fable`) never landed.

Verified live on marko + klanker: the gateway already reads the reported model honestly from `.active-session-model` (the model the boot's transcript actually ran matched the report). The premise that the gateway "computes the wrong model from cleared override state" does **not** hold on current code — `launched` is read straight from the file start.sh wrote. The real gap was purely the **confirmation wording**: under the old inline `isApplyBoot ? applied : green-default`, a *reverted non-default switch* was indistinguishable from an intended `/model default`.

marko log evidence: `19:30:12Z scheduled token=fable` → `19:30:19Z boot.lock_stale_recovered_boot_mismatch` → `19:30:22Z applied launched=opus configured=opus`. That boot's session ran opus (170 transcript lines); fable went live only on a later boot.

## Change

New pure, unit-tested `classifyModelSwitchConfirmation({ reason, launched, configured })` in `model-command.ts`:

- `applied`     — launched ≠ configured default → green ✅ (session-only override landed)
- `default`     — operator asked for `/model default` or the configured model itself → green ✅ (N4 preserved)
- `not-applied` — operator asked for a **non-default** model but the boot came back on the default → **⚠️** `Your switch to \`fable\` didn't apply — the agent reverted to \`opus\` (the apply-boot didn't complete). Re-issue /model fable to try again.`

The gateway boot confirmation (`gateway.ts`) now derives its card body from the classifier instead of the inline ternary. Self-corrects across boots: a later boot that genuinely launches the target reports `applied` and shows the normal green card.

## Scope

User-facing confirmation only. The **deeper root cause** — why the apply-boot wedges on `boot.lock_stale_recovered_boot_mismatch` and reverts, so `fable` applies first-try — is tracked in #3284 (not addressed here).

## Tests

- `telegram-plugin/tests/model-command.test.ts` — behavioral coverage of `classifyModelSwitchConfirmation` + `parseModelSwitchTarget`. The headline case (`reason=/model fable, launched=opus, configured=opus` ⇒ `not-applied`, i.e. ⚠️ not green) is the failing-then-passing regression guard: the old inline logic produced the green default card for exactly this input.
- `telegram-plugin/tests/gateway-session-model-relaunch.test.ts` — source pins updated for the new wiring + a pin that the ⚠️ mismatch branch exists.

Local: scoped vitest 85/85 pass; `tsc --noEmit` clean; `npm run lint` clean. CI green is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)