### PR TITLE
feat(telegram-plugin): number workers on the combined Workers card (#3298)

### DIFF
--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -754,6 +754,48 @@ describe('renderCombinedWorkerFeed (pure)', () => {
     expect(combinedHistoryDepth(6)).toBe(1)
     expect(combinedHistoryDepth(8)).toBe(1)
   })
+
+  // ── Worker numbering (#3298): stable ordinal prefix at 2+ workers ──────────
+  const rowN = (i: number, ordinal: number) => ({ ...row(i, `step ${i}`), ordinal })
+
+  it('numbers the workers with a literal "N. " prefix inside the bold header when 2+ run', () => {
+    const body = renderCombinedWorkerFeed([rowN(1, 1), rowN(2, 2)], { maxRows: 8 })!
+    // The literal `1. ` must survive markdown rendering, inside the bold span
+    // before the escaped description.
+    expect(body).toContain('**1. task number 1**')
+    expect(body).toContain('**2. task number 2**')
+  })
+
+  it('renders non-contiguous ordinals as-is (survivors keep their numbers after a finish)', () => {
+    // Worker 1 finished upstream — the surviving rows arrive with their
+    // ORIGINAL ordinals. Positional numbering would render 1./2. here; the
+    // stable scheme must render 2./3. and never a `1. `.
+    const body = renderCombinedWorkerFeed([rowN(2, 2), rowN(3, 3)], { maxRows: 8 })!
+    expect(body).toContain('**2. task number 2**')
+    expect(body).toContain('**3. task number 3**')
+    expect(body).not.toContain('**1. ')
+  })
+
+  it('a single row is never numbered, even when it carries an ordinal', () => {
+    const body = renderCombinedWorkerFeed([rowN(1, 1)], { maxRows: 8 })!
+    expect(body).toContain('**task number 1**')
+    expect(body).not.toContain('**1. ')
+  })
+
+  it('rows without ordinals render unnumbered (back-compat for direct callers)', () => {
+    const body = renderCombinedWorkerFeed([row(1, 'alpha'), row(2, 'beta')], { maxRows: 8 })!
+    expect(body).toContain('**task number 1**')
+    expect(body).toContain('**task number 2**')
+    expect(body).not.toContain('1. task')
+  })
+
+  it('spilled rows take their ordinals with them; visible ordinals do not shift', () => {
+    const rows = Array.from({ length: 10 }, (_, i) => rowN(i + 1, i + 1))
+    const body = renderCombinedWorkerFeed(rows, { maxRows: 4 })!
+    expect(body).toContain('+6 more working')
+    for (let n = 1; n <= 4; n++) expect(body).toContain(`**${n}. task number ${n}**`)
+    expect(body).not.toContain('**5. ')
+  })
 })
 
 /**
@@ -1017,5 +1059,89 @@ describe('worker-feed ghost-leak — deterministic terminal removal + backstop',
     await feed.update('e', 'chat', view('task e', 'same step', 0))
     await drain()
     expect(edits.length).toBe(afterPaint)
+  })
+})
+
+describe('worker numbering — stable per-card ordinals end to end (#3298)', () => {
+  const doneView = (desc: string, elapsedMs: number): WorkerActivityView => ({
+    description: desc,
+    lastTool: null,
+    toolCount: 3,
+    latestSummary: `${desc} result`,
+    elapsedMs,
+    state: 'done',
+  })
+  const lastBody = (h: { sends: { text: string }[]; edits: { messageId: number; text: string }[] }): string => {
+    if (h.edits.length > 0) return h.edits[h.edits.length - 1].text
+    return h.sends[h.sends.length - 1].text
+  }
+
+  it('assigns 1./2./3. at dispatch and survivors KEEP their numbers when an earlier worker finishes', async () => {
+    let clock = 1000
+    const h = ghostHarness({ now: () => clock })
+    await h.feed.update('a', 'chat', view('task alpha', 'a-doing', 0))
+    await h.feed.update('b', 'chat', view('task beta', 'b-doing', 0))
+    await h.feed.update('c', 'chat', view('task gamma', 'c-doing', 0))
+    await drain()
+
+    let body = lastBody(h)
+    expect(body).toContain('**1. task alpha**')
+    expect(body).toContain('**2. task beta**')
+    expect(body).toContain('**3. task gamma**')
+
+    // Worker 1 finishes: the survivors must STILL be 2. and 3. — positional
+    // numbering would renumber them 1./2. and this assertion would fail.
+    clock = 2000
+    await h.feed.finish('a', doneView('task alpha', 1000))
+    await drain()
+    body = lastBody(h)
+    expect(body).toContain('2 running')
+    expect(body).toContain('**2. task beta**')
+    expect(body).toContain('**3. task gamma**')
+    expect(body).not.toContain('**1. ')
+  })
+
+  it('a single running worker is never numbered (single-worker layout)', async () => {
+    const h = ghostHarness({ now: () => 1000 })
+    await h.feed.update('solo', 'chat', view('task solo', 'working', 0))
+    await drain()
+    const body = lastBody(h)
+    expect(body).toContain('task solo')
+    expect(body).not.toContain('1. task solo')
+  })
+
+  it('a fresh card after ALL workers finish numbers from 1 again', async () => {
+    let clock = 1000
+    const h = ghostHarness({ now: () => clock })
+    await h.feed.update('a', 'chat', view('task alpha', 'a-doing', 0))
+    await h.feed.update('b', 'chat', view('task beta', 'b-doing', 0))
+    await drain()
+    clock = 2000
+    await h.feed.finish('a', doneView('task alpha', 1000))
+    await h.feed.finish('b', doneView('task beta', 1000))
+    await drain()
+    expect(h.feed.size).toBe(0)
+
+    // New fan-out in the same chat → a NEW card that starts at 1., not 3.
+    clock = 3000
+    await h.feed.update('c', 'chat', view('task gamma', 'c-doing', 0))
+    await h.feed.update('d', 'chat', view('task delta', 'd-doing', 0))
+    await drain()
+    const body = lastBody(h)
+    expect(body).toContain('**1. task gamma**')
+    expect(body).toContain('**2. task delta**')
+  })
+
+  it('introducing ordinals causes no dedup churn (same substance → edit still skipped)', async () => {
+    const h = ghostHarness({ now: () => 1000 })
+    await h.feed.update('a', 'chat', view('task alpha', 'same step', 0))
+    await h.feed.update('b', 'chat', view('task beta', 'same step', 0))
+    await drain()
+    const landed = h.edits.length
+    // Byte-identical substance re-update: the dedup/no-op skip must still fire
+    // (a stable ordinal never varies the substance between identical renders).
+    await h.feed.update('a', 'chat', view('task alpha', 'same step', 0))
+    await drain()
+    expect(h.edits.length).toBe(landed)
   })
 })

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -646,6 +646,15 @@ export interface CombinedWorkerRow {
   /** Running total tokens for this worker — rendered as `· {N} tok` on the row
    *  header. Omitted (0/undefined) → no token segment. */
   totalTokens?: number
