### PR TITLE
fix(hindsight): compose LiteLLM parity + reaper/doctor follow-ups (#3421)

### DIFF
--- a/docker/hindsight-entrypoint.sh
+++ b/docker/hindsight-entrypoint.sh
@@ -119,18 +119,19 @@ EOF
     return 0
   fi
   [ -n "${_pgpw}" ] || return 0
-  # NOTE (2026-07-19 dual-writer recovery): avoid the old UPDATE-returning
-  # + count-via-grep pattern — concurrent activity made that form abort
-  # with a spurious unique-constraint error on pk_async_operations, so the
-  # reaper silently no-oped and crash-orphaned consolidations stayed
-  # processing (blocking every new claim for that bank). Plain UPDATE + a
-  # follow-up SELECT of newly-unlocked pending ops is enough to count.
-  PGPASSWORD="${_pgpw}" "${_psql}" -U "${_pguser}" -h /tmp -p "${_pgport}" -d "${_pgdb}" -v ON_ERROR_STOP=1 -c \
+  # NOTE (2026-07-19 dual-writer recovery): never count via an UPDATE that
+  # returns rows piped into a line-counter (the recovery-title form aborted
+  # under concurrent activity with a spurious unique-constraint error on
+  # pk_async_operations, so the reaper silently no-oped and crash-orphaned
+  # consolidations stayed processing, blocking every new claim for that bank).
+  #
+  # Count comes from psql's own `UPDATE N` tag (ROW_COUNT of THIS statement).
+  # A post-UPDATE `SELECT count(*) … updated_at > now()-5s` inflated the
+  # log with fresh enqueues that never matched the stale-processing WHERE.
+  _out="$(PGPASSWORD="${_pgpw}" "${_psql}" -U "${_pguser}" -h /tmp -p "${_pgport}" -d "${_pgdb}" -v ON_ERROR_STOP=1 -c \
     "UPDATE async_operations SET status='pending', worker_id=NULL, claimed_at=NULL, updated_at=now() WHERE status='processing' AND claimed_at < now() - make_interval(secs => ${REAP_STALE_S}) AND coalesce(result_metadata->>'batch_id','') = ''" \
-    >/dev/null 2>&1 || return 0
-  _n="$(PGPASSWORD="${_pgpw}" "${_psql}" -U "${_pguser}" -h /tmp -p "${_pgport}" -d "${_pgdb}" -tAc \
-    "SELECT count(*) FROM async_operations WHERE status='pending' AND worker_id IS NULL AND claimed_at IS NULL AND updated_at > now() - interval '5 seconds'" \
-    2>/dev/null || echo 0)"
+    2>/dev/null)" || return 0
+  _n="$(printf '%s\n' "${_out}" | awk '/^UPDATE[[:space:]]+[0-9]+/ { print $2; exit }')"
   _n="$(echo "${_n}" | tr -d '[:space:]')"
   if [ "${_n:-0}" -gt 0 ] 2>/dev/null; then
     log "stale-claim reaper reset ${_n} stuck 'processing' op(s) older than ${REAP_STALE_S}s -> pending"

