### PR TITLE
fix(memory): tighten DEFAULT_RETAIN_MISSION against process narration

### DIFF
--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -225,6 +225,16 @@ export function isHindsightEnabled(
  * memory quality (less conversational filler stored, fewer marginal hits
  * surfacing in subsequent recalls).
  *
+ * 2026-07-19 (hindsight fleet review): live fleet banks skewed heavily
+ * toward transient in-flight-task narration ("P6 worker paused waiting on
+ * its PR", "three more tracks dispatched") — experience-node volume
+ * exceeded world-fact volume on the busiest bank. That class of memory is
+ * process status, not a fact/decision/outcome worth recalling later, and
+ * it's exactly what feeds the consolidation backlog. Added an explicit
+ * carve-out below so the extraction step recognizes it as noise alongside
+ * one-off chatter, not just "temporary task noise" (which didn't stop the
+ * pattern in practice).
+ *
  * Switchroom seeds this for newly scaffolded agents only (see
  * `scaffoldAgent` in `src/agents/scaffold.ts`). Existing agents'
  * missions are left alone — operators may have customized them, and
@@ -235,7 +245,10 @@ export function isHindsightEnabled(
 export const DEFAULT_RETAIN_MISSION =
   "Extract user preferences, ongoing projects, recurring commitments, " +
   "important context, and durable facts that should help across future " +
-  "conversations. Skip one-off chatter and temporary task noise.";
+  "conversations. Skip one-off chatter and temporary task noise, " +
+  "including in-flight workflow/process narration (a sub-task started, " +
+  "paused, or is still running) — only retain the outcome once a task " +
+  "actually completes or a decision is made.";
 
 /**
  * Hindsight bank disposition traits (1-5 each). Mirrors the engine's flat

--- a/tests/memory.bank-missions.test.ts
+++ b/tests/memory.bank-missions.test.ts
@@ -23,15 +23,16 @@ async function captureUpdateBankArgs(
 }
 
 describe("DEFAULT_RETAIN_MISSION", () => {
-  it("matches upstream Hindsight per-user-memory guide wording", () => {
-    // Sourced verbatim from
+  it("starts from the upstream Hindsight per-user-memory guide wording", () => {
+    // Base sourced verbatim from
     // hindsight-docs/guides/2026-04-15-guide-openclaw-per-user-memory-across-channels-setup.md
-    // lines 188-193.
-    expect(DEFAULT_RETAIN_MISSION).toBe(
+    // lines 188-193; extended 2026-07-19 (hindsight fleet review) with an
+    // explicit in-flight-process-narration carve-out — see block comment.
+    expect(DEFAULT_RETAIN_MISSION.startsWith(
       "Extract user preferences, ongoing projects, recurring commitments, " +
         "important context, and durable facts that should help across future " +
-        "conversations. Skip one-off chatter and temporary task noise.",
-    );
+        "conversations. Skip one-off chatter and temporary task noise,",
+    )).toBe(true);
   });
 
   it("explicitly tells extraction to skip conversational filler", () => {
@@ -42,6 +43,17 @@ describe("DEFAULT_RETAIN_MISSION", () => {
   it("focuses on durable, cross-conversation signal", () => {
     expect(DEFAULT_RETAIN_MISSION).toContain("durable facts");
     expect(DEFAULT_RETAIN_MISSION).toContain("across future");
+  });
+
+  // Regression for the 2026-07-19 fleet review (REPORT.md finding B1):
+  // live banks were dominated by transient in-flight task narration
+  // ("P6 worker paused waiting on its PR") rather than durable facts —
+  // that class of memory feeds the consolidation backlog for no lasting
+  // recall value. The mission must name it explicitly so extraction
+  // recognizes it, not just lump it under vague "task noise".
+  it("explicitly excludes in-flight workflow/process narration", () => {
+    expect(DEFAULT_RETAIN_MISSION).toContain("in-flight workflow/process narration");
+    expect(DEFAULT_RETAIN_MISSION).toContain("only retain the outcome once a task");
   });
 });
 


### PR DESCRIPTION
## Summary
- 2026-07-19 fleet review (`work/hindsight-review-20260719/REPORT.md`, finding B1) found retain signal on the busiest live bank skewed to transient in-flight workflow narration ("P6 worker paused waiting on its PR") rather than durable facts — experience nodes (30.5k) outnumbered world-fact nodes (22.8k) on klanker's bank. That class of memory feeds the consolidation backlog for no lasting recall value.
- `DEFAULT_RETAIN_MISSION` (`src/memory/hindsight.ts`) already told extraction to skip "one-off chatter and temporary task noise" but that wording didn't stop the pattern in practice — the mission needs to name in-flight process/workflow narration explicitly.
- Applies to newly-scaffolded agents only (existing agents' missions are operator-owned per `reconcileAgent`'s documented behavior — out of scope here; see report for the live-bank remediation done as a direct infra action).

## Test plan
- [x] `./node_modules/.bin/vitest run tests/memory.bank-missions.test.ts tests/setup/hindsight.test.ts` — 78/78 passing, including new regression `explicitly excludes in-flight workflow/process narration`
- [x] `npm run lint` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)