### PR TITLE
fix(telegram): single-writer election kills duplicate silent-end replies

### DIFF
--- a/telegram-plugin/gateway/gateway-heartbeat.ts
+++ b/telegram-plugin/gateway/gateway-heartbeat.ts
@@ -1,0 +1,72 @@
+/**
+ * Gateway liveness heartbeat (duplicate-message fix, single-writer election).
+ *
+ * The silent-end Stop hook's single-writer election (see
+ * `hooks/silent-end-scan.mjs` `decideStopHookDisposition`) may ALLOW a turn to
+ * end without re-prompting — handing delivery of the model's trailing prose to
+ * the gateway's turn-end flush / captured-prose bridge. That hand-off is only
+ * safe when the gateway is actually alive and WILL run its `turn_end` handler.
+ * Allowing into a DEAD gateway would drop the answer entirely — the one outcome
+ * worse than a duplicate.
+ *
+ * Existing markers under `TELEGRAM_STATE_DIR` (`turn-active.json`) only exist
+ * DURING a turn and are removed at turn_complete, so they can't prove
+ * "gateway alive and ready to process the NEXT turn_end". This adds a minimal,
+ * always-on gateway heartbeat: the gateway process touches
+ * `<STATE_DIR>/gateway-heartbeat` on a fixed interval while it lives. The Stop
+ * hook stats its mtime and requires it fresh before electing an allow.
+ *
+ * Pure file I/O, best-effort — the heartbeat is a safety gate, never a
+ * correctness dependency of the turn path. A write failure just means the hook
+ * conservatively BLOCKS (re-prompt), which is the safe direction.
+ */
+
+import { mkdirSync, utimesSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** Filename under `TELEGRAM_STATE_DIR`. MUST stay in sync with
+ * `GATEWAY_HEARTBEAT_FILE` in `hooks/silent-end-scan.mjs`. */
+export const GATEWAY_HEARTBEAT_FILE = 'gateway-heartbeat'
+
+/** How often the gateway refreshes the heartbeat while alive. The hook's
+ * freshness bound (`GATEWAY_HEARTBEAT_FRESH_MS`, 60s) is 4× this — tolerant of
+ * event-loop / scheduler jitter, tight enough that a crashed gateway is
+ * detected within one turn's election window. */
+export const GATEWAY_HEARTBEAT_INTERVAL_MS = 15_000
+
+/**
+ * Write / refresh the heartbeat file's mtime. Creates the file (and the state
+ * dir) on first call, then bumps mtime via `utimesSync` on subsequent calls.
+ * Never throws.
+ */
+export function touchGatewayHeartbeat(stateDir: string): void {
+  const path = join(stateDir, GATEWAY_HEARTBEAT_FILE)
+  const now = new Date()
+  try {
+    utimesSync(path, now, now)
+  } catch {
+    // File doesn't exist yet (or unstattable) — create it.
+    try {
+      mkdirSync(stateDir, { recursive: true })
+      writeFileSync(path, `${Date.now()}\n`, { mode: 0o600 })
+    } catch {
+      // Best-effort — a heartbeat write failure makes the hook BLOCK
+      // (re-prompt), which is the safe direction.
+    }
+  }
+}
+
+/**
+ * Start the periodic heartbeat. Returns the interval handle (unref'd so it
+ * never keeps the process alive on its own). Touches once immediately so the
+ * file exists before the first turn can end.
+ */
+export function startGatewayHeartbeat(
+  stateDir: string,
+  intervalMs: number = GATEWAY_HEARTBEAT_INTERVAL_MS,
+): ReturnType<typeof setInterval> {
+  touchGatewayHeartbeat(stateDir)
+  const timer = setInterval(() => touchGatewayHeartbeat(stateDir), intervalMs)
+  timer.unref?.()
+  return timer
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -899,6 +899,7 @@ import {
   TURN_ACTIVE_HARD_TTL_MS,
   TURN_ACTIVE_IDLE_SWEEP_MS,
 } from './turn-active-marker.js'
+import { startGatewayHeartbeat } from './gateway-heartbeat.js'
 import {
   VERSION,
   COMMIT_SHA,
@@ -2327,6 +2328,13 @@ function checkApprovals(): void {
   }
 }
 if (isGatewayMain && !STATIC) setInterval(checkApprovals, 5000).unref()
+// Gateway liveness heartbeat — touches `<STATE_DIR>/gateway-heartbeat` while
+// the gateway lives so the silent-end Stop hook's single-writer election can
+// confirm the gateway is alive (and WILL run its turn_end delivery) before
+// electing to allow a turn to end without re-prompting. Allowing into a dead
+// gateway would drop the answer — the one outcome worse than a duplicate. See
+// gateway/gateway-heartbeat.ts + hooks/silent-end-scan.mjs.
+if (isGatewayMain && !STATIC) startGatewayHeartbeat(STATE_DIR)
 // Idle auto-clear: check wall-clock idle every minute; maybeIdleClear no-ops
 // when disabled ('0s'), mid-turn, or already cleared this idle period. The
 // `let` state + maybeIdleClear are hoisted/initialized before this fires.

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -2018,6 +2018,23 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
           // represent. The delivery closes the obligation + records dedup, so
           // the represent and a late reply-tool retry are both suppressed —
           // captured-prose delivery and represent are mutually exclusive.
+          // Capture-divergence corner (duplicate-message fix): when this is a
+          // ZERO-reply silent-end AND the gateway's OWN capture came up empty
+          // (so `decideTurnFlush` had nothing to flush — its 'empty-text'
+          // skip), the captured-prose bridge is the ONLY delivery machine
+          // left. The Stop hook scanned the transcript and DID find the
+          // model's short trailing answer, persisting it as `pendingText`. In
+          // that corner the 200-char substance floor would wrongly drop a
+          // legitimately-short answer that no other machine can deliver, so
+          // lower the floor to 1. This is scoped tightly: only when the model
+          // never called reply (`replyCalled === false`) AND the gateway
+          // captured nothing — the interim-ack case (replyCalled) keeps the
+          // full 200 floor (a short closer after a real reply is not a dropped
+          // answer, and the hook already refuses to persist <200 there).
+          const gatewayCapturedEmpty =
+            turn.capturedText.join('\n\n').trim().length === 0
+          const proseMinChars =
+            !turn.replyCalled && gatewayCapturedEmpty ? 1 : CAPTURED_PROSE_MIN_CHARS
           const proseDecision = CAPTURED_PROSE_DELIVERY_ENABLED
             ? decideCapturedProseDelivery({
                 turnKey: tKey,
@@ -2025,7 +2042,7 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
                 // belong to THIS turn, not a stale carryover from a prior turn
                 // on the same chat/thread (tKey is not per-turn unique).
                 turnId: turn.turnId,
-                minChars: CAPTURED_PROSE_MIN_CHARS,
+                minChars: proseMinChars,
               })
             : { deliver: false as const, reason: 'no-state' as const }
           if (proseDecision.deliver && proseDecision.text != null) {

--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -58,7 +58,13 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 
-import { scanTurnForFinalReply } from './silent-end-scan.mjs'
+import {
+  scanTurnForFinalReply,
+  decideStopHookDisposition,
+  isTurnFlushSafetyEnabledEnv,
+  isCapturedProseDeliveryEnabledEnv,
+  isGatewayHeartbeatFresh,
+} from './silent-end-scan.mjs'
 
 // MUST stay in sync with SILENT_END_MAX_RETRIES in telegram-plugin/silent-end.ts
 // (this hook is a standalone .mjs and can't import the TS module).
@@ -75,6 +81,54 @@ function readStdin() {
 
 function getStateDir() {
   return process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
+}
+
+/**
+ * Build the state-file payload the gateway reads back: carries `turnKey` /
+ * `chatId` / `threadId` / per-turn `turnId` nonce and the Option-A
+ * `pendingText` bridge, with the given `retryCount`. Stale carryover values
+ * from the prior on-disk state (`base`) are explicitly dropped when THIS turn
+ * has no derivable nonce / no deliverable prose.
+ *
+ * @param {object} base   Prior on-disk state (spread as a starting point).
+ * @param {ReturnType<import('./silent-end-scan.mjs').scanTurnForFinalReply>} decision
+ * @param {number} retryCount
+ */
+function buildNextState(base, decision, retryCount) {
+  const next = { ...base, retryCount, timestamp: Date.now() }
+  if (decision.turnKey) {
+    next.turnKey = decision.turnKey
+    next.chatId = decision.chatId
+    if (decision.threadId != null) next.threadId = decision.threadId
+    if (decision.turnId) next.turnId = decision.turnId
+    else delete next.turnId
+  } else {
+    delete next.turnId
+  }
+  if (typeof decision.pendingText === 'string' && decision.pendingText.length > 0) {
+    next.pendingText = decision.pendingText
+  } else {
+    delete next.pendingText
+  }
+  return next
+}
+
+/**
+ * Persist the elected state file (single-writer election allow path).
+ * retryCount is left UNCHANGED (this is a hand-off to the gateway's delivery
+ * machine, not a re-prompt). Fail-open on write error — an allow never loops.
+ *
+ * @param {string} statePath
+ * @param {object} base
+ * @param {ReturnType<import('./silent-end-scan.mjs').scanTurnForFinalReply>} decision
+ */
+function writeElectedState(statePath, base, decision) {
+  const retryCount = typeof base.retryCount === 'number' ? base.retryCount : 0
+  try {
+    writeFileSync(statePath, JSON.stringify(buildNextState(base, decision, retryCount)), 'utf8')
+  } catch (err) {
+    process.stderr.write(`[silent-end-interrupt] failed to write elected state file: ${err.message}\n`)
+  }
 }
 
 function main() {
@@ -136,6 +190,34 @@ function main() {
 
   const retryCount = typeof state.retryCount === 'number' ? state.retryCount : 0
 
+  // ── Single-writer election (duplicate-message fix) ────────────────
+  // On a would-BLOCK scan, ALLOW the stop (while still writing the state
+  // file so the gateway's delivery machines have their input) IFF a
+  // gateway delivery machine is PROVABLY going to deliver the trailing
+  // prose. Otherwise BLOCK exactly as today. See
+  // `decideStopHookDisposition` in silent-end-scan.mjs for the four
+  // never-drop gates. This eliminates the double-send: the gateway flush
+  // / captured-prose bridge is the single writer; the hook no longer
+  // re-prompts a reworded reply that defeats the exact-match dedup.
+  const disposition = decideStopHookDisposition({
+    scan: decision,
+    retryCount,
+    turnFlushSafetyEnabled: isTurnFlushSafetyEnabledEnv(process.env),
+    capturedProseDeliveryEnabled: isCapturedProseDeliveryEnabledEnv(process.env),
+    gatewayLive: isGatewayHeartbeatFresh(stateDir),
+  })
+  if (disposition.action === 'allow-elected') {
+    // Persist the state file (turnKey / turnId / pendingText) so the
+    // gateway's turn-end path delivers the answer — retryCount stays at 0
+    // (this is NOT a re-prompt, it's a hand-off to the single writer).
+    writeElectedState(statePath, state, decision)
+    process.stderr.write(
+      `[silent-end-interrupt] single-writer election ALLOWED stop ` +
+        `(scan=${decision.reason} elect=${disposition.reason}) — gateway will deliver\n`,
+    )
+    process.exit(0)
+  }
+
   if (retryCount >= MAX_RETRIES) {
     // Budget spent. Let the session end so the gateway's
     // `silent-end.ts:recordUndeliveredTurnEnd` path delivers the
@@ -161,41 +243,10 @@ function main() {
   // doubles the effective re-prompt budget vs. the design. With turnKey
   // present (same chatKey shape the gateway uses), the match succeeds
   // and the budget is honored.
-  const nextState = {
-    ...state,
-    retryCount: retryCount + 1,
-    timestamp: Date.now(),
-  }
-  if (decision.turnKey) {
-    nextState.turnKey = decision.turnKey
-    nextState.chatId = decision.chatId
-    if (decision.threadId != null) {
-      nextState.threadId = decision.threadId
-    }
-    // Per-turn nonce (Finding 3, #3228). The gateway requires this to match
-    // the live turn's `turnId` before delivering `pendingText`, so a stale
-    // record left over from a prior turn on the same chat/thread can never
-    // deliver a previous turn's answer on a later one. Explicitly drop a
-    // carried-over `turnId` from the spread `...state` when THIS turn has no
-    // derivable nonce, so an old value never lingers.
-    if (decision.turnId) nextState.turnId = decision.turnId
-    else delete nextState.turnId
-  } else {
-    delete nextState.turnId
-  }
-  // Option A transcript-prose bridge: when the scan isolated a substantive
-  // final answer the model wrote as plain text but never sent through the
-  // reply tool, persist it so the gateway's turn-end path can deliver it
-  // directly on the first silent-end (instead of relying on this hook's
-  // re-prompt / the obligation represent to eventually recover it). The
-  // gateway reads this field back out of the same state file. Explicitly
-  // clear a stale carryover value from a prior turn's spread `...state` when
-  // THIS turn has no deliverable prose, so an old answer is never re-sent.
-  if (typeof decision.pendingText === 'string' && decision.pendingText.length > 0) {
-    nextState.pendingText = decision.pendingText
-  } else {
-    delete nextState.pendingText
-  }
+  //
+  // Per-turn nonce (Finding 3, #3228) and the Option-A `pendingText` bridge
+  // are plumbed by `buildNextState`.
+  const nextState = buildNextState(state, decision, retryCount + 1)
   try {
     writeFileSync(statePath, JSON.stringify(nextState), 'utf8')
   } catch (err) {

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -100,6 +100,68 @@ export function endsWithSilentMarker(text) {
   return SILENT_MARKER_RE.test(lines[lines.length - 1])
 }
 
+// ── Narration heuristics — ported from `turn-flush-safety.ts:198-274` ──
+//
+// Kept byte-parallel with `selectFlushDeliveryText` / `isNarrationBlock` so
+// the JOINED multi-block prose the scan persists as `pendingText` (for the
+// capture-divergence corner) matches what the gateway flush would itself have
+// delivered. The scan has no structural `followedByToolUse` provenance, so it
+// uses the opener/trailer heuristic fallback (the same branch the TS side
+// takes when the flag is absent). MUST stay in sync with the TS source; a
+// drift only affects the rare capture-empty corner, never the primary flush.
+const NARRATION_OPENER =
+  /^(let me\b|lemme\b|i'?ll\b|i will\b|i am going to\b|i'?m going to\b|i'?m about to\b|going to\b|first,?\s+(?:let me|i'?ll|i will)\b|now,?\s+(?:let me|i'?ll|i will)\b|next,?\s+(?:let me|i'?ll|i will)\b|let'?s\b)/i
+const NARRATION_TRAILER = /(?:\.{3}|…|:)\s*$/
+
+function isTrailingNarrationLine(block) {
+  const t = block.trim()
+  if (t.length === 0 || t.length >= FINAL_ANSWER_MIN_CHARS) return false
+  if (t.includes('\n')) return false
+  return NARRATION_TRAILER.test(t)
+}
+
+function isNarrationBlock(block) {
+  return NARRATION_OPENER.test(block.trimStart()) || isTrailingNarrationLine(block)
+}
+
+/**
+ * Choose the prose the captured-prose bridge should deliver from the trailing
+ * text blocks in the ZERO-reply case, mirroring `selectFlushDeliveryText`
+ * (`turn-flush-safety.ts:198-232`). `texts` are already trimmed non-empty.
+ *
+ *   - 0 blocks   → undefined (nothing to deliver).
+ *   - 1 block    → that block (the real single-block short-answer shape;
+ *                  persisted even below the substance floor so the lowered-
+ *                  floor capture-divergence corner can deliver it).
+ *   - ≥2 blocks  → strip leading narration exactly as the flush does: if EVERY
+ *                  preceding block is narration, deliver only the terminal
+ *                  block; otherwise JOIN all blocks with a paragraph break (a
+ *                  genuine multi-paragraph answer split across blocks). When
+ *                  the result is narration-only (terminal block is itself
+ *                  narration AND all preceding are narration) → undefined, so a
+ *                  pure narration run never masquerades as an answer (#3228
+ *                  Finding 2 parity).
+ *
+ * @param {string[]} texts
+ * @returns {string | undefined}
+ */
+export function selectBridgePendingText(texts) {
+  const candidates = texts.map((t) => t.trim()).filter((t) => t.length > 0)
+  if (candidates.length === 0) return undefined
+  if (candidates.length === 1) return candidates[0]
+  const answer = candidates[candidates.length - 1]
+  const preceding = candidates.slice(0, -1)
+  const allPrecedingNarration = preceding.every((b) => isNarrationBlock(b))
+  if (allPrecedingNarration) {
+    // Deliver only the terminal block — unless it too is pure narration, in
+    // which case the whole run is narration and there is no answer to bridge.
+    return isNarrationBlock(answer) ? undefined : answer
+  }
+  // A preceding block carries real content → keep the whole answer joined so a
+  // multi-block answer is never truncated to its last paragraph.
+  return candidates.join('\n\n')
+}
+
 /**
  * Predicate ported from `telegram-plugin/final-answer-detect.ts:78-83`.
  * Kept in this .mjs so the hook is fully self-contained (no TS import).
@@ -458,14 +520,17 @@ export function scanTurnForFinalReply(jsonl) {
   // floor unchanged — a short closer after a real reply is not a dropped
   // answer.
   //
-  // Scoped to the SINGLE-trailing-block shape so the #3228 Finding 2 guard is
-  // preserved: a RUN of short narration blocks ("Let me check…", "Still
-  // querying…") must still yield NO pendingText (never masquerade a joined
-  // narration run as an answer). A single trailing block IS the real
-  // short-answer shape the model produces when it writes one plain-text reply.
+  // Multi-block corner (review item 3): a real answer split across ≥2
+  // individually-sub-200 blocks (e.g. two ~150-char paragraphs) would
+  // otherwise yield NO pendingText — and in the capture-divergence-empty
+  // corner (gateway `capturedText` empty → flush skips 'empty-text') the
+  // bridge would then have nothing to deliver and the hook already allowed the
+  // stop: a DROPPED ANSWER. `selectBridgePendingText` mirrors the flush's own
+  // `selectFlushDeliveryText` narration-strip/join, so the bridge delivers the
+  // joined prose (with the lowered `minChars`) instead of dropping. The #3228
+  // Finding 2 guard is preserved: a pure narration run still yields undefined.
   const zeroReplyPendingText =
-    pendingText ??
-    (trailingTextBlocks.length === 1 ? trailingTextBlocks[0].text : undefined)
+    pendingText ?? selectBridgePendingText(trailingTextBlocks.map((b) => b.text))
 
   if (lastAllowBlockIdx === -1) {
     // No qualifying delivery/silence event anywhere in the turn.

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -55,6 +55,9 @@
 // (`done:true`) call as the qualifying one regardless of how many
 // intermediate non-final `stream_reply` calls preceded it. No gap found;
 // re-verify only if a new outbound-delivery tool is added to bridge.ts.
+import { statSync } from 'node:fs'
+import { join } from 'node:path'
+
 const REPLY_TOOLS = new Set([
   'mcp__switchroom-telegram__reply',
   'mcp__switchroom-telegram__stream_reply',
@@ -193,8 +196,16 @@ function buildTurnId(chatId, threadId, messageId) {
  *   clears the substance floor, so the gateway never re-delivers a short
  *   trailing pleasantry. Omitted entirely otherwise.
  */
-function buildBlockResult(envelope, reason, pendingText) {
+function buildBlockResult(envelope, reason, pendingText, hasTrailingProse) {
   const block = { decided: 'block', reason }
+  // Single-writer election input (#duplicate-message fix): does ANY
+  // non-empty, non-silent trailing text block exist after the last
+  // delivery event? The zero-reply election allows only when this is
+  // true — `decideTurnFlush` has no length floor, so any non-empty
+  // non-silent captured text WILL flush; but a turn with NO trailing
+  // prose at all (tool calls only) has nothing for any delivery
+  // machine to send and must keep blocking.
+  if (hasTrailingProse === true) block.hasTrailingProse = true
   if (envelope.chatId) {
     block.chatId = envelope.chatId
     block.threadId = envelope.threadId
@@ -432,6 +443,29 @@ export function scanTurnForFinalReply(jsonl) {
     substantiveBlocks.length > 0
       ? substantiveBlocks[substantiveBlocks.length - 1].text
       : undefined
+  const trailingTextBlocks = undeliveredSlice.filter(
+    (b) => b.kind === 'text' && typeof b.text === 'string' && b.text.length > 0,
+  )
+  const hasTrailingProse = trailingTextBlocks.length > 0
+  // Capture-divergence bridge (#duplicate-message fix): in the ZERO-reply
+  // case, persist the last trailing block even when no single block clears
+  // the 200-char substance floor. The gateway's flush normally delivers any
+  // non-empty captured text, but when the gateway's own capture diverged
+  // (captured empty) the captured-prose bridge is the only delivery machine
+  // left, and it reads `pendingText` — the gateway lowers `minChars` for
+  // exactly this corner (`capturedProseMinCharsFor`, silent-end.ts). The
+  // interim-ack case (`trailing-text-after-reply`) keeps the substantive
+  // floor unchanged — a short closer after a real reply is not a dropped
+  // answer.
+  //
+  // Scoped to the SINGLE-trailing-block shape so the #3228 Finding 2 guard is
+  // preserved: a RUN of short narration blocks ("Let me check…", "Still
+  // querying…") must still yield NO pendingText (never masquerade a joined
+  // narration run as an answer). A single trailing block IS the real
+  // short-answer shape the model produces when it writes one plain-text reply.
+  const zeroReplyPendingText =
+    pendingText ??
+    (trailingTextBlocks.length === 1 ? trailingTextBlocks[0].text : undefined)
 
   if (lastAllowBlockIdx === -1) {
     // No qualifying delivery/silence event anywhere in the turn.
@@ -444,7 +478,7 @@ export function scanTurnForFinalReply(jsonl) {
     if (envelope.source === 'cron') {
       return { decided: 'allow', reason: 'cron-source' }
     }
-    return buildBlockResult(envelope, 'no-final-reply', pendingText)
+    return buildBlockResult(envelope, 'no-final-reply', zeroReplyPendingText, hasTrailingProse)
   }
 
   if (sawUndeliveredTextAfterAllow) {
@@ -453,8 +487,169 @@ export function scanTurnForFinalReply(jsonl) {
     // sent through a delivery tool. This is the "at least once" bug:
     // an early ack (or any qualifying reply) must not amnesty
     // everything written afterward.
-    return buildBlockResult(envelope, 'trailing-text-after-reply', pendingText)
+    return buildBlockResult(envelope, 'trailing-text-after-reply', pendingText, hasTrailingProse)
   }
 
   return { decided: 'allow', reason: lastAllowReason }
+}
+
+// ── Single-writer election (duplicate-message fix) ───────────────────
+//
+// RCA: when a turn ends with its final answer as plain transcript text,
+// TWO uncoordinated recovery paths both fire — (A) the gateway's
+// deterministic turn-end flush (`decideTurnFlush` /
+// `answer-ready-flush.ts`) delivers the captured transcript prose, AND
+// (B) this Stop hook blocks and re-prompts the model, which regenerates
+// a REWORDED reply that defeats the exact-match dedup
+// (`flushed-turn-supersede.ts` `flushedAnswerMatchesReply`). The user
+// gets two near-identical messages.
+//
+// Fix: the Stop hook is the single elector. On a would-BLOCK scan it
+// ALLOWS the stop (still persisting the state file so the gateway's
+// delivery machines have their input) IFF it can PROVE a gateway
+// delivery machine will handle the trailing prose. Every gate below
+// exists to prevent a DROP (worse than a duplicate):
+//
+//   1. deliverable trailing prose exists AND the right machine covers it
+//      - zero-reply (`no-final-reply`): ANY non-empty non-silent
+//        trailing prose — `decideTurnFlush` has no length floor and
+//        flushes any non-empty non-silent captured text. (No 200-char
+//        floor here.)
+//      - interim-ack (`trailing-text-after-reply`, replyCalled=true):
+//        ONLY the captured-prose bridge delivers there (the flush skips
+//        on reply-called), and its floor is 200 — so short trailing
+//        text after a real reply keeps BLOCKING (no duplicate exists in
+//        that case today).
+//   2. the governing delivery flag is enabled (read by the hook from
+//      its own env): zero-reply needs the turn-flush-safety flag AND
+//      the captured-prose flag (the bridge is the capture-divergence
+//      backstop when the gateway captured empty); interim-ack needs the
+//      captured-prose flag. Flag off → the machine won't fire → BLOCK.
+//   3. retryCount === 0 — a prior failed delivery must fall back to
+//      today's BLOCK, preserving the #3228 send-failure recovery net.
+//   4. gateway liveness — the gateway heartbeat file must be FRESH.
+//      Allowing into a dead gateway is the one drop worse than a
+//      duplicate; when liveness can't be established, BLOCK.
+//
+// Pure and deterministic: the hook wrapper does the IO (env read, stat,
+// state-file write) and maps this verdict to exit-0-allow vs
+// decision:block.
+
+/**
+ * @param {{
+ *   scan: ReturnType<typeof scanTurnForFinalReply>,
+ *   retryCount: number,
+ *   turnFlushSafetyEnabled: boolean,
+ *   capturedProseDeliveryEnabled: boolean,
+ *   gatewayLive: boolean,
+ * }} input
+ * @returns {{ action: 'allow-scan' | 'allow-elected' | 'block', reason: string }}
+ */
+export function decideStopHookDisposition(input) {
+  const {
+    scan,
+    retryCount,
+    turnFlushSafetyEnabled,
+    capturedProseDeliveryEnabled,
+    gatewayLive,
+  } = input
+  if (scan == null || scan.decided !== 'block') {
+    return { action: 'allow-scan', reason: `scan-${scan?.decided ?? 'unknown'}` }
+  }
+  // Gate 4 — never allow into a possibly-dead gateway.
+  if (gatewayLive !== true) {
+    return { action: 'block', reason: 'gateway-liveness-not-fresh' }
+  }
+  // Gate 3 — a retry ladder already in flight means a prior delivery
+  // attempt failed; today's BLOCK is the recovery net (#3228).
+  if (retryCount !== 0) {
+    return { action: 'block', reason: 'retry-ladder-in-flight' }
+  }
+  if (scan.reason === 'no-final-reply') {
+    // Gate 2 (zero-reply): the turn-end flush is the delivery machine;
+    // the captured-prose bridge is the capture-divergence backstop.
+    if (!turnFlushSafetyEnabled) {
+      return { action: 'block', reason: 'turn-flush-flag-disabled' }
+    }
+    if (!capturedProseDeliveryEnabled) {
+      return { action: 'block', reason: 'captured-prose-flag-disabled' }
+    }
+    // Gate 1 (zero-reply): any non-empty non-silent trailing prose.
+    if (scan.hasTrailingProse !== true) {
+      return { action: 'block', reason: 'no-trailing-prose' }
+    }
+    return { action: 'allow-elected', reason: 'flush-will-deliver' }
+  }
+  if (scan.reason === 'trailing-text-after-reply') {
+    // Gate 2 (interim-ack): only the captured-prose bridge delivers here.
+    if (!capturedProseDeliveryEnabled) {
+      return { action: 'block', reason: 'captured-prose-flag-disabled' }
+    }
+    // Gate 1 (interim-ack): the bridge's substance floor is 200 chars
+    // (CAPTURED_PROSE_MIN_CHARS, silent-end.ts). Below it the bridge
+    // will NOT deliver — keep blocking (matches today: no duplicate
+    // exists for short trailing text after a real reply).
+    if (
+      typeof scan.pendingText !== 'string' ||
+      scan.pendingText.trim().length < FINAL_ANSWER_MIN_CHARS
+    ) {
+      return { action: 'block', reason: 'short-trailing-after-reply' }
+    }
+    return { action: 'allow-elected', reason: 'bridge-will-deliver' }
+  }
+  // Unknown block reason — conservatively keep today's behaviour.
+  return { action: 'block', reason: `unrecognized-scan-reason-${scan.reason}` }
+}
+
+/**
+ * Mirror of `isTurnFlushSafetyEnabled` (`turn-flush-safety.ts:392-400`).
+ * Kept in this .mjs so the hook is self-contained (no TS import); MUST
+ * stay in sync — default ON, disabled by `0` / `false` / `off` / `no`.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {boolean}
+ */
+export function isTurnFlushSafetyEnabledEnv(env) {
+  const raw = env.SWITCHROOM_TG_TURN_FLUSH_SAFETY
+  if (raw == null) return true
+  const v = raw.trim().toLowerCase()
+  return !(v === '0' || v === 'false' || v === 'off' || v === 'no')
+}
+
+/**
+ * Mirror of `CAPTURED_PROSE_DELIVERY_ENABLED` (`gateway/gateway.ts` —
+ * `SWITCHROOM_TG_CAPTURED_PROSE_DELIVERY !== '0'`). MUST stay in sync.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {boolean}
+ */
+export function isCapturedProseDeliveryEnabledEnv(env) {
+  return env.SWITCHROOM_TG_CAPTURED_PROSE_DELIVERY !== '0'
+}
+
+// MUST stay in sync with gateway/gateway-heartbeat.ts (the hook is a
+// standalone .mjs and can't import the TS module). The gateway touches
+// the file every GATEWAY_HEARTBEAT_INTERVAL_MS (15s); freshness bound is
+// 4 intervals — conservative against scheduler jitter, small enough that
+// a dead gateway is detected before its stale heartbeat can swallow more
+// than one turn's election.
+export const GATEWAY_HEARTBEAT_FILE = 'gateway-heartbeat'
+export const GATEWAY_HEARTBEAT_FRESH_MS = 60_000
+
+/**
+ * Gate 4 IO helper: is the gateway heartbeat file fresh? Missing,
+ * unstattable, or stale ⇒ false (BLOCK — never allow into a possibly-
+ * dead gateway).
+ *
+ * @param {string} stateDir
+ * @param {number} [now]
+ * @returns {boolean}
+ */
+export function isGatewayHeartbeatFresh(stateDir, now = Date.now()) {
+  try {
+    const st = statSync(join(stateDir, GATEWAY_HEARTBEAT_FILE))
+    return now - st.mtimeMs <= GATEWAY_HEARTBEAT_FRESH_MS
+  } catch {
+    return false
+  }
 }

--- a/telegram-plugin/tests/gateway-heartbeat.test.ts
+++ b/telegram-plugin/tests/gateway-heartbeat.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Gateway liveness heartbeat writer (duplicate-message fix).
+ *
+ * The Stop hook's single-writer election only ALLOWS a stop (handing delivery
+ * to the gateway) when the gateway heartbeat file is fresh. This pins the
+ * writer: it creates the file, bumps its mtime on subsequent touches, and the
+ * hook's freshness reader agrees on the filename + bound.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, existsSync, rmSync, utimesSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  touchGatewayHeartbeat,
+  startGatewayHeartbeat,
+  GATEWAY_HEARTBEAT_FILE,
+} from '../gateway/gateway-heartbeat.js'
+import {
+  isGatewayHeartbeatFresh,
+  GATEWAY_HEARTBEAT_FILE as HOOK_HEARTBEAT_FILE,
+} from '../hooks/silent-end-scan.mjs'
+
+describe('gateway-heartbeat writer', () => {
+  it('creates the heartbeat file on first touch under a fresh state dir', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gw-hb-w-'))
+    try {
+      const path = join(dir, GATEWAY_HEARTBEAT_FILE)
+      expect(existsSync(path)).toBe(false)
+      touchGatewayHeartbeat(dir)
+      expect(existsSync(path)).toBe(true)
+      // The hook's freshness reader agrees it's fresh.
+      expect(isGatewayHeartbeatFresh(dir)).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('refreshes an aged heartbeat back to fresh on a subsequent touch', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gw-hb-w-'))
+    try {
+      const path = join(dir, GATEWAY_HEARTBEAT_FILE)
+      touchGatewayHeartbeat(dir)
+      // Backdate the mtime to stale, then touch again → back to fresh.
+      const old = new Date(Date.now() - 10 * 60_000)
+      utimesSync(path, old, old)
+      expect(isGatewayHeartbeatFresh(dir)).toBe(false)
+      touchGatewayHeartbeat(dir)
+      expect(isGatewayHeartbeatFresh(dir)).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('startGatewayHeartbeat writes immediately and returns an unref-able timer', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gw-hb-w-'))
+    try {
+      const timer = startGatewayHeartbeat(dir, 60_000)
+      expect(existsSync(join(dir, GATEWAY_HEARTBEAT_FILE))).toBe(true)
+      clearInterval(timer)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('the writer filename and the hook reader filename are identical (no drift)', () => {
+    expect(GATEWAY_HEARTBEAT_FILE).toBe(HOOK_HEARTBEAT_FILE)
+    expect(GATEWAY_HEARTBEAT_FILE).toBe('gateway-heartbeat')
+  })
+})

--- a/telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts
+++ b/telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts
@@ -296,4 +296,67 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
     expect(r.status).toBe(0)
     expect(r.stdout.trim()).toBe('')
   })
+
+  // ── Single-writer election (duplicate-message fix) ─────────────────
+  describe('single-writer election end-to-end', () => {
+    function writeFreshHeartbeat() {
+      writeFileSync(join(stateDir, 'gateway-heartbeat'), String(Date.now()), 'utf8')
+    }
+
+    it('zero-reply ≥200 + FRESH gateway heartbeat → ALLOW (no block re-prompt), state file still written for the flush', () => {
+      // The duplicate repro: today this BLOCKS *and* the gateway flush fires →
+      // two messages. With a fresh heartbeat the election ALLOWS the stop so
+      // the gateway flush is the single writer.
+      writeFreshHeartbeat()
+      const transcript = writeTranscript(tmp, [
+        ENQUEUE,
+        { type: 'assistant', message: { content: [{ type: 'text', text: 'A'.repeat(300) }] } },
+      ])
+      const r = runHook({ event: { session_id: 's1', transcript_path: transcript }, stateDir })
+      expect(r.status).toBe(0)
+      // ALLOW → no block JSON on stdout.
+      expect(r.stdout.trim()).toBe('')
+      expect(r.stderr).toMatch(/single-writer election ALLOWED/)
+      // State file IS written so the gateway's captured-prose bridge has its
+      // input (turnKey/turnId/pendingText); retryCount stays 0 (not a re-prompt).
+      const statePath = join(stateDir, 'silent-end-pending.json')
+      expect(existsSync(statePath)).toBe(true)
+      const state = JSON.parse(readFileSync(statePath, 'utf8'))
+      expect(state.retryCount).toBe(0)
+      expect(state.turnKey).toBe('111:_')
+      expect(state.pendingText).toBe('A'.repeat(300))
+    })
+
+    it('zero-reply ≥200 + STALE/missing heartbeat → BLOCK (never allow into a possibly-dead gateway)', () => {
+      // No heartbeat file → the liveness gate forces today's BLOCK behaviour.
+      const transcript = writeTranscript(tmp, [
+        ENQUEUE,
+        { type: 'assistant', message: { content: [{ type: 'text', text: 'A'.repeat(300) }] } },
+      ])
+      const r = runHook({ event: { session_id: 's1', transcript_path: transcript }, stateDir })
+      expect(r.status).toBe(0)
+      expect(JSON.parse(r.stdout).decision).toBe('block')
+      const state = JSON.parse(readFileSync(join(stateDir, 'silent-end-pending.json'), 'utf8'))
+      expect(state.retryCount).toBe(1)
+    })
+
+    it('retryCount>0 (prior failed delivery) + fresh heartbeat → BLOCK (preserve #3228 send-failure net)', () => {
+      writeFreshHeartbeat()
+      // Seed a prior state file with retryCount=1 (a delivery already failed).
+      writeFileSync(
+        join(stateDir, 'silent-end-pending.json'),
+        JSON.stringify({ chatId: '111', threadId: null, turnKey: '111:_', retryCount: 1, timestamp: Date.now() }),
+        'utf8',
+      )
+      const transcript = writeTranscript(tmp, [
+        ENQUEUE,
+        { type: 'assistant', message: { content: [{ type: 'text', text: 'A'.repeat(300) }] } },
+      ])
+      const r = runHook({ event: { session_id: 's1', transcript_path: transcript }, stateDir })
+      expect(r.status).toBe(0)
+      // retryCount was 1 → not the exhaustion boundary (MAX=2) → still blocks,
+      // and the election does NOT allow (retry-ladder-in-flight).
+      expect(JSON.parse(r.stdout).decision).toBe('block')
+    })
+  })
 })

--- a/telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts
+++ b/telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts
@@ -395,14 +395,19 @@ describe('scanTurnForFinalReply — pendingText is a single substantive block, n
   // "Let me check…" / "Still querying…" narration crossed 200 and was delivered
   // as if it were the answer. Post-fix only a single block that clears the floor
   // ON ITS OWN becomes pendingText.
-  const NARRATION_A = 'Let me check the first data source now — pulling the records and scanning for the relevant rows.' // ~95
-  const NARRATION_B = 'Still querying; the second source is slower than expected, so hang tight while it finishes loading.' // ~98
-  const NARRATION_C = 'Almost there, cross-referencing the last set of figures against the ledger before I summarise it.' // ~96
+  // Genuinely-narration blocks: each matches the opener/trailer heuristic
+  // (`isNarrationBlock`) the flush's `selectFlushDeliveryText` uses, so a pure
+  // run of them is delivered as NOTHING by the flush — and the scan must agree
+  // (no pendingText) so the capture-divergence bridge never masquerades a
+  // narration run as an answer (#3228 Finding 2).
+  const NARRATION_A = 'Let me check the first data source now, pulling the records and scanning the rows…' // opener + …
+  const NARRATION_B = "Now let me query the second source; it is slower than expected, hang tight…" // opener + …
+  const NARRATION_C = "I'll cross-reference the last set of figures against the ledger before I summarise…" // opener + …
 
-  it('zero-delivery turn of only short narration blocks → block WITHOUT pendingText (fails on the old joined-floor code)', () => {
-    // Combined length of the three blocks is ≥ 200, so the OLD code would join
-    // them and set pendingText (masquerade). The NEW code sets nothing because
-    // no single block clears the floor.
+  it('zero-delivery turn of only NARRATION blocks → block WITHOUT pendingText (#3228 Finding 2 / flush parity)', () => {
+    // Combined length of the three blocks is ≥ 200, so the OLD joined-floor code
+    // would join them and set pendingText (masquerade). The NEW code mirrors the
+    // flush's narration strip: every block is narration → nothing to deliver.
     expect((NARRATION_A + '\n\n' + NARRATION_B + '\n\n' + NARRATION_C).length)
       .toBeGreaterThanOrEqual(200)
     const text = jsonl(
@@ -418,6 +423,35 @@ describe('scanTurnForFinalReply — pendingText is a single substantive block, n
     expect(r.reason).toBe('no-final-reply')
     // The masquerade must NOT happen — no answer to deliver, take the re-prompt.
     expect(r.pendingText).toBeUndefined()
+  })
+
+  it('zero-delivery turn of MULTIPLE sub-200 REAL-CONTENT blocks → JOINED pendingText (review item 3 drop fix)', () => {
+    // A real answer split as two ~150-char paragraphs, each individually under
+    // the 200-char substance floor. Pre-fix the scan set NO pendingText — and in
+    // the capture-divergence-empty corner (gateway captured nothing → flush
+    // skips 'empty-text') the bridge then had nothing to deliver and the hook
+    // had already allowed the stop → DROPPED ANSWER. Post-fix the scan mirrors
+    // the flush's join so the bridge delivers the joined prose.
+    const PARA_1 = 'The root cause is a stale cache entry that survives the reload because the invalidation key is derived from the wrong field.' // ~150, real content
+    const PARA_2 = 'The fix is to key invalidation off the canonical id so the entry is dropped on every write; I have verified it against the repro.' // ~150, real content
+    expect(PARA_1.length).toBeLessThan(200)
+    expect(PARA_2.length).toBeLessThan(200)
+    const text = jsonl(ENQUEUE, assistantText(PARA_1), assistantText(PARA_2))
+    const r = scanTurnForFinalReply(text)
+    expect(r.decided).toBe('block')
+    expect(r.reason).toBe('no-final-reply')
+    // Joined prose, mirroring the flush's selectFlushDeliveryText.
+    expect(r.pendingText).toBe(`${PARA_1}\n\n${PARA_2}`)
+    expect(r.hasTrailingProse).toBe(true)
+  })
+
+  it('leading narration + a real sub-200 answer block → only the answer is delivered (narration stripped)', () => {
+    const NARR = 'Let me pull the numbers first…' // narration opener + …
+    const ANSWER = 'Revenue was up 12% quarter-over-quarter, driven mostly by the new enterprise tier.' // ~85, real
+    const text = jsonl(ENQUEUE, assistantText(NARR), assistantText(ANSWER))
+    const r = scanTurnForFinalReply(text)
+    expect(r.decided).toBe('block')
+    expect(r.pendingText).toBe(ANSWER)
   })
 
   it('trailing narration after a delivered reply, all sub-floor → block only if a real ≥floor block exists; here → allow, no pendingText', () => {

--- a/telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts
+++ b/telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts
@@ -184,13 +184,20 @@ describe('scanTurnForFinalReply — final-reply detection', () => {
     expect(r.pendingText).toBe(trailing)
   })
 
-  it('Option A: a SHORT trailing/only fragment does NOT set pendingText (substance floor)', () => {
-    // A genuinely empty-ish turn: a short plain-text closer under the 200-char
-    // floor must not be re-delivered as if it were the answer.
-    const text = jsonl(ENQUEUE, assistantText('ok done, let me know if you need anything else'))
+  it('Option A: a SHORT single trailing fragment (zero-reply) IS persisted for the lowered-floor corner', () => {
+    // Post duplicate-message fix: a single short plain-text block in the
+    // ZERO-reply case is the real short-answer shape, so the scan persists it
+    // as pendingText for the capture-divergence corner (gateway captured empty →
+    // the bridge delivers with a lowered floor). Under the gateway's DEFAULT
+    // 200-char floor it is still NOT delivered, so the substance guard holds at
+    // the delivery layer.
+    const short = 'ok done, let me know if you need anything else'
+    const text = jsonl(ENQUEUE, assistantText(short))
     const r = scanTurnForFinalReply(text)
     expect(r.decided).toBe('block')
-    expect(r.pendingText).toBeUndefined()
+    expect(r.reason).toBe('no-final-reply')
+    expect(r.pendingText).toBe(short)
+    expect(r.hasTrailingProse).toBe(true)
   })
 
   it('notification-bearing reply → allow', () => {
@@ -447,9 +454,12 @@ describe('scanTurnForFinalReply — pendingText is a single substantive block, n
       const text = jsonl(ENQUEUE, assistantText('X'.repeat(n)))
       return scanTurnForFinalReply(text)
     }
-    // 199 → under floor, no pendingText (block still fires for the zero-delivery
-    // turn, but there is nothing substantive to deliver).
-    expect(at(199).pendingText).toBeUndefined()
+    // 199 → under the 200-char SUBSTANCE floor, but a SINGLE trailing block is
+    // the real short-answer shape: post duplicate-message fix the scan persists
+    // it as pendingText so the capture-divergence corner can deliver it with a
+    // lowered floor. The gateway's default-floor decide still won't deliver it,
+    // so the #3228 masquerade guard is unchanged at the delivery layer.
+    expect(at(199).pendingText).toBe('X'.repeat(199))
     // 200 → exactly the floor, delivered.
     expect(at(200).pendingText).toBe('X'.repeat(200))
     // 201 → over floor, delivered.

--- a/telegram-plugin/tests/silent-end-single-writer-election.test.ts
+++ b/telegram-plugin/tests/silent-end-single-writer-election.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Regression tests for the single-writer election (duplicate-message fix).
+ *
+ * RCA: when a turn ends with its final answer as PLAIN TRANSCRIPT TEXT (no
+ * `reply` tool call), two uncoordinated recovery paths both fired — (A) the
+ * gateway turn-end flush (`decideTurnFlush`) delivered the captured prose, and
+ * (B) this Stop hook blocked and re-prompted, regenerating a REWORDED reply
+ * that defeated the exact-match dedup. The user got two near-identical
+ * messages.
+ *
+ * Fix: the Stop hook is the single elector (`decideStopHookDisposition`). On a
+ * would-BLOCK scan it ALLOWS the stop — handing delivery to the gateway's
+ * flush / captured-prose bridge — IFF four never-drop gates all hold; otherwise
+ * it BLOCKS exactly as today. These tests pin the whole verdict matrix and
+ * prove every allow path has a delivery machine and every guard forces BLOCK.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  decideStopHookDisposition,
+  isTurnFlushSafetyEnabledEnv,
+  isCapturedProseDeliveryEnabledEnv,
+  isGatewayHeartbeatFresh,
+  GATEWAY_HEARTBEAT_FRESH_MS,
+} from '../hooks/silent-end-scan.mjs'
+import {
+  mkdtempSync,
+  writeFileSync,
+  utimesSync,
+  rmSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Scan fixtures — the shapes `scanTurnForFinalReply` returns on a would-block.
+const ZERO_REPLY_LONG = {
+  decided: 'block' as const,
+  reason: 'no-final-reply',
+  turnKey: 'c:_',
+  hasTrailingProse: true,
+  pendingText: 'A'.repeat(300),
+}
+const ZERO_REPLY_SHORT = {
+  decided: 'block' as const,
+  reason: 'no-final-reply',
+  turnKey: 'c:_',
+  hasTrailingProse: true,
+  pendingText: 'ok done',
+}
+const ZERO_REPLY_NO_PROSE = {
+  decided: 'block' as const,
+  reason: 'no-final-reply',
+  turnKey: 'c:_',
+  // hasTrailingProse absent — tool-calls-only turn, nothing for a machine to send.
+}
+const INTERIM_ACK_LONG = {
+  decided: 'block' as const,
+  reason: 'trailing-text-after-reply',
+  turnKey: 'c:_',
+  hasTrailingProse: true,
+  pendingText: 'B'.repeat(300),
+}
+const INTERIM_ACK_SHORT = {
+  decided: 'block' as const,
+  reason: 'trailing-text-after-reply',
+  turnKey: 'c:_',
+  hasTrailingProse: true,
+  pendingText: 'thanks!',
+}
+
+const ALL_ON = {
+  retryCount: 0,
+  turnFlushSafetyEnabled: true,
+  capturedProseDeliveryEnabled: true,
+  gatewayLive: true,
+}
+
+describe('decideStopHookDisposition — duplicate repro (#1: zero-reply ≥200)', () => {
+  it('zero-reply long answer, flags on, retry 0, live → ALLOW-elected (today it blocks → duplicate)', () => {
+    const d = decideStopHookDisposition({ scan: ZERO_REPLY_LONG, ...ALL_ON })
+    expect(d.action).toBe('allow-elected')
+    expect(d.reason).toBe('flush-will-deliver')
+  })
+})
+
+describe('decideStopHookDisposition — short-answer repro (#2: zero-reply <200)', () => {
+  it('zero-reply SHORT answer, flags on, retry 0, live → ALLOW-elected (flush has no length floor)', () => {
+    // Today this BLOCKS *and* the flush fires → duplicate. Exactly one machine
+    // must win: the flush. The election allows the stop so the hook does not
+    // also re-prompt.
+    const d = decideStopHookDisposition({ scan: ZERO_REPLY_SHORT, ...ALL_ON })
+    expect(d.action).toBe('allow-elected')
+  })
+})
+
+describe('decideStopHookDisposition — never-drop matrix (#3)', () => {
+  it('every ALLOW verdict is backed by a delivery machine', () => {
+    // Zero-reply → the turn-flush delivers (no length floor); interim-ack ≥200 →
+    // the captured-prose bridge delivers. Both are allow.
+    expect(decideStopHookDisposition({ scan: ZERO_REPLY_LONG, ...ALL_ON }).action).toBe('allow-elected')
+    expect(decideStopHookDisposition({ scan: ZERO_REPLY_SHORT, ...ALL_ON }).action).toBe('allow-elected')
+    expect(decideStopHookDisposition({ scan: INTERIM_ACK_LONG, ...ALL_ON }).action).toBe('allow-elected')
+  })
+
+  it('turn-flush flag OFF (zero-reply) → BLOCK (the flush will not fire)', () => {
+    const d = decideStopHookDisposition({ scan: ZERO_REPLY_LONG, ...ALL_ON, turnFlushSafetyEnabled: false })
+    expect(d.action).toBe('block')
+    expect(d.reason).toBe('turn-flush-flag-disabled')
+  })
+
+  it('captured-prose flag OFF (interim-ack) → BLOCK (the bridge will not fire)', () => {
+    const d = decideStopHookDisposition({ scan: INTERIM_ACK_LONG, ...ALL_ON, capturedProseDeliveryEnabled: false })
+    expect(d.action).toBe('block')
+    expect(d.reason).toBe('captured-prose-flag-disabled')
+  })
+
+  it('captured-prose flag OFF (zero-reply) → BLOCK (bridge is the capture-divergence backstop)', () => {
+    const d = decideStopHookDisposition({ scan: ZERO_REPLY_LONG, ...ALL_ON, capturedProseDeliveryEnabled: false })
+    expect(d.action).toBe('block')
+    expect(d.reason).toBe('captured-prose-flag-disabled')
+  })
+
+  it('retryCount > 0 → BLOCK (a prior failed delivery keeps the #3228 recovery net)', () => {
+    const d = decideStopHookDisposition({ scan: ZERO_REPLY_LONG, ...ALL_ON, retryCount: 1 })
+    expect(d.action).toBe('block')
+    expect(d.reason).toBe('retry-ladder-in-flight')
+  })
+
+  it('gateway NOT live → BLOCK (never allow into a possibly-dead gateway)', () => {
+    const d = decideStopHookDisposition({ scan: ZERO_REPLY_LONG, ...ALL_ON, gatewayLive: false })
+    expect(d.action).toBe('block')
+    expect(d.reason).toBe('gateway-liveness-not-fresh')
+  })
+
+  it('interim-ack SHORT (<200) → BLOCK (bridge floor is 200; no duplicate exists today)', () => {
+    const d = decideStopHookDisposition({ scan: INTERIM_ACK_SHORT, ...ALL_ON })
+    expect(d.action).toBe('block')
+    expect(d.reason).toBe('short-trailing-after-reply')
+  })
+
+  it('zero-reply with NO trailing prose (tool-calls only) → BLOCK (nothing to deliver)', () => {
+    const d = decideStopHookDisposition({ scan: ZERO_REPLY_NO_PROSE, ...ALL_ON })
+    expect(d.action).toBe('block')
+    expect(d.reason).toBe('no-trailing-prose')
+  })
+
+  it('a non-block scan (allow/unknown) is passed straight through as allow-scan', () => {
+    expect(decideStopHookDisposition({ scan: { decided: 'allow', reason: 'final-reply' }, ...ALL_ON }).action).toBe('allow-scan')
+    expect(decideStopHookDisposition({ scan: { decided: 'unknown', reason: 'no-turn-start' }, ...ALL_ON }).action).toBe('allow-scan')
+  })
+
+  it('gateway-liveness gate is checked BEFORE the flag/prose gates (dead gateway always blocks)', () => {
+    // Even with an otherwise-perfect zero-reply allow, a dead gateway forces block.
+    const d = decideStopHookDisposition({ scan: ZERO_REPLY_LONG, ...ALL_ON, gatewayLive: false, retryCount: 0 })
+    expect(d.action).toBe('block')
+    expect(d.reason).toBe('gateway-liveness-not-fresh')
+  })
+})
+
+describe('env-flag mirrors stay in sync with the TS source', () => {
+  it('turn-flush-safety: default ON; 0/false/off/no disable', () => {
+    expect(isTurnFlushSafetyEnabledEnv({})).toBe(true)
+    for (const v of ['0', 'false', 'off', 'no', 'FALSE', 'Off']) {
+      expect(isTurnFlushSafetyEnabledEnv({ SWITCHROOM_TG_TURN_FLUSH_SAFETY: v })).toBe(false)
+    }
+    expect(isTurnFlushSafetyEnabledEnv({ SWITCHROOM_TG_TURN_FLUSH_SAFETY: '1' })).toBe(true)
+  })
+  it('captured-prose: default ON; only exact "0" disables', () => {
+    expect(isCapturedProseDeliveryEnabledEnv({})).toBe(true)
+    expect(isCapturedProseDeliveryEnabledEnv({ SWITCHROOM_TG_CAPTURED_PROSE_DELIVERY: '0' })).toBe(false)
+    expect(isCapturedProseDeliveryEnabledEnv({ SWITCHROOM_TG_CAPTURED_PROSE_DELIVERY: '1' })).toBe(true)
+  })
+})
+
+describe('isGatewayHeartbeatFresh — liveness gate IO', () => {
+  it('fresh heartbeat → true; stale → false; missing → false', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gw-hb-'))
+    try {
+      // Missing file → not fresh.
+      expect(isGatewayHeartbeatFresh(dir)).toBe(false)
+      const path = join(dir, 'gateway-heartbeat')
+      writeFileSync(path, 'x')
+      // Just-written → fresh.
+      expect(isGatewayHeartbeatFresh(dir)).toBe(true)
+      // Age it past the freshness bound → stale.
+      const old = new Date(Date.now() - GATEWAY_HEARTBEAT_FRESH_MS - 10_000)
+      utimesSync(path, old, old)
+      expect(isGatewayHeartbeatFresh(dir)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/telegram-plugin/tests/silent-end.test.ts
+++ b/telegram-plugin/tests/silent-end.test.ts
@@ -736,10 +736,15 @@ describe('silent-end-interrupt-stop hook — integration (#1775: transcript-scan
       expect(decision.reason).toBe('no-state')
     })
 
-    it('a genuinely empty turn (no substantive prose) → hook blocks WITHOUT pendingText → decide falls through', () => {
-      // Short closer under the substance floor: not a dropped answer. The hook
-      // still blocks (re-prompt), but writes NO pendingText, so the gateway
-      // takes the existing recordUndeliveredTurnEnd / represent path unchanged.
+    it('a short single-block answer → hook persists pendingText but default-floor decide falls through', () => {
+      // Single short trailing block under the 200-char substance floor. Post
+      // duplicate-message fix the hook persists it as pendingText (so the
+      // capture-divergence corner can deliver it with a lowered floor when the
+      // gateway captured nothing), but under the DEFAULT floor the gateway's
+      // decide returns no-substantive-prose — the normal recordUndeliveredTurnEnd
+      // / represent path is unchanged. (No gateway heartbeat file exists in this
+      // test's state dir, so the single-writer election also BLOCKS on the
+      // liveness gate rather than allowing the stop.)
       const transcript = writeTranscript([
         ENQUEUE,
         { type: 'assistant', message: { content: [{ type: 'text', text: 'ok done' }] } },
@@ -747,10 +752,15 @@ describe('silent-end-interrupt-stop hook — integration (#1775: transcript-scan
       const r = runHook({ session_id: 's', transcript_path: transcript, hook_event_name: 'Stop' })
       expect(JSON.parse(r.stdout.trim()).decision).toBe('block')
       const state = readSilentEndState()!
-      expect(state.pendingText).toBeUndefined()
+      expect(state.pendingText).toBe('ok done')
+      // Default floor (200) → short prose is not delivered on the normal path.
       const decision = decideCapturedProseDelivery({ turnKey: 'c:_' })
       expect(decision.deliver).toBe(false)
       expect(decision.reason).toBe('no-substantive-prose')
+      // Lowered floor (capture-divergence corner) → the short answer IS delivered.
+      const lowered = decideCapturedProseDelivery({ turnKey: 'c:_', minChars: 1 })
+      expect(lowered.deliver).toBe(true)
+      expect(lowered.text).toBe('ok done')
     })
 
     it('a stale pendingText for a DIFFERENT turn is never delivered (turnKey guard)', () => {

--- a/telegram-plugin/tests/silent-end.test.ts
+++ b/telegram-plugin/tests/silent-end.test.ts
@@ -763,6 +763,51 @@ describe('silent-end-interrupt-stop hook — integration (#1775: transcript-scan
       expect(lowered.text).toBe('ok done')
     })
 
+    it('review item 3: multi sub-200 REAL blocks + capture-empty corner → bridge delivers JOINED prose (no drop)', () => {
+      // A real answer split as two ~150-char paragraphs, each under the 200-char
+      // floor. Pre-fix: scan set NO pendingText → in the capture-divergence-empty
+      // corner (gateway captured nothing → flush skips 'empty-text') the bridge
+      // had nothing → hook already allowed the stop → DROPPED ANSWER. Post-fix
+      // the hook persists the JOINED prose so the lowered-floor bridge delivers
+      // exactly one message.
+      // Each block short enough that the JOINED prose is still under the 200-char
+      // default floor — so this also exercises the lowered-floor plumbing.
+      const PARA_1 = 'The root cause is a stale cache entry surviving reload.'
+      const PARA_2 = 'The fix keys invalidation off the canonical id; verified.'
+      const joined = `${PARA_1}\n\n${PARA_2}`
+      expect(joined.length).toBeLessThan(200)
+      const transcript = writeTranscript([
+        ENQUEUE,
+        { type: 'assistant', message: { content: [{ type: 'text', text: PARA_1 }] } },
+        { type: 'assistant', message: { content: [{ type: 'text', text: PARA_2 }] } },
+      ])
+      const r = runHook({ session_id: 's', transcript_path: transcript, hook_event_name: 'Stop' })
+      expect(JSON.parse(r.stdout.trim()).decision).toBe('block')
+      const state = readSilentEndState()!
+      expect(state.pendingText).toBe(joined)
+      // Default floor → not delivered on the normal path (no duplicate risk).
+      expect(decideCapturedProseDelivery({ turnKey: 'c:_' }).deliver).toBe(false)
+      // Capture-divergence corner (gateway captured empty → lowered floor) →
+      // exactly one delivery of the joined answer, instead of a silent drop.
+      const lowered = decideCapturedProseDelivery({ turnKey: 'c:_', minChars: 1 })
+      expect(lowered.deliver).toBe(true)
+      expect(lowered.text).toBe(joined)
+    })
+
+    it('review item 3: NARRATION-only multi-block → still NO pendingText (no masquerade, #3228 Finding 2)', () => {
+      const transcript = writeTranscript([
+        ENQUEUE,
+        { type: 'assistant', message: { content: [{ type: 'text', text: 'Let me check the first source now, scanning the rows…' }] } },
+        { type: 'assistant', message: { content: [{ type: 'text', text: "Now let me query the second source; hang tight…" }] } },
+      ])
+      const r = runHook({ session_id: 's', transcript_path: transcript, hook_event_name: 'Stop' })
+      expect(JSON.parse(r.stdout.trim()).decision).toBe('block')
+      const state = readSilentEndState()!
+      expect(state.pendingText).toBeUndefined()
+      // Even at the lowered floor there is nothing to deliver.
+      expect(decideCapturedProseDelivery({ turnKey: 'c:_', minChars: 1 }).deliver).toBe(false)
+    })
+
     it('a stale pendingText for a DIFFERENT turn is never delivered (turnKey guard)', () => {
       const path = join(stateDir, 'silent-end-pending.json')
       mkdirSync(stateDir, { recursive: true })


### PR DESCRIPTION
## Summary

Kills the duplicate-message bug where a turn that writes its final answer as **plain transcript text** (no `reply` tool call) delivers **two** near-identical replies to the user.

## Why (RCA)

Two uncoordinated recovery paths both fired on the same undelivered answer:

- **(A) gateway flush** — `decideTurnFlush` (`turn-flush-safety.ts`) / the quiescence + turn-end flush via `gateway/stream-render.ts` delivered the captured transcript prose.
- **(B) Stop hook re-prompt** — `hooks/silent-end-interrupt-stop.mjs` blocked and re-prompted the model, which regenerated a **reworded** reply. The rewording defeated the exact-match dedup (`flushed-turn-supersede.ts` `flushedAnswerMatchesReply`), so both went out.

## Design — single-writer election at the Stop hook

The Stop hook becomes the single elector (`decideStopHookDisposition`, a pure function in `silent-end-scan.mjs`). On a would-BLOCK scan it **ALLOWS** the stop — handing delivery to the gateway's flush / captured-prose bridge and NOT re-prompting — IFF **all four never-drop gates** hold; otherwise it BLOCKS exactly as today. The hook wrapper does only IO (env read, heartbeat stat, state-file write) and maps the verdict to exit-0-allow vs `decision:block`. The state file is still written on the allow path (retryCount stays 0) so the gateway's delivery machines have their `turnKey`/`turnId`/`pendingText` input.

### The four allow-gates (each prevents a drop)

1. **Deliverable trailing prose + the right machine covers it.** Zero-reply (`no-final-reply`): any non-empty non-silent trailing prose — `decideTurnFlush` has **no length floor** and flushes any non-empty non-silent captured text, so no 200-char floor here. Interim-ack (`trailing-text-after-reply`, replyCalled=true): only the captured-prose bridge delivers there (the flush skips on reply-called, `turn-flush-safety.ts:346`) and its floor is 200 — so short trailing text after a real reply keeps **BLOCKING** (no duplicate exists there today).
2. **Governing delivery flag on**, read in the hook from its own env: zero-reply needs `SWITCHROOM_TG_TURN_FLUSH_SAFETY` (+ the captured-prose flag as the capture-divergence backstop); interim-ack needs `SWITCHROOM_TG_CAPTURED_PROSE_DELIVERY !== '0'`. Flag off ⇒ the machine won't fire ⇒ BLOCK.
3. **retryCount === 0.** A prior failed delivery (retryCount>0) falls back to today's BLOCK, preserving the #3228 send-failure recovery net.
4. **Gateway liveness.** A new always-on gateway heartbeat (`gateway/gateway-heartbeat.ts` touches `<STATE_DIR>/gateway-heartbeat` every 15s) must be **fresh** (≤60s). Allowing into a dead gateway would drop the answer — the one outcome worse than a duplicate — so when liveness can't be established the hook BLOCKS.

Additionally: in the zero-reply case the scan now persists `pendingText` for the **single-trailing-block** short-answer shape even below 200 chars, and `stream-render.ts` lowers `minChars` to 1 for the capture-divergence corner (gateway captured empty + short answer) so the bridge still delivers. The #3228 Finding-2 masquerade guard is preserved: a *run* of short narration blocks still yields no `pendingText`.

**`flushedAnswerMatchesReply` is left exactly as-is** — the red-team rejected the Jaccard/fuzzy secondary (re-opens #3429: it would edit/delete genuine async sub-agent handbacks that share vocabulary).

## Test plan

New: `silent-end-single-writer-election.test.ts` (pure verdict matrix + env mirrors + liveness IO), `gateway-heartbeat.test.ts` (writer + no-drift with the hook reader), plus end-to-end election cases in `silent-end-interrupt-stop-integration.test.ts`. Updated the zero-reply short-answer `pendingText` assertions to the new contract in `silent-end-interrupt-stop-scan.test.ts` / `silent-end.test.ts`.

- Duplicate repro (zero-reply ≥200, flags on, retry 0, live) → ALLOW-elected (today it blocks → duplicate).
- Short-answer repro (zero-reply <200) → ALLOW-elected (flush has no length floor).
- Never-drop matrix: every allow verdict has a delivery machine; each guard forces BLOCK (flush-flag off, captured-prose flag off, retryCount>0, stale/missing heartbeat, interim-ack <200, no trailing prose).
- Send-failure net intact and #3429 supersede tests unweakened (no fuzzy match added).

Scoped vitest (13 files, 305 tests) green; `npm run lint` (tsc + all guards) clean.

## Risk

Sensitive turn-end delivery net. The liveness gate is fail-safe: any doubt ⇒ BLOCK (today's behaviour). Both delivery flags default ON. Supersede/dedup logic untouched.

Job spec: `reference/jobs/` always-available / no-drop reply delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)