### PR TITLE
feat(auth-broker): External spend via broker (no agent master key)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1707,6 +1707,15 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   //   /state/agents    → ~/.switchroom/agents/
   //   /state/auth-broker → ~/.switchroom/state/auth-broker/
   lines.push(`      SWITCHROOM_AUTH_BROKER_STATE_DIR: /state/auth-broker`);
+  {
+    // LiteLLM root URL for get-external-spend (OpenRouter cash on /usage).
+    // Broker holds master key in state-dir; agents never see it.
+    const llBase =
+      (config as { litellm?: { base_url?: string } }).litellm?.base_url;
+    if (typeof llBase === "string" && llBase.trim()) {
+      lines.push(`      SWITCHROOM_LITELLM_BASE: ${JSON.stringify(llBase.trim())}`);
+    }
+  }
   lines.push(`      SWITCHROOM_ACCOUNTS_DIR: /state/accounts`);
   lines.push(`      SWITCHROOM_AGENTS_DIR: /state/agents`);
   // Operator UID — when set, the broker binds an additional listener at

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1686,10 +1686,6 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      - "FOWNER"`);
   lines.push(`      - "DAC_READ_SEARCH"`);
   lines.push(`      - "DAC_OVERRIDE"`);
-  // Reach host-published LiteLLM (and any other host-gateway service)
-  // when base_url is rewritten off loopback for get-external-spend.
-  lines.push(`    extra_hosts:`);
-  lines.push(`      - "host.docker.internal:host-gateway"`);
   // Operator UID — when set, pass `--operator-uid <N>` so the broker
   // entry binds the operator listener at
   // /run/switchroom/auth-broker/operator/sock and chowns it to <N>.
@@ -1717,6 +1713,10 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // base_url is almost always loopback (socat on the host) — rewrite
   // 127.0.0.1/localhost → host.docker.internal so the broker can reach
   // the host-published proxy. Non-loopback URLs pass through unchanged.
+  // extra_hosts is only emitted when we configure a base — keeps the
+  // zero-litellm fleet compose free of host-gateway (network_isolation
+  // regression receive).
+  let authBrokerNeedsHostGateway = false;
   {
     const llBase =
       (config as { litellm?: { base_url?: string } }).litellm?.base_url;
@@ -1728,6 +1728,9 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
         .replace(/^https:\/\/127\.0\.0\.1(?=[:/]|$)/i, "https://host.docker.internal")
         .replace(/^https:\/\/localhost(?=[:/]|$)/i, "https://host.docker.internal");
       lines.push(`      SWITCHROOM_LITELLM_BASE: ${JSON.stringify(bridged)}`);
+      // Always pair with host-gateway when base is set: loopback rewrite
+      // needs it; non-loopback? harmless + covers mixed host socat names.
+      authBrokerNeedsHostGateway = true;
     }
   }
   lines.push(`      SWITCHROOM_ACCOUNTS_DIR: /state/accounts`);
@@ -1740,6 +1743,10 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // below is unused dead weight.
   if (opts.operatorUid !== undefined) {
     lines.push(`      SWITCHROOM_AUTH_BROKER_OPERATOR_UID: "${opts.operatorUid}"`);
+  }
+  if (authBrokerNeedsHostGateway) {
+    lines.push(`    extra_hosts:`);
+    lines.push(`      - "host.docker.internal:host-gateway"`);
   }
   lines.push(`    volumes:`);
   // Per-agent socket dir (named volume; agent side mounts the parent).

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1686,6 +1686,10 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      - "FOWNER"`);
   lines.push(`      - "DAC_READ_SEARCH"`);
   lines.push(`      - "DAC_OVERRIDE"`);
+  // Reach host-published LiteLLM (and any other host-gateway service)
+  // when base_url is rewritten off loopback for get-external-spend.
+  lines.push(`    extra_hosts:`);
+  lines.push(`      - "host.docker.internal:host-gateway"`);
   // Operator UID — when set, pass `--operator-uid <N>` so the broker
   // entry binds the operator listener at
   // /run/switchroom/auth-broker/operator/sock and chowns it to <N>.
@@ -1707,13 +1711,23 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   //   /state/agents    → ~/.switchroom/agents/
   //   /state/auth-broker → ~/.switchroom/state/auth-broker/
   lines.push(`      SWITCHROOM_AUTH_BROKER_STATE_DIR: /state/auth-broker`);
+  // LiteLLM root for get-external-spend (OpenRouter cash on /usage).
+  // Broker holds the master key in state-dir; agents never see it.
+  // Auth-broker runs on the compose bridge (not host net). Operator
+  // base_url is almost always loopback (socat on the host) — rewrite
+  // 127.0.0.1/localhost → host.docker.internal so the broker can reach
+  // the host-published proxy. Non-loopback URLs pass through unchanged.
   {
-    // LiteLLM root URL for get-external-spend (OpenRouter cash on /usage).
-    // Broker holds master key in state-dir; agents never see it.
     const llBase =
       (config as { litellm?: { base_url?: string } }).litellm?.base_url;
     if (typeof llBase === "string" && llBase.trim()) {
-      lines.push(`      SWITCHROOM_LITELLM_BASE: ${JSON.stringify(llBase.trim())}`);
+      const raw = llBase.trim().replace(/\/+$/, "");
+      const bridged = raw
+        .replace(/^http:\/\/127\.0\.0\.1(?=[:/]|$)/i, "http://host.docker.internal")
+        .replace(/^http:\/\/localhost(?=[:/]|$)/i, "http://host.docker.internal")
+        .replace(/^https:\/\/127\.0\.0\.1(?=[:/]|$)/i, "https://host.docker.internal")
+        .replace(/^https:\/\/localhost(?=[:/]|$)/i, "https://host.docker.internal");
+      lines.push(`      SWITCHROOM_LITELLM_BASE: ${JSON.stringify(bridged)}`);
     }
   }
   lines.push(`      SWITCHROOM_ACCOUNTS_DIR: /state/accounts`);

--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -339,6 +339,16 @@ export interface ProbeQuotaEntry {
   capturedAt?: number;
 }
 
+export interface GetExternalSpendData {
+  available: boolean;
+  day24hUsd?: number;
+  day7dUsd?: number;
+  top?: Array<{ label: string; usd: number }>;
+  capturedAtMs?: number;
+  served?: "live" | "cache";
+  reason?: string;
+}
+
 export interface ProbeQuotaData {
   results: ProbeQuotaEntry[];
 }
@@ -593,6 +603,21 @@ export class AuthBrokerClient {
       }
     }
     return parsed;
+  }
+
+
+  /**
+   * Fleet external (OpenRouter cash) spend summary for `/usage`.
+   * Auth-broker owns the LiteLLM master key; agents never see it.
+   */
+  async getExternalSpend(forceLive?: boolean): Promise<GetExternalSpendData> {
+    const data = await this.send({
+      v: PROTOCOL_VERSION,
+      id: randomUUID(),
+      op: "get-external-spend",
+      ...(forceLive ? { forceLive: true } : {}),
+    });
+    return data as GetExternalSpendData;
   }
 
   async setActive(account: string): Promise<SetActiveData> {

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -412,6 +412,23 @@ export const ClaimNotificationRequestSchema = z.object({
   windowMs: z.number().int().positive().max(86_400_000),
 });
 
+/**
+ * Fleet external (OpenRouter / non-Claude cash) spend summary for the
+ * `/usage` card. ACL matches `list-state` — any authenticated identity.
+ * The auth-broker holds the LiteLLM master key and publishes only a
+ * sanitized summary (no key material on the wire).
+ *
+ * forceLive bypasses the broker's refresh TTL (same idea as probe-quota)
+ * when the operator re-opens /usage and wants fresher totals.
+ */
+export const GetExternalSpendRequestSchema = z.object({
+  v: z.literal(PROTOCOL_VERSION),
+  op: z.literal("get-external-spend"),
+  id: z.string().min(1),
+  /** Bypass the ~90s live-refresh TTL and re-query LiteLLM. */
+  forceLive: z.boolean().optional(),
+});
+
 export const RequestSchema = z.discriminatedUnion("op", [
   GetCredentialsRequestSchema,
   ListStateRequestSchema,
@@ -426,6 +443,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   ListMicrosoftAccountsRequestSchema,
   ProbeQuotaRequestSchema,
   ClaimNotificationRequestSchema,
+  GetExternalSpendRequestSchema,
 ]);
 
 export type Request = z.infer<typeof RequestSchema>;
@@ -541,6 +559,28 @@ export const ClaimNotificationDataSchema = z.object({
  * inventory don't need those, and never returning them keeps the wire
  * surface narrow.
  */
+export const GetExternalSpendDataSchema = z.object({
+  /** False when the broker has no master key / LiteLLM unreachable and no cache. */
+  available: z.boolean(),
+  day24hUsd: z.number().optional(),
+  day7dUsd: z.number().optional(),
+  top: z
+    .array(
+      z.object({
+        label: z.string(),
+        usd: z.number(),
+      }),
+    )
+    .optional(),
+  /** Unix ms when the summary was computed. */
+  capturedAtMs: z.number().int().nonnegative().optional(),
+  /** "live" freshly fetched, "cache" served from durable/TTL cache. */
+  served: z.enum(["live", "cache"]).optional(),
+  /** Short reason when available=false (never includes secrets). */
+  reason: z.string().optional(),
+});
+
+
 export const GoogleAccountStateSchema = z.object({
   account: z.string(),
   expiresAt: z.number(),

--- a/src/auth/broker/server-external-spend.test.ts
+++ b/src/auth/broker/server-external-spend.test.ts
@@ -227,4 +227,86 @@ describe("get-external-spend", () => {
       broker.stop();
     }
   });
+
+  it("reads master key from state-dir file when env/test override absent", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    writeFileSync(join(h.stateDir, "litellm-master-key"), "sk-from-file\n", {
+      mode: 0o600,
+    });
+    let sawKey: string | undefined;
+    const config = makeConfig(h);
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      // undefined ⇒ fall through to file
+      _testFetchExternalSpend: async ({ adminKey }) => {
+        sawKey = adminKey;
+        return {
+          day24hUsd: 0,
+          day7dUsd: 0,
+          top: [],
+        };
+      },
+    });
+    await broker.start();
+    try {
+      const sock = join(h.socketRoot, "alice", "sock");
+      const resp = (await rpc(sock, {
+        v: PROTOCOL_VERSION,
+        id: "4",
+        op: "get-external-spend",
+        forceLive: true,
+      })) as { ok: boolean; data?: { available?: boolean; day24hUsd?: number } };
+      expect(resp.ok).toBe(true);
+      expect(resp.data?.available).toBe(true);
+      expect(resp.data?.day24hUsd).toBe(0);
+      expect(sawKey).toBe("sk-from-file");
+      expect(JSON.stringify(resp)).not.toContain("sk-from-file");
+    } finally {
+      broker.stop();
+    }
+  });
+
+  it("rejects malformed durable cache (dot not poison available totals)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    writeFileSync(
+      join(h.stateDir, "external-spend.json"),
+      JSON.stringify({
+        summary: {
+          day24hUsd: "nope",
+          day7dUsd: 2,
+          top: [{ label: "x", usd: 1 }],
+        },
+        capturedAtMs: Date.now() - 1_000,
+      }),
+      { mode: 0o600 },
+    );
+    const config = makeConfig(h);
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      _testLitellmMasterKey: null,
+    });
+    await broker.start();
+    try {
+      const sock = join(h.socketRoot, "alice", "sock");
+      const resp = (await rpc(sock, {
+        v: PROTOCOL_VERSION,
+        id: "5",
+        op: "get-external-spend",
+      })) as { ok: boolean; data?: { available?: boolean; reason?: string } };
+      expect(resp.ok).toBe(true);
+      expect(resp.data?.available).toBe(false);
+      expect(resp.data?.reason).toBe("master_key_unavailable");
+    } finally {
+      broker.stop();
+    }
+  });
+
 });

