### PR TITLE
fix(gateway): content-gate flush supersede so async handbacks send fresh instead of silent edit-in-place (#3429)

### DIFF
--- a/telegram-plugin/flushed-turn-supersede.ts
+++ b/telegram-plugin/flushed-turn-supersede.ts
@@ -31,7 +31,16 @@
  * `record()` (a much smaller window), `take` finds no record and the duplicate
  * can still slip through. We deliberately trade that residual window for the
  * safety guarantee that we NEVER delete a message we cannot positively attribute
- * to the reply's own turn (identity-only supersede — see `decideSupersede`).
+ * to the reply's own turn (identity-scoped supersede — see `decideSupersede`).
+ *
+ * #3429 content gate: identity is NECESSARY but not sufficient. Because the
+ * flush ends its turn before recording, an async sub-agent handback landing
+ * within the TTL resolves the flush-delivered ENDED turn as its owner too —
+ * same identity as the turn's own late replay. When the caller supplies the
+ * landing reply's text, `decideSupersede` additionally requires it to BE the
+ * flushed answer (`flushedAnswerMatchesReply`); otherwise the decision is
+ * 'new-content' and the gateway sends fresh (a notifying new message) with the
+ * record left intact.
  *
  * Pure module: no I/O, no globals, no clock reads beyond the caller-supplied
  * `now`. Fully unit-testable; the gateway wires the actual delete/send.
@@ -51,9 +60,11 @@ export interface FlushedTurnRecord {
   /** The Telegram message id(s) the flush posted (edit target + any extra
    *  chunk messages). Superseding deletes all of them. */
   messageIds: number[]
-  /** The text the flush delivered — retained for diagnostics/logging only. The
-   *  supersede decision NEVER compares text (that is the whole point: it fires
-   *  even when the flushed text differs from the reply text). */
+  /** The text the flush delivered. Originally diagnostics-only; since #3429 it
+   *  also feeds the new-content gate (`flushedAnswerMatchesReply`): an
+   *  identity-matched reply that is NOT the same answer (neither equal nor a
+   *  bounded containment) is an async handback and must send fresh instead of
+   *  editing/deleting the flushed message. */
   text: string
   /** Wall-clock ms when recorded. */
   ts: number
@@ -71,8 +82,67 @@ export interface SupersedeDecision {
   /** Message ids the gateway must delete before/instead of the fresh send.
    *  Empty when `supersede` is false. */
   deleteMessageIds: number[]
-  /** Machine-readable reason (for logs / tests). */
-  reason: 'supersede' | 'no-record' | 'expired' | 'different-turn'
+  /** Machine-readable reason (for logs / tests). `'new-content'` (#3429): the
+   *  record matched by identity + TTL but the landing reply carries genuinely
+   *  DIFFERENT content than the flushed answer — an async handback attributed
+   *  to the flush-delivered ended turn, NOT that turn's own answer landing
+   *  late. The gateway must send FRESH (a notifying new message), never
+   *  edit/delete the flushed message; the record is NOT consumed. */
+  reason: 'supersede' | 'no-record' | 'expired' | 'different-turn' | 'new-content'
+  /** The matched record's flushed text — populated whenever a fresh record for
+   *  the reply's turn identity was found (`reason` 'supersede' or
+   *  'new-content'). The gateway stashes it on the owner turn atom so the
+   *  answer-delivered latch can make the same content-vs-flush discrimination
+   *  on the no-record retry/race paths (#3429). */
+  recordText?: string
+}
+
+/**
+ * #3429 — minimum length a CONTAINED text must have for a containment match.
+ * The legitimate containment class is a flush that delivered
+ * `narration\n\nanswer` being corrected by the clean `answer`-only reply — the
+ * contained side is a full answer, comfortably long. A trivially short
+ * contained string (e.g. a reply "Done." that happens to appear inside the
+ * flushed blob) is NOT positive evidence of the same answer, and a false match
+ * here silently edits/suppresses genuinely new content — the exact #3429
+ * failure. Below this floor only whitespace-normalized EQUALITY matches; the
+ * worst case of declining is a rare duplicate message, which beats a silent
+ * drop (the #3426/#3428 precedent).
+ */
+export const SUPERSEDE_MATCH_MIN_CONTAINMENT_CHARS = 32
+
+/** Collapse whitespace runs so flush-pipeline vs reply-pipeline spacing
+ *  (paragraph spacers, hard-break promotion) never defeats the comparison. */
+function normalizeForMatch(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * #3429 — is the landing reply the SAME ANSWER the flush already delivered
+ * (a late canonical correction), as opposed to genuinely new content (an async
+ * handback that merely resolved the flush-delivered ended turn as its owner)?
+ *
+ * Deterministic string decision, no timing:
+ *   - whitespace-normalized equality → same answer;
+ *   - containment either direction (flush = `narration\n\nanswer` ⊇ reply, or
+ *     reply ⊇ a partially-delivered flush), guarded by
+ *     `SUPERSEDE_MATCH_MIN_CONTAINMENT_CHARS` on the CONTAINED side so a short
+ *     coincidental substring can never claim a match.
+ *
+ * A model-REGENERATED paraphrase of the same answer is indistinguishable from
+ * new content and therefore sends fresh — a rare duplicate message, the same
+ * conscious trade #3428 shipped for the reply-armed latch. A silent
+ * drop/edit-in-place of a genuinely new handback is the strictly worse
+ * failure.
+ */
+export function flushedAnswerMatchesReply(flushedText: string, replyText: string): boolean {
+  const flushed = normalizeForMatch(flushedText)
+  const reply = normalizeForMatch(replyText)
+  if (flushed.length === 0 || reply.length === 0) return false
+  if (flushed === reply) return true
+  if (reply.length >= SUPERSEDE_MATCH_MIN_CONTAINMENT_CHARS && flushed.includes(reply)) return true
+  if (flushed.length >= SUPERSEDE_MATCH_MIN_CONTAINMENT_CHARS && reply.includes(flushed)) return true
+  return false
 }
 
 /**
@@ -93,10 +163,25 @@ export interface SupersedeDecision {
  * now resolves a last-known turnId for the reply before calling in, so the
  * common late-replay case still matches by identity rather than relying on the
  * promiscuous null branch.)
+ *
+ * #3429 content gate: identity alone is NOT sufficient. The flush ends its
+ * turn synchronously BEFORE recording (stream-render `endCurrentTurnAtomic` →
+ * `record`), so EVERY superseding reply is a late reply, and an async
+ * sub-agent handback landing within the TTL with no live gateway turn resolves
+ * the flush-delivered ENDED turn as its owner via the latest-ended tier —
+ * exactly the same identity as the turn's own canonical late replay. The
+ * observed failure (msgs 10482/10486, 2026-07-20): the handback consumed the
+ * record and EDITED the flushed message in place with unrelated new content —
+ * Telegram edits do not re-notify, so the handback never surfaced client-side
+ * AND the flushed answer was destroyed. When the caller supplies `replyText`
+ * and it is NOT the same answer (`flushedAnswerMatchesReply`), the decision is
+ * `'new-content'`: no supersede, record left intact for the genuine replay,
+ * and the gateway sends the reply FRESH. Callers that omit `replyText`
+ * (identity-only legacy shape) keep the pre-#3429 behaviour.
  */
 export function decideSupersede(
   record: FlushedTurnRecord | undefined,
-  args: { liveTurnId: string | null; now: number; ttlMs?: number },
+  args: { liveTurnId: string | null; replyText?: string | null; now: number; ttlMs?: number },
 ): SupersedeDecision {
   const ttlMs = args.ttlMs ?? DEFAULT_SUPERSEDE_TTL_MS
   if (record == null) return { supersede: false, deleteMessageIds: [], reason: 'no-record' }
@@ -110,7 +195,18 @@ export function decideSupersede(
   if (!sameTurn) {
     return { supersede: false, deleteMessageIds: [], reason: 'different-turn' }
   }
-  return { supersede: true, deleteMessageIds: [...record.messageIds], reason: 'supersede' }
+  // #3429 — same turn identity, but genuinely different content: an async
+  // handback attributed to the flush-delivered ended turn, not the turn's own
+  // answer landing late. Never edit/delete the flushed message for it.
+  if (args.replyText != null && !flushedAnswerMatchesReply(record.text, args.replyText)) {
+    return { supersede: false, deleteMessageIds: [], reason: 'new-content', recordText: record.text }
+  }
+  return {
+    supersede: true,
+    deleteMessageIds: [...record.messageIds],
+    reason: 'supersede',
+    recordText: record.text,
+  }
 }
 
 /**
@@ -225,23 +321,31 @@ export class FlushedTurnSupersedeRegistry {
 
   /** Decide supersede for a landing reply WITHOUT consuming the record. Selects
    *  the record whose turnId matches the reply's resolved `liveTurnId` (or the
-   *  null-turnId record when `liveTurnId == null`). */
+   *  null-turnId record when `liveTurnId == null`). `replyText` (#3429) enables
+   *  the new-content gate; omitting it keeps the identity-only legacy shape. */
   peek(
     chatId: string,
     threadId: number | undefined,
-    args: { liveTurnId: string | null; now: number },
+    args: { liveTurnId: string | null; replyText?: string | null; now: number },
   ): SupersedeDecision {
     const rec = this.entries.get(makeKey(chatId, threadId))?.get(turnKey(args.liveTurnId))
-    return decideSupersede(rec, { liveTurnId: args.liveTurnId, now: args.now, ttlMs: this.ttlMs })
+    return decideSupersede(rec, {
+      liveTurnId: args.liveTurnId,
+      replyText: args.replyText,
+      now: args.now,
+      ttlMs: this.ttlMs,
+    })
   }
 
   /** Decide supersede AND, on a supersede, consume the matched record (so a
    *  second replay of the same reply doesn't try to delete the same — now gone —
-   *  messages again). Returns the same decision `peek` would. */
+   *  messages again). A `'new-content'` decision (#3429) does NOT consume: the
+   *  record stays live for the turn's own canonical replay until the TTL.
+   *  Returns the same decision `peek` would. */
   take(
     chatId: string,
     threadId: number | undefined,
-    args: { liveTurnId: string | null; now: number },
+    args: { liveTurnId: string | null; replyText?: string | null; now: number },
   ): SupersedeDecision {
     const lane = makeKey(chatId, threadId)
     const decision = this.peek(chatId, threadId, args)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3429,6 +3429,17 @@ export type CurrentTurn = {
   // not silently drop. Scoped to the substantive floor so an interim sub-floor
   // ack NEITHER sets nor trips it. Reset false at turn start.
   answerDelivered: AnswerDeliveredLatch
+  // #3429 — the text the turn-flush backstop delivered (or is mid-delivering)
+  // as this turn's answer. Stamped SYNCHRONOUSLY alongside the 'flush' latch
+  // arm (stream-render fire site; outbound-send-path supersede-consumption
+  // resurrection site) and cleared wherever that latch is reset. Lets the
+  // late-reply suppression discriminate BY CONTENT between the flushed answer
+  // landing again (suppress — the flush race) and a genuinely new async
+  // handback attributed to this flush-delivered ended turn (deliver fresh —
+  // suppressing/editing it is the #3429 silent client-side drop), including in
+  // the post-fire pre-record window where no supersede record exists yet.
+  // Null when no flush armed this turn. Reset null at turn start.
+  flushedAnswerText: string | null
   // 2026-07 double-reply-on-DM fix (F2 — recency bound). Wall-clock ms the turn
   // ENDED (stamped once by `endCurrentTurnAtomic`), or null while still live.
   // The `findLatestEndedTurnForChat` supersede tier carries DESTRUCTIVE

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -53,7 +53,11 @@ import { resolveChatIdFallback } from './chat-id-fallback.js'
 import { isFinalAnswerReply, isSubstantiveFinalReply } from '../final-answer-detect.js'
 import { decideOverPing, type OverPingDecision } from '../over-ping-safety-net.js'
 import { decideSilentReplyAnchor } from '../silent-reply-anchor.js'
-import { decideSupersedeCorrection, type FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
+import {
+  decideSupersedeCorrection,
+  flushedAnswerMatchesReply,
+  type FlushedTurnSupersedeRegistry,
+} from '../flushed-turn-supersede.js'
 import { decideAnswerLatchSuppression } from '../reply-owner-resolve.js'
 import { deriveTelegraphTitle } from '../telegraph.js'
 import {
@@ -872,10 +876,16 @@ export async function sendReply(
     // resolvers agree and the late-reply supersede fires by identity.
     const ownerTurn = resolveReplyOwnerTurn(turn, chat_id, args)
     const resolvedTurnId = ownerTurn?.turnId ?? null
+    // #3429 — pass the (normalized) reply text so the registry can apply the
+    // new-content gate: identity match + TTL alone also fits an async handback
+    // that merely resolved this flush-delivered ENDED turn as its owner via
+    // the latest-ended tier. Editing the flushed message in place with that
+    // handback's text does not re-notify client-side (Telegram edits never
+    // push) — the observed silent non-surfacing of msgs 10482/10486.
     const decision = flushedTurnSupersede.take(
       chat_id,
       replyThreadId,
-      { liveTurnId: resolvedTurnId, now: Date.now() },
+      { liveTurnId: resolvedTurnId, replyText: text, now: Date.now() },
     )
     if (decision.supersede) {
       process.stderr.write(
@@ -901,8 +911,14 @@ export async function sendReply(
       // (no-throw) path is unaffected: the correction below still ships B once.
       // Tagged 'flush' (#3426): a flush record existed for this turn (take()
       // just consumed it), so the flushed message A is what the suppression
-      // protects against duplicating.
-      if (ownerTurn != null) ownerTurn.answerDelivered = 'flush'
+      // protects against duplicating. #3429: stash the record's flushed text
+      // alongside, so the retry's latch check can discriminate by content —
+      // the retry of THIS superseding reply matches and stays suppressed, while
+      // a later genuinely-new handback does not and delivers.
+      if (ownerTurn != null) {
+        ownerTurn.answerDelivered = 'flush'
+        if (decision.recordText != null) ownerTurn.flushedAnswerText = decision.recordText
+      }
     } else {
       // 2026-07 double-reply-on-DM fix (Part 2) — answer-delivered race latch.
       // Supersede found no record. Either there was no flush (normal reply), or
@@ -925,12 +941,33 @@ export async function sendReply(
         text: rawText,
         disableNotification: args.disable_notification === true,
       })
+      // #3429 — content evidence for the latch. `'new-content'` is the
+      // registry's POSITIVE determination that this reply differs from the
+      // flushed answer (record present, identity matched, text did not);
+      // otherwise compare against the owner turn's stashed `flushedAnswerText`
+      // (covers the post-fire pre-record race window, where no record exists
+      // yet but the fire site already stamped what it is delivering). Null —
+      // no flushed text to compare — keeps the conservative pre-#3429
+      // flush-armed suppression.
+      const replyMatchesFlushedAnswer: boolean | null =
+        decision.reason === 'new-content'
+          ? false
+          : ownerTurn?.flushedAnswerText != null
+            ? flushedAnswerMatchesReply(ownerTurn.flushedAnswerText, text)
+            : null
       const suppressByLatch = decideAnswerLatchSuppression({
         superseded: false,
         replySubstantive,
         isLateReply: turn == null,
         ownerAnswerDelivered: ownerTurn?.answerDelivered ?? false,
+        replyMatchesFlushedAnswer,
       })
+      if (decision.reason === 'new-content') {
+        process.stderr.write(
+          `telegram gateway: reply: flush supersede declined — new content (#3429) ` +
+          `chatId=${chat_id} ownerTurnId=${JSON.stringify(resolvedTurnId)}; sending fresh\n`,
+        )
+      }
       if (suppressByLatch) {
         process.stderr.write(
           `telegram gateway: reply: suppressed by answer-delivered latch ` +

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -307,6 +307,9 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
           // 2026-07 double-reply-on-DM fix (Part 2) — answer-delivered race
           // latch, reset at turn start alongside the other answer flags.
           answerDelivered: false,
+          // #3429 — flushed-answer text for the content-vs-flush latch
+          // discrimination; stamped at flush arm, reset at turn start.
+          flushedAnswerText: null,
           // 2026-07 double-reply-on-DM fix (F2) — stamped at turn end.
           endedAt: null,
           firstPingAt: null,
@@ -1636,6 +1639,12 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
         //       arbitrate the late reply (that is (a)); it is redundant-but-
         //       cheap with the `currentTurn == null` bail below.
         turn.answerDelivered = 'flush'
+        // #3429 — stamp WHAT the flush is delivering alongside the arm, so the
+        // late-reply suppression can discriminate by content: a late reply
+        // carrying this same answer is the flush race (suppress/supersede); a
+        // late reply carrying DIFFERENT content is a genuinely new async
+        // handback attributed to this ended turn and must send fresh.
+        turn.flushedAnswerText = capturedText
         const backstopLatchClaimed = backstopDeliveryLedger.claim(turn.turnId)
 
         // #654 deterministic double-message fix. Hand off the pinned
@@ -1833,6 +1842,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
               if (backstopCtrl) backstopCtrl.finalize('error')
               backstopDeliveryLedger.release(turn.turnId)
               turn.answerDelivered = false
+              turn.flushedAnswerText = null // #3429 — cleared with the latch
             } else if (backstopCtrl) {
               backstopCtrl.finalize('done')
             }
@@ -1857,6 +1867,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
             process.stderr.write(`telegram gateway: turn-flush post-delivery bookkeeping failed: ${(err as Error).message}\n`)
             if (!delivered) {
               turn.answerDelivered = false
+              turn.flushedAnswerText = null // #3429 — cleared with the latch
               backstopDeliveryLedger.release(turn.turnId)
               if (backstopCtrl) backstopCtrl.finalize('error')
             }

--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -178,6 +178,19 @@ export interface AnswerLatchSuppressInput {
   isLateReply: boolean
   /** The resolved owner turn's source-tagged `answerDelivered` latch. */
   ownerAnswerDelivered: AnswerDeliveredLatch
+  /** #3429 — content evidence: does the landing reply carry the SAME answer
+   *  the flush delivered (`flushedAnswerMatchesReply` against the supersede
+   *  record's text or the owner turn's stashed `flushedAnswerText`)?
+   *    - `false`  → POSITIVE evidence of genuinely new content (an async
+   *                 handback attributed to the flush-delivered ended turn).
+   *                 Suppressing it would silently drop the user's answer —
+   *                 never suppress.
+   *    - `true`   → the reply is the flushed answer landing again — suppress
+   *                 (the flush race the latch exists for).
+   *    - `null` / omitted → no flushed text available to compare (legacy atom,
+   *                 pre-#3429 caller). Conservative: keep the pre-#3429
+   *                 flush-armed suppression. */
+  replyMatchesFlushedAnswer?: boolean | null
 }
 
 /**
@@ -195,10 +208,18 @@ export interface AnswerLatchSuppressInput {
  * (typically) an async sub-agent handback carrying genuinely new content, and
  * suppressing it silently drops the user's answer. Byte-identical replays of
  * the delivered reply are still deduped by the content-keyed #546 cache.
+ *
+ * #3429 refinement: even a FLUSH-armed latch does not suppress when there is
+ * POSITIVE content evidence (`replyMatchesFlushedAnswer === false`) that the
+ * landing reply is NOT the flushed answer — an async handback attributed to a
+ * flush-delivered ended turn must send fresh, not vanish. Absent evidence
+ * (`null`/omitted) the flush-armed suppression holds, preserving the #2996
+ * Part 2 race backstop.
  */
 export function decideAnswerLatchSuppression(input: AnswerLatchSuppressInput): boolean {
   if (input.superseded) return false
   if (!input.replySubstantive) return false
   if (!input.isLateReply) return false
+  if (input.replyMatchesFlushedAnswer === false) return false
   return input.ownerAnswerDelivered === 'flush'
 }

--- a/telegram-plugin/tests/flushed-turn-supersede.test.ts
+++ b/telegram-plugin/tests/flushed-turn-supersede.test.ts
@@ -21,8 +21,10 @@ import { describe, it, expect } from 'vitest'
 import {
   decideSupersede,
   decideSupersedeCorrection,
+  flushedAnswerMatchesReply,
   FlushedTurnSupersedeRegistry,
   DEFAULT_SUPERSEDE_TTL_MS,
+  SUPERSEDE_MATCH_MIN_CONTAINMENT_CHARS,
   type FlushedTurnRecord,
 } from '../flushed-turn-supersede.js'
 
@@ -262,5 +264,120 @@ describe('FlushedTurnSupersedeRegistry — record / peek / take lifecycle', () =
     // Only the fresh record remains; the orphan was swept, not left to leak.
     expect(reg.size(5000)).toBe(1)
     expect(reg.peek('chat1', undefined, { liveTurnId: 'turn-A', now: 5000 }).reason).toBe('no-record')
+  })
+})
+
+/**
+ * #3429 — async handback edit-in-place supersede of a flush-delivered message
+ * can fail to surface client-side.
+ *
+ * The flush ends its turn synchronously BEFORE recording, so EVERY superseding
+ * reply is a late reply — and an async sub-agent handback landing within the
+ * 60 s TTL with no live gateway turn resolves the flush-delivered ENDED turn
+ * as its owner via the latest-ended tier, the SAME identity as the turn's own
+ * canonical late replay. Identity-only supersede then consumed the record and
+ * EDITED the flushed message in place with the handback's unrelated content
+ * (msgs 10482/10486, 2026-07-20) — Telegram edits never push-notify, so the
+ * handback silently failed to surface AND the flushed answer was destroyed.
+ *
+ * The content gate: `replyText` is compared against the record's flushed text
+ * (`flushedAnswerMatchesReply` — whitespace-normalized equality, or containment
+ * with a minimum-length guard on the contained side). Same answer → supersede
+ * (the wanted correction); different content → 'new-content', send fresh,
+ * record NOT consumed.
+ */
+describe('#3429 — flushedAnswerMatchesReply (content discriminator)', () => {
+  const ANSWER = 'The deploy is green: all 12 services rolled out and health checks pass.'
+  const FLUSH_BLOB = `Let me check the rollout status.\n\n${ANSWER}`
+
+  it('matches whitespace-normalized equality', () => {
+    expect(flushedAnswerMatchesReply(ANSWER, ANSWER)).toBe(true)
+    expect(flushedAnswerMatchesReply(`${ANSWER}\n`, ANSWER.replace(': ', ':  '))).toBe(true)
+  })
+
+  it('matches the classic containment class: flush = narration+answer ⊇ clean reply', () => {
+    expect(flushedAnswerMatchesReply(FLUSH_BLOB, ANSWER)).toBe(true)
+  })
+
+  it('matches reverse containment: reply ⊇ partially-delivered flush text', () => {
+    expect(flushedAnswerMatchesReply(ANSWER, FLUSH_BLOB)).toBe(true)
+  })
+
+  it('does NOT match genuinely different content (the handback)', () => {
+    const handback =
+      'Worker finished: PR #3430 is up with the fix for the vault broker timeout, ' +
+      'tests are green, ready for your review.'
+    expect(flushedAnswerMatchesReply(FLUSH_BLOB, handback)).toBe(false)
+  })
+
+  it('short containment below the minimum-length guard does NOT match ' +
+    '(a coincidental substring must never claim a handback)', () => {
+    const shortReply = 'rolled out'
+    expect(shortReply.length).toBeLessThan(SUPERSEDE_MATCH_MIN_CONTAINMENT_CHARS)
+    expect(FLUSH_BLOB.includes(shortReply)).toBe(true)
+    expect(flushedAnswerMatchesReply(FLUSH_BLOB, shortReply)).toBe(false)
+  })
+
+  it('short EQUAL texts still match (equality has no length floor)', () => {
+    expect(flushedAnswerMatchesReply('yes, done', 'yes, done')).toBe(true)
+  })
+})
+
+describe('#3429 — decideSupersede new-content gate', () => {
+  const FLUSHED = 'Narration first.\n\nHere is the finished summary of the incident you asked about.'
+  const HANDBACK =
+    'Sub-agent handback: the researcher finished and found three root causes, ' +
+    'written up in the report at /tmp/report.md — want the highlights?'
+
+  it('same-turn same-answer late reply still supersedes (the wanted correction)', () => {
+    const d = decideSupersede(rec({ text: FLUSHED }), {
+      liveTurnId: 'turn-A',
+      replyText: 'Here is the finished summary of the incident you asked about.',
+      now: 1_000_010,
+    })
+    expect(d.supersede).toBe(true)
+    expect(d.reason).toBe('supersede')
+    expect(d.recordText).toBe(FLUSHED)
+  })
+
+  it('CORE #3429: same turn identity + DIFFERENT content → new-content, NO supersede', () => {
+    const d = decideSupersede(rec({ text: FLUSHED }), {
+      liveTurnId: 'turn-A',
+      replyText: HANDBACK,
+      now: 1_000_010,
+    })
+    expect(d.supersede).toBe(false)
+    expect(d.reason).toBe('new-content')
+    expect(d.deleteMessageIds).toEqual([])
+    expect(d.recordText).toBe(FLUSHED)
+  })
+
+  it('legacy identity-only callers (no replyText) keep the pre-#3429 behaviour', () => {
+    const d = decideSupersede(rec({ text: FLUSHED }), { liveTurnId: 'turn-A', now: 1_000_010 })
+    expect(d.supersede).toBe(true)
+  })
+
+  it('take() does NOT consume the record on new-content — the genuine replay ' +
+    'can still correct the flushed message afterwards', () => {
+    const reg = new FlushedTurnSupersedeRegistry()
+    const now = 1_000_000
+    reg.record('chat9', undefined, { turnId: 'turn-F', messageIds: [7001], text: FLUSHED }, now)
+
+    // The handback lands first: new-content, nothing consumed, nothing deleted.
+    const d1 = reg.take('chat9', undefined, { liveTurnId: 'turn-F', replyText: HANDBACK, now: now + 10_000 })
+    expect(d1.supersede).toBe(false)
+    expect(d1.reason).toBe('new-content')
+
+    // The turn's own canonical replay lands later: record still there, supersede
+    // fires and consumes it.
+    const d2 = reg.take('chat9', undefined, {
+      liveTurnId: 'turn-F',
+      replyText: 'Here is the finished summary of the incident you asked about.',
+      now: now + 20_000,
+    })
+    expect(d2.supersede).toBe(true)
+    expect(d2.deleteMessageIds).toEqual([7001])
+    // Now consumed.
+    expect(reg.peek('chat9', undefined, { liveTurnId: 'turn-F', now: now + 21_000 }).reason).toBe('no-record')
   })
 })

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -563,3 +563,51 @@ describe('#3426 — async sub-agent handback after an interim-ack turn', () => {
     expect(handback).toBeNull()
   })
 })
+
+/**
+ * #3429 — content evidence in the answer-delivered latch.
+ *
+ * A flush-armed latch used to suppress ANY late substantive reply resolving
+ * the flush-delivered ended turn. With the supersede path now declining
+ * new-content handbacks (they must send FRESH, not edit the flushed message in
+ * place), those handbacks fall through to this latch — which would have
+ * converted the #3429 silent edit into a #3426-style silent drop. The
+ * `replyMatchesFlushedAnswer` evidence closes that: positive FALSE (the reply
+ * is NOT the flushed answer) never suppresses; TRUE or unknown (null/omitted)
+ * preserves the #2996 Part 2 flush-race backstop exactly as before.
+ */
+describe('#3429 — flush-armed latch with content evidence', () => {
+  const base = {
+    superseded: false,
+    replySubstantive: true,
+    isLateReply: true,
+    ownerAnswerDelivered: 'flush' as const,
+  }
+
+  it('CORE: positive new-content evidence (matches === false) is NEVER suppressed ' +
+    '— the handback after a flush-delivered turn delivers fresh', () => {
+    expect(decideAnswerLatchSuppression({ ...base, replyMatchesFlushedAnswer: false })).toBe(false)
+  })
+
+  it('the flushed answer landing again (matches === true) is still suppressed ' +
+    '(the flush race the latch exists for)', () => {
+    expect(decideAnswerLatchSuppression({ ...base, replyMatchesFlushedAnswer: true })).toBe(true)
+  })
+
+  it('unknown evidence (null) keeps the conservative pre-#3429 suppression', () => {
+    expect(decideAnswerLatchSuppression({ ...base, replyMatchesFlushedAnswer: null })).toBe(true)
+  })
+
+  it('omitted evidence keeps the conservative pre-#3429 suppression (back-compat)', () => {
+    expect(decideAnswerLatchSuppression(base)).toBe(true)
+  })
+
+  it('evidence never overrides the reply-armed/unarmed rules (still no suppression)', () => {
+    expect(
+      decideAnswerLatchSuppression({ ...base, ownerAnswerDelivered: 'reply', replyMatchesFlushedAnswer: true }),
+    ).toBe(false)
+    expect(
+      decideAnswerLatchSuppression({ ...base, ownerAnswerDelivered: false, replyMatchesFlushedAnswer: true }),
+    ).toBe(false)
+  })
+})

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -569,3 +569,157 @@ describe('structural wiring — the singleton + the gateway entry point (#2996 P
     expect(win.match(/getCurrentTurn\(\)/g)!.length).toBeGreaterThanOrEqual(5)
   })
 })
+
+/**
+ * #3429 — GATEWAY-LEVEL regression: an async handback landing after a
+ * flush-delivered turn ENDED must produce a FRESH, notifying message — never a
+ * silent edit-in-place of the prior turn's flushed message.
+ *
+ * This drives the REAL `sendReply` body (the exact gateway send path: the
+ * supersede consumption at outbound-send-path.ts ~874-905 and the deferred
+ * `decideSupersedeCorrection` edit-in-place lane at ~1462-1477) against the
+ * fake bot API, with a REAL `FlushedTurnSupersedeRegistry` seeded exactly the
+ * way the turn-flush backstop seeds it (record + 'flush'-armed ended owner
+ * turn). The incident (msgs 10482/10486, 2026-07-20): the handback resolved
+ * the flush-delivered ENDED turn as owner via the latest-ended tier (inside
+ * the 60 s TTL), consumed the supersede record, and EDITED the flushed message
+ * in place — Telegram edits never push-notify, so genuinely new content failed
+ * to surface client-side. Red on pre-fix code: these first asserts see an
+ * `editMessageText` call and no fresh send.
+ *
+ * The turn-end-funnel flag (SWITCHROOM_TURN_END_FUNNEL_V2, default ON) does
+ * not fork this path — the flush branch records into the SAME registry and the
+ * reply path consumes it identically under both settings — so this covers the
+ * v2 funnel default.
+ */
+describe('#3429 — post-turn-end handback vs flush-delivered supersede (real send path)', () => {
+  const OWNER_TURN_ID = `${CHAT}:_#ended-40`
+  const FLUSH_MSG_ID = 4242
+  const FLUSHED_TEXT =
+    'Checking the fleet status now.\n\n' +
+    'All twelve agents are healthy: the gateway, the vault broker, and the approval kernel ' +
+    'all report green health checks, and no container has restarted in the last twenty-four hours. ' +
+    'Nothing needs attention right now.'
+  const CANONICAL_REPLY =
+    'All twelve agents are healthy: the gateway, the vault broker, and the approval kernel ' +
+    'all report green health checks, and no container has restarted in the last twenty-four hours. ' +
+    'Nothing needs attention right now.'
+  const HANDBACK =
+    'Worker handback: the researcher sub-agent finished the migration audit. It found three ' +
+    'schema drifts in the staging database, wrote the full report to the shared drive, and ' +
+    'opened PR #3430 with the corrective migration. Tests are green and it is ready for review.'
+
+  /** An ENDED, flush-delivered owner turn — exactly the atom state the
+   *  turn-flush fire site leaves in `recentTurnsById` (latch 'flush', flushed
+   *  text stamped, endedAt within the supersede TTL). */
+  function makeFlushDeliveredEndedTurn(): CurrentTurn {
+    return {
+      turnId: OWNER_TURN_ID,
+      sessionChatId: CHAT,
+      answerDelivered: 'flush',
+      flushedAnswerText: FLUSHED_TEXT,
+      endedAt: Date.now() - 30_000,
+      replyCalled: false,
+      finalAnswerDelivered: true,
+      finalAnswerSubstantive: true,
+    } as unknown as CurrentTurn
+  }
+
+  function seedFlushRecord(h: ReturnType<typeof makeHarness>, owner: CurrentTurn): void {
+    h.deps.flushedTurnSupersede.record(
+      CHAT,
+      undefined,
+      { turnId: owner.turnId, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
+      Date.now(),
+    )
+    // The late reply resolves the ENDED flush-delivered turn as its owner
+    // (latest-ended tier — no live turn, no origin echo, no quote in a DM).
+    h.deps.resolveReplyOwnerTurn = () => owner
+  }
+
+  it('CORE REGRESSION (red pre-fix): a handback with genuinely NEW content sends a ' +
+    'FRESH message — no silent edit-in-place of the flushed message', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedFlushRecord(h, owner)
+
+    // The handback lands LATE: req.turn = null (no live gateway turn — a
+    // sub-agent completion is not a new inbound).
+    const res = await sendReply(h.deps, req(HANDBACK))
+
+    // A NEW client-visible message shipped (fresh send ⇒ Telegram push
+    // notifies)…
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.text).toContain('migration audit')
+    expect(fresh[0]!.message_id).not.toBe(FLUSH_MSG_ID)
+    // …and the flushed message was NEITHER edited nor deleted (edits never
+    // re-notify — the pre-fix silent path).
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+
+    // The supersede record was NOT consumed: the turn's own canonical replay
+    // could still correct the flushed message afterwards.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        replyText: CANONICAL_REPLY,
+        now: Date.now(),
+      }).supersede,
+    ).toBe(true)
+  })
+
+  it('PRESERVED: the turn\'s OWN canonical late replay (same answer, contained in ' +
+    'the flushed blob) still supersedes via edit-in-place — no duplicate bubble', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedFlushRecord(h, owner)
+
+    const res = await sendReply(h.deps, req(CANONICAL_REPLY))
+
+    // The single flushed message was edited into the canonical reply…
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(edits[0]!.text).toContain('All twelve agents are healthy')
+    // …and NO second bubble shipped (the #3236/#2996 duplicate class stays closed).
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent/)
+    // Record consumed — a retry cannot re-target the now-corrected message.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        now: Date.now(),
+      }).reason,
+    ).toBe('no-record')
+  })
+
+  it('PRE-RECORD RACE, new content: flush fired (latch armed + text stamped) but ' +
+    'record not yet written — the handback still delivers FRESH, not suppressed', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    // NO registry record (the post-fire pre-record window); owner resolution
+    // still recovers the ended flush-armed turn.
+    h.deps.resolveReplyOwnerTurn = () => owner
+
+    const res = await sendReply(h.deps, req(HANDBACK))
+
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.text).toContain('migration audit')
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+  })
+
+  it('PRE-RECORD RACE, same answer: the flushed answer landing again in the race ' +
+    'window is still suppressed (the #2996 Part 2 backstop holds)', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    h.deps.resolveReplyOwnerTurn = () => owner
+
+    const res = await sendReply(h.deps, req(FLUSHED_TEXT))
+
+    expect(h.calls).toHaveLength(0) // nothing sent, nothing edited
+    expect(res.content[0]!.text).toContain('deduped')
+  })
+})


