### PR TITLE
fix(scaffold): harden Hindsight boot gate — real MCP initialize probe, 120s bound, logged outcome

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -613,22 +613,37 @@ export MCP_TIMEOUT="${MCP_TIMEOUT:-30000}"
 # a 30s bare-GET gate — the endpoint returned HTTP 200 mid-restart while a
 # real MCP initialize still failed). So: probe with an actual JSON-RPC
 # initialize POST and require a JSON-RPC result, not just HTTP 200.
-# Bounded at 120s; on timeout we log a warning and boot anyway (degraded
+# Bounded at 120s of real wall-clock time (each probe costs up to ~3s of
+# curl timeout + 1s sleep, so an iteration count would overshoot — measure
+# elapsed seconds against the deadline instead; HINDSIGHT_WAIT holds real
+# elapsed seconds). On timeout we log a warning and boot anyway (degraded
 # beats never-boots — the plugin reconnects once Hindsight recovers).
 HINDSIGHT_WAIT=0
 HINDSIGHT_READY=0
+_hs_start=$(date +%s)
 while [ $HINDSIGHT_WAIT -lt 120 ]; do
-  if curl -sf --max-time 3 \
+  _hs_resp=$(curl -sf --max-time 3 -i \
        -X POST {{{hindsightApiBaseUrlQ}}}/mcp/ \
        -H "Content-Type: application/json" \
        -H "Accept: application/json, text/event-stream" \
        -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"switchroom-boot-gate","version":"1.0"}}}' \
-       2>/dev/null | grep -q '"result"'; then
+       2>/dev/null)
+  # Match on serverInfo — only present in a successful initialize result;
+  # a JSON-RPC *error* body could legitimately contain the substring "result".
+  if printf '%s\n' "$_hs_resp" | grep -q '"serverInfo"'; then
     HINDSIGHT_READY=1
+    # Best-effort cleanup of the probe's server-side MCP session (one would
+    # leak per boot otherwise). Header may be absent on stateless servers.
+    _hs_sid=$(printf '%s\n' "$_hs_resp" | tr -d '\r' | sed -n 's/^[Mm][Cc][Pp]-[Ss]ession-[Ii][Dd]: *//p' | head -n 1)
+    if [ -n "$_hs_sid" ]; then
+      curl -s -o /dev/null --max-time 2 -X DELETE {{{hindsightApiBaseUrlQ}}}/mcp/ \
+        -H "Mcp-Session-Id: $_hs_sid" 2>/dev/null || true
+    fi
+    HINDSIGHT_WAIT=$(( $(date +%s) - _hs_start ))
     break
   fi
   sleep 1
-  HINDSIGHT_WAIT=$((HINDSIGHT_WAIT + 1))
+  HINDSIGHT_WAIT=$(( $(date +%s) - _hs_start ))
 done
 if [ "$HINDSIGHT_READY" = "1" ]; then
   echo "start.sh: hindsight boot gate — MCP initialize OK after ${HINDSIGHT_WAIT}s" >&2

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -602,16 +602,39 @@ export HINDSIGHT_SENDER_BANKS_JSON={{{hindsightSenderBanksJsonQ}}}
 {{#if hindsightTopicFilterMode}}
 export HINDSIGHT_TOPIC_FILTER_MODE={{hindsightTopicFilterMode}}
 {{/if}}
-# Wait for Hindsight API to be reachable before launching Claude, otherwise
-# the MCP server connection fails at startup with "1 MCP server failed".
+# Give Claude Code a longer MCP server-startup budget (ms). The default can
+# race a Hindsight restart window; the boot gate below usually absorbs it,
+# but this keeps the in-session connect attempt itself patient too.
+# Documented Claude Code env var (MCP server startup timeout).
+export MCP_TIMEOUT="${MCP_TIMEOUT:-30000}"
+# Wait for Hindsight MCP to be READY before launching Claude, otherwise the
+# MCP server connection fails at startup with "1 MCP server failed" and the
+# session boots toolless (incident 2026-07-18: clerk booted toolless despite
+# a 30s bare-GET gate — the endpoint returned HTTP 200 mid-restart while a
+# real MCP initialize still failed). So: probe with an actual JSON-RPC
+# initialize POST and require a JSON-RPC result, not just HTTP 200.
+# Bounded at 120s; on timeout we log a warning and boot anyway (degraded
+# beats never-boots — the plugin reconnects once Hindsight recovers).
 HINDSIGHT_WAIT=0
-while [ $HINDSIGHT_WAIT -lt 30 ]; do
-  if curl -sf -o /dev/null --max-time 2 {{{hindsightApiBaseUrlQ}}}/mcp/; then
+HINDSIGHT_READY=0
+while [ $HINDSIGHT_WAIT -lt 120 ]; do
+  if curl -sf --max-time 3 \
+       -X POST {{{hindsightApiBaseUrlQ}}}/mcp/ \
+       -H "Content-Type: application/json" \
+       -H "Accept: application/json, text/event-stream" \
+       -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"switchroom-boot-gate","version":"1.0"}}}' \
+       2>/dev/null | grep -q '"result"'; then
+    HINDSIGHT_READY=1
     break
   fi
   sleep 1
   HINDSIGHT_WAIT=$((HINDSIGHT_WAIT + 1))
 done
