### PR TITLE
refactor(gateway): extract interrupt-marker intercept (#2996 P7 PR-3)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -116,7 +116,11 @@ import {
   type MediaEnvelopeDeps,
 } from './media-message-handlers.js'
 import { routeInbound, type InboundRouterDeps } from './inbound-router.js'
-import { interceptStopKeyword, type InboundInterceptorDeps } from './inbound-interceptors.js'
+import {
+  interceptStopKeyword,
+  interceptInterruptMarker,
+  type InboundInterceptorDeps,
+} from './inbound-interceptors.js'
 import {
   handleDocumentMessage,
   handleAudioMessage,
@@ -15398,6 +15402,9 @@ const inboundInterceptorDeps: InboundInterceptorDeps = {
   swallowingApiCall,
   botApi: () => bot.api,
   log: line => process.stderr.write(line),
+  loadAccess,
+  toolFlightTracker,
+  cancelInterruptedObligation,
 }
 
 export async function handleInbound(
@@ -15596,84 +15603,21 @@ export async function handleInbound(
 
   const interrupt = parseInterruptMarker(text)
   // Problem B: defer this `!`'s SIGINT to a safe boundary instead of firing it
-  // synchronously below. Set only when the `interrupt.safe_boundary` flag is on
-  // AND a top-level tool call is in flight AND the body is non-empty (an empty
-  // `!` is a halt-now — routed through `executeHaltNow`, which honors the same
-  // safe-boundary deferral internally, #3020). When set, we skip the
-  // synchronous SIGINT here and stash the built inbound at the delivery site.
+  // synchronously. Extracted to interceptInterruptMarker (#2996 P7 PR-3);
+  // `deferInterrupt` comes back as an at-receipt captured VALUE the delivery
+  // site consumes (when true the synchronous SIGINT was skipped and the built
+  // inbound is stashed at the delivery site, #3020 semantics unchanged).
   let deferInterrupt = false
-  if (interrupt.isInterrupt) {
-    const agentName = process.env.SWITCHROOM_AGENT_NAME
-    const access = loadAccess()
-    deferInterrupt =
-      !interrupt.emptyBody &&
-      decideInterruptTiming({
-        safeBoundaryEnabled: resolveSafeBoundaryEnabled(access.interruptSafeBoundary),
-        midToolCall: toolFlightTracker.isMidToolCall(),
-      }) === 'defer'
-    process.stderr.write(
-      `telegram gateway: interrupt-marker received chat_id=${chat_id} agent=${agentName ?? '-'} ` +
-      `body_len=${interrupt.body.length} empty=${interrupt.emptyBody} defer=${deferInterrupt} ` +
-      `in_flight=${toolFlightTracker.inFlightCount()}\n`,
+  {
+    const interruptOutcome = await interceptInterruptMarker(
+      { interrupt, chat_id, msgId, messageThreadId },
+      inboundInterceptorDeps,
     )
-    if (msgId != null) {
-      void sendReaction(chat_id, msgId, '⚡' as ReactionTypeEmoji['emoji']).catch(() => {})
-    }
-    if (interrupt.emptyBody) {
-      // #3020: empty `!` is a pure halt (no replacement body) — same shared
-      // sequence as /stop: safe-boundary deferral, tmux C-c, obligation
-      // cancel, deterministic busy release.
-      await executeHaltNow('bang-empty')
-      // #1075: thread-id-bearing — route through swallowingApiCall so
-      // a deleted topic doesn't crash the gateway; the reaction
-      // already acked the user so a missing follow-up is tolerable.
-      await swallowingApiCall(
-        () =>
-          bot.api.sendMessage(
-            chat_id,
-            '⚡ Interrupted. Send your replacement instruction now.',
-            messageThreadId != null ? { message_thread_id: messageThreadId } : {},
-          ),
-        {
-          chat_id,
-          verb: 'interrupt-empty-body',
-          ...(messageThreadId != null ? { threadId: messageThreadId } : {}),
-        },
-      )
-      return
-    }
-    if (agentName && !deferInterrupt) {
-      try {
-        // The gateway runs INSIDE the agent container in docker mode,
-        // so calling `interruptAgent` (which probes `docker inspect`
-        // for the PID) always returns "no running PID" — the host's
-        // docker socket isn't visible to us. Skip the PID round-trip
-        // entirely and use tmux send-keys directly: the tmux socket
-        // is local to our container. Discovered during UAT overnight
-        // 2026-05-13 — pre-fix every `!` interrupt produced an
-        // "Agent has no running PID" stderr line and the user got
-        // ghosted because the SIGINT never fired.
-        const { sendAgentInterrupt } = await import('../../src/agents/tmux.js')
-        const r = sendAgentInterrupt({ agentName })
-        if ('ok' in r) {
-          process.stderr.write(
-            `telegram gateway: interrupt-marker SIGINT delivered via tmux send-keys agent=${agentName}\n`,
-          )
-        } else {
-          process.stderr.write(
-            `telegram gateway: interrupt-marker SIGINT via tmux failed agent=${agentName}: ${r.error}\n`,
-          )
-        }
-      } catch (err) {
-        process.stderr.write(`telegram gateway: interrupt-marker SIGINT failed: ${(err as Error).message}\n`)
-      }
-      // The SIGINT just killed the in-flight turn — cancel its obligation so the
-      // interrupted (user-redirected) question isn't re-presented/escalated later.
-      cancelInterruptedObligation()
-    }
-    // Replace the inbound text with the body and continue normal
+    if (interruptOutcome.handled) return
+    deferInterrupt = interruptOutcome.deferInterrupt
+    // Replace the inbound text with the `!` body and continue normal
     // processing. The agent receives a fresh turn with no `!` prefix.
-    text = interrupt.body
+    if (interruptOutcome.replacedText != null) text = interruptOutcome.replacedText
   }
 
   // Issue #109: when the user has to ask "status?" mid-turn, the live progress

--- a/telegram-plugin/gateway/inbound-interceptors.ts
+++ b/telegram-plugin/gateway/inbound-interceptors.ts
@@ -17,6 +17,8 @@
 
 import type { ReactionTypeEmoji } from 'grammy/types'
 import { parseStopKeyword, buildStopReply } from './stop-command.js'
+import { decideInterruptTiming, resolveSafeBoundaryEnabled } from './interrupt-defer.js'
+import type { parseInterruptMarker } from '../interrupt-marker.js'
 import type { RetryCallOpts } from '../retry-api-call.js'
 import type { AttachmentMeta } from './gateway.js'
 
@@ -57,6 +59,10 @@ export interface InboundInterceptorDeps {
     ) => Promise<unknown>
   }
   log: (line: string) => void
+  // --- interrupt-marker (P7 PR-3) collaborators ---
+  loadAccess: () => { interruptSafeBoundary?: boolean }
+  toolFlightTracker: { isMidToolCall: () => boolean; inFlightCount: () => number }
+  cancelInterruptedObligation: () => void
 }
 
 /**
@@ -128,4 +134,122 @@ export async function interceptStopKeyword(
     },
   )
   return { handled: true }
+}
+
+/** Per-message facts for the interrupt-marker intercept (P7 PR-3). */
+export interface InterruptMarkerParams {
+  /** The parse result — the caller keeps `parseInterruptMarker(text)` inline
+   * because `interrupt.isInterrupt` also feeds the downstream envelope/delivery
+   * path; the same value object crosses here so parse happens exactly once. */
+  interrupt: ReturnType<typeof parseInterruptMarker>
+  chat_id: string
+  msgId: number | undefined
+  messageThreadId: number | undefined
+}
+
+/**
+ * Outcome of the interrupt-marker intercept. `handled: true` — empty `!` fully
+ * serviced (halt fired + follow-up sent), caller returns. Otherwise the caller
+ * continues the pipeline with `replacedText` (the `!` body for an interrupt,
+ * the original text untouched for a non-interrupt) and `deferInterrupt` — an
+ * AT-RECEIPT captured VALUE the delivery site consumes (Problem B: when true,
+ * the synchronous SIGINT was skipped and the built inbound is stashed at the
+ * delivery site to fire at a safe boundary).
+ */
+export type InterruptMarkerOutcome =
+  | { handled: true }
+  | { handled: false; deferInterrupt: boolean; replacedText: string | null }
+
+/**
+ * `!`-prefix interrupt (#575): SIGINT the in-flight turn and replace the
+ * inbound with the marker body. Empty `!` is a pure halt (#3020) — same shared
+ * `executeHaltNow` sequence as /stop. Safe-boundary deferral (Problem B): a
+ * non-empty `!` mid-tool-call defers the SIGINT to the delivery site instead
+ * of firing synchronously.
+ *
+ * The tmux SIGINT keeps its dynamic `import('../../src/agents/tmux.js')`
+ * exactly as inline — the gateway runs INSIDE the agent container in docker
+ * mode, so `sendAgentInterrupt` (tmux send-keys, local socket) is used instead
+ * of the docker-inspect PID probe (UAT 2026-05-13 discovery).
+ */
+export async function interceptInterruptMarker(
+  p: InterruptMarkerParams,
+  deps: InboundInterceptorDeps,
+): Promise<InterruptMarkerOutcome> {
+  const { interrupt } = p
+  if (!interrupt.isInterrupt) {
+    return { handled: false, deferInterrupt: false, replacedText: null }
+  }
+
+  const agentName = process.env.SWITCHROOM_AGENT_NAME
+  const access = deps.loadAccess()
+  const deferInterrupt =
+    !interrupt.emptyBody &&
+    decideInterruptTiming({
+      safeBoundaryEnabled: resolveSafeBoundaryEnabled(access.interruptSafeBoundary),
+      midToolCall: deps.toolFlightTracker.isMidToolCall(),
+    }) === 'defer'
+  deps.log(
+    `telegram gateway: interrupt-marker received chat_id=${p.chat_id} agent=${agentName ?? '-'} ` +
+      `body_len=${interrupt.body.length} empty=${interrupt.emptyBody} defer=${deferInterrupt} ` +
+      `in_flight=${deps.toolFlightTracker.inFlightCount()}\n`,
+  )
+  if (p.msgId != null) {
+    void deps.sendReaction(p.chat_id, p.msgId, '⚡' as ReactionTypeEmoji['emoji']).catch(() => {})
+  }
+  if (interrupt.emptyBody) {
+    // #3020: empty `!` is a pure halt (no replacement body) — same shared
+    // sequence as /stop: safe-boundary deferral, tmux C-c, obligation
+    // cancel, deterministic busy release.
+    await deps.executeHaltNow('bang-empty')
+    // #1075: thread-id-bearing — route through swallowingApiCall so
+    // a deleted topic doesn't crash the gateway; the reaction
+    // already acked the user so a missing follow-up is tolerable.
+    await deps.swallowingApiCall(
+      () =>
+        deps.botApi().sendMessage(
+          p.chat_id,
+          '⚡ Interrupted. Send your replacement instruction now.',
+          p.messageThreadId != null ? { message_thread_id: p.messageThreadId } : {},
+        ),
+      {
+        chat_id: p.chat_id,
+        verb: 'interrupt-empty-body',
+        ...(p.messageThreadId != null ? { threadId: p.messageThreadId } : {}),
+      },
+    )
+    return { handled: true }
+  }
+  if (agentName && !deferInterrupt) {
+    try {
+      // The gateway runs INSIDE the agent container in docker mode,
+      // so calling `interruptAgent` (which probes `docker inspect`
+      // for the PID) always returns "no running PID" — the host's
+      // docker socket isn't visible to us. Skip the PID round-trip
+      // entirely and use tmux send-keys directly: the tmux socket
+      // is local to our container. Discovered during UAT overnight
+      // 2026-05-13 — pre-fix every `!` interrupt produced an
+      // "Agent has no running PID" stderr line and the user got
+      // ghosted because the SIGINT never fired.
+      const { sendAgentInterrupt } = await import('../../src/agents/tmux.js')
+      const r = sendAgentInterrupt({ agentName })
+      if ('ok' in r) {
+        deps.log(
+          `telegram gateway: interrupt-marker SIGINT delivered via tmux send-keys agent=${agentName}\n`,
+        )
+      } else {
+        deps.log(
+          `telegram gateway: interrupt-marker SIGINT via tmux failed agent=${agentName}: ${r.error}\n`,
+        )
+      }
+    } catch (err) {
+      deps.log(`telegram gateway: interrupt-marker SIGINT failed: ${(err as Error).message}\n`)
+    }
+    // The SIGINT just killed the in-flight turn — cancel its obligation so the
+    // interrupted (user-redirected) question isn't re-presented/escalated later.
+    deps.cancelInterruptedObligation()
+  }
+  // Replace the inbound text with the body and continue normal
+  // processing. The agent receives a fresh turn with no `!` prefix.
+  return { handled: false, deferInterrupt, replacedText: interrupt.body }
 }

--- a/telegram-plugin/tests/stop-command.test.ts
+++ b/telegram-plugin/tests/stop-command.test.ts
@@ -196,7 +196,8 @@ describe('gateway wiring — /stop cancels the in-flight turn (#3020)', () => {
   })
 
   it('the empty-`!` interrupt routes through the same executeHaltNow helper', () => {
-    expect(GATEWAY_SRC).toContain("executeHaltNow('bang-empty')")
+    // P7 PR-3: the `!`-marker intercept moved to inbound-interceptors.ts.
+    expect(INTERCEPTORS_SRC).toContain("deps.executeHaltNow('bang-empty')")
   })
 
   it('/stop with an argument warns and does NOT halt (old container-stop muscle memory)', () => {


### PR DESCRIPTION
## Summary
Extracts the `!`-prefix interrupt block (SIGINT / safe-boundary defer / empty-`!` halt-now) out of `handleInbound` into `inbound-interceptors.ts` as `interceptInterruptMarker(params, deps)`. Mechanical, behaviour-preserving move — third stage of the P7 extraction (routing design §2 PR-3).

## Design-faithful details
- Caller keeps `parseInterruptMarker(text)` inline (`interrupt.isInterrupt` feeds the downstream envelope/delivery path); the parse-result value crosses the boundary in params — parse happens exactly once.
- **F4 invariant honoured:** `deferInterrupt` returns as an at-receipt captured VALUE consumed by the delivery site — never a live Deps getter.
- The tmux `sendAgentInterrupt` dynamic import moves verbatim (resolves to the same module path, so the characterization harness's module mock still applies — verified green).
- Deps grow three live references: `loadAccess`, `toolFlightTracker`, `cancelInterruptedObligation`.
- Bang-empty source scrape in `stop-command.test.ts` retargeted onto the interceptors module in the same PR.

## Test plan
- Characterization harness 18/18 green (parity oracle; includes `!`-interrupt SIGINT + defer cases).
- `stop-command`, `interrupt-marker`, `inbound-delivery-gate`, `silent-end-interrupt-stop` scan+integration, `catch-all-unhandled-message`, `gateway-handler-registration-wiring`, `inbound-message-types` all green.
- `npm run lint` clean (tsc + plugin-references + bot-api-wrapping + ratchet; gateway.ts 26567 lines, below the 26611 main floor).

## Risk
Low — mechanical move, intercept ordering (stop-keyword → interrupt-marker) preserved.

Job: inbound message delivery (no-drop admission path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)