### PR TITLE
fix(gateway): use block provenance for flush narration-strip (#3237)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3386,6 +3386,13 @@ export type CurrentTurn = {
   silentAnchorMessageId: number | null
   silentAnchorText: string
   capturedText: string[]
+  // #3237 — per-block structural provenance, pushed in LOCKSTEP with
+  // `capturedText` at the `case 'text'` accumulation site (stream-render.ts).
+  // `capturedBlockMeta[i] === true` ⇒ a tool_use followed `capturedText[i]` in
+  // its assistant message (`!ev.lastInMessage`), i.e. the model drafted then
+  // acted — the deterministic narration signal the flush strip uses to avoid
+  // truncating a real answer that merely opens with "Let me explain…".
+  capturedBlockMeta: boolean[]
   orphanedReplyTimeoutId: ReturnType<typeof setTimeout> | null
   // PR A — answer-ready quiescence flush timer. Armed in `case 'text'` once the
   // turn has a genuine composed terminal answer and is quiescent; fires a
@@ -14344,6 +14351,7 @@ const answerReadyFlush = new AnswerReadyFlushController<CurrentTurn>({
       chatId: turn.sessionChatId,
       replyCalled: turn.replyCalled,
       capturedText: turn.capturedText,
+      capturedBlockMeta: turn.capturedBlockMeta,
       flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
     },
     inFlightToolCount: toolFlightTracker.inFlightCount(),

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -317,6 +317,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
           silentAnchorMessageId: null,
           silentAnchorText: '',
           capturedText: [],
+          capturedBlockMeta: [],
           orphanedReplyTimeoutId: null,
           answerReadyFlushTimeoutId: null,
           // Fresh liveness tracker: lastStreamEventAt seeded to the turn start
@@ -813,6 +814,13 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
       const turn = getCurrentTurn()
       if (turn != null) {
         turn.capturedText.push(ev.text)
+        // #3237 — accumulate the block's structural provenance in LOCKSTEP with
+        // the text (same push, same index). `ev.lastInMessage` is true when NO
+        // tool_use follows this text block in its assistant message; its
+        // negation is the draft-then-send narration signal the turn-flush strip
+        // uses (`selectFlushDeliveryText`) to keep a real answer intact instead
+        // of truncating a paragraph that merely opens with "Let me explain…".
+        turn.capturedBlockMeta.push(!ev.lastInMessage)
         // Narrative-dedup gate step 1 (JSONL-text-narrative primitive):
         // stage this text block for one lookahead step. If a previous block
         // was pending with nothing reply-shaped after it, it flushes here as
@@ -1366,6 +1374,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
             chatId: turn.sessionChatId,
             replyCalled: turn.replyCalled,
             capturedText: turn.capturedText,
+            capturedBlockMeta: turn.capturedBlockMeta,
             flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
           })
       // #1667 — resolve the turn_end answer-delivery gate once, here, via the

--- a/telegram-plugin/tests/stream-render-golden.test.ts
+++ b/telegram-plugin/tests/stream-render-golden.test.ts
@@ -75,6 +75,7 @@ function makeTurn(over: Partial<CurrentTurn> = {}): CurrentTurn {
     lastReplyText: '',
     answerStream: null,
     capturedText: ['The composed terminal answer that the model never sent via reply.'],
+    capturedBlockMeta: [false],
     finalAnswerDelivered: false,
     finalAnswerSubstantive: false,
     answerDelivered: false,
@@ -288,6 +289,65 @@ describe('stream-render — turn-flush records into the shared OutboundDedupCach
     expect(h.delivered).toContain(answer)
     // the module's OWN record statement (stream-render.ts:1784) ran
     expect(h.dedup.check(CHAT, undefined, answer, Date.now(), null)).not.toBeNull()
+  })
+})
+
+// ── #3237 HARD GATE: block provenance survives stream-render accumulation ───
+// The whole fix hinges on `ev.lastInMessage` surviving the `case 'text'`
+// accumulation into `turn.capturedBlockMeta` and reaching selectFlushDeliveryText
+// via decideTurnFlush. These drive the REAL handleSessionEvent text path (not a
+// preset capturedText) so the accumulation code actually runs, then assert BOTH
+// the accumulated provenance AND the flush's delivered text. Each case is
+// engineered so the OPPOSITE outcome would result if provenance were lost and
+// the strip fell back to the opener heuristic — proving structure is consulted.
+describe('#3237 — block provenance survives accumulation and reaches the flush strip', () => {
+  function driveTextTurn(blocks: Array<{ text: string; lastInMessage: boolean }>) {
+    const turn = makeTurn({ capturedText: [], capturedBlockMeta: [], answerStream: null })
+    const h = makeStreamDeps({ turn })
+    blocks.forEach((b, i) =>
+      handleSessionEvent(h.deps, {
+        kind: 'text',
+        text: b.text,
+        blockIndex: i,
+        lastInMessage: b.lastInMessage,
+      }),
+    )
+    return { turn, h }
+  }
+
+  it('narration FOLLOWED by a tool_use (lastInMessage=false) → provenance=[true,false], flush strips the preamble', async () => {
+    // "Here are the figures." matches NO opener regex — if provenance were lost
+    // the opener-only strip would KEEP it and deliver the whole blob. Structure
+    // ([true,false]) strips it. Asserting answer-only proves structure was used.
+    const narration = 'Here are the figures you asked about.'
+    const answer = 'All three services are green.'
+    const { turn, h } = driveTextTurn([
+      { text: narration, lastInMessage: false }, // a tool_use followed it in its message
+      { text: answer, lastInMessage: true }, // terminal
+    ])
+    // Provenance survived the accumulation into the parallel array.
+    expect(turn.capturedBlockMeta).toEqual([true, false])
+    handleSessionEvent(h.deps, { kind: 'turn_end', durationMs: 1200 })
+    await settle()
+    expect(h.delivered.join('\n')).toContain(answer)
+    expect(h.delivered.join('\n')).not.toContain('Here are the figures')
+  })
+
+  it('#3237 real answer: two paragraphs, NEITHER followed by a tool_use (lastInMessage=true) → provenance=[false,false], flush keeps BOTH (no truncation)', async () => {
+    // p1 OPENS with "Let me explain…" — the opener strip WOULD drop it if
+    // provenance were lost. Structure ([false,false]) keeps the full answer.
+    const p1 = 'Let me explain the plan in two parts.'
+    const p2 = 'Part two: we ship it behind the existing flag.'
+    const { turn, h } = driveTextTurn([
+      { text: p1, lastInMessage: true },
+      { text: p2, lastInMessage: true },
+    ])
+    expect(turn.capturedBlockMeta).toEqual([false, false])
+    handleSessionEvent(h.deps, { kind: 'turn_end', durationMs: 1200 })
+    await settle()
+    const out = h.delivered.join('\n')
+    expect(out).toContain('Let me explain the plan')
+    expect(out).toContain('Part two')
   })
 })
 

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -691,3 +691,120 @@ describe('selectFlushDeliveryText — deliver the terminal answer, strip only na
     }
   })
 })