--- a/src/auth/broker/server-external-spend.test.ts
+++ b/src/auth/broker/server-external-spend.test.ts
@@ -1,0 +1,230 @@
+/**
+ * get-external-spend — broker publishes sanitized OpenRouter/$ summary;
+ * master key never leaves the broker.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as net from "node:net";
+
+import { AuthBroker } from "./server.js";
+import { decodeResponse, encodeRequest, PROTOCOL_VERSION } from "./protocol.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import { writeAccountCredentials } from "../account-store.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-ext-spend-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  mkdirSync(join(agentsDir, "alice"), { recursive: true });
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try {
+      rmSync(h.tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents: { alice: {} },
+    auth: { active: "default", fallback_order: ["default"] },
+    litellm: { enabled: true, base_url: "http://litellm.test:4010" },
+  } as unknown as SwitchroomConfig;
+}
+
+function seedAccount(h: Harness, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: `at-${label}`,
+        refreshToken: `rt-${label}`,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    },
+    h.home,
+  );
+}
+
+async function rpc(socketPath: string, req: object): Promise<unknown> {
+  return await new Promise((resolveP, rejectP) => {
+    const c = net.createConnection(socketPath);
+    let buf = "";
+    let settled = false;
+    const settle = (v: unknown, err?: Error) => {
+      if (settled) return;
+      settled = true;
+      try {
+        c.destroy();
+      } catch {
+        /* ignore */
+      }
+      if (err) rejectP(err);
+      else resolveP(v);
+    };
+    c.on("connect", () => {
+      c.write(encodeRequest(req as Parameters<typeof encodeRequest>[0]));
+    });
+    c.on("data", (chunk) => {
+      buf += chunk.toString("utf-8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        try {
+          settle(decodeResponse(buf.slice(0, nl)));
+        } catch (err) {
+          settle(null, err as Error);
+        }
+      }
+    });
+    c.on("error", (err) => settle(null, err));
+    setTimeout(() => settle(null, new Error("rpc timeout")), 3000);
+  });
+}
+
+describe("get-external-spend", () => {
+  it("returns available:false when master key missing", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    const config = makeConfig(h);
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      _testLitellmMasterKey: null,
+    });
+    await broker.start();
+    try {
+      const sock = join(h.socketRoot, "alice", "sock");
+      const resp = (await rpc(sock, {
+        v: PROTOCOL_VERSION,
+        id: "1",
+        op: "get-external-spend",
+      })) as { ok: boolean; data?: { available?: boolean; reason?: string } };
+      expect(resp.ok).toBe(true);
+      expect(resp.data?.available).toBe(false);
+      expect(resp.data?.reason).toBe("master_key_unavailable");
+    } finally {
+      broker.stop();
+    }
+  });
+
+  it("returns sanitized summary from live fetch; never echo key", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    let sawKey: string | undefined;
+    const config = makeConfig(h);
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      _testLitellmMasterKey: "sk-secret-master-do-not-leak",
+      _testFetchExternalSpend: async ({ adminKey }) => {
+        sawKey = adminKey;
+        return {
+          day24hUsd: 8.07,
+          day7dUsd: 119.89,
+          top: [{ label: "gpt-oss-20b", usd: 6.1 }],
+        };
+      },
+    });
+    await broker.start();
+    try {
+      const sock = join(h.socketRoot, "alice", "sock");
+      const resp = (await rpc(sock, {
+        v: PROTOCOL_VERSION,
+        id: "2",
+        op: "get-external-spend",
+        forceLive: true,
+      })) as {
+        ok: boolean;
+        data?: Record<string, unknown>;
+      };
+      expect(resp.ok).toBe(true);
+      expect(resp.data?.available).toBe(true);
+      expect(resp.data?.day24hUsd).toBeCloseTo(8.07, 5);
+      expect(resp.data?.day7dUsd).toBeCloseTo(119.89, 5);
+      expect(resp.data?.top).toEqual([{ label: "gpt-oss-20b", usd: 6.1 }]);
+      expect(sawKey).toBe("sk-secret-master-do-not-leak");
+      expect(JSON.stringify(resp)).not.toContain("sk-secret-master");
+    } finally {
+      broker.stop();
+    }
+  });
+
+  it("serves durable cache when live refresh fails", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    writeFileSync(
+      join(h.stateDir, "external-spend.json"),
+      JSON.stringify({
+        summary: {
+          day24hUsd: 1,
+          day7dUsd: 2,
+          top: [{ label: "grok-4.5", usd: 1 }],
+        },
+        capturedAtMs: Date.now() - 60_000,
+      }),
+      { mode: 0o600 },
+    );
+    let fetches = 0;
+    const config = makeConfig(h);
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      _testLitellmMasterKey: "sk-x",
+      _testFetchExternalSpend: async () => {
+        fetches += 1;
+        return null;
+      },
+    });
+    await broker.start();
+    try {
+      const sock = join(h.socketRoot, "alice", "sock");
+      const resp = (await rpc(sock, {
+        v: PROTOCOL_VERSION,
+        id: "3",
+        op: "get-external-spend",
+        forceLive: true,
+      })) as { ok: boolean; data?: { available?: boolean; day24hUsd?: number } };
+      expect(resp.ok).toBe(true);
+      expect(resp.data?.available).toBe(true);
+      expect(resp.data?.day24hUsd).toBe(1);
+      expect(fetches).toBeGreaterThanOrEqual(1);
+    } finally {
+      broker.stop();
+    }
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -17,7 +17,7 @@
  *
  * Verbs (RFC H §4.3): get-credentials, list-state, set-active,
  * mark-exhausted, mark-throttled, refresh-account, add-account,
- * rm-account, set-override.
+ * rm-account, set-override, get-external-spend.
  */
 
 import * as net from "node:net";
@@ -85,6 +85,14 @@ import {
 } from "./account-eligibility.js";
 import type { AuthConfig, AuthConsumer, SwitchroomConfig } from "../../config/schema.js";
 import { atomicWriteJsonSync } from "../../util/atomic.js";
