### PR TITLE
hindsight recall: directives-list TTL cache with in-session invalidation (A4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
   #546 content dedup's case), and a model-regenerated paraphrase is
   indistinguishable from a genuine handback, so delivering is correct. A rare
   duplicate message beats a silent drop.
+- Hindsight recall: cache the active-directives list on the recall critical path
+  with a short TTL (default 120s, `directivesCacheTtlSeconds` /
+  `HINDSIGHT_DIRECTIVES_CACHE_TTL_SECONDS`; 0 disables). `directive_verify.py`
+  (Stop hook) invalidates the cache when the just-ended turn wrote a directive,
+  so in-session create/update/delete is visible on the very next turn; cross-
+  process writes (and sub-agent / Bash-CLI writes with no main-transcript
+  tool_use) are at most TTL stale. Saves the 2s-timeout `list_directives`
+  round-trip on cache-hit turns. (hindsight-leverage A4)
 
 ## v0.19.2 — Hindsight recovery, External spend on /usage, auth-broker hardening, /model carrier doctor
 

--- a/vendor/hindsight-memory/scripts/directive_verify.py
+++ b/vendor/hindsight-memory/scripts/directive_verify.py
@@ -59,6 +59,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from lib.config import debug_log, load_config  # noqa: E402
 from lib.directives import (  # noqa: E402
+    DIRECTIVES_CACHE_TTL_SECONDS,
     invalidate_directives_cache,
     parse_active_directives_block,
     rule_already_captured,
@@ -359,15 +360,18 @@ def turn_contains_directive_write(messages: list, start_index: int) -> bool:
     return False
 
 
-def invalidate_cache_on_directive_write(hook_input: dict, config: dict) -> None:
+def invalidate_cache_on_directive_write(messages: list, config: dict) -> None:
     """Delete the directives cache if this turn wrote a directive.
 
-    Runs independently of the capture-verify decision (and of the
-    directiveCaptureNudge knob) — the cache is a separate feature. Best-effort;
-    never raises, so a bug here can never wedge Stop.
+    Takes the ALREADY-READ transcript ``messages`` (main() reads the transcript
+    exactly once and shares it with the capture verifier — a Stop hook must not
+    parse a multi-MB session twice). Only the tail after the last human turn is
+    scanned, since only writes issued THIS turn matter. Runs independently of
+    the capture-verify decision (and of the directiveCaptureNudge knob) — the
+    cache is a separate feature. Best-effort; never raises, so a bug here can
+    never wedge Stop.
     """
     try:
-        messages = read_transcript(hook_input.get("transcript_path", ""))
         if not messages:
             return
         idx, _text = find_last_human_turn(messages)
@@ -410,11 +414,15 @@ def read_transcript(transcript_path: str) -> list:
     return messages
 
 
-def evaluate(hook_input: dict, config: dict) -> str | None:
+def evaluate(hook_input: dict, config: dict, messages: list | None = None) -> str | None:
     """Core decision. Returns a block reason string, or None to allow stop.
 
     None → the turn is allowed to end (no-op). A non-empty string → block the
     stop once and feed the string back to the model.
+
+    ``messages`` is the pre-read transcript when the caller already parsed it
+    (main() reads once and shares it); when None, the transcript is read here so
+    direct callers/tests keep the old single-arg contract.
     """
     # Same knob as Stage B — disabling the nudge disables this verification.
     if not config.get("directiveCaptureNudge", True):
@@ -433,7 +441,8 @@ def evaluate(hook_input: dict, config: dict) -> str | None:
         debug_log(config, "Directive-capture verify: stop_hook_active, not re-blocking")
         return None
 
-    messages = read_transcript(hook_input.get("transcript_path", ""))
+    if messages is None:
+        messages = read_transcript(hook_input.get("transcript_path", ""))
     if not messages:
         return None
 
@@ -485,13 +494,34 @@ def main():
         config = load_config()
     except Exception:
         return
+
+    # Read the transcript AT MOST ONCE and share it with both consumers below
+    # (a Stop hook must not parse a multi-MB session twice, nor at all when
+    # nothing here needs it). Two features want the transcript:
+    #   * A4 directives-cache invalidation — only when the cache is enabled
+    #     (TTL > 0); with the cache off there is nothing to invalidate.
+    #   * capture-verify (evaluate) — only when the nudge+verify knobs are on
+    #     and this is not an already-blocked re-fire.
+    ttl = config.get("directivesCacheTtlSeconds", DIRECTIVES_CACHE_TTL_SECONDS)
+    cache_on = isinstance(ttl, (int, float)) and ttl > 0
+    verify_maybe = (
+        config.get("directiveCaptureNudge", True)
+        and config.get("directiveCaptureVerify", True)
+        and not hook_input.get("stop_hook_active")
+    )
+
+    messages: list = []
+    if cache_on or verify_maybe:
+        messages = read_transcript(hook_input.get("transcript_path", ""))
+
     # A4: invalidate the directives cache when this turn wrote a directive, so
     # the change is visible on the very next recall. Independent of the
     # capture-verify decision below and self-guarded — runs on every Stop.
-    invalidate_cache_on_directive_write(hook_input, config)
+    if cache_on:
+        invalidate_cache_on_directive_write(messages, config)
 
     try:
-        reason = evaluate(hook_input, config)
+        reason = evaluate(hook_input, config, messages=messages)
     except Exception as e:  # never wedge a turn on a verify bug
         debug_log(config, f"Directive-capture verify error (allowing stop): {e}")
         return

--- a/vendor/hindsight-memory/scripts/directive_verify.py
+++ b/vendor/hindsight-memory/scripts/directive_verify.py
@@ -59,6 +59,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from lib.config import debug_log, load_config  # noqa: E402
 from lib.directives import (  # noqa: E402
+    invalidate_directives_cache,
     parse_active_directives_block,
     rule_already_captured,
 )
@@ -317,6 +318,67 @@ def directive_recorded_after(messages: list, start_index: int) -> bool:
     return False
 
 
+# --- Directives-cache invalidation (switchroom hindsight-leverage A4) ---------
+#
+# recall.py caches the bank's active-directives list with a short TTL to skip an
+# HTTP round-trip on the critical path. That cache would otherwise stay stale
+# until the TTL elapsed — so this Stop hook, which already re-reads the turn's
+# transcript, deletes the cache whenever the just-ended turn performed a
+# directive WRITE (create/update/delete). The next recall then re-fetches, so an
+# in-session directive change is visible in the very next turn's
+# <active_directives> block (cross-process writes still rely on TTL alone).
+
+# Matches the hindsight directive-write MCP tools by their bare or namespaced
+# name, e.g. "create_directive", "mcp__hindsight__update_directive",
+# "delete_directive". Read-only "list_directives" is deliberately excluded.
+_DIRECTIVE_WRITE_TOOL_RE = re.compile(r"(?:create|update|delete)_directive")
+
+
+def _is_directive_write_tool(name) -> bool:
+    return isinstance(name, str) and bool(_DIRECTIVE_WRITE_TOOL_RE.search(name))
+
+
+def turn_contains_directive_write(messages: list, start_index: int) -> bool:
+    """True if any assistant turn after ``start_index`` issued a directive-write
+    tool_use (create/update/delete). ``start_index = -1`` scans all messages
+    (used when there is no human turn, e.g. a synthetic/cron inbound that still
+    wrote a directive). Pure inspection; no API call."""
+    for msg in messages[start_index + 1:]:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for p in content:
+            if (
+                isinstance(p, dict)
+                and p.get("type") == "tool_use"
+                and _is_directive_write_tool(p.get("name", ""))
+            ):
+                return True
+    return False
+
+
+def invalidate_cache_on_directive_write(hook_input: dict, config: dict) -> None:
+    """Delete the directives cache if this turn wrote a directive.
+
+    Runs independently of the capture-verify decision (and of the
+    directiveCaptureNudge knob) — the cache is a separate feature. Best-effort;
+    never raises, so a bug here can never wedge Stop.
+    """
+    try:
+        messages = read_transcript(hook_input.get("transcript_path", ""))
+        if not messages:
+            return
+        idx, _text = find_last_human_turn(messages)
+        start = idx if idx is not None else -1
+        if turn_contains_directive_write(messages, start):
+            invalidate_directives_cache()
+            debug_log(config, "Directives cache invalidated — turn wrote a directive")
+    except Exception as e:  # pragma: no cover - defensive; Stop must not wedge
+        debug_log(config, f"Directives cache invalidation skipped (error): {e}")
+
+
 def read_transcript(transcript_path: str) -> list:
     """Read a JSONL transcript into a list of message dicts (role/content).
 
@@ -423,6 +485,11 @@ def main():
         config = load_config()
     except Exception:
         return
+    # A4: invalidate the directives cache when this turn wrote a directive, so
+    # the change is visible on the very next recall. Independent of the
+    # capture-verify decision below and self-guarded — runs on every Stop.
+    invalidate_cache_on_directive_write(hook_input, config)
+
     try:
         reason = evaluate(hook_input, config)
     except Exception as e:  # never wedge a turn on a verify bug

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -71,6 +71,12 @@ DEFAULTS = {
     # per-agent via memory.directive_capture_verify=false →
     # HINDSIGHT_DIRECTIVE_CAPTURE_VERIFY.
     "directiveCaptureVerify": True,
+    # Switchroom hindsight-leverage A4 — TTL (seconds) for the directives-list
+    # cache on the recall critical path (see lib/directives.py). The list is
+    # re-fetched at most once per TTL window for no-write turns; in-session
+    # directive writes invalidate the cache immediately via directive_verify.py.
+    # 0 disables the cache (live fetch every turn — the A4 rollback lever).
+    "directivesCacheTtlSeconds": 120,
     "recallContextTurns": 1,
     "recallMaxQueryChars": 800,
     "recallRoles": ["user", "assistant"],
@@ -171,6 +177,9 @@ ENV_OVERRIDES = {
     # agents.<name>.memory.directive_capture_verify only when the operator
     # overrode it; the switchroom default is on.
     "HINDSIGHT_DIRECTIVE_CAPTURE_VERIFY": ("directiveCaptureVerify", bool),
+    # Switchroom hindsight-leverage A4 — directives-list cache TTL (seconds).
+    # 0 disables the cache (rollback lever).
+    "HINDSIGHT_DIRECTIVES_CACHE_TTL_SECONDS": ("directivesCacheTtlSeconds", int),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     # Upstream 962140eef — recall tag filters. The tags env var accepts JSON

--- a/vendor/hindsight-memory/scripts/lib/directives.py
+++ b/vendor/hindsight-memory/scripts/lib/directives.py
@@ -45,6 +45,15 @@ DIRECTIVES_TIMEOUT_SECONDS = 2
 #   * Cross-process writes (another session, operator CLI) have no invalidation
 #     channel and rely on TTL alone → at most TTL seconds stale.
 #
+# Invalidation blind spots (both fall back to TTL, ≤ TTL stale — acceptable):
+#   * Sub-agent / sidechain directive writes: the create_directive tool_use is
+#     in the SIDECHAIN transcript, not the parent's, so the parent's Stop hook
+#     (which reads the parent transcript) never sees it. PR 5 (SubagentStop)
+#     is where sidechain awareness lands.
+#   * Bash / operator-CLI directive writes (`switchroom` or a curl) produce no
+#     tool_use in any transcript, so there is nothing for the Stop hook to
+#     detect.
+#
 # Rollback: set the TTL to 0 (HINDSIGHT_DIRECTIVES_CACHE_TTL_SECONDS=0) to
 # disable the cache entirely — every turn fetches live, as before A4.
 DIRECTIVES_CACHE_TTL_SECONDS = 120
@@ -120,9 +129,16 @@ def _read_cache(bank_id: str) -> Optional[dict]:
     additionally reject a non-dict envelope, a non-numeric timestamp, or a
     non-list directive payload) is treated as a MISS so the caller falls back to
     a live fetch rather than injecting garbage.
+
+    Also rejects an envelope whose stored ``bank_id`` does not match the
+    requested one: ``_safe_filename`` can collapse two distinct bank ids onto a
+    single cache file, and serving bank A's directives for bank B would leak
+    rules across banks. The embedded ``bank_id`` is the authoritative key.
     """
     raw = read_state(_cache_name(bank_id), None)
     if not isinstance(raw, dict):
+        return None
+    if raw.get("bank_id") != bank_id:
         return None
     ts = raw.get("ts")
     directives = raw.get("directives")
@@ -160,8 +176,14 @@ def fetch_active_directives_cached(
 
     if caching:
         cached = _read_cache(bank_id)
-        if cached is not None and (now - cached["ts"]) < ttl_seconds:
-            return cached["directives"]
+        if cached is not None:
+            age = now - cached["ts"]
+            # A negative age means the stored timestamp is in the FUTURE
+            # (wall-clock step-back / a doctored envelope) — treat it as
+            # expired rather than "fresh forever", so a clock correction can't
+            # pin a stale cache.
+            if 0 <= age < ttl_seconds:
+                return cached["directives"]
 
     ok, directives = _fetch_directives_with_status(client, bank_id, timeout)
 

--- a/vendor/hindsight-memory/scripts/lib/directives.py
+++ b/vendor/hindsight-memory/scripts/lib/directives.py
@@ -18,7 +18,10 @@ recall path; a directive-fetch failure must not kill the recall block.
 
 import re
 import sys
+import time
 from typing import Optional
+
+from .state import list_state_names, read_state, remove_state, write_state
 
 # Sanity cap on how many directives we ever inject into the prompt. Banks
 # with more active directives than this are pathological; truncate with a
@@ -28,6 +31,69 @@ MAX_DIRECTIVES = 15
 # Hard timeout for the list_directives call. The recall hook is on the
 # UserPromptSubmit critical path — we cannot block it for long.
 DIRECTIVES_TIMEOUT_SECONDS = 2
+
+# --- Directives-list cache (switchroom hindsight-leverage A4) -----------------
+#
+# `list_directives` runs on the recall (UserPromptSubmit) critical path every
+# non-skipped turn — a fresh 2s-timeout HTTP round-trip whose result changes
+# only when a directive is created/updated/deleted (rare). We cache the fetched
+# list in the plugin state dir with a short TTL so the common no-write turn
+# skips the round-trip, while bounding staleness:
+#   * In-session writes: directive_verify.py (Stop hook) deletes the cache when
+#     the just-ended turn contains a create/update/delete_directive tool_use, so
+#     the very next recall re-fetches — the new state is visible in turn N+1.
+#   * Cross-process writes (another session, operator CLI) have no invalidation
+#     channel and rely on TTL alone → at most TTL seconds stale.
+#
+# Rollback: set the TTL to 0 (HINDSIGHT_DIRECTIVES_CACHE_TTL_SECONDS=0) to
+# disable the cache entirely — every turn fetches live, as before A4.
+DIRECTIVES_CACHE_TTL_SECONDS = 120
+
+# All directive cache files share this basename prefix so they can be
+# enumerated for bulk (bank-agnostic) invalidation.
+_CACHE_PREFIX = "directives_cache."
+
+
+def _cache_name(bank_id: str) -> str:
+    """State-file name for a bank's cached directive list."""
+    return f"{_CACHE_PREFIX}{bank_id}.json"
+
+
+def _fetch_directives_with_status(client, bank_id: str, timeout: int) -> tuple:
+    """Fetch + normalize active directives, reporting fetch success.
+
+    Returns ``(ok, directives)``. ``ok`` is False only on a genuine fetch
+    FAILURE (HTTP error, non-dict response) — a bank that simply has no
+    directives returns ``(True, [])``. Callers use ``ok`` to avoid caching a
+    transient failure's empty result (which would mask real directives for a
+    whole TTL window). Never raises; logs a single warn line on failure.
+    """
+    try:
+        response = client.list_directives(bank_id=bank_id, active_only=True, timeout=timeout)
+    except Exception as e:
+        print(f"[Hindsight] list_directives failed for bank '{bank_id}': {e}", file=sys.stderr)
+        return False, []
+
+    if not isinstance(response, dict):
+        print(
+            f"[Hindsight] list_directives returned non-dict for bank '{bank_id}': "
+            f"{type(response).__name__}",
+            file=sys.stderr,
+        )
+        return False, []
+
+    items = response.get("items")
+    if not isinstance(items, list):
+        # Empty / malformed response — quiet success, no warn (banks with
+        # no directives are normal). Cacheable.
+        return True, []
+
+    # Filter to dicts only, then sort by priority descending. Treat missing
+    # priority as 0 so malformed entries sink to the bottom rather than
+    # crashing.
+    valid = [d for d in items if isinstance(d, dict)]
+    valid.sort(key=lambda d: d.get("priority", 0), reverse=True)
+    return True, valid
 
 
 def fetch_active_directives(client, bank_id: str, timeout: int = DIRECTIVES_TIMEOUT_SECONDS) -> list:
@@ -43,32 +109,81 @@ def fetch_active_directives(client, bank_id: str, timeout: int = DIRECTIVES_TIME
         tags, ...), sorted by priority descending. On any failure returns
         an empty list and logs a single warn line to stderr — never raises.
     """
-    try:
-        response = client.list_directives(bank_id=bank_id, active_only=True, timeout=timeout)
-    except Exception as e:
-        print(f"[Hindsight] list_directives failed for bank '{bank_id}': {e}", file=sys.stderr)
-        return []
+    _ok, directives = _fetch_directives_with_status(client, bank_id, timeout)
+    return directives
 
-    if not isinstance(response, dict):
-        print(
-            f"[Hindsight] list_directives returned non-dict for bank '{bank_id}': "
-            f"{type(response).__name__}",
-            file=sys.stderr,
-        )
-        return []
 
-    items = response.get("items")
-    if not isinstance(items, list):
-        # Empty / malformed response — quiet success, no warn (banks with
-        # no directives are normal).
-        return []
+def _read_cache(bank_id: str) -> Optional[dict]:
+    """Read + validate a bank's cache envelope. Returns None on miss/corruption.
 
-    # Filter to dicts only, then sort by priority descending. Treat missing
-    # priority as 0 so malformed entries sink to the bottom rather than
-    # crashing.
-    valid = [d for d in items if isinstance(d, dict)]
-    valid.sort(key=lambda d: d.get("priority", 0), reverse=True)
-    return valid
+    A corrupted or wrong-shaped cache (bad JSON handled by read_state; here we
+    additionally reject a non-dict envelope, a non-numeric timestamp, or a
+    non-list directive payload) is treated as a MISS so the caller falls back to
+    a live fetch rather than injecting garbage.
+    """
+    raw = read_state(_cache_name(bank_id), None)
+    if not isinstance(raw, dict):
+        return None
+    ts = raw.get("ts")
+    directives = raw.get("directives")
+    if not isinstance(ts, (int, float)) or isinstance(ts, bool):
+        return None
+    if not isinstance(directives, list):
+        return None
+    return raw
+
+
+def fetch_active_directives_cached(
+    client,
+    bank_id: str,
+    ttl_seconds: int = DIRECTIVES_CACHE_TTL_SECONDS,
+    timeout: int = DIRECTIVES_TIMEOUT_SECONDS,
+    now: Optional[float] = None,
+) -> list:
+    """Cached wrapper around :func:`fetch_active_directives`.
+
+    On a fresh cache hit (age < ``ttl_seconds``) returns the cached list WITHOUT
+    an HTTP call. On a miss / expiry / corrupted cache, fetches live and, when
+    the fetch SUCCEEDED, writes the cache. A failed fetch is never cached, so a
+    transient error can't mask real directives for a TTL window.
+
+    ``ttl_seconds <= 0`` disables the cache (always live-fetch, never write) —
+    the A4 rollback lever.
+
+    Args:
+        now: Injectable current epoch seconds, for deterministic tests.
+    """
+    if now is None:
+        now = time.time()
+
+    caching = isinstance(ttl_seconds, (int, float)) and ttl_seconds > 0
+
+    if caching:
+        cached = _read_cache(bank_id)
+        if cached is not None and (now - cached["ts"]) < ttl_seconds:
+            return cached["directives"]
+
+    ok, directives = _fetch_directives_with_status(client, bank_id, timeout)
+
+    if caching and ok:
+        write_state(_cache_name(bank_id), {"ts": now, "bank_id": bank_id, "directives": directives})
+
+    return directives
+
+
+def invalidate_directives_cache(bank_id: Optional[str] = None) -> None:
+    """Delete the directives cache so the next recall re-fetches live.
+
+    With ``bank_id`` set, removes just that bank's cache file. With no argument
+    (the Stop-hook invalidation path, which does not resolve the bank), removes
+    EVERY directive cache file — directive writes are rare, so a bank-agnostic
+    sweep is cheap and robust. Best-effort; never raises.
+    """
+    if bank_id is not None:
+        remove_state(_cache_name(bank_id))
+        return
+    for name in list_state_names(_CACHE_PREFIX):
+        remove_state(name)
 
 
 def format_active_directives_block(directives: list, max_directives: int = MAX_DIRECTIVES) -> Optional[str]:

--- a/vendor/hindsight-memory/scripts/lib/state.py
+++ b/vendor/hindsight-memory/scripts/lib/state.py
@@ -82,6 +82,37 @@ def write_state(name: str, data):
             pass
 
 
+def remove_state(name: str) -> None:
+    """Delete a state file if it exists. Best-effort; never raises.
+
+    Name is sanitized through the same path-traversal guard as read/write, so
+    callers cannot escape the state directory.
+    """
+    try:
+        path = _state_file(name)
+    except ValueError:
+        return
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def list_state_names(prefix: str = "") -> list:
+    """List state-file basenames in the state dir, optionally by prefix.
+
+    Returns [] on any error. Used to enumerate a family of cache files (e.g.
+    per-bank directive caches) for bulk invalidation.
+    """
+    try:
+        names = os.listdir(_state_dir())
+    except OSError:
+        return []
+    if prefix:
+        return [n for n in names if n.startswith(prefix)]
+    return names
+
+
 def get_turn_count(session_id: str) -> int:
     """Get the current turn count for a session."""
     turns = read_state("turns.json", {})

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -61,7 +61,11 @@ from lib.content import (
     truncate_recall_query,
 )
 from lib.daemon import get_api_url
-from lib.directives import fetch_active_directives, format_active_directives_block
+from lib.directives import (
+    DIRECTIVES_CACHE_TTL_SECONDS,
+    fetch_active_directives_cached,
+    format_active_directives_block,
+)
 from lib.gateway_ipc import extract_chat_id_from_prompt, extract_topic_from_prompt, extract_user_from_prompt, update_placeholder
 from lib.state import read_state, write_state
 
@@ -1090,10 +1094,21 @@ def main():
     # surfaced every turn). Workaround for upstream bug
     # vectorize-io/hindsight#1269 (tagged directives silently dropped from
     # `reflect`); `list_directives` itself works correctly upstream, so this
-    # is a pure client-side surface. fetch_active_directives is failure-safe
-    # and returns [] on any error.
+    # is a pure client-side surface. fetch_active_directives_cached is
+    # failure-safe and returns [] on any error.
+    #
+    # A4: cache the list with a short TTL (invalidated in-session by
+    # directive_verify.py on a directive write) so the common no-write turn
+    # skips the HTTP round-trip. TTL=0 disables the cache (live every turn).
+    # The A3 timing wrapper below measures the fetch either way — on a cache
+    # HIT directives_elapsed_ms reads ~0 (that is the A4 latency win, not a
+    # telemetry regression).
     _directives_start = time.monotonic()
-    directives = fetch_active_directives(client, bank_id)
+    directives = fetch_active_directives_cached(
+        client,
+        bank_id,
+        ttl_seconds=config.get("directivesCacheTtlSeconds", DIRECTIVES_CACHE_TTL_SECONDS),
+    )
     directives_elapsed_ms = int((time.monotonic() - _directives_start) * 1000)
     directives_block = format_active_directives_block(directives) if directives else None
     if directives_block:

--- a/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
@@ -25,6 +25,7 @@ Stdlib-only.
 import os
 import sys
 import unittest
+import unittest.mock
 
 SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if SCRIPTS_DIR not in sys.path:
@@ -32,11 +33,14 @@ if SCRIPTS_DIR not in sys.path:
 
 from directive_verify import (  # noqa: E402
     _VERIFY_BLOCK_REASON,
+    _is_directive_write_tool,
     directive_recorded_after,
     evaluate,
     find_last_human_turn,
+    invalidate_cache_on_directive_write,
     is_synthetic_inbound,
     looks_like_durable_directive,
+    turn_contains_directive_write,
 )
 from recall import looks_like_standing_rule  # noqa: E402
 
@@ -510,6 +514,123 @@ class TestBlockReason(unittest.TestCase):
         self.assertIn("create_directive", _VERIFY_BLOCK_REASON)
         self.assertIn("one-off", _VERIFY_BLOCK_REASON)
         self.assertIn("<directive_capture_verify>", _VERIFY_BLOCK_REASON)
+
+
+class TestDirectiveWriteDetection(unittest.TestCase):
+    """A4 — the Stop-hook detector that decides whether the just-ended turn
+    wrote a directive (and should therefore invalidate the recall cache)."""
+
+    def test_write_tool_names_recognised(self):
+        for name in (
+            "create_directive",
+            "update_directive",
+            "delete_directive",
+            "mcp__hindsight__create_directive",
+            "mcp__hindsight__update_directive",
+        ):
+            self.assertTrue(_is_directive_write_tool(name), name)
+
+    def test_read_and_unrelated_tools_ignored(self):
+        for name in ("list_directives", "recall", "retain", "reflect", "", None):
+            self.assertFalse(_is_directive_write_tool(name), name)
+
+    def _assistant_tool_use(self, tool_name):
+        return {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t1", "name": tool_name, "input": {}}],
+        }
+
+    def test_turn_with_create_directive_detected(self):
+        messages = [
+            {"role": "user", "content": "From now on call me Ken."},
+            self._assistant_tool_use("mcp__hindsight__create_directive"),
+        ]
+        self.assertTrue(turn_contains_directive_write(messages, 0))
+
+    def test_turn_without_write_not_detected(self):
+        messages = [
+            {"role": "user", "content": "What did we decide?"},
+            self._assistant_tool_use("mcp__hindsight__list_directives"),
+        ]
+        self.assertFalse(turn_contains_directive_write(messages, 0))
+
+    def test_write_before_start_index_ignored(self):
+        # A directive write in a PRIOR turn (before the current human turn) does
+        # not count — only writes after start_index are this turn's.
+        messages = [
+            self._assistant_tool_use("create_directive"),  # prior turn
+            {"role": "user", "content": "Now do something else."},
+            {"role": "assistant", "content": "Sure."},
+        ]
+        self.assertFalse(turn_contains_directive_write(messages, 1))
+
+
+class TestCacheInvalidationHook(unittest.TestCase):
+    """A4 — invalidate_cache_on_directive_write end-to-end: a real transcript
+    containing a directive write deletes a seeded cache file."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._patch = unittest.mock.patch.dict(
+            os.environ, {"CLAUDE_PLUGIN_DATA": self._tmp.name}
+        )
+        self._patch.start()
+        self.addCleanup(self._patch.stop)
+
+    def _write_transcript(self, messages):
+        import json
+        import tempfile
+
+        fd, path = tempfile.mkstemp(suffix=".jsonl")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            for m in messages:
+                f.write(json.dumps({"type": m["role"], "message": m}) + "\n")
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+        return path
+
+    def _seed_cache(self, bank_id="bank1"):
+        from lib.directives import _cache_name
+        from lib.state import read_state, write_state
+
+        write_state(_cache_name(bank_id), {"ts": 1000.0, "bank_id": bank_id, "directives": []})
+        self.assertIsNotNone(read_state(_cache_name(bank_id), None))
+
+    def _cache_present(self, bank_id="bank1"):
+        from lib.directives import _cache_name
+        from lib.state import read_state
+
+        return read_state(_cache_name(bank_id), None) is not None
+
+    def test_directive_write_invalidates_cache(self):
+        self._seed_cache()
+        path = self._write_transcript([
+            {"role": "user", "content": "From now on call me Ken."},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "create_directive", "input": {}}
+                ],
+            },
+        ])
+        invalidate_cache_on_directive_write({"transcript_path": path}, {})
+        self.assertFalse(self._cache_present())
+
+    def test_no_write_leaves_cache_intact(self):
+        self._seed_cache()
+        path = self._write_transcript([
+            {"role": "user", "content": "What's the weather?"},
+            {"role": "assistant", "content": "Sunny."},
+        ])
+        invalidate_cache_on_directive_write({"transcript_path": path}, {})
+        self.assertTrue(self._cache_present())
+
+    def test_missing_transcript_is_noop(self):
+        self._seed_cache()
+        invalidate_cache_on_directive_write({"transcript_path": "/no/such/file"}, {})
+        self.assertTrue(self._cache_present())
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
@@ -580,17 +580,6 @@ class TestCacheInvalidationHook(unittest.TestCase):
         self._patch.start()
         self.addCleanup(self._patch.stop)
 
