### PR TITLE
test(gateway): fold P0d process-wiring into boot side-effect sentinels (#2996)

### DIFF
--- a/telegram-plugin/tests/gateway-boot-side-effect-gating.test.ts
+++ b/telegram-plugin/tests/gateway-boot-side-effect-gating.test.ts
@@ -5,36 +5,41 @@
  * `startGateway()` at the bottom of the file.
  *
  * WHY this asserts on the parsed SOURCE, not a real `import()`:
- * gateway.ts statically reaches modules whose bun:sqlite access + the still-
- * ungated P0d process-handler / reaction-sweep registrations make a hermetic
- * `await import()` under vitest impractical without heavy mocking (see the P0e
- * note in the PR). The repo's oracle for "pin gateway structure without booting
- * it" is source-parsing via `ts.createSourceFile` — the same pattern as
+ * the repo's oracle for "pin gateway structure without booting it" is
+ * source-parsing via `ts.createSourceFile` — the same pattern as
  * gateway-bot-construction-deferral.test.ts (P0b) and
- * gateway-handler-registration-wiring.test.ts (P0a). This test follows it and
- * asserts OUTCOMES:
+ * gateway-handler-registration-wiring.test.ts (P0a). (Since P0e, #3318, a
+ * hermetic `await import()` of gateway.ts does complete cleanly; upgrading
+ * this oracle to a real runtime import is possible but deliberately out of
+ * scope here — the source parse stays the pinned pattern.) This test follows
+ * it and asserts OUTCOMES:
  *
  *   1. `isGatewayMain` is a module-scope const whose value is the argv[1]
  *      main-check (true only when this module is the process entrypoint).
  *   2. The boot sequence is `async function startGateway()`, invoked EXACTLY
  *      once, and that sole invocation is guarded by `isGatewayMain`. The old
  *      top-level boot IIFE (`void (async () => …)()`) is gone.
- *   3. No UNGUARDED module-scope P0c side effect remains: every top-level
+ *   3. No UNGUARDED module-scope side effect remains: every top-level
  *      `setInterval` / `setTimeout` / `<x>.startTimer(…)` / `mkdirSync` /
  *      `runHistoryReaperNow` / `openTurnsDb` / `initHistory` /
  *      `acquireStartupLock` / `startWebhookIngestServer` /
- *      `createPollHealthCheck` / `loadObligations` call, and every module-scope
- *      `await`, sits inside an `isGatewayMain` guard (an `if (isGatewayMain …)`
- *      or an `isGatewayMain ? … : …` ternary) — or inside a function body.
+ *      `createPollHealthCheck` / `loadObligations` /
+ *      `installPosthogErrorHandlers` / `sweepActiveReactions` /
+ *      `process.on(…)` call, and every module-scope `await`, sits inside an
+ *      `isGatewayMain` guard (an `if (isGatewayMain …)` or an
+ *      `isGatewayMain ? … : …` ternary) — or inside a function body.
  *
  * A regression that re-hoists a timer, the startup-lock await, the boot IIFE,
  * or the turn-registry open back to unguarded module scope fails (3).
  *
- * OUT OF SCOPE (P0d, deliberately still unguarded — see the PR/issue): the
- * process signal/error handlers (`process.on('SIGTERM'|'SIGINT'|'beforeExit'|
- * 'unhandledRejection'|'uncaughtException')`, `installPosthogErrorHandlers()`)
- * and the startup reaction sweep (`sweepActiveReactions`). Those are NOT in the
- * sentinel set below.
+ * The process signal/error handlers (`process.on('SIGTERM'|'SIGINT'|
+ * 'beforeExit'|'unhandledRejection'|'uncaughtException')`,
+ * `installPosthogErrorHandlers()`) and the startup reaction sweep
+ * (`sweepActiveReactions`) — the "P0d" inventory from the P0c handback — were
+ * gated behind `isGatewayMain` by P0e (#3318, `ab34bb7b`) too; #2996 P0d was
+ * verified already-delivered and closed with no PR (plan Amendment 11). They
+ * ARE in the sentinel set below, so a regression that un-gates any of them
+ * back to bare module scope fails (3) as well.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -71,8 +76,9 @@ function lineOf(n: ts.Node): number {
   return sourceFile.getLineAndCharacterOfPosition(n.getStart(sourceFile)).line + 1
 }
 
-// The P0c-scoped side-effect sentinels. Each of these, at module scope, MUST be
-// isGatewayMain-guarded after P0c.
+// The side-effect sentinels. Each of these, at module scope, MUST be
+// isGatewayMain-guarded: the first block since P0c, the last two — the "P0d"
+// process-wiring inventory, gated by P0e (#3318) — since P0e.
 const CALL_SENTINELS = new Set([
   'setInterval',
   'setTimeout',
@@ -84,6 +90,8 @@ const CALL_SENTINELS = new Set([
   'startWebhookIngestServer',
   'createPollHealthCheck',
   'loadObligations',
+  'installPosthogErrorHandlers',
+  'sweepActiveReactions',
 ])
 
 function sentinelName(n: ts.Node): string | null {
@@ -93,6 +101,19 @@ function sentinelName(n: ts.Node): string | null {
     // `<obj>.startTimer(...)` — the silencePoke / pendingProgress timers.
     if (ts.isPropertyAccessExpression(e) && e.name.text === 'startTimer') {
       return `${e.expression.getText(sourceFile)}.startTimer`
+    }
+    // `process.on(...)` — the P0d signal/error-handler registrations
+    // (SIGTERM / SIGINT / beforeExit / unhandledRejection /
+    // uncaughtException), gated by P0e. Several route through shutdown() →
+    // process.exit, so an unguarded registration makes exit reachable from a
+    // bare import.
+    if (
+      ts.isPropertyAccessExpression(e) &&
+      e.name.text === 'on' &&
+      ts.isIdentifier(e.expression) &&
+      e.expression.text === 'process'
+    ) {
+      return 'process.on'
     }
   }
   if (n.kind === ts.SyntaxKind.AwaitExpression) return 'await'


### PR DESCRIPTION
## Summary
Single-concern test fix, follow-up to the #2996 P0d verification ([P0d phase comment](https://github.com/switchroom/switchroom/issues/2996#issuecomment-5010296655)): `telegram-plugin/tests/gateway-boot-side-effect-gating.test.ts` still described the process signal/error handlers (`SIGTERM`/`SIGINT`/`beforeExit`/`unhandledRejection`/`uncaughtException`, `installPosthogErrorHandlers`) and the startup reaction sweep (`sweepActiveReactions`) as "OUT OF SCOPE (P0d, deliberately still unguarded)" — stale wording shipped in the very commit (P0e #3318, `ab34bb7b`) that gated them all behind `isGatewayMain`. P0d was verified already-delivered by P0e (plan Amendment 11; no P0d PR).

- Header rewritten to describe reality (handlers gated by P0e; P0d closed as subsumed).
- The now-gated handlers are folded into the sentinel set: `installPosthogErrorHandlers`, `sweepActiveReactions`, plus a `process.on(...)` matcher in `sentinelName()`.

## Why
Without the sentinel additions the test passed vacuously w.r.t. this side-effect class — a regression un-gating a `process.on` handler (several route through `shutdown()` → `process.exit`, making exit reachable from a bare import) would NOT fail it. Now it asserts the outcome (CLAUDE.md: tests assert outcomes, not just code paths).

Deliberately NOT upgrading the source-parse oracle to a real `await import()` — single concern, noted in the header as possible-but-out-of-scope.

Job spec: `reference/jobs/` — reliability guard-rail on the gateway boot surface (#2996 decomposition series; same citation basis as P0a–P0e).

## Test plan
- `vitest run telegram-plugin/tests/gateway-boot-side-effect-gating.test.ts` → 5/5 pass.
- Negative proof: temporarily un-gating the SIGTERM/SIGINT block in gateway.ts makes the suite fail with `process.on@28404` (reverted; gateway.ts untouched in this PR).
- `npm run lint` fully clean (tsc + all 10 guard scripts; ratchet clean — gateway.ts untouched, 30471 lines, ratchet 30422).

## Risk
Minimal: test-only diff, one file. Worst case a false-positive sentinel hit on some future legitimate top-level `process.on` — which is exactly the review prompt we want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
