### PR TITLE
fix: /model override silently dropped at boot — gateway consumes the carrier before start.sh reads it

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -340,9 +340,14 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   # re-apply a consumed override on a later restart.
   rm -f "{{agentDir}}/.session-model.boot-snapshot" "{{agentDir}}/.session-model-boot-attempts.boot-snapshot"
   if [ -f "{{agentDir}}/.session-model" ]; then
-    cp -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model.boot-snapshot" 2>/dev/null || true
+    # A failed copy (ENOSPC, perms) must not be a SILENT drop — the resolution
+    # block still falls back to the live carrier, but the gateway may consume
+    # that first, so warn loudly enough to diagnose a reverted override.
+    cp -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model.boot-snapshot" 2>/dev/null \
+      || echo "session-model: WARNING — failed to snapshot .session-model before the gateway fork; if the gateway consumes the carrier first, this boot's /model override may silently revert to the configured default" >&2
     if [ -f "{{agentDir}}/.session-model-boot-attempts" ]; then
-      cp -f "{{agentDir}}/.session-model-boot-attempts" "{{agentDir}}/.session-model-boot-attempts.boot-snapshot" 2>/dev/null || true
+      cp -f "{{agentDir}}/.session-model-boot-attempts" "{{agentDir}}/.session-model-boot-attempts.boot-snapshot" 2>/dev/null \
+        || echo "session-model: WARNING — failed to snapshot .session-model-boot-attempts before the gateway fork (retry-budget count may be lost this boot)" >&2
     fi
   fi
 
@@ -1373,6 +1378,13 @@ if [ -f "{{agentDir}}/.session-model-override" ]; then
     # pass's snapshot point, and the resolution below prefers the snapshot. A
     # newer legacy intent must win over any stale pre-fork copy (and survive
     # an early gateway consume of the live file).
+    #
+    # KNOWN one-release quirk (accepted): this live write also lands AFTER the
+    # gateway's boot-lock consume already fired, so on a healthy boot nothing
+    # deletes it until the NEXT boot's gateway consume — the migrated legacy
+    # override therefore applies for up to TWO boots instead of one. Shim-only
+    # (the mainline gateway writes `.session-model` directly, pre-restart, so
+    # it is snapshotted and consumed normally); the shim dies next release.
     cp -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model.boot-snapshot" 2>/dev/null || true
     echo "session-model: migrated legacy one-shot carrier '$_mig' to .session-model (applying + consuming this boot)" >&2
   else

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -325,6 +325,27 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   #    retrying — it recovers on its own the moment the broker
   #    unlocks (no human, no container recreate); bot token invalid
   #    → 401 → gateway exits 78 → quarantined (operator action).