+  /**
+   * Stable per-card ordinal (1-based), assigned when the worker joins its feed
+   * group and KEPT for the card's lifetime — survivors keep their numbers when
+   * an earlier worker finishes (the card may show `2.`/`3.` with no `1.`; the
+   * `N running` chrome carries the count). Rendered as a `{ordinal}. ` prefix
+   * inside the bold header when the card has 2+ rows. Omitted → unnumbered
+   * (back-compat for direct callers).
+   */
+  ordinal?: number
 }
 
 export interface CombinedWorkerFeedOpts {
@@ -687,12 +696,18 @@ export function combinedHistoryDepth(w: number): number {
  * markdown; callers send verbatim — do NOT re-escape). Layout:
  *
  *   🛠 **Workers** · _N running_
- *   **{desc1}** _· {elapsed} · {n} tools_
+ *   **1. {desc1}** _· {elapsed} · {n} tools_
  *   ~~_✓ {earlier step}_~~
  *   **→ {newest step}**
- *   **{desc2}** _· {elapsed} · {n} tools_
+ *   **2. {desc2}** _· {elapsed} · {n} tools_
  *   **→ {newest step}**
  *   _+M more working…_
+ *
+ * NUMBERING (#3298): when the card tracks 2+ rows AND a row carries `ordinal`,
+ * its header gets a stable `{ordinal}. ` prefix. Ordinals are assigned by the
+ * caller at dispatch and kept for the card's life — after an earlier worker
+ * finishes the survivors keep their numbers (`2.`, `3.` with no `1.`). A lone
+ * row, or rows without ordinals, render unnumbered.
  *
  * ADAPTIVE DENSITY: each visible worker renders its last-K narrative lines as a
  * `✓`/`→` trail (prior steps struck, newest bold in-progress) — the single-
@@ -716,6 +731,11 @@ export function renderCombinedWorkerFeed(
   if (rows.length === 0) return null
   const maxRows = Math.max(1, Math.floor(opts.maxRows))
 
+  // Number the workers only when the CARD tracks 2+ (a lone worker stays
+  // unnumbered). Uses the total row count, not the visible count, so ordinals
+  // don't appear/vanish as the overflow backstop shrinks the visible set.
+  const numbered = rows.length >= 2
+
   const rowHeader = (r: CombinedWorkerRow): string => {
     const desc = escapeMarkdown(
       truncate(stripMarkdown(r.description).replace(/\s+/g, ' ').trim() || 'background task', COMBINED_ROW_DESC_MAX),
@@ -724,7 +744,11 @@ export function renderCombinedWorkerFeed(
     const tokPart = tokenSegment(r.totalTokens)
     const modelLabel = formatModelLabel(r.model)
     const modelPart = modelLabel != null ? ` · ${escapeMarkdown(modelLabel)}` : ''
-    return `**${desc}** _· ${formatFeedElapsed(r.elapsedMs)} · ${r.toolCount} ${toolWord}${tokPart}${modelPart}_`
+    // Stable ordinal prefix INSIDE the bold span, before the already-escaped
+    // description — no new escaping surface, and the gateway md→HTML conversion
+    // has no ordered-list auto-formatting on bolded text.
+    const num = numbered && r.ordinal != null ? `${r.ordinal}. ` : ''
+    return `**${num}${desc}** _· ${formatFeedElapsed(r.elapsedMs)} · ${r.toolCount} ${toolWord}${tokPart}${modelPart}_`
   }
 
   // Raw (unescaped) history for a worker, oldest→newest, empty lines stripped.

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -471,6 +471,14 @@ interface WorkerRow {
    * once past STEP_TIMER_MIN_MS.
    */
   stepStartedAtMs: number | null
+  /**
+   * Stable 1-based ordinal within the group's CURRENT card, assigned from the
+   * group's monotonic counter when the row is first registered and IMMUTABLE
+   * thereafter. The combined feed renders it as a `{n}. ` header prefix when
+   * 2+ workers are running; survivors keep their numbers when an earlier
+   * worker finishes (never renumbered positionally — #3298).
+   */
+  ordinal: number
 }
 
 /**
@@ -511,6 +519,13 @@ interface FeedGroup {
   chain: Promise<void>
   /** Live workers in this group, keyed by agentId (insertion ≈ dispatch order). */
   workers: Map<string, WorkerRow>
+  /**
+   * Monotonic per-card worker counter — `++counter` hands each newly
+   * registered row its stable {@link WorkerRow.ordinal}. Reset to 0 whenever a
+   * fresh card starts (group creation / the group-reuse-after-terminal repaint
+   * / registration into an emptied group), so every new card numbers from 1.
+   */
+  workerOrdinalCounter: number
   /**
    * Terminal renders (per finishing worker's recap) staged because a 429
    * cooldown / flood window blocked the edit. Keyed by agentId so a SECOND
@@ -844,6 +859,9 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       const currentStep = r.narrative.length > 0 ? r.narrative[r.narrative.length - 1] : v.latestSummary
       return {
         description: v.description,
+        // Stable per-card ordinal — assigned at registration, kept for the
+        // card's life (survivors don't renumber when an earlier worker ends).
+        ordinal: r.ordinal,
         elapsedMs: elapsedFor(r),
         toolCount: v.toolCount,
         totalTokens: v.totalTokens,
@@ -1488,6 +1506,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           cooldownUntil: 0,
           chain: Promise.resolve(),
           workers: new Map(),
+          workerOrdinalCounter: 0,
           pendingFinalize: new Map(),
           terminalPainted: false,
         }
@@ -1512,8 +1531,12 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       }
       let row = g.workers.get(agentId)
       if (row == null) {
+        // A registration into an EMPTIED group starts a fresh card — number
+        // from 1 again rather than continuing the dead card's sequence.
+        if (g.workers.size === 0) g.workerOrdinalCounter = 0
         row = {
           agentId,
+          ordinal: ++g.workerOrdinalCounter,
           narrative: [],
           lastView: null,
           state: 'running',

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -522,8 +522,9 @@ interface FeedGroup {
   /**
    * Monotonic per-card worker counter — `++counter` hands each newly
    * registered row its stable {@link WorkerRow.ordinal}. Reset to 0 whenever a
-   * fresh card starts (group creation / the group-reuse-after-terminal repaint
-   * / registration into an emptied group), so every new card numbers from 1.
+   * fresh card starts (group creation, and registration into an emptied group
+   * — which covers the group-reuse-after-terminal repaint, since finalize
+   * drops rows from `workers` immediately), so every new card numbers from 1.
    */
   workerOrdinalCounter: number
   /**


### PR DESCRIPTION
Fixes switchroom/switchroom#3298

## Summary

When 2+ background workers render into the combined `🛠 Workers` card, each worker's header now carries a stable `1. ` / `2. ` ordinal prefix inside the bold span. A single running worker stays unnumbered (single-worker layout untouched).

Ordinals are **stable for the card's life**: assigned from a per-group monotonic counter when the worker registers, immutable thereafter. When an earlier worker finishes, survivors keep their numbers — the card may show `2.`/`3.` with no `1.` (the `N running` chrome carries the count). A fresh card (all workers finished, new fan-out) numbers from 1 again.

Per the scope comment's design of record on #3298 (stable-ordinal recommendation, not positional).

## Why

With several workers running, the rows are hard to reference and track across edits ("the second one is stuck"). Positional numbering would renumber survivors mid-run and defeat visual tracking; stable ordinals preserve identity.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md` — the card is the worker-visibility surface; numbering makes multi-worker state referenceable at a glance.

## What changed

- `telegram-plugin/tool-activity-summary.ts` — `CombinedWorkerRow.ordinal?` + `{n}. ` prefix in `rowHeader` when the card tracks 2+ rows; rows without ordinals render unchanged (back-compat for direct callers).
- `telegram-plugin/worker-activity-feed.ts` — `WorkerRow.ordinal` from a per-`FeedGroup` `workerOrdinalCounter` (reset when a fresh card starts); threaded into the combined-row mapping.
- `telegram-plugin/tests/worker-feed-coalesce.test.ts` — outcome tests: literal `1. ` survives render at 2+, single row never numbered, non-contiguous survivor ordinals (fails under positional numbering), spill keeps ordinals, fresh card restarts at 1, no dedup churn (identical substance still no-op).

Documented choice: the 2→1 transition switches to the unnumbered single-worker layout, per scope ("single stays as-is"). The overflow oldest/newest comment mismatch flagged in the scope is deliberately NOT touched here (separate concern).

## Test plan

- Scoped: `vitest run telegram-plugin/tests/worker-feed-coalesce.test.ts` — 37 pass (10 new).
- All 16 test files touching the feed/renderer: 344 pass; bun-only `nested-worker-visibility-harness.test.ts`: 2 pass.
- `npm run lint` clean (tsc + all guard scripts).

## Risk

Low — pure render change plus one immutable per-row field; no config, no migration. Substance key unchanged (ordinal is a stable function of the row), so no edit churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)