### PR TITLE
fix(errors): proxy-fallback 401 is an operator-only infra fault, not a user re-auth card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,16 @@
   `litellm-local`) instead of `auth`. Per Ken's deterministic error-surfacing
   policy, operator-actionable faults (credential / credit / proxy-misconfig) are
   now delivered to the OPERATOR chat ONLY; other allowlist users get, at most, a
-  brief diagnosis-free "couldn't complete — it's on our side" notice. The
+  brief diagnosis-free "couldn't complete — it's on our side" notice. The user
+  notice is gated on the TURN OUTCOME, not the error line: it is deferred to the
+  turn-end funnel and dropped when the turn still delivered a reply (a fallback
+  401 followed by a successful retry produces NO false failure notice), sent
+  only when the turn ends reply-less, and silently expired if no turn end
+  resolves it (bias to silence). The misconfig detection requires the definitive
+  "x-api-key header is required" marker or the fallback + x-api-key structural
+  pair — an ambiguous proxy envelope keeps the credentials diagnosis. The
   operator (allowlist head, including their own DM in a DM agent) always keeps
-  the full card. LiteLLM config itself is fixed separately on the host.
+  the full immediate card. LiteLLM config itself is fixed separately on the host.
 - **Telegram `/logs` works again** (#3283) — the gateway passed `--lines`
   to `switchroom agent logs`, which didn't accept the flag; it now exists
   (`-n, --lines <count>`). Behavior change for direct CLI users:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@
   do NOT become agent turns. A rate-limited diagnostic tap logs every
   received update's type + content keys (never payload bodies) so any drop at
   this layer is diagnosable from logs.
+- **LiteLLM proxy-fallback 401 no longer mis-fires a "re-authenticate" card at
+  end users** — LiteLLM's internal model-fallback chain re-dispatches a failed
+  primary WITHOUT forwarding the client's OAuth `Authorization` header; the
+  keyless (passthrough) fallback deployment therefore draws a 401
+  `authentication_error` "x-api-key header is required" from Anthropic. The
+  gateway classifier mapped ANY `authentication_error` → `credentials-invalid`
+  → an always-rendered "🔑 Claude login needs re-authentication" card that was
+  broadcast to EVERY allowlist chat — wrong audience (a non-operator user can't
+  re-auth) and wrong diagnosis (the login is fine; the proxy fallback config is
+  not). New `isLitellmProxyAuthMisconfig()` (mirroring the `isLitellmProxyLocal429`
+  precedent) detects the keyless-401 shape and both classifiers now route it to
+  an operator-only infra fault (`proxy-misconfig` / `infra_misconfig`, source
+  `litellm-local`) instead of `auth`. Per Ken's deterministic error-surfacing
+  policy, operator-actionable faults (credential / credit / proxy-misconfig) are
+  now delivered to the OPERATOR chat ONLY; other allowlist users get, at most, a
+  brief diagnosis-free "couldn't complete — it's on our side" notice. The
+  operator (allowlist head, including their own DM in a DM agent) always keeps
+  the full card. LiteLLM config itself is fixed separately on the host.
 - **Telegram `/logs` works again** (#3283) — the gateway passed `--lines`
   to `switchroom agent logs`, which didn't accept the flag; it now exists
   (`-n, --lines <count>`). Behavior change for direct CLI users:

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -333,6 +333,7 @@ import {
   type OperatorEvent,
   type OperatorEventKind,
 } from '../operator-events.js'
+import { pendingUserNoticeGate } from '../pending-user-notice.js'
 import { recordOperatorEvent } from '../operator-events-history.js'
 import {
   parseLlmError,
@@ -5357,6 +5358,13 @@ function endCurrentTurnAtomic(
   // wedging forever. No-op when this turn delivered, when nothing is
   // buffered, or when the serialize feature is off.
   armNoReplyDrainTimer(turn)
+  // #3293 finding 1 — resolve any deferred non-operator failure notice against
+  // this turn's outcome: replied → the turn recovered from the error line, the
+  // gate drops the notice; reply-less → the turn genuinely died, the notice is
+  // sent now. replyCalled covers the short-answer/#2624 shape where
+  // finalAnswerDelivered stays false despite an explicit reply. No-op when
+  // nothing is pending (the overwhelmingly common path).
+  flushPendingUserFailureNotices(turn.finalAnswerDelivered || turn.replyCalled)
   return turnEndedAt
 }
 
@@ -8615,22 +8623,58 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
       })
   }
 
