### PR TITLE
fix(gateway): make dup-reply defense self-enforcing (outcome guards + thread-key + invariant)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3889,12 +3889,15 @@ const recentTurnsById = new Map<string, CurrentTurn>()
 // Evicted in lock-step with recentTurnsById so it can't outgrow it.
 const recentTurnIdBySourceMessageId = new Map<number, string>()
 
-// fix/backstop-duplicate-reply — per-chat marker of the most recent
+// fix/backstop-duplicate-reply — per-chat/thread marker of the most recent
 // gateway-synthesized `subagent_handback` enqueue (logic in
 // subagent-handback-marker.ts; extracted per the gateway anti-inflation ratchet).
+// Thread-keyed (dup-audit F2) so it gates exactly the `chatId|threadId` lane the
+// supersede registry acts on — a handback in one forum topic never holds the
+// content gate open in another.
 const subagentHandbackMarker = new SubagentHandbackMarker()
-const getLastSubagentHandbackAt = (chatId: string): number | null =>
-  subagentHandbackMarker.lastAt(chatId)
+const getLastSubagentHandbackAt = (chatId: string, threadId: number | undefined): number | null =>
+  subagentHandbackMarker.lastAt(chatId, threadId)
 
 function rememberRecentTurn(turn: CurrentTurn): void {
   recentTurnsById.set(turn.turnId, turn)
@@ -9984,7 +9987,7 @@ const pendingInboundBuffer = createPendingInboundBuffer({
   // fix/backstop-duplicate-reply MUST-FIX 2 — stamp the handback marker at the
   // enqueue chokepoint so a boot-replayed handback (not just the live synthesis
   // push) populates it. Every `subagent_handback` push funnels through here.
-  onHandbackEnqueue: (chatId, ts) => subagentHandbackMarker.record(chatId, ts),
+  onHandbackEnqueue: (chatId, threadId, ts) => subagentHandbackMarker.record(chatId, threadId, ts),
 })
 
 // PR2 obligation-ledger idle sweep. Re-present an OPEN obligation only at a

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3892,12 +3892,14 @@ const recentTurnIdBySourceMessageId = new Map<number, string>()
 // fix/backstop-duplicate-reply — per-chat/thread marker of the most recent
 // gateway-synthesized `subagent_handback` enqueue (logic in
 // subagent-handback-marker.ts; extracted per the gateway anti-inflation ratchet).
-// Thread-keyed (dup-audit F2) so it gates exactly the `chatId|threadId` lane the
-// supersede registry acts on — a handback in one forum topic never holds the
-// content gate open in another.
+// The record is thread-resolved (retains the originating topic), but the
+// content-gate READ is CHAT-WIDE (dup-audit MUST-FIX 2): the latest-ended owner
+// tier is chat-wide, so a thread-specific gate read was steerable by the reply's
+// own `message_thread_id` → silent edit-over. `lastAtInChat` makes the gate
+// un-steerable (any in-window handback in the chat keeps the content gate).
 const subagentHandbackMarker = new SubagentHandbackMarker()
-const getLastSubagentHandbackAt = (chatId: string, threadId: number | undefined): number | null =>
-  subagentHandbackMarker.lastAt(chatId, threadId)
+const getLastSubagentHandbackAt = (chatId: string): number | null =>
+  subagentHandbackMarker.lastAtInChat(chatId)
 
 function rememberRecentTurn(turn: CurrentTurn): void {
   recentTurnsById.set(turn.turnId, turn)

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -672,7 +672,7 @@ export interface SendReplyGatewayDeps {
   ): number | undefined
   resolveThreadId(chatId: string, explicit?: string | number | null): number | undefined
   getLatestInboundMessageId(chatId: string, threadId: number | null): number | null | undefined
-  getLastSubagentHandbackAt(chatId: string, threadId: number | undefined): number | null
+  getLastSubagentHandbackAt(chatId: string): number | null
   recordOutbound(rec: {
     chat_id: string
     thread_id: number | null
@@ -898,36 +898,72 @@ export async function sendReply(
     //
     // MUST-FIX 1 (silent-data-loss): the owner-resolution `quoted` / `origin`
     // tiers are derived from MODEL-SUPPLIED args (`args.reply_to` /
-    // `args.origin_turn_id`), so a background handback turn can STEER them —
-    // pass `reply_to = <the user's original msg id>` and it resolves the PRIOR
-    // flushed turn via `quoted`, which used to force the bypass and silently
-    // edit-over that turn's delivered answer (#3429-class, model-steerable). So
-    // a positive tier NEVER overrides an in-window handback; only the
-    // FRAMEWORK-owned `live` tier (the live `currentTurn`, not model-derived,
-    // and structurally unable to collide with an ended turn's flush record —
-    // `decideSupersede` requires same turnId) may bypass a handback window.
+    // `args.origin_turn_id`), so a reply can STEER itself — pass
+    // `reply_to = <another ended turn's source msg>` and it resolves THAT turn via
+    // `quoted`. Marker-absence proves "own answer" ONLY for the framework-derived
+    // `latest-ended` tier; a model-steered `quoted`/`origin` attribution with no
+    // marker is NOT evidence of ownership, so bypassing the content gate there
+    // silently edits over a different ended turn's delivered answer (the #3429
+    // double-loss, executed by Fable 2026-07-21). The `replyIsOwnAnswer`
+    // computation below therefore restricts the bypass to `live` + `latest-ended`;
+    // `quoted`/`origin` ALWAYS traverse the content gate. See that comment.
     //
-    // The content gate is therefore kept whenever a handback WAS enqueued in the
-    // window (any non-live tier): the late reply might BE that handback, so
-    // genuinely-new content sends fresh (two messages, #3429 preserved).
-    // Concurrency note: a case-A own reply coinciding with an unrelated
-    // background handback in the same ≤TTL window degrades to today's behaviour
-    // (two messages) — safe (never a silent drop/edit), just not collapsed.
+    // The content gate is therefore kept whenever a decoupled completion WAS
+    // enqueued in the window (on the latest-ended tier) OR the reply resolved via
+    // a model-steerable tier: the late reply might carry foreign content, so it
+    // sends fresh (two messages, #3429 preserved). Concurrency note: a case-A own
+    // reply coinciding with an unrelated background handback in the same ≤TTL
+    // window degrades to two messages — safe (never a silent drop/edit).
     const ownerEndedAt = ownerTurn?.endedAt ?? null
-    // F2 (dup-audit): read the marker on the SAME `chatId|threadId` lane the
-    // supersede acts on. A handback in another forum topic must not hold this
-    // topic's content gate open (the visible-dup regression F2 closed).
-    const handbackAt = getLastSubagentHandbackAt(chat_id, replyThreadId)
+    // MUST-FIX 2 (dup-audit / Fable 2026-07-21) — key BOTH the supersede lane and
+    // the marker-gate read on the FRAMEWORK-resolved thread (the owner turn's
+    // `sessionThreadId` — the lane the flush recorded on), NOT the raw model arg
+    // `args.message_thread_id` (`replyThreadId`). The flush records on
+    // `turn.sessionThreadId`; the owner turn resolved here IS that turn, so its
+    // thread is where its record and its handback marker live. Reading the gate on
+    // the raw arg let a reply carry `message_thread_id=<other topic>` to dodge a
+    // handback marker stamped on the real topic → silent edit-over (the regression
+    // F2's raw-arg keying introduced). The owner turn's thread is not model-
+    // derived, so it cannot be steered. Falls back to the raw arg only when no
+    // owner turn resolved (no record to clobber on the collapse path).
+    const gateThreadId = ownerTurn?.sessionThreadId ?? replyThreadId
+    // MUST-FIX 2 (dup-audit / Fable) — the content-gate READ is CHAT-WIDE, not
+    // lane-specific: `findLatestEndedTurnForChat` resolves owners chat-wide, so a
+    // handback in topic A can supersede topic B's ended turn; a thread-keyed gate
+    // read (the F2 regression) let a reply dodge that handback by carrying a
+    // different `message_thread_id`. Chat-wide makes the gate un-steerable — any
+    // in-window handback in the chat keeps the content gate (accepting the F2
+    // visible-dup in the overlap window; a self-healing dup beats a silent loss).
+    // The supersede `take()` LANE below stays thread-resolved (`gateThreadId` =
+    // the owner turn's framework thread, not the raw arg), so a handback's
+    // correction only ever touches ITS OWN topic's record.
+    const handbackAt = getLastSubagentHandbackAt(chat_id)
     const now = Date.now()
     const handbackCouldOwnReply =
       handbackAt != null &&
       ownerEndedAt != null &&
       handbackAt > ownerEndedAt &&
       now - handbackAt <= DEFAULT_SUPERSEDE_TTL_MS
-    const replyIsOwnAnswer = ownerTier === 'live' || !handbackCouldOwnReply
+    // MUST-FIX 1 (silent-data-loss, PROVEN by Fable 2026-07-21) — restrict the
+    // content-gate BYPASS to the tiers whose attribution is NOT model-steerable:
+    //   - `live`   — the framework-owned live `currentTurn` (not model-derived,
+    //                and `decideSupersede`'s same-turnId check bars it from an
+    //                ended turn's record). Bypasses even a handback window.
+    //   - `latest-ended` — the ambiguous DM/late-reply fallback the marko fix
+    //                actually needs; bypass ONLY when no decoupled completion is
+    //                in the window (marker-absence ⇒ own answer).
+    // The `quoted` / `origin` tiers resolve from MODEL-SUPPLIED args
+    // (`args.reply_to` / `args.origin_turn_id`), so a reply can steer ITSELF onto
+    // a DIFFERENT ended turn's record — with marker-absence they used to bypass
+    // the content gate and silently edit-over that turn's delivered answer (the
+    // #3429 double-loss, executed by Fable). Those tiers therefore NEVER bypass:
+    // they always go through the content gate, so foreign content sends fresh and
+    // only a genuine same-answer reply collapses.
+    const replyIsOwnAnswer =
+      ownerTier === 'live' || (ownerTier === 'latest-ended' && !handbackCouldOwnReply)
     const decision = flushedTurnSupersede.take(
       chat_id,
-      replyThreadId,
+      gateThreadId,
       { liveTurnId: resolvedTurnId, replyText: text, positiveAttribution: replyIsOwnAnswer, now },
     )
     if (decision.supersede) {

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -672,7 +672,7 @@ export interface SendReplyGatewayDeps {
   ): number | undefined
   resolveThreadId(chatId: string, explicit?: string | number | null): number | undefined
   getLatestInboundMessageId(chatId: string, threadId: number | null): number | null | undefined
-  getLastSubagentHandbackAt(chatId: string): number | null
+  getLastSubagentHandbackAt(chatId: string, threadId: number | undefined): number | null
   recordOutbound(rec: {
     chat_id: string
     thread_id: number | null
@@ -914,7 +914,10 @@ export async function sendReply(
     // background handback in the same ≤TTL window degrades to today's behaviour
     // (two messages) — safe (never a silent drop/edit), just not collapsed.
     const ownerEndedAt = ownerTurn?.endedAt ?? null
-    const handbackAt = getLastSubagentHandbackAt(chat_id)
+    // F2 (dup-audit): read the marker on the SAME `chatId|threadId` lane the
+    // supersede acts on. A handback in another forum topic must not hold this
+    // topic's content gate open (the visible-dup regression F2 closed).
+    const handbackAt = getLastSubagentHandbackAt(chat_id, replyThreadId)
     const now = Date.now()
     const handbackCouldOwnReply =
       handbackAt != null &&

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -31,6 +31,7 @@
 
 import type { InboundMessage } from './ipc-protocol.js'
 import type { InboundSpool } from './inbound-spool.js'
+import { stampsHandbackMarker } from './subagent-handback-marker.js'
 
 /** Default cap per agent. Tuned for `should fit a reasonable backlog of
  *  approval cards stacked while bridge is offline` but no more. */
@@ -82,13 +83,17 @@ export interface PendingInboundBufferOptions {
   /**
    * fix/backstop-duplicate-reply MUST-FIX 2 — called on every push of a
    * `subagent_handback` envelope (live synthesis AND boot-replay re-push),
-   * carrying the envelope's `chatId` and its own `ts` (ms). The gateway wires
-   * this to the per-chat subagent-handback marker so the supersede path can tell
-   * a flushed turn's own late reply from a background handback attributed to it
-   * — INCLUDING after a restart, where the only handback push is the replay.
-   * Best-effort: a throw here never breaks the push hot path.
+   * carrying the envelope's `chatId`, its `threadId` (the originating forum
+   * topic, or undefined for a DM), and its own `ts` (ms). The gateway wires this
+   * to the per-chat/thread subagent-handback marker so the supersede path can
+   * tell a flushed turn's own late reply from a background handback attributed to
+   * it — INCLUDING after a restart, where the only handback push is the replay.
+   * The `threadId` is passed so the marker keys on the SAME `chatId|threadId`
+   * lane the supersede registry uses (dup-audit F2): a handback in one topic must
+   * not hold the content gate open in another. Best-effort: a throw here never
+   * breaks the push hot path.
    */
-  onHandbackEnqueue?: (chatId: string, ts: number) => void
+  onHandbackEnqueue?: (chatId: string, threadId: number | undefined, ts: number) => void
 }
 
 /**
@@ -362,9 +367,17 @@ export function createPendingInboundBuffer(
       // content gate → silent edit-over-answer. Uses the envelope's own `ts`
       // (ms, `Date.now()`-derived at synthesis) so the marker reflects when the
       // handback actually happened, not the replay moment. Best-effort.
-      if (msg.meta?.source === 'subagent_handback' && opts.onHandbackEnqueue != null) {
+      // F1 (dup-audit) — the ONE chokepoint that decides which sources stamp the
+      // decoupled-completion marker, delegated to the single `stampsHandbackMarker`
+      // predicate (its membership is the invariant's only extension point). Every
+      // inbound — live synthesis AND boot-replay — funnels through this push(), so
+      // routing the decision here makes "a decoupled late-reply source stamps the
+      // marker" true BY CONSTRUCTION rather than by per-feature discipline.
+      if (stampsHandbackMarker(msg.meta?.source) && opts.onHandbackEnqueue != null) {
         try {
-          opts.onHandbackEnqueue(msg.chatId, msg.ts)
+          // F2 (dup-audit): pass the envelope's originating topic so the marker
+          // keys on the same `chatId|threadId` lane as the supersede registry.
+          opts.onHandbackEnqueue(msg.chatId, msg.threadId, msg.ts)
         } catch {
           /* marker stamp is best-effort; never break the push hot path */
         }

--- a/telegram-plugin/gateway/subagent-handback-marker.ts
+++ b/telegram-plugin/gateway/subagent-handback-marker.ts
@@ -1,18 +1,18 @@
 /**
- * Per-chat marker of the most recent gateway-synthesized `subagent_handback`
- * enqueue (fix/backstop-duplicate-reply).
+ * Per-chat-and-thread marker of the most recent gateway-synthesized
+ * `subagent_handback` enqueue (fix/backstop-duplicate-reply).
  *
  * A BACKGROUND sub-agent completion is a GATEWAY-SYNTHESIZED event, not model
  * output: when a background worker terminates the gateway wakes the agent with a
- * `subagent_handback` inbound. Recording WHEN one was enqueued, per chat, is the
- * ONE deterministic signal that distinguishes the two late-reply cases that both
- * resolve a flush-delivered ENDED turn via the latest-ended tier — the case the
- * owner-resolution tier alone cannot separate (a DM late reply has no
+ * `subagent_handback` inbound. Recording WHEN one was enqueued, per chat/thread,
+ * is the ONE deterministic signal that distinguishes the two late-reply cases
+ * that both resolve a flush-delivered ENDED turn via the latest-ended tier — the
+ * case the owner-resolution tier alone cannot separate (a DM late reply has no
  * live/origin/quoted attribution, so both land on latest-ended):
  *
  *   - CASE A — the flushed turn's OWN reworded reply landing late. NO
- *     `subagent_handback` was enqueued for this chat after the turn ended, so the
- *     reply is that turn's own answer → the supersede path collapses the
+ *     `subagent_handback` was enqueued for this chat/thread after the turn ended,
+ *     so the reply is that turn's own answer → the supersede path collapses the
  *     provisional flush REGARDLESS of the model's rewording (closes the #3429
  *     reworded-duplicate regression: agent:marko 2026-07-20, turns
  *     #1177/#1182/#1201 double-sent).
@@ -22,21 +22,88 @@
  *     and send fresh (two messages), never silently edit/delete the flushed
  *     answer.
  *
- * One entry per chat (overwritten on each enqueue), so bounded by chat count. No
- * clock reads beyond the caller-supplied `now`; the gateway wires the actual
- * enqueue site and the supersede-path read. Deterministic — keyed on a
- * gateway-emitted event, never on model discipline (Ken's controls-in-code rule).
+ * ## Why thread-keyed (F2, dup-audit 2026-07-21)
+ *
+ * The supersede registry this marker gates is keyed on `chatId|threadId`
+ * (`flushed-turn-supersede.ts` `makeKey`). Keying the marker on `chatId` ALONE
+ * was inconsistent: in a forum supergroup a background handback in topic A
+ * stamped the chat-wide marker, and a genuine CASE-A reworded own-reply in ANY
+ * other topic within the 60 s TTL then computed `handbackCouldOwnReply = true` →
+ * kept the content gate → shipped a second visible bubble instead of collapsing.
+ * The blast radius was every topic in the chat for 60 s per handback. Keying on
+ * `chatId + threadId` — the SAME lane the supersede registry uses — confines a
+ * handback's gate-hold to the topic it actually landed in, so an unrelated
+ * topic's CASE-A collapse is untouched. A DM (no thread) collapses to the
+ * chat-only key, so single-lane behaviour is unchanged.
+ *
+ * One entry per chat/thread (overwritten on each enqueue), so bounded by
+ * chat×topic count. No clock reads beyond the caller-supplied `now`; the gateway
+ * wires the actual enqueue site and the supersede-path read. Deterministic —
+ * keyed on a gateway-emitted event, never on model discipline (Ken's
+ * controls-in-code rule).
  */
-export class SubagentHandbackMarker {
-  private readonly lastAtByChat = new Map<string, number>()
+/**
+ * ## The enforced invariant (F1, dup-audit 2026-07-21)
+ *
+ * The whole content-gate bypass rests on this premise: *a decoupled late reply
+ * (turn == null) carrying content that is NOT the flushed turn's own answer,
+ * resolving an ENDED flushed turn as its owner, can ONLY be a gateway-synthesized
+ * completion — and every such completion stamps this marker.* If that premise
+ * holds, then marker-ABSENCE in the window proves the late reply IS the flushed
+ * turn's own (possibly reworded) answer, so bypassing the content gate is safe
+ * (closes the marko duplicate). If a NEW synthesized-inbound source were ever
+ * able to land as a decoupled late reply with foreign content WITHOUT stamping,
+ * it would silently edit over a delivered answer (the #3429 failure).
+ *
+ * We make the premise an ENFORCED invariant rather than an architectural
+ * coincidence by routing the stamp decision through this ONE predicate at the ONE
+ * chokepoint every inbound funnels through (`pendingInboundBuffer.push` — live
+ * synthesis, boot-replay, and every future source alike). The membership of the
+ * decoupled-completion class is defined HERE and nowhere else:
+ *
+ *   - `subagent_handback` — the only source today that wakes the agent to emit a
+ *     reply with NO live gateway turn of its own (a background worker completion),
+ *     so its reply resolves a DIFFERENT, already-ended turn via the latest-ended
+ *     tier. It is the F1 vector.
+ *   - Every OTHER synthesized source (cron, resume_*, reaction, vault_*, …) lands
+ *     as its OWN live inbound turn, so its reply resolves the `live` tier for its
+ *     own turnId and structurally cannot supersede a different ended turn's flush
+ *     record (`decideSupersede` requires `record.turnId === liveTurnId`). Those
+ *     must NOT stamp — stamping them would needlessly hold the content gate open
+ *     for an unrelated own-reply in the window (a safe but avoidable visible dup).
+ *
+ * This predicate is therefore the SINGLE point of extension: any future feature
+ * that synthesizes an inbound which can land as a DECOUPLED late reply (no live
+ * turn) MUST add its `meta.source` here — and because the chokepoint consults
+ * this predicate, doing so is the whole wiring. A source that forgets to opt in
+ * cannot reach the bypass unnoticed: the negative outcome guard
+ * (`send-reply-golden.test.ts`) pins that a decoupled foreign-content reply on a
+ * non-live tier never silently edits over the flushed answer.
+ */
+export function stampsHandbackMarker(source: string | null | undefined): boolean {
+  return source === 'subagent_handback'
+}
 
-  /** Record that a `subagent_handback` was enqueued for `chatId` at `now` (ms). */
-  record(chatId: string, now: number): void {
-    this.lastAtByChat.set(chatId, now)
+export class SubagentHandbackMarker {
+  private readonly lastAtByLane = new Map<string, number>()
+
+  /** Compose the lane key consistently with the supersede registry's
+   *  `makeKey(chatId, threadId)`: a bare chat id for the no-thread (DM) case,
+   *  `chatId|threadId` for a forum topic. Keeping these two keyings identical is
+   *  what makes the marker gate exactly the lane the supersede acts on. */
+  private lane(chatId: string, threadId: number | undefined): string {
+    return threadId == null ? chatId : `${chatId}|${threadId}`
   }
 
-  /** Wall-clock ms of the most recent handback enqueue for `chatId`, or null. */
-  lastAt(chatId: string): number | null {
-    return this.lastAtByChat.get(chatId) ?? null
+  /** Record that a `subagent_handback` was enqueued for `chatId`/`threadId` at
+   *  `now` (ms). */
+  record(chatId: string, threadId: number | undefined, now: number): void {
+    this.lastAtByLane.set(this.lane(chatId, threadId), now)
+  }
+
+  /** Wall-clock ms of the most recent handback enqueue for `chatId`/`threadId`,
+   *  or null. */
+  lastAt(chatId: string, threadId: number | undefined): number | null {
+    return this.lastAtByLane.get(this.lane(chatId, threadId)) ?? null
   }
 }

--- a/telegram-plugin/gateway/subagent-handback-marker.ts
+++ b/telegram-plugin/gateway/subagent-handback-marker.ts
@@ -137,6 +137,21 @@ export const INBOUND_SOURCE_CLASSIFICATION: Record<string, { decoupledCompletion
   missed_approval_retry: { decoupledCompletion: false },
   skill_proposal_apply: { decoupledCompletion: false },
   warmup: { decoupledCompletion: false },
+  // dup-audit pass-2 (Fable) — sources the widened exhaustiveness scanner now
+  // sees. Each lands as its OWN live inbound turn (not a decoupled completion
+  // resolving a DIFFERENT ended turn), so it must NOT stamp — else its fail-safe
+  // stamp would hold the content gate chat-wide for 60 s and re-open the
+  // reworded-own-answer visible dup in that window.
+  //   - mental_model_proposal_{applied,denied,failed}: resume-synthetic inbounds
+  //     injected via `deliverResumeSyntheticOrBuffer` as their own live turn.
+  //   - webhook / linear: built in `src/web/webhook-dispatch.ts`, delivered via
+  //     the gateway's `webhookInject` (`sendToAgent`, buffer on miss) as their
+  //     own live turn.
+  mental_model_proposal_applied: { decoupledCompletion: false },
+  mental_model_proposal_denied: { decoupledCompletion: false },
+  mental_model_proposal_failed: { decoupledCompletion: false },
+  webhook: { decoupledCompletion: false },
+  linear: { decoupledCompletion: false },
 }
 
 /**

--- a/telegram-plugin/gateway/subagent-handback-marker.ts
+++ b/telegram-plugin/gateway/subagent-handback-marker.ts
@@ -79,31 +79,128 @@
  * cannot reach the bypass unnoticed: the negative outcome guard
  * (`send-reply-golden.test.ts`) pins that a decoupled foreign-content reply on a
  * non-live tier never silently edits over the flushed answer.
+ *
+ * ## Inbound meta.source classification registry (F1 durability — dup-audit
+ * MUST-FIX 3, Fable 2026-07-21)
+ *
+ * The old predicate was a bare `=== 'subagent_handback'` with NO tripwire and an
+ * UNSAFE default: adding a new decoupled-completion source tripped nothing — no
+ * stamp → content-gate bypass eligible → silent edit-over of a delivered answer.
+ * This registry makes the classification EXPLICIT, EXHAUSTIVE and FAIL-SAFE:
+ *
+ *   - Every known `meta.source` is listed with `decoupledCompletion`. Today ONLY
+ *     `subagent_handback` is true; every other synthesized source lands as its
+ *     OWN live inbound turn (live tier → cannot supersede a different ended
+ *     turn's record), so it must NOT stamp.
+ *   - An UNKNOWN / unclassified source FAILS SAFE: `stampsHandbackMarker` returns
+ *     `true`, so it STAMPS → the content gate is KEPT → the worst case is a
+ *     visible duplicate, NEVER a silent edit-over (inverted from the old
+ *     deny-default, which failed toward silent loss).
+ *   - The exhaustiveness test (`subagent-handback-marker.test.ts`) scans the
+ *     gateway for `source:` / `meta.source ===` literals and FAILS when a new one
+ *     is added without a registry entry — forcing a conscious classification.
+ *
+ * Defense-in-depth with the tier restriction (`outbound-send-path.ts`): the
+ * content-gate bypass is now limited to the `live` + `latest-ended` tiers, so
+ * model-steerable `quoted`/`origin` attributions can never bypass regardless of
+ * the marker. This registry closes the residual `latest-ended` vector for a
+ * FUTURE decoupled source, fail-safe.
  */
-export function stampsHandbackMarker(source: string | null | undefined): boolean {
-  return source === 'subagent_handback'
+export const INBOUND_SOURCE_CLASSIFICATION: Record<string, { decoupledCompletion: boolean }> = {
+  // The ONE decoupled-completion source today: a background worker termination
+  // wakes the agent with no live turn of its own → its reply resolves a
+  // different, already-ended turn via the latest-ended tier. THE F1 vector.
+  subagent_handback: { decoupledCompletion: true },
+  // Everything below lands as its OWN live inbound turn (live tier), so its reply
+  // resolves the live tier for its own turnId and structurally cannot supersede a
+  // different ended turn's record → not a decoupled-completion vector, must not stamp.
+  cron: { decoupledCompletion: false },
+  reaction: { decoupledCompletion: false },
+  subagent_progress: { decoupledCompletion: false },
+  resume_interrupted: { decoupledCompletion: false },
+  resume_deferred: { decoupledCompletion: false },
+  resume_watchdog_timeout: { decoupledCompletion: false },
+  vault_grant_approved: { decoupledCompletion: false },
+  vault_grant_denied: { decoupledCompletion: false },
+  vault_grant_timeout: { decoupledCompletion: false },
+  vault_save_completed: { decoupledCompletion: false },
+  vault_save_discarded: { decoupledCompletion: false },
+  vault_save_failed: { decoupledCompletion: false },
+  vault_save_timeout: { decoupledCompletion: false },
+  secret_provided: { decoupledCompletion: false },
+  secret_declined: { decoupledCompletion: false },
+  secret_provide_failed: { decoupledCompletion: false },
+  secret_request_timeout: { decoupledCompletion: false },
+  mental_model_propose_timeout: { decoupledCompletion: false },
+  bridge_dead_restart: { decoupledCompletion: false },
+  obligation_represent: { decoupledCompletion: false },
+  missed_approval_retry: { decoupledCompletion: false },
+  skill_proposal_apply: { decoupledCompletion: false },
+  warmup: { decoupledCompletion: false },
 }
 
-export class SubagentHandbackMarker {
-  private readonly lastAtByLane = new Map<string, number>()
+/**
+ * Whether an inbound of this `meta.source` must stamp the decoupled-completion
+ * marker. Null/undefined (a normal user inbound — not synthesized) → false.
+ * A known source → its registry classification. An UNKNOWN source → true
+ * (fail-safe: stamp, so an unclassified future decoupled source can only cause a
+ * visible dup, never a silent edit-over).
+ */
+export function stampsHandbackMarker(source: string | null | undefined): boolean {
+  if (source == null) return false
+  const known = INBOUND_SOURCE_CLASSIFICATION[source]
+  if (known == null) return true // fail-safe: unknown synthesized source stamps
+  return known.decoupledCompletion
+}
 
-  /** Compose the lane key consistently with the supersede registry's
-   *  `makeKey(chatId, threadId)`: a bare chat id for the no-thread (DM) case,
-   *  `chatId|threadId` for a forum topic. Keeping these two keyings identical is
-   *  what makes the marker gate exactly the lane the supersede acts on. */
-  private lane(chatId: string, threadId: number | undefined): string {
-    return threadId == null ? chatId : `${chatId}|${threadId}`
+/** Sentinel thread key for the no-thread (DM / bare-chat) lane. */
+const MAIN_THREAD_KEY = '<main>'
+
+export class SubagentHandbackMarker {
+  // chatId → (threadKey → last enqueue ms). Nested so the CONTENT-GATE read can
+  // query chat-wide (`lastAtInChat`) while the record stays thread-resolved.
+  private readonly byChat = new Map<string, Map<string, number>>()
+
+  private threadKey(threadId: number | undefined): string {
+    return threadId == null ? MAIN_THREAD_KEY : String(threadId)
   }
 
   /** Record that a `subagent_handback` was enqueued for `chatId`/`threadId` at
-   *  `now` (ms). */
+   *  `now` (ms). Thread-resolved so the record retains the originating topic. */
   record(chatId: string, threadId: number | undefined, now: number): void {
-    this.lastAtByLane.set(this.lane(chatId, threadId), now)
+    let inner = this.byChat.get(chatId)
+    if (inner == null) {
+      inner = new Map<string, number>()
+      this.byChat.set(chatId, inner)
+    }
+    inner.set(this.threadKey(threadId), now)
   }
 
-  /** Wall-clock ms of the most recent handback enqueue for `chatId`/`threadId`,
-   *  or null. */
+  /** Wall-clock ms of the most recent handback enqueue for a SPECIFIC
+   *  `chatId`/`threadId` lane, or null. (Diagnostics / unit tests.) */
   lastAt(chatId: string, threadId: number | undefined): number | null {
-    return this.lastAtByLane.get(this.lane(chatId, threadId)) ?? null
+    return this.byChat.get(chatId)?.get(this.threadKey(threadId)) ?? null
+  }
+
+  /**
+   * Wall-clock ms of the most recent handback enqueue ANYWHERE in `chatId`
+   * (across every topic lane), or null. This is what the content-gate read uses
+   * (dup-audit MUST-FIX 2, Fable 2026-07-21): the owner-resolution latest-ended
+   * tier is CHAT-WIDE (`findLatestEndedTurnForChat` ignores thread), so a
+   * background handback in topic A can resolve — and supersede — topic B's
+   * ended turn. A thread-SPECIFIC gate read (the F2 regression) let a reply
+   * dodge that handback by carrying a different `message_thread_id`, silently
+   * editing over the answer. Querying chat-wide makes the gate un-steerable by
+   * the reply's own thread arg: any in-window handback in the chat keeps the
+   * content gate. The cost is the F2 visible-dup (a handback in one topic keeps
+   * the gate for a coinciding own-reply in another for ≤TTL) — a self-healing
+   * visible duplicate, which is strictly better than a silent edit-over.
+   */
+  lastAtInChat(chatId: string): number | null {
+    const inner = this.byChat.get(chatId)
+    if (inner == null || inner.size === 0) return null
+    let max = -Infinity
+    for (const ts of inner.values()) if (ts > max) max = ts
+    return max === -Infinity ? null : max
   }
 }

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -911,8 +911,8 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const owner = makeFlushDeliveredEndedTurn()
     seedRecord(h, owner)
     h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
-    // The gateway reads the marker the boot-replay stamped.
-    h.deps.getLastSubagentHandbackAt = (chatId, threadId) => marker.lastAt(chatId, threadId)
+    // The gateway reads the marker the boot-replay stamped (chat-wide gate).
+    h.deps.getLastSubagentHandbackAt = (chatId) => marker.lastAtInChat(chatId)
 
     const res = await sendReply(h.deps, req(HANDBACK))
 
@@ -938,18 +938,19 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     expect(marker.lastAt(CHAT, undefined)).toBe(null)
   })
 
-  // ─── F2 (dup-audit): thread-keyed marker — no cross-topic gate leak ───
+  // ─── MUST-FIX 2 (dup-audit / Fable): the gate is un-steerable by a model
+  //     thread arg — a cross-topic handback still keeps the content gate ───
   //
-  // The supersede registry is keyed on `chatId|threadId`; the marker used to key
-  // on `chatId` alone. In a forum supergroup a background handback in topic A
-  // stamped the chat-wide marker, so a genuine CASE-A reworded own-reply in topic
-  // B within 60 s kept the content gate and shipped a SECOND visible bubble
-  // instead of collapsing. Thread-keying confines the gate-hold to the topic the
-  // handback landed in. This drives the REAL buffer chokepoint (which now passes
-  // the envelope's threadId) + the REAL send path, and asserts topic B's
-  // delivered-message outcome is UNCHANGED by topic A's handback.
-  it('F2: a handback in forum topic A does NOT change topic B\'s CASE-A collapse ' +
-    '(delivered-count unchanged) — thread-keyed marker', async () => {
+  // Fable's PROVEN regression: F2's thread-keyed gate read let a foreign-content
+  // reply carrying `message_thread_id=<other topic>` dodge a handback marker
+  // stamped on the real topic → silent edit-over (the #3429 double-loss). Because
+  // `findLatestEndedTurnForChat` resolves owners CHAT-WIDE, a topic-A handback can
+  // resolve — and supersede — topic B's ended turn. The gate read is therefore
+  // chat-wide (`lastAtInChat`): any in-window handback in the chat keeps the gate,
+  // so the reply's own thread arg cannot bypass it. Drives the REAL buffer
+  // chokepoint + REAL send path.
+  it('MUST-FIX 2: a handback stamped in topic A keeps the content gate for a ' +
+    'foreign reply steered to topic B (message_thread_id) — FRESH send, no silent edit-over', async () => {
     const TOPIC_A = 111
     const TOPIC_B = 222
     const marker = new SubagentHandbackMarker()
@@ -957,38 +958,72 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
       log: () => {},
       onHandbackEnqueue: (chatId, threadId, ts) => marker.record(chatId, threadId, ts),
     })
-    // A background handback lands in TOPIC A (its envelope carries threadId=A).
+    // A background handback lands in TOPIC A (envelope threadId=A) via the real
+    // chokepoint — after topic B's turn ended (now-30s), within the 60s TTL.
     const handbackTs = Date.now() - 15_000
     buffer.push('marko', {
       type: 'inbound', chatId: CHAT, threadId: TOPIC_A, messageId: handbackTs,
       user: 'subagent-watcher', userId: 0, ts: handbackTs, text: 'handback',
       meta: { source: 'subagent_handback' },
     })
-    // Topic A is marked; topic B is NOT (the fix — pre-fix both were marked).
-    expect(marker.lastAt(CHAT, TOPIC_A)).toBe(handbackTs)
-    expect(marker.lastAt(CHAT, TOPIC_B)).toBe(null)
 
-    // A genuine CASE-A reworded own-reply now lands late in TOPIC B: latest-ended
-    // tier, and — because the marker is thread-keyed — NO handback is in flight
-    // for topic B, so it collapses the flushed draft to ONE message.
+    // Topic B has its OWN flush-delivered ended turn with a real answer.
     const h = makeHarness()
-    const owner = makeFlushDeliveredEndedTurn()
-    // Seed the flush record on topic B's lane.
+    const owner = { ...makeFlushDeliveredEndedTurn(), sessionThreadId: TOPIC_B } as unknown as CurrentTurn
     h.deps.flushedTurnSupersede.record(
       CHAT, TOPIC_B,
-      { turnId: owner.turnId, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
+      { turnId: (owner as CurrentTurn).turnId, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
       Date.now(),
     )
-    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
-    h.deps.getLastSubagentHandbackAt = (chatId, threadId) => marker.lastAt(chatId, threadId)
+    // The topic-A handback's reply is STEERED to topic B (message_thread_id=222)
+    // and resolves topic B's ended turn chat-wide (latest-ended), carrying FOREIGN
+    // content. The gate read is chat-wide, so the topic-A stamp is seen.
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner as CurrentTurn, tier: 'latest-ended' })
+    h.deps.getLastSubagentHandbackAt = (chatId) => marker.lastAtInChat(chatId)
 
     const res = await sendReply(
       h.deps,
-      req(REWORDED_SAME_TURN_ANSWER, { message_thread_id: TOPIC_B }),
+      req(HANDBACK, { message_thread_id: TOPIC_B }),
     )
 
-    // Topic B collapses to ONE message (edit-in-place) — topic A's handback did
-    // not leak its gate-hold into topic B.
+    // Gate kept → FRESH notifying send; topic B's flushed answer is NEITHER
+    // edited nor deleted. (Under the F2 thread-keyed gate this was editMessageText
+    // ×1 over msg 4242 — the silent-loss regression this closes.)
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+    // Topic B's flush record NOT consumed — the delivered answer stands.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, TOPIC_B, {
+        liveTurnId: (owner as CurrentTurn).turnId,
+        replyText: CANONICAL_REPLY,
+        now: Date.now(),
+      }).supersede,
+    ).toBe(true)
+  })
+
+  // Thread-keyed COLLAPSE still routes per-topic: a topic reply supersedes its
+  // OWN topic's flush record (via the framework-resolved owner thread, not the
+  // raw arg), so a genuine own-reply in a forum topic collapses to one message.
+  it('F2 positive: a topic own-reply (no handback) supersedes its own topic\'s ' +
+    'flush record — one message, on the framework-resolved thread lane', async () => {
+    const TOPIC = 222
+    const h = makeHarness()
+    const owner = { ...makeFlushDeliveredEndedTurn(), sessionThreadId: TOPIC } as unknown as CurrentTurn
+    // Flush recorded on the owner turn's OWN topic lane (what the flush does).
+    h.deps.flushedTurnSupersede.record(
+      CHAT, TOPIC,
+      { turnId: (owner as CurrentTurn).turnId, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
+      Date.now(),
+    )
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner as CurrentTurn, tier: 'latest-ended' })
+    h.deps.getLastSubagentHandbackAt = () => null // no handback anywhere
+
+    const res = await sendReply(h.deps, req(REWORDED_SAME_TURN_ANSWER, { message_thread_id: TOPIC }))
+
+    // Collapses to ONE message: the topic's flushed message edited in place.
     const edits = h.calls.filter((c) => c.method === 'editMessageText')
     expect(edits).toHaveLength(1)
     expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
@@ -1054,5 +1089,66 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     expect(stampsHandbackMarker('cron')).toBe(false)
     expect(stampsHandbackMarker('resume_interrupted')).toBe(false)
     expect(stampsHandbackMarker(undefined)).toBe(false)
+  })
+
+  // ─── MUST-FIX 1 (dup-audit / Fable): model-steerable tiers NEVER bypass ───
+  //
+  // The `quoted`/`origin` tiers resolve from MODEL-supplied args (reply_to /
+  // origin_turn_id), so a reply can steer ITSELF onto a different ended turn's
+  // record. Marker-absence proves "own answer" only for the framework-derived
+  // latest-ended tier — a quoted/origin resolution with no marker is NOT
+  // ownership evidence. Fable executed this exact path (quoted tier, no marker,
+  // foreign content → editMessageText ×1 over the flushed answer). With the tier
+  // restriction, quoted/origin ALWAYS traverse the content gate → foreign content
+  // sends FRESH, the flushed answer untouched. RED on pre-fix code
+  // (replyIsOwnAnswer = tier==='live' || !handbackCouldOwnReply → quoted bypassed).
+  it('MUST-FIX 1: a quoted-tier reply with NO marker and FOREIGN content does NOT ' +
+    'bypass the content gate — FRESH send, flushed answer never edited/deleted', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    // Model-steered `quoted` attribution to a DIFFERENT ended flushed turn, with
+    // NO decoupled completion anywhere in the chat (the residual F1 vector).
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'quoted' })
+    h.deps.getLastSubagentHandbackAt = () => null
+
+    const res = await sendReply(h.deps, req(HANDBACK))
+
+    // FRESH notifying send; the flushed answer is NEITHER edited nor deleted.
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.text).toContain('migration audit')
+    expect(fresh[0]!.message_id).not.toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+    // Flush record NOT consumed — the delivered answer stands.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        replyText: CANONICAL_REPLY,
+        now: Date.now(),
+      }).supersede,
+    ).toBe(true)
+  })
+
+  // Sibling positive: a quoted-tier reply carrying the turn's OWN answer (same
+  // content, contained in the flushed blob) still collapses through the content
+  // gate — the tier restriction only blocks FOREIGN content, not genuine replays.
+  it('MUST-FIX 1 sibling: a quoted-tier reply with the SAME answer still collapses ' +
+    '(content gate passes) — one message', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'quoted' })
+    h.deps.getLastSubagentHandbackAt = () => null
+
+    const res = await sendReply(h.deps, req(CANONICAL_REPLY))
+
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent/)
   })
 })

