### PR TITLE
fix(ci): reap stale wedged workdirs on the self-hosted UAT runner (#3335)

### DIFF
--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -134,6 +134,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      # Runner guard (#3335): sweep stale `switchroom.wedged-*` remnants from the
+      # persistent _work tree so a prior mid-checkout wedge (git clean -ffdx into
+      # D-state on the slow uat-runner-state volume) doesn't accumulate as dead
+      # weight. The remnants are SIBLINGS of the checkout dir (renamed aside by
+      # manual recovery), so `git clean` never touches them and running this
+      # right after checkout is sound. Age-gated (keeps fresh wedges for
+      # forensics) and self-bounded (each rm is `timeout`-wrapped so the guard
+      # can't itself wedge). Best-effort — never fails the job.
+      - name: Reap stale wedged workdirs (runner guard)
+        shell: bash
+        run: bash scripts/ci/reap-stale-workdirs.sh
       - name: Secrets gate
         id: secrets
         run: |
@@ -218,6 +229,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      # Runner guard (#3335): sweep stale `switchroom.wedged-*` remnants — see
+      # the uat-gate-run job above for rationale.
+      - name: Reap stale wedged workdirs (runner guard)
+        shell: bash
+        run: bash scripts/ci/reap-stale-workdirs.sh
       - name: Secrets gate
         id: secrets
         run: |

--- a/scripts/ci/reap-stale-workdirs.sh
+++ b/scripts/ci/reap-stale-workdirs.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Reap stale wedged runner workdirs on the self-hosted uat-host runner (#3335).
+#
+# Self-hosted runners reuse a PERSISTENT `_work` tree across jobs (unlike the
+# ephemeral hosted runners). On 2026-07-18 a canary UAT run wedged mid-checkout:
+# `actions/checkout`'s `git clean -ffdx` went into uninterruptible D-state
+# (disk-wait) on the slow `uat-runner-state` volume. Manual recovery renamed the
+# wedged checkout aside to `switchroom.wedged-<date>` so a fresh clone could
+# proceed — but those remnants then accumulate as dead weight on an already
+# contended volume.
+#
+# This guard sweeps stale `switchroom.wedged-*` remnants BEFORE checkout so they
+# don't pile up. It is deliberately conservative:
+#   - Age-gated: only remnants older than REAP_RETAIN_DAYS (default 1 day) are
+#     removed, so a FRESH wedge from the current incident stays inspectable for
+#     forensics — the exact tension the source issue flags.
+#   - Self-bounded: each `rm -rf` is wrapped in `timeout` so this guard can NEVER
+#     itself wedge the runner on the same slow disk; a timed-out removal warns
+#     and is left in place rather than hanging the job.
+#   - Never fails the job: cleanup is best-effort defense-in-depth, not a gate.
+#
+# Env overrides (all optional):
+#   REAP_ROOT         directory to scan (default: dirname of GITHUB_WORKSPACE —
+#                     the runner's per-repo _work subdir holding the live
+#                     checkout + any renamed-aside wedged remnants).
+#   REAP_RETAIN_DAYS  keep wedged dirs modified within this many days (default 1).
+#   REAP_RM_TIMEOUT   per-dir removal budget in seconds (default 120).
+set -uo pipefail
+
+reap_root="${REAP_ROOT:-}"
+if [ -z "$reap_root" ]; then
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    reap_root="$(dirname "$GITHUB_WORKSPACE")"
+  else
+    echo "reap-stale-workdirs: neither REAP_ROOT nor GITHUB_WORKSPACE set — nothing to do"
+    exit 0
+  fi
+fi
+
+retain_days="${REAP_RETAIN_DAYS:-1}"
+rm_timeout="${REAP_RM_TIMEOUT:-120}"
+retain_min=$(( retain_days * 1440 ))
+
+if [ ! -d "$reap_root" ]; then
+  echo "reap-stale-workdirs: reap root '$reap_root' absent — nothing to do"
+  exit 0
+fi
+
+echo "reap-stale-workdirs: scanning '$reap_root' for switchroom.wedged-* older than ${retain_days}d"
+
+found=0
+reaped=0
+while IFS= read -r -d '' d; do
+  found=$(( found + 1 ))
+  echo "reap-stale-workdirs: removing stale remnant '$d'"
+  if timeout "$rm_timeout" rm -rf "$d"; then
+    reaped=$(( reaped + 1 ))
+  else
+    echo "::warning::reap-stale-workdirs: rm of '$d' exceeded ${rm_timeout}s (disk may be wedged again) — leaving it and continuing"
+  fi
+done < <(find "$reap_root" -maxdepth 1 -type d -name 'switchroom.wedged-*' -mmin "+${retain_min}" -print0 2>/dev/null)
+
+echo "reap-stale-workdirs: done — ${found} stale remnant(s) matched, ${reaped} removed"
+exit 0

--- a/tests/reap-stale-workdirs.test.ts
+++ b/tests/reap-stale-workdirs.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the self-hosted runner guard `scripts/ci/reap-stale-workdirs.sh`
+ * (switchroom#3335 — UAT runner git-clean D-state wedge cleanup).
+ *
+ * The guard sweeps stale `switchroom.wedged-*` remnants that manual recovery
+ * renames aside on the persistent `_work` tree. We assert OUTCOMES against a
+ * real temp dir driven through the actual script:
+ *   - a STALE (old-mtime) wedged remnant is removed,
+ *   - a FRESH wedged remnant is KEPT (forensics retention),
+ *   - non-matching siblings (the live checkout, unrelated dirs) are untouched,
+ *   - a missing reap root is a clean no-op (never fails the job).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, existsSync, utimesSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const SCRIPT = resolve(__dirname, '..', 'scripts', 'ci', 'reap-stale-workdirs.sh')
+
+function runReap(reapRoot: string, env: Record<string, string> = {}): string {
+  return execFileSync('bash', [SCRIPT], {
+    encoding: 'utf-8',
+    env: { ...process.env, REAP_ROOT: reapRoot, ...env },
+  })
+}
+
+/** Backdate a path's mtime by `days` days. */
+function ageDir(path: string, days: number): void {
+  const when = (Date.now() - days * 86_400_000) / 1000
+  utimesSync(path, when, when)
+}
+
+describe('reap-stale-workdirs.sh', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'reap-workdirs-'))
+  })
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('removes a stale (old) switchroom.wedged-* remnant', () => {
+    const stale = join(root, 'switchroom.wedged-20260718')
+    mkdirSync(stale)
+    writeFileSync(join(stale, 'node_modules-remnant'), 'x')
+    ageDir(stale, 5)
+    const out = runReap(root)
+    expect(existsSync(stale)).toBe(false)
+    expect(out).toContain('1 stale remnant(s) matched, 1 removed')
+  })
+
+  it('keeps a FRESH wedged remnant for forensics (age gate)', () => {
+    const fresh = join(root, 'switchroom.wedged-today')
+    mkdirSync(fresh)
+    // mtime = now → younger than the 1-day default retention.
+    const out = runReap(root)
+    expect(existsSync(fresh)).toBe(true)
+    expect(out).toContain('0 stale remnant(s) matched, 0 removed')
+  })
+
+  it('respects REAP_RETAIN_DAYS override (reap even fresh when set to 0)', () => {
+    const fresh = join(root, 'switchroom.wedged-today')
+    mkdirSync(fresh)
+    runReap(root, { REAP_RETAIN_DAYS: '0' })
+    expect(existsSync(fresh)).toBe(false)
+  })
+
+  it('never touches the live checkout or unrelated siblings', () => {
+    const live = join(root, 'switchroom')
+    const other = join(root, 'some-other-repo')
+    mkdirSync(live)
+    mkdirSync(other)
+    ageDir(live, 5)
+    ageDir(other, 5)
+    runReap(root)
+    expect(existsSync(live)).toBe(true)
+    expect(existsSync(other)).toBe(true)
+  })
+
+  it('only sweeps the top level, not nested wedged dirs (maxdepth 1)', () => {
+    const nestedParent = join(root, 'sub')
+    mkdirSync(nestedParent)
+    const nested = join(nestedParent, 'switchroom.wedged-old')
+    mkdirSync(nested)
+    ageDir(nested, 5)
+    runReap(root)
+    expect(existsSync(nested)).toBe(true)
+  })
+
+  it('is a clean no-op when the reap root is absent (never fails the job)', () => {
+    const out = runReap(join(root, 'does-not-exist'))
+    expect(out).toContain('nothing to do')
+  })
+})