-  // Non-operator users: only the plain-language failure notice, and ONLY for
-  // an operator-actionable fault that genuinely ends the turn (userNoticeChats
-  // is empty for every non-actionable kind — see decideOperatorEventAudience).
-  // No diagnosis, no re-auth instructions, no raw error text.
+  // Non-operator users: only the plain-language failure notice, and ONLY when
+  // the turn genuinely dies (userNoticeChats is empty for every non-actionable
+  // kind — see decideOperatorEventAudience). #3293 review finding 1: an error
+  // line is NOT proof of turn failure — the LiteLLM fallback can 401 while a
+  // retry / another deployment still serves the turn, and sending "couldn't
+  // complete that" for a turn that completed is a false failure report. So the
+  // notice is never sent here: it is SCHEDULED on the pendingUserNoticeGate and
+  // resolved at the turn-end funnel (endCurrentTurnAtomic) — dropped when the
+  // turn delivered a reply (recovered), sent when it ended reply-less (died).
+  // Un-resolved notices expire after PENDING_USER_NOTICE_TTL_MS (bias to
+  // silence over a false failure claim). Operator cards above stay immediate.
   if (userNoticeChats.length > 0) {
-    const userNoticeText = renderUserFacingFailureNotice()
-    for (const chat_id of userNoticeChats) {
-      const opEventThread = topicForRecipient({ recipientChatId: chat_id, resolvedTopic: opEventTopic, supergroupChatId: opEventSupergroup })
+    pendingUserNoticeGate.schedule({
+      chatIds: userNoticeChats,
+      text: renderUserFacingFailureNotice(),
+      agent,
+      kind,
+      atMs: Date.now(),
+    })
+    process.stderr.write(
+      `telegram gateway: operator-event user-notice deferred to turn-end agent=${agent} kind=${kind} chats=${userNoticeChats.length}\n`,
+    )
+  }
+}
+
+/**
+ * Turn-end resolution of deferred user failure notices (#3293 finding 1).
+ * Called from `endCurrentTurnAtomic` — the ONE funnel every turn-end path
+ * passes through. `turnDeliveredReply` is `finalAnswerDelivered || replyCalled`
+ * (the model explicitly replied → the turn recovered → notices are dropped by
+ * the gate). Only a reply-less turn end flushes the pending notices to the
+ * non-operator chats, so the user notice fires IFF the turn genuinely died.
+ */
+function flushPendingUserFailureNotices(turnDeliveredReply: boolean): void {
+  const notices = pendingUserNoticeGate.resolveTurnEnd(turnDeliveredReply)
+  if (notices.length === 0) return
+  const noticeTopic = resolveAgentOutboundTopic({ kind: 'compact-watchdog' })
+  const noticeSupergroup = resolveAgentSupergroupChatId()
+  for (const notice of notices) {
+    process.stderr.write(
+      `telegram gateway: user-notice flush (turn died reply-less) agent=${notice.agent} kind=${notice.kind} chats=${notice.chatIds.length}\n`,
+    )
+    for (const chat_id of notice.chatIds) {
+      const thread = topicForRecipient({ recipientChatId: chat_id, resolvedTopic: noticeTopic, supergroupChatId: noticeSupergroup })
       const opts = {
-        ...(opEventThread != null ? { message_thread_id: opEventThread } : {}),
+        ...(thread != null ? { message_thread_id: thread } : {}),
       }
-      // allow-raw-bot-api: operator-event user-notice loop; topic-aware opts
-      void bot.api.sendRichMessage(chat_id, richMessage(userNoticeText), opts as never)
+      // allow-raw-bot-api: deferred user-notice flush loop; topic-aware opts
+      void bot.api.sendRichMessage(chat_id, richMessage(notice.text), opts as never)
         .catch(e => {
           process.stderr.write(
-            `telegram gateway: operator-event user-notice send to ${chat_id} failed agent=${agent} kind=${kind}: ${e}\n`,
+            `telegram gateway: user-notice send to ${chat_id} failed agent=${notice.agent} kind=${notice.kind}: ${e}\n`,
           )
         })
     }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -328,6 +328,8 @@ import { autoClassifyMidTurnInbound } from './auto-classify-mid-turn.js'
 import {
   renderOperatorEvent,
   shouldEmitOperatorEvent,
+  decideOperatorEventAudience,
+  renderUserFacingFailureNotice,
   type OperatorEvent,
   type OperatorEventKind,
 } from '../operator-events.js'
@@ -8558,7 +8560,24 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     `telegram gateway: operator-event posting agent=${agent} kind=${kind} to ${access.allowFrom.length} chat(s)` +
       (opEventTopic != null ? ` topic=${opEventTopic}` : '') + '\n',
   )
-  for (const chat_id of access.allowFrom) {
+  // Ken's deterministic error-surfacing policy: an OPERATOR-ACTIONABLE fault
+  // (credentials / credit / proxy-misconfig) must not reach non-operator users
+  // as a raw or misleading card they can't act on. Split the audience — the
+  // operator (allowlist head) gets the full card; every other allowlist chat
+  // gets, at most, a brief plain-language "it's on our side" notice. Non-
+  // actionable kinds keep their existing broadcast (all chats are operatorChats).
+  const { operatorChats, userNoticeChats } = decideOperatorEventAudience(
+    kind,
+    access.allowFrom,
+    access.allowFrom[0],
+  )
+  if (userNoticeChats.length > 0) {
+    process.stderr.write(
+      `telegram gateway: operator-event operator-only routing agent=${agent} kind=${kind} operatorChats=${operatorChats.length} userNoticeChats=${userNoticeChats.length}\n`,
+    )
+  }
+
+  for (const chat_id of operatorChats) {
     // The resolved topic is valid ONLY in the agent's supergroup — attaching
     // it to an operator DM recipient yields 400 "message thread not found" and
     // the event silently fails to deliver (the marko #2096 class). Guard it:
@@ -8594,6 +8613,27 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
           `telegram gateway: operator-event send to ${chat_id} failed agent=${agent} kind=${kind}: ${e}\n`,
         )
       })
+  }
+
+  // Non-operator users: only the plain-language failure notice, and ONLY for
+  // an operator-actionable fault that genuinely ends the turn (userNoticeChats
+  // is empty for every non-actionable kind — see decideOperatorEventAudience).
+  // No diagnosis, no re-auth instructions, no raw error text.
+  if (userNoticeChats.length > 0) {
+    const userNoticeText = renderUserFacingFailureNotice()
+    for (const chat_id of userNoticeChats) {
+      const opEventThread = topicForRecipient({ recipientChatId: chat_id, resolvedTopic: opEventTopic, supergroupChatId: opEventSupergroup })
+      const opts = {
+        ...(opEventThread != null ? { message_thread_id: opEventThread } : {}),
+      }
+      // allow-raw-bot-api: operator-event user-notice loop; topic-aware opts
+      void bot.api.sendRichMessage(chat_id, richMessage(userNoticeText), opts as never)
+        .catch(e => {
+          process.stderr.write(
+            `telegram gateway: operator-event user-notice send to ${chat_id} failed agent=${agent} kind=${kind}: ${e}\n`,
+          )
+        })
+    }
   }
 }
 

--- a/telegram-plugin/llm-error-present.ts
+++ b/telegram-plugin/llm-error-present.ts
@@ -30,6 +30,7 @@
 import {
   detectModelUnavailable,
   isLitellmProxyLocal429,
+  isLitellmProxyAuthMisconfig,
   parseResetTime,
 } from './model-unavailable.js'
 import { classify429Detail } from './throttle-tier.js'
@@ -46,6 +47,7 @@ export type LlmErrorKind =
   | 'overload_529'
   | 'quota_wall'
   | 'auth'
+  | 'infra_misconfig'
   | 'transient'
   | 'unknown'
 
