### PR TITLE
feat(gateway): per-tool-call wall-clock deadline (Stage A hang prevention)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -243,6 +243,14 @@ import {
   distinctRequestIds,
 } from './permission-rearm.js'
 import { sweepPermissionTtl } from './permission-ttl-sweep.js'
+import {
+  ToolCallDeadlineTracker,
+  resolveDeadlineConfig,
+  observeToolUse,
+  toolCallDeadlineEnabled,
+  toolCallDeadlineEnforced,
+  sweepToolCallDeadlines,
+} from './tool-call-deadline.js'
 import { createMissedApprovalsStore, type MissedApproval } from './missed-approvals-store.js'
 import {
   createAlwaysAllowPersistQueue,
@@ -4429,6 +4437,13 @@ function postBusyAck(chatId: string, threadId: number | undefined, text: string)
 // stashed inbound, the original deadline is preserved (bounded wait).
 const toolFlightTracker = new ToolFlightTracker()
 
+// Per-tool-call wall-clock deadline (Stage A prevention) — see
+// tool-call-deadline.ts. `standard` tools get a ~120s ceiling; `human` waits
+// (owned by the #2724 permission-TTL sweep) and `background` tools (Task/Agent/
+// long Bash) are excluded. Enforcement is opt-in (SWITCHROOM_TOOL_DEADLINE_ENFORCE=1).
+const toolCallDeadline = new ToolCallDeadlineTracker()
+const TOOL_DEADLINE_CONFIG = resolveDeadlineConfig()
+
 interface PendingDeferredInterrupt {
   agentName: string
   inboundMsg: InboundMessage
@@ -7736,6 +7751,30 @@ const pendingStateReaper = isGatewayMain ? setInterval(() => {  // #2996 P0c gat
 }, 60_000) : undefined
 pendingStateReaper?.unref()
 
+// Stage A: dedicated 5s per-tool-call deadline sweep (the 60s reaper above is
+// too coarse to catch a 120s breach near its ceiling). Decision + logging live
+// in sweepToolCallDeadlines; the gateway owns the timer + the force-fail IO.
+const toolCallDeadlineSweep = isGatewayMain ? setInterval(() => {
+  if (!toolCallDeadlineEnabled()) return
+  try {
+    sweepToolCallDeadlines(toolCallDeadline, Date.now(), TOOL_DEADLINE_CONFIG, {
+      enforce: toolCallDeadlineEnforced(),
+      log: (l) => process.stderr.write(`telegram gateway: ${l}\n`),
+      onForceFail: (b) => {
+        toolFlightTracker.drop(b.toolUseId)
+        if (currentTurn != null) {
+          silencePoke.noteToolEnd(
+            statusKey(currentTurn.sessionChatId, currentTurn.sessionThreadId),
+            b.toolUseId, Date.now())
+        }
+      },
+    })
+  } catch (err) {
+    process.stderr.write(`telegram gateway: [tool-deadline] sweep failed: ${(err as Error).message}\n`)
+  }
+}, 5_000) : undefined
+toolCallDeadlineSweep?.unref()
+
 /**
  * Does a message look like a Claude setup-token browser code?
  *
@@ -10814,6 +10853,10 @@ if (isGatewayMain) ipcServer = createIpcServer({
     // interrupt is parked waiting for a clean boundary and this event drains
     // the last in-flight tool, fire it now rather than waiting out the timer.
     toolFlightTracker.onEvent(ev)
+    // Stage A: a new turn starts clean; a killed turn may never emit trailing
+    // tool_results — mirror ToolFlightTracker's clear so stale deadlines don't
+    // leak across turns.
+    if (ev.kind === 'turn_end' || ev.kind === 'enqueue') toolCallDeadline.clear()
     if (pendingDeferredInterrupt != null && !toolFlightTracker.isMidToolCall()) {
       void fireDeferredInterrupt('boundary')
     }
@@ -10856,6 +10899,8 @@ if (isGatewayMain) ipcServer = createIpcServer({
             label.length > 0 ? label : null,
             Date.now(),
           )
+          // Stage A: track this tool against its per-call deadline.
+          observeToolUse(toolCallDeadline, ev.toolUseId, ev.toolName, ev.input, Date.now())
           // #1445 cross-turn pending-async ambient. Mark the chat as
           // having dispatched background work this turn so a turn_end
           // that follows activates the edit-in-place ambient line.
@@ -10878,6 +10923,10 @@ if (isGatewayMain) ipcServer = createIpcServer({
         // (covers Telegram-surface tools we skipped at start time).
         if (ev.toolUseId != null && ev.toolUseId.length > 0) {
           silencePoke.noteToolEnd(key, ev.toolUseId, Date.now())
+          // Stage A per-toolUseId guard: a real result arriving after a
+          // force-fail returns false (already stood in for) — drop, don't
+          // double-process. Bookkeeping-only here (silence-poke already drained).
+          if (toolCallDeadlineEnabled()) toolCallDeadline.noteResult(ev.toolUseId)
         }
       }
     }

--- a/telegram-plugin/gateway/interrupt-defer.ts
+++ b/telegram-plugin/gateway/interrupt-defer.ts
@@ -67,6 +67,18 @@ export class ToolFlightTracker {
     return this.inFlight.size
   }
 
+  /**
+   * Drop a single in-flight tool by id. Used when the per-tool-call deadline
+   * force-fails a wedged tool: the gateway injects a synthetic tool_result and
+   * must clear THIS tool's masked flight entry so `isMidToolCall()` stops
+   * classifying the hang as healthy work (which otherwise defers the
+   * silence-poke fallback to its 15-min ceiling). Idempotent — dropping an
+   * absent id is a no-op. Returns true when an entry was removed.
+   */
+  drop(toolUseId: string): boolean {
+    return this.inFlight.delete(toolUseId)
+  }
+
   clear(): void {
     this.inFlight.clear()
   }

--- a/telegram-plugin/gateway/tool-call-deadline.ts
+++ b/telegram-plugin/gateway/tool-call-deadline.ts
@@ -1,0 +1,369 @@
+/**
+ * tool-call-deadline.ts — deterministic per-tool-call wall-clock deadline.
+ *
+ * WHY THIS EXISTS
+ *
+ * The gateway classifies "a tool is mid-call" as healthy work: while any
+ * tool_use is open, `isLegitimatelyWorking` (gateway.ts) returns true and the
+ * silence-poke 300s framework fallback is DEFERRED all the way to the 15-min
+ * hard ceiling (silence-poke.ts tick()). A tool that never returns therefore
+ * pins the conversation for 15 minutes before any net even considers acting —
+ * and even then the fallback only tears down gateway state, never the child.
+ * This is the "carrie" hang mode: an in-flight tool call that waits forever.
+ *
+ * This module bounds every in-flight tool with a hard wall-clock deadline,
+ * measured from the tool's own `startedAt`, independent of the outbound-silence
+ * clock. Past the class ceiling the tracker reports a BREACH; the gateway
+ * injects a synthetic `tool_result` error for that toolUseId and drops the
+ * masked flight entry so the hang stops being classified as healthy work.
+ *
+ * THREE CLASSES
+ *
+ *   - `standard`  — ordinary foreground tool calls (Read, Grep, most MCP tools).
+ *                   Short ceiling (~120s). A standard tool that runs longer than
+ *                   this is either genuinely wedged or so slow the model is
+ *                   better served by an error it can react to than by an
+ *                   unbounded stall.
+ *   - `human`     — genuine human-in-the-loop waits (`ask_user`, and any tool
+ *                   parked on an operator approval card). These are NOT
+ *                   force-failed here: their lifetime is owned by the existing
+ *                   permission-TTL sweep (`permission-ttl-sweep.ts`, #2724),
+ *                   which auto-denies on a human-scale TTL. Double-reaping them
+ *                   on a 120s clock would deny operators mid-decision.
+ *   - `background`— legitimately long-running foreground tools whose progress
+ *                   the gateway measures by a SEPARATE signal, so a fixed
+ *                   wall-clock ceiling would misjudge them as hung: `Task` /
+ *                   `Agent` sub-agent dispatches (progress = sub-agent JSONL
+ *                   growth, `subagent-watcher.ts`) and long `Bash` runs. These
+ *                   are EXCLUDED from the short ceiling — keying a kill on
+ *                   "tool open N seconds" is exactly the anti-pattern the
+ *                   turn-active-marker discriminator (Stage B) exists to avoid.
+ *
+ * The `human` and `background` classes exist so the tracker excludes them from
+ * the short ceiling DETERMINISTICALLY rather than by omission.
+ *
+ * ENFORCEMENT IS OPT-IN. The tracker always observes and always reports
+ * breaches, but the gateway only takes the destructive force-fail action when
+ * enforcement is explicitly enabled (`SWITCHROOM_TOOL_DEADLINE_ENFORCE=1`).
+ * Shipping the mechanism inert-by-default keeps the blast radius low: the
+ * deterministic machinery + the per-toolUseId guard land and are proven by
+ * tests, and enforcement is switched on per-agent once the Stage B
+ * marker-staleness discriminator can distinguish a hang from a slow tool.
+ *
+ * THE PER-toolUseId GUARD (critical)
+ *
+ * After a breach the tracker remembers the toolUseId in a `reaped` set. If the
+ * real `tool_result` for that id later arrives (the tool finally returned, or
+ * the injected error raced the genuine completion), `noteResult` returns
+ * `false` so the caller DROPS it — the model already received the synthetic
+ * error, and processing the late real result would double-count the flight and
+ * corrupt the silence/liveness bookkeeping. A result for a never-breached id
+ * returns `true` (process normally).
+ *
+ * This module is pure and deterministic: the clock is injected, there are no
+ * timers or IO. The gateway owns the timer and the injection side effect.
+ */
+
+/** Deadline class for an in-flight tool call. */
+export type ToolDeadlineClass = 'standard' | 'human' | 'background'
+
+/** An in-flight tool call under deadline tracking. */
+export interface DeadlineEntry {
+  toolUseId: string
+  name: string
+  startedAt: number
+  klass: ToolDeadlineClass
+}
+
+/** A tool call that has exceeded its deadline and must be force-failed. */
+export interface DeadlineBreach {
+  toolUseId: string
+  name: string
+  klass: ToolDeadlineClass
+  /** Wall-clock ms the tool was in flight when the breach was detected. */
+  elapsedMs: number
+  /** The class ceiling that was crossed, in ms. */
+  deadlineMs: number
+}
+
+export interface DeadlineConfig {
+  /** Ceiling for `standard` tools (default 120_000). */
+  standardMs: number
+  /**
+   * Ceiling for `human` tools. Defaults to +Infinity: human waits are owned by
+   * the permission-TTL sweep, so this tracker never force-fails them. Kept
+   * configurable so a test can prove the exclusion explicitly.
+   */
+  humanMs: number
+  /**
+   * Ceiling for `background` tools (Task/Agent/long Bash). Defaults to
+   * +Infinity: their health is judged by the marker-staleness discriminator
+   * (Stage B), not a wall-clock. Configurable so a test can prove the exclusion.
+   */
+  backgroundMs: number
+}
+
+/** Default short ceiling for a standard tool call. */
+export const DEFAULT_STANDARD_DEADLINE_MS = 120_000
+
+export const DEFAULT_DEADLINE_CONFIG: DeadlineConfig = {
+  standardMs: DEFAULT_STANDARD_DEADLINE_MS,
+  humanMs: Number.POSITIVE_INFINITY,
+  backgroundMs: Number.POSITIVE_INFINITY,
+}
+
+/**
+ * Resolve the live deadline config from the environment: `standard` from
+ * `SWITCHROOM_TOOL_DEADLINE_STANDARD_MS`; `human` + `background` stay +Infinity
+ * (owned by the permission-TTL sweep / marker-staleness discriminator).
+ */
+export function resolveDeadlineConfig(
+  env: Record<string, string | undefined> = process.env,
+): DeadlineConfig {
+  return {
+    standardMs: standardDeadlineMs(env),
+    humanMs: Number.POSITIVE_INFINITY,
+    backgroundMs: Number.POSITIVE_INFINITY,
+  }
+}
+
+/**
+ * Resolve the standard-tool deadline from the environment. Threaded as
+ * `SWITCHROOM_TOOL_DEADLINE_STANDARD_MS`; a blank/garbage/non-positive value
+ * falls back to the default so the deadline can never be born already-expired.
+ */
+export function standardDeadlineMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env.SWITCHROOM_TOOL_DEADLINE_STANDARD_MS
+  if (raw === undefined || raw.trim() === '') return DEFAULT_STANDARD_DEADLINE_MS
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_STANDARD_DEADLINE_MS
+  return Math.floor(n)
+}
+
+/** Kill switch — the tracker stops OBSERVING entirely when set to `0`/`false`. */
+export function toolCallDeadlineEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const v = env.SWITCHROOM_DISABLE_TOOL_DEADLINE
+  return !(v === '1' || v === 'true')
+}
+
+/**
+ * Whether the gateway takes the destructive force-fail action on a breach.
+ * OPT-IN (default OFF): the tracker + guard ship inert so the mechanism lands
+ * with low blast radius; enforcement is enabled per-agent once Stage B's
+ * marker-staleness discriminator is in place. See file header § ENFORCEMENT.
+ */
+export function toolCallDeadlineEnforced(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const v = env.SWITCHROOM_TOOL_DEADLINE_ENFORCE
+  return v === '1' || v === 'true'
+}
+
+/** Tool names that are genuine human-in-the-loop waits (deadline class `human`). */
+const HUMAN_WAIT_TOOLS = new Set<string>(['ask_user'])
+
+/**
+ * Tool names whose progress is measured by a separate signal (sub-agent JSONL
+ * growth / background output), so a fixed wall-clock ceiling would misjudge a
+ * healthy long run as a hang — deadline class `background`.
+ */
+const BACKGROUND_TOOLS = new Set<string>(['Task', 'Agent'])
+
+/**
+ * Classify a tool call into a deadline class.
+ *
+ *  - `ask_user`, or any tool the caller flags as parked on an operator approval
+ *    card → `human` (owned by the permission-TTL sweep).
+ *  - `Task` / `Agent` sub-agent dispatch, or a `Bash` flagged as a background /
+ *    long run → `background` (health judged by marker staleness, Stage B).
+ *  - everything else → `standard`.
+ */
+export function classifyToolClass(
+  toolName: string,
+  opts: { awaitingApproval?: boolean; backgroundBash?: boolean } = {},
+): ToolDeadlineClass {
+  if (opts.awaitingApproval === true) return 'human'
+  if (HUMAN_WAIT_TOOLS.has(toolName)) return 'human'
+  if (BACKGROUND_TOOLS.has(toolName)) return 'background'
+  if (toolName === 'Bash' && opts.backgroundBash === true) return 'background'
+  return 'standard'
+}
+
+/**
+ * The synthetic `tool_result` error body injected when a standard tool breaches
+ * its deadline. Phrased so the model treats it as an operational error it can
+ * react to (retry differently / report / move on), not a denial.
+ */
+export function deadlineErrorText(name: string, deadlineMs: number): string {
+  const seconds = Math.round(deadlineMs / 1000)
+  return (
+    `Tool "${name}" exceeded its ${seconds}s wall-clock deadline and was ` +
+    `force-failed by the gateway. It did not return in time. Do not simply ` +
+    `retry the identical call — either take a different approach or tell the ` +
+    `user this step could not complete.`
+  )
+}
+
+/**
+ * Deterministic tracker of in-flight tool calls against a per-call deadline.
+ * Pure: the caller injects the clock (`now`) and owns the timer + the synthetic
+ * result injection. See file header for the class + guard semantics.
+ */
+export class ToolCallDeadlineTracker {
+  private readonly inFlight = new Map<string, DeadlineEntry>()
+  /** toolUseIds force-failed on a breach — a later real result for one of these
+   *  is dropped (the per-toolUseId double-processing guard). */
+  private readonly reaped = new Set<string>()
+
+  /**
+   * Record the start of a tool call. Idempotent: a repeat start for the same
+   * id overwrites (refreshes startedAt/label), matching silence-poke's
+   * noteToolStart. Clears any stale reaped mark for a reused id.
+   */
+  noteStart(
+    toolUseId: string,
+    name: string,
+    klass: ToolDeadlineClass,
+    startedAt: number,
+  ): void {
+    if (toolUseId.length === 0) return
+    this.reaped.delete(toolUseId)
+    this.inFlight.set(toolUseId, { toolUseId, name, startedAt, klass })
+  }
+
+  /**
+   * Record a tool_result for `toolUseId`.
+   *
+   * Returns `true` when the caller should process the result normally, `false`
+   * when it must be DROPPED because the tool was already force-failed on a
+   * breach (the synthetic error was injected; the late real result would
+   * double-process). A result for an unknown/never-tracked id returns `true`
+   * (nothing to guard).
+   */
+  noteResult(toolUseId: string): boolean {
+    if (toolUseId.length === 0) return true
+    if (this.reaped.delete(toolUseId)) return false
+    this.inFlight.delete(toolUseId)
+    return true
+  }
+
+  /**
+   * Detect deadline breaches at wall-clock `now`. For every in-flight tool
+   * whose class ceiling has been crossed, emit a breach, mark it reaped, and
+   * drop it from the in-flight map (so the next sweep does not re-report it and
+   * so `has`/`size` reflect that the gateway is about to force-fail it).
+   *
+   * `human` tools are never breached here (their ceiling defaults to +Infinity)
+   * — the permission-TTL sweep owns them.
+   */
+  sweep(now: number, cfg: DeadlineConfig = DEFAULT_DEADLINE_CONFIG): DeadlineBreach[] {
+    const breaches: DeadlineBreach[] = []
+    for (const [id, entry] of this.inFlight) {
+      const deadlineMs =
+        entry.klass === 'human'
+          ? cfg.humanMs
+          : entry.klass === 'background'
+            ? cfg.backgroundMs
+            : cfg.standardMs
+      if (!Number.isFinite(deadlineMs)) continue
+      const elapsedMs = now - entry.startedAt
+      if (elapsedMs >= deadlineMs) {
+        breaches.push({
+          toolUseId: id,
+          name: entry.name,
+          klass: entry.klass,
+          elapsedMs,
+          deadlineMs,
+        })
+      }
+    }
+    for (const b of breaches) {
+      this.inFlight.delete(b.toolUseId)
+      this.reaped.add(b.toolUseId)
+    }
+    return breaches
+  }
+
+  /** True when at least one tool is in flight under deadline tracking. */
+  hasInFlight(): boolean {
+    return this.inFlight.size > 0
+  }
+
+  /** Count of in-flight tool calls under deadline tracking (diagnostics). */
+  inFlightCount(): number {
+    return this.inFlight.size
+  }
+
+  /**
+   * Clear all in-flight + reaped state — called on turn_end / enqueue (a new
+   * turn starts clean; a killed turn may never emit trailing results). Mirrors
+   * ToolFlightTracker.clear().
+   */
+  clear(): void {
+    this.inFlight.clear()
+    this.reaped.clear()
+  }
+}
+
+/**
+ * Observe a `tool_use` event: classify the tool and start its deadline clock.
+ * Keeps the gateway's session-event handler a thin call. No-op when the
+ * subsystem is disabled or the id is empty.
+ */
+export function observeToolUse(
+  tracker: ToolCallDeadlineTracker,
+  toolUseId: string | null | undefined,
+  toolName: string,
+  input: unknown,
+  now: number,
+): void {
+  if (!toolCallDeadlineEnabled()) return
+  if (toolUseId == null || toolUseId.length === 0) return
+  const backgroundBash = (input as { run_in_background?: boolean } | undefined)?.run_in_background === true
+  tracker.noteStart(toolUseId, toolName, classifyToolClass(toolName, { backgroundBash }), now)
+}
+
+/** Gateway-supplied side effects for the deadline sweep (P0c: the module owns
+ *  the decision, the gateway owns the timer + the IO). */
+export interface DeadlineSweepDeps {
+  /** When false, breaches are only logged (observe-only) — not force-failed. */
+  enforce: boolean
+  /** Emit one diagnostic line (gateway prefixes + writes to stderr). */
+  log: (line: string) => void
+  /**
+   * Force-fail a breached tool: the gateway un-masks the hang by dropping the
+   * flight entry from the interrupt-defer tracker + the silence-poke in-flight
+   * map so `isMidToolCall` stops classifying it as healthy work.
+   */
+  onForceFail: (breach: DeadlineBreach) => void
+}
+
+/**
+ * Sweep the tracker at `now`, log every breach, and force-fail each one when
+ * enforcement is enabled. The pure decision (which tools breached) lives in
+ * `tracker.sweep`; this wraps it with the logging + enforcement policy so the
+ * gateway's timer callback stays a thin shell (gateway anti-inflation ratchet,
+ * switchroom#2996).
+ */
+export function sweepToolCallDeadlines(
+  tracker: ToolCallDeadlineTracker,
+  now: number,
+  cfg: DeadlineConfig,
+  deps: DeadlineSweepDeps,
+): DeadlineBreach[] {
+  const breaches = tracker.sweep(now, cfg)
+  for (const b of breaches) {
+    deps.log(
+      `[tool-deadline] breach tool=${b.name} class=${b.klass} ` +
+      `elapsed=${Math.round(b.elapsedMs / 1000)}s ` +
+      `deadline=${Math.round(b.deadlineMs / 1000)}s enforce=${deps.enforce} ` +
+      `synthetic="${deadlineErrorText(b.name, b.deadlineMs)}"`,
+    )
+    if (deps.enforce) deps.onForceFail(b)
+  }
+  return breaches
+}

