### PR TITLE
test(gateway): P8 PR-A turn-lifecycle characterization harness (#2996)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10421,7 +10421,12 @@ function sweepSuspendedTargets(): { keys: Set<string>; chats: Set<string> } {
   return { keys, chats }
 }
 
-const _deliveryConfirmSweep = isGatewayMain ? setInterval(() => {  // #2996 P0c gate
+// #2996 P0c/P8 PR-A: the sweep TICK body is a named function so it can be driven
+// by the turn-lifecycle characterization harness (idle-gate / card-suspension
+// pins) — the gateway still owns the `setInterval` (the P0c gate rule). PR-C1
+// moves this body into `delivery-confirm-wiring.ts`; keeping it named here is a
+// pure hoist, no behaviour change.
+function runDeliveryConfirmSweep(): void {
   if (!DELIVERY_CONFIRM_ENABLED) return
   // Re-deliver ONLY when claude is genuinely idle. `currentTurn` is set solely
   // by the enqueue session-event and nulled at turn-end, so `currentTurn != null`
@@ -10440,7 +10445,8 @@ const _deliveryConfirmSweep = isGatewayMain ? setInterval(() => {  // #2996 P0c 
     if (isRedeliverySuspended(p.key, suspended)) continue
     void redeliverStrandedInbound(p)
   }
-}, DELIVERY_CONFIRM_SWEEP_MS) : undefined
+}
+const _deliveryConfirmSweep = isGatewayMain ? setInterval(runDeliveryConfirmSweep, DELIVERY_CONFIRM_SWEEP_MS) : undefined
 _deliveryConfirmSweep?.unref?.()
 
 // #1445 cross-turn pending-async ambient. When a turn ends after the
@@ -15219,6 +15225,35 @@ export const __inboundRouterTestSeam = {
   // `reset()` (cancel stale timers) in beforeEach. Read/reset only — no
   // production behaviour change.
   inboundCoalescer,
+  // ── P8 PR-A: turn-lifecycle WIRING handles (the parity oracle for PR-E). ──
+  // The turn-end funnel + its idle stores + the two idle-only sweeps, exposed
+  // read/drive-only so `turn-lifecycle-characterization.test.ts` can pin the
+  // wiring (map purge, obligation close, buffer drain, no-reply timer arm,
+  // pending-restart drain at turn-complete) BEFORE any of it moves to
+  // `turn-end.ts` (PR-B) / the wiring modules (PR-C). No production behaviour
+  // change — these are the same identifiers the deps builders will inject.
+  // `setCurrentTurn` is the SANCTIONED keyed writer (PR-4e accessor), NOT a raw
+  // `currentTurn =` setter — the harness registers a live turn through it so
+  // the funnel's keyed-liveness guard sees it.
+  setCurrentTurn,
+  getCurrentTurn: (): CurrentTurn | null => currentTurn,
+  // Test-teardown reset of the live-turn store (the disconnect/bridge-died
+  // ghost-clear primitive; PR-E names it a `*-clear` no-op-effect reason). The
+  // harness calls it in beforeEach so a live turn a prior case left set can't
+  // leak into the next case's `currentTurn?.replyCalled` fallback read.
+  clearAllCurrentTurns,
+  endCurrentTurnAtomic,
+  purgeReactionTracking,
+  releaseTurnBufferGate,
+  armNoReplyDrainTimer,
+  statusKey,
+  obligationLedger,
+  pendingInboundBuffer,
+  pendingRestarts,
+  deliveryQueue,
+  runDeliveryConfirmSweep,
+  obligationSweep,
+  activeReactionMsgIds,
 }
 
 export async function handleInboundCoalesced(

--- a/tests/turn-lifecycle-characterization.test.ts
+++ b/tests/turn-lifecycle-characterization.test.ts
@@ -1,0 +1,335 @@
+/**
+ * P8 PR-A — Turn-lifecycle CHARACTERIZATION HARNESS (#2996 P8).
+ *
+ * The functional net for the turn-END funnel + the two idle-only sweeps, and
+ * the PARITY ORACLE for the eventual PR-E cutover (`endTurn(reason)` behind
+ * SWITCHROOM_TURN_END_FUNNEL_V2). Every P8 extraction PR (PR-B..PR-E) must keep
+ * this file green — a moved funnel edge that changes the shadow-event sequence,
+ * a dropped map purge, an un-closed obligation, a skipped buffer drain, or the
+ * lost pending-restart drain all fail here BEFORE they ship.
+ *
+ * HOW IT WORKS — the real funnel bodies execute (`endCurrentTurnAtomic`,
+ * `purgeReactionTracking`, `releaseTurnBufferGate`, `armNoReplyDrainTimer`) and
+ * we spy ONLY at the Deps boundary — the exact collaborators a later
+ * `TurnEndDeps` injects:
+ *   - inbound-delivery-machine-shadow.js → `shadowEmit` (L1, folded): the spy
+ *     records the `turnEnd` shadow-event SEQUENCE (kind/key/outboundEmitted) per
+ *     case. This IS the PR-E parity oracle — an assertion, not an aspiration.
+ *     `isMachineInTurn` stays the REAL (idle) machine; the turn-in-flight gate is
+ *     driven deterministically via the `pendingPermissions` leg instead.
+ *   - node:child_process → `spawn` (case 8 / M2): observes the queued
+ *     self-restart actually firing at turn-complete (legacy systemctl path).
+ *   - a fake `ipcServer` (seam-injected) whose `sendToAgent` records buffer
+ *     drains — the deliver-vs-hold oracle for the serialize gate.
+ *
+ * The turn atom is registered through the SANCTIONED keyed writer
+ * (`setCurrentTurn`), never a raw `currentTurn =` — so the funnel's
+ * keyed-liveness guard (`turnLiveForItsTopic`) sees the live turn and the PR-4e
+ * accessor guard is respected.
+ *
+ * F2 (P7, binds here) — `_ENABLED` / drain-window flags are module-level consts
+ * captured at import, so env is set BEFORE the dynamic import below. This file
+ * pins the default-ON behaviour (obligation ledger on, serialize-until-replied
+ * on); PR-E drives the funnel flag in a separate worker with its env pre-set.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// ─── Fixtures / identity ────────────────────────────────────────────────
+const SELF_AGENT = 'chartestagent'
+const DM_CHAT = '222'
+
+// ─── Env BEFORE import (F2: flags are const-captured at module load) ─────
+const stateDir = mkdtempSync(join(tmpdir(), 'turn-lifecycle-char-'))
+process.env.TELEGRAM_STATE_DIR = stateDir
+process.env.SWITCHROOM_AGENT_STATE_DIR = stateDir
+process.env.SWITCHROOM_AGENT_NAME = SELF_AGENT
+// Keep the bounded no-reply drain small so case 2 can advance fake timers to it
+// without a multi-second real wait. (Set here so the const capture picks it up.)
+process.env.SWITCHROOM_SERIALIZE_NOREPLY_DRAIN_MS = '2500'
+// NOT docker → triggerSelfRestart takes the legacy `spawn(systemctl …)` path,
+// which the child_process mock intercepts (case 8). A docker path would
+// `process.kill(1, 'SIGTERM')` — never do that in a test runner.
+delete process.env.SWITCHROOM_RUNTIME
+
+// ─── Deps-boundary spies ────────────────────────────────────────────────
+// The turnEnd shadow-event SEQUENCE oracle (L1). Each entry mirrors the exact
+// `shadowEmit({kind:'turnEnd', …})` payload the funnel emits.
+type ShadowEvent = { kind: string; key?: string; outboundEmitted?: boolean }
+const shadowEvents: ShadowEvent[] = []
+const turnEnds = () => shadowEvents.filter((e) => e.kind === 'turnEnd')
+
+vi.mock('../telegram-plugin/gateway/inbound-delivery-machine-shadow.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../telegram-plugin/gateway/inbound-delivery-machine-shadow.js')>()
+  return {
+    ...actual,
+    // Spy the emit at the boundary; the REAL machine (isMachineInTurn) is left
+    // untouched and idle — the in-flight gate is driven via pendingPermissions.
+    shadowEmit: (ev: ShadowEvent) => {
+      shadowEvents.push(ev)
+      return []
+    },
+  }
+})
+
+// spawn spy — the queued-self-restart observability point (M2 / case 8).
+const spawnSpy = vi.fn(() => ({ unref: () => {} }))
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  return { ...actual, spawn: spawnSpy }
+})
+
+// Fake ipcServer sendToAgent — the buffer-drain observability point.
+const ipcSends: unknown[] = []
+
+beforeAll(() => {
+  // Neutralize the fire-and-forget presentation egress the funnel tail attempts
+  // (status-pin reconcile, typing-loop stop). Swallowed in the gateway; the
+  // harness asserts WIRING, not presentation.
+  vi.stubGlobal('fetch', vi.fn(async () => new Response('{"ok":true,"result":{}}', { status: 200 })))
+})
+
+let gw: typeof import('../telegram-plugin/gateway/gateway.js')
+let seam: any
+
+beforeAll(async () => {
+  gw = await import('../telegram-plugin/gateway/gateway.js')
+  seam = gw.__inboundRouterTestSeam
+  seam.setIpcServer({
+    sendToAgent: (_agent: string, m: unknown) => {
+      ipcSends.push(m)
+      return true
+    },
+    broadcast: () => {},
+  } as any)
+})
+
+beforeEach(() => {
+  shadowEvents.length = 0
+  ipcSends.length = 0
+  spawnSpy.mockClear()
+  seam.clearAllCurrentTurns()
+  seam.activeStatusReactions.clear()
+  seam.activeTurnStartedAt.clear()
+  seam.activeReactionMsgIds.clear()
+  seam.pendingPermissions.clear?.()
+  seam.pendingRestarts.clear()
+  // Drain any buffered inbound a prior test left behind.
+  for (const m of seam.pendingInboundBuffer.drain(SELF_AGENT)) void m
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ─── Turn factory ───────────────────────────────────────────────────────
+// A cast CurrentTurn carrying exactly the fields the turn-end funnel reads
+// (status-surface log, emitTurnRecord, obligation close, timer clears, purge).
+// narrativeGate is optional-chained in the funnel, so it can stay undefined.
+let turnSeq = 0
+function makeTurn(over: Partial<any> = {}): any {
+  turnSeq += 1
+  return {
+    sessionChatId: DM_CHAT,
+    sessionThreadId: undefined,
+    sourceMessageId: null,
+    startedAt: Date.now() - 1000,
+    gatewayReceiveAt: Date.now() - 1000,
+    turnId: `t-${turnSeq}`,
+    replyCalled: false,
+    finalAnswerDelivered: false,
+    finalAnswerSubstantive: false,
+    finalAnswerEverDelivered: false,
+    answerDelivered: false,
+    endedAt: null,
+    firstPingAt: null,
+    firstPingWasSubstantive: false,
+    silentAnchorMessageId: null,
+    silentAnchorText: '',
+    capturedText: [],
+    capturedBlockMeta: [],
+    orphanedReplyTimeoutId: null,
+    answerReadyFlushTimeoutId: null,
+    noReplyDrainTimer: null,
+    registryKey: null,
+    lastAssistantMsgId: null,
+    lastAssistantDone: false,
+    toolCallCount: 0,
+    labeledToolCount: 0,
+    totalTokens: 0,
+    activityMessageId: null,
+    activityEverOpened: false,
+    activityDrainFailures: 0,
+    deliveryOutcome: undefined,
+    narrativeGate: undefined,
+    ...over,
+  }
+}
+
+function bufferedInbound(messageId: number): any {
+  return {
+    type: 'inbound',
+    chatId: DM_CHAT,
+    messageId,
+    user: 'T',
+    userId: 111,
+    ts: Date.now(),
+    text: `buffered ${messageId}`,
+    meta: {},
+  }
+}
+
+/** Register `turn` as the live turn for its topic (sanctioned keyed writer). */
+function goLive(turn: any): string {
+  const key = seam.statusKey(turn.sessionChatId, turn.sessionThreadId)
+  seam.setCurrentTurn(turn, key)
+  seam.activeStatusReactions.set(key, {})
+  seam.activeTurnStartedAt.set(key, Date.now())
+  return key
+}
+
+// ══════════════════════════════════════════════════════════════════════
+describe('turn-lifecycle characterization — funnel (endCurrentTurnAtomic)', () => {
+  it('case 1 — replied turn end: maps purged, obligation closed, buffer drained (turn-complete)', () => {
+    const turn = makeTurn({ replyCalled: true, finalAnswerDelivered: true })
+    const key = goLive(turn)
+    seam.obligationLedger.openIfAbsent({
+      originTurnId: turn.turnId, chatId: DM_CHAT, messageId: 1, text: 'q', openedAt: Date.now(),
+    })
+    seam.pendingInboundBuffer.push(SELF_AGENT, bufferedInbound(2))
+
+    seam.endCurrentTurnAtomic(turn)
+
+    // Maps purged.
+    expect(seam.activeStatusReactions.has(key)).toBe(false)
+    expect(seam.activeTurnStartedAt.has(key)).toBe(false)
+    // Obligation closed (delivered a final answer).
+    expect(seam.obligationLedger.isOpen(turn.turnId)).toBe(false)
+    // Buffer drained (final answer delivered → serialize gate opens).
+    expect(ipcSends.length).toBe(1)
+    // Shadow-event oracle: exactly one turnEnd, outboundEmitted from replyCalled.
+    expect(turnEnds()).toEqual([{ kind: 'turnEnd', key, at: expect.any(Number), outboundEmitted: true }])
+  })
+
+  it('case 2 — no-reply turn end: obligation stays open + grace; bounded drain timer arms and FIRES', () => {
+    vi.useFakeTimers()
+    const turn = makeTurn({ replyCalled: false, finalAnswerDelivered: false })
+    goLive(turn)
+    seam.obligationLedger.openIfAbsent({
+      originTurnId: turn.turnId, chatId: DM_CHAT, messageId: 1, text: 'q', openedAt: Date.now(),
+    })
+    seam.pendingInboundBuffer.push(SELF_AGENT, bufferedInbound(2))
+
+    seam.endCurrentTurnAtomic(turn)
+
+    // Obligation NOT closed — a reply-less turn stays open for re-present (grace
+    // clock stamped via noteTurnEnded).
+    expect(seam.obligationLedger.isOpen(turn.turnId)).toBe(true)
+    // Serialize gate held the drain (no final answer): nothing sent yet.
+    expect(ipcSends.length).toBe(0)
+    // The bounded no-reply escape hatch armed on the turn object.
+    expect(turn.noReplyDrainTimer).not.toBeNull()
+
+    // Advance to the bounded drain — the liveness guarantee fires.
+    vi.advanceTimersByTime(2500)
+    expect(ipcSends.length).toBe(1)
+  })
+
+  it('case 3 — wrong-turn end guard no-ops: a stale turn handle neither purges nor emits', () => {
+    // The halt path's wrong-turn guard: endCurrentTurnAtomic on a turn that is
+    // NOT the live turn for its topic returns null and touches nothing (the
+    // keyed-liveness guard, funnel-scoped manifestation of the halt no-op).
+    const live = makeTurn({ replyCalled: true, finalAnswerDelivered: true })
+    const key = goLive(live)
+    const stale = makeTurn({ turnId: 'stale', sessionChatId: DM_CHAT }) // same key, different object
+
+    const ret = seam.endCurrentTurnAtomic(stale)
+
+    expect(ret).toBeNull()
+    expect(turnEnds()).toEqual([]) // no shadow turnEnd for a non-live turn
+    expect(seam.activeStatusReactions.has(key)).toBe(true) // live turn's maps untouched
+    expect(seam.activeTurnStartedAt.has(key)).toBe(true)
+  })
+
+  it('case 8 (M2) — a queued self-restart FIRES at turn-complete via the purge tail', () => {
+    seam.pendingRestarts.set(SELF_AGENT, Date.now())
+    const turn = makeTurn({ replyCalled: true, finalAnswerDelivered: true })
+    goLive(turn)
+
+    seam.endCurrentTurnAtomic(turn)
+
+    // Drained at idle: the entry is consumed and the restart spawned.
+    expect(seam.pendingRestarts.size).toBe(0)
+    expect(spawnSpy).toHaveBeenCalledTimes(1)
+    expect(String(spawnSpy.mock.calls[0]?.[1])).toContain('systemctl')
+  })
+
+  it('case 8 (M2) — the queued restart DEFERS while a turn is in flight (gate busy)', () => {
+    // pendingPermissions makes turnInFlightForGate() true → the idle-only
+    // restart tail is skipped; the entry survives for the next idle boundary.
+    seam.pendingPermissions.set('k', { at: Date.now() } as any)
+    seam.pendingRestarts.set(SELF_AGENT, Date.now())
+    const turn = makeTurn({ replyCalled: true, finalAnswerDelivered: true })
+    goLive(turn)
+
+    seam.endCurrentTurnAtomic(turn)
+
+    expect(seam.pendingRestarts.size).toBe(1) // deferred, not drained
+    expect(spawnSpy).not.toHaveBeenCalled()
+    seam.pendingPermissions.clear?.()
+  })
+})
+
+describe('turn-lifecycle characterization — releaseTurnBufferGate (first reply)', () => {
+  it('case 7 — first-reply gate release deletes activeTurnStartedAt and drains', () => {
+    const turn = makeTurn({ replyCalled: true, finalAnswerDelivered: true })
+    const key = goLive(turn)
+    seam.pendingInboundBuffer.push(SELF_AGENT, bufferedInbound(2))
+
+    seam.releaseTurnBufferGate(key, turn)
+
+    expect(seam.activeTurnStartedAt.has(key)).toBe(false)
+    // Reaction controller stays (only the buffer gate flips — #1718 contract).
+    expect(seam.activeStatusReactions.has(key)).toBe(true)
+    expect(ipcSends.length).toBe(1)
+    expect(turnEnds()).toEqual([{ kind: 'turnEnd', key, at: expect.any(Number), outboundEmitted: true }])
+  })
+})
+
+describe('turn-lifecycle characterization — fallback purge (silence-poke framework fallback)', () => {
+  it('case 6 — fallback purge (no ending turn) clears the maps and emits a turnEnd', () => {
+    const key = seam.statusKey(DM_CHAT, undefined)
+    seam.activeStatusReactions.set(key, {})
+    seam.activeTurnStartedAt.set(key, Date.now())
+
+    // The silence-poke framework fallback calls purgeReactionTracking(fbKey)
+    // WITHOUT an ending-turn handle — the abnormal turn-end shape.
+    seam.purgeReactionTracking(key)
+
+    expect(seam.activeStatusReactions.has(key)).toBe(false)
+    expect(seam.activeTurnStartedAt.has(key)).toBe(false)
+    // outboundEmitted falls back to currentTurn?.replyCalled (null → false).
+    expect(turnEnds()).toEqual([{ kind: 'turnEnd', key, at: expect.any(Number), outboundEmitted: false }])
+  })
+})
+
+describe('turn-lifecycle characterization — idle-only sweeps (P0c gate: tick body only)', () => {
+  it('case 4 — delivery-confirm sweep is a no-op mid-turn (currentTurn != null)', () => {
+    const turn = makeTurn({ replyCalled: true, finalAnswerDelivered: true })
+    goLive(turn) // currentTurn != null → the idle gate suppresses redelivery
+    expect(() => seam.runDeliveryConfirmSweep()).not.toThrow()
+    // Nothing re-delivered while a turn is live (the documented mid-turn wedge
+    // guard, gateway.ts delivery-sweep idle gate).
+    expect(ipcSends.length).toBe(0)
+  })
+
+  it('case 5 — obligation sweep is idle-only and safe to tick with no open obligations', () => {
+    // No live turn (idle) and an empty ledger → the sweep runs its idle path
+    // without re-presenting anything (grace windows / never-storm invariant).
+    expect(() => seam.obligationSweep()).not.toThrow()
+    expect(ipcSends.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
Adds `tests/turn-lifecycle-characterization.test.ts` — the functional net for the turn-**END** funnel + the two idle-only sweeps, and the **parity oracle** for the eventual PR-E cutover (`endTurn(reason)` behind `SWITCHROOM_TURN_END_FUNNEL_V2`). First stage of #2996 **P8** (turn-lifecycle core extraction).

## Why
P8 moves the turn-end funnel (`endCurrentTurnAtomic` / `purgeReactionTracking` / `releaseTurnBufferGate` / drain family) and four background sweeps out of `gateway.ts`. Post-#3316 there is no live gate-parity probe, so a WIRING characterization harness is the only mechanism that pins v1 == v2 behaviour across the moves. Every later P8 PR (PR-B..PR-E) must keep this file green.

Real funnel bodies execute; spies sit **only at the Deps boundary**:
- `shadowEmit` — the `turnEnd` shadow-event **sequence** oracle (amendment L1).
- `spawn` — observes the queued self-restart firing at turn-complete (amendment M2, case 8).
- a fake `ipcServer.sendToAgent` — the buffer-drain deliver-vs-hold oracle.

Cases 1-8 per design §2 PR-A, including **M2 case 8** (pending-restart drain fires at turn-complete via the purge tail, defers while the gate is busy).

## Test plan
- New harness 9/9 green.
- `npm run lint` fully clean (tsc + all guards; `gateway.ts` 26602 < ratchet 26611; bot-api clean).
- `per-topic-current-turn.test.ts` (bun, PR-4e guard) 19/19 — seam exposes no raw `currentTurn` setter.
- `gateway-boot-side-effect-gating.test.ts` 5/5 (delivery-sweep P0c anchor holds after the tick-body hoist).
- `inbound-router-characterization.test.ts` (shares the widened seam) green.

## Risk
No production behaviour change. `gateway.ts` diff = widen `__inboundRouterTestSeam` with funnel/sweep/store handles (`getCurrentTurn` / `clearAllCurrentTurns` via sanctioned keyed accessors) + hoist the delivery-confirm sweep tick body to a named `runDeliveryConfirmSweep` (gateway still owns the `setInterval`). Call graph unchanged.

Job spec: `reference/jobs/on-the-leash.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)