### PR TITLE
fix(launch): resolve the configured model LIVE at boot — model: edits apply on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ### Fixes
 
+- **`model:` edits in switchroom.yaml now apply on a plain restart — the
+  launcher resolves the configured model LIVE at boot** (Defect B, the
+  fable-pin-runs-opus bug). The model used to be baked into `start.sh` at
+  `switchroom apply` time, while /status read the live yaml — two sources of
+  truth that silently disagreed after any `model:` edit without a full
+  re-apply. start.sh now shells `switchroom agent effective-model <name>`
+  (new verb; the SAME `resolveMainModel` resolver `agent list --json` and the
+  gateway use — never re-implemented in shell) against the live-mounted
+  config, with a bounded, never-silent fallback chain: live yaml →
+  `.configured-default-model` (last-known-good) → the apply-time bake, each
+  fallback alerting the operator via `.session-model-alert`. Claude↔sr-*
+  routing-class flips are detected and refused with a "run switchroom apply"
+  alert instead of half-applied against stale routing; a proxy-only
+  configured default (`fable`) with LiteLLM unreachable at boot degrades to
+  `opus` with an alert instead of 4xx-ing every call; `agent list --json`
+  now reports the resolved model (`default` → the fleet default) and the
+  retired `claude-fable-5` codename is normalized to the `fable` alias
+  everywhere the resolver runs. Rendered-script ordering (live resolution →
+  recorded default → carrier compare → litellm guard → repoint → exec) is
+  locked by tests, including the previously-missing regression
+  "baked=opus, live yaml=fable → boots fable".
 - **Inbound Telegram messages are never silently dropped at the routing
   layer** (#3300) — the gateway registered only content-specific handlers
   (`bot.on('message:text')`, `:photo`, … `:paid_media`); grammy ^1.44 routes

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -263,3 +263,34 @@ did not touch the Anthropic subscription endpoint. The live LiteLLM config
 and Hindsight's live container env (`ANTHROPIC_BASE_URL=http://127.0.0.1:4010`,
 global model `openrouter/z-ai/glm-5.2`) were also read directly for the I2 and
 Hindsight-credential claims above.
+
+## Boot-time model resolution is LIVE (Defect B fix, 2026-07-17)
+
+The model an agent boots with is **no longer frozen at `switchroom apply`
+time**. `profiles/_base/start.sh.hbs` ("Live configured-default resolution")
+resolves the configured model at every boot by shelling
+`switchroom agent effective-model <name>` against the live-mounted
+`$SWITCHROOM_CONFIG` — the same `resolveMainModel` resolver the gateway's
+/status and `agent list --json` use, so what-you-see and what-runs come from
+one implementation. Editing `model:` in switchroom.yaml + `docker restart`
+now applies the change; no full apply needed for Claude↔Claude switches.
+
+Bounded fallback chain (never silent past the live read): live yaml →
+`.configured-default-model` (last-known-good from the prior boot) → the
+apply-time bake, with a `.session-model-alert` relayed to the operator on any
+fallback. Two deliberate boundaries:
+
+- **Claude↔sr-\* class flips still require a real `switchroom apply`** —
+  routing (`ANTHROPIC_BASE_URL` passthrough vs router root, litellm
+  provisioning) is rendered into compose at apply time. The launcher detects
+  a class flip between the live value and the bake, refuses to half-apply it,
+  boots the baked model, and alerts "run switchroom apply".
+- **A proxy-only configured default (`fable`) with LiteLLM unreachable at
+  boot degrades to `opus` with an alert** instead of 4xx-ing every call
+  (the codename is retired direct-to-Anthropic; only the router serves it).
+
+Known residual (tracked follow-up): the single-file yaml bind mount is
+inode-pinned per container start, and host-side CLI writers save via atomic
+rename — so a LONG-RUNNING gateway's mid-life `agent list` reads reflect the
+yaml as of its last container start. Boot-time reads (the path above) always
+re-resolve and are unaffected.

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1170,15 +1170,92 @@ fi
 # which the gateway relays to the operator chat once at boot. The normal apply
 # path is silent here — the gateway already acked the `/model` in chat.
 #
+# --- Live configured-default resolution (Defect B / drift fix) ---
+#
+# The apply-time bake ({{{modelQ}}}) is only the LAST-DITCH fallback: editing
+# `model:` in switchroom.yaml and restarting must take effect WITHOUT a full
+# `switchroom apply`. The launcher asks the SAME resolver the gateway's
+# /status uses (`switchroom agent effective-model`, which applies
+# resolveMainModel server-side) against the live mounted yaml — one resolver,
+# never re-implemented in shell, so what-you-see and what-runs cannot split.
+#
+# Fallback chain, never silent past step 1:
+#   1. live read of $SWITCHROOM_CONFIG (one bounded retry — a host-side
+#      in-place rewrite can present a torn file for a moment);
+#   2. `.configured-default-model` — the last-known-good live value this
+#      launcher recorded on every prior boot (read BEFORE it is overwritten);
+#   3. the apply-time bake.
+# Steps 2/3 append to `.session-model-alert` so the gateway tells the
+# operator once at boot. No SWITCHROOM_CONFIG mount at all means there is
+# nothing to read live — the bake IS the truth there (stderr note only; an
+# operator alert every boot forever would be noise with no action).
+#
+# The yaml file bind mount re-resolves by PATH at container start, so a
+# host-side atomic-rename write is always picked up by the NEXT boot — the
+# path this block runs on. Only mid-life reads by long-running processes can
+# see a stale inode; that pre-existing edge is out of scope here (tracked as
+# a follow-up on the drift fix).
+#
 # NB {{{modelQ}}} is already shell-single-quoted by the scaffold (it renders as
 # a quoted token, e.g. 'claude-sonnet-5'), so it is assigned BARE here — never
 # inside additional double quotes, which would embed the literal quote chars in
 # the value and break `claude --model`.
