### PR TITLE
docs: hindsight per-op model change runbook + operator skill pointer

### DIFF
--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -9,7 +9,10 @@ optional metering gateway sits in the path. Related reading:
 [`docs/architecture.md`](architecture.md) (process model),
 [`docs/vault-broker.md`](vault-broker.md) (per-consumer virtual keys),
 [`docs/operators/hindsight-memory.md`](operators/hindsight-memory.md) (the
-`hindsight.llm` operator surface), and
+`hindsight.llm` operator surface),
+[`docs/operators/hindsight-model-change.md`](operators/hindsight-model-change.md)
+(runbook for swapping hindsight per-op models — routing lanes, recreate,
+verification, rollback), and
 [`reference/invariants.md`](../reference/invariants.md) §"Operator-controlled
 gateway carve-out".
 

--- a/docs/operators/hindsight-memory.md
+++ b/docs/operators/hindsight-memory.md
@@ -138,6 +138,12 @@ anything unset.
 Takes effect on the next `switchroom memory setup` / rollout recreate of the
 hindsight container (env is read at container launch).
 
+**Changing models?** Follow the step-by-step runbook in
+[`hindsight-model-change.md`](hindsight-model-change.md) — it covers the two
+routing lanes (per-op `model:` alone does NOT reroute under a `claude-code`
+global; see `docs/model-routing.md` G1/G5), the recreate-from-the-host
+requirement, verification, and rollback.
+
 ## Health
 
 The container now carries a Docker **healthcheck** (`/health` via

--- a/docs/operators/hindsight-model-change.md
+++ b/docs/operators/hindsight-model-change.md
@@ -1,0 +1,161 @@
+# Runbook — changing Hindsight per-op LLM models
+
+How to change which model runs Hindsight's LLM operations (retain /
+reflect / consolidation — recall is local-only, no LLM) **without**
+accidentally leaving the traffic on the wrong lane or the old config
+silently live. Each step below encodes a mistake that was actually made
+in production; don't skip the verification.
+
+Background surfaces: schema + inheritance in
+[`hindsight-memory.md` § "LLM model selection"](hindsight-memory.md#llm-model-selection-hindsightllm);
+routing internals and known gaps (G1–G7) in
+[`docs/model-routing.md`](../model-routing.md).
+
+## 1. The yaml shape
+
+Per-op routing lives in the operator's `switchroom.yaml` under
+`hindsight.llm.{retain,reflect,consolidation}`. Any field an op omits
+inherits the global `hindsight.llm.provider`/`model`.
+
+```yaml
+hindsight:
+  llm:
+    # global default (omit to keep the fleet default)
+    # provider: claude-code
+    # model: claude-sonnet-5
+    retain:
+      provider: litellm
+      model: openai/gpt-oss-20b
+      base_url: "http://127.0.0.1:4010/v1"
+      api_key: "vault:litellm/hindsight-virtual-key"   # LiteLLM virtual key
+    reflect:
+      provider: litellm
+      model: openai/gpt-oss-20b
+      base_url: "http://127.0.0.1:4010/v1"
+      api_key: "vault:litellm/hindsight-virtual-key"
+    consolidation:
+      provider: litellm
+      model: openai/gpt-oss-20b
+      base_url: "http://127.0.0.1:4010/v1"
+      api_key: "vault:litellm/hindsight-virtual-key"
+```
+
+## 2. Pick the routing lane — `model:` alone does NOT reroute
+
+This is the #1 repeat mistake (`docs/model-routing.md` G1/G5): when the
+**global** provider is `claude-code`, setting only a per-op `model:` does
+not change where the traffic goes. The container-level
+`ANTHROPIC_BASE_URL`/OAuth path is derived from the **global** model
+only, and the upstream `claude-code` provider ignores `ANTHROPIC_BASE_URL`
+under OAuth auth regardless. Two correct lanes:
+
+**Lane A — non-Claude model via LiteLLM** (move burn off the Anthropic
+subscription onto e.g. `openai/gpt-oss-20b`). The op MUST carry all four
+fields — `provider: litellm` selects hindsight's real OpenAI-compatible
+client (no OAuth), and it needs its own endpoint + credential:
+
+```yaml
+retain:
+  provider: litellm
+  model: openai/gpt-oss-20b
+  base_url: "http://127.0.0.1:4010/v1"     # LiteLLM proxy, /v1
+  api_key: "vault:litellm/hindsight-virtual-key"
+```
+
+**Lane B — subscription Claude via the broker OAuth passthrough**. Use
+`provider: claude-code` + a Claude model-group name, with **no**
+`base_url` / `api_key` (the broker-written OAuth credential and the
+LiteLLM `/anthropic` passthrough handle routing):
+
+```yaml
+retain:
+  provider: claude-code
+  model: claude-sonnet-5
+```
+
+Mixing the lanes (e.g. `provider: claude-code` + `base_url`) or taking a
+half-lane (`provider: litellm` without `base_url`/`api_key`) is a
+misconfiguration — expect hard-failed memory ops or, worse, traffic
+silently landing on the subscription.
+
+## 3. Apply — recreate the container, from the HOST
+
+Env is read only at container launch. A plain `docker restart
+switchroom-hindsight` does **not** re-derive env from yaml — you must
+recreate:
+
+```bash
+switchroom memory setup --recreate            # follows release.pin if set
+switchroom memory setup --recreate --tag vX.Y.Z   # explicit fleet-release pin
+```
+
+**Run this on the host, not inside an agent container.** Agent containers
+export `SWITCHROOM_CONFIG=/state/config/switchroom.yaml` — a read-only,
+apply-time **snapshot**. A CLI run in that environment silently reads the
+stale snapshot and recreates hindsight with the OLD config, reporting
+success. If you must run it from a container that mounts the host, point
+the CLI at the real yaml explicitly:
+
+```bash
+SWITCHROOM_CONFIG=/host/home/<operator>/.switchroom/switchroom.yaml \
+  switchroom memory setup --recreate
+```
+
+## 4. Verify — env, then health
+
+Don't trust the recreate's exit code; check what the container actually
+got:
+
+```bash
+docker inspect switchroom-hindsight --format '{{json .Config.Env}}' \
+  | tr ',' '\n' | grep -E 'HINDSIGHT_API_(RETAIN|REFLECT|CONSOLIDATION)?_?LLM'
+docker inspect switchroom-hindsight --format '{{.State.Health.Status}}'
+```
+
+Expect `HINDSIGHT_API_<OP>_LLM_MODEL` / `_PROVIDER` (and `_BASE_URL` for
+lane A) to match the new yaml, and health to reach `healthy`. If an op's
+vars are absent, it inherits the global `HINDSIGHT_API_LLM_*` — confirm
+that's what you intended.
+
+## 5. Rollouts can silently REVERT your change — refresh hostd's config view
+
+Observed live (v0.19.1 rollout, 2026-07-19): a hostd-driven
+`switchroom rollout` recreated hindsight from hostd's **own** view of
+`/state/config/switchroom.yaml`, which was hours stale, and silently
+reverted a just-applied retain model change. The host yaml edit was
+intact; only hostd's view of it was stale.
+
+Why: the singletons bind-mount the yaml as a **single file**
+(`<home>/.switchroom/switchroom.yaml:/state/config/switchroom.yaml`,
+`src/cli/hostd.ts:316`). Switchroom's config writers are atomic
+(write-temp + `rename`, e.g. `src/config/overlay-writer.ts:181`), and many
+editors save the same way — the rename swaps the **inode**, while Docker's
+file bind mount stays pinned to the old inode. From that moment the
+container reads a frozen pre-edit snapshot until it restarts (restart
+re-resolves the bind path).
+
+So, after editing `hindsight.llm` in the host yaml:
+
+- **Refresh hostd's view**: `docker restart switchroom-hostd` (do the same
+  for any singleton that will act on the config) so a later rollout
+  carries your edit instead of the stale inode.
+- **After ANY fleet rollout or hostd-driven recreate**, re-run the step-4
+  `docker inspect` verification — assume a rollout may have reverted the
+  hindsight env until proven otherwise.
+- Recovery if it did revert: re-run `switchroom memory setup --recreate`
+  on the host against the live yaml, then re-verify.
+
+## 6. Rollback — keep the previous config in a comment
+
+Before editing, copy the outgoing per-op block into a dated yaml comment
+next to the new one ("interim config, restore if X fails again: …").
+Rollback is then: uncomment / re-paste the old block, re-run the recreate
+(step 3), re-verify (step 4). The live host yaml carries examples of this
+comment convention.
+
+## Known failure modes to watch after a swap
+
+- **Proxy down ⇒ hindsight hard-fails** memory ops (no boot probe, no
+  fallback — `docs/model-routing.md` G2).
+- **OpenRouter credit exhaustion ⇒ op-class goes dark silently** (G6);
+  consolidation stalls and re-polls until credits are topped up.

