### PR TITLE
fix(gateway): gate structural flush-strip with substantive floor (#3237)

### DIFF
--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -807,4 +807,52 @@ describe('selectFlushDeliveryText — structural provenance (followedByToolUse) 
     expect(strip.kind).toBe('flush')
     if (strip.kind === 'flush') expect(strip.text).toBe('Revenue was 4.2M.')
   })
+
+  // Regression for the post-#3338 review finding: a SUBSTANTIAL real-content
+  // block (≥ FLUSH_SUBSTANTIVE_MIN_CHARS, NOT narration-shaped) that happens to
+  // be followed by a tool_use must be KEPT — the model can write a real answer
+  // paragraph, then call a memory/verify tool, then a short wrap-up. Trusting
+  // followedByToolUse ALONE (the pre-fix behaviour) dropped the real answer and
+  // delivered only the wrap-up. The structural strip is gated by the substantive
+  // floor, so the substantial block survives.
+  it('substantial real-content block followed by a tool_use is KEPT (structural flag gated by the substantive floor)', () => {
+    const realAnswer =
+      'The migration completed cleanly across all five shards: each shard was ' +
+      'drained, the schema applied under an advisory lock, and traffic cut back ' +
+      'over with zero dropped requests. The new index brought the p99 query time ' +
+      'down from 840ms to 60ms, and the old columns are now safe to remove in ' +
+      'the next release once the read path is confirmed off them entirely.'
+    expect(realAnswer.length).toBeGreaterThanOrEqual(FLUSH_SUBSTANTIVE_MIN_CHARS)
+    // Not narration-shaped: no first-person "about to do X" opener, no
+    // trailing ellipsis/colon — so only the structural flag could strip it.
+    const wrapUp = 'Saved that to memory.'
+    // meta[0]=true (a memory tool_use followed the real answer), [1]=false.
+    const out = selectFlushDeliveryText([realAnswer, wrapUp], [true, false])
+    expect(out).toBe(`${realAnswer}\n\n${wrapUp}`)
+    expect(out).toContain('The migration completed cleanly')
+
+    // End-to-end through decideTurnFlush.
+    const decision = decideTurnFlush({
+      chatId: 'chat1',
+      replyCalled: false,
+      capturedText: [realAnswer, wrapUp],
+      capturedBlockMeta: [true, false],
+    })
+    expect(decision.kind).toBe('flush')
+    if (decision.kind === 'flush') {
+      expect(decision.text).toBe(`${realAnswer}\n\n${wrapUp}`)
+    }
+  })
+
+  // A SHORT block followed by a tool_use is still stripped via the length floor
+  // (the pre-#3237 "short preamble the opener misses" behaviour is preserved):
+  // it is below FLUSH_SUBSTANTIVE_MIN_CHARS, so the gated strip still fires.
+  it('short block followed by a tool_use is still stripped (length-floor branch of the gate)', () => {
+    const shortPreamble = 'Here are the figures you asked about.'
+    expect(shortPreamble.length).toBeLessThan(FLUSH_SUBSTANTIVE_MIN_CHARS)
+    const realAnswer = 'The three services are all green.'
+    const out = selectFlushDeliveryText([shortPreamble, realAnswer], [true, false])
+    expect(out).toBe(realAnswer)
+    expect(out).not.toContain('Here are the figures')
+  })
 })

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -170,13 +170,21 @@ export const FLUSH_SUBSTANTIVE_MIN_CHARS = 200
  * the model ACTS (a tool call follows it); a terminal answer paragraph is not
  * followed by any tool call. That per-block flag (`lastInMessage`) is computed
  * upstream by `projectAssistantTextBlocks` (session-tail.ts) and, when the
- * caller plumbs it through as `followedByToolUse`, we trust STRUCTURE ALONE:
- * a preceding block is narration iff it was followed by a tool_use. Where the
- * structural flag is ABSENT for a block (legacy `string[]` caller, or the
- * accumulator lost provenance) we fall back to the opener/trailer heuristic for
- * that block — so the change is strictly additive: never worse than the
- * opener-only strip, deterministic and truncation-free when the signal is
- * present.
+ * caller plumbs it through as `followedByToolUse`, we consult STRUCTURE, but
+ * asymmetrically:
+ *   - present-and-FALSE (no tool_use followed) is purely additive — it can only
+ *     RESCUE a block the opener regex would have mis-stripped (a terminal answer
+ *     opening "Let me explain…"); it never drops a block the heuristic kept.
+ *   - present-and-TRUE (a tool_use followed) is NOT taken as narration on its
+ *     own: a substantial real-content paragraph can precede a tool call, so the
+ *     strip is GATED by the substance check (narration only if it also matches
+ *     the opener/trailer heuristic OR falls below the substantive floor). This
+ *     is deliberately not "strictly additive" over the opener-only strip — it
+ *     both rescues real content the old flag-alone path would have dropped and
+ *     stays truncation-free.
+ * Where the structural flag is ABSENT for a block (legacy `string[]` caller, or
+ * the accumulator lost provenance) we fall back to the opener/trailer heuristic
+ * for that block.
  *
  * `followedByToolUse` is a parallel array aligned to `blocks` (index `i` ⇒
  * `blocks[i]`); it is zipped BEFORE the empty-block filter so alignment holds
