### PR TITLE
feat(model): add sol/terra/luna /model aliases for GPT-5.6 tiers

### DIFF
--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -699,6 +699,11 @@ export const SR_MODEL_ALIASES: Record<string, string> = {
   grok: 'sr-grok-4.5',
   kimi: 'sr-kimi-k3',
   gpt: 'sr-gpt-5.6-sol',
+  // Per-tier buttons for the GPT-5.6 line so each is a one-word shortcut
+  // (`gpt` stays the flagship-Sol default). Added 2026-07-19.
+  sol: 'sr-gpt-5.6-sol',
+  terra: 'sr-gpt-5.6-terra',
+  luna: 'sr-gpt-5.6-luna',
 }
 
 /** Expand a short alias (case-insensitive) to its full sr-* id, or return the original. */

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -449,6 +449,12 @@ describe("SR_MODEL_ALIASES / expandSrAlias", () => {
     expect(expandSrAlias("kimi")).toBe("sr-kimi-k3");
     expect(expandSrAlias("gpt")).toBe("sr-gpt-5.6-sol");
   });
+  it("per-tier GPT-5.6 buttons sol/terra/luna expand to their sr-* ids", () => {
+    expect(expandSrAlias("sol")).toBe("sr-gpt-5.6-sol");
+    expect(expandSrAlias("terra")).toBe("sr-gpt-5.6-terra");
+    expect(expandSrAlias("luna")).toBe("sr-gpt-5.6-luna");
+    for (const a of ["sol", "terra", "luna"]) expect(isOfflineTrustedModelToken(a)).toBe(true);
+  });
   it("new flagship buttons are offline-trustable carriers (#3042 gate)", () => {
     for (const a of ["grok", "kimi", "gpt"]) expect(isOfflineTrustedModelToken(a)).toBe(true);
     for (const id of ["sr-grok-4.5", "sr-kimi-k3", "sr-gpt-5.6-sol"])


### PR DESCRIPTION
## Summary
Follow-up to #3341. Adds one-word `/model` shortcuts + keyboard buttons for each GPT-5.6 tier:
| alias | sr-* id |
|---|---|
| `sol` | `sr-gpt-5.6-sol` (flagship) |
| `terra` | `sr-gpt-5.6-terra` (balanced) |
| `luna` | `sr-gpt-5.6-luna` (cost-efficient) |

`gpt` stays the flagship-Sol default alias. These route to the same live LiteLLM `sr-*` model_list entries already in the proxy (no OAuth forward — I2/I6).

## Why
Operator asked for friendly aliases for all three tiers, not just the flagship.

## Test plan
- `telegram-plugin/tests/model-command.test.ts` — 75 pass; new case asserts sol/terra/luna expand to their sr-* ids and are offline-trusted carriers (#3042).
- `npm run lint` clean.

## Risk
Low — three additive `SR_MODEL_ALIASES` entries, no routing/transport change.

Job: on-the-leash model selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)