-    def _write_transcript(self, messages):
-        import json
-        import tempfile
-
-        fd, path = tempfile.mkstemp(suffix=".jsonl")
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            for m in messages:
-                f.write(json.dumps({"type": m["role"], "message": m}) + "\n")
-        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
-        return path
-
     def _seed_cache(self, bank_id="bank1"):
         from lib.directives import _cache_name
         from lib.state import read_state, write_state
@@ -606,7 +595,7 @@ class TestCacheInvalidationHook(unittest.TestCase):
 
     def test_directive_write_invalidates_cache(self):
         self._seed_cache()
-        path = self._write_transcript([
+        messages = [
             {"role": "user", "content": "From now on call me Ken."},
             {
                 "role": "assistant",
@@ -614,23 +603,82 @@ class TestCacheInvalidationHook(unittest.TestCase):
                     {"type": "tool_use", "id": "t1", "name": "create_directive", "input": {}}
                 ],
             },
-        ])
-        invalidate_cache_on_directive_write({"transcript_path": path}, {})
+        ]
+        invalidate_cache_on_directive_write(messages, {})
         self.assertFalse(self._cache_present())
 
     def test_no_write_leaves_cache_intact(self):
         self._seed_cache()
-        path = self._write_transcript([
+        messages = [
             {"role": "user", "content": "What's the weather?"},
             {"role": "assistant", "content": "Sunny."},
-        ])
-        invalidate_cache_on_directive_write({"transcript_path": path}, {})
+        ]
+        invalidate_cache_on_directive_write(messages, {})
         self.assertTrue(self._cache_present())
 
