### PR TITLE
feat(litellm): config-time model-reference validation vs proxy model_list (#3407)

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -32,6 +32,8 @@ import { probeHindsight, isHindsightEnabled, fetchHindsightToolsList, collectPro
 import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
 import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, classifyConsolidationBacklog } from "./doctor-memory.js";
+import { runLitellmModelChecks } from "../litellm/model-validation.js";
+import { isVaultReference, parseVaultReference } from "../vault/resolver.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runHostdChecks } from "./doctor-hostd.js";
@@ -3046,6 +3048,25 @@ export function registerDoctorCommand(program: Command): void {
           },
           { title: "Vault access", results: await runSecretAccessChecks(config) },
           { title: "Memory (Hindsight)", results: await checkHindsight(config) },
+          {
+            // #3407: config-time drift guard — every switchroom-managed LLM
+            // model reference (hindsight llm config + explicit agent litellm
+            // routes) must exist in the live proxy model_list. FAILs loudly at
+            // doctor time instead of 400ing silently at runtime; WARNs (never
+            // fails) when the proxy is unreachable.
+            title: "LiteLLM model routing (#3407)",
+            results: await runLitellmModelChecks(config, {
+              resolveSecret: (ref) => {
+                if (!isVaultReference(ref)) return ref; // literal admin_key
+                if (!passphrase || !existsSync(vaultPath)) return null;
+                try {
+                  return getStringSecret(passphrase, vaultPath, parseVaultReference(ref));
+                } catch {
+                  return null;
+                }
+              },
+            }),
+          },
           { title: "Telegram", results: await checkTelegram(config) },
           { title: "Agents", results: checkAgents(config, configPath) },
           {

--- a/src/litellm/model-validation.ts
+++ b/src/litellm/model-validation.ts
@@ -1,0 +1,292 @@
+/**
+ * Config-time validation: every LLM model referenced by a switchroom-managed
+ * consumer must exist in the live LiteLLM proxy's model list (#3407).
+ *
+ * The 2026-07-19 outage: an operator edit to the Coolify-hosted LiteLLM
+ * `model_list` ("degemini") removed the OpenRouter Gemini model groups, but the
+ * shared `switchroom-hindsight` container's env still pinned
+ * `openrouter/google/gemini-3.1-flash-lite` (`HINDSIGHT_API_LLM_MODEL` /
+ * `ANTHROPIC_MODEL`). Every hindsight default-config LLM call then 400'd
+ * ("Invalid model name") for ~2h. The proxy's model list and switchroom's model
+ * references drifted apart with no deterministic check catching it.
+ *
+ * This module closes that gap. It is pure over its inputs except for one small
+ * injectable HTTP fetch (`fetchProxyModels`), so the collection + validation
+ * logic is trivially unit-testable and the doctor/validate path wires the real
+ * proxy query + secret resolution in.
+ *
+ * Scope (deliberately conservative to avoid false positives):
+ *   - Hindsight LLM config — `hindsight.llm.model` (global) and the per-op
+ *     `retain`/`reflect`/`consolidation` `.model` overrides. These are explicit
+ *     full model identifiers the hindsight container hands the proxy verbatim,
+ *     so ALL of them are validated when the fleet carve-out (`litellm.enabled`)
+ *     is on.
+ *   - Agent model pins — `agents.<name>.model` / `fallback_model` — but ONLY
+ *     values that are explicit litellm routes (contain a `/`, e.g.
+ *     `openrouter/z-ai/glm-5.2`). Bare Claude aliases (`sonnet`/`opus`/`haiku`)
+ *     are expanded by the `claude` CLI and served by the proxy's `/anthropic`
+ *     passthrough, so flagging them against `/v1/models` would false-positive.
+ *
+ * Failure semantics (owned by the caller / doctor wiring):
+ *   - A referenced model missing from `/v1/models` → FAIL, naming the model AND
+ *     the consumer(s) referencing it. Loud, at validate/doctor time.
+ *   - Proxy unreachable / non-200 → WARN, never a hard fail (mirrors the
+ *     existing #2781 broker-unreachable degrade — an environment limitation,
+ *     not a config error).
+ *   - LiteLLM disabled, or no litellm-routable references → nothing to check.
+ */
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckResult } from "../cli/doctor-memory.js";
+
+/** A single model reference drawn from switchroom-managed config. */
+export interface ModelReference {
+  /** The model identifier as written in config (handed to the proxy verbatim). */
+  model: string;
+  /** Human-readable consumer that references it, e.g. `hindsight.llm.retain`. */
+  consumer: string;
+}
+
+/**
+ * Pure: is a model value an explicit litellm route we can validate against the
+ * proxy model list? True for provider-prefixed ids (`openrouter/...`,
+ * `anthropic/...`) — anything carrying a `/`. Bare CLI aliases (`sonnet`) are
+ * intentionally excluded (passthrough-served; would false-positive).
+ */
+export function isExplicitLitellmRoute(model: string): boolean {
+  return model.includes("/");
+}
+
+/**
+ * Pure: collect every switchroom-managed model reference that should exist in
+ * the LiteLLM proxy model list. Returns [] when the fleet carve-out is off
+ * (`litellm.enabled` !== true) — with no proxy in the path there is nothing to
+ * validate against. Never throws.
+ */
+export function collectReferencedModels(config: SwitchroomConfig): ModelReference[] {
+  const refs: ModelReference[] = [];
+  const litellmEnabled = config.litellm?.enabled === true;
+  if (!litellmEnabled) return refs;
+
+  // ── Hindsight LLM config — global + per-op. Validated verbatim (explicit
+  // full model ids, not CLI aliases). Dedup by (model, consumer).
+  const llm = config.hindsight?.llm;
+  if (llm) {
+    const push = (model: string | undefined, consumer: string) => {
+      if (model) refs.push({ model, consumer });
+    };
+    push(llm.model, "hindsight.llm.model (global)");
+    push(llm.retain?.model, "hindsight.llm.retain");
+    push(llm.reflect?.model, "hindsight.llm.reflect");
+    push(llm.consolidation?.model, "hindsight.llm.consolidation");
+  }
+
+  // ── Agent model pins — only explicit litellm routes (contain `/`), and only
+  // for agents that actually route through the proxy (top-level enabled AND the
+  // agent hasn't opted out with `litellm.enabled: false`).
+  for (const [name, agent] of Object.entries(config.agents ?? {})) {
+    if (!agent) continue;
+    const agentRoutes = agent.litellm?.enabled !== false; // inherits fleet-on
+    if (!agentRoutes) continue;
+    if (agent.model && isExplicitLitellmRoute(agent.model)) {
+      refs.push({ model: agent.model, consumer: `agents.${name}.model` });
+    }
+    if (agent.fallback_model && isExplicitLitellmRoute(agent.fallback_model)) {
+      refs.push({ model: agent.fallback_model, consumer: `agents.${name}.fallback_model` });
+    }
+  }
+
+  return refs;
+}
+
+/** One missing model with every consumer that references it. */
+export interface MissingModel {
+  model: string;
+  consumers: string[];
+}
+
+/**
+ * Pure: validate references against the set of model ids the proxy advertises.
+ * Returns the missing models grouped with their referencing consumers, in
+ * stable (first-seen) order. `proxyModels` is the set of `id`s from
+ * `/v1/models`. Never throws.
+ */
+export function validateModelReferences(
+  refs: ModelReference[],
+  proxyModels: Set<string>,
+): MissingModel[] {
+  const missing = new Map<string, string[]>();
+  for (const { model, consumer } of refs) {
+    if (proxyModels.has(model)) continue;
+    const list = missing.get(model);
+    if (list) {
+      if (!list.includes(consumer)) list.push(consumer);
+    } else {
+      missing.set(model, [consumer]);
+    }
+  }
+  return [...missing.entries()].map(([model, consumers]) => ({ model, consumers }));
+}
+
+/** Injectable fetch — just the call signature we use (see litellm/provision.ts). */
+export type FetchFn = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+) => Promise<Response>;
+
+/** Result of probing the proxy's model list. */
+export type ProxyModelsResult =
+  | { kind: "ok"; models: string[] }
+  | { kind: "unreachable"; msg: string };
+
+/**
+ * Query the LiteLLM proxy's OpenAI-format model list (`GET {base}/v1/models`),
+ * authenticated with the master/admin key as a Bearer token. Returns the model
+ * `id`s on success, or an `unreachable` result (network error, non-200, or
+ * unparseable body) the caller degrades to a WARNING. Never throws.
+ */
+export async function fetchProxyModels(
+  baseUrl: string,
+  apiKey: string,
+  fetchFn: FetchFn = fetch,
+  timeoutMs = 8000,
+): Promise<ProxyModelsResult> {
+  const url = `${baseUrl.replace(/\/+$/, "")}/v1/models`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchFn(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      // AbortSignal is accepted by real fetch; the injectable type omits it to
+      // stay minimal, so pass it through a widened cast.
+      ...({ signal: controller.signal } as Record<string, unknown>),
+    });
+    if (!res.ok) {
+      return { kind: "unreachable", msg: `proxy returned HTTP ${res.status} for ${url}` };
+    }
+    const body = (await res.json()) as unknown;
+    const data = (body as { data?: unknown })?.data;
+    if (!Array.isArray(data)) {
+      return { kind: "unreachable", msg: `proxy ${url} response had no model \`data\` array` };
+    }
+    const models = data
+      .map((m) => (m as { id?: unknown })?.id)
+      .filter((id): id is string => typeof id === "string");
+    return { kind: "ok", models };
+  } catch (err) {
+    return { kind: "unreachable", msg: (err as Error).message ?? String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Pure: turn a missing-model list (from {@link validateModelReferences}) into a
+ * single doctor `CheckResult`. FAIL when anything is missing, naming each model
+ * and its consumer(s); OK otherwise. `refCount` is the number of references
+ * actually validated, for the OK detail line.
+ */
+export function classifyModelReferences(
+  missing: MissingModel[],
+  refCount: number,
+): CheckResult {
+  if (missing.length === 0) {
+    return {
+      name: "litellm model routing",
+      status: "ok",
+      detail: `all ${refCount} referenced model(s) present in the proxy model_list`,
+    };
+  }
+  const detail = missing
+    .map((m) => `\`${m.model}\` (referenced by ${m.consumers.join(", ")})`)
+    .join("; ");
+  return {
+    name: "litellm model routing",
+    status: "fail",
+    detail:
+      `${missing.length} model reference(s) NOT in the LiteLLM proxy model_list: ` +
+      `${detail} — every LLM call from that consumer will 400 ("Invalid model ` +
+      `name") until the proxy lists it or the reference is corrected`,
+    fix:
+      "Either add the missing model group back to the LiteLLM proxy config " +
+      "(the operator-maintained `litellm-config.yaml` `model_list`) and redeploy " +
+      "the proxy, or repoint the consumer at a model the proxy DOES route " +
+      "(`switchroom doctor` lists them via the proxy `/v1/models`). For " +
+      "hindsight, then `switchroom memory --restart` so it re-verifies.",
+  };
+}
+
+/** Options for {@link runLitellmModelChecks} — IO injected for testability. */
+export interface LitellmModelCheckOpts {
+  /**
+   * Resolve the admin/master key: a literal string is returned as-is; a
+   * `vault:<key>` reference is resolved to its secret value, or `null` when it
+   * can't be read. The doctor wiring passes a vault-backed resolver.
+   */
+  resolveSecret: (ref: string) => string | null;
+  /** Injectable fetch (defaults to global `fetch`). */
+  fetchFn?: FetchFn;
+}
+
+/**
+ * Orchestrate the config-time model-reference check for `switchroom doctor` /
+ * the validate path. Gate order:
+ *   1. LiteLLM off or no litellm-routable references → [] (nothing to check).
+ *   2. base_url / admin_key unresolved → single WARN (can't reach the proxy).
+ *   3. Proxy unreachable → single WARN (environment limitation, never fatal).
+ *   4. Otherwise → validate and return the FAIL/OK row.
+ * Never throws.
+ */
+export async function runLitellmModelChecks(
+  config: SwitchroomConfig,
+  opts: LitellmModelCheckOpts,
+): Promise<CheckResult[]> {
+  const refs = collectReferencedModels(config);
+  if (refs.length === 0) return [];
+
+  const litellm = config.litellm;
+  const baseUrl = litellm?.base_url;
+  const adminKeyRef = litellm?.admin_key;
+  if (!baseUrl || !adminKeyRef) {
+    return [
+      {
+        name: "litellm model routing",
+        status: "warn",
+        detail:
+          `${refs.length} model reference(s) to validate but litellm ` +
+          `${!baseUrl ? "base_url" : "admin_key"} is unresolved — cannot query ` +
+          `the proxy model_list`,
+      },
+    ];
+  }
+
+  const apiKey = opts.resolveSecret(adminKeyRef);
+  if (!apiKey) {
+    return [
+      {
+        name: "litellm model routing",
+        status: "warn",
+        detail:
+          `could not resolve the litellm admin_key (\`${adminKeyRef}\`) to query ` +
+          `the proxy model_list — ${refs.length} model reference(s) left unverified`,
+      },
+    ];
+  }
+
+  const probe = await fetchProxyModels(baseUrl, apiKey, opts.fetchFn);
+  if (probe.kind === "unreachable") {
+    return [
+      {
+        name: "litellm model routing",
+        status: "warn",
+        detail:
+          `LiteLLM proxy unreachable (${probe.msg}) — ${refs.length} model ` +
+          `reference(s) left unverified; not failing on an environment limitation`,
+      },
+    ];
+  }
+
+  const missing = validateModelReferences(refs, new Set(probe.models));
+  return [classifyModelReferences(missing, refs.length)];
+}

--- a/tests/litellm.model-validation.test.ts
+++ b/tests/litellm.model-validation.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from "vitest";
+import {
+  isExplicitLitellmRoute,
+  collectReferencedModels,
+  validateModelReferences,
+  classifyModelReferences,
+  fetchProxyModels,
+  runLitellmModelChecks,
+  type ModelReference,
+} from "../src/litellm/model-validation.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+/** Minimal config builder — cast through unknown so tests stay terse without
+ *  restating the whole (large) schema shape. */
+function cfg(partial: Record<string, unknown>): SwitchroomConfig {
+  return partial as unknown as SwitchroomConfig;
+}
+
+describe("isExplicitLitellmRoute", () => {
+  it("treats provider-prefixed ids (with `/`) as explicit routes", () => {
+    expect(isExplicitLitellmRoute("openrouter/google/gemini-3.1-flash-lite")).toBe(true);
+    expect(isExplicitLitellmRoute("anthropic/claude-sonnet-5")).toBe(true);
+  });
+  it("excludes bare CLI aliases (no `/`) — passthrough-served, would false-positive", () => {
+    expect(isExplicitLitellmRoute("sonnet")).toBe(false);
+    expect(isExplicitLitellmRoute("opus")).toBe(false);
+    expect(isExplicitLitellmRoute("claude-sonnet-5")).toBe(false);
+  });
+});
+
+describe("collectReferencedModels", () => {
+  it("returns [] when the litellm carve-out is off", () => {
+    const c = cfg({
+      litellm: { enabled: false },
+      hindsight: { llm: { model: "openrouter/x/y" } },
+    });
+    expect(collectReferencedModels(c)).toEqual([]);
+  });
+
+  it("collects hindsight global + per-op models verbatim when enabled", () => {
+    const c = cfg({
+      litellm: { enabled: true, base_url: "http://p:4010", admin_key: "sk-master" },
+      hindsight: {
+        llm: {
+          model: "openrouter/google/gemini-3.1-flash-lite",
+          retain: { model: "claude-haiku-5" },
+          reflect: { model: "openrouter/z-ai/glm-5.2" },
+          consolidation: {},
+        },
+      },
+    });
+    const refs = collectReferencedModels(c);
+    expect(refs).toEqual([
+      { model: "openrouter/google/gemini-3.1-flash-lite", consumer: "hindsight.llm.model (global)" },
+      { model: "claude-haiku-5", consumer: "hindsight.llm.retain" },
+      { model: "openrouter/z-ai/glm-5.2", consumer: "hindsight.llm.reflect" },
+    ]);
+  });
+
+  it("collects only explicit-route agent pins (with `/`), skipping bare aliases", () => {
+    const c = cfg({
+      litellm: { enabled: true, base_url: "http://p:4010", admin_key: "sk" },
+      agents: {
+        clerk: { model: "openrouter/z-ai/glm-5.2", fallback_model: "sonnet" },
+        scribe: { model: "opus" },
+        router: { fallback_model: "openrouter/x/fallback" },
+      },
+    });
+    const refs = collectReferencedModels(c);
+    expect(refs).toEqual([
+      { model: "openrouter/z-ai/glm-5.2", consumer: "agents.clerk.model" },
+      { model: "openrouter/x/fallback", consumer: "agents.router.fallback_model" },
+    ]);
+  });
+
+  it("skips an agent that opted out with litellm.enabled: false", () => {
+    const c = cfg({
+      litellm: { enabled: true, base_url: "http://p", admin_key: "sk" },
+      agents: {
+        offgrid: { model: "openrouter/a/b", litellm: { enabled: false } },
+        online: { model: "openrouter/c/d" },
+      },
+    });
+    const refs = collectReferencedModels(c);
+    expect(refs.map((r) => r.consumer)).toEqual(["agents.online.model"]);
+  });
+});
+
+describe("validateModelReferences", () => {
+  const refs: ModelReference[] = [
+    { model: "openrouter/gemini", consumer: "hindsight.llm.model (global)" },
+    { model: "openrouter/gemini", consumer: "hindsight.llm.retain" },
+    { model: "claude-sonnet-5", consumer: "agents.clerk.model" },
+  ];
+  it("groups a missing model with ALL its consumers, deduped", () => {
+    const missing = validateModelReferences(refs, new Set(["claude-sonnet-5"]));
+    expect(missing).toEqual([
+      {
+        model: "openrouter/gemini",
+        consumers: ["hindsight.llm.model (global)", "hindsight.llm.retain"],
+      },
+    ]);
+  });
+  it("returns [] when every reference is present", () => {
+    const present = new Set(["openrouter/gemini", "claude-sonnet-5"]);
+    expect(validateModelReferences(refs, present)).toEqual([]);
+  });
+});
+
+describe("classifyModelReferences", () => {
+  it("OK names the count when nothing is missing", () => {
+    const r = classifyModelReferences([], 3);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("3");
+  });
+  it("FAIL names the model and its consumers", () => {
+    const r = classifyModelReferences(
+      [{ model: "openrouter/gemini", consumers: ["hindsight.llm.model (global)"] }],
+      2,
+    );
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("openrouter/gemini");
+    expect(r.detail).toContain("hindsight.llm.model (global)");
+    expect(r.fix).toContain("model_list");
+  });
+});
+
+describe("fetchProxyModels", () => {
+  const okResponse = (ids: string[]) =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: ids.map((id) => ({ id })) }),
+    }) as unknown as Response;
+
+  it("parses the OpenAI-format id list and sends a Bearer auth header", async () => {
+    let seenUrl = "";
+    let seenAuth = "";
+    const res = await fetchProxyModels("http://proxy:4010/", "sk-master", async (url, init) => {
+      seenUrl = url;
+      seenAuth = (init?.headers?.Authorization as string) ?? "";
+      return okResponse(["sonnet", "openrouter/gemini"]);
+    });
+    expect(seenUrl).toBe("http://proxy:4010/v1/models"); // trailing slash normalized
+    expect(seenAuth).toBe("Bearer sk-master");
+    expect(res).toEqual({ kind: "ok", models: ["sonnet", "openrouter/gemini"] });
+  });
+
+  it("degrades a non-200 to unreachable (never throws)", async () => {
+    const res = await fetchProxyModels("http://p", "sk", async () =>
+      ({ ok: false, status: 401 }) as unknown as Response,
+    );
+    expect(res.kind).toBe("unreachable");
+    expect(res.kind === "unreachable" && res.msg).toContain("401");
+  });
+
+  it("degrades a network error to unreachable", async () => {
+    const res = await fetchProxyModels("http://p", "sk", async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    expect(res).toEqual({ kind: "unreachable", msg: "ECONNREFUSED" });
+  });
+
+  it("degrades a malformed body (no data array) to unreachable", async () => {
+    const res = await fetchProxyModels("http://p", "sk", async () =>
+      ({ ok: true, status: 200, json: async () => ({ oops: true }) }) as unknown as Response,
+    );
+    expect(res.kind).toBe("unreachable");
+  });
+});
+
+describe("runLitellmModelChecks (orchestration)", () => {
+  const baseCfg = (extra: Record<string, unknown> = {}) =>
+    cfg({
+      litellm: { enabled: true, base_url: "http://p:4010", admin_key: "vault:litellm/master-key" },
+      hindsight: { llm: { model: "openrouter/google/gemini-3.1-flash-lite" } },
+      ...extra,
+    });
+
+  it("returns [] when there are no references (litellm off)", async () => {
+    const out = await runLitellmModelChecks(cfg({ litellm: { enabled: false } }), {
+      resolveSecret: () => "sk",
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("WARNs when base_url/admin_key is unresolved", async () => {
+    const out = await runLitellmModelChecks(
+      cfg({
+        litellm: { enabled: true },
+        hindsight: { llm: { model: "openrouter/x/y" } },
+      }),
+      { resolveSecret: () => "sk" },
+    );
+    expect(out[0].status).toBe("warn");
+    expect(out[0].detail).toContain("unresolved");
+  });
+
+  it("WARNs when the admin_key can't be resolved to a secret", async () => {
+    const out = await runLitellmModelChecks(baseCfg(), { resolveSecret: () => null });
+    expect(out[0].status).toBe("warn");
+    expect(out[0].detail).toContain("admin_key");
+  });
+
+  it("WARNs (never fails) when the proxy is unreachable", async () => {
+    const out = await runLitellmModelChecks(baseCfg(), {
+      resolveSecret: () => "sk-master",
+      fetchFn: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    expect(out[0].status).toBe("warn");
+    expect(out[0].detail).toContain("unreachable");
+  });
+
+  it("FAILs loudly, naming the missing model + consumer, on real drift", async () => {
+    const out = await runLitellmModelChecks(baseCfg(), {
+      resolveSecret: () => "sk-master",
+      // proxy no longer lists the gemini model (the degemini edit)
+      fetchFn: async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [{ id: "claude-sonnet-5" }, { id: "sonnet" }] }),
+        }) as unknown as Response,
+    });
+    expect(out[0].status).toBe("fail");
+    expect(out[0].detail).toContain("openrouter/google/gemini-3.1-flash-lite");
+    expect(out[0].detail).toContain("hindsight.llm.model (global)");
+  });
+
+  it("is OK when the proxy lists every referenced model", async () => {
+    const out = await runLitellmModelChecks(baseCfg(), {
+      resolveSecret: () => "sk-master",
+      fetchFn: async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [{ id: "openrouter/google/gemini-3.1-flash-lite" }] }),
+        }) as unknown as Response,
+    });
+    expect(out[0].status).toBe("ok");
+  });
+
+  it("passes the resolved admin_key vault ref through resolveSecret", async () => {
+    let seenRef = "";
+    await runLitellmModelChecks(baseCfg(), {
+      resolveSecret: (ref) => {
+        seenRef = ref;
+        return "sk-master";
+      },
+      fetchFn: async () =>
+        ({ ok: true, status: 200, json: async () => ({ data: [] }) }) as unknown as Response,
+    });
+    expect(seenRef).toBe("vault:litellm/master-key");
+  });
+});


