### PR TITLE
refactor(gateway): make gateway.ts import-clean — defer last module-load side effects (#2996 P0e)

### DIFF
--- a/telegram-plugin/gateway/gateway-import-clean.test.ts
+++ b/telegram-plugin/gateway/gateway-import-clean.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+/**
+ * #2996 P0e — gateway.ts import-cleanliness.
+ *
+ * Prior phases (P0a/P0b/P0c) could only pin import-cleanliness with AST/source
+ * checks because importing gateway.ts under vitest was *impossible*: the
+ * module-scope `createIpcServer(...)` calls `Bun.listen` at construction, and
+ * `Bun` is undefined under Node/vitest, so a bare `import('./gateway.js')`
+ * threw `ReferenceError: Bun is not defined` before any assertion could run.
+ *
+ * P0e removes the last import-time side effects. This test therefore uses the
+ * thing prior phases could not: an ACTUAL runtime import of gateway.ts as the
+ * oracle for the import-clean half, and deterministic source-pins for the
+ * boot-fires-under-`isGatewayMain` half (which cannot be runtime-exercised
+ * under vitest — the prod boot path needs Bun, a real Bot token, and the
+ * vault, none of which exist here).
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_SRC = readFileSync(join(here, 'gateway.ts'), 'utf8')
+
+// The process-signal / lifecycle events gateway.ts wires on the prod boot path.
+// Under a vitest import (isGatewayMain === false) it must register NONE of them.
+const GATEWAY_SIGNALS = ['SIGTERM', 'SIGINT', 'beforeExit'] as const
+
+function signalListenerCounts(): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const sig of GATEWAY_SIGNALS) out[sig] = process.listenerCount(sig)
+  return out
+}
+
+describe('gateway.ts import-cleanliness (#2996 P0e)', () => {
+  it('runtime-imports with zero side effects: resolves, no process.exit, no gateway signal handlers', async () => {
+    const before = signalListenerCounts()
+
+    // Any reachable process.exit during import is a hard failure ("no exit
+    // reachable on import"). Throw instead of exiting so the harness survives
+    // and the assertion is legible.
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit(${code}) was reached during import()`)
+      }) as never)
+
+    // Positive oracle that no UDS server is bound at import: if the gate
+    // regressed and `createIpcServer` ran, it would call this Bun.listen fake.
+    // With the gate intact it is never invoked. (Also proves the import no
+    // longer depends on a real Bun global — it resolves whether or not one
+    // exists.)
+    const listenSpy = vi.fn(() => {
+      throw new Error('Bun.listen was called during import() — an IPC server was bound')
+    })
+    const priorBun = (globalThis as { Bun?: unknown }).Bun
+    ;(globalThis as { Bun?: unknown }).Bun = { listen: listenSpy }
+
+    let mod: Record<string, unknown>
+    try {
+      mod = (await import('./gateway.js')) as Record<string, unknown>
+    } finally {
+      if (priorBun === undefined) delete (globalThis as { Bun?: unknown }).Bun
+      else (globalThis as { Bun?: unknown }).Bun = priorBun
+      exitSpy.mockRestore()
+    }
+
+    // Import resolved (did not throw). Under P0c-and-earlier this line was
+    // unreachable — the import rejected with `Bun is not defined`.
+    expect(mod).toBeTruthy()
+
+    // No IPC server bound.
+    expect(listenSpy).not.toHaveBeenCalled()
+
+    // No exit reachable on import.
+    expect(exitSpy).not.toHaveBeenCalled()
+
+    // No gateway-owned SIGTERM / SIGINT / beforeExit handlers registered.
+    // (vitest owns a baseline uncaughtException/unhandledRejection listener of
+    // its own, so those two are asserted via the delta only.)
+    const after = signalListenerCounts()
+    for (const sig of GATEWAY_SIGNALS) {
+      expect(after[sig] - before[sig], `${sig} listeners added by import`).toBe(0)
+    }
+  }, 60_000)
+
+  it('does not add uncaughtException / unhandledRejection handlers on import', async () => {
+    // Distinct from the signal test: gateway.ts registers TWO families of these
+    // (installGlobalErrorHandlers @ ~910 and its own shutdown-routing handlers
+    // @ ~29926/29935). Both call process.exit, both are gated on P0e. Assert the
+    // delta the import contributed is zero (vitest's own baseline is subtracted).
+    const before = {
+      uncaughtException: process.listenerCount('uncaughtException'),
+      unhandledRejection: process.listenerCount('unhandledRejection'),
+    }
+    const mod = await import('./gateway.js')
+    expect(mod).toBeTruthy()
+    const after = {
+      uncaughtException: process.listenerCount('uncaughtException'),
+      unhandledRejection: process.listenerCount('unhandledRejection'),
+    }
+    expect(after.uncaughtException - before.uncaughtException).toBe(0)
+    expect(after.unhandledRejection - before.unhandledRejection).toBe(0)
+  }, 60_000)
+
+  describe('boot wiring is gated on isGatewayMain (source pins — the prod path still fires)', () => {
+    // These pin, deterministically, that each side-effecting construct remains
+    // (a) gated so the import stays clean, and (b) present so the prod boot path
+    // (isGatewayMain === true) still constructs it. They guard against a future
+    // edit silently ungating one of them (re-inflating the import surface) OR
+    // deleting the construction (breaking boot).
+
+    it('IPC server construction is deferred behind isGatewayMain', () => {
+      expect(GATEWAY_SRC).toMatch(/let ipcServer!: IpcServer/)
+      expect(GATEWAY_SRC).toMatch(/if \(isGatewayMain\) ipcServer = createIpcServer\(\{/)
+      // No ungated `const ipcServer = createIpcServer` remains.
+      expect(GATEWAY_SRC).not.toMatch(/const ipcServer[^\n]*= createIpcServer/)
+    })
+
+    it('inbound spool construction is deferred behind isGatewayMain', () => {
+      expect(GATEWAY_SRC).toMatch(
+        /let inboundSpool: ReturnType<typeof createInboundSpool> \| undefined/,
+      )
+      expect(GATEWAY_SRC).toMatch(/if \(isGatewayMain\) inboundSpool = STATIC/)
+      expect(GATEWAY_SRC).not.toMatch(/const inboundSpool = STATIC/)
+    })
+
+    it('global error handlers + beforeExit are gated on isGatewayMain', () => {
+      // installPosthogErrorHandlers must not sit ungated at module scope.
+      expect(GATEWAY_SRC).not.toMatch(/^installPosthogErrorHandlers\(\)/m)
+      expect(GATEWAY_SRC).toMatch(
+        /if \(isGatewayMain\) \{\n {2}installPosthogErrorHandlers\(\)/,
+      )
+    })
+
+    it('signal + crash handlers are gated on isGatewayMain', () => {
+      // No ungated (column-0) process.on wiring survives.
+      expect(GATEWAY_SRC).not.toMatch(/^process\.on\('SIGTERM'/m)
+      expect(GATEWAY_SRC).not.toMatch(/^process\.on\('SIGINT'/m)
+      expect(GATEWAY_SRC).not.toMatch(/^process\.on\('unhandledRejection'/m)
+      expect(GATEWAY_SRC).not.toMatch(/^process\.on\('uncaughtException'/m)
+      // The gateway's beforeExit analytics flush is likewise not at column 0.
+      expect(GATEWAY_SRC).not.toMatch(/^process\.on\('beforeExit'/m)
+    })
+
+    it('startup reaction sweep (module-load IO) is gated on isGatewayMain', () => {
+      expect(GATEWAY_SRC).toMatch(
+        /if \(isGatewayMain\) \{\n {2}const startupAgentDir = resolveAgentDirFromEnv\(\)/,
+      )
+    })
+
+    it('preserves prod construction order: inboundSpool before pendingInboundBuffer before ipcServer', () => {
+      const iSpool = GATEWAY_SRC.indexOf('if (isGatewayMain) inboundSpool = STATIC')
+      const iPending = GATEWAY_SRC.indexOf('const pendingInboundBuffer = createPendingInboundBuffer(')
+      const iIpc = GATEWAY_SRC.indexOf('if (isGatewayMain) ipcServer = createIpcServer({')
+      expect(iSpool).toBeGreaterThan(0)
+      expect(iPending).toBeGreaterThan(0)
+      expect(iIpc).toBeGreaterThan(0)
+      expect(iSpool).toBeLessThan(iPending)
+      expect(iPending).toBeLessThan(iIpc)
+    })
+
+    it('startGateway() remains the single guarded boot invocation', () => {
+      expect(GATEWAY_SRC).toMatch(/if \(isGatewayMain\) void startGateway\(\)/)
+    })
+  })
+})

--- a/telegram-plugin/gateway/gateway-import-clean.test.ts
+++ b/telegram-plugin/gateway/gateway-import-clean.test.ts
@@ -51,18 +51,35 @@ describe('gateway.ts import-cleanliness (#2996 P0e)', () => {
     // With the gate intact it is never invoked. (Also proves the import no
     // longer depends on a real Bun global — it resolves whether or not one
     // exists.)
+    //
+    // Dual-runner note: this file runs under BOTH vitest (Node) and `bun test`
+    // (the plugin bun suite globs every *.test.ts). Under Node `globalThis.Bun`
+    // is undefined and the fake installs cleanly — that run holds the no-bind
+    // oracle. Under the Bun runtime the `Bun` global is READONLY (assignment
+    // throws "Attempted to assign to readonly property"), so the swap is
+    // best-effort there; the bind oracle is then carried by the vitest run and
+    // the source pins below, while the remaining outcome assertions (resolve /
+    // no exit / no listeners) still run in both runtimes.
     const listenSpy = vi.fn(() => {
       throw new Error('Bun.listen was called during import() — an IPC server was bound')
     })
     const priorBun = (globalThis as { Bun?: unknown }).Bun
-    ;(globalThis as { Bun?: unknown }).Bun = { listen: listenSpy }
+    let bunSwapped = false
+    try {
+      ;(globalThis as { Bun?: unknown }).Bun = { listen: listenSpy }
+      bunSwapped = true
+    } catch {
+      // Bun runtime — readonly global; see dual-runner note above.
+    }
 
     let mod: Record<string, unknown>
     try {
       mod = (await import('./gateway.js')) as Record<string, unknown>
     } finally {
-      if (priorBun === undefined) delete (globalThis as { Bun?: unknown }).Bun
-      else (globalThis as { Bun?: unknown }).Bun = priorBun
+      if (bunSwapped) {
+        if (priorBun === undefined) delete (globalThis as { Bun?: unknown }).Bun
+        else (globalThis as { Bun?: unknown }).Bun = priorBun
+      }
       exitSpy.mockRestore()
     }
 
@@ -70,7 +87,8 @@ describe('gateway.ts import-cleanliness (#2996 P0e)', () => {
     // unreachable — the import rejected with `Bun is not defined`.
     expect(mod).toBeTruthy()
 
-    // No IPC server bound.
+    // No IPC server bound (Node run; under Bun the swap is best-effort and the
+    // spy simply stays uninstalled + uncalled).
     expect(listenSpy).not.toHaveBeenCalled()
 
     // No exit reachable on import.
@@ -81,7 +99,9 @@ describe('gateway.ts import-cleanliness (#2996 P0e)', () => {
     // its own, so those two are asserted via the delta only.)
     const after = signalListenerCounts()
     for (const sig of GATEWAY_SIGNALS) {
-      expect(after[sig] - before[sig], `${sig} listeners added by import`).toBe(0)
+      // Runner-agnostic single-arg expect (bun's expect has no message arg):
+      // encode the signal name in the compared value so a failure is legible.
+      expect(`${sig}:+${after[sig] - before[sig]}`).toBe(`${sig}:+0`)
     }
   }, 60_000)
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -907,14 +907,22 @@ installPluginLogger()
 // PostHog Error Tracking before the process dies. Mirrors the CLI's
 // install (src/cli/index.ts), so gateway + CLI errors land in the same
 // dashboard tagged `source: 'gateway'` vs `source: 'cli'`.
-installPosthogErrorHandlers()
-// Flush analytics on graceful shutdown so the last batch isn't lost.
-// The signal handlers themselves remain owned by other modules — we
-// piggyback by emitting a `beforeExit` listener which fires after
-// SIGTERM/SIGINT have run their handlers and the event loop is empty.
-process.on('beforeExit', () => {
-  void shutdownAnalytics()
-})
+// #2996 P0e: global error handlers + the analytics-flush `beforeExit` listener
+// are boot process-wiring, not import-time state. installGlobalErrorHandlers
+// registers an `uncaughtException` handler that calls `process.exit(1)`, so
+// leaving it ungated would make exit reachable from a bare `import(gateway.ts)`.
+// Gate on isGatewayMain: registered verbatim (same order, same position) on the
+// prod boot path; a no-op under a vitest import.
+if (isGatewayMain) {
+  installPosthogErrorHandlers()
+  // Flush analytics on graceful shutdown so the last batch isn't lost.
+  // The signal handlers themselves remain owned by other modules — we
+  // piggyback by emitting a `beforeExit` listener which fires after
+  // SIGTERM/SIGINT have run their handlers and the event loop is empty.
+  process.on('beforeExit', () => {
+    void shutdownAnalytics()
+  })
+}
 
 // ─── Env + state dir ──────────────────────────────────────────────────────
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
@@ -10407,7 +10415,13 @@ if (isGatewayMain) pendingProgress.startTimer({
 // processed when it reconnects" promise deterministic across a
 // gateway/container restart (finn/carrie lost-on-restart incident,
 // 2026-05-19). STATIC mode has no runtime/bridge, so no spool.
-const inboundSpool = STATIC
+// #2996 P0e: createInboundSpool hydrates its in-memory projection from the
+// on-disk spool at construction (readFileSync) — a module-load disk read.
+// Defer past import; still constructs at the identical boot point in prod
+// (isGatewayMain true). Under an import()/vitest load it stays undefined, which
+// is exactly the STATIC-mode shape every reader already guards for (`!= null`).
+let inboundSpool: ReturnType<typeof createInboundSpool> | undefined
+if (isGatewayMain) inboundSpool = STATIC
   ? undefined
   : createInboundSpool({
       path: join(STATE_DIR, 'inbound-spool.jsonl'),
@@ -11351,7 +11365,15 @@ if (isGatewayMain && BRIDGE_DEAD_ESCALATION_ENABLED) {
   )
 }
 
-const ipcServer: IpcServer = createIpcServer({
+// #2996 P0e: constructing the IPC server renames/unlinks the socket file and
+// binds a UDS listener (`Bun.listen`) at call time — a hard module-load side
+// effect (and the reason `import(gateway.ts)` threw `Bun is not defined` under
+// vitest). Defer construction past import; it still constructs at the identical
+// boot point in prod, where `isGatewayMain` is true. Definite-assignment `!`:
+// every reader runs only after boot (in a handler / timer / startGateway), so
+// the binding is always populated before first read on the prod path.
+let ipcServer!: IpcServer
+if (isGatewayMain) ipcServer = createIpcServer({
   socketPath: SOCKET_PATH,
 
   onClientRegistered(client: IpcClient) {
@@ -29843,11 +29865,17 @@ async function shutdown(signal: string): Promise<void> {
 
   process.exit(0)
 }
-process.on('SIGTERM', () => void shutdown('SIGTERM'))
-process.on('SIGINT', () => void shutdown('SIGINT'))
+// #2996 P0e: signal handlers route through shutdown() → process.exit; gate on
+// isGatewayMain so a bare import doesn't register exit-reachable handlers.
+if (isGatewayMain) {
+  process.on('SIGTERM', () => void shutdown('SIGTERM'))
+  process.on('SIGINT', () => void shutdown('SIGINT'))
+}
 
 // ─── Stale reaction sweep (gateway crash recovery) ────────────────────────
-{
+// #2996 P0e: the boot-time sweep reads the agent dir and sends reactions —
+// module-load IO. Gate on isGatewayMain (runs verbatim on the prod boot path).
+if (isGatewayMain) {
   const startupAgentDir = resolveAgentDirFromEnv()
   if (startupAgentDir != null) {
     void sweepActiveReactions(
@@ -29895,19 +29923,23 @@ process.on('SIGINT', () => void shutdown('SIGINT'))
 // found") are logged but NOT crashed-on. These leaked through restart loops
 // for klanker (#99) and lawgpt's mid-day crash family — see the unit tests
 // in `tests/unhandled-rejection-policy.test.ts`.
-process.on('unhandledRejection', err => {
-  const action = classifyRejection(err)
-  process.stderr.write(
-    `telegram gateway: unhandled rejection (${action}): ${err}\n`,
-  )
-  if (action === 'shutdown') {
-    void shutdown('unhandledRejection')
-  }
-})
-process.on('uncaughtException', err => {
-  process.stderr.write(`telegram gateway: uncaught exception: ${err}\n`)
-  void shutdown('uncaughtException')
-})
+// #2996 P0e: these route through shutdown() → process.exit; gate on
+// isGatewayMain so importing the module registers no exit-reachable handlers.
+if (isGatewayMain) {
+  process.on('unhandledRejection', err => {
+    const action = classifyRejection(err)
+    process.stderr.write(
+      `telegram gateway: unhandled rejection (${action}): ${err}\n`,
+    )
+    if (action === 'shutdown') {
+      void shutdown('unhandledRejection')
+    }
+  })
+  process.on('uncaughtException', err => {
+    process.stderr.write(`telegram gateway: uncaught exception: ${err}\n`)
+    void shutdown('uncaughtException')
+  })
+}
 
 let runnerHandle: RunnerHandle | null = null
 


### PR DESCRIPTION
## Summary

Makes `telegram-plugin/gateway/gateway.ts` genuinely importable under vitest. Before this PR, `import('./gateway.js')` threw `ReferenceError: Bun is not defined` — `createIpcServer(...)` binds a UDS listener (`Bun.listen`) at module-scope construction, so the module could not be runtime-imported at all. This blocked the P2 `executeReply` golden harness (per PLAN Amendment 9).

Every remaining import-time side effect is now gated on `isGatewayMain` **in place**, so a bare `import()` fires nothing while the prod entrypoint (`bun dist/gateway/gateway.js`, where `isGatewayMain` is true) constructs everything in byte-identical order.

## Why

#3010's merge note named import-cleanliness as the blocker to an end-to-end `executeReply`/`handleSessionEvent`/`handleInbound` harness. P0a/P0b/P0c deferred handler registration, bot construction, and the boot IIFE — but the three const-factories plus several process handlers still fired at import. This is the P0e step that finishes the seam.

## Frozen import-time side-effect inventory (live @ pre-change `98f52675`, 31905 lines)

| Site | Line (pre) | Side effect at construction/module-eval | Disposition |
|---|---|---|---|
| `ipcServer = createIpcServer({...})` | 11354 | `renameSync`/`unlinkSync` socket file, `Bun.listen` UDS bind, heartbeat `setInterval` | **gated** on `isGatewayMain` (`let ipcServer!: IpcServer`) — the actual `Bun is not defined` blocker |
| `inboundSpool = STATIC ? … : createInboundSpool({...})` | 10410 | `readFileSync` hydrate of the on-disk spool | **gated**; stays `undefined` under import (identical to STATIC-mode, which readers already guard for) |
| `installGlobalErrorHandlers()` + `process.on('beforeExit')` | 910 / 915 | registers an `uncaughtException` handler that calls `process.exit(1)` | **gated** (made "exit reachable on import") |
| `process.on('SIGTERM')` / `process.on('SIGINT')` | 29846 / 29847 | route through `shutdown()` → `process.exit(0)` | **gated** |
| startup stale-reaction sweep `{ … sweepActiveReactions … }` | 29849–29859 | reads agent dir + sends Telegram reactions (IO) | **gated** |
| `process.on('unhandledRejection')` / `process.on('uncaughtException')` | 29898 / 29907 | route through `shutdown()` → `process.exit` | **gated** |
| `pendingInboundBuffer = createPendingInboundBuffer({...})` | 10443 | none — pure (Map + captured refs; `onEvict`/`bot` are lazy) | **left eager** (stays a real instance; side-effect-free) |
| `pollHealthCheck` / all timers / registration block / boot IIFE | — | — | already gated by P0a–P0c; unchanged |

Everything gated stays at the same file position, so prod module-eval order is unchanged (in prod `isGatewayMain` is always true → the `if` is a pass-through). No reader is reordered relative to first use.

## Contradiction with the brief's premise (reported, not force-fit)

The task brief stated P0a/P0b/P0c already put "the boot IIFE **+ process wiring**" behind `isGatewayMain`/`startGateway()`. Live source at `98f52675` contradicts that: `installGlobalErrorHandlers()` (`gateway.ts:910`), `beforeExit` (`:915`), `SIGTERM`/`SIGINT` (`:29846-47`), the reaction sweep (`:29849`), and `unhandledRejection`/`uncaughtException` (`:29898/:29907`) were all **ungated at column 0**. Because `installGlobalErrorHandlers` registers `uncaughtException → process.exit(1)`, the brief's own test assertion ("no exit reachable on import") cannot hold unless these are gated too. I therefore expanded P0e from the literal three const-factories to **all** remaining import-time side effects — one coherent concern (import-cleanliness). PLAN Amendment 4 independently lists these (`beforeExit @915`, the process handlers, the startup reaction sweep) as part of the P0 inventory, so this is the intended scope.

## Reference-semantics note (for the P2 harness)

`ipcServer` uses a definite-assignment `let ipcServer!: IpcServer`, so under a vitest import it is runtime-`undefined` while typed non-null. No reader runs at import (proven by the runtime oracle below), and on the prod path it is always assigned before first read. A future P2/harness path that reads `ipcServer`/`inboundSpool` off the non-main path must inject them — noted for the harness author; no prod reader breaks.

## Test plan

New `telegram-plugin/gateway/gateway-import-clean.test.ts` (9 tests, vitest):

- **Runtime oracle** — actually `import('./gateway.js')` and assert: it resolves (previously threw), a `Bun.listen` spy is never called (no UDS bind), a `process.exit` spy is never reached, and the import registers **zero** gateway-owned `SIGTERM`/`SIGINT`/`beforeExit` (and delta-zero `uncaughtException`/`unhandledRejection`) handlers. This is the capability prior phases lacked — runtime import was impossible, so they could only AST-pin.
- **Source pins** for the boot-fires-under-`isGatewayMain` half (construction present + gated + prod order `inboundSpool` → `pendingInboundBuffer` → `ipcServer`, and `startGateway()` still the single guarded boot invocation). Full boot can't run under vitest (needs Bun + a real Bot token + the vault), so these deterministically guard the prod path against a future ungating/deletion regression.

Local: `npm run lint` clean (tsc + all 10 guards, incl. `check-bot-api-wrapping` — gateway.ts uses drift-proof inline markers, no line-range allowlist entries, no edit needed — and `check-gateway-line-ratchet`: 31937 ≤ 31905 + 50 slack, ratchet unchanged). `gateway-import-clean.test.ts` + `tests/check-gateway-line-ratchet.test.ts` green (23 tests).

## Risk

Pure init reorder, zero prod behavior change (gates are pass-throughs when `isGatewayMain`). Line delta 31905 → 31937 (+32), within the P0.5 ratchet slack.

Job spec: inbound-delivery reliability — this unblocks the P2 send-path golden harness (`reference/jobs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)