--- a/telegram-plugin/tests/send-reply-golden.test.ts
+++ b/telegram-plugin/tests/send-reply-golden.test.ts
@@ -46,7 +46,7 @@ import {
 } from '../gateway/outbound-send-path.js'
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
-import { SubagentHandbackMarker } from '../gateway/subagent-handback-marker.js'
+import { SubagentHandbackMarker, stampsHandbackMarker } from '../gateway/subagent-handback-marker.js'
 import { createPendingInboundBuffer } from '../gateway/pending-inbound-buffer.js'
 import { redact } from '../secret-detect/redact.js'
 import type { CurrentTurn, Access } from '../gateway/gateway.js'
@@ -887,7 +887,7 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const marker = new SubagentHandbackMarker()
     const buffer = createPendingInboundBuffer({
       log: () => {},
-      onHandbackEnqueue: (chatId, ts) => marker.record(chatId, ts),
+      onHandbackEnqueue: (chatId, threadId, ts) => marker.record(chatId, threadId, ts),
     })
 
     // Simulate the boot-replay re-push of an un-acked spooled handback envelope.
@@ -905,14 +905,14 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
       meta: { source: 'subagent_handback' },
     })
     // The chokepoint stamped the marker from the replay push (pre-fix: empty).
-    expect(marker.lastAt(CHAT)).toBe(handbackTs)
+    expect(marker.lastAt(CHAT, undefined)).toBe(handbackTs)
 
     const h = makeHarness()
     const owner = makeFlushDeliveredEndedTurn()
     seedRecord(h, owner)
     h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
     // The gateway reads the marker the boot-replay stamped.