--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -550,16 +550,40 @@ export function checkHindsightContainerHealth(
     const envBlob = exec("docker", [
       "inspect", name, "--format", "{{range .Config.Env}}{{println .}}{{end}}",
     ]);
-    const litellmConfigured =
-      /HINDSIGHT_API_(RETAIN|REFLECT|CONSOLIDATION)_LLM_BASE_URL=/.test(envBlob) ||
-      /ANTHROPIC_BASE_URL=/.test(envBlob);
+    // Gate primarily on the retained per-op LLM base URLs (set whenever
+    // hindsight.llm.{retain,reflect,consolidation}.base_url or startHindsight's
+    // litellm path is active). ANTHROPIC_BASE_URL alone is common on ordinary
+    // agent containers / residual env and is NOT a LiteLLM signal unless its
+    // value looks like a litellm proxy path (host :4010 or /anthropic suffix).
+    const perOpBasePresent =
+      /HINDSIGHT_API_(RETAIN|REFLECT|CONSOLIDATION)_LLM_BASE_URL=/.test(envBlob);
+    const anthropicBaseMatch = envBlob.match(/(?:^|\n)ANTHROPIC_BASE_URL=(\S+)/);
+    const anthropicLooksLikeLiteLlm = (() => {
+      const raw = anthropicBaseMatch?.[1]?.trim();
+      if (!raw) return false;
+      try {
+        const u = new URL(raw.includes("://") ? raw : `http://${raw}`);
+        const port = u.port || (u.protocol === "https:" ? "443" : "80");
+        const path = (u.pathname || "").replace(/\/+$/, "");
+        // Fleet LiteLLM default is :4010; pass-through is <root>/anthropic.
+        if (port === "4010") return true;
+        if (/\/anthropic$/i.test(path)) return true;
+        if (/litellm/i.test(u.hostname || "")) return true;
+        return false;
+      } catch {
+        return false;
+      }
+    })();
+    const litellmConfigured = perOpBasePresent || anthropicLooksLikeLiteLlm;
     results.push(classifyHindsightNetworkMode(netMode, litellmConfigured));
 
     if (litellmConfigured) {
-      // Prefer the retained base URL; default to host LiteLLM.
+      // Prefer per-op retained base URL; only fall back to ANTHROPIC_BASE_URL
+      // when it already looked like LiteLLM above. Default host LiteLLM.
       const m = envBlob.match(/HINDSIGHT_API_RETAIN_LLM_BASE_URL=(\S+)/)
         ?? envBlob.match(/HINDSIGHT_API_REFLECT_LLM_BASE_URL=(\S+)/)
-        ?? envBlob.match(/ANTHROPIC_BASE_URL=(\S+)/);
+        ?? envBlob.match(/HINDSIGHT_API_CONSOLIDATION_LLM_BASE_URL=(\S+)/)
+        ?? (anthropicLooksLikeLiteLlm ? anthropicBaseMatch : null);
       let endpoint = "127.0.0.1:4010";
       if (m) {
         try {

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -767,14 +767,81 @@ export function resolveHindsightLlm(
  */
 
 /**
- * Build a docker `--health-cmd` that requires BOTH the hindsight /health
- * endpoint and TCP reachability of the LiteLLM base URL. /health alone is
- * DB-backed — a container mis-created on the bridge network still answers
- * 200 while every retain dies with "Connection error" to 127.0.0.1:4010
- * (2026-07-19 recovery regression). Pairing catches that class of silent
- * outage in `docker ps` health.
+ * True when `url` resolves to a host-loopback listener (localhost / 127.0.0.1 /
+ * ::1). Used to decide whether hindsight must join the host network so the
+ * container can reach a LiteLLM base the operator wrote as loopback.
  */
-export function buildLiteLlmAwareHealthCmd(apiPort: number, litellmBaseUrl: string): string {
+export function isLoopbackHttpUrl(url: string): boolean {
+  try {
+    const u = new URL(url.includes("://") ? url : `http://${url}`);
+    const h = (u.hostname || "").toLowerCase();
+    return h === "localhost" || h === "127.0.0.1" || h === "::1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Collect every configured LiteLLM / per-op LLM base URL from the same inputs
+ * `startHindsight` / `generateHindsightComposeSnippet` take. Order is
+ * stable: explicit `litellm.baseUrl` first, then retain/reflect/consolidation
+ * per-op base URLs in that op order.
+ */
+export function collectHindsightLlmBaseUrls(
+  llm?: HindsightLlmConfig,
+  litellm?: LiteLLMHindsightConfig,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (raw: string | undefined) => {
+    const v = raw?.trim();
+    if (!v || seen.has(v)) return;
+    seen.add(v);
+    out.push(v);
+  };
+  push(litellm?.baseUrl);
+  for (const [k, v] of resolveHindsightPerOpLlm(llm)) {
+    if (k.endsWith("_BASE_URL")) push(v);
+  }
+  return out;
+}
+
+/**
+ * Whether the hindsight container must use host networking so LLM base URLs
+ * remain reachable. Mirrors `startHindsight`: an explicit LiteLLM routing
+ * config always forces host network; otherwise any configured per-op base
+ * URL that points at host loopback does the same (compose used to stay on
+ * bridge forever while still emitting `http://127.0.0.1:4010` — silent retain
+ * outage that doctor now flags).
+ */
+export function hindsightNeedsHostNetwork(
+  llm?: HindsightLlmConfig,
+  litellm?: LiteLLMHindsightConfig,
+): boolean {
+  if (litellm?.baseUrl?.trim()) return true;
+  return collectHindsightLlmBaseUrls(llm).some(isLoopbackHttpUrl);
+}
+
+/**
+ * Prefered LiteLLM base URL for health/TCP probes: explicit litellm config,
+ * else the first per-op `*_LLM_BASE_URL`. Undefined when nothing is configured.
+ */
+export function pickHindsightLiteLlmProbeUrl(
+  llm?: HindsightLlmConfig,
+  litellm?: LiteLLMHindsightConfig,
+): string | undefined {
+  return collectHindsightLlmBaseUrls(llm, litellm)[0];
+}
+
+/**
+ * Bare python body (compose exec-form `["CMD","python3","-c",PY]`) that requires
+ * BOTH the hindsight /health endpoint and TCP reachability of the LiteLLM base
+ * URL. /health alone is DB-backed — a container mis-created on the bridge
+ * network still answers 200 while every retain dies with "Connection error"
+ * to 127.0.0.1:4010 (2026-07-19 recovery regression). Pairing catches that
+ * class of silent outage in `docker ps` health.
+ */
+export function buildLiteLlmAwareHealthPy(apiPort: number, litellmBaseUrl: string): string {
   let host = "127.0.0.1";
   let port = "80";
   try {
@@ -784,14 +851,23 @@ export function buildLiteLlmAwareHealthCmd(apiPort: number, litellmBaseUrl: stri
   } catch {
     // fall through with defaults; better a weak probe than a throw in start
   }
-  // One-liner python (docker health-cmd is shell-eval'd; keep it single-line).
-  // Exit 0 only when BOTH /health is 200 AND the LiteLLM host:port accepts TCP.
+  // One-liner python (docker health-cmd / compose CMD is single-arg). Exit 0
+  // only when BOTH /health is 200 AND the LiteLLM host:port accepts TCP.
   return (
-    `python3 -c "import socket,urllib.request,sys;` +
+    `import socket,urllib.request,sys;` +
     `r=urllib.request.urlopen('http://localhost:${apiPort}/health',timeout=4);` +
     `(r.getcode()==200) or sys.exit(1);` +
-    `s=socket.create_connection(('${host}',${Number(port)}),2);s.close()"`
+    `s=socket.create_connection(('${host}',${Number(port)}),2);s.close()`
   );
+}
+
+/**
+ * Build a docker `--health-cmd` string wrapping {@link buildLiteLlmAwareHealthPy}.
+ * Shared by the `docker run` path ({@link startHindsight}); compose uses the
+ * bare PY body via exec-form CMD so the generators never drift.
+ */
+export function buildLiteLlmAwareHealthCmd(apiPort: number, litellmBaseUrl: string): string {
+  return `python3 -c "${buildLiteLlmAwareHealthPy(apiPort, litellmBaseUrl)}"`;
 }
 
 export function startHindsight(
@@ -934,23 +1010,45 @@ export function startHindsight(
     // status through the docker-socket-proxy and issues `docker restart` with
     // a sliding-window cap + backoff. python3 is always present in the image;
     // curl/wget are not.
-    // Liveness: API /health alone is necessary but NOT sufficient when the
-    // container is on host network for LiteLLM — a bridge mis-create still
+    // Liveness: API /health alone is necessary but NOT sufficient when LLM
+    // routing depends on a side-car base URL — a bridge mis-create still
     // answers /health (DB-backed) while every retain/LLM op dies with
-    // Connection error. Pair the health endpoint with a TCP probe to the
-    // LiteLLM base URL so docker health reflects LLM reachability too.
-    "--health-cmd", litellm
-      ? buildLiteLlmAwareHealthCmd(apiPort, litellm.baseUrl)
-      : HINDSIGHT_HEALTHCHECK_CMD,
+    // Connection error. Pair the health endpoint with a TCP probe so docker
+    // health reflects LLM reachability too. Host network is required for
+    // loopback bases (see hindsightNeedsHostNetwork); probe TCP still applies
+    // on bridge when the LLM is a non-loopback address.
+    ...(() => {
+      const hostNet = hindsightNeedsHostNetwork(llm, litellm);
+      // Inside the container: host-net API binds HINDSIGHT_API_PORT; bridge
+      // maps host:apiPort → container:8888 (image default).
+      const healthApiPort = hostNet ? apiPort : 8888;
+      const probe = pickHindsightLiteLlmProbeUrl(llm, litellm);
+      return [
+        "--health-cmd",
+        probe
+          ? buildLiteLlmAwareHealthCmd(healthApiPort, probe)
+          : HINDSIGHT_HEALTHCHECK_CMD,
+      ] as string[];
+    })(),
     "--health-interval", "30s",
     "--health-timeout", "5s",
     "--health-retries", "3",
     "--health-start-period", "60s",
   ];
 
-  if (litellm) {
-    // Host network: ports are published directly (no -p flags).
+  if (hindsightNeedsHostNetwork(llm, litellm)) {
+    // Host network: ports are published directly (no -p flags). Required so
+    // loopback LiteLLM (127.0.0.1:4010) is reachable from the container.
     args.push("--network", "host");
+    // When only per-op loopback bases forced host net (no full litellm cfg),
+    // still pin API/CP ports the way the litellm branch does — otherwise the
+    // image default 8888 binds on the shared host stack.
+    if (!litellm) {
+      envArgs.push(
+        "-e", `HINDSIGHT_API_PORT=${apiPort}`,
+        "-e", `HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:${apiPort}`,
+      );
+    }
   } else {
     args.push(
       "-p", `127.0.0.1:${apiPort}:8888`,
@@ -1058,6 +1156,15 @@ export function stopHindsight(
 ): void {
   const names = new Set<string>([HINDSIGHT_DEFAULT_WORKER_ID, ...listMounts()]);
   for (const name of names) {
+    // Surface non-canonical twins (canary holdback / `-old-*` rename) so the
+    // dual-writer cleanup is operator-visible in the memory/setup CLI stream.
+    // Match the console.* style used by src/cli/memory.ts around start/stop —
+    // this helper has no logger dependency today.
+    if (name !== HINDSIGHT_DEFAULT_WORKER_ID) {
+      console.error(
+        `stopHindsight: removing hindsight data-volume twin ${name} (not the canonical ${HINDSIGHT_DEFAULT_WORKER_ID})`,
+      );
+    }
     try { exec("docker", ["update", "--restart=no", name]); } catch { /* gone */ }
     try { exec("docker", ["stop", name]); } catch { /* gone */ }
     try { exec("docker", ["rm", "-f", name]); } catch { /* gone */ }
@@ -1203,6 +1310,15 @@ export function getHindsightMcpUrl(): {
  * because it's owned by the switchroom compose project (the auth-broker
  * container chowns and binds the per-consumer socket inside it). The
  * hindsight compose project is separate; it consumes the volume.
+ *
+ * Networking + healthcheck track {@link startHindsight}: when an explicit
+ * LiteLLM config is passed, OR any configured per-op `*_LLM_BASE_URL`
+ * points at host loopback, the snippet emits `network_mode: host` (ports
+ * are published on the host stack directly — no `ports:` mapping) and pairs
+ * /health with a TCP probe of the LiteLLM base. The live fleet deploys
+ * hindsight this way for loopback LiteLLM (`http://127.0.0.1:4010`); leaving
+ * compose on bridge with a loopback BASE_URL is the silent-retain class
+ * of outage doctor already fails closed on.
  */
 export function generateHindsightComposeSnippet(
   llm?: HindsightLlmConfig,
@@ -1215,9 +1331,29 @@ export function generateHindsightComposeSnippet(
    * output identical to pre-#2578.
    */
   mirrorDir?: string,
+  /**
+   * Optional LiteLLM routing config (same shape as {@link startHindsight}).
+   * When set — or when `llm` carries a loopback per-op base URL — the
+   * snippet switches to `network_mode: host` and a LiteLLM-aware healthcheck
+   * so compose never silently diverges from the docker-run path.
+   */
+  litellm?: LiteLLMHindsightConfig,
 ): string {
-  const { provider: llmProvider, model: llmModel } = resolveHindsightLlm(llm);
+  const { provider: llmProvider, model: llmModel } = resolveHindsightLlm(llm, litellm);
   const perOpLlm = resolveHindsightPerOpLlm(llm);
+  const hostNetwork = hindsightNeedsHostNetwork(llm, litellm);
+  const apiPort = HINDSIGHT_DEFAULT_API_PORT;
+  // Bridge compose keeps the image-default internal bind (8888) and maps the
+  // host port onto it. Host-network binds HINDSIGHT_API_PORT on the host
+  // stack directly (same as startHindsight) so agents' memory.config.url
+  // still hits the right place.
+  const internalApiPort = hostNetwork ? apiPort : 8888;
+  const probeUrl = pickHindsightLiteLlmProbeUrl(llm, litellm);
+  // Pair /health with LiteLLM TCP whenever any base URL is configured —
+  // including bridge+non-loopback. Host network is the loopback case only.
+  const healthPy = probeUrl
+    ? buildLiteLlmAwareHealthPy(internalApiPort, probeUrl)
+    : HINDSIGHT_HEALTHCHECK_PY;
   const environment = [
     `      - HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
     `      - HINDSIGHT_API_LLM_PROVIDER=${llmProvider}`,
@@ -1227,16 +1363,30 @@ export function generateHindsightComposeSnippet(
     // Mirror of the docker-run path: with the claude-code provider, pin
     // ANTHROPIC_MODEL to the same model for the underlying claude subprocess.
     ...(llmProvider === "claude-code" ? [`      - ANTHROPIC_MODEL=${llmModel}`] : []),
-    // Pin the CP dashboard's dataplane URL to the port the API actually
-    // binds INSIDE the container. This compose path is bridge-networked
-    // (host ${HINDSIGHT_DEFAULT_API_PORT} → container 8888), so the API binds
-    // the image default 8888 internally and there is no host-port collision
-    // in the container's own netns. We still set the var explicitly (rather
-    // than leaning on the image default) so it stays correct and matches the
-    // docker-run path, where host-network mode requires it point at the
-    // moved-off API port to dodge the squatted-8888 → 502 dashboard bug.
-    `      - HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:8888`,
+    // Host-network: API binds HINDSIGHT_API_PORT on the shared host stack
+    // (and CP dataplane must track it so it doesn't hit squatted 8888).
+    // Bridge: API binds image-default 8888 inside the container netns.
+    ...(hostNetwork
+      ? [
+          `      - HINDSIGHT_API_PORT=${apiPort}`,
+          `      - HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:${apiPort}`,
+        ]
+      : [`      - HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:8888`]),
   ];
+  // Optional LiteLLM proxy env (ANTHROPIC_BASE_URL + spend-tag headers) —
+  // same shape startHindsight emits when litellm is configured. Requires the
+  // api key; compose generators without a vault-resolved key skip headers
+  // but still get host network + health pairing from loopback per-op URLs.
+  if (litellm?.baseUrl?.trim() && litellm.apiKey?.trim()) {
+    const litellmRoot = litellm.baseUrl.replace(/\/+$/, "");
+    const anthropicBaseUrl = isClaudeModel(llmModel)
+      ? `${litellmRoot}/anthropic`
+      : litellmRoot;
+    environment.push(
+      `      - ANTHROPIC_BASE_URL=${anthropicBaseUrl}`,
+      `      - ANTHROPIC_CUSTOM_HEADERS=x-litellm-api-key: Bearer ${litellm.apiKey}\\nx-litellm-customer-id: hindsight\\nx-litellm-tags: service:hindsight`,
+    );
+  }
   // Mirror mode (#2578): a one-shot init service chowns the fresh shared
   // creds volume to the consumer UID (a named volume mounts root:root, but
   // hindsight's entrypoint runs as UID 11000 and would EACCES on its
@@ -1261,6 +1411,25 @@ export function generateHindsightComposeSnippet(
         "        condition: service_completed_successfully",
       ]
     : [];
+  // network_mode: host OR bridge port publish — mutually exclusive in compose
+  // (docker rejects `ports:` alongside host network).
+  const networkOrPorts = hostNetwork
+    ? [
+        // Match startHindsight(--network host): LiteLLM on host loopback is
+        // reachable, HINDSIGHT_API_PORT binds directly on the host stack.
+        "    network_mode: host",
+      ]
+    : [
+        "    ports:",
+        // Host side 18888/19999 → container 8888/9999. The host port MUST match
+        // HINDSIGHT_DEFAULT_API_PORT / the scaffolded memory.config.url or agents
+        // point at a dead URL (see the 2026-07 outage).
+        // Bind to 127.0.0.1 only: the hindsight API is TOKENLESS, so publishing on
+        // 0.0.0.0 would expose the unauthenticated MCP/REST surface to the network.
+        // This mirrors the startHindsight() docker-run path, which binds loopback.
+        `      - "127.0.0.1:${HINDSIGHT_DEFAULT_API_PORT}:8888"`,
+        "      - \"127.0.0.1:19999:9999\"",
+      ];
   return [
     "services:",
     ...initService,
@@ -1268,15 +1437,7 @@ export function generateHindsightComposeSnippet(
     `    image: ${HINDSIGHT_IMAGE}`,
     "    container_name: switchroom-hindsight",
     ...dependsOn,
-    "    ports:",
-    // Host side 18888/19999 → container 8888/9999. The host port MUST match
-    // HINDSIGHT_DEFAULT_API_PORT / the scaffolded memory.config.url or agents
-    // point at a dead URL (see the 2026-07 outage).
-    // Bind to 127.0.0.1 only: the hindsight API is TOKENLESS, so publishing on
-    // 0.0.0.0 would expose the unauthenticated MCP/REST surface to the network.
-    // This mirrors the startHindsight() docker-run path, which binds loopback.
-    `      - "127.0.0.1:${HINDSIGHT_DEFAULT_API_PORT}:8888"`,
-    "      - \"127.0.0.1:19999:9999\"",
+    ...networkOrPorts,
     "    environment:",
     ...environment,
     `      - HINDSIGHT_API_MCP_STATELESS=${HINDSIGHT_DEFAULT_MCP_STATELESS}`,
@@ -1297,8 +1458,10 @@ export function generateHindsightComposeSnippet(
     // container gets Docker's 64MB default and all writes/queries fail.
     `    shm_size: ${HINDSIGHT_DEFAULT_SHM_SIZE}`,
     // Liveness — restart a wedged/never-booted API (see the docker-run path).
+    // When host-network + LiteLLM base is known, pair /health with a TCP
+    // probe of the proxy so docker health reflects LLM reachability too.
     "    healthcheck:",
-    `      test: ${JSON.stringify(["CMD", "python3", "-c", HINDSIGHT_HEALTHCHECK_PY])}`,
+    `      test: ${JSON.stringify(["CMD", "python3", "-c", healthPy])}`,
     "      interval: 30s",
     "      timeout: 5s",
     "      retries: 3",

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -460,4 +460,57 @@ describe("hindsight dual-writer + LiteLLM silent-outage classifiers (2026-07-19)
     expect(classifyLiteLlmReachability(true, "127.0.0.1:4010")?.status).toBe("ok");
     expect(classifyLiteLlmReachability(null, "x")).toBeNull();
   });
+
+  it("does NOT treat bare ANTHROPIC_BASE_URL alone as LiteLLM configured", () => {
+    const exec = (_cmd: string, args: string[]) => {
+      if (args.includes("inspect") && args.some((a) => String(a).includes("ShmSize"))) {
+        return "2147483648\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("StartedAt"))) {
+        return "2020-01-01T00:00:00Z\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("NetworkMode"))) {
+        return "bridge\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("Config.Env"))) {
+        // Residual / non-litellm anthropic base — must NOT trip network-mode fail.
+        return "ANTHROPIC_BASE_URL=https://api.anthropic.com\nHINDSIGHT_API_LLM_PROVIDER=claude-code\n";
+      }
+      if (args.includes("inspect")) return "2147483648\n";
+      if (args.includes("ps")) return "switchroom-hindsight\n";
+      if (args.includes("switchroom-hindsight-autoheal")) throw new Error("No such container");
+      if (args.includes("logs")) return "Extract facts: 4 facts, 1 chunks from 1 contents in 12s";
+      return "";
+    };
+    const results = checkHindsightContainerHealth({ exec });
+    const net = results.find((r) => r.name === "hindsight network mode");
+    expect(net?.status).toBe("ok");
+    expect(results.find((r) => r.name === "hindsight LiteLLM reachability")).toBeUndefined();
+  });
+
+  it("treats ANTHROPIC_BASE_URL on :4010 /anthropic as LiteLLM configured", () => {
+    const exec = (_cmd: string, args: string[]) => {
+      if (args.includes("inspect") && args.some((a) => String(a).includes("ShmSize"))) {
+        return "2147483648\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("StartedAt"))) {
+        return "2020-01-01T00:00:00Z\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("NetworkMode"))) {
+        return "bridge\n";
+      }
+      if (args.includes("inspect") && args.some((a) => String(a).includes("Config.Env"))) {
+        return "ANTHROPIC_BASE_URL=http://127.0.0.1:4010/anthropic\n";
+      }
+      if (args.includes("inspect")) return "2147483648\n";
+      if (args.includes("ps")) return "switchroom-hindsight\n";
+      if (_cmd === "bash") throw new Error("refused");
+      if (args.includes("switchroom-hindsight-autoheal")) throw new Error("No such container");
+      if (args.includes("logs")) return "Extract facts: 4 facts, 1 chunks from 1 contents in 12s";
+      return "";
+    };
+    const results = checkHindsightContainerHealth({ exec });
+    expect(results.find((r) => r.name === "hindsight network mode")?.status).toBe("fail");
+    expect(results.find((r) => r.name === "hindsight LiteLLM reachability")?.status).toBe("fail");
+  });
 });

--- a/tests/docker/hindsight-entrypoint.test.ts
+++ b/tests/docker/hindsight-entrypoint.test.ts
@@ -455,6 +455,13 @@ describe("hindsight-entrypoint.sh (#1245)", () => {
     // aborted under concurrent activity). A mention of RETURNING in a
     // comment is fine — ban the pipeline shape only.
     expect(raw).not.toMatch(/RETURNING[\s\S]{0,80}grep -c/);
+    // Count must come from THIS UPDATE's rowcount (psql `UPDATE N` tag), not a
+    // follow-up SELECT of recently-touched pending rows (that counted fresh
+    // enqueues and inflated the reaper log after #3421).
+    expect(raw).toMatch(/\^UPDATE\[\[:space:\]\]\+/);
+    expect(raw).not.toMatch(
+      /SELECT count\(\*\) FROM async_operations WHERE status='pending' AND worker_id IS NULL/,
+    );
     // Gated + best-effort: 0 disables, and it rides the existing loop.
     expect(raw).toMatch(/REAP_STALE_S.*-gt 0.*\|\| return 0/);
     expect(raw).toMatch(/reap_stale_processing \|\| true/);

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -790,22 +790,88 @@ describe("hindsight recovery footguns (2026-07-19 dual-writer + silent LLM)", ()
     expect(built).toContain(",9)");
   });
 
+  it("compose with loopback per-op LiteLLM base uses host network + LiteLLM-aware healthcheck", async () => {
+    const {
+      generateHindsightComposeSnippet,
+      HINDSIGHT_DEFAULT_API_PORT,
+      HINDSIGHT_HEALTHCHECK_PY,
+    } = await import("../../src/setup/hindsight.js");
+    const snippet = generateHindsightComposeSnippet({
+      retain: {
+        provider: "litellm",
+        model: "openai/gpt-oss-20b",
+        base_url: "http://127.0.0.1:4010/v1",
+      },
+      reflect: {
+        provider: "litellm",
+        model: "openai/gpt-oss-20b",
+        base_url: "http://127.0.0.1:4010/v1",
+      },
+    });
+    // Match live fleet deploy + startHindsight: host net for loopback LiteLLM.
+    expect(snippet).toContain("network_mode: host");
+    expect(snippet).not.toMatch(/^\s+ports:/m);
+    expect(snippet).toContain(`HINDSIGHT_API_PORT=${HINDSIGHT_DEFAULT_API_PORT}`);
+    expect(snippet).toContain(
+      `HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:${HINDSIGHT_DEFAULT_API_PORT}`,
+    );
+    // Health pairs /health with TCP to LiteLLM — not the bare DB-only probe.
+    expect(snippet).toContain("create_connection(('127.0.0.1',4010)");
+    expect(snippet).toContain(`localhost:${HINDSIGHT_DEFAULT_API_PORT}/health`);
+    expect(snippet).not.toContain(HINDSIGHT_HEALTHCHECK_PY);
+  });
+
+  it("compose with explicit litellm config uses host network + LiteLLM-aware healthcheck", async () => {
+    const { generateHindsightComposeSnippet } = await import("../../src/setup/hindsight.js");
+    const snippet = generateHindsightComposeSnippet(
+      undefined,
+      undefined,
+      { baseUrl: "http://127.0.0.1:4010", apiKey: "sk-test" },
+    );
+    expect(snippet).toContain("network_mode: host");
+    expect(snippet).toContain("create_connection(('127.0.0.1',4010)");
+    expect(snippet).toContain("ANTHROPIC_BASE_URL=");
+  });
+
+  it("compose without LiteLLM stays bridge + plain /health probe", async () => {
+    const {
+      generateHindsightComposeSnippet,
+      HINDSIGHT_HEALTHCHECK_PY,
+      HINDSIGHT_DEFAULT_API_PORT,
+    } = await import("../../src/setup/hindsight.js");
+    const snippet = generateHindsightComposeSnippet();
+    expect(snippet).not.toContain("network_mode: host");
+    expect(snippet).toContain(`"127.0.0.1:${HINDSIGHT_DEFAULT_API_PORT}:8888"`);
+    // JSON.stringify escapes embedded quotes in the CMD python body, so the
+    // raw HINDSIGHT_HEALTHCHECK_PY string is not a literal substring.
+    expect(snippet).toMatch(/healthcheck:[\s\S]*localhost:8888\/health/);
+    expect(snippet).not.toContain("create_connection");
+  });
+
   it("stopHindsight disables restart and removes every data-volume twin, not just the live name", () => {
     const calls: string[][] = [];
     const exec = (cmd: string, args: string[]) => {
       calls.push([cmd, ...args]);
     };
-    stopHindsight(exec, () => [
-      HINDSIGHT_DEFAULT_WORKER_ID,
-      "switchroom-hindsight-old-v01833",
-    ]);
-    const twin = "switchroom-hindsight-old-v01833";
-    const lines = calls.map((c) => c.join(" "));
-    expect(lines).toContain(`docker update --restart=no ${twin}`);
-    expect(lines).toContain(`docker stop ${twin}`);
-    expect(lines).toContain(`docker rm -f ${twin}`);
-    expect(lines).toContain(`docker update --restart=no ${HINDSIGHT_DEFAULT_WORKER_ID}`);
-    expect(lines).toContain(`docker rm -f ${HINDSIGHT_DEFAULT_WORKER_ID}`);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      stopHindsight(exec, () => [
+        HINDSIGHT_DEFAULT_WORKER_ID,
+        "switchroom-hindsight-old-v01833",
+      ]);
+      const twin = "switchroom-hindsight-old-v01833";
+      const lines = calls.map((c) => c.join(" "));
+      expect(lines).toContain(`docker update --restart=no ${twin}`);
+      expect(lines).toContain(`docker stop ${twin}`);
+      expect(lines).toContain(`docker rm -f ${twin}`);
+      expect(lines).toContain(`docker update --restart=no ${HINDSIGHT_DEFAULT_WORKER_ID}`);
+      expect(lines).toContain(`docker rm -f ${HINDSIGHT_DEFAULT_WORKER_ID}`);
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining("switchroom-hindsight-old-v01833"),
+      );
+    } finally {
+      errSpy.mockRestore();
+    }
   });
 
   it("listHindsightDataVolumeMounts uses docker ps filter on the data volume", () => {


### PR DESCRIPTION
## Summary
Follow-ups from independent adversarial review of merged #3421 (`619779ba`).

- **Compose/LiteLLM parity (MEDIUM):** `generateHindsightComposeSnippet` no longer stays bridge + plain `/health` while emitting loopback `HINDSIGHT_API_*_LLM_BASE_URL` values. When LiteLLM is explicit or any per-op base is host-loopback, compose now mirrors live fleet / `startHindsight`: `network_mode: host`, API/CP port pins, and LiteLLM-aware healthcheck (`/health` + TCP to the LLM base). Shared helpers: `isLoopbackHttpUrl`, `collectHindsightLlmBaseUrls`, `hindsightNeedsHostNetwork`, `pickHindsightLiteLlmProbeUrl`, `buildLiteLlmAwareHealthPy`.
- **Reaper count (LOW):** `reap_stale_processing` counts via psql’s `UPDATE N` tag (this statement’s rowcount) instead of a post-UPDATE `SELECT count(*) … updated_at > now()-5s` that inflated with fresh enqueues. Still avoids the banned `RETURNING` + `grep -c` pipeline.
- **Doctor litellmConfigured (LOW):** primary gate is `HINDSIGHT_API_(RETAIN|REFLECT|CONSOLIDATION)_LLM_BASE_URL`. Bare `ANTHROPIC_BASE_URL` only counts when it looks like LiteLLM (`:4010`, `/anthropic`, or hostname containing `litellm`). Endpoint preference includes consolidation base URL.
- **stopHindsight (NIT):** `console.error` one line when removing a non-canonical data-volume twin.

## Test plan
- [x] `bun x vitest run tests/setup/hindsight.test.ts tests/cli.doctor.memory-health.test.ts tests/docker/hindsight-entrypoint.test.ts` → **123 passed**
- [x] `npm run lint:tsc` → clean
- [ ] CI full suite

## Evidence / residual
- Live host hindsight already runs `NetworkMode=host` with loopback `*_LLM_BASE_URL=http://127.0.0.1:4010/v1` (checked via `docker inspect`) — compose approach (a) host network matches that deploy shape.
- `memory docker-compose` still only passes `hindsight.llm` + mirror_dir (3rd `litellm` arg optional). Loopback per-op bases alone are enough to flip host network without vault-resolved litellm headers.
- Do not change agent model defaults / telegram-plugin model-command (out of scope per review).