### PR TITLE
fix(narrative-dedup): make REPLY_TOOLS matching prefix-aware (#3231)

### DIFF
--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -57,7 +57,7 @@ import { createAnswerStream } from '../answer-stream.js'
 import { LivenessTracker, isContextExhaustionText } from '../context-exhaustion.js'
 import { normalizeParagraphBreaks, normalizePunctuation, repairEscapedWhitespace, stripExcessBold } from '../format.js'
 import { hasOutboundDeliveredSince, recordOutbound } from '../history.js'
-import { REPLY_TOOLS } from '../narrative-dedup.js'
+import { isReplyTool } from '../narrative-dedup.js'
 import { NarrativeFlushController } from '../narrative-flush.js'
 import { recordTurnEnd, recordTurnStart } from '../registry/turns-schema.js'
 import { retryWithThreadFallback } from '../retry-api-call.js'
@@ -623,9 +623,10 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
         // text so flushPendingNarrativeAtTurnEnd compares a trailing
         // narrative block against the real answer surface, not
         // capturedText.join('') (which mis-suppresses when the model emits
-        // the same short string twice in a turn). REPLY_TOOLS ('reply',
+        // the same short string twice in a turn). Reply tools ('reply',
         // 'stream_reply') carry the answer in input.text; only those count.
-        if (REPLY_TOOLS.has(name) && typeof ev.input?.text === 'string') {
+        // Prefix-aware: prod jsonl carries the mcp__…__stream_reply form.
+        if (isReplyTool(name) && typeof ev.input?.text === 'string') {
           turn.lastReplyText = ev.input.text as string
         }
         if (turn.orphanedReplyTimeoutId != null) {

--- a/telegram-plugin/narrative-dedup.ts
+++ b/telegram-plugin/narrative-dedup.ts
@@ -25,8 +25,31 @@
  * message.
  */
 
-/** Tools whose `input.text` IS the canonical answer surface. */
+/** Tool suffixes whose `input.text` IS the canonical answer surface. */
 export const REPLY_TOOLS = new Set(['reply', 'stream_reply'])
+
+/**
+ * Strip this plugin's `mcp__<server-key>__telegram__` prefix, matched by the
+ * same key-agnostic regex `computeLabel` / `isTelegramReplyTool` use so renames
+ * and forks (`clerk-telegram`, `switchroom-telegram`, …) all resolve. A bare
+ * name (no prefix) is returned unchanged.
+ */
+const TELEGRAM_TOOL_PREFIX_RE = /^mcp__[^_].*?telegram__/
+
+/**
+ * Prefix-aware membership test for {@link REPLY_TOOLS}.
+ *
+ * Production jsonl carries the fully-qualified MCP tool name
+ * (`mcp__switchroom-telegram__stream_reply`), so a bare `REPLY_TOOLS.has(name)`
+ * is always false in prod and the draft-then-send suppression path silently
+ * goes inert (#3231). Bare names ('reply' / 'stream_reply') can still appear
+ * from non-MCP sources, so both wire shapes must match: strip the telegram MCP
+ * prefix (a no-op for bare names) then test the suffix against REPLY_TOOLS.
+ */
+export function isReplyTool(toolName: string | null | undefined): boolean {
+  if (typeof toolName !== 'string') return false
+  return REPLY_TOOLS.has(toolName.replace(TELEGRAM_TOOL_PREFIX_RE, ''))
+}
 
 /**
  * Normalize for prefix comparison: strip markdown/HTML-ish emphasis,

--- a/telegram-plugin/narrative-flush.ts
+++ b/telegram-plugin/narrative-flush.ts
@@ -39,7 +39,7 @@
  * effects and the per-turn lifetime.
  */
 
-import { REPLY_TOOLS, isDraftOfReply } from './narrative-dedup.js'
+import { isReplyTool, isDraftOfReply } from './narrative-dedup.js'
 
 /**
  * Time-box for the parked-narrative early-paint (the kernel's home for the
@@ -139,7 +139,7 @@ export class NarrativeFlushController {
   resolveOnTool(toolName: string, input: Record<string, unknown> | undefined): void {
     this.scheduler.disarm()
     const replyText =
-      REPLY_TOOLS.has(toolName) && typeof input?.text === 'string' ? (input.text as string) : null
+      isReplyTool(toolName) && typeof input?.text === 'string' ? (input.text as string) : null
     if (replyText != null) this.maybeRetract(replyText)
     const pending = this.pending
     if (pending == null) return

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -46,7 +46,7 @@ import { homedir } from 'os'
 import { projectSubagentLine, sanitizeCwdToProjectName, detectErrorInTranscriptLine } from './session-tail.js'
 import { sanitiseToolArg } from './fleet-state.js'
 import { clipNarrative, describeToolUse } from './tool-activity-summary.js'
-import { REPLY_TOOLS } from './narrative-dedup.js'
+import { isReplyTool } from './narrative-dedup.js'
 import { NarrativeFlushController, PENDING_NARRATIVE_FLUSH_MS } from './narrative-flush.js'
 import { truncate } from './card-format.js'
 import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows, countRunningBackgroundSubagents, recordNestedSubagentDispatch, recordSubagentModel } from './registry/subagents-schema.js'
@@ -1551,8 +1551,8 @@ export function readSubTail(
           const narrativeJustFired = resolvePendingSubNarrative(ev.toolName, ev.input)
           // NIT 3: capture a foreground sub-agent's actual reply text so the
           // turn_end path can suppress a trailing draft of it (see
-          // resolvePendingSubNarrative). Only REPLY_TOOLS carry the answer.
-          if (REPLY_TOOLS.has(ev.toolName) && typeof ev.input?.text === 'string') {
+          // resolvePendingSubNarrative). Only reply tools carry the answer.
+          if (isReplyTool(ev.toolName) && typeof ev.input?.text === 'string') {
             entry.lastReplyText = ev.input.text as string
           }
           entry.toolCount++

--- a/telegram-plugin/tests/narrative-dedup.test.ts
+++ b/telegram-plugin/tests/narrative-dedup.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeNarrative,
   prefixSimilarity,
   isDraftOfReply,
+  isReplyTool,
   DRAFT_SUPPRESS_THRESHOLD,
   REPLY_TOOLS,
 } from '../narrative-dedup.js'
@@ -16,6 +17,37 @@ describe('narrative-dedup', () => {
     expect(REPLY_TOOLS.has('reply')).toBe(true)
     expect(REPLY_TOOLS.has('stream_reply')).toBe(true)
     expect(REPLY_TOOLS.has('Bash')).toBe(false)
+  })
+
+  describe('isReplyTool (#3231 prefix-aware matching)', () => {
+    it('matches the PREFIXED prod wire shape (what real jsonl actually carries)', () => {
+      // The whole point of #3231: production jsonl carries mcp__…__telegram__<tool>,
+      // so a bare REPLY_TOOLS.has(name) was always false in prod → suppression inert.
+      expect(isReplyTool('mcp__switchroom-telegram__stream_reply')).toBe(true)
+      expect(isReplyTool('mcp__switchroom-telegram__reply')).toBe(true)
+    })
+
+    it('matches under ANY registration key (clerk-telegram, forks)', () => {
+      expect(isReplyTool('mcp__clerk-telegram__stream_reply')).toBe(true)
+      expect(isReplyTool('mcp__my-fork-telegram__reply')).toBe(true)
+    })
+
+    it('still matches BARE names (non-MCP sources)', () => {
+      expect(isReplyTool('reply')).toBe(true)
+      expect(isReplyTool('stream_reply')).toBe(true)
+    })
+
+    it('rejects non-reply tools, prefixed or bare', () => {
+      expect(isReplyTool('Bash')).toBe(false)
+      expect(isReplyTool('mcp__switchroom-telegram__react')).toBe(false)
+      expect(isReplyTool('mcp__switchroom-telegram__edit_message')).toBe(false)
+      expect(isReplyTool('mcp__hindsight__retain')).toBe(false)
+    })
+
+    it('is null/undefined safe', () => {
+      expect(isReplyTool(null)).toBe(false)
+      expect(isReplyTool(undefined)).toBe(false)
+    })
   })
 
   describe('normalizeNarrative', () => {

--- a/telegram-plugin/tests/narrative-flush.test.ts
+++ b/telegram-plugin/tests/narrative-flush.test.ts
@@ -101,7 +101,10 @@ describe('anti-double-print (deferred path) — a draft-then-send reply is suppr
     const answer = 'The build is green — all 412 tests pass.'
     ctrl.stage(answer) // the model drafting its answer just before reply()
 
-    ctrl.resolveOnTool('reply', { text: answer }) // draft-then-send → SUPPRESS
+    // #3231: feed the PREFIXED prod wire shape (mcp__…__reply). Before the
+    // isReplyTool fix a bare REPLY_TOOLS.has() missed this and the draft was
+    // WRONGLY shown — the suppression path was inert on the real wire shape.
+    ctrl.resolveOnTool('mcp__switchroom-telegram__reply', { text: answer }) // draft-then-send → SUPPRESS
     expect(show).not.toHaveBeenCalled()
     expect(retractShown).not.toHaveBeenCalled() // nothing was shown to retract
     expect(scheduler.isArmed).toBe(false)
@@ -128,7 +131,8 @@ describe('anti-double-print (TIMER path) — a timer-painted draft is retracted'
 
     // The reply finally lands and IS that block → must be retracted, not left
     // on the card to double-print against the canonical reply.
-    ctrl.resolveOnTool('stream_reply', { text: answer })
+    // #3231: prefixed prod wire shape.
+    ctrl.resolveOnTool('mcp__switchroom-telegram__stream_reply', { text: answer })
     expect(retractShown).toHaveBeenCalledTimes(1)
     expect(retractShown).toHaveBeenCalledWith(answer)
     expect(show).toHaveBeenCalledTimes(1) // not re-shown

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -647,6 +647,36 @@ describe('startSubagentWatcher', () => {
       h.poll()
       // The draft is staged, not yet resolved — no cue yet.
       // The very next event is a reply tool with matching text → SUPPRESS.
+      // #3231: feed the PREFIXED prod wire shape (mcp__…__stream_reply), the
+      // form real jsonl actually carries. Before the isReplyTool fix a bare
+      // REPLY_TOOLS.has() missed this and the draft was WRONGLY surfaced.
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'mcp__switchroom-telegram__stream_reply', id: 'r1', input: { text: answer } }] },
+      }))
+      h.poll()
+      expect(narrativeCues.length).toBe(0)
+    })
+
+    it('narrative gate: a draft-then-reply sub_agent_text is SUPPRESSED with a BARE reply tool name too (#3231)', () => {
+      // Symmetric with the prefixed case above: bare 'stream_reply' can still
+      // arrive from non-MCP sources, so isReplyTool must match it as well.
+      const narrativeCues: string[] = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ progressLine, latestSummary, skeleton }) => {
+          if (!skeleton && progressLine == null) narrativeCues.push(latestSummary)
+        },
+      })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Find the repo path')))
+      h.poll()
+      const answer = 'The repo is at /home/user/code/switchroom.'
+      appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText(answer)))
+      h.poll()
       appendFileSync(jsonlPath, buildJSONL({
         type: 'assistant',
         message: { content: [{ type: 'tool_use', name: 'stream_reply', id: 'r1', input: { text: answer } }] },
@@ -786,10 +816,11 @@ describe('startSubagentWatcher', () => {
       writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Summarise the diff')))
       h.poll()
       const answer = 'The fix touches three files and adds a unit test for the double-Done case.'
-      // Final tool of the turn is stream_reply carrying the answer.
+      // Final tool of the turn is stream_reply carrying the answer. #3231: use
+      // the PREFIXED prod wire shape so lastReplyText capture (isReplyTool) fires.
       appendFileSync(jsonlPath, buildJSONL({
         type: 'assistant',
-        message: { content: [{ type: 'tool_use', name: 'stream_reply', id: 'r1', input: { text: answer } }] },
+        message: { content: [{ type: 'tool_use', name: 'mcp__switchroom-telegram__stream_reply', id: 'r1', input: { text: answer } }] },
       }))
       h.poll()
       // Trailing text block (separate message) that drafts the delivered answer.
@@ -819,9 +850,10 @@ describe('startSubagentWatcher', () => {
       writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Summarise the diff')))
       h.poll()
       const answer = 'The fix touches three files and adds a unit test for the double-Done case.'
+      // #3231: prefixed prod wire shape.
       appendFileSync(jsonlPath, buildJSONL({
         type: 'assistant',
-        message: { content: [{ type: 'tool_use', name: 'stream_reply', id: 'r1', input: { text: answer } }] },
+        message: { content: [{ type: 'tool_use', name: 'mcp__switchroom-telegram__stream_reply', id: 'r1', input: { text: answer } }] },
       }))
       h.poll()
       appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText('Done — cleaning up the worktree now.')))


### PR DESCRIPTION
## Summary
`narrative-dedup.ts` defined `REPLY_TOOLS` as a **bare-name** set (`{'reply','stream_reply'}`) and the draft-then-send narrative-suppression path gated on `REPLY_TOOLS.has(ev.toolName)`. Production jsonl carries **prefixed** MCP tool names (`mcp__switchroom-telegram__stream_reply`), so the check was **always false in prod** → the draft-suppression path was **inert on the real wire shape** (#3231).

No live double-print existed (the reply row is separately suppressed by the prefix-aware `computeLabel`), so this was a belt to already-fastened suspenders — but the belt never engaged.

## Why
Fixes #3231. Restores the intended draft-then-send suppression on the production wire shape and closes the test-fidelity gap (tests fed the bare form prod never emits).

## What changed
- **`narrative-dedup.ts`**: add prefix-aware `isReplyTool()` — strips the key-agnostic `mcp__<key>__telegram__` prefix (mirroring `computeLabel` / `isTelegramReplyTool`) then tests the suffix against `REPLY_TOOLS`. Matches BOTH prefixed prod names AND bare names (still possible from non-MCP sources). `REPLY_TOOLS` stays exported as the source-of-truth set.
- Repoint the **three real call sites**: `narrative-flush.ts` `resolveOnTool` (the primary inert gate, shared by the main gateway and subagent-watcher), `subagent-watcher.ts` lastReplyText capture, `gateway/stream-render.ts` lastReplyText capture (already nested under prefix-aware `isTelegramReplyTool`, so its inner `REPLY_TOOLS.has` was dead in prod).
- `gateway.ts` imports `REPLY_TOOLS` but no longer references it (stale after the P4 extraction); **left untouched** to keep this fix disjoint from gateway.ts / the line ratchet.

## Test plan
- Repointed the dedup tests at the **prefixed prod wire shape** (`narrative-flush.test.ts`, `subagent-watcher.test.ts`) plus explicit **bare-name** coverage, and added `isReplyTool` unit tests (prefixed / any-registration-key / bare / non-reply / null-safe).
- **Oracle verified**: reverting the matcher to bare-only (the bug) fails **6** of these tests; the fix greens all.
- Scoped: `vitest run` narrative-dedup + narrative-flush + narrative-render + subagent-watcher → **72 pass**.
- `npm run lint` guards + `tsc --noEmit` → clean. gateway.ts untouched, so `check-gateway-line-ratchet` unchanged (27932).

## Risk
Low — behavior-preserving on the render surface (no live double-print existed); activates a dormant belt-and-suspenders suppression on the prod wire shape.

Job spec: `reference/jobs/` — turn liveness / progress-card render fidelity (narrative dedup keeps the answer from double-surfacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)