@@ -150,8 +152,22 @@ export function parseLlmError(
 function classifyKindAndSource(text: string): { kind: LlmErrorKind; source: LlmErrorSource } {
   const lower = text.toLowerCase()
 
+  // 0. LiteLLM-proxy AUTH misconfig — checked BEFORE the auth branch. The
+  //    proxy's internal fallback re-dispatched WITHOUT the OAuth header onto a
+  //    keyless deployment, so Anthropic 401'd it ("x-api-key header is
+  //    required"). This is an OPERATOR-only infra fault, NOT an end-user login
+  //    wall — never the user-facing 'auth' kind (which renders a re-auth card a
+  //    non-operator user cannot act on). Source is the local proxy, not
+  //    Anthropic. See isLitellmProxyAuthMisconfig for provenance.
+  if (isLitellmProxyAuthMisconfig(text)) {
+    return { kind: 'infra_misconfig', source: 'litellm-local' }
+  }
+
   // 1. Auth — always terminal, always actionable.
   const claudeKind = classifyClaudeError({ message: text, type: text })
+  if (claudeKind === 'proxy-misconfig') {
+    return { kind: 'infra_misconfig', source: 'litellm-local' }
+  }
   if (claudeKind === 'credentials-expired' || claudeKind === 'credentials-invalid') {
     return { kind: 'auth', source: 'anthropic' }
   }
@@ -212,6 +228,8 @@ function buildCoreText(kind: LlmErrorKind, source: LlmErrorSource): string {
       return 'Usage limit reached on this Claude subscription.'
     case 'auth':
       return 'Claude login needs re-authentication.'
+    case 'infra_misconfig':
+      return 'Local model-gateway auth misconfig (proxy fallback dropped the OAuth header).'
     case 'transient':
       return source === 'network'
         ? "Couldn't reach Anthropic (network) — retrying automatically."
@@ -280,6 +298,10 @@ function buildRecommendation(parsed: ParsedLlmError, tz: string): string | undef
   switch (parsed.kind) {
     case 'auth':
       return '→ Re-authenticate this account to continue.'
+    case 'infra_misconfig':
+      // Operator-facing — NO re-auth wording (the login is fine). Points at the
+      // real remedy: the local LiteLLM proxy fallback config.
+      return '→ Fix the LiteLLM proxy fallback config (deployment missing OAuth passthrough).'
     case 'quota_wall': {
       const reset = formatResetClock(parsed.resetAt, tz)
       return reset
@@ -353,6 +375,8 @@ function kindEmoji(kind: LlmErrorKind): string {
       return '⚠️'
     case 'auth':
       return '🔑'
+    case 'infra_misconfig':
+      return '🛠️'
     case 'transient':
       return '🌐'
     case 'unknown':

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -220,8 +220,18 @@ export function isLitellmProxyLocal429(text: string): boolean {
  * Detection (deterministic wording, mirrors `isLitellmProxyLocal429`):
  *   - the definitive "x-api-key header is required" marker (impossible for our
  *     OAuth flow — only the keyless-proxy path emits it), OR
- *   - an `authentication_error` CO-OCCURRING with LiteLLM-proxy / fallback
- *     provenance markers (the proxy wraps the upstream 401 as it re-dispatches).
+ *   - an `authentication_error` CO-OCCURRING with the proxy-FALLBACK-specific
+ *     structural pair: "fallback" re-dispatch provenance AND an explicit
+ *     "x-api-key" mention.
+ *
+ * PRECISION over recall (#3293 review finding 2): an earlier draft matched any
+ * `authentication_error` + (litellm|proxy) + (fallback|x-api-key|api_key) —
+ * broad enough that a GENUINE OAuth expiry wrapped in a proxy envelope that
+ * merely mentions "api_key" would misdiagnose as proxy-misconfig (still
+ * operator-visible, but the recommendation would point at the proxy config
+ * instead of a re-auth). Both classes route operator-only now, so an ambiguous
+ * envelope deliberately KEEPS the credentials-invalid/-expired diagnosis;
+ * only the unambiguous keyless-fallback signature classifies as misconfig.
  * Never throws on weird input.
  */
 export function isLitellmProxyAuthMisconfig(text: string): boolean {
@@ -230,16 +240,14 @@ export function isLitellmProxyAuthMisconfig(text: string): boolean {
   const lower = sample.toLowerCase()
   // Definitive marker — see provenance above.
   if (lower.includes('x-api-key header is required')) return true
-  // Structural co-occurrence: an authentication_error wrapped by the local
-  // proxy's fallback re-dispatch. Keyed tightly so a genuine Anthropic OAuth
-  // expiry (which never mentions the proxy or an x-api-key) is NOT down-classified.
+  // Structural signature: an authentication_error carrying BOTH the fallback
+  // re-dispatch provenance AND an explicit x-api-key mention. A proxy envelope
+  // that merely mentions litellm/proxy/api_key stays on the credentials
+  // diagnosis (ambiguous → not misconfig).
   const isAuthErr =
     lower.includes('authentication_error') || lower.includes('authenticationerror')
   if (!isAuthErr) return false
-  return (
-    (lower.includes('litellm') || lower.includes('proxy')) &&
-    (lower.includes('fallback') || lower.includes('x-api-key') || lower.includes('api_key'))
-  )
+  return lower.includes('fallback') && lower.includes('x-api-key')
 }
 
 /**

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -196,6 +196,53 @@ export function isLitellmProxyLocal429(text: string): boolean {
 }
 
 /**
+ * True when `text` is a LiteLLM-proxy-LOCAL AUTH misconfiguration — the
+ * proxy-fallback keyless-401 class, NOT a genuine end-user credential wall.
+ *
+ * PROVENANCE (incident, 2026-07-16). LiteLLM's internal model-fallback chain
+ * (`gpt-oss-20b -> [gpt-oss-20b-openrouter, claude-sonnet-5]`) re-dispatches a
+ * failed primary WITHOUT forwarding the client's OAuth `Authorization` header.
+ * The `claude-sonnet-5` deployment is deliberately keyless (passthrough auth —
+ * it expects the forwarded OAuth), so Anthropic rejects the header-less
+ * fallback with a 401 `authentication_error` whose message is
+ * "x-api-key header is required". Switchroom agents authenticate the unmodified
+ * `claude` CLI with an OAuth Bearer token and NEVER an `x-api-key`, so that
+ * demand can only originate from the proxy dropping the header on a keyless
+ * fallback deployment — a host-side infra misconfig for the OPERATOR to fix,
+ * never a login problem an end user (or even the operator's OAuth) can act on.
+ *
+ * Misclassifying it (as `classifyClaudeError` did → `credentials-invalid` →
+ * a "🔑 re-authenticate" card) is doubly wrong: wrong AUDIENCE (a non-operator
+ * user like Lisa cannot re-auth anything) and wrong DIAGNOSIS (the login is
+ * fine; the proxy fallback config is not). Detecting it here lets both
+ * classifiers route it to the operator-only infra surface instead.
+ *
+ * Detection (deterministic wording, mirrors `isLitellmProxyLocal429`):
+ *   - the definitive "x-api-key header is required" marker (impossible for our
+ *     OAuth flow — only the keyless-proxy path emits it), OR
+ *   - an `authentication_error` CO-OCCURRING with LiteLLM-proxy / fallback
+ *     provenance markers (the proxy wraps the upstream 401 as it re-dispatches).
+ * Never throws on weird input.
+ */
+export function isLitellmProxyAuthMisconfig(text: string): boolean {
+  if (typeof text !== 'string' || text.length === 0) return false
+  const sample = text.length > 16_384 ? text.slice(0, 16_384) : text
+  const lower = sample.toLowerCase()
+  // Definitive marker — see provenance above.
+  if (lower.includes('x-api-key header is required')) return true
+  // Structural co-occurrence: an authentication_error wrapped by the local
+  // proxy's fallback re-dispatch. Keyed tightly so a genuine Anthropic OAuth
+  // expiry (which never mentions the proxy or an x-api-key) is NOT down-classified.
+  const isAuthErr =
+    lower.includes('authentication_error') || lower.includes('authenticationerror')
+  if (!isAuthErr) return false
+  return (
+    (lower.includes('litellm') || lower.includes('proxy')) &&
+    (lower.includes('fallback') || lower.includes('x-api-key') || lower.includes('api_key'))
+  )
+}
+
+/**
  * Best-effort extraction of the limit detail LiteLLM embeds in its
  * proxy-local 429 bodies, for instrumentation (the `rate_limit_429_classified`
  * runtime metric). All fields null when nothing parseable is found — never

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -14,12 +14,14 @@
 
 import { escapeMarkdown } from './format.js'
 import { stripRawErrorBytes } from './raw-error-scrub.js'
+import { isLitellmProxyAuthMisconfig } from './model-unavailable.js'
 
 // ─── Taxonomy ────────────────────────────────────────────────────────────────
 
 export type OperatorEventKind =
   | 'credentials-expired'
   | 'credentials-invalid'
+  | 'proxy-misconfig'
   | 'credit-exhausted'
   | 'quota-exhausted'
   | 'rate-limited'
@@ -91,6 +93,20 @@ function classifyInner(raw: unknown): OperatorEventKind {
 
   // Anthropic SDK: error_code field (newer SDK shape)
   const sdkCode = extractString(obj, 'error_code') ?? ''
+
+  // LiteLLM-proxy AUTH misconfig — checked BEFORE the generic
+  // authentication_error branch. The proxy's internal fallback chain
+  // re-dispatches without the client's OAuth Authorization header onto a
+  // keyless deployment, so Anthropic returns a 401 authentication_error
+  // ("x-api-key header is required"). That is a HOST-side infra misconfig for
+  // the operator to fix — NOT an end-user login wall. Mapping it to
+  // credentials-invalid mis-fired a "🔑 re-authenticate" card at non-operator
+  // users who cannot re-auth anything (incident 2026-07-16). Route it to the
+  // operator-only infra kind instead. Scanned across type/code/message so the
+  // marker is caught wherever the proxy stamps it.
+  if (isLitellmProxyAuthMisconfig(`${errorType}\n${errorCode}\n${sdkCode}\n${message}`)) {
+    return 'proxy-misconfig'
+  }
 
   // Map known Anthropic error types/codes first.
   // Source: https://docs.anthropic.com/en/api/errors
@@ -259,6 +275,27 @@ export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
               { text: '🔐 Reauth now', callback_data: `op:reauth:${encodeURIComponent(ev.agent)}` },
               { text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` },
             ],
+          ],
+        },
+      }
+
+    // Operator-only infra fault. Deliberately NO "Reauth" button and NO
+    // login language: the OAuth credential is fine — the local LiteLLM proxy
+    // re-dispatched an internal fallback without forwarding the OAuth header
+    // onto a keyless deployment, so Anthropic 401'd it. The fix is in the
+    // proxy fallback config (host-side), not a re-auth. Dismiss-only.
+    case 'proxy-misconfig':
+      return {
+        text: [
+          `🛠️ **Model-gateway auth misconfig** for **${agent}**.`,
+          detail ? `_${detail}_` : '',
+          `The local LiteLLM proxy re-dispatched a fallback without forwarding the OAuth header (keyless deployment → Anthropic 401). Fix the proxy fallback config — this is NOT a login problem.`,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        keyboard: {
+          inline_keyboard: [
+            [{ text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
           ],
         },
       }
@@ -485,6 +522,82 @@ export function clearOperatorEventCooldown(agent: string, kind: OperatorEventKin
 /** Reset ALL cooldowns (for testing). */
 export function resetAllCooldowns(): void {
   cooldownMap.clear()
+}
+
+// ─── Audience routing (Ken's deterministic error-surfacing policy) ────────────
+
+/**
+ * Kinds that are OPERATOR-ACTIONABLE and NOT user-actionable: a credential /
+ * infra fault whose remedy (re-auth, switch account slot, fix the proxy
+ * fallback config) only the operator can perform. Per Ken's standing policy
+ * (2026-07): raw or misleading auth/infra errors must not reach non-operator
+ * end users — they cannot act on them and the diagnosis is often wrong for
+ * them (e.g. a proxy misconfig rendered as "your login expired"). These route
+ * to the operator surface ONLY; a non-operator user gets at most a brief
+ * plain-language "couldn't complete, it's on our side" notice.
+ *
+ * NOTE: `quota-exhausted` / `rate-limited` are deliberately EXCLUDED — they
+ * carry their own auto-fallback UX + card-collapse machinery and are handled
+ * upstream; this set is scoped to the credential/infra fault classes.
+ */
+export const OPERATOR_ACTIONABLE_KINDS: ReadonlySet<OperatorEventKind> = new Set<OperatorEventKind>([
+  'credentials-expired',
+  'credentials-invalid',
+  'credit-exhausted',
+  'proxy-misconfig',
+])
+
+export function isOperatorActionableKind(kind: OperatorEventKind): boolean {
+  return OPERATOR_ACTIONABLE_KINDS.has(kind)
+}
+
+export interface OperatorEventAudience {
+  /** Chats that receive the full operator card (with any action buttons). */
+  operatorChats: string[]
+  /** Non-operator chats that receive only the plain-language failure notice. */
+  userNoticeChats: string[]
+}
+
+/**
+ * Split an operator-event's allowlist audience per Ken's routing policy.
+ *
+ * - Non-operator-actionable kinds (transient rate-limit, 5xx, crash, config
+ *   warning, …) keep their existing broadcast: every allowlist chat is an
+ *   `operatorChat`. Behavior unchanged.
+ * - Operator-actionable kinds (see {@link OPERATOR_ACTIONABLE_KINDS}) go to the
+ *   OPERATOR chat only. `operatorChatId` is the operator (in switchroom the
+ *   allowlist HEAD — `allowFrom[0]`); it stays an `operatorChat` even in a DM
+ *   agent where the operator is their own user (so the operator NEVER has an
+ *   error hidden from their own DM). Every other allowlist chat becomes a
+ *   `userNoticeChat`.
+ *
+ * Pure — no IPC, no bot. `allowFrom` order is preserved.
+ */
+export function decideOperatorEventAudience(
+  kind: OperatorEventKind,
+  allowFrom: readonly string[],
+  operatorChatId: string | undefined,
+): OperatorEventAudience {
+  if (!isOperatorActionableKind(kind)) {
+    return { operatorChats: [...allowFrom], userNoticeChats: [] }
+  }
+  const operator =
+    operatorChatId != null && allowFrom.includes(operatorChatId)
+      ? operatorChatId
+      : allowFrom[0]
+  const operatorChats = operator != null ? [operator] : []
+  const userNoticeChats = allowFrom.filter((c) => c !== operator)
+  return { operatorChats, userNoticeChats }
+}
+
+/**
+ * The ONE brief, plain-language failure notice a non-operator user gets when a
+ * turn genuinely can't be served because of an operator-actionable fault.
+ * Deliberately carries NO diagnosis, NO agent internals, NO re-auth / config
+ * instructions, and NO raw error text — just an honest "it's on our side".
+ */
+export function renderUserFacingFailureNotice(): string {
+  return "⚠️ Sorry — I couldn't complete that just now. It's a problem on our side, not anything you did. Please try again shortly."
 }
 
 // ─── Markdown escape (#2669) ──────────────────────────────────────────────────

--- a/telegram-plugin/pending-user-notice.ts
+++ b/telegram-plugin/pending-user-notice.ts
@@ -1,0 +1,88 @@
+/**
+ * pending-user-notice.ts — deterministic turn-outcome gate for the
+ * non-operator user failure notice (#3293 review finding 1).
+ *
+ * THE PROBLEM this closes: `emitGatewayOperatorEvent` fires whenever
+ * session-tail sees an api_error line, with no knowledge of whether the turn
+ * ultimately RECOVERS (e.g. the LiteLLM fallback 401s but a retry / another
+ * deployment serves the turn). Sending the "couldn't complete that — it's on
+ * our side" notice at error time would tell users a turn failed that actually
+ * completed. The 5-min per-kind operator-event cooldown debounces retry SPAM
+ * but cannot know the turn's outcome.
+ *
+ * THE MECHANISM: the notice is never sent at error time. It is SCHEDULED here,
+ * and resolved at the gateway's single turn-end funnel (`endCurrentTurnAtomic`):
+ *   - turn ended WITH a delivered reply  → the turn recovered → DROP the notice
+ *   - turn ended WITHOUT a delivered reply → the turn genuinely died → SEND it
+ * Operator cards are NOT gated — they stay immediate (the operator must see
+ * the infra fault even when the turn recovers).
+ *
+ * CONSERVATIVE TTL: if no turn end resolves a scheduled notice within
+ * {@link PENDING_USER_NOTICE_TTL_MS} (error arrived between turns, or the turn
+ * record was lost), the notice is silently discarded — a missed notice costs a
+ * user some confusion; a FALSE "couldn't complete" on a served turn costs
+ * trust. Bias to silence.
+ *
+ * Pure module: no IPC, no bot, no FS. Injectable `now` throughout.
+ */
+
+export interface PendingUserNotice {
+  /** Non-operator allowlist chats that should receive the notice. */
+  chatIds: string[]
+  /** The plain-language notice text (renderUserFacingFailureNotice()). */
+  text: string
+  agent: string
+  /** The operator-event kind that produced it (log/debug context only). */
+  kind: string
+  /** When the notice was scheduled (ms epoch). */
+  atMs: number
+}
+
+/** How long a scheduled notice may wait for a resolving turn end. */
+export const PENDING_USER_NOTICE_TTL_MS = 10 * 60_000
+
+export class PendingUserNoticeGate {
+  private pending: PendingUserNotice[] = []
+
+  /**
+   * Schedule a notice for turn-end resolution. Collapses per agent — a burst
+   * of error lines within one turn holds ONE pending notice, not a stack.
+   */
+  schedule(notice: PendingUserNotice): void {
+    this.prune(notice.atMs)
+    this.pending = this.pending.filter((p) => p.agent !== notice.agent)
+    this.pending.push(notice)
+  }
+
+  /**
+   * Resolve at turn end. `turnDeliveredReply` is the turn's outcome signal
+   * (the gateway passes `finalAnswerDelivered || replyCalled`):
+   *   - true  → the turn recovered; every pending notice is dropped, [] returned.
+   *   - false → the turn died without a reply; the un-expired pending notices
+   *     are returned EXACTLY ONCE for the caller to send.
+   * Either way the ledger is cleared (a notice never survives its turn end).
+   */
+  resolveTurnEnd(turnDeliveredReply: boolean, now: number = Date.now()): PendingUserNotice[] {
+    this.prune(now)
+    const out = turnDeliveredReply ? [] : [...this.pending]
+    this.pending = []
+    return out
+  }
+
+  /** True when at least one un-expired notice is pending (does not mutate). */
+  hasPending(now: number = Date.now()): boolean {
+    return this.pending.some((p) => now - p.atMs < PENDING_USER_NOTICE_TTL_MS)
+  }
+
+  private prune(now: number): void {
+    this.pending = this.pending.filter((p) => now - p.atMs < PENDING_USER_NOTICE_TTL_MS)
+  }
+
+  /** Test-only: forget everything. */
+  reset(): void {
+    this.pending = []
+  }
+}
+
+/** The process-wide gate the gateway consults. */
+export const pendingUserNoticeGate = new PendingUserNoticeGate()

--- a/telegram-plugin/tests/litellm-proxy-auth-misconfig.test.ts
+++ b/telegram-plugin/tests/litellm-proxy-auth-misconfig.test.ts
@@ -34,6 +34,11 @@ import {
 } from '../operator-events.js'
 import { isLitellmProxyAuthMisconfig } from '../model-unavailable.js'
 import { parseLlmError, renderLlmError } from '../llm-error-present.js'
+import {
+  PendingUserNoticeGate,
+  PENDING_USER_NOTICE_TTL_MS,
+  type PendingUserNotice,
+} from '../pending-user-notice.js'
 
 // The verbatim shape Anthropic returns to the header-less proxy fallback.
 const PROXY_401_MESSAGE =
@@ -56,10 +61,10 @@ describe('isLitellmProxyAuthMisconfig', () => {
     expect(isLitellmProxyAuthMisconfig('x-api-key header is required')).toBe(true)
   })
 
-  it('detects an authentication_error co-occurring with proxy/fallback provenance', () => {
+  it('detects an authentication_error carrying the fallback + x-api-key structural pair', () => {
     expect(
       isLitellmProxyAuthMisconfig(
-        'litellm proxy fallback: authentication_error while routing to backup deployment',
+        'litellm fallback re-dispatch: authentication_error — upstream demanded x-api-key on backup deployment',
       ),
     ).toBe(true)
   })
@@ -71,6 +76,26 @@ describe('isLitellmProxyAuthMisconfig', () => {
       ),
     ).toBe(false)
     expect(isLitellmProxyAuthMisconfig('authentication_error: invalid bearer token')).toBe(false)
+  })
+
+  // #3293 review finding 2 — precision over recall: an AMBIGUOUS proxy
+  // envelope (mentions litellm/proxy/api_key but lacks the keyless-fallback
+  // signature) must KEEP the credentials diagnosis, not become misconfig.
+  it('does NOT claim a genuine expiry wrapped in a proxy envelope mentioning api_key', () => {
+    const wrappedExpiry =
+      'litellm.AuthenticationError: AnthropicException - authentication_error: OAuth token has expired (api_key slot proxy-default). Please refresh.'
+    expect(isLitellmProxyAuthMisconfig(wrappedExpiry)).toBe(false)
+    expect(
+      classifyClaudeError({ type: 'authentication_error', status: 401, message: wrappedExpiry }),
+    ).toBe('credentials-expired')
+  })
+
+  it('does NOT claim proxy+fallback wording without an explicit x-api-key signal', () => {
+    expect(
+      isLitellmProxyAuthMisconfig(
+        'litellm proxy fallback: authentication_error while routing to backup deployment',
+      ),
+    ).toBe(false)
   })
 
   it('never throws on junk input', () => {
@@ -184,6 +209,57 @@ describe('decideOperatorEventAudience — Ken routing policy', () => {
     expect(isOperatorActionableKind('credit-exhausted')).toBe(true)
     expect(isOperatorActionableKind('rate-limited')).toBe(false)
     expect(isOperatorActionableKind('quota-exhausted')).toBe(false)
+  })
+})
+
+// #3293 review finding 1 — the user notice is gated on the TURN OUTCOME, not
+// the error line: a turn that 401s on the proxy fallback but still delivers a
+// reply must produce NO user notice; only a reply-less turn end flushes it.
+describe('PendingUserNoticeGate — notice fires IFF the turn dies reply-less', () => {
+  function makeNotice(overrides?: Partial<PendingUserNotice>): PendingUserNotice {
+    return {
+      chatIds: ['5000000002', '5000000003'],
+      text: renderUserFacingFailureNotice(),
+      agent: 'gymbro',
+      kind: 'proxy-misconfig',
+      atMs: 1_000_000,
+      ...overrides,
+    }
+  }
+
+  it('DROPS the notice when the turn recovered (delivered a reply)', () => {
+    const gate = new PendingUserNoticeGate()
+    gate.schedule(makeNotice())
+    expect(gate.resolveTurnEnd(true, 1_001_000)).toEqual([])
+    // And it does not resurrect on a later failed turn end.
+    expect(gate.resolveTurnEnd(false, 1_002_000)).toEqual([])
+  })
+
+  it('SENDS the notice exactly once when the turn ends without a reply', () => {
+    const gate = new PendingUserNoticeGate()
+    const notice = makeNotice()
+    gate.schedule(notice)
+    const flushed = gate.resolveTurnEnd(false, 1_001_000)
+    expect(flushed).toHaveLength(1)
+    expect(flushed[0].chatIds).toEqual(['5000000002', '5000000003'])
+    // Exactly once — a second turn end flushes nothing.
+    expect(gate.resolveTurnEnd(false, 1_002_000)).toEqual([])
+  })
+
+  it('collapses an error burst within one turn to ONE pending notice per agent', () => {
+    const gate = new PendingUserNoticeGate()
+    gate.schedule(makeNotice({ atMs: 1_000_000 }))
+    gate.schedule(makeNotice({ atMs: 1_000_500 }))
+    gate.schedule(makeNotice({ atMs: 1_001_000 }))
+    expect(gate.resolveTurnEnd(false, 1_002_000)).toHaveLength(1)
+  })
+
+  it('expires an unresolved notice after the TTL (bias to silence over false failure)', () => {
+    const gate = new PendingUserNoticeGate()
+    gate.schedule(makeNotice({ atMs: 1_000_000 }))
+    const after = 1_000_000 + PENDING_USER_NOTICE_TTL_MS + 1
+    expect(gate.hasPending(after)).toBe(false)
+    expect(gate.resolveTurnEnd(false, after)).toEqual([])
   })
 })
 

--- a/telegram-plugin/tests/litellm-proxy-auth-misconfig.test.ts
+++ b/telegram-plugin/tests/litellm-proxy-auth-misconfig.test.ts
@@ -1,0 +1,202 @@
+/**
+ * litellm-proxy-auth-misconfig.test.ts — outcome-asserting tests for Ken's
+ * deterministic error-surfacing policy applied to the LiteLLM proxy-fallback
+ * 401 incident (2026-07-16).
+ *
+ * Root cause: LiteLLM's internal fallback chain re-dispatched WITHOUT the
+ * client's OAuth Authorization header onto a keyless `claude-sonnet-5`
+ * deployment, so Anthropic returned 401 authentication_error "x-api-key header
+ * is required". The gateway classifier mapped ANY authentication_error →
+ * credentials-invalid → an always-rendered "🔑 re-authenticate" card that was
+ * broadcast to EVERY allowlist chat — wrong audience (a non-operator user like
+ * Lisa cannot re-auth) and wrong diagnosis (the login is fine).
+ *
+ * These assert OUTCOMES:
+ *   1. the proxy 401 classifies as an operator-only infra fault, NEVER auth /
+ *      credentials-invalid, and NEVER renders a re-auth card;
+ *   2. a genuine credential expiry still classifies as credentials-expired and
+ *      still reaches the operator;
+ *   3. the audience router sends operator-actionable faults to the operator
+ *      ONLY, and hands non-operator users a diagnosis-free plain-language
+ *      notice — while the operator (allowlist head, incl. their own DM) always
+ *      keeps the full card.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  classifyClaudeError,
+  renderOperatorEvent,
+  decideOperatorEventAudience,
+  isOperatorActionableKind,
+  renderUserFacingFailureNotice,
+  type OperatorEvent,
+  type OperatorEventKind,
+} from '../operator-events.js'
+import { isLitellmProxyAuthMisconfig } from '../model-unavailable.js'
+import { parseLlmError, renderLlmError } from '../llm-error-present.js'
+
+// The verbatim shape Anthropic returns to the header-less proxy fallback.
+const PROXY_401_MESSAGE =
+  'litellm.AuthenticationError: AnthropicException - {"type":"error","error":{"type":"authentication_error","message":"x-api-key header is required"}} (fallback deployment claude-sonnet-5)'
+
+function makeEvent(kind: OperatorEventKind, overrides?: Partial<OperatorEvent>): OperatorEvent {
+  return {
+    kind,
+    agent: 'gymbro',
+    detail: '',
+    suggestedActions: [],
+    firstSeenAt: new Date('2026-07-16T20:00:00Z'),
+    ...overrides,
+  }
+}
+
+describe('isLitellmProxyAuthMisconfig', () => {
+  it('detects the definitive keyless-401 marker', () => {
+    expect(isLitellmProxyAuthMisconfig(PROXY_401_MESSAGE)).toBe(true)
+    expect(isLitellmProxyAuthMisconfig('x-api-key header is required')).toBe(true)
+  })
+
+  it('detects an authentication_error co-occurring with proxy/fallback provenance', () => {
+    expect(
+      isLitellmProxyAuthMisconfig(
+        'litellm proxy fallback: authentication_error while routing to backup deployment',
+      ),
+    ).toBe(true)
+  })
+
+  it('does NOT down-classify a genuine Anthropic OAuth expiry', () => {
+    expect(
+      isLitellmProxyAuthMisconfig(
+        'authentication_error: OAuth token has expired. Please run /login to refresh.',
+      ),
+    ).toBe(false)
+    expect(isLitellmProxyAuthMisconfig('authentication_error: invalid bearer token')).toBe(false)
+  })
+
+  it('never throws on junk input', () => {
+    expect(isLitellmProxyAuthMisconfig('')).toBe(false)
+    // @ts-expect-error — deliberate wrong type
+    expect(isLitellmProxyAuthMisconfig(null)).toBe(false)
+  })
+})
+
+describe('classifyClaudeError — proxy 401 vs genuine credential faults', () => {
+  it('classifies the proxy fallback 401 as proxy-misconfig, NOT credentials-invalid', () => {
+    const kind = classifyClaudeError({
+      type: 'authentication_error',
+      status: 401,
+      message: PROXY_401_MESSAGE,
+    })
+    expect(kind).toBe('proxy-misconfig')
+    expect(kind).not.toBe('credentials-invalid')
+    expect(kind).not.toBe('credentials-expired')
+  })
+
+  it('still classifies a genuine expired credential as credentials-expired', () => {
+    const kind = classifyClaudeError({
+      type: 'authentication_error',
+      message: 'authentication_error: your OAuth token has expired, please refresh',
+    })
+    expect(kind).toBe('credentials-expired')
+  })
+
+  it('still classifies a bare invalid credential as credentials-invalid', () => {
+    const kind = classifyClaudeError({
+      type: 'authentication_error',
+      message: 'authentication_error: credentials are not valid',
+    })
+    expect(kind).toBe('credentials-invalid')
+  })
+})
+
+describe('renderOperatorEvent — proxy-misconfig card', () => {
+  it('renders an operator infra card with NO re-auth button and NO login language', () => {
+    const { text, keyboard } = renderOperatorEvent(makeEvent('proxy-misconfig', { detail: 'x-api-key header is required' }))
+    // No re-auth instruction reaches the surface.
+    expect(text.toLowerCase()).not.toContain('re-authenticate')
+    expect(text.toLowerCase()).not.toContain('reauth')
+    expect(text).toContain('misconfig')
+    // Only a Dismiss button — never a Reauth callback.
+    const callbacks = keyboard.inline_keyboard.flat().map((b) => b.callback_data ?? '')
+    expect(callbacks.some((c) => c.startsWith('op:reauth:'))).toBe(false)
+  })
+})
+
+describe('parseLlmError — proxy 401 never becomes the user-facing auth kind', () => {
+  it('parses the proxy 401 as infra_misconfig (operator-only), source litellm-local', () => {
+    const parsed = parseLlmError(PROXY_401_MESSAGE)
+    expect(parsed.kind).toBe('infra_misconfig')
+    expect(parsed.kind).not.toBe('auth')
+    expect(parsed.source).toBe('litellm-local')
+  })
+
+  it('the rendered infra_misconfig line carries NO re-auth recommendation', () => {
+    const parsed = parseLlmError(PROXY_401_MESSAGE)
+    const { text } = renderLlmError(parsed, 'gymbro', 'UTC')
+    expect(text.toLowerCase()).not.toContain('re-authenticate this account')
+  })
+
+  it('a genuine OAuth expiry still parses as the actionable auth kind', () => {
+    const parsed = parseLlmError('authentication_error: OAuth token has expired, please refresh')
+    expect(parsed.kind).toBe('auth')
+  })
+})
+
+describe('decideOperatorEventAudience — Ken routing policy', () => {
+  const allow = ['5000000001' /* operator */, '5000000002' /* Lisa */, '5000000003']
+
+  it('routes the proxy misconfig to the operator ONLY; users get a plain notice', () => {
+    const { operatorChats, userNoticeChats } = decideOperatorEventAudience(
+      'proxy-misconfig',
+      allow,
+      allow[0],
+    )
+    expect(operatorChats).toEqual(['5000000001'])
+    expect(userNoticeChats).toEqual(['5000000002', '5000000003'])
+  })
+
+  it('routes credentials-invalid / -expired / credit-exhausted to the operator ONLY', () => {
+    for (const kind of ['credentials-invalid', 'credentials-expired', 'credit-exhausted'] as const) {
+      const a = decideOperatorEventAudience(kind, allow, allow[0])
+      expect(a.operatorChats).toEqual(['5000000001'])
+      expect(a.userNoticeChats).toEqual(['5000000002', '5000000003'])
+    }
+  })
+
+  it('preserves the operator DM: a lone-operator allowlist still gets the full card, no user notice', () => {
+    const a = decideOperatorEventAudience('proxy-misconfig', ['5000000001'], '5000000001')
+    expect(a.operatorChats).toEqual(['5000000001'])
+    expect(a.userNoticeChats).toEqual([])
+  })
+
+  it('leaves non-operator-actionable kinds broadcasting to every allowlist chat', () => {
+    for (const kind of ['rate-limited', 'unknown-5xx', 'agent-crashed', 'quota-exhausted'] as const) {
+      const a = decideOperatorEventAudience(kind, allow, allow[0])
+      expect(a.operatorChats).toEqual(allow)
+      expect(a.userNoticeChats).toEqual([])
+    }
+  })
+
+  it('isOperatorActionableKind gates exactly the credential/infra fault classes', () => {
+    expect(isOperatorActionableKind('proxy-misconfig')).toBe(true)
+    expect(isOperatorActionableKind('credentials-invalid')).toBe(true)
+    expect(isOperatorActionableKind('credentials-expired')).toBe(true)
+    expect(isOperatorActionableKind('credit-exhausted')).toBe(true)
+    expect(isOperatorActionableKind('rate-limited')).toBe(false)
+    expect(isOperatorActionableKind('quota-exhausted')).toBe(false)
+  })
+})
+
+describe('renderUserFacingFailureNotice', () => {
+  it('is a diagnosis-free, re-auth-free, byte-free plain-language notice', () => {
+    const notice = renderUserFacingFailureNotice()
+    const lower = notice.toLowerCase()
+    expect(lower).not.toContain('re-auth')
+    expect(lower).not.toContain('reauth')
+    expect(lower).not.toContain('x-api-key')
+    expect(lower).not.toContain('litellm')
+    expect(lower).not.toContain('authentication_error')
+    // Communicates "our side" honestly.
+    expect(lower).toContain('our side')
+  })
+})


### PR DESCRIPTION
## Root cause (verified this branch)

LiteLLM's internal model-fallback chain `gpt-oss-20b -> [gpt-oss-20b-openrouter, claude-sonnet-5]` re-dispatches a failed primary **without** forwarding the client's OAuth `Authorization` header. The `claude-sonnet-5` deployment is deliberately keyless (passthrough auth — it expects the forwarded OAuth), so Anthropic rejects the header-less fallback with a 401 `authentication_error` "**x-api-key header is required**" (14 hits in litellm logs, Jul 16 evening).

The gateway's classifier maps **any** `authentication_error` to `credentials-invalid`:
- `telegram-plugin/operator-events.ts:97-108` `classifyClaudeError` → `credentials-invalid`
- `telegram-plugin/session-tail.ts:910/937` feed that kind to the operator-event pipeline
- `telegram-plugin/gateway/gateway.ts` `emitGatewayOperatorEvent` rendered the `credentials-invalid` "🔑 re-authenticate" card and **broadcast it to every `access.allowFrom` chat**

Result: a non-operator user (e.g. Lisa) gets a re-auth card they cannot act on, diagnosing a login failure that never happened. Wrong audience **and** wrong diagnosis.

## Fix (Ken's deterministic error-surfacing policy)

1. **`isLitellmProxyAuthMisconfig()`** in `model-unavailable.ts` — mirrors the `isLitellmProxyLocal429` precedent (#3155/#3166). Requires the definitive "x-api-key header is required" marker, OR an `authentication_error` carrying the proxy-fallback structural pair (`fallback` + explicit `x-api-key`). **Precision over recall** (review finding 2): an ambiguous proxy envelope that merely mentions litellm/proxy/api_key keeps the `credentials-invalid`/`-expired` diagnosis — both classes are operator-only now, so the safer diagnosis wins.
2. **Reclassification** — `classifyClaudeError` (new `proxy-misconfig` kind) and `parseLlmError` (new `infra_misconfig` kind, source `litellm-local`) route the keyless-fallback 401 to an operator-only infra fault, **never** the user-facing `auth` kind. The `proxy-misconfig` operator card has no re-auth button and no login language — it points at the proxy fallback config.
3. **Audience routing** — `decideOperatorEventAudience` splits the allowlist: operator-actionable faults (`credentials-expired`/`credentials-invalid`/`credit-exhausted`/`proxy-misconfig`) go to the operator chat **only** (allowlist head); the operator (incl. their own DM in a DM agent) always keeps the full immediate card. Non-actionable kinds broadcast unchanged.
4. **Turn-outcome-gated user notice** (review finding 1) — the non-operator "couldn't complete — it's on our side" notice is never sent at error time. `emitGatewayOperatorEvent` schedules it on the new `PendingUserNoticeGate` (`telegram-plugin/pending-user-notice.ts`); `endCurrentTurnAtomic` — the single funnel every turn-end path passes through — resolves it against the turn outcome (`finalAnswerDelivered || replyCalled`): **turn recovered → notice dropped; reply-less turn end → notice sent exactly once**. Unresolved notices expire after 10 min (bias to silence over a false failure claim). Operator cards stay immediate.

`quota-exhausted`/`rate-limited` are deliberately excluded from the operator-only set — they carry their own auto-fallback/card-collapse machinery.

## Review finding resolution (563939eb)

- **Finding 1 (recovered-turn false notice)** — fixed via the deferred `PendingUserNoticeGate` + turn-end resolution above. Deterministic mechanism, not prompt discipline; per-agent burst collapse; exactly-once send; conservative TTL discard.
- **Finding 2 (detector precision)** — co-occurrence branch tightened to `fallback` + `x-api-key` (or the definitive marker). New tests pin: a genuine OAuth expiry wrapped in a proxy envelope mentioning `api_key` → `credentials-expired`, not misconfig; proxy+fallback wording without an `x-api-key` signal → not misconfig.

## Tests (outcome-asserting)

`telegram-plugin/tests/litellm-proxy-auth-misconfig.test.ts` (23 tests): proxy 401 never renders a re-auth card to a non-operator user; genuine credential expiry still reaches the operator (incl. ambiguous proxy-envelope case); router sends operator-actionable faults to the operator only; user notice is byte/diagnosis/re-auth-free AND fires iff the turn dies reply-less (drop-on-recovery, send-once-on-death, burst-collapse, TTL expiry); lone-operator DM keeps the full card.

Scoped `vitest` (202 tests across the 4 touched suites) + `tsc --noEmit` + all lint guards green locally. LiteLLM config itself is fixed separately on the host (not touched here). CI is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)