### PR TITLE
fix(auth-broker): symlink-safe unified mirror write (H1 + M1)

### DIFF
--- a/src/auth/broker/mirror-write.ts
+++ b/src/auth/broker/mirror-write.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared symlink-safe mirror write primitive (#1393 WS1 → M1 TOCTOU close).
+ *
+ * The auth-broker runs as ROOT with CAP_DAC_OVERRIDE and mirrors the
+ * effective account's OAuth credentials into two agent/consumer-writable
+ * trees:
+ *
+ *   - per-agent   ~/.switchroom/agents/<name>/.claude/.credentials.json
+ *   - per-consumer <consumer.mirror_dir>/.credentials.json
+ *
+ * Both destinations live under a directory the (potentially
+ * prompt-injected) consumer/agent owns and can pre-plant with symlinks.
+ * A raw `mkdirSync({recursive}) + atomicWriteFileSync + chownSync(path)`
+ * would dereference those symlinks and let the peer redirect a
+ * root-owned write/chown to an arbitrary host path — an agent→host
+ * trust-boundary crossing on every fanout.
+ *
+ * This module centralises the write half so BOTH callers share one
+ * hardened path:
+ *
+ *   1. The caller lstat-validates every controllable path component
+ *      (agentsDir/agentDir/.claude/target, or mirror_dir-parent/mirror_dir/
+ *      target) and refuses a symlink or wrong type — fail closed.
+ *   2. `safeMirrorWrite` re-pins the containing directory's *canonical*
+ *      (`realpathSync`) location against the caller's `expectedRealParent`
+ *      immediately before the write. This closes the residual
+ *      lstat→open TOCTOU: if a peer raced a controllable component into a
+ *      symlink after the sweep, the resolved path diverges and we refuse.
+ *   3. The write itself goes through `atomicWriteFileSync`, which opens
+ *      the tempfile `O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW`, `fchmod`/`fchown`s
+ *      the **fd** (never a path — kills the symlink-following chown), then
+ *      `rename(2)`s over the destination (rename replaces a symlink at the
+ *      target rather than following it).
+ *
+ * Node lacks the `*at()` syscall family, so canonical-parent pinning plus
+ * fd-relative metadata ops is the strongest guard available; the residual
+ * is a parent-directory swap in the sub-millisecond window between the
+ * `realpathSync` check and the `rename` (documented, accepted).
+ *
+ * Fail closed per-target: `safeMirrorWrite` returns false + audits, and
+ * never throws across the fanout — one poisoned peer must not deny the
+ * whole fleet's auth (doctrine of #1393).
+ */
+
+import { lstatSync, realpathSync, type Stats } from "node:fs";
+
+import { atomicWriteFileSync } from "../../util/atomic.js";
+
+/** Audit + log a refusal for a controllable component. Never throws. */
+export type MirrorRefuse = (component: string, reason: string) => void;
+
+export interface SafeMirrorWriteInput {
+  /**
+   * The directory that will contain the target file — already
+   * lstat-validated (real dir) and, where applicable, created by the
+   * caller.
+   */
+  parentDir: string;
+  /**
+   * The expected canonical (`realpathSync`) location of `parentDir`,
+   * derived by the caller from a TRUSTED anchor's realpath + the
+   * lstat-validated controllable component names. `safeMirrorWrite`
+   * recomputes `realpathSync(parentDir)` and refuses on any divergence
+   * (the M1 TOCTOU pin).
+   */
+  expectedRealParent: string;
+  /** Absolute path of the target file inside `parentDir`. */
+  targetPath: string;
+  content: string;
+  /** uid/gid to `fchown` the fd to before rename (fd-based, symlink-proof). */
+  uid: number;
+  gid?: number;
+  mode?: number;
+  /**
+   * Swallow an `fchown` EPERM on CAP_CHOWN-less dev hosts — the mirror
+   * still lands (just not re-owned). MUST NOT abort the write.
+   */
+  onChownError: (err: unknown) => void;
+  /** Audit + log a symlink/TOCTOU refusal. */
+  refuse: MirrorRefuse;
+  /** Log a non-security write failure. */
+  logErr: (msg: string) => void;
+}
+
+/** `lstat` a path, returning null (not throwing) when it doesn't exist. */
+export function lstatOrNull(path: string): Stats | null {
+  try {
+    return lstatSync(path);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Perform the pinned, symlink-safe mirror write. Returns true on
+ * success, false on refusal or a non-fatal write failure (both already
+ * logged/audited). Never throws.
+ */
+export function safeMirrorWrite(input: SafeMirrorWriteInput): boolean {
+  // M1: re-pin the parent's canonical path right before the write. If a
+  // peer swapped any controllable component to a symlink after the
+  // caller's lstat sweep, the fully-resolved path diverges → refuse.
+  let realParent: string;
+  try {
+    realParent = realpathSync(input.parentDir);
+  } catch (err) {
+    input.logErr(`mirror parent realpath failed: ${(err as Error).message}`);
+    return false;
+  }
+  if (realParent !== input.expectedRealParent) {
+    input.refuse("parentDir", "realpath-mismatch");
+    return false;
+  }
+
+  try {
+    atomicWriteFileSync(input.targetPath, input.content, {
+      mode: input.mode ?? 0o600,
+      uid: input.uid,
+      gid: input.gid ?? input.uid,
+      onChownError: input.onChownError,
+    });
+    return true;
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    // O_NOFOLLOW/O_EXCL trip: a symlink or inode was raced into place at
+    // the temp/target path between validation and open. Treat as a
+    // security refusal, not a generic failure.
+    if (e.code === "ELOOP" || e.code === "EEXIST") {
+      input.refuse("targetPath", `open-${e.code}`);
+      return false;
+    }
+    input.logErr(`mirror write failed: ${e.message}`);
+    return false;
+  }
+}

--- a/src/auth/broker/server-consumer-mirror-symlink-guard.test.ts
+++ b/src/auth/broker/server-consumer-mirror-symlink-guard.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Regression test for #1393 / M1 — the CONSUMER mirror write path.
+ *
+ * BUG (pre-PR1): `mirrorAccountToConsumer` (auth-broker, runs as root
+ * with CAP_DAC_OVERRIDE) wrote the effective-account OAuth mirror into
+ * `<consumer.mirror_dir>/.credentials.json` with a raw
+ * `mkdirSync({recursive}) + atomicWriteFileSync + chownSync(path)` and
+ * ZERO symlink guard — unlike the per-agent path which already had
+ * `resolveMirrorPathsSafe`. `mirror_dir` is consumer-writable, so a
+ * prompt-injected / compromised consumer could pre-plant `mirror_dir`
+ * (or a symlinked ancestor of a not-yet-existing `mirror_dir`) as a
+ * symlink and have the root broker dereference it on the next
+ * fanout → a root-owned credential write at an arbitrary host path,
+ * plus a path-based `chownSync` that follows the same symlink.
+ *
+ * FIX (PR1): both mirror paths share one `safeMirrorWrite` primitive.
+ * The consumer resolver `resolveConsumerMirrorPathsSafe` lstat-validates
+ * `mirror_dir` (real dir, or absent → created only through a real,
+ * non-symlink parent) and the target file (absent or a regular file,
+ * never a symlink), then `safeMirrorWrite` re-pins the containing dir's
+ * canonical realpath and writes via the O_NOFOLLOW|O_EXCL tempfile +
+ * fd-based fchmod/fchown + rename (never a path-based chown). Fail
+ * closed: skip that consumer's mirror, log + audit, never crash the
+ * fanout (one poisoned consumer must not DoS the fleet).
+ *
+ * These tests drive the real boot fanout (`broker.start()` →
+ * `fanoutAllConsumers`) through a temp HOME, exactly like
+ * `server-mirror-symlink-guard.test.ts`.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// fchown swallow test: the broker runs as root in some CI/dev contexts
+// (fchown succeeds) and non-root in others (fchown EPERM). To exercise
+// the swallow path deterministically we wrap `fchownSync` behind a hoisted
+// flag and force EPERM only for that one test. Everything else delegates
+// to the real fs.
+const mockState = vi.hoisted(() => ({ throwEpermOnFchown: false }));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    default: actual,
+    fchownSync: (fd: number, uid: number, gid: number) => {
+      if (mockState.throwEpermOnFchown) {
+        const err = new Error("EPERM: operation not permitted, fchown");
+        (err as NodeJS.ErrnoException).code = "EPERM";
+        throw err;
+      }
+      return actual.fchownSync(fd, uid, gid);
+    },
+  };
+});
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AuthBroker } from "./server.js";
+import { accountCredentialsPath, accountDir } from "../account-store.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-consumer-symlink-guard-test-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  mockState.throwEpermOnFchown = false;
+  for (const h of harnesses) {
+    try {
+      rmSync(h.tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness, consumers: object[]): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents: {},
+    auth: { active: "default", consumers },
+  } as unknown as SwitchroomConfig;
+}
+
+function writeSourceCreds(h: Harness, label: string): void {
+  mkdirSync(accountDir(label, h.home), { recursive: true });
+  writeFileSync(
+    accountCredentialsPath(label, h.home),
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at-default",
+        refreshToken: "rt-default",
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    }),
+  );
+}
+
+function readAudit(h: Harness): string {
+  const p = join(h.stateDir, "audit.jsonl");
+  return existsSync(p) ? readFileSync(p, "utf-8") : "";
+}
+
+async function bootFanout(h: Harness, consumers: object[]): Promise<void> {
+  const broker = new AuthBroker(makeConfig(h, consumers), {
+    home: h.home,
+    stateDir: h.stateDir,
+    socketRoot: h.socketRoot,
+    disableRefreshLoop: true,
+  });
+  await broker.start(); // boot fanout (fanoutAllConsumers) fires here
+  broker.stop();
+}
+
+describe("AuthBroker — symlink-guarded per-consumer mirror (#1393 / M1)", () => {
+  it("REFUSES to write through a pre-planted `mirror_dir` symlink and keeps mirroring other consumers", async () => {
+    const h = makeHarness();
+    writeSourceCreds(h, "default");
+
+    // Poisoned consumer: `mirror_dir` itself is a symlink to an
+    // attacker-chosen escape directory.
+    const escapeTarget = join(h.tmp, "escape-target");
+    mkdirSync(escapeTarget, { recursive: true });
+    const evilDir = join(h.tmp, "evil-mirror");
+    symlinkSync(escapeTarget, evilDir);
+
+    // Legit consumer: a real (not-yet-existing) mirror dir the broker
+    // safely creates.
+    const goodDir = join(h.tmp, "good-mirror");
+
+    await bootFanout(h, [
+      { name: "evil", uid: 0, mirror_dir: evilDir },
+      { name: "good", uid: 0, mirror_dir: goodDir },
+    ]);
+
+    // The broker must NOT have dereferenced the symlink into the escape.
+    expect(existsSync(join(escapeTarget, ".credentials.json"))).toBe(false);
+    // The symlink is left intact (not replaced by a real dir/file).
+    expect(lstatSync(evilDir).isSymbolicLink()).toBe(true);
+
+    // The refusal is audited as a structured security event.
+    const audit = readAudit(h);
+    expect(audit).toContain('"op":"mirror-symlink-refused"');
+    expect(audit).toContain('"peer":"consumer:evil"');
+    expect(audit).toContain("mirror_dir:is-a-symlink");
+
+    // The legit consumer still got a correct mirror — no fleet DoS.
+    const good = JSON.parse(readFileSync(join(goodDir, ".credentials.json"), "utf-8"));
+    expect(good.claudeAiOauth.accessToken).toBe("at-default");
+  });
+
+  it("REFUSES a pre-planted `.credentials.json` symlink pointing outside; the outside file is untouched", async () => {
+    const h = makeHarness();
+    writeSourceCreds(h, "default");
+
+    const mirrorDir = join(h.tmp, "consumer-mirror");
+    mkdirSync(mirrorDir, { recursive: true });
+    const escapeFile = join(h.tmp, "escape-file");
+    writeFileSync(escapeFile, "original-secret");
+    symlinkSync(escapeFile, join(mirrorDir, ".credentials.json"));
+
+    await bootFanout(h, [{ name: "c1", uid: 0, mirror_dir: mirrorDir }]);
+
+    // The outside file must not have been overwritten with creds.
+    expect(readFileSync(escapeFile, "utf-8")).toBe("original-secret");
+    const audit = readAudit(h);
+    expect(audit).toContain('"op":"mirror-symlink-refused"');
+    expect(audit).toContain(".credentials.json:is-a-symlink");
+  });
+
+  it("REFUSES to CREATE a not-yet-existing `mirror_dir` through a symlinked ancestor", async () => {
+    const h = makeHarness();
+    writeSourceCreds(h, "default");
+
+    // A symlinked PARENT of a not-yet-existing mirror_dir. Current
+    // (pre-fix) code `mkdirSync({recursive})` would traverse the symlink
+    // and create + write into the escape target.
+    const escapeTarget = join(h.tmp, "escape-parent");
+    mkdirSync(escapeTarget, { recursive: true });
+    const symlinkedParent = join(h.tmp, "planted-parent");
+    symlinkSync(escapeTarget, symlinkedParent);
+    const mirrorDir = join(symlinkedParent, "mirror"); // does not exist yet
+
+    await bootFanout(h, [{ name: "c1", uid: 0, mirror_dir: mirrorDir }]);
+
+    // No escape write, and the leaf was never created under the escape.
+    expect(existsSync(join(escapeTarget, "mirror", ".credentials.json"))).toBe(false);
+    expect(existsSync(join(escapeTarget, "mirror"))).toBe(false);
+    const audit = readAudit(h);
+    expect(audit).toContain('"op":"mirror-symlink-refused"');
+    expect(audit).toContain("mirror_dir-parent:is-a-symlink");
+  });
+
+  it("happy path: creates the mirror, mode 0600, content enriched, canonical (non-symlink) path", async () => {
+    const h = makeHarness();
+    writeSourceCreds(h, "default");
+
+    const consumerUid = process.getuid && process.getuid() === 0 ? 12345 : (process.getuid?.() ?? 0);
+    const mirrorDir = join(h.tmp, "consumer-mirror");
+
+    await bootFanout(h, [{ name: "c1", uid: consumerUid, mirror_dir: mirrorDir }]);
+
+    const target = join(mirrorDir, ".credentials.json");
+    expect(existsSync(target)).toBe(true);
+    // Real file at the expected path — never a symlink.
+    expect(realpathSync(target)).toBe(target);
+    const st = lstatSync(target);
+    expect(st.isFile()).toBe(true);
+    // Exact 0600 regardless of umask (fchmod on the fd).
+    expect(st.mode & 0o777).toBe(0o600);
+    // Ownership is only assertable when the broker actually holds
+    // CAP_CHOWN (running as root); otherwise fchown EPERM is swallowed.
+    if (process.getuid && process.getuid() === 0) {
+      expect(st.uid).toBe(consumerUid);
+    }
+
+    // enrichMirrorContent is applied (defense-in-depth): the mirror is
+    // valid JSON carrying the source access token.
+    const mirror = JSON.parse(readFileSync(target, "utf-8"));
+    expect(mirror.claudeAiOauth.accessToken).toBe("at-default");
+    expect(mirror.claudeAiOauth.refreshToken).toBe("rt-default");
+
+    // No spurious refusal audited on the happy path.
+    expect(readAudit(h)).not.toContain("mirror-symlink-refused");
+  });
+
+  it("fchown EPERM (no CAP_CHOWN) does NOT abort the write — the mirror still lands 0600", async () => {
+    const h = makeHarness();
+    writeSourceCreds(h, "default");
+
+    const mirrorDir = join(h.tmp, "consumer-mirror");
+    mockState.throwEpermOnFchown = true;
+
+    await bootFanout(h, [{ name: "c1", uid: 4321, mirror_dir: mirrorDir }]);
+
+    const target = join(mirrorDir, ".credentials.json");
+    // The write completed despite the fchown EPERM.
+    expect(existsSync(target)).toBe(true);
+    const st = lstatSync(target);
+    expect(st.isFile()).toBe(true);
+    expect(st.mode & 0o777).toBe(0o600);
+    const mirror = JSON.parse(readFileSync(target, "utf-8"));
+    expect(mirror.claudeAiOauth.accessToken).toBe("at-default");
+    // Not a security refusal — the swallow path must not audit one.
+    expect(readAudit(h)).not.toContain("mirror-symlink-refused");
+  });
+});

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -2656,34 +2656,38 @@ describe("AuthBroker — historical-bug regressions (2026-05-14 fanout incident)
   it("Bug 1: per-agent mirror is chowned to the per-agent UID, never left as root", async () => {
     // The broker container runs as root and writes per-agent credentials.json.
     // Without an explicit chown, the file would land as root:root 0600 and
-    // the agent (running as 10001–10999) couldn't read it. server.ts:953-956
-    // calls `chownSync(targetPath, uid, uid)` where uid = allocateAgentUid().
-    // We can't run as root in the test (so chownSync is a best-effort no-op
-    // under dev — see the catch block), but we CAN verify the call is made
-    // and reaches the right UID by spying on chownSync indirectly:
-    // statSync(targetPath).uid will equal the test runner's UID in dev mode
-    // (broker tried to chown to per-agent UID but lacked CAP_CHOWN). In
-    // production with CAP_CHOWN, it would equal allocateAgentUid("ziggy").
+    // the agent (running as 10001–10999) couldn't read it. mirrorAccountToAgent
+    // flips ownership to `allocateAgentUid(agentName)`.
     //
-    // The pin: read the broker's source to confirm the chown call exists
-    // with the right argument shape — a structural assertion that survives
-    // a future "just remove the chown, it's a no-op in dev" refactor.
+    // Since PR1 (#1393 / M1) the ownership flip is done on the tempfile *fd*
+    // inside `safeMirrorWrite` → `atomicWriteFileSync` (fd-based fchown BEFORE
+    // rename), NOT a path-based `chownSync(targetPath)`. A path-based chown
+    // after the write would follow a symlink an attacker raced into place at
+    // the destination — the M1 TOCTOU this PR closes. So the pin now asserts
+    // the *new* hardened shape and that the old path-chown did NOT come back.
+    //
+    // We can't reliably run as root in CI (so the fchown is a best-effort
+    // no-op under dev — swallowed via onChownError), but we CAN verify the
+    // call is made and reaches the right UID by reading the source.
     const fs = await import("node:fs");
     const url = await import("node:url");
     const path = await import("node:path");
     const here = path.dirname(url.fileURLToPath(import.meta.url));
     const serverSrc = fs.readFileSync(path.join(here, "server.ts"), "utf-8");
-    // Must chown the mirror file to allocateAgentUid(agentName), not leave
-    // it root-owned. The exact pattern (a chownSync call against the
-    // freshly-written .credentials.json path inside mirrorAccountToAgent)
-    // is what closes Bug 1.
-    // Budget bumped from 1600 → 3000 when mirror-time enrichment
-    // landed (enrichMirrorContent call + load-bearing inline comments
-    // about the .credentials.json dotfile invariant). The pin is still
-    // meaningful — it asserts the chown call is *inside* the function,
-    // not extracted to a remote helper that could regress silently.
-    expect(serverSrc).toMatch(/mirrorAccountToAgent[\s\S]{0,3000}allocateAgentUid/);
-    expect(serverSrc).toMatch(/mirrorAccountToAgent[\s\S]{0,3000}chownSync\(targetPath/);
+    const atomicSrc = fs.readFileSync(
+      path.join(here, "..", "..", "util", "atomic.ts"),
+      "utf-8",
+    );
+    // mirrorAccountToAgent must hand the per-agent UID to the shared write
+    // primitive, not leave the mirror root-owned. The pin asserts the uid is
+    // wired through inside the function, not silently dropped.
+    expect(serverSrc).toMatch(/mirrorAccountToAgent[\s\S]{0,3000}safeMirrorWrite/);
+    expect(serverSrc).toMatch(/mirrorAccountToAgent[\s\S]{0,3000}uid:\s*allocateAgentUid/);
+    // M1 regression guard: the path-based chown that followed a raced symlink
+    // must NOT be reintroduced inside mirrorAccountToAgent.
+    expect(serverSrc).not.toMatch(/mirrorAccountToAgent[\s\S]{0,3000}chownSync\(targetPath/);
+    // The ownership flip lands on the fd (fchownSync), before rename.
+    expect(atomicSrc).toMatch(/fchownSync\(fd/);
   });
 
   it("Bug 2: refresh tick writes ONLY the agent's effective account, not last-iterated label", async () => {

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -29,6 +29,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   renameSync,
   rmSync,
   statSync,
@@ -38,7 +39,7 @@ import {
 import { closeSync, openSync, writeSync } from "node:fs";
 import * as constants from "node:constants";
 import { createHash } from "node:crypto";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 
 import { allocateAgentUid } from "../../agents/compose.js";
 import { resolveAgentsDir } from "../../config/loader.js";
@@ -83,7 +84,8 @@ import {
   SNAPSHOT_STALE_AGE_MS,
 } from "./account-eligibility.js";
 import type { AuthConfig, AuthConsumer, SwitchroomConfig } from "../../config/schema.js";
-import { atomicWriteFileSync, atomicWriteJsonSync } from "../../util/atomic.js";
+import { atomicWriteJsonSync } from "../../util/atomic.js";
+import { safeMirrorWrite } from "./mirror-write.js";
 import {
   REFRESH_THRESHOLD_MS,
   refreshAccountIfNeeded,
@@ -3914,24 +3916,101 @@ export class AuthBroker {
   private mirrorAccountToConsumer(label: string, consumer: { name: string; uid?: number; mirror_dir?: string }): boolean {
     const mirrorDir = consumer.mirror_dir;
     if (!mirrorDir) return false;
-    const targetPath = join(mirrorDir, ".credentials.json");
     const credsPath = accountCredentialsPath(label, this.home);
     if (!existsSync(credsPath)) return false;
     const mirrorContent = enrichMirrorContent(readFileSync(credsPath, "utf-8"));
-    try {
-      mkdirSync(mirrorDir, { recursive: true, mode: 0o700 });
-      atomicWriteFileSync(targetPath, mirrorContent, 0o600);
+
+    // Symlink guard (#1393 / M1): the consumer owns `mirror_dir` and its
+    // contents, so it can pre-plant `mirror_dir` (or the target file, or
+    // any ancestor of a not-yet-existing `mirror_dir`) as a symlink. The
+    // broker runs as root; a raw recursive-mkdir + path-chown would
+    // dereference that and hand the consumer a root-owned write/chown at
+    // an arbitrary host path. Validate + safely create BEFORE any write.
+    const safe = this.resolveConsumerMirrorPathsSafe(consumer.name, mirrorDir);
+    if (!safe) return false;
+
+    return safeMirrorWrite({
+      parentDir: safe.mirrorDir,
+      expectedRealParent: safe.expectedRealParent,
+      targetPath: safe.targetPath,
+      content: mirrorContent,
+      uid: consumer.uid ?? 0,
+      onChownError: (err) => this.warnCapChownMissing(err),
+      refuse: (component, reason) =>
+        this.auditMirrorRefused({ kind: "consumer", name: consumer.name }, component, reason),
+      logErr: (msg) => this.logErr(`consumer-mirror ${consumer.name} <- ${label}: ${msg}`),
+    });
+  }
+
+  /**
+   * Symlink guard for a consumer's `mirror_dir` write path (#1393 / M1).
+   *
+   * Harsher than the per-agent tree: the broker `mkdirSync({recursive})`s
+   * `mirror_dir`, and that directory is consumer-writable. So we refuse to
+   * CREATE it through any symlinked ancestor — the leaf `mirror_dir` is
+   * mkdir'd (non-recursively) only after `lstat` confirms it is absent and
+   * its parent is a real (non-symlink) directory. An already-existing
+   * `mirror_dir` must itself be a real directory (not a symlink the
+   * consumer swapped in). The target `.credentials.json` must be
+   * absent or a regular file — never a symlink.
+   *
+   * Returns the validated paths + the canonical-parent pin for
+   * `safeMirrorWrite`, or `null` if the mirror must be skipped (already
+   * logged + audited). Never throws.
+   */
+  private resolveConsumerMirrorPathsSafe(
+    consumerName: string,
+    mirrorDir: string,
+  ): { mirrorDir: string; targetPath: string; expectedRealParent: string } | null {
+    const identity: Identity = { kind: "consumer", name: consumerName };
+    const refuse = (component: string, reason: string): null => {
+      this.auditMirrorRefused(identity, component, reason);
+      return null;
+    };
+
+    const parent = dirname(mirrorDir);
+    const mirrorStat = this.lstatOrNull(mirrorDir);
+    if (mirrorStat) {
+      // `mirror_dir` exists — it must be a real directory, not a symlink
+      // the consumer swapped in to redirect the root write.
+      if (mirrorStat.isSymbolicLink()) return refuse("mirror_dir", "is-a-symlink");
+      if (!mirrorStat.isDirectory()) return refuse("mirror_dir", "is-not-a-directory");
+    } else {
+      // `mirror_dir` absent — create it, but ONLY through a real
+      // (non-symlink) parent: refuse to mkdir through a symlinked
+      // ancestor the consumer could have planted.
+      const parentStat = this.lstatOrNull(parent);
+      if (!parentStat) return refuse("mirror_dir-parent", "does-not-exist");
+      if (parentStat.isSymbolicLink()) return refuse("mirror_dir-parent", "is-a-symlink");
+      if (!parentStat.isDirectory()) return refuse("mirror_dir-parent", "is-not-a-directory");
       try {
-        const uid = consumer.uid ?? 0;
-        chownSync(targetPath, uid, uid);
+        mkdirSync(mirrorDir, { recursive: false, mode: 0o700 });
       } catch (err) {
-        this.warnCapChownMissing(err);
+        this.logErr(`consumer-mirror ${consumerName}: mkdir ${mirrorDir}: ${(err as Error).message}`);
+        return null;
       }
-      return true;
-    } catch (err) {
-      this.logErr(`consumer-mirror ${consumer.name} <- ${label}: ${(err as Error).message}`);
-      return false;
     }
+
+    const targetPath = join(mirrorDir, ".credentials.json");
+    const targetStat = this.lstatOrNull(targetPath);
+    if (targetStat) {
+      if (targetStat.isSymbolicLink()) return refuse(".credentials.json", "is-a-symlink");
+      if (!targetStat.isFile()) return refuse(".credentials.json", "is-not-a-regular-file");
+    }
+
+    // Canonical-parent pin (M1): derive the expected realpath from the
+    // parent's canonical location + the leaf name. `safeMirrorWrite`
+    // recomputes `realpathSync(mirror_dir)` and refuses on divergence —
+    // catching a raced swap of `mirror_dir` to a symlink after this sweep.
+    let expectedRealParent: string;
+    try {
+      expectedRealParent = join(realpathSync(parent), basename(mirrorDir));
+    } catch (err) {
+      this.logErr(`consumer-mirror ${consumerName}: realpath ${parent}: ${(err as Error).message}`);
+      return null;
+    }
+
+    return { mirrorDir, targetPath, expectedRealParent };
   }
 
   /**
@@ -4033,23 +4112,14 @@ export class AuthBroker {
    */
   private resolveMirrorPathsSafe(
     agentName: string,
-  ): { agentDir: string; claudeDir: string; targetPath: string } | null {
+  ): { agentDir: string; claudeDir: string; targetPath: string; expectedRealParent: string } | null {
     const agentsDir = resolveAgentsDir(this.config);
     const agentDir = resolve(agentsDir, agentName);
     const claudeDir = join(agentDir, ".claude");
     const targetPath = join(claudeDir, ".credentials.json");
 
     const refuse = (component: string, reason: string): null => {
-      this.logErr(
-        `fanout ${agentName}: REFUSING mirror — ${component} ${reason} ` +
-          `(symlink-guard #1393; agent-owned tree may be attacker-poisoned)`,
-      );
-      this.audit({
-        op: "mirror-symlink-refused",
-        identity: { kind: "agent", name: agentName, admin: false },
-        ok: false,
-        error: `${component}:${reason}`,
-      });
+      this.auditMirrorRefused({ kind: "agent", name: agentName, admin: false }, component, reason);
       return null;
     };
 
@@ -4098,7 +4168,16 @@ export class AuthBroker {
         return refuse(".credentials.json", "is-not-a-regular-file");
     }
 
-    return { agentDir, claudeDir, targetPath };
+    // Canonical-parent pin (M1): derive `claudeDir`'s expected realpath
+    // from the trusted anchor (`agentsDir`, root-owned, lstat-verified
+    // non-symlink) + the lstat-validated component names. `safeMirrorWrite`
+    // recomputes `realpathSync(claudeDir)` right before the write and
+    // refuses on divergence — catching a raced swap of `agentDir`/`.claude`
+    // to a symlink after this sweep. `agentsDir` is guaranteed to exist
+    // here (validated above), so `realpathSync` cannot throw for it.
+    const expectedRealParent = join(realpathSync(agentsDir), agentName, ".claude");
+
+    return { agentDir, claudeDir, targetPath, expectedRealParent };
   }
 
   private lstatOrNull(path: string): ReturnType<typeof lstatSync> | null {
@@ -4107,6 +4186,25 @@ export class AuthBroker {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Log + audit a symlink/TOCTOU mirror refusal (#1393). Shared by the
+   * per-agent and per-consumer resolvers and the `safeMirrorWrite`
+   * primitive. Never throws.
+   */
+  private auditMirrorRefused(identity: Identity, component: string, reason: string): void {
+    const who = identity.kind === "operator" ? "operator" : identity.name;
+    this.logErr(
+      `mirror ${who}: REFUSING mirror — ${component} ${reason} ` +
+        `(symlink-guard #1393; peer-owned tree may be attacker-poisoned)`,
+    );
+    this.audit({
+      op: "mirror-symlink-refused",
+      identity,
+      ok: false,
+      error: `${component}:${reason}`,
+    });
   }
 
   private mirrorAccountToAgent(label: string, agentName: string): boolean {
@@ -4121,7 +4219,13 @@ export class AuthBroker {
     // the fanout.
     const safe = this.resolveMirrorPathsSafe(agentName);
     if (!safe) return false;
-    const { claudeDir, targetPath } = safe;
+    const { claudeDir, targetPath, expectedRealParent } = safe;
+    // `.claude` was lstat-verified (absent or a real dir) by
+    // `resolveMirrorPathsSafe`; `agentDir` is a verified real dir, so a
+    // recursive mkdir here only ever creates the single `.claude` leaf and
+    // cannot traverse a symlink. `safeMirrorWrite` then re-pins
+    // `realpathSync(claudeDir)` against `expectedRealParent` right before
+    // the write to close the residual lstat→write TOCTOU.
     mkdirSync(claudeDir, { recursive: true, mode: 0o700 });
     // Claude Code (2.x) reads OAuth credentials from `.credentials.json`
     // (dotfile, see the binary string table). The pre-RFC-H fanout used
@@ -4132,19 +4236,17 @@ export class AuthBroker {
     // must land at the dotfile path or agents silently lose auth on
     // first restart. Pinned by tests in server.test.ts. `targetPath`
     // is the symlink-guarded path from `resolveMirrorPathsSafe`.
-    try {
-      atomicWriteFileSync(targetPath, mirrorContent, 0o600);
-      try {
-        const uid = allocateAgentUid(agentName);
-        chownSync(targetPath, uid, uid);
-      } catch (err) {
-        this.warnCapChownMissing(err);
-      }
-      return true;
-    } catch (err) {
-      this.logErr(`fanout ${agentName} <- ${label}: ${(err as Error).message}`);
-      return false;
-    }
+    return safeMirrorWrite({
+      parentDir: claudeDir,
+      expectedRealParent,
+      targetPath,
+      content: mirrorContent,
+      uid: allocateAgentUid(agentName),
+      onChownError: (err) => this.warnCapChownMissing(err),
+      refuse: (component, reason) =>
+        this.auditMirrorRefused({ kind: "agent", name: agentName, admin: false }, component, reason),
+      logErr: (msg) => this.logErr(`fanout ${agentName} <- ${label}: ${msg}`),
+    });
   }
 
   /* ─── State persistence ─────────────────────────────────────── */

--- a/src/util/atomic.ts
+++ b/src/util/atomic.ts
@@ -27,7 +27,7 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { closeSync, constants, fsyncSync, openSync, renameSync, rmSync, writeSync } from "node:fs";
+import { closeSync, constants, fchmodSync, fchownSync, fsyncSync, openSync, renameSync, rmSync, writeSync } from "node:fs";
 
 /**
  * Tempfile open flags — sec #1410 (follow-up to CRITICAL #1393).
@@ -60,17 +60,63 @@ const TMP_OPEN_FLAGS =
   constants.O_EXCL |
   (constants.O_NOFOLLOW ?? 0);
 
+/**
+ * Options form of `atomicWriteFileSync` — lets a caller flip file
+ * ownership on the tempfile **fd** (never a path) before the rename.
+ *
+ * `uid`/`gid`: when set, the primitive `fchownSync`s the open tempfile
+ * fd to that owner *before* `rename(2)`. Doing the chown on the fd (not
+ * the destination path) is the M1 fix (#1393 follow-up): a path-based
+ * `chownSync(dest, …)` after the write would follow a symlink an
+ * attacker raced into place at the destination and hand them a
+ * root-owned chown of an arbitrary inode. The fd already points at the
+ * O_NOFOLLOW|O_EXCL-created tempfile inode, so `fchownSync` cannot be
+ * redirected.
+ *
+ * `onChownError`: dev hosts without CAP_CHOWN return EPERM on the
+ * `fchownSync`. That must NOT abort the write (the mirror still lands,
+ * just owned by whoever the broker runs as). When provided, an
+ * `fchownSync` error is passed here and swallowed; otherwise it throws.
+ * A chmod/write/fsync/rename error is always fatal (tempfile cleaned,
+ * rethrown) regardless.
+ */
+export interface AtomicWriteOptions {
+  mode?: number;
+  uid?: number;
+  gid?: number;
+  onChownError?: (err: unknown) => void;
+}
+
 export function atomicWriteFileSync(
   destPath: string,
   contents: string | Buffer,
-  mode = 0o600,
+  modeOrOpts: number | AtomicWriteOptions = 0o600,
 ): void {
+  const opts: AtomicWriteOptions =
+    typeof modeOrOpts === "number" ? { mode: modeOrOpts } : modeOrOpts;
+  const mode = opts.mode ?? 0o600;
   const tmp = `${destPath}.tmp-${process.pid}-${randomBytes(4).toString("hex")}`;
   const buf = typeof contents === "string" ? Buffer.from(contents, "utf-8") : contents;
   let fd: number | null = null;
   try {
     fd = openSync(tmp, TMP_OPEN_FLAGS, mode);
     writeSync(fd, buf, 0, buf.length, 0);
+    // Pin the mode on the fd explicitly: the O_CREAT `mode` above is
+    // masked by the process umask, but the callers here write secrets
+    // and need an exact 0600 regardless of umask.
+    fchmodSync(fd, mode);
+    // fd-based ownership flip BEFORE rename — never a path-based chown
+    // (which would follow a raced symlink at the destination). EPERM on
+    // a CAP_CHOWN-less host is swallowed via onChownError so the write
+    // still lands.
+    if (opts.uid !== undefined) {
+      try {
+        fchownSync(fd, opts.uid, opts.gid ?? opts.uid);
+      } catch (chownErr) {
+        if (opts.onChownError) opts.onChownError(chownErr);
+        else throw chownErr;
+      }
+    }
     fsyncSync(fd);
     closeSync(fd);
     fd = null;


### PR DESCRIPTION
## PR1 of the auth-broker fix package — H1 + M1

Extracts a shared **`safeMirrorWrite`** primitive used by BOTH
`mirrorAccountToConsumer` and `mirrorAccountToAgent`, closing two
vulnerabilities in the root broker's credential fanout (it runs with
`CAP_DAC_OVERRIDE` over agent/consumer-writable trees).

### H1 — consumer mirror had zero symlink guard
`mirrorAccountToConsumer` did a raw `mkdirSync({recursive}) +
atomicWriteFileSync + chownSync(path)` with **no** lstat validation
(unlike the agent path's `resolveMirrorPathsSafe`). A compromised
consumer could plant `mirror_dir`, its `.credentials.json` target, or a
**symlinked ancestor of a not-yet-existing `mirror_dir`** and redirect
the root write to an arbitrary host path.

New `resolveConsumerMirrorPathsSafe` lstat-validates every controllable
component and — harsher than the agent tree, since `mirror_dir` is
consumer-writable and broker-created — creates `mirror_dir`
**non-recursively, only through a real (non-symlink) parent**.

### M1 — residual lstat→open/chown TOCTOU closed
- `safeMirrorWrite` re-pins the containing dir's **canonical
  `realpathSync`** against the caller's expected parent immediately
  before the write.
- `atomicWriteFileSync` now flips ownership on the tempfile **fd**
  (`fchmod`/`fchown` before `rename`) instead of a path-based
  `chownSync` that would follow a raced symlink at the destination. The
  existing `O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW` tempfile dance is
  **reused, not reimplemented**.

Node lacks the `*at()` syscall family, so canonical-parent pinning +
fd-relative metadata is the strongest available guard; the residual
(a parent-dir swap in the sub-ms window between `realpathSync` and
`rename`) is documented.

### Preserved behaviour (red-team item 4)
- `resolveMirrorPathsSafe` still **silently skips** a not-yet-scaffolded
  `agentDir` (returns null, no audit) — no audit spam for unscaffolded
  agents.
- The CAP_CHOWN-missing swallow moved to the `fchown(fd)` site: an
  `fchown` EPERM does **not** abort the write (mirror still lands 0600).

### Fail-closed
A refusal skips that one peer's mirror, logs + audits
`mirror-symlink-refused`, and never throws across the fanout — one
poisoned peer cannot DoS the fleet's auth.

### Tests
`src/auth/broker/server-consumer-mirror-symlink-guard.test.ts`:
- `mirror_dir` symlink → refused + audited; **other consumers still
  mirrored** (no fleet DoS)
- pre-planted `.credentials.json` symlink → refused; outside file
  untouched
- symlinked ancestor of not-yet-existing `mirror_dir` → refused (this
  case actually escape-writes on pre-fix code)
- happy path → 0600, enriched content, canonical non-symlink path
- `fchown` EPERM → file still lands 0600

The three symlink-refusal tests were confirmed to **fail against
pre-fix code** (the ancestor case escape-writes today). Updated the
existing Bug-1 source pin to assert the fd-based chown and to guard
against reintroducing the path-based `chownSync`.

Scoped `vitest` (all 536 auth-broker + atomic tests) and `npm run lint`
green locally.

Live-config note: no consumer currently sets `mirror_dir`, so this
hardens a currently-unexercised path — correct to fix, zero live blast
radius today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)