### PR TITLE
fix(subagent-watcher): re-register resumed sub-agents so progress cards resume (#3315)

### DIFF
--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -855,13 +855,14 @@ const BACKFILL_RETRY_INTERVAL_MS = 3000
 
 /**
  * Fix #9a: cap on `terminatedAgentIds` (the re-discovery dedup guard in
- * `cleanupTerminalAgent` / `scanSubagentsDir`). Pre-fix the Set only grew
+ * `cleanupTerminalAgent` / `scanSubagentsDir`). Pre-fix the map only grew
  * (added on every terminal cleanup, only ever cleared wholesale in
  * `stop()`), so a long-lived gateway with sustained sub-agent throughput
- * accumulated ids without bound. A `Set` preserves insertion order, so once
+ * accumulated ids without bound. A `Map` preserves insertion order, so once
  * the cap is hit the OLDEST id is evicted on each new insert (simple ring
  * buffer semantics) — recently-terminated ids (the ones actually at risk of
- * a re-discovery race) always stay covered.
+ * a re-discovery race, or of a SendMessage resume — issue #3315) always stay
+ * covered.
  */
 const TERMINATED_AGENT_IDS_CAP = 5000
 
@@ -1861,18 +1862,26 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
   const historicalFiles = new Set<string>()
   /**
    * AgentIds that have transitioned to a terminal state and been swept
-   * out of `registry` by `cleanupTerminalAgent`. Issue #1116 (Bug B):
-   * the JSONL file outlives the registry entry — Claude Code leaves
-   * the file on disk after the sub-agent finishes. Without this guard,
-   * the next `rescanSubagentDirs` poll re-discovered the file, called
-   * `registerAgent`, the fresh entry read the terminal `turn_duration`
-   * line, and `maybySendStateTransition` fired a duplicate "Worker done"
-   * notification — looping forever every grace-window.
+   * out of `registry` by `cleanupTerminalAgent`, mapped to the JSONL byte
+   * SIZE at cleanup time. Issue #1116 (Bug B): the JSONL file outlives the
+   * registry entry — Claude Code leaves the file on disk after the sub-agent
+   * finishes. Without this guard, the next `rescanSubagentDirs` poll
+   * re-discovered the file, called `registerAgent`, the fresh entry read the
+   * terminal `turn_duration` line, and `maybySendStateTransition` fired a
+   * duplicate "Worker done" notification — looping forever every grace-window.
    *
-   * `scanSubagentsDir` consults this set and treats re-discovered
-   * terminal JSONLs as a no-op.
+   * Issue #3315 (SendMessage resume): a resumed sub-agent reuses the SAME
+   * `agent-<id>.jsonl`, appending a NEW turn to it — so the file's size grows
+   * PAST the size it had at terminal cleanup. `scanSubagentsDir` compares the
+   * live file size against this recorded terminal size: at/below it the JSONL
+   * is a static leftover and stays suppressed (#1116 Bug B); above it the
+   * worker resumed and is re-registered live (#3315) so its progress card
+   * updates again. Storing the size (not a bare membership flag) is what makes
+   * that distinction deterministic and lifecycle-driven rather than a
+   * heuristic. Map iteration order is insertion order, so the eviction ring
+   * buffer (Fix #9a) still evicts the oldest id.
    */
-  const terminatedAgentIds = new Set<string>()
+  const terminatedAgentIds = new Map<string, number>()
   /**
    * Issue #3023 (card resurrection). Per-worker record of a FALSE terminal
    * finish — a terminal state produced by silent-stall synthesis (NOT a real
@@ -1916,7 +1925,17 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
 
   // ─── Per-agent registration ─────────────────────────────────────────────
 
-  function registerAgent(filePath: string, agentId: string): void {
+  /**
+   * @param resumeFromCursor Issue #3315: when re-registering a worker whose
+   *   JSONL resumed growing after a terminal cleanup (a SendMessage resume),
+   *   start the tail cursor at the terminal byte boundary instead of 0. The
+   *   already-handed-back completed turn (its `sub_agent_turn_end` and all
+   *   prior events) is therefore never re-read — so the fresh entry stays
+   *   `running` on the NEW turn's content rather than instantly re-reading the
+   *   old terminal line and re-finalising. Omitted (⇒ 0) for every normal
+   *   registration, which reads from the start.
+   */
+  function registerAgent(filePath: string, agentId: string, resumeFromCursor?: number): void {
     if (registry.has(agentId)) return
     const n = nowFn()
     const isHistorical = historicalFiles.has(filePath)
@@ -1976,7 +1995,12 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     }
 
     const tail: SubTail = {
-      cursor: 0, // read from start to capture description
+      // Normally read from the start (to replay the full transcript); on a
+      // resume re-registration (#3315) start at the terminal boundary so only
+      // the new turn is read. A resumed cursor sits on a JSONL newline boundary
+      // (the prior turn ended with a complete `turn_end` line), so no partial
+      // line is straddled.
+      cursor: resumeFromCursor ?? 0,
       pendingPartial: '',
       hasEmittedStart: false,
       watcher: null,
@@ -2274,24 +2298,42 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       try { tail.watcher.close() } catch { /* ignore */ }
       tail.watcher = null
     }
-    tails.delete(agentId)
     const entry = registry.get(agentId)
+    // Issue #3315: snapshot the JSONL byte size at cleanup so a later
+    // SendMessage-resume — which appends a NEW turn to the SAME
+    // agent-<id>.jsonl — is detected by `scanSubagentsDir` as growth PAST this
+    // size and re-registered. The on-disk stat is the source of truth (it
+    // captures any bytes that landed during the terminal-cleanup grace window,
+    // so only genuinely post-cleanup writes trip a resume); fall back to the
+    // tail cursor, then 0, when the file is unreadable.
+    let terminalSize = tail?.cursor ?? 0
+    if (entry?.filePath) {
+      try {
+        terminalSize = fs.statSync(entry.filePath).size
+      } catch { /* keep the cursor-based fallback */ }
+    }
+    tails.delete(agentId)
     if (entry?.filePath) {
       knownFiles.delete(entry.filePath)
     }
     registry.delete(agentId)
     // Issue #1116 (Bug B): record that this agent has been fully
-    // processed so a rescan that rediscovers the still-present JSONL
-    // doesn't re-register and re-notify.
+    // processed so a rescan that rediscovers the still-present (unchanged)
+    // JSONL doesn't re-register and re-notify. The recorded value is the
+    // terminal byte size (issue #3315): `scanSubagentsDir` keeps suppressing
+    // while the file stays at/below it, and re-registers once it grows past it
+    // (a resume).
     //
-    // Fix #9a: bound the Set so it can't grow unboundedly over a long-lived
-    // gateway — evict the oldest id once the cap is hit (Set iteration
-    // order is insertion order, so `.values().next().value` is the oldest).
+    // Fix #9a: bound the Map so it can't grow unboundedly over a long-lived
+    // gateway — evict the oldest id once the cap is hit (Map iteration
+    // order is insertion order, so the first key is the oldest). A re-set of
+    // an existing key updates its value without moving it, so a re-completed
+    // (resumed-then-finished-again) agent just refreshes its terminal size.
     if (!terminatedAgentIds.has(agentId) && terminatedAgentIds.size >= terminatedAgentIdsCap) {
-      const oldest = terminatedAgentIds.values().next().value
+      const oldest = terminatedAgentIds.keys().next().value
       if (oldest != null) terminatedAgentIds.delete(oldest)
     }
-    terminatedAgentIds.add(agentId)
+    terminatedAgentIds.set(agentId, terminalSize)
     log?.(`subagent-watcher: cleaned up terminal agent ${agentId}`)
     // Authoritative terminal sweep → notify the worker-activity feed so its row
     // for this agent is removed even on the paths that never fire `onFinish`
@@ -2865,11 +2907,52 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       const filePath = join(subagentsPath, e)
       if (knownFiles.has(filePath)) continue
       const agentId = e.slice('agent-'.length, -'.jsonl'.length)
-      // Issue #1116 (Bug B): skip JSONLs whose agent already completed
-      // and was swept by cleanupTerminalAgent. Re-adding to knownFiles
-      // here would let a subsequent rescan re-register, fire a duplicate
-      // "Worker done", and loop forever every grace-window.
-      if (terminatedAgentIds.has(agentId)) continue
+      // Issue #1116 (Bug B) + issue #3315 (SendMessage resume). A rediscovered
+      // JSONL whose agent already went terminal + was swept is normally a
+      // static leftover Claude Code left on disk — re-registering it would
+      // re-read the terminal turn and re-fire a duplicate handback, looping
+      // every grace-window (#1116). BUT a SendMessage resume appends a NEW turn
+      // to the SAME agent-<id>.jsonl, growing the file PAST the size it had at
+      // terminal cleanup. That growth is the deterministic, lifecycle-driven
+      // signal (not a heuristic) that the worker resumed and must be tracked
+      // again so its progress card resumes updating. Distinguish the two by the
+      // recorded terminal size.
+      const terminalSize = terminatedAgentIds.get(agentId)
+      if (terminalSize !== undefined) {
+        // A worker whose terminal state was a FALSE finish (silent-stall
+        // synthesis) is owned by the issue-#3023 resurrection path
+        // (`checkResurrections`), which carries the bounded-chain +
+        // `onResurrect`/`onWorkerLost` semantics and re-reads from cursor 0 to
+        // rebuild the still-in-progress turn. Skipping it here avoids
+        // double-handling the same growth in one poll; this branch's concern is
+        // GENUINE terminal completions (real `turn_end`, no false-finish record)
+        // that were resumed via SendMessage (issue #3315). A false finish that
+        // has since been evicted from `falseFinishTracker` (512-cap) is no
+        // longer double-handled, so falling through to re-register it live here
+        // is correct.
+        if (falseFinishTracker.has(agentId)) continue
+        let currentSize: number
+        try {
+          currentSize = fs.statSync(filePath).size
+        } catch {
+          continue // unreadable — nothing to resume; keep suppressing
+        }
+        // At/below the terminal snapshot ⇒ static leftover file (#1116 Bug B):
+        // stay suppressed, do NOT re-register.
+        if (currentSize <= terminalSize) continue
+        // Grew past it ⇒ the worker resumed (#3315). Re-register as a fresh
+        // LIVE worker, reading only from the terminal boundary so the
+        // already-completed turn is not replayed. At-most-once per resume:
+        // dropping the id from terminatedAgentIds means the next completion
+        // re-adds it with the new (larger) terminal size, so one resume yields
+        // exactly one re-registration.
+        log?.(`subagent-watcher: agent ${agentId} resumed after terminal cleanup — JSONL grew ${terminalSize} → ${currentSize} bytes (SendMessage resume); re-registering as live so its progress card resumes (issue #3315)`)
+        terminatedAgentIds.delete(agentId)
+        historicalFiles.delete(filePath)
+        knownFiles.add(filePath)
+        registerAgent(filePath, agentId, terminalSize)
+        continue
+      }
       knownFiles.add(filePath)
       // During the initial boot scan, mark every discovered file as
       // historical so stall-detection and completion notifications are

--- a/telegram-plugin/tests/subagent-watcher-resume-reregister.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-resume-reregister.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for SubagentWatcher re-registration after a SendMessage resume
+ * (issue #3315).
+ *
+ * A background worker that completes normally (a REAL `sub_agent_turn_end`)
+ * is swept out of the registry by `cleanupTerminalAgent`, which records the
+ * agent id in `terminatedAgentIds` so a rescan of the still-present JSONL
+ * doesn't re-register and re-fire a duplicate handback (issue #1116 Bug B).
+ *
+ * But a SendMessage-resume reuses the SAME `agent-<id>.jsonl`, appending a
+ * NEW turn to it. Pre-fix the `terminatedAgentIds` guard suppressed that file
+ * forever regardless of growth, so the resumed worker was never tracked again:
+ * no FSWatcher, no `onProgress`, no progress card — the exact UX failure the
+ * card exists to prevent (operator: "I don't see any progress cards, anything
+ * happening??").
+ *
+ * This suite pins BOTH directions of the deterministic size-based mechanism:
+ *
+ *  (a) terminal cleanup → resume (JSONL grows past the terminal size) ⇒ the
+ *      watcher re-registers the agent as a LIVE worker and emits progress
+ *      cues again. The re-registration reads only the NEW turn — it does NOT
+ *      replay the already-handed-back completed turn (no duplicate onFinish
+ *      until the resumed turn genuinely ends).
+ *  (b) terminal cleanup with NO resume (JSONL static) ⇒ the agent stays
+ *      cleaned up: no re-registration, no duplicate onFinish, no leaked card.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+import * as fs from 'fs'
+
+function buildJSONL(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+}
+function subAgentUserMsg(promptText: string) {
+  return { type: 'user', message: { content: [{ type: 'text', text: promptText }] } }
+}
+function subAgentToolUse(name: string, id: string, input: Record<string, unknown> = {}) {
+  return { type: 'assistant', message: { content: [{ type: 'tool_use', name, id, input }] } }
+}
+function subAgentTurnEnd() {
+  return { type: 'system', subtype: 'turn_duration', duration_ms: 1234 }
+}
+
+const RESCAN_MS = 500
+const CLEANUP_GRACE_MS = 30_000 // TERMINAL_CLEANUP_GRACE_MS in subagent-watcher.ts
+
+interface ProgressCall {
+  agentId: string
+  skeleton: boolean
+  progressLine?: string
+  toolCount: number
+}
+
+function makeHarness(opts: { agentId?: string } = {}) {
+  const { agentId = 'resume-agent' } = opts
+
+  let currentTime = 1000
+  const progressCalls: ProgressCall[] = []
+  const finishCalls: Array<{ agentId: string; outcome: string }> = []
+  const terminalCleanupCalls: string[] = []
+  const logs: string[] = []
+
+  const agentDir = '/home/user/.switchroom/agents/myagent'
+  const sessionId = 'mock-session'
+  const projectsRoot = `${agentDir}/.claude/projects`
+  const projectDir = `${projectsRoot}/mock-cwd`
+  const sessionDir = `${projectDir}/${sessionId}`
+  const subagentsDir = `${sessionDir}/subagents`
+  const jsonlPath = `${subagentsDir}/agent-${agentId}.jsonl`
+
+  // The agent JSONL is NOT present at construction, so the boot scan registers
+  // nothing and the file — when it later appears — registers post-boot as a
+  // LIVE (non-historical) worker, exactly like a freshly-dispatched one.
+  const fileContents = new Map<string, Buffer>()
+
+  let lastOpenedPath: string | null = null
+  const mockFs = {
+    existsSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (ps === projectsRoot || ps === projectDir || ps === sessionDir || ps === subagentsDir) return true
+      return fileContents.has(ps)
+    }) as typeof fs.existsSync,
+    readdirSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (ps === projectsRoot) return ['mock-cwd']
+      if (ps === projectDir) return [sessionId]
+      if (ps === sessionDir) return ['subagents']
+      if (ps === subagentsDir) {
+        // Dynamic: list the agent-*.jsonl files currently present on "disk".
+        const names: string[] = []
+        for (const key of fileContents.keys()) {
+          if (key.startsWith(subagentsDir + '/agent-') && key.endsWith('.jsonl')) {
+            names.push(key.slice(subagentsDir.length + 1))
+          }
+        }
+        return names
+      }
+      return []
+    }) as unknown as typeof fs.readdirSync,
+    statSync: ((p: fs.PathLike) =>
+      ({ size: fileContents.get(String(p))?.length ?? 0, mtimeMs: currentTime }) as fs.Stats) as typeof fs.statSync,
+    openSync: ((p: fs.PathLike) => {
+      lastOpenedPath = String(p)
+      return 42
+    }) as unknown as typeof fs.openSync,
+    closeSync: (() => { lastOpenedPath = null }) as typeof fs.closeSync,
+    readSync: ((
+      _fd: number,
+      buf: NodeJS.ArrayBufferView,
+      offset: number,
+      length: number,
+      position: number | null,
+    ): number => {
+      const content = lastOpenedPath != null ? fileContents.get(lastOpenedPath) : undefined
+      if (!content) return 0
+      const pos = position ?? 0
+      const src = content.slice(pos, pos + length)
+      ;(src as Buffer).copy(buf as Buffer, offset)
+      return src.length
+    }) as unknown as typeof fs.readSync,
+    watch: (() => ({ close: vi.fn() }) as unknown as fs.FSWatcher) as unknown as typeof fs.watch,
+  }
+
+  const intervals: Array<{ fn: () => void; ms: number; ref: number; fireAt: number }> = []
+  const timeouts: Array<{ fn: () => void; ref: number; fireAt: number }> = []
+  let nextRef = 1
+
+  const watcher = startSubagentWatcher({
+    agentDir,
+    rescanMs: RESCAN_MS,
+    onProgress: ({ agentId: id, skeleton, progressLine, toolCount }) =>
+      progressCalls.push({ agentId: id, skeleton: skeleton === true, progressLine, toolCount }),
+    onFinish: ({ agentId: id, outcome }) => finishCalls.push({ agentId: id, outcome }),
+    onTerminalCleanup: (id) => terminalCleanupCalls.push(id),
+    now: () => currentTime,
+    setInterval: (fn, ms) => {
+      const ref = nextRef++
+      intervals.push({ fn, ms, ref, fireAt: currentTime + ms })
+      return { ref }
+    },
+    clearInterval: (handle) => {
+      const { ref } = handle as { ref: number }
+      const idx = intervals.findIndex((i) => i.ref === ref)
+      if (idx !== -1) intervals.splice(idx, 1)
+    },
+    setTimeout: (fn, ms) => {
+      const ref = nextRef++
+      timeouts.push({ fn, ref, fireAt: currentTime + ms })
+      return { ref }
+    },
+    clearTimeout: (handle) => {
+      const { ref } = handle as { ref: number }
+      const idx = timeouts.findIndex((t) => t.ref === ref)
+      if (idx !== -1) timeouts.splice(idx, 1)
+    },
+    fs: mockFs,
+    log: (msg) => logs.push(msg),
+  })
+
+  const advance = (ms: number): void => {
+    currentTime += ms
+    for (;;) {
+      intervals.sort((a, b) => a.fireAt - b.fireAt)
+      timeouts.sort((a, b) => a.fireAt - b.fireAt)
+      const nextI = intervals[0]
+      const nextT = timeouts[0]
+      const iReady = nextI && nextI.fireAt <= currentTime
+      const tReady = nextT && nextT.fireAt <= currentTime
+      if (!iReady && !tReady) break
+      if (tReady && (!iReady || nextT!.fireAt <= nextI!.fireAt)) {
+        timeouts.shift()
+        nextT!.fn()
+      } else {
+        nextI!.fireAt += nextI!.ms
+        nextI!.fn()
+      }
+    }
+  }
+
+  const setFile = (content: string): void => {
+    fileContents.set(jsonlPath, Buffer.from(content, 'utf-8'))
+  }
+  const append = (content: string): void => {
+    const cur = fileContents.get(jsonlPath) ?? Buffer.alloc(0)
+    fileContents.set(jsonlPath, Buffer.concat([cur, Buffer.from(content, 'utf-8')]))
+  }
+
+  return {
+    agentId,
+    progressCalls,
+    finishCalls,
+    terminalCleanupCalls,
+    logs,
+    advance,
+    watcher,
+    setFile,
+    append,
+  }
+}
+
+describe('subagent-watcher resume re-registration (issue #3315)', () => {
+  it('(a) re-registers a terminal-then-resumed worker so its progress card resumes', () => {
+    const agentId = 'resume-live'
+    const h = makeHarness({ agentId })
+
+    // A worker is dispatched post-boot: its JSONL appears with a running turn.
+    h.setFile(buildJSONL(subAgentUserMsg('bg task'), subAgentToolUse('Bash', 't1')))
+    h.advance(RESCAN_MS) // rescan discovers the file → LIVE registration
+
+    const registered = h.watcher.getRegistry().get(agentId)
+    expect(registered).toBeDefined()
+    expect(registered!.state).toBe('running')
+    expect(registered!.historical).toBe(false)
+
+    // It completes normally with a REAL turn_end.
+    h.append(buildJSONL(subAgentTurnEnd()))
+    h.advance(RESCAN_MS) // poll reads turn_end → done → onFinish(completed)
+    expect(h.finishCalls).toHaveLength(1)
+    expect(h.finishCalls[0].outcome).toBe('completed')
+
+    // Grace elapses → the entry is swept out of the registry.
+    h.advance(CLEANUP_GRACE_MS)
+    expect(h.watcher.getRegistry().has(agentId)).toBe(false)
+    expect(h.terminalCleanupCalls).toContain(agentId)
+
+    const progressBeforeResume = h.progressCalls.length
+
+    // SendMessage resume: Claude Code appends a NEW turn to the SAME JSONL.
+    h.append(buildJSONL(
+      subAgentUserMsg('follow-up question'),
+      subAgentToolUse('Read', 't2', { file_path: '/tmp/x' }),
+    ))
+    h.advance(RESCAN_MS) // rescan sees growth past terminal size → re-register
+
+    // The worker is tracked again — live, running, non-historical.
+    const revived = h.watcher.getRegistry().get(agentId)
+    expect(revived).toBeDefined()
+    expect(revived!.state).toBe('running')
+    expect(revived!.historical).toBe(false)
+    expect(h.logs.some((l) => l.includes('resumed after terminal cleanup') && l.includes(agentId))).toBe(true)
+
+    // Progress cues resume (the card updates again) — the user-visible fix.
+    expect(h.progressCalls.length).toBeGreaterThan(progressBeforeResume)
+    expect(h.progressCalls.slice(progressBeforeResume).some((c) => c.agentId === agentId)).toBe(true)
+
+    // The completed turn was NOT replayed — no duplicate onFinish fired on
+    // re-registration (the old turn_end sits before the resume cursor).
+    expect(h.finishCalls).toHaveLength(1)
+
+    // When the resumed turn genuinely ends, onFinish fires again for the new
+    // turn — the resumed work gets its own handback.
+    h.append(buildJSONL(subAgentTurnEnd()))
+    h.advance(RESCAN_MS)
+    expect(h.finishCalls).toHaveLength(2)
+    expect(h.finishCalls[1].outcome).toBe('completed')
+
+    h.watcher.stop()
+  })
+
+  it('(b) a terminal worker that is NOT resumed stays cleaned up (no re-register, no duplicate handback)', () => {
+    const agentId = 'stay-clean'
+    const h = makeHarness({ agentId })
+
+    h.setFile(buildJSONL(subAgentUserMsg('bg task'), subAgentToolUse('Bash', 't1')))
+    h.advance(RESCAN_MS)
+    expect(h.watcher.getRegistry().has(agentId)).toBe(true)
+
+    h.append(buildJSONL(subAgentTurnEnd()))
+    h.advance(RESCAN_MS)
+    expect(h.finishCalls).toHaveLength(1)
+
+    h.advance(CLEANUP_GRACE_MS) // sweep
+    expect(h.watcher.getRegistry().has(agentId)).toBe(false)
+    const finishAfterCleanup = h.finishCalls.length
+    const progressAfterCleanup = h.progressCalls.length
+
+    // The JSONL stays on disk, static (Claude Code leaves it), and the worker
+    // is never resumed. Many rescans must NOT re-register it or re-fire the
+    // handback (issue #1116 Bug B guard preserved) — the reverse-bug direction.
+    for (let i = 0; i < 20; i++) h.advance(RESCAN_MS)
+
+    expect(h.watcher.getRegistry().has(agentId)).toBe(false)
+    expect(h.finishCalls).toHaveLength(finishAfterCleanup) // no duplicate
+    expect(h.progressCalls).toHaveLength(progressAfterCleanup) // no card churn
+    // Cleanup fired exactly once — no leaked/duplicated terminal sweep.
+    expect(h.terminalCleanupCalls.filter((id) => id === agentId)).toHaveLength(1)
+
+    h.watcher.stop()
+  })
+})

