### PR TITLE
fix(telegram): universal accidental-formatting guard transformer

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -295,7 +295,7 @@ import {
 } from '../retry-api-call.js'
 import { createSendGate, sendGateConfigFromEnv, isSendGateShed } from '../send-gate.js'
 import { createStatsLogger, createFloodWindowObserver } from '../send-gate-observability.js'
-import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
+import { installTgPostLogger, installRichMarkdownGuard, withTgPostTags } from '../shared/bot-runtime.js'
 import {
   floodStatePath,
   floodWindowsPath,
@@ -22970,7 +22970,7 @@ async function initGatewayBot(): Promise<void> {
   }
 
   bot = new Bot(TOKEN)
-  installTgPostLogger(bot)
+  installTgPostLogger(bot); installRichMarkdownGuard(bot) // #3252/#3463: universal fmt guard installed after logger (composes outermost); see installRichMarkdownGuard docblock
 
   // Diagnostic update tap (#3300): one compact line per received update, logged
   // BEFORE any specific handler runs, so a routing-layer drop is diagnosable

--- a/telegram-plugin/rich-send.ts
+++ b/telegram-plugin/rich-send.ts
@@ -67,16 +67,22 @@ export function guardAccidentalFormatting(markdown: string): string {
 /**
  * Wrap raw GFM markdown into the rich-message input object.
  *
- * This is the ONE adapter every `{ markdown }` wire send funnels through
- * (`sendRichMessage` / `editMessageText({ markdown })`) — the reply-tool final
- * answer, draft-stream previews, cards, approvals, banners. It is therefore the
- * single deterministic seam for the #3252 accidental-formatting guards (F1):
- * applying `guardAccidentalFormatting` here guards EVERY markdown-parsed
- * outbound exactly once, without touching `plain`-mode degradations (which
- * bypass this wrapper and go straight to `sendMessage`, where no markdown
- * parsing happens). The composed guard is a strict no-op for any body without
- * an accidental-formatting signal and is idempotent, so callers that already
- * ran it (or the streaming path that renders then re-wraps) stay byte-identical.
+ * This is a CONVENIENCE adapter — NOT the universal seam. It applies
+ * `guardAccidentalFormatting` for the many callers that build a body through
+ * it (the reply-tool final answer, draft-stream previews, cards), but it is
+ * NOT the one place every `{ markdown }` wire send funnels through: several
+ * sites build a raw `{ markdown }` and call `sendRichMessage` /
+ * `editMessageText` directly, bypassing this wrapper (see the correctness
+ * audit's F1 list — banners, switchroomReply html, approval/folder-picker
+ * edits). The REAL universal seam for the #3252 accidental-formatting guards
+ * is the grammy API transformer `installRichMarkdownGuard`
+ * (`shared/bot-runtime.ts`), installed on the production Bot in gateway boot,
+ * which guards EVERY sendRichMessage/editMessageText payload regardless of the
+ * call site. This wrapper is kept belt-and-braces: the composed guard is a
+ * strict no-op for any body without an accidental-formatting signal and is
+ * idempotent, so a body guarded here and re-guarded by the transformer stays
+ * byte-identical. `plain`-mode degradations bypass both (they go straight to
+ * `sendMessage`, where no markdown parsing happens).
  */
 export function richMessage(markdown: string): InputRichMessageMarkdown {
   return { markdown: guardAccidentalFormatting(markdown) }

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -32,6 +32,7 @@ import { createRetryApiCall } from '../retry-api-call.js'
 import { makeFloodWaitRecorder, makeFloodWaitProbe } from '../flood-circuit-breaker.js'
 import { RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { shouldEmitTgPost } from './gw-trace-gate.js'
+import { guardAccidentalFormatting } from '../rich-send.js'
 
 // ─── tg-post tag plumbing ─────────────────────────────────────────────────
 
@@ -144,6 +145,62 @@ export function installTgPostLogger(bot: Bot): void {
       )
       throw err
     }
+  })
+}
+
+/**
+ * Universal accidental-formatting guard, installed as a grammy API transformer
+ * on the single production Bot (#3252/#3463 follow-up). This is the REAL
+ * universal seam — not `richMessage()`. `richMessage()` only guards bodies its
+ * callers remember to wrap; the correctness audit found ~6 sites that build a
+ * raw `{ markdown }` and call `sendRichMessage` / `editMessageText` directly,
+ * bypassing it (`shared/bot-runtime.ts` switchroomReply html path,
+ * `slot-banner-driver.ts` OAuth banners, and edits in `folder-picker-handler`,
+ * `approval-callback`, `inline-keyboard-callbacks`). A transformer at the
+ * grammy `bot.api.config.use` layer sees every rich send regardless of the
+ * call site, `ctx.*` sugar, `lockedBot`, or `bot.api.raw`, so it closes the
+ * whole bypass class deterministically.
+ *
+ * Payload shape (verified against grammy 1.44.0 `out/core/api.js`, the pinned
+ * lockfile version):
+ *   - `sendRichMessage(chat_id, rich_message, ...)` → raw payload
+ *     `{ chat_id, rich_message: { markdown }, ... }`
+ *   - `editMessageText(chat_id, message_id, arg, ...)` → raw payload
+ *     `{ ..., rich_message: { markdown } }` when `arg` is an object, or
+ *     `{ ..., text }` when `arg` is a plain string.
+ * The markdown therefore lives at `payload.rich_message.markdown`, NOT
+ * `payload.markdown` (gating on the latter matches nothing — a silent no-op).
+ * Gating on `rich_message?.markdown` also structurally skips every literal /
+ * plain-string edit (they carry `text`, not `rich_message`), so those pass
+ * through byte-identical. `sendRichMessageDraft` is not wired in the repo
+ * (draft streaming uses sendMessage+editMessageText); extend the method gate
+ * here if a future draft adopter starts using it.
+ *
+ * The composed `guardAccidentalFormatting` is idempotent, so double-guarding a
+ * `richMessage()`-wrapped body that also passes through here is byte-identical
+ * (the internal guard in `richMessage()` is kept belt-and-braces).
+ *
+ * We clone `rich_message` before mutating: callers can share the object by
+ * reference (e.g. `richMessage()` output reused across a retry), and a
+ * transformer must not mutate the caller's input.
+ */
+export function installRichMarkdownGuard(bot: Bot): void {
+  bot.api.config.use(async (prev, method, payload, signal) => {
+    if (
+      (method === 'sendRichMessage' || method === 'editMessageText') &&
+      payload != null
+    ) {
+      const p = payload as Record<string, unknown>
+      const rich = p.rich_message as { markdown?: unknown } | undefined
+      if (rich != null && typeof rich.markdown === 'string') {
+        const guarded = guardAccidentalFormatting(rich.markdown)
+        if (guarded !== rich.markdown) {
+          // Clone rather than mutate the caller's shared object.
+          p.rich_message = { ...rich, markdown: guarded }
+        }
+      }
+    }
+    return prev(method, payload, signal)
   })
 }
 

