### PR TITLE
fix(telegram): turn-flush suppression can no longer eat an answer (S1) + S2/S4 sharp edges

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2399,6 +2399,13 @@ async function deliverAnswer(args: {
   text: string
   turnId: string
   cardMessageId: number | null
+  /** S4 (fable red-team 2026-07-17) — the inbound message this turn answers
+   *  (`turn.sourceMessageId`). When present, the FIRST chunk is sent as a
+   *  native quote-reply so the flushed answer anchors to the user's question,
+   *  matching `executeReply`'s default. `allow_sending_without_reply` keeps
+   *  the send alive if the user deleted their message. Null for synthesized
+   *  turns (cron/handback) — those send bare, as before. */
+  replyToMessageId: number | null
 }): Promise<{ sentIds: number[]; chunkCount: number; delivered: boolean; exhausted: boolean }> {
   const { chatId, turnId } = args
   // Inject visible blank-line spacers into `\n\n` gaps, then split — exactly as
@@ -2447,8 +2454,17 @@ async function deliverAnswer(args: {
   // landed message id(s) (a length-resplit chunk may land >1); throws on an
   // unrecoverable send failure so the retry orchestrator can resume.
   let liveThreadId = args.threadId
-  const sendChunk = async (_chunkIndex: number, text: string): Promise<number[]> => {
+  const sendChunk = async (chunkIndex: number, text: string): Promise<number[]> => {
     const chunkIds: number[] = []
+    // S4 — quote-anchor the FIRST chunk only (chunkIndex is the OVERALL chunk
+    // index across the retry orchestrator; each sendReplyChunks call here
+    // carries exactly one chunk, so the inner index is always 0). Mirrors
+    // executeReply's first-chunk-only default. The ledger resumes retries at
+    // the first UNSENT chunk, so chunk 0 keeps its anchor across retries.
+    const anchor =
+      chunkIndex === 0 && args.replyToMessageId != null
+        ? { reply_parameters: { message_id: args.replyToMessageId, allow_sending_without_reply: true } }
+        : {}
     const res = await sendReplyChunks(deps, {
       chatId,
       chunks: [text],
@@ -2458,6 +2474,7 @@ async function deliverAnswer(args: {
       previewMessageId: null,
       sentIds: chunkIds,
       buildSendOpts: (_i, _isLast, tid) => ({
+        ...anchor,
         ...(tid != null ? { message_thread_id: tid } : {}),
         link_preview_options: { is_disabled: true },
       }),
@@ -18097,6 +18114,16 @@ function handleSessionEvent(ev: SessionEvent): void {
       // — read `turn` once, don't re-read currentTurn after any await.
       const turn = currentTurn
       if (turn == null) return
+      // S2 fix (fable red-team 2026-07-17) — a thinking block means the model
+      // is still working, not quiescent. Without this, "prose → >1s thinking
+      // pause → trailing NO_REPLY" let the answer-ready quiescence timer fire
+      // mid-pause and deliver a turn the model was about to mark silent
+      // (#2053 in miniature). Re-arm (not just clear): `reset()` re-verifies
+      // via `decideTurnFlush` and pushes the debounce out by a fresh window,
+      // so the trailing sentinel gets to land before any fire; if no further
+      // text arrives, the flush still fires one window after the LAST
+      // thinking event — the fast path is deferred, never lost.
+      resetAnswerReadyFlushTimeout()
       const ctrl = activeStatusReactions.get(statusKey(turn.sessionChatId, turn.sessionThreadId))
       if (ctrl) ctrl.setThinking()
       return
@@ -19208,10 +19235,28 @@ function handleSessionEvent(ev: SessionEvent): void {
           await new Promise<void>(resolve => setTimeout(resolve, 500))
           if (HISTORY_ENABLED) {
             try {
-              const { getRecentOutboundCount } = await import('../history.js')
-              const recentCount = getRecentOutboundCount(backstopChatId, 2)
-              if (recentCount > 0) {
-                process.stderr.write(`telegram gateway: turn-flush suppressed — reply tool sent ${recentCount} message(s) within 2s\n`)
+              // S1 fix (fable red-team 2026-07-17) — the old predicate here,
+              // `getRecentOutboundCount(chatId, 2) > 0`, counted ANY assistant
+              // row in the WHOLE chat: a worker `progress_update`, a command
+              // ack / restart notice, or a reply in a DIFFERENT forum topic all
+              // suppressed the flush and (worse) CLOSED the obligation below —
+              // silently dropping the user's real answer. The scoped predicate
+              // (same thread, length ≥ min(answerLength, 200)) lives in
+              // `turn-flush-suppression.ts`; `hasOutboundDeliveredSince` is the
+              // durable oracle whose thread/length semantics history tests pin.
+              const { hasOutboundDeliveredSince } = await import('../history.js')
+              const { shouldSuppressTurnFlush } = await import('./turn-flush-suppression.js')
+              const suppress = shouldSuppressTurnFlush(
+                { hasSubstantiveOutbound: hasOutboundDeliveredSince },
+                {
+                  chatId: backstopChatId,
+                  threadId: backstopThreadId ?? null,
+                  answerLength: capturedText.length,
+                  nowMs: Date.now(),
+                },
+              )
+              if (suppress) {
+                process.stderr.write(`telegram gateway: turn-flush suppressed — a substantive same-thread outbound landed within 2s\n`)
                 // Do NOT finalize the status reaction here. As of #1713
                 // the reaction is only finalized by the `turn_end` IPC
                 // handler — mid-turn delivery proofs (local history,
@@ -19223,19 +19268,23 @@ function handleSessionEvent(ev: SessionEvent): void {
                 // here re-fired on an already-cleared key WITHOUT `endingTurn`,
                 // emitting an inconsistent shadow trace. Removed.
                 //
-                // PR B — the reply tool already delivered this turn's answer, so
-                // the flush was legitimately suppressed. Emit the deferred record
-                // as 'suppressed' (→ `complete`, since the reply path set
-                // finalAnswerDelivered). Not a failure.
+                // PR B — a substantive same-thread outbound just delivered this
+                // turn's answer, so the flush was legitimately suppressed. Emit
+                // the deferred record as 'suppressed'. Not a failure.
                 if (backstopTurnEndedAt != null) {
                   turn.deliveryOutcome = 'suppressed'
-                  // #3276 finding 1 — obligation close was DEFERRED out of
-                  // endCurrentTurnAtomic. The reply tool already delivered this
-                  // turn's answer (recentCount>0), so resolve it as satisfied
-                  // here (idempotent with the reply path's own close). Without
-                  // this the deferred obligation would linger OPEN and spuriously
-                  // re-present a turn that WAS answered.
-                  if (OBLIGATION_LEDGER_ENABLED) obligationLedger.close(turn.turnId)
+                  // S1 fix — do NOT close the obligation here. When the recent
+                  // outbound is genuinely this turn's answer (a raced reply /
+                  // stream materialization), the reply path closes its own
+                  // obligation idempotently; when the suppression is a false
+                  // positive (a long same-thread non-answer inside the 2s
+                  // window — the residual the scoped predicate can't
+                  // discriminate), closing here made the drop PERMANENT.
+                  // Leaving it open lets the obligation sweep arbitrate: it
+                  // stands down silently if a substantive outbound answered
+                  // the user, and re-presents otherwise. `noteTurnEnded` arms
+                  // the liveness floor exactly as the send-failed path does.
+                  if (OBLIGATION_LEDGER_ENABLED) obligationLedger.noteTurnEnded(turn.turnId, Date.now())
                   emitTurnRecord(turn, backstopTurnEndedAt)
                 }
                 return
@@ -19283,6 +19332,9 @@ function handleSessionEvent(ev: SessionEvent): void {
               text: capturedText,
               turnId: turn.turnId,
               cardMessageId: backstopCardMessageId,
+              // S4 — anchor the flushed answer to the inbound it answers
+              // (null for synthesized turns, which send bare as before).
+              replyToMessageId: turn.sourceMessageId,
             })
             sentIds = delivery.sentIds
             chunkCount = delivery.chunkCount

--- a/telegram-plugin/gateway/turn-flush-suppression.ts
+++ b/telegram-plugin/gateway/turn-flush-suppression.ts
@@ -1,0 +1,82 @@
+/**
+ * Turn-flush pre-delivery suppression decision (S1 fix, fable red-team
+ * 2026-07-17 — `~klanker/work/fable-redteam-delivery-20260717/REDTEAM.md`).
+ *
+ * Before the turn-flush backstop posts the captured terminal answer, it asks:
+ * "did a reply already land for this turn in the last ~2s?" (a race guard for
+ * a reply whose IPC signal hadn't registered when `decideTurnFlush` ran, and
+ * for answer-stream materializations that already delivered the answer text).
+ *
+ * The OLD predicate — `getRecentOutboundCount(chatId, 2) > 0` — counted ANY
+ * assistant row in the WHOLE chat: a background worker's `progress_update`, a
+ * command ack / restart notice, or a reply in a DIFFERENT forum topic all
+ * suppressed the flush, and the branch then CLOSED the delivery obligation —
+ * the user's real answer was dropped with no re-present. This module scopes
+ * the predicate to a SUBSTANTIVE (≥ `FINAL_ANSWER_MIN_CHARS`) outbound in the
+ * SAME thread, via the injected `hasSubstantiveOutbound` (the gateway wires
+ * `hasOutboundDeliveredSince`, whose thread/length semantics are pinned by
+ * `history.test.ts`).
+ *
+ * Residual (documented, accepted): a ≥200-char same-thread non-answer outbound
+ * (e.g. an unusually long progress update) inside the 2s window still
+ * suppresses — the history schema has no message-kind column to discriminate
+ * further. That residual is why the CALLER must NOT close the obligation on
+ * suppression: a genuine reply closes its own obligation idempotently, while a
+ * false-positive suppression leaves it open for the liveness floor / sweep.
+ */
+
+import { FINAL_ANSWER_MIN_CHARS } from '../final-answer-detect.js'
+
+/** How far back a just-landed reply can be and still suppress the flush. */
+export const FLUSH_SUPPRESSION_WINDOW_MS = 2000
+
+export interface FlushSuppressionDeps {
+  /** Durable substantive-outbound oracle — the gateway passes
+   *  `hasOutboundDeliveredSince` (thread-scoped, length-floored). */
+  hasSubstantiveOutbound(
+    chatId: string,
+    sinceMs: number,
+    threadId: number | null,
+    minChars: number,
+  ): boolean
+}
+
+export interface FlushSuppressionArgs {
+  chatId: string
+  /** The turn's origin thread. `null` = chat root / DM (matches the
+   *  `hasOutboundDeliveredSince` explicit-null semantics — never pass
+   *  `undefined`, which would match ANY thread and re-open the
+   *  cross-topic false positive this module exists to close). */
+  threadId: number | null
+  /** Length of the captured answer the flush is about to deliver. The
+   *  length floor is `min(FINAL_ANSWER_MIN_CHARS, answerLength)`: a row
+   *  can only suppress the flush if it is at least as long as the answer
+   *  itself (up to the 200-char substantive cap). A TERSE captured answer
+   *  ("Yes — done.") is therefore still suppressible by its own short
+   *  answer-stream materialization (avoiding a duplicate bubble), while a
+   *  short progress ping can never suppress a LONG composed answer. */
+  answerLength: number
+  nowMs: number
+}
+
+/**
+ * True iff the flush should be suppressed: a substantive same-thread outbound
+ * landed within the suppression window. Fails open (no suppression) on oracle
+ * errors — delivering a possible duplicate beats dropping the only copy.
+ */
+export function shouldSuppressTurnFlush(
+  deps: FlushSuppressionDeps,
+  args: FlushSuppressionArgs,
+): boolean {
+  const minChars = Math.max(1, Math.min(FINAL_ANSWER_MIN_CHARS, args.answerLength))
+  try {
+    return deps.hasSubstantiveOutbound(
+      args.chatId,
+      args.nowMs - FLUSH_SUPPRESSION_WINDOW_MS,
+      args.threadId,
+      minChars,
+    )
+  } catch {
+    return false
+  }
+}

--- a/telegram-plugin/tests/turn-flush-suppression.test.ts
+++ b/telegram-plugin/tests/turn-flush-suppression.test.ts
@@ -1,0 +1,90 @@
+/**
+ * S1 fix (fable red-team 2026-07-17) — turn-flush pre-delivery suppression.
+ *
+ * The old gateway predicate (`getRecentOutboundCount(chatId, 2) > 0`) counted
+ * ANY assistant row in the WHOLE chat, so a worker progress ping, a command
+ * ack, or a reply in a different forum topic suppressed the flush and closed
+ * the obligation — silently dropping the user's real answer. These tests pin
+ * the scoped replacement: the oracle must be asked for a SAME-THREAD row of
+ * substantive length within the 2s window, and oracle failures fail OPEN
+ * (deliver, don't drop). The oracle's own thread/length SQL semantics are
+ * pinned separately in `history.test.ts` (`hasOutboundDeliveredSince`).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  shouldSuppressTurnFlush,
+  FLUSH_SUPPRESSION_WINDOW_MS,
+} from '../gateway/turn-flush-suppression.js'
+import { FINAL_ANSWER_MIN_CHARS } from '../final-answer-detect.js'
+
+type OracleCall = { chatId: string; sinceMs: number; threadId: number | null; minChars: number }
+
+function capture(result: boolean) {
+  const calls: OracleCall[] = []
+  const deps = {
+    hasSubstantiveOutbound: (chatId: string, sinceMs: number, threadId: number | null, minChars: number) => {
+      calls.push({ chatId, sinceMs, threadId, minChars })
+      return result
+    },
+  }
+  return { calls, deps }
+}
+
+describe('shouldSuppressTurnFlush', () => {
+  it('suppresses iff the oracle finds a substantive same-thread outbound', () => {
+    const yes = capture(true)
+    expect(
+      shouldSuppressTurnFlush(yes.deps, { chatId: '-100', threadId: 7, answerLength: 500, nowMs: 10_000 }),
+    ).toBe(true)
+    const no = capture(false)
+    expect(
+      shouldSuppressTurnFlush(no.deps, { chatId: '-100', threadId: 7, answerLength: 500, nowMs: 10_000 }),
+    ).toBe(false)
+  })
+
+  it('scopes the oracle query to the turn thread and the 2s window', () => {
+    const { calls, deps } = capture(true)
+    shouldSuppressTurnFlush(deps, { chatId: '-100', threadId: 7, answerLength: 500, nowMs: 10_000 })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.chatId).toBe('-100')
+    // Explicit thread id — never `undefined` (undefined would match rows in
+    // ANY topic and re-open the cross-topic false positive).
+    expect(calls[0]!.threadId).toBe(7)
+    expect(calls[0]!.sinceMs).toBe(10_000 - FLUSH_SUPPRESSION_WINDOW_MS)
+  })
+
+  it('passes an explicit null thread for DM / chat-root turns', () => {
+    const { calls, deps } = capture(false)
+    shouldSuppressTurnFlush(deps, { chatId: '55', threadId: null, answerLength: 300, nowMs: 5_000 })
+    expect(calls[0]!.threadId).toBeNull()
+  })
+
+  it('caps the length floor at FINAL_ANSWER_MIN_CHARS for long answers (a short ping can never suppress a long answer)', () => {
+    const { calls, deps } = capture(false)
+    shouldSuppressTurnFlush(deps, { chatId: '-100', threadId: null, answerLength: 5_000, nowMs: 10_000 })
+    expect(calls[0]!.minChars).toBe(FINAL_ANSWER_MIN_CHARS)
+  })
+
+  it('lowers the floor to the answer length for terse answers (their own stream materialization still suppresses a duplicate)', () => {
+    const { calls, deps } = capture(true)
+    shouldSuppressTurnFlush(deps, { chatId: '-100', threadId: null, answerLength: 12, nowMs: 10_000 })
+    expect(calls[0]!.minChars).toBe(12)
+  })
+
+  it('clamps the floor to >= 1 for a degenerate empty answer', () => {
+    const { calls, deps } = capture(false)
+    shouldSuppressTurnFlush(deps, { chatId: '-100', threadId: null, answerLength: 0, nowMs: 10_000 })
+    expect(calls[0]!.minChars).toBe(1)
+  })
+
+  it('fails open (no suppression) when the oracle throws — deliver beats drop', () => {
+    const deps = {
+      hasSubstantiveOutbound: () => {
+        throw new Error('sqlite unavailable')
+      },
+    }
+    expect(
+      shouldSuppressTurnFlush(deps, { chatId: '-100', threadId: null, answerLength: 300, nowMs: 10_000 }),
+    ).toBe(false)
+  })
+})

--- a/work/apply-drift-architecture-20260717/ARCHITECTURE.md
+++ b/work/apply-drift-architecture-20260717/ARCHITECTURE.md
@@ -1,0 +1,148 @@
+# Apply-time model bake vs. boot-time live config — architecture dig
+
+**Repo HEAD analyzed:** `7729c67` — *"fix(errors): proxy-fallback 401 is an operator-only infra fault… (#3293)"* (2026-07-17 10:52 +1000)
+**Working tree:** `~/work/repo` (freshly `git pull`ed to origin/main).
+
+---
+
+## Top line (for a CPO)
+
+Today when the operator edits an agent's `model:` in `switchroom.yaml` and just restarts the
+container, the agent silently launches the **old** model — while `/status` and the /model menu
+report the **new** one. That split is real and load-bearing-free for the model field: the live
+yaml is **already mounted read-only inside every agent container**, and the model resolver is a
+**pure static function with no vault/network/ordering dependency**. So we *can* make "edit config +
+restart" just take effect, like operators expect. The minimal safe change is ~15 lines of shell in
+`start.sh.hbs` that resolve the configured default from the live yaml at boot, falling back to the
+baked literal if the yaml is unreadable. Model **class** changes (Claude ⇄ non-Claude `sr-*`) still
+want a full apply because they also touch the compose file — but Claude⇄Claude (opus/sonnet/haiku),
+the operator's actual pain, needs nothing but the boot-time read.
+
+---
+
+## Q1 — Why is a full `apply` needed at all? What does it bake?
+
+`switchroom apply` (`src/cli/apply.ts`) does five distinct things a `docker restart` does **not**:
+
+| Artifact | Rendered where | Must be build-time? |
+|---|---|---|
+| **`start.sh`** (launcher, incl. `_EFFECTIVE_MODEL`) | `scaffoldAgent` → `profiles/_base/start.sh.hbs`; model injected at `scaffold.ts:3232` (`modelQ: shellSingleQuote(resolveMainModel(agentConfig.model))`) → template line `start.sh.hbs:1177` `_EFFECTIVE_MODEL={{{modelQ}}}` | **No** for the model value (see Q3). Yes for the script *structure*. |
+| **`.mcp.json`** | `scaffold.ts` (SWITCHROOM_CONFIG etc., ~`3471`) | Mostly static paths; not the drift source. |
+| **`settings.json`** (`settings.model` also = `resolveMainModel`, `scaffold.ts:4312` & `:6912`) | scaffold | **No** — duplicate of the same baked model; could be dropped/boot-resolved. |
+| **`docker-compose.yml`** (service env, UID, volume mounts, **model-class routing** of `ANTHROPIC_BASE_URL` gated on `resolveMainModel(resolved.model)`, `compose.ts:862` → `emitAgentService`) | `write-compose.js` | **Partly yes** — only the *routing class* (Claude passthrough vs LiteLLM router) is compose-level. |
+| **Vault key provisioning** (LiteLLM per-agent virtual key) + **UID alignment / chown** | apply.ts | **Yes** — genuinely host/privileged, one-time. |
+
+A container **restart just re-execs the already-rendered `start.sh`** — it re-renders nothing. So
+every field baked into that script (the model literal) is frozen until the next host-side apply.
+That is the entire mechanism of the drift.
+
+## Q2 — Why is the model baked instead of read live?
+
+Git history shows the model bake is **incidental/legacy, not a load-bearing design decision.** The
+model has been a `--model` literal in the launcher since long before the session-override machinery;
+the churn on `start.sh.hbs` (`#2993 → #3042 → #3184 → #3277 → #3284`, `git log` on the template) is
+**all about the `/model` *override* carrier** (`.session-model`), never about the *configured
+default*, which has quietly stayed a scaffold-time literal the whole time.
+
+`resolveMainModel` (`scaffold.ts:1364`) is the proof it isn't load-bearing:
+
+```ts
+export function resolveMainModel(model: string | undefined): string {
+  if (model === undefined || model === "default") return SWITCHROOM_DEFAULT_MAIN_MODEL; // "claude-sonnet-5"
+  return model;
+}
+```
+
+Pure. No vault, no network, no ordering dependency, no bootstrap-before-gateway problem — the model
+string is needed only at the final `exec claude --model` line, which is the **last** thing start.sh
+does, long after the LiteLLM probe and env setup. There is **no** "model needed before the CLI
+exists" constraint. The only genuinely build-time-coupled piece is the LiteLLM **routing class**
+(Q1/Q4), and start.sh *already* re-derives that live (see Q3).
+
+## Q3 — Why can't the yaml just be hot-loaded at boot? (What actually blocks it — spoiler: almost nothing)
+
+**The live yaml is already there.** Every agent service bind-mounts it **read-only**:
+
+- `compose.ts:1446 / :1628` → `- ${switchroomConfigPath}:/state/config/switchroom.yaml:ro`
+- `CONTAINER_CONFIG_PATH = "/state/config/switchroom.yaml"` (`compose.ts:975`), exported as
+  `SWITCHROOM_CONFIG` into the service (`compose.ts:1401`) **and** re-exported by start.sh itself
+  (`start.sh.hbs:520`).
+- A `:ro` bind mount reflects host edits live — the operator's `switchroom.yaml` change is visible
+  inside the container **the instant they save it**, no apply required.
+
+**The CLI works in-container at boot.** start.sh already shells out to `switchroom vault get …` at
+boot (`start.sh.hbs:100`, `:1063`) and it succeeds — so the `switchroom` binary + `SWITCHROOM_CONFIG`
+are functional before the model line. The exact resolver `/status` uses,
+`switchroom agent list --json`, computes the model via
+`resolveAgentConfig(config.defaults, config.profiles, agentConfig)` then `resolved.model ?? default`
+(`agent.ts:859-864`) — reading the mounted yaml, **no vault, no docker** needed for the model field
+(model is always a plain string, never a `vault:` ref).
+
+**What would it take for the model field:** in `start.sh.hbs`, before line 1177, attempt a live
+resolve and fall back to the baked literal:
+
+```sh
+_BAKED_MODEL={{{modelQ}}}
+_EFFECTIVE_MODEL="$_BAKED_MODEL"
+if [ -r "$SWITCHROOM_CONFIG" ]; then
+  _live="$(switchroom agent model "$SWITCHROOM_AGENT_NAME" 2>/dev/null | tr -d '[:space:]')"
+  if printf '%s' "$_live" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
+    _EFFECTIVE_MODEL="$_live"
+  fi
+fi
+```
+
+(A tiny `switchroom agent model <name>` subcommand — or `agent list --json | jq` — is the one new
+piece; the resolver already exists.) The existing session-override, invalidation, and sr-*/fable
+repoint logic below it all keep working unchanged because they operate on `_EFFECTIVE_MODEL`.
+
+**Failure modes, all already handled or trivial:**
+- *yaml unreadable / partial write* → `[ -r ]` + shape-gate regex fall back to baked literal. Safe.
+- *vault dependency* → none for the model field.
+- *ordering/perf* → resolve happens at the end of boot; one extra sub-100ms CLI call.
+- *`configuredDefaultAtWrite` compare* (`start.sh.hbs:1216,1260`) already exists to invalidate a
+  stale `/model` override when the default changes — it composes cleanly with a live default.
+
+## Q4 — Blast radius & risk
+
+**Derives from `_EFFECTIVE_MODEL` (all keep working — they read the variable, not the literal):**
+`--model`, `--fallback-model` (`fallbackModelQ`), effort routing, and the sr-*/fable
+passthrough→router repoint (`start.sh.hbs:1386-1393`), which **already re-derives routing live at
+boot** whenever LiteLLM is reachable.
+
+**Must stay build-time:**
+1. **compose-level model-class routing** — `ANTHROPIC_BASE_URL` passthrough (Claude) vs LiteLLM
+   router (non-Claude `sr-*`) is chosen in `emitAgentService` from `resolveMainModel(resolved.model)`
+   (`compose.ts:862`). Switching an agent **across** that class boundary changes the compose env, so
+   it needs a compose regen (apply). **But** start.sh's boot repoint already covers the reachable
+   case, so even this degrades gracefully rather than breaking.
+2. **UID alignment / chown** and **LiteLLM virtual-key provisioning** — privileged, host-only,
+   one-time; unaffected by model edits.
+3. **The `start.sh` script structure itself** — template changes still need a re-render.
+
+**Net risk of hot-loading the model default:** low, and strictly *narrowing* the drift. Worst case
+(yaml unreadable) falls back to exactly today's behavior — the baked literal. There is no path where
+boot-resolve is *less* safe than the status quo.
+
+---
+
+## Recommendation
+
+**Yes — eliminate this drift class for the model field by boot-time live resolution.** Minimal safe change:
+
+1. Add a thin `switchroom agent model <name>` (or reuse `agent list --json`) that prints the
+   cascade-resolved default — the resolver already exists (`agent.ts:859`).
+2. In `start.sh.hbs`, resolve `_EFFECTIVE_MODEL` from the **mounted live yaml** with the baked
+   literal as fallback (snippet in Q3), *above* the existing override block. Do the same for
+   `settings.json`'s `settings.model` or simply stop baking it.
+3. Keep **compose/UID/vault** build-time. For a Claude⇄`sr-*` **class** switch, still require apply
+   (the compose env changes) — but this is rare and already partially self-heals at boot.
+4. **Whole-config hot-load** is a larger, separately-scoped follow-up (env blocks, tools, permissions
+   also bake into settings.json/.mcp.json); the model field is the high-value, low-risk first slice
+   and resolves the operator's actual pain.
+
+**Locking test:** an integration test that (a) renders an agent with `model: opus`, (b) rewrites the
+mounted `switchroom.yaml` to `model: sonnet` **without** re-running apply, (c) execs start.sh, and
+(d) asserts the `exec claude … --model` line (capture via a stub `claude`) carries `sonnet`, i.e.
+**launched model == live yaml model**. Add the negative: corrupt/absent yaml ⇒ launches the baked
+literal.


### PR DESCRIPTION
## What

Fixes three of the four sharp edges from the fable red-team of the durable-delivery fix (2026-07-17, follow-up to #3276/#3279):

- **S1 (HIGH — could still drop answers today):** the turn-flush pre-delivery suppression used `getRecentOutboundCount(chatId, 2) > 0` — ANY assistant row in the WHOLE chat (a worker `progress_update`, a command ack/restart notice, a reply in a *different forum topic*) suppressed the flush, and the branch then **closed the delivery obligation**, so the user's answer was dropped with no re-present. Now:
  - predicate scoped to a **substantive same-thread** outbound (`hasOutboundDeliveredSince`, length floor `min(answerLength, FINAL_ANSWER_MIN_CHARS)`), extracted to `turn-flush-suppression.ts` (unit-tested; the oracle's thread/length SQL semantics were already pinned in `history.test.ts`);
  - suppression **no longer closes the obligation** — a genuine raced reply closes its own idempotently; a false positive leaves it open (`noteTurnEnded`, same as the send-failed path) so the sweep/liveness floor re-presents instead of a permanent silent drop.
- **S2 (MED):** the ~1s answer-ready quiescence debounce only re-armed on `text` events, so "prose → >1s thinking pause → trailing `NO_REPLY`" could deliver a turn the model intended silent (#2053 in miniature). The `thinking` event now re-arms the debounce (`reset()` re-verifies via `decideTurnFlush`; the fast path is deferred, never lost).
- **S4 (LOW):** flushed answers sent bare. `deliverAnswer` now quote-anchors the FIRST chunk to `turn.sourceMessageId` with `allow_sending_without_reply: true`, matching `executeReply`'s first-chunk default. Synthesized turns (cron/handback, `sourceMessageId == null`) send bare as before. Retries keep the anchor (ledger resumes at first unsent chunk).

**S3 (crash-window ledger durability) is deliberately NOT here** — it stays on #3278 per the red-team's recommendation; annotated there.

## Known residuals (documented in code)

- A ≥`min(answerLength,200)`-char same-thread non-answer outbound inside the 2s window can still suppress (no message-kind column in history) — but the obligation now stays open, so the sweep arbitrates instead of a permanent drop. Direction of error is always deliver/re-present, never silent loss.
- A stream-materialized terse answer that triggers suppression may draw a spurious re-present (obligation no longer force-closed). Duplicate nudge beats dropped answer.

## Tests

- New `turn-flush-suppression.test.ts` (7 tests): thread scoping (explicit null vs topic id — `undefined` would re-open the cross-topic false positive), 2s window math, length-floor cap/lower/clamp, fail-open on oracle error.
- Adjacent suites green: answer-ready-flush, backstop-delivery, outbound-send-chunks, turn-end-gate-backstop, turn-flush-safety, turn-flush-dedup, silent-end-transport, represent-guard, feed-open-gate, redelivery-decision (vitest) + history, obligation-ledger, emission-authority, cross-turn-card-gate (bun).
- `npm run lint` clean (incl. `check-bot-api-wrapping`).
- Gateway wiring lines (the `thinking` re-arm call, the suppression call site) are inside the untestable 30k-line gateway module — behavior is pinned at the extracted-module layer, per repo precedent (`answer-ready-flush.ts`).

## Rollout verification (red-team ask)

Live fleet runs `switchroom-agent:v0.18.30`; `14b156f` **is** an ancestor of `v0.18.30` — the #3279 durable-delivery fix is already deployed fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)