### PR TITLE
fix(tz): local-render recalled-memory + /logs timestamps; reject typo'd IANA zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@
   directory. Two new doctor probes flag a persistently un-checkpointed WAL
   inside the broker and any agent `.vault-token` referencing a grant id
   absent from the DB (the orphan-token symptom).
+- **Timestamps you can read** (#3286) — three follow-ups to the #3275
+  timezone fix. Recalled-memory `mentioned_at` timestamps and Telegram
+  `/logs` output now render in local am/pm instead of UTC (`/logs` gains
+  a per-line docker timestamp via a new `agent logs -t/--timestamps`
+  flag; the conversion is display-only, in the gateway/operator zone).
+  **Behavior change:** a `timezone:` config value that is shape-valid
+  but names a non-existent IANA zone (e.g. `Australia/Melbrone`) now
+  fails config load/apply loudly with the offending field named. Such a
+  typo previously passed validation and silently ran the agent on UTC —
+  if your apply starts failing here, the fleet was already mis-timed;
+  fix the zone name.
 
 ## v0.18.27 — Steadier Telegram cards and more reliable model switching
 

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -763,18 +763,36 @@ export function attachAgent(name: string, tmuxSupervisor = true): void {
  * the CLI action now always passes a tail (default 50), so a bare
  * `switchroom agent logs <name>` no longer dumps the entire log.
  */
-export function buildAgentLogsArgs(name: string, follow: boolean, tail?: number): string[] {
+export function buildAgentLogsArgs(
+  name: string,
+  follow: boolean,
+  tail?: number,
+  timestamps?: boolean,
+): string[] {
   const args = ["logs"];
   if (follow) args.push("-f");
   if (tail !== undefined && Number.isFinite(tail) && tail >= 1) {
     args.push("--tail", String(Math.floor(tail)));
   }
+  // #tz-fix audit (gap 2): `--timestamps` prefixes EVERY line with docker's
+  // own UTC ISO-8601-Z stamp (e.g. `2026-07-16T20:17:58.433481596Z `) —
+  // the only deterministic per-line timestamp available. Without it, lines
+  // carry only whatever stamp the app itself printed (often none, or a
+  // local-zone `%H:%M:%S,mmm` form). The Telegram /logs path requests this
+  // so the gateway can render the stamp in the operator's local am/pm at
+  // display time (renderLogTimestampsLocal).
+  if (timestamps) args.push("--timestamps");
   args.push(containerName(name));
   return args;
 }
 
-export function getAgentLogs(name: string, follow: boolean, tail?: number): void {
-  const args = buildAgentLogsArgs(name, follow, tail);
+export function getAgentLogs(
+  name: string,
+  follow: boolean,
+  tail?: number,
+  timestamps?: boolean,
+): void {
+  const args = buildAgentLogsArgs(name, follow, tail, timestamps);
 
   const child = spawn("docker", args, { stdio: "inherit" });
   child.on("error", (err) => {

--- a/src/cli/agent.test.ts
+++ b/src/cli/agent.test.ts
@@ -70,6 +70,22 @@ describe("buildAgentLogsArgs (docker argv contract)", () => {
       "logs", "switchroom-coach",
     ]);
   });
+
+  // #tz-fix audit gap 2: the Telegram /logs local-time render depends on
+  // docker's own UTC ISO-Z per-line stamp, which ONLY exists when the argv
+  // carries --timestamps. Without this, raw lines have no leading ISO-Z
+  // stamp and the display transform is dead code.
+  it("emits --timestamps when requested (the Telegram /logs shape)", () => {
+    expect(buildAgentLogsArgs("coach", false, 20, true)).toEqual([
+      "logs", "--tail", "20", "--timestamps", "switchroom-coach",
+    ]);
+  });
+
+  it("omits --timestamps by default (plain CLI dump unchanged)", () => {
+    expect(buildAgentLogsArgs("coach", false, 20)).toEqual([
+      "logs", "--tail", "20", "switchroom-coach",
+    ]);
+  });
 });
 
 describe("agent logs command options", () => {
@@ -102,6 +118,18 @@ describe("agent logs command options", () => {
   it("advertises --lines in its help output", () => {
     const logs = findLogsCommand();
     expect(logs.helpInformation()).toContain("--lines");
+  });
+
+  // Same drift-class outcome test for --timestamps: the gateway's /logs now
+  // builds `agent logs <name> --lines <n> --timestamps`; an unregistered
+  // option would make every /logs invocation error out.
+  it("registers a --timestamps / -t boolean option", () => {
+    const logs = findLogsCommand();
+    const opt = logs.options.find((o) => o.long === "--timestamps");
+    expect(opt).toBeDefined();
+    expect(opt!.short).toBe("-t");
+    // boolean flag (takes no value)
+    expect(opt!.required || opt!.optional).toBe(false);
   });
 });
 

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1674,8 +1674,12 @@ export function registerAgentCommand(program: Command): void {
       "-n, --lines <count>",
       "Number of trailing log lines to show (default 50, capped at 1000; with -f, bounds the initial backlog before streaming). Note: Telegram's /logs applies its own chat-sized default of 20 / max 200 before invoking this.",
     )
+    .option(
+      "-t, --timestamps",
+      "Prefix each line with docker's UTC ISO-8601 timestamp (docker logs --timestamps). Telegram's /logs passes this so the gateway can render each stamp in the operator's local time at display.",
+    )
     .action(
-      withConfigError(async (name: string, opts: { follow?: boolean; lines?: string }) => {
+      withConfigError(async (name: string, opts: { follow?: boolean; lines?: string; timestamps?: boolean }) => {
         const config = getConfig(program);
 
         if (!config.agents[name]) {
@@ -1683,7 +1687,7 @@ export function registerAgentCommand(program: Command): void {
           process.exit(1);
         }
 
-        getAgentLogs(name, opts.follow ?? false, resolveLogsTail(opts.lines));
+        getAgentLogs(name, opts.follow ?? false, resolveLogsTail(opts.lines), opts.timestamps ?? false);
       })
     );
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -392,3 +392,74 @@ agents:
     expect(joined).toContain("alerst");
   });
 });
+
+describe("loader: timezone validity (#tz-fix audit gap 3)", () => {
+  it("accepts a real IANA zone on an agent", () => {
+    const path = writeTempConfig(`${validBaseYaml.replace("agents: {}", "")}
+agents:
+  alice:
+    topic_name: "alice"
+    timezone: "Australia/Melbourne"
+`);
+    const config = loadConfig(path);
+    expect(config.agents.alice?.timezone).toBe("Australia/Melbourne");
+  });
+
+  it("accepts UTC and a real global switchroom.timezone", () => {
+    const path = writeTempConfig(`
+switchroom:
+  version: 1
+  timezone: "America/New_York"
+telegram:
+  bot_token: "x"
+  forum_chat_id: "1"
+agents:
+  bob:
+    topic_name: "bob"
+    timezone: "UTC"
+`.trim());
+    const config = loadConfig(path);
+    expect(config.switchroom.timezone).toBe("America/New_York");
+    expect(config.agents.bob?.timezone).toBe("UTC");
+  });
+
+  it("rejects a shape-valid but non-existent IANA zone (typo) at load", () => {
+    // Passes TIMEZONE_REGEX (Region/City shape) but no such zone exists — it
+    // would silently degrade to UTC at runtime without this check.
+    const path = writeTempConfig(`${validBaseYaml.replace("agents: {}", "")}
+agents:
+  carol:
+    topic_name: "carol"
+    timezone: "Australia/Melbrone"
+`);
+    let caught: Error | null = null;
+    try { loadConfig(path); } catch (e) { caught = e as Error; }
+    expect(caught).toBeInstanceOf(ConfigError);
+    const joined = (caught as ConfigError).details?.join("\n") ?? "";
+    expect(joined).toContain("agents.carol.timezone");
+    expect(joined).toContain("Australia/Melbrone");
+  });
+
+  it("aggregates typos across the global layer and multiple agents", () => {
+    const path = writeTempConfig(`
+switchroom:
+  version: 1
+  timezone: "America/New_Yrok"
+telegram:
+  bot_token: "x"
+  forum_chat_id: "1"
+agents:
+  dave:
+    topic_name: "dave"
+    timezone: "Europe/Lodnon"
+`.trim());
+    let caught: Error | null = null;
+    try { loadConfig(path); } catch (e) { caught = e as Error; }
+    expect(caught).toBeInstanceOf(ConfigError);
+    const details = (caught as ConfigError).details ?? [];
+    expect(details.length).toBe(2);
+    const joined = details.join("\n");
+    expect(joined).toContain("switchroom.timezone");
+    expect(joined).toContain("agents.dave.timezone");
+  });
+});

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -8,6 +8,7 @@ import { resolveDualPath } from "./paths.js";
 import { applyAgentOverlays } from "./overlay-loader.js";
 import { resolveAgentConfig } from "./merge.js";
 import { validateNotionWorkspaceConfig } from "./notion-workspace-acl.js";
+import { isResolvableTimezone } from "./timezone.js";
 
 export class ConfigError extends Error {
   constructor(
@@ -222,7 +223,57 @@ export function loadConfig(configPath?: string): SwitchroomConfig {
     );
   }
 
+  // #tz-fix audit (LOW gap 3): the `timezone` zod fields enforce SHAPE only
+  // (TIMEZONE_REGEX). A shape-valid TYPO like `Australia/Melbrone` passes the
+  // schema, then silently degrades to UTC at runtime when `Intl`/`ZoneInfo`
+  // reject the unknown zone. Reject it here — at config load/apply — so the
+  // operator sees a loud failure instead of every agent quietly running in
+  // UTC. Same fail-fast rationale as the cron-topic and notion checks above.
+  validateAllTimezones(config, filePath);
+
   return config;
+}
+
+/**
+ * Reject any declared `timezone:` value that is shape-valid (passes the zod
+ * TIMEZONE_REGEX) but names a zone the runtime cannot actually resolve — the
+ * typo case that would otherwise degrade silently to UTC at runtime.
+ *
+ * Walks every layer that carries a `timezone` field (global, defaults, each
+ * profile, each agent), aggregating all violations into one `ConfigError` so a
+ * yaml with several typos surfaces them all in a single pass.
+ */
+function validateAllTimezones(
+  config: SwitchroomConfig,
+  filePath: string,
+): void {
+  const issues: string[] = [];
+  const check = (zone: string | undefined, where: string): void => {
+    if (zone == null) return;
+    if (!isResolvableTimezone(zone)) {
+      issues.push(
+        `  ${where}: "${zone}" is not a resolvable IANA timezone ` +
+        `(shape is valid but no such zone exists — check for a typo, ` +
+        `e.g. "Australia/Melbourne", "America/New_York", "UTC").`,
+      );
+    }
+  };
+
+  check(config.switchroom?.timezone, "switchroom.timezone");
+  check(config.defaults?.timezone, "defaults.timezone");
+  for (const [profileName, profile] of Object.entries(config.profiles ?? {})) {
+    check(profile?.timezone, `profiles.${profileName}.timezone`);
+  }
+  for (const [agentName, agentRaw] of Object.entries(config.agents)) {
+    check(agentRaw?.timezone, `agents.${agentName}.timezone`);
+  }
+
+  if (issues.length > 0) {
+    throw new ConfigError(
+      `Invalid timezone configuration in ${filePath}`,
+      issues,
+    );
+  }
 }
 
 /**

--- a/src/config/timezone.ts
+++ b/src/config/timezone.ts
@@ -40,6 +40,32 @@
 import { readFileSync, readlinkSync } from "node:fs";
 import type { AgentConfig, SwitchroomConfig } from "./schema.js";
 
+/**
+ * Does this string name a timezone the runtime can actually resolve?
+ *
+ * `isValidTimezone` (schema.ts) is a SHAPE check — a cheap regex that accepts
+ * any `Region/City` pair without shipping the IANA database. That lets a
+ * shape-valid TYPO (e.g. `Australia/Melbrone`, `America/New_Yrok`) pass config
+ * load, then silently degrade to UTC at runtime because `Intl` / `ZoneInfo`
+ * reject the unknown zone (#tz-fix audit, LOW gap 3).
+ *
+ * This predicate closes that gap by asking the runtime directly: constructing
+ * an `Intl.DateTimeFormat` with an unknown `timeZone` throws `RangeError`,
+ * while every real IANA zone (and `UTC`) succeeds. Node ships full-ICU by
+ * default, so the tz database backing this is the same one the agent's
+ * `Intl`-based local-time rendering uses — a zone that passes here is a zone
+ * that renders correctly at runtime. Total: never throws, returns a boolean.
+ */
+export function isResolvableTimezone(zone: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new Intl.DateTimeFormat("en-US", { timeZone: zone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export interface ResolveTimezoneOpts {
   /**
    * Read /etc/timezone (or equivalent). Return the trimmed string or

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -102,7 +102,7 @@ import {
   forwardOriginDateIso,
   type ForwardOriginInfo,
 } from './forward-origin.js'
-import { fmtLocalStamp, resolveEnvTimezone } from '../shared/local-time.js'
+import { fmtLocalStamp, resolveEnvTimezone, renderLogTimestampsLocal } from '../shared/local-time.js'
 import { StatusReactionController } from '../status-reactions.js'
 import { DeferredDoneReactions } from '../reaction-defer.js'
 import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
@@ -22911,9 +22911,14 @@ async function runSwitchroomCommand(
   // commands) preserve in-place reply behavior. /logs /audit
   // /upgradestatus /memory pass 'heavy' to route to admin alias.
   classification: 'query' | 'mutation' | 'heavy' = 'query',
+  // Optional DISPLAY-ONLY transform applied to the stripped command output
+  // before formatting (never mutates the underlying stored logs). /logs uses
+  // this to render leading UTC ISO docker-log timestamps in local am/pm.
+  transformOutput?: (raw: string) => string,
 ): Promise<void> {
   try {
-    const output = stripAnsi(switchroomExec(args))
+    const stripped = stripAnsi(switchroomExec(args))
+    const output = transformOutput ? transformOutput(stripped) : stripped
     const formatted = formatSwitchroomOutput(output)
     if (formatted) { await switchroomReply(ctx, preBlock(formatted), { html: true, classification }) }
     else { await switchroomReply(ctx, `${label}: done (no output)`, { classification }) }
@@ -26982,7 +26987,18 @@ bot.command('logs', async ctx => {
   const lines = linesArg ? parseInt(linesArg, 10) : 20
   const lineCount = isNaN(lines) || lines < 1 ? 20 : Math.min(lines, 200)
   // PR5 — heavy-output → admin alias in supergroup mode (CPO #4).
-  await runSwitchroomCommand(ctx, ['agent', 'logs', name, '--lines', String(lineCount)], `logs ${name}`, 'heavy')
+  // #tz-fix audit (MEDIUM gap 2): docker log lines carry a leading UTC ISO-Z
+  // timestamp. Render it in the operator's local am/pm at DISPLAY time so
+  // `/logs` doesn't surface UTC (competing with the local-time hint). Stored
+  // logs are untouched — this transform runs only on the text sent to chat.
+  const tz = resolveEnvTimezone()
+  await runSwitchroomCommand(
+    ctx,
+    ['agent', 'logs', name, '--lines', String(lineCount)],
+    `logs ${name}`,
+    'heavy',
+    (raw) => renderLogTimestampsLocal(raw, tz),
+  )
 })
 
 bot.command('memory', async ctx => {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -26987,14 +26987,19 @@ bot.command('logs', async ctx => {
   const lines = linesArg ? parseInt(linesArg, 10) : 20
   const lineCount = isNaN(lines) || lines < 1 ? 20 : Math.min(lines, 200)
   // PR5 — heavy-output → admin alias in supergroup mode (CPO #4).
-  // #tz-fix audit (MEDIUM gap 2): docker log lines carry a leading UTC ISO-Z
-  // timestamp. Render it in the operator's local am/pm at DISPLAY time so
-  // `/logs` doesn't surface UTC (competing with the local-time hint). Stored
-  // logs are untouched — this transform runs only on the text sent to chat.
+  // #tz-fix audit (MEDIUM gap 2): `--timestamps` makes docker prefix every
+  // line with its own UTC ISO-8601-Z stamp — the only deterministic per-line
+  // timestamp (raw app lines often carry no stamp, or a local-zone one that
+  // must NOT be re-shifted). We then render that stamp in local am/pm at
+  // DISPLAY time so `/logs` doesn't surface UTC (competing with the
+  // local-time hint). The zone is the GATEWAY/operator zone
+  // (resolveEnvTimezone of this process), not the target agent's zone —
+  // intended: /logs is an operator surface. Stored logs are untouched —
+  // the transform runs only on the text sent to chat.
   const tz = resolveEnvTimezone()
   await runSwitchroomCommand(
     ctx,
-    ['agent', 'logs', name, '--lines', String(lineCount)],
+    ['agent', 'logs', name, '--lines', String(lineCount), '--timestamps'],
     `logs ${name}`,
     'heavy',
     (raw) => renderLogTimestampsLocal(raw, tz),

--- a/telegram-plugin/shared/local-time.ts
+++ b/telegram-plugin/shared/local-time.ts
@@ -123,3 +123,36 @@ export function fmtLocalStamp(ms: number, tz: string): string {
     return new Date(ms).toISOString()
   }
 }
+
+/**
+ * Leading ISO-8601-Z timestamp at the start of a log line, e.g.
+ * `2026-07-16T04:09:00.123456789Z` or `2026-07-16T04:09:00Z`. Docker log
+ * lines (as surfaced by `switchroom agent logs`) carry one of these per line.
+ * Anchored at line start; the trailing capture is the rest of the line.
+ */
+const LEADING_ISO_Z = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)(\s|$)/
+
+/**
+ * DISPLAY-ONLY: rewrite a leading UTC ISO-8601-Z timestamp on each line of
+ * `text` into the operator's LOCAL am/pm wall clock via {@link fmtLocalStamp},
+ * so `/logs` output reads `Thursday 2026-07-16 02:09 PM AEST …` instead of a
+ * raw `…T04:09:00Z`. Applied at send time; never mutates stored logs.
+ *
+ * Pure / total — matches ONLY a well-formed leading ISO-Z stamp and preserves
+ * every other line (and any line whose timestamp doesn't parse) verbatim, so a
+ * non-timestamped or partial log line is passed through untouched. `\r`
+ * line endings are preserved.
+ */
+export function renderLogTimestampsLocal(text: string, tz: string): string {
+  if (!text) return text
+  return text
+    .split('\n')
+    .map((line) => {
+      const m = LEADING_ISO_Z.exec(line)
+      if (!m) return line
+      const ms = Date.parse(m[1])
+      if (Number.isNaN(ms)) return line
+      return `${fmtLocalStamp(ms, tz)}${m[2] === '' ? '' : ' '}${line.slice(m[0].length)}`
+    })
+    .join('\n')
+}

--- a/telegram-plugin/shared/local-time.ts
+++ b/telegram-plugin/shared/local-time.ts
@@ -134,9 +134,19 @@ const LEADING_ISO_Z = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)(\s|$)/
 
 /**
  * DISPLAY-ONLY: rewrite a leading UTC ISO-8601-Z timestamp on each line of
- * `text` into the operator's LOCAL am/pm wall clock via {@link fmtLocalStamp},
+ * `text` into the caller's LOCAL am/pm wall clock via {@link fmtLocalStamp},
  * so `/logs` output reads `Thursday 2026-07-16 02:09 PM AEST …` instead of a
  * raw `…T04:09:00Z`. Applied at send time; never mutates stored logs.
+ *
+ * The leading stamp comes from `docker logs --timestamps` (requested by the
+ * /logs path via `switchroom agent logs --timestamps`) — docker's stamp is
+ * ALWAYS UTC ISO-Z, which is what makes this conversion deterministic. App-
+ * emitted stamps inside the line body (e.g. Python's `%H:%M:%S,mmm`) are
+ * deliberately NOT converted: post-#3275 containers run with local TZ baked,
+ * so those are already local wall clock — re-shifting them as UTC would be
+ * wrong. The `tz` passed by /logs is the GATEWAY/operator zone
+ * (`resolveEnvTimezone` of the gateway process), not the target agent's
+ * zone — intended, since /logs is an operator-facing surface.
  *
  * Pure / total — matches ONLY a well-formed leading ISO-Z stamp and preserves
  * every other line (and any line whose timestamp doesn't parse) verbatim, so a

--- a/telegram-plugin/tests/local-time.test.ts
+++ b/telegram-plugin/tests/local-time.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { fmtLocalStamp, resolveEnvTimezone } from '../shared/local-time.js'
+import { fmtLocalStamp, resolveEnvTimezone, renderLogTimestampsLocal } from '../shared/local-time.js'
 
 // 2025-06-15T14:26:40Z — a fixed instant so the local rendering is deterministic.
 const MS = 1750000000 * 1000
@@ -64,5 +64,52 @@ describe('fmtLocalStamp', () => {
       expect(s).toMatch(/ (?:AM|PM) /)
       expect(s).not.toContain('UTC')
     }
+  })
+})
+
+describe('renderLogTimestampsLocal', () => {
+  // #tz-fix audit (MEDIUM gap 2): /logs docker lines carry a leading UTC
+  // ISO-Z stamp; render it in local am/pm at display time.
+  it('rewrites a leading UTC ISO-Z timestamp into local am/pm', () => {
+    // 04:09Z in July → Melbourne AEST (UTC+10) → 02:09 PM.
+    const out = renderLogTimestampsLocal(
+      '2026-07-16T04:09:00.123456789Z gateway boot ok',
+      'Australia/Melbourne',
+    )
+    expect(out).toContain('2026-07-16 02:09 PM AEST')
+    expect(out).toContain('gateway boot ok')
+    expect(out).not.toContain('T04:09')
+    expect(out).not.toContain('Z gateway')
+  })
+
+  it('handles a fractionless ISO-Z timestamp', () => {
+    const out = renderLogTimestampsLocal('2026-07-16T04:09:00Z hello', 'Australia/Melbourne')
+    expect(out).toContain('2026-07-16 02:09 PM AEST hello')
+  })
+
+  it('converts every line and preserves non-timestamped lines verbatim', () => {
+    const input = [
+      '2026-07-16T04:09:00Z first',
+      '  continuation line with no timestamp',
+      '2026-07-16T05:10:00Z second',
+    ].join('\n')
+    const out = renderLogTimestampsLocal(input, 'Australia/Melbourne').split('\n')
+    expect(out[0]).toContain('02:09 PM AEST first')
+    expect(out[1]).toBe('  continuation line with no timestamp')
+    expect(out[2]).toContain('03:10 PM AEST second')
+  })
+
+  it('preserves a line whose leading token is not a valid ISO-Z stamp', () => {
+    const raw = 'not-a-timestamp still here'
+    expect(renderLogTimestampsLocal(raw, 'Australia/Melbourne')).toBe(raw)
+  })
+
+  it('does not touch a timestamp that is not at line start', () => {
+    const raw = 'prefix 2026-07-16T04:09:00Z trailing'
+    expect(renderLogTimestampsLocal(raw, 'Australia/Melbourne')).toBe(raw)
+  })
+
+  it('returns empty input unchanged', () => {
+    expect(renderLogTimestampsLocal('', 'Australia/Melbourne')).toBe('')
   })
 })

--- a/telegram-plugin/tests/local-time.test.ts
+++ b/telegram-plugin/tests/local-time.test.ts
@@ -112,4 +112,24 @@ describe('renderLogTimestampsLocal', () => {
   it('returns empty input unchanged', () => {
     expect(renderLogTimestampsLocal('', 'Australia/Melbourne')).toBe('')
   })
+
+  // End-to-end shape check against REAL `docker logs --timestamps` output —
+  // the /logs path requests --timestamps precisely so this prefix exists.
+  // (Captured verbatim from a live container; nanosecond precision.)
+  it('converts a verbatim docker --timestamps line (the real /logs input shape)', () => {
+    const real = '2026-07-16T20:17:58.433481596Z gateway-supervisor: heartbeat ok'
+    const out = renderLogTimestampsLocal(real, 'Australia/Melbourne')
+    // 20:17:58Z on 16 Jul → AEST (UTC+10) → 06:17 AM on 17 Jul local.
+    expect(out).toBe('Friday 2026-07-17 06:17 AM AEST gateway-supervisor: heartbeat ok')
+    expect(out).not.toContain('Z ')
+    expect(out).not.toContain('UTC')
+  })
+
+  it('does NOT touch an app-emitted local-zone stamp (no double shift)', () => {
+    // Post-#3275 containers run with local TZ baked, so Python-style
+    // `%H:%M:%S,mmm` stamps are already local wall clock — converting them
+    // as UTC would be wrong. They must pass through verbatim.
+    const appLine = '2026-07-16 20:14:14,725 - INFO - scheduler tick'
+    expect(renderLogTimestampsLocal(appLine, 'Australia/Melbourne')).toBe(appLine)
+  })
 })

--- a/tests/handoff-briefing.test.ts
+++ b/tests/handoff-briefing.test.ts
@@ -228,6 +228,21 @@ function dateInZone(tz: string): string {
 const AGENT_ZONE = "Pacific/Kiritimati"; // UTC+14 — the agent's SWITCHROOM_TIMEZONE
 const PROC_ZONE = "Pacific/Midway"; //     UTC-11 — the process TZ (what un-TZ'd `date` reads)
 
+/**
+ * "Today" exactly as handoff-briefing.sh will compute it — run the SAME
+ * `date +%Y-%m-%d` the script runs (bin/handoff-briefing.sh `TODAY=`),
+ * under the EXACT env the script will receive. Tests that pin or delete
+ * TZ/SWITCHROOM_TIMEZONE in the child env MUST name the daily-memory file
+ * with this (not `localDateString()`, which uses the vitest process TZ):
+ * a UTC runner between 14:00–24:00 UTC is already "tomorrow" in
+ * Australia/Melbourne, so the two dates disagree and the script finds no
+ * daily memory — the pre-existing date-boundary flake in this file.
+ */
+function scriptDateString(env: NodeJS.ProcessEnv): string {
+  const r = spawnSync("bash", ["-c", "date +%Y-%m-%d"], { env, timeout: 5_000 });
+  return r.stdout.toString().trim();
+}
+
 describe("handoff-briefing.sh assembler", () => {
   let tmpDir: string;
 
@@ -369,29 +384,29 @@ describe("handoff-briefing.sh assembler", () => {
     // must be local am/pm, NOT the old `date -u +%Y-%m-%dT%H:%M:%SZ`. Nothing
     // guarded this before, which is how it slipped past the first pass.
     //
-    // Name the daily-memory file in the SAME zone we pass to the script
-    // (Australia/Melbourne) — NOT the test process's zone. The script resolves
-    // TODAY in Melbourne, so during the UTC/local date-divergence window a
-    // parent-zone name (e.g. localDateString() on a UTC CI runner) would write
-    // the wrong day's file, the daily section would be empty, the whole briefing
-    // would be empty, and the regex below would match null. Zone-align the name
-    // so this test is deterministic regardless of the runner's wall clock.
-    const today = dateInZone("Australia/Melbourne");
+    // The script runs under TZ=Australia/Melbourne, so "today" (and the
+    // daily-memory filename it looks for) must be derived under THAT zone —
+    // not the runner's process TZ. A UTC CI runner after 14:00 UTC is
+    // already tomorrow in Melbourne; using localDateString() here made the
+    // script find no daily memory and the regex match null (date-boundary
+    // flake, pre-existing from #3275). Derive it under the child's exact env.
+    const env = {
+      ...process.env,
+      AGENT_DIR: tmpDir,
+      TELEGRAM_STATE_DIR: "",
+      HINDSIGHT_API_URL: "",
+      HINDSIGHT_BANK_ID: "",
+      WORKSPACE_DIR: tmpDir,
+      SWITCHROOM_TIMEZONE: "Australia/Melbourne",
+      TZ: "Australia/Melbourne",
+    };
+    const today = scriptDateString(env);
     const memDir = join(tmpDir, "memory");
     mkdirSync(memDir, { recursive: true });
     writeFileSync(join(memDir, `${today}.md`), "- Restart-time guard\n", "utf-8");
 
     const result = spawnSync("bash", [HANDOFF_BRIEFING_SCRIPT, "--stdout"], {
-      env: {
-        ...process.env,
-        AGENT_DIR: tmpDir,
-        TELEGRAM_STATE_DIR: "",
-        HINDSIGHT_API_URL: "",
-        HINDSIGHT_BANK_ID: "",
-        WORKSPACE_DIR: tmpDir,
-        SWITCHROOM_TIMEZONE: "Australia/Melbourne",
-        TZ: "Australia/Melbourne",
-      },
+      env,
       timeout: 10_000,
     });
     expect(result.status).toBe(0);
@@ -451,11 +466,6 @@ describe("handoff-briefing.sh assembler", () => {
   });
 
   it("restart timestamp falls back to am/pm even with no timezone configured (no UTC 24h form)", () => {
-    const today = localDateString();
-    const memDir = join(tmpDir, "memory");
-    mkdirSync(memDir, { recursive: true });
-    writeFileSync(join(memDir, `${today}.md`), "- Restart-time fallback guard\n", "utf-8");
-
     const env = {
       ...process.env,
       AGENT_DIR: tmpDir,
@@ -466,6 +476,14 @@ describe("handoff-briefing.sh assembler", () => {
     } as NodeJS.ProcessEnv;
     delete env.SWITCHROOM_TIMEZONE;
     delete env.TZ;
+
+    // With TZ deleted, the child bash falls back to the SYSTEM zone, which
+    // may differ from the vitest process's TZ env — derive "today" under the
+    // child's env (same date-boundary rationale as the Melbourne test above).
+    const today = scriptDateString(env);
+    const memDir = join(tmpDir, "memory");
+    mkdirSync(memDir, { recursive: true });
+    writeFileSync(join(memDir, `${today}.md`), "- Restart-time fallback guard\n", "utf-8");
 
     const result = spawnSync("bash", [HANDOFF_BRIEFING_SCRIPT, "--stdout"], {
       env,

--- a/tests/timezone.test.ts
+++ b/tests/timezone.test.ts
@@ -4,6 +4,7 @@ import {
   extractZoneFromLocaltimeLink,
   resolveTimezone,
   classifyTimezoneSource,
+  isResolvableTimezone,
 } from "../src/config/timezone.js";
 import { SwitchroomConfigSchema, type AgentConfig, type SwitchroomConfig } from "../src/config/schema.js";
 
@@ -421,5 +422,27 @@ describe("schema validation — timezone", () => {
       baseConfig({ timezone: zone }),
     );
     expect(result.success).toBe(false);
+  });
+});
+
+describe("isResolvableTimezone (#tz-fix audit gap 3)", () => {
+  it.each(["UTC", "Australia/Melbourne", "America/New_York", "America/Argentina/Buenos_Aires"])(
+    "accepts the real IANA zone %s",
+    (zone) => {
+      expect(isResolvableTimezone(zone)).toBe(true);
+    },
+  );
+
+  it.each(["Australia/Melbrone", "America/New_Yrok", "Europe/Lodnon", "Foo/Bar"])(
+    "rejects the shape-valid-but-nonexistent zone %s",
+    (zone) => {
+      // These pass TIMEZONE_REGEX (Region/City shape) but no such zone exists;
+      // the runtime would silently degrade them to UTC without this check.
+      expect(isResolvableTimezone(zone)).toBe(false);
+    },
+  );
+
+  it("rejects garbage without throwing", () => {
+    expect(isResolvableTimezone("not a zone!!")).toBe(false);
   });
 });

--- a/vendor/hindsight-memory/scripts/lib/content.py
+++ b/vendor/hindsight-memory/scripts/lib/content.py
@@ -255,7 +255,13 @@ def format_memories(results: list) -> str:
         mem_type = r.get("type", "")
         mentioned_at = r.get("mentioned_at", "")
         type_str = f" [{mem_type}]" if mem_type else ""
-        date_str = f" ({mentioned_at})" if mentioned_at else ""
+        # switchroom #tz-fix (recall side): mentioned_at arrives as a UTC ISO
+        # timestamp from the Hindsight server. Render it through the same
+        # SWITCHROOM_TIMEZONE→TZ→UTC zoneinfo conversion as format_current_time
+        # so recall lines never inject a UTC "when". Date-only / unparseable
+        # values are surfaced verbatim rather than crashing recall.
+        display_at = _format_local_timestamp(mentioned_at) if mentioned_at else ""
+        date_str = f" ({display_at})" if display_at else ""
         lines.append(f"- {text}{type_str}{date_str}")
     return "\n\n".join(lines)
 
@@ -269,6 +275,52 @@ def _resolve_agent_timezone() -> str:
     so it inherits both env vars (compose.ts bakes them onto the container).
     """
     return os.environ.get("SWITCHROOM_TIMEZONE") or os.environ.get("TZ") or "UTC"
+
+
+def _format_local_timestamp(value: str) -> str:
+    """Render a UTC ISO timestamp in the agent's LOCAL timezone (am/pm form).
+
+    Used by ``format_memories`` to convert the server-supplied ``mentioned_at``
+    (UTC ISO, e.g. ``2026-07-16T04:09:00Z``) through the same
+    SWITCHROOM_TIMEZONE→TZ→UTC zoneinfo cascade as ``format_current_time``,
+    so recalled memories never surface a UTC "when".
+
+    Guarding: only full ISO *datetime* values (those carrying a time component,
+    i.e. containing ``T``) are converted. Date-only strings (``2024-01-01``) and
+    anything unparseable are returned verbatim rather than crashing recall or
+    fabricating a midnight time.
+    """
+    if not isinstance(value, str):
+        return value
+    raw = value.strip()
+    # Only convert full ISO datetimes — a bare date has no wall-clock to shift.
+    if "T" not in raw:
+        return value
+    parsed = None
+    try:
+        # Python <3.11 fromisoformat rejects a trailing 'Z'; normalise it.
+        iso = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+        parsed = datetime.fromisoformat(iso)
+    except (ValueError, TypeError):
+        return value
+    # Naive value → server sends UTC, so assume UTC before converting.
+    if parsed.tzinfo is None:
+        if ZoneInfo is not None:
+            try:
+                parsed = parsed.replace(tzinfo=ZoneInfo("UTC"))
+            except Exception:
+                return value
+        else:
+            return value
+    tz_name = _resolve_agent_timezone()
+    if ZoneInfo is not None:
+        try:
+            local = parsed.astimezone(ZoneInfo(tz_name))
+        except Exception:  # unknown/invalid zone — degrade to process-local.
+            local = parsed.astimezone()
+    else:
+        local = parsed.astimezone()
+    return local.strftime("%Y-%m-%d %I:%M %p %Z")
 
 
 def format_current_time() -> str:

--- a/vendor/hindsight-memory/tests/test_content.py
+++ b/vendor/hindsight-memory/tests/test_content.py
@@ -329,6 +329,41 @@ class TestFormatMemories:
         result = format_memories(mems)
         assert "bare memory" in result
 
+    # switchroom #tz-fix (recall side): mentioned_at is a UTC ISO timestamp
+    # from the Hindsight server; recall must render it in the agent's LOCAL
+    # am/pm, not surface a UTC "when".
+    def test_mentioned_at_utc_iso_rendered_local(self, monkeypatch):
+        monkeypatch.setenv("SWITCHROOM_TIMEZONE", "Australia/Melbourne")
+        monkeypatch.delenv("TZ", raising=False)
+        # 04:09Z in July → AEST (UTC+10) → 02:09 PM local.
+        mems = [{"text": "m", "mentioned_at": "2026-07-16T04:09:00Z"}]
+        result = format_memories(mems)
+        assert "(2026-07-16 02:09 PM AEST)" in result
+        # Never the raw UTC value.
+        assert "04:09:00Z" not in result
+        assert "T04:09" not in result
+
+    def test_mentioned_at_offset_form_rendered_local(self, monkeypatch):
+        monkeypatch.setenv("SWITCHROOM_TIMEZONE", "Australia/Melbourne")
+        monkeypatch.delenv("TZ", raising=False)
+        mems = [{"text": "m", "mentioned_at": "2026-07-16T04:09:00+00:00"}]
+        result = format_memories(mems)
+        assert "(2026-07-16 02:09 PM AEST)" in result
+
+    def test_mentioned_at_date_only_preserved_verbatim(self, monkeypatch):
+        # A bare date has no wall clock to shift — surface it verbatim rather
+        # than fabricating a midnight time.
+        monkeypatch.setenv("SWITCHROOM_TIMEZONE", "Australia/Melbourne")
+        mems = [{"text": "m", "mentioned_at": "2024-01-01"}]
+        result = format_memories(mems)
+        assert "(2024-01-01)" in result
+
+    def test_mentioned_at_unparseable_preserved_verbatim(self, monkeypatch):
+        monkeypatch.setenv("SWITCHROOM_TIMEZONE", "Australia/Melbourne")
+        mems = [{"text": "m", "mentioned_at": "not-a-timestampT!!"}]
+        result = format_memories(mems)
+        assert "(not-a-timestampT!!)" in result
+
 
 # ---------------------------------------------------------------------------
 # _is_channel_message_tool


### PR DESCRIPTION
> **Depends on #3283 (`fix/logs-lines-flag`).** This branch is rebased on top of it — the `/logs` path needs its `--lines`/`--tail` support. Merge #3283 first; this PR then reduces to its own commits.

## Summary

Follow-up to the timezone input-side fix (#3275, commit `a1872cc1`). The fleet-wide tz audit confirmed the input side is deterministic but left three surfaces still leaking UTC to the user or silently accepting bad config. This closes all three.

**Gap 1 (MEDIUM) — Recalled-memory timestamps unconverted.** `vendor/hindsight-memory/scripts/lib/content.py` `format_memories()` surfaced the server's `mentioned_at` (UTC ISO) verbatim. It now renders through the same `SWITCHROOM_TIMEZONE→TZ→UTC` zoneinfo cascade as `format_current_time`, via a new `_format_local_timestamp` helper. Date-only (`2024-01-01`) and unparseable values are surfaced verbatim rather than crashing recall or fabricating a midnight time.

**Gap 2 (MEDIUM) — `/logs` shown in UTC.** Raw `docker logs` output carries **no** leading timestamp (verified against a live container) — so the display transform alone would be dead code. Fixed end to end:
- `buildAgentLogsArgs` / `getAgentLogs` (`src/agents/lifecycle.ts`) gain a `timestamps` arg that emits `docker logs --timestamps`, whose per-line prefix is **always UTC ISO-8601-Z** — the only deterministic per-line stamp.
- New `-t/--timestamps` flag on `switchroom agent logs` (`src/cli/agent.ts`).
- The Telegram `/logs` handler passes `--timestamps` and pipes the output through the new pure/total `renderLogTimestampsLocal` (`telegram-plugin/shared/local-time.ts`, built on `fmtLocalStamp`/`resolveEnvTimezone`), rewriting each leading stamp to local am/pm **at display time only** — stored logs are never mutated; non-matching lines pass through verbatim.
- **Deliberately NOT converted:** app-emitted stamps inside the line body (e.g. Python `%H:%M:%S,mmm`). Post-#3275, containers run with local TZ baked, so those are already local wall clock — re-shifting them as UTC would double-shift. Pinned by a regression test.
- The render zone is the **gateway/operator zone** (`resolveEnvTimezone` of the gateway process), not the target agent's zone — intended, since `/logs` is an operator surface. Documented in the docstring and handler comment.

**Gap 3 (LOW) — Invalid timezone config fails silently to UTC.** A shape-valid but non-existent IANA zone (e.g. a typo `Australia/Melbrone`) passed the `TIMEZONE_REGEX` zod check and then silently degraded to UTC at runtime. New `isResolvableTimezone` (`src/config/timezone.ts`, Intl-backed) plus a `validateAllTimezones` pass in the config loader now reject it **loudly at config load / apply** across the global, defaults, profile and agent layers, aggregating all typos into one `ConfigError` (same fail-fast pattern as the cron-topic-alias and notion checks).

## ⚠️ Behavior change (release-note callout)

Config load/apply now **hard-fails** on a `timezone:` value that is shape-valid but names a non-existent IANA zone. Any fleet currently running with such a typo has been silently on UTC the whole time — the failure is the intended loud signal, and the error names the exact field to fix. Also in the CHANGELOG under Unreleased.

## Why

Advances the "on the leash / always available" outcome: an operator reading `/logs` or a recalled memory on their phone should see their own wall clock, and a typo'd zone should fail the apply instead of quietly making every agent run in UTC.

## Out of scope (deliberate)

Outbound-prose time formatting — the model writing "14:30" in a free-text reply — is **explicitly out of scope pending a product decision**. This PR only touches deterministic, code-controlled render points.

## Test plan

Scoped, outcome-asserting:
- `vendor/hindsight-memory/tests/test_content.py` — UTC ISO `mentioned_at` renders as `2026-07-16 02:09 PM AEST`; offset form; date-only + unparseable verbatim. pytest → **67 passed**.
- `telegram-plugin/tests/local-time.test.ts` — **verbatim real `docker logs --timestamps` line** (captured live, nanosecond precision) renders end-to-end as `Friday 2026-07-17 06:17 AM AEST …`; app-format `%H:%M:%S,mmm` line passes through untouched (no double shift); multi-line, non-leading, unparseable, empty inputs preserved. **14 passed**.
- `src/cli/agent.test.ts` — argv contract includes `--timestamps` when requested and omits it by default; the `--timestamps` option is registered on the command (the same drift class that broke `--lines` in #3283). **20 passed**.
- `tests/timezone.test.ts` — `isResolvableTimezone` accepts real zones + `UTC`, rejects shape-valid typos without throwing. **67 passed**.
- `src/config/loader.test.ts` — typo'd agent/global zone rejected at `loadConfig` with the offending path named; valid zones load; multiple typos aggregate. **23 passed**.
- `npm run lint` — clean (all gates).

## Risk

Low-medium. Gaps 1 and 2 are display-only. Gap 3 is the deliberate breaking-on-bad-input change called out above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Folded in: pre-existing CI flake fix

`tests/handoff-briefing.test.ts` had a date-boundary flake (from #3275, on main) failing vitest-shard 1 on any CI run between 14:00–24:00 UTC: the tests named the daily-memory file via `localDateString()` (vitest process TZ) but ran `handoff-briefing.sh` under a different zone (pinned `Australia/Melbourne`, or TZ deleted), so across a date boundary the script's `date +%Y-%m-%d` looked for a different filename, found nothing, emitted nothing, and the regex matched null. Fixed by deriving "today" via a `scriptDateString(env)` helper that runs the script's own `date +%Y-%m-%d` under the exact child env — both sides agree by construction in any runner TZ. Verified: pre-fix reproduces (2 failed) with runner TZ=America/New_York while Melbourne is past midnight; post-fix 24/24 under runner TZ of UTC, America/New_York, Pacific/Kiritimati (UTC+14), Pacific/Midway (UTC-11), Australia/Melbourne.