### PR TITLE
fix(telegram): escape accidental line-leading `#` headings at the universal send seam

### DIFF
--- a/telegram-plugin/render/line-start-guard.ts
+++ b/telegram-plugin/render/line-start-guard.ts
@@ -43,11 +43,20 @@
 // punctuation may be backslash-escaped" rule; Telegram's rich parser strips
 // the backslash the same way `escapeMarkdown` relies on for `~ = | * _`.
 //
+// ── Accidental heading (`#3460`, `#foo`) — guarded by guardAccidentalHeading ─
+//   Telegram's Bot API rich-markdown parser is NON-spec: it promotes ANY
+//   line-leading `#{1,6}` run to a heading even WITHOUT the CommonMark-required
+//   trailing space (`#3460 done` renders as a huge heading). This is
+//   deterministically disambiguable: a `#{1,6}` run followed by a space,
+//   another `#`, or end-of-line is an INTENDED heading (or ambiguous) and is
+//   LEFT ALONE; a run glued to a non-space, non-`#` char (`#3460`, `#foo`,
+//   `###x`) is the accidental Telegram-only heading and IS escaped. See
+//   `guardAccidentalHeading` below — it mirrors the render.ts:escapeLineLeadingHash
+//   fix (#3306) but runs at the universal wire seam, independent of the
+//   SWITCHROOM_RICH_RENDER kill-switch, so cards/banners/status/approval sends
+//   (which bypass the rich renderer) are also covered.
+//
 // ── What is DEFERRED (left to the rich-formatting workstream) ────────────
-//   • Heading `# ` (with the required space): indistinguishable from an
-//     INTENDED heading. `#1` / `#foo` (NO space) is not a GFM heading at all
-//     (ATX headings require `#`+space) → Telegram renders it literally → no
-//     guard needed. So there is no safely-guardable heading sub-case.
 //   • Bullet lists `-`/`+`/`*` + space (`- 5 degrees`): genuinely ambiguous
 //     with the heavily-used bullet construct; the glued form `-5` (no space)
 //     is not a list item → already literal → no guard needed. Escaping the