+import {
+  fetchAndSummarizeExternalSpend,
+  EXTERNAL_SPEND_CACHE_TTL_MS,
+  EXTERNAL_SPEND_FETCH_TIMEOUT_MS,
+  LITELLM_MASTER_KEY_STATE_BASENAME,
+  DEFAULT_LITELLM_BASE,
+  type ExternalSpendSummary,
+} from "../../litellm/external-spend.js";
 import { safeMirrorWrite } from "./mirror-write.js";
 import {
   REFRESH_THRESHOLD_MS,
@@ -475,6 +483,18 @@ export interface AuthBrokerOptions {
    *  0 to disable auto-scheduling so tests drive `corroborateExhaustionMark`
    *  directly; defaults to `MARK_CORROBORATION_PROBE_DELAY_MS`. */
   _testCorroborationDelayMs?: number;
+  /**
+   * Test-only: replace the LiteLLM external-spend live fetch. Production
+   * never sets this; `get-external-spend` calls LiteLLM with the master key.
+   */
+  _testFetchExternalSpend?: (opts: {
+    adminKey: string;
+    baseUrl: string;
+    now: Date;
+    forceLive?: boolean;
+  }) => Promise<ExternalSpendSummary | null>;
+  /** Test-only: override master-key resolution (skips file/env). */
+  _testLitellmMasterKey?: string | null;
 }
 
 /* ───────────────────────── Helpers ───────────────────────── */
@@ -606,6 +626,17 @@ export class AuthBroker {
   /** Utilization cache. Populated by opProbeQuota; mirrored to disk
    *  (`last-quota.json`) and reloaded on boot — #2495 Change 1. */
   private lastQuotaCache: LastQuotaCache = {};
+  /**
+   * External OpenRouter/$ spend summary for `/usage`. Broker owns the
+   * LiteLLM master key; agents only pull this sanitized snapshot via
+   * `get-external-spend`. Mirrored to `external-spend.json`.
+   */
+  private externalSpendCache: {
+    summary: ExternalSpendSummary;
+    capturedAtMs: number;
+  } | null = null;
+  /** Single-flight for live LiteLLM external-spend refresh. */
+  private externalSpendInFlight: Promise<void> | null = null;
   /** #2495 Change 2 — single-flight: in-flight live probes keyed by account
    *  label. Concurrent `probe-quota` requests for the same label share the one
    *  pending upstream call (a render storm = 1 API call per account, not N). */
@@ -1364,6 +1395,9 @@ export class AuthBroker {
           break;
         case "claim-notification":
           this.opClaimNotification(socket, reqId, identity, req.key, req.windowMs);
+          break;
+        case "get-external-spend":
+          await this.opGetExternalSpend(socket, reqId, identity, req.forceLive);
           break;
       }
     } catch (err) {
@@ -3139,7 +3173,148 @@ export class AuthBroker {
    * (N-1 of N agents per event) — auditing them would re-create the
    * very log spam this op exists to remove.
    */
-  private opClaimNotification(
+  
+  /**
+   * `get-external-spend` — fleet OpenRouter/cash spend for `/usage`.
+   * ACL: same as list-state (any bound identity). Never puts the master
+   * key on the wire. Soft-fails with `available:false` when the key is
+   * missing or LiteLLM is unreachable and no durable cache exists.
+   */
+  private async opGetExternalSpend(
+    socket: net.Socket,
+    id: string,
+    _identity: Identity,
+    forceLive?: boolean,
+  ): Promise<void> {
+    const nowMs = this.now();
+    const ttl = EXTERNAL_SPEND_CACHE_TTL_MS;
+    const fresh =
+      this.externalSpendCache != null &&
+      nowMs - this.externalSpendCache.capturedAtMs < ttl;
+
+    if (forceLive || !fresh) {
+      try {
+        await this.refreshExternalSpend(forceLive === true);
+      } catch (err) {
+        this.logErr(
+          `external-spend refresh failed: ${(err as Error)?.message ?? err}`,
+        );
+      }
+    }
+
+    if (!this.externalSpendCache) {
+      socket.write(
+        encodeSuccess(id, {
+          available: false,
+          reason: this.resolveLitellmMasterKey()
+            ? "litellm_unreachable"
+            : "master_key_unavailable",
+        }),
+      );
+      return;
+    }
+
+    const recently =
+      nowMs - this.externalSpendCache.capturedAtMs < 5_000;
+    const outServed: "live" | "cache" = recently && (forceLive || !fresh)
+      ? "live"
+      : "cache";
+
+    const s = this.externalSpendCache.summary;
+    socket.write(
+      encodeSuccess(id, {
+        available: true,
+        day24hUsd: s.day24hUsd,
+        day7dUsd: s.day7dUsd,
+        top: s.top,
+        capturedAtMs: this.externalSpendCache.capturedAtMs,
+        served: outServed,
+      }),
+    );
+  }
+
+  /** Resolve LiteLLM master key: test override → env → state-dir file. Never logs value. */
+  private resolveLitellmMasterKey(): string | null {
+    if (this.opts._testLitellmMasterKey !== undefined) {
+      const v = this.opts._testLitellmMasterKey;
+      return v && v.trim() ? v.trim() : null;
+    }
+    const envKey = (
+      process.env.SWITCHROOM_LITELLM_ADMIN_KEY ??
+      process.env.LITELLM_MASTER_KEY ??
+      ""
+    ).trim();
+    if (envKey) return envKey;
+    try {
+      const path = join(this.stateDir, LITELLM_MASTER_KEY_STATE_BASENAME);
+      if (!existsSync(path)) return null;
+      const raw = readFileSync(path, "utf-8").trim();
+      return raw.length > 0 ? raw : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private resolveLitellmBaseUrl(): string {
+    const fromCfg = (this.config as { litellm?: { base_url?: string } }).litellm
+      ?.base_url;
+    const raw = (
+      process.env.SWITCHROOM_LITELLM_BASE ??
+      fromCfg ??
+      DEFAULT_LITELLM_BASE
+    ).trim();
+    return raw.replace(/\/+$/, "") || DEFAULT_LITELLM_BASE;
+  }
+
+  /**
+   * Live-refresh external spend from LiteLLM. Single-flight. On failure
+   * leaves any existing durable cache in place.
+   */
+  private async refreshExternalSpend(forceLive: boolean): Promise<void> {
+    if (this.externalSpendInFlight) {
+      await this.externalSpendInFlight;
+      return;
+    }
+    const run = (async () => {
+      const nowMs = this.now();
+      if (
+        !forceLive &&
+        this.externalSpendCache &&
+        nowMs - this.externalSpendCache.capturedAtMs < EXTERNAL_SPEND_CACHE_TTL_MS
+      ) {
+        return;
+      }
+      const key = this.resolveLitellmMasterKey();
+      if (!key) return;
+      const baseUrl = this.resolveLitellmBaseUrl();
+      const now = new Date(nowMs);
+      let summary: ExternalSpendSummary | null = null;
+      if (this.opts._testFetchExternalSpend) {
+        summary = await this.opts._testFetchExternalSpend({
+          adminKey: key,
+          baseUrl,
+          now,
+          forceLive,
+        });
+      } else {
+        summary = await fetchAndSummarizeExternalSpend({
+          adminKey: key,
+          baseUrl,
+          now,
+          timeoutMs: EXTERNAL_SPEND_FETCH_TIMEOUT_MS,
+        });
+      }
+      if (!summary) return;
+      this.externalSpendCache = { summary, capturedAtMs: this.now() };
+      this.persistExternalSpendCache();
+    })();
+    this.externalSpendInFlight = run.finally(() => {
+      this.externalSpendInFlight = null;
+    });
+    await this.externalSpendInFlight;
+  }
+
+private opClaimNotification(
     socket: net.Socket,
     id: string,
     identity: Identity,
@@ -4478,6 +4653,25 @@ export class AuthBroker {
     // #3185 — reload the durable per-(account, tier) usage ledger so a restart
     // keeps the rolling history instead of starting the trend from scratch.
     this.usageLedger = this.readJson<UsageLedger>("usage-ledger.json") ?? {};
+    {
+      const es = this.readJson<{
+        summary?: ExternalSpendSummary;
+        capturedAtMs?: number;
+      }>("external-spend.json");
+      if (
+        es &&
+        es.summary &&
+        typeof es.capturedAtMs === "number" &&
+        typeof es.summary.day24hUsd === "number" &&
+        typeof es.summary.day7dUsd === "number" &&
+        Array.isArray(es.summary.top)
+      ) {
+        this.externalSpendCache = {
+          summary: es.summary,
+          capturedAtMs: es.capturedAtMs,
+        };
+      }
+    }
     this.applyActiveOverride();
   }
 
@@ -4542,6 +4736,14 @@ export class AuthBroker {
   /** #2495 Change 1 — mirror the utilization cache to disk so it survives
    *  a broker restart. Same atomic-write pattern as the exhaustion ledger. */
   private persistLastQuotaCache(): void { atomicWriteJsonSync(join(this.stateDir, "last-quota.json"), this.lastQuotaCache, 0o600); }
+  private persistExternalSpendCache(): void {
+    if (!this.externalSpendCache) return;
+    atomicWriteJsonSync(
+      join(this.stateDir, "external-spend.json"),
+      this.externalSpendCache,
+      0o600,
+    );
+  }
   /** #3176 — mirror the flagship-tier canary cache to disk. */
   private persistLastTierQuotaCache(): void { atomicWriteJsonSync(join(this.stateDir, "last-tier-quota.json"), this.lastTierQuotaCache, 0o600); }
   /** #3185 — mirror the per-(account, tier) usage ledger to disk so the rolling

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -3163,18 +3163,6 @@ export class AuthBroker {
   }
 
   /**
-   * Fleet notification-dedup claim. Grants the FIRST caller of a given
-   * `key` inside `windowMs`; everyone else is denied. The check-and-set
-   * is fully synchronous (no awaits), so two agents racing the same key
-   * serialize on the event loop — exactly one grant per window, by
-   * construction.
-   *
-   * Audit: granted claims only. Denials are the designed common case
-   * (N-1 of N agents per event) — auditing them would re-create the
-   * very log spam this op exists to remove.
-   */
-  
-  /**
    * `get-external-spend` — fleet OpenRouter/cash spend for `/usage`.
    * ACL: same as list-state (any bound identity). Never puts the master
    * key on the wire. Soft-fails with `available:false` when the key is
@@ -3271,9 +3259,20 @@ export class AuthBroker {
    * leaves any existing durable cache in place.
    */
   private async refreshExternalSpend(forceLive: boolean): Promise<void> {
-    if (this.externalSpendInFlight) {
+    // Wait for any in-flight refresh, then re-evaluate. A concurrent
+    // forceLive must not be starved by a non-force flight that no-ops
+    // on a still-within-TTL (but operator-stale) cache.
+    while (this.externalSpendInFlight) {
       await this.externalSpendInFlight;
-      return;
+      if (!forceLive) return;
+      const justNow = this.now();
+      if (
+        this.externalSpendCache &&
+        justNow - this.externalSpendCache.capturedAtMs < 5_000
+      ) {
+        return;
+      }
+      // lost the race to start another force — loop and try again
     }
     const run = (async () => {
       const nowMs = this.now();
@@ -3314,7 +3313,18 @@ export class AuthBroker {
     await this.externalSpendInFlight;
   }
 
-private opClaimNotification(
+  /**
+   * Fleet notification-dedup claim. Grants the FIRST caller of a given
+   * `key` inside `windowMs`; everyone else is denied. The check-and-set
+   * is fully synchronous (no awaits), so two agents racing the same key
+   * serialize on the event loop — exactly one grant per window, by
+   * construction.
+   *
+   * Audit: granted claims only. Denials are the designed common case
+   * (N-1 of N agents per event) — auditing them would re-create the
+   * very log spam this op exists to remove.
+   */
+  private opClaimNotification(
     socket: net.Socket,
     id: string,
     identity: Identity,
@@ -4662,12 +4672,26 @@ private opClaimNotification(
         es &&
         es.summary &&
         typeof es.capturedAtMs === "number" &&
-        typeof es.summary.day24hUsd === "number" &&
-        typeof es.summary.day7dUsd === "number" &&
-        Array.isArray(es.summary.top)
+        Number.isFinite(es.summary.day24hUsd) &&
+        Number.isFinite(es.summary.day7dUsd) &&
+        Array.isArray(es.summary.top) &&
+        es.summary.top.every(
+          (t) =>
+            t &&
+            typeof t.label === "string" &&
+            typeof t.usd === "number" &&
+            Number.isFinite(t.usd),
+        )
       ) {
         this.externalSpendCache = {
-          summary: es.summary,
+          summary: {
+            day24hUsd: es.summary.day24hUsd,
+            day7dUsd: es.summary.day7dUsd,
+            top: es.summary.top.map((t) => ({
+              label: t.label,
+              usd: t.usd,
+            })),
+          },
           capturedAtMs: es.capturedAtMs,
         };
       }

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -76,6 +76,7 @@ import { refreshAgentConnectionHealth } from "../agents/connection-health.js";
 import type { VaultAclResult } from "./doctor-mcp-secrets.js";
 import { installUpdatePromptHook } from "./update-prompt-hook.js";
 import { allocateAgentUid } from "../agents/compose.js";
+import { LITELLM_MASTER_KEY_STATE_BASENAME } from "../litellm/external-spend.js";
 import { writeComposeFile, computeComposeContent, resolveHostSwitchroomConfigPath, resolveHostHomeForCompose } from "./write-compose.js";
 import { getProfilePath } from "../agents/profiles.js";
 import { detectInstallType } from "./install-detect.js";
@@ -285,7 +286,7 @@ export function materializeLitellmMasterKeyForBroker(
   try {
     const stateDir = join(home, ".switchroom", "state", "auth-broker");
     mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-    const path = join(stateDir, "litellm-master-key");
+    const path = join(stateDir, LITELLM_MASTER_KEY_STATE_BASENAME);
     writeFileSync(path, masterKey.trim() + "\n", { mode: 0o600 });
     try {
       chmodSync(path, 0o600);

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -17,7 +17,7 @@
  */
 import { Option, type Command } from "commander";
 import chalk from "chalk";
-import { accessSync, chownSync, constants as fsConstants, copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { accessSync, chmodSync, chownSync, constants as fsConstants, copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { mkdir } from "node:fs/promises";
 import { spawnSync as childSpawnSync } from "node:child_process";
@@ -271,6 +271,33 @@ export async function resolveOperatorVaultPassphrase(home: string): Promise<stri
 /**
  * @internal exported for the apply-level e2e (src/litellm/provision-apply-e2e.test.ts).
  */
+
+/**
+ * Materialize the LiteLLM master key into the auth-broker state dir so the
+ * broker can publish `get-external-spend` without every agent holding the
+ * key. File mode 0600; path is never mounted into agent containers.
+ * Best-effort: failures are warnings (agents just omit the External block).
+ */
+export function materializeLitellmMasterKeyForBroker(
+  masterKey: string,
+  home: string = process.env.HOME ?? "/root",
+): { ok: true; path: string } | { ok: false; error: string } {
+  try {
+    const stateDir = join(home, ".switchroom", "state", "auth-broker");
+    mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    const path = join(stateDir, "litellm-master-key");
+    writeFileSync(path, masterKey.trim() + "\n", { mode: 0o600 });
+    try {
+      chmodSync(path, 0o600);
+    } catch {
+      /* best-effort */
+    }
+    return { ok: true, path };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
 export async function provisionLiteLLMKeys(
   config: SwitchroomConfig,
   agentNames: string[],
@@ -300,6 +327,7 @@ export async function provisionLiteLLMKeys(
     (config as { litellm?: { enabled?: boolean } }).litellm?.enabled === true &&
     (config as { memory?: { backend?: string } }).memory?.backend === "hindsight";
   if (optedIn.length === 0 && !needsHindsight) return; // zero-impact when the feature is off
+  let brokerKeyMaterialized = false;
 
   // Lazy imports — only paid for when at least one agent opts in or hindsight is wired.
   const [{ getViaBrokerStructured, putViaBroker }, { ensureTeam, ensureKey, validateKey, bindKeyToTeam }, { addAgentSecret }] =
@@ -531,6 +559,21 @@ export async function provisionLiteLLMKeys(
           masterKeyErr = `litellm: admin_key vault ref '${adminKeyRef}' is not a string secret.`;
         } else {
           masterKey = resolved.entry.value;
+        }
+      }
+
+      if (masterKey && !brokerKeyMaterialized) {
+        const mat = materializeLitellmMasterKeyForBroker(
+          masterKey,
+          ctx.home ?? homedir(),
+        );
+        brokerKeyMaterialized = true;
+        if (!mat.ok) {
+          ctx.writeErr(
+            chalk.yellow(
+              `  ! litellm: could not materialize master key for auth-broker external-spend (${mat.error})\n`,
+            ),
+          );
         }
       }
 

--- a/src/litellm/external-spend.test.ts
+++ b/src/litellm/external-spend.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  addUtcDays,
+  fetchAndSummarizeExternalSpend,
+  formatUsd,
+  isExternalModel,
+  normalizeSpendLogRows,
+  shortModelLabel,
+  summarizeExternalSpend,
+  utcDateString,
+  type LiteLLMDaySpendRow,
+} from "./external-spend.js";
+
+const NOW = new Date("2026-07-19T15:30:00.000Z");
+
+describe("isExternalModel", () => {
+  it("includes openrouter/sr/cash needles and excludes Claude", () => {
+    expect(isExternalModel("openrouter/openai/gpt-oss-20b")).toBe(true);
+    expect(isExternalModel("sr-grok-4.5")).toBe(true);
+    expect(isExternalModel("gpt-oss-20b")).toBe(true);
+    expect(isExternalModel("claude-sonnet-5")).toBe(false);
+    expect(isExternalModel("openrouter/anthropic/claude-3.5-sonnet")).toBe(false);
+    expect(isExternalModel("anthropic/claude-fable-5")).toBe(false);
+  });
+});
+
+describe("shortModelLabel / formatUsd / dates", () => {
+  it("shortens labels and formats money", () => {
+    expect(shortModelLabel("openrouter/openai/gpt-oss-20b")).toBe("gpt-oss-20b");
+    expect(shortModelLabel("sr-grok-4.5")).toBe("grok-4.5");
+    expect(formatUsd(8.066)).toBe("$8.07");
+    expect(formatUsd(-1)).toBe("$0.00");
+  });
+  it("UTC calendar helpers", () => {
+    expect(utcDateString(NOW)).toBe("2026-07-19");
+    expect(addUtcDays("2026-07-19", -6)).toBe("2026-07-13");
+    expect(addUtcDays("2026-07-19", 1)).toBe("2026-07-20");
+  });
+});
+
+describe("summarizeExternalSpend", () => {
+  const rows: LiteLLMDaySpendRow[] = [
+    {
+      startTime: "2026-07-19",
+      spend: 50,
+      models: {
+        "claude-sonnet-5": 40,
+        "openrouter/openai/gpt-oss-20b": 6.1,
+        "sr-grok-4.5": 1.18,
+        "gemini-3.1-flash-lite": 0.79,
+      },
+    },
+    {
+      startTime: "2026-07-18",
+      models: { "openrouter/openai/gpt-oss-20b": 10 },
+    },
+    {
+      startTime: "2026-07-12",
+      models: { "openrouter/openai/gpt-oss-20b": 100 },
+    },
+    {
+      startTime: "2026-07-13",
+      models: { "sr-deepseek-r1": 2 },
+    },
+  ];
+
+  it("sums UTC today + 7d external only; top-3 from 7d", () => {
+    const s = summarizeExternalSpend(rows, NOW);
+    expect(s.day24hUsd).toBeCloseTo(8.07, 5);
+    expect(s.day7dUsd).toBeCloseTo(20.07, 5);
+    expect(s.top.map((t) => t.label)).toEqual([
+      "gpt-oss-20b",
+      "deepseek-r1",
+      "grok-4.5",
+    ]);
+  });
+});
+
+describe("normalizeSpendLogRows", () => {
+  it("accepts array or {data}", () => {
+    expect(normalizeSpendLogRows([{ startTime: "x" }])).toHaveLength(1);
+    expect(normalizeSpendLogRows({ data: [{ startTime: "x" }] })).toHaveLength(1);
+    expect(normalizeSpendLogRows({})).toEqual([]);
+  });
+});
+
+describe("fetchAndSummarizeExternalSpend", () => {
+  it("returns null on 401", async () => {
+    const fetchImpl = vi.fn(async () => new Response("no", { status: 401 }));
+    const s = await fetchAndSummarizeExternalSpend({
+      adminKey: "sk-x",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: NOW,
+    });
+    expect(s).toBeNull();
+  });
+
+  it("summarizes OK body", async () => {
+    const body = [
+      {
+        startTime: "2026-07-19",
+        models: { "openrouter/openai/gpt-oss-20b": 1.5, "claude-sonnet-5": 9 },
+      },
+    ];
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(String(url)).toContain("start_date=2026-07-13");
+      expect(String(url)).toContain("end_date=2026-07-20");
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
+    const s = await fetchAndSummarizeExternalSpend({
+      adminKey: "sk-x",
+      baseUrl: "http://litellm.test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: NOW,
+    });
+    expect(s?.day24hUsd).toBeCloseTo(1.5, 5);
+    expect(s?.top[0]?.label).toBe("gpt-oss-20b");
+  });
+});

--- a/src/litellm/external-spend.ts
+++ b/src/litellm/external-spend.ts
@@ -1,0 +1,230 @@
+/**
+ * External (non-Claude / OpenRouter cash) spend — pure helpers shared by
+ * the auth-broker publisher and the Telegram `/usage` card renderer.
+ *
+ * Windows are **UTC calendar days** on LiteLLM `/spend/logs` `startTime`
+ * (the card still labels the today window "24h" per operator layout B).
+ *
+ * Security: never put the LiteLLM master key in agent containers. The
+ * auth-broker fetches with the master key and serves only a sanitized
+ * summary over UDS (`get-external-spend`).
+ */
+
+export interface ExternalSpendTopModel {
+  label: string;
+  usd: number;
+}
+
+export interface ExternalSpendSummary {
+  day24hUsd: number;
+  day7dUsd: number;
+  top: ExternalSpendTopModel[];
+}
+
+/** One daily row from LiteLLM summarized `/spend/logs`. */
+export interface LiteLLMDaySpendRow {
+  startTime?: string;
+  /** Day total including Claude — never used as External. */
+  spend?: number;
+  models?: Record<string, number | string>;
+}
+
+export const EXTERNAL_SPEND_TOP_N = 3;
+export const DEFAULT_LITELLM_BASE = "http://127.0.0.1:4010";
+
+/** Broker cooldown between live refreshes (also agent soft-cache). */
+export const EXTERNAL_SPEND_CACHE_TTL_MS = 90_000;
+
+/** Live LiteLLM fetch timeout. */
+export const EXTERNAL_SPEND_FETCH_TIMEOUT_MS = 5_000;
+
+/**
+ * Filename under the auth-broker state dir for the master key material
+ * written by `switchroom apply` (mode 0600). Never mounted into agents.
+ */
+export const LITELLM_MASTER_KEY_STATE_BASENAME = "litellm-master-key";
+
+const BARE_EXTERNAL_NEEDLES = [
+  "gpt-oss",
+  "grok",
+  "gemini",
+  "deepseek",
+  "kimi",
+  "glm-",
+  "qwen",
+  "llama",
+] as const;
+
+/**
+ * True when a LiteLLM model name is cash/external (OpenRouter etc.), not
+ * Anthropic Max/Pro subscription passthrough via the proxy.
+ */
+export function isExternalModel(model: string): boolean {
+  const m = model.trim().toLowerCase();
+  if (!m) return false;
+  // Subscription Claude / Anthropic passthrough — never External $.
+  // Note: `openrouter/anthropic/claude-*` is still Claude API cash via
+  // OpenRouter, not Max/Pro — but operators treat Claude-named routes as
+  // non-External for this card (filters openrouter/anthropic/claude too).
+  if (m.startsWith("claude")) return false;
+  if (m.includes("anthropic/claude")) return false;
+
+  if (m.startsWith("openrouter/")) return true;
+  if (m.startsWith("sr-")) return true;
+
+  for (const needle of BARE_EXTERNAL_NEEDLES) {
+    if (m.includes(needle)) return true;
+  }
+  return false;
+}
+
+/** Strip openrouter/ and keep a short trailing id for the top line. */
+export function shortModelLabel(model: string): string {
+  let m = model.trim();
+  if (m.toLowerCase().startsWith("openrouter/")) {
+    m = m.slice("openrouter/".length);
+  }
+  const parts = m.split("/").filter(Boolean);
+  if (parts.length >= 2) {
+    m = parts[parts.length - 1]!;
+  }
+  if (m.toLowerCase().startsWith("sr-")) {
+    m = m.slice(3);
+  }
+  return m || model.trim();
+}
+
+export function formatUsd(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return "$0.00";
+  return `$${n.toFixed(2)}`;
+}
+
+export function utcDateString(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function addUtcDays(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const dt = new Date(Date.UTC(y!, m! - 1, d!));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return utcDateString(dt);
+}
+
+function rowDay(row: LiteLLMDaySpendRow): string | null {
+  const st = row.startTime;
+  if (!st || typeof st !== "string") return null;
+  return st.length >= 10 ? st.slice(0, 10) : null;
+}
+
+function externalModelsFromRow(row: LiteLLMDaySpendRow): Record<string, number> {
+  const out: Record<string, number> = {};
+  const models = row.models ?? {};
+  for (const [name, raw] of Object.entries(models)) {
+    if (!isExternalModel(name)) continue;
+    const n = typeof raw === "number" ? raw : Number(raw);
+    if (!Number.isFinite(n) || n === 0) continue;
+    out[name] = (out[name] ?? 0) + n;
+  }
+  return out;
+}
+
+/**
+ * Pure aggregator. `now` pins the UTC "today" for 24h / 7d windows.
+ * Does NOT use `row.spend` (mixed Claude + external).
+ */
+export function summarizeExternalSpend(
+  days: readonly LiteLLMDaySpendRow[],
+  now: Date = new Date(),
+): ExternalSpendSummary {
+  const today = utcDateString(now);
+  const start7 = addUtcDays(today, -6);
+
+  let day24hUsd = 0;
+  let day7dUsd = 0;
+  const byModel: Record<string, number> = {};
+
+  for (const row of days) {
+    const day = rowDay(row);
+    if (!day) continue;
+    if (day < start7 || day > today) continue;
+    const ext = externalModelsFromRow(row);
+    let rowSum = 0;
+    for (const [name, usd] of Object.entries(ext)) {
+      rowSum += usd;
+      byModel[name] = (byModel[name] ?? 0) + usd;
+    }
+    day7dUsd += rowSum;
+    if (day === today) day24hUsd += rowSum;
+  }
+
+  const top = Object.entries(byModel)
+    .filter(([, usd]) => usd > 0)
+    .sort((a, b) => b[1]! - a[1]! || a[0]!.localeCompare(b[0]!))
+    .slice(0, EXTERNAL_SPEND_TOP_N)
+    .map(([name, usd]) => ({ label: shortModelLabel(name), usd }));
+
+  return { day24hUsd, day7dUsd, top };
+}
+
+/** Normalize `/spend/logs` JSON body into day rows. */
+export function normalizeSpendLogRows(body: unknown): LiteLLMDaySpendRow[] {
+  if (Array.isArray(body)) return body as LiteLLMDaySpendRow[];
+  if (body && typeof body === "object") {
+    const data = (body as { data?: unknown }).data;
+    if (Array.isArray(data)) return data as LiteLLMDaySpendRow[];
+  }
+  return [];
+}
+
+export function resolveLitellmBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const raw = (env.SWITCHROOM_LITELLM_BASE ?? DEFAULT_LITELLM_BASE).trim();
+  return raw.replace(/\/+$/, "") || DEFAULT_LITELLM_BASE;
+}
+
+/**
+ * Fetch + summarize external spend from LiteLLM. Pure-ish: inject fetch/key.
+ * Returns null on transport/auth/timeout failure.
+ */
+export async function fetchAndSummarizeExternalSpend(opts: {
+  adminKey: string;
+  baseUrl?: string;
+  now?: Date;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<ExternalSpendSummary | null> {
+  const now = opts.now ?? new Date();
+  const base = (opts.baseUrl ?? DEFAULT_LITELLM_BASE).replace(/\/+$/, "");
+  const today = utcDateString(now);
+  const start = addUtcDays(today, -6);
+  const end = addUtcDays(today, 1);
+  const url =
+    `${base}/spend/logs?start_date=${encodeURIComponent(start)}` +
+    `&end_date=${encodeURIComponent(end)}`;
+
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? EXTERNAL_SPEND_FETCH_TIMEOUT_MS;
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${opts.adminKey}`,
+        Accept: "application/json",
+      },
+      signal: ac.signal,
+    });
+    if (!res.ok) return null;
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      return null;
+    }
+    return summarizeExternalSpend(normalizeSpendLogRows(body), now);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/telegram-plugin/external-spend.ts
+++ b/telegram-plugin/external-spend.ts
@@ -8,179 +8,40 @@
  * - top `model $a` · `model $b` · `model $c`
  * ```
  *
- * Source: LiteLLM `GET /spend/logs?start_date&end_date` daily summaries
- * (admin/master key). Agent virtual keys get 401 — resolve master via env
- * or vault `litellm/master-key`. On any failure, callers OMIT the block.
+ * **Durable path:** the auth-broker holds the LiteLLM master key and
+ * serves a sanitized summary via `get-external-spend`. Agents never
+ * receive the master key. Soft-fail → omit the External block.
  *
- * Successful summaries are cached in-process (~90s) so Refresh spam does not
- * hammer LiteLLM. Never log key material.
+ * Pure helpers (filter/format) live in `src/litellm/external-spend.ts`
+ * and are re-exported here for card rendering + tests.
  */
 
 import {
-  getViaBrokerStructured,
-  readVaultTokenFile,
-} from '../src/vault/broker/client.js';
-import { loadConfig, findConfigFile } from '../src/config/loader.js';
+  formatUsd,
+  type ExternalSpendSummary,
+  type ExternalSpendTopModel,
+} from '../src/litellm/external-spend.js';
 
-export interface ExternalSpendTopModel {
-  label: string;
-  usd: number;
-}
+export type { ExternalSpendSummary, ExternalSpendTopModel };
+export {
+  isExternalModel,
+  shortModelLabel,
+  formatUsd,
+  summarizeExternalSpend,
+  normalizeSpendLogRows,
+  utcDateString,
+  addUtcDays,
+  EXTERNAL_SPEND_CACHE_TTL_MS,
+  type LiteLLMDaySpendRow,
+} from '../src/litellm/external-spend.js';
 
-export interface ExternalSpendSummary {
-  day24hUsd: number;
-  day7dUsd: number;
-  top: ExternalSpendTopModel[];
-}
+/** Soft client-side cache so strip double-taps of /usage within a process. */
+const CLIENT_CACHE_TTL_MS = 30_000;
+let clientCache: { atMs: number; summary: ExternalSpendSummary } | null = null;
 
-/** One daily row from LiteLLM summarized `/spend/logs`. */
-export interface LiteLLMDaySpendRow {
-  startTime?: string;
-  /** Day total including Claude — never used as External. */
-  spend?: number;
-  models?: Record<string, number | string>;
-}
-
-export const EXTERNAL_SPEND_CACHE_TTL_MS = 90_000;
-export const EXTERNAL_SPEND_FETCH_TIMEOUT_MS = 4_000;
-export const DEFAULT_LITELLM_BASE = 'http://127.0.0.1:4010';
-const TOP_N = 3;
-
-const BARE_EXTERNAL_NEEDLES = [
-  'gpt-oss',
-  'grok',
-  'gemini',
-  'deepseek',
-  'kimi',
-  'glm-',
-  'qwen',
-  'llama',
-] as const;
-
-let cache: { atMs: number; summary: ExternalSpendSummary } | null = null;
-
-/** Test seam — clear the in-process cache. */
+/** Test seam. */
 export function clearExternalSpendCache(): void {
-  cache = null;
-}
-
-/**
- * True when a LiteLLM model name is cash/external (OpenRouter etc.), not
- * Anthropic Max/Pro subscription passthrough via the proxy.
- */
-export function isExternalModel(model: string): boolean {
-  const m = model.trim().toLowerCase();
-  if (!m) return false;
-  // Subscription Claude / Anthropic passthrough — never External $.
-  if (m.startsWith('claude')) return false;
-  if (m.includes('anthropic/claude')) return false;
-  if (m.startsWith('anthropic/claude')) return false;
-
-  if (m.startsWith('openrouter/')) return true;
-  if (m.startsWith('sr-')) return true;
-
-  // Bare aliases / non-openrouter-prefixed cash models seen in logs.
-  for (const needle of BARE_EXTERNAL_NEEDLES) {
-    if (m.includes(needle)) return true;
-  }
-  return false;
-}
-
-/** Strip openrouter/ and keep a short trailing id for the top line. */
-export function shortModelLabel(model: string): string {
-  let m = model.trim();
-  if (m.toLowerCase().startsWith('openrouter/')) {
-    m = m.slice('openrouter/'.length);
-  }
-  // Path-like org/model → last segment (openai/gpt-oss-20b → gpt-oss-20b).
-  const parts = m.split('/').filter(Boolean);
-  if (parts.length >= 2) {
-    m = parts[parts.length - 1]!;
-  }
-  if (m.toLowerCase().startsWith('sr-')) {
-    // sr-grok-4.5 → grok-4.5
-    m = m.slice(3);
-  }
-  return m || model.trim();
-}
-
-export function formatUsd(n: number): string {
-  if (!Number.isFinite(n) || n < 0) return '$0.00';
-  return `$${n.toFixed(2)}`;
-}
-
-export function utcDateString(d: Date): string {
-  return d.toISOString().slice(0, 10);
-}
-
-export function addUtcDays(dateStr: string, days: number): string {
-  const [y, m, d] = dateStr.split('-').map(Number);
-  const dt = new Date(Date.UTC(y!, m! - 1, d!));
-  dt.setUTCDate(dt.getUTCDate() + days);
-  return utcDateString(dt);
-}
-
-function rowDay(row: LiteLLMDaySpendRow): string | null {
-  const st = row.startTime;
-  if (!st || typeof st !== 'string') return null;
-  // "2026-07-19" or ISO timestamp
-  return st.length >= 10 ? st.slice(0, 10) : null;
-}
-
-function externalModelsFromRow(row: LiteLLMDaySpendRow): Record<string, number> {
-  const out: Record<string, number> = {};
-  const models = row.models ?? {};
-  for (const [name, raw] of Object.entries(models)) {
-    if (!isExternalModel(name)) continue;
-    const n = typeof raw === 'number' ? raw : Number(raw);
-    if (!Number.isFinite(n) || n === 0) continue;
-    out[name] = (out[name] ?? 0) + n;
-  }
-  return out;
-}
-
-/**
- * Pure aggregator — unit-test without network.
- * `now` pins the UTC "today" used for 24h / 7d windows.
- *
- * Windows (UTC calendar days on LiteLLM `startTime`):
- *   - 24h: today only
- *   - 7d:  today-6 .. today inclusive
- * Top models: aggregate external spend across the 7d window, top 3.
- * Does NOT use `row.spend` (mixed Claude + external).
- */
-export function summarizeExternalSpend(
-  days: readonly LiteLLMDaySpendRow[],
-  now: Date = new Date(),
-): ExternalSpendSummary {
-  const today = utcDateString(now);
-  const start7 = addUtcDays(today, -6); // inclusive 7 calendar days
-
-  let day24hUsd = 0;
-  let day7dUsd = 0;
-  const byModel: Record<string, number> = {};
-
-  for (const row of days) {
-    const day = rowDay(row);
-    if (!day) continue;
-    if (day < start7 || day > today) continue;
-    const ext = externalModelsFromRow(row);
-    let rowSum = 0;
-    for (const [name, usd] of Object.entries(ext)) {
-      rowSum += usd;
-      byModel[name] = (byModel[name] ?? 0) + usd;
-    }
-    day7dUsd += rowSum;
-    if (day === today) day24hUsd += rowSum;
-  }
-
-  const top = Object.entries(byModel)
-    .filter(([, usd]) => usd > 0)
-    .sort((a, b) => b[1]! - a[1]! || a[0]!.localeCompare(b[0]!))
-    .slice(0, TOP_N)
-    .map(([name, usd]) => ({ label: shortModelLabel(name), usd }));
-
-  return { day24hUsd, day7dUsd, top };
+  clientCache = null;
 }
 
 /**
@@ -203,178 +64,72 @@ export function formatExternalSpendBlock(
   return lines;
 }
 
-/** Strip a leading `vault:` reference to the bare key name. */
-export function vaultKeyFromRef(ref: string): string | null {
-  const t = ref.trim();
-  if (!t.toLowerCase().startsWith('vault:')) return null;
-  const key = t.slice('vault:'.length).trim();
-  return key.length > 0 ? key : null;
-}
-
-export function resolveLitellmBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
-  const raw = (env.SWITCHROOM_LITELLM_BASE ?? DEFAULT_LITELLM_BASE).trim();
-  return raw.replace(/\/+$/, '') || DEFAULT_LITELLM_BASE;
-}
-
-/**
- * Normalize a `/spend/logs` JSON body into day rows. LiteLLM has returned
- * either a bare array or `{ data: [...] }` depending on version.
- */
-export function normalizeSpendLogRows(body: unknown): LiteLLMDaySpendRow[] {
-  if (Array.isArray(body)) return body as LiteLLMDaySpendRow[];
-  if (body && typeof body === 'object') {
-    const data = (body as { data?: unknown }).data;
-    if (Array.isArray(data)) return data as LiteLLMDaySpendRow[];
-  }
-  return [];
-}
-
-export interface ResolveAdminKeyDeps {
-  env?: NodeJS.ProcessEnv;
-  /** Raw `litellm.admin_key` from config (may be `vault:…`). */
-  readAdminKeyRef?: () => string | null | undefined;
-  vaultGet?: (key: string) => Promise<string | null>;
-  agentName?: string;
-}
-
-/**
- * Resolve LiteLLM master/admin key for `/spend/logs`. Never logs the value.
- * Order: env → config vault ref via broker → null.
- */
-export async function resolveLitellmAdminKey(
-  deps: ResolveAdminKeyDeps = {},
-): Promise<string | null> {
-  const env = deps.env ?? process.env;
-  const fromEnv = (
-    env.SWITCHROOM_LITELLM_ADMIN_KEY ??
-    env.LITELLM_MASTER_KEY ??
-    ''
-  ).trim();
-  if (fromEnv) return fromEnv;
-
-  let ref: string | null | undefined;
-  try {
-    ref = deps.readAdminKeyRef
-      ? deps.readAdminKeyRef()
-      : defaultReadAdminKeyRef();
-  } catch {
-    ref = null;
-  }
-
-  const vaultKey = ref ? vaultKeyFromRef(ref) : null;
-  if (ref && !vaultKey) {
-    // Literal non-vault value in config (dev only).
-    const plain = ref.trim();
-    return plain.length > 0 ? plain : null;
-  }
-  const keyName = vaultKey ?? 'litellm/master-key';
-
-  if (deps.vaultGet) {
-    try {
-      return await deps.vaultGet(keyName);
-    } catch {
-      return null;
-    }
-  }
-
-  try {
-    const agent = deps.agentName ?? env.SWITCHROOM_AGENT_NAME;
-    const token = agent ? (readVaultTokenFile(agent) ?? undefined) : undefined;
-    const result = await getViaBrokerStructured(keyName, token ? { token } : {});
-    if (result.kind === 'ok' && result.entry.kind === 'string' && result.entry.value) {
-      const v = result.entry.value.trim();
-      return v.length > 0 ? v : null;
-    }
-  } catch {
-    // omit External
-  }
-  return null;
-}
-
-function defaultReadAdminKeyRef(): string | null {
-  try {
-    const cfgPath = findConfigFile();
-    const cfg = loadConfig(cfgPath) as { litellm?: { admin_key?: string } };
-    const ref = cfg.litellm?.admin_key;
-    return typeof ref === 'string' && ref.trim() ? ref.trim() : null;
-  } catch {
-    return null;
-  }
-}
-
 export interface FetchExternalSpendDeps {
-  env?: NodeJS.ProcessEnv;
   now?: Date;
-  fetchImpl?: typeof fetch;
-  resolveAdminKey?: () => Promise<string | null>;
-  resolveBaseUrl?: () => string;
-  cacheTtlMs?: number;
-  timeoutMs?: number;
-  /** When true, bypass the in-process TTL cache (tests). */
+  /** Prefer injected client for tests; defaults to env agent socket. */
+  getExternalSpend?: (forceLive?: boolean) => Promise<{
+    available: boolean;
+    day24hUsd?: number;
+    day7dUsd?: number;
+    top?: Array<{ label: string; usd: number }>;
+    capturedAtMs?: number;
+    served?: 'live' | 'cache';
+    reason?: string;
+  }>;
+  forceLive?: boolean;
   bypassCache?: boolean;
+  cacheTtlMs?: number;
 }
 
 /**
- * Best-effort fleet External spend for `/usage`. Returns null when the
- * summary is unavailable (no key, timeout, 401, etc.) — caller omits the block.
- * Successful results are cached ~90s.
+ * Best-effort fleet External spend for `/usage`.
+ * Primary: auth-broker `get-external-spend` (master key stays in broker).
+ * Returns null when unavailable — caller omits the block.
  */
 export async function fetchExternalSpendSummary(
   nowOrDeps: Date | FetchExternalSpendDeps = {},
 ): Promise<ExternalSpendSummary | null> {
-  // Backward-compatible: `fetchExternalSpendSummary(new Date())` still works.
   const deps: FetchExternalSpendDeps =
     nowOrDeps instanceof Date ? { now: nowOrDeps } : nowOrDeps;
-  const now = deps.now ?? new Date();
-  const ttl = deps.cacheTtlMs ?? EXTERNAL_SPEND_CACHE_TTL_MS;
-  if (!deps.bypassCache && cache && Date.now() - cache.atMs < ttl) {
-    return cache.summary;
+  const ttl = deps.cacheTtlMs ?? CLIENT_CACHE_TTL_MS;
+  if (!deps.bypassCache && clientCache && Date.now() - clientCache.atMs < ttl) {
+    return clientCache.summary;
   }
 
-  const env = deps.env ?? process.env;
-  const resolveKey =
-    deps.resolveAdminKey ?? (() => resolveLitellmAdminKey({ env }));
-  let key: string | null;
   try {
-    key = await resolveKey();
-  } catch {
-    return null;
-  }
-  if (!key) return null;
-
-  const base = (deps.resolveBaseUrl ?? (() => resolveLitellmBaseUrl(env)))();
-  const today = utcDateString(now);
-  const start = addUtcDays(today, -6);
-  const end = addUtcDays(today, 1); // exclusive-ish end for LiteLLM
-  const url = `${base}/spend/logs?start_date=${encodeURIComponent(start)}&end_date=${encodeURIComponent(end)}`;
-
-  const fetchImpl = deps.fetchImpl ?? fetch;
-  const timeoutMs = deps.timeoutMs ?? EXTERNAL_SPEND_FETCH_TIMEOUT_MS;
-  const ac = new AbortController();
-  const timer = setTimeout(() => ac.abort(), timeoutMs);
-  try {
-    const res = await fetchImpl(url, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${key}`,
-        Accept: 'application/json',
-      },
-      signal: ac.signal,
-    });
-    if (!res.ok) return null;
-    let body: unknown;
-    try {
-      body = await res.json();
-    } catch {
+    let data: Awaited<ReturnType<NonNullable<FetchExternalSpendDeps['getExternalSpend']>>>;
+    if (deps.getExternalSpend) {
+      data = await deps.getExternalSpend(deps.forceLive);
+    } else {
+      // Lazy import avoids pulling the full client graph into pure test paths.
+      const { AuthBrokerClient } = await import('../src/auth/broker/client.js');
+      const client = new AuthBrokerClient();
+      try {
+        data = await client.getExternalSpend(deps.forceLive);
+      } finally {
+        try {
+          await client.close();
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    if (!data?.available) return null;
+    if (
+      typeof data.day24hUsd !== 'number' ||
+      typeof data.day7dUsd !== 'number' ||
+      !Array.isArray(data.top)
+    ) {
       return null;
     }
-    const rows = normalizeSpendLogRows(body);
-    const summary = summarizeExternalSpend(rows, now);
-    cache = { atMs: Date.now(), summary };
+    const summary: ExternalSpendSummary = {
+      day24hUsd: data.day24hUsd,
+      day7dUsd: data.day7dUsd,
+      top: data.top.map((t) => ({ label: String(t.label), usd: Number(t.usd) })),
+    };
+    clientCache = { atMs: Date.now(), summary };
     return summary;
   } catch {
     return null;
-  } finally {
-    clearTimeout(timer);
   }
 }

--- a/telegram-plugin/tests/external-spend.test.ts
+++ b/telegram-plugin/tests/external-spend.test.ts
@@ -1,333 +1,168 @@
 /**
- * Pure unit tests for External OpenRouter/$ spend (layout B on /usage).
+ * Unit tests for External OpenRouter/$ spend (layout B on /usage).
+ * Pure filter/format coverage lives primarily in
+ * `src/litellm/external-spend.test.ts`. This file covers the card
+ * block formatter + broker-backed fetch ExternalSpendSummary path.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
-  isExternalModel,
-  shortModelLabel,
-  formatUsd,
-  summarizeExternalSpend,
   formatExternalSpendBlock,
-  normalizeSpendLogRows,
-  resolveLitellmBaseUrl,
-  resolveLitellmAdminKey,
   fetchExternalSpendSummary,
   clearExternalSpendCache,
-  vaultKeyFromRef,
-  addUtcDays,
-  utcDateString,
-  type LiteLLMDaySpendRow,
+  formatUsd,
+  isExternalModel,
+  shortModelLabel,
+  summarizeExternalSpend,
 } from '../external-spend.js';
+import { renderUsageCard } from '../quota-bar-format.js';
+import type { AccountSnapshot } from '../auth-snapshot-format.js';
+import type { QuotaUtilization } from '../quota-check.js';
 
-const NOW = new Date('2026-07-19T15:30:00.000Z'); // UTC today = 2026-07-19
+const NOW = new Date('2026-07-19T15:30:00.000Z');
 
 beforeEach(() => {
   clearExternalSpendCache();
 });
 
-describe('isExternalModel', () => {
-  it('includes openrouter/ and sr- models', () => {
+describe('re-exported pure helpers', () => {
+  it('filter / labels / money still work from the telegram module', () => {
     expect(isExternalModel('openrouter/openai/gpt-oss-20b')).toBe(true);
-    expect(isExternalModel('sr-grok-4.5')).toBe(true);
-    expect(isExternalModel('SR-GLM-5')).toBe(true);
-  });
-
-  it('includes bare cash-model needles', () => {
-    expect(isExternalModel('gpt-oss-20b')).toBe(true);
-    expect(isExternalModel('x-ai/grok-4.5')).toBe(true);
-    expect(isExternalModel('gemini-3.1-flash-lite')).toBe(true);
-    expect(isExternalModel('deepseek-r1')).toBe(true);
-    expect(isExternalModel('moonshot/kimi-k2')).toBe(true);
-    expect(isExternalModel('glm-5.2')).toBe(true);
-    expect(isExternalModel('qwen3-coder')).toBe(true);
-    expect(isExternalModel('meta-llama/llama-3.1')).toBe(true);
-  });
-
-  it('excludes Claude / Anthropic subscription passthrough', () => {
-    expect(isExternalModel('claude-sonnet-4-20250514')).toBe(false);
-    expect(isExternalModel('claude-opus-4-5')).toBe(false);
-    expect(isExternalModel('anthropic/claude-sonnet-4')).toBe(false);
-    expect(isExternalModel('openrouter/anthropic/claude-3.5-sonnet')).toBe(false);
-  });
-
-  it('rejects empty / unknown non-cash names', () => {
-    expect(isExternalModel('')).toBe(false);
-    expect(isExternalModel('some-internal-router')).toBe(false);
-  });
-});
-
-describe('shortModelLabel', () => {
-  it('strips openrouter/ and org path to last segment', () => {
-    expect(shortModelLabel('openrouter/openai/gpt-oss-20b')).toBe('gpt-oss-20b');
+    expect(isExternalModel('claude-sonnet-5')).toBe(false);
     expect(shortModelLabel('openrouter/x-ai/grok-4.5')).toBe('grok-4.5');
-    expect(shortModelLabel('openai/gpt-oss-20b')).toBe('gpt-oss-20b');
-  });
-
-  it('strips sr- prefix', () => {
-    expect(shortModelLabel('sr-grok-4.5')).toBe('grok-4.5');
-    expect(shortModelLabel('sr-gemini-2.5-flash')).toBe('gemini-2.5-flash');
-  });
-});
-
-describe('formatUsd', () => {
-  it('always formats two decimal places', () => {
     expect(formatUsd(8.07)).toBe('$8.07');
-    expect(formatUsd(0)).toBe('$0.00');
-    expect(formatUsd(0.004)).toBe('$0.00');
-    expect(formatUsd(119.894)).toBe('$119.89');
-  });
-
-  it('guards non-finite / negative', () => {
-    expect(formatUsd(Number.NaN)).toBe('$0.00');
-    expect(formatUsd(-3)).toBe('$0.00');
-  });
-});
-
-describe('summarizeExternalSpend', () => {
-  const rows: LiteLLMDaySpendRow[] = [
-    {
-      startTime: '2026-07-19',
-      spend: 50, // mixed — must be ignored
-      models: {
-        'claude-sonnet-4-20250514': 40,
-        'openrouter/openai/gpt-oss-20b': 6.1,
-        'sr-grok-4.5': 1.18,
-        'gemini-3.1-flash-lite': 0.79,
-      },
-    },
-    {
-      startTime: '2026-07-18',
-      models: {
-        'openrouter/openai/gpt-oss-20b': 10,
-        'claude-opus-4': 5,
-      },
-    },
-    {
-      startTime: '2026-07-12', // outside 7d (today-6 = 2026-07-13)
-      models: { 'openrouter/openai/gpt-oss-20b': 100 },
-    },
-    {
-      startTime: '2026-07-13', // edge of window
-      models: { 'sr-deepseek-r1': 2 },
-    },
-  ];
-
-  it('sums 24h (UTC today) and 7d external only — ignores day.spend and Claude', () => {
-    const s = summarizeExternalSpend(rows, NOW);
-    // 24h: 6.1 + 1.18 + 0.79
-    expect(s.day24hUsd).toBeCloseTo(8.07, 5);
-    // 7d: today + 18th (10) + 13th (2) = 8.07 + 10 + 2
-    expect(s.day7dUsd).toBeCloseTo(20.07, 5);
-  });
-
-  it('top-3 by 7d external spend with short labels', () => {
-    const s = summarizeExternalSpend(rows, NOW);
-    expect(s.top.map((t) => t.label)).toEqual([
-      'gpt-oss-20b',
-      'deepseek-r1',
-      'grok-4.5',
-    ]);
-    expect(s.top[0]!.usd).toBeCloseTo(16.1, 5); // 6.1 + 10
-    expect(s.top[1]!.usd).toBeCloseTo(2, 5);
-    expect(s.top[2]!.usd).toBeCloseTo(1.18, 5);
-  });
-
-  it('returns zeros when no external spend', () => {
     const s = summarizeExternalSpend(
-      [{ startTime: '2026-07-19', models: { 'claude-sonnet-4': 9 } }],
+      [
+        {
+          startTime: '2026-07-19',
+          models: { 'openrouter/openai/gpt-oss-20b': 1.5, 'claude-sonnet-5': 9 },
+        },
+      ],
       NOW,
     );
-    expect(s).toEqual({ day24hUsd: 0, day7dUsd: 0, top: [] });
-  });
-
-  it('excludes future/out-of-window days', () => {
-    const s = summarizeExternalSpend(
-      [{ startTime: '2026-07-20', models: { 'sr-grok-4.5': 9 } }],
-      NOW,
-    );
-    expect(s.day7dUsd).toBe(0);
+    expect(s.day24hUsd).toBeCloseTo(1.5, 5);
   });
 });
 
 describe('formatExternalSpendBlock', () => {
   it('renders locked layout B', () => {
-    const lines = formatExternalSpendBlock({
-      day24hUsd: 8.07,
-      day7dUsd: 119.89,
-      top: [
-        { label: 'gpt-oss-20b', usd: 6.1 },
-        { label: 'grok-4.5', usd: 1.18 },
-        { label: 'gemini-3.1-flash-lite', usd: 0.79 },
-      ],
-    });
-    expect(lines).toEqual([
+    expect(
+      formatExternalSpendBlock({
+        day24hUsd: 8.07,
+        day7dUsd: 119.89,
+        top: [
+          { label: 'gpt-oss-20b', usd: 6.1 },
+          { label: 'grok-4.5', usd: 1.18 },
+          { label: 'gemini-3.1-flash-lite', usd: 0.79 },
+        ],
+      }),
+    ).toEqual([
       '- 💸 External',
       '- 24h `$8.07` · 7d `$119.89`',
       '- top `gpt-oss-20b $6.10` · `grok-4.5 $1.18` · `gemini-3.1-flash-lite $0.79`',
     ]);
   });
 
-  it('omits top line when empty but still shows totals (incl. zeros)', () => {
+  it('omits top and returns [] for null', () => {
     expect(formatExternalSpendBlock({ day24hUsd: 0, day7dUsd: 0, top: [] })).toEqual([
       '- 💸 External',
       '- 24h `$0.00` · 7d `$0.00`',
     ]);
-  });
-
-  it('returns [] for null/undefined (omit block)', () => {
     expect(formatExternalSpendBlock(null)).toEqual([]);
-    expect(formatExternalSpendBlock(undefined)).toEqual([]);
   });
 });
 
-describe('normalizeSpendLogRows / base url / vault ref', () => {
-  it('accepts bare array and {data:[]}', () => {
-    expect(normalizeSpendLogRows([{ startTime: '2026-07-19' }])).toHaveLength(1);
-    expect(normalizeSpendLogRows({ data: [{ startTime: 'x' }] })).toHaveLength(1);
-    expect(normalizeSpendLogRows({ oops: true })).toEqual([]);
-  });
-
-  it('trims trailing slash on base URL', () => {
-    expect(resolveLitellmBaseUrl({ SWITCHROOM_LITELLM_BASE: 'http://h:4010/' })).toBe(
-      'http://h:4010',
-    );
-    expect(resolveLitellmBaseUrl({})).toBe('http://127.0.0.1:4010');
-  });
-
-  it('parses vault: refs', () => {
-    expect(vaultKeyFromRef('vault:litellm/master-key')).toBe('litellm/master-key');
-    expect(vaultKeyFromRef('plain')).toBeNull();
-  });
-
-  it('utc window helpers', () => {
-    expect(utcDateString(NOW)).toBe('2026-07-19');
-    expect(addUtcDays('2026-07-19', -6)).toBe('2026-07-13');
-    expect(addUtcDays('2026-07-19', 1)).toBe('2026-07-20');
-  });
-});
-
-describe('resolveLitellmAdminKey', () => {
-  const savedAdmin = process.env.SWITCHROOM_LITELLM_ADMIN_KEY;
-  const savedMaster = process.env.LITELLM_MASTER_KEY;
-
-  afterEach(() => {
-    if (savedAdmin === undefined) delete process.env.SWITCHROOM_LITELLM_ADMIN_KEY;
-    else process.env.SWITCHROOM_LITELLM_ADMIN_KEY = savedAdmin;
-    if (savedMaster === undefined) delete process.env.LITELLM_MASTER_KEY;
-    else process.env.LITELLM_MASTER_KEY = savedMaster;
-  });
-
-  it('prefers SWITCHROOM_LITELLM_ADMIN_KEY env', async () => {
-    const key = await resolveLitellmAdminKey({
-      env: { SWITCHROOM_LITELLM_ADMIN_KEY: ' sk-from-env ' },
-      readAdminKeyRef: () => 'vault:litellm/master-key',
-      vaultGet: async () => 'sk-vault',
-    });
-    expect(key).toBe('sk-from-env');
-  });
-
-  it('falls back to vault when env unset', async () => {
-    const vaultGet = vi.fn(async () => 'sk-vault-value');
-    const key = await resolveLitellmAdminKey({
-      env: {},
-      readAdminKeyRef: () => 'vault:litellm/master-key',
-      vaultGet,
-    });
-    expect(key).toBe('sk-vault-value');
-    expect(vaultGet).toHaveBeenCalledWith('litellm/master-key');
-  });
-
-  it('soft-fails when vault denies', async () => {
-    const key = await resolveLitellmAdminKey({
-      env: {},
-      readAdminKeyRef: () => 'vault:litellm/master-key',
-      vaultGet: async () => null,
-    });
-    expect(key).toBeNull();
-  });
-});
-
-describe('fetchExternalSpendSummary', () => {
-  it('returns null without admin key', async () => {
-    const summary = await fetchExternalSpendSummary({
-      now: NOW,
-      resolveAdminKey: async () => null,
+describe('fetchExternalSpendSummary (broker path)', () => {
+  it('returns null when broker says unavailable', async () => {
+    const s = await fetchExternalSpendSummary({
+      getExternalSpend: async () => ({ available: false, reason: 'master_key_unavailable' }),
       bypassCache: true,
     });
-    expect(summary).toBeNull();
+    expect(s).toBeNull();
   });
 
-  it('returns null on non-OK response', async () => {
-    const fetchImpl = vi.fn(async () => new Response('nope', { status: 401 }));
-    const summary = await fetchExternalSpendSummary({
-      now: NOW,
-      resolveAdminKey: async () => 'sk-test',
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-      bypassCache: true,
-    });
-    expect(summary).toBeNull();
-  });
-
-  it('aggregates successful spend/logs body and caches', async () => {
-    const body = [
-      {
-        startTime: '2026-07-19',
-        models: {
-          'openrouter/openai/gpt-oss-20b': 1.5,
-          'claude-sonnet-4': 9,
-        },
-      },
-    ];
+  it('maps available broker payload + caches', async () => {
     let calls = 0;
-    const fetchImpl = vi.fn(async (url: string) => {
+    const getExternalSpend = vi.fn(async () => {
       calls += 1;
-      expect(String(url)).toContain('start_date=2026-07-13');
-      expect(String(url)).toContain('end_date=2026-07-20');
-      return new Response(JSON.stringify(body), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return {
+        available: true,
+        day24hUsd: 1.5,
+        day7dUsd: 10,
+        top: [{ label: 'gpt-oss-20b', usd: 1.5 }],
+        served: 'live' as const,
+        capturedAtMs: Date.now(),
+      };
     });
     const first = await fetchExternalSpendSummary({
-      now: NOW,
-      resolveAdminKey: async () => 'sk-test',
-      resolveBaseUrl: () => 'http://litellm.test',
-      fetchImpl: fetchImpl as unknown as typeof fetch,
+      getExternalSpend,
       bypassCache: true,
     });
-    expect(first?.day24hUsd).toBeCloseTo(1.5, 5);
-    expect(first?.top[0]?.label).toBe('gpt-oss-20b');
-
-    // Second call should hit cache (no bypass) with zero additional fetches.
-    const second = await fetchExternalSpendSummary({
-      now: NOW,
-      resolveAdminKey: async () => 'sk-test',
-      fetchImpl: fetchImpl as unknown as typeof fetch,
+    expect(first).toEqual({
+      day24hUsd: 1.5,
+      day7dUsd: 10,
+      top: [{ label: 'gpt-oss-20b', usd: 1.5 }],
     });
+    const second = await fetchExternalSpendSummary({ getExternalSpend });
     expect(second?.day24hUsd).toBeCloseTo(1.5, 5);
     expect(calls).toBe(1);
   });
 
-  it('returns null on timeout/abort', async () => {
-    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
-      const signal = init?.signal;
-      return await new Promise<Response>((_resolve, reject) => {
-        if (signal?.aborted) {
-          reject(new DOMException('Aborted', 'AbortError'));
-          return;
-        }
-        signal?.addEventListener('abort', () => {
-          reject(new DOMException('Aborted', 'AbortError'));
-        });
-      });
-    });
-    const summary = await fetchExternalSpendSummary({
-      now: NOW,
-      resolveAdminKey: async () => 'sk-test',
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-      timeoutMs: 20,
+  it('returns null on thrown broker error', async () => {
+    const s = await fetchExternalSpendSummary({
+      getExternalSpend: async () => {
+        throw new Error('unreachable');
+      },
       bypassCache: true,
     });
-    expect(summary).toBeNull();
+    expect(s).toBeNull();
+  });
+});
+
+describe('renderUsageCard + externalSpend', () => {
+  function quota(part: Partial<QuotaUtilization>): QuotaUtilization {
+    return {
+      fiveHourUtilizationPct: 0,
+      sevenDayUtilizationPct: 0,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+      ...part,
+    };
+  }
+  const snapshots: AccountSnapshot[] = [
+    {
+      label: 'ken@example.com',
+      isActive: true,
+      quota: quota({
+        fiveHourUtilizationPct: 0,
+        sevenDayUtilizationPct: 47,
+        fiveHourResetAt: new Date(NOW.getTime() + 60 * 60_000),
+        sevenDayResetAt: new Date(NOW.getTime() + (3 * 24 + 1) * 60 * 60_000),
+      }),
+    },
+  ];
+  const exhausted = new Map<string, boolean>([['ken@example.com', false]]);
+
+  it('inserts External between recommendation and freshness', () => {
+    const out = renderUsageCard(snapshots, exhausted, {
+      now: NOW,
+      externalSpend: {
+        day24hUsd: 8.07,
+        day7dUsd: 119.89,
+        top: [{ label: 'gpt-oss-20b', usd: 6.1 }],
+      },
+    });
+    const lines = out.split('\n');
+    const recIdx = lines.findIndex((l) => l.includes('Recommendation'));
+    const extIdx = lines.findIndex((l) => l.includes('💸 External'));
+    expect(extIdx).toBe(recIdx + 1);
+    expect(lines[lines.length - 1]).toBe('_Live_');
+  });
+
+  it('omits External when null', () => {
+    const out = renderUsageCard(snapshots, exhausted, { now: NOW, externalSpend: null });
+    expect(out).not.toContain('💸 External');
   });
 });

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -3356,9 +3356,67 @@ describe("generateCompose — LiteLLM ANTHROPIC_BASE_URL model-class routing", (
 
   it("no virtual key confirmed → NO routing env injected at all (fail-safe)", () => {
     const out = composeFor("sr-glm-5", false);
-    // keyConfirmed false ⇒ the whole routing block is skipped, so the proxy URL
-    // never appears for this agent (no unauthenticated proxy calls).
-    expect(out).not.toContain(ROOT);
+    // keyConfirmed false ⇒ agent routing env is skipped (no unauthenticated
+    // proxy calls from the *agent*). The auth-broker still gets a
+    // SWITCHROOM_LITELLM_BASE for get-external-spend (fleet /usage card) —
+    // that is intentional and authenticated with the master key inside
+    // the broker, not with a missing agent VK. Scope the assert to the
+    // agent service block, not the whole compose document.
+    const agentBlock =
+      /agent-router:[\s\S]*?(?=\n  [a-zA-Z]|\nvolumes:|\nnetworks:|$)/.exec(out)?.[0] ?? "";
+    expect(agentBlock).not.toContain(ROOT);
+    expect(agentBlock).not.toMatch(/ANTHROPIC_BASE_URL:/);
+    expect(agentBlock).not.toMatch(/SWITCHROOM_LITELLM:/);
+    // Broker still receives the base (loopback rewritten to host-gateway).
+    const ab =
+      /switchroom-auth-broker:[\s\S]*?(?=\n  [a-zA-Z]|\nvolumes:|$)/.exec(out)?.[0] ?? "";
+    expect(ab).toMatch(/SWITCHROOM_LITELLM_BASE:/);
+  });
+});
+
+
+describe("generateCompose — auth-broker LiteLLM base for external spend", () => {
+  it("rewrites loopback base_url to host.docker.internal + set extra_hosts", () => {
+    const out = generateCompose({
+      config: makeConfig(
+        { router: {} },
+        { litellm: { enabled: true, base_url: "http://127.0.0.1:4010" } },
+      ),
+    });
+    const block =
+      /switchroom-auth-broker:[\s\S]*?(?=\n  [a-zA-Z]|\nvolumes:|$)/.exec(out)?.[0] ?? "";
+    expect(block).toContain(
+      'SWITCHROOM_LITELLM_BASE: "http://host.docker.internal:4010"',
+    );
+    expect(block).not.toContain(
+      'SWITCHROOM_LITELLM_BASE: "http://127.0.0.1:4010"',
+    );
+    expect(block).toMatch(
+      /extra_hosts:\n {6}- "host\.docker\.internal:host-gateway"/,
+    );
+  });
+
+  it("passes non-loopback base_url through unchanged", () => {
+    const out = generateCompose({
+      config: makeConfig(
+        { router: {} },
+        { litellm: { enabled: true, base_url: "http://litellm.internal:4010" } },
+      ),
+    });
+    const block =
+      /switchroom-auth-broker:[\s\S]*?(?=\n  [a-zA-Z]|\nvolumes:|$)/.exec(out)?.[0] ?? "";
+    expect(block).toContain(
+      'SWITCHROOM_LITELLM_BASE: "http://litellm.internal:4010"',
+    );
+  });
+
+  it("omits SWITCHROOM_LITELLM_BASE on auth-broker when litellm base_url unset", () => {
+    const out = generateCompose({
+      config: makeConfig({ router: {} }),
+    });
+    const block =
+      /switchroom-auth-broker:[\s\S]*?(?=\n  [a-zA-Z]|\nvolumes:|$)/.exec(out)?.[0] ?? "";
+    expect(block).not.toMatch(/SWITCHROOM_LITELLM_BASE:/);
   });
 });
 

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -3410,13 +3410,14 @@ describe("generateCompose — auth-broker LiteLLM base for external spend", () =
     );
   });
 
-  it("omits SWITCHROOM_LITELLM_BASE on auth-broker when litellm base_url unset", () => {
+  it("omits SWITCHROOM_LITELLM_BASE + extra_hosts on auth-broker when litellm base_url unset", () => {
     const out = generateCompose({
       config: makeConfig({ router: {} }),
     });
     const block =
       /switchroom-auth-broker:[\s\S]*?(?=\n  [a-zA-Z]|\nvolumes:|$)/.exec(out)?.[0] ?? "";
     expect(block).not.toMatch(/SWITCHROOM_LITELLM_BASE:/);
+    expect(block).not.toContain("host.docker.internal:host-gateway");
   });
 });
 


### PR DESCRIPTION
## Summary
Durable path for **layout B** External $ on `/usage` so **no agent needs** `litellm/master-key`.

| Layer | Role |
|-------|------|
| **auth-broker** | Owns master key (state-dir file from `apply`, or env). Live-refreshes LiteLLM `/spend/logs`, filters Claude out, caches `external-spend.json`. |
| **Wire** | New `get-external-spend` op (ACL = `list-state`). Sanitized: `available`, `day24hUsd`, `day7dUsd`, `top[]`, `served`. |
| **Gateway** | `/usage` calls broker only; soft-fail omits External block. |
| **apply** | Materializes master key to `~/.switchroom/state/auth-broker/litellm-master-key` (0600). |
| **compose** | auth-broker gets `SWITCHROOM_LITELLM_BASE` when configured. |

Pure helpers moved to `src/litellm/external-spend.ts` (shared broker + card).

### Adversarial design (pre-implement)
- **Rejected:** per-agent master-key grants (blast radius, drift).
- **Rejected:** fleet file only without broker (stale ↻, no single privileged writer contract).
- **Chosen:** broker publisher — same trust boundary as quota; agents never see key.
- **Wire leak:** tests assert response JSON never contains `sk-…` master material.
- **Unavailable:** `available:false` + reason (`master_key_unavailable` / `litellm_unreachable`); card omits block.
- **Stale/live fail:** durable cache still served; single-flight refresh.
- **Windows:** still UTC calendar day (LiteLLM rows); label stays `24h` per locked UX B.

## Test plan
- [x] `vitest` — `src/litellm/external-spend.test.ts`, `server-external-spend.test.ts`, telegram external/quota-bar — **64 passed**
- [x] `tsc --noEmit` clean
- [x] gateway line ratchet + no-pii-secrets clean
- [ ] CI green
- [ ] After merge: `switchroom apply` (materialize key) + restart auth-broker + roll agents; `/usage` on any agent shows External without widget-side vault grant