### PR TITLE
fix(progress-card): durable status-pin rows, per-key reconcile serialization, fork model

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -652,6 +652,7 @@ import {
   mutateStatusPinRow,
   reconcileAndPersistStatusPin,
   runStatusPinBootCleanup,
+  withPinReconcileLock,
   type PersistedStatusPin,
   type StatusPinPersistOp,
 } from './status-pin-store.js'
@@ -8441,6 +8442,10 @@ const PIN_STATUS_WHILE_WORKING = (() => {
 // handlers unconditionally unpinning on every send) and runs NO polling
 // watchdog / getChat().pinned_message reconciler.
 const statusPinState = new Map<string, PinState>()
+// F2 serialization: same-pinKey reconciles run one-at-a-time via
+// `withPinReconcileLock` (status-pin-store.ts — kept there so it's
+// unit-testable) so each reads a fresh `prev`; see its doc for the stale-`prev`
+// race it closes. Adds zero Telegram API calls (a serialized noop still no-ops).
 // Companion registry: pinKey → chatId, so the pre-restart sweep can unpin
 // owned pins without threading the chat id through every call site. Written on
 // every desired-pinned reconcile, cleared alongside the state on unpin.
@@ -9024,7 +9029,10 @@ async function reconcileStatusPin(
   // absorbed. (The `pin_message` MCP tool still surfaces failures to the agent
   // as a normal tool-error — that path is `executePinMessage`, not this one.)
   try {
-    await reconcileStatusPinInner(pinKey, chatId, desired)
+    // Serialize per pinKey (F2): reconcileStatusPinInner reads `prev` from the
+    // in-memory claim map at its top, so overlapping same-key reconciles must
+    // run one-at-a-time or a stale `prev` clears the disk row under a live pin.
+    await withPinReconcileLock(pinKey, () => reconcileStatusPinInner(pinKey, chatId, desired))
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     process.stderr.write(
@@ -9041,14 +9049,11 @@ async function reconcileStatusPinInner(
 ): Promise<void> {
   if (!PIN_STATUS_WHILE_WORKING) return
   if (chatId.length === 0) return
-  // NOTE (invisible-worker-cards review, intentionally left): this reconcile is
-  // NOT serialized per pinKey — it snapshots `prev` then awaits. Two edits that
-  // fire `syncPin` in the same microtask window after a dropped claim can both
-  // read `prev=null` and both issue a `pinChatMessage` for the SAME id. That is
-  // benign and self-healing: re-pinning an already-pinned id is idempotent on
-  // Telegram, and the first reconcile to set the claim makes every subsequent
-  // edit a no-op — it converges in one round, never a storm. A per-key mutex
-  // would remove the duplicate pin but adds lock complexity for zero UX gain.
+  // Serialized per pinKey by `withPinReconcileLock` at the caller (F2), so this
+  // `prev` snapshot is taken only after any prior same-key reconcile fully
+  // settled — always the true current claim. Closes the stale-`prev` race (a
+  // turn-end clear dropping the disk row under a flood-delayed open-pin) and the
+  // older duplicate-pin concern (two edits both reading prev=null).
   const prev = statusPinState.get(pinKey) ?? null
 
   const runReconcile = () =>

--- a/telegram-plugin/gateway/narrative-lane.ts
+++ b/telegram-plugin/gateway/narrative-lane.ts
@@ -389,7 +389,18 @@ export function createNarrativeLane(deps: NarrativeLaneDeps) {
             // mid-turn has something to finalize on next boot instead of
             // leaving this card frozen forever. Fire-and-forget/best-effort:
             // a failed persist degrades to the pre-fix (in-memory-only)
-            // behaviour, never blocks the card opening.
+            // behaviour, never blocks the card opening (writeActivityCardRecord
+            // → persistActivityCards swallows write errors — it never throws).
+            //
+            // F6 (persist-intent-first ordering): this write is the FIRST action
+            // taken after the send resolves and BEFORE the status-pin reconcile
+            // below — no `await` sits between the send and this persist, so the
+            // crash window in which a sent card has no durable record (and is
+            // thus unreapable by the boot reaper) is the minimum achievable. A
+            // true pre-send provisional record is impossible: the reaper keys
+            // its finalizing edit on `activityMessageId`, which only exists once
+            // sendRichMessage returns. Keep this persist synchronous and ahead
+            // of the pin; do not move it after an await.
             if (activityCardPersistEnabled) {
               writeActivityCardRecord(ACTIVITY_CARD_STORE_PATH, activityCardStoreFs, {
                 turnKey: statusKey(chat, thread),
@@ -397,15 +408,18 @@ export function createNarrativeLane(deps: NarrativeLaneDeps) {
                 threadId: thread ?? null,
                 activityMessageId: sent.message_id,
                 startedAt: turn.startedAt,
-                // Mirror the ACTUAL pin decision, not an unconditional `true`:
-                // the OPEN below silently-pins the fresh card only when
-                // `PIN_STATUS_WHILE_WORKING` is on (`reconcileStatusPin` no-ops
-                // when it's off, and can also fail on missing supergroup
-                // rights). Persisting `pinned: true` regardless would make the
-                // boot reaper attempt an unpin on a card that was never pinned.
-                // The reaper's unpin is defense-in-depth anyway
+                // F5 (persist-intent honesty): mirror the ACTUAL pin decision,
+                // not an unconditional `true`. The OPEN below silently-pins the
+                // fresh card only when `PIN_STATUS_WHILE_WORKING` is on
+                // (`reconcileStatusPin` no-ops when it's off, and can also fail
+                // on missing supergroup rights). Persisting `pinned: true`
+                // regardless would make the boot reaper attempt an unpin on a
+                // card that was never pinned. The persist is intentionally
+                // written BEFORE the fire-and-forget pin resolves (intent, not
+                // outcome); the reaper's unpin is idempotent defense-in-depth
                 // (`statusPinBootCleanup` owns the primary unpin), so tracking
-                // the flag honestly is what matters here.
+                // the DECISION honestly — pinned iff we will actually attempt a
+                // pin — is what matters here, not the async pin's result.
                 pinned: PIN_STATUS_WHILE_WORKING,
               })
             }

--- a/telegram-plugin/gateway/status-pin-store.ts
+++ b/telegram-plugin/gateway/status-pin-store.ts
@@ -314,6 +314,40 @@ export function withStoreLock<T>(
 }
 
 /**
+ * Per-pinKey async serial lock (F2, invisible-worker-cards review).
+ *
+ * The gateway's status-pin reconcile reads its `prev` claim from an in-memory
+ * map at the TOP of the reconcile, then awaits the persist+pin. Two overlapping
+ * reconciles for the SAME key could each capture a stale `prev`: a turn-end
+ * `{pinned:false}` reading prev=null no-ops and clears the durable row while a
+ * flood-delayed open-pin lands right after — a stuck pin with NO on-disk record.
+ *
+ * Chaining every reconcile for one pinKey through this tail map guarantees the
+ * NEXT reconcile reads `prev` only after the prior one for that key has fully
+ * settled (its in-memory Maps updated), so the pin decision always sees the true
+ * current claim. Different keys never contend. Same non-rejecting-tail contract
+ * as `withStoreLock`. Keyed by pinKey, held by the gateway around the WHOLE
+ * read-prev → decide → reconcileAndPersistStatusPin → update-Maps sequence.
+ */
+const pinReconcileTails = new Map<string, Promise<unknown>>()
+
+export function withPinReconcileLock<T>(
+  pinKey: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev = pinReconcileTails.get(pinKey) ?? Promise.resolve()
+  const run = prev.then(fn, fn)
+  pinReconcileTails.set(
+    pinKey,
+    run.then(
+      () => undefined,
+      () => undefined,
+    ),
+  )
+  return run
+}
+
+/**
  * READ-MODIFY-WRITE for exactly ONE pinKey's row, against the authoritative
  * on-disk file. Loads the current snapshot from disk, drops any row for
  * `pinKey`, appends `row` (unless null = removal), and persists atomically.
@@ -431,11 +465,37 @@ export function reconcileAndPersistStatusPin(args: {
       return next
     }
 
-    // clear: unpin (best-effort) THEN drop the record. Ordering is safe here —
-    // if we crash after the unpin but before the rewrite, the stale record just
-    // gets unpinned again next boot (idempotent), never a lingering pin.
+    // clear: unpin (best-effort) THEN reconcile the record with the OUTCOME.
+    //
+    // F1 (invisible-worker-cards review): a `clear` op covers BOTH a genuine
+    // unpin AND a `noop: already pinned` — the pin decision maps every non-`pin`
+    // action here (see decidePinAction → the gateway's op mapping). For a real
+    // unpin, applyPin drops the claim and returns null → we remove the row. But
+    // for a noop-already-pinned, reconcilePin returns the LIVE claim unchanged
+    // (non-null) and issues NO Telegram call — the pin is still up. The worker
+    // feed calls syncPin on EVERY steady-state edit, so a noop-clear fires
+    // constantly; unconditionally deleting the row there erased the durable
+    // status-pins.json entry for a still-live pin. A crash after that left a
+    // stuck pinned card boot cleanup could never see. So: only drop the row when
+    // the claim is actually gone (next == null); when applyPin returns a live
+    // claim, PRESERVE the row (rewritten confirmed) so the durable record keeps
+    // tracking the pin that is genuinely still up. No extra Telegram API call is
+    // added — applyPin already ran; this only changes the disk write's content.
+    // Ordering for the real-unpin case is safe: if we crash after the unpin but
+    // before the rewrite, the stale record just gets unpinned again next boot
+    // (idempotent), never a lingering pin.
     const next = await args.applyPin()
-    applyStatusPinRow(path, fs, pinKey, null, log)
+    if (next == null) {
+      applyStatusPinRow(path, fs, pinKey, null, log)
+    } else {
+      applyStatusPinRow(
+        path,
+        fs,
+        pinKey,
+        { pinKey, chatId, messageId: next.messageId },
+        log,
+      )
+    }
     return next
   })
 }

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -360,6 +360,22 @@ function main() {
   }
 
   const input = event.tool_input ?? {}
+  // F3 (progress-card fork model): a FORK dispatch (`subagent_type === 'fork'`)
+  // inherits the PARENT session's model and IGNORES any `tool_input.model`
+  // override. Seeding the row's first-paint model from that ignored override
+  // makes the worker card show a WRONG model (e.g. "sonnet" while the fork
+  // actually runs Opus) until the watcher overwrites it from the fork's own
+  // transcript. Suppress the dispatch-time seed for forks — leave model NULL so
+  // the card omits the model rather than showing a value the fork won't honor;
+  // the transcript-sourced model then paints as soon as the first assistant
+  // line lands (transcript wins, exactly as for non-fork workers). Fixing it at
+  // the seed source (not downstream in worker-feed-dispatch) keeps the
+  // transcript-confirmed model flowing to the terminal card unchanged.
+  const isFork = input.subagent_type === 'fork'
+  const dispatchModel =
+    !isFork && typeof input.model === 'string' && input.model.length > 0
+      ? input.model
+      : null
   // Resolve parent_turn_key from the live turn-active marker (the turn whose
   // tool call is dispatching this sub-agent). Claude Code's PreToolUse payload
   // carries only its own session id, never the gateway-minted Telegram turn_key
@@ -384,8 +400,9 @@ function main() {
       // BEFORE the sub-agent writes its first assistant line. Persisted so the
       // card can render the model from dispatch; the watcher later overwrites it
       // from the worker's own transcript (transcript wins). Only a non-empty
-      // string is stored — never guess from config.
-      model: typeof input.model === 'string' && input.model.length > 0 ? input.model : null,
+      // string is stored — never guess from config. NULL for a fork dispatch,
+      // which ignores the model override (see dispatchModel above, F3).
+      model: dispatchModel,
       now: Date.now(),
     },
     (err) => {

--- a/telegram-plugin/tests/activity-card-wiring.test.ts
+++ b/telegram-plugin/tests/activity-card-wiring.test.ts
@@ -58,6 +58,53 @@ describe('activity-card durability wiring', () => {
     expect(recordCode).not.toMatch(/pinned: true/)
   })
 
+  // F6 (persist-intent-first ordering): the durable record must be written in
+  // the SAME synchronous block as the send, BEFORE the status-pin reconcile and
+  // with NO `await` between the send resolving and the persist — otherwise the
+  // crash window in which a sent card has no reapable record reopens. Structural
+  // lock (the gateway IIFE can't be instantiated in-process); complements the
+  // behavioural store/reaper tests in activity-card-store.test.ts.
+  it('(F6) persists the record BEFORE the status-pin reconcile, with no await between send and persist', () => {
+    const openBranch = between(
+      laneSrc,
+      'if (turn.activityMessageId == null) {',
+      'turn.activityLastSentRender = target',
+    )
+    const persistIdx = openBranch.indexOf('writeActivityCardRecord(')
+    const pinIdx = openBranch.indexOf('void reconcileStatusPin(')
+    expect(persistIdx).toBeGreaterThanOrEqual(0)
+    expect(pinIdx).toBeGreaterThanOrEqual(0)
+    // Persist-intent-first: the record write precedes the pin reconcile.
+    expect(persistIdx).toBeLessThan(pinIdx)
+    // No `await` sits between the send returning and the persist — the whole
+    // window from `const sent =` to writeActivityCardRecord( is synchronous.
+    const sendToPersist = between(openBranch, 'const sent = await robustApiCall', 'writeActivityCardRecord(')
+    const codeOnly = sendToPersist
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*'))
+      .join('\n')
+    expect(codeOnly).not.toMatch(/\bawait\b/)
+  })
+
+  // F5 (persist-intent honesty): the persisted `pinned` mirrors the ACTUAL pin
+  // decision (PIN_STATUS_WHILE_WORKING), never a bare `pinned: true`. This is
+  // also asserted in the OPEN test above; kept as a named F5 lock so a rename or
+  // refactor that reintroduces an unconditional `pinned: true` is caught here too.
+  it('(F5) the persisted record mirrors the real pin decision, not an unconditional pinned:true', () => {
+    const openBranch = between(
+      laneSrc,
+      'if (turn.activityMessageId == null) {',
+      'turn.activityLastSentRender = target',
+    )
+    const recordBlock = between(openBranch, 'writeActivityCardRecord(', 'void reconcileStatusPin(')
+    const recordCode = recordBlock
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//'))
+      .join('\n')
+    expect(recordCode).toMatch(/pinned: PIN_STATUS_WHILE_WORKING/)
+    expect(recordCode).not.toMatch(/pinned: true/)
+  })
+
   it('the normal-CLOSE path clears the durable handle, id-scoped (reap-race guard)', () => {
     const closeBody = between(
       laneSrc,

--- a/telegram-plugin/tests/status-pin-store.test.ts
+++ b/telegram-plugin/tests/status-pin-store.test.ts
@@ -7,10 +7,13 @@ import {
   pinnedMessageIsOurs,
   reconcileAndPersistStatusPin,
   runStatusPinBootCleanup,
+  withPinReconcileLock,
   type PersistedStatusPin,
   type StatusPinStoreFsSeam,
   type TrackedStatusPin,
 } from "../gateway/status-pin-store.js";
+import { decidePinAction, type PinState, type DesiredPin } from "../status-pin.js";
+import { reconcilePin, type PinBotApi } from "../status-pin-driver.js";
 
 /** In-memory fs seam with an atomic rename, so the store's tmp→rename
  *  crash-safety contract is exercised without touching the real disk. */
@@ -717,5 +720,200 @@ describe("reconcileAndPersistStatusPin — persist-before-pin ordering", () => {
     });
     expect(next).toBeNull();
     expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  // F1 (invisible-worker-cards review): a `clear` op is emitted for BOTH a real
+  // unpin AND a `noop: already pinned`. For a noop, reconcilePin issues NO
+  // Telegram call and returns the LIVE claim (non-null). The pre-fix clear
+  // branch dropped the row unconditionally, so the worker feed's per-edit
+  // syncPin (every steady-state edit maps to a noop-clear) erased the durable
+  // row for a still-live pin — a crash after that left a stuck pinned card boot
+  // cleanup could never see. The row MUST be preserved when applyPin returns a
+  // live claim.
+  it("clear op with a LIVE claim (noop-already-pinned) PRESERVES the durable row", async () => {
+    const { fs, calls } = memFs();
+    persistStatusPins(PATH, fs, [pin({ pinKey: "wk:group:g1", messageId: 715 })]);
+    const before = calls.length;
+    // applyPin returns the live claim unchanged (what reconcilePin does on noop).
+    const next = await reconcileAndPersistStatusPin({
+      path: PATH,
+      fs,
+      pinKey: "wk:group:g1",
+      chatId: "-100123",
+      op: { kind: "clear" },
+      applyPin: async () => ({ messageId: 715 }),
+      log: () => {},
+    });
+    expect(next).toEqual({ messageId: 715 });
+    // Row survives (rewritten confirmed, no `pending`).
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "wk:group:g1", chatId: "-100123", messageId: 715 },
+    ]);
+    // Sanity: at least one disk write happened (the confirm rewrite) — the fix
+    // does not skip persistence, it changes the CONTENT from delete to upsert.
+    expect(calls.length).toBeGreaterThan(before);
+  });
+
+  it("repeated steady-state noop-clears keep the row present across many edits", async () => {
+    const { fs } = memFs();
+    persistStatusPins(PATH, fs, [pin({ pinKey: "wk:group:g1", messageId: 715 })]);
+    for (let i = 0; i < 5; i++) {
+      await reconcileAndPersistStatusPin({
+        path: PATH,
+        fs,
+        pinKey: "wk:group:g1",
+        chatId: "-100123",
+        op: { kind: "clear" },
+        applyPin: async () => ({ messageId: 715 }),
+        log: () => {},
+      });
+    }
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "wk:group:g1", chatId: "-100123", messageId: 715 },
+    ]);
+  });
+});
+
+/**
+ * F2 (invisible-worker-cards review): the gateway's status-pin reconcile reads
+ * its `prev` claim from an in-memory map at the top of the reconcile, then
+ * awaits. Two overlapping reconciles for ONE key with OPPOSITE desires could
+ * both capture a stale `prev` → a turn-end `{pinned:false}` clears the durable
+ * row while a flood-delayed open-pin lands, leaving a stuck pin with no row.
+ *
+ * These tests exercise the REAL fix primitives — `withPinReconcileLock` +
+ * `reconcileAndPersistStatusPin` + `reconcilePin` + `decidePinAction` — composed
+ * exactly as the gateway wires them (read prev INSIDE the per-key lock), and
+ * prove the row survives. The `noLock` control models the pre-fix ordering
+ * (prev read OUTSIDE the lock) and shows it regresses — so the lock, not luck,
+ * is what fixes it.
+ */
+describe("status-pin-store — F2 per-key reconcile serialization", () => {
+  // A gateway-faithful reconcile: an in-memory claim map (the `prev` source read
+  // at the TOP of the reconcile), the real decide→op mapping, and
+  // reconcileAndPersistStatusPin driving reconcilePin against a call-counting
+  // pin API. An optional gate lets a test hold ONE reconcile's applyPin open to
+  // force the exact interleave. `serialize` toggles the F2 fix.
+  function makeReconciler(fs: StatusPinStoreFsSeam, opts: { serialize: boolean }) {
+    const claims = new Map<string, PinState>();
+    const pinCalls: number[] = [];
+    const unpinCalls: number[] = [];
+    const api: PinBotApi = {
+      pinChatMessage: async (_c, id) => {
+        pinCalls.push(id);
+      },
+      unpinChatMessage: async (_c, id) => {
+        unpinCalls.push(id);
+      },
+    };
+    async function core(
+      pinKey: string,
+      chatId: string,
+      desired: DesiredPin,
+      gate?: Promise<void>,
+    ) {
+      const prev = claims.get(pinKey) ?? null; // read BEFORE the store op (the F2 window)
+      const action = decidePinAction(prev, desired);
+      const op =
+        action.kind === "pin"
+          ? ({ kind: "pin", messageId: action.messageId } as const)
+          : ({ kind: "clear" } as const);
+      const next = await reconcileAndPersistStatusPin({
+        path: PATH,
+        fs,
+        pinKey,
+        chatId,
+        op,
+        applyPin: async () => {
+          if (gate) await gate; // hold the pin open inside the store lock
+          return reconcilePin({ api, chatId, prevState: prev, desired });
+        },
+        log: () => {},
+      });
+      if (next == null) claims.delete(pinKey);
+      else claims.set(pinKey, next);
+    }
+    function reconcile(
+      pinKey: string,
+      chatId: string,
+      desired: DesiredPin,
+      gate?: Promise<void>,
+    ) {
+      return opts.serialize
+        ? withPinReconcileLock(pinKey, () => core(pinKey, chatId, desired, gate))
+        : core(pinKey, chatId, desired, gate);
+    }
+    return { reconcile, claims, pinCalls, unpinCalls };
+  }
+
+  // The exact review sequence: a flood-delayed OPEN-pin (A) is in-flight inside
+  // the store lock; a turn-end UNPIN (B) starts during A's await window and
+  // reads prev=null (A has not set the claim yet). Pre-fix, B's clear then drops
+  // the disk row A wrote — stranding a live in-memory claim with NO durable row.
+  async function runStrandingSequence(serialize: boolean) {
+    const { fs } = memFs();
+    const r = makeReconciler(fs, { serialize });
+    let releaseA!: () => void;
+    const gateA = new Promise<void>((res) => {
+      releaseA = res;
+    });
+    // A: open-pin 900, held open at applyPin.
+    const aDone = r.reconcile("fg:c:3", "-100123", { pinned: true, messageId: 900 }, gateA);
+    // Let A reach its applyPin await (pending row on disk; claim NOT yet set).
+    await Promise.resolve();
+    await Promise.resolve();
+    // B: turn-end unpin, starts now — reads prev from the in-memory claim map.
+    const bDone = r.reconcile("fg:c:3", "-100123", { pinned: false });
+    await Promise.resolve();
+    releaseA();
+    await Promise.all([aDone, bDone]);
+    return { fs, claims: r.claims, unpinCalls: r.unpinCalls, pinCalls: r.pinCalls };
+  }
+
+  it("serialized: turn-end unpin waits for the in-flight open-pin, so the pinned message is genuinely UNPINNED (not stranded)", async () => {
+    const { fs, claims, pinCalls, unpinCalls } = await runStrandingSequence(true);
+    const rows = loadStatusPins(PATH, fs);
+    // Under serialization B runs only after A fully settles, so B reads
+    // prev={900}, issues a REAL unpin of the pinned message, and clears the row
+    // and claim together. The Telegram pin is cleaned up — nothing stuck.
+    expect(pinCalls).toEqual([900]); // A pinned it
+    expect(unpinCalls).toEqual([900]); // B unpinned it (the fix)
+    expect(rows).toEqual([]);
+    expect(claims.get("fg:c:3") ?? null).toBeNull();
+  });
+
+  it("pre-fix control (no per-key lock): the same interleave STRANDS the pinned message — pinned, row cleared, NEVER unpinned", async () => {
+    const { fs, unpinCalls, pinCalls } = await runStrandingSequence(false);
+    const rows = loadStatusPins(PATH, fs);
+    // Reproduces the F2 defect the lock removes: B read prev=null during A's
+    // await window, so its clear was a NO-OP unpin (issued no Telegram unpin)
+    // yet still dropped the durable row A wrote — while A's pin call landed. The
+    // message 900 stays pinned on Telegram with NO durable row and no unpin ever
+    // issued → stuck until a boot cleanup that can no longer see it.
+    expect(pinCalls).toEqual([900]); // message 900 WAS pinned
+    expect(unpinCalls).toEqual([]); // …but never unpinned (no-op clear on prev=null)
+    expect(rows).toEqual([]); // …and the durable row is gone → unreapable
+  });
+
+  it("serialized steady-state noop reconciles add ZERO pin/unpin API calls (finn-flood guard)", async () => {
+    const { fs } = memFs();
+    const r = makeReconciler(fs, { serialize: true });
+    // First open pins exactly once.
+    await r.reconcile("wk:group:g1", "-100123", { pinned: true, messageId: 900 });
+    expect(r.pinCalls).toEqual([900]);
+    expect(r.unpinCalls).toEqual([]);
+
+    // 20 steady-state edits — each a re-pin of the SAME id → decidePinAction
+    // noop → reconcilePin issues NO Telegram call. The serialization + F1
+    // row-preservation must not add a single pin/unpin API call.
+    for (let i = 0; i < 20; i++) {
+      await r.reconcile("wk:group:g1", "-100123", { pinned: true, messageId: 900 });
+    }
+    expect(r.pinCalls).toEqual([900]); // still exactly one pin, ever
+    expect(r.unpinCalls).toEqual([]); // never unpinned
+    // The durable row is intact throughout (F1).
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "wk:group:g1", chatId: "-100123", messageId: 900 },
+    ]);
   });
 });