### PR DESCRIPTION
Closes part of #3335 (guard #2 — leftover-dir cleanup).

## What & why
The self-hosted \`uat-host\` runner reuses a **persistent** \`_work\` tree across jobs. On 2026-07-18 a canary UAT run wedged mid-checkout — \`actions/checkout\`'s \`git clean -ffdx\` went into uninterruptible **D-state** on the slow \`uat-runner-state\` volume. Manual recovery renamed the wedged checkout aside to \`switchroom.wedged-<date>\`, and those remnants then accumulate as dead weight on an already contended volume.

## Change
- Add \`scripts/ci/reap-stale-workdirs.sh\`, invoked right after \`Checkout\` on **both** self-hosted jobs (\`uat-gate-run\`, \`uat-fuzz\`). The \`switchroom.wedged-*\` remnants are **siblings** of the checkout dir, untouched by \`git clean\`, so running the sweep just after checkout is sound.
- Conservative by design:
  - **Age-gated** (\`REAP_RETAIN_DAYS\`, default 1 day) so a **fresh** wedge stays inspectable for forensics — the exact tension the issue flags for the current \`switchroom.wedged-20260718\` dir (it's now old, so it gets reaped on the next self-hosted run).
  - **Self-bounded** — each \`rm -rf\` is \`timeout\`-wrapped so the guard can *never* itself wedge on the same slow disk; a timed-out removal warns and is left in place.
  - **Best-effort** — never fails the job.

## Scope
This is **guard #2** (leftover-dir cleanup) only. **Guard #1** (bounded checkout/clean timeout) is intentionally deferred: bounding a step won't clear a D-state process (uninterruptible even by SIGKILL), so it needs a design decision on how to actually recover a wedged runner — filed as follow-up rather than shipped blind.

## Decision needed (non-blocking for this PR)
The current \`switchroom.wedged-20260718\` will be auto-reaped on the next self-hosted run (it's older than the 1-day retention). If it's still wanted for forensics, an operator should copy it off the volume before then, or we bump \`REAP_RETAIN_DAYS\`.

## Tests
- \`tests/reap-stale-workdirs.test.ts\` (6, pass) — drives the real script: stale removed, fresh kept, retention override, live checkout + siblings untouched, maxdepth-1 scope, absent-root no-op.
- \`npm run lint\` clean; workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)