### PR TITLE
test(uat): surface restart-resume self-skips loudly (#3334 item d)

### DIFF
--- a/telegram-plugin/uat/restart-capability.ts
+++ b/telegram-plugin/uat/restart-capability.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared restart-capability probe + loud-skip announcer for the
+ * restart/resume UAT scenarios.
+ *
+ * These scenarios (`jtbd-deliberate-restart-resumes-dm`,
+ * `jtbd-interrupted-turn-resumes-dm`, `jtbd-always-on-after-restart-dm`)
+ * can only exercise a REAL restart when the runner has NOPASSWD `sudo` and
+ * the `switchroom` CLI on PATH. On a sandboxed runner that lacks those,
+ * `vitest`'s `describe.skip` marks them skipped — but a bare skip reads as
+ * a plain green in a summarised board, which is exactly how the v0.18.32
+ * UAT canary over-claimed "#3315 restart/resume validated" when in fact
+ * these three self-skipped (#3334 item d).
+ *
+ * The durable fix has two parts. Part 2 (a runner that can actually
+ * restart) is infrastructure and is tracked separately. Part 1 — this file
+ * — makes the skip LOUD and unmistakable: a single-source-of-truth probe
+ * plus a banner printed to stderr at collection time, so a green that is
+ * really a skip can never be silently indistinguishable from a green that
+ * ran live.
+ */
+
+import { execSync } from "node:child_process";
+
+/**
+ * True only when the runner can drive a real agent restart: NOPASSWD
+ * `sudo` is available (the scenarios shell out to
+ * `sudo -n switchroom agent restart …`). A sandboxed CI runner returns
+ * false, which routes the scenario to `describe.skip`.
+ */
+export function canShellSudo(): boolean {
+  try {
+    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Print a loud, unmissable banner to stderr when a restart/resume scenario
+ * is about to self-skip because the runner cannot exercise a real restart.
+ * Call this at module-collection time (top level of the scenario file) so
+ * the banner lands in CI stdout/stderr regardless of the reporter's
+ * skip-count rendering.
+ *
+ * The banner deliberately spells out that a GREEN here is a SKIP, not live
+ * proof — the exact confusion #3334 item d flags as "the dangerous one".
+ */
+export function announceRestartSkip(scenarioTitle: string): void {
+  console.warn(
+    "\n" +
+      "════════════════════════════════════════════════════════════════════\n" +
+      "  ⚠️  UAT SKIPPED — NOT LIVE-VALIDATED (restart capability absent)\n" +
+      `      scenario: ${scenarioTitle}\n` +
+      "      reason:   this runner has no NOPASSWD sudo + switchroom CLI, so\n" +
+      "                it cannot exercise a real agent restart. The scenario\n" +
+      "                self-skips. Its GREEN is a SKIP, not live proof.\n" +
+      "      see:      #3334 item (d) / #3315 — restart/resume assurance from\n" +
+      "                this run rests on the unit/vitest layer, not this UAT.\n" +
+      "════════════════════════════════════════════════════════════════════\n",
+  );
+}
+
+/**
+ * Convenience: probe capability once and, when absent, emit the loud-skip
+ * banner. Returns the capability boolean so the caller can gate
+ * `describe` vs `describe.skip`:
+ *
+ *   const sudoOk = restartCapableOrAnnounceSkip(TITLE);
+ *   (sudoOk ? describe : describe.skip)(TITLE, () => { … });
+ */
+export function restartCapableOrAnnounceSkip(scenarioTitle: string): boolean {
+  const ok = canShellSudo();
+  if (!ok) announceRestartSkip(scenarioTitle);
+  return ok;
+}

--- a/telegram-plugin/uat/scenarios/jtbd-always-on-after-restart-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-always-on-after-restart-dm.test.ts
@@ -55,8 +55,10 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { execSync } from "node:child_process";
 import { spinUp } from "../harness.js";
+import { restartCapableOrAnnounceSkip } from "../restart-capability.js";
 
 const AGENT = "test-harness";
+const SCENARIO_TITLE = "uat: always-on after restart";
 
 // Budget for the marker-safe restart itself (per
 // feedback_agent_restart_needs_sudo_when_running.md, restart blocks
@@ -74,15 +76,6 @@ const HARD_REPLY_BUDGET_MS = 120_000;
 // contract but worth logging for forensic visibility.
 const VISION_REPLY_BUDGET_MS = 30_000;
 
-function canShellSudo(): boolean {
-  try {
-    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function restartAgent(name: string): void {
   // Marker-safe restart per memory feedback_compose_rollout.md +
   // feedback_agent_restart_needs_sudo_when_running.md. Apply step
@@ -96,11 +89,12 @@ function restartAgent(name: string): void {
 }
 
 // This scenario requires NOPASSWD sudo + the switchroom CLI on PATH on
-// the harness host. Skip on CI runners that don't expose those.
-const sudoOk = canShellSudo();
+// the harness host. Skip on CI runners that don't expose those — and when
+// we skip, announce it LOUDLY so a green isn't mistaken for live proof.
+const sudoOk = restartCapableOrAnnounceSkip(SCENARIO_TITLE);
 
 (sudoOk ? describe : describe.skip)(
-  "uat: always-on after restart",
+  SCENARIO_TITLE,
   () => {
     beforeAll(() => {
       restartAgent(AGENT);

--- a/telegram-plugin/uat/scenarios/jtbd-deliberate-restart-resumes-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-deliberate-restart-resumes-dm.test.ts
@@ -21,10 +21,13 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { execSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import { spinUp } from "../harness.js";
+import { restartCapableOrAnnounceSkip } from "../restart-capability.js";
 
 const AGENT = "test-harness";
+const SCENARIO_TITLE =
+  "uat: deliberate restart mid-turn resumes exactly once (DM, #2988)";
 const MID_TURN_MS = 10_000;        // let the turn get in-flight before the bounce
 const RESUME_BUDGET_MS = 180_000;  // boot + resume + reply
 const QUIET_WINDOW_MS = 90_000;    // after the resume completes, no second resume may fire
@@ -35,15 +38,6 @@ const QUIET_WINDOW_MS = 90_000;    // after the resume completes, no second resu
 const SAME_TURN_GRACE_MS = 20_000;
 
 const RESUME_FRAMING = /resum|picking .*back|interrupted|cut off|just restarted/i;
-
-function canShellSudo(): boolean {
-  try {
-    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 function kickRestartDetached(name: string): void {
   // A deliberate operator restart: clean SIGTERM path, clean-shutdown marker
@@ -57,10 +51,10 @@ function kickRestartDetached(name: string): void {
   child.unref();
 }
 
-const sudoOk = canShellSudo();
+const sudoOk = restartCapableOrAnnounceSkip(SCENARIO_TITLE);
 
 (sudoOk ? describe : describe.skip)(
-  "uat: deliberate restart mid-turn resumes exactly once (DM, #2988)",
+  SCENARIO_TITLE,
   () => {
     it(
       "an operator restart mid-turn resumes the work once, and never a second time",

--- a/telegram-plugin/uat/scenarios/jtbd-interrupted-turn-resumes-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-interrupted-turn-resumes-dm.test.ts
@@ -23,25 +23,19 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { execSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import { spinUp } from "../harness.js";
+import { restartCapableOrAnnounceSkip } from "../restart-capability.js";
 
 const AGENT = "test-harness";
 const MID_TURN_MS = 10_000;        // let the turn enqueue (become a recorded interrupted turn)
 const RESUME_BUDGET_MS = 180_000;  // boot + resume + reply
 
+const SCENARIO_TITLE = "uat: interrupted turn resumes after restart (DM)";
+
 // The resume builder tells the model to "briefly let the user know you're
 // resuming what was interrupted" — so the reply always opens with this framing.
 const RESUME_FRAMING = /resum|picking .*back|interrupted|cut off|just restarted/i;
-
-function canShellSudo(): boolean {
-  try {
-    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 function kickRestartDetached(name: string): void {
   // --force WITHOUT --wait → recreate now, interrupting the in-flight turn.
@@ -54,9 +48,9 @@ function kickRestartDetached(name: string): void {
   child.unref();
 }
 
-const sudoOk = canShellSudo();
+const sudoOk = restartCapableOrAnnounceSkip(SCENARIO_TITLE);
 
-(sudoOk ? describe : describe.skip)("uat: interrupted turn resumes after restart (DM)", () => {
+(sudoOk ? describe : describe.skip)(SCENARIO_TITLE, () => {
   it(
     "a turn interrupted by a restart is resumed and the resume turn completes",
     async () => {


### PR DESCRIPTION
Item (d) part 1 of #3334.

The three restart/resume scenarios self-skip on a sandboxed runner without NOPASSWD sudo — but a bare `describe.skip` reads as plain green on a summarised board, which is how the v0.18.32 canary over-claimed "#3315 restart/resume validated" when these actually skipped. **The dangerous one: green reads as live proof but is a skip.**

- new `telegram-plugin/uat/restart-capability.ts`: single-source capability probe + a loud stderr banner at collection time ("GREEN is a SKIP, not live proof")
- dedupes three copy-pasted `canShellSudo()` probes; wires all three scenarios to it

Part 2 (a runner that can exercise restarts) is CI infra, deferred/tracked separately.

Verified locally: banner renders, scenarios still `describe.skip`. Test/harness only; no gateway.ts touch. `tsc --noEmit` clean.

Refs #3334

🤖 Generated with [Claude Code](https://claude.com/claude-code)