### PR TITLE
retain: SubagentStop sidechain coverage + recallTagWeights demotion (PR5, workstream B)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2963,6 +2963,17 @@ function renderHindsightSettingsOverrides(
   // =false (exported as HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE only when overridden;
   // the env value wins over this settings.json default).
   settings.directiveCaptureNudge = true;
+  // hindsight-leverage PR5 — recall-side weight for sidechain (sub-agent)
+  // memories. The paired SubagentStop retain (vendor .../subagent_retain.py)
+  // tags delegated worker process-facts `sidechain`; this down-weights their
+  // recall `scores.final` by 0.8 so first-party session memory ranks first,
+  // while a sidechain fact still surfaces when it is the only relevant hit
+  // (a DOWN-RANK, not the hard demote-tag DROP filter). No first-class cascade
+  // knob yet (mirrors the intentionally-dormant recallTags port below);
+  // operators re-tune per-agent by setting HINDSIGHT_RECALL_TAG_WEIGHTS (a JSON
+  // object) via the agent's `env:` map in switchroom.yaml — the env value wins
+  // over this scaffold default (config.py ENV_OVERRIDES).
+  settings.recallTagWeights = { sidechain: 0.8 };
   // Static shared-bank recall (RFC reference/rfcs/per-speaker-memory-routing.md,
   // ship-B): recall these extra banks on every turn, merged into the agent's
   // own bank results. Sourced from memory.recall.additional_banks (cascaded);

--- a/vendor/hindsight-memory/CHANGELOG.md
+++ b/vendor/hindsight-memory/CHANGELOG.md
@@ -20,7 +20,12 @@
   carries a first-class `agent_transcript_path` pointing at
   `<project>/<session>/subagents/agent-<agent_id>.jsonl` (used as the primary
   path), with a directory-scan of the newest `isSidechain:true` jsonl as the
-  fallback for CLIs that omit the field.
+  fallback for CLIs that omit the field. `reconcile_tail.py` and any transcript
+  sweeper now **skip** sidechain transcripts (shared
+  `content.transcript_first_line_is_sidechain` predicate) so the boot reconciler
+  cannot re-retain a sub-agent fork as a pseudo-session — untagged, at full
+  recall weight, bypassing the volume gate — which its recursive `**/*.jsonl`
+  glob would otherwise do one restart after any worker.
 
 - **recall.py: `recallTagWeights` per-tag score penalty** (switchroom
   hindsight-leverage PR5). A `{tag: multiplier}` config map (default `{}`,

--- a/vendor/hindsight-memory/CHANGELOG.md
+++ b/vendor/hindsight-memory/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## [Unreleased]
 
+### Added (switchroom divergence)
+
+- **SubagentStop sidechain retain** (switchroom hindsight-leverage PR5). New
+  `scripts/subagent_retain.py`, registered on the `SubagentStop` event in
+  `hooks/hooks.json` (async, 15s). Delegated (Task-tool / sub-agent) work was
+  the biggest systematic memory hole — the main-session Stop retain only reads
+  the parent `transcript_path`, so a worker's process facts reached memory only
+  as its terse final report. This hook retains a bounded window (last 40 human
+  turns) of the *sidechain* transcript, tagged `sidechain` +
+  `parent_session:<id>`, with a deterministic content-derived `document_id` in a
+  distinct namespace (`{session}-sub-{agent}-r{start}-{end}`) so re-fires upsert.
+  Failures enqueue to the same `pending-retains` durability queue the Stop retain
+  uses. A **volume gate** (< 6 human turns OR < 2,000 chars of non-tool-result
+  text) skips trivial forks (every Task fires SubagentStop, including
+  10-second ones). Empirically probed on Claude Code 2.1.215: the hook input
+  carries a first-class `agent_transcript_path` pointing at
+  `<project>/<session>/subagents/agent-<agent_id>.jsonl` (used as the primary
+  path), with a directory-scan of the newest `isSidechain:true` jsonl as the
+  fallback for CLIs that omit the field.
+
+- **recall.py: `recallTagWeights` per-tag score penalty** (switchroom
+  hindsight-leverage PR5). A `{tag: multiplier}` config map (default `{}`,
+  env `HINDSIGHT_RECALL_TAG_WEIGHTS`) applied to each result's `scores.final`
+  immediately before the relevance sort. Unlike the demote-tag DROP filter
+  (`_is_demoted_memory`), which removes a tagged memory from recall entirely,
+  this DEMOTES (down-ranks) a memory while keeping it recallable when it is the
+  only relevant hit — the "reduced weight" the drop filter cannot express.
+  Switchroom's scaffold seeds `{"sidechain": 0.8}` so delegated-worker
+  process-memories rank just below first-party session memory. **Candidate to
+  upstream** — a general recall-shaping primitive, not switchroom-specific.
+
 ### Changed (switchroom divergence)
 
 - **retain.py: decouple chunked window-slicing from the `retainEveryNTurns > 1`

--- a/vendor/hindsight-memory/hooks/hooks.json
+++ b/vendor/hindsight-memory/hooks/hooks.json
@@ -43,6 +43,18 @@
         ]
       }
     ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent_retain.py\"",
