### PR TITLE
fix(gateway): captured-answer resume for partial backstop delivery (#3282)

### DIFF
--- a/telegram-plugin/gateway/captured-answer-resume.ts
+++ b/telegram-plugin/gateway/captured-answer-resume.ts
@@ -1,0 +1,259 @@
+/**
+ * captured-answer-resume.ts — durable captured-answer resume for a partially
+ * delivered turn-flush backstop (#3282).
+ *
+ * ── The bug this closes ──────────────────────────────────────────────────────
+ * When the turn-flush backstop (`deliverAnswer` → `runBackstopDelivery`) lands
+ * chunks 0,1 of a 3-chunk answer but chunk 2 exhausts its bounded retries, the
+ * turn-flush IIFE historically (a) cleared the per-chunk `BackstopDeliveryLedger`
+ * unconditionally and (b) left the delivery obligation OPEN. The liveness floor
+ * then re-presented the obligation as a FRESH must-answer model turn, which
+ * REGENERATED the whole answer — re-posting chunks 0,1's content the user already
+ * received. Result: the user sees the head of the answer twice after a partial
+ * failure (or after a restart mid-delivery). #3282.
+ *
+ * ── The fix (design-of-record §2.2) ─────────────────────────────────────────
+ * Make the re-present a *byte-identical captured-answer resume* of ONLY the
+ * not-yet-`landed-confirmed` tail — never a regeneration — so a chunk that
+ * already reached the chat is provably never re-posted:
+ *
+ *   1. On a partial (`!delivered`) turn-flush, persist a {@link
+ *      CapturedDeliverySnapshot} (the split chunks + each landed chunk's ids and
+ *      confirmed flag) onto the durable obligation record, keyed by
+ *      `originTurnId`. This rides the obligation ledger's existing atomic
+ *      snapshot, so it survives a gateway/container restart.
+ *   2. The obligation sweep's `represent` branch becomes source-aware: when the
+ *      obligation carries a captured-delivery snapshot it drives THIS resume
+ *      (re-run `runBackstopDelivery` for the SAME `turnId` and the SAME captured
+ *      chunks, resuming at the first non-`landed-confirmed` index) instead of
+ *      pushing a fresh-generation inbound. No snapshot ⇒ the genuine "model wrote
+ *      nothing / never fired a backstop" case falls through to fresh generation
+ *      unchanged.
+ *   3. The in-memory ledger is rehydrated from the snapshot AND reconciled against
+ *      the durable outbound-text oracle (`hasOutboundWithText`), so a chunk that
+ *      landed a durable history row is confirmed even if the snapshot's flag was
+ *      not yet flushed when the process died (crash-idempotency, design §2.3/A5).
+ *
+ * Chunk identity is the chunk INDEX within `turnId`, stable across the represent
+ * boundary and across restart because the resume re-delivers the exact captured
+ * chunks (not a regenerated answer). #3278's per-chunk state machine
+ * (`unsent → pending → landed-unconfirmed → {landed-confirmed | unsent}`) binds
+ * here too: the resume re-PROBES `landed-unconfirmed` chunks (never re-sends
+ * them) and re-SENDS only `unsent` ones, so a confirmed chunk is never duplicated
+ * by either the in-fire retry OR the cross-represent resume.
+ *
+ * This module is PURE state + orchestration over injected effects — no Telegram,
+ * no SQLite, no gateway module state — so the resume decision is unit-testable
+ * (see tests/captured-answer-resume.test.ts). The gateway owns the real
+ * `deliver` (via `deliverAnswer`), the durable oracle, and the obligation I/O.
+ */
+
+import { hasOutboundWithText } from '../history.js'
+import type { BackstopDeliveryLedger } from './backstop-delivery.js'
+import type { CapturedDeliverySnapshot, Obligation } from './obligation-ledger.js'
+
+/**
+ * Build the durable {@link CapturedDeliverySnapshot} from the live per-chunk
+ * ledger after a partial `runBackstopDelivery`. Captures every LANDED chunk's
+ * message ids + confirmed flag so the resume can (a) never re-send a confirmed
+ * chunk and (b) re-PROBE a landed-unconfirmed chunk instead of blindly re-sending
+ * it. Chunks that never landed (send threw) are simply absent → the resume treats
+ * them as `unsent` and re-sends them. Pure.
+ */
+export function buildCapturedDeliverySnapshot(
+  ledger: BackstopDeliveryLedger,
+  turnId: string,
+  chunks: readonly string[],
+): CapturedDeliverySnapshot {
+  const chunkStates = ledger.entries(turnId).map(({ index, messageIds }) => ({
+    index,
+    messageIds,
+    confirmed: ledger.hasConfirmedChunk(turnId, index),
+  }))
+  return { chunks: [...chunks], chunkStates }
+}
+
+/**
+ * Rehydrate a `BackstopDeliveryLedger` for a captured-answer resume from a
+ * durable snapshot, reconciled against the durable outbound-text oracle. For each
+ * landed chunk in the snapshot:
+ *   - re-record its landed message id(s) so `unsentIndices` excludes it (the
+ *     resume never re-sends a chunk that already landed);
+ *   - mark it `landed-confirmed` when the snapshot flag says so OR the oracle
+ *     proves its text is a durable outbound row (crash-idempotency, §2.3/A5) —
+ *     a confirmed chunk is neither re-probed nor re-sent.
+ * Chunks absent from the snapshot stay `unsent` (re-sent by the resume). Pure over
+ * the injected `hasLanded` oracle.
+ */
+export function hydrateResumeLedger(
+  ledger: BackstopDeliveryLedger,
+  turnId: string,
+  snapshot: CapturedDeliverySnapshot,
+  hasLanded: (chunkText: string, index: number) => boolean,
+): void {
+  for (const st of snapshot.chunkStates) {
+    if (st.messageIds.length === 0) continue // never actually landed → leave unsent
+    ledger.recordChunk(turnId, st.index, [...st.messageIds])
+    if (st.confirmed || hasLanded(snapshot.chunks[st.index] ?? '', st.index)) {
+      ledger.confirmChunk(turnId, st.index)
+    }
+  }
+}
+
+/** The args the module hands the gateway's `deliverAnswer` to run a resume. */
+export interface CapturedResumeArgs {
+  chatId: string
+  threadId: number | undefined
+  text: string
+  turnId: string
+  cardMessageId: number | null
+  replyToMessageId: number | null
+  resume: {
+    snapshot: CapturedDeliverySnapshot
+    hydrate: (ledger: BackstopDeliveryLedger, turnId: string) => void
+  }
+}
+
+/**
+ * The RAW gateway singletons the dispatcher wires. Structural (no gateway class
+ * imports) and kept minimal so the gateway injection stays a handful of lines
+ * under the gateway.ts line ratchet — the module builds every resume closure
+ * (the `deliverAnswer` resume args, the oracle-reconciled hydrate, the supersede
+ * record) itself.
+ */
+export interface CapturedResumePorts {
+  /** The gateway's `deliverAnswer`, invoked in RESUME mode (byte-identical tail,
+   *  no card gate). Only `delivered`/`sentIds` are read. */
+  deliverAnswer: (args: CapturedResumeArgs) => Promise<{ delivered: boolean; sentIds: number[] }>
+  /** The single obligation ledger. `markRepresented` consumes one represent-budget
+   *  unit + stamps the per-represent grace (bounding the resume ladder exactly
+   *  like a fresh-generation represent → escalate at the cap); `close` drops the
+   *  captured snapshot once fully delivered. */
+  obligationLedger: {
+    markRepresented: (originTurnId: string) => unknown
+    close: (originTurnId: string) => unknown
+  }
+  /** The per-chunk backstop ledger — GC'd for a fully delivered turn. */
+  backstopDeliveryLedger: { clear: (turnId: string) => void }
+  /** flushedTurnSupersede — feed the resume's fresh chat ids in so a late reply
+   *  after the resumed tail still corrects the delivered set (design §4). */
+  flushedTurnSupersede: {
+    record: (
+      chatId: string,
+      threadId: number | undefined,
+      rec: { turnId: string; messageIds: number[]; text: string },
+      nowMs: number,
+    ) => void
+  }
+  /** True when history is queryable (else the durable-text oracle reconcile that
+   *  gives crash-idempotency — §2.3/A5 — is skipped). */
+  historyEnabled: boolean
+  stderr?: (s: string) => void
+}
+
+export interface CapturedResumeDispatcher {
+  /** Fire a captured-answer resume for `o` (fire-and-forget; the sweep is sync).
+   *  De-duped per `originTurnId` so two sweeps never launch concurrent resumes;
+   *  a no-op when `o` carries no non-empty captured snapshot (the caller should
+   *  then fall through to fresh generation). */
+  dispatch: (o: Obligation) => void
+  /** In-flight origin ids (test introspection). */
+  inFlight: () => string[]
+}
+
+/**
+ * The obligation-sweep's captured-answer resume driver. Owns the in-flight guard
+ * + the deliver→close/leave-open orchestration so the gateway sweep stays a
+ * two-line dispatch. On each dispatch it consumes one represent-budget unit
+ * (bounding the ladder → escalate), re-delivers only the non-confirmed tail, and:
+ *   - fully delivered ⇒ record the supersede tail, close the obligation, GC the
+ *     ledger (the represent ladder stops);
+ *   - still partial / error ⇒ leave the obligation OPEN so the next eligible
+ *     sweep (after the per-represent grace) retries, until the represent cap
+ *     escalates it to the operator nudge — no infinite loop.
+ */
+export function createCapturedResumeDispatcher(ports: CapturedResumePorts): CapturedResumeDispatcher {
+  const stderr = ports.stderr ?? (() => {})
+  const inFlight = new Set<string>()
+
+  /** Re-deliver the non-confirmed tail of `o`'s captured answer, byte-identical,
+   *  by rehydrating the per-chunk ledger from the snapshot reconciled against the
+   *  durable text oracle. Never regenerates. */
+  function deliver(o: Obligation, snapshot: CapturedDeliverySnapshot): Promise<{ delivered: boolean; sentIds: number[] }> {
+    return ports.deliverAnswer({
+      chatId: o.chatId,
+      threadId: o.threadId,
+      text: '',
+      turnId: o.originTurnId,
+      cardMessageId: null,
+      replyToMessageId: o.messageId,
+      resume: {
+        snapshot,
+        hydrate: (ledger, turnId) =>
+          hydrateResumeLedger(ledger, turnId, snapshot, (txt) =>
+            ports.historyEnabled &&
+            hasOutboundWithText(o.chatId, txt, o.threadId ?? null, o.openedAt),
+          ),
+      },
+    })
+  }
+
+  /** Record the resume's FULL delivered id set (rehydrated-confirmed + freshly
+   *  re-sent — `runBackstopDelivery` returns `ledger.sentIds`, i.e. all landed
+   *  ids in index order) into the supersede lane, keyed by the turn id. This
+   *  REPLACES the partial turn-flush record in place with the complete set, so a
+   *  late reply for this turn corrects the WHOLE delivered answer (design §4) —
+   *  no-op when nothing has landed. */
+  function supersede(o: Obligation, snapshot: CapturedDeliverySnapshot, sentIds: number[]): void {
+    if (sentIds.length === 0) return
+    ports.flushedTurnSupersede.record(
+      o.chatId,
+      o.threadId,
+      { turnId: o.originTurnId, messageIds: sentIds, text: snapshot.chunks.join('') },
+      Date.now(),
+    )
+  }
+
+  async function run(o: Obligation, snapshot: CapturedDeliverySnapshot): Promise<void> {
+    try {
+      const { delivered, sentIds } = await deliver(o, snapshot)
+      supersede(o, snapshot, sentIds)
+      if (delivered) {
+        ports.obligationLedger.close(o.originTurnId)
+        ports.backstopDeliveryLedger.clear(o.originTurnId)
+        stderr(
+          `telegram gateway: captured-answer resume delivered — origin=${o.originTurnId} ` +
+            `${sentIds.length} chunk(s) confirmed; obligation closed\n`,
+        )
+      } else {
+        // Tail still not confirmed — leave the obligation OPEN for the next paced
+        // sweep / escalation (bounded by the represent cap).
+        stderr(
+          `telegram gateway: captured-answer resume partial — origin=${o.originTurnId} ` +
+            `tail still not confirmed; left OPEN for retry\n`,
+        )
+      }
+    } catch (err) {
+      stderr(
+        `telegram gateway: captured-answer resume error — origin=${o.originTurnId}: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      )
+    } finally {
+      inFlight.delete(o.originTurnId)
+    }
+  }
+
+  return {
+    dispatch(o: Obligation): void {
+      const snapshot = o.capturedDelivery
+      if (snapshot == null || snapshot.chunks.length === 0) return
+      if (inFlight.has(o.originTurnId)) return
+      inFlight.add(o.originTurnId)
+      // Consume represent budget + arm the per-represent grace up front so the
+      // ladder is bounded and the sweep can't immediately re-dispatch mid-flight.
+      ports.obligationLedger.markRepresented(o.originTurnId)
+      void run(o, snapshot)
+    },
+    inFlight: () => [...inFlight],
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -569,8 +569,10 @@ import {
   ObligationLedger,
   buildObligationRepresentInbound,
   obligationEscalationText,
+  type CapturedDeliverySnapshot,
 } from './obligation-ledger.js'
 import { loadObligations, persistObligations } from './obligation-store.js'
+import { buildCapturedDeliverySnapshot, createCapturedResumeDispatcher } from './captured-answer-resume.js'
 import {
   loadStatusPins,
   mutateStatusPinRow,
@@ -2331,12 +2333,14 @@ async function deliverAnswer(args: {
    *  the send alive if the user deleted their message. Null for synthesized
    *  turns (cron/handback) — those send bare, as before. */
   replyToMessageId: number | null
+  /** #3282 captured-answer RESUME (see captured-answer-resume.ts): re-deliver the SAME byte-identical chunks + pre-hydrate the ledger (non-confirmed tail only). */
+  resume?: { snapshot: CapturedDeliverySnapshot; hydrate: (ledger: BackstopDeliveryLedger, turnId: string) => void }
 }): Promise<{ sentIds: number[]; chunkCount: number; delivered: boolean; exhausted: boolean }> {
   const { chatId, turnId } = args
-  // Inject visible blank-line spacers into `\n\n` gaps, then split — exactly as
-  // executeReply does on the non-literal path (idempotent, one U+00A0 per gap).
-  const rendered = addParagraphSpacers(args.text)
-  const chunks = splitMarkdownChunks(rendered, RICH_MESSAGE_MAX_CHARS)
+  // Spacers into `\n\n` gaps then split (as executeReply); a resume re-delivers the EXACT captured chunks (byte-stable, no re-split).
+  const chunks = args.resume
+    ? args.resume.snapshot.chunks
+    : splitMarkdownChunks(addParagraphSpacers(args.text), RICH_MESSAGE_MAX_CHARS)
 
   const deps: ReplyChunkSendDeps = {
     sendRich: (opts, body, tid) =>
@@ -2427,6 +2431,9 @@ async function deliverAnswer(args: {
     threadId: args.threadId,
   })
 
+  // #3282 — a resume pre-hydrates the ledger (confirmed chunks never re-sent).
+  if (args.resume) args.resume.hydrate(backstopDeliveryLedger, turnId)
+
   // Bounded in-turn retry (finding-1 fix): resumes at the first unsent chunk on
   // each attempt via the ledger, so chunk 0 is delivered exactly once even
   // across retries. `delivered`/`exhausted` tell the caller whether the answer
@@ -2436,7 +2443,7 @@ async function deliverAnswer(args: {
     backstopDeliveryLedger,
     turnId,
     chunks,
-    args.cardMessageId,
+    args.resume ? null : args.cardMessageId,
     {
       sendChunk,
       readBack,
@@ -2456,6 +2463,9 @@ async function deliverAnswer(args: {
     },
     BACKSTOP_DELIVERY_MAX_ATTEMPTS,
   )
+  // #3282 — on a PARTIAL first-delivery, persist the per-chunk snapshot onto the still-OPEN obligation so the represent resumes the tail (not a regeneration).
+  if (!args.resume && !result.delivered && OBLIGATION_LEDGER_ENABLED)
+    obligationLedger.noteCapturedDelivery(turnId, buildCapturedDeliverySnapshot(backstopDeliveryLedger, turnId, chunks))
   return {
     sentIds: result.sentIds,
     chunkCount: result.chunkCount,
@@ -2722,6 +2732,12 @@ if (isGatewayMain && !STATIC && OBLIGATION_LEDGER_ENABLED) {
 // firing a second concurrent send for the same obligation while the first is
 // still awaiting (an escalation that takes >5s, or repeated failures).
 const obligationEscalateInFlight = new Set<string>()
+
+// #3282 — captured-answer resume driver (orchestration in the extracted module).
+const capturedResume = createCapturedResumeDispatcher({
+  deliverAnswer: (a) => deliverAnswer(a), obligationLedger, backstopDeliveryLedger,
+  flushedTurnSupersede, historyEnabled: HISTORY_ENABLED,
+})
 
 // ─── Serialize-until-replied (multitopic reply-routing) ───────────────────
 // Component 1 (deliver-before-drain gate). A buffered cross-topic inbound
@@ -10859,6 +10875,8 @@ function obligationSweep(): void {
       obligationLedger.close(o.originTurnId)
       return
     }
+    // #3282 — source-aware represent: a captured snapshot ⇒ resume the non-confirmed tail byte-identically; no snapshot ⇒ the fresh-generation represent below.
+    if (o.capturedDelivery != null) { capturedResume.dispatch(o); return }
     // Re-present goes through the bridge → buffer. Only the represent path is
     // gated on an empty buffer (let the existing drain run first, avoid
     // double-presenting). Escalation below is NOT gated on the buffer — it is a
@@ -17718,8 +17736,8 @@ function handleSessionEvent(ev: SessionEvent): void {
               }
               emitTurnRecord(turn, backstopTurnEndedAt)
             }
-            // GC the ledger only now — after success OR retry exhaustion — so a
-            // resume could always read prior progress up to this point.
+            // GC the IN-MEMORY ledger now; on a partial, deliverAnswer already
+            // persisted the snapshot to the durable obligation (#3282) to resume.
             backstopDeliveryLedger.clear(turn.turnId)
           }
           // #2094 cosmetic: the trailing `finally { purgeReactionTracking() }`

--- a/telegram-plugin/gateway/obligation-ledger.ts
+++ b/telegram-plugin/gateway/obligation-ledger.ts
@@ -26,6 +26,28 @@
 
 import type { InboundMessage } from './ipc-protocol.js'
 
+/**
+ * #3282 — the durable per-chunk snapshot of a PARTIALLY delivered backstop
+ * answer, attached to the obligation so the represent can resume the exact
+ * captured answer's non-`landed-confirmed` tail (byte-identical) instead of
+ * regenerating it (which re-posts chunks that already landed). Rides the
+ * obligation ledger's atomic snapshot, so it survives a gateway/container
+ * restart. See captured-answer-resume.ts for the resume mechanism.
+ */
+export interface CapturedDeliverySnapshot {
+  /** The byte-identical captured answer, split into chunks (the SAME split the
+   *  original backstop delivery used). Re-delivered verbatim on resume. */
+  readonly chunks: string[]
+  /** Per-LANDED-chunk state: the landed message id(s) + whether a read-back
+   *  confirmed the message exists. A chunk absent here never landed → the resume
+   *  treats it as `unsent` and re-sends it. */
+  readonly chunkStates: Array<{
+    readonly index: number
+    readonly messageIds: number[]
+    readonly confirmed: boolean
+  }>
+}
+
 export interface Obligation {
   /** deriveTurnId(chat, thread, messageId) — the stable identity. */
   readonly originTurnId: string
@@ -61,6 +83,12 @@ export interface Obligation {
    *  re-present/escalate when the sweep fires < 5s later. Durable (part of the
    *  snapshot) so the grace window survives a restart. */
   lastRepresentedAt?: number
+  /** #3282 — durable captured-answer snapshot for a PARTIALLY delivered backstop
+   *  answer. Present ⇒ the represent branch drives a byte-identical captured-answer
+   *  RESUME of the non-confirmed tail (never a regeneration); absent ⇒ the genuine
+   *  "model wrote nothing" represent falls through to fresh generation. Dropped
+   *  with the obligation on close/escalate (bounded lifetime, design A6). */
+  capturedDelivery?: CapturedDeliverySnapshot
 }
 
 /** What the gateway should do for the oldest open obligation at an idle boundary. */
@@ -314,6 +342,20 @@ export class ObligationLedger {
     if (routedOriginId != null) return routedOriginId
     if (liveTurnId != null && this.open.has(liveTurnId)) return liveTurnId
     return null
+  }
+
+  /**
+   * #3282 — attach (or refresh) the durable captured-answer snapshot for a
+   * PARTIALLY delivered backstop answer. No-op if the obligation isn't open (a
+   * fully delivered turn closes its obligation, so there is nothing to resume).
+   * Persists, so the snapshot survives a restart and the represent resumes the
+   * missing tail instead of regenerating the whole answer.
+   */
+  noteCapturedDelivery(originTurnId: string, snapshot: CapturedDeliverySnapshot): void {
+    const o = this.open.get(originTurnId)
+    if (o === undefined || snapshot.chunks.length === 0) return
+    o.capturedDelivery = snapshot
+    this.persist()
   }
 
   /** Record that an obligation was just re-presented (bumps representCount, stamps

--- a/telegram-plugin/gateway/obligation-store.ts
+++ b/telegram-plugin/gateway/obligation-store.ts
@@ -56,6 +56,42 @@ function isObligationRow(x: unknown): x is Obligation {
 }
 
 /**
+ * #3282 — true iff the optional captured-answer snapshot is structurally sound.
+ * A malformed blob (partial write, forward-incompatible shape) must NOT crash the
+ * resume: `sanitizeCapturedDelivery` strips it, so the obligation degrades to a
+ * fresh-generation represent (today's behaviour) rather than throwing.
+ */
+function isValidCapturedDelivery(x: unknown): boolean {
+  if (x == null || typeof x !== 'object') return false
+  const c = x as Record<string, unknown>
+  // Empty chunks ⇒ nothing to resume: treat as malformed so it is STRIPPED and
+  // the obligation degrades to a (bounded) fresh-generation represent rather than
+  // sitting non-null-but-empty and no-op'ing the sweep forever.
+  if (!Array.isArray(c.chunks) || c.chunks.length === 0 || !c.chunks.every((t) => typeof t === 'string')) return false
+  if (!Array.isArray(c.chunkStates)) return false
+  return c.chunkStates.every((s) => {
+    if (s == null || typeof s !== 'object') return false
+    const st = s as Record<string, unknown>
+    return (
+      typeof st.index === 'number' &&
+      typeof st.confirmed === 'boolean' &&
+      Array.isArray(st.messageIds) &&
+      st.messageIds.every((m) => typeof m === 'number')
+    )
+  })
+}
+
+/** Drop a malformed `capturedDelivery` in place so a corrupt snapshot degrades to
+ *  fresh-generation represent instead of crashing the resume (fail-open). */
+function sanitizeCapturedDelivery(o: Obligation): Obligation {
+  if (o.capturedDelivery != null && !isValidCapturedDelivery(o.capturedDelivery)) {
+    const { capturedDelivery: _drop, ...rest } = o
+    return rest
+  }
+  return o
+}
+
+/**
  * Load the persisted open set. Returns [] on a missing, unreadable, or
  * malformed file (fail-open to empty: a corrupt snapshot must never crash boot;
  * worst case we lose the cross-restart obligation guarantee for that boot and
@@ -78,7 +114,7 @@ export function loadObligations(path: string, fs: ObligationStoreFsSeam): Obliga
   if (parsed == null || typeof parsed !== 'object') return []
   const env = parsed as Record<string, unknown>
   if (env.v !== 1 || !Array.isArray(env.obligations)) return []
-  return env.obligations.filter(isObligationRow)
+  return env.obligations.filter(isObligationRow).map(sanitizeCapturedDelivery)
 }
 
 /**

--- a/telegram-plugin/tests/captured-answer-resume.test.ts
+++ b/telegram-plugin/tests/captured-answer-resume.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// The dispatcher's resume closure reaches for the durable outbound-text oracle
+// (history.hasOutboundWithText) to reconcile crash-idempotency. Mock it so these
+// stay pure vitest unit tests (no bun:sqlite / real DB) and we can control the
+// "did this chunk's text land durably?" answer per scenario.
+let mockOracle: (chatId: string, text: string, threadId: number | null, since: number) => boolean = () => false
+vi.mock('../history.js', () => ({
+  hasOutboundWithText: (chatId: string, text: string, threadId: number | null, since: number) =>
+    mockOracle(chatId, text, threadId, since),
+}))
+
+import {
+  BackstopDeliveryLedger,
+  runBackstopDelivery,
+  type ReadBackResult,
+} from '../gateway/backstop-delivery.js'
+import { ObligationLedger, type Obligation } from '../gateway/obligation-ledger.js'
+import {
+  buildCapturedDeliverySnapshot,
+  hydrateResumeLedger,
+  createCapturedResumeDispatcher,
+  type CapturedResumeArgs,
+} from '../gateway/captured-answer-resume.js'
+
+/**
+ * #3282 — a partial turn-flush backstop that left an obligation OPEN used to be
+ * re-presented as a FRESH model generation, re-posting chunks that already
+ * landed (the user saw the head of the answer twice). These assert the
+ * deterministic OUTCOME of the fix — the represent is now a byte-identical
+ * captured-answer RESUME of ONLY the non-`landed-confirmed` tail:
+ *   (a) 3-chunk answer, tail fails ⇒ resume sends EXACTLY the unlanded tail,
+ *       chunk 0 is NEVER re-sent, and the chat ends with each chunk once;
+ *   (b) a restart between landing and confirmation does NOT re-send a chunk the
+ *       durable oracle proves landed;
+ *   (c) a fully-landed answer's represent sends NOTHING.
+ * A test that would still pass if the resume re-sent a confirmed chunk is not a
+ * test — every scenario asserts the exact `sendChunk` index set.
+ */
+
+beforeEach(() => {
+  mockOracle = () => false
+})
+
+function obligation(over: Partial<Obligation> = {}): Obligation {
+  return {
+    originTurnId: '#t1',
+    chatId: '900',
+    threadId: undefined,
+    messageId: 42,
+    text: 'the question',
+    openedAt: 1000,
+    representCount: 0,
+    ...over,
+  }
+}
+
+/** Simulate the ORIGINAL partial backstop delivery into `ledger`, then snapshot
+ *  it — the exact input the represent resume consumes. `landPlan(i)` returns the
+ *  per-chunk behavior: 'ok' (lands + confirms), 'throw' (send fails → unsent),
+ *  or 'unconfirmed' (lands but read-back ambiguous → landed-unconfirmed). */
+async function seedPartial(
+  ledger: BackstopDeliveryLedger,
+  turnId: string,
+  chunks: string[],
+  landPlan: (i: number) => 'ok' | 'throw' | 'unconfirmed',
+): Promise<void> {
+  await runBackstopDelivery(
+    ledger,
+    turnId,
+    chunks,
+    null,
+    {
+      sendChunk: async (i: number) => {
+        if (landPlan(i) === 'throw') throw new Error('FLOOD_WAIT_ACTIVE')
+        return [5000 + i]
+      },
+      readBack: async (i: number): Promise<ReadBackResult> =>
+        landPlan(i) === 'unconfirmed' ? 'ambiguous' : 'exists',
+    },
+    1, // a single attempt → a genuine partial (no in-fire retry masking it)
+  )
+}
+
+/** A fake `deliverAnswer` that faithfully replicates the gateway's RESUME path:
+ *  run the injected `hydrate`, then `runBackstopDelivery` over the captured
+ *  chunks with a `sendChunk` that records which indices are (re-)sent. */
+function makeResumeDeliverAnswer(ledger: BackstopDeliveryLedger, sentIdx: number[]) {
+  return async (a: CapturedResumeArgs): Promise<{ delivered: boolean; sentIds: number[] }> => {
+    a.resume.hydrate(ledger, a.turnId)
+    const res = await runBackstopDelivery(
+      ledger,
+      a.turnId,
+      a.resume.snapshot.chunks,
+      a.cardMessageId,
+      {
+        sendChunk: async (i: number) => {
+          sentIdx.push(i)
+          return [7000 + i]
+        },
+        readBack: async (): Promise<ReadBackResult> => 'exists',
+      },
+      3,
+    )
+    return { delivered: res.delivered, sentIds: res.sentIds }
+  }
+}
+
+async function flush(dispatcher: { inFlight: () => string[] }): Promise<void> {
+  for (let i = 0; i < 50 && dispatcher.inFlight().length > 0; i++) {
+    await new Promise((r) => setTimeout(r, 0))
+  }
+}
+
+describe('#3282 buildCapturedDeliverySnapshot — captures per-chunk landed state', () => {
+  it('captures landed chunks (ids + confirmed flag); an unsent chunk is absent', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const chunks = ['c0', 'c1', 'c2']
+    // chunk 0 confirmed, chunk 1 landed-unconfirmed, chunk 2 never sent.
+    await seedPartial(ledger, '#s', chunks, (i) => (i === 0 ? 'ok' : i === 1 ? 'unconfirmed' : 'throw'))
+    const snap = buildCapturedDeliverySnapshot(ledger, '#s', chunks)
+    expect(snap.chunks).toEqual(chunks)
+    const byIndex = Object.fromEntries(snap.chunkStates.map((s) => [s.index, s]))
+    expect(byIndex[0]).toMatchObject({ index: 0, confirmed: true })
+    expect(byIndex[0].messageIds.length).toBeGreaterThan(0)
+    expect(byIndex[1]).toMatchObject({ index: 1, confirmed: false })
+    expect(byIndex[2]).toBeUndefined() // never landed → not in the snapshot
+  })
+})
+
+describe('#3282 hydrateResumeLedger — rebuilds ledger + oracle reconcile', () => {
+  it('confirmed chunk ⇒ excluded from the resume send set; unsent chunk ⇒ included', () => {
+    const l = new BackstopDeliveryLedger()
+    const snap = {
+      chunks: ['c0', 'c1', 'c2'],
+      chunkStates: [{ index: 0, messageIds: [10], confirmed: true }],
+    }
+    hydrateResumeLedger(l, '#h', snap, () => false)
+    expect(l.hasConfirmedChunk('#h', 0)).toBe(true)
+    // chunk 0 confirmed → not resent; chunks 1,2 unsent → the resume tail.
+    expect(l.unsentIndices('#h', 3)).toEqual([1, 2])
+  })
+
+  it('landed-unconfirmed chunk ⇒ re-PROBED (landedUnconfirmed), not re-sent', () => {
+    const l = new BackstopDeliveryLedger()
+    const snap = {
+      chunks: ['c0', 'c1'],
+      chunkStates: [{ index: 0, messageIds: [10], confirmed: false }],
+    }
+    hydrateResumeLedger(l, '#h', snap, () => false)
+    expect(l.landedUnconfirmedIndices('#h', 2)).toEqual([0]) // will be re-probed
+    expect(l.unsentIndices('#h', 2)).toEqual([1]) // only chunk 1 is unsent
+  })
+
+  it('oracle proves a landed-unconfirmed chunk landed ⇒ CONFIRMED (crash-idempotency A5)', () => {
+    const l = new BackstopDeliveryLedger()
+    const snap = {
+      chunks: ['c0', 'c1'],
+      chunkStates: [{ index: 0, messageIds: [10], confirmed: false }],
+    }
+    // The durable outbound row for c0 exists → confirm without re-probe/re-send.
+    hydrateResumeLedger(l, '#h', snap, (txt) => txt === 'c0')
+    expect(l.hasConfirmedChunk('#h', 0)).toBe(true)
+    expect(l.landedUnconfirmedIndices('#h', 2)).toEqual([])
+    expect(l.unsentIndices('#h', 2)).toEqual([1])
+  })
+
+  it('a chunkState with no message ids is left unsent (never fabricates a landing)', () => {
+    const l = new BackstopDeliveryLedger()
+    const snap = { chunks: ['c0'], chunkStates: [{ index: 0, messageIds: [], confirmed: false }] }
+    hydrateResumeLedger(l, '#h', snap, () => false)
+    expect(l.unsentIndices('#h', 1)).toEqual([0])
+  })
+})
+
+describe('#3282 createCapturedResumeDispatcher — the represent RESUME outcome', () => {
+  it('(a) partial [0 confirmed, 1+2 unsent] ⇒ resume sends EXACTLY [1,2]; chunk 0 never re-sent; each chunk once', async () => {
+    const chunks = ['c0', 'c1', 'c2']
+    // Original delivery: chunk 0 lands+confirms, chunks 1,2 fail (unsent).
+    const orig = new BackstopDeliveryLedger()
+    await seedPartial(orig, '#t1', chunks, (i) => (i === 0 ? 'ok' : 'throw'))
+    const snapshot = buildCapturedDeliverySnapshot(orig, '#t1', chunks)
+    orig.clear('#t1') // the turn-flush GCs the in-memory ledger (state is durable)
+
+    // The represent runs on a FRESH ledger (as after a sweep / restart).
+    const resumeLedger = new BackstopDeliveryLedger()
+    const sentIdx: number[] = []
+    const oblLedger = new ObligationLedger(2)
+    const supersedes: Array<{ ids: number[] }> = []
+    const o = obligation({ capturedDelivery: snapshot })
+    oblLedger.openIfAbsent(o)
+    oblLedger.noteCapturedDelivery('#t1', snapshot)
+
+    const dispatcher = createCapturedResumeDispatcher({
+      deliverAnswer: makeResumeDeliverAnswer(resumeLedger, sentIdx),
+      obligationLedger: oblLedger,
+      backstopDeliveryLedger: resumeLedger,
+      flushedTurnSupersede: { record: (_c, _t, rec) => supersedes.push({ ids: rec.messageIds }) },
+      historyEnabled: false,
+    })
+    dispatcher.dispatch(oblLedger.list()[0])
+    await flush(dispatcher)
+
+    // The core anti-regression assertion: ONLY the unlanded tail is (re-)sent.
+    expect(sentIdx.sort()).toEqual([1, 2])
+    expect(sentIdx).not.toContain(0) // chunk 0 (already landed) NEVER re-posted
+    expect(oblLedger.isOpen('#t1')).toBe(false) // fully delivered ⇒ closed
+    // §4 — the supersede record covers the WHOLE delivered set (original landed
+    // chunk 0's id 5000 + the resumed tail's ids), keyed by turn so a late reply
+    // corrects the complete answer in place.
+    expect(supersedes.at(-1)?.ids).toEqual([5000, 7001, 7002])
+  })
+
+  it('(b) restart between landing and confirmation ⇒ oracle-confirmed chunk NOT re-sent', async () => {
+    const chunks = ['c0', 'c1']
+    // Snapshot has chunk 0 landed-unconfirmed (crashed before read-back), chunk 1 unsent.
+    const snapshot = {
+      chunks,
+      chunkStates: [{ index: 0, messageIds: [5000], confirmed: false }],
+    }
+    const resumeLedger = new BackstopDeliveryLedger()
+    const sentIdx: number[] = []
+    const oblLedger = new ObligationLedger(2)
+    oblLedger.openIfAbsent(obligation({ capturedDelivery: snapshot }))
+    oblLedger.noteCapturedDelivery('#t1', snapshot)
+
+    // The durable oracle proves chunk 0's text landed → confirm, don't re-send.
+    mockOracle = (_c, txt) => txt === 'c0'
+
+    const dispatcher = createCapturedResumeDispatcher({
+      deliverAnswer: makeResumeDeliverAnswer(resumeLedger, sentIdx),
+      obligationLedger: oblLedger,
+      backstopDeliveryLedger: resumeLedger,
+      flushedTurnSupersede: { record: () => {} },
+      historyEnabled: true,
+    })
+    dispatcher.dispatch(oblLedger.list()[0])
+    await flush(dispatcher)
+
+    expect(sentIdx).toEqual([1]) // chunk 0 reconciled-confirmed, only chunk 1 sent
+    expect(sentIdx).not.toContain(0)
+    expect(oblLedger.isOpen('#t1')).toBe(false)
+  })
+
+  it('(c) fully-landed answer ⇒ resume sends NOTHING and closes the obligation', async () => {
+    const chunks = ['c0', 'c1']
+    const snapshot = {
+      chunks,
+      chunkStates: [
+        { index: 0, messageIds: [5000], confirmed: true },
+        { index: 1, messageIds: [5001], confirmed: true },
+      ],
+    }
+    const resumeLedger = new BackstopDeliveryLedger()
+    const sentIdx: number[] = []
+    const oblLedger = new ObligationLedger(2)
+    oblLedger.openIfAbsent(obligation({ capturedDelivery: snapshot }))
+    oblLedger.noteCapturedDelivery('#t1', snapshot)
+
+    const dispatcher = createCapturedResumeDispatcher({
+      deliverAnswer: makeResumeDeliverAnswer(resumeLedger, sentIdx),
+      obligationLedger: oblLedger,
+      backstopDeliveryLedger: resumeLedger,
+      flushedTurnSupersede: { record: () => {} },
+      historyEnabled: false,
+    })
+    dispatcher.dispatch(oblLedger.list()[0])
+    await flush(dispatcher)
+
+    expect(sentIdx).toEqual([]) // nothing re-posted
+    expect(oblLedger.isOpen('#t1')).toBe(false)
+  })
+
+  it('a partial RESUME (tail still fails) leaves the obligation OPEN + consumes represent budget', async () => {
+    const chunks = ['c0', 'c1']
+    const snapshot = {
+      chunks,
+      chunkStates: [{ index: 0, messageIds: [5000], confirmed: true }],
+    }
+    const resumeLedger = new BackstopDeliveryLedger()
+    const oblLedger = new ObligationLedger(2)
+    oblLedger.openIfAbsent(obligation({ capturedDelivery: snapshot }))
+    oblLedger.noteCapturedDelivery('#t1', snapshot)
+
+    // A resume whose tail send keeps throwing ⇒ not delivered ⇒ obligation stays OPEN.
+    const dispatcher = createCapturedResumeDispatcher({
+      deliverAnswer: async (a) => {
+        a.resume.hydrate(resumeLedger, a.turnId)
+        const res = await runBackstopDelivery(
+          resumeLedger, a.turnId, a.resume.snapshot.chunks, a.cardMessageId,
+          { sendChunk: async () => { throw new Error('FLOOD_WAIT_ACTIVE') }, readBack: async () => 'exists' as ReadBackResult },
+          2,
+        )
+        return { delivered: res.delivered, sentIds: res.sentIds }
+      },
+      obligationLedger: oblLedger,
+      backstopDeliveryLedger: resumeLedger,
+      flushedTurnSupersede: { record: () => {} },
+      historyEnabled: false,
+    })
+    dispatcher.dispatch(oblLedger.list()[0])
+    await flush(dispatcher)
+
+    expect(oblLedger.isOpen('#t1')).toBe(true) // left OPEN for the next paced sweep
+    expect(oblLedger.list()[0].representCount).toBe(1) // budget consumed → bounded ladder
+  })
+
+  it('de-dupes concurrent dispatches for the same origin (only one resume runs)', async () => {
+    const chunks = ['c0', 'c1']
+    const orig = new BackstopDeliveryLedger()
+    await seedPartial(orig, '#t1', chunks, (i) => (i === 0 ? 'ok' : 'throw'))
+    const snapshot = buildCapturedDeliverySnapshot(orig, '#t1', chunks)
+    orig.clear('#t1')
+
+    const resumeLedger = new BackstopDeliveryLedger()
+    let deliverCalls = 0
+    const oblLedger = new ObligationLedger(2)
+    oblLedger.openIfAbsent(obligation({ capturedDelivery: snapshot }))
+    oblLedger.noteCapturedDelivery('#t1', snapshot)
+
+    const dispatcher = createCapturedResumeDispatcher({
+      deliverAnswer: async (a) => {
+        deliverCalls++
+        a.resume.hydrate(resumeLedger, a.turnId)
+        const res = await runBackstopDelivery(
+          resumeLedger, a.turnId, a.resume.snapshot.chunks, a.cardMessageId,
+          { sendChunk: async (i: number) => [7000 + i], readBack: async () => 'exists' as ReadBackResult },
+          3,
+        )
+        return { delivered: res.delivered, sentIds: res.sentIds }
+      },
+      obligationLedger: oblLedger,
+      backstopDeliveryLedger: resumeLedger,
+      flushedTurnSupersede: { record: () => {} },
+      historyEnabled: false,
+    })
+    const o = oblLedger.list()[0]
+    dispatcher.dispatch(o)
+    dispatcher.dispatch(o) // second, concurrent — must be a no-op
+    await flush(dispatcher)
+    expect(deliverCalls).toBe(1)
+  })
+
+  it('no captured snapshot ⇒ dispatch is a no-op (caller falls through to fresh generation)', async () => {
+    let delivered = false
+    const dispatcher = createCapturedResumeDispatcher({
+      deliverAnswer: async () => { delivered = true; return { delivered: true, sentIds: [] } },
+      obligationLedger: new ObligationLedger(2),
+      backstopDeliveryLedger: new BackstopDeliveryLedger(),
+      flushedTurnSupersede: { record: () => {} },
+      historyEnabled: false,
+    })
+    dispatcher.dispatch(obligation()) // no capturedDelivery
+    dispatcher.dispatch(obligation({ capturedDelivery: { chunks: [], chunkStates: [] } })) // empty
+    await flush(dispatcher)
+    expect(delivered).toBe(false)
+  })
+})

--- a/telegram-plugin/tests/obligation-ledger.test.ts
+++ b/telegram-plugin/tests/obligation-ledger.test.ts
@@ -620,3 +620,43 @@ describe("ObligationLedger — escalation suppression predicate (Fix 4)", () => 
     expect(snapshots[1]).toEqual([]);
   });
 });
+
+// #3282 — the durable captured-answer snapshot attaches to the OPEN obligation
+// so a partial backstop delivery is resumed (tail only) rather than regenerated.
+describe("ObligationLedger — noteCapturedDelivery (#3282)", () => {
+  function input(id: string, openedAt: number) {
+    return { originTurnId: id, chatId: "-100123", threadId: 3, messageId: 1, text: "q", openedAt };
+  }
+  const snap = { chunks: ["c0", "c1"], chunkStates: [{ index: 0, messageIds: [10], confirmed: true }] };
+
+  it("attaches the snapshot to an OPEN obligation and persists it", () => {
+    const snapshots: Obligation[][] = [];
+    const L = new ObligationLedger(2, { onChange: (s) => snapshots.push(s) });
+    L.openIfAbsent(input("c:3#1", 1000));
+    L.noteCapturedDelivery("c:3#1", snap);
+    expect(L.list()[0]!.capturedDelivery).toEqual(snap);
+    // The mutation persisted (onChange fired again after open).
+    expect(snapshots.at(-1)![0]!.capturedDelivery).toEqual(snap);
+  });
+
+  it("is a no-op for an obligation that is not open (a delivered turn has none to resume)", () => {
+    const L = new ObligationLedger(2);
+    L.noteCapturedDelivery("c:3#missing", snap); // never opened
+    expect(L.isOpen("c:3#missing")).toBe(false);
+  });
+
+  it("ignores an EMPTY snapshot (nothing to resume)", () => {
+    const L = new ObligationLedger(2);
+    L.openIfAbsent(input("c:3#1", 1000));
+    L.noteCapturedDelivery("c:3#1", { chunks: [], chunkStates: [] });
+    expect(L.list()[0]!.capturedDelivery).toBeUndefined();
+  });
+
+  it("close drops the snapshot with the obligation (bounded lifetime, A6)", () => {
+    const L = new ObligationLedger(2);
+    L.openIfAbsent(input("c:3#1", 1000));
+    L.noteCapturedDelivery("c:3#1", snap);
+    expect(L.close("c:3#1")).toBe(true);
+    expect(L.isOpen("c:3#1")).toBe(false);
+  });
+});

--- a/telegram-plugin/tests/obligation-store.test.ts
+++ b/telegram-plugin/tests/obligation-store.test.ts
@@ -118,6 +118,49 @@ describe("obligation-store", () => {
     expect(loaded[0]!.representCount).toBe(1);
   });
 
+  it("round-trips a valid capturedDelivery snapshot through persist → load (#3282)", () => {
+    const { fs } = memFs();
+    const capturedDelivery = {
+      chunks: ["c0", "c1"],
+      chunkStates: [
+        { index: 0, messageIds: [10], confirmed: true },
+        { index: 1, messageIds: [11, 12], confirmed: false },
+      ],
+    };
+    persistObligations(PATH, fs, [ob("c:3#715", { capturedDelivery })]);
+    const loaded = loadObligations(PATH, fs);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]!.capturedDelivery).toEqual(capturedDelivery);
+  });
+
+  it("STRIPS a malformed capturedDelivery (fail-open to fresh-generation represent) (#3282)", () => {
+    // A partial write / forward-incompatible shape must not crash the resume: the
+    // row survives (obligation preserved), the bad blob is dropped.
+    const bad = {
+      v: 1,
+      obligations: [
+        { ...ob("c:3#715"), capturedDelivery: { chunks: "not-an-array", chunkStates: [] } },
+        { ...ob("c:3#716"), capturedDelivery: { chunks: ["c0"], chunkStates: [{ index: 0 }] } },
+      ],
+    };
+    const { fs } = memFs({ [PATH]: JSON.stringify(bad) });
+    const loaded = loadObligations(PATH, fs);
+    expect(loaded.map((o) => o.originTurnId)).toEqual(["c:3#715", "c:3#716"]);
+    expect(loaded[0]!.capturedDelivery).toBeUndefined();
+    expect(loaded[1]!.capturedDelivery).toBeUndefined();
+  });
+
+  it("STRIPS an empty-chunks capturedDelivery (nothing to resume → fresh-gen, bounded) (#3282)", () => {
+    const bad = {
+      v: 1,
+      obligations: [{ ...ob("c:3#715"), capturedDelivery: { chunks: [], chunkStates: [] } }],
+    };
+    const { fs } = memFs({ [PATH]: JSON.stringify(bad) });
+    const loaded = loadObligations(PATH, fs);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]!.capturedDelivery).toBeUndefined();
+  });
+
   it("never throws on a write failure — degrades to in-memory (logs)", () => {
     const logs: string[] = [];
     const fs: ObligationStoreFsSeam = {


### PR DESCRIPTION
## Summary

A **partial** turn-flush backstop delivery (chunks `0..k` land, the tail exhausts its bounded retries) left the delivery obligation OPEN, and the ~150s liveness floor re-presented it as a **fresh must-answer model turn** — regenerating the whole answer and **re-posting the chunks that already reached the chat**. The user saw the head of the answer twice after a partial failure or a restart mid-delivery (#3282).

This makes the re-present a **byte-identical captured-answer resume** of only the non-`landed-confirmed` tail, built directly on #3321's per-chunk confirmation state machine (`unsent → landed-unconfirmed → landed-confirmed`).

## Why (design of record — `DESIGN-delivery-fixes.md` §2, §3, §5)

- **§2.2 durable captured-answer resume, not chunk-index-into-a-fresh-turn.** The residual is the combination of the ledger being cleared on exhaustion *and* the represent being a fresh generation with no memory of what landed. The fix is a deterministic captured-answer replay of the missing tail, keyed on `originTurnId` — sound because it re-delivers the *same* bytes, not a regeneration (design §0/A4).
- **§2.3 durability / crash-safety.** The per-chunk snapshot rides the obligation ledger's existing atomic snapshot (survives restart); the resume rehydrates it and reconciles against the durable outbound-text oracle `hasOutboundWithText`, so a chunk whose row landed is confirmed even if its snapshot flag never flushed (A5).
- **§3 shared contract.** Resume re-sends only `unsent` chunks and re-PROBES `landed-unconfirmed` ones (never re-sends on ambiguous), so a confirmed chunk is provably never re-posted by either the in-fire retry or the cross-represent resume.
- **§2.4 / A6 pacing + bounded lifetime.** The resume consumes the represent budget (`markRepresented`) and inherits the per-represent grace; it escalates at the represent cap and the snapshot is dropped with the obligation on close/escalate — no infinite loop, no unbounded store.

## What changed

- `captured-answer-resume.ts` (new, extracted): `buildCapturedDeliverySnapshot`, `hydrateResumeLedger` (pure; oracle-reconciled), and `createCapturedResumeDispatcher` (in-flight-guarded deliver→close/leave-open orchestration).
- `obligation-ledger.ts`: `CapturedDeliverySnapshot` type + `noteCapturedDelivery` (durable, ignores empty / closed).
- `obligation-store.ts`: validate/sanitize the optional snapshot on load (fail-open — a malformed or empty blob is stripped → fresh-generation represent).
- `gateway.ts`: `deliverAnswer` gains a `resume?` mode + persists the snapshot on a partial; the sweep's `represent` branch is source-aware. Kept under the gateway line ratchet (30471 ≤ 30472) by moving all orchestration into the module.

## Test plan

New/extended vitest (all assert user-visible outcomes; each fails on the duplicate-posting bug):

- **`captured-answer-resume.test.ts`** — 3-chunk answer, tail fails ⇒ resume sends **exactly** the unlanded tail and chunk 0 is **never** re-posted (chat ends with each chunk once); restart between landing and confirmation ⇒ the oracle-confirmed chunk is **not** re-sent; a fully-landed answer's represent sends **nothing**; partial resume leaves the obligation OPEN + consumes budget; concurrent-dispatch de-dupe; supersede covers the full delivered set.
- **`obligation-ledger.test.ts` / `obligation-store.test.ts`** — `noteCapturedDelivery` attach/persist/no-op-when-closed/ignore-empty; snapshot round-trips through persist→load; malformed / empty snapshot stripped.
- Regression sweep green: obligation-ledger/-store/-determinism (3000-schedule fuzz)/-turn-end, backstop-delivery/-readback, represent-guard, turn-end-gate-backstop, outbound-send-path/-chunks. `npm run lint` clean (incl. `check-bot-api-wrapping`, gateway line ratchet).

## Risk

Behavior-changing bugfix, no refactor mixing. The fresh-generation represent path is unchanged when no snapshot exists (regression-guarded). Honest residual (follow-up): a crash *during* `runBackstopDelivery` (before it returns) leaves no snapshot, so that narrow window still falls back to fresh generation — strictly better than today, and the landed chunks already have durable rows for a future boot-reconcile enhancement.

Job spec: `reference/jobs/survive-reboots-and-real-life.md` (answers resume cleanly after a partial failure / restart; the user is never shown a duplicated or silently-dropped answer).

Closes #3282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)