### PR TITLE
fix(usage): honesty + info-exposure hardening for /usage card

### DIFF
--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -1012,6 +1012,45 @@ export function zipProbeResults(
 }
 
 /**
+ * The freshness-marker subset of the /usage card's render opts. Mirrors the
+ * three mutually-prioritised fields on `UsageCardRenderOpts`
+ * (quota-bar-format.ts) without importing across the module — cache-stale >
+ * live > probe-failed.
+ */
+export interface UsageFooterFreshness {
+  staleCachedAtMs?: number;
+  liveProbedAtMs?: number;
+  probeFailed?: boolean;
+}
+
+/**
+ * Decide the /usage card's freshness footer from a broker probe response.
+ *
+ * Adversarial-review F1: the caller must NEVER stamp "Live" when no account
+ * row carries usable live data. A non-empty `results` array is NOT proof of
+ * that — opProbeQuota (src/auth/broker/server.ts) returns
+ * `{result:{ok:false}, served:"live"}` for a failed live probe against an
+ * empty cache, so every row can be `ok:false` while `results.length > 0`.
+ * `zipProbeResults` only marks `served==="cache"` rows stale, so those failed
+ * rows carry no cache stamp either. The honest signal is whether ANY row's
+ * `result.ok` is true.
+ *
+ * Precedence (highest first): cache-served data (`staleCachedAtMs`, real but
+ * stale) → live data present (`liveProbedAtMs`) → nothing usable
+ * (`probeFailed`). Extracted so the decision is unit-testable and can't drift
+ * back to a length check.
+ */
+export function deriveUsageFooterFreshness(
+  results: readonly ProbeQuotaResultRow[],
+  staleCachedAtMs: number | undefined,
+  liveProbedAtMs: number,
+): UsageFooterFreshness {
+  if (staleCachedAtMs != null) return { staleCachedAtMs };
+  if (results.some((r) => r.result.ok)) return { liveProbedAtMs };
+  return { probeFailed: true };
+}
+
+/**
  * Given the broker's `listState` data + a parallel array of live quota
  * results (same length, same order), return the AccountSnapshot[] the
  * formatters need.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -42,6 +42,7 @@ import {
   resolveSafeBoundaryEnabled,
 } from './interrupt-defer.js'
 import { parseStopKeyword, buildStopReply } from './stop-command.js'
+import { shouldMaskUsageLabels } from './usage-mask.js'
 import { shouldPostBusyAck, formatBusyAckText, BUSY_ACK_STEP_AGE_THRESHOLD_MS } from './busy-ack.js'
 import {
   resolveStickerSendArgs,
@@ -877,7 +878,7 @@ import {
   decideAnnouncementDelivery,
   foldAnnouncementIntoCard,
 } from '../fallback-card-collapse.js'
-import { buildSnapshotsFromState, buildSnapshotsFromCachedState, zipProbeResults } from '../auth-snapshot-format.js'
+import { buildSnapshotsFromState, buildSnapshotsFromCachedState, zipProbeResults, deriveUsageFooterFreshness } from '../auth-snapshot-format.js'
 import { maskUsername } from '../demo-mask.js'
 import {
   writeTurnActiveMarker,
@@ -14333,6 +14334,26 @@ function isAuthorizedSender(ctx: Context): boolean {
   return false
 }
 
+// Adversarial-review F4 — a group configured with an EMPTY `allowFrom`
+// authorizes every member (isAuthorizedSender returns true for any sender in
+// that group). That's an intentional "whole-group" access mode, but it means
+// `/usage` would expose per-account email labels + quota headroom to every
+// member of a broadly-shared group. Harden minimally: for the quota-bearing
+// card in a non-private chat, mask account labels (reusing the demo-mask
+// machinery) UNLESS the group pinned a non-empty `allowFrom` — i.e. an
+// explicit operator-curated member list is treated as trusted enough to see
+// the real labels. Private (operator DM) chats are never masked. This changes
+// only what /usage REVEALS, not who may run it. The pure decision lives in
+// ./usage-mask.ts (shouldMaskUsageLabels) so it is unit-testable without
+// importing the whole gateway module.
+function shouldMaskAccountLabels(ctx: Context): boolean {
+  const groupAllowFrom =
+    ctx.chat?.type === 'group' || ctx.chat?.type === 'supergroup'
+      ? loadAccess().groups[String(ctx.chat.id)]?.allowFrom
+      : undefined
+  return shouldMaskUsageLabels(ctx.chat?.type, groupAllowFrom)
+}
+
 // safeName moved to ./media-message-handlers.ts (switchroom#2996 P6 cluster A);
 // imported above and shared with the attachment handlers still inline here.
 
@@ -21444,7 +21465,12 @@ bot.command('issues', async ctx => {
 })
 bot.command('usage', async ctx => {
   if (!isAuthorizedSender(ctx)) return
-  const demo = hasDemoFlag(getCommandArgs(ctx))
+  // `demo` is the explicit `/usage demo` opt-in mask. F4 additionally masks
+  // account labels for a non-private chat whose group has no pinned
+  // `allowFrom` (open-membership group) — see shouldMaskAccountLabels. The
+  // effective mask feeds the label-rendering paths (renderUsageCard,
+  // buildSnapshotKeyboard) exactly as `demo` did.
+  const demo = hasDemoFlag(getCommandArgs(ctx)) || shouldMaskAccountLabels(ctx)
   // Format 2 path: enumerate every account in the broker's known set,
   // probe live quota in parallel, render the health-grouped snapshot.
   // Falls back to the legacy single-agent shape when the broker is
@@ -21496,14 +21522,17 @@ bot.command('usage', async ctx => {
           // Honesty backstop: a TOTAL probe failure (the .catch above
           // returned `{results: []}` and nothing was served from cache)
           // must render an explicit "probe failed" marker, NOT a false
-          // "Live" stamp next to "⚠️ no data" rows. Without this the
-          // footer claimed "Live · refreshed 0s ago" while every account
-          // row said "no data — probe failed" (#2959 review finding).
-          ...(staleCachedAtMs != null
-            ? { staleCachedAtMs }
-            : probeResp.results.length > 0
-              ? { liveProbedAtMs: renderNow.getTime() }
-              : { probeFailed: true }),
+          // "Live" stamp next to "⚠️ no data" rows (#2959 review finding).
+          // Honesty invariant (adversarial-review F1): the live stamp is
+          // derived from whether ANY row carries usable data, NOT from the
+          // array length — a failed live probe against an empty cache returns
+          // a non-empty results array of all-`ok:false` rows. Full rationale
+          // in deriveUsageFooterFreshness (auth-snapshot-format.ts).
+          ...deriveUsageFooterFreshness(
+            probeResp.results,
+            staleCachedAtMs,
+            renderNow.getTime(),
+          ),
         })
         // Preserve the Switch/Refresh/usage/Add inline keyboard on the
         // rich-message render — the table card carries the same actions the

--- a/telegram-plugin/gateway/usage-mask.ts
+++ b/telegram-plugin/gateway/usage-mask.ts
@@ -1,0 +1,29 @@
+/**
+ * Adversarial-review F4 — account-label masking policy for the `/usage` card.
+ *
+ * A group configured with an EMPTY `allowFrom` authorizes every member
+ * (`isAuthorizedSender` returns true for any sender in that group). That is an
+ * intentional "whole-group" access mode, but it means `/usage` would expose
+ * per-account email labels + quota headroom to every member of a broadly
+ * shared group. This predicate decides whether to mask account labels for the
+ * quota-bearing card, reusing the existing demo-mask machinery:
+ *
+ *   - private (operator DM) chat  → never mask
+ *   - group / supergroup with a NON-empty pinned `allowFrom` → trusted,
+ *     operator-curated member list → don't mask
+ *   - group / supergroup with an EMPTY `allowFrom` (open membership) → mask
+ *   - any other chat type reaching a quota render → mask defensively
+ *
+ * This changes only what `/usage` REVEALS, not who may run it — general
+ * command authorization semantics are untouched.
+ */
+export function shouldMaskUsageLabels(
+  chatType: string | undefined,
+  groupAllowFrom: readonly string[] | undefined,
+): boolean {
+  if (chatType === 'private') return false
+  if (chatType === 'group' || chatType === 'supergroup') {
+    return (groupAllowFrom ?? []).length === 0
+  }
+  return true
+}

