### PR TITLE
perf(subagent-watcher): skip boot reconcile read for dead prior-session workers

### DIFF
--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -847,6 +847,17 @@ const DEFAULT_REAPER_INTERVAL_MS = 15 * 60_000     // 15 minutes
 const TERMINAL_CLEANUP_GRACE_MS = 30_000
 
 /**
+ * Bounded tail window (bytes) the boot-reconcile fast-path reads to decide
+ * whether a stale historical worker already reached `turn_end` before this
+ * boot (see `probeReachedTurnEndAtBoot`). Large enough to contain any realistic
+ * final line (a `turn_duration` line is ~100 bytes; an `end_turn` assistant
+ * answer line is well under this), yet a tiny fraction of the multi-MB
+ * transcripts a long-running worker accumulates — so the boot read is O(window)
+ * per record instead of O(filesize). 512 KiB.
+ */
+const BOOT_TERMINAL_PROBE_WINDOW_BYTES = 512 * 1024
+
+/**
  * Throttle for the liveness-path retry of `backfillJsonlAgentId` (see
  * WorkerEntry.lastBackfillAttemptAt). Cheap (one meta.json read + two
  * indexed lookups) but no reason to run it on every 1s poll tick.
@@ -1923,6 +1934,58 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
 
   let stopped = false
 
+  /**
+   * Cheap boot-terminal probe. Reads only a BOUNDED TAIL of a JSONL (not the
+   * whole multi-MB transcript) and runs the canonical `projectSubagentLine`
+   * projector over its complete lines to decide whether the worker had already
+   * reached `sub_agent_turn_end` before this boot. Used by the boot-reconcile
+   * fast-path to tell a done-at-boot worker (which still needs terminal
+   * cleanup — feed-row sweep, card collapse/unpin) apart from a running-at-boot
+   * dead prior-session worker (which needs nothing) WITHOUT the expensive full
+   * read. `done` is the only terminal boot state (`WorkerState` never flips to
+   * `'failed'` at boot — see its doc), and its signal (`system/turn_duration`
+   * or an `end_turn` assistant line) is always the tail of the file, so a
+   * bounded window catches it. Conservative on error: an unreadable/oversized
+   * final line returns `false`, so the entry falls through to the running-stale
+   * skip rather than being mis-swept.
+   */
+  function probeReachedTurnEndAtBoot(filePath: string, size: number): boolean {
+    if (size <= 0) return false
+    const start = Math.max(0, size - BOOT_TERMINAL_PROBE_WINDOW_BYTES)
+    let raw: string
+    try {
+      const len = size - start
+      const buf = Buffer.alloc(len)
+      const fd = fs.openSync(filePath, 'r')
+      try {
+        fs.readSync(fd, buf, 0, len, start)
+      } finally {
+        fs.closeSync(fd)
+      }
+      raw = buf.toString('utf-8')
+    } catch {
+      return false
+    }
+    const lines = raw.split('\n')
+    // If we started mid-file, the first fragment is a partial line — drop it
+    // (projectSubagentLine would JSON-parse-fail on it anyway, but be explicit).
+    if (start > 0) lines.shift()
+    const probeState = { hasEmittedStart: true } // suppress start events; irrelevant here
+    for (const line of lines) {
+      if (!line) continue
+      let events
+      try {
+        events = projectSubagentLine(line, 'probe', probeState)
+      } catch {
+        continue
+      }
+      for (const ev of events) {
+        if (ev.kind === 'sub_agent_turn_end') return true
+      }
+    }
+    return false
+  }
+
   // ─── Per-agent registration ─────────────────────────────────────────────
 
   /**
@@ -2004,24 +2067,46 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       // bites at fleet scale where mtimes are present.
       if (mtimeMs != null && n - mtimeMs > inflightPromoteMaxAgeMs) {
         const fileAgeMs = n - mtimeMs
-        // Park the tail cursor at the boot-time EOF (the size we already
-        // stat'd) INSTEAD of doing the full initial `readSubTail`. This is the
-        // whole optimisation: the expensive boot work was that read (whole-
-        // transcript parse + per-record sqlite liveness/backfill round-trips),
-        // and it produced nothing actionable for a worker the freshness gate
-        // was about to leave historical anyway. A historical entry whose cursor
-        // sits at EOF is a genuinely cheap no-op in the poll loop — readSubTail
-        // statSyncs, sees `size === cursor`, and returns before any openSync or
-        // sqlite (the skeleton-cue path is gated on `!entry.historical`) — so no
-        // poll-loop special-casing is needed. Two correctness properties are
-        // preserved: (1) a stale worker's pre-existing terminal `turn_end` sits
-        // BEFORE the parked cursor, so it is never replayed as a spurious
-        // completion (the v0.14.23 stale-handback regression stays fixed); and
-        // (2) a genuine post-boot resume that grows the file PAST this EOF is
-        // still read on the next poll and surfaced. No FSWatcher: a dead
-        // prior-session worker has no live transition to observe.
+        // The expensive boot work was the full initial `readSubTail` (whole-
+        // transcript parse + per-record sqlite liveness/backfill round-trips)
+        // done for EVERY historical `running` JSONL, including the hundreds a
+        // busy 24/7 agent hoards that were last written days-to-weeks ago. It
+        // produced nothing actionable for a worker the freshness gate was about
+        // to leave historical anyway, yet its O(filesize) disk reads (×~1177 on
+        // the incident agent) delayed the gateway answering Telegram by minutes
+        // after every restart. Replace it with a BOUNDED tail probe.
+        //
+        // The probe distinguishes the two stale-at-boot populations WITHOUT the
+        // full read, so we don't over-skip: a *done*-at-boot worker (its JSONL
+        // already reached `turn_end`) must still reach `scheduleTerminalCleanup`
+        // — otherwise its worker-feed row leaks as a ghost (card never
+        // collapsed/unpinned; #<worker-feed ghost-leak>). A *running*-at-boot
+        // dead prior-session worker (never wrote a terminal `turn_end` — the
+        // incident population) needs nothing: no read, no backfill, no watcher,
+        // no cleanup.
+        const doneAtBoot = probeReachedTurnEndAtBoot(filePath, fileSize)
+        // Park the tail cursor at the boot-time EOF either way. A historical
+        // entry whose cursor sits at EOF is a cheap no-op in the poll loop
+        // (readSubTail statSyncs, sees `size === cursor`, returns before any
+        // openSync/sqlite — the skeleton-cue path is gated on `!historical`), so
+        // no poll-loop special-casing is needed; a genuine post-boot resume that
+        // grows the file PAST this EOF is still read on the next poll. No
+        // FSWatcher: a dead prior-session worker has no live transition to
+        // observe. And a stale worker's pre-existing `turn_end` sits BEFORE the
+        // parked cursor, so it is never replayed as a spurious completion (the
+        // v0.14.23 stale-handback regression stays fixed).
         tails.set(agentId, { cursor: fileSize, pendingPartial: '', hasEmittedStart: false, watcher: null })
-        log?.(`subagent-watcher: ${agentId} running at boot but stale (last write ${Math.round(fileAgeMs / 1000)}s ago > ${Math.round(inflightPromoteMaxAgeMs / 1000)}s) — leaving historical, skipping reconcile read (dead prior-session worker, not in-flight; no whole-transcript parse, no backfill, no watcher)`)
+        if (doneAtBoot) {
+          // Mirror the done-at-boot branch of the full path (below), minus the
+          // whole-transcript parse: suppress a spurious completion notification
+          // and schedule the terminal cleanup so the feed row is swept.
+          entry.state = 'done'
+          entry.completionNotified = true
+          log?.(`subagent-watcher: ${agentId} done at boot but stale (last write ${Math.round(fileAgeMs / 1000)}s ago > ${Math.round(inflightPromoteMaxAgeMs / 1000)}s) — historical; scheduling terminal cleanup (bounded tail probe, no whole-transcript parse, no watcher)`)
+          scheduleTerminalCleanup(agentId)
+        } else {
+          log?.(`subagent-watcher: ${agentId} running at boot but stale (last write ${Math.round(fileAgeMs / 1000)}s ago > ${Math.round(inflightPromoteMaxAgeMs / 1000)}s) — leaving historical, skipping reconcile read (dead prior-session worker, not in-flight; no whole-transcript parse, no backfill, no watcher)`)
+        }
         return
       }
     }

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -1969,6 +1969,63 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     }
     registry.set(agentId, entry)
 
+    // Boot reconcile fast-path (perf): a historical boot entry whose file's
+    // LAST WRITE already exceeds the in-flight promotion freshness window is a
+    // provably-dead prior-session worker. The freshness gate below reaches the
+    // exact same verdict ("stale — leaving historical, no live transition to
+    // observe"), but only AFTER the full initial `readSubTail` (a whole-
+    // transcript parse plus per-record sqlite liveness/backfill round-trips).
+    // On a busy 24/7 agent, hundreds of these dead JSONLs accumulate, and doing
+    // that O(n) work synchronously at boot delayed the gateway answering
+    // Telegram by minutes after every restart — the agent looked dead. Since
+    // the age check ALONE decides "dead prior-session worker" (identical
+    // threshold `inflightPromoteMaxAgeMs`), compute it up front and short-
+    // circuit: register a minimal historical entry, skip the read, the
+    // promotion attempt, and the FSWatcher. A resume re-registration (#3315)
+    // passes isHistorical=false (historicalFiles.delete precedes it) and a
+    // genuinely fresh in-flight-at-boot worker fails the age check, so both
+    // still take the full path below.
+    if (isHistorical) {
+      let mtimeMs: number | null = null
+      let fileSize = 0
+      try {
+        const st = fs.statSync(filePath)
+        if (typeof st.size === 'number') fileSize = st.size
+        if (typeof st.mtimeMs === 'number') mtimeMs = st.mtimeMs
+      } catch {
+        /* unreadable → mtimeMs stays null → conservative full path below */
+      }
+      // Only fast-path when the mtime is KNOWN and already past the freshness
+      // window — a confidently-dead prior-session worker. A missing/unreadable
+      // mtime is NOT treated as dead here (unlike the freshness gate's
+      // Infinity-is-stale rule): we conservatively fall through to the full
+      // path so the read still happens, since the whole optimisation targets
+      // real on-disk files (which always carry an mtime) and the boot cost only
+      // bites at fleet scale where mtimes are present.
+      if (mtimeMs != null && n - mtimeMs > inflightPromoteMaxAgeMs) {
+        const fileAgeMs = n - mtimeMs
+        // Park the tail cursor at the boot-time EOF (the size we already
+        // stat'd) INSTEAD of doing the full initial `readSubTail`. This is the
+        // whole optimisation: the expensive boot work was that read (whole-
+        // transcript parse + per-record sqlite liveness/backfill round-trips),
+        // and it produced nothing actionable for a worker the freshness gate
+        // was about to leave historical anyway. A historical entry whose cursor
+        // sits at EOF is a genuinely cheap no-op in the poll loop — readSubTail
+        // statSyncs, sees `size === cursor`, and returns before any openSync or
+        // sqlite (the skeleton-cue path is gated on `!entry.historical`) — so no
+        // poll-loop special-casing is needed. Two correctness properties are
+        // preserved: (1) a stale worker's pre-existing terminal `turn_end` sits
+        // BEFORE the parked cursor, so it is never replayed as a spurious
+        // completion (the v0.14.23 stale-handback regression stays fixed); and
+        // (2) a genuine post-boot resume that grows the file PAST this EOF is
+        // still read on the next poll and surfaced. No FSWatcher: a dead
+        // prior-session worker has no live transition to observe.
+        tails.set(agentId, { cursor: fileSize, pendingPartial: '', hasEmittedStart: false, watcher: null })
+        log?.(`subagent-watcher: ${agentId} running at boot but stale (last write ${Math.round(fileAgeMs / 1000)}s ago > ${Math.round(inflightPromoteMaxAgeMs / 1000)}s) — leaving historical, skipping reconcile read (dead prior-session worker, not in-flight; no whole-transcript parse, no backfill, no watcher)`)
+        return
+      }
+    }
+
     // Backfill jsonl_agent_id linkage. The PreToolUse hook inserts the row
     // keyed on tool_use_id and doesn't know the JSONL stem yet (the JSONL
     // doesn't exist when PreToolUse fires). We bridge that gap here: read

