### PR TITLE
feat(gateway): default SWITCHROOM_INBOUND_ROUTER_V2 ON (=0 escape hatch)

### DIFF
--- a/telegram-plugin/gateway/inbound-router.ts
+++ b/telegram-plugin/gateway/inbound-router.ts
@@ -335,18 +335,18 @@ export function buildInboundEnvelope(p: EnvelopeBuildParams): InboundMessage {
 /**
  * THE deterministic cutover switch (#2996 P7 PR-11, design §2). Read ONCE at
  * module load (F2: flags are const-captured — flipping requires an agent
- * restart, same as every other `_ENABLED` flag). Default OFF: the legacy
- * inline delegation sequence in gateway.ts `handleInbound` remains the
- * production control flow until the canary (flag `=1`) bakes clean. The v2
- * chain and the legacy sequence call the SAME extracted intercept functions
- * in the SAME order — the characterization harness is the parity oracle (F6;
- * the #3316-removed gate-parity probe is not relied on), and
- * tests/inbound-router-v2-chain.test.ts pins the v2 path with the flag set
- * env-before-import.
+ * restart, same as every other `_ENABLED` flag). Default ON (canary-validated
+ * on v0.18.33 — 5/5 UAT, DM + supergroup): the v2 consolidated intercept chain
+ * is the production control flow. The v2 chain and the legacy sequence call the
+ * SAME extracted intercept functions in the SAME order — the characterization
+ * harness is the parity oracle (F6; the #3316-removed gate-parity probe is not
+ * relied on), and tests/inbound-router-v2-chain.test.ts pins the v2 path with
+ * the flag set env-before-import.
  *
- * Rollback: unset / `=0` + agent restart. No model involvement.
+ * Rollback (escape hatch): `SWITCHROOM_INBOUND_ROUTER_V2=0` + agent restart.
+ * No model involvement.
  */
-export const INBOUND_ROUTER_V2 = process.env.SWITCHROOM_INBOUND_ROUTER_V2 === '1'
+export const INBOUND_ROUTER_V2 = process.env.SWITCHROOM_INBOUND_ROUTER_V2 !== '0'
 
 /** Outcome of the pre-turn chain: stop-keyword then interrupt-marker. */
 export type PreTurnChainOutcome = InterruptMarkerOutcome

--- a/tests/inbound-router-characterization.test.ts
+++ b/tests/inbound-router-characterization.test.ts
@@ -71,6 +71,12 @@ writeFileSync(
 )
 process.env.TELEGRAM_STATE_DIR = stateDir
 process.env.SWITCHROOM_AGENT_NAME = 'chartestagent'
+// This harness pins the LEGACY (v1) inline-delegation arm. Now that
+// SWITCHROOM_INBOUND_ROUTER_V2 defaults ON (`!== '0'`), pin it to '0' here so
+// the legacy arm stays covered until the legacy path is deleted. Use `??=` so
+// the v2 wrapper (inbound-router-characterization-v2.test.ts sets `='1'` then
+// re-imports THIS file) is NOT clobbered — only a standalone run defaults to '0'.
+process.env.SWITCHROOM_INBOUND_ROUTER_V2 ??= '0'
 
 // ─── Deps-boundary spies ────────────────────────────────────────────────
 // A single ordered call log across every boundary mock — the intercept-ORDER


### PR DESCRIPTION
Flip the inbound-router v2 consolidated intercept-chain gate from opt-in (`=== '1'`) to default-ON (`!== '0'`).

## Why
Canary-validated on v0.18.33 — 5/5 UAT pass, DM + supergroup. Escape hatch: `SWITCHROOM_INBOUND_ROUTER_V2=0` + agent restart.

## Both-arm coverage preserved
The legacy (v1) characterization harness `tests/inbound-router-characterization.test.ts` now pins the flag to `'0'` via `??=` so a standalone run still exercises the legacy arm. The `??=` (not `=`) matters: the v2 wrapper `tests/inbound-router-characterization-v2.test.ts` sets `='1'` then re-imports the base file — an unconditional assignment would clobber it and silently re-run legacy as fake "v2 parity".

## Gates
- Scoped vitest: inbound-router-characterization (both arms) + gateway-boot-smoke — 39 passed
- `npm run lint` clean; gateway line ratchet untouched (no gateway.ts line change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)