-    def test_missing_transcript_is_noop(self):
+    def test_empty_messages_is_noop(self):
         self._seed_cache()
-        invalidate_cache_on_directive_write({"transcript_path": "/no/such/file"}, {})
+        invalidate_cache_on_directive_write([], {})
         self.assertTrue(self._cache_present())
+
+
+class TestMainSingleTranscriptRead(unittest.TestCase):
+    """A4 finding 2 — main() must parse the transcript AT MOST ONCE (shared by
+    cache-invalidation + capture-verify), and not at all when nothing needs it.
+    A Stop hook on a multi-MB session cannot afford a doubled multi-second
+    parse inside its 10s budget."""
+
+    def _run_main_counting_reads(self, config, stop_hook_active=False):
+        import io
+        import json
+
+        import directive_verify as dv
+
+        calls = {"n": 0}
+
+        def _counting_read(_path):
+            calls["n"] += 1
+            return []
+
+        hook_input = {"transcript_path": "/some/transcript", "stop_hook_active": stop_hook_active}
+        with unittest.mock.patch.object(dv, "read_transcript", side_effect=_counting_read), \
+             unittest.mock.patch.object(dv, "load_config", return_value=config), \
+             unittest.mock.patch("sys.stdin", new=io.StringIO(json.dumps(hook_input))), \
+             unittest.mock.patch("sys.stdout", new=io.StringIO()):
+            dv.main()
+        return calls["n"]
+
+    def test_reads_once_when_cache_and_verify_on(self):
+        n = self._run_main_counting_reads({
+            "directivesCacheTtlSeconds": 120,
+            "directiveCaptureNudge": True,
+            "directiveCaptureVerify": True,
+        })
+        self.assertEqual(n, 1)
+
+    def test_reads_once_when_only_cache_on(self):
+        n = self._run_main_counting_reads({
+            "directivesCacheTtlSeconds": 120,
+            "directiveCaptureNudge": False,
+            "directiveCaptureVerify": False,
+        })
+        self.assertEqual(n, 1)
+
+    def test_reads_once_when_only_verify_on(self):
+        n = self._run_main_counting_reads({
+            "directivesCacheTtlSeconds": 0,
+            "directiveCaptureNudge": True,
+            "directiveCaptureVerify": True,
+        })
+        self.assertEqual(n, 1)
+
+    def test_reads_zero_when_all_disabled(self):
+        n = self._run_main_counting_reads({
+            "directivesCacheTtlSeconds": 0,
+            "directiveCaptureNudge": False,
+            "directiveCaptureVerify": False,
+        })
+        self.assertEqual(n, 0)
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/tests/test_directives.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directives.py
@@ -10,6 +10,7 @@ Run from the repo root:
 
 import os
 import sys
