### PR TITLE
fix(model): survive a wedged apply-boot so /model re-applies instead of reverting (#3284)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1182,10 +1182,17 @@ _EFFECTIVE_MODEL={{{modelQ}}}
 printf '%s\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.configured-default-model" 2>/dev/null || true
 
 # Rev-4 hygiene (#3184 review LOW-2): remove the files retired with the
-# keep/revert intent subsystem and the crashloop self-heal. Nothing reads them
-# anymore; without this rm they would linger in the bind-mounted state dir
-# forever after rollout. Idempotent — a cheap no-op once clean.
-rm -f "{{agentDir}}/.relaunch-model-intent" "{{agentDir}}/.session-model-boot-attempts" "{{agentDir}}/.session-model-kept-notified"
+# keep/revert intent subsystem. Nothing reads them anymore; without this rm they
+# would linger in the bind-mounted state dir forever after rollout. Idempotent —
+# a cheap no-op once clean.
+rm -f "{{agentDir}}/.relaunch-model-intent" "{{agentDir}}/.session-model-kept-notified"
+# `.session-model-boot-attempts` is REVIVED as LIVE state (#3284 bounded-retry
+# counter, see the resolution block below): the gateway clears it on a healthy
+# boot, and start.sh gives up + reverts once it exceeds the attempt bound. It is
+# meaningless without a carrier to belong to, so sweep it as stale ONLY when no
+# `.session-model` carrier is present (rollout leftover / completed apply / a
+# prior giveup that didn't get to delete it).
+[ -f "{{agentDir}}/.session-model" ] || rm -f "{{agentDir}}/.session-model-boot-attempts"
 
 # Migration shim (one release): a leftover one-shot `.session-model-override`
 # carrier from a pre-consume-once gateway means an OLD gateway wrote it
@@ -1207,11 +1214,34 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   _smf="$(cat "{{agentDir}}/.session-model" 2>/dev/null || true)"
   _sm_model="$(printf '%s' "$_smf" | sed -n 's/.*"model"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
   _sm_cfg="$(printf '%s' "$_smf" | sed -n 's/.*"configuredDefaultAtWrite"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
-  # CONSUME-ONCE: delete the carrier now, before any apply/exec. The carrier
-  # governs exactly this one boot; a bad token can therefore crash at most one
-  # boot (the next boot has no carrier and reverts), so no crashloop self-heal
-  # is needed. Every branch below has already removed the file.
-  rm -f "{{agentDir}}/.session-model"
+  # BOUNDED-RETRY CONSUME (#3284) — the carrier is NO LONGER deleted here before
+  # the apply/exec. It used to be (pure consume-once), but a boot that reads the
+  # carrier may WEDGE before its gateway acquires the boot lock (the
+  # boot.lock_stale_recovered_boot_mismatch race, e.g. a proxy-only `fable`
+  # apply-boot) and never become the surviving healthy session. Deleting before
+  # apply handed the requested model to that loser: the retry boot found no
+  # carrier and silently reverted to the configured default. Instead:
+  #
+  #   - the GATEWAY deletes the carrier + the attempt counter once it ACQUIRES
+  #     the boot lock (boot.lock_acquired in gateway.ts — the healthy-boot signal
+  #     a wedged boot cannot fake), so a GOOD token survives a transient wedge
+  #     and RE-APPLIES on the retry boot instead of reverting;
+  #   - a persisted attempt counter (`.session-model-boot-attempts`) BOUNDS the
+  #     retries: a token that never reaches a healthy gateway (a genuinely BAD
+  #     token that crashes claude before lock-acquire) is given up after
+  #     _SM_MAX_ATTEMPTS boots — deleted, reverted, and alerted — so a bad token
+  #     can NEVER produce an unbounded wedge→retry→wedge crashloop. The original
+  #     "a bad token crashes at most one boot then reverts" guarantee becomes "at
+  #     most _SM_MAX_ATTEMPTS boots then reverts", still a hard finite bound.
+  #
+  # Every INVALIDATION / GIVEUP branch below deletes BOTH the carrier and the
+  # counter; only the APPLY branch keeps the carrier (for the gateway to clear)
+  # and persists the incremented counter. The delete-before-apply that used to
+  # sit here is GONE by design.
+  _SM_MAX_ATTEMPTS=3
+  _sm_attempts="$(cat "{{agentDir}}/.session-model-boot-attempts" 2>/dev/null | tr -dc '0-9' || true)"
+  [ -z "$_sm_attempts" ] && _sm_attempts=0
+  _sm_attempts=$(( _sm_attempts + 1 ))
   # Shape gate — kept BYTE-IDENTICAL with MODEL_ARG_RE in
   # telegram-plugin/gateway/model-command.ts. `/` is allowed for
   # OpenRouter-style `sr-vendor/model` ids; it is not a shell metachar inside
@@ -1222,33 +1252,56 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   # `claude --model` (parity with parseSessionModel's single-string check).
   if [ "$(printf '%s' "$_sm_model" | wc -c)" -eq 0 ] || [ "$(printf '%s' "$_sm_model" | wc -l)" -ne 0 ] || ! printf '%s' "$_sm_model" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
     # Invalid carrier: fall back to the configured default AND tell the
-    # operator once — never a silent stderr-only drop.
+    # operator once — never a silent stderr-only drop. Terminal → drop the
+    # carrier + counter (a corrupt token is never worth retrying).
+    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-boot-attempts"
     echo "session-model: ignoring malformed .session-model (failed shape gate) — using configured default '$_EFFECTIVE_MODEL'" >&2
     printf 'Your saved session model override could not be read (invalid or corrupt), so the agent booted on its configured default `%s`. Re-issue /model <name> if you want a different model.\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   elif [ "$_sm_cfg" != "$_EFFECTIVE_MODEL" ]; then
     # switchroom.yaml `model:` changed between the switch and this apply-boot →
     # the carrier is against a default that no longer exists. Invalidate +
-    # announce once.
+    # announce once. Terminal → drop the carrier + counter.
+    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-boot-attempts"
     echo "session-model: configured default changed ('$_sm_cfg' → '$_EFFECTIVE_MODEL') — dropping session override '$_sm_model'" >&2
     printf 'The configured default model changed (`%s` → `%s`), so your session override to `%s` was not applied — the agent booted on the new configured default. Re-issue /model %s if you still want it.\n' "$_sm_cfg" "$_EFFECTIVE_MODEL" "$_sm_model" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   elif { [ "${_sm_model#sr-}" != "$_sm_model" ] || [ "$_sm_model" = fable ] || [ "$_sm_model" = claude-fable-5 ]; } && [ -z "$_LITELLM_OK" ]; then
     # Proxy-only override + LiteLLM unreachable at the apply-boot: booting the
     # override would 4xx (sr-* against Anthropic; `fable`/`claude-fable-5` is a
     # retired codename direct-to-Anthropic and ONLY resolves via the LiteLLM
-    # router — see the repoint case below). Consume-once means we can't retain it
-    # for a later relaunch, so boot the configured default and tell the operator
-    # to re-issue once the proxy is back. (Rev 5: Fable is now reachable via the
-    # carrier relaunch — the old live-inject path never launched it — so it needs
-    # the same down-guard as sr-*.)
+    # router — see the repoint case below). The litellm probe already waited out
+    # its full 120s window before we got here, so "still unreachable" is a real
+    # down-state, not the transient boot-lock wedge the bounded-retry counter
+    # covers — drop the carrier + counter (terminal) and tell the operator to
+    # re-issue once the proxy is back, rather than looping against a dead proxy.
+    # (Rev 5: Fable is now reachable via the carrier relaunch — the old
+    # live-inject path never launched it — so it needs the same down-guard as sr-*.)
+    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-boot-attempts"
     echo "session-model: LiteLLM proxy unreachable at boot — NOT applying proxy-only override '$_sm_model'; booting configured default '$_EFFECTIVE_MODEL' (re-issue /model when the proxy is back)" >&2
     printf 'LiteLLM proxy was unreachable at boot, so the session model override `%s` was not applied — the agent booted on its configured default `%s`. Re-issue /model %s once the proxy is reachable.\n' "$_sm_model" "$_EFFECTIVE_MODEL" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+  elif [ "$_sm_attempts" -gt "$_SM_MAX_ATTEMPTS" ]; then
+    # CRASHLOOP BOUND (#3284). This carrier has now been read on more than
+    # _SM_MAX_ATTEMPTS boots WITHOUT the gateway ever reaching boot.lock_acquired
+    # to clear it — i.e. every apply-boot wedged/crashed before a healthy
+    # gateway. That is the signature of a genuinely bad token (one that will
+    # never boot), NOT the transient boot-lock race we retry for. Give up:
+    # drop the carrier + counter, revert to the configured default, and alert.
+    # This is the hard finite bound that guarantees no unbounded crashloop.
+    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-boot-attempts"
+    echo "session-model: override '$_sm_model' did not reach a healthy boot after $_SM_MAX_ATTEMPTS attempts — reverting to configured default '$_EFFECTIVE_MODEL'" >&2
+    printf 'Your session model override `%s` could not boot successfully after %s attempts, so the agent reverted to its configured default `%s`. Re-issue /model %s to try again.\n' "$_sm_model" "$_SM_MAX_ATTEMPTS" "$_EFFECTIVE_MODEL" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   else
-    # Apply the carrier for THIS session. No boot alert — the gateway already
-    # acked the /model switch in chat, and the override reverts on next restart.
+    # Apply the carrier for THIS session and KEEP it: the gateway deletes the
+    # carrier + counter once it acquires the boot lock (healthy boot), so a
+    # transient wedge before that RE-APPLIES on the retry boot instead of
+    # reverting. Persist the incremented attempt counter so the crashloop bound
+    # above can fire if this token keeps wedging. No boot alert — the gateway
+    # already acked the /model switch in chat, and the override reverts on the
+    # next restart (once the gateway has cleared the carrier).
+    printf '%s\n' "$_sm_attempts" > "{{agentDir}}/.session-model-boot-attempts" 2>/dev/null || true
     _EFFECTIVE_MODEL="$_sm_model"
-    echo "session-model: applying session override '$_sm_model' this boot (consume-once — reverts on next restart)" >&2
+    echo "session-model: applying session override '$_sm_model' this boot (attempt $_sm_attempts/$_SM_MAX_ATTEMPTS — cleared by the gateway on a healthy boot, reverts on next restart)" >&2
   fi
-  unset _smf _sm_model _sm_cfg
+  unset _smf _sm_model _sm_cfg _sm_attempts _SM_MAX_ATTEMPTS
 fi
 
 # --- Session effort resolution (consume-once .session-effort carrier, #3186) ---

--- a/reference/rfcs/session-model-stickiness.md
+++ b/reference/rfcs/session-model-stickiness.md
@@ -8,12 +8,60 @@ status: Accepted — revised per adversarial review + operator decision (default
 
 # RFC — Session-scoped `/model` stickiness
 
-**Status:** Accepted (rev 5 — deterministic switch, §0.05, operator decision 2026-07-16; rev 4 session-scoped consume-once §0.1 stands EXCEPT its "live Claude switches write no carrier" bullet, now superseded by §0.05; rev 3 keep-by-default and rev 2 revert-by-default superseded where §0.1 says so)
+**Status:** Accepted (rev 6 — bounded-retry consume, §0.03, #3284, 2026-07-16, refines rev 4/5's "start.sh deletes the carrier before apply"; rev 5 — deterministic switch, §0.05, operator decision 2026-07-16; rev 4 session-scoped consume-once §0.1 stands EXCEPT its "live Claude switches write no carrier" bullet, now superseded by §0.05, and its "start.sh deletes the carrier on apply" mechanic, now refined by §0.03; rev 3 keep-by-default and rev 2 revert-by-default superseded where §0.1 says so)
 **Author:** (agent-authored, operator-directed; semantics decided by the operator 2026-07)
 **Targets:** `origin/main` @ v0.18.7
 **Builds on:** #2982 (in-memory `sessionModelSource` + one-shot `.session-model-override` carrier), #2983 (live model on progress cards), #3178 (durable /model ack/trace/queue)
 
 ---
+
+## 0.03 Rev 6 amendment (#3284, 2026-07-16) — BOUNDED-RETRY consume (who deletes the carrier, and when)
+
+**Problem.** Rev 4/5 had start.sh `rm` the `.session-model` carrier **before**
+apply/exec (pure consume-once). But a boot that reads the carrier can **wedge
+before its gateway acquires the boot lock** — e.g. the
+`boot.lock_stale_recovered_boot_mismatch` race a proxy-only `fable` apply-boot
+hit on marko/klanker (2026-07-16Z): two boots overlapped, the LOSER consumed
+(deleted) the carrier, and the WINNER's start.sh then found no carrier and
+booted the configured default (`opus`). The requested model was lost with no
+alert until a later boot happened to re-apply it. Deleting the carrier on the
+apply boot hands it to whichever start.sh runs first, which is **not
+necessarily the surviving healthy session**.
+
+**Decision.** The carrier is **APPLIED by start.sh but consumed by the
+gateway** on a healthy boot:
+
+- **start.sh applies, does NOT delete.** The boot that reads the carrier sets
+  `_EFFECTIVE_MODEL` and `exec claude --model <token>` as before, then **leaves
+  the carrier in place**. So a wedge before a healthy gateway leaves the carrier
+  for the retry boot to RE-APPLY instead of silently reverting. The lock-WINNER
+  always runs the applied model, because its start.sh read the carrier (present
+  until consumed) before exec.
+- **The gateway consumes on `boot.lock_acquired`.** Once this gateway acquires
+  the boot lock (`startup-mutex.ts` → `consumeSessionModelCarrierOnHealthyBoot`
+  in `session-model-file.ts`, called from `gateway.ts`), it deletes BOTH the
+  carrier and the attempt counter. Lock acquisition is the deterministic
+  "this boot is the surviving healthy session" signal a wedged boot cannot fake.
+  The consume is post-application cleanup for FUTURE boots — the running process
+  already has the model baked into its `exec`.
+- **Crashloop bound (REVIVED `.session-model-boot-attempts`).** start.sh
+  increments a persisted attempt counter on every apply boot and **gives up
+  after `_SM_MAX_ATTEMPTS` (3)** — deletes the carrier + counter, reverts to the
+  configured default, and writes a `.session-model-alert`. A genuinely BAD token
+  (one that crashes claude before lock-acquire on every boot) therefore reverts
+  after a hard finite bound, NEVER an unbounded wedge→retry→wedge crashloop.
+  This restores rev 4's "a bad token crashes at most one boot then reverts"
+  guarantee as "at most `_SM_MAX_ATTEMPTS` boots then reverts". The counter is
+  swept as stale by start.sh whenever no carrier is present.
+- **Unchanged.** All invalidation branches (corrupt / shape-gate-fail /
+  configured-default-changed / proxy-only+LiteLLM-down) still drop the carrier
+  immediately and alert — they now also drop the counter. The LiteLLM-down guard
+  stays a terminal revert (the 120s probe already elapsed, so "still down" is a
+  real down-state, not the transient boot-lock wedge the counter covers).
+
+This refines rev 4/5's consume mechanic; the session-scoped semantics
+(override reverts on the next ordinary restart) are unchanged — a healthy boot
+consumes, so the next restart finds no carrier.
 
 ## 0.05 Rev 5 amendment (operator decision 2026-07-16) — DETERMINISTIC switch (reverses §0.1's "live Claude switches write no carrier")
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -496,6 +496,7 @@ import {
   readSessionModelFileRaw,
   restoreSessionModelFileRaw,
   clearSessionModelFile,
+  consumeSessionModelCarrierOnHealthyBoot,
   readConfiguredDefaultModel,
   writeSessionEffortFile,
   clearSessionEffortFile,
@@ -9679,6 +9680,18 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
     process.stderr.write(
       `telegram gateway: wrote PID file ${GATEWAY_PID_PATH} pid=${process.pid} startedAt=${GATEWAY_STARTED_AT_MS}\n`,
     )
+    // #3284 — this boot ACQUIRED the boot lock, so it is the surviving healthy
+    // session. Consume the session-model carrier now (delete the carrier + the
+    // bounded-retry attempt counter). start.sh no longer deletes the carrier
+    // before apply: an apply-boot that wedged before reaching this point leaves
+    // the carrier in place so the retry boot RE-APPLIES the intended model
+    // instead of silently reverting to the configured default (the marko/klanker
+    // boot.lock_stale_recovered_boot_mismatch revert). Best-effort, gated on
+    // lock ownership so a LOSING double-boot never clears the winner's carrier.
+    {
+      const carrierAgentDir = resolveAgentDirFromEnv()
+      if (carrierAgentDir != null) consumeSessionModelCarrierOnHealthyBoot(carrierAgentDir)
+    }
     // We WON the startup mutex — this gateway is the sole live owner of the
     // shared per-agent status-pin store, so it's now safe to clean up orphaned
     // pins from a prior (dead) session. Gated here (not at import time) so a
@@ -9702,6 +9715,13 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
       // probe + 409-retry loop is still the liveness guard on this path. A
       // successful writePidFile here means no live holder was detected, so
       // running orphan cleanup is consistent with the pre-mutex behaviour.
+      // #3284: same healthy-boot carrier consume as the mutex-acquired path —
+      // a successful writePidFile means no live holder was detected, so this is
+      // the surviving session.
+      {
+        const carrierAgentDir = resolveAgentDirFromEnv()
+        if (carrierAgentDir != null) consumeSessionModelCarrierOnHealthyBoot(carrierAgentDir)
+      }
       // #3026: same sequenced cleanup + DM stale-pin sweep as the mutex path.
       void runBootPinCleanupAndDmSweep()
     } catch (writeErr) {

--- a/telegram-plugin/gateway/session-model-file.ts
+++ b/telegram-plugin/gateway/session-model-file.ts
@@ -38,6 +38,15 @@ import { isValidModelArg } from './model-command.js'
 
 export const SESSION_MODEL_FILE = '.session-model'
 export const CONFIGURED_DEFAULT_MODEL_FILE = '.configured-default-model'
+/**
+ * Bounded-retry attempt counter for the session-model carrier (#3284).
+ * start.sh increments this on every boot that reads `.session-model` and
+ * applies it, and gives up (reverts + alerts) once it exceeds its bound. The
+ * gateway clears BOTH this file and the carrier on a healthy boot (see
+ * consumeSessionModelCarrierOnHealthyBoot) — the "healthy" signal a wedged
+ * boot cannot fake. Kept in sync with start.sh.hbs.
+ */
+export const SESSION_MODEL_BOOT_ATTEMPTS_FILE = '.session-model-boot-attempts'
 
 export interface SessionModelRecord {
   model: string
@@ -120,6 +129,37 @@ export function readSessionModelFile(agentDir: string): SessionModelRecord | nul
 export function clearSessionModelFile(agentDir: string): void {
   try {
     rmSync(join(agentDir, SESSION_MODEL_FILE), { force: true })
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Consume the session-model carrier on a HEALTHY boot (#3284).
+ *
+ * Called once this gateway has ACQUIRED the boot lock (boot.lock_acquired) —
+ * the deterministic signal that THIS boot is the surviving healthy session,
+ * which a boot that wedges before lock-acquire cannot fake. Deletes BOTH the
+ * consume-once carrier and the bounded-retry attempt counter, so:
+ *   - the next ordinary restart (deploy, /restart, crash) finds no carrier and
+ *     reverts to the configured default (session-scoped semantics preserved);
+ *   - a transient wedge BEFORE this point leaves the carrier in place, so the
+ *     retry boot re-applies the intended model instead of silently reverting.
+ *
+ * This is what moved out of start.sh's old delete-before-apply: start.sh no
+ * longer consumes the carrier itself, it only APPLIES it and lets this healthy
+ * signal do the consume. Best-effort — a failure here just means the carrier is
+ * re-read (and re-applied, harmlessly) on the next boot, still bounded by the
+ * counter. Idempotent.
+ */
+export function consumeSessionModelCarrierOnHealthyBoot(agentDir: string): void {
+  try {
+    rmSync(join(agentDir, SESSION_MODEL_FILE), { force: true })
+  } catch {
+    /* best-effort */
+  }
+  try {
+    rmSync(join(agentDir, SESSION_MODEL_BOOT_ATTEMPTS_FILE), { force: true })
   } catch {
     /* best-effort */
   }

--- a/telegram-plugin/tests/session-model-file.test.ts
+++ b/telegram-plugin/tests/session-model-file.test.ts
@@ -17,8 +17,10 @@ import {
   readSessionModelFileRaw,
   restoreSessionModelFileRaw,
   clearSessionModelFile,
+  consumeSessionModelCarrierOnHealthyBoot,
   readConfiguredDefaultModel,
   SESSION_MODEL_FILE,
+  SESSION_MODEL_BOOT_ATTEMPTS_FILE,
   CONFIGURED_DEFAULT_MODEL_FILE,
   parseSessionEffort,
   writeSessionEffortFile,
@@ -77,6 +79,27 @@ describe('rollback snapshot (scheduleModelRelaunch dispatch failure)', () => {
     writeSessionModelFile(dir, 'sr-glm-5', 'claude-sonnet-5')
     restoreSessionModelFileRaw(dir, snapshot)
     expect(existsSync(join(dir, SESSION_MODEL_FILE))).toBe(false)
+  })
+})
+
+describe('consumeSessionModelCarrierOnHealthyBoot (#3284 healthy-boot consume)', () => {
+  it('deletes BOTH the carrier and the bounded-retry attempt counter', () => {
+    writeFileSync(join(dir, SESSION_MODEL_FILE), 'whatever\n')
+    writeFileSync(join(dir, SESSION_MODEL_BOOT_ATTEMPTS_FILE), '2\n')
+    consumeSessionModelCarrierOnHealthyBoot(dir)
+    expect(existsSync(join(dir, SESSION_MODEL_FILE))).toBe(false)
+    expect(existsSync(join(dir, SESSION_MODEL_BOOT_ATTEMPTS_FILE))).toBe(false)
+  })
+
+  it('is idempotent / best-effort when neither file exists (no throw)', () => {
+    expect(() => consumeSessionModelCarrierOnHealthyBoot(dir)).not.toThrow()
+    expect(existsSync(join(dir, SESSION_MODEL_FILE))).toBe(false)
+  })
+
+  it('clears the counter even when the carrier is already gone (wedge that lost its carrier mid-race)', () => {
+    writeFileSync(join(dir, SESSION_MODEL_BOOT_ATTEMPTS_FILE), '1\n')
+    consumeSessionModelCarrierOnHealthyBoot(dir)
+    expect(existsSync(join(dir, SESSION_MODEL_BOOT_ATTEMPTS_FILE))).toBe(false)
   })
 })
 

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -11,13 +11,19 @@ import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/confi
 // (reference/rfcs/session-model-stickiness.md §0.1, rev 4). Driven as
 // sh-harness fixtures against the RENDERED block.
 //
-// Contract under test (CONSUME-ONCE): a `.session-model` carrier is applied on
-// the single boot that reads it and then DELETED, so the model-apply relaunch
-// picks it up and EVERY subsequent restart reverts to the configured default.
-// There is no `.relaunch-model-intent`, no crashloop counter, and no
-// kept-notified sentinel. Invalidation (corrupt / configured-default changed /
-// sr-*+LiteLLM-down) drops the carrier and writes a `.session-model-alert` the
-// gateway relays.
+// Contract under test (BOUNDED-RETRY CONSUME, #3284): a `.session-model`
+// carrier is APPLIED on the boot that reads it but NOT deleted by start.sh —
+// the GATEWAY deletes it (+ the `.session-model-boot-attempts` counter) once it
+// acquires the boot lock (boot.lock_acquired, the healthy-boot signal). So a
+// boot that WEDGES before a healthy gateway leaves the carrier in place and the
+// retry boot RE-APPLIES the intended model instead of silently reverting (the
+// marko/klanker fable→opus revert). A persisted attempt counter BOUNDS the
+// retries: a token that never reaches a healthy gateway is given up after
+// _SM_MAX_ATTEMPTS boots (revert + alert), so a bad token can never crashloop.
+// There is no `.relaunch-model-intent` and no kept-notified sentinel.
+// Invalidation (corrupt / configured-default changed / sr-*+LiteLLM-down /
+// attempts-exceeded) drops the carrier + counter and writes a
+// `.session-model-alert` the gateway relays.
 
 const telegramConfig: TelegramConfig = {
   bot_token: "123456:ABC-DEF",
@@ -113,20 +119,41 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     return readFileSync(join(agentDir, ".session-model-alert"), "utf-8");
   }
 
+  // #3284: start.sh no longer consumes the carrier on apply — the GATEWAY does,
+  // once it acquires the boot lock (boot.lock_acquired). These helpers simulate
+  // that healthy-boot consume and inspect the bounded-retry attempt counter so
+  // the sh-harness can model both a healthy boot and a wedge (no consume).
+  function healthyBootConsume(): void {
+    rmSync(join(agentDir, ".session-model"), { force: true });
+    rmSync(join(agentDir, ".session-model-boot-attempts"), { force: true });
+  }
+  function carrierExists(): boolean {
+    return existsSync(join(agentDir, ".session-model"));
+  }
+  function attemptCount(): string {
+    return existsSync(join(agentDir, ".session-model-boot-attempts"))
+      ? readFileSync(join(agentDir, ".session-model-boot-attempts"), "utf-8").trim()
+      : "";
+  }
+
   it("renders the consume-once carrier wiring in start.sh (no intent resolution)", () => {
     expect(block).toContain(".session-model");
     expect(block).toContain(".configured-default-model");
     expect(block).toContain(".session-model-alert");
     // Migration shim still consumes the legacy one-shot carrier.
     expect(block).toContain(".session-model-override");
-    // The retired keep/revert intent + crashloop machinery is no longer
-    // RESOLVED — the retired filenames appear only in the one-line hygiene
+    // The retired keep/revert intent + kept-notified machinery is no longer
+    // RESOLVED — those retired filenames appear only in the one-line hygiene
     // `rm -f` (#3184 LOW-2), never in a read/parse/stamp.
     expect(block).not.toContain('"intent"');
     expect(block).not.toContain("_sm_revert");
     expect(block).not.toMatch(/(cat|read -r|<)[^\n]*\.relaunch-model-intent/);
-    expect(block).not.toMatch(/(cat|read -r|<)[^\n]*\.session-model-boot-attempts/);
     expect(block).not.toMatch(/(cat|read -r|<)[^\n]*\.session-model-kept-notified/);
+    // #3284: `.session-model-boot-attempts` is REVIVED as the live bounded-retry
+    // counter — the block now READS it (cat|tr) and PERSISTS it, and the gateway
+    // clears it on a healthy boot.
+    expect(block).toMatch(/cat[^\n]*\.session-model-boot-attempts/);
+    expect(block).toContain("_SM_MAX_ATTEMPTS");
     // modelQ is assigned BARE (already shell-quoted by the scaffold).
     expect(block).toContain("_EFFECTIVE_MODEL='claude-sonnet-5'");
     const startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
@@ -145,11 +172,13 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     expect(existsSync(join(agentDir, ".session-model-boot-attempts"))).toBe(false);
     expect(existsSync(join(agentDir, ".session-model-kept-notified"))).toBe(false);
     // A stale intent file has NO effect on carrier resolution: a carrier still
-    // applies + consumes regardless of any leftover intent content.
+    // applies regardless of any leftover intent content. (#3284: the carrier is
+    // now consumed by the gateway on a healthy boot, not by start.sh, so it
+    // survives the apply boot; the retired intent file is still swept.)
     writeFileSync(join(agentDir, ".relaunch-model-intent"), `${JSON.stringify({ intent: "revert", reason: "old", ts: Date.now() })}\n`);
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
     expect(runBlock("1")).toBe("claude-opus-4-8");
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    expect(carrierExists()).toBe(true); // kept for the gateway to consume
     expect(existsSync(join(agentDir, ".relaunch-model-intent"))).toBe(false);
   });
 
@@ -192,22 +221,75 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
   });
 
   // ── requirement (a): the apply-relaunch picks up the carrier ─────────────
-  it("valid carrier → APPLIES the override this boot and CONSUMES the carrier (no boot alert)", () => {
+  it("valid carrier → APPLIES the override this boot and KEEPS the carrier for the gateway (no boot alert)", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
     expect(runBlock("1")).toBe("claude-opus-4-8");
-    // Consume-once: the carrier is deleted on the apply boot.
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    // #3284: start.sh no longer consumes — it applies and leaves the carrier +
+    // an attempt counter for the gateway to clear on a healthy boot.
+    expect(carrierExists()).toBe(true);
+    expect(attemptCount()).toBe("1");
     // The gateway already acked the /model in chat — no boot alert on apply.
     expect(existsSync(join(agentDir, ".session-model-alert"))).toBe(false);
   });
 
-  // ── requirement (b): the next restart reverts to the configured default ──
-  it("SUBSEQUENT restart (carrier already consumed) → reverts to the configured default", () => {
+  // ── requirement (b): after the gateway consumes, the next restart reverts ──
+  it("SUBSEQUENT restart (after the gateway's healthy-boot consume) → reverts to the configured default", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
     expect(runBlock("1")).toBe("claude-opus-4-8"); // apply-relaunch
+    healthyBootConsume(); // the gateway acquired the boot lock and cleared the carrier
     expect(runBlock("1")).toBe(DEFAULT_MODEL); // any later restart
     expect(runBlock("1")).toBe(DEFAULT_MODEL); // and every one after
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    expect(carrierExists()).toBe(false);
+    expect(attemptCount()).toBe(""); // counter swept once the carrier is gone
+  });
+
+  // ── #3284 requirement (a): a GOOD token survives a boot-lock wedge ───────
+  // A boot that reads the carrier but WEDGES before its gateway acquires the
+  // boot lock (boot.lock_stale_recovered_boot_mismatch) never calls
+  // healthyBootConsume(); the carrier + counter survive, so the retry boot
+  // RE-APPLIES the intended model instead of silently reverting. This is the
+  // marko/klanker `fable → opus` revert the pre-fix start.sh produced.
+  it("good token + wedge before healthy boot → RE-APPLIES on the retry boot (no silent revert)", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("fable"));
+    // Apply-boot 1 wedges (proxy up so `fable` is applied; gateway never reaches
+    // boot.lock_acquired, so NO healthyBootConsume()).
+    expect(runBlockRouting("1").effective).toBe("fable");
+    expect(carrierExists()).toBe(true);
+    expect(attemptCount()).toBe("1");
+    // Retry boot re-applies `fable` — the pre-fix behavior reverted to default
+    // here because the carrier had already been consumed by the wedged boot.
+    expect(runBlockRouting("1").effective).toBe("fable");
+    expect(attemptCount()).toBe("2");
+    // Now the gateway finally acquires the lock and consumes the carrier.
+    healthyBootConsume();
+    expect(runBlock("1")).toBe(DEFAULT_MODEL); // next ordinary restart reverts
+  });
+
+  // ── #3284 CRASHLOOP BOUND: a BAD token gives up after N attempts ─────────
+  // A token that NEVER reaches a healthy gateway (claude crashes before
+  // boot.lock_acquire on every boot, so healthyBootConsume() is never called)
+  // must not wedge→retry→wedge forever. After _SM_MAX_ATTEMPTS (3) apply boots
+  // the carrier is dropped, the default is booted, and the operator is alerted.
+  it("bad token that keeps wedging → gives up after the bounded attempts, reverts + alerts (no crashloop)", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
+    // Attempts 1..3 apply the override and KEEP the carrier (each boot wedges).
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(attemptCount()).toBe("1");
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(attemptCount()).toBe("2");
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(attemptCount()).toBe("3");
+    // Attempt 4 exceeds the bound → give up: revert to default, drop the
+    // carrier + counter, and alert. This is the hard crashloop bound.
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    expect(carrierExists()).toBe(false);
+    expect(attemptCount()).toBe("");
+    const alert = alertText();
+    expect(alert).toContain("claude-opus-4-8");
+    expect(alert).toContain("after 3 attempts");
+    expect(alert).toContain("reverted");
+    // And it STAYS reverted — no resurrection, no loop.
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
   });
 
   // ── invalidation branches (all consume + alert) ──────────────────────────
@@ -257,19 +339,19 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     expect(alert).toContain("Re-issue /model");
   });
 
-  it("Claude carrier does NOT require LiteLLM (applies with proxy down, consumed)", () => {
+  it("Claude carrier does NOT require LiteLLM (applies with proxy down, carrier kept for the gateway)", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
     expect(runBlock("")).toBe("claude-opus-4-8");
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    expect(carrierExists()).toBe(true); // #3284: kept for the gateway's healthy-boot consume
   });
 
-  it("sr-* carrier + LiteLLM up → applies once + repoints ANTHROPIC_BASE_URL + consumed", () => {
+  it("sr-* carrier + LiteLLM up → applies once + repoints ANTHROPIC_BASE_URL + carrier kept for the gateway", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("sr-glm-5"));
     const { effective, baseUrl } = runBlockRouting("1");
     expect(effective).toBe("sr-glm-5");
     expect(baseUrl).toBe(ROUTER_ROOT);
     expect(baseUrl.endsWith("/anthropic")).toBe(false);
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    expect(carrierExists()).toBe(true);
   });
 
   it("no carrier (Claude default) → KEEPS the /anthropic passthrough (guards the Opus SSE fix)", () => {
@@ -295,7 +377,7 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     expect(effective).toBe("fable");
     expect(baseUrl).toBe(ROUTER_ROOT);
     expect(baseUrl.endsWith("/anthropic")).toBe(false);
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    expect(carrierExists()).toBe(true); // #3284: kept for the gateway's healthy-boot consume
   });
 
   it("claude-fable-5 carrier + LiteLLM up → also repoints to the router root", () => {
@@ -317,12 +399,14 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
   });
 
   // ── migration from the one-shot carrier ──────────────────────────────────
-  it("legacy .session-model-override carrier → converted, applied + consumed THIS boot", () => {
+  it("legacy .session-model-override carrier → converted + applied THIS boot (carrier kept for the gateway)", () => {
     writeFileSync(join(agentDir, ".session-model-override"), "sr-glm-5\n");
     expect(runBlock("1")).toBe("sr-glm-5");
     expect(existsSync(join(agentDir, ".session-model-override"))).toBe(false);
-    // Consume-once: the converted carrier is also gone after the apply boot.
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    // #3284: the converted carrier is APPLIED then kept for the gateway's
+    // healthy-boot consume (not deleted by start.sh).
+    expect(carrierExists()).toBe(true);
+    expect(attemptCount()).toBe("1");
   });
 
   it("legacy carrier WINS over an existing .session-model (newer intent)", () => {
@@ -390,13 +474,14 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
   // two native guarantees the downgrade relies on at the boot layer: revert is
   // free (consume-once) and the downgraded default resolves the CONFIGURED
   // (low) effort because the downgrade writes NO `.session-effort` carrier.
-  it("tier-downgrade carrier (model == configured default) → applies the default, consumes, reverts on next restart", () => {
+  it("tier-downgrade carrier (model == configured default) → applies the default, gateway consumes, reverts on next restart", () => {
     // The gateway writes {model: <configured default>, configuredDefaultAtWrite:
     // <same>} immediately before the resume restart.
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson(DEFAULT_MODEL, DEFAULT_MODEL));
     expect(runBlock("1")).toBe(DEFAULT_MODEL); // resume boot runs the default
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false); // consume-once
+    expect(carrierExists()).toBe(true); // #3284: kept for the gateway's healthy-boot consume
     expect(existsSync(join(agentDir, ".session-model-alert"))).toBe(false); // silent apply
+    healthyBootConsume(); // gateway acquired the boot lock and cleared the carrier
     // Native revert: every subsequent restart is already the default (the
     // premium override was session-scoped and never wrote a surviving carrier).
     expect(runBlock("1")).toBe(DEFAULT_MODEL);


### PR DESCRIPTION
Closes the carrier-lifecycle half of #3284: a `/model <non-default>` switch (notably proxy-only `fable`) silently reverts to the configured default when its apply-boot wedges before the gateway acquires the boot lock.

## Root cause
`start.sh` `rm`'d the consume-once `.session-model` carrier **before** apply (`profiles/_base/start.sh.hbs`, the old delete-at-line-~1214). On the `boot.lock_stale_recovered_boot_mismatch` race (two boots overlap; verified live on marko 19:30:12Z→19:30:22Z `fable`→`opus`, and klanker), the LOSER boot consumed the carrier and the WINNER (lock owner) then found none and booted the configured default with no alert. Consume-once handed the carrier to whichever `start.sh` ran first, which is not necessarily the surviving healthy session.

## Fix — bounded-retry consume
- **`start.sh` applies, does not delete.** The boot that reads the carrier sets `_EFFECTIVE_MODEL` + `exec claude --model <token>` and leaves the carrier in place, so a wedge before a healthy gateway re-applies on the retry boot. The lock-winner always runs the applied model (it read the carrier before any consume).
- **The gateway consumes on `boot.lock_acquired`** — `consumeSessionModelCarrierOnHealthyBoot` (`session-model-file.ts`) called from the mutex-acquired path in `gateway.ts`, deleting the carrier + counter. Lock acquisition is the deterministic healthy-boot signal a wedged boot cannot fake; the consume is cleanup for future boots (the running process already `exec`'d with the model).

## Crashloop bound (the critical constraint)
A revived `.session-model-boot-attempts` counter is incremented on each apply boot; `start.sh` gives up after `_SM_MAX_ATTEMPTS` (3) — drops the carrier + counter, reverts, and writes a `.session-model-alert`. A token that never reaches a healthy gateway reverts after a **hard finite bound**, never an unbounded wedge→retry→wedge loop. The counter climbs monotonically across serial re-execs (the crashloop case), so it must exceed the bound within a bounded number of boots. This restores rev 4's "a bad token crashes at most one boot then reverts" as "at most N boots then reverts". All existing invalidation branches (corrupt / shape / cfg-changed / LiteLLM-down) stay terminal reverts and now also drop the counter.

## Tests
- `tests/scaffold.session-model.test.ts` (sh-harness against the rendered `start.sh`):
  - **(a)** good token + wedge before healthy boot → RE-APPLIES on the retry boot (fails pre-fix — the old code reverted).
  - **(b)** bad token that keeps wedging → gives up after the bounded attempts, reverts + alerts, stays reverted (proves no crashloop).
  - updated the consume-once assertions to the new lifecycle (carrier kept on apply, consumed by a simulated healthy boot).
- `telegram-plugin/tests/session-model-file.test.ts`: unit tests for `consumeSessionModelCarrierOnHealthyBoot`.

Local: `npx vitest run` on the touched files green; `npm run lint` (incl. `tsc --noEmit`) clean.

## Not in this PR (investigation half of #3284)
The *why does the apply-boot wedge* half (LiteLLM-readiness race vs `exec claude`, `resume_watchdog_timeout` interaction) is reported in the handback for the reviewer; this PR is the durable carrier-lifecycle fix and does not change the boot-lock or litellm-probe code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)