### PR TITLE
fix(tests): drain the inbound-coalesce window in the characterization harness (#3359 CI flake) + spill-direction doc fixes

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -15199,6 +15199,15 @@ export const __inboundRouterTestSeam = {
   // a test import it is undefined, so the imperative deliver / permission-
   // verdict paths would deref undefined. Let the harness inject a fake.
   setIpcServer: (s: IpcServer): void => { ipcServer = s },
+  // The coalesce window holds real setTimeout flush timers whose callback
+  // fires `void handleInbound(...)`. Under a test import, an entry still
+  // buffered when a test ends flushes DURING a later test and pollutes its
+  // dispatch log (the #3359 CI flake: the "stop with attachment" entry's
+  // deferred flush delivered mid-way through the FAIL-CLOSED test). Exposed
+  // so the harness can `peek()` (assert content-path buffering) and
+  // `reset()` (cancel stale timers) in beforeEach. Read/reset only — no
+  // production behaviour change.
+  inboundCoalescer,
 }
 
 export async function handleInboundCoalesced(

--- a/telegram-plugin/tests/worker-feed-coalesce.test.ts
+++ b/telegram-plugin/tests/worker-feed-coalesce.test.ts
@@ -757,9 +757,9 @@ describe('renderCombinedWorkerFeed (pure)', () => {
     expect(headerAndHistory.length).toBeLessThanOrEqual(24)
   })
 
-  it('drops OLDEST rows into the spill when the fan-out overflows the 24-line body budget, keeping per-worker depth at 3 (#3349)', () => {
+  it('drops NEWEST (trailing) rows into the spill when the fan-out overflows the 24-line body budget, keeping per-worker depth at 3 (#3349)', () => {
     // 8 workers × (1 header + 3 depth) = 32 > 24 → the backstop collapses the 2
-    // oldest visible rows into `+M more working…`, so 6 rows render at full
+    // newest (trailing) visible rows into `+M more working…`, so 6 rows render at full
     // depth-3 (24 lines) rather than every worker losing a step.
     const rows = Array.from({ length: 8 }, (_, i) =>
       rowH(i, [`w${i} s1`, `w${i} s2`, `w${i} s3`]),

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -670,8 +670,9 @@ export interface CombinedWorkerRow {
 
 export interface CombinedWorkerFeedOpts {
   /** Max worker rows rendered before the `+M more working…` spill line.
-   *  The overflow is ordered oldest-hidden-first (the newest/most-recently
-   *  active workers stay visible). */
+   *  Rows are kept head-first (`rows.slice(0, visibleCount)`): the earliest
+   *  supplied (oldest dispatch-order) workers stay visible and the
+   *  newest/trailing rows spill. */
   maxRows: number
 }
 
@@ -687,7 +688,7 @@ const MIN_WORKER_DEPTH = 3
 /**
  * Design fan-out: the largest concurrent-worker count whose full Ken curve is
  * allowed to render before the total-line backstop starts collapsing the
- * OLDEST rows into `+M more working…`. Chosen at 6 — beyond six live workers a
+ * NEWEST (trailing) rows into `+M more working…`. Chosen at 6 — beyond six live workers a
  * per-worker trail is no longer a glanceable card, so extra rows spill rather
  * than every shown worker losing depth. Every worker that IS shown keeps its
  * full curve depth; the ceiling trims row COUNT, never per-worker depth.
@@ -757,7 +758,7 @@ export const workerHistoryDepth = combinedHistoryDepth
  * Pure. Rows are rendered in the order supplied (the manager passes them
  * dispatch-order, oldest first). `maxRows` caps the visible rows; the hidden
  * remainder collapses to a single `+M more working…` line. A total-budget
- * backstop drops the OLDEST visible rows one at a time (growing the spill)
+ * backstop drops the NEWEST (trailing) visible rows one at a time (growing the spill)
  * until the body fits STATUS_CARD_CHAR_BUDGET, so a burst of long descriptions
  * can never overflow the wire limit. Returns null only when `rows` is empty.
  */

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -706,7 +706,7 @@ const DESIGN_FANOUT = 6
  * DESIGN_FANOUT of 6 fully-rendered workers needs 6 × 4 = 24 lines. That fully
  * fits every fan-out through 6 workers (w1=7, w2=12, w3=15, w4=16, w5=20,
  * w6=24); a 7th/8th concurrent worker overflows and the backstop drops the
- * oldest visible rows to the spill — bounding the card at 24 body lines so a
+ * newest (trailing) visible rows to the spill — bounding the card at 24 body lines so a
  * big swarm never explodes it. The per-worker curve wins on DEPTH; this ceiling
  * wins on ROW COUNT.
  */
@@ -825,8 +825,9 @@ export function renderCombinedWorkerFeed(
 
   // Cap to maxRows first, then shrink the visible set while EITHER the total
   // body-line budget (#3349: bounds a big swarm without stealing depth from the
-  // shown workers) OR the wire char budget is exceeded. Oldest rows collapse
-  // into the `+M more working…` spill.
+  // shown workers) OR the wire char budget is exceeded. Newest (trailing) rows
+  // collapse into the `+M more working…` spill (`rows.slice(0, visibleCount)`
+  // keeps the head of the list).
   let visible = Math.min(rows.length, maxRows)
   let { body, bodyLines } = compose(visible)
   while (

--- a/tests/inbound-router-characterization.test.ts
+++ b/tests/inbound-router-characterization.test.ts
@@ -48,6 +48,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { chatKey } from '../telegram-plugin/gateway/chat-key.js'
+import { inboundCoalesceKey } from '../telegram-plugin/gateway/inbound-coalesce.js'
 
 // ─── Fixtures / identity ────────────────────────────────────────────────
 const SENDER = '111'
@@ -147,7 +148,9 @@ beforeAll(async () => {
   // machine-authoritative deliver/buffer routing goes through the mocked
   // dispatchEffects instead; this fake only backstops the legacy callsites.
   gw.__inboundRouterTestSeam.setIpcServer({
-    sendToAgent: () => true,
+    // Logged so ORDER assertions can pin imperative-path deliveries (the
+    // `!`-interrupt body ships via this legacy callsite, not dispatchEffects).
+    sendToAgent: () => { callLog.push('ipcSend'); return true },
     broadcast: () => {},
   } as any)
 })
@@ -167,6 +170,13 @@ beforeEach(() => {
   gw.__inboundRouterTestSeam.activeStatusReactions.clear()
   gw.__inboundRouterTestSeam.activeTurnStartedAt.clear()
   gw.__inboundRouterTestSeam.vaultPassphraseCache.clear?.()
+  // Drain the coalesce window: an entry a prior test left buffered (e.g. the
+  // "stop with attachment" content path) holds a REAL setTimeout whose flush
+  // fires `void handleInbound(...)` — on a slow runner that deferred flush
+  // lands DURING a later test and appends a stray deliverToBridge/bufferInbound
+  // to dispatchCalls (the #3359 CI flake against the FAIL-CLOSED test).
+  // Cancelling the timers here makes every test start from an empty window.
+  gw.__inboundRouterTestSeam.inboundCoalescer.reset()
 })
 
 // ─── ctx factory ────────────────────────────────────────────────────────
@@ -283,10 +293,20 @@ describe('inbound-router characterization — interrupt / stop intercepts', () =
     // interrupt must not sit in the coalesce window.
     await gw.handleInboundCoalesced(makeCtx({ text: '!stop and do X', msgId: 3 }), '!stop and do X', undefined, undefined)
     expect(sendAgentInterrupt).toHaveBeenCalledTimes(1)
-    // ORDER: the SIGINT precedes any deliver-effect dispatch.
+    // ORDER: the SIGINT precedes the delivery of the replacement body.
+    // Characterization: today the interrupt body ships via the imperative
+    // ipcServer path (`ipcSend`), not a dispatchEffects deliver — so pin the
+    // SIGINT-before-ipcSend order UNCONDITIONALLY. The old
+    // `if (dispatchIdx >= 0)` guard was vacuously true (dispatch never fires
+    // here) and would have silently unpinned the ordering forever.
     const sigintIdx = callLog.indexOf('sigint')
-    const dispatchIdx = callLog.findIndex((t) => t.startsWith('dispatch:'))
+    const ipcSendIdx = callLog.indexOf('ipcSend')
     expect(sigintIdx).toBeGreaterThanOrEqual(0)
+    expect(ipcSendIdx).toBeGreaterThanOrEqual(0)
+    expect(sigintIdx).toBeLessThan(ipcSendIdx)
+    // And if a dispatchEffects deliver ever DOES appear on this path, it must
+    // still come after the SIGINT.
+    const dispatchIdx = callLog.findIndex((t) => t.startsWith('dispatch:'))
     if (dispatchIdx >= 0) expect(sigintIdx).toBeLessThan(dispatchIdx)
   })
 
@@ -302,6 +322,12 @@ describe('inbound-router characterization — interrupt / stop intercepts', () =
     await primeInFlightTurn()
     await gw.handleInboundCoalesced(makeCtx({ text: 'stop', msgId: 5 }), 'stop', dl, undefined)
     expect(sendAgentInterrupt).not.toHaveBeenCalled()
+    // Positive content-path assertion: the message PARKED in the coalesce
+    // window (it did not bypass, did not halt, and has not yet flushed).
+    // Its pending flush timer is cancelled by the next beforeEach — see the
+    // inboundCoalescer.reset() note there (#3359 flake).
+    const key = inboundCoalesceKey(String(DM_CHAT), undefined, SENDER)
+    expect(gw.__inboundRouterTestSeam.inboundCoalescer.peek(key as string)?.count).toBe(1)
   })
 })
 


### PR DESCRIPTION
## Flake root cause (run 29664734109, attempt 1, vitest-shard 2)

`FAIL-CLOSED: a pipeline throw drops the message` failed with `expect(delivered()).toBe(false)` receiving `true` at 4000ms, while passing locally and on re-run.

Root cause (verified against the attempt-1 job logs and real source):

- The **"bare `stop` with an attachment is CONTENT"** test calls `handleInboundCoalesced` with a download closure, which **parks the message in the real `inboundCoalescer`** (500ms sliding window, `gateway.ts` ~15290) and the test ends without draining it.
- The window's `setTimeout` flush fires `void handleInbound(...)` (`gateway.ts` ~8114) — a fire-and-forget async tail that crosses the test boundary.
- Under a test import the module-global `bot` is undefined, so every delete/reply path throws `Cannot read properties of undefined (reading 'api')` and burns ~1s in the retry/queue paths (visible as 1s-spaced `SECURITY: delete ... FAILED` lines in the attempt-1 log, including a late `message 5` delete — the coalesced attachment test's msgId — at 23:10:37, mid-way through the FAIL-CLOSED test).
- On the slow CI runner the deferred flush's `deliverToBridge` dispatch therefore landed **inside the FAIL-CLOSED test's window**, polluting `dispatchCalls` after `beforeEach` cleared it → `delivered()` true. Locally the flush lands harmlessly inside/between faster tests — hence the flake.

## Fix (deterministic, no sleeps/retries)

- `gateway.ts`: expose the module-local `inboundCoalescer` on `__inboundRouterTestSeam` (read/reset only — same F1 pattern as `setIpcServer`; no production behaviour change).
- Harness `beforeEach`: `inboundCoalescer.reset()` cancels stale flush timers so every test starts from an empty window.
- The attachment test now **positively asserts** the message parked in the window (`peek(...).count === 1`) — pinning the content path instead of only "no SIGINT".

## SIGINT-order assertion tightened (#3355 review finding)

The `if (dispatchIdx >= 0)` guard at ~line 290 was **vacuously true** — `dispatchEffects` never fires on the `!`-interrupt path (the body ships via the imperative `ipcServer.sendToAgent` callsite), so the ordering was never actually pinned. The fake ipcServer now logs `ipcSend` and SIGINT-before-ipcSend is asserted **unconditionally**; the dispatch-order check is kept as a belt-and-braces conditional.

## Doc-only fixes (#3359 review: spill direction misdocumented)

`renderCombinedWorkerFeed` keeps `rows.slice(0, visibleCount)` — the **head** of the list — and spills the **newest/trailing** rows into `+M more working…` (the existing test asserts w5 kept, w7 spilled). Corrected:
- `tool-activity-summary.ts` MAX_COMBINED_BODY_LINES doc ("drops the oldest visible rows" → newest/trailing)
- `tool-activity-summary.ts` shrink-loop comment ("Oldest rows collapse" → newest/trailing)
- `worker-feed-coalesce.test.ts` test title ("drops OLDEST rows" → NEWEST (trailing))

No behavior change anywhere outside the test harness seam.

## Stability evidence

- `tests/inbound-router-characterization.test.ts` run **20/20 green** in a loop (`failures: 0/20`).
- Touched test files green: 62/62 across the characterization harness + `worker-feed-coalesce.test.ts`.
- `npm run lint` clean (tsc + all 8 guard scripts, incl. the gateway line ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)