### PR TITLE
doctor: directive-count WARN/FAIL + MAX_DIRECTIVES truncation surfacing (C2)

### DIFF
--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -42,6 +42,71 @@ export interface CheckResult {
 /** 1 GiB in bytes — the floor below which PostgreSQL's shared segments fail. */
 export const MIN_HINDSIGHT_SHM_BYTES = 1024 * 1024 * 1024;
 
+/**
+ * Hard cap on how many active directives the recall hook ever injects into the
+ * prompt — MUST mirror `MAX_DIRECTIVES` in
+ * `vendor/hindsight-memory/scripts/lib/directives.py`. A bank with MORE active
+ * directives than this has its list SILENTLY truncated (`directives[:15]`) in the
+ * `<active_directives>` recall block: the lowest-priority directives beyond the
+ * cap never reach the agent. The doctor surfaces that truncation so it isn't
+ * silent (workstream C2).
+ */
+export const MAX_DIRECTIVES = 15;
+
+/**
+ * Soft threshold: a bank with MORE active directives than this earns a WARN
+ * before it hits the truncating hard cap. Directive count is a slow-moving
+ * signal an operator should prune well before recall starts dropping rules.
+ */
+export const DIRECTIVE_WARN_THRESHOLD = 12;
+
+/**
+ * Pure: classify a bank's ACTIVE-directive count into a health result.
+ *
+ * - `null` count (directive fetch failed / not attempted) → no row (returns null).
+ * - `<= DIRECTIVE_WARN_THRESHOLD` (≤12) → healthy, no row (avoids one ok line per
+ *   bank across the fleet; the issues card stays focused on problems).
+ * - `> DIRECTIVE_WARN_THRESHOLD` and `<= MAX_DIRECTIVES` (13–15) → **warn**: pile-up
+ *   approaching the truncating cap.
+ * - `> MAX_DIRECTIVES` (16+) → **fail**: the recall block silently truncates the
+ *   overflow; the lowest-priority directives never reach the agent.
+ */
+export function classifyDirectiveCount(
+  count: number | null,
+  bankLabel: string,
+): CheckResult | null {
+  if (count === null) return null;
+  const name = `${bankLabel} directives`;
+  if (count > MAX_DIRECTIVES) {
+    const truncated = count - MAX_DIRECTIVES;
+    return {
+      name,
+      status: "fail",
+      detail:
+        `${count} active directives — exceeds MAX_DIRECTIVES=${MAX_DIRECTIVES}, so the ` +
+        `${truncated} lowest-priority directive(s) are SILENTLY truncated from the ` +
+        `<active_directives> recall block and never reach the agent`,
+      fix:
+        "Retire or merge stale directives so the active count is at or below " +
+        `${MAX_DIRECTIVES} (deletes stay operator-approved). The mental-model-curator ` +
+        "skill's directive merge/retire pass is the durable path.",
+    };
+  }
+  if (count > DIRECTIVE_WARN_THRESHOLD) {
+    return {
+      name,
+      status: "warn",
+      detail:
+        `${count} active directives — approaching the MAX_DIRECTIVES=${MAX_DIRECTIVES} cap ` +
+        `above which the recall block silently truncates the overflow`,
+      fix:
+        "Prune or merge low-value directives before the count crosses " +
+        `${MAX_DIRECTIVES}. Review with \`switchroom memory --directives <bank>\`.`,
+    };
+  }
+  return null;
+}
+
 /** Pure: classify a container's ShmSize (bytes) into a health result. */
 export function classifyShmSize(bytes: number): CheckResult {
   const mib = Math.round(bytes / 1024 / 1024);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -31,7 +31,7 @@ import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
 import { probeHindsight, isHindsightEnabled, fetchHindsightToolsList, collectProfileBanks } from "../memory/hindsight.js";
 import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
-import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, classifyConsolidationBacklog } from "./doctor-memory.js";
+import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, classifyConsolidationBacklog, classifyDirectiveCount } from "./doctor-memory.js";
 import { runLitellmModelChecks } from "../litellm/model-validation.js";
 import { isVaultReference, parseVaultReference } from "../vault/resolver.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
