### PR TITLE
fix(auth-broker): reach loopback LiteLLM via host network so /usage External row populates

### DIFF
--- a/src/agents/compose-auth-broker-litellm.test.ts
+++ b/src/agents/compose-auth-broker-litellm.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression guard: the auth-broker must be able to reach the LiteLLM proxy
+ * for `get-external-spend` (the `/usage` External OpenRouter row).
+ *
+ * Bug: with a loopback LiteLLM base (`http://127.0.0.1:4010`, the normal
+ * Coolify/socat host-loopback publish), the generator rewrote the base to
+ * `host.docker.internal` and left the broker on the compose bridge. But
+ * host.docker.internal/host-gateway routes to the host's *bridge* IP, NOT to
+ * host loopback — a 127.0.0.1-bound host port is unreachable from the bridge.
+ * The broker's live `/spend/logs` fetch was refused, `get-external-spend`
+ * returned `available:false`, and the `/usage` External row rendered blank.
+ *
+ * Fix: a loopback base makes the broker join the host network (mirroring the
+ * hindsight consumer's proven path) and keep the loopback URL verbatim. A
+ * non-loopback base stays on the bridge with host-gateway.
+ */
+
+import { describe, expect, it } from "vitest";
+import { generateCompose, isLoopbackHttpBase } from "./compose.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const AGENTS_DIR = "/home/op/.switchroom/agents";
+
+function configWithLitellmBase(baseUrl?: string): SwitchroomConfig {
+  return {
+    agents: {
+      alice: { profile: "engineer", claudeAccount: "default" },
+    },
+    profiles: {},
+    defaults: {},
+    switchroom: { agents_dir: AGENTS_DIR },
+    telegram: { forum_chat_id: "0" },
+    ...(baseUrl ? { litellm: { enabled: true, base_url: baseUrl } } : {}),
+  } as unknown as SwitchroomConfig;
+}
+
+function gen(config: SwitchroomConfig): string {
+  return generateCompose({ config, homeDir: "/home/op", warn: () => {} });
+}
+
+/** Slice the generated compose to the `switchroom-auth-broker:` service block. */
+function authBrokerBlock(yaml: string): string {
+  const lines = yaml.split("\n");
+  const start = lines.findIndex((l) => l.trimEnd() === "  switchroom-auth-broker:");
+  expect(start).toBeGreaterThanOrEqual(0);
+  // Next top-level service (2-space indent + name) or the volumes: block.
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    const l = lines[i]!;
+    if (/^ {2}\S/.test(l) || /^\S/.test(l)) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+describe("isLoopbackHttpBase", () => {
+  it("recognizes host-loopback bases", () => {
+    expect(isLoopbackHttpBase("http://127.0.0.1:4010")).toBe(true);
+    expect(isLoopbackHttpBase("http://localhost:4010")).toBe(true);
+    expect(isLoopbackHttpBase("http://127.0.0.1:4010/")).toBe(true);
+  });
+
+  it("rejects non-loopback bases", () => {
+    expect(isLoopbackHttpBase("http://litellm:4010")).toBe(false);
+    expect(isLoopbackHttpBase("http://10.0.0.5:4010")).toBe(false);
+    expect(isLoopbackHttpBase("https://proxy.example.com")).toBe(false);
+  });
+});
+
+describe("compose generator — auth-broker LiteLLM reachability", () => {
+  it("loopback base: broker joins host network and keeps the loopback URL verbatim", () => {
+    const block = authBrokerBlock(gen(configWithLitellmBase("http://127.0.0.1:4010")));
+
+    // Host network so 127.0.0.1:4010 (loopback-published proxy) is reachable.
+    expect(block).toContain("network_mode: host");
+    // The loopback URL is passed to the broker unchanged — NOT rewritten to a
+    // host.docker.internal address that cannot reach a loopback-bound port.
+    expect(block).toContain('SWITCHROOM_LITELLM_BASE: "http://127.0.0.1:4010"');
+    expect(block).not.toContain("host.docker.internal");
+    expect(block).not.toContain("extra_hosts");
+  });
+
+  it("localhost base: same host-network treatment", () => {
+    const block = authBrokerBlock(gen(configWithLitellmBase("http://localhost:4010")));
+    expect(block).toContain("network_mode: host");
+    expect(block).toContain('SWITCHROOM_LITELLM_BASE: "http://localhost:4010"');
+    expect(block).not.toContain("host.docker.internal");
+  });
+
+  it("non-loopback base: stays on the bridge with host-gateway, no host network", () => {
+    const block = authBrokerBlock(gen(configWithLitellmBase("http://litellm-proxy.internal:4010")));
+
+    expect(block).not.toContain("network_mode: host");
+    expect(block).toContain('SWITCHROOM_LITELLM_BASE: "http://litellm-proxy.internal:4010"');
+    expect(block).toContain("extra_hosts");
+    expect(block).toContain("host.docker.internal:host-gateway");
+  });
+
+  it("no litellm base configured: neither host network nor host-gateway", () => {
+    const block = authBrokerBlock(gen(configWithLitellmBase(undefined)));
+    expect(block).not.toContain("network_mode: host");
+    expect(block).not.toContain("extra_hosts");
+    expect(block).not.toContain("SWITCHROOM_LITELLM_BASE");
+  });
+});

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1001,6 +1001,24 @@ export function normalizeBindMountPath(p: string): string {
   return out;
 }
 
+/**
+ * True when a LiteLLM base URL points at the HOST's loopback interface
+ * (localhost / 127.0.0.1 / ::1). Such a proxy is only reachable via the host
+ * loopback, NOT through host.docker.internal/host-gateway (which routes to the
+ * host's bridge IP) — so a consumer container must join the host network to
+ * reach it. Mirrors `isLoopbackHttpUrl` in src/setup/hindsight.ts; kept local
+ * to avoid pulling the heavy hindsight module into the compose generator.
+ */
+export function isLoopbackHttpBase(url: string): boolean {
+  try {
+    const u = new URL(url.includes("://") ? url : `http://${url}`);
+    const h = (u.hostname || "").toLowerCase();
+    return h === "localhost" || h === "127.0.0.1" || h === "::1";
+  } catch {
+    return false;
+  }
+}
+
 /** The in-container path the config is mounted AT (also the SWITCHROOM_CONFIG
  *  value for containerised services). Never a valid host bind SOURCE. */
 export const CONTAINER_CONFIG_PATH = "/state/config/switchroom.yaml";
@@ -1740,28 +1758,36 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      SWITCHROOM_AUTH_BROKER_STATE_DIR: /state/auth-broker`);
   // LiteLLM root for get-external-spend (OpenRouter cash on /usage).
   // Broker holds the master key in state-dir; agents never see it.
-  // Auth-broker runs on the compose bridge (not host net). Operator
-  // base_url is almost always loopback (socat on the host) — rewrite
-  // 127.0.0.1/localhost → host.docker.internal so the broker can reach
-  // the host-published proxy. Non-loopback URLs pass through unchanged.
-  // extra_hosts is only emitted when we configure a base — keeps the
-  // zero-litellm fleet compose free of host-gateway (network_isolation
-  // regression receive).
+  //
+  // Reachability: the broker must connect out to the LiteLLM proxy the
+  // same way the hindsight consumer does (see generateHindsightComposeSnippet).
+  //   - Loopback base (127.0.0.1/localhost:4010): the proxy is published on
+  //     the HOST's loopback interface only (Coolify/socat bind 127.0.0.1).
+  //     A bridge container CANNOT reach a 127.0.0.1-bound host port —
+  //     host.docker.internal/host-gateway routes to the host's *bridge* IP
+  //     (e.g. 10.0.0.1), not to host loopback, so the connection is refused
+  //     and get-external-spend silently returns available:false (blank
+  //     /usage External row). Join the host network so 127.0.0.1:4010 is
+  //     directly reachable, and keep the loopback base URL verbatim.
+  //   - Non-loopback base (a real bridge-reachable host/socat name): stay on
+  //     the compose bridge and pair host-gateway so a mixed host-socat name
+  //     written as host.docker.internal still resolves.
+  // extra_hosts / network_mode are only emitted when a base is configured —
+  // keeps the zero-litellm fleet compose free of both (network_isolation
+  // regression guard).
   let authBrokerNeedsHostGateway = false;
+  let authBrokerNeedsHostNetwork = false;
   {
     const llBase =
       (config as { litellm?: { base_url?: string } }).litellm?.base_url;
     if (typeof llBase === "string" && llBase.trim()) {
       const raw = llBase.trim().replace(/\/+$/, "");
-      const bridged = raw
-        .replace(/^http:\/\/127\.0\.0\.1(?=[:/]|$)/i, "http://host.docker.internal")
-        .replace(/^http:\/\/localhost(?=[:/]|$)/i, "http://host.docker.internal")
-        .replace(/^https:\/\/127\.0\.0\.1(?=[:/]|$)/i, "https://host.docker.internal")
-        .replace(/^https:\/\/localhost(?=[:/]|$)/i, "https://host.docker.internal");
-      lines.push(`      SWITCHROOM_LITELLM_BASE: ${JSON.stringify(bridged)}`);
-      // Always pair with host-gateway when base is set: loopback rewrite
-      // needs it; non-loopback? harmless + covers mixed host socat names.
-      authBrokerNeedsHostGateway = true;
+      lines.push(`      SWITCHROOM_LITELLM_BASE: ${JSON.stringify(raw)}`);
+      if (isLoopbackHttpBase(raw)) {
+        authBrokerNeedsHostNetwork = true;
+      } else {
+        authBrokerNeedsHostGateway = true;
+      }
     }
   }
   lines.push(`      SWITCHROOM_ACCOUNTS_DIR: /state/accounts`);
@@ -1775,7 +1801,13 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   if (opts.operatorUid !== undefined) {
     lines.push(`      SWITCHROOM_AUTH_BROKER_OPERATOR_UID: "${opts.operatorUid}"`);
   }
-  if (authBrokerNeedsHostGateway) {
+  if (authBrokerNeedsHostNetwork) {
+    // Host network stack: 127.0.0.1:4010 (loopback-published LiteLLM) is
+    // directly reachable, mirroring the hindsight consumer's proven path.
+    // The broker's agent-facing IPC is unix-domain sockets in bind-mounted
+    // named volumes, so host networking does not affect how agents reach it.
+    lines.push(`    network_mode: host`);
+  } else if (authBrokerNeedsHostGateway) {
     lines.push(`    extra_hosts:`);
     lines.push(`      - "host.docker.internal:host-gateway"`);
   }

--- a/src/auth/broker/server-external-spend.test.ts
+++ b/src/auth/broker/server-external-spend.test.ts
@@ -182,6 +182,81 @@ describe("get-external-spend", () => {
     }
   });
 
+  it("returns available:true with per-model summary from a healthy /spend/logs body (real fetch path, openrouter rows)", async () => {
+    // End-to-end handoff guard: drive the REAL fetchAndSummarizeExternalSpend
+    // (no _testFetchExternalSpend seam) against a stubbed global fetch that
+    // returns a healthy `/spend/logs` body with openrouter/* rows. Locks that
+    // a live, reachable proxy yields available:true + the per-model top block —
+    // the state the /usage External row needs (and rendered blank in the bug).
+    const h = makeHarness();
+    seedAccount(h, "default");
+    const today = new Date().toISOString().slice(0, 10);
+    const realFetch = globalThis.fetch;
+    let calledUrl = "";
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      calledUrl = String(input);
+      const body = {
+        data: [
+          {
+            startTime: `${today}T00:00:00Z`,
+            spend: 12.5,
+            models: {
+              "openrouter/openai/gpt-oss-120b": 6.1,
+              "openrouter/x-ai/grok-4": 3.4,
+              "claude-sonnet-4": 99.0, // subscription passthrough — excluded
+            },
+          },
+        ],
+      };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const config = makeConfig(h);
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      _testLitellmMasterKey: "sk-secret-master-do-not-leak",
+    });
+    await broker.start();
+    try {
+      const sock = join(h.socketRoot, "alice", "sock");
+      const resp = (await rpc(sock, {
+        v: PROTOCOL_VERSION,
+        id: "e2e",
+        op: "get-external-spend",
+        forceLive: true,
+      })) as {
+        ok: boolean;
+        data?: {
+          available?: boolean;
+          day24hUsd?: number;
+          day7dUsd?: number;
+          top?: Array<{ label: string; usd: number }>;
+        };
+      };
+      expect(resp.ok).toBe(true);
+      expect(resp.data?.available).toBe(true);
+      // openrouter/* rows summed; Claude passthrough excluded.
+      expect(resp.data?.day24hUsd).toBeCloseTo(9.5, 5);
+      expect(resp.data?.day7dUsd).toBeCloseTo(9.5, 5);
+      const top = resp.data?.top ?? [];
+      expect(top.map((t) => t.label)).toEqual(["gpt-oss-120b", "grok-4"]);
+      expect(top[0]?.usd).toBeCloseTo(6.1, 5);
+      // Went through the real /spend/logs endpoint, not the enterprise report.
+      expect(calledUrl).toContain("/spend/logs");
+      // Master key never crosses the wire.
+      expect(JSON.stringify(resp)).not.toContain("sk-secret-master");
+    } finally {
+      broker.stop();
+      globalThis.fetch = realFetch;
+    }
+  });
+
   it("serves durable cache when live refresh fails", async () => {
     const h = makeHarness();
     seedAccount(h, "default");

--- a/src/litellm/external-spend.ts
+++ b/src/litellm/external-spend.ts
@@ -214,15 +214,33 @@ export async function fetchAndSummarizeExternalSpend(opts: {
       },
       signal: ac.signal,
     });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      // Operator-observable signal (broker log): a 401 here is the classic
+      // stale/wrong master key; a 5xx is proxy trouble. Without this the
+      // /usage External row just silently vanishes with no breadcrumb.
+      console.warn(
+        `external-spend: LiteLLM /spend/logs returned HTTP ${res.status} — ` +
+          `External /usage row will be blank (check master key / proxy)`,
+      );
+      return null;
+    }
     let body: unknown;
     try {
       body = await res.json();
-    } catch {
+    } catch (err) {
+      console.warn(
+        `external-spend: failed to parse /spend/logs JSON: ${(err as Error)?.message ?? err}`,
+      );
       return null;
     }
     return summarizeExternalSpend(normalizeSpendLogRows(body), now);
-  } catch {
+  } catch (err) {
+    // Transport failure (unreachable / DNS / timeout-abort). This is the
+    // exact branch the bridge-vs-loopback outage hit: the broker could not
+    // reach a loopback-published proxy and the error was swallowed to null.
+    console.warn(
+      `external-spend: LiteLLM /spend/logs fetch failed: ${(err as Error)?.message ?? err}`,
+    );
     return null;
   } finally {
     clearTimeout(timer);

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -3454,7 +3454,7 @@ describe("generateCompose — LiteLLM ANTHROPIC_BASE_URL model-class routing", (
     expect(agentBlock).not.toContain(ROOT);
     expect(agentBlock).not.toMatch(/ANTHROPIC_BASE_URL:/);
     expect(agentBlock).not.toMatch(/SWITCHROOM_LITELLM:/);
-    // Broker still receives the base (loopback rewritten to host-gateway).
+    // Broker still receives the base (non-loopback ROOT → passed through).
     const ab =
       /switchroom-auth-broker:[\s\S]*?(?=\n  [a-zA-Z]|\nvolumes:|$)/.exec(out)?.[0] ?? "";
     expect(ab).toMatch(/SWITCHROOM_LITELLM_BASE:/);
@@ -3463,7 +3463,11 @@ describe("generateCompose — LiteLLM ANTHROPIC_BASE_URL model-class routing", (
 
 
 describe("generateCompose — auth-broker LiteLLM base for external spend", () => {
-  it("rewrites loopback base_url to host.docker.internal + set extra_hosts", () => {
+  it("loopback base_url → host network + verbatim URL (not host.docker.internal)", () => {
+    // host.docker.internal/host-gateway routes to the host BRIDGE IP, not to
+    // a 127.0.0.1-bound host port — so a loopback-published proxy is only
+    // reachable when the broker joins the host network. See the dedicated
+    // compose-auth-broker-litellm.test.ts for the full matrix.
     const out = generateCompose({
       config: makeConfig(
         { router: {} },
@@ -3473,14 +3477,11 @@ describe("generateCompose — auth-broker LiteLLM base for external spend", () =
     const block =
       /switchroom-auth-broker:[\s\S]*?(?=\n  [a-zA-Z]|\nvolumes:|$)/.exec(out)?.[0] ?? "";
     expect(block).toContain(
-      'SWITCHROOM_LITELLM_BASE: "http://host.docker.internal:4010"',
-    );
-    expect(block).not.toContain(
       'SWITCHROOM_LITELLM_BASE: "http://127.0.0.1:4010"',
     );
-    expect(block).toMatch(
-      /extra_hosts:\n {6}- "host\.docker\.internal:host-gateway"/,
-    );
+    expect(block).not.toContain("host.docker.internal");
+    expect(block).not.toContain("extra_hosts");
+    expect(block).toContain("network_mode: host");
   });
 
   it("passes non-loopback base_url through unchanged", () => {


### PR DESCRIPTION
## Symptom
The `/usage` Telegram card's **External** OpenRouter-spend row (24h/7d + top models) renders **nothing** — silently absent for the operator.

## Root cause (contradicts the key-mismatch hypothesis)
Not a data/license/key problem. Verified live on the fleet:
- `/spend/logs` is healthy and returns real `openrouter/*` rows with dollar figures.
- The broker's resolved master key (`/state/auth-broker/litellm-master-key`) **matches** the live litellm container's `LITELLM_MASTER_KEY` (sha256 identical, trimmed) — so the key-mismatch hypothesis is **wrong**.

The break is in the broker→proxy network path, generated in **`src/agents/compose.ts`**:
- Pre-fix (`compose.ts` ~L1750-1780) rewrote a loopback base_url `http://127.0.0.1:4010` → `http://host.docker.internal:4010` and left `switchroom-auth-broker` on the compose bridge (`switchroom_default`), pairing `extra_hosts: host.docker.internal:host-gateway`.
- But litellm publishes its port as `127.0.0.1:4010->4000/tcp` (host **loopback only**), and `host.docker.internal`/host-gateway resolves to the host's **bridge** IP (observed `10.0.0.1`), which does **not** route to a 127.0.0.1-bound host port.

Observed on the live broker (`switchroom-auth-broker`, `SWITCHROOM_LITELLM_BASE=http://host.docker.internal:4010`):
```
node fetch http://host.docker.internal:4010/spend/logs  => "fetch failed"
node fetch http://127.0.0.1:4010/health/liveliness       => "fetch failed"
curl (bridge container) http://10.0.0.1:4010/...         => 000 / fail
```
`fetchAndSummarizeExternalSpend` (`src/litellm/external-spend.ts:208-229`) **swallows** the transport error and returns `null` — so nothing is thrown, there is **no** `"external-spend refresh failed"` log line and **no** `external-spend.json` on disk. `opGetExternalSpend` (`src/auth/broker/server.ts:3324-3334`) then returns `available:false` (reason `litellm_unreachable`, since the key resolves), and `formatExternalSpendBlock(null)` omits the block → blank card.

## Fix
Mirror the hindsight consumer's proven loopback-LiteLLM path (`generateHindsightComposeSnippet` uses `network_mode: host`). In `compose.ts`:
- **Loopback** base_url → auth-broker joins `network_mode: host` and keeps the loopback URL **verbatim** (so `127.0.0.1:4010` is directly reachable). No `host.docker.internal`, no `extra_hosts`.
- **Non-loopback** base_url → unchanged (bridge + `host-gateway`).
- No base → neither (zero-litellm fleet output unchanged).

Security model intact: the master key still never leaves the broker; the broker's agent-facing IPC is unix-domain sockets in bind-mounted named volumes, unaffected by host networking. Agents still receive only the sanitized summary.

## Tests (scoped, assert outcomes)
- `src/agents/compose-auth-broker-litellm.test.ts` (new) — loopback base ⇒ `network_mode: host` + verbatim loopback URL, no `host.docker.internal`/`extra_hosts`; non-loopback ⇒ bridge + host-gateway; no base ⇒ neither. **Fails on the pre-fix code** (verified by reverting `compose.ts`).
- `src/auth/broker/server-external-spend.test.ts` (extended) — end-to-end through the **real** fetch path with a healthy `/spend/logs` body of `openrouter/*` rows ⇒ `available:true` with per-model top summary (Claude passthrough excluded), master key never on the wire.

Scoped `vitest`: **27 passed** (4 files). `npm run lint`: **clean** (litellm-config-guard SKIPs in hermetic dev — host-only sensor).

Do not merge — pending adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 2 (addressed in this PR)
- **BLOCKER fixed** — obsoleted `tests/docker/compose-generator.test.ts` case ("rewrites loopback → host.docker.internal") updated to assert the new `network_mode: host` + verbatim-URL behavior (was failing shard 3).
- **SHOULD fixed** — `src/litellm/external-spend.ts` now `console.warn`s on the non-ok HTTP, JSON-parse, and outer transport branches (operator-observable broker log) instead of silently returning null.

## Non-blocking follow-ups (NOT in this PR — filed for later)
- **(a) unset `base_url` gap:** host-net keys off an *explicit-loopback* `base_url`. A fleet with `litellm.enabled:true` but no explicit `base_url` still defaults the broker to loopback `127.0.0.1:4010` on the bridge and hits the same unreachability. Fix would key host-net off the *resolved* base (including the default), or emit host-net whenever litellm is enabled without a non-loopback base.
- **(b) strict network-isolation (#1413) interaction:** when the broker is forced onto `network_mode: host` for a loopback proxy, that supersedes any per-service bridge isolation. Worth a one-line comment / explicit reconciliation with the #1413 strict-isolation model so the two features don't silently conflict.