-_EFFECTIVE_MODEL={{{modelQ}}}
+_BAKED_MODEL={{{modelQ}}}
+_LKG_MODEL="$(cat "{{agentDir}}/.configured-default-model" 2>/dev/null | tr -d '[:space:]' || true)"
+_EFFECTIVE_MODEL=""
+if [ -n "$SWITCHROOM_CONFIG" ] && [ -f "$SWITCHROOM_CONFIG" ] && command -v switchroom >/dev/null 2>&1; then
+  _lm_live=""
+  for _lm_try in 1 2; do
+    _lm_live="$(timeout 20 switchroom --config "$SWITCHROOM_CONFIG" agent effective-model "{{name}}" 2>/dev/null | tail -n 1 | tr -d '[:space:]')" || _lm_live=""
+    # Shape gate — same regex as the .session-model carrier below (byte-kept
+    # with MODEL_ARG_RE); the tr above already guarantees single-line.
+    if [ -n "$_lm_live" ] && printf '%s' "$_lm_live" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
+      break
+    fi
+    _lm_live=""
+    if [ "$_lm_try" -eq 1 ]; then sleep 1; fi
+  done
+  if [ -n "$_lm_live" ]; then
+    # Routing class (Claude passthrough vs sr-* router root) is baked into
+    # compose at render time, so a Claude<->sr-* class flip CANNOT be applied
+    # by a bare restart — half-applying would run the new model against the
+    # old routing. Detect the flip, keep the baked model, and tell the
+    # operator to run a real apply.
+    case "$_BAKED_MODEL" in sr-*) _lm_baked_class=router ;; *) _lm_baked_class=claude ;; esac
+    case "$_lm_live" in sr-*) _lm_live_class=router ;; *) _lm_live_class=claude ;; esac
+    if [ "$_lm_live_class" != "$_lm_baked_class" ]; then
+      echo "session-model: configured model class changed ('$_BAKED_MODEL' -> '$_lm_live', $_lm_baked_class -> $_lm_live_class) — routing is render-time, NOT applying; run 'switchroom apply' then restart" >&2
+      printf 'The configured model changed from `%s` to `%s`, which switches routing class — a restart alone cannot apply that. The agent booted on `%s`. Run `switchroom apply` on the host, then restart this agent.\n' "$_BAKED_MODEL" "$_lm_live" "$_BAKED_MODEL" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+      _EFFECTIVE_MODEL="$_BAKED_MODEL"
+    else
+      _EFFECTIVE_MODEL="$_lm_live"
+      if [ "$_lm_live" != "$_BAKED_MODEL" ]; then
+        echo "session-model: live configured model '$_lm_live' differs from apply-time bake '$_BAKED_MODEL' — using the live value (switchroom.yaml is the source of truth)" >&2
+      fi
+    fi
+  elif [ -n "$_LKG_MODEL" ] && printf '%s' "$_LKG_MODEL" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
+    # Live read failed (torn write mid-read, yaml schema error, CLI wedge).
+    # Last-known-good beats the bake: it was live truth on a prior boot,
+    # while the bake can predate any number of yaml edits. Loud either way —
+    # a silent fallback here would resurrect Defect B as an intermittent flap.
+    _EFFECTIVE_MODEL="$_LKG_MODEL"
+    echo "session-model: live config read FAILED — using last-known-good configured model '$_LKG_MODEL' (apply-time bake: '$_BAKED_MODEL')" >&2
+    printf 'switchroom.yaml could not be read at boot, so the agent booted on the last-known-good configured model `%s`. If you just changed `model:`, check the yaml for errors and restart the agent.\n' "$_LKG_MODEL" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+  else
+    _EFFECTIVE_MODEL="$_BAKED_MODEL"
+    echo "session-model: live config read FAILED and no last-known-good value — using apply-time baked model '$_BAKED_MODEL'" >&2
+    printf 'switchroom.yaml could not be read at boot and no prior boot recorded a model, so the agent booted on the apply-time default `%s`. If you just changed `model:`, check the yaml for errors and restart the agent.\n' "$_BAKED_MODEL" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+  fi
+  unset _lm_live _lm_try _lm_baked_class _lm_live_class
+else
+  _EFFECTIVE_MODEL="$_BAKED_MODEL"
+fi
+unset _BAKED_MODEL _LKG_MODEL
 # Record the RESOLVED configured default (raw, unquoted) every boot, before
 # override resolution. The gateway copies this into the carrier's
 # `configuredDefaultAtWrite`, so both sides of the invalidation compare below
