### PR TITLE
perf(reconcile): instrument agent-tree ownership sweep (#3333 stage 1)

### DIFF
--- a/src/agents/agent-owned-tree.ts
+++ b/src/agents/agent-owned-tree.ts
@@ -76,6 +76,27 @@ export const ownershipRuntime = {
       stdio: ["ignore", "ignore", "pipe"],
     });
   },
+  /** Monotonic clock (ms), injectable so the timing log is deterministic in tests. */
+  now: (): number => Date.now(),
+  /**
+   * Count the inodes under `rootDir` (best-effort, instrumentation only —
+   * #3333). Shells `find | wc -l` so busybox and GNU both work; `rootDir`
+   * is passed as a positional arg (not interpolated) to avoid shell
+   * injection. Returns null when the count itself fails — instrumentation
+   * must never break the sweep.
+   */
+  countInodes: (rootDir: string): number | null => {
+    try {
+      const out = execFileSync("sh", ["-c", 'find "$1" 2>/dev/null | wc -l', "sh", rootDir], {
+        encoding: "utf8",
+        maxBuffer: 256 * 1024 * 1024,
+      });
+      const n = Number.parseInt(out.trim(), 10);
+      return Number.isFinite(n) ? n : null;
+    } catch {
+      return null;
+    }
+  },
 };
 
 /**
@@ -97,8 +118,19 @@ export function alignAgentTreeOwnershipIfRoot(
   if (ownershipRuntime.geteuid() !== 0) return null;
   if (!existsSync(agentDir)) return null;
   const uid = allocateAgentUid(name);
+  // Instrumentation (#3333 stage 1): time the sweep and count the inodes it
+  // walks, so a real roll can validate the "~620k → ~5k" scoping thesis
+  // before the scoped sweep flips on. Pure observation — no behaviour change,
+  // never allowed to break the sweep (countInodes returns null on failure).
+  const inodes = ownershipRuntime.countInodes(agentDir);
+  const startedAt = ownershipRuntime.now();
   try {
     ownershipRuntime.chownTree(uid, uid, agentDir);
+    const elapsedMs = ownershipRuntime.now() - startedAt;
+    console.log(
+      `[ownership-sweep] #3333 agent=${name} scope=full uid=${uid} ` +
+        `inodes=${inodes ?? "unknown"} elapsedMs=${elapsedMs} dir=${agentDir}`,
+    );
   } catch (err) {
     throw new Error(
       `reconcile wrote into ${agentDir} as root but could not restore agent ` +

--- a/tests/reconcile.sweep-instrumentation.test.ts
+++ b/tests/reconcile.sweep-instrumentation.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #3333 stage 1 — instrumentation for the reconcile ownership sweep.
+ *
+ * The scoped-sweep work (stage 2+) narrows the chown from the full ~620k-inode
+ * agent tree to the ~5k state dirs. Before flipping that on, stage 1 adds pure
+ * observation (elapsed time + inode count) so a real roll can validate the
+ * scoping thesis. These tests pin that the instrumentation:
+ *   - reads the inode count via the injectable seam (so it's measured, not guessed)
+ *   - times the sweep and logs it
+ *   - NEVER changes sweep behaviour, even when the count itself fails
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  alignAgentTreeOwnershipIfRoot,
+  ownershipRuntime,
+} from "../src/agents/agent-owned-tree.js";
+import { allocateAgentUid } from "../src/agents/agent-uid.js";
+
+const AGENT = "instr-agent";
+
+const realGeteuid = ownershipRuntime.geteuid;
+const realChownTree = ownershipRuntime.chownTree;
+const realNow = ownershipRuntime.now;
+const realCountInodes = ownershipRuntime.countInodes;
+
+describe("ownership sweep instrumentation (#3333 stage 1)", () => {
+  afterEach(() => {
+    ownershipRuntime.geteuid = realGeteuid;
+    ownershipRuntime.chownTree = realChownTree;
+    ownershipRuntime.now = realNow;
+    ownershipRuntime.countInodes = realCountInodes;
+    vi.restoreAllMocks();
+  });
+
+  it("counts inodes and logs elapsed time around the sweep", () => {
+    const dir = mkdtempSync(join(tmpdir(), "switchroom-instr-"));
+    try {
+      ownershipRuntime.geteuid = () => 0;
+      ownershipRuntime.chownTree = () => {};
+      ownershipRuntime.countInodes = () => 4242;
+      let t = 1000;
+      ownershipRuntime.now = () => (t += 7); // first call 1007, second 1014 → 7ms
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      const uid = alignAgentTreeOwnershipIfRoot(AGENT, dir);
+
+      expect(uid).toBe(allocateAgentUid(AGENT));
+      const line = log.mock.calls.map((c) => String(c[0])).find((l) => l.includes("[ownership-sweep]"));
+      expect(line).toBeDefined();
+      expect(line).toContain("inodes=4242");
+      expect(line).toContain("elapsedMs=7");
+      expect(line).toContain(`agent=${AGENT}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still sweeps (behaviour unchanged) when inode counting fails", () => {
+    const dir = mkdtempSync(join(tmpdir(), "switchroom-instr-"));
+    try {
+      const calls: string[] = [];
+      ownershipRuntime.geteuid = () => 0;
+      ownershipRuntime.chownTree = (_u, _g, d) => calls.push(d);
+      ownershipRuntime.countInodes = () => null; // count failed
+      vi.spyOn(console, "log").mockImplementation(() => {});
+
+      expect(alignAgentTreeOwnershipIfRoot(AGENT, dir)).toBe(allocateAgentUid(AGENT));
+      expect(calls).toEqual([dir]); // sweep ran exactly as before
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("real countInodes returns a positive count for a populated dir", () => {
+    const dir = mkdtempSync(join(tmpdir(), "switchroom-instr-"));
+    try {
+      const n = ownershipRuntime.countInodes(dir);
+      expect(n).not.toBeNull();
+      expect(n as number).toBeGreaterThanOrEqual(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Stage 1 of #3333 — scoped agent-home ownership sweep

Per the approved design (APPROVE-WITH-AMENDMENTS), this is the first of four single-concern PRs. Pure instrumentation, **no behaviour change**.

### What this ships
Timing + inode-count observation around the reconcile-path chown sweep (`alignAgentTreeOwnershipIfRoot`), so a real roll can validate the "~620k → ~5k inode" scoping thesis before the scoped sweep (stage 2) is flipped on.

- `ownershipRuntime.now` + `ownershipRuntime.countInodes` seams (injectable for tests)
- `countInodes` shells `find | wc -l` (busybox + GNU), `rootDir` passed as a positional arg (no shell injection), returns `null` on failure so it can never break the sweep
- one `[ownership-sweep] #3333 ... scope=full uid=… inodes=… elapsedMs=…` log line per sweep

### Tests
`tests/reconcile.sweep-instrumentation.test.ts` — counts logged, timing logged, sweep behaviour unchanged when counting fails, real `countInodes` returns a positive count. Existing `tests/reconcile.agent-ownership.test.ts` unchanged and green.

### Staged plan
2. `chownScopedTree` behind flag default OFF + unit tests
3. widened union assert
4. canary wiring (per-invocation env into the isCanary spawn)

Stages 5 (default ON) and 6 (apply-path twin) are follow-up issues. Refs #3333 (does not close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)