### PR TITLE
fix(gateway): close reworded-late-reply duplicate via subagent-handback marker

### DIFF
--- a/telegram-plugin/flushed-turn-supersede.ts
+++ b/telegram-plugin/flushed-turn-supersede.ts
@@ -201,22 +201,24 @@ export function decideSupersede(
   if (!sameTurn) {
     return { supersede: false, deleteMessageIds: [], reason: 'different-turn' }
   }
-  // #3429 content gate — but ONLY on the AMBIGUOUS owner resolution. When the
-  // caller resolved this reply's owner turn by POSITIVE attribution (a live
-  // atom, the model's own `origin_turn_id` echo, or the framework-owned quoted
-  // message id — `positiveAttribution === true`), the reply IS this turn's own
-  // answer landing late; supersede its flushed provisional draft REGARDLESS of
-  // text, so a model that RE-WORDED the answer between the narration that
+  // #3429 content gate — but ONLY when the caller is UNSURE the reply is this
+  // turn's own answer. `positiveAttribution === true` means the gateway
+  // established the reply IS this turn's OWN late answer — either by a positive
+  // owner-resolution tier (live atom / `origin_turn_id` echo / quoted message
+  // id) OR because no background `subagent_handback` could own it (none enqueued
+  // for the chat after the flushed turn ended within the supersede TTL; see
+  // outbound-send-path). Then supersede the flushed provisional draft REGARDLESS
+  // of text, so a model that RE-WORDED the answer between the narration that
   // flushed and the `reply` tool call still collapses to ONE message (the
   // duplicate-reply regression #3429 introduced on the reworded same-turn path).
   //
-  // The content gate remains for the LATEST-ENDED fallback tier
-  // (`positiveAttribution` falsey), where identity alone cannot tell the turn's
-  // own late reply from an async sub-agent handback that merely resolved this
-  // flush-delivered ended turn as its owner — there, genuinely different content
-  // is a handback and must send FRESH (both messages surface), never
-  // edit/delete the flushed answer. Legacy identity-only callers (no
-  // `replyText`) keep the pre-#3429 behaviour unchanged.
+  // The content gate remains when `positiveAttribution` is falsey — the
+  // ambiguous residual (latest-ended tier AND a handback in flight) where
+  // identity alone cannot tell the turn's own late reply from a background
+  // sub-agent handback that resolved this flush-delivered ended turn as its
+  // owner. There, genuinely different content is a handback and must send FRESH
+  // (both messages surface), never edit/delete the flushed answer. Legacy
+  // identity-only callers (no `replyText`) keep the pre-#3429 behaviour.
   if (
     !args.positiveAttribution &&
     args.replyText != null &&

--- a/telegram-plugin/flushed-turn-supersede.ts
+++ b/telegram-plugin/flushed-turn-supersede.ts
@@ -181,7 +181,13 @@ export function flushedAnswerMatchesReply(flushedText: string, replyText: string
  */
 export function decideSupersede(
   record: FlushedTurnRecord | undefined,
-  args: { liveTurnId: string | null; replyText?: string | null; now: number; ttlMs?: number },
+  args: {
+    liveTurnId: string | null
+    replyText?: string | null
+    positiveAttribution?: boolean
+    now: number
+    ttlMs?: number
+  },
 ): SupersedeDecision {
   const ttlMs = args.ttlMs ?? DEFAULT_SUPERSEDE_TTL_MS
   if (record == null) return { supersede: false, deleteMessageIds: [], reason: 'no-record' }
@@ -195,10 +201,27 @@ export function decideSupersede(
   if (!sameTurn) {
     return { supersede: false, deleteMessageIds: [], reason: 'different-turn' }
   }
-  // #3429 — same turn identity, but genuinely different content: an async
-  // handback attributed to the flush-delivered ended turn, not the turn's own
-  // answer landing late. Never edit/delete the flushed message for it.
-  if (args.replyText != null && !flushedAnswerMatchesReply(record.text, args.replyText)) {
+  // #3429 content gate — but ONLY on the AMBIGUOUS owner resolution. When the
+  // caller resolved this reply's owner turn by POSITIVE attribution (a live
+  // atom, the model's own `origin_turn_id` echo, or the framework-owned quoted
+  // message id — `positiveAttribution === true`), the reply IS this turn's own
+  // answer landing late; supersede its flushed provisional draft REGARDLESS of
+  // text, so a model that RE-WORDED the answer between the narration that
+  // flushed and the `reply` tool call still collapses to ONE message (the
+  // duplicate-reply regression #3429 introduced on the reworded same-turn path).
+  //
+  // The content gate remains for the LATEST-ENDED fallback tier
+  // (`positiveAttribution` falsey), where identity alone cannot tell the turn's
+  // own late reply from an async sub-agent handback that merely resolved this
+  // flush-delivered ended turn as its owner — there, genuinely different content
+  // is a handback and must send FRESH (both messages surface), never
+  // edit/delete the flushed answer. Legacy identity-only callers (no
+  // `replyText`) keep the pre-#3429 behaviour unchanged.
+  if (
+    !args.positiveAttribution &&
+    args.replyText != null &&
+    !flushedAnswerMatchesReply(record.text, args.replyText)
+  ) {
     return { supersede: false, deleteMessageIds: [], reason: 'new-content', recordText: record.text }
   }
   return {
@@ -326,12 +349,18 @@ export class FlushedTurnSupersedeRegistry {
   peek(
     chatId: string,
     threadId: number | undefined,
-    args: { liveTurnId: string | null; replyText?: string | null; now: number },
+    args: {
+      liveTurnId: string | null
+      replyText?: string | null
+      positiveAttribution?: boolean
+      now: number
+    },
   ): SupersedeDecision {
     const rec = this.entries.get(makeKey(chatId, threadId))?.get(turnKey(args.liveTurnId))
     return decideSupersede(rec, {
       liveTurnId: args.liveTurnId,
       replyText: args.replyText,
+      positiveAttribution: args.positiveAttribution,
       now: args.now,
       ttlMs: this.ttlMs,
     })
@@ -345,7 +374,12 @@ export class FlushedTurnSupersedeRegistry {
   take(
     chatId: string,
     threadId: number | undefined,
-    args: { liveTurnId: string | null; replyText?: string | null; now: number },
+    args: {
+      liveTurnId: string | null
+      replyText?: string | null
+      positiveAttribution?: boolean
+      now: number
+    },
   ): SupersedeDecision {
     const lane = makeKey(chatId, threadId)
     const decision = this.peek(chatId, threadId, args)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -485,6 +485,8 @@ import {
 } from '../turn-flush-safety.js'
 import {
   resolveReplyOwnerTurnId,
+  resolveReplyOwnerTier,
+  type ReplyOwnerTier,
   type AnswerDeliveredLatch,
 } from '../reply-owner-resolve.js'
 // PR A — deterministic answer-ready quiescence flush (late-delivery fix).
@@ -4009,7 +4011,7 @@ function resolveReplyOwnerTurn(
   liveTurn: CurrentTurn | null,
   chatId: string,
   args: Record<string, unknown>,
-): CurrentTurn | null {
+): { turn: CurrentTurn | null; tier: ReplyOwnerTier } {
   const origin = findTurnByOriginId(args.origin_turn_id as string | undefined)
   const quoted = findTurnByQuotedMessageId(chatId, args.reply_to)
   const latestEnded = findLatestEndedTurnForChat(chatId)
@@ -4026,15 +4028,23 @@ function resolveReplyOwnerTurn(
   // fabricate one.
   const latestEndedAgeMs =
     latestEnded?.endedAt != null ? Date.now() - latestEnded.endedAt : null
-  const winnerId = resolveReplyOwnerTurnId({
+  const candidates = {
     liveTurnId: liveTurn?.turnId ?? null,
     originTurnId: origin?.turnId ?? null,
     quotedTurnId: quoted?.turnId ?? null,
     latestEndedTurnId: latestEnded?.turnId ?? null,
     latestEndedAgeMs,
     latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
-  })
-  return winnerId != null ? (byId.get(winnerId) ?? null) : null
+  }
+  // #3429 — the WINNING tier travels with the turn. A positive tier
+  // (live/origin/quoted) means the reply is this turn's own answer and the
+  // supersede fires regardless of text; the ambiguous `latest-ended` fallback
+  // keeps the content gate (it cannot tell a late own-reply from an async
+  // sub-agent handback). Both derive from the SAME candidates, so the id and the
+  // tier can never disagree.
+  const tier = resolveReplyOwnerTier(candidates)
+  const winnerId = resolveReplyOwnerTurnId(candidates)
+  return { turn: winnerId != null ? (byId.get(winnerId) ?? null) : null, tier }
 }
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -489,6 +489,7 @@ import {
   type ReplyOwnerTier,
   type AnswerDeliveredLatch,
 } from '../reply-owner-resolve.js'
+import { SubagentHandbackMarker } from './subagent-handback-marker.js'
 // PR A — deterministic answer-ready quiescence flush (late-delivery fix).
 import {
   AnswerReadyFlushController,
@@ -3887,6 +3888,14 @@ const recentTurnsById = new Map<string, CurrentTurn>()
 // real message_id the framework stamped, never a model-asserted thread.
 // Evicted in lock-step with recentTurnsById so it can't outgrow it.
 const recentTurnIdBySourceMessageId = new Map<number, string>()
+
+// fix/backstop-duplicate-reply — per-chat marker of the most recent
+// gateway-synthesized `subagent_handback` enqueue (logic in
+// subagent-handback-marker.ts; extracted per the gateway anti-inflation ratchet).
+const subagentHandbackMarker = new SubagentHandbackMarker()
+const getLastSubagentHandbackAt = (chatId: string): number | null =>
+  subagentHandbackMarker.lastAt(chatId)
+
 function rememberRecentTurn(turn: CurrentTurn): void {
   recentTurnsById.set(turn.turnId, turn)
   if (turn.sourceMessageId != null) {
@@ -12577,6 +12586,7 @@ function gatewaySendReplyDeps(): SendReplyGatewayDeps {
     resolveAnswerThreadWithLog,
     resolveThreadId,
     getLatestInboundMessageId,
+    getLastSubagentHandbackAt,
     recordOutbound,
     emissionAuthorityFor,
     clearActivitySummary,
@@ -24469,6 +24479,9 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 // turn), so the handback always lands as a clean fresh
                 // turn and never races a turn-in-flight composer (#1556).
                 pendingInboundBuffer.push(process.env.SWITCHROOM_AGENT_NAME ?? '', decision.inbound)
+                // fix/backstop-duplicate-reply — stamp the per-chat handback
+                // marker at enqueue (see subagent-handback-marker.ts).
+                subagentHandbackMarker.record(decision.chatId, Date.now())
                 process.stderr.write(
                   `telegram gateway: subagent-handback queued agent=${agentId} outcome=${outcome} chat=${decision.chatId} resultChars=${resultText.length}\n`,
                 )

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9981,6 +9981,10 @@ const pendingInboundBuffer = createPendingInboundBuffer({
       { chat_id: chat, verb: 'inbound-buffer-eviction' },
     )
   },
+  // fix/backstop-duplicate-reply MUST-FIX 2 — stamp the handback marker at the
+  // enqueue chokepoint so a boot-replayed handback (not just the live synthesis
+  // push) populates it. Every `subagent_handback` push funnels through here.
+  onHandbackEnqueue: (chatId, ts) => subagentHandbackMarker.record(chatId, ts),
 })
 
 // PR2 obligation-ledger idle sweep. Re-present an OPEN obligation only at a
@@ -24478,10 +24482,10 @@ async function startGateway(): Promise<void> {  // #2996 P0c: the boot IIFE, now
                 // The drain only releases at an idle prompt (no active
                 // turn), so the handback always lands as a clean fresh
                 // turn and never races a turn-in-flight composer (#1556).
+                // The handback marker is stamped inside pendingInboundBuffer.push
+                // (the enqueue chokepoint) so BOTH this live synthesis push and
+                // the boot-replay re-push populate it — see MUST-FIX 2.
                 pendingInboundBuffer.push(process.env.SWITCHROOM_AGENT_NAME ?? '', decision.inbound)
-                // fix/backstop-duplicate-reply — stamp the per-chat handback
-                // marker at enqueue (see subagent-handback-marker.ts).
-                subagentHandbackMarker.record(decision.chatId, Date.now())
                 process.stderr.write(
                   `telegram gateway: subagent-handback queued agent=${agentId} outcome=${outcome} chat=${decision.chatId} resultChars=${resultText.length}\n`,
                 )

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -58,7 +58,7 @@ import {
   flushedAnswerMatchesReply,
   type FlushedTurnSupersedeRegistry,
 } from '../flushed-turn-supersede.js'
-import { decideAnswerLatchSuppression } from '../reply-owner-resolve.js'
+import { decideAnswerLatchSuppression, type ReplyOwnerTier } from '../reply-owner-resolve.js'
 import { deriveTelegraphTitle } from '../telegraph.js'
 import {
   mintVoiceOnDemandToken,
@@ -658,7 +658,7 @@ export interface SendReplyGatewayDeps {
   assertSendable(f: string): void
   statusKey(chatId: string, threadId?: number | null): string
   streamKey(chatId: string, threadId?: number | null): string
-  resolveReplyOwnerTurn(liveTurn: CurrentTurn | null, chatId: string, args: Record<string, unknown>): CurrentTurn | null
+  resolveReplyOwnerTurn(liveTurn: CurrentTurn | null, chatId: string, args: Record<string, unknown>): { turn: CurrentTurn | null; tier: ReplyOwnerTier }
   findTurnByOriginId(originTurnId: string | null | undefined): CurrentTurn | null
   findTurnByQuotedMessageId(chatId: string, replyTo: unknown): CurrentTurn | null
   resolveAnswerThreadWithLog(
@@ -874,7 +874,7 @@ export async function sendReply(
     // double-send). The quoted / latest-ended recoveries are precisely what the
     // router already did for the same reply, so unifying here makes the two
     // resolvers agree and the late-reply supersede fires by identity.
-    const ownerTurn = resolveReplyOwnerTurn(turn, chat_id, args)
+    const { turn: ownerTurn, tier: ownerTier } = resolveReplyOwnerTurn(turn, chat_id, args)
     const resolvedTurnId = ownerTurn?.turnId ?? null
     // #3429 — pass the (normalized) reply text so the registry can apply the
     // new-content gate: identity match + TTL alone also fits an async handback
@@ -882,10 +882,20 @@ export async function sendReply(
     // the latest-ended tier. Editing the flushed message in place with that
     // handback's text does not re-notify client-side (Telegram edits never
     // push) — the observed silent non-surfacing of msgs 10482/10486.
+    //
+    // But the content gate must NOT fire when the owner turn was resolved by
+    // POSITIVE attribution (live / origin-echo / quoted): there the reply is
+    // this turn's OWN answer landing late, so it supersedes its flushed
+    // provisional draft REGARDLESS of a model rewording between the narration
+    // that flushed and the `reply` tool call — collapsing the reworded
+    // same-turn duplicate (#3429 regression) to one message. The content gate
+    // stays for the ambiguous `latest-ended` fallback tier, which cannot
+    // distinguish the turn's own late reply from an async sub-agent handback.
+    const positiveAttribution = ownerTier !== 'latest-ended'
     const decision = flushedTurnSupersede.take(
       chat_id,
       replyThreadId,
-      { liveTurnId: resolvedTurnId, replyText: text, now: Date.now() },
+      { liveTurnId: resolvedTurnId, replyText: text, positiveAttribution, now: Date.now() },
     )
     if (decision.supersede) {
       process.stderr.write(

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -56,6 +56,7 @@ import { decideSilentReplyAnchor } from '../silent-reply-anchor.js'
 import {
   decideSupersedeCorrection,
   flushedAnswerMatchesReply,
+  DEFAULT_SUPERSEDE_TTL_MS,
   type FlushedTurnSupersedeRegistry,
 } from '../flushed-turn-supersede.js'
 import { decideAnswerLatchSuppression, type ReplyOwnerTier } from '../reply-owner-resolve.js'
@@ -671,6 +672,7 @@ export interface SendReplyGatewayDeps {
   ): number | undefined
   resolveThreadId(chatId: string, explicit?: string | number | null): number | undefined
   getLatestInboundMessageId(chatId: string, threadId: number | null): number | null | undefined
+  getLastSubagentHandbackAt(chatId: string): number | null
   recordOutbound(rec: {
     chat_id: string
     thread_id: number | null
@@ -735,7 +737,7 @@ export async function sendReply(
     statusKey, streamKey,
     resolveReplyOwnerTurn, findTurnByOriginId, findTurnByQuotedMessageId,
     resolveAnswerThreadWithLog, resolveThreadId,
-    getLatestInboundMessageId, recordOutbound,
+    getLatestInboundMessageId, getLastSubagentHandbackAt, recordOutbound,
     emissionAuthorityFor, clearActivitySummary,
     startTypingLoop, stopTypingLoop, logOutbound,
     closeObligationOnSubstantiveReply, finalizeStatusReaction,
@@ -876,26 +878,49 @@ export async function sendReply(
     // resolvers agree and the late-reply supersede fires by identity.
     const { turn: ownerTurn, tier: ownerTier } = resolveReplyOwnerTurn(turn, chat_id, args)
     const resolvedTurnId = ownerTurn?.turnId ?? null
-    // #3429 — pass the (normalized) reply text so the registry can apply the
-    // new-content gate: identity match + TTL alone also fits an async handback
-    // that merely resolved this flush-delivered ENDED turn as its owner via
-    // the latest-ended tier. Editing the flushed message in place with that
-    // handback's text does not re-notify client-side (Telegram edits never
-    // push) — the observed silent non-surfacing of msgs 10482/10486.
+    // #3429 — pass the (normalized) reply text so the registry CAN apply the
+    // new-content gate: identity match + TTL alone also fits a background
+    // sub-agent handback that merely resolved this flush-delivered ENDED turn as
+    // its owner via the latest-ended tier. Editing/deleting the flushed message
+    // for that handback's unrelated text is the #3429 silent client-side drop
+    // (msgs 10482/10486). But that gate ALSO declines the turn's OWN reworded
+    // late reply (model narrated → flushed → fired `reply` with a paraphrase),
+    // which is the dominant real duplicate (agent:marko 2026-07-20: 11/11
+    // declines were own-replies, turns #1177/#1182/#1201 double-sent). So we
+    // BYPASS the content gate whenever the reply is confidently the flushed
+    // turn's OWN answer, established by EITHER of two deterministic signals:
     //
-    // But the content gate must NOT fire when the owner turn was resolved by
-    // POSITIVE attribution (live / origin-echo / quoted): there the reply is
-    // this turn's OWN answer landing late, so it supersedes its flushed
-    // provisional draft REGARDLESS of a model rewording between the narration
-    // that flushed and the `reply` tool call — collapsing the reworded
-    // same-turn duplicate (#3429 regression) to one message. The content gate
-    // stays for the ambiguous `latest-ended` fallback tier, which cannot
-    // distinguish the turn's own late reply from an async sub-agent handback.
+    //   (a) POSITIVE owner-resolution tier (live / origin-echo / quoted) — the
+    //       reply is provably attributed to this turn (chiefly the supergroup
+    //       explicit-quote / echo path); OR
+    //   (b) NO background sub-agent handback could own it — the gateway records
+    //       when it synthesizes a `subagent_handback` inbound per chat, and NONE
+    //       was enqueued for this chat AFTER the flushed turn ended within the
+    //       supersede TTL. This is the signal that closes the DM default-reply
+    //       duplicate, where every own-reply resolves via the latest-ended tier
+    //       (no live/origin/quote) and (a) never fires.
+    //
+    // The content gate is kept ONLY for the residual ambiguous case: latest-ended
+    // tier AND a handback WAS enqueued in the window — there the late reply might
+    // BE that handback, so genuinely-new content must send fresh (two messages,
+    // #3429 preserved). Concurrency note: a case-A own reply that happens to
+    // coincide with an unrelated background handback completing in the same ≤TTL
+    // window falls into this residual and degrades to today's behaviour (two
+    // messages) — safe (never a silent drop/edit), just not collapsed.
     const positiveAttribution = ownerTier !== 'latest-ended'
+    const ownerEndedAt = ownerTurn?.endedAt ?? null
+    const handbackAt = getLastSubagentHandbackAt(chat_id)
+    const now = Date.now()
+    const handbackCouldOwnReply =
+      handbackAt != null &&
+      ownerEndedAt != null &&
+      handbackAt > ownerEndedAt &&
+      now - handbackAt <= DEFAULT_SUPERSEDE_TTL_MS
+    const replyIsOwnAnswer = positiveAttribution || !handbackCouldOwnReply
     const decision = flushedTurnSupersede.take(
       chat_id,
       replyThreadId,
-      { liveTurnId: resolvedTurnId, replyText: text, positiveAttribution, now: Date.now() },
+      { liveTurnId: resolvedTurnId, replyText: text, positiveAttribution: replyIsOwnAnswer, now },
     )
     if (decision.supersede) {
       process.stderr.write(

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -887,27 +887,32 @@ export async function sendReply(
     // late reply (model narrated → flushed → fired `reply` with a paraphrase),
     // which is the dominant real duplicate (agent:marko 2026-07-20: 11/11
     // declines were own-replies, turns #1177/#1182/#1201 double-sent). So we
-    // BYPASS the content gate whenever the reply is confidently the flushed
-    // turn's OWN answer, established by EITHER of two deterministic signals:
+    // BYPASS the content gate ONLY when the reply is confidently the flushed
+    // turn's OWN answer. The primary, deterministic signal is the absence of a
+    // background sub-agent handback that could own this reply: the gateway
+    // records when it synthesizes a `subagent_handback` inbound per chat, and if
+    // NONE was enqueued for this chat AFTER the flushed turn ended within the
+    // supersede TTL, the reply is that turn's own answer → supersede regardless
+    // of a model rewording (closes the DM default-reply duplicate, where every
+    // own-reply resolves via the latest-ended tier).
     //
-    //   (a) POSITIVE owner-resolution tier (live / origin-echo / quoted) — the
-    //       reply is provably attributed to this turn (chiefly the supergroup
-    //       explicit-quote / echo path); OR
-    //   (b) NO background sub-agent handback could own it — the gateway records
-    //       when it synthesizes a `subagent_handback` inbound per chat, and NONE
-    //       was enqueued for this chat AFTER the flushed turn ended within the
-    //       supersede TTL. This is the signal that closes the DM default-reply
-    //       duplicate, where every own-reply resolves via the latest-ended tier
-    //       (no live/origin/quote) and (a) never fires.
+    // MUST-FIX 1 (silent-data-loss): the owner-resolution `quoted` / `origin`
+    // tiers are derived from MODEL-SUPPLIED args (`args.reply_to` /
+    // `args.origin_turn_id`), so a background handback turn can STEER them —
+    // pass `reply_to = <the user's original msg id>` and it resolves the PRIOR
+    // flushed turn via `quoted`, which used to force the bypass and silently
+    // edit-over that turn's delivered answer (#3429-class, model-steerable). So
+    // a positive tier NEVER overrides an in-window handback; only the
+    // FRAMEWORK-owned `live` tier (the live `currentTurn`, not model-derived,
+    // and structurally unable to collide with an ended turn's flush record —
+    // `decideSupersede` requires same turnId) may bypass a handback window.
     //
-    // The content gate is kept ONLY for the residual ambiguous case: latest-ended
-    // tier AND a handback WAS enqueued in the window — there the late reply might
-    // BE that handback, so genuinely-new content must send fresh (two messages,
-    // #3429 preserved). Concurrency note: a case-A own reply that happens to
-    // coincide with an unrelated background handback completing in the same ≤TTL
-    // window falls into this residual and degrades to today's behaviour (two
-    // messages) — safe (never a silent drop/edit), just not collapsed.
-    const positiveAttribution = ownerTier !== 'latest-ended'
+    // The content gate is therefore kept whenever a handback WAS enqueued in the
+    // window (any non-live tier): the late reply might BE that handback, so
+    // genuinely-new content sends fresh (two messages, #3429 preserved).
+    // Concurrency note: a case-A own reply coinciding with an unrelated
+    // background handback in the same ≤TTL window degrades to today's behaviour
+    // (two messages) — safe (never a silent drop/edit), just not collapsed.
     const ownerEndedAt = ownerTurn?.endedAt ?? null
     const handbackAt = getLastSubagentHandbackAt(chat_id)
     const now = Date.now()
@@ -916,7 +921,7 @@ export async function sendReply(
       ownerEndedAt != null &&
       handbackAt > ownerEndedAt &&
       now - handbackAt <= DEFAULT_SUPERSEDE_TTL_MS
-    const replyIsOwnAnswer = positiveAttribution || !handbackCouldOwnReply
+    const replyIsOwnAnswer = ownerTier === 'live' || !handbackCouldOwnReply
     const decision = flushedTurnSupersede.take(
       chat_id,
       replyThreadId,

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -79,6 +79,16 @@ export interface PendingInboundBufferOptions {
    * never breaks the push hot path.
    */
   onEvict?: (agent: string, evicted: InboundMessage) => void
+  /**
+   * fix/backstop-duplicate-reply MUST-FIX 2 — called on every push of a
+   * `subagent_handback` envelope (live synthesis AND boot-replay re-push),
+   * carrying the envelope's `chatId` and its own `ts` (ms). The gateway wires
+   * this to the per-chat subagent-handback marker so the supersede path can tell
+   * a flushed turn's own late reply from a background handback attributed to it
+   * — INCLUDING after a restart, where the only handback push is the replay.
+   * Best-effort: a throw here never breaks the push hot path.
+   */
+  onHandbackEnqueue?: (chatId: string, ts: number) => void
 }
 
 /**
@@ -342,6 +352,23 @@ export function createPendingInboundBuffer(
         }
       }
       q.push(msg)
+      // fix/backstop-duplicate-reply MUST-FIX 2 — stamp the subagent-handback
+      // marker at THIS chokepoint, not at the live onFinish enqueue site alone.
+      // Every handback enqueue funnels through here — the live synthesis push
+      // AND the boot-replay re-push of un-acked spooled inbounds — so stamping
+      // here (rather than only at the live site) means a handback replayed after
+      // a restart still populates the marker. Otherwise the Map is empty
+      // post-boot and a replayed handback's late reply bypasses the #3429
+      // content gate → silent edit-over-answer. Uses the envelope's own `ts`
+      // (ms, `Date.now()`-derived at synthesis) so the marker reflects when the
+      // handback actually happened, not the replay moment. Best-effort.
+      if (msg.meta?.source === 'subagent_handback' && opts.onHandbackEnqueue != null) {
+        try {
+          opts.onHandbackEnqueue(msg.chatId, msg.ts)
+        } catch {
+          /* marker stamp is best-effort; never break the push hot path */
+        }
+      }
       // Durable record FIRST-class to the in-memory queue: spool BEFORE
       // returning, regardless of the cap eviction above — an entry the
       // in-memory cap drops still survives in the spool (boot-replayed /

--- a/telegram-plugin/gateway/subagent-handback-marker.ts
+++ b/telegram-plugin/gateway/subagent-handback-marker.ts
@@ -1,0 +1,42 @@
+/**
+ * Per-chat marker of the most recent gateway-synthesized `subagent_handback`
+ * enqueue (fix/backstop-duplicate-reply).
+ *
+ * A BACKGROUND sub-agent completion is a GATEWAY-SYNTHESIZED event, not model
+ * output: when a background worker terminates the gateway wakes the agent with a
+ * `subagent_handback` inbound. Recording WHEN one was enqueued, per chat, is the
+ * ONE deterministic signal that distinguishes the two late-reply cases that both
+ * resolve a flush-delivered ENDED turn via the latest-ended tier — the case the
+ * owner-resolution tier alone cannot separate (a DM late reply has no
+ * live/origin/quoted attribution, so both land on latest-ended):
+ *
+ *   - CASE A — the flushed turn's OWN reworded reply landing late. NO
+ *     `subagent_handback` was enqueued for this chat after the turn ended, so the
+ *     reply is that turn's own answer → the supersede path collapses the
+ *     provisional flush REGARDLESS of the model's rewording (closes the #3429
+ *     reworded-duplicate regression: agent:marko 2026-07-20, turns
+ *     #1177/#1182/#1201 double-sent).
+ *   - CASE B — a background handback attributed to that ended turn. A
+ *     `subagent_handback` WAS enqueued after the turn ended and within the
+ *     supersede TTL, so the late reply might BE it → keep the #3429 content gate
+ *     and send fresh (two messages), never silently edit/delete the flushed
+ *     answer.
+ *
+ * One entry per chat (overwritten on each enqueue), so bounded by chat count. No
+ * clock reads beyond the caller-supplied `now`; the gateway wires the actual
+ * enqueue site and the supersede-path read. Deterministic — keyed on a
+ * gateway-emitted event, never on model discipline (Ken's controls-in-code rule).
+ */
+export class SubagentHandbackMarker {
+  private readonly lastAtByChat = new Map<string, number>()
+
+  /** Record that a `subagent_handback` was enqueued for `chatId` at `now` (ms). */
+  record(chatId: string, now: number): void {
+    this.lastAtByChat.set(chatId, now)
+  }
+
+  /** Wall-clock ms of the most recent handback enqueue for `chatId`, or null. */
+  lastAt(chatId: string): number | null {
+    return this.lastAtByChat.get(chatId) ?? null
+  }
+}

--- a/telegram-plugin/reply-owner-resolve.ts
+++ b/telegram-plugin/reply-owner-resolve.ts
@@ -85,6 +85,37 @@ function latestEndedAccepted(candidates: ReplyOwnerCandidates): boolean {
 }
 
 /**
+ * Which precedence tier resolved a reply's owner turn.
+ *
+ *   - `'live'` / `'origin'` / `'quoted'` are POSITIVE attributions: the reply
+ *     is tied to a specific turn by a live atom, the model's own echo, or the
+ *     framework-owned quoted message id — it IS that turn's answer.
+ *   - `'latest-ended'` is the ambiguous FALLBACK: no positive link exists, so
+ *     the reply is merely attributed to the chat's most-recently-ended turn.
+ *     This tier cannot tell the turn's OWN late reply from an async sub-agent
+ *     handback that has no live turn and no quote linkage — both land here with
+ *     the same resolved turnId (#3429). The supersede content gate
+ *     (`flushedAnswerMatchesReply`) is therefore applied ONLY on this tier.
+ *   - `'none'` — every lookup missed (a genuinely unattributable reply).
+ */
+export type ReplyOwnerTier = 'live' | 'origin' | 'quoted' | 'latest-ended' | 'none'
+
+/**
+ * The tier that WINS owner resolution for these candidates — the single source
+ * of the precedence order, consumed by both `resolveReplyOwnerTurnId` (which id)
+ * and the gateway (which discrimination the supersede applies). Same precedence,
+ * first non-null wins; the destructive latest-ended tier is honoured only when
+ * fresh (`latestEndedAccepted`).
+ */
+export function resolveReplyOwnerTier(candidates: ReplyOwnerCandidates): ReplyOwnerTier {
+  if (candidates.liveTurnId != null) return 'live'
+  if (candidates.originTurnId != null) return 'origin'
+  if (candidates.quotedTurnId != null) return 'quoted'
+  if (latestEndedAccepted(candidates)) return 'latest-ended'
+  return 'none'
+}
+
+/**
  * Resolve the turnId that OWNS a landing reply, using the SAME full chain the
  * thread-router uses. Precedence, first non-null wins:
  *
@@ -98,13 +129,18 @@ function latestEndedAccepted(candidates: ReplyOwnerCandidates): boolean {
  * to delete any turnId-bearing flush record.
  */
 export function resolveReplyOwnerTurnId(candidates: ReplyOwnerCandidates): string | null {
-  return (
-    candidates.liveTurnId ??
-    candidates.originTurnId ??
-    candidates.quotedTurnId ??
-    (latestEndedAccepted(candidates) ? candidates.latestEndedTurnId : null) ??
-    null
-  )
+  switch (resolveReplyOwnerTier(candidates)) {
+    case 'live':
+      return candidates.liveTurnId
+    case 'origin':
+      return candidates.originTurnId
+    case 'quoted':
+      return candidates.quotedTurnId
+    case 'latest-ended':
+      return candidates.latestEndedTurnId
+    case 'none':
+      return null
+  }
 }
 
 /**

--- a/telegram-plugin/tests/flushed-turn-supersede.test.ts
+++ b/telegram-plugin/tests/flushed-turn-supersede.test.ts
@@ -381,3 +381,92 @@ describe('#3429 — decideSupersede new-content gate', () => {
     expect(reg.peek('chat9', undefined, { liveTurnId: 'turn-F', now: now + 21_000 }).reason).toBe('no-record')
   })
 })
+
+/**
+ * The tier discriminator (fix/backstop-duplicate-reply). `positiveAttribution`
+ * lets the gateway bypass the #3429 content gate when the reply's owner turn was
+ * resolved by POSITIVE attribution (live / origin echo / quoted) rather than the
+ * ambiguous latest-ended fallback. On a positive tier a genuinely-DIFFERENT
+ * (reworded) reply for the same turn still supersedes — closing the reworded
+ * same-turn duplicate — while the latest-ended path keeps the content gate so a
+ * true async handback still sends fresh.
+ */
+describe('positiveAttribution — tier-gated content check', () => {
+  const FLUSHED = 'Narration first.\n\nHere is the finished summary of the incident you asked about.'
+  const REWORDED =
+    'So, to wrap up: the incident boiled down to a stale cache entry, and it is fully resolved now.'
+
+  it('positiveAttribution=true: same turn + DIFFERENT (reworded) content STILL supersedes', () => {
+    // Guard: the reworded text is genuinely new vs the flushed blob (would be
+    // declined new-content without the tier bypass).
+    expect(flushedAnswerMatchesReply(FLUSHED, REWORDED)).toBe(false)
+
+    const d = decideSupersede(rec({ text: FLUSHED }), {
+      liveTurnId: 'turn-A',
+      replyText: REWORDED,
+      positiveAttribution: true,
+      now: 1_000_010,
+    })
+    expect(d.supersede).toBe(true)
+    expect(d.reason).toBe('supersede')
+    expect(d.deleteMessageIds).toEqual([101, 102])
+  })
+
+  it('positiveAttribution=false (latest-ended): the SAME reworded content declines as new-content', () => {
+    const d = decideSupersede(rec({ text: FLUSHED }), {
+      liveTurnId: 'turn-A',
+      replyText: REWORDED,
+      positiveAttribution: false,
+      now: 1_000_010,
+    })
+    expect(d.supersede).toBe(false)
+    expect(d.reason).toBe('new-content')
+  })
+
+  it('positiveAttribution=true still requires turn IDENTITY (different turn never supersedes)', () => {
+    const d = decideSupersede(rec({ turnId: 'turn-A', text: FLUSHED }), {
+      liveTurnId: 'turn-B',
+      replyText: REWORDED,
+      positiveAttribution: true,
+      now: 1_000_010,
+    })
+    expect(d.supersede).toBe(false)
+    expect(d.reason).toBe('different-turn')
+  })
+
+  it('positiveAttribution=true still respects the TTL (expired record never supersedes)', () => {
+    const d = decideSupersede(rec({ text: FLUSHED }), {
+      liveTurnId: 'turn-A',
+      replyText: REWORDED,
+      positiveAttribution: true,
+      now: 1_000_000 + DEFAULT_SUPERSEDE_TTL_MS + 1,
+    })
+    expect(d.supersede).toBe(false)
+    expect(d.reason).toBe('expired')
+  })
+
+  it('registry take() threads positiveAttribution through to the decision', () => {
+    const reg = new FlushedTurnSupersedeRegistry()
+    const now = 1_000_000
+    reg.record('chatT', undefined, { turnId: 'turn-Q', messageIds: [8001], text: FLUSHED }, now)
+
+    // latest-ended (positiveAttribution falsey): reworded → new-content, kept.
+    const ambiguous = reg.peek('chatT', undefined, {
+      liveTurnId: 'turn-Q',
+      replyText: REWORDED,
+      now: now + 5_000,
+    })
+    expect(ambiguous.reason).toBe('new-content')
+
+    // positive tier: same reworded reply supersedes and consumes the record.
+    const positive = reg.take('chatT', undefined, {
+      liveTurnId: 'turn-Q',
+      replyText: REWORDED,
+      positiveAttribution: true,
+      now: now + 6_000,
+    })
+    expect(positive.supersede).toBe(true)
+    expect(positive.deleteMessageIds).toEqual([8001])
+    expect(reg.peek('chatT', undefined, { liveTurnId: 'turn-Q', now: now + 7_000 }).reason).toBe('no-record')
+  })
+})

--- a/telegram-plugin/tests/narrative-lane-golden.test.ts
+++ b/telegram-plugin/tests/narrative-lane-golden.test.ts
@@ -371,7 +371,7 @@ function makeSendReplyDeps(dedup: OutboundDedupCache) {
     assertSendable: () => {},
     statusKey: key,
     streamKey: key,
-    resolveReplyOwnerTurn: () => null,
+    resolveReplyOwnerTurn: () => ({ turn: null, tier: 'none' as const }),
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
     resolveAnswerThreadWithLog: (_c: string, explicit: number | undefined) => explicit,

--- a/telegram-plugin/tests/narrative-lane-golden.test.ts
+++ b/telegram-plugin/tests/narrative-lane-golden.test.ts
@@ -372,6 +372,7 @@ function makeSendReplyDeps(dedup: OutboundDedupCache) {
     statusKey: key,
     streamKey: key,
     resolveReplyOwnerTurn: () => ({ turn: null, tier: 'none' as const }),
+    getLastSubagentHandbackAt: () => null,
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
     resolveAnswerThreadWithLog: (_c: string, explicit: number | undefined) => explicit,

--- a/telegram-plugin/tests/reply-owner-resolve.test.ts
+++ b/telegram-plugin/tests/reply-owner-resolve.test.ts
@@ -32,6 +32,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   resolveReplyOwnerTurnId,
+  resolveReplyOwnerTier,
   decideAnswerLatchSuppression,
   type ReplyOwnerCandidates,
   type AnswerDeliveredLatch,
@@ -609,5 +610,78 @@ describe('#3429 — flush-armed latch with content evidence', () => {
     expect(
       decideAnswerLatchSuppression({ ...base, ownerAnswerDelivered: false, replyMatchesFlushedAnswer: true }),
     ).toBe(false)
+  })
+})
+
+/**
+ * `resolveReplyOwnerTier` (fix/backstop-duplicate-reply) exposes WHICH precedence
+ * tier won, so the gateway can apply the #3429 content gate ONLY on the ambiguous
+ * `latest-ended` fallback. It shares one precedence with `resolveReplyOwnerTurnId`
+ * (asserted equivalent below), so the winning id and the winning tier can never
+ * disagree.
+ */
+describe('resolveReplyOwnerTier — precedence + latest-ended TTL bound', () => {
+  const base: ReplyOwnerCandidates = {
+    liveTurnId: null,
+    originTurnId: null,
+    quotedTurnId: null,
+    latestEndedTurnId: null,
+  }
+
+  it('live wins over every lower tier', () => {
+    expect(
+      resolveReplyOwnerTier({ ...base, liveTurnId: 'L', originTurnId: 'O', quotedTurnId: 'Q', latestEndedTurnId: 'E' }),
+    ).toBe('live')
+  })
+
+  it('origin wins when no live turn', () => {
+    expect(resolveReplyOwnerTier({ ...base, originTurnId: 'O', quotedTurnId: 'Q', latestEndedTurnId: 'E' })).toBe('origin')
+  })
+
+  it('quoted wins when no live/origin turn (the positive DM recovery tier)', () => {
+    expect(resolveReplyOwnerTier({ ...base, quotedTurnId: 'Q', latestEndedTurnId: 'E' })).toBe('quoted')
+  })
+
+  it('latest-ended is the ambiguous FALLBACK when only it resolves', () => {
+    expect(resolveReplyOwnerTier({ ...base, latestEndedTurnId: 'E' })).toBe('latest-ended')
+  })
+
+  it('none when every lookup missed', () => {
+    expect(resolveReplyOwnerTier(base)).toBe('none')
+  })
+
+  it('a STALE latest-ended (age > TTL) is NOT accepted → none, never latest-ended', () => {
+    const stale: ReplyOwnerCandidates = {
+      ...base,
+      latestEndedTurnId: 'E',
+      latestEndedAgeMs: DEFAULT_SUPERSEDE_TTL_MS + 1,
+      latestEndedTtlMs: DEFAULT_SUPERSEDE_TTL_MS,
+    }
+    expect(resolveReplyOwnerTier(stale)).toBe('none')
+    // And the id resolver agrees (no destructive authority granted to a stale turn).
+    expect(resolveReplyOwnerTurnId(stale)).toBe(null)
+  })
+
+  it('tier and id resolver share one precedence for every candidate shape', () => {
+    const shapes: ReplyOwnerCandidates[] = [
+      base,
+      { ...base, liveTurnId: 'L', quotedTurnId: 'Q', latestEndedTurnId: 'E' },
+      { ...base, originTurnId: 'O', latestEndedTurnId: 'E' },
+      { ...base, quotedTurnId: 'Q' },
+      { ...base, latestEndedTurnId: 'E' },
+    ]
+    const idForTier = (s: ReplyOwnerCandidates): string | null => {
+      switch (resolveReplyOwnerTier(s)) {
+        case 'live': return s.liveTurnId
+        case 'origin': return s.originTurnId
+        case 'quoted': return s.quotedTurnId
+        case 'latest-ended': return s.latestEndedTurnId
+        case 'none': return null
+      }
+    }
+    for (const s of shapes) {
+      // The id the winning tier points at equals what the id resolver returns.
+      expect(resolveReplyOwnerTurnId(s)).toBe(idForTier(s))
+    }
   })
 })

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -46,6 +46,8 @@ import {
 } from '../gateway/outbound-send-path.js'
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
+import { SubagentHandbackMarker } from '../gateway/subagent-handback-marker.js'
+import { createPendingInboundBuffer } from '../gateway/pending-inbound-buffer.js'
 import { redact } from '../secret-detect/redact.js'
 import type { CurrentTurn, Access } from '../gateway/gateway.js'
 
@@ -824,23 +826,115 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     ).toBe(true)
   })
 
-  it('SECONDARY (tier path): a reworded reply POSITIVELY attributed (quoted tier) ' +
-    'supersedes regardless of text EVEN with a handback in flight (positive tier wins)', async () => {
+  it('MUST-FIX 1 (silent-data-loss): a handback reply model-STEERED to the quoted ' +
+    'tier (reply_to = the flushed turn\'s source msg) must NOT edit/delete the flushed ' +
+    'answer while a handback is in flight — sends FRESH (two messages)', async () => {
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
     seedRecord(h, owner)
-    // Positive attribution (supergroup explicit-quote/echo path): the reply is
-    // provably this turn's own answer, so a coincident background handback does
-    // NOT downgrade it — the tier signal alone bypasses the content gate.
+    // The `quoted` tier is derived from the MODEL-SUPPLIED `args.reply_to`, so a
+    // background handback turn can point reply_to at the user's original message
+    // (which the prior turn's flush is recorded against) to resolve THAT turn via
+    // `quoted`. A handback IS in flight, so a positive tier must NOT override the
+    // #3429 content gate — else the reworded handback text silently edits over
+    // the flushed turn's DELIVERED answer (Telegram edits don't re-notify).
     h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'quoted' })
     h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
 
     const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
 
+    // Fresh notifying send; the flushed answer is NEITHER edited nor deleted.
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.message_id).not.toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+    // Flush record NOT consumed — the flushed answer stands.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        replyText: CANONICAL_REPLY,
+        now: Date.now(),
+      }).supersede,
+    ).toBe(true)
+  })
+
+  it('the framework-owned `live` tier MAY still bypass a handback window (a live ' +
+    'currentTurn is not model-derived and cannot collide with an ended turn\'s record)', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'live' })
+    h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
+
+    const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
+
+    // Live tier bypasses → supersede via edit-in-place (one message).
     const edits = h.calls.filter((c) => c.method === 'editMessageText')
     expect(edits).toHaveLength(1)
     expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
     expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
     expect(res.content[0]!.text).toMatch(/^sent/)
+  })
+
+  it('MUST-FIX 2 (boot-replay): a handback re-pushed through the buffer chokepoint ' +
+    'stamps the marker (with the envelope ts) → gate preserved → FRESH send, no silent edit', async () => {
+    // Real marker + real buffer wired exactly as the gateway wires them. The
+    // boot-replay loop re-pushes un-acked spooled inbounds — including handback
+    // envelopes — through this SAME push(); the chokepoint stamp is what makes a
+    // replayed handback populate the (post-restart empty) marker.
+    const marker = new SubagentHandbackMarker()
+    const buffer = createPendingInboundBuffer({
+      log: () => {},
+      onHandbackEnqueue: (chatId, ts) => marker.record(chatId, ts),
+    })
+
+    // Simulate the boot-replay re-push of an un-acked spooled handback envelope.
+    // The envelope carries its own ms `ts` (after the flushed turn ended, within
+    // TTL) — owner.endedAt below is now-30s, this handback is now-15s.
+    const handbackTs = Date.now() - 15_000
+    buffer.push('marko', {
+      type: 'inbound',
+      chatId: CHAT,
+      messageId: handbackTs,
+      user: 'subagent-watcher',
+      userId: 0,
+      ts: handbackTs,
+      text: 'handback result',
+      meta: { source: 'subagent_handback' },
+    })
+    // The chokepoint stamped the marker from the replay push (pre-fix: empty).
+    expect(marker.lastAt(CHAT)).toBe(handbackTs)
+
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    // The gateway reads the marker the boot-replay stamped.
+    h.deps.getLastSubagentHandbackAt = (chatId) => marker.lastAt(chatId)
+
+    const res = await sendReply(h.deps, req(HANDBACK))
+
+    // Gate preserved → the replayed handback delivers FRESH; the post-boot
+    // flushed answer is NEITHER edited nor deleted (no silent #3429 on restart).
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+  })
+
+  it('the buffer chokepoint stamps ONLY handback envelopes (a normal inbound does not)', () => {
+    const marker = new SubagentHandbackMarker()
+    const buffer = createPendingInboundBuffer({
+      log: () => {},
+      onHandbackEnqueue: (chatId, ts) => marker.record(chatId, ts),
+    })
+    buffer.push('marko', {
+      type: 'inbound', chatId: CHAT, messageId: 5, user: 'ken', userId: 1,
+      ts: Date.now(), text: 'hi', meta: {},
+    })
+    expect(marker.lastAt(CHAT)).toBe(null)
   })
 })

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -210,6 +210,7 @@ function makeHarness(opts?: {
     statusKey: key,
     streamKey: key,
     resolveReplyOwnerTurn: () => ({ turn: null, tier: 'none' as const }),
+    getLastSubagentHandbackAt: () => null,
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
     resolveAnswerThreadWithLog: (_c, explicit) => explicit,
@@ -645,6 +646,11 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
     seedFlushRecord(h, owner)
+    // A background sub-agent handback WAS enqueued for this chat after the
+    // flushed turn ended and within the supersede TTL — so this late reply might
+    // BE that handback. The marker keeps the #3429 content gate. (owner.endedAt
+    // = now-30s; handback at now-15s is after it and within the 60s TTL.)
+    h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
 
     // The handback lands LATE: req.turn = null (no live gateway turn — a
     // sub-agent completion is not a new inbound).
@@ -726,47 +732,60 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     expect(res.content[0]!.text).toContain('deduped')
   })
 
-  // The tier discriminator (fix/backstop-duplicate-reply). A model that narrates
-  // its answer as prose (flushed as message A) then fires the `reply` tool with a
-  // genuinely RE-WORDED version of the same answer is the dominant real-world
-  // duplicate (agent:marko 39/54 flushes on 2026-07-20; turns #1177/#1182/#1201
-  // double-sent). The reworded reply is NOT contained in the flushed blob, so
-  // the #3429 content gate alone declines the supersede → fresh second bubble =
-  // the visible duplicate. The fix: when the owner turn was resolved by POSITIVE
-  // attribution (live / origin echo / quoted message id — NOT the ambiguous
-  // latest-ended fallback), the reply IS this turn's own answer and supersedes
-  // its flushed provisional draft REGARDLESS of the rewording. A genuine handback
-  // (latest-ended tier) with the same divergent content must still send fresh.
+  // ─── The REAL marko DM incident (fix/backstop-duplicate-reply) ───
+  //
+  // The dominant real duplicate: the model narrates its answer as prose (flushed
+  // as message A), then fires the `reply` tool with a RE-WORDED version of the
+  // same answer. On a DM this late reply has NO live turn, NO `origin_turn_id`
+  // echo, and NO explicit `reply_to`, so it resolves its owner via the ambiguous
+  // `latest-ended` tier — the #3429 content gate then declines (reworded text ⊄
+  // flushed blob) and a fresh SECOND bubble ships = the visible duplicate
+  // (agent:marko 2026-07-20: turns #1177/#1182/#1201 double-sent; 11/11 declines
+  // were own-replies with NO handback in flight).
+  //
+  // The two cases are indistinguishable by tier (both latest-ended) and by
+  // content (rewording). The deterministic discriminator is the gateway-
+  // synthesized `subagent_handback` marker: case A has NONE enqueued after the
+  // flushed turn ended; a genuine background handback (case B) does. These two
+  // tests drive the REAL send path with the REAL supersede registry over the
+  // SAME reworded text and the SAME latest-ended tier, differing ONLY in the
+  // handback marker — proving it is the marker that flips the outcome.
   const REWORDED_SAME_TURN_ANSWER =
     'Good news on the fleet: every one of the twelve agents is running fine right now. ' +
     'The gateway, the vault broker and the approval kernel are all green, and nothing has ' +
     'restarted in the past day — so there is nothing you need to do.'
 
-  it('CASE A (dup regression): a RE-WORDED reply resolved by a POSITIVE tier (quoted) ' +
-    'supersedes the flushed draft — collapses to ONE message despite the rewording', async () => {
-    const h = makeHarness()
-    const owner = makeFlushDeliveredEndedTurn()
+  function seedRecord(h: ReturnType<typeof makeHarness>, owner: CurrentTurn): void {
     h.deps.flushedTurnSupersede.record(
       CHAT,
       undefined,
       { turnId: owner.turnId, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
       Date.now(),
     )
-    // Positive attribution: the model's own reply quotes the user's inbound, so
-    // owner resolution wins at the `quoted` tier — this reply IS turn's answer.
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'quoted' })
+  }
+
+  it('CASE A — REAL marko DM incident: reworded own reply, latest-ended tier, ' +
+    'NO handback in flight → supersedes the flushed draft, collapses to ONE message', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    // Late DM reply: latest-ended tier (the path the tier discriminator MISSES),
+    // and crucially NO subagent_handback was enqueued for this chat after the
+    // turn ended — so the reply is the flushed turn's OWN answer.
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    h.deps.getLastSubagentHandbackAt = () => null
 
     const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
 
-    // The single flushed message was edited into the reworded reply (edit-in-
-    // place correction) — exactly ONE client-visible message, no fresh bubble.
+    // Exactly ONE client-visible message: the flushed message edited in place
+    // into the reworded reply — NO fresh second bubble (duplicate closed).
     const edits = h.calls.filter((c) => c.method === 'editMessageText')
     expect(edits).toHaveLength(1)
     expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
     expect(edits[0]!.text).toContain('every one of the twelve agents')
     expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
     expect(res.content[0]!.text).toMatch(/^sent/)
-    // Record consumed — no second correction can re-fire.
+    // Record consumed.
     expect(
       h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
         liveTurnId: OWNER_TURN_ID,
@@ -775,32 +794,27 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     ).toBe('no-record')
   })
 
-  it('CASE B (no #3429 regression): the SAME divergent content resolved by the ' +
-    'ambiguous latest-ended tier is treated as a handback — sends FRESH (TWO messages), ' +
-    'flushed message preserved', async () => {
+  it('CASE B — genuine background handback: SAME reworded text, SAME latest-ended tier, ' +
+    'but a handback WAS enqueued in-window → keeps the gate, sends FRESH (TWO messages)', async () => {
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
-    h.deps.flushedTurnSupersede.record(
-      CHAT,
-      undefined,
-      { turnId: owner.turnId, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
-      Date.now(),
-    )
-    // Ambiguous fallback: no live turn, no echo, no quote → latest-ended tier.
+    seedRecord(h, owner)
     h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    // A background sub-agent handback was enqueued for this chat AFTER the turn
+    // ended (now-30s) and within the 60s TTL (now-15s) — this reply might BE it.
+    h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
 
     const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
 
-    // A fresh, notifying bubble ships and the flushed message is NEITHER edited
-    // nor deleted — the flush (A) plus the fresh send (B) = two surfaced
-    // messages, the correct behaviour for a genuine async handback (#3429).
+    // A fresh notifying bubble ships; the flushed message is NEITHER edited nor
+    // deleted — flush (A) + fresh (B) = two surfaced messages (#3429 preserved).
     const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
     expect(fresh).toHaveLength(1)
     expect(fresh[0]!.message_id).not.toBe(FLUSH_MSG_ID)
     expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
     expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
     expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
-    // Record NOT consumed (the turn's own canonical replay could still correct).
+    // Record NOT consumed.
     expect(
       h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
         liveTurnId: OWNER_TURN_ID,
@@ -808,5 +822,25 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
         now: Date.now(),
       }).supersede,
     ).toBe(true)
+  })
+
+  it('SECONDARY (tier path): a reworded reply POSITIVELY attributed (quoted tier) ' +
+    'supersedes regardless of text EVEN with a handback in flight (positive tier wins)', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    // Positive attribution (supergroup explicit-quote/echo path): the reply is
+    // provably this turn's own answer, so a coincident background handback does
+    // NOT downgrade it — the tier signal alone bypasses the content gate.
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'quoted' })
+    h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
+
+    const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
+
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent/)
   })
 })

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -209,7 +209,7 @@ function makeHarness(opts?: {
     assertSendable: () => {},
     statusKey: key,
     streamKey: key,
-    resolveReplyOwnerTurn: () => null,
+    resolveReplyOwnerTurn: () => ({ turn: null, tier: 'none' as const }),
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
     resolveAnswerThreadWithLog: (_c, explicit) => explicit,
@@ -633,8 +633,11 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
       Date.now(),
     )
     // The late reply resolves the ENDED flush-delivered turn as its owner
-    // (latest-ended tier — no live turn, no origin echo, no quote in a DM).
-    h.deps.resolveReplyOwnerTurn = () => owner
+    // (latest-ended tier — no live turn, no origin echo, no quote in a DM). This
+    // is the AMBIGUOUS fallback tier: the content gate applies here, so a
+    // genuinely-new handback sends fresh while the turn's own contained answer
+    // still supersedes.
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
   }
 
   it('CORE REGRESSION (red pre-fix): a handback with genuinely NEW content sends a ' +
@@ -700,8 +703,8 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
     // NO registry record (the post-fire pre-record window); owner resolution
-    // still recovers the ended flush-armed turn.
-    h.deps.resolveReplyOwnerTurn = () => owner
+    // still recovers the ended flush-armed turn via the latest-ended tier.
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
 
     const res = await sendReply(h.deps, req(HANDBACK))
 
@@ -715,11 +718,95 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     'window is still suppressed (the #2996 Part 2 backstop holds)', async () => {
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
-    h.deps.resolveReplyOwnerTurn = () => owner
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
 
     const res = await sendReply(h.deps, req(FLUSHED_TEXT))
 
     expect(h.calls).toHaveLength(0) // nothing sent, nothing edited
     expect(res.content[0]!.text).toContain('deduped')
+  })
+
+  // The tier discriminator (fix/backstop-duplicate-reply). A model that narrates
+  // its answer as prose (flushed as message A) then fires the `reply` tool with a
+  // genuinely RE-WORDED version of the same answer is the dominant real-world
+  // duplicate (agent:marko 39/54 flushes on 2026-07-20; turns #1177/#1182/#1201
+  // double-sent). The reworded reply is NOT contained in the flushed blob, so
+  // the #3429 content gate alone declines the supersede → fresh second bubble =
+  // the visible duplicate. The fix: when the owner turn was resolved by POSITIVE
+  // attribution (live / origin echo / quoted message id — NOT the ambiguous
+  // latest-ended fallback), the reply IS this turn's own answer and supersedes
+  // its flushed provisional draft REGARDLESS of the rewording. A genuine handback
+  // (latest-ended tier) with the same divergent content must still send fresh.
+  const REWORDED_SAME_TURN_ANSWER =
+    'Good news on the fleet: every one of the twelve agents is running fine right now. ' +
+    'The gateway, the vault broker and the approval kernel are all green, and nothing has ' +
+    'restarted in the past day — so there is nothing you need to do.'
+
+  it('CASE A (dup regression): a RE-WORDED reply resolved by a POSITIVE tier (quoted) ' +
+    'supersedes the flushed draft — collapses to ONE message despite the rewording', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    h.deps.flushedTurnSupersede.record(
+      CHAT,
+      undefined,
+      { turnId: owner.turnId, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
+      Date.now(),
+    )
+    // Positive attribution: the model's own reply quotes the user's inbound, so
+    // owner resolution wins at the `quoted` tier — this reply IS turn's answer.
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'quoted' })
+
+    const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
+
+    // The single flushed message was edited into the reworded reply (edit-in-
+    // place correction) — exactly ONE client-visible message, no fresh bubble.
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(edits[0]!.text).toContain('every one of the twelve agents')
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent/)
+    // Record consumed — no second correction can re-fire.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        now: Date.now(),
+      }).reason,
+    ).toBe('no-record')
+  })
+
+  it('CASE B (no #3429 regression): the SAME divergent content resolved by the ' +
+    'ambiguous latest-ended tier is treated as a handback — sends FRESH (TWO messages), ' +
+    'flushed message preserved', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    h.deps.flushedTurnSupersede.record(
+      CHAT,
+      undefined,
+      { turnId: owner.turnId, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
+      Date.now(),
+    )
+    // Ambiguous fallback: no live turn, no echo, no quote → latest-ended tier.
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+
+    const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER))
+
+    // A fresh, notifying bubble ships and the flushed message is NEITHER edited
+    // nor deleted — the flush (A) plus the fresh send (B) = two surfaced
+    // messages, the correct behaviour for a genuine async handback (#3429).
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.message_id).not.toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+    // Record NOT consumed (the turn's own canonical replay could still correct).
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        replyText: CANONICAL_REPLY,
+        now: Date.now(),
+      }).supersede,
+    ).toBe(true)
   })
 })