+import tempfile
 import unittest
 from io import StringIO
 from unittest.mock import patch
@@ -20,12 +21,17 @@ if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
 from lib.directives import (  # noqa: E402
+    DIRECTIVES_CACHE_TTL_SECONDS,
     MAX_DIRECTIVES,
+    _cache_name,
     fetch_active_directives,
+    fetch_active_directives_cached,
     format_active_directives_block,
+    invalidate_directives_cache,
     parse_active_directives_block,
     rule_already_captured,
 )
+from lib.state import read_state, write_state  # noqa: E402
 
 
 class _StubClient:
@@ -292,6 +298,154 @@ class TestDirectiveDedup(unittest.TestCase):
                 "capital python quarterly monthly weekly", [directive]
             )
         )
+
+
+class _CountingClient:
+    """List-directives stub that can vary its behaviour per call.
+
+    ``responses`` / ``excs`` are per-call sequences (last value repeats). Counts
+    total calls so a test can assert cache hits saved the HTTP round-trip.
+    """
+
+    def __init__(self, response=None, exc=None):
+        self._response = response
+        self._exc = exc
+        self.calls = 0
+
+    def list_directives(self, bank_id, active_only=True, timeout=2):
+        self.calls += 1
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+class DirectivesCacheTests(unittest.TestCase):
+    """A4 — directives-list cache: hit/miss, TTL expiry, invalidation on write,
+    corrupted-cache fallback. State is isolated to a temp CLAUDE_PLUGIN_DATA."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._env = patch.dict(os.environ, {"CLAUDE_PLUGIN_DATA": self._tmp.name})
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+        self._tmp.cleanup()
+
+    def _resp(self, *names):
+        return {"items": [_directive(n, f"content {n}", priority=5) for n in names]}
+
+    def test_cache_hit_skips_second_http_call(self):
+        # Acceptance (a): two consecutive recalls with no write → exactly one
+        # list_directives call; both return the same content.
+        client = _CountingClient(response=self._resp("alpha"))
+        first = fetch_active_directives_cached(client, "bank1", now=1000.0)
+        second = fetch_active_directives_cached(client, "bank1", now=1000.5)
+        self.assertEqual(client.calls, 1)
+        self.assertEqual([d["name"] for d in first], ["alpha"])
+        self.assertEqual([d["name"] for d in second], ["alpha"])
+
+    def test_cache_miss_when_no_prior_entry(self):
+        client = _CountingClient(response=self._resp("alpha"))
+        result = fetch_active_directives_cached(client, "bank1", now=1000.0)
+        self.assertEqual(client.calls, 1)
+        self.assertEqual([d["name"] for d in result], ["alpha"])
+        # Cache file was written.
+        cached = read_state(_cache_name("bank1"), None)
+        self.assertIsInstance(cached, dict)
+        self.assertEqual(cached["ts"], 1000.0)
+
+    def test_ttl_expiry_refetches(self):
+        client = _CountingClient(response=self._resp("alpha"))
+        fetch_active_directives_cached(client, "bank1", ttl_seconds=120, now=1000.0)
+        # Just inside TTL → hit.
+        fetch_active_directives_cached(client, "bank1", ttl_seconds=120, now=1000.0 + 119)
+        self.assertEqual(client.calls, 1)
+        # Just past TTL → miss → refetch.
+        fetch_active_directives_cached(client, "bank1", ttl_seconds=120, now=1000.0 + 121)
+        self.assertEqual(client.calls, 2)
+
+    def test_ttl_zero_disables_cache(self):
+        # Rollback lever: TTL=0 → live fetch every time, nothing written.
+        client = _CountingClient(response=self._resp("alpha"))
+        fetch_active_directives_cached(client, "bank1", ttl_seconds=0, now=1000.0)
+        fetch_active_directives_cached(client, "bank1", ttl_seconds=0, now=1000.1)
+        self.assertEqual(client.calls, 2)
+        self.assertIsNone(read_state(_cache_name("bank1"), None))
+
+    def test_invalidation_forces_refetch(self):
+        # Acceptance (a) in-session: a directive write invalidates the cache, so
+        # the next recall re-fetches (fresh directive becomes visible).
+        client = _CountingClient(response=self._resp("alpha"))
+        fetch_active_directives_cached(client, "bank1", now=1000.0)
+        self.assertEqual(client.calls, 1)
+        invalidate_directives_cache()  # bank-agnostic sweep (Stop-hook path)
+        fetch_active_directives_cached(client, "bank1", now=1000.1)
+        self.assertEqual(client.calls, 2)
+
+    def test_invalidation_specific_bank_only(self):
+        client = _CountingClient(response=self._resp("alpha"))
+        fetch_active_directives_cached(client, "bankA", now=1000.0)
+        fetch_active_directives_cached(client, "bankB", now=1000.0)
+        self.assertEqual(client.calls, 2)
+        invalidate_directives_cache("bankA")
+        # bankA re-fetches, bankB still served from cache.
+        fetch_active_directives_cached(client, "bankA", now=1000.1)
+        self.assertEqual(client.calls, 3)
+        fetch_active_directives_cached(client, "bankB", now=1000.1)
+        self.assertEqual(client.calls, 3)
+
+    def test_corrupted_cache_falls_back_to_live(self):
+        # A non-JSON cache file → read_state returns default → live fetch.
+        from lib.state import _state_file  # noqa: PLC0415
+
+        path = _state_file(_cache_name("bank1"))
+        with open(path, "w") as f:
+            f.write("{ this is not valid json ]")
+        client = _CountingClient(response=self._resp("alpha"))
+        result = fetch_active_directives_cached(client, "bank1", now=1000.0)
+        self.assertEqual(client.calls, 1)
+        self.assertEqual([d["name"] for d in result], ["alpha"])
+
+    def test_wrong_shape_cache_falls_back_to_live(self):
+        # Valid JSON but missing the ts/directives envelope → treated as a miss.
+        write_state(_cache_name("bank1"), {"directives": [{"name": "stale"}]})
+        client = _CountingClient(response=self._resp("fresh"))
+        result = fetch_active_directives_cached(client, "bank1", now=1000.0)
+        self.assertEqual(client.calls, 1)
+        self.assertEqual([d["name"] for d in result], ["fresh"])
+
+    def test_bool_timestamp_rejected_as_corrupt(self):
+        # bool is an int subclass — guard must not accept True as a timestamp.
+        write_state(_cache_name("bank1"), {"ts": True, "directives": []})
+        client = _CountingClient(response=self._resp("fresh"))
+        fetch_active_directives_cached(client, "bank1", now=1000.0)
+        self.assertEqual(client.calls, 1)
+
+    def test_failed_fetch_not_cached(self):
+        # A transient fetch FAILURE must not poison the cache with [] — the next
+        # call must retry live rather than serving a cached empty list.
+        failing = _CountingClient(exc=RuntimeError("HTTP 503"))
+        with patch("sys.stderr", new=StringIO()):
+            first = fetch_active_directives_cached(failing, "bank1", now=1000.0)
+        self.assertEqual(first, [])
+        self.assertIsNone(read_state(_cache_name("bank1"), None))
+        # A subsequent successful fetch is served live and then cached.
+        ok = _CountingClient(response=self._resp("alpha"))
+        result = fetch_active_directives_cached(ok, "bank1", now=1000.1)
+        self.assertEqual(ok.calls, 1)
+        self.assertEqual([d["name"] for d in result], ["alpha"])
+
+    def test_empty_bank_is_cached(self):
+        # A genuinely empty bank (items: []) is a successful fetch → cacheable,
+        # so a directive-free agent also saves the round-trip.
+        client = _CountingClient(response={"items": []})
+        fetch_active_directives_cached(client, "bank1", now=1000.0)
+        fetch_active_directives_cached(client, "bank1", now=1000.1)
+        self.assertEqual(client.calls, 1)
+
+    def test_default_ttl_constant(self):
+        self.assertEqual(DIRECTIVES_CACHE_TTL_SECONDS, 120)
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/tests/test_directives.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directives.py
@@ -444,6 +444,29 @@ class DirectivesCacheTests(unittest.TestCase):
         fetch_active_directives_cached(client, "bank1", now=1000.1)
         self.assertEqual(client.calls, 1)
 
+    def test_bank_id_mismatch_falls_back_to_live(self):
+        # _safe_filename can collapse two bank ids onto one cache file; an
+        # envelope whose embedded bank_id != the requested one must be rejected
+        # (a live fetch) rather than serving another bank's directives.
+        write_state(
+            _cache_name("bank1"),
+            {"ts": 1000.0, "bank_id": "a-DIFFERENT-bank", "directives": [{"name": "leaked"}]},
+        )
+        client = _CountingClient(response=self._resp("mine"))
+        result = fetch_active_directives_cached(client, "bank1", now=1000.0)
+        self.assertEqual(client.calls, 1)
+        self.assertEqual([d["name"] for d in result], ["mine"])
+
+    def test_future_timestamp_treated_as_expired(self):
+        # A stored ts in the future (wall-clock step-back) → negative age → NOT
+        # served as fresh; the cache re-fetches instead of pinning stale.
+        client = _CountingClient(response=self._resp("alpha"))
+        fetch_active_directives_cached(client, "bank1", ttl_seconds=120, now=5000.0)
+        self.assertEqual(client.calls, 1)
+        # Clock steps back well before the cached ts → age is negative.
+        fetch_active_directives_cached(client, "bank1", ttl_seconds=120, now=1000.0)
+        self.assertEqual(client.calls, 2)
+
     def test_default_ttl_constant(self):
         self.assertEqual(DIRECTIVES_CACHE_TTL_SECONDS, 120)
 

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -58,8 +58,12 @@ class _FakeClient:
         # One entry per recall() call — lets tests assert the tag-filter
         # kwargs (upstream 962140eef) that main() passed per bank.
         self.recall_calls = []
+        # Count list_directives calls so a test can prove the A4 cache saved a
+        # round-trip across two recall.main() runs (and did NOT when TTL=0).
+        self.list_directives_calls = 0
 
     def list_directives(self, bank_id, active_only=True, timeout=2):
+        self.list_directives_calls += 1
         if self._list_exc is not None:
             raise self._list_exc
         return {"items": list(self._directives)}
@@ -706,6 +710,47 @@ class RecallTagFilterIntegrationTests(unittest.TestCase):
         self.assertEqual(extra["tags"], ["memory_type:rule"])
         # Global tags_match defaults are only sent when filters are active.
         self.assertEqual(extra["tags_match"], None)
+
+
+class DirectivesCacheIntegrationTests(unittest.TestCase):
+    """A4 finding 4 — recall.main() honours the directivesCacheTtlSeconds knob
+    end-to-end. Isolated CLAUDE_PLUGIN_DATA so the cache file lands in a temp
+    state dir and does not leak into (or out of) other tests."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._env = patch.dict(os.environ, {"CLAUDE_PLUGIN_DATA": self._tmp.name})
+        self._env.start()
+        self.addCleanup(self._env.stop)
+
+    def test_ttl_cache_saves_second_list_directives_call(self):
+        # Two consecutive recalls (same bank, no directive write between) with a
+        # live TTL → exactly one list_directives round-trip; the second serves
+        # from cache.
+        client = _FakeClient(
+            directives=[_directive("trailer", "End every response with: [VERIFIED]", priority=10)],
+            memories=[],
+        )
+        ctx1, _ = _run_main_with(client, config_extra={"directivesCacheTtlSeconds": 60})
+        ctx2, _ = _run_main_with(client, config_extra={"directivesCacheTtlSeconds": 60})
+        self.assertEqual(client.list_directives_calls, 1)
+        # Both turns still emit the directives block (the cache serves the same
+        # content on the hit).
+        self.assertIn("<active_directives>", ctx1)
+        self.assertIn("<active_directives>", ctx2)
+
+    def test_ttl_zero_refetches_each_run(self):
+        # TTL=0 disables the cache → every recall fetches live.
+        client = _FakeClient(
+            directives=[_directive("trailer", "End every response with: [VERIFIED]", priority=10)],
+            memories=[],
+        )
+        _run_main_with(client, config_extra={"directivesCacheTtlSeconds": 0})
+        _run_main_with(client, config_extra={"directivesCacheTtlSeconds": 0})
+        self.assertEqual(client.list_directives_calls, 2)
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -114,6 +114,12 @@ def _run_main_with(client, prompt="What is the meaning of life?", config_extra=N
         "recallContextTurns": 1,
         "recallMaxQueryChars": 800,
         "recallPromptPreamble": "",
+        # Disable the A4 directives cache for these integration tests: they all
+        # share bank "test-bank" under a real wall clock, so a live cache would
+        # leak one test's directive set into the next within the TTL window.
+        # Cache hit/miss/TTL/invalidation behaviour is covered hermetically in
+        # test_directives.py (isolated CLAUDE_PLUGIN_DATA + injected clock).
+        "directivesCacheTtlSeconds": 0,
     }
     if config_extra:
         config.update(config_extra)