+
+// ── #3237: STRUCTURAL block-provenance discriminator ───────────────────────
+// The opener heuristic cannot tell a narration preamble from a real answer
+// paragraph that merely opens with "Let me explain…". The structural flag
+// (`followedByToolUse`, = `!lastInMessage`) can: a narration preamble is
+// followed by a tool_use in its message; a terminal answer paragraph is not.
+describe('selectFlushDeliveryText — structural provenance (followedByToolUse) #3237', () => {
+  // The exact real-answer shape from #3237: a genuine two-paragraph answer
+  // whose FIRST block opens with a narration phrase, written as plain text with
+  // NO tool calls (the model forgot the reply tool → flush path). Structure
+  // says neither block was followed by a tool_use, so nothing is narration.
+  const p1 =
+    'Let me explain how the flush path works: it fires at turn_end when the ' +
+    'model never called the reply tool, joining the captured assistant text ' +
+    'blocks with a paragraph break so the answer renders with real separation.'
+  const p2 =
+    'The terminal block is always delivered, so the answer is never fully ' +
+    'lost — but the opening paragraph could be dropped by the opener-only strip.'
+
+  it('#3237 regression: a real 2-paragraph answer opening with "Let me explain…" is NOT truncated when structure says neither block was followed by a tool_use', () => {
+    // With NO structural signal (legacy string[]) the opener strip DROPS p1.
+    expect(selectFlushDeliveryText([p1, p2])).toBe(p2) // documents the bug
+    // With structure present ([false,false]) the full answer is delivered.
+    const out = selectFlushDeliveryText([p1, p2], [false, false])
+    expect(out).toBe(`${p1}\n\n${p2}`)
+    expect(out).toContain('Let me explain how the flush path works')
+  })
+
+  it('duplicate-reply fix preserved: a narration block FOLLOWED by a tool_use is stripped, terminal answer delivered', () => {
+    const narration = 'Let me pull the numbers together before I answer.'
+    const realAnswer = 'Revenue was 4.2M, up 12% year over year.'
+    // followedByToolUse[0]=true (the model drafted then acted), [1]=false (terminal).
+    const out = selectFlushDeliveryText([narration, realAnswer], [true, false])
+    expect(out).toBe(realAnswer)
+    expect(out).not.toContain('Let me pull the numbers')
+  })
+
+  it('structure alone drives the strip — a preamble the opener regex would MISS is still stripped when it was followed by a tool_use', () => {
+    // "Here are the figures" matches no NARRATION_OPENER, but a tool_use
+    // followed it → structural narration → stripped.
+    const preamble = 'Here are the figures you asked about.'
+    const realAnswer = 'The three services are all green.'
+    const out = selectFlushDeliveryText([preamble, realAnswer], [true, false])
+    expect(out).toBe(realAnswer)
+    expect(out).not.toContain('Here are the figures')
+  })
+
+  it('structure WINS over the opener heuristic — a "Let me…" opener NOT followed by a tool_use is kept (never truncated)', () => {
+    const first = 'Let me walk you through the three steps in order.'
+    const second = 'Step one is to branch off fresh main.'
+    // Opener-only would strip `first`; structure ([false,false]) keeps it.
+    expect(selectFlushDeliveryText([first, second], [false, false])).toBe(
+      `${first}\n\n${second}`,
+    )
+  })
+
+  it('per-block fallback: an UNDEFINED entry falls back to the opener heuristic for that block only', () => {
+    const narration = 'Let me check that.'
+    const realAnswer = 'Done — all green.'
+    // meta[0] undefined → fall back to isNarrationBlock("Let me check that.") = true → stripped.
+    const out = selectFlushDeliveryText([narration, realAnswer], [undefined, false])
+    expect(out).toBe(realAnswer)
+  })
+
+  it('flag-absent back-compat: omitting the meta array reproduces today\'s opener-strip EXACTLY', () => {
+    // Every legacy case behaves identically with no meta argument.
+    expect(selectFlushDeliveryText(['Let me check.', 'the answer'])).toBe('the answer')
+    expect(selectFlushDeliveryText(['Checking now…', 'The build is green.'])).toBe(
+      'The build is green.',
+    )
+    expect(selectFlushDeliveryText([p1, p2])).toBe(p2) // opener strip drops p1
+    const first = 'B'.repeat(FLUSH_SUBSTANTIVE_MIN_CHARS + 5)
+    const last = 'C'.repeat(FLUSH_SUBSTANTIVE_MIN_CHARS + 5)
+    expect(selectFlushDeliveryText([first, last])).toBe(`${first}\n\n${last}`)
+  })
+
+  it('meta stays ALIGNED across the empty-block filter (zip-before-filter)', () => {
+    // An empty block between narration and answer must not shift the meta index.
+    const narration = 'Let me look that up.'
+    const realAnswer = 'The value is 42.'
+    // blocks[1] is empty (dropped); meta must still map [narration→true, ''→_, answer→false].
+    const out = selectFlushDeliveryText([narration, '   ', realAnswer], [true, false, false])
+    expect(out).toBe(realAnswer)
+    expect(out).not.toContain('Let me look that up')
+  })
+
+  it('cross-message shape: narration (msg1, tool_use after) + answer (msg2, terminal) → narration stripped', () => {
+    // lastInMessage semantics are per-message; a narration that is the last text
+    // of msg1 but has a tool_use after it in msg1 is followedByToolUse=true.
+    const narration = 'Let me search the codebase for the symbol.'
+    const realAnswer = 'It is defined in session-tail.ts.'
+    const out = selectFlushDeliveryText([narration, realAnswer], [true, false])
+    expect(out).toBe(realAnswer)
+  })
+
+  it('decideTurnFlush plumbs capturedBlockMeta through to the strip (#3237 end-to-end)', () => {
+    // Real-answer case: structure keeps both paragraphs.
+    const keep = decideTurnFlush({
+      chatId: 'chat1',
+      replyCalled: false,
+      capturedText: [p1, p2],
+      capturedBlockMeta: [false, false],
+    })
+    expect(keep.kind).toBe('flush')
+    if (keep.kind === 'flush') expect(keep.text).toBe(`${p1}\n\n${p2}`)
+
+    // Narration case: structure strips the preamble.
+    const strip = decideTurnFlush({
+      chatId: 'chat1',
+      replyCalled: false,
+      capturedText: ['Let me pull the numbers.', 'Revenue was 4.2M.'],
+      capturedBlockMeta: [true, false],
+    })
+    expect(strip.kind).toBe('flush')
+    if (strip.kind === 'flush') expect(strip.text).toBe('Revenue was 4.2M.')
+  })
+})

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -155,28 +155,60 @@ export const FLUSH_SUBSTANTIVE_MIN_CHARS = 200
  * `[verboseNarration(250), realAnswer(150)]` a reversed length scan returns the
  * 250-char narration and DROPS the 150-char real answer. Instead we take the
  * last non-empty block as the answer and strip only the EARLIER blocks — and
