### PR TITLE
refactor(gateway): extract reauth paste-back intercept (#2996 P7 PR-7)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -122,6 +122,7 @@ import {
   interceptPermissionReply,
   interceptAuthAdd,
   interceptLoopbackRelay,
+  interceptReauth,
   type InboundInterceptorDeps,
 } from './inbound-interceptors.js'
 import {
@@ -15425,6 +15426,12 @@ const inboundInterceptorDeps: InboundInterceptorDeps = {
     redactAuthCodeMessage(redactAuthCodeApi as never, chatId, redactMsgId, line =>
       process.stderr.write(line),
     ),
+  pendingReauthFlows,
+  execAuthCode,
+  renderAuthCodeOutcome: outcome => renderAuthCodeOutcome(outcome as AuthCodeOutcome | null),
+  preBlock,
+  formatSwitchroomOutput,
+  formatAuthOutputForTelegram,
 }
 
 export async function handleInbound(
@@ -15744,34 +15751,16 @@ export async function handleInbound(
     if (loopbackOutcome.handled) return
   }
 
-  // Auth-code intercept
-  const pendingReauth = pendingReauthFlows.get(interceptKey)
-  if (pendingReauth && looksLikeAuthCode(text)) {
-    const elapsed = Date.now() - pendingReauth.startedAt
-    if (elapsed < REAUTH_INTERCEPT_TTL_MS) {
-      pendingReauthFlows.delete(interceptKey)
-      const { result, errorText } = execAuthCode(pendingReauth.agent, text.trim())
-      if (errorText) {
-        await switchroomReply(ctx, `**auth code failed:**\n${preBlock(formatSwitchroomOutput(errorText))}`, { html: true })
-      } else if (result) {
-        const outcomeMsg = renderAuthCodeOutcome(result.outcome)
-        if (outcomeMsg) {
-          await switchroomReply(ctx, outcomeMsg, { html: true })
-        } else {
-          // success or no structured outcome — fall back to formatted text
-          const output = result.instructions.join('\n')
-          const formatted = formatAuthOutputForTelegram(output)
-          await switchroomReply(ctx, formatted.text, { html: true })
-        }
-      }
-      // Redact the OAuth code paste from chat history (#488).
-      // Single-use code so a third party can't replay it after exchange,
-      // but plaintext OAuth tokens in chat history are still poor
-      // hygiene. The helper handles delete + 🔑 reaction silently.
-      redactAuthCodeMessage(redactAuthCodeApi as never, chat_id, msgId ?? null, line => process.stderr.write(line))
-      return
-    }
-    pendingReauthFlows.delete(interceptKey)
+  // Auth-code (reauth) intercept — moved to interceptReauth (#2996 P7 PR-7).
+  // Structural anchor for gateway-loopback-paste-redact.test.ts ordering:
+  // const pendingReauth = pendingReauthFlows.get(interceptKey) now lives in
+  // the interceptor; the delegation below preserves its position.
+  {
+    const reauthOutcome = await interceptReauth(
+      { ctx, text, chat_id, msgId, interceptKey },
+      inboundInterceptorDeps,
+    )
+    if (reauthOutcome.handled) return
   }
 
   // Vault intercept

--- a/telegram-plugin/gateway/inbound-interceptors.ts
+++ b/telegram-plugin/gateway/inbound-interceptors.ts
@@ -104,6 +104,21 @@ export interface InboundInterceptorDeps {
   escapeHtmlForTg: (text: string) => string
   /** Closure over redactAuthCodeMessage + the gateway's redactAuthCodeApi (#488). */
   redactAuthCode: (chatId: string, msgId: number | null) => void
+  // --- reauth paste-back (P7 PR-7) collaborators ---
+  pendingReauthFlows: {
+    get: (key: string) => { agent: string; startedAt: number } | undefined
+    delete: (key: string) => boolean
+  }
+  execAuthCode: (
+    agent: string,
+    code: string,
+  ) =>
+    | { result: { outcome: unknown; instructions: string[] }; errorText: null }
+    | { result: null; errorText: string }
+  renderAuthCodeOutcome: (outcome: unknown) => string | null
+  preBlock: (text: string) => string
+  formatSwitchroomOutput: (output: string) => string
+  formatAuthOutputForTelegram: (output: string) => { text: string; url: string | null }
 }
 
 /**
@@ -530,5 +545,51 @@ export async function interceptLoopbackRelay(
     )
     return { handled: true }
   }
+  return { handled: false }
+}
+
+/**
+ * /reauth OAuth-code paste-back intercept — the elder sibling of auth-add
+ * (mutates an existing agent's slot via `switchroom auth code`, vs /auth add
+ * which creates fresh credentials at the broker). Runs AFTER auth-add /
+ * loopback (load-bearing order). Same chatKey-scoped isolation + TTL window;
+ * the code paste is redacted from history either way (#488). A stale entry is
+ * dropped and the message falls through (`handled: false`).
+ */
+export async function interceptReauth(
+  p: AuthAddParams,
+  deps: InboundInterceptorDeps,
+): Promise<InterceptOutcome> {
+  const pendingReauth = deps.pendingReauthFlows.get(p.interceptKey)
+  if (!(pendingReauth && deps.looksLikeAuthCode(p.text))) return { handled: false }
+  const elapsed = Date.now() - pendingReauth.startedAt
+  if (elapsed < deps.reauthInterceptTtlMs) {
+    deps.pendingReauthFlows.delete(p.interceptKey)
+    const { result, errorText } = deps.execAuthCode(pendingReauth.agent, p.text.trim())
+    if (errorText) {
+      await deps.switchroomReply(
+        p.ctx,
+        `**auth code failed:**\n${deps.preBlock(deps.formatSwitchroomOutput(errorText))}`,
+        { html: true },
+      )
+    } else if (result) {
+      const outcomeMsg = deps.renderAuthCodeOutcome(result.outcome)
+      if (outcomeMsg) {
+        await deps.switchroomReply(p.ctx, outcomeMsg, { html: true })
+      } else {
+        // success or no structured outcome — fall back to formatted text
+        const output = result.instructions.join('\n')
+        const formatted = deps.formatAuthOutputForTelegram(output)
+        await deps.switchroomReply(p.ctx, formatted.text, { html: true })
+      }
+    }
+    // Redact the OAuth code paste from chat history (#488).
+    // Single-use code so a third party can't replay it after exchange,
+    // but plaintext OAuth tokens in chat history are still poor
+    // hygiene. The helper handles delete + 🔑 reaction silently.
+    deps.redactAuthCode(p.chat_id, p.msgId ?? null)
+    return { handled: true }
+  }
+  deps.pendingReauthFlows.delete(p.interceptKey)
   return { handled: false }
 }

--- a/telegram-plugin/tests/gateway-loopback-paste-redact.test.ts
+++ b/telegram-plugin/tests/gateway-loopback-paste-redact.test.ts
@@ -72,7 +72,9 @@ describe('gateway loopback-paste fail-safe redaction — structural wiring', () 
     expect(failSafeIdx).toBeGreaterThan(pendingLoopIdx)
 
     const loopbackCallIdx = gatewaySrc.indexOf('interceptLoopbackRelay(')
-    const reauthIdx = gatewaySrc.indexOf('const pendingReauth = pendingReauthFlows.get')
+    // P7 PR-7: the reauth intercept body also moved; its gateway call site is
+    // the ordering anchor.
+    const reauthIdx = gatewaySrc.indexOf('interceptReauth(')
     expect(loopbackCallIdx).toBeGreaterThan(-1)
     expect(reauthIdx).toBeGreaterThan(loopbackCallIdx)
   })

--- a/telegram-plugin/tests/secret-detect-oauth-code.test.ts
+++ b/telegram-plugin/tests/secret-detect-oauth-code.test.ts
@@ -191,8 +191,12 @@ describe('anthropic_oauth_code pattern — URL false-positive regression', () =>
 // Test 2: Blocker 1 sequencing — structural check that deleteMessage is called
 // inside the pendingReauthFlows intercept path, before setMessageReaction.
 describe('pendingReauthFlows intercept — deleteMessage sequencing (Blocker 1)', () => {
+  // P7 PR-7 (#2996): the reauth intercept body moved verbatim into
+  // gateway/inbound-interceptors.ts (interceptReauth); the redaction is the
+  // injected deps.redactAuthCode closure over redactAuthCodeMessage +
+  // redactAuthCodeApi (bound in gateway.ts). Same pins, new file owner.
   const src = readFileSync(
-    new URL('../gateway/gateway.ts', import.meta.url),
+    new URL('../gateway/inbound-interceptors.ts', import.meta.url),
     'utf8',
   )
 
@@ -202,7 +206,7 @@ describe('pendingReauthFlows intercept — deleteMessage sequencing (Blocker 1)'
     // `setMessageReaction(...)` literals, but #488 consolidated all 6
     // auth-code paste paths through `redactAuthCodeMessage`. The pin
     // is now: the intercept block must call the helper.
-    const interceptIdx = src.indexOf('// Auth-code intercept')
+    const interceptIdx = src.indexOf('export async function interceptReauth(')
     expect(interceptIdx).toBeGreaterThan(0)
 
     // Find the end of this intercept block — the next blank line after
@@ -215,7 +219,7 @@ describe('pendingReauthFlows intercept — deleteMessage sequencing (Blocker 1)'
     // (optionally cast, #623), now the gated `redactAuthCodeApi` adapter whose
     // reaction routes through the send gate + flood breaker (#3155). `msgId`
     // may be narrowed (`msgId ?? null`).
-    expect(window).toMatch(/redactAuthCodeMessage\((?:bot\.api|redactAuthCodeApi)(?:\s+as\s+\w+)?,\s*chat_id,\s*msgId(?:\s*\?\?\s*null)?(?:,\s*[^)]+)?\)/)
+    expect(window).toMatch(/deps\.redactAuthCode\(p\.chat_id,\s*p\.msgId(?:\s*\?\?\s*null)?\)/)
   })
 
   it('redaction lands AFTER the success/error reply renders', () => {
@@ -224,10 +228,10 @@ describe('pendingReauthFlows intercept — deleteMessage sequencing (Blocker 1)'
     // even if their original message disappears mid-render. Same
     // ordering the helper preserves — fire-and-forget redaction
     // happens after `await switchroomReply(...)`.
-    const interceptIdx = src.indexOf('// Auth-code intercept')
+    const interceptIdx = src.indexOf('export async function interceptReauth(')
     const window = src.slice(interceptIdx, interceptIdx + 2000)
-    const replyIdx = window.indexOf('switchroomReply(ctx,')
-    const redactIdx = window.indexOf('redactAuthCodeMessage(')
+    const replyIdx = window.indexOf('deps.switchroomReply(')
+    const redactIdx = window.indexOf('deps.redactAuthCode(')
     expect(replyIdx).toBeGreaterThan(0)
     expect(redactIdx).toBeGreaterThan(0)
     expect(replyIdx).toBeLessThan(redactIdx)


### PR DESCRIPTION
## Summary
Extracts the `/reauth` OAuth-code paste-back intercept out of `handleInbound` into `inbound-interceptors.ts` as `interceptReauth(params, deps)`. Mechanical, behaviour-preserving — seventh stage of the P7 extraction (routing design §2 PR-7).

## Details
- Same chatKey-scoped TTL window, `switchroom auth code` exec tri-path (error / structured outcome / formatted fallback), #488 redaction with the reply-before-redact sequencing preserved, stale-entry fall-through.
- Deps grow: `pendingReauthFlows` (live sweepable-store ref), `execAuthCode`, `renderAuthCodeOutcome` (outcome crosses as `unknown`; gateway binds the cast), `preBlock`, `formatSwitchroomOutput`, `formatAuthOutputForTelegram`.
- Structural pins retargeted in the same PR: `secret-detect-oauth-code.test.ts` (redaction-inside-intercept + sequencing) and `gateway-loopback-paste-redact.test.ts` (loopback-before-reauth ordering anchor).

## Test plan
- Characterization harness 18/18.
- `secret-detect-oauth-code`, `gateway-loopback-paste-redact`, `inbound-emit-after-intercepts`, `auth-code-redact`, `auth-code-auto-capture`, `callback-query-handlers`, `pending-state-stores`, `welcome-text`, `stop-command` — all green.
- `npm run lint` clean (gateway.ts 26445, ratchet within slack).

## Risk
Low — mechanical move; the load-bearing auth-add → loopback → reauth ordering is preserved.

Job: inbound message delivery (no-drop admission path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)