-# come from the same resolver. Overwrite, not consumed.
+# come from the same resolver. Overwrite, not consumed — and doubling as the
+# last-known-good live value the fallback chain above reads on the NEXT boot.
 printf '%s\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.configured-default-model" 2>/dev/null || true
 
 # Rev-4 hygiene (#3184 review LOW-2): remove the files retired with the
@@ -1303,6 +1380,26 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   fi
   unset _smf _sm_model _sm_cfg _sm_attempts _SM_MAX_ATTEMPTS
 fi
+
+# Configured-default LiteLLM guard. A proxy-only *configured* model with
+# LiteLLM unreachable at boot would exec against the /anthropic passthrough,
+# where `fable`/`claude-fable-5` is a retired codename and EVERY call 4xxs —
+# a total outage. The carrier block above already drops proxy-only OVERRIDES
+# on a down proxy; this extends the same guard to the configured default,
+# which the live-config read above makes a mainline path (pinning `model:
+# fable` in yaml is now the normal way to run Fable). Claude agents have a
+# safe same-class fallback (opus); sr-* configured defaults keep today's
+# loud-degraded behavior — there is no Claude fallback for them and the
+# repoint case below already leaves their routing to self-heal.
+case "$_EFFECTIVE_MODEL" in
+  fable|claude-fable-5)
+    if [ -z "$_LITELLM_OK" ]; then
+      echo "session-model: configured model '$_EFFECTIVE_MODEL' is proxy-only but LiteLLM is unreachable at boot — booting 'opus' until the proxy recovers" >&2
+      printf 'LiteLLM was unreachable at boot, so the configured model `%s` (proxy-only) could not be used — the agent booted on `opus` instead. Restart the agent once the proxy is back to return to `%s`.\n' "$_EFFECTIVE_MODEL" "$_EFFECTIVE_MODEL" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+      _EFFECTIVE_MODEL="opus"
+    fi
+    ;;
+esac
 
 # --- Session effort resolution (consume-once .session-effort carrier, #3186) ---
 #

