### PR TITLE
recall: strip <channel> envelope from query + breach telemetry (A1, #3431)

### DIFF
--- a/vendor/hindsight-memory/scripts/lib/content.py
+++ b/vendor/hindsight-memory/scripts/lib/content.py
@@ -79,7 +79,14 @@ def compose_recall_query(
 
         <latest query>
     """
-    latest = latest_query.strip()
+    # Switchroom A1 (hindsight-leverage PR 1) — strip the <channel> envelope
+    # from the latest query INSIDE the helper as well, so any caller (present
+    # or future) gets an envelope-free composed query. The recall.py caller
+    # already strips before calling, but keeping the strip here is defence in
+    # depth: it guarantees the trailing latest-query segment appended below
+    # (and returned on the turns<=1 short-circuit) never carries the raw
+    # chat_id/ts/user XML noise into the embedding or the char cap.
+    latest = strip_channel_envelope(latest_query).strip()
     if recall_context_turns <= 1 or not isinstance(messages, list) or not messages:
         return latest
 

--- a/vendor/hindsight-memory/scripts/lib/content.py
+++ b/vendor/hindsight-memory/scripts/lib/content.py
@@ -33,11 +33,17 @@ def strip_channel_envelope(content: str) -> str:
     This is the Claude Code equivalent of Openclaw's stripMetadataEnvelopes().
     Extracts the inner text, preserving the actual user message while removing
     transport metadata that Hindsight doesn't need.
+
+    A single prompt may carry MORE THAN ONE envelope (e.g. a coalesced
+    burst where several inbound messages were concatenated). Since this now
+    sits on the live recall-query path (hindsight-leverage PR 1, review
+    finding 6), coalesce EVERY envelope's inner text rather than keeping only
+    the first and silently dropping everything after the first ``</channel>``.
     """
-    # Match <channel ...>content</channel> — extract inner text
-    match = re.search(r"<channel\b[^>]*>([\s\S]*?)</channel>", content)
-    if match:
-        return match.group(1).strip()
+    # Match every <channel ...>content</channel> — extract & join inner texts.
+    matches = re.findall(r"<channel\b[^>]*>([\s\S]*?)</channel>", content)
+    if matches:
+        return "\n".join(m.strip() for m in matches if m.strip()).strip()
     return content
 
 

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -176,6 +176,15 @@ def _summarise_source_topics(results: list) -> dict:
 # `switchroom memory recall-log <agent>`.
 RECALL_LOG_FILE = "recall_log.jsonl"
 RECALL_LOG_MAX_LINES = 5000
+# Honest per-line upper-bound estimate for the size-gated trim (hindsight-
+# leverage PR 1, review finding 5). The A3-telemetry row (bounded query
+# excerpt ≤200 chars + bank_timings + memory_ids) runs ~700-900 bytes worst
+# case; 1024 is a safe upper bound. The size gate only reads+trims the file
+# when it plausibly exceeds the line cap, so it must OVER-estimate row size
+# (threshold = cap × upper-bound) — otherwise a file over the old 250 B/line
+# threshold but still under the line cap triggers a full-file read on every
+# hook (critical-path thrash) that never actually trims.
+RECALL_LOG_BYTES_PER_LINE_EST = 1024
 
 
 def _cache_ttl_secs() -> int:
@@ -526,6 +535,20 @@ def _is_timeout_error(exc: BaseException) -> bool:
     """
     if isinstance(exc, (socket.timeout, TimeoutError)):
         return True
+
+    # An HTTP status response is NEVER a client-side read deadline, even when
+    # its body says "upstream timed out" / "gateway timeout" (502/504). Rule
+    # these out BEFORE the message sniff below (review finding 4), both when
+    # the HTTPError is raised directly and when lib.client wraps it as
+    # `RuntimeError(f"HTTP {code} from {url}: {body}")` — whose body can carry
+    # a proxy's "timed out" text and would otherwise be misclassified.
+    cause = getattr(exc, "__cause__", None)
+    if isinstance(exc, urllib.error.HTTPError) or isinstance(cause, urllib.error.HTTPError):
+        return False
+    if re.match(r"HTTP \d+ from ", str(exc)):
+        return False
+
+    # A non-HTTP URLError (DNS, connection, read timeout) — inspect the reason.
     if isinstance(exc, urllib.error.URLError):
         reason = getattr(exc, "reason", None)
         if isinstance(reason, (socket.timeout, TimeoutError)):
@@ -533,7 +556,9 @@ def _is_timeout_error(exc: BaseException) -> bool:
         # Some stdlib versions stringify the timeout into the reason.
         if isinstance(reason, str) and "timed out" in reason.lower():
             return True
-    # Fall back to a message sniff for RuntimeError wrappers from lib.client.
+
+    # Fall back to a message sniff for RuntimeError wrappers from lib.client
+    # (non-HTTP failures — the HTTP-wrapper shape was ruled out above).
     return "timed out" in str(exc).lower()
 
 
@@ -559,13 +584,15 @@ def _write_recall_log(entry: dict) -> None:
         # under the cap and the trim path is a no-op.
         with open(log_path, "a", encoding="utf-8") as f:
             f.write(line)
-        # Cheap rolling trim every ~50 writes (estimated by file size
-        # vs. 200 bytes/line average) to amortize the read cost.
+        # Size-gated trim: only pay the full-file read when the byte size
+        # says we plausibly exceed the line cap. The estimate is a per-line
+        # UPPER bound (see RECALL_LOG_BYTES_PER_LINE_EST) so we don't read on
+        # every hook once rows grew past the old 200 B/line assumption.
         try:
             size = os.path.getsize(log_path)
         except OSError:
             return
-        if size > RECALL_LOG_MAX_LINES * 250:
+        if size > RECALL_LOG_MAX_LINES * RECALL_LOG_BYTES_PER_LINE_EST:
             try:
                 with open(log_path, "r", encoding="utf-8") as f:
                     lines = f.readlines()
@@ -996,10 +1023,15 @@ def main():
                 # A3 stage-1 telemetry keys kept present for a uniformly
                 # queryable schema; a cache hit issues no bank HTTP, so there
                 # is no per-bank timing and no deadline pressure to record.
+                # All are None/[] (NOT False) so a cache-hit row is never
+                # miscounted as an observed no-timeout recall in the breach
+                # baseline — `deadline_hit is False` means "banks ran, none
+                # timed out"; `deadline_hit is None` means "no banks ran"
+                # (review finding 3).
                 "total_elapsed_ms": None,
                 "directives_elapsed_ms": None,
                 "bank_timings": [],
-                "deadline_hit": False,
+                "deadline_hit": None,
                 # PR6 — record the active topic on cache hits too so the
                 # log is uniformly queryable (cache_key now includes
                 # active_thread_id, so a hit means the prior recall was
@@ -1301,6 +1333,77 @@ def main():
     if placeholder_chat_id:
         update_placeholder(placeholder_chat_id, "💭 thinking")
 
+    # Switchroom #432 phase 4.3 — telemetry log. memory IDs (when
+    # available) let an operator confirm what was injected on a given turn.
+    # Failure-tolerant.
+    #
+    # Hoisted ABOVE the empty-block early-return (hindsight-leverage PR 1,
+    # review finding 1): a turn where every bank times out AND directives
+    # fail produces no directives_block and no memories_block — precisely the
+    # breach event the A3 baseline counts. Logging here (not after the return)
+    # guarantees every cache-MISS recall attempt records bank_timings /
+    # deadline_hit / total_elapsed_ms.
+    #
+    # NOTE on the PR-3 baseline denominator (review finding 2): a hook the
+    # Claude Code UserPromptSubmit ceiling *kills* mid-flight (sequential
+    # worst case ~18s > the 12s ceiling) never reaches this line, so a true
+    # ceiling breach manifests as a MISSING row, not a logged one. The
+    # baseline method is therefore two-signal: (a) ceiling-breach (total-drop)
+    # rate = recall-log rows-missing vs the UserPromptSubmit turn count over
+    # the window; (b) `deadline_hit` here = per-bank hard-timeout among the
+    # hooks that survived long enough to log. Neither number alone is the
+    # breach rate; PR 3's before/after must cite both.
+    _write_recall_log({
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "session_id": (session_id or "")[:32],
+        "bank_id": bank_id,
+        "additional_banks": additional_banks,
+        "query_chars": len(query),
+        # Switchroom A1 (hindsight-leverage PR 1) — a BOUNDED excerpt (≤200
+        # chars, review finding 5) of the envelope-stripped, truncated query
+        # actually sent to recall. Enough to assert no `<channel` substring
+        # reaches the embedding and to pair queries with hits (D2) without
+        # bloating each row (which would thrash the size-based trim below).
+        # `query_chars` above carries the full untruncated length.
+        "query": query[:200],
+        "result_count": len(results),
+        "directive_count": len(directives),
+        "demoted_count": demoted_count,
+        "overlap_dropped": overlap_dropped,
+        "capped": capped,
+        "pre_cap_count": pre_cap_count,
+        "memory_ids": [
+            m.get("id") for m in results
+            if isinstance(m, dict) and m.get("id")
+        ],
+        "cache_hit": False,
+        # Switchroom A3 stage-1 telemetry (hindsight-leverage PR 1) — per-bank
+        # latency + timeout breakdown, directives-fetch latency, total
+        # critical-path wall time, and a derived `deadline_hit` (any bank hit
+        # its hard per-request timeout). Accrues the fresh pre-A3 baseline the
+        # parallelism change measures against; the 17-26% figure it replaces is
+        # the stale 2026-05-24 pre-fix audit.
+        "total_elapsed_ms": int((time.monotonic() - recall_start_monotonic) * 1000),
+        "directives_elapsed_ms": directives_elapsed_ms,
+        "bank_timings": bank_timings,
+        "deadline_hit": any(bt["timed_out"] for bt in bank_timings),
+        # PR6 — instrumentation for binding-failure analysis.
+        # `active_thread_id`: the current prompt's topic (null on
+        # DM / fleet-shared). `source_topics`: distribution of
+        # source thread_ids in the recall set (before optional
+        # hard-filter). `topic_filter_mode`: "soft-preamble" or
+        # "hard-filter". `topic_dropped`: count dropped by hard
+        # filter. From these fields we can derive the cross-topic
+        # recall rate over time and decide whether to flip to
+        # hard-filter mode based on real data.
+        "active_thread_id": active_thread_id,
+        "active_topic_alias": active_topic_alias,
+        "source_topics": source_topic_summary,
+        "topic_filter_mode": topic_filter_mode,
+        "topic_dropped": topic_dropped,
+        "directive_nudge": bool(nudge_block),
+    })
+
     # If neither block has content, there's nothing to inject — exit
     # silently to avoid emitting an empty hookSpecificOutput. #2848: unless
     # the directive-capture nudge fired, in which case emit the nudge alone
@@ -1339,57 +1442,8 @@ def main():
         except Exception as e:
             debug_log(config, f"Recall cache write failed (non-fatal): {e}")
 
-    # Switchroom #432 phase 4.3 — telemetry log. memory IDs (when
-    # available) let an operator confirm what was injected on a given
-    # turn. Failure-tolerant.
-    _write_recall_log({
-        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "session_id": (session_id or "")[:32],
-        "bank_id": bank_id,
-        "additional_banks": additional_banks,
-        "query_chars": len(query),
-        # Switchroom A1 (hindsight-leverage PR 1) — the envelope-stripped,
-        # truncated query text actually sent to recall. Persisted so the
-        # query-hygiene acceptance check can assert no `<channel` substring
-        # ever reaches the embedding, and so D2 can pair queries with hits.
-        "query": query,
-        "result_count": len(results),
-        "directive_count": len(directives),
-        "demoted_count": demoted_count,
-        "overlap_dropped": overlap_dropped,
-        "capped": capped,
-        "pre_cap_count": pre_cap_count,
-        "memory_ids": [
-            m.get("id") for m in results
-            if isinstance(m, dict) and m.get("id")
-        ],
-        "cache_hit": False,
-        # Switchroom A3 stage-1 telemetry (hindsight-leverage PR 1) — per-bank
-        # latency + timeout breakdown, directives-fetch latency, total
-        # critical-path wall time, and a derived `deadline_hit` (any bank hit
-        # its hard per-request timeout). Accrues the fresh pre-A3 baseline the
-        # parallelism change measures against; the 17-26% figure it replaces is
-        # the stale 2026-05-24 pre-fix audit.
-        "total_elapsed_ms": int((time.monotonic() - recall_start_monotonic) * 1000),
-        "directives_elapsed_ms": directives_elapsed_ms,
-        "bank_timings": bank_timings,
-        "deadline_hit": any(bt["timed_out"] for bt in bank_timings),
-        # PR6 — instrumentation for binding-failure analysis.
-        # `active_thread_id`: the current prompt's topic (null on
-        # DM / fleet-shared). `source_topics`: distribution of
-        # source thread_ids in the recall set (before optional
-        # hard-filter). `topic_filter_mode`: "soft-preamble" or
-        # "hard-filter". `topic_dropped`: count dropped by hard
-        # filter. From these fields we can derive the cross-topic
-        # recall rate over time and decide whether to flip to
-        # hard-filter mode based on real data.
-        "active_thread_id": active_thread_id,
-        "active_topic_alias": active_topic_alias,
-        "source_topics": source_topic_summary,
-        "topic_filter_mode": topic_filter_mode,
-        "topic_dropped": topic_dropped,
-        "directive_nudge": bool(nudge_block),
-    })
+    # (Telemetry log already written above, before the empty-block return, so
+    # total-failure turns are recorded — hindsight-leverage PR 1 finding 1.)
 
     # Output JSON for Claude Code hook system. #2848: append the
     # directive-capture nudge (if it fired) at emit time — it's kept out of

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -43,8 +43,10 @@ import hashlib
 import json
 import os
 import re
+import socket
 import sys
 import time
+import urllib.error
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -55,6 +57,7 @@ from lib.content import (
     compose_recall_query,
     format_current_time,
     format_memories,
+    strip_channel_envelope,
     truncate_recall_query,
 )
 from lib.daemon import get_api_url
@@ -509,6 +512,31 @@ def _sort_by_final_score(results):
     return results
 
 
+def _is_timeout_error(exc: BaseException) -> bool:
+    """True if `exc` is (or wraps) a network read/connect timeout.
+
+    Switchroom A3 stage-1 telemetry (hindsight-leverage PR 1). The recall
+    HTTP path is `urllib.request.urlopen(..., timeout=8)`. On a hard timeout
+    urlopen raises either a bare ``socket.timeout`` / ``TimeoutError`` or a
+    ``urllib.error.URLError`` whose ``.reason`` is one of those. We classify
+    both so the per-bank ``timed_out`` flag (and the derived ``deadline_hit``)
+    distinguishes a bank that hit its deadline from one that failed fast
+    (5xx, connection refused, malformed response). Best-effort: anything we
+    can't positively identify as a timeout is treated as a non-timeout error.
+    """
+    if isinstance(exc, (socket.timeout, TimeoutError)):
+        return True
+    if isinstance(exc, urllib.error.URLError):
+        reason = getattr(exc, "reason", None)
+        if isinstance(reason, (socket.timeout, TimeoutError)):
+            return True
+        # Some stdlib versions stringify the timeout into the reason.
+        if isinstance(reason, str) and "timed out" in reason.lower():
+            return True
+    # Fall back to a message sniff for RuntimeError wrappers from lib.client.
+    return "timed out" in str(exc).lower()
+
+
 def _write_recall_log(entry: dict) -> None:
     """Append a JSONL line to recall_log.jsonl. Bounded by line count.
 
@@ -959,11 +987,19 @@ def main():
                 "bank_id": bank_id,
                 "additional_banks": additional_banks,
                 "query_chars": len(prompt),
+                "query": None,  # no recall query composed on a cache hit
                 "result_count": None,  # not known on cache hit
                 "directive_count": None,
                 "demoted_count": 0,
                 "capped": False,
                 "cache_hit": True,
+                # A3 stage-1 telemetry keys kept present for a uniformly
+                # queryable schema; a cache hit issues no bank HTTP, so there
+                # is no per-bank timing and no deadline pressure to record.
+                "total_elapsed_ms": None,
+                "directives_elapsed_ms": None,
+                "bank_timings": [],
+                "deadline_hit": False,
                 # PR6 — record the active topic on cache hits too so the
                 # log is uniformly queryable (cache_key now includes
                 # active_thread_id, so a hit means the prior recall was
@@ -976,6 +1012,12 @@ def main():
             return
         debug_log(config, f"Recall cache MISS (key={cache_key[:12]}…)")
 
+    # Switchroom A3 stage-1 telemetry (hindsight-leverage PR 1). Wall-clock
+    # start for the recall critical path (mission ensure + transcript read +
+    # directives fetch + every bank recall). Feeds `total_elapsed_ms` in the
+    # log so a fresh pre-parallelism (pre-A3) breach baseline can accrue.
+    recall_start_monotonic = time.monotonic()
+
     # Set bank mission on first use
     ensure_bank_mission(client, bank_id, config, debug_fn=_dbg)
 
@@ -984,15 +1026,26 @@ def main():
     recall_max_query_chars = config.get("recallMaxQueryChars", 800)
     recall_roles = config.get("recallRoles", ["user", "assistant"])
 
+    # Switchroom A1 (hindsight-leverage PR 1) — strip the <channel …> transport
+    # envelope from the prompt ONCE, before both the single-turn and multi-turn
+    # branches, so ~100-200 chars of chat_id/ts/user XML noise never reach the
+    # embedding or consume the recallMaxQueryChars cap. `prompt` itself is left
+    # untouched (the ack/nudge gates and cache-hit log-length field still want
+    # the raw form); only the value fed to the recall query is stripped.
+    # compose_recall_query also strips its latest_query internally (defence in
+    # depth), but we strip here too so the single-turn path and
+    # truncate_recall_query's latest_query arg are both envelope-free.
+    recall_query_text = strip_channel_envelope(prompt)
+
     if recall_context_turns > 1:
         transcript_path = hook_input.get("transcript_path", "")
         messages = read_transcript_messages(transcript_path)
         debug_log(config, f"Multi-turn context: {recall_context_turns} turns, {len(messages)} messages from transcript")
-        query = compose_recall_query(prompt, messages, recall_context_turns, recall_roles)
+        query = compose_recall_query(recall_query_text, messages, recall_context_turns, recall_roles)
     else:
-        query = prompt
+        query = recall_query_text
 
-    query = truncate_recall_query(query, prompt, recall_max_query_chars)
+    query = truncate_recall_query(query, recall_query_text, recall_max_query_chars)
 
     # Final defensive cap (mirrors Openclaw)
     if len(query) > recall_max_query_chars:
@@ -1007,13 +1060,23 @@ def main():
     # `reflect`); `list_directives` itself works correctly upstream, so this
     # is a pure client-side surface. fetch_active_directives is failure-safe
     # and returns [] on any error.
+    _directives_start = time.monotonic()
     directives = fetch_active_directives(client, bank_id)
+    directives_elapsed_ms = int((time.monotonic() - _directives_start) * 1000)
     directives_block = format_active_directives_block(directives) if directives else None
     if directives_block:
         debug_log(config, f"Injecting {len(directives)} active directives")
 
     # Call Hindsight recall API
+    #
+    # Switchroom A3 stage-1 telemetry — per-bank timing + timeout flag.
+    # `bank_timings` accumulates one record per bank queried (own bank first,
+    # then each additional bank) so the log carries a per-bank latency and
+    # deadline-hit breakdown ahead of the A3 parallelism change.
+    bank_timings = []
     results = []
+    _own_bank_start = time.monotonic()
+    _own_bank_timed_out = False
     try:
         response = client.recall(
             bank_id=bank_id,
@@ -1043,10 +1106,16 @@ def main():
         )
         results = response.get("results", [])
     except Exception as e:
+        _own_bank_timed_out = _is_timeout_error(e)
         print(f"[Hindsight] Recall failed: {e}", file=sys.stderr)
         # Fall through — we still want to emit the directives block if we
         # have one, so a recall API failure doesn't blind the agent to
         # its own active directives.
+    bank_timings.append({
+        "bank_id": bank_id,
+        "elapsed_ms": int((time.monotonic() - _own_bank_start) * 1000),
+        "timed_out": _own_bank_timed_out,
+    })
 
     # Also recall from any additional banks (e.g. shared user profile bank).
     # `additional_banks` was already extracted above the cache check so the
@@ -1066,6 +1135,8 @@ def main():
             "recallTagsMatch",
             tags_match if extra_tags or extra_tag_groups else None,
         )
+        _extra_start = time.monotonic()
+        _extra_timed_out = False
         try:
             extra_response = client.recall(
                 bank_id=extra_bank_id,
@@ -1095,7 +1166,13 @@ def main():
                 debug_log(config, f"Got {len(extra_results)} memories from additional bank '{extra_bank_id}'")
                 results = results + extra_results
         except Exception as e:
+            _extra_timed_out = _is_timeout_error(e)
             debug_log(config, f"Recall from additional bank '{extra_bank_id}' failed: {e}")
+        bank_timings.append({
+            "bank_id": extra_bank_id,
+            "elapsed_ms": int((time.monotonic() - _extra_start) * 1000),
+            "timed_out": _extra_timed_out,
+        })
 
     # Switchroom #432 phase 4.4 — drop demote-tagged memories before
     # the cap. Filtering early means the cap kicks in over the
@@ -1271,6 +1348,11 @@ def main():
         "bank_id": bank_id,
         "additional_banks": additional_banks,
         "query_chars": len(query),
+        # Switchroom A1 (hindsight-leverage PR 1) — the envelope-stripped,
+        # truncated query text actually sent to recall. Persisted so the
+        # query-hygiene acceptance check can assert no `<channel` substring
+        # ever reaches the embedding, and so D2 can pair queries with hits.
+        "query": query,
         "result_count": len(results),
         "directive_count": len(directives),
         "demoted_count": demoted_count,
@@ -1282,6 +1364,16 @@ def main():
             if isinstance(m, dict) and m.get("id")
         ],
         "cache_hit": False,
+        # Switchroom A3 stage-1 telemetry (hindsight-leverage PR 1) — per-bank
+        # latency + timeout breakdown, directives-fetch latency, total
+        # critical-path wall time, and a derived `deadline_hit` (any bank hit
+        # its hard per-request timeout). Accrues the fresh pre-A3 baseline the
+        # parallelism change measures against; the 17-26% figure it replaces is
+        # the stale 2026-05-24 pre-fix audit.
+        "total_elapsed_ms": int((time.monotonic() - recall_start_monotonic) * 1000),
+        "directives_elapsed_ms": directives_elapsed_ms,
+        "bank_timings": bank_timings,
+        "deadline_hit": any(bt["timed_out"] for bt in bank_timings),
         # PR6 — instrumentation for binding-failure analysis.
         # `active_thread_id`: the current prompt's topic (null on
         # DM / fleet-shared). `source_topics`: distribution of

--- a/vendor/hindsight-memory/scripts/tests/test_recall_envelope_strip_telemetry.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_envelope_strip_telemetry.py
@@ -37,7 +37,7 @@ if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
 import recall  # noqa: E402
-from lib.content import compose_recall_query  # noqa: E402
+from lib.content import compose_recall_query, strip_channel_envelope  # noqa: E402
 
 
 def _memory(text, mem_type="fact", mentioned_at="2026-01-01", mem_id=None):
@@ -317,6 +317,104 @@ class RecallTelemetryFields(_LogTestBase):
         self.assertFalse(timings["shared-bank"]["timed_out"])
 
 
+class TotalFailureStillLogs(_LogTestBase):
+    """Review finding 1 — a turn where every bank times out AND directives
+    are empty produces no injected block, yet the telemetry row (the exact
+    breach event the baseline counts) must still be written."""
+
+    def test_own_bank_timeout_no_directives_still_writes_row(self):
+        client = _RecordingClient(
+            memories=[],
+            directives=[],
+            bank_behaviour={"test-bank": socket.timeout("timed out")},
+        )
+        ctx, raw = _run_main_with(client, prompt=BARE)
+        # No block injected (no directives, no memories).
+        self.assertIsNone(ctx)
+        self.assertEqual(raw.strip(), "")
+        # …but the telemetry row exists and records the deadline hit.
+        entries = self._read_log()
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertFalse(e["cache_hit"])
+        self.assertTrue(e["deadline_hit"])
+        self.assertEqual(e["result_count"], 0)
+        self.assertEqual(len(e["bank_timings"]), 1)
+        self.assertTrue(e["bank_timings"][0]["timed_out"])
+        self.assertIsInstance(e["total_elapsed_ms"], int)
+
+    def test_query_field_is_bounded_excerpt(self):
+        # Review finding 5 — the stored query is a bounded excerpt (≤200)
+        # even when the real query is long; query_chars keeps the full length.
+        long_tail = "auth flow " * 200  # ~2000 chars, well over the 800 cap
+        client = _RecordingClient(memories=[_memory("m", mem_id="m1")])
+        _run_main_with(client, prompt="decide " + long_tail)
+        e = self._read_log()[0]
+        self.assertLessEqual(len(e["query"]), 200)
+        # Full (post-truncation) length is still recorded separately.
+        self.assertGreater(e["query_chars"], 200)
+
+
+class CacheHitRowSchema(_LogTestBase):
+    """Review finding 3 — a cache-hit row carries the telemetry keys as
+    None/[] (no banks ran), never `deadline_hit: False`."""
+
+    def test_cache_hit_row_has_none_telemetry(self):
+        client = _RecordingClient(memories=[_memory("unused")])
+        with patch.object(recall, "_cache_ttl_secs", return_value=300), patch.object(
+            recall, "_cache_lookup", return_value="cached context block"
+        ):
+            _run_main_with(client, prompt=BARE)
+        # The cache hit returns before any client.recall call.
+        self.assertEqual(client.queries, [])
+        entries = self._read_log()
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertTrue(e["cache_hit"])
+        self.assertIsNone(e["deadline_hit"])
+        self.assertEqual(e["bank_timings"], [])
+        self.assertIsNone(e["total_elapsed_ms"])
+        self.assertIsNone(e["directives_elapsed_ms"])
+        self.assertIsNone(e["query"])
+
+
+class MultiEnvelopeStrip(unittest.TestCase):
+    """Review finding 6 — strip_channel_envelope now sits on the live query
+    path, so a coalesced multi-envelope prompt must keep every inner text,
+    not just the first."""
+
+    def test_single_envelope_unchanged(self):
+        self.assertEqual(
+            strip_channel_envelope('<channel source="telegram">hello there</channel>'),
+            "hello there",
+        )
+
+    def test_bare_text_unchanged(self):
+        self.assertEqual(strip_channel_envelope("no envelope here"), "no envelope here")
+
+    def test_two_envelopes_are_coalesced(self):
+        content = (
+            '<channel source="telegram" chat_id="1">first message</channel>'
+            '<channel source="telegram" chat_id="1">second message</channel>'
+        )
+        out = strip_channel_envelope(content)
+        self.assertIn("first message", out)
+        self.assertIn("second message", out)
+        self.assertNotIn("<channel", out)
+        self.assertNotIn("chat_id", out)
+
+    def test_three_envelopes_with_interleaved_whitespace(self):
+        content = (
+            '<channel source="telegram">alpha</channel>\n'
+            '<channel source="telegram">beta</channel>\n'
+            '<channel source="telegram">gamma</channel>'
+        )
+        out = strip_channel_envelope(content)
+        for tok in ("alpha", "beta", "gamma"):
+            self.assertIn(tok, out)
+        self.assertNotIn("<channel", out)
+
+
 class TimeoutClassifier(unittest.TestCase):
     """Unit coverage for _is_timeout_error's classification."""
 
@@ -340,6 +438,33 @@ class TimeoutClassifier(unittest.TestCase):
 
     def test_connection_refused_is_not_timeout(self):
         self.assertFalse(recall._is_timeout_error(ConnectionRefusedError("refused")))
+
+    def test_http_504_wrapper_with_timed_out_body_is_not_timeout(self):
+        # Review finding 4 — lib.client wraps HTTP errors as
+        # `RuntimeError("HTTP <code> from <url>: <body>")`. A 502/504 body
+        # containing an upstream proxy's "timed out" text is a SERVER status,
+        # not a client-side read deadline.
+        self.assertFalse(
+            recall._is_timeout_error(
+                RuntimeError("HTTP 504 from http://h/recall: upstream request timed out")
+            )
+        )
+
+    def test_direct_httperror_is_not_timeout(self):
+        import urllib.error
+        exc = urllib.error.HTTPError(
+            url="http://h/recall", code=504, msg="Gateway Timeout", hdrs=None, fp=None
+        )
+        self.assertFalse(recall._is_timeout_error(exc))
+
+    def test_runtimeerror_causing_httperror_is_not_timeout(self):
+        import urllib.error
+        http = urllib.error.HTTPError(
+            url="http://h/recall", code=502, msg="Bad Gateway", hdrs=None, fp=None
+        )
+        wrapper = RuntimeError("wrapped: connection timed out")
+        wrapper.__cause__ = http
+        self.assertFalse(recall._is_timeout_error(wrapper))
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/tests/test_recall_envelope_strip_telemetry.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_envelope_strip_telemetry.py
@@ -1,0 +1,346 @@
+"""Switchroom hindsight-leverage PR 1 (workstream A1 + A3 stage-1 telemetry).
+
+Two single-concern guarantees:
+
+  1. Query hygiene — the ``<channel …>`` transport envelope is stripped from
+     the recall query on BOTH the single-turn and the multi-turn (composed)
+     paths, so ~100-200 chars of chat_id/ts/user XML noise never reach the
+     embedding or consume the recallMaxQueryChars cap. The stripped query is
+     the one recorded in ``recall_log.jsonl`` (acceptance: no ``<channel``
+     substring in the logged query). The multi-turn fixture is a regression
+     guard for the future ``recallContextTurns`` default flip (A2): it locks
+     in that the composed query — both its "Prior context:" lines and its
+     trailing latest-query segment — is envelope-free.
+
+  2. Telemetry — every non-cache recall log carries per-bank latency +
+     timeout flags, directives-fetch latency, total critical-path wall time,
+     and a derived ``deadline_hit`` (any bank hit its hard per-request
+     timeout). This is the A3 stage-1 baseline instrumentation, landed ahead
+     of the parallelism change so a fresh pre-A3 breach baseline can accrue.
+
+Stdlib-only (unittest + mock); runs under ``python3 -m unittest discover
+tests/``. Mirrors the harness in ``test_recall_integration.py``.
+"""
+
+import io
+import json
+import os
+import socket
+import sys
+import tempfile
+import shutil
+import unittest
+from unittest.mock import patch
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import recall  # noqa: E402
+from lib.content import compose_recall_query  # noqa: E402
+
+
+def _memory(text, mem_type="fact", mentioned_at="2026-01-01", mem_id=None):
+    out = {"text": text, "type": mem_type, "mentioned_at": mentioned_at}
+    if mem_id is not None:
+        out["id"] = mem_id
+    return out
+
+
+class _RecordingClient:
+    """Fake HindsightClient that records the exact `query` passed to recall().
+
+    Per-bank behaviour (results / exception) is configurable so a bank can be
+    made to raise a timeout for the telemetry tests.
+    """
+
+    def __init__(self, memories=None, directives=None, bank_behaviour=None):
+        self._memories = memories if memories is not None else []
+        self._directives = directives if directives is not None else []
+        # Maps bank_id -> Exception to raise (e.g. a timeout).
+        self._bank_behaviour = bank_behaviour or {}
+        self.queries = []  # every query string passed, in call order
+
+    def list_directives(self, bank_id, active_only=True, timeout=2):
+        return {"items": list(self._directives)}
+
+    def recall(self, bank_id, query, **kwargs):
+        self.queries.append(query)
+        exc = self._bank_behaviour.get(bank_id)
+        if exc is not None:
+            raise exc
+        return {"results": list(self._memories)}
+
+
+def _run_main_with(client, prompt, config_extra=None):
+    """Invoke recall.main with a fake client; capture stdout JSON."""
+    hook_input = {
+        "prompt": prompt,
+        "session_id": "test-session",
+        "transcript_path": "",
+        "cwd": "/tmp",
+    }
+    config = {
+        "autoRecall": True,
+        "bankId": "test-bank",
+        "recallMaxTokens": 1024,
+        "recallBudget": "mid",
+        "recallContextTurns": 1,
+        "recallMaxQueryChars": 800,
+        "recallPromptPreamble": "",
+    }
+    if config_extra:
+        config.update(config_extra)
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with patch.object(recall, "load_config", return_value=config), patch.object(
+        recall, "get_api_url", return_value="http://localhost:18888"
+    ), patch.object(recall, "HindsightClient", return_value=client), patch.object(
+        recall, "ensure_bank_mission", return_value=None
+    ), patch.object(recall, "write_state", return_value=None), patch(
+        "sys.stdin", new=io.StringIO(json.dumps(hook_input))
+    ), patch("sys.stdout", new=stdout), patch("sys.stderr", new=stderr):
+        recall.main()
+
+    raw = stdout.getvalue()
+    if not raw.strip():
+        return None, raw
+    parsed = json.loads(raw)
+    return parsed["hookSpecificOutput"]["additionalContext"], raw
+
+
+WRAPPED = (
+    '<channel source="switchroom-telegram" chat_id="1000000001" '
+    'message_id="42" user="testuser" ts="2026-07-20T10:00:00Z">'
+    "what did we decide about the auth flow</channel>"
+)
+BARE = "what did we decide about the auth flow"
+
+
+class SingleTurnEnvelopeStrip(unittest.TestCase):
+    """The single-turn recall query must be the envelope-free inner text —
+    identical to what a bare (unwrapped) prompt produces."""
+
+    def test_wrapped_and_bare_produce_identical_query(self):
+        wrapped_client = _RecordingClient(memories=[_memory("m")])
+        bare_client = _RecordingClient(memories=[_memory("m")])
+        _run_main_with(wrapped_client, prompt=WRAPPED)
+        _run_main_with(bare_client, prompt=BARE)
+        self.assertEqual(len(wrapped_client.queries), 1)
+        self.assertEqual(len(bare_client.queries), 1)
+        self.assertEqual(wrapped_client.queries[0], bare_client.queries[0])
+        self.assertEqual(wrapped_client.queries[0], BARE)
+
+    def test_no_channel_substring_or_attrs_in_query(self):
+        client = _RecordingClient(memories=[_memory("m")])
+        _run_main_with(client, prompt=WRAPPED)
+        q = client.queries[0]
+        self.assertNotIn("<channel", q)
+        self.assertNotIn("chat_id", q)
+        self.assertNotIn("1000000001", q)
+        self.assertNotIn("ts=", q)
+
+
+class MultiTurnComposedEnvelopeStrip(unittest.TestCase):
+    """Regression guard for the future recallContextTurns default flip (A2):
+    the composed multi-turn query must be envelope-free in BOTH the trailing
+    latest-query segment and the "Prior context:" lines."""
+
+    def test_composed_query_helper_strips_wrapped_latest(self):
+        # compose_recall_query is called directly here (the helper must be
+        # safe for any future caller, per A1). A wrapped latest query and a
+        # wrapped prior user turn must both be stripped.
+        messages = [
+            {"role": "user", "content": '<channel source="telegram" chat_id="9">'
+                                         "we were discussing the auth flow</channel>"},
+            {"role": "assistant", "content": "right, the OAuth refresh path"},
+        ]
+        composed = compose_recall_query(WRAPPED, messages, recall_context_turns=2)
+        self.assertNotIn("<channel", composed)
+        self.assertNotIn("chat_id", composed)
+        self.assertIn("Prior context:", composed)
+        # Trailing latest-query segment is the bare text.
+        self.assertTrue(composed.rstrip().endswith(BARE))
+        # Prior user turn text survives, stripped.
+        self.assertIn("we were discussing the auth flow", composed)
+
+    def test_composed_query_via_main_has_no_channel(self):
+        # End-to-end through main() with recallContextTurns=2 and a transcript
+        # on disk whose latest user turn is wrapped.
+        tmpdir = tempfile.mkdtemp(prefix="recall-transcript-")
+        try:
+            transcript = os.path.join(tmpdir, "t.jsonl")
+            rows = [
+                {"type": "user", "message": {"role": "user",
+                 "content": "earlier i mentioned the ORCHID database"}},
+                {"type": "assistant", "message": {"role": "assistant",
+                 "content": "noted, ORCHID_PRIMARY"}},
+                {"type": "user", "message": {"role": "user", "content": WRAPPED}},
+            ]
+            with open(transcript, "w", encoding="utf-8") as f:
+                for r in rows:
+                    f.write(json.dumps(r) + "\n")
+
+            client = _RecordingClient(memories=[_memory("m")])
+            hook_input = {
+                "prompt": WRAPPED,
+                "session_id": "test-session",
+                "transcript_path": transcript,
+                "cwd": "/tmp",
+            }
+            config = {
+                "autoRecall": True,
+                "bankId": "test-bank",
+                "recallMaxTokens": 1024,
+                "recallBudget": "mid",
+                "recallContextTurns": 2,
+                "recallMaxQueryChars": 800,
+                "recallPromptPreamble": "",
+            }
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with patch.object(recall, "load_config", return_value=config), patch.object(
+                recall, "get_api_url", return_value="http://localhost:18888"
+            ), patch.object(recall, "HindsightClient", return_value=client), patch.object(
+                recall, "ensure_bank_mission", return_value=None
+            ), patch.object(recall, "write_state", return_value=None), patch(
+                "sys.stdin", new=io.StringIO(json.dumps(hook_input))
+            ), patch("sys.stdout", new=stdout), patch("sys.stderr", new=stderr):
+                recall.main()
+
+            self.assertEqual(len(client.queries), 1)
+            q = client.queries[0]
+            self.assertNotIn("<channel", q)
+            self.assertNotIn("chat_id", q)
+            self.assertIn("Prior context:", q)
+            self.assertTrue(q.rstrip().endswith(BARE))
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class _LogTestBase(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="recall-log-test-")
+        self._prev = os.environ.get("CLAUDE_PLUGIN_DATA")
+        os.environ["CLAUDE_PLUGIN_DATA"] = self._tmpdir
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        if self._prev is None:
+            os.environ.pop("CLAUDE_PLUGIN_DATA", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_DATA"] = self._prev
+
+    def _read_log(self):
+        path = os.path.join(self._tmpdir, "state", "recall_log.jsonl")
+        if not os.path.isfile(path):
+            return []
+        with open(path, encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+
+class StrippedQueryInLog(_LogTestBase):
+    def test_logged_query_has_no_channel_envelope(self):
+        client = _RecordingClient(memories=[_memory("m", mem_id="m1")])
+        _run_main_with(client, prompt=WRAPPED)
+        entries = self._read_log()
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertIn("query", e)
+        self.assertEqual(e["query"], BARE)
+        self.assertNotIn("<channel", e["query"])
+        self.assertNotIn("chat_id", e["query"])
+
+
+class RecallTelemetryFields(_LogTestBase):
+    def test_telemetry_fields_present_on_success(self):
+        client = _RecordingClient(memories=[_memory("m", mem_id="m1")])
+        _run_main_with(client, prompt=BARE)
+        e = self._read_log()[0]
+        self.assertIn("total_elapsed_ms", e)
+        self.assertIsInstance(e["total_elapsed_ms"], int)
+        self.assertGreaterEqual(e["total_elapsed_ms"], 0)
+        self.assertIn("directives_elapsed_ms", e)
+        self.assertIsInstance(e["directives_elapsed_ms"], int)
+        self.assertIn("deadline_hit", e)
+        self.assertFalse(e["deadline_hit"])
+        # One bank timing record for the own bank, no timeout.
+        self.assertIn("bank_timings", e)
+        self.assertEqual(len(e["bank_timings"]), 1)
+        bt = e["bank_timings"][0]
+        self.assertEqual(bt["bank_id"], "test-bank")
+        self.assertFalse(bt["timed_out"])
+        self.assertIsInstance(bt["elapsed_ms"], int)
+
+    def test_additional_bank_gets_its_own_timing_record(self):
+        client = _RecordingClient(memories=[_memory("m", mem_id="m1")])
+        _run_main_with(
+            client,
+            prompt=BARE,
+            config_extra={"recallAdditionalBanks": ["shared-bank"]},
+        )
+        e = self._read_log()[0]
+        banks = [bt["bank_id"] for bt in e["bank_timings"]]
+        self.assertEqual(banks, ["test-bank", "shared-bank"])
+
+    def test_deadline_hit_true_when_a_bank_times_out(self):
+        # Own bank succeeds; the additional bank raises a socket timeout.
+        client = _RecordingClient(
+            memories=[_memory("m", mem_id="m1")],
+            bank_behaviour={"shared-bank": socket.timeout("timed out")},
+        )
+        _run_main_with(
+            client,
+            prompt=BARE,
+            config_extra={"recallAdditionalBanks": ["shared-bank"]},
+        )
+        e = self._read_log()[0]
+        self.assertTrue(e["deadline_hit"])
+        timings = {bt["bank_id"]: bt for bt in e["bank_timings"]}
+        self.assertFalse(timings["test-bank"]["timed_out"])
+        self.assertTrue(timings["shared-bank"]["timed_out"])
+
+    def test_non_timeout_error_is_not_deadline_hit(self):
+        # A 5xx / connection error is an error but NOT a deadline hit.
+        client = _RecordingClient(
+            memories=[_memory("m", mem_id="m1")],
+            bank_behaviour={"shared-bank": RuntimeError("HTTP 503 from server")},
+        )
+        _run_main_with(
+            client,
+            prompt=BARE,
+            config_extra={"recallAdditionalBanks": ["shared-bank"]},
+        )
+        e = self._read_log()[0]
+        self.assertFalse(e["deadline_hit"])
+        timings = {bt["bank_id"]: bt for bt in e["bank_timings"]}
+        self.assertFalse(timings["shared-bank"]["timed_out"])
+
+
+class TimeoutClassifier(unittest.TestCase):
+    """Unit coverage for _is_timeout_error's classification."""
+
+    def test_socket_timeout(self):
+        self.assertTrue(recall._is_timeout_error(socket.timeout("timed out")))
+
+    def test_builtin_timeout_error(self):
+        self.assertTrue(recall._is_timeout_error(TimeoutError("timed out")))
+
+    def test_urlerror_wrapping_timeout(self):
+        import urllib.error
+        self.assertTrue(
+            recall._is_timeout_error(urllib.error.URLError(socket.timeout("timed out")))
+        )
+
+    def test_runtime_error_with_timeout_message(self):
+        self.assertTrue(recall._is_timeout_error(RuntimeError("request timed out after 8s")))
+
+    def test_plain_http_error_is_not_timeout(self):
+        self.assertFalse(recall._is_timeout_error(RuntimeError("HTTP 503 from server")))
+
+    def test_connection_refused_is_not_timeout(self):
+        self.assertFalse(recall._is_timeout_error(ConnectionRefusedError("refused")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR 1 of the hindsight leverage programme (epic #3430; workstream A child #3431). Single concern: **recall query hygiene + observability**. Implements A1 (envelope strip on both query paths) plus the A3 stage-1 telemetry fields (moved forward from PR 3 so a fresh pre-parallelism breach baseline can start accruing ≥3 days before PR 3 merges).

## Problem

- The recall query on the single-turn path re-used the **raw prompt** (`recall.py` `else: query = prompt`), so ~100–200 chars of `chat_id`/`ts`/`user`/`message_id` XML from the `<channel …>` transport envelope entered the embedding and consumed the `recallMaxQueryChars` (800) cap.
- `compose_recall_query` did **not** fix this: it stripped context messages only (`content.py:96-98`) and returned/appended the latest query **raw** (`:83-84`, `:110-115`). So the bug lived on **both** the single-turn and multi-turn paths.
- `recall_log.jsonl` carried no per-bank latency or timeout signal, so there was no way to establish the fresh pre-A3 breach baseline the parallelism change (PR 3) measures against. The oft-quoted 17–26% figure is the stale 2026-05-24 pre-fix audit, not a valid before-number.

## Change

- **`recall.py`** — strip the envelope **once** (`strip_channel_envelope`) before both branches; feed the stripped text to `compose_recall_query`, the single-turn assignment, and `truncate_recall_query`'s `latest_query` arg. The raw `prompt` is left untouched for the ack/nudge gates and the cache-hit log-length field.
- **`content.py`** — `compose_recall_query` strips `latest_query` internally too, so the helper is envelope-safe for any future caller (defence in depth, e.g. the A2 `contextTurns` flip).
- **Telemetry** — each non-cache recall log now carries per-bank `{elapsed_ms, timed_out}`, `directives_elapsed_ms`, `total_elapsed_ms`, and a derived `deadline_hit` (any bank hit its hard per-request timeout). A new `_is_timeout_error` classifier distinguishes a deadline hit from a fast 5xx/refused failure. The stripped query text is recorded in the log so the query-hygiene acceptance check can assert directly.
- Cache-hit log rows carry the same telemetry keys (nulls / empty) for a uniformly queryable schema.

## Acceptance evidence

- **New `tests/test_recall_envelope_strip_telemetry.py` (15 tests):**
  - single-turn wrapped prompt produces a query identical to the bare prompt; no `<channel`/`chat_id`/`ts=` substrings;
  - **multi-turn composed query** (regression guard for the future `contextTurns` flip) has no `<channel` in the `Prior context:` lines or the trailing latest-query segment — both via the helper directly and end-to-end through `main()` with an on-disk transcript;
  - logged query has no envelope (`e["query"] == bare`);
  - telemetry fields present; per-additional-bank timing record; `deadline_hit` **true** on a bank `socket.timeout`, **false** on a `RuntimeError("HTTP 503")`;
  - `_is_timeout_error` unit coverage (socket.timeout / TimeoutError / URLError-wrapped / message-sniff / non-timeout).
- **Scoped suite green:** `python3 -m unittest discover tests/` → **293 passed**.
- **Lint:** `check-no-pii-secrets`, `check-plugin-references`, `check-stale-tool-descriptions`, `check-vault-test-hermeticity` all clean (synthetic `chat_id` used, no operator PII). `tsc`/bun-dependent guards not run locally (Python-only change, no TS touched, deps not installed offline) — CI is the authority there.

## Deviations from the design

- The A1 acceptance requires "the query recorded in `recall_log.jsonl` contains no `<channel`", but the log previously stored only `query_chars` (length). Added an explicit `query` field holding the envelope-stripped, truncated query text so the assertion (and D2's later query↔hit pairing) is possible. Query is already capped at `recallMaxQueryChars` (≤800).
- `deadline_hit` is defined here as "any per-bank hard-timeout" (there is no shared deadline until A3 stage-2); documented inline. Also added `directives_elapsed_ms` since the directives fetch is on the same critical path A3 will parallelise.

Do **not** merge until adversarial review + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)