--- a/vendor/hindsight-memory/settings.json
+++ b/vendor/hindsight-memory/settings.json
@@ -11,6 +11,7 @@
   "recallMaxMemories": 12,
   "recallTypes": ["world", "experience"],
   "recallContextTurns": 1,
+  "directivesCacheTtlSeconds": 120,
   "recallMaxQueryChars": 800,
   "recallRoles": ["user", "assistant"],
   "recallTags": [],


### PR DESCRIPTION
## What

PR 4 of the hindsight-leverage programme (workstream **A4**). Caches the
active-directives list on the recall critical path with a short TTL, invalidated
in-session on a directive write.

Epic: #3430 · Workstream A: #3431

## Why

`list_directives` runs on the recall (`UserPromptSubmit`) hook every non-skipped
turn — a fresh 2s-timeout HTTP round-trip whose result changes only when a
directive is created/updated/deleted (rare). Every no-write turn pays for a
round-trip that returns the same block.

## Change

- **`lib/directives.py`** — `fetch_active_directives_cached()` reads a per-bank
  cache envelope (`{ts, bank_id, directives}`) from the plugin state dir; on a
  fresh hit (`0 <= age < TTL`) it returns the cached list with **no HTTP call**.
  The fetch is split into `_fetch_directives_with_status()` so a genuine fetch
  **failure** is never cached (a transient error can't mask real directives for
  a TTL window); a corrupted / wrong-shaped / **bank-id-mismatched** cache falls
  back to a live fetch, and a **future timestamp** (clock step-back) is treated
  as expired. `invalidate_directives_cache()` removes one bank's cache, or (no
  arg) sweeps all directive caches — the Stop-hook path, which doesn't resolve
  the bank.
