### PR TITLE
feat(gateway): default SWITCHROOM_TURN_END_FUNNEL_V2 ON (=0 escape hatch)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4816,7 +4816,7 @@ export type TurnEndDeps = ReturnType<typeof gatewayTurnEndDeps>
 // paths verbatim. =1 routes every wrapper (and the two ghost-clear callsites)
 // through the single `endTurn` dispatcher — same code, one auditable entry
 // point. Module-load const: flipping requires an agent restart (P7 F2).
-const TURN_END_FUNNEL_V2 = process.env.SWITCHROOM_TURN_END_FUNNEL_V2 === '1'  // default OFF during bake
+const TURN_END_FUNNEL_V2 = process.env.SWITCHROOM_TURN_END_FUNNEL_V2 !== '0'  // default ON (canary-validated v0.18.33); escape hatch =0
 
 let _turnEndFunnel: ReturnType<typeof createTurnEndFunnel> | undefined
 function turnEndFunnel(): ReturnType<typeof createTurnEndFunnel> {

--- a/telegram-plugin/tests/gateway-boot-smoke.test.ts
+++ b/telegram-plugin/tests/gateway-boot-smoke.test.ts
@@ -28,8 +28,10 @@
  * Parameterized over the two kill-switch postures so a future eager-read
  * introduced on either the router-v2 or turn-end-funnel-v2 path is also
  * caught:
- *   - both flags unset (production default today)
+ *   - both flags unset (production default — now BOTH v2 ON after the flip)
  *   - SWITCHROOM_INBOUND_ROUTER_V2=1 + SWITCHROOM_TURN_END_FUNNEL_V2=1
+ *   - both flags =0 (the escape-hatch legacy v1 posture — kept so the legacy
+ *     module-eval paths stay boot-smoked until the legacy delete)
  *
  * Bun is the prod + CI gateway runtime (`bun test` is a required check), so
  * spawning it here is CI-native, not CI-hostile.
@@ -125,10 +127,18 @@ function bootGateway(extraEnv: Record<string, string>): Promise<BootResult> {
 }
 
 const POSTURES: Array<{ name: string; env: Record<string, string> }> = [
-  { name: 'both kill switches unset (prod default)', env: {} },
+  // Flags unset is now the DEFAULT-ON posture (both `!== '0'`) after the
+  // v0.18.33 canary flip — the v2 router + v2 turn-end funnel are live.
+  { name: 'both kill switches unset (prod default — now BOTH v2 ON)', env: {} },
   {
-    name: 'router-v2 + turn-end-funnel-v2 enabled',
+    name: 'router-v2 + turn-end-funnel-v2 explicitly enabled',
     env: { SWITCHROOM_INBOUND_ROUTER_V2: '1', SWITCHROOM_TURN_END_FUNNEL_V2: '1' },
+  },
+  {
+    // Explicit legacy posture: with both flags defaulting ON, the only way to
+    // boot-smoke the legacy (v1) module-eval paths is the `=0` escape hatch.
+    name: 'both kill switches disabled (=0 escape hatch — legacy v1 paths)',
+    env: { SWITCHROOM_INBOUND_ROUTER_V2: '0', SWITCHROOM_TURN_END_FUNNEL_V2: '0' },
   },
 ]
 

--- a/tests/turn-lifecycle-characterization.test.ts
+++ b/tests/turn-lifecycle-characterization.test.ts
@@ -53,6 +53,12 @@ process.env.SWITCHROOM_SERIALIZE_NOREPLY_DRAIN_MS = '2500'
 // which the child_process mock intercepts (case 8). A docker path would
 // `process.kill(1, 'SIGTERM')` — never do that in a test runner.
 delete process.env.SWITCHROOM_RUNTIME
+// This harness pins the LEGACY turn-END funnel arm. Now that
+// SWITCHROOM_TURN_END_FUNNEL_V2 defaults ON (`!== '0'`), pin it to '0' here so
+// a standalone run exercises the legacy path. Use `??=` so the PR-E v2 wrapper
+// (turn-lifecycle-characterization-v2.test.ts sets `='1'` then re-imports THIS
+// file) is NOT clobbered — only a standalone run defaults to '0'.
+process.env.SWITCHROOM_TURN_END_FUNNEL_V2 ??= '0'
 
 // ─── Deps-boundary spies ────────────────────────────────────────────────
 // The turnEnd shadow-event SEQUENCE oracle (L1). Each entry mirrors the exact


### PR DESCRIPTION
Flip the turn-END funnel v2 gate (the single `endTurn(reason)` dispatcher branch) from opt-in (`=== '1'`) to default-ON (`!== '0'`).

## Why
Canary-validated on v0.18.33 — 5/5 UAT pass, DM + supergroup. Escape hatch: `SWITCHROOM_TURN_END_FUNNEL_V2=0` + agent restart.

## Both-arm coverage preserved
- `tests/turn-lifecycle-characterization.test.ts` (legacy funnel) now pins the flag to `'0'` via `??=` — a standalone run exercises the legacy path; the PR-E v2 wrapper (`turn-lifecycle-characterization-v2.test.ts` sets `='1'` then re-imports the base) is not clobbered.
- `telegram-plugin/tests/gateway-boot-smoke.test.ts` gains a third posture — both flags `=0` — so the legacy v1 module-eval paths stay boot-smoked now that flags-unset means BOTH v2 ON.

## Gates
- Scoped vitest: turn-lifecycle-characterization (both arms) + gateway-boot-smoke (3 postures) — 25 passed
- `npm run lint` clean; gateway line ratchet unchanged (single-line comment edit, no line delta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)