+            "timeout": 15,
+            "async": true
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -80,6 +80,19 @@ DEFAULTS = {
     "recallTagsMatch": "any",
     "recallTagGroups": None,
     "recallAdditionalBankFilters": {},
+    # Switchroom (hindsight-leverage PR5) — per-tag recall score weights. A map
+    # of ``{tag: multiplier}`` applied to each result's ``scores.final`` just
+    # before the final relevance sort/cap in recall.py. A weight < 1.0 DEMOTES
+    # (down-ranks) memories carrying that tag without DROPPING them — distinct
+    # from the hard demote-tag drop filter (`_is_demoted_memory`), which removes
+    # a memory from recall entirely. This is the "reduced weight" the drop
+    # filter cannot express: a demoted memory still surfaces when it is the only
+    # relevant hit, just below equal-scoring untagged memories. Default {} =
+    # no-op (identity weighting). Switchroom's scaffold seeds
+    # ``{"sidechain": 0.8}`` so delegated sub-agent process-memories rank just
+    # under first-party session memories. Env: HINDSIGHT_RECALL_TAG_WEIGHTS
+    # (JSON object).
+    "recallTagWeights": {},
     "recallPromptPreamble": (
         "Relevant memories from past conversations (prioritize recent when "
         "conflicting). Only use memories that are directly useful to continue "
@@ -178,6 +191,7 @@ ENV_OVERRIDES = {
     "HINDSIGHT_RECALL_TAGS": ("recallTags", list),
     "HINDSIGHT_RECALL_TAGS_MATCH": ("recallTagsMatch", str),
     "HINDSIGHT_RECALL_TAG_GROUPS": ("recallTagGroups", dict),
+    "HINDSIGHT_RECALL_TAG_WEIGHTS": ("recallTagWeights", dict),
     "HINDSIGHT_RECALL_ADDITIONAL_BANK_FILTERS": ("recallAdditionalBankFilters", dict),
     "HINDSIGHT_API_PORT": ("apiPort", int),
     "HINDSIGHT_DAEMON_IDLE_TIMEOUT": ("daemonIdleTimeout", int),

--- a/vendor/hindsight-memory/scripts/lib/content.py
+++ b/vendor/hindsight-memory/scripts/lib/content.py
@@ -250,6 +250,43 @@ def slice_last_turns_by_user_boundary(messages: list, turns: int) -> list:
 
 
 # ---------------------------------------------------------------------------
+# Sidechain (sub-agent transcript) detection
+# ---------------------------------------------------------------------------
+
+
+def transcript_first_line_is_sidechain(path: str) -> bool:
+    """True when the first JSON line of ``path`` carries ``isSidechain: true``.
+
+    Switchroom hindsight-leverage PR5. Claude Code writes sub-agent (Task-tool)
+    transcripts as separate ``.jsonl`` files under
+    ``<project>/<session>/subagents/agent-<agent_id>.jsonl`` whose every line
+    carries ``isSidechain: true``. This shared predicate lets BOTH the
+    SubagentStop retain (which resolves + retains these deliberately, tagged
+    ``sidechain`` + volume-gated) AND the boot reconciler / any transcript
+    sweeper (which must NOT treat a sidechain as a pseudo-session and re-retain
+    it untagged, at full recall weight, bypassing the volume gate) recognise a
+    sidechain file from its first line alone — a cheap single-line read. Any
+    read/parse error is treated as "not a sidechain" (fail-open: a
+    genuinely-unreadable file is skipped elsewhere by its empty transcript).
+    """
+    import json
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    return json.loads(line).get("isSidechain") is True
+                except json.JSONDecodeError:
+                    return False
+    except OSError:
+        return False
+    return False
+
+
+# ---------------------------------------------------------------------------
 # Memory formatting (recall results → context string)
 # ---------------------------------------------------------------------------
 

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -562,6 +562,59 @@ def _is_timeout_error(exc: BaseException) -> bool:
     return "timed out" in str(exc).lower()
 
 
+def _apply_tag_weights(results, tag_weights) -> int:
+    """Multiply each result's ``scores.final`` by a per-tag weight in place.
+
+    Switchroom hindsight-leverage PR5 — the recall-side counterpart to the
+    ``sidechain`` retain tag. A NEW mechanism, deliberately distinct from the
+    demote-tag DROP filter (`_is_demoted_memory`): that path removes a tagged
+    memory from recall entirely, which cannot express "keep it, but rank it
+    lower". This step DOWN-WEIGHTS a memory's engine relevance score so a
+    penalised memory sorts below an equal-scoring un-penalised one at the sort
+    below, yet is still returned when it is the only relevant hit (the cap sees
+    the full penalised set, not a filtered one).
+
+    ``tag_weights`` is a ``{tag: multiplier}`` map. For each result, the
+    multipliers of ALL its tags that appear in the map are multiplied together
+    and applied to ``scores.final`` (so a memory carrying two penalised tags is
+    penalised compoundly — intended). Tags are matched case-sensitively after
+    ``strip()`` (consistent with ``_is_demoted_memory``). Results whose
+    ``scores.final`` is absent or non-numeric are left untouched — a score-less
+    entry already sorts last and there is nothing to scale. A weight of exactly
+    1.0 (or a non-positive / non-numeric weight) is a no-op for that tag.
+
+    Returns the number of results whose score was actually changed (for the
+    debug log). Mutation is intentional: the effective (post-weight) score is
+    what the sort, the cap, and the recall-log ranking should all reflect.
+    """
+    if not isinstance(tag_weights, dict) or not tag_weights:
+        return 0
+    changed = 0
+    for m in results:
+        if not isinstance(m, dict):
+            continue
+        tags = m.get("tags")
+        if not isinstance(tags, list):
+            continue
+        factor = 1.0
+        for tag in tags:
+            if not isinstance(tag, str):
+                continue
+            w = tag_weights.get(tag.strip())
+            if isinstance(w, (int, float)) and not isinstance(w, bool) and w > 0:
+                factor *= float(w)
+        if factor == 1.0:
+            continue
+        scores = m.get("scores")
+        if not isinstance(scores, dict):
+            continue
+        val = scores.get("final")
+        if isinstance(val, (int, float)) and not isinstance(val, bool):
+            scores["final"] = float(val) * factor
+            changed += 1
+    return changed
+
+
 def _write_recall_log(entry: dict) -> None:
     """Append a JSONL line to recall_log.jsonl. Bounded by line count.
 
@@ -1256,6 +1309,17 @@ def main():
             )
     else:
         overlap_dropped = 0
+
+    # Switchroom hindsight-leverage PR5 — per-tag score penalty. Applied
+    # IMMEDIATELY before the relevance sort so a down-weighted tag (e.g.
+    # `sidechain: 0.8`) reorders the merged set without dropping anything. This
+    # is the "reduced weight" the demote-tag DROP filter above cannot express:
+    # a penalised memory ranks below equal-scoring untagged memories yet still
+    # survives the cap when it is the only relevant hit. See _apply_tag_weights.
+    tag_weights = config.get("recallTagWeights")
+    weighted = _apply_tag_weights(results, tag_weights)
+    if weighted > 0:
+        debug_log(config, f"Applied recallTagWeights to {weighted} memories: {tag_weights}")
 
     # Switchroom Phase-1 precision — sort the merged primary + additional-bank
     # result set by the engine's relevance score (`scores.final`) descending

--- a/vendor/hindsight-memory/scripts/reconcile_tail.py
+++ b/vendor/hindsight-memory/scripts/reconcile_tail.py
@@ -42,7 +42,11 @@ from lib import watermark
 from lib.bank import derive_bank_id
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
-from lib.content import _is_tool_result_only_user_message, slice_last_turns_by_user_boundary
+from lib.content import (
+    _is_tool_result_only_user_message,
+    slice_last_turns_by_user_boundary,
+    transcript_first_line_is_sidechain,
+)
 from lib.daemon import get_api_url
 from lib.pacing import inflight_lock
 from lib.pending import enqueue as pending_enqueue
@@ -135,6 +139,7 @@ def reconcile(config: dict | None = None, hook_input: dict | None = None) -> dic
         "posts_ok": 0,
         "enqueued": 0,        # slices deferred to pending-retains (bounds/failure)
         "skipped_clean": 0,
+        "skipped_sidechain": 0,  # sub-agent transcripts (owned by subagent_retain.py)
         "disabled": False,
     }
     if not config.get("autoRetain"):
@@ -184,6 +189,22 @@ def reconcile(config: dict | None = None, hook_input: dict | None = None) -> dic
     for path in transcripts:
         summary["scanned"] += 1
         session_id = _session_id_from_path(path)
+
+        # Sub-agent (sidechain) transcripts are NOT sessions. The recursive glob
+        # above matches <session>/subagents/agent-<id>.jsonl, each of which has a
+        # human turn, no watermark, and (fresh) an in-lookback mtime — so without
+        # this guard reconcile would treat every worker fork as a pseudo-session
+        # and retain it here at boot: an UNTAGGED document
+        # (agent-<id>-r{u}-{u}, disjoint namespace from subagent_retain.py's
+        # {parent}-sub-{agent} ids ⇒ permanent duplicate), at FULL recall weight
+        # (defeating the recallTagWeights sidechain:0.8 demotion), bypassing the
+        # volume gate (trivial 10s forks get LLM-extracted at boot). Sidechains
+        # are owned SOLELY by subagent_retain.py (SubagentStop) — skip them here.
+        if transcript_first_line_is_sidechain(path):
+            summary["skipped_sidechain"] += 1
+            debug_log(config, f"reconcile_tail: skipping sidechain transcript {path}")
+            continue
+
         try:
             mtime = os.path.getmtime(path)
         except OSError:

--- a/vendor/hindsight-memory/scripts/retain.py
+++ b/vendor/hindsight-memory/scripts/retain.py
@@ -38,7 +38,7 @@ from lib.pacing import inflight_lock
 from lib.state import increment_turn_count, track_retention
 
 
-def read_transcript(transcript_path: str) -> list:
+def read_transcript(transcript_path: str, max_bytes: int | None = None) -> list:
     """Read a JSONL transcript file and return list of message dicts.
 
     Claude Code transcript format nests messages:
@@ -52,12 +52,30 @@ def read_transcript(transcript_path: str) -> list:
     watermark can key on it. The uuid is stable across compaction and unique
     per entry. Adding the key is inert for downstream formatting
     (``lib/content`` reads only ``role``/``content``).
+
+    ``max_bytes`` (switchroom hindsight-leverage PR5 — bounded read): when set,
+    only the LAST ``max_bytes`` of the file are read and the first (possibly
+    partial) line of that window is discarded, so a multi-hour worker's
+    arbitrarily-large sidechain transcript can never eat the hook budget on the
+    read before the volume-gate/POST. Transcript ORDER is preserved (we read the
+    tail, in order); a window this covers >> the retain window + gate floors, so
+    the "last N turns" slice and PASS/skip decision are unaffected in practice.
+    ``None`` (default) reads the whole file — the main Stop/reconcile paths are
+    unchanged.
     """
     if not transcript_path or not os.path.isfile(transcript_path):
         return []
     messages = []
     try:
-        with open(transcript_path, encoding="utf-8") as f:
+        with open(transcript_path, encoding="utf-8", errors="replace") as f:
+            if max_bytes is not None and max_bytes > 0:
+                try:
+                    size = os.path.getsize(transcript_path)
+                    if size > max_bytes:
+                        f.seek(size - max_bytes)
+                        f.readline()  # drop the partial first line of the window
+                except OSError:
+                    pass
             for line in f:
                 line = line.strip()
                 if not line:

--- a/vendor/hindsight-memory/scripts/subagent_retain.py
+++ b/vendor/hindsight-memory/scripts/subagent_retain.py
@@ -41,6 +41,7 @@ Exit codes:
 import json
 import os
 import sys
+import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -51,6 +52,7 @@ from lib.content import (
     _extract_message_blocks,
     _is_tool_result_only_user_message,
     slice_last_turns_by_user_boundary,
+    transcript_first_line_is_sidechain,
 )
 from lib.daemon import get_api_url
 from lib.pacing import inflight_lock
@@ -67,6 +69,25 @@ SIDECHAIN_WINDOW_TURNS = 40
 # Volume gate floors — SubagentStop fires for every Task, so skip trivial forks.
 MIN_HUMAN_TURNS = 6
 MIN_NON_TOOL_RESULT_CHARS = 2000
+
+# Bounded read (review finding 4): cap the sidechain transcript read so a
+# multi-hour worker's arbitrarily-large jsonl can't eat the 15s hook budget on
+# the read before the POST/enqueue. 8 MB comfortably holds >> the 40-turn retain
+# window and the gate floors even with truncated tool_results; the tail is read
+# in order, so the window slice and PASS/skip are unaffected in practice.
+SIDECHAIN_MAX_READ_BYTES = 8 * 1024 * 1024
+
+# Fallback scan freshness window (review finding 3): when we have to SCAN for the
+# sidechain (older CLIs with no ``agent_transcript_path``), only accept a file
+# whose mtime is within this many seconds of the hook fire, so a stale sidechain
+# from an earlier turn in the same session dir is never mis-picked. Residual race
+# (documented, unavoidable without the first-class field): two old-CLI workers
+# that BOTH stop inside this window pick the newest by mtime, so the other's
+# sidechain is skipped this fire — it is recovered on no path (old CLIs predate
+# agent_transcript_path); this is strictly better than the pre-field behaviour of
+# no sidechain retain at all, and does not affect any CLI that populates the
+# first-class field (the common path, which never scans).
+SIDECHAIN_SCAN_FRESH_WINDOW_S = 300
 
 # Extraction-framing header prepended to the retained content. The retain API
 # has no per-call mission (mission is bank-level), so we bias the consolidation
@@ -90,45 +111,45 @@ def _agent_id_from_path(path: str) -> str:
     return ""
 
 
-def _first_line_is_sidechain(path: str) -> bool:
-    """True when the first JSON line of ``path`` carries ``isSidechain: true``."""
-    try:
-        with open(path, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    return json.loads(line).get("isSidechain") is True
-                except json.JSONDecodeError:
-                    return False
-    except OSError:
-        return False
-    return False
-
-
 def resolve_sidechain_transcript(hook_input: dict) -> str:
     """Resolve the sidechain transcript path from the SubagentStop hook input.
 
     Layered, most-authoritative first:
 
     1. ``agent_transcript_path`` — the first-class field the CLI provides
-       (probe-confirmed on 2.1.215). Used verbatim when it points at a file.
+       (probe-confirmed on 2.1.215). Accepted only after VALIDATION (review
+       finding 2): it must exist, actually be a sidechain
+       (``transcript_first_line_is_sidechain``), and NOT equal the parent
+       ``transcript_path`` — so a CLI that populates the field differently can
+       never make us retain the parent's main-session content under the
+       sub-agent namespace (systematic double-retain).
     2. Derived ``<projectdir>/<session_id>/subagents/agent-<agent_id>.jsonl``
        from ``transcript_path`` + ``session_id`` + ``agent_id`` — for CLIs that
        omit ``agent_transcript_path`` but still write the standard layout.
-    3. Newest ``isSidechain:true`` ``.jsonl`` in that ``subagents/`` dir, then
-       (last resort) anywhere under the project dir, whose mtime is the most
-       recent — the design's documented directory-scan fallback.
+    3. Newest ``isSidechain:true`` ``.jsonl`` in that exact ``subagents/`` dir
+       whose mtime is the most recent AND within ``SIDECHAIN_SCAN_FRESH_WINDOW_S``
+       of the hook fire — the design's documented directory-scan fallback (see
+       that constant for the residual old-CLI race bound). The scan is
+       deliberately confined to the derived ``<session_id>/subagents/`` dir
+       (a single, bounded ``listdir``) — NOT a recursive walk of the project
+       dir, which for a malformed ``transcript_path`` could resolve to ``/`` and
+       walk the whole filesystem.
 
     Returns "" when nothing plausible is found.
     """
-    # 1. First-class field.
+    parent_transcript = hook_input.get("transcript_path", "") or ""
+
+    # 1. First-class field — validated (finding 2).
     p = hook_input.get("agent_transcript_path")
-    if isinstance(p, str) and p and os.path.isfile(p):
+    if (
+        isinstance(p, str)
+        and p
+        and p != parent_transcript
+        and os.path.isfile(p)
+        and transcript_first_line_is_sidechain(p)
+    ):
         return p
 
-    parent_transcript = hook_input.get("transcript_path", "") or ""
     session_id = hook_input.get("session_id", "") or ""
     agent_id = hook_input.get("agent_id", "") or ""
 
@@ -139,45 +160,55 @@ def resolve_sidechain_transcript(hook_input: dict) -> str:
     if project_dir and session_id:
         subagents_dir = os.path.join(project_dir, session_id, "subagents")
 
-    # 2. Derived exact path from agent_id.
+    # 2. Derived exact path from agent_id — still validated as a sidechain and
+    # not the parent (defensive symmetry with path 1).
     if subagents_dir and agent_id:
         cand = os.path.join(subagents_dir, f"agent-{agent_id}.jsonl")
-        if os.path.isfile(cand):
+        if (
+            os.path.isfile(cand)
+            and cand != parent_transcript
+            and transcript_first_line_is_sidechain(cand)
+        ):
             return cand
 
-    # 3a. Newest isSidechain jsonl in the subagents dir.
-    newest = _newest_sidechain_jsonl(subagents_dir) if subagents_dir else ""
-    if newest:
-        return newest
-
-    # 3b. Last resort — newest isSidechain jsonl anywhere under the project dir.
-    return _newest_sidechain_jsonl(project_dir, recursive=True) if project_dir else ""
+    # 3. Newest fresh isSidechain jsonl in the bounded subagents dir (never a
+    # recursive project-dir walk — see the docstring).
+    return _newest_sidechain_jsonl(subagents_dir, exclude=parent_transcript) if subagents_dir else ""
 
 
-def _newest_sidechain_jsonl(root: str, recursive: bool = False) -> str:
-    """Newest (by mtime) ``.jsonl`` under ``root`` whose first line is a
-    sidechain entry. Returns "" if none / dir missing."""
+def _newest_sidechain_jsonl(root: str, exclude: str = "") -> str:
+    """Newest (by mtime) ``.jsonl`` directly in ``root`` whose first line is a
+    sidechain entry AND whose mtime is within ``SIDECHAIN_SCAN_FRESH_WINDOW_S``
+    of now. Non-recursive: a single bounded ``listdir`` of the derived
+    ``<session_id>/subagents/`` dir.
+
+    ``exclude`` skips a specific path (the parent transcript). Returns "" if none
+    / dir missing. The freshness window (finding 3) keeps a stale sidechain from
+    a prior turn out of contention; see the constant for the residual race bound.
+    """
     if not root or not os.path.isdir(root):
         return ""
+    cutoff = time.time() - SIDECHAIN_SCAN_FRESH_WINDOW_S
     best_path = ""
     best_mtime = -1.0
-    walker = os.walk(root) if recursive else [(root, [], os.listdir(root))]
     try:
-        for dirpath, _dirs, files in walker:
-            for name in files:
-                if not name.endswith(".jsonl"):
-                    continue
-                full = os.path.join(dirpath, name)
-                try:
-                    mtime = os.path.getmtime(full)
-                except OSError:
-                    continue
-                if mtime <= best_mtime:
-                    continue
-                if _first_line_is_sidechain(full):
-                    best_path, best_mtime = full, mtime
+        names = os.listdir(root)
     except OSError:
-        return best_path
+        return ""
+    for name in names:
+        if not name.endswith(".jsonl"):
+            continue
+        full = os.path.join(root, name)
+        if exclude and os.path.abspath(full) == os.path.abspath(exclude):
+            continue
+        try:
+            mtime = os.path.getmtime(full)
+        except OSError:
+            continue
+        if mtime < cutoff or mtime <= best_mtime:
+            continue
+        if transcript_first_line_is_sidechain(full):
+            best_path, best_mtime = full, mtime
     return best_path
 
 
@@ -192,7 +223,7 @@ def count_human_turns(messages: list) -> int:
     return n
 
 
-def non_tool_result_char_count(messages: list) -> int:
+def non_tool_result_char_count(messages: list, stop_at: int | None = None) -> int:
     """Total chars of non-tool-result content across the transcript.
 
     Sums the extracted text + tool_use (command/input) blocks and EXCLUDES
@@ -201,6 +232,13 @@ def non_tool_result_char_count(messages: list) -> int:
     gate wants: a 10-second fork with almost no narration/commands falls under
     the floor even if it emitted a large tool_result, while a real worker's
     commands and decisions count.
+
+    ``stop_at`` (review finding 4 — early short-circuit): return as soon as the
+    running total reaches this many chars. The gate only needs to know whether
+    the floor is CLEARED, not the exact size — so on a large worker transcript
+    we stop the block walk the moment the floor is met (the returned value is
+    then a floor, ``>= stop_at``, sufficient for the ``>=`` comparison and the
+    skip log's "chars>=N" read).
     """
     total = 0
     for m in messages:
@@ -215,6 +253,8 @@ def non_tool_result_char_count(messages: list) -> int:
             elif b.get("type") == "tool_use":
                 # Command / input is a process fact; count its serialized size.
                 total += len(b.get("name", "")) + len(json.dumps(b.get("input", {}), ensure_ascii=False))
+        if stop_at is not None and total >= stop_at:
+            return total
     return total
 
 
@@ -222,10 +262,12 @@ def passes_volume_gate(messages: list, config: dict) -> tuple:
     """Return ``(passed, human_turns, char_count)`` for the volume gate.
 
     Skip sub-agents below EITHER floor: < ``MIN_HUMAN_TURNS`` human turns OR
-    < ``MIN_NON_TOOL_RESULT_CHARS`` chars of non-tool-result text.
+    < ``MIN_NON_TOOL_RESULT_CHARS`` chars of non-tool-result text. The char walk
+    short-circuits at the floor (finding 4) — ``char_count`` is exact when below
+    the floor and a lower bound (``>= floor``) once cleared.
     """
     turns = count_human_turns(messages)
-    chars = non_tool_result_char_count(messages)
+    chars = non_tool_result_char_count(messages, stop_at=MIN_NON_TOOL_RESULT_CHARS)
     passed = turns >= MIN_HUMAN_TURNS and chars >= MIN_NON_TOOL_RESULT_CHARS
     return passed, turns, chars
 
@@ -247,6 +289,16 @@ def run_subagent_retain(hook_input: dict) -> dict:
 
     # Blocked-Stop-style re-fire guard: harmless here (deterministic id upserts),
     # but skip a re-fire to avoid a redundant LLM extraction.
+    #
+    # KNOWN LIMITATION (review finding 5): if another SubagentStop hook BLOCKS
+    # the stop, the sub-agent continues and SubagentStop re-fires carrying
+    # ``stop_hook_active: true``; we skip that fire, so any turns the sub-agent
+    # ADDED after the block are not retained on the re-fire. Accepted, because
+    # (a) the deterministic ``{session}-sub-{agent}-r{start}-{end}`` id means the
+    # eventual non-blocked fire (or a later re-dispatch) upserts the fuller
+    # window, and (b) skipping avoids a duplicate LLM extraction on every blocked
+    # continuation. No sidechain currently registers a blocking SubagentStop, so
+    # this is latent; revisit if one is added.
     if hook_input.get("stop_hook_active"):
         debug_log(config, "SubagentStop re-fire (stop_hook_active) — skipping")
         return {"status": "skipped", "reason": "stop_hook_active"}
@@ -267,7 +319,10 @@ def run_subagent_retain(hook_input: dict) -> dict:
     if not agent_id:
         agent_id = _agent_id_from_path(transcript_path) or "unknown"
 
-    all_messages = read_transcript(transcript_path)
+    # Bounded read (finding 4): cap the read so an arbitrarily-large worker
+    # transcript can't eat the hook budget before the gate/POST. The tail is read
+    # in order and covers >> the retain window + gate floors.
+    all_messages = read_transcript(transcript_path, max_bytes=SIDECHAIN_MAX_READ_BYTES)
     if not all_messages:
         debug_log(config, f"SubagentStop: empty sidechain transcript {transcript_path}")
         return {"status": "skipped", "reason": "empty transcript"}

--- a/vendor/hindsight-memory/scripts/subagent_retain.py
+++ b/vendor/hindsight-memory/scripts/subagent_retain.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Auto-retain hook for the SubagentStop event (switchroom hindsight-leverage PR5).
+
+Delegated (sub-agent / Task-tool) work is the biggest systematic memory hole:
+the main-session Stop retain only ever reads the parent ``transcript_path``, so
+a worker's hours of process work — the paths it touched, the commands that
+worked, the dead ends — reach memory only as the terse final report the parent
+transcript captures. This hook closes that hole by retaining a bounded window of
+the *sidechain* transcript when a sub-agent terminates.
+
+Probe result (Claude Code 2.1.215, PR5 Task 0 — recorded in the PR body):
+the ``SubagentStop`` hook input carries BOTH the parent ``transcript_path`` AND
+a first-class ``agent_transcript_path`` pointing straight at the sidechain
+``.jsonl`` (``<projectdir>/<session_id>/subagents/agent-<agent_id>.jsonl``),
+plus ``agent_id`` / ``agent_type`` / ``last_assistant_message``. So the design's
+assumed field exists — just named ``agent_transcript_path``, not
+``transcript_path``. We use it as the primary path and keep the documented
+directory-scan (newest ``isSidechain:true`` jsonl) as a fallback for older CLIs
+that predate the field.
+
+Flow:
+  1. Read hook input from stdin (session_id, transcript_path,
+     agent_transcript_path, agent_id, cwd, ...).
+  2. Resolve the sidechain transcript (agent_transcript_path → derived
+     subagents/ dir → project-dir scan).
+  3. Volume gate: skip sub-agents below the floor (< 6 human turns OR
+     < 2,000 chars of non-tool-result text) — SubagentStop fires for every
+     Task including 10-second forks, and each retain is an LLM-backed
+     extraction.
+  4. Retain a bounded window (last N=40 human turns), tagged ``sidechain`` +
+     ``parent_session:<id>``, with a deterministic content-derived document_id
+     so re-fires upsert instead of duplicating.
+  5. Failures enqueue to the SAME pending-retains durability queue the Stop
+     retain uses (drained at the next SessionStart) — no new machinery.
+
+Exit codes:
+  0 — always (graceful degradation on any error). Durability comes from the
+      pending-retains enqueue, not the exit code (retain.py mirrors this).
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.bank import derive_bank_id, ensure_bank_mission
+from lib.client import HindsightClient
+from lib.config import debug_log, load_config
+from lib.content import (
+    _extract_message_blocks,
+    _is_tool_result_only_user_message,
+    slice_last_turns_by_user_boundary,
+)
+from lib.daemon import get_api_url
+from lib.pacing import inflight_lock
+
+# retain.py owns the transcript reader, the deterministic-id recipe and the
+# network-free payload builder; reuse them wholesale so the sidechain path
+# stays byte-identical to the main path where it matters (dedup ids, formatting).
+from retain import build_retain_payload, read_transcript
+
+# Retain the last N human turns of the sidechain. Tool-result bodies inside the
+# window are truncated by _extract_message_blocks (content.py) already.
+SIDECHAIN_WINDOW_TURNS = 40
+
+# Volume gate floors — SubagentStop fires for every Task, so skip trivial forks.
+MIN_HUMAN_TURNS = 6
+MIN_NON_TOOL_RESULT_CHARS = 2000
+
+# Extraction-framing header prepended to the retained content. The retain API
+# has no per-call mission (mission is bank-level), so we bias the consolidation
+# engine toward PROCESS facts with a short in-content note. Deterministic text —
+# it does not change the document_id (that is computed from the raw slice before
+# this is prepended).
+SIDECHAIN_MISSION_HEADER = (
+    "[sidechain sub-agent work log — extract PROCESS facts: files/paths touched, "
+    "commands that worked, decisions made, dead ends hit and why. Ignore the "
+    "restated mission prose and routine tool chatter.]"
+)
+
+
+def _agent_id_from_path(path: str) -> str:
+    """Best-effort agent id from a ``.../subagents/agent-<id>.jsonl`` filename."""
+    if not path:
+        return ""
+    base = os.path.basename(path)
+    if base.startswith("agent-") and base.endswith(".jsonl"):
+        return base[len("agent-"):-len(".jsonl")]
+    return ""
+
+
+def _first_line_is_sidechain(path: str) -> bool:
+    """True when the first JSON line of ``path`` carries ``isSidechain: true``."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    return json.loads(line).get("isSidechain") is True
+                except json.JSONDecodeError:
+                    return False
+    except OSError:
+        return False
+    return False
+
+
+def resolve_sidechain_transcript(hook_input: dict) -> str:
+    """Resolve the sidechain transcript path from the SubagentStop hook input.
+
+    Layered, most-authoritative first:
+
+    1. ``agent_transcript_path`` — the first-class field the CLI provides
+       (probe-confirmed on 2.1.215). Used verbatim when it points at a file.
+    2. Derived ``<projectdir>/<session_id>/subagents/agent-<agent_id>.jsonl``
+       from ``transcript_path`` + ``session_id`` + ``agent_id`` — for CLIs that
+       omit ``agent_transcript_path`` but still write the standard layout.
+    3. Newest ``isSidechain:true`` ``.jsonl`` in that ``subagents/`` dir, then
+       (last resort) anywhere under the project dir, whose mtime is the most
+       recent — the design's documented directory-scan fallback.
+
+    Returns "" when nothing plausible is found.
+    """
+    # 1. First-class field.
+    p = hook_input.get("agent_transcript_path")
+    if isinstance(p, str) and p and os.path.isfile(p):
+        return p
+
+    parent_transcript = hook_input.get("transcript_path", "") or ""
+    session_id = hook_input.get("session_id", "") or ""
+    agent_id = hook_input.get("agent_id", "") or ""
+
+    # The parent transcript lives at <projectdir>/<session_id>.jsonl; the
+    # sidechains sit under <projectdir>/<session_id>/subagents/.
+    project_dir = os.path.dirname(parent_transcript) if parent_transcript else ""
+    subagents_dir = ""
+    if project_dir and session_id:
+        subagents_dir = os.path.join(project_dir, session_id, "subagents")
+
+    # 2. Derived exact path from agent_id.
+    if subagents_dir and agent_id:
+        cand = os.path.join(subagents_dir, f"agent-{agent_id}.jsonl")
+        if os.path.isfile(cand):
+            return cand
+
+    # 3a. Newest isSidechain jsonl in the subagents dir.
+    newest = _newest_sidechain_jsonl(subagents_dir) if subagents_dir else ""
+    if newest:
+        return newest
+
+    # 3b. Last resort — newest isSidechain jsonl anywhere under the project dir.
+    return _newest_sidechain_jsonl(project_dir, recursive=True) if project_dir else ""
+
+
+def _newest_sidechain_jsonl(root: str, recursive: bool = False) -> str:
+    """Newest (by mtime) ``.jsonl`` under ``root`` whose first line is a
+    sidechain entry. Returns "" if none / dir missing."""
+    if not root or not os.path.isdir(root):
+        return ""
+    best_path = ""
+    best_mtime = -1.0
+    walker = os.walk(root) if recursive else [(root, [], os.listdir(root))]
+    try:
+        for dirpath, _dirs, files in walker:
+            for name in files:
+                if not name.endswith(".jsonl"):
+                    continue
+                full = os.path.join(dirpath, name)
+                try:
+                    mtime = os.path.getmtime(full)
+                except OSError:
+                    continue
+                if mtime <= best_mtime:
+                    continue
+                if _first_line_is_sidechain(full):
+                    best_path, best_mtime = full, mtime
+    except OSError:
+        return best_path
+    return best_path
+
+
+def count_human_turns(messages: list) -> int:
+    """Genuine human-turn count (tool_result-only user messages don't count)."""
+    n = 0
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        if m.get("role") == "user" and not _is_tool_result_only_user_message(m):
+            n += 1
+    return n
+
+
+def non_tool_result_char_count(messages: list) -> int:
+    """Total chars of non-tool-result content across the transcript.
+
+    Sums the extracted text + tool_use (command/input) blocks and EXCLUDES
+    tool_result bodies — the same "text vs tool output" split
+    ``_extract_message_blocks`` already draws. This is the signal the volume
+    gate wants: a 10-second fork with almost no narration/commands falls under
+    the floor even if it emitted a large tool_result, while a real worker's
+    commands and decisions count.
+    """
+    total = 0
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        blocks = _extract_message_blocks(m.get("content", ""), role=m.get("role", ""))
+        for b in blocks:
+            if not isinstance(b, dict) or b.get("type") == "tool_result":
+                continue
+            if b.get("type") == "text":
+                total += len(b.get("text", ""))
+            elif b.get("type") == "tool_use":
+                # Command / input is a process fact; count its serialized size.
+                total += len(b.get("name", "")) + len(json.dumps(b.get("input", {}), ensure_ascii=False))
+    return total
+
+
+def passes_volume_gate(messages: list, config: dict) -> tuple:
+    """Return ``(passed, human_turns, char_count)`` for the volume gate.
+
+    Skip sub-agents below EITHER floor: < ``MIN_HUMAN_TURNS`` human turns OR
+    < ``MIN_NON_TOOL_RESULT_CHARS`` chars of non-tool-result text.
+    """
+    turns = count_human_turns(messages)
+    chars = non_tool_result_char_count(messages)
+    passed = turns >= MIN_HUMAN_TURNS and chars >= MIN_NON_TOOL_RESULT_CHARS
+    return passed, turns, chars
+
+
+def run_subagent_retain(hook_input: dict) -> dict:
+    """Retain a bounded window of the sidechain transcript.
+
+    Returns a status dict shaped like ``retain.run_retain``::
+
+        {"status": "ok" | "skipped" | "failed",
+         "payload": {...},   # only when status == "failed" (for enqueue)
+         "error":   Exception}  # only when status == "failed"
+    """
+    config = load_config()
+
+    if not config.get("autoRetain"):
+        debug_log(config, "Auto-retain disabled, exiting subagent retain")
+        return {"status": "skipped", "reason": "autoRetain disabled"}
+
+    # Blocked-Stop-style re-fire guard: harmless here (deterministic id upserts),
+    # but skip a re-fire to avoid a redundant LLM extraction.
+    if hook_input.get("stop_hook_active"):
+        debug_log(config, "SubagentStop re-fire (stop_hook_active) — skipping")
+        return {"status": "skipped", "reason": "stop_hook_active"}
+
+    session_id = hook_input.get("session_id", "unknown")
+    agent_id = hook_input.get("agent_id", "") or ""
+    agent_type = hook_input.get("agent_type", "") or ""
+
+    transcript_path = resolve_sidechain_transcript(hook_input)
+    if not transcript_path:
+        debug_log(
+            config,
+            f"SubagentStop: no sidechain transcript resolved "
+            f"(session={session_id}, agent={agent_id}) — skipping",
+        )
+        return {"status": "skipped", "reason": "no sidechain transcript"}
+
+    if not agent_id:
+        agent_id = _agent_id_from_path(transcript_path) or "unknown"
+
+    all_messages = read_transcript(transcript_path)
+    if not all_messages:
+        debug_log(config, f"SubagentStop: empty sidechain transcript {transcript_path}")
+        return {"status": "skipped", "reason": "empty transcript"}
+
+    # Volume gate — skip trivial forks, log the skip for coverage auditing.
+    passed, turns, chars = passes_volume_gate(all_messages, config)
+    if not passed:
+        debug_log(
+            config,
+            f"SubagentStop volume-gate SKIP: session={session_id} agent={agent_id} "
+            f"turns={turns} (min {MIN_HUMAN_TURNS}) chars={chars} "
+            f"(min {MIN_NON_TOOL_RESULT_CHARS})",
+        )
+        return {"status": "skipped", "reason": "volume gate", "turns": turns, "chars": chars}
+
+    # Bounded window: last N human turns (extends to end, so the sub-agent's
+    # final report is always included).
+    messages_to_retain = slice_last_turns_by_user_boundary(all_messages, SIDECHAIN_WINDOW_TURNS)
+
+    # Resolve API URL + client.
+    def _dbg(*a):
+        debug_log(config, *a)
+
+    try:
+        api_url = get_api_url(config, debug_fn=_dbg, allow_daemon_start=True)
+    except RuntimeError as e:
+        print(f"[Hindsight] {e}", file=sys.stderr)
+        return {"status": "failed", "error": e, "payload": None}
+
+    api_token = config.get("hindsightApiToken")
+    try:
+        client = HindsightClient(
+            api_url,
+            api_token,
+            request_timeout_override=config.get("requestTimeoutSeconds"),
+        )
+    except ValueError as e:
+        print(f"[Hindsight] Invalid API URL: {e}", file=sys.stderr)
+        return {"status": "failed", "error": e, "payload": None}
+
+    # Bank == the parent agent's bank (derive_bank_id keys on cwd/session, both
+    # shared with the parent), so sidechain memories land alongside the agent's
+    # own memory rather than a stray per-worker bank.
+    bank_id = derive_bank_id(hook_input, config)
+    ensure_bank_mission(client, bank_id, config, debug_fn=_dbg)
+
+    # Deterministic content-derived document_id in a DISTINCT namespace from the
+    # main-session retains: reuse retain.py's ``slice_document_id`` recipe via a
+    # composite session key so (a) re-fires of the SAME sub-agent window upsert
+    # server-side, and (b) it never collides with the parent's own
+    # ``{session_id}-r...`` documents. Client-side diffing against the parent's
+    # final-report retain is deliberately NOT attempted — overlap is fine, and
+    # hindsight's consolidation dedups (design item 4).
+    sub_session_id = f"{session_id}-sub-{agent_id}"
+
+    # Sidechain tags + a topic-friendly parent link. Reuse the config-driven tag
+    # machinery by augmenting a copy of retainTags (template {session_id} →
+    # sub_session_id). ``sidechain`` is the recall-side weight key
+    # (recallTagWeights); ``parent_session:<id>`` lets a fresh session pull a
+    # worker's process facts by parent.
+    sub_config = dict(config)
+    base_tags = list(config.get("retainTags") or [])
+    extra_tags = ["sidechain", f"parent_session:{session_id}"]
+    if agent_type:
+        extra_tags.append(f"agent_type:{agent_type}")
+    sub_config["retainTags"] = base_tags + extra_tags
+
+    built = build_retain_payload(
+        sub_config,
+        sub_session_id,
+        messages_to_retain,
+        all_messages,
+        bank_id=bank_id,
+        api_url=api_url,
+        api_token=api_token,
+        retain_full_window=True,
+        document_id=None,  # content-derived from the slice's first/last uuids
+    )
+    if built is None:
+        debug_log(config, "SubagentStop: empty transcript after formatting, skipping")
+        return {"status": "skipped", "reason": "empty transcript after formatting"}
+
+    payload = built["payload"]
+    # Prepend the process-fact extraction framing (does not affect document_id,
+    # which was computed from the raw slice inside build_retain_payload).
+    payload["content"] = SIDECHAIN_MISSION_HEADER + "\n\n" + payload["content"]
+    payload["context"] = "claude-code-sidechain"
+    payload["metadata"]["parent_session_id"] = session_id
+    payload["metadata"]["agent_id"] = agent_id
+    if agent_type:
+        payload["metadata"]["agent_type"] = agent_type
+
+    document_id = built["document_id"]
+    debug_log(
+        config,
+        f"SubagentStop retain: bank='{bank_id}' doc='{document_id}' "
+        f"turns={turns} chars={chars} msgs={built['message_count']}",
+    )
+
+    # POST under the shared fleet pacing lock, NON-BLOCKING (an async Stop hook
+    # must not wait on a boot reconcile / backfill). On a busy lock we defer to
+    # pending-retains, mirroring retain.py exactly.
+    with inflight_lock(blocking=False) as acquired:
+        if not acquired:
+            debug_log(config, "retain-inflight lock busy; deferring sidechain retain to pending-retains")
+            return {
+                "status": "failed",
+                "error": RuntimeError("retain-inflight lock busy; deferring to pending-retains"),
+                "payload": payload,
+            }
+        try:
+            response = client.retain(
+                bank_id=bank_id,
+                content=payload["content"],
+                document_id=document_id,
+                context=payload["context"],
+                metadata=payload["metadata"],
+                tags=payload["tags"],
+                timeout=15,
+                async_processing=False,
+            )
+        except Exception as e:
+            print(f"[Hindsight] Sidechain retain failed: {e}", file=sys.stderr)
+            return {"status": "failed", "error": e, "payload": payload}
+
+    debug_log(config, f"Sidechain retain response: {json.dumps(response)[:200]}")
+    return {"status": "ok", "response": response}
+
+
+def main():
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        print("[Hindsight] Failed to read SubagentStop hook input", file=sys.stderr)
+        return
+
+    result = run_subagent_retain(hook_input) or {}
+    # On a failed retain WITH a payload, durably enqueue to pending-retains so
+    # the next SessionStart drain replays it — identical durability path to
+    # retain.py's Stop entrypoint. The deterministic content-derived id means a
+    # queued entry and a later re-fire collide on id ⇒ upsert, not duplicate.
+    if result.get("status") == "failed" and result.get("payload"):
+        try:
+            from lib.pending import MAX_ENTRIES, count as pending_count, enqueue as pending_enqueue
+
+            err = result.get("error") or RuntimeError("subagent retain failed")
+            queued = pending_enqueue(result["payload"], err)
+            if queued is None:
+                print(
+                    f"[Hindsight] pending-retains queue full ({MAX_ENTRIES} entries); "
+                    f"dropping this SubagentStop retain. Operator: drain manually, "
+                    f"then run `switchroom doctor`.",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"[Hindsight] SubagentStop retain failed: queued to pending-retains "
+                    f"(error: {type(err).__name__}: {err}, pending={pending_count()}). "
+                    f"Will retry on next SessionStart.",
+                    file=sys.stderr,
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            print(f"[Hindsight] SubagentStop retain enqueue failed: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"[Hindsight] Unexpected error in subagent_retain: {e}", file=sys.stderr)
+        try:
+            from lib.config import load_config
+
+            sys.exit(2 if load_config().get("debug") else 0)
+        except Exception:
+            sys.exit(0)

--- a/vendor/hindsight-memory/scripts/tests/test_recall_tag_weights.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_tag_weights.py
@@ -1,0 +1,96 @@
+"""Switchroom hindsight-leverage PR5 — unit tests for recall tag-weight demotion.
+
+`_apply_tag_weights` multiplies a result's ``scores.final`` by a per-tag weight
+BEFORE the relevance sort, so a down-weighted tag (e.g. ``sidechain: 0.8``) is
+DEMOTED (ranked lower) rather than DROPPED. The load-bearing properties:
+
+  1. A penalised memory sorts BELOW an equal-score un-penalised one.
+  2. A penalised memory STILL surfaces when it is the only relevant hit — i.e.
+     the mechanism is a re-rank, never the hard demote-tag drop filter.
+
+Stdlib-only; runs under ``python3 -m unittest discover tests/``.
+"""
+
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from recall import _apply_tag_weights, _sort_by_final_score  # noqa: E402
+
+
+def _mem(text, final, tags=None):
+    return {"text": text, "tags": tags or [], "scores": {"final": final}}
+
+
+class ApplyTagWeights(unittest.TestCase):
+    def test_penalised_memory_sorts_below_equal_score_neutral(self):
+        neutral = _mem("neutral fact", 0.50, [])
+        sidechain = _mem("sidechain fact", 0.50, ["sidechain"])
+        results = [sidechain, neutral]  # sidechain first before weighting
+        changed = _apply_tag_weights(results, {"sidechain": 0.8})
+        _sort_by_final_score(results)
+        self.assertEqual(changed, 1)
+        # After the 0.8 penalty, the neutral memory ranks first.
+        self.assertEqual(results[0]["text"], "neutral fact")
+        self.assertEqual(results[1]["text"], "sidechain fact")
+
+    def test_sidechain_still_surfaces_when_only_hit(self):
+        # Only a sidechain memory is relevant — it must remain, just penalised.
+        only = _mem("the only relevant fact", 0.42, ["sidechain"])
+        results = [only]
+        _apply_tag_weights(results, {"sidechain": 0.8})
+        _sort_by_final_score(results)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["text"], "the only relevant fact")
+        # Score was scaled, not zeroed/removed.
+        self.assertAlmostEqual(results[0]["scores"]["final"], 0.42 * 0.8)
+
+    def test_higher_scored_sidechain_can_still_beat_weaker_neutral(self):
+        # Demotion is a multiplier, not a floor: a strong sidechain hit still
+        # outranks a much weaker neutral one.
+        strong_sidechain = _mem("strong sidechain", 0.90, ["sidechain"])
+        weak_neutral = _mem("weak neutral", 0.30, [])
+        results = [weak_neutral, strong_sidechain]
+        _apply_tag_weights(results, {"sidechain": 0.8})  # 0.90*0.8 = 0.72 > 0.30
+        _sort_by_final_score(results)
+        self.assertEqual(results[0]["text"], "strong sidechain")
+
+    def test_empty_or_missing_weights_is_noop(self):
+        m = _mem("x", 0.5, ["sidechain"])
+        self.assertEqual(_apply_tag_weights([m], {}), 0)
+        self.assertEqual(_apply_tag_weights([m], None), 0)
+        self.assertEqual(m["scores"]["final"], 0.5)
+
+    def test_untagged_memory_untouched(self):
+        m = _mem("x", 0.5, [])
+        self.assertEqual(_apply_tag_weights([m], {"sidechain": 0.8}), 0)
+        self.assertEqual(m["scores"]["final"], 0.5)
+
+    def test_compound_weight_for_multiple_matching_tags(self):
+        m = _mem("x", 1.0, ["sidechain", "anti-pattern"])
+        _apply_tag_weights([m], {"sidechain": 0.8, "anti-pattern": 0.5})
+        self.assertAlmostEqual(m["scores"]["final"], 1.0 * 0.8 * 0.5)
+
+    def test_weight_of_one_is_noop(self):
+        m = _mem("x", 0.5, ["sidechain"])
+        self.assertEqual(_apply_tag_weights([m], {"sidechain": 1.0}), 0)
+        self.assertEqual(m["scores"]["final"], 0.5)
+
+    def test_scoreless_result_left_untouched(self):
+        m = {"text": "x", "tags": ["sidechain"]}  # no scores dict
+        self.assertEqual(_apply_tag_weights([m], {"sidechain": 0.8}), 0)
+        self.assertNotIn("scores", m)
+
+    def test_non_positive_or_bad_weight_ignored(self):
+        m = _mem("x", 0.5, ["sidechain"])
+        _apply_tag_weights([m], {"sidechain": 0})       # non-positive → ignored
+        _apply_tag_weights([m], {"sidechain": "bad"})   # non-numeric → ignored
+        self.assertEqual(m["scores"]["final"], 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py
+++ b/vendor/hindsight-memory/scripts/tests/test_reconcile_durability.py
@@ -341,6 +341,55 @@ class TestWatermark(DurabilityTestBase):
         self.assertIsNone(watermark.load("wm2"))
 
 
+class TestSidechainSkip(DurabilityTestBase):
+    """PR5 review finding 1: reconcile must NOT treat a sub-agent sidechain
+    transcript as a pseudo-session. The recursive glob matches
+    <session>/subagents/agent-<id>.jsonl; without the guard reconcile would
+    retain it at boot with an untagged, disjoint-namespace document (permanent
+    duplicate of subagent_retain.py's tagged retain, at full recall weight,
+    bypassing the volume gate)."""
+
+    def _write_sidechain(self, path, n_turns):
+        lines = []
+        for i in range(n_turns):
+            lines.append(json.dumps({
+                "type": "user", "isSidechain": True, "agentId": "af5",
+                "uuid": f"su{i}", "message": {"role": "user", "content": f"sc turn {i}"},
+            }))
+            lines.append(json.dumps({
+                "type": "assistant", "isSidechain": True, "agentId": "af5",
+                "uuid": f"sa{i}", "message": {"role": "assistant", "content": f"sc did {i}"},
+            }))
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+    def test_reconcile_skips_sidechain_transcript(self):
+        session = "sessX"
+        # A real parent session with un-committed turns (must still reconcile).
+        parent = os.path.join(self.transcripts, f"{session}.jsonl")
+        _write_transcript(parent, 4, session_prefix=session)
+        # A sidechain under <session>/subagents/ that the recursive glob matches.
+        sub_dir = os.path.join(self.transcripts, session, "subagents")
+        os.makedirs(sub_dir)
+        sc = os.path.join(sub_dir, "agent-af5.jsonl")
+        self._write_sidechain(sc, 5)
+
+        hook = {"session_id": session, "transcript_path": parent, "cwd": "/x"}
+        summary = reconcile_tail.reconcile(self._config(), hook_input=hook)
+
+        # The sidechain was recognised and skipped ...
+        self.assertGreaterEqual(summary["skipped_sidechain"], 1)
+        blob = self.daemon.content_blob()
+        # ... none of its content was retained ...
+        self.assertNotIn("sc turn", blob)
+        self.assertNotIn("sc did", blob)
+        # ... and no document carries the untagged agent-<id> namespace.
+        self.assertFalse(any(did.startswith("agent-af5") for did in self.daemon.docs))
+        # ... while the genuine parent session WAS reconciled.
+        for i in range(4):
+            self.assertIn(f"user turn {i}", blob)
+
+
 def _stdin(obj):
     import io
     return io.StringIO(json.dumps(obj))

--- a/vendor/hindsight-memory/scripts/tests/test_subagent_retain.py
+++ b/vendor/hindsight-memory/scripts/tests/test_subagent_retain.py
@@ -1,0 +1,345 @@
+"""Switchroom hindsight-leverage PR5 — unit tests for subagent_retain.py.
+
+Covers the SubagentStop sidechain retain: transcript resolution (first-class
+``agent_transcript_path`` + directory-scan fallback), the volume gate, the
+window slice + deterministic dedup id, and the pending-retains enqueue on
+failure. Stdlib-only; runs under ``python3 -m unittest discover tests/``.
+"""
+
+import contextlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import subagent_retain  # noqa: E402
+
+
+CONFIG = {
+    "autoRetain": True,
+    "retainMode": "chunked",
+    "retainRoles": ["user", "assistant"],
+    "retainToolCalls": True,
+    "retainTags": ["{session_id}"],
+    "retainMetadata": {},
+    "retainContext": "claude-code",
+    "hindsightApiToken": None,
+    "debug": False,
+}
+
+
+def _sidechain_line(role: str, text: str, uuid: str, is_tool_result: bool = False) -> str:
+    """One nested Claude Code sidechain jsonl entry."""
+    if is_tool_result:
+        content = [{"type": "tool_result", "tool_use_id": "t1", "content": text}]
+    else:
+        content = text
+    return json.dumps(
+        {
+            "type": role,
+            "isSidechain": True,
+            "agentId": "af5fba739c0ee6b38",
+            "sessionId": "parentsess",
+            "uuid": uuid,
+            "message": {"role": role, "content": content},
+        }
+    )
+
+
+def _write_sidechain(path: str, num_turns: int, chars_per_msg: int = 500) -> None:
+    """Write a sidechain jsonl with num_turns human turns of substantive text."""
+    lines = []
+    for i in range(num_turns):
+        body = f"turn {i} " + ("x" * chars_per_msg)
+        lines.append(_sidechain_line("user", body, f"u{i}"))
+        lines.append(_sidechain_line("assistant", f"did work {i} " + ("y" * chars_per_msg), f"a{i}"))
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+@contextlib.contextmanager
+def _lock_acquired(blocking=False):
+    yield True
+
+
+class ResolveSidechainTranscript(unittest.TestCase):
+    def test_prefers_agent_transcript_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "agent-abc.jsonl")
+            _write_sidechain(sc, 3)
+            got = subagent_retain.resolve_sidechain_transcript(
+                {"agent_transcript_path": sc, "transcript_path": "/nope", "session_id": "s"}
+            )
+            self.assertEqual(got, sc)
+
+    def test_derives_from_session_and_agent_id_when_field_absent(self):
+        with tempfile.TemporaryDirectory() as d:
+            proj = d
+            parent = os.path.join(proj, "sess1.jsonl")
+            open(parent, "w").close()
+            sub_dir = os.path.join(proj, "sess1", "subagents")
+            os.makedirs(sub_dir)
+            sc = os.path.join(sub_dir, "agent-XYZ.jsonl")
+            _write_sidechain(sc, 2)
+            got = subagent_retain.resolve_sidechain_transcript(
+                {"transcript_path": parent, "session_id": "sess1", "agent_id": "XYZ"}
+            )
+            self.assertEqual(got, sc)
+
+    def test_scan_fallback_picks_newest_sidechain_jsonl(self):
+        with tempfile.TemporaryDirectory() as d:
+            parent = os.path.join(d, "sess1.jsonl")
+            open(parent, "w").close()
+            sub_dir = os.path.join(d, "sess1", "subagents")
+            os.makedirs(sub_dir)
+            older = os.path.join(sub_dir, "agent-old.jsonl")
+            newer = os.path.join(sub_dir, "agent-new.jsonl")
+            _write_sidechain(older, 2)
+            _write_sidechain(newer, 2)
+            # Make `newer` genuinely newer by mtime.
+            os.utime(older, (1000, 1000))
+            os.utime(newer, (2000, 2000))
+            # No agent_id → must scan and pick newest.
+            got = subagent_retain.resolve_sidechain_transcript(
+                {"transcript_path": parent, "session_id": "sess1"}
+            )
+            self.assertEqual(got, newer)
+
+    def test_ignores_non_sidechain_jsonl_in_scan(self):
+        with tempfile.TemporaryDirectory() as d:
+            parent = os.path.join(d, "sess1.jsonl")
+            open(parent, "w").close()
+            sub_dir = os.path.join(d, "sess1", "subagents")
+            os.makedirs(sub_dir)
+            # A non-sidechain file (first line lacks isSidechain).
+            plain = os.path.join(sub_dir, "agent-plain.jsonl")
+            with open(plain, "w") as f:
+                f.write(json.dumps({"type": "user", "message": {"role": "user", "content": "hi"}}) + "\n")
+            got = subagent_retain.resolve_sidechain_transcript(
+                {"transcript_path": parent, "session_id": "sess1"}
+            )
+            self.assertEqual(got, "")
+
+    def test_returns_empty_when_nothing_found(self):
+        got = subagent_retain.resolve_sidechain_transcript(
+            {"transcript_path": "/does/not/exist.jsonl", "session_id": "x"}
+        )
+        self.assertEqual(got, "")
+
+
+class VolumeGate(unittest.TestCase):
+    def test_counts_human_turns_excluding_tool_results(self):
+        msgs = [
+            {"role": "user", "content": "real turn 1"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t", "content": "x"}]},
+            {"role": "user", "content": "real turn 2"},
+        ]
+        self.assertEqual(subagent_retain.count_human_turns(msgs), 2)
+
+    def test_skip_below_turn_floor(self):
+        # 3 turns, plenty of chars → still skipped (turns < 6).
+        msgs = []
+        for i in range(3):
+            msgs.append({"role": "user", "content": "x" * 2000})
+            msgs.append({"role": "assistant", "content": "y" * 2000})
+        passed, turns, chars = subagent_retain.passes_volume_gate(msgs, CONFIG)
+        self.assertFalse(passed)
+        self.assertEqual(turns, 3)
+
+    def test_skip_below_char_floor(self):
+        # 8 turns but tiny → skipped (chars < 2000).
+        msgs = []
+        for i in range(8):
+            msgs.append({"role": "user", "content": "hi"})
+            msgs.append({"role": "assistant", "content": "ok"})
+        passed, turns, chars = subagent_retain.passes_volume_gate(msgs, CONFIG)
+        self.assertFalse(passed)
+        self.assertGreaterEqual(turns, 6)
+        self.assertLess(chars, subagent_retain.MIN_NON_TOOL_RESULT_CHARS)
+
+    def test_tool_result_bodies_do_not_count_toward_char_floor(self):
+        # 8 turns whose ONLY bulk is tool_result output → below char floor.
+        msgs = []
+        for i in range(8):
+            msgs.append({"role": "user", "content": "go"})
+            msgs.append(
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "k"},
+                        {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                    ],
+                }
+            )
+            msgs.append(
+                {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t", "content": "Z" * 5000}]}
+            )
+        passed, turns, chars = subagent_retain.passes_volume_gate(msgs, CONFIG)
+        self.assertFalse(passed)
+        self.assertLess(chars, subagent_retain.MIN_NON_TOOL_RESULT_CHARS)
+
+    def test_passes_when_both_floors_met(self):
+        msgs = []
+        for i in range(7):
+            msgs.append({"role": "user", "content": "x" * 400})
+            msgs.append({"role": "assistant", "content": "y" * 400})
+        passed, turns, chars = subagent_retain.passes_volume_gate(msgs, CONFIG)
+        self.assertTrue(passed)
+
+
+class RunSubagentRetain(unittest.TestCase):
+    def _run(self, hook_input):
+        captured = {}
+
+        class _Client:
+            def __init__(self, *a, **k):
+                pass
+
+            def retain(self, **kwargs):
+                captured.update(kwargs)
+                return {"ok": True}
+
+        with mock.patch("subagent_retain.load_config", return_value=dict(CONFIG)), \
+                mock.patch("subagent_retain.get_api_url", return_value="http://x"), \
+                mock.patch("subagent_retain.ensure_bank_mission"), \
+                mock.patch("subagent_retain.derive_bank_id", return_value="agentbank"), \
+                mock.patch("subagent_retain.HindsightClient", _Client), \
+                mock.patch("subagent_retain.inflight_lock", _lock_acquired):
+            result = subagent_retain.run_subagent_retain(hook_input)
+        return result, captured
+
+    def test_substantive_sidechain_retained_with_tags_and_window(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "agent-af5.jsonl")
+            _write_sidechain(sc, 8, chars_per_msg=400)
+            hook_input = {
+                "session_id": "parentsess",
+                "agent_id": "af5",
+                "agent_type": "worker",
+                "agent_transcript_path": sc,
+                "transcript_path": os.path.join(d, "parentsess.jsonl"),
+                "cwd": d,
+            }
+            result, captured = self._run(hook_input)
+
+        self.assertEqual(result["status"], "ok")
+        # Tagged sidechain + parent link.
+        self.assertIn("sidechain", captured["tags"])
+        self.assertIn("parent_session:parentsess", captured["tags"])
+        self.assertIn("agent_type:worker", captured["tags"])
+        # Deterministic id in a DISTINCT namespace from parent retains.
+        self.assertTrue(captured["document_id"].startswith("parentsess-sub-af5-r"))
+        # Process-fact framing header is prepended.
+        self.assertIn("extract PROCESS facts", captured["content"])
+        # Distinct provenance context.
+        self.assertEqual(captured["context"], "claude-code-sidechain")
+        self.assertEqual(captured["metadata"]["parent_session_id"], "parentsess")
+
+    def test_document_id_is_stable_across_refires(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "agent-af5.jsonl")
+            _write_sidechain(sc, 8, chars_per_msg=400)
+            hook_input = {
+                "session_id": "parentsess",
+                "agent_id": "af5",
+                "agent_transcript_path": sc,
+                "transcript_path": os.path.join(d, "parentsess.jsonl"),
+                "cwd": d,
+            }
+            r1, c1 = self._run(hook_input)
+            r2, c2 = self._run(hook_input)
+        self.assertEqual(c1["document_id"], c2["document_id"])
+
+    def test_window_capped_at_N_turns(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "agent-af5.jsonl")
+            # More than the window: 50 turns, window is 40.
+            _write_sidechain(sc, 50, chars_per_msg=60)
+            hook_input = {
+                "session_id": "parentsess",
+                "agent_id": "af5",
+                "agent_transcript_path": sc,
+                "transcript_path": os.path.join(d, "parentsess.jsonl"),
+                "cwd": d,
+            }
+            result, captured = self._run(hook_input)
+        self.assertEqual(result["status"], "ok")
+        content = captured["content"]
+        # The last turn (49) must be present; an early dropped turn (0) absent.
+        self.assertIn("turn 49", content)
+        self.assertNotIn("turn 0 ", content)
+
+    def test_volume_gate_skips_trivial_fork_no_retain(self):
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "agent-tiny.jsonl")
+            _write_sidechain(sc, 2, chars_per_msg=5)  # 2 turns, tiny
+            hook_input = {
+                "session_id": "parentsess",
+                "agent_id": "tiny",
+                "agent_transcript_path": sc,
+                "transcript_path": os.path.join(d, "parentsess.jsonl"),
+                "cwd": d,
+            }
+            result, captured = self._run(hook_input)
+        self.assertEqual(result["status"], "skipped")
+        self.assertEqual(result["reason"], "volume gate")
+        self.assertEqual(captured, {})  # nothing posted
+
+    def test_no_transcript_skips(self):
+        result, captured = self._run(
+            {"session_id": "s", "agent_id": "a", "transcript_path": "/no/where.jsonl"}
+        )
+        self.assertEqual(result["status"], "skipped")
+
+    def test_lock_busy_returns_failed_payload_for_enqueue(self):
+        @contextlib.contextmanager
+        def _busy(blocking=False):
+            yield False
+
+        with tempfile.TemporaryDirectory() as d:
+            sc = os.path.join(d, "agent-af5.jsonl")
+            _write_sidechain(sc, 8, chars_per_msg=400)
+            hook_input = {
+                "session_id": "parentsess",
+                "agent_id": "af5",
+                "agent_transcript_path": sc,
+                "transcript_path": os.path.join(d, "parentsess.jsonl"),
+                "cwd": d,
+            }
+            with mock.patch("subagent_retain.load_config", return_value=dict(CONFIG)), \
+                    mock.patch("subagent_retain.get_api_url", return_value="http://x"), \
+                    mock.patch("subagent_retain.ensure_bank_mission"), \
+                    mock.patch("subagent_retain.derive_bank_id", return_value="agentbank"), \
+                    mock.patch("subagent_retain.HindsightClient"), \
+                    mock.patch("subagent_retain.inflight_lock", _busy):
+                result = subagent_retain.run_subagent_retain(hook_input)
+        self.assertEqual(result["status"], "failed")
+        self.assertIsNotNone(result["payload"])
+        # Payload is enqueue-shaped (matches lib.pending expectations).
+        for k in ("bank_id", "content", "document_id", "context", "metadata", "tags"):
+            self.assertIn(k, result["payload"])
+
+
+class HookRegistration(unittest.TestCase):
+    def test_subagentstop_registered_in_plugin_hooks_json(self):
+        hooks_path = os.path.abspath(
+            os.path.join(SCRIPTS_DIR, "..", "hooks", "hooks.json")
+        )
+        with open(hooks_path) as f:
+            hooks = json.load(f)
+        self.assertIn("SubagentStop", hooks["hooks"])
+        entry = hooks["hooks"]["SubagentStop"][0]["hooks"][0]
+        self.assertIn("subagent_retain.py", entry["command"])
+        self.assertTrue(entry.get("async"))
+        self.assertEqual(entry.get("timeout"), 15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_subagent_retain.py
+++ b/vendor/hindsight-memory/scripts/tests/test_subagent_retain.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 import tempfile
+import time
 import unittest
 from unittest import mock
 
@@ -102,14 +103,56 @@ class ResolveSidechainTranscript(unittest.TestCase):
             newer = os.path.join(sub_dir, "agent-new.jsonl")
             _write_sidechain(older, 2)
             _write_sidechain(newer, 2)
-            # Make `newer` genuinely newer by mtime.
-            os.utime(older, (1000, 1000))
-            os.utime(newer, (2000, 2000))
+            # Both FRESH (within SIDECHAIN_SCAN_FRESH_WINDOW_S of now), `newer`
+            # genuinely newer by mtime.
+            now = time.time()
+            os.utime(older, (now - 30, now - 30))
+            os.utime(newer, (now - 5, now - 5))
             # No agent_id → must scan and pick newest.
             got = subagent_retain.resolve_sidechain_transcript(
                 {"transcript_path": parent, "session_id": "sess1"}
             )
             self.assertEqual(got, newer)
+
+    def test_scan_ignores_stale_sidechain_outside_fresh_window(self):
+        with tempfile.TemporaryDirectory() as d:
+            parent = os.path.join(d, "sess1.jsonl")
+            open(parent, "w").close()
+            sub_dir = os.path.join(d, "sess1", "subagents")
+            os.makedirs(sub_dir)
+            stale = os.path.join(sub_dir, "agent-stale.jsonl")
+            _write_sidechain(stale, 2)
+            # Older than the freshness window → NOT picked (finding 3).
+            old = time.time() - subagent_retain.SIDECHAIN_SCAN_FRESH_WINDOW_S - 60
+            os.utime(stale, (old, old))
+            got = subagent_retain.resolve_sidechain_transcript(
+                {"transcript_path": parent, "session_id": "sess1"}
+            )
+            self.assertEqual(got, "")
+
+    def test_rejects_agent_transcript_path_equal_to_parent(self):
+        # finding 2: a CLI that sets agent_transcript_path == transcript_path
+        # must NOT cause the parent (main-session) transcript to be retained
+        # under the sub namespace.
+        with tempfile.TemporaryDirectory() as d:
+            parent = os.path.join(d, "sess1.jsonl")
+            _write_sidechain(parent, 3)  # even if it looked like a sidechain
+            got = subagent_retain.resolve_sidechain_transcript(
+                {"agent_transcript_path": parent, "transcript_path": parent, "session_id": "sess1"}
+            )
+            self.assertEqual(got, "")
+
+    def test_rejects_non_sidechain_agent_transcript_path(self):
+        # finding 2: agent_transcript_path pointing at a NON-sidechain file
+        # (e.g. the parent under a different name) is rejected.
+        with tempfile.TemporaryDirectory() as d:
+            notsc = os.path.join(d, "agent-notsc.jsonl")
+            with open(notsc, "w") as f:
+                f.write(json.dumps({"type": "user", "message": {"role": "user", "content": "hi"}}) + "\n")
+            got = subagent_retain.resolve_sidechain_transcript(
+                {"agent_transcript_path": notsc, "transcript_path": "/nope", "session_id": "s"}
+            )
+            self.assertEqual(got, "")
 
     def test_ignores_non_sidechain_jsonl_in_scan(self):
         with tempfile.TemporaryDirectory() as d:
@@ -131,6 +174,18 @@ class ResolveSidechainTranscript(unittest.TestCase):
             {"transcript_path": "/does/not/exist.jsonl", "session_id": "x"}
         )
         self.assertEqual(got, "")
+
+    def test_malformed_transcript_path_does_not_walk_filesystem(self):
+        # Regression: a transcript_path whose dirname is "/" must NOT trigger a
+        # recursive filesystem walk. The bounded listdir of a non-existent
+        # <root>/<session>/subagents returns "" immediately (mock listdir to
+        # assert it is never called on "/").
+        with mock.patch("subagent_retain.os.walk") as walk:
+            got = subagent_retain.resolve_sidechain_transcript(
+                {"agent_transcript_path": "/x", "transcript_path": "/nope", "session_id": "s"}
+            )
+            self.assertEqual(got, "")
+            walk.assert_not_called()
 
 
 class VolumeGate(unittest.TestCase):
@@ -192,6 +247,45 @@ class VolumeGate(unittest.TestCase):
             msgs.append({"role": "assistant", "content": "y" * 400})
         passed, turns, chars = subagent_retain.passes_volume_gate(msgs, CONFIG)
         self.assertTrue(passed)
+
+    def test_char_count_short_circuits_at_floor(self):
+        # finding 4: once the floor is met the walk stops — the returned count is
+        # a lower bound (>= stop_at), not the full sum, and later messages are
+        # not visited.
+        msgs = []
+        for i in range(20):
+            msgs.append({"role": "assistant", "content": "z" * 500})
+        total = subagent_retain.non_tool_result_char_count(
+            msgs, stop_at=subagent_retain.MIN_NON_TOOL_RESULT_CHARS
+        )
+        self.assertGreaterEqual(total, subagent_retain.MIN_NON_TOOL_RESULT_CHARS)
+        # Full sum would be 20*500=10000; short-circuit stops well before.
+        self.assertLess(total, 10000)
+
+
+class BoundedRead(unittest.TestCase):
+    def test_read_transcript_max_bytes_reads_only_tail(self):
+        from retain import read_transcript
+
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "big.jsonl")
+            _write_sidechain(p, 60, chars_per_msg=400)  # large file
+            full = read_transcript(p)
+            tail = read_transcript(p, max_bytes=8000)
+            # Bounded read returns fewer messages, and they are the LAST ones
+            # (order preserved) — the final turn is present in both.
+            self.assertLess(len(tail), len(full))
+            self.assertGreater(len(tail), 0)
+            last_uuid_full = full[-1].get("uuid")
+            self.assertEqual(tail[-1].get("uuid"), last_uuid_full)
+
+    def test_max_bytes_none_reads_whole_file(self):
+        from retain import read_transcript
+
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "x.jsonl")
+            _write_sidechain(p, 5)
+            self.assertEqual(len(read_transcript(p, max_bytes=None)), len(read_transcript(p)))
 
 
 class RunSubagentRetain(unittest.TestCase):


### PR DESCRIPTION
Implements **workstream B** of the hindsight-leverage programme — sub-agent (sidechain) retain coverage. Closes #3432; part of epic #3430.

## Problem
Delegated (Task-tool / sub-agent) work is the biggest systematic memory hole. The main-session `Stop` retain reads only the parent `transcript_path`, so a worker's hours of process work — paths touched, commands that worked, decisions, dead ends — reach memory only as its terse final report in the parent transcript. There was **no** `SubagentStop` registration and **no** `isSidechain` handling anywhere in the plugin (grep-verified).

## Task 0 — the probe (this gated the PR)
The design's assumption that `SubagentStop` hook input carries the sidechain `transcript_path` was **UNVERIFIED** (zero SubagentStop usage in the repo). I ran a **live empirical probe**: registered a logging-only `SubagentStop` hook in a scratch project on **Claude Code 2.1.215** and dispatched a real Task subagent.

**Result — the assumption is half-right, and reality is better than the fallback:**
- `SubagentStop` input's `transcript_path` points at the **parent** session jsonl, NOT the sidechain.
- But the input also carries a **first-class `agent_transcript_path`** pointing straight at the sidechain: `<project>/<session_id>/subagents/agent-<agent_id>.jsonl`. Plus `agent_id`, `agent_type`, `last_assistant_message`, `stop_hook_active`.
- The sidechain jsonl exists, with `isSidechain: true`, per-line `uuid`, and `agentId` on every line — the same structure switchroom's own `session-tail.ts` already documents.

Captured `SubagentStop` input (redacted paths):
```
"transcript_path": ".../<session>.jsonl"                                  (parent)
"agent_transcript_path": ".../<session>/subagents/agent-<id>.jsonl"       (sidechain)
"agent_id": "af5fba739c0ee6b38", "agent_type": "general-purpose", ...
```

**Shipped mechanism:** `agent_transcript_path` as the **primary** path; the design's documented directory-scan (newest `isSidechain:true` jsonl under the `subagents/` dir, then the project dir) as the **fallback** for older CLIs that omit the field.

## Changes
- **`hooks/hooks.json`** — register `SubagentStop` → `scripts/subagent_retain.py` (async, 15s). Loaded via `--plugin-dir`, so no scaffold hook wiring needed.
- **`scripts/subagent_retain.py`** (new):
  - Resolves the sidechain transcript (probe-confirmed field → derived path → scan fallback).
  - **Volume gate**: skip sub-agents under **6 human turns** OR **2,000 chars of non-tool-result text** (tool_result-only user messages don't count as turns; tool_result bodies don't count toward chars). Skips logged for coverage auditing.
  - Retains a bounded **last-40-human-turn** window, reusing `retain.py`'s window slice + network-free `build_retain_payload`. Tagged `sidechain` + `parent_session:<id>` (+ `agent_type:<t>`), deterministic content-derived `document_id` in a **distinct namespace** (`{session}-sub-{agent}-r{start}-{end}`) so re-fires upsert. A short process-fact framing header biases extraction (retain API has no per-call mission).
  - Failures enqueue to the **same** `pending-retains` durability queue (drained at SessionStart) — no new machinery.
- **`scripts/recall.py`** — new `recallTagWeights` per-tag score penalty (`_apply_tag_weights`): multiplies `scores.final` per matching tag immediately before `_sort_by_final_score`. This is the **NEW** mechanism the design called for — the existing demote-tag path (`_is_demoted_memory`) is a hard **DROP** filter and cannot express "reduced weight". A penalised memory sorts below equal-score untagged memories yet **still surfaces when it's the only relevant hit**. Deliberately NOT added to the drop filter.
- **`scripts/lib/config.py`** — `recallTagWeights` default `{}` + `HINDSIGHT_RECALL_TAG_WEIGHTS` env override (dict).
- **`src/agents/scaffold.ts`** — seed `recallTagWeights: { sidechain: 0.8 }` so sidechain process-memories rank just under first-party session memory.
- **`vendor/.../CHANGELOG.md`** — divergence entries.

## Tests (`python3 -m unittest discover tests/`)
- `test_subagent_retain.py` — transcript resolution (primary field, agent_id-derived path, newest-sidechain scan fallback, non-sidechain ignored); volume gate (turn floor, char floor, tool_result bodies excluded, pass case); run (correct tags + window + dedup id, stable id across re-fires, window cap at 40, trivial-fork skip posts nothing, lock-busy returns enqueue-shaped payload); hook registration wiring.
- `test_recall_tag_weights.py` — penalised sorts below equal-score neutral; **lone sidechain hit still surfaces**; strong sidechain still beats weak neutral; empty/None/1.0/scoreless/bad-weight no-ops; compound weights.

**Full python suite: 304 pass. `tsc --noEmit` clean. `npm run lint` clean (all 8 guards). Scaffold vitest (22) pass.**

## Deliberate non-goals (per design)
- Backfill sweep of historical sidechain transcripts — OUT of scope (value decays, cost unbounded).
- Client-side content diff vs the parent's final-report retain — NOT attempted; overlap is fine, hindsight consolidation dedups.

## Rollback
Unregister the `SubagentStop` hook; `recallTagWeights` defaults to `{}` (no-op) for standalone users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)