### PR TITLE
fix(model): rev5 carrier auto-remediation + test hardening (#3427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,13 @@
   (idempotent; healthy agents untouched; takes effect on the agent's next
   restart). The requested-vs-served `--fallback-model` masking window is now
   loud: the `/model` ack warns immediately for unvalidatable free-text
-  `claude-*` ids, and the first assistant line after an apply-boot is verified
-  against the requested token — a mismatch logs `gw /model served-model
-  DIVERGENCE`, drops the bogus override, and warns the initiating chat. The
+  `claude-*` ids, and the first LIVE assistant line after an apply-boot is
+  verified against the requested token — a mismatch logs `gw /model
+  served-model DIVERGENCE` and warns the initiating chat, naming both
+  candidate causes (invalid id or transient unavailability). Verification
+  arms only at the boot-rehydration site and skips first-attach replay lines
+  from the pre-relaunch session, so a valid mid-turn switch can never be
+  false-accused. The
   #3424 source-string (`toContain`) tests are converted to behavioral tests of
   the classify → log/card pipeline, and the `scaffold.session-model.test.ts`
   live-resolution subset red on `main` is fixed (the fake `switchroom` CLI now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@
   process writes (and sub-agent / Bash-CLI writes with no main-transcript
   tool_use) are at most TTL stale. Saves the 2s-timeout `list_directives`
   round-trip on cache-hit turns. (hindsight-leverage A4)
+- **`/model` rev5 carrier: auto-remediation + test hardening** (#3427, follow-up
+  to #3424) — `switchroom doctor --fix` now HEALS rev5 `.session-model` carrier
+  drift instead of only detecting it: each drifted/missing `start.sh` is
+  regenerated from the current template via the standard per-agent reconcile
+  (idempotent; healthy agents untouched; takes effect on the agent's next
+  restart). The requested-vs-served `--fallback-model` masking window is now
+  loud: the `/model` ack warns immediately for unvalidatable free-text
+  `claude-*` ids, and the first assistant line after an apply-boot is verified
+  against the requested token — a mismatch logs `gw /model served-model
+  DIVERGENCE`, drops the bogus override, and warns the initiating chat. The
+  #3424 source-string (`toContain`) tests are converted to behavioral tests of
+  the classify → log/card pipeline, and the `scaffold.session-model.test.ts`
+  live-resolution subset red on `main` is fixed (the fake `switchroom` CLI now
+  lives on an exec-capable filesystem — `/tmp` is noexec in the dev container).
 
 ## v0.19.2 — Hindsight recovery, External spend on /usage, auth-broker hardening, /model carrier doctor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,10 @@
   `claude-*` ids, and the first LIVE assistant line after an apply-boot is
   verified against the requested token — a mismatch logs `gw /model
   served-model DIVERGENCE` and warns the initiating chat, naming both
-  candidate causes (invalid id or transient unavailability). Verification
+  candidate causes (invalid id or transient unavailability). The override is
+  KEPT on divergence (M2): a transient substitution self-corrects and /status
+  freshness already surfaces the served model, so the card only advises
+  re-issuing `/model <valid id>` (or `/model default`) if it persists. Verification
   arms only at the boot-rehydration site and skips first-attach replay lines
   from the pre-relaunch session, so a valid mid-turn switch can never be
   false-accused. The

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,7 +10,7 @@ runtime (including `deps`, `issues`, `migrate`).
 
 ```bash
 switchroom setup                              # Interactive wizard
-switchroom doctor                             # Health check
+switchroom doctor [--fix]                     # Health check; --fix auto-heals rev5 /model carrier drift (regenerates drifted start.sh)
 switchroom apply                              # Reconcile + regenerate docker-compose.yml (self-elevates via sudo for scaffolds). Does NOT run docker; prints the `up` command
 switchroom update [--check|--status|--rebuild] # Operator catch-up: pull images + apply + recreate fleet + doctor
 switchroom restart [agent] [--force]          # Bounce agent(s); drains in-flight turn by default

--- a/reference/rfcs/session-model-stickiness.md
+++ b/reference/rfcs/session-model-stickiness.md
@@ -95,12 +95,18 @@ Everything else in §0.1 (session-scoped revert on the next restart, consume-onc
   `.active-session-model` holds the requested token. This is NOT a persistent
   lie: the transcript's `message.model` reclaims the source on the first
   assistant line, correcting `/status` to the model actually serving calls. The
-  pre-first-assistant window is the only optimistic window (bounded,
-  self-healing); it is documented here, not silently asserted as success. The
-  honest-FAILURE surface is scoped to the three modes start.sh's
-  `.session-model-alert` can report (corrupt carrier / configured-default changed
-  / proxy-only + LiteLLM-down); other divergence is corrected by the transcript,
-  not announced.
+  pre-first-assistant window is the only optimistic window (bounded). Since
+  #3427 item 4 the correction is LOUD, not silent: (a) the `/model` ack for a
+  free-text `claude-*` full id carries an immediate caveat that the id cannot
+  be pre-validated (Claude-native constraint — no raw API probe) and that the
+  fallback may substitute; (b) the session-model source verifies the FIRST
+  post-override transcript line against the requested token
+  (`servedModelMatchesRequested`, conservative — never accuses a
+  non-comparable pair) and on mismatch the gateway logs
+  `gw /model served-model DIVERGENCE`, drops the bogus override, and sends a
+  one-shot ⚠️ card to the initiating chat. The honest-FAILURE surface at boot
+  remains the three `.session-model-alert` modes (corrupt carrier /
+  configured-default changed / proxy-only + LiteLLM-down).
 
 - **`default` reverts via relaunch.** With inject retired, `/model default`
   clears the carrier + in-memory override and RELAUNCHES so the live session

--- a/reference/rfcs/session-model-stickiness.md
+++ b/reference/rfcs/session-model-stickiness.md
@@ -99,12 +99,18 @@ Everything else in §0.1 (session-scoped revert on the next restart, consume-onc
   #3427 item 4 the correction is LOUD, not silent: (a) the `/model` ack for a
   free-text `claude-*` full id carries an immediate caveat that the id cannot
   be pre-validated (Claude-native constraint — no raw API probe) and that the
-  fallback may substitute; (b) the session-model source verifies the FIRST
-  post-override transcript line against the requested token
+  fallback may substitute; (b) the session-model source verifies the first
+  LIVE post-boot transcript line against the requested token
   (`servedModelMatchesRequested`, conservative — never accuses a
-  non-comparable pair) and on mismatch the gateway logs
-  `gw /model served-model DIVERGENCE`, drops the bogus override, and sends a
-  one-shot ⚠️ card to the initiating chat. The honest-FAILURE surface at boot
+  non-comparable pair; verification arms ONLY at the boot-rehydration
+  `setOverride(…, { verify: true })` site, and first-attach REPLAY lines from
+  the pre-relaunch session are flagged and skipped — the #3437 H1/H2
+  false-positive guards) and on mismatch the gateway logs
+  `gw /model served-model DIVERGENCE` and sends a one-shot ⚠️ card to the
+  initiating chat naming BOTH candidate causes (invalid id, or transient
+  unavailability — `--fallback-model` substitutes for either). The override
+  record is kept: a transient substitution self-corrects on later replies,
+  and freshness rules already point /status at the served model. The honest-FAILURE surface at boot
   remains the three `.session-model-alert` modes (corrupt carrier /
   configured-default changed / proxy-only + LiteLLM-down).
 

--- a/src/cli/doctor-fix-session-model.ts
+++ b/src/cli/doctor-fix-session-model.ts
@@ -53,11 +53,34 @@ export interface SessionModelCarrierFixDeps {
   /** The #3424 tripwire — checkStartShSessionModelCarrier from doctor.ts. */
   check: (agentName: string, startShPath: string) => FixCheckResult;
   /**
-   * Regenerate the agent's switchroom-managed files (start.sh included) from
-   * the current templates — reconcileAgent(name, …, { preserveClaudeMd: true }).
-   * Throws on failure.
+   * Regenerate the agent's switchroom-managed files from the current
+   * templates — reconcileAgent(name, …, { preserveClaudeMd: true }). NB this
+   * is the FULL per-agent reconcile (start.sh, .mcp.json, settings.json,
+   * plugins, skills — everything `switchroom apply` manages for that agent
+   * except CLAUDE.md), not a start.sh-only rewrite; the returned `changes`
+   * (every file the reconcile actually rewrote) are disclosed verbatim in
+   * the result row so an operator with staged switchroom.yaml edits sees
+   * exactly what was applied (#3437 review M1). Throws on failure.
    */
-  reconcile: (agentName: string) => void;
+  reconcile: (agentName: string) => { changes: string[] };
+}
+
+
+/**
+ * Honest disclosure of what the heal's FULL reconcile actually rewrote
+ * (#3437 review M1): the fix regenerates every switchroom-managed file for
+ * the agent, not just start.sh, and any staged switchroom.yaml edits land
+ * with it — so the row must name the files, not claim a start.sh-only write.
+ */
+function describeReconcileChanges(changes: string[]): string {
+  if (changes.length === 0) return "Reconcile rewrote no other files.";
+  const MAX_LISTED = 6;
+  const listed = changes.slice(0, MAX_LISTED).join(", ");
+  const more = changes.length > MAX_LISTED ? ` (+${changes.length - MAX_LISTED} more)` : "";
+  return (
+    `Full per-agent reconcile applied — rewrote ${changes.length} managed file(s): ` +
+    listed + more
+  );
 }
 
 /**
@@ -94,8 +117,9 @@ export function fixSessionModelCarrierDrift(
 
     // fail (drifted / legacy-only) or warn (start.sh missing): regenerate via
     // the reconcile path, then RE-CHECK — the heal claim is the re-run check.
+    let reconcileChanges: string[];
     try {
-      deps.reconcile(name);
+      reconcileChanges = deps.reconcile(name).changes;
     } catch (err) {
       results.push({
         name: label,
@@ -112,7 +136,8 @@ export function fixSessionModelCarrierDrift(
         name: label,
         status: "ok",
         detail:
-          "healed: start.sh regenerated with the rev5 `.session-model` carrier — takes effect on the agent's next restart",
+          "healed: start.sh regenerated with the rev5 `.session-model` carrier — takes effect on the agent's next restart. " +
+          describeReconcileChanges(reconcileChanges),
       });
     } else {
       results.push({

--- a/src/cli/doctor-fix-session-model.ts
+++ b/src/cli/doctor-fix-session-model.ts
@@ -1,0 +1,128 @@
+/**
+ * `switchroom doctor --fix` — auto-remediation for rev5 `.session-model`
+ * carrier drift (#3427 item 1, follow-up to #3424).
+ *
+ * #3424 shipped DETECTION (`checkStartShSessionModelCarrier`): a start.sh that
+ * predates the rev5 consume-once `.session-model` JSON carrier silently boots
+ * the yaml pin on every Telegram `/model` switch while the logs look
+ * successful. Healing previously required the operator to notice the doctor
+ * FAIL, run a manual `switchroom apply`, and restart the agent — so a drifted
+ * fleet could stay drifted unattended. This module closes that gap: for every
+ * agent whose carrier check fails, regenerate start.sh from the CURRENT
+ * template via the standard per-agent reconcile (the same code path
+ * `switchroom apply` uses — `reconcileAgent` re-renders start.sh from
+ * profiles/_base/start.sh.hbs), then re-run the check to prove the heal.
+ *
+ * Why reconcile rather than an in-container boot-time self-heal: start.sh is
+ * purely template-driven ("no user-merged sections", scaffold.ts — safe to
+ * overwrite in full), but the template tree (`profiles/_base/`) is NOT shipped
+ * into the agent image (see ReconcileOptions.skipProfileTemplates), so an
+ * agent cannot regenerate its own start.sh at boot. The host-side doctor is
+ * the earliest place both the drift signal and the template exist together.
+ *
+ * Determinism + idempotency: healthy agents are never reconciled (the check
+ * gates the write), and `reconcileAgent` itself only writes start.sh when the
+ * rendered content differs. Running `doctor --fix` twice is a no-op the second
+ * time. `preserveClaudeMd: true` keeps the fix scoped — CLAUDE.md regeneration
+ * is `switchroom apply`'s business, not a carrier fix's.
+ *
+ * The regenerated start.sh takes effect on the agent's NEXT restart (same
+ * semantics as apply); the result row says so.
+ */
+
+import { join } from "node:path";
+
+import { resolveAgentsDir } from "../config/loader.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckStatus } from "./doctor-status.js";
+
+/** Structural copy of doctor.ts's CheckResult (avoids a doctor.ts import cycle). */
+export interface FixCheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/**
+ * Injected seams so the drift→heal→re-check pipeline is testable with the
+ * real `reconcileAgent` (integration) or a stub (unit), and so this module
+ * never imports doctor.ts (which imports it).
+ */
+export interface SessionModelCarrierFixDeps {
+  /** The #3424 tripwire — checkStartShSessionModelCarrier from doctor.ts. */
+  check: (agentName: string, startShPath: string) => FixCheckResult;
+  /**
+   * Regenerate the agent's switchroom-managed files (start.sh included) from
+   * the current templates — reconcileAgent(name, …, { preserveClaudeMd: true }).
+   * Throws on failure.
+   */
+  reconcile: (agentName: string) => void;
+}
+
+/**
+ * For every configured agent: run the carrier check; heal drifted/missing
+ * start.sh via reconcile; re-check and report the POST-fix status. Pure
+ * orchestration — every result row is an outcome of a real check run after
+ * any write, never an assumption that the write worked.
+ */
+export function fixSessionModelCarrierDrift(
+  config: SwitchroomConfig,
+  deps: SessionModelCarrierFixDeps,
+): FixCheckResult[] {
+  const agentsDir = resolveAgentsDir(config);
+  const results: FixCheckResult[] = [];
+
+  for (const name of Object.keys(config.agents ?? {})) {
+    const startShPath = join(agentsDir, name, "start.sh");
+    const label = `${name}: start.sh /model session carrier (--fix)`;
+    const pre = deps.check(name, startShPath);
+
+    if (pre.status === "ok") {
+      results.push({
+        name: label,
+        status: "ok",
+        detail: "rev5 carrier already present — nothing to fix",
+      });
+      continue;
+    }
+    if (pre.status === "skip") {
+      // Unreadable from the host UID — we cannot verify OR safely rewrite.
+      results.push({ ...pre, name: label });
+      continue;
+    }
+
+    // fail (drifted / legacy-only) or warn (start.sh missing): regenerate via
+    // the reconcile path, then RE-CHECK — the heal claim is the re-run check.
+    try {
+      deps.reconcile(name);
+    } catch (err) {
+      results.push({
+        name: label,
+        status: "fail",
+        detail: `drift detected (${pre.detail ?? "carrier check failed"}) but reconcile failed: ${(err as Error).message}`,
+        fix: "Fix the reconcile error, or run `switchroom apply` manually.",
+      });
+      continue;
+    }
+
+    const post = deps.check(name, startShPath);
+    if (post.status === "ok") {
+      results.push({
+        name: label,
+        status: "ok",
+        detail:
+          "healed: start.sh regenerated with the rev5 `.session-model` carrier — takes effect on the agent's next restart",
+      });
+    } else {
+      results.push({
+        name: label,
+        status: "fail",
+        detail: `regenerated start.sh still fails the carrier check: ${post.detail ?? post.status} — the installed template may be stale`,
+        fix: "Update switchroom (the bundled profiles/_base/start.sh.hbs must carry the rev5 carrier), then re-run `switchroom doctor --fix`.",
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3009,7 +3009,7 @@ export function registerDoctorCommand(program: Command): void {
     )
     .option(
       "--fix",
-      "Auto-remediate rev5 /model `.session-model` carrier drift: regenerate each drifted agent's start.sh from the current template (same path as `switchroom apply`; takes effect on the agent's next restart)",
+      "Auto-remediate rev5 /model `.session-model` carrier drift by running the FULL per-agent reconcile for each drifted agent (start.sh + all switchroom-managed files, same as `switchroom apply` for that agent; staged switchroom.yaml edits land too — files rewritten are listed in the result row). Takes effect on the agent's next restart",
     )
     .action(
       withConfigError(async (opts: { json?: boolean; skill?: string; fast?: boolean; fix?: boolean }) => {
@@ -3137,7 +3137,7 @@ export function registerDoctorCommand(program: Command): void {
                   reconcile: (name) => {
                     const agentConfig = config.agents?.[name];
                     if (!agentConfig) throw new Error(`agent ${name} not in config`);
-                    reconcileAgent(
+                    const result = reconcileAgent(
                       name,
                       agentConfig,
                       resolveAgentsDir(config),
@@ -3146,6 +3146,9 @@ export function registerDoctorCommand(program: Command): void {
                       configPath,
                       { preserveClaudeMd: true },
                     );
+                    // M1: pass the FULL change list through so the fix row
+                    // discloses every managed file the reconcile rewrote.
+                    return { changes: result.changes };
                   },
                 }),
               },

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -24,6 +24,7 @@ import { resolveStatePath, LEGACY_STATE_DIR } from "../config/paths.js";
 import { getConfig, getConfigPath, withConfigError } from "./helpers.js";
 import { getAllAgentStatuses } from "../agents/lifecycle.js";
 import { readQuarantineMarkerForAgent } from "../agents/quarantine.js";
+import { reconcileAgent } from "../agents/scaffold.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
 import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
@@ -56,6 +57,7 @@ import { runAuditIntegrityChecks } from "./doctor-audit-integrity.js";
 import { runAgentSmokeChecks } from "./doctor-agent-smoke.js";
 import { runVaultBrokerDurabilityChecks } from "./doctor-vault-broker-durability.js";
 import { runTimezoneChecks } from "./doctor-timezone.js";
+import { fixSessionModelCarrierDrift } from "./doctor-fix-session-model.js";
 
 /**
  * Result of a single doctor check.
@@ -1846,7 +1848,7 @@ export function checkStartShSessionModelCarrier(
       name: label,
       status: "warn",
       detail: `${startShPath} not found`,
-      fix: `Run \`switchroom apply\` to scaffold start.sh (rev5 \`.session-model\` carrier).`,
+      fix: `Run \`switchroom doctor --fix\` (or \`switchroom apply\`) to scaffold start.sh (rev5 \`.session-model\` carrier).`,
     };
   }
   let content: string;
@@ -1886,7 +1888,7 @@ export function checkStartShSessionModelCarrier(
       detail:
         "start.sh tests `.session-model` but lacks rev5 JSON apply (`configuredDefaultAtWrite` / boot-attempts) — /model switches may not stick",
       fix:
-        "Run `switchroom apply` to regenerate start.sh from profiles/_base/start.sh.hbs (rev5 carrier). Takes effect on the next agent restart (no need to bounce until release).",
+        "Run `switchroom doctor --fix` (or `switchroom apply`) to regenerate start.sh from profiles/_base/start.sh.hbs (rev5 carrier). Takes effect on the next agent restart (no need to bounce until release).",
     };
   }
   const legacyOnly =
