### PR TITLE
fix(model): doctor + logs for rev5 .session-model carrier drift

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1211,6 +1211,7 @@ fi
 
 # --- Session model resolution (consume-once .session-model carrier) ---
 #
+# Doctor (checkStartShSessionModelCarrier) and tests pin this path against gateway SESSION_MODEL_FILE — regenerate via `switchroom apply` if fleet start.sh drifts.
 # Contract: reference/rfcs/session-model-stickiness.md §0.05 (rev 5, operator
 # decision 2026-07-16 — DETERMINISTIC SWITCH, superseding rev 4 §0.1's "live
 # Claude switches write no carrier"). A `/model` override lasts only for the

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1819,6 +1819,90 @@ export function checkStartShStale(
 }
 
 /**
+ * Detect agents whose start.sh predates the rev-5 `/model` consume-once
+ * carrier (`.session-model` JSON). The gateway writes that file on every
+ * Telegram `/model` / menu switch; a stale start.sh that only reads the
+ * legacy one-shot `.session-model-override` text carrier silently boots the
+ * yaml pin and the switch looks applied (`override=cleared`) while it isn't.
+ * Same class as #911 silent-cron-loss — doctor is the fleet-wide tripwire
+ * until the next `switchroom apply` rewrites start.sh from start.sh.hbs.
+ *
+ * Match shell structure, not bare comments: require an `[ -f …/.session-model ]`
+ * whose basename is exactly `.session-model` (not `-override` / `-alert` /
+ * `-boot-attempts` / `-kept-notified`), plus a rev5 JSON-apply marker
+ * (`configuredDefaultAtWrite` or `session-model-boot-attempts`). Live hbs
+ * also migrates a leftover `.session-model-override` into `.session-model`;
+ * that hangs off the same bare path test and is fine. Legacy-only scripts fail.
+ *
+ * @internal exported for testing
+ */
+export function checkStartShSessionModelCarrier(
+  agentName: string,
+  startShPath: string,
+): CheckResult {
+  const label = `${agentName}: start.sh /model session carrier`;
+  if (!existsSync(startShPath)) {
+    return {
+      name: label,
+      status: "warn",
+      detail: `${startShPath} not found`,
+      fix: `Run \`switchroom apply\` to scaffold start.sh (rev5 \`.session-model\` carrier).`,
+    };
+  }
+  let content: string;
+  try {
+    content = readFileSync(startShPath, "utf-8");
+  } catch (err) {
+    return {
+      name: label,
+      status: "skip",
+      detail: `unreadable from host (${(err as Error).message}) — agent-UID-owned; the session-model carrier block can't be checked from the operator UID`,
+      fix: `Verify in-agent: docker exec switchroom-${agentName} sh -c 'grep -E "\\[ -f .*\\.session-model\\" \\]" /state/agent/start.sh && echo ok'`,
+    };
+  }
+  // Every `[ -f …]` path; require at least one whose trailing basename is
+  // exactly `.session-model` (optional quotes stripped). Comments alone never match.
+  const fileTestPaths = [...content.matchAll(/\[\s*-f\s+([^\]]+?)\s*\]/g)].map(
+    (m) => m[1].replace(/["']/g, "").trim(),
+  );
+  const hasBareSessionModelTest = fileTestPaths.some((p) =>
+    /(?:^|\/)\.session-model$/.test(p),
+  );
+  // Primary JSON shape start.sh parses from the gateway-written carrier.
+  const hasJsonCarrierParse =
+    /configuredDefaultAtWrite/.test(content) ||
+    /session-model-boot-attempts/.test(content);
+  if (hasBareSessionModelTest && hasJsonCarrierParse) {
+    return {
+      name: label,
+      status: "ok",
+      detail: "rev5 `.session-model` consume-once carrier present",
+    };
+  }
+  if (hasBareSessionModelTest && !hasJsonCarrierParse) {
+    return {
+      name: label,
+      status: "fail",
+      detail:
+        "start.sh tests `.session-model` but lacks rev5 JSON apply (`configuredDefaultAtWrite` / boot-attempts) — /model switches may not stick",
+      fix:
+        "Run `switchroom apply` to regenerate start.sh from profiles/_base/start.sh.hbs (rev5 carrier). Takes effect on the next agent restart (no need to bounce until release).",
+    };
+  }
+  const legacyOnly =
+    /\.session-model-override/.test(content) && !hasBareSessionModelTest;
+  return {
+    name: label,
+    status: "fail",
+    detail: legacyOnly
+      ? "start.sh only reads legacy `.session-model-override`; gateway writes rev5 `.session-model` — Telegram /model relaunches boot the yaml pin (silent miss)"
+      : "start.sh missing rev5 `.session-model` carrier file test — Telegram /model cannot apply session overrides across relaunch",
+    fix:
+      "Run `switchroom apply` to regenerate start.sh from the latest template (rev5 `.session-model` carrier). The rewrite is on disk immediately; session switches apply on the next agent restart/release bounce.",
+  };
+}
+
+/**
  * Detect leaked $HOME/.switchroom state inside an agent's bind-mounted
  * state dir (#933). Agents that ran before #910's symlink fix landed
  * may have written analytics-id / quota-cache / logs into the wrong
@@ -2055,6 +2139,10 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
 
     // 1b. start.sh has the post-Phase-4 scheduler supervisor block
     results.push(checkStartShStale(name, join(agentDir, "start.sh")));
+    // 1b2. start.sh speaks rev5 `.session-model` (Telegram /model carrier)
+    results.push(
+      checkStartShSessionModelCarrier(name, join(agentDir, "start.sh")),
+    );
 
     // 1c. Leaked $HOME/.switchroom state from pre-#910 runs (#933).
     // Inside the container HOME=/state/agent/home; if the agent ever

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -538,6 +538,9 @@ import {
   modelCommandReceiptLine,
   handleModelCommand,
   classifyModelSwitchConfirmation,
+  formatModelRelaunchDiagLog,
+  formatModelSwitchConfirmationBody,
+  formatModelRelaunchSuppressNotAppliedLog,
   buildModelMenu,
   handleModelMenuCallback,
   isValidModelArg,
@@ -23907,70 +23910,36 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 // scraped pane or an optimistic record.
                 const isApplyBoot = launched.length > 0 && launched !== configured
                 sessionModelSource.setOverride(isApplyBoot ? launched : null)
-                // Switch-confirmation (F1 / PLAN §4 step 2): on a /model apply-boot
-                // with a known initiating chat, send ONE confirmation built from the
-                // ACTUAL launched model — never optimistic. Keyed on the DETERMINISTIC
-                // /model switch reason (from the clean-shutdown marker), not on
-                // `launched !== configured`, so it ALSO fires when a switch landed on
-                // the configured default (`/model default`, or `/model <configured>`)
-                // — N4. The generic boot card is suppressed for this boot (N3), so
-                // this is the single card the operator sees for the switch.
-                //
-                // Diagnosability (rev 5): outcome KIND is greppable —
-                // `grep 'gw /model relaunch'`. Never emit a bare
-                // `override=cleared` alone after a /model switch reason — that
-                // looked like success when the carrier missed (stale start.sh).
-                // F4: `launched` is start.sh's pre-exec token, not a post-launch
-                // confirmation; transcript `message.model` reclaims /status (G2).
-                if (modelSwitchReason != null && modelSwitchMarkerChat) {
-                  const chat = modelSwitchMarkerChat
-                  // Derive the confirmation from the DETERMINISTIC post-boot
-                  // signals. A non-default switch that reverted to the configured
-                  // default (a wedged/consumed apply-boot — the silent-revert bug)
-                  // must WARN, not print a misleading green "✅ Now running
-                  // <default>" card. `applied` / `default` keep the honest green
-                  // card (N4: the default/revert case still confirms).
-                  const confirmation = classifyModelSwitchConfirmation({
-                    reason: modelSwitchReason,
+                // F1/N4: classify + log + one confirmation card. Formatters live
+                // in model-command.ts so this file does not inflate (#2996 ratchet).
+                const confirmation = modelSwitchReason != null
+                  ? classifyModelSwitchConfirmation({
+                      reason: modelSwitchReason,
+                      launched,
+                      configured,
+                    })
+                  : null
+                process.stderr.write(
+                  formatModelRelaunchDiagLog({
+                    agent: getMyAgentName(),
                     launched,
                     configured,
-                  })
-                  if (confirmation.kind === 'not-applied') {
-                    process.stderr.write(
-                      `telegram gateway: gw /model relaunch NOT-APPLIED agent=${getMyAgentName()} target=${confirmation.target} launched=${launched || '(none)'} configured=${configured} revertedTo=${confirmation.revertedTo}
-`,
-                    )
-                  } else if (confirmation.kind === 'applied') {
-                    process.stderr.write(
-                      `telegram gateway: gw /model relaunch applied agent=${getMyAgentName()} launched=${launched || '(none)'} configured=${configured} override=set outcome=applied
-`,
-                    )
-                  } else {
-                    process.stderr.write(
-                      `telegram gateway: gw /model relaunch default/cleared agent=${getMyAgentName()} launched=${launched || '(none)'} configured=${configured} override=cleared
-`,
-                    )
-                  }
-                  // LOW-2 dedup: the config-default-changed / proxy-down revert
-                  // paths in start.sh write a TAILORED `.session-model-alert`
-                  // (relayed to operators below) that already explains why the
-                  // switch didn't apply and how to re-issue it. Suppress the
-                  // generic not-applied card when such an alert is present for
-                  // this boot so the operator isn't double-warned — the alert is
-                  // the more specific message. The not-applied card still fires
-                  // for the plain wedge/revert case (no alert on disk).
+                    confirmation,
+                    isApplyBoot,
+                  }),
+                )
+                if (confirmation != null && modelSwitchMarkerChat) {
+                  const chat = modelSwitchMarkerChat
                   const hasSessionModelAlert = existsSync(join(smAgentDir, '.session-model-alert'))
                   if (confirmation.kind === 'not-applied' && hasSessionModelAlert) {
                     process.stderr.write(
-                      `telegram gateway: gw /model relaunch NOT-APPLIED — suppressing not-applied confirmation (a .session-model-alert is present and will be relayed) agent=${getMyAgentName()} target=${confirmation.target}\n`,
+                      formatModelRelaunchSuppressNotAppliedLog({
+                        agent: getMyAgentName(),
+                        target: confirmation.target,
+                      }),
                     )
                   } else {
-                    const body =
-                      confirmation.kind === 'applied'
-                        ? `✅ Now running \`${confirmation.launched}\` — session-only, reverts to the configured model on the next restart. Fresh session; memory and the handoff briefing carry the context.`
-                        : confirmation.kind === 'not-applied'
-                          ? `⚠️ Your switch to \`${confirmation.target}\` didn't apply — the agent reverted to \`${confirmation.revertedTo}\` (the apply-boot didn't complete). Re-issue \`/model ${confirmation.target}\` to try again.`
-                          : `✅ Now running \`${confirmation.launched}\` (the configured default) — fresh session; memory and the handoff briefing carry the context.`
+                    const body = formatModelSwitchConfirmationBody(confirmation)
                     // allow-raw-bot-api: one-shot boot confirmation, same shape as the session-model alert relay below
                     void lockedBot.api
                       .sendMessage(chat.chatId, body, {
@@ -23983,13 +23952,6 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                         ),
                       )
                   }
-                } else {
-                  // Ordinary boot (no /model switch reason): keep a single
-                  // diagnostic line for override hydrations without implying
-                  // a switch applied.
-                  process.stderr.write(
-                    `telegram gateway: gw /model relaunch applied agent=${getMyAgentName()} launched=${launched || '(none)'} configured=${configured} override=${isApplyBoot ? 'set' : 'cleared'}\n`,
-                  )
                 }
               } catch { /* leave override as-is on a bad read */ }
             }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -23907,21 +23907,6 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 // scraped pane or an optimistic record.
                 const isApplyBoot = launched.length > 0 && launched !== configured
                 sessionModelSource.setOverride(isApplyBoot ? launched : null)
