### PR TITLE
fix(worker-feed): re-surface a resumed background worker's live card (#3373)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -26106,6 +26106,26 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                   `telegram gateway: worker ${agentId} card RESURRECTED — false terminal finish reversed, worker resumed (issue #3023)\n`,
                 )
               },
+              // Issue #3373 (SendMessage-resume feed re-surface). A worker with a
+              // GENUINE terminal completion that is resumed via SendMessage grows
+              // its jsonl past the terminal boundary and is re-registered live by
+              // the watcher (#3315). Clear the feed's terminal `finalized` latch so
+              // the resumed worker's next onProgress cue repaints a fresh live row
+              // (without this the latch swallows every resumed cue → the worker
+              // reads as silence). Distinct from onResurrect: no bounded-chain
+              // budget — a worker may be stopped/resumed any number of times.
+              onResume: (agentId, _description) => {
+                try {
+                  workerActivityFeed?.resurrect(agentId)
+                } catch (err) {
+                  process.stderr.write(
+                    `telegram gateway: worker resume feed re-surface error agent=${agentId}: ${(err as Error).message}\n`,
+                  )
+                }
+                process.stderr.write(
+                  `telegram gateway: worker ${agentId} card RE-SURFACED — resumed via SendMessage after a genuine terminal (issue #3373)\n`,
+                )
+              },
               // Issue #3023 (bounded chain). A worker resurrected once and then
               // falsely finalised again is NOT resurrected forever — the
               // watcher names it lost. Surface the fact in the log; the

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -552,6 +552,31 @@ export interface SubagentWatcherConfig {
    */
   onWorkerLost?: (agentId: string, description: string) => void
   /**
+   * Issue #3373 (SendMessage-resume feed re-surface). Fires when a worker that
+   * had a GENUINE terminal completion (a real `sub_agent_turn_end`, then swept
+   * by `cleanupTerminalAgent`) is RESUMED via SendMessage — its
+   * `agent-<id>.jsonl` grows PAST the byte size recorded at terminal cleanup,
+   * and `scanSubagentsDir` re-registers it as a fresh live entry (#3315).
+   *
+   * This is DISTINCT from `onResurrect` (#3023), which reverses a FALSE finish
+   * from silent-stall synthesis and carries bounded-chain semantics. A
+   * SendMessage resume is a real, legitimately-unbounded lifecycle event (a
+   * worker may be stopped and resumed many times), so it does NOT route through
+   * the resurrection budget — it fires here every time growth-past-terminal is
+   * observed.
+   *
+   * Why it exists: the live worker-activity feed latches a terminal `finalized`
+   * gate per agentId (worker-activity-feed.ts) so a late zombie tick can't
+   * repaint a done worker. The #3315 re-registration re-arms the watcher and
+   * re-fires `onProgress`, but those cues are SWALLOWED by that latch — so a
+   * resumed long-running worker reads as silence with no card. The gateway
+   * wires this to `feed.resurrect(agentId)` (clear the latch) so the subsequent
+   * `onProgress` cue repaints a fresh live row. Deterministic: gated solely on
+   * the file growing past the recorded terminal boundary, never on model
+   * discipline. Best-effort; the callback is expected to be idempotent.
+   */
+  onResume?: (agentId: string, description: string) => void
+  /**
    * Called exactly once per sub-agent when its watcher observes a terminal
    * transition (`done` or `failed`). Mirrors the existing `sub_agent_started`
    * surface (emitted from session-tail) so the audit trail is symmetric.
@@ -3092,6 +3117,22 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
         terminatedAgentIds.delete(agentId)
         historicalFiles.delete(filePath)
         knownFiles.add(filePath)
+        // Issue #3373: the worker-activity feed latched a terminal `finalized`
+        // gate for this agentId at its genuine completion, so the `onProgress`
+        // cues the re-registration is about to re-fire would be SWALLOWED and no
+        // card would re-surface. Fire onResume FIRST (before registerAgent, whose
+        // initial read can synchronously re-emit onProgress) so the gateway clears
+        // that gate; the subsequent live cue then repaints a fresh row. Fired only
+        // on growth-past-terminal — never for a static leftover (the
+        // `currentSize <= terminalSize` continue above), so the anti-zombie latch
+        // still blocks genuinely-finished workers.
+        if (config.onResume != null) {
+          try {
+            config.onResume(agentId, registry.get(agentId)?.description ?? 'sub-agent')
+          } catch (cbErr) {
+            log?.(`subagent-watcher: onResume callback error ${agentId}: ${(cbErr as Error).message}`)
+          }
+        }
         registerAgent(filePath, agentId, terminalSize)
         continue
       }

--- a/telegram-plugin/tests/subagent-watcher-resume-reregister.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-resume-reregister.test.ts
@@ -59,6 +59,7 @@ function makeHarness(opts: { agentId?: string } = {}) {
   const progressCalls: ProgressCall[] = []
   const finishCalls: Array<{ agentId: string; outcome: string }> = []
   const terminalCleanupCalls: string[] = []
+  const resumeCalls: Array<{ agentId: string; description: string }> = []
   const logs: string[] = []
 
   const agentDir = '/home/user/.switchroom/agents/myagent'
@@ -133,6 +134,7 @@ function makeHarness(opts: { agentId?: string } = {}) {
       progressCalls.push({ agentId: id, skeleton: skeleton === true, progressLine, toolCount }),
     onFinish: ({ agentId: id, outcome }) => finishCalls.push({ agentId: id, outcome }),
     onTerminalCleanup: (id) => terminalCleanupCalls.push(id),
+    onResume: (id, description) => resumeCalls.push({ agentId: id, description }),
     now: () => currentTime,
     setInterval: (fn, ms) => {
       const ref = nextRef++
@@ -191,6 +193,7 @@ function makeHarness(opts: { agentId?: string } = {}) {
     progressCalls,
     finishCalls,
     terminalCleanupCalls,
+    resumeCalls,
     logs,
     advance,
     watcher,
@@ -240,6 +243,13 @@ describe('subagent-watcher resume re-registration (issue #3315)', () => {
     expect(revived!.historical).toBe(false)
     expect(h.logs.some((l) => l.includes('resumed after terminal cleanup') && l.includes(agentId))).toBe(true)
 
+    // Issue #3373: onResume fired exactly once for the resumed worker, BEFORE
+    // registration re-fires onProgress — this is what clears the feed's terminal
+    // `finalized` latch so the resumed cues re-surface a card instead of being
+    // swallowed. (The feed-side re-surface behaviour is covered in
+    // worker-activity-feed.test.ts.)
+    expect(h.resumeCalls.filter((c) => c.agentId === agentId)).toHaveLength(1)
+
     // Progress cues resume (the card updates again) — the user-visible fix.
     expect(h.progressCalls.length).toBeGreaterThan(progressBeforeResume)
     expect(h.progressCalls.slice(progressBeforeResume).some((c) => c.agentId === agentId)).toBe(true)
@@ -285,6 +295,10 @@ describe('subagent-watcher resume re-registration (issue #3315)', () => {
     expect(h.progressCalls).toHaveLength(progressAfterCleanup) // no card churn
     // Cleanup fired exactly once — no leaked/duplicated terminal sweep.
     expect(h.terminalCleanupCalls.filter((id) => id === agentId)).toHaveLength(1)
+    // Issue #3373 anti-zombie: a genuinely-finished worker that never grew past
+    // its terminal boundary must NEVER fire onResume — otherwise the feed's
+    // finalized latch would be cleared and a dead worker could zombie-resurface.
+    expect(h.resumeCalls.filter((c) => c.agentId === agentId)).toHaveLength(0)
 
     h.watcher.stop()
   })

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -1063,6 +1063,37 @@ describe('createWorkerActivityFeed — resurrection guard + deferred finalize', 
     expect(bot.sent[1].text).toContain('back to work')
   })
 
+  it('#3373: a GENUINE terminal then a SendMessage resume re-surfaces a live card (resurrect+update), while an un-resumed terminal stays dead', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    // Worker runs, then GENUINELY completes (a real turn_end handback) — the
+    // row is dropped and the agentId latched into the terminal `finalized` gate.
+    await feed.update('w1', 'chat', view({ toolCount: 1, latestSummary: 'step one' }))
+    await feed.finish('w1', view({ state: 'done', toolCount: 1, latestSummary: 'real result' }))
+    expect(feed.has('w1')).toBe(false)
+
+    // Anti-zombie: with NO resume signal, later cues stay swallowed forever — a
+    // genuinely-finished worker must never zombie-resurface on a stray tick.
+    clock = 12_000
+    await feed.update('w1', 'chat', view({ toolCount: 2, latestSummary: 'stray tick' }))
+    expect(bot.sent).toHaveLength(1)
+    expect(feed.has('w1')).toBe(false)
+
+    // Now the worker is RESUMED via SendMessage: the watcher observes jsonl
+    // growth past the terminal boundary (#3315) and fires onResume, which the
+    // gateway wires to feed.resurrect — clearing the finalized latch.
+    feed.resurrect('w1')
+
+    // The resumed worker's next progress cue re-surfaces a fresh live card.
+    clock = 13_000
+    await feed.update('w1', 'chat', view({ toolCount: 3, latestSummary: 'resumed work' }))
+    expect(bot.sent).toHaveLength(2)
+    expect(feed.has('w1')).toBe(true)
+    expect(bot.sent[1].text).toContain('resumed work')
+  })
+
   it('#3023: resurrect() on a never-finalized worker is a harmless no-op', () => {
     const bot = makeFakeBot()
     const feed = createWorkerActivityFeed({ bot, now: () => 10_000 })


### PR DESCRIPTION
Root cause: a genuine terminal (real turn_end → cleanupTerminalAgent) latches the worker-feed's per-agentId `finalized` gate; a SendMessage resume re-registers the worker live (#3315) and re-fires onProgress, but those cues are swallowed by the still-set latch so no card re-appears. Only the #3023 false-finish path cleared it (via onResurrect).

Fix: new watcher `onResume(agentId, description)` fired in the #3315 scanSubagentsDir branch before re-registration; gateway wires it to feed.resurrect(agentId), clearing the latch so the next onProgress repaints a fresh live row. Deterministic (gated on jsonl growth past the terminal boundary, no model discipline), unbounded (distinct from #3023's bounded chain).

Anti-zombie preserved: onResume fires ONLY on growth-past-terminal; an un-resumed static terminal hits the currentSize<=terminalSize continue and stays suppressed, and stray post-finish ticks stay blocked by the latch.

Files: subagent-watcher.ts, gateway/gateway.ts (~20 lines, within ratchet slack), + two test files.

Verification: 86 scoped tests pass; npm run lint clean (tsc + all checks + gateway-line-ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)