### PR TITLE
fix(telegram): line-leading issue refs (#123) are not headings

### DIFF
--- a/telegram-plugin/render/render.ts
+++ b/telegram-plugin/render/render.ts
@@ -203,10 +203,34 @@ function renderTable(node: TableNode): string {
   return [headerLine, sepLine, ...bodyLines].join("\n");
 }
 
+/**
+ * Escape a line-leading `#` in rendered PROSE so Telegram cannot promote the
+ * line to a heading (#3304 regression).
+ *
+ * Per CommonMark/GFM, `#` opens an ATX heading only when followed by a space,
+ * another `#`, or end-of-line — so micromark correctly parses `#3304 is
+ * merged.` as a plain paragraph, and this renderer re-emits it verbatim
+ * (`escapeMarkdown` deliberately leaves `#` alone). But Telegram's Bot API
+ * 10.1 server-side rich-markdown parser is NON-spec here: any line-leading
+ * `#` run is read as a heading, so an issue reference opening a line renders
+ * the whole paragraph as huge heading text. Backslash-escaping the first `#`
+ * of each such line keeps it literal on Telegram while remaining a no-op
+ * visually (Telegram honours backslash escapes, same mechanism the link-href
+ * `)` escape relies on).
+ *
+ * Applied ONLY to paragraph output (including paragraphs nested in
+ * blockquotes / list items via their renderBlock recursion), never to
+ * heading, code-block, or table nodes — so a genuine `# Title` heading node
+ * still renders as `# Title`.
+ */
+function escapeLineLeadingHash(text: string): string {
+  return text.replace(/^([ \t]{0,3})#/gm, "$1\\#");
+}
+
 function renderBlock(node: Block): string {
   switch (node.type) {
     case "paragraph":
-      return renderInlineChildren(node.children);
+      return escapeLineLeadingHash(renderInlineChildren(node.children));
     case "heading":
       return `${"#".repeat(node.level)} ${renderInlineChildren(node.children)}`;
     case "blockquote":

--- a/telegram-plugin/tests/render/render.test.ts
+++ b/telegram-plugin/tests/render/render.test.ts
@@ -143,6 +143,48 @@ describe("render: inline palette", () => {
   });
 });
 
+describe("render: line-leading issue refs are not headings (#3304 regression)", () => {
+  it("multi-line message whose first line starts with #3304 stays a paragraph", () => {
+    const md = "#3304 is merged. The regression suite is green.\n\nNext up: the follow-up PR.";
+    const doc = parse(md);
+    // Spec-correct parse: `#` without a following space is NOT an ATX heading.
+    expect(doc.blocks.map((b) => b.type)).toEqual(["paragraph", "paragraph"]);
+
+    const out = render(doc);
+    // The line-leading `#` must be escaped so Telegram's non-spec rich parser
+    // cannot promote the line to a heading...
+    expect(out.startsWith("\\#3304 is merged.")).toBe(true);
+    expect(out).not.toMatch(/^#{1,6} /m);
+    // ...and the escape resolves back to the literal "#3304" on re-parse
+    // (what the reader sees), with no heading node anywhere.
+    const reparsed = parse(out);
+    expect(reparsed.blocks.map((b) => b.type)).toEqual(["paragraph", "paragraph"]);
+    expect((reparsed.blocks[0] as any).children[0].text).toContain("#3304 is merged.");
+  });
+
+  it("issue ref at line start mid-message is escaped too", () => {
+    const md = "Shipped today:\n#123 closes the loop on retries.";
+    const out = render(parse(md));
+    expect(out).toContain("\n\\#123 closes the loop");
+    const reparsed = parse(out);
+    expect(reparsed.blocks.every((b) => b.type !== "heading")).toBe(true);
+  });
+
+  it("a genuine `# Heading` still renders as a heading", () => {
+    const md = "# Release notes\n\n#456 fixed the flake.";
+    const out = render(parse(md));
+    expect(out.startsWith("# Release notes")).toBe(true);
+    expect(out).toContain("\\#456 fixed the flake.");
+    const reparsed = parse(out);
+    expect(reparsed.blocks[0].type).toBe("heading");
+  });
+
+  it("mid-line `#` is left alone", () => {
+    const md = "merged in PR #789 yesterday";
+    expect(render(parse(md))).toBe(md);
+  });
+});
+
 describe("render: block palette", () => {
   it("heading levels 1-6", () => {
     for (let level = 1; level <= 6; level++) {


### PR DESCRIPTION
## Problem

An outbound message whose line starts with an issue reference — e.g. `#3304 is merged. The regression suite is green.` — renders in Telegram as a huge heading spanning the whole paragraph.

**Before (Telegram):** the entire first paragraph in giant heading text.
**After:** plain body text, literal `#3304` preserved.

## Root cause

- The parser is spec-correct: micromark reads `#3304` as a plain paragraph (GFM/CommonMark: `#` opens an ATX heading only when followed by a space, another `#`, or EOL). No bug there.
- The renderer (`telegram-plugin/render/render.ts`, `renderBlock` paragraph case) re-emits the text via `escapeMarkdown`, which deliberately never escapes `#` (format.ts:53). So the wire body still begins with a literal line-leading `#`.
- Telegram's Bot API 10.1 server-side rich-markdown parser is **non-spec**: it promotes any line-leading `#` run to a heading, space or not. That's the promotion step.

## Fix

New `escapeLineLeadingHash` helper applied only to rendered **paragraph** output: backslash-escapes the first `#` of each line (`/^([ \t]{0,3})#/gm`). Telegram honours backslash escapes (same mechanism as the existing link-href `)` escape), so the reader sees a literal `#3304`. Heading IR nodes render untouched, so genuine `# Title` headings keep working; mid-line `#` is untouched; code blocks/tables/blockquote markers unaffected. This is the single shared render path (`renderOutboundChunks` → stream-controller), so every agent's outbound gets the fix automatically.

## Tests

New describe block in `tests/render/render.test.ts`:
- multi-line message starting `#3304 is merged.` → stays paragraphs, output starts `\#3304`, no heading on re-parse, literal `#3304` round-trips
- `#123` at line start mid-message → escaped, no heading
- genuine `# Heading` still renders as a heading
- mid-line `#` left alone

Results: `tests/render/` 10 files / 232 tests pass; normalizer suites (paragraph-normalizer, paragraph-spacer-golden, telegram-format, format-consistency, formatting-parse-regression, card-format) 221 tests pass — no block-spacing/bullet regressions. `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)