### PR TITLE
recall: parallel multi-bank recall under one shared deadline (A3, #3431)

### DIFF
--- a/vendor/hindsight-memory/CHANGELOG.md
+++ b/vendor/hindsight-memory/CHANGELOG.md
@@ -23,6 +23,29 @@
 
 ### Added (switchroom divergence)
 
+- **recall.py: parallel multi-bank recall under one shared deadline**
+  (switchroom hindsight-leverage PR3, workstream A3 stage 2). The directives
+  fetch and every bank recall (own + additional/profile/shared/sender banks)
+  now run CONCURRENTLY in daemon threads via `lib/parallel_recall.py`
+  (`run_parallel`), bounded by ONE shared deadline
+  (`recallParallelDeadlineSeconds`, default 10 = the 12s UserPromptSubmit hook
+  ceiling minus 2s headroom). Serially the round-trips SUM, so a heavy
+  multi-bank agent could breach the ceiling and drop recall entirely; parallel
+  makes the critical path the SLOWEST slot. A slot still running at the deadline
+  is abandoned (daemon thread, reaped on process exit) and marked `timed_out` —
+  a straggler bank can never hold the hook open past its ceiling; `recall.py`'s
+  `__main__` additionally `os._exit(0)`s (after a stdout flush) as a
+  belt-and-suspenders. The directives slot is dedicated and composes with the A4
+  directives cache (a cache HIT returns near-instantly with no HTTP). Env-gated
+  rollback: `HINDSIGHT_RECALL_PARALLEL=false` restores the pre-A3 serial path.
+  The `deadline_hit` telemetry field (shipped interim in PR1) is FINALIZED:
+  True when any bank raised a hard per-request timeout OR any bank/directives
+  slot was abandoned at the shared deadline; serial mode reduces to the pre-A3
+  per-bank-only form so both modes' `recall_log.jsonl` rows stay comparable in
+  the breach baseline. New log fields: `recall_mode`, `deadline_budget_ms`,
+  `directives_timed_out`. Acceptance: `scripts/tests/test_recall_parallel_deadline.py`
+  (stub-timing tests proving a 3s bank cannot breach a 0.6s deadline).
+
 - **SubagentStop sidechain retain** (switchroom hindsight-leverage PR5). New
   `scripts/subagent_retain.py`, registered on the `SubagentStop` event in
   `hooks/hooks.json` (async, 15s). Delegated (Task-tool / sub-agent) work was

--- a/vendor/hindsight-memory/CHANGELOG.md
+++ b/vendor/hindsight-memory/CHANGELOG.md
@@ -42,7 +42,9 @@
   True when any bank raised a hard per-request timeout OR any bank/directives
   slot was abandoned at the shared deadline; serial mode reduces to the pre-A3
   per-bank-only form so both modes' `recall_log.jsonl` rows stay comparable in
-  the breach baseline. New log fields: `recall_mode`, `deadline_budget_ms`,
+  the breach baseline. New log fields: `recall_mode`, `deadline_budget_ms`
+  (the CONFIGURED budget), `deadline_effective_ms` (the smaller wait the slots
+  actually got after pre-fan-out spend; null in serial mode / on cache hits),
   `directives_timed_out`. Acceptance: `scripts/tests/test_recall_parallel_deadline.py`
   (stub-timing tests proving a 3s bank cannot breach a 0.6s deadline).
 

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -135,6 +135,20 @@ DEFAULTS = {
     # HINDSIGHT_RECONCILE_{LOOKBACK_H,MAX_TURNS,BUDGET_S} bounds (read directly).
     "reconcileOnStart": True,
     "recallAdditionalBanks": [],
+    # Switchroom hindsight-leverage A3 — parallelise multi-bank recall.
+    # When on (default), the directives fetch and every bank recall run
+    # concurrently in daemon threads under ONE shared deadline
+    # (recallParallelDeadlineSeconds), so total critical-path latency is the
+    # SLOWEST slot instead of their SUM. Set false
+    # (HINDSIGHT_RECALL_PARALLEL=false) to restore the pre-A3 serial path —
+    # the rollback lever if the parallel path ever misbehaves.
+    "recallParallel": True,
+    # Shared deadline (seconds) for the whole parallel recall section. Sized
+    # at the UserPromptSubmit hook ceiling (12s, hooks.json) MINUS 2s headroom
+    # for block formatting + cache write + stdout flush, so a straggler bank
+    # can never push the hook past its ceiling. Slots still unfinished when the
+    # deadline elapses are abandoned (daemon threads) and marked timed_out.
+    "recallParallelDeadlineSeconds": 10,
     # Connection
     "hindsightApiUrl": None,
     "hindsightApiToken": None,
@@ -207,6 +221,11 @@ ENV_OVERRIDES = {
     # Switchroom hindsight-leverage A4 — directives-list cache TTL (seconds).
     # 0 disables the cache (rollback lever).
     "HINDSIGHT_DIRECTIVES_CACHE_TTL_SECONDS": ("directivesCacheTtlSeconds", int),
+    # Switchroom hindsight-leverage A3 — parallel multi-bank recall toggle +
+    # shared deadline. HINDSIGHT_RECALL_PARALLEL=false is the serial rollback
+    # lever; the deadline is the ceiling-minus-2s hard budget (see DEFAULTS).
+    "HINDSIGHT_RECALL_PARALLEL": ("recallParallel", bool),
+    "HINDSIGHT_RECALL_PARALLEL_DEADLINE_SECONDS": ("recallParallelDeadlineSeconds", int),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     # Switchroom hindsight-leverage A2 — byte-tail bound for the multi-turn

--- a/vendor/hindsight-memory/scripts/lib/parallel_recall.py
+++ b/vendor/hindsight-memory/scripts/lib/parallel_recall.py
@@ -1,0 +1,138 @@
+"""Deadline-bounded parallel fan-out for the recall critical path.
+
+Switchroom hindsight-leverage A3 (parallel multi-bank recall). The recall
+hook (``recall.py``) queries the agent's own bank, every additional bank
+(profile / shared / sender), and the active-directives list. Serially, the
+critical-path latency is the SUM of those round-trips — a heavy agent with two
+extra banks plus directives can serialise four 2-8s calls and breach the 12s
+UserPromptSubmit hook ceiling, which drops recall entirely for that turn.
+
+This runs each labelled task in its OWN daemon thread and waits only until a
+single SHARED deadline (the hook ceiling minus a headroom margin). Key
+properties, all enforced by mechanism rather than convention:
+
+  * **Daemon threads.** Every worker is a daemon, so a thread still blocked on
+    a socket read when the deadline elapses can NEVER keep the interpreter (and
+    therefore the hook) alive past the ceiling — the process exits and the
+    kernel reaps the socket. ``recall.py``'s ``__main__`` additionally calls
+    ``os._exit(0)`` after flushing stdout as a belt-and-suspenders against any
+    non-daemon thread a client library might spawn.
+
+  * **One shared deadline.** Total wait is bounded by ``deadline_seconds`` from
+    the moment ``run_parallel`` is entered — not per-task — so N slow banks
+    cost the deadline ONCE, not N times.
+
+  * **Completion is observed, not assumed.** Each slot records whether its
+    thread finished before we stopped waiting (``completed``), its return value
+    or exception, and its wall-clock ``elapsed_ms``. A slot still running at the
+    deadline is ``completed=False`` with ``elapsed_ms`` pinned to the deadline —
+    the caller maps that to ``timed_out`` for telemetry.
+
+Stdlib-only (threading + time); no third-party deps, importable under the
+plugin's ``python3 -m unittest`` harness.
+"""
+
+import threading
+import time
+
+
+class SlotResult:
+    """Outcome of one labelled task run under the shared deadline.
+
+    Attributes:
+        label:      the task's key in the ``tasks`` mapping.
+        value:      the callable's return value, or None if it raised / did not
+                    finish before the deadline.
+        error:      the exception the callable raised, or None. A slot that hit
+                    the deadline mid-flight has ``error=None`` and
+                    ``completed=False`` (it never got to raise or return).
+        completed:  True iff the worker thread finished (returned or raised)
+                    before ``run_parallel`` stopped waiting on it. False means
+                    the shared deadline elapsed first.
+        elapsed_ms: wall-clock ms the slot took. For a completed slot this is
+                    its real duration; for a deadline-abandoned slot it is the
+                    time from fan-out start to the deadline.
+    """
+
+    __slots__ = ("label", "value", "error", "completed", "elapsed_ms")
+
+    def __init__(self, label):
+        self.label = label
+        self.value = None
+        self.error = None
+        self.completed = False
+        self.elapsed_ms = None
+
+
+def _runner(slot, fn, start):
+    """Worker body: run the task, capturing value/exception and duration.
+
+    Catches ``BaseException`` deliberately — a recall client can raise
+    ``socket.timeout`` (a ``BaseException`` subclass only in some stdlib
+    versions, but ``OSError`` in others) and we must never let a worker thread
+    die with an unhandled exception that the deadline join would then miss.
+    """
+    try:
+        slot.value = fn()
+    except BaseException as e:  # noqa: BLE001 - deliberate: isolate the slot
+        slot.error = e
+    finally:
+        slot.elapsed_ms = int((time.monotonic() - start) * 1000)
+
+
+def run_parallel(tasks, deadline_seconds):
+    """Run ``{label: callable}`` concurrently under one shared deadline.
+
+    Args:
+        tasks: mapping of label -> zero-arg callable. Each is invoked once in
+            its own daemon thread. Insertion order is preserved in the returned
+            mapping (Python dicts are ordered) so the caller can emit per-slot
+            telemetry deterministically regardless of completion order.
+        deadline_seconds: total wall-clock budget for ALL tasks combined,
+            measured from entry. Non-positive values run every task with a
+            zero join (each slot is recorded as not-completed unless it was
+            already instantaneous) — a degenerate "give up immediately" mode.
+
+    Returns:
+        ``dict[label] -> SlotResult`` in the same order as ``tasks``. Never
+        raises for a task failure — a raising task surfaces via
+        ``SlotResult.error``.
+    """
+    start = time.monotonic()
+    pairs = []  # (SlotResult, Thread) in task order
+    for label, fn in tasks.items():
+        slot = SlotResult(label)
+        thread = threading.Thread(
+            target=_runner,
+            args=(slot, fn, start),
+            daemon=True,
+            name=f"recall-slot-{label}",
+        )
+        pairs.append((slot, thread))
+
+    for _slot, thread in pairs:
+        thread.start()
+
+    # Join each thread, but never wait past the SHARED deadline. Because the
+    # remaining budget is recomputed from ``start`` on every iteration, the
+    # total time spent here is bounded by ``deadline_seconds`` even with many
+    # slow slots — a fast early slot leaves more budget for later ones, and
+    # once the budget is exhausted every subsequent join is a non-blocking
+    # ``is_alive`` check.
+    for _slot, thread in pairs:
+        remaining = deadline_seconds - (time.monotonic() - start)
+        if remaining > 0:
+            thread.join(remaining)
+
+    # Classify each slot as completed (thread finished) or deadline-abandoned.
+    now = time.monotonic()
+    results = {}
+    for slot, thread in pairs:
+        if thread.is_alive():
+            slot.completed = False
+            if slot.elapsed_ms is None:
+                slot.elapsed_ms = int((now - start) * 1000)
+        else:
+            slot.completed = True
+        results[slot.label] = slot
+    return results

--- a/vendor/hindsight-memory/scripts/lib/parallel_recall.py
+++ b/vendor/hindsight-memory/scripts/lib/parallel_recall.py
@@ -67,10 +67,14 @@ class SlotResult:
 def _runner(slot, fn, start):
     """Worker body: run the task, capturing value/exception and duration.
 
-    Catches ``BaseException`` deliberately — a recall client can raise
-    ``socket.timeout`` (a ``BaseException`` subclass only in some stdlib
-    versions, but ``OSError`` in others) and we must never let a worker thread
-    die with an unhandled exception that the deadline join would then miss.
+    Catches ``BaseException`` deliberately for slot isolation: a slot runs in
+    its own daemon thread, and a task failure of ANY kind — including
+    non-``Exception`` subclasses like ``KeyboardInterrupt`` /
+    ``SystemExit`` — must be captured into ``slot.error`` rather than escaping
+    the thread. An escaped exception would let the slot die silently and the
+    deadline join would then see no value AND no recorded error. (``socket.timeout``
+    is itself just an ``OSError`` subclass, i.e. an ordinary ``Exception``; the
+    broad catch is about never letting any slot failure leak out of the thread.)
     """
     try:
         slot.value = fn()

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -67,10 +67,16 @@ from lib.directives import (
     format_active_directives_block,
 )
 from lib.gateway_ipc import extract_chat_id_from_prompt, extract_topic_from_prompt, extract_user_from_prompt, update_placeholder
+from lib.parallel_recall import run_parallel
 from lib.state import read_state, write_state
 
 LAST_RECALL_STATE = "last_recall.json"
 RECALL_CACHE_STATE = "recall_cache.json"
+
+# Switchroom hindsight-leverage A3 — label for the directives fetch slot in the
+# parallel fan-out. Distinct from any bank_id (banks can't start with "__") so a
+# bank named "directives" never collides with the directives slot.
+DIRECTIVES_SLOT = "__directives__"
 
 # Switchroom #424 phase 4.1 — per-session recall cache.
 #
@@ -1126,6 +1132,11 @@ def main():
                 "directives_elapsed_ms": None,
                 "bank_timings": [],
                 "deadline_hit": None,
+                # A3 — no banks ran on a cache hit, so mode/deadline are null
+                # for a uniformly queryable schema (never "serial"/"parallel").
+                "recall_mode": None,
+                "deadline_budget_ms": None,
+                "directives_timed_out": None,
                 # PR6 — record the active topic on cache hits too so the
                 # log is uniformly queryable (cache_key now includes
                 # active_thread_id, so a hit means the prior recall was
@@ -1190,82 +1201,68 @@ def main():
     # is a pure client-side surface. fetch_active_directives_cached is
     # failure-safe and returns [] on any error.
     #
-    # A4: cache the list with a short TTL (invalidated in-session by
+    # A4: cache the directives list with a short TTL (invalidated in-session by
     # directive_verify.py on a directive write) so the common no-write turn
     # skips the HTTP round-trip. TTL=0 disables the cache (live every turn).
-    # The A3 timing wrapper below measures the fetch either way — on a cache
-    # HIT directives_elapsed_ms reads ~0 (that is the A4 latency win, not a
-    # telemetry regression).
-    _directives_start = time.monotonic()
-    directives = fetch_active_directives_cached(
-        client,
-        bank_id,
-        ttl_seconds=config.get("directivesCacheTtlSeconds", DIRECTIVES_CACHE_TTL_SECONDS),
-    )
-    directives_elapsed_ms = int((time.monotonic() - _directives_start) * 1000)
-    directives_block = format_active_directives_block(directives) if directives else None
-    if directives_block:
-        debug_log(config, f"Injecting {len(directives)} active directives")
-
-    # Call Hindsight recall API
     #
-    # Switchroom A3 stage-1 telemetry — per-bank timing + timeout flag.
-    # `bank_timings` accumulates one record per bank queried (own bank first,
-    # then each additional bank) so the log carries a per-bank latency and
-    # deadline-hit breakdown ahead of the A3 parallelism change.
-    bank_timings = []
-    results = []
-    _own_bank_start = time.monotonic()
-    _own_bank_timed_out = False
-    try:
-        response = client.recall(
-            bank_id=bank_id,
-            query=query,
-            max_tokens=config.get("recallMaxTokens", 1024),
-            budget=config.get("recallBudget", "mid"),
-            types=config.get("recallTypes"),
-            # Upstream 962140eef — optional tag filters (resolved above the
-            # cache check; part of the cache key).
-            tags=recall_tags,
-            tags_match=tags_match,
-            tag_groups=tag_groups,
-            # Switchroom Phase-1 precision — prefer deduped observation
-            # statements over the raw facts they supersede, backfilling freed
-            # slots for denser coverage inside the same budget. On by default;
-            # operators can pin off via `recallPreferObservations: false`.
-            prefer_observations=config.get("recallPreferObservations", True),
-            # 8s in-script timeout leaves 4s headroom inside the 12s
-            # UserPromptSubmit hook ceiling (see hooks.json:20) for cache
-            # write + block formatting. Tightened from 10s in switchroom
-            # v0.13.22: the 2026-05-24 audit showed 17-26% of turns
-            # breaching the 12s hook timeout on heavy agents (finn /
-            # gymbro / klanker), which dropped the recall entirely; an
-            # earlier-hard-timeout failure returns cleanly with no
-            # memories instead of blowing past the hook ceiling.
-            timeout=8,
-        )
-        results = response.get("results", [])
-    except Exception as e:
-        _own_bank_timed_out = _is_timeout_error(e)
-        print(f"[Hindsight] Recall failed: {e}", file=sys.stderr)
-        # Fall through — we still want to emit the directives block if we
-        # have one, so a recall API failure doesn't blind the agent to
-        # its own active directives.
-    bank_timings.append({
-        "bank_id": bank_id,
-        "elapsed_ms": int((time.monotonic() - _own_bank_start) * 1000),
-        "timed_out": _own_bank_timed_out,
-    })
+    # Switchroom hindsight-leverage A3 — the directives fetch and every bank
+    # recall run CONCURRENTLY (daemon threads) under ONE shared deadline instead
+    # of serially. Serially their latencies SUM (own bank + N extra banks +
+    # directives), and a heavy multi-bank agent can breach the 12s
+    # UserPromptSubmit ceiling — dropping recall for the turn. Parallel makes the
+    # critical path the SLOWEST slot, bounded by `recallParallelDeadlineSeconds`
+    # (the hook ceiling minus 2s headroom). A slot still running at the deadline
+    # is abandoned (daemon thread, reaped on process exit) and marked timed_out —
+    # a straggler bank can never push the hook past its ceiling.
+    # HINDSIGHT_RECALL_PARALLEL=false restores the serial path (rollback lever).
+    # The directives slot composes with the A4 cache: on a cache HIT it returns
+    # near-instantly with no HTTP, so directives_elapsed_ms reads ~0.
 
-    # Also recall from any additional banks (e.g. shared user profile bank).
-    # `additional_banks` was already extracted above the cache check so the
-    # cache key reflects every bank queried; reuse that local instead of
-    # re-reading config.
+    def _directives_task():
+        return fetch_active_directives_cached(
+            client,
+            bank_id,
+            ttl_seconds=config.get("directivesCacheTtlSeconds", DIRECTIVES_CACHE_TTL_SECONDS),
+        )
+
+    def _make_bank_task(target_bank_id, b_tags, b_tags_match, b_tag_groups):
+        def _bank_task():
+            return client.recall(
+                bank_id=target_bank_id,
+                query=query,
+                max_tokens=config.get("recallMaxTokens", 1024),
+                budget=config.get("recallBudget", "mid"),
+                types=config.get("recallTypes"),
+                # Upstream 962140eef — optional per-bank tag filters (resolved
+                # above the cache check; part of the cache key).
+                tags=b_tags,
+                tags_match=b_tags_match,
+                tag_groups=b_tag_groups,
+                # Switchroom Phase-1 precision — prefer deduped observation
+                # statements over the raw facts they supersede, backfilling freed
+                # slots for denser coverage inside the same budget. On by default;
+                # operators can pin off via `recallPreferObservations: false`.
+                prefer_observations=config.get("recallPreferObservations", True),
+                # 8s in-script per-request timeout: even parallelised, each bank
+                # carries its own hard deadline so a single hung bank returns
+                # cleanly with no memories rather than sitting on the shared
+                # deadline. Tightened from 10s in v0.13.22 (2026-05-24 breach
+                # audit); the shared deadline below is the outer ceiling guard.
+                timeout=8,
+            )
+        return _bank_task
+
+    # Resolve (bank_id, tags, tags_match, tag_groups) for every bank we query —
+    # own bank first, then each additional bank in config order. This order is
+    # preserved for bank_timings and the result-merge sequence regardless of
+    # thread completion order, so the emitted telemetry is deterministic.
+    # `additional_banks` was extracted above the cache check (so the cache key
+    # reflects every bank queried); reuse that local.
+    bank_specs = [(bank_id, recall_tags, tags_match, tag_groups)]
     for extra_bank_id in additional_banks:
-        # Upstream 962140eef — per-bank tag-filter overrides; fall back to
-        # the global filters when the bank has no entry. Applies uniformly
-        # to config-listed banks and sender banks appended by
-        # _resolve_sender_bank (both flow through `additional_banks`).
+        # Upstream 962140eef — per-bank tag-filter overrides; fall back to the
+        # global filters when the bank has no entry. Applies uniformly to
+        # config-listed banks and sender banks appended by _resolve_sender_bank.
         extra_filter = additional_bank_filters.get(extra_bank_id, {})
         if not isinstance(extra_filter, dict):
             extra_filter = {}
@@ -1275,44 +1272,118 @@ def main():
             "recallTagsMatch",
             tags_match if extra_tags or extra_tag_groups else None,
         )
-        _extra_start = time.monotonic()
-        _extra_timed_out = False
-        try:
-            extra_response = client.recall(
-                bank_id=extra_bank_id,
-                query=query,
-                max_tokens=config.get("recallMaxTokens", 1024),
-                budget=config.get("recallBudget", "mid"),
-                types=config.get("recallTypes"),
-                tags=extra_tags,
-                tags_match=extra_tags_match,
-                tag_groups=extra_tag_groups,
-                # Switchroom Phase-1 precision — prefer deduped observation
-                # statements here too so additional banks contribute their
-                # densest statements to the merged, score-sorted set.
-                prefer_observations=config.get("recallPreferObservations", True),
-                # 8s in-script timeout leaves 4s headroom inside the 12s
-                # UserPromptSubmit hook ceiling (see hooks.json:20) for cache
-                # write + block formatting. Tightened from 10s in switchroom
-                # v0.13.22: the 2026-05-24 audit showed 17-26% of turns
-                # breaching the 12s hook timeout on heavy agents (finn /
-                # gymbro / klanker), which dropped the recall entirely; an
-                # earlier-hard-timeout failure returns cleanly with no
-                # memories instead of blowing past the hook ceiling.
-                timeout=8,
+        bank_specs.append((extra_bank_id, extra_tags, extra_tags_match, extra_tag_groups))
+
+    recall_parallel = bool(config.get("recallParallel", True))
+    try:
+        deadline_seconds = float(config.get("recallParallelDeadlineSeconds", 10))
+    except (TypeError, ValueError):
+        deadline_seconds = 10.0
+
+    directives = []
+    directives_timed_out = False
+    bank_timings = []
+    results = []
+
+    if recall_parallel:
+        recall_mode = "parallel"
+        deadline_budget_ms = int(deadline_seconds * 1000)
+        # The shared deadline is measured from recall_start_monotonic (the top
+        # of the critical path), so mission-ensure + transcript read already
+        # spent budget: subtract what elapsed so the remaining wait still
+        # respects the ceiling-minus-2s guarantee.
+        already_spent = time.monotonic() - recall_start_monotonic
+        remaining_deadline = max(0.0, deadline_seconds - already_spent)
+
+        tasks = {DIRECTIVES_SLOT: _directives_task}
+        for spec in bank_specs:
+            tasks[spec[0]] = _make_bank_task(spec[0], spec[1], spec[2], spec[3])
+        outcomes = run_parallel(tasks, remaining_deadline)
+
+        # Directives slot. A slot that hit the deadline OR raised yields [] —
+        # the same failure-safe contract fetch_active_directives_cached honours.
+        d_outcome = outcomes[DIRECTIVES_SLOT]
+        directives_elapsed_ms = d_outcome.elapsed_ms if d_outcome.elapsed_ms is not None else 0
+        directives_timed_out = not d_outcome.completed
+        if d_outcome.completed and isinstance(d_outcome.value, list):
+            directives = d_outcome.value
+        elif directives_timed_out:
+            debug_log(config, "Directives slot hit the shared recall deadline")
+        elif d_outcome.error is not None:
+            debug_log(config, f"Directives fetch failed: {d_outcome.error}")
+
+        # Bank slots, own-bank first in config order. A bank is timed_out if it
+        # did not complete before the shared deadline OR completed by raising a
+        # hard timeout error (the finalized `deadline_hit` semantics — an
+        # abandoned straggler now counts, which the serial-era per-request-only
+        # flag could not express).
+        for spec in bank_specs:
+            b_id = spec[0]
+            b_outcome = outcomes[b_id]
+            b_timed_out = (not b_outcome.completed) or (
+                b_outcome.error is not None and _is_timeout_error(b_outcome.error)
             )
-            extra_results = extra_response.get("results", [])
-            if extra_results:
-                debug_log(config, f"Got {len(extra_results)} memories from additional bank '{extra_bank_id}'")
-                results = results + extra_results
-        except Exception as e:
-            _extra_timed_out = _is_timeout_error(e)
-            debug_log(config, f"Recall from additional bank '{extra_bank_id}' failed: {e}")
-        bank_timings.append({
-            "bank_id": extra_bank_id,
-            "elapsed_ms": int((time.monotonic() - _extra_start) * 1000),
-            "timed_out": _extra_timed_out,
-        })
+            if b_outcome.completed and b_outcome.error is None:
+                bank_results = (
+                    b_outcome.value.get("results", [])
+                    if isinstance(b_outcome.value, dict)
+                    else []
+                )
+                if bank_results:
+                    debug_log(config, f"Got {len(bank_results)} memories from bank '{b_id}'")
+                    results = results + bank_results
+            elif b_outcome.error is not None:
+                # Own bank failure surfaces on stderr (journald signal); extra
+                # banks are debug-only, matching the pre-A3 serial behaviour.
+                if b_id == bank_id:
+                    print(f"[Hindsight] Recall failed: {b_outcome.error}", file=sys.stderr)
+                else:
+                    debug_log(config, f"Recall from additional bank '{b_id}' failed: {b_outcome.error}")
+            elif not b_outcome.completed:
+                debug_log(config, f"Recall from bank '{b_id}' hit the shared deadline")
+            bank_timings.append({
+                "bank_id": b_id,
+                "elapsed_ms": b_outcome.elapsed_ms if b_outcome.elapsed_ms is not None else 0,
+                "timed_out": b_timed_out,
+            })
+    else:
+        # Pre-A3 serial path (rollback lever, HINDSIGHT_RECALL_PARALLEL=false).
+        # Directives first, then each bank in turn — total latency is the SUM of
+        # the round-trips, byte-for-byte the pre-parallelism behaviour.
+        recall_mode = "serial"
+        deadline_budget_ms = None
+        _directives_start = time.monotonic()
+        directives = fetch_active_directives_cached(
+            client,
+            bank_id,
+            ttl_seconds=config.get("directivesCacheTtlSeconds", DIRECTIVES_CACHE_TTL_SECONDS),
+        )
+        directives_elapsed_ms = int((time.monotonic() - _directives_start) * 1000)
+        for spec in bank_specs:
+            b_id, b_tags, b_tags_match, b_tag_groups = spec
+            _bank_start = time.monotonic()
+            _bank_timed_out = False
+            try:
+                response = _make_bank_task(b_id, b_tags, b_tags_match, b_tag_groups)()
+                bank_results = response.get("results", []) if isinstance(response, dict) else []
+                if bank_results:
+                    debug_log(config, f"Got {len(bank_results)} memories from bank '{b_id}'")
+                    results = results + bank_results
+            except Exception as e:
+                _bank_timed_out = _is_timeout_error(e)
+                if b_id == bank_id:
+                    print(f"[Hindsight] Recall failed: {e}", file=sys.stderr)
+                else:
+                    debug_log(config, f"Recall from additional bank '{b_id}' failed: {e}")
+            bank_timings.append({
+                "bank_id": b_id,
+                "elapsed_ms": int((time.monotonic() - _bank_start) * 1000),
+                "timed_out": _bank_timed_out,
+            })
+
+    directives_block = format_active_directives_block(directives) if directives else None
+    if directives_block:
+        debug_log(config, f"Injecting {len(directives)} active directives")
 
     # Switchroom #432 phase 4.4 — drop demote-tagged memories before
     # the cap. Filtering early means the cap kicks in over the
@@ -1505,7 +1576,22 @@ def main():
         "total_elapsed_ms": int((time.monotonic() - recall_start_monotonic) * 1000),
         "directives_elapsed_ms": directives_elapsed_ms,
         "bank_timings": bank_timings,
-        "deadline_hit": any(bt["timed_out"] for bt in bank_timings),
+        # Switchroom hindsight-leverage A3 — FINALIZED `deadline_hit` semantics
+        # (PR 1 shipped the interim per-bank-only form pending this PR). It is
+        # now True when ANY slot on the critical path hit its deadline: a bank
+        # that raised a hard per-request timeout OR (parallel mode) a bank/
+        # directives slot abandoned when the shared deadline elapsed. In serial
+        # (rollback) mode `directives_timed_out` is always False and each bank's
+        # `timed_out` is per-request only, so this reduces to the pre-A3 form —
+        # keeping the two modes' rows directly comparable in the breach baseline.
+        "deadline_hit": any(bt["timed_out"] for bt in bank_timings) or directives_timed_out,
+        # A3 — recall execution mode ("parallel"/"serial") and the shared
+        # deadline budget (ms; None in serial mode). These distinguish pre-A3
+        # (serial) from post-A3 (parallel) rows so the ≥3-day breach baseline
+        # can segment by mode without guessing from timing.
+        "recall_mode": recall_mode,
+        "deadline_budget_ms": deadline_budget_ms,
+        "directives_timed_out": directives_timed_out,
         # PR6 — instrumentation for binding-failure analysis.
         # `active_thread_id`: the current prompt's topic (null on
         # DM / fleet-shared). `source_topics`: distribution of
@@ -1661,6 +1747,21 @@ def _record_issue_safely(detail: str, class_name: str) -> None:
 if __name__ == "__main__":
     try:
         main()
+        # Switchroom hindsight-leverage A3 — hard, immediate process exit.
+        #
+        # The parallel recall path spawns daemon threads. Daemon threads already
+        # do not block a normal interpreter shutdown, but two things still can:
+        # (a) a non-daemon thread a client library might spawn, and (b) atexit /
+        # interpreter-shutdown thread-join bookkeeping. A straggler bank still
+        # blocked on an 8s socket read must NEVER hold the UserPromptSubmit hook
+        # open past its 12s ceiling. os._exit skips all of that and returns
+        # control to Claude Code immediately — but it also skips stdout buffer
+        # flushing, so flush FIRST or the hookSpecificOutput JSON is lost.
+        try:
+            sys.stdout.flush()
+        except Exception:
+            pass
+        os._exit(0)
     except Exception as e:
         # Switchroom #1070 (redo per #1085 review).
         #

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -1136,6 +1136,7 @@ def main():
                 # for a uniformly queryable schema (never "serial"/"parallel").
                 "recall_mode": None,
                 "deadline_budget_ms": None,
+                "deadline_effective_ms": None,
                 "directives_timed_out": None,
                 # PR6 — record the active topic on cache hits too so the
                 # log is uniformly queryable (cache_key now includes
@@ -1294,6 +1295,10 @@ def main():
         # respects the ceiling-minus-2s guarantee.
         already_spent = time.monotonic() - recall_start_monotonic
         remaining_deadline = max(0.0, deadline_seconds - already_spent)
+        # `deadline_budget_ms` is the CONFIGURED budget; the wait the slots
+        # actually get is `remaining_deadline` after pre-fan-out spend. Log both
+        # so the breach baseline can tell "configured" from "effectively granted".
+        deadline_effective_ms = int(remaining_deadline * 1000)
 
         tasks = {DIRECTIVES_SLOT: _directives_task}
         for spec in bank_specs:
@@ -1349,9 +1354,13 @@ def main():
     else:
         # Pre-A3 serial path (rollback lever, HINDSIGHT_RECALL_PARALLEL=false).
         # Directives first, then each bank in turn — total latency is the SUM of
-        # the round-trips, byte-for-byte the pre-parallelism behaviour.
+        # the round-trips. Behaviourally equivalent to the pre-parallelism path
+        # (log rows stay comparable), NOT byte-for-byte: this path emits an extra
+        # own-bank debug line, logs the directives block after the bank loop
+        # rather than before, and __main__ still os._exit(0)s on completion.
         recall_mode = "serial"
         deadline_budget_ms = None
+        deadline_effective_ms = None
         _directives_start = time.monotonic()
         directives = fetch_active_directives_cached(
             client,
@@ -1591,6 +1600,11 @@ def main():
         # can segment by mode without guessing from timing.
         "recall_mode": recall_mode,
         "deadline_budget_ms": deadline_budget_ms,
+        # A3 — effective deadline actually granted to the slots after pre-fan-out
+        # spend (mission-ensure + transcript read). `deadline_budget_ms` is the
+        # configured ceiling; this is the smaller wait the slots really got.
+        # None in serial mode and on cache hits (no fan-out).
+        "deadline_effective_ms": deadline_effective_ms,
         "directives_timed_out": directives_timed_out,
         # PR6 — instrumentation for binding-failure analysis.
         # `active_thread_id`: the current prompt's topic (null on

--- a/vendor/hindsight-memory/scripts/tests/test_recall_parallel_deadline.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_parallel_deadline.py
@@ -1,0 +1,403 @@
+"""Switchroom hindsight-leverage PR 3 (workstream A3 stage 2) — parallel
+multi-bank recall under one shared deadline.
+
+Acceptance guarantees (epic #3430 exit-criterion 1 fallback: stub-timing
+acceptance tests that prove a slow bank cannot breach the hook ceiling):
+
+  1. **A slow bank cannot breach the ceiling.** With a bank stubbed to sleep far
+     past the shared deadline, `recall.main()` returns in ~deadline (NOT
+     ~sleep), the fast banks' memories still arrive, and the straggler is
+     recorded `timed_out=True` / `deadline_hit=True` — the finalized deadline
+     semantics (a deadline-abandoned straggler counts, even though it never
+     raised a timeout error, which the PR-1 interim per-bank-only form could
+     not express).
+
+  2. **Latency is the slowest slot, not the sum.** Three banks each sleeping S
+     complete in ~S wall-clock, not ~3S — the whole point of the fan-out.
+
+  3. **The directives slot is dedicated + composes with the A4 cache.** A slow
+     directives fetch is abandoned at the deadline (empty directives, no crash)
+     while bank memories still inject; a fast directives fetch runs concurrently
+     with the banks.
+
+  4. **Env-gated rollback.** `HINDSIGHT_RECALL_PARALLEL=false` (or
+     `recallParallel: False`) restores the serial path — `recall_mode="serial"`,
+     `deadline_budget_ms=None`, results still merged.
+
+  5. **The `run_parallel` primitive** classifies completed vs deadline-abandoned
+     slots correctly and bounds total wait by the shared deadline with daemon
+     threads.
+
+Stdlib-only (unittest + threading); runs under
+``python3 -m unittest discover tests/`` from ``scripts/``.
+"""
+
+import io
+import json
+import os
+import shutil
+import socket
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import recall  # noqa: E402
+from lib.parallel_recall import run_parallel  # noqa: E402
+
+BARE = "what did we decide about the auth flow last week"
+
+
+def _memory(text, mem_id=None):
+    out = {"text": text, "type": "fact", "mentioned_at": "2026-01-01"}
+    if mem_id is not None:
+        out["id"] = mem_id
+    return out
+
+
+class _SleepyClient:
+    """Fake HindsightClient with per-bank sleep + result control.
+
+    ``bank_sleep``  : {bank_id: seconds} — how long recall() blocks for a bank.
+    ``bank_results``: {bank_id: [memory, ...]} — what recall() returns.
+    ``directives_sleep`` / ``directives`` — for the directives slot.
+    Sleeps are real (threading), so wall-clock timing assertions exercise the
+    genuine daemon-thread fan-out rather than a mocked clock.
+    """
+
+    def __init__(self, bank_sleep=None, bank_results=None, directives=None,
+                 directives_sleep=0.0):
+        self._bank_sleep = bank_sleep or {}
+        self._bank_results = bank_results or {}
+        self._directives = directives or []
+        self._directives_sleep = directives_sleep
+        self._lock = threading.Lock()
+        self.recall_calls = []  # bank_ids, in call order (thread-safe append)
+
+    def list_directives(self, bank_id, active_only=True, timeout=2):
+        if self._directives_sleep:
+            time.sleep(self._directives_sleep)
+        return {"items": list(self._directives)}
+
+    def recall(self, bank_id, query, **kwargs):
+        with self._lock:
+            self.recall_calls.append(bank_id)
+        sleep_s = self._bank_sleep.get(bank_id, 0.0)
+        if sleep_s:
+            time.sleep(sleep_s)
+        return {"results": list(self._bank_results.get(bank_id, []))}
+
+
+class _RaisingClient(_SleepyClient):
+    """A client whose named bank raises a supplied exception."""
+
+    def __init__(self, raise_for=None, **kw):
+        super().__init__(**kw)
+        self._raise_for = raise_for or {}
+
+    def recall(self, bank_id, query, **kwargs):
+        with self._lock:
+            self.recall_calls.append(bank_id)
+        exc = self._raise_for.get(bank_id)
+        if exc is not None:
+            raise exc
+        return super().recall(bank_id, query, **kwargs)
+
+
+class _MainHarness(unittest.TestCase):
+    """Runs recall.main() with a fake client and an isolated recall log."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="recall-parallel-test-")
+        self._prev = os.environ.get("CLAUDE_PLUGIN_DATA")
+        os.environ["CLAUDE_PLUGIN_DATA"] = self._tmpdir
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        if self._prev is None:
+            os.environ.pop("CLAUDE_PLUGIN_DATA", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_DATA"] = self._prev
+
+    def _read_log(self):
+        path = os.path.join(self._tmpdir, "state", "recall_log.jsonl")
+        if not os.path.isfile(path):
+            return []
+        with open(path, encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def _run(self, client, config_extra=None, prompt=BARE):
+        hook_input = {
+            "prompt": prompt,
+            "session_id": "test-session",
+            "transcript_path": "",
+            "cwd": "/tmp",
+        }
+        config = {
+            "autoRecall": True,
+            "bankId": "own-bank",
+            "recallMaxTokens": 1024,
+            "recallBudget": "mid",
+            "recallContextTurns": 1,
+            "recallMaxQueryChars": 800,
+            "recallPromptPreamble": "",
+        }
+        if config_extra:
+            config.update(config_extra)
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        started = time.monotonic()
+        with patch.object(recall, "load_config", return_value=config), patch.object(
+            recall, "get_api_url", return_value="http://localhost:18888"
+        ), patch.object(recall, "HindsightClient", return_value=client), patch.object(
+            recall, "ensure_bank_mission", return_value=None
+        ), patch.object(recall, "write_state", return_value=None), patch(
+            "sys.stdin", new=io.StringIO(json.dumps(hook_input))
+        ), patch("sys.stdout", new=stdout), patch("sys.stderr", new=stderr):
+            recall.main()
+        elapsed = time.monotonic() - started
+        raw = stdout.getvalue()
+        context = None
+        if raw.strip():
+            context = json.loads(raw)["hookSpecificOutput"]["additionalContext"]
+        return context, elapsed
+
+
+class SlowBankCannotBreachCeiling(_MainHarness):
+    def test_straggler_bank_abandoned_at_deadline(self):
+        # own-bank fast, shared-bank sleeps 3s — far past the 0.6s deadline.
+        client = _SleepyClient(
+            bank_sleep={"own-bank": 0.0, "shared-bank": 3.0},
+            bank_results={"own-bank": [_memory("own hit", "m-own")]},
+        )
+        context, elapsed = self._run(
+            client,
+            config_extra={
+                "recallAdditionalBanks": ["shared-bank"],
+                "recallParallelDeadlineSeconds": 0.6,
+            },
+        )
+        # Returned in ~deadline, NOT ~3s. Generous upper bound absorbs CI jitter
+        # while still proving the straggler did not hold the hook open.
+        self.assertLess(
+            elapsed, 2.0,
+            f"recall breached its deadline (took {elapsed:.2f}s with a 3s bank)",
+        )
+        # The fast bank's memory still injected.
+        self.assertIsNotNone(context)
+        self.assertIn("own hit", context)
+        # Telemetry: parallel mode, straggler timed_out, deadline_hit True.
+        e = self._read_log()[0]
+        self.assertEqual(e["recall_mode"], "parallel")
+        self.assertEqual(e["deadline_budget_ms"], 600)
+        timings = {bt["bank_id"]: bt for bt in e["bank_timings"]}
+        self.assertFalse(timings["own-bank"]["timed_out"])
+        self.assertTrue(timings["shared-bank"]["timed_out"])
+        self.assertTrue(e["deadline_hit"])
+
+    def test_bank_timings_own_bank_first_deterministic(self):
+        client = _SleepyClient(
+            bank_sleep={"own-bank": 0.2, "b1": 0.0, "b2": 0.0},
+            bank_results={"own-bank": [_memory("x", "m1")]},
+        )
+        self._run(
+            client,
+            config_extra={
+                "recallAdditionalBanks": ["b1", "b2"],
+                "recallParallelDeadlineSeconds": 5,
+            },
+        )
+        e = self._read_log()[0]
+        order = [bt["bank_id"] for bt in e["bank_timings"]]
+        # Own bank is slowest yet listed first — order is config order, not
+        # completion order.
+        self.assertEqual(order, ["own-bank", "b1", "b2"])
+
+
+class ParallelLatencyIsSlowestSlot(_MainHarness):
+    def test_three_banks_run_concurrently(self):
+        s = 0.4
+        client = _SleepyClient(
+            bank_sleep={"own-bank": s, "b1": s, "b2": s},
+            bank_results={"own-bank": [_memory("x", "m1")]},
+        )
+        _, elapsed = self._run(
+            client,
+            config_extra={
+                "recallAdditionalBanks": ["b1", "b2"],
+                "recallParallelDeadlineSeconds": 5,
+            },
+        )
+        # Serial would be ~3*s = 1.2s; parallel is ~s. Assert well under 2*s.
+        self.assertLess(
+            elapsed, 2 * s,
+            f"banks did not run concurrently (took {elapsed:.2f}s for 3x{s}s)",
+        )
+
+
+class DirectivesSlotDedicated(_MainHarness):
+    def test_slow_directives_abandoned_banks_still_inject(self):
+        client = _SleepyClient(
+            bank_sleep={"own-bank": 0.0},
+            bank_results={"own-bank": [_memory("bank memory", "m1")]},
+            directives=[{"id": "d1", "name": "rule", "content": "always X", "priority": 5}],
+            directives_sleep=3.0,  # far past the deadline
+        )
+        context, elapsed = self._run(
+            client,
+            config_extra={"recallParallelDeadlineSeconds": 0.6},
+        )
+        self.assertLess(elapsed, 2.0)
+        # Bank memory injected despite the directives slot dying.
+        self.assertIsNotNone(context)
+        self.assertIn("bank memory", context)
+        e = self._read_log()[0]
+        self.assertTrue(e["directives_timed_out"])
+        self.assertEqual(e["directive_count"], 0)
+        self.assertTrue(e["deadline_hit"])
+
+    def test_fast_directives_inject_alongside_banks(self):
+        client = _SleepyClient(
+            bank_sleep={"own-bank": 0.0},
+            bank_results={"own-bank": [_memory("bank memory", "m1")]},
+            directives=[{"id": "d1", "name": "rule", "content": "always X", "priority": 5}],
+            directives_sleep=0.0,
+        )
+        context, _ = self._run(client, config_extra={"recallParallelDeadlineSeconds": 5})
+        self.assertIsNotNone(context)
+        self.assertIn("always X", context)
+        e = self._read_log()[0]
+        self.assertFalse(e["directives_timed_out"])
+        self.assertEqual(e["directive_count"], 1)
+        self.assertFalse(e["deadline_hit"])
+
+
+class RaisedTimeoutStillClassified(_MainHarness):
+    def test_raised_timeout_marks_deadline_hit(self):
+        # A bank that RAISES socket.timeout (fast fail) is timed_out too — the
+        # finalized semantics keep the per-request-timeout signal as well as the
+        # abandonment signal.
+        client = _RaisingClient(
+            raise_for={"shared-bank": socket.timeout("read timed out")},
+            bank_results={"own-bank": [_memory("x", "m1")]},
+        )
+        self._run(
+            client,
+            config_extra={
+                "recallAdditionalBanks": ["shared-bank"],
+                "recallParallelDeadlineSeconds": 5,
+            },
+        )
+        e = self._read_log()[0]
+        timings = {bt["bank_id"]: bt for bt in e["bank_timings"]}
+        self.assertTrue(timings["shared-bank"]["timed_out"])
+        self.assertFalse(timings["own-bank"]["timed_out"])
+        self.assertTrue(e["deadline_hit"])
+
+    def test_non_timeout_error_is_not_deadline_hit(self):
+        client = _RaisingClient(
+            raise_for={"shared-bank": RuntimeError("HTTP 503 from x: boom")},
+            bank_results={"own-bank": [_memory("x", "m1")]},
+        )
+        self._run(
+            client,
+            config_extra={
+                "recallAdditionalBanks": ["shared-bank"],
+                "recallParallelDeadlineSeconds": 5,
+            },
+        )
+        e = self._read_log()[0]
+        timings = {bt["bank_id"]: bt for bt in e["bank_timings"]}
+        self.assertFalse(timings["shared-bank"]["timed_out"])
+        self.assertFalse(e["deadline_hit"])
+
+
+class SerialRollback(_MainHarness):
+    def test_rollback_flag_uses_serial_path(self):
+        client = _SleepyClient(
+            bank_sleep={"own-bank": 0.0, "shared-bank": 0.0},
+            bank_results={
+                "own-bank": [_memory("own", "m1")],
+                "shared-bank": [_memory("shared", "m2")],
+            },
+        )
+        context, _ = self._run(
+            client,
+            config_extra={
+                "recallAdditionalBanks": ["shared-bank"],
+                "recallParallel": False,
+            },
+        )
+        self.assertIsNotNone(context)
+        e = self._read_log()[0]
+        self.assertEqual(e["recall_mode"], "serial")
+        self.assertIsNone(e["deadline_budget_ms"])
+        self.assertFalse(e["directives_timed_out"])
+        # Both banks were queried and merged.
+        self.assertEqual(sorted(e["memory_ids"]), ["m1", "m2"])
+        self.assertEqual(sorted(client.recall_calls), ["own-bank", "shared-bank"])
+
+
+class RunParallelPrimitive(unittest.TestCase):
+    def test_completed_vs_abandoned_classification(self):
+        results = {"v": None}
+
+        def fast():
+            return 42
+
+        def slow():
+            time.sleep(2.0)
+            return "late"
+
+        started = time.monotonic()
+        outcomes = run_parallel({"fast": fast, "slow": slow}, deadline_seconds=0.4)
+        elapsed = time.monotonic() - started
+        # Bounded by the shared deadline, not the 2s slow task.
+        self.assertLess(elapsed, 1.5)
+        self.assertTrue(outcomes["fast"].completed)
+        self.assertEqual(outcomes["fast"].value, 42)
+        self.assertIsNone(outcomes["fast"].error)
+        self.assertFalse(outcomes["slow"].completed)
+        self.assertIsNone(outcomes["slow"].value)
+        # elapsed_ms recorded for both (deadline pin for the abandoned one).
+        self.assertIsInstance(outcomes["fast"].elapsed_ms, int)
+        self.assertIsInstance(outcomes["slow"].elapsed_ms, int)
+
+    def test_raising_task_surfaces_error_not_raise(self):
+        def boom():
+            raise ValueError("nope")
+
+        outcomes = run_parallel({"boom": boom}, deadline_seconds=1.0)
+        self.assertTrue(outcomes["boom"].completed)
+        self.assertIsInstance(outcomes["boom"].error, ValueError)
+        self.assertIsNone(outcomes["boom"].value)
+
+    def test_workers_are_daemon_threads(self):
+        seen = {"daemon": None}
+
+        def check():
+            seen["daemon"] = threading.current_thread().daemon
+
+        run_parallel({"c": check}, deadline_seconds=1.0)
+        self.assertTrue(seen["daemon"])
+
+    def test_total_wait_bounded_by_deadline_with_many_slow_slots(self):
+        def slow():
+            time.sleep(2.0)
+
+        tasks = {f"s{i}": slow for i in range(4)}
+        started = time.monotonic()
+        run_parallel(tasks, deadline_seconds=0.5)
+        elapsed = time.monotonic() - started
+        # 4 slow slots cost the deadline ONCE (parallel), not 4x.
+        self.assertLess(elapsed, 1.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_recall_parallel_deadline.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_parallel_deadline.py
@@ -196,6 +196,11 @@ class SlowBankCannotBreachCeiling(_MainHarness):
         e = self._read_log()[0]
         self.assertEqual(e["recall_mode"], "parallel")
         self.assertEqual(e["deadline_budget_ms"], 600)
+        # Effective deadline is the configured budget minus pre-fan-out spend,
+        # so it is present, positive, and never exceeds the configured budget.
+        self.assertIsNotNone(e["deadline_effective_ms"])
+        self.assertGreater(e["deadline_effective_ms"], 0)
+        self.assertLessEqual(e["deadline_effective_ms"], e["deadline_budget_ms"])
         timings = {bt["bank_id"]: bt for bt in e["bank_timings"]}
         self.assertFalse(timings["own-bank"]["timed_out"])
         self.assertTrue(timings["shared-bank"]["timed_out"])
@@ -338,6 +343,7 @@ class SerialRollback(_MainHarness):
         e = self._read_log()[0]
         self.assertEqual(e["recall_mode"], "serial")
         self.assertIsNone(e["deadline_budget_ms"])
+        self.assertIsNone(e["deadline_effective_ms"])
         self.assertFalse(e["directives_timed_out"])
         # Both banks were queried and merged.
         self.assertEqual(sorted(e["memory_ids"]), ["m1", "m2"])


### PR DESCRIPTION
PR 3 of the hindsight-leverage programme (epic #3430; workstream A child #3431). Single concern: **parallelise the recall critical path under one shared deadline** so a slow bank can no longer push the `UserPromptSubmit` hook past its 12s ceiling.

> [!IMPORTANT]
> **MERGE IS HELD — do not merge yet.** Per the epic gate, PR 1's (#3435) `deadline_hit` breach telemetry must accrue a **fresh ≥3-day baseline** before this parallelism change merges (the oft-quoted 17–26% figure is the stale 2026-05-24 pre-fix audit, NOT a valid before-number). This PR is filed as a **draft** and stays draft until that window has elapsed and the fresh baseline is recorded. It ships on resilience merits + the stub-timing acceptance tests even if the fresh baseline is already <2% (epic exit-criterion 1 fallback).

## Problem

Recall serially queries the agent's own bank, every additional bank (profile / shared / sender), **and** the active-directives list. Serially those round-trips **SUM** — a heavy multi-bank agent can serialise four 2–8s calls and breach the 12s hook ceiling, which drops recall entirely for that turn. PR 1 shipped the `deadline_hit` telemetry with **interim** semantics pending this PR; this PR finalises them.

## Change

- **`lib/parallel_recall.py` (new)** — `run_parallel(tasks, deadline_seconds)` runs each labelled task in its own **daemon thread**, waits only until one **shared deadline**, and records per-slot `completed` / `value` / `error` / `elapsed_ms`. Total wait is bounded by the deadline regardless of how many slots are slow. Daemon threads mean a slot still blocked on a socket read at the deadline can never keep the interpreter (hook) alive.
- **`recall.py`** — the directives fetch + own bank + every additional bank now run concurrently through `run_parallel` under `recallParallelDeadlineSeconds` (default **10** = the 12s ceiling minus 2s headroom, measured from the top of the critical path). The **directives slot is dedicated** and composes with the A4 directives cache (merged #3436) — on a cache HIT it returns near-instantly with no HTTP. `bank_timings` and the result-merge order stay **own-bank-first, config-order** regardless of thread completion order, so telemetry is deterministic. `__main__` calls `os._exit(0)` (after a stdout flush) as a belt-and-suspenders so no straggler thread can hold the hook open.
- **Rollback lever** — `HINDSIGHT_RECALL_PARALLEL=false` (or `recallParallel: false`) restores the byte-for-byte pre-A3 **serial** path.
- **Finalised `deadline_hit` semantics** — now True when any bank raised a hard per-request timeout **OR** any bank/directives slot was **abandoned at the shared deadline** (the straggler case the interim per-bank-only form could not express). In serial (rollback) mode it reduces to the pre-A3 form, so both modes' `recall_log.jsonl` rows stay directly comparable in the breach baseline. New log fields: `recall_mode` (`parallel`/`serial`), `deadline_budget_ms`, `directives_timed_out`.

## Acceptance evidence

- **New `scripts/tests/test_recall_parallel_deadline.py` (12 tests):** a bank stubbed to sleep 3s cannot breach a 0.6s deadline (`main()` returns <2s, fast bank's memory still injects, straggler recorded `timed_out`/`deadline_hit`); three 0.4s banks complete in ~0.4s not ~1.2s; the dedicated directives slot is abandoned at the deadline while bank memories still inject (and runs concurrently when fast); a raised `socket.timeout` and a deadline-abandoned straggler both mark `deadline_hit`, a `HTTP 503` does not; `recallParallel: false` uses the serial path; the `run_parallel` primitive classifies completed vs abandoned slots, surfaces errors without raising, uses daemon threads, and bounds total wait with 4 slow slots.
- **Scoped suite green:** `python3 -m unittest discover -s scripts/tests -t scripts` → **377 passed**. New tests: **12 passed**.
- **Pre-existing, unrelated:** the pytest full-suite run shows 9 cross-test-pollution failures in `test_reconcile_durability` / `test_retain_window` (retain path, untouched here) — they pass in isolation and fail identically on pristine `origin/main`, and 2 `test_recall_exit_codes` subprocess-shim failures are likewise pre-existing on main. The canonical `unittest discover` runner is green.
- **Lint:** Python-only change under `vendor/`; no Python linter is configured in-repo and the TS `npm run lint` guards don't cover these paths (offline deps not installed) — CI is the authority there, same posture as #3435.

## Verdict rule

- **Vision outcome:** *remember across sessions* — recall stops silently dropping on heavy multi-bank agents.
- **Job spec:** `reference/jobs/remember-across-sessions.md`.
- **Invariants:** claude-native (no model callsite; pure threading), deterministic mechanism (daemon threads + `os._exit`, not prompt discipline), single-tenant (no auth change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
