### PR TITLE
refactor(gateway): give worker-feed origin-defer wiring real regression coverage (#3460)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -953,7 +953,7 @@ import {
 import { findAgentProcessInContainer } from './boot-probes.js'
 import { applySubagentsSchema, getSubagentByJsonlId, resolveSubagentOriginTurnKey, listNonTerminalSubagentsForTurn } from '../registry/subagents-schema.js'
 import type { InterruptedSubagent } from './resume-inbound-builder.js'
-import { resolveWorkerFeedDispatch, decideWorkerFeedOriginDefer, handleWorkerResume, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
+import { resolveWorkerFeedDispatch, decideWorkerFeedDestination, handleWorkerResume, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
 import {
   resolveSubagentStatusSurface,
   isOrphanSubagentStatusEnabled,
@@ -2180,6 +2180,20 @@ const WORKER_FEED_GROUP_MESSAGE_LIFETIME_CAP_MS = (() => {
 })()
 const workerFeedOwnerDmFallbackLogged = new Set<string>()
 
+// Once-per-agent owner-DM-fallback routing line (bounded FIFO set). Shared by
+// `resolveWorkerFeedChat` and the origin-defer paint path so both log alike.
+function noteWorkerFeedOwnerDmFallback(agentId: string): void {
+  if (workerFeedOwnerDmFallbackLogged.has(agentId)) return
+  workerFeedOwnerDmFallbackLogged.add(agentId)
+  if (workerFeedOwnerDmFallbackLogged.size > WORKER_FEED_FALLBACK_LOG_CAP) {
+    const oldest = workerFeedOwnerDmFallbackLogged.values().next().value
+    if (oldest != null) workerFeedOwnerDmFallbackLogged.delete(oldest)
+  }
+  process.stderr.write(
+    `telegram gateway: worker-feed origin unresolved agent=${agentId} — routing card to owner DM\n`,
+  )
+}
+
 // Per-agent consecutive origin-race deferrals (rationale in
 // `decideWorkerFeedOriginDefer`, worker-feed-dispatch.ts). Bounds the wait for
 // the `jsonl_agent_id` backfill; deleted on link, card-exists, and finish/drop
@@ -2221,20 +2235,8 @@ function resolveWorkerFeedChat(
   if (fleetChatId.length > 0) return { chatId: fleetChatId, threadId: fallbackThreadId }
   const ownerDm = loadAccess().allowFrom[0] ?? ''
   if (origin == null && fleetChatId.length === 0 && ownerDm.length > 0) {
-    // Routing decision, not a warning: origin resolution failed and no
-    // fleet chat is configured, so the nested worker's card lands in the
-    // owner DM. Logged ONCE per agent so the misroute is auditable
-    // without spamming every tick (the watcher drives onProgress ~1/s).
-    if (!workerFeedOwnerDmFallbackLogged.has(agentId)) {
-      workerFeedOwnerDmFallbackLogged.add(agentId)
-      if (workerFeedOwnerDmFallbackLogged.size > WORKER_FEED_FALLBACK_LOG_CAP) {
-        const oldest = workerFeedOwnerDmFallbackLogged.values().next().value
-        if (oldest != null) workerFeedOwnerDmFallbackLogged.delete(oldest)
-      }
-      process.stderr.write(
-        `telegram gateway: worker-feed origin unresolved agent=${agentId} — routing card to owner DM\n`,
-      )
-    }
+    // Origin unresolved and no fleet chat — the card lands in the owner DM.
+    noteWorkerFeedOwnerDmFallback(agentId)
   }
   return { chatId: ownerDm, threadId: origin?.threadId ?? fallbackThreadId }
 }
@@ -24908,53 +24910,48 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 // resolved (the pinned-card fleet that used to carry the chat
                 // is gone — see resolveSubagentOriginChat).
                 if (workerFeedEnabled) {
-                  // Origin-race defer (decideWorkerFeedOriginDefer): the first
-                  // tick of a fresh sub-agent can beat the async jsonl_agent_id
-                  // backfill that links its row to the origin turn — resolving
-                  // origin to null and CREATING the card in the owner DM, which
-                  // then stays visible even after the origin (supergroup + forum
-                  // topic) resolves ~3s later. Defer CARD CREATION until linked;
-                  // the watcher re-fires and paints in the correct chat+topic.
-                  const originResolved = resolveSubagentOriginChat(agentId) != null
-                  const cardExists = workerActivityFeed?.has(agentId) === true
-                  const { defer, deferrals } = decideWorkerFeedOriginDefer({
-                    originResolved,
-                    cardExists,
+                  // Origin-race defer + destination (decideWorkerFeedDestination,
+                  // worker-feed-dispatch.ts): the first tick of a fresh sub-agent
+                  // can beat the async jsonl_agent_id backfill that links its row
+                  // to the origin turn — origin resolves null and the card would be
+                  // CREATED in the owner DM, staying visible even after the origin
+                  // (supergroup + forum topic) resolves ~3s later. Defer CARD
+                  // CREATION until linked; the watcher re-fires and paints in the
+                  // right chat+topic. The FULL decision (defer-or-paint AND the
+                  // chat/thread resolution `resolveWorkerFeedChat` did) is now one
+                  // pure, unit-tested function; the gateway keeps only the defer-map
+                  // bookkeeping, the two audit logs, and the feed.update.
+                  const dest = decideWorkerFeedDestination({
+                    origin: resolveSubagentOriginChat(agentId),
+                    cardExists: workerActivityFeed?.has(agentId) === true,
                     priorDeferrals: workerFeedOriginDeferrals.get(agentId) ?? 0,
                     maxDeferrals: WORKER_FEED_ORIGIN_DEFER_MAX,
+                    fleetChatId,
+                    stampChatId: stampTurn?.sessionChatId,
+                    stampThreadId: stampTurn?.sessionThreadId,
+                    ownerDm: loadAccess().allowFrom[0] ?? '',
                   })
-                  if (defer) {
-                    workerFeedOriginDeferrals.set(agentId, deferrals)
-                    // Defer this tick: no card created, no owner-DM fallback.
-                    // The watcher re-fires once the jsonl_agent_id backfill links
-                    // the row to its origin turn, and the card is then created in
-                    // the correct chat+topic.
+                  if (dest.action === 'defer') {
+                    // No card created this tick; the watcher re-fires and paints
+                    // once the jsonl_agent_id backfill links the row to its origin.
+                    workerFeedOriginDeferrals.set(agentId, dest.deferrals)
                     return
                   }
-                  if (!originResolved && !cardExists) {
+                  // Painting: clear defer state so the map can't leak.
+                  workerFeedOriginDeferrals.delete(agentId)
+                  if (dest.exhausted) {
                     // Bounded-defer exhausted — backfill never linked (history
-                    // disabled / row reaped / ancestor never stamped). Stop
-                    // deferring and let the card paint so active work stays
-                    // visible (universal-liveness contract).
+                    // disabled / row reaped / ancestor never stamped). Paint anyway
+                    // so active work stays visible (universal-liveness contract).
                     process.stderr.write(
-                      `telegram gateway: worker-feed origin backfill never linked agent=${agentId} after ${deferrals} deferrals — painting card\n`,
+                      `telegram gateway: worker-feed origin backfill never linked agent=${agentId} after ${dest.deferrals} deferrals — painting card\n`,
                     )
                   }
-                  // Linked (or a card already exists, or defer exhausted): clear
-                  // any defer state so the map can't leak.
-                  workerFeedOriginDeferrals.delete(agentId)
-                  // Prefer the live turn's chat/topic over the owner DM if we do
-                  // have to fall back — a misroute at least lands near the work.
-                  const usingStampFallback = fleetChatId.length === 0
-                  const workerFleetChatId = usingStampFallback
-                    ? stampTurn?.sessionChatId ?? fleetChatId
-                    : fleetChatId
-                  // Carry the fallback chat's forum topic id (#3458) so the card lands in the origin topic, not General.
-                  const wk = resolveWorkerFeedChat(agentId, workerFleetChatId, usingStampFallback ? stampTurn?.sessionThreadId : undefined)
-                  const wkChat = wk.chatId
+                  // Card fell to the owner DM — log the misroute once per agent.
+                  if (dest.ownerDmFallback) noteWorkerFeedOwnerDmFallback(agentId)
                   void workerActivityFeed?.update(
                     agentId,
-                    wkChat,
+                    dest.chatId,
                     {
                       description: dispatch.feedDescription,
                       lastTool,
@@ -24968,7 +24965,7 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                       model: feedModel,
                       totalTokens,
                     },
-                    wk.threadId,
+                    dest.threadId,
                   )
                   // #3207: the feed pins the group's shared message itself when
                   // it first paints (reconcilePin → `wk:group:<feedKey>`); no

--- a/telegram-plugin/gateway/worker-feed-dispatch.ts
+++ b/telegram-plugin/gateway/worker-feed-dispatch.ts
@@ -81,6 +81,104 @@ export function decideWorkerFeedOriginDefer(input: {
   return { defer: true, deferrals }
 }
 
+/**
+ * The FULL worker-feed destination decision for a single onProgress tick,
+ * extracted verbatim from the gateway's inline `onProgress` block (issue
+ * #3460). It folds two concerns that the gateway used to run inline:
+ *
+ *  1. the origin-race defer choice (`decideWorkerFeedOriginDefer`), and
+ *  2. the chat/thread RESOLUTION the gateway's `resolveWorkerFeedChat`
+ *     performed (origin chat → fleet chat / stamp-turn fallback → owner DM),
+ *     including the exhausted-defer stamp-turn forum-thread carry (#3458).
+ *
+ * Returning a plain decision object lets the gateway keep only a thin
+ * delegation (defer-map bookkeeping + the two audit logs + the feed.update)
+ * and gives this whole path REAL regression coverage — the test drives THIS
+ * function, the same code the gateway runs, instead of a hand-rolled replica.
+ *
+ * Pure and side-effect-free: the two audit-log side effects the gateway used
+ * to emit inline (`exhausted`, `ownerDmFallback`) are returned as flags so the
+ * caller performs them against its module-level state. Behavior — routing — is
+ * identical to the prior inline path; only the seam moved.
+ *
+ * Precedence for a PAINT (mirrors `resolveWorkerFeedChat`):
+ *   origin chat (when resolved, non-empty) → fleet chat, else stamp-turn chat
+ *   when no fleet chat is configured (carrying the stamp-turn forum topic) →
+ *   owner DM (durable floor). Never returns an empty chat for a paint unless
+ *   every source is empty.
+ */
+export type WorkerFeedDestination =
+  | { action: 'defer'; deferrals: number }
+  | {
+      action: 'paint'
+      chatId: string
+      threadId: number | undefined
+      /** New consecutive-deferral count to persist (0 once painting resumes). */
+      deferrals: number
+      /** True when painting only because the bounded defer cap was hit and the
+       *  origin never linked — the gateway logs the "never linked" audit line. */
+      exhausted: boolean
+      /** True when the paint fell all the way to the owner DM (origin unresolved
+       *  AND no fleet/stamp chat) — the gateway logs the once-per-agent misroute. */
+      ownerDmFallback: boolean
+    }
+
+export function decideWorkerFeedDestination(input: {
+  /** Resolved origin chat/topic (`resolveSubagentOriginChat`), or null if the
+   *  `jsonl_agent_id` backfill hasn't linked the row to its origin turn yet. */
+  origin: { chatId: string; threadId?: number } | null
+  /** True if the feed already has a posted message for this worker. */
+  cardExists: boolean
+  /** Consecutive prior deferrals for this agent (0 on the first tick). */
+  priorDeferrals: number
+  /** Max consecutive deferrals before painting anyway. */
+  maxDeferrals: number
+  /** The gateway's outer `fleetChatId` (may be empty). */
+  fleetChatId: string
+  /** Live turn's chat (`stampTurn.sessionChatId`) — the stamp-turn fallback
+   *  used only when no fleet chat is configured. */
+  stampChatId?: string
+  /** Live turn's forum topic (`stampTurn.sessionThreadId`), carried on the
+   *  stamp-turn fallback so an exhausted-defer paint lands in the origin
+   *  topic, not General (#3458). */
+  stampThreadId?: number
+  /** Owner DM chat id (`loadAccess().allowFrom[0]`) — the durable floor. */
+  ownerDm: string
+}): WorkerFeedDestination {
+  const { origin, cardExists, priorDeferrals, maxDeferrals, fleetChatId, stampChatId, stampThreadId, ownerDm } = input
+  const originResolved = origin != null
+  const { defer, deferrals } = decideWorkerFeedOriginDefer({
+    originResolved,
+    cardExists,
+    priorDeferrals,
+    maxDeferrals,
+  })
+  if (defer) return { action: 'defer', deferrals }
+  // Painting: exhausted-defer iff we're painting despite no origin and no card.
+  const exhausted = !originResolved && !cardExists
+  // Prefer the live turn's chat/topic over the owner DM when we must fall back
+  // (a misroute at least lands near the work) — only when NO fleet chat is set.
+  const usingStampFallback = fleetChatId.length === 0
+  const workerFleetChatId = usingStampFallback ? stampChatId ?? fleetChatId : fleetChatId
+  const fallbackThreadId = usingStampFallback ? stampThreadId : undefined
+  // resolveWorkerFeedChat precedence:
+  if (origin != null && origin.chatId.length > 0) {
+    return { action: 'paint', chatId: origin.chatId, threadId: origin.threadId, deferrals, exhausted, ownerDmFallback: false }
+  }
+  if (workerFleetChatId.length > 0) {
+    return { action: 'paint', chatId: workerFleetChatId, threadId: fallbackThreadId, deferrals, exhausted, ownerDmFallback: false }
+  }
+  const ownerDmFallback = origin == null && workerFleetChatId.length === 0 && ownerDm.length > 0
+  return {
+    action: 'paint',
+    chatId: ownerDm,
+    threadId: origin?.threadId ?? fallbackThreadId,
+    deferrals,
+    exhausted,
+    ownerDmFallback,
+  }
+}
+
 export interface WorkerFeedDispatch {
   /** True when the sub-agent was dispatched with `run_in_background: true`. */
   isBackground: boolean

--- a/telegram-plugin/tests/worker-feed-origin-race-defer.test.ts
+++ b/telegram-plugin/tests/worker-feed-origin-race-defer.test.ts
@@ -5,21 +5,25 @@
  * progress tick of a new sub-agent. That tick can beat the async
  * `jsonl_agent_id` backfill that links the sub-agent's registry row to its
  * origin turn (retried ~every 3s). Until linked, origin resolution returns
- * null and `resolveWorkerFeedChat` hard-falls back to the owner DM — CREATING
- * the card there. The origin (supergroup + forum topic) resolves ~3s later,
- * but the DM card already exists and stays the visible one.
+ * null and the destination hard-falls back to the owner DM — CREATING the card
+ * there. The origin (supergroup + forum topic) resolves ~3s later, but the DM
+ * card already exists and stays the visible one.
  *
  * Fix (approach #1 — defer): when the agent is not yet linked AND no card
  * exists yet, SKIP card creation for that tick. The watcher re-fires within
  * seconds; once the backfill links the row the card is created in the correct
  * chat+topic.
  *
- * These tests assert the OUTCOME (no card ever posted to the owner DM), not
- * just the decision code path — the integration case drives the REAL
- * `createWorkerActivityFeed` with a mock Bot API that records every send.
+ * These tests exercise the REAL exported decision function
+ * `decideWorkerFeedDestination` (worker-feed-dispatch.ts) — the SAME code the
+ * gateway's `onProgress` block calls (issue #3460) — plus, in the integration
+ * case, the REAL `createWorkerActivityFeed` with a mock Bot API that records
+ * every send. A regression in the gateway's defer/route decision now fails a
+ * test, because the test binds to the shared function the gateway runs, not to
+ * a hand-rolled replica.
  */
 import { describe, it, expect } from 'vitest'
-import { decideWorkerFeedOriginDefer } from '../gateway/worker-feed-dispatch.js'
+import { decideWorkerFeedDestination } from '../gateway/worker-feed-dispatch.js'
 import {
   createWorkerActivityFeed,
   type BotApiForWorkerFeed,
@@ -27,57 +31,120 @@ import {
 } from '../worker-activity-feed.js'
 
 const MAX = 10
-
-describe('decideWorkerFeedOriginDefer (origin-race defer decision)', () => {
-  it('DEFERS the first tick of a not-yet-linked worker with no card', () => {
-    const out = decideWorkerFeedOriginDefer({
-      originResolved: false,
-      cardExists: false,
-      priorDeferrals: 0,
-      maxDeferrals: MAX,
-    })
-    expect(out.defer).toBe(true)
-    expect(out.deferrals).toBe(1)
-  })
-
-  it('does NOT defer once the origin has resolved (row linked)', () => {
-    const out = decideWorkerFeedOriginDefer({
-      originResolved: true,
-      cardExists: false,
-      priorDeferrals: 3,
-      maxDeferrals: MAX,
-    })
-    expect(out.defer).toBe(false)
-  })
-
-  it('does NOT defer when a card already exists (updates proceed)', () => {
-    const out = decideWorkerFeedOriginDefer({
-      originResolved: false,
-      cardExists: true,
-      priorDeferrals: 0,
-      maxDeferrals: MAX,
-    })
-    expect(out.defer).toBe(false)
-  })
-
-  it('stops deferring once the bounded cap is reached (pathological backfill)', () => {
-    // priorDeferrals = MAX-1 → this tick is the MAX-th; paint anyway.
-    const out = decideWorkerFeedOriginDefer({
-      originResolved: false,
-      cardExists: false,
-      priorDeferrals: MAX - 1,
-      maxDeferrals: MAX,
-    })
-    expect(out.defer).toBe(false)
-    expect(out.deferrals).toBe(MAX)
-  })
-})
-
-// ─── Integration: no card is ever created in the owner DM on the racing tick ──
-
 const OWNER_DM = '111111'
 const ORIGIN_CHAT = '-1002000000000' // supergroup
 const ORIGIN_THREAD = 42 // forum topic
+
+// The gateway resolves the owner DM from access config; the extracted pure
+// function takes it as an explicit input. All calls in this suite pass the
+// same owner DM so a fall-through to it is observable.
+function decide(overrides: Partial<Parameters<typeof decideWorkerFeedDestination>[0]>) {
+  return decideWorkerFeedDestination({
+    origin: null,
+    cardExists: false,
+    priorDeferrals: 0,
+    maxDeferrals: MAX,
+    fleetChatId: '',
+    stampChatId: undefined,
+    stampThreadId: undefined,
+    ownerDm: OWNER_DM,
+    ...overrides,
+  })
+}
+
+describe('decideWorkerFeedDestination (origin-race defer + routing decision)', () => {
+  it('(a) unlinked + no card → DEFER (no paint)', () => {
+    const out = decide({ origin: null, cardExists: false, priorDeferrals: 0 })
+    expect(out.action).toBe('defer')
+    if (out.action === 'defer') expect(out.deferrals).toBe(1)
+  })
+
+  it('(b) linked → PAINT to the origin chat + forum thread', () => {
+    const out = decide({
+      origin: { chatId: ORIGIN_CHAT, threadId: ORIGIN_THREAD },
+      cardExists: false,
+      priorDeferrals: 3,
+    })
+    expect(out.action).toBe('paint')
+    if (out.action === 'paint') {
+      expect(out.chatId).toBe(ORIGIN_CHAT)
+      expect(out.threadId).toBe(ORIGIN_THREAD)
+      expect(out.deferrals).toBe(0)
+      expect(out.exhausted).toBe(false)
+      expect(out.ownerDmFallback).toBe(false)
+    }
+  })
+
+  it('(c) exhausted defer (never-backfill, forum) → PAINT to the stamp chat + stamp FORUM THREAD, not owner DM', () => {
+    // priorDeferrals = MAX-1 → this tick is the MAX-th: paint anyway. No fleet
+    // chat is configured, so the destination is the live turn's chat AND its
+    // forum topic (stamp-turn fallback, #3458) — NOT General, NOT the owner DM.
+    const out = decide({
+      origin: null,
+      cardExists: false,
+      priorDeferrals: MAX - 1,
+      fleetChatId: '',
+      stampChatId: ORIGIN_CHAT,
+      stampThreadId: ORIGIN_THREAD,
+    })
+    expect(out.action).toBe('paint')
+    if (out.action === 'paint') {
+      expect(out.chatId).toBe(ORIGIN_CHAT)
+      expect(out.threadId).toBe(ORIGIN_THREAD) // forum topic carried, not General
+      expect(out.chatId).not.toBe(OWNER_DM)
+      expect(out.exhausted).toBe(true)
+      expect(out.deferrals).toBe(MAX)
+    }
+  })
+
+  it('exhausted defer with NO stamp chat → owner DM (durable floor), flagged as fallback', () => {
+    const out = decide({
+      origin: null,
+      cardExists: false,
+      priorDeferrals: MAX - 1,
+      fleetChatId: '',
+      stampChatId: undefined,
+    })
+    expect(out.action).toBe('paint')
+    if (out.action === 'paint') {
+      expect(out.chatId).toBe(OWNER_DM)
+      expect(out.ownerDmFallback).toBe(true)
+      expect(out.exhausted).toBe(true)
+    }
+  })
+
+  it('(d) existing card always PAINTS (updates proceed) even while unlinked', () => {
+    const out = decide({
+      origin: null,
+      cardExists: true,
+      priorDeferrals: 0,
+      fleetChatId: ORIGIN_CHAT,
+    })
+    expect(out.action).toBe('paint')
+    if (out.action === 'paint') {
+      expect(out.chatId).toBe(ORIGIN_CHAT)
+      expect(out.deferrals).toBe(0)
+    }
+  })
+
+  it('fleet chat wins over the stamp fallback when configured', () => {
+    const out = decide({
+      origin: null,
+      cardExists: true, // paint (not defer) so we observe the route
+      fleetChatId: ORIGIN_CHAT,
+      stampChatId: '999999',
+      stampThreadId: 7,
+    })
+    expect(out.action).toBe('paint')
+    if (out.action === 'paint') {
+      expect(out.chatId).toBe(ORIGIN_CHAT)
+      // Fleet-chat route carries no stamp thread (usingStampFallback is false).
+      expect(out.threadId).toBeUndefined()
+    }
+  })
+})
+
+// ─── Integration: the real feed, driven by the real decision ──────────────────
 
 interface SentRecord {
   chatId: string
@@ -101,11 +168,10 @@ function makeRecordingBot(sent: SentRecord[]): BotApiForWorkerFeed {
 }
 
 /**
- * Faithful model of the gateway `onProgress` worker-feed block (gateway.ts):
- * run the real defer decision, and — only when NOT deferring — call the real
- * feed with the resolved chat. `resolveOrigin` mimics `resolveSubagentOriginChat`
- * (null until the backfill links the row); the owner-DM fallback mirrors
- * `resolveWorkerFeedChat` (origin → owner DM when unresolved).
+ * Faithful model of the gateway `onProgress` worker-feed block: run the REAL
+ * `decideWorkerFeedDestination` and — only when it says paint — call the real
+ * feed with the resolved chat/thread. `resolveOrigin` mimics
+ * `resolveSubagentOriginChat` (null until the backfill links the row).
  */
 function workerFeedTick(
   feed: ReturnType<typeof createWorkerActivityFeed>,
@@ -113,29 +179,26 @@ function workerFeedTick(
   agentId: string,
   resolveOrigin: () => { chatId: string; threadId?: number } | null,
   view: WorkerActivityView,
-  // The fallback used when origin is unresolved. Mirrors the gateway's
-  // exhausted-defer paint: the live turn's chat + its sibling forum-topic id
-  // (stampTurn.sessionChatId / .sessionThreadId), else the owner DM.
-  fallback: { chatId: string; threadId?: number } = { chatId: OWNER_DM, threadId: undefined },
+  // The stamp-turn fallback used when no fleet chat is configured. Mirrors the
+  // gateway's exhausted-defer paint source (stampTurn.sessionChatId / thread).
+  stamp: { chatId?: string; threadId?: number } = { chatId: OWNER_DM, threadId: undefined },
 ): void {
-  const origin = resolveOrigin()
-  const originResolved = origin != null
-  const cardExists = feed.has(agentId)
-  const { defer, deferrals: next } = decideWorkerFeedOriginDefer({
-    originResolved,
-    cardExists,
+  const dest = decideWorkerFeedDestination({
+    origin: resolveOrigin(),
+    cardExists: feed.has(agentId),
     priorDeferrals: deferrals.get(agentId) ?? 0,
     maxDeferrals: MAX,
+    fleetChatId: '',
+    stampChatId: stamp.chatId,
+    stampThreadId: stamp.threadId,
+    ownerDm: OWNER_DM,
   })
-  if (defer) {
-    deferrals.set(agentId, next)
+  if (dest.action === 'defer') {
+    deferrals.set(agentId, dest.deferrals)
     return
   }
   deferrals.delete(agentId)
-  // resolveWorkerFeedChat: origin chat when resolved, else the fallback
-  // chat AND its forum-topic id (#3458) — never dropping the thread.
-  const chat = originResolved ? origin! : fallback
-  void feed.update(agentId, chat.chatId, view, chat.threadId)
+  void feed.update(agentId, dest.chatId, view, dest.threadId)
 }
 
 describe('worker-feed origin race — outcome: no owner-DM card', () => {
@@ -216,7 +279,8 @@ describe('worker-feed origin race — outcome: no owner-DM card', () => {
 
     // The first MAX-1 ticks deferred; the MAX-th painted. The universal-liveness
     // contract wins over infinite silence, so a card IS eventually created —
-    // here to the owner DM (the only resort when origin never resolves).
+    // here to the owner DM (the only resort when origin never resolves and no
+    // stamp chat is set).
     expect(sent.length).toBeGreaterThanOrEqual(1)
     expect(sent.every((s) => s.chatId === OWNER_DM)).toBe(true)
   })


### PR DESCRIPTION
## Summary

The `onProgress` worker-feed destination decision — the origin-race **defer-or-paint** choice AND the chat/thread **resolution** (`resolveWorkerFeedChat`) — lived inline in the gateway's `onProgress` closure (`telegram-plugin/gateway/gateway.ts`) and was only covered by a hand-rolled **replica** (`workerFeedTick`) in the test. A regression in the real gateway lines would therefore fail no test.

This PR extracts the full decision into an exported pure function that the real gateway calls, and rewrites the test to bind to that shared function.

## Why

Test-faithfulness: the wiring added in #3458 (defer worker-feed card creation until the sub-agent origin links, + carry the forum topic on the exhausted-defer fallback) had no coverage of the code the gateway actually runs.

## What changed

- **New exported pure `decideWorkerFeedDestination`** in `telegram-plugin/gateway/worker-feed-dispatch.ts`. Takes plain inputs (`origin`, `cardExists`, `priorDeferrals`, `maxDeferrals`, `fleetChatId`, `stampChatId`, `stampThreadId`, `ownerDm`) and returns a plain decision: `{action:'defer', deferrals}` or `{action:'paint', chatId, threadId, deferrals, exhausted, ownerDmFallback}`. It folds `decideWorkerFeedOriginDefer` (kept, still exported) with the `resolveWorkerFeedChat` precedence: origin chat → fleet chat / stamp-turn fallback (carrying the #3458 forum topic) → owner DM. The two audit-log side effects are returned as flags so the gateway performs them against its module state.
- **gateway.ts now CALLS the extracted fn** instead of doing the logic inline. The inline decision is removed; `resolveSubagentOriginChat` is now called once per tick instead of twice. A shared `noteWorkerFeedOwnerDmFallback` helper backs both `resolveWorkerFeedChat` and the origin-defer paint path so both log the misroute identically. **Net gateway.ts delta: -3 lines** (25103 → 25100; ratchet clean) — also chips at the #3461 line-ratchet.
- **Test rewritten** (`telegram-plugin/tests/worker-feed-origin-race-defer.test.ts`): the `workerFeedTick` replica is deleted; every assertion now drives the real `decideWorkerFeedDestination`. Cases: (a) unlinked + no card → defer, no paint; (b) linked → paint origin chat + forum thread; (c) exhausted defer → paint stamp chat + stamp FORUM thread (not General, not owner DM); (d) existing card → always paint. The integration case still drives the real `createWorkerActivityFeed` through the real decision.

## Behavior

Identical — pure refactor + test-faithfulness change, **no routing change**. Routing precedence, defer bounds, the exhausted-defer forum-thread carry (#3458), and the once-per-agent owner-DM audit line are all preserved.

## Test plan

- `vitest run` on the two worker-feed suites: **36 passed** (9 in the rewritten origin-race suite, 27 in worker-feed-dispatch).
- `npm run lint` (tsc + all guards incl. `check-gateway-line-ratchet.mjs` and `check-bot-api-wrapping`): **clean**.

## Risk

Low. No functional change to worker-feed routing; the extraction is a mechanical move of the decision into a unit-tested seam. Job spec: universal-liveness contract (any active work has a card, in the right chat+topic).

Closes #3460
Refs #3461

🤖 Generated with [Claude Code](https://claude.com/claude-code)