### PR TITLE
refactor(gateway): defer token materialization + Bot construction to boot (#2996 P0b)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1236,56 +1236,10 @@ try {
   }
 }
 
-// Issue #758: if TELEGRAM_BOT_TOKEN is not set in env (e.g. agent's .env was
-// never written because bot_token in switchroom.yaml is a `vault:` reference),
-// materialize it from the vault at startup. Resolved value is held in
-// process.env only — never written back to disk.
-//
-// The outer try/catch is narrowed (post-#761 review) to ONLY catch the case
-// where the helper module itself fails to load (ERR_MODULE_NOT_FOUND from the
-// dynamic import). Anything else — including throws from inside
-// materializeBotToken that aren't BotTokenMaterializeError — must propagate
-// with its original message so we don't mask real bugs behind the legacy
-// "set in .env" hint.
+// P0b (#2996): the bot token (Issue #758: vault materialization → TELEGRAM_BOT_TOKEN
+// env → refuse) is resolved at boot in initGatewayBot(), not at import — order + exit(1) refusal unchanged.
 type MaterializeMod = typeof import('../../src/telegram/materialize-bot-token.js')
-let materializeMod: MaterializeMod | null = null
-try {
-  materializeMod = await import('../../src/telegram/materialize-bot-token.js')
-} catch (err) {
-  const code = (err as NodeJS.ErrnoException | undefined)?.code
-  if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
-    // Module genuinely missing — fall through with materializeMod=null and
-    // handle below.
-  } else {
-    // Programming error, side-effect failure during module init, etc.
-    // Propagate the real message rather than masking it.
-    throw err
-  }
-}
-
 let TOKEN: string
-if (materializeMod !== null) {
-  const { materializeBotToken, BotTokenMaterializeError } = materializeMod
-  try {
-    TOKEN = await materializeBotToken({ agentName: process.env.SWITCHROOM_AGENT_NAME })
-  } catch (err) {
-    if (err instanceof BotTokenMaterializeError) {
-      process.stderr.write(`telegram gateway: ${err.message}\n`)
-      process.exit(1)
-    }
-    throw err
-  }
-} else if (process.env.TELEGRAM_BOT_TOKEN) {
-  TOKEN = process.env.TELEGRAM_BOT_TOKEN
-} else {
-  process.stderr.write(
-    `telegram gateway: TELEGRAM_BOT_TOKEN required\n` +
-    `  set in ${ENV_FILE}\n` +
-    `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n` +
-    `  (token-materialization helper not found)\n`,
-  )
-  process.exit(1)
-}
 
 const STATIC = process.env.TELEGRAM_ACCESS_MODE === 'static'
 const TOPIC_ID = process.env.TELEGRAM_TOPIC_ID ? Number(process.env.TELEGRAM_TOPIC_ID) : undefined
