### PR TITLE
feat(m365): multi-account per agent (RFC #1873 extension)

### DIFF
--- a/reference/rfcs/microsoft-multi-account-per-agent.md
+++ b/reference/rfcs/microsoft-multi-account-per-agent.md
@@ -3,8 +3,8 @@
 Status: Design (read-only research, no implementation)
 Extends: RFC #1873 (`reference/rfcs/microsoft-workspace.md`)
 Driving requirement: one agent (Marko) must bind TWO Microsoft accounts at once —
-`lisa_goodfellow@hotmail.com` scoped to OneDrive storage tools, and
-`lisa@thinksolve.com.au` scoped to the 4 read-only mail tools.
+`alice@example.com` scoped to OneDrive storage tools, and
+`bob@example.com` scoped to the 4 read-only mail tools.
 
 ---
 
@@ -300,14 +300,14 @@ agents:
   marko:
     microsoft_workspace:
       accounts:
-        - account: lisa_goodfellow@hotmail.com
+        - account: alice@example.com
           tools: [drive, upload-file, create-upload-session, download-file, delete-file, list-drives]
-        - account: lisa@thinksolve.com.au
+        - account: bob@example.com
           tools: [list-mail-messages, get-mail-message, list-mail-folders, search-mail]  # 4 read-only
 microsoft_accounts:
-  lisa_goodfellow@hotmail.com:
+  alice@example.com:
     enabled_for: [marko]
-  lisa@thinksolve.com.au:
+  bob@example.com:
     enabled_for: [marko]
 ```
 (Exact softeria tool-name tokens are NEEDS-VERIFY against `@softeria/ms-365-mcp-server@0.113.0`.)

--- a/reference/rfcs/microsoft-multi-account-per-agent.md
+++ b/reference/rfcs/microsoft-multi-account-per-agent.md
@@ -1,0 +1,313 @@
+# RFC: Multiple Microsoft accounts per agent, each with its own tool scope
+
+Status: Design (read-only research, no implementation)
+Extends: RFC #1873 (`reference/rfcs/microsoft-workspace.md`)
+Driving requirement: one agent (Marko) must bind TWO Microsoft accounts at once —
+`lisa_goodfellow@hotmail.com` scoped to OneDrive storage tools, and
+`lisa@thinksolve.com.au` scoped to the 4 read-only mail tools.
+
+---
+
+## 0. Two premises in the task that the source CONTRADICTS
+
+Before the design, two corrections grounded in the real tree — the design is built on the
+corrected facts, not the task's stated premises.
+
+1. **There is no `ENABLED_TOOLS` / launcher tool-name regex today.** The task described
+   ENABLED_TOOLS as "the tool-name regex … applied over tool names" set by the launcher.
+   Grep for `ENABLED_TOOLS`/`enabledTools`/`--enabled-tools` across `src/` returns nothing
+   for M365. The launcher's *only* tool gate is `--org-mode`:
+   `buildSofteriaArgs` (`src/cli/m365-mcp-launcher.ts:125-130`) appends `--org-mode` and
+   nothing else; `getMs365McpSettingsEntry` (`src/memory/scaffold-integration.ts:251-263`)
+   emits `args: ["m365-mcp-launcher", ...orgArgs]`. So **per-account tool scoping does not
+   exist yet at all** — it must be *added* by this RFC, not merely extended.
+
+2. **Tool restriction today is a PreToolUse hook, not a launcher/OAuth gate.** M365 write
+   tools are gated at call time by `src/cli/ms-365-write-pretool.ts` (RFC #1873 §8): it keys
+   off the `mcp__ms-365__` tool-name prefix (`ms-365-write-pretool.ts:33`), passes verified
+   read-only tools (`KNOWN_SAFE_MS365_READ_TOOLS`) and fails-closed (approval card) on writes
+   and unrecognized `mcp__ms-365__*` tools. OAuth scopes are **fixed broad at consent**
+   (`selectMicrosoftScopes`, `src/microsoft/scopes.ts:35-37` → `SCOPE_SET_DEFAULT` includes
+   `Mail.ReadWrite` + `Files.ReadWrite.All`), confirming the task's suspicion: scope is NOT
+   per-account-narrowed — a token is broad and tools are meant to be restricted downstream.
+
+3. **Multi-account-per-agent is explicitly OUT OF SCOPE in RFC #1873** (`microsoft-workspace.md`
+   §12 lines 683-684, 717-724): "Multi-account-per-agent … separate RFC", with a note to first
+   read softeria's own multi-account issue ("may have rough edges in its multi-account model")
+   before designing switchroom's contract. This RFC is that separate RFC.
+
+The requirement's scope strings (`drive|upload-file|create-upload-session|download-file|…`
+and the 4 read-only mail verbs) are exactly a **softeria `--enabled-tools <regex>`
+alternation** (upstream softeria supports `--enabled-tools`/`MS365_MCP_ENABLED_TOOLS` +
+`--read-only`). NEEDS-VERIFY against the pinned `@softeria/ms-365-mcp-server@0.113.0`
+(`scaffold-integration.ts:121`) that `--enabled-tools` exists and is a regex over tool
+names — softeria is npx-fetched at runtime, not vendored, so I could not read its `--help`
+in this tree.
+
+---
+
+## 1. What exists today (single-account binding), with citations
+
+The single-account binding is a **twin-key** contract:
+
+- **Per-agent selector** — `agents.<name>.microsoft_workspace.account` (singular string).
+  Schema: `AgentMicrosoftWorkspaceConfigSchema` (`src/config/schema.ts:2250-2279`): an object
+  with `account` (email regex `^[^@\s:]+@[^@\s:]+\.[^@\s:]+$`, `.transform` → trim+lowercase,
+  `.optional()`) and `org_mode` (bool, optional). Mounted at `schema.ts:3250`.
+- **Top-level ACL** — `microsoft_accounts.<email>.enabled_for[]` (list of agent slugs).
+  Schema: `schema.ts:4156-4181`, email-keyed record, each entry `{ enabled_for: string[] }`.
+- **The "both are required" check** — the broker requires BOTH: agent's
+  `microsoft_workspace.account` is set AND that account's `enabled_for[]` includes the agent.
+  - Predicate: `shouldEmitMs365Mcp` (`src/config/microsoft-workspace-acl.ts:28-42`) — used by
+    scaffold to decide whether to emit the `ms-365` MCP entry and by broker ACL for the vault
+    client-cred grant (`isMicrosoftClientCredentialKeyForAgent`, same file:67-96).
+  - Broker enforcement: `opMicrosoftGetCredentials` (`src/auth/broker/server.ts:3265-3327`):
+    reads `agent.microsoft_workspace.account` (:3284); `ACCOUNT_NOT_FOUND` if unset (:3285-3294);
+    `FORBIDDEN` if not in `enabled_for[]` (:3300-3309); else reads
+    `readMicrosoftAccountCredentials(stateDir, account)` (:3312) →
+    `state/auth-broker/microsoft/<account>/credentials.json`.
+  - **Crucially, `get-credentials` carries NO account arg.** `GetCredentialsRequestSchema`
+    (`src/auth/broker/protocol.ts:74-91`) has only `{v, op, id, provider?}`; the account is
+    *derived server-side from config*. `client.getCredentials(provider?)`
+    (`src/auth/broker/client.ts:521`) has no account param. The launcher calls
+    `client.getCredentials("microsoft")` (`m365-mcp-launcher.ts:535`).
+- **Launcher = one MCP process = one account, today.** `resolveMs365McpEntry`
+  (`src/agents/scaffold.ts:3485-3518`) emits exactly one MCP entry keyed `ms-365`
+  (`scaffold-integration.ts:257`), whose tools Claude Code namespaces as `mcp__ms-365__*`.
+  The launcher spawns one softeria child in BYOT mode and refreshes it in-process
+  (`runMs365McpLauncher`, `m365-mcp-launcher.ts:284-512`).
+- **YAML editors** for the twin keys: `setAgentWorkspaceAccount`/`clearAgentWorkspaceAccount`
+  (`src/config/agent-workspace-account.ts:34-95`, singular path
+  `["agents",agent,"microsoft_workspace","account"]`) and
+  `enable/disableAgentsOnMicrosoftAccount` (`src/cli/microsoft-accounts-yaml.ts`).
+- **Token/scope**: `selectMicrosoftScopes(orgMode)` (`scopes.ts:35`); `microsoft_client_id`/
+  `_secret` are top-level only, not per-agent (`schema.ts:2071-2117`, comment at :2247-2248).
+  OAuth scopes are chosen at *consent* (`auth microsoft account add`), broad, not narrowed
+  per tool.
+
+---
+
+## 2. Design — additive, backward-compatible
+
+### 2.1 Config schema (zod)
+
+Add a `tools` field and an `accounts[]` array form to
+`AgentMicrosoftWorkspaceConfigSchema`, keeping the singular `account` valid.
+
+```ts
+const MicrosoftAccountBindingSchema = z.object({
+  account: z.string().regex(EMAIL_RE).transform(v => v.trim().toLowerCase()),
+  tools: z.array(z.string().min(1)).min(1).optional()   // softeria tool-name / regex tokens
+    .describe("Per-account tool allowlist → softeria --enabled-tools. Omitted = all tools."),
+  org_mode: z.boolean().optional(),
+});
+
+AgentMicrosoftWorkspaceConfigSchema = z.object({
+  account:  z.string()...optional(),            // EXISTING singular — unchanged
+  tools:    z.array(z.string().min(1)).min(1).optional(),  // NEW: scope for the singular form
+  org_mode: z.boolean().optional(),             // EXISTING
+  accounts: z.array(MicrosoftAccountBindingSchema).min(1).optional(),  // NEW plural
+}).superRefine((v, ctx) => {
+  const hasSingular = v.account !== undefined;
+  const hasPlural   = v.accounts !== undefined;
+  if (hasSingular && hasPlural)
+    ctx.addIssue({ code: "custom", message:
+      "microsoft_workspace: use EITHER `account` (singular) OR `accounts` (plural array), not both" });
+  if (hasPlural) {
+    const seen = new Set<string>();
+    for (const b of v.accounts!) {
+      if (seen.has(b.account))
+        ctx.addIssue({ code:"custom", message:`duplicate account '${b.account}' in accounts[]` });
+      seen.add(b.account);
+    }
+  }
+  // (`tools`/`org_mode` at the block level apply to the singular form only; on the plural
+  //  form they live per-binding. A block-level `tools` WITH `accounts` → error, to avoid
+  //  ambiguous "which account does this scope?".)
+}).optional();
+```
+
+**Coexistence / migration rule (the one-liner):** singular `account` XOR plural `accounts`;
+both present → schema error. Singular `account` is interpreted as a one-element
+`accounts` list `[{ account, tools?, org_mode? }]` by a `normalizeMicrosoftBindings(agentCfg)`
+helper that every consumer (broker, scaffold, launcher, ACL predicate) calls — so there is
+exactly one code path and the singular form can never drift from the plural one. No config
+rewrite/migration is forced; existing `account:` configs keep working byte-for-byte.
+
+### 2.2 Launcher approach — N processes, one per account (RECOMMENDED)
+
+**Recommendation: N MCP instances (one launcher process + one softeria child per bound
+account), NOT one MCP multiplexing N accounts.** Evidence:
+
+- **softeria identifies its account by the single injected `MS365_MCP_OAUTH_TOKEN`** (BYOT,
+  `SOFTERIA_TOKEN_ENV`, `m365-mcp-launcher.ts:47`, `buildSofteriaEnv:137-144`). It has no
+  concept of "call tool X as account A vs B" — one process = one token = one account. A
+  multiplexer would have to fork softeria per account internally anyway, i.e. N processes with
+  extra plumbing.
+- **Tool-name collision under multiplexing.** All of softeria's tools carry the same names
+  (`download-file`, `list-mail-messages`, …). Claude Code namespaces per MCP-server key, so
+  two accounts under one `ms-365` server would present two `mcp__ms-365__download-file` tools —
+  the agent cannot address the right account. Distinct server keys are the natural namespace.
+- **Per-account tool scope is a per-process softeria flag** (`--enabled-tools`/`--read-only`);
+  N processes let each child get its own scope with zero cross-talk.
+- **Blast radius**: one crash-looping account (the launcher's `#2586` backoff,
+  `m365-mcp-launcher.ts:340-391`) doesn't take down the other account's tools.
+
+**Naming / namespacing (N processes):** emit one MCP entry per binding, keyed
+`ms-365-<slug>` where `<slug>` is a deterministic short label derived from the account
+(local-part + hash suffix, sanitized to `[a-z0-9-]`), e.g. `ms-365-lisa-goodfellow`,
+`ms-365-lisa-thinksolve`. Tools then namespace as `mcp__ms-365-lisa-goodfellow__download-file`
+etc., which the agent addresses unambiguously. **Backward-compat pin:** a single-account agent
+(singular `account`, or a one-element `accounts`) keeps the bare `ms-365` key so existing
+`.mcp.json`, the pretool hook prefix, and habits don't break. Only 2+ bindings introduce the
+`ms-365-<slug>` keys.
+
+`resolveMs365McpEntry` becomes `resolveMs365McpEntries` (plural) returning
+`{key,value}[]`; each entry's launcher args gain `--account <email>` and
+`--enabled-tools <joined>` (and `--org-mode` per-binding). The
+`IntegrationMcpResolver` registry (`scaffold.ts:3595+`) — which currently assumes one
+key per integration — must accept a resolver that returns N keys and a set of retraction
+keys; the reconcile sites that `delete` stale keys must delete all `ms-365*` keys not in the
+current emit set.
+
+### 2.3 Broker change — account-parameterized get-credentials
+
+`get-credentials` must learn *which* account the caller wants:
+
+- Add optional `account?: string` to `GetCredentialsRequestSchema`
+  (`protocol.ts:74-91`) and `client.getCredentials(provider?, account?)` (`client.ts:521`).
+- `opMicrosoftGetCredentials` (`server.ts:3265`): if `req.account` is present, validate it is
+  one of the agent's bound accounts (`normalizeMicrosoftBindings(agent).some(b => b.account===req.account)`)
+  AND `microsoft_accounts[req.account].enabled_for[]` includes the agent (the existing
+  `enabled_for` gate, :3300, now per requested account); then read that account's
+  credentials.json. If `req.account` absent → current single-account behavior (back-compat).
+  Both a missing binding and an ACL miss keep their existing error codes
+  (`ACCOUNT_NOT_FOUND` / `FORBIDDEN`) so nothing silently downgrades.
+- The launcher passes its `--account` value into `getCredentials("microsoft", account)`.
+
+### 2.4 Two-part-binding validation, array form
+
+Add cross-field validation (alongside `shouldEmitMs365Mcp`): for the plural form, **every**
+`accounts[].account` must have `microsoft_accounts.<account>.enabled_for[]` containing the
+agent — else a load-time config error naming the offending `(agent, account)` pair (mirror the
+broker's FORBIDDEN message so operators get the same `switchroom auth microsoft enable …`
+hint). `shouldEmitMs365Mcp` gains a plural sibling `bindingsForAgent(agentName, agentCfg,
+microsoftAccounts)` returning the subset of bindings that pass the twin-key gate; scaffold
+emits one MCP entry per passing binding (and none for a binding whose ACL is missing — same
+"emit iff enabled" semantics as today, per-account).
+
+### 2.5 ENABLED_TOOLS (per account)
+
+Thread each binding's `tools[]` into the launcher as `--enabled-tools <regex>` (joined with
+`|`) and/or `--read-only` when the token set is exactly softeria's read-only subset. Because
+the OAuth token is broad (scopes fixed at consent), tool scope is enforced at the softeria
+process, **and** the existing PreToolUse write-gate (`ms-365-write-pretool.ts`) still runs.
+Update that hook's prefix match from the literal `mcp__ms-365__` to `mcp__ms-365(-[a-z0-9-]+)?__`
+so it continues to gate writes on the per-account server keys (otherwise multi-account write
+tools would sail through un-gated — a fail-open regression).
+
+### 2.6 Apply / reconcile / restart implications
+
+- Config schema + broker + scaffold changes ship in the switchroom build. Editing an agent's
+  `microsoft_workspace.accounts` is a `switchroom.yaml` edit → needs
+  `switchroom apply`/reconcile to rewrite the agent's `.mcp.json`/`settings.json` (new
+  `ms-365-<slug>` MCP entries) and then an **agent container restart** to pick up the new MCP
+  server set (same as any MCP-entry change today). The broker re-reads config on its own
+  boot/reload; the `get-credentials` account param is runtime, no restart needed on the broker
+  beyond loading the new build.
+- Backward-compat: agents on singular `account` get byte-identical output (bare `ms-365` key,
+  no `--account`, `get-credentials` with no account param).
+
+---
+
+## 3. Test plan (assert OUTCOMES)
+
+Existing coverage of the singular path to keep green:
+`src/config/microsoft-workspace-acl.test.ts` (`shouldEmitMs365Mcp` 9 cases,
+`isMicrosoftClientCredentialKeyForAgent`); `src/cli/m365-mcp-launcher.test.ts`
+(`buildSofteriaArgs` org-mode on/off, `buildSofteriaEnv`, refresh timing, `runMs365McpLauncher`
+spawns one child); `src/config/agent-workspace-account.test.ts`;
+`src/cli/microsoft-accounts-yaml.test.ts`; broker `server-microsoft.test.ts`.
+
+New tests:
+1. **Schema accept/reject** — accept singular `account`; accept plural `accounts:[{account,tools},…]`;
+   reject BOTH present; reject duplicate account in `accounts[]`; reject block-level `tools`
+   together with `accounts`; reject empty `accounts:[]` and empty `tools:[]`. Assert the specific
+   `superRefine` messages.
+2. **normalizeMicrosoftBindings** — singular → one-element list identical to explicit
+   one-element plural (the drift guard).
+3. **Scaffold emits N entries** — 2 bound+enabled accounts → two MCP keys `ms-365-<slugA>`,
+   `ms-365-<slugB>` with distinct `--account`/`--enabled-tools`; 1 account → bare `ms-365`
+   key (back-compat). A binding whose account lacks the agent in `enabled_for[]` → NOT emitted.
+4. **Per-account tool scoping** — `buildSofteriaArgs` includes `--enabled-tools <joined>` for a
+   binding with `tools`, omits it when `tools` absent; storage binding gets the OneDrive verbs,
+   mail binding gets the 4 read verbs (assert exact arg array).
+5. **Launcher spawns per account with the right token** — `runMs365McpLauncher` with
+   `--account X` calls `getCredentials("microsoft", "X")` and injects THAT account's token
+   (assert the account threaded into the broker stub, and the env token).
+6. **Broker mismatch validation** — `get-credentials` with `account` not in the agent's
+   bindings → `ACCOUNT_NOT_FOUND`; account bound but agent not in `enabled_for[]` → `FORBIDDEN`;
+   valid pair → returns that account's creds (assert the returned `account` field).
+7. **Two-part array validation** — load config where one of two `accounts[]` is missing from
+   `enabled_for[]` → load-time error naming that pair.
+8. **PreToolUse prefix** — `mcp__ms-365-lisa-goodfellow__delete-file` is still gated
+   (fail-closed) by the updated prefix regex; a read tool passes.
+
+---
+
+## 4. Red-team of this design
+
+- **Same account listed twice in `accounts[]`** → collides on slug/server-key and doubles
+  softeria processes. Handled: `superRefine` duplicate-account reject (test 1).
+- **Account in `accounts[]` but not in `enabled_for[]`** → an emitted MCP entry whose broker
+  fetch would `FORBIDDEN`, giving the agent a dead tool namespace. Handled: scaffold emits
+  per-binding **iff** the twin-key gate passes (§2.4), so a non-enabled binding produces no MCP
+  entry; plus a load-time validation error (test 7) so the operator sees the misconfig loudly
+  rather than a silent missing tool.
+- **Token missing for one of N** (`credentials.json` absent for one account) → that launcher's
+  initial `fetchCreds` fails and it exits 1 (`m365-mcp-launcher.ts:479-483`); Claude Code shows
+  that one `ms-365-<slug>` server as failed while the other account's tools keep working. The N-process
+  design contains the failure; a multiplexer would have risked taking both down. Doctor/heartbeat
+  must become per-account: `heartbeatPath` (`m365-mcp-launcher.ts:195-201`) is currently a single
+  fixed path `/state/agent/m365-launcher.heartbeat.json` — with N launchers they'd clobber each
+  other; make it `m365-launcher-<slug>.heartbeat.json` and teach the PR-5 doctor probe to read all.
+  **This is a concrete must-fix, not optional.**
+- **One softeria crashes** → per-process `#2586` crash-loop backoff already isolates it
+  (`m365-mcp-launcher.ts:340-391`); the other account is unaffected (N-process win).
+- **Slug collision** (two different emails mapping to the same sanitized slug, e.g.
+  `lisa@a.com` vs `lisa@b.com` both → `ms-365-lisa`) → append a short stable hash of the full
+  email to the slug; assert uniqueness across an agent's bindings at scaffold time (fail loud).
+- **Broad OAuth scope vs narrow tool scope** — `tools` restricts the *tool surface*, but the
+  token still carries `Mail.ReadWrite`/`Files.ReadWrite.All`. A read-only mail binding is
+  read-only only because softeria isn't given the write tools + the PreToolUse gate blocks
+  writes — NOT because the token can't write. Acceptable for v1 (matches today's model) but
+  document it: true least-privilege at the token level needs per-account scope-at-consent,
+  which is a larger change (re-consent flow) and explicitly deferred.
+- **PreToolUse fail-open regression** — the biggest correctness risk: if the hook's prefix
+  isn't widened to the `ms-365-<slug>` keys, every multi-account write tool bypasses the
+  approval card. Covered by §2.5 + test 8; call it out as a merge-blocker.
+- **Registry single-key assumption** — `IntegrationMcpResolver` and the 4 mcpServers-assembly
+  sites (`scaffold.ts` comment :3567-3593) assume one key per integration; the plural resolver
+  and multi-key retraction must be handled at every site or stale `ms-365-<slug>` entries leak
+  across reconciles when bindings shrink.
+
+---
+
+## 5. Concrete config for the driving requirement
+
+```yaml
+agents:
+  marko:
+    microsoft_workspace:
+      accounts:
+        - account: lisa_goodfellow@hotmail.com
+          tools: [drive, upload-file, create-upload-session, download-file, delete-file, list-drives]
+        - account: lisa@thinksolve.com.au
+          tools: [list-mail-messages, get-mail-message, list-mail-folders, search-mail]  # 4 read-only
+microsoft_accounts:
+  lisa_goodfellow@hotmail.com:
+    enabled_for: [marko]
+  lisa@thinksolve.com.au:
+    enabled_for: [marko]
+```
+(Exact softeria tool-name tokens are NEEDS-VERIFY against `@softeria/ms-365-mcp-server@0.113.0`.)