- * only when they look like intent-narration (short, or the classic "Let me…" /
- * "I'll…" openers). If the earlier blocks are themselves substantial (a genuine
- * multi-paragraph answer written as several blocks) we keep the whole thing
- * joined, so we never truncate a real long answer down to its last paragraph.
+ * only when they look like intent-narration. If the earlier blocks are
+ * themselves substantial (a genuine multi-paragraph answer written as several
+ * blocks) we keep the whole thing joined, so we never truncate a real long
+ * answer down to its last paragraph.
+ *
+ * #3237 — the STRUCTURAL discriminator. The opener heuristic below
+ * (`isNarrationBlock`) cannot tell a narration preamble ("Let me pull the
+ * numbers…" followed by a separate reply) from a real answer paragraph that
+ * merely OPENS with "Let me explain…": both match the same regex, and length
+ * cannot separate them (the observed narration was itself ≥200 chars). The one
+ * signal that DOES separate them is structural — did a `tool_use` follow this
+ * block in the model's actual message? A narration preamble is drafted, then
+ * the model ACTS (a tool call follows it); a terminal answer paragraph is not
+ * followed by any tool call. That per-block flag (`lastInMessage`) is computed
+ * upstream by `projectAssistantTextBlocks` (session-tail.ts) and, when the
+ * caller plumbs it through as `followedByToolUse`, we trust STRUCTURE ALONE:
+ * a preceding block is narration iff it was followed by a tool_use. Where the
+ * structural flag is ABSENT for a block (legacy `string[]` caller, or the
+ * accumulator lost provenance) we fall back to the opener/trailer heuristic for
+ * that block — so the change is strictly additive: never worse than the
+ * opener-only strip, deterministic and truncation-free when the signal is
+ * present.
+ *
+ * `followedByToolUse` is a parallel array aligned to `blocks` (index `i` ⇒
+ * `blocks[i]`); it is zipped BEFORE the empty-block filter so alignment holds
+ * even if the caller passes empty/whitespace blocks. `undefined` at an index
+ * (or a missing/short array) means "no reliable structural signal for this
+ * block" → opener-heuristic fallback.
  *
  * `blocks` are already trimmed/non-empty candidates (silent markers removed by
  * the caller's guards). Returns the chosen delivery text.
  */
-export function selectFlushDeliveryText(blocks: string[]): string {
+export function selectFlushDeliveryText(
+  blocks: string[],
+  followedByToolUse?: ReadonlyArray<boolean | undefined>,
+): string {
   const candidates = blocks
-    .map(b => b.trim())
-    .filter(b => b.length > 0)
+    .map((b, i) => ({ text: b.trim(), followedByToolUse: followedByToolUse?.[i] }))
+    .filter(c => c.text.length > 0)
   if (candidates.length === 0) return ''
-  if (candidates.length === 1) return candidates[0]
-  const answer = candidates[candidates.length - 1]
+  if (candidates.length === 1) return candidates[0].text
+  const answer = candidates[candidates.length - 1].text
   const preceding = candidates.slice(0, -1)
   // Deliver only the terminal answer when every earlier block is
-  // intent-narration (a short block, or a "Let me…/I'll…/I'm going to…" opener).
-  // Otherwise the earlier blocks carry real content — keep the full joined text
-  // so a legitimate multi-block answer is never truncated to its last paragraph.
-  const allNarration = preceding.every(isNarrationBlock)
-  return allNarration ? answer : candidates.join('\n\n')
+  // intent-narration. Per block: when a reliable structural signal is present
+  // (`followedByToolUse !== undefined`) trust it ALONE — a block followed by a
+  // tool_use in its message is the model drafting-then-acting (narration);
+  // otherwise fall back to the opener/trailer heuristic. Otherwise the earlier
+  // blocks carry real content — keep the full joined text so a legitimate
+  // multi-block answer is never truncated to its last paragraph (#3237).
+  const allNarration = preceding.every(c =>
+    c.followedByToolUse !== undefined ? c.followedByToolUse : isNarrationBlock(c.text),
+  )
+  return allNarration ? answer : candidates.map(c => c.text).join('\n\n')
 }
 
 /**
@@ -244,6 +276,15 @@ export interface FlushDecisionInput {
    * is false — once the model has called reply / stream_reply the turn is
    * served and trailing terminal text is dropped (see `decideTurnFlush`). */
   capturedText: string[]
+  /** Optional per-block structural provenance, aligned to `capturedText`
+   * (index `i` describes `capturedText[i]`). `true` ⇒ a `tool_use` followed
+   * this text block in its assistant message (the draft-then-send narration
+   * signal — the negation of `projectAssistantTextBlocks`' `lastInMessage`).
+   * Consumed by `selectFlushDeliveryText` to separate a narration preamble from
+   * a real answer paragraph that merely opens with a narration phrase (#3237).
+   * When absent (legacy caller / lost provenance) the strip falls back to the
+   * opener/trailer heuristic, so this field is strictly additive. */
+  capturedBlockMeta?: boolean[]
   /** Feature flag — defaults to true. Pass `false` to force skip everywhere. */
   flushEnabled?: boolean
 }
@@ -316,7 +357,10 @@ export function decideTurnFlush(input: FlushDecisionInput): FlushDecision {
   // blob (see `selectFlushDeliveryText`). The silent-marker / empty guards above
   // still run on the full `joined` string so a partly-silent turn is classified
   // correctly; only the DELIVERED text is narrowed to the answer.
-  return { kind: 'flush', text: selectFlushDeliveryText(input.capturedText) }
+  return {
+    kind: 'flush',
+    text: selectFlushDeliveryText(input.capturedText, input.capturedBlockMeta),
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #3237. `selectFlushDeliveryText` (the turn-flush narration-strip) was
opener-only and deliberately NOT length-gated, so it could not tell a
narration preamble ("Let me pull the numbers…" then a separate reply) apart
from a real answer paragraph that merely OPENS with "Let me explain…". Both
match the same `NARRATION_OPENER` regex and length cannot separate them (the
observed narration was itself >=200 chars), so the opener strip truncated the
rare real answer down to its last paragraph.

This plumbs the one signal that *does* separate them — **structure**. Each
text block already knows, from `projectAssistantTextBlocks` (session-tail.ts),
whether a `tool_use` followed it in its assistant message (`lastInMessage`).
A narration preamble is drafted, then the model acts (a tool call follows it);
a terminal answer paragraph is not. That per-block flag is computed upstream
and then discarded at the boundary into the strip. We now carry it through:

- `stream-render.ts` `case 'text'`: push `!ev.lastInMessage` into a new
  `turn.capturedBlockMeta: boolean[]`, in lockstep with `capturedText`.
- `FlushDecisionInput.capturedBlockMeta?: boolean[]` (optional -> back-compat);
  both callers (turn-end flush + answer-ready arm) pass `turn.capturedBlockMeta`.
- `selectFlushDeliveryText(blocks, followedByToolUse?)`: a preceding block is
  narration iff `followedByToolUse === true`. **Product call: trust structure
  ALONE when the per-block flag is present** — the opener/trailer heuristic is
  the fallback ONLY when the flag is absent (legacy `string[]` caller / lost
  provenance). The meta is zipped BEFORE the empty-block filter so index
  alignment holds.

The change is strictly additive: where the structural flag is missing,
behaviour is byte-identical to today's opener-only strip.

## Why

Approach C from the design report (design-aligned, CPO-approved). It is the
only candidate that *deterministically* separates the two indistinguishable
cases, reuses machinery already in the tree, degrades gracefully, and matches
the repo principle "deterministic mechanisms over model-dependent behavior".
Approaches A/B were text-heuristic patches that trade one guessing rule for
another and can't close the "Let me explain…" case without risking the older,
more common duplicate-reply regression.

## HARD GATE — provenance survival (verified)

The fix is only viable if the block/message provenance survives gateway
accumulation. It does: `stream-render.ts:815` is the sole `capturedText.push`
site and `ev` there is the `text` SessionEvent carrying `lastInMessage`
statically — the flag was never lost, only discarded. Encoded as an
integration test that drives the REAL `handleSessionEvent` text path and
asserts `turn.capturedBlockMeta` accumulated correctly AND the flush delivered
the structurally-correct text.

## Test plan

- `telegram-plugin/tests/turn-flush-safety.test.ts` (+11 cases): #3237 no-trim
  (documents the pre-fix truncation, then asserts the fix keeps both
  paragraphs), duplicate-reply strip preserved, structure-wins-over-opener,
  structure catches a preamble the regex misses, per-block undefined fallback,
  flag-absent back-compat parity, zip-before-filter alignment, cross-message,
  `decideTurnFlush` plumbing.
- `telegram-plugin/tests/stream-render-golden.test.ts` (+2 gate cases): drive
  real `handleSessionEvent` text->turn_end; assert `capturedBlockMeta` survives
  accumulation and the flush strips/keeps correctly. Each case is engineered so
  the opposite outcome would result if provenance were lost.
- Scoped vitest across 11 flush suites: 229 pass. `npm run test:bun`: 1221
  pass / 0 fail. `npm run lint`: clean (gateway line-ratchet within slack).

## Adversarial self-review (this is behavior-changing, not a refactor)

**What could now leak as a duplicate reply?** The residual case: a narration
block NOT followed by any `tool_use` in its message, then a separate reply
that lands after an answer-ready flush already fired. Structure marks that
narration `followedByToolUse=false` -> the strip KEEPS it -> narration+answer
is delivered and may not dedup against the later clean reply. This is the
explicitly-accepted tradeoff (design section 6.2, CPO-confirmed):
over-inclusion of a narration sentence is *visible and harmless*; the
alternative (OR-ing the opener heuristic back in) reintroduces the #3237
truncation. It is also narrow: the classic duplicate-reply shape
(`["Let me check…", answer]` where the model actually did work) has the
narration followed by a real tool_use, so structure strips it — covered by the
"duplicate-reply fix preserved" test. And on the pure turn-end flush path there
is no competing reply to dedup against.

**What could still be trimmed wrongly (a real answer truncated)?** Only if a
real terminal answer's preceding block were wrongly tagged
`followedByToolUse=true`. That flag is `!lastInMessage`, computed by
`projectAssistantTextBlocks` purely from content-array positions
(`i <= lastToolUseIdx`), and is separately unit-pinned in
`session-tail.test.ts`. The zip-before-filter guard prevents an empty block
from shifting the alignment (pinned by the alignment test). When the flag is
absent we fall back to exactly today's behaviour, so no NEW wrong-trim is
introduced relative to `main`.

**Why the tests catch each:** the #3237 keep-case and the integration keep-case
both use a `"Let me explain…"` opener that the fallback heuristic WOULD strip —
so if provenance failed to reach the strip (or were ignored), the answer would
be truncated and the assertion `toContain('Let me explain')` fails. The
strip-case uses a preamble (`"Here are the figures"`) the opener regex does NOT
match — so it can only be stripped via structure; if provenance were lost the
whole blob would be delivered and `not.toContain('Here are the figures')`
fails. The two directions together prove structure is consulted, not the
opener.

## Risk

Low. No persisted state, no schema. Feature-flagged path
(`SWITCHROOM_TG_TURN_FLUSH_SAFETY`). Additive optional field; all legacy
callers/tests unchanged. Blast radius bounded to the flush delivery text.

Job spec: `reference/jobs/feel-like-a-colleague.md` — a truncated answer that
silently drops its opening paragraph is the agent "being caught as a chatbot";
delivering the model's whole answer preserves the colleague illusion. (Flush
safety-net context: `reference/jobs/fleet-stays-healthy.md`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
