### PR TITLE
fix(gateway): key PendingUserNoticeGate by turn/topic (#3294)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5191,8 +5191,9 @@ function endCurrentTurnAtomic(
   // gate drops the notice; reply-less → the turn genuinely died, the notice is
   // sent now. replyCalled covers the short-answer/#2624 shape where
   // finalAnswerDelivered stays false despite an explicit reply. No-op when
-  // nothing is pending (the overwhelmingly common path).
-  flushPendingUserFailureNotices(turn.finalAnswerDelivered || turn.replyCalled)
+  // nothing is pending (the overwhelmingly common path). #3294 — `key` scopes
+  // resolution to THIS turn's topic under keyed liveness.
+  flushPendingUserFailureNotices(turn.finalAnswerDelivered || turn.replyCalled, key)
   return turnEndedAt
 }
 
@@ -8463,15 +8464,23 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
   // Un-resolved notices expire after PENDING_USER_NOTICE_TTL_MS (bias to
   // silence over a false failure claim). Operator cards above stay immediate.
   if (userNoticeChats.length > 0) {
+    // #3294 — key the notice to the live turn's topic so under PR-4e keyed
+    // liveness only THAT topic's turn end resolves it (full rationale on
+    // `PendingUserNotice.key`). `undefined` (no live turn — the event is
+    // agent-level, empty wire chatId) keeps the legacy agent-wide resolution.
+    const liveTurn = currentTurn
+    const noticeKey =
+      liveTurn != null ? statusKey(liveTurn.sessionChatId, liveTurn.sessionThreadId) : undefined
     pendingUserNoticeGate.schedule({
       chatIds: userNoticeChats,
       text: renderUserFacingFailureNotice(),
       agent,
       kind,
       atMs: Date.now(),
+      key: noticeKey,
     })
     process.stderr.write(
-      `telegram gateway: operator-event user-notice deferred to turn-end agent=${agent} kind=${kind} chats=${userNoticeChats.length}\n`,
+      `telegram gateway: operator-event user-notice deferred to turn-end agent=${agent} kind=${kind} chats=${userNoticeChats.length} topic=${noticeKey ?? '-'}\n`,
     )
   }
 }
@@ -8483,9 +8492,11 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
  * (the model explicitly replied → the turn recovered → notices are dropped by
  * the gate). Only a reply-less turn end flushes the pending notices to the
  * non-operator chats, so the user notice fires IFF the turn genuinely died.
