### PR TITLE
fix(gateway): defer worker-feed card creation until sub-agent origin links

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2211,10 +2211,14 @@ const WORKER_FEED_ORIGIN_DEFER_MAX = 10
 function resolveWorkerFeedChat(
   agentId: string,
   fleetChatId: string,
+  // Origin sources threadId; when origin is null the caller can pass the
+  // fallback chat's sibling forum-topic id so a misrouted card still lands
+  // in the origin topic instead of General (#3458 exhausted-defer paint).
+  fallbackThreadId?: number,
 ): { chatId: string; threadId?: number } {
   const origin = resolveSubagentOriginChat(agentId)
   if (origin != null && origin.chatId.length > 0) return origin
-  if (fleetChatId.length > 0) return { chatId: fleetChatId }
+  if (fleetChatId.length > 0) return { chatId: fleetChatId, threadId: fallbackThreadId }
   const ownerDm = loadAccess().allowFrom[0] ?? ''
   if (origin == null && fleetChatId.length === 0 && ownerDm.length > 0) {
     // Routing decision, not a warning: origin resolution failed and no
@@ -2232,7 +2236,7 @@ function resolveWorkerFeedChat(
       )
     }
   }
-  return { chatId: ownerDm, threadId: origin?.threadId }
+  return { chatId: ownerDm, threadId: origin?.threadId ?? fallbackThreadId }
 }
 
 // ─── Periodic history reaper (#1073) ──────────────────────────────────────
@@ -24941,11 +24945,12 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                   workerFeedOriginDeferrals.delete(agentId)
                   // Prefer the live turn's chat/topic over the owner DM if we do
                   // have to fall back — a misroute at least lands near the work.