--- a/src/agents/scaffold-ms365-multi.test.ts
+++ b/src/agents/scaffold-ms365-multi.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Scaffold emission for multi-account Microsoft 365 bindings.
+ *
+ * `resolveMs365McpEntries` is the plural resolver both the scaffold and
+ * reconcile mcpServers-assembly paths call. Pins:
+ *   - 1 bound+enabled account → bare `ms-365` key (back-compat, no --account);
+ *   - 2 bound+enabled accounts → two `ms-365-<slug>` keys with distinct
+ *     --account and --enabled-tools;
+ *   - a binding whose account lacks the agent in enabled_for[] → NOT emitted;
+ *   - ms365OwnedKeys returns every retractable key for stale-key cleanup.
+ * See reference/rfcs/microsoft-multi-account-per-agent.md §2.2, §3.3–3.4.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DOCKER_SWITCHROOM_CLI_PATH,
+  resolveMs365McpEntries,
+  resolveMs365McpEntry,
+  ms365OwnedKeys,
+} from "./scaffold.js";
+import { microsoftAccountSlug } from "../config/microsoft-workspace-acl.js";
+import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
+
+function cfg(
+  microsoft_accounts: Record<string, { enabled_for?: string[] }>,
+): SwitchroomConfig {
+  return { microsoft_accounts } as unknown as SwitchroomConfig;
+}
+
+function agent(partial: Partial<AgentConfig>): AgentConfig {
+  return partial as unknown as AgentConfig;
+}
+
+const STORAGE = "alice@example.com";
+const MAIL = "bob@example.com";
+
+describe("resolveMs365McpEntries — single-account back-compat", () => {
+  it("emits the bare `ms-365` key with NO --account for a single binding", () => {
+    const entries = resolveMs365McpEntries(
+      "marko",
+      agent({ microsoft_workspace: { account: MAIL } }),
+      cfg({ [MAIL]: { enabled_for: ["marko"] } }),
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].key).toBe("ms-365");
+    expect(entries[0].value.command).toBe(DOCKER_SWITCHROOM_CLI_PATH);
+    expect(entries[0].value.args?.[0]).toBe("m365-mcp-launcher");
+    expect(entries[0].value.args).not.toContain("--account");
+    // singular shim agrees with the first plural entry
+    expect(resolveMs365McpEntry("marko", agent({ microsoft_workspace: { account: MAIL } }), cfg({ [MAIL]: { enabled_for: ["marko"] } }))?.key).toBe("ms-365");
+  });
+
+  it("threads block-level tools → --enabled-tools even in the singular form", () => {
+    const entries = resolveMs365McpEntries(
+      "marko",
+      agent({ microsoft_workspace: { account: MAIL, tools: ["list-mail-messages", "get-mail-message"] } }),
+      cfg({ [MAIL]: { enabled_for: ["marko"] } }),
+    );
+    const args = entries[0].value.args ?? [];
+    const i = args.indexOf("--enabled-tools");
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i + 1]).toBe("list-mail-messages|get-mail-message");
+  });
+});
+
+describe("resolveMs365McpEntries — multi-account", () => {
+  const config = cfg({
+    [STORAGE]: { enabled_for: ["marko"] },
+    [MAIL]: { enabled_for: ["marko"] },
+  });
+  const agentCfg = agent({
+    microsoft_workspace: {
+      accounts: [
+        { account: STORAGE, tools: ["drive", "upload-file", "download-file"] },
+        { account: MAIL, tools: ["list-mail-messages", "get-mail-message", "list-mail-folders", "search-mail"] },
+      ],
+    },
+  });
+
+  it("emits two entries with distinct ms-365-<slug> keys", () => {
+    const entries = resolveMs365McpEntries("marko", agentCfg, config);
+    expect(entries).toHaveLength(2);
+    const keys = entries.map((e) => e.key).sort();
+    expect(keys).toEqual([
+      `ms-365-${microsoftAccountSlug(STORAGE)}`,
+      `ms-365-${microsoftAccountSlug(MAIL)}`,
+    ].sort());
+  });
+
+  it("threads the right --account and --enabled-tools per entry", () => {
+    const entries = resolveMs365McpEntries("marko", agentCfg, config);
+    const byKey = Object.fromEntries(entries.map((e) => [e.key, e.value.args ?? []]));
+
+    const storageArgs = byKey[`ms-365-${microsoftAccountSlug(STORAGE)}`];
+    expect(storageArgs[storageArgs.indexOf("--account") + 1]).toBe(STORAGE);
+    expect(storageArgs[storageArgs.indexOf("--enabled-tools") + 1]).toBe("drive|upload-file|download-file");
+
+    const mailArgs = byKey[`ms-365-${microsoftAccountSlug(MAIL)}`];
+    expect(mailArgs[mailArgs.indexOf("--account") + 1]).toBe(MAIL);
+    expect(mailArgs[mailArgs.indexOf("--enabled-tools") + 1]).toBe(
+      "list-mail-messages|get-mail-message|list-mail-folders|search-mail",
+    );
+  });
+
+  it("does NOT emit a binding whose account lacks the agent in enabled_for[]", () => {
+    const partial = cfg({
+      [STORAGE]: { enabled_for: ["marko"] },
+      [MAIL]: { enabled_for: ["someone-else"] }, // marko not enabled here
+    });
+    const entries = resolveMs365McpEntries("marko", agentCfg, partial);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].key).toBe(`ms-365-${microsoftAccountSlug(STORAGE)}`);
+  });
+
+  it("ms365OwnedKeys returns bare + all per-slug keys for retraction", () => {
+    const owned = ms365OwnedKeys(agentCfg);
+    expect(owned.has("ms-365")).toBe(true);
+    expect(owned.has(`ms-365-${microsoftAccountSlug(STORAGE)}`)).toBe(true);
+    expect(owned.has(`ms-365-${microsoftAccountSlug(MAIL)}`)).toBe(true);
+  });
+
+  it("hard opt-out (mcp_servers: { ms-365: false }) suppresses all entries", () => {
+    const entries = resolveMs365McpEntries(
+      "marko",
+      agent({ ...agentCfg, mcp_servers: { "ms-365": false } }),
+      config,
+    );
+    expect(entries).toHaveLength(0);
+  });
+});

--- a/src/agents/scaffold-ms365-multi.test.ts
+++ b/src/agents/scaffold-ms365-multi.test.ts
@@ -18,6 +18,10 @@ import {
   resolveMs365McpEntries,
   resolveMs365McpEntry,
   ms365OwnedKeys,
+  retractStaleIntegrationKeys,
+  integrationMcpEntries,
+  userDeclaredMcpKeys,
+  INTEGRATION_MCP_RESOLVERS,
 } from "./scaffold.js";
 import { microsoftAccountSlug } from "../config/microsoft-workspace-acl.js";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
@@ -127,5 +131,106 @@ describe("resolveMs365McpEntries — multi-account", () => {
       config,
     );
     expect(entries).toHaveLength(0);
+  });
+});
+
+describe("retractStaleIntegrationKeys — durable shrink retraction (namespace diff)", () => {
+  const ms365 = INTEGRATION_MCP_RESOLVERS.find((i) => i.emitKey === "ms-365")!;
+  const slugA = `ms-365-${microsoftAccountSlug(STORAGE)}`;
+  const slugB = `ms-365-${microsoftAccountSlug(MAIL)}`;
+  const config = cfg({
+    [STORAGE]: { enabled_for: ["marko"] },
+    [MAIL]: { enabled_for: ["marko"] },
+  });
+
+  it("drops a FULLY-REMOVED binding's stale key that config enumeration cannot see", () => {
+    // Simulate settings.json.mcpServers from a prior 3-account apply where
+    // account B has since been removed. The config still binds 2+ accounts
+    // (A, C) so the survivors keep their per-slug keys. Emitted = {slugA, slugC}.
+    const slugC = `ms-365-${microsoftAccountSlug("carol@example.com")}`;
+    const stillMultiCfg = agent({
+      microsoft_workspace: {
+        accounts: [{ account: STORAGE }, { account: "carol@example.com" }],
+      },
+    });
+    const cfgAC = cfg({
+      [STORAGE]: { enabled_for: ["marko"] },
+      "carol@example.com": { enabled_for: ["marko"] },
+    });
+    const emitted = new Set(
+      integrationMcpEntries(ms365, "marko", stillMultiCfg, cfgAC).map((e) => e.key),
+    );
+    expect([...emitted].sort()).toEqual([slugA, slugC].sort());
+
+    const existing: Record<string, unknown> = {
+      hindsight: { command: "x" },
+      [slugA]: { command: "a" },
+      [slugB]: { command: "b" }, // account B removed from config → stale
+      [slugC]: { command: "c" },
+    };
+
+    const removed = retractStaleIntegrationKeys(
+      ms365,
+      emitted,
+      existing,
+      userDeclaredMcpKeys(stillMultiCfg),
+    );
+
+    expect(removed).toEqual([slugB]);
+    expect(existing[slugB]).toBeUndefined(); // stale gone — config enumeration alone could NOT see this
+    expect(existing[slugA]).toBeDefined(); // surviving account kept
+    expect(existing[slugC]).toBeDefined(); // surviving account kept
+    expect(existing.hindsight).toBeDefined(); // foreign key untouched
+  });
+
+  it("multi→single collapse retracts BOTH old per-slug keys (survivor reverts to bare `ms-365`)", () => {
+    // Shrinking from 2 accounts to 1 flips the survivor from `ms-365-<slug>`
+    // back to the bare `ms-365` key (documented back-compat). Both stale
+    // per-slug keys must be dropped.
+    const singleCfg = agent({ microsoft_workspace: { accounts: [{ account: STORAGE }] } });
+    const emitted = new Set(
+      integrationMcpEntries(ms365, "marko", singleCfg, config).map((e) => e.key),
+    );
+    expect([...emitted]).toEqual(["ms-365"]); // single-account collapses to bare key
+
+    const existing: Record<string, unknown> = {
+      [slugA]: { command: "a" },
+      [slugB]: { command: "b" },
+    };
+    const removed = retractStaleIntegrationKeys(ms365, emitted, existing, userDeclaredMcpKeys(singleCfg));
+    expect(removed.sort()).toEqual([slugA, slugB].sort());
+    expect(existing[slugA]).toBeUndefined();
+    expect(existing[slugB]).toBeUndefined();
+  });
+
+  it("also retracts the bare `ms-365` key when an agent goes from single → zero bindings", () => {
+    const existing: Record<string, unknown> = { "ms-365": { command: "x" } };
+    const removed = retractStaleIntegrationKeys(ms365, new Set(), existing);
+    expect(removed).toEqual(["ms-365"]);
+    expect(existing["ms-365"]).toBeUndefined();
+  });
+
+  it("PROTECTS an operator's hand-declared ms-365-* mcp_servers key", () => {
+    const existing: Record<string, unknown> = { "ms-365-custom": { command: "x" } };
+    const removed = retractStaleIntegrationKeys(
+      ms365,
+      new Set(),
+      existing,
+      new Set(["ms-365-custom"]),
+    );
+    expect(removed).toEqual([]);
+    expect(existing["ms-365-custom"]).toBeDefined();
+  });
+
+  it("does not touch keys outside the ms-365 namespace", () => {
+    const existing: Record<string, unknown> = {
+      gdrive: { command: "g" },
+      notion: { command: "n" },
+      "ms-365": { command: "m" },
+    };
+    retractStaleIntegrationKeys(ms365, new Set(), existing);
+    expect(existing.gdrive).toBeDefined();
+    expect(existing.notion).toBeDefined();
+    expect(existing["ms-365"]).toBeUndefined();
   });
 });

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3679,11 +3679,72 @@ export interface IntegrationMcpResolver {
   ) => { key: string; value: McpServerConfig }[];
   /**
    * OPTIONAL retraction-key set for plural integrations: every mcpServers
-   * key this integration COULD own for the agent (regardless of ACL), so
-   * reconcile can delete stale per-account keys when bindings shrink.
-   * When present it supersedes `retractionKey`.
+   * key this integration COULD own for the agent under the CURRENT config
+   * (regardless of ACL). NOTE: this cannot see a FULLY-REMOVED binding
+   * (its slug is gone from config), so it only handles the
+   * ACL-revoked-while-still-declared case. Durable full retraction uses
+   * `ownsKeyName` (namespace predicate) instead — see
+   * `retractStaleIntegrationKeys`.
    */
   ownedKeys?: (agentConfig: AgentConfig) => Set<string>;
