### PR TITLE
feat(routing): deterministic + observable agent→LiteLLM routing (fable demotion split by cause, .routing-mode, boot-card row)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -96,6 +96,13 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   #
   # SWITCHROOM_AGENT_NAME is injected by compose env (compose.ts:1816)
   # so it is available here, before the inner-pass export at line ~320.
+  #
+  # Capture whether LiteLLM routing was configured at compose time BEFORE the
+  # missing-key fail-open below can strip SWITCHROOM_LITELLM. The routing-mode
+  # observability block (inner pass, pre-exec) reads this to distinguish
+  # "litellm never configured" (declared intent IS direct-oauth — no
+  # divergence) from "configured but stripped at boot" (real divergence).
+  export SWITCHROOM_LITELLM_DECLARED="${SWITCHROOM_LITELLM_DECLARED:-${SWITCHROOM_LITELLM:-}}"
   if [ -n "${SWITCHROOM_LITELLM:-}" ] && [ -z "$ANTHROPIC_CUSTOM_HEADERS" ] && command -v switchroom >/dev/null 2>&1; then
     sr_ll_key="$(switchroom vault get "litellm/$SWITCHROOM_AGENT_NAME/api-key" 2>/dev/null || true)"
     sr_ll_ok=""
@@ -1096,7 +1103,20 @@ fi
 # unreachable at boot, or claude would 4xx an unknown model against Anthropic.
 # Empty by default (proxy not confirmed live); set to "1" only on a successful
 # liveliness probe. Deliberately NOT unset with the sr_ll_* scratch vars.
+#
+# _LITELLM_UNREACHABLE distinguishes WHY _LITELLM_OK is empty (routing-cause
+# split, 2026-07-17 boot-race incident): "1" means the key was present and the
+# probe failed — routing was LEFT IN PLACE pointing at the proxy, so a
+# proxy-only model (fable/sr-*) can boot loud-degraded and self-heal per
+# request. Empty means either the key is MISSING (routing stripped — a
+# proxy-only model genuinely cannot work and must demote) or LiteLLM is not
+# configured at all (same conclusion). Deliberately NOT unset either.
 _LITELLM_OK=""
+_LITELLM_UNREACHABLE=""
+# Idempotent mirror of the outer-pass capture (first setter wins) — on the
+# non-docker path only this inner block runs, so capture here too, before the
+# missing-key fail-open below can strip SWITCHROOM_LITELLM.
+export SWITCHROOM_LITELLM_DECLARED="${SWITCHROOM_LITELLM_DECLARED:-${SWITCHROOM_LITELLM:-}}"
 if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; then
   sr_ll_key="$(switchroom vault get "litellm/$SWITCHROOM_AGENT_NAME/api-key" 2>/dev/null || true)"
   sr_ll_ok=""
@@ -1112,10 +1132,14 @@ if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; th
     # co-boots, the litellm proxy's heavy Python app is often not yet healthy
     # in the first few seconds. A single one-shot probe fails-open and takes
     # this agent dark (untracked) for the WHOLE session. Poll the liveliness
-    # endpoint every ~3s for up to 120s (hard budget) and only fall open if
+    # endpoint every ~3s for up to SWITCHROOM_LITELLM_BOOT_BUDGET seconds
+    # (default 240 — the INNER budget only; the outer/gateway-pass probe stays
+    # at 120s so gateway boot latency is not doubled) and only fall open if
     # it is STILL unreachable after that whole window.
     sr_ll_url="${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness"
-    sr_ll_deadline=$(( $(date +%s) + 120 ))
+    sr_ll_budget="${SWITCHROOM_LITELLM_BOOT_BUDGET:-240}"
+    case "$sr_ll_budget" in *[!0-9]*|"") sr_ll_budget=240 ;; esac
+    sr_ll_deadline=$(( $(date +%s) + sr_ll_budget ))
     sr_ll_up=""
     while :; do
       if curl -fsS -m 5 -o /dev/null "$sr_ll_url" 2>/dev/null; then sr_ll_up="1"; break; fi
@@ -1127,8 +1151,9 @@ if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; th
       # leave it pointed at litellm so the fleet self-heals once the proxy is
       # back (the socat forwarder at 127.0.0.1:4010 reconnects per-connection).
       sr_ll_unreachable="1"
+      _LITELLM_UNREACHABLE="1"
       echo "==================== litellm UNREACHABLE ====================" >&2
-      echo "WARNING: litellm proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} after 120s of retries;" >&2
+      echo "WARNING: litellm proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} after ${sr_ll_budget}s of retries;" >&2
       echo "WARNING: Claude traffic will FAIL until it recovers — routing LEFT IN PLACE" >&2
       echo "WARNING: so it self-heals (socat forwarder reconnects per-connection)." >&2
       echo "WARNING: NOT falling back to untracked direct Anthropic OAuth." >&2
@@ -1136,7 +1161,7 @@ if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; th
     else
       sr_ll_ok="1"
     fi
-    unset sr_ll_url sr_ll_deadline sr_ll_up
+    unset sr_ll_url sr_ll_budget sr_ll_deadline sr_ll_up
   else
     sr_ll_ok="1"
   fi
@@ -1419,22 +1444,37 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   unset _smf _sm_model _sm_cfg _sm_attempts _SM_MAX_ATTEMPTS
 fi
 
-# Configured-default LiteLLM guard. A proxy-only *configured* model with
-# LiteLLM unreachable at boot would exec against the /anthropic passthrough,
-# where `fable`/`claude-fable-5` is a retired codename and EVERY call 4xxs —
-# a total outage. The carrier block above already drops proxy-only OVERRIDES
-# on a down proxy; this extends the same guard to the configured default,
-# which the live-config read above makes a mainline path (pinning `model:
-# fable` in yaml is now the normal way to run Fable). Claude agents have a
-# safe same-class fallback (opus); sr-* configured defaults keep today's
-# loud-degraded behavior — there is no Claude fallback for them and the
-# repoint case below already leaves their routing to self-heal.
+# Configured-default LiteLLM guard, SPLIT BY CAUSE (2026-07-17 boot-race
+# incident: a slow LiteLLM co-boot demoted a configured-fable agent to opus on
+# the passthrough — silent divergence that persisted for the whole session).
+#
+#   - MISSING KEY / LiteLLM not configured (_LITELLM_UNREACHABLE empty):
+#     routing was STRIPPED (direct Anthropic OAuth), where `fable`/
+#     `claude-fable-5` is a retired codename and EVERY call 4xxs — a total
+#     outage. Claude agents have a safe same-class fallback: demote to opus,
+#     loudly (stderr + .session-model-alert).
+#   - PROXY UNREACHABLE, key present (_LITELLM_UNREACHABLE="1"): routing was
+#     LEFT IN PLACE pointing at the proxy. Do NOT demote — boot the declared
+#     fable model against the LiteLLM router root (the repoint case below
+#     includes the unreachable path) and run loud-degraded, the same policy as
+#     sr-* configured defaults: requests fail until the proxy heals, then work
+#     with ZERO divergence and no restart needed (per-request recovery — see
+#     the repoint comment below).
+#
+# The carrier block above already drops proxy-only OVERRIDES on a down proxy;
+# this guard covers only the configured default, which the live-config read
+# above makes a mainline path (pinning `model: fable` in yaml is the normal
+# way to run Fable).
 case "$_EFFECTIVE_MODEL" in
   fable|claude-fable-5)
     if [ -z "$_LITELLM_OK" ]; then