--- a/telegram-plugin/tests/stream-render-golden.test.ts
+++ b/telegram-plugin/tests/stream-render-golden.test.ts
@@ -238,7 +238,7 @@ function makeSendReplyDeps(dedup: OutboundDedupCache) {
     assertSendable: () => {},
     statusKey: key,
     streamKey: key,
-    resolveReplyOwnerTurn: () => null,
+    resolveReplyOwnerTurn: () => ({ turn: null, tier: 'none' as const }),
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
     resolveAnswerThreadWithLog: (_c: string, explicit: number | undefined) => explicit,

--- a/telegram-plugin/tests/stream-render-golden.test.ts
+++ b/telegram-plugin/tests/stream-render-golden.test.ts
@@ -239,6 +239,7 @@ function makeSendReplyDeps(dedup: OutboundDedupCache) {
     statusKey: key,
     streamKey: key,
     resolveReplyOwnerTurn: () => ({ turn: null, tier: 'none' as const }),
+    getLastSubagentHandbackAt: () => null,
     findTurnByOriginId: () => null,
     findTurnByQuotedMessageId: () => null,
     resolveAnswerThreadWithLog: (_c: string, explicit: number | undefined) => explicit,

--- a/telegram-plugin/tests/subagent-handback-marker.test.ts
+++ b/telegram-plugin/tests/subagent-handback-marker.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Unit coverage for the per-chat subagent-handback marker
+ * (fix/backstop-duplicate-reply). The marker is the deterministic signal the
+ * supersede path uses to tell a flushed turn's OWN reworded late reply (no
+ * handback in flight → supersede) from a background handback attributed to that
+ * ended turn (handback in flight → keep the #3429 content gate).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { SubagentHandbackMarker } from '../gateway/subagent-handback-marker.js'
+
+describe('SubagentHandbackMarker', () => {
+  it('returns null for a chat with no recorded handback', () => {
+    const m = new SubagentHandbackMarker()
+    expect(m.lastAt('chatA')).toBe(null)
+  })
+
+  it('returns the recorded enqueue ts for the chat', () => {
+    const m = new SubagentHandbackMarker()
+    m.record('chatA', 1_000_000)
+    expect(m.lastAt('chatA')).toBe(1_000_000)
+  })
+
+  it('is per-chat — one chat never leaks into another', () => {
+    const m = new SubagentHandbackMarker()
+    m.record('chatA', 1_000_000)
+    expect(m.lastAt('chatB')).toBe(null)
+  })
+
+  it('keeps only the MOST RECENT enqueue (overwrites)', () => {
+    const m = new SubagentHandbackMarker()
+    m.record('chatA', 1_000_000)
+    m.record('chatA', 1_050_000)
+    expect(m.lastAt('chatA')).toBe(1_050_000)
+  })
+})


### PR DESCRIPTION
## Summary

Closes a high-frequency **duplicate-reply** regression on the Telegram gateway: an agent narrates its answer as prose (the turn-flush posts it as message **A**), then fires the `reply` tool with a **reworded** version of the same answer, and the user sees the answer **twice**. Fingerprint `agent:marko::duplicate_reply_backstop_flush`.

The fix is a **deterministic, gateway-synthesized signal** — the `subagent_handback` in-flight marker — not text-matching or model discipline.

## Why the earlier tier-only approach was a no-op (course correction)

The first cut gated on the owner-resolution **tier** (supersede regardless of text when positively attributed). Verification against real source proved this misses the **dominant** case: on a **DM**, the reworded late reply has no live turn, no `origin_turn_id` echo, and no explicit `reply_to` at supersede time (`gateway.ts ~2892` "model rarely passes reply_to"; the default quote is applied later at `outbound-send-path.ts ~1237`). It therefore resolves via the ambiguous `latest-ended` tier, `positiveAttribution` is false, the #3429 content gate declines the paraphrase, and a fresh second bubble ships. Production confirms: marko turn `#1177` resolved `via=recovered` (latest-ended), and **11/11** declines today were own-replies.

## Root cause

PR #3429 added a content gate to the identity-keyed supersede to protect a real case — a **background sub-agent handback** attributed to the flush-delivered ended turn, which must send fresh (two messages), not silently edit the flushed answer. But that gate also declines the turn's **own reworded reply**. Case A (own reply) and case B (handback) both resolve `latest-ended` and both differ in text — indistinguishable by tier or content.

## The discriminator

They differ in exactly one **gateway-observable** way: case B exists **only** because the gateway *synthesized* a `subagent_handback` inbound (a background worker completion — foreground handbacks return inside the parent's own turn). So:

- **`gateway/subagent-handback-marker.ts`** (new pure module) — tracks, per chat, the ms of the most recent `subagent_handback` enqueue; stamped at the enqueue site in `gateway.ts`.
- **`outbound-send-path.ts`** — when the owner resolves to the flushed turn, bypass the #3429 content gate when the reply is confidently the turn's OWN answer: **positive tier** (live/origin/quoted) **OR** **no** `subagent_handback` enqueued for the chat after the turn ended within the supersede TTL. Otherwise keep the gate.
- **`flushed-turn-supersede.ts`** — `decideSupersede` applies the content gate only when `!positiveAttribution` (now set from tier OR handback-absence).

The tier signal is retained as a **secondary** positive-attribution path (it fixes the supergroup explicit-quote/echo case and narrows the concurrency window below).

## Bracketing evidence (load-bearing — verified against the marko gateway log)

Every case-A incident today had **no** `subagent_handback` in `[endedAt, endedAt+60s]`:

| turn | turn_end | late reply | nearest handback |
|---|---|---|---|
| #1165 | 10:17:28 | 10:17:34 | 10:46:48 (+29m) |
| #1177 | 10:22:56 | 10:23:13 | 10:46:48 (+24m) |
| #1182 | 10:30:08 | 10:30:29 | 10:46:48 (+16m) |
| #1201 | 10:50:15 | 10:50:22 | 10:46:48 (−3.5m, before end) |
| #1211 | 10:59:41 | 10:59:51 | 11:12:08 (+12m) |
| #1224 | 11:04:16 | 11:04:37 | 11:12:08 (+7m) |

The 4 handbacks today (08:18:14, 08:45:44, 10:46:48, 11:12:08) are all minutes from any incident → the marker supersedes all 11 declines (duplicate closed) and never false-gates.

## Concurrency degradation (explicit)

If a case-A own reply coincides with an **unrelated** background handback completing in the same ≤TTL window, the marker keeps the content gate and the reply degrades to **today's behaviour: two messages**. Safe — never a silent drop/edit (the gate only ever sends fresh). Zero such overlaps occurred in the 11 observed incidents; the secondary tier path further narrows it (a positively-attributed own reply supersedes even with a handback in flight).

## Test plan

`send-reply-golden` drives the **real** send path + real supersede registry:
- **CASE A** — reworded own reply, `latest-ended` tier, **no** handback → edit-in-place, **ONE** message, record consumed.
- **CASE B** — **same** reworded text, **same** tier, handback in-window → fresh, **TWO** messages, flushed message preserved.
- **SECONDARY** — quoted tier + handback in flight → supersede (positive tier wins).

Proven **RED with the marker disabled** (CASE A ships the duplicate) and **GREEN** with it. Plus a unit suite for the marker module, and the retained tier / `positiveAttribution` unit tests.

Local: `tsc --noEmit` clean; `npm run lint` clean (all guards incl. gateway line-ratchet — marker logic lives in its own module); scoped vitest (6 files) = **128 passed**.

## Job spec
`reference/jobs/` — the always-available / on-the-leash reply path: exactly one clean answer per turn (chat is source of truth). No invariant crossed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)