### PR TITLE
feat(gateway): kill-switched endTurn(reason) turn-end dispatcher (#2996 P8 PR-E)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -716,7 +716,7 @@ import { chatKey, chatKeyWithSuffix, chatIdOfChatKey } from './chat-key.js'
 // carve-outs at the handleInbound delivery site).
 import { shadowEmit, isMachineInTurn } from './inbound-delivery-machine-shadow.js'
 // #2996 P8 PR-B — the extracted turn-end funnel (state stays here; logic moved).
-import { createTurnEndFunnel } from './turn-end.js'
+import { createTurnEndFunnel, type TurnEndReason } from './turn-end.js'
 // #2996 P8 PR-C1 — the extracted delivery-confirm sweep wiring.
 import { createDeliveryConfirmWiring } from './delivery-confirm-wiring.js'
 // #2996 P8 PR-C2 — the extracted obligation wiring.
@@ -3062,7 +3062,10 @@ function resolveModelEffortBusy(now = Date.now()): { currentTurnActive: boolean;
     // the only live turn, and a stale atom is a ghost (its `turn_end` never
     // fired) — clearing every entry is equivalent to clearing it, matching the
     // bridge-died "every entry is a ghost" semantics.
-    clearAllCurrentTurns()
+    // PR-E (M1): under the v2 funnel this is the named 'phantom-ttl-clear'
+    // reason — atom-clear ONLY (no purge / obligation close / drain).
+    if (TURN_END_FUNNEL_V2) turnEndFunnel().endTurn('phantom-ttl-clear')
+    else clearAllCurrentTurns()
   }
   return { currentTurnActive: resolved.currentTurnActive, turnInFlight: resolved.turnInFlight }
 }