-      echo "session-model: configured model '$_EFFECTIVE_MODEL' is proxy-only but LiteLLM is unreachable at boot — booting 'opus' until the proxy recovers" >&2
-      printf 'LiteLLM was unreachable at boot, so the configured model `%s` (proxy-only) could not be used — the agent booted on `opus` instead. Restart the agent once the proxy is back to return to `%s`.\n' "$_EFFECTIVE_MODEL" "$_EFFECTIVE_MODEL" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
-      _EFFECTIVE_MODEL="opus"
+      if [ -n "$_LITELLM_UNREACHABLE" ]; then
+        echo "session-model: configured model '$_EFFECTIVE_MODEL' is proxy-only and LiteLLM is unreachable at boot — booting '$_EFFECTIVE_MODEL' anyway against the LiteLLM router (loud-degraded; requests fail until the proxy recovers, then self-heal per-request). NOT demoting to opus." >&2
+      else
+        echo "session-model: configured model '$_EFFECTIVE_MODEL' is proxy-only but no LiteLLM virtual key is available (routing stripped to direct Anthropic, where it would 4xx every call) — booting 'opus' instead" >&2
+        printf 'No LiteLLM virtual key was available at boot (routing stripped to direct Anthropic), so the configured model `%s` (proxy-only) cannot work — the agent booted on `opus` instead. Run `switchroom apply` on the host (it provisions the LiteLLM key), then restart this agent to return to `%s`.\n' "$_EFFECTIVE_MODEL" "$_EFFECTIVE_MODEL" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+        _EFFECTIVE_MODEL="opus"
+      fi
     fi
     ;;
 esac
@@ -1518,9 +1558,16 @@ printf '%s\n' "$_EFFECTIVE_EFFORT" > "{{agentDir}}/.active-session-effort" 2>/de
 # /v1/models (both `fable` and `claude-fable-5` served). Other Claude sessions
 # (opus/sonnet/haiku/default) keep the passthrough — it dodges the Opus SSE
 # re-chunk stall; Fable trades that for being routable at all.
+# Repoint fires when the proxy is LIVE (_LITELLM_OK) OR when it is unreachable
+# with the key present (_LITELLM_UNREACHABLE — routing left in place, cause
+# split above): a configured fable that survives the unreachable guard must
+# land on the ROUTER ROOT, not the model-agnostic passthrough, or it would
+# keep 4xxing even after the proxy heals. Missing-key boots never get here
+# with a proxy-only model (the guard above demoted fable to opus, and sr-*
+# had its routing stripped anyway).
 case "$_EFFECTIVE_MODEL" in
   sr-*|fable|claude-fable-5)
-    if [ -n "$_LITELLM_OK" ] && [ -n "$SWITCHROOM_LITELLM_BASE" ]; then
+    if { [ -n "$_LITELLM_OK" ] || [ -n "$_LITELLM_UNREACHABLE" ]; } && [ -n "$SWITCHROOM_LITELLM_BASE" ]; then
       export ANTHROPIC_BASE_URL="$SWITCHROOM_LITELLM_BASE"
       echo "session-model: effective model '$_EFFECTIVE_MODEL' is proxy-only (sr-*/fable) — routing via LiteLLM model router '$SWITCHROOM_LITELLM_BASE' (off /anthropic passthrough)" >&2
     fi
@@ -1530,6 +1577,38 @@ esac
 # in-memory session-model state after this restart, keeping /status and the
 # welcome card honest. Overwrite (not consumed) — the gateway reads it at boot.
 printf '%s\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.active-session-model" 2>/dev/null || true