-                // Diagnosability (rev 5): the applied model is now always
-                // greppable — `grep 'gw /model relaunch applied'`. F4 note:
-                // `launched` is the REQUESTED token start.sh wrote before `exec
-                // claude` (it is NOT a post-launch confirmation). If a shape-valid
-                // but unknown Claude id was requested, `--fallback-model` may mask
-                // it: claude serves a fallback while this records the requested
-                // token. That divergence is NOT a persistent lie — the transcript's
-                // `message.model` (noteTranscriptModel) reclaims the source from
-                // this override on the first assistant line, correcting /status to
-                // the model actually serving calls. The pre-first-assistant window
-                // is the only optimistic window (G2), and it is bounded and
-                // self-healing; it is documented, not silently asserted as success.
-                process.stderr.write(
-                  `telegram gateway: gw /model relaunch applied agent=${getMyAgentName()} launched=${launched || '(none)'} configured=${configured} override=${isApplyBoot ? 'set' : 'cleared'}\n`,
-                )
                 // Switch-confirmation (F1 / PLAN §4 step 2): on a /model apply-boot
                 // with a known initiating chat, send ONE confirmation built from the
                 // ACTUAL launched model — never optimistic. Keyed on the DETERMINISTIC
@@ -23930,6 +23915,13 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 // the configured default (`/model default`, or `/model <configured>`)
                 // — N4. The generic boot card is suppressed for this boot (N3), so
                 // this is the single card the operator sees for the switch.
