### PR TITLE
build(docker): bump bundled Claude Code CLI to 2.1.215

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Bundled Claude Code CLI bumped 2.1.205 → 2.1.215** (#3405) —
+  `CLAUDE_CODE_VERSION` in `docker/Dockerfile.base` and
+  `docker/Dockerfile.hindsight` (lockstep per #1978). Pulls in upstream
+  security hardening from 2.1.214 (bash permission bypass fixes, docker
+  daemon-redirect prompts), the scheduled-task untrusted-input fix,
+  gateway prompt caching, and MCP auto-backgrounding.
+
 ## v0.19.0 — Re-architected inbound routing and turn-lifecycle paths are now ON by default
 
 The two gateway-decomposition kill switches that shipped default-OFF in

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.205
+ARG CLAUDE_CODE_VERSION=2.1.215
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -51,7 +51,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.205
+ARG CLAUDE_CODE_VERSION=2.1.215
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 


### PR DESCRIPTION
Bumps `CLAUDE_CODE_VERSION` from 2.1.205 to 2.1.215 in `docker/Dockerfile.base` and `docker/Dockerfile.hindsight`, in lockstep per #1978.

Why:
- Security hardening in 2.1.214: bash permission bypass fixes, docker daemon-redirect prompts
- Scheduled-task untrusted-input fix
- Gateway prompt caching
- MCP auto-backgrounding

Remaining 2.1.205 references are historical verified-against notes (docs/comments), left as-is per the #2951 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)