### PR TITLE
refactor(gateway): extract stop-keyword intercept to inbound-interceptors (#2996 P7 PR-2)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -116,6 +116,7 @@ import {
   type MediaEnvelopeDeps,
 } from './media-message-handlers.js'
 import { routeInbound, type InboundRouterDeps } from './inbound-router.js'
+import { interceptStopKeyword, type InboundInterceptorDeps } from './inbound-interceptors.js'
 import {
   handleDocumentMessage,
   handleAudioMessage,
@@ -15375,6 +15376,21 @@ function maybePokeFloorForMidTurnInbound(ctx: Context, from: NonNullable<Context
   silencePoke.pokeFloorNow(key, Date.now())
 }
 
+// Live collaborators for the extracted intercept gauntlet (switchroom#2996 P7).
+// Bound once; every field is a live reference (never a value snapshot). `botApi`
+// is a lazy accessor for `bot.api` (the grammY `bot` is assigned late on the
+// prod boot path) so the moved raw call keeps riding the same
+// `swallowingApiCall` retry wrapper it used inline, deref'd at call time.
+const inboundInterceptorDeps: InboundInterceptorDeps = {
+  pendingSessionCommand,
+  turnInFlightForGate,
+  sendReaction,
+  executeHaltNow,
+  swallowingApiCall,
+  botApi: () => bot.api,
+  log: line => process.stderr.write(line),
+}
+
 export async function handleInbound(
   ctx: Context,
   text: string,
@@ -15561,40 +15577,12 @@ export async function handleInbound(
   // Pure text only (7b): a photo/attachment captioned "stop" is content for
   // the agent, not a halt request — it must never trip the halt-and-drop
   // path (the caption + attachment flow through as a normal turn).
-  if (
-    parseStopKeyword(text) &&
-    downloadImage == null &&
-    attachment == null &&
-    (extraAttachments == null || extraAttachments.length === 0)
-  ) {
-    const queuedLabels = pendingSessionCommand.list().map(c => `/${c.kind} ${c.targetLabel}`)
-    const inFlight = turnInFlightForGate()
-    process.stderr.write(
-      `telegram gateway: stop-keyword received chat_id=${chat_id} in_flight_turn=${inFlight} ` +
-      `queued_cmds=${queuedLabels.length}\n`,
+  {
+    const stopOutcome = await interceptStopKeyword(
+      { text, chat_id, msgId, messageThreadId, downloadImage, attachment, extraAttachments },
+      inboundInterceptorDeps,
     )
-    if (inFlight) {
-      if (msgId != null) {
-        void sendReaction(chat_id, msgId, '⚡' as ReactionTypeEmoji['emoji']).catch(() => {})
-      }
-      await executeHaltNow('stop-keyword')
-    }
-    const stopReply = buildStopReply(inFlight, queuedLabels)
-    // #1075: thread-id-bearing — swallow so a deleted topic can't crash us.
-    await swallowingApiCall(
-      () =>
-        bot.api.sendMessage(
-          chat_id,
-          stopReply.text,
-          messageThreadId != null ? { message_thread_id: messageThreadId } : {},
-        ),
-      {
-        chat_id,
-        verb: 'stop-keyword-reply',
-        ...(messageThreadId != null ? { threadId: messageThreadId } : {}),
-      },
-    )
-    return
+    if (stopOutcome.handled) return
   }
 
   const interrupt = parseInterruptMarker(text)

--- a/telegram-plugin/gateway/inbound-interceptors.ts
+++ b/telegram-plugin/gateway/inbound-interceptors.ts
@@ -1,0 +1,131 @@
+/**
+ * Inbound intercept gauntlet (switchroom#2996 P7).
+ *
+ * The side-effecting early-return checks that sit at the head of
+ * `handleInbound`, extracted one-per-PR out of gateway.ts into pure,
+ * unit-testable functions that take (a) the per-message routing facts captured
+ * in `handleInbound` before the gauntlet and (b) an `InboundInterceptorDeps`
+ * object holding LIVE references to the gateway's collaborators (functions,
+ * Maps, the bound `bot.api` surface) — never value snapshots. Each returns an
+ * `InterceptOutcome`; when `handled` is true the caller must return immediately
+ * (the intercept has fully serviced the message and it is never forwarded).
+ *
+ * Ordering is load-bearing and preserved by the caller: the functions here fire
+ * in the same sequence they did inline. The characterization harness
+ * (tests/inbound-router-characterization.test.ts) is the parity oracle.
+ */
+
+import type { ReactionTypeEmoji } from 'grammy/types'
+import { parseStopKeyword, buildStopReply } from './stop-command.js'
+import type { RetryCallOpts } from '../retry-api-call.js'
+import type { AttachmentMeta } from './gateway.js'
+
+/**
+ * Result of an intercept. `handled: true` means the intercept fully serviced
+ * the message and the caller must `return` (never forward to the agent).
+ */
+export interface InterceptOutcome {
+  handled: boolean
+}
+
+/**
+ * Live collaborators injected from gateway.ts module scope. Grows as each P7
+ * stage moves an intercept across this boundary. Every field is a live
+ * reference (function / Map / object) — never a captured value snapshot.
+ *
+ * `botApi` is a LAZY accessor for the gateway's bound `bot.api` surface — the
+ * grammY `bot` is assigned late (only on the prod boot path), so the deref is
+ * deferred to call time. Injecting it as `deps.botApi().sendMessage(...)` also
+ * keeps the raw Telegram send a false-positive-free non-`bot.api.` literal that
+ * still rides the same `swallowingApiCall` retry wrapper it did inline.
+ */
+export interface InboundInterceptorDeps {
+  pendingSessionCommand: { list: () => Array<{ kind: string; targetLabel: string }> }
+  turnInFlightForGate: () => boolean
+  sendReaction: (
+    chatId: string,
+    messageId: number,
+    emoji: ReactionTypeEmoji['emoji'],
+  ) => Promise<unknown>
+  executeHaltNow: (origin: string) => Promise<void>
+  swallowingApiCall: <T>(fn: () => Promise<T>, opts?: RetryCallOpts) => Promise<T | undefined>
+  botApi: () => {
+    sendMessage: (
+      chatId: string,
+      text: string,
+      other?: { message_thread_id?: number },
+    ) => Promise<unknown>
+  }
+  log: (line: string) => void
+}
+
+/**
+ * Per-message routing facts captured in `handleInbound` before the gauntlet.
+ * `extraAttachments` is only length-inspected here, so it is typed structurally
+ * to avoid pulling gateway-local attachment types across the boundary.
+ */
+export interface StopKeywordParams {
+  text: string
+  chat_id: string
+  msgId: number | undefined
+  messageThreadId: number | undefined
+  downloadImage: (() => Promise<string | undefined>) | undefined
+  attachment: AttachmentMeta | undefined
+  extraAttachments: readonly unknown[] | undefined
+}
+
+/**
+ * #3020 — bare operator "stop": the kill switch without the `!` marker.
+ * Exact-word only (`parseStopKeyword`): "stop the build" flows to the agent as
+ * a normal turn. Intercepted here (never forwarded) so it fires mid-turn
+ * instead of queueing behind the very turn it's trying to cancel. Pure text
+ * only (7b): a photo/attachment captioned "stop" is content for the agent, not
+ * a halt request — it flows through as a normal turn.
+ *
+ * Authorization: the same allowFrom gate as any inbound (the caller's `gate()`
+ * runs before this) — unauthorized senders never reach here.
+ */
+export async function interceptStopKeyword(
+  p: StopKeywordParams,
+  deps: InboundInterceptorDeps,
+): Promise<InterceptOutcome> {
+  if (
+    !(
+      parseStopKeyword(p.text) &&
+      p.downloadImage == null &&
+      p.attachment == null &&
+      (p.extraAttachments == null || p.extraAttachments.length === 0)
+    )
+  ) {
+    return { handled: false }
+  }
+
+  const queuedLabels = deps.pendingSessionCommand.list().map(c => `/${c.kind} ${c.targetLabel}`)
+  const inFlight = deps.turnInFlightForGate()
+  deps.log(
+    `telegram gateway: stop-keyword received chat_id=${p.chat_id} in_flight_turn=${inFlight} ` +
+      `queued_cmds=${queuedLabels.length}\n`,
+  )
+  if (inFlight) {
+    if (p.msgId != null) {
+      void deps.sendReaction(p.chat_id, p.msgId, '⚡' as ReactionTypeEmoji['emoji']).catch(() => {})
+    }
+    await deps.executeHaltNow('stop-keyword')
+  }
+  const stopReply = buildStopReply(inFlight, queuedLabels)
+  // #1075: thread-id-bearing — swallow so a deleted topic can't crash us.
+  await deps.swallowingApiCall(
+    () =>
+      deps.botApi().sendMessage(
+        p.chat_id,
+        stopReply.text,
+        p.messageThreadId != null ? { message_thread_id: p.messageThreadId } : {},
+      ),
+    {
+      chat_id: p.chat_id,
+      verb: 'stop-keyword-reply',
+      ...(p.messageThreadId != null ? { threadId: p.messageThreadId } : {}),
+    },
+  )
+  return { handled: true }
+}

--- a/telegram-plugin/tests/stop-command.test.ts
+++ b/telegram-plugin/tests/stop-command.test.ts
@@ -17,6 +17,13 @@ import { switchroomHelpCommandNames, switchroomHelpText } from '../welcome-text.
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const GATEWAY_SRC = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf8')
+// P7 PR-2 (#2996): the handleInbound stop-keyword intercept block moved into
+// inbound-interceptors.ts (`interceptStopKeyword`). The coalescer bypass stays
+// in gateway.ts. Scrapes anchor on whichever file now owns each literal.
+const INTERCEPTORS_SRC = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'inbound-interceptors.ts'),
+  'utf8',
+)
 
 describe('parseStopKeyword', () => {
   it('matches the exact word stop, case-insensitively', () => {
@@ -177,14 +184,15 @@ describe('gateway wiring — /stop cancels the in-flight turn (#3020)', () => {
     expect(bypassIdx).toBeGreaterThan(0)
     const bypassWin = GATEWAY_SRC.slice(bypassIdx, bypassIdx + 800)
     expect(bypassWin).toContain('parseStopKeyword(text)')
-    // handleInbound keyword block: honest idle reply or halt + confirmation.
-    const kwIdx = GATEWAY_SRC.indexOf("executeHaltNow('stop-keyword')")
+    // interceptStopKeyword block (P7 PR-2, inbound-interceptors.ts): honest
+    // idle reply or halt + confirmation.
+    const kwIdx = INTERCEPTORS_SRC.indexOf("deps.executeHaltNow('stop-keyword')")
     expect(kwIdx).toBeGreaterThan(0)
-    const kwWin = GATEWAY_SRC.slice(kwIdx - 1600, kwIdx + 900)
-    expect(kwWin).toContain('turnInFlightForGate()')
+    const kwWin = INTERCEPTORS_SRC.slice(kwIdx - 1600, kwIdx + 900)
+    expect(kwWin).toContain('deps.turnInFlightForGate()')
     expect(kwWin).toContain('buildStopReply(inFlight, queuedLabels)')
     // Intercepted — never forwarded to the agent as a turn.
-    expect(kwWin).toContain('return')
+    expect(kwWin).toContain('return { handled: true }')
   })
 
   it('the empty-`!` interrupt routes through the same executeHaltNow helper', () => {
@@ -210,12 +218,13 @@ describe('gateway wiring — /stop cancels the in-flight turn (#3020)', () => {
       'parseStopKeyword(text) && downloadImage == null && attachment == null',
     )
     expect(bypassIdx).toBeGreaterThan(0)
-    // handleInbound keyword block: also excludes coalesced extra attachments.
-    const kwIdx = GATEWAY_SRC.indexOf("executeHaltNow('stop-keyword')")
-    const kwWin = GATEWAY_SRC.slice(kwIdx - 2400, kwIdx)
-    expect(kwWin).toContain('downloadImage == null')
-    expect(kwWin).toContain('attachment == null')
-    expect(kwWin).toContain('extraAttachments == null || extraAttachments.length === 0')
+    // interceptStopKeyword block (P7 PR-2): also excludes coalesced extra
+    // attachments (per-message facts arrive as the `p.` params object).
+    const kwIdx = INTERCEPTORS_SRC.indexOf("deps.executeHaltNow('stop-keyword')")
+    const kwWin = INTERCEPTORS_SRC.slice(kwIdx - 2400, kwIdx)
+    expect(kwWin).toContain('p.downloadImage == null')
+    expect(kwWin).toContain('p.attachment == null')
+    expect(kwWin).toContain('p.extraAttachments == null || p.extraAttachments.length === 0')
   })
 })
 


### PR DESCRIPTION
## Summary
Extracts the first intercept of the `handleInbound` gauntlet — the bare-"stop" halt — out of gateway.ts into a new `telegram-plugin/gateway/inbound-interceptors.ts` as `interceptStopKeyword(params, deps)`. Mechanical, behaviour-preserving move: same pure-text-only `parseStopKeyword` condition, same turn-in-flight gating, ⚡ reaction, `executeHaltNow('stop-keyword')`, and `buildStopReply` confirmation — now behind the `InboundInterceptorDeps` seam.

## Why
Second stage of the P7 inbound-routing extraction (routing design §2 PR-2). Each intercept moves one-per-PR behind the Deps boundary; the eventual kill-switched v2 chain (PR-11) assembles them.

## Design-faithful details
- **Deps hold live references, never snapshots.** `botApi` is a lazy `() => bot.api` accessor because the grammY `bot` is assigned late on the prod boot path — the moved raw send still rides the same `swallowingApiCall` retry wrapper it used inline. `deps.botApi().sendMessage` is a non-`bot.api.` literal, so `check-bot-api-wrapping` stays clean with no allowlist entry.
- Per-message routing facts (text / chat_id / msgId / messageThreadId / attachments) cross the boundary as a captured `params` value object.

## Test plan
- `tests/inbound-router-characterization.test.ts` — 18 cases green (parity oracle).
- `stop-command` (2 gateway-source scrapes retargeted onto the new interceptors-module owner; coalescer-bypass scrapes unchanged), `gateway-secret-detect`, `catch-all-unhandled-message`, `gateway-handler-registration-wiring`, `inbound-message-types` all green.
- `npm run lint` clean: tsc + plugin-references + bot-api-wrapping + gateway-line-ratchet (26614, within slack).

## Risk
Low — mechanical move, no ordering/timing change.

Job: inbound message delivery (no-drop admission path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)