--- a/telegram-plugin/tests/rich-markdown-guard-transformer.test.ts
+++ b/telegram-plugin/tests/rich-markdown-guard-transformer.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Wire-level outcome tests for the universal accidental-formatting guard
+ * (`installRichMarkdownGuard`, #3252/#3463 follow-up).
+ *
+ * These MUST go through a REAL grammy `Bot` with a stubbed transport. The
+ * existing unit/golden harnesses (`tests/bot-api.harness.ts` etc.) mock the
+ * `api` object ABOVE the grammy transformer layer, so `api.config.use`
+ * transformers never run there — a test written through them is a FALSE guard
+ * (it stays green with the transformer absent or mis-gated). By stubbing
+ * `client.fetch` we capture the exact serialized wire body AFTER the
+ * transformer has mutated the raw payload, which is the only place the guard's
+ * effect is observable.
+ *
+ * Red-team F-R1: the markdown lives at `payload.rich_message.markdown`, NOT
+ * `payload.markdown`. A guard gating on the latter matches nothing and every
+ * one of these assertions would still fail — so these tests pin the correct
+ * field shape too.
+ */
+import { describe, it, expect } from 'vitest'
+import { Bot } from 'grammy'
+import { installTgPostLogger, installRichMarkdownGuard } from '../shared/bot-runtime.js'
+
+interface CapturedCall {
+  method: string
+  body: Record<string, unknown>
+}
+
+/**
+ * Build a real grammy Bot whose transport is stubbed: every API call is
+ * captured (method + parsed JSON body) and answered with a minimal ok
+ * response. `botInfo` is supplied so `bot.init()` never hits the network.
+ */
+function makeCapturingBot(): { bot: Bot; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = []
+  const fakeFetch = (async (url: unknown, init?: { body?: unknown }) => {
+    const method = String(url).split('/').pop() ?? ''
+    let body: Record<string, unknown> = {}
+    if (typeof init?.body === 'string') {
+      body = JSON.parse(init.body) as Record<string, unknown>
+    }
+    calls.push({ method, body })
+    // Minimal Telegram ok envelope. `result` shape doesn't matter for these
+    // send/edit calls — grammy only reads `ok`/`result`.
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, result: { message_id: 1, date: 0, chat: { id: 1, type: 'private' } } }),
+    } as unknown as Response
+  }) as unknown as typeof fetch
+
+  const bot = new Bot('123456:TEST_TOKEN', {
+    botInfo: {
+      id: 123456,
+      is_bot: true,
+      first_name: 'Test',
+      username: 'test_bot',
+      can_join_groups: false,
+      can_read_all_group_messages: false,
+      supports_inline_queries: false,
+      can_connect_to_business: false,
+      has_main_web_app: false,
+    },
+    client: { fetch: fakeFetch },
+  })
+  // Install exactly the production transformer stack ordering: logger first,
+  // then guard (guard composes outermost — grammy runs last-installed first).
+  installTgPostLogger(bot)
+  installRichMarkdownGuard(bot)
+  return { bot, calls }
+}
+
+function lastRichMarkdown(calls: CapturedCall[]): unknown {
+  const c = calls[calls.length - 1]
+  return (c.body.rich_message as { markdown?: unknown } | undefined)?.markdown
+}
+
+describe('installRichMarkdownGuard — universal wire seam', () => {
+  it('(a) escapes a raw { markdown } sendRichMessage on the wire', async () => {
+    const { bot, calls } = makeCapturingBot()
+    await bot.api.sendRichMessage(1, { markdown: '#3460 done' })
+    expect(calls[calls.length - 1].method).toBe('sendRichMessage')
+    expect(lastRichMarkdown(calls)).toBe('\\#3460 done')
+  })
+
+  it('(b) escapes an editMessageText object-arg { markdown } on the wire', async () => {
+    const { bot, calls } = makeCapturingBot()
+    await bot.api.editMessageText(1, 42, { markdown: '#3460 done' })
+    expect(calls[calls.length - 1].method).toBe('editMessageText')
+    expect(lastRichMarkdown(calls)).toBe('\\#3460 done')
+  })
+
+  it('(c) leaves a literalText / string-arg edit UNTOUCHED (carries text, not rich_message)', async () => {
+    const { bot, calls } = makeCapturingBot()
+    await bot.api.editMessageText(1, 42, '#3460 done')
+    const c = calls[calls.length - 1]
+    expect(c.method).toBe('editMessageText')
+    expect(c.body.text).toBe('#3460 done')
+    expect(c.body.rich_message).toBeUndefined()
+  })
+
+  it('(d) leaves a genuine heading byte-identical', async () => {
+    const { bot, calls } = makeCapturingBot()
+    await bot.api.sendRichMessage(1, { markdown: '# Title\n## Sub' })
+    expect(lastRichMarkdown(calls)).toBe('# Title\n## Sub')
+  })
+
+  it('(e) is idempotent on an already-guarded (richMessage-wrapped) body', async () => {
+    const { bot, calls } = makeCapturingBot()
+    // Simulate a body that already went through richMessage()'s internal guard.
+    await bot.api.sendRichMessage(1, { markdown: '\\#3460 done' })
+    expect(lastRichMarkdown(calls)).toBe('\\#3460 done')
+  })
+
+  it('does not mutate the caller\'s shared input object', async () => {
+    const { bot } = makeCapturingBot()
+    const input = { markdown: '#3460 done' }
+    await bot.api.sendRichMessage(1, input)
+    // Caller's object is unchanged; only the cloned wire payload is escaped.
+    expect(input.markdown).toBe('#3460 done')
+  })
+})