--- a/telegram-plugin/quota-check.ts
+++ b/telegram-plugin/quota-check.ts
@@ -252,11 +252,26 @@ export function formatQuotaBlock(q: QuotaUtilization, now: Date = new Date()): s
   const lines: string[] = [];
   lines.push("**Claude plan quota**");
   lines.push("");
+  // #2494 Bug C / adversarial-review F3 — a window whose utilization header
+  // was absent (a thin probe) has a numeric field that coalesced to 0, so a
+  // naive `${pct}%` renders a confident `0%` indistinguishable from a genuine
+  // fresh-account 0%. The modern bar card (quota-bar-format.ts ~200) already
+  // renders these as "no data"; backport that honesty here. The presence
+  // markers are optional — `undefined` means a legacy/real probe (render the
+  // percent); only an explicit `false` suppresses the number.
+  const fiveHour =
+    q.fiveHourUtilPresent === false
+      ? "no data"
+      : `\`${Math.round(q.fiveHourUtilizationPct)}%\``;
+  const sevenDay =
+    q.sevenDayUtilPresent === false
+      ? "no data"
+      : `\`${Math.round(q.sevenDayUtilizationPct)}%\``;
   lines.push(
-    `**5h window**  \`${Math.round(q.fiveHourUtilizationPct)}%\` · \`${formatResetRelative(q.fiveHourResetAt, now)}\``,
+    `**5h window**  ${fiveHour} · \`${formatResetRelative(q.fiveHourResetAt, now)}\``,
   );
   lines.push(
-    `**7d window**  \`${Math.round(q.sevenDayUtilizationPct)}%\` · \`${formatResetRelative(q.sevenDayResetAt, now)}\``,
+    `**7d window**  ${sevenDay} · \`${formatResetRelative(q.sevenDayResetAt, now)}\``,
   );
   if (q.representativeClaim) {
     lines.push("");

--- a/telegram-plugin/tests/quota-check.test.ts
+++ b/telegram-plugin/tests/quota-check.test.ts
@@ -118,6 +118,63 @@ describe('formatQuotaBlock', () => {
     })
     expect(block).toContain('Overage: disabled (spend_cap_reached)')
   })