@@ -1898,7 +1900,7 @@ export function checkStartShSessionModelCarrier(
       ? "start.sh only reads legacy `.session-model-override`; gateway writes rev5 `.session-model` — Telegram /model relaunches boot the yaml pin (silent miss)"
       : "start.sh missing rev5 `.session-model` carrier file test — Telegram /model cannot apply session overrides across relaunch",
     fix:
-      "Run `switchroom apply` to regenerate start.sh from the latest template (rev5 `.session-model` carrier). The rewrite is on disk immediately; session switches apply on the next agent restart/release bounce.",
+      "Run `switchroom doctor --fix` (or `switchroom apply`) to regenerate start.sh from the latest template (rev5 `.session-model` carrier). The rewrite is on disk immediately; session switches apply on the next agent restart/release bounce.",
   };
 }
 
@@ -3005,8 +3007,12 @@ export function registerDoctorCommand(program: Command): void {
       "--fast",
       "Skip in-agent (hostd) liveness probes — offline/quick; the host-unverifiable rows stay `skip`",
     )
+    .option(
+      "--fix",
+      "Auto-remediate rev5 /model `.session-model` carrier drift: regenerate each drifted agent's start.sh from the current template (same path as `switchroom apply`; takes effect on the agent's next restart)",
+    )
     .action(
-      withConfigError(async (opts: { json?: boolean; skill?: string; fast?: boolean }) => {
+      withConfigError(async (opts: { json?: boolean; skill?: string; fast?: boolean; fix?: boolean }) => {
         // Pre-config-load short-circuit: if no switchroom.yaml exists yet
         // (e.g. fresh install before `switchroom setup`), running doctor
         // should still be useful — that's exactly when an operator wants
@@ -3117,7 +3123,37 @@ export function registerDoctorCommand(program: Command): void {
           }
         };
 
+        // --fix (#3427): heal rev5 /model carrier drift BEFORE the standard
+        // sections run, so the Agents section below reports the POST-fix
+        // state. Each row is the outcome of a re-run check after the write
+        // (fixSessionModelCarrierDrift), never an assumed success. Healthy
+        // agents are not touched (idempotent — see doctor-fix-session-model.ts).
+        const fixSections: Array<{ title: string; results: CheckResult[] }> = opts.fix
+          ? [
+              {
+                title: "Auto-remediation (--fix)",
+                results: fixSessionModelCarrierDrift(config, {
+                  check: checkStartShSessionModelCarrier,
+                  reconcile: (name) => {
+                    const agentConfig = config.agents?.[name];
+                    if (!agentConfig) throw new Error(`agent ${name} not in config`);
+                    reconcileAgent(
+                      name,
+                      agentConfig,
+                      resolveAgentsDir(config),
+                      config.telegram,
+                      config,
+                      configPath,
+                      { preserveClaudeMd: true },
+                    );
+                  },
+                }),
+              },
+            ]
+          : [];
+
         const sections: Array<{ title: string; results: CheckResult[] }> = [
+          ...fixSections,
           { title: "Dependencies", results: checkDependencies() },
           { title: "Skills Prerequisites", results: checkSkillsPrerequisites() },
           { title: "Manifest Drift", results: await checkManifestDrift() },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -23928,16 +23928,20 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 // real post-boot signal (`.active-session-model`), never from a
                 // scraped pane or an optimistic record.
                 const isApplyBoot = launched.length > 0 && launched !== configured
-                sessionModelSource.setOverride(isApplyBoot ? launched : null)
-                // #3427 item 4: arm the requested-vs-served tripwire — if the
-                // FIRST assistant line after this apply-boot serves a different
-                // model (invalid requested id, --fallback-model substituted),
-                // log, drop the bogus override, warn the operator (no silent heal).
+                // { verify: true } (#3427 item 4 / H1): ONLY this site arms the
+                // requested-vs-served tripwire — `launched` IS the token of the
+                // session now serving. Command-time setOverride never arms.
+                sessionModelSource.setOverride(isApplyBoot ? launched : null, { verify: true })
+                // Tripwire handler: the first LIVE assistant line serving a
+                // different model (invalid id OR transient unavailability —
+                // --fallback-model substituted) logs + warns the operator. The
+                // override is KEPT (M2): freshness rules already make /status
+                // show the served model, and a transient substitution
+                // self-corrects without us destroying the switch record.
                 if (isApplyBoot) {
                   const dChat = modelSwitchMarkerChat
                   sessionModelSource.setDivergenceHandler((d) => {
                     process.stderr.write(formatServedModelDivergenceLog({ agent: getMyAgentName(), ...d }))
-                    sessionModelSource.setOverride(null)
                     if (!dChat) return
                     // allow-raw-bot-api: one-shot divergence warn, same shape as the switch confirmation below
                     void lockedBot.api

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -540,10 +540,10 @@ import {
   handleModelCommand,
   classifyModelSwitchConfirmation,
   formatModelRelaunchDiagLog,
-  resolveModelSwitchBootNotice,
   servedModelMatchesRequested,
-  formatServedModelDivergenceLog,
-  formatServedModelDivergenceCard,
+  buildServedModelDivergenceHandler,
+  deliverModelSwitchBootNotice,
+  type ModelBootCardDeps,
   buildModelMenu,
   handleModelMenuCallback,
   isValidModelArg,
@@ -23932,27 +23932,18 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 // requested-vs-served tripwire — `launched` IS the token of the
                 // session now serving. Command-time setOverride never arms.
                 sessionModelSource.setOverride(isApplyBoot ? launched : null, { verify: true })
-                // Tripwire handler: the first LIVE assistant line serving a
-                // different model (invalid id OR transient unavailability —
-                // --fallback-model substituted) logs + warns the operator. The
-                // override is KEPT (M2): freshness rules already make /status
-                // show the served model, and a transient substitution
-                // self-corrects without us destroying the switch record.
+                // Boot /model cards (#3427): the divergence tripwire warn and
+                // the switch confirmation share one deps surface; the card
+                // logic lives in model-command.ts (#2996 ratchet).
+                const modelBootCardDeps: ModelBootCardDeps = {
+                  agent: getMyAgentName(),
+                  chat: modelSwitchMarkerChat,
+                  log: (line) => process.stderr.write(line),
+                  // allow-raw-bot-api: one-shot boot /model cards (divergence warn + switch confirmation), same shape as the session-model alert relay below
+                  sendCard: (chatId, body, opts) => lockedBot.api.sendMessage(chatId, body, opts),
+                }
                 if (isApplyBoot) {
-                  const dChat = modelSwitchMarkerChat
-                  sessionModelSource.setDivergenceHandler((d) => {
-                    process.stderr.write(formatServedModelDivergenceLog({ agent: getMyAgentName(), ...d }))
-                    if (!dChat) return
-                    // allow-raw-bot-api: one-shot divergence warn, same shape as the switch confirmation below
-                    void lockedBot.api
-                      .sendMessage(dChat.chatId, formatServedModelDivergenceCard(d), {
-                        parse_mode: 'Markdown',
-                        ...(dChat.threadId != null ? { message_thread_id: dChat.threadId } : {}),
-                      })
-                      .catch((err: unknown) =>
-                        process.stderr.write(`telegram gateway: served-model divergence send failed: ${(err as Error)?.message ?? String(err)}\n`),
-                      )
-                  })
+                  sessionModelSource.setDivergenceHandler(buildServedModelDivergenceHandler(modelBootCardDeps))
                 }
                 // F1/N4: classify + log + one confirmation card. Formatters live
                 // in model-command.ts so this file does not inflate (#2996 ratchet).
@@ -23972,29 +23963,13 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                     isApplyBoot,
                   }),
                 )
-                if (confirmation != null && modelSwitchMarkerChat) {
-                  const chat = modelSwitchMarkerChat
+                if (confirmation != null) {
                   // #3427 item 2: card-vs-suppress decision is pure + behaviorally tested.
-                  const notice = resolveModelSwitchBootNotice({
-                    agent: getMyAgentName(),
+                  deliverModelSwitchBootNotice({
+                    ...modelBootCardDeps,
                     confirmation,
                     hasSessionModelAlert: existsSync(join(smAgentDir, '.session-model-alert')),
                   })
-                  if (notice.kind === 'suppress') {
-                    process.stderr.write(notice.log)
-                  } else {
-                    // allow-raw-bot-api: one-shot boot confirmation, same shape as the session-model alert relay below
-                    void lockedBot.api
-                      .sendMessage(chat.chatId, notice.body, {
-                        parse_mode: 'Markdown',
-                        ...(chat.threadId != null ? { message_thread_id: chat.threadId } : {}),
-                      })
-                      .catch((err: unknown) =>
-                        process.stderr.write(
-                          `telegram gateway: model-switch confirmation send failed: ${(err as Error)?.message ?? String(err)}\n`,
-                        ),
-                      )
-                  }
                 }
               } catch { /* leave override as-is on a bad read */ }
             }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -540,8 +540,10 @@ import {
   handleModelCommand,
   classifyModelSwitchConfirmation,
   formatModelRelaunchDiagLog,
-  formatModelSwitchConfirmationBody,
-  formatModelRelaunchSuppressNotAppliedLog,
+  resolveModelSwitchBootNotice,
+  servedModelMatchesRequested,
+  formatServedModelDivergenceLog,
+  formatServedModelDivergenceCard,
   buildModelMenu,
   handleModelMenuCallback,
   isValidModelArg,
@@ -3689,8 +3691,9 @@ const currentTurnMap = new CurrentTurnMap<CurrentTurn>()
 // is seq-stamped and `resolve()` prefers the NEWER observation, so neither
 // source can go stale behind the other (session-model-source.ts, pinned by
 // tests/session-model-source.test.ts). buildAgentMetadata reads resolve();
-// the /model command paths write via setOverride.
-const sessionModelSource = createSessionModelSource()
+// the /model command paths write via setOverride. The comparator arms the
+// #3427 requested-vs-served tripwire (handler registered at boot rehydration).
+const sessionModelSource = createSessionModelSource({ servedMatchesRequested: servedModelMatchesRequested })
 // Captures the most-recently-started turn's sessionChatId. Unlike currentTurn,
 // this is NOT cleared by the silence poke (firePoke/clearTurnStarted). It lets
 // the Bug B fallback in executeReply route to the correct chat even when the
@@ -23926,6 +23929,27 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 // scraped pane or an optimistic record.
                 const isApplyBoot = launched.length > 0 && launched !== configured
                 sessionModelSource.setOverride(isApplyBoot ? launched : null)
+                // #3427 item 4: arm the requested-vs-served tripwire — if the
+                // FIRST assistant line after this apply-boot serves a different
+                // model (invalid requested id, --fallback-model substituted),
+                // log, drop the bogus override, warn the operator (no silent heal).
+                if (isApplyBoot) {
+                  const dChat = modelSwitchMarkerChat
+                  sessionModelSource.setDivergenceHandler((d) => {
+                    process.stderr.write(formatServedModelDivergenceLog({ agent: getMyAgentName(), ...d }))
+                    sessionModelSource.setOverride(null)
+                    if (!dChat) return
+                    // allow-raw-bot-api: one-shot divergence warn, same shape as the switch confirmation below
+                    void lockedBot.api
+                      .sendMessage(dChat.chatId, formatServedModelDivergenceCard(d), {
+                        parse_mode: 'Markdown',
+                        ...(dChat.threadId != null ? { message_thread_id: dChat.threadId } : {}),
+                      })
+                      .catch((err: unknown) =>
+                        process.stderr.write(`telegram gateway: served-model divergence send failed: ${(err as Error)?.message ?? String(err)}\n`),
+                      )
+                  })
+                }
                 // F1/N4: classify + log + one confirmation card. Formatters live
                 // in model-command.ts so this file does not inflate (#2996 ratchet).
                 const confirmation = modelSwitchReason != null
@@ -23946,19 +23970,18 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 )
                 if (confirmation != null && modelSwitchMarkerChat) {
                   const chat = modelSwitchMarkerChat
-                  const hasSessionModelAlert = existsSync(join(smAgentDir, '.session-model-alert'))
-                  if (confirmation.kind === 'not-applied' && hasSessionModelAlert) {
-                    process.stderr.write(
-                      formatModelRelaunchSuppressNotAppliedLog({
-                        agent: getMyAgentName(),
-                        target: confirmation.target,
-                      }),
-                    )
+                  // #3427 item 2: card-vs-suppress decision is pure + behaviorally tested.
+                  const notice = resolveModelSwitchBootNotice({
+                    agent: getMyAgentName(),
+                    confirmation,
+                    hasSessionModelAlert: existsSync(join(smAgentDir, '.session-model-alert')),
+                  })
+                  if (notice.kind === 'suppress') {
+                    process.stderr.write(notice.log)
                   } else {
-                    const body = formatModelSwitchConfirmationBody(confirmation)
                     // allow-raw-bot-api: one-shot boot confirmation, same shape as the session-model alert relay below
                     void lockedBot.api
-                      .sendMessage(chat.chatId, body, {
+                      .sendMessage(chat.chatId, notice.body, {
                         parse_mode: 'Markdown',
                         ...(chat.threadId != null ? { message_thread_id: chat.threadId } : {}),
                       })

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -293,6 +293,100 @@ export function formatModelRelaunchSuppressNotAppliedLog(input: {
   )
 }
 
+/**
+ * The single boot-time notification decision for a classified /model switch
+ * (#3427 item 2): either the ONE confirmation card (green applied/default or
+ * the ⚠️ not-applied warn), or — LOW-2 dedup — a suppress log when start.sh
+ * wrote a TAILORED `.session-model-alert` for this boot that already explains
+ * why the switch didn't apply (the alert relay is the more specific message,
+ * so the generic not-applied card would double-warn). Pure so the decision is
+ * unit-testable end-to-end (classify → notice) without booting the gateway;
+ * gateway.ts only sends `card` bodies / writes `suppress` logs.
+ */
+export type ModelSwitchBootNotice =
+  | { kind: 'card'; body: string }
+  | { kind: 'suppress'; log: string }
+
+export function resolveModelSwitchBootNotice(input: {
+  agent: string
+  confirmation: ModelSwitchConfirmation
+  hasSessionModelAlert: boolean
+}): ModelSwitchBootNotice {
+  const { agent, confirmation, hasSessionModelAlert } = input
+  if (confirmation.kind === 'not-applied' && hasSessionModelAlert) {
+    return {
+      kind: 'suppress',
+      log: formatModelRelaunchSuppressNotAppliedLog({ agent, target: confirmation.target }),
+    }
+  }
+  return { kind: 'card', body: formatModelSwitchConfirmationBody(confirmation) }
+}
+
+/**
+ * Requested-vs-served divergence gate (#3427 item 4). `--fallback-model` masks
+ * a shape-valid but UNKNOWN requested Claude id: claude silently serves the
+ * fallback while `.active-session-model` (and the boot confirmation) carry the
+ * requested token, until the first assistant transcript line reclaims /status.
+ * That window used to self-heal SILENTLY — the operator was never told their
+ * requested id was bogus. This comparator lets the session-model source flag
+ * the divergence deterministically at the FIRST possible post-launch signal
+ * (the first assistant line's `message.model`).
+ *
+ * Deliberately conservative — return true ("matches") whenever the pair is not
+ * DETERMINISTICALLY comparable, so a false accusation is impossible:
+ *   - served non-`claude-*` ids (sr-* / LiteLLM-mapped names) are skipped: the
+ *     proxy may echo an alias, a mapped id, or the raw route name;
+ *   - a requested alias (opus/sonnet/haiku/fable) family-matches its resolved
+ *     full id (`sonnet` ≡ `claude-sonnet-5-…`) via modelFamilyToken;
+ *   - a requested full `claude-*` id must be served exactly, or as a
+ *     date-stamped descendant (`claude-sonnet-5` ≡ `claude-sonnet-5-20260203`);
+ *   - anything else (sr-* requests, legacy friendly labels like "Opus 4.8")
+ *     is not comparable → true.
+ */
+export function servedModelMatchesRequested(requested: string, served: string): boolean {
+  const req = requested.trim().toLowerCase()
+  const srv = served.trim().toLowerCase()
+  if (!srv.startsWith('claude-')) return true
+  if ((MODEL_ALIASES as readonly string[]).includes(req)) {
+    if (req === 'default') return true
+    return modelFamilyToken(srv) === req
+  }
+  if (req.startsWith('claude-')) {
+    return srv === req || srv.startsWith(req + '-')
+  }
+  return true
+}
+
+/** Greppable stderr line for a requested-vs-served divergence (#3427 item 4). */
+export function formatServedModelDivergenceLog(input: {
+  agent: string
+  requested: string
+  served: string
+}): string {
+  return (
+    'telegram gateway: gw /model served-model DIVERGENCE agent=' +
+    input.agent +
+    ' requested=' +
+    input.requested +
+    ' served=' +
+    input.served +
+    ' (requested id likely invalid/unknown — --fallback-model substituted)\n'
+  )
+}
+
+/** Operator card for a requested-vs-served divergence (#3427 item 4). */
+export function formatServedModelDivergenceCard(input: {
+  requested: string
+  served: string
+}): string {
+  return (
+    '⚠️ The session is serving `' +
+    input.served +
+    '`, not the requested `' +
+    input.requested +
+    '` — the requested id is likely invalid or unknown, so claude silently substituted the fallback model. Re-issue `/model <valid id>` (or `/model default`); `/status` now reflects the model actually serving calls.'
+  )
+}
 
 export type ParsedModelCommand =
   | { kind: 'show' }
@@ -634,6 +728,23 @@ function relaunchErrorReply(
   return { text: `❌ Could not schedule model switch: ${deps.escapeHtml(msg)}`, html: true }
 }
 
+/**
+ * Fail-fast caveat (#3427 item 4) for a free-text full `claude-*` id: the
+ * gateway cannot pre-validate an arbitrary id against the API (Claude-native
+ * constraint — no raw API probes), so if the id is bogus `--fallback-model`
+ * silently serves the fallback. Say so IMMEDIATELY in the switch ack, and
+ * point at the first-reply tripwire that will catch it. Aliases and sr-* ids
+ * are vouched by their own gates (MODEL_ALIASES / the LiteLLM route probe),
+ * so only typed `claude-*` ids carry the caveat. Exported for tests.
+ */
+export function unvalidatedIdCaveat(
+  deps: Pick<ModelCommandDeps, 'escapeHtml'>,
+  model: string,
+): string | null {
+  if (!model.trim().toLowerCase().startsWith('claude-')) return null
+  return `_\`${deps.escapeHtml(model)}\` can't be validated before launch — if it isn't a real Claude model id, claude will silently serve the configured fallback model instead. I check the first reply and will warn if that happens._`
+}
+
 /** Schedule a carrier relaunch onto `model`, returning the deterministic ack. */
 async function scheduleRelaunchReply(
   deps: ModelCommandDeps,
@@ -645,7 +756,11 @@ async function scheduleRelaunchReply(
   } catch (err) {
     return relaunchErrorReply(deps, model, err)
   }
-  return { text: [switchingLine(deps, model), PERSIST_NOTE].join('\n'), html: true }
+  const caveat = unvalidatedIdCaveat(deps, model)
+  return {
+    text: [switchingLine(deps, model), ...(caveat ? [caveat] : []), PERSIST_NOTE].join('\n'),
+    html: true,
+  }
 }
 
 /** Schedule the `/model default` clear + revert relaunch, returning its ack. */

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -398,6 +398,83 @@ export function formatServedModelDivergenceCard(input: {
   )
 }
 
+/** The boot marker chat that initiated a /model switch (thread-aware). */
+export interface ModelBootCardTarget {
+  chatId: string
+  threadId: number | null
+}
+
+/**
+ * Injected side-effect surface for the boot-time /model cards (#3427): the
+ * served-model divergence warn and the switch confirmation share ONE raw
+ * Markdown send closure plus a stderr log sink. Lives here (not inline in
+ * gateway.ts's boot IIFE) so gateway.ts does not inflate (#2996 ratchet).
+ */
+export interface ModelBootCardDeps {
+  agent: string
+  /** null → no initiating chat known; cards are skipped, logs still write. */
+  chat: ModelBootCardTarget | null
+  log: (line: string) => void
+  sendCard: (
+    chatId: string,
+    body: string,
+    opts: { parse_mode: 'Markdown'; message_thread_id?: number },
+  ) => Promise<unknown>
+}
+
+/** One-shot fire-and-forget card to the marker chat; send failures log, never throw. */
+function sendModelBootCard(deps: ModelBootCardDeps, chat: ModelBootCardTarget, body: string, failLabel: string): void {
+  void deps
+    .sendCard(chat.chatId, body, {
+      parse_mode: 'Markdown',
+      ...(chat.threadId != null ? { message_thread_id: chat.threadId } : {}),
+    })
+    .catch((err: unknown) =>
+      deps.log(`telegram gateway: ${failLabel} send failed: ${(err as Error)?.message ?? String(err)}\n`),
+    )
+}
+
+/**
+ * Build the divergence-tripwire handler gateway.ts registers at the boot
+ * rehydration site (#3427 item 4): the first LIVE assistant line serving a
+ * different model (invalid id OR transient unavailability — --fallback-model
+ * substituted) logs + warns the operator. The override is KEPT (M2): freshness
+ * rules already make /status show the served model, and a transient
+ * substitution self-corrects without destroying the switch record.
+ */
+export function buildServedModelDivergenceHandler(
+  deps: ModelBootCardDeps,
+): (d: { requested: string; served: string }) => void {
+  return (d) => {
+    deps.log(formatServedModelDivergenceLog({ agent: deps.agent, requested: d.requested, served: d.served }))
+    if (deps.chat == null) return
+    sendModelBootCard(deps, deps.chat, formatServedModelDivergenceCard(d), 'served-model divergence')
+  }
+}
+
+/**
+ * Deliver the boot-time model-switch confirmation (#3427 item 2): resolve the
+ * card-vs-suppress decision (pure — resolveModelSwitchBootNotice) and either
+ * log the suppress line or send the card. No-op when no initiating chat is
+ * known — matching the pre-extraction inline gateway.ts behavior (the
+ * suppress log only ever wrote when a marker chat existed).
+ */
+export function deliverModelSwitchBootNotice(
+  deps: ModelBootCardDeps & { confirmation: ModelSwitchConfirmation; hasSessionModelAlert: boolean },
+): void {
+  if (deps.chat == null) return
+  const notice = resolveModelSwitchBootNotice({
+    agent: deps.agent,
+    confirmation: deps.confirmation,
+    hasSessionModelAlert: deps.hasSessionModelAlert,
+  })
+  if (notice.kind === 'suppress') {
+    deps.log(notice.log)
+    return
+  }
+  sendModelBootCard(deps, deps.chat, notice.body, 'model-switch confirmation')
+}
+
 export type ParsedModelCommand =
   | { kind: 'show' }
   | { kind: 'set'; model: string }

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -349,7 +349,12 @@ export function servedModelMatchesRequested(requested: string, served: string): 
   if (!srv.startsWith('claude-')) return true
   if ((MODEL_ALIASES as readonly string[]).includes(req)) {
     if (req === 'default') return true
-    return modelFamilyToken(srv) === req
+    if (modelFamilyToken(srv) === req) return true
+    // L3 (#3437 review): legacy id shapes put the family AFTER the version
+    // (`claude-3-opus-20240229` → first segment "3", not "opus"). Accept any
+    // dash-segment equal to the alias — widens toward "match" only, so it can
+    // suppress a real accusation in weird shapes but never create a false one.
+    return srv.slice('claude-'.length).split('-').includes(req)
   }
   if (req.startsWith('claude-')) {
     return srv === req || srv.startsWith(req + '-')
@@ -357,7 +362,12 @@ export function servedModelMatchesRequested(requested: string, served: string): 
   return true
 }
 
-/** Greppable stderr line for a requested-vs-served divergence (#3427 item 4). */
+/**
+ * Greppable stderr line for a requested-vs-served divergence (#3427 item 4).
+ * Names BOTH candidate causes (M2): `--fallback-model` substitutes for an
+ * invalid/unknown id AND for a transiently-unavailable one — the signal alone
+ * cannot distinguish them, so the log must not assert "invalid".
+ */
 export function formatServedModelDivergenceLog(input: {
   agent: string
   requested: string
@@ -370,21 +380,21 @@ export function formatServedModelDivergenceLog(input: {
     input.requested +
     ' served=' +
     input.served +
-    ' (requested id likely invalid/unknown — --fallback-model substituted)\n'
+    ' (--fallback-model substituted: requested id invalid/unknown OR model transiently unavailable)\n'
   )
 }
 
-/** Operator card for a requested-vs-served divergence (#3427 item 4). */
+/** Operator card for a requested-vs-served divergence (#3427 item 4, M2-softened). */
 export function formatServedModelDivergenceCard(input: {
   requested: string
   served: string
 }): string {
   return (
-    '⚠️ The session is serving `' +
+    '⚠️ The first reply was served by `' +
     input.served +
     '`, not the requested `' +
     input.requested +
-    '` — the requested id is likely invalid or unknown, so claude silently substituted the fallback model. Re-issue `/model <valid id>` (or `/model default`); `/status` now reflects the model actually serving calls.'
+    '` — claude substituted the fallback model. Either the requested id is invalid/unknown, or the model was temporarily unavailable for that call (a transient substitution self-corrects on later replies). If it persists, re-issue `/model <valid id>` or `/model default`. `/status` always shows the model actually serving calls.'
   )
 }
 

--- a/telegram-plugin/gateway/session-model-source.ts
+++ b/telegram-plugin/gateway/session-model-source.ts
@@ -23,11 +23,25 @@
  *
  * Divergence tripwire (#3427 item 4): `--fallback-model` masks an invalid
  * requested model id — claude silently serves the fallback while the override
- * carries the requested token. The FIRST transcript observation after an
- * override is set is therefore the earliest deterministic verification point:
- * when the injected comparator says the served id does NOT satisfy the
- * requested token, the registered divergence handler fires (once per override)
- * so the gateway can log + warn instead of self-healing silently.
+ * carries the requested token. The FIRST live transcript observation of the
+ * post-relaunch session is therefore the earliest deterministic verification
+ * point: when the injected comparator says the served id does NOT satisfy the
+ * requested token, the registered divergence handler fires (once per armed
+ * override) so the gateway can log + warn instead of self-healing silently.
+ *
+ * Two false-positive guards (#3437 review H1/H2 — "a false accusation must be
+ * impossible" is the contract, enforced HERE, not by caller discipline):
+ *   - H1: verification arms ONLY on an explicit `setOverride(model,
+ *     { verify: true })` — the boot-rehydration site, where the override IS
+ *     the launched token of the session now serving. A command-time
+ *     `setOverride(model)` (the pre-restart status-honesty record in
+ *     scheduleModelRelaunch) must NOT arm: an assistant line landing in the
+ *     pre-restart window is served by the OLD model and would false-mismatch
+ *     the NEW requested token.
+ *   - H2: observations flagged `replayed: true` (the session-tail's
+ *     first-attach replay of a prior session's in-flight turn — OLD-model
+ *     lines delivered AFTER boot) neither consume nor fire verification;
+ *     the tripwire waits for the first LIVE observation.
  */
 
 export interface SessionModelResolution {
@@ -38,7 +52,7 @@ export interface SessionModelResolution {
   source: 'transcript' | 'override'
 }
 
-/** The first post-override assistant line served a different model (#3427). */
+/** The first live post-override assistant line served a different model (#3427). */
 export interface SessionModelDivergence {
   /** The override token the operator requested (`/model <token>`). */
   requested: string
@@ -58,13 +72,25 @@ export interface SessionModelSourceOptions {
 }
 
 export interface SessionModelSource {
-  /** Record a transcript observation (an assistant line's `message.model`,
-   *  already sentinel-filtered by the session-tail projection). */
-  noteTranscriptModel(model: string): void
-  /** Record an override set (a positively-confirmed /model switch), or clear
-   *  it with null. Setting stamps a fresh sequence, so the override wins over
-   *  every EARLIER transcript observation until a new assistant line lands. */
-  setOverride(model: string | null): void
+  /**
+   * Record a transcript observation (an assistant line's `message.model`,
+   * already sentinel-filtered by the session-tail projection). Pass
+   * `replayed: true` for lines delivered by the session-tail's first-attach
+   * replay (a PRIOR session's in-flight turn): they still update /status
+   * freshness exactly as before, but are excluded from divergence
+   * verification (H2 — they carry the pre-relaunch model).
+   */
+  noteTranscriptModel(model: string, opts?: { replayed?: boolean }): void
+  /**
+   * Record an override set (a positively-confirmed /model switch), or clear
+   * it with null. Setting stamps a fresh sequence, so the override wins over
+   * every EARLIER transcript observation until a new assistant line lands.
+   * `verify: true` additionally ARMS divergence verification for this
+   * override — pass it ONLY when the override is the launched token of the
+   * session currently serving (the boot-rehydration site). Default: not
+   * armed (H1 — command-time/rollback sets must never arm).
+   */
+  setOverride(model: string | null, opts?: { verify?: boolean }): void
   /** Current override value (the #2982 in-memory record), independent of
    *  freshness — for callers that need the override itself (e.g. the model
    *  menu's "session" marker), not the /status resolution. */
@@ -72,9 +98,9 @@ export interface SessionModelSource {
   /** The freshest observation across both sources, or null when neither has
    *  reported yet. */
   resolve(): SessionModelResolution | null
-  /** Register the handler fired when the FIRST transcript observation after a
-   *  set override fails the comparator (#3427 item 4). At most once per
-   *  override set; null unregisters. Replaces any prior handler. */
+  /** Register the handler fired when the first LIVE transcript observation
+   *  after an ARMED override fails the comparator (#3427 item 4). At most
+   *  once per armed override; null unregisters. Replaces any prior handler. */
   setDivergenceHandler(handler: ((d: SessionModelDivergence) => void) | null): void
 }
 
@@ -84,14 +110,16 @@ export function createSessionModelSource(
   let seq = 0
   let transcript: { model: string; seq: number } | null = null
   let override: { model: string; seq: number } | null = null
-  // True while a non-null override awaits its first transcript observation.
-  // Consumed (set false) on that observation whether or not it diverges, so
-  // the handler fires at most once per override set.
+  // True while an ARMED ({ verify: true }) non-null override awaits its first
+  // LIVE transcript observation. Consumed (set false) on that observation
+  // whether or not it diverges, so the handler fires at most once per armed
+  // override. Replayed observations neither consume nor fire (H2).
   let overrideUnverified = false
   let onDivergence: ((d: SessionModelDivergence) => void) | null = null
   return {
-    noteTranscriptModel(model: string): void {
+    noteTranscriptModel(model: string, opts?: { replayed?: boolean }): void {
       transcript = { model, seq: ++seq }
+      if (opts?.replayed === true) return // H2: pre-relaunch line — no verification
       if (override != null && overrideUnverified) {
         overrideUnverified = false
         const matches = options.servedMatchesRequested
@@ -100,9 +128,12 @@ export function createSessionModelSource(
         }
       }
     },
-    setOverride(model: string | null): void {
+    setOverride(model: string | null, opts?: { verify?: boolean }): void {
       override = model == null ? null : { model, seq: ++seq }
-      overrideUnverified = model != null
+      // H1: only an explicit verify-arm (the boot-rehydration site) starts
+      // verification; a plain set (command-time record, rollback restore)
+      // clears any pending arm — its token is NOT what is serving right now.
+      overrideUnverified = model != null && opts?.verify === true
     },
     getOverride(): string | null {
       return override?.model ?? null

--- a/telegram-plugin/gateway/session-model-source.ts
+++ b/telegram-plugin/gateway/session-model-source.ts
@@ -20,6 +20,14 @@
  * whichever was observed last. A fresh assistant line always reclaims the
  * transcript as the source; a confirmed switch always beats an older
  * transcript line. Pinned by tests/session-model-source.test.ts.
+ *
+ * Divergence tripwire (#3427 item 4): `--fallback-model` masks an invalid
+ * requested model id — claude silently serves the fallback while the override
+ * carries the requested token. The FIRST transcript observation after an
+ * override is set is therefore the earliest deterministic verification point:
+ * when the injected comparator says the served id does NOT satisfy the
+ * requested token, the registered divergence handler fires (once per override)
+ * so the gateway can log + warn instead of self-healing silently.
  */
 
 export interface SessionModelResolution {
@@ -28,6 +36,25 @@ export interface SessionModelResolution {
    *  ("Opus 4.8") or sr-* ids depending on the /model path that set them. */
   model: string
   source: 'transcript' | 'override'
+}
+
+/** The first post-override assistant line served a different model (#3427). */
+export interface SessionModelDivergence {
+  /** The override token the operator requested (`/model <token>`). */
+  requested: string
+  /** The transcript's `message.model` — the model actually serving calls. */
+  served: string
+}
+
+export interface SessionModelSourceOptions {
+  /**
+   * Comparator for the divergence tripwire: does `served` (a resolved
+   * transcript id) satisfy `requested` (the override token)? Must be
+   * CONSERVATIVE — return true when the pair is not deterministically
+   * comparable (see servedModelMatchesRequested in model-command.ts).
+   * Absent → the tripwire never fires (verification is skipped).
+   */
+  servedMatchesRequested?: (requested: string, served: string) => boolean
 }
 
 export interface SessionModelSource {
@@ -45,18 +72,37 @@ export interface SessionModelSource {
   /** The freshest observation across both sources, or null when neither has
    *  reported yet. */
   resolve(): SessionModelResolution | null
+  /** Register the handler fired when the FIRST transcript observation after a
+   *  set override fails the comparator (#3427 item 4). At most once per
+   *  override set; null unregisters. Replaces any prior handler. */
+  setDivergenceHandler(handler: ((d: SessionModelDivergence) => void) | null): void
 }
 
-export function createSessionModelSource(): SessionModelSource {
+export function createSessionModelSource(
+  options: SessionModelSourceOptions = {},
+): SessionModelSource {
   let seq = 0
   let transcript: { model: string; seq: number } | null = null
   let override: { model: string; seq: number } | null = null
+  // True while a non-null override awaits its first transcript observation.
+  // Consumed (set false) on that observation whether or not it diverges, so
+  // the handler fires at most once per override set.
+  let overrideUnverified = false
+  let onDivergence: ((d: SessionModelDivergence) => void) | null = null
   return {
     noteTranscriptModel(model: string): void {
       transcript = { model, seq: ++seq }
+      if (override != null && overrideUnverified) {
+        overrideUnverified = false
+        const matches = options.servedMatchesRequested
+        if (matches != null && !matches(override.model, model)) {
+          onDivergence?.({ requested: override.model, served: model })
+        }
+      }
     },
     setOverride(model: string | null): void {
       override = model == null ? null : { model, seq: ++seq }
+      overrideUnverified = model != null
     },
     getOverride(): string | null {
       return override?.model ?? null
@@ -68,6 +114,9 @@ export function createSessionModelSource(): SessionModelSource {
         return { model: override.model, source: 'override' }
       }
       return { model: transcript.model, source: 'transcript' }
+    },
+    setDivergenceHandler(handler: ((d: SessionModelDivergence) => void) | null): void {
+      onDivergence = handler
     },
   }
 }

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -538,7 +538,10 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
       if (turn != null) {
         turn.currentModel = ev.model
       }
-      sessionModelSource.noteTranscriptModel(ev.model)
+      // `replayed` (#3427 H2): a first-attach replay line carries the
+      // PRE-restart session's model — record it for freshness (unchanged
+      // behavior) but exclude it from divergence verification.
+      sessionModelSource.noteTranscriptModel(ev.model, { replayed: ev.replayed === true })
       return
     }
     case 'usage': {

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -100,7 +100,12 @@ export type SessionEvent =
   // same batch already reflects the current model. Sentinels (`<synthetic>` on
   // compaction lines, fixture junk) are filtered at projection — see
   // isModelSentinel — so this only ever carries a real resolved model id.
-  | { kind: 'model'; model: string }
+  // `replayed: true` marks a model observation delivered by the FIRST-ATTACH
+  // replay of a prior session's in-flight turn (computeFirstAttachCursor) —
+  // it reflects the PRE-restart session's model, not the live one. Consumers
+  // that verify the live model (#3427 divergence tripwire, H2) must skip
+  // replayed observations; freshness consumers may still record them.
+  | { kind: 'model'; model: string; replayed?: boolean }
   | { kind: 'tool_use'; toolName: string; toolUseId?: string | null; input?: Record<string, unknown>; precomputedLabel?: string }
   // Real-time tool label from the PreToolUse-hook sidecar — fires when the
   // hook writes the label (synchronous at tool-call time), independent of
@@ -1217,6 +1222,17 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
   // re-attach.
   const fileCursors = new Map<string, { cursor: number; pendingPartial: string }>()
 
+  // First-attach REPLAY window per file (#3427 H2): when attachToFile replays
+  // a prior session's in-flight turn (computeFirstAttachCursor returned an
+  // offset below the size-at-attach), every byte below that size is HISTORY
+  // written by the pre-restart session. Model observations projected from it
+  // must be marked `replayed` so the divergence tripwire ignores them.
+  // Granularity is the read CHUNK (a batch whose read started inside the
+  // window is marked wholesale) — deliberately conservative: over-marking a
+  // boundary batch can only delay verification to the next live line, never
+  // false-accuse.
+  const replayUntilByFile = new Map<string, number>()
+
   function readNew(): void {
     if (stopped || !currentFile) return
     try {
@@ -1226,9 +1242,14 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
         // stored per-file state for this path.
         cursor = 0
         pendingPartial = ''
-        if (currentFile != null) fileCursors.delete(currentFile)
+        if (currentFile != null) {
+          fileCursors.delete(currentFile)
+          replayUntilByFile.delete(currentFile)
+        }
       }
       if (stat.size === cursor) return
+      const chunkStart = cursor
+      const isReplayChunk = chunkStart < (replayUntilByFile.get(currentFile) ?? 0)
       const buf = Buffer.alloc(stat.size - cursor)
       const fd = openSync(currentFile, 'r')
       try {
@@ -1247,7 +1268,7 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
         const sid = sessionIdForFile(currentFile)
         for (const ev of events) {
           try {
-            onEvent(decorate(ev, sid))
+            onEvent(decorate(isReplayChunk && ev.kind === 'model' ? { ...ev, replayed: true } : ev, sid))
           } catch (err) {
             log?.(`session-tail: onEvent threw: ${(err as Error).message}`)
           }
@@ -1322,6 +1343,9 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
         const size = statSync(file).size
         cursor = computeFirstAttachCursor(file, size)
         if (cursor < size) {
+          // #3427 H2: everything below size-at-attach is pre-restart history;
+          // model events projected from it are marked `replayed` in readNew.
+          replayUntilByFile.set(file, size)
           log?.(`session-tail: attached to ${file} (cursor=${cursor}, replaying in-flight turn from offset; size=${size})`)
         } else {
           log?.(`session-tail: attached to ${file} (cursor=${cursor})`)

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -153,7 +153,7 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
     const win = GATEWAY_SRC.slice(idx - 200, idx + 3200)
     // F1: `launched !== configured` is the deterministic apply-boot signal.
     expect(win).toContain('const isApplyBoot = launched.length > 0 && launched !== configured')
-    expect(win).toContain('sessionModelSource.setOverride(isApplyBoot ? launched : null)')
+    expect(win).toContain('sessionModelSource.setOverride(isApplyBoot ? launched : null, { verify: true })')
     expect(win).toContain('resolveMainModel(raw ?? undefined)')
   })
 
@@ -311,14 +311,31 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
   it('arms the #3427 requested-vs-served tripwire on an apply-boot (comparator + handler)', () => {
     // The source is constructed with the conservative comparator…
     expect(GATEWAY_SRC).toContain('createSessionModelSource({ servedMatchesRequested: servedModelMatchesRequested })')
-    // …and the apply-boot rehydration registers the handler that logs, drops
-    // the bogus override, and warns the initiating chat.
+    // …and the apply-boot rehydration verify-ARMS the override (H1: the ONLY
+    // arming site) and registers the handler that logs + warns.
     const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
-    const win = GATEWAY_SRC.slice(idx, idx + 4200)
+    const win = GATEWAY_SRC.slice(idx, idx + 4500)
+    expect(win).toContain('sessionModelSource.setOverride(isApplyBoot ? launched : null, { verify: true })')
     expect(win).toContain('sessionModelSource.setDivergenceHandler((d) =>')
     expect(win).toContain('formatServedModelDivergenceLog')
-    expect(win).toContain('sessionModelSource.setOverride(null)')
     expect(win).toContain('formatServedModelDivergenceCard(d)')
+    // M2: the handler must NOT destroy the override record — a transient
+    // fallback substitution self-corrects; freshness already fixes /status.
+    const handlerStart = win.indexOf('setDivergenceHandler((d) =>')
+    const handlerWin = win.slice(handlerStart, handlerStart + 900)
+    expect(handlerWin).not.toContain('setOverride(null)')
+  })
+
+  it('H1 (#3437): the command-time relaunch record does NOT verify-arm the tripwire', () => {
+    // scheduleModelRelaunch sets the pre-restart status-honesty override with a
+    // BARE setOverride — arming it would let an OLD-model assistant line in the
+    // pre-restart window false-accuse a valid NEW token. The behavioral guard
+    // lives in session-model-source.test.ts; this pins the gateway call sites.
+    const idx = GATEWAY_SRC.indexOf('scheduleModelRelaunch: async (model: string, reason: string)')
+    expect(idx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(idx, idx + 2600)
+    expect(win).toContain('sessionModelSource.setOverride(model)')
+    expect(win).not.toContain('verify')
   })
 
   it('N4/reason: the /model switch reason is captured from the clean-shutdown marker', () => {

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -300,12 +300,16 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
     const win = GATEWAY_SRC.slice(idx, idx + 4200)
     expect(win).toContain('classifyModelSwitchConfirmation({')
     expect(win).toContain('formatModelRelaunchDiagLog')
-    expect(win).toContain('if (confirmation != null && modelSwitchMarkerChat)')
-    expect(win).toContain('resolveModelSwitchBootNotice({')
+    expect(win).toContain('if (confirmation != null)')
+    expect(win).toContain('deliverModelSwitchBootNotice({')
     expect(win).toContain("existsSync(join(smAgentDir, '.session-model-alert'))")
-    // Both notice arms are consumed: suppress → stderr, card → sendMessage.
-    expect(win).toContain('process.stderr.write(notice.log)')
-    expect(win).toContain('.sendMessage(chat.chatId, notice.body')
+    // Both notice arms (suppress → stderr, card → sendMessage) now live in
+    // model-command.ts (deliverModelSwitchBootNotice — behaviorally tested in
+    // model-command.test.ts); the gateway injects the shared boot-card deps
+    // (stderr log sink + one raw thread-aware send closure).
+    expect(win).toContain('...modelBootCardDeps')
+    expect(win).toContain('log: (line) => process.stderr.write(line)')
+    expect(win).toContain('lockedBot.api.sendMessage(chatId, body, opts)')
   })
 
   it('arms the #3427 requested-vs-served tripwire on an apply-boot (comparator + handler)', () => {
@@ -316,14 +320,24 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
     const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
     const win = GATEWAY_SRC.slice(idx, idx + 4500)
     expect(win).toContain('sessionModelSource.setOverride(isApplyBoot ? launched : null, { verify: true })')
-    expect(win).toContain('sessionModelSource.setDivergenceHandler((d) =>')
-    expect(win).toContain('formatServedModelDivergenceLog')
-    expect(win).toContain('formatServedModelDivergenceCard(d)')
+    // The handler body lives in model-command.ts (buildServedModelDivergenceHandler,
+    // behaviorally tested in model-command.test.ts — log line + operator card);
+    // the gateway registers it ONLY on an apply-boot, fed by the shared deps.
+    expect(win).toContain(
+      'sessionModelSource.setDivergenceHandler(buildServedModelDivergenceHandler(modelBootCardDeps))',
+    )
+    const armIdx = win.indexOf('sessionModelSource.setDivergenceHandler(')
+    expect(win.slice(0, armIdx)).toContain('if (isApplyBoot) {')
     // M2: the handler must NOT destroy the override record — a transient
     // fallback substitution self-corrects; freshness already fixes /status.
-    const handlerStart = win.indexOf('setDivergenceHandler((d) =>')
-    const handlerWin = win.slice(handlerStart, handlerStart + 900)
-    expect(handlerWin).not.toContain('setOverride(null)')
+    // Structurally guaranteed post-extraction: the injected ModelBootCardDeps
+    // surface (agent/chat/log/sendCard) carries NO handle to the source, so
+    // the handler CANNOT call setOverride. Pin that the deps object stays free
+    // of any source handle.
+    const depsStart = win.indexOf('const modelBootCardDeps')
+    expect(depsStart).toBeGreaterThan(0)
+    const depsWin = win.slice(depsStart, win.indexOf('if (isApplyBoot)'))
+    expect(depsWin).not.toContain('sessionModelSource')
   })
 
   it('H1 (#3437): the command-time relaunch record does NOT verify-arm the tripwire', () => {

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -17,6 +17,11 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { SESSION_MODEL_FILE } from '../gateway/session-model-file.js'
+import {
+  classifyModelSwitchConfirmation,
+  formatModelRelaunchDiagLog,
+  resolveModelSwitchBootNotice,
+} from '../gateway/model-command.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const MODEL_COMMAND_SRC = readFileSync(
@@ -158,42 +163,162 @@ describe('gateway boot: session-model re-hydration + confirmation + alert relay'
     expect(MODEL_COMMAND_SRC).toContain('gw /model relaunch applied agent=')
   })
 
-  it('logs outcome KIND explicitly on /model switch rehydration (NOT-APPLIED vs applied vs default)', () => {
-    // Formatters live in model-command.ts (gateway line-ratchet); gateway only calls them.
-    expect(GATEWAY_SRC).toContain('formatModelRelaunchDiagLog')
-    expect(GATEWAY_SRC).toContain('formatModelSwitchConfirmationBody')
-    expect(GATEWAY_SRC).toContain('formatModelRelaunchSuppressNotAppliedLog')
-    expect(MODEL_COMMAND_SRC).toContain('gw /model relaunch NOT-APPLIED agent=')
-    expect(MODEL_COMMAND_SRC).toContain('override=set outcome=applied')
-    expect(MODEL_COMMAND_SRC).toContain('override=cleared outcome=default')
-    expect(MODEL_COMMAND_SRC).toContain('gw /model relaunch NOT-APPLIED — suppressing not-applied confirmation')
+  // #3427 item 2: the following are BEHAVIORAL tests — they run the real
+  // classifier → formatter/notice pipeline and assert the EMITTED outcome
+  // (log line / card body), not that a string merely exists in the source.
+  // The thin `wires …` test at the end pins that gateway.ts actually calls
+  // this pipeline (the gateway boot IIFE cannot be unit-booted).
+
+  it('emits the NOT-APPLIED log for a silent revert (classify → formatModelRelaunchDiagLog)', () => {
+    const confirmation = classifyModelSwitchConfirmation({
+      reason: 'user: /model fable (session-only relaunch, menu)',
+      launched: 'claude-opus-4-8',
+      configured: 'claude-opus-4-8',
+    })
+    expect(confirmation.kind).toBe('not-applied')
+    const log = formatModelRelaunchDiagLog({
+      agent: 'klanker',
+      launched: 'claude-opus-4-8',
+      configured: 'claude-opus-4-8',
+      confirmation,
+      isApplyBoot: false,
+    })
+    expect(log).toContain('gw /model relaunch NOT-APPLIED agent=klanker')
+    expect(log).toContain('target=fable')
+    expect(log).toContain('revertedTo=claude-opus-4-8')
   })
 
-  it('sends ONE switch-confirmation from the ACTUAL launched model, keyed on the /model reason (F1/N4)', () => {
+  it('emits outcome=applied for a landed switch and outcome=default for a revert', () => {
+    const applied = classifyModelSwitchConfirmation({
+      reason: 'user: /model claude-haiku-4-5 (session-only relaunch)',
+      launched: 'claude-haiku-4-5',
+      configured: 'claude-opus-4-8',
+    })
+    expect(
+      formatModelRelaunchDiagLog({
+        agent: 'a', launched: 'claude-haiku-4-5', configured: 'claude-opus-4-8',
+        confirmation: applied, isApplyBoot: true,
+      }),
+    ).toContain('override=set outcome=applied')
+    const dflt = classifyModelSwitchConfirmation({
+      reason: 'user: /model default (revert relaunch)',
+      launched: 'claude-opus-4-8',
+      configured: 'claude-opus-4-8',
+    })
+    expect(
+      formatModelRelaunchDiagLog({
+        agent: 'a', launched: 'claude-opus-4-8', configured: 'claude-opus-4-8',
+        confirmation: dflt, isApplyBoot: false,
+      }),
+    ).toContain('override=cleared outcome=default')
+  })
+
+  it('sends the green applied card for a landed switch, the default card for an intended revert (F1/N4)', () => {
+    const applied = resolveModelSwitchBootNotice({
+      agent: 'a',
+      confirmation: classifyModelSwitchConfirmation({
+        reason: 'user: /model fable (session-only relaunch)',
+        launched: 'fable',
+        configured: 'claude-opus-4-8',
+      }),
+      hasSessionModelAlert: false,
+    })
+    expect(applied.kind).toBe('card')
+    if (applied.kind === 'card') {
+      expect(applied.body).toContain('✅ Now running `fable`')
+      expect(applied.body).toContain('session-only')
+    }
+    // N4: launched===configured on a /model default reason still confirms.
+    const dflt = resolveModelSwitchBootNotice({
+      agent: 'a',
+      confirmation: classifyModelSwitchConfirmation({
+        reason: 'user: /model default (revert relaunch)',
+        launched: 'claude-opus-4-8',
+        configured: 'claude-opus-4-8',
+      }),
+      hasSessionModelAlert: false,
+    })
+    expect(dflt.kind).toBe('card')
+    if (dflt.kind === 'card') {
+      expect(dflt.body).toContain('✅ Now running `claude-opus-4-8` (the configured default)')
+    }
+  })
+
+  it('warns (⚠️, not a green ✅) when a non-default switch silently reverted to the default (silent-revert fix)', () => {
+    const notice = resolveModelSwitchBootNotice({
+      agent: 'a',
+      confirmation: classifyModelSwitchConfirmation({
+        reason: 'user: /model fable (session-only relaunch, menu)',
+        launched: 'claude-opus-4-8',
+        configured: 'claude-opus-4-8',
+      }),
+      hasSessionModelAlert: false,
+    })
+    expect(notice.kind).toBe('card')
+    if (notice.kind === 'card') {
+      expect(notice.body).toContain("⚠️ Your switch to `fable` didn't apply")
+      expect(notice.body).toContain('reverted to `claude-opus-4-8`')
+      // LOW-3: the re-issue hint keeps the target inside backticks.
+      expect(notice.body).toContain('Re-issue `/model fable`')
+      expect(notice.body).not.toContain('✅')
+    }
+  })
+
+  it('suppresses ONLY the not-applied card when a tailored .session-model-alert is present (LOW-2)', () => {
+    const reverted = classifyModelSwitchConfirmation({
+      reason: 'user: /model fable (session-only relaunch)',
+      launched: 'claude-opus-4-8',
+      configured: 'claude-opus-4-8',
+    })
+    const suppressed = resolveModelSwitchBootNotice({
+      agent: 'klanker',
+      confirmation: reverted,
+      hasSessionModelAlert: true,
+    })
+    expect(suppressed.kind).toBe('suppress')
+    if (suppressed.kind === 'suppress') {
+      expect(suppressed.log).toContain('suppressing not-applied confirmation')
+      expect(suppressed.log).toContain('agent=klanker')
+      expect(suppressed.log).toContain('target=fable')
+    }
+    // An APPLIED switch still confirms even when an (unrelated) alert exists.
+    const applied = resolveModelSwitchBootNotice({
+      agent: 'klanker',
+      confirmation: classifyModelSwitchConfirmation({
+        reason: 'user: /model fable (session-only relaunch)',
+        launched: 'fable',
+        configured: 'claude-opus-4-8',
+      }),
+      hasSessionModelAlert: true,
+    })
+    expect(applied.kind).toBe('card')
+  })
+
+  it('wires the pipeline into the boot rehydration (gateway calls classify → diag log → notice)', () => {
     const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
     expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 2500)
+    const win = GATEWAY_SRC.slice(idx, idx + 4200)
+    expect(win).toContain('classifyModelSwitchConfirmation({')
+    expect(win).toContain('formatModelRelaunchDiagLog')
     expect(win).toContain('if (confirmation != null && modelSwitchMarkerChat)')
-    expect(win).toContain('formatModelSwitchConfirmationBody')
-    expect(MODEL_COMMAND_SRC).toContain('✅ Now running')
-    expect(MODEL_COMMAND_SRC).toContain('(the configured default)')
-  })
-
-  it('warns instead of a green ✅ when a non-default switch silently reverted to the default (silent-revert fix)', () => {
-    expect(GATEWAY_SRC).toContain('classifyModelSwitchConfirmation({')
-    expect(GATEWAY_SRC).toContain('formatModelSwitchConfirmationBody')
-    expect(MODEL_COMMAND_SRC).toContain('⚠️ Your switch to')
-    expect(MODEL_COMMAND_SRC).toContain("didn't apply")
-    // LOW-3: re-issue hint keeps target in backticks
-    expect(MODEL_COMMAND_SRC).toContain('Re-issue `/model ')
-  })
-
-  it('dedups the not-applied card against a tailored .session-model-alert (LOW-2)', () => {
-    const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
-    const win = GATEWAY_SRC.slice(idx, idx + 2500)
+    expect(win).toContain('resolveModelSwitchBootNotice({')
     expect(win).toContain("existsSync(join(smAgentDir, '.session-model-alert'))")
-    expect(win).toContain("confirmation.kind === 'not-applied' && hasSessionModelAlert")
-    expect(win).toContain('formatModelRelaunchSuppressNotAppliedLog')
+    // Both notice arms are consumed: suppress → stderr, card → sendMessage.
+    expect(win).toContain('process.stderr.write(notice.log)')
+    expect(win).toContain('.sendMessage(chat.chatId, notice.body')
+  })
+
+  it('arms the #3427 requested-vs-served tripwire on an apply-boot (comparator + handler)', () => {
+    // The source is constructed with the conservative comparator…
+    expect(GATEWAY_SRC).toContain('createSessionModelSource({ servedMatchesRequested: servedModelMatchesRequested })')
+    // …and the apply-boot rehydration registers the handler that logs, drops
+    // the bogus override, and warns the initiating chat.
+    const idx = GATEWAY_SRC.indexOf('const isApplyBoot = launched.length > 0')
+    const win = GATEWAY_SRC.slice(idx, idx + 4200)
+    expect(win).toContain('sessionModelSource.setDivergenceHandler((d) =>')
+    expect(win).toContain('formatServedModelDivergenceLog')
+    expect(win).toContain('sessionModelSource.setOverride(null)')
+    expect(win).toContain('formatServedModelDivergenceCard(d)')
   })
 
   it('N4/reason: the /model switch reason is captured from the clean-shutdown marker', () => {

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -734,6 +734,15 @@ describe("servedModelMatchesRequested", () => {
     // The default sentinel never diverges.
     expect(servedModelMatchesRequested("default", "claude-opus-4-8")).toBe(true);
   });
+
+  it("L3 (#3437): legacy id shapes (family after version) never false-accuse an alias request", () => {
+    // `claude-3-opus-20240229` → modelFamilyToken yields "3", not "opus"; the
+    // segment fallback must still match the alias.
+    expect(servedModelMatchesRequested("opus", "claude-3-opus-20240229")).toBe(true);
+    expect(servedModelMatchesRequested("haiku", "claude-3-5-haiku-20241022")).toBe(true);
+    // …while a genuinely different family still fires.
+    expect(servedModelMatchesRequested("sonnet", "claude-3-opus-20240229")).toBe(false);
+  });
 });
 
 describe("served-model divergence formatters (#3427 item 4)", () => {
@@ -759,6 +768,24 @@ describe("served-model divergence formatters (#3427 item 4)", () => {
     expect(card).toContain("`claude-sonnet-9`");
     expect(card).toContain("/model");
     expect(card).not.toContain("✅");
+  });
+
+  it("M2 (#3437): the card and log name BOTH causes — never a flat 'invalid' accusation", () => {
+    // --fallback-model also substitutes on transient overload/unavailability;
+    // the signal cannot distinguish that from a bogus id, so neither surface
+    // may assert invalidity as fact.
+    const card = formatServedModelDivergenceCard({
+      requested: "claude-sonnet-9",
+      served: "claude-opus-4-8",
+    });
+    expect(card).toContain("temporarily unavailable");
+    expect(card).toContain("invalid");
+    expect(card).toContain("If it persists");
+    expect(card).toContain("Either"); // hedged alternatives, not an assertion of invalidity
+    const log = formatServedModelDivergenceLog({
+      agent: "a", requested: "claude-sonnet-9", served: "claude-opus-4-8",
+    });
+    expect(log).toContain("invalid/unknown OR model transiently unavailable");
   });
 });
 

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -35,7 +35,10 @@ import {
   servedModelMatchesRequested,
   formatServedModelDivergenceLog,
   formatServedModelDivergenceCard,
+  buildServedModelDivergenceHandler,
+  deliverModelSwitchBootNotice,
   unvalidatedIdCaveat,
+  type ModelBootCardDeps,
   type ModelCommandDeps,
 } from "../gateway/model-command.js";
 
@@ -786,6 +789,99 @@ describe("served-model divergence formatters (#3427 item 4)", () => {
       agent: "a", requested: "claude-sonnet-9", served: "claude-opus-4-8",
     });
     expect(log).toContain("invalid/unknown OR model transiently unavailable");
+  });
+});
+
+describe("boot /model cards — buildServedModelDivergenceHandler / deliverModelSwitchBootNotice (#2996 extraction)", () => {
+  function makeCardDeps(overrides: Partial<ModelBootCardDeps> = {}) {
+    const logs: string[] = [];
+    const sends: Array<{ chatId: string; body: string; opts: Record<string, unknown> }> = [];
+    const deps: ModelBootCardDeps = {
+      agent: "klanker",
+      chat: { chatId: "-100123", threadId: 42 },
+      log: (line) => { logs.push(line); },
+      sendCard: (chatId, body, opts) => {
+        sends.push({ chatId, body, opts });
+        return Promise.resolve();
+      },
+      ...overrides,
+    };
+    return { deps, logs, sends };
+  }
+
+  it("divergence handler logs the DIVERGENCE line and sends the card to the marker chat + thread", () => {
+    const { deps, logs, sends } = makeCardDeps();
+    buildServedModelDivergenceHandler(deps)({ requested: "claude-sonnet-9", served: "claude-opus-4-8" });
+    expect(logs.some((l) => l.includes("gw /model served-model DIVERGENCE agent=klanker"))).toBe(true);
+    expect(sends).toHaveLength(1);
+    expect(sends[0].chatId).toBe("-100123");
+    expect(sends[0].body).toContain("`claude-opus-4-8`");
+    expect(sends[0].opts).toEqual({ parse_mode: "Markdown", message_thread_id: 42 });
+  });
+
+  it("divergence handler with NO marker chat still logs but never sends", () => {
+    const { deps, logs, sends } = makeCardDeps({ chat: null });
+    buildServedModelDivergenceHandler(deps)({ requested: "sonnet", served: "claude-opus-4-8" });
+    expect(logs.some((l) => l.includes("DIVERGENCE"))).toBe(true);
+    expect(sends).toHaveLength(0);
+  });
+
+  it("divergence card send rejection is swallowed and logged — never throws", async () => {
+    const { deps, logs } = makeCardDeps({
+      sendCard: () => Promise.reject(new Error("THREAD_NOT_FOUND")),
+    });
+    expect(() =>
+      buildServedModelDivergenceHandler(deps)({ requested: "claude-sonnet-9", served: "claude-opus-4-8" }),
+    ).not.toThrow();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(logs.some((l) => l.includes("served-model divergence send failed: THREAD_NOT_FOUND"))).toBe(true);
+  });
+
+  it("boot notice: applied confirmation sends the ✅ card (thread-aware), no suppress log", () => {
+    const { deps, logs, sends } = makeCardDeps();
+    deliverModelSwitchBootNotice({
+      ...deps,
+      confirmation: { kind: "applied", launched: "claude-opus-4-8" },
+      hasSessionModelAlert: false,
+    });
+    expect(sends).toHaveLength(1);
+    expect(sends[0].body).toContain("✅ Now running `claude-opus-4-8`");
+    expect(sends[0].opts).toEqual({ parse_mode: "Markdown", message_thread_id: 42 });
+    expect(logs).toHaveLength(0);
+  });
+
+  it("boot notice: not-applied + .session-model-alert suppresses the card and writes the suppress log", () => {
+    const { deps, logs, sends } = makeCardDeps({ chat: { chatId: "-100123", threadId: null } });
+    deliverModelSwitchBootNotice({
+      ...deps,
+      confirmation: { kind: "not-applied", target: "fable", revertedTo: "claude-sonnet-5" },
+      hasSessionModelAlert: true,
+    });
+    expect(sends).toHaveLength(0);
+    expect(logs.some((l) => l.includes("suppressing not-applied confirmation") && l.includes("target=fable"))).toBe(true);
+  });
+
+  it("boot notice: no marker chat is a full no-op (matches pre-extraction inline behavior)", () => {
+    const { deps, logs, sends } = makeCardDeps({ chat: null });
+    deliverModelSwitchBootNotice({
+      ...deps,
+      confirmation: { kind: "not-applied", target: "fable", revertedTo: "claude-sonnet-5" },
+      hasSessionModelAlert: true,
+    });
+    expect(sends).toHaveLength(0);
+    expect(logs).toHaveLength(0);
+  });
+
+  it("boot notice: threadId null omits message_thread_id from send opts", () => {
+    const { deps, sends } = makeCardDeps({ chat: { chatId: "777", threadId: null } });
+    deliverModelSwitchBootNotice({
+      ...deps,
+      confirmation: { kind: "default", launched: "claude-sonnet-5" },
+      hasSessionModelAlert: false,
+    });
+    expect(sends).toHaveLength(1);
+    expect(sends[0].chatId).toBe("777");
+    expect(sends[0].opts).toEqual({ parse_mode: "Markdown" });
   });
 });
 

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -32,6 +32,10 @@ import {
   parseModelSwitchTarget,
   modelFamilyToken,
   MODEL_ALIASES,
+  servedModelMatchesRequested,
+  formatServedModelDivergenceLog,
+  formatServedModelDivergenceCard,
+  unvalidatedIdCaveat,
   type ModelCommandDeps,
 } from "../gateway/model-command.js";
 
@@ -689,5 +693,98 @@ describe("modelFamilyToken", () => {
   it("keeps sr-* routing ids verbatim (no claude- prefix)", () => {
     expect(modelFamilyToken("sr-glm-5")).toBe("sr-glm-5");
     expect(modelFamilyToken("sr-gemini-2.5-flash")).toBe("sr-gemini-2.5-flash");
+  });
+});
+
+// ── #3427 item 4: requested-vs-served divergence (fallback-model masking) ────
+
+describe("servedModelMatchesRequested", () => {
+  it("matches a requested alias against its resolved full id (family)", () => {
+    expect(servedModelMatchesRequested("sonnet", "claude-sonnet-5")).toBe(true);
+    expect(servedModelMatchesRequested("opus", "claude-opus-4-8")).toBe(true);
+    expect(servedModelMatchesRequested("fable", "claude-fable-5")).toBe(true);
+  });
+
+  it("flags a requested alias served by a DIFFERENT family (fallback substituted)", () => {
+    expect(servedModelMatchesRequested("sonnet", "claude-opus-4-8")).toBe(false);
+    expect(servedModelMatchesRequested("haiku", "claude-sonnet-5")).toBe(false);
+  });
+
+  it("matches a full id exactly and as a date-stamped descendant", () => {
+    expect(servedModelMatchesRequested("claude-sonnet-5", "claude-sonnet-5")).toBe(true);
+    expect(servedModelMatchesRequested("claude-sonnet-5", "claude-sonnet-5-20260203")).toBe(true);
+    expect(servedModelMatchesRequested("Claude-Sonnet-5", "claude-sonnet-5")).toBe(true);
+  });
+
+  it("flags an invalid/unknown full id served by the fallback — the masking case", () => {
+    // THE #3427 item-4 case: `/model claude-sonnet-9` (nonexistent) launches,
+    // --fallback-model silently serves opus. A test that wouldn't fail on the
+    // masking is not a test: this must be a MISMATCH.
+    expect(servedModelMatchesRequested("claude-sonnet-9", "claude-opus-4-8")).toBe(false);
+    // Same-family but wrong version is still a mismatch (sonnet-9 ≠ sonnet-5).
+    expect(servedModelMatchesRequested("claude-sonnet-9", "claude-sonnet-5")).toBe(false);
+  });
+
+  it("is conservative: non-claude served ids and non-comparable requests never accuse", () => {
+    // LiteLLM/sr-* served names are not deterministically comparable.
+    expect(servedModelMatchesRequested("sr-glm-5", "glm-5")).toBe(true);
+    expect(servedModelMatchesRequested("claude-sonnet-5", "sr-glm-5")).toBe(true);
+    // Legacy friendly-label overrides ("Opus 4.8") are not comparable either.
+    expect(servedModelMatchesRequested("Opus 4.8", "claude-opus-4-8")).toBe(true);
+    // The default sentinel never diverges.
+    expect(servedModelMatchesRequested("default", "claude-opus-4-8")).toBe(true);
+  });
+});
+
+describe("served-model divergence formatters (#3427 item 4)", () => {
+  it("log line is greppable and names requested + served", () => {
+    const log = formatServedModelDivergenceLog({
+      agent: "klanker",
+      requested: "claude-sonnet-9",
+      served: "claude-opus-4-8",
+    });
+    expect(log).toContain("gw /model served-model DIVERGENCE agent=klanker");
+    expect(log).toContain("requested=claude-sonnet-9");
+    expect(log).toContain("served=claude-opus-4-8");
+    expect(log.endsWith("\n")).toBe(true);
+  });
+
+  it("card warns, names both models in backticks, and says how to recover", () => {
+    const card = formatServedModelDivergenceCard({
+      requested: "claude-sonnet-9",
+      served: "claude-opus-4-8",
+    });
+    expect(card).toContain("⚠️");
+    expect(card).toContain("`claude-opus-4-8`");
+    expect(card).toContain("`claude-sonnet-9`");
+    expect(card).toContain("/model");
+    expect(card).not.toContain("✅");
+  });
+});
+
+describe("unvalidatedIdCaveat — immediate fail-fast warn on free-text claude-* ids (#3427 item 4)", () => {
+  const esc = { escapeHtml: (s: string) => s };
+
+  it("warns for a full claude-* id (cannot be pre-validated)", () => {
+    const caveat = unvalidatedIdCaveat(esc, "claude-sonnet-9");
+    expect(caveat).not.toBeNull();
+    expect(caveat).toContain("claude-sonnet-9");
+    expect(caveat).toContain("fallback");
+  });
+
+  it("stays silent for aliases, sr-* ids and the default sentinel", () => {
+    expect(unvalidatedIdCaveat(esc, "opus")).toBeNull();
+    expect(unvalidatedIdCaveat(esc, "sonnet")).toBeNull();
+    expect(unvalidatedIdCaveat(esc, "sr-glm-5")).toBeNull();
+    expect(unvalidatedIdCaveat(esc, "default")).toBeNull();
+  });
+
+  it("the /model set ACK carries the caveat for a typed full id — and not for an alias", async () => {
+    const { deps } = makeDeps();
+    const full = await handleModelCommand({ kind: "set", model: "claude-sonnet-9" }, deps);
+    expect(full.text).toContain("can't be validated before launch");
+    expect(full.text).toContain("fallback");
+    const alias = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(alias.text).not.toContain("can't be validated before launch");
   });
 });

--- a/telegram-plugin/tests/session-model-source.test.ts
+++ b/telegram-plugin/tests/session-model-source.test.ts
@@ -82,11 +82,12 @@ describe('createSessionModelSource — freshest observation wins', () => {
 // ── #3427 item 4: requested-vs-served divergence tripwire ────────────────────
 //
 // `--fallback-model` masks an invalid requested id: the override carries the
-// requested token while claude silently serves the fallback. The FIRST
-// transcript observation after an override is the earliest deterministic
-// verification point — these assert the handler FIRES on a mismatch (with the
-// right payload), fires at most once per override, and never fires without a
-// comparator or on a match.
+// requested token while claude silently serves the fallback. The FIRST live
+// transcript observation of the post-relaunch session is the earliest
+// deterministic verification point — these assert the handler FIRES on a
+// mismatch (with the right payload), fires at most once per armed override,
+// and — the #3437 H1/H2 false-positive contract — NEVER fires from a
+// command-time (unarmed) override set or from a first-attach replay line.
 
 describe('createSessionModelSource — divergence tripwire (#3427)', () => {
   function armed() {
@@ -96,61 +97,122 @@ describe('createSessionModelSource — divergence tripwire (#3427)', () => {
     return { s, fired }
   }
 
-  it('fires ONCE with requested+served when the first post-override line serves a different model', () => {
+  it('fires ONCE with requested+served when the first post-boot line serves a different model', () => {
     const { s, fired } = armed()
-    s.setOverride('claude-sonnet-9') // invalid id — --fallback-model will substitute
+    s.setOverride('claude-sonnet-9', { verify: true }) // boot rehydration: invalid id, fallback will substitute
     s.noteTranscriptModel('claude-opus-4-8') // first assistant line: the fallback
     expect(fired).toEqual([{ requested: 'claude-sonnet-9', served: 'claude-opus-4-8' }])
-    // Subsequent lines do not re-fire (once per override set).
+    // Subsequent lines do not re-fire (once per armed override).
     s.noteTranscriptModel('claude-opus-4-8')
     expect(fired).toHaveLength(1)
   })
 
   it('does NOT fire when the served model satisfies the requested token (alias → full id)', () => {
     const { s, fired } = armed()
-    s.setOverride('sonnet')
+    s.setOverride('sonnet', { verify: true })
     s.noteTranscriptModel('claude-sonnet-5')
     expect(fired).toHaveLength(0)
   })
 
-  it('verification is consumed by the FIRST observation — a later different model is a normal switch, not a divergence', () => {
+  it('verification is consumed by the FIRST live observation — a later different model is a normal switch, not a divergence', () => {
     const { s, fired } = armed()
-    s.setOverride('claude-opus-4-8')
+    s.setOverride('claude-opus-4-8', { verify: true })
     s.noteTranscriptModel('claude-opus-4-8') // verified OK
     s.noteTranscriptModel('claude-sonnet-5') // e.g. a native in-session switch
     expect(fired).toHaveLength(0)
   })
 
-  it('re-arms on every new override set', () => {
+  it('re-arms on every verify-set', () => {
     const { s, fired } = armed()
-    s.setOverride('claude-opus-4-8')
+    s.setOverride('claude-opus-4-8', { verify: true })
     s.noteTranscriptModel('claude-opus-4-8') // ok
-    s.setOverride('claude-sonnet-9') // second switch, bogus id
+    s.setOverride('claude-sonnet-9', { verify: true }) // next apply-boot, bogus id
     s.noteTranscriptModel('claude-opus-4-8') // fallback again
     expect(fired).toEqual([{ requested: 'claude-sonnet-9', served: 'claude-opus-4-8' }])
   })
 
   it('clearing the override disarms (nothing to verify)', () => {
     const { s, fired } = armed()
-    s.setOverride('claude-sonnet-9')
+    s.setOverride('claude-sonnet-9', { verify: true })
     s.setOverride(null)
     s.noteTranscriptModel('claude-opus-4-8')
     expect(fired).toHaveLength(0)
+  })
+
+  // H1 (#3437 review blocker): the command-time scheduleModelRelaunch record —
+  // setOverride(model) with NO verify — must not arm. The prior boot may have
+  // left the handler registered and its own arm consumed; an assistant line in
+  // the pre-restart window is served by the OLD model and would otherwise
+  // false-accuse a perfectly valid NEW token.
+  it('H1: a command-time setOverride (no verify) NEVER arms — no false DIVERGENCE in the pre-restart window', () => {
+    const { s, fired } = armed()
+    // Prior apply-boot: armed, verified OK on the first line.
+    s.setOverride('claude-opus-4-8', { verify: true })
+    s.noteTranscriptModel('claude-opus-4-8')
+    // Operator issues /model <valid new id>; scheduleModelRelaunch records it
+    // pre-restart (status honesty) WITHOUT verify.
+    s.setOverride('claude-sonnet-5')
+    // The still-running OLD session emits another assistant line before the
+    // restart lands — served by the OLD model. Must NOT fire.
+    s.noteTranscriptModel('claude-opus-4-8')
+    expect(fired).toHaveLength(0)
+    // …and the override record itself is intact for /status honesty.
+    expect(s.getOverride()).toBe('claude-sonnet-5')
+  })
+
+  it('H1: a verify-arm is CLEARED by a later plain set (the newest write wins, unarmed)', () => {
+    const { s, fired } = armed()
+    s.setOverride('claude-sonnet-9', { verify: true }) // armed, not yet verified
+    s.setOverride('claude-haiku-4-5') // command-time re-set before any line
+    s.noteTranscriptModel('claude-opus-4-8')
+    expect(fired).toHaveLength(0)
+  })
+
+  // H2 (#3437 review blocker): the session-tail's first-attach replay delivers
+  // the PRIOR session's in-flight turn AFTER boot — OLD-model lines. They must
+  // neither fire nor consume verification; the first LIVE line still verifies.
+  it('H2: replayed observations neither fire nor consume — the first LIVE line still verifies (valid switch, no card)', () => {
+    const { s, fired } = armed()
+    s.setOverride('claude-sonnet-5', { verify: true }) // apply-boot onto a VALID id
+    // Boot replay of the pre-relaunch in-flight turn (old model claude-opus-4-8).
+    s.noteTranscriptModel('claude-opus-4-8', { replayed: true })
+    s.noteTranscriptModel('claude-opus-4-8', { replayed: true })
+    expect(fired).toHaveLength(0) // the false-positive path the review flagged
+    // First LIVE line of the new session: the requested model. Verified clean.
+    s.noteTranscriptModel('claude-sonnet-5')
+    expect(fired).toHaveLength(0)
+  })
+
+  it('H2: a genuinely bogus id still fires on the first LIVE line after replay', () => {
+    const { s, fired } = armed()
+    s.setOverride('claude-sonnet-9', { verify: true })
+    s.noteTranscriptModel('claude-opus-4-8', { replayed: true }) // replayed old-turn line: ignored
+    expect(fired).toHaveLength(0)
+    s.noteTranscriptModel('claude-opus-4-8') // first LIVE line: the fallback
+    expect(fired).toEqual([{ requested: 'claude-sonnet-9', served: 'claude-opus-4-8' }])
+  })
+
+  it('replayed observations still update /status freshness exactly as before', () => {
+    const { s } = armed()
+    s.setOverride('claude-sonnet-5', { verify: true })
+    s.noteTranscriptModel('claude-opus-4-8', { replayed: true })
+    // Freshness contract unchanged: the newer observation (transcript) wins.
+    expect(s.resolve()).toEqual({ model: 'claude-opus-4-8', source: 'transcript' })
   })
 
   it('never fires without a comparator (default construction) — old callers unchanged', () => {
     const fired: SessionModelDivergence[] = []
     const s = createSessionModelSource()
     s.setDivergenceHandler((d) => fired.push(d))
-    s.setOverride('claude-sonnet-9')
+    s.setOverride('claude-sonnet-9', { verify: true })
     s.noteTranscriptModel('claude-opus-4-8')
     expect(fired).toHaveLength(0)
   })
 
-  it('the handler may clear the override (the gateway does) without breaking resolution', () => {
+  it('a handler that clears the override does not break resolution', () => {
     const s = createSessionModelSource({ servedMatchesRequested: servedModelMatchesRequested })
     s.setDivergenceHandler(() => s.setOverride(null))
-    s.setOverride('claude-sonnet-9')
+    s.setOverride('claude-sonnet-9', { verify: true })
     s.noteTranscriptModel('claude-opus-4-8')
     expect(s.getOverride()).toBeNull()
     expect(s.resolve()).toEqual({ model: 'claude-opus-4-8', source: 'transcript' })

--- a/telegram-plugin/tests/session-model-source.test.ts
+++ b/telegram-plugin/tests/session-model-source.test.ts
@@ -10,6 +10,8 @@
  */
 import { describe, it, expect } from 'vitest'
 import { createSessionModelSource } from '../gateway/session-model-source.js'
+import type { SessionModelDivergence } from '../gateway/session-model-source.js'
+import { servedModelMatchesRequested } from '../gateway/model-command.js'
 
 describe('createSessionModelSource — freshest observation wins', () => {
   it('returns null when neither source has reported', () => {
@@ -74,5 +76,83 @@ describe('createSessionModelSource — freshest observation wins', () => {
     expect(s.resolve()?.source).toBe('transcript')
     // ...but the override record itself is still readable (menu "session" marker).
     expect(s.getOverride()).toBe('sr-glm-5')
+  })
+})
+
+// ── #3427 item 4: requested-vs-served divergence tripwire ────────────────────
+//
+// `--fallback-model` masks an invalid requested id: the override carries the
+// requested token while claude silently serves the fallback. The FIRST
+// transcript observation after an override is the earliest deterministic
+// verification point — these assert the handler FIRES on a mismatch (with the
+// right payload), fires at most once per override, and never fires without a
+// comparator or on a match.
+
+describe('createSessionModelSource — divergence tripwire (#3427)', () => {
+  function armed() {
+    const fired: SessionModelDivergence[] = []
+    const s = createSessionModelSource({ servedMatchesRequested: servedModelMatchesRequested })
+    s.setDivergenceHandler((d) => fired.push(d))
+    return { s, fired }
+  }
+
+  it('fires ONCE with requested+served when the first post-override line serves a different model', () => {
+    const { s, fired } = armed()
+    s.setOverride('claude-sonnet-9') // invalid id — --fallback-model will substitute
+    s.noteTranscriptModel('claude-opus-4-8') // first assistant line: the fallback
+    expect(fired).toEqual([{ requested: 'claude-sonnet-9', served: 'claude-opus-4-8' }])
+    // Subsequent lines do not re-fire (once per override set).
+    s.noteTranscriptModel('claude-opus-4-8')
+    expect(fired).toHaveLength(1)
+  })
+
+  it('does NOT fire when the served model satisfies the requested token (alias → full id)', () => {
+    const { s, fired } = armed()
+    s.setOverride('sonnet')
+    s.noteTranscriptModel('claude-sonnet-5')
+    expect(fired).toHaveLength(0)
+  })
+
+  it('verification is consumed by the FIRST observation — a later different model is a normal switch, not a divergence', () => {
+    const { s, fired } = armed()
+    s.setOverride('claude-opus-4-8')
+    s.noteTranscriptModel('claude-opus-4-8') // verified OK
+    s.noteTranscriptModel('claude-sonnet-5') // e.g. a native in-session switch
+    expect(fired).toHaveLength(0)
+  })
+
+  it('re-arms on every new override set', () => {
+    const { s, fired } = armed()
+    s.setOverride('claude-opus-4-8')
+    s.noteTranscriptModel('claude-opus-4-8') // ok
+    s.setOverride('claude-sonnet-9') // second switch, bogus id
+    s.noteTranscriptModel('claude-opus-4-8') // fallback again
+    expect(fired).toEqual([{ requested: 'claude-sonnet-9', served: 'claude-opus-4-8' }])
+  })
+
+  it('clearing the override disarms (nothing to verify)', () => {
+    const { s, fired } = armed()
+    s.setOverride('claude-sonnet-9')
+    s.setOverride(null)
+    s.noteTranscriptModel('claude-opus-4-8')
+    expect(fired).toHaveLength(0)
+  })
+
+  it('never fires without a comparator (default construction) — old callers unchanged', () => {
+    const fired: SessionModelDivergence[] = []
+    const s = createSessionModelSource()
+    s.setDivergenceHandler((d) => fired.push(d))
+    s.setOverride('claude-sonnet-9')
+    s.noteTranscriptModel('claude-opus-4-8')
+    expect(fired).toHaveLength(0)
+  })
+
+  it('the handler may clear the override (the gateway does) without breaking resolution', () => {
+    const s = createSessionModelSource({ servedMatchesRequested: servedModelMatchesRequested })
+    s.setDivergenceHandler(() => s.setOverride(null))
+    s.setOverride('claude-sonnet-9')
+    s.noteTranscriptModel('claude-opus-4-8')
+    expect(s.getOverride()).toBeNull()
+    expect(s.resolve()).toEqual({ model: 'claude-opus-4-8', source: 'transcript' })
   })
 })

--- a/telegram-plugin/tests/session-tail-first-attach.test.ts
+++ b/telegram-plugin/tests/session-tail-first-attach.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, statSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, appendFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { computeFirstAttachCursor } from '../session-tail.js'
+import {
+  computeFirstAttachCursor,
+  getProjectsDirForCwd,
+  startSessionTail,
+  type SessionEvent,
+} from '../session-tail.js'
 
 /**
  * computeFirstAttachCursor: on first attach to a transcript, seek to EOF
@@ -61,5 +66,113 @@ describe('computeFirstAttachCursor', () => {
   it('empty / missing file → returns the given size (degrades to EOF)', () => {
     const missing = join(dir, 'nope.jsonl')
     expect(computeFirstAttachCursor(missing, 0)).toBe(0)
+  })
+})
+
+// ── #3427 H2: first-attach replay marks `model` events as replayed ───────────
+//
+// A /model relaunch during an active turn is EXACTLY the shape that triggers
+// the in-flight-turn replay above: the new gateway attaches to the OLD
+// session's JSONL and replays its enqueue + assistant lines — which carry the
+// PRE-relaunch model. Those replayed `model` observations must be flagged so
+// the divergence tripwire (session-model-source) ignores them; live lines
+// appended after attach must NOT be flagged. Outcome-asserted against the
+// real tailer, not the source.
+
+describe('startSessionTail — replayed model events are flagged (#3427 H2)', () => {
+  const tempDirs: string[] = []
+  afterEach(() => {
+    for (const d of tempDirs) {
+      try { rmSync(d, { recursive: true, force: true }) } catch { /* ignore */ }
+    }
+    tempDirs.length = 0
+  })
+
+  function mkProjectsDir(): { claudeHome: string; cwd: string; projectsDir: string } {
+    const base = mkdtempSync(join(tmpdir(), 'first-attach-replayed-'))
+    tempDirs.push(base)
+    const cwd = join(base, 'agent')
+    const claudeHome = join(base, 'claude-home')
+    const projectsDir = getProjectsDirForCwd(cwd, claudeHome)
+    mkdirSync(projectsDir, { recursive: true })
+    return { claudeHome, cwd, projectsDir }
+  }
+
+  const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+  const assistantModelLine = (model: string): string =>
+    JSON.stringify({
+      type: 'assistant',
+      message: { model, content: [{ type: 'text', text: 'hi' }] },
+    }) + '\n'
+
+  function modelEvents(events: SessionEvent[]): Array<{ model: string; replayed?: boolean }> {
+    return events.filter((e): e is Extract<SessionEvent, { kind: 'model' }> => e.kind === 'model')
+  }
+
+  it('mid-turn restart: replayed OLD-model lines carry replayed:true; a live line appended after attach does not', async () => {
+    const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+    const file = join(projectsDir, 'sess.jsonl')
+    // The pre-relaunch session ended mid-turn: enqueue with no turn_duration,
+    // followed by an assistant line served by the OLD model.
+    writeFileSync(
+      file,
+      ENQUEUE + '\n' + DEQUEUE + '\n' + assistantModelLine('claude-opus-4-8'),
+    )
+
+    const events: SessionEvent[] = []
+    const handle = startSessionTail({
+      cwd,
+      claudeHome,
+      rescanIntervalMs: 50,
+      onEvent: (ev) => { events.push(ev) },
+    })
+    try {
+      await wait(200) // attach + replay the in-flight turn
+      const replayedBatch = modelEvents(events)
+      expect(replayedBatch.length).toBeGreaterThan(0)
+      // THE H2 false-positive shape: the old model arrives AFTER boot — but
+      // flagged, so the divergence tripwire skips it.
+      expect(replayedBatch[0]).toMatchObject({ model: 'claude-opus-4-8', replayed: true })
+
+      // The live session now writes its first assistant line (new model).
+      appendFileSync(file, assistantModelLine('claude-sonnet-5'))
+      await wait(200)
+      const all = modelEvents(events)
+      const live = all[all.length - 1]
+      expect(live.model).toBe('claude-sonnet-5')
+      expect(live.replayed).not.toBe(true)
+    } finally {
+      handle.stop()
+    }
+  })
+
+  it('completed-turn attach (no replay): appended model lines are never flagged', async () => {
+    const { claudeHome, cwd, projectsDir } = mkProjectsDir()
+    const file = join(projectsDir, 'sess.jsonl')
+    writeFileSync(
+      file,
+      ENQUEUE + '\n' + assistantModelLine('claude-opus-4-8') + TURN_DURATION + '\n',
+    )
+
+    const events: SessionEvent[] = []
+    const handle = startSessionTail({
+      cwd,
+      claudeHome,
+      rescanIntervalMs: 50,
+      onEvent: (ev) => { events.push(ev) },
+    })
+    try {
+      await wait(200) // attach seeks to EOF — no replay
+      expect(modelEvents(events)).toHaveLength(0)
+      appendFileSync(file, assistantModelLine('claude-sonnet-5'))
+      await wait(200)
+      const all = modelEvents(events)
+      expect(all.length).toBeGreaterThan(0)
+      expect(all[all.length - 1].model).toBe('claude-sonnet-5')
+      expect(all[all.length - 1].replayed).not.toBe(true)
+    } finally {
+      handle.stop()
+    }
   })
 })

--- a/tests/doctor-fix-session-model.test.ts
+++ b/tests/doctor-fix-session-model.test.ts
@@ -13,8 +13,9 @@ import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from "node
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
+import { Command } from "commander";
 import { scaffoldAgent, reconcileAgent } from "../src/agents/scaffold.js";
-import { checkStartShSessionModelCarrier } from "../src/cli/doctor.js";
+import { checkStartShSessionModelCarrier, registerDoctorCommand } from "../src/cli/doctor.js";
 import {
   fixSessionModelCarrierDrift,
   type SessionModelCarrierFixDeps,
@@ -76,9 +77,10 @@ describe("fixSessionModelCarrierDrift — integration (real scaffold + real reco
       check: checkStartShSessionModelCarrier,
       reconcile: (agent) => {
         reconcileCalls.push(agent);
-        reconcileAgent(agent, config.agents![agent]!, agentsDir, telegramConfig, config, undefined, {
+        const result = reconcileAgent(agent, config.agents![agent]!, agentsDir, telegramConfig, config, undefined, {
           preserveClaudeMd: true,
         });
+        return { changes: result.changes };
       },
     };
   });
@@ -98,6 +100,10 @@ describe("fixSessionModelCarrierDrift — integration (real scaffold + real reco
     expect(results[0].status).toBe("ok");
     expect(results[0].detail).toContain("healed");
     expect(results[0].detail).toContain("next restart");
+    // M1 (#3437): the row discloses the FULL reconcile scope — the actual
+    // rewritten file list (start.sh among them), not a start.sh-only claim.
+    expect(results[0].detail).toContain("Full per-agent reconcile applied");
+    expect(results[0].detail).toContain("start.sh");
     expect(reconcileCalls).toEqual([name]);
 
     // The heal claim is grounded: the file on disk now passes the tripwire
@@ -162,7 +168,7 @@ describe("fixSessionModelCarrierDrift — failure honesty (stubbed seams)", () =
         calls += 1;
         return { name: "x", status: "fail", detail: "still legacy" };
       },
-      reconcile: () => {},
+      reconcile: () => ({ changes: ["/a/start.sh"] }),
     });
     expect(calls).toBe(2); // pre + post
     expect(results[0].status).toBe("fail");
@@ -175,9 +181,24 @@ describe("fixSessionModelCarrierDrift — failure honesty (stubbed seams)", () =
       check: () => ({ name: "x", status: "skip", detail: "unreadable from host" }),
       reconcile: () => {
         reconciled = true;
+        return { changes: [] };
       },
     });
     expect(results[0].status).toBe("skip");
     expect(reconciled).toBe(false);
+  });
+});
+
+describe("doctor --fix commander wiring (L2)", () => {
+  it("registers --fix on the doctor command with the full-reconcile disclosure", () => {
+    const program = new Command();
+    registerDoctorCommand(program);
+    const doctor = program.commands.find((c) => c.name() === "doctor");
+    expect(doctor).toBeDefined();
+    const fixOpt = doctor!.options.find((o) => o.long === "--fix");
+    expect(fixOpt).toBeDefined();
+    // The help text must disclose that --fix is a FULL per-agent reconcile
+    // (M1), not a start.sh-only rewrite.
+    expect(fixOpt!.description).toContain("FULL per-agent reconcile");
   });
 });

--- a/tests/doctor-fix-session-model.test.ts
+++ b/tests/doctor-fix-session-model.test.ts
@@ -1,0 +1,183 @@
+/**
+ * `switchroom doctor --fix` — rev5 /model carrier auto-remediation
+ * (#3427 item 1, follow-up to #3424's detection-only tripwire).
+ *
+ * Outcome tests, not code-path tests: the integration suite scaffolds a REAL
+ * agent tree, mangles start.sh to the live pre-rev5 legacy shape (the drift
+ * #3424 detected in the field), runs the fix with the REAL `reconcileAgent`,
+ * and asserts the healed start.sh actually passes the #3424 carrier check —
+ * plus idempotency (a second run performs NO reconcile and rewrites nothing).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { scaffoldAgent, reconcileAgent } from "../src/agents/scaffold.js";
+import { checkStartShSessionModelCarrier } from "../src/cli/doctor.js";
+import {
+  fixSessionModelCarrierDrift,
+  type SessionModelCarrierFixDeps,
+} from "../src/cli/doctor-fix-session-model.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeConfig(name: string, agentsDir: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: agentsDir,
+      skills_dir: join(agentsDir, "..", "skills"),
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  } as SwitchroomConfig;
+}
+
+/** The live pre-rev5 legacy start.sh shape #3424's doctor check FAILs on. */
+const LEGACY_START_SH = [
+  "#!/usr/bin/env bash",
+  "# --- Session-only model override (carrier: .session-model-override) ---",
+  'if [ -f "/state/agent/.session-model-override" ]; then',
+  '  _override="$(cat "/state/agent/.session-model-override")"',
+  '  rm -f "/state/agent/.session-model-override"',
+  '  _EFFECTIVE_MODEL="$_override"',
+  "fi",
+  'exec claude --model "$_EFFECTIVE_MODEL"',
+].join("\n");
+
+describe("fixSessionModelCarrierDrift — integration (real scaffold + real reconcile)", () => {
+  let agentsDir: string;
+  const name = "fixme";
+  let config: SwitchroomConfig;
+  let reconcileCalls: string[];
+  let deps: SessionModelCarrierFixDeps;
+
+  beforeEach(() => {
+    agentsDir = mkdtempSync(join(tmpdir(), "switchroom-doctor-fix-"));
+    const agentConfig = makeAgentConfig();
+    config = makeConfig(name, agentsDir, agentConfig);
+    scaffoldAgent(name, agentConfig, agentsDir, telegramConfig, config);
+    reconcileCalls = [];
+    deps = {
+      check: checkStartShSessionModelCarrier,
+      reconcile: (agent) => {
+        reconcileCalls.push(agent);
+        reconcileAgent(agent, config.agents![agent]!, agentsDir, telegramConfig, config, undefined, {
+          preserveClaudeMd: true,
+        });
+      },
+    };
+  });
+
+  afterEach(() => {
+    rmSync(agentsDir, { recursive: true, force: true });
+  });
+
+  it("drift → heal → the regenerated start.sh PASSES the #3424 carrier check", () => {
+    const startShPath = join(agentsDir, name, "start.sh");
+    // Mangle to the live pre-rev5 legacy shape and prove it's detected as drift.
+    writeFileSync(startShPath, LEGACY_START_SH);
+    expect(checkStartShSessionModelCarrier(name, startShPath).status).toBe("fail");
+
+    const results = fixSessionModelCarrierDrift(config, deps);
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("ok");
+    expect(results[0].detail).toContain("healed");
+    expect(results[0].detail).toContain("next restart");
+    expect(reconcileCalls).toEqual([name]);
+
+    // The heal claim is grounded: the file on disk now passes the tripwire
+    // and carries the real rev5 apply path (not just any content change).
+    expect(checkStartShSessionModelCarrier(name, startShPath).status).toBe("ok");
+    const healed = readFileSync(startShPath, "utf-8");
+    expect(healed).toContain(".session-model");
+    expect(healed).toContain("configuredDefaultAtWrite");
+  });
+
+  it("is idempotent: a healthy fleet is never reconciled and start.sh is not rewritten", () => {
+    const startShPath = join(agentsDir, name, "start.sh");
+    writeFileSync(startShPath, LEGACY_START_SH);
+    fixSessionModelCarrierDrift(config, deps); // heal
+    const healedContent = readFileSync(startShPath, "utf-8");
+    const healedMtime = statSync(startShPath).mtimeMs;
+    reconcileCalls.length = 0;
+
+    const second = fixSessionModelCarrierDrift(config, deps);
+    expect(second).toHaveLength(1);
+    expect(second[0].status).toBe("ok");
+    expect(second[0].detail).toContain("nothing to fix");
+    expect(reconcileCalls).toEqual([]); // the gate, not just writeIfChanged
+    expect(readFileSync(startShPath, "utf-8")).toBe(healedContent);
+    expect(statSync(startShPath).mtimeMs).toBe(healedMtime);
+  });
+
+  it("heals a MISSING start.sh too (warn → regenerate → ok)", () => {
+    const startShPath = join(agentsDir, name, "start.sh");
+    rmSync(startShPath);
+    expect(checkStartShSessionModelCarrier(name, startShPath).status).toBe("warn");
+
+    const results = fixSessionModelCarrierDrift(config, deps);
+    expect(results[0].status).toBe("ok");
+    expect(results[0].detail).toContain("healed");
+    expect(checkStartShSessionModelCarrier(name, startShPath).status).toBe("ok");
+  });
+});
+
+describe("fixSessionModelCarrierDrift — failure honesty (stubbed seams)", () => {
+  const config = makeConfig("stub", "/nonexistent-agents-dir", makeAgentConfig());
+
+  it("reports a fail (not a heal) when reconcile throws", () => {
+    const results = fixSessionModelCarrierDrift(config, {
+      check: () => ({ name: "x", status: "fail", detail: "legacy-only carrier" }),
+      reconcile: () => {
+        throw new Error("profiles tree missing");
+      },
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("fail");
+    expect(results[0].detail).toContain("reconcile failed: profiles tree missing");
+    expect(results[0].detail).toContain("legacy-only carrier");
+  });
+
+  it("reports a fail when the regenerated start.sh STILL fails the check (stale template)", () => {
+    // A reconcile that "succeeds" but the re-run check still fails must NOT be
+    // reported as healed — the claim is the post-write check, never the write.
+    let calls = 0;
+    const results = fixSessionModelCarrierDrift(config, {
+      check: () => {
+        calls += 1;
+        return { name: "x", status: "fail", detail: "still legacy" };
+      },
+      reconcile: () => {},
+    });
+    expect(calls).toBe(2); // pre + post
+    expect(results[0].status).toBe("fail");
+    expect(results[0].detail).toContain("still fails the carrier check");
+  });
+
+  it("passes through the host-unreadable skip untouched (cannot verify → must not write)", () => {
+    let reconciled = false;
+    const results = fixSessionModelCarrierDrift(config, {
+      check: () => ({ name: "x", status: "skip", detail: "unreadable from host" }),
+      reconcile: () => {
+        reconciled = true;
+      },
+    });
+    expect(results[0].status).toBe("skip");
+    expect(reconciled).toBe(false);
+  });
+});

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, chmodSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, chmodSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -628,8 +628,13 @@ describe("scaffoldAgent: live configured-default resolution (start.sh)", () => {
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "switchroom-live-model-"));
-    fakeBin = join(tmpDir, "fakebin");
-    mkdirSync(fakeBin, { recursive: true });
+    // The fake `switchroom` CLI must live on a filesystem that allows exec —
+    // os.tmpdir() (/tmp) is mounted noexec in the dev container, which made
+    // every live read silently fail (exit 126, stderr suppressed) and fall
+    // back to the bake, failing the live-resolution subset on main (#3427
+    // item 3). /var/tmp is exec-capable here and on CI; same convention as
+    // turn-pacing-hook.test.ts and host-control/server.test.ts.
+    fakeBin = mkdtempSync(join("/var/tmp", "switchroom-live-model-bin-"));
     cfgPath = join(tmpDir, "switchroom.yaml");
     writeFileSync(cfgPath, "agents: {}\n");
     scaffold();
@@ -637,6 +642,7 @@ describe("scaffoldAgent: live configured-default resolution (start.sh)", () => {
 
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(fakeBin, { recursive: true, force: true });
   });
 
   // THE regression test the fable launch bug was missing: yaml edited to

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -641,8 +641,11 @@ describe("scaffoldAgent: live configured-default resolution (start.sh)", () => {
   });
 
   afterEach(() => {
-    rmSync(tmpDir, { recursive: true, force: true });
-    rmSync(fakeBin, { recursive: true, force: true });
+    // Guard both: a beforeEach that throws mid-way leaves one (or both)
+    // unassigned, and an unguarded rmSync(undefined) would mask the real
+    // failure with a TypeError in afterEach.
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    if (fakeBin) rmSync(fakeBin, { recursive: true, force: true });
   });
 
   // THE regression test the fable launch bug was missing: yaml edited to


### PR DESCRIPTION
Implements all four items of #3427 (follow-ups to #3424, which shipped detection + honesty only).

## 1. Auto-remediation (primary) — DONE
`switchroom doctor --fix` heals rev5 `.session-model` carrier drift instead of only reporting it:

- New module `src/cli/doctor-fix-session-model.ts`: for each agent, run the #3424 tripwire (`checkStartShSessionModelCarrier`); on `fail`/`warn` regenerate `start.sh` via the standard per-agent **reconcile** (`reconcileAgent(…, { preserveClaudeMd: true })` — the same code path `switchroom apply` uses), then **re-run the check** and report the post-fix status. The heal claim is always a re-run check, never an assumed success.
- **Deterministic + idempotent**: healthy agents are never reconciled (proven by test — second run performs zero reconcile calls, content + mtime unchanged). `start.sh` is purely template-driven ("no user-merged sections, safe to overwrite" — `scaffold.ts`), so full regeneration IS the sanctioned mechanism; no operator content exists in it to clobber. `preserveClaudeMd` keeps the fix scoped away from CLAUDE.md.
- Why not option (a) (boot-time self-heal): the `profiles/_base/` template tree is **not shipped into the agent image** (see `ReconcileOptions.skipProfileTemplates` in `scaffold.ts`) — an agent cannot re-render its own start.sh in-container. The host-side doctor is the earliest place the drift signal and the template coexist.
- The `--fix` remediation section runs before the standard sections, so the Agents section reports post-fix state; check fix strings and `docs/cli-reference.md` now advertise `switchroom doctor --fix`.

## 2. Behavioral tests over source-string assertions — DONE
- The card-vs-suppress decision moved out of the gateway boot IIFE into pure `resolveModelSwitchBootNotice` (model-command.ts) — line-ratchet friendly and unit-testable.
- `gateway-session-model-relaunch.test.ts`'s `toContain`-on-source tests are replaced by behavioral tests that run the real `classifyModelSwitchConfirmation → formatModelRelaunchDiagLog / resolveModelSwitchBootNotice` pipeline and assert the **emitted** outcomes: `NOT-APPLIED` / `outcome=applied` / `outcome=default` log lines, the green applied/default cards, the ⚠️ silent-revert card (with the back-ticked re-issue hint), and the LOW-2 suppress arm (including "applied + alert still confirms"). One thin wiring pin remains for the un-bootable gateway IIFE (documented as such).

## 3. Fix the failing `scaffold.session-model.test.ts` subset — DONE (root-caused, not skipped)
- Root cause: the fake `switchroom` CLI was written under `os.tmpdir()`; `/tmp` is mounted **noexec** in the dev container, so every live read exited 126 (stderr suppressed by the launcher) and fell back to the bake — failing the 7 tests that expect the live value. Repo already has a convention for this (`/var/tmp`, see `turn-pacing-hook.test.ts`, `host-control/server.test.ts`); the fake bin now lives there. **45/45 green** (was 38/45), and runtime dropped 33s → 8s (no more retry timeouts).

## 4. Requested-vs-served divergence window — DONE (in this PR, right-sized)
Two deterministic surfaces replace the silent self-heal:
- **Immediate (command time)**: the `/model` ack for a free-text full `claude-*` id carries a caveat that the id cannot be pre-validated (Claude-native constraint — no raw API probe) and that `--fallback-model` may substitute. Aliases / sr-* / menu-picker tokens (vouched by their own gates) are unaffected.
- **First-output tripwire**: `createSessionModelSource` now verifies the FIRST post-override transcript line against the requested token via `servedModelMatchesRequested` (conservative comparator — alias↔family, full-id↔date-stamped-descendant, never accuses non-comparable pairs like sr-*/labels). On mismatch the gateway logs greppable `gw /model served-model DIVERGENCE …`, **drops the bogus override** (so /status + menu stop claiming it), and sends a one-shot ⚠️ card to the initiating chat.
- RFC `session-model-stickiness.md` "Determinism scope" updated to the new loud contract.
- True pre-launch validation of arbitrary ids would need an API probe, which the Claude-native pillar forbids — this is the tightest deterministic closure available; noted in code comments.

## Tests & lint
- New: `tests/doctor-fix-session-model.test.ts` (6) — real scaffold → mangle to live pre-rev5 legacy shape → real `reconcileAgent` heal → tripwire passes; idempotency (no reconcile calls, no rewrite); missing-start.sh heal; reconcile-throw honesty; still-failing-after-write honesty; skip passthrough.
- New behavioral suites in `model-command.test.ts` (+10), `session-model-source.test.ts` (+7), rewritten `gateway-session-model-relaunch.test.ts`.
- Scoped run: **11 files, 288 passed | 2 skipped** (`doctor.test.ts`, `doctor-fix-session-model.test.ts`, `scaffold.session-model.test.ts`, `check-gateway-line-ratchet.test.ts`, `gateway-session-model-relaunch.test.ts`, `session-model-source.test.ts`, `model-command.test.ts`, `session-model-file.test.ts`, `bot-commands-model-effort.test.ts`, `narrative-lane-golden.test.ts`, `stream-render-golden.test.ts`).
- `npm run lint` exit 0 (tsc + all 12 guard scripts; gateway line ratchet clean at 25099 ≤ 25053+50).
- `npm run build` clean.

Closes #3427

🤖 Generated with [Claude Code](https://claude.com/claude-code)