@@ -4759,6 +4762,7 @@ function gatewayTurnEndDeps() {
     turnInFlightForGate,
     turnLiveForItsTopic,
     endCurrentTurnForKey,
+    clearAllCurrentTurns,
     statusKey,
     reapQueuedStatus,
     stopTurnTypingLoop,
@@ -4794,6 +4798,13 @@ export type TurnEndDeps = ReturnType<typeof gatewayTurnEndDeps>
 // real turn end everything is assigned). Function-declaration wrappers (never
 // reassigned bindings) so by-name captures (stream-render deps, the
 // deferredDoneReactions purge arrow) resolve at call time, as before.
+// PR-E (#2996 P8) — deterministic kill switch for the endTurn(reason)
+// consolidation. Default OFF during bake: the wrappers below run the PR-B code
+// paths verbatim. =1 routes every wrapper (and the two ghost-clear callsites)
+// through the single `endTurn` dispatcher — same code, one auditable entry
+// point. Module-load const: flipping requires an agent restart (P7 F2).
+const TURN_END_FUNNEL_V2 = process.env.SWITCHROOM_TURN_END_FUNNEL_V2 === '1'  // default OFF during bake
+
 let _turnEndFunnel: ReturnType<typeof createTurnEndFunnel> | undefined
 function turnEndFunnel(): ReturnType<typeof createTurnEndFunnel> {
   return (_turnEndFunnel ??= createTurnEndFunnel(gatewayTurnEndDeps()))
@@ -4812,10 +4823,12 @@ function armNoReplyDrainTimer(turn: CurrentTurn): void {
 }
 
 function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
+  if (TURN_END_FUNNEL_V2) { turnEndFunnel().endTurn('fallback-purge', { key, endingTurn }); return }
   turnEndFunnel().purgeReactionTracking(key, endingTurn)
 }
 
 function releaseTurnBufferGate(key: string, endingTurn?: CurrentTurn): void {
+  if (TURN_END_FUNNEL_V2) { turnEndFunnel().endTurn('reply-gate-release', { key, endingTurn }); return }
   turnEndFunnel().releaseTurnBufferGate(key, endingTurn)
 }
 
@@ -4823,6 +4836,7 @@ function endCurrentTurnAtomic(
   turn: CurrentTurn,
   opts?: { deferRecord?: boolean; deferObligationClose?: boolean },
 ): number | null {
+  if (TURN_END_FUNNEL_V2) return turnEndFunnel().endTurn('turn-end', { turn, opts }) ?? null
   return turnEndFunnel().endCurrentTurnAtomic(turn, opts)
 }
 
@@ -10614,7 +10628,10 @@ if (isGatewayMain) ipcServer = createIpcServer({
           // PR-4e — the bridge DIED with a turn in flight: EVERY per-topic entry
           // is a ghost, not just the mirror's. Clear the whole map + mirror.
           // Flag-OFF: this nulls the singleton only (the map is empty), verbatim.
-          clearAllCurrentTurns()
+          // PR-E (M1): under the v2 funnel this is the named 'bridge-died-clear'
+          // reason — atom-clear ONLY (no purge / obligation close / drain).
+          if (TURN_END_FUNNEL_V2) turnEndFunnel().endTurn('bridge-died-clear')
+          else clearAllCurrentTurns()
         }
       },
       log: (msg) => process.stderr.write(`${msg}\n`),
@@ -14302,6 +14319,14 @@ export const __inboundRouterTestSeam = {
   purgeReactionTracking,
   releaseTurnBufferGate,
   armNoReplyDrainTimer,
+  // PR-E: the v2 dispatcher (always constructible; production callsites route
+  // through it only under SWITCHROOM_TURN_END_FUNNEL_V2=1) + the captured flag,
+  // so the harness can pin ghost-clear no-op effects and drive both branches.
+  endTurn: (
+    reason: TurnEndReason,
+    args?: { turn?: CurrentTurn; opts?: { deferRecord?: boolean; deferObligationClose?: boolean }; key?: string; endingTurn?: CurrentTurn },
+  ) => turnEndFunnel().endTurn(reason, args),
+  TURN_END_FUNNEL_V2,
   statusKey,
   obligationLedger,
   pendingInboundBuffer,

--- a/telegram-plugin/gateway/turn-end.ts
+++ b/telegram-plugin/gateway/turn-end.ts
@@ -46,6 +46,7 @@ export function createTurnEndFunnel(deps: TurnEndDeps) {
     turnInFlightForGate,
     turnLiveForItsTopic,
     endCurrentTurnForKey,
+    clearAllCurrentTurns,
     statusKey,
     reapQueuedStatus,
     stopTurnTypingLoop,
@@ -536,6 +537,55 @@ function endCurrentTurnAtomic(
   return turnEndedAt
 }
 
+  /**
+   * PR-E (#2996 P8, amendment M1) — the single auditable turn-end entry point,
+   * reached by production callsites ONLY when SWITCHROOM_TURN_END_FUNNEL_V2=1
+   * (the gateway wrappers gate on the flag; default OFF runs the PR-B paths
+   * verbatim). Dispatches to the EXACT legacy shape per reason — goal:
+   * byte-identical effects, verified by the PR-A shadowEmit sequence oracle
+   * run under both flag settings.
+   *
+   * FIVE end shapes (M1), not three:
+   *   1. 'turn-end'           — the canonical funnel (endCurrentTurnAtomic).
+   *   2. 'fallback-purge'     — purge without/with a turn handle (disconnect
+   *                             flush, silence-poke framework fallback).
+   *   3. 'reply-gate-release' — first-reply buffer-gate release (executeReply).
+   *   4. 'phantom-ttl-clear'  — the /model|/effort busy-check hard-TTL clear.
+   *   5. 'bridge-died-clear'  — the onDanglingTurnsSwept disconnect clear.
+   * Shapes 4-5 are GHOST-clears: the turns are dead (a stale atom / a dead
+   * bridge), so their effect set is EXACTLY the atom clear and nothing else —
+   * no purge, no obligation close, no drain, no shadow turnEnd. Routing them
+   * through the full funnel would close obligations and drain buffers against
+   * a dead bridge.
+   */
+  function endTurn(
+    reason: TurnEndReason,
+    args: {
+      turn?: CurrentTurn
+      opts?: { deferRecord?: boolean; deferObligationClose?: boolean }
+      key?: string
+      endingTurn?: CurrentTurn
+    } = {},
+  ): number | null | undefined {
+    switch (reason) {
+      case 'turn-end':
+        return endCurrentTurnAtomic(args.turn as CurrentTurn, args.opts)
+      case 'fallback-purge':
+        purgeReactionTracking(args.key as string, args.endingTurn)
+        return undefined
+      case 'reply-gate-release':
+        releaseTurnBufferGate(args.key as string, args.endingTurn)
+        return undefined
+      case 'phantom-ttl-clear':
+      case 'bridge-died-clear':
+        // M1 — atom-clear ONLY. See the docblock above; harness case 9 pins
+        // that a ghost-clear emits NO shadow turnEnd, closes NO obligation,
+        // drains NO buffer.
+        clearAllCurrentTurns()
+        return undefined
+    }
+  }
+
   return {
     performBufferDrain,
     drainBufferedIfAllowed,
@@ -543,5 +593,14 @@ function endCurrentTurnAtomic(
     purgeReactionTracking,
     releaseTurnBufferGate,
     endCurrentTurnAtomic,
+    endTurn,
   }
 }
+
+/** PR-E — the five named end shapes (amendment M1). */
+export type TurnEndReason =
+  | 'turn-end'
+  | 'fallback-purge'
+  | 'reply-gate-release'
+  | 'phantom-ttl-clear'
+  | 'bridge-died-clear'

--- a/tests/turn-lifecycle-characterization-v2.test.ts
+++ b/tests/turn-lifecycle-characterization-v2.test.ts
@@ -1,0 +1,12 @@
+/**
+ * P8 PR-E — the SAME turn-lifecycle characterization harness with
+ * SWITCHROOM_TURN_END_FUNNEL_V2=1 (the endTurn(reason) dispatcher branch).
+ *
+ * Env flags are module-load consts (P7 F2), so the flag must be set BEFORE the
+ * gateway import — hence a separate vitest worker file whose only job is to
+ * pre-set the env and then load the base harness. Every case (1-9) must pass
+ * IDENTICALLY under both flag settings: the shadowEmit turnEnd-sequence spy in
+ * the base harness is the parity oracle (design §2 PR-E — v1 == v2 effects).
+ */
+process.env.SWITCHROOM_TURN_END_FUNNEL_V2 = '1'
+await import('./turn-lifecycle-characterization.test.js')

--- a/tests/turn-lifecycle-characterization.test.ts
+++ b/tests/turn-lifecycle-characterization.test.ts
@@ -316,6 +316,33 @@ describe('turn-lifecycle characterization — fallback purge (silence-poke frame
   })
 })
 