-    h.deps.getLastSubagentHandbackAt = (chatId) => marker.lastAt(chatId)
+    h.deps.getLastSubagentHandbackAt = (chatId, threadId) => marker.lastAt(chatId, threadId)
 
     const res = await sendReply(h.deps, req(HANDBACK))
 
@@ -929,12 +929,130 @@ describe('#3429 — post-turn-end handback vs flush-delivered supersede (real se
     const marker = new SubagentHandbackMarker()
     const buffer = createPendingInboundBuffer({
       log: () => {},
-      onHandbackEnqueue: (chatId, ts) => marker.record(chatId, ts),
+      onHandbackEnqueue: (chatId, threadId, ts) => marker.record(chatId, threadId, ts),
     })
     buffer.push('marko', {
       type: 'inbound', chatId: CHAT, messageId: 5, user: 'ken', userId: 1,
       ts: Date.now(), text: 'hi', meta: {},
     })
-    expect(marker.lastAt(CHAT)).toBe(null)
+    expect(marker.lastAt(CHAT, undefined)).toBe(null)
+  })
+
+  // ─── F2 (dup-audit): thread-keyed marker — no cross-topic gate leak ───
+  //
+  // The supersede registry is keyed on `chatId|threadId`; the marker used to key
+  // on `chatId` alone. In a forum supergroup a background handback in topic A
+  // stamped the chat-wide marker, so a genuine CASE-A reworded own-reply in topic
+  // B within 60 s kept the content gate and shipped a SECOND visible bubble
+  // instead of collapsing. Thread-keying confines the gate-hold to the topic the
+  // handback landed in. This drives the REAL buffer chokepoint (which now passes
+  // the envelope's threadId) + the REAL send path, and asserts topic B's
+  // delivered-message outcome is UNCHANGED by topic A's handback.
+  it('F2: a handback in forum topic A does NOT change topic B\'s CASE-A collapse ' +
+    '(delivered-count unchanged) — thread-keyed marker', async () => {
+    const TOPIC_A = 111
+    const TOPIC_B = 222
+    const marker = new SubagentHandbackMarker()
+    const buffer = createPendingInboundBuffer({
+      log: () => {},
+      onHandbackEnqueue: (chatId, threadId, ts) => marker.record(chatId, threadId, ts),
+    })
+    // A background handback lands in TOPIC A (its envelope carries threadId=A).
+    const handbackTs = Date.now() - 15_000
+    buffer.push('marko', {
+      type: 'inbound', chatId: CHAT, threadId: TOPIC_A, messageId: handbackTs,
+      user: 'subagent-watcher', userId: 0, ts: handbackTs, text: 'handback',
+      meta: { source: 'subagent_handback' },
+    })
+    // Topic A is marked; topic B is NOT (the fix — pre-fix both were marked).
+    expect(marker.lastAt(CHAT, TOPIC_A)).toBe(handbackTs)
+    expect(marker.lastAt(CHAT, TOPIC_B)).toBe(null)
+
+    // A genuine CASE-A reworded own-reply now lands late in TOPIC B: latest-ended
+    // tier, and — because the marker is thread-keyed — NO handback is in flight
+    // for topic B, so it collapses the flushed draft to ONE message.
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    // Seed the flush record on topic B's lane.
+    h.deps.flushedTurnSupersede.record(
+      CHAT, TOPIC_B,
+      { turnId: owner.turnId, messageIds: [FLUSH_MSG_ID], text: FLUSHED_TEXT },
+      Date.now(),
+    )
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    h.deps.getLastSubagentHandbackAt = (chatId, threadId) => marker.lastAt(chatId, threadId)
+
+    const res = await sendReply(
+      h.deps,
+      req(REWORDED_SAME_TURN_ANSWER, { message_thread_id: TOPIC_B }),
+    )
+
+    // Topic B collapses to ONE message (edit-in-place) — topic A's handback did
+    // not leak its gate-hold into topic B.
+    const edits = h.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent/)
+  })
+
+  // ─── F1 (dup-audit): negative outcome guard — no silent edit-over ───
+  //
+  // The content-gate bypass must NEVER silently edit over a flush-delivered
+  // answer with FOREIGN content on a non-live tier. A decoupled completion (the
+  // handback class the marker covers) landing with genuinely different content,
+  // resolving an ended flushed turn via the latest-ended tier, must SEND FRESH —
+  // the flushed answer left untouched (Telegram edits do not re-notify, so an
+  // edit-over is a silent double-loss: the handback never surfaces AND the answer
+  // is destroyed — the #3429 incident). This pins the invariant's OUTCOME: the
+  // stamp (driven by the single chokepoint predicate) keeps the gate, and the
+  // foreign reply never touches the delivered answer.
+  it('F1: a decoupled foreign-content reply on a non-live tier resolving a ' +
+    'DIFFERENT ended turn sends FRESH — the flushed answer is never edited/deleted', async () => {
+    const h = makeHarness()
+    const owner = makeFlushDeliveredEndedTurn()
+    seedRecord(h, owner)
+    // The reply resolves the flush-delivered ENDED turn via the ambiguous
+    // latest-ended tier (no live turn, no positive attribution) and carries
+    // FOREIGN content (a worker report, not this turn's answer nor a rewording).
+    h.deps.resolveReplyOwnerTurn = () => ({ turn: owner, tier: 'latest-ended' })
+    // A decoupled completion IS in the window (the marker stamped it) — so this
+    // late reply might BE it. The invariant keeps the content gate.
+    h.deps.getLastSubagentHandbackAt = () => Date.now() - 15_000
+
+    const res = await sendReply(h.deps, req(HANDBACK))
+
+    // FRESH notifying send; the flushed answer is NEITHER edited nor deleted.
+    const fresh = h.calls.filter((c) => c.method === 'sendRichMessage')
+    expect(fresh).toHaveLength(1)
+    expect(fresh[0]!.text).toContain('migration audit')
+    expect(fresh[0]!.message_id).not.toBe(FLUSH_MSG_ID)
+    expect(h.calls.filter((c) => c.method === 'editMessageText')).toHaveLength(0)
+    expect(h.calls.filter((c) => c.method === 'deleteMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent \(id: \d+\)$/)
+    // The flush record is NOT consumed — the flushed answer stands, and the
+    // turn's OWN canonical replay can still correct it.
+    expect(
+      h.deps.flushedTurnSupersede.peek(CHAT, undefined, {
+        liveTurnId: OWNER_TURN_ID,
+        replyText: CANONICAL_REPLY,
+        now: Date.now(),
+      }).supersede,
+    ).toBe(true)
+  })
+
+  // Structural: the stamp membership lives in exactly ONE predicate, consulted
+  // at the ONE buffer chokepoint. If a future refactor inlines a bare
+  // `=== 'subagent_handback'` check at the chokepoint (bypassing the predicate),
+  // the invariant's single-extension-point guarantee is lost — fail loudly.
+  it('F1: the buffer chokepoint stamps via the stampsHandbackMarker predicate, ' +
+    'not an inlined source literal', () => {
+    const bufferSrc = readFileSync(new URL('../gateway/pending-inbound-buffer.ts', import.meta.url), 'utf8')
+    expect(bufferSrc).toContain('stampsHandbackMarker(msg.meta?.source)')
+    // The predicate itself is the single membership definition.
+    expect(stampsHandbackMarker('subagent_handback')).toBe(true)
+    expect(stampsHandbackMarker('cron')).toBe(false)
+    expect(stampsHandbackMarker('resume_interrupted')).toBe(false)
+    expect(stampsHandbackMarker(undefined)).toBe(false)
   })
 })

