### PR TITLE
feat(progress-card): per-worker step trail scaled by worker count (6/5/4/3)

### DIFF
--- a/telegram-plugin/status-no-truncate.ts
+++ b/telegram-plugin/status-no-truncate.ts
@@ -29,6 +29,19 @@ import { RICH_MESSAGE_MAX_CHARS } from './format.js'
 export const STATUS_ROLLING_LINES = 5
 
 /**
+ * Ceiling on the per-worker recent-step history RETAINED in `row.narrative`
+ * (worker-activity-feed.ts) and the deepest trail the worker cards will render.
+ *
+ * Distinct from `STATUS_ROLLING_LINES` (which governs the 🤖 agent card's
+ * window and stays at 5) so raising the worker trail never widens the agent
+ * card. Set to 6 because the deterministic per-worker depth curve
+ * (`workerHistoryDepth`, tool-activity-summary.ts) peaks at 6 for a lone
+ * worker — `max(3, 7 − workerCount)` at `w = 1`. The buffer must retain at
+ * least this many lines or the renderer would ask for 6 and only find 5.
+ */
+export const WORKER_HISTORY_MAX = 6
+
+/**
  * Per-line character cap, applied to every step + child step on BOTH
  * surfaces before HTML-escaping (clip raw → escape last). A line longer
  * than this is truncated with a trailing `…`.

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -6,7 +6,7 @@ import {
   type WorkerActivityView,
   type BotApiForWorkerFeed,
 } from '../worker-activity-feed.js'
-import { STATUS_ROLLING_LINES, STATUS_LINE_MAX } from '../status-no-truncate.js'
+import { STATUS_ROLLING_LINES, WORKER_HISTORY_MAX, STATUS_LINE_MAX } from '../status-no-truncate.js'
 import { SEND_GATE_SHED } from '../send-gate.js'
 
 describe('isWorkerActivityFeedEnabled (default ON)', () => {
@@ -188,17 +188,31 @@ describe('renderWorkerActivity', () => {
     expect(stepCount(out)).toBe(2)
   })
 
-  it('shows a "+N earlier…" header when the feed exceeds STATUS_ROLLING_LINES (worker surface)', () => {
-    const total = STATUS_ROLLING_LINES + 3
+  it('shows a "+N earlier…" header when the feed exceeds WORKER_HISTORY_MAX (worker surface, #3349)', () => {
+    const total = WORKER_HISTORY_MAX + 3
     const lines = Array.from({ length: total }, (_, i) => `step ${i + 1}`)
     const out = renderWorkerActivity(view({ narrativeLines: lines }))
-    expect(out).toContain(`_✓ +${total - STATUS_ROLLING_LINES} earlier…_`)
+    expect(out).toContain(`_✓ +${total - WORKER_HISTORY_MAX} earlier…_`)
     expect(out).not.toContain('step 1<')
-    const firstVisible = total - STATUS_ROLLING_LINES + 1
+    const firstVisible = total - WORKER_HISTORY_MAX + 1
     expect(out).toContain(`~~_✓ step ${firstVisible}_~~`)
     expect(out).toContain(`**→ step ${total}**`)
-    // STATUS_ROLLING_LINES visible step lines (the overflow header isn't a step).
-    expect(out.match(/step \d/g) ?? []).toHaveLength(STATUS_ROLLING_LINES)
+    // WORKER_HISTORY_MAX visible step lines (the overflow header isn't a step).
+    expect(out.match(/step \d/g) ?? []).toHaveLength(WORKER_HISTORY_MAX)
+  })
+
+  it('the lone-worker card shows the full 6-step trail — the raised ceiling (#3349)', () => {
+    // Ken's curve at w=1 is 6; the single-worker surface must reach it (the old
+    // STATUS_ROLLING_LINES=5 cap could never show the 6th step).
+    expect(WORKER_HISTORY_MAX).toBe(6)
+    const lines = Array.from({ length: 8 }, (_, n) => `ln-${n + 1}`)
+    const out = renderWorkerActivity(view({ narrativeLines: lines }))
+    // Last 6 render (ln-3 … ln-8); the two oldest collapse into a "+2 earlier…".
+    for (let n = 3; n <= 8; n++) expect(out).toContain(`ln-${n}`)
+    expect(out).toContain('_✓ +2 earlier…_')
+    expect(out).toContain('**→ ln-8**') // newest last, bold in-progress
+    // Exactly 6 rendered step bullets (the +N header is not a bullet).
+    expect((out.match(/ln-\d/g) ?? []).length).toBe(6)
   })
 
   it('strips the CONTENT Markdown markup (the card keeps its own ** / _ wrappers, #2669)', () => {
@@ -457,7 +471,7 @@ describe('createWorkerActivityFeed', () => {
     expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(1)
   })
 
-  it('rolls the narrative block to the last STATUS_ROLLING_LINES lines', async () => {
+  it('rolls the narrative block to the last WORKER_HISTORY_MAX lines (#3349)', async () => {
     const bot = makeFakeBot()
     let clock = 10_000
     const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
@@ -469,10 +483,32 @@ describe('createWorkerActivityFeed', () => {
     }
 
     const last = bot.edits.at(-1)!
-    expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(STATUS_ROLLING_LINES)
-    const firstVisible = total - STATUS_ROLLING_LINES + 1
+    expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(WORKER_HISTORY_MAX)
+    const firstVisible = total - WORKER_HISTORY_MAX + 1
     for (let i = 1; i < firstVisible; i++) expect(last.text).not.toContain(`ln-${String(i).padStart(3, '0')}`)
     for (let i = firstVisible; i <= total; i++) expect(last.text).toContain(`ln-${String(i).padStart(3, '0')}`)
+  })
+
+  it('the deeper 6-step trail does NOT add edits — one landed render per substantive step (#3349, no #3270 flood)', async () => {
+    // Render-only change: edit frequency is a function of SUBSTANTIVE changes
+    // (new narrative step), never of how many trail lines a render carries. Push
+    // 8 distinct steps to a lone worker; with the edit floor at 0 exactly one
+    // render lands per step: 1 send + 7 edits = 8 landed renders, regardless of
+    // the 6-line trail depth. A widened window that re-fired edits would break
+    // this (that is the #3270 flood we must not reintroduce).
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+    for (let i = 1; i <= 8; i++) {
+      clock += 1000
+      await feed.update('w1', 'chat', view({ toolCount: i, latestSummary: `edit-step-${i}` }))
+    }
+    expect(bot.sent).toHaveLength(1)
+    expect(bot.edits).toHaveLength(7)
+    // Re-pushing the SAME newest step (no substance change) fires NO extra edit.
+    clock += 1000
+    await feed.update('w1', 'chat', view({ toolCount: 8, latestSummary: 'edit-step-8' }))
+    expect(bot.edits).toHaveLength(7)
   })
 
   it('grows the narrative even while throttled (line surfaces on next edit)', async () => {
@@ -576,10 +612,10 @@ describe('createWorkerActivityFeed — log sink', () => {
 // char-budget backstop is the only wire-limit ceiling.
 
 describe('rolling window + STATUS_LINE_MAX — renderWorkerActivity', () => {
-  it('with 12 narrative lines, exactly the last STATUS_ROLLING_LINES render + a +N earlier header', () => {
+  it('with 12 narrative lines, exactly the last WORKER_HISTORY_MAX render + a +N earlier header (#3349)', () => {
     const narrativeLines = Array.from({ length: 12 }, (_, i) => `stp-${String(i + 1).padStart(3, '0')}`)
     const out = renderWorkerActivity(view({ narrativeLines }))
-    const firstVisible = 12 - STATUS_ROLLING_LINES + 1
+    const firstVisible = 12 - WORKER_HISTORY_MAX + 1
     for (let i = firstVisible; i <= 12; i++) {
       expect(out).toContain(`stp-${String(i).padStart(3, '0')}`)
     }
@@ -587,7 +623,7 @@ describe('rolling window + STATUS_LINE_MAX — renderWorkerActivity', () => {
       expect(out).not.toContain(`stp-${String(i).padStart(3, '0')}`)
     }
     // Overflow header now appears on the worker surface too.
-    expect(out).toContain(`_✓ +${12 - STATUS_ROLLING_LINES} earlier…_`)
+    expect(out).toContain(`_✓ +${12 - WORKER_HISTORY_MAX} earlier…_`)
     expect(out).toContain('**→ stp-012**')
   })
 
@@ -623,7 +659,7 @@ describe('rolling window + STATUS_LINE_MAX — renderWorkerActivity', () => {
 })
 
 describe('rolling window — createWorkerActivityFeed narrative accumulation', () => {
-  it('with 12 pushes, only the last STATUS_ROLLING_LINES appear in the render', async () => {
+  it('with 12 pushes, only the last WORKER_HISTORY_MAX appear in the render (#3349)', async () => {
     const bot = makeFakeBot()
     let clock = 10_000
     const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
@@ -634,16 +670,16 @@ describe('rolling window — createWorkerActivityFeed narrative accumulation', (
     }
 
     const last = bot.edits.at(-1)!
-    const firstVisible = 12 - STATUS_ROLLING_LINES + 1
+    const firstVisible = 12 - WORKER_HISTORY_MAX + 1
     for (let i = firstVisible; i <= 12; i++) {
       expect(last.text).toContain(`ln-${String(i).padStart(3, '0')}`)
     }
     for (let i = 1; i < firstVisible; i++) {
       expect(last.text).not.toContain(`ln-${String(i).padStart(3, '0')}`)
     }
-    // The manager caps the in-memory narrative at STATUS_ROLLING_LINES, so the
+    // The manager caps the in-memory narrative at WORKER_HISTORY_MAX, so the
     // render never sees overflow — no "+N earlier…" marker on the manager path
-    // (it surfaces only on direct renderWorkerActivity calls with >5 lines).
+    // (it surfaces only on direct renderWorkerActivity calls with >6 lines).
     expect(last.text).not.toContain('earlier…')
     expect(last.text).toContain('**→ ln-012**')
   })
@@ -1337,8 +1373,8 @@ describe('narrative dedup — non-adjacent repeats collapse (A,B,A)', () => {
     const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
 
     await feed.update('w2', 'chat', view({ latestSummary: 'step-repeat' }))
-    // Push STATUS_ROLLING_LINES distinct lines so 'step-repeat' scrolls out.
-    for (let i = 0; i < STATUS_ROLLING_LINES; i++) {
+    // Push WORKER_HISTORY_MAX distinct lines so 'step-repeat' scrolls out (#3349).
+    for (let i = 0; i < WORKER_HISTORY_MAX; i++) {
       clock += 1000
       await feed.update('w2', 'chat', view({ latestSummary: `filler-${i}` }))
     }

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -186,12 +186,20 @@ describe('coalesced worker feed — one message per chat under load', () => {
     // would shed ~ (N-1)/N of every second's cosmetic edits.
     expect(gate.stats().global.shed).toBeLessThanOrEqual(3)
 
-    // Liveness: the LAST landed edit carries EVERY worker's latest step — all
-    // rows refreshed together in the one message within one edit cycle.
+    // Liveness + bounded card (#3349): under Ken's curve every SHOWN worker
+    // keeps depth 3, so a 15-way storm cannot render every row — the 24-line
+    // body ceiling collapses the newest rows into a `+N more working…` spill.
+    // The last landed edit still carries the VISIBLE workers' latest steps
+    // (refreshed together in the one message) and a spill marker for the rest.
     const lastBody = edits[edits.length - 1].text
-    for (const id of ids) {
-      expect(lastBody).toContain(latest[id])
+    // 6 rows fit the 24-line budget (6·(1 header + 3 depth) = 24); the oldest
+    // rows (w0…w5) stay visible, the 9 newest spill.
+    for (let i = 0; i < 6; i++) {
+      expect(lastBody).toContain(latest[`w${i}`])
     }
+    expect(lastBody).toContain('more working')
+    // Still exactly ONE message — the spill is a render detail, not a new send.
+    expect(sends.length).toBe(1)
   })
 
   it('admits a critical reply mid-storm (never shed or starved by the cosmetic feed)', async () => {
@@ -722,21 +730,23 @@ describe('renderCombinedWorkerFeed (pure)', () => {
     expect(body).toContain('b first')
   })
 
-  it('degrades to ONE history line per worker at a large fan-out and stays within the body budget', () => {
+  it('holds the MIN_WORKER_DEPTH (3) floor per shown worker at a large fan-out and stays within the body budget (#3349)', () => {
+    // 6 workers each with a deep (5-line) history. Ken's curve pins depth=3 at
+    // 4+ workers, so every SHOWN worker paints its last 3 steps. 6·(1 header +
+    // 3 history) = 24 lines = MAX_COMBINED_BODY_LINES, so all 6 stay visible.
     const rows = Array.from({ length: 6 }, (_, i) =>
-      rowH(i, [`w${i} oldest`, `w${i} middle`, `w${i} newest`]),
+      rowH(i, [`w${i} s1`, `w${i} s2`, `w${i} s3`, `w${i} s4`, `w${i} s5`]),
     )
     const body = renderCombinedWorkerFeed(rows, { maxRows: 8 })!
-    // Only the newest step of each worker survives — the earlier lines are
-    // dropped by the per-worker depth clamp (floor((13-6)/6)=1).
     for (let i = 0; i < 6; i++) {
-      expect(body).toContain(current(`w${i} newest`))
-      expect(body).not.toContain(`w${i} oldest`)
-      expect(body).not.toContain(`w${i} middle`)
+      // Last 3 steps shown; the two oldest dropped by the depth-3 window.
+      expect(body).toContain(current(`w${i} s5`))
+      expect(body).toContain(struck(`w${i} s4`))
+      expect(body).toContain(struck(`w${i} s3`))
+      expect(body).not.toContain(`w${i} s1`)
+      expect(body).not.toContain(`w${i} s2`)
     }
-    // Total body lines (worker headers + history) stay within the budget: 6
-    // header lines + 6 history lines = 12 ≤ MAX_COMBINED_BODY_LINES (13). Count
-    // only the per-worker body lines (exclude the top count line + any spill).
+    // Body lines (worker headers + history) stay within the re-derived budget.
     const bodyLines = body
       .split('\n')
       .map((l) => l.trim())
@@ -744,15 +754,43 @@ describe('renderCombinedWorkerFeed (pure)', () => {
     const headerAndHistory = bodyLines.filter(
       (l) => !l.startsWith('🛠') && !l.includes('more working'),
     )
-    expect(headerAndHistory.length).toBeLessThanOrEqual(13)
+    expect(headerAndHistory.length).toBeLessThanOrEqual(24)
   })
 
-  it('exposes the deterministic depth formula (2→5, 3→3, 4→2, 6→1)', () => {
+  it('drops OLDEST rows into the spill when the fan-out overflows the 24-line body budget, keeping per-worker depth at 3 (#3349)', () => {
+    // 8 workers × (1 header + 3 depth) = 32 > 24 → the backstop collapses the 2
+    // oldest visible rows into `+M more working…`, so 6 rows render at full
+    // depth-3 (24 lines) rather than every worker losing a step.
+    const rows = Array.from({ length: 8 }, (_, i) =>
+      rowH(i, [`w${i} s1`, `w${i} s2`, `w${i} s3`]),
+    )
+    const body = renderCombinedWorkerFeed(rows, { maxRows: 8 })!
+    expect(body).toContain('more working')
+    const bodyLines = body
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+    const headerAndHistory = bodyLines.filter(
+      (l) => !l.startsWith('🛠') && !l.includes('more working'),
+    )
+    expect(headerAndHistory.length).toBeLessThanOrEqual(24)
+    expect(body).toContain('+2 more working')
+    // The 6 kept rows render at full depth-3 (last row kept shows all 3 steps).
+    expect(body).toContain(current('w5 s3'))
+    expect(body).toContain(struck('w5 s2'))
+    expect(body).toContain(struck('w5 s1'))
+    // The 2 trailing rows spilled — none of worker 7's lines render.
+    expect(body).not.toContain('w7 s3')
+  })
+
+  it("exposes Ken's deterministic depth curve max(3, 7−w): 1→6, 2→5, 3→4, 4→3, 5+→3 (#3349)", () => {
+    expect(combinedHistoryDepth(1)).toBe(6)
     expect(combinedHistoryDepth(2)).toBe(5)
-    expect(combinedHistoryDepth(3)).toBe(3)
-    expect(combinedHistoryDepth(4)).toBe(2)
-    expect(combinedHistoryDepth(6)).toBe(1)
-    expect(combinedHistoryDepth(8)).toBe(1)
+    expect(combinedHistoryDepth(3)).toBe(4)
+    expect(combinedHistoryDepth(4)).toBe(3)
+    expect(combinedHistoryDepth(5)).toBe(3)
+    expect(combinedHistoryDepth(6)).toBe(3)
+    expect(combinedHistoryDepth(8)).toBe(3)
   })
 
   // ── Worker numbering (#3298): stable ordinal prefix at 2+ workers ──────────
@@ -795,6 +833,58 @@ describe('renderCombinedWorkerFeed (pure)', () => {
     expect(body).toContain('+6 more working')
     for (let n = 1; n <= 4; n++) expect(body).toContain(`**${n}. task number ${n}**`)
     expect(body).not.toContain('**5. ')
+  })
+})
+
+// ── #3349: Ken's per-worker depth curve 6/5/4/3, exact rendered depth ─────────
+describe("Ken's per-worker step-trail depth curve (#3349)", () => {
+  // A worker with a DEEP history (8 lines) so the depth curve — not the buffer —
+  // is always the binding limit. Each history line is uniquely tokenised
+  // (`w{i}-s{n}`) so we can count exactly how many of a worker's steps rendered.
+  const deepRow = (i: number) => ({
+    description: `task w${i}`,
+    elapsedMs: 12_000 + i * 1000,
+    toolCount: 3,
+    ordinal: i + 1,
+    currentStep: `w${i}-s8`,
+    historyLines: Array.from({ length: 8 }, (_, n) => `w${i}-s${n + 1}`),
+  })
+  // Count how many of worker `i`'s step tokens appear in the rendered body.
+  const shownSteps = (body: string, i: number): number =>
+    (body.match(new RegExp(`w${i}-s\\d`, 'g')) ?? []).length
+
+  it.each([
+    [1, 6],
+    [2, 5],
+    [3, 4],
+    [4, 3],
+    [5, 3],
+  ])('%i worker(s) → exactly %i steps rendered per worker', (workers, expectedDepth) => {
+    const rows = Array.from({ length: workers }, (_, i) => deepRow(i))
+    const body = renderCombinedWorkerFeed(rows, { maxRows: 8 })!
+    expect(combinedHistoryDepth(workers)).toBe(expectedDepth)
+    for (let i = 0; i < workers; i++) {
+      expect(shownSteps(body, i)).toBe(expectedDepth)
+    }
+    // Newest step last (bottom-anchored → bold), oldest rendered step struck.
+    const worker0 = `**→ w0-s8**`
+    expect(body).toContain(worker0)
+  })
+
+  it('a worker with FEWER steps than the depth shows all it has, no padding', () => {
+    // 3 workers → depth 4, but this worker only has 2 steps: render both, no more.
+    const rows = [
+      { description: 'shallow', elapsedMs: 12_000, toolCount: 1, ordinal: 1,
+        currentStep: 'only-b', historyLines: ['only-a', 'only-b'] },
+      deepRow(1),
+      deepRow(2),
+    ]
+    const body = renderCombinedWorkerFeed(rows, { maxRows: 8 })!
+    expect(combinedHistoryDepth(3)).toBe(4)
+    expect(body).toContain('~~_✓ only-a_~~')
+    expect(body).toContain('**→ only-b**')
+    // Deep workers still get their full 4.
+    expect(shownSteps(body, 1)).toBe(4)
   })
 })
 

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -86,6 +86,7 @@ export function describeToolUse(
 import {
   STATUS_CARD_CHAR_BUDGET,
   STATUS_ROLLING_LINES,
+  WORKER_HISTORY_MAX,
   STATUS_LINE_MAX,
   NESTED_PREFIX,
 } from './status-no-truncate.js'
@@ -286,7 +287,8 @@ function escapeStepLine(raw: string): string {
 
 /**
  * Shared step-feed emitter. Appends `✓`/`→` bullet lines to `out` for the
- * given ALREADY-ESCAPED step strings, windowing to STATUS_ROLLING_LINES and
+ * given ALREADY-ESCAPED step strings, windowing to `window` (default
+ * STATUS_ROLLING_LINES; the worker surfaces pass a deeper window) and
  * prepending a `+N earlier…` header when the feed overflows the window (on
  * BOTH surfaces now). The worker feed imports this directly.
  *
@@ -301,9 +303,10 @@ export function renderStepFeed(
   steps: string[],
   allDone: boolean,
   liveSuffix = '',
+  window: number = STATUS_ROLLING_LINES,
 ): void {
   if (steps.length === 0) return
-  const shown = steps.slice(-STATUS_ROLLING_LINES)
+  const shown = steps.slice(-Math.max(1, window))
   const hidden = steps.length - shown.length
   if (hidden > 0) out.push(`_✓ +${hidden} earlier…_`)
   const lastIdx = shown.length - 1
@@ -351,6 +354,13 @@ export interface StatusCardOpts {
   stepCount?: number
   /** Optional terminal result block (worker recap), already-cleaned text + emoji. */
   result?: { emoji: string; text: string }
