### PR TITLE
fix(vault): grants survive broker recreate — mount grants-DB directory, not the bare file (#3289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@
   `agent logs` now defaults to the last 50 lines (cap 1000) instead of
   dumping the entire log, and `-f` starts from a 50-line backlog before
   streaming.
+- **Vault grants survive broker container recreate** (#3289) — the
+  capability-grants SQLite DB is now mounted into the vault-broker as a
+  dedicated `~/.switchroom/vault-broker/` DIRECTORY instead of a single
+  file, so the WAL `-wal`/`-shm` sidecars persist on the host fs alongside
+  the main DB. Previously the sidecars landed in the container's ephemeral
+  overlayfs and committed grants sat in the container-local WAL until a rare
+  checkpoint — a broker recreate discarded them (the v0.13.31 grant-wipe
+  class). Belt-and-braces: every mint/revoke now runs `PRAGMA
+  wal_checkpoint(TRUNCATE)` so the main file is always current for host-side
+  readers, and `switchroom apply` / broker boot idempotently relocates any
+  legacy `~/.switchroom/vault-grants.db` (plus its sidecars) into the new
+  directory. Two new doctor probes flag a persistently un-checkpointed WAL
+  inside the broker and any agent `.vault-token` referencing a grant id
+  absent from the DB (the orphan-token symptom).
 
 ## v0.18.27 — Steadier Telegram cards and more reliable model switching
 

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -89,6 +89,7 @@ import { getBundledSkillsPoolDir } from "./reconcile-default-skills.js";
 import { loadHostCapabilities } from "../setup/host-capabilities.js";
 import type { VoiceEngine } from "../setup/gpu-detect.js";
 import { AGENT_UID_MIN, AGENT_UID_MAX, allocateAgentUid } from "./agent-uid.js";
+import { GRANTS_DB_DIRNAME, GRANTS_DB_CONTAINER_DIR } from "../vault/grants-db-path.js";
 
 // UID derivation lives in agent-uid.ts (a leaf module) so scaffold.ts can
 // import it without a compose ↔ scaffold cycle (compose.ts imports
@@ -1489,32 +1490,41 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // because broker appends; broker runs as root with CAP_DAC_OVERRIDE
   // so file ownership/mode doesn't gate the write path. See #1025.
   lines.push(`      - ${homePrefix}/.switchroom/vault-audit.log:/root/.switchroom/vault-audit.log`);
-  // Capability grants DB — bind-mount the host SQLite file into the
-  // broker so grants survive container recreate. Without this mount
-  // the broker writes to `/root/.switchroom/vault-grants.db` inside
-  // the container (which evaporates on every recreate). The token
-  // files on disk (`~/.switchroom/agents/<agent>/.vault-token`)
-  // persist via the per-agent bind mounts and reference a grant ID
-  // that no longer exists in the fresh broker DB — the broker's
-  // #1496 fall-through routes the call to the standing schedule.
-  // secrets ACL, which usually denies because the granted key
-  // isn't in the agent's static config (the whole reason a grant
-  // was minted in the first place). Surfaces as
-  // `VAULT-BROKER-DENIED [DENIED]: key 'X' not in ACL for agent
-  // 'Y'` on every `switchroom vault get` from inside the agent
-  // container after a broker recreate.
+  // Capability grants DB — bind-mount the host DIRECTORY that holds the
+  // grants SQLite file (and its WAL sidecars) into the broker so grants
+  // survive container recreate. Without this mount the broker writes to
+  // `/root/.switchroom/vault-broker/vault-grants.db` inside the container
+  // (which evaporates on every recreate). The token files on disk
+  // (`~/.switchroom/agents/<agent>/.vault-token`) persist via the per-agent
+  // bind mounts and reference a grant ID that no longer exists in the fresh
+  // broker DB — the broker's #1496 fall-through routes the call to the
+  // standing schedule.secrets ACL, which usually denies because the granted
+  // key isn't in the agent's static config (the whole reason a grant was
+  // minted in the first place). Surfaces as `VAULT-BROKER-DENIED [DENIED]:
+  // key 'X' not in ACL for agent 'Y'` on every `switchroom vault get` from
+  // inside the agent container after a broker recreate.
+  //
+  // WHY A DIRECTORY, NOT THE BARE FILE (#3289): the grants DB runs in WAL
+  // mode, which writes `-wal`/`-shm` sidecars BESIDE the main file. When only
+  // the single main file was mounted (pre-#3289), those sidecars landed in the
+  // container's ephemeral overlayfs — so a committed grant sat in the
+  // container-local WAL until a rare automatic checkpoint and was LOST on
+  // container recreate. Mounting the whole `vault-broker` directory keeps the
+  // main file AND its sidecars together on the host fs. The in-container path
+  // and the host directory are resolved from `grants-db.ts` helpers so no path
+  // literal is duplicated.
   //
   // Surfaced 2026-05-24 after the v0.13.31 broker recreate wiped
   // every grant minted earlier the same day (clerk's vg_5e1991 for
   // `ha/access-token`). The doctor probe doesn't catch this — it
   // only inspects path-as-identity ACL, not grant-based access.
   //
-  // Pre-created mode 0600 by `ensureHostMountSources()` (apply.ts)
-  // so docker doesn't auto-create a directory at the source path.
-  // Broker writes via root with CAP_DAC_OVERRIDE so file
-  // ownership doesn't gate the write path. (Same pattern as
-  // vault-audit.log above and host-control-audit.log on hostd.)
-  lines.push(`      - ${homePrefix}/.switchroom/vault-grants.db:/root/.switchroom/vault-grants.db`);
+  // The directory is pre-created (mode 0700, with the DB migrated in) by
+  // `ensureHostMountSources()` (apply.ts) so docker doesn't auto-create a
+  // root-owned path at the source. Broker writes via root with
+  // CAP_DAC_OVERRIDE so ownership doesn't gate the write path. (Same pattern
+  // as vault-audit.log above and host-control-audit.log on hostd.)
+  lines.push(`      - ${homePrefix}/.switchroom/${GRANTS_DB_DIRNAME}:${GRANTS_DB_CONTAINER_DIR}`);
   // Per-agent vault-grant token files. The broker's mint_grant
   // handler (server.ts ~2222) writes the minted token at
   // `os.homedir() + .switchroom/agents/<agent>/.vault-token`.

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -66,6 +66,11 @@ import {
   ConfigError,
 } from "../config/loader.js";
 import { scaffoldAgent, alignAgentUid, renderFleetInvariants, toHostHomePath } from "../agents/scaffold.js";
+import {
+  getGrantsDbDir,
+  getGrantsDbPath,
+  migrateLegacyGrantsDbLocation,
+} from "../vault/grants-db-path.js";
 import { renderFleetDefaultsClaudeMd } from "../agents/fleet-defaults.js";
 import { refreshAgentConnectionHealth } from "../agents/connection-health.js";
 import type { VaultAclResult } from "./doctor-mcp-secrets.js";
@@ -1019,23 +1024,31 @@ export async function ensureHostMountSources(
   }
 
   // vault-grants.db: capability-token grants persisted to a SQLite
-  // file. Same dir-vs-file race as vault-audit.log — if the source
-  // path doesn't exist, docker auto-creates it as a root-owned
-  // DIRECTORY and the broker can't write. Pre-create as a 0-byte
-  // file owned by the operator (mode 0600 — secrets material, no
-  // group/other access). The broker's `openGrantsDb` runs the SQL
-  // migration on first open and turns the empty file into a valid
-  // schema, so the broker boots cleanly on either a fresh empty
-  // file OR an existing populated DB.
+  // file inside a DEDICATED directory (`~/.switchroom/vault-broker/`).
   //
-  // Without this bind mount + pre-create, broker recreates wipe
-  // every capability grant — the orphaned `.vault-token` files
-  // on disk then fail every `vault get` from inside agent
-  // containers. Surfaced 2026-05-24 after the v0.13.31 rollout.
-  const grantsDbPath = join(home, ".switchroom", "vault-grants.db");
-  if (!existsSync(grantsDbPath)) {
-    writeFileSync(grantsDbPath, "", { mode: 0o600 });
-  }
+  // WHY A DIRECTORY, NOT THE BARE FILE (#3289): the grants DB runs in WAL
+  // mode, which writes `-wal`/`-shm` sidecars beside the main file. The old
+  // single-file bind mount left those sidecars in the broker's ephemeral
+  // overlayfs, so a committed grant sat in the container-local WAL until a
+  // rare checkpoint and was LOST on container recreate. Bind-mounting the
+  // whole directory keeps the main file AND its sidecars on the host fs.
+  //
+  // Pre-create the directory (mode 0700 — secrets material, no group/other
+  // access) so docker doesn't auto-create a root-owned path at the bind
+  // source, then relocate any legacy `~/.switchroom/vault-grants.db` (plus its
+  // WAL sidecars) into it. `migrateLegacyGrantsDbLocation` is idempotent and a
+  // no-op on greenfield / already-migrated hosts. The broker's `openGrantsDb`
+  // runs the SQL migration on first open, so it boots cleanly on a fresh empty
+  // directory OR an existing populated DB. Both resolve the path from the
+  // shared `grants-db-path` helpers — no duplicated literal.
+  //
+  // Without this bind mount + pre-create, broker recreates wipe every
+  // capability grant — the orphaned `.vault-token` files on disk then fail
+  // every `vault get` from inside agent containers. Surfaced 2026-05-24 after
+  // the v0.13.31 rollout; WAL-sidecar durability hardened in #3289.
+  const grantsDbDir = getGrantsDbDir(home);
+  mkdirSync(grantsDbDir, { recursive: true, mode: 0o700 });
+  migrateLegacyGrantsDbLocation(getGrantsDbPath(home));
 
   // host-control-audit.log: same pattern as vault-audit.log — hostd
   // is the writer (from inside its own container at /host-home),

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -1046,6 +1046,16 @@ export async function ensureHostMountSources(
   // capability grant — the orphaned `.vault-token` files on disk then fail
   // every `vault get` from inside agent containers. Surfaced 2026-05-24 after
   // the v0.13.31 rollout; WAL-sidecar durability hardened in #3289.
+  //
+  // UPGRADE-WINDOW CAVEAT: while a PRE-fix broker is still running, it holds
+  // the legacy DB open via the old single-file mount. A grant minted between
+  // this migration and the broker's recreate (`docker compose up`, which the
+  // operator/updater runs after apply) lands in a fresh container-local
+  // legacy -wal the new broker never replays and may need re-minting. This
+  // window is unavoidable without stopping the broker before apply; apply
+  // therefore runs the migration as late as it can — inside the mount-source
+  // preparation immediately preceding the compose handoff. The broker's own
+  // boot re-runs the same idempotent migration as a second chance.
   const grantsDbDir = getGrantsDbDir(home);
   mkdirSync(grantsDbDir, { recursive: true, mode: 0o700 });
   migrateLegacyGrantsDbLocation(getGrantsDbPath(home));

--- a/src/cli/doctor-approval-attribution.ts
+++ b/src/cli/doctor-approval-attribution.ts
@@ -41,6 +41,7 @@ import { readFileSync as fsReadFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { canonicalizeApproverSet } from "../vault/approvals/canonical.js";
+import { GRANTS_DB_CONTAINER_PATH } from "../vault/grants-db-path.js";
 
 import type { CheckStatus } from "./doctor-status.js";
 
@@ -196,17 +197,16 @@ function parseSqlite3Lines(stdout: string, sep: string): DecisionRow[] {
  * Default loader: read approval_decisions out of vault-grants.db.
  *
  * Primary path — HOST-SIDE bun:sqlite read of the canonical
- * `~/.switchroom/vault-grants.db` (grants-db.ts DEFAULT_GRANTS_DB_PATH):
- * doctor runs on the host, and the broker container merely bind-mounts that
- * same file to `/root/.switchroom/vault-grants.db` (compose.ts — the
- * `${homePrefix}/.switchroom/vault-grants.db:/root/.switchroom/vault-grants.db`
- * mount), so the host file IS the authoritative DB and needs neither docker
- * nor a sqlite3 binary. The built CLI runs under bun (scripts/build.mjs
- * rewrites the shebang to bun precisely because of `bun:sqlite`), so the
- * dynamic import resolves; under vitest/node the `typeof Bun` guard skips it.
+ * `~/.switchroom/vault-broker/vault-grants.db` (grants-db-path.ts
+ * `getGrantsDbPath()`): doctor runs on the host, and the broker container
+ * bind-mounts that directory to `/root/.switchroom/vault-broker` (compose.ts),
+ * so the host file IS the authoritative DB and needs neither docker nor a
+ * sqlite3 binary. The built CLI runs under bun (scripts/build.mjs rewrites the
+ * shebang to bun precisely because of `bun:sqlite`), so the dynamic import
+ * resolves; under vitest/node the `typeof Bun` guard skips it.
  *
  * Fallback — `docker exec switchroom-vault-broker sqlite3` against the
- * IN-CONTAINER path `/root/.switchroom/vault-grants.db`. Best-effort only:
+ * IN-CONTAINER path `GRANTS_DB_CONTAINER_PATH`. Best-effort only:
  * requires sqlite3 in the broker image, and the container name assumes the
  * default compose project prefix ("switchroom-"); a custom prefix makes this
  * fallback miss and the check degrades to `skip`.
@@ -218,10 +218,9 @@ async function defaultLoadDecisions(): Promise<DecisionRow[] | null> {
   // Path 1: direct host-file read via bun:sqlite (readonly).
   try {
     if (typeof Bun !== "undefined") {
-      const os = await import("node:os");
-      const path = await import("node:path");
       const fs = await import("node:fs");
-      const dbPath = path.join(os.homedir(), ".switchroom", "vault-grants.db");
+      const { getGrantsDbPath } = await import("../vault/grants-db-path.js");
+      const dbPath = getGrantsDbPath();
       if (fs.existsSync(dbPath)) {
         const { Database } = await import("bun:sqlite");
         const db = new Database(dbPath, { readonly: true });
@@ -266,7 +265,7 @@ async function defaultLoadDecisions(): Promise<DecisionRow[] | null> {
         "sqlite3",
         "-separator",
         SEP,
-        "/root/.switchroom/vault-grants.db",
+        GRANTS_DB_CONTAINER_PATH,
         DECISIONS_SQL,
       ],
       { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 10_000 },

--- a/src/cli/doctor-vault-broker-durability.test.ts
+++ b/src/cli/doctor-vault-broker-durability.test.ts
@@ -31,9 +31,20 @@ import {
   formatBindMountResult,
   probeBrokerUnlocked,
   probeKernelDbDurability,
+  probeGrantsWalDivergence,
+  probeOrphanVaultTokens,
   type BindMountStatResult,
   type BrokerStatResult,
+  type BrokerFileStat,
 } from "./doctor-vault-broker-durability.js";
+import { GRANTS_DB_CONTAINER_PATH } from "../vault/grants-db-path.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+function fakeConfig(agents: string[]): SwitchroomConfig {
+  const map: Record<string, unknown> = {};
+  for (const a of agents) map[a] = {};
+  return { agents: map } as unknown as SwitchroomConfig;
+}
 
 describe("probeBindMountInode — inode-equality bind-mount probe", () => {
   it("returns ok when host and broker inodes + sizes match", () => {
@@ -276,5 +287,100 @@ describe("probeKernelDbDurability — approval-kernel approvals bind mount", () 
     });
     expect(r.name).toContain("approval-kernel");
     expect(r.name).toContain("allow_always");
+  });
+});
+
+describe("probeGrantsWalDivergence — WAL checkpoint state (#3289)", () => {
+  const main = GRANTS_DB_CONTAINER_PATH;
+  const wal = `${main}-wal`;
+
+  it("skips when the broker container is unreachable", () => {
+    const r = probeGrantsWalDivergence(() => ({ kind: "unreachable" }));
+    expect(r.status).toBe("skip");
+  });
+
+  it("ok when there is no grants DB yet (empty fleet)", () => {
+    const r = probeGrantsWalDivergence((p) =>
+      p === main ? { kind: "missing" } : { kind: "missing" },
+    );
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("no grants DB");
+  });
+
+  it("ok when the -wal sidecar is absent (fully checkpointed)", () => {
+    const r = probeGrantsWalDivergence((p) =>
+      p === main
+        ? { kind: "ok", mtime: 1000, size: 4096 }
+        : { kind: "missing" },
+    );
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("no -wal sidecar");
+  });
+
+  it("ok when the -wal is present but truncated to 0 bytes", () => {
+    const r = probeGrantsWalDivergence((p) =>
+      p === main
+        ? { kind: "ok", mtime: 1000, size: 4096 }
+        : { kind: "ok", mtime: 1200, size: 0 },
+    );
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("truncated");
+  });
+
+  it("warns when a NON-empty -wal is newer than the main DB (un-checkpointed grants)", () => {
+    const r = probeGrantsWalDivergence((p) =>
+      p === main
+        ? { kind: "ok", mtime: 1000, size: 4096 }
+        : { kind: "ok", mtime: 2000, size: 32768 },
+    );
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("un-checkpointed");
+    expect(r.fix).toBeTruthy();
+  });
+
+  it("ok when a non-empty -wal is NOT newer than main", () => {
+    const r = probeGrantsWalDivergence((p): BrokerFileStat =>
+      p === wal
+        ? { kind: "ok", mtime: 500, size: 32768 }
+        : { kind: "ok", mtime: 1000, size: 4096 },
+    );
+    expect(r.status).toBe("ok");
+  });
+});
+
+describe("probeOrphanVaultTokens — #1737 / #3289 orphan-token detector", () => {
+  it("ok when no agent holds a vault-token", () => {
+    const r = probeOrphanVaultTokens(fakeConfig(["a", "b"]), {
+      readTokenId: () => null,
+    });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("nothing to orphan-check");
+  });
+
+  it("ok when every token references a live grant row", () => {
+    const r = probeOrphanVaultTokens(fakeConfig(["a", "b"]), {
+      readTokenId: (agent) => `vg_${agent}id`,
+      grantIdExists: () => true,
+    });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("all reference a live grant");
+  });
+
+  it("FAILS when a token references a grant id absent from the DB", () => {
+    const r = probeOrphanVaultTokens(fakeConfig(["clerk"]), {
+      readTokenId: () => "vg_5e1991",
+      grantIdExists: (id) => id !== "vg_5e1991",
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("clerk=vg_5e1991");
+    expect(r.detail).toContain("DENIES");
+  });
+
+  it("skips when the grants DB can't be read on the host", () => {
+    const r = probeOrphanVaultTokens(fakeConfig(["a"]), {
+      readTokenId: () => "vg_x",
+      grantIdExists: () => null,
+    });
+    expect(r.status).toBe("skip");
   });
 });

--- a/src/cli/doctor-vault-broker-durability.test.ts
+++ b/src/cli/doctor-vault-broker-durability.test.ts
@@ -327,15 +327,34 @@ describe("probeGrantsWalDivergence — WAL checkpoint state (#3289)", () => {
     expect(r.detail).toContain("truncated");
   });
 
-  it("warns when a NON-empty -wal is newer than the main DB (un-checkpointed grants)", () => {
-    const r = probeGrantsWalDivergence((p) =>
-      p === main
-        ? { kind: "ok", mtime: 1000, size: 4096 }
-        : { kind: "ok", mtime: 2000, size: 32768 },
+  it("warns when a NON-empty -wal is newer than the main DB AND stale (un-checkpointed grants)", () => {
+    // Divergence has persisted well past the settle window (now = wal mtime
+    // + 1 hour) — the checkpoint-after-mutation defense isn't firing.
+    const r = probeGrantsWalDivergence(
+      (p) =>
+        p === main
+          ? { kind: "ok", mtime: 1000, size: 4096 }
+          : { kind: "ok", mtime: 2000, size: 32768 },
+      { nowEpochSecs: 2000 + 3600 },
     );
     expect(r.status).toBe("warn");
     expect(r.detail).toContain("un-checkpointed");
     expect(r.fix).toBeTruthy();
+  });
+
+  it("does NOT warn on a FRESH divergence (busy checkpoint under read contention — N1)", () => {
+    // A healthy broker: PRAGMA wal_checkpoint(TRUNCATE) returned SQLITE_BUSY
+    // (as a row, not an error) because a reader held the DB, so the -wal is
+    // momentarily newer than main. Within the settle window this is ok.
+    const r = probeGrantsWalDivergence(
+      (p) =>
+        p === main
+          ? { kind: "ok", mtime: 1000, size: 4096 }
+          : { kind: "ok", mtime: 2000, size: 32768 },
+      { nowEpochSecs: 2000 + 10 },
+    );
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("settle window");
   });
 
   it("ok when a non-empty -wal is NOT newer than main", () => {

--- a/src/cli/doctor-vault-broker-durability.ts
+++ b/src/cli/doctor-vault-broker-durability.ts
@@ -45,12 +45,19 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, statSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { createRequire } from "node:module";
 
 import type { SwitchroomConfig } from "../config/schema.js";
 import type { CheckResult } from "./doctor.js";
+import {
+  GRANTS_DB_CONTAINER_DIR,
+  GRANTS_DB_CONTAINER_PATH,
+  getGrantsDbDir,
+  getGrantsDbPath,
+} from "../vault/grants-db-path.js";
 
 /**
  * Result of a single `docker exec`-based stat probe: host inode/size
@@ -332,6 +339,9 @@ export function runVaultBrokerDurabilityChecks(
     inodeProbe?: typeof probeBindMountInode;
     statusProbe?: Parameters<typeof probeBrokerUnlocked>[0];
     kernelStatBroker?: (p: string) => BrokerStatResult;
+    walStatBroker?: (p: string) => BrokerFileStat;
+    grantIdExists?: (id: string) => boolean | null;
+    readTokenId?: (agent: string, home: string) => string | null;
   },
 ): CheckResult[] {
   const home = homedir();
@@ -351,14 +361,17 @@ export function runVaultBrokerDurabilityChecks(
       ),
     ),
     formatBindMountResult(
-      "vault-broker: vault-grants.db bind mount (#1737)",
-      join(home, ".switchroom", "vault-grants.db"),
-      "/root/.switchroom/vault-grants.db",
-      probe(
-        join(home, ".switchroom", "vault-grants.db"),
-        "/root/.switchroom/vault-grants.db",
-      ),
+      "vault-broker: vault-grants dir bind mount (#1737 / #3289)",
+      getGrantsDbDir(home),
+      GRANTS_DB_CONTAINER_DIR,
+      probe(getGrantsDbDir(home), GRANTS_DB_CONTAINER_DIR),
     ),
+    probeGrantsWalDivergence(opts?.walStatBroker),
+    probeOrphanVaultTokens(_config, {
+      home,
+      grantIdExists: opts?.grantIdExists,
+      readTokenId: opts?.readTokenId,
+    }),
     formatBindMountResult(
       "vault-broker: vault-audit.log bind mount (#1025)",
       join(home, ".switchroom", "vault-audit.log"),
@@ -475,6 +488,207 @@ function defaultKernelStatBroker(p: string): BrokerStatResult {
     };
   }
   return { kind: "ok-with-stat", ino: inoStr, size };
+}
+
+/**
+ * Broker-side stat of a single file: mtime (epoch seconds) + size, or a
+ * failure shape. Used by the WAL-divergence probe.
+ */
+export type BrokerFileStat =
+  | { kind: "ok"; mtime: number; size: number }
+  | { kind: "missing" }
+  | { kind: "unreachable" }
+  | { kind: "failed"; msg: string };
+
+function defaultWalStatBroker(p: string): BrokerFileStat {
+  // `docker exec switchroom-vault-broker stat -c '%Y %s' <path>` →
+  // "<mtime-epoch> <size>". Exit 1 = path missing; ≥125 = unreachable.
+  try {
+    const stdout = execFileSync(
+      "docker",
+      ["exec", "switchroom-vault-broker", "stat", "-c", "%Y %s", p],
+      { stdio: ["ignore", "pipe", "pipe"], timeout: 3000, encoding: "utf8" },
+    );
+    const [mStr, sStr] = stdout.trim().split(/\s+/);
+    const mtime = Number(mStr);
+    const size = Number(sStr);
+    if (!Number.isFinite(mtime) || !Number.isFinite(size)) {
+      return { kind: "failed", msg: `unparseable stat output: ${stdout.trim()}` };
+    }
+    return { kind: "ok", mtime, size };
+  } catch (err: unknown) {
+    const e = err as { status?: number; stderr?: string; message?: string };
+    if (typeof e.status !== "number") return { kind: "unreachable" };
+    if (e.status >= 125) return { kind: "unreachable" };
+    // exit 1 from `stat` on a non-existent path
+    return { kind: "missing" };
+  }
+}
+
+/**
+ * Flag WAL divergence inside the broker container: a `-wal` sidecar that is
+ * non-empty AND newer than the main DB file means committed grants are sitting
+ * in the write-ahead log that has not been checkpointed back into the main
+ * file. Post-#3289 the whole grants directory is persisted so this is no
+ * longer a data-loss condition on its own, but a persistently non-empty WAL
+ * means the checkpoint-after-every-mutation defense (grants.ts) is not firing
+ * — worth surfacing, and it is the exact signal the host-side readers (doctor,
+ * migration) depend on the main file being current for.
+ *
+ * @internal exported for testing
+ */
+export function probeGrantsWalDivergence(
+  statBroker: (p: string) => BrokerFileStat = defaultWalStatBroker,
+): CheckResult {
+  const name = "vault-broker: grants WAL checkpointed (#3289)";
+  const main = statBroker(GRANTS_DB_CONTAINER_PATH);
+  if (main.kind === "unreachable") {
+    return { name, status: "skip", detail: "vault-broker container unreachable" };
+  }
+  if (main.kind === "missing") {
+    // No DB yet (empty fleet) — nothing to diverge.
+    return { name, status: "ok", detail: "no grants DB yet — nothing to checkpoint" };
+  }
+  if (main.kind === "failed") {
+    return { name, status: "warn", detail: `broker stat failed: ${main.msg}` };
+  }
+  const wal = statBroker(`${GRANTS_DB_CONTAINER_PATH}-wal`);
+  if (wal.kind === "missing") {
+    return { name, status: "ok", detail: "no -wal sidecar — grants DB fully checkpointed" };
+  }
+  if (wal.kind === "unreachable") {
+    return { name, status: "skip", detail: "vault-broker container unreachable" };
+  }
+  if (wal.kind === "failed") {
+    return { name, status: "warn", detail: `broker -wal stat failed: ${wal.msg}` };
+  }
+  if (wal.size === 0) {
+    return { name, status: "ok", detail: "-wal is truncated (0 bytes) — checkpointed" };
+  }
+  if (wal.mtime > main.mtime) {
+    return {
+      name,
+      status: "warn",
+      detail:
+        `-wal (${wal.size} bytes, mtime ${wal.mtime}) is newer than the main DB ` +
+        `(mtime ${main.mtime}) — un-checkpointed grant writes are sitting in the ` +
+        `write-ahead log. The grants directory is bind-mounted so these persist ` +
+        `across container recreate, but the checkpoint-after-mutation defense ` +
+        `(grants.ts) appears not to be firing.`,
+      fix:
+        "Verify the broker is running the #3289 build (checkpoint after every " +
+        "mint/revoke). A one-off `PRAGMA wal_checkpoint(TRUNCATE)` clears the backlog.",
+    };
+  }
+  return { name, status: "ok", detail: `-wal present (${wal.size} bytes) but not newer than main DB` };
+}
+
+/**
+ * Flag any agent `.vault-token` on disk whose grant id has NO matching row in
+ * the grants DB — the exact #1737 / #3289 orphan-token symptom that appears
+ * after a broker recreate wipes grants written to an ephemeral (unmounted or
+ * un-checkpointed) DB. The token still authenticates format-wise but every
+ * `vault get` DENIES because the grant it references is gone.
+ *
+ * @internal exported for testing
+ */
+export function probeOrphanVaultTokens(
+  config: SwitchroomConfig,
+  opts?: {
+    home?: string;
+    readTokenId?: (agent: string, home: string) => string | null;
+    grantIdExists?: (id: string) => boolean | null;
+  },
+): CheckResult {
+  const name = "vault-broker: no orphan .vault-token grants (#1737 / #3289)";
+  const home = opts?.home ?? homedir();
+  const agents = Object.keys(config.agents ?? {});
+  const readTokenId = opts?.readTokenId ?? defaultReadTokenId;
+  const grantIdExists = opts?.grantIdExists ?? defaultGrantIdExists;
+
+  const tokens: { agent: string; id: string }[] = [];
+  for (const agent of agents) {
+    const id = readTokenId(agent, home);
+    if (id) tokens.push({ agent, id });
+  }
+  if (tokens.length === 0) {
+    return { name, status: "ok", detail: "no agent holds a vault-token — nothing to orphan-check" };
+  }
+
+  const orphans: { agent: string; id: string }[] = [];
+  for (const t of tokens) {
+    const exists = grantIdExists(t.id);
+    if (exists === null) {
+      return {
+        name,
+        status: "skip",
+        detail: "grants DB not readable on host — orphan-token check skipped",
+      };
+    }
+    if (!exists) orphans.push(t);
+  }
+
+  if (orphans.length === 0) {
+    return {
+      name,
+      status: "ok",
+      detail: `${tokens.length} vault-token(s) all reference a live grant row`,
+    };
+  }
+  return {
+    name,
+    status: "fail",
+    detail:
+      `${orphans.length} agent vault-token(s) reference a grant id absent from the ` +
+      `grants DB: ${orphans.map((o) => `${o.agent}=${o.id}`).join(", ")}. ` +
+      `This is the classic broker-recreate grant-wipe: every \`vault get\` from ` +
+      `these agents DENIES because the grant no longer exists.`,
+    fix:
+      "Re-mint the grants (`switchroom vault grant <agent> --keys …`). If this " +
+      "recurs after a broker recreate, the grants directory bind mount is broken " +
+      "— see the `vault-grants dir bind mount` probe above.",
+  };
+}
+
+function defaultReadTokenId(agent: string, home: string): string | null {
+  const tokenPath = join(home, ".switchroom", "agents", agent, ".vault-token");
+  try {
+    const raw = readFileSync(tokenPath, "utf8").trim();
+    if (!raw) return null;
+    // Token format: `vg_<id>.<secret>` — the grant id is everything before the
+    // first dot (it includes the `vg_` prefix, matching the DB row id).
+    const dot = raw.indexOf(".");
+    const id = dot === -1 ? raw : raw.slice(0, dot);
+    return id.startsWith("vg_") ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Host-side readonly lookup of a grant id in the grants DB. Returns null when
+ * the DB can't be read (no Bun runtime under vitest, missing file) so the
+ * caller degrades to `skip` rather than a false `fail`.
+ */
+function defaultGrantIdExists(id: string): boolean | null {
+  try {
+    if (typeof (globalThis as { Bun?: unknown }).Bun === "undefined") return null;
+    const dbPath = getGrantsDbPath();
+    if (!existsSync(dbPath)) return null;
+    const req = createRequire(import.meta.url);
+    const { Database } = req("bun:sqlite") as typeof import("bun:sqlite");
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const row = db
+        .query("SELECT 1 AS ok FROM vault_grants WHERE id = ? AND revoked_at IS NULL")
+        .get(id);
+      return !!row;
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null;
+  }
 }
 
 function probeAutoUnlockBlob(home: string): CheckResult {

--- a/src/cli/doctor-vault-broker-durability.ts
+++ b/src/cli/doctor-vault-broker-durability.ts
@@ -535,11 +535,24 @@ function defaultWalStatBroker(p: string): BrokerFileStat {
  * — worth surfacing, and it is the exact signal the host-side readers (doctor,
  * migration) depend on the main file being current for.
  *
+ * FALSE-POSITIVE GUARD: `PRAGMA wal_checkpoint(TRUNCATE)` legitimately leaves
+ * the WAL non-empty when a concurrent reader holds the DB busy (SQLITE_BUSY is
+ * reported as a result ROW, not an error) — a healthy broker under normal read
+ * contention would trip a naive newer-than-main check. So the probe only warns
+ * when the divergent WAL is also STALE: its mtime is older than
+ * `staleThresholdSecs` (default 300s). A fresh divergence means writes are
+ * in-flight or a busy checkpoint just deferred — the next mutation's
+ * checkpoint clears it; only a divergence that has persisted implies the
+ * defense isn't firing.
+ *
  * @internal exported for testing
  */
 export function probeGrantsWalDivergence(
   statBroker: (p: string) => BrokerFileStat = defaultWalStatBroker,
+  opts?: { nowEpochSecs?: number; staleThresholdSecs?: number },
 ): CheckResult {
+  const now = opts?.nowEpochSecs ?? Math.floor(Date.now() / 1000);
+  const staleThreshold = opts?.staleThresholdSecs ?? 300;
   const name = "vault-broker: grants WAL checkpointed (#3289)";
   const main = statBroker(GRANTS_DB_CONTAINER_PATH);
   if (main.kind === "unreachable") {
@@ -566,15 +579,29 @@ export function probeGrantsWalDivergence(
     return { name, status: "ok", detail: "-wal is truncated (0 bytes) — checkpointed" };
   }
   if (wal.mtime > main.mtime) {
+    const ageSecs = now - wal.mtime;
+    if (ageSecs < staleThreshold) {
+      // Fresh divergence — writes in flight or a busy checkpoint just
+      // deferred; a healthy broker under read contention looks like this.
+      return {
+        name,
+        status: "ok",
+        detail:
+          `-wal (${wal.size} bytes) is newer than the main DB but only ` +
+          `${Math.max(ageSecs, 0)}s old — within the ${staleThreshold}s ` +
+          `settle window (busy checkpoints are normal under read contention)`,
+      };
+    }
     return {
       name,
       status: "warn",
       detail:
         `-wal (${wal.size} bytes, mtime ${wal.mtime}) is newer than the main DB ` +
-        `(mtime ${main.mtime}) — un-checkpointed grant writes are sitting in the ` +
-        `write-ahead log. The grants directory is bind-mounted so these persist ` +
-        `across container recreate, but the checkpoint-after-mutation defense ` +
-        `(grants.ts) appears not to be firing.`,
+        `(mtime ${main.mtime}) and has been divergent for ${ageSecs}s — ` +
+        `un-checkpointed grant writes are sitting in the write-ahead log. The ` +
+        `grants directory is bind-mounted so these persist across container ` +
+        `recreate, but the checkpoint-after-mutation defense (grants.ts) ` +
+        `appears not to be firing.`,
       fix:
         "Verify the broker is running the #3289 build (checkpoint after every " +
         "mint/revoke). A one-off `PRAGMA wal_checkpoint(TRUNCATE)` clears the backlog.",

--- a/src/vault/backup.ts
+++ b/src/vault/backup.ts
@@ -27,8 +27,8 @@
  * Hard rules:
  *   - NEVER copies `~/.switchroom/vault-auto-unlock` (machine-bound; if
  *     leaked, gives the passphrase — and is useless off-host anyway).
- *   - NEVER copies `vault-grants.db` (per-agent grant tokens; different
- *     threat model).
+ *   - NEVER copies the grants DB (`vault-broker/vault-grants.db`; per-agent
+ *     grant tokens; different threat model).
  *   - REFUSES to write backups into a directory that already contains an
  *     `auto-unlock`-shaped sibling — defense-in-depth against an operator
  *     one day pointing `--to ~/.switchroom/` and bulk-syncing the

--- a/src/vault/grants-db-path.ts
+++ b/src/vault/grants-db-path.ts
@@ -70,19 +70,49 @@ export const WAL_SIDECAR_SUFFIXES = ["-wal", "-shm"] as const;
  *
  *   - No-op when the legacy file is absent (greenfield) or the new file
  *     already exists (already migrated), or when the two resolve equal.
- *   - Moves the main DB file AND any `-wal`/`-shm` sidecars TOGETHER into the
- *     new directory. Moving them together (rather than checkpointing then
- *     discarding) is the conservative, `bun:sqlite`-free choice: SQLite
- *     replays a matched `-wal` against its main file on the next open, so no
- *     committed grant can be lost even if a checkpoint would have failed. This
- *     keeps the migration usable from vitest-run host code (`apply`) that must
- *     not import `bun:sqlite`.
+ *   - Moves any `-wal`/`-shm` sidecars FIRST, then the main DB file. Ordering
+ *     matters: a `-wal` can hold committed-but-not-checkpointed grants, and
+ *     SQLite only replays a `-wal` that sits BESIDE its main file. If a
+ *     sidecar move fails (EXDEV, perms), already-moved sidecars are rolled
+ *     back and the migration aborts loudly with the legacy pair intact — it
+ *     retries on the next apply/boot. Moving the main file first would risk
+ *     splitting the pair (main at the new path, `-wal` stranded at the old
+ *     one) and silently losing committed grants — exactly the bug class this
+ *     migration exists to fix.
+ *   - Moving (rather than checkpointing then discarding) is the conservative,
+ *     `bun:sqlite`-free choice: SQLite replays a matched `-wal` against its
+ *     main file on the next open, so no committed grant can be lost even if a
+ *     checkpoint would have failed. This keeps the migration usable from
+ *     vitest-run host code (`apply`) that must not import `bun:sqlite`.
+ *   - Concurrency (apply racing a broker boot): the final main-file rename is
+ *     guarded — if it throws but the new path now exists and the legacy one is
+ *     gone, the other migrator won the race and this call returns
+ *     `{migrated: false}` instead of propagating a spurious ENOENT that would
+ *     abort apply or wedge the broker boot loop.
+ *
+ * UPGRADE-WINDOW CAVEAT (inherent, documented): a still-running PRE-fix
+ * broker holds the legacy DB open via the old single-file bind mount. A grant
+ * minted between this migration and the broker's recreate lands in a fresh
+ * container-local legacy `-wal` the new broker never replays. This window is
+ * unavoidable without stopping the broker first; it is why apply runs the
+ * migration as part of compose-source preparation immediately before the
+ * `docker compose up` that recreates the broker, and why a grant minted
+ * mid-upgrade may need re-minting.
  *
  * Returns a small descriptor so callers can log/observe the outcome.
  */
 export function migrateLegacyGrantsDbLocation(
   newDbPath: string = getGrantsDbPath(),
+  deps?: {
+    /**
+     * Injection seam for tests — how a file is renamed. Lets tests force a
+     * sidecar-move or main-move failure (EXDEV, ENOENT race) deterministically
+     * without depending on filesystem quirks. DO NOT set outside tests.
+     */
+    rename?: (from: string, to: string) => void;
+  },
 ): { migrated: boolean; from?: string; to?: string } {
+  const rename = deps?.rename ?? fs.renameSync;
   const legacyPath = getLegacyGrantsDbPath(newDbPath);
 
   if (path.resolve(legacyPath) === path.resolve(newDbPath)) {
@@ -93,24 +123,54 @@ export function migrateLegacyGrantsDbLocation(
 
   fs.mkdirSync(path.dirname(newDbPath), { recursive: true, mode: 0o700 });
 
-  fs.renameSync(legacyPath, newDbPath);
+  // Sidecars FIRST (see doc comment). Track moves so a mid-way failure can
+  // roll back and leave the legacy main+wal pair intact for a retry.
+  const movedSidecars: { from: string; to: string }[] = [];
+  const rollbackSidecars = () => {
+    for (const m of [...movedSidecars].reverse()) {
+      try {
+        rename(m.to, m.from);
+      } catch {
+        // Rollback is best-effort; the main file has NOT moved, so the worst
+        // case is a stray sidecar copy at the new path, which the next
+        // successful migration's rename overwrites.
+      }
+    }
+  };
+  for (const suffix of WAL_SIDECAR_SUFFIXES) {
+    const from = `${legacyPath}${suffix}`;
+    const to = `${newDbPath}${suffix}`;
+    if (!fs.existsSync(from)) continue;
+    try {
+      rename(from, to);
+      movedSidecars.push({ from, to });
+    } catch (err) {
+      // A half-migrated WAL pair means committed grants could be split from
+      // their main file — abort loudly with the legacy pair intact (M1).
+      rollbackSidecars();
+      throw new Error(
+        `grants-db migration: failed to move WAL sidecar ${from} -> ${to} ` +
+          `(${(err as Error).message}); aborted with the legacy DB intact — ` +
+          `will retry on the next apply/boot`,
+      );
+    }
+  }
+
+  // Main file LAST, guarded against a concurrent migrator (L1 TOCTOU).
+  try {
+    rename(legacyPath, newDbPath);
+  } catch (err) {
+    if (fs.existsSync(newDbPath) && !fs.existsSync(legacyPath)) {
+      // Lost the race to a concurrent apply/boot — already migrated by them.
+      return { migrated: false };
+    }
+    rollbackSidecars();
+    throw err;
+  }
   try {
     fs.chmodSync(newDbPath, 0o600);
   } catch {
     // Non-fatal: FS may ignore modes, or perms already correct.
-  }
-
-  for (const suffix of WAL_SIDECAR_SUFFIXES) {
-    const from = `${legacyPath}${suffix}`;
-    const to = `${newDbPath}${suffix}`;
-    if (fs.existsSync(from)) {
-      try {
-        fs.renameSync(from, to);
-      } catch {
-        // Best-effort; a `-shm` is rebuildable and a lone leftover sidecar
-        // beside the now-absent legacy main file is inert.
-      }
-    }
   }
 
   return { migrated: true, from: legacyPath, to: newDbPath };

--- a/src/vault/grants-db-path.ts
+++ b/src/vault/grants-db-path.ts
@@ -1,0 +1,117 @@
+/**
+ * vault/grants-db-path.ts — pure path resolution for the vault-grants DB.
+ *
+ * Kept free of any `bun:sqlite` import so it can be pulled into vitest-run
+ * modules (e.g. the compose generator and doctor probes) without breaking the
+ * vitest loader. The DB-opening + migration logic that DOES need `bun:sqlite`
+ * lives in `grants-db.ts`, which re-exports these helpers.
+ *
+ * Canonical location: `~/.switchroom/vault-broker/vault-grants.db`.
+ *
+ * WHY A DEDICATED DIRECTORY (not the bare `~/.switchroom/vault-grants.db`):
+ * the DB runs in WAL mode, which writes `-wal`/`-shm` sidecars BESIDE the main
+ * file. The broker bind-mounts this DB in; if only the single main file is
+ * mounted, the sidecars land in the container's ephemeral overlayfs, so
+ * committed grants sit in the container-local WAL until a rare checkpoint and
+ * are LOST on container recreate (the v0.13.31 grant-wipe incident, #1737 /
+ * #3289). Mounting the whole directory keeps the main file AND its sidecars on
+ * the host fs together.
+ */
+
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+
+/** Dedicated directory that holds the grants DB + its WAL sidecars. */
+export const GRANTS_DB_DIRNAME = "vault-broker";
+/** Basename of the grants SQLite file inside {@link GRANTS_DB_DIRNAME}. */
+export const GRANTS_DB_FILENAME = "vault-grants.db";
+
+/**
+ * In-container path the broker sees for the grants DB. The compose generator
+ * bind-mounts the host `~/.switchroom/vault-broker` DIRECTORY here (not the
+ * bare file), so the WAL sidecars persist alongside the main file.
+ */
+export const GRANTS_DB_CONTAINER_DIR = `/root/.switchroom/${GRANTS_DB_DIRNAME}`;
+export const GRANTS_DB_CONTAINER_PATH = `${GRANTS_DB_CONTAINER_DIR}/${GRANTS_DB_FILENAME}`;
+
+/** Resolve the dedicated grants-DB directory for a given home. */
+export function getGrantsDbDir(home: string = os.homedir()): string {
+  return path.join(home, ".switchroom", GRANTS_DB_DIRNAME);
+}
+
+/** Resolve the canonical grants-DB file path for a given home. */
+export function getGrantsDbPath(home: string = os.homedir()): string {
+  return path.join(getGrantsDbDir(home), GRANTS_DB_FILENAME);
+}
+
+/**
+ * Legacy pre-#3289 location: the bare `~/.switchroom/vault-grants.db` file
+ * (mounted into the broker as a single file, which is exactly the WAL
+ * durability bug the directory move fixes). Derived from the NEW path so a
+ * single shared definition covers both prod and test homes.
+ */
+export function getLegacyGrantsDbPath(
+  newDbPath: string = getGrantsDbPath(),
+): string {
+  // new    = <home>/.switchroom/vault-broker/vault-grants.db
+  // legacy = <home>/.switchroom/vault-grants.db
+  return path.join(path.dirname(path.dirname(newDbPath)), GRANTS_DB_FILENAME);
+}
+
+/** WAL sidecar suffixes that live beside the main DB file. */
+export const WAL_SIDECAR_SUFFIXES = ["-wal", "-shm"] as const;
+
+/**
+ * One-time relocation of the legacy `~/.switchroom/vault-grants.db` file (and
+ * its WAL sidecars) into the dedicated `~/.switchroom/vault-broker/` directory
+ * — the #3289 WAL-durability fix. Idempotent and safe to call on every
+ * apply/boot:
+ *
+ *   - No-op when the legacy file is absent (greenfield) or the new file
+ *     already exists (already migrated), or when the two resolve equal.
+ *   - Moves the main DB file AND any `-wal`/`-shm` sidecars TOGETHER into the
+ *     new directory. Moving them together (rather than checkpointing then
+ *     discarding) is the conservative, `bun:sqlite`-free choice: SQLite
+ *     replays a matched `-wal` against its main file on the next open, so no
+ *     committed grant can be lost even if a checkpoint would have failed. This
+ *     keeps the migration usable from vitest-run host code (`apply`) that must
+ *     not import `bun:sqlite`.
+ *
+ * Returns a small descriptor so callers can log/observe the outcome.
+ */
+export function migrateLegacyGrantsDbLocation(
+  newDbPath: string = getGrantsDbPath(),
+): { migrated: boolean; from?: string; to?: string } {
+  const legacyPath = getLegacyGrantsDbPath(newDbPath);
+
+  if (path.resolve(legacyPath) === path.resolve(newDbPath)) {
+    return { migrated: false };
+  }
+  if (!fs.existsSync(legacyPath)) return { migrated: false };
+  if (fs.existsSync(newDbPath)) return { migrated: false };
+
+  fs.mkdirSync(path.dirname(newDbPath), { recursive: true, mode: 0o700 });
+
+  fs.renameSync(legacyPath, newDbPath);
+  try {
+    fs.chmodSync(newDbPath, 0o600);
+  } catch {
+    // Non-fatal: FS may ignore modes, or perms already correct.
+  }
+
+  for (const suffix of WAL_SIDECAR_SUFFIXES) {
+    const from = `${legacyPath}${suffix}`;
+    const to = `${newDbPath}${suffix}`;
+    if (fs.existsSync(from)) {
+      try {
+        fs.renameSync(from, to);
+      } catch {
+        // Best-effort; a `-shm` is rebuildable and a lone leftover sidecar
+        // beside the now-absent legacy main file is inert.
+      }
+    }
+  }
+
+  return { migrated: true, from: legacyPath, to: newDbPath };
+}

--- a/src/vault/grants-db.test.ts
+++ b/src/vault/grants-db.test.ts
@@ -243,6 +243,105 @@ describe("migrateLegacyGrantsDbLocation — #3289 WAL-durability relocation", ()
     expect(fs.existsSync(legacyPath)).toBe(false);
     expect(fs.existsSync(newPath)).toBe(true);
   });
+
+  it("aborts with the legacy pair INTACT when a -wal sidecar move fails (M1)", () => {
+    const home = tmpDir;
+    const legacyPath = getLegacyGrantsDbPath(getGrantsDbPath(home));
+    const newPath = getGrantsDbPath(home);
+
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(legacyPath, "main-bytes");
+    fs.writeFileSync(`${legacyPath}-wal`, "wal-bytes");
+    fs.writeFileSync(`${legacyPath}-shm`, "shm-bytes");
+
+    // Force the -shm move to fail AFTER the -wal already moved, so the
+    // rollback path is exercised too.
+    const failingRename = (from: string, to: string) => {
+      if (from.endsWith("-shm") && to.startsWith(path.dirname(newPath))) {
+        throw Object.assign(new Error("EXDEV: cross-device link"), {
+          code: "EXDEV",
+        });
+      }
+      fs.renameSync(from, to);
+    };
+
+    expect(() =>
+      migrateLegacyGrantsDbLocation(newPath, { rename: failingRename }),
+    ).toThrow(/failed to move WAL sidecar/);
+
+    // The legacy main + BOTH sidecars must still be intact (the -wal that
+    // moved first was rolled back), and nothing landed at the new main path.
+    expect(fs.readFileSync(legacyPath, "utf8")).toBe("main-bytes");
+    expect(fs.readFileSync(`${legacyPath}-wal`, "utf8")).toBe("wal-bytes");
+    expect(fs.readFileSync(`${legacyPath}-shm`, "utf8")).toBe("shm-bytes");
+    expect(fs.existsSync(newPath)).toBe(false);
+    expect(fs.existsSync(`${newPath}-wal`)).toBe(false);
+
+    // And a plain retry (no failure injection) completes the migration —
+    // committed WAL bytes travel with the main file.
+    const res = migrateLegacyGrantsDbLocation(newPath);
+    expect(res.migrated).toBe(true);
+    expect(fs.readFileSync(`${newPath}-wal`, "utf8")).toBe("wal-bytes");
+  });
+
+  it("treats losing the main-rename race to a concurrent migrator as already-migrated (L1)", () => {
+    const home = tmpDir;
+    const legacyPath = getLegacyGrantsDbPath(getGrantsDbPath(home));
+    const newPath = getGrantsDbPath(home);
+
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(legacyPath, "main-bytes");
+
+    // Simulate the TOCTOU: between the existsSync gates and the main rename,
+    // a concurrent migrator (broker boot) moves the file itself. Our rename
+    // then throws ENOENT — but the new path exists and the legacy is gone.
+    const racingRename = (from: string, to: string) => {
+      if (from === legacyPath) {
+        fs.renameSync(legacyPath, newPath); // the "other" migrator wins
+        throw Object.assign(new Error("ENOENT: no such file or directory"), {
+          code: "ENOENT",
+        });
+      }
+      fs.renameSync(from, to);
+    };
+
+    const res = migrateLegacyGrantsDbLocation(newPath, {
+      rename: racingRename,
+    });
+    expect(res.migrated).toBe(false);
+    expect(fs.existsSync(newPath)).toBe(true);
+    expect(fs.readFileSync(newPath, "utf8")).toBe("main-bytes");
+    expect(fs.existsSync(legacyPath)).toBe(false);
+  });
+
+  it("rethrows a GENUINE main-rename failure and rolls the sidecars back (L1 guard is not a blanket swallow)", () => {
+    const home = tmpDir;
+    const legacyPath = getLegacyGrantsDbPath(getGrantsDbPath(home));
+    const newPath = getGrantsDbPath(home);
+
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(legacyPath, "main-bytes");
+    fs.writeFileSync(`${legacyPath}-wal`, "wal-bytes");
+
+    const failingMainRename = (from: string, to: string) => {
+      if (from === legacyPath) {
+        throw Object.assign(new Error("EACCES: permission denied"), {
+          code: "EACCES",
+        });
+      }
+      fs.renameSync(from, to);
+    };
+
+    expect(() =>
+      migrateLegacyGrantsDbLocation(newPath, { rename: failingMainRename }),
+    ).toThrow(/EACCES/);
+
+    // Sidecar rolled back beside the untouched legacy main.
+    expect(fs.readFileSync(legacyPath, "utf8")).toBe("main-bytes");
+    expect(fs.readFileSync(`${legacyPath}-wal`, "utf8")).toBe("wal-bytes");
+    expect(fs.existsSync(newPath)).toBe(false);
+    expect(fs.existsSync(`${newPath}-wal`)).toBe(false);
+  });
 });
 
 describe("grants durability — survives simulated container recreate", () => {

--- a/src/vault/grants-db.test.ts
+++ b/src/vault/grants-db.test.ts
@@ -18,8 +18,15 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Database } from "bun:sqlite";
-import { openGrantsDb, isGrantsDbCorruption } from "./grants-db.js";
-import { mintGrant, listGrants } from "./grants.js";
+import {
+  openGrantsDb,
+  isGrantsDbCorruption,
+  migrateLegacyGrantsDbLocation,
+  getGrantsDbPath,
+  getGrantsDbDir,
+  getLegacyGrantsDbPath,
+} from "./grants-db.js";
+import { mintGrant, listGrants, revokeGrant } from "./grants.js";
 
 let tmpDir: string;
 let dbPath: string;
@@ -147,6 +154,173 @@ describe("openGrantsDb — non-corruption failure", () => {
       .readdirSync(tmpDir)
       .filter((f) => f.includes(".corrupt-"));
     expect(quarantined).toEqual([]);
+  });
+});
+
+describe("migrateLegacyGrantsDbLocation — #3289 WAL-durability relocation", () => {
+  // Treat tmpDir as a fake $HOME. Legacy DB sits at <home>/.switchroom/
+  // vault-grants.db; the new location is <home>/.switchroom/vault-broker/
+  // vault-grants.db.
+  it("moves the legacy DB (and its WAL sidecars) into the dedicated dir, preserving grants", async () => {
+    const home = tmpDir;
+    const legacyPath = getLegacyGrantsDbPath(getGrantsDbPath(home));
+    const newPath = getGrantsDbPath(home);
+    expect(legacyPath).toBe(path.join(home, ".switchroom", "vault-grants.db"));
+
+    // Seed a populated legacy DB. openGrantsDb(legacyPath) is a no-op-migrate
+    // (its computed legacy-of-legacy doesn't exist), so it just opens+seeds.
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    const seed = openGrantsDb(legacyPath);
+    await mintGrant(seed, "alice", ["svc/key"], 3600);
+    seed.close();
+    // Simulate an un-checkpointed WAL sidecar left beside the legacy file.
+    fs.writeFileSync(`${legacyPath}-wal`, "wal-bytes");
+    fs.writeFileSync(`${legacyPath}-shm`, "shm-bytes");
+
+    const res = migrateLegacyGrantsDbLocation(newPath);
+    expect(res.migrated).toBe(true);
+    expect(res.from).toBe(legacyPath);
+    expect(res.to).toBe(newPath);
+
+    // Legacy main + sidecars gone; new main + sidecars present.
+    expect(fs.existsSync(legacyPath)).toBe(false);
+    expect(fs.existsSync(`${legacyPath}-wal`)).toBe(false);
+    expect(fs.existsSync(`${legacyPath}-shm`)).toBe(false);
+    expect(fs.existsSync(newPath)).toBe(true);
+    expect(fs.existsSync(`${newPath}-wal`)).toBe(true);
+    expect(fs.readFileSync(`${newPath}-wal`, "utf8")).toBe("wal-bytes");
+
+    // The relocated DB still holds the grant.
+    const reopened = openGrantsDb(newPath);
+    expect(listGrants(reopened, "alice").length).toBe(1);
+    reopened.close();
+  });
+
+  it("is a no-op on greenfield (no legacy file)", () => {
+    const home = tmpDir;
+    const res = migrateLegacyGrantsDbLocation(getGrantsDbPath(home));
+    expect(res.migrated).toBe(false);
+    expect(fs.existsSync(getGrantsDbPath(home))).toBe(false);
+  });
+
+  it("is a no-op when the new DB already exists (already migrated)", async () => {
+    const home = tmpDir;
+    const legacyPath = getLegacyGrantsDbPath(getGrantsDbPath(home));
+    const newPath = getGrantsDbPath(home);
+
+    // Seed the live NEW DB first (no legacy present yet, so no auto-migrate),
+    // THEN drop a stale legacy file beside it — the "already migrated but the
+    // old file was never cleaned up" state.
+    const live = openGrantsDb(newPath);
+    await mintGrant(live, "bob", ["svc/key"], 3600);
+    live.close();
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    fs.writeFileSync(legacyPath, "legacy-bytes");
+
+    const res = migrateLegacyGrantsDbLocation(newPath);
+    expect(res.migrated).toBe(false);
+    // Legacy untouched, new DB intact.
+    expect(fs.existsSync(legacyPath)).toBe(true);
+    const reopened = openGrantsDb(newPath);
+    expect(listGrants(reopened, "bob").length).toBe(1);
+    reopened.close();
+  });
+
+  it("openGrantsDb auto-migrates a legacy DB on first boot at the new path", async () => {
+    const home = tmpDir;
+    const legacyPath = getLegacyGrantsDbPath(getGrantsDbPath(home));
+    const newPath = getGrantsDbPath(home);
+
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    const seed = openGrantsDb(legacyPath);
+    await mintGrant(seed, "carol", ["svc/key"], 3600);
+    seed.close();
+
+    // Boot the broker against the NEW path — it should relocate the legacy DB.
+    const db = openGrantsDb(newPath);
+    expect(listGrants(db, "carol").length).toBe(1);
+    db.close();
+    expect(fs.existsSync(legacyPath)).toBe(false);
+    expect(fs.existsSync(newPath)).toBe(true);
+  });
+});
+
+describe("grants durability — survives simulated container recreate", () => {
+  it("grants persist when the DB is reopened from the persisted directory only", async () => {
+    const home = tmpDir;
+    const newPath = getGrantsDbPath(home);
+
+    const db = openGrantsDb(newPath);
+    const { id } = await mintGrant(db, "alice", ["svc/key"], 3600);
+    db.close();
+
+    // Simulate a container recreate: everything ephemeral is discarded; only
+    // the bind-mounted directory (getGrantsDbDir) survives. Assert the file
+    // lives under that directory and reopening from it alone recovers the grant.
+    expect(path.dirname(newPath)).toBe(getGrantsDbDir(home));
+    expect(fs.existsSync(newPath)).toBe(true);
+
+    const reopened = openGrantsDb(newPath);
+    const grants = listGrants(reopened, "alice");
+    expect(grants.length).toBe(1);
+    expect(grants[0].id).toBe(id);
+    reopened.close();
+  });
+
+  it("checkpoint-after-mutation leaves the MAIN db file current (no grant stranded in WAL)", async () => {
+    const home = tmpDir;
+    const newPath = getGrantsDbPath(home);
+
+    const db = openGrantsDb(newPath);
+    await mintGrant(db, "alice", ["svc/key"], 3600);
+
+    // Copy ONLY the main DB file (not the -wal/-shm sidecars) to a fresh path
+    // and open it. If the checkpoint-after-mutation defense did not run, the
+    // grant would live only in the -wal and this main-file-only copy would be
+    // empty. A present grant proves the main file is current.
+    const copyPath = path.join(tmpDir, "main-only-copy.db");
+    fs.copyFileSync(newPath, copyPath);
+    db.close();
+
+    const copy = new Database(copyPath, { readonly: true });
+    try {
+      const rows = copy
+        .query("SELECT id FROM vault_grants WHERE agent_slug = 'alice'")
+        .all();
+      expect(rows.length).toBe(1);
+    } finally {
+      copy.close();
+    }
+
+    // The live WAL sidecar, if present, must be truncated (0 bytes) after the
+    // TRUNCATE checkpoint.
+    const walPath = `${newPath}-wal`;
+    if (fs.existsSync(walPath)) {
+      expect(fs.statSync(walPath).size).toBe(0);
+    }
+  });
+
+  it("revoke is also checkpointed into the main file", async () => {
+    const home = tmpDir;
+    const newPath = getGrantsDbPath(home);
+    const db = openGrantsDb(newPath);
+    const { id } = await mintGrant(db, "alice", ["svc/key"], 3600);
+    expect(revokeGrant(db, id)).toBe(true);
+
+    const copyPath = path.join(tmpDir, "after-revoke-copy.db");
+    fs.copyFileSync(newPath, copyPath);
+    db.close();
+
+    const copy = new Database(copyPath, { readonly: true });
+    try {
+      const row = copy
+        .query("SELECT revoked_at FROM vault_grants WHERE id = ?")
+        .get(id) as { revoked_at: number | null } | undefined;
+      expect(row).toBeTruthy();
+      expect(row!.revoked_at).not.toBeNull();
+    } finally {
+      copy.close();
+    }
   });
 });
 

--- a/src/vault/grants-db.ts
+++ b/src/vault/grants-db.ts
@@ -1,26 +1,55 @@
 /**
  * vault/grants-db.ts — open the vault-grants SQLite database.
  *
- * DB path: ~/.switchroom/vault-grants.db (mode 0600, beside vault.enc).
+ * DB path: ~/.switchroom/vault-broker/vault-grants.db (mode 0600).
  * Runs the schema migration on every open (idempotent).
+ *
+ * WHY A DEDICATED DIRECTORY (not the bare `~/.switchroom/vault-grants.db`):
+ * the DB runs in WAL mode, which writes `-wal`/`-shm` sidecars BESIDE the main
+ * file. The broker bind-mounts this DB in; if only the single main file is
+ * mounted, the sidecars land in the container's ephemeral overlayfs, so
+ * committed grants sit in the container-local WAL until a rare checkpoint and
+ * are LOST on container recreate (the v0.13.31 grant-wipe incident, #1737).
+ * Mounting the whole directory keeps the main file AND its sidecars on the
+ * host fs together, so grants survive recreate regardless of checkpoint state.
+ * All readers/writers resolve the path from `getGrantsDbPath()` — never a
+ * duplicated literal.
  *
  * This module is kept separate from grants.ts so callers can inject any
  * Database handle in tests (in-memory), while production always uses this
  * canonical path.
  */
 
-import * as os from "node:os";
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { Database } from "bun:sqlite";
 import { migrateGrantsSchema } from "./grants.js";
 import { migrateApprovalSchema } from "./approvals/schema.js";
+import {
+  GRANTS_DB_DIRNAME,
+  GRANTS_DB_FILENAME,
+  GRANTS_DB_CONTAINER_DIR,
+  GRANTS_DB_CONTAINER_PATH,
+  getGrantsDbDir,
+  getGrantsDbPath,
+  getLegacyGrantsDbPath,
+  migrateLegacyGrantsDbLocation,
+} from "./grants-db-path.js";
 
-export const DEFAULT_GRANTS_DB_PATH = path.join(
-  os.homedir(),
-  ".switchroom",
-  "vault-grants.db",
-);
+// Re-export the pure path + migration helpers so existing `grants-db.js`
+// importers keep working without needing to know about the split.
+export {
+  GRANTS_DB_DIRNAME,
+  GRANTS_DB_FILENAME,
+  GRANTS_DB_CONTAINER_DIR,
+  GRANTS_DB_CONTAINER_PATH,
+  getGrantsDbDir,
+  getGrantsDbPath,
+  getLegacyGrantsDbPath,
+  migrateLegacyGrantsDbLocation,
+};
+
+export const DEFAULT_GRANTS_DB_PATH = getGrantsDbPath();
 
 /**
  * WAL sidecar suffixes that must be quarantined alongside the main DB file.
@@ -167,6 +196,12 @@ export function openGrantsDb(
 ): Database {
   const dir = path.dirname(dbPath);
   fs.mkdirSync(dir, { recursive: true });
+
+  // Boot-time relocation: if a legacy `~/.switchroom/vault-grants.db` still
+  // sits at the old single-file location and nothing has been written to the
+  // new path yet, move it into the dedicated directory before opening. Safe
+  // no-op on greenfield and on already-migrated deployments.
+  migrateLegacyGrantsDbLocation(dbPath);
 
   try {
     return opener(dbPath);

--- a/src/vault/grants.ts
+++ b/src/vault/grants.ts
@@ -148,6 +148,33 @@ function rowToGrant(row: Record<string, unknown>): GrantRow {
 }
 
 /**
+ * Defense-in-depth WAL durability: fold the write-ahead log back into the
+ * main DB file immediately after a grant mutation.
+ *
+ * The primary durability fix is mounting the whole grants-DB DIRECTORY into
+ * the broker (so `-wal`/`-shm` persist across container recreate — see
+ * grants-db.ts). This checkpoint is the belt-and-braces: grant write volume
+ * is trivial (a mint or revoke is a rare, human-paced event), so truncating
+ * the WAL after every mutation is effectively free and guarantees the main
+ * file is always current for host-side readers (doctor, migration) without a
+ * race on the next automatic checkpoint. We keep WAL mode (not journal_mode=
+ * DELETE) because the broker and the approval-kernel share this one handle and
+ * rely on WAL's concurrent-reader behaviour + busy_timeout; DELETE would
+ * change those shared semantics, whereas an explicit checkpoint does not.
+ *
+ * Best-effort: an in-memory test DB or a non-WAL handle makes this a harmless
+ * no-op/throw which we swallow — the mutation is already committed; this only
+ * advances the durability point of the main file.
+ */
+function checkpointGrantsWal(db: Database): void {
+  try {
+    db.run("PRAGMA wal_checkpoint(TRUNCATE)");
+  } catch {
+    // Non-fatal — see above.
+  }
+}
+
+/**
  * Match a key name against a list of patterns. Patterns are literal
  * key names, optionally with a trailing `*` for prefix-glob (e.g.
  * `OPENAI_*` matches `OPENAI_API_KEY` and `OPENAI_TIMEOUT`). No other
@@ -214,6 +241,7 @@ export async function mintGrant(
       description ?? null,
     ],
   );
+  checkpointGrantsWal(db);
 
   return { token, id, expires_at };
 }
@@ -361,6 +389,7 @@ export function revokeGrant(db: Database, id: string): boolean {
     `UPDATE vault_grants SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`,
     [now, id],
   );
+  checkpointGrantsWal(db);
   return (result.changes ?? 0) > 0;
 }
 

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -1115,31 +1115,39 @@ describe("generateCompose", () => {
     );
   });
 
-  it("broker bind-mounts the host vault-grants.db onto /root/.switchroom/vault-grants.db (#1737 wedge)", () => {
-    // fails when: the broker writes the capability-grants SQLite to a
-    // container-local path that evaporates on recreate. Token files on
-    // disk (~/.switchroom/agents/<agent>/.vault-token) persist via the
-    // per-agent bind mounts and reference grant IDs that no longer
-    // exist in the fresh broker DB — every `switchroom vault get` from
-    // inside an agent container returns
-    // `VAULT-BROKER-DENIED [DENIED]: key 'X' not in ACL for agent 'Y'`
-    // because the #1496 fall-through routes the unusable token to the
-    // standing schedule.secrets ACL, which usually denies (the whole
-    // reason a grant was minted in the first place).
+  it("broker bind-mounts the host vault-broker DIRECTORY onto /root/.switchroom/vault-broker (#1737 / #3289 WAL durability)", () => {
+    // fails when: the broker writes the capability-grants SQLite (and its
+    // WAL sidecars) to a container-local path that evaporates on recreate.
+    // Token files on disk (~/.switchroom/agents/<agent>/.vault-token) persist
+    // via the per-agent bind mounts and reference grant IDs that no longer
+    // exist in the fresh broker DB — every `switchroom vault get` from inside
+    // an agent container returns `VAULT-BROKER-DENIED [DENIED]: key 'X' not in
+    // ACL for agent 'Y'` because the #1496 fall-through routes the unusable
+    // token to the standing schedule.secrets ACL, which usually denies (the
+    // whole reason a grant was minted in the first place).
     //
-    // Surfaced 2026-05-24 when clerk's vg_5e1991 grant for
-    // `ha/access-token` disappeared after the v0.13.31 broker recreate.
-    // The doctor probe doesn't catch it — doctor only inspects path-
-    // as-identity ACL, not grant-based access.
+    // #3289: the mount is now the whole `vault-broker` DIRECTORY (not the bare
+    // `vault-grants.db` file) so the WAL `-wal`/`-shm` sidecars persist on the
+    // host fs alongside the main DB. Mounting only the single file left the
+    // sidecars in the container's ephemeral overlayfs, so committed grants sat
+    // in the container-local WAL until a rare checkpoint and were lost on
+    // recreate.
+    //
+    // Surfaced 2026-05-24 when clerk's vg_5e1991 grant for `ha/access-token`
+    // disappeared after the v0.13.31 broker recreate.
     //
     // Mount is RW (not :ro) because the broker writes new rows on every
-    // mint_grant call; `ensureHostMountSources()` in apply.ts pre-
-    // creates the source file mode 0600 (secrets material) so docker
-    // doesn't auto-create a directory at the mount path.
+    // mint_grant call; `ensureHostMountSources()` in apply.ts pre-creates the
+    // source DIRECTORY mode 0700 (secrets material) so docker doesn't
+    // auto-create a root-owned path at the mount source.
     const out = generateCompose({ config: makeConfig({ a: {} }) });
     const block = /vault-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
     expect(block).toMatch(
-      /-\s+\$\{HOME\}\/\.switchroom\/vault-grants\.db:\/root\/\.switchroom\/vault-grants\.db(?!:ro)/,
+      /-\s+\$\{HOME\}\/\.switchroom\/vault-broker:\/root\/\.switchroom\/vault-broker(?!:ro)/,
+    );
+    // And the OLD single-file mount must be gone (regression guard for #3289).
+    expect(block).not.toMatch(
+      /vault-grants\.db:\/root\/\.switchroom\/vault-grants\.db/,
     );
   });
 

--- a/tests/docker/phase2a-broker-ipc.test.ts
+++ b/tests/docker/phase2a-broker-ipc.test.ts
@@ -151,8 +151,8 @@ const AGENTS = ["alice", "bob", "carol"];
  */
 function readGrantsSchemaVersion(containerName: string): number | null {
   // The broker opens ~/.switchroom/vault-grants.db inside the container —
-  // that resolves to /root/.switchroom/vault-grants.db (USER 0:0).
-  const dbPath = "/root/.switchroom/vault-grants.db";
+  // that resolves to /root/.switchroom/vault-broker/vault-grants.db (USER 0:0).
+  const dbPath = "/root/.switchroom/vault-broker/vault-grants.db";
   try {
     const out = execSync(
       `docker exec ${containerName} bun -e ` +

--- a/tests/docker/phase2c-vault-integration.test.ts
+++ b/tests/docker/phase2c-vault-integration.test.ts
@@ -475,7 +475,7 @@ beforeAll(() => {
     brokerName,
     kernelName,
     agentNames,
-    initialBrokerSchemaVersion: readSchemaVersion(brokerName, "/root/.switchroom/vault-grants.db"),
+    initialBrokerSchemaVersion: readSchemaVersion(brokerName, "/root/.switchroom/vault-broker/vault-grants.db"),
     initialKernelSchemaVersion: readSchemaVersion(kernelName, "/state/approvals/kernel.db"),
     prodSnapshot,
   };
@@ -884,7 +884,7 @@ describe.skipIf(!imagesOk)(
         // Broker grants DB.
         const afterBroker = readSchemaVersion(
           fx.brokerName,
-          "/root/.switchroom/vault-grants.db",
+          "/root/.switchroom/vault-broker/vault-grants.db",
         );
         if (fx.initialBrokerSchemaVersion !== null && afterBroker !== null) {
           expect(afterBroker).toBe(fx.initialBrokerSchemaVersion);


### PR DESCRIPTION
Fixes #3289.

## Summary

The vault capability-grants SQLite DB survives a vault-broker container recreate. Previously it did not.

## Root cause

The grants DB `~/.switchroom/vault-grants.db` was bind-mounted into the broker **as a single file** (`src/agents/compose.ts`), but `src/vault/grants-db.ts` opens it in WAL mode (`PRAGMA journal_mode=WAL`). SQLite writes the `-wal`/`-shm` sidecars **beside the DB path inside the container's ephemeral overlayfs**, so a committed grant sat in the container-local WAL until a rare automatic checkpoint. Container recreation (e.g. `switchroom update`) discarded them — the v0.13.31 grant-wipe class: the on-disk `.vault-token` files persist but reference a grant id absent from the fresh broker DB, so every `switchroom vault get` returns `VAULT-BROKER-DENIED`.

Bonus hazard: host-side direct opens (doctor) create their own `-wal`/`-shm` on the host against the same main file — two writers with different shm/wal defeat SQLite locking.

## What changed

1. **Mount a directory, not a file.** The DB now lives at `~/.switchroom/vault-broker/vault-grants.db` and the broker bind-mounts the whole `vault-broker` directory (`compose.ts`), so the WAL sidecars persist on the host fs alongside the main DB. All readers/writers (broker, doctor, apply) resolve the path from one shared, `bun:sqlite`-free helper (`src/vault/grants-db-path.ts`) — no duplicated literals. An idempotent legacy-location migration runs on `switchroom apply` (`src/cli/apply.ts`) and on broker boot (`openGrantsDb`).

2. **Migration safety (review M1/L1).** The migration moves the `-wal`/`-shm` sidecars **first**, then the main file — a sidecar-move failure (EXDEV, perms) rolls back and aborts loudly with the legacy pair intact, retrying on the next apply/boot; the pair is never split (a stranded `-wal` = silently lost committed grants). The final main-file rename is guarded against a concurrent migrator (apply racing broker boot): losing the race returns `{migrated:false}` instead of aborting apply or wedging the boot loop; genuine failures still rethrow after sidecar rollback. Moving (rather than checkpoint-then-discard) keeps the migration `bun:sqlite`-free so vitest-run `apply` can call it; SQLite replays a matched `-wal` on next open.

3. **Defense-in-depth checkpoint.** Every mint/revoke runs `PRAGMA wal_checkpoint(TRUNCATE)` (`src/vault/grants.ts`) — grant write volume is trivial, so this is effectively free and keeps the main file current for host-side readers. **Chose checkpoint over `journal_mode=DELETE`**: the broker and the approval-kernel share this one DB handle and rely on WAL's concurrent-reader behaviour + `busy_timeout`; DELETE would change those shared semantics, an explicit checkpoint does not.

4. **Doctor probes** (`src/cli/doctor-vault-broker-durability.ts`): (a) WAL divergence inside the broker — warns only when the non-empty `-wal` newer than the main DB is also **stale** (default 300s settle window; review N1: `wal_checkpoint(TRUNCATE)` legitimately returns SQLITE_BUSY as a row under normal read contention, so a fresh divergence is healthy); (b) any agent `.vault-token` whose grant id has no matching DB row (the orphan-token symptom). The existing grants-mount probe now checks the directory inode.

5. **Upgrade window documented (review L2).** A still-running pre-fix broker holds the legacy DB open during apply's migration; a grant minted between migration and broker recreate lands in a fresh container-local legacy `-wal` the new broker never replays and may need re-minting. Inherent without stopping the broker first; noted in the migration doc comment and `apply.ts`. Apply runs the migration at the latest point it controls (mount-source prep immediately before the compose handoff — apply itself does not run `docker compose up`), and broker boot re-runs the idempotent migration as a second chance.

## Test plan

- `bun test src/vault/grants-db.test.ts src/vault/grants.test.ts` — 39 pass: grants survive a simulated container-recreate (reopen from the persisted dir only), migration moves legacy DB + sidecars correctly, sidecar-move failure aborts with the legacy pair intact and a plain retry succeeds (M1), concurrent-migrator race returns already-migrated while a genuine EACCES rethrows with sidecars rolled back (L1), checkpoint-after-mutation leaves the main file current (main-file-only copy still holds the grant), revoke is checkpointed too.
- `vitest run` for `doctor-vault-broker-durability.test.ts` (WAL-divergence probe incl. fresh-vs-stale settle window (N1) + orphan-token probes), `compose-generator.test.ts` (directory-mount assertion + old-mount regression guard), `apply.test.ts`, `doctor-approval-attribution.test.ts` — 269 pass, 1 skipped.
- `npm run lint` clean.
- Updated the two docker e2e suites (`phase2a`/`phase2c`) to the new in-container path.

## Risk

Low-to-moderate: changes a bind-mount shape and the on-disk DB location. Migration is idempotent, sidecar-first, rollback-on-failure, and race-guarded. An applied edit isn't live until the broker is recreated. Not merged, not rolled out.

## Job spec

`reference/jobs/` — on-the-leash / always-available: a broker recreate must not silently strip agents of their granted secret access.

## Review

Adversarial review round 1: MERGEABLE with 4 findings (M1 partial-sidecar-move data loss, L1 concurrent-migration TOCTOU, L2 upgrade-window note, N1 WAL-probe false-warn under read contention) — all four fixed in 033b7d6b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)