### PR DESCRIPTION
Fixes #3429 — "Async handback edit-in-place supersede of a flush-delivered message can fail to surface client-side."

## Root cause

`decideSupersede` (`telegram-plugin/flushed-turn-supersede.ts`) matched by turn IDENTITY + TTL only. An async sub-agent handback landing with NO live gateway turn resolves the flush-delivered ENDED prior turn as its owner via the latest-ended tier (≤60 s), identity-matches that turn's supersede record, and the reply path (`telegram-plugin/gateway/outbound-send-path.ts:875-905`) consumed the record and applied the deferred `decideSupersedeCorrection` **edit-in-place** (`outbound-send-path.ts` ~1470-1476): the prior turn's flushed message was edited to the handback's text. Telegram edits do not push-notify, so the handback "delivered" server-side but never surfaced client-side (msgs `10482`/`10486`, 2026-07-20) — and the flushed answer text was destroyed.

## Contradiction with the issue-dispatch premise (reported per protocol)

The suggested gate — "supersede only when the reply belongs to the same still-**live** turn" — cannot work: the flush ends its turn synchronously **before** recording (`telegram-plugin/gateway/stream-render.ts:1671` `endCurrentTurnAtomic` runs before the `flushedTurnSupersede.record` at `:1816`), so **every** superseding reply is a late reply (`req.turn == null`), including the legitimate same-turn canonical replay (#2996 Part 1 / #3236's 216-occurrence containment class). A live-turn gate would (a) disable the supersede correction entirely, and (b) let the declined replies fall through to the flush-armed answer-delivered latch, which would **silently drop** new-content handbacks — the #3426 failure mode, strictly worse than the edit.

## Fix (deterministic, content-scoped)

The discriminator between "this turn's own answer landing late" (correction wanted) and "a genuinely new handback that merely resolved this ended turn" (fresh notifying send wanted) is **content vs the record's flushed text**:

- `flushedAnswerMatchesReply(flushedText, replyText)` — pure: whitespace-normalized equality, or containment either direction with a `SUPERSEDE_MATCH_MIN_CONTAINMENT_CHARS` (32) floor on the contained side (a short coincidental substring can never claim a handback).
- `decideSupersede` takes the landing reply's text: identity+TTL match with **same answer** → `supersede` (edit-in-place/delete-resend correction preserved, unchanged); with **different content** → new `'new-content'` reason: no supersede, **record NOT consumed** (the true replay can still correct later), gateway sends **FRESH** — a new message that push-notifies.
- `decideAnswerLatchSuppression` (`telegram-plugin/reply-owner-resolve.ts`) accepts `replyMatchesFlushedAnswer`: positive `false` evidence never suppresses — required, otherwise the declined supersede falls through to the flush-armed latch and converts the silent edit into a #3426-style silent drop. `true`/unknown (`null`) preserve the #2996 Part 2 flush-race suppression exactly.
- `CurrentTurn.flushedAnswerText` (new field) is stamped synchronously at the flush arm site (`stream-render.ts`, next to `answerDelivered = 'flush'`) and at the supersede-consumption resurrection site, cleared wherever the latch is reset — so the content discrimination also covers the post-fire **pre-record race window** (no registry record yet).

## Preserved vs changed

- **Preserved:** same-answer late replay (equality or ≥32-char containment) still supersedes via edit-in-place — no duplicate bubble, the #3236/#2996 class stays closed. Flush-race suppression for the same answer in the pre-record window still fires. The L1 resurrection guard (throw-then-retry) still yields exactly one message. Legacy identity-only callers (no `replyText`) keep pre-#3429 behavior.
- **Changed:** a post-turn-end reply with genuinely different content now sends fresh (notifying) and leaves the record intact — never edits/deletes the prior turn's flushed message, never latch-suppressed.
- **Honest bound (conscious trade, #3428 precedent):** a model-REGENERATED paraphrase of the flushed answer, or a same-answer replay shorter than 32 chars wrapped in a narration blob, is indistinguishable from new content and now ships as a rare duplicate message instead of an edit — a duplicate beats a silent drop.

## v2 funnel

`SWITCHROOM_TURN_END_FUNNEL_V2` defaults ON (`gateway.ts:4829`, `!== '0'`). Verified the flag does not fork this path: the funnel only changes the turn-end dispatch shape; the flush branch (record + latch arm) and the reply consumption path are shared across both settings. The scoped run includes both `tests/turn-lifecycle-characterization.test.ts` (legacy-pinned) and `tests/turn-lifecycle-characterization-v2.test.ts` (v2), plus the new gateway-level regression which runs under the v2 default.

## Tests

- **Gateway-level integration** (`telegram-plugin/tests/send-reply-golden.test.ts`, new `#3429` describe — drives the REAL `sendReply` body against the fake bot API with a real `FlushedTurnSupersedeRegistry`):
  - **CORE REGRESSION**: flush-delivered ended owner + seeded record; late handback (no live turn) → asserts ONE fresh `sendRichMessage`, ZERO `editMessageText`/`deleteMessage`, record not consumed. **Verified red pre-fix** (gates temporarily reverted: test fails with the edit observed and no fresh send).
  - **PRESERVED**: the turn's own canonical replay (contained in the flushed blob) → `editMessageText` on the flushed id, zero fresh bubbles, record consumed.
  - **PRE-RECORD RACE** both directions: new-content handback delivers fresh (verified red pre-fix); same-answer replay still suppressed.
- **Pure cores**: `flushed-turn-supersede.test.ts` (matcher incl. containment-floor negative; `'new-content'` decision; take() non-consumption; legacy no-replyText back-compat) and `reply-owner-resolve.test.ts` (latch evidence matrix incl. null/omitted conservative back-compat).

## Test + lint results (verbatim)

- `vitest run telegram-plugin/tests/reply-owner-resolve.test.ts telegram-plugin/tests/outbound-send-path.test.ts telegram-plugin/tests/stream-render-golden.test.ts tests/turn-lifecycle-characterization.test.ts tests/turn-lifecycle-characterization-v2.test.ts telegram-plugin/tests/flushed-turn-supersede.test.ts telegram-plugin/tests/recent-outbound-dedup.test.ts telegram-plugin/tests/answer-ready-flush.test.ts telegram-plugin/tests/turn-flush-safety.test.ts telegram-plugin/tests/turn-flush-suppression.test.ts telegram-plugin/tests/send-reply-golden.test.ts telegram-plugin/tests/captured-answer-resume.test.ts` — **`Test Files 11 passed (11)`, `Tests 271 passed (271)`** (+ `captured-answer-resume.test.ts` standalone: `Tests 11 passed (11)`).
- `npm run lint` — **clean**: `tsc --noEmit` + all guard scripts pass (`check-litellm-config-guard: SKIP — config file absent`, expected in hermetic dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)