### PR TITLE
fix(gateway): read-back confirmation for backstop delivery (#3278)

### DIFF
--- a/telegram-plugin/gateway/backstop-delivery.ts
+++ b/telegram-plugin/gateway/backstop-delivery.ts
@@ -40,6 +40,12 @@ export class BackstopDeliveryLedger {
   private chunks = new Map<string, Map<number, number[]>>()
   /** turnId -> chunk indices with an in-flight (pre-ack) send (guard 6). */
   private pending = new Map<string, Set<number>>()
+  /** turnId -> chunk indices whose read-back probe CONFIRMED the message
+   *  actually exists in the chat (#3278). A chunk with a landed message id but
+   *  no confirmation is `landed-unconfirmed` — the Bot API accepted the send but
+   *  a server-side silent discard (flood/anti-spam) can return a fresh id for a
+   *  message the user never sees, so an id alone is NOT proof of delivery. */
+  private confirmed = new Map<string, Set<number>>()
 
   /**
    * Guard 5 — once-per-turn BACKSTOP double-fire latch. Returns `true` on the
@@ -99,6 +105,78 @@ export class BackstopDeliveryLedger {
     return (this.chunks.get(turnId)?.get(index)?.length ?? 0) > 0
   }
 
+  /** The landed message id(s) for one chunk (empty when unsent). The read-back
+   *  probe reads these to confirm every id of the chunk (guard A7 — a
+   *  length-resplit chunk lands >1 id and all must exist to count confirmed). */
+  chunkIds(turnId: string, index: number): number[] {
+    return (this.chunks.get(turnId)?.get(index) ?? []).slice()
+  }
+
+  /**
+   * #3278 — transition a landed-unconfirmed chunk to `landed-confirmed` after a
+   * read-back probe proved the message exists in the chat. Only a confirmed
+   * chunk counts toward delivery / `complete`.
+   */
+  confirmChunk(turnId: string, index: number): void {
+    let set = this.confirmed.get(turnId)
+    if (set == null) {
+      set = new Set()
+      this.confirmed.set(turnId, set)
+    }
+    set.add(index)
+  }
+
+  /**
+   * #3278 — demote a chunk back to `unsent` on a POSITIVE absence read-back
+   * (Telegram `400 message to edit not found`): the send was silently dropped,
+   * so re-sending it is safe (it never reached the user). Clears the landed ids,
+   * the pending marker, and any stale confirmation. NEVER call this on an
+   * ambiguous probe (429/5xx/network) — that would risk a duplicate.
+   */
+  demoteChunk(turnId: string, index: number): void {
+    this.chunks.get(turnId)?.delete(index)
+    this.pending.get(turnId)?.delete(index)
+    this.confirmed.get(turnId)?.delete(index)
+  }
+
+  /** True only for a `landed-confirmed` chunk (read-back proved it exists). */
+  hasConfirmedChunk(turnId: string, index: number): boolean {
+    return this.confirmed.get(turnId)?.has(index) ?? false
+  }
+
+  /** Chunk indices that have landed at least one id but are NOT yet confirmed —
+   *  the set the read-back probe must resolve (confirm / demote / leave). */
+  landedUnconfirmedIndices(turnId: string, chunkCount: number): number[] {
+    const out: number[] = []
+    for (let i = 0; i < chunkCount; i++) {
+      if (this.hasChunk(turnId, i) && !this.hasConfirmedChunk(turnId, i)) out.push(i)
+    }
+    return out
+  }
+
+  /** True IFF every chunk 0..chunkCount-1 is `landed-confirmed`. `chunkCount===0`
+   *  is never "all confirmed" (nothing was delivered). */
+  allConfirmed(turnId: string, chunkCount: number): boolean {
+    if (chunkCount <= 0) return false
+    for (let i = 0; i < chunkCount; i++) {
+      if (!this.hasConfirmedChunk(turnId, i)) return false
+    }
+    return true
+  }
+
+  /** Landed message ids of CONFIRMED chunks only, in chunk-index order — the set
+   *  the delivery predicate counts (fresh non-card ids that are proven-present). */
+  confirmedIds(turnId: string): number[] {
+    const m = this.chunks.get(turnId)
+    const set = this.confirmed.get(turnId)
+    if (m == null || set == null) return []
+    const out: number[] = []
+    for (const index of Array.from(m.keys()).sort((a, b) => a - b)) {
+      if (set.has(index)) out.push(...(m.get(index) ?? []))
+    }
+    return out
+  }
+
   /** All landed message ids for this turn, in chunk-index order. */
   sentIds(turnId: string): number[] {
     const m = this.chunks.get(turnId)
@@ -137,7 +215,47 @@ export class BackstopDeliveryLedger {
     this.latched.delete(turnId)
     this.chunks.delete(turnId)
     this.pending.delete(turnId)
+    this.confirmed.delete(turnId)
   }
+}
+
+/**
+ * #3278 — the tri-state a read-back probe resolves a landed chunk into:
+ *  - `exists`    — a no-op `editMessageText` succeeded or returned "message is
+ *                  not modified" ⇒ the message is present at the chat_id ⇒
+ *                  `landed-confirmed` (counts toward delivery).
+ *  - `absent`    — Telegram `400 message to edit not found` ⇒ positive absence
+ *                  ⇒ demote to `unsent` (safe to re-send — it never landed).
+ *  - `ambiguous` — 429 / 5xx / network / gate-shed / anything else ⇒ leave
+ *                  `landed-unconfirmed`; NEVER re-send (a re-send would risk a
+ *                  duplicate, and duplicate-risk beats missing-risk here).
+ *
+ * NOTE (honest limitation, #3278 §1.4): a passing probe proves only that the
+ * message EXISTS at that chat_id. It does NOT prove the human's client rendered
+ * it, and it does NOT catch a wrong-thread/chat misroute (the edit succeeds
+ * because the message exists — just not where the operator is looking).
+ * Read-back is necessary-but-not-sufficient; it is paired with the correct
+ * chat/thread resolution already pinned by the backstop caller.
+ */
+export type ReadBackResult = 'exists' | 'absent' | 'ambiguous'
+
+/**
+ * Combine the per-id read-back results of ONE chunk into the chunk's verdict
+ * (guard A7 — a length-resplit chunk lands >1 message id and every id must be
+ * present for the chunk to count confirmed). Pure:
+ *  - ANY id `absent`               ⇒ `absent`   (the chunk is incomplete on the
+ *                                     wire → re-send the whole chunk)
+ *  - ALL ids `exists`              ⇒ `exists`
+ *  - otherwise (some `ambiguous`,
+ *    none `absent`)                ⇒ `ambiguous` (never re-send)
+ *  - empty id set                  ⇒ `ambiguous` (nothing to probe → don't
+ *                                     fabricate a confirmation OR a demotion)
+ */
+export function combineReadBackResults(perId: readonly ReadBackResult[]): ReadBackResult {
+  if (perId.length === 0) return 'ambiguous'
+  if (perId.some(r => r === 'absent')) return 'absent'
+  if (perId.every(r => r === 'exists')) return 'exists'
+  return 'ambiguous'
 }
 
 /**
@@ -175,6 +293,25 @@ export interface BackstopDeliveryDeps {
   /** Record the delivered ids + aligned texts to history (called once, after
    *  the attempts resolve, with the full landed set). */
   recordOutbound?: (messageIds: number[], texts: string[]) => void
+  /**
+   * #3278 read-back confirmation. After a chunk lands a message id, a no-op
+   * `editMessageText` probe re-confirms the message ACTUALLY exists in the chat
+   * (a returned id is only an API accept, not proof of visibility). Returns the
+   * chunk's {@link ReadBackResult} — `exists` ⇒ landed-confirmed, `absent` ⇒
+   * demote to unsent + re-send, `ambiguous` ⇒ stay landed-unconfirmed and NEVER
+   * re-send. Runs once per landed chunk after the send attempts resolve, and is
+   * itself flood-window-paced by the caller (never a storm).
+   *
+   * When OMITTED, a landed chunk is confirmed on landing (pre-#3278 behavior) —
+   * still gated by the fresh-non-card receipt filter, so a card-only "delivery"
+   * is never counted. This is the hot-path default: read-back is scoped to the
+   * RARE backstop delivery, so the reply-tool path issues ZERO probes (§1.3).
+   */
+  readBack?: (
+    chunkIndex: number,
+    messageIds: readonly number[],
+    text: string,
+  ) => Promise<ReadBackResult>
   /** Optional stderr sink for progress/resume logging. */
   stderr?: (s: string) => void
 }
@@ -204,6 +341,14 @@ export interface BackstopDeliveryResult {
  * so the caller can leave the delivery obligation OPEN for the liveness floor
  * to re-present — instead of the old silent `send_failed` drop.
  *
+ * #3278 — after each attempt's sends resolve, every `landed-unconfirmed` chunk
+ * is read-back-probed via `deps.readBack` (when provided): `exists` confirms it,
+ * `absent` demotes it to `unsent` so the NEXT attempt re-sends only that chunk,
+ * and `ambiguous` leaves it `landed-unconfirmed` — never re-sent (duplicate-risk
+ * beats missing-risk). `delivered` now requires every chunk `landed-confirmed`,
+ * so an API-ack'd-but-silently-dropped send (fresh id, absent on read-back) is
+ * reported `delivered:false` and the caller leaves the obligation OPEN.
+ *
  * `recordOutbound` (when provided) fires ONCE at the end with the full landed
  * set and a `texts` array ALIGNED to the actual sent ids (via `ledger.entries`).
  * The ledger is NOT cleared here — the caller clears it only after success or
@@ -223,37 +368,92 @@ export async function runBackstopDelivery(
 
   for (let attempt = 1; attempt <= Math.max(1, maxAttempts); attempt++) {
     attempts = attempt
+    // 1. SEND the `unsent` chunks (never-landed OR demoted by a prior absent
+    //    read-back), resuming in chunk-index order. Guard 6 keeps a chunk that
+    //    already landed from being re-sent.
     const resume = ledger.unsentIndices(turnId, chunkCount)
-    if (resume.length === 0) break // everything already landed
-    if (attempt > 1) {
-      stderr(
-        `telegram gateway: backstop delivery retry ${attempt}/${maxAttempts} — ` +
-        `resuming at unsent chunk(s) [${resume.join(', ')}] for turn ${turnId}\n`,
-      )
-    }
     let attemptThrew = false
-    try {
-      for (const i of resume) {
-        // Guard 6 — never re-send a chunk that already landed for this turn.
-        if (ledger.hasChunk(turnId, i)) continue
-        ledger.markPending(turnId, i)
-        const ids = await deps.sendChunk(i, chunks[i])
-        ledger.recordChunk(turnId, i, ids)
+    if (resume.length > 0) {
+      if (attempt > 1) {
+        stderr(
+          `telegram gateway: backstop delivery retry ${attempt}/${maxAttempts} — ` +
+          `resuming at unsent chunk(s) [${resume.join(', ')}] for turn ${turnId}\n`,
+        )
       }
-    } catch (err) {
-      attemptThrew = true
-      stderr(
-        `telegram gateway: backstop delivery attempt ${attempt}/${maxAttempts} failed: ` +
-        `${err instanceof Error ? err.message : String(err)}\n`,
-      )
+      try {
+        for (const i of resume) {
+          if (ledger.hasChunk(turnId, i)) continue
+          ledger.markPending(turnId, i)
+          const ids = await deps.sendChunk(i, chunks[i])
+          ledger.recordChunk(turnId, i, ids) // → landed-unconfirmed
+        }
+      } catch (err) {
+        attemptThrew = true
+        stderr(
+          `telegram gateway: backstop delivery attempt ${attempt}/${maxAttempts} failed: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+        )
+      }
     }
-    if (!attemptThrew && ledger.unsentIndices(turnId, chunkCount).length === 0) break
+
+    // 2. CONFIRM landed-unconfirmed chunks via read-back (#3278). Without a probe
+    //    wired, landing IS confirmation (pre-#3278) — the fresh-non-card receipt
+    //    filter below still rejects a card-only "delivery".
+    let demotedAny = false
+    for (const i of ledger.landedUnconfirmedIndices(turnId, chunkCount)) {
+      if (deps.readBack == null) {
+        ledger.confirmChunk(turnId, i)
+        continue
+      }
+      let verdict: ReadBackResult
+      try {
+        verdict = await deps.readBack(i, ledger.chunkIds(turnId, i), chunks[i])
+      } catch (err) {
+        // A probe adapter that itself throws must NEVER trigger a re-send.
+        verdict = 'ambiguous'
+        stderr(
+          `telegram gateway: backstop read-back probe threw for chunk ${i} ` +
+          `(turn ${turnId}) — treating as ambiguous: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+        )
+      }
+      if (verdict === 'exists') {
+        ledger.confirmChunk(turnId, i)
+      } else if (verdict === 'absent') {
+        // Positive absence — the send was silently dropped. Safe to re-send.
+        ledger.demoteChunk(turnId, i)
+        demotedAny = true
+        stderr(
+          `telegram gateway: backstop read-back — chunk ${i} not found in chat ` +
+          `(turn ${turnId}); demoting to unsent for re-send\n`,
+        )
+      } else {
+        // Ambiguous (429/5xx/network/gate-shed) — leave landed-unconfirmed and
+        // NEVER re-send it (would risk a duplicate).
+        stderr(
+          `telegram gateway: backstop read-back — chunk ${i} ambiguous ` +
+          `(turn ${turnId}); left landed-unconfirmed, not re-sending\n`,
+        )
+      }
+    }
+
+    // 3. Fully confirmed ⇒ done.
+    if (ledger.allConfirmed(turnId, chunkCount)) break
+    // 4. Another attempt ONLY re-sends chunks demoted to `unsent`. If nothing is
+    //    unsent, the remaining non-confirmed chunks are all `landed-unconfirmed`
+    //    (ambiguous) — re-sending them would duplicate, so stop here.
+    if (ledger.unsentIndices(turnId, chunkCount).length === 0) break
+    // 5. Guard against a spin: if this attempt neither sent, threw, nor demoted
+    //    anything, another identical attempt is pointless.
+    if (resume.length === 0 && !attemptThrew && !demotedAny) break
   }
 
   const sentIds = ledger.sentIds(turnId)
+  // #3278 — delivered IFF every chunk is `landed-confirmed` AND at least one
+  // confirmed id is a fresh non-card chat id (the receipt gate, guard 7).
   const delivered =
-    chunkCount > 0 && ledger.unsentIndices(turnId, chunkCount).length === 0 &&
-    backstopReceiptIds(sentIds, cardMessageId).length > 0
+    ledger.allConfirmed(turnId, chunkCount) &&
+    backstopReceiptIds(ledger.confirmedIds(turnId), cardMessageId).length > 0
   const exhausted = !delivered
 
   if (deps.recordOutbound && sentIds.length > 0) {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -216,7 +216,7 @@ import {
   retryWithThreadFallback,
   isFloodWaitActiveError,
 } from '../retry-api-call.js'
-import { createSendGate, sendGateConfigFromEnv } from '../send-gate.js'
+import { createSendGate, sendGateConfigFromEnv, isSendGateShed } from '../send-gate.js'
 import { createStatsLogger, createFloodWindowObserver } from '../send-gate-observability.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
 import {
@@ -369,6 +369,7 @@ import {
   sendReplyChunks,
   sendReply,
   deliverCapturedProse as deliverCapturedProseCore,
+  createBackstopReadBack,
   type ReplyChunkSendDeps,
   type SendReplyGatewayDeps,
   type DeliverCapturedProseDeps,
@@ -2408,6 +2409,24 @@ async function deliverAnswer(args: {
     return chunkIds
   }
 
+  // #3278 read-back confirmation. A returned message_id proves Telegram
+  // ACCEPTED a send, not that the message is VISIBLE — a server-side
+  // accept-then-silently-discard (flood/anti-spam) returns a fresh id yet the
+  // user sees nothing. `createBackstopReadBack` re-confirms each landed chunk
+  // via a no-op editMessageText before it counts as delivered; it is paced
+  // COSMETIC through the send gate (sheds under a flood window → ambiguous,
+  // never a re-send) and scoped to this RARE backstop path — the hot reply-tool
+  // path issues ZERO probes (#3278 §1.3/§1.5).
+  const readBack = createBackstopReadBack({
+    // allow-raw-bot-api: #3278 read-back probe — no-op editMessageText, paced by the injected sendGate.gate (cosmetic) and classified by classifyReadBackError; a gate shed / any throw → ambiguous (never re-send)
+    editMessageText: (mid, body, apiOpts) => bot.api.editMessageText(chatId, mid, body as never, apiOpts as never),
+    gate: (fn, opts) => sendGate.gate(fn, opts),
+    isShed: isSendGateShed,
+    richMessage,
+    chatId,
+    threadId: args.threadId,
+  })
+
   // Bounded in-turn retry (finding-1 fix): resumes at the first unsent chunk on
   // each attempt via the ledger, so chunk 0 is delivered exactly once even
   // across retries. `delivered`/`exhausted` tell the caller whether the answer
@@ -2420,6 +2439,7 @@ async function deliverAnswer(args: {
     args.cardMessageId,
     {
       sendChunk,
+      readBack,
       recordOutbound: HISTORY_ENABLED
         ? (messageIds, texts) => {
             try {

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -40,7 +40,11 @@ import { isMessageTooLongError, isHtmlParseRejectError } from '../retry-api-call
 // surfaces are injected via SendReplyGatewayDeps (see the DI contract below).
 import { statSync } from 'fs'
 import { extname } from 'path'
-import { InputFile, type Bot, type Context } from 'grammy'
+import { GrammyError, InputFile, type Bot, type Context } from 'grammy'
+import {
+  combineReadBackResults,
+  type ReadBackResult,
+} from './backstop-delivery.js'
 import {
   escapeMarkdown,
 } from '../format.js'
@@ -424,6 +428,130 @@ export async function sendReplyChunks(
   }
 
   return { threadId, previewMessageId }
+}
+
+// ─── Read-back confirmation probe (#3278) ─────────────────────────────────
+//
+// A returned message_id proves Telegram ACCEPTED a send, not that the message
+// is VISIBLE: a server-side accept-then-silently-discard (flood/anti-spam)
+// returns a fresh id yet the user sees nothing. The only echo primitive the Bot
+// API offers (there is no getMessage) is a no-op `editMessageText` against the
+// returned id — a `400 message to edit not found` proves absence, an edit-ok /
+// `message is not modified` proves presence. This primitive classifies that
+// probe per id and combines a chunk's ids into one verdict; the backstop
+// delivery orchestrator (`runBackstopDelivery`) consumes the verdict to decide
+// confirm / demote-and-re-send / leave-unconfirmed. Scoped to the RARE backstop
+// path only — the hot reply-tool send path issues ZERO probes (#3278 §1.3/§1.5).
+
+/**
+ * Classify a single-id read-back `editMessageText` FAILURE into a
+ * {@link ReadBackResult}. Pure over the thrown error:
+ *  - `400 message to edit not found` ⇒ `absent`   (positive drop → safe re-send)
+ *  - `400 message is not modified`   ⇒ `exists`   (a no-op edit → message present)
+ *  - anything else (429 / 5xx / network / thread-not-found / parse) ⇒ `ambiguous`
+ *    (never re-send — a re-send would risk a duplicate).
+ *
+ * A read-back that RESOLVES (the edit applied) means the message existed and is
+ * classified `exists` by the caller — this helper only maps the error branch.
+ */
+export function classifyReadBackError(err: unknown): ReadBackResult {
+  if (err instanceof GrammyError && err.error_code === 400) {
+    const d = (err.description || '').toLowerCase()
+    if (d.includes('message to edit not found')) return 'absent'
+    if (d.includes('not modified')) return 'exists'
+  }
+  return 'ambiguous'
+}
+
+/** Injected per-id probe for {@link createBackstopReadBackProbe}. Resolves to the
+ *  chunk-id's {@link ReadBackResult} — the gateway wires this to a no-op
+ *  `editMessageText` paced through the send gate (cosmetic priority, so it sheds
+ *  under a flood window and never storms); a test supplies a scripted fake. */
+export interface BackstopReadBackDeps {
+  /** Probe ONE landed message id (edit it to `body`, its identical rich render). */
+  probeId: (messageId: number, body: unknown) => Promise<ReadBackResult>
+  /** rich-markdown wrapper (`richMessage`) — the probe edits to the SAME body the
+   *  chunk was sent with, so an existing message returns "not modified" (no
+   *  visible mutation) rather than actually changing the delivered answer. */
+  richMessage: (s: string) => unknown
+}
+
+/**
+ * Build the `readBack` dep injected into `runBackstopDelivery` (#3278). For each
+ * landed chunk it probes EVERY message id (a length-resplit chunk lands >1) and
+ * combines them (guard A7 — the chunk is confirmed only if ALL ids exist; ANY
+ * positive absence ⇒ re-send the whole chunk). An empty id set is `ambiguous`
+ * (nothing to probe → fabricate neither a confirmation nor a demotion).
+ */
+export function createBackstopReadBackProbe(
+  deps: BackstopReadBackDeps,
+): (chunkIndex: number, messageIds: readonly number[], text: string) => Promise<ReadBackResult> {
+  return async (_chunkIndex, messageIds, text) => {
+    if (messageIds.length === 0) return 'ambiguous'
+    const body = deps.richMessage(text)
+    const perId: ReadBackResult[] = []
+    for (const id of messageIds) {
+      perId.push(await deps.probeId(id, body))
+    }
+    return combineReadBackResults(perId)
+  }
+}
+
+/** Injected wiring for {@link createBackstopReadBack}. The gateway supplies its
+ *  raw send primitives; a test can drive the whole probe with fakes. */
+export interface BackstopReadBackWiring {
+  /** Raw `editMessageText` with the chat_id baked in by the caller — edits the
+   *  message to `body` with `apiOpts`; resolves grammy's result or throws the
+   *  raw grammy error (NOT swallowed, so not-found/not-modified stay
+   *  distinguishable via {@link classifyReadBackError}). */
+  editMessageText: (messageId: number, body: unknown, apiOpts: unknown) => Promise<unknown>
+  /** Send-gate wrapper — the probe routes through it at COSMETIC priority so it
+   *  sheds under a flood window (never storms) and paces like every other send. */
+  gate: <T>(fn: () => Promise<T>, opts: RetryCallOpts) => Promise<T>
+  /** `SEND_GATE_SHED` sentinel detector: a shed probe is `ambiguous` (never a
+   *  re-send), NOT a false `exists`. */
+  isShed: (r: unknown) => boolean
+  /** rich-markdown wrapper (`richMessage`). */
+  richMessage: (s: string) => unknown
+  chatId: string
+  threadId: number | undefined
+}
+
+/**
+ * Build the complete #3278 `readBack` dep for `runBackstopDelivery`, owning the
+ * per-id probe: a no-op `editMessageText` to the message's IDENTICAL body,
+ * paced cosmetic through the send gate. A resolved edit (or a `not modified`
+ * 400) ⇒ `exists`; a `message to edit not found` 400 ⇒ `absent`; a gate shed,
+ * 429/5xx/network, or any other throw ⇒ `ambiguous` (never re-send). Per-chunk
+ * ids are combined by {@link createBackstopReadBackProbe} (guard A7).
+ */
+export function createBackstopReadBack(
+  w: BackstopReadBackWiring,
+): (chunkIndex: number, messageIds: readonly number[], text: string) => Promise<ReadBackResult> {
+  const probeId = async (messageId: number, body: unknown): Promise<ReadBackResult> => {
+    // Match the SEND's link_preview_options so editing to the identical body is
+    // a genuine no-op ("message is not modified") and never visibly mutates the
+    // delivered answer. editMessageText targets a globally-unique message_id, so
+    // no message_thread_id is needed on the edit itself.
+    const editApiOpts = { link_preview_options: { is_disabled: true } }
+    // Retry/gate metadata (RetryCallOpts) — keys the gate's per-message edit
+    // floor + cosmetic shedding; NOT sent to Telegram as API params.
+    const gateOpts: RetryCallOpts = {
+      chat_id: w.chatId,
+      verb: 'backstop.readback',
+      priorityClass: 'cosmetic',
+      messageId,
+      editPayload: body,
+      ...(w.threadId != null ? { threadId: w.threadId } : {}),
+    }
+    try {
+      const r = await w.gate(() => w.editMessageText(messageId, body, editApiOpts), gateOpts)
+      return w.isShed(r) ? 'ambiguous' : 'exists'
+    } catch (err) {
+      return classifyReadBackError(err)
+    }
+  }
+  return createBackstopReadBackProbe({ probeId, richMessage: w.richMessage })
 }
 
 // ─── Send-orchestration façade (#2996 P2, Amendments 9/10) ────────────────

--- a/telegram-plugin/tests/backstop-delivery.test.ts
+++ b/telegram-plugin/tests/backstop-delivery.test.ts
@@ -5,6 +5,8 @@ import {
   backstopReceiptIds,
   backstopDelivered,
   runBackstopDelivery,
+  combineReadBackResults,
+  type ReadBackResult,
 } from '../gateway/backstop-delivery.js'
 import {
   backstopSendOutcomeGated,
@@ -246,5 +248,170 @@ describe('runBackstopDelivery — integration oracle over the delivery wiring', 
     expect(recorded[0].ids).toEqual([10, 11, 12])
     expect(recorded[0].texts).toEqual(['A', 'B', 'B'])
     expect(recorded[0].ids).toHaveLength(recorded[0].texts.length)
+  })
+})
+
+/**
+ * #3278 — read-back confirmation of an accepted-but-dropped send.
+ *
+ * A returned message_id proves Telegram ACCEPTED the send, not that the message
+ * is VISIBLE (a flood/anti-spam silent discard returns a fresh id yet the user
+ * sees nothing). These assert the deterministic OUTCOMES of the per-chunk state
+ * machine `unsent → pending → landed-unconfirmed → {landed-confirmed | unsent}`
+ * driven by a no-op editMessageText read-back — NOT code-path execution.
+ */
+describe('#3278 read-back — the ledger confirmation state machine', () => {
+  it('confirmChunk transitions landed-unconfirmed → landed-confirmed', () => {
+    const l = new BackstopDeliveryLedger()
+    l.recordChunk('#t', 0, [900]) // landed-unconfirmed
+    expect(l.hasChunk('#t', 0)).toBe(true)
+    expect(l.hasConfirmedChunk('#t', 0)).toBe(false)
+    expect(l.landedUnconfirmedIndices('#t', 1)).toEqual([0])
+    l.confirmChunk('#t', 0)
+    expect(l.hasConfirmedChunk('#t', 0)).toBe(true)
+    expect(l.landedUnconfirmedIndices('#t', 1)).toEqual([])
+    expect(l.allConfirmed('#t', 1)).toBe(true)
+    expect(l.confirmedIds('#t')).toEqual([900])
+  })
+
+  it('demoteChunk resets a landed(-unconfirmed) chunk back to unsent (safe re-send)', () => {
+    const l = new BackstopDeliveryLedger()
+    l.recordChunk('#t', 0, [901])
+    l.confirmChunk('#t', 0)
+    l.demoteChunk('#t', 0) // positive-absence read-back
+    expect(l.hasChunk('#t', 0)).toBe(false)
+    expect(l.hasConfirmedChunk('#t', 0)).toBe(false)
+    expect(l.unsentIndices('#t', 1)).toEqual([0]) // resume set includes it again
+    expect(l.confirmedIds('#t')).toEqual([])
+  })
+
+  it('allConfirmed is false while any chunk is only landed-unconfirmed', () => {
+    const l = new BackstopDeliveryLedger()
+    l.recordChunk('#t', 0, [1]); l.confirmChunk('#t', 0)
+    l.recordChunk('#t', 1, [2]) // landed-unconfirmed
+    expect(l.allConfirmed('#t', 2)).toBe(false)
+    expect(l.landedUnconfirmedIndices('#t', 2)).toEqual([1])
+  })
+
+  it('confirmedIds returns ONLY confirmed chunk ids, in index order', () => {
+    const l = new BackstopDeliveryLedger()
+    l.recordChunk('#t', 0, [10]); l.confirmChunk('#t', 0)
+    l.recordChunk('#t', 1, [11]) // unconfirmed
+    l.recordChunk('#t', 2, [12, 13]); l.confirmChunk('#t', 2)
+    expect(l.confirmedIds('#t')).toEqual([10, 12, 13])
+  })
+})
+
+describe('#3278 combineReadBackResults — per-chunk id combine (guard A7)', () => {
+  it('ANY absent id ⇒ absent (re-send the whole chunk)', () => {
+    expect(combineReadBackResults(['exists', 'absent'])).toBe('absent')
+    expect(combineReadBackResults(['absent', 'ambiguous'])).toBe('absent')
+  })
+  it('ALL exist ⇒ exists', () => {
+    expect(combineReadBackResults(['exists', 'exists'])).toBe('exists')
+  })
+  it('some ambiguous, none absent ⇒ ambiguous (never re-send)', () => {
+    expect(combineReadBackResults(['exists', 'ambiguous'])).toBe('ambiguous')
+  })
+  it('empty id set ⇒ ambiguous (fabricate neither confirm nor demote)', () => {
+    expect(combineReadBackResults([])).toBe('ambiguous')
+  })
+})
+
+describe('#3278 runBackstopDelivery — read-back drives the delivery outcome', () => {
+  it('exists probe ⇒ landed-confirmed, delivered=true, ONE probe, no re-send', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const sendChunk = vi.fn(async () => [960])
+    const readBack = vi.fn(async (): Promise<ReadBackResult> => 'exists')
+    const res = await runBackstopDelivery(ledger, '#ok', ['the answer'], null, { sendChunk, readBack }, 3)
+    expect(res.delivered).toBe(true)
+    expect(res.exhausted).toBe(false)
+    expect(sendChunk).toHaveBeenCalledTimes(1) // never re-sent
+    expect(readBack).toHaveBeenCalledTimes(1) // exactly one probe per chunk
+    expect(ledger.hasConfirmedChunk('#ok', 0)).toBe(true)
+  })
+
+  it('400/absent probe ⇒ demote → RE-SENT EXACTLY ONCE, then confirmed', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    let sends = 0
+    const sendChunk = vi.fn(async () => { sends++; return [900 + sends] })
+    let probes = 0
+    // First probe: the send was silently dropped (absent). After the re-send the
+    // message is present (exists).
+    const readBack = vi.fn(async (): Promise<ReadBackResult> => {
+      probes++
+      return probes === 1 ? 'absent' : 'exists'
+    })
+    const res = await runBackstopDelivery(ledger, '#drop', ['answer'], null, { sendChunk, readBack }, 3)
+    expect(sendChunk).toHaveBeenCalledTimes(2) // initial + exactly one re-send
+    expect(res.delivered).toBe(true)
+    expect(ledger.hasConfirmedChunk('#drop', 0)).toBe(true)
+  })
+
+  it('429/ambiguous probe ⇒ NOT re-sent, stays landed-unconfirmed, delivered=false', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const sendChunk = vi.fn(async () => [950])
+    const readBack = vi.fn(async (): Promise<ReadBackResult> => 'ambiguous')
+    const res = await runBackstopDelivery(ledger, '#amb', ['answer'], null, { sendChunk, readBack }, 3)
+    expect(sendChunk).toHaveBeenCalledTimes(1) // never re-sent on ambiguous
+    expect(res.delivered).toBe(false)
+    expect(res.exhausted).toBe(true)
+    expect(ledger.hasConfirmedChunk('#amb', 0)).toBe(false)
+    expect(ledger.landedUnconfirmedIndices('#amb', 1)).toEqual([0]) // still landed-unconfirmed
+  })
+
+  it('a read-back adapter THAT THROWS is treated as ambiguous — never re-sent', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const sendChunk = vi.fn(async () => [951])
+    const readBack = vi.fn(async () => { throw new Error('boom') })
+    const res = await runBackstopDelivery(ledger, '#throw', ['answer'], null, { sendChunk, readBack }, 3)
+    expect(sendChunk).toHaveBeenCalledTimes(1)
+    expect(res.delivered).toBe(false)
+  })
+
+  it('#3278 CORE: API-ack fresh id but read-back ABSENT ⇒ send_failed, NOT complete', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const cardId = 500
+    // The Bot API returns a fresh non-card id (an accept) every time...
+    const sendChunk = vi.fn(async () => [970])
+    // ...but the read-back proves the message is not actually in the chat
+    // (flood/anti-spam silent discard). It never confirms.
+    const readBack = vi.fn(async (): Promise<ReadBackResult> => 'absent')
+    const res = await runBackstopDelivery(ledger, '#ghost', ['answer'], cardId, { sendChunk, readBack }, 3)
+    expect(res.delivered).toBe(false) // pre-#3278 this was true → false `complete`
+    expect(res.exhausted).toBe(true)
+    // The exact input the gateway feeds the turn record: delivered=false ⇒ the
+    // status is send_failed and the obligation is left OPEN — the answer is NOT
+    // silently marked complete.
+    const turn: { finalAnswerDelivered: boolean; deliveryOutcome?: 'delivered' | 'failed' | 'suppressed' } = {
+      finalAnswerDelivered: true,
+    }
+    finalizeBackstopSendGated(turn, {
+      threw: !res.delivered, sentIds: res.sentIds, chunkCount: res.chunkCount, cardMessageId: cardId,
+    })
+    expect(computeTurnStatus(turn)).toBe('send_failed')
+  })
+
+  it('scope guard: NO readBack dep ⇒ ZERO probes, legacy confirm-on-landing preserved', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const readBack = vi.fn()
+    const sendChunk = vi.fn(async () => [980])
+    // deliberately omit `readBack` — the hot path / opt-out shape.
+    const res = await runBackstopDelivery(ledger, '#noprobe', ['answer'], null, { sendChunk })
+    expect(readBack).not.toHaveBeenCalled()
+    expect(res.delivered).toBe(true) // confirmed on landing (receipt-gated)
+    expect(ledger.hasConfirmedChunk('#noprobe', 0)).toBe(true)
+  })
+
+  it('partial: chunk 0 confirmed, chunk 1 ambiguous ⇒ delivered=false, chunk 0 not re-sent', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const calls: number[] = []
+    const sendChunk = vi.fn(async (i: number) => { calls.push(i); return [700 + i] })
+    const readBack = vi.fn(async (i: number): Promise<ReadBackResult> => (i === 0 ? 'exists' : 'ambiguous'))
+    const res = await runBackstopDelivery(ledger, '#part', ['c0', 'c1'], null, { sendChunk, readBack }, 3)
+    expect(res.delivered).toBe(false)
+    expect(calls.filter(i => i === 0)).toHaveLength(1) // confirmed chunk never re-sent
+    expect(ledger.hasConfirmedChunk('#part', 0)).toBe(true)
+    expect(ledger.hasConfirmedChunk('#part', 1)).toBe(false)
   })
 })

--- a/telegram-plugin/tests/backstop-readback-probe.test.ts
+++ b/telegram-plugin/tests/backstop-readback-probe.test.ts
@@ -1,0 +1,144 @@
+/**
+ * #3278 — read-back confirmation probe primitive (outbound-send-path.ts).
+ *
+ * `classifyReadBackError` maps a raw grammy `editMessageText` FAILURE into the
+ * confirmation tri-state, and `createBackstopReadBackProbe` combines a chunk's
+ * per-id probes into the chunk verdict `runBackstopDelivery` consumes. These
+ * assert OUTCOMES: which error shape means present vs absent vs ambiguous, and
+ * that a length-resplit chunk (>1 id) is confirmed only if EVERY id is present.
+ */
+import { describe, test, expect, vi } from 'vitest'
+import { GrammyError } from 'grammy'
+import {
+  classifyReadBackError,
+  createBackstopReadBackProbe,
+  createBackstopReadBack,
+} from '../gateway/outbound-send-path.js'
+import type { ReadBackResult } from '../gateway/backstop-delivery.js'
+
+// GrammyError's constructor takes (message, payload, method, parameters).
+function grammy(code: number, description: string): GrammyError {
+  return new GrammyError(
+    `Call to 'editMessageText' failed! (${code}: ${description})`,
+    { ok: false, error_code: code, description },
+    'editMessageText',
+    {},
+  )
+}
+
+describe('#3278 classifyReadBackError — raw edit-failure → confirmation tri-state', () => {
+  test('400 "message to edit not found" ⇒ absent (positive drop → safe re-send)', () => {
+    expect(classifyReadBackError(grammy(400, 'Bad Request: message to edit not found'))).toBe('absent')
+  })
+
+  test('400 "message is not modified" ⇒ exists (a no-op edit → message present)', () => {
+    expect(classifyReadBackError(grammy(400, 'Bad Request: message is not modified'))).toBe('exists')
+  })
+
+  test('429 flood ⇒ ambiguous (never re-send)', () => {
+    expect(classifyReadBackError(grammy(429, 'Too Many Requests: retry after 30'))).toBe('ambiguous')
+  })
+
+  test('5xx / non-grammy network error ⇒ ambiguous', () => {
+    expect(classifyReadBackError(grammy(500, 'Internal Server Error'))).toBe('ambiguous')
+    expect(classifyReadBackError(new Error('fetch failed: ECONNRESET'))).toBe('ambiguous')
+  })
+
+  test('an unrelated 400 (e.g. thread not found) is ambiguous, NOT absent', () => {
+    // A wrong-classification here would demote-and-re-send a message that may
+    // well exist — the never-demote-on-ambiguous rule guards against duplicates.
+    expect(classifyReadBackError(grammy(400, 'Bad Request: message thread not found'))).toBe('ambiguous')
+  })
+})
+
+describe('#3278 createBackstopReadBackProbe — per-chunk id combine', () => {
+  test('single id present ⇒ exists; probes the id with the SAME rich body', async () => {
+    const probeId = vi.fn(async (): Promise<ReadBackResult> => 'exists')
+    const richMessage = vi.fn((s: string) => ({ rich: s }))
+    const readBack = createBackstopReadBackProbe({ probeId, richMessage })
+    const verdict = await readBack(0, [111], 'answer')
+    expect(verdict).toBe('exists')
+    expect(richMessage).toHaveBeenCalledWith('answer')
+    expect(probeId).toHaveBeenCalledTimes(1)
+    expect(probeId).toHaveBeenCalledWith(111, { rich: 'answer' })
+  })
+
+  test('resplit chunk (2 ids): one absent ⇒ absent (whole chunk re-sent)', async () => {
+    const probeId = vi.fn(async (id: number): Promise<ReadBackResult> => (id === 12 ? 'absent' : 'exists'))
+    const readBack = createBackstopReadBackProbe({ probeId, richMessage: (s) => s })
+    expect(await readBack(1, [11, 12], 'B')).toBe('absent')
+    expect(probeId).toHaveBeenCalledTimes(2) // every id of the chunk is probed
+  })
+
+  test('resplit chunk (2 ids): all present ⇒ exists', async () => {
+    const probeId = vi.fn(async (): Promise<ReadBackResult> => 'exists')
+    const readBack = createBackstopReadBackProbe({ probeId, richMessage: (s) => s })
+    expect(await readBack(0, [1, 2], 'A')).toBe('exists')
+  })
+
+  test('empty id set ⇒ ambiguous and NEVER probes (no confirm, no demote)', async () => {
+    const probeId = vi.fn(async (): Promise<ReadBackResult> => 'exists')
+    const readBack = createBackstopReadBackProbe({ probeId, richMessage: (s) => s })
+    expect(await readBack(0, [], 'A')).toBe('ambiguous')
+    expect(probeId).not.toHaveBeenCalled()
+  })
+})
+
+const SHED = Symbol.for('switchroom.send-gate.shed')
+
+describe('#3278 createBackstopReadBack — full gate+edit+classify wiring', () => {
+  function wiring(overrides: Partial<Parameters<typeof createBackstopReadBack>[0]> = {}) {
+    return {
+      editMessageText: vi.fn(async () => true), // edit applied → exists
+      gate: vi.fn(async (fn: () => Promise<unknown>) => fn()), // passthrough gate
+      isShed: (r: unknown) => r === SHED,
+      richMessage: (s: string) => ({ rich: s }),
+      chatId: '1001',
+      threadId: undefined as number | undefined,
+      ...overrides,
+    }
+  }
+
+  test('edit RESOLVES ⇒ exists; edits to the identical rich body (no visible mutation)', async () => {
+    const w = wiring()
+    const readBack = createBackstopReadBack(w)
+    expect(await readBack(0, [55], 'answer')).toBe('exists')
+    // Probed the landed id with the SAME rich body the chunk was sent with.
+    expect(w.editMessageText).toHaveBeenCalledWith(55, { rich: 'answer' }, expect.anything())
+    // Routed through the send gate (pacing) rather than a raw call.
+    expect(w.gate).toHaveBeenCalledTimes(1)
+  })
+
+  test('400 message-not-found ⇒ absent (safe re-send)', async () => {
+    const editMessageText = vi.fn(async () => {
+      throw new GrammyError('boom', { ok: false, error_code: 400, description: 'Bad Request: message to edit not found' }, 'editMessageText', {})
+    })
+    const readBack = createBackstopReadBack(wiring({ editMessageText }))
+    expect(await readBack(0, [55], 'answer')).toBe('absent')
+  })
+
+  test('400 not-modified ⇒ exists (a no-op edit on a present message)', async () => {
+    const editMessageText = vi.fn(async () => {
+      throw new GrammyError('boom', { ok: false, error_code: 400, description: 'Bad Request: message is not modified' }, 'editMessageText', {})
+    })
+    const readBack = createBackstopReadBack(wiring({ editMessageText }))
+    expect(await readBack(0, [55], 'answer')).toBe('exists')
+  })
+
+  test('429 flood ⇒ ambiguous (never re-send)', async () => {
+    const editMessageText = vi.fn(async () => {
+      throw new GrammyError('boom', { ok: false, error_code: 429, description: 'Too Many Requests' }, 'editMessageText', {})
+    })
+    const readBack = createBackstopReadBack(wiring({ editMessageText }))
+    expect(await readBack(0, [55], 'answer')).toBe('ambiguous')
+  })
+
+  test('gate SHED (SEND_GATE_SHED sentinel) ⇒ ambiguous, NOT a false exists', async () => {
+    // Under a flood window the cosmetic probe sheds — the gate resolves the
+    // sentinel, not the edit. Must be ambiguous so the chunk is never demoted.
+    const gate = vi.fn(async () => SHED)
+    const editMessageText = vi.fn(async () => true)
+    const readBack = createBackstopReadBack(wiring({ gate, editMessageText }))
+    expect(await readBack(0, [55], 'answer')).toBe('ambiguous')
+  })
+})


### PR DESCRIPTION
## Summary
A returned `message_id` proves Telegram **accepted** a backstop send, not that the message is **visible**. A server-side accept-then-silently-discard (flood/anti-spam) returns a fresh non-card id yet the user sees nothing, so the pre-fix receipt gate counted it delivered → false `complete` → the delivery obligation was wrongly closed and the answer never seen (the "dropped reply" class, #3276 residual).

This adds a **read-back confirmation transition** on the per-chunk backstop ledger. After each landed chunk, a no-op `editMessageText` probes whether the message actually exists in the chat before it counts as delivered.

## State machine (per turnId, per chunk)
```
unsent → pending → landed-unconfirmed → { landed-confirmed | unsent }
```
| read-back probe result | transition | rationale |
|---|---|---|
| edit-ok / `message is not modified` | **landed-confirmed** | message exists at chat_id |
| `400 message to edit not found` | **unsent** (demote) | positive absence → safe to re-send |
| `429` / `5xx` / network / gate-shed | **landed-unconfirmed** (no demotion) | ambiguous → re-sending would duplicate |

`delivered` now requires **every chunk landed-confirmed**; an API-ack'd-but-absent-on-read-back send is reported `delivered:false`, so the caller leaves the obligation **OPEN** rather than recording a false `complete`.

## Design decisions cited
- **Read-back probe is the mechanism** (design §1.2/§1.3): the only robust echo the Bot API allows (there is no `getMessage`). A no-op `editMessageText` to the message's identical body — a `400 message to edit not found` proves absence, `not modified` proves presence.
- **Never re-send on an unconfirmed chunk** (design §3, A1): a chunk is demoted to `unsent` *only* on a positive `not found`. 429/5xx/network/gate-shed leave it `landed-unconfirmed` and it is **never re-sent** — duplicate-risk beats missing-risk.
- **Backstop path only; hot path issues zero probes** (design §1.3/§1.5, A3): scoped to the RARE `deliverAnswer` backstop. Every probe is COSMETIC priority through the send gate, so it **sheds under a flood window** (→ ambiguous, never a re-send) and never storms — no hot-path API volume change.
- **Honest limitation** (design §1.4): a passing probe proves only that the message EXISTS at that chat_id — not that the client rendered it, and not a wrong-thread misroute. Necessary-but-not-sufficient (documented in code).

## Deviation from the design (deliberate, sound)
The design §3 suggested *redefining* `unsentIndices` to include landed-unconfirmed chunks. Instead this keeps `unsentIndices` = "needs a fresh send" and adds a separate `landedUnconfirmedIndices` predicate. This preserves the existing guard-6 resume contract (and its tests) exactly, and within a single fire re-probing an ambiguous chunk is pointless (same flood window → same shed). The cross-fire confirmed-aware resume the design wanted that redefinition for is PR-B (#3282), which can add it without breaking guard-6.

## Test plan
- `telegram-plugin/tests/backstop-delivery.test.ts` — ledger state machine + `runBackstopDelivery` outcomes: absent probe ⇒ **re-sent exactly once** then confirmed; ambiguous probe ⇒ **NOT re-sent**, stays landed-unconfirmed, `delivered:false`; exists ⇒ confirmed with **one probe**; API-ack fresh id + absent ⇒ **`send_failed` NOT `complete`** (the #3278 acceptance criterion); no `readBack` dep ⇒ **zero probes** (legacy confirm-on-landing preserved).
- `telegram-plugin/tests/backstop-readback-probe.test.ts` — `classifyReadBackError` (not-found→absent, not-modified→exists, 429/5xx→ambiguous) and `createBackstopReadBack` wiring (gate-shed sentinel → ambiguous, per-id combine guard A7).
- `tsc --noEmit` + full `npm run lint` (incl. `check-bot-api-wrapping` + gateway line ratchet 30453 ≤ 30472) green locally.

## Risk
Behaviour-changing bugfix, backstop path only. Adds ≤1 paced probe per backstop chunk (backstop deliveries are rare — only when the model ended a turn without calling the reply tool). New logic lives in the extracted modules (`backstop-delivery.ts` / `outbound-send-path.ts`); `gateway.ts` grows 22 lines of thin wiring.

Job spec: `reference/jobs/talk-to-agents-from-anywhere.md` — the inbound→answer round-trip completing (serves the *always available* vision outcome).

Closes #3278

🤖 Generated with [Claude Code](https://claude.com/claude-code)