+  # --- Session-model carrier PRE-FORK SNAPSHOT (gateway-consume boot race) ---
+  # The gateway forked just below consumes `.session-model` (+ the bounded-retry
+  # attempt counter) the moment it acquires the boot lock (#3284 healthy-boot
+  # consume, gateway.ts). But the session-model RESOLUTION block runs much later
+  # in the INNER pass — behind the LiteLLM probe's up-to-120s wait — so the
+  # gateway reliably won the race and the carrier vanished before resolution
+  # ever read it: a `/model <target>` differing from the configured default was
+  # silently dropped and the boot reverted (the overlord `/model fable`
+  # NOT-APPLIED incident, 2026-07). Snapshot the carrier + counter HERE, before
+  # the fork, into `.boot-snapshot` siblings the gateway never touches; the
+  # resolution block prefers the snapshot and deletes it after use (per-boot
+  # ephemeral). Refresh-or-remove every boot so a stale snapshot can never
+  # re-apply a consumed override on a later restart.
+  rm -f "{{agentDir}}/.session-model.boot-snapshot" "{{agentDir}}/.session-model-boot-attempts.boot-snapshot"
+  if [ -f "{{agentDir}}/.session-model" ]; then
+    cp -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model.boot-snapshot" 2>/dev/null || true
+    if [ -f "{{agentDir}}/.session-model-boot-attempts" ]; then
+      cp -f "{{agentDir}}/.session-model-boot-attempts" "{{agentDir}}/.session-model-boot-attempts.boot-snapshot" 2>/dev/null || true
+    fi
+  fi
+
   _gateway_bundle=/opt/switchroom/telegram-plugin/dist/gateway/gateway.js
   _telegram_enabled={{#if telegramEnabledFlag}}{{telegramEnabledFlag}}{{else}}true{{/if}}
   if [ "$_telegram_enabled" = "true" ] && [ -f "$_gateway_bundle" ] && command -v bun >/dev/null 2>&1; then
@@ -1333,7 +1354,11 @@ rm -f "{{agentDir}}/.relaunch-model-intent" "{{agentDir}}/.session-model-kept-no
 # meaningless without a carrier to belong to, so sweep it as stale ONLY when no
 # `.session-model` carrier is present (rollout leftover / completed apply / a
 # prior giveup that didn't get to delete it).
-[ -f "{{agentDir}}/.session-model" ] || rm -f "{{agentDir}}/.session-model-boot-attempts"
+# (Gateway-consume race fix: the outer pass snapshotted the carrier BEFORE the
+# gateway fork — the gateway may already have consumed the live carrier by now
+# on a healthy boot, so the snapshot is an equally valid "a carrier existed
+# this boot" signal.)
+{ [ -f "{{agentDir}}/.session-model" ] || [ -f "{{agentDir}}/.session-model.boot-snapshot" ]; } || rm -f "{{agentDir}}/.session-model-boot-attempts"
 
 # Migration shim (one release): a leftover one-shot `.session-model-override`
 # carrier from a pre-consume-once gateway means an OLD gateway wrote it
@@ -1344,6 +1369,11 @@ if [ -f "{{agentDir}}/.session-model-override" ]; then
   rm -f "{{agentDir}}/.session-model-override"
   if printf '%s' "$_mig" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
     printf '{"model":"%s","configuredDefaultAtWrite":"%s","ts":%s}\n' "$_mig" "$_EFFECTIVE_MODEL" "$(( $(date +%s) * 1000 ))" > "{{agentDir}}/.session-model" 2>/dev/null || true
+    # Also refresh the pre-fork snapshot: this write happened AFTER the outer
+    # pass's snapshot point, and the resolution below prefers the snapshot. A
+    # newer legacy intent must win over any stale pre-fork copy (and survive
+    # an early gateway consume of the live file).
+    cp -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model.boot-snapshot" 2>/dev/null || true
     echo "session-model: migrated legacy one-shot carrier '$_mig' to .session-model (applying + consuming this boot)" >&2
   else
     echo "session-model: ignoring malformed legacy .session-model-override (failed shape gate)" >&2
@@ -1351,8 +1381,19 @@ if [ -f "{{agentDir}}/.session-model-override" ]; then
   unset _mig
 fi
 
-if [ -f "{{agentDir}}/.session-model" ]; then
-  _smf="$(cat "{{agentDir}}/.session-model" 2>/dev/null || true)"
+# Prefer the PRE-FORK SNAPSHOT over the live carrier: on a healthy boot the
+# gateway (forked long before this block runs) has typically ALREADY consumed
+# the live `.session-model` by now — reading only the live file silently
+# reverted every `/model <target>` that differed from the configured default
+# (the overlord `/model fable` NOT-APPLIED incident). The snapshot was taken
+# before the gateway fork so it is race-free; fall back to the live file when
+# no snapshot exists (non-docker runtimes / block run standalone in tests).
+if [ -f "{{agentDir}}/.session-model.boot-snapshot" ] || [ -f "{{agentDir}}/.session-model" ]; then
+  if [ -f "{{agentDir}}/.session-model.boot-snapshot" ]; then
+    _smf="$(cat "{{agentDir}}/.session-model.boot-snapshot" 2>/dev/null || true)"
+  else
+    _smf="$(cat "{{agentDir}}/.session-model" 2>/dev/null || true)"
+  fi
   _sm_model="$(printf '%s' "$_smf" | sed -n 's/.*"model"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
   _sm_cfg="$(printf '%s' "$_smf" | sed -n 's/.*"configuredDefaultAtWrite"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
   # BOUNDED-RETRY CONSUME (#3284) — the carrier is NO LONGER deleted here before
@@ -1380,7 +1421,13 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   # and persists the incremented counter. The delete-before-apply that used to
   # sit here is GONE by design.
   _SM_MAX_ATTEMPTS=3
-  _sm_attempts="$(cat "{{agentDir}}/.session-model-boot-attempts" 2>/dev/null | tr -dc '0-9' || true)"
+  # Counter read prefers the pre-fork snapshot for the same race reason (the
+  # gateway deletes the live counter alongside the carrier on healthy consume).
+  if [ -f "{{agentDir}}/.session-model-boot-attempts.boot-snapshot" ]; then
+    _sm_attempts="$(cat "{{agentDir}}/.session-model-boot-attempts.boot-snapshot" 2>/dev/null | tr -dc '0-9' || true)"
+  else
+    _sm_attempts="$(cat "{{agentDir}}/.session-model-boot-attempts" 2>/dev/null | tr -dc '0-9' || true)"
+  fi
   [ -z "$_sm_attempts" ] && _sm_attempts=0
   _sm_attempts=$(( _sm_attempts + 1 ))
   # Shape gate — kept BYTE-IDENTICAL with MODEL_ARG_RE in
@@ -1444,6 +1491,10 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   fi
   unset _smf _sm_model _sm_cfg _sm_attempts _SM_MAX_ATTEMPTS
 fi
+# The snapshot is strictly per-boot: consumed here regardless of which branch
+# fired, so it can never re-apply an already-consumed override on a later boot
+# (the outer pass also refresh-or-removes it, belt and braces).
+rm -f "{{agentDir}}/.session-model.boot-snapshot" "{{agentDir}}/.session-model-boot-attempts.boot-snapshot"
 
 # Configured-default LiteLLM guard, SPLIT BY CAUSE (2026-07-17 boot-race
 # incident: a slow LiteLLM co-boot demoted a configured-fable agent to opus on

--- a/telegram-plugin/gateway/session-model-file.ts
+++ b/telegram-plugin/gateway/session-model-file.ts
@@ -104,6 +104,19 @@ export function writeSessionModelFile(
   if (!isValidModelArg(model)) {
     throw new Error(`refusing to persist non-canonical session model token: ${JSON.stringify(model)}`)
   }
+  // A FRESH carrier gets a FRESH retry budget: clear any bounded-retry counter
+  // left over from a prior carrier's boots. Without this, an orphan counter
+  // survives the whole session on a healthy snapshot-apply boot (the apply
+  // branch re-writes the live counter AFTER the gateway's healthy-boot consume
+  // already deleted it), gets snapshotted alongside the NEW carrier at the next
+  // boot, and burns the new override's retry budget from a stale count — three
+  // such sessions in a row and a perfectly healthy /model is refused with a
+  // false "did not reach a healthy boot after 3 attempts" revert.
+  try {
+    rmSync(join(agentDir, SESSION_MODEL_BOOT_ATTEMPTS_FILE), { force: true })
+  } catch {
+    /* best-effort — worst case is a stale count, bounded and non-fatal */
+  }
   atomicWrite(
     join(agentDir, SESSION_MODEL_FILE),
     serializeSessionModel({ model, configuredDefaultAtWrite, ts: Date.now() }),

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -353,6 +353,35 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     expect(existsSync(join(agentDir, ATTEMPTS_SNAPSHOT))).toBe(false);
   });
 
+  it("orphan attempt counter from a prior healthy snapshot-apply does NOT burn a NEW carrier's retry budget (fresh carrier = fresh budget)", async () => {
+    const { writeSessionModelFile } = await import(
+      "../telegram-plugin/gateway/session-model-file.js"
+    );
+    // Boot A (healthy, snapshot apply): gateway already consumed the live
+    // carrier; resolution applies from the snapshot and re-writes the LIVE
+    // counter AFTER the consume — leaving an orphan attempts=1 all session.
+    writeFileSync(join(agentDir, SNAPSHOT), sessionModelJson("claude-opus-4-8"));
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(attemptCount()).toBe("1"); // the orphan
+    // In-session `/model sr-glm-5`: the gateway writes a FRESH carrier. This
+    // must also clear the orphan counter (the blocker fix) — otherwise the
+    // stale count is snapshotted with the new carrier and after three such
+    // sessions a healthy /model is falsely refused as "3 failed attempts".
+    writeSessionModelFile(agentDir, "sr-glm-5", DEFAULT_MODEL);
+    expect(attemptCount()).toBe(""); // fresh carrier = fresh retry budget
+    // Boot B outer pass: snapshot the live carrier (+ counter if any)…
+    execFileSync("bash", ["-c", [
+      `cd ${JSON.stringify(agentDir)}`,
+      `cp -f .session-model ${JSON.stringify(SNAPSHOT)}`,
+      `[ -f .session-model-boot-attempts ] && cp -f .session-model-boot-attempts ${JSON.stringify(ATTEMPTS_SNAPSHOT)} || true`,
+    ].join("\n")]);
+    // …then the gateway's healthy-boot consume eats the live files…
+    healthyBootConsume();
+    // …and resolution applies the NEW override as attempt 1, not 2.
+    expect(runBlock("1")).toBe("sr-glm-5");
+    expect(attemptCount()).toBe("1");
+  });
+
   it("rendered start.sh takes the pre-fork snapshot BEFORE the gateway fork (ordering is the whole fix)", () => {
     const startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
     const snapIdx = startSh.indexOf(".session-model.boot-snapshot");

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -300,6 +300,71 @@ describe("scaffoldAgent: session-model consume-once boot resolver (start.sh)", (
     expect(runBlock("1")).toBe(DEFAULT_MODEL);
   });
 
+  // ── gateway-consume boot race (overlord `/model fable` NOT-APPLIED) ──────
+  // The gateway sidecar forks near the TOP of start.sh and consumes the live
+  // carrier at boot.lock_acquired (#3284) — normally LONG before the resolution
+  // block runs (it sits behind the LiteLLM probe's up-to-120s wait). Pre-fix,
+  // resolution read only the live file, found nothing, and silently booted the
+  // configured default: a `/model <target>` differing from the default NEVER
+  // reached the claude spawn. The fix snapshots the carrier before the gateway
+  // fork; resolution prefers the snapshot. These tests assert the OUTCOME.
+  const SNAPSHOT = ".session-model.boot-snapshot";
+  const ATTEMPTS_SNAPSHOT = ".session-model-boot-attempts.boot-snapshot";
+
+  it("gateway consumed the live carrier before resolution → the PRE-FORK SNAPSHOT still applies the override (the /model≠default bug)", () => {
+    // Simulate the real sequence: outer pass snapshotted the carrier, then the
+    // gateway's healthy-boot consume deleted the live carrier + counter BEFORE
+    // resolution ran. The override differs from the configured default.
+    writeFileSync(join(agentDir, SNAPSHOT), sessionModelJson("claude-opus-4-8"));
+    // live .session-model absent — the gateway already ate it.
+    expect(carrierExists()).toBe(false);
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    // The launched model is recorded for the gateway's NOT-APPLIED check.
+    expect(readFileSync(join(agentDir, ".active-session-model"), "utf-8").trim()).toBe("claude-opus-4-8");
+    // No alert — this is a clean apply.
+    expect(existsSync(join(agentDir, ".session-model-alert"))).toBe(false);
+    // The snapshot is consumed by the block (per-boot ephemeral)…
+    expect(existsSync(join(agentDir, SNAPSHOT))).toBe(false);
+    // …so the NEXT restart (no carrier, no snapshot) reverts to the configured
+    // default — the session-scoped invariant holds.
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    expect(readFileSync(join(agentDir, ".active-session-model"), "utf-8").trim()).toBe(DEFAULT_MODEL);
+  });
+
+  it("snapshot WINS over the live carrier when both exist (snapshot is this boot's pre-fork truth)", () => {
+    writeFileSync(join(agentDir, SNAPSHOT), sessionModelJson("claude-opus-4-8"));
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("sr-glm-5"));
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+  });
+
+  it("proxy-only snapshot (fable) + LiteLLM up → applies AND repoints to the router root (routing preserved through the snapshot path)", () => {
+    writeFileSync(join(agentDir, SNAPSHOT), sessionModelJson("fable"));
+    const { effective, baseUrl } = runBlockRouting("1");
+    expect(effective).toBe("fable");
+    expect(baseUrl).toBe(ROUTER_ROOT);
+  });
+
+  it("attempt counter read from its snapshot when the gateway deleted the live counter (crashloop bound survives the race)", () => {
+    writeFileSync(join(agentDir, SNAPSHOT), sessionModelJson("claude-opus-4-8"));
+    writeFileSync(join(agentDir, ATTEMPTS_SNAPSHOT), "3\n");
+    // 3 prior attempts + this one = 4 > _SM_MAX_ATTEMPTS(3) → give up + alert.
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    expect(alertText()).toContain("after 3 attempts");
+    expect(existsSync(join(agentDir, ATTEMPTS_SNAPSHOT))).toBe(false);
+  });
+
+  it("rendered start.sh takes the pre-fork snapshot BEFORE the gateway fork (ordering is the whole fix)", () => {
+    const startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
+    const snapIdx = startSh.indexOf(".session-model.boot-snapshot");
+    const forkIdx = startSh.indexOf("_switchroom_supervise gateway");
+    const resolveIdx = startSh.indexOf(BLOCK_HEADER);
+    expect(snapIdx).toBeGreaterThan(-1);
+    expect(forkIdx).toBeGreaterThan(-1);
+    expect(resolveIdx).toBeGreaterThan(-1);
+    expect(snapIdx).toBeLessThan(forkIdx);
+    expect(forkIdx).toBeLessThan(resolveIdx);
+  });
+
   // ── invalidation branches (all consume + alert) ──────────────────────────
   it("corrupt .session-model → deletes it, boots default, notifies (never a silent drop)", () => {
     writeFileSync(join(agentDir, ".session-model"), "{broken\n");
@@ -759,7 +824,12 @@ if [ -f "$marker" ]; then echo claude-opus-4-8; else touch "$marker"; echo "mang
     const startSh = readFileSync(join(agentDir, "start.sh"), "utf-8");
     const idxLive = startSh.indexOf("# --- Live configured-default resolution");
     const idxRecord = startSh.indexOf('.configured-default-model" 2>/dev/null || true');
-    const idxCarrier = startSh.indexOf('if [ -f "' + agentDir + '/.session-model" ]');
+    // The carrier apply condition (snapshot-preferred since the gateway-consume
+    // race fix — the pre-fork snapshot block earlier also tests .session-model,
+    // so anchor on the snapshot-OR-live compound condition).
+    const idxCarrier = startSh.indexOf(
+      '.session-model.boot-snapshot" ] || [ -f "' + agentDir + '/.session-model" ]',
+    );
     const idxGuard = startSh.indexOf("# Configured-default LiteLLM guard");
     const idxRepoint = startSh.indexOf("sr-* passthrough→router repoint");
     const idxActive = startSh.indexOf('.active-session-model"');


### PR DESCRIPTION
## Root cause

A `/model <target>` differing from the configured default is **silently dropped at boot**: the agent relaunches on the configured default instead.

Live trace (overlord agent):
- `gw /model relaunch scheduled agent=overlord token=fable reason="user: /model fable (session-only relaunch)"` — carrier written correctly.
- After restart: `gw /model relaunch NOT-APPLIED agent=overlord target=fable launched=opus configured=opus revertedTo=opus` — the running `claude` was spawned with `--model opus`.

The seam, in source:

- `profiles/_base/start.sh.hbs:331` — the gateway sidecar is forked (`_switchroom_supervise gateway … bun gateway.js &`) near the **top** of start.sh's outer pass.
- `telegram-plugin/gateway/gateway.ts:9434` (and the mutex-fallback twin at `:9464`) — on acquiring the boot lock, the gateway calls `consumeSessionModelCarrierOnHealthyBoot()`, deleting `.session-model` + `.session-model-boot-attempts` (#3284 healthy-boot consume).
- `profiles/_base/start.sh.hbs:1354` (pre-fix) — the session-model resolution block reads `.session-model` **much later**, in the inner pass, behind the LiteLLM probe's up-to-120s wait.

The gateway reliably acquires the boot lock long before resolution runs, so it consumes the carrier **before start.sh ever reads it**. Resolution finds nothing and boots the configured default. The #3284 change moved the consume from start.sh (delete-at-apply) to the gateway (delete-at-lock-acquire) without accounting for the gateway forking *before* the resolution block — the consume that was meant to fire *after* apply now fires *before* it. Earlier `/model fable` switches only "worked" because fable was the configured default then, making the revert invisible. The NOT-APPLIED detection is downstream and correct — it caught the mismatch as designed.

## Fix

`profiles/_base/start.sh.hbs`: snapshot the carrier + bounded-retry counter into `.session-model.boot-snapshot` / `.session-model-boot-attempts.boot-snapshot` **before the gateway fork** (the gateway never touches those names). The resolution block prefers the snapshot and falls back to the live file (non-docker runtimes / standalone-block tests); the snapshot is consumed at the end of the block and refresh-or-removed at every boot's outer pass, so a stale snapshot can never re-apply a consumed override.

Preserved invariants (red-teamed):
- **Session-scoped**: healthy boot → gateway consumes live carrier, block consumes snapshot → next restart has neither → configured default. Asserted by test.
- **#3284 wedge-retry**: a boot that wedges before the gateway acquires the lock leaves the live carrier + counter intact; the next boot re-snapshots and re-applies. Crashloop bound intact — the counter read also prefers its snapshot so the bound survives the gateway deleting the live counter.
- **Routing**: the snapshot path feeds the same `_EFFECTIVE_MODEL`, so the sr-*/fable → LiteLLM router-root repoint fires exactly as before (test asserts `fable` snapshot + LiteLLM up → router root).
- **Migration shim**: the legacy `.session-model-override` conversion also refreshes the snapshot so the newer intent wins.

## Does `.active-session-effort` / `.session-effort` share the bug?

**No.** `consumeSessionModelCarrierOnHealthyBoot` deletes only the model carrier + attempts counter; the gateway never consumes `.session-effort` at boot (its only clears are the live `/effort default` paths, gateway.ts:17456/17569). start.sh itself deletes the effort carrier at resolution time (true consume-once in the shell block), so there is no cross-process race. No effort change needed.

## Tests

`tests/scaffold.session-model.test.ts` — new outcome-asserting cases (each fails on the pre-fix template):
- gateway consumed the live carrier before resolution → snapshot still applies the override; `.active-session-model` = target; next restart reverts to configured default
- snapshot wins over a live carrier when both exist
- fable snapshot + LiteLLM up → applies **and** repoints to the router root
- attempts counter honored from its snapshot (crashloop bound survives the race)
- rendered-script ordering lock: snapshot lines < gateway fork < resolution block

Scoped runs (local): `tests/scaffold.session-model.test.ts` 50/50 pass; `tests/scaffold.routing-mode.test.ts` + `tests/doctor.test.ts` + `tests/doctor-fix-session-model.test.ts` 76 pass / 2 skipped; `telegram-plugin/tests/gateway-session-model-relaunch.test.ts` + `model-command.test.ts` 121/121 pass. `npm run lint` clean. CI is the full-suite authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)