@@ -157,6 +166,69 @@ export function guardAccidentalBlockConstructs(text: string): string {
       // so its first line is a real line start only if the running flag says so.
       const lineIsAtStart = k === 0 ? atLineStart : true;
       const processed = lineIsAtStart ? escapeAccidentalLineStart(lines[k]) : lines[k];
+      out += processed;
+      if (k < lines.length - 1) out += "\n";
+    }
+    atLineStart = seg.text.endsWith("\n");
+  }
+
+  return out;
+}
+
+/** Line-start `#{1,6}` run glued DIRECTLY to a non-space, non-`#` char — the
+ *  Telegram-non-spec accidental heading (`#3460`, `#foo`, `###x`). The negative
+ *  lookahead `(?=[^\s#])` requires a following char that is neither whitespace,
+ *  a `#`, nor end-of-line, so an intended `# Title` / `## Sub` (space-delimited)
+ *  and a bare `#` / `##` (end-of-line) are NEVER matched. Up to 3 leading spaces
+ *  are permitted (4+ is indented code, and the `{0,3}` bound then leaves a space
+ *  before the `#`, so it correctly does not match). Only the first `#` of the run
+ *  is backslash-escaped, which is sufficient to stop Telegram promoting the line
+ *  to a heading. Idempotent: an already-escaped `\#3460` starts with `\`, so the
+ *  `#{1,6}` no longer sits at the (post-indent) line start. */
+const ACCIDENTAL_HEADING = /^([ \t]{0,3})(#{1,6})(?=[^\s#])/;
+
+/**
+ * Escape the accidental heading trigger at the start of ONE line (the string
+ * must NOT contain a newline; the caller guarantees a true line start). A no-op
+ * unless the line begins with a `#{1,6}` run glued to a non-space, non-`#` char.
+ */
+function escapeAccidentalHeadingLine(line: string): string {
+  return line.replace(ACCIDENTAL_HEADING, "$1\\$2");
+}
+
+/**
+ * Neutralise accidental line-start HEADING promotion (`#3460 done` → giant
+ * heading) on the FINAL rendered rich-markdown string. Telegram's Bot API
+ * parser promotes a line-leading `#{1,6}` run to a heading even without the
+ * CommonMark-required trailing space; this escapes ONLY the space-less,
+ * non-`#`-adjacent form and leaves genuine `# Title` / `## Sub` headings
+ * untouched. Code spans / fenced blocks / link destinations / table rows are
+ * never touched (shared `splitProtectedSegments`). Idempotent and a strict
+ * no-op absent a real signal. Mirrors render.ts:escapeLineLeadingHash (#3306)
+ * but runs at the universal wire seam, so it also covers the card / banner /
+ * status / approval sends that bypass the rich renderer.
+ */
+export function guardAccidentalHeading(text: string): string {
+  // Cheap short-circuit: no `#` at all => no-op.
+  if (!text.includes("#")) return text;
+
+  const segments = splitProtectedSegments(text);
+  let out = "";
+  // True at text start and immediately after any emitted `\n`.
+  let atLineStart = true;
+
+  for (const seg of segments) {
+    if (seg.code) {
+      out += seg.text;
+      atLineStart = seg.text.endsWith("\n");
+      continue;
+    }
+    const lines = seg.text.split("\n");
+    for (let k = 0; k < lines.length; k++) {
+      // A prose segment can begin MID-LINE (right after an inline code span),
+      // so its first line is a real line start only if the running flag says so.
+      const lineIsAtStart = k === 0 ? atLineStart : true;
+      const processed = lineIsAtStart ? escapeAccidentalHeadingLine(lines[k]) : lines[k];
       out += processed;
       if (k < lines.length - 1) out += "\n";
     }

--- a/telegram-plugin/rich-send.ts
+++ b/telegram-plugin/rich-send.ts
@@ -20,7 +20,7 @@
 import { GrammyError } from 'grammy'
 import { guardDollarMath } from './render/dollar-math-guard.js'
 import { guardAccidentalEmphasis } from './render/emphasis-guard.js'
-import { guardAccidentalBlockConstructs } from './render/line-start-guard.js'
+import { guardAccidentalBlockConstructs, guardAccidentalHeading } from './render/line-start-guard.js'
 import { guardAccidentalInlinePairs } from './render/inline-pairs-guard.js'
 
 /** The `InputRichMessage` shape grammy 1.44 accepts on send AND edit. */
@@ -36,6 +36,12 @@ export interface InputRichMessageMarkdown {
  * idempotent and safe to apply once per send.
  *
  * ── Ordering (deliberate, not arbitrary) ──────────────────────────────────
+ * `guardAccidentalHeading` runs right after emphasis and before block-constructs.
+ * It only ever inserts `\` before a line-leading `#{1,6}` run; `#` is inspected
+ * and inserted by no other guard (disjoint char set), so its position among the
+ * siblings is order-independent — it neither creates nor destroys a signal for
+ * any of them.
+ *
  * `guardDollarMath` runs LAST. It backslash-escapes `$` → `\$`, and the
  * inline-pairs guard's approximation-tilde signal is `~(?=\$?\.?\d)` — a `~`
  * glued to a `$digit`. If the dollar guard ran first, a body like
@@ -51,6 +57,7 @@ export interface InputRichMessageMarkdown {
 export function guardAccidentalFormatting(markdown: string): string {
   let out = markdown
   out = guardAccidentalEmphasis(out)
+  out = guardAccidentalHeading(out)
   out = guardAccidentalBlockConstructs(out)
   out = guardAccidentalInlinePairs(out)
   out = guardDollarMath(out)

--- a/telegram-plugin/tests/render/heading-guard.test.ts
+++ b/telegram-plugin/tests/render/heading-guard.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { guardAccidentalHeading } from "../../render/line-start-guard.js";
+import { guardAccidentalFormatting } from "../../rich-send.js";
+
+// Accidental-heading guard (#3306 follow-up): Telegram's Bot API rich-markdown
+// parser is NON-spec and promotes a line-leading `#{1,6}` run to a heading even
+// WITHOUT the CommonMark-required trailing space, so `#3460 done` renders as a
+// giant heading. The guard escapes ONLY the space-less, non-`#`-adjacent form
+// and leaves genuine `# Title` / `## Sub` headings byte-for-byte untouched.
+//
+// The load-bearing assertions run against the REAL universal wire seam
+// `guardAccidentalFormatting` (rich-send.ts) — the composed guard every
+// `{ markdown }` send funnels through — not the renderer, so cards / banners /
+// status / approval sends (which bypass the rich renderer) are proven covered.
+
+/** Strip the defusing backslash so we can assert the reader-visible text is
+ *  byte-identical to the original prose (Telegram consumes the `\`). */
+function copyText(s: string): string {
+  return s.replace(/\\#/g, "#");
+}
+
+describe("guardAccidentalHeading — accidental Telegram heading is escaped", () => {
+  it("escapes ONLY the line-leading `#3460`, not the mid-line `#3462` after `PR `", () => {
+    expect(guardAccidentalHeading("#3460 done and up as PR #3462")).toBe(
+      "\\#3460 done and up as PR #3462",
+    );
+  });
+
+  it("escapes `#foo` (no space, glued to a letter)", () => {
+    expect(guardAccidentalHeading("#foo bar")).toBe("\\#foo bar");
+  });
+
+  it("escapes `###x` (multi-hash run, no space)", () => {
+    expect(guardAccidentalHeading("###x")).toBe("\\###x");
+  });
+
+  it("reader-visible text is byte-identical after stripping the backslash", () => {
+    const s = "#3460 done";
+    expect(copyText(guardAccidentalHeading(s))).toBe(s);
+  });
+});
+
+describe("guardAccidentalHeading — intended headings are NEVER touched", () => {
+  it("leaves `# Real Heading` (space form) untouched", () => {
+    const s = "# Real Heading";
+    expect(guardAccidentalHeading(s)).toBe(s);
+  });
+
+  it("leaves `## Sub` untouched", () => {
+    const s = "## Sub";
+    expect(guardAccidentalHeading(s)).toBe(s);
+  });
+
+  it("leaves a bare `#` / `##` (end-of-line) untouched", () => {
+    expect(guardAccidentalHeading("#")).toBe("#");
+    expect(guardAccidentalHeading("##\nbody")).toBe("##\nbody");
+  });
+
+  it("leaves a multi-line mix intact: heading kept, glued ref escaped", () => {
+    const s = "# Title\n#3460 is the issue";
+    expect(guardAccidentalHeading(s)).toBe("# Title\n\\#3460 is the issue");
+  });
+
+  it("leaves a 4-space indented `#3460` (indented code) untouched", () => {
+    const s = "    #3460 indented code";
+    expect(guardAccidentalHeading(s)).toBe(s);
+  });
+});
+
+describe("guardAccidentalHeading — code spans / fences are verbatim", () => {
+  it("does not escape `#` inside an inline code span", () => {
+    expect(guardAccidentalHeading("`#3460`")).toBe("`#3460`");
+  });
+
+  it("does not escape a line-leading `#3460` inside a fenced block", () => {
+    const s = "```\n#3460 in code\n```";
+    expect(guardAccidentalHeading(s)).toBe(s);
+  });
+});
+
+describe("guardAccidentalHeading — idempotent + no-op", () => {
+  it("running twice equals running once", () => {
+    const once = guardAccidentalHeading("#3460 done");
+    expect(guardAccidentalHeading(once)).toBe(once);
+  });
+
+  it("is a strict no-op on hash-free text", () => {
+    const s = "no hashes here at all";
+    expect(guardAccidentalHeading(s)).toBe(s);
+  });
+});
+
+describe("guardAccidentalFormatting (universal seam) escapes accidental headings", () => {
+  it("escapes the line-leading `#3460`, leaves the mid-line `#3462`", () => {
+    expect(
+      guardAccidentalFormatting("#3460 done and up as PR #3462"),
+    ).toBe("\\#3460 done and up as PR #3462");
+  });
+
+  it("leaves `# Real Heading` untouched through the full composition", () => {
+    expect(guardAccidentalFormatting("# Real Heading")).toBe("# Real Heading");
+  });
+
+  it("does not double-escape an already-escaped `\\#3460` (renderer belt + seam)", () => {
+    // render.ts:escapeLineLeadingHash may already have escaped the `#`; the seam
+    // must not turn `\#3460` into `\\#3460`.
+    expect(guardAccidentalFormatting("\\#3460 done")).toBe("\\#3460 done");
+  });
+
+  it("is idempotent at the seam", () => {
+    const once = guardAccidentalFormatting("#3460 done");
+    expect(guardAccidentalFormatting(once)).toBe(once);
+  });
+});


### PR DESCRIPTION
## Summary

A reply line starting with `#` glued to a non-space char (e.g. `#3460 done`) renders as a giant HEADING in Telegram. Telegram's Bot API rich-markdown parser is **non-spec**: it promotes any line-leading `#{1,6}` run to a heading even without the CommonMark-required trailing space. This fix escapes that accidental form at the universal outbound send seam, so every card / banner / status / approval / reply send is covered.

## Why — two guards disagreed, and the load-bearing one bypassed the fix

- The #3306 fix (`escapeLineLeadingHash`, `render/render.ts:226`) already escapes line-leading `#`, but it runs **only inside the rich renderer** (`render/rich-render.ts`), which is (a) behind the `SWITCHROOM_RICH_RENDER` kill-switch and (b) wired to a single call site. `richMessage`/`sendRichMessage` callers — cards, banners, status lines, approvals, interceptor sends — **bypass it entirely**.
- The universal seam every `{ markdown }` send funnels through — `guardAccidentalFormatting` in `rich-send.ts` — did **not** escape `#`. And `guardAccidentalBlockConstructs` (`render/line-start-guard.ts`) explicitly **deferred** `#` on a now-false assumption ("`#foo` without a space is not a GFM heading → renders literally"), which directly contradicts `render.ts`'s own doc that Telegram promotes it anyway.

So the two guards disagreed, and the load-bearing one (the seam) declined to act. The seam is the load-bearing fix because it is the single deterministic point every markdown-parsed outbound passes through exactly once — escaping here makes the fix unconditional and kill-switch-independent.

## The CommonMark-correct rule

Escape a line-leading `#{1,6}` run **only when it is NOT followed by a space, another `#`, or end-of-line**:

```
/^([ \t]{0,3})(#{1,6})(?=[^\s#])/  →  "$1\\$2"
```

- `#3460` / `#foo` / `###x` (Telegram-only accidental heading) → escaped
- `# Title` / `## Sub` (space form) / bare `#` (EOL) → **untouched**
- Reuses `splitProtectedSegments` so `#` inside code spans / fenced blocks / links / table rows is never touched
- Idempotent, and does **not** double-escape an already-escaped `\#` from the renderer belt (verified by test)

Wired into `guardAccidentalFormatting` right after emphasis, before block-constructs — disjoint char set (`#` inspected/inserted by no other guard), so ordering is safe. The render.ts:226 escape is left as-is (harmless idempotent belt).

## Test plan

- New `telegram-plugin/tests/render/heading-guard.test.ts` (17 tests) asserts on the **real** `guardAccidentalHeading` and the composed `guardAccidentalFormatting` seam.
- Scoped: `vitest run telegram-plugin/tests/render/` + `formatting-parse-regression` → **275 passed**.
- `npm run lint` (tsc + 11 guards) → clean.

## Risk

Low. Additive, disjoint-char guard at an already-idempotent seam; no existing test changed. `plain`-mode degradations bypass the seam and are untouched.

Prior art: #3306 (partial fix, renderer-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
