### PR TITLE
feat(rollout): gate scoped sweep on canary via per-invocation env (#3333 stage 4)

### DIFF
--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -34,6 +34,7 @@ import {
   type RolloutResult,
   type RolloutStep,
 } from "./rollout.js";
+import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
 
 describe("normalizeVersion", () => {
   it("strips a leading v and trims so config pin == in-container version", () => {
@@ -131,17 +132,20 @@ function harness(opts: {
 }): {
   deps: RolloutDeps;
   runs: string[][];
+  runEnvs: Array<Record<string, string> | undefined>;
   logs: string[];
   persisted: string[];
   phases: RolloutPhase[];
 } {
   const runs: string[][] = [];
+  const runEnvs: Array<Record<string, string> | undefined> = [];
   const logs: string[] = [];
   const persisted: string[] = [];
   const phases: RolloutPhase[] = [];
   const deps: RolloutDeps = {
-    run: (args) => {
+    run: (args, runOpts) => {
       runs.push(args);
+      runEnvs.push(runOpts?.env);
       return { status: opts.runStatus ? opts.runStatus(args) : 0 };
     },
     probeVersion: (agent) => opts.versions[agent] ?? null,
@@ -151,7 +155,7 @@ function harness(opts: {
     hindsightExists: () => opts.hindsightExists ?? false,
     webImageTag: () => opts.webImageTag ?? null,
   };
-  return { deps, runs, logs, persisted, phases };
+  return { deps, runs, runEnvs, logs, persisted, phases };
 }
 
 describe("executeRollout", () => {
@@ -171,6 +175,34 @@ describe("executeRollout", () => {
     expect(runs).toContainEqual(["agent", "restart", "clerk", "--wait", "--force"]);
     expect(runs).toContainEqual(["webd", "install", "--tag", TARGET]);
     expect(runs).toContainEqual(["hostd", "install", "--tag", TARGET]);
+  });
+
+  it("injects the scoped-sweep env into ONLY the canary restart spawn (#3333 amendment C)", () => {
+    const steps = planRollout(["clerk", "marko", "nadia"]);
+    const { deps, runs, runEnvs } = harness({
+      versions: { clerk: "0.15.18", marko: "0.15.18", nadia: "0.15.18" },
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+
+    // Correlate each restart spawn with the env it was given.
+    const restartIdxs = runs
+      .map((a, i) => ({ a, i }))
+      .filter(({ a }) => a[0] === "agent" && a[1] === "restart")
+      .map(({ i }) => i);
+    expect(restartIdxs.length).toBe(3);
+
+    // Canary = first restarted agent → gets the flag.
+    expect(runEnvs[restartIdxs[0]]).toEqual({ [SCOPED_SWEEP_ENV]: "1" });
+    // Every subsequent agent → NO flag (global env would defeat the canary).
+    expect(runEnvs[restartIdxs[1]]).toBeUndefined();
+    expect(runEnvs[restartIdxs[2]]).toBeUndefined();
+
+    // And nothing else in the roll (apply, webd, hostd) carries the flag.
+    for (let i = 0; i < runs.length; i++) {
+      if (i === restartIdxs[0]) continue;
+      expect(runEnvs[i]?.[SCOPED_SWEEP_ENV]).toBeUndefined();
+    }
   });
 
   it("persists the pin BEFORE a bare apply when pinToPersist is set", () => {

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -55,6 +55,7 @@ import { SWITCHROOM_VERSION } from "./resolve-version.js";
 import { readAndFilter, defaultAuditLogPath } from "../host-control/audit-reader.js";
 import { isHindsightContainerExists } from "../setup/hindsight.js";
 import { deployedImageTag } from "./deploy-version-guard.js";
+import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
 
 /** One ordered step of a rollout plan. Pure data so it unit-tests. */
 export type RolloutStep =
@@ -362,8 +363,16 @@ export function parseRolloutPhaseLine(line: string): RolloutPhase | null {
 
 /** Injectable side-effects so the executor unit-tests without docker. */
 export interface RolloutDeps {
-  /** Run a `switchroom <args>` subcommand; returns the exit status. */
-  run(args: string[]): { status: number };
+  /**
+   * Run a `switchroom <args>` subcommand; returns the exit status.
+   *
+   * `opts.env` layers extra env vars onto the spawned process's environment
+   * (#3333 amendment C). This is how the scoped-sweep flag is injected into
+   * ONLY the canary restart spawn — the reconcile ownership sweep runs
+   * inside this spawned `switchroom agent restart` process, so an env set
+   * here (and nowhere else) gates exactly one agent, never the whole fleet.
+   */
+  run(args: string[], opts?: { env?: Record<string, string> }): { status: number };
   /** Probe the in-container `switchroom --version` for an agent. */
   probeVersion(agent: string): string | null;
   /** Emit a progress line. */
@@ -680,7 +689,19 @@ export function executeRollout(
         const restartArgs = execOpts.hostdContext
           ? ["agent", "restart", step.agent, "--wait", "--force", "--pin", target]
           : ["agent", "restart", step.agent, "--wait", "--force"];
-        deps.run(restartArgs);
+        // #3333 amendment C — staged canary rollout of the scoped ownership
+        // sweep. The reconcile sweep runs INSIDE this spawned `switchroom
+        // agent restart` process, so injecting the scoped-sweep env into the
+        // canary spawn ONLY (and reading it at the sweep site) flips exactly
+        // one agent per roll — the first-restarted canary. A global/container
+        // boot env would flip every agent at once and defeat the canary gate.
+        // Verify on the roll: the canary's restart-time collapse (scope=scoped
+        // in its `[ownership-sweep] #3333` log) with no approval-card storm,
+        // before the default is flipped ON (stage 5).
+        deps.run(
+          restartArgs,
+          isCanary ? { env: { [SCOPED_SWEEP_ENV]: "1" } } : undefined,
+        );
         const got = deps.probeVersion(step.agent);
         if (got === null || normalizeVersion(got) !== targetNorm) {
           deps.log(`  ✗ ${step.agent} → ${got ?? "<unreachable>"} (expected ${target}) — STOPPING`);
@@ -1024,8 +1045,13 @@ export function registerRolloutCommand(program: Command): void {
       const configPath = getConfigPath(program);
       const scriptPath = process.argv[1] ?? "switchroom";
       const deps: RolloutDeps = {
-        run: (args) => {
-          const r = spawnSync(process.execPath, [scriptPath, ...args], { stdio: "inherit" });
+        run: (args, opts) => {
+          const r = spawnSync(process.execPath, [scriptPath, ...args], {
+            stdio: "inherit",
+            // #3333 amendment C: layer the per-invocation env (the scoped-sweep
+            // flag on the canary spawn) onto the inherited environment.
+            env: opts?.env ? { ...process.env, ...opts.env } : process.env,
+          });
           return { status: r.status ?? 1 };
         },
         probeVersion: (agent) => {


### PR DESCRIPTION
## Stage 4 of #3333 — scoped agent-home ownership sweep

Stacked on #3363 (stage 3). Wires the scoped sweep to the rollout canary so it can be observed on one agent before the default flips ON.

### Amendment C — per-invocation env, not global
The reconcile sweep runs **inside** the `switchroom agent restart` process the rollout spawns (`deps.run(restartArgs)`). So injecting `SWITCHROOM_SCOPED_OWNERSHIP_SWEEP=1` into **only** the `isCanary` spawn's env flips exactly one agent per roll — the first-restarted canary — and the sweep reads it there. A global / container-boot env would flip the whole fleet at once and defeat the canary gate, so it is deliberately not that.

- `RolloutDeps.run` gains an optional `{ env }` that layers onto the spawned process env; production impl merges over `process.env`
- the `restart-agent` step passes the flag env only when `isCanary`

### Verify on the roll (before stage 5)
The canary's restart-time collapse (`scope=scoped` in its `[ownership-sweep] #3333` log from stage 1) with no approval-card storm.

### Test
`src/cli/rollout.test.ts` — the canary (first restart) spawn carries `{ SWITCHROOM_SCOPED_OWNERSHIP_SWEEP: "1" }`, every subsequent agent's spawn and all non-restart steps (apply/webd/hostd) do not.

### Not in this PR (follow-up issues)
- **Stage 5** (flip default ON + one-release escape hatch) — waits for a real canary-roll observation
- **Stage 6** (apply-path twin `alignAgentUid`, amendment D) — after bake

Refs #3333 (does not close — closes when stage 5 default-ON ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)