--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -263,6 +263,31 @@ If the user asks whether scheduled runs were missed during downtime: the schedul
 
 ---
 
+## Hindsight model change — "swap the memory model", "move retain off the subscription"
+
+Changing which LLM runs Hindsight's retain / reflect / consolidation ops is a
+config-plus-recreate operation with three known traps. **Follow the runbook:
+`docs/operators/hindsight-model-change.md`.** The short version:
+
+1. Edit `hindsight.llm.{retain,reflect,consolidation}` in the operator's
+   `switchroom.yaml` — keep the outgoing block in a dated comment for rollback.
+2. Pick a full lane: non-Claude via LiteLLM needs `provider: litellm` +
+   `model` + `base_url` + `api_key`; subscription Claude needs
+   `provider: claude-code` + a Claude model name with NO base_url/api_key.
+   A per-op `model:` alone does **not** reroute (docs/model-routing.md G1/G5).
+3. Apply with `switchroom memory setup --recreate` **on the host** — a plain
+   `docker restart` does not re-derive env, and running the CLI inside an
+   agent container silently reads the stale `SWITCHROOM_CONFIG` snapshot.
+4. Verify with `docker inspect switchroom-hindsight`:
+   `HINDSIGHT_API_<OP>_LLM_MODEL` / `_PROVIDER` / `_BASE_URL` match the yaml,
+   and health reaches `healthy`.
+5. `docker restart switchroom-hostd` after the yaml edit, and **re-verify after
+   any fleet rollout** — the singletons bind-mount the yaml as a single file,
+   so an atomic (rename-based) edit leaves them pinned to the stale old inode
+   and a hostd-driven rollout can silently revert the model change.
+
+---
+
 ## Telegram plugin reference — "what MCP tools", "how does reply work"
 
 The `switchroom-telegram` plugin is an enhanced fork of the official Telegram MCP plugin and is the default for all switchroom agents. It exposes **9 MCP tools** (all prefixed `mcp__switchroom-telegram__`):

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -359,7 +359,7 @@ export function registerMemoryCommand(program: Command): void {
     .option("--status", "Show Hindsight container status")
     .option(
       "--recreate",
-      "Pull the latest image and recreate the container (reusing its current port). Used by `switchroom update` to keep the hindsight singleton current.",
+      "Pull the latest image and recreate the container (reusing its current port). Used by `switchroom update` to keep the hindsight singleton current. Also required after any `hindsight.llm` model/provider config change — env is only re-derived on recreate, a plain docker restart is not enough (see docs/operators/hindsight-model-change.md).",
     )
     .option(
       "--tag <version>",


### PR DESCRIPTION
## What

Durable guidance for changing Hindsight per-op LLM models (`hindsight.llm.{retain,reflect,consolidation}`), so future swaps stop repeating the same production mistakes.

- **New runbook** `docs/operators/hindsight-model-change.md`: yaml shape, both routing lanes (LiteLLM `provider: litellm` + base_url + api_key vs subscription Claude `provider: claude-code` with neither), the `memory setup --recreate` requirement, the stale `SWITCHROOM_CONFIG` snapshot pitfall (run on the host), env + health verification, rollout-revert pitfall, and comment-based rollback.
- **Cross-links** from `docs/operators/hindsight-memory.md` (LLM section) and `docs/model-routing.md` intro.
- **Operator-facing skill pointer**: new "Hindsight model change" section in `skills/switchroom-cli/SKILL.md` with the 5-step short version.
- **CLI help**: `memory setup --recreate` description now says it is required for `hindsight.llm` changes (a plain docker restart is not enough).

## Live-verified pitfall #4 (2026-07-19, v0.19.1 rollout)

A hostd-driven rollout recreated hindsight from a stale config view and silently reverted a just-applied retain model change. Root cause verified live: the singletons bind-mount `switchroom.yaml` as a **single file** (`src/cli/hostd.ts:316`); atomic write-temp+`rename` edits (e.g. `src/config/overlay-writer.ts:181`, and most editors) swap the inode while the bind mount stays pinned to the old one (host inode `28108609` vs hostd's `28108318`, observed today). The runbook now says: restart hostd after editing, and re-verify hindsight env after any rollout.

## Follow-up (not in this PR)

A cheap durable fix would be for the rollout / hostd recreate path to re-open the config from the bind path per-operation AND for the singleton mounts to bind the *directory* (`~/.switchroom`) rather than the single file, so rename-based edits are always visible without a container restart. Filed as a suggestion here rather than ballooning this docs PR.

## Testing

- `npm run lint` clean (exit 0)
- Scoped: `vitest run src/cli/memory-atomic.test.ts src/cli/memory-setup-tag.test.ts` — 9/9 pass (help-string-only change in `src/cli/memory.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)