+                //
+                // Diagnosability (rev 5): outcome KIND is greppable —
+                // `grep 'gw /model relaunch'`. Never emit a bare
+                // `override=cleared` alone after a /model switch reason — that
+                // looked like success when the carrier missed (stale start.sh).
+                // F4: `launched` is start.sh's pre-exec token, not a post-launch
+                // confirmation; transcript `message.model` reclaims /status (G2).
                 if (modelSwitchReason != null && modelSwitchMarkerChat) {
                   const chat = modelSwitchMarkerChat
                   // Derive the confirmation from the DETERMINISTIC post-boot
@@ -23943,6 +23935,22 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                     launched,
                     configured,
                   })
+                  if (confirmation.kind === 'not-applied') {
+                    process.stderr.write(
+                      `telegram gateway: gw /model relaunch NOT-APPLIED agent=${getMyAgentName()} target=${confirmation.target} launched=${launched || '(none)'} configured=${configured} revertedTo=${confirmation.revertedTo}
+`,
+                    )
+                  } else if (confirmation.kind === 'applied') {
+                    process.stderr.write(
+                      `telegram gateway: gw /model relaunch applied agent=${getMyAgentName()} launched=${launched || '(none)'} configured=${configured} override=set outcome=applied
+`,
+                    )
+                  } else {
+                    process.stderr.write(
+                      `telegram gateway: gw /model relaunch default/cleared agent=${getMyAgentName()} launched=${launched || '(none)'} configured=${configured} override=cleared
+`,
+                    )
+                  }
                   // LOW-2 dedup: the config-default-changed / proxy-down revert
                   // paths in start.sh write a TAILORED `.session-model-alert`
                   // (relayed to operators below) that already explains why the
