### PR TITLE
test(render): characterize glued-# after blockquote/list marker (#3464)

### DIFF
--- a/telegram-plugin/tests/render/heading-guard-blockquote-glued-hash.test.ts
+++ b/telegram-plugin/tests/render/heading-guard-blockquote-glued-hash.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { guardAccidentalHeading } from "../../render/line-start-guard.js";
+import { guardAccidentalFormatting } from "../../rich-send.js";
+
+// Characterization test for #3464 — glued `#` AFTER a blockquote/list marker.
+//
+// ── The observation (#3464, follow-up from #3463 review) ─────────────────────
+// `guardAccidentalHeading` is `^`-anchored (`ACCIDENTAL_HEADING = /^([ \t]{0,3})
+// (#{1,6})(?=[^\s#])/`), so a `#` glued after a blockquote or list marker on the
+// same line — `> #3460`, `- #3460`, `1. #3460` — is NOT matched, and the seam
+// leaves it untouched. On the RENDERER path this position is incidentally
+// escaped, because render.ts:escapeLineLeadingHash runs on the paragraph's
+// rendered text BEFORE renderBlockquote/renderList prepend the `> `/`- ` marker.
+// On the renderer-BYPASS seam (cards / banners / status / approval sends), no
+// such belt runs, so the glued `#` reaches Telegram unescaped.
+//
+// ── Why this test PINS the current behavior instead of changing it ───────────
+// Whether this is a bug depends on a fact we CANNOT determine from the byte
+// stream: does Telegram's non-spec Bot API rich parser actually promote a
+// space-less `#` to a heading when it sits AFTER a `>`/list marker, the way it
+// demonstrably does at a bare line start (`#3460` → giant heading, #3306/#3463)?
+//   - CommonMark treats `> #3460` as a blockquote whose content is the paragraph
+//     `#3460` (no ATX heading — no space after `#`); `> # Heading` (WITH space)
+//     is a real nested heading. Telegram's promotion of the SPACE-LESS form is
+//     the documented non-spec deviation — but only ever OBSERVED at a bare line
+//     start, never confirmed inside a blockquote/list.
+//   - There is no repo evidence (UAT fixture, doc note, or #3306/#3463 UAT
+//     result) establishing that the promotion fires in this nested position.
+//     The render.ts belt escaping it is a GENERIC side effect of a `^…#`
+//     paragraph regex, not a confirmed-behavior signal.
+// Issue #3464 itself says: "Verify against Telegram live-UAT whether the
+// non-spec heading promotion actually fires inside blockquotes/lists before
+// adding escaping (avoid stray backslashes if it does not)." That live UAT
+// cannot run in vitest. Ken's hard constraint on this guard family is that a
+// wrong "fix" adding stray backslashes would itself corrupt legitimate
+// formatting — the exact thing to avoid. So this test DOCUMENTS the current,
+// deliberately-conservative behavior; if live UAT later confirms Telegram DOES
+// promote here, extend the guard and flip these expectations in the same PR.
+
+describe("guardAccidentalHeading — glued `#` after a blockquote/list marker is NOT escaped (#3464, awaits live-UAT)", () => {
+  it("leaves `> #3460` untouched (glued hash after a blockquote marker)", () => {
+    expect(guardAccidentalHeading("> #3460 done")).toBe("> #3460 done");
+  });
+
+  it("leaves `- #3460` untouched (glued hash after an unordered-list marker)", () => {
+    expect(guardAccidentalHeading("- #3460 done")).toBe("- #3460 done");
+  });
+
+  it("leaves `* #3460` untouched (glued hash after a `*` bullet)", () => {
+    expect(guardAccidentalHeading("* #3460 x")).toBe("* #3460 x");
+  });
+
+  it("leaves `1. #3460` untouched (glued hash after an ordered-list marker)", () => {
+    expect(guardAccidentalHeading("1. #3460 x")).toBe("1. #3460 x");
+  });
+
+  it("still escapes the SAME `#3460` at a bare line start (the confirmed case)", () => {
+    // Proves the untouched results above are the `^`-anchor scope, not the guard
+    // being disabled: at a real line start the accidental heading IS escaped.
+    expect(guardAccidentalHeading("#3460 done")).toBe("\\#3460 done");
+  });
+});
+
+describe("guardAccidentalHeading — a real nested heading (space form) must stay untouched (#3464)", () => {
+  it("leaves `> # Heading` untouched (intended heading inside a blockquote)", () => {
+    expect(guardAccidentalHeading("> # Heading")).toBe("> # Heading");
+  });
+
+  it("leaves `- # Heading` untouched (intended heading inside a list item)", () => {
+    expect(guardAccidentalHeading("- # Heading")).toBe("- # Heading");
+  });
+});
+
+describe("guardAccidentalFormatting (universal seam) — same conservative behavior end-to-end (#3464)", () => {
+  it("leaves `> #3460` untouched through the full composition", () => {
+    expect(guardAccidentalFormatting("> #3460 done")).toBe("> #3460 done");
+  });
+
+  it("leaves `- #3460` untouched through the full composition", () => {
+    expect(guardAccidentalFormatting("- #3460 done")).toBe("- #3460 done");
+  });
+
+  it("still escapes a bare line-leading `#3460` at the seam (control)", () => {
+    expect(guardAccidentalFormatting("#3460 done")).toBe("\\#3460 done");
+  });
+});