+  /**
+   * OPTIONAL namespace predicate: does `key` belong to THIS integration's
+   * mcpServers namespace (e.g. `ms-365` or `ms-365-<slug>`)? Used by
+   * `retractStaleIntegrationKeys` to drop stale keys present in EXISTING
+   * settings that are no longer emitted — WITHOUT enumerating from the
+   * current config, so a binding that was fully removed (its slug no
+   * longer in config) is still retracted. When absent, retraction falls
+   * back to the single literal `retractionKey`.
+   */
+  ownsKeyName?: (key: string) => boolean;
+}
+
+/**
+ * Durable, namespace-scoped retraction: delete every key in `existing`
+ * that (a) belongs to the integration's namespace (`ownsKeyName`, or the
+ * literal `retractionKey` fallback), (b) is NOT in the freshly-emitted
+ * set, and (c) is NOT a user-declared mcp_servers key. Mutates `existing`
+ * in place and returns the removed keys.
+ *
+ * This is the fix for the multi-account retraction gap: `ownedKeys`
+ * (config enumeration) minus emitted can never drop a binding that was
+ * FULLY removed from `microsoft_workspace.accounts` (its slug is in
+ * neither set). Diffing the EXISTING mcpServers object against the emitted
+ * set by namespace catches the removed slug. The user-declared guard keeps
+ * an operator's hand-written `mcp_servers` entry from being swept.
+ */
+export function retractStaleIntegrationKeys(
+  integration: IntegrationMcpResolver,
+  emittedKeys: ReadonlySet<string>,
+  existing: Record<string, unknown>,
+  protectedKeys?: ReadonlySet<string>,
+): string[] {
+  const removed: string[] = [];
+  for (const key of Object.keys(existing)) {
+    if (emittedKeys.has(key)) continue;
+    if (protectedKeys?.has(key)) continue;
+    const owns = integration.ownsKeyName
+      ? integration.ownsKeyName(key)
+      : key === integration.retractionKey;
+    if (owns) {
+      delete existing[key];
+      removed.push(key);
+    }
+  }
+  return removed;
+}
+
+/**
+ * The set of user-declared mcp_servers keys (truthy values only — `false`
+ * is an opt-out sentinel, not a declaration) — protected from namespace
+ * retraction so an operator's hand-written entry survives.
+ */
+export function userDeclaredMcpKeys(agentConfig: AgentConfig): Set<string> {
+  return new Set(
+    Object.entries(agentConfig.mcp_servers ?? {})
+      .filter(([, v]) => v !== false)
+      .map(([k]) => k),
+  );
 }
 
 /**
@@ -3782,6 +3843,10 @@ export const INTEGRATION_MCP_RESOLVERS: readonly IntegrationMcpResolver[] = [
     resolve: resolveMs365McpEntry,
     resolveEntries: resolveMs365McpEntries,
     ownedKeys: ms365OwnedKeys,
+    // Namespace: the bare `ms-365` OR any `ms-365-<slug>` per-account key.
+    // Lets retraction drop a fully-removed binding's stale key without
+    // enumerating from the (already-shrunk) config.
+    ownsKeyName: (key: string) => key === "ms-365" || /^ms-365-[a-z0-9-]+$/.test(key),
   },
   {
     label: "Notion",
@@ -4162,17 +4227,41 @@ export function scaffoldAgent(
       // entry already in settings.mcpServers takes priority. Registry
       // iteration preserves the gdrive → ms-365 → notion order from
       // INTEGRATION_MCP_RESOLVERS.
+      const site1Protected = userDeclaredMcpKeys(agentConfig);
       for (const integration of INTEGRATION_MCP_RESOLVERS) {
-        for (const entry of integrationMcpEntries(
+        const entries = integrationMcpEntries(
           integration,
           name,
           agentConfig,
           switchroomConfig,
-        )) {
+        );
+        for (const entry of entries) {
           if (!settings.mcpServers[entry.key]) {
             settings.mcpServers[entry.key] = entry.value;
           }
         }
+        // Durable retraction on this MERGE path (existing settings.json is
+        // read + merged, never rebuilt): drop any owned-namespace key
+        // (bare `ms-365` or `ms-365-<slug>`) still present from a prior
+        // apply that is no longer emitted — e.g. an account removed from
+        // `microsoft_workspace.accounts`. Without this the stale per-account
+        // key lingers in settings.json.mcpServers across `switchroom apply`.
+        //
+        // This IS load-bearing, not hygiene: the main session's `exec claude`
+        // in profiles/_base/start.sh.hbs does NOT pass `--strict-mcp-config`
+        // (only the cron session does — cron-session.sh.hbs), so Claude Code
+        // loads MCP servers from settings.json.mcpServers in ADDITION to
+        // .mcp.json. A stale `ms-365-<slug>` left here would resurrect the
+        // removed account's tool namespace. (The reconcileAgentInner
+        // settings.json + .mcp.json paths rebuild `mcpServers` from scratch,
+        // so they retract fully-removed slugs by reconstruction — this merge
+        // path is the only one that needs an explicit prefix-scoped diff.)
+        retractStaleIntegrationKeys(
+          integration,
+          new Set(entries.map((e) => e.key)),
+          settings.mcpServers,
+          site1Protected,
+        );
       }
 
       // Hindsight memory plugin install (replaces our old shell hook).

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -628,7 +628,13 @@ import {
   getNotionMcpSettingsEntry,
 } from "../memory/scaffold-integration.js";
 import { shouldEmitGdriveMcp } from "../config/google-workspace-acl.js";
-import { shouldEmitMs365Mcp } from "../config/microsoft-workspace-acl.js";
+import {
+  shouldEmitMs365Mcp,
+  bindingsForAgent,
+  ms365McpKeyForBinding,
+  microsoftAccountSlug,
+  normalizeMicrosoftBindings,
+} from "../config/microsoft-workspace-acl.js";
 import { shouldEmitNotionMcp } from "../config/notion-workspace-acl.js";
 import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
 import { applyTelegramProgressGuidance, applySubAgentLocalTimeGuidance } from "./sub-agent-telegram-prompt.js";
@@ -3482,39 +3488,89 @@ export function resolveGdriveMcpEntry(
  *
  * Returns null when the entry must not be emitted.
  */
+export function resolveMs365McpEntries(
+  agentName: string,
+  agentConfig: AgentConfig,
+  switchroomConfig: SwitchroomConfig | undefined,
+): { key: string; value: McpServerConfig }[] {
+  if ((agentConfig.mcp_servers ?? {})["ms-365"] === false) return [];
+  const mw = agentConfig.microsoft_workspace;
+  const microsoftAccounts = switchroomConfig?.microsoft_accounts;
+  const bindings = bindingsForAgent(agentName, mw, microsoftAccounts);
+  if (bindings.length === 0) return [];
+
+  // Guard against two distinct emails colliding on the same slug/key on
+  // one agent — fail loud rather than silently dropping a binding.
+  const seenKeys = new Set<string>();
+  const entries: { key: string; value: McpServerConfig }[] = [];
+  for (const b of bindings) {
+    const key = ms365McpKeyForBinding(mw, b.account);
+    if (seenKeys.has(key)) {
+      throw new Error(
+        `agent '${agentName}': Microsoft account slug collision on MCP key '${key}' ` +
+        `(account '${b.account}'). Rename or disambiguate the accounts.`,
+      );
+    }
+    seenKeys.add(key);
+    // org_mode: per-binding override → top-level default. Launcher
+    // re-reads from config and is authoritative; threading here just
+    // makes the resolved choice visible in settings.json.
+    const orgMode =
+      b.org_mode ??
+      switchroomConfig?.microsoft_workspace?.org_mode ??
+      false;
+    // Only thread --account for the multi-account (plural) form so a
+    // single-account agent keeps byte-identical settings (bare ms-365,
+    // no --account) — back-compat.
+    const isMulti = key !== "ms-365";
+    const entry = getMs365McpSettingsEntry(DOCKER_SWITCHROOM_CLI_PATH, {
+      orgMode,
+      key,
+      ...(isMulti ? { account: b.account } : {}),
+      ...(b.tools ? { enabledTools: b.tools } : {}),
+    });
+    // Env-threading shape, minus vault-broker (the m365 launcher only
+    // talks to the auth-broker — no vault calls for client_secret yet
+    // because that gates per-agent vault ACL which isn't wired in PR 3).
+    // If a future PR teaches the launcher to resolve `vault:` refs for
+    // client_secret directly, re-add SWITCHROOM_VAULT_BROKER_SOCK here.
+    entry.value.env = {
+      SWITCHROOM_CONFIG: DOCKER_CONFIG_PATH,
+      SWITCHROOM_AGENT_NAME: agentName,
+      SWITCHROOM_CONTAINER: "1",
+      SWITCHROOM_AUTH_BROKER_SOCKET: DOCKER_AUTH_BROKER_SOCKET,
+      HOME: DOCKER_AGENT_HOME,
+    };
+    entries.push(entry);
+  }
+  return entries;
+}
+
+/**
+ * Singular back-compat shim: returns the FIRST resolved ms-365 entry (or
+ * null). Retained for callers/tests that expect one entry; multi-account
+ * callers use `resolveMs365McpEntries`.
+ */
 export function resolveMs365McpEntry(
   agentName: string,
   agentConfig: AgentConfig,
   switchroomConfig: SwitchroomConfig | undefined,
 ): { key: string; value: McpServerConfig } | null {
-  if ((agentConfig.mcp_servers ?? {})["ms-365"] === false) return null;
-  const account = agentConfig.microsoft_workspace?.account;
-  const microsoftAccounts = switchroomConfig?.microsoft_accounts;
-  if (!shouldEmitMs365Mcp(agentName, account, microsoftAccounts)) return null;
-  // org_mode: per-agent override → top-level default. Launcher
-  // re-reads from config and is authoritative; threading here just
-  // makes the resolved choice visible in settings.json.
-  const orgMode =
-    agentConfig.microsoft_workspace?.org_mode ??
-    switchroomConfig?.microsoft_workspace?.org_mode ??
-    false;
-  const entry = getMs365McpSettingsEntry(
-    DOCKER_SWITCHROOM_CLI_PATH,
-    orgMode ? { orgMode: true } : {},
-  );
-  // Env-threading shape, minus vault-broker (the m365 launcher only
-  // talks to the auth-broker — no vault calls for client_secret yet
-  // because that gates per-agent vault ACL which isn't wired in PR 3).
-  // If a future PR teaches the launcher to resolve `vault:` refs for
-  // client_secret directly, re-add SWITCHROOM_VAULT_BROKER_SOCK here.
-  entry.value.env = {
-    SWITCHROOM_CONFIG: DOCKER_CONFIG_PATH,
-    SWITCHROOM_AGENT_NAME: agentName,
-    SWITCHROOM_CONTAINER: "1",
-    SWITCHROOM_AUTH_BROKER_SOCKET: DOCKER_AUTH_BROKER_SOCKET,
-    HOME: DOCKER_AGENT_HOME,
-  };
-  return entry;
+  return resolveMs365McpEntries(agentName, agentConfig, switchroomConfig)[0] ?? null;
+}
+
+/**
+ * All mcpServers keys the ms-365 integration COULD own for this agent —
+ * the bare `ms-365` plus `ms-365-<slug>` for every declared binding
+ * (regardless of ACL). Used at reconcile to retract stale per-account
+ * keys when an agent's bindings shrink or the ACL is revoked.
+ */
+export function ms365OwnedKeys(agentConfig: AgentConfig): Set<string> {
+  const keys = new Set<string>(["ms-365"]);
+  for (const b of normalizeMicrosoftBindings(agentConfig.microsoft_workspace)) {
+    keys.add(`ms-365-${microsoftAccountSlug(b.account)}`);
+  }
+  return keys;
 }
 
 /**
@@ -3609,6 +3665,63 @@ export interface IntegrationMcpResolver {
     agentConfig: AgentConfig,
     switchroomConfig: SwitchroomConfig | undefined,
   ) => { key: string; value: McpServerConfig } | null;
+  /**
+   * OPTIONAL plural resolver for integrations that emit MORE THAN ONE
+   * mcpServers key (e.g. Microsoft 365 multi-account: one `ms-365-<slug>`
+   * per bound account). When present it supersedes `resolve` for
+   * emission; `resolve` is kept as a single-entry shim for callers/tests
+   * that expect one entry.
+   */
+  resolveEntries?: (
+    name: string,
+    agentConfig: AgentConfig,
+    switchroomConfig: SwitchroomConfig | undefined,
+  ) => { key: string; value: McpServerConfig }[];
+  /**
+   * OPTIONAL retraction-key set for plural integrations: every mcpServers
+   * key this integration COULD own for the agent (regardless of ACL), so
+   * reconcile can delete stale per-account keys when bindings shrink.
+   * When present it supersedes `retractionKey`.
+   */
+  ownedKeys?: (agentConfig: AgentConfig) => Set<string>;
+}
+
+/**
+ * The mcpServers entries an integration emits for an agent — plural-aware.
+ * Uses `resolveEntries` when present, else wraps the single `resolve`.
+ */
+export function integrationMcpEntries(
+  integration: IntegrationMcpResolver,
+  name: string,
+  agentConfig: AgentConfig,
+  switchroomConfig: SwitchroomConfig | undefined,
+): { key: string; value: McpServerConfig }[] {
+  if (integration.resolveEntries) {
+    return integration.resolveEntries(name, agentConfig, switchroomConfig);
+  }
+  const entry = integration.resolve(name, agentConfig, switchroomConfig);
+  return entry ? [entry] : [];
+}
+
+/**
+ * The set of mcpServers keys to `delete` for an integration at reconcile
+ * that are NOT in the currently-emitted set — plural-aware retraction.
+ */
+export function integrationRetractionKeys(
+  integration: IntegrationMcpResolver,
+  name: string,
+  agentConfig: AgentConfig,
+  switchroomConfig: SwitchroomConfig | undefined,
+): string[] {
+  const emitted = new Set(
+    integrationMcpEntries(integration, name, agentConfig, switchroomConfig).map(
+      (e) => e.key,
+    ),
+  );
+  const owned = integration.ownedKeys
+    ? integration.ownedKeys(agentConfig)
+    : new Set<string>([integration.retractionKey]);
+  return [...owned].filter((k) => !emitted.has(k));
 }
 
 /**
@@ -3667,6 +3780,8 @@ export const INTEGRATION_MCP_RESOLVERS: readonly IntegrationMcpResolver[] = [
     emitKey: "ms-365",
     retractionKey: "ms-365",
     resolve: resolveMs365McpEntry,
+    resolveEntries: resolveMs365McpEntries,
+    ownedKeys: ms365OwnedKeys,
   },
   {
     label: "Notion",
@@ -4048,9 +4163,15 @@ export function scaffoldAgent(
       // iteration preserves the gdrive → ms-365 → notion order from
       // INTEGRATION_MCP_RESOLVERS.
       for (const integration of INTEGRATION_MCP_RESOLVERS) {
-        const entry = integration.resolve(name, agentConfig, switchroomConfig);
-        if (entry && !settings.mcpServers[entry.key]) {
-          settings.mcpServers[entry.key] = entry.value;
+        for (const entry of integrationMcpEntries(
+          integration,
+          name,
+          agentConfig,
+          switchroomConfig,
+        )) {
+          if (!settings.mcpServers[entry.key]) {
+            settings.mcpServers[entry.key] = entry.value;
+          }
         }
       }
 
@@ -4245,8 +4366,12 @@ export function scaffoldAgent(
       // INTEGRATION_MCP_RESOLVERS so two integrations never silently
       // disagree on precedence between sites.
       for (const integration of INTEGRATION_MCP_RESOLVERS) {
-        const entry = integration.resolve(name, agentConfig, switchroomConfig);
-        if (entry) {
+        for (const entry of integrationMcpEntries(
+          integration,
+          name,
+          agentConfig,
+          switchroomConfig,
+        )) {
           mcpServers[entry.key] = entry.value;
         }
       }
@@ -6516,11 +6641,24 @@ function reconcileAgentInner(
       // from its emit key cannot silently drift between emit and
       // retract paths. Mirrors how #235 switchroom-mcp retraction works.
       for (const integration of INTEGRATION_MCP_RESOLVERS) {
-        const entry = integration.resolve(name, agentConfig, switchroomConfig);
-        if (entry) {
+        for (const entry of integrationMcpEntries(
+          integration,
+          name,
+          agentConfig,
+          switchroomConfig,
+        )) {
           mcpServers[entry.key] = entry.value;
-        } else {
-          delete mcpServers[integration.retractionKey];
+        }
+        // Retract every owned key NOT in the current emit set — for the
+        // plural ms-365 integration this deletes stale `ms-365-<slug>`
+        // entries when an agent's bindings shrink or an ACL is revoked.
+        for (const stale of integrationRetractionKeys(
+          integration,
+          name,
+          agentConfig,
+          switchroomConfig,
+        )) {
+          delete mcpServers[stale];
         }
       }
     }
@@ -6883,8 +7021,12 @@ function reconcileAgentInner(
       // fresh from the hardcoded set each reconcile, so a retracted
       // entry simply isn't re-added (no explicit delete needed).
       for (const integration of INTEGRATION_MCP_RESOLVERS) {
-        const entry = integration.resolve(name, agentConfig, switchroomConfig);
-        if (entry) {
+        for (const entry of integrationMcpEntries(
+          integration,
+          name,
+          agentConfig,
+          switchroomConfig,
+        )) {
           mcpServers[entry.key] = entry.value;
         }
       }

--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -518,13 +518,18 @@ export class AuthBrokerClient {
 
   // ─── Verb methods ────────────────────────────────────────────────────
 
-  async getCredentials(provider?: ProviderName): Promise<GetCredentialsData> {
+  async getCredentials(
+    provider?: ProviderName,
+    account?: string,
+  ): Promise<GetCredentialsData> {
     const base = {
       v: PROTOCOL_VERSION,
       id: randomUUID(),
       op: "get-credentials" as const,
     };
-    const req = (provider !== undefined ? { ...base, provider } : base) as Request;
+    let req: Request = base as Request;
+    if (provider !== undefined) req = { ...req, provider } as Request;
+    if (account !== undefined) req = { ...req, account } as Request;
     const data = await this.send(req);
     return data as GetCredentialsData;
   }

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -88,6 +88,15 @@ export const GetCredentialsRequestSchema = z.object({
    * returning credentials.
    */
   provider: ProviderNameSchema.optional(),
