### PR TITLE
fix(cli): resolve profiles root layout-aware; ship profiles in agent image (closes #3346)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -310,6 +310,17 @@ RUN chmod 0755 /opt/switchroom/security-plugin/hooks/*.mjs
 # shells out to `switchroom <verb>` for /auth, /vault, /agent, /topics
 # and friends (see telegram-plugin/gateway/gateway.ts:switchroomExec).
 COPY dist/cli/switchroom.js /opt/switchroom/switchroom.js
+# Ship the render profiles next to the bundle (#3346). The CLI resolves
+# PROFILES_ROOT relative to the bundle dir: in the npm/dev layout that's
+# `<pkg>/dist/cli/../../profiles`, but in THIS image the bundle lives at
+# /opt/switchroom/switchroom.js, so `../../profiles` would resolve to
+# `/profiles` — a dir the image never shipped. That broke every
+# in-container `rollout`/`apply` with `Profile not found: default
+# (searched /profiles)`. src/agents/profiles.ts now also probes
+# `<bundle-dir>/profiles`, so shipping them here makes profile
+# re-rendering work in-container. Placed in the frequently-changed dist
+# zone since profile templates change with src.
+COPY profiles /opt/switchroom/profiles
 # Ship package.json next to the bundle so `switchroom --version` resolves the
 # authoritative version at runtime (src/cli/resolve-version.ts), immune to a
 # stale build-info baked into the prebuilt bundle or a build-cache layer.

--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { sep as pathSep, resolve } from "node:path";
 import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync, readFileSync, existsSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -8,9 +8,49 @@ import {
   listAvailableProfiles,
   renderProfileClaudeTemplate,
   renderVaultProtocolFragment,
+  resolveProfilesRoot,
 } from "./profiles.js";
 import { scaffoldAgent } from "./scaffold.js";
 import type { AgentConfig, TelegramConfig } from "../config/schema.js";
+
+describe("resolveProfilesRoot (#3346)", () => {
+  const ENV_KEY = "SWITCHROOM_PROFILES_ROOT";
+  const saved = process.env[ENV_KEY];
+  afterEach(() => {
+    if (saved === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = saved;
+  });
+
+  it("honours the SWITCHROOM_PROFILES_ROOT env override", () => {
+    const dir = mkdtempSync(join(tmpdir(), "profiles-root-"));
+    try {
+      process.env[ENV_KEY] = dir;
+      expect(resolveProfilesRoot()).toBe(resolve(dir));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("probes candidates and returns a profiles dir that exists on disk", () => {
+    // In the dev/npm layout the real profiles dir must resolve and exist —
+    // this is the resolution that also underpins the in-container fix: the
+    // function does not hardcode one relative path, it picks the first
+    // candidate present.
+    delete process.env[ENV_KEY];
+    const root = resolveProfilesRoot();
+    expect(existsSync(root)).toBe(true);
+    expect(existsSync(join(root, "default"))).toBe(true);
+  });
+
+  it("does not resolve to the historically-broken /profiles path", () => {
+    // Regression guard for the exact failure in #3346: the bundle-relative
+    // `../../profiles` resolved to `/profiles` inside the agent image, a dir
+    // that was never shipped. The resolver must never land there when a real
+    // profiles dir is reachable.
+    delete process.env[ENV_KEY];
+    expect(resolveProfilesRoot()).not.toBe("/profiles");
+  });
+});
 
 describe("getProfilePath", () => {
   it("resolves a real profile that exists on disk", () => {

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -3,14 +3,53 @@ import { resolve, join, sep as pathSep } from "node:path";
 import Handlebars from "handlebars";
 
 /**
- * Root of the filesystem profiles directory (project-level). Each
- * subdirectory is a named profile containing `CLAUDE.md.hbs`,
+ * Resolve the root of the filesystem profiles directory (project-level).
+ * Each subdirectory is a named profile containing `CLAUDE.md.hbs`,
  * optional `SOUL.md.hbs`, and an optional `skills/` subdir. The
  * `_base/` sibling holds framework-level render templates
  * (start.sh.hbs, settings.json.hbs) that every agent uses regardless
  * of their `extends:` choice.
+ *
+ * The bundle can live in two layouts and the profiles dir sits in a
+ * DIFFERENT relative spot in each — a single hardcoded relative path
+ * only works for one and silently breaks the other (#3346):
+ *
+ *   - npm / dev layout: bundle at `<pkg>/dist/cli/switchroom.js`, so
+ *     profiles are two dirs up at `<pkg>/profiles` (`../../profiles`).
+ *   - agent Docker image: bundle at `/opt/switchroom/switchroom.js`,
+ *     so `../../profiles` resolves to `/profiles` — a path the image
+ *     never shipped, which broke every in-container `rollout`/`apply`
+ *     with `Profile not found: default (searched /profiles)`. The
+ *     Dockerfile now COPYs profiles to `/opt/switchroom/profiles`, i.e.
+ *     `./profiles` relative to the bundle dir.
+ *
+ * Rather than hardcode one relative path, probe an ordered list of
+ * candidates and pick the first that actually exists on disk. The
+ * `SWITCHROOM_PROFILES_ROOT` env override wins for tests and operator
+ * escape hatches. If none exist we fall back to the npm-layout path so
+ * the downstream "Profile not found" error still names a sensible root.
  */
-const PROFILES_ROOT = resolve(import.meta.dirname, "../../profiles");
+export function resolveProfilesRoot(): string {
+  const envOverride = process.env.SWITCHROOM_PROFILES_ROOT?.trim();
+  if (envOverride) {
+    return resolve(envOverride);
+  }
+  const candidates = [
+    // npm / dev layout: <pkg>/dist/cli -> <pkg>/profiles
+    resolve(import.meta.dirname, "../../profiles"),
+    // agent Docker image: /opt/switchroom -> /opt/switchroom/profiles
+    resolve(import.meta.dirname, "profiles"),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  // Preserve the historical default so error messages stay meaningful.
+  return candidates[0];
+}
+
+export const PROFILES_ROOT = resolveProfilesRoot();
 
 /**
  * Resolve the filesystem path for a named profile. Falls back to

--- a/src/setup/profile-picker.ts
+++ b/src/setup/profile-picker.ts
@@ -32,7 +32,7 @@
 
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { resolve } from "node:path";
-import { listAvailableProfiles } from "../agents/profiles.js";
+import { listAvailableProfiles, PROFILES_ROOT } from "../agents/profiles.js";
 
 /**
  * Short description per profile — kept as a static map so the picker UI
@@ -101,7 +101,8 @@ export interface ProfilePickerResult {
 }
 
 const DEFAULT_MAX_ATTEMPTS = 3;
-const PROFILES_ROOT = resolve(import.meta.dirname, "../../profiles");
+// Reuse the layout-aware profiles root from ../agents/profiles.js so the
+// dev/npm vs. Docker-image resolution (#3346) lives in exactly one place.
 
 /**
  * Default real-fs implementation of listProfileSkills. Returns the

--- a/tests/docker/dockerfile-agent-bakes.test.ts
+++ b/tests/docker/dockerfile-agent-bakes.test.ts
@@ -30,6 +30,16 @@ describe("Dockerfile.agent bakes", () => {
     );
   });
 
+  // #3346: profiles must ship next to the bundle at /opt/switchroom/profiles.
+  // The CLI resolves PROFILES_ROOT relative to the bundle dir; without this
+  // COPY, in-container `rollout`/`apply` fail with `Profile not found:
+  // default (searched /profiles)`.
+  it("bakes the render profiles next to the bundle", () => {
+    expect(dockerfile).toMatch(
+      /COPY\s+profiles\s+\/opt\/switchroom\/profiles/,
+    );
+  });
+
   it("bakes the autoaccept-poll bundle", () => {
     expect(dockerfile).toMatch(
       /COPY\s+dist\/cli\/autoaccept-poll\.js\s+\/opt\/switchroom\/autoaccept-poll\.js/,

--- a/work/NOTES-3346.md
+++ b/work/NOTES-3346.md
@@ -1,0 +1,36 @@
+# Fix #3346 — Profile not found: default (searched /profiles)
+
+## Root cause (verified in real source)
+- `src/agents/profiles.ts:13` (and `src/setup/profile-picker.ts:104`) resolved
+  `PROFILES_ROOT = resolve(import.meta.dirname, "../../profiles")`.
+- npm/dev layout: bundle at `<pkg>/dist/cli/switchroom.js` → `../../profiles` =
+  `<pkg>/profiles`. Works.
+- Agent Docker image (`docker/Dockerfile.agent`): bundle COPYed to
+  `/opt/switchroom/switchroom.js` → `../../profiles` = `/profiles`. The image
+  ships NO `/profiles`, so in-container `rollout`/`apply` throws
+  `Profile not found: default (searched /profiles)`.
+- Cross-cutting: same const feeds getProfilePath / listAvailableProfiles /
+  base + shared fragments and the picker — so it's not rollout-only.
+
+## Options considered
+- A. `--no-profiles` skip flag for pure version bumps — hack, only patches the
+  rollout path, leaves scaffold/apply broken in-container. Rejected.
+- B. Ship profiles in image only — works but leaves the resolver brittle
+  (single hardcoded relative path).
+- C. Layout-aware resolver + ship profiles in image (chosen). Durable: the
+  resolver probes ordered candidates and an env override; the image ships
+  profiles at a candidate path. Fixes every in-container consumer, not just
+  rollout.
+
+## Fix (single concern)
+1. `resolveProfilesRoot()` in profiles.ts: `SWITCHROOM_PROFILES_ROOT` env
+   override → `../../profiles` (npm/dev) → `./profiles` (image, bundle at
+   /opt/switchroom) → first existing wins; falls back to npm-layout path so
+   the error message stays meaningful. Exported + reused by profile-picker.ts
+   (single source of truth).
+2. `docker/Dockerfile.agent`: `COPY profiles /opt/switchroom/profiles`.
+
+## Tests
+- `src/agents/profiles.test.ts`: resolveProfilesRoot — env override wins;
+  probes to an existing dir; never resolves to `/profiles` (exact regression).
+- `tests/docker/dockerfile-agent-bakes.test.ts`: asserts the profiles COPY.


### PR DESCRIPTION
## Problem

During the v0.18.32 fleet roll, in-container `switchroom rollout`/`apply` failed for all agents with `Profile not found: default (searched /profiles)`.

**Root cause (verified in source):** `src/agents/profiles.ts` and `src/setup/profile-picker.ts` resolved `PROFILES_ROOT = resolve(import.meta.dirname, "../../profiles")`.
- npm/dev layout: bundle at `<pkg>/dist/cli/switchroom.js` → `../../profiles` = `<pkg>/profiles` ✅
- agent Docker image (`docker/Dockerfile.agent`): bundle COPYed to `/opt/switchroom/switchroom.js` → `../../profiles` = `/profiles`, a dir the image never shipped ❌

This is cross-cutting, not rollout-only: the same const feeds `getProfilePath`, `listAvailableProfiles`, the `_base`/`_shared` fragment renders, and the profile picker.

## Fix (single concern)

Combines the two durable halves the issue suggested:

1. **Layout-aware resolver** — `resolveProfilesRoot()` probes an ordered candidate list: `SWITCHROOM_PROFILES_ROOT` env override → `../../profiles` (npm/dev) → `./profiles` (image, bundle at `/opt/switchroom`) → first existing wins; falls back to the npm-layout path so the "Profile not found" error message stays meaningful. Exported and reused by `profile-picker.ts` so resolution lives in exactly one place.
2. **Ship profiles in the image** — `docker/Dockerfile.agent` now `COPY profiles /opt/switchroom/profiles`.

Rejected a `--no-profiles` skip flag: it only patches the rollout path and leaves scaffold/apply broken in-container.

## Tests

- `src/agents/profiles.test.ts` — `resolveProfilesRoot`: env override wins; probes to a dir that exists; never resolves to `/profiles` (the exact #3346 failure).
- `tests/docker/dockerfile-agent-bakes.test.ts` — asserts the profiles COPY; **verified it fails without the Dockerfile change**.

Scoped tests green (87 passed), `npm run lint` clean.

closes #3346

🤖 Generated with [Claude Code](https://claude.com/claude-code)