### PR TITLE
fix(hindsight): close dual-writer + silent-LLM recovery footguns

### DIFF
--- a/docker/hindsight-entrypoint.sh
+++ b/docker/hindsight-entrypoint.sh
@@ -119,12 +119,47 @@ EOF
     return 0
   fi
   [ -n "${_pgpw}" ] || return 0
+  # NOTE (2026-07-19 dual-writer recovery): avoid the old UPDATE-returning
+  # + count-via-grep pattern — concurrent activity made that form abort
+  # with a spurious unique-constraint error on pk_async_operations, so the
+  # reaper silently no-oped and crash-orphaned consolidations stayed
+  # processing (blocking every new claim for that bank). Plain UPDATE + a
+  # follow-up SELECT of newly-unlocked pending ops is enough to count.
+  PGPASSWORD="${_pgpw}" "${_psql}" -U "${_pguser}" -h /tmp -p "${_pgport}" -d "${_pgdb}" -v ON_ERROR_STOP=1 -c \
+    "UPDATE async_operations SET status='pending', worker_id=NULL, claimed_at=NULL, updated_at=now() WHERE status='processing' AND claimed_at < now() - make_interval(secs => ${REAP_STALE_S}) AND coalesce(result_metadata->>'batch_id','') = ''" \
+    >/dev/null 2>&1 || return 0
   _n="$(PGPASSWORD="${_pgpw}" "${_psql}" -U "${_pguser}" -h /tmp -p "${_pgport}" -d "${_pgdb}" -tAc \
-    "UPDATE async_operations SET status='pending', worker_id=NULL, claimed_at=NULL, updated_at=now() WHERE status='processing' AND claimed_at < now() - make_interval(secs => ${REAP_STALE_S}) AND result_metadata->>'batch_id' IS NULL RETURNING 1" \
-    2>/dev/null | grep -c 1 || true)"
-  if [ "${_n:-0}" -gt 0 ]; then
+    "SELECT count(*) FROM async_operations WHERE status='pending' AND worker_id IS NULL AND claimed_at IS NULL AND updated_at > now() - interval '5 seconds'" \
+    2>/dev/null || echo 0)"
+  _n="$(echo "${_n}" | tr -d '[:space:]')"
+  if [ "${_n:-0}" -gt 0 ] 2>/dev/null; then
     log "stale-claim reaper reset ${_n} stuck 'processing' op(s) older than ${REAP_STALE_S}s -> pending"
   fi
+}
+
+# Boot-deferred reaper (2026-07-19): the refresh-loop reaper only fires after
+# the first REFRESH_S sleep (default 1800s). After a crash/recreate that leaves
+# orphaned `processing` claims, consolidation is blocked until that first tick
+# — or until an operator hand-resets them. Fire ONE reaper attempt as soon as
+# embedded pg accepts connections, without holding boot. Best-effort; dies with
+# the container when PID 1 exits.
+reap_stale_processing_when_ready() {
+  [ "${REAP_STALE_S}" -gt 0 ] || return 0
+  # Host unit tests point PG0_INSTANCE at a missing path — skip entirely so we
+  # don't leave a long-lived sleep loop under PID 1 replacement and dilate the
+  # suite. Live containers always have the pg0 descriptor on the data volume.
+  [ -r "${PG0_INSTANCE}" ] || return 0
+  (
+    # Up to ~2 min for embedded pg to finish recovery + accept.
+    for _i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24; do
+      if ls /tmp/.s.PGSQL.* >/dev/null 2>&1; then
+        sleep 2
+        reap_stale_processing || true
+        exit 0
+      fi
+      sleep 5
+    done
+  ) &
 }
 
 # 1. Wait for the broker socket. The broker may still be starting on
@@ -181,6 +216,9 @@ if [ "${REFRESH_S}" -gt 0 ] && [ -f "${FETCHER}" ]; then
 fi
 
 export CLAUDE_CONFIG_DIR="${CRED_DIR}"
+
+# 4b. Boot-deferred stale-claim reaper (does not block boot; see fn header).
+reap_stale_processing_when_ready || true
 
 # 5. Hand off to upstream start-all.sh.
 exec "$@"

