### PR TITLE
test(worker-feed): guard the #3373 onResume seam; extract handler from gateway (#3376 follow-up)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -913,7 +913,7 @@ import {
 import { findAgentProcessInContainer } from './boot-probes.js'
 import { applySubagentsSchema, getSubagentByJsonlId, resolveSubagentOriginTurnKey, listNonTerminalSubagentsForTurn } from '../registry/subagents-schema.js'
 import type { InterruptedSubagent } from './resume-inbound-builder.js'
-import { resolveWorkerFeedDispatch, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
+import { resolveWorkerFeedDispatch, handleWorkerResume, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
 import {
   resolveSubagentStatusSurface,
   isOrphanSubagentStatusEnabled,
@@ -25946,25 +25946,12 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                   `telegram gateway: worker ${agentId} card RESURRECTED — false terminal finish reversed, worker resumed (issue #3023)\n`,
                 )
               },
-              // Issue #3373 (SendMessage-resume feed re-surface). A worker with a
-              // GENUINE terminal completion that is resumed via SendMessage grows
-              // its jsonl past the terminal boundary and is re-registered live by
-              // the watcher (#3315). Clear the feed's terminal `finalized` latch so
-              // the resumed worker's next onProgress cue repaints a fresh live row
-              // (without this the latch swallows every resumed cue → the worker
-              // reads as silence). Distinct from onResurrect: no bounded-chain
-              // budget — a worker may be stopped/resumed any number of times.
+              // Issue #3373 (SendMessage-resume feed re-surface): clear the
+              // feed's terminal `finalized` latch so a resumed worker's cues
+              // repaint a live card. Body lives in worker-feed-dispatch.ts
+              // (handleWorkerResume, unit-tested there) — thin delegation only.
               onResume: (agentId, _description) => {
-                try {
-                  workerActivityFeed?.resurrect(agentId)
-                } catch (err) {
-                  process.stderr.write(
-                    `telegram gateway: worker resume feed re-surface error agent=${agentId}: ${(err as Error).message}\n`,
-                  )
-                }
-                process.stderr.write(
-                  `telegram gateway: worker ${agentId} card RE-SURFACED — resumed via SendMessage after a genuine terminal (issue #3373)\n`,
-                )
+                handleWorkerResume(workerActivityFeed, agentId, (m) => process.stderr.write(m + '\n'))
               },
               // Issue #3023 (bounded chain). A worker resurrected once and then
               // falsely finalised again is NOT resurrected forever — the

--- a/telegram-plugin/gateway/worker-feed-dispatch.ts
+++ b/telegram-plugin/gateway/worker-feed-dispatch.ts
@@ -1,5 +1,45 @@
 import type { Subagent } from '../registry/subagents-schema.js'
 
+/**
+ * The narrow slice of the worker-activity feed `handleWorkerResume` needs —
+ * structurally satisfied by `WorkerActivityFeed` (worker-activity-feed.ts)
+ * without importing it (keeps this module dependency-light and the seam
+ * trivially mockable in tests).
+ */
+export interface WorkerFeedForResume {
+  resurrect(agentId: string): void
+}
+
+/**
+ * Issue #3373 (SendMessage-resume feed re-surface) — the gateway's `onResume`
+ * handler body, extracted so the seam is unit-testable and gateway.ts keeps
+ * only a thin delegation (the line-ratchet drains inline bodies).
+ *
+ * A worker with a GENUINE terminal completion that is resumed via SendMessage
+ * grows its jsonl past the terminal boundary and is re-registered live by the
+ * watcher (#3315). This clears the feed's terminal `finalized` latch
+ * (`feed.resurrect`) so the resumed worker's next onProgress cue repaints a
+ * fresh live row — without it the latch swallows every resumed cue and the
+ * worker reads as silence. Distinct from the #3023 `onResurrect` path: no
+ * bounded-chain budget (a worker may be stopped/resumed any number of times).
+ *
+ * Best-effort: a resurrect failure is logged, never thrown back into the
+ * watcher's poll loop. `feed` may be null/undefined (feed disabled) — the
+ * re-surface log line is still emitted for the audit trail.
+ */
+export function handleWorkerResume(
+  feed: WorkerFeedForResume | null | undefined,
+  agentId: string,
+  log: (msg: string) => void,
+): void {
+  try {
+    feed?.resurrect(agentId)
+  } catch (err) {
+    log(`telegram gateway: worker resume feed re-surface error agent=${agentId}: ${(err as Error).message}`)
+  }
+  log(`telegram gateway: worker ${agentId} card RE-SURFACED — resumed via SendMessage after a genuine terminal (issue #3373)`)
+}
+
 export interface WorkerFeedDispatch {
   /** True when the sub-agent was dispatched with `run_in_background: true`. */
   isBackground: boolean

--- a/telegram-plugin/tests/worker-feed-resume-guard.test.ts
+++ b/telegram-plugin/tests/worker-feed-resume-guard.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Issue #3373 follow-up (PR #3376 adversarial review) — guards for the
+ * SendMessage-resume → feed re-surface seam.
+ *
+ * The #3376 fix has three links: the watcher fires `onResume` on jsonl growth
+ * past a genuine terminal (pinned by subagent-watcher-resume-reregister.test.ts),
+ * the gateway's `onResume` handler delegates to `handleWorkerResume`, and
+ * `handleWorkerResume` calls `feed.resurrect(agentId)` to clear the terminal
+ * `finalized` latch. The review found the middle + last links untested: deleting
+ * the gateway handler (or gutting its body) left every test green. This file
+ * closes both:
+ *
+ *   1. UNIT — `handleWorkerResume` calls `feed.resurrect` with the agentId,
+ *      never throws when resurrect throws or the feed is absent, and always
+ *      emits the re-surface audit line.
+ *   2. SOURCE SCAN (mirrors permission-verdict-resume-guard.test.ts) — the
+ *      gateway wires an `onResume:` callback into the watcher config AND that
+ *      callback delegates to `handleWorkerResume`. Deleting the handler, or
+ *      replacing the delegation with a no-op body, reds this suite.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { handleWorkerResume } from '../gateway/worker-feed-dispatch.js'
+
+describe('handleWorkerResume (issue #3373 seam unit)', () => {
+  it('calls feed.resurrect with the agentId and logs the re-surface line', () => {
+    const calls: string[] = []
+    const logs: string[] = []
+    handleWorkerResume({ resurrect: (id) => calls.push(id) }, 'w1', (m) => logs.push(m))
+    expect(calls).toEqual(['w1'])
+    expect(logs.some((l) => l.includes('w1') && l.includes('RE-SURFACED'))).toBe(true)
+  })
+
+  it('a throwing resurrect is logged, never propagated (watcher poll loop safety)', () => {
+    const logs: string[] = []
+    expect(() =>
+      handleWorkerResume(
+        { resurrect: () => { throw new Error('boom') } },
+        'w2',
+        (m) => logs.push(m),
+      ),
+    ).not.toThrow()
+    expect(logs.some((l) => l.includes('boom') && l.includes('w2'))).toBe(true)
+    // The audit line still lands after the failure.
+    expect(logs.some((l) => l.includes('RE-SURFACED'))).toBe(true)
+  })
+
+  it('a null/undefined feed (feed disabled) is a safe no-op that still audits', () => {
+    const logs: string[] = []
+    expect(() => handleWorkerResume(null, 'w3', (m) => logs.push(m))).not.toThrow()
+    expect(logs.some((l) => l.includes('w3') && l.includes('RE-SURFACED'))).toBe(true)
+  })
+})
+
+describe('gateway onResume wiring (issue #3373 source-scan guard)', () => {
+  const __dirname = dirname(fileURLToPath(import.meta.url))
+  const GATEWAY_SRC = readFileSync(
+    resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+    'utf8',
+  )
+
+  it('the watcher config carries an onResume callback', () => {
+    expect(/\bonResume:\s*\(/.test(GATEWAY_SRC)).toBe(true)
+  })
+
+  it('the onResume callback delegates to handleWorkerResume (not an inline no-op)', () => {
+    // Match the `onResume: (…) => { … }` callback body and require the
+    // delegation call inside it. A gutted handler (empty body / dropped
+    // resurrect) fails here even though tsc stays green.
+    const m = GATEWAY_SRC.match(/\bonResume:\s*\([^)]*\)\s*=>\s*\{([\s\S]*?)\n\s{14}\},/)
+    expect(m, 'onResume callback not found in gateway.ts').not.toBeNull()
+    expect(m![1]).toMatch(/\bhandleWorkerResume\s*\(/)
+    expect(m![1]).toMatch(/\bworkerActivityFeed\b/)
+  })
+
+  it('handleWorkerResume is imported from worker-feed-dispatch (the tested seam)', () => {
+    expect(
+      /import\s*\{[^}]*\bhandleWorkerResume\b[^}]*\}\s*from\s*'\.\/worker-feed-dispatch\.js'/.test(
+        GATEWAY_SRC,
+      ),
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
Follow-up to PR #3376 per adversarial review (all findings addressed):

1. **MEDIUM (real regression guard for the seam):** new `telegram-plugin/tests/worker-feed-resume-guard.test.ts` — unit tests on the extracted `handleWorkerResume` (calls `feed.resurrect(agentId)`; a throwing resurrect is logged, never propagated into the watcher poll loop; null/disabled feed is a safe no-op that still audits).
2. **LOW (gateway wiring coverage):** same file adds a `GATEWAY_SRC` source-scan (mirroring `permission-verdict-resume-guard.test.ts`) asserting the `onResume:` callback exists in the watcher config, its body delegates to `handleWorkerResume(workerActivityFeed, …)`, and the import comes from `worker-feed-dispatch.js`. Deleting or gutting the handler now reds CI.
3. **Ratchet hygiene:** the onResume handler body moved out of gateway.ts into `worker-feed-dispatch.ts` (`handleWorkerResume` + narrow `WorkerFeedForResume` interface); gateway keeps a 3-line thin delegation. Net gateway.ts shrink (26618 lines vs ratchet 26611, within slack).

Verification: 116 scoped tests pass (resume-reregister, worker-activity-feed, worker-feed-dispatch, new guard suite); `npm run lint` fully clean including gateway-line-ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)