### PR TITLE
fix(pacer): gate the /v1/messages router path (H3)

### DIFF
--- a/docker/litellm-pacer/custom_pacing.py
+++ b/docker/litellm-pacer/custom_pacing.py
@@ -13,9 +13,22 @@ Mechanism (deterministic, version-independent, config-only-impossible under
 LiteLLM v3's per-key reject-based limiter):
 
   * Runs as a LiteLLM CustomLogger callback. Its async_pre_call_hook is
-    invoked on the /anthropic passthrough path (call_type ==
-    "pass_through_endpoint") — verified against litellm v1.91
-    proxy/utils.py::pre_call_hook + pass_through_endpoints.py:845.
+    invoked on BOTH subscription-Claude paths — verified against litellm
+    v1.91.0:
+      - the /anthropic PASSTHROUGH path (call_type ==
+        "pass_through_endpoint" — proxy/utils.py::pre_call_hook +
+        pass_through_endpoints.py:845), and
+      - the /v1/messages ROUTER path (call_type == "anthropic_messages" —
+        proxy/endpoints.py route_type; exactly one pre_call per request,
+        no double-pacing).
+    The passthrough path is always paced (it has no routable group). The
+    router path is gated on an explicit paced-GROUP allowlist
+    (PACE_MODEL_GROUPS), because data["model"] on the router path is the
+    requested GROUP name (pre-routing), not the resolved deployment: e.g.
+    subscription-Claude aliases "sonnet"/"fable" and "claude-*" ARE paced,
+    but OpenRouter groups like "claude-sonnet-5-openrouter" are NOT (their
+    upstream limits differ from the fleet's Anthropic account, so the
+    Anthropic cooldown must not hold them).
   * Bounded global CONCURRENCY: at most PACE_MAX_CONCURRENCY upstream
     requests in flight across all 8 proxy workers, coordinated in Redis
     via a self-healing sorted-set lease (missed releases age out after
@@ -48,6 +61,7 @@ the proxy's sys.path). See PLAN.md for exact compose + apply steps.
 """
 
 import asyncio
+import fnmatch
 import os
 import random
 import time
@@ -70,6 +84,19 @@ def _float_env(name: str, default: float) -> float:
         return float(os.getenv(name, str(default)))
     except Exception:
         return default
+
+
+def _csv_env(name: str, default_csv: str) -> list[str]:
+    """Parse a comma-separated env list into a list of stripped, non-empty
+    entries. Falls back to the default CSV when the env is unset. Never
+    raises — a bad value degrades to the default."""
+    try:
+        raw = os.getenv(name)
+        if raw is None:
+            raw = default_csv
+        return [x.strip() for x in raw.split(",") if x.strip()]
+    except Exception:
+        return [x.strip() for x in default_csv.split(",") if x.strip()]
 
 
 # The gateway nulls a silent turn at SILENCE_FALLBACK_MS (default 300000ms /
@@ -154,8 +181,37 @@ class _Cfg:
     # Master on/off. Set PACE_ENABLED=false to make the hook a pure no-op
     # without touching config wiring.
     ENABLED = os.getenv("PACE_ENABLED", "true").lower() != "false"
-    # Only pace these call types. Passthrough is what agents use.
-    CALL_TYPES = {"pass_through_endpoint"}
+    # Only pace these call types. Both are subscription-Claude paths:
+    #   * "pass_through_endpoint" — the /anthropic passthrough (always paced;
+    #     no routable group).
+    #   * "anthropic_messages"   — the /v1/messages ROUTER path (paced only
+    #     when its GROUP is in the PACE_MODEL_GROUPS allowlist below).
+    # Env-overridable as a comma list (PACE_CALL_TYPES).
+    CALL_TYPES = set(
+        _csv_env("PACE_CALL_TYPES", "pass_through_endpoint,anthropic_messages")
+    )
+    # The passthrough call type carries no routable model GROUP, so it is
+    # never subject to the group allowlist below — it is paced whenever its
+    # call type is enabled. Every OTHER call type in CALL_TYPES is treated as
+    # a router path and gated on PACE_MODEL_GROUPS.
+    PASSTHROUGH_CALL_TYPE = os.getenv(
+        "PACE_PASSTHROUGH_CALL_TYPE", "pass_through_endpoint"
+    )
+    # Explicit allowlist of paced router GROUP names (fnmatch globs allowed).
+    # Seeded to cover the live subscription-Claude groups: the "claude-*"
+    # family plus the "sonnet"/"fable" aliases agents actually request (all
+    # carry forward_client_headers_to_llm_api:true in litellm-config.yaml).
+    # An explicit allowlist — NOT a "claude-*" prefix heuristic — because that
+    # heuristic is wrong both ways: "sonnet"/"fable" don't match it (would
+    # stay unpaced) and "claude-sonnet-5-openrouter" DOES match it (would be
+    # wrongly held by the Anthropic cooldown though it is an OpenRouter group).
+    PACE_MODEL_GROUPS = _csv_env("PACE_MODEL_GROUPS", "claude-*,sonnet,fable")
+    # Exclusion globs applied AFTER the allowlist (exclusion wins). Keeps any
+    # "*-openrouter" group out even though it may match "claude-*", since its
+    # upstream rate limits are OpenRouter's, not the fleet Anthropic account's.
+    PACE_MODEL_GROUPS_EXCLUDE = _csv_env(
+        "PACE_MODEL_GROUPS_EXCLUDE", "*-openrouter"
+    )
 
     REDIS_HOST = os.getenv("REDIS_HOST", "redis")
     REDIS_PORT = _int_env("REDIS_PORT", 6379)
@@ -294,6 +350,40 @@ class FleetPacer(CustomLogger):
         except Exception:
             pass
 
+    # ----- gating ------------------------------------------------------
+    @staticmethod
+    def _group_of(data: Any) -> Optional[str]:
+        """The requested model GROUP name on the router path. On /v1/messages
+        the pre_call hook sees the pre-routing group in data["model"], not the
+        resolved deployment."""
+        if isinstance(data, dict):
+            m = data.get("model")
+            if isinstance(m, str) and m:
+                return m
+        return None
+
+    @staticmethod
+    def _group_is_paced(group: Optional[str]) -> bool:
+        """A router GROUP is paced iff it matches the PACE_MODEL_GROUPS
+        allowlist AND is not excluded by PACE_MODEL_GROUPS_EXCLUDE
+        (exclusion wins). Unknown group -> not paced (can't attribute it to
+        the fleet Anthropic account)."""
+        if not group:
+            return False
+        if any(fnmatch.fnmatch(group, pat) for pat in _Cfg.PACE_MODEL_GROUPS_EXCLUDE):
+            return False
+        return any(fnmatch.fnmatch(group, pat) for pat in _Cfg.PACE_MODEL_GROUPS)
+
+    def _should_pace(self, call_type: str, data: Any) -> bool:
+        """Decide whether this request participates in pacing. Passthrough is
+        always paced (no routable group); every other enabled call type is a
+        router path gated on the paced-GROUP allowlist."""
+        if call_type not in _Cfg.CALL_TYPES:
+            return False
+        if call_type == _Cfg.PASSTHROUGH_CALL_TYPE:
+            return True
+        return self._group_is_paced(self._group_of(data))
+
     # ----- LiteLLM hooks ----------------------------------------------
     async def async_pre_call_hook(
         self,
@@ -302,8 +392,10 @@ class FleetPacer(CustomLogger):
         data: dict,
         call_type: str,
     ):
-        # Fast bail: disabled, wrong call type, or bad payload -> no-op.
-        if not _Cfg.ENABLED or call_type not in _Cfg.CALL_TYPES or not isinstance(data, dict):
+        # Fast bail: disabled, bad payload, or not a paced request -> no-op.
+        # Router-path traffic (e.g. anthropic_messages) is paced only when its
+        # requested GROUP is in the allowlist; passthrough is always paced.
+        if not _Cfg.ENABLED or not isinstance(data, dict) or not self._should_pace(call_type, data):
             return data
 
         r = await self._get_redis()

--- a/docker/litellm-pacer/test_custom_pacing.py
+++ b/docker/litellm-pacer/test_custom_pacing.py
@@ -594,5 +594,133 @@ class ReleaseJitterTests(_CfgPatchMixin, unittest.TestCase):
         self.assertTrue(all(0.10 <= x <= 0.40 for x in holding))
 
 
+# --- Router-path gating (H3: pacer must gate the /v1/messages router path) ---
+# The pacer historically paced only the /anthropic PASSTHROUGH path
+# (call_type "pass_through_endpoint"). Live litellm v1.91.0 routes /v1/messages
+# traffic through the ROUTER with call_type "anthropic_messages", which was
+# left UNPACED — reopening the burst-storm H3 for the aliases agents use. These
+# tests pin the corrected gate: an explicit paced-GROUP allowlist, NOT a
+# "claude-*" prefix heuristic (which is wrong both ways — see custom_pacing.py).
+class RouterGatePureTests(unittest.TestCase):
+    """Pure decision surface: _should_pace / _group_is_paced. No redis."""
+
+    def setUp(self):
+        self.pacer = custom_pacing.FleetPacer()
+
+    def _pace(self, call_type, model=None):
+        data = {} if model is None else {"model": model}
+        return self.pacer._should_pace(call_type, data)
+
+    def test_passthrough_always_paced_no_group(self):
+        # Existing behaviour preserved: passthrough is paced with no model group.
+        self.assertTrue(self._pace("pass_through_endpoint"))
+
+    def test_router_sonnet_alias_paced(self):
+        # Live subscription-Claude alias (config line 146) — MUST be paced even
+        # though it does NOT match a "claude-*" prefix.
+        self.assertTrue(self._pace("anthropic_messages", "sonnet"))
+
+    def test_router_fable_alias_paced(self):
+        # Live subscription-Claude alias (config line 158) — MUST be paced.
+        self.assertTrue(self._pace("anthropic_messages", "fable"))
+
+    def test_router_claude_group_paced(self):
+        self.assertTrue(self._pace("anthropic_messages", "claude-opus-4-5"))
+        self.assertTrue(self._pace("anthropic_messages", "claude-sonnet-4-5"))
+
+    def test_router_openrouter_claude_group_not_paced(self):
+        # "claude-sonnet-5-openrouter" (config line 309) MATCHES a claude-*
+        # prefix but is OpenRouter — must NOT be held by the Anthropic cooldown.
+        self.assertFalse(self._pace("anthropic_messages", "claude-sonnet-5-openrouter"))
+
+    def test_router_non_claude_openrouter_not_paced(self):
+        self.assertFalse(self._pace("anthropic_messages", "gpt-5-openrouter"))
+        self.assertFalse(self._pace("anthropic_messages", "kimi-k2-openrouter"))
+
+    def test_router_unknown_group_not_paced(self):
+        # Can't attribute an out-of-allowlist / missing group to the fleet
+        # Anthropic account -> do not pace.
+        self.assertFalse(self._pace("anthropic_messages", "some-random-group"))
+        self.assertFalse(self._pace("anthropic_messages"))
+
+    def test_disabled_call_type_not_paced(self):
+        self.assertFalse(self._pace("acompletion", "claude-opus-4-5"))
+
+    def test_default_call_types_cover_both_paths(self):
+        # Regression: the vendored defaults must include BOTH the passthrough
+        # and the router call types (read from source so runner env can't mask).
+        src = os.path.join(os.path.dirname(__file__), "custom_pacing.py")
+        with open(src, "r", encoding="utf-8") as fh:
+            source = fh.read()
+        self.assertIn("pass_through_endpoint,anthropic_messages", source)
+
+
+class RouterGateHookTests(_CfgPatchMixin, unittest.IsolatedAsyncioTestCase):
+    """Drive the real async_pre_call_hook to prove the gate actually engages /
+    bypasses the wait loop for router traffic. A paced request hits redis
+    (eval_calls>0); a no-op request never touches it (eval_calls==0)."""
+
+    async def _run(self, r, call_type, model=None):
+        pacer = custom_pacing.FleetPacer()
+        pacer._redis = r  # bypass _get_redis
+        data = {} if model is None else {"model": model}
+        custom_pacing._Cfg.MAX_WAIT_S = 0.15
+        custom_pacing._Cfg.HARD_MAX_WAIT_S = 0.2
+        custom_pacing._Cfg.COOLDOWN_HOLD = False
+        return await pacer.async_pre_call_hook(None, None, data, call_type)
+
+    async def test_router_sonnet_enters_pacer(self):
+        r = FakeRedis(eval_result=0)  # deny -> forces the wait loop
+        await self._run(r, "anthropic_messages", "sonnet")
+        self.assertGreaterEqual(r.eval_calls, 1)
+
+    async def test_router_openrouter_is_noop(self):
+        r = FakeRedis(eval_result=0)
+        data_back = await self._run(r, "anthropic_messages", "claude-sonnet-5-openrouter")
+        self.assertEqual(r.eval_calls, 0)  # never entered the pacer
+        self.assertIsInstance(data_back, dict)
+
+    async def test_passthrough_still_paced(self):
+        r = FakeRedis(eval_result=0)
+        await self._run(r, "pass_through_endpoint")
+        self.assertGreaterEqual(r.eval_calls, 1)
+
+
+class RouterCooldownHoldsTests(_CfgPatchMixin, unittest.IsolatedAsyncioTestCase):
+    """LOAD-BEARING H3 fix: a fleet cooldown SET by a router-path 429 must now
+    HOLD a subsequent router-path admission. Pre-fix the router pre_call was a
+    no-op, so the cooldown (though set) never gated router traffic."""
+
+    async def test_router_429_cooldown_holds_router_admission(self):
+        custom_pacing._Cfg.COOLDOWN_HOLD = True
+        custom_pacing._Cfg.MAX_WAIT_S = 0.2
+        custom_pacing._Cfg.COOLDOWN_HOLD_CEILING_S = 1.0
+        custom_pacing._Cfg.HARD_MAX_WAIT_S = 5.0
+
+        pacer = custom_pacing.FleetPacer()
+        r = FakeRedis(eval_result=0)  # never admit -> exercise the hold
+        pacer._redis = r
+
+        # A router-path (anthropic_messages) request 429s and parks the fleet
+        # cooldown (failure hook is ungated on call_type — it always sets it).
+        exc = types.SimpleNamespace(
+            status_code=429, message="would exceed your account rate limit"
+        )
+        await pacer.async_post_call_failure_hook(
+            {"model": "sonnet"}, exc, None
+        )
+        self.assertIn(custom_pacing._COOLDOWN_KEY, r.store)
+
+        # A subsequent router-path admission for a paced group must HOLD past
+        # the short burst ceiling because it now honours that cooldown.
+        t0 = time.time()
+        await pacer.async_pre_call_hook(None, None, {"model": "sonnet"}, "anthropic_messages")
+        elapsed = time.time() - t0
+        self.assertGreater(elapsed, custom_pacing._Cfg.MAX_WAIT_S + 0.15)
+        self.assertLessEqual(
+            elapsed, custom_pacing._Cfg.COOLDOWN_HOLD_CEILING_S + 0.4
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## H3 — pacer must gate the router path

The fleet pacer (`docker/litellm-pacer/custom_pacing.py`) only paced the `/anthropic` **passthrough** path (`call_type == "pass_through_endpoint"`). On live litellm **v1.91.0**, `/v1/messages` traffic is routed through the **router** with `call_type == "anthropic_messages"` (verified) — that path was **unpaced**, reopening the burst-storm H3 for the subscription-Claude aliases agents actually request (`sonnet`, `fable`).

### Change
- `CALL_TYPES` now includes `anthropic_messages`, env-overridable via `PACE_CALL_TYPES` (comma list).
- Router traffic is gated on an **explicit paced-GROUP allowlist** `PACE_MODEL_GROUPS` (default `claude-*,sonnet,fable`) with an exclusion list `PACE_MODEL_GROUPS_EXCLUDE` (default `*-openrouter`, exclusion wins) — **not** a `claude-*` prefix heuristic.

### Corrected gating (red-team item 1)
The `claude-*` prefix heuristic is wrong **both** directions:
- `sonnet` (config :146) and `fable` (:158) are subscription-Claude (`forward_client_headers_to_llm_api:true`) but do **not** match `claude-*` → would stay **unpaced**.
- `claude-sonnet-5-openrouter` (:309) **matches** `claude-*` but is OpenRouter → would be **wrongly held** by the Anthropic fleet cooldown.

The pre_call hook sees the **pre-routing GROUP** name in `data["model"]`, not the resolved deployment. Passthrough is always paced (no routable group). Exactly one pre_call per request — no double-pacing. The already-ungated failure hook keeps setting cooldowns from router-path 429s; this change makes router **admission** actually honour them.

### Tests (`test_custom_pacing.py`)
- Router `sonnet` / `fable` / `claude-*` → **paced**.
- Router `claude-sonnet-5-openrouter` and non-Claude `*-openrouter` → **NO-OP**.
- Passthrough behaviour **unchanged**.
- A cooldown set by a router-path 429 now **HOLDS** a subsequent router-path admission.
- Confirmed failing pre-fix (3 failures + 8 errors); 49 tests green post-fix.

Header comment updated from passthrough-only to both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)