- **`directive_verify.py`** (registered Stop hook) — `main()` reads the
  transcript **at most once** and shares the parsed messages with both the cache
  invalidation and the capture verifier (no doubled parse; no parse at all when
  the cache is off *and* verify is off). `invalidate_cache_on_directive_write()`
  deletes the cache when the just-ended turn's tail (after the last human turn)
  contains a `create`/`update`/`delete_directive` `tool_use`. Self-guarded so it
  can never wedge Stop.
- **`recall.py`** — call the cached fetch, TTL from config.
- **`lib/state.py`** — `remove_state()` / `list_state_names()` helpers (path-safe).
- **`lib/config.py` + `settings.json`** — `directivesCacheTtlSeconds` (default
  120) + `HINDSIGHT_DIRECTIVES_CACHE_TTL_SECONDS`. **`0` disables the cache** —
  the rollback lever.

## Acceptance (per design A4)

- **In-session**: a `create_directive` in turn N clears the cache → turn N+1
  re-fetches and shows it; two consecutive no-write recalls make exactly one
  `list_directives` call — proven end-to-end through `recall.main()`
  (`DirectivesCacheIntegrationTests`).
- **Cross-process**: another process's write appears within ≤ TTL (TTL-expiry
  test).
- **Critical path**: cache-hit turns skip the HTTP round-trip.