+describe('turn-lifecycle characterization — PR-E ghost-clears (M1: atom-clear ONLY)', () => {
+  for (const reason of ['phantom-ttl-clear', 'bridge-died-clear'] as const) {
+    it(`case 9 — '${reason}' clears the turn atom and does NOTHING else (no shadow turnEnd, no obligation close, no drain)`, () => {
+      const turn = makeTurn({ replyCalled: true, finalAnswerDelivered: true })
+      const key = goLive(turn)
+      seam.obligationLedger.openIfAbsent({
+        originTurnId: turn.turnId, chatId: DM_CHAT, messageId: 1, text: 'q', openedAt: Date.now(),
+      })
+      seam.pendingInboundBuffer.push(SELF_AGENT, bufferedInbound(2))
+
+      seam.endTurn(reason)
+
+      // The atom is cleared…
+      expect(seam.getCurrentTurn()).toBeNull()
+      // …and NOTHING else happened: the ghost-clear must not run the funnel.
+      expect(turnEnds()).toEqual([])                                // no shadow turnEnd
+      expect(seam.obligationLedger.isOpen(turn.turnId)).toBe(true)  // no obligation close
+      expect(ipcSends.length).toBe(0)                               // no drain
+      expect(seam.activeStatusReactions.has(key)).toBe(true)        // no map purge
+      expect(seam.activeTurnStartedAt.has(key)).toBe(true)
+      // Clean up for the next case.
+      seam.pendingInboundBuffer.drain(SELF_AGENT)
+      seam.obligationLedger.close(turn.turnId)
+    })
+  }
+})
+
 describe('turn-lifecycle characterization — idle-only sweeps (P0c gate: tick body only)', () => {
   it('case 4 — delivery-confirm sweep is a no-op mid-turn (currentTurn != null)', () => {
     const turn = makeTurn({ replyCalled: true, finalAnswerDelivered: true })


### PR DESCRIPTION
## Summary
The one behavioural stage of P8: `endTurn(reason, args)` in `turn-end.ts` as the single auditable turn-end entry point, behind `SWITCHROOM_TURN_END_FUNNEL_V2` (**default OFF** — module-load const, flip requires agent restart). Final P8 stage after PR-C3 (#3392).

## Why
Auditability + a seam for P9 machine-modelled turn end. Per design amendment **M1** there are FIVE end shapes, not three: `'turn-end'` (canonical funnel), `'fallback-purge'` (disconnect-flush / silence-poke fallback), `'reply-gate-release'` (executeReply), plus two **ghost-clears** — `'phantom-ttl-clear'` (the `/model|/effort` busy-check hard-TTL clear) and `'bridge-died-clear'` (`onDanglingTurnsSwept`). The ghost-clear effect set is **exactly the atom clear** — no purge, no obligation close, no drain, no shadow `turnEnd` — because those turns are ghosts; running the funnel would close obligations and drain buffers against a dead bridge.

- Flag OFF (default): PR-B code paths verbatim — zero behaviour change shipped today.
- Flag ON: the same code reached through the dispatcher (goal: byte-identical effects).

## Test plan / parity oracle
- **Harness case 9** (new): each ghost-clear reason clears the atom and does NOTHING else (asserted: no shadow `turnEnd`, obligation stays open, no drain, maps untouched).
- **`tests/turn-lifecycle-characterization-v2.test.ts`** (new): re-runs the ENTIRE PR-A harness in a separate vitest worker with the flag pre-set (P7 F2 — env is const-captured at import). All cases pass identically under both branches; the shadowEmit `turnEnd`-sequence spy is the v1 == v2 oracle. CI runs both workers on every PR from here on.
- `no-reply-bounded-drain`, `buffer-gate-broadened`, `per-topic-current-turn` (bun, raw-write guard) green; `npm run lint` fully clean.

## Bake plan (#2794 cadence)
Canary on test-harness with `=1` → run `jtbd-fast-trivial-dm` (12 s HARD_TTFO_MS), `inbound-no-drop`, `jtbd-interrupted-turn-resumes-dm` → default-flip (`!== '0'`) → ~1 week bake → delete the legacy branch. Rollback at any point = `=0` + agent restart (no model involvement). uat-gate self-checked before merge (not ruleset-required).

## Risk
Default-OFF ship: the only code executed in production today is the PR-B path plus one flag check per wrapper call. The dispatcher branch is fully covered by the duplicated harness worker.

Job spec: `reference/jobs/on-the-leash.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)