### PR TITLE
feat(gateway): kill-switched v2 inbound intercept chain (#2996 P7 PR-11)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -120,6 +120,9 @@ import {
   admitInbound,
   buildReplyForwardContext,
   buildInboundEnvelope,
+  INBOUND_ROUTER_V2,
+  runPreTurnIntercepts,
+  runPasteBackIntercepts,
   type InboundRouterDeps,
   type InboundAdmissionDeps,
 } from './inbound-router.js'
@@ -14758,31 +14761,54 @@ export async function handleInbound(
   // Pure text only (7b): a photo/attachment captioned "stop" is content for
   // the agent, not a halt request — it must never trip the halt-and-drop
   // path (the caption + attachment flow through as a normal turn).
-  {
-    const stopOutcome = await interceptStopKeyword(
-      { text, chat_id, msgId, messageThreadId, downloadImage, attachment, extraAttachments },
-      inboundInterceptorDeps,
-    )
-    if (stopOutcome.handled) return
-  }
-
-  const interrupt = parseInterruptMarker(text)
   // Problem B: defer this `!`'s SIGINT to a safe boundary instead of firing it
   // synchronously. Extracted to interceptInterruptMarker (#2996 P7 PR-3);
   // `deferInterrupt` comes back as an at-receipt captured VALUE the delivery
   // site consumes (when true the synchronous SIGINT was skipped and the built
   // inbound is stashed at the delivery site, #3020 semantics unchanged).
+  // `interrupt` is parsed from the ORIGINAL text on both arms (isInterrupt
+  // feeds the downstream envelope/delivery path).
+  let interrupt: ReturnType<typeof parseInterruptMarker>
   let deferInterrupt = false
-  {
-    const interruptOutcome = await interceptInterruptMarker(
-      { interrupt, chat_id, msgId, messageThreadId },
+  if (INBOUND_ROUTER_V2) {
+    // v2 (#2996 P7 PR-11): consolidated pre-turn chain — stop-keyword then
+    // interrupt-marker, ordering owned by runPreTurnIntercepts. Same
+    // intercept functions as the legacy arm; the characterization harness +
+    // inbound-router-v2-chain.test.ts pin parity.
+    interrupt = parseInterruptMarker(text)
+    const pre = await runPreTurnIntercepts(
+      {
+        stop: { text, chat_id, msgId, messageThreadId, downloadImage, attachment, extraAttachments },
+        interrupt: { interrupt, chat_id, msgId, messageThreadId },
+      },
       inboundInterceptorDeps,
     )
-    if (interruptOutcome.handled) return
-    deferInterrupt = interruptOutcome.deferInterrupt
+    if (pre.handled) return
+    deferInterrupt = pre.deferInterrupt
     // Replace the inbound text with the `!` body and continue normal
     // processing. The agent receives a fresh turn with no `!` prefix.
-    if (interruptOutcome.replacedText != null) text = interruptOutcome.replacedText
+    if (pre.replacedText != null) text = pre.replacedText
+  } else {
+    {
+      const stopOutcome = await interceptStopKeyword(
+        { text, chat_id, msgId, messageThreadId, downloadImage, attachment, extraAttachments },
+        inboundInterceptorDeps,
+      )
+      if (stopOutcome.handled) return
+    }
+
+    interrupt = parseInterruptMarker(text)
+    {
+      const interruptOutcome = await interceptInterruptMarker(
+        { interrupt, chat_id, msgId, messageThreadId },
+        inboundInterceptorDeps,
+      )
+      if (interruptOutcome.handled) return
+      deferInterrupt = interruptOutcome.deferInterrupt
+      // Replace the inbound text with the `!` body and continue normal
+      // processing. The agent receives a fresh turn with no `!` prefix.
+      if (interruptOutcome.replacedText != null) text = interruptOutcome.replacedText
+    }
   }
 
   // Issue #109: when the user has to ask "status?" mid-turn, the live progress
@@ -14841,80 +14867,96 @@ export async function handleInbound(
     }
   }
 
-  // Permission-reply intercept (moved to interceptPermissionReply, #2996 P7
-  // PR-4; PERMISSION_REPLY_RE lives in inbound-interceptors.ts now).
-  {
-    const permOutcome = interceptPermissionReply({ text, chat_id, msgId }, inboundInterceptorDeps)
-    if (permOutcome.handled) return
-  }
-
-  // `/auth add` paste-back intercept — sibling to pendingReauthFlows.
-  // Both intercepts are deliberate so the LLM never sees the OAuth
-  // code (it doesn't need to + plaintext OAuth in chat history is bad
-  // hygiene). The add-flow intercept comes first because /auth add
-  // creates fresh credentials at the broker layer, vs /reauth which
-  // mutates an existing agent's slot — different success paths.
-  //
-  // PR3 supergroup-mode: keyed by chatKey(chat, thread) so an OAuth
-  // code pasted into topic A isn't intercepted when topic B has a
-  // separate /auth add flow pending (security: prevents cross-topic
-  // credential mis-attribution).
+  // PR3 supergroup-mode: keyed by chatKey(chat, thread) so an OAuth code
+  // pasted into topic A isn't intercepted when topic B has a separate flow
+  // pending (security: prevents cross-topic credential mis-attribution).
   const interceptKey = chatKey(chat_id, messageThreadId) as string
-  // (moved to interceptAuthAdd, #2996 P7 PR-5; the anchor literal
-  // pendingAuthAddFlows.get(interceptKey) lives inside the delegation now)
-  {
-    const authAddOutcome = await interceptAuthAdd(
+
+  if (INBOUND_ROUTER_V2) {
+    // v2 (#2996 P7 PR-11): consolidated reply/paste-back chain — permission
+    // → auth-add → loopback (incl. #3084 fail-safe) → reauth → vault →
+    // secret-staging, ordering owned by runPasteBackIntercepts. Same
+    // intercept functions as the legacy arm below.
+    const pasteBackOutcome = await runPasteBackIntercepts(
       { ctx, text, chat_id, msgId, interceptKey },
       inboundInterceptorDeps,
     )
-    if (authAddOutcome.handled) return
-  }
+    if (pasteBackOutcome.handled) return
+  } else {
+    // Permission-reply intercept (moved to interceptPermissionReply, #2996 P7
+    // PR-4; PERMISSION_REPLY_RE lives in inbound-interceptors.ts now).
+    {
+      const permOutcome = interceptPermissionReply({ text, chat_id, msgId }, inboundInterceptorDeps)
+      if (permOutcome.handled) return
+    }
 
-  // Loopback OAuth relay paste-back intercept (issue #2582) — sibling to
-  // the /auth add intercept above. When a Google/Microsoft loopback relay is
-  // pending for this chat and the operator pastes their `127.0.0.1:<port>`
-  // redirect URL, validate `state` and hand the code to the waiting CLI
-  // listener. The LLM never sees the code (same hygiene rationale as above).
-  // Consume-gate is deliberately narrow (PR #3100 review finding 1): only a
-  // message that actually parses as a loopback redirect — carrying a code,
-  // or a provider `error` param — is consumed and deleted. Unrelated chatter
-  // that merely mentions localhost/127.0.0.1 flows through untouched.
-  // (moved to interceptLoopbackRelay incl. the #3084 fail-safe redaction tail,
-  // #2996 P7 PR-6)
-  {
-    const loopbackOutcome = await interceptLoopbackRelay(
-      { ctx, text, chat_id, msgId, interceptKey },
-      inboundInterceptorDeps,
-    )
-    if (loopbackOutcome.handled) return
-  }
+    // `/auth add` paste-back intercept — sibling to pendingReauthFlows.
+    // Both intercepts are deliberate so the LLM never sees the OAuth
+    // code (it doesn't need to + plaintext OAuth in chat history is bad
+    // hygiene). The add-flow intercept comes first because /auth add
+    // creates fresh credentials at the broker layer, vs /reauth which
+    // mutates an existing agent's slot — different success paths.
+    //
+    // PR3 supergroup-mode: keyed by chatKey(chat, thread) so an OAuth
+    // code pasted into topic A isn't intercepted when topic B has a
+    // separate /auth add flow pending (security: prevents cross-topic
+    // credential mis-attribution).
+    // (moved to interceptAuthAdd, #2996 P7 PR-5; the anchor literal
+    // pendingAuthAddFlows.get(interceptKey) lives inside the delegation now)
+    {
+      const authAddOutcome = await interceptAuthAdd(
+        { ctx, text, chat_id, msgId, interceptKey },
+        inboundInterceptorDeps,
+      )
+      if (authAddOutcome.handled) return
+    }
 
-  // Auth-code (reauth) intercept — moved to interceptReauth (#2996 P7 PR-7).
-  // Structural anchor for gateway-loopback-paste-redact.test.ts ordering:
-  // const pendingReauth = pendingReauthFlows.get(interceptKey) now lives in
-  // the interceptor; the delegation below preserves its position.
-  {
-    const reauthOutcome = await interceptReauth(
-      { ctx, text, chat_id, msgId, interceptKey },
-      inboundInterceptorDeps,
-    )
-    if (reauthOutcome.handled) return
-  }
+    // Loopback OAuth relay paste-back intercept (issue #2582) — sibling to
+    // the /auth add intercept above. When a Google/Microsoft loopback relay is
+    // pending for this chat and the operator pastes their `127.0.0.1:<port>`
+    // redirect URL, validate `state` and hand the code to the waiting CLI
+    // listener. The LLM never sees the code (same hygiene rationale as above).
+    // Consume-gate is deliberately narrow (PR #3100 review finding 1): only a
+    // message that actually parses as a loopback redirect — carrying a code,
+    // or a provider `error` param — is consumed and deleted. Unrelated chatter
+    // that merely mentions localhost/127.0.0.1 flows through untouched.
+    // (moved to interceptLoopbackRelay incl. the #3084 fail-safe redaction tail,
+    // #2996 P7 PR-6)
+    {
+      const loopbackOutcome = await interceptLoopbackRelay(
+        { ctx, text, chat_id, msgId, interceptKey },
+        inboundInterceptorDeps,
+      )
+      if (loopbackOutcome.handled) return
+    }
 
-  // Vault intercept — moved to interceptVault (#2996 P7 PR-8).
-  {
-    const vaultOutcome = await interceptVault({ ctx, text, chat_id, msgId }, inboundInterceptorDeps)
-    if (vaultOutcome.handled) return
-  }
+    // Auth-code (reauth) intercept — moved to interceptReauth (#2996 P7 PR-7).
+    // Structural anchor for gateway-loopback-paste-redact.test.ts ordering:
+    // const pendingReauth = pendingReauthFlows.get(interceptKey) now lives in
+    // the interceptor; the delegation below preserves its position.
+    {
+      const reauthOutcome = await interceptReauth(
+        { ctx, text, chat_id, msgId, interceptKey },
+        inboundInterceptorDeps,
+      )
+      if (reauthOutcome.handled) return
+    }
 
-  // Secret-detect follow-up command intercept — moved to
-  // interceptSecretStagingCommand (#2996 P7 PR-9).
-  {
-    const stagingOutcome = await interceptSecretStagingCommand(
-      { ctx, text, chat_id, msgId },
-      inboundInterceptorDeps,
-    )
-    if (stagingOutcome.handled) return
+    // Vault intercept — moved to interceptVault (#2996 P7 PR-8).
+    {
+      const vaultOutcome = await interceptVault({ ctx, text, chat_id, msgId }, inboundInterceptorDeps)
+      if (vaultOutcome.handled) return
+    }
+
+    // Secret-detect follow-up command intercept — moved to
+    // interceptSecretStagingCommand (#2996 P7 PR-9).
+    {
+      const stagingOutcome = await interceptSecretStagingCommand(
+        { ctx, text, chat_id, msgId },
+        inboundInterceptorDeps,
+      )
+      if (stagingOutcome.handled) return
+    }
   }
 
   // Typing indicator in the ORIGINATING topic — on a supergroup-topic inbound,

--- a/telegram-plugin/gateway/inbound-router.ts
+++ b/telegram-plugin/gateway/inbound-router.ts
@@ -17,6 +17,22 @@
 
 import type { Context } from 'grammy'
 import type { AttachmentMeta } from './gateway.js'
+import {
+  interceptStopKeyword,
+  interceptInterruptMarker,
+  interceptPermissionReply,
+  interceptAuthAdd,
+  interceptLoopbackRelay,
+  interceptReauth,
+  interceptVault,
+  interceptSecretStagingCommand,
+  type InboundInterceptorDeps,
+  type InterceptOutcome,
+  type StopKeywordParams,
+  type InterruptMarkerParams,
+  type InterruptMarkerOutcome,
+  type AuthAddParams,
+} from './inbound-interceptors.js'
 import type { InboundMessage } from './ipc-protocol.js'
 import { deriveTurnId } from './derive-turn-id.js'
 import { formatReplyToText } from '../steering.js'
@@ -311,4 +327,74 @@ export function buildInboundEnvelope(p: EnvelopeBuildParams): InboundMessage {
     },
   }
   return inboundMsg
+}
+
+
+// ─── P7 PR-11: kill-switched v2 intercept chain ────────────────────────────
+
+/**
+ * THE deterministic cutover switch (#2996 P7 PR-11, design §2). Read ONCE at
+ * module load (F2: flags are const-captured — flipping requires an agent
+ * restart, same as every other `_ENABLED` flag). Default OFF: the legacy
+ * inline delegation sequence in gateway.ts `handleInbound` remains the
+ * production control flow until the canary (flag `=1`) bakes clean. The v2
+ * chain and the legacy sequence call the SAME extracted intercept functions
+ * in the SAME order — the characterization harness is the parity oracle (F6;
+ * the #3316-removed gate-parity probe is not relied on), and
+ * tests/inbound-router-v2-chain.test.ts pins the v2 path with the flag set
+ * env-before-import.
+ *
+ * Rollback: unset / `=0` + agent restart. No model involvement.
+ */
+export const INBOUND_ROUTER_V2 = process.env.SWITCHROOM_INBOUND_ROUTER_V2 === '1'
+
+/** Outcome of the pre-turn chain: stop-keyword then interrupt-marker. */
+export type PreTurnChainOutcome = InterruptMarkerOutcome
+
+/**
+ * v2 chain, segment 1 — the pre-turn kill switches, in load-bearing order:
+ * stop-keyword (#3020) THEN interrupt-marker (#575). Between this chain and
+ * the paste-back chain the caller runs the stay-behind status-KPI telemetry
+ * block (F3 — non-intercepting, position preserved).
+ */
+export async function runPreTurnIntercepts(
+  p: { stop: StopKeywordParams; interrupt: InterruptMarkerParams },
+  deps: InboundInterceptorDeps,
+): Promise<PreTurnChainOutcome> {
+  const stopOutcome = await interceptStopKeyword(p.stop, deps)
+  if (stopOutcome.handled) return { handled: true }
+  return interceptInterruptMarker(p.interrupt, deps)
+}
+
+/**
+ * v2 chain, segment 2 — the reply/paste-back gauntlet, in load-bearing order:
+ * permission-reply → auth-add → loopback-relay (incl. #3084 fail-safe) →
+ * reauth → vault → secret-staging command. Auth-add-before-reauth and
+ * fail-safe-before-reauth orderings are enforced structurally here (the
+ * design's PR-11 goal: ordering by code, not by comment).
+ */
+export async function runPasteBackIntercepts(
+  p: AuthAddParams,
+  deps: InboundInterceptorDeps,
+): Promise<InterceptOutcome> {
+  const perm = interceptPermissionReply(
+    { text: p.text, chat_id: p.chat_id, msgId: p.msgId },
+    deps,
+  )
+  if (perm.handled) return perm
+  const authAdd = await interceptAuthAdd(p, deps)
+  if (authAdd.handled) return authAdd
+  const loopback = await interceptLoopbackRelay(p, deps)
+  if (loopback.handled) return loopback
+  const reauth = await interceptReauth(p, deps)
+  if (reauth.handled) return reauth
+  const vault = await interceptVault(
+    { ctx: p.ctx, text: p.text, chat_id: p.chat_id, msgId: p.msgId },
+    deps,
+  )
+  if (vault.handled) return vault
+  return interceptSecretStagingCommand(
+    { ctx: p.ctx, text: p.text, chat_id: p.chat_id, msgId: p.msgId },
+    deps,
+  )
 }

--- a/tests/inbound-router-v2-chain.test.ts
+++ b/tests/inbound-router-v2-chain.test.ts
@@ -1,0 +1,203 @@
+/**
+ * P7 PR-11 — v2 intercept-chain smoke/parity suite (#2996).
+ *
+ * Runs the SAME harness fixtures as tests/inbound-router-characterization.test.ts
+ * but with `SWITCHROOM_INBOUND_ROUTER_V2=1` set BEFORE the gateway import
+ * (design F2: the flag is a module-level const captured at load — a flip
+ * requires a separate vitest worker/file, exactly this one). The
+ * characterization harness pins the legacy arm; this file pins the v2
+ * consolidated chain (runPreTurnIntercepts / runPasteBackIntercepts) producing
+ * the SAME observable effects for the load-bearing cases:
+ *   - bare `stop` mid-turn halts (SIGINT) and never delivers
+ *   - `stop` + attachment is content (no SIGINT)
+ *   - `!`-interrupt fires SIGINT before the replacement body ships
+ *   - permission-reply `y <id>` is consumed, never forwarded
+ *   - a fresh turn still DELIVERS (F4 at-receipt snapshot — no self-block)
+ *   - a genuinely mid-turn inbound still BUFFERS
+ *   - the secret-detect fail-closed drop still drops
+ *
+ * Together with the characterization harness (the PR-11 parity oracle, F6)
+ * this is the merge gate for the cutover: both arms green on every PR.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inboundCoalesceKey } from '../telegram-plugin/gateway/inbound-coalesce.js'
+
+const SENDER = '111'
+const DM_CHAT = 222
+
+// ─── Env BEFORE import (F2) ─────────────────────────────────────────────
+const stateDir = mkdtempSync(join(tmpdir(), 'inbound-router-v2-'))
+writeFileSync(
+  join(stateDir, 'access.json'),
+  JSON.stringify({ allowFrom: [SENDER], pending: {}, groups: {} }),
+)
+process.env.TELEGRAM_STATE_DIR = stateDir
+process.env.SWITCHROOM_AGENT_NAME = 'v2testagent'
+process.env.SWITCHROOM_INBOUND_ROUTER_V2 = '1' // THE cutover flag — v2 arm
+
+// ─── Deps-boundary spies (same boundary as the characterization harness) ─
+const callLog: string[] = []
+const dispatchCalls: { kinds: string[] }[] = []
+
+vi.mock('../telegram-plugin/gateway/inbound-delivery-machine-dispatch.js', () => ({
+  dispatchEffects: (effects: { kind: string }[], deps: any) => {
+    const kinds = effects.map((e) => e.kind)
+    callLog.push('dispatch:' + kinds.join(','))
+    dispatchCalls.push({ kinds })
+    deps?.onDeliverResult?.('k', true)
+  },
+}))
+
+const sendAgentInterrupt = vi.fn(() => {
+  callLog.push('sigint')
+  return { ok: true }
+})
+vi.mock('../src/agents/tmux.js', () => ({
+  sendAgentInterrupt,
+  clearAgentComposer: vi.fn(() => ({ ok: true })),
+}))
+
+let pipelineImpl: (args: any) => any = () => ({ stored: [], rewritten_text: '', deferred: [] })
+vi.mock('../telegram-plugin/secret-detect/pipeline.js', () => ({
+  runPipeline: (args: any) => {
+    callLog.push('runPipeline')
+    return pipelineImpl(args)
+  },
+}))
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('{"ok":true,"result":{}}', { status: 200 })),
+  )
+})
+
+let gw: typeof import('../telegram-plugin/gateway/gateway.js')
+let router: typeof import('../telegram-plugin/gateway/inbound-router.js')
+let shadow: typeof import('../telegram-plugin/gateway/inbound-delivery-machine-shadow.js')
+
+beforeAll(async () => {
+  gw = await import('../telegram-plugin/gateway/gateway.js')
+  router = await import('../telegram-plugin/gateway/inbound-router.js')
+  shadow = await import('../telegram-plugin/gateway/inbound-delivery-machine-shadow.js')
+  gw.__inboundRouterTestSeam.setIpcServer({
+    sendToAgent: () => { callLog.push('ipcSend'); return true },
+    broadcast: () => {},
+  } as any)
+})
+
+beforeEach(() => {
+  callLog.length = 0
+  dispatchCalls.length = 0
+  sendAgentInterrupt.mockClear()
+  pipelineImpl = () => ({ stored: [], rewritten_text: '', deferred: [] })
+  shadow.__shadowResetForTests()
+  shadow.shadowEmit({ kind: 'bridgeUp', at: Date.now() })
+  gw.__inboundRouterTestSeam.activeStatusReactions.clear()
+  gw.__inboundRouterTestSeam.activeTurnStartedAt.clear()
+  gw.__inboundRouterTestSeam.vaultPassphraseCache.clear?.()
+  gw.__inboundRouterTestSeam.inboundCoalescer.reset()
+})
+
+function makeCtx(opts: { text: string; msgId?: number }) {
+  const message: any = {
+    message_id: opts.msgId ?? 1,
+    text: opts.text,
+    date: Math.floor(Date.now() / 1000),
+    chat: { id: DM_CHAT, type: 'private' },
+  }
+  return {
+    from: { id: Number(SENDER), is_bot: false, first_name: 'T' },
+    chat: { id: DM_CHAT, type: 'private' },
+    message,
+    reply: vi.fn(async () => ({})),
+    replyWithRichMessage: vi.fn(async () => ({})),
+    api: { sendMessage: vi.fn(async () => ({})), config: { use: () => {} } },
+  } as any
+}
+
+async function primeInFlightTurn() {
+  await gw.handleInbound(makeCtx({ text: 'first turn', msgId: 900 }), 'first turn', undefined, undefined)
+  dispatchCalls.length = 0
+  callLog.length = 0
+}
+
+const delivered = () => dispatchCalls.some((c) => c.kinds.includes('deliverToBridge'))
+const buffered = () => dispatchCalls.some((c) => c.kinds.includes('bufferInbound'))
+
+describe('v2 chain — flag sanity', () => {
+  it('this worker runs with INBOUND_ROUTER_V2 = true (env captured at import)', () => {
+    expect(router.INBOUND_ROUTER_V2).toBe(true)
+  })
+})
+
+describe('v2 chain — pre-turn intercepts (segment 1)', () => {
+  it('bare `stop` mid-turn fires SIGINT and does NOT deliver', async () => {
+    await primeInFlightTurn()
+    await gw.handleInboundCoalesced(makeCtx({ text: 'stop', msgId: 4 }), 'stop', undefined, undefined)
+    expect(sendAgentInterrupt).toHaveBeenCalledTimes(1)
+    expect(delivered()).toBe(false)
+  })
+
+  it('bare `stop` with an attachment is CONTENT, not a halt (no SIGINT)', async () => {
+    const dl = vi.fn(async () => '/tmp/stopsign.jpg')
+    await primeInFlightTurn()
+    await gw.handleInboundCoalesced(makeCtx({ text: 'stop', msgId: 5 }), 'stop', dl, undefined)
+    expect(sendAgentInterrupt).not.toHaveBeenCalled()
+    const key = inboundCoalesceKey(String(DM_CHAT), undefined, SENDER)
+    expect(gw.__inboundRouterTestSeam.inboundCoalescer.peek(key as string)?.count).toBe(1)
+  })
+
+  it('`!`-interrupt with body fires SIGINT before the replacement body ships', async () => {
+    await primeInFlightTurn()
+    await gw.handleInboundCoalesced(makeCtx({ text: '!stop and do X', msgId: 3 }), '!stop and do X', undefined, undefined)
+    expect(sendAgentInterrupt).toHaveBeenCalledTimes(1)
+    const sigintIdx = callLog.indexOf('sigint')
+    const ipcSendIdx = callLog.indexOf('ipcSend')
+    expect(sigintIdx).toBeGreaterThanOrEqual(0)
+    expect(ipcSendIdx).toBeGreaterThanOrEqual(0)
+    expect(sigintIdx).toBeLessThan(ipcSendIdx)
+  })
+})
+
+describe('v2 chain — paste-back gauntlet (segment 2)', () => {
+  it('permission-reply (`y <id>`) is intercepted — never delivered as a turn', async () => {
+    await gw.handleInbound(makeCtx({ text: 'y abcde' }), 'y abcde', undefined, undefined)
+    expect(delivered()).toBe(false)
+    expect(buffered()).toBe(false)
+  })
+})
+
+describe('v2 chain — F4 at-receipt snapshot unchanged', () => {
+  it('fresh turn DELIVERS despite its own emit advancing the machine (no self-block)', async () => {
+    await gw.handleInbound(makeCtx({ text: 'first ever' }), 'first ever', undefined, undefined)
+    expect(delivered()).toBe(true)
+    expect(buffered()).toBe(false)
+  })
+
+  it('genuinely mid-turn inbound BUFFERS', async () => {
+    await primeInFlightTurn()
+    await gw.handleInbound(makeCtx({ text: 'follow up', msgId: 2 }), 'follow up', undefined, undefined)
+    expect(buffered()).toBe(true)
+    expect(delivered()).toBe(false)
+  })
+})
+
+describe('v2 chain — secret-detect fail-closed unchanged', () => {
+  it('a pipeline throw drops the message (never delivered with raw bytes)', async () => {
+    // Cache a passphrase so the pipeline path runs.
+    gw.__inboundRouterTestSeam.vaultPassphraseCache.set(String(DM_CHAT), {
+      passphrase: 'pp',
+      expiresAt: Date.now() + 60_000,
+    })
+    pipelineImpl = () => {
+      throw new Error('boom')
+    }
+    await gw.handleInbound(makeCtx({ text: 'sk-' + 'ant-fake-secret', msgId: 7 }), 'sk-' + 'ant-fake-secret', undefined, undefined)
+    expect(delivered()).toBe(false)
+    expect(buffered()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
The risky-cut PR of the P7 train (routing design §2 PR-11), behind a deterministic env kill switch, **default OFF**:

```ts
export const INBOUND_ROUTER_V2 = process.env.SWITCHROOM_INBOUND_ROUTER_V2 === '1'
```

`inbound-router.ts` gains the consolidated ordered chain:
- **`runPreTurnIntercepts`** — stop-keyword (#3020) then interrupt-marker (#575).
- **`runPasteBackIntercepts`** — permission-reply → auth-add → loopback (incl. #3084 fail-safe) → reauth → vault → secret-staging. The load-bearing orderings are now enforced structurally in code.

`handleInbound` branches per segment: v2 → chain; legacy (default) → the existing inline sequence kept verbatim. **Both arms call the same extracted intercept functions** — single intercept implementation, so a later fix cannot land in one path only (the design red-team's dual-surface rot concern is structurally avoided). Stay-behind blocks (F3 status-KPI, typing, steer parse, #2045 capture, pipeline seam) keep exact positions on both arms; `deferInterrupt` crosses as an at-receipt captured value (F4).

## Flag semantics + rollout (per approved plan)
- F2: const-captured at module load — flip requires agent restart. Rollback: unset/`=0` + restart. No model involvement.
- Default OFF in code; the canary agent (test-harness) runs `SWITCHROOM_INBOUND_ROUTER_V2=1` immediately; default flips in a follow-up after a clean bake; legacy-arm delete is scheduled after fleet-clean.

## Parity oracle (F6)
- `tests/inbound-router-characterization.test.ts` — legacy arm, 18 cases.
- **NEW** `tests/inbound-router-v2-chain.test.ts` — v2 arm, 8 cases (mid-turn stop halt, stop+attachment content, `!`-interrupt SIGINT-before-body, permission-reply consume, F4 fresh-deliver + mid-turn-buffer, fail-closed drop), flag set env-before-import in its own vitest worker (F2).

## Test plan
- Both harness files green (26 cases). `npm run lint` clean. Full telegram-plugin bun suite green locally (sole failure = pre-existing root-uid env artifact in `approval-hold-record`, reproduced on pristine main).
- UAT note: the flag is dark by default, so this PR does not change any live agent's routing; canary UAT (`jtbd-fast-trivial-dm`, `inbound-no-drop`, `jtbd-rich-formatting-render-dm`) applies at flag-flip time on the canary, per the design's §3 gate.

## Risk
Medium by class, bounded by construction — default-OFF flag; v2 arm dark until canary opt-in; both arms share one intercept implementation.

Job: inbound message delivery (no-drop admission path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)