### PR TITLE
feat(usage): External 24h/7d OpenRouter spend on /usage card

### DIFF
--- a/telegram-plugin/external-spend.ts
+++ b/telegram-plugin/external-spend.ts
@@ -293,10 +293,6 @@ export async function resolveLitellmAdminKey(
 
 function defaultReadAdminKeyRef(): string | null {
   try {
-    // Dynamic import path keeps unit tests that never touch config hermetic
-    // when they inject readAdminKeyRef. Production uses loadConfig.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { loadConfig, findConfigFile } = require('../src/config/loader.js') as typeof import('../src/config/loader.js');
     const cfgPath = findConfigFile();
     const cfg = loadConfig(cfgPath) as { litellm?: { admin_key?: string } };
     const ref = cfg.litellm?.admin_key;

--- a/telegram-plugin/external-spend.ts
+++ b/telegram-plugin/external-spend.ts
@@ -1,0 +1,384 @@
+/**
+ * External (non-Claude / OpenRouter cash) spend for the `/usage` card.
+ *
+ * Layout B (operator-locked 2026-07-19):
+ * ```
+ * - 💸 External
+ * - 24h `$X.XX` · 7d `$Y.YY`
+ * - top `model $a` · `model $b` · `model $c`
+ * ```
+ *
+ * Source: LiteLLM `GET /spend/logs?start_date&end_date` daily summaries
+ * (admin/master key). Agent virtual keys get 401 — resolve master via env
+ * or vault `litellm/master-key`. On any failure, callers OMIT the block.
+ *
+ * Successful summaries are cached in-process (~90s) so Refresh spam does not
+ * hammer LiteLLM. Never log key material.
+ */
+
+import {
+  getViaBrokerStructured,
+  readVaultTokenFile,
+} from '../src/vault/broker/client.js';
+import { loadConfig, findConfigFile } from '../src/config/loader.js';
+
+export interface ExternalSpendTopModel {
+  label: string;
+  usd: number;
+}
+
+export interface ExternalSpendSummary {
+  day24hUsd: number;
+  day7dUsd: number;
+  top: ExternalSpendTopModel[];
+}
+
+/** One daily row from LiteLLM summarized `/spend/logs`. */
+export interface LiteLLMDaySpendRow {
+  startTime?: string;
+  /** Day total including Claude — never used as External. */
+  spend?: number;
+  models?: Record<string, number | string>;
+}
+
+export const EXTERNAL_SPEND_CACHE_TTL_MS = 90_000;
+export const EXTERNAL_SPEND_FETCH_TIMEOUT_MS = 4_000;
+export const DEFAULT_LITELLM_BASE = 'http://127.0.0.1:4010';
+const TOP_N = 3;
+
+const BARE_EXTERNAL_NEEDLES = [
+  'gpt-oss',
+  'grok',
+  'gemini',
+  'deepseek',
+  'kimi',
+  'glm-',
+  'qwen',
+  'llama',
+] as const;
+
+let cache: { atMs: number; summary: ExternalSpendSummary } | null = null;
+
+/** Test seam — clear the in-process cache. */
+export function clearExternalSpendCache(): void {
+  cache = null;
+}
+
+/**
+ * True when a LiteLLM model name is cash/external (OpenRouter etc.), not
+ * Anthropic Max/Pro subscription passthrough via the proxy.
+ */
+export function isExternalModel(model: string): boolean {
+  const m = model.trim().toLowerCase();
+  if (!m) return false;
+  // Subscription Claude / Anthropic passthrough — never External $.
+  if (m.startsWith('claude')) return false;
+  if (m.includes('anthropic/claude')) return false;
+  if (m.startsWith('anthropic/claude')) return false;
+
+  if (m.startsWith('openrouter/')) return true;
+  if (m.startsWith('sr-')) return true;
+
+  // Bare aliases / non-openrouter-prefixed cash models seen in logs.
+  for (const needle of BARE_EXTERNAL_NEEDLES) {
+    if (m.includes(needle)) return true;
+  }
+  return false;
+}
+
+/** Strip openrouter/ and keep a short trailing id for the top line. */
+export function shortModelLabel(model: string): string {
+  let m = model.trim();
+  if (m.toLowerCase().startsWith('openrouter/')) {
+    m = m.slice('openrouter/'.length);
+  }
+  // Path-like org/model → last segment (openai/gpt-oss-20b → gpt-oss-20b).
+  const parts = m.split('/').filter(Boolean);
+  if (parts.length >= 2) {
+    m = parts[parts.length - 1]!;
+  }
+  if (m.toLowerCase().startsWith('sr-')) {
+    // sr-grok-4.5 → grok-4.5
+    m = m.slice(3);
+  }
+  return m || model.trim();
+}
+
+export function formatUsd(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return '$0.00';
+  return `$${n.toFixed(2)}`;
+}
+
+export function utcDateString(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function addUtcDays(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const dt = new Date(Date.UTC(y!, m! - 1, d!));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return utcDateString(dt);
+}
+
+function rowDay(row: LiteLLMDaySpendRow): string | null {
+  const st = row.startTime;
+  if (!st || typeof st !== 'string') return null;
+  // "2026-07-19" or ISO timestamp
+  return st.length >= 10 ? st.slice(0, 10) : null;
+}
+
+function externalModelsFromRow(row: LiteLLMDaySpendRow): Record<string, number> {
+  const out: Record<string, number> = {};
+  const models = row.models ?? {};
+  for (const [name, raw] of Object.entries(models)) {
+    if (!isExternalModel(name)) continue;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isFinite(n) || n === 0) continue;
+    out[name] = (out[name] ?? 0) + n;
+  }
+  return out;
+}
+
+/**
+ * Pure aggregator — unit-test without network.
+ * `now` pins the UTC "today" used for 24h / 7d windows.
+ *
+ * Windows (UTC calendar days on LiteLLM `startTime`):
+ *   - 24h: today only
+ *   - 7d:  today-6 .. today inclusive
+ * Top models: aggregate external spend across the 7d window, top 3.
+ * Does NOT use `row.spend` (mixed Claude + external).
+ */
+export function summarizeExternalSpend(
+  days: readonly LiteLLMDaySpendRow[],
+  now: Date = new Date(),
+): ExternalSpendSummary {
+  const today = utcDateString(now);
+  const start7 = addUtcDays(today, -6); // inclusive 7 calendar days
+
+  let day24hUsd = 0;
+  let day7dUsd = 0;
+  const byModel: Record<string, number> = {};
+
+  for (const row of days) {
+    const day = rowDay(row);
+    if (!day) continue;
+    if (day < start7 || day > today) continue;
+    const ext = externalModelsFromRow(row);
+    let rowSum = 0;
+    for (const [name, usd] of Object.entries(ext)) {
+      rowSum += usd;
+      byModel[name] = (byModel[name] ?? 0) + usd;
+    }
+    day7dUsd += rowSum;
+    if (day === today) day24hUsd += rowSum;
+  }
+
+  const top = Object.entries(byModel)
+    .filter(([, usd]) => usd > 0)
+    .sort((a, b) => b[1]! - a[1]! || a[0]!.localeCompare(b[0]!))
+    .slice(0, TOP_N)
+    .map(([name, usd]) => ({ label: shortModelLabel(name), usd }));
+
+  return { day24hUsd, day7dUsd, top };
+}
+
+/**
+ * Render layout-B bullet lines (no trailing freshness).
+ * Returns `[]` when summary is null/undefined so callers can omit.
+ * Zero totals still render — honest "no external spend".
+ */
+export function formatExternalSpendBlock(
+  summary: ExternalSpendSummary | null | undefined,
+): string[] {
+  if (summary == null) return [];
+  const lines = [
+    '- 💸 External',
+    `- 24h \`${formatUsd(summary.day24hUsd)}\` · 7d \`${formatUsd(summary.day7dUsd)}\``,
+  ];
+  if (summary.top.length > 0) {
+    const topParts = summary.top.map((t) => `\`${t.label} ${formatUsd(t.usd)}\``);
+    lines.push(`- top ${topParts.join(' · ')}`);
+  }
+  return lines;
+}
+
+/** Strip a leading `vault:` reference to the bare key name. */
+export function vaultKeyFromRef(ref: string): string | null {
+  const t = ref.trim();
+  if (!t.toLowerCase().startsWith('vault:')) return null;
+  const key = t.slice('vault:'.length).trim();
+  return key.length > 0 ? key : null;
+}
+
+export function resolveLitellmBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const raw = (env.SWITCHROOM_LITELLM_BASE ?? DEFAULT_LITELLM_BASE).trim();
+  return raw.replace(/\/+$/, '') || DEFAULT_LITELLM_BASE;
+}
+
+/**
+ * Normalize a `/spend/logs` JSON body into day rows. LiteLLM has returned
+ * either a bare array or `{ data: [...] }` depending on version.
+ */
+export function normalizeSpendLogRows(body: unknown): LiteLLMDaySpendRow[] {
+  if (Array.isArray(body)) return body as LiteLLMDaySpendRow[];
+  if (body && typeof body === 'object') {
+    const data = (body as { data?: unknown }).data;
+    if (Array.isArray(data)) return data as LiteLLMDaySpendRow[];
+  }
+  return [];
+}
+
+export interface ResolveAdminKeyDeps {
+  env?: NodeJS.ProcessEnv;
+  /** Raw `litellm.admin_key` from config (may be `vault:…`). */
+  readAdminKeyRef?: () => string | null | undefined;
+  vaultGet?: (key: string) => Promise<string | null>;
+  agentName?: string;
+}
+
+/**
+ * Resolve LiteLLM master/admin key for `/spend/logs`. Never logs the value.
+ * Order: env → config vault ref via broker → null.
+ */
+export async function resolveLitellmAdminKey(
+  deps: ResolveAdminKeyDeps = {},
+): Promise<string | null> {
+  const env = deps.env ?? process.env;
+  const fromEnv = (
+    env.SWITCHROOM_LITELLM_ADMIN_KEY ??
+    env.LITELLM_MASTER_KEY ??
+    ''
+  ).trim();
+  if (fromEnv) return fromEnv;
+
+  let ref: string | null | undefined;
+  try {
+    ref = deps.readAdminKeyRef
+      ? deps.readAdminKeyRef()
+      : defaultReadAdminKeyRef();
+  } catch {
+    ref = null;
+  }
+
+  const vaultKey = ref ? vaultKeyFromRef(ref) : null;
+  if (ref && !vaultKey) {
+    // Literal non-vault value in config (dev only).
+    const plain = ref.trim();
+    return plain.length > 0 ? plain : null;
+  }
+  const keyName = vaultKey ?? 'litellm/master-key';
+
+  if (deps.vaultGet) {
+    try {
+      return await deps.vaultGet(keyName);
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    const agent = deps.agentName ?? env.SWITCHROOM_AGENT_NAME;
+    const token = agent ? (readVaultTokenFile(agent) ?? undefined) : undefined;
+    const result = await getViaBrokerStructured(keyName, token ? { token } : {});
+    if (result.kind === 'ok' && result.entry.kind === 'string' && result.entry.value) {
+      const v = result.entry.value.trim();
+      return v.length > 0 ? v : null;
+    }
+  } catch {
+    // omit External
+  }
+  return null;
+}
+
+function defaultReadAdminKeyRef(): string | null {
+  try {
+    // Dynamic import path keeps unit tests that never touch config hermetic
+    // when they inject readAdminKeyRef. Production uses loadConfig.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { loadConfig, findConfigFile } = require('../src/config/loader.js') as typeof import('../src/config/loader.js');
+    const cfgPath = findConfigFile();
+    const cfg = loadConfig(cfgPath) as { litellm?: { admin_key?: string } };
+    const ref = cfg.litellm?.admin_key;
+    return typeof ref === 'string' && ref.trim() ? ref.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface FetchExternalSpendDeps {
+  env?: NodeJS.ProcessEnv;
+  now?: Date;
+  fetchImpl?: typeof fetch;
+  resolveAdminKey?: () => Promise<string | null>;
+  resolveBaseUrl?: () => string;
+  cacheTtlMs?: number;
+  timeoutMs?: number;
+  /** When true, bypass the in-process TTL cache (tests). */
+  bypassCache?: boolean;
+}
+
+/**
+ * Best-effort fleet External spend for `/usage`. Returns null when the
+ * summary is unavailable (no key, timeout, 401, etc.) — caller omits the block.
+ * Successful results are cached ~90s.
+ */
+export async function fetchExternalSpendSummary(
+  nowOrDeps: Date | FetchExternalSpendDeps = {},
+): Promise<ExternalSpendSummary | null> {
+  // Backward-compatible: `fetchExternalSpendSummary(new Date())` still works.
+  const deps: FetchExternalSpendDeps =
+    nowOrDeps instanceof Date ? { now: nowOrDeps } : nowOrDeps;
+  const now = deps.now ?? new Date();
+  const ttl = deps.cacheTtlMs ?? EXTERNAL_SPEND_CACHE_TTL_MS;
+  if (!deps.bypassCache && cache && Date.now() - cache.atMs < ttl) {
+    return cache.summary;
+  }
+
+  const env = deps.env ?? process.env;
+  const resolveKey =
+    deps.resolveAdminKey ?? (() => resolveLitellmAdminKey({ env }));
+  let key: string | null;
+  try {
+    key = await resolveKey();
+  } catch {
+    return null;
+  }
+  if (!key) return null;
+
+  const base = (deps.resolveBaseUrl ?? (() => resolveLitellmBaseUrl(env)))();
+  const today = utcDateString(now);
+  const start = addUtcDays(today, -6);
+  const end = addUtcDays(today, 1); // exclusive-ish end for LiteLLM
+  const url = `${base}/spend/logs?start_date=${encodeURIComponent(start)}&end_date=${encodeURIComponent(end)}`;
+
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const timeoutMs = deps.timeoutMs ?? EXTERNAL_SPEND_FETCH_TIMEOUT_MS;
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${key}`,
+        Accept: 'application/json',
+      },
+      signal: ac.signal,
+    });
+    if (!res.ok) return null;
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      return null;
+    }
+    const rows = normalizeSpendLogRows(body);
+    const summary = summarizeExternalSpend(rows, now);
+    cache = { atMs: Date.now(), summary };
+    return summary;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -21515,12 +21515,17 @@ bot.command('usage', async ctx => {
         // segment, just relative instead of absolute — no info lost; the
         // recommendation + cached/live footer the table used to carry are
         // preserved by renderUsageCard.
+        // External OpenRouter/$ block (layout B) — best-effort; omitted when
+        // LiteLLM admin key is unavailable or the spend endpoint fails.
+        const { fetchExternalSpendSummary } = await import('../external-spend.js')
+        const externalSpend = await fetchExternalSpendSummary(renderNow).catch(() => null)
         const exhaustedByLabel = new Map<string, boolean>(
           state.accounts.map((a) => [a.label, a.exhausted]),
         )
         const text = renderUsageCard(snapshots, exhaustedByLabel, {
           now: renderNow,
           demo,
+          externalSpend,
           // #2495 Change 2 — a TTL-hit / failed-probe fallback is tagged
           // served:"cache"; surface it as `⚠ cached Nm ago` instead of a
           // false live stamp. Otherwise stamp the live refresh time.

--- a/telegram-plugin/quota-bar-format.ts
+++ b/telegram-plugin/quota-bar-format.ts
@@ -42,6 +42,7 @@ import type { AccountState, ListStateData } from '../src/auth/broker/client.js';
 import { reviveLastQuota, recommendation, type AccountSnapshot } from './auth-snapshot-format.js';
 import { escapeMarkdown } from './card-format.js';
 import { maskEmail } from './demo-mask.js';
+import { formatExternalSpendBlock } from './external-spend.js';
 
 // ── dot thresholds ───────────────────────────────────────────────────
 
@@ -257,6 +258,17 @@ export interface UsageCardRenderOpts extends QuotaBarRenderOpts {
    * because in that case there IS real data, just stale.
    */
   probeFailed?: boolean;
+  /**
+   * Optional External (OpenRouter / non-Claude cash) spend block — layout B
+   * (operator-locked 2026-07-19). When null/undefined the block is omitted
+   * entirely (no error rows). When present (including $0.00), bullets land
+   * after the recommendation and before the freshness footer.
+   */
+  externalSpend?: {
+    day24hUsd: number;
+    day7dUsd: number;
+    top: Array<{ label: string; usd: number }>;
+  } | null;
 }
 
 /**
@@ -342,6 +354,11 @@ export function renderUsageCard(
   const lines = [bar];
   // Actionable cross-account verdict — restored from renderAuthSnapshotFormat2.
   lines.push(`_${recommendation(snapshots, now, demo)}_`);
+  // External cash spend (OpenRouter / non-Claude) — layout B. Omitted when
+  // the caller could not fetch a summary (no admin key, timeout, etc.).
+  if (opts.externalSpend) {
+    lines.push(...formatExternalSpendBlock(opts.externalSpend));
+  }
   // Freshness signal: stale-cache warning takes precedence over a live stamp,
   // which takes precedence over an explicit probe-failed marker (no live data
   // AND no cache — the card is showing "⚠️ no data" rows, so "Live" would be

--- a/telegram-plugin/quota-bar-format.ts
+++ b/telegram-plugin/quota-bar-format.ts
@@ -355,8 +355,9 @@ export function renderUsageCard(
   // Actionable cross-account verdict — restored from renderAuthSnapshotFormat2.
   lines.push(`_${recommendation(snapshots, now, demo)}_`);
   // External cash spend (OpenRouter / non-Claude) — layout B. Omitted when
-  // the caller could not fetch a summary (no admin key, timeout, etc.).
-  if (opts.externalSpend) {
+  // the caller could not fetch a summary (null/undefined: no admin key,
+  // timeout, error). Present summary including $0.00 still renders.
+  if (opts.externalSpend != null) {
     lines.push(...formatExternalSpendBlock(opts.externalSpend));
   }
   // Freshness signal: stale-cache warning takes precedence over a live stamp,

--- a/telegram-plugin/tests/external-spend.test.ts
+++ b/telegram-plugin/tests/external-spend.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatExternalSpendBlock,
+  formatUsd,
+  isExternalModel,
+  shortModelLabel,
+  summarizeExternalSpend,
+  type LiteLLMDaySpendRow,
+} from '../external-spend.js';
+import { renderUsageCard } from '../quota-bar-format.js';
+import type { AccountSnapshot } from '../auth-snapshot-format.js';
+import type { QuotaUtilization } from '../quota-check.js';
+
+describe('isExternalModel', () => {
+  it('includes openrouter and sr-* cash models', () => {
+    expect(isExternalModel('openrouter/openai/gpt-oss-20b')).toBe(true);
+    expect(isExternalModel('openrouter/x-ai/grok-4.5')).toBe(true);
+    expect(isExternalModel('sr-grok-4.5')).toBe(true);
+    expect(isExternalModel('gpt-oss-20b')).toBe(true);
+  });
+
+  it('excludes Claude / Anthropic subscription passthrough', () => {
+    expect(isExternalModel('claude-sonnet-5')).toBe(false);
+    expect(isExternalModel('claude-opus-4-8')).toBe(false);
+    expect(isExternalModel('anthropic/claude-fable-5')).toBe(false);
+    expect(isExternalModel('anthropic/claude-sonnet-5')).toBe(false);
+  });
+});
+
+describe('shortModelLabel', () => {
+  it('strips openrouter and keeps the trailing model id', () => {
+    expect(shortModelLabel('openrouter/openai/gpt-oss-20b')).toBe('gpt-oss-20b');
+    expect(shortModelLabel('openrouter/x-ai/grok-4.5')).toBe('grok-4.5');
+    expect(shortModelLabel('sr-grok-4.5')).toBe('grok-4.5');
+  });
+});
+
+describe('formatUsd', () => {
+  it('formats two decimal places', () => {
+    expect(formatUsd(8.0667)).toBe('$8.07');
+    expect(formatUsd(0)).toBe('$0.00');
+    expect(formatUsd(119.892)).toBe('$119.89');
+  });
+});
+
+describe('summarizeExternalSpend', () => {
+  // Fixed "now": 2026-07-19T12:00:00Z → UTC today 2026-07-19
+  const now = new Date('2026-07-19T12:00:00.000Z');
+
+  const days: LiteLLMDaySpendRow[] = [
+    {
+      startTime: '2026-07-18',
+      spend: 500,
+      models: {
+        'claude-sonnet-5': 100,
+        'openrouter/openai/gpt-oss-20b': 107.78,
+        'openrouter/google/gemini-3.1-flash-lite': 0.01,
+      },
+    },
+    {
+      startTime: '2026-07-19',
+      spend: 200,
+      models: {
+        'anthropic/claude-fable-5': 50,
+        'openrouter/openai/gpt-oss-20b': 6.1,
+        'openrouter/x-ai/grok-4.5': 1.18,
+        'openrouter/google/gemini-3.1-flash-lite': 0.79,
+      },
+    },
+    // Outside 7d window (today-6 = 2026-07-13)
+    {
+      startTime: '2026-07-10',
+      models: { 'openrouter/openai/gpt-oss-20b': 999 },
+    },
+  ];
+
+  it('sums 24h = UTC today external only; 7d = rolling 7 calendar days; top from 7d', () => {
+    const s = summarizeExternalSpend(days, now);
+    expect(s.day24hUsd).toBeCloseTo(6.1 + 1.18 + 0.79, 5);
+    expect(s.day7dUsd).toBeCloseTo(107.78 + 0.01 + 6.1 + 1.18 + 0.79, 5);
+    expect(s.top.map((t) => t.label)).toEqual([
+      'gpt-oss-20b',
+      'grok-4.5',
+      'gemini-3.1-flash-lite',
+    ]);
+    expect(s.top[0]!.usd).toBeCloseTo(107.78 + 6.1, 5);
+  });
+
+  it('ignores Claude even when dominant in day.spend', () => {
+    const s = summarizeExternalSpend(
+      [{ startTime: '2026-07-19', spend: 999, models: { 'claude-opus-4-8': 999 } }],
+      now,
+    );
+    expect(s.day24hUsd).toBe(0);
+    expect(s.day7dUsd).toBe(0);
+    expect(s.top).toEqual([]);
+  });
+});
+
+describe('formatExternalSpendBlock', () => {
+  it('matches layout B', () => {
+    const lines = formatExternalSpendBlock({
+      day24hUsd: 8.07,
+      day7dUsd: 119.89,
+      top: [
+        { label: 'gpt-oss-20b', usd: 6.1 },
+        { label: 'grok-4.5', usd: 1.18 },
+        { label: 'gemini-3.1-flash-lite', usd: 0.79 },
+      ],
+    });
+    expect(lines).toEqual([
+      '- 💸 External',
+      '- 24h `$8.07` · 7d `$119.89`',
+      '- top `gpt-oss-20b $6.10` · `grok-4.5 $1.18` · `gemini-3.1-flash-lite $0.79`',
+    ]);
+  });
+
+  it('omits top line when empty', () => {
+    const lines = formatExternalSpendBlock({ day24hUsd: 0, day7dUsd: 0, top: [] });
+    expect(lines).toEqual(['- 💸 External', '- 24h `$0.00` · 7d `$0.00`']);
+  });
+});
+
+describe('renderUsageCard + externalSpend', () => {
+  const NOW = new Date('2026-07-10T12:00:00Z');
+  function quota(part: Partial<QuotaUtilization>): QuotaUtilization {
+    return {
+      fiveHourUtilizationPct: 0,
+      sevenDayUtilizationPct: 0,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+      ...part,
+    };
+  }
+  const snapshots: AccountSnapshot[] = [
+    {
+      label: 'ken@example.com',
+      isActive: true,
+      quota: quota({
+        fiveHourUtilizationPct: 0,
+        sevenDayUtilizationPct: 47,
+        fiveHourResetAt: new Date(NOW.getTime() + 60 * 60_000),
+        sevenDayResetAt: new Date(NOW.getTime() + (3 * 24 + 1) * 60 * 60_000),
+      }),
+    },
+  ];
+  const exhausted = new Map<string, boolean>([['ken@example.com', false]]);
+
+  it('omits External when externalSpend is null/undefined', () => {
+    const out = renderUsageCard(snapshots, exhausted, { now: NOW });
+    expect(out).not.toContain('External');
+    expect(out.split('\n').pop()).toBe('_Live_');
+  });
+
+  it('inserts External between recommendation and freshness footer', () => {
+    const out = renderUsageCard(snapshots, exhausted, {
+      now: NOW,
+      externalSpend: {
+        day24hUsd: 8.07,
+        day7dUsd: 119.89,
+        top: [
+          { label: 'gpt-oss-20b', usd: 6.1 },
+          { label: 'grok-4.5', usd: 1.18 },
+        ],
+      },
+    });
+    const lines = out.split('\n');
+    expect(out).toContain('- 💸 External');
+    expect(out).toContain('- 24h `$8.07` · 7d `$119.89`');
+    expect(out).toContain('top `gpt-oss-20b $6.10`');
+    // Freshness remains last.
+    expect(lines[lines.length - 1]).toBe('_Live_');
+    // Recommendation precedes External.
+    const recIdx = lines.findIndex((l) => l.includes('Recommendation'));
+    const extIdx = lines.findIndex((l) => l.includes('💸 External'));
+    expect(recIdx).toBeGreaterThanOrEqual(0);
+    expect(extIdx).toBeGreaterThan(recIdx);
+  });
+});

--- a/telegram-plugin/tests/external-spend.test.ts
+++ b/telegram-plugin/tests/external-spend.test.ts
@@ -1,104 +1,156 @@
-import { describe, expect, it } from 'vitest';
+/**
+ * Pure unit tests for External OpenRouter/$ spend (layout B on /usage).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
-  formatExternalSpendBlock,
-  formatUsd,
   isExternalModel,
   shortModelLabel,
+  formatUsd,
   summarizeExternalSpend,
+  formatExternalSpendBlock,
+  normalizeSpendLogRows,
+  resolveLitellmBaseUrl,
+  resolveLitellmAdminKey,
+  fetchExternalSpendSummary,
+  clearExternalSpendCache,
+  vaultKeyFromRef,
+  addUtcDays,
+  utcDateString,
   type LiteLLMDaySpendRow,
 } from '../external-spend.js';
-import { renderUsageCard } from '../quota-bar-format.js';
-import type { AccountSnapshot } from '../auth-snapshot-format.js';
-import type { QuotaUtilization } from '../quota-check.js';
+
+const NOW = new Date('2026-07-19T15:30:00.000Z'); // UTC today = 2026-07-19
+
+beforeEach(() => {
+  clearExternalSpendCache();
+});
 
 describe('isExternalModel', () => {
-  it('includes openrouter and sr-* cash models', () => {
+  it('includes openrouter/ and sr- models', () => {
     expect(isExternalModel('openrouter/openai/gpt-oss-20b')).toBe(true);
-    expect(isExternalModel('openrouter/x-ai/grok-4.5')).toBe(true);
     expect(isExternalModel('sr-grok-4.5')).toBe(true);
+    expect(isExternalModel('SR-GLM-5')).toBe(true);
+  });
+
+  it('includes bare cash-model needles', () => {
     expect(isExternalModel('gpt-oss-20b')).toBe(true);
+    expect(isExternalModel('x-ai/grok-4.5')).toBe(true);
+    expect(isExternalModel('gemini-3.1-flash-lite')).toBe(true);
+    expect(isExternalModel('deepseek-r1')).toBe(true);
+    expect(isExternalModel('moonshot/kimi-k2')).toBe(true);
+    expect(isExternalModel('glm-5.2')).toBe(true);
+    expect(isExternalModel('qwen3-coder')).toBe(true);
+    expect(isExternalModel('meta-llama/llama-3.1')).toBe(true);
   });
 
   it('excludes Claude / Anthropic subscription passthrough', () => {
-    expect(isExternalModel('claude-sonnet-5')).toBe(false);
-    expect(isExternalModel('claude-opus-4-8')).toBe(false);
-    expect(isExternalModel('anthropic/claude-fable-5')).toBe(false);
-    expect(isExternalModel('anthropic/claude-sonnet-5')).toBe(false);
+    expect(isExternalModel('claude-sonnet-4-20250514')).toBe(false);
+    expect(isExternalModel('claude-opus-4-5')).toBe(false);
+    expect(isExternalModel('anthropic/claude-sonnet-4')).toBe(false);
+    expect(isExternalModel('openrouter/anthropic/claude-3.5-sonnet')).toBe(false);
+  });
+
+  it('rejects empty / unknown non-cash names', () => {
+    expect(isExternalModel('')).toBe(false);
+    expect(isExternalModel('some-internal-router')).toBe(false);
   });
 });
 
 describe('shortModelLabel', () => {
-  it('strips openrouter and keeps the trailing model id', () => {
+  it('strips openrouter/ and org path to last segment', () => {
     expect(shortModelLabel('openrouter/openai/gpt-oss-20b')).toBe('gpt-oss-20b');
     expect(shortModelLabel('openrouter/x-ai/grok-4.5')).toBe('grok-4.5');
+    expect(shortModelLabel('openai/gpt-oss-20b')).toBe('gpt-oss-20b');
+  });
+
+  it('strips sr- prefix', () => {
     expect(shortModelLabel('sr-grok-4.5')).toBe('grok-4.5');
+    expect(shortModelLabel('sr-gemini-2.5-flash')).toBe('gemini-2.5-flash');
   });
 });
 
 describe('formatUsd', () => {
-  it('formats two decimal places', () => {
-    expect(formatUsd(8.0667)).toBe('$8.07');
+  it('always formats two decimal places', () => {
+    expect(formatUsd(8.07)).toBe('$8.07');
     expect(formatUsd(0)).toBe('$0.00');
-    expect(formatUsd(119.892)).toBe('$119.89');
+    expect(formatUsd(0.004)).toBe('$0.00');
+    expect(formatUsd(119.894)).toBe('$119.89');
+  });
+
+  it('guards non-finite / negative', () => {
+    expect(formatUsd(Number.NaN)).toBe('$0.00');
+    expect(formatUsd(-3)).toBe('$0.00');
   });
 });
 
 describe('summarizeExternalSpend', () => {
-  // Fixed "now": 2026-07-19T12:00:00Z → UTC today 2026-07-19
-  const now = new Date('2026-07-19T12:00:00.000Z');
-
-  const days: LiteLLMDaySpendRow[] = [
-    {
-      startTime: '2026-07-18',
-      spend: 500,
-      models: {
-        'claude-sonnet-5': 100,
-        'openrouter/openai/gpt-oss-20b': 107.78,
-        'openrouter/google/gemini-3.1-flash-lite': 0.01,
-      },
-    },
+  const rows: LiteLLMDaySpendRow[] = [
     {
       startTime: '2026-07-19',
-      spend: 200,
+      spend: 50, // mixed — must be ignored
       models: {
-        'anthropic/claude-fable-5': 50,
+        'claude-sonnet-4-20250514': 40,
         'openrouter/openai/gpt-oss-20b': 6.1,
-        'openrouter/x-ai/grok-4.5': 1.18,
-        'openrouter/google/gemini-3.1-flash-lite': 0.79,
+        'sr-grok-4.5': 1.18,
+        'gemini-3.1-flash-lite': 0.79,
       },
     },
-    // Outside 7d window (today-6 = 2026-07-13)
     {
-      startTime: '2026-07-10',
-      models: { 'openrouter/openai/gpt-oss-20b': 999 },
+      startTime: '2026-07-18',
+      models: {
+        'openrouter/openai/gpt-oss-20b': 10,
+        'claude-opus-4': 5,
+      },
+    },
+    {
+      startTime: '2026-07-12', // outside 7d (today-6 = 2026-07-13)
+      models: { 'openrouter/openai/gpt-oss-20b': 100 },
+    },
+    {
+      startTime: '2026-07-13', // edge of window
+      models: { 'sr-deepseek-r1': 2 },
     },
   ];
 
-  it('sums 24h = UTC today external only; 7d = rolling 7 calendar days; top from 7d', () => {
-    const s = summarizeExternalSpend(days, now);
-    expect(s.day24hUsd).toBeCloseTo(6.1 + 1.18 + 0.79, 5);
-    expect(s.day7dUsd).toBeCloseTo(107.78 + 0.01 + 6.1 + 1.18 + 0.79, 5);
-    expect(s.top.map((t) => t.label)).toEqual([
-      'gpt-oss-20b',
-      'grok-4.5',
-      'gemini-3.1-flash-lite',
-    ]);
-    expect(s.top[0]!.usd).toBeCloseTo(107.78 + 6.1, 5);
+  it('sums 24h (UTC today) and 7d external only — ignores day.spend and Claude', () => {
+    const s = summarizeExternalSpend(rows, NOW);
+    // 24h: 6.1 + 1.18 + 0.79
+    expect(s.day24hUsd).toBeCloseTo(8.07, 5);
+    // 7d: today + 18th (10) + 13th (2) = 8.07 + 10 + 2
+    expect(s.day7dUsd).toBeCloseTo(20.07, 5);
   });
 
-  it('ignores Claude even when dominant in day.spend', () => {
+  it('top-3 by 7d external spend with short labels', () => {
+    const s = summarizeExternalSpend(rows, NOW);
+    expect(s.top.map((t) => t.label)).toEqual([
+      'gpt-oss-20b',
+      'deepseek-r1',
+      'grok-4.5',
+    ]);
+    expect(s.top[0]!.usd).toBeCloseTo(16.1, 5); // 6.1 + 10
+    expect(s.top[1]!.usd).toBeCloseTo(2, 5);
+    expect(s.top[2]!.usd).toBeCloseTo(1.18, 5);
+  });
+
+  it('returns zeros when no external spend', () => {
     const s = summarizeExternalSpend(
-      [{ startTime: '2026-07-19', spend: 999, models: { 'claude-opus-4-8': 999 } }],
-      now,
+      [{ startTime: '2026-07-19', models: { 'claude-sonnet-4': 9 } }],
+      NOW,
     );
-    expect(s.day24hUsd).toBe(0);
+    expect(s).toEqual({ day24hUsd: 0, day7dUsd: 0, top: [] });
+  });
+
+  it('excludes future/out-of-window days', () => {
+    const s = summarizeExternalSpend(
+      [{ startTime: '2026-07-20', models: { 'sr-grok-4.5': 9 } }],
+      NOW,
+    );
     expect(s.day7dUsd).toBe(0);
-    expect(s.top).toEqual([]);
   });
 });
 
 describe('formatExternalSpendBlock', () => {
-  it('matches layout B', () => {
+  it('renders locked layout B', () => {
     const lines = formatExternalSpendBlock({
       day24hUsd: 8.07,
       day7dUsd: 119.89,
@@ -115,68 +167,167 @@ describe('formatExternalSpendBlock', () => {
     ]);
   });
 
-  it('omits top line when empty', () => {
-    const lines = formatExternalSpendBlock({ day24hUsd: 0, day7dUsd: 0, top: [] });
-    expect(lines).toEqual(['- 💸 External', '- 24h `$0.00` · 7d `$0.00`']);
+  it('omits top line when empty but still shows totals (incl. zeros)', () => {
+    expect(formatExternalSpendBlock({ day24hUsd: 0, day7dUsd: 0, top: [] })).toEqual([
+      '- 💸 External',
+      '- 24h `$0.00` · 7d `$0.00`',
+    ]);
+  });
+
+  it('returns [] for null/undefined (omit block)', () => {
+    expect(formatExternalSpendBlock(null)).toEqual([]);
+    expect(formatExternalSpendBlock(undefined)).toEqual([]);
   });
 });
 
-describe('renderUsageCard + externalSpend', () => {
-  const NOW = new Date('2026-07-10T12:00:00Z');
-  function quota(part: Partial<QuotaUtilization>): QuotaUtilization {
-    return {
-      fiveHourUtilizationPct: 0,
-      sevenDayUtilizationPct: 0,
-      fiveHourResetAt: null,
-      sevenDayResetAt: null,
-      representativeClaim: null,
-      overageStatus: null,
-      overageDisabledReason: null,
-      ...part,
-    };
-  }
-  const snapshots: AccountSnapshot[] = [
-    {
-      label: 'ken@example.com',
-      isActive: true,
-      quota: quota({
-        fiveHourUtilizationPct: 0,
-        sevenDayUtilizationPct: 47,
-        fiveHourResetAt: new Date(NOW.getTime() + 60 * 60_000),
-        sevenDayResetAt: new Date(NOW.getTime() + (3 * 24 + 1) * 60 * 60_000),
-      }),
-    },
-  ];
-  const exhausted = new Map<string, boolean>([['ken@example.com', false]]);
-
-  it('omits External when externalSpend is null/undefined', () => {
-    const out = renderUsageCard(snapshots, exhausted, { now: NOW });
-    expect(out).not.toContain('External');
-    expect(out.split('\n').pop()).toBe('_Live_');
+describe('normalizeSpendLogRows / base url / vault ref', () => {
+  it('accepts bare array and {data:[]}', () => {
+    expect(normalizeSpendLogRows([{ startTime: '2026-07-19' }])).toHaveLength(1);
+    expect(normalizeSpendLogRows({ data: [{ startTime: 'x' }] })).toHaveLength(1);
+    expect(normalizeSpendLogRows({ oops: true })).toEqual([]);
   });
 
-  it('inserts External between recommendation and freshness footer', () => {
-    const out = renderUsageCard(snapshots, exhausted, {
-      now: NOW,
-      externalSpend: {
-        day24hUsd: 8.07,
-        day7dUsd: 119.89,
-        top: [
-          { label: 'gpt-oss-20b', usd: 6.1 },
-          { label: 'grok-4.5', usd: 1.18 },
-        ],
-      },
+  it('trims trailing slash on base URL', () => {
+    expect(resolveLitellmBaseUrl({ SWITCHROOM_LITELLM_BASE: 'http://h:4010/' })).toBe(
+      'http://h:4010',
+    );
+    expect(resolveLitellmBaseUrl({})).toBe('http://127.0.0.1:4010');
+  });
+
+  it('parses vault: refs', () => {
+    expect(vaultKeyFromRef('vault:litellm/master-key')).toBe('litellm/master-key');
+    expect(vaultKeyFromRef('plain')).toBeNull();
+  });
+
+  it('utc window helpers', () => {
+    expect(utcDateString(NOW)).toBe('2026-07-19');
+    expect(addUtcDays('2026-07-19', -6)).toBe('2026-07-13');
+    expect(addUtcDays('2026-07-19', 1)).toBe('2026-07-20');
+  });
+});
+
+describe('resolveLitellmAdminKey', () => {
+  const savedAdmin = process.env.SWITCHROOM_LITELLM_ADMIN_KEY;
+  const savedMaster = process.env.LITELLM_MASTER_KEY;
+
+  afterEach(() => {
+    if (savedAdmin === undefined) delete process.env.SWITCHROOM_LITELLM_ADMIN_KEY;
+    else process.env.SWITCHROOM_LITELLM_ADMIN_KEY = savedAdmin;
+    if (savedMaster === undefined) delete process.env.LITELLM_MASTER_KEY;
+    else process.env.LITELLM_MASTER_KEY = savedMaster;
+  });
+
+  it('prefers SWITCHROOM_LITELLM_ADMIN_KEY env', async () => {
+    const key = await resolveLitellmAdminKey({
+      env: { SWITCHROOM_LITELLM_ADMIN_KEY: ' sk-from-env ' },
+      readAdminKeyRef: () => 'vault:litellm/master-key',
+      vaultGet: async () => 'sk-vault',
     });
-    const lines = out.split('\n');
-    expect(out).toContain('- 💸 External');
-    expect(out).toContain('- 24h `$8.07` · 7d `$119.89`');
-    expect(out).toContain('top `gpt-oss-20b $6.10`');
-    // Freshness remains last.
-    expect(lines[lines.length - 1]).toBe('_Live_');
-    // Recommendation precedes External.
-    const recIdx = lines.findIndex((l) => l.includes('Recommendation'));
-    const extIdx = lines.findIndex((l) => l.includes('💸 External'));
-    expect(recIdx).toBeGreaterThanOrEqual(0);
-    expect(extIdx).toBeGreaterThan(recIdx);
+    expect(key).toBe('sk-from-env');
+  });
+
+  it('falls back to vault when env unset', async () => {
+    const vaultGet = vi.fn(async () => 'sk-vault-value');
+    const key = await resolveLitellmAdminKey({
+      env: {},
+      readAdminKeyRef: () => 'vault:litellm/master-key',
+      vaultGet,
+    });
+    expect(key).toBe('sk-vault-value');
+    expect(vaultGet).toHaveBeenCalledWith('litellm/master-key');
+  });
+
+  it('soft-fails when vault denies', async () => {
+    const key = await resolveLitellmAdminKey({
+      env: {},
+      readAdminKeyRef: () => 'vault:litellm/master-key',
+      vaultGet: async () => null,
+    });
+    expect(key).toBeNull();
+  });
+});
+
+describe('fetchExternalSpendSummary', () => {
+  it('returns null without admin key', async () => {
+    const summary = await fetchExternalSpendSummary({
+      now: NOW,
+      resolveAdminKey: async () => null,
+      bypassCache: true,
+    });
+    expect(summary).toBeNull();
+  });
+
+  it('returns null on non-OK response', async () => {
+    const fetchImpl = vi.fn(async () => new Response('nope', { status: 401 }));
+    const summary = await fetchExternalSpendSummary({
+      now: NOW,
+      resolveAdminKey: async () => 'sk-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      bypassCache: true,
+    });
+    expect(summary).toBeNull();
+  });
+
+  it('aggregates successful spend/logs body and caches', async () => {
+    const body = [
+      {
+        startTime: '2026-07-19',
+        models: {
+          'openrouter/openai/gpt-oss-20b': 1.5,
+          'claude-sonnet-4': 9,
+        },
+      },
+    ];
+    let calls = 0;
+    const fetchImpl = vi.fn(async (url: string) => {
+      calls += 1;
+      expect(String(url)).toContain('start_date=2026-07-13');
+      expect(String(url)).toContain('end_date=2026-07-20');
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const first = await fetchExternalSpendSummary({
+      now: NOW,
+      resolveAdminKey: async () => 'sk-test',
+      resolveBaseUrl: () => 'http://litellm.test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      bypassCache: true,
+    });
+    expect(first?.day24hUsd).toBeCloseTo(1.5, 5);
+    expect(first?.top[0]?.label).toBe('gpt-oss-20b');
+
+    // Second call should hit cache (no bypass) with zero additional fetches.
+    const second = await fetchExternalSpendSummary({
+      now: NOW,
+      resolveAdminKey: async () => 'sk-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(second?.day24hUsd).toBeCloseTo(1.5, 5);
+    expect(calls).toBe(1);
+  });
+
+  it('returns null on timeout/abort', async () => {
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      const signal = init?.signal;
+      return await new Promise<Response>((_resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'));
+          return;
+        }
+        signal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      });
+    });
+    const summary = await fetchExternalSpendSummary({
+      now: NOW,
+      resolveAdminKey: async () => 'sk-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      timeoutMs: 20,
+      bypassCache: true,
+    });
+    expect(summary).toBeNull();
   });
 });

--- a/telegram-plugin/tests/quota-bar-format.test.ts
+++ b/telegram-plugin/tests/quota-bar-format.test.ts
@@ -441,4 +441,47 @@ describe('renderUsageCard', () => {
     const out = renderUsageCard(snapshots, exhausted, { now: NOW });
     expect(out).toContain('- **ken@example.com** (active)');
   });
+
+  it('inserts External layout-B block after recommendation and before freshness', () => {
+    const out = renderUsageCard(snapshots, exhausted, {
+      now: NOW,
+      externalSpend: {
+        day24hUsd: 8.07,
+        day7dUsd: 119.89,
+        top: [
+          { label: 'gpt-oss-20b', usd: 6.1 },
+          { label: 'grok-4.5', usd: 1.18 },
+          { label: 'gemini-3.1-flash-lite', usd: 0.79 },
+        ],
+      },
+    });
+    const lines = out.split('\n');
+    // recommendation then External header then totals then top then freshness
+    const recIdx = lines.findIndex((l) => l.includes('Recommendation:'));
+    expect(recIdx).toBeGreaterThan(0);
+    expect(lines[recIdx + 1]).toBe('- 💸 External');
+    expect(lines[recIdx + 2]).toBe('- 24h `$8.07` · 7d `$119.89`');
+    expect(lines[recIdx + 3]).toBe(
+      '- top `gpt-oss-20b $6.10` · `grok-4.5 $1.18` · `gemini-3.1-flash-lite $0.79`',
+    );
+    expect(lines[lines.length - 1]).toBe('_Live_');
+  });
+
+  it('omits External block when externalSpend is null/undefined', () => {
+    const bare = renderUsageCard(snapshots, exhausted, { now: NOW });
+    const withNull = renderUsageCard(snapshots, exhausted, { now: NOW, externalSpend: null });
+    expect(bare).not.toContain('💸 External');
+    expect(withNull).not.toContain('💸 External');
+    expect(bare).toBe(withNull);
+  });
+
+  it('still renders External block at $0.00 when summary is present', () => {
+    const out = renderUsageCard(snapshots, exhausted, {
+      now: NOW,
+      externalSpend: { day24hUsd: 0, day7dUsd: 0, top: [] },
+    });
+    expect(out).toContain('- 💸 External');
+    expect(out).toContain('- 24h `$0.00` · 7d `$0.00`');
+    expect(out).not.toContain('- top ');
+  });
 });


### PR DESCRIPTION
## Problem

`/usage` shows Claude subscription quota bars only. Fleet **cash** spend (OpenRouter / `sr-*` / other non-Claude models via LiteLLM) is invisible on the operator card, so operators cannot see short-window external burn without checking LiteLLM separately.

## UX (layout B — operator-locked 2026-07-19)

After Claude quota bars + recommendation line, before freshness footer:

```
- 💸 External
- 24h `$X.XX` · 7d `$Y.YY`
- top `gpt-oss-20b $6.10` · `grok-4.5 $1.18` · `gemini-3.1-flash-lite $0.79`
```

- On fetch failure / no admin key: **omit** the block entirely (no error clutter).
- When summary is available with **$0.00**: still show the block (honest empty).
- Top line omitted only when there are no external models; zeros keep totals.

Claude bar geometry and footer freshness logic are unchanged. Format 2 table is not touched.

## Data source

LiteLLM `GET /spend/logs?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD` (end = UTC today+1 exclusive-ish) with **master/admin key**.

- Aggregate from each row’s `models` map only — **do not** use `day.spend` (includes Claude passthrough).
- **External filter** includes: `openrouter/*`, `sr-*`, bare names matching gpt-oss/grok/gemini/deepseek/kimi/glm-/qwen/llama.
- **Excludes** Claude/Anthropic subscription passthrough (`claude*`, `*anthropic/claude*`).
- Windows (UTC calendar days): **24h** = today; **7d** = today-6..today inclusive.
- Top 3 by 7d external spend; short labels strip `openrouter/` + org path + leading `sr-`.

## Auth / degrade

Resolve admin key (never logged):

1. `SWITCHROOM_LITELLM_ADMIN_KEY` or `LITELLM_MASTER_KEY`
2. Else vault broker read of `litellm.admin_key` (`vault:litellm/master-key` default)

Base: `SWITCHROOM_LITELLM_BASE` else `http://127.0.0.1:4010`.

Soft-fail → omit block. In-process ~90s TTL cache; ~4s fetch timeout.

## Code

| File | Role |
|------|------|
| `telegram-plugin/external-spend.ts` | filter, windows, top labels, format, fetch + cache |
| `telegram-plugin/quota-bar-format.ts` | `UsageCardRenderOpts.externalSpend` + layout B in `renderUsageCard` |
| `telegram-plugin/gateway/gateway.ts` | `/usage` best-effort `fetchExternalSpendSummary` |
| `telegram-plugin/tests/external-spend.test.ts` | pure + fetch unit tests |
| `telegram-plugin/tests/quota-bar-format.test.ts` | card includes/omits External |

## Operator follow-up (not in this PR)

For External to populate at runtime on overlord/admin gateways, grant `litellm/master-key` (standing secrets or env `SWITCHROOM_LITELLM_ADMIN_KEY`). Without the grant the block is simply omitted — safe degrade.

Example (host yaml — operator apply, not part of this PR):

```yaml
# overlord (admin) — allow fleet external spend on /usage
agents:
  overlord:
    secrets:
      - litellm/master-key   # standing read for /spend/logs
```

## Note on ↻ Refresh

Shared `auth:refresh` rebuilds the **Format 2 /auth** snapshot, not the `/usage` bar card. Fresh External on demand = send `/usage` again (or use the `/usage` keyboard insert). Wiring External into auth Format 2 is out of scope.

## Test plan

- [x] `npx vitest run telegram-plugin/tests/external-spend.test.ts telegram-plugin/tests/quota-bar-format.test.ts telegram-plugin/tests/usage-footer-freshness.test.ts` — 78 passed
- [x] `npx tsc --noEmit` clean
- [x] gateway line ratchet + no-pii-secrets clean
- [ ] Live: `/usage` with master key granted shows External block
- [ ] Live: without grant, Claude bars unchanged and no External clutter

## Text mock

```
- **you@example.com** (active)
- 🟢 5h `[┃░░░░░░░░░] 0% / 4h20m left`
- 🟡 7d `[████┃█░░░░] 47% / 3d1h left`
_Recommendation: stay on you@example.com._
- 💸 External
- 24h `$8.07` · 7d `$119.89`
- top `gpt-oss-20b $6.10` · `grok-4.5 $1.18` · `gemini-3.1-flash-lite $0.79`
_Live · refreshed 0s ago_
```