@@ -199,14 +207,26 @@ export function selectFlushDeliveryText(
   const answer = candidates[candidates.length - 1].text
   const preceding = candidates.slice(0, -1)
   // Deliver only the terminal answer when every earlier block is
-  // intent-narration. Per block: when a reliable structural signal is present
-  // (`followedByToolUse !== undefined`) trust it ALONE — a block followed by a
-  // tool_use in its message is the model drafting-then-acting (narration);
-  // otherwise fall back to the opener/trailer heuristic. Otherwise the earlier
-  // blocks carry real content — keep the full joined text so a legitimate
-  // multi-block answer is never truncated to its last paragraph (#3237).
+  // intent-narration. Per block:
+  //   - structural flag TRUE ⇒ a tool_use followed this block, but that alone
+  //     is NOT sufficient to drop it: a substantial real-content paragraph can
+  //     legitimately precede a tool call (the model writes a real answer, then
+  //     calls a memory/verify tool, then a short wrap-up). So gate the
+  //     structural strip with the substantive floor — narration only if the
+  //     block ALSO looks like narration OR is below the substantive floor.
+  //   - structural flag FALSE ⇒ present-and-false definitively overrides the
+  //     opener regex: no tool_use followed, so it is a terminal-style block,
+  //     never narration (#3237).
+  //   - structural flag ABSENT ⇒ fall back to the opener/trailer heuristic.
+  // Otherwise the earlier blocks carry real content — keep the full joined text
+  // so a legitimate multi-block answer is never truncated to its last
+  // paragraph (#3237).
   const allNarration = preceding.every(c =>
-    c.followedByToolUse !== undefined ? c.followedByToolUse : isNarrationBlock(c.text),
+    c.followedByToolUse === true
+      ? isNarrationBlock(c.text) || c.text.trim().length < FLUSH_SUBSTANTIVE_MIN_CHARS
+      : c.followedByToolUse === false
+        ? false
+        : isNarrationBlock(c.text),
   )
   return allNarration ? answer : candidates.map(c => c.text).join('\n\n')
 }
@@ -283,7 +303,9 @@ export interface FlushDecisionInput {
    * Consumed by `selectFlushDeliveryText` to separate a narration preamble from
    * a real answer paragraph that merely opens with a narration phrase (#3237).
    * When absent (legacy caller / lost provenance) the strip falls back to the
-   * opener/trailer heuristic, so this field is strictly additive. */
+   * opener/trailer heuristic. Present-and-false is additive (only rescues a
+   * mis-stripped terminal answer); present-and-true is gated by the substantive
+   * floor rather than trusted alone. */
   capturedBlockMeta?: boolean[]
   /** Feature flag — defaults to true. Pass `false` to force skip everywhere. */
   flushEnabled?: boolean


### PR DESCRIPTION
## Summary

Post-merge review of #3338 (commit 4f167b9, \"fix(gateway): use block provenance for flush narration-strip (#3237)\") flagged three findings in `telegram-plugin/turn-flush-safety.ts`. This fixes all three.

**F1 (MEDIUM, correctness regression).** `selectFlushDeliveryText` classified a captured block as narration UNCONDITIONALLY when its `followedByToolUse === true`. So a substantial real-content block followed by any `tool_use` — the model writes a real answer paragraph, calls a memory/verify tool, then a short wrap-up — was dropped and only the wrap-up delivered. The structural strip is now gated by the substantive floor:

```
c.followedByToolUse === true
  ? isNarrationBlock(c.text) || c.text.trim().length < FLUSH_SUBSTANTIVE_MIN_CHARS
  : c.followedByToolUse === false ? false : isNarrationBlock(c.text)
```

Intent: structural flag true ⇒ narration only if it ALSO fails the substance check. Present-and-false still overrides the opener regex (the #3237 fix); a short preamble the opener misses is still stripped via the length floor.

**F2 (LOW).** Corrected the comments that falsely claimed the provenance change is \"strictly additive / never worse than the opener-only strip\". Present-and-false is additive; present-and-true is now gated by substance.

**F3 (LOW, test gap).** Added a regression test exercising a SUBSTANTIAL real-content block (≥ `FLUSH_SUBSTANTIVE_MIN_CHARS`, not narration-shaped) with `meta=true` preceding the terminal block — asserts it is KEPT. Verified it FAILS on pre-fix source and passes with the fix. Also added a companion test asserting a SHORT block with `meta=true` is still stripped (length-floor branch). All existing tests stay green, including the #3237 regression test and the zip-alignment test.

## Why

Restores correctness for the common draft-then-verify shape while preserving the #3237 duplicate-reply fix.

## Test plan

- Scoped vitest `telegram-plugin/tests/turn-flush-safety.test.ts`: 68 pass.
- New F3 test fails on pre-fix `turn-flush-safety.ts` (1 failed / 67 passed), passes with fix.
- `npm run lint`: clean.
- `npm run test:bun`: 1221 pass / 2 skip / 0 fail.

## Risk

Low, single pure function + comments + tests. Job spec: conversational-pacing / turn-flush safety net (`reference/rfcs/conversational-pacing.md`).

Refs #3338 #3237

🤖 Generated with [Claude Code](https://claude.com/claude-code)