### PR TITLE
fix(gateway): scope answer-delivered latch to flush-armed source so async handbacks deliver (#3426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@
   turn, resolved the ended ack turn as owner (latest-ended tier, ≤60 s), and
   was suppressed with a false "deduped" success. Flush-race dedup (post-fire
   pre-record window, supersede resurrection window) and byte-identical replay
-  dedup (#546 content cache) are unchanged.
+  dedup (#546 content cache) are unchanged. Conscious trade: the weak
+  "reworded/bridge-replayed duplicate" suppression the reply-armed latch used
+  to provide is dropped — un-acked tool_call replays are byte-identical (the
+  #546 content dedup's case), and a model-regenerated paraphrase is
+  indistinguishable from a genuine handback, so delivering is correct. A rare
+  duplicate message beats a silent drop.
 
 ## v0.19.2 — Hindsight recovery, External spend on /usage, auth-broker hardening, /model carrier doctor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Async sub-agent handback no longer dropped by a stale answer-delivered latch**
+  (#3426) — the gateway's answer-delivered latch is now source-tagged
+  (`'flush'` / `'reply'`), and the late-reply suppression fires only for a
+  FLUSH-armed latch. Previously the dispatch → interim-ack → turn_end →
+  handback pattern silently dropped the handback: the substantive ack armed the
+  boolean latch, the sub-agent completion reply landed with no live gateway
+  turn, resolved the ended ack turn as owner (latest-ended tier, ≤60 s), and
+  was suppressed with a false "deduped" success. Flush-race dedup (post-fire
+  pre-record window, supersede resurrection window) and byte-identical replay
+  dedup (#546 content cache) are unchanged.
+
 ## v0.19.2 — Hindsight recovery, External spend on /usage, auth-broker hardening, /model carrier doctor
 
 Closes dual-writer and silent-LLM footguns in Hindsight, puts short-window OpenRouter

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -483,6 +483,7 @@ import {
 } from '../turn-flush-safety.js'
 import {
   resolveReplyOwnerTurnId,
+  type AnswerDeliveredLatch,
 } from '../reply-owner-resolve.js'
 // PR A — deterministic answer-ready quiescence flush (late-delivery fix).
 import {
@@ -3412,18 +3413,22 @@ export type CurrentTurn = {
   // false ONLY at turn start, mirroring `activityEverOpened`'s sticky-true
   // contract.
   finalAnswerEverDelivered: boolean
-  // 2026-07 double-reply-on-DM fix (Part 2 — race backstop). Set true
-  // SYNCHRONOUSLY at turn-flush FIRE time (before the ~500 ms async send and
-  // before `flushedTurnSupersede.record`) when the flush delivers a SUBSTANTIVE
-  // (≥`FLUSH_SUBSTANTIVE_MIN_CHARS`) terminal answer, and also set when a
-  // substantive `reply` sends. It persists on the ended turn in
+  // 2026-07 double-reply-on-DM fix (Part 2 — race backstop), SOURCE-TAGGED
+  // since #3426. Set to 'flush' SYNCHRONOUSLY at turn-flush FIRE time (before
+  // the ~500 ms async send and before `flushedTurnSupersede.record`) and at
+  // supersede-record consumption (the resurrection window); set to 'reply'
+  // when a substantive `reply` sends. It persists on the ended turn in
   // `recentTurnsById`, so a LATE reply landing in the flush's post-fire
   // pre-record race window (where `flushedTurnSupersede` finds no record to
   // delete yet) resolves this turn via the unified owner resolver, sees the
-  // latch already set, and suppresses itself — closing the residual window Part
-  // 1's supersede cannot reach. Scoped to the substantive floor so an interim
-  // sub-floor ack NEITHER sets nor trips it. Reset false at turn start.
-  answerDelivered: boolean
+  // 'flush' latch already set, and suppresses itself — closing the residual
+  // window Part 1's supersede cannot reach. The 'reply' tag deliberately does
+  // NOT suppress a late reply (#3426): a substantive interim ack followed by
+  // an async sub-agent handback (which lands with NO live gateway turn and
+  // resolves this ended turn as owner via the latest-ended tier) must deliver,
+  // not silently drop. Scoped to the substantive floor so an interim sub-floor
+  // ack NEITHER sets nor trips it. Reset false at turn start.
+  answerDelivered: AnswerDeliveredLatch
   // 2026-07 double-reply-on-DM fix (F2 — recency bound). Wall-clock ms the turn
   // ENDED (stamped once by `endCurrentTurnAtomic`), or null while still live.
   // The `findLatestEndedTurnForChat` supersede tier carries DESTRUCTIVE

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -899,20 +899,25 @@ export async function sendReply(
       // resolves the same ended owner turn, sees the latch, and is suppressed —
       // exactly one message ever ships. The latch is idempotent and the normal
       // (no-throw) path is unaffected: the correction below still ships B once.
-      if (ownerTurn != null) ownerTurn.answerDelivered = true
+      // Tagged 'flush' (#3426): a flush record existed for this turn (take()
+      // just consumed it), so the flushed message A is what the suppression
+      // protects against duplicating.
+      if (ownerTurn != null) ownerTurn.answerDelivered = 'flush'
     } else {
       // 2026-07 double-reply-on-DM fix (Part 2) — answer-delivered race latch.
       // Supersede found no record. Either there was no flush (normal reply), or
       // the flush FIRED but has not yet recorded its message ids (the residual
       // pre-record race Part 1's supersede cannot reach). The flush sets
-      // `answerDelivered = true` synchronously at fire time (before its async
-      // send AND before `record`), and it persists on the ended turn — so when
-      // this LATE, substantive reply resolves its owner turn and sees the latch
-      // already set, the flush's message A is already on its way out and this
-      // reply would ship a duplicate. Suppress it. Scoped to the substantive
-      // ≥`FLUSH_SUBSTANTIVE_MIN_CHARS` floor and the late-reply case so an
-      // interim sub-floor ack, a chunked multi-part answer, or a legitimate
-      // second in-turn substantive reply (live `currentTurn`) is never
+      // `answerDelivered = 'flush'` synchronously at fire time (before its
+      // async send AND before `record`), and it persists on the ended turn — so
+      // when this LATE, substantive reply resolves its owner turn and sees the
+      // FLUSH-armed latch, the flush's message A is already on its way out and
+      // this reply would ship a duplicate. Suppress it. Scoped to the
+      // substantive ≥`FLUSH_SUBSTANTIVE_MIN_CHARS` floor, the late-reply case,
+      // AND the 'flush' latch source (#3426) so an interim sub-floor ack, a
+      // chunked multi-part answer, a legitimate second in-turn substantive
+      // reply (live `currentTurn`), or an async sub-agent handback landing
+      // after a reply-delivered turn ended (latch = 'reply') is never
       // suppressed. `isSubstantiveFinalReply` reduces to the ≥200-char test on
       // the `reply` path (no `done`); pass the model's original notification
       // intent to mirror the #2533 decoupling call shape.
@@ -934,11 +939,16 @@ export async function sendReply(
         )
         return { content: [{ type: 'text', text: 'sent (deduped — answer already delivered via turn-flush)' }] }
       }
-      // A substantive answer is going out via this reply — set the latch on its
-      // owner turn so a later bridge-replayed / reworded duplicate of the same
-      // answer is caught by the branch above.
+      // A substantive answer is going out via this reply — record it on the
+      // owner turn, tagged 'reply' (#3426). The 'reply' tag does NOT trip the
+      // late-reply suppression above: a later reply attributed to this turn
+      // after it ends (the async sub-agent handback pattern — dispatch, interim
+      // ack, turn_end, handback with no live gateway turn) is genuinely new
+      // content and must deliver. Byte-identical replays of THIS answer are
+      // deduped by the content-keyed #546 cache at the top of this function,
+      // whose 60 s TTL matches the latest-ended owner tier's supersede TTL.
       if (replySubstantive && ownerTurn != null) {
-        ownerTurn.answerDelivered = true
+        ownerTurn.answerDelivered = 'reply'
       }
     }
   }

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -945,8 +945,14 @@ export async function sendReply(
       // after it ends (the async sub-agent handback pattern — dispatch, interim
       // ack, turn_end, handback with no live gateway turn) is genuinely new
       // content and must deliver. Byte-identical replays of THIS answer are
-      // deduped by the content-keyed #546 cache at the top of this function,
-      // whose 60 s TTL matches the latest-ended owner tier's supersede TTL.
+      // deduped by the content-keyed #546 cache at the top of this function.
+      // Honest bound: the dedup TTL (60 s) is anchored at reply RECORD time,
+      // while the latest-ended owner tier's 60 s is anchored at `endedAt` —
+      // later by the reply→turn_end gap. A byte-identical replay landing >60 s
+      // after record but ≤60 s after endedAt is evicted from dedup yet still
+      // resolves this ended turn, so it now DELIVERS as a duplicate message.
+      // Conscious trade: a rare duplicate beats the silent handback drop the
+      // boolean latch caused (#3426).
       if (replySubstantive && ownerTurn != null) {
         ownerTurn.answerDelivered = 'reply'
       }

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -1623,16 +1623,19 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
         // corrects it in place.
         //
         // TWO distinct arbiters set synchronously here, before any `await`:
-        //   (a) `turn.answerDelivered` — the backstop-vs-LATE-REPLY signal the
-        //       reply path already reads (`decideAnswerLatchSuppression` +
-        //       `flushedTurnSupersede`), exactly as on `main`.
+        //   (a) `turn.answerDelivered = 'flush'` — the backstop-vs-LATE-REPLY
+        //       signal the reply path already reads
+        //       (`decideAnswerLatchSuppression` + `flushedTurnSupersede`).
+        //       Source-tagged 'flush' (#3426): the late-reply suppression is
+        //       scoped to flush-armed latches, so a later async handback
+        //       attributed to a reply-delivered ended turn is never dropped.
         //   (b) `backstopDeliveryLedger.claim` — the backstop-vs-BACKSTOP
         //       double-fire latch: `claim` returning false means this turn
         //       already fired a backstop (answer-ready quiescence, then the
         //       turn-end backstop), so this fire is a no-op. It does NOT
         //       arbitrate the late reply (that is (a)); it is redundant-but-
         //       cheap with the `currentTurn == null` bail below.
-        turn.answerDelivered = true
+        turn.answerDelivered = 'flush'
         const backstopLatchClaimed = backstopDeliveryLedger.claim(turn.turnId)
 
         // #654 deterministic double-message fix. Hand off the pinned

--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -108,6 +108,31 @@ export function resolveReplyOwnerTurnId(candidates: ReplyOwnerCandidates): strin
 }
 
 /**
+ * The answer-delivered latch value — SOURCE-TAGGED (#3426).
+ *
+ * `false`   — no answer delivered this turn (latch unarmed).
+ * `'flush'` — the TURN-FLUSH backstop delivered (or is mid-delivering) this
+ *             turn's answer as its own message A. Set synchronously at
+ *             flush-fire time, and at supersede-record consumption (the
+ *             resurrection window — a flush record existed for this turn).
+ * `'reply'` — a normally-delivered `reply` tool call carried this turn's
+ *             answer (no flush involved).
+ *
+ * Why the tag exists: the late-reply suppression below is a race backstop for
+ * FLUSH duplicates only. A boolean latch also suppressed the async sub-agent
+ * handback pattern (#3426): the parent turn's interim ack (a substantive
+ * `reply`) armed the latch, the turn ended, and the sub-agent completion
+ * handback — a genuinely NEW answer arriving with no live gateway turn —
+ * resolved the ended turn as owner (latest-ended tier, inside the 60 s
+ * supersede TTL), saw the stale latch, and was silently dropped with a false
+ * "deduped" success. Tagging the source lets the suppression fire ONLY for the
+ * flush races it exists for; byte-identical replays of a reply-delivered
+ * answer remain covered by the content-keyed outbound dedup (#546), whose 60 s
+ * TTL matches the latest-ended owner tier's bound.
+ */
+export type AnswerDeliveredLatch = false | 'flush' | 'reply'
+
+/**
  * The answer-delivered latch inputs (Part 2 — the race backstop).
  *
  * The unified resolver (Part 1) closes the common late-reply case where the
@@ -118,11 +143,11 @@ export function resolveReplyOwnerTurnId(candidates: ReplyOwnerCandidates): strin
  * There `flushed-turn-supersede` finds no record (nothing to delete yet) and the
  * reply would ship message B as a duplicate of the flush's message A.
  *
- * The latch closes that window: the gateway sets `answerDelivered = true` on the
- * turn atom SYNCHRONOUSLY at flush-fire time — before the ~500 ms async send and
- * before the record — and the flag persists on the ended turn (readable via the
- * unified resolver after `currentTurn` is null). A reply landing in the race
- * window then sees the latch already set and suppresses itself.
+ * The latch closes that window: the gateway sets `answerDelivered = 'flush'` on
+ * the turn atom SYNCHRONOUSLY at flush-fire time — before the ~500 ms async send
+ * and before the record — and the flag persists on the ended turn (readable via
+ * the unified resolver after `currentTurn` is null). A reply landing in the race
+ * window then sees the flush latch already set and suppresses itself.
  */
 export interface AnswerLatchSuppressInput {
   /** True when Part 1's supersede already fired for THIS reply (message A was
@@ -140,21 +165,29 @@ export interface AnswerLatchSuppressInput {
    *  legitimate second in-turn substantive reply (a genuine multi-message
    *  answer, live currentTurn) untouched. */
   isLateReply: boolean
-  /** The resolved owner turn's `answerDelivered` latch. */
-  ownerAnswerDelivered: boolean
+  /** The resolved owner turn's source-tagged `answerDelivered` latch. */
+  ownerAnswerDelivered: AnswerDeliveredLatch
 }
 
 /**
  * Decide whether the answer-delivered latch suppresses a landing reply.
  *
  * Suppress IFF: Part 1 did NOT already supersede, the reply is a substantive
- * final answer, it is a late reply (no live turn), AND the owner turn's latch is
- * already set (the flush delivered the same substantive answer as message A in
- * the pre-record race window). Otherwise the reply sends.
+ * final answer, it is a late reply (no live turn), AND the owner turn's latch
+ * was armed by the TURN-FLUSH path (`'flush'` — the flush delivered the same
+ * substantive answer as message A in the pre-record race window, or the
+ * supersede-consumed resurrection window). Otherwise the reply sends.
+ *
+ * A `'reply'`-armed latch deliberately does NOT suppress (#3426): the prior
+ * answer went out via a normal, completed `reply`, so a later late-landing
+ * reply attributed to that ended turn is NOT a flush duplicate — it is
+ * (typically) an async sub-agent handback carrying genuinely new content, and
+ * suppressing it silently drops the user's answer. Byte-identical replays of
+ * the delivered reply are still deduped by the content-keyed #546 cache.
  */
 export function decideAnswerLatchSuppression(input: AnswerLatchSuppressInput): boolean {
   if (input.superseded) return false
   if (!input.replySubstantive) return false
   if (!input.isLateReply) return false
-  return input.ownerAnswerDelivered
+  return input.ownerAnswerDelivered === 'flush'
 }

--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -127,8 +127,19 @@ export function resolveReplyOwnerTurnId(candidates: ReplyOwnerCandidates): strin
  * supersede TTL), saw the stale latch, and was silently dropped with a false
  * "deduped" success. Tagging the source lets the suppression fire ONLY for the
  * flush races it exists for; byte-identical replays of a reply-delivered
- * answer remain covered by the content-keyed outbound dedup (#546), whose 60 s
- * TTL matches the latest-ended owner tier's bound.
+ * answer remain covered by the content-keyed outbound dedup (#546).
+ *
+ * Honest bound on that dedup cover: the #546 TTL (60 s) is anchored at reply
+ * RECORD time, while the latest-ended owner tier's 60 s is anchored at the
+ * turn's `endedAt` — later by the reply→turn_end gap. A byte-identical replay
+ * landing >60 s after record but ≤60 s after endedAt is evicted from dedup yet
+ * still resolves the ended turn, so it DELIVERS as a duplicate message. That
+ * is a conscious trade: this fix also drops the weak "reworded/bridge-replayed
+ * duplicate" suppression the reply-armed boolean latch used to provide —
+ * replays of an un-acked tool_call are byte-identical (content dedup's case),
+ * and a model-REGENERATED paraphrase is indistinguishable from a genuinely new
+ * handback, so delivering it is the correct default. A rare duplicate message
+ * beats the silent handback drop.
  */
 export type AnswerDeliveredLatch = false | 'flush' | 'reply'
 

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -400,8 +400,12 @@ describe('reply-flicker edit-in-place — mid-path throw + retry never resurrect
  * flush-armed latch — a 'reply'-armed latch never suppresses, so the
  * dispatch → ack → turn_end → handback sequence always delivers. Genuine
  * byte-identical replays of the delivered reply remain covered by the
- * content-keyed #546 outbound dedup (whose 60 s TTL matches the latest-ended
- * owner tier bound), asserted below.
+ * content-keyed #546 outbound dedup, asserted below. (Honest bound: the dedup
+ * TTL is anchored at reply RECORD time, the latest-ended owner tier at
+ * `endedAt` — a replay landing in the gap between those 60 s windows now
+ * delivers as a rare duplicate rather than being suppressed; a conscious
+ * trade against the silent handback drop. See the `AnswerDeliveredLatch`
+ * docblock.)
  */
 describe('#3426 — async sub-agent handback after an interim-ack turn', () => {
   const CHAT = '12345'

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -34,8 +34,10 @@ import {
   resolveReplyOwnerTurnId,
   decideAnswerLatchSuppression,
   type ReplyOwnerCandidates,
+  type AnswerDeliveredLatch,
 } from '../reply-owner-resolve.js'
 import { FlushedTurnSupersedeRegistry, DEFAULT_SUPERSEDE_TTL_MS } from '../flushed-turn-supersede.js'
+import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 
 const NONE: ReplyOwnerCandidates = {
   liveTurnId: null,
@@ -129,13 +131,13 @@ describe('Part 1 end-to-end: unified resolver drives the flush supersede', () =>
 
 describe('decideAnswerLatchSuppression — race backstop (Part 2)', () => {
   it('RACE: a late substantive reply lands in the flush post-fire pre-record ' +
-    'window (no supersede record yet) → SUPPRESSED by the latch', () => {
+    'window (no supersede record yet) → SUPPRESSED by the flush-armed latch', () => {
     expect(
       decideAnswerLatchSuppression({
         superseded: false,
         replySubstantive: true,
         isLateReply: true,
-        ownerAnswerDelivered: true,
+        ownerAnswerDelivered: 'flush',
       }),
     ).toBe(true)
   })
@@ -147,7 +149,7 @@ describe('decideAnswerLatchSuppression — race backstop (Part 2)', () => {
         superseded: true,
         replySubstantive: true,
         isLateReply: true,
-        ownerAnswerDelivered: true,
+        ownerAnswerDelivered: 'flush',
       }),
     ).toBe(false)
   })
@@ -159,7 +161,7 @@ describe('decideAnswerLatchSuppression — race backstop (Part 2)', () => {
         superseded: false,
         replySubstantive: false,
         isLateReply: true,
-        ownerAnswerDelivered: true,
+        ownerAnswerDelivered: 'flush',
       }),
     ).toBe(false)
   })
@@ -171,7 +173,7 @@ describe('decideAnswerLatchSuppression — race backstop (Part 2)', () => {
         superseded: false,
         replySubstantive: true,
         isLateReply: false,
-        ownerAnswerDelivered: true,
+        ownerAnswerDelivered: 'flush',
       }),
     ).toBe(false)
   })
@@ -195,7 +197,7 @@ describe('F1 — flush send failure must NOT suppress the late reply (zero-messa
   // latch armed would make a genuine late reply suppress itself → the user gets
   // ZERO messages. The gateway's send-failure catch resets `answerDelivered =
   // false`; these assert the resulting coordination outcome at the pure core.
-  const lateSubstantiveReply = (ownerAnswerDelivered: boolean) =>
+  const lateSubstantiveReply = (ownerAnswerDelivered: AnswerDeliveredLatch) =>
     decideAnswerLatchSuppression({
       superseded: false,
       replySubstantive: true,
@@ -205,8 +207,8 @@ describe('F1 — flush send failure must NOT suppress the late reply (zero-messa
 
   it('WITHOUT the catch-reset (latch still armed) the late reply is suppressed ' +
     '— the zero-message bug', () => {
-    // Models the buggy state: flush armed the latch, send failed, latch left true.
-    expect(lateSubstantiveReply(true)).toBe(true)
+    // Models the buggy state: flush armed the latch, send failed, latch left armed.
+    expect(lateSubstantiveReply('flush')).toBe(true)
   })
 
   it('WITH the catch-reset (answerDelivered=false) the late reply DELIVERS', () => {
@@ -293,15 +295,15 @@ describe('F2 — recency-bound the destructive latest-ended supersede tier', () 
  * consumed — the retry takes the no-record branch. Without a latch the retry
  * would ship a fresh B alongside the stale narration A (both visible).
  *
- * The fix latches `ownerTurn.answerDelivered = true` at record consumption, so
- * the retry (resolving the SAME ended owner turn) is caught by
+ * The fix latches `ownerTurn.answerDelivered = 'flush'` at record consumption,
+ * so the retry (resolving the SAME ended owner turn) is caught by
  * `decideAnswerLatchSuppression` and suppressed — exactly one message survives.
  */
 describe('reply-flicker edit-in-place — mid-path throw + retry never resurrects the duplicate (L1)', () => {
   const CHAT = '636363'
 
   /** Minimal model of the ended owner turn atom the gateway mutates + reads. */
-  interface OwnerTurn { turnId: string; answerDelivered: boolean }
+  interface OwnerTurn { turnId: string; answerDelivered: AnswerDeliveredLatch }
 
   /**
    * Drive the two gateway `reply` calls the incident produces, threading the
@@ -325,8 +327,9 @@ describe('reply-flicker edit-in-place — mid-path throw + retry never resurrect
     const d1 = reg.take(CHAT, undefined, { liveTurnId: owner.turnId, now: now + 10 })
     const firstSuperseded = d1.supersede
     if (d1.supersede && setLatchOnSupersede) {
-      // The fix: latch at consumption, BEFORE the arg-validation throw.
-      owner.answerDelivered = true
+      // The fix: latch at consumption, BEFORE the arg-validation throw. Tagged
+      // 'flush' (#3426) — a flush record existed for this turn.
+      owner.answerDelivered = 'flush'
     }
     // Arg-validation throw fires here (oversized file / invalid keyboard):
     // the correction never runs → A is neither deleted nor edited, B not sent.
@@ -365,5 +368,194 @@ describe('reply-flicker edit-in-place — mid-path throw + retry never resurrect
     expect(r.retrySuppressed).toBe(false)
     // The exact regression: stale narration A AND the retry reply B are both visible.
     expect(r.visible).toEqual(['A(flush-narration)', 'B(retry-reply)'])
+  })
+})
+
+/**
+ * #3426 — async sub-agent handback silently dropped by a stale answer-delivered
+ * latch.
+ *
+ * ## The incident these tests pin (overlord, chat 12345, turn …#10473)
+ *
+ *   11:28:00  interim ack `reply` (321 chars — ABOVE the ≥200 substantive
+ *             floor) lands in the LIVE turn; the gateway records the answer on
+ *             the turn atom (outbound-send-path no-record branch tail).
+ *   11:28:10  turn_end (replyCalled=true, finalAnswer=true); the atom persists
+ *             in recentTurnsById with endedAt stamped.
+ *   11:28:51  the async sub-agent completes and the agent's handback `reply`
+ *             (1365 chars, GENUINELY DIFFERENT content) lands with NO live
+ *             gateway turn (a sub-agent completion is not a new inbound, so no
+ *             new turn atom exists). The owner resolves to the ENDED ack turn
+ *             via the latest-ended tier (41 s ≤ the 60 s supersede TTL), whose
+ *             boolean latch was still armed → the handback was suppressed as a
+ *             "flush duplicate" and a false "deduped" success returned. The
+ *             user never saw the sub-agent's findings.
+ *
+ * ## The fix
+ *
+ * The latch is SOURCE-TAGGED (`AnswerDeliveredLatch`): 'flush' when the
+ * turn-flush backstop armed it (the two races the suppression exists for),
+ * 'reply' when a normally-delivered reply carried the answer.
+ * `decideAnswerLatchSuppression` suppresses a late reply ONLY for a
+ * flush-armed latch — a 'reply'-armed latch never suppresses, so the
+ * dispatch → ack → turn_end → handback sequence always delivers. Genuine
+ * byte-identical replays of the delivered reply remain covered by the
+ * content-keyed #546 outbound dedup (whose 60 s TTL matches the latest-ended
+ * owner tier bound), asserted below.
+ */
+describe('#3426 — async sub-agent handback after an interim-ack turn', () => {
+  const CHAT = '12345'
+  const ACK_TURN = '12345:_#10473'
+  /** ms between turn_end (11:28:10) and the handback landing (11:28:51). */
+  const HANDBACK_AGE_MS = 41_000
+
+  interface OwnerTurn { turnId: string; answerDelivered: AnswerDeliveredLatch }
+
+  /** The OLD (pre-#3426) decision, reproduced verbatim for the red-on-main
+   *  contrast: the latch was a plain boolean, so ANY armed latch suppressed a
+   *  late substantive reply regardless of which path armed it. */
+  function oldBooleanLatchSuppression(input: {
+    superseded: boolean
+    replySubstantive: boolean
+    isLateReply: boolean
+    ownerAnswerDelivered: boolean
+  }): boolean {
+    if (input.superseded) return false
+    if (!input.replySubstantive) return false
+    if (!input.isLateReply) return false
+    return input.ownerAnswerDelivered
+  }
+
+  /**
+   * Drive the incident timeline through the SAME pure cores the gateway runs.
+   * `latchSemantics` toggles the fixed source-tagged decision ('tagged') vs
+   * the pre-fix boolean decision ('boolean' — red-on-main contrast).
+   * Returns what the user ends up seeing.
+   */
+  function runDispatchAckHandback(latchSemantics: 'tagged' | 'boolean'): {
+    delivered: string[]
+    ownerId: string | null
+    handbackSuppressed: boolean
+  } {
+    const reg = new FlushedTurnSupersedeRegistry()
+    const now = 1_000_000
+    const owner: OwnerTurn = { turnId: ACK_TURN, answerDelivered: false }
+    const delivered: string[] = []
+
+    // ── 1. Interim ack lands IN the live turn (substantive: 321 ≥ 200). ──
+    // Live turn ⇒ isLateReply=false ⇒ never suppressed; the gateway then
+    // arms the latch on the owner turn (outbound-send-path no-record tail).
+    const ackSuppressed = decideAnswerLatchSuppression({
+      superseded: false,
+      replySubstantive: true,
+      isLateReply: false, // currentTurn is live at ack time
+      ownerAnswerDelivered: owner.answerDelivered,
+    })
+    expect(ackSuppressed).toBe(false)
+    delivered.push('ack("Kicked off a fable researcher…")')
+    owner.answerDelivered = 'reply' // the fixed arm site tags the source
+
+    // ── 2. turn_end — the atom persists (endedAt stamped), latch still armed. ──
+
+    // ── 3. The async handback lands 41 s later with NO live gateway turn. ──
+    // DM ⇒ no origin_turn_id; no quote recovery; the latest-ended tier
+    // resolves the ENDED ack turn as owner (41 s ≤ 60 s TTL) — the latch IS
+    // genuinely reachable, which is exactly how the incident happened.
+    const ownerId = resolveReplyOwnerTurnId({
+      liveTurnId: null,
+      originTurnId: null,
+      quotedTurnId: null,
+      latestEndedTurnId: owner.turnId,
+      latestEndedAgeMs: HANDBACK_AGE_MS,
+      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+    })
+    expect(ownerId).toBe(ACK_TURN)
+
+    // No flush ever fired this turn ⇒ no supersede record to take.
+    const supersede = reg.take(CHAT, undefined, { liveTurnId: ownerId, now: now + HANDBACK_AGE_MS })
+    expect(supersede.supersede).toBe(false)
+
+    const handbackSuppressed = latchSemantics === 'tagged'
+      ? decideAnswerLatchSuppression({
+          superseded: false,
+          replySubstantive: true, // 1365 chars
+          isLateReply: true, // no live gateway turn at handback time
+          ownerAnswerDelivered: owner.answerDelivered,
+        })
+      : oldBooleanLatchSuppression({
+          superseded: false,
+          replySubstantive: true,
+          isLateReply: true,
+          // Pre-fix the latch was `true` (a bare boolean, source-blind).
+          ownerAnswerDelivered: owner.answerDelivered !== false,
+        })
+    if (!handbackSuppressed) delivered.push('handback("Fable\'s back. The /model fix…")')
+    return { delivered, ownerId, handbackSuppressed }
+  }
+
+  it('CORE REGRESSION (the fix): the handback is NOT suppressed — the user ' +
+    'receives BOTH the interim ack AND the sub-agent findings', () => {
+    const r = runDispatchAckHandback('tagged')
+    expect(r.handbackSuppressed).toBe(false)
+    expect(r.delivered).toEqual([
+      'ack("Kicked off a fable researcher…")',
+      'handback("Fable\'s back. The /model fix…")',
+    ])
+  })
+
+  it('RED-ON-MAIN CONTRAST: the pre-fix boolean latch suppresses the handback ' +
+    '— the silent drop (only the ack ever reaches the user)', () => {
+    const r = runDispatchAckHandback('boolean')
+    // Owner resolution is identical in both worlds — the ended ack turn.
+    expect(r.ownerId).toBe(ACK_TURN)
+    expect(r.handbackSuppressed).toBe(true)
+    expect(r.delivered).toEqual(['ack("Kicked off a fable researcher…")'])
+  })
+
+  it('pure core: a reply-armed latch never suppresses a late substantive reply', () => {
+    expect(
+      decideAnswerLatchSuppression({
+        superseded: false,
+        replySubstantive: true,
+        isLateReply: true,
+        ownerAnswerDelivered: 'reply',
+      }),
+    ).toBe(false)
+  })
+
+  it('flush race NOT reopened: the same late-landing shape against a ' +
+    'FLUSH-armed latch is still suppressed (the Part 2 backstop holds)', () => {
+    // Same timeline shape, but the turn's answer went out via the turn-flush
+    // backstop (post-fire pre-record window): latch = 'flush', no record yet.
+    expect(
+      decideAnswerLatchSuppression({
+        superseded: false,
+        replySubstantive: true,
+        isLateReply: true,
+        ownerAnswerDelivered: 'flush',
+      }),
+    ).toBe(true)
+  })
+
+  it('double-send NOT reopened: a byte-identical replay of the delivered ' +
+    'reply is still caught by the #546 content dedup (60 s TTL)', () => {
+    const dedup = new OutboundDedupCache()
+    const now = 5_000_000
+    const answer =
+      'Fable is back. The /model fix landed in release 1.0.128 and the fallback ' +
+      'behaviour matches what we saw in the transcripts yesterday evening.'
+    // The reply path records what it sent (with its turn key)…
+    dedup.record(CHAT, undefined, answer, now, ACK_TURN)
+    // …and a late byte-identical replay (no live turn ⇒ null turnKey, which
+    // matches any recorded entry) is deduped before the latch is ever consulted.
+    const replay = dedup.check(CHAT, undefined, answer, now + HANDBACK_AGE_MS, null)
+    expect(replay).not.toBeNull()
+    // While the DIFFERENT-content handback sails past the content dedup…
+    const handback = dedup.check(
+      CHAT, undefined,
+      'Completely different sub-agent findings text, long enough to clear the dedup floor.',
+      now + HANDBACK_AGE_MS, null,
+    )
+    expect(handback).toBeNull()
   })
 })


### PR DESCRIPTION
Fixes #3426 — "Async sub-agent handback reply silently dropped by stale answer-delivered latch."

## Root cause

The answer-delivered latch (`CurrentTurn.answerDelivered`) was a plain boolean, armed by BOTH:

- the turn-flush backstop at fire time (`telegram-plugin/gateway/stream-render.ts:1635`) — the race it exists for, and
- any normally-delivered substantive (>=200 char) `reply` (`telegram-plugin/gateway/outbound-send-path.ts` no-record branch tail).

`decideAnswerLatchSuppression` (`telegram-plugin/reply-owner-resolve.ts`) suppressed any LATE substantive reply whose resolved owner turn had the latch armed. In the incident (overlord, turn `…#10473`):

1. Interim ack (321 chars — above the substantive floor) delivered in the live turn and armed the latch.
2. `turn_end` — the atom persists in `recentTurnsById` with the latch still armed.
3. The async sub-agent handback landed 41 s later with **no live gateway turn** (a sub-agent completion is not a new inbound, so no new turn atom exists). `resolveReplyOwnerTurn` recovered the ENDED ack turn via the latest-ended tier (41 s <= `DEFAULT_SUPERSEDE_TTL_MS` = 60 s), the stale latch suppressed the handback as a "flush duplicate", and a false `deduped` success was returned to the caller. Silent drop in both directions.

Note: "reset the latch at new-turn start" would NOT fix this — there is no new gateway turn at handback time; the latch is reset at turn start already (`stream-render.ts:309`). And clearing it at `turn_end` would break the flush race backstop, which by design persists past the flush's synthetic `turn_end`.

## Fix (deterministic, source-scoped)

Source-tag the latch: `AnswerDeliveredLatch = false | 'flush' | 'reply'` (`telegram-plugin/reply-owner-resolve.ts`).

- `'flush'` — armed at turn-flush fire time (`stream-render.ts`) and at supersede-record consumption (the resurrection window, `outbound-send-path.ts`). These are the two races the suppression exists for; late-reply suppression still fires for them.
- `'reply'` — armed when a substantive `reply` delivers. `decideAnswerLatchSuppression` now returns `ownerAnswerDelivered === 'flush'`, so a reply-armed latch never suppresses a later late-landing reply — the async handback always delivers.

Genuine double-send protection is NOT reopened:

- flush post-fire pre-record race + supersede resurrection window: still suppressed (flush-armed latch, covered by tests).
- byte-identical replays of a delivered reply: caught by the content-keyed #546 `OutboundDedupCache` (covered by test). **Honest bound** (review finding, commit cd76f32c): the dedup 60 s TTL is anchored at reply RECORD time while the latest-ended owner tier's 60 s is anchored at `endedAt` — later by the reply→turn_end gap. A byte-identical replay landing >60 s after record but ≤60 s after `endedAt` is evicted from dedup yet still resolves the ended turn, so it now delivers as a rare duplicate MESSAGE (not data loss).

**Consciously dropped** (review finding 2): the weak "reworded/bridge-replayed duplicate" suppression the reply-armed boolean latch used to provide. Replays of an un-acked tool_call are byte-identical, which is exactly the #546 content-dedup case; the only escapee is a model-REGENERATED paraphrase, which is indistinguishable from a genuinely new handback — so delivering it is the correct default. A rare duplicate beats the silent drop.

## Tests

`telegram-plugin/tests/reply-owner-resolve.test.ts`, new `#3426` describe:

- **CORE REGRESSION**: drives the incident timeline (ack in live turn -> arm -> turn_end -> handback 41 s later, owner resolved via latest-ended tier) through the exact pure cores the gateway runs; asserts the handback is DELIVERED and the user receives both messages. **Verified red on pre-fix code**: with the old `decideAnswerLatchSuppression` body restored, this test fails (`handbackSuppressed` = true, only the ack delivered).
- **RED-ON-MAIN CONTRAST**: reproduces the pre-fix boolean decision verbatim and asserts it drops the handback.
- flush-race NOT reopened (flush-armed latch still suppresses), reply-armed latch never suppresses, byte-identical replay still content-deduped while different-content handback passes.
- Existing Part 2 / F1 / L1 latch suites updated to the tagged type ('flush' at the flush/supersede arm sites); all semantics preserved.

## Test + lint results

- `vitest run telegram-plugin/tests/reply-owner-resolve.test.ts telegram-plugin/tests/outbound-send-path.test.ts telegram-plugin/tests/stream-render-golden.test.ts tests/turn-lifecycle-characterization.test.ts telegram-plugin/tests/flushed-turn-supersede.test.ts telegram-plugin/tests/recent-outbound-dedup.test.ts telegram-plugin/tests/answer-ready-flush.test.ts telegram-plugin/tests/turn-flush-safety.test.ts telegram-plugin/tests/turn-flush-suppression.test.ts` — **8 files, 208 tests passed**.
- `npm run lint` (tsc --noEmit + all guard scripts) — **clean** (litellm-config guard SKIP as expected in hermetic dev).

## Not addressed here (same family, separate)

The issue's secondary symptom — `superseding flushed message via edit-in-place` messages 10482/10486 not surfacing client-side — shares the latest-ended/60 s owner-resolution path but is a different mechanism (a handback CAN still supersede a prior turn's flushed message within 60 s, replacing its text via edit-in-place). Kept out per one-concern-per-PR; worth a follow-up issue if the client-side non-surfacing reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