@@ -1296,16 +1250,9 @@ const TOPIC_ID = process.env.TELEGRAM_TOPIC_ID ? Number(process.env.TELEGRAM_TOP
 const AGENT_ADMIN = process.env.SWITCHROOM_AGENT_ADMIN === 'true'
 
 // ─── Bot + chat lock ──────────────────────────────────────────────────────
-const bot = new Bot(TOKEN)
-installTgPostLogger(bot)
-
-// ─── Diagnostic update tap (#3300) ────────────────────────────────────────
-// One compact line per received update, logged BEFORE any specific handler
-// runs, so a drop at the grammy-routing layer is always diagnosable from the
-// logs. Pass-through middleware — never consumes an update or alters routing.
-// Rate-limited inside installUpdateTap (per-minute cap + suppression summary
-// line so even a flood is never invisible).
-installUpdateTap(bot, line => process.stderr.write(line))
+// P0b (#2996): `bot` is constructed at boot in initGatewayBot(), not at import
+// (`!` — its ~300 in-function references all run post-boot).
+let bot!: Bot<Context>
 
 // ─── getUpdates heartbeat ─────────────────────────────────────────────────
 // Tracks the last time getUpdates completed (success OR error). Used by
@@ -1313,19 +1260,10 @@ installUpdateTap(bot, line => process.stderr.write(line))
 // getUpdates hasn't responded in a while, the grammy runner loop is frozen
 // without the network being down (2026-06-30: clerk/klanker deaf for 2h
 // after a single timeout — getMe stayed green so the getMe-only check
-// never fired). Initialized to now so the first health-check interval
-// doesn't false-positive before the runner makes its first poll.
+// never fired). Initialized to now so the first health-check interval doesn't
+// false-positive before the runner's first poll. The api middleware that writes
+// it is installed in initGatewayBot() (P0b, #2996).
 let lastGetUpdatesHeartbeatMs = Date.now()
-bot.api.config.use(async (prev, method, payload, signal) => {
-  try {
-    const result = await prev(method, payload, signal)
-    if (method === 'getUpdates') lastGetUpdatesHeartbeatMs = Date.now()
-    return result
-  } catch (err) {
-    if (method === 'getUpdates') lastGetUpdatesHeartbeatMs = Date.now()
-    throw err
-  }
-})
 
 const GRAMMY_VERSION: string = (() => {
   try {
@@ -1337,22 +1275,14 @@ const GRAMMY_VERSION: string = (() => {
 })()
 
 // ─── sendChecklist / editMessageChecklist boot probes ─────────────────────
-// grammY 1.x exposes new Telegram Bot API methods via bot.api.raw before the
-// typed wrapper is generated. We probe for availability at boot so callers
-// can detect degraded mode gracefully instead of throwing at call time.
-const _rawSendChecklist = (bot.api.raw as unknown as Record<string, unknown>).sendChecklist
-const _rawEditMessageChecklist = (bot.api.raw as unknown as Record<string, unknown>).editMessageChecklist
-
-/** True when the connected Telegram Bot API supports native checklists. */
-const CHECKLIST_API_AVAILABLE =
-  typeof _rawSendChecklist === 'function' &&
-  typeof _rawEditMessageChecklist === 'function'
-
-if (!CHECKLIST_API_AVAILABLE) {
-  process.stderr.write(
-    `telegram gateway: sendChecklist / editMessageChecklist not available in this grammY/Bot API version (${GRAMMY_VERSION}) — checklist tools will error gracefully\n`,
-  )
-}
+// grammY 1.x exposes new Bot API methods via bot.api.raw before the typed
+// wrapper is generated; we probe availability at boot so callers degrade
+// gracefully instead of throwing at call time. P0b (#2996): the probe reads
+// `bot.api.raw` in initGatewayBot() — module-scope so the wrappers read them.
+let _rawSendChecklist: unknown
+let _rawEditMessageChecklist: unknown
+/** True when the connected Telegram Bot API supports native checklists. Set in initGatewayBot() (#2996 P0b). */
+let CHECKLIST_API_AVAILABLE = false
 
 /**
  * Send a native Telegram checklist message.
@@ -1416,7 +1346,8 @@ async function rawEditMessageChecklist(args: {
 }
 
 const chatLock = createChatLock()
-const lockedBot = chatLock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+// P0b (#2996): wrapped in initGatewayBot() once `bot` is constructed at boot.
+let lockedBot!: Bot<Context>
 let botUsername = ''
 
 // ─── Access control ───────────────────────────────────────────────────────
@@ -20783,7 +20714,7 @@ async function handleInbound(
         }
         vaultPassphraseCache.set(chat_id, { passphrase, expiresAt: Date.now() + VAULT_PASSPHRASE_TTL_MS })
         if (msgId != null) await deleteSensitiveMessage(chat_id, msgId, 'vault passphrase')
-        await executeDeferredSecretSave(ctx, pendingVault.deferKey, passphrase, pendingVault.cardMessageId)
+        await callbackQueryHandlers.executeDeferredSecretSave(ctx, pendingVault.deferKey, passphrase, pendingVault.cardMessageId)
       } else if (pendingVault.kind === 'passphrase-for-access-approve') {
         // #1012 Phase 2 follow-up + #1051: operator tapped Approve on
         // one or more vault_request_access cards without first
@@ -20823,12 +20754,12 @@ async function handleInbound(
               .catch(() => {})
             continue
           }
-          await performVaultAccessApproval(ctx, stagedAccess, item.stageId, item.senderId, { kind: 'passphrase', passphrase })
+          await callbackQueryHandlers.performVaultAccessApproval(ctx, stagedAccess, item.stageId, item.senderId, { kind: 'passphrase', passphrase })
         }
       } else if (pendingVault.kind === 'grant-wizard' && pendingVault.awaitingCustomDuration) {
         // Issue #227: custom duration text reply for grant wizard
         const input = text.trim()
-        const ttlSeconds = parseGrantDuration(input)
+        const ttlSeconds = callbackQueryHandlers.parseGrantDuration(input)
         if (ttlSeconds === null) {
           // Re-set state so user can try again
           pendingVaultOps.set(chat_id, { ...pendingVault, startedAt: Date.now() })
@@ -20836,7 +20767,7 @@ async function handleInbound(
           return
         }
         const newState = { ...pendingVault, ttlSeconds, awaitingCustomDuration: false }
-        await grantWizardConfirm(ctx, chat_id, newState)
+        await callbackQueryHandlers.grantWizardConfirm(ctx, chat_id, newState)
       } else if (pendingVault.kind === 'grant-wizard') {
         // Text received mid-wizard but not awaiting custom duration — ignore and re-set
         pendingVaultOps.set(chat_id, { ...pendingVault, startedAt: Date.now() })
@@ -23414,16 +23345,10 @@ async function buildLiveProbeRows(agentName: string): Promise<StatusProbeRow[]> 
   }
 }
 
-// RFC B §9: register /approvals list|revoke against the approval kernel.
-// The kernel's IPC client (`src/vault/approvals/client.ts`) round-trips
-// through the vault broker — same socket, no new daemon. The isApprover
-// gate reuses the existing dmCommandGate / allowFrom pattern.
-{
-  const { registerApprovalsCommands } = await import('./approvals-commands.js')
-  registerApprovalsCommands(bot, {
-    isApprover: ctx => dmCommandGate(ctx) !== null,
-  })
-}
+// RFC B §9: /approvals list|revoke is registered against the approval kernel.
+// P0b (#2996): this references `bot`, so it moved to initGatewayBot() at boot —
+// kept AHEAD of registerGatewayHandlers so /approvals stays before the admin-gate
+// bot.use in the grammY stack (unchanged pre-P0b ordering; /approvals not gated).
 
 
 
@@ -25563,67 +25488,13 @@ function resolveAgentDirForName(agent: string): string | null {
 
 // ─── Callback-query handler families (#2996 Phase 5, remaining item 2) ─────
 // Extracted verbatim to callback-query-handlers.ts behind an injected deps
-// object (see that module's header for what moved and what deliberately
-// stayed). Destructuring keeps every call site below byte-identical.
-const callbackQueryHandlers = createCallbackQueryHandlers({
-  bot,
-  lockedBot,
-  loadAccess,
-  escapeHtmlForTg,
-  switchroomReply,
-  resolveThreadId,
-  deliverResumeSyntheticOrBuffer,
-  expireMentalModelProposeCard,
-  readLiveSwitchroomConfigText,
-  mentalModelCorrelationKey,
-  getMyAgentName,
-  triggerSelfRestart,
-  runSwitchroomAuthCommand,
-  switchroomExecJson,
-  assertSafeAgentName,
-  buildDeferredSecretKeyboard,
-  recordDeferredSecretKernelDecision,
-  mintGrantWizardKernelRequest,
-  recordGrantWizardKernelDecision,
-  robustApiCall,
-  swallowingApiCall,
-  pendingVaultRequestAccesses,
-  pendingVaultRequestSaves,
-  pendingMentalModelProposes,
-  pendingCardStore,
-  pendingMentalModelCorrelations,
-  pendingVaultOps,
-  vaultPassphraseCache,
-  deferredSecrets,
-  pendingReauthFlows,
-  secretStaging,
-  lastAuthRefreshAtMs,
-  // Mutable module `let`s — injected as getters so the startup config
-  // assignment (and any later reload) stays observable from the module.
-  getVaultApprovalAuthMode: () => VAULT_APPROVAL_AUTH_MODE,
-  getAdminOnlyKeys: () => ADMIN_ONLY_KEYS,
-  vaultKeyRegex: VAULT_KEY_REGEX,
-  mentalModelProposeTtlMs: MENTAL_MODEL_PROPOSE_TTL_MS,
-  // #2975 Stage 1 — loud-failure funnel for a rate-window retry that also
-  // failed (cooldown + record + broadcast in one place).
-  emitOperatorEvent: emitGatewayOperatorEvent,
-})
-const {
-  handleVaultRecentDenialCallback,
-  performVaultAccessApproval,
-  handleSkillProposalCallback,
-  handleMentalModelProposeCallback,
-  handleVaultRequestAccessCallback,
-  handleVaultRequestSaveCallback,
-  handleVaultDeferCallback,
-  parseGrantDuration,
-  startGrantWizardStep1,
-  grantWizardConfirm,
-  handleVaultGrantCallback,
-  executeDeferredSecretSave,
-  handleOperatorEventCallback,
-  handleAuthDashboardCallback,
-} = callbackQueryHandlers
+// object (see that module's header for what moved and what deliberately stayed).
+// P0b (#2996): the factory injects `bot`/`lockedBot`, so it is invoked at boot in
+// initGatewayBot(). Call sites reference `callbackQueryHandlers.<name>` (the
+// former module-scope destructure was removed — its names would be unassigned at
+// import once construction is deferred). This module-scope `let` is assigned once
+// at boot, before the runner, so every call site (all post-boot) resolves.
+let callbackQueryHandlers!: ReturnType<typeof createCallbackQueryHandlers>
 
 // /reauth was removed in v0.6.13 — the `/auth` dashboard's
 // `🔄 Reauth default` button fires the same flow (the `case 'reauth':`
@@ -26537,13 +26408,13 @@ async function handleMessageReaction(ctx: Context): Promise<void> {
 // invariant in catch-all-unhandled-message.test.ts. Behaviour-preserving leaf
 // move: registration ORDER is byte-identical (every message:* handler still
 // precedes the installUnhandledMessageCatchAll terminal catch-all, which still
-// precedes message_reaction + the error boundary) and the single call below
-// runs at the same point in module evaluation as the old last registration, so
-// grammY sees the exact same middleware/handler sequence. `bot` is injected
-// (P0b defers its construction); `deps` is the forward seam for per-handler
-// dependency injection that later #2996 phases widen — in P0a the handler
-// bodies still close over gateway module scope. Statements keep their original
-// indentation (no reindent) so the move is a byte-verifiable relocation.
+// precedes message_reaction + the error boundary) and the single call site (now
+// inside initGatewayBot() — P0b, #2996) runs at the same boot point as the old
+// module-scope registration: after `bot` is constructed, before the runner, so
+// grammY sees the exact same middleware/handler sequence. `bot` is injected (P0b
+// defers construction); `deps` is the forward seam for per-handler DI later
+// #2996 phases widen — in P0a the bodies still close over module scope.
+// Statements keep original indentation (no reindent): a byte-verifiable move.
 type RegisterGatewayHandlersDeps = Record<string, never>
 function registerGatewayHandlers(bot: Bot<Context>, deps: RegisterGatewayHandlersDeps): void {
   void deps
@@ -28008,7 +27879,7 @@ bot.command('vault', async ctx => {
 
   // Issue #227: /vault grant — inline-keyboard wizard to mint capability tokens
   if (sub === 'grant') {
-    await startGrantWizardStep1(ctx, chatId)
+    await callbackQueryHandlers.startGrantWizardStep1(ctx, chatId)
     return
   }
 
@@ -28293,7 +28164,7 @@ bot.on('callback_query:data', async ctx => {
       await ctx.answerCallbackQuery({ text: 'Not authorized.' })
       return
     }
-    await handleAuthDashboardCallback(ctx)
+    await callbackQueryHandlers.handleAuthDashboardCallback(ctx)
     return
   }
 
@@ -28611,7 +28482,7 @@ bot.on('callback_query:data', async ctx => {
   // renderOperatorEvent(). Agent name is URL-encoded at emit (issue #24).
   // Actions: dismiss, restart, reauth, logs.
   if (data.startsWith('op:')) {
-    await handleOperatorEventCallback(ctx, data)
+    await callbackQueryHandlers.handleOperatorEventCallback(ctx, data)
     return
   }
 
@@ -28619,7 +28490,7 @@ bot.on('callback_query:data', async ctx => {
   // Actions: unlock (prompt for passphrase + auto-write), cancel.
   // Issue #44.
   if (data.startsWith('vd:')) {
-    await handleVaultDeferCallback(ctx, data)
+    await callbackQueryHandlers.handleVaultDeferCallback(ctx, data)
     return
   }
 
@@ -28652,7 +28523,7 @@ bot.on('callback_query:data', async ctx => {
   // vg:confirm:<id> — execute revoke
   // vg:cancel:<id> — dismiss
   if (data.startsWith('vg:')) {
-    await handleVaultGrantCallback(ctx, data)
+    await callbackQueryHandlers.handleVaultGrantCallback(ctx, data)
     return
   }
 
@@ -28661,7 +28532,7 @@ bot.on('callback_query:data', async ctx => {
   // vrs:discard:<stageId>  — drop the staged value, edit card to discarded
   // vrs:rename:<stageId>   — prompt for a new key name, then resume
   if (data.startsWith('vrs:')) {
-    await handleVaultRequestSaveCallback(ctx, data)
+    await callbackQueryHandlers.handleVaultRequestSaveCallback(ctx, data)
     return
   }
 
@@ -28669,7 +28540,7 @@ bot.on('callback_query:data', async ctx => {
   // vra:approve:<stageId> — mint scoped grant via broker, write token
   // vra:deny:<stageId>    — refuse, edit card to denied
   if (data.startsWith('vra:')) {
-    await handleVaultRequestAccessCallback(ctx, data)
+    await callbackQueryHandlers.handleVaultRequestAccessCallback(ctx, data)
     return
   }
 
@@ -28686,7 +28557,7 @@ bot.on('callback_query:data', async ctx => {
   //                           via operator-approved config edit) + ensure it
   //   mmp:deny:<stageId>    — drop the proposal; NOTHING is written
   if (data.startsWith('mmp:')) {
-    await handleMentalModelProposeCallback(ctx, data)
+    await callbackQueryHandlers.handleMentalModelProposeCallback(ctx, data)
     return
   }
 
@@ -28696,7 +28567,7 @@ bot.on('callback_query:data', async ctx => {
   //   skprop:deny:<id>    — dismiss + record a rejection fingerprint so it
   //                         isn't re-proposed
   if (data.startsWith('skprop:')) {
-    await handleSkillProposalCallback(ctx, data)
+    await callbackQueryHandlers.handleSkillProposalCallback(ctx, data)
     return
   }
 
@@ -28713,7 +28584,7 @@ bot.on('callback_query:data', async ctx => {
   //   vrd:<agent>:<key> — mint a 30-day read-grant for the agent + key
   // Posted by /vault audit <agent> in the "Recent denials" section.
   if (data.startsWith('vrd:')) {
-    await handleVaultRecentDenialCallback(ctx, data)
+    await callbackQueryHandlers.handleVaultRecentDenialCallback(ctx, data)
     return
   }
 
@@ -29951,8 +29822,8 @@ bot.catch(err => {
   process.stderr.write(`telegram gateway: handler error (polling continues): ${err.error}\n`)
 })
 }
-registerGatewayHandlers(bot, {})
-
+// registerGatewayHandlers(bot, {}) is invoked from initGatewayBot() at boot
+// (#2996 P0b) — off module top level now that `bot` is constructed at boot.
 // ─── Shutdown ─────────────────────────────────────────────────────────────
 //
 // 35-second drain budget. The 2026-04-23 incident showed that a 3-second
@@ -30346,6 +30217,153 @@ if (POLL_HEALTH_INTERVAL_MS > 0) {
   })
 }
 
+// ─── Boot-time bot construction (#2996 P0b) ───────────────────────────────
+// Deferred out of module import so `import`ing gateway.ts performs no token
+// materialization, no `new Bot`, and has no reachable process.exit(1). Invoked
+// once from the boot IIFE below, before initVaultApprovalPosture() and the
+// runner, reproducing the original import-time order VERBATIM: token → new Bot →
+// installTgPostLogger → installUpdateTap → heartbeat middleware → checklist
+// probes → chatLock.wrapBot → registerGatewayHandlers. Token (Issue #758): if
+// TELEGRAM_BOT_TOKEN isn't in env, materialize from the vault (stays in
+// process.env, never on disk); the try/catch around the dynamic import is
+// narrowed (post-#761) to ONLY ERR_MODULE_NOT_FOUND, anything else propagates.
+async function initGatewayBot(): Promise<void> {
+  let materializeMod: MaterializeMod | null = null
+  try {
+    materializeMod = await import('../../src/telegram/materialize-bot-token.js')
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code
+    if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+      // Module genuinely missing — fall through with materializeMod=null and
+      // handle below.
+    } else {
+      // Programming error, side-effect failure during module init, etc.
+      // Propagate the real message rather than masking it.
+      throw err
+    }
+  }
+
+  if (materializeMod !== null) {
+    const { materializeBotToken, BotTokenMaterializeError } = materializeMod
+    try {
+      TOKEN = await materializeBotToken({ agentName: process.env.SWITCHROOM_AGENT_NAME })
+    } catch (err) {
+      if (err instanceof BotTokenMaterializeError) {
+        process.stderr.write(`telegram gateway: ${err.message}\n`)
+        process.exit(1)
+      }
+      throw err
+    }
+  } else if (process.env.TELEGRAM_BOT_TOKEN) {
+    TOKEN = process.env.TELEGRAM_BOT_TOKEN
+  } else {
+    process.stderr.write(
+      `telegram gateway: TELEGRAM_BOT_TOKEN required\n` +
+      `  set in ${ENV_FILE}\n` +
+      `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n` +
+      `  (token-materialization helper not found)\n`,
+    )
+    process.exit(1)
+  }
+
+  bot = new Bot(TOKEN)
+  installTgPostLogger(bot)
+
+  // Diagnostic update tap (#3300): one compact line per received update, logged
+  // BEFORE any specific handler runs, so a routing-layer drop is diagnosable
+  // from the logs. Pass-through middleware; rate-limited inside installUpdateTap.
+  installUpdateTap(bot, line => process.stderr.write(line))
+
+  // getUpdates heartbeat instrumentation — writes lastGetUpdatesHeartbeatMs
+  // (declared module-scope, read by the poll health check).
+  bot.api.config.use(async (prev, method, payload, signal) => {
+    try {
+      const result = await prev(method, payload, signal)
+      if (method === 'getUpdates') lastGetUpdatesHeartbeatMs = Date.now()
+      return result
+    } catch (err) {
+      if (method === 'getUpdates') lastGetUpdatesHeartbeatMs = Date.now()
+      throw err
+    }
+  })
+
+  // sendChecklist / editMessageChecklist boot probes (see declarations above).
+  _rawSendChecklist = (bot.api.raw as unknown as Record<string, unknown>).sendChecklist
+  _rawEditMessageChecklist = (bot.api.raw as unknown as Record<string, unknown>).editMessageChecklist
+  CHECKLIST_API_AVAILABLE =
+    typeof _rawSendChecklist === 'function' &&
+    typeof _rawEditMessageChecklist === 'function'
+  if (!CHECKLIST_API_AVAILABLE) {
+    process.stderr.write(
+      `telegram gateway: sendChecklist / editMessageChecklist not available in this grammY/Bot API version (${GRAMMY_VERSION}) — checklist tools will error gracefully\n`,
+    )
+  }
+
+  lockedBot = chatLock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+
+  // RFC B §9 (moved here by P0b): register /approvals against the approval
+  // kernel. The kernel's IPC client round-trips through the vault broker; the
+  // isApprover gate reuses dmCommandGate / allowFrom. Kept BEFORE
+  // registerGatewayHandlers so /approvals stays ahead of the admin-gate bot.use
+  // in the grammY stack — byte-identical middleware order to pre-P0b.
+  {
+    const { registerApprovalsCommands } = await import('./approvals-commands.js')
+    registerApprovalsCommands(bot, {
+      isApprover: ctx => dmCommandGate(ctx) !== null,
+    })
+  }
+
+  // Callback-query handler families (#2996 Phase 5) — factory injects bot/
+  // lockedBot, so it is constructed here at boot (P0b). Moved verbatim from
+  // module scope; every injected dep is a module-scope singleton available now.
+  callbackQueryHandlers = createCallbackQueryHandlers({
+    bot,
+    lockedBot,
+    loadAccess,
+    escapeHtmlForTg,
+    switchroomReply,
+    resolveThreadId,
+    deliverResumeSyntheticOrBuffer,
+    expireMentalModelProposeCard,
+    readLiveSwitchroomConfigText,
+    mentalModelCorrelationKey,
+    getMyAgentName,
+    triggerSelfRestart,
+    runSwitchroomAuthCommand,
+    switchroomExecJson,
+    assertSafeAgentName,
+    buildDeferredSecretKeyboard,
+    recordDeferredSecretKernelDecision,
+    mintGrantWizardKernelRequest,
+    recordGrantWizardKernelDecision,
+    robustApiCall,
+    swallowingApiCall,
+    pendingVaultRequestAccesses,
+    pendingVaultRequestSaves,
+    pendingMentalModelProposes,
+    pendingCardStore,
+    pendingMentalModelCorrelations,
+    pendingVaultOps,
+    vaultPassphraseCache,
+    deferredSecrets,
+    pendingReauthFlows,
+    secretStaging,
+    lastAuthRefreshAtMs,
+    // Mutable module `let`s — injected as getters so the startup config
+    // assignment (and any later reload) stays observable from the module.
+    getVaultApprovalAuthMode: () => VAULT_APPROVAL_AUTH_MODE,
+    getAdminOnlyKeys: () => ADMIN_ONLY_KEYS,
+    vaultKeyRegex: VAULT_KEY_REGEX,
+    mentalModelProposeTtlMs: MENTAL_MODEL_PROPOSE_TTL_MS,
+    // #2975 Stage 1 — loud-failure funnel for a rate-window retry that also
+    // failed (cooldown + record + broadcast in one place).
+    emitOperatorEvent: emitGatewayOperatorEvent,
+  })
+
+  // Install the grammY registration surface (P0a) — once, before the runner.
+  registerGatewayHandlers(bot, {})
+}
+
 // One-shot startup guard. The outer for-loop below re-enters its try block
 // on 409 Conflict retries — those are transient polling conflicts, not
 // process restarts. Anything that should fire exactly once per gateway
@@ -30359,6 +30377,11 @@ if (POLL_HEALTH_INTERVAL_MS > 0) {
 let didOneTimeSetup = false
 
 void (async () => {
+  // #2996 P0b: construct the bot + install the registration surface FIRST,
+  // before vault-posture init and the runner. Keeps failure modes in pre-P0b
+  // order: token refusal (exit 1) precedes the vault-posture refusal (exit 78).
+  await initGatewayBot()
+
   // Load vault-grant approval posture once at startup. Side-effect: when
   // posture is `telegram-id`, this reads the machine-bound auto-unlock
   // blob and holds the plaintext passphrase in memory for silent

--- a/telegram-plugin/tests/gateway-bot-construction-deferral.test.ts
+++ b/telegram-plugin/tests/gateway-bot-construction-deferral.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Import-safety pin for the #2996 P0b move: token materialization + `new Bot`
+ * construction are DEFERRED out of module import into the boot function
+ * `initGatewayBot()`.
+ *
+ * WHY this asserts on the parsed SOURCE, not a real `import()`:
+ * gateway.ts is NOT import-safe under vitest yet — the boot IIFE (`void (async
+ * () => { … })()`) still fires at module evaluation and P0b deliberately does
+ * NOT touch it (that guard is P0c/P0d scope). So a real `await import()` would
+ * still trigger the boot path. The oracle for "how the repo pins gateway
+ * structure without booting it" is source-parsing via `ts.createSourceFile`
+ * (see gateway-handler-registration-wiring.test.ts /
+ * gateway-pending-command-wiring.test.ts). This test follows that pattern and
+ * asserts OUTCOMES about where construction lives:
+ *
+ *   1. Module import (top-level, outside any function body) performs NO
+ *      `new Bot(...)`, NO dynamic import of the materialize-bot-token helper,
+ *      NO `materializeBotToken(...)` call, and has NO reachable `process.exit`
+ *      and NO top-level `await`. i.e. importing gateway.ts constructs no bot,
+ *      reads no token, and cannot exit the process.
+ *   2. `bot` is a deferred module-scope `let` (definite-assignment), NOT a
+ *      `const bot = new Bot(...)`.
+ *   3. The boot function `initGatewayBot()` DOES all of the above: it is an
+ *      async function whose body contains the `new Bot(...)`, the materialize
+ *      dynamic import, the `materializeBotToken(...)` call, and the single
+ *      `registerGatewayHandlers(bot, …)` wiring call.
+ *
+ * A count/handler-theater test would not catch a regression that re-hoists
+ * `new Bot` or the token read back to module scope; these node-location
+ * assertions do.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import ts from 'typescript'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_PATH = resolve(__dirname, '..', 'gateway', 'gateway.ts')
+const GATEWAY_SRC = readFileSync(GATEWAY_PATH, 'utf8')
+
+const sourceFile = ts.createSourceFile(
+  GATEWAY_PATH,
+  GATEWAY_SRC,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS,
+)
+
+const MATERIALIZE_MODULE_HINT = 'materialize-bot-token'
+
+function isFunctionLike(n: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(n) ||
+    ts.isFunctionExpression(n) ||
+    ts.isArrowFunction(n) ||
+    ts.isMethodDeclaration(n) ||
+    ts.isConstructorDeclaration(n) ||
+    ts.isGetAccessorDeclaration(n) ||
+    ts.isSetAccessorDeclaration(n)
+  )
+}
+
+/**
+ * Walk every node that executes at MODULE SCOPE — i.e. descend through the
+ * source file but STOP at any function-like boundary (function/arrow/method
+ * bodies run later, when called, not at import). A `new Bot` or token read
+ * found here would fire at import; the whole point of P0b is that none do.
+ */
+function walkModuleScope(visitor: (n: ts.Node) => void): void {
+  const recur = (node: ts.Node): void => {
+    ts.forEachChild(node, child => {
+      if (isFunctionLike(child)) return // do not descend into function bodies
+      visitor(child)
+      recur(child)
+    })
+  }
+  recur(sourceFile)
+}
+
+function isNewBot(n: ts.Node): boolean {
+  return ts.isNewExpression(n) && ts.isIdentifier(n.expression) && n.expression.text === 'Bot'
+}
+
+function isMaterializeDynamicImport(n: ts.Node): boolean {
+  // `import('…materialize-bot-token…')`
+  if (!ts.isCallExpression(n)) return false
+  if (n.expression.kind !== ts.SyntaxKind.ImportKeyword) return false
+  const arg = n.arguments[0]
+  return arg != null && ts.isStringLiteralLike(arg) && arg.text.includes(MATERIALIZE_MODULE_HINT)
+}
+
+function isMaterializeBotTokenCall(n: ts.Node): boolean {
+  return ts.isCallExpression(n) && ts.isIdentifier(n.expression) && n.expression.text === 'materializeBotToken'
+}
+
+function isProcessExitCall(n: ts.Node): boolean {
+  return (
+    ts.isCallExpression(n) &&
+    ts.isPropertyAccessExpression(n.expression) &&
+    ts.isIdentifier(n.expression.expression) &&
+    n.expression.expression.text === 'process' &&
+    n.expression.name.text === 'exit'
+  )
+}
+
+function findFunction(name: string): ts.FunctionDeclaration | undefined {
+  for (const s of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(s) && s.name?.text === name) return s
+  }
+  return undefined
+}
+
+/** Count nodes matching a predicate anywhere within a subtree. */
+function countIn(root: ts.Node, pred: (n: ts.Node) => boolean): number {
+  let count = 0
+  const visit = (node: ts.Node): void => {
+    if (pred(node)) count++
+    ts.forEachChild(node, visit)
+  }
+  visit(root)
+  return count
+}
+
+describe('gateway #2996 P0b: token materialization + new Bot are deferred to boot, import is construction-clean', () => {
+  it('constructs NO Bot at module import (no top-level `new Bot`)', () => {
+    let count = 0
+    walkModuleScope(n => {
+      if (isNewBot(n)) count++
+    })
+    expect(count).toBe(0)
+  })
+
+  it('reads NO token at module import (no top-level materialize import or materializeBotToken call)', () => {
+    let dynImports = 0
+    let materializeCalls = 0
+    walkModuleScope(n => {
+      if (isMaterializeDynamicImport(n)) dynImports++
+      if (isMaterializeBotTokenCall(n)) materializeCalls++
+    })
+    expect(dynImports).toBe(0)
+    expect(materializeCalls).toBe(0)
+  })
+
+  it('performs NO token-refusal exit at module import (no top-level process.exit for token materialization)', () => {
+    // NOTE: the pre-existing startup-lock mutex (#…) still has one top-level
+    // process.exit + top-level await — that is P0c/P0d scope, deliberately NOT
+    // touched here. This asserts specifically that the TOKEN-materialization
+    // exit paths (exit(1) on materialize failure / missing token) are gone from
+    // module scope: there is at most the single startup-lock exit, and none of
+    // them sit in a materialize/`new Bot` context (covered by the tests above).
+    let exits = 0
+    walkModuleScope(n => {
+      if (isProcessExitCall(n)) exits++
+    })
+    // The two token-materialization exit(1) sites moved into initGatewayBot;
+    // only the pre-existing startup-lock exit remains at module scope.
+    expect(exits).toBeLessThanOrEqual(1)
+  })
+
+  it('leaves NO module-scope reference to `bot` or `lockedBot` outside their declarations (all consumers deferred)', () => {
+    // Completeness pin: after P0b, the ONLY module-scope occurrences of `bot` /
+    // `lockedBot` are their `let` declarations. Every consumer — the api-tap /
+    // heartbeat wiring, checklist probes, chatLock.wrapBot, the /approvals
+    // registration, the callback-query factory, and registerGatewayHandlers —
+    // must live inside a function (initGatewayBot or a post-boot handler). A
+    // regression that re-hoists any consumer to import scope fails here.
+    const declLines = new Set<number>()
+    for (const stmt of sourceFile.statements) {
+      if (!ts.isVariableStatement(stmt)) continue
+      for (const decl of stmt.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name) && (decl.name.text === 'bot' || decl.name.text === 'lockedBot')) {
+          declLines.add(sourceFile.getLineAndCharacterOfPosition(decl.name.getStart(sourceFile)).line)
+        }
+      }
+    }
+    const stray: string[] = []
+    walkModuleScope(n => {
+      if (ts.isIdentifier(n) && (n.text === 'bot' || n.text === 'lockedBot')) {
+        const line = sourceFile.getLineAndCharacterOfPosition(n.getStart(sourceFile)).line
+        if (!declLines.has(line)) stray.push(`${n.text}@${line + 1}`)
+      }
+    })
+    expect(stray).toEqual([])
+  })
+
+  it('declares `bot` as a deferred module-scope `let`, not `const bot = new Bot(...)`', () => {
+    let botDecls = 0
+    let botHasInitializer = false
+    for (const stmt of sourceFile.statements) {
+      if (!ts.isVariableStatement(stmt)) continue
+      for (const decl of stmt.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name) && decl.name.text === 'bot') {
+          botDecls++
+          if (decl.initializer != null) botHasInitializer = true
+          // `let`, not `const`
+          expect(stmt.declarationList.flags & ts.NodeFlags.Const).toBe(0)
+        }
+      }
+    }
+    expect(botDecls).toBe(1)
+    expect(botHasInitializer).toBe(false)
+  })
+
+  it('defines an async initGatewayBot() boot function', () => {
+    const fn = findFunction('initGatewayBot')
+    expect(fn).toBeDefined()
+    const isAsync = (fn!.modifiers ?? []).some(m => m.kind === ts.SyntaxKind.AsyncKeyword)
+    expect(isAsync).toBe(true)
+  })
+
+  it('initGatewayBot() performs the construction: new Bot, token materialization, and the registration wiring call', () => {
+    const fn = findFunction('initGatewayBot')
+    expect(fn?.body).toBeDefined()
+    const body = fn!.body!
+
+    // Exactly one `new Bot(...)` — the single constructed instance.
+    expect(countIn(body, isNewBot)).toBe(1)
+
+    // Token materialization lives here (dynamic import + the resolve call).
+    expect(countIn(body, isMaterializeDynamicImport)).toBe(1)
+    expect(countIn(body, isMaterializeBotTokenCall)).toBe(1)
+
+    // The two P0a-missed import-time bot consumers also moved here (P0b): the
+    // callback-query factory and the /approvals registration.
+    const isNamedCall = (name: string) => (n: ts.Node) =>
+      ts.isCallExpression(n) && ts.isIdentifier(n.expression) && n.expression.text === name
+    expect(countIn(body, isNamedCall('createCallbackQueryHandlers'))).toBe(1)
+    expect(countIn(body, isNamedCall('registerApprovalsCommands'))).toBe(1)
+
+    // The refuse-to-boot exits (process.exit(1)) live here, not at import.
+    expect(countIn(body, isProcessExitCall)).toBeGreaterThanOrEqual(1)
+
+    // The single registerGatewayHandlers(bot, …) wiring call moved here (P0b).
+    let regCalls = 0
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'registerGatewayHandlers'
+      ) {
+        regCalls++
+        expect(node.arguments[0]?.getText(sourceFile)).toBe('bot')
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(body)
+    expect(regCalls).toBe(1)
+  })
+})