### PR DESCRIPTION
Closes #3407.

## Problem
2026-07-19 outage: an operator edit to the LiteLLM proxy `model_list` ("degemini") dropped the OpenRouter Gemini groups, but `switchroom-hindsight`'s env still pinned `openrouter/google/gemini-3.1-flash-lite`. Every hindsight default-config LLM call 400'd (`Invalid model name`) for ~2h. The proxy model list and switchroom's model references drifted with **no deterministic check** catching it — the failure was visible only as container log lines, and nobody was alerted.

## Change
New `src/litellm/model-validation.ts`, wired into `switchroom doctor` as the **"LiteLLM model routing (#3407)"** section:

- **`collectReferencedModels`** — `hindsight.llm.{model,retain,reflect,consolidation}` models (validated **verbatim** — hindsight hands the exact string to the proxy) + agent pins `model`/`fallback_model` **only when they are explicit litellm routes** (contain `/`, e.g. `openrouter/...`). Bare Claude aliases (`sonnet`/`opus`/`haiku`) are deliberately excluded — the `claude` CLI expands them and the proxy serves them via `/anthropic` passthrough, so validating them against `/v1/models` would false-positive. Gated on `litellm.enabled` and per-agent `litellm.enabled: false` opt-out.
- **`fetchProxyModels`** — `GET {base}/v1/models` with the master/admin key as Bearer; degrades any network error / non-200 / malformed body to `unreachable`.
- **`validateModelReferences` / `classifyModelReferences`** — pure: a referenced model absent from the proxy list → **FAIL**, naming the model AND every consumer referencing it.
- **`runLitellmModelChecks`** — orchestration + gate order: litellm off / no routable refs → nothing; base_url or admin_key unresolved → WARN; **proxy unreachable → WARN (never a hard fail**, mirrors the #2781 broker-unreachable degrade); missing model → **FAIL loudly at doctor time**, not silently at runtime.

The doctor wiring resolves the `admin_key` (literal or `vault:` ref) through the vault.

## Assumption
Scoped the validate surface to `switchroom doctor` (the documented validate path) rather than also threading it into the apply provisioning loop — single-concern PR; the issue allows "doctor/validate path **and/or** memory setup". Agent-pin validation is intentionally limited to explicit `/`-routes to avoid false positives on CLI aliases; noted inline.

## Tests
21 cases in `tests/litellm.model-validation.test.ts` (route detection, collection incl. carve-out-off + agent opt-out, grouping/dedup, OK/FAIL classification, fetch parsing + all degrade paths, and full orchestration incl. the exact degemini drift scenario). Scoped `vitest` green (21/21); `npm run lint` (tsc + guards) clean.

Companion PR: hindsight boot LLM-verification alerting (#3409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)