--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -26,6 +26,11 @@
  */
 import { execFileSync } from "node:child_process";
 import { EXPECTED_HINDSIGHT_TOOLS } from "../memory/hindsight-tools.js";
+import {
+  HINDSIGHT_DATA_VOLUME,
+  HINDSIGHT_DEFAULT_WORKER_ID,
+  listHindsightDataVolumeMounts,
+} from "../setup/hindsight.js";
 
 export interface CheckResult {
   name: string;
@@ -342,6 +347,114 @@ export function classifyLlmVerification(logs: string): CheckResult | null {
  * logs. Returns [] (silently skipped) when hindsight isn't a local container —
  * a remote `memory.config.url`, no docker, or running inside an agent container.
  */
+
+/**
+ * Pure: classify containers mounting the live hindsight data volume.
+ * More than one mount with anything besides the canonical name is the
+ * 2026-07-19 dual-writer class (canary holdback left `restart=always` on
+ * the renamed twin → corrupt PG checkpoint).
+ */
+export function classifyHindsightDataVolumeMounts(names: string[]): CheckResult {
+  const uniq = [...new Set(names.filter(Boolean))];
+  if (uniq.length === 0) {
+    return {
+      name: "hindsight data-volume exclusive",
+      status: "ok",
+      detail: "no container currently mounts the live data volume",
+    };
+  }
+  const twins = uniq.filter((n) => n !== HINDSIGHT_DEFAULT_WORKER_ID);
+  if (uniq.length === 1 && uniq[0] === HINDSIGHT_DEFAULT_WORKER_ID) {
+    return {
+      name: "hindsight data-volume exclusive",
+      status: "ok",
+      detail: `only ${HINDSIGHT_DEFAULT_WORKER_ID} mounts ${HINDSIGHT_DATA_VOLUME}`,
+    };
+  }
+  if (twins.length > 0) {
+    return {
+      name: "hindsight data-volume exclusive",
+      status: "fail",
+      detail:
+        `multiple containers mount ${HINDSIGHT_DATA_VOLUME}: [${uniq.join(", ")}] — ` +
+        `dual postmasters corrupt the embedded PG checkpoint`,
+      fix:
+        "`switchroom memory --restart` (stopHindsight now disables restart + removes " +
+        "every volume twin), or manually `docker update --restart=no <twin> && " +
+        "docker rm -f <twin>` before starting the live container.",
+    };
+  }
+  // >1 names but all equal canonical? weird but ok-ish
+  return {
+    name: "hindsight data-volume exclusive",
+    status: "warn",
+    detail: `unexpected volume mount set: [${uniq.join(", ")}]`,
+  };
+}
+
+/**
+ * Pure: classify NetworkMode when LiteLLM routing is configured.
+ * LiteLLM publishes on the host's 127.0.0.1:4010; a bridge-networked
+ * hindsight answering /health is a silent retain outage.
+ */
+export function classifyHindsightNetworkMode(
+  networkMode: string | null | undefined,
+  litellmConfigured: boolean,
+): CheckResult {
+  if (!litellmConfigured) {
+    return {
+      name: "hindsight network mode",
+      status: "ok",
+      detail: networkMode ? `${networkMode} (LiteLLM not configured)` : "unknown (LiteLLM not configured)",
+    };
+  }
+  const mode = (networkMode ?? "").trim() || "unknown";
+  if (mode === "host") {
+    return {
+      name: "hindsight network mode",
+      status: "ok",
+      detail: "host — LiteLLM 127.0.0.1 reachable",
+    };
+  }
+  return {
+    name: "hindsight network mode",
+    status: "fail",
+    detail:
+      `NetworkMode=${mode} while LiteLLM routing is configured — retains will die with ` +
+      `"Connection error" to 127.0.0.1:4010 while /health stays green`,
+    fix:
+      "`switchroom memory --restart` so startHindsight recreates with --network host. " +
+      "Do not `docker start` a bridge/mis-networked container.",
+  };
+}
+
+/**
+ * Pure: classify a Ronnie TCP probe of the LiteLLM base URL from the host.
+ * `reachable=true` when connect succeeded; `false` when refused/timeout;
+ * `null` when the probe was skipped.
+ */
+export function classifyLiteLlmReachability(
+  reachable: boolean | null,
+  endpoint: string,
+): CheckResult | null {
+  if (reachable === null) return null;
+  if (reachable) {
+    return {
+      name: "hindsight LiteLLM reachability",
+      status: "ok",
+      detail: `TCP ok to ${endpoint}`,
+    };
+  }
+  return {
+    name: "hindsight LiteLLM reachability",
+    status: "fail",
+    detail: `cannot TCP-connect to ${endpoint} — hindsight LLM ops will fail`,
+    fix:
+      "Start/fix the LiteLLM proxy (host :4010), then `switchroom memory --restart` " +
+      "if hindsight was started while it was down.",
+  };
+}
+
 export function checkHindsightContainerHealth(
   opts?: { exec?: (cmd: string, args: string[]) => string; containerName?: string },
 ): CheckResult[] {
@@ -416,6 +529,60 @@ export function checkHindsightContainerHealth(
     results.push(classifyAutohealStatus(autohealLogs));
   } catch {
     // no autoheal sidecar (no hostd project / not deployed) — nothing to report
+  }
+
+  // Dual-writer footgun (2026-07-19): any second container mounting the live
+  // data volume. Uses the same docker filter stopHindsight relies on.
+  try {
+    const mounts = listHindsightDataVolumeMounts(exec);
+    results.push(classifyHindsightDataVolumeMounts(mounts));
+  } catch {
+    // docker unavailable mid-check — skip
+  }
+
+  // Network mode + LiteLLM reachability when hindsight is configured for it.
+  try {
+    const netMode = exec("docker", [
+      "inspect", name, "--format", "{{.HostConfig.NetworkMode}}",
+    ]).trim();
+    // Detect LiteLLM routing via the retained per-op/base URL env on the
+    // container (set by startHindsight when litellm is configured).
+    const envBlob = exec("docker", [
+      "inspect", name, "--format", "{{range .Config.Env}}{{println .}}{{end}}",
+    ]);
+    const litellmConfigured =
+      /HINDSIGHT_API_(RETAIN|REFLECT|CONSOLIDATION)_LLM_BASE_URL=/.test(envBlob) ||
+      /ANTHROPIC_BASE_URL=/.test(envBlob);
+    results.push(classifyHindsightNetworkMode(netMode, litellmConfigured));
+
+    if (litellmConfigured) {
+      // Prefer the retained base URL; default to host LiteLLM.
+      const m = envBlob.match(/HINDSIGHT_API_RETAIN_LLM_BASE_URL=(\S+)/)
+        ?? envBlob.match(/HINDSIGHT_API_REFLECT_LLM_BASE_URL=(\S+)/)
+        ?? envBlob.match(/ANTHROPIC_BASE_URL=(\S+)/);
+      let endpoint = "127.0.0.1:4010";
+      if (m) {
+        try {
+          const u = new URL(m[1].includes("://") ? m[1] : `http://${m[1]}`);
+          endpoint = `${u.hostname || "127.0.0.1"}:${u.port || "80"}`;
+        } catch { /* keep default */ }
+      }
+      const [host, portStr] = endpoint.split(":");
+      const port = Number(portStr) || 80;
+      let reachable: boolean | null = null;
+      try {
+        // bash /dev/tcp is available in this fleet's environments; keep the
+        // probe short. Nonzero exit → unreachable.
+        exec("bash", ["-c", `echo > /dev/tcp/${host}/${port}`]);
+        reachable = true;
+      } catch {
+        reachable = false;
+      }
+      const row = classifyLiteLlmReachability(reachable, endpoint);
+      if (row) results.push(row);
+    }
+  } catch {
+    // inspect failed — secondary to the shm probe's empty return above
   }
 
   return results;

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -74,6 +74,19 @@ export const HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE = 1000;
 export const HINDSIGHT_CONSUMER_NAME = "hindsight";
 
 /**
+ * Stable hindsight worker identity pinned into the container env so
+ * every recreate reclaims stranded `processing` async ops via
+ * upstream `recover_own_tasks()` (keyed on worker_id). Without this the
+ * worker falls back to the container hostname (ephemeral), and a
+ * crash-orphaned consolidation can block a bank forever. Mirrors the
+ * entrypoint-side default; docker-run must set it too so recover fires
+ * *before* the deferred reaper.
+ */
+export const HINDSIGHT_DEFAULT_WORKER_ID = "switchroom-hindsight";
+/** Named volume holding embedded pg — dual mounts = dual writers. */
+export const HINDSIGHT_DATA_VOLUME = "switchroom-hindsight-data";
+
+/**
  * Default UID for the hindsight container's broker socket. The container
  * runs as the upstream `hindsight` user; we pick a fixed UID in the
  * consumer range (>10000, not colliding with switchroom agent UIDs at
@@ -752,6 +765,35 @@ export function resolveHindsightLlm(
  *   preserved via `HINDSIGHT_API_PORT` (the only port knob the upstream
  *   config.py recognizes; the CP service has no env var override).
  */
+
+/**
+ * Build a docker `--health-cmd` that requires BOTH the hindsight /health
+ * endpoint and TCP reachability of the LiteLLM base URL. /health alone is
+ * DB-backed — a container mis-created on the bridge network still answers
+ * 200 while every retain dies with "Connection error" to 127.0.0.1:4010
+ * (2026-07-19 recovery regression). Pairing catches that class of silent
+ * outage in `docker ps` health.
+ */
+export function buildLiteLlmAwareHealthCmd(apiPort: number, litellmBaseUrl: string): string {
+  let host = "127.0.0.1";
+  let port = "80";
+  try {
+    const u = new URL(litellmBaseUrl.includes("://") ? litellmBaseUrl : `http://${litellmBaseUrl}`);
+    host = u.hostname || host;
+    port = u.port || (u.protocol === "https:" ? "443" : "80");
+  } catch {
+    // fall through with defaults; better a weak probe than a throw in start
+  }
+  // One-liner python (docker health-cmd is shell-eval'd; keep it single-line).
+  // Exit 0 only when BOTH /health is 200 AND the LiteLLM host:port accepts TCP.
+  return (
+    `python3 -c "import socket,urllib.request,sys;` +
+    `r=urllib.request.urlopen('http://localhost:${apiPort}/health',timeout=4);` +
+    `(r.getcode()==200) or sys.exit(1);` +
+    `s=socket.create_connection(('${host}',${Number(port)}),2);s.close()"`
+  );
+}
+
 export function startHindsight(
   ports?: { apiPort: number; uiPort: number },
   litellm?: LiteLLMHindsightConfig,
@@ -813,6 +855,12 @@ export function startHindsight(
     "-e", `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
     "-e", `HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
     "-e", `HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,
+    // Stable worker identity (see HINDSIGHT_DEFAULT_WORKER_ID). Must be on
+    // the docker-run path — the entrypoint only fills the var with `:=` when
+    // unset, which is fine, but an explicit pin makes the intent legible in
+    // `docker inspect` and survives operators who wrap start without the
+    // entrypoint default.
+    "-e", `HINDSIGHT_API_WORKER_ID=${HINDSIGHT_DEFAULT_WORKER_ID}`,
   ];
 
   // The `claude-code` provider drives an underlying claude subprocess; pin
@@ -886,8 +934,13 @@ export function startHindsight(
     // status through the docker-socket-proxy and issues `docker restart` with
     // a sliding-window cap + backoff. python3 is always present in the image;
     // curl/wget are not.
+    // Liveness: API /health alone is necessary but NOT sufficient when the
+    // container is on host network for LiteLLM — a bridge mis-create still
+    // answers /health (DB-backed) while every retain/LLM op dies with
+    // Connection error. Pair the health endpoint with a TCP probe to the
+    // LiteLLM base URL so docker health reflects LLM reachability too.
     "--health-cmd", litellm
-      ? `python3 -c 'import urllib.request,sys; sys.exit(0 if urllib.request.urlopen("http://localhost:${apiPort}/health",timeout=4).getcode()==200 else 1)'`
+      ? buildLiteLlmAwareHealthCmd(apiPort, litellm.baseUrl)
       : HINDSIGHT_HEALTHCHECK_CMD,
     "--health-interval", "30s",
     "--health-timeout", "5s",
@@ -960,15 +1013,55 @@ export function startHindsight(
 }
 
 /**
- * Stop and remove the Hindsight Docker container.
+ * List container names that currently mount the live hindsight data volume.
+ * Dual mounts with restart=always corrupt the embedded PG checkpoint
+ * (2026-07-19 dual-writer outage: `switchroom-hindsight` +
+ * `switchroom-hindsight-old-v01833`). Used by {@link stopHindsight} and doctor.
+ *
+ * Returns [] when docker is unavailable. Names only — no IDs.
  */
-export function stopHindsight(): void {
+export function listHindsightDataVolumeMounts(
+  exec: (cmd: string, args: string[]) => string = (cmd, args) =>
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" }),
+): string[] {
   try {
-    execFileSync("docker", ["stop", "switchroom-hindsight"], { stdio: "pipe" });
-  } catch { /* container may already be stopped */ }
-  try {
-    execFileSync("docker", ["rm", "switchroom-hindsight"], { stdio: "pipe" });
-  } catch { /* container may already be removed */ }
+    // docker ps -a --filter volume=… is the garbage-collector gate. Format
+    // since docker 1.13; fall back to empty on older hosts/agents without docker.
+    const out = exec("docker", [
+      "ps", "-a",
+      "--filter", `volume=${HINDSIGHT_DATA_VOLUME}`,
+      "--format", "{{.Names}}",
+    ]);
+    return out
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((n) => n.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Stop and remove the Hindsight Docker container — and any stale twin
+ * (canary holdback/`-old-*` rename) that still mounts the live data volume
+ * with restart=always. Leaving a second postmaster on the same volume is
+ * how the 2026-07-19 checkpoint corruption happened.
+ *
+ * Order: disable restart on twins → stop → rm. The live name is always
+ * removed too so `startHindsight` can recreate cleanly.
+ */
+export function stopHindsight(
+  exec: (cmd: string, args: string[]) => void = (cmd, args) => {
+    execFileSync(cmd, args, { stdio: "pipe" });
+  },
+  listMounts: () => string[] = () => listHindsightDataVolumeMounts(),
+): void {
+  const names = new Set<string>([HINDSIGHT_DEFAULT_WORKER_ID, ...listMounts()]);
+  for (const name of names) {
+    try { exec("docker", ["update", "--restart=no", name]); } catch { /* gone */ }
+    try { exec("docker", ["stop", name]); } catch { /* gone */ }
+    try { exec("docker", ["rm", "-f", name]); } catch { /* gone */ }
+  }
 }
 
 /**
@@ -1196,6 +1289,7 @@ export function generateHindsightComposeSnippet(
     `      - HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
     `      - HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
     `      - HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,
+    `      - HINDSIGHT_API_WORKER_ID=${HINDSIGHT_DEFAULT_WORKER_ID}`,
     `    mem_limit: ${HINDSIGHT_DEFAULT_MEM_LIMIT}`,
     `    mem_reservation: ${HINDSIGHT_DEFAULT_MEM_RESERVATION}`,
     `    pids_limit: ${HINDSIGHT_DEFAULT_PIDS_LIMIT}`,

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -11,6 +11,9 @@ import {
   classifyConsolidationBacklog,
   classifyAutohealStatus,
   classifyLlmVerification,
+  classifyHindsightDataVolumeMounts,
+  classifyHindsightNetworkMode,
+  classifyLiteLlmReachability,
   CONSOLIDATION_BACKLOG_WARN,
   CONSOLIDATION_BACKLOG_FAIL,
   type AdvertisedTool,
@@ -274,29 +277,69 @@ describe("checkHindsightContainerHealth (docker wrapper)", () => {
 
   it("classifies shm + logs + autoheal when docker is available", () => {
     const exec = (_cmd: string, args: string[]) => {
+      if (args.includes("inspect") && args.some((a) => String(a).includes("ShmSize"))) {
+        return "2147483648\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("StartedAt"))) {
+        return "2020-01-01T00:00:00Z\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("NetworkMode"))) {
+        return "host\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("Config.Env"))) {
+        return "HINDSIGHT_API_RETAIN_LLM_BASE_URL=http://127.0.0.1:4010/v1\n";
+      }
       if (args.includes("inspect")) return "2147483648\n";
-      if (args.includes("switchroom-hindsight-autoheal")) return "hindsight-autoheal event=started target=switchroom-hindsight";
+      if (args.includes("ps")) return "switchroom-hindsight\n";
+      if (_cmd === "bash") return ""; // LiteLLM /dev/tcp probe succeeds
+      if (args.includes("switchroom-hindsight-autoheal")) {
+        return "hindsight-autoheal event=started target=switchroom-hindsight";
+      }
       if (args.includes("logs")) return "Extract facts: 4 facts, 1 chunks from 1 contents in 12s";
       return "";
     };
     const results = checkHindsightContainerHealth({ exec });
-    expect(results.map((r) => r.name)).toEqual([
+    const names = results.map((r) => r.name);
+    expect(names).toEqual(expect.arrayContaining([
       "hindsight shm-size",
       "hindsight extraction",
       "hindsight autoheal",
-    ]);
+    ]));
+    expect(names).toEqual(expect.arrayContaining([
+      "hindsight data-volume exclusive",
+      "hindsight network mode",
+      "hindsight LiteLLM reachability",
+    ]));
     expect(results.every((r) => r.status === "ok")).toBe(true);
   });
 
   it("skips the autoheal line when the sidecar container isn't present", () => {
     const exec = (_cmd: string, args: string[]) => {
       if (args.includes("switchroom-hindsight-autoheal")) throw new Error("No such container");
+      if (args.includes("inspect") && args.some((a) => String(a).includes("ShmSize"))) {
+        return "2147483648\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("StartedAt"))) {
+        return "2020-01-01T00:00:00Z\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("NetworkMode"))) {
+        return "bridge\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("Config.Env"))) {
+        return "HINDSIGHT_API_LLM_PROVIDER=claude-code\n";
+      }
       if (args.includes("inspect")) return "2147483648\n";
+      if (args.includes("ps")) return "switchroom-hindsight\n";
       if (args.includes("logs")) return "Extract facts: 4 facts, 1 chunks from 1 contents in 12s";
       return "";
     };
     const results = checkHindsightContainerHealth({ exec });
-    expect(results.map((r) => r.name)).toEqual(["hindsight shm-size", "hindsight extraction"]);
+    const names = results.map((r) => r.name);
+    expect(names).not.toContain("hindsight autoheal");
+    expect(names).toEqual(expect.arrayContaining([
+      "hindsight shm-size",
+      "hindsight extraction",
+    ]));
   });
 
   it("surfaces an autoheal give-up as a FAIL line", () => {
@@ -373,5 +416,48 @@ describe("checkHindsightHealthEndpoint — async probe wrapper", () => {
     }) as unknown as typeof fetch;
     const r = await checkHindsightHealthEndpoint("http://127.0.0.1:18888/mcp/", { fetchImpl });
     expect(r.status).toBe("fail");
+  });
+});
+
+describe("hindsight dual-writer + LiteLLM silent-outage classifiers (2026-07-19)", () => {
+  it("fails when a canary twin also mounts the live data volume", () => {
+    const r = classifyHindsightDataVolumeMounts([
+      "switchroom-hindsight",
+      "switchroom-hindsight-old-v01833",
+    ]);
+    expect(r.status).toBe("fail");
+    expect(r.detail).toMatch(/multiple containers/);
+    expect(r.fix).toBeDefined();
+  });
+
+  it("ok when only the canonical hindsight container mounts the volume", () => {
+    const r = classifyHindsightDataVolumeMounts(["switchroom-hindsight"]);
+    expect(r.status).toBe("ok");
+  });
+
+  it("fails NetworkMode=bridge when LiteLLM is configured", () => {
+    const r = classifyHindsightNetworkMode("bridge", true);
+    expect(r.status).toBe("fail");
+    expect(r.detail).toMatch(/bridge/);
+    expect(r.fix).toMatch(/memory --restart/);
+  });
+
+  it("ok NetworkMode=host when LiteLLM is configured", () => {
+    expect(classifyHindsightNetworkMode("host", true).status).toBe("ok");
+  });
+
+  it("ok non-host network when LiteLLM is NOT configured", () => {
+    expect(classifyHindsightNetworkMode("bridge", false).status).toBe("ok");
+  });
+
+  it("fails LiteLLM reachability when TCP probe misses", () => {
+    const r = classifyLiteLlmReachability(false, "127.0.0.1:4010");
+    expect(r?.status).toBe("fail");
+    expect(r?.detail).toMatch(/127\.0\.0\.1:4010/);
+  });
+
+  it("ok when TCP probe hits; null when skipped", () => {
+    expect(classifyLiteLlmReachability(true, "127.0.0.1:4010")?.status).toBe("ok");
+    expect(classifyLiteLlmReachability(null, "x")).toBeNull();
   });
 });

--- a/tests/docker/hindsight-entrypoint.test.ts
+++ b/tests/docker/hindsight-entrypoint.test.ts
@@ -446,11 +446,20 @@ describe("hindsight-entrypoint.sh (#1245)", () => {
     expect(raw).toMatch(/status='processing'/);
     // Keyed on claim AGE (lease timeout), not the ephemeral worker_id.
     expect(raw).toMatch(/claimed_at < now\(\) - make_interval\(secs => \$\{REAP_STALE_S\}\)/);
-    // Mirrors upstream recover_own_tasks(): never reset in-flight batch ops.
-    expect(raw).toMatch(/result_metadata->>'batch_id' IS NULL/);
+    // Batch-ops guard — coalesce(...)='' form. RETURNING was removed after
+    // the 2026-07-19 dual-writer recovery: the RETURNING variant aborted
+    // under concurrent activity with a spurious pk_async_operations
+    // violation and the reaper silently stopped working.
+    expect(raw).toMatch(/coalesce\(result_metadata->>'batch_id',''\) = ''/);
+    // Concrete anti-pattern: RETURNING piped into grep -c (the form that
+    // aborted under concurrent activity). A mention of RETURNING in a
+    // comment is fine — ban the pipeline shape only.
+    expect(raw).not.toMatch(/RETURNING[\s\S]{0,80}grep -c/);
     // Gated + best-effort: 0 disables, and it rides the existing loop.
     expect(raw).toMatch(/REAP_STALE_S.*-gt 0.*\|\| return 0/);
     expect(raw).toMatch(/reap_stale_processing \|\| true/);
+    // Boot-deferred single shot so recreate doesn't wait REAP_STALE_S (30m).
+    expect(raw).toMatch(/reap_stale_processing_when_ready/);
   });
 
   it("the reaper no-ops cleanly when the embedded pg descriptor is absent (host/test)", async () => {

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -16,9 +16,14 @@ vi.mock("node:child_process", () => ({
 import { execFileSync } from "node:child_process";
 import {
   startHindsight,
+  stopHindsight,
   ensureHindsightConsumer,
+  buildLiteLlmAwareHealthCmd,
+  listHindsightDataVolumeMounts,
   HINDSIGHT_CONSUMER_NAME,
   HINDSIGHT_DEFAULT_UID,
+  HINDSIGHT_DEFAULT_WORKER_ID,
+  HINDSIGHT_DATA_VOLUME,
   HINDSIGHT_BROKER_SOCK_VOLUME,
   HINDSIGHT_IMAGE,
   HINDSIGHT_DEFAULT_SHM_SIZE,
@@ -748,3 +753,77 @@ describe("ensureHindsightConsumer (#1245)", () => {
     expect(HINDSIGHT_CONSUMER_NAME).toBe("hindsight");
   });
 });
+
+describe("hindsight recovery footguns (2026-07-19 dual-writer + silent LLM)", () => {
+  beforeEach(() => {
+    mockedExec.mockReset();
+    mockedExec.mockReturnValue("");
+  });
+
+  it("pins HINDSIGHT_API_WORKER_ID on both docker-run and compose emit paths", async () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const env: string[] = [];
+    const args = findRunArgs();
+    for (let i = 0; i < args.length - 1; i++) {
+      if (args[i] === "-e") env.push(args[i + 1] as string);
+    }
+    expect(env).toContain(`HINDSIGHT_API_WORKER_ID=${HINDSIGHT_DEFAULT_WORKER_ID}`);
+    const { generateHindsightComposeSnippet } = await import("../../src/setup/hindsight.js");
+    expect(generateHindsightComposeSnippet()).toContain(
+      `HINDSIGHT_API_WORKER_ID=${HINDSIGHT_DEFAULT_WORKER_ID}`,
+    );
+  });
+
+  it("pairs /health with LiteLLM TCP in litellm-mode health-cmd", () => {
+    startHindsight(
+      { apiPort: 18888, uiPort: 19999 },
+      { baseUrl: "http://127.0.0.1:4010", apiKey: "sk-test" },
+    );
+    const args = findRunArgs();
+    const i = args.indexOf("--health-cmd");
+    expect(i).toBeGreaterThan(-1);
+    const cmd = args[i + 1] as string;
+    expect(cmd).toContain("localhost:18888/health");
+    expect(cmd).toContain("create_connection(('127.0.0.1',4010)");
+    const built = buildLiteLlmAwareHealthCmd(18888, "http://10.0.0.5:9/v1");
+    expect(built).toContain("10.0.0.5");
+    expect(built).toContain(",9)");
+  });
+
+  it("stopHindsight disables restart and removes every data-volume twin, not just the live name", () => {
+    const calls: string[][] = [];
+    const exec = (cmd: string, args: string[]) => {
+      calls.push([cmd, ...args]);
+    };
+    stopHindsight(exec, () => [
+      HINDSIGHT_DEFAULT_WORKER_ID,
+      "switchroom-hindsight-old-v01833",
+    ]);
+    const twin = "switchroom-hindsight-old-v01833";
+    const lines = calls.map((c) => c.join(" "));
+    expect(lines).toContain(`docker update --restart=no ${twin}`);
+    expect(lines).toContain(`docker stop ${twin}`);
+    expect(lines).toContain(`docker rm -f ${twin}`);
+    expect(lines).toContain(`docker update --restart=no ${HINDSIGHT_DEFAULT_WORKER_ID}`);
+    expect(lines).toContain(`docker rm -f ${HINDSIGHT_DEFAULT_WORKER_ID}`);
+  });
+
+  it("listHindsightDataVolumeMounts uses docker ps filter on the data volume", () => {
+    const exec = vi.fn((..._args: unknown[]) =>
+      ["switchroom-hindsight", "switchroom-hindsight-old-v01833"].join("\n") + "\n",
+    );
+    const names = listHindsightDataVolumeMounts(
+      exec as unknown as (cmd: string, args: string[]) => string,
+    );
+    expect(exec).toHaveBeenCalledWith("docker", [
+      "ps", "-a",
+      "--filter", `volume=${HINDSIGHT_DATA_VOLUME}`,
+      "--format", "{{.Names}}",
+    ]);
+    expect(names).toEqual([
+      "switchroom-hindsight",
+      "switchroom-hindsight-old-v01833",
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- **Dual-writer canary footgun:** `stopHindsight` now `update --restart=no` + stop + `rm -f` every container mounting `switchroom-hindsight-data` (not just the live name). Doctor fails if more than the canonical container mounts the volume.
- **Silent LLM-outage while /health is green:** litellm-mode docker health-cmd requires API `/health` **and** TCP to the LiteLLM base URL; doctor classifies `NetworkMode` + LiteLLM reachability when routing is configured.
- **Stuck consolidation after crash:** entrypoint stale-claim reaper drops the broken `UPDATE … RETURNING | grep -c` form (was aborting under concurrent activity) for plain UPDATE + SELECT; boot-deferred one-shot reaper no longer waits the 30m refresh tick; `HINDSIGHT_API_WORKER_ID` pinned on both docker-run and compose paths.

## Context
Came out of the 2026-07-19 adversarial pass after park-and-wait recovery: dual canary container corrupted PG checkpoint; bridge recreate left retains dying; orphaned `processing` consolidations blocked drain even after slots were raised.

## Test plan
- [x] `vitest run tests/setup/hindsight.test.ts tests/cli.doctor.memory-health.test.ts tests/docker/hindsight-entrypoint.test.ts` — **118/118**
- [x] `npm run lint:tsc` clean
- [ ] CI green
- [ ] After merge: next `switchroom memory --restart` / roll picks up entrypoint + startHindsight changes (image rebuild for entrypoint)