@@ -23954,7 +23962,7 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                   const hasSessionModelAlert = existsSync(join(smAgentDir, '.session-model-alert'))
                   if (confirmation.kind === 'not-applied' && hasSessionModelAlert) {
                     process.stderr.write(
-                      `telegram gateway: gw /model relaunch applied — suppressing not-applied confirmation (a .session-model-alert is present and will be relayed) agent=${getMyAgentName()} target=${confirmation.target}\n`,
+                      `telegram gateway: gw /model relaunch NOT-APPLIED — suppressing not-applied confirmation (a .session-model-alert is present and will be relayed) agent=${getMyAgentName()} target=${confirmation.target}\n`,
                     )
                   } else {
                     const body =
@@ -23975,6 +23983,13 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                         ),
                       )
                   }
+                } else {
+                  // Ordinary boot (no /model switch reason): keep a single
+                  // diagnostic line for override hydrations without implying
+                  // a switch applied.
+                  process.stderr.write(
+                    `telegram gateway: gw /model relaunch applied agent=${getMyAgentName()} launched=${launched || '(none)'} configured=${configured} override=${isApplyBoot ? 'set' : 'cleared'}\n`,
+                  )
                 }
               } catch { /* leave override as-is on a bad read */ }
             }

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -188,6 +188,112 @@ export function classifyModelSwitchConfirmation(input: {
   return { kind: 'default', launched: revertedTo }
 }
 
+/**
+ * Diagnostic stderr lines for a /model apply-boot rehydration.
+ * Pure strings so gateway.ts stays thin (line-ratchet #2996).
+ */
+export function formatModelRelaunchDiagLog(input: {
+  agent: string
+  launched: string
+  configured: string
+  confirmation: ModelSwitchConfirmation | null
+  isApplyBoot: boolean
+}): string {
+  const { agent, launched, configured, confirmation, isApplyBoot } = input
+  const L = launched || '(none)'
+  if (confirmation == null) {
+    return (
+      'telegram gateway: gw /model relaunch applied agent=' +
+      agent +
+      ' launched=' +
+      L +
+      ' configured=' +
+      configured +
+      ' override=' +
+      (isApplyBoot ? 'set' : 'cleared') +
+      '\n'
+    )
+  }
+  if (confirmation.kind === 'not-applied') {
+    return (
+      'telegram gateway: gw /model relaunch NOT-APPLIED agent=' +
+      agent +
+      ' target=' +
+      confirmation.target +
+      ' launched=' +
+      L +
+      ' configured=' +
+      configured +
+      ' revertedTo=' +
+      confirmation.revertedTo +
+      '\n'
+    )
+  }
+  if (confirmation.kind === 'applied') {
+    return (
+      'telegram gateway: gw /model relaunch applied agent=' +
+      agent +
+      ' launched=' +
+      L +
+      ' configured=' +
+      configured +
+      ' override=set outcome=applied\n'
+    )
+  }
+  return (
+    'telegram gateway: gw /model relaunch applied agent=' +
+    agent +
+    ' launched=' +
+    L +
+    ' configured=' +
+    configured +
+    ' override=cleared outcome=default\n'
+  )
+}
+
+/** Telegram body for the single switch-confirmation card (F1/N4). */
+export function formatModelSwitchConfirmationBody(
+  confirmation: ModelSwitchConfirmation,
+): string {
+  if (confirmation.kind === 'applied') {
+    return (
+      '✅ Now running `' +
+      confirmation.launched +
+      '` — session-only, reverts to the configured model on the next restart. Fresh session; memory and the handoff briefing carry the context.'
+    )
+  }
+  if (confirmation.kind === 'not-applied') {
+    return (
+      "⚠️ Your switch to `" +
+      confirmation.target +
+      "` didn't apply — the agent reverted to `" +
+      confirmation.revertedTo +
+      "` (the apply-boot didn't complete). Re-issue `/model " +
+      confirmation.target +
+      "` to try again."
+    )
+  }
+  return (
+    '✅ Now running `' +
+    confirmation.launched +
+    '` (the configured default) — fresh session; memory and the handoff briefing carry the context.'
+  )
+}
+
+export function formatModelRelaunchSuppressNotAppliedLog(input: {
+  agent: string
+  target: string
+}): string {
+  return (
+    'telegram gateway: gw /model relaunch NOT-APPLIED — suppressing not-applied confirmation (a .session-model-alert is present and will be relayed) agent=' +
+    input.agent +
+    ' target=' +
+    input.target +
+    '\n'
+  )
+}
+
+
 export type ParsedModelCommand =
   | { kind: 'show' }
   | { kind: 'set'; model: string }

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -19,6 +19,10 @@ import { dirname, resolve } from 'node:path'
 import { SESSION_MODEL_FILE } from '../gateway/session-model-file.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+const MODEL_COMMAND_SRC = readFileSync(
+  resolve(__dirname, '../gateway/model-command.ts'),
+  'utf8',
+)
 const GATEWAY_SRC = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf8')
 
 describe('gateway: the .relaunch-model-intent subsystem is retired (rev 4)', () => {
@@ -149,58 +153,47 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
   })
 
   it('logs the applied model for diagnosability (F1)', () => {
-    expect(GATEWAY_SRC).toContain('gw /model relaunch applied agent=')
+    expect(GATEWAY_SRC).toContain('formatModelRelaunchDiagLog')
     expect(GATEWAY_SRC).toContain('gw /model relaunch scheduled agent=')
+    expect(MODEL_COMMAND_SRC).toContain('gw /model relaunch applied agent=')
   })
 
   it('logs outcome KIND explicitly on /model switch rehydration (NOT-APPLIED vs applied vs default)', () => {
-    const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
-    expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 5200)
-    // Grepping never confuses silent fail with success — kind is in the line.
-    expect(win).toContain('gw /model relaunch NOT-APPLIED agent=')
-    expect(win).toContain('override=set outcome=applied')
-    expect(win).toContain('gw /model relaunch default/cleared agent=')
-    expect(win).toContain("confirmation.kind === 'not-applied'")
-    expect(win).toContain("confirmation.kind === 'applied'")
-    // Suppress path also tags NOT-APPLIED (not the ambiguous "relaunch applied —")
-    expect(win).toContain('gw /model relaunch NOT-APPLIED — suppressing not-applied confirmation')
+    // Formatters live in model-command.ts (gateway line-ratchet); gateway only calls them.
+    expect(GATEWAY_SRC).toContain('formatModelRelaunchDiagLog')
+    expect(GATEWAY_SRC).toContain('formatModelSwitchConfirmationBody')
+    expect(GATEWAY_SRC).toContain('formatModelRelaunchSuppressNotAppliedLog')
+    expect(MODEL_COMMAND_SRC).toContain('gw /model relaunch NOT-APPLIED agent=')
+    expect(MODEL_COMMAND_SRC).toContain('override=set outcome=applied')
+    expect(MODEL_COMMAND_SRC).toContain('override=cleared outcome=default')
+    expect(MODEL_COMMAND_SRC).toContain('gw /model relaunch NOT-APPLIED — suppressing not-applied confirmation')
   })
 
   it('sends ONE switch-confirmation from the ACTUAL launched model, keyed on the /model reason (F1/N4)', () => {
     const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
     expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 5200)
-    // Keyed on the deterministic /model switch reason, so it also fires on a
-    // launched===configured apply-boot (/model default) — N4. Never optimistic.
-    expect(win).toContain('if (modelSwitchReason != null && modelSwitchMarkerChat)')
-    expect(win).toContain('✅ Now running')
-    // N4: the launched===configured branch still confirms.
-    expect(win).toContain('(the configured default)')
+    const win = GATEWAY_SRC.slice(idx, idx + 2500)
+    expect(win).toContain('if (confirmation != null && modelSwitchMarkerChat)')
+    expect(win).toContain('formatModelSwitchConfirmationBody')
+    expect(MODEL_COMMAND_SRC).toContain('✅ Now running')
+    expect(MODEL_COMMAND_SRC).toContain('(the configured default)')
   })
 
   it('warns instead of a green ✅ when a non-default switch silently reverted to the default (silent-revert fix)', () => {
-    const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
-    const win = GATEWAY_SRC.slice(idx, idx + 5200)
-    // The confirmation card is derived from the pure classifier, not an inline
-    // isApplyBoot ternary — so a reverted non-default switch yields the ⚠️ card.
-    expect(win).toContain('classifyModelSwitchConfirmation({')
-    expect(win).toContain("confirmation.kind === 'applied'")
-    expect(win).toContain("confirmation.kind === 'not-applied'")
-    expect(win).toContain("⚠️ Your switch to")
-    expect(win).toContain("didn't apply")
-    // LOW-3: the re-issue hint interpolates the target inside backticks so a
-    // token containing Markdown metachars can't italicize / 400 the send.
-    expect(win).toContain('Re-issue \\`/model ${confirmation.target}\\`')
+    expect(GATEWAY_SRC).toContain('classifyModelSwitchConfirmation({')
+    expect(GATEWAY_SRC).toContain('formatModelSwitchConfirmationBody')
+    expect(MODEL_COMMAND_SRC).toContain('⚠️ Your switch to')
+    expect(MODEL_COMMAND_SRC).toContain("didn't apply")
+    // LOW-3: re-issue hint keeps target in backticks
+    expect(MODEL_COMMAND_SRC).toContain('Re-issue `/model ')
   })
 
   it('dedups the not-applied card against a tailored .session-model-alert (LOW-2)', () => {
     const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
-    const win = GATEWAY_SRC.slice(idx, idx + 5200)
-    // When start.sh wrote a specific alert for this revert, the classifier's
-    // generic not-applied card is suppressed (the alert relay is the message).
+    const win = GATEWAY_SRC.slice(idx, idx + 2500)
     expect(win).toContain("existsSync(join(smAgentDir, '.session-model-alert'))")
     expect(win).toContain("confirmation.kind === 'not-applied' && hasSessionModelAlert")
+    expect(win).toContain('formatModelRelaunchSuppressNotAppliedLog')
   })
 
   it('N4/reason: the /model switch reason is captured from the clean-shutdown marker', () => {

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
+import { SESSION_MODEL_FILE } from '../gateway/session-model-file.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const GATEWAY_SRC = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf8')
@@ -152,6 +153,20 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
     expect(GATEWAY_SRC).toContain('gw /model relaunch scheduled agent=')
   })
 