+if [ "$HINDSIGHT_READY" = "1" ]; then
+  echo "start.sh: hindsight boot gate — MCP initialize OK after ${HINDSIGHT_WAIT}s" >&2
+else
+  echo "start.sh: WARNING hindsight boot gate TIMED OUT after ${HINDSIGHT_WAIT}s — MCP initialize never returned a JSON-RPC result; launching claude anyway (memory tools may be unavailable this session)" >&2
+fi
 {{/if}}
 {{#if userEnvQuoted}}
 # User-declared env vars from switchroom.yaml (agent + defaults merged).

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2297,9 +2297,22 @@ describe("reconcileAgent", () => {
     expect(startSh).toContain('"method":"initialize"');
     expect(startSh).toContain("-X POST");
     expect(startSh).toContain('-H "Accept: application/json, text/event-stream"');
-    expect(startSh).toContain(`grep -q '"result"'`);
-    // Bounded at 120s; boots anyway on timeout with a warning line
+    expect(startSh).toContain(`grep -q '"serverInfo"'`);
+    // The probe payload must be valid JSON after Handlebars rendering — a
+    // template mangle should fail here, not just a substring check
+    const payloadMatch = startSh.match(/-d '(\{.*\})'/);
+    expect(payloadMatch).toBeTruthy();
+    const payload = JSON.parse(payloadMatch![1]);
+    expect(payload.jsonrpc).toBe("2.0");
+    expect(payload.method).toBe("initialize");
+    expect(payload.params.protocolVersion).toBeTruthy();
+    // Best-effort session cleanup after a successful probe
+    expect(startSh).toContain("-X DELETE");
+    expect(startSh).toContain("Mcp-Session-Id");
+    // True 120s wall-clock bound (elapsed via date +%s, not iteration count);
+    // boots anyway on timeout with a warning line
     expect(startSh).toContain("HINDSIGHT_WAIT -lt 120");
+    expect(startSh).toContain("_hs_start=$(date +%s)");
     expect(startSh).toContain("hindsight boot gate TIMED OUT");
     expect(startSh).toContain("/mcp/");
   });

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2292,7 +2292,15 @@ describe("reconcileAgent", () => {
 
     const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
     expect(startSh).toContain("HINDSIGHT_WAIT=0");
-    expect(startSh).toContain("curl -sf -o /dev/null --max-time 2");
+    // Real MCP initialize probe (a bare GET returned 200 mid-restart and let
+    // a toolless session boot — 2026-07-18 clerk incident)
+    expect(startSh).toContain('"method":"initialize"');
+    expect(startSh).toContain("-X POST");
+    expect(startSh).toContain('-H "Accept: application/json, text/event-stream"');
+    expect(startSh).toContain(`grep -q '"result"'`);
+    // Bounded at 120s; boots anyway on timeout with a warning line
+    expect(startSh).toContain("HINDSIGHT_WAIT -lt 120");
+    expect(startSh).toContain("hindsight boot gate TIMED OUT");
     expect(startSh).toContain("/mcp/");
   });
 


### PR DESCRIPTION
## Why

On 2026-07-18 the **clerk** agent booted toolless ("1 MCP server failed") despite the existing 30s pre-launch gate in `profiles/_base/start.sh.hbs`. Root cause: the gate polled a **bare GET** on `/mcp/`, which can return HTTP 200 mid-restart while a real MCP `initialize` still fails — and 30s undershoots a Hindsight restart window.

## What changed

- **Real readiness probe**: POST a JSON-RPC `initialize` request to `/mcp/` with `Content-Type: application/json` and `Accept: application/json, text/event-stream`, and require a JSON-RPC `"result"` in the response body (dependency-free: curl + grep; works for both plain-JSON and SSE-framed responses). Verified functionally against a mock MCP HTTP server.
- **Bound extended 30s → 120s**; on timeout the agent still boots (degraded beats never-boots) with a clear `WARNING ... TIMED OUT` line.
- **Gate outcome logged** to the start.sh stderr stream either way (`initialize OK after Ns` / timeout warning) so future incidents are diagnosable.
- **`export MCP_TIMEOUT=${MCP_TIMEOUT:-30000}`** so claude's own MCP startup connect is patient too. Env var name verified present in the shipped claude binary (`bin/claude.exe`, v2.1.205); operator env overrides win via the default-expansion form.
- **Tests**: extended the existing scaffold render test to assert the rendered start.sh contains the initialize probe, the 120s bound, and the timeout warning; the omit-when-memory-disabled test still covers the negative path.

This is the only occurrence of the gate block — no other profile/template duplicates it (`grep -rn HINDSIGHT_WAIT profiles/` → `_base` only; `docker/hindsight-entrypoint.sh`'s `SWITCHROOM_HINDSIGHT_WAIT_S` is the container's own wait, untouched).

## Test results

- `vitest run tests/scaffold.test.ts` — 212 passed (one later re-run showed an unrelated 5s-timeout flake in the `resume_mode` test on a slow-IO sandbox; passed on the clean run).
- `npm run lint` — tsc + all guard scripts clean.
- Rendered gate block passes `bash -n` and `sh -n`; probe verified end-to-end against a mock MCP initialize endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)