### Invalidation blind spots (both fall back to TTL, ≤ TTL stale — documented)

- **Sub-agent / sidechain** directive writes: the `create_directive` tool_use is
  in the sidechain transcript, not the parent's, so the parent Stop hook never
  sees it. PR 5 (SubagentStop) is where sidechain awareness lands.
- **Bash / operator-CLI** directive writes produce no tool_use in any
  transcript, so there is nothing for the Stop hook to detect.

Both are acceptable (TTL-bounded) and noted in the `lib/directives.py` module
comment + CHANGELOG.

## Tests

New: cache hit/miss, TTL expiry, TTL=0 disable, per-bank + sweep invalidation,
corrupted + wrong-shape + **bank-id-mismatch** + **future-timestamp** fallback,
transient-failure-not-cached, empty-bank-cached; directive-write detection +
end-to-end invalidation hook; `main()` **single/zero transcript read** across
knob combos; and an end-to-end `recall.main()` integration test proving TTL>0 →
one `list_directives` call across two runs, TTL=0 → two. Full vendored plugin
suite green (**306 tests**) via `python3 -m unittest discover tests/`.

`test_recall_integration.py`'s shared helper pins `directivesCacheTtlSeconds: 0`
so those shared-`test-bank` tests stay hermetic under a real clock; the new
integration tests use an isolated `CLAUDE_PLUGIN_DATA`.

## Deviations

- Scope necessarily touched `recall.py` (one call site), `lib/state.py` (two
  path-safe file helpers), `lib/config.py` + `settings.json` (the TTL knob), and
  the integration-test helper (hermeticity) beyond the two files named in the
  task. All minimal and single-concern.
- Scaffold env plumbing for the TTL knob is **not** wired (out of scope, config
  PR territory); the `HINDSIGHT_DIRECTIVES_CACHE_TTL_SECONDS` env override still
  works if set, which is enough for the rollback lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rebase note (on top of #3435 / A1 telemetry)

#3435's per-bank timing wrapper (`_directives_start = time.monotonic()` … `directives_elapsed_ms`) now wraps the A4 `fetch_active_directives_cached(...)` call. On a cache **hit** `directives_elapsed_ms` legitimately reads ~0 — that is the A4 latency win, not a telemetry regression.
