### PR TITLE
feat(auth): show retired accounts as RETIRED, not "available"

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -168,6 +168,23 @@ export interface AccountState {
   label: string;
   expiresAt?: number;
   exhausted: boolean;
+  /**
+   * Fleet in-service classification: TRUE when the config still routes to this
+   * account (it is the active, a `fallback_order` candidate, or an agent /
+   * consumer pin). FALSE → RETIRED — the credentials still sit on disk but the
+   * fleet no longer routes to it, so every account view must render it "retired"
+   * rather than "available". Absent on a pre-field broker (treat absent as
+   * in-service — only an explicit `false` retires an account, so a broker that
+   * predates this field never falsely retires the whole fleet).
+   */
+  in_service?: boolean;
+  /**
+   * Org / entitlement-level block: TRUE when Anthropic reports the account
+   * disabled at the organization level (populated by the entitlement probe in
+   * PR2). Renders as "DISABLED (org)" and OUTRANKS `in_service` retirement.
+   * Absent / false on a pre-PR2 broker (treat as not-blocked).
+   */
+  entitlement_blocked?: boolean;
   exhausted_until?: number;
   /**
    * 429 throttle tier — unix ms until which the account is transiently

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -464,13 +464,17 @@ export const AccountStateSchema = z.object({
    *  account (it is the active, a `fallback_order` candidate, or an agent /
    *  consumer pin). FALSE → RETIRED: credentials linger on disk but the fleet no
    *  longer routes to it, so the account views render it "retired", never
-   *  "available". Optional (default false) for pre-field brokers. */
-  in_service: z.boolean().optional().default(false),
+   *  "available". Optional: ABSENT means in-service — only an explicit `false`
+   *  retires, so a pre-field broker (no field) never retires the fleet. Do NOT
+   *  add `.default(false)`: if a decode path ever parses this schema, a default
+   *  would silently coerce absent→false and retire every account. */
+  in_service: z.boolean().optional(),
   /** Org / entitlement-level block: TRUE when Anthropic reports the account
    *  disabled at the organization level (the entitlement probe, populated by
-   *  PR2). Renders as "DISABLED (org)" and outranks RETIRED. Optional
-   *  (default false); a pre-PR2 broker reports every account un-blocked. */
-  entitlement_blocked: z.boolean().optional().default(false),
+   *  PR2). Renders as "DISABLED (org)" and outranks RETIRED. Optional: absent /
+   *  a pre-PR2 broker reports every account un-blocked (only explicit `true`
+   *  blocks). No `.default(false)` — same decode-path safety as `in_service`. */
+  entitlement_blocked: z.boolean().optional(),
   exhausted_until: z.number().optional(),
   /** 429 throttle tier — unix ms until which the account is transiently
    *  rate-limited (`mark-throttled`). Informational: never gates serving

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -460,6 +460,17 @@ export const AccountStateSchema = z.object({
   label: z.string(),
   expiresAt: z.number().optional(),
   exhausted: z.boolean(),
+  /** Fleet in-service classification: TRUE when the config still routes to this
+   *  account (it is the active, a `fallback_order` candidate, or an agent /
+   *  consumer pin). FALSE → RETIRED: credentials linger on disk but the fleet no
+   *  longer routes to it, so the account views render it "retired", never
+   *  "available". Optional (default false) for pre-field brokers. */
+  in_service: z.boolean().optional().default(false),
+  /** Org / entitlement-level block: TRUE when Anthropic reports the account
+   *  disabled at the organization level (the entitlement probe, populated by
+   *  PR2). Renders as "DISABLED (org)" and outranks RETIRED. Optional
+   *  (default false); a pre-PR2 broker reports every account un-blocked. */
+  entitlement_blocked: z.boolean().optional().default(false),
   exhausted_until: z.number().optional(),
   /** 429 throttle tier — unix ms until which the account is transiently
    *  rate-limited (`mark-throttled`). Informational: never gates serving

--- a/src/auth/broker/server-list-state-in-service.test.ts
+++ b/src/auth/broker/server-list-state-in-service.test.ts
@@ -1,0 +1,199 @@
+/**
+ * `list-state` in-service classification (retired-account display, PR1).
+ *
+ * The bug: a disabled/retired Anthropic account — removed from `fallback_order`
+ * and every per-agent / consumer pin — still had its credentials on disk, so the
+ * account views listed it as "available". `list-state` now stamps each account
+ * with `in_service` = membership in the fleet's routing set (active ∪
+ * fallback_order ∪ agent `auth.override` ∪ consumer pins). An account absent from
+ * that set reports `in_service: false` → the renderers show RETIRED.
+ *
+ * `entitlement_blocked` is DEFINED here (schema + wire) but PR2 populates it; a
+ * pre-PR2 broker must report every account `entitlement_blocked: false`, which
+ * these tests pin.
+ *
+ * Tmpdir-isolation strategy mirrors server-active-override.test.ts (never
+ * touches ~/.switchroom).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as net from "node:net";
+
+import { AuthBroker } from "./server.js";
+import { decodeResponse, encodeRequest } from "./protocol.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import { writeAccountCredentials } from "../account-store.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-list-state-in-service-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try { rmSync(h.tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  harnesses = [];
+});
+
+interface ConfigShape {
+  active?: string;
+  fallback_order?: string[];
+  agents?: Record<string, { auth?: { override?: string } }>;
+  consumers?: Array<{ name: string; account?: string }>;
+}
+
+function makeConfig(h: Harness, overrides: ConfigShape = {}): SwitchroomConfig {
+  return ({
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents: overrides.agents ?? {},
+    auth: {
+      active: overrides.active,
+      fallback_order: overrides.fallback_order,
+      consumers: overrides.consumers,
+    },
+  } as unknown) as SwitchroomConfig;
+}
+
+async function rpc(socketPath: string, req: object): Promise<unknown> {
+  return await new Promise<unknown>((resolveP, rejectP) => {
+    const c = net.createConnection(socketPath);
+    let buf = "";
+    let settled = false;
+    const settle = (v: unknown, err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      try { c.destroy(); } catch { /* ignore */ }
+      if (err) rejectP(err); else resolveP(v);
+    };
+    c.on("connect", () => {
+      c.write(encodeRequest(req as Parameters<typeof encodeRequest>[0]));
+    });
+    c.on("data", (chunk) => {
+      buf += chunk.toString("utf-8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        try { settle(decodeResponse(buf.slice(0, nl))); } catch (err) { settle(null, err as Error); }
+      }
+    });
+    c.on("error", (err) => settle(null, err));
+    setTimeout(() => settle(null, new Error("rpc timeout")), 3000);
+  });
+}
+
+function seedAccount(h: Harness, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: `at-${label}`,
+        refreshToken: `rt-${label}`,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    },
+    h.home,
+  );
+}
+
+interface AccountRow {
+  label: string;
+  in_service?: boolean;
+  entitlement_blocked?: boolean;
+}
+
+async function listAccountsState(h: Harness, agent: string): Promise<AccountRow[]> {
+  const resp = await rpc(join(h.socketRoot, agent, "sock"), {
+    v: 1, id: "ls", op: "list-state",
+  }) as { ok: boolean; data: { accounts: AccountRow[] } };
+  expect(resp.ok).toBe(true);
+  return resp.data.accounts;
+}
+
+describe("list-state — in_service classification", () => {
+  it("marks the active, fallback, agent-override, and consumer-pinned accounts in-service; a stored-but-unlisted account RETIRED", async () => {
+    const h = makeHarness();
+    // Five stored accounts on disk. `retired` is removed from every config list.
+    seedAccount(h, "active-acct");
+    seedAccount(h, "fallback-acct");
+    seedAccount(h, "agent-pin");
+    seedAccount(h, "consumer-pin");
+    seedAccount(h, "retired");
+    mkdirSync(join(h.agentsDir, "worker"), { recursive: true });
+
+    const config = makeConfig(h, {
+      active: "active-acct",
+      fallback_order: ["active-acct", "fallback-acct"],
+      agents: { worker: { auth: { override: "agent-pin" } } },
+      consumers: [{ name: "sidecar", account: "consumer-pin" }],
+    });
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+    try {
+      const accounts = await listAccountsState(h, "worker");
+      const byLabel = new Map(accounts.map((a) => [a.label, a]));
+
+      // Every account the config still routes to → in_service TRUE.
+      expect(byLabel.get("active-acct")?.in_service).toBe(true);
+      expect(byLabel.get("fallback-acct")?.in_service).toBe(true);
+      expect(byLabel.get("agent-pin")?.in_service).toBe(true);
+      expect(byLabel.get("consumer-pin")?.in_service).toBe(true);
+
+      // The account dropped from every list → in_service FALSE (RETIRED). This
+      // is the bug: its credentials are still on disk, but it must not read as
+      // available.
+      expect(byLabel.get("retired")?.in_service).toBe(false);
+    } finally {
+      broker.stop();
+    }
+  });
+
+  it("reports entitlement_blocked=false for every account (PR1 leaves it un-populated)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "active-acct");
+    seedAccount(h, "retired");
+    mkdirSync(join(h.agentsDir, "worker"), { recursive: true });
+    const config = makeConfig(h, {
+      active: "active-acct",
+      fallback_order: ["active-acct"],
+      agents: { worker: {} },
+    });
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+    try {
+      const accounts = await listAccountsState(h, "worker");
+      for (const a of accounts) {
+        expect(a.entitlement_blocked).toBe(false);
+      }
+    } finally {
+      broker.stop();
+    }
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -2072,6 +2072,11 @@ export class AuthBroker {
     identity: Identity,
   ): Promise<void> {
     const auth = this.config.auth ?? {};
+    // The config's in-service account set (active ∪ fallback_order ∪ agent
+    // overrides ∪ consumer pins). An account absent from this set is RETIRED —
+    // its credentials linger on disk but the fleet no longer routes to it, so
+    // the views must not render it as "available". Computed once per call.
+    const inService = this.inServiceSet();
     const accounts = listAccounts(this.home).map((label) => {
       const creds = readAccountCredentials(label, this.home);
       const meta = readAccountMeta(label, this.home);
@@ -2086,6 +2091,15 @@ export class AuthBroker {
         label,
         expiresAt: creds?.claudeAiOauth?.expiresAt,
         exhausted,
+        // Fleet in-service classification: true when the config still routes to
+        // this account. false → RETIRED (removed from rotation); the views
+        // render it as such instead of "available".
+        in_service: inService.has(label),
+        // #org-disable — populated by PR2 (the entitlement/org-level block
+        // probe). Left false here; a pre-PR2 broker reports every account
+        // un-blocked, and RETIRED classification works standalone off
+        // `in_service` regardless.
+        entitlement_blocked: false,
         exhausted_until: q?.exhausted_until,
         // 429 throttle tier — raw ledger value for transparency (consumers
         // compare against their own clock). Never feeds `exhausted`.
@@ -2567,6 +2581,27 @@ export class AuthBroker {
     if (active) set.add(active);
     for (const cand of this.config.auth?.fallback_order ?? []) set.add(cand);
     for (const acct of this.pinnedAgentAccounts()) set.add(acct);
+    return set;
+  }
+
+  /**
+   * The fleet's IN-SERVICE account set — every account the config still routes
+   * traffic to: the fleet active, every `fallback_order` candidate, every
+   * per-agent `auth.override` pin, and every consumer pin
+   * (`auth.consumers[].account`). An account NOT in this set has been fully
+   * removed from rotation (dropped from `fallback_order` and every agent /
+   * consumer pin) — it is RETIRED, and the account views must render it as such
+   * rather than "available", even though its credentials still sit on disk.
+   *
+   * Superset of {@link premiumCanarySet} (adds consumer pins). Built ON TOP of
+   * it deliberately: the flagship-canary probe scope (bounded by
+   * `premiumCanarySet`) is unchanged by this display-only classifier.
+   */
+  private inServiceSet(): Set<string> {
+    const set = this.premiumCanarySet();
+    for (const c of this.config.auth?.consumers ?? []) {
+      if (c.account) set.add(c.account);
+    }
     return set;
   }
 

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.18.0";
-export const COMMIT_SHA: string | null = "440bd187";
-export const COMMIT_DATE: string | null = "2026-07-20T09:16:08+10:00";
-export const LATEST_PR: number | null = 3446;
-export const COMMITS_AHEAD_OF_TAG: number | null = 12;
+export const COMMIT_SHA: string | null = "037ba5ab";
+export const COMMIT_DATE: string | null = "2026-07-20T10:16:08+10:00";
+export const LATEST_PR: number | null = null;
+export const COMMITS_AHEAD_OF_TAG: number | null = 13;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.18.0";
-export const COMMIT_SHA: string | null = "5584bf20";
-export const COMMIT_DATE: string | null = "2026-07-11T19:02:16+10:00";
-export const LATEST_PR: number | null = 3097;
-export const COMMITS_AHEAD_OF_TAG: number | null = 42;
+export const COMMIT_SHA: string | null = "440bd187";
+export const COMMIT_DATE: string | null = "2026-07-20T09:16:08+10:00";
+export const LATEST_PR: number | null = 3446;
+export const COMMITS_AHEAD_OF_TAG: number | null = 12;

--- a/src/cli/auth-schedule.test.ts
+++ b/src/cli/auth-schedule.test.ts
@@ -252,6 +252,8 @@ describe("#2494 — formatStateCell: out_of_credits informational annotation, no
     label: "x",
     isActive: false,
     fallbackRank: 2,
+    inService: true,
+    entitlementBlocked: false,
     window,
     exhausted: false,
     exhaustedUntil: null,
@@ -446,6 +448,8 @@ describe("formatStateCell horizon", () => {
       label: "x",
       isActive: false,
       fallbackRank: 2,
+      inService: true,
+      entitlementBlocked: false,
       window: {
         fiveHourPct: 0,
         fiveHourResetAt: new Date("2026-06-07T06:27:00Z"),
@@ -473,6 +477,8 @@ describe("formatStateCell horizon", () => {
       label: "x",
       isActive: false,
       fallbackRank: 2,
+      inService: true,
+      entitlementBlocked: false,
       window: {
         ...NONE,
         fiveHourPct: 0,
@@ -584,5 +590,116 @@ describe("#2500 — formatFooter does not stamp 'probed live' on a cache-served 
     const footer = formatFooter(emptyRows, { liveRequested: false, probedLive: false }, NOW);
     expect(footer[0]).toContain("cached snapshot");
     expect(footer[0]).not.toContain("probed live");
+  });
+});
+
+// ── retired / org-disabled account display (PR1) ──────────────────────────
+describe("classifyState — retired / org-disabled precedence", () => {
+  const healthyWin = (): WindowSnapshot => ({
+    ...NONE,
+    fiveHourPct: 0,
+    weeklyPct: 0,
+    fiveHourResetAt: FIVE_RESET,
+    weeklyResetAt: WEEKLY_RESET,
+    source: "live",
+  });
+
+  it("inService=false → 'retired' even with a fully-healthy window (never available)", () => {
+    const state = classifyState({
+      exhausted: false,
+      exhaustedUntil: null,
+      window: healthyWin(),
+      now: NOW,
+      inService: false,
+    });
+    expect(state).toBe("retired");
+    expect(state).not.toBe("healthy");
+  });
+
+  it("entitlementBlocked=true → 'org-disabled', outranking retirement AND healthy", () => {
+    expect(
+      classifyState({
+        exhausted: false,
+        exhaustedUntil: null,
+        window: healthyWin(),
+        now: NOW,
+        inService: false,
+        entitlementBlocked: true,
+      }),
+    ).toBe("org-disabled");
+  });
+
+  it("omitted inService (pre-field data) does NOT retire — classifies off the window", () => {
+    expect(
+      classifyState({
+        exhausted: false,
+        exhaustedUntil: null,
+        window: healthyWin(),
+        now: NOW,
+      }),
+    ).toBe("healthy");
+  });
+});
+
+describe("formatStateCell — retired / org-disabled labels", () => {
+  const mk = (state: ScheduleRow["state"], over: Partial<ScheduleRow> = {}): ScheduleRow => ({
+    label: "retired@example.com",
+    isActive: false,
+    fallbackRank: null,
+    inService: state !== "retired",
+    entitlementBlocked: state === "org-disabled",
+    window: NONE,
+    exhausted: false,
+    exhaustedUntil: null,
+    state,
+    ...over,
+  });
+
+  it("retired → plain 'retired' with no reset countdown", () => {
+    const cell = formatStateCell(mk("retired"), NOW);
+    expect(cell).toBe("retired");
+    expect(cell).not.toMatch(/\d+[dhm]/);
+  });
+
+  it("org-disabled → 'DISABLED (org)'", () => {
+    expect(formatStateCell(mk("org-disabled"), NOW)).toBe("DISABLED (org)");
+  });
+});
+
+describe("buildScheduleRows — retired classification, pool label, and last-sort", () => {
+  function stateWithRetired(): ListStateData {
+    return {
+      active: "active-acct",
+      fallback_order: ["active-acct"],
+      accounts: [
+        // A retired account seeded FIRST to prove it is sorted LAST, not by input order.
+        { label: "retired-acct", exhausted: false, in_service: false },
+        { label: "active-acct", exhausted: false, in_service: true },
+      ],
+      agents: [],
+      consumers: [],
+    } as ListStateData;
+  }
+
+  const rows = buildScheduleRows(stateWithRetired(), undefined, NOW);
+
+  it("classifies the out-of-service account as 'retired'", () => {
+    const retired = rows.find((r) => r.label === "retired-acct")!;
+    expect(retired.state).toBe("retired");
+    expect(retired.inService).toBe(false);
+  });
+
+  it("sorts the retired account LAST (after the active account)", () => {
+    expect(rows[0].label).toBe("active-acct");
+    expect(rows[rows.length - 1].label).toBe("retired-acct");
+  });
+
+  it("labels the retired row 'retired' in the rendered pool column, never 'excluded'/'available'", () => {
+    const lines = formatScheduleRows(rows, NOW, { color: false, tz: "UTC" });
+    const retiredLine = lines.find((l) => l.includes("retired-acct"))!;
+    expect(retiredLine).toContain("retired");
+    expect(retiredLine).not.toContain("excluded");
+    expect(retiredLine).not.toContain("available");
+    expect(retiredLine).not.toContain("healthy");
   });
 });

--- a/src/cli/auth-schedule.ts
+++ b/src/cli/auth-schedule.ts
@@ -73,6 +73,13 @@ function overageReasonBlocks(reason: string | null | undefined): boolean {
 }
 
 export type AccountWindowState =
+  // #org-disable — Anthropic reports the account disabled at the org level
+  // (entitlement block). Outranks every other state. Populated by PR2.
+  | "org-disabled"
+  // #retired — the config no longer routes to this account (removed from
+  // `fallback_order` and every agent / consumer pin). Out of service, NOT a
+  // quota problem — but must never read as available/healthy. Outranks quota.
+  | "retired"
   // #2494 Bug C — recoverable quota exhaustion: a util window is maxed but the
   // account comes back when that window rolls. Carries a reset countdown.
   | "quota-exhausted"
@@ -90,6 +97,11 @@ export interface ScheduleRow {
   isActive: boolean;
   /** 1-based position in fallback_order, or null when not listed. */
   fallbackRank: number | null;
+  /** Fleet in-service classification (from broker `in_service`). false →
+   *  RETIRED: the config no longer routes to this account. */
+  inService: boolean;
+  /** Org / entitlement-level block (from broker `entitlement_blocked`, PR2). */
+  entitlementBlocked: boolean;
   window: WindowSnapshot;
   exhausted: boolean;
   exhaustedUntil: Date | null;
@@ -167,8 +179,19 @@ export function classifyState(args: {
   exhaustedUntil: Date | null;
   window: WindowSnapshot;
   now: Date;
+  /** Fleet in-service flag. false → RETIRED (out of rotation). Defaults true
+   *  so a caller that omits it (pre-field data) never falsely retires. */
+  inService?: boolean;
+  /** Org-level entitlement block. true → DISABLED (org). Defaults false. */
+  entitlementBlocked?: boolean;
 }): AccountWindowState {
   const { exhausted, exhaustedUntil, window, now } = args;
+  // Precedence: DISABLED (org) > RETIRED > every quota/window state. An
+  // org-disabled or retired account is out of service regardless of its cached
+  // quota windows, and must never render as healthy/available. Only an explicit
+  // retirement (`inService === false`) retires — an omitted flag stays in-service.
+  if (args.entitlementBlocked === true) return "org-disabled";
+  if (args.inService === false) return "retired";
   // #2494 Bug C — a thin/headerless probe carries no real utilization; it must
   // not pose as a confident reading. Treat as unprobed (renders "unknown").
   if (window.probeThin) return "unprobed";
@@ -246,18 +269,37 @@ export function buildScheduleRows(
       typeof a.exhausted_until === "number" ? new Date(a.exhausted_until) : null;
     const exhausted = a.exhausted && (exhaustedUntil?.getTime() ?? 0) > now.getTime();
     const rank = state.fallback_order.indexOf(a.label);
+    const isActive = a.label === state.active;
+    // Only an explicit `in_service === false` retires (a pre-field broker omits
+    // the flag → treat as in-service). The active account is always in service
+    // and never org-disabled in the view (precedence: active outranks both).
+    const inService = isActive ? true : a.in_service !== false;
+    const entitlementBlocked = isActive ? false : a.entitlement_blocked === true;
     return {
       label: a.label,
-      isActive: a.label === state.active,
+      isActive,
       fallbackRank: rank === -1 ? null : rank + 1,
+      inService,
+      entitlementBlocked,
       window,
       exhausted,
       exhaustedUntil,
-      state: classifyState({ exhausted, exhaustedUntil, window, now }),
+      state: classifyState({
+        exhausted,
+        exhaustedUntil,
+        window,
+        now,
+        inService,
+        entitlementBlocked,
+      }),
     };
   });
-  // Pool priority: active first, then fallback_order rank, then excluded.
-  const key = (r: ScheduleRow) => (r.isActive ? -1 : (r.fallbackRank ?? 9999));
+  // Pool priority: active first, then fallback_order rank, then in-service
+  // "excluded" accounts, and RETIRED / org-disabled (out-of-service) rows LAST —
+  // they no longer carry pool priority at all.
+  const outOfService = (r: ScheduleRow) => !r.inService || r.entitlementBlocked;
+  const key = (r: ScheduleRow) =>
+    outOfService(r) ? 100_000 : r.isActive ? -1 : (r.fallbackRank ?? 9999);
   return rows.sort((a, b) => key(a) - key(b) || a.label.localeCompare(b.label));
 }
 
@@ -322,6 +364,11 @@ export function formatWeeklyCell(w: WindowSnapshot, now: Date, tz?: string): str
 }
 
 function poolLabel(row: ScheduleRow): string {
+  // Out-of-service accounts have no pool position — surface WHY (retired vs
+  // org-disabled) instead of the misleading "excluded", which reads like a
+  // deliberate-but-live exclusion rather than "removed from the fleet".
+  if (row.entitlementBlocked) return "disabled";
+  if (!row.inService) return "retired";
   if (row.isActive) return row.fallbackRank ? `active #${row.fallbackRank}` : "active";
   if (row.fallbackRank) return `#${row.fallbackRank}`;
   return "excluded";
@@ -351,6 +398,14 @@ export function formatStateCell(row: ScheduleRow, now: Date): string {
         ? " (overage off)"
         : "";
   switch (row.state) {
+    case "org-disabled":
+      // Disabled by Anthropic at the org level — no reset horizon, no overage
+      // note; the account is simply not serviceable until re-entitled.
+      return "DISABLED (org)";
+    case "retired":
+      // Out of fleet rotation (removed from config). Not a quota state — no
+      // reset countdown; the operator re-adds it to a pool to bring it back.
+      return "retired";
     case "quota-exhausted":
       // Recoverable: comes back when the 5h window rolls. Carries the reset
       // countdown. No overage annotation — quota exhaustion is the binding cause.
@@ -377,13 +432,24 @@ function pad(s: string, n: number): string {
 }
 
 function glyphFor(row: ScheduleRow, color: boolean): string {
-  const g = row.isActive ? "●" : row.exhausted ? "!" : row.state === "unprobed" ? "·" : "✓";
+  // Out-of-service glyphs never use the healthy "✓" — an org-disabled or retired
+  // account must not read as fine at a glance.
+  const g = row.isActive
+    ? "●"
+    : row.state === "org-disabled"
+      ? "⊘"
+      : row.state === "retired"
+        ? "∅"
+        : row.exhausted
+          ? "!"
+          : row.state === "unprobed"
+            ? "·"
+            : "✓";
   if (!color) return g;
-  return row.isActive
-    ? chalk.green(g)
-    : row.exhausted
-      ? chalk.red(g)
-      : chalk.gray(g);
+  if (row.isActive) return chalk.green(g);
+  if (row.state === "org-disabled") return chalk.red(g);
+  if (row.state === "retired") return chalk.gray(g);
+  return row.exhausted ? chalk.red(g) : chalk.gray(g);
 }
 
 function colorState(text: string, state: AccountWindowState, color: boolean): string {
@@ -391,12 +457,15 @@ function colorState(text: string, state: AccountWindowState, color: boolean): st
   switch (state) {
     case "healthy":
       return chalk.green(text);
+    case "org-disabled":
     case "weekly-walled":
       return chalk.red(text);
     case "quota-exhausted":
       return chalk.yellow(text);
     case "5h-walled":
       return chalk.yellow(text);
+    // "retired" and everything else → gray (out of service / unknown, not an
+    // active problem to action).
     default:
       return chalk.gray(text);
   }

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -298,18 +298,32 @@ function printAccountsTable(state: ListStateData): void {
     chalk.bold("  ACCOUNT                           STATUS       EXPIRES    QUOTA 5h·7d          QUOTA-RESET"),
   );
   for (const a of state.accounts) {
-    const marker =
-      a.label === state.active
-        ? chalk.green("●")
-        : a.exhausted
-          ? chalk.red("!")
-          : chalk.gray("✓");
-    const status =
-      a.label === state.active
-        ? chalk.green("active   ")
-        : a.exhausted
-          ? chalk.red("exhausted")
-          : "available";
+    // Status precedence: active > DISABLED (org) > RETIRED > exhausted >
+    // available. A retired account (removed from every config list — `!in_service`)
+    // and an org-disabled account both linger on disk but must never read
+    // "available". `in_service === false` (not `!in_service`) so a pre-field
+    // broker, which omits the flag, never falsely retires the fleet.
+    const isActive = a.label === state.active;
+    const orgBlocked = a.entitlement_blocked === true;
+    const retired = a.in_service === false;
+    const marker = isActive
+      ? chalk.green("●")
+      : orgBlocked
+        ? chalk.red("⊘")
+        : retired
+          ? chalk.gray("∅")
+          : a.exhausted
+            ? chalk.red("!")
+            : chalk.gray("✓");
+    const status = isActive
+      ? chalk.green("active   ")
+      : orgBlocked
+        ? chalk.red("DISABLED ")
+        : retired
+          ? chalk.gray("retired  ")
+          : a.exhausted
+            ? chalk.red("exhausted")
+            : "available";
     const label = a.label.padEnd(32);
     const exp = formatExpiry(a.expiresAt).padEnd(10);
     const util = formatQuotaUtilCell(a).padEnd(20);
@@ -386,8 +400,27 @@ function printUsageTable(state: ListStateData): void {
   );
   const WIDTH = 44;
   for (const a of state.accounts) {
-    const marker = a.label === state.active ? chalk.green("*") : " ";
+    const isActive = a.label === state.active;
+    const orgBlocked = a.entitlement_blocked === true;
+    const retired = a.in_service === false;
+    const marker = isActive
+      ? chalk.green("*")
+      : orgBlocked
+        ? chalk.red("⊘")
+        : retired
+          ? chalk.gray("∅")
+          : " ";
     const label = a.label.padEnd(32);
+    // Precedence DISABLED (org) > RETIRED: an out-of-service account's live
+    // headroom is meaningless (and misleading — it reads as available), so
+    // replace both cells with a single status note rather than a quota bar.
+    if (orgBlocked || retired) {
+      const note = orgBlocked
+        ? chalk.red("DISABLED (org) — no fleet routing")
+        : chalk.gray("retired — removed from fleet rotation");
+      console.log(`  ${marker} ${label} ${note}`);
+      continue;
+    }
     const premium = usageHeadroomCell(a.usage_ledger?.premium ?? null);
     const standard = usageHeadroomCell(a.usage_ledger?.standard ?? null);
     // Pad the PLAIN text to a fixed column, THEN color — ANSI escapes can never

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -26,8 +26,24 @@ import { escapeMarkdown, codeSpanSafe } from './card-format.js';
 
 // ── shared types ─────────────────────────────────────────────────────
 
-/** Tri-state health verdict per account, derived from live quota. */
-export type AccountHealth = 'healthy' | 'throttling' | 'blocked' | 'unknown';
+/**
+ * Health verdict per account. The first three are derived from live quota;
+ * `retired` and `org-blocked` are config/entitlement classifications that
+ * OUTRANK quota (an out-of-service account has no meaningful "health"):
+ *   - `org-blocked` — Anthropic disabled the account at the org level
+ *     (entitlement_blocked); renders "DISABLED (org)". Populated by PR2.
+ *   - `retired` — the config no longer routes to the account (`in_service`
+ *     false: removed from fallback_order + every agent/consumer pin). It must
+ *     never read as available/healthy, is sorted LAST, and is excluded from
+ *     the switch keyboard + the recommendation.
+ */
+export type AccountHealth =
+  | 'healthy'
+  | 'throttling'
+  | 'blocked'
+  | 'unknown'
+  | 'retired'
+  | 'org-blocked';
 
 /**
  * Combined per-account view used by every formatter in this module.
@@ -51,6 +67,19 @@ export interface AccountSnapshot {
    *  stale data as current; undefined for live-probe snapshots (fresh
    *  by construction). */
   capturedAtMs?: number;
+  /**
+   * Fleet in-service classification (broker `in_service`). TRUE when the config
+   * still routes to this account; `false` → RETIRED. Absent → treated as
+   * in-service (only an explicit `false` retires, so a pre-field broker never
+   * falsely retires the fleet). Drives the `retired` health verdict.
+   */
+  inService?: boolean;
+  /**
+   * Org / entitlement-level block (broker `entitlement_blocked`, populated by
+   * PR2). TRUE → `org-blocked` health verdict ("DISABLED (org)"), which OUTRANKS
+   * retirement. Absent / false on a pre-PR2 broker.
+   */
+  entitlementBlocked?: boolean;
 }
 
 // ── health classification ────────────────────────────────────────────
@@ -98,6 +127,18 @@ const OVERAGE_EXHAUSTED_REASONS = new Set<string>(['out_of_credits']);
  * Failover safety against a real 429 is preserved via the mark-exhausted path.
  */
 export function classifyHealth(snap: AccountSnapshot, now: Date = new Date()): AccountHealth {
+  // Precedence (config/entitlement outranks quota): active > DISABLED (org) >
+  // RETIRED > quota-derived health. The active account always keeps its
+  // quota-derived verdict (it is by definition in-service and never org-blocked
+  // in the view). For every non-active account, an org-level entitlement block
+  // wins over retirement, and either wins over the quota windows — an
+  // out-of-service account has no meaningful quota "health". Only an explicit
+  // `inService === false` retires (absent → in-service), so a pre-field broker
+  // never falsely retires the fleet.
+  if (!snap.isActive) {
+    if (snap.entitlementBlocked === true) return 'org-blocked';
+    if (snap.inService === false) return 'retired';
+  }
   if (!snap.quota) return 'unknown';
   const q = snap.quota;
   // #2494 Bug C — a thin/headerless probe (no real utilization signal on
@@ -308,6 +349,8 @@ const HEALTH_EMOJI: Record<AccountHealth, string> = {
   throttling: '🟡',
   blocked: '🔴',
   unknown: '⚪',
+  'org-blocked': '⛔',
+  retired: '⚫',
 };
 
 /**
@@ -331,6 +374,19 @@ function renderAccountRow(
   const lines: string[] = [];
   const marker = snap.isActive ? '● ' : '';
   const label = displayLabel(snap.label, opts);
+
+  // Out-of-service accounts (org-disabled / retired) outrank quota: their live
+  // windows are irrelevant and misleading (a retired account at 0%/0% reads as
+  // "available"), so render a single status note instead of a quota bar.
+  const health = classifyHealth(snap, now);
+  if (health === 'org-blocked' || health === 'retired') {
+    const note =
+      health === 'org-blocked'
+        ? 'DISABLED (org) — no fleet routing'
+        : 'retired — removed from fleet rotation';
+    lines.push(`${marker}\`${codeSpanSafe(label)}\`  _${note}_`);
+    return lines;
+  }
 
   if (!snap.quota) {
     lines.push(
@@ -360,7 +416,6 @@ function renderAccountRow(
     `${marker}\`${codeSpanSafe(label)}\`  ${fiveStr} / ${sevenStr}`,
   );
 
-  const health = classifyHealth(snap, now);
   if (health === 'blocked') {
     // quota-exhausted (recoverable): surface only the recovery countdown — the
     // binding window's reset is the only thing that matters until then.
@@ -432,10 +487,14 @@ function formatAgeStamp(atMs: number, now: Date = new Date()): string {
  * blocked → throttling → unknown → healthy.
  */
 const TABLE_HEALTH_RANK: Record<AccountHealth, number> = {
-  blocked: 0,
-  throttling: 1,
-  unknown: 2,
-  healthy: 3,
+  // org-disabled is a hard, actionable problem → first. RETIRED is out of
+  // service (informational, not actionable) → LAST, after healthy.
+  'org-blocked': 0,
+  blocked: 1,
+  throttling: 2,
+  unknown: 3,
+  healthy: 4,
+  retired: 5,
 };
 
 /** Escape a cell value for a GFM table cell: pipes break the column grid, and
@@ -565,7 +624,15 @@ export function recommendation(
   const active = snapshots.find((s) => s.isActive);
   if (!active) return 'No active account set.';
   const activeHealth = classifyHealth(active, now);
-  const others = snapshots.filter((s) => !s.isActive);
+  // EXCLUDE out-of-service accounts (retired / org-disabled) from the
+  // recommendation entirely: a retired account is not a switch target and must
+  // not inflate an "all accounts blocked" verdict. Only in-service accounts are
+  // candidate alternatives or count toward the fleet-blocked summary.
+  const inServiceFleet = snapshots.filter((s) => {
+    const h = classifyHealth(s, now);
+    return h !== 'retired' && h !== 'org-blocked';
+  });
+  const others = inServiceFleet.filter((s) => !s.isActive);
   const healthyAlt = others.find((s) => classifyHealth(s, now) === 'healthy');
   // Demo mode masks the email labels that appear in the recommendation
   // sentence, in lockstep with the per-account rows above.
@@ -590,7 +657,8 @@ export function recommendation(
     // #2494 Bug B — no healthy alternative. Do NOT collapse to "All accounts
     // blocked": that's only honest when EVERY account is truly walled with no
     // usable or imminently-refilling slot. Distinguish the buckets first.
-    return summarizeNoHealthyAlt(snapshots, now, demo);
+    // Only in-service accounts count — a retired account is not "blocked".
+    return summarizeNoHealthyAlt(inServiceFleet, now, demo);
   }
 
   // unknown
@@ -770,7 +838,15 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
       // Blocked-first ordering mirrors renderAuthSnapshotFormat2 — the user
       // scans the walled accounts (and their recovery times) at the top, with
       // the active account floating first within its group.
-      const healthOrder: AccountHealth[] = ['blocked', 'throttling', 'healthy', 'unknown'];
+      const healthOrder: AccountHealth[] = [
+        'org-blocked',
+        'blocked',
+        'throttling',
+        'healthy',
+        'unknown',
+        // RETIRED last — out of service, informational only.
+        'retired',
+      ];
       const rank = (s: AccountSnapshot): number => healthOrder.indexOf(classifyHealth(s, now));
       const ordered = [...fleet].sort(
         (a, b) => rank(a) - rank(b) || Number(b.isActive) - Number(a.isActive),
@@ -937,7 +1013,18 @@ export function buildSnapshotKeyboard(
   const switchTargets = snapshots
     .filter((s) => !s.isActive)
     .sort((a, b) => switchPriority(a, now) - switchPriority(b, now))
-    .filter((s) => classifyHealth(s, now) !== 'blocked' && classifyHealth(s, now) !== 'unknown')
+    .filter((s) => {
+      const h = classifyHealth(s, now);
+      // Never offer a switch into a target we can't (or shouldn't) serve on:
+      // blocked / unknown (existing), and now RETIRED / org-disabled — an
+      // out-of-service account is not a valid fleet target.
+      return (
+        h !== 'blocked' &&
+        h !== 'unknown' &&
+        h !== 'retired' &&
+        h !== 'org-blocked'
+      );
+    })
     .slice(0, max);
 
   for (const t of switchTargets) {
@@ -964,7 +1051,8 @@ function switchPriority(s: AccountSnapshot, now: Date = new Date()): number {
   if (h === 'healthy') return 0;
   if (h === 'throttling') return 1;
   if (h === 'unknown') return 2;
-  return 3; // blocked
+  if (h === 'blocked') return 3;
+  return 4; // retired / org-blocked — out of service, always last (and filtered)
 }
 
 // ── shared HTML escape ───────────────────────────────────────────────
@@ -1073,6 +1161,8 @@ export function buildSnapshotsFromState(
       quota: q && q.ok ? q.data : null,
       quotaError: q && !q.ok ? q.reason : undefined,
       expiresAtMs: acc.expiresAt,
+      inService: acc.in_service,
+      entitlementBlocked: acc.entitlement_blocked,
     });
   }
   return out;
@@ -1128,6 +1218,8 @@ export function buildSnapshotsFromCachedState(
       // stale data (the 2026-06-09 incident: a recovery latched days
       // earlier only surfaced — and notified — at the next fleet bounce).
       capturedAtMs: lq?.capturedAt,
+      inService: acc.in_service,
+      entitlementBlocked: acc.entitlement_blocked,
     };
   });
 }

--- a/telegram-plugin/quota-bar-format.ts
+++ b/telegram-plugin/quota-bar-format.ts
@@ -147,18 +147,41 @@ export function buildBar(pct: number, elapsedFrac: number): string {
 
 // ── account status (title-line suffix) ───────────────────────────────
 
-export type QuotaBarAccountStatus = 'active' | 'exhausted' | 'idle';
+export type QuotaBarAccountStatus =
+  | 'active'
+  | 'org-disabled'
+  | 'retired'
+  | 'exhausted'
+  | 'idle';
+
+/** Title-line display word for each status (some differ from the enum key). */
+const STATUS_LABEL: Record<QuotaBarAccountStatus, string> = {
+  active: 'active',
+  'org-disabled': 'DISABLED (org)',
+  retired: 'retired',
+  exhausted: 'exhausted',
+  idle: 'idle',
+};
 
 /**
- * Title-line status word. `active` wins over `exhausted` (the fleet's
- * pinned account is reported as active even if the broker also flags it
- * exhausted — matches the locked example where the operator wants to know
- * WHICH account is live first, and its health second, from the two window
- * rows underneath). Otherwise: `exhausted` if the broker's own flag says
- * so, else `idle` (present, healthy, just not the current pick).
+ * Title-line status word. Precedence: `active` > `DISABLED (org)` > `retired` >
+ * `exhausted` > `idle`.
+ *   - `active` wins over everything (the fleet's pinned account is reported
+ *     active even if also flagged exhausted — the operator wants WHICH account
+ *     is live first, health second, from the window rows underneath).
+ *   - `org-disabled` (entitlement block, PR2) and `retired` (`in_service` false:
+ *     removed from every config list) are OUT OF SERVICE — never "idle", which
+ *     reads as an available-but-unused account.
+ *   - else `exhausted` if the broker flags it, else `idle`.
  */
-export function accountStatus(isActive: boolean, exhausted: boolean): QuotaBarAccountStatus {
+export function accountStatus(
+  isActive: boolean,
+  exhausted: boolean,
+  opts: { inService?: boolean; entitlementBlocked?: boolean } = {},
+): QuotaBarAccountStatus {
   if (isActive) return 'active';
+  if (opts.entitlementBlocked === true) return 'org-disabled';
+  if (opts.inService === false) return 'retired';
   if (exhausted) return 'exhausted';
   return 'idle';
 }
@@ -188,8 +211,9 @@ export function renderQuotaBarAccount(
   quota: QuotaUtilization | null,
   now: Date = new Date(),
   demo = false,
+  service: { inService?: boolean; entitlementBlocked?: boolean } = {},
 ): string[] {
-  const status = accountStatus(isActive, exhausted);
+  const status = accountStatus(isActive, exhausted, service);
   // Title line wraps `label` in GFM `**bold**`, NOT a code span — so this
   // needs `escapeMarkdown` (backslash-escapes *, _, [, ], etc.), not
   // `codeSpanSafe` (which only defuses backticks and is only correct
@@ -197,7 +221,18 @@ export function renderQuotaBarAccount(
   // was a bug: a label containing e.g. `**` or `[x](url)` would break the
   // bold run or inject a markdown link into the card.
   const displayLabel = demo ? maskEmail(label) : label;
-  const lines: string[] = [`- **${escapeMarkdown(displayLabel)}** (${status})`];
+  const lines: string[] = [`- **${escapeMarkdown(displayLabel)}** (${STATUS_LABEL[status]})`];
+  // Out-of-service accounts (retired / org-disabled) have no meaningful live
+  // windows — a 0%/0% bar would read as "available", the exact bug this fixes.
+  // Replace the two window rows with a single status note (shape stays a list).
+  if (status === 'retired' || status === 'org-disabled') {
+    const note =
+      status === 'org-disabled'
+        ? 'disabled by org — no fleet routing'
+        : 'retired — removed from fleet rotation';
+    lines.push(`- ⚫ \`${note}\``);
+    return lines;
+  }
   if (!quota || isProbeThin(quota)) {
     // Data-quality gap. A failed / thin probe carries NO real utilization
     // signal, so it must NOT render as a healthy 🟢 0% bar — that's
@@ -288,10 +323,21 @@ export function renderQuotaBarBlock(
   const now = opts.now ?? new Date();
   const demo = opts.demo ?? false;
   const lines: string[] = [];
-  for (const snap of snapshots) {
+  // Out-of-service accounts (retired / org-disabled) sort LAST — stable
+  // partition preserves the caller's active-first ordering among the rest.
+  const outOfService = (s: AccountSnapshot) =>
+    !s.isActive && (s.entitlementBlocked === true || s.inService === false);
+  const ordered = [
+    ...snapshots.filter((s) => !outOfService(s)),
+    ...snapshots.filter(outOfService),
+  ];
+  for (const snap of ordered) {
     const exhausted = exhaustedByLabel.get(snap.label) ?? false;
     lines.push(
-      ...renderQuotaBarAccount(snap.label, snap.isActive, exhausted, snap.quota, now, demo),
+      ...renderQuotaBarAccount(snap.label, snap.isActive, exhausted, snap.quota, now, demo, {
+        inService: snap.inService,
+        entitlementBlocked: snap.entitlementBlocked,
+      }),
     );
   }
   return lines.join('\n');
@@ -319,6 +365,8 @@ export function renderQuotaBarBlockFromListState(
     quotaError: acc.last_quota ? undefined : 'no cached quota (no probe since broker start)',
     expiresAtMs: acc.expiresAt,
     capturedAtMs: acc.last_quota?.capturedAt,
+    inService: acc.in_service,
+    entitlementBlocked: acc.entitlement_blocked,
   }));
   return renderQuotaBarBlock(snapshots, exhaustedByLabel, { now });
 }

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -1199,3 +1199,44 @@ describe('#2494 — renderAuthSnapshotFormat2 row rendering (out_of_credits demo
     expect(out).not.toContain('All accounts blocked');
   });
 });
+
+// ── retired / org-blocked (in-service classification, PR1) ────────────
+describe('classifyHealth — retired / org-blocked precedence', () => {
+  // A retired/org-disabled account must NEVER read as available: config and
+  // entitlement outrank the quota windows for any non-active account.
+  const healthyQ = quota({ fiveHourUtilizationPct: 5, sevenDayUtilizationPct: 10 });
+
+  it('non-active account with inService:false → retired, even on healthy quota', () => {
+    expect(classifyHealth(snap({ inService: false, quota: healthyQ }))).toBe('retired');
+  });
+  it('non-active account with entitlementBlocked → org-blocked', () => {
+    expect(classifyHealth(snap({ entitlementBlocked: true, quota: healthyQ }))).toBe('org-blocked');
+  });
+  it('entitlement block outranks retirement', () => {
+    expect(
+      classifyHealth(snap({ inService: false, entitlementBlocked: true, quota: healthyQ })),
+    ).toBe('org-blocked');
+  });
+  it('absent inService defaults to in-service (a pre-field broker is never falsely retired)', () => {
+    expect(classifyHealth(snap({ quota: healthyQ }))).toBe('healthy');
+  });
+  it('the active account keeps its quota-derived health even if inService is false', () => {
+    // active is in-service by definition; the guard skips retirement for it.
+    expect(classifyHealth(snap({ isActive: true, inService: false, quota: healthyQ }))).toBe('healthy');
+  });
+});
+
+describe('recommendation — excludes retired/org-blocked accounts', () => {
+  it('a retired account (even with healthy quota) is never offered as a switch target', () => {
+    // active is throttling; the only OTHER account is retired but at 0% util.
+    // Without the exclusion it would be recommended as a healthy switch target;
+    // with it, the retired account is invisible → "no healthy alternative".
+    const snaps: AccountSnapshot[] = [
+      snap({ label: 'a@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 90 }) }),
+      snap({ label: 'retired@x', inService: false, quota: quota({ fiveHourUtilizationPct: 0 }) }),
+    ];
+    const out = recommendation(snaps, NOW);
+    expect(out).not.toContain('retired@x');
+    expect(out).toContain('no healthy alternative');
+  });
+});


### PR DESCRIPTION
## What

Accounts removed from every selection list (`fallback_order` + all per-agent `accounts:` + consumer pins) still rendered as **"available"** in `auth list` / `auth usage` / `auth schedule` and the Telegram `/usage` card — because every view enumerates the broker credential-store directory directly and never cross-checks the config. This is what let the disabled `me@kenthompson.com.au` keep showing as available after it was pulled from the fleet.

## How

- **In-service classification** — generalize `premiumCanarySet()` into an `inServiceSet()` = `{auth.active}` ∪ `fallback_order` ∪ agent auth overrides ∪ consumer pins. `opListState` emits `in_service` per account.
- **Render RETIRED** across all four views: sorted **last**, excluded from the switch keyboard and the `recommendation` (a retired account is not a switch target and must not inflate an "all blocked" verdict).
- Wires an `entitlement_blocked` flag (populated by the PR2 probe-hardening change, #3454) that renders **DISABLED (org)** and outranks retirement.

Precedence: `active` > `DISABLED (org)` > `RETIRED` > quota-derived health. Only an explicit `in_service=false` retires — a pre-field broker never falsely retires the fleet.

## PR of 2

This is **PR1 (display)** of a two-PR change. **PR2 (#3454)** is the backend probe-hardening that produces `entitlement_blocked`; it rebases onto this after merge (small expected schema-field reconciliation).

## Tests

`auth-schedule.test.ts`, new `server-list-state-in-service.test.ts`, and `auth-snapshot-format.test.ts` (retired/org-blocked precedence + recommendation exclusion). Build + lint (gateway ratchet clean) + scoped suites all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)