--- a/src/agents/scaffold.model.test.ts
+++ b/src/agents/scaffold.model.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { resolveMainModel, normalizeModelAlias, SWITCHROOM_DEFAULT_MAIN_MODEL } from "./scaffold.js";
+
+// The ONE model resolver — shared by the scaffold bake, `agent list --json`,
+// and the launcher's boot-time `agent effective-model` read. These pin the
+// mapping so launcher and gateway can never disagree.
+describe("resolveMainModel / normalizeModelAlias", () => {
+  it("maps unset and the `default` alias to the switchroom default (account-default 4xx footgun)", () => {
+    expect(resolveMainModel(undefined)).toBe(SWITCHROOM_DEFAULT_MAIN_MODEL);
+    expect(resolveMainModel("default")).toBe(SWITCHROOM_DEFAULT_MAIN_MODEL);
+  });
+
+  it("passes real ids and aliases through unchanged", () => {
+    expect(resolveMainModel("opus")).toBe("opus");
+    expect(resolveMainModel("claude-opus-4-8")).toBe("claude-opus-4-8");
+    expect(resolveMainModel("sr-glm-5")).toBe("sr-glm-5");
+    expect(resolveMainModel("fable")).toBe("fable");
+  });
+
+  it("never emits the retired claude-fable-5 codename — normalizes to the fable alias", () => {
+    // The codename 4xxs direct-to-Anthropic; only the alias is safe to
+    // launch/persist (the CLI maps it via ANTHROPIC_DEFAULT_FABLE_MODEL).
+    expect(resolveMainModel("claude-fable-5")).toBe("fable");
+    expect(normalizeModelAlias("claude-fable-5")).toBe("fable");
+    expect(normalizeModelAlias("fable")).toBe("fable");
+    expect(normalizeModelAlias("claude-sonnet-5")).toBe("claude-sonnet-5");
+  });
+});

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1363,7 +1363,19 @@ export const SWITCHROOM_DEFAULT_THINKING_EFFORT = "low";
  */
 export function resolveMainModel(model: string | undefined): string {
   if (model === undefined || model === "default") return SWITCHROOM_DEFAULT_MAIN_MODEL;
-  return model;
+  return normalizeModelAlias(model);
+}
+
+/**
+ * Prefer the `fable` alias over the retired `claude-fable-5` codename in
+ * anything we launch or persist. The codename 4xxs direct-to-Anthropic and
+ * only resolves via the LiteLLM router; the alias resolves everywhere the
+ * model is reachable at all (the claude CLI maps it via
+ * ANTHROPIC_DEFAULT_FABLE_MODEL), so it is the only safe spelling to write.
+ * Everything else passes through unchanged.
+ */
+export function normalizeModelAlias(model: string): string {
+  return model === "claude-fable-5" ? "fable" : model;
 }
 
 /**

--- a/src/cli/agent.test.ts
+++ b/src/cli/agent.test.ts
@@ -167,3 +167,22 @@ describe("summarizeReconcileBatch", () => {
     expect(out!.header).toBe("Summary: 0 succeeded, 2 failed");
   });
 });
+
+describe("agent effective-model command", () => {
+  // The launcher (start.sh) shells `switchroom agent effective-model <name>`
+  // at every boot — an unregistered verb would silently fail the live read
+  // on EVERY agent and drop the whole fleet to baked/LKG fallbacks. Same
+  // drift-class outcome test as the /logs options above.
+  function findCommand(): Command | undefined {
+    const program = new Command();
+    registerAgentCommand(program);
+    const agent = program.commands.find((c) => c.name() === "agent")!;
+    return agent.commands.find((c) => c.name() === "effective-model");
+  }
+
+  it("is registered with a required <name> argument", () => {
+    const cmd = findCommand();
+    expect(cmd).toBeDefined();
+    expect(cmd!.registeredArguments.map((a) => `${a.name()}:${a.required}`)).toEqual(["name:true"]);
+  });
+});

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -10,7 +10,7 @@ import { isHindsightEnabled } from "../memory/hindsight.js";
 import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
-import { scaffoldAgent, reconcileAgent, buildSettingsHooksBlock, detectHooksDrift, SWITCHROOM_DEFAULT_MAIN_MODEL, SWITCHROOM_DEFAULT_THINKING_EFFORT } from "../agents/scaffold.js";
+import { scaffoldAgent, reconcileAgent, buildSettingsHooksBlock, detectHooksDrift, resolveMainModel, SWITCHROOM_DEFAULT_MAIN_MODEL, SWITCHROOM_DEFAULT_THINKING_EFFORT } from "../agents/scaffold.js";
 import { writeComposeFile } from "./write-compose.js";
 import type { ReleaseBlockShape } from "../config/release-resolve.js";
 import { bareClonePath } from "../repos/bare-clone.js";
@@ -852,16 +852,17 @@ export function registerAgentCommand(program: Command): void {
             const agentConfig = config.agents[name];
             const status = statuses[name];
             const sched = schedulerStates[name];
-            // Cascade-resolved effective model — the same value scaffold
-            // bakes into settings.json / `--model` (falls back to the
-            // baked default when unset). Consumed by the gateway's
-            // /status and /model surfaces.
+            // Cascade-resolved effective model, through the SAME resolver
+            // scaffold bakes with (`default`/unset → switchroom default,
+            // retired codenames → alias). Consumed by the gateway's
+            // /status and /model surfaces AND `agent effective-model`, so
+            // launcher and gateway can never disagree on the mapping.
             const resolved = resolveAgentConfig(config.defaults, config.profiles, agentConfig);
             return {
               name,
               status: status?.active ?? "unknown",
               uptime: formatUptime(status?.uptime ?? null),
-              model: resolved.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL,
+              model: resolveMainModel(resolved.model),
               // Cascade-resolved effort — what start.sh bakes into
               // `--effort`, and the default the /effort session switch
               // reverts to on restart. Consumed by the gateway's /effort.
@@ -903,6 +904,34 @@ export function registerAgentCommand(program: Command): void {
         console.log();
         printTable(headers, rows, widths);
         console.log();
+      })
+    );
+
+  // switchroom agent effective-model <name>
+  //
+  // The ONE model resolver, exposed as a verb. Prints exactly the value the
+  // agent's launcher should pass to `claude --model`: cascade-resolved
+  // (defaults/profiles/agent), `default`/unset remapped to the switchroom
+  // default, retired codenames normalized to their alias. start.sh calls this
+  // at boot against the live mounted switchroom.yaml (see profiles/_base/
+  // start.sh.hbs "Live configured-default resolution") so a `model:` edit +
+  // restart takes effect WITHOUT a full apply, and the gateway's /status
+  // reads the same resolver via `agent list --json` — one implementation,
+  // no shell re-derivation, no drift. Plain single-line stdout on purpose:
+  // the shell consumer wants a bare token, not JSON.
+  agent
+    .command("effective-model <name>")
+    .description("Print the cascade-resolved model the agent's launcher boots with")
+    .action(
+      withConfigError(async (name: string) => {
+        const config = getConfig(program);
+        const agentConfig = config.agents[name];
+        if (!agentConfig) {
+          console.error(chalk.red(`Agent "${name}" is not defined in switchroom.yaml`));
+          process.exit(1);
+        }
+        const resolved = resolveAgentConfig(config.defaults, config.profiles, agentConfig);
+        console.log(resolveMainModel(resolved.model));
       })
     );
 

--- a/tests/reconcile.default-model.test.ts
+++ b/tests/reconcile.default-model.test.ts
@@ -164,8 +164,11 @@ describe("resolveMainModel — the `model: default` footgun guard", () => {
     expect(resolveMainModel("opus")).toBe("opus");
     expect(resolveMainModel("sonnet")).toBe("sonnet");
     expect(resolveMainModel("claude-haiku-4-5-20251001")).toBe("claude-haiku-4-5-20251001");
-    // a deliberate fable id (an account that HAS access) is honoured — we only
-    // guard the bare `default` alias, not fable itself.
-    expect(resolveMainModel("claude-fable-5")).toBe("claude-fable-5");
+    // a deliberate fable pin is honoured, but as the `fable` ALIAS: the
+    // retired `claude-fable-5` codename 4xxs direct-to-Anthropic and only
+    // resolves via the LiteLLM router, so the resolver normalizes it to the
+    // alias that resolves everywhere (see normalizeModelAlias).
+    expect(resolveMainModel("fable")).toBe("fable");
+    expect(resolveMainModel("claude-fable-5")).toBe("fable");
   });
 });

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, chmodSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -89,9 +89,15 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  /** Run the extracted block with a given _LITELLM_OK, echo the effective model. */
+  /**
+   * Run the extracted block with a given _LITELLM_OK, echo the effective
+   * model. SWITCHROOM_CONFIG is unset so the live-config resolution branch
+   * is skipped and the bake seeds $_EFFECTIVE_MODEL — the carrier contract
+   * under test here is independent of where the configured default came
+   * from. The live-read branch has its own suite below.
+   */
   function runBlock(litellmOk: string): string {
-    const script = `set -e\n_LITELLM_OK=${JSON.stringify(litellmOk)}\n${block}\necho "EFFECTIVE=$_EFFECTIVE_MODEL"`;
+    const script = `set -e\nunset SWITCHROOM_CONFIG\n_LITELLM_OK=${JSON.stringify(litellmOk)}\n${block}\necho "EFFECTIVE=$_EFFECTIVE_MODEL"`;
     const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
     const m = out.match(/EFFECTIVE=(.*)/);
     return m ? m[1].trim() : "";
@@ -102,6 +108,7 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
   function runBlockRouting(litellmOk: string): { effective: string; baseUrl: string } {
     const script = [
       "set -e",
+      "unset SWITCHROOM_CONFIG",
       `export ANTHROPIC_BASE_URL=${JSON.stringify(PASSTHROUGH)}`,
       `export SWITCHROOM_LITELLM_BASE=${JSON.stringify(ROUTER_ROOT)}`,
       `_LITELLM_OK=${JSON.stringify(litellmOk)}`,
@@ -154,8 +161,9 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     // clears it on a healthy boot.
     expect(block).toMatch(/cat[^\n]*\.session-model-boot-attempts/);
     expect(block).toContain("_SM_MAX_ATTEMPTS");
-    // modelQ is assigned BARE (already shell-quoted by the scaffold).
-    expect(block).toContain("_EFFECTIVE_MODEL='claude-sonnet-5'");
+    // modelQ is assigned BARE (already shell-quoted by the scaffold), as the
+    // last-ditch fallback seed for the live-config resolution.
+    expect(block).toContain("_BAKED_MODEL='claude-sonnet-5'");
     const startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
     expect(startSh).toContain('--model "$_EFFECTIVE_MODEL"');
     expect(startSh).not.toContain("--model {{{modelQ}}}");
@@ -427,7 +435,7 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     return `${JSON.stringify({ level, configuredDefaultAtWrite: cfg, ts })}\n`;
   }
   function runBlockEffort(): { model: string; effortArg: string } {
-    const script = `set -e\n_LITELLM_OK=1\n${block}\necho "EFFECTIVE=$_EFFECTIVE_MODEL"\necho "EFFORTARG=$_EFFORT_ARG"`;
+    const script = `set -e\nunset SWITCHROOM_CONFIG\n_LITELLM_OK=1\n${block}\necho "EFFECTIVE=$_EFFECTIVE_MODEL"\necho "EFFORTARG=$_EFFORT_ARG"`;
     const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
     return {
       model: out.match(/EFFECTIVE=(.*)/)?.[1].trim() ?? "",
@@ -517,9 +525,10 @@ describe("scaffoldAgent: configured-default sr-* model (no override)", () => {
   it("LiteLLM up → repoints to router root", () => {
     const { tmp, block } = scaffoldSrDefault("switchroom-session-model-srdef-");
     try {
-      expect(block).toContain("_EFFECTIVE_MODEL='sr-glm-5'");
+      expect(block).toContain("_BAKED_MODEL='sr-glm-5'");
       const script = [
         "set -e",
+        "unset SWITCHROOM_CONFIG",
         `export ANTHROPIC_BASE_URL=${JSON.stringify(PASSTHROUGH)}`,
         `export SWITCHROOM_LITELLM_BASE=${JSON.stringify(ROUTER_ROOT)}`,
         "_LITELLM_OK=1",
@@ -541,6 +550,7 @@ describe("scaffoldAgent: configured-default sr-* model (no override)", () => {
     try {
       const script = [
         "set -e",
+        "unset SWITCHROOM_CONFIG",
         `export ANTHROPIC_BASE_URL=${JSON.stringify(ROUTER_ROOT)}`,
         `export SWITCHROOM_LITELLM_BASE=${JSON.stringify(ROUTER_ROOT)}`,
         '_LITELLM_OK=""',
@@ -554,5 +564,207 @@ describe("scaffoldAgent: configured-default sr-* model (no override)", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+// ── Live configured-default resolution (Defect B / drift fix) ────────────────
+//
+// The launcher no longer trusts the apply-time bake: at boot it resolves the
+// agent's configured model from the LIVE mounted switchroom.yaml via
+// `switchroom agent effective-model` (the same resolver the gateway's /status
+// uses), falling back live → last-known-good (.configured-default-model) →
+// bake, never silently past the live read. These are outcome tests against
+// the RENDERED block, with a fake `switchroom` on PATH standing in for the
+// CLI so each failure mode is actually exercised (a test that wouldn't fail
+// on the drift is not a test).
+describe("scaffoldAgent: live configured-default resolution (start.sh)", () => {
+  let tmpDir: string;
+  let agentDir: string;
+  let block: string;
+  let fakeBin: string;
+  let cfgPath: string;
+
+  function scaffold(model?: string): void {
+    const name = "live-agent";
+    const config = makeAgentConfig(model ? ({ model } as Partial<AgentConfig>) : {});
+    const res = scaffoldAgent(name, config, tmpDir, telegramConfig, makeSwitchroomConfig(name, config));
+    agentDir = res.agentDir;
+    block = extractBlock(readFileSync(join(agentDir, "start.sh"), "utf-8"));
+  }
+
+  /** Install a fake `switchroom` CLI; its stdout/exit code drive the live read. */
+  function fakeSwitchroom(body: string): void {
+    writeFileSync(join(fakeBin, "switchroom"), `#!/bin/bash\necho "$@" >> ${JSON.stringify(join(fakeBin, "args.log"))}\n${body}\n`);
+    chmodSync(join(fakeBin, "switchroom"), 0o755);
+  }
+
+  function fakeArgs(): string {
+    const p = join(fakeBin, "args.log");
+    return existsSync(p) ? readFileSync(p, "utf-8") : "";
+  }
+
+  function runLive(litellmOk = "1"): string {
+    const script = [
+      "set -e",
+      `export PATH=${JSON.stringify(fakeBin)}:"$PATH"`,
+      `export SWITCHROOM_CONFIG=${JSON.stringify(cfgPath)}`,
+      `_LITELLM_OK=${JSON.stringify(litellmOk)}`,
+      block,
+      'echo "EFFECTIVE=$_EFFECTIVE_MODEL"',
+    ].join("\n");
+    const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+    const m = out.match(/EFFECTIVE=(.*)/);
+    return m ? m[1].trim() : "";
+  }
+
+  function alertText(): string {
+    const p = join(agentDir, ".session-model-alert");
+    return existsSync(p) ? readFileSync(p, "utf-8") : "";
+  }
+
+  function recordedDefault(): string {
+    return readFileSync(join(agentDir, ".configured-default-model"), "utf-8").trim();
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-live-model-"));
+    fakeBin = join(tmpDir, "fakebin");
+    mkdirSync(fakeBin, { recursive: true });
+    cfgPath = join(tmpDir, "switchroom.yaml");
+    writeFileSync(cfgPath, "agents: {}\n");
+    scaffold();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // THE regression test the fable launch bug was missing: yaml edited to
+  // fable after apply (bake still sonnet) + plain restart → boots fable.
+  it("boots the LIVE yaml model when it differs from the apply-time bake (Defect B)", () => {
+    fakeSwitchroom('echo fable');
+    expect(runLive("1")).toBe("fable");
+    // The recorded configured default is the live value (next boot's LKG)…
+    expect(recordedDefault()).toBe("fable");
+    // …and the resolver was asked with the live config and the agent's name.
+    expect(fakeArgs()).toContain("--config");
+    expect(fakeArgs()).toContain("agent effective-model live-agent");
+    // Normal path: no operator alert.
+    expect(alertText()).toBe("");
+  });
+
+  it("retries once on a torn/failed first read, then uses the live value", () => {
+    fakeSwitchroom(`marker=${JSON.stringify(join(fakeBin, "second-call"))}
+if [ -f "$marker" ]; then echo claude-opus-4-8; else touch "$marker"; echo "mangled: [truncated ya" ; fi`);
+    expect(runLive("1")).toBe("claude-opus-4-8");
+    expect(alertText()).toBe("");
+  });
+
+  it("live read fails → falls back to last-known-good with an operator alert", () => {
+    writeFileSync(join(agentDir, ".configured-default-model"), "claude-opus-4-8\n");
+    fakeSwitchroom("exit 1");
+    expect(runLive("1")).toBe("claude-opus-4-8");
+    expect(alertText()).toContain("last-known-good");
+    expect(alertText()).toContain("claude-opus-4-8");
+  });
+
+  it("live read fails with no last-known-good → falls back to the bake with an operator alert", () => {
+    fakeSwitchroom("exit 1");
+    expect(runLive("1")).toBe(DEFAULT_MODEL);
+    expect(alertText()).toContain("apply-time default");
+    expect(alertText()).toContain(DEFAULT_MODEL);
+  });
+
+  it("garbage CLI output fails the shape gate and falls back (never reaches --model)", () => {
+    fakeSwitchroom('echo "not a!! model;; rm -rf"');
+    expect(runLive("1")).toBe(DEFAULT_MODEL);
+    expect(alertText()).not.toBe("");
+  });
+
+  it("Claude→sr-* class flip is NOT half-applied: keeps the bake and tells the operator to run apply", () => {
+    fakeSwitchroom("echo sr-glm-5");
+    expect(runLive("1")).toBe(DEFAULT_MODEL);
+    expect(alertText()).toContain("switchroom apply");
+    // The recorded default must be what actually booted, not the unapplied flip.
+    expect(recordedDefault()).toBe(DEFAULT_MODEL);
+  });
+
+  it("sr-*→Claude class flip is symmetric: keeps the sr-* bake and alerts", () => {
+    scaffold("sr-glm-5");
+    fakeSwitchroom("echo claude-opus-4-8");
+    expect(runLive("1")).toBe("sr-glm-5");
+    expect(alertText()).toContain("switchroom apply");
+  });
+
+  it("no SWITCHROOM_CONFIG mount → bake, silently (nothing live to read, nothing actionable)", () => {
+    fakeSwitchroom("echo fable");
+    const script = [
+      "set -e",
+      `export PATH=${JSON.stringify(fakeBin)}:"$PATH"`,
+      "unset SWITCHROOM_CONFIG",
+      '_LITELLM_OK="1"',
+      block,
+      'echo "EFFECTIVE=$_EFFECTIVE_MODEL"',
+    ].join("\n");
+    const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+    expect(out).toContain(`EFFECTIVE=${DEFAULT_MODEL}`);
+    expect(alertText()).toBe("");
+    expect(fakeArgs()).toBe(""); // CLI never invoked
+  });
+
+  // SE-3 ordering: the live value must land before the carrier compare, so a
+  // session override written against the current live default still applies.
+  it("resolves live BEFORE the carrier compare: override against the live default applies", () => {
+    fakeSwitchroom(`echo ${DEFAULT_MODEL}`);
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
+    expect(runLive("1")).toBe("claude-opus-4-8");
+  });
+
+  it("carrier written against a SUPERSEDED live default is dropped (compare uses the live value)", () => {
+    fakeSwitchroom("echo claude-opus-4-8");
+    // Carrier recorded when the configured default was still sonnet.
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-haiku-4-5", DEFAULT_MODEL));
+    expect(runLive("1")).toBe("claude-opus-4-8");
+    expect(alertText()).toContain("configured default model changed");
+  });
+
+  // SE-4: a proxy-only CONFIGURED default with LiteLLM down must not 4xx
+  // every call — Claude agents degrade to opus, loudly.
+  it("configured fable + LiteLLM down → boots opus with an operator alert", () => {
+    fakeSwitchroom("echo fable");
+    expect(runLive("")).toBe("opus");
+    expect(alertText()).toContain("LiteLLM");
+    expect(alertText()).toContain("fable");
+  });
+
+  it("configured fable + LiteLLM up → boots fable (guard is down-only)", () => {
+    fakeSwitchroom("echo fable");
+    expect(runLive("1")).toBe("fable");
+    expect(alertText()).toBe("");
+  });
+
+  // SE-3 rendered-script ordering lock: live resolution → recorded default →
+  // carrier block → configured-default litellm guard → repoint → active-model
+  // write → exec. If any of these move, the override/invalidate logic misfires.
+  it("locks the resolution ordering in the rendered start.sh", () => {
+    const startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
+    const idxLive = startSh.indexOf("# --- Live configured-default resolution");
+    const idxRecord = startSh.indexOf('.configured-default-model" 2>/dev/null || true');
+    const idxCarrier = startSh.indexOf('if [ -f "' + agentDir + '/.session-model" ]');
+    const idxGuard = startSh.indexOf("# Configured-default LiteLLM guard");
+    const idxRepoint = startSh.indexOf("sr-* passthrough→router repoint");
+    const idxActive = startSh.indexOf('.active-session-model"');
+    const idxExec = startSh.lastIndexOf('--model "$_EFFECTIVE_MODEL"');
+    expect(idxLive).toBeGreaterThan(-1);
+    expect(idxRecord).toBeGreaterThan(idxLive);
+    expect(idxCarrier).toBeGreaterThan(idxRecord);
+    expect(idxGuard).toBeGreaterThan(idxCarrier);
+    expect(idxRepoint).toBeGreaterThan(idxGuard);
+    expect(idxActive).toBeGreaterThan(idxRepoint);
+    expect(idxExec).toBeGreaterThan(idxActive);
+    // And the LKG read happens BEFORE the recorded-default overwrite.
+    const idxLkg = startSh.indexOf('_LKG_MODEL="$(cat');
+    expect(idxLkg).toBeGreaterThan(-1);
+    expect(idxLkg).toBeLessThan(idxRecord);
   });
 });

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -291,9 +291,10 @@ describe("scaffoldAgent", () => {
     const config = makeAgentConfig();
     const result = scaffoldAgent("no-model-agent", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-    // The configured/default model is baked as the seed for $_EFFECTIVE_MODEL,
-    // which the exec line then passes through via --model "$_EFFECTIVE_MODEL".
-    expect(startSh).toContain("_EFFECTIVE_MODEL='claude-sonnet-5'");
+    // The configured/default model is baked as the last-ditch fallback seed
+    // ($_BAKED_MODEL, live-config resolution preferred at boot), and the exec
+    // line passes the resolved value through via --model "$_EFFECTIVE_MODEL".
+    expect(startSh).toContain("_BAKED_MODEL='claude-sonnet-5'");
     expect(startSh).toContain('--model "$_EFFECTIVE_MODEL"');
   });
 
@@ -301,12 +302,12 @@ describe("scaffoldAgent", () => {
     const config = makeAgentConfig({ model: "claude-opus-4-7" });
     const result = scaffoldAgent("opus-agent", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-    // The explicit yaml model is baked into the $_EFFECTIVE_MODEL seed and reaches launch.
-    expect(startSh).toContain("_EFFECTIVE_MODEL='claude-opus-4-7'");
+    // The explicit yaml model is baked into the $_BAKED_MODEL seed and reaches launch.
+    expect(startSh).toContain("_BAKED_MODEL='claude-opus-4-7'");
     expect(startSh).toContain('--model "$_EFFECTIVE_MODEL"');
-    // The default sonnet model must NOT be baked as the effective-model seed
+    // The default sonnet model must NOT be baked as the fallback seed
     // (a doc comment may still reference it as an example — only the seed matters).
-    expect(startSh).not.toContain("_EFFECTIVE_MODEL='claude-sonnet-5'");
+    expect(startSh).not.toContain("_BAKED_MODEL='claude-sonnet-5'");
   });
 
   it("start.sh includes --permission-mode flag when permission_mode is set", () => {
@@ -3085,9 +3086,9 @@ describe("scaffoldAgent with global defaults cascade", () => {
     );
 
     expect(settings.model).toBe("claude-opus-4-7");
-    // And the model is baked as the $_EFFECTIVE_MODEL seed and passed to exec claude in start.sh
+    // And the model is baked as the $_BAKED_MODEL fallback seed and the resolved value passed to exec claude in start.sh
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-    expect(startSh).toContain("_EFFECTIVE_MODEL='claude-opus-4-7'");
+    expect(startSh).toContain("_BAKED_MODEL='claude-opus-4-7'");
     expect(startSh).toContain('--model "$_EFFECTIVE_MODEL"');
   });
 
@@ -3649,7 +3650,7 @@ describe("scaffoldAgent with global defaults cascade", () => {
 
     const startSh = readFileSync(join(tmpDir, "rec-phase2", "start.sh"), "utf-8");
     expect(startSh).toContain("export NEW_VAR='hello'");
-    expect(startSh).toContain("_EFFECTIVE_MODEL='claude-sonnet-5'");
+    expect(startSh).toContain("_BAKED_MODEL='claude-sonnet-5'");
     expect(startSh).toContain('--model "$_EFFECTIVE_MODEL"');
   });
 


### PR DESCRIPTION
## What users get

Editing `model:` in switchroom.yaml and restarting the agent **now actually changes the model**. Previously the launch model was frozen into `start.sh` at `switchroom apply` time while every status surface read the live yaml — so a pin to `fable` kept silently booting `opus` until a full re-apply (Defect B, observed live on klanker 2026-07-17: `launched=opus configured=claude-fable-5` on every relaunch).

## How

`start.sh` resolves the configured model at every boot via a new `switchroom agent effective-model <name>` verb — the SAME `resolveMainModel` resolver `agent list --json` and the gateway use (one implementation, nothing re-derived in shell). The feasibility pieces all pre-existed: the yaml is already bind-mounted ro into every agent container with `SWITCHROOM_CONFIG` set, and the CLI is already in-container.

Red-team amendments implemented (report: fable-redteam-drift-20260717, all 5 mandatory):

1. **Torn/failed-read fallback chain, never silent:** live yaml → `.configured-default-model` (last-known-good from the prior boot, read before it's overwritten) → apply-time bake; one bounded retry; every fallback appends `.session-model-alert` so the gateway tells the operator.
2. **Class-flip refusal:** a Claude↔sr-* flip can't be applied by a restart (routing is render-time); the launcher detects it, keeps the bake, and alerts "run switchroom apply" instead of half-applying.
3. **Configured-default LiteLLM guard:** `model: fable` + proxy down at boot now degrades to `opus` with an alert instead of 4xx-ing every call (previously only the /model carrier path was guarded).
4. **Ordering lock:** live resolution → recorded default → carrier compare → litellm guard → repoint → exec, pinned by a rendered-script test; the carrier's configured-default compare now runs against the truly-live default.
5. **One resolver + alias hygiene:** `agent list --json` now emits the resolved model (`default` → fleet default, matching its own comment), and the retired `claude-fable-5` codename normalizes to the `fable` alias everywhere the resolver runs.

## Tests

sh-harness outcome tests against the RENDERED block with a fake `switchroom` CLI: the previously-missing regression "baked=opus, live yaml=fable → boots fable", torn-read retry, LKG/bake fallbacks + alerts, both class-flip directions, fable+litellm-down guard, carrier-vs-live ordering, no-mount silence, garbage-output shape gate. Existing 44 session-model tests, 212 scaffold tests, CLI + gateway model suites all green; `npm run lint` clean. (Local note: suites need an exec-capable `TMPDIR` per repo CLAUDE.md.)

## Scope / residual

Claude↔Claude switches apply on restart; class flips still need a real apply (by design, alerted). Known residual documented in docs/model-routing.md: mid-life gateway reads of the single-file yaml bind mount can go inode-stale after host-side atomic-rename writes — boot reads always re-resolve; follow-up issue to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)