+  /**
+   * How many trailing step/child lines the rolling window shows. Defaults to
+   * STATUS_ROLLING_LINES (the 🤖 agent card). The 🛠 single-worker card passes
+   * a deeper window (`workerHistoryDepth(1)` = 6) so a lone worker can show its
+   * full recent trail — see WORKER_HISTORY_MAX.
+   */
+  historyWindow?: number
 }
 
 /**
@@ -364,6 +374,7 @@ export interface StatusCardOpts {
  */
 export function renderStatusCard(opts: StatusCardOpts): string | null {
   const { header, final = false, liveSuffix = '', stepCount, result } = opts
+  const window = Math.max(1, opts.historyWindow ?? STATUS_ROLLING_LINES)
   const rawSteps = opts.steps.filter((s) => s != null)
   const rawChildren = (opts.childSteps ?? []).map((s) => s.trim()).filter((s) => s.length > 0)
   const hasChildren = rawChildren.length > 0
@@ -393,12 +404,12 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
 
   if (hasChildren) {
     // Parent lines all render done — the live → step lives in the nested block.
-    const shownParent = steps.slice(-STATUS_ROLLING_LINES)
+    const shownParent = steps.slice(-window)
     const hiddenParent = steps.length - shownParent.length
     if (hiddenParent > 0) out.push(`_✓ +${hiddenParent} earlier…_`)
     for (const s of shownParent) out.push(`~~_✓ ${s}_~~`)
     // Child block.
-    const shownChild = children.slice(-STATUS_ROLLING_LINES)
+    const shownChild = children.slice(-window)
     const hiddenChild = children.length - shownChild.length
     if (hiddenChild > 0) out.push(`${NESTED_PREFIX}_+${hiddenChild} earlier…_`)
     const lastChildIdx = shownChild.length - 1
@@ -410,7 +421,7 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
       )
     })
   } else {
-    renderStepFeed(out, steps, final, liveSuffix)
+    renderStepFeed(out, steps, final, liveSuffix, window)
   }
 
   if (final && stepCount != null && stepCount > 0) {
@@ -664,32 +675,58 @@ export interface CombinedWorkerFeedOpts {
   maxRows: number
 }
 
-/**
- * Total per-worker BODY line budget for the combined feed — the sum, across all
- * visible workers, of (one header line + that worker's history lines). The top
- * `🛠 Workers · N running` line and the `+M more working…` spill are OUTSIDE
- * this budget (fixed chrome). 13 is chosen so the card stays a compact glance,
- * not a wall: at 2 workers it yields the full 5-line history each (2·1 header +
- * 2·5 history = 12 ≤ 13), and it degrades to a single history line each by ~6
- * workers — matching the pre-adaptive one-line-per-worker floor while never
- * letting a 2–3 worker fan-out lose its narrative trail.
- */
-const MAX_COMBINED_BODY_LINES = 13
 /** Each visible worker costs one header line before any history. */
 const PER_WORKER_HEADER_COST = 1
 
 /**
+ * Floor of the per-worker depth curve — every SHOWN worker renders at least
+ * this many recent steps, no matter how large the fan-out (Ken's "4+ → 3 each").
+ */
+const MIN_WORKER_DEPTH = 3
+
+/**
+ * Design fan-out: the largest concurrent-worker count whose full Ken curve is
+ * allowed to render before the total-line backstop starts collapsing the
+ * OLDEST rows into `+M more working…`. Chosen at 6 — beyond six live workers a
+ * per-worker trail is no longer a glanceable card, so extra rows spill rather
+ * than every shown worker losing depth. Every worker that IS shown keeps its
+ * full curve depth; the ceiling trims row COUNT, never per-worker depth.
+ */
+const DESIGN_FANOUT = 6
+
+/**
+ * Total per-worker BODY line budget for the combined feed — the sum, across all
+ * visible workers, of (one header line + that worker's history lines). The top
+ * `🛠 Workers · N running` line and the `+M more working…` spill are OUTSIDE
+ * this budget (fixed chrome).
+ *
+ * Re-derived (#3349) to fit Ken's per-worker curve `max(3, 7 − w)` rather than
+ * to DRIVE the depth: at the flat tail (w ≥ 4, depth = MIN_WORKER_DEPTH) each
+ * worker costs `PER_WORKER_HEADER_COST + MIN_WORKER_DEPTH` = 4 lines, so a
+ * DESIGN_FANOUT of 6 fully-rendered workers needs 6 × 4 = 24 lines. That fully
+ * fits every fan-out through 6 workers (w1=7, w2=12, w3=15, w4=16, w5=20,
+ * w6=24); a 7th/8th concurrent worker overflows and the backstop drops the
+ * oldest visible rows to the spill — bounding the card at 24 body lines so a
+ * big swarm never explodes it. The per-worker curve wins on DEPTH; this ceiling
+ * wins on ROW COUNT.
+ */
+const MAX_COMBINED_BODY_LINES = DESIGN_FANOUT * (PER_WORKER_HEADER_COST + MIN_WORKER_DEPTH)
+
+/**
  * Deterministic per-worker history depth for `w` visible workers:
- *   clamp( floor( (BUDGET − headerCost·w) / w ), 1, STATUS_ROLLING_LINES )
- * So 2 workers → 5 lines each, 3 → 3, 4 → 2, ≥6 → 1 (today's single-line floor
- * is the graceful-degradation floor, never below it). Pure function of the
- * visible worker count — no model input, consistent with deterministic controls.
+ *   clamp( max(MIN_WORKER_DEPTH, 7 − w), 1, WORKER_HISTORY_MAX )
+ * So 1 worker → 6, 2 → 5, 3 → 4, 4 → 3, ≥4 → 3 (Ken's 6/5/4/3 curve, #3349).
+ * Pure function of the visible worker count — no model input, consistent with
+ * deterministic controls. Replaces the former budget-driven divide (which
+ * yielded 5/5/3/2/… and could never reach 6 for a lone worker).
  */
 export function combinedHistoryDepth(w: number): number {
   if (w <= 0) return 1
-  const raw = Math.floor((MAX_COMBINED_BODY_LINES - PER_WORKER_HEADER_COST * w) / w)
-  return Math.max(1, Math.min(STATUS_ROLLING_LINES, raw))
+  return Math.min(WORKER_HISTORY_MAX, Math.max(MIN_WORKER_DEPTH, 7 - w))
 }
+
+/** Alias for readability at the single-worker call site — same curve. */
+export const workerHistoryDepth = combinedHistoryDepth
 
 /**
  * Render N≥1 live workers into ONE combined feed body (ready Telegram
@@ -758,37 +795,46 @@ export function renderCombinedWorkerFeed(
     return src.filter((s) => s != null && stripMarkdown(s).replace(/\s+/g, ' ').trim().length > 0)
   }
 
-  const compose = (visibleCount: number): string => {
+  const compose = (visibleCount: number): { body: string; bodyLines: number } => {
     const shown = rows.slice(0, visibleCount)
     const hidden = rows.length - shown.length
-    // Adaptive depth: split the fixed body-line budget across the VISIBLE
-    // workers so the card stays bounded regardless of fan-out.
+    // Per-worker depth follows Ken's deterministic curve max(3, 7−w) (#3349):
+    // the curve drives DEPTH; the total-line budget below drives ROW COUNT.
     const depth = combinedHistoryDepth(shown.length)
-    const out: string[] = [`🛠 **Workers** · _${rows.length} running_`]
+    const chrome: string[] = [`🛠 **Workers** · _${rows.length} running_`]
+    const bodyOut: string[] = []
     for (const r of shown) {
-      out.push(rowHeader(r))
+      bodyOut.push(rowHeader(r))
       const hist = rowHistory(r)
       if (hist.length === 0) {
-        out.push('→ _starting…_')
+        bodyOut.push('→ _starting…_')
         continue
       }
       // Paint the last-K history lines with the SAME `✓`/`→` idiom as the
       // single-worker card: escape each raw line through the shared per-line
       // pipeline (escapeStepLine), then renderStepFeed strikes the prior steps
-      // and bolds the newest in-progress step.
+      // and bolds the newest in-progress step. The window equals the depth so a
+      // per-worker `+N earlier…` marker never appears inside the combined feed.
       const esc = hist.slice(-depth).map(escapeStepLine)
-      renderStepFeed(out, esc, false)
+      renderStepFeed(bodyOut, esc, false, '', depth)
     }
+    const out = [...chrome, ...bodyOut]
     if (hidden > 0) out.push(`_+${hidden} more working…_`)
-    return stackCardLines(out)
+    return { body: stackCardLines(out), bodyLines: bodyOut.length }
   }
 
-  // Cap to maxRows first, then shrink further only if the char budget demands.
+  // Cap to maxRows first, then shrink the visible set while EITHER the total
+  // body-line budget (#3349: bounds a big swarm without stealing depth from the
+  // shown workers) OR the wire char budget is exceeded. Oldest rows collapse
+  // into the `+M more working…` spill.
   let visible = Math.min(rows.length, maxRows)
-  let body = compose(visible)
-  while (body.length > STATUS_CARD_CHAR_BUDGET && visible > 1) {
+  let { body, bodyLines } = compose(visible)
+  while (
+    (bodyLines > MAX_COMBINED_BODY_LINES || body.length > STATUS_CARD_CHAR_BUDGET) &&
+    visible > 1
+  ) {
     visible -= 1
-    body = compose(visible)
+    ;({ body, bodyLines } = compose(visible))
   }
   return body
 }

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -54,11 +54,12 @@ import {
   stripMarkdown,
   truncate,
 } from './card-format.js'
-import { STATUS_ROLLING_LINES } from './status-no-truncate.js'
+import { WORKER_HISTORY_MAX } from './status-no-truncate.js'
 import {
   renderStatusCard,
   formatStepSuffix,
   renderCombinedWorkerFeed,
+  workerHistoryDepth,
   type CombinedWorkerRow,
 } from './tool-activity-summary.js'
 import { isSendGateShed } from './send-gate.js'
@@ -213,6 +214,9 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     final: finished,
     liveSuffix: finished ? '' : liveSuffix,
     result,
+    // Lone-worker card: window to the w=1 point of Ken's curve (6) so it shows
+    // the full recent trail, not the 5-line agent-card default (#3349).
+    historyWindow: workerHistoryDepth(1),
   })
   if (card == null) {
     // Unreachable (header always present) — defensive.
@@ -420,7 +424,7 @@ interface WorkerRow {
   agentId: string
   /**
    * Accumulated narrative lines (oldest→newest), deduped within the whole
-   * rolling window. Rolling-window capped to STATUS_ROLLING_LINES. Grows the
+   * rolling window. Rolling-window capped to WORKER_HISTORY_MAX. Grows the
    * live render so the feed reads like the main agent's answer.
    */
   narrative: string[]
@@ -797,8 +801,10 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     row.narrative.push(line)
     // The `→` current-step line just CHANGED — reset the per-step timer.
     row.stepStartedAtMs = nowFn()
-    if (row.narrative.length > STATUS_ROLLING_LINES) {
-      row.narrative.splice(0, row.narrative.length - STATUS_ROLLING_LINES)
+    // Retain up to WORKER_HISTORY_MAX (6) — the lone-worker card's deepest
+    // window (#3349). STATUS_ROLLING_LINES (5) governs the agent card, not this.
+    if (row.narrative.length > WORKER_HISTORY_MAX) {
+      row.narrative.splice(0, row.narrative.length - WORKER_HISTORY_MAX)
     }
   }
 


### PR DESCRIPTION
## What

Re-tunes the Telegram **Workers** progress card's per-worker recent-step trail to Ken's deterministic curve **`max(3, 7 − workerCount)`** — 6 steps for a lone worker, 5 at 2, 4 at 3, 3 at 4+ — and raises the retention/window ceiling so the single-worker case (the most common one) can actually reach 6. Closes #3349.

The premise that "each worker shows only its current step" was ~6 days stale — the trail already existed (#3220/#3298). This is a **re-tune of the existing depth curve + a raised ceiling**, not a new feature.

## Depth behaviour shipped

| workers | steps/worker | mechanism |
|--:|:--:|--|
| 1 | 6 | lone-worker card windows to `workerHistoryDepth(1)` |
| 2 | 5 | `combinedHistoryDepth` = `max(3, 7−w)` |
| 3 | 4 | " |
| 4 | 3 | " |
| 5+ | 3 | floor `MIN_WORKER_DEPTH` |

- **New `WORKER_HISTORY_MAX = 6`** (`status-no-truncate.ts`), distinct from `STATUS_ROLLING_LINES = 5` which still governs the 🤖 agent card. The per-worker `row.narrative` ring buffer now retains 6 lines.
- `renderStepFeed` / `renderStatusCard` gained a `window` / `historyWindow` param; the lone-worker 🛠 card passes `workerHistoryDepth(1)` = 6. **Agent card unchanged at 5.**
- `combinedHistoryDepth` replaced: `min(WORKER_HISTORY_MAX, max(3, 7−w))` (was the budget-driven divide yielding 5/5/3/2/… — could never reach 6).

## Budget resolution (the open design question)

The old `MAX_COMBINED_BODY_LINES = 13` cannot fit the new curve at 3–4 workers. Resolved **in favour of Ken's curve**:

- **Per-worker curve wins on DEPTH.** Every *shown* worker always renders its full curve depth.
- **A re-derived total ceiling wins on ROW COUNT:**
  `MAX_COMBINED_BODY_LINES = DESIGN_FANOUT(6) × (PER_WORKER_HEADER_COST 1 + MIN_WORKER_DEPTH 3) = 24`.
  This fully fits every fan-out through 6 workers (w1=7, w2=12, w3=15, w4=16, w5=20, w6=24). A 7th/8th concurrent worker overflows and the existing row-drop backstop collapses the oldest visible rows into `+M more working…` — so a swarm never explodes the card while each shown worker keeps depth 3.

## Not a #3270 regression

Pure render change: same edit that fires today just carries more lines. No new heartbeat/triggers. An added edit-count invariant test asserts one landed render per substantive step (and none on a no-op re-push).

## Tests

Outcome-asserting, added/updated:
- exact rendered depth at **1/2/3/4/5** workers (`it.each`, cross-checked against `combinedHistoryDepth`)
- fewer-steps-than-N → shows all it has, no padding
- lone-worker card renders the full **6-step** trail
- 24-line row-drop backstop at **6 / 8 / 15** workers (oldest spill, per-worker depth held at 3)
- edit-count invariant (no flood)
- dedup / revisit-scroll-out unchanged (buffer now 6)

Scoped vitest green (231 in the 3 renderer suites + terminal-state suite), `tsc --noEmit` + full `npm run lint` clean. No `gateway.ts` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)