+
+  it('renders "no data" (never a confident 0%) for an absent window header (F3)', () => {
+    // Adversarial-review F3 — a thin probe leaves the utilization field
+    // coalesced to 0 but flags the window absent. The legacy block renderer
+    // used to print a confident `0%`, indistinguishable from a genuine
+    // fresh-account 0%. Backport the modern card's handling: absent → no data.
+    const block = formatQuotaBlock({
+      fiveHourUtilizationPct: 0,
+      sevenDayUtilizationPct: 0,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+      fiveHourUtilPresent: false,
+      sevenDayUtilPresent: false,
+    })
+    const fiveLine = block.split('\n').find((l) => l.includes('5h window'))!
+    const sevenLine = block.split('\n').find((l) => l.includes('7d window'))!
+    expect(fiveLine).toContain('no data')
+    expect(sevenLine).toContain('no data')
+    // The confident-0% lie must be gone.
+    expect(fiveLine).not.toContain('`0%`')
+    expect(sevenLine).not.toContain('`0%`')
+  })
+
+  it('still renders the percent when a window is present but genuinely 0% (F3 guard)', () => {
+    const block = formatQuotaBlock({
+      fiveHourUtilizationPct: 0,
+      sevenDayUtilizationPct: 0,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+      fiveHourUtilPresent: true,
+      sevenDayUtilPresent: true,
+    })
+    expect(block).toContain('`0%`')
+    expect(block).not.toContain('no data')
+  })
+
+  it('renders the percent for legacy snapshots with no presence markers (F3 back-compat)', () => {
+    // Optional markers unset → real/legacy probe → render the number.
+    const block = formatQuotaBlock({
+      fiveHourUtilizationPct: 0,
+      sevenDayUtilizationPct: 5,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+    })
+    expect(block).toContain('`0%`')
+    expect(block).toContain('`5%`')
+    expect(block).not.toContain('no data')
+  })
 })
 
 describe('fetchQuota', () => {

--- a/telegram-plugin/tests/usage-footer-freshness.test.ts
+++ b/telegram-plugin/tests/usage-footer-freshness.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Adversarial-review F1 + F2 — the /usage card must NEVER stamp "Live" when
+ * no account row carries usable live data.
+ *
+ * Root cause (F1): the gateway `/usage` handler decided the freshness footer
+ * from `probeResp.results.length > 0`. But opProbeQuota
+ * (src/auth/broker/server.ts) returns `{result:{ok:false}, served:"live"}`
+ * for a failed live probe against an EMPTY cache — a non-empty results array
+ * where every row is `ok:false`. `zipProbeResults` only marks
+ * `served==="cache"` rows stale, so those failed rows carry no cache stamp
+ * either. Result: on a fresh restart (empty cache) + a transient probe
+ * failure, every row rendered "⚠️ no data — probe failed" UNDER a false
+ * "Live · refreshed 0s ago" stamp.
+ *
+ * F2 (test gap): the footer decision had zero coverage. This drives the
+ * extracted decision (`deriveUsageFooterFreshness`) composed with the real
+ * card renderer (`renderUsageCard`) with an all-`ok:false`, no-cache broker
+ * stub and asserts the rendered footer is NOT "Live" — i.e. it would fail
+ * against the pre-fix `.length > 0` gate.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  deriveUsageFooterFreshness,
+  type AccountSnapshot,
+  type ProbeQuotaResultRow,
+} from '../auth-snapshot-format.js'
+import { renderUsageCard } from '../quota-bar-format.js'
+
+const NOW = new Date('2026-07-19T12:00:00Z')
+
+// Two accounts, no usable quota (the probe failed, nothing cached) — mirrors
+// what the gateway hands renderUsageCard when the broker cache is empty and
+// the live probe threw for every account.
+const NO_DATA_SNAPSHOTS: AccountSnapshot[] = [
+  { label: 'alice@example.com', isActive: true, quota: null, quotaError: 'probe failed' },
+  { label: 'bob@example.com', isActive: false, quota: null, quotaError: 'probe failed' },
+]
+
+// A broker probe-quota response where every row failed and nothing was served
+// from cache — the exact shape opProbeQuota returns for a failed live probe
+// against an empty cache.
+const ALL_FAILED_NO_CACHE: ProbeQuotaResultRow[] = [
+  { label: 'alice@example.com', result: { ok: false, reason: 'network error' }, served: 'live' },
+  { label: 'bob@example.com', result: { ok: false, reason: 'network error' }, served: 'live' },
+]
+
+const EXHAUSTED = new Map<string, boolean>()
+
+describe('deriveUsageFooterFreshness (F1)', () => {
+  it('flags probeFailed when every row is ok:false and there is no cache', () => {
+    const opts = deriveUsageFooterFreshness(ALL_FAILED_NO_CACHE, undefined, NOW.getTime())
+    // Would have been { liveProbedAtMs } under the old `.length > 0` gate.
+    expect(opts).toEqual({ probeFailed: true })
+    expect(opts.liveProbedAtMs).toBeUndefined()
+  })
+
+  it('stamps liveProbedAtMs when at least one row carries usable data', () => {
+    const rows: ProbeQuotaResultRow[] = [
+      ALL_FAILED_NO_CACHE[0],
+      {
+        label: 'bob@example.com',
+        result: {
+          ok: true,
+          data: {
+            fiveHourUtilizationPct: 12,
+            sevenDayUtilizationPct: 34,
+            fiveHourResetAt: null,
+            sevenDayResetAt: null,
+            representativeClaim: null,
+            overageStatus: null,
+            overageDisabledReason: null,
+            fiveHourUtilPresent: true,
+            sevenDayUtilPresent: true,
+          },
+        },
+        served: 'live',
+      },
+    ]
+    const opts = deriveUsageFooterFreshness(rows, undefined, NOW.getTime())
+    expect(opts).toEqual({ liveProbedAtMs: NOW.getTime() })
+    expect(opts.probeFailed).toBeUndefined()
+  })
+
+  it('gives cache-served data precedence over both live and failed', () => {
+    const capturedAt = NOW.getTime() - 60_000
+    expect(deriveUsageFooterFreshness(ALL_FAILED_NO_CACHE, capturedAt, NOW.getTime())).toEqual({
+      staleCachedAtMs: capturedAt,
+    })
+  })
+
+  it('flags probeFailed for a totally empty results array', () => {
+    expect(deriveUsageFooterFreshness([], undefined, NOW.getTime())).toEqual({ probeFailed: true })
+  })
+})
+
+describe('/usage card footer end-to-end (F2)', () => {
+  it('renders "probe failed", NOT "Live", when no row carries live data', () => {
+    const freshness = deriveUsageFooterFreshness(ALL_FAILED_NO_CACHE, undefined, NOW.getTime())
+    const card = renderUsageCard(NO_DATA_SNAPSHOTS, EXHAUSTED, { now: NOW, ...freshness })
+    expect(card).toContain('probe failed — no live data')
+    // The honesty invariant: no "Live" stamp when every row shows no data.
+    expect(card).not.toContain('Live')
+    // And the rows themselves are the no-data warning, not a fake 0% bar.
+    expect(card).toContain('no data — probe failed')
+  })
+
+  it('renders a "Live" footer when a row carries usable data', () => {
+    const liveSnapshots: AccountSnapshot[] = [
+      {
+        label: 'bob@example.com',
+        isActive: true,
+        quota: {
+          fiveHourUtilizationPct: 12,
+          sevenDayUtilizationPct: 34,
+          fiveHourResetAt: null,
+          sevenDayResetAt: null,
+          representativeClaim: null,
+          overageStatus: null,
+          overageDisabledReason: null,
+          fiveHourUtilPresent: true,
+          sevenDayUtilPresent: true,
+        },
+      },
+    ]
+    const freshness = deriveUsageFooterFreshness(
+      [
+        {
+          label: 'bob@example.com',
+          result: { ok: true, data: liveSnapshots[0].quota! },
+          served: 'live',
+        },
+      ],
+      undefined,
+      NOW.getTime(),
+    )
+    const card = renderUsageCard(liveSnapshots, EXHAUSTED, { now: NOW, ...freshness })
+    expect(card).toContain('Live · refreshed')
+    expect(card).not.toContain('probe failed')
+  })
+})

--- a/telegram-plugin/tests/usage-mask.test.ts
+++ b/telegram-plugin/tests/usage-mask.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Adversarial-review F4 — `/usage` account-label masking policy.
+ *
+ * A group with an empty `allowFrom` authorizes every member, so the quota
+ * card would leak per-account email labels to a broadly shared group unless
+ * masked. `shouldMaskUsageLabels` (gateway/usage-mask.ts) is the pure
+ * decision the gateway feeds into the existing demo-mask machinery.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { shouldMaskUsageLabels } from '../gateway/usage-mask.js'
+
+describe('shouldMaskUsageLabels (F4)', () => {
+  it('never masks in a private (operator DM) chat', () => {
+    expect(shouldMaskUsageLabels('private', undefined)).toBe(false)
+    expect(shouldMaskUsageLabels('private', [])).toBe(false)
+    expect(shouldMaskUsageLabels('private', ['123'])).toBe(false)
+  })
+
+  it('masks in a group with an EMPTY allowFrom (open membership)', () => {
+    expect(shouldMaskUsageLabels('group', [])).toBe(true)
+    expect(shouldMaskUsageLabels('group', undefined)).toBe(true)
+    expect(shouldMaskUsageLabels('supergroup', [])).toBe(true)
+  })
+
+  it('does NOT mask in a group with a curated non-empty allowFrom', () => {
+    expect(shouldMaskUsageLabels('group', ['123'])).toBe(false)
+    expect(shouldMaskUsageLabels('supergroup', ['123', '456'])).toBe(false)
+  })
+
+  it('masks defensively for any other chat type reaching a quota render', () => {
+    expect(shouldMaskUsageLabels('channel', undefined)).toBe(true)
+    expect(shouldMaskUsageLabels(undefined, undefined)).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #3411.

Four findings from an adversarial review of the `/usage` Telegram command. One focused PR.

## F1 (medium, accuracy) — false "Live" stamp on a failed no-cache probe
The `/usage` handler decided the freshness footer from `probeResp.results.length > 0`. But `opProbeQuota` (`src/auth/broker/server.ts`) returns `{result:{ok:false}, served:"live"}` for a failed live probe against an empty cache — a **non-empty** results array where every row is `ok:false`, and `zipProbeResults` leaves those rows without a cache marker. Fresh restart (empty cache) + transient probe failure ⇒ every row rendered `⚠️ no data — probe failed` under a false `Live · refreshed 0s ago` stamp.

Fix: extracted `deriveUsageFooterFreshness` (`telegram-plugin/auth-snapshot-format.ts`), keying the live stamp on `results.some(r => r.result.ok)` (cache > live > probe-failed precedence). The extraction makes the decision unit-testable and stops it drifting back to a length check.

## F2 (medium, test gap)
`telegram-plugin/tests/usage-footer-freshness.test.ts` drives the extracted decision composed with the real `renderUsageCard` against an all-`ok:false` no-cache broker stub and asserts the footer is NOT "Live" (would fail against the old `.length > 0` gate), plus the live/cache-precedence branches.

## F3 (low-medium, accuracy)
`formatQuotaBlock` (legacy fallback renderer, `telegram-plugin/quota-check.ts`) ignored `fiveHourUtilPresent`/`sevenDayUtilPresent` and rendered a confident `0%` for an absent window header. Backported the modern card's handling — absent ⇒ "no data", never 0% — with the present-0% and legacy-unset back-compat cases guarded.

## F4 (low, info exposure)
A group with an empty `allowFrom` authorizes every member, exposing account email labels via `/usage`. The quota card now masks account labels in non-private chats unless the group pinned a non-empty `allowFrom`, reusing the existing demo-mask machinery. Pure predicate extracted to `telegram-plugin/gateway/usage-mask.ts` with unit tests. General command authorization semantics unchanged.

## Tests
- `usage-footer-freshness.test.ts` (6), `usage-mask.test.ts` (4), `quota-check.test.ts` (+3, F3) — 26 scoped tests green locally.
- `npm run lint` clean (tsc + all guards, incl. bot-api-wrapping and gateway line ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)