+
+# --- Routing-mode observability (.routing-mode, 2026-07-17 boot-race incident) ---
+#
+# Deterministic record of WHERE this boot actually landed, written immediately
+# before exec claude (overwrite-per-boot, one line). Consumers: the gateway
+# boot card's "routing" row and any operator shell. _DECLARED_ROUTING is baked
+# at render time from the same isClaudeModel() split compose.ts uses for
+# ANTHROPIC_BASE_URL (passthrough for Claude-class models, router-root
+# otherwise) — the apply-time INTENT the landed mode is compared against.
+# Divergence (landed ≠ declared) appends a consume-once .session-model-alert
+# line the gateway relays to the operator, but ONLY when the landed mode
+# differs from the PREVIOUS boot's landed mode — a persistently degraded agent
+# alerts once, not on every restart.
+_DECLARED_ROUTING={{{declaredRoutingQ}}}
+# When LiteLLM was never configured for this agent (no SWITCHROOM_LITELLM at
+# boot entry, captured before any strip), compose injects NO routing env — the
+# declared intent genuinely IS direct-oauth, not the model-class bake. This
+# keeps non-LiteLLM fleets from false-alerting divergence on every boot.
+if [ -z "${SWITCHROOM_LITELLM_DECLARED:-}" ]; then _DECLARED_ROUTING="direct-oauth"; fi
+case "${ANTHROPIC_BASE_URL:-}" in
+  "") _ROUTING_MODE="direct-oauth" ;;
+  */anthropic) _ROUTING_MODE="passthrough" ;;
+  *) _ROUTING_MODE="router-root" ;;
+esac
+_prev_routing_mode="$(sed -n 's/^mode=\([^ ]*\).*/\1/p' "{{agentDir}}/.routing-mode" 2>/dev/null | head -n 1 || true)"
+_routing_line="mode=$_ROUTING_MODE base=${ANTHROPIC_BASE_URL:-direct} model=$_EFFECTIVE_MODEL litellm_ok=${_LITELLM_OK:-0} declared=$_DECLARED_ROUTING ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf '%s\n' "$_routing_line" > "{{agentDir}}/.routing-mode" 2>/dev/null || true
+echo "routing: $_routing_line" >&2
+if [ "$_ROUTING_MODE" != "$_DECLARED_ROUTING" ] && [ "$_ROUTING_MODE" != "$_prev_routing_mode" ]; then
+  printf 'Routing divergence: this agent landed on `%s` (base `%s`, model `%s`) but its declared routing is `%s`. Check `%s/.routing-mode` and the boot log for the cause (LiteLLM key/provision or proxy reachability).\n' "$_ROUTING_MODE" "${ANTHROPIC_BASE_URL:-direct}" "$_EFFECTIVE_MODEL" "$_DECLARED_ROUTING" "{{agentDir}}" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+fi
+unset _prev_routing_mode _routing_line
 
 {{#if useSwitchroomPlugin}}
 if [ -n "$APPEND_PROMPT" ]; then

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1583,13 +1583,16 @@ printf '%s\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.active-session-model" 2>/dev/
 # Deterministic record of WHERE this boot actually landed, written immediately
 # before exec claude (overwrite-per-boot, one line). Consumers: the gateway
 # boot card's "routing" row and any operator shell. _DECLARED_ROUTING is baked
-# at render time from the same isClaudeModel() split compose.ts uses for
-# ANTHROPIC_BASE_URL (passthrough for Claude-class models, router-root
-# otherwise) — the apply-time INTENT the landed mode is compared against.
+# at render time by declaredRoutingMode() — the POST-REPOINT mode this boot is
+# meant to land on (fable/claude-fable-5/sr-* declare router-root because the
+# repoint case below moves them there; only non-fable Claude models declare
+# passthrough) — the apply-time INTENT the landed mode is compared against.
 # Divergence (landed ≠ declared) appends a consume-once .session-model-alert
-# line the gateway relays to the operator, but ONLY when the landed mode
-# differs from the PREVIOUS boot's landed mode — a persistently degraded agent
-# alerts once, not on every restart.
+# line the gateway relays to the operator, but ONLY when the (landed, declared)
+# PAIR differs from the PREVIOUS boot's pair — a persistently degraded agent
+# alerts once, not on every restart, yet a declared-only flip (operator changes
+# the configured model class while the agent stays stuck on the same wrong
+# landed mode) still re-alerts.
 _DECLARED_ROUTING={{{declaredRoutingQ}}}
 # When LiteLLM was never configured for this agent (no SWITCHROOM_LITELLM at
 # boot entry, captured before any strip), compose injects NO routing env — the
@@ -1602,13 +1605,18 @@ case "${ANTHROPIC_BASE_URL:-}" in
   *) _ROUTING_MODE="router-root" ;;
 esac
 _prev_routing_mode="$(sed -n 's/^mode=\([^ ]*\).*/\1/p' "{{agentDir}}/.routing-mode" 2>/dev/null | head -n 1 || true)"
+_prev_declared_routing="$(sed -n 's/.* declared=\([^ ]*\).*/\1/p' "{{agentDir}}/.routing-mode" 2>/dev/null | head -n 1 || true)"
 _routing_line="mode=$_ROUTING_MODE base=${ANTHROPIC_BASE_URL:-direct} model=$_EFFECTIVE_MODEL litellm_ok=${_LITELLM_OK:-0} declared=$_DECLARED_ROUTING ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 printf '%s\n' "$_routing_line" > "{{agentDir}}/.routing-mode" 2>/dev/null || true
 echo "routing: $_routing_line" >&2
-if [ "$_ROUTING_MODE" != "$_DECLARED_ROUTING" ] && [ "$_ROUTING_MODE" != "$_prev_routing_mode" ]; then
+# Dedup on the (landed, declared) PAIR, not landed alone: a persistently
+# degraded agent alerts once, but if the operator flips the declared class
+# while the agent stays stuck on the same wrong landed mode, the pair changes
+# and we re-alert (LOW-2).
+if [ "$_ROUTING_MODE" != "$_DECLARED_ROUTING" ] && { [ "$_ROUTING_MODE" != "$_prev_routing_mode" ] || [ "$_DECLARED_ROUTING" != "$_prev_declared_routing" ]; }; then
   printf 'Routing divergence: this agent landed on `%s` (base `%s`, model `%s`) but its declared routing is `%s`. Check `%s/.routing-mode` and the boot log for the cause (LiteLLM key/provision or proxy reachability).\n' "$_ROUTING_MODE" "${ANTHROPIC_BASE_URL:-direct}" "$_EFFECTIVE_MODEL" "$_DECLARED_ROUTING" "{{agentDir}}" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
 fi
-unset _prev_routing_mode _routing_line
+unset _prev_routing_mode _prev_declared_routing _routing_line
 
 {{#if useSwitchroomPlugin}}
 if [ -n "$APPEND_PROMPT" ]; then

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -599,6 +599,7 @@ export function maybeWriteCronMcp(
   return path;
 }
 import { resolveUsers, resolvePersonEntries } from "../config/users.js";
+import { isClaudeModel } from "../../telegram-plugin/gateway/model-command.js";
 import {
   resolveAgentConfig,
   translateHooksToClaudeShape,
@@ -3242,6 +3243,13 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     // switchroom.yaml. See profiles/_base/start.sh.hbs (Session model
     // resolution) and telegram-plugin/gateway/model-command.ts.
     modelQ: shellSingleQuote(resolveMainModel(agentConfig.model)),
+    // Declared routing INTENT, baked with the same isClaudeModel split
+    // compose.ts uses to pick ANTHROPIC_BASE_URL (passthrough vs router
+    // root). start.sh compares the LANDED routing mode against this and
+    // writes both to `.routing-mode` (2026-07-17 boot-race incident).
+    declaredRoutingQ: shellSingleQuote(
+      isClaudeModel(resolveMainModel(agentConfig.model)) ? "passthrough" : "router-root",
+    ),
     ...buildCronSessionContext(agentConfig),
     thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
     permissionMode: agentConfig.permission_mode,
@@ -6458,6 +6466,11 @@ function reconcileAgentInner(
       // home, not /host-home (see hostHomeForBake).
       hostHomeQ: hostHomeQForBake(),
       modelQ: shellSingleQuote(resolveMainModel(agentConfig.model)),
+      // Mirror buildWorkspaceContext: declared routing intent for the
+      // `.routing-mode` landed-vs-declared comparison in start.sh.
+      declaredRoutingQ: shellSingleQuote(
+        isClaudeModel(resolveMainModel(agentConfig.model)) ? "passthrough" : "router-root",
+      ),
       ...buildCronSessionContext(agentConfig),
       thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
       permissionMode: agentConfig.permission_mode,

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1368,6 +1368,33 @@ export function resolveMainModel(model: string | undefined): string {
 }
 
 /**
+ * Declared routing INTENT for a resolved main model — the mode start.sh will
+ * actually LAND on after its repoint case, NOT the raw compose `isClaudeModel`
+ * env split. start.sh (profiles/_base/start.sh.hbs) repoints
+ * `sr-*|fable|claude-fable-5` onto the LiteLLM model-router ROOT whenever the
+ * proxy is live/unreachable-with-key, so a healthy configured-fable boot lands
+ * on `router-root` even though compose baked its ANTHROPIC_BASE_URL on the
+ * `/anthropic` passthrough (fable is a Claude model). Only NON-fable Claude
+ * models (opus/sonnet/haiku/default) keep the passthrough. Non-Claude models
+ * (sr-*) have no `.session-model-override` carrier and route via the root too.
+ *
+ * `.routing-mode` compares the LANDED mode against this DECLARED value, so it
+ * must encode the post-repoint intent — otherwise a healthy fable boot fires a
+ * spurious "Routing divergence" alert and a permanent 🟡 boot-card row.
+ * Mirror the repoint `case` set exactly.
+ */
+export function declaredRoutingMode(resolvedModel: string): "passthrough" | "router-root" {
+  if (
+    resolvedModel === "fable" ||
+    resolvedModel === "claude-fable-5" ||
+    resolvedModel.startsWith("sr-")
+  ) {
+    return "router-root";
+  }
+  return isClaudeModel(resolvedModel) ? "passthrough" : "router-root";
+}
+
+/**
  * Prefer the `fable` alias over the retired `claude-fable-5` codename in
  * anything we launch or persist. The codename 4xxs direct-to-Anthropic and
  * only resolves via the LiteLLM router; the alias resolves everywhere the
@@ -3243,12 +3270,14 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     // switchroom.yaml. See profiles/_base/start.sh.hbs (Session model
     // resolution) and telegram-plugin/gateway/model-command.ts.
     modelQ: shellSingleQuote(resolveMainModel(agentConfig.model)),
-    // Declared routing INTENT, baked with the same isClaudeModel split
-    // compose.ts uses to pick ANTHROPIC_BASE_URL (passthrough vs router
-    // root). start.sh compares the LANDED routing mode against this and
-    // writes both to `.routing-mode` (2026-07-17 boot-race incident).
+    // Declared routing INTENT — the POST-REPOINT mode start.sh lands on (see
+    // declaredRoutingMode), NOT the raw compose isClaudeModel env split: a
+    // configured fable rides compose's `/anthropic` env but start.sh repoints
+    // it onto the router root, so declared must say `router-root`. start.sh
+    // compares the LANDED routing mode against this and writes both to
+    // `.routing-mode` (2026-07-17 boot-race incident).
     declaredRoutingQ: shellSingleQuote(
-      isClaudeModel(resolveMainModel(agentConfig.model)) ? "passthrough" : "router-root",
+      declaredRoutingMode(resolveMainModel(agentConfig.model)),
     ),
     ...buildCronSessionContext(agentConfig),
     thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
@@ -6469,7 +6498,7 @@ function reconcileAgentInner(
       // Mirror buildWorkspaceContext: declared routing intent for the
       // `.routing-mode` landed-vs-declared comparison in start.sh.
       declaredRoutingQ: shellSingleQuote(
-        isClaudeModel(resolveMainModel(agentConfig.model)) ? "passthrough" : "router-root",
+        declaredRoutingMode(resolveMainModel(agentConfig.model)),
       ),
       ...buildCronSessionContext(agentConfig),
       thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -68,6 +68,7 @@ import {
   type ConfigDiff,
 } from './config-snapshot.js'
 import { join } from 'path'
+import { readFileSync, statSync } from 'fs'
 import { bootCardChatKey, loadBootCardMsgId, saveBootCardMsgId } from './boot-card-msgid.js'
 import { nonEssentialSendSuppression } from '../flood-circuit-breaker.js'
 import { loadConfig as _loadSwitchroomConfig } from '../../src/config/loader.js'
@@ -278,6 +279,89 @@ const REASON_LABEL: Record<RestartReason, string> = {
   fresh:    'fresh start',
 }
 
+// ─── Routing-mode row (.routing-mode observability) ─────────────────────────
+
+/**
+ * Parsed `.routing-mode` state file — one overwrite-per-boot line written by
+ * start.sh immediately before `exec claude`:
+ *
+ *   mode=<router-root|passthrough|direct-oauth> base=<url> model=<effective>
+ *   litellm_ok=<0|1> declared=<mode> ts=<iso>
+ *
+ * `prevBoot` marks a RENDER-TIMING hazard, not file corruption: the gateway
+ * (outer pass) can render the boot card BEFORE the inner pass writes this
+ * boot's line (the inner LiteLLM probe can hold the write back for minutes on
+ * a degraded proxy). When the file's mtime predates this gateway process
+ * start, the value belongs to the PREVIOUS boot and must be labeled as such —
+ * never shown as current.
+ */
+export interface RoutingModeInfo {
+  /** Landed routing mode this boot: router-root | passthrough | direct-oauth. */
+  mode: string
+  /** Declared (apply-time) routing intent, when present in the file. */
+  declared?: string
+  /** Effective launched model recorded alongside the mode. */
+  model?: string
+  /** LiteLLM liveliness at boot ("1" ok / "0" not confirmed). */
+  litellmOk?: string
+  /** True when the file predates this gateway boot (stale — prev boot's value). */
+  prevBoot: boolean
+}
+
+/**
+ * Read + parse `<agentDir>/.routing-mode`. Returns null when the file is
+ * absent, unreadable, or carries no `mode=` field (tolerant by design — the
+ * boot card must render fine on fleets that pre-date the state file).
+ *
+ * `bootStartMs` is the epoch-ms this gateway process started; a file mtime
+ * strictly older than it is flagged `prevBoot` so the renderer can label the
+ * row instead of presenting stale data as current.
+ */
+export function readRoutingMode(
+  agentDir: string,
+  bootStartMs: number,
+  fsImpl: { readFileSync: typeof readFileSync; statSync: typeof statSync } = { readFileSync, statSync },
+): RoutingModeInfo | null {
+  const path = join(agentDir, '.routing-mode')
+  try {
+    const raw = fsImpl.readFileSync(path, 'utf-8')
+    const line = raw.split('\n')[0] ?? ''
+    const field = (key: string): string | undefined => {
+      const m = line.match(new RegExp(`(?:^|\\s)${key}=([^\\s]+)`))
+      return m ? m[1] : undefined
+    }
+    const mode = field('mode')
+    if (!mode) return null
+    const mtimeMs = fsImpl.statSync(path).mtimeMs
+    return {
+      mode,
+      declared: field('declared'),
+      model: field('model'),
+      litellmOk: field('litellm_ok'),
+      prevBoot: mtimeMs < bootStartMs,
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Render the routing row for the boot card. Divergence (landed ≠ declared)
+ * gets the warning dot; a converged mode renders as a dim informational row —
+ * deliberately always visible (2026-07-17 incident: both divergence cases
+ * were SILENT; the row is the standing observability surface).
+ */
+export function renderRoutingRow(r: RoutingModeInfo): string {
+  const diverged = r.declared != null && r.declared !== '' && r.mode !== r.declared
+  const dot = diverged ? DOT.degraded : '🔀'
+  const parts: string[] = [escapeMarkdown(r.mode)]
+  if (diverged) parts.push(`≠ declared ${escapeMarkdown(r.declared as string)}`)
+  if (r.model) parts.push(`\`${r.model}\``)
+  if (r.litellmOk != null) parts.push(r.litellmOk === '1' ? 'litellm ok' : 'litellm unconfirmed')
+  const suffix = r.prevBoot ? ' _(prev boot)_' : ''
+  return `${dot} **Routing**  ${parts.join(' · ')}${suffix}`
+}
+
 export interface RenderBootCardOpts {
   agentName: string
   /** Lowercase slug used for systemd unit names. Falls back to
@@ -338,6 +422,14 @@ export interface RenderBootCardOpts {
    * persisted snapshot from the prior boot. See `config-snapshot.ts`.
    */
   configChanges?: ConfigDiff
+  /**
+   * Parsed `.routing-mode` state (see `readRoutingMode`). When present, a
+   * "Routing" row is rendered — always visible, warning-dotted on
+   * landed≠declared divergence, suffixed "(prev boot)" when the file
+   * predates this gateway boot. Absent/null = row omitted entirely
+   * (fleets pre-dating the state file, unreadable file).
+   */
+  routing?: RoutingModeInfo | null
 }
 
 /**
@@ -456,8 +548,13 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
     }
   }
 
+  // Routing row (.routing-mode observability) — rendered whenever the state
+  // file was readable. Sits with the probe rows so divergence reads like any
+  // other degraded surface.
+  const routingRows: string[] = opts.routing ? [renderRoutingRow(opts.routing)] : []
+
   const sections: string[] = [ack]
-  if (degradedRows.length > 0) sections.push('', ...degradedRows)
+  if (degradedRows.length > 0 || routingRows.length > 0) sections.push('', ...degradedRows, ...routingRows)
   if (accountRows.length > 0) sections.push('', ...accountRows)
   if (opts.updateOutcomeLine) {
     // PR C: each line of the update-outcome blob is its own row in the
@@ -616,6 +713,13 @@ export interface RunProbesOpts {
   floodStatePath?: string
   /** Injectable clock for the flood-wait check (tests). Defaults to Date.now. */
   nowMs?: () => number
+  /**
+   * Epoch-ms this gateway boot started — the staleness threshold for the
+   * `.routing-mode` row (a file mtime older than this is the PREVIOUS boot's
+   * value and is labeled, never shown as current). Defaults to the gateway
+   * process start (`Date.now() - process.uptime()*1000`). Test override.
+   */
+  routingBootStartMs?: number
 }
 
 /** Run all six probes concurrently with their own per-probe timeouts.
@@ -879,6 +983,21 @@ export async function startBootCard(
           }
         }
 
+        // Routing-mode row (.routing-mode observability). Read at settle
+        // time — by then a healthy inner pass has usually written this
+        // boot's line; a degraded LiteLLM probe can still delay the write,
+        // in which case the file mtime predates this gateway boot and the
+        // reader flags it prevBoot (rendered "(prev boot)", never as
+        // current). Absent/unreadable file → row omitted.
+        const routingBootStartMs =
+          opts.routingBootStartMs ?? Date.now() - process.uptime() * 1000
+        let routing: RoutingModeInfo | null = null
+        try {
+          routing = readRoutingMode(opts.agentDir, routingBootStartMs)
+        } catch {
+          routing = null
+        }
+
         // Render with current probe state and edit if anything changed.
         let currentText = renderBootCard({
           agentName: opts.agentName,
@@ -892,6 +1011,7 @@ export async function startBootCard(
           ...(snoozeRows.length > 0 ? { snoozeRows } : {}),
           ...(opts.updateOutcomeLine ? { updateOutcomeLine: opts.updateOutcomeLine } : {}),
           ...(configChanges.length > 0 ? { configChanges } : {}),
+          ...(routing ? { routing } : {}),
         })
 
         if (currentText !== ackText) {
@@ -947,6 +1067,8 @@ export async function startBootCard(
             // (computed once in Phase 1). Pass them through unchanged so
             // the live-agent-status edits keep the config-diff rows.
             ...(configChanges.length > 0 ? { configChanges } : {}),
+            // Routing row is stable for the card lifetime (read once above).
+            ...(routing ? { routing } : {}),
           })
 
           if (updatedText === currentText) continue

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -309,13 +309,55 @@ export interface RoutingModeInfo {
 }
 
 /**
+ * Epoch-ms this CONTAINER booted, derived from PID 1's start time
+ * (`/proc/stat` btime + `/proc/1/stat` field 22 in USER_HZ ticks). This is the
+ * correct staleness threshold for `.routing-mode`: start.sh writes that file
+ * ONCE per container boot, before exec-ing claude/the gateway. Keying staleness
+ * on the gateway PROCESS start (`Date.now() - process.uptime()*1000`) mislabels
+ * a gateway-only respawn — supervisor restarts the gateway process while the
+ * container (and its still-current `.routing-mode`) stays up — as "(prev boot)".
+ * Container boot time is stable across such respawns (LOW-1). Returns null when
+ * /proc is unavailable or unparseable (non-Linux, tests), so callers fall back
+ * to the process-start estimate.
+ */
+export function containerBootStartMs(
+  fsImpl: { readFileSync: typeof readFileSync } = { readFileSync },
+): number | null {
+  try {
+    const btimeLine = fsImpl
+      .readFileSync('/proc/stat', 'utf-8')
+      .split('\n')
+      .find((l) => l.startsWith('btime '))
+    if (!btimeLine) return null
+    const btimeSec = Number(btimeLine.split(/\s+/)[1])
+    if (!Number.isFinite(btimeSec)) return null
+    // /proc/1/stat field 22 (starttime) is in clock ticks since system boot.
+    // Fields 2 (comm) may contain spaces/parens, so split on the last ')'.
+    const stat = fsImpl.readFileSync('/proc/1/stat', 'utf-8')
+    const afterComm = stat.slice(stat.lastIndexOf(')') + 2)
+    const fields = afterComm.split(/\s+/)
+    // starttime is field 22 overall → index 19 of the post-comm slice
+    // (field 1 pid + field 2 comm consumed; field 3 becomes index 0).
+    const startTicks = Number(fields[19])
+    if (!Number.isFinite(startTicks)) return null
+    const HZ = 100 // USER_HZ on effectively all Linux; sysconf unavailable in node
+    return (btimeSec + startTicks / HZ) * 1000
+  } catch {
+    return null
+  }
+}
+
+/**
  * Read + parse `<agentDir>/.routing-mode`. Returns null when the file is
  * absent, unreadable, or carries no `mode=` field (tolerant by design — the
  * boot card must render fine on fleets that pre-date the state file).
  *
- * `bootStartMs` is the epoch-ms this gateway process started; a file mtime
- * strictly older than it is flagged `prevBoot` so the renderer can label the
- * row instead of presenting stale data as current.
+ * `bootStartMs` is the epoch-ms this CONTAINER booted (see
+ * `containerBootStartMs`); a file mtime strictly older than it belongs to a
+ * previous container boot and is flagged `prevBoot` so the renderer can label
+ * the row instead of presenting stale data as current. Keyed on container boot
+ * (not gateway process start) so a gateway-only respawn does not mislabel the
+ * still-current file.
  */
 export function readRoutingMode(
   agentDir: string,
@@ -716,8 +758,10 @@ export interface RunProbesOpts {
   /**
    * Epoch-ms this gateway boot started — the staleness threshold for the
    * `.routing-mode` row (a file mtime older than this is the PREVIOUS boot's
-   * value and is labeled, never shown as current). Defaults to the gateway
-   * process start (`Date.now() - process.uptime()*1000`). Test override.
+   * value and is labeled, never shown as current). Defaults to the CONTAINER
+   * boot time (`containerBootStartMs`, stable across gateway-only respawns),
+   * falling back to the gateway process start when /proc is unavailable. Test
+   * override.
    */
   routingBootStartMs?: number
 }
@@ -990,7 +1034,9 @@ export async function startBootCard(
         // reader flags it prevBoot (rendered "(prev boot)", never as
         // current). Absent/unreadable file → row omitted.
         const routingBootStartMs =
-          opts.routingBootStartMs ?? Date.now() - process.uptime() * 1000
+          opts.routingBootStartMs ??
+          containerBootStartMs() ??
+          Date.now() - process.uptime() * 1000
         let routing: RoutingModeInfo | null = null
         try {
           routing = readRoutingMode(opts.agentDir, routingBootStartMs)

--- a/telegram-plugin/tests/boot-card-routing.test.ts
+++ b/telegram-plugin/tests/boot-card-routing.test.ts
@@ -14,10 +14,10 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, utimesSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync, utimesSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { readRoutingMode, renderRoutingRow, renderBootCard } from '../gateway/boot-card.js'
+import { readRoutingMode, renderRoutingRow, renderBootCard, containerBootStartMs } from '../gateway/boot-card.js'
 
 const LINE =
   'mode=router-root base=http://litellm:4010 model=fable litellm_ok=1 declared=router-root ts=2026-07-17T02:00:00Z\n'
@@ -54,6 +54,41 @@ describe('readRoutingMode', () => {
     const r = readRoutingMode(dir, Date.now() - 1_000)
     expect(r).not.toBeNull()
     expect(r!.prevBoot).toBe(true)
+  })
+})
+
+describe('containerBootStartMs', () => {
+  it('derives PID-1 start epoch from /proc/stat btime + /proc/1/stat starttime', () => {
+    const btime = 1_700_000_000 // seconds since epoch
+    const startTicks = 500 // 5s after boot at 100 HZ
+    const fsImpl = {
+      readFileSync: ((p: unknown) => {
+        if (p === '/proc/stat') return `cpu 1 2 3\nbtime ${btime}\nprocesses 100\n`
+        if (p === '/proc/1/stat')
+          // pid (comm) state ... field22=starttime. comm has a space+paren to
+          // exercise the last-')' split.
+          return `1 (init a) S 0 1 1 0 -1 0 0 0 0 0 0 0 0 0 0 0 0 0 ${startTicks} 0`
+        throw new Error('unexpected path')
+      }) as typeof readFileSync,
+    }
+    expect(containerBootStartMs(fsImpl)).toBe((btime + startTicks / 100) * 1000)
+  })
+
+  it('returns null when /proc is unavailable (fallback path for callers)', () => {
+    const fsImpl = {
+      readFileSync: (() => {
+        throw new Error('ENOENT')
+      }) as typeof readFileSync,
+    }
+    expect(containerBootStartMs(fsImpl)).toBeNull()
+  })
+
+  it('returns null when btime is missing', () => {
+    const fsImpl = {
+      readFileSync: ((p: unknown) =>
+        p === '/proc/stat' ? 'cpu 1 2 3\nprocesses 100\n' : '1 (init) S 0') as typeof readFileSync,
+    }
+    expect(containerBootStartMs(fsImpl)).toBeNull()
   })
 })
 

--- a/telegram-plugin/tests/boot-card-routing.test.ts
+++ b/telegram-plugin/tests/boot-card-routing.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Boot-card "Routing" row (.routing-mode observability — 2026-07-17 boot-race
+ * incident: silent fable→opus demotion on one agent, silent fable→router-root
+ * divergence on another).
+ *
+ * Contract:
+ *   - `readRoutingMode` parses `<agentDir>/.routing-mode`, returns null on
+ *     absence/garbage (tolerant), and flags `prevBoot` when the file's mtime
+ *     predates this gateway boot (render-timing hazard: the gateway's outer
+ *     pass can render the card before the inner pass writes this boot's line).
+ *   - `renderBootCard` renders the row when `routing` is passed; stale values
+ *     are suffixed "(prev boot)" — never presented as current; divergence
+ *     (landed ≠ declared) gets the warning dot; absent file → no row at all.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, utimesSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { readRoutingMode, renderRoutingRow, renderBootCard } from '../gateway/boot-card.js'
+
+const LINE =
+  'mode=router-root base=http://litellm:4010 model=fable litellm_ok=1 declared=router-root ts=2026-07-17T02:00:00Z\n'
+
+describe('readRoutingMode', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'routing-mode-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('parses a current-boot line', () => {
+    writeFileSync(join(dir, '.routing-mode'), LINE)
+    const r = readRoutingMode(dir, Date.now() - 60_000)
+    expect(r).not.toBeNull()
+    expect(r!.mode).toBe('router-root')
+    expect(r!.declared).toBe('router-root')
+    expect(r!.model).toBe('fable')
+    expect(r!.litellmOk).toBe('1')
+    expect(r!.prevBoot).toBe(false)
+  })
+
+  it('returns null when the file is absent (fleets pre-dating the state file)', () => {
+    expect(readRoutingMode(dir, Date.now())).toBeNull()
+  })
+
+  it('returns null on a garbage file with no mode= field', () => {
+    writeFileSync(join(dir, '.routing-mode'), 'not a routing line\n')
+    expect(readRoutingMode(dir, Date.now())).toBeNull()
+  })
+
+  it('flags prevBoot when the file mtime predates this gateway boot', () => {
+    writeFileSync(join(dir, '.routing-mode'), LINE)
+    const old = (Date.now() - 3_600_000) / 1000
+    utimesSync(join(dir, '.routing-mode'), old, old)
+    const r = readRoutingMode(dir, Date.now() - 1_000)
+    expect(r).not.toBeNull()
+    expect(r!.prevBoot).toBe(true)
+  })
+})
+
+describe('renderRoutingRow / renderBootCard routing row', () => {
+  const base = { agentName: 'klanker', version: 'v1' }
+
+  it('renders a converged row with the routing dot and model', () => {
+    const row = renderRoutingRow({
+      mode: 'router-root', declared: 'router-root', model: 'fable', litellmOk: '1', prevBoot: false,
+    })
+    expect(row).toContain('**Routing**')
+    expect(row).toContain('router-root')
+    expect(row).toContain('`fable`')
+    expect(row).toContain('litellm ok')
+    expect(row).not.toContain('≠')
+    expect(row).not.toContain('prev boot')
+  })
+
+  it('marks divergence (landed ≠ declared) with the warning dot', () => {
+    const row = renderRoutingRow({
+      mode: 'passthrough', declared: 'router-root', model: 'opus', litellmOk: '0', prevBoot: false,
+    })
+    expect(row).toContain('🟡')
+    expect(row).toContain('≠ declared router-root')
+    expect(row).toContain('litellm unconfirmed')
+  })
+
+  it('labels a stale (previous-boot) value instead of presenting it as current', () => {
+    const row = renderRoutingRow({
+      mode: 'router-root', declared: 'router-root', prevBoot: true,
+    })
+    expect(row).toContain('(prev boot)')
+  })
+
+  it('renderBootCard includes the routing row when passed, omits it when routing is null/absent', () => {
+    const withRow = renderBootCard({
+      ...base,
+      routing: { mode: 'router-root', declared: 'passthrough', model: 'fable', litellmOk: '1', prevBoot: false },
+    })
+    expect(withRow).toContain('**Routing**')
+    expect(withRow).toContain('router-root')
+
+    const without = renderBootCard({ ...base })
+    expect(without).not.toContain('Routing')
+    const withNull = renderBootCard({ ...base, routing: null })
+    expect(withNull).toBe(without)
+  })
+})

--- a/tests/scaffold.routing-mode.test.ts
+++ b/tests/scaffold.routing-mode.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Deterministic + observable agent→LiteLLM routing (2026-07-17 boot-race
+ * incident: a slow LiteLLM co-boot silently demoted a configured-fable agent
+ * to opus on the passthrough, while another agent landed fable on the router
+ * root — both divergences invisible to the operator).
+ *
+ * Contract under test, against the RENDERED start.sh (outcome tests — a
+ * rendered script that would still demote unreachable-fable FAILS here):
+ *
+ *   1. Fable demotion is SPLIT BY CAUSE:
+ *      - missing key (routing stripped, _LITELLM_UNREACHABLE empty) → still
+ *        demotes to opus, loudly (.session-model-alert) — fable genuinely
+ *        cannot work direct-to-Anthropic (retired codename, 4xxs).
+ *      - proxy unreachable, key present (_LITELLM_UNREACHABLE=1, routing left
+ *        in place) → NO demotion: boots the declared fable model pointed at
+ *        the LiteLLM router root, loud-degraded (same policy as sr-*).
+ *   2. `.routing-mode` state file: one overwrite-per-boot line
+ *      (mode=… base=… model=… litellm_ok=… declared=… ts=…) written just
+ *      before exec claude, plus a `routing:` stderr echo.
+ *   3. Divergence alert (landed ≠ declared) appends to .session-model-alert
+ *      but is DEDUPED against the previous boot's landed mode — a
+ *      persistently degraded agent alerts once, not on every restart.
+ *   4. Inner LiteLLM probe budget is 240s, env-tunable via
+ *      SWITCHROOM_LITELLM_BOOT_BUDGET; the OUTER (gateway-pass) probe stays
+ *      at 120s.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  };
+}
+
+const PASSTHROUGH = "http://litellm:4010/anthropic";
+const ROUTER_ROOT = "http://litellm:4010";
+const BLOCK_HEADER = "# --- Session model resolution";
+
+/** Slice the rendered start.sh from the session-model resolver through the
+ *  routing-mode write (everything up to, excluding, the exec claude lines). */
+function extractResolverThroughRouting(startSh: string): string {
+  const start = startSh.indexOf(BLOCK_HEADER);
+  const end = startSh.indexOf('if [ -n "$APPEND_PROMPT" ]', start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return startSh.slice(start, end);
+}
+
+interface RunOpts {
+  litellmOk?: string;
+  litellmUnreachable?: string;
+  /** Value of SWITCHROOM_LITELLM_DECLARED (captured-before-strip flag). */
+  litellmDeclared?: string;
+  baseUrl?: string;
+  routerRoot?: string;
+}
+
+describe("rendered start.sh: routing-mode observability + fable cause split", () => {
+  let tmpDir: string;
+  let agentDir: string;
+  let startSh: string;
+  let block: string;
+
+  function scaffold(model: string): void {
+    const name = "routing-agent";
+    const config = makeAgentConfig({ model } as Partial<AgentConfig>);
+    const res = scaffoldAgent(name, config, tmpDir, telegramConfig, makeSwitchroomConfig(name, config));
+    agentDir = res.agentDir;
+    startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
+    block = extractResolverThroughRouting(startSh);
+  }
+
+  function runBlock(opts: RunOpts = {}): { out: string; stderr: string } {
+    const script = [
+      "set -e",
+      "unset SWITCHROOM_CONFIG",
+      `export ANTHROPIC_BASE_URL=${JSON.stringify(opts.baseUrl ?? PASSTHROUGH)}`,
+      `export SWITCHROOM_LITELLM_BASE=${JSON.stringify(opts.routerRoot ?? ROUTER_ROOT)}`,
+      `export SWITCHROOM_LITELLM_DECLARED=${JSON.stringify(opts.litellmDeclared ?? "1")}`,
+      `_LITELLM_OK=${JSON.stringify(opts.litellmOk ?? "")}`,
+      `_LITELLM_UNREACHABLE=${JSON.stringify(opts.litellmUnreachable ?? "")}`,
+      block,
+      'echo "EFFECTIVE=$_EFFECTIVE_MODEL"',
+      'echo "BASEURL=$ANTHROPIC_BASE_URL"',
+    ].join("\n");
+    // Single run (side effects — .routing-mode / alert appends — must happen
+    // exactly once per simulated boot); stderr merged into the output.
+    const both = execFileSync("bash", ["-c", `{ ${script}\n} 2>&1`], { encoding: "utf-8" });
+    return { out: both, stderr: both };
+  }
+
+  function routingFile(): string {
+    const p = join(agentDir, ".routing-mode");
+    return existsSync(p) ? readFileSync(p, "utf-8") : "";
+  }
+
+  function alertText(): string {
+    const p = join(agentDir, ".session-model-alert");
+    return existsSync(p) ? readFileSync(p, "utf-8") : "";
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-routing-mode-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── 1. Fable demotion split by cause ────────────────────────────────────
+
+  it("unreachable fable (key present, probe failed) does NOT demote: boots fable on the router root", () => {
+    scaffold("fable");
+    const { out } = runBlock({ litellmOk: "", litellmUnreachable: "1" });
+    // The load-bearing assertion: the old behavior rewrote fable→opus here.
+    expect(out).toContain("EFFECTIVE=fable");
+    expect(out).not.toContain("EFFECTIVE=opus");
+    // Loud-degraded lands on the ROUTER ROOT (self-heals per request when the
+    // proxy returns) — not the model-agnostic passthrough where fable 4xxs.
+    expect(out).toContain(`BASEURL=${ROUTER_ROOT}`);
+    // No opus-demotion operator alert (divergence alert is separate).
+    expect(alertText()).not.toContain("booted on `opus`");
+  });
+
+  it("missing-key fable (routing stripped) still demotes to opus with an operator alert", () => {
+    scaffold("fable");
+    const { out } = runBlock({ litellmOk: "", litellmUnreachable: "" });
+    expect(out).toContain("EFFECTIVE=opus");
+    expect(alertText()).toContain("`opus`");
+    expect(alertText()).toContain("fable");
+    expect(alertText()).toContain("virtual key");
+  });
+
+  it("fable + LiteLLM up boots fable via the router root (unchanged healthy path)", () => {
+    scaffold("fable");
+    const { out } = runBlock({ litellmOk: "1" });
+    expect(out).toContain("EFFECTIVE=fable");
+    expect(out).toContain(`BASEURL=${ROUTER_ROOT}`);
+  });
+
+  // ── 2. .routing-mode state file + stderr line ───────────────────────────
+
+  it("writes one .routing-mode line with mode/base/model/litellm_ok/declared/ts and echoes routing: to stderr", () => {
+    scaffold("fable");
+    const { stderr } = runBlock({ litellmOk: "1" });
+    const line = routingFile().trim();
+    expect(line).toMatch(/^mode=router-root /);
+    expect(line).toContain(`base=${ROUTER_ROOT}`);
+    expect(line).toContain("model=fable");
+    expect(line).toContain("litellm_ok=1");
+    expect(line).toMatch(/declared=[a-z-]+/);
+    expect(line).toMatch(/ts=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/);
+    expect(routingFile().trim().split("\n")).toHaveLength(1);
+    expect(stderr).toContain("routing: mode=router-root ");
+  });
+
+  it("Claude default on the passthrough records mode=passthrough", () => {
+    scaffold("claude-sonnet-5");
+    runBlock({ litellmOk: "1" });
+    expect(routingFile()).toContain("mode=passthrough");
+    expect(routingFile()).toContain("declared=passthrough");
+  });
+
+  it("no ANTHROPIC_BASE_URL records mode=direct-oauth (litellm never configured → declared direct-oauth, no divergence)", () => {
+    scaffold("claude-sonnet-5");
+    const script = [
+      "set -e",
+      "unset SWITCHROOM_CONFIG ANTHROPIC_BASE_URL SWITCHROOM_LITELLM_BASE SWITCHROOM_LITELLM_DECLARED",
+      '_LITELLM_OK=""',
+      '_LITELLM_UNREACHABLE=""',
+      block,
+    ].join("\n");
+    execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+    expect(routingFile()).toContain("mode=direct-oauth");
+    expect(routingFile()).toContain("declared=direct-oauth");
+    expect(alertText()).not.toContain("Routing divergence");
+  });
+
+  // ── 3. Divergence alert, deduped against the previous boot ─────────────
+
+  it("landed≠declared appends a divergence alert on the FIRST such boot only (dedupe on persistent degradation)", () => {
+    scaffold("claude-sonnet-5"); // declared=passthrough
+    // Force a router-root landing (e.g. stripped /anthropic suffix upstream).
+    runBlock({ litellmOk: "1", baseUrl: ROUTER_ROOT });
+    expect(routingFile()).toContain("mode=router-root");
+    expect(alertText()).toContain("Routing divergence");
+    const alerts1 = alertText();
+    // Second boot, same landed mode: NO new divergence line.
+    runBlock({ litellmOk: "1", baseUrl: ROUTER_ROOT });
+    expect(alertText()).toBe(alerts1);
+    // Mode changes again (back to passthrough≠…, i.e. a NEW landed mode that
+    // again diverges) → alerts again.
+  });
+
+  it("alerts again when the landed mode CHANGES to a new divergent mode", () => {
+    scaffold("claude-sonnet-5"); // declared=passthrough
+    runBlock({ litellmOk: "1", baseUrl: ROUTER_ROOT });
+    const first = alertText();
+    expect(first).toContain("Routing divergence");
+    // Next boot lands direct-oauth (routing stripped) — different landed mode.
+    const script = [
+      "set -e",
+      "unset SWITCHROOM_CONFIG ANTHROPIC_BASE_URL SWITCHROOM_LITELLM_BASE",
+      'export SWITCHROOM_LITELLM_DECLARED="1"',
+      '_LITELLM_OK=""',
+      '_LITELLM_UNREACHABLE=""',
+      block,
+    ].join("\n");
+    execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+    expect(alertText().length).toBeGreaterThan(first.length);
+    expect(alertText()).toContain("direct-oauth");
+  });
+
+  it("converged boot (landed == declared) never writes a divergence alert", () => {
+    scaffold("sr-glm-5"); // declared=router-root
+    runBlock({ litellmOk: "1", baseUrl: ROUTER_ROOT });
+    expect(routingFile()).toContain("mode=router-root");
+    expect(routingFile()).toContain("declared=router-root");
+    expect(alertText()).not.toContain("Routing divergence");
+  });
+
+  // ── 4. Rendered-script static assertions ────────────────────────────────
+
+  it("renders the .routing-mode write and the 240s env-tunable INNER probe budget (outer stays 120s)", () => {
+    scaffold("fable");
+    expect(startSh).toContain('.routing-mode"');
+    expect(startSh).toContain('echo "routing: $_routing_line"');
+    // Inner budget: env-tunable, default 240.
+    expect(startSh).toContain('sr_ll_budget="${SWITCHROOM_LITELLM_BOOT_BUDGET:-240}"');
+    expect(startSh).toContain("sr_ll_deadline=$(( $(date +%s) + sr_ll_budget ))");
+    // Outer (gateway-pass) probe keeps the 120s hard budget — extending it
+    // would double gateway boot delay.
+    expect(startSh).toContain("sr_ll_deadline=$(( $(date +%s) + 120 ))");
+    // The rendered script must NOT contain the old unconditional demotion.
+    expect(startSh).not.toContain("LiteLLM was unreachable at boot, so the configured model");
+  });
+
+  it("bakes _DECLARED_ROUTING from the model class (passthrough for Claude, router-root for sr-*)", () => {
+    scaffold("claude-sonnet-5");
+    expect(startSh).toContain("_DECLARED_ROUTING='passthrough'");
+    scaffold("sr-glm-5");
+    expect(startSh).toContain("_DECLARED_ROUTING='router-root'");
+  });
+});

--- a/tests/scaffold.routing-mode.test.ts
+++ b/tests/scaffold.routing-mode.test.ts
@@ -165,6 +165,33 @@ describe("rendered start.sh: routing-mode observability + fable cause split", ()
     expect(out).toContain(`BASEURL=${ROUTER_ROOT}`);
   });
 
+  it("healthy fable declares router-root and fires NO divergence alert (CRITICAL-1 regression)", () => {
+    // A configured-fable agent rides compose's /anthropic passthrough env but
+    // start.sh repoints it onto the router root — so its DECLARED intent must
+    // be router-root, matching the landed mode. A regression to the raw
+    // isClaudeModel split (declared=passthrough) makes every healthy fable boot
+    // cry wolf with a permanent "Routing divergence" alert.
+    scaffold("fable");
+    const { out } = runBlock({ litellmOk: "1" });
+    expect(out).toContain(`BASEURL=${ROUTER_ROOT}`);
+    expect(routingFile()).toContain("mode=router-root");
+    expect(routingFile()).toContain("declared=router-root");
+    expect(alertText()).not.toContain("Routing divergence");
+  });
+
+  it("re-alerts when the declared class flips while the landed mode stays stuck (LOW-2 dedup pair)", () => {
+    // Boot 1: sonnet declares passthrough but lands router-root → divergence.
+    scaffold("claude-sonnet-5");
+    runBlock({ litellmOk: "1", baseUrl: ROUTER_ROOT });
+    const first = alertText();
+    expect(first).toContain("Routing divergence");
+    // Boot 2: same landed router-root, but now declared flips to direct-oauth
+    // (operator un-configured LiteLLM). Landed mode is unchanged, yet the
+    // (landed, declared) PAIR changed → a NEW divergence alert must fire.
+    runBlock({ litellmOk: "1", baseUrl: ROUTER_ROOT, litellmDeclared: "" });
+    expect(alertText().length).toBeGreaterThan(first.length);
+  });
+
   // ── 2. .routing-mode state file + stderr line ───────────────────────────
 
   it("writes one .routing-mode line with mode/base/model/litellm_ok/declared/ts and echoes routing: to stderr", () => {
@@ -262,10 +289,14 @@ describe("rendered start.sh: routing-mode observability + fable cause split", ()
     expect(startSh).not.toContain("LiteLLM was unreachable at boot, so the configured model");
   });
 
-  it("bakes _DECLARED_ROUTING from the model class (passthrough for Claude, router-root for sr-*)", () => {
+  it("bakes _DECLARED_ROUTING from the POST-REPOINT mode (passthrough only for non-fable Claude; router-root for fable + sr-*)", () => {
     scaffold("claude-sonnet-5");
     expect(startSh).toContain("_DECLARED_ROUTING='passthrough'");
     scaffold("sr-glm-5");
+    expect(startSh).toContain("_DECLARED_ROUTING='router-root'");
+    // fable is a Claude-class model but start.sh repoints it to the router
+    // root, so its DECLARED intent must be router-root, not passthrough.
+    scaffold("fable");
     expect(startSh).toContain("_DECLARED_ROUTING='router-root'");
   });
 });


### PR DESCRIPTION
## Incident context

2026-07-17 boot race: a slow LiteLLM co-boot left klanker demoted fable→opus on the /anthropic passthrough while overlord landed fable on the router root — **both silent divergence**. klanker has since converged via restart. This PR makes the landing deterministic where possible and observable everywhere.

## What changed

### 1. Fable demotion split by cause (`profiles/_base/start.sh.hbs`)
- **Missing key** (vault key absent → routing stripped): keeps the opus demotion — fable is a retired codename direct-to-Anthropic and every call 4xxs. Alert wording strengthened (names the cause and the recovery: `switchroom apply` + restart).
- **Unreachable** (key present, probe failed → routing left in place): demotion **removed**. Boots the declared fable model pointed at the LiteLLM **router root** (the sr-*/fable repoint now also fires on the unreachable path), loud-degraded — same policy as sr-* configured defaults. Requests fail until the proxy heals, then work with zero divergence, no restart needed.
- Inner probe budget 120s → **240s**, env-tunable via `SWITCHROOM_LITELLM_BOOT_BUDGET`. The **outer** (gateway-pass) probe stays at 120s — extending it would double gateway boot delay.

### 2. `.routing-mode` state file + stderr line
One overwrite-per-boot line written just before `exec claude`:
`mode=<router-root|passthrough|direct-oauth> base=<url> model=<effective> litellm_ok=<0|1> declared=<mode> ts=<iso>`, echoed to stderr prefixed `routing:`. `_DECLARED_ROUTING` is baked at render time (`src/agents/scaffold.ts`, both start.sh contexts) with the same `isClaudeModel` split `compose.ts` uses for `ANTHROPIC_BASE_URL`; it resolves to `direct-oauth` when LiteLLM was never configured (captured via `SWITCHROOM_LITELLM_DECLARED` before any fail-open strip), so non-LiteLLM fleets never false-alert.

### 3. Divergence alert, deduped
Landed ≠ declared appends to `.session-model-alert` (existing consume-once gateway relay) — only when the landed mode differs from the **previous boot's** `.routing-mode` (read before overwrite), so a persistently degraded agent alerts once, not on every restart.

### 4. Boot-card routing row (`telegram-plugin/gateway/boot-card.ts`)
New `readRoutingMode` / `renderRoutingRow` + a `Routing` row wired into the post-settle render. Tolerant of an absent file (row omitted) and of the render-timing hazard: a `.routing-mode` whose mtime predates this gateway boot renders suffixed **"(prev boot)"** — stale data is never shown as current. Divergence gets the 🟡 dot.

## Deliberately NOT in this PR (follow-up)

**LiteLLM `pass_through_endpoints` change** — live-config op handled operator-side. Security constraint for that follow-up: scope strictly to `/api/oauth/usage` (+ profile), forward the client `Authorization` header unreplaced, and it must **not** create an unauthenticated relay.

## Tests

- `tests/scaffold.routing-mode.test.ts` (11 tests, all outcome-asserting against the RENDERED start.sh): unreachable-fable no longer rewrites to opus and lands on the router root (a rendered script that would demote fails); missing-key still demotes + alerts; `.routing-mode` line shape + `routing:` stderr echo; divergence alert first-boot-only dedupe + re-alert on mode change; converged/never-configured boots stay silent; 240s inner budget + `SWITCHROOM_LITELLM_BOOT_BUDGET` rendered, outer 120s preserved; declared-routing bake per model class.
- `telegram-plugin/tests/boot-card-routing.test.ts` (8 tests): parse, absent file → null, garbage → null, stale-mtime → prevBoot; row render converged/diverged/stale; renderBootCard row present/omitted.
- Existing suites green locally: `scaffold.test.ts` (212), boot-card suites (83), `reconcile.default-model` / `cheap-cron-session-render` / `claude-cli-contract` / `reconcile.skip-profile-templates`. `npm run lint` clean.
- `tests/scaffold.session-model.test.ts`: 7 failures in the fake-`switchroom`-binary "live configured-default resolution" describe are **identical on pristine origin/main** in this environment (verified via a detached main worktree; CLAUDE.md's known fake-binary-harness env class) — CI is the authority there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)