### PR TITLE
refactor(gateway): gate module-load boot side effects behind startGateway() (#2996 P0c)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -895,6 +895,8 @@ import {
   type StatusQuerySurfaces,
 } from '../status-query-telemetry.js'
 
+const isGatewayMain = typeof process !== 'undefined' && process.argv[1] != null && (process.argv[1].endsWith('gateway.ts') || process.argv[1].endsWith('gateway.js'))  // #2996 P0c: true only when this module is the process entrypoint (prod `bun .../gateway.js`; under vitest argv[1] is the runner → false; mirrors streaming-report.ts). Every module-load side effect below is guarded by it; the boot sequence is the guarded startGateway() at the bottom, so an import() fires nothing.
+
 // ─── Stderr logging ───────────────────────────────────────────────────────
 // Install the line-stamper FIRST so it wraps closest to the original
 // stderr.write. plugin-logger's file mirror then sees the timestamped text.
@@ -1636,7 +1638,7 @@ function pruneExpired(a: Access): boolean {
 // ─── History ──────────────────────────────────────────────────────────────
 const HISTORY_ACCESS = loadAccess()
 const HISTORY_ENABLED = HISTORY_ACCESS.historyEnabled !== false
-if (HISTORY_ENABLED) {
+if (isGatewayMain && HISTORY_ENABLED) {  // #2996 P0c: gated — initHistory opens bun:sqlite
   try {
     initHistory(STATE_DIR, HISTORY_ACCESS.historyRetentionDays ?? 30)
     process.stderr.write(`telegram gateway: history capture enabled at ${join(STATE_DIR, 'history.db')}\n`)
@@ -1676,7 +1678,7 @@ let pendingRedelivery: { turn: Turn; maxAgeMs: number } | null = null
 // boots (the consumed marker's `count`; 0 when no fresh marker). Set in
 // the boot block below, consumed by the watchdog constructor further down.
 let bridgeDeadPriorStreak = 0
-try {
+if (isGatewayMain) try {  // #2996 P0c: gated — opens bun:sqlite + writes .pending-turn.env
   // STATE_DIR is `<agentDir>/telegram` in production. openTurnsDb expects
   // the parent (agent dir) and joins `telegram/registry.db` itself.
   const agentDir = STATE_DIR.endsWith('/telegram')
@@ -2205,11 +2207,11 @@ function runHistoryReaperNow(reason: 'boot' | 'periodic'): void {
     }
   }
 }
-// Run once at boot to catch up long-stopped agents.
-runHistoryReaperNow('boot')
+// Run once at boot to catch up long-stopped agents. (#2996 P0c: gated.)
+if (isGatewayMain) runHistoryReaperNow('boot')
 // Then every 6h. unref() so the interval doesn't keep the process alive
 // past shutdown.
-if (!STATIC) {
+if (isGatewayMain && !STATIC) {
   setInterval(() => runHistoryReaperNow('periodic'), REGISTRY_REAPER_INTERVAL_MS).unref()
 }
 
@@ -2229,12 +2231,12 @@ function checkApprovals(): void {
     )
   }
 }
-if (!STATIC) setInterval(checkApprovals, 5000).unref()
+if (isGatewayMain && !STATIC) setInterval(checkApprovals, 5000).unref()
 // Idle auto-clear: check wall-clock idle every minute; maybeIdleClear no-ops
 // when disabled ('0s'), mid-turn, or already cleared this idle period. The
 // `let` state + maybeIdleClear are hoisted/initialized before this fires.
 const IDLE_CLEAR_CHECK_MS = Number(process.env.SWITCHROOM_IDLE_CLEAR_CHECK_MS ?? 60_000)
-if (!STATIC && IDLE_CLEAR_CHECK_MS > 0) setInterval(maybeIdleClear, IDLE_CLEAR_CHECK_MS).unref()
+if (isGatewayMain && !STATIC && IDLE_CLEAR_CHECK_MS > 0) setInterval(maybeIdleClear, IDLE_CLEAR_CHECK_MS).unref()
 
 // ─── Thread / status / stream state ───────────────────────────────────────
 const chatThreadMap = new Map<string, number>()
@@ -2771,7 +2773,7 @@ const obligationLedger = new ObligationLedger(OBLIGATION_REPRESENT_MAX, {
       ? undefined
       : (snapshot) => persistObligations(OBLIGATION_STORE_PATH, obligationStoreFs, snapshot),
 })
-if (!STATIC && OBLIGATION_LEDGER_ENABLED) {
+if (isGatewayMain && !STATIC && OBLIGATION_LEDGER_ENABLED) {
   // Restart-durability: re-open obligations that were OPEN/ESCALATING when the
   // gateway last ran. The very next idle sweep re-presents or re-escalates them.
   const restored = loadObligations(OBLIGATION_STORE_PATH, obligationStoreFs)
@@ -6179,7 +6181,7 @@ const floodWindowObserver = createFloodWindowObserver({
     )
   },
 })
-if (sendGateConfig.enabled) {
+if (isGatewayMain && sendGateConfig.enabled) {
   const observeTimer = setInterval(() => {
     try {
       sendGateStatsLogger.tick()
@@ -7766,7 +7768,7 @@ function sweepHeldPermissionCards(): void {
 }
 
 // 60-second sweep drops anything past its documented TTL.
-const pendingStateReaper = setInterval(() => {
+const pendingStateReaper = isGatewayMain ? setInterval(() => {  // #2996 P0c gate
   const now = Date.now()
   // #3084 follow-up — bring held cards BACK the moment the channel reopens.
   // Runs before the TTL sweep below so a card that can be re-delivered on this
@@ -8034,8 +8036,8 @@ const pendingStateReaper = setInterval(() => {
     )
     void drainPendingSessionCommand()
   }
-}, 60_000)
-pendingStateReaper.unref()
+}, 60_000) : undefined
+pendingStateReaper?.unref()
 
 /**
  * Does a message look like a Claude setup-token browser code?
@@ -9319,10 +9321,10 @@ async function runMidSessionCardReaper(): Promise<void> {
   }
 }
 
-const midSessionCardReaper = setInterval(() => {
+const midSessionCardReaper = isGatewayMain ? setInterval(() => {  // #2996 P0c gate
   void runMidSessionCardReaper()
-}, MID_SESSION_CARD_REAPER_INTERVAL_MS)
-midSessionCardReaper.unref()
+}, MID_SESSION_CARD_REAPER_INTERVAL_MS) : undefined
+midSessionCardReaper?.unref()
 
 // NOTE: statusPinBootCleanup() is deliberately NOT invoked here at import time.
 // The status-pin store is a SHARED per-agent file, and cleanup issues real
@@ -9605,8 +9607,8 @@ let workerActivityFeed: ReturnType<typeof createWorkerActivityFeed> | null = nul
 
 // ─── IPC server ───────────────────────────────────────────────────────────
 const SOCKET_PATH = process.env.SWITCHROOM_GATEWAY_SOCKET ?? join(STATE_DIR, 'gateway.sock')
-// Ensure the directory for the socket exists
-mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 })
+// Ensure the directory for the socket exists (#2996 P0c: gated — disk write).
+if (isGatewayMain) mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 })
 
 // PID file + session marker. See pid-file.ts and session-marker.ts for
 // the 2026-04-22 incident that motivates these. The PID file lets the
@@ -9700,7 +9702,7 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
 //
 // We use top-level await so the mutex resolves BEFORE any other module
 // code runs (in particular before the bot.start IIFE further down).
-{
+if (isGatewayMain) {  // #2996 P0c: gated in place; guarded await never runs on import
   const SWITCHROOM_AGENT_NAME = process.env.SWITCHROOM_AGENT_NAME ?? '-'
   try {
     const outcome = await acquireStartupLock({
@@ -9924,7 +9926,7 @@ function parseKeyForSurvival(key: string): { chatId: string } {
   return { chatId: idx < 0 ? key : key.slice(0, idx) }
 }
 
-silencePoke.startTimer({
+if (isGatewayMain) silencePoke.startTimer({
   thresholdsMs: { fallback: SILENCE_FALLBACK_MS, fallbackHardCeiling: SILENCE_FALLBACK_HARD_MS, floor: SILENCE_FLOOR_MS },
   deferFallbackWhileToolInFlight: SILENCE_DEFER_INFLIGHT_TOOLS,
   isLegitimatelyWorking: (key) => isLegitimatelyWorking(key),
@@ -10325,10 +10327,10 @@ silencePoke.startTimer({
 // imperative silence-poke still owns the user-facing ping), so there
 // is no double-poke. unref so the interval never holds the process.
 const DELIVERY_MACHINE_TICK_MS = 30_000
-const _deliveryMachineTick = setInterval(() => {
+const _deliveryMachineTick = isGatewayMain ? setInterval(() => {  // #2996 P0c gate
   shadowEmit({ kind: 'tick', now: Date.now() })
-}, DELIVERY_MACHINE_TICK_MS)
-_deliveryMachineTick.unref?.()
+}, DELIVERY_MACHINE_TICK_MS) : undefined
+_deliveryMachineTick?.unref?.()
 
 // Enrol a buffer-redelivered inbound in the deliver-until-acked queue so the
 // existing sweep re-delivers it until claude's `enqueue` ack lands. Wired into
@@ -10457,7 +10459,7 @@ function sweepSuspendedTargets(): { keys: Set<string>; chats: Set<string> } {
   return { keys, chats }
 }
 
-const _deliveryConfirmSweep = setInterval(() => {
+const _deliveryConfirmSweep = isGatewayMain ? setInterval(() => {  // #2996 P0c gate
   if (!DELIVERY_CONFIRM_ENABLED) return
   // Re-deliver ONLY when claude is genuinely idle. `currentTurn` is set solely
   // by the enqueue session-event and nulled at turn-end, so `currentTurn != null`
@@ -10478,8 +10480,8 @@ const _deliveryConfirmSweep = setInterval(() => {
     if (isRedeliverySuspended(p.key, suspended)) continue
     void redeliverStrandedInbound(p)
   }
-}, DELIVERY_CONFIRM_SWEEP_MS)
-_deliveryConfirmSweep.unref?.()
+}, DELIVERY_CONFIRM_SWEEP_MS) : undefined
+_deliveryConfirmSweep?.unref?.()
 
 // #1445 cross-turn pending-async ambient. When a turn ends after the
 // model dispatched background async work (Agent / Task / Bash run-in-
@@ -10490,7 +10492,7 @@ _deliveryConfirmSweep.unref?.()
 // model synthesises a handback. The full design rationale lives in
 // `pending-work-progress.ts`'s header docblock. Kill switch:
 // `SWITCHROOM_DISABLE_PENDING_PROGRESS=1`.
-pendingProgress.startTimer({
+if (isGatewayMain) pendingProgress.startTimer({
   editMessage: async (ctx) => {
     // #2669: re-edit via the SAME shape the anchor was sent with. A rich
     // anchor (the reply tool's default) re-edits via the rich-markdown
@@ -11223,7 +11225,7 @@ function obligationSweep(): void {
     deadlineMs: OBLIGATION_ESCALATE_SEND_DEADLINE_MS,
   })
 }
-if (!STATIC && OBLIGATION_LEDGER_ENABLED) {
+if (isGatewayMain && !STATIC && OBLIGATION_LEDGER_ENABLED) {
   setInterval(obligationSweep, OBLIGATION_SWEEP_MS).unref()
 }
 
@@ -11235,7 +11237,7 @@ if (!STATIC && OBLIGATION_LEDGER_ENABLED) {
 // and it hasn't been delivered yet — so a multi-restart sequence resumes a
 // given turn once, not N times. When there's no spool (STATIC mode) push
 // straight to the in-memory buffer.
-if (bootResumeInbound != null) {
+if (isGatewayMain && bootResumeInbound != null) {
   if (inboundSpool != null) {
     inboundSpool.put(bootResumeInbound.agent, bootResumeInbound.msg)
   } else {
@@ -11267,7 +11269,7 @@ if (bootResumeInbound != null) {
 // spool.put dedups on the already-live id, so this re-push does NOT
 // double-append. This is what makes a queued message survive a
 // restart instead of being silently lost.
-if (inboundSpool != null) {
+if (isGatewayMain && inboundSpool != null) {
   const replay = inboundSpool.liveEntries()
   for (const e of replay) pendingInboundBuffer.push(e.agent, e.msg)
   if (replay.length > 0) {
@@ -11480,7 +11482,7 @@ const bridgeDeadWatchdog = createBridgeDeadWatchdog({
   // "any named non-cron client" test inside the watchdog.
   selfAgentName: process.env.SWITCHROOM_AGENT_NAME ?? '',
 })
-if (BRIDGE_DEAD_ESCALATION_ENABLED) {
+if (isGatewayMain && BRIDGE_DEAD_ESCALATION_ENABLED) {
   bridgeDeadWatchdog.arm()
   process.stderr.write(
     `telegram gateway: [bridge-dead-watchdog] armed (grace=${BRIDGE_DEAD_GRACE_MS}ms)\n`,
@@ -12860,7 +12862,7 @@ const ipcServer: IpcServer = createIpcServer({
 // peercred-gated UDS; this gateway (agent UID) owns the jsonl append,
 // dedup, and dispatch firing. Wrapped so any failure is best-effort and can
 // NEVER crash gateway boot (which would take the agent down).
-;(() => {
+if (isGatewayMain) (() => {  // #2996 P0c: gated — starts webhook-ingest UDS server
   try {
     const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
     if (!selfAgent) return
@@ -12961,7 +12963,7 @@ const ipcServer: IpcServer = createIpcServer({
 // reuse the #1546 `redeliverBufferedInbound` (lossless: re-buffers any
 // per-message miss).
 const IDLE_DRAIN_INTERVAL_MS = 5000
-if (!STATIC) {
+if (isGatewayMain && !STATIC) {
   setInterval(() => {
     const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
     const r = idleDrainTick(
@@ -13362,7 +13364,7 @@ function sweepVoiceCache(): void {
   }
 }
 
-if (!STATIC) {
+if (isGatewayMain && !STATIC) {
   sweepVoiceCache() // boot sweep — covers a died timer / long downtime
   setInterval(sweepVoiceCache, VOICE_SWEEP_INTERVAL_MS).unref()
 }
@@ -17283,7 +17285,7 @@ function feedHeartbeatTick(): void {
   }
   })
 }
-if (!STATIC && FEED_HEARTBEAT_ENABLED) {
+if (isGatewayMain && !STATIC && FEED_HEARTBEAT_ENABLED) {
   setInterval(feedHeartbeatTick, FEED_HEARTBEAT_TICK_MS).unref()
 }
 
@@ -30022,7 +30024,7 @@ async function shutdown(signal: string): Promise<void> {
   // any timer-driven flushes during drain still call into handleInbound
   // (which itself short-circuits when shuttingDown is true).
 
-  clearInterval(pendingStateReaper)
+  if (pendingStateReaper) clearInterval(pendingStateReaper)
   vaultPassphraseCache.clear()
 
   // #1067: orphaned-reply timeout now lives on the per-turn atom.
@@ -30186,7 +30188,7 @@ const POLL_HEALTH_THRESHOLD = Number(
 )
 
 let pollHealthCheck: PollHealthCheckHandle | null = null
-if (POLL_HEALTH_INTERVAL_MS > 0) {
+if (isGatewayMain && POLL_HEALTH_INTERVAL_MS > 0) {  // #2996 P0c: gated (probe timer)
   pollHealthCheck = createPollHealthCheck({
     ping: async () => {
       await bot.api.getMe()
@@ -30376,7 +30378,7 @@ async function initGatewayBot(): Promise<void> {
 // grammY 409 retry loop).
 let didOneTimeSetup = false
 
-void (async () => {
+async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now invoked once at the bottom only under isGatewayMain; body byte-identical to the pre-P0c IIFE
   // #2996 P0b: construct the bot + install the registration surface FIRST,
   // before vault-posture init and the runner. Keeps failure modes in pre-P0b
   // order: token refusal (exit 1) precedes the vault-posture refusal (exit 78).
@@ -32156,4 +32158,6 @@ void (async () => {
       process.exit(1)
     }
   }
-})()
+}
+
+if (isGatewayMain) void startGateway()  // #2996 P0c: the single, guarded boot invocation

--- a/telegram-plugin/tests/gateway-boot-side-effect-gating.test.ts
+++ b/telegram-plugin/tests/gateway-boot-side-effect-gating.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Import-safety pin for the #2996 P0c move: the remaining module-load side
+ * effects of gateway.ts are gated behind `isGatewayMain` so importing the
+ * module performs NO boot side effects, and the boot sequence is the guarded
+ * `startGateway()` at the bottom of the file.
+ *
+ * WHY this asserts on the parsed SOURCE, not a real `import()`:
+ * gateway.ts statically reaches modules whose bun:sqlite access + the still-
+ * ungated P0d process-handler / reaction-sweep registrations make a hermetic
+ * `await import()` under vitest impractical without heavy mocking (see the P0e
+ * note in the PR). The repo's oracle for "pin gateway structure without booting
+ * it" is source-parsing via `ts.createSourceFile` — the same pattern as
+ * gateway-bot-construction-deferral.test.ts (P0b) and
+ * gateway-handler-registration-wiring.test.ts (P0a). This test follows it and
+ * asserts OUTCOMES:
+ *
+ *   1. `isGatewayMain` is a module-scope const whose value is the argv[1]
+ *      main-check (true only when this module is the process entrypoint).
+ *   2. The boot sequence is `async function startGateway()`, invoked EXACTLY
+ *      once, and that sole invocation is guarded by `isGatewayMain`. The old
+ *      top-level boot IIFE (`void (async () => …)()`) is gone.
+ *   3. No UNGUARDED module-scope P0c side effect remains: every top-level
+ *      `setInterval` / `setTimeout` / `<x>.startTimer(…)` / `mkdirSync` /
+ *      `runHistoryReaperNow` / `openTurnsDb` / `initHistory` /
+ *      `acquireStartupLock` / `startWebhookIngestServer` /
+ *      `createPollHealthCheck` / `loadObligations` call, and every module-scope
+ *      `await`, sits inside an `isGatewayMain` guard (an `if (isGatewayMain …)`
+ *      or an `isGatewayMain ? … : …` ternary) — or inside a function body.
+ *
+ * A regression that re-hoists a timer, the startup-lock await, the boot IIFE,
+ * or the turn-registry open back to unguarded module scope fails (3).
+ *
+ * OUT OF SCOPE (P0d, deliberately still unguarded — see the PR/issue): the
+ * process signal/error handlers (`process.on('SIGTERM'|'SIGINT'|'beforeExit'|
+ * 'unhandledRejection'|'uncaughtException')`, `installPosthogErrorHandlers()`)
+ * and the startup reaction sweep (`sweepActiveReactions`). Those are NOT in the
+ * sentinel set below.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import ts from 'typescript'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_PATH = resolve(__dirname, '..', 'gateway', 'gateway.ts')
+const GATEWAY_SRC = readFileSync(GATEWAY_PATH, 'utf8')
+
+const sourceFile = ts.createSourceFile(
+  GATEWAY_PATH,
+  GATEWAY_SRC,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS,
+)
+
+function isFunctionLike(n: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(n) ||
+    ts.isFunctionExpression(n) ||
+    ts.isArrowFunction(n) ||
+    ts.isMethodDeclaration(n) ||
+    ts.isConstructorDeclaration(n) ||
+    ts.isGetAccessorDeclaration(n) ||
+    ts.isSetAccessorDeclaration(n)
+  )
+}
+
+function lineOf(n: ts.Node): number {
+  return sourceFile.getLineAndCharacterOfPosition(n.getStart(sourceFile)).line + 1
+}
+
+// The P0c-scoped side-effect sentinels. Each of these, at module scope, MUST be
+// isGatewayMain-guarded after P0c.
+const CALL_SENTINELS = new Set([
+  'setInterval',
+  'setTimeout',
+  'mkdirSync',
+  'runHistoryReaperNow',
+  'openTurnsDb',
+  'initHistory',
+  'acquireStartupLock',
+  'startWebhookIngestServer',
+  'createPollHealthCheck',
+  'loadObligations',
+])
+
+function sentinelName(n: ts.Node): string | null {
+  if (ts.isCallExpression(n)) {
+    const e = n.expression
+    if (ts.isIdentifier(e) && CALL_SENTINELS.has(e.text)) return e.text
+    // `<obj>.startTimer(...)` — the silencePoke / pendingProgress timers.
+    if (ts.isPropertyAccessExpression(e) && e.name.text === 'startTimer') {
+      return `${e.expression.getText(sourceFile)}.startTimer`
+    }
+  }
+  if (n.kind === ts.SyntaxKind.AwaitExpression) return 'await'
+  return null
+}
+
+function guardsOnMain(cond: ts.Expression): boolean {
+  return cond.getText(sourceFile).includes('isGatewayMain')
+}
+
+/**
+ * Walk the module top level (never descending into function bodies) collecting
+ * unguarded sentinels. `guarded` becomes true beneath an isGatewayMain
+ * if/ternary branch.
+ */
+function collectUnguarded(): string[] {
+  const findings: string[] = []
+  function walk(node: ts.Node, guarded: boolean): void {
+    if (isFunctionLike(node)) return
+    if (ts.isIfStatement(node) && guardsOnMain(node.expression)) {
+      walk(node.thenStatement, true)
+      if (node.elseStatement) walk(node.elseStatement, guarded)
+      return
+    }
+    if (ts.isConditionalExpression(node) && guardsOnMain(node.condition)) {
+      walk(node.whenTrue, true)
+      walk(node.whenFalse, guarded)
+      return
+    }
+    const s = sentinelName(node)
+    if (s && !guarded) findings.push(`${s}@${lineOf(node)}`)
+    ts.forEachChild(node, c => walk(c, guarded))
+  }
+  for (const stmt of sourceFile.statements) walk(stmt, false)
+  return findings
+}
+
+describe('gateway #2996 P0c: module-load boot side effects are gated behind isGatewayMain', () => {
+  it('declares `isGatewayMain` as a module-scope const with the argv[1] main-check', () => {
+    let found = false
+    for (const stmt of sourceFile.statements) {
+      if (!ts.isVariableStatement(stmt)) continue
+      for (const decl of stmt.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name) && decl.name.text === 'isGatewayMain') {
+          found = true
+          const init = decl.initializer?.getText(sourceFile) ?? ''
+          // Guards on argv[1] ending in the source or the built bundle name.
+          expect(init).toContain('process.argv[1]')
+          expect(init).toContain("endsWith('gateway.ts')")
+          expect(init).toContain("endsWith('gateway.js')")
+        }
+      }
+    }
+    expect(found).toBe(true)
+  })
+
+  it('defines an async `startGateway()` boot function and NO leftover boot IIFE', () => {
+    let startGatewayFn: ts.FunctionDeclaration | undefined
+    for (const stmt of sourceFile.statements) {
+      if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === 'startGateway') {
+        startGatewayFn = stmt
+      }
+    }
+    expect(startGatewayFn).toBeDefined()
+    const isAsync = (startGatewayFn!.modifiers ?? []).some(
+      m => m.kind === ts.SyntaxKind.AsyncKeyword,
+    )
+    expect(isAsync).toBe(true)
+
+    // The old top-level boot IIFE `void (async () => {…})()` must be gone: no
+    // module-scope immediately-invoked async arrow remains.
+    let bootIifes = 0
+    for (const stmt of sourceFile.statements) {
+      if (!ts.isExpressionStatement(stmt)) continue
+      let expr = stmt.expression
+      if (ts.isVoidExpression(expr)) expr = expr.expression
+      if (
+        ts.isCallExpression(expr) &&
+        (ts.isArrowFunction(expr.expression) || ts.isFunctionExpression(expr.expression))
+      ) {
+        const inner = expr.expression
+        const asyncArrow =
+          (inner.modifiers ?? []).some(m => m.kind === ts.SyntaxKind.AsyncKeyword)
+        if (asyncArrow) bootIifes++
+      }
+    }
+    expect(bootIifes).toBe(0)
+  })
+
+  it('invokes startGateway() EXACTLY once, guarded by isGatewayMain', () => {
+    let total = 0
+    let guardedCalls = 0
+    function walk(node: ts.Node, guarded: boolean): void {
+      if (isFunctionLike(node)) return // only the module-scope invocation
+      if (ts.isIfStatement(node) && guardsOnMain(node.expression)) {
+        walk(node.thenStatement, true)
+        if (node.elseStatement) walk(node.elseStatement, guarded)
+        return
+      }
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'startGateway'
+      ) {
+        total++
+        if (guarded) guardedCalls++
+      }
+      ts.forEachChild(node, c => walk(c, guarded))
+    }
+    for (const stmt of sourceFile.statements) walk(stmt, false)
+    expect(total).toBe(1)
+    expect(guardedCalls).toBe(1)
+  })
+
+  it('leaves NO unguarded module-scope timer / boot-I/O / startup-lock side effect', () => {
+    // If this fails it prints exactly which sentinel (e.g. `setInterval@1234`,
+    // `await@9750`, `openTurnsDb@1700`) escaped the isGatewayMain guard.
+    expect(collectUnguarded()).toEqual([])
+  })
+
+  it('gates every module-scope timer handle (the 4 reaper/tick consts)', () => {
+    // pendingStateReaper / midSessionCardReaper / _deliveryMachineTick /
+    // _deliveryConfirmSweep are `const X = isGatewayMain ? setInterval(…) :
+    // undefined` — their setInterval must be inside an isGatewayMain ternary.
+    const timerConsts = new Set([
+      'pendingStateReaper',
+      'midSessionCardReaper',
+      '_deliveryMachineTick',
+      '_deliveryConfirmSweep',
+    ])
+    const seen = new Set<string>()
+    for (const stmt of sourceFile.statements) {
+      if (!ts.isVariableStatement(stmt)) continue
+      for (const decl of stmt.declarationList.declarations) {
+        if (
+          ts.isIdentifier(decl.name) &&
+          timerConsts.has(decl.name.text) &&
+          decl.initializer
+        ) {
+          seen.add(decl.name.text)
+          const init = decl.initializer
+          // Must be a conditional whose condition mentions isGatewayMain and
+          // whose truthy branch is the setInterval call.
+          expect(ts.isConditionalExpression(init)).toBe(true)
+          if (ts.isConditionalExpression(init)) {
+            expect(guardsOnMain(init.condition)).toBe(true)
+            expect(init.whenTrue.getText(sourceFile)).toContain('setInterval')
+          }
+        }
+      }
+    }
+    expect([...seen].sort()).toEqual([...timerConsts].sort())
+  })
+})

--- a/telegram-plugin/tests/pending-card-durability-wiring.test.ts
+++ b/telegram-plugin/tests/pending-card-durability-wiring.test.ts
@@ -143,7 +143,8 @@ describe('resolution clears the durable store (Defect A)', () => {
 
 describe('TTL expiry wakes the parked agent (Defect B)', () => {
   it('the periodic reaper runs the approval-card expiry sweep inside try/catch', () => {
-    const reaper = slice(GATEWAY, 'const pendingStateReaper = setInterval', 12000)
+    // Anchor tolerates the #2996 P0c `isGatewayMain ? setInterval(...)` boot gate.
+    const reaper = slice(GATEWAY, 'const pendingStateReaper = ', 12000)
     // The sweep call must be guarded like the sibling sweepStaleTurnActiveMarker:
     // an escaped throw inside this setInterval callback reaches uncaughtException
     // and takes the whole gateway down.

--- a/telegram-plugin/tests/secret-detect-oauth-code.test.ts
+++ b/telegram-plugin/tests/secret-detect-oauth-code.test.ts
@@ -145,8 +145,9 @@ describe('auth-flow context rule — Channel B (structural wiring in gateway.ts)
   })
 
   it('reaps awaitingAuthCodeAt in the TTL reaper alongside other pending-state maps', () => {
-    // The pendingStateReaper interval must sweep expired auth-code-context entries
-    const reaperIdx = src.indexOf('pendingStateReaper = setInterval')
+    // The pendingStateReaper interval must sweep expired auth-code-context entries.
+    // Anchor tolerates the #2996 P0c `isGatewayMain ? setInterval(...)` boot gate.
+    const reaperIdx = src.indexOf('pendingStateReaper = ')
     expect(reaperIdx).toBeGreaterThan(0)
     const reaperBlock = src.slice(reaperIdx, reaperIdx + 800)
     expect(reaperBlock).toMatch(/awaitingAuthCodeAt/)


### PR DESCRIPTION
## Summary

Guard **every remaining module-load side effect** of `gateway.ts` behind a new `isGatewayMain` main-check, and turn the boot IIFE into a callable `async function startGateway()` invoked **once** at the bottom of the module ONLY when this module is the process entrypoint. Importing `gateway.ts` no longer starts any timer, opens bun:sqlite, acquires the startup mutex, writes the socket dir / `.pending-turn.env`, starts the webhook UDS server, or enters the polling runner — and reaches no `process.exit`.

This is #2996 **P0c**, following the merged P0a (`registerGatewayHandlers`, #3308) and P0b (defer `new Bot` construction, #3310).

## Why

#3010's merge note names module-load side effects as the blocker to importing `gateway.ts` under vitest. P0a/P0b deferred the bot; P0c gates the rest so the module reaches construction cleanly.

## What's gated (P0c scope)

- history init (`initHistory`, bun:sqlite) + the turn-registry / boot-resume block (`openTurnsDb`, `.pending-turn.env`)
- boot history reaper + **all** reaper/sweep/heartbeat `setInterval` timers (registry, approvals, idle-clear, `pendingStateReaper`, `midSessionCardReaper`, sendGate observe, delivery tick + confirm sweep, obligation sweep, idle-drain, voice-cache sweep, feed heartbeat)
- `silencePoke`/`pendingProgress` `.startTimer`, `pollHealthCheck` probe
- socket-dir `mkdir`, the **startup-mutex** block (guarded top-level `await` + `exit`), obligation-ledger restore, spool boot-inject + replay, bridge-dead watchdog `arm`, webhook-ingest UDS server
- the boot IIFE → `startGateway()`, invoked once under `isGatewayMain`

## Behavior guarantee — byte-identical in prod

Every guard is `isGatewayMain && <orig>` or `if (isGatewayMain) <orig>` (always true as the entrypoint); the four reaper/tick timers become `const X = isGatewayMain ? setInterval(...) : undefined`; `startGateway()`'s body is the **verbatim** pre-P0c IIFE body. The full diff is guard additions + those ternaries only — no logic moved, no ordering changed (the startup lock stays ordered before the reaction sweep + runner; the boot IIFE already ran last).

## Verified prod launch (main-detection works in the real container)

`profiles/_base/start.sh.hbs:321-325` launches the gateway as:
```
_gateway_bundle=/opt/switchroom/telegram-plugin/dist/gateway/gateway.js
_switchroom_supervise gateway ... bun "$_gateway_bundle" &
```
So in prod `process.argv[1]` ends with `gateway.js` → `isGatewayMain === true` → boots exactly as before. Under vitest `argv[1]` is the runner → `false`. The `argv[1].endsWith('gateway.ts'|'gateway.js')` convention mirrors the plugin's own bundled entrypoint `telegram-plugin/streaming-report.ts` (the closest analog to the gateway's bun-bundled launch; the import.meta main-check in `scripts/check-gateway-line-ratchet.mjs` is the same idea for a plain node script).

## Is import now fully side-effect-free? Not yet — what remains

A scratch `await import('../gateway/gateway.ts')` (with `argv[1]` forced non-main) now proceeds through **every gated block firing nothing** and fails only at the first **ungated const-factory**: `const ipcServer = createIpcServer()` → `Bun.listen(...)` at `gateway.ts:~11492` (a UDS socket opened at module scope, requires the Bun runtime). So P0c eliminates the enumerated side effects but a hermetic runtime import still needs:

- **P0e** — defer the const-factory eager-I/O chain (`ipcServer` = `Bun.listen`; `createInboundSpool().hydrate()`), a bot-sized ref-web deferral (out of ratchet room here).
- **P0d** — the process signal/error handlers (`SIGTERM`/`SIGINT`/`beforeExit`/`unhandledRejection`/`uncaughtException`, `installPosthogErrorHandlers`) + the startup reaction sweep (`sweepActiveReactions`), still registered at import, deliberately left ungated to keep this PR single-concern.

Because a hermetic `import()` remains blocked by the P0e const-factory chain, the pin stays **AST-source-based** like P0a/P0b (the runtime smoke test is deferred to P0e — noted, not cheap).

## Test plan

- New pin `telegram-plugin/tests/gateway-boot-side-effect-gating.test.ts` (5 tests): `isGatewayMain` const shape; `startGateway` is async + the old boot IIFE is gone; `startGateway` invoked exactly once, guarded; **no unguarded module-scope timer / boot-I/O / startup-lock / `await` sentinel**; the 4 timer consts are `isGatewayMain` ternaries.
- P0a/P0b pins still green (14). Scoped gateway boot/startup vitest green (62) + `gateway-startup-mutex` bun green (10).
- `npm run lint` clean, incl. the gateway line ratchet (**32163 == ratchet 32113 + slack 50**, exactly at ceiling; ratchet not raised).

Ref: `reference/jobs/always-available.md` — the importability seam unblocks the P2/P4/P6 test harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)