+  /**
+   * Requested Microsoft account (multi-account-per-agent). Optional. When
+   * present (provider="microsoft"), the broker validates it is one of the
+   * agent's `microsoft_workspace` bindings AND that the account lists this
+   * agent in `microsoft_accounts.<account>.enabled_for[]`, then returns
+   * THAT account's credentials. Omitted → single-account back-compat (the
+   * account is derived from the agent's singular `microsoft_workspace.account`).
+   */
+  account: z.string().min(1).optional(),
 });
 
 export const ListStateRequestSchema = z.object({

--- a/src/auth/broker/server-microsoft.test.ts
+++ b/src/auth/broker/server-microsoft.test.ts
@@ -854,4 +854,54 @@ describe("AuthBroker — Microsoft get-credentials, multi-account per agent", ()
 
     broker.stop();
   });
+
+  it("Finding 2 — INVALID_ARGS (not a silent bindings[0]) when multi-account and NO account requested", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      agents: {
+        marko: {
+          microsoft_workspace: {
+            accounts: [
+              { account: "alice@example.com" },
+              { account: "bob@example.com" },
+            ],
+          },
+        },
+      },
+      microsoftAccounts: {
+        "alice@example.com": { enabled_for: ["marko"] },
+        "bob@example.com": { enabled_for: ["marko"] },
+      },
+    });
+    seedMicrosoftAccount(h, "alice@example.com", {
+      expiresAt: Date.now() + 3600_000,
+      accessToken: "at-alice",
+    });
+    seedMicrosoftAccount(h, "bob@example.com", {
+      expiresAt: Date.now() + 3600_000,
+      accessToken: "at-bob",
+    });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    // Account-less request on a multi-account agent must NOT silently return
+    // bindings[0] (alice) — that was the root of the wrong-account card.
+    const resp = (await rpc(join(h.socketRoot, "marko", "sock"), {
+      v: 1,
+      id: "mm-5",
+      op: "get-credentials",
+      provider: "microsoft",
+    })) as { ok: false; error: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error.code).toBe("INVALID_ARGS");
+    expect(resp.error.message).toContain("account must be specified");
+
+    broker.stop();
+  });
 });

--- a/src/auth/broker/server-microsoft.test.ts
+++ b/src/auth/broker/server-microsoft.test.ts
@@ -719,3 +719,139 @@ describe("AuthBroker — Microsoft refresh-tick", () => {
     broker.stop();
   });
 });
