### PR TITLE
fix(handoff): deterministic date-boundary in #3275 handoff-briefing test

### DIFF
--- a/bin/handoff-briefing.sh
+++ b/bin/handoff-briefing.sh
@@ -135,8 +135,14 @@ $RECALL_TEXT"
 fi
 
 # ── Source 3: Today's daily memory ─────────────────────────────────────────────
+# Resolve "today" in the agent's LOCAL time — NOT the process default (UTC on
+# most hosts/CI). TODAY keys the daily-memory lookup (memory/${TODAY}.md); using
+# UTC here would look up the wrong day's file during the window where the local
+# date is ahead of/behind UTC, silently dropping today's memory. Same
+# SWITCHROOM_TIMEZONE → TZ → UTC cascade the restart-timestamp render below uses.
+_TZ_VAL="${SWITCHROOM_TIMEZONE:-${TZ:-UTC}}"
 DAILY_SECTION=""
-TODAY=$(date +%Y-%m-%d 2>/dev/null || true)
+TODAY=$(TZ="$_TZ_VAL" date +%Y-%m-%d 2>/dev/null || date +%Y-%m-%d 2>/dev/null || true)
 if [ -n "$TODAY" ] && [ -n "$WORKSPACE_DIR" ]; then
   DAILY_FILE="$WORKSPACE_DIR/memory/${TODAY}.md"
   if [ -f "$DAILY_FILE" ] && [ -s "$DAILY_FILE" ]; then
@@ -156,7 +162,7 @@ fi
 # UTC "now" (the whole point of the deterministic-local-time work). Same
 # SWITCHROOM_TIMEZONE → TZ → UTC cascade and `%A %Y-%m-%d %I:%M %p %Z` am/pm
 # format the UserPromptSubmit local-time hook (bin/timezone-hook.sh) uses.
-_TZ_VAL="${SWITCHROOM_TIMEZONE:-${TZ:-UTC}}"
+# (_TZ_VAL is computed once above, in the daily-memory section.)
 TIMESTAMP=$(TZ="$_TZ_VAL" date '+%A %Y-%m-%d %I:%M %p %Z' 2>/dev/null || date '+%A %Y-%m-%d %I:%M %p %Z')
 
 # Determine restart reason if available

--- a/tests/handoff-briefing.test.ts
+++ b/tests/handoff-briefing.test.ts
@@ -209,6 +209,25 @@ function localDateString(): string {
   return `${year}-${month}-${day}`;
 }
 