--- a/telegram-plugin/tests/stream-render-golden.test.ts
+++ b/telegram-plugin/tests/stream-render-golden.test.ts
@@ -56,7 +56,12 @@ function makeFakeBot() {
   const api = {
     sendRichMessage: async (c: string, b: { markdown: string }, o: Record<string, unknown> = {}) => rec('sendRichMessage', c, b.markdown, o),
     sendMessage: async (c: string, t: string, o: Record<string, unknown> = {}) => rec('sendMessage', c, t, o),
-    editMessageText: async (c: string, m: number, b: unknown, o: Record<string, unknown> = {}) => { rec('editMessageText', c, typeof b === 'string' ? b : (b as { markdown: string }).markdown, o); return {} },
+    editMessageText: async (c: string, m: number, b: unknown, o: Record<string, unknown> = {}) => {
+      // Preserve the REAL edit target id (m) so tests can assert an edit-in-place
+      // hit the flushed message, not a synthetic fresh id.
+      calls.push({ method: 'editMessageText', chat_id: c, text: typeof b === 'string' ? b : (b as { markdown: string }).markdown, opts: o, reply_markup: o.reply_markup ?? null, message_id: m })
+      return {}
+    },
     deleteMessage: async (c: string, m: number) => { rec('deleteMessage', c, null); return true },
   }
   return { api, calls }
@@ -100,6 +105,7 @@ function makeStreamDeps(opts?: {
   dedup?: OutboundDedupCache
   turn?: CurrentTurn | null
   deliverResult?: { sentIds: number[]; chunkCount: number; delivered: boolean; exhausted: boolean }
+  flushedTurnSupersede?: FlushedTurnSupersedeRegistry
 }): StreamHarness {
   const { api, calls } = makeFakeBot()
   const dedup = opts?.dedup ?? new OutboundDedupCache()
@@ -135,7 +141,7 @@ function makeStreamDeps(opts?: {
     activeTurnStartedAt: new Map(),
     backstopDeliveryLedger: ledger,
     bot: { api },
-    flushedTurnSupersede: new FlushedTurnSupersedeRegistry(),
+    flushedTurnSupersede: opts?.flushedTurnSupersede ?? new FlushedTurnSupersedeRegistry(),
     idleTracker: { noteEvent: noop },
     lastPtyPreviewByChat: new Map(),
     obligationLedger: { close: noop, noteTurnEnded: noop },
@@ -206,12 +212,12 @@ function makeStreamDeps(opts?: {
 }
 
 // ── the P2 sendReply harness (same content, sharing the ONE cache) ─────────
-function makeSendReplyDeps(dedup: OutboundDedupCache) {
+function makeSendReplyDeps(dedup: OutboundDedupCache, sharedSupersede?: FlushedTurnSupersedeRegistry) {
   const { api, calls } = makeFakeBot()
   const key = (c: string, t?: number | null) => `${c}:${t ?? 'main'}`
   const deps = {
     outboundDedup: dedup,
-    flushedTurnSupersede: new FlushedTurnSupersedeRegistry(),
+    flushedTurnSupersede: sharedSupersede ?? new FlushedTurnSupersedeRegistry(),
     firstTextReplyLogged: new Set<string>(),
     suppressPtyPreview: new Set<string>(),
     activeDraftStreams: new Map(),
@@ -383,6 +389,136 @@ describe('cross-surface dedup — ONE OutboundDedupCache across P4 stream + P2 r
     const s = makeSendReplyDeps(new OutboundDedupCache())
     await sendReply(s.deps, req(answer))
     expect(s.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(1)
+  })
+})
+
+// ── F3 (dup-audit 2026-07-21): the flush RECORD wiring is load-bearing ──────
+//
+// The entire flush→reply dedup depends on stream-render.ts recording the
+// flush's delivered ids into the shared FlushedTurnSupersedeRegistry
+// (`flushedTurnSupersede.record(...)`). Every OTHER outcome test seeds that
+// record by hand (send-reply-golden's seedRecord/seedFlushRecord), so DELETING
+// the record call would reintroduce the dominant flush→reply duplicate with all
+// those tests still green. This drives the REAL flush record() end-to-end (no
+// pre-seed) across ONE shared registry and asserts the reworded same-turn reply
+// collapses to EXACTLY ONE message — so it goes RED if the record() call is
+// removed. This is the guard the audit flagged as missing.
+describe('F3 — flush record() → same-turn reworded reply collapse (end-to-end, no pre-seed)', () => {
+  const settleFlush = () => new Promise((r) => setTimeout(r, 650))
+  const FLUSHED_ANSWER =
+    'All twelve agents are healthy right now. The gateway, the vault broker and the ' +
+    'approval kernel all report green health checks, and no container has restarted in ' +
+    'the last twenty four hours, so there is nothing that needs your attention at the moment.'
+  const REWORDED =
+    'Good news on the fleet. Every one of the twelve agents is running fine at the moment. ' +
+    'Gateway, vault broker and approval kernel are all green, and nothing has restarted in ' +
+    'the past day, so you do not need to do anything right now.'
+
+  it('flush → record → late reworded reply collapses to ONE message ' +
+    '(RED if stream-render flushedTurnSupersede.record is removed)', async () => {
+    // ONE shared supersede registry across BOTH surfaces — exactly the gateway
+    // singleton wiring. The flush RECORDS (the real stream-render.ts:1828 call);
+    // the reply CONSUMES. Nothing is pre-seeded.
+    const supersede = new FlushedTurnSupersedeRegistry()
+    const turn = makeTurn({ capturedText: [FLUSHED_ANSWER], capturedBlockMeta: [true] })
+    const sh = makeStreamDeps({ turn, flushedTurnSupersede: supersede })
+
+    // Drive the REAL turn-flush path: it delivers message A (deliverAnswer → id
+    // 4242) AND records {turnId, [4242]} into the shared registry.
+    handleSessionEvent(sh.deps, { kind: 'turn_end', durationMs: 1200 })
+    await settleFlush()
+    expect(sh.delivered).toContain(FLUSHED_ANSWER)
+    // The record actually landed (this is what a removal breaks first).
+    expect(
+      supersede.peek(CHAT, undefined, { liveTurnId: turn.turnId, now: Date.now() }).reason,
+    ).toBe('supersede')
+
+    // The model's REAL reply lands late with a REWORDED version of the same
+    // answer: no live turn, latest-ended tier, NO handback in flight (CASE A).
+    const s = makeSendReplyDeps(new OutboundDedupCache(), supersede)
+    s.deps.resolveReplyOwnerTurn = () => ({ turn, tier: 'latest-ended' as const })
+    // (getLastSubagentHandbackAt returns null in the base deps → own answer.)
+
+    const res = await sendReply(s.deps, req(REWORDED))
+
+    // EXACTLY ONE client-visible message: the flushed message (4242) edited in
+    // place into the reworded reply — NO fresh second bubble. Without the
+    // record(), the reply finds no record, falls to the latch branch, sees
+    // reworded ≠ flushed content, does NOT suppress, and ships a DUPLICATE
+    // sendRichMessage (edits=0, sends=1) → these assertions fail.
+    const edits = s.calls.filter((c) => c.method === 'editMessageText')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.message_id).toBe(4242)
+    expect(s.calls.filter((c) => c.method === 'sendRichMessage')).toHaveLength(0)
+    expect(res.content[0]!.text).toMatch(/^sent/)
+  })
+})
+
+// ── F5 (dup-audit): true take()-before-record() interleaving ────────────────
+//
+// The residual race the supersede registry cannot reach: a reply whose
+// supersede take() runs in the window AFTER the flush FIRED but BEFORE it
+// recorded its message ids. The flush arms `turn.answerDelivered='flush'` (+
+// flushedAnswerText) SYNCHRONOUSLY at fire time — before its async deliver and
+// before record — so a same-answer reply landing in that window is suppressed by
+// the latch, not shipped as a duplicate. This drives a genuine two-emitter
+// interleave (inverted ordering: reply take() strictly before flush record())
+// and asserts exactly one delivered message.
+describe('F5 — take()-before-record() interleaving delivers exactly one message', () => {
+  const settleFlush = () => new Promise((r) => setTimeout(r, 650))
+  // ≥200 chars so the late reply is a substantive final answer (the floor the
+  // flush latch is scoped to) — else it would never trip the suppression.
+  const ANSWER =
+    'Yes, that is all done and confirmed. The migration ran cleanly against the staging ' +
+    'database, every integration check passed on the first attempt, the rollback plan is ' +
+    'staged in case it is ever needed, and I have written the full run log to the shared ' +
+    'drive so the team can review exactly what changed and when it happened.'
+
+  it('a reply whose take() runs BEFORE the flush record() is suppressed by the ' +
+    'flush-armed latch — one delivered message, not two', async () => {
+    const supersede = new FlushedTurnSupersedeRegistry()
+    const turn = makeTurn({ capturedText: [ANSWER], capturedBlockMeta: [true] })
+    const sh = makeStreamDeps({ turn, flushedTurnSupersede: supersede })
+
+    // Fire the flush. Its latch is set SYNCHRONOUSLY here; deliverAnswer + record
+    // run in the async IIFE that has NOT completed — the pre-record window.
+    handleSessionEvent(sh.deps, { kind: 'turn_end', durationMs: 1200 })
+    // INVERTED ORDERING: the reply's take() runs now, before the flush record().
+    expect(
+      supersede.peek(CHAT, undefined, { liveTurnId: turn.turnId, now: Date.now() }).reason,
+    ).toBe('no-record') // record genuinely not written yet
+
+    const s = makeSendReplyDeps(new OutboundDedupCache(), supersede)
+    s.deps.resolveReplyOwnerTurn = () => ({ turn, tier: 'latest-ended' as const })
+    // The same answer landing again in the race window → latch backstop suppresses.
+    const res = await sendReply(s.deps, req(ANSWER))
+
+    expect(s.calls).toHaveLength(0) // the reply shipped nothing
+    expect(res.content[0]!.text).toContain('deduped')
+
+    await settleFlush() // let the flush's async deliver + record complete
+    // Exactly one message reached the user: the flush's message A.
+    expect(sh.delivered).toHaveLength(1)
+    expect(sh.delivered[0]).toContain('done and confirmed')
+  })
+})
+
+// ── Double-flush idempotency at the delivery primitive (audit §3.5) ─────────
+//
+// The E2-vs-E3 double flush (answer-ready quiescence THEN turn-end backstop for
+// the SAME turn) is guarded by backstopDeliveryLedger.claim. The ledger is
+// unit-tested, but the audit wanted it pinned at the SEND-COUNT level in the
+// flush integration. Two turn_end dispatches for one turn must deliver once.
+describe('double-flush idempotency — deliverAnswer fires once (send-count level)', () => {
+  const settleFlush = () => new Promise((r) => setTimeout(r, 650))
+  it('two turn_end dispatches for the same turn deliver the answer EXACTLY once', async () => {
+    const turn = makeTurn()
+    const answer = turn.capturedText.join('')
+    const sh = makeStreamDeps({ turn })
+    handleSessionEvent(sh.deps, { kind: 'turn_end', durationMs: 1200 }) // claims the latch
+    handleSessionEvent(sh.deps, { kind: 'turn_end', durationMs: 1200 }) // claim fails → no-op
+    await settleFlush()
+    expect(sh.delivered).toEqual([answer])
   })
 })
 

--- a/telegram-plugin/tests/subagent-handback-marker.test.ts
+++ b/telegram-plugin/tests/subagent-handback-marker.test.ts
@@ -114,19 +114,39 @@ describe('inbound source classification (F1 durability)', () => {
   // The real tripwire: scan the gateway for meta.source literals and FAIL when a
   // new one is added without a registry classification. The grep-the-predicate
   // structural test could not catch rot; this does.
-  it('exhaustiveness: every gateway meta.source literal is classified in the registry', () => {
+  it('exhaustiveness: every gateway-inbound meta.source literal is classified in the registry', () => {
     const gatewayDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'gateway')
+    const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
     // `source:` fields that are NOT inbound meta.source tags (config cascade, the
     // model-source selector, doc comments, typeof guards). Allowlisted so a
     // genuinely new INBOUND source still trips this guard.
     const NON_INBOUND_SOURCE_LITERALS = new Set([
       'env', 'config', 'default', 'transcript', 'override', 'gateway', 'cli', 'string', 'github',
     ])
-    const files = readdirSync(gatewayDir).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+    // The scan surface = every gateway module PLUS the out-of-gateway inbound
+    // builders whose synthesized inbounds are delivered THROUGH the gateway
+    // (dup-audit pass-2 / Fable): `src/web/webhook-dispatch.ts` builds the
+    // `webhook` / `linear` inbounds injected via `webhookInject` → the same
+    // buffer chokepoint. Grep for other `meta:`+`source:` inbound builders if new
+    // dirs appear.
+    const files: string[] = [
+      ...readdirSync(gatewayDir)
+        .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+        .map((f) => join(gatewayDir, f)),
+      join(repoRoot, 'src', 'web', 'webhook-dispatch.ts'),
+    ]
     const found = new Set<string>()
-    const patterns = [/source:\s*'([a-z_]+)'/g, /meta\??\.source\s*===\s*'([a-z_]+)'/g]
+    // Catch BOTH quote styles and full source spellings (digits / underscores /
+    // any case) — a single-quote-only, `[a-z_]+`-only regex silently missed the
+    // double-quoted `mental_model_proposal_*` and the out-of-gateway webhook
+    // sources (pass-2 porosity). Variable-valued `source: expr` stays structurally
+    // invisible; the fail-safe stamp default is the safety boundary, not this scan.
+    const patterns = [
+      /source:\s*['"]([A-Za-z0-9_]+)['"]/g,
+      /meta\??\.source\s*===\s*['"]([A-Za-z0-9_]+)['"]/g,
+    ]
     for (const f of files) {
-      const src = readFileSync(join(gatewayDir, f), 'utf8')
+      const src = readFileSync(f, 'utf8')
       for (const re of patterns) {
         let m: RegExpExecArray | null
         while ((m = re.exec(src)) != null) found.add(m[1]!)

--- a/telegram-plugin/tests/subagent-handback-marker.test.ts
+++ b/telegram-plugin/tests/subagent-handback-marker.test.ts
@@ -1,9 +1,10 @@
 /**
- * Unit coverage for the per-chat subagent-handback marker
- * (fix/backstop-duplicate-reply). The marker is the deterministic signal the
- * supersede path uses to tell a flushed turn's OWN reworded late reply (no
- * handback in flight → supersede) from a background handback attributed to that
- * ended turn (handback in flight → keep the #3429 content gate).
+ * Unit coverage for the per-chat/thread subagent-handback marker
+ * (fix/backstop-duplicate-reply; thread-keying — dup-audit F2 2026-07-21). The
+ * marker is the deterministic signal the supersede path uses to tell a flushed
+ * turn's OWN reworded late reply (no handback in flight → supersede) from a
+ * background handback attributed to that ended turn (handback in flight → keep
+ * the #3429 content gate).
  */
 
 import { describe, it, expect } from 'vitest'
@@ -12,25 +13,49 @@ import { SubagentHandbackMarker } from '../gateway/subagent-handback-marker.js'
 describe('SubagentHandbackMarker', () => {
   it('returns null for a chat with no recorded handback', () => {
     const m = new SubagentHandbackMarker()
-    expect(m.lastAt('chatA')).toBe(null)
+    expect(m.lastAt('chatA', undefined)).toBe(null)
   })
 
   it('returns the recorded enqueue ts for the chat', () => {
     const m = new SubagentHandbackMarker()
-    m.record('chatA', 1_000_000)
-    expect(m.lastAt('chatA')).toBe(1_000_000)
+    m.record('chatA', undefined, 1_000_000)
+    expect(m.lastAt('chatA', undefined)).toBe(1_000_000)
   })
 
   it('is per-chat — one chat never leaks into another', () => {
     const m = new SubagentHandbackMarker()
-    m.record('chatA', 1_000_000)
-    expect(m.lastAt('chatB')).toBe(null)
+    m.record('chatA', undefined, 1_000_000)
+    expect(m.lastAt('chatB', undefined)).toBe(null)
   })
 
   it('keeps only the MOST RECENT enqueue (overwrites)', () => {
     const m = new SubagentHandbackMarker()
-    m.record('chatA', 1_000_000)
-    m.record('chatA', 1_050_000)
-    expect(m.lastAt('chatA')).toBe(1_050_000)
+    m.record('chatA', undefined, 1_000_000)
+    m.record('chatA', undefined, 1_050_000)
+    expect(m.lastAt('chatA', undefined)).toBe(1_050_000)
+  })
+
+  // ── F2: thread-keying (dup-audit 2026-07-21) ────────────────────────────
+  it('is per-THREAD — a handback in topic A does not leak into topic B', () => {
+    const m = new SubagentHandbackMarker()
+    m.record('chatA', 111, 1_000_000)
+    // Same chat, different topic → no marker: topic B's CASE-A collapse is
+    // untouched by topic A's handback (the visible-dup gap F2 closed).
+    expect(m.lastAt('chatA', 222)).toBe(null)
+    expect(m.lastAt('chatA', 111)).toBe(1_000_000)
+  })
+
+  it('a thread handback does not leak into the DM (no-thread) lane of the same chat', () => {
+    const m = new SubagentHandbackMarker()
+    m.record('chatA', 111, 1_000_000)
+    expect(m.lastAt('chatA', undefined)).toBe(null)
+  })
+
+  it('the no-thread lane keys identically to the supersede registry (chat only)', () => {
+    const m = new SubagentHandbackMarker()
+    m.record('chatA', undefined, 1_000_000)
+    // A later thread read must NOT see the DM stamp, and vice-versa.
+    expect(m.lastAt('chatA', undefined)).toBe(1_000_000)
+    expect(m.lastAt('chatA', 111)).toBe(null)
   })
 })

--- a/telegram-plugin/tests/subagent-handback-marker.test.ts
+++ b/telegram-plugin/tests/subagent-handback-marker.test.ts
@@ -8,7 +8,14 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { SubagentHandbackMarker } from '../gateway/subagent-handback-marker.js'
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import {
+  SubagentHandbackMarker,
+  stampsHandbackMarker,
+  INBOUND_SOURCE_CLASSIFICATION,
+} from '../gateway/subagent-handback-marker.js'
 
 describe('SubagentHandbackMarker', () => {
   it('returns null for a chat with no recorded handback', () => {
@@ -57,5 +64,82 @@ describe('SubagentHandbackMarker', () => {
     // A later thread read must NOT see the DM stamp, and vice-versa.
     expect(m.lastAt('chatA', undefined)).toBe(1_000_000)
     expect(m.lastAt('chatA', 111)).toBe(null)
+  })
+
+  // ── MUST-FIX 2 (dup-audit / Fable): chat-wide gate read ─────────────────
+  it('lastAtInChat returns the MOST RECENT handback across ALL topics of a chat', () => {
+    const m = new SubagentHandbackMarker()
+    m.record('chatA', 111, 1_000)
+    m.record('chatA', 222, 3_000)
+    m.record('chatA', undefined, 2_000)
+    expect(m.lastAtInChat('chatA')).toBe(3_000)
+    expect(m.lastAtInChat('chatB')).toBe(null)
+  })
+
+  it('lastAtInChat makes the gate un-steerable: a topic-A stamp is seen chat-wide ' +
+    'even when a thread-specific read of topic B would miss it', () => {
+    const m = new SubagentHandbackMarker()
+    m.record('chatA', 111, 5_000)
+    // The content gate reads chat-wide → sees topic A's handback…
+    expect(m.lastAtInChat('chatA')).toBe(5_000)
+    // …whereas a thread-specific read of topic 222 (the F2 regression) missed it,
+    // which is exactly how a steered `message_thread_id` bypassed the gate.
+    expect(m.lastAt('chatA', 222)).toBe(null)
+  })
+})
+
+// ── MUST-FIX 3 (dup-audit / Fable): fail-safe classification + exhaustiveness ──
+describe('inbound source classification (F1 durability)', () => {
+  it('stampsHandbackMarker: subagent_handback stamps; other known sources do not', () => {
+    expect(stampsHandbackMarker('subagent_handback')).toBe(true)
+    expect(stampsHandbackMarker('cron')).toBe(false)
+    expect(stampsHandbackMarker('reaction')).toBe(false)
+    expect(stampsHandbackMarker('resume_interrupted')).toBe(false)
+    expect(stampsHandbackMarker('vault_grant_approved')).toBe(false)
+  })
+
+  it('a normal user inbound (no meta.source) never stamps', () => {
+    expect(stampsHandbackMarker(null)).toBe(false)
+    expect(stampsHandbackMarker(undefined)).toBe(false)
+  })
+
+  it('FAIL-SAFE default: an UNKNOWN synthesized source STAMPS (visible dup, never ' +
+    'silent edit-over)', () => {
+    // The unsafe old default (deny → no stamp → bypass eligible → silent loss)
+    // is inverted: an unclassified future decoupled source keeps the content gate.
+    expect(stampsHandbackMarker('some_future_decoupled_source')).toBe(true)
+    expect(stampsHandbackMarker('another_unclassified_source')).toBe(true)
+  })
+
+  // The real tripwire: scan the gateway for meta.source literals and FAIL when a
+  // new one is added without a registry classification. The grep-the-predicate
+  // structural test could not catch rot; this does.
+  it('exhaustiveness: every gateway meta.source literal is classified in the registry', () => {
+    const gatewayDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'gateway')
+    // `source:` fields that are NOT inbound meta.source tags (config cascade, the
+    // model-source selector, doc comments, typeof guards). Allowlisted so a
+    // genuinely new INBOUND source still trips this guard.
+    const NON_INBOUND_SOURCE_LITERALS = new Set([
+      'env', 'config', 'default', 'transcript', 'override', 'gateway', 'cli', 'string', 'github',
+    ])
+    const files = readdirSync(gatewayDir).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+    const found = new Set<string>()
+    const patterns = [/source:\s*'([a-z_]+)'/g, /meta\??\.source\s*===\s*'([a-z_]+)'/g]
+    for (const f of files) {
+      const src = readFileSync(join(gatewayDir, f), 'utf8')
+      for (const re of patterns) {
+        let m: RegExpExecArray | null
+        while ((m = re.exec(src)) != null) found.add(m[1]!)
+      }
+    }
+    const unclassified = [...found]
+      .filter((s) => !NON_INBOUND_SOURCE_LITERALS.has(s))
+      .filter((s) => INBOUND_SOURCE_CLASSIFICATION[s] == null)
+      .sort()
+    // If this fails: a new meta.source literal was added. Classify it in
+    // INBOUND_SOURCE_CLASSIFICATION (decoupledCompletion true ONLY if its reply
+    // can land as a late reply with no live turn of its own), or — if it is a
+    // non-inbound `source:` field — add it to NON_INBOUND_SOURCE_LITERALS.
+    expect(unclassified).toEqual([])
   })
 })


### PR DESCRIPTION
Hardens the duplicate-Telegram-reply defense per the hostile dup-audit (v0.19.6). The core DM duplicate is genuinely fixed and outcome-guarded; this closes the gaps that left the *defense* not self-enforcing. Does **not** weaken the CASE A / CASE B golden tests or regress the core DM fix.

## What changed, per finding

### F3 — the load-bearing guard (flush→record wiring had no outcome test)
Every existing outcome test manually seeds the supersede record (`seedRecord`/`seedFlushRecord`), so deleting `stream-render.ts`'s `flushedTurnSupersede.record(...)` regressed the dominant flush→reply duplicate with all tests green. Added an **end-to-end** outcome test (`stream-render-golden.test.ts`) that drives the REAL turn-flush `record()` into a **shared** `FlushedTurnSupersedeRegistry` across both surfaces (no pre-seed), then a same-turn reworded reply through the REAL `sendReply`, asserting exactly ONE delivered message (edit-in-place, zero fresh bubbles). **Proven RED when the `record()` call is removed.**

### F2 — thread-key the handback marker (visible-dup)
The marker keyed on `chatId` alone while the supersede registry keys on `chatId|threadId`; a handback in one forum topic held the #3429 content gate open in *every* topic for 60 s. Thread-keyed the marker (same lane as the registry); buffer chokepoint passes the envelope's `threadId`, read path passes the reply thread. Outcome test: a handback in topic A does not change topic B's CASE-A collapse.

### F1 — enforce the invariant by construction (silent-data-loss class)
Made "a decoupled late-reply source stamps the marker" an **enforced invariant**: the stamp decision flows through one exported predicate `stampsHandbackMarker(source)` consulted at the single `pendingInboundBuffer.push` chokepoint every inbound funnels through — the sole extension point for the decoupled-completion class. Added a **negative outcome guard** (decoupled foreign content, non-live tier, resolving a different ended turn → FRESH send, flushed answer untouched) and a structural guard pinning the chokepoint uses the predicate, not an inlined literal.

> Honest divergence: the audit's literal F1 wording ("no handback → fresh send") conflicts with the marko fix (a reworded own-reply with no decoupled source in window must collapse). The durable resolution is option (a): guarantee every decoupled source stamps, so marker-absence provably means "own answer." The negative guard pins the outcome with a decoupled source present + foreign content, plus single-chokepoint enforcement.

### F5 + double-flush idempotency
True two-emitter **take()-before-record() interleaving** test (inverted ordering) asserting exactly one delivered message via the flush-armed latch, plus a double-flush idempotency assertion at the `deliverAnswer` send-count level.

## Red→green proof
- **F3**: RED when `stream-render.ts` `record(...)` deleted (verified); GREEN with it.
- **F2**: RED under per-chat keying (verified); GREEN thread-keyed.
- **F5 / double-flush**: GREEN, exercising the real flush path.

## Tests + lint
- Scoped vitest: 7 files, **189 passed**.
- `npm run lint`: clean (tsc + all guard scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)