### PR TITLE
fix(reconcile): widen post-sweep assert to static∪changes union (#3333 stage 3)

### DIFF
--- a/src/agents/agent-owned-tree.ts
+++ b/src/agents/agent-owned-tree.ts
@@ -83,6 +83,41 @@ export const SCOPED_RECURSIVE_SUBDIRS = [
 ] as const;
 
 /**
+ * Top-level agent-dir files a root reconcile writer can create/rewrite that
+ * MUST stay agent-readable (#3333 amendment A + finding 1). These are the
+ * critical members of the top-level SHALLOW sweep — the ones whose owner-only
+ * (0600) form would silently wedge the agent (#3168). `cron-session.sh` and
+ * `.resume-mode-migration-warned` are the leak-list entries the enumeration
+ * found outside the original static assert set; `CLAUDE.md` is included
+ * because it is root-rewritten in place. Not exhaustive of every top-level
+ * file (the sweep re-owns them all) — this is the ASSERT allowlist, the
+ * subset we fail loudly on.
+ */
+export const SCOPED_TOP_LEVEL_CRITICAL = [
+  "start.sh",
+  ".mcp.json",
+  "CLAUDE.md",
+  "cron-session.sh",
+  ".resume-mode-migration-warned",
+] as const;
+
+/**
+ * The STATIC scoped candidate set for the post-sweep readability assert
+ * (#3333 stage 3, amendment B). Derived from the SAME scope constants the
+ * sweep uses, so scope-of-sweep == scope-of-assert. The reconcile assert
+ * unions this with the dynamic per-run `changes` list — it NEVER replaces
+ * it (dropping `changes` would narrow coverage of touched-but-out-of-scope
+ * files). Missing paths are harmless: findAgentUnreadablePaths skips them.
+ */
+export function scopedAssertCandidates(agentDir: string): string[] {
+  return [
+    join(agentDir, ".claude", "settings.json"),
+    join(agentDir, ".claude-cron", ".mcp.json"),
+    ...SCOPED_TOP_LEVEL_CRITICAL.map((f) => join(agentDir, f)),
+  ];
+}
+
+/**
  * Env flag that switches the reconcile sweep from the full recursive chown
  * to the scoped sweep (#3333). Default OFF — the flag is injected by the
  * rollout ONLY into the canary restart spawn (stage 4, amendment C), never

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -23,7 +23,11 @@ import chalk from "chalk";
 import type { AgentConfig, QuotaConfig, SwitchroomConfig, TelegramConfig } from "../config/schema.js";
 import { CRON_SCRIPT_BASENAME_RE, LEGACY_CRON_SCRIPT_BASENAME_RE } from "./cron-unit-name.js";
 import { atomicWriteFileSync } from "../util/atomic.js";
-import { alignAgentTreeOwnershipIfRoot, findAgentUnreadablePaths } from "./agent-owned-tree.js";
+import {
+  alignAgentTreeOwnershipIfRoot,
+  findAgentUnreadablePaths,
+  scopedAssertCandidates,
+} from "./agent-owned-tree.js";
 
 // Repo root for referencing bin/ scripts in hooks
 const REPO_ROOT = resolve(import.meta.dirname, "../..");
@@ -7339,12 +7343,18 @@ function reconcileAgentInner(
   {
     const sweptUid = alignAgentTreeOwnershipIfRoot(name, agentDir);
     if (sweptUid !== null) {
+      // #3333 amendment B: the assert candidate set is the UNION of the
+      // static scoped set (derived from the same scope constants the sweep
+      // uses — scope-of-sweep == scope-of-assert) and this run's dynamic
+      // `changes` list. The `changes` term must be PRESERVED, never
+      // replaced: it is what catches a touched-but-out-of-scope file (e.g.
+      // a future top-level write) that the static set doesn't name. Dedup
+      // so a file in both terms is only reported once.
       const critical = [
-        join(agentDir, ".claude", "settings.json"),
-        join(agentDir, ".mcp.json"),
-        join(agentDir, ".claude-cron", ".mcp.json"),
-        join(agentDir, "start.sh"),
-        ...changes.filter((p) => p.startsWith(agentDir + "/")),
+        ...new Set([
+          ...scopedAssertCandidates(agentDir),
+          ...changes.filter((p) => p.startsWith(agentDir + "/")),
+        ]),
       ];
       const unreadable = findAgentUnreadablePaths(critical, sweptUid);
       if (unreadable.length > 0) {

--- a/tests/reconcile.union-assert.test.ts
+++ b/tests/reconcile.union-assert.test.ts
@@ -14,12 +14,20 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execFileSync } from "node:child_process";
 import {
   findAgentUnreadablePaths,
+  ownershipRuntime,
   scopedAssertCandidates,
   SCOPED_TOP_LEVEL_CRITICAL,
 } from "../src/agents/agent-owned-tree.js";
 import { allocateAgentUid } from "../src/agents/agent-uid.js";
+import { reconcileAgent, scaffoldAgent } from "../src/agents/scaffold.js";
+import type {
+  AgentConfig,
+  SwitchroomConfig,
+  TelegramConfig,
+} from "../src/config/schema.js";
 
 describe("scopedAssertCandidates (#3333 stage 3)", () => {
   it("includes the settings/mcp critical files and the leak-list top-level files", () => {
@@ -89,5 +97,86 @@ describe("union assert coverage (#3333 stage 3, amendment B)", () => {
     ];
     const bad = findAgentUnreadablePaths(critical, foreignUid);
     expect(bad.filter((p) => p === settings)).toHaveLength(1);
+  });
+});
+
+describe("union assert at the REAL call site — reconcileAgent (#3363 review fix 1)", () => {
+  // The inline-union tests above replicate the scaffold expression; a
+  // regression that drops the `changes` term AT THE CALL SITE
+  // (scaffold.ts's post-sweep `critical` construction) would still pass
+  // them. This drives the real path end-to-end:
+  //
+  //   1. scaffold an agent WITH a subagent → `.claude/agents/helper.md`
+  //      exists — a file NOT named by scopedAssertCandidates
+  //   2. tamper it on disk so the next reconcile detects a diff, rewrites
+  //      it, and pushes it to `changes`
+  //   3. run reconcile as fake-root with a sweep stub that makes the tree
+  //      readable EXCEPT that one file (left 0600, foreign-to-agent-uid —
+  //      the #3168 poison shape)
+  //   4. reconcile MUST throw naming helper.md — it is only reachable via
+  //      the dynamic `changes` term of the union. Drop the union → green
+  //      reconcile → this test fails.
+  const AGENT = "union-real-agent";
+  const telegramConfig: TelegramConfig = {
+    bot_token: "123456:ABC-DEF",
+    forum_chat_id: "-1001234567890",
+  };
+  const switchroomConfig: SwitchroomConfig = {
+    agents: {},
+    telegram: telegramConfig,
+    defaults: {},
+  };
+  const config = {
+    extends: "default",
+    topic_name: "Union Real",
+    schedule: [],
+    subagents: {
+      helper: { description: "test helper", prompt: "You help." },
+    },
+  } as unknown as AgentConfig;
+
+  const realGeteuid = ownershipRuntime.geteuid;
+  const realChownTree = ownershipRuntime.chownTree;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-union-real-"));
+  });
+
+  afterEach(() => {
+    ownershipRuntime.geteuid = realGeteuid;
+    ownershipRuntime.chownTree = realChownTree;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("fails reconcile when a changes-tracked file OUTSIDE the static set is left unreadable", () => {
+    const { agentDir } = scaffoldAgent(AGENT, config, tmpDir, telegramConfig);
+    const helperMd = join(agentDir, ".claude", "agents", "helper.md");
+    // Sanity: the file exists and the static set does NOT name it — the
+    // ONLY route into the assert is the dynamic `changes` union.
+    writeFileSync(helperMd, "tampered — reconcile must rewrite me");
+    expect(scopedAssertCandidates(agentDir)).not.toContain(helperMd);
+
+    ownershipRuntime.geteuid = () => 0;
+    ownershipRuntime.chownTree = (_uid, _gid, rootDir) => {
+      // Sweep stand-in: make everything agent-readable EXCEPT the
+      // changes-tracked helper.md, which stays owner-only under a uid
+      // foreign to the agent's 10001+ — the incident combination.
+      execFileSync("chmod", ["-R", "a+rX", rootDir]);
+      chmodSync(helperMd, 0o600);
+    };
+
+    // Single invocation (a second reconcile would find helper.md already
+    // regenerated and push nothing): capture the one thrown error and
+    // assert both the loud-assert shape and the culprit file.
+    let thrown: Error | null = null;
+    try {
+      reconcileAgent(AGENT, config, tmpDir, telegramConfig, switchroomConfig);
+    } catch (err) {
+      thrown = err as Error;
+    }
+    expect(thrown).not.toBeNull();
+    expect(thrown!.message).toMatch(/agent-unreadable files/);
+    expect(thrown!.message).toMatch(/helper\.md/);
   });
 });

--- a/tests/reconcile.union-assert.test.ts
+++ b/tests/reconcile.union-assert.test.ts
@@ -1,0 +1,93 @@
+/**
+ * #3333 stage 3 — widened UNION assert (amendment B).
+ *
+ * The post-sweep readability assert must be the UNION of:
+ *   - the static scoped candidate set (derived from the same scope constants
+ *     the sweep uses, so scope-of-sweep == scope-of-assert), and
+ *   - this run's dynamic `changes` list (touched-but-out-of-scope files).
+ *
+ * It must NEVER replace the `changes` term with a static set — that would
+ * narrow today's coverage of touched files outside the static names.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  findAgentUnreadablePaths,
+  scopedAssertCandidates,
+  SCOPED_TOP_LEVEL_CRITICAL,
+} from "../src/agents/agent-owned-tree.js";
+import { allocateAgentUid } from "../src/agents/agent-uid.js";
+
+describe("scopedAssertCandidates (#3333 stage 3)", () => {
+  it("includes the settings/mcp critical files and the leak-list top-level files", () => {
+    const dir = "/agents/x";
+    const cands = scopedAssertCandidates(dir);
+    expect(cands).toContain(join(dir, ".claude", "settings.json"));
+    expect(cands).toContain(join(dir, ".claude-cron", ".mcp.json"));
+    // finding-1 leak-list entries are now asserted candidates
+    expect(cands).toContain(join(dir, "cron-session.sh"));
+    expect(cands).toContain(join(dir, ".resume-mode-migration-warned"));
+    expect(cands).toContain(join(dir, "CLAUDE.md"));
+    expect(cands).toContain(join(dir, "start.sh"));
+    expect(cands).toContain(join(dir, ".mcp.json"));
+    // derived from the shared constant
+    for (const f of SCOPED_TOP_LEVEL_CRITICAL) {
+      expect(cands).toContain(join(dir, f));
+    }
+  });
+});
+
+describe("union assert coverage (#3333 stage 3, amendment B)", () => {
+  const foreignUid = allocateAgentUid("union-agent"); // never the test process uid
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "switchroom-union-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("catches a leak-list top-level file left root-owned 0600 (static term)", () => {
+    const cron = join(dir, "cron-session.sh");
+    writeFileSync(cron, "#!/bin/sh\n", { mode: 0o600 });
+    chmodSync(cron, 0o600); // umask-proof; owner-only, foreign uid
+    const bad = findAgentUnreadablePaths(scopedAssertCandidates(dir), foreignUid);
+    expect(bad).toContain(cron);
+  });
+
+  it("catches a touched-but-out-of-scope file present ONLY in the changes term", () => {
+    // A file the static set does not name, but reconcile pushed to `changes`.
+    const touched = join(dir, "novel-top-level-file");
+    writeFileSync(touched, "x", { mode: 0o600 });
+    chmodSync(touched, 0o600);
+
+    // Replicate the scaffold union: static ∪ changes.
+    const changes = [touched];
+    const critical = [
+      ...new Set([...scopedAssertCandidates(dir), ...changes]),
+    ];
+    const bad = findAgentUnreadablePaths(critical, foreignUid);
+    expect(bad).toContain(touched); // dropped if `changes` term were removed
+
+    // And with the changes term REMOVED it would be missed — pin the regression.
+    const staticOnly = findAgentUnreadablePaths(scopedAssertCandidates(dir), foreignUid);
+    expect(staticOnly).not.toContain(touched);
+  });
+
+  it("dedups a file present in both terms", () => {
+    const settings = join(dir, ".claude", "settings.json");
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+    writeFileSync(settings, "{}", { mode: 0o600 });
+    chmodSync(settings, 0o600);
+    const changes = [settings]; // also in the static set
+    const critical = [
+      ...new Set([...scopedAssertCandidates(dir), ...changes]),
+    ];
+    const bad = findAgentUnreadablePaths(critical, foreignUid);
+    expect(bad.filter((p) => p === settings)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Stage 3 of #3333 — scoped agent-home ownership sweep

Stacked on #3362 (stage 2). Widens the post-sweep readability assert so the scoped sweep stays self-checking BEFORE the default flips on.

### Amendment B — union, not replace
The assert candidate set is now the **UNION** of:
- `scopedAssertCandidates(agentDir)` — a static set derived from the **same** scope constants the sweep uses (`SCOPED_RECURSIVE_SUBDIRS` / `SCOPED_TOP_LEVEL_CRITICAL`), so scope-of-sweep == scope-of-assert
- this run's dynamic `changes.filter(startsWith agentDir)` — **preserved, never replaced**. Dropping it would narrow today's coverage of touched-but-out-of-scope files.

Deduped via `Set`. `findAgentUnreadablePaths` skips missing paths, so naming a candidate that a given agent doesn't have (e.g. `cron-session.sh` on a non-cron agent) is harmless.

The static set now also names the finding-1 leak-list top-level files (`cron-session.sh`, `.resume-mode-migration-warned`) and `CLAUDE.md` — so a future change lowering any of them to root:root 0600 fails loudly instead of silently wedging the agent (the #3168 mode). No previously-checked file is dropped (`start.sh`, `.mcp.json`, `.claude/settings.json`, `.claude-cron/.mcp.json` all retained).

### Tests
`tests/reconcile.union-assert.test.ts`:
- leak-list file left root-owned 0600 is caught (static term)
- a `changes`-only out-of-scope file is caught by the union and **missed** by static-only (regression pin for "never replace")
- dedup of a file present in both terms

Refs #3333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)