### PR DESCRIPTION
## Summary

Verify-first outcome for #3464. I took the **characterization-test path**, not
an escaping change — see "Why" below.

`telegram-plugin/tests/render/heading-guard-blockquote-glued-hash.test.ts`
pins the CURRENT, deliberately-conservative behavior of the accidental-heading
guard for a `#` glued after a blockquote/list marker:

- `> #3460`, `- #3460`, `* #3460`, `1. #3460` → left untouched (both at
  `guardAccidentalHeading` and through the full `guardAccidentalFormatting` seam)
- bare line-start `#3460` → still escaped (`\#3460`) — control proving the
  untouched results are the `^`-anchor scope, not the guard disabled
- real nested headings `> # Heading` / `- # Heading` (space form) → untouched

## Why I did NOT add escaping (verify-first conclusion)

#3464 flags that `guardAccidentalHeading` (`^`-anchored) does not escape a `#`
glued after a `>`/list marker on the renderer-bypass path, and asks to **verify
via live-UAT whether Telegram's non-spec parser actually promotes a heading in
that nested position before adding escaping** (to avoid stray backslashes if it
does not).

Evidence gathered:

- **No repo evidence** establishes the promotion fires in the nested position.
  The `#3306`/`#3463` non-spec behavior is only ever observed/asserted at a
  **bare line start**. The rich-formatting UAT
  (`jtbd-rich-formatting-render-dm`) does not cover it.
- The renderer path escaping this position (`render.ts:escapeLineLeadingHash`
  runs on paragraph text before `renderBlockquote`/`renderList` prepend the
  marker) is a **generic side effect** of a `^…#` paragraph regex, not a
  confirmed-behavior signal about Telegram.
- CommonMark treats `> #3460` as a blockquote containing the paragraph `#3460`
  (no heading); only `> # Heading` (with space) is a nested ATX heading.
  Telegram's space-less promotion is the documented deviation — but its scope
  inside blockquotes/lists is genuinely uncertain.
- Live Telegram UAT can't run in vitest / from this environment.

Ken's hard constraint on this guard family is that a wrong "fix" adding stray
backslashes would itself restrict/corrupt legitimate formatting — the exact
thing to avoid. So rather than guess-fix, this PR pins the current behavior and
leaves a comment: if live-UAT later confirms Telegram promotes here, extend the
guard (reusing the existing lookahead + `splitProtectedSegments`) and flip these
expectations in the same PR.

## Test plan

- `vitest run telegram-plugin/tests/render/heading-guard-blockquote-glued-hash.test.ts` → 10 passed
- `npm run lint` → clean

## Risk

None — test-only, no source/escaping change, so no legitimate formatting can be
restricted.

Refs #3464
Job spec: `reference/jobs/` rich-formatting render (Bot API 10.1 markdown send).

🤖 Generated with [Claude Code](https://claude.com/claude-code)