+
+describe("AuthBroker — Microsoft get-credentials, multi-account per agent", () => {
+  it("returns the REQUESTED account's creds when the agent binds multiple accounts", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      agents: {
+        marko: {
+          microsoft_workspace: {
+            accounts: [
+              { account: "alice@example.com", tools: ["list-drives"] },
+              { account: "bob@example.com", tools: ["list-mail-messages"] },
+            ],
+          },
+        },
+      },
+      microsoftAccounts: {
+        "alice@example.com": { enabled_for: ["marko"] },
+        "bob@example.com": { enabled_for: ["marko"] },
+      },
+    });
+    seedMicrosoftAccount(h, "alice@example.com", {
+      expiresAt: Date.now() + 3600_000,
+      accessToken: "at-storage",
+    });
+    seedMicrosoftAccount(h, "bob@example.com", {
+      expiresAt: Date.now() + 3600_000,
+      accessToken: "at-mail",
+    });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const storage = (await rpc(join(h.socketRoot, "marko", "sock"), {
+      v: 1,
+      id: "mm-1",
+      op: "get-credentials",
+      provider: "microsoft",
+      account: "alice@example.com",
+    })) as { ok: true; data: { account: string; credentials: MicrosoftCredentialsShape } };
+    expect(storage.ok).toBe(true);
+    expect(storage.data.account).toBe("alice@example.com");
+    expect(storage.data.credentials.microsoftOauth.accessToken).toBe("at-storage");
+
+    const mail = (await rpc(join(h.socketRoot, "marko", "sock"), {
+      v: 1,
+      id: "mm-2",
+      op: "get-credentials",
+      provider: "microsoft",
+      account: "bob@example.com",
+    })) as { ok: true; data: { account: string; credentials: MicrosoftCredentialsShape } };
+    expect(mail.ok).toBe(true);
+    expect(mail.data.account).toBe("bob@example.com");
+    expect(mail.data.credentials.microsoftOauth.accessToken).toBe("at-mail");
+
+    broker.stop();
+  });
+
+  it("ACCOUNT_NOT_FOUND when the requested account is not one of the agent's bindings", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      agents: {
+        marko: {
+          microsoft_workspace: {
+            accounts: [{ account: "bob@example.com" }],
+          },
+        },
+      },
+      microsoftAccounts: {
+        "bob@example.com": { enabled_for: ["marko"] },
+        "someone@else.com": { enabled_for: ["marko"] },
+      },
+    });
+    seedMicrosoftAccount(h, "someone@else.com", { expiresAt: Date.now() + 3600_000 });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "marko", "sock"), {
+      v: 1,
+      id: "mm-3",
+      op: "get-credentials",
+      provider: "microsoft",
+      account: "someone@else.com",
+    })) as { ok: false; error: { code: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error.code).toBe("ACCOUNT_NOT_FOUND");
+
+    broker.stop();
+  });
+
+  it("FORBIDDEN when a bound account does not list the agent in enabled_for[]", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      agents: {
+        marko: {
+          microsoft_workspace: {
+            accounts: [{ account: "bob@example.com" }],
+          },
+        },
+      },
+      // bound, but enabled for a DIFFERENT agent → per-account ACL miss.
+      microsoftAccounts: { "bob@example.com": { enabled_for: ["clerk"] } },
+    });
+    seedMicrosoftAccount(h, "bob@example.com", { expiresAt: Date.now() + 3600_000 });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "marko", "sock"), {
+      v: 1,
+      id: "mm-4",
+      op: "get-credentials",
+      provider: "microsoft",
+      account: "bob@example.com",
+    })) as { ok: false; error: { code: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error.code).toBe("FORBIDDEN");
+
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -3311,6 +3311,24 @@ export class AuthBroker {
         return;
       }
       account = bound.account;
+    } else if (bindings.length > 1) {
+      // Multi-account agent but NO account requested. Silently returning
+      // bindings[0] here is the root of the write-approval-card mis-resolve
+      // (review 2026-07-17, Finding 2): callers that forget to thread the
+      // account would enrich/act against the wrong mailbox. Fail loudly with
+      // a hint instead — every legitimate multi-account caller passes the
+      // account explicitly.
+      this.audit({ op: "get-credentials", identity, accountKind: "microsoft", ok: false, error: "account-ambiguous" });
+      socket.write(
+        encodeError(
+          id,
+          "INVALID_ARGS",
+          `agent '${agentName}' is bound to ${bindings.length} Microsoft accounts (${bindings
+            .map((b) => b.account)
+            .join(", ")}); an account must be specified — call getCredentials("microsoft", <account>)`,
+        ),
+      );
+      return;
     } else {
       // Back-compat: derive the single account from the (normalized)
       // bindings. Exactly one binding is expected in the singular form.

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -110,6 +110,10 @@ import {
   writeMicrosoftAccountCredentials,
 } from "./microsoft-storage.js";
 import { ProviderRegistry, type ProviderName } from "./provider.js";
+import {
+  normalizeMicrosoftBindings,
+  type MicrosoftWorkspaceLike,
+} from "../../config/microsoft-workspace-acl.js";
 import type { GoogleCredentialsShape, MicrosoftCredentialsShape } from "./protocol.js";
 import {
   accountCredentialsPath,
@@ -1043,7 +1047,12 @@ export class AuthBroker {
             break;
           }
           if (provider === "microsoft") {
-            await this.opMicrosoftGetCredentials(socket, reqId, identity);
+            await this.opMicrosoftGetCredentials(
+              socket,
+              reqId,
+              identity,
+              req.account,
+            );
             break;
           }
           socket.write(
@@ -3266,6 +3275,7 @@ export class AuthBroker {
     socket: net.Socket,
     id: string,
     identity: Identity,
+    requestedAccount?: string,
   ): Promise<void> {
     if (identity.kind !== "agent") {
       socket.write(
@@ -3279,9 +3289,33 @@ export class AuthBroker {
     }
     const agentName = identity.name;
     const agent = (this.config.agents ?? {})[agentName] as
-      | { microsoft_workspace?: { account?: string } }
+      | { microsoft_workspace?: MicrosoftWorkspaceLike }
       | undefined;
-    const account = agent?.microsoft_workspace?.account;
+    const bindings = normalizeMicrosoftBindings(agent?.microsoft_workspace);
+    let account: string | undefined;
+    if (requestedAccount !== undefined) {
+      // Multi-account form: the requested account must be one of the
+      // agent's bindings. A mismatch keeps the ACCOUNT_NOT_FOUND code so
+      // nothing silently downgrades.
+      const wanted = requestedAccount.trim().toLowerCase();
+      const bound = bindings.find((b) => b.account === wanted);
+      if (!bound) {
+        this.audit({ op: "get-credentials", identity, account: wanted, accountKind: "microsoft", ok: false, error: "account-not-bound" });
+        socket.write(
+          encodeError(
+            id,
+            "ACCOUNT_NOT_FOUND",
+            `agent '${agentName}' is not bound to Microsoft account '${wanted}' in switchroom.yaml microsoft_workspace`,
+          ),
+        );
+        return;
+      }
+      account = bound.account;
+    } else {
+      // Back-compat: derive the single account from the (normalized)
+      // bindings. Exactly one binding is expected in the singular form.
+      account = bindings[0]?.account;
+    }
     if (!account) {
       this.audit({ op: "get-credentials", identity, accountKind: "microsoft", ok: false, error: "no-microsoft-account-configured" });
       socket.write(

--- a/src/cli/doctor-microsoft.ts
+++ b/src/cli/doctor-microsoft.ts
@@ -36,6 +36,11 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 
 import type { SwitchroomConfig } from "../config/schema.js";
+import {
+  bindingsForAgent,
+  isMultiAccount,
+  microsoftAccountSlug,
+} from "../config/microsoft-workspace-acl.js";
 
 import type { CheckStatus } from "./doctor-status.js";
 import { checkIntegrationScaffoldWiring } from "./doctor-scaffold-wiring.js";
@@ -192,11 +197,31 @@ interface LauncherHeartbeat {
   expiresAtMs: number;
 }
 
-function readHeartbeat(
+/**
+ * The heartbeat filename for a binding — mirrors
+ * `heartbeatPath()` in m365-mcp-launcher.ts. Single-account agents keep
+ * the bare `m365-launcher.heartbeat.json`; multi-account agents get one
+ * `m365-launcher-<slug>.heartbeat.json` per bound account so N launchers
+ * don't clobber each other.
+ */
+function heartbeatFileName(
+  config: SwitchroomConfig,
+  agentName: string,
+  account: string,
+): string {
+  const mw = config.agents?.[agentName]?.microsoft_workspace;
+  if (isMultiAccount(mw)) {
+    return `m365-launcher-${microsoftAccountSlug(account)}.heartbeat.json`;
+  }
+  return "m365-launcher.heartbeat.json";
+}
+
+function readHeartbeatFile(
   d: ResolvedDeps,
   agentName: string,
+  fileName: string,
 ): LauncherHeartbeat | { error: string } {
-  const path = join(d.agentsDir, agentName, "m365-launcher.heartbeat.json");
+  const path = join(d.agentsDir, agentName, fileName);
   if (!d.existsSync(path)) {
     return { error: "heartbeat file missing — launcher has not yet started" };
   }
@@ -217,21 +242,49 @@ function readHeartbeat(
 }
 
 function checkLauncherHeartbeat(
+  config: SwitchroomConfig,
   msEnabledAgents: string[],
   d: ResolvedDeps,
 ): CheckResult[] {
   const results: CheckResult[] = [];
   for (const name of msEnabledAgents) {
-    const hb = readHeartbeat(d, name);
-    if ("error" in hb) {
-      results.push({
-        name: `microsoft:launcher-heartbeat:${name}`,
-        status: "warn",
-        detail: `${hb.error} (path: ~/.switchroom/agents/${name}/m365-launcher.heartbeat.json)`,
-        fix: `Launcher writes the heartbeat on its first refresh tick. If agent has been running for >5min and the file is still missing, check the launcher log via 'docker logs switchroom-${name}'.`,
-      });
-      continue;
+    // One heartbeat per passing binding (bare file for single-account,
+    // per-slug files for multi-account). Read them all.
+    const bindings = bindingsForAgent(
+      name,
+      config.agents?.[name]?.microsoft_workspace,
+      config.microsoft_accounts,
+    );
+    for (const b of bindings) {
+      const multi = bindings.length > 1 || isMultiAccount(config.agents?.[name]?.microsoft_workspace);
+      const checkName = multi
+        ? `microsoft:launcher-heartbeat:${name}:${b.account}`
+        : `microsoft:launcher-heartbeat:${name}`;
+      const fileName = heartbeatFileName(config, name, b.account);
+      const hb = readHeartbeatFile(d, name, fileName);
+      if ("error" in hb) {
+        results.push({
+          name: checkName,
+          status: "warn",
+          detail: `${hb.error} (path: ~/.switchroom/agents/${name}/${fileName})`,
+          fix: `Launcher writes the heartbeat on its first refresh tick. If agent has been running for >5min and the file is still missing, check the launcher log via 'docker logs switchroom-${name}'.`,
+        });
+        continue;
+      }
+      results.push(...evaluateHeartbeat(checkName, hb, name, d));
     }
+  }
+  return results;
+}
+
+function evaluateHeartbeat(
+  checkName: string,
+  hb: LauncherHeartbeat,
+  name: string,
+  d: ResolvedDeps,
+): CheckResult[] {
+  const results: CheckResult[] = [];
+  {
     const now = d.now();
     const ageSinceLastRefresh = now - hb.lastRefreshMs;
     const untilNextRefresh = hb.nextRefreshMs - now;
@@ -239,21 +292,21 @@ function checkLauncherHeartbeat(
     // OR nextRefreshMs in the past (refresh tick didn't fire when scheduled).
     if (ageSinceLastRefresh > 90 * 60 * 1000) {
       results.push({
-        name: `microsoft:launcher-heartbeat:${name}`,
+        name: checkName,
         status: "fail",
         detail: `last refresh was ${Math.round(ageSinceLastRefresh / 60000)}min ago (>90min) — launcher refresh loop appears dead`,
         fix: `Restart the agent: 'switchroom agent restart ${name}'. If problem recurs, check launcher logs for broker/network failures.`,
       });
     } else if (untilNextRefresh < -5 * 60 * 1000) {
       results.push({
-        name: `microsoft:launcher-heartbeat:${name}`,
+        name: checkName,
         status: "warn",
         detail: `nextRefreshMs was ${Math.round(-untilNextRefresh / 60000)}min ago — refresh tick missed its scheduled time`,
         fix: `Tick is overdue but not yet stale. Monitor; if it doesn't update within a few minutes, restart the agent.`,
       });
     } else {
       results.push({
-        name: `microsoft:launcher-heartbeat:${name}`,
+        name: checkName,
         status: "ok",
         detail: `last refresh ${Math.round(ageSinceLastRefresh / 60000)}min ago, next in ${Math.round(untilNextRefresh / 60000)}min`,
       });
@@ -284,15 +337,16 @@ export function computeMicrosoftEnabledAgents(
   // invariant ever weakens, route through `shouldEmitMs365Mcp` from
   // `src/config/microsoft-workspace-acl.ts` (which re-normalizes
   // defensively) to keep this in sync with the scaffold gate.
-  const accounts = config.microsoft_accounts ?? {};
-  return Object.keys(config.agents ?? {}).filter((name) => {
-    const acct = agentMicrosoftAccount(config, name);
-    return (
-      !!acct &&
-      !!accounts[acct] &&
-      (accounts[acct].enabled_for ?? []).includes(name)
-    );
-  });
+  // Multi-account-aware: an agent is "enabled" iff AT LEAST ONE of its
+  // Microsoft bindings (singular OR plural) passes the twin-key gate.
+  return Object.keys(config.agents ?? {}).filter(
+    (name) =>
+      bindingsForAgent(
+        name,
+        config.agents?.[name]?.microsoft_workspace,
+        config.microsoft_accounts,
+      ).length > 0,
+  );
 }
 
 export function runMicrosoftChecks(
@@ -317,7 +371,7 @@ export function runMicrosoftChecks(
 
   const msAgents = computeMicrosoftEnabledAgents(config);
   results.push(...checkOAuthClient(config, msAgents.length > 0));
-  results.push(...checkLauncherHeartbeat(msAgents, d));
+  results.push(...checkLauncherHeartbeat(config, msAgents, d));
   results.push(
     ...checkIntegrationScaffoldWiring({
       label: "microsoft",

--- a/src/cli/m365-mcp-launcher.test.ts
+++ b/src/cli/m365-mcp-launcher.test.ts
@@ -698,3 +698,94 @@ describe("runMs365McpLauncher — crash-loop backoff (#2586)", () => {
     delete process.env.SWITCHROOM_M365_HEARTBEAT_DIR;
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────
+// Multi-account per agent — enabled-tools + per-slug heartbeat isolation
+// ────────────────────────────────────────────────────────────────────────
+
+describe("buildSofteriaArgs — --enabled-tools (per-account tool scope)", () => {
+  it("appends --enabled-tools when a pattern is given", () => {
+    const args = buildSofteriaArgs({ enabledTools: "list-mail-messages|get-mail-message" });
+    const i = args.indexOf("--enabled-tools");
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i + 1]).toBe("list-mail-messages|get-mail-message");
+  });
+
+  it("omits --enabled-tools when absent (all tools)", () => {
+    expect(buildSofteriaArgs()).not.toContain("--enabled-tools");
+    expect(buildSofteriaArgs({ orgMode: true })).not.toContain("--enabled-tools");
+  });
+});
+
+describe("heartbeatPath — per-slug isolation for N launchers", () => {
+  const hbDir = `/tmp/m365-multi-hb-${process.pid}-${Date.now()}`;
+  beforeEach(() => {
+    process.env.SWITCHROOM_M365_HEARTBEAT_DIR = hbDir;
+  });
+  afterEach(() => {
+    delete process.env.SWITCHROOM_M365_HEARTBEAT_DIR;
+    rmSync(hbDir, { recursive: true, force: true });
+  });
+
+  it("two accounts on one agent get DISTINCT heartbeat files (no clobber)", () => {
+    const a = heartbeatPath("marko", "alice@example.com");
+    const b = heartbeatPath("marko", "bob@example.com");
+    expect(a).not.toBe(b);
+    // both are per-slug, not the bare single-account path
+    expect(a).not.toContain("m365-launcher-marko.heartbeat.json");
+    expect(b).not.toContain("m365-launcher-marko.heartbeat.json");
+  });
+
+  it("no account (single-account) keeps the bare per-agent path", () => {
+    const p = heartbeatPath("marko");
+    expect(p).toContain("m365-launcher-marko.heartbeat.json");
+  });
+
+  it("writing two accounts' heartbeats leaves both files intact", () => {
+    writeRefreshHeartbeat("marko", { lastRefreshMs: 1, nextRefreshMs: 2, expiresAtMs: 3 }, "alice@example.com");
+    writeRefreshHeartbeat("marko", { lastRefreshMs: 4, nextRefreshMs: 5, expiresAtMs: 6 }, "bob@example.com");
+    const a = heartbeatPath("marko", "alice@example.com");
+    const b = heartbeatPath("marko", "bob@example.com");
+    expect(existsSync(a)).toBe(true);
+    expect(existsSync(b)).toBe(true);
+    expect(JSON.parse(readFileSync(a, "utf-8")).lastRefreshMs).toBe(1);
+    expect(JSON.parse(readFileSync(b, "utf-8")).lastRefreshMs).toBe(4);
+  });
+});
+
+describe("runMs365McpLauncher — per-account (multi) writes a per-slug heartbeat", () => {
+  const hbDir = `/tmp/m365-run-multi-hb-${process.pid}-${Date.now()}`;
+  afterEach(() => {
+    delete process.env.SWITCHROOM_AGENT_NAME;
+    delete process.env.SWITCHROOM_M365_HEARTBEAT_DIR;
+    rmSync(hbDir, { recursive: true, force: true });
+  });
+
+  it("keys the heartbeat by the --account slug and threads that account's token", async () => {
+    process.env.SWITCHROOM_AGENT_NAME = "marko";
+    process.env.SWITCHROOM_M365_HEARTBEAT_DIR = hbDir;
+    const account = "bob@example.com";
+    let spawnedEnv: NodeJS.ProcessEnv | undefined;
+    const child = makeFakeChild();
+    const promise = runMs365McpLauncher(
+      { account },
+      {
+        fetchCreds: async () => ({ accessToken: "at-mail", expiresAt: Date.now() + 60 * 60 * 1000 }),
+        spawnSofteria: (env) => {
+          spawnedEnv = env;
+          return child as unknown as import("node:child_process").ChildProcess;
+        },
+        setTimer: ((_cb: () => void, _ms: number) => setTimeout(() => {}, 0)) as typeof setTimeout,
+        log: () => {},
+      },
+    );
+    await new Promise((r) => setImmediate(r));
+    expect(spawnedEnv?.[SOFTERIA_TOKEN_ENV]).toBe("at-mail");
+    // heartbeat lands at the per-slug path, NOT the bare single-account path.
+    expect(existsSync(heartbeatPath("marko", account))).toBe(true);
+    expect(existsSync(heartbeatPath("marko"))).toBe(false);
+    child.exitCode = 0;
+    child.emit("exit", 0, null);
+    await promise;
+  });
+});

--- a/src/cli/m365-mcp-launcher.ts
+++ b/src/cli/m365-mcp-launcher.ts
@@ -38,6 +38,7 @@ import {
   MICROSOFT_WORKSPACE_MCP_PACKAGE,
   MICROSOFT_WORKSPACE_MCP_PINNED_VERSION,
 } from "../memory/scaffold-integration.js";
+import { microsoftAccountSlug } from "../config/microsoft-workspace-acl.js";
 
 /**
  * The env var softeria reads at startup to receive a pre-acquired
@@ -99,6 +100,18 @@ export function computeRestartBackoffMs(attempt: number): number {
 export interface LauncherOptions {
   /** Whether to pass `--org-mode` to softeria (Teams/SharePoint). */
   orgMode?: boolean;
+  /**
+   * The Microsoft account this launcher instance serves (multi-account
+   * form). Threaded to the broker as `getCredentials("microsoft", account)`
+   * and used to key the per-account heartbeat file. Omitted → single-
+   * account back-compat (broker derives the account from config).
+   */
+  account?: string;
+  /**
+   * Per-account tool allowlist regex → softeria `--enabled-tools`. Already
+   * joined (e.g. `list-mail-messages|get-mail-message`). Omitted = all tools.
+   */
+  enabledTools?: string;
 }
 
 export interface LauncherRuntime {
@@ -126,6 +139,9 @@ export function buildSofteriaArgs(opts: LauncherOptions = {}): string[] {
   const pkg = `${MICROSOFT_WORKSPACE_MCP_PACKAGE}@${MICROSOFT_WORKSPACE_MCP_PINNED_VERSION}`;
   const args = ["-y", pkg];
   if (opts.orgMode) args.push("--org-mode");
+  if (opts.enabledTools && opts.enabledTools.length > 0) {
+    args.push("--enabled-tools", opts.enabledTools);
+  }
   return args;
 }
 
@@ -167,8 +183,9 @@ export function computeRefreshDelayMs(
 export function writeRefreshHeartbeat(
   agentName: string,
   data: { lastRefreshMs: number; nextRefreshMs: number; expiresAtMs: number },
+  account?: string,
 ): void {
-  const path = heartbeatPath(agentName);
+  const path = heartbeatPath(agentName, account);
   try {
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, JSON.stringify(data, null, 2), { mode: 0o644 });
@@ -191,13 +208,25 @@ export function writeRefreshHeartbeat(
  * Test override: if `SWITCHROOM_M365_HEARTBEAT_DIR` is set, write
  * there instead. Lets tests use a per-test tmpdir without poking
  * `/state/agent/`.
+ *
+ * **Per-account (multi-account form):** when `account` is set, the file
+ * is keyed by the account slug so N launchers don't clobber each other:
+ * `m365-launcher-<slug>.heartbeat.json`. Single-account launchers (no
+ * `account`) keep the bare path for back-compat. The doctor probe globs
+ * `m365-launcher*.heartbeat.json` to read all of them.
  */
-export function heartbeatPath(agentName: string): string {
+export function heartbeatPath(agentName: string, account?: string): string {
+  const slug = account ? microsoftAccountSlug(account) : undefined;
   const override = process.env.SWITCHROOM_M365_HEARTBEAT_DIR;
   if (override) {
-    return join(override, `m365-launcher-${agentName}.heartbeat.json`);
+    const base = slug
+      ? `m365-launcher-${agentName}-${slug}`
+      : `m365-launcher-${agentName}`;
+    return join(override, `${base}.heartbeat.json`);
   }
-  return "/state/agent/m365-launcher.heartbeat.json";
+  return slug
+    ? `/state/agent/m365-launcher-${slug}.heartbeat.json`
+    : "/state/agent/m365-launcher.heartbeat.json";
 }
 
 /**
@@ -401,11 +430,15 @@ export async function runMs365McpLauncher(
   const scheduleRefresh = (expiresAtMs: number) => {
     const delayMs = computeRefreshDelayMs(expiresAtMs, now());
     const nextRefreshMs = now() + delayMs;
-    writeRefreshHeartbeat(agentName, {
-      lastRefreshMs: now(),
-      nextRefreshMs,
-      expiresAtMs,
-    });
+    writeRefreshHeartbeat(
+      agentName,
+      {
+        lastRefreshMs: now(),
+        nextRefreshMs,
+        expiresAtMs,
+      },
+      opts.account,
+    );
     log(
       `m365-launcher: scheduled refresh in ${Math.round(delayMs / 1000)}s (token expires at ${new Date(expiresAtMs).toISOString()})`,
     );
@@ -523,16 +556,24 @@ export function registerM365McpLauncherCommand(program: Command): void {
       "Pass --org-mode to softeria (Teams/SharePoint tools).",
       false,
     )
+    .option(
+      "--account <email>",
+      "Microsoft account this launcher serves (multi-account form). Fetches THAT account's token from the broker and keys a per-account heartbeat. Omitted → single-account back-compat.",
+    )
+    .option(
+      "--enabled-tools <pattern>",
+      "Per-account tool allowlist regex forwarded to softeria --enabled-tools (tokens joined with |). Omitted = all tools.",
+    )
     .description(
       "Internal — Microsoft 365 MCP launcher. Acquires a fresh access token from the auth-broker and execs softeria/ms-365-mcp-server in BYOT mode, restarting it ~55min before token expiry. RFC #1873 PR 3.",
     )
-    .action(async (opts: { orgMode?: boolean }) => {
+    .action(async (opts: { orgMode?: boolean; account?: string; enabledTools?: string }) => {
       const { brokerCall } = await import("./broker-call.js");
 
       const code = await runMs365McpLauncher(opts, {
         fetchCreds: async () => {
           return await brokerCall(async (client) => {
-            const data = await client.getCredentials("microsoft");
+            const data = await client.getCredentials("microsoft", opts.account);
             const mc = (data.credentials as {
               microsoftOauth?: { accessToken?: string; expiresAt?: number };
             }) ?? {};

--- a/src/cli/ms-365-write-pretool.test.ts
+++ b/src/cli/ms-365-write-pretool.test.ts
@@ -31,7 +31,48 @@ import {
   buildCalendarChanges,
   enrichCalendarPreview,
   loadAllowFrom,
+  ms365BareToolName,
 } from "./ms-365-write-pretool.js";
+
+describe("multi-account prefix widening (MERGE-BLOCKER — fail-open regression guard)", () => {
+  // If the PreToolUse prefix isn't widened from the literal `mcp__ms-365__`
+  // to `mcp__ms-365(-<slug>)?__`, every multi-account write tool sails
+  // through UN-gated. These assertions FAIL unless the prefix is widened.
+  it("GATES a write tool on a per-account server key", () => {
+    expect(isGatedMs365Tool("mcp__ms-365-lisa-goodfellow-1a2b__delete-onedrive-file")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365-lisa-thinksolve-3c4d__send-mail")).toBe(true);
+    // unrecognized tool on a per-account key still fail-closes
+    expect(isGatedMs365Tool("mcp__ms-365-acct-9999__some-new-write-tool")).toBe(true);
+  });
+
+  it("PASSES a verified read tool on a per-account server key", () => {
+    expect(isGatedMs365Tool("mcp__ms-365-lisa-thinksolve-3c4d__list-mail-messages")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365-lisa-goodfellow-1a2b__list-drives")).toBe(false);
+  });
+
+  it("still gates + passes on the bare single-account key (back-compat)", () => {
+    expect(isGatedMs365Tool("mcp__ms-365__delete-onedrive-file")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__list-mail-messages")).toBe(false);
+  });
+
+  it("ignores non-ms-365 tools", () => {
+    expect(isGatedMs365Tool("mcp__gdrive__delete-file")).toBe(false);
+    expect(isGatedMs365Tool("Bash")).toBe(false);
+    // a look-alike that isn't the ms-365 namespace
+    expect(isGatedMs365Tool("mcp__ms-366__delete-file")).toBe(false);
+  });
+
+  it("ms365BareToolName extracts the bare tool after the last __ (single + multi)", () => {
+    expect(ms365BareToolName("mcp__ms-365__send-mail")).toBe("send-mail");
+    expect(ms365BareToolName("mcp__ms-365-lisa-1a2b__send-mail")).toBe("send-mail");
+    expect(ms365BareToolName("Bash")).toBeNull();
+  });
+
+  it("isCalendarEventTool works on per-account keys", () => {
+    expect(isCalendarEventTool("mcp__ms-365-acct-1a2b__update-calendar-event")).toBe(true);
+    expect(isCalendarEventTool("mcp__ms-365-acct-1a2b__list-mail-messages")).toBe(false);
+  });
+});
 
 describe("isGatedMs365Tool — real softeria write names (Bug 1: gate)", () => {
   it("GATES real calendar writes", () => {

--- a/src/cli/ms-365-write-pretool.test.ts
+++ b/src/cli/ms-365-write-pretool.test.ts
@@ -32,7 +32,10 @@ import {
   enrichCalendarPreview,
   loadAllowFrom,
   ms365BareToolName,
+  ms365AccountSlugFromToolName,
 } from "./ms-365-write-pretool.js";
+import { resolveMicrosoftAccountBySlug } from "../ms365/graph-resolve.js";
+import { microsoftAccountSlug } from "../config/microsoft-workspace-acl.js";
 
 describe("multi-account prefix widening (MERGE-BLOCKER — fail-open regression guard)", () => {
   // If the PreToolUse prefix isn't widened from the literal `mcp__ms-365__`
@@ -460,5 +463,64 @@ describe("enrichCalendarPreview — resolves subject + account for a body-only e
     // Still resolves the account (from the token identity) and the after-value.
     expect(e.accountEmail).toBe("ken@example.com");
     expect(e.changes).toEqual([{ field: "location", after: "New" }]);
+  });
+});
+
+describe("Finding 1 — enrichment resolves the CORRECT account on a multi-account agent", () => {
+  it("ms365AccountSlugFromToolName extracts the per-account slug (multi) / null (bare)", () => {
+    expect(ms365AccountSlugFromToolName("mcp__ms-365-lisa-1a2b__update-calendar-event")).toBe(
+      "lisa-1a2b",
+    );
+    // bare single-account key → no slug
+    expect(ms365AccountSlugFromToolName("mcp__ms-365__update-calendar-event")).toBeNull();
+    expect(ms365AccountSlugFromToolName("Bash")).toBeNull();
+  });
+
+  it("resolveMicrosoftAccountBySlug maps a slug back to its account email", async () => {
+    const first = "alice@contoso.com";
+    const second = "bob@fabrikam.com";
+    const secondSlug = microsoftAccountSlug(second);
+    const account = await resolveMicrosoftAccountBySlug(secondSlug, {
+      listAccounts: async () => [first, second],
+    });
+    expect(account).toBe(second);
+    // null slug (single-account back-compat) → no resolution
+    expect(
+      await resolveMicrosoftAccountBySlug(null, {
+        listAccounts: async () => [first, second],
+      }),
+    ).toBeNull();
+  });
+
+  it("enriches the card against the SECOND binding's mailbox, not bindings[0]", async () => {
+    // Simulate the broker: each account has its OWN token/identity. An
+    // account-less load (the pre-fix bug) returns bindings[0] — asserting the
+    // second account below FAILS on the buggy account-less path.
+    const first = "alice@contoso.com";
+    const second = "bob@fabrikam.com";
+    const secondSlug = microsoftAccountSlug(second);
+    const handlesByAccount: Record<string, string> = {
+      [first]: first,
+      [second]: second,
+    };
+    // The tool fires on the SECOND account's per-account server key.
+    const enrichment = await enrichCalendarPreview(
+      `mcp__ms-365-${secondSlug}__update-calendar-event`,
+      { eventId: "AQMkADAw==", body: { content: "<p>new</p>" } },
+      {
+        resolveAccount: async (slug) =>
+          slug === secondSlug ? second : slug === microsoftAccountSlug(first) ? first : null,
+        loadHandle: async (account) => ({
+          access_token: "at",
+          expires_at: Date.now() + 3_600_000,
+          // Back-compat account-less broker branch would return bindings[0]
+          // (== first). We echo the REQUESTED account's identity here.
+          account_email: account ? handlesByAccount[account] : first,
+        }),
+        fetchEvent: async () => ({ subject: "Bob's review", bodyPreview: "old" }),
+      },
+    );
+    expect(enrichment.accountEmail).toBe(second);
+    expect(enrichment.itemDisplayName).toBe("Bob's review");
   });
 });

--- a/src/cli/ms-365-write-pretool.ts
+++ b/src/cli/ms-365-write-pretool.ts
@@ -51,6 +51,7 @@ import { randomBytes } from "node:crypto";
 
 import {
   loadMicrosoftFromAuthBroker,
+  resolveMicrosoftAccountBySlug,
   fetchCalendarEventContext,
   type Ms365AccessHandle,
   type CalendarEventContext,
@@ -93,7 +94,7 @@ const KERNEL_SOCKET =
  * write tool sailed through UN-gated (fail-open). The `(-[a-z0-9-]+)?`
  * group closes that.
  */
-const MS365_TOOL_RE = /^mcp__ms-365(?:-[a-z0-9-]+)?__(.+)$/;
+const MS365_TOOL_RE = /^mcp__ms-365(?:-([a-z0-9-]+))?__(.+)$/;
 
 /**
  * Return the bare softeria tool name if `toolName` is on the MS-365
@@ -101,7 +102,20 @@ const MS365_TOOL_RE = /^mcp__ms-365(?:-[a-z0-9-]+)?__(.+)$/;
  */
 export function ms365BareToolName(toolName: string): string | null {
   const m = MS365_TOOL_RE.exec(toolName);
-  return m ? m[1] : null;
+  return m ? m[2] : null;
+}
+
+/**
+ * Return the per-account MCP-key slug if `toolName` is on a MULTI-account
+ * MS-365 server key (`mcp__ms-365-<slug>__<tool>` → `<slug>`), else null
+ * (bare single-account key `mcp__ms-365__<tool>`, or not our surface).
+ *
+ * The slug is what threads the correct account through the enrichment path
+ * on a multi-account agent (review 2026-07-17, Finding 1).
+ */
+export function ms365AccountSlugFromToolName(toolName: string): string | null {
+  const m = MS365_TOOL_RE.exec(toolName);
+  return m && m[1] ? m[1] : null;
 }
 
 /**
@@ -500,7 +514,19 @@ export function buildCalendarChanges(
 }
 
 export interface EnrichCalendarDeps {
-  loadHandle?: () => Promise<Ms365AccessHandle | null>;
+  /**
+   * Load the Graph access handle for a specific account. The `account`
+   * argument is the email resolved from the tool-name slug — threading it
+   * is what makes the card enrich against the RIGHT mailbox on a
+   * multi-account agent (Finding 1). `undefined` → single-account
+   * back-compat (broker derives the sole account from config).
+   */
+  loadHandle?: (account?: string) => Promise<Ms365AccessHandle | null>;
+  /**
+   * Resolve the per-account slug (from the tool name) back to an account
+   * email. Injectable for tests; defaults to the broker inventory match.
+   */
+  resolveAccount?: (slug: string | null) => Promise<string | null>;
   fetchEvent?: (args: {
     accessToken: string;
     eventId: string;
@@ -519,15 +545,36 @@ export async function enrichCalendarPreview(
   deps: EnrichCalendarDeps = {},
 ): Promise<Ms365CalendarEnrichment> {
   if (!isCalendarEventTool(toolName)) return {};
-  const loadHandle = deps.loadHandle ?? (() => loadMicrosoftFromAuthBroker());
+  const loadHandle =
+    deps.loadHandle ??
+    ((account?: string) =>
+      loadMicrosoftFromAuthBroker(
+        account !== undefined ? { account } : {},
+      ));
+  const resolveAccount =
+    deps.resolveAccount ??
+    ((slug: string | null) => resolveMicrosoftAccountBySlug(slug));
   const fetchEvent =
     deps.fetchEvent ??
     ((a: { accessToken: string; eventId: string }) =>
       fetchCalendarEventContext(a));
 
+  // Multi-account agents key each binding as `mcp__ms-365-<slug>__*`. Resolve
+  // the slug back to the account email so the broker returns THAT mailbox's
+  // token — not the account-less back-compat `bindings[0]` (Finding 1). On a
+  // single-account (bare) key the slug is null → account stays undefined and
+  // the broker derives the sole configured account.
+  const slug = ms365AccountSlugFromToolName(toolName);
+  let account: string | undefined;
+  try {
+    account = (await resolveAccount(slug)) ?? undefined;
+  } catch {
+    account = undefined;
+  }
+
   let handle: Ms365AccessHandle | null;
   try {
-    handle = await loadHandle();
+    handle = await loadHandle(account);
   } catch {
     return { resolveAttemptedButFailed: true };
   }

--- a/src/cli/ms-365-write-pretool.ts
+++ b/src/cli/ms-365-write-pretool.ts
@@ -82,7 +82,27 @@ const GATEWAY_SOCKET =
 const KERNEL_SOCKET =
   process.env.SWITCHROOM_KERNEL_SOCKET ?? "/run/switchroom/kernel/sock";
 
-const TOOL_PREFIX = "mcp__ms-365__";
+/**
+ * Multi-account-aware MS-365 tool-name matcher. Matches BOTH the bare
+ * single-account server key (`mcp__ms-365__<tool>`) AND the per-account
+ * multi-account keys (`mcp__ms-365-<slug>__<tool>`), capturing the bare
+ * softeria tool name after the LAST `__`.
+ *
+ * MERGE-BLOCKER (multi-account RFC §2.5): before this, the gate keyed off
+ * the literal `mcp__ms-365__` prefix, so every `mcp__ms-365-<slug>__*`
+ * write tool sailed through UN-gated (fail-open). The `(-[a-z0-9-]+)?`
+ * group closes that.
+ */
+const MS365_TOOL_RE = /^mcp__ms-365(?:-[a-z0-9-]+)?__(.+)$/;
+
+/**
+ * Return the bare softeria tool name if `toolName` is on the MS-365
+ * surface (single OR multi-account server key), else null.
+ */
+export function ms365BareToolName(toolName: string): string | null {
+  const m = MS365_TOOL_RE.exec(toolName);
+  return m ? m[1] : null;
+}
 
 /**
  * Gated softeria write tools — AUTHORITATIVE names.
@@ -240,8 +260,9 @@ export const KNOWN_SAFE_MS365_READ_TOOLS = new Set<string>([
  *     unrecognized / renamed tool) → true (gate).
  */
 export function isGatedMs365Tool(toolName: string): boolean {
-  if (!toolName.startsWith(TOOL_PREFIX)) return false;
-  const bare = toolName.slice(TOOL_PREFIX.length);
+  const bare = ms365BareToolName(toolName);
+  // Not an MS-365 tool (single or multi-account) → not our surface.
+  if (bare === null) return false;
   // Degenerate prefix-only name — not a real tool invocation.
   if (bare.length === 0) return false;
   // Verified read-only tools pass through without a card.
@@ -367,8 +388,8 @@ export interface Ms365CalendarEnrichment {
  * a single event id are excluded — nothing to resolve.)
  */
 export function isCalendarEventTool(toolName: string): boolean {
-  if (!toolName.startsWith(TOOL_PREFIX)) return false;
-  const bare = toolName.slice(TOOL_PREFIX.length);
+  const bare = ms365BareToolName(toolName);
+  if (bare === null) return false;
   return bare.includes("calendar-event");
 }
 

--- a/src/config/microsoft-multi-account.test.ts
+++ b/src/config/microsoft-multi-account.test.ts
@@ -93,6 +93,28 @@ describe("AgentMicrosoftWorkspaceConfigSchema — reject forms", () => {
     });
     expect(r.success).toBe(false);
   });
+
+  it("Finding 4 — rejects tool tokens with regex metacharacters (singular + plural)", () => {
+    // An unescaped metacharacter would reach softeria's --enabled-tools regex
+    // and can throw on `new RegExp(...)`, crashing the launcher into a restart
+    // loop. The schema must reject it at load time.
+    for (const bad of ["send-mail|(", "mail.*", "cal[endar", "back\\slash"]) {
+      const singular = AgentMicrosoftWorkspaceConfigSchema.safeParse({
+        account: "a@outlook.com",
+        tools: [bad],
+      });
+      expect(singular.success).toBe(false);
+      const plural = AgentMicrosoftWorkspaceConfigSchema.safeParse({
+        accounts: [{ account: "a@outlook.com", tools: [bad] }],
+      });
+      expect(plural.success).toBe(false);
+    }
+    // Legitimate lowercase kebab-case tokens still pass.
+    const ok = AgentMicrosoftWorkspaceConfigSchema.safeParse({
+      accounts: [{ account: "a@outlook.com", tools: ["mail", "calendar", "send-mail"] }],
+    });
+    expect(ok.success).toBe(true);
+  });
 });
 
 describe("normalizeMicrosoftBindings — the drift guard", () => {

--- a/src/config/microsoft-multi-account.test.ts
+++ b/src/config/microsoft-multi-account.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Multi-account-per-agent Microsoft 365 — schema + normalizer + slug tests.
+ *
+ * Covers the additive, backward-compatible schema (singular `account` XOR
+ * plural `accounts[]`), the shared `normalizeMicrosoftBindings` drift guard,
+ * and the deterministic slug/key derivation. See
+ * reference/rfcs/microsoft-multi-account-per-agent.md §2.1, §3.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { AgentMicrosoftWorkspaceConfigSchema, SwitchroomConfigSchema } from "./schema.js";
+import {
+  normalizeMicrosoftBindings,
+  microsoftAccountSlug,
+  ms365McpKeyForBinding,
+  isMultiAccount,
+  bindingsForAgent,
+} from "./microsoft-workspace-acl.js";
+
+describe("AgentMicrosoftWorkspaceConfigSchema — accept forms", () => {
+  it("accepts the singular `account` form (back-compat)", () => {
+    const r = AgentMicrosoftWorkspaceConfigSchema.safeParse({
+      account: "Lisa@Outlook.com",
+      org_mode: true,
+    });
+    expect(r.success).toBe(true);
+    // normalized to lowercase
+    expect(r.success && r.data?.account).toBe("lisa@outlook.com");
+  });
+
+  it("accepts singular `account` with block-level `tools`", () => {
+    const r = AgentMicrosoftWorkspaceConfigSchema.safeParse({
+      account: "lisa@outlook.com",
+      tools: ["list-drives", "get-drive-item"],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts the plural `accounts[]` form with per-binding tools", () => {
+    const r = AgentMicrosoftWorkspaceConfigSchema.safeParse({
+      accounts: [
+        { account: "alice@example.com", tools: ["list-drives"] },
+        { account: "bob@example.com", tools: ["list-mail-messages"], org_mode: true },
+      ],
+    });
+    expect(r.success).toBe(true);
+    expect(r.success && r.data?.accounts?.[0].account).toBe("alice@example.com");
+  });
+});
+
+describe("AgentMicrosoftWorkspaceConfigSchema — reject forms", () => {
+  it("rejects BOTH singular `account` and plural `accounts` present", () => {
+    const r = AgentMicrosoftWorkspaceConfigSchema.safeParse({
+      account: "lisa@outlook.com",
+      accounts: [{ account: "other@outlook.com" }],
+    });
+    expect(r.success).toBe(false);
+    expect(!r.success && r.error.issues.some((i) => /not both/.test(i.message))).toBe(true);
+  });
+
+  it("rejects a duplicate account inside `accounts[]`", () => {
+    const r = AgentMicrosoftWorkspaceConfigSchema.safeParse({
+      accounts: [
+        { account: "dupe@outlook.com" },
+        { account: "Dupe@Outlook.com" }, // same after normalize
+      ],
+    });
+    expect(r.success).toBe(false);
+    expect(!r.success && r.error.issues.some((i) => /duplicate account/.test(i.message))).toBe(true);
+  });
+
+  it("rejects block-level `tools` together with `accounts`", () => {
+    const r = AgentMicrosoftWorkspaceConfigSchema.safeParse({
+      tools: ["list-drives"],
+      accounts: [{ account: "a@outlook.com" }],
+    });
+    expect(r.success).toBe(false);
+    expect(
+      !r.success && r.error.issues.some((i) => /block-level `tools`/.test(i.message)),
+    ).toBe(true);
+  });
+
+  it("rejects empty `accounts: []`", () => {
+    const r = AgentMicrosoftWorkspaceConfigSchema.safeParse({ accounts: [] });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects empty `tools: []`", () => {
+    const r = AgentMicrosoftWorkspaceConfigSchema.safeParse({
+      account: "a@outlook.com",
+      tools: [],
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("normalizeMicrosoftBindings — the drift guard", () => {
+  it("maps the singular form to a one-element list identical to explicit plural", () => {
+    const singular = normalizeMicrosoftBindings({
+      account: "lisa@outlook.com",
+      tools: ["list-drives"],
+      org_mode: true,
+    });
+    const plural = normalizeMicrosoftBindings({
+      accounts: [{ account: "lisa@outlook.com", tools: ["list-drives"], org_mode: true }],
+    });
+    expect(singular).toEqual(plural);
+    expect(singular).toEqual([
+      { account: "lisa@outlook.com", tools: ["list-drives"], org_mode: true },
+    ]);
+  });
+
+  it("lowercases the account and returns [] for an empty block", () => {
+    expect(normalizeMicrosoftBindings({ account: "A@B.com" })[0].account).toBe("a@b.com");
+    expect(normalizeMicrosoftBindings(undefined)).toEqual([]);
+    expect(normalizeMicrosoftBindings({})).toEqual([]);
+  });
+});
+
+describe("microsoftAccountSlug + ms365McpKeyForBinding", () => {
+  it("produces a stable, [a-z0-9-] slug", () => {
+    const slug = microsoftAccountSlug("Alice@Example.com");
+    expect(slug).toMatch(/^[a-z0-9-]+$/);
+    expect(slug).toBe(microsoftAccountSlug("alice@example.com"));
+  });
+
+  it("does NOT collide for two emails sharing a local-part", () => {
+    expect(microsoftAccountSlug("lisa@a.com")).not.toBe(microsoftAccountSlug("lisa@b.com"));
+  });
+
+  it("keeps the bare `ms-365` key for single-account and `ms-365-<slug>` for multi", () => {
+    const single = { account: "lisa@outlook.com" };
+    expect(isMultiAccount(single)).toBe(false);
+    expect(ms365McpKeyForBinding(single, "lisa@outlook.com")).toBe("ms-365");
+
+    const multi = {
+      accounts: [{ account: "a@x.com" }, { account: "b@y.com" }],
+    };
+    expect(isMultiAccount(multi)).toBe(true);
+    expect(ms365McpKeyForBinding(multi, "a@x.com")).toBe(`ms-365-${microsoftAccountSlug("a@x.com")}`);
+  });
+});
+
+describe("SwitchroomConfigSchema — two-part binding validation (plural)", () => {
+  const base = {
+    switchroom: { version: 1 },
+    telegram: { bot_token: "x", forum_chat_id: "1" },
+  };
+
+  it("accepts a plural config where every bound account enables the agent", () => {
+    const r = SwitchroomConfigSchema.safeParse({
+      ...base,
+      agents: {
+        marko: {
+          topic_name: "Marko",
+          microsoft_workspace: {
+            accounts: [
+              { account: "alice@example.com", tools: ["list-drives"] },
+              { account: "bob@example.com", tools: ["list-mail-messages"] },
+            ],
+          },
+        },
+      },
+      microsoft_accounts: {
+        "alice@example.com": { enabled_for: ["marko"] },
+        "bob@example.com": { enabled_for: ["marko"] },
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects at load time when a bound account omits the agent from enabled_for[]", () => {
+    const r = SwitchroomConfigSchema.safeParse({
+      ...base,
+      agents: {
+        marko: {
+          topic_name: "Marko",
+          microsoft_workspace: {
+            accounts: [
+              { account: "alice@example.com" },
+              { account: "bob@example.com" },
+            ],
+          },
+        },
+      },
+      microsoft_accounts: {
+        "alice@example.com": { enabled_for: ["marko"] },
+        "bob@example.com": { enabled_for: ["clerk"] }, // NOT marko
+      },
+    });
+    expect(r.success).toBe(false);
+    expect(
+      !r.success &&
+        r.error.issues.some(
+          (i) => /binds Microsoft account 'bob@example.com'/.test(i.message),
+        ),
+    ).toBe(true);
+  });
+});
+
+describe("bindingsForAgent — twin-key gate applied per account", () => {
+  it("returns only bindings whose account lists the agent in enabled_for[]", () => {
+    const mw = {
+      accounts: [{ account: "a@x.com" }, { account: "b@y.com" }],
+    };
+    const microsoftAccounts = {
+      "a@x.com": { enabled_for: ["marko"] },
+      "b@y.com": { enabled_for: ["someone-else"] },
+    };
+    const out = bindingsForAgent("marko", mw, microsoftAccounts);
+    expect(out.map((b) => b.account)).toEqual(["a@x.com"]);
+  });
+});

--- a/src/config/microsoft-workspace-acl.ts
+++ b/src/config/microsoft-workspace-acl.ts
@@ -11,6 +11,110 @@
 import type { SwitchroomConfig } from "./schema.js";
 
 /**
+ * The normalized shape of ONE Microsoft account binding, produced by
+ * `normalizeMicrosoftBindings`. Both the singular `account` form and the
+ * plural `accounts[]` form collapse to a list of these so every consumer
+ * (broker, scaffold, launcher, ACL) has a single representation and the
+ * two config forms can never drift.
+ */
+export interface MicrosoftBinding {
+  account: string;
+  tools?: string[];
+  org_mode?: boolean;
+}
+
+/** The raw `microsoft_workspace` block, singular OR plural form. */
+export interface MicrosoftWorkspaceLike {
+  account?: string;
+  tools?: string[];
+  org_mode?: boolean;
+  accounts?: Array<{ account: string; tools?: string[]; org_mode?: boolean }>;
+}
+
+/**
+ * Collapse a `microsoft_workspace` block (singular `account` OR plural
+ * `accounts[]`) into a single list of bindings. The singular form maps to
+ * a one-element list `[{ account, tools?, org_mode? }]` so downstream code
+ * has exactly one code path. Returns `[]` when the block is absent or
+ * binds no account.
+ *
+ * This is THE shared normalizer — every consumer calls it so the singular
+ * and plural forms can never drift.
+ */
+export function normalizeMicrosoftBindings(
+  mw: MicrosoftWorkspaceLike | undefined,
+): MicrosoftBinding[] {
+  if (!mw) return [];
+  if (mw.accounts !== undefined) {
+    return mw.accounts
+      .filter((b) => b && typeof b.account === "string" && b.account.length > 0)
+      .map((b) => ({
+        account: b.account.trim().toLowerCase(),
+        tools: b.tools,
+        org_mode: b.org_mode,
+      }));
+  }
+  if (typeof mw.account === "string" && mw.account.length > 0) {
+    return [
+      {
+        account: mw.account.trim().toLowerCase(),
+        tools: mw.tools,
+        org_mode: mw.org_mode,
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Whether an agent's `microsoft_workspace` binds more than one account
+ * (i.e. uses the plural multi-account form with 2+ accounts). Single or
+ * zero bindings keep the back-compat bare `ms-365` MCP key.
+ */
+export function isMultiAccount(mw: MicrosoftWorkspaceLike | undefined): boolean {
+  return normalizeMicrosoftBindings(mw).length > 1;
+}
+
+/**
+ * Deterministic short, filesystem/MCP-key-safe slug for a Microsoft
+ * account email. `<local-part sanitized to [a-z0-9-]>-<4-hex hash>` where
+ * the hash is a stable digest of the FULL lowercased email — so two
+ * different emails that sanitize to the same local part (e.g.
+ * `lisa@a.com` vs `lisa@b.com`) never collide.
+ *
+ * Pure (no crypto import) so this file stays dependency-free and shared
+ * by scaffold, launcher, heartbeat, and the pretool doctor.
+ */
+export function microsoftAccountSlug(account: string): string {
+  const email = account.trim().toLowerCase();
+  const local = email.split("@")[0] ?? email;
+  let base = local.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  if (base.length === 0) base = "acct";
+  if (base.length > 24) base = base.slice(0, 24).replace(/-+$/g, "");
+  // FNV-1a 32-bit over the full email for a stable collision-resistant tail.
+  let h = 0x811c9dc5;
+  for (let i = 0; i < email.length; i++) {
+    h ^= email.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  const hex = (h >>> 0).toString(16).padStart(8, "0").slice(0, 4);
+  return `${base}-${hex}`;
+}
+
+/**
+ * The MCP server key for a binding on an agent. Single-account agents keep
+ * the bare `ms-365` key (back-compat — tools stay `mcp__ms-365__*`).
+ * Multi-account agents get `ms-365-<slug>` per binding.
+ */
+export function ms365McpKeyForBinding(
+  mw: MicrosoftWorkspaceLike | undefined,
+  account: string,
+): string {
+  if (isMultiAccount(mw)) return `ms-365-${microsoftAccountSlug(account)}`;
+  return "ms-365";
+}
+
+/**
  * Shared gate: should agent `<agentName>` receive the `ms-365` MCP
  * entry (and equivalently be served the Microsoft OAuth client
  * credential by the vault-broker)?
@@ -39,6 +143,26 @@ export function shouldEmitMs365Mcp(
   if (!acctEntry) return false;
   const enabledFor = acctEntry.enabled_for ?? [];
   return enabledFor.includes(agentName);
+}
+
+/**
+ * Plural sibling of `shouldEmitMs365Mcp`: the subset of an agent's
+ * Microsoft account bindings that pass the twin-key gate (account listed
+ * in `microsoft_accounts.<account>.enabled_for[]` with this agent). The
+ * scaffold emits exactly one MCP entry per returned binding — a binding
+ * whose ACL is missing produces no entry (same "emit iff enabled"
+ * semantics as the singular path, applied per account).
+ */
+export function bindingsForAgent(
+  agentName: string,
+  mw: MicrosoftWorkspaceLike | undefined,
+  microsoftAccounts:
+    | Record<string, { enabled_for?: string[] } | undefined>
+    | undefined,
+): MicrosoftBinding[] {
+  return normalizeMicrosoftBindings(mw).filter((b) =>
+    shouldEmitMs365Mcp(agentName, b.account, microsoftAccounts),
+  );
 }
 
 /**
@@ -82,8 +206,14 @@ export function isMicrosoftClientCredentialKeyForAgent(
     return false;
   }
 
-  const account = agentConfig.microsoft_workspace?.account;
-  if (!shouldEmitMs365Mcp(agentName, account, config.microsoft_accounts)) {
+  // Grant the client credential iff AT LEAST ONE of the agent's bindings
+  // passes the twin-key gate (singular or plural form via the shared
+  // normalizer). The credential is the same top-level app-reg for every
+  // account, so one passing binding is sufficient.
+  if (
+    bindingsForAgent(agentName, agentConfig.microsoft_workspace, config.microsoft_accounts)
+      .length === 0
+  ) {
     return false;
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2257,6 +2257,30 @@ const MicrosoftAccountEmailSchema = z
   .transform((v) => v.trim().toLowerCase());
 
 /**
+ * A single per-account tool-allowlist token. These are forwarded verbatim
+ * to softeria as `--enabled-tools <tokens joined by |>` and evaluated by
+ * softeria as an UNANCHORED, case-insensitive regex against each tool alias.
+ *
+ * Restricting the token charset to `[a-z0-9-]+` (review 2026-07-17, Finding
+ * 4) is a defense-in-depth guard: an unescaped regex metacharacter in a
+ * token (`(`, `[`, `\`, `*`, …) would otherwise reach softeria's `new
+ * RegExp(...)` and can throw on startup — crashing the launcher child into a
+ * restart loop. Softeria tool aliases are all lowercase kebab-case
+ * (`send-mail`, `list-calendar-events`), so this charset loses no legitimate
+ * matching power while making a malformed-regex crash impossible.
+ */
+const MicrosoftToolTokenSchema = z
+  .string()
+  .min(1)
+  .regex(/^[a-z0-9-]+$/, {
+    message:
+      "microsoft_workspace tools[] tokens are forwarded to softeria's " +
+      "--enabled-tools regex; each must be lowercase kebab-case " +
+      "([a-z0-9-]+, e.g. 'mail', 'calendar', 'send-mail') so an unescaped " +
+      "regex metacharacter can't crash the launcher",
+  });
+
+/**
  * A single Microsoft account binding in the plural `accounts[]` form
  * (multi-account-per-agent RFC). Each binding pins one account, an
  * optional per-account tool allowlist (→ softeria `--enabled-tools`),
@@ -2268,7 +2292,7 @@ export const MicrosoftAccountBindingSchema = z.object({
     "`microsoft_accounts:` with this agent in its `enabled_for[]`."
   ),
   tools: z
-    .array(z.string().min(1))
+    .array(MicrosoftToolTokenSchema)
     .min(1)
     .optional()
     .describe(
@@ -2293,7 +2317,7 @@ export const AgentMicrosoftWorkspaceConfigSchema = z
       "also normalized). Mutually exclusive with `accounts` (plural)."
     ),
     tools: z
-      .array(z.string().min(1))
+      .array(MicrosoftToolTokenSchema)
       .min(1)
       .optional()
       .describe(
@@ -4332,6 +4356,18 @@ export const SwitchroomConfigSchema = z.object({
   // the broker's FORBIDDEN hint) rather than a silently-missing tool
   // namespace. The singular `account` form keeps its lenient
   // emit-iff-enabled behavior (no hard error) for back-compat.
+  //
+  // DECISION (review 2026-07-17, Finding 3): the fleet-wide hard-fail is
+  // DELIBERATE and asymmetric with the singular form by design. Zod parse is
+  // all-or-nothing — there is no per-agent scoping at this layer — and a
+  // multi-account misconfig is an operator authoring error that should be
+  // caught at `switchroom apply`/load time, not silently drop one agent's
+  // M365 surface (which is much harder to notice than a failed load). The
+  // singular form stays lenient ONLY for back-compat with configs authored
+  // before the twin-key gate existed; new plural authors opt into the strict
+  // gate. Per-agent-scoped degradation (load the rest of the fleet, disable
+  // just the offending agent's M365) is tracked as a follow-up — it needs
+  // loader-level support, not a schema tweak.
   const microsoftAccounts = (cfg as {
     microsoft_accounts?: Record<string, { enabled_for?: string[] } | undefined>;
   }).microsoft_accounts;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2247,25 +2247,60 @@ export const AgentGoogleWorkspaceConfigSchema = z
  * `microsoft_client_id/secret` are not per-agent (one app reg per
  * switchroom install).
  */
+const MicrosoftAccountEmailSchema = z
+  .string()
+  .regex(/^[^@\s:]+@[^@\s:]+\.[^@\s:]+$/, {
+    message:
+      "microsoft_workspace.account must be a Microsoft account email like " +
+      "'alice@outlook.com' or 'alice@contoso.com' (colons not allowed)",
+  })
+  .transform((v) => v.trim().toLowerCase());
+
+/**
+ * A single Microsoft account binding in the plural `accounts[]` form
+ * (multi-account-per-agent RFC). Each binding pins one account, an
+ * optional per-account tool allowlist (→ softeria `--enabled-tools`),
+ * and an optional per-binding org_mode override.
+ */
+export const MicrosoftAccountBindingSchema = z.object({
+  account: MicrosoftAccountEmailSchema.describe(
+    "The Microsoft account this binding uses. Must be a key in top-level " +
+    "`microsoft_accounts:` with this agent in its `enabled_for[]`."
+  ),
+  tools: z
+    .array(z.string().min(1))
+    .min(1)
+    .optional()
+    .describe(
+      "Per-account tool allowlist → softeria `--enabled-tools <regex>` " +
+      "(tokens joined with `|`). Omitted = all tools exposed for this account."
+    ),
+  org_mode: z
+    .boolean()
+    .optional()
+    .describe("Per-binding org_mode override (RFC #1873 §6.4)."),
+});
+
 export const AgentMicrosoftWorkspaceConfigSchema = z
   .object({
-    account: z
-      .string()
-      .regex(/^[^@\s:]+@[^@\s:]+\.[^@\s:]+$/, {
-        message:
-          "microsoft_workspace.account must be a Microsoft account email like " +
-          "'alice@outlook.com' or 'alice@contoso.com' (colons not allowed)",
-      })
-      .transform((v) => v.trim().toLowerCase())
+    account: MicrosoftAccountEmailSchema.optional().describe(
+      "RFC #1873: the Microsoft account this agent uses for the M365 MCP. " +
+      "Must be a key in top-level `microsoft_accounts:` with this agent " +
+      "listed in its `enabled_for[]`. Read by the auth-broker " +
+      "(get-credentials, provider=microsoft) and by the scaffold to " +
+      "decide whether to emit the `ms-365` MCP entry. Normalized to " +
+      "lowercase so it matches the microsoft_accounts key (which is " +
+      "also normalized). Mutually exclusive with `accounts` (plural)."
+    ),
+    tools: z
+      .array(z.string().min(1))
+      .min(1)
       .optional()
       .describe(
-        "RFC #1873: the Microsoft account this agent uses for the M365 MCP. " +
-        "Must be a key in top-level `microsoft_accounts:` with this agent " +
-        "listed in its `enabled_for[]`. Read by the auth-broker " +
-        "(get-credentials, provider=microsoft) and by the scaffold to " +
-        "decide whether to emit the `ms-365` MCP entry. Normalized to " +
-        "lowercase so it matches the microsoft_accounts key (which is " +
-        "also normalized)."
+        "Per-account tool allowlist for the SINGULAR `account` form → " +
+        "softeria `--enabled-tools <regex>`. Omitted = all tools. Only " +
+        "valid with the singular `account`; using it together with the " +
+        "plural `accounts` (which carries per-binding `tools`) is an error."
       ),
     org_mode: z
       .boolean()
@@ -2275,6 +2310,51 @@ export const AgentMicrosoftWorkspaceConfigSchema = z
         "the top-level microsoft_workspace.org_mode for this agent. " +
         "Defaults to top-level value (which defaults to false)."
       ),
+    accounts: z
+      .array(MicrosoftAccountBindingSchema)
+      .min(1)
+      .optional()
+      .describe(
+        "Plural multi-account form: bind MULTIPLE Microsoft accounts to " +
+        "this agent, each with its own tool scope. Mutually exclusive with " +
+        "the singular `account`. Each account gets its own `ms-365-<slug>` " +
+        "MCP server."
+      ),
+  })
+  .superRefine((v, ctx) => {
+    const hasSingular = v.account !== undefined;
+    const hasPlural = v.accounts !== undefined;
+    if (hasSingular && hasPlural) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "microsoft_workspace: use EITHER `account` (singular) OR " +
+          "`accounts` (plural array), not both",
+        path: ["accounts"],
+      });
+    }
+    if (hasPlural && v.tools !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "microsoft_workspace: block-level `tools` applies to the singular " +
+          "`account` only; with `accounts` put `tools` inside each binding",
+        path: ["tools"],
+      });
+    }
+    if (hasPlural) {
+      const seen = new Set<string>();
+      for (const b of v.accounts!) {
+        if (seen.has(b.account)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `microsoft_workspace: duplicate account '${b.account}' in accounts[]`,
+            path: ["accounts"],
+          });
+        }
+        seen.add(b.account);
+      }
+    }
   })
   .optional();
 
@@ -4243,6 +4323,38 @@ export const SwitchroomConfigSchema = z.object({
   }
   for (const [name, a] of Object.entries(cfg.agents ?? {})) {
     checkServes((a as { serves?: string[] }).serves, ["agents", name, "serves"]);
+  }
+
+  // Multi-account-per-agent: for the PLURAL `microsoft_workspace.accounts`
+  // form, EVERY bound account must list this agent in
+  // `microsoft_accounts.<account>.enabled_for[]` — the twin-key gate,
+  // applied per account. A missing pair is a loud load-time error (mirrors
+  // the broker's FORBIDDEN hint) rather than a silently-missing tool
+  // namespace. The singular `account` form keeps its lenient
+  // emit-iff-enabled behavior (no hard error) for back-compat.
+  const microsoftAccounts = (cfg as {
+    microsoft_accounts?: Record<string, { enabled_for?: string[] } | undefined>;
+  }).microsoft_accounts;
+  for (const [name, a] of Object.entries(cfg.agents ?? {})) {
+    const mw = (a as { microsoft_workspace?: { accounts?: Array<{ account?: string }> } })
+      .microsoft_workspace;
+    const accounts = mw?.accounts;
+    if (!accounts) continue;
+    accounts.forEach((b, i) => {
+      const acct = b?.account?.trim().toLowerCase();
+      if (!acct) return;
+      const enabledFor = microsoftAccounts?.[acct]?.enabled_for ?? [];
+      if (!enabledFor.includes(name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            `agent '${name}' binds Microsoft account '${acct}' but is not in ` +
+            `microsoft_accounts['${acct}'].enabled_for[] — operator must run ` +
+            `\`switchroom auth microsoft enable ${acct} ${name}\``,
+          path: ["agents", name, "microsoft_workspace", "accounts", i, "account"],
+        });
+      }
+    });
   }
 });
 

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -237,6 +237,23 @@ export interface Ms365McpEntryOptions {
    * resolved choice visible in settings.json.
    */
   orgMode?: boolean;
+  /**
+   * The MCP server key. Single-account agents keep the bare `ms-365`
+   * (back-compat); multi-account agents get `ms-365-<slug>` per binding.
+   * Defaults to `ms-365`.
+   */
+  key?: string;
+  /**
+   * The Microsoft account this entry binds. When set, threaded to the
+   * launcher as `--account <email>` so it fetches THAT account's token
+   * from the broker. Omitted (singular back-compat) → no `--account`.
+   */
+  account?: string;
+  /**
+   * Per-account tool allowlist → softeria `--enabled-tools <regex>`
+   * (tokens joined with `|`). Omitted = all tools for this account.
+   */
+  enabledTools?: string[];
 }
 
 /**
@@ -252,12 +269,17 @@ export function getMs365McpSettingsEntry(
   switchroomCliPath: string,
   options: Ms365McpEntryOptions = {},
 ): { key: string; value: McpServerConfig } {
-  const orgArgs = options.orgMode ? ["--org-mode"] : [];
+  const args: string[] = ["m365-mcp-launcher"];
+  if (options.orgMode) args.push("--org-mode");
+  if (options.account) args.push("--account", options.account);
+  if (options.enabledTools && options.enabledTools.length > 0) {
+    args.push("--enabled-tools", options.enabledTools.join("|"));
+  }
   return {
-    key: "ms-365",
+    key: options.key ?? "ms-365",
     value: {
       command: switchroomCliPath,
-      args: ["m365-mcp-launcher", ...orgArgs],
+      args,
     },
   };
 }

--- a/src/ms365/graph-resolve.ts
+++ b/src/ms365/graph-resolve.ts
@@ -43,6 +43,15 @@ export interface LoadMicrosoftFromAuthBrokerOptions {
   /** Override the broker socket path (tests pass a tmp socket). */
   socketPath?: string;
   /**
+   * The Microsoft account (email) to resolve credentials for. On a
+   * multi-account agent this MUST be threaded so the broker returns the
+   * token for the RIGHT mailbox — otherwise the account-less back-compat
+   * branch returns `bindings[0]`'s token and the card enriches against the
+   * wrong account (review 2026-07-17, Finding 1). Omitted → single-account
+   * back-compat (broker derives the sole account from config).
+   */
+  account?: string;
+  /**
    * If the broker's credentials expire within this many ms, treat them as
    * unusable and return null (caller degrades gracefully). Default 60_000.
    */
@@ -75,7 +84,7 @@ export async function loadMicrosoftFromAuthBroker(
   try {
     result = await withAuthBrokerClient(
       async (client) => {
-        return (await client.getCredentials("microsoft")) as {
+        return (await client.getCredentials("microsoft", options.account)) as {
           account: string;
           credentials: unknown;
           expiresAt?: number;
@@ -114,6 +123,70 @@ export async function loadMicrosoftFromAuthBroker(
     expires_at: expiresAt,
     account_email: creds.microsoftOauth?.accountEmail,
   };
+}
+
+/** Options for {@link resolveMicrosoftAccountBySlug}. */
+export interface ResolveAccountBySlugOptions {
+  /** Override the broker socket path (tests pass a tmp socket). */
+  socketPath?: string;
+  /**
+   * Injectable account inventory (tests). Defaults to the broker's
+   * `list-microsoft-accounts`. Returns candidate account emails.
+   */
+  listAccounts?: () => Promise<string[]>;
+}
+
+/**
+ * Map a per-account MCP-key slug (`ms-365-<slug>` → `<slug>`) back to the
+ * Microsoft account email it was derived from, by recomputing
+ * `microsoftAccountSlug` over the broker's account inventory and matching.
+ *
+ * This is how the write-approval hook threads the CORRECT account on a
+ * multi-account agent: the invoking tool name (`mcp__ms-365-<slug>__*`)
+ * carries the slug, and we resolve it to an email to pass to
+ * `getCredentials("microsoft", account)` (review 2026-07-17, Finding 1).
+ *
+ * Fail-soft: returns `null` when the broker is unreachable, no slug is
+ * given (single-account back-compat), or nothing matches — the caller then
+ * falls back to the account-less broker path. The broker's per-agent ACL
+ * still applies downstream, so a slug that resolves to an account the agent
+ * isn't bound to is rejected there (never a silent cross-account leak).
+ */
+export async function resolveMicrosoftAccountBySlug(
+  slug: string | null | undefined,
+  options: ResolveAccountBySlugOptions = {},
+): Promise<string | null> {
+  if (!slug) return null;
+  const { microsoftAccountSlug } = await import(
+    "../config/microsoft-workspace-acl.js"
+  );
+
+  let accounts: string[];
+  try {
+    if (options.listAccounts) {
+      accounts = await options.listAccounts();
+    } else {
+      const { withAuthBrokerClient } = await import("../auth/broker/client.js");
+      accounts = await withAuthBrokerClient(
+        async (client) => {
+          const data = (await client.listMicrosoftAccounts()) as {
+            accounts?: Array<{ account?: string }>;
+          };
+          return (data.accounts ?? [])
+            .map((a) => a.account)
+            .filter((a): a is string => typeof a === "string");
+        },
+        options.socketPath !== undefined ? { socket: options.socketPath } : undefined,
+      );
+    }
+  } catch {
+    return null;
+  }
+
+  for (const account of accounts) {
+    if (microsoftAccountSlug(account) === slug) return account;
+  }
+  return null;
 }
 
 // ────────────────────────────────────────────────────────────────────────

--- a/tests/scaffold.ms365-multi-shrink.test.ts
+++ b/tests/scaffold.ms365-multi-shrink.test.ts
@@ -1,0 +1,126 @@
+/**
+ * End-to-end shrink retraction for multi-account Microsoft 365 bindings.
+ *
+ * Reproduces the review finding on PR #3295 (item 6): when an agent's
+ * `microsoft_workspace.accounts` shrinks (an account is FULLY removed),
+ * the stale `ms-365-<slug>` key must be dropped from the persisted
+ * settings.json.mcpServers on the next `switchroom apply` (the scaffoldAgent
+ * MERGE path — the one reconcile site that reads + merges existing state
+ * rather than rebuilding it). This test FAILS without the prefix-scoped
+ * namespace retraction at that site.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import { microsoftAccountSlug } from "../src/config/microsoft-workspace-acl.js";
+import type {
+  AgentConfig,
+  SwitchroomConfig,
+  TelegramConfig,
+} from "../src/config/schema.js";
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+const ACCT_A = "alice@example.com";
+const ACCT_B = "bob@example.com";
+const ACCT_C = "carol@example.com";
+const SLUG_A = `ms-365-${microsoftAccountSlug(ACCT_A)}`;
+const SLUG_B = `ms-365-${microsoftAccountSlug(ACCT_B)}`;
+const SLUG_C = `ms-365-${microsoftAccountSlug(ACCT_C)}`;
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(
+  name: string,
+  agentConfig: AgentConfig,
+  microsoftAccounts: Record<string, { enabled_for?: string[] }>,
+): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+    microsoft_accounts: microsoftAccounts,
+  } as unknown as SwitchroomConfig;
+}
+
+function readMcpServers(agentDir: string): Record<string, unknown> {
+  const settings = JSON.parse(
+    readFileSync(join(agentDir, ".claude", "settings.json"), "utf-8"),
+  );
+  return settings.mcpServers ?? {};
+}
+
+describe("scaffoldAgent: multi-account ms-365 shrink retraction (PR #3295 item 6)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-ms365-shrink-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("drops a fully-removed account's ms-365-<slug> from settings.json on re-apply", () => {
+    const name = "marko";
+    const accounts = {
+      [ACCT_A]: { enabled_for: [name] },
+      [ACCT_B]: { enabled_for: [name] },
+      [ACCT_C]: { enabled_for: [name] },
+    };
+
+    // First apply: bind THREE accounts → three per-slug keys land.
+    const threeAccountCfg = makeAgentConfig({
+      microsoft_workspace: {
+        accounts: [{ account: ACCT_A }, { account: ACCT_B }, { account: ACCT_C }],
+      },
+    } as Partial<AgentConfig>);
+    const first = scaffoldAgent(
+      name,
+      threeAccountCfg,
+      tmpDir,
+      telegramConfig,
+      makeSwitchroomConfig(name, threeAccountCfg, accounts),
+    );
+    const afterFirst = readMcpServers(first.agentDir);
+    expect(afterFirst[SLUG_A]).toBeDefined();
+    expect(afterFirst[SLUG_B]).toBeDefined();
+    expect(afterFirst[SLUG_C]).toBeDefined();
+
+    // Second apply: account B removed from the config (A + C remain, still
+    // multi-account so survivors keep their per-slug keys). settings.json
+    // already exists → scaffoldAgent takes the MERGE path (writeIfMissing
+    // skips the template). The stale SLUG_B must be retracted.
+    const twoAccountCfg = makeAgentConfig({
+      microsoft_workspace: { accounts: [{ account: ACCT_A }, { account: ACCT_C }] },
+    } as Partial<AgentConfig>);
+    const second = scaffoldAgent(
+      name,
+      twoAccountCfg,
+      tmpDir,
+      telegramConfig,
+      makeSwitchroomConfig(name, twoAccountCfg, accounts),
+    );
+    const afterSecond = readMcpServers(second.agentDir);
+    expect(afterSecond[SLUG_A]).toBeDefined(); // surviving account kept
+    expect(afterSecond[SLUG_C]).toBeDefined(); // surviving account kept
+    expect(afterSecond[SLUG_B]).toBeUndefined(); // FULLY-REMOVED account gone
+  });
+});


### PR DESCRIPTION
## Summary

Lets one agent bind **multiple** Microsoft 365 accounts, each tool-scoped. Marko can bind `alice@example.com` (OneDrive/storage tools) **and** `bob@example.com` (read-only mail tools) simultaneously. Implements `reference/rfcs/microsoft-multi-account-per-agent.md`.

### Schema (additive, backward-compatible)
- Keeps singular `microsoft_workspace.account` valid; adds plural `microsoft_workspace.accounts: [{account, tools?, org_mode?}]`.
- `superRefine` enforces singular **XOR** plural (both → error), rejects a duplicate account in the array, and rejects block-level `tools` alongside `accounts`.
- One shared `normalizeMicrosoftBindings()` maps the singular form to a one-element binding list, so downstream code has a single representation and the two forms can't drift.
- Top-level `superRefine` adds a per-account **twin-key load-time error** for the plural form (mirrors the broker's FORBIDDEN hint).

### Launcher = N processes
- One `m365-mcp-launcher` + softeria child per account. Distinct MCP keys `ms-365-<slug>` → tools surface as `mcp__ms-365-<slug>__*`. **Single-account agents keep the bare `ms-365` key** byte-identically (back-compat).
- Slug = sanitized local-part + FNV-1a hash tail of the full email (no collisions for same local-part / different domain; scaffold also fails loud on key collision).
- Per-account tool scoping threads softeria's **`--enabled-tools <regex>`** (tokens joined with `|`). Per-account OAuth token threaded via `getCredentials("microsoft", account)`.
- Per-slug heartbeat paths so N launchers don't clobber each other; the doctor probe reads all of them.

### Broker
- Optional `account?` on `GetCredentialsRequestSchema`; each requested account must be one of the agent's bindings **AND** have the agent in `microsoft_accounts.<account>.enabled_for[]` (existing twin-key gate, per account). Mismatch → existing `ACCOUNT_NOT_FOUND` / `FORBIDDEN`.

### Registry
- Plural resolver (`resolveMs365McpEntries`) + multi-key retraction (`ms365OwnedKeys`) wired at all reconcile sites so stale `ms-365-<slug>` entries don't leak when an agent's bindings shrink.

### MERGE-BLOCKER — PreToolUse write-gate widening
- Widened `src/cli/ms-365-write-pretool.ts` from the literal `mcp__ms-365__` prefix to `mcp__ms-365(-[a-z0-9-]+)?__` so multi-account write tools still hit the approval card. Test fails if the prefix isn't widened.

## `--enabled-tools` verification
Verified against the pinned `@softeria/ms-365-mcp-server@0.113.0`: `--enabled-tools <pattern>` exists (`dist/cli.js`), is a **case-insensitive regex matched against each tool alias** (`dist/graph-tools.js`: `enabledToolsRegex.test(tool.alias)`). Flag name is exactly as assumed. (Env var is `ENABLED_TOOLS`, not the RFC-guessed `MS365_MCP_ENABLED_TOOLS` — we use the CLI flag, so this is moot.)

## Known v1 limitation
Tool scope is enforced by **tool omission** (softeria `--enabled-tools`) + the PreToolUse write-gate — **not** token-level least-privilege. The OAuth token is still broad (`Mail.ReadWrite` / `Files.ReadWrite.All`, fixed at consent). A read-only mail binding is read-only because softeria isn't given the write tools and the gate blocks writes, not because the token can't write. True per-account scope-at-consent (re-consent flow) is deferred.

## Tests
Singular-path suites stay green (`microsoft-workspace-acl`, `m365-mcp-launcher`, `agent-workspace-account`, `server-microsoft`, `doctor-microsoft`). New: schema accept/reject; normalize drift guard; slug uniqueness; scaffold N-entries + back-compat + retraction; per-account `--enabled-tools`; launcher per-slug heartbeat isolation + right token; broker mismatch codes; PreToolUse gates `mcp__ms-365-<slug>__` writes. `npm run lint` (incl. tsc) clean.

Do **not** merge — for adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)