--- a/telegram-plugin/tests/subagent-tracker-hooks.test.ts
+++ b/telegram-plugin/tests/subagent-tracker-hooks.test.ts
@@ -147,6 +147,56 @@ describe('subagent-tracker-pretool', () => {
     expect(row?.model ?? null).toBeNull()
   })
 
+  // F3 (progress-card fork model): a fork dispatch inherits the parent's model
+  // and IGNORES tool_input.model, so seeding the row's first-paint model from
+  // that ignored override made the worker card show a WRONG model (e.g. "sonnet"
+  // while the fork runs Opus) until the transcript overwrote it. The seed must
+  // be suppressed for forks — model stays NULL and the card omits it until the
+  // watcher records the real model from the fork's own transcript.
+  it('leaves model null for a FORK dispatch even when tool_input.model is set (F3)', () => {
+    const event = {
+      session_id: 'sess-fork',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_fork001',
+      tool_input: {
+        subagent_type: 'fork',
+        description: 'Fork the session',
+        run_in_background: true,
+        model: 'sonnet', // override a fork ignores — must NOT be persisted
+      },
+    }
+    const result = runHook(PRETOOL_SCRIPT, event)
+    expect(result.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT model FROM subagents WHERE id = ?').get('toolu_fork001') as
+      | { model: string | null }
+      | undefined
+    expect(row?.model ?? null).toBeNull()
+  })
+
+  it('still persists tool_input.model for a NON-fork dispatch (fork suppression is scoped)', () => {
+    const event = {
+      session_id: 'sess-nonfork',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_nonfork001',
+      tool_input: {
+        subagent_type: 'researcher',
+        description: 'Research with a pinned model',
+        run_in_background: true,
+        model: 'claude-opus-4-8',
+      },
+    }
+    const result = runHook(PRETOOL_SCRIPT, event)
+    expect(result.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT model FROM subagents WHERE id = ?').get('toolu_nonfork001') as
+      | { model: string | null }
+      | undefined
+    expect(row?.model).toBe('claude-opus-4-8')
+  })
+
   it('does not write a row when tool_name is not Agent', () => {
     const event = {
       session_id: 'sess-abc123',

--- a/telegram-plugin/tests/worker-feed-dispatch.test.ts
+++ b/telegram-plugin/tests/worker-feed-dispatch.test.ts
@@ -72,6 +72,33 @@ describe('resolveWorkerFeedDispatch (#2002 regression pin)', () => {
     expect(resolveWorkerFeedDispatch(null, 'sub-agent').feedModel).toBeNull()
     expect(resolveWorkerFeedDispatch(makeSub({ model: null }), 'sub-agent').feedModel).toBeNull()
   })
+
+  // F3 (progress-card fork model) — outcome coverage. The dispatch-time seed is
+  // suppressed for forks at the hook (subagent-tracker-pretool.mjs), so a fork
+  // row carries model=null and the card omits the model until the watcher writes
+  // the transcript model. resolveWorkerFeedDispatch simply surfaces the row's
+  // CURRENT model, so these assert the feed-level outcomes on top of that.
+  it('(b) a fork row carries no dispatch-time model → feedModel null (card omits it until transcript)', () => {
+    // What the hook now writes for a fork dispatch: agent_type 'fork', model null
+    // (the ignored override is not persisted).
+    const forkRow = makeSub({ background: true, agent_type: 'fork', model: null })
+    expect(resolveWorkerFeedDispatch(forkRow, 'sub-agent').feedModel).toBeNull()
+  })
+
+  it('(a) once the watcher overwrites the row model from the transcript, feedModel reflects the transcript model', () => {
+    // Transcript wins: the watcher (recordSubagentModel) overwrites the row's
+    // model column in place, so the resolved feedModel is the transcript value —
+    // even for a fork that started with model=null.
+    const afterTranscript = makeSub({ background: true, agent_type: 'fork', model: 'claude-opus-4-8' })
+    expect(resolveWorkerFeedDispatch(afterTranscript, 'sub-agent').feedModel).toBe('claude-opus-4-8')
+  })
+
+  it('(c) a mid-run model switch is reflected: feedModel tracks the row’s latest recorded model', () => {
+    // The watcher writes model-on-change; the row holds the LATEST model, so a
+    // later substantive tick resolves the switched-to model.
+    const switchedTo = makeSub({ background: true, model: 'sr-glm-5' })
+    expect(resolveWorkerFeedDispatch(switchedTo, 'sub-agent').feedModel).toBe('sr-glm-5')
+  })
 })
 
 describe('gateway onFinish — fix #1: resultText-driven handback fallback (model)', () => {

--- a/telegram-plugin/tests/worker-feed-pin-persistence.test.ts
+++ b/telegram-plugin/tests/worker-feed-pin-persistence.test.ts
@@ -5,7 +5,12 @@ import {
   type BotApiForWorkerFeed,
 } from '../worker-activity-feed.js'
 import { reconcilePin, type PinBotApi } from '../status-pin-driver.js'
-import type { PinState, DesiredPin } from '../status-pin.js'
+import { decidePinAction, type PinState, type DesiredPin } from '../status-pin.js'
+import {
+  reconcileAndPersistStatusPin,
+  loadStatusPins,
+  type StatusPinStoreFsSeam,
+} from '../gateway/status-pin-store.js'
 
 /**
  * Outcome tests for the invisible-worker-cards fix (2026-07-15).
@@ -118,6 +123,131 @@ function makePinHarness() {
 async function flush(): Promise<void> {
   for (let i = 0; i < 8; i++) await new Promise((r) => setImmediate(r))
 }
+
+/** In-memory fs seam with atomic rename, mirroring status-pin-store.test.ts. */
+function memFs(): { fs: StatusPinStoreFsSeam; files: Map<string, string> } {
+  const files = new Map<string, string>()
+  const fs: StatusPinStoreFsSeam = {
+    readFileSync: (p) => {
+      if (!files.has(p)) throw new Error(`ENOENT ${p}`)
+      return files.get(p)!
+    },
+    writeFileSync: (p, d) => {
+      files.set(p, d)
+    },
+    renameSync: (a, b) => {
+      if (!files.has(a)) throw new Error(`ENOENT ${a}`)
+      files.set(b, files.get(a)!)
+      files.delete(a)
+    },
+    existsSync: (p) => files.has(p),
+  }
+  return { fs, files }
+}
+
+/**
+ * A pin harness that routes the feed's `reconcilePin` hook through the REAL
+ * persistence path (`reconcileAndPersistStatusPin`) against a memFs-backed
+ * status-pins.json — exactly as the gateway wires it: read prev claim → decide
+ * → map to a persist op → reconcileAndPersistStatusPin(applyPin=reconcilePin).
+ * This lets a test INSPECT THE FILE across steady-state edits (F1).
+ */
+function makePersistingPinHarness(path: string) {
+  const { fs } = memFs()
+  const claims = new Map<string, PinState>()
+  const pinCalls: number[] = []
+  const unpinCalls: number[] = []
+  const api: PinBotApi = {
+    pinChatMessage: async (_c, id) => {
+      pinCalls.push(id)
+    },
+    unpinChatMessage: async (_c, id) => {
+      unpinCalls.push(id)
+    },
+  }
+  async function reconcile(key: string, chatId: string, desired: DesiredPin): Promise<void> {
+    const prev = claims.get(key) ?? null
+    const action = decidePinAction(prev, desired)
+    const op = action.kind === 'pin'
+      ? ({ kind: 'pin', messageId: action.messageId } as const)
+      : ({ kind: 'clear' } as const)
+    const next = await reconcileAndPersistStatusPin({
+      path,
+      fs,
+      pinKey: key,
+      chatId,
+      op,
+      applyPin: () => reconcilePin({ api, chatId, prevState: prev, desired }),
+      log: () => {},
+    })
+    if (next == null) claims.delete(key)
+    else claims.set(key, next)
+  }
+  const reconcilePinFn = (args: {
+    feedKey: string
+    chatId: string
+    threadId?: number
+    messageId: number | null
+  }): void => {
+    const key = `wk:group:${args.feedKey}`
+    if (args.messageId != null) void reconcile(key, args.chatId, { pinned: true, messageId: args.messageId })
+    else void reconcile(key, args.chatId, { pinned: false })
+  }
+  return {
+    reconcilePinFn,
+    fs,
+    pinCalls,
+    unpinCalls,
+    rows: () => loadStatusPins(path, fs),
+  }
+}
+
+describe('worker-feed pin persistence — durable status-pins.json survives steady-state edits (F1)', () => {
+  const PATH = '/state/agent/telegram/status-pins.json'
+
+  it('preserves the wk:group row across many steady-state edits (noop-clear must NOT delete it)', async () => {
+    const bot = makeFakeBot()
+    const pin = makePersistingPinHarness(PATH)
+    let clock = 0
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      firstPaintMinMs: 0,
+      minEditIntervalMs: 0,
+      reconcilePin: pin.reconcilePinFn,
+    })
+
+    // First paint → message posted, pinned once, durable row written.
+    clock = 1000
+    await feed.update('w1', 'chat', view({ elapsedMs: 1000, toolCount: 1 }))
+    await flush()
+    const msgId = bot.sent[0].messageId
+    expect(pin.pinCalls).toEqual([msgId])
+    expect(pin.rows()).toHaveLength(1)
+    const pinKey = pin.rows()[0].pinKey
+    expect(pinKey).toMatch(/^wk:group:/)
+    expect(pin.rows()).toEqual([
+      { pinKey, chatId: 'chat', messageId: msgId },
+    ])
+
+    // Many steady-state edits — the feed calls syncPin on EVERY edit, each a
+    // re-pin of the SAME id → noop → a `clear` op with a LIVE claim. Pre-fix the
+    // clear branch deleted the durable row here; the fix preserves it.
+    for (let i = 2; i <= 8; i++) {
+      clock = i * 1000
+      await feed.update('w1', 'chat', view({ elapsedMs: i * 1000, toolCount: i }))
+      await flush()
+    }
+
+    // The durable row is STILL on disk (inspect the file), and no extra pin/
+    // unpin API call was issued across all those steady-state edits.
+    expect(pin.rows()).toEqual([
+      { pinKey, chatId: 'chat', messageId: msgId },
+    ])
+    expect(pin.pinCalls).toEqual([msgId]) // exactly one pin, ever
+    expect(pin.unpinCalls).toEqual([]) // never unpinned
+  })
+})
 
 describe('worker-feed pin persistence — steady-state re-pin (invisible-worker-cards)', () => {
   it('re-pins on a steady-state edit when the claim was lost, and does NOT re-pin when already correct (no storm)', async () => {


### PR DESCRIPTION
## Summary
Fixes all findings from the invisible-worker-cards adversarial review of the progress-card / status-pin system.

- **F1 (MEDIUM)** `status-pin-store.ts` — a `noop: already pinned` maps to a `clear` persist op whose branch unconditionally deleted the `status-pins.json` row even though the pin claim was live. The worker feed calls `syncPin` on every steady-state edit, so the durable row was erased after the second edit; a crash after that left a stuck pinned `wk:` card boot cleanup could never see. The clear branch now **preserves the row when `applyPin` returns a live claim** (deletes only when the claim is genuinely gone). No extra Telegram API call.
- **F2 (LOW-MEDIUM)** `gateway.ts` + `status-pin-store.ts` — `reconcileStatusPinInner` snapshotted `prev` before the store lock, so overlapping opposite-desire reconciles on one key could read a stale `prev` and clear the disk row under a flood-delayed open-pin (stuck `fg:` pin, no row). Same-key reconciles are now **serialized through `withPinReconcileLock`** (added to `status-pin-store.ts` so it is unit-testable); each reads `prev` fresh. Zero added API calls. The mid-session `wk:` sweep is deliberately left as-is: extending it to `fg:` keys (different turn-end lifecycle) is not cheap/safe, and the serialization prevents the strand deterministically at the source (boot cleanup already reaps `fg:` rows).
- **F3 (LOW)** `subagent-tracker-pretool.mjs` — the hook seeded first-paint model from `tool_input.model` even for **fork** dispatches, which ignore the model override, so the card showed a wrong model (e.g. `sonnet` while running Opus) until the transcript event. **Fixed at the seed source**: forks store `model=null` so the card omits it until the watcher records the real transcript model (which then flows to the terminal card too — nulling downstream in `worker-feed-dispatch.ts` would have suppressed the transcript-confirmed model on terminal cards).
- **F5/F6 (LOW hardening)** `narrative-lane.ts` — the activity-card open path already applies persist-intent-first (record written synchronously right after the send, before the pin, through a never-throwing store, with `pinned` mirroring the real decision). Documented the ordering invariant and pinned it with structural tests. A true pre-send provisional record is impossible: the reaper keys its finalizing edit on `activityMessageId`, which only exists once `sendRichMessage` returns.

## Why
Chat-is-the-single-source-of-truth: a stuck/wrong pinned worker card is a durable lie in the chat surface. These fixes are deterministic (row preservation + per-key serialization) rather than reactive sweeps.

## Test plan
Scoped vitest + bun locally green:
- `status-pin-store.test.ts` (+F1 preserve, +F2 serialization/stranding/finn-flood) — 37 pass
- `worker-feed-pin-persistence.test.ts` (+F1 file-inspection) — 5 pass
- `worker-feed-dispatch.test.ts` (+F3 outcome (a)/(b)/(c)) — 27 pass
- `subagent-tracker-hooks.test.ts` (+F3 fork null / non-fork scoped) — bun, 21 pass
- `activity-card-wiring.test.ts` (+F5/F6 ordering locks) — 6 pass

Each regression test verified to FAIL on pre-fix source (F1: 4 tests; F3: fork test fails, non-fork passes). API-call-count guards assert steady-state edits issue no extra pin/unpin calls. `npm run lint` gateway guards clean (bot-api-wrapping, line-ratchet, bun-imports, pii). CI is the full-suite authority.

## Risk
Low. Behavior changes are narrow (row-preservation on live-claim clear; per-key ordering; fork model suppression). Comment-only in `narrative-lane.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)