+  it('logs outcome KIND explicitly on /model switch rehydration (NOT-APPLIED vs applied vs default)', () => {
+    const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
+    expect(idx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(idx, idx + 5200)
+    // Grepping never confuses silent fail with success — kind is in the line.
+    expect(win).toContain('gw /model relaunch NOT-APPLIED agent=')
+    expect(win).toContain('override=set outcome=applied')
+    expect(win).toContain('gw /model relaunch default/cleared agent=')
+    expect(win).toContain("confirmation.kind === 'not-applied'")
+    expect(win).toContain("confirmation.kind === 'applied'")
+    // Suppress path also tags NOT-APPLIED (not the ambiguous "relaunch applied —")
+    expect(win).toContain('gw /model relaunch NOT-APPLIED — suppressing not-applied confirmation')
+  })
+
   it('sends ONE switch-confirmation from the ACTUAL launched model, keyed on the /model reason (F1/N4)', () => {
     const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
     expect(idx).toBeGreaterThan(0)
@@ -212,6 +227,32 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
     expect(win).toContain('.sendMessage(operator')
   })
 })
+
+
+describe('gateway SESSION_MODEL_FILE stays pinned to start.sh.hbs rev5 carrier', () => {
+  it('hbs applies the same basename gateway writes (no rev4/rev5 name drift)', async () => {
+    const { SESSION_MODEL_FILE } = await import('../gateway/session-model-file.js')
+    const { readFileSync } = await import('node:fs')
+    const { resolve, dirname } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    expect(SESSION_MODEL_FILE).toBe('.session-model')
+    // Vitest may run with import.meta or __dirname depending on config.
+    const here = typeof __dirname !== 'undefined'
+      ? __dirname
+      : dirname(fileURLToPath(import.meta.url))
+    const hbs = readFileSync(
+      resolve(here, '../../profiles/_base/start.sh.hbs'),
+      'utf8',
+    )
+    // Bare file test on the rev5 carrier (not only -override/-alert siblings).
+    expect(hbs).toMatch(/\[\s*-f\s+[^\]]*\/\.session-model["\s\]]/)
+    expect(hbs).toContain('configuredDefaultAtWrite')
+    // Legacy migration shim still converts leftover override → .session-model.
+    expect(hbs).toContain('.session-model-override')
+    expect(hbs).toMatch(/migrated legacy one-shot carrier/)
+  })
+})
+
 
 describe('gateway: the legacy one-shot carrier is no longer written', () => {
   it('no gateway code writes .session-model-override anymore (start.sh migration shim only reads it)', () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -13,6 +13,7 @@ import {
   checkSkillsPrerequisites,
   checkConfig,
   checkStartShStale,
+  checkStartShSessionModelCarrier,
 } from "../src/cli/doctor.js";
 import { findConfigFile } from "../src/config/loader.js";
 import type { SwitchroomConfig } from "../src/config/schema.js";
@@ -732,6 +733,211 @@ describe("checkStartShStale", () => {
     );
     const result = checkStartShStale("clerk", startShPath);
     expect(result.status).toBe("ok");
+  });
+});
+
+describe("checkStartShSessionModelCarrier", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = resolve(tmpdir(), `switchroom-doctor-sm-carrier-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("warns when start.sh is missing entirely", () => {
+    const result = checkStartShSessionModelCarrier(
+      "klanker",
+      join(tempDir, "missing.sh"),
+    );
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("not found");
+    expect(result.fix).toContain("switchroom apply");
+  });
+
+  it("fails legacy-only .session-model-override primary (live pre-rev5 start.sh)", () => {
+    // Mirrors the live stale klanker start.sh signature:_header comments
+    // the override carrier, file-tests ONLY `.session-model-override`, never
+    // has a bare `.session-model` apply path or JSON shape.
+    const startShPath = join(tempDir, "start.sh");
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        "# --- Session-only model override (carrier: .session-model-override) ---",
+        'if [ -f "/home/x/.switchroom/agents/klanker/.session-model-override" ]; then',
+        '  _override="$(tr -d \'[:space:]\' < "/home/x/.switchroom/agents/klanker/.session-model-override" 2>/dev/null || true)"',
+        '  rm -f "/home/x/.switchroom/agents/klanker/.session-model-override"',
+        '  echo "session-model: applied override $_override" >&2',
+        "fi",
+        // Comments that merely mention the rev5 name must not pass:
+        "# note: someday migrate to .session-model JSON",
+      ].join("\n"),
+    );
+    const result = checkStartShSessionModelCarrier("klanker", startShPath);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/legacy|\.session-model-override|yaml pin/i);
+    expect(result.fix).toContain("switchroom apply");
+    expect(result.fix).toMatch(/rev5|\.session-model/);
+  });
+
+  it("fails when a comment mentions .session-model but there is no file-test (false-positive guard)", () => {
+    const startShPath = join(tempDir, "start.sh");
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        "# TODO: honor .session-model carrier from gateway",
+        'echo "session-model: nothing wired" >&2',
+      ].join("\n"),
+    );
+    const result = checkStartShSessionModelCarrier("clerk", startShPath);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/missing rev5|\.session-model/);
+  });
+
+  it("fails file-test of sibling paths only (.session-model-alert / boot-attempts / override)", () => {
+    const startShPath = join(tempDir, "start.sh");
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        'if [ -f "/a/.session-model-alert" ]; then cat "/a/.session-model-alert"; fi',
+        'if [ -f "/a/.session-model-boot-attempts" ]; then cat "/a/.session-model-boot-attempts"; fi',
+        'if [ -f "/a/.session-model-override" ]; then cat "/a/.session-model-override"; fi',
+        // Looking like JSON apply without the bare carrier path must still fail.
+        'echo configuredDefaultAtWrite',
+      ].join("\n"),
+    );
+    const result = checkStartShSessionModelCarrier("clerk", startShPath);
+    expect(result.status).toBe("fail");
+  });
+
+  it("fails bare .session-model file-test without rev5 JSON apply markers", () => {
+    const startShPath = join(tempDir, "start.sh");
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        'if [ -f "/a/.session-model" ]; then',
+        '  cat "/a/.session-model"',
+        "fi",
+      ].join("\n"),
+    );
+    const result = checkStartShSessionModelCarrier("clerk", startShPath);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/JSON|configuredDefaultAtWrite|boot-attempts/);
+  });
+
+  it("ok for rev5 hbs shape: bare .session-model test + JSON apply + legacy migration shim", () => {
+    const startShPath = join(tempDir, "start.sh");
+    // Minimal reduction of profiles/_base/start.sh.hbs rev5 block.
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        "# --- Session model resolution (consume-once .session-model carrier) ---",
+        // Migration shim (reads override, WRITES .session-model) — OK.
+        'if [ -f "/a/.session-model-override" ]; then',
+        '  _mig="$(tr -d \'[:space:]\' < "/a/.session-model-override" 2>/dev/null || true)"',
+        '  rm -f "/a/.session-model-override"',
+        '  printf \'{"model":"%s","configuredDefaultAtWrite":"%s","ts":1}\\n\' "$_mig" "opus" > "/a/.session-model"',
+        "fi",
+        'if [ -f "/a/.session-model" ]; then',
+        '  _smf="$(cat "/a/.session-model" 2>/dev/null || true)"',
+        '  _sm_model="$(printf \'%s\' "$_smf" | sed -n \'s/.*"model":"\\([^"]*\\)".*/\\1/p\')"',
+        '  _sm_cfg="$(printf \'%s\' "$_smf" | sed -n \'s/.*"configuredDefaultAtWrite":"\\([^"]*\\)".*/\\1/p\')"',
+        '  _sm_attempts="$(cat "/a/.session-model-boot-attempts" 2>/dev/null | tr -dc \'0-9\' || true)"',
+        '  echo "session-model: applying $_sm_model (cfg=$_sm_cfg)" >&2',
+        "fi",
+      ].join("\n"),
+    );
+    const result = checkStartShSessionModelCarrier("clerk", startShPath);
+    expect(result.status).toBe("ok");
+    expect(result.detail).toMatch(/rev5|\.session-model/);
+  });
+});
+
+
+describe("checkStartShSessionModelCarrier (rev5 /model)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = resolve(tmpdir(), `switchroom-doctor-smcarrier-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("warns when start.sh is missing", () => {
+    const result = checkStartShSessionModelCarrier(
+      "klanker",
+      join(tempDir, "missing.sh"),
+    );
+    expect(result.status).toBe("warn");
+    expect(result.fix).toMatch(/switchroom apply/);
+  });
+
+  it("fails legacy-only .session-model-override start.sh (live pre-rev5 shape)", () => {
+    // Mirrors live klanker start.sh before apply — silent /model miss class.
+    const startShPath = join(tempDir, "start.sh");
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        "# --- Session-only model override (carrier: .session-model-override) ---",
+        'if [ -f "/home/x/.switchroom/agents/klanker/.session-model-override" ]; then',
+        '  _override="$(cat "/home/x/.switchroom/agents/klanker/.session-model-override")"',
+        '  rm -f "/home/x/.switchroom/agents/klanker/.session-model-override"',
+        '  _EFFECTIVE_MODEL="$_override"',
+        "fi",
+      ].join("\n"),
+    );
+    const result = checkStartShSessionModelCarrier("klanker", startShPath);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toMatch(/session-model-override/);
+    expect(result.fix).toMatch(/switchroom apply/);
+  });
+
+  it("fails when only comments mention .session-model (no real file test)", () => {
+    const startShPath = join(tempDir, "start.sh");
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        "# TODO: wire .session-model rev5 carrier",
+        "# configuredDefaultAtWrite goes here someday",
+        'if [ -f "/tmp/unrelated" ]; then true; fi',
+      ].join("\n"),
+    );
+    const result = checkStartShSessionModelCarrier("klanker", startShPath);
+    expect(result.status).toBe("fail");
+  });
+
+  it("ok for rev5 hbs shape: bare .session-model file test + JSON parse markers", () => {
+    const startShPath = join(tempDir, "start.sh");
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        'if [ -f "/home/x/agents/a/.session-model-override" ]; then',
+        '  printf \'{"model":"%s","configuredDefaultAtWrite":"%s"}\' "x" "y" > "/home/x/agents/a/.session-model"',
+        "fi",
+        'if [ -f "/home/x/agents/a/.session-model" ]; then',
+        '  _smf="$(cat "/home/x/agents/a/.session-model" 2>/dev/null || true)"',
+        "  : configuredDefaultAtWrite",
+        '  _sm_attempts="$(cat "/home/x/agents/a/.session-model-boot-attempts" 2>/dev/null || true)"',
+        "fi",
+      ].join("\n"),
+    );
+    const result = checkStartShSessionModelCarrier("klanker", startShPath);
+    expect(result.status).toBe("ok");
+    expect(result.detail).toMatch(/rev5/);
   });
 });
 

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -768,3 +768,26 @@ if [ -f "$marker" ]; then echo claude-opus-4-8; else touch "$marker"; echo "mang
     expect(idxLkg).toBeLessThan(idxRecord);
   });
 });