-                  const workerFleetChatId =
-                    fleetChatId.length > 0
-                      ? fleetChatId
-                      : stampTurn?.sessionChatId ?? fleetChatId
-                  const wk = resolveWorkerFeedChat(agentId, workerFleetChatId)
+                  const usingStampFallback = fleetChatId.length === 0
+                  const workerFleetChatId = usingStampFallback
+                    ? stampTurn?.sessionChatId ?? fleetChatId
+                    : fleetChatId
+                  // Carry the fallback chat's forum topic id (#3458) so the card lands in the origin topic, not General.
+                  const wk = resolveWorkerFeedChat(agentId, workerFleetChatId, usingStampFallback ? stampTurn?.sessionThreadId : undefined)
                   const wkChat = wk.chatId
                   void workerActivityFeed?.update(
                     agentId,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -953,7 +953,7 @@ import {
 import { findAgentProcessInContainer } from './boot-probes.js'
 import { applySubagentsSchema, getSubagentByJsonlId, resolveSubagentOriginTurnKey, listNonTerminalSubagentsForTurn } from '../registry/subagents-schema.js'
 import type { InterruptedSubagent } from './resume-inbound-builder.js'
-import { resolveWorkerFeedDispatch, handleWorkerResume, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
+import { resolveWorkerFeedDispatch, decideWorkerFeedOriginDefer, handleWorkerResume, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
 import {
   resolveSubagentStatusSurface,
   isOrphanSubagentStatusEnabled,
@@ -2179,6 +2179,15 @@ const WORKER_FEED_GROUP_MESSAGE_LIFETIME_CAP_MS = (() => {
   return Number.isFinite(v) && v > 0 ? v : 60 * 60_000
 })()
 const workerFeedOwnerDmFallbackLogged = new Set<string>()
+
+// Per-agent consecutive origin-race deferrals (rationale in
+// `decideWorkerFeedOriginDefer`, worker-feed-dispatch.ts). Bounds the wait for
+// the `jsonl_agent_id` backfill; deleted on link, card-exists, and finish/drop
+// so the map stays bounded.
+const workerFeedOriginDeferrals = new Map<string, number>()
+// Watcher ticks ~1/s and the backfill retries ~every 3s, so ~10 ticks is a
+// comfortable ceiling on the race window before painting anyway.
+const WORKER_FEED_ORIGIN_DEFER_MAX = 10
 
 /**
  * Resolve a worker-feed destination chat with a guaranteed last resort.
@@ -24397,6 +24406,9 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
               // live worker, collapses the shared card to its terminal summary
               // and unpins it — closing the immortal/unpinned/buried-card leak.
               onTerminalCleanup: (agentId) => {
+                // A worker that terminated while still unlinked never links —
+                // clear its origin-race defer state so the map can't leak.
+                workerFeedOriginDeferrals.delete(agentId)
                 try {
                   void workerActivityFeed?.terminate(agentId)
                 } catch (err) {
@@ -24406,6 +24418,8 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 }
               },
               onFinish: ({ agentId, outcome, description, resultText, toolCount, totalTokens, durationMs, background: entryBackground }) => {
+                // Clear origin-race defer state — the worker is terminal.
+                workerFeedOriginDeferrals.delete(agentId)
                 // Reaction promotion: if the parent turn already ended
                 // with this (or another) worker still running, its 👍 was
                 // deferred (held on ✍️/⚡). Now that a worker finished,
@@ -24890,7 +24904,48 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 // resolved (the pinned-card fleet that used to carry the chat
                 // is gone — see resolveSubagentOriginChat).
                 if (workerFeedEnabled) {
-                  const wk = resolveWorkerFeedChat(agentId, fleetChatId)
+                  // Origin-race defer (decideWorkerFeedOriginDefer): the first
+                  // tick of a fresh sub-agent can beat the async jsonl_agent_id
+                  // backfill that links its row to the origin turn — resolving
+                  // origin to null and CREATING the card in the owner DM, which
+                  // then stays visible even after the origin (supergroup + forum
+                  // topic) resolves ~3s later. Defer CARD CREATION until linked;
+                  // the watcher re-fires and paints in the correct chat+topic.
+                  const originResolved = resolveSubagentOriginChat(agentId) != null
+                  const cardExists = workerActivityFeed?.has(agentId) === true
+                  const { defer, deferrals } = decideWorkerFeedOriginDefer({
+                    originResolved,
+                    cardExists,
+                    priorDeferrals: workerFeedOriginDeferrals.get(agentId) ?? 0,
+                    maxDeferrals: WORKER_FEED_ORIGIN_DEFER_MAX,
+                  })
+                  if (defer) {
+                    workerFeedOriginDeferrals.set(agentId, deferrals)
+                    // Defer this tick: no card created, no owner-DM fallback.
+                    // The watcher re-fires once the jsonl_agent_id backfill links
+                    // the row to its origin turn, and the card is then created in
+                    // the correct chat+topic.
+                    return
+                  }
+                  if (!originResolved && !cardExists) {
+                    // Bounded-defer exhausted — backfill never linked (history
+                    // disabled / row reaped / ancestor never stamped). Stop
+                    // deferring and let the card paint so active work stays
+                    // visible (universal-liveness contract).
+                    process.stderr.write(
+                      `telegram gateway: worker-feed origin backfill never linked agent=${agentId} after ${deferrals} deferrals — painting card\n`,
+                    )
+                  }
+                  // Linked (or a card already exists, or defer exhausted): clear
+                  // any defer state so the map can't leak.
+                  workerFeedOriginDeferrals.delete(agentId)
+                  // Prefer the live turn's chat/topic over the owner DM if we do
+                  // have to fall back — a misroute at least lands near the work.
+                  const workerFleetChatId =
+                    fleetChatId.length > 0
+                      ? fleetChatId
+                      : stampTurn?.sessionChatId ?? fleetChatId
+                  const wk = resolveWorkerFeedChat(agentId, workerFleetChatId)
                   const wkChat = wk.chatId
                   void workerActivityFeed?.update(
                     agentId,

--- a/telegram-plugin/gateway/worker-feed-dispatch.ts
+++ b/telegram-plugin/gateway/worker-feed-dispatch.ts
@@ -40,6 +40,47 @@ export function handleWorkerResume(
   log(`telegram gateway: worker ${agentId} card RE-SURFACED — resumed via SendMessage after a genuine terminal (issue #3373)`)
 }
 
+/**
+ * Worker-feed origin-race defer decision (issue: DM-misrouted worker card).
+ *
+ * The gateway picks a worker card's destination on the FIRST progress tick of
+ * a new sub-agent. That tick can beat the async `jsonl_agent_id` backfill that
+ * links the sub-agent's registry row to its origin turn (retried ~every 3s).
+ * Until the link lands, origin resolution returns null and the gateway's
+ * `resolveWorkerFeedChat` hard-falls back to the owner DM — CREATING the card
+ * there. The origin (supergroup + forum topic) resolves ~3s later, but the DM
+ * card already exists and stays the visible one.
+ *
+ * Decision: DEFER card creation while the agent is not yet linked to its
+ * origin AND no card exists yet for it. The subagent-watcher re-fires within
+ * seconds; once the backfill completes the origin resolves and the card is
+ * created in the correct chat+topic. Only CARD CREATION is deferred — if a
+ * card already exists, updates always proceed (`defer:false`). A bounded
+ * counter caps the wait: after `maxDeferrals` unlinked ticks (pathological
+ * backfill failure) it stops deferring so active work always gets a card.
+ *
+ * Pure so the seam is unit-testable — see worker-feed-dispatch.test.ts. The
+ * gateway must never inline this decision again.
+ */
+export function decideWorkerFeedOriginDefer(input: {
+  /** True once `resolveSubagentOriginChat` returns a chat (row linked). */
+  originResolved: boolean
+  /** True if the feed already has a posted message for this worker. */
+  cardExists: boolean
+  /** Consecutive prior deferrals for this agent (0 on the first tick). */
+  priorDeferrals: number
+  /** Max consecutive deferrals before painting anyway. */
+  maxDeferrals: number
+}): { defer: boolean; deferrals: number } {
+  const { originResolved, cardExists, priorDeferrals, maxDeferrals } = input
+  // A card already exists, or the origin has resolved: never defer.
+  if (originResolved || cardExists) return { defer: false, deferrals: 0 }
+  const deferrals = priorDeferrals + 1
+  // Bounded: stop deferring once we've waited long enough for the backfill.
+  if (deferrals >= maxDeferrals) return { defer: false, deferrals }
+  return { defer: true, deferrals }
+}
+
 export interface WorkerFeedDispatch {
   /** True when the sub-agent was dispatched with `run_in_background: true`. */
   isBackground: boolean

--- a/telegram-plugin/tests/worker-feed-origin-race-defer.test.ts
+++ b/telegram-plugin/tests/worker-feed-origin-race-defer.test.ts
@@ -113,6 +113,10 @@ function workerFeedTick(
   agentId: string,
   resolveOrigin: () => { chatId: string; threadId?: number } | null,
   view: WorkerActivityView,
+  // The fallback used when origin is unresolved. Mirrors the gateway's
+  // exhausted-defer paint: the live turn's chat + its sibling forum-topic id
+  // (stampTurn.sessionChatId / .sessionThreadId), else the owner DM.
+  fallback: { chatId: string; threadId?: number } = { chatId: OWNER_DM, threadId: undefined },
 ): void {
   const origin = resolveOrigin()
   const originResolved = origin != null
@@ -128,8 +132,9 @@ function workerFeedTick(
     return
   }
   deferrals.delete(agentId)
-  // resolveWorkerFeedChat: origin chat when resolved, else owner DM.
-  const chat = originResolved ? origin! : { chatId: OWNER_DM, threadId: undefined }
+  // resolveWorkerFeedChat: origin chat when resolved, else the fallback
+  // chat AND its forum-topic id (#3458) — never dropping the thread.
+  const chat = originResolved ? origin! : fallback
   void feed.update(agentId, chat.chatId, view, chat.threadId)
 }
 
@@ -214,5 +219,39 @@ describe('worker-feed origin race — outcome: no owner-DM card', () => {
     // here to the owner DM (the only resort when origin never resolves).
     expect(sent.length).toBeGreaterThanOrEqual(1)
     expect(sent.every((s) => s.chatId === OWNER_DM)).toBe(true)
+  })
+
+  it('exhausted-defer (never-backfill) fallback lands in the origin FORUM THREAD, not General (#3458)', async () => {
+    // The backfill never links, so origin stays null through the bounded cap.
+    // In a forum supergroup the gateway paints using the live turn's chat AND
+    // its forum-topic id (stampTurn.sessionChatId / .sessionThreadId). Before
+    // the fix the thread was dropped and the card landed in General (thread
+    // undefined). Assert the thread id is carried to the painted card.
+    let now = 0
+    const sent: SentRecord[] = []
+    const feed = createWorkerActivityFeed({
+      bot: makeRecordingBot(sent),
+      now: () => now,
+      firstPaintMinMs: 0,
+      minEditIntervalMs: 0,
+    })
+    const deferrals = new Map<string, number>()
+    const agentId = 'neverlinks-forum'
+    const resolveOrigin = () => null // backfill permanently broken
+    // Live turn's chat + forum topic — the exhausted-defer fallback source.
+    const liveFallback = { chatId: ORIGIN_CHAT, threadId: ORIGIN_THREAD }
+
+    for (let i = 0; i < MAX; i++) {
+      now = i * 1000
+      workerFeedTick(feed, deferrals, agentId, resolveOrigin, runningView(now), liveFallback)
+      await Promise.resolve()
+    }
+    await Promise.resolve()
+
+    // OUTCOME: a card painted, in the origin supergroup AND its forum topic —
+    // the thread id survived the never-backfill fallback (not General).
+    expect(sent.length).toBeGreaterThanOrEqual(1)
+    expect(sent.every((s) => s.chatId === ORIGIN_CHAT)).toBe(true)
+    expect(sent.every((s) => s.threadId === ORIGIN_THREAD)).toBe(true)
   })
 })

--- a/telegram-plugin/tests/worker-feed-origin-race-defer.test.ts
+++ b/telegram-plugin/tests/worker-feed-origin-race-defer.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Worker-feed origin-race defer (DM-misrouted worker card).
+ *
+ * Root cause: the gateway picks a worker card's destination on the FIRST
+ * progress tick of a new sub-agent. That tick can beat the async
+ * `jsonl_agent_id` backfill that links the sub-agent's registry row to its
+ * origin turn (retried ~every 3s). Until linked, origin resolution returns
+ * null and `resolveWorkerFeedChat` hard-falls back to the owner DM — CREATING
+ * the card there. The origin (supergroup + forum topic) resolves ~3s later,
+ * but the DM card already exists and stays the visible one.
+ *
+ * Fix (approach #1 — defer): when the agent is not yet linked AND no card
+ * exists yet, SKIP card creation for that tick. The watcher re-fires within
+ * seconds; once the backfill links the row the card is created in the correct
+ * chat+topic.
+ *
+ * These tests assert the OUTCOME (no card ever posted to the owner DM), not
+ * just the decision code path — the integration case drives the REAL
+ * `createWorkerActivityFeed` with a mock Bot API that records every send.
+ */
+import { describe, it, expect } from 'vitest'
+import { decideWorkerFeedOriginDefer } from '../gateway/worker-feed-dispatch.js'
+import {
+  createWorkerActivityFeed,
+  type BotApiForWorkerFeed,
+  type WorkerActivityView,
+} from '../worker-activity-feed.js'
+
+const MAX = 10
+
+describe('decideWorkerFeedOriginDefer (origin-race defer decision)', () => {
+  it('DEFERS the first tick of a not-yet-linked worker with no card', () => {
+    const out = decideWorkerFeedOriginDefer({
+      originResolved: false,
+      cardExists: false,
+      priorDeferrals: 0,
+      maxDeferrals: MAX,
+    })
+    expect(out.defer).toBe(true)
+    expect(out.deferrals).toBe(1)
+  })
+
+  it('does NOT defer once the origin has resolved (row linked)', () => {
+    const out = decideWorkerFeedOriginDefer({
+      originResolved: true,
+      cardExists: false,
+      priorDeferrals: 3,
+      maxDeferrals: MAX,
+    })
+    expect(out.defer).toBe(false)
+  })
+
+  it('does NOT defer when a card already exists (updates proceed)', () => {
+    const out = decideWorkerFeedOriginDefer({
+      originResolved: false,
+      cardExists: true,
+      priorDeferrals: 0,
+      maxDeferrals: MAX,
+    })
+    expect(out.defer).toBe(false)
+  })
+
+  it('stops deferring once the bounded cap is reached (pathological backfill)', () => {
+    // priorDeferrals = MAX-1 → this tick is the MAX-th; paint anyway.
+    const out = decideWorkerFeedOriginDefer({
+      originResolved: false,
+      cardExists: false,
+      priorDeferrals: MAX - 1,
+      maxDeferrals: MAX,
+    })
+    expect(out.defer).toBe(false)
+    expect(out.deferrals).toBe(MAX)
+  })
+})
+
+// ─── Integration: no card is ever created in the owner DM on the racing tick ──
+
+const OWNER_DM = '111111'
+const ORIGIN_CHAT = '-1002000000000' // supergroup
+const ORIGIN_THREAD = 42 // forum topic
+
+interface SentRecord {
+  chatId: string
+  threadId: number | undefined
+}
+
+function makeRecordingBot(sent: SentRecord[]): BotApiForWorkerFeed {
+  let nextId = 1000
+  return {
+    async sendMessage(chatId, _text, opts) {
+      sent.push({
+        chatId,
+        threadId: (opts?.message_thread_id as number | undefined) ?? undefined,
+      })
+      return { message_id: nextId++ }
+    },
+    async editMessageText() {
+      return {}
+    },
+  }
+}
+
+/**
+ * Faithful model of the gateway `onProgress` worker-feed block (gateway.ts):
+ * run the real defer decision, and — only when NOT deferring — call the real
+ * feed with the resolved chat. `resolveOrigin` mimics `resolveSubagentOriginChat`
+ * (null until the backfill links the row); the owner-DM fallback mirrors
+ * `resolveWorkerFeedChat` (origin → owner DM when unresolved).
+ */
+function workerFeedTick(
+  feed: ReturnType<typeof createWorkerActivityFeed>,
+  deferrals: Map<string, number>,
+  agentId: string,
+  resolveOrigin: () => { chatId: string; threadId?: number } | null,
+  view: WorkerActivityView,
+): void {
+  const origin = resolveOrigin()
+  const originResolved = origin != null
+  const cardExists = feed.has(agentId)
+  const { defer, deferrals: next } = decideWorkerFeedOriginDefer({
+    originResolved,
+    cardExists,
+    priorDeferrals: deferrals.get(agentId) ?? 0,
+    maxDeferrals: MAX,
+  })
+  if (defer) {
+    deferrals.set(agentId, next)
+    return
+  }
+  deferrals.delete(agentId)
+  // resolveWorkerFeedChat: origin chat when resolved, else owner DM.
+  const chat = originResolved ? origin! : { chatId: OWNER_DM, threadId: undefined }
+  void feed.update(agentId, chat.chatId, view, chat.threadId)
+}
+
+describe('worker-feed origin race — outcome: no owner-DM card', () => {
+  const runningView = (elapsedMs: number): WorkerActivityView => ({
+    description: 'racing worker',
+    lastTool: 'Read',
+    toolCount: 1,
+    latestSummary: 'reading files',
+    elapsedMs,
+    state: 'running',
+    model: 'sonnet',
+    totalTokens: 10,
+  })
+
+  it('defers the racing first tick, then paints the card in the ORIGIN topic — never the DM', async () => {
+    let now = 0
+    const sent: SentRecord[] = []
+    const feed = createWorkerActivityFeed({
+      bot: makeRecordingBot(sent),
+      now: () => now,
+      firstPaintMinMs: 0, // paint immediately once we do update
+      minEditIntervalMs: 0,
+    })
+    const deferrals = new Map<string, number>()
+    const agentId = 'a37ad7639ae61476c'
+
+    // The backfill has NOT linked the row yet: origin resolves to null.
+    let linked = false
+    const resolveOrigin = () =>
+      linked ? { chatId: ORIGIN_CHAT, threadId: ORIGIN_THREAD } : null
+
+    // First progress tick — races the backfill (origin unresolved).
+    workerFeedTick(feed, deferrals, agentId, resolveOrigin, runningView(1000))
+    await Promise.resolve()
+
+    // OUTCOME: nothing sent. In particular, no card in the owner DM.
+    expect(sent).toHaveLength(0)
+    expect(deferrals.get(agentId)).toBe(1)
+    expect(feed.has(agentId)).toBe(false)
+
+    // ~3s later the backfill completes and links the row → origin resolves.
+    linked = true
+    now = 4000
+    workerFeedTick(feed, deferrals, agentId, resolveOrigin, runningView(4000))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // OUTCOME: the card is created in the ORIGIN supergroup + forum topic,
+    // and NEVER in the owner DM.
+    expect(sent.length).toBeGreaterThanOrEqual(1)
+    for (const s of sent) {
+      expect(s.chatId).not.toBe(OWNER_DM)
+    }
+    expect(sent.some((s) => s.chatId === ORIGIN_CHAT && s.threadId === ORIGIN_THREAD)).toBe(true)
+    // Defer state cleared once linked.
+    expect(deferrals.has(agentId)).toBe(false)
+  })
+
+  it('bounded fallback: paints anyway if the backfill never links (no infinite defer)', async () => {
+    let now = 0
+    const sent: SentRecord[] = []
+    const feed = createWorkerActivityFeed({
+      bot: makeRecordingBot(sent),
+      now: () => now,
+      firstPaintMinMs: 0,
+      minEditIntervalMs: 0,
+    })
+    const deferrals = new Map<string, number>()
+    const agentId = 'neverlinks00000'
+    const resolveOrigin = () => null // backfill permanently broken
+
+    for (let i = 0; i < MAX; i++) {
+      now = i * 1000
+      workerFeedTick(feed, deferrals, agentId, resolveOrigin, runningView(now))
+      await Promise.resolve()
+    }
+    await Promise.resolve()
+
+    // The first MAX-1 ticks deferred; the MAX-th painted. The universal-liveness
+    // contract wins over infinite silence, so a card IS eventually created —
+    // here to the owner DM (the only resort when origin never resolves).
+    expect(sent.length).toBeGreaterThanOrEqual(1)
+    expect(sent.every((s) => s.chatId === OWNER_DM)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

The worker-feed progress card was landing in the **owner DM** instead of the origin supergroup topic for freshly-spawned sub-agents.

**Root cause (race):** the gateway picks a worker card's destination on the **first** progress tick of a new sub-agent. That tick can beat the async `jsonl_agent_id` backfill (meta.json / Phase-2 pre-hook, retried ~every 3s) that links the sub-agent's registry `subagents` row to its origin turn. Until the link lands, `resolveSubagentOriginChat` returns null and `resolveWorkerFeedChat` hard-falls back to `allowFrom[0]` (owner DM) and **immediately creates the card there**. The origin (supergroup chat + forum `message_thread_id`) resolves ~3s later, but the DM card already exists and stays the visible one.

## Why this fix (approach #1 — defer)

In the `onProgress` worker-feed path, if the agent is **not yet linked** to its origin **and no card exists yet**, we **skip that tick** — no card creation, no owner-DM fallback. The subagent-watcher re-fires within seconds once the backfill completes, at which point the origin resolves and the card is created in the correct chat + topic.

- Only **card CREATION** is deferred. If a card already exists (`feed.has(agentId)`), normal updates proceed regardless of link state.
- Guarded against pathological backfill failure (history disabled / row reaped / ancestor never stamped): a bounded counter `WORKER_FEED_ORIGIN_DEFER_MAX` (10 ticks) stops deferring and paints anyway, so the universal-liveness contract still holds. That fallback now prefers the **live turn's chat** over `allowFrom[0]`.
- The defer decision is extracted to a pure `decideWorkerFeedOriginDefer` helper (`worker-feed-dispatch.ts`) so the seam is unit-testable and the gateway keeps a thin delegation (gateway line-ratchet respected). Defer state is cleared on link, card-exists, and `onFinish`/`onTerminalCleanup` so the map stays bounded.

## Test plan

New `telegram-plugin/tests/worker-feed-origin-race-defer.test.ts` (6 tests):

- Unit: `decideWorkerFeedOriginDefer` defers the first unlinked tick, never defers once origin resolved or a card exists, stops at the bounded cap.
- **Outcome (integration, real `createWorkerActivityFeed` + recording Bot API):** a not-yet-linked sub-agent's first tick creates **no** card in the owner DM; once the row links, the card is posted to the origin supergroup + forum topic and **never** to the DM.
- Bounded fallback: if the backfill never links, a card is eventually painted (no infinite defer).

Scoped locally: `vitest` on the new + `worker-feed-dispatch` + `worker-activity-feed` + `worker-feed-terminal-cleanup` suites -> 119 passed. `npm run lint` clean (tsc + guard scripts, gateway line-ratchet included).

## Risk

Low. Scoped to the first ticks of a not-yet-linked worker (previously a DM misroute). Existing linked-worker and card-update paths unchanged. Bounded defer guarantees a card always eventually appears.

Job spec: worker/sub-agent activity visibility (universal-liveness contract — "any active work has a card, in the right chat").

🤖 Generated with [Claude Code](https://claude.com/claude-code)