### PR TITLE
test(uat): fix four stale delivery-scenario oracles (v0.18.32 canary triage)

### DIFF
--- a/telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts
@@ -89,7 +89,17 @@ const BG_DISPATCH_PROMPT =
   `brief reply saying you've kicked off the background worker so I can ` +
   `watch the progress feed.`;
 
-const WORKER_RUNNING_RE = /running\s*·/i;
+// Single-worker RUNNING headers show NO literal "running" — they render
+// `<elapsed> · <n> tools[ · <tok> tok][ · <model>]`
+// (`tool-activity-summary.ts` renderActivityHeader, running branch); the
+// word "running" only appears on the MULTI-worker combined header
+// (`🛠 Workers · N running`). The old `/running\s*·/i` oracle matched only
+// by accident when the multi-worker header happened to render (failed live
+// 2026-07-18, ci-uat run 29634400115, against a healthy in-flight card).
+// In-flight signal = either header shape's live metric, paired with the
+// `not.toMatch(WORKER_DONE_RE)` terminal exclusion below — a skeleton that
+// paints only `🛠 Worker · <name>` with no metric line still fails.
+const WORKER_RUNNING_RE = /\brunning\b|·\s*\d+\s+tools?\b/i;
 const WORKER_DONE_RE = /finished\s*·\s*(completed|failed)/i;
 
 describe("uat: background sub-agent visibility (#709/#776/#782/#788)", () => {
@@ -117,9 +127,9 @@ describe("uat: background sub-agent visibility (#709/#776/#782/#788)", () => {
         expect(feed.messageId).toBeGreaterThan(0);
         expect(feed.text).toMatch(WORKER_FEED_RE);
 
-        // AC-2 step 1: feed body MUST show "running ·" (the in-flight
-        // status), NOT the terminal "finished ·" — the worker hasn't
-        // completed yet.
+        // AC-2 step 1: feed body MUST show an in-flight signal (live
+        // metric line, or multi-worker "N running"), NOT the terminal
+        // "finished ·" — the worker hasn't completed yet.
         expect(feed.text).toMatch(WORKER_RUNNING_RE);
         expect(feed.text).not.toMatch(WORKER_DONE_RE);
 

--- a/telegram-plugin/uat/scenarios/bridge-flap-resilience-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/bridge-flap-resilience-dm.test.ts
@@ -123,8 +123,18 @@ describe("uat: bridge-flap resilience — agent stays responsive, gateway does n
             `overall deadline hit before DM ${i} — earlier turns were too slow`,
           ).toBeGreaterThan(0);
 
+          // Skip empty-text observations: the Bot API cannot send an
+          // empty text message (Telegram rejects it), so an empty-text
+          // fromBot observation is by construction a SERVICE message —
+          // e.g. the `[pinned_message]` event from the progress-card pin.
+          // One of those latched here as "the reply" on 2026-07-18
+          // (ci-uat run 29634400115: pinChatMessage 06:54:36.420Z → rx
+          // [pinned_message] 06:54:37.012Z, exactly at the DM-2 failure).
+          // A genuinely eaten turn_end still fails loudly: no non-empty
+          // reply arrives and this expectMessage times out.
           const reply = await sc.expectMessage(
-            (m: ObservedMessage) => m.fromBot && !m.edited,
+            (m: ObservedMessage) =>
+              m.fromBot && !m.edited && m.text.length > 0,
             { from: "bot", timeout: remaining },
           );
           expect(

--- a/telegram-plugin/uat/scenarios/cross-turn-pending-progress-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/cross-turn-pending-progress-dm.test.ts
@@ -81,8 +81,16 @@ interface TrailEntry {
   text: string;
 }
 
+// Mirrors the production matcher (`pending-work-progress.ts` SUFFIX_RE):
+// the CURRENT emit is the italic rich-markdown form
+// `\n\n_still working (Nm) · message me anytime, I'll keep you posted_`
+// (#2669) — mtcute's parsed `Message.text` strips the italic markers, so
+// the observed text is `\n\nstill working (Nm) · …`. The legacy em-dash
+// prefix (`— still working`) and a literal-underscore render are also
+// tolerated. The old mandatory-em-dash regex could not match ANY current
+// production edit (stale oracle, diagnosed 2026-07-18).
 const SUFFIX_RE =
-  /\n\n— still working \(\d+m\)( · message me anytime, I'll keep you posted)?$/;
+  /\n\n(?:— |_)?still working \(\d+m\)( · message me anytime, I'll keep you posted)?_?$/;
 
 function pad(s: string, n: number): string {
   return s.length >= n ? s : s + " ".repeat(n - s.length);

--- a/telegram-plugin/uat/scenarios/jtbd-multipart-render-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-multipart-render-dm.test.ts
@@ -70,23 +70,47 @@ const TAIL = "MULTITAIL9";
 
 // We need the composed reply to exceed the 32768-char cap so the gateway
 // chunks it. Asking a model to emit ~40k literal chars is flaky (it'll
-// summarize or truncate). Instead we ask it to REPEAT a fixed, cheap-to-
-// generate padding block a deterministic number of times — a task an agent
-// reliably obeys because it's mechanical, not generative.
-const PAD_LINE = "The quick brown fox jumps over the lazy dog. ";
-// Overshoot the cap by a comfortable margin so a slightly-short reply still
-// splits: (cap / line) rounded up, times a 1.3 safety factor.
-const REPEATS = Math.ceil((RICH_MESSAGE_MAX_CHARS / PAD_LINE.length) * 1.3);
+// summarize or truncate). We keep the task MECHANICAL (cycle a fixed
+// sentence list, prefix each line with its index) so an agent reliably
+// obeys — but every emitted line is UNIQUE. Verbatim repetition of one
+// sentence 900+ times reads as degenerate output to Anthropic's content
+// filter and 4xx-kills the turn before any reply exists to send (observed
+// live 2026-07-18, ci-uat run 29634400115: four "unknown-4xx / Output
+// blocked by content filtering policy" events, gateway-supervisor.log
+// 06:43–06:53Z — the reply never reached the send path).
+const PAD_SENTENCES = [
+  "The quick brown fox jumps over the lazy dog.",
+  "Pack my box with five dozen liquor jugs.",
+  "How vexingly quick daft zebras jump.",
+  "Sphinx of black quartz, judge my vow.",
+  "The five boxing wizards jump quickly.",
+  "Jackdaws love my big sphinx of quartz.",
+  "Waltz, bad nymph, for quick jigs vex.",
+  "Glib jocks quiz nymph to vex dwarf.",
+  "Bright vixens jump; dozy fowl quack.",
+  "Quick zephyrs blow, vexing daft Jim.",
+];
+// Conservative per-line floor: the SHORTEST pad sentence plus the numeric
+// prefix. Overshoot the cap by a 1.3 safety factor so a slightly-short
+// reply still splits.
+const PER_LINE_MIN =
+  Math.min(...PAD_SENTENCES.map((s) => s.length)) + "Line 1: ".length;
+const LINE_COUNT = Math.ceil((RICH_MESSAGE_MAX_CHARS / PER_LINE_MIN) * 1.3);
 
 const PROMPT = [
   `I need a LONG reply to test message chunking. Do EXACTLY this, nothing else:`,
   ``,
   `1. Start your reply with: ${HEAD}: **head bold marker**`,
-  `2. Then output this exact sentence ${REPEATS} times, each on its own line:`,
-  `   "${PAD_LINE.trim()}"`,
+  `2. Then output ${LINE_COUNT} numbered lines. Line i (1-based) must be:`,
+  `   "Line i: " followed by sentence number (i mod 10) from this list`,
+  `   (list index 0-9):`,
+  ...PAD_SENTENCES.map((s, idx) => `     ${idx}: "${s}"`),
+  `   So line 1 is "Line 1: ${PAD_SENTENCES[1]}", line 2 is`,
+  `   "Line 2: ${PAD_SENTENCES[2]}", and so on, wrapping the list.`,
   `3. End your reply with: ${TAIL}: **tail bold marker**`,
   ``,
-  `Do not summarize or shorten. Emit all ${REPEATS} repetitions verbatim.`,
+  `Every line is unique because of its number. Do not summarize, do not`,
+  `stop early — emit all ${LINE_COUNT} lines.`,
 ].join("\n");
 
 function kinds(msg: ObservedMessage): Set<string> {


### PR DESCRIPTION
## Summary
Fixes the four test-side defects found in the adversarial UAT pass confirming release v0.18.32 on the canary (ci-uat run 29634400115). Test files only — no production code.

- **jtbd-multipart-render-dm** — filter-tolerant prompt: 991 unique numbered lines cycling 10 pangrams, replacing 947 verbatim repetitions of one sentence. The repeated form tripped Anthropic's output content filter (four `unknown-4xx / Output blocked by content filtering policy` events in the test-harness gateway log, 06:43–06:53Z 2026-07-18), so no long reply ever existed and the >32768-char chunk path (#3282's target surface) got zero live signal.
- **bg-sub-agent-dispatch-dm** — the `/running\s*·/i` oracle never matches the single-worker running header (`<elapsed> · <n> tools…`, `tool-activity-summary.ts` running branch — the literal word only appears on the multi-worker combined header). Replaced with the real in-flight signal per the prior diagnosis; the paired `WORKER_DONE_RE` exclusion keeps a bare skeleton red.
- **bridge-flap-resilience-dm** — reply matcher now skips empty-text observations: Bot API cannot send empty text, so an empty-text fromBot message is a service message (`[pinned_message]` from the progress-card pin), which latched as "the reply" for DM 2 in the canary run. An eaten turn_end still fails via expectMessage timeout.
- **cross-turn-pending-progress-dm** — `SUFFIX_RE` required the legacy em-dash `— still working` form; production emits the italic `_still working (Nm) · …_` since #2669 (`pending-work-progress.ts` SUFFIX_RE accepts both). Test now mirrors the production matcher, tolerant of mtcute's entity-stripped text.

## Why
These scenarios are the live gate for the delivery surfaces v0.18.32 touched (#3278/#3282/#3294/#3315/#3298/#2996). With stale oracles they red on healthy behavior, and the multipart prompt could never exercise the chunk path at all.

## Test plan
- `npm run lint` green (tsc + all 11 guards).
- All four files transpile clean (`bun build --no-bundle`); uat scenarios are outside tsc coverage and need live driver creds to execute, so CI + the follow-up scoped ci-uat dispatch on the canary are the live authority.
- Regex sanity verified: new WORKER_RUNNING_RE matches both header shapes and rejects a metric-less skeleton; new SUFFIX_RE matches plain/em-dash/underscore forms; new prompt computes 991 lines ≈ 48k chars > 32768 cap.

## Risk
Low — UAT test files only; scenarios self-skip without driver creds. Oracles were loosened only toward the real render contract, each keeping a paired negative assertion so the underlying bug class still fails.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md` (progress cards / render fidelity) — these scenarios are its live outcome tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)