### PR TITLE
feat(model): add Grok 4.5/4.3, Kimi K3/K2.7-code, GPT-5.6 to /model picker

### DIFF
--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -666,6 +666,16 @@ export const SR_MODEL_LABELS: Record<string, string> = {
   'sr-gemini-flash-lite': 'Gemini 3.1 Flash Lite',
   'sr-minimax-m3': 'MiniMax M3',
   'sr-deepseek-v4-flash': 'DeepSeek V4 Flash',
+  // xAI Grok / Moonshot Kimi / OpenAI GPT-5.6 (added 2026-07-19, pairs with the
+  // live litellm sr-* model_name additions). The `.5`/`.7`/`.6` version dots are
+  // valid model-arg chars (MODEL_ARG_RE) and match the sr-* ids in the proxy config.
+  'sr-grok-4.5': 'Grok 4.5',
+  'sr-grok-4.3': 'Grok 4.3',
+  'sr-kimi-k3': 'Kimi K3',
+  'sr-kimi-k2.7-code': 'Kimi K2.7 Code',
+  'sr-gpt-5.6-sol': 'GPT-5.6 Sol',
+  'sr-gpt-5.6-terra': 'GPT-5.6 Terra',
+  'sr-gpt-5.6-luna': 'GPT-5.6 Luna',
 }
 
 /**
@@ -681,6 +691,14 @@ export const SR_MODEL_ALIASES: Record<string, string> = {
   r1: 'sr-deepseek-r1',
   glm: 'sr-glm-5',
   codex: 'sr-codex-5.5',
+  // Flagship keyboard buttons for the three providers added 2026-07-19. Each
+  // points at that provider's top tier; the cheaper tiers (grok-4.3,
+  // kimi-k2.7-code, gpt-5.6-terra/luna) stay typeable via `/model sr-<id>` and
+  // keep a friendly label above, matching the "labels are a superset of buttons"
+  // design (SR_MODEL_LABELS doc comment).
+  grok: 'sr-grok-4.5',
+  kimi: 'sr-kimi-k3',
+  gpt: 'sr-gpt-5.6-sol',
 }
 
 /** Expand a short alias (case-insensitive) to its full sr-* id, or return the original. */

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -444,6 +444,30 @@ describe("SR_MODEL_ALIASES / expandSrAlias", () => {
   it("every alias target is a sr-* id", () => {
     for (const target of Object.values(SR_MODEL_ALIASES)) expect(isSrModel(target)).toBe(true);
   });
+  it("2026-07-19 grok/kimi/gpt flagship buttons expand to their sr-* ids", () => {
+    expect(expandSrAlias("grok")).toBe("sr-grok-4.5");
+    expect(expandSrAlias("kimi")).toBe("sr-kimi-k3");
+    expect(expandSrAlias("gpt")).toBe("sr-gpt-5.6-sol");
+  });
+  it("new flagship buttons are offline-trustable carriers (#3042 gate)", () => {
+    for (const a of ["grok", "kimi", "gpt"]) expect(isOfflineTrustedModelToken(a)).toBe(true);
+    for (const id of ["sr-grok-4.5", "sr-kimi-k3", "sr-gpt-5.6-sol"])
+      expect(isOfflineTrustedModelToken(id)).toBe(true);
+  });
+  it("labels every new grok/kimi/gpt-5.6 sr-* id (typeable tiers included)", () => {
+    for (const id of [
+      "sr-grok-4.5",
+      "sr-grok-4.3",
+      "sr-kimi-k3",
+      "sr-kimi-k2.7-code",
+      "sr-gpt-5.6-sol",
+      "sr-gpt-5.6-terra",
+      "sr-gpt-5.6-luna",
+    ]) {
+      expect(SR_MODEL_LABELS[id]).toBeTypeOf("string");
+      expect(isValidModelArg(id)).toBe(true);
+    }
+  });
 });
 
 describe("classifyDiscoveredOptions", () => {


### PR DESCRIPTION
## Summary
Adds friendly labels + flagship keyboard buttons for seven new `sr-*` models to the Telegram `/model` picker, pairing with the live LiteLLM proxy `model_list` additions.

New models (all via OpenRouter, no OAuth forwarding — invariants I2/I6):
| Button / alias | sr-* id | Route |
|---|---|---|
| `grok` | `sr-grok-4.5` | x-ai/grok-4.5 (flagship) |
| — | `sr-grok-4.3` | x-ai/grok-4.3 |
| `kimi` | `sr-kimi-k3` | moonshotai/kimi-k3 (flagship) |
| — | `sr-kimi-k2.7-code` | moonshotai/kimi-k2.7-code |
| `gpt` | `sr-gpt-5.6-sol` | openai/gpt-5.6-sol (flagship) |
| — | `sr-gpt-5.6-terra` | openai/gpt-5.6-terra |
| — | `sr-gpt-5.6-luna` | openai/gpt-5.6-luna |

Cheaper tiers stay typeable via `/model sr-<id>` and keep a friendly label (labels-are-a-superset-of-buttons design).

## Why
Operator asked to make the new Grok/OpenAI/Kimi models available on LiteLLM and selectable by switchroom agents. **The host LiteLLM `config.yaml` already carries these 7 models (canonical `openrouter/*` + `sr-*` twins, cost overrides, none in `model_group_settings`) — applied, restarted, and verified end-to-end (both `/v1/messages` and `/v1/chat/completions` return 200 for every new `sr-*` name), and synced into Coolify's `local_file_volumes` DB so a redeploy won't revert it.** This PR is the `/model` UX layer that ships with the next release.

## Test plan
- `telegram-plugin/tests/model-command.test.ts` — 74 pass. New cases: grok/kimi/gpt expand to their `sr-*` ids; are offline-trusted carriers (#3042); every new `sr-*` id is labeled + a valid model arg.
- `npm run lint` clean (all guards).

## Risk
Low — additive to two display tables (`SR_MODEL_LABELS`, `SR_MODEL_ALIASES`). No routing/transport/gateway change.

Job: on-the-leash model selection — advances the subscription-honest + always-available outcomes via metered LiteLLM routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)