+ * `turnKey` (#3294) scopes resolution to the ending turn's topic — a concurrent
+ * topic's pending notice is left for its own turn end under keyed liveness.
  */
-function flushPendingUserFailureNotices(turnDeliveredReply: boolean): void {
-  const notices = pendingUserNoticeGate.resolveTurnEnd(turnDeliveredReply)
+function flushPendingUserFailureNotices(turnDeliveredReply: boolean, turnKey: string): void {
+  const notices = pendingUserNoticeGate.resolveTurnEnd(turnKey, turnDeliveredReply)
   if (notices.length === 0) return
   const noticeTopic = resolveAgentOutboundTopic({ kind: 'compact-watchdog' })
   const noticeSupergroup = resolveAgentSupergroupChatId()

--- a/telegram-plugin/pending-user-notice.ts
+++ b/telegram-plugin/pending-user-notice.ts
@@ -36,6 +36,25 @@ export interface PendingUserNotice {
   kind: string
   /** When the notice was scheduled (ms epoch). */
   atMs: number
+  /**
+   * TOPIC KEY (#3294) — `statusKey(chatId, threadId)` of the turn that was live
+   * when the error surfaced, or `undefined` when no turn was attributable (the
+   * error arrived between turns, or after a silence poke nulled the live turn).
+   *
+   * Why it exists: the api_error operator event is agent-level (its wire
+   * `chatId` is always empty), so the gate USED to collapse per-agent and let
+   * ANY turn end resolve the notice. Under the PR-4e keyed-liveness flag
+   * (concurrent per-topic turns) that is a bug: turn B's reply-less end would
+   * flush turn A's pending notice while A may still recover — a FALSE "couldn't
+   * complete" claim. Keying the notice by the live turn's topic means only a
+   * turn end on the SAME topic resolves it (see {@link
+   * PendingUserNoticeGate.resolveTurnEnd}).
+   *
+   * A notice with an UNDEFINED key keeps the legacy agent-wide resolution (any
+   * turn end resolves it), so single-turn gateways — the current norm, where
+   * there is only ever one topic — are byte-identical to the pre-#3294 gate.
+   */
+  key?: string
 }
 
 /** How long a scheduled notice may wait for a resolving turn end. */
@@ -45,28 +64,55 @@ export class PendingUserNoticeGate {
   private pending: PendingUserNotice[] = []
 
   /**
-   * Schedule a notice for turn-end resolution. Collapses per agent — a burst
-   * of error lines within one turn holds ONE pending notice, not a stack.
+   * Schedule a notice for turn-end resolution. Collapses per (agent, topic key)
+   * — a burst of error lines within one turn holds ONE pending notice for that
+   * topic, not a stack. Distinct concurrent topics (keyed liveness) each keep
+   * their own pending notice, so one topic's burst never overwrites another's.
+   * (For a single-turn gateway every notice shares the one topic — or an
+   * undefined key — so the collapse is identical to the pre-#3294 per-agent one.)
    */
   schedule(notice: PendingUserNotice): void {
     this.prune(notice.atMs)
-    this.pending = this.pending.filter((p) => p.agent !== notice.agent)
+    this.pending = this.pending.filter(
+      (p) => !(p.agent === notice.agent && p.key === notice.key),
+    )
     this.pending.push(notice)
   }
 
   /**
-   * Resolve at turn end. `turnDeliveredReply` is the turn's outcome signal
-   * (the gateway passes `finalAnswerDelivered || replyCalled`):
-   *   - true  → the turn recovered; every pending notice is dropped, [] returned.
-   *   - false → the turn died without a reply; the un-expired pending notices
-   *     are returned EXACTLY ONCE for the caller to send.
-   * Either way the ledger is cleared (a notice never survives its turn end).
+   * Resolve at the end of the turn whose topic is `turnKey`. `turnDeliveredReply`
+   * is the turn's outcome signal (the gateway passes `finalAnswerDelivered ||
+   * replyCalled`).
+   *
+   * A pending notice is RESOLVED by this turn end iff it belongs to the ending
+   * turn's topic (`p.key === turnKey`) OR it is unattributed (`p.key ===
+   * undefined` — legacy agent-wide resolution, kept so single-turn gateways are
+   * unchanged). Notices scheduled for a DIFFERENT live topic stay pending until
+   * their own topic's turn ends (or the TTL expires) — this is the #3294 fix:
+   * turn B's end no longer flushes turn A's pending notice.
+   *
+   * Of the resolved notices:
+   *   - `turnDeliveredReply === true`  → the turn recovered; the resolved
+   *     notices are dropped and `[]` is returned.
+   *   - `turnDeliveredReply === false` → the turn died reply-less; the resolved,
+   *     un-expired notices are returned EXACTLY ONCE for the caller to send.
+   * Either way the resolved notices leave the ledger (a notice never survives
+   * the end of the turn it is keyed to).
    */
-  resolveTurnEnd(turnDeliveredReply: boolean, now: number = Date.now()): PendingUserNotice[] {
+  resolveTurnEnd(
+    turnKey: string | undefined,
+    turnDeliveredReply: boolean,
+    now: number = Date.now(),
+  ): PendingUserNotice[] {
     this.prune(now)
-    const out = turnDeliveredReply ? [] : [...this.pending]
-    this.pending = []
-    return out
+    const resolved: PendingUserNotice[] = []
+    const remaining: PendingUserNotice[] = []
+    for (const p of this.pending) {
+      if (p.key === turnKey || p.key === undefined) resolved.push(p)
+      else remaining.push(p)
+    }
+    this.pending = remaining
+    return turnDeliveredReply ? [] : resolved
   }
 
   /** True when at least one un-expired notice is pending (does not mutate). */

--- a/telegram-plugin/tests/litellm-proxy-auth-misconfig.test.ts
+++ b/telegram-plugin/tests/litellm-proxy-auth-misconfig.test.ts
@@ -227,39 +227,94 @@ describe('PendingUserNoticeGate — notice fires IFF the turn dies reply-less', 
     }
   }
 
+  // The single-turn norm: the error surfaced while topic A's turn was live, so
+  // the notice is keyed to A and topic A's turn end resolves it. `TOPIC_A` is a
+  // `statusKey(chatId, threadId)`-shaped value.
+  const TOPIC_A = '5000000002'
+  const TOPIC_B = '5000000009:42'
+
   it('DROPS the notice when the turn recovered (delivered a reply)', () => {
     const gate = new PendingUserNoticeGate()
-    gate.schedule(makeNotice())
-    expect(gate.resolveTurnEnd(true, 1_001_000)).toEqual([])
+    gate.schedule(makeNotice({ key: TOPIC_A }))
+    expect(gate.resolveTurnEnd(TOPIC_A, true, 1_001_000)).toEqual([])
     // And it does not resurrect on a later failed turn end.
-    expect(gate.resolveTurnEnd(false, 1_002_000)).toEqual([])
+    expect(gate.resolveTurnEnd(TOPIC_A, false, 1_002_000)).toEqual([])
   })
 
   it('SENDS the notice exactly once when the turn ends without a reply', () => {
     const gate = new PendingUserNoticeGate()
-    const notice = makeNotice()
-    gate.schedule(notice)
-    const flushed = gate.resolveTurnEnd(false, 1_001_000)
+    gate.schedule(makeNotice({ key: TOPIC_A }))
+    const flushed = gate.resolveTurnEnd(TOPIC_A, false, 1_001_000)
     expect(flushed).toHaveLength(1)
     expect(flushed[0].chatIds).toEqual(['5000000002', '5000000003'])
     // Exactly once — a second turn end flushes nothing.
-    expect(gate.resolveTurnEnd(false, 1_002_000)).toEqual([])
+    expect(gate.resolveTurnEnd(TOPIC_A, false, 1_002_000)).toEqual([])
   })
 
-  it('collapses an error burst within one turn to ONE pending notice per agent', () => {
+  it('collapses an error burst within one turn to ONE pending notice per topic', () => {
     const gate = new PendingUserNoticeGate()
-    gate.schedule(makeNotice({ atMs: 1_000_000 }))
-    gate.schedule(makeNotice({ atMs: 1_000_500 }))
-    gate.schedule(makeNotice({ atMs: 1_001_000 }))
-    expect(gate.resolveTurnEnd(false, 1_002_000)).toHaveLength(1)
+    gate.schedule(makeNotice({ atMs: 1_000_000, key: TOPIC_A }))
+    gate.schedule(makeNotice({ atMs: 1_000_500, key: TOPIC_A }))
+    gate.schedule(makeNotice({ atMs: 1_001_000, key: TOPIC_A }))
+    expect(gate.resolveTurnEnd(TOPIC_A, false, 1_002_000)).toHaveLength(1)
   })
 
   it('expires an unresolved notice after the TTL (bias to silence over false failure)', () => {
     const gate = new PendingUserNoticeGate()
-    gate.schedule(makeNotice({ atMs: 1_000_000 }))
+    gate.schedule(makeNotice({ atMs: 1_000_000, key: TOPIC_A }))
     const after = 1_000_000 + PENDING_USER_NOTICE_TTL_MS + 1
     expect(gate.hasPending(after)).toBe(false)
-    expect(gate.resolveTurnEnd(false, after)).toEqual([])
+    expect(gate.resolveTurnEnd(TOPIC_A, false, after)).toEqual([])
+  })
+
+  // ── #3294 — keyed by turn/topic so concurrent per-topic turns don't
+  //    cross-resolve each other's pending notices. ─────────────────────────────
+  it("does NOT flush topic A's notice when a DIFFERENT topic's turn ends reply-less", () => {
+    const gate = new PendingUserNoticeGate()
+    gate.schedule(makeNotice({ atMs: 1_000_000, key: TOPIC_A }))
+    // Topic B's turn ends WITHOUT a reply. Pre-#3294 this flushed A's notice
+    // (a false "couldn't complete" for a turn that may still recover). Now B's
+    // end resolves nothing keyed to A.
+    expect(gate.resolveTurnEnd(TOPIC_B, false, 1_000_500)).toEqual([])
+    // A's notice is still pending, and A's OWN reply-less end flushes it.
+    expect(gate.hasPending(1_000_600)).toBe(true)
+    const flushed = gate.resolveTurnEnd(TOPIC_A, false, 1_000_700)
+    expect(flushed).toHaveLength(1)
+    expect(flushed[0].key).toBe(TOPIC_A)
+  })
+
+  it("does NOT drop topic A's notice when a DIFFERENT topic's turn recovers", () => {
+    const gate = new PendingUserNoticeGate()
+    gate.schedule(makeNotice({ atMs: 1_000_000, key: TOPIC_A }))
+    // Topic B's turn recovered (delivered a reply). It must not drop A's notice.
+    expect(gate.resolveTurnEnd(TOPIC_B, true, 1_000_500)).toEqual([])
+    // A's notice survives and still flushes on A's reply-less end.
+    expect(gate.resolveTurnEnd(TOPIC_A, false, 1_000_700)).toHaveLength(1)
+  })
+
+  it('keeps a per-topic pending notice for each concurrent topic (no cross-collapse)', () => {
+    const gate = new PendingUserNoticeGate()
+    gate.schedule(makeNotice({ atMs: 1_000_000, key: TOPIC_A, chatIds: ['5000000002'] }))
+    gate.schedule(makeNotice({ atMs: 1_000_100, key: TOPIC_B, chatIds: ['5000000009'] }))
+    // A's end flushes only A.
+    const a = gate.resolveTurnEnd(TOPIC_A, false, 1_000_200)
+    expect(a).toHaveLength(1)
+    expect(a[0].chatIds).toEqual(['5000000002'])
+    // B is still pending and flushes on B's end.
+    const b = gate.resolveTurnEnd(TOPIC_B, false, 1_000_300)
+    expect(b).toHaveLength(1)
+    expect(b[0].chatIds).toEqual(['5000000009'])
+  })
+
+  it('an UNATTRIBUTED (undefined-key) notice resolves on any turn end (legacy single-turn behavior)', () => {
+    const gate = new PendingUserNoticeGate()
+    // No key — the error arrived with no live turn (between turns / post-poke).
+    gate.schedule(makeNotice({ atMs: 1_000_000 }))
+    // Any topic's reply-less end flushes it (preserves pre-#3294 behavior so a
+    // genuine death on a single-turn gateway still notifies the user).
+    const flushed = gate.resolveTurnEnd(TOPIC_B, false, 1_000_500)
+    expect(flushed).toHaveLength(1)
+    expect(flushed[0].key).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

Keys the deferred non-operator failure-notice gate (`telegram-plugin/pending-user-notice.ts`, from #3293) by **turn/topic** instead of per-agent, so under the PR-4e keyed-liveness flag (concurrent per-topic turns) one topic's turn end no longer resolves another topic's pending notice.

Closes #3294.

## Why

The user-facing "couldn't complete that — it's on our side" notice is never sent at error time; it is *scheduled* and resolved at the single turn-end funnel (`endCurrentTurnAtomic`): a turn that recovered (delivered a reply) drops it, a turn that died reply-less sends it. The gate collapsed **per-agent** and `resolveTurnEnd` cleared *all* pending notices on *any* turn end.

Under PR-4e keyed liveness (concurrent per-topic turns) that races: turn B's reply-less end flushed turn A's pending notice while A might still recover — a **false failure claim** in that interleaving. Single-turn gateways (the current norm — only one topic ever) were unaffected, which is why this lands *before* the keyed-turn flag ships broadly.

## What changed

- `PendingUserNotice` gains an optional `key` (topic key = `statusKey(chatId, threadId)`).
- `schedule` collapses per `(agent, key)` — concurrent topics each keep their own pending notice; a burst within one turn still collapses to one.
- `resolveTurnEnd(turnKey, delivered, now)` resolves **only** notices matching the ending turn's topic (or unattributed `undefined`-key ones — the legacy agent-wide fallback that keeps single-turn byte-identical). Other topics' notices stay pending until their own turn end or TTL.
- Gateway wiring: the schedule site attributes the notice to the live turn's topic; `endCurrentTurnAtomic` passes its own topic `key` into the flush.

### User-visible behavior change

Under keyed liveness, a concurrent topic ending reply-less (or recovering) no longer triggers/drops another topic's "couldn't complete" notice. Each user's failure notice now fires IFF *their own* turn genuinely died. Single-turn gateways: no change.

## Honest limitation

The `api_error` operator event is agent-level (its wire `chatId` is always empty), so the notice is attributed to the **most-recently-set live turn** — best-effort under the sequential-CLI invariant, and strictly better than the pre-existing agent-wide flush. Perfect per-turn attribution would require plumbing a topic onto the operator-event IPC, which is out of scope for this issue. `undefined` key (no live turn: error between turns / after a silence poke) keeps the legacy agent-wide resolution so a genuine death still notifies.

## Test plan

`telegram-plugin/tests/litellm-proxy-auth-misconfig.test.ts` — updated to the keyed contract + 4 new keyed-liveness cases that assert **outcomes** (a notice gated under the wrong topic key fails):
- cross-topic reply-less end returns `[]` and leaves A pending; A's own end flushes it
- cross-topic recover does not drop A's notice
- per-topic notices do not cross-collapse (each topic's end flushes only its own)
- an unattributed (undefined-key) notice still resolves on any turn end (legacy)

`./node_modules/.bin/vitest run telegram-plugin/tests/litellm-proxy-auth-misconfig.test.ts` → 27 passed. Adjacent `operator-events` + `llm-error-present` → 108 passed. `npm run lint` clean (tsc, `check-bot-api-wrapping` — all gateway raw calls use shift-stable inline markers — and the gateway line-ratchet: +20 lines within the 50-line slack).

## Risk

Low. Single-concern, additive keying; single-turn path byte-identical (undefined-key + one-topic collapse reproduce the old per-agent behavior). No new imports, no send-path change, recipients unchanged. Disjoint from the #2996 P0a registration-extraction region (~L23484–29013) — edits are at L5384, L8655, L8689.

Job spec: `reference/jobs/survive-reboots-and-real-life.md` — "The user is told when something went wrong, never left in silence." This fix guards the inverse failure: never told a turn *failed* that didn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)