@@ -1170,6 +1170,14 @@ export async function checkBankIngestHealth(
       });
       continue;
     }
+
+    // Active-directive count (workstream C2): WARN past DIRECTIVE_WARN_THRESHOLD,
+    // FAIL past MAX_DIRECTIVES (where the recall block silently truncates the
+    // overflow). Emitted as its OWN row, independent of the ingest-health branch
+    // chain below (which `continue`s after the first match), so a directive
+    // pile-up surfaces even on a bank that also has an ingest issue.
+    const directiveRow = classifyDirectiveCount(h.activeDirectiveCount, label);
+    if (directiveRow) results.push(directiveRow);
     if (h.totalDocuments === 0) {
       results.push({
         name: label,

--- a/src/memory/bank-health.test.ts
+++ b/src/memory/bank-health.test.ts
@@ -108,6 +108,31 @@ describe("inspectBankHealth", () => {
     expect(h.mentalModels.map((m) => m.id)).toEqual(["ok"]);
   });
 
+  it("counts active directives from the directives REST surface", async () => {
+    const fetchImpl = jsonFetch({
+      "/stats": { total_documents: 1, total_nodes: 1, pending_operations: 0 },
+      "/documents": { items: [] },
+      "/mental-models": { items: [] },
+      "/directives": { items: [{ id: "x1" }, { id: "x2" }, { id: "x3" }] },
+    });
+    const h = await inspectBankHealth(MCP_URL, "coach", { fetchImpl });
+    expect(h.ok).toBe(true);
+    expect(h.activeDirectiveCount).toBe(3);
+  });
+
+  it("leaves activeDirectiveCount null (not zero) when the directives fetch fails — without failing the bank", async () => {
+    // No /directives route → 404. The directives fetch is best-effort: the bank
+    // still inspects ok, but the count is unknown (null), not a misleading 0.
+    const fetchImpl = jsonFetch({
+      "/stats": { total_documents: 1, total_nodes: 1, pending_operations: 0 },
+      "/documents": { items: [] },
+      "/mental-models": { items: [] },
+    });
+    const h = await inspectBankHealth(MCP_URL, "coach", { fetchImpl });
+    expect(h.ok).toBe(true);
+    expect(h.activeDirectiveCount).toBeNull();
+  });
+
   it("returns ok:false with the failing stage's reason when a REST call errors", async () => {
     const fetchImpl = (async () => new Response("boom", { status: 500 })) as unknown as typeof fetch;
     const h = await inspectBankHealth(MCP_URL, "coach", { fetchImpl });

--- a/src/memory/bank-health.ts
+++ b/src/memory/bank-health.ts
@@ -108,6 +108,15 @@ export interface BankHealth {
   unextractedDocuments: BankDocumentSummary[];
   /** From /mental-models */
   mentalModels: BankMentalModelSummary[];
+  /**
+   * Count of ACTIVE directives on this bank (from `GET .../directives?active_only=true`
+   * — the same REST surface `lib/directives.py` fetches on the recall hook). `null`
+   * when the directives fetch failed / wasn't attempted (best-effort: a directive-
+   * fetch error must not fail the whole bank inspection). Used by the doctor to
+   * WARN/FAIL on runaway directive counts and to surface silent MAX_DIRECTIVES
+   * truncation of the recall block.
+   */
+  activeDirectiveCount: number | null;
 }
 
 /** Derive the REST base URL from the configured MCP URL (strip /mcp/ suffix). */
@@ -200,6 +209,7 @@ export async function inspectBankHealth(
     newestDocumentAt: null,
     unextractedDocuments: [],
     mentalModels: [],
+    activeDirectiveCount: null,
   };
 
   const stats = await getJson<{
@@ -236,6 +246,20 @@ export async function inspectBankHealth(
   }>(`${base}/v1/default/banks/${bank}/mental-models`, opts);
   if (!models.ok) return { ...empty, reason: models.reason };
 
+  // Active directives — best-effort, on the SAME REST surface `lib/directives.py`
+  // fetches on the recall hook (`?active_only=true`, `items[]`). A directive-fetch
+  // failure must NOT fail the whole bank inspection (the ingest-health signal is
+  // more important), so on error we leave the count `null` (= unknown) rather than
+  // returning `{ ok: false }`.
+  const directives = await getJson<{ items?: unknown[] }>(
+    `${base}/v1/default/banks/${bank}/directives?active_only=true`,
+    opts,
+  );
+  const activeDirectiveCount =
+    directives.ok && Array.isArray(directives.data.items)
+      ? directives.data.items.length
+      : null;
+
   const docItems = docs.data.items ?? [];
   let newestDocumentAt: string | null = null;
   const unextracted: BankDocumentSummary[] = [];
@@ -263,6 +287,7 @@ export async function inspectBankHealth(
     pendingOperations: stats.data.pending_operations ?? 0,
     newestDocumentAt,
     unextractedDocuments: unextracted,
+    activeDirectiveCount,
     mentalModels: (models.data.items ?? [])
       .filter((m): m is { id: string; name: string; last_refreshed_at?: string | null; created_at?: string | null; content?: string | null; source_query?: string | null; trigger?: { mode?: string | null } | null; reflect_response?: { based_on?: Record<string, unknown> | null } | null } =>
         typeof m?.id === "string" && typeof m?.name === "string",

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -147,6 +147,16 @@ describe("classifyDirectiveCount (workstream C2 — directive pile-up + truncati
     // 20 - 15 = 5 truncated.
     expect(r!.detail).toContain("5 lowest-priority directive");
   });
+
+  it("TS MAX_DIRECTIVES pins the Python constant in vendor/hindsight-memory (drift guard)", () => {
+    const py = readFileSync(
+      resolve(__dirname, "..", "vendor", "hindsight-memory", "scripts", "lib", "directives.py"),
+      "utf-8",
+    );
+    const m = py.match(/^MAX_DIRECTIVES\s*=\s*(\d+)\s*$/m);
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBe(MAX_DIRECTIVES);
+  });
 });
 
 describe("classifyShmSize", () => {

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -9,6 +9,9 @@ import {
   classifyHindsightHealthProbe,
   checkHindsightHealthEndpoint,
   classifyConsolidationBacklog,
+  classifyDirectiveCount,
+  MAX_DIRECTIVES,
+  DIRECTIVE_WARN_THRESHOLD,
   classifyAutohealStatus,
   classifyLlmVerification,
   classifyHindsightDataVolumeMounts,
@@ -99,6 +102,50 @@ describe("classifyConsolidationBacklog (#2903 fix 5.3)", () => {
   it("omits the age clause when age is unknown (REST /stats has no per-op age — #2847)", () => {
     const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_WARN, null);
     expect(r.detail).not.toMatch(/oldest/);
+  });
+});
+
+describe("classifyDirectiveCount (workstream C2 — directive pile-up + truncation surfacing)", () => {
+  it("no row when the directive fetch failed / count is unknown", () => {
+    expect(classifyDirectiveCount(null, "bank coach")).toBeNull();
+  });
+
+  it("no row at or below the warn threshold (avoids one ok line per bank)", () => {
+    expect(classifyDirectiveCount(0, "bank coach")).toBeNull();
+    expect(classifyDirectiveCount(DIRECTIVE_WARN_THRESHOLD, "bank coach")).toBeNull();
+  });
+
+  it("WARNs at 13 (one past the warn threshold, still under the cap)", () => {
+    const r = classifyDirectiveCount(DIRECTIVE_WARN_THRESHOLD + 1, "bank coach");
+    expect(r).not.toBeNull();
+    expect(r!.status).toBe("warn");
+    expect(r!.name).toBe("bank coach directives");
+    expect(r!.detail).toContain("13 active directives");
+    expect(r!.detail).toContain(`MAX_DIRECTIVES=${MAX_DIRECTIVES}`);
+  });
+
+  it("still WARNs (not FAILs) exactly at the cap of 15 — nothing is truncated yet", () => {
+    const r = classifyDirectiveCount(MAX_DIRECTIVES, "bank coach");
+    expect(r!.status).toBe("warn");
+  });
+
+  it("FAILs at 16 and surfaces the SILENT MAX_DIRECTIVES truncation", () => {
+    const r = classifyDirectiveCount(MAX_DIRECTIVES + 1, "bank coach");
+    expect(r).not.toBeNull();
+    expect(r!.status).toBe("fail");
+    expect(r!.detail).toContain("16 active directives");
+    expect(r!.detail).toMatch(/silently truncated/i);
+    expect(r!.detail).toContain(`MAX_DIRECTIVES=${MAX_DIRECTIVES}`);
+    // 16 - 15 = 1 directive dropped from the recall block.
+    expect(r!.detail).toContain("1 lowest-priority directive");
+    expect(r!.fix).toBeDefined();
+  });
+
+  it("reports the correct truncated count as the overflow grows", () => {
+    const r = classifyDirectiveCount(20, "bank coach");
+    expect(r!.status).toBe("fail");
+    // 20 - 15 = 5 truncated.
+    expect(r!.detail).toContain("5 lowest-priority directive");
   });
 });
 

--- a/tests/memory.bank-health.test.ts
+++ b/tests/memory.bank-health.test.ts
@@ -19,6 +19,7 @@ function fakeFetchFor(banks: Record<string, {
   stats?: unknown;
   documents?: unknown;
   models?: unknown;
+  directives?: unknown;
   failWith?: number;
 }>): typeof fetch {
   return (async (input: RequestInfo | URL) => {
@@ -34,7 +35,7 @@ function fakeFetchFor(banks: Record<string, {
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
     }
-    const m = url.match(/\/v1\/default\/banks\/([^/]+)\/(stats|documents|mental-models)/);
+    const m = url.match(/\/v1\/default\/banks\/([^/?]+)\/(stats|documents|mental-models|directives)/);
     if (!m) return new Response("not found", { status: 404 });
     const bank = decodeURIComponent(m[1]);
     const fixture = banks[bank];
@@ -43,6 +44,7 @@ function fakeFetchFor(banks: Record<string, {
     const body =
       m[2] === "stats" ? fixture.stats ?? {} :
       m[2] === "documents" ? fixture.documents ?? { items: [] } :
+      m[2] === "directives" ? fixture.directives ?? { items: [] } :
       fixture.models ?? { items: [] };
     return new Response(JSON.stringify(body), {
       status: 200,
@@ -386,6 +388,51 @@ describe("checkBankIngestHealth (doctor)", () => {
     expect(names).toContain("bank ken-profile (profile)");
     // the agent-less profile bank must NOT render the empty "()" label
     expect(names).not.toContain("bank ken-profile ()");
+  });
+
+  it("emits a FAIL directives row surfacing MAX_DIRECTIVES truncation (workstream C2), alongside the ingest row", async () => {
+    const OVER_CAP = {
+      ...HEALTHY_BANK,
+      directives: { items: Array.from({ length: 16 }, (_, i) => ({ id: `dir-${i}` })) },
+    };
+    const results = await checkBankIngestHealth(
+      minimalConfig({ marko: {} }),
+      "http://x/mcp/",
+      { fetchImpl: fakeFetchFor({ marko: OVER_CAP }), now: NOW },
+    );
+    const byName = Object.fromEntries(results.map((r) => [r.name, r]));
+    // Healthy ingest row still present…
+    expect(byName["bank marko"].status).toBe("ok");
+    // …plus a distinct FAIL directives row that names the silent truncation.
+    const dir = byName["bank marko directives"];
+    expect(dir.status).toBe("fail");
+    expect(dir.detail).toMatch(/silently truncated/i);
+    expect(dir.detail).toContain("16 active directives");
+  });
+
+  it("emits a WARN directives row at 13, and NO directives row at 12 or below", async () => {
+    const WARN_BANK = {
+      ...HEALTHY_BANK,
+      directives: { items: Array.from({ length: 13 }, (_, i) => ({ id: `dir-${i}` })) },
+    };
+    const OK_BANK = {
+      ...HEALTHY_BANK,
+      directives: { items: Array.from({ length: 12 }, (_, i) => ({ id: `dir-${i}` })) },
+    };
+    const warn = await checkBankIngestHealth(
+      minimalConfig({ marko: {} }),
+      "http://x/mcp/",
+      { fetchImpl: fakeFetchFor({ marko: WARN_BANK }), now: NOW },
+    );
+    expect(warn.find((r) => r.name === "bank marko directives")?.status).toBe("warn");
+
+    const ok = await checkBankIngestHealth(
+      minimalConfig({ marko: {} }),
+      "http://x/mcp/",
+      { fetchImpl: fakeFetchFor({ marko: OK_BANK }), now: NOW },
+    );
+    // At the threshold and below, no directives row is emitted at all.
+    expect(ok.some((r) => r.name === "bank marko directives")).toBe(false);
   });
 
   it("omits the fleet consolidation-backlog row unless opted in (#2903 fix 5.3)", async () => {


### PR DESCRIPTION
## What

PR 6 of the hindsight-leverage programme (workstream **C2**). Teaches `switchroom doctor` to catch runaway Hindsight **active-directive** counts before they silently degrade recall, and to surface the `MAX_DIRECTIVES=15` truncation so it is no longer invisible.

Epic: #3430 · Workstream C: #3433 · Depends on merged #3436 (A4 directives TTL cache).

## Why

The recall hook injects a bank's active directives into every turn as an `<active_directives>` block, but `lib/directives.py` hard-caps that block at `MAX_DIRECTIVES = 15` (`directives[:15]`). A bank that accrues more than 15 active directives has its **lowest-priority directives silently dropped** from every recall — no surface goes red, the operator never knows. Nothing warned before the cap either.

Programme exit criterion 4: *fleet doctor shows no agent > 15 active directives (or FAILs loudly)*.

## Change

Reuses the **same REST surface** `lib/directives.py` fetches on the recall hook (`GET /v1/default/banks/<bank>/directives?active_only=true`) rather than adding a new fetch path.

- **`src/memory/bank-health.ts`** — `inspectBankHealth` now also counts active directives into `BankHealth.activeDirectiveCount`. Best-effort: a directive-fetch failure leaves the count `null` (unknown, not a misleading `0`) and never fails the whole bank inspection.
- **`src/cli/doctor-memory.ts`** — `MAX_DIRECTIVES = 15` (mirrors the Python constant, with a comment tying the two), `DIRECTIVE_WARN_THRESHOLD = 12`, and a pure `classifyDirectiveCount()`:
  - `null` / `≤12` → no row (keeps the issues card focused).
  - `13–15` → **warn** (approaching the truncating cap).
  - `16+` → **fail**, naming the exact number of lowest-priority directives silently truncated from the recall block.
- **`src/cli/doctor.ts`** — emits the directives row per bank in `checkBankIngestHealth`, independent of the ingest-branch chain (so a directive pile-up surfaces even on a bank that also has an ingest issue).

## Tests (assert outcomes)

- `classifyDirectiveCount`: WARN at 13, still WARN (nothing truncated) at exactly 15, FAIL at 16 with the truncation surfaced, correct overflow count as it grows, no row at ≤12 / `null`.
- `inspectBankHealth`: counts directives from the REST surface; leaves `null` (not `0`) on fetch failure without failing the bank.
- `checkBankIngestHealth` (doctor integration): FAIL directives row at 16 alongside the healthy ingest row; WARN at 13; no row at 12.
- Scoped: `vitest run tests/memory.bank-health.test.ts src/memory/bank-health.test.ts tests/cli.doctor.memory-health.test.ts` → 97 passed. `npm run lint` clean.

## C2 acceptance mapping

| C2 requirement | Where |
|---|---|
| WARN when >12 active directives | `classifyDirectiveCount` warn branch (13–15) |
| FAIL when >15 active directives | `classifyDirectiveCount` fail branch (16+) |
| surface `MAX_DIRECTIVES=15` truncation to the issues card | FAIL detail names the silently-truncated lowest-priority directives |

Not merging — leaving for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)