--- a/telegram-plugin/tests/subagent-watcher-resurrection.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-resurrection.test.ts
@@ -395,4 +395,36 @@ describe('subagent-watcher card resurrection (issue #3023)', () => {
     h.advance(500)
     expect(h.resurrectCalls).toHaveLength(1)
   })
+
+  it('(f) a false finish resumed after cleanup grace is owned by resurrection, not the #3315 resume path', () => {
+    // Non-interference guard (issue #3315 × #3023): once the terminal-cleanup
+    // grace has elapsed, a falsely-finalised worker's id sits in BOTH
+    // `terminatedAgentIds` (the #3315 resume-detection map) AND
+    // `falseFinishTracker`. Its JSONL resuming must be handled by the
+    // resurrection path (bounded-chain + onResurrect semantics), NOT
+    // double-handled by the scanSubagentsDir resume branch. The branch defers
+    // when a false-finish record exists.
+    const agentId = 'false-finish-post-grace'
+    const h = makeHarness({ agentId })
+
+    h.advance(500)
+    unmarkHistorical(h, agentId)
+
+    driveToFalseFinish(h, agentId)
+    // Let the 30s terminal-cleanup grace elapse so the entry is swept — its id
+    // is now in BOTH terminatedAgentIds and falseFinishTracker.
+    h.advance(30_000)
+    expect(h.watcher.getRegistry().has(agentId)).toBe(false)
+
+    // JSONL resumes growing.
+    h.appendActivity()
+    h.advance(500)
+
+    // Resurrected exactly once via the #3023 path...
+    expect(h.resurrectCalls).toHaveLength(1)
+    expect(h.watcher.getRegistry().get(agentId)?.state).toBe('running')
+    // ...and NOT re-registered by the #3315 resume branch (its log marker is
+    // absent — the branch deferred because a false-finish record existed).
+    expect(h.logs.some((l) => l.includes('resumed after terminal cleanup'))).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

Resumed sub-agents (worker stopped, then continued via `SendMessage`) were never re-registered with the subagent-watcher, so their `🛠 Worker` progress surface went dark for the entire resumed run. Observed live 2026-07-18 (agent `klanker`): two Opus workers resumed ~01:16–01:18Z, both actively writing their transcripts, zero progress cards — operator asked "I don't see any progress cards, anything happening??".

Closes #3315.

## Why

A worker that completes normally (real `sub_agent_turn_end`) is swept from the registry by `cleanupTerminalAgent`, which adds its id to `terminatedAgentIds` so a rescan of the leftover JSONL doesn't re-register and re-fire a duplicate handback (issue #1116 Bug B). A `SendMessage` resume reuses the **same** `agent-<id>.jsonl`, appending a new turn — but `scanSubagentsDir` skipped that id unconditionally regardless of file growth. No FSWatcher re-armed, no `onProgress`, no card. The pre-existing `checkResurrections` path only covers **false** finishes (silent-stall synthesis, #3023), not genuine completions, so a real-completion-then-resume was invisible.

Root cause: `telegram-plugin/subagent-watcher.ts` `scanSubagentsDir` — `if (terminatedAgentIds.has(agentId)) continue`.

## Fix (deterministic, lifecycle-driven)

- `terminatedAgentIds` is now `Map<string, number>` — agentId → JSONL byte size at terminal cleanup.
- `scanSubagentsDir` compares the live file size to that snapshot: **at/below** ⇒ static leftover, stay suppressed (#1116 Bug B preserved); **grown past** ⇒ the worker resumed, re-register as live.
- `registerAgent` gains a `resumeFromCursor` param so the re-registration reads only the **new** turn (starts the tail at the terminal boundary) — the already-handed-back turn is never replayed and can't instantly re-finalise.
- At-most-once per resume: the id leaves the map on re-register; the next completion re-adds it with the new size.
- The resume append IS the signal (not a poll heuristic). Genuinely-terminal workers whose file never grows stay cleaned up — no leaked cards.

Non-interference with #3023: a **false** finish (silent-stall synthesis) is owned by the resurrection path (bounded-chain + `onResurrect`/`onWorkerLost`); the resume branch defers when a `falseFinishTracker` record exists.

## Test plan

`telegram-plugin/tests/subagent-watcher-resume-reregister.test.ts` (new):
- (a) terminal-cleanup → resume ⇒ re-registers live + emits progress cues again; the completed turn is not replayed (no duplicate `onFinish` until the resumed turn genuinely ends). **Fails on pre-fix source** (`expected undefined to be defined`).
- (b) terminal-cleanup with no resume ⇒ stays cleaned (no re-register, no duplicate handback, cleanup fires once) — reverse-bug guard.

`subagent-watcher-resurrection.test.ts` (f, new): a post-grace **false** finish resume is owned by resurrection, not the #3315 branch — load-bearing for the deferral guard (fails if the guard is removed).

Local: `vitest` watcher suite 129 pass; bun `registry/subagents.test.ts` 54 pass; root `tsc --noEmit` clean; all 8 lint guard scripts pass. (The `check-plugin-references` tsc reds only on missing `mdast`/`@mtcute` deps in untouched `render/`·`uat/` files — a local symlinked-node_modules artifact; CI runs full deps.)

## Risk

Low. Single concern (watcher resume surface); gateway/outbound paths untouched. The `#1116` Bug B dedup and `#3023` resurrection paths are both preserved and covered.

Job spec: progress-card liveness — active work must always be visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)