+
+describe("carrier name consistency: gateway SESSION_MODEL_FILE ↔ start.sh.hbs", () => {
+  it("pins gateway SESSION_MODEL_FILE basename into hbs apply path + legacy shim", async () => {
+    const { SESSION_MODEL_FILE } = await import("../telegram-plugin/gateway/session-model-file.js");
+    const hbs = readFileSync(
+      join(process.cwd(), "profiles/_base/start.sh.hbs"),
+      "utf-8",
+    );
+    expect(SESSION_MODEL_FILE).toBe(".session-model");
+    // Real file-test on the rev5 carrier path (not -override/-alert siblings).
+    const bare = new RegExp(
+      String.raw`\[\s*-f\s+[^\n\]]*` +
+        SESSION_MODEL_FILE.replace(".", "\\.") +
+        String.raw`(?!-(?:override|alert|boot-attempts|kept))"?\s*\]`,
+    );
+    expect(hbs).toMatch(bare);
+    expect(hbs).toContain(`{{agentDir}}/${SESSION_MODEL_FILE}`);
+    expect(hbs).toContain("configuredDefaultAtWrite");
+    // Migration shim for leftover one-shot carriers.
+    expect(hbs).toContain(".session-model-override");
+    expect(hbs).toMatch(/migrated legacy one-shot carrier/);
+  });
+});