--- a/telegram-plugin/tests/interrupt-defer.test.ts
+++ b/telegram-plugin/tests/interrupt-defer.test.ts
@@ -62,6 +62,20 @@ describe('ToolFlightTracker', () => {
     expect(t.isMidToolCall()).toBe(false)
   })
 
+  it('drop(id) clears a single masked entry (used by the deadline force-fail)', () => {
+    const t = new ToolFlightTracker()
+    t.onEvent({ kind: 'tool_use', toolUseId: 'tu_1' })
+    t.onEvent({ kind: 'tool_use', toolUseId: 'tu_2' })
+    expect(t.drop('tu_1')).toBe(true)
+    // tu_2 still open — the boundary is still unsafe.
+    expect(t.isMidToolCall()).toBe(true)
+    expect(t.inFlightCount()).toBe(1)
+    // Dropping the last one clears the boundary; dropping an absent id is a no-op.
+    expect(t.drop('tu_2')).toBe(true)
+    expect(t.isMidToolCall()).toBe(false)
+    expect(t.drop('tu_1')).toBe(false)
+  })
+
   it('ignores sub-agent and non-tool events', () => {
     const t = new ToolFlightTracker()
     t.onEvent({ kind: 'sub_agent_tool_use', toolUseId: 'sub_1' })

--- a/telegram-plugin/tests/tool-call-deadline.test.ts
+++ b/telegram-plugin/tests/tool-call-deadline.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for the per-tool-call wall-clock deadline (Stage A prevention).
+ *
+ * The gateway-side wiring (5s sweep timer, synthetic-result injection, flight
+ * clearing) is exercised by integration; these pin the pure, deterministic
+ * core:
+ *   - a never-returning STANDARD tool breaches within its ceiling, and the
+ *     injected synthetic error lets the turn proceed;
+ *   - the per-toolUseId guard drops a real result that arrives AFTER the
+ *     synthetic error (no double-processing);
+ *   - human + background classes are EXCLUDED from the short ceiling;
+ *   - classification + config helpers behave.
+ *
+ * FAILS on current head: `../gateway/tool-call-deadline.js` does not exist
+ * there — the deadline mechanism is the contribution under test.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  ToolCallDeadlineTracker,
+  classifyToolClass,
+  standardDeadlineMs,
+  toolCallDeadlineEnforced,
+  deadlineErrorText,
+  sweepToolCallDeadlines,
+  resolveDeadlineConfig,
+  observeToolUse,
+  DEFAULT_STANDARD_DEADLINE_MS,
+  DEFAULT_DEADLINE_CONFIG,
+  type DeadlineConfig,
+  type DeadlineBreach,
+} from '../gateway/tool-call-deadline.js'
+
+const cfg: DeadlineConfig = { standardMs: 120_000, humanMs: Number.POSITIVE_INFINITY, backgroundMs: Number.POSITIVE_INFINITY }
+
+describe('ToolCallDeadlineTracker — standard ceiling', () => {
+  it('a never-returning standard tool breaches within the ceiling and the turn proceeds', () => {
+    const t = new ToolCallDeadlineTracker()
+    const t0 = 1_000_000
+    t.noteStart('tu_1', 'Read', 'standard', t0)
+
+    // Just under the ceiling: no breach, still in flight.
+    expect(t.sweep(t0 + 119_999, cfg)).toEqual([])
+    expect(t.hasInFlight()).toBe(true)
+
+    // At the ceiling: exactly one breach for tu_1; the gateway injects the
+    // synthetic error and the flight entry is cleared so isMidToolCall stops
+    // masking the hang and the turn can proceed.
+    const breaches = t.sweep(t0 + 120_000, cfg)
+    expect(breaches).toHaveLength(1)
+    expect(breaches[0]!.toolUseId).toBe('tu_1')
+    expect(breaches[0]!.name).toBe('Read')
+    expect(breaches[0]!.klass).toBe('standard')
+    expect(breaches[0]!.deadlineMs).toBe(120_000)
+    expect(breaches[0]!.elapsedMs).toBe(120_000)
+    expect(t.hasInFlight()).toBe(false)
+
+    // The synthetic result the gateway injects reads as an operational error.
+    const text = deadlineErrorText(breaches[0]!.name, breaches[0]!.deadlineMs)
+    expect(text).toContain('exceeded')
+    expect(text).toContain('120s')
+  })
+
+  it('does not re-report a breach on the next sweep', () => {
+    const t = new ToolCallDeadlineTracker()
+    t.noteStart('tu_1', 'Read', 'standard', 0)
+    expect(t.sweep(200_000, cfg)).toHaveLength(1)
+    expect(t.sweep(300_000, cfg)).toEqual([])
+  })
+
+  it('a fast standard tool that returns before the ceiling never breaches', () => {
+    const t = new ToolCallDeadlineTracker()
+    t.noteStart('tu_1', 'Read', 'standard', 0)
+    expect(t.noteResult('tu_1')).toBe(true)
+    expect(t.sweep(10_000_000, cfg)).toEqual([])
+    expect(t.hasInFlight()).toBe(false)
+  })
+})
+
+describe('ToolCallDeadlineTracker — per-toolUseId guard (critical)', () => {
+  it('drops a real result that arrives AFTER the synthetic error', () => {
+    const t = new ToolCallDeadlineTracker()
+    t.noteStart('tu_1', 'Read', 'standard', 0)
+    // Force-fail on breach.
+    expect(t.sweep(120_000, cfg)).toHaveLength(1)
+    // The real tool_result finally arrives — it MUST be dropped, not processed.
+    expect(t.noteResult('tu_1')).toBe(false)
+    // And the drop is one-shot: a second stray result for the same id is not
+    // still flagged as reaped (defensive) but is a harmless unknown → true.
+    expect(t.noteResult('tu_1')).toBe(true)
+  })
+
+  it('a result for a never-breached / unknown id is processed normally', () => {
+    const t = new ToolCallDeadlineTracker()
+    expect(t.noteResult('unknown')).toBe(true)
+  })
+
+  it('a reused toolUseId after a breach clears the stale reaped mark', () => {
+    const t = new ToolCallDeadlineTracker()
+    t.noteStart('tu_1', 'Read', 'standard', 0)
+    expect(t.sweep(120_000, cfg)).toHaveLength(1)
+    // Reused id (fresh call) — noteStart clears the reaped mark so its real
+    // result is processed normally.
+    t.noteStart('tu_1', 'Read', 'standard', 500_000)
+    expect(t.noteResult('tu_1')).toBe(true)
+  })
+})
+
+describe('ToolCallDeadlineTracker — excluded classes', () => {
+  it('human waits are never force-failed on the short ceiling', () => {
+    const t = new ToolCallDeadlineTracker()
+    t.noteStart('tu_h', 'ask_user', 'human', 0)
+    expect(t.sweep(10_000_000, cfg)).toEqual([])
+    expect(t.hasInFlight()).toBe(true)
+  })
+
+  it('background (Task/Agent/long Bash) tools are never force-failed on the short ceiling', () => {
+    const t = new ToolCallDeadlineTracker()
+    t.noteStart('tu_b', 'Task', 'background', 0)
+    expect(t.sweep(10_000_000, cfg)).toEqual([])
+    expect(t.hasInFlight()).toBe(true)
+  })
+
+  it('a finite override CAN bound human/background if an operator sets one', () => {
+    const t = new ToolCallDeadlineTracker()
+    t.noteStart('tu_h', 'ask_user', 'human', 0)
+    const bounded: DeadlineConfig = { standardMs: 120_000, humanMs: 60_000, backgroundMs: Number.POSITIVE_INFINITY }
+    expect(t.sweep(60_000, bounded)).toHaveLength(1)
+  })
+
+  it('clear() drops in-flight and reaped state', () => {
+    const t = new ToolCallDeadlineTracker()
+    t.noteStart('tu_1', 'Read', 'standard', 0)
+    t.sweep(120_000, cfg)
+    t.clear()
+    expect(t.hasInFlight()).toBe(false)
+    // reaped cleared too: a post-clear result for the old id is unknown → true.
+    expect(t.noteResult('tu_1')).toBe(true)
+  })
+})
+
+describe('classifyToolClass', () => {
+  it('ask_user → human', () => {
+    expect(classifyToolClass('ask_user')).toBe('human')
+  })
+  it('a tool parked on an approval card → human', () => {
+    expect(classifyToolClass('Bash', { awaitingApproval: true })).toBe('human')
+  })
+  it('Task / Agent → background', () => {
+    expect(classifyToolClass('Task')).toBe('background')
+    expect(classifyToolClass('Agent')).toBe('background')
+  })
+  it('a run_in_background Bash → background', () => {
+    expect(classifyToolClass('Bash', { backgroundBash: true })).toBe('background')
+  })
+  it('an ordinary foreground tool → standard', () => {
+    expect(classifyToolClass('Read')).toBe('standard')
+    expect(classifyToolClass('Grep')).toBe('standard')
+    expect(classifyToolClass('Bash')).toBe('standard')
+  })
+})
+
+describe('sweepToolCallDeadlines (gateway wrapper)', () => {
+  it('observe-only: logs a breach but does NOT force-fail when enforce=false', () => {
+    const t = new ToolCallDeadlineTracker()
+    t.noteStart('tu_1', 'Read', 'standard', 0)
+    const logs: string[] = []
+    const forced: DeadlineBreach[] = []
+    const out = sweepToolCallDeadlines(t, 120_000, cfg, {
+      enforce: false,
+      log: (l) => logs.push(l),
+      onForceFail: (b) => forced.push(b),
+    })
+    expect(out).toHaveLength(1)
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toContain('[tool-deadline] breach tool=Read')
+    expect(logs[0]).toContain('enforce=false')
+    expect(forced).toEqual([])
+  })
+
+  it('enforce: force-fails each breached tool', () => {
+    const t = new ToolCallDeadlineTracker()
+    t.noteStart('tu_1', 'Read', 'standard', 0)
+    const forced: DeadlineBreach[] = []
+    sweepToolCallDeadlines(t, 120_000, cfg, {
+      enforce: true,
+      log: () => {},
+      onForceFail: (b) => forced.push(b),
+    })
+    expect(forced.map((b) => b.toolUseId)).toEqual(['tu_1'])
+  })
+})
+
+describe('observeToolUse', () => {
+  it('starts a standard deadline for an ordinary tool', () => {
+    const prev = process.env.SWITCHROOM_DISABLE_TOOL_DEADLINE
+    delete process.env.SWITCHROOM_DISABLE_TOOL_DEADLINE
+    const t = new ToolCallDeadlineTracker()
+    observeToolUse(t, 'tu_1', 'Read', undefined, 0)
+    expect(t.sweep(120_000, cfg)).toHaveLength(1)
+    if (prev !== undefined) process.env.SWITCHROOM_DISABLE_TOOL_DEADLINE = prev
+  })
+
+  it('classes a run_in_background Bash as background (excluded)', () => {
+    const t = new ToolCallDeadlineTracker()
+    observeToolUse(t, 'tu_1', 'Bash', { run_in_background: true }, 0)
+    expect(t.sweep(10_000_000, cfg)).toEqual([])
+  })
+
+  it('is a no-op when the subsystem is disabled', () => {
+    process.env.SWITCHROOM_DISABLE_TOOL_DEADLINE = '1'
+    const t = new ToolCallDeadlineTracker()
+    observeToolUse(t, 'tu_1', 'Read', undefined, 0)
+    expect(t.hasInFlight()).toBe(false)
+    delete process.env.SWITCHROOM_DISABLE_TOOL_DEADLINE
+  })
+
+  it('is a no-op for an empty toolUseId', () => {
+    const t = new ToolCallDeadlineTracker()
+    observeToolUse(t, '', 'Read', undefined, 0)
+    expect(t.hasInFlight()).toBe(false)
+  })
+})
+
+describe('config helpers', () => {
+  it('resolveDeadlineConfig reads standard from env, excludes human/background', () => {
+    const c = resolveDeadlineConfig({ SWITCHROOM_TOOL_DEADLINE_STANDARD_MS: '90000' })
+    expect(c.standardMs).toBe(90_000)
+    expect(c.humanMs).toBe(Number.POSITIVE_INFINITY)
+    expect(c.backgroundMs).toBe(Number.POSITIVE_INFINITY)
+  })
+  it('standardDeadlineMs falls back on blank / garbage / non-positive', () => {
+    expect(standardDeadlineMs({})).toBe(DEFAULT_STANDARD_DEADLINE_MS)
+    expect(standardDeadlineMs({ SWITCHROOM_TOOL_DEADLINE_STANDARD_MS: '' })).toBe(DEFAULT_STANDARD_DEADLINE_MS)
+    expect(standardDeadlineMs({ SWITCHROOM_TOOL_DEADLINE_STANDARD_MS: 'nope' })).toBe(DEFAULT_STANDARD_DEADLINE_MS)
+    expect(standardDeadlineMs({ SWITCHROOM_TOOL_DEADLINE_STANDARD_MS: '0' })).toBe(DEFAULT_STANDARD_DEADLINE_MS)
+    expect(standardDeadlineMs({ SWITCHROOM_TOOL_DEADLINE_STANDARD_MS: '-5' })).toBe(DEFAULT_STANDARD_DEADLINE_MS)
+  })
+  it('standardDeadlineMs honours a valid override', () => {
+    expect(standardDeadlineMs({ SWITCHROOM_TOOL_DEADLINE_STANDARD_MS: '90000' })).toBe(90_000)
+  })
+  it('enforcement is OPT-IN (default off)', () => {
+    expect(toolCallDeadlineEnforced({})).toBe(false)
+    expect(toolCallDeadlineEnforced({ SWITCHROOM_TOOL_DEADLINE_ENFORCE: '1' })).toBe(true)
+    expect(toolCallDeadlineEnforced({ SWITCHROOM_TOOL_DEADLINE_ENFORCE: 'true' })).toBe(true)
+  })
+  it('DEFAULT_DEADLINE_CONFIG excludes human + background by default', () => {
+    expect(DEFAULT_DEADLINE_CONFIG.standardMs).toBe(DEFAULT_STANDARD_DEADLINE_MS)
+    expect(DEFAULT_DEADLINE_CONFIG.humanMs).toBe(Number.POSITIVE_INFINITY)
+    expect(DEFAULT_DEADLINE_CONFIG.backgroundMs).toBe(Number.POSITIVE_INFINITY)
+  })
+})


### PR DESCRIPTION
## What & why

There is no working hang-watchdog for the "carrie" mode: an in-flight tool call that never returns. While any `tool_use` is open, `isLegitimatelyWorking()` returns true and the silence-poke 300s framework fallback is **deferred to its 15-min hard ceiling** — so a hung tool pins the conversation for 15 minutes before any net even considers acting, and even then the fallback only resets gateway state, never the child (why carrie needed a manual restart).

This PR is **Stage A: prevention** — a deterministic per-tool-call wall-clock deadline. It ships the mechanism with **enforcement opt-in / default-off** so blast radius is low. Stage B (progress-based restart keyed on turn-active-marker staleness) is a separate PR.

## Design

New pure module `telegram-plugin/gateway/tool-call-deadline.ts` bounds every in-flight tool with a ceiling measured from its own `startedAt`. Three classes:

| class | tools | ceiling |
|---|---|---|
| `standard` | ordinary foreground tools (Read, Grep, most MCP) | ~120s |
| `human` | `ask_user` / approval-card waits | **excluded** — owned by the existing #2724 permission-TTL sweep (`permission-ttl-sweep.ts`); a 120s clock would deny operators mid-decision |
| `background` | `Task`/`Agent`/`run_in_background` Bash | **excluded** — health judged by marker staleness (Stage B); keying a kill on "tool open N seconds" is the anti-pattern that discriminator exists to avoid |

On a breach the sweep force-fails the tool: logs the synthetic `tool_result` error and drops the masked flight entry from `ToolFlightTracker` + the silence-poke in-flight map, so `isMidToolCall` stops masking the hang and the net can act ~13 min sooner than the 15-min defer ceiling.

**Critical per-`toolUseId` guard:** after a force-fail the id is remembered in a `reaped` set; a real `tool_result` arriving *after* the synthetic error returns `false` from `noteResult` and is dropped — never double-processed.

### Honest scope note (source contradicts the naive premise)

A built-in tool executing *inside the unmodified claude process* has **no injection channel** — auto-allowed tools short-circuit in the bridge and never reach the gateway. The permission-gated waits that *do* have a channel (`dispatchPermissionVerdict`) are exactly the `human` class, already reaped by #2724. So Stage A's real production effect for a standard hang is **un-masking** the flight state to let the Stage B net act; the "synthetic tool_result injection" is realized at the module boundary (tested via the `sweepToolCallDeadlines` deps) and logged in the gateway. This is why enforcement is opt-in and the real kill lives in Stage B.

## Tests (fail on current head)

`telegram-plugin/tests/tool-call-deadline.test.ts` (26) + a `drop()` case in `interrupt-defer.test.ts`. They fail on `main` because `tool-call-deadline.ts` does not exist there. Key assertions:
- a never-returning standard tool breaches at exactly its 120s ceiling; the turn proceeds (flight cleared);
- the per-`toolUseId` guard drops a real result that arrives after the synthetic error;
- `human` + `background` classes are never force-failed on the short ceiling;
- observe-only vs enforce behaviour of the sweep wrapper.

## Safety
- Enforcement default-OFF (`SWITCHROOM_TOOL_DEADLINE_ENFORCE=1` to enable); observation-only otherwise.
- Gateway growth stays under the anti-inflation ratchet (decision+logging in the module).
- `tsc --noEmit` + full `npm run lint` clean; scoped vitest green. Full suite is CI's authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)