### PR TITLE
refactor(gateway): inbound-router seam + routeInbound indirection (#2996 P7 PR-1)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -115,6 +115,7 @@ import {
   handlePaidMediaMessage,
   type MediaEnvelopeDeps,
 } from './media-message-handlers.js'
+import { routeInbound, type InboundRouterDeps } from './inbound-router.js'
 import {
   handleDocumentMessage,
   handleAudioMessage,
@@ -8023,7 +8024,7 @@ function looksLikeAuthCode(text: string): boolean {
 }
 
 // ─── Coalescing ───────────────────────────────────────────────────────────
-type AttachmentMeta = {
+export type AttachmentMeta = {
   kind: string
   file_id: string
   size?: number
@@ -24050,8 +24051,15 @@ bot.on('callback_query:data', async ctx => {
     },
   })
 })
+// Injected collaborators for the P7 inbound-routing seam (switchroom#2996 P7).
+// Bound once here so the coalesced entry points (message:text + the terminal
+// catch-all) delegate through the single `routeInbound` chokepoint. Live
+// references only — no value snapshots (see InboundRouterDeps).
+const inboundRouterDeps: InboundRouterDeps = {
+  handleInboundCoalesced,
+}
 bot.on('message:text', async ctx => {
-  await handleInboundCoalesced(ctx, ctx.message.text, undefined)
+  await routeInbound(ctx, ctx.message.text, undefined, undefined, inboundRouterDeps)
 })
 bot.on('message:photo', ctx => handlePhotoMessage(ctx, photoHandlerDeps))
 bot.on('message:document', ctx => handleDocumentMessage(ctx, attachmentHandlerDeps))
@@ -24223,7 +24231,7 @@ bot.on('message:checklist_tasks_added' as Parameters<typeof bot.on>[0], (ctx) =>
 bot.on('message:pinned_message', ctx => handlePinnedMessage(ctx, pinnedMessageHandlerDeps))
 installUnhandledMessageCatchAll(
   bot,
-  (ctx, text) => handleInboundCoalesced(ctx, text, undefined),
+  (ctx, text) => routeInbound(ctx, text, undefined, undefined, inboundRouterDeps),
   line => process.stderr.write(line),
 )
 bot.on('message_reaction' as Parameters<typeof bot.on>[0], (ctx) => {

--- a/telegram-plugin/gateway/inbound-router.ts
+++ b/telegram-plugin/gateway/inbound-router.ts
@@ -1,0 +1,48 @@
+/**
+ * Inbound routing seam (switchroom#2996 P7).
+ *
+ * `routeInbound` is the single entry point the gateway's coalesced inbound
+ * surfaces (`bot.on('message:text')` and the terminal
+ * `installUnhandledMessageCatchAll`) delegate through. TODAY it is a pure
+ * indirection: it forwards straight to the existing `handleInboundCoalesced`
+ * via an injected `InboundRouterDeps` — behaviour-identical, zero control-flow
+ * change. It exists so the later P7 stages can (a) move the intercept gauntlet
+ * into `inbound-interceptors.ts` behind this same Deps boundary and (b) put the
+ * eventual v2 consolidated control flow behind a deterministic kill switch at
+ * one chokepoint, mirroring the P6 `MediaEnvelopeDeps` injection idiom.
+ *
+ * The Deps object holds LIVE references to the gateway's collaborators (never
+ * value snapshots), bound once in gateway.ts alongside `mediaEnvelopeDeps`.
+ */
+
+import type { Context } from 'grammy'
+import type { AttachmentMeta } from './gateway.js'
+
+/**
+ * Collaborators `routeInbound` needs, injected from gateway.ts module scope so
+ * this module stays importable + unit-testable without gateway's boot side
+ * effects. Extended by later P7 stages as intercepts move across the boundary;
+ * every field is a live reference (function / Map / object), not a snapshot.
+ */
+export interface InboundRouterDeps {
+  handleInboundCoalesced: (
+    ctx: Context,
+    text: string,
+    downloadImage: (() => Promise<string | undefined>) | undefined,
+    attachment?: AttachmentMeta,
+  ) => Promise<void>
+}
+
+/**
+ * Route a coalesced inbound message. Pure indirection in P7 PR-1 — forwards to
+ * `deps.handleInboundCoalesced` unchanged.
+ */
+export async function routeInbound(
+  ctx: Context,
+  text: string,
+  downloadImage: (() => Promise<string | undefined>) | undefined,
+  attachment: AttachmentMeta | undefined,
+  deps: InboundRouterDeps,
+): Promise<void> {
+  return deps.handleInboundCoalesced(ctx, text, downloadImage, attachment)
+}

--- a/telegram-plugin/tests/catch-all-unhandled-message.test.ts
+++ b/telegram-plugin/tests/catch-all-unhandled-message.test.ts
@@ -256,9 +256,12 @@ describe('gateway.ts catch-all registration invariant', () => {
     expect(SRC.indexOf('installUnhandledMessageCatchAll(', installIdx + 1)).toBe(-1)
   })
 
-  it('routes the catch-all through handleInboundCoalesced (same gating + forward-origin path)', () => {
+  it('routes the catch-all through routeInbound → handleInboundCoalesced (same gating + forward-origin path)', () => {
+    // P7 PR-1: the catch-all now delegates through the single `routeInbound`
+    // seam, which forwards to `handleInboundCoalesced` unchanged (pure
+    // indirection). Anchor on the seam call the registration actually makes.
     const installIdx = SRC.indexOf('installUnhandledMessageCatchAll(')
     const body = SRC.slice(installIdx, installIdx + 400)
-    expect(body).toMatch(/handleInboundCoalesced\(ctx, text, undefined\)/)
+    expect(body).toMatch(/routeInbound\(ctx, text, undefined, undefined, inboundRouterDeps\)/)
   })
 })


### PR DESCRIPTION
## Summary
Introduces `telegram-plugin/gateway/inbound-router.ts` exporting `routeInbound` and the `InboundRouterDeps` interface. In P7 PR-1 `routeInbound` is a **pure indirection** — it forwards straight to the existing `handleInboundCoalesced` via injected deps. Behaviour-identical, zero control-flow change.

The two coalesced inbound entry points — `bot.on('message:text')` and the terminal `installUnhandledMessageCatchAll` — now delegate through the single `routeInbound` chokepoint, mirroring the P6 `MediaEnvelopeDeps` injection idiom. `inboundRouterDeps` is bound once at module scope with **live references** (no value snapshots). `AttachmentMeta` is exported so the router module types its delegation without pulling gateway boot side effects.

## Why
Establishes the extraction boundary the later P7 stages build on: the intercept gauntlet moves behind this Deps seam (PR-2..PR-9) and the eventual kill-switched v2 control flow branches at this one chokepoint (PR-11). Per the authoritative routing design (§2 PR-1).

## Test plan
- `tests/inbound-router-characterization.test.ts` — 18 cases green (the P7 parity oracle).
- `catch-all-unhandled-message` / `gateway-handler-registration-wiring` / `inbound-message-types` scrape tests green; catch-all source-scrape retargeted onto the new `routeInbound(...)` literal in the same PR.
- `npm run lint` clean: tsc + `check-bot-api-wrapping` + `check-gateway-line-ratchet` all pass (ratchet within slack, 26639 vs floor 26611 / slack 50).

## Risk
Low — pure indirection, no routing/ordering/timing change. Harness pins the observable effects.

Job: inbound message delivery (no-drop admission path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)