--- a/telegram-plugin/tests/gateway-handler-registration-wiring.test.ts
+++ b/telegram-plugin/tests/gateway-handler-registration-wiring.test.ts
@@ -18,6 +18,13 @@
  * module top-level (which would change its evaluation order relative to the
  * single call site).
  *
+ * P0b (#2996) update: the single `registerGatewayHandlers(bot, {})` call moved
+ * OFF module top level into the boot function `initGatewayBot()` — because P0b
+ * defers `new Bot` construction to boot, so `bot` no longer exists at import.
+ * The call still fires exactly once, after construction and before the runner,
+ * preserving registration order. The call-site assertion below now pins that
+ * new location (zero top-level calls; exactly one inside initGatewayBot).
+ *
  * The golden sequence below was captured from `origin/main` immediately
  * BEFORE the move (parser-extracted top-level `bot.*` order) so the same
  * assertion holds pre- and post-move — the ordered list is a behaviour
@@ -209,8 +216,12 @@ describe('gateway #2996 P0a: registerGatewayHandlers is the single ordered regis
     expect(leaked).toEqual([])
   })
 
-  it('calls registerGatewayHandlers(bot, ...) exactly once at module top level', () => {
-    let calls = 0
+  it('calls registerGatewayHandlers(bot, ...) exactly once, inside initGatewayBot (P0b), never at module top level', () => {
+    // P0b (#2996): the call moved off module top level into the boot function
+    // initGatewayBot(). Assert (a) ZERO top-level calls — proving the deferral —
+    // and (b) exactly one call in the whole file, with `bot` as its first arg,
+    // located inside initGatewayBot's body.
+    let topLevelCalls = 0
     for (const stmt of sourceFile.statements) {
       if (
         ts.isExpressionStatement(stmt) &&
@@ -218,12 +229,38 @@ describe('gateway #2996 P0a: registerGatewayHandlers is the single ordered regis
         ts.isIdentifier(stmt.expression.expression) &&
         stmt.expression.expression.text === 'registerGatewayHandlers'
       ) {
-        calls++
-        // first arg is the bot singleton
-        expect(stmt.expression.arguments[0]?.getText(sourceFile)).toBe('bot')
+        topLevelCalls++
       }
     }
-    expect(calls).toBe(1)
+    expect(topLevelCalls).toBe(0)
+
+    // Count every registerGatewayHandlers(...) call anywhere in the module, and
+    // record whether it is lexically inside the initGatewayBot function.
+    const initGatewayBot = findFunction('initGatewayBot')
+    expect(initGatewayBot).toBeDefined()
+    const initStart = initGatewayBot!.getStart(sourceFile)
+    const initEnd = initGatewayBot!.getEnd()
+
+    let totalCalls = 0
+    let callsInsideInit = 0
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'registerGatewayHandlers'
+      ) {
+        totalCalls++
+        // first arg is the bot singleton
+        expect(node.arguments[0]?.getText(sourceFile)).toBe('bot')
+        const start = node.getStart(sourceFile)
+        if (start >= initStart && node.getEnd() <= initEnd) callsInsideInit++
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(sourceFile)
+
+    expect(totalCalls).toBe(1)
+    expect(callsInsideInit).toBe(1)
   })
 
   it('registers the admin-gate middleware (bot.use) FIRST and the error boundary (bot.catch) LAST', () => {


### PR DESCRIPTION
## Summary
Move bot token materialization + `new Bot(TOKEN)` construction (and **every import-time consumer of the constructed `bot`**) out of module import into a new boot function `initGatewayBot()`, invoked once as the first step of the existing boot IIFE. Importing `gateway.ts` now performs no vault read, no dynamic import of the materialize helper, no `new Bot`, and has no reachable token-refusal `process.exit(1)`. `bot` / `lockedBot` / `callbackQueryHandlers` become deferred module-scope `let`s assigned at boot; the ~300 in-function references (all post-boot) are unchanged.

## Why
`#2996` **P0b**: the importability seam needs module load to be free of token materialization and network-capable construction so the P2/P4/P6 harnesses can import gateway modules. Builds on the P0a `registerGatewayHandlers` extraction (#3308).

## What moved into `initGatewayBot()` — byte-identical original order
`token materialization → new Bot(TOKEN) → installTgPostLogger → installUpdateTap → getUpdates-heartbeat api middleware → sendChecklist probes → chatLock.wrapBot → /approvals registration → callback-query factory → registerGatewayHandlers(bot, {})`

### Audit finding (deviation from the "P0a-only" premise)
P0a consolidated the `bot.*` registration statements but left **two import-time `bot` consumers** at module scope that are **not** `bot.*` calls, so its wiring test didn't catch them:
- the `/approvals` block (`registerApprovalsCommands(bot, …)`) — `gateway.ts` ~23353 pre-change
- `createCallbackQueryHandlers({ bot, lockedBot, … })` + its 16-handler destructure — ~25499 pre-change

Deferring `new Bot` without also deferring these would **crash the module at import** (they'd deref an unassigned `bot`). Both are relocated verbatim, order-preserving. `/approvals` is kept **ahead of** `registerGatewayHandlers` so it stays before the admin-gate `bot.use` in the grammY stack (unchanged pre-P0b ordering; `/approvals` is not admin-gated). The callback-query destructure was replaced by member access (`callbackQueryHandlers.<name>`) at its 14 call sites so no 16 module-scope `let`s are added (keeps the P0.5 line ratchet green).

## Test plan
- **New pin** `telegram-plugin/tests/gateway-bot-construction-deferral.test.ts` — AST-asserts import is construction-clean (no top-level `new Bot` / materialize / token-refusal exit), no module-scope `bot`/`lockedBot` refs outside their declarations, and `initGatewayBot()` does the construction + both moved consumers. Source-parsing (not import) because the boot IIFE still fires at load (P0c/P0d scope) — mirrors the existing wiring-test oracle.
- **Updated** `gateway-handler-registration-wiring.test.ts`: the single `registerGatewayHandlers(bot, {})` call now pins its new location (zero top-level calls; exactly one inside `initGatewayBot`). The 6 order-invariant assertions are untouched and green.
- `npm run lint` clean (tsc + all guards incl. `gateway-line-ratchet`: **32159 ≤ 32163** ceiling). Scoped vitest: wiring (7) + deferral (7) + callback-query (43) + 8 gateway source-parsing suites (168) green. Pre-existing env-only failure in `approval-hold-record.test.ts` (root-uid `/tmp` ownership) reproduces on clean `main` — not this change.

## Risk
Behavior-preserving pure relocation: identical order, identical injected deps (all module-scope singletons available at boot; moving *later* removes any TDZ risk), mutable config injected via lazy getters, `lastAuthRefreshAtMs` is a `Map` (by reference). `shutdown()`'s `bot.stop()` is guarded by `runnerHandle != null`, only set at `run(bot)` after construction — so the sub-ms boot window where `bot` is unassigned is unreachable. No reapers / intervals / IIFEs / process handlers moved (P0c/P0d scope).

Job spec: `reference/jobs/always-available.md` — the gateway is the always-on inbound path; this is behavior-preserving refactor groundwork, no UX change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)