### PR TITLE
test(uat): require exact "done" for looksLikeDone (#3334 item b)

### DIFF
--- a/telegram-plugin/uat/scenarios/cross-turn-pending-progress-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/cross-turn-pending-progress-dm.test.ts
@@ -147,11 +147,20 @@ describe("uat: cross-turn pending-async ambient progress (#1445)", () => {
             if (firstAnchorMsgId == null && entry.kind === "fresh") {
               firstAnchorMsgId = entry.messageId;
             }
+            // EXACT match only. The prompt demands the completion signal be
+            // the single word "done" and nothing else; the loose `/\bdone\b/`
+            // fallback false-positived on the model's beat-1 ACK ("…I'll
+            // reply \"done\" when it finishes"), tripping a 10s wind-down that
+            // quit the test ~22s BEFORE the turn even ended — so the ambient
+            // edit mechanism was never observable (#3334 item b, observed UAT
+            // v0.18.32 r2). Requiring `trim() === "done"` makes the terminal
+            // signal deterministic and un-spoofable by an ack that merely
+            // mentions the word.
             const trimmedFinal = entry.text.trim().toLowerCase();
             const looksLikeDone =
               entry.kind === "fresh" &&
               entry.messageId !== firstAnchorMsgId &&
-              (trimmedFinal === "done" || /\bdone\b/.test(trimmedFinal));
+              trimmedFinal === "done";
             if (looksLikeDone) {
               sawDone = true;
               quiescenceDeadline = Date.now() + 10_000;


### PR DESCRIPTION
Item (b) of #3334.

`cross-turn-pending-progress-dm`'s `looksLikeDone` matched `/\bdone\b/` on any fresh non-anchor message. In v0.18.32 UAT r2 the model's beat-1 ack ("…I'll reply \"done\" when it finishes") tripped it → 10s wind-down → the test quit ~22s **before the turn even ended**, so the ambient-edit mechanism was never observable.

Fix: require `text.trim().toLowerCase() === "done"` — the prompt demands the completion signal be exactly the single word. Deterministic, un-spoofable by an ack that merely mentions "done".

Note: the residual card-bleed in this scenario shares root cause with item (c) (shared-chat temporal bleed) and is only fully resolved by the deferred reaper.

Test-file only; no gateway.ts touch. `tsc --noEmit` clean.

Refs #3334

🤖 Generated with [Claude Code](https://claude.com/claude-code)