+// YYYY-MM-DD for "now" as observed in the given IANA timezone (en-CA yields
+// ISO-ordered date parts). Matches what `TZ=<zone> date +%Y-%m-%d` prints.
+function dateInZone(tz: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date());
+}
+
+// Two real IANA zones whose local clocks are 25h apart (UTC+14 vs UTC-11), so
+// their calendar dates ALWAYS differ by exactly one day — at every instant,
+// independent of the runner's wall clock. This gives a *deterministic* (not
+// luck-of-the-date) UTC/local date-divergence window: agentZone is a full day
+// ahead of procZone, always.
+const AGENT_ZONE = "Pacific/Kiritimati"; // UTC+14 — the agent's SWITCHROOM_TIMEZONE
+const PROC_ZONE = "Pacific/Midway"; //     UTC-11 — the process TZ (what un-TZ'd `date` reads)
+
 describe("handoff-briefing.sh assembler", () => {
   let tmpDir: string;
 
@@ -349,7 +368,15 @@ describe("handoff-briefing.sh assembler", () => {
     // at …" line is injected into the resume-turn system prompt, so its time
     // must be local am/pm, NOT the old `date -u +%Y-%m-%dT%H:%M:%SZ`. Nothing
     // guarded this before, which is how it slipped past the first pass.
-    const today = localDateString();
+    //
+    // Name the daily-memory file in the SAME zone we pass to the script
+    // (Australia/Melbourne) — NOT the test process's zone. The script resolves
+    // TODAY in Melbourne, so during the UTC/local date-divergence window a
+    // parent-zone name (e.g. localDateString() on a UTC CI runner) would write
+    // the wrong day's file, the daily section would be empty, the whole briefing
+    // would be empty, and the regex below would match null. Zone-align the name
+    // so this test is deterministic regardless of the runner's wall clock.
+    const today = dateInZone("Australia/Melbourne");
     const memDir = join(tmpDir, "memory");
     mkdirSync(memDir, { recursive: true });
     writeFileSync(join(memDir, `${today}.md`), "- Restart-time guard\n", "utf-8");
@@ -380,6 +407,47 @@ describe("handoff-briefing.sh assembler", () => {
     expect(stamp).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/);
     expect(stamp.endsWith("Z")).toBe(false);
     expect(stamp).not.toContain("UTC");
+  });
+
+  it("resolves TODAY (daily-memory lookup) in the agent's LOCAL zone, not UTC — date-boundary regression", () => {
+    // Regression for the un-TZ'd `TODAY=$(date +%Y-%m-%d)` at bin/handoff-briefing.sh:139.
+    // TODAY keys the memory/${TODAY}.md lookup. The agent's SWITCHROOM_TIMEZONE
+    // (AGENT_ZONE, UTC+14) is a full calendar day AHEAD of the process TZ
+    // (PROC_ZONE, UTC-11) at every instant. We write the daily file under the
+    // agent-LOCAL date. Old code reads the process TZ → PROC_ZONE date → looks up
+    // the WRONG (day-behind) file → miss → drops the whole restart header. Fixed
+    // code applies the SWITCHROOM_TIMEZONE cascade → AGENT_ZONE date → hit.
+    const agentDate = dateInZone(AGENT_ZONE);
+    const procDate = dateInZone(PROC_ZONE);
+    expect(agentDate).not.toBe(procDate); // deterministic: 25h apart ⇒ always different days
+
+    const memDir = join(tmpDir, "memory");
+    mkdirSync(memDir, { recursive: true });
+    // File named for the agent's LOCAL date only — NOT the process-TZ date.
+    writeFileSync(join(memDir, `${agentDate}.md`), "- Local-date daily memory\n", "utf-8");
+
+    const result = spawnSync("bash", [HANDOFF_BRIEFING_SCRIPT, "--stdout"], {
+      env: {
+        ...process.env,
+        AGENT_DIR: tmpDir,
+        TELEGRAM_STATE_DIR: "",
+        HINDSIGHT_API_URL: "",
+        HINDSIGHT_BANK_ID: "",
+        WORKSPACE_DIR: tmpDir,
+        // Agent's local zone via SWITCHROOM_TIMEZONE; process TZ a full day behind
+        // so the OLD un-TZ'd `date` resolves to the wrong day and misses the file.
+        SWITCHROOM_TIMEZONE: AGENT_ZONE,
+        TZ: PROC_ZONE,
+      },
+      timeout: 10_000,
+    });
+    expect(result.status).toBe(0);
+    const output = result.stdout.toString();
+    // The daily memory (and therefore the restart header) must be present because
+    // TODAY resolved to the agent-LOCAL date the file was written under.
+    expect(output).toContain("Local-date daily memory");
+    expect(output).toContain(`Today's memory (${agentDate})`);
+    expect(output).toContain("You just restarted at");
   });
 
   it("restart timestamp falls back to am/pm even with no timezone configured (no UTC 24h form)", () => {


### PR DESCRIPTION
## What this is
A **date-boundary flake fix** for the #3275 test `renders the restart timestamp in LOCAL am/pm — never a UTC Z instant`, which fails on CI with `expected null not to be null` whenever CI runs during the UTC/local date-divergence window. (Not, as the first draft of this PR claimed, a live production daily-memory drop — see the script note below.)

## Root cause (the test)
The test names the daily-memory file via `localDateString()` — `new Date().getFullYear()/getMonth()/getDate()`, i.e. the **test process's** zone (the CI runner = UTC). But it spawns `handoff-briefing.sh` with `TZ`/`SWITCHROOM_TIMEZONE=Australia/Melbourne`, and the script resolves `TODAY` in Melbourne.

In the divergence window the test writes `memory/<UTC-date>.md` while the script looks up `memory/<Melbourne-date>.md` → daily section empty → `SECTIONS` empty → script `exit 0` with **no output** → the `You just restarted at …` regex matches `null` → FAIL. It passed at merge time only because the dates happened to be aligned then.

## Fix (makes CI green)
Name the daily-memory file in the **same zone the test passes to the script** (`Australia/Melbourne`) via a new `dateInZone()` helper, so the test is deterministic regardless of the runner's wall-clock UTC/local relationship.

## Proof
- **Pre-fix** (original `localDateString()` line), node process forced divergent (`TZ=America/New_York`): the `renders the restart timestamp in LOCAL am/pm` test fails — `AssertionError: expected null not to be null` (the exact CI red).
- **Post-fix**: that test passes under `TZ=America/New_York`; whole file `25/25` green under `TZ=UTC`, `TZ=America/New_York`, and `TZ=Pacific/Kiritimati`.
- `npm run lint`: clean.

## Script change — defensive consistency, NOT a live prod bug
`bin/handoff-briefing.sh:139` derived `TODAY` from a bare `date +%Y-%m-%d`. In the real agent container `start.sh` exports `TZ == SWITCHROOM_TIMEZONE`, so the bare `date` already resolved correctly — this was **not** a live production daily-memory drop. The change applies the same `SWITCHROOM_TIMEZONE → TZ → UTC` cascade the restart-timestamp render (`:160`) already uses, hardening `TODAY` for the case where ambient `TZ` ever diverges from `SWITCHROOM_TIMEZONE`, and keeping the two derivations consistent. A deterministic regression test accompanies it (agent zone UTC+14 vs process TZ UTC-11, 25h apart ⇒ their calendar dates always differ).

Single-concern: the handoff-briefing test + the consistency hardening of the same script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)