### PR TITLE
perf(reconcile): scoped ownership sweep behind flag, default OFF (#3333 stage 2)

### DIFF
--- a/src/agents/agent-owned-tree.ts
+++ b/src/agents/agent-owned-tree.ts
@@ -57,8 +57,38 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, lstatSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { allocateAgentUid } from "./agent-uid.js";
+
+/**
+ * The agent-dir SUBDIRECTORIES the scoped sweep recurses into (#3333
+ * amendment A). Root reconcile writers land inside these state dirs
+ * (`.claude/` — settings.json + subagents + backups; `.claude-cron/` —
+ * the cron .mcp.json; `telegram/` — the inbox). Everything else at the top
+ * level is a single file (start.sh, CLAUDE.md*, cron-session.sh,
+ * .mcp.json, .resume-mode-migration-warned, the SOUL.md symlink) captured
+ * by the top-level SHALLOW chown; the giant caches that make the full
+ * sweep slow (home/ ~96% of inodes, workspace/, tmp/) are deliberately
+ * NOT recursed into.
+ *
+ * This is the single source of truth for scope-of-sweep; the widened
+ * post-sweep assert (#3333 stage 3) derives its candidate set from the
+ * same constant so scope-of-sweep == scope-of-assert.
+ */
+export const SCOPED_RECURSIVE_SUBDIRS = [
+  ".claude",
+  ".claude-cron",
+  "telegram",
+] as const;
+
+/**
+ * Env flag that switches the reconcile sweep from the full recursive chown
+ * to the scoped sweep (#3333). Default OFF — the flag is injected by the
+ * rollout ONLY into the canary restart spawn (stage 4, amendment C), never
+ * globally, so a staged canary roll flips one agent at a time.
+ */
+export const SCOPED_SWEEP_ENV = "SWITCHROOM_SCOPED_OWNERSHIP_SWEEP";
 
 /**
  * Process/syscall seams, injectable for tests (unit tests run as an
@@ -76,6 +106,26 @@ export const ownershipRuntime = {
       stdio: ["ignore", "ignore", "pipe"],
     });
   },
+  /**
+   * SHALLOW chown (no `-R`) of the given paths — the top-level pass of the
+   * scoped sweep (#3333 amendment A). `-h` is retained for the same busybox
+   * symlink-safety reason as chownTree: a top-level entry may be a symlink
+   * (SOUL.md → workspace/SOUL.md) and must be lchowned, not dereferenced.
+   * Without `-R`, a directory arg chowns only the dir inode, not its
+   * contents — so home/ workspace/ tmp/ are never traversed here.
+   */
+  chownShallow: (uid: number, gid: number, paths: string[]): void => {
+    if (paths.length === 0) return;
+    execFileSync("chown", ["-h", `${uid}:${gid}`, ...paths], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+  },
+  /**
+   * Whether the scoped sweep is enabled for this invocation (#3333). Reads
+   * the per-invocation env flag; default OFF. Injectable so tests can flip
+   * it without mutating process.env.
+   */
+  scopedSweepEnabled: (): boolean => process.env[SCOPED_SWEEP_ENV] === "1",
   /** Monotonic clock (ms), injectable so the timing log is deterministic in tests. */
   now: (): number => Date.now(),
   /**
@@ -100,6 +150,41 @@ export const ownershipRuntime = {
 };
 
 /**
+ * The scoped sweep (#3333 amendment A). Instead of `chown -h -R` over the
+ * whole ~620k-inode agent tree (hours at single-spindle IOPS), re-own only
+ * what root reconcile writers actually touch:
+ *
+ *   1. SHALLOW chown of the agent dir itself + every direct child (files
+ *      and symlinks — captures start.sh, CLAUDE.md*, cron-session.sh,
+ *      .mcp.json, .resume-mode-migration-warned, SOUL.md, regardless of
+ *      name). Directory children get only their dir inode chowned, NOT
+ *      their contents — so home/ workspace/ tmp/ are skipped.
+ *   2. Recursive `chown -h -R` into the scoped state SUBDIRS
+ *      (SCOPED_RECURSIVE_SUBDIRS) that exist — the dirs root writers create
+ *      new inodes inside (.claude/settings.json, subagents, backups;
+ *      .claude-cron/.mcp.json; telegram/ inbox).
+ *
+ * The walk itself is never hand-rolled: `readdirSync` reads ONE directory
+ * level for the shallow pass, and the recursion is done by `chown -h -R`,
+ * preserving `-h` symlink semantics throughout (amendment A).
+ */
+export function chownScopedTree(uid: number, gid: number, agentDir: string): void {
+  let children: string[];
+  try {
+    children = readdirSync(agentDir).map((name) => join(agentDir, name));
+  } catch {
+    children = [];
+  }
+  ownershipRuntime.chownShallow(uid, gid, [agentDir, ...children]);
+  for (const sub of SCOPED_RECURSIVE_SUBDIRS) {
+    const subPath = join(agentDir, sub);
+    if (existsSync(subPath)) {
+      ownershipRuntime.chownTree(uid, gid, subPath);
+    }
+  }
+}
+
+/**
  * When the current process runs as root, chown the agent's state tree to
  * the agent's deterministic container UID. No-op (returns null) when not
  * root: a non-root writer is either the agent itself (files already land
@@ -122,13 +207,18 @@ export function alignAgentTreeOwnershipIfRoot(
   // walks, so a real roll can validate the "~620k → ~5k" scoping thesis
   // before the scoped sweep flips on. Pure observation — no behaviour change,
   // never allowed to break the sweep (countInodes returns null on failure).
+  const scoped = ownershipRuntime.scopedSweepEnabled();
   const inodes = ownershipRuntime.countInodes(agentDir);
   const startedAt = ownershipRuntime.now();
   try {
-    ownershipRuntime.chownTree(uid, uid, agentDir);
+    if (scoped) {
+      chownScopedTree(uid, uid, agentDir);
+    } else {
+      ownershipRuntime.chownTree(uid, uid, agentDir);
+    }
     const elapsedMs = ownershipRuntime.now() - startedAt;
     console.log(
-      `[ownership-sweep] #3333 agent=${name} scope=full uid=${uid} ` +
+      `[ownership-sweep] #3333 agent=${name} scope=${scoped ? "scoped" : "full"} uid=${uid} ` +
         `inodes=${inodes ?? "unknown"} elapsedMs=${elapsedMs} dir=${agentDir}`,
     );
   } catch (err) {

--- a/src/agents/agent-owned-tree.ts
+++ b/src/agents/agent-owned-tree.ts
@@ -83,6 +83,41 @@ export const SCOPED_RECURSIVE_SUBDIRS = [
 ] as const;
 
 /**
+ * Top-level agent-dir files a root reconcile writer can create/rewrite that
+ * MUST stay agent-readable (#3333 amendment A + finding 1). These are the
+ * critical members of the top-level SHALLOW sweep — the ones whose owner-only
+ * (0600) form would silently wedge the agent (#3168). `cron-session.sh` and
+ * `.resume-mode-migration-warned` are the leak-list entries the enumeration
+ * found outside the original static assert set; `CLAUDE.md` is included
+ * because it is root-rewritten in place. Not exhaustive of every top-level
+ * file (the sweep re-owns them all) — this is the ASSERT allowlist, the
+ * subset we fail loudly on.
+ */
+export const SCOPED_TOP_LEVEL_CRITICAL = [
+  "start.sh",
+  ".mcp.json",
+  "CLAUDE.md",
+  "cron-session.sh",
+  ".resume-mode-migration-warned",
+] as const;
+
+/**
+ * The STATIC scoped candidate set for the post-sweep readability assert
+ * (#3333 stage 3, amendment B). Derived from the SAME scope constants the
+ * sweep uses, so scope-of-sweep == scope-of-assert. The reconcile assert
+ * unions this with the dynamic per-run `changes` list — it NEVER replaces
+ * it (dropping `changes` would narrow coverage of touched-but-out-of-scope
+ * files). Missing paths are harmless: findAgentUnreadablePaths skips them.
+ */
+export function scopedAssertCandidates(agentDir: string): string[] {
+  return [
+    join(agentDir, ".claude", "settings.json"),
+    join(agentDir, ".claude-cron", ".mcp.json"),
+    ...SCOPED_TOP_LEVEL_CRITICAL.map((f) => join(agentDir, f)),
+  ];
+}
+
+/**
  * Env flag that switches the reconcile sweep from the full recursive chown
  * to the scoped sweep (#3333). Default OFF — the flag is injected by the
  * rollout ONLY into the canary restart spawn (stage 4, amendment C), never

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -23,7 +23,11 @@ import chalk from "chalk";
 import type { AgentConfig, QuotaConfig, SwitchroomConfig, TelegramConfig } from "../config/schema.js";
 import { CRON_SCRIPT_BASENAME_RE, LEGACY_CRON_SCRIPT_BASENAME_RE } from "./cron-unit-name.js";
 import { atomicWriteFileSync } from "../util/atomic.js";
-import { alignAgentTreeOwnershipIfRoot, findAgentUnreadablePaths } from "./agent-owned-tree.js";
+import {
+  alignAgentTreeOwnershipIfRoot,
+  findAgentUnreadablePaths,
+  scopedAssertCandidates,
+} from "./agent-owned-tree.js";
 
 // Repo root for referencing bin/ scripts in hooks
 const REPO_ROOT = resolve(import.meta.dirname, "../..");
@@ -7339,12 +7343,18 @@ function reconcileAgentInner(
   {
     const sweptUid = alignAgentTreeOwnershipIfRoot(name, agentDir);
     if (sweptUid !== null) {
+      // #3333 amendment B: the assert candidate set is the UNION of the
+      // static scoped set (derived from the same scope constants the sweep
+      // uses — scope-of-sweep == scope-of-assert) and this run's dynamic
+      // `changes` list. The `changes` term must be PRESERVED, never
+      // replaced: it is what catches a touched-but-out-of-scope file (e.g.
+      // a future top-level write) that the static set doesn't name. Dedup
+      // so a file in both terms is only reported once.
       const critical = [
-        join(agentDir, ".claude", "settings.json"),
-        join(agentDir, ".mcp.json"),
-        join(agentDir, ".claude-cron", ".mcp.json"),
-        join(agentDir, "start.sh"),
-        ...changes.filter((p) => p.startsWith(agentDir + "/")),
+        ...new Set([
+          ...scopedAssertCandidates(agentDir),
+          ...changes.filter((p) => p.startsWith(agentDir + "/")),
+        ]),
       ];
       const unreadable = findAgentUnreadablePaths(critical, sweptUid);
       if (unreadable.length > 0) {

--- a/tests/reconcile.scoped-sweep.test.ts
+++ b/tests/reconcile.scoped-sweep.test.ts
@@ -206,6 +206,32 @@ describe("alignAgentTreeOwnershipIfRoot — flag gating (#3333 stage 2)", () => 
   });
 });
 
+describe("chownShallow — -h symlink semantics on non-root CI (#3362 review fix 2)", () => {
+  // The root-gated -h tests below self-skip on the non-root CI runner, so a
+  // `-h` removal from chownShallow's argv would ship green there. This test
+  // runs UNPRIVILEGED: chown to our OWN uid:gid needs no CAP_CHOWN, and a
+  // DANGLING symlink makes -h load-bearing — without -h (GNU non-recursive
+  // chown and busybox both dereference by default) the chown hits ENOENT and
+  // throws; with -h it lchowns the link and succeeds. Outcome-asserting:
+  // fails if -h is ever dropped, on any runner.
+  it("real chownShallow lchowns a dangling symlink instead of dereferencing (would throw without -h)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "switchroom-shallow-h-"));
+    try {
+      const file = join(dir, "plain");
+      writeFileSync(file, "x");
+      const dangling = join(dir, "dangling");
+      symlinkSync("/nonexistent/target/for-h-test", dangling);
+      const uid = process.getuid?.() ?? 0;
+      const gid = process.getgid?.() ?? 0;
+      expect(() =>
+        real.chownShallow(uid, gid, [dir, file, dangling]),
+      ).not.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 // Real-outcome pins: only where the test process has CAP_CHOWN (self-skip on
 // the non-root CI runner). The recorder tests above cover the wiring there.
 describe("chownScopedTree — real outcomes (root only)", () => {

--- a/tests/reconcile.scoped-sweep.test.ts
+++ b/tests/reconcile.scoped-sweep.test.ts
@@ -1,0 +1,260 @@
+/**
+ * #3333 stage 2 — scoped ownership sweep behind a flag (default OFF).
+ *
+ * The full recursive `chown -h -R` over an agent's ~620k-inode tree takes
+ * hours at single-spindle IOPS (home/ is ~96% of the inodes and is caches,
+ * not agent state). The scoped sweep (amendment A) re-owns only what root
+ * reconcile writers actually touch: a SHALLOW chown of the top-level
+ * (files + symlinks + dir inodes) plus a recursive chown into the scoped
+ * state subdirs {.claude/, .claude-cron/, telegram/}. home/ workspace/ tmp/
+ * are never traversed.
+ *
+ * These tests pin:
+ *   - flag OFF (default) => full sweep, unchanged (chownTree over agentDir)
+ *   - flag ON => shallow top-level + recursion only into existing scoped subdirs
+ *   - the excluded caches (home/) are NEVER recursed into
+ *   - `-h` symlink safety on the real shallow chown (root-gated)
+ *   - a planted root:root 0600 file in .claude IS re-owned by the scoped
+ *     sweep; one planted in the excluded home/ is left (root-gated)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  alignAgentTreeOwnershipIfRoot,
+  chownScopedTree,
+  ownershipRuntime,
+  SCOPED_SWEEP_ENV,
+} from "../src/agents/agent-owned-tree.js";
+import { allocateAgentUid } from "../src/agents/agent-uid.js";
+
+const AGENT = "scoped-agent";
+
+const real = {
+  geteuid: ownershipRuntime.geteuid,
+  chownTree: ownershipRuntime.chownTree,
+  chownShallow: ownershipRuntime.chownShallow,
+  scopedSweepEnabled: ownershipRuntime.scopedSweepEnabled,
+  now: ownershipRuntime.now,
+  countInodes: ownershipRuntime.countInodes,
+};
+
+/** Build an agent-dir skeleton: top-level files + symlink, scoped subdirs, and excluded caches. */
+function makeTree(): string {
+  const dir = mkdtempSync(join(tmpdir(), "switchroom-scoped-"));
+  writeFileSync(join(dir, "start.sh"), "#!/bin/sh\n");
+  writeFileSync(join(dir, "CLAUDE.md"), "x");
+  writeFileSync(join(dir, "CLAUDE.md.fingerprint"), "abc");
+  writeFileSync(join(dir, "cron-session.sh"), "#!/bin/sh\n");
+  writeFileSync(join(dir, ".resume-mode-migration-warned"), "1");
+  writeFileSync(join(dir, ".mcp.json"), "{}");
+  mkdirSync(join(dir, ".claude"), { recursive: true });
+  writeFileSync(join(dir, ".claude", "settings.json"), "{}");
+  mkdirSync(join(dir, ".claude-cron"), { recursive: true });
+  writeFileSync(join(dir, ".claude-cron", ".mcp.json"), "{}");
+  mkdirSync(join(dir, "telegram"), { recursive: true });
+  // Excluded caches — must never be recursed into.
+  mkdirSync(join(dir, "home"), { recursive: true });
+  writeFileSync(join(dir, "home", "cache.bin"), "big");
+  mkdirSync(join(dir, "workspace"), { recursive: true });
+  mkdirSync(join(dir, "tmp"), { recursive: true });
+  // Top-level symlink (SOUL.md → workspace/SOUL.md shape).
+  writeFileSync(join(dir, "workspace", "SOUL.md"), "soul");
+  symlinkSync("workspace/SOUL.md", join(dir, "SOUL.md"));
+  return dir;
+}
+
+describe("chownScopedTree — call shape (#3333 stage 2)", () => {
+  afterEach(() => {
+    ownershipRuntime.chownTree = real.chownTree;
+    ownershipRuntime.chownShallow = real.chownShallow;
+  });
+
+  it("shallow-chowns agentDir + all direct children, recurses only into existing scoped subdirs", () => {
+    const dir = makeTree();
+    try {
+      const shallow: string[][] = [];
+      const recursed: string[] = [];
+      ownershipRuntime.chownShallow = (_u, _g, paths) => shallow.push(paths);
+      ownershipRuntime.chownTree = (_u, _g, root) => recursed.push(root);
+
+      const uid = allocateAgentUid(AGENT);
+      chownScopedTree(uid, uid, dir);
+
+      expect(shallow.length).toBe(1);
+      const paths = shallow[0];
+      expect(paths[0]).toBe(dir); // the dir inode itself
+      // every direct child included (files, symlink, subdir inodes)
+      for (const child of [
+        "start.sh",
+        "CLAUDE.md",
+        "CLAUDE.md.fingerprint",
+        "cron-session.sh",
+        ".resume-mode-migration-warned",
+        ".mcp.json",
+        "SOUL.md",
+        "home",
+        "workspace",
+        "tmp",
+      ]) {
+        expect(paths).toContain(join(dir, child));
+      }
+
+      // recursion ONLY into the three scoped subdirs that exist
+      expect(recursed.sort()).toEqual(
+        [".claude", ".claude-cron", "telegram"].map((s) => join(dir, s)).sort(),
+      );
+      // excluded caches are NEVER a recursion root
+      expect(recursed).not.toContain(join(dir, "home"));
+      expect(recursed).not.toContain(join(dir, "workspace"));
+      expect(recursed).not.toContain(join(dir, "tmp"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips a scoped subdir that does not exist", () => {
+    const dir = mkdtempSync(join(tmpdir(), "switchroom-scoped-"));
+    try {
+      mkdirSync(join(dir, ".claude"), { recursive: true });
+      const recursed: string[] = [];
+      ownershipRuntime.chownShallow = () => {};
+      ownershipRuntime.chownTree = (_u, _g, root) => recursed.push(root);
+      chownScopedTree(1, 1, dir);
+      expect(recursed).toEqual([join(dir, ".claude")]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("alignAgentTreeOwnershipIfRoot — flag gating (#3333 stage 2)", () => {
+  beforeEach(() => {
+    ownershipRuntime.now = () => 0;
+    ownershipRuntime.countInodes = () => 0;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    ownershipRuntime.geteuid = real.geteuid;
+    ownershipRuntime.chownTree = real.chownTree;
+    ownershipRuntime.chownShallow = real.chownShallow;
+    ownershipRuntime.scopedSweepEnabled = real.scopedSweepEnabled;
+    ownershipRuntime.now = real.now;
+    ownershipRuntime.countInodes = real.countInodes;
+    delete process.env[SCOPED_SWEEP_ENV];
+    vi.restoreAllMocks();
+  });
+
+  it("flag OFF (default): full sweep — chownTree over agentDir, no shallow pass", () => {
+    const dir = makeTree();
+    try {
+      const full: string[] = [];
+      const shallow: string[][] = [];
+      ownershipRuntime.geteuid = () => 0;
+      ownershipRuntime.scopedSweepEnabled = real.scopedSweepEnabled; // reads env (unset)
+      ownershipRuntime.chownTree = (_u, _g, root) => full.push(root);
+      ownershipRuntime.chownShallow = (_u, _g, p) => shallow.push(p);
+
+      alignAgentTreeOwnershipIfRoot(AGENT, dir);
+      expect(full).toEqual([dir]);
+      expect(shallow).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("flag ON: scoped sweep — shallow top-level + scoped subdir recursion, agentDir never a full-tree root", () => {
+    const dir = makeTree();
+    try {
+      const recursed: string[] = [];
+      const shallow: string[][] = [];
+      ownershipRuntime.geteuid = () => 0;
+      ownershipRuntime.scopedSweepEnabled = () => true;
+      ownershipRuntime.chownTree = (_u, _g, root) => recursed.push(root);
+      ownershipRuntime.chownShallow = (_u, _g, p) => shallow.push(p);
+
+      alignAgentTreeOwnershipIfRoot(AGENT, dir);
+      expect(shallow.length).toBe(1);
+      // the whole-tree chown root (agentDir) must NOT appear — that's the slow path we removed
+      expect(recursed).not.toContain(dir);
+      expect(recursed.sort()).toEqual(
+        [".claude", ".claude-cron", "telegram"].map((s) => join(dir, s)).sort(),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("scopedSweepEnabled reads the per-invocation env flag (default OFF)", () => {
+    delete process.env[SCOPED_SWEEP_ENV];
+    expect(real.scopedSweepEnabled()).toBe(false);
+    process.env[SCOPED_SWEEP_ENV] = "1";
+    expect(real.scopedSweepEnabled()).toBe(true);
+    process.env[SCOPED_SWEEP_ENV] = "0";
+    expect(real.scopedSweepEnabled()).toBe(false);
+  });
+});
+
+// Real-outcome pins: only where the test process has CAP_CHOWN (self-skip on
+// the non-root CI runner). The recorder tests above cover the wiring there.
+describe("chownScopedTree — real outcomes (root only)", () => {
+  it.runIf(process.getuid?.() === 0)(
+    "re-owns a planted root:root 0600 file in .claude, leaves the one in excluded home/",
+    () => {
+      const dir = makeTree();
+      try {
+        const planted = join(dir, ".claude", "planted.json");
+        writeFileSync(planted, "{}", { mode: 0o600 });
+        execFileSync("chown", ["0:0", planted]);
+        const cachePlanted = join(dir, "home", "planted.bin");
+        writeFileSync(cachePlanted, "x", { mode: 0o600 });
+        execFileSync("chown", ["0:0", cachePlanted]);
+
+        const uid = allocateAgentUid(AGENT);
+        chownScopedTree(uid, uid, dir);
+
+        expect(statSync(planted).uid).toBe(uid); // scoped subdir → re-owned
+        expect(statSync(cachePlanted).uid).toBe(0); // excluded cache → untouched
+        // top-level shallow pass re-owned the direct children
+        expect(statSync(join(dir, "start.sh")).uid).toBe(uid);
+        expect(statSync(join(dir, "cron-session.sh")).uid).toBe(uid);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.getuid?.() === 0)(
+    "-h: a planted top-level symlink is lchowned, its target is NOT dereferenced",
+    () => {
+      const dir = makeTree();
+      const outside = mkdtempSync(join(tmpdir(), "switchroom-outside-"));
+      const secret = join(outside, "secret");
+      try {
+        writeFileSync(secret, "shadow", { mode: 0o600 });
+        execFileSync("chown", ["0:0", secret]);
+        symlinkSync(secret, join(dir, "evil-link"));
+
+        const uid = allocateAgentUid(AGENT);
+        chownScopedTree(uid, uid, dir);
+
+        // the symlink target (outside the tree) must stay root-owned
+        expect(statSync(secret).uid).toBe(0);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+        rmSync(outside, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/tests/reconcile.union-assert.test.ts
+++ b/tests/reconcile.union-assert.test.ts
@@ -1,0 +1,182 @@
+/**
+ * #3333 stage 3 — widened UNION assert (amendment B).
+ *
+ * The post-sweep readability assert must be the UNION of:
+ *   - the static scoped candidate set (derived from the same scope constants
+ *     the sweep uses, so scope-of-sweep == scope-of-assert), and
+ *   - this run's dynamic `changes` list (touched-but-out-of-scope files).
+ *
+ * It must NEVER replace the `changes` term with a static set — that would
+ * narrow today's coverage of touched files outside the static names.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  findAgentUnreadablePaths,
+  ownershipRuntime,
+  scopedAssertCandidates,
+  SCOPED_TOP_LEVEL_CRITICAL,
+} from "../src/agents/agent-owned-tree.js";
+import { allocateAgentUid } from "../src/agents/agent-uid.js";
+import { reconcileAgent, scaffoldAgent } from "../src/agents/scaffold.js";
+import type {
+  AgentConfig,
+  SwitchroomConfig,
+  TelegramConfig,
+} from "../src/config/schema.js";
+
+describe("scopedAssertCandidates (#3333 stage 3)", () => {
+  it("includes the settings/mcp critical files and the leak-list top-level files", () => {
+    const dir = "/agents/x";
+    const cands = scopedAssertCandidates(dir);
+    expect(cands).toContain(join(dir, ".claude", "settings.json"));
+    expect(cands).toContain(join(dir, ".claude-cron", ".mcp.json"));
+    // finding-1 leak-list entries are now asserted candidates
+    expect(cands).toContain(join(dir, "cron-session.sh"));
+    expect(cands).toContain(join(dir, ".resume-mode-migration-warned"));
+    expect(cands).toContain(join(dir, "CLAUDE.md"));
+    expect(cands).toContain(join(dir, "start.sh"));
+    expect(cands).toContain(join(dir, ".mcp.json"));
+    // derived from the shared constant
+    for (const f of SCOPED_TOP_LEVEL_CRITICAL) {
+      expect(cands).toContain(join(dir, f));
+    }
+  });
+});
+
+describe("union assert coverage (#3333 stage 3, amendment B)", () => {
+  const foreignUid = allocateAgentUid("union-agent"); // never the test process uid
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "switchroom-union-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("catches a leak-list top-level file left root-owned 0600 (static term)", () => {
+    const cron = join(dir, "cron-session.sh");
+    writeFileSync(cron, "#!/bin/sh\n", { mode: 0o600 });
+    chmodSync(cron, 0o600); // umask-proof; owner-only, foreign uid
+    const bad = findAgentUnreadablePaths(scopedAssertCandidates(dir), foreignUid);
+    expect(bad).toContain(cron);
+  });
+
+  it("catches a touched-but-out-of-scope file present ONLY in the changes term", () => {
+    // A file the static set does not name, but reconcile pushed to `changes`.
+    const touched = join(dir, "novel-top-level-file");
+    writeFileSync(touched, "x", { mode: 0o600 });
+    chmodSync(touched, 0o600);
+
+    // Replicate the scaffold union: static ∪ changes.
+    const changes = [touched];
+    const critical = [
+      ...new Set([...scopedAssertCandidates(dir), ...changes]),
+    ];
+    const bad = findAgentUnreadablePaths(critical, foreignUid);
+    expect(bad).toContain(touched); // dropped if `changes` term were removed
+
+    // And with the changes term REMOVED it would be missed — pin the regression.
+    const staticOnly = findAgentUnreadablePaths(scopedAssertCandidates(dir), foreignUid);
+    expect(staticOnly).not.toContain(touched);
+  });
+
+  it("dedups a file present in both terms", () => {
+    const settings = join(dir, ".claude", "settings.json");
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+    writeFileSync(settings, "{}", { mode: 0o600 });
+    chmodSync(settings, 0o600);
+    const changes = [settings]; // also in the static set
+    const critical = [
+      ...new Set([...scopedAssertCandidates(dir), ...changes]),
+    ];
+    const bad = findAgentUnreadablePaths(critical, foreignUid);
+    expect(bad.filter((p) => p === settings)).toHaveLength(1);
+  });
+});
+
+describe("union assert at the REAL call site — reconcileAgent (#3363 review fix 1)", () => {
+  // The inline-union tests above replicate the scaffold expression; a
+  // regression that drops the `changes` term AT THE CALL SITE
+  // (scaffold.ts's post-sweep `critical` construction) would still pass
+  // them. This drives the real path end-to-end:
+  //
+  //   1. scaffold an agent WITH a subagent → `.claude/agents/helper.md`
+  //      exists — a file NOT named by scopedAssertCandidates
+  //   2. tamper it on disk so the next reconcile detects a diff, rewrites
+  //      it, and pushes it to `changes`
+  //   3. run reconcile as fake-root with a sweep stub that makes the tree
+  //      readable EXCEPT that one file (left 0600, foreign-to-agent-uid —
+  //      the #3168 poison shape)
+  //   4. reconcile MUST throw naming helper.md — it is only reachable via
+  //      the dynamic `changes` term of the union. Drop the union → green
+  //      reconcile → this test fails.
+  const AGENT = "union-real-agent";
+  const telegramConfig: TelegramConfig = {
+    bot_token: "123456:ABC-DEF",
+    forum_chat_id: "-1001234567890",
+  };
+  const switchroomConfig: SwitchroomConfig = {
+    agents: {},
+    telegram: telegramConfig,
+    defaults: {},
+  };
+  const config = {
+    extends: "default",
+    topic_name: "Union Real",
+    schedule: [],
+    subagents: {
+      helper: { description: "test helper", prompt: "You help." },
+    },
+  } as unknown as AgentConfig;
+
+  const realGeteuid = ownershipRuntime.geteuid;
+  const realChownTree = ownershipRuntime.chownTree;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-union-real-"));
+  });
+
+  afterEach(() => {
+    ownershipRuntime.geteuid = realGeteuid;
+    ownershipRuntime.chownTree = realChownTree;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("fails reconcile when a changes-tracked file OUTSIDE the static set is left unreadable", () => {
+    const { agentDir } = scaffoldAgent(AGENT, config, tmpDir, telegramConfig);
+    const helperMd = join(agentDir, ".claude", "agents", "helper.md");
+    // Sanity: the file exists and the static set does NOT name it — the
+    // ONLY route into the assert is the dynamic `changes` union.
+    writeFileSync(helperMd, "tampered — reconcile must rewrite me");
+    expect(scopedAssertCandidates(agentDir)).not.toContain(helperMd);
+
+    ownershipRuntime.geteuid = () => 0;
+    ownershipRuntime.chownTree = (_uid, _gid, rootDir) => {
+      // Sweep stand-in: make everything agent-readable EXCEPT the
+      // changes-tracked helper.md, which stays owner-only under a uid
+      // foreign to the agent's 10001+ — the incident combination.
+      execFileSync("chmod", ["-R", "a+rX", rootDir]);
+      chmodSync(helperMd, 0o600);
+    };
+
+    // Single invocation (a second reconcile would find helper.md already
+    // regenerated and push nothing): capture the one thrown error and
+    // assert both the loud-assert shape and the culprit file.
+    let thrown: Error | null = null;
+    try {
+      reconcileAgent(AGENT, config, tmpDir, telegramConfig, switchroomConfig);
+    } catch (err) {
+      thrown = err as Error;
+    }
+    expect(thrown).not.toBeNull();
+    expect(thrown!.message).toMatch(/agent-unreadable files/);
+    expect(thrown!.message).toMatch(/helper\.md/);
+  });
+});


### PR DESCRIPTION
## Stage 2 of #3333 — scoped agent-home ownership sweep

Stacked on #3360 (stage 1). Adds `chownScopedTree` behind the `SWITCHROOM_SCOPED_OWNERSHIP_SWEEP` env flag, **default OFF** — zero behaviour change until the canary flip (stage 4).

### Amendment A shape
- **SHALLOW** chown (no `-R`) of the agent dir + every direct child (files, symlinks, subdir inodes) — captures `start.sh`, `CLAUDE.md*`, `cron-session.sh`, `.mcp.json`, `.resume-mode-migration-warned`, `SOUL.md` regardless of name
- recursive `chown -h -R` **only** into the scoped state subdirs that exist: `SCOPED_RECURSIVE_SUBDIRS = {.claude/, .claude-cron/, telegram/}`
- `home/` `workspace/` `tmp/` are never traversed (home/ is ~96% of inodes)
- the walk is **never hand-rolled**: `readdirSync` reads ONE level for the shallow pass, recursion is `chown -h -R`; `-h` symlink semantics preserved throughout

Folds in finding-1's leak list: `cron-session.sh` and `.resume-mode-migration-warned` are top-level files captured by the shallow pass; `workspace/CLAUDE.custom.md` stays excluded (per amendment A, workspace/ is not swept — it is world-readable today, and the widened assert in stage 3 catches it if it ever becomes critical).

`SCOPED_RECURSIVE_SUBDIRS` is the single source of truth for scope-of-sweep; stage 3's widened assert derives its candidate set from the same constant (scope-of-sweep == scope-of-assert).

### Tests
`tests/reconcile.scoped-sweep.test.ts`:
- call shape — shallow path list + recursion only into existing scoped subdirs, excluded caches never a recursion root
- flag gating — OFF = full sweep (unchanged), ON = scoped
- env parsing (default OFF)
- root-gated real outcomes — planted `.claude` 0600 re-owned, planted `home/` 0600 left, `-h` symlink target not dereferenced
- non-root `-h` pin (review fix 2) — real `chownShallow` over a dangling symlink to our own uid succeeds only because of `-h`; fails on `-h` removal on the non-root CI runner

### Residual risk (documented per review fix 3)
A future root writer that creates a NEW top-level **subdirectory** not in `SCOPED_RECURSIVE_SUBDIRS` gets its dir inode re-owned by the shallow pass, but its **contents** are neither swept nor asserted unless the write site pushes the paths into `changes` (which the union assert then covers). `SCOPED_RECURSIVE_SUBDIRS` is therefore a **maintained invariant**: anyone adding a new root-written state subdir under the agent home must add it to the constant (which automatically widens both sweep and assert, since both derive from it). Same discipline as the agent-owned-tree.ts "rule for future scaffold/reconcile authors" doc block.

Refs #3333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
