### PR TITLE
hindsight recall: bounded transcript-grep fallback for empty fact layer (E1, PR8) (#3369)

### DIFF
--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -149,6 +149,32 @@ DEFAULTS = {
     # can never push the hook past its ceiling. Slots still unfinished when the
     # deadline elapses are abandoned (daemon threads) and marked timed_out.
     "recallParallelDeadlineSeconds": 10,
+    # Switchroom hindsight-leverage E1 / PR8 (#3369) — bounded transcript-grep
+    # fallback. Boot reconciliation (reconcile_tail.py) closes the crash-loss
+    # window at the NEXT SessionStart, but between an abrupt kill and that boot,
+    # live recall returns nothing for the lost turns because the fact layer was
+    # never told about them. When on (default) AND every bank returned zero
+    # results AND no bank/directives slot hit its deadline (deadline_hit False —
+    # so a timed-out bank can't masquerade as a genuinely empty fact layer, the
+    # #3369 sequencing constraint that depends on A3's shared-deadline telemetry),
+    # recall greps the CURRENT session's transcript tail for turns that mention
+    # the query's terms and injects them as a clearly-labelled, lower-confidence
+    # fallback block. Everything is bounded: the tail read (…MaxBytes), the number
+    # of matched turns (…MaxTurns), the emitted characters (…MaxChars), and the
+    # grep wall-time (…DeadlineMs). Set false (HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK
+    # =false) to disable — the rollback lever.
+    "recallTranscriptFallback": True,
+    # Tail bytes read from the session transcript for the grep. 256 KiB covers
+    # many turns of recent conversation while keeping the read well inside the
+    # hook budget; only the LAST max_bytes are read (partial first line dropped).
+    "recallTranscriptFallbackMaxBytes": 262144,
+    # Hard ceiling on matched turns injected into the fallback block.
+    "recallTranscriptFallbackMaxTurns": 6,
+    # Hard ceiling on the fallback block's excerpt characters.
+    "recallTranscriptFallbackMaxChars": 2000,
+    # Wall-clock bound (ms) on the grep itself — abandons scanning older turns
+    # once exceeded so the fallback can never eat the recall critical path.
+    "recallTranscriptFallbackDeadlineMs": 1500,
     # Connection
     "hindsightApiUrl": None,
     "hindsightApiToken": None,
@@ -226,6 +252,14 @@ ENV_OVERRIDES = {
     # lever; the deadline is the ceiling-minus-2s hard budget (see DEFAULTS).
     "HINDSIGHT_RECALL_PARALLEL": ("recallParallel", bool),
     "HINDSIGHT_RECALL_PARALLEL_DEADLINE_SECONDS": ("recallParallelDeadlineSeconds", int),
+    # Switchroom hindsight-leverage E1 / PR8 (#3369) — transcript-grep fallback
+    # toggle + bounds. HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK=false is the rollback
+    # lever; the others tune the byte / turn / char / time bounds.
+    "HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK": ("recallTranscriptFallback", bool),
+    "HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK_MAX_BYTES": ("recallTranscriptFallbackMaxBytes", int),
+    "HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK_MAX_TURNS": ("recallTranscriptFallbackMaxTurns", int),
+    "HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK_MAX_CHARS": ("recallTranscriptFallbackMaxChars", int),
+    "HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK_DEADLINE_MS": ("recallTranscriptFallbackDeadlineMs", int),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     # Switchroom hindsight-leverage A2 — byte-tail bound for the multi-turn

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -54,10 +54,12 @@ from lib.bank import derive_bank_id, ensure_bank_mission
 from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.content import (
+    _extract_text_content,
     compose_recall_query,
     format_current_time,
     format_memories,
     strip_channel_envelope,
+    strip_memory_tags,
     truncate_recall_query,
 )
 from lib.daemon import get_api_url
@@ -714,7 +716,9 @@ def read_transcript_messages(transcript_path: str, tail_bytes: int = 0) -> list:
     ``tail_bytes`` (Switchroom A2) byte-bounds the read: when > 0 and the file
     is larger, only the trailing ``tail_bytes`` (complete lines) are parsed, so
     the added per-recall transcript read stays cheap on long sessions. 0 reads
-    the whole file.
+    the whole file. The #3369 grep fallback reuses this same tail-reader (see
+    ``_transcript_grep_fallback``) rather than shipping its own seek logic, so
+    there is a single byte-bounded transcript reader.
     """
     if not transcript_path or not os.path.isfile(transcript_path):
         return []
@@ -739,6 +743,129 @@ def read_transcript_messages(transcript_path: str, tail_bytes: int = 0) -> list:
     except OSError:
         pass
     return messages
+
+
+# Switchroom hindsight-leverage E1 / PR8 (#3369) — bounded transcript-grep
+# fallback telemetry shape. A zeroed record is the "did not fire" default,
+# emitted on the recall_log row whenever the fallback is gated off, skipped, or
+# produced no match — so the log schema is uniform and a downstream query can
+# always read `transcript_fallback` without a KeyError.
+_FALLBACK_TELEMETRY_ZERO = {
+    "fired": False,
+    "matched_turns": 0,
+    "chars": 0,
+    "elapsed_ms": 0,
+    "bytes_read": 0,
+    "truncated": False,
+}
+
+_FALLBACK_BLOCK_PREAMBLE = (
+    "No stored memories matched this query — the fact layer may not have "
+    "reconciled this session yet (e.g. an abrupt session death before boot "
+    "reconciliation). The following are VERBATIM excerpts from recent turns of "
+    "THIS session that mention related terms. Treat them as lower-confidence "
+    "than stored memory — they are raw transcript, not synthesized fact:"
+)
+
+
+def _transcript_grep_fallback(transcript_path, query, config):
+    """Bounded transcript-grep fallback for the empty-fact-layer window (#3369).
+
+    Reads the CURRENT session transcript's tail (bounded bytes), keeps the most
+    recent user/assistant turns whose terms lexically overlap the recall query,
+    and returns a clearly-labelled, size-bounded fallback context block plus a
+    telemetry dict. Every dimension is bounded: bytes read
+    (``recallTranscriptFallbackMaxBytes``), matched turns
+    (``recallTranscriptFallbackMaxTurns``), emitted characters
+    (``recallTranscriptFallbackMaxChars``), and grep wall-time
+    (``recallTranscriptFallbackDeadlineMs``). The caller only invokes this when
+    all banks returned zero AND no slot hit its deadline, so a timed-out bank can
+    never masquerade as a genuinely empty fact layer.
+
+    Returns ``(block_or_None, telemetry)``. Failure-safe: any error path returns
+    ``(None, zeroed-telemetry)`` so the fallback can never break recall.
+    """
+    telemetry = dict(_FALLBACK_TELEMETRY_ZERO)
+    start = time.monotonic()
+
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return None, telemetry
+
+    def _int_cfg(key, default):
+        try:
+            val = int(config.get(key, default))
+        except (TypeError, ValueError):
+            return default
+        return val
+
+    max_bytes = _int_cfg("recallTranscriptFallbackMaxBytes", 262144)
+    max_turns = _int_cfg("recallTranscriptFallbackMaxTurns", 6)
+    max_chars = _int_cfg("recallTranscriptFallbackMaxChars", 2000)
+    deadline_ms = _int_cfg("recallTranscriptFallbackDeadlineMs", 1500)
+
+    if max_turns <= 0 or max_chars <= 0 or max_bytes <= 0:
+        return None, telemetry
+
+    query_tokens = _overlap_tokens(query)
+    if not query_tokens:
+        return None, telemetry
+
+    try:
+        telemetry["bytes_read"] = min(os.path.getsize(transcript_path), max_bytes)
+    except OSError:
+        pass
+
+    messages = read_transcript_messages(transcript_path, tail_bytes=max_bytes)
+
+    matched = []
+    total_chars = 0
+    # Newest-first so, under the turn/char/time bounds, we keep the MOST RECENT
+    # relevant turns; the collected list is reversed back to chronological order
+    # before formatting.
+    for msg in reversed(messages):
+        if (time.monotonic() - start) * 1000.0 > deadline_ms:
+            telemetry["truncated"] = True
+            break
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role not in ("user", "assistant"):
+            continue
+        text = _extract_text_content(msg.get("content", ""), role=role)
+        text = strip_memory_tags(strip_channel_envelope(text)).strip()
+        if not text:
+            continue
+        if not (_overlap_tokens(text) & query_tokens):
+            continue
+        entry = f"[{role}] {text}"
+        remaining = max_chars - total_chars
+        if remaining <= 0:
+            telemetry["truncated"] = True
+            break
+        if len(entry) > remaining:
+            entry = entry[:remaining].rstrip() + "…"
+            telemetry["truncated"] = True
+        matched.append(entry)
+        total_chars += len(entry)
+        if len(matched) >= max_turns:
+            break
+
+    telemetry["elapsed_ms"] = int((time.monotonic() - start) * 1000)
+
+    if not matched:
+        return None, telemetry
+
+    matched.reverse()  # restore chronological order for the model
+    block = (
+        "<hindsight_transcript_fallback>\n"
+        f"{_FALLBACK_BLOCK_PREAMBLE}\n\n"
+        + "\n".join(matched)
+        + "\n</hindsight_transcript_fallback>"
+    )
+    telemetry["fired"] = True
+    telemetry["matched_turns"] = len(matched)
+    telemetry["chars"] = len(block)
+    return block, telemetry
 
 
 # Switchroom Phase 6a — stateless-prompt classifier for the recall skip.
@@ -1146,6 +1273,15 @@ def main():
                 "active_topic_alias": active_topic_alias,
                 "topic_filter_mode": _topic_filter_mode(),
                 "directive_nudge": bool(nudge_block),
+                # E1 / PR8 (#3369) — no banks ran on a cache hit, so the
+                # transcript fallback never fires; carry the zeroed fields for a
+                # uniformly queryable schema.
+                "transcript_fallback": False,
+                "transcript_fallback_turns": 0,
+                "transcript_fallback_chars": 0,
+                "transcript_fallback_bytes_read": 0,
+                "transcript_fallback_elapsed_ms": 0,
+                "transcript_fallback_truncated": False,
             })
             return
         debug_log(config, f"Recall cache MISS (key={cache_key[:12]}…)")
@@ -1390,6 +1526,14 @@ def main():
                 "timed_out": _bank_timed_out,
             })
 
+    # Switchroom hindsight-leverage A3 — FINALIZED `deadline_hit`: True when ANY
+    # slot on the critical path hit its deadline (a bank that raised a hard
+    # per-request timeout, or — parallel mode — a bank/directives slot abandoned
+    # at the shared deadline). Hoisted here (was inline in the recall_log write)
+    # so the E1 / PR8 transcript fallback can gate on it: the #3369 fallback must
+    # NOT fire when a bank timed out, only when the fact layer is genuinely empty.
+    deadline_hit = any(bt["timed_out"] for bt in bank_timings) or directives_timed_out
+
     directives_block = format_active_directives_block(directives) if directives else None
     if directives_block:
         debug_log(config, f"Injecting {len(directives)} active directives")
@@ -1524,6 +1668,35 @@ def main():
     else:
         debug_log(config, "No memories found")
 
+    # Switchroom hindsight-leverage E1 / PR8 (#3369) — bounded transcript-grep
+    # fallback. Fires ONLY when every bank returned zero results (pre_filter_count
+    # == 0 — the merged pre-demote bank count) AND no slot hit its deadline
+    # (deadline_hit False, so a timed-out bank can't masquerade as an empty fact
+    # layer — the #3369 sequencing constraint on A3's telemetry). This recovers
+    # the crash-loss window between an abrupt session death and the next boot
+    # reconciliation, where live recall would otherwise return nothing for the
+    # lost turns. Everything is bounded inside the helper (bytes/turns/chars/time).
+    # On by default; HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK=false is the rollback
+    # lever. Mutually exclusive with memories_block by construction: a non-empty
+    # memories_block requires results, which requires pre_filter_count > 0.
+    transcript_fallback_block = None
+    transcript_fallback_telemetry = dict(_FALLBACK_TELEMETRY_ZERO)
+    if (
+        config.get("recallTranscriptFallback", True)
+        and pre_filter_count == 0
+        and not deadline_hit
+    ):
+        transcript_fallback_block, transcript_fallback_telemetry = _transcript_grep_fallback(
+            hook_input.get("transcript_path", ""),
+            query,
+            config,
+        )
+        if transcript_fallback_block:
+            debug_log(
+                config,
+                f"Transcript-grep fallback fired: {transcript_fallback_telemetry}",
+            )
+
     # Switchroom #303 — recall is done, model is about to start the long
     # TTFT. Update the placeholder so the user doesn't keep staring at
     # `📚 recalling memories` for the next 15–20 s of opus thinking.
@@ -1593,7 +1766,7 @@ def main():
         # (rollback) mode `directives_timed_out` is always False and each bank's
         # `timed_out` is per-request only, so this reduces to the pre-A3 form —
         # keeping the two modes' rows directly comparable in the breach baseline.
-        "deadline_hit": any(bt["timed_out"] for bt in bank_timings) or directives_timed_out,
+        "deadline_hit": deadline_hit,
         # A3 — recall execution mode ("parallel"/"serial") and the shared
         # deadline budget (ms; None in serial mode). These distinguish pre-A3
         # (serial) from post-A3 (parallel) rows so the ≥3-day breach baseline
@@ -1621,24 +1794,39 @@ def main():
         "topic_filter_mode": topic_filter_mode,
         "topic_dropped": topic_dropped,
         "directive_nudge": bool(nudge_block),
+        # Switchroom hindsight-leverage E1 / PR8 (#3369) — transcript-grep
+        # fallback telemetry so its firing (and its bounds) are visible per turn
+        # in recall_log.jsonl. `transcript_fallback` True only on an all-zero,
+        # no-deadline-hit turn where the grep found ≥1 matching session turn.
+        "transcript_fallback": transcript_fallback_telemetry["fired"],
+        "transcript_fallback_turns": transcript_fallback_telemetry["matched_turns"],
+        "transcript_fallback_chars": transcript_fallback_telemetry["chars"],
+        "transcript_fallback_bytes_read": transcript_fallback_telemetry["bytes_read"],
+        "transcript_fallback_elapsed_ms": transcript_fallback_telemetry["elapsed_ms"],
+        "transcript_fallback_truncated": transcript_fallback_telemetry["truncated"],
     })
 
     # If neither block has content, there's nothing to inject — exit
     # silently to avoid emitting an empty hookSpecificOutput. #2848: unless
     # the directive-capture nudge fired, in which case emit the nudge alone
     # (a correction with no memories/directives still needs the reminder).
-    if not directives_block and not memories_block:
+    if not directives_block and not memories_block and not transcript_fallback_block:
         if nudge_block:
             _emit_cached_context(nudge_block)
         return
 
     # Compose final context. Directives block goes ABOVE memories so the
-    # agent reads HARD RULES before low-signal recall traces.
+    # agent reads HARD RULES before low-signal recall traces. The E1/PR8
+    # transcript fallback (#3369) goes LAST — it is the lowest-confidence
+    # signal (raw transcript, not synthesized fact) and only present when
+    # memories_block is empty by construction.
     parts = []
     if directives_block:
         parts.append(directives_block)
     if memories_block:
         parts.append(memories_block)
+    if transcript_fallback_block:
+        parts.append(transcript_fallback_block)
     context_message = "\n\n".join(parts)
 
     # Save last recall to state for diagnostics

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -1293,6 +1293,11 @@ def main():
                 "transcript_fallback_bytes_read": 0,
                 "transcript_fallback_elapsed_ms": 0,
                 "transcript_fallback_truncated": False,
+                # PR8 (#3369) — no banks ran on a cache hit, so no bank raised a
+                # hard error. None (NOT False) so a cache-hit row is never
+                # miscounted as an observed no-error recall — matching the
+                # deadline_hit / directives_timed_out convention above.
+                "bank_errored": None,
             })
             return
         debug_log(config, f"Recall cache MISS (key={cache_key[:12]}…)")

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -810,12 +810,20 @@ def _transcript_grep_fallback(transcript_path, query, config):
     if not query_tokens:
         return None, telemetry
 
+    # TODO(consolidation, #3450 / epic #3430): two bounded transcript tail-readers now
+    # coexist post-merge — retain's, and recall's shared ``_read_transcript_lines``
+    # (#3443, which this #3369 fallback now reuses via ``read_transcript_messages``).
+    # They each re-implement "read the last N bytes of the session JSONL and parse
+    # turns". Consolidate onto a single shared bounded tail-reader helper. Tracked
+    # in follow-up #3450 (tied to epic #3430).
+    messages = read_transcript_messages(transcript_path, tail_bytes=max_bytes)
+
+    # Review finding — record bytes_read only AFTER the read succeeds, so a
+    # failed/partial read doesn't report bytes we never actually consumed.
     try:
         telemetry["bytes_read"] = min(os.path.getsize(transcript_path), max_bytes)
     except OSError:
         pass
-
-    messages = read_transcript_messages(transcript_path, tail_bytes=max_bytes)
 
     matched = []
     total_chars = 0
@@ -843,7 +851,10 @@ def _transcript_grep_fallback(transcript_path, query, config):
             telemetry["truncated"] = True
             break
         if len(entry) > remaining:
-            entry = entry[:remaining].rstrip() + "…"
+            # Review finding — reserve 1 char for the ellipsis so the emitted
+            # entry is EXACTLY `remaining` chars, not remaining+1 (the "…" is a
+            # single code point). Keeps the char budget an exact bound.
+            entry = entry[:remaining - 1].rstrip() + "…"
             telemetry["truncated"] = True
         matched.append(entry)
         total_chars += len(entry)
@@ -1464,6 +1475,12 @@ def main():
             b_timed_out = (not b_outcome.completed) or (
                 b_outcome.error is not None and _is_timeout_error(b_outcome.error)
             )
+            # Switchroom review finding (PR8 gating hole) — a bank that raised a
+            # HARD (non-timeout) error: connection refused, 5xx, daemon down,
+            # malformed response. Distinct from `timed_out` so the transcript
+            # fallback can be suppressed on a genuine outage (the fact layer was
+            # unreachable, not "empty because nothing reconciled yet").
+            b_errored = b_outcome.error is not None and not _is_timeout_error(b_outcome.error)
             if b_outcome.completed and b_outcome.error is None:
                 bank_results = (
                     b_outcome.value.get("results", [])
@@ -1486,6 +1503,7 @@ def main():
                 "bank_id": b_id,
                 "elapsed_ms": b_outcome.elapsed_ms if b_outcome.elapsed_ms is not None else 0,
                 "timed_out": b_timed_out,
+                "errored": b_errored,
             })
     else:
         # Pre-A3 serial path (rollback lever, HINDSIGHT_RECALL_PARALLEL=false).
@@ -1508,6 +1526,7 @@ def main():
             b_id, b_tags, b_tags_match, b_tag_groups = spec
             _bank_start = time.monotonic()
             _bank_timed_out = False
+            _bank_errored = False
             try:
                 response = _make_bank_task(b_id, b_tags, b_tags_match, b_tag_groups)()
                 bank_results = response.get("results", []) if isinstance(response, dict) else []
@@ -1516,6 +1535,8 @@ def main():
                     results = results + bank_results
             except Exception as e:
                 _bank_timed_out = _is_timeout_error(e)
+                # Non-timeout error → hard outage (see parallel-path note above).
+                _bank_errored = not _bank_timed_out
                 if b_id == bank_id:
                     print(f"[Hindsight] Recall failed: {e}", file=sys.stderr)
                 else:
@@ -1524,6 +1545,7 @@ def main():
                 "bank_id": b_id,
                 "elapsed_ms": int((time.monotonic() - _bank_start) * 1000),
                 "timed_out": _bank_timed_out,
+                "errored": _bank_errored,
             })
 
     # Switchroom hindsight-leverage A3 — FINALIZED `deadline_hit`: True when ANY
@@ -1533,6 +1555,15 @@ def main():
     # so the E1 / PR8 transcript fallback can gate on it: the #3369 fallback must
     # NOT fire when a bank timed out, only when the fact layer is genuinely empty.
     deadline_hit = any(bt["timed_out"] for bt in bank_timings) or directives_timed_out
+
+    # Switchroom review finding (PR8 gating hole) — True when ANY bank raised a
+    # HARD (non-timeout) error. A connection-refused / 5xx / daemon-down outage
+    # contributes zero results with `deadline_hit` False, which would otherwise
+    # let the empty-fact-layer transcript fallback fire on every turn for the
+    # whole outage — mislabelling "fact layer unreachable" as "nothing
+    # reconciled yet" and flooding telemetry. Gated on below so the fallback
+    # only fires when all banks genuinely returned zero: no timeout AND no error.
+    bank_errored = any(bt.get("errored") for bt in bank_timings)
 
     directives_block = format_active_directives_block(directives) if directives else None
     if directives_block:
@@ -1672,7 +1703,10 @@ def main():
     # fallback. Fires ONLY when every bank returned zero results (pre_filter_count
     # == 0 — the merged pre-demote bank count) AND no slot hit its deadline
     # (deadline_hit False, so a timed-out bank can't masquerade as an empty fact
-    # layer — the #3369 sequencing constraint on A3's telemetry). This recovers
+    # layer — the #3369 sequencing constraint on A3's telemetry) AND no bank
+    # raised a hard error (bank_errored False, so a connection-refused / 5xx /
+    # daemon-down outage can't masquerade as an empty fact layer either — the
+    # PR8 gating-hole fix). This recovers
     # the crash-loss window between an abrupt session death and the next boot
     # reconciliation, where live recall would otherwise return nothing for the
     # lost turns. Everything is bounded inside the helper (bytes/turns/chars/time).
@@ -1685,6 +1719,7 @@ def main():
         config.get("recallTranscriptFallback", True)
         and pre_filter_count == 0
         and not deadline_hit
+        and not bank_errored
     ):
         transcript_fallback_block, transcript_fallback_telemetry = _transcript_grep_fallback(
             hook_input.get("transcript_path", ""),
@@ -1696,6 +1731,14 @@ def main():
                 config,
                 f"Transcript-grep fallback fired: {transcript_fallback_telemetry}",
             )
+    elif pre_filter_count == 0 and bank_errored:
+        # Suppressed: a bank outage (hard error), not a genuinely empty fact
+        # layer. Logged so the gate decision is visible during an outage.
+        debug_log(
+            config,
+            "Transcript-grep fallback suppressed: bank_errored (hard bank error, "
+            "not an empty fact layer)",
+        )
 
     # Switchroom #303 — recall is done, model is about to start the long
     # TTFT. Update the placeholder so the user doesn't keep staring at
@@ -1767,6 +1810,12 @@ def main():
         # `timed_out` is per-request only, so this reduces to the pre-A3 form —
         # keeping the two modes' rows directly comparable in the breach baseline.
         "deadline_hit": deadline_hit,
+        # Switchroom review finding (PR8 gating hole) — True when any bank raised
+        # a hard (non-timeout) error this turn. Gates the transcript fallback
+        # (suppressed on a real outage) and makes the outage visible per-row so a
+        # spike in empty-result turns can be attributed to unreachable banks
+        # rather than a genuinely empty fact layer.
+        "bank_errored": bank_errored,
         # A3 — recall execution mode ("parallel"/"serial") and the shared
         # deadline budget (ms; None in serial mode). These distinguish pre-A3
         # (serial) from post-A3 (parallel) rows so the ≥3-day breach baseline

--- a/vendor/hindsight-memory/scripts/tests/test_recall_envelope_strip_telemetry.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_envelope_strip_telemetry.py
@@ -376,6 +376,12 @@ class CacheHitRowSchema(_LogTestBase):
         self.assertIsNone(e["total_elapsed_ms"])
         self.assertIsNone(e["directives_elapsed_ms"])
         self.assertIsNone(e["query"])
+        # PR8 (#3369) — the bank_errored field is present on cache-hit rows
+        # for a uniform schema, and is None (NOT False) since no banks ran, so
+        # a reader can do row["bank_errored"] without a KeyError and the row is
+        # never miscounted as an observed no-error recall.
+        self.assertIn("bank_errored", e)
+        self.assertIsNone(e["bank_errored"])
 
 
 class MultiEnvelopeStrip(unittest.TestCase):

--- a/vendor/hindsight-memory/scripts/tests/test_recall_transcript_fallback.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_transcript_fallback.py
@@ -1,0 +1,328 @@
+"""Switchroom hindsight-leverage E1 / PR8 (#3369) — bounded transcript-grep
+fallback when the fact layer is empty pre-reconcile.
+
+Acceptance guarantees (outcomes, not code paths):
+
+  1. **Fires on all-zero + no deadline hit.** Every bank returns zero results
+     and no slot timed out → recall injects a ``<hindsight_transcript_fallback>``
+     block containing the recent session turn(s) that mention the query's
+     terms, and the recall_log row records ``transcript_fallback=True``.
+
+  2. **Does NOT fire when any bank returned memories.** A non-empty bank result
+     suppresses the fallback entirely (no fallback block, log False) — the
+     fact layer is not empty.
+
+  3. **Does NOT fire when a bank hit its deadline.** deadline_hit True (a bank
+     abandoned at the shared deadline) means the empty result set may be a
+     TIMEOUT, not a genuinely empty fact layer — the #3369 sequencing
+     constraint — so the fallback is suppressed even though results are empty.
+
+  4. **Byte bound holds.** With a small ``…MaxBytes``, only the transcript TAIL
+     is read: a query-matching line that lives only in the (discarded) HEAD is
+     never surfaced, and ``transcript_fallback_bytes_read`` never exceeds the
+     configured cap.
+
+  5. **Turn + char bounds hold.** ``…MaxTurns`` caps the number of injected
+     turns; ``…MaxChars`` caps the emitted characters and sets the
+     ``transcript_fallback_truncated`` telemetry flag.
+
+  6. **Config gate + relevance.** ``recallTranscriptFallback=False`` disables it;
+     a transcript with no term overlap with the query never fires.
+
+Stdlib-only (unittest); runs under ``python3 -m unittest discover tests/``
+from ``scripts/``.
+"""
+
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import recall  # noqa: E402
+
+# Query terms: decide, auth, flow, week (stopwords stripped by _overlap_tokens).
+BARE = "what did we decide about the auth flow last week"
+
+
+def _memory(text, mem_id=None):
+    out = {"text": text, "type": "fact", "mentioned_at": "2026-01-01"}
+    if mem_id is not None:
+        out["id"] = mem_id
+    return out
+
+
+class _Client:
+    """Fake HindsightClient with per-bank sleep + result control."""
+
+    def __init__(self, bank_sleep=None, bank_results=None, directives=None):
+        self._bank_sleep = bank_sleep or {}
+        self._bank_results = bank_results or {}
+        self._directives = directives or []
+        self._lock = threading.Lock()
+        self.recall_calls = []
+
+    def list_directives(self, bank_id, active_only=True, timeout=2):
+        return {"items": list(self._directives)}
+
+    def recall(self, bank_id, query, **kwargs):
+        with self._lock:
+            self.recall_calls.append(bank_id)
+        sleep_s = self._bank_sleep.get(bank_id, 0.0)
+        if sleep_s:
+            time.sleep(sleep_s)
+        return {"results": list(self._bank_results.get(bank_id, []))}
+
+
+def _nested_line(role, text):
+    """One Claude Code nested-format transcript line."""
+    return json.dumps({
+        "type": role,
+        "uuid": f"u-{abs(hash((role, text))) % 10_000_000}",
+        "message": {"role": role, "content": text},
+    })
+
+
+class _Harness(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="recall-fallback-test-")
+        self._prev = os.environ.get("CLAUDE_PLUGIN_DATA")
+        os.environ["CLAUDE_PLUGIN_DATA"] = self._tmpdir
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        if self._prev is None:
+            os.environ.pop("CLAUDE_PLUGIN_DATA", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_DATA"] = self._prev
+
+    def _write_transcript(self, lines):
+        path = os.path.join(self._tmpdir, "transcript.jsonl")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+        return path
+
+    def _read_log(self):
+        path = os.path.join(self._tmpdir, "state", "recall_log.jsonl")
+        if not os.path.isfile(path):
+            return []
+        with open(path, encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def _run(self, client, config_extra=None, prompt=BARE, transcript_path=""):
+        hook_input = {
+            "prompt": prompt,
+            "session_id": "test-session",
+            "transcript_path": transcript_path,
+            "cwd": "/tmp",
+        }
+        config = {
+            "autoRecall": True,
+            "bankId": "own-bank",
+            "recallMaxTokens": 1024,
+            "recallBudget": "mid",
+            "recallContextTurns": 1,
+            "recallMaxQueryChars": 800,
+            "recallPromptPreamble": "",
+            # Keep the shared deadline generous unless a test overrides it.
+            "recallParallelDeadlineSeconds": 5,
+            # Fallback bounds (defaults mirror config.py; explicit for clarity).
+            "recallTranscriptFallback": True,
+            "recallTranscriptFallbackMaxBytes": 262144,
+            "recallTranscriptFallbackMaxTurns": 6,
+            "recallTranscriptFallbackMaxChars": 2000,
+            "recallTranscriptFallbackDeadlineMs": 1500,
+        }
+        if config_extra:
+            config.update(config_extra)
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with patch.object(recall, "load_config", return_value=config), patch.object(
+            recall, "get_api_url", return_value="http://localhost:18888"
+        ), patch.object(recall, "HindsightClient", return_value=client), patch.object(
+            recall, "ensure_bank_mission", return_value=None
+        ), patch.object(recall, "write_state", return_value=None), patch(
+            "sys.stdin", new=io.StringIO(json.dumps(hook_input))
+        ), patch("sys.stdout", new=stdout), patch("sys.stderr", new=stderr):
+            recall.main()
+        raw = stdout.getvalue()
+        context = None
+        if raw.strip():
+            context = json.loads(raw)["hookSpecificOutput"]["additionalContext"]
+        return context
+
+
+class FiresOnEmptyFactLayer(_Harness):
+    def test_fires_when_all_banks_zero_and_no_deadline_hit(self):
+        transcript = self._write_transcript([
+            _nested_line("user", "hello there"),
+            _nested_line("user", "we should redo the auth flow with PKCE"),
+            _nested_line("assistant", "agreed, the auth flow now uses PKCE"),
+            _nested_line("user", "thanks"),
+        ])
+        client = _Client(bank_results={"own-bank": []})
+        context = self._run(client, transcript_path=transcript)
+
+        self.assertIsNotNone(context, "fallback should have produced context")
+        self.assertIn("<hindsight_transcript_fallback>", context)
+        self.assertIn("PKCE", context)
+        # Chronological order preserved (user turn before assistant turn).
+        self.assertLess(
+            context.index("we should redo the auth flow"),
+            context.index("the auth flow now uses PKCE"),
+        )
+
+        e = self._read_log()[0]
+        self.assertTrue(e["transcript_fallback"])
+        self.assertGreaterEqual(e["transcript_fallback_turns"], 2)
+        self.assertGreater(e["transcript_fallback_chars"], 0)
+        self.assertFalse(e["deadline_hit"])
+        self.assertEqual(e["result_count"], 0)
+
+    def test_no_match_in_transcript_does_not_fire(self):
+        # Transcript turns share NO terms with the auth-flow query.
+        transcript = self._write_transcript([
+            _nested_line("user", "what should we cook for dinner tonight"),
+            _nested_line("assistant", "maybe a pasta with roasted vegetables"),
+        ])
+        client = _Client(bank_results={"own-bank": []})
+        context = self._run(client, transcript_path=transcript)
+        self.assertIsNone(context)
+        e = self._read_log()[0]
+        self.assertFalse(e["transcript_fallback"])
+        self.assertEqual(e["transcript_fallback_turns"], 0)
+
+
+class DoesNotFireWhenFactLayerNotEmpty(_Harness):
+    def test_bank_returned_memories_suppresses_fallback(self):
+        transcript = self._write_transcript([
+            _nested_line("user", "we should redo the auth flow with PKCE"),
+        ])
+        client = _Client(bank_results={"own-bank": [_memory("auth uses PKCE", "m1")]})
+        context = self._run(client, transcript_path=transcript)
+        self.assertIsNotNone(context)
+        self.assertIn("<hindsight_memories>", context)
+        self.assertNotIn("<hindsight_transcript_fallback>", context)
+        e = self._read_log()[0]
+        self.assertFalse(e["transcript_fallback"])
+        self.assertEqual(e["result_count"], 1)
+
+
+class DoesNotFireWhenDeadlineHit(_Harness):
+    def test_timed_out_bank_suppresses_fallback(self):
+        transcript = self._write_transcript([
+            _nested_line("user", "we should redo the auth flow with PKCE"),
+        ])
+        # Own bank returns zero fast; an extra bank sleeps past the 0.5s
+        # deadline → abandoned → deadline_hit True even though results are empty.
+        client = _Client(
+            bank_sleep={"own-bank": 0.0, "slow-bank": 3.0},
+            bank_results={"own-bank": [], "slow-bank": []},
+        )
+        context = self._run(
+            client,
+            transcript_path=transcript,
+            config_extra={
+                "recallAdditionalBanks": ["slow-bank"],
+                "recallParallelDeadlineSeconds": 0.5,
+            },
+        )
+        self.assertIsNone(context, "fallback must not fire when a bank timed out")
+        e = self._read_log()[0]
+        self.assertTrue(e["deadline_hit"])
+        self.assertFalse(e["transcript_fallback"])
+
+
+class BoundsHold(_Harness):
+    def test_byte_bound_only_reads_tail(self):
+        # A query-matching line in the HEAD, padded past the byte window, must
+        # not be surfaced; a recent matching line must be.
+        pad = _nested_line("assistant", "filler noise " * 40)
+        head = _nested_line("user", "the OLD auth flow decision was OAuth1")
+        lines = [head] + [pad] * 60 + [
+            _nested_line("user", "the NEW auth flow uses PKCE tokens"),
+        ]
+        transcript = self._write_transcript(lines)
+        client = _Client(bank_results={"own-bank": []})
+        # 4 KiB tail — comfortably smaller than the head+padding above it.
+        context = self._run(
+            client,
+            transcript_path=transcript,
+            config_extra={"recallTranscriptFallbackMaxBytes": 4096},
+        )
+        self.assertIsNotNone(context)
+        self.assertIn("PKCE tokens", context)
+        self.assertNotIn("OAuth1", context)
+        e = self._read_log()[0]
+        self.assertTrue(e["transcript_fallback"])
+        self.assertLessEqual(e["transcript_fallback_bytes_read"], 4096)
+
+    def test_turn_bound_caps_matched_turns(self):
+        # Ten matching turns, but MaxTurns=3 → at most 3 injected.
+        lines = [
+            _nested_line("user", f"auth flow revision number {i}")
+            for i in range(10)
+        ]
+        transcript = self._write_transcript(lines)
+        client = _Client(bank_results={"own-bank": []})
+        context = self._run(
+            client,
+            transcript_path=transcript,
+            config_extra={"recallTranscriptFallbackMaxTurns": 3},
+        )
+        self.assertIsNotNone(context)
+        e = self._read_log()[0]
+        self.assertEqual(e["transcript_fallback_turns"], 3)
+
+    def test_char_bound_truncates(self):
+        big = "auth flow " + ("detail " * 400)  # ~2800 chars, one turn
+        transcript = self._write_transcript([_nested_line("user", big)])
+        client = _Client(bank_results={"own-bank": []})
+        context = self._run(
+            client,
+            transcript_path=transcript,
+            config_extra={"recallTranscriptFallbackMaxChars": 300},
+        )
+        self.assertIsNotNone(context)
+        e = self._read_log()[0]
+        self.assertTrue(e["transcript_fallback"])
+        self.assertTrue(e["transcript_fallback_truncated"])
+        # The injected excerpt characters are bounded by the cap (the wrapper
+        # block adds the fixed preamble/tags around it).
+        self.assertLessEqual(e["transcript_fallback_chars"], 300 + len(recall._FALLBACK_BLOCK_PREAMBLE) + 200)
+
+
+class ConfigGate(_Harness):
+    def test_disabled_by_config(self):
+        transcript = self._write_transcript([
+            _nested_line("user", "we should redo the auth flow with PKCE"),
+        ])
+        client = _Client(bank_results={"own-bank": []})
+        context = self._run(
+            client,
+            transcript_path=transcript,
+            config_extra={"recallTranscriptFallback": False},
+        )
+        self.assertIsNone(context)
+        e = self._read_log()[0]
+        self.assertFalse(e["transcript_fallback"])
+
+    def test_no_transcript_path_is_safe(self):
+        client = _Client(bank_results={"own-bank": []})
+        context = self._run(client, transcript_path="")
+        self.assertIsNone(context)
+        e = self._read_log()[0]
+        self.assertFalse(e["transcript_fallback"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_recall_transcript_fallback.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_transcript_fallback.py
@@ -64,10 +64,14 @@ def _memory(text, mem_id=None):
 class _Client:
     """Fake HindsightClient with per-bank sleep + result control."""
 
-    def __init__(self, bank_sleep=None, bank_results=None, directives=None):
+    def __init__(self, bank_sleep=None, bank_results=None, directives=None,
+                 bank_errors=None):
         self._bank_sleep = bank_sleep or {}
         self._bank_results = bank_results or {}
         self._directives = directives or []
+        # {bank_id: Exception instance} — raised (hard, non-timeout error) to
+        # simulate a connection-refused / 5xx / daemon-down outage.
+        self._bank_errors = bank_errors or {}
         self._lock = threading.Lock()
         self.recall_calls = []
 
@@ -80,6 +84,9 @@ class _Client:
         sleep_s = self._bank_sleep.get(bank_id, 0.0)
         if sleep_s:
             time.sleep(sleep_s)
+        err = self._bank_errors.get(bank_id)
+        if err is not None:
+            raise err
         return {"results": list(self._bank_results.get(bank_id, []))}
 
 
@@ -242,6 +249,74 @@ class DoesNotFireWhenDeadlineHit(_Harness):
         self.assertFalse(e["transcript_fallback"])
 
 
+class DoesNotFireWhenBankErrored(_Harness):
+    """PR8 gating-hole fix — a HARD (non-timeout) bank error contributes zero
+    results with deadline_hit False. The fallback must be suppressed: an
+    unreachable fact layer is NOT a genuinely empty one, and firing every turn
+    during an outage would flood telemetry and mislabel the cause."""
+
+    def test_errored_bank_suppresses_fallback_parallel(self):
+        transcript = self._write_transcript([
+            _nested_line("user", "we should redo the auth flow with PKCE"),
+        ])
+        # Own bank raises a hard, non-timeout error (connection refused).
+        client = _Client(
+            bank_errors={"own-bank": ConnectionRefusedError("connection refused")},
+        )
+        context = self._run(client, transcript_path=transcript)
+        self.assertIsNone(context, "fallback must not fire when a bank hard-errored")
+        e = self._read_log()[0]
+        self.assertTrue(e["bank_errored"])
+        self.assertFalse(e["deadline_hit"])
+        self.assertFalse(e["transcript_fallback"])
+        self.assertEqual(e["result_count"], 0)
+
+    def test_errored_bank_suppresses_fallback_serial(self):
+        transcript = self._write_transcript([
+            _nested_line("user", "we should redo the auth flow with PKCE"),
+        ])
+        client = _Client(
+            bank_errors={"own-bank": RuntimeError("upstream 503 service unavailable")},
+        )
+        context = self._run(
+            client,
+            transcript_path=transcript,
+            config_extra={"recallParallel": False},
+        )
+        self.assertIsNone(context, "fallback must not fire when a bank hard-errored")
+        e = self._read_log()[0]
+        self.assertEqual(e["recall_mode"], "serial")
+        self.assertTrue(e["bank_errored"])
+        self.assertFalse(e["deadline_hit"])
+        self.assertFalse(e["transcript_fallback"])
+
+
+class FiresInSerialMode(_Harness):
+    """Rollback (serial) mode gates the fallback identically to parallel mode:
+    on an all-zero, no-timeout, no-error turn it fires; the mode is only a
+    latency lever, not a behavioural one."""
+
+    def test_fires_when_all_banks_zero_serial(self):
+        transcript = self._write_transcript([
+            _nested_line("user", "we should redo the auth flow with PKCE"),
+            _nested_line("assistant", "agreed, the auth flow now uses PKCE"),
+        ])
+        client = _Client(bank_results={"own-bank": []})
+        context = self._run(
+            client,
+            transcript_path=transcript,
+            config_extra={"recallParallel": False},
+        )
+        self.assertIsNotNone(context, "fallback should fire in serial mode too")
+        self.assertIn("<hindsight_transcript_fallback>", context)
+        self.assertIn("PKCE", context)
+        e = self._read_log()[0]
+        self.assertEqual(e["recall_mode"], "serial")
+        self.assertTrue(e["transcript_fallback"])
+        self.assertFalse(e["deadline_hit"])
+        self.assertFalse(e["bank_errored"])
+
+
 class BoundsHold(_Harness):
     def test_byte_bound_only_reads_tail(self):
         # A query-matching line in the HEAD, padded past the byte window, must
@@ -296,9 +371,19 @@ class BoundsHold(_Harness):
         e = self._read_log()[0]
         self.assertTrue(e["transcript_fallback"])
         self.assertTrue(e["transcript_fallback_truncated"])
-        # The injected excerpt characters are bounded by the cap (the wrapper
-        # block adds the fixed preamble/tags around it).
-        self.assertLessEqual(e["transcript_fallback_chars"], 300 + len(recall._FALLBACK_BLOCK_PREAMBLE) + 200)
+        # The injected excerpt characters are bounded by the cap. The emitted
+        # block is: the fixed wrapper tags + preamble, plus the excerpt whose
+        # length is capped at MaxChars (300). We compute the EXACT wrapper
+        # overhead so a cap breach (e.g. the off-by-one that made a truncated
+        # entry cap+1 chars) would actually fail this assertion — the previous
+        # `+ 200` slack was loose enough to swallow such a breach.
+        wrapper = len(
+            "<hindsight_transcript_fallback>\n"
+            + recall._FALLBACK_BLOCK_PREAMBLE
+            + "\n\n"
+            + "\n</hindsight_transcript_fallback>"
+        )
+        self.assertLessEqual(e["transcript_fallback_chars"], 300 + wrapper)
 
 
 class ConfigGate(_Harness):


### PR DESCRIPTION
## What & why

Workstream **E1** of the hindsight leverage programme epic (#3430), closing #3369.

Between an abrupt session death (SIGKILL/OOM/watchdog) and the next boot, `reconcile_tail.py` has not yet re-committed the lost transcript tail, so **live recall returns nothing** for those turns — the fact layer is empty even though the conversation happened. Boot reconciliation only closes this window at the *next* SessionStart; there was no recall-time fallback.

This adds a **bounded transcript-grep fallback** in `recall.py` (Option B in the #3369 / #3244 design) that greps the CURRENT session's transcript tail for turns whose terms lexically overlap the recall query and injects them as a clearly-labelled, lower-confidence `<hindsight_transcript_fallback>` block.

## Firing condition (both required)

- **All banks returned zero results** (`pre_filter_count == 0`, the merged pre-demote bank count), AND
- **`deadline_hit` is False** — no bank/directives slot hit its deadline. A timed-out bank must NOT masquerade as a genuinely empty fact layer. This is the #3369 sequencing constraint and the reason PR 8 stacks on PR 3's shared-deadline telemetry.

## Bounds (all config-gated, env-overridable)

- `recallTranscriptFallbackMaxBytes` (256 KiB) — tail read only, via the seek/discard-partial-line machinery mirrored from `retain.read_transcript` (the #3443 tail-read pattern; #3443 is not yet in this branch's base, so the equivalent reader is reused rather than imported).
- `recallTranscriptFallbackMaxTurns` (6) — matched turns cap.
- `recallTranscriptFallbackMaxChars` (2000) — emitted excerpt cap.
- `recallTranscriptFallbackDeadlineMs` (1500) — grep wall-time cap.
- `recallTranscriptFallback` (default on); `HINDSIGHT_RECALL_TRANSCRIPT_FALLBACK=false` is the rollback lever.

## Telemetry

`recall_log.jsonl` rows now carry `transcript_fallback{,_turns,_chars,_bytes_read,_elapsed_ms,_truncated}` so firing and bounds are visible per turn (uniform schema across miss / cache-hit rows).

## Tests (assert outcomes)

`tests/test_recall_transcript_fallback.py` — 9 tests: fires on all-zero + no-deadline-hit with a matching transcript (chronological order preserved); does NOT fire when a bank returned memories or when a bank timed out; byte bound (head-only match excluded), turn bound, char bound + truncation flag; config gate + relevance (no-overlap) gate; empty-transcript-path safety.

Scoped suite green: `python3 -m unittest discover -s vendor/hindsight-memory/scripts/tests` → **386 tests OK**.

## Stacking

Branched off **`feat/parallel-multibank-recall`** (PR 3, #3445, currently draft held behind a telemetry gate) — both rework `recall.py`. Base retargets to `main` automatically when #3445 merges. **Draft — merge held behind #3445's gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)