### PR DESCRIPTION
## Summary

Durable fix for broken Telegram `/model` when fleet `start.sh` is stale vs gateway rev5 **without bouncing agents**.

**Root cause:** gateway rev5 writes consume-once `.session-model` (JSON). Live agent `start.sh` can still be pre-rev5 (only `.session-model-override` text). `/model` relaunch then boots the yaml pin while logs look successful (`override=cleared`).

### Changes
1. **Doctor** — `checkStartShSessionModelCarrier` fails readable `start.sh` missing a bare `[ -f …/.session-model ]` apply path + rev5 JSON markers (`configuredDefaultAtWrite` / boot-attempts). Legacy-only override primary fails. Fix: `switchroom apply` (takes effect next restart/release).
2. **Gateway log honesty** — after `classifyModelSwitchConfirmation`, log outcome kind explicitly:
   - `gw /model relaunch NOT-APPLIED …`
   - `… override=set outcome=applied`
   - `gw /model relaunch default/cleared …`
3. **Carrier consistency tests** — pin `SESSION_MODEL_FILE` against `start.sh.hbs` (gateway test + scaffold test); gate that gateway never writeFileSyncs `.session-model-override` as primary.
4. **Hbs note** — doctor/tests pin the path against gateway `SESSION_MODEL_FILE`.

### Out of scope (per request)
- No agent bounce
- No hand-edit of live `/host-home/.switchroom/agents/*/start.sh`
- No yaml model pin changes

## Test plan
- [x] `bun x vitest run tests/doctor.test.ts` — 58 tests (2 skipped)
- [x] `bun x vitest run telegram-plugin/tests/gateway-session-model-relaunch.test.ts` — 23 tests
- [x] `bun x vitest run telegram-plugin/tests/model-command.test.ts` — 75 tests
- [x] scaffold carrier pin + consume-once/legacy-migration cases
- [x] `npm run lint:tsc`
- [ ] CI full suite
- Note: `tests/scaffold.session-model.test.ts` **live configured-default** subset already fails on `main` in this environment (fake `switchroom` PATH); unrelated to this PR.

## After merge
Operator runs `switchroom apply` (rewrites start.sh). Carriers take effect on next agent restart/release bounce — not required immediately.