### PR DESCRIPTION
## Problem
The line-leading `#`-heading escape and the other `guardAccidentalFormatting` guards only ran inside `richMessage()`. The correctness audit found ~6 sites that build a raw `{ markdown }` and call `sendRichMessage`/`editMessageText` directly, bypassing it:

- `shared/bot-runtime.ts:323` — `switchroomReply` html path (backs `/doctor`, `/grant`, error replies)
- `slot-banner-driver.ts:147,182` — OAuth slot banner send + edit
- `gateway/folder-picker-handler.ts:315`, `gateway/approval-callback.ts:175`, `inline-keyboard-callbacks.ts:583` — raw `{ markdown }` edits

So a reply containing `#3460` still rendered as a Telegram heading on those surfaces.

## Fix
Install a grammy API transformer `installRichMarkdownGuard(bot)` on the single production Bot in gateway boot (next to `installTgPostLogger`). It is the real universal seam — every `sendRichMessage`/`editMessageText` is covered regardless of call site, `ctx.*` sugar, `lockedBot`, or `bot.api.raw`.

Key correctness point (red-team F-R1): the markdown lives at **`payload.rich_message.markdown`**, NOT `payload.markdown`, verified against grammy 1.44.0 `out/core/api.js` (the pinned lockfile version). Gating on `payload.markdown` would match nothing (silent no-op). Gating on `rich_message?.markdown` also structurally skips string-arg edits (they carry `text`), so those pass through untouched. The caller's object is cloned, not mutated.

`richMessage()`'s internal guard is kept belt-and-braces (guards are idempotent — no double-escape). The false "ONE adapter" doc comment at `rich-send.ts` is corrected.

Ordering: installed AFTER the logger so it composes outermost (grammy runs transformers last-installed-first). Moot for logging in practice — `installTgPostLogger` reads only string `p.text`, so it already logs `bytes=0` for every rich body (tg-post is blind to rich_message payloads; separate follow-up).

## Tests
`telegram-plugin/tests/rich-markdown-guard-transformer.test.ts` goes through a REAL grammy `Bot` with a stubbed `client.fetch` transport (mocked-api harnesses bypass transformers and would be false guards — red-team F-R5). Asserts on delivered wire bytes: (a) raw `{ markdown: "#3460 done" }` send escaped; (b) object-arg edit escaped; (c) string-arg edit untouched (`text`, no `rich_message`); (d) genuine `# Title`/`## Sub` byte-identical; (e) idempotence on pre-guarded body; (f) caller input not mutated.

Scoped vitest: 6/6 green. `npm run lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)