### PR TITLE
test: regression coverage for 2026-07-17 fixes

### DIFF
--- a/telegram-plugin/tests/turn-flush-suppression-wiring.test.ts
+++ b/telegram-plugin/tests/turn-flush-suppression-wiring.test.ts
@@ -1,0 +1,112 @@
+/**
+ * S1/S2/S4 WIRING (fable red-team 2026-07-17, fixed in #3299 @ a6e09dfb).
+ *
+ * The behavioural suite `turn-flush-suppression.test.ts` proves the scoped
+ * suppression predicate in isolation, and `answer-ready-flush.test.ts` proves
+ * the quiescence controller's reset/re-arm semantics — but neither says
+ * whether the GATEWAY actually calls them, or what it does with the answer.
+ * That decision-vs-delivery gap is exactly how the original S1 bug shipped:
+ * every routine was individually correct while the gateway's call site
+ * counted ANY chat-wide outbound and then CLOSED the obligation, silently
+ * dropping the user's real answer.
+ *
+ * gateway.ts is a side-effecting IIFE that cannot be imported in a unit test
+ * (same constraint as activity-card-wiring.test.ts /
+ * silence-liveness-wiring.test.ts), so these are STRUCTURAL assertions that
+ * pin the load-bearing call sites. They COMPLEMENT the behavioural suites —
+ * the outcomes are proven at routine level; this guards the wiring those
+ * routines depend on. Each test names the regression it would catch.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf-8')
+
+function between(src: string, startMarker: string, endMarker: string): string {
+  const after = src.split(startMarker)[1] ?? ''
+  return after.split(endMarker)[0] ?? ''
+}
+
+/** Strip // comment lines so prose quoting the OLD (buggy) shape can't
+ *  satisfy — or trip — an assertion about the CODE. */
+function codeOnly(src: string): string {
+  return src
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('/*'))
+    .join('\n')
+}
+
+describe('S1 wiring — turn-flush suppression call site', () => {
+  // The whole suppression branch: predicate call through the end of the
+  // `if (suppress)` early-return.
+  const branch = between(
+    gatewaySrc,
+    'const { shouldSuppressTurnFlush }',
+    '// #3276 guard 5',
+  )
+
+  it('the gateway asks the SCOPED predicate, not a chat-wide outbound count', () => {
+    expect(branch.length).toBeGreaterThan(100)
+    const code = codeOnly(branch)
+    // The oracle is the thread/length-scoped history query…
+    expect(code).toMatch(/hasSubstantiveOutbound:\s*hasOutboundDeliveredSince/)
+    // …with an EXPLICIT null thread for chat-root turns (undefined would
+    // match rows in ANY topic and re-open the cross-topic false positive)…
+    expect(code).toMatch(/threadId:\s*backstopThreadId\s*\?\?\s*null/)
+    // …and the captured answer's length driving the substantive floor.
+    expect(code).toMatch(/answerLength:\s*capturedText\.length/)
+    // The OLD chat-wide predicate must never come back anywhere in the branch.
+    expect(code).not.toMatch(/getRecentOutboundCount/)
+  })
+
+  it('suppression leaves the obligation OPEN (noteTurnEnded) — never closes it', () => {
+    const code = codeOnly(branch)
+    // A false-positive suppression must stay recoverable: the sweep/liveness
+    // floor arbitrates. Closing here made the drop PERMANENT (the S1 bug).
+    expect(code).toMatch(/obligationLedger\.noteTurnEnded\(turn\.turnId/)
+    expect(code).not.toMatch(/obligationLedger\.close\(/)
+  })
+
+  it('the old predicate is gone from the whole gateway turn-flush path', () => {
+    // getRecentOutboundCount must not be consulted anywhere in gateway.ts —
+    // any reintroduction re-opens the chat-wide suppression class.
+    expect(codeOnly(gatewaySrc)).not.toMatch(/getRecentOutboundCount/)
+  })
+})
+
+describe('S2 wiring — thinking events re-arm the answer-ready quiescence flush', () => {
+  it("the 'thinking' event arm calls resetAnswerReadyFlushTimeout()", () => {
+    // Without this, "prose → >1s thinking pause → trailing NO_REPLY" lets the
+    // quiescence timer fire mid-pause and deliver a turn the model intended
+    // silent. Scope to the thinking case arm only.
+    const arm = between(gatewaySrc, "case 'thinking': {", "case 'tool_use': {")
+    expect(arm.length).toBeGreaterThan(50)
+    expect(codeOnly(arm)).toMatch(/resetAnswerReadyFlushTimeout\(\)/)
+  })
+})
+
+describe('S4 wiring — flushed answers quote-anchor to the inbound they answer', () => {
+  it('deliverAnswer anchors the FIRST chunk with reply_parameters + allow_sending_without_reply', () => {
+    const sendChunk = between(
+      gatewaySrc,
+      'const sendChunk = async (chunkIndex: number',
+      'buildSendOpts:',
+    )
+    expect(sendChunk.length).toBeGreaterThan(50)
+    const code = codeOnly(sendChunk)
+    // First chunk only, and only when the turn has an inbound to anchor to.
+    expect(code).toMatch(/chunkIndex === 0 && args\.replyToMessageId != null/)
+    // allow_sending_without_reply keeps the send alive if the user deleted
+    // their message — without it the whole flush would fail on a dangling id.
+    expect(code).toMatch(/allow_sending_without_reply:\s*true/)
+    expect(code).toMatch(/reply_parameters/)
+  })
+
+  it('the turn-flush call site passes the turn’s inbound id (bare for synthesized turns)', () => {
+    // The anchor must be the message this TURN answers — turn.sourceMessageId
+    // is null for cron/handback turns, which therefore still send bare.
+    expect(codeOnly(gatewaySrc)).toMatch(/replyToMessageId:\s*turn\.sourceMessageId/)
+  })
+})


### PR DESCRIPTION
Audit of yesterday's fix commits on main: does each have a regression test that would FAIL if the bug returned (outcome, not code-path)?

## Coverage table

| Commit | Fix | Verdict | Evidence |
|---|---|---|---|
| cafb77f4 | launch: resolve model LIVE at boot | **COVERED** (existing) | `tests/scaffold.session-model.test.ts` — sh-harness outcome tests incl. "boots the LIVE yaml model when it differs from the apply-time bake (Defect B)", torn-read retry, LKG/bake fallbacks + alerts, class-flip refusal, fable+LiteLLM-down guard |
| a6e09dfb | telegram: turn-flush suppression / quiescence / quote-anchor | **PARTIAL → closed** | Predicate covered by `turn-flush-suppression.test.ts`; the gateway WIRING legs (scoped-predicate call, obligation left OPEN via `noteTurnEnded` not `close`, thinking re-arms `resetAnswerReadyFlushTimeout`, first-chunk quote-anchor) were unpinned — reverting them kept all tests green. **Added `telegram-plugin/tests/turn-flush-suppression-wiring.test.ts`** (structural style per `activity-card-wiring.test.ts`; gateway.ts is an unimportable IIFE, comment-stripped assertions, also pins `getRecentOutboundCount` never returns) |
| 7729c674 | errors: proxy-fallback 401 operator-only | **COVERED** (existing) | `litellm-proxy-auth-misconfig.test.ts` — proxy 401 never renders re-auth card, genuine expiry still reaches operator, user notice diagnosis-free, PendingUserNoticeGate drop-on-recovery/send-once/TTL |
| 40c957ee | gateway: terminal catch-all | **COVERED** (existing) | `catch-all-unhandled-message.test.ts` drives the REAL production module through a real grammy 1.44 Bot (unregistered content → turn; service noise → no turn) + structural registration-order guard; `catch-all-forwarded-history.test.ts` |
| 9225ef95 | tz: local-render + reject typo'd zones | **COVERED** (existing) | `src/config/loader.test.ts` (typo'd IANA rejected at load), `local-time.test.ts` (/logs UTC→local incl. no-double-shift), `vendor/hindsight-memory/tests/test_content.py` (recalled-memory local render) |
| db4e6933 | vault: grants survive broker recreate | **COVERED** (existing) | `src/vault/grants-db.test.ts` — "grants persist when the DB is reopened from the persisted directory only", checkpoint-after-mutation, legacy migration; `tests/docker/compose-generator.test.ts` pins the DIRECTORY bind mount |
| de3265e1 | cli: re-add --lines to agent logs | **COVERED** (existing) | `src/cli/agent.test.ts` — option registration + `resolveLogsTail` clamp contract + `buildAgentLogsArgs` docker argv (`--tail`) |
| bd6e861b | model: survive wedged apply-boot | **COVERED** (existing) | `tests/scaffold.session-model.test.ts` — "good token + wedge before healthy boot → RE-APPLIES on the retry boot (no silent revert)", bounded-attempts giveup + alert; `session-model-file.test.ts` healthy-boot consume |
| 305ebfb5 | model: honest confirmation on silent revert | **COVERED** (existing) | `model-command.test.ts` — `classifyModelSwitchConfirmation` flags reverted switch as not-applied, family-alias matching; `gateway-session-model-relaunch.test.ts` warns instead of green ✅ |
| d412cfb0 | (test fix) handoff-briefing date boundary | **Deterministic — confirmed** | Names the daily-memory file via zone-pinned `dateInZone` (same zone passed to the script); commit verified green under TZ=UTC / America/New_York / Pacific/Kiritimati; the UTC+14-vs-UTC-11 boundary test forces divergent dates deterministically |

## Honest residuals

- The wiring test is structural (source-text pins) because `gateway.ts` is a side-effecting IIFE that cannot be instantiated in a unit test — same accepted constraint as `activity-card-wiring.test.ts` / `silence-liveness-wiring.test.ts`. The behavioural outcomes are proven at routine level in the existing suites; this closes the decision-vs-delivery gap only.
- S4's end-to-end "Telegram message actually quotes the inbound" is not deterministically testable without a live Bot API; the anchor construction + call-site are pinned instead.

## Verification

- New + existing suppression suite: 13/13 green.
- All 15 cited suites re-run scoped: 405 tests green (one env artifact: `scaffold.session-model` live-resolution tests need an exec-able TMPDIR — my sandbox's /tmp is noexec; green with `TMPDIR` on a normal FS, and green on CI at merge).
- `npm run lint`: tsc + all 9 guard scripts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)