### PR TITLE
fix(gateway): defer pendingInboundBuffer to a getter — P0 TDZ boot crash + boot-smoke test

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9635,7 +9635,14 @@ function gatewayLivenessWiringDeps() {
     currentTurnMap,
     turnLiveForItsTopic,
     endCurrentTurnForKey,
-    pendingInboundBuffer,
+    // Getter, not an eager read: `pendingInboundBuffer` (const) is declared
+    // LATER in this module (~9863) than the module-load `startTimer` call that
+    // invokes this builder (isGatewayMain path). A by-value capture here is a
+    // temporal-dead-zone ReferenceError that crash-loops every gateway boot
+    // (#3392 regression). Deferring to a getter — matching getInboundSpool /
+    // getTurnsDb / ipcServer — means the binding is only read when the
+    // fallback actually fires, well after module eval.
+    getPendingInboundBuffer: () => pendingInboundBuffer,
     trackRedeliveredInbound,
     closeActivityLane,
     closeProgressLane,

--- a/telegram-plugin/gateway/liveness-wiring.ts
+++ b/telegram-plugin/gateway/liveness-wiring.ts
@@ -56,7 +56,7 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     currentTurnMap,
     turnLiveForItsTopic,
     endCurrentTurnForKey,
-    pendingInboundBuffer,
+    getPendingInboundBuffer,
     trackRedeliveredInbound,
     closeActivityLane,
     closeProgressLane,
@@ -421,7 +421,7 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     // re-buffers so nothing is lost if the bridge is genuinely offline.
     const fbSelfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
     const fbRedeliver = redeliverBufferedInbound(
-      pendingInboundBuffer,
+      getPendingInboundBuffer(),
       fbSelfAgent,
       (m) => sendToAgent(fbSelfAgent, m),
       getInboundSpool(),

--- a/telegram-plugin/tests/gateway-boot-smoke.test.ts
+++ b/telegram-plugin/tests/gateway-boot-smoke.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Runtime boot-smoke pin (finding M-1, full-stack adversarial review).
+ *
+ * The source-parse pin `gateway-boot-side-effect-gating.test.ts` proves the
+ * module-load side effects are `isGatewayMain`-guarded, but it NEVER actually
+ * boots the gateway — so it is structurally blind to a temporal-dead-zone
+ * ReferenceError inside a guarded builder. That exact class shipped on main:
+ * PR-C3 (#3392) made `gatewayLivenessWiringDeps()` eagerly read
+ * `pendingInboundBuffer` (a `const` declared ~200 lines LATER than the
+ * module-load `silencePoke.startTimer(...)` call that invokes the builder),
+ * crash-looping every real gateway boot with
+ *   `uncaughtException: ReferenceError: Cannot access 'pendingInboundBuffer'
+ *    before initialization`
+ * right after the boot lock — while CI stayed green because `isGatewayMain`
+ * is false under vitest (argv[1] is the runner).
+ *
+ * This test closes that blind spot the only way a source parse can't: it
+ * SPAWNS `bun telegram-plugin/gateway/gateway.ts` as the process entrypoint
+ * (so `isGatewayMain` is TRUE and every guarded module-load side effect
+ * actually runs), in a hermetic TELEGRAM_STATE_DIR with a fake bot token, and
+ * asserts the gateway reaches a POST-module-eval stderr marker
+ * (`ipc — listening`, emitted when `createIpcServer` binds its UDS at
+ * gateway.ts ~10454, well past the TDZ site) with NO
+ * `uncaughtException: ReferenceError` on the way. The 401-Unauthorized the
+ * fake token later triggers happens INSIDE `startGateway()` — after module
+ * eval — so it never precedes the marker and is not a boot-order failure.
+ *
+ * Parameterized over the two kill-switch postures so a future eager-read
+ * introduced on either the router-v2 or turn-end-funnel-v2 path is also
+ * caught:
+ *   - both flags unset (production default today)
+ *   - SWITCHROOM_INBOUND_ROUTER_V2=1 + SWITCHROOM_TURN_END_FUNNEL_V2=1
+ *
+ * Bun is the prod + CI gateway runtime (`bun test` is a required check), so
+ * spawning it here is CI-native, not CI-hostile.
+ *
+ * VERIFIED to red on pre-fix main: reverting the getter fix in the working
+ * tree makes both parameterizations fail — the child dies on the ReferenceError
+ * and never emits the marker (mutation evidence in the PR body).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { spawn } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { dirname } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_PATH = resolve(__dirname, '..', 'gateway', 'gateway.ts')
+
+// The marker is emitted synchronously by createIpcServer() at gateway.ts
+// (~10454), which is AFTER the module-load silence-poke wiring (~9653) that
+// held the TDZ read. Reaching it proves module eval cleared the crash site.
+const POST_EVAL_MARKER = 'ipc — listening'
+// A fake bot token: valid Bot API shape (<digits>:<35 chars>) so grammy's
+// constructor accepts it; the 401 only lands later during startGateway().
+const FAKE_BOT_TOKEN = '123456:' + 'A'.repeat(35)
+const BOOT_TIMEOUT_MS = 45_000
+
+interface BootResult {
+  reachedMarker: boolean
+  sawReferenceError: boolean
+  stderr: string
+}
+
+function bootGateway(extraEnv: Record<string, string>): Promise<BootResult> {
+  return new Promise<BootResult>((resolvePromise, rejectPromise) => {
+    const stateDir = mkdtempSync(join(tmpdir(), 'gw-boot-smoke-'))
+    const child = spawn('bun', [GATEWAY_PATH], {
+      env: {
+        ...process.env,
+        TELEGRAM_STATE_DIR: stateDir,
+        SWITCHROOM_GATEWAY_PID_FILE: join(stateDir, 'gateway.pid.json'),
+        TELEGRAM_BOT_TOKEN: FAKE_BOT_TOKEN,
+        SWITCHROOM_AGENT_NAME: 'boot-smoke',
+        // Scrub the two kill switches to a known-OFF baseline so the
+        // "unset" posture is genuinely unset even if the CI shell exports
+        // them; the "enabled" posture re-sets them via extraEnv below.
+        SWITCHROOM_INBOUND_ROUTER_V2: '',
+        SWITCHROOM_TURN_END_FUNNEL_V2: '',
+        ...extraEnv,
+      },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+
+    let stderr = ''
+    let settled = false
+    const finish = (): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try { child.kill('SIGKILL') } catch { /* already gone */ }
+      try { rmSync(stateDir, { recursive: true, force: true }) } catch { /* best-effort */ }
+      resolvePromise({
+        reachedMarker: stderr.includes(POST_EVAL_MARKER),
+        sawReferenceError: /uncaughtException:\s*ReferenceError/.test(stderr),
+        stderr,
+      })
+    }
+
+    const timer = setTimeout(finish, BOOT_TIMEOUT_MS)
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+      // As soon as we see the marker OR a boot-order ReferenceError, we have
+      // our verdict — no need to keep the child alive.
+      if (stderr.includes(POST_EVAL_MARKER) || /uncaughtException:\s*ReferenceError/.test(stderr)) {
+        finish()
+      }
+    })
+    child.on('error', (err) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try { rmSync(stateDir, { recursive: true, force: true }) } catch { /* best-effort */ }
+      rejectPromise(err)
+    })
+    // If the process exits before the marker (e.g. the TDZ crash aborts the
+    // process), resolve with whatever we captured so the assertion can fail
+    // with the real stderr.
+    child.on('exit', finish)
+  })
+}
+
+const POSTURES: Array<{ name: string; env: Record<string, string> }> = [
+  { name: 'both kill switches unset (prod default)', env: {} },
+  {
+    name: 'router-v2 + turn-end-funnel-v2 enabled',
+    env: { SWITCHROOM_INBOUND_ROUTER_V2: '1', SWITCHROOM_TURN_END_FUNNEL_V2: '1' },
+  },
+]
+
+describe('gateway boot-smoke (M-1): real bun boot reaches post-module-eval marker with no TDZ ReferenceError', () => {
+  it.each(POSTURES)('boots cleanly with %s', async ({ env }) => {
+    const result = await bootGateway(env)
+    // The load-bearing assertion: no temporal-dead-zone crash during module
+    // eval. If this reds, the stderr tail names the offending binding.
+    expect(
+      result.sawReferenceError,
+      `gateway boot emitted a ReferenceError before module eval finished:\n${result.stderr.slice(-2000)}`,
+    ).toBe(false)
+    // And it actually got past the TDZ site to the IPC-listening marker.
+    expect(
+      result.reachedMarker,
+      `gateway boot never reached "${POST_EVAL_MARKER}"; stderr tail:\n${result.stderr.slice(-2000)}`,
+    ).toBe(true)
+  }, BOOT_TIMEOUT_MS + 15_000)
+})


### PR DESCRIPTION
## P0 — every gateway from #3392 crash-loops on boot

**Root cause (empirically confirmed).** `telegram-plugin/gateway/gateway.ts:9653` — `if (isGatewayMain) silencePoke.startTimer(buildSilencePokeOptions(gatewayLivenessWiringDeps()))` runs at **module load**. `gatewayLivenessWiringDeps()` eagerly read `pendingInboundBuffer` **by value**, but `const pendingInboundBuffer` is declared ~210 lines **later** (~9863) — a temporal-dead-zone `ReferenceError: Cannot access 'pendingInboundBuffer' before initialization` during module eval, right after the boot lock. Introduced by PR-C3 (#3392), which moved the wiring out of the lazy `onFrameworkFallback` closure that previously captured it lazily. Flag-independent: every gateway from #3392 onward dies on boot. **CI missed it because `isGatewayMain` is false under vitest.**

Reproduction (pre-fix): `bun telegram-plugin/gateway/gateway.ts` (fake token, tmp state dir) → `uncaughtException: ReferenceError: Cannot access ...`, never reaches `ipc — listening`.

## Fix — durable getter, not a line move
- `gateway.ts`: dep becomes `getPendingInboundBuffer: () => pendingInboundBuffer`, matching the existing `getInboundSpool` / `getTurnsDb` / `ipcServer` getter idiom. Read only when the framework-fallback fires — well after module eval. A line move would work but stays fragile to future reordering; the getter is reorder-proof.
- `liveness-wiring.ts`: destructures `getPendingInboundBuffer`, calls it at the redeliver site (its only usage).

**Scan for other module-load eager reads:** only `gatewayLivenessWiringDeps()` is invoked at module load. `gatewayObligationWiringDeps` / `gatewayTurnEndDeps` / `gatewayDeliveryConfirmDeps` are lazy `??=` getters (run post-eval, no TDZ); `pendingProgress.startTimer` args are deferred closures. No other eager read.

## M-1 — boot-smoke test
`telegram-plugin/tests/gateway-boot-smoke.test.ts` spawns `bun gateway.ts` as the entrypoint (so `isGatewayMain` is **true** and every guarded module-load side effect runs), hermetic `TELEGRAM_STATE_DIR` + pid file + fake token, asserts stderr reaches the post-module-eval marker `ipc — listening` (createIpcServer UDS bind, ~10454 — past the TDZ site) with no `uncaughtException: ReferenceError`. Parameterized ×2: (1) both kill switches unset; (2) `SWITCHROOM_INBOUND_ROUTER_V2=1` + `SWITCHROOM_TURN_END_FUNNEL_V2=1`. The existing `gateway-boot-side-effect-gating.test.ts` is a source parse that never boots — blind to this class. `vitest-shard` runs `bunx vitest` (bun on PATH), so the spawn is CI-native.

### Mutation verification (test reds on pre-fix)
Reverting the getter fix, both parameterizations fail — child dies on `ReferenceError`, marker unreached (`expected true to be false` on `sawReferenceError`, 2 failed). Restoring → green (2 passed). Confirmed both directions locally.

## Checks
- `npm run lint` — all gates clean (`check-bot-api-wrapping` clean; `check-gateway-line-ratchet` = 25060 lines, within slack 50, **ratchet not raised**).
- Scoped vitest: `gateway-boot-smoke` (2), `gateway-boot-side-effect-gating` (5), `silence-liveness-wiring` (6) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)