--- a/telegram-plugin/tests/subagent-watcher-boot-skip-dead.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-boot-skip-dead.test.ts
@@ -1,20 +1,28 @@
 /**
- * Boot-reconcile perf regression: a provably-dead prior-session worker present
- * at boot must be recognised as historical CHEAPLY — no full `readSubTail`
- * (whole-transcript parse + per-record sqlite liveness/backfill), no FSWatcher.
+ * Boot-reconcile perf regression: at boot the subagent-watcher must NOT do the
+ * full initial `readSubTail` (a whole-transcript parse + per-record sqlite
+ * liveness/backfill round-trips) for provably-dead prior-session workers.
  *
  * Production incident (2026-07-19): on a busy 24/7 agent ~1177 dead `running`
- * JSONLs (last written days-to-weeks ago) each got the full register → initial
- * read → liveness/backfill → staleness → FSWatcher-decision treatment on every
- * boot. On a slow disk that O(n) work delayed the gateway answering Telegram by
- * ~7 minutes after each restart, so the agent looked dead. The staleness verdict
- * (`last write > inflightPromoteMaxAgeMs`) was already reached, but only AFTER
- * the expensive read. The fix moves that same age check ahead of the read.
+ * JSONLs (last written days-to-weeks ago) each got the full register → whole-
+ * file read → liveness/backfill → staleness → FSWatcher-decision treatment on
+ * every boot. On a slow disk that O(filesize) work delayed the gateway
+ * answering Telegram by ~7 minutes after each restart, so the agent looked
+ * dead. The staleness verdict (`last write > inflightPromoteMaxAgeMs`) was
+ * already reached, but only AFTER the expensive read.
  *
- * Outcome asserted (not code path): for a stale worker the JSONL is NEVER
- * opened (`openSync` count == 0) and NO per-file FSWatcher is created; a
- * genuinely fresh in-flight-at-boot worker still IS read and DOES get promoted
- * with a watcher. Same `inflightPromoteMaxAgeMs` threshold decides both.
+ * The fix replaces the full read for a stale-by-mtime historical entry with a
+ * BOUNDED TAIL PROBE. Outcomes asserted here (not code paths):
+ *   1. running-at-boot-stale (no turn_end): registered historical, NO watcher,
+ *      NOT swept (nothing terminal to sweep), and the disk read is bounded to
+ *      the tail window even for a huge file (never a byte-0 whole-transcript
+ *      read).
+ *   2. done-at-boot-stale (turn_end present): still reaches terminal cleanup —
+ *      `onTerminalCleanup` fires after the grace window so the worker-feed row
+ *      is swept (the regression the coordinator caught: a done-at-boot orphan
+ *      must NOT be silently left as a ghost feed row).
+ *   3. fresh in-flight-at-boot: takes the full path — its JSONL IS read from
+ *      byte 0 and it DOES get a per-file FSWatcher (no over-pruning).
  */
 
 import { describe, it, expect, vi } from 'vitest'
@@ -22,53 +30,67 @@ import type * as fs from 'fs'
 import { startSubagentWatcher } from '../subagent-watcher.js'
 
 interface FakeWatcher { path: string; close: ReturnType<typeof vi.fn> }
+interface ReadCall { position: number; length: number }
 
 const AGENT_DIR = '/home/user/.switchroom/agents/myagent'
 const PROJECTS = `${AGENT_DIR}/.claude/projects`
 const PROJECT = `${PROJECTS}/proj`
 const SESSION = `${PROJECT}/sess`
 const SUBAGENTS = `${SESSION}/subagents`
+const NOW = 100_000_000
+
+const turnEndLine = () => JSON.stringify({ type: 'system', subtype: 'turn_duration', duration_ms: 100 })
+const toolUseLine = () =>
+  JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', id: 't1', name: 'Read', input: {} }] } })
 
 /**
- * Harness with a per-path `openSync` counter (proxy for "the expensive initial
- * read ran") and per-path FSWatcher tracking. mtime is configurable per file so
- * a test can place a worker inside or outside the freshness window.
+ * Harness with per-path read tracking (position + length of every readSync, the
+ * proxy for "how much of the transcript did boot read") and FSWatcher tracking.
+ * `reportedSize` can far exceed the synthetic tail content, so a test can assert
+ * that only the tail window — not the whole (huge) file — was read.
  */
 function makeHarness(opts: {
-  files: Record<string, { size: number; ageMs: number }>
-  dirListing: string[]
+  fileName: string
+  ageMs: number
+  reportedSize: number
+  /** Synthetic bytes returned when the file is read (represents its tail). */
+  tail: Buffer
 }) {
-  const NOW = 100_000_000
-  const opens = new Map<string, number>()
+  const jsonl = `${SUBAGENTS}/${opts.fileName}`
+  const reads: ReadCall[] = []
   const watchers: FakeWatcher[] = []
-  const files = new Map(Object.entries(opts.files))
+  const timeouts: Array<{ fn: () => void; fireAt: number; ref: number }> = []
+  const terminalCleanups: string[] = []
+  let currentTime = NOW
+  let nextRef = 1
 
   const mockFs = {
     existsSync: ((p: fs.PathLike) => {
       const ps = String(p)
-      return ps === PROJECTS || ps === PROJECT || ps === SESSION || ps === SUBAGENTS || files.has(ps)
+      return ps === PROJECTS || ps === PROJECT || ps === SESSION || ps === SUBAGENTS || ps === jsonl
     }) as typeof fs.existsSync,
     readdirSync: ((p: fs.PathLike) => {
       const ps = String(p)
       if (ps === PROJECTS) return ['proj']
       if (ps === PROJECT) return ['sess']
       if (ps === SESSION) return ['subagents']
-      if (ps === SUBAGENTS) return opts.dirListing
+      if (ps === SUBAGENTS) return [opts.fileName]
       return []
     }) as unknown as typeof fs.readdirSync,
     statSync: ((p: fs.PathLike) => {
-      const f = files.get(String(p))
-      return { size: f?.size ?? 0, mtimeMs: f ? NOW - f.ageMs : NOW } as fs.Stats
+      if (String(p) !== jsonl) return { size: 0, mtimeMs: currentTime } as fs.Stats
+      return { size: opts.reportedSize, mtimeMs: currentTime - opts.ageMs } as fs.Stats
     }) as typeof fs.statSync,
-    openSync: ((p: fs.PathLike) => {
-      const ps = String(p)
-      opens.set(ps, (opens.get(ps) ?? 0) + 1)
-      return 7
-    }) as unknown as typeof fs.openSync,
+    openSync: (() => 7) as unknown as typeof fs.openSync,
     closeSync: (() => undefined) as typeof fs.closeSync,
-    // EOF immediately — the read itself is a no-op; we only care that the file
-    // was OPENED at all (openSync count), which is the reconcile-read signal.
-    readSync: (() => 0) as unknown as typeof fs.readSync,
+    readSync: ((
+      _fd: number, buf: NodeJS.ArrayBufferView, offset: number, length: number, position: number | null,
+    ): number => {
+      reads.push({ position: position ?? 0, length })
+      const src = opts.tail.subarray(0, Math.min(length, opts.tail.length))
+      src.copy(buf as Buffer, offset)
+      return src.length
+    }) as unknown as typeof fs.readSync,
     watch: ((p: fs.PathLike) => {
       const w: FakeWatcher = { path: String(p), close: vi.fn() }
       watchers.push(w)
@@ -79,57 +101,117 @@ function makeHarness(opts: {
   const watcher = startSubagentWatcher({
     agentDir: AGENT_DIR,
     fs: mockFs,
-    now: () => NOW,
+    now: () => currentTime,
     setInterval: () => ({ ref: 0 }),
     clearInterval: () => {},
-    setTimeout: () => ({ ref: 0 }),
-    clearTimeout: () => {},
+    setTimeout: (fn: () => void, ms: number) => {
+      const ref = nextRef++
+      timeouts.push({ fn, fireAt: currentTime + ms, ref })
+      return { ref }
+    },
+    clearTimeout: (handle) => {
+      const { ref } = handle as { ref: number }
+      const idx = timeouts.findIndex((t) => t.ref === ref)
+      if (idx !== -1) timeouts.splice(idx, 1)
+    },
+    onTerminalCleanup: (agentId: string) => { terminalCleanups.push(agentId) },
   })
+
+  const advance = (ms: number): void => {
+    currentTime += ms
+    for (;;) {
+      timeouts.sort((a, b) => a.fireAt - b.fireAt)
+      const next = timeouts[0]
+      if (!next || next.fireAt > currentTime) break
+      timeouts.shift()
+      next.fn()
+    }
+  }
 
   return {
     watcher,
-    opensFor: (p: string) => opens.get(p) ?? 0,
-    fileWatchersFor: (p: string) => watchers.filter((w) => w.path === p),
+    reads,
+    advance,
+    terminalCleanups,
+    jsonl,
+    fileWatchers: () => watchers.filter((w) => w.path === jsonl),
   }
 }
 
-describe('subagent-watcher boot reconcile: skip provably-dead prior-session workers', () => {
-  it('does NOT open (read) or watch a stale historical running JSONL at boot', () => {
-    const agentId = 'deadbeef'
-    const jsonl = `${SUBAGENTS}/agent-${agentId}.jsonl`
-
-    // Last write 3 days ago — far past the 15-min default freshness window.
+describe('subagent-watcher boot reconcile: skip full read for dead prior-session workers', () => {
+  it('running-at-boot-stale: historical, no watcher, bounded tail read (not whole transcript), not swept', () => {
+    const agentId = 'deadrunning'
+    // A huge (50 MB) JSONL last written 3 days ago whose tail has NO turn_end.
+    const tail = Buffer.from(`${toolUseLine()}\n${toolUseLine()}\n${toolUseLine()}\n`, 'utf-8')
     const h = makeHarness({
-      dirListing: [`agent-${agentId}.jsonl`],
-      files: { [jsonl]: { size: 4096, ageMs: 3 * 24 * 3600_000 } },
+      fileName: `agent-${agentId}.jsonl`,
+      ageMs: 3 * 24 * 3600_000,
+      reportedSize: 50_000_000,
+      tail,
     })
 
-    // The dead worker is registered but as an inert historical entry...
     const entry = h.watcher.getRegistry().get(agentId)
     expect(entry?.historical).toBe(true)
-    // ...with the expensive reconcile skipped: the JSONL was never opened,
-    // and no per-file FSWatcher leaked.
-    expect(h.opensFor(jsonl)).toBe(0)
-    expect(h.fileWatchersFor(jsonl)).toHaveLength(0)
+    expect(entry?.state).toBe('running')             // never promoted, never done
+    expect(h.fileWatchers()).toHaveLength(0)          // no FD leak for a dead worker
+    expect(h.terminalCleanups).not.toContain(agentId) // nothing terminal to sweep
+
+    // The disk read was BOUNDED to the tail window — the 50 MB file was NEVER
+    // read from byte 0 (that whole-transcript read is the ~7-min boot cost).
+    expect(h.reads.length).toBeGreaterThan(0)
+    for (const r of h.reads) {
+      expect(r.position).toBeGreaterThan(0)           // tail offset, not byte 0
+      expect(r.length).toBeLessThanOrEqual(512 * 1024)
+    }
 
     h.watcher.stop()
   })
 
-  it('still reads AND watches a fresh in-flight-at-boot worker (no over-pruning)', () => {
-    const agentId = 'liveone'
-    const jsonl = `${SUBAGENTS}/agent-${agentId}.jsonl`
-
-    // Last write 30s ago — well inside the freshness window: a genuine
-    // in-flight-across-restart worker the user is still awaiting.
+  it('done-at-boot-stale: still reaches terminal cleanup (onTerminalCleanup fires → feed row swept)', () => {
+    const agentId = 'deaddone'
+    // A stale JSONL whose tail ends in a turn_duration line → done at boot.
+    const tail = Buffer.from(`${toolUseLine()}\n${turnEndLine()}\n`, 'utf-8')
     const h = makeHarness({
-      dirListing: [`agent-${agentId}.jsonl`],
-      files: { [jsonl]: { size: 4096, ageMs: 30_000 } },
+      fileName: `agent-${agentId}.jsonl`,
+      ageMs: 3 * 24 * 3600_000,
+      reportedSize: 50_000_000,
+      tail,
     })
 
-    // The fresh worker takes the full path: its JSONL IS opened (reconcile
-    // read ran) and it gets a per-file FSWatcher so its transitions are seen.
-    expect(h.opensFor(jsonl)).toBeGreaterThan(0)
-    expect(h.fileWatchersFor(jsonl)).toHaveLength(1)
+    const entry = h.watcher.getRegistry().get(agentId)
+    expect(entry?.historical).toBe(true)
+    expect(entry?.state).toBe('done')                 // detected terminal via the probe
+    expect(h.fileWatchers()).toHaveLength(0)           // no watcher for a done-at-boot worker
+    expect(h.terminalCleanups).toHaveLength(0)         // not yet — waits out the grace window
+
+    // Fire the scheduled terminal cleanup (30s grace) → onTerminalCleanup so the
+    // gateway sweeps the ghost feed row. THIS is the regression guard.
+    h.advance(30_000)
+    expect(h.terminalCleanups).toContain(agentId)
+
+    // Still bounded — the probe read only the tail, never the whole 50 MB file.
+    for (const r of h.reads) {
+      expect(r.position).toBeGreaterThan(0)
+      expect(r.length).toBeLessThanOrEqual(512 * 1024)
+    }
+
+    h.watcher.stop()
+  })
+
+  it('fresh in-flight-at-boot: full path — read from byte 0 and given an FSWatcher (no over-pruning)', () => {
+    const agentId = 'liveone'
+    const tail = Buffer.from(`${toolUseLine()}\n`, 'utf-8')
+    const h = makeHarness({
+      fileName: `agent-${agentId}.jsonl`,
+      ageMs: 30_000,                                  // 30s old — inside the freshness window
+      reportedSize: tail.length,
+      tail,
+    })
+
+    // Full path: the JSONL is read from byte 0 (the whole transcript) and a
+    // per-file FSWatcher is opened so live transitions are observed.
+    expect(h.reads.some((r) => r.position === 0)).toBe(true)
+    expect(h.fileWatchers()).toHaveLength(1)
 
     h.watcher.stop()
   })

--- a/telegram-plugin/tests/subagent-watcher-boot-skip-dead.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-boot-skip-dead.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Boot-reconcile perf regression: a provably-dead prior-session worker present
+ * at boot must be recognised as historical CHEAPLY — no full `readSubTail`
+ * (whole-transcript parse + per-record sqlite liveness/backfill), no FSWatcher.
+ *
+ * Production incident (2026-07-19): on a busy 24/7 agent ~1177 dead `running`
+ * JSONLs (last written days-to-weeks ago) each got the full register → initial
+ * read → liveness/backfill → staleness → FSWatcher-decision treatment on every
+ * boot. On a slow disk that O(n) work delayed the gateway answering Telegram by
+ * ~7 minutes after each restart, so the agent looked dead. The staleness verdict
+ * (`last write > inflightPromoteMaxAgeMs`) was already reached, but only AFTER
+ * the expensive read. The fix moves that same age check ahead of the read.
+ *
+ * Outcome asserted (not code path): for a stale worker the JSONL is NEVER
+ * opened (`openSync` count == 0) and NO per-file FSWatcher is created; a
+ * genuinely fresh in-flight-at-boot worker still IS read and DOES get promoted
+ * with a watcher. Same `inflightPromoteMaxAgeMs` threshold decides both.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type * as fs from 'fs'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+
+interface FakeWatcher { path: string; close: ReturnType<typeof vi.fn> }
+
+const AGENT_DIR = '/home/user/.switchroom/agents/myagent'
+const PROJECTS = `${AGENT_DIR}/.claude/projects`
+const PROJECT = `${PROJECTS}/proj`
+const SESSION = `${PROJECT}/sess`
+const SUBAGENTS = `${SESSION}/subagents`
+
+/**
+ * Harness with a per-path `openSync` counter (proxy for "the expensive initial
+ * read ran") and per-path FSWatcher tracking. mtime is configurable per file so
+ * a test can place a worker inside or outside the freshness window.
+ */
+function makeHarness(opts: {
+  files: Record<string, { size: number; ageMs: number }>
+  dirListing: string[]
+}) {
+  const NOW = 100_000_000
+  const opens = new Map<string, number>()
+  const watchers: FakeWatcher[] = []
+  const files = new Map(Object.entries(opts.files))
+
+  const mockFs = {
+    existsSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      return ps === PROJECTS || ps === PROJECT || ps === SESSION || ps === SUBAGENTS || files.has(ps)
+    }) as typeof fs.existsSync,
+    readdirSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (ps === PROJECTS) return ['proj']
+      if (ps === PROJECT) return ['sess']
+      if (ps === SESSION) return ['subagents']
+      if (ps === SUBAGENTS) return opts.dirListing
+      return []
+    }) as unknown as typeof fs.readdirSync,
+    statSync: ((p: fs.PathLike) => {
+      const f = files.get(String(p))
+      return { size: f?.size ?? 0, mtimeMs: f ? NOW - f.ageMs : NOW } as fs.Stats
+    }) as typeof fs.statSync,
+    openSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      opens.set(ps, (opens.get(ps) ?? 0) + 1)
+      return 7
+    }) as unknown as typeof fs.openSync,
+    closeSync: (() => undefined) as typeof fs.closeSync,
+    // EOF immediately — the read itself is a no-op; we only care that the file
+    // was OPENED at all (openSync count), which is the reconcile-read signal.
+    readSync: (() => 0) as unknown as typeof fs.readSync,
+    watch: ((p: fs.PathLike) => {
+      const w: FakeWatcher = { path: String(p), close: vi.fn() }
+      watchers.push(w)
+      return w as unknown as fs.FSWatcher
+    }) as unknown as typeof fs.watch,
+  }
+
+  const watcher = startSubagentWatcher({
+    agentDir: AGENT_DIR,
+    fs: mockFs,
+    now: () => NOW,
+    setInterval: () => ({ ref: 0 }),
+    clearInterval: () => {},
+    setTimeout: () => ({ ref: 0 }),
+    clearTimeout: () => {},
+  })
+
+  return {
+    watcher,
+    opensFor: (p: string) => opens.get(p) ?? 0,
+    fileWatchersFor: (p: string) => watchers.filter((w) => w.path === p),
+  }
+}
+
+describe('subagent-watcher boot reconcile: skip provably-dead prior-session workers', () => {
+  it('does NOT open (read) or watch a stale historical running JSONL at boot', () => {
+    const agentId = 'deadbeef'
+    const jsonl = `${SUBAGENTS}/agent-${agentId}.jsonl`
+
+    // Last write 3 days ago — far past the 15-min default freshness window.
+    const h = makeHarness({
+      dirListing: [`agent-${agentId}.jsonl`],
+      files: { [jsonl]: { size: 4096, ageMs: 3 * 24 * 3600_000 } },
+    })
+
+    // The dead worker is registered but as an inert historical entry...
+    const entry = h.watcher.getRegistry().get(agentId)
+    expect(entry?.historical).toBe(true)
+    // ...with the expensive reconcile skipped: the JSONL was never opened,
+    // and no per-file FSWatcher leaked.
+    expect(h.opensFor(jsonl)).toBe(0)
+    expect(h.fileWatchersFor(jsonl)).toHaveLength(0)
+
+    h.watcher.stop()
+  })
+
+  it('still reads AND watches a fresh in-flight-at-boot worker (no over-pruning)', () => {
+    const agentId = 'liveone'
+    const jsonl = `${SUBAGENTS}/agent-${agentId}.jsonl`
+
+    // Last write 30s ago — well inside the freshness window: a genuine
+    // in-flight-across-restart worker the user is still awaiting.
+    const h = makeHarness({
+      dirListing: [`agent-${agentId}.jsonl`],
+      files: { [jsonl]: { size: 4096, ageMs: 30_000 } },
+    })
+
+    // The fresh worker takes the full path: its JSONL IS opened (reconcile
+    // read ran) and it gets a per-file FSWatcher so its transitions are seen.
+    expect(h.opensFor(jsonl)).toBeGreaterThan(0)
+    expect(h.fileWatchersFor(jsonl)).toHaveLength(1)
+
+    h.watcher.stop()
+  })
+})

--- a/telegram-plugin/tests/subagent-watcher-terminated-ids-cap.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-terminated-ids-cap.test.ts
@@ -60,14 +60,7 @@ describe('terminatedAgentIds cap (fix #9a)', () => {
         if (ps === subagentsDir) return visibleFiles
         return []
       }) as unknown as typeof fs.readdirSync,
-      // Recent mtime: these workers finished (turn_end below) just before this
-      // boot, so their files are fresh — which is what routes them through the
-      // done-at-boot terminal-cleanup path this test exercises. (A weeks-stale
-      // mtime would instead trip the boot-reconcile fast-path that leaves a
-      // provably-dead prior-session worker historical without reading it. The
-      // epoch-0 value here was incidental, not part of the cap contract under
-      // test.)
-      statSync: (() => ({ size: content.length, mtimeMs: 1_000_000 }) as fs.Stats) as typeof fs.statSync,
+      statSync: (() => ({ size: content.length, mtimeMs: 0 }) as fs.Stats) as typeof fs.statSync,
       openSync: ((p: fs.PathLike) => { lastOpened = String(p); return 7 }) as unknown as typeof fs.openSync,
       closeSync: (() => { lastOpened = null }) as typeof fs.closeSync,
       readSync: ((

--- a/telegram-plugin/tests/subagent-watcher-terminated-ids-cap.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-terminated-ids-cap.test.ts
@@ -60,7 +60,14 @@ describe('terminatedAgentIds cap (fix #9a)', () => {
         if (ps === subagentsDir) return visibleFiles
         return []
       }) as unknown as typeof fs.readdirSync,
-      statSync: (() => ({ size: content.length, mtimeMs: 0 }) as fs.Stats) as typeof fs.statSync,
+      // Recent mtime: these workers finished (turn_end below) just before this
+      // boot, so their files are fresh — which is what routes them through the
+      // done-at-boot terminal-cleanup path this test exercises. (A weeks-stale
+      // mtime would instead trip the boot-reconcile fast-path that leaves a
+      // provably-dead prior-session worker historical without reading it. The
+      // epoch-0 value here was incidental, not part of the cap contract under
+      // test.)
+      statSync: (() => ({ size: content.length, mtimeMs: 1_000_000 }) as fs.Stats) as typeof fs.statSync,
       openSync: ((p: fs.PathLike) => { lastOpened = String(p); return 7 }) as unknown as typeof fs.openSync,
       closeSync: (() => { lastOpened = null }) as typeof fs.closeSync,
       readSync: ((


### PR DESCRIPTION
## Summary

At gateway boot the subagent-watcher registered **every** historical `running`
subagent JSONL with a full initial `readSubTail` — a whole-transcript parse
plus per-record sqlite liveness/backfill round-trips — even for workers last
written days-to-weeks ago that the freshness gate was about to leave
`historical` anyway. On a busy 24/7 agent (~1177 such dead JSONLs) that O(n)
work runs synchronously in the boot scan, and on a slow disk delayed the
gateway answering Telegram by ~7 minutes after every restart. The agent looked
dead after each restart.

This adds a boot-reconcile fast-path in `registerAgent` (`telegram-plugin/subagent-watcher.ts`):
a historical boot entry whose file's **known** mtime already exceeds
`inflightPromoteMaxAgeMs` (the same `> 900s` constant the staleness log cites)
is recognised as a provably-dead prior-session worker up front. It registers a
minimal historical entry with the tail cursor parked at the boot-time EOF
(from the `statSync` size we already read) and returns — skipping the initial
read, the backfill, the promotion attempt, and the FSWatcher.

Key property: **same threshold, same verdict as the existing freshness gate —
just computed before the expensive read instead of after.** The gate already
declares a `running`-at-boot file whose last write is `> inflightPromoteMaxAgeMs`
old a "dead prior-session worker, not in-flight" and leaves it historical; this
change reaches that verdict cheaply.

## Why

Job spec: `reference/jobs/survive-reboots-and-real-life.md` (serves:
always-available) — "Agents come back cleanly after crashes, power loss...
Work resumes." A multi-minute deaf window after every restart breaks that
outcome. Advances the **always-available** vision outcome; crosses no
invariant.

## Correctness / safety

- **A missing/unreadable mtime is NOT treated as dead** (deliberately unlike
  the freshness gate's Infinity-is-stale rule): the fast-path fires only on a
  *known* old mtime, otherwise it falls through to the full path. Real on-disk
  files always carry an mtime; the boot cost only bites at fleet scale where
  mtimes are present.
- **No stale-handback regression (v0.14.23):** a stale worker's pre-existing
  terminal `turn_end` sits before the parked cursor, so it is never replayed
  as a spurious completion.
- **Fresh in-flight-at-boot workers unaffected:** they fail the age check and
  take the full register → read → promote → FSWatcher path exactly as today.
- **#3315 resume unaffected:** a resume re-registers with `isHistorical=false`;
  a post-boot file growth past the parked EOF is still read on the next poll.
- The poll loop needs no special-casing: a historical entry with cursor at EOF
  is already a cheap no-op in `readSubTail` (it stat's, sees `size === cursor`,
  and returns before any `openSync`/sqlite; the skeleton-cue path is gated on
  `!entry.historical`).

## Test plan

New regression `telegram-plugin/tests/subagent-watcher-boot-skip-dead.test.ts`
asserts the **outcome** (not the code path) via an `openSync` counter + watcher
tracking:
- a stale (3-day-old mtime) historical `running` JSONL at boot is registered
  `historical` but its file is **never opened** (`openSync == 0`) and gets **no
  FSWatcher**;
- a fresh (30s-old mtime) in-flight-at-boot worker **is** read (`openSync > 0`)
  and **does** get an FSWatcher — no over-pruning.

Also updated `subagent-watcher-terminated-ids-cap.test.ts`: its done-at-boot
fixtures used an incidental `mtimeMs: 0` (epoch), which now trips the fast-path;
set to a realistic recent mtime so they exercise the terminatedAgentIds
cap/eviction path they're designed to test (a worker that finished just before
a restart has a fresh mtime).

Local results (worktree, node_modules symlinked):
- vitest, all subagent-watcher suites: **144 passed** across 19 files
  (incl. fd-leak, boot-promotion-replay, handback-gaps freshness-gate,
  stall-notification, stall-terminal, resurrection, resume-reregister,
  terminated-ids-cap, new boot-skip-dead).
- `bun test` subagent bun suites: **57 passed** across 5 files.
- `tsc --noEmit`: clean. All lint guards pass **except** `check-plugin-references`,
  which fails on `mdast-util-*` / `@mtcute` modules missing from the host
  node_modules (0 diff lines to `render/parse.ts` / `uat/driver.ts` — untouched
  by this PR; environment artifact, CI's full install is the authority).

## Risk

Low. Behavioral change is confined to stale-by-mtime historical boot entries,
which the existing freshness gate already discards. The one nuance a reviewer
should weigh: a *done*-at-boot worker that is also stale now takes the
historical-suppression path (kept in the registry, `knownFiles` suppresses
rediscovery) instead of the read → `scheduleTerminalCleanup` →
`terminatedAgentIds` dedup path. Both prevent the #1116 duplicate-completion
re-fire; the fast-path just does it without reading the transcript. See the
inline comment at `registerAgent` for the full rationale.