### PR TITLE
docs(telegram): truth pass on formatting guide + IR/render headers

### DIFF
--- a/reference/telegram-formatting-guide.md
+++ b/reference/telegram-formatting-guide.md
@@ -78,7 +78,6 @@ Bot API 10.1 rich messages.
 | Subscript | `~text~` (single tilde) | **Falls back to literal text** in rich messages (Bot API 10.1) — the only GFM construct that doesn't render. Avoid. |
 | Superscript | `^text^` | **Falls back to literal text** in rich messages — avoid (use words, e.g. "squared"). |
 | Custom emoji | Telegram premium custom-emoji entity | Premium-only; renders as a normal emoji for non-premium viewers. Don't rely on it conveying meaning. |
-| Inline math | `$ … $` | LaTeX-style inline math (Bot API 10.1). |
 | Link | `[label](https://…)` | Standard GFM link. |
 
 **Block types**
@@ -99,15 +98,12 @@ Bot API 10.1 rich messages.
 - **Section heading** — `#` … `######`. Only in a genuinely long, multi-section answer.
 - **Preformatted block** — a code fence with no language, for fixed-width non-code
   (ASCII tables, aligned columns).
-- **Details / collapsible** — Bot API 10.1 collapsible section. For optional depth the
-  reader can expand (full logs under a one-line summary).
 - **Collage / slideshow** — multiple images grouped in one message (album / media
   group). Send via the attachment path, not markdown.
 - **Divider** — `---` (thematic break). Heavy horizontal rule between genuinely
   separate sections. Use sparingly.
-- **Footnotes** — GFM `[^1]` reference + `[^1]: …` definition.
 
-> Reach for the exotic spans (spoiler, highlight, math, custom emoji) only when they
+> Reach for the exotic spans (spoiler, highlight, custom emoji) only when they
 > genuinely serve the reader. The floor card's "why" applies: structure for the reader,
 > not the writer. Two constructs do NOT render as intended and should be avoided:
 > **sub/superscript** falls back to literal text, and **underline (`__text__`) renders

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -295,7 +295,7 @@ import {
 } from '../retry-api-call.js'
 import { createSendGate, sendGateConfigFromEnv, isSendGateShed } from '../send-gate.js'
 import { createStatsLogger, createFloodWindowObserver } from '../send-gate-observability.js'
-import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
+import { installTgPostLogger, installRichMarkdownGuard, withTgPostTags } from '../shared/bot-runtime.js'
 import {
   floodStatePath,
   floodWindowsPath,
@@ -22970,7 +22970,7 @@ async function initGatewayBot(): Promise<void> {
   }
 
   bot = new Bot(TOKEN)
-  installTgPostLogger(bot)
+  installTgPostLogger(bot); installRichMarkdownGuard(bot) // #3252/#3463: universal fmt guard installed after logger (composes outermost); see installRichMarkdownGuard docblock
 
   // Diagnostic update tap (#3300): one compact line per received update, logged
   // BEFORE any specific handler runs, so a routing-layer drop is diagnosable

--- a/telegram-plugin/render/ir.ts
+++ b/telegram-plugin/render/ir.ts
@@ -66,10 +66,12 @@ export interface ItalicNode extends Pos {
   children: Inline[];
 }
 
-/** Telegram underline (<u>…</u>). In Bot API 10.1 rich markdown the `__…__`
- *  double-underscore run is UNDERLINE — distinct from `**…**` bold, even though
- *  GFM/micromark folds both into a single `strong` mdast node. `parse.ts`
- *  disambiguates the two by looking at the run's source delimiter. */
+/** A `__…__` double-underscore run. `parse.ts` keeps it as a distinct node
+ *  (separate from `**…**` bold) by looking at the source delimiter, even though
+ *  GFM/micromark folds both into a single `strong` mdast node. NOTE: on the
+ *  Telegram wire this renders as BOLD, not a distinct underline style — Bot API
+ *  10.1 rich markdown has no underline entity here, so the round-trip is faithful
+ *  but the delivered text is bold. Kept distinct only to preserve authoring intent. */
 export interface UnderlineNode extends Pos {
   type: "underline";
   children: Inline[];

--- a/telegram-plugin/render/ir.ts
+++ b/telegram-plugin/render/ir.ts
@@ -1,38 +1,44 @@
-// Typed intermediate representation (IR) for the Telegram HTML render engine.
+// Typed intermediate representation (IR) for the Telegram rich-markdown render
+// engine. (Historical note: this file and render.ts were named for an "HTML
+// render engine" during Increment 1, before the Bot API 10.1 migration (#2669)
+// made GFM `{ markdown }` the live send path. There is NO HTML anywhere on the
+// outbound path today — the renderer in render.ts emits raw GFM markdown for
+// the `markdown` field of `InputRichMessageMarkdown`.)
 //
 // This is the parser <-> renderer contract. `parse()` (parse.ts) folds an
-// mdast tree into this shape; a later increment's renderer walks it and emits
-// Telegram Bot API HTML. Increment 1 lands ONLY the parser + this IR — there
-// is no renderer yet.
+// mdast tree into this shape; `render.ts` walks it and emits Telegram
+// rich-message GFM markdown.
 //
 // Every node carries `{ start, end }` UTF-16 source offsets copied verbatim
 // from mdast `position.start.offset` / `position.end.offset`. They are UTF-16
 // code-unit indices into the original markdown string, so
 // `source.slice(node.start, node.end)` round-trips to the node's source text.
 //
-// Telegram HTML tag mapping (for the next increment — NOT implemented here):
+// IR node -> emitted GFM markdown (see render.ts `renderInline`/block render):
 //
 //   Inline
-//     plain     -> (raw text, HTML-escaped)
-//     bold      -> <b>…</b>                 (markdown `**…**`)
-//     italic    -> <i>…</i>                 (markdown `*…*`)
-//     underline -> <u>…</u>                 (markdown `__…__`, Bot API 10.1)
-//     strike    -> <s>…</s>                 (markdown `~~…~~`)
-//     spoiler   -> <tg-spoiler>…</tg-spoiler> (markdown `||…||`)
-//     highlight -> <mark>…</mark>           (markdown `==…==`, Bot API 10.1)
-//     code      -> <code>…</code>
-//     link      -> <a href="…">…</a>
+//     plain     -> raw text (escapeMarkdown'd)
+//     bold      -> `**…**`
+//     italic    -> `*…*`
+//     underline -> `__…__`  — NOTE: the wire renders `__…__` as BOLD, not
+//                  underline. Telegram's rich-message markdown has no underline
+//                  token (live-verified, see reference/telegram-formatting-guide.md).
+//                  The node preserves the author's `__` bytes faithfully; it is
+//                  a distinct IR node but NOT a distinct wire style.
+//     strike    -> `~~…~~`
+//     spoiler   -> `||…||`
+//     highlight -> `==…==`  (Bot API 10.1 marked entity)
+//     code      -> `` `…` ``
+//     link      -> `[…](…)`
 //
 //   Block
 //     paragraph      -> children joined; blocks separated by "\n\n"
-//     heading        -> <b>…</b> (Telegram HTML has no <h1>…<h6>; bold + newlines)
-//     blockquote     -> <blockquote>…</blockquote>
-//                       (expandable === true -> <blockquote expandable>)
-//     code-block     -> <pre><code class="language-…">…</code></pre>
-//     list           -> rendered line-per-item with "•"/"1." bullets
-//                       (Telegram HTML has no <ul>/<ol>)
-//     thematic-break -> a horizontal-rule text line (e.g. "───")
-//     table          -> monospaced <pre> table (Telegram HTML has no <table>)
+//     heading        -> `#`…`######` line
+//     blockquote     -> `> …` (expandable === true -> `**> …` expandable blockquote)
+//     code-block     -> ```` ```lang … ``` ````
+//     list           -> line-per-item with `-`/`1.` markers
+//     thematic-break -> `---` thematic break
+//     table          -> GFM pipe table
 
 export interface Pos {
   /** UTF-16 code-unit offset of the node's first char (mdast position.start.offset). */

--- a/telegram-plugin/render/render.ts
+++ b/telegram-plugin/render/render.ts
@@ -1,6 +1,7 @@
-// IR -> Telegram rich-markdown renderer for the Telegram HTML render engine
-// (name kept for continuity with render/ir.ts + render/parse.ts; the actual
-// wire format is GFM markdown, NOT HTML — see the note below).
+// IR -> Telegram rich-markdown renderer. (The render/ir.ts + render/parse.ts
+// files were originally named for an "HTML render engine"; that name is
+// historical — the actual wire format is GFM markdown, NOT HTML. See the note
+// below and the refreshed header in render/ir.ts.)
 //
 // Increment 2 of the render pipeline: takes the typed IR produced by
 // `parse.ts` (per `ir.ts`) and emits a string suitable for the `markdown`
@@ -67,6 +68,11 @@ function renderInline(node: Inline, ctx: InlineCtx = {}): string {
     case "italic":
       return `*${renderInlineChildren(node.children, ctx)}*`;
     case "underline":
+      // The wire renders `__…__` as BOLD, not underline — Telegram's
+      // rich-message markdown has no underline token (live-verified; see
+      // reference/telegram-formatting-guide.md). We preserve the author's `__`
+      // bytes faithfully rather than rewriting them to `**`; the IR keeps
+      // underline as a distinct node, but it is NOT a distinct wire style.
       return `__${renderInlineChildren(node.children, ctx)}__`;
     case "strike":
       return `~~${renderInlineChildren(node.children, ctx)}~~`;
@@ -284,6 +290,9 @@ export const SUPPORTED_INLINE = [
   "plain",
   "bold",
   "italic",
+  // "underline" parses `__…__` into a distinct node and round-trips it, but the
+  // wire renders it as BOLD (no underline token on this path). Kept for faithful
+  // `__` byte round-trip, NOT because it is a distinct rendered style.
   "underline",
   "strike",
   "spoiler",

--- a/telegram-plugin/rich-send.ts
+++ b/telegram-plugin/rich-send.ts
@@ -67,16 +67,22 @@ export function guardAccidentalFormatting(markdown: string): string {
 /**
  * Wrap raw GFM markdown into the rich-message input object.
  *
- * This is the ONE adapter every `{ markdown }` wire send funnels through
- * (`sendRichMessage` / `editMessageText({ markdown })`) — the reply-tool final
- * answer, draft-stream previews, cards, approvals, banners. It is therefore the
- * single deterministic seam for the #3252 accidental-formatting guards (F1):
- * applying `guardAccidentalFormatting` here guards EVERY markdown-parsed
- * outbound exactly once, without touching `plain`-mode degradations (which
- * bypass this wrapper and go straight to `sendMessage`, where no markdown
- * parsing happens). The composed guard is a strict no-op for any body without
- * an accidental-formatting signal and is idempotent, so callers that already
- * ran it (or the streaming path that renders then re-wraps) stay byte-identical.
+ * This is a CONVENIENCE adapter — NOT the universal seam. It applies
+ * `guardAccidentalFormatting` for the many callers that build a body through
+ * it (the reply-tool final answer, draft-stream previews, cards), but it is
+ * NOT the one place every `{ markdown }` wire send funnels through: several
+ * sites build a raw `{ markdown }` and call `sendRichMessage` /
+ * `editMessageText` directly, bypassing this wrapper (see the correctness
+ * audit's F1 list — banners, switchroomReply html, approval/folder-picker
+ * edits). The REAL universal seam for the #3252 accidental-formatting guards
+ * is the grammy API transformer `installRichMarkdownGuard`
+ * (`shared/bot-runtime.ts`), installed on the production Bot in gateway boot,
+ * which guards EVERY sendRichMessage/editMessageText payload regardless of the
+ * call site. This wrapper is kept belt-and-braces: the composed guard is a
+ * strict no-op for any body without an accidental-formatting signal and is
+ * idempotent, so a body guarded here and re-guarded by the transformer stays
+ * byte-identical. `plain`-mode degradations bypass both (they go straight to
+ * `sendMessage`, where no markdown parsing happens).
  */
 export function richMessage(markdown: string): InputRichMessageMarkdown {
   return { markdown: guardAccidentalFormatting(markdown) }

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -32,6 +32,7 @@ import { createRetryApiCall } from '../retry-api-call.js'
 import { makeFloodWaitRecorder, makeFloodWaitProbe } from '../flood-circuit-breaker.js'
 import { RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { shouldEmitTgPost } from './gw-trace-gate.js'
+import { guardAccidentalFormatting } from '../rich-send.js'
 
 // ─── tg-post tag plumbing ─────────────────────────────────────────────────
 
@@ -144,6 +145,62 @@ export function installTgPostLogger(bot: Bot): void {
       )
       throw err
     }
+  })
+}
+
+/**
+ * Universal accidental-formatting guard, installed as a grammy API transformer
+ * on the single production Bot (#3252/#3463 follow-up). This is the REAL
+ * universal seam — not `richMessage()`. `richMessage()` only guards bodies its
+ * callers remember to wrap; the correctness audit found ~6 sites that build a
+ * raw `{ markdown }` and call `sendRichMessage` / `editMessageText` directly,
+ * bypassing it (`shared/bot-runtime.ts` switchroomReply html path,
+ * `slot-banner-driver.ts` OAuth banners, and edits in `folder-picker-handler`,
+ * `approval-callback`, `inline-keyboard-callbacks`). A transformer at the
+ * grammy `bot.api.config.use` layer sees every rich send regardless of the
+ * call site, `ctx.*` sugar, `lockedBot`, or `bot.api.raw`, so it closes the
+ * whole bypass class deterministically.
+ *
+ * Payload shape (verified against grammy 1.44.0 `out/core/api.js`, the pinned
+ * lockfile version):
+ *   - `sendRichMessage(chat_id, rich_message, ...)` → raw payload
+ *     `{ chat_id, rich_message: { markdown }, ... }`
+ *   - `editMessageText(chat_id, message_id, arg, ...)` → raw payload
+ *     `{ ..., rich_message: { markdown } }` when `arg` is an object, or
+ *     `{ ..., text }` when `arg` is a plain string.
+ * The markdown therefore lives at `payload.rich_message.markdown`, NOT
+ * `payload.markdown` (gating on the latter matches nothing — a silent no-op).
+ * Gating on `rich_message?.markdown` also structurally skips every literal /
+ * plain-string edit (they carry `text`, not `rich_message`), so those pass
+ * through byte-identical. `sendRichMessageDraft` is not wired in the repo
+ * (draft streaming uses sendMessage+editMessageText); extend the method gate
+ * here if a future draft adopter starts using it.
+ *
+ * The composed `guardAccidentalFormatting` is idempotent, so double-guarding a
+ * `richMessage()`-wrapped body that also passes through here is byte-identical
+ * (the internal guard in `richMessage()` is kept belt-and-braces).
+ *
+ * We clone `rich_message` before mutating: callers can share the object by
+ * reference (e.g. `richMessage()` output reused across a retry), and a
+ * transformer must not mutate the caller's input.
+ */
+export function installRichMarkdownGuard(bot: Bot): void {
+  bot.api.config.use(async (prev, method, payload, signal) => {
+    if (
+      (method === 'sendRichMessage' || method === 'editMessageText') &&
+      payload != null
+    ) {
+      const p = payload as Record<string, unknown>
+      const rich = p.rich_message as { markdown?: unknown } | undefined
+      if (rich != null && typeof rich.markdown === 'string') {
+        const guarded = guardAccidentalFormatting(rich.markdown)
+        if (guarded !== rich.markdown) {
+          // Clone rather than mutate the caller's shared object.
+          p.rich_message = { ...rich, markdown: guarded }
+        }
+      }
+    }
+    return prev(method, payload, signal)
   })
 }
 

--- a/telegram-plugin/tests/format-guard-pins.test.ts
+++ b/telegram-plugin/tests/format-guard-pins.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Pin tests for the accidental-formatting guard (#3252/#3463).
+ *
+ * Two internal-hardening assertions, no user-visible change:
+ *
+ *  1. Documents the `#{1,6}` cap in ACCIDENTAL_HEADING as intentional: a run of
+ *     7+ `#` glued to non-space is left UNescaped (CommonMark caps heading
+ *     promotion at 6 `#`, and the guard mirrors that). Correctness-audit F2
+ *     flagged this as asserted-but-untested.
+ *
+ *  2. A wiring assertion that PR1's `installRichMarkdownGuard` transformer is
+ *     actually installed on the production Bot in `initGatewayBot()`, so the
+ *     universal seam can't be silently dropped in a later refactor. Grammy's
+ *     installed transformers are anonymous fns (nothing to grip at runtime), so
+ *     this is a source-level AST assertion on the boot path — the same approach
+ *     `gateway-bot-construction-deferral.test.ts` uses.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import ts from 'typescript'
+import { guardAccidentalFormatting } from '../rich-send.js'
+import { guardAccidentalHeading } from '../render/line-start-guard.js'
+
+describe('accidental-heading guard: #{1,6} cap is intentional (F2)', () => {
+  it('escapes a 6-# run glued to non-space (upper bound of the cap)', () => {
+    expect(guardAccidentalHeading('######x')).toBe('\\######x')
+    expect(guardAccidentalFormatting('######x')).toBe('\\######x')
+  })
+
+  it('leaves a 7-# run glued to non-space UNescaped (past the CommonMark cap)', () => {
+    expect(guardAccidentalHeading('#######x')).toBe('#######x')
+    expect(guardAccidentalFormatting('#######x')).toBe('#######x')
+  })
+
+  it('leaves an 8+-# run glued to non-space UNescaped', () => {
+    expect(guardAccidentalHeading('##########x')).toBe('##########x')
+    expect(guardAccidentalFormatting('##########x')).toBe('##########x')
+  })
+})
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_PATH = resolve(__dirname, '..', 'gateway', 'gateway.ts')
+const GATEWAY_SRC = readFileSync(GATEWAY_PATH, 'utf8')
+const sourceFile = ts.createSourceFile(
+  GATEWAY_PATH,
+  GATEWAY_SRC,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS,
+)
+
+function findFunction(name: string): ts.FunctionDeclaration | undefined {
+  for (const s of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(s) && s.name?.text === name) return s
+  }
+  return undefined
+}
+
+function countCallsTo(root: ts.Node, name: string): number {
+  let count = 0
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === name
+    ) {
+      count++
+      // Installed on the constructed bot instance.
+      expect(node.arguments[0]?.getText(sourceFile)).toBe('bot')
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(root)
+  return count
+}
+
+describe('boot wiring: installRichMarkdownGuard is installed on the production Bot', () => {
+  it('imports installRichMarkdownGuard from ../shared/bot-runtime.js', () => {
+    // The import must exist for the boot call to resolve; a refactor that drops
+    // the import would break the seam.
+    expect(GATEWAY_SRC).toMatch(
+      /import\s*\{[^}]*\binstallRichMarkdownGuard\b[^}]*\}\s*from\s*'\.\.\/shared\/bot-runtime\.js'/,
+    )
+  })
+
+  it('calls installRichMarkdownGuard(bot) exactly once inside initGatewayBot()', () => {
+    const fn = findFunction('initGatewayBot')
+    expect(fn?.body).toBeDefined()
+    expect(countCallsTo(fn!.body!, 'installRichMarkdownGuard')).toBe(1)
+  })
+})

--- a/telegram-plugin/tests/render/underline-wire-outcome.test.ts
+++ b/telegram-plugin/tests/render/underline-wire-outcome.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Truth-pass pin (#3252 formatting-truth follow-up): the REAL wire outcome for
+ * a `__…__` run.
+ *
+ * The parser folds `__x__` into a distinct `underline` IR node and the renderer
+ * round-trips it back to `__x__` (asserted in parse.test.ts / render.test.ts).
+ * But Telegram's rich-message markdown has NO underline token: the wire renders
+ * `__x__` identically to `**x__` — i.e. as BOLD (live-verified 2026-07, see
+ * reference/telegram-formatting-guide.md).
+ *
+ * Decision (documented in the fmt-audit BUILD-LOG): we keep the underline node
+ * and faithfully preserve the author's `__` bytes rather than rewriting them to
+ * `**` — full removal would invert several green tests and change wire bytes for
+ * zero wire-visible benefit (both render as bold). This test pins the honest
+ * contract: `__x__` emits `__x__`, which the wire treats as bold, NOT a distinct
+ * underline style.
+ */
+import { describe, it, expect } from "vitest";
+import { parse } from "../../render/parse.js";
+import { render } from "../../render/render.js";
+
+describe("underline: real wire outcome for `__…__`", () => {
+  it("round-trips `__x__` to `__x__` on the wire (which Telegram renders as BOLD)", () => {
+    // The emitted bytes preserve the author's `__` delimiters verbatim.
+    expect(render(parse("__x__"))).toBe("__x__");
+  });
+
+  it("does NOT rewrite `__x__` to `**x**` (author bytes preserved, not normalised to bold syntax)", () => {
+    expect(render(parse("__underlined__"))).not.toContain("**");
+    expect(render(parse("__underlined__"))).toBe("__underlined__");
+  });
+});

--- a/telegram-plugin/tests/rich-markdown-guard-transformer.test.ts
+++ b/telegram-plugin/tests/rich-markdown-guard-transformer.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Wire-level outcome tests for the universal accidental-formatting guard
+ * (`installRichMarkdownGuard`, #3252/#3463 follow-up).
+ *
+ * These MUST go through a REAL grammy `Bot` with a stubbed transport. The
+ * existing unit/golden harnesses (`tests/bot-api.harness.ts` etc.) mock the
+ * `api` object ABOVE the grammy transformer layer, so `api.config.use`
+ * transformers never run there — a test written through them is a FALSE guard
+ * (it stays green with the transformer absent or mis-gated). By stubbing
+ * `client.fetch` we capture the exact serialized wire body AFTER the
+ * transformer has mutated the raw payload, which is the only place the guard's
+ * effect is observable.
+ *
+ * Red-team F-R1: the markdown lives at `payload.rich_message.markdown`, NOT
+ * `payload.markdown`. A guard gating on the latter matches nothing and every
+ * one of these assertions would still fail — so these tests pin the correct
+ * field shape too.
+ */
+import { describe, it, expect } from 'vitest'
+import { Bot } from 'grammy'
+import { installTgPostLogger, installRichMarkdownGuard } from '../shared/bot-runtime.js'
+
+interface CapturedCall {
+  method: string
+  body: Record<string, unknown>
+}
+
+/**
+ * Build a real grammy Bot whose transport is stubbed: every API call is
+ * captured (method + parsed JSON body) and answered with a minimal ok
+ * response. `botInfo` is supplied so `bot.init()` never hits the network.
+ */
+function makeCapturingBot(): { bot: Bot; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = []
+  const fakeFetch = (async (url: unknown, init?: { body?: unknown }) => {
+    const method = String(url).split('/').pop() ?? ''
+    let body: Record<string, unknown> = {}
+    if (typeof init?.body === 'string') {
+      body = JSON.parse(init.body) as Record<string, unknown>
+    }
+    calls.push({ method, body })
+    // Minimal Telegram ok envelope. `result` shape doesn't matter for these
+    // send/edit calls — grammy only reads `ok`/`result`.
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, result: { message_id: 1, date: 0, chat: { id: 1, type: 'private' } } }),
+    } as unknown as Response
+  }) as unknown as typeof fetch
+
+  const bot = new Bot('123456:TEST_TOKEN', {
+    botInfo: {
+      id: 123456,
+      is_bot: true,
+      first_name: 'Test',
+      username: 'test_bot',
+      can_join_groups: false,
+      can_read_all_group_messages: false,
+      supports_inline_queries: false,
+      can_connect_to_business: false,
+      has_main_web_app: false,
+    },
+    client: { fetch: fakeFetch },
+  })
+  // Install exactly the production transformer stack ordering: logger first,
+  // then guard (guard composes outermost — grammy runs last-installed first).
+  installTgPostLogger(bot)
+  installRichMarkdownGuard(bot)
+  return { bot, calls }
+}
+
+function lastRichMarkdown(calls: CapturedCall[]): unknown {
+  const c = calls[calls.length - 1]
+  return (c.body.rich_message as { markdown?: unknown } | undefined)?.markdown
+}
+
+describe('installRichMarkdownGuard — universal wire seam', () => {
+  it('(a) escapes a raw { markdown } sendRichMessage on the wire', async () => {
+    const { bot, calls } = makeCapturingBot()
+    await bot.api.sendRichMessage(1, { markdown: '#3460 done' })
+    expect(calls[calls.length - 1].method).toBe('sendRichMessage')
+    expect(lastRichMarkdown(calls)).toBe('\\#3460 done')
+  })
+
+  it('(b) escapes an editMessageText object-arg { markdown } on the wire', async () => {
+    const { bot, calls } = makeCapturingBot()
+    await bot.api.editMessageText(1, 42, { markdown: '#3460 done' })
+    expect(calls[calls.length - 1].method).toBe('editMessageText')
+    expect(lastRichMarkdown(calls)).toBe('\\#3460 done')
+  })
+
+  it('(c) leaves a literalText / string-arg edit UNTOUCHED (carries text, not rich_message)', async () => {
+    const { bot, calls } = makeCapturingBot()
+    await bot.api.editMessageText(1, 42, '#3460 done')
+    const c = calls[calls.length - 1]
+    expect(c.method).toBe('editMessageText')
+    expect(c.body.text).toBe('#3460 done')
+    expect(c.body.rich_message).toBeUndefined()
+  })
+
+  it('(d) leaves a genuine heading byte-identical', async () => {
+    const { bot, calls } = makeCapturingBot()
+    await bot.api.sendRichMessage(1, { markdown: '# Title\n## Sub' })
+    expect(lastRichMarkdown(calls)).toBe('# Title\n## Sub')
+  })
+
+  it('(e) is idempotent on an already-guarded (richMessage-wrapped) body', async () => {
+    const { bot, calls } = makeCapturingBot()
+    // Simulate a body that already went through richMessage()'s internal guard.
+    await bot.api.sendRichMessage(1, { markdown: '\\#3460 done' })
+    expect(lastRichMarkdown(calls)).toBe('\\#3460 done')
+  })
+
+  it('does not mutate the caller\'s shared input object', async () => {
+    const { bot } = makeCapturingBot()
+    const input = { markdown: '#3460 done' }
+    await bot.api.sendRichMessage(1, input)
+    // Caller's object is unchanged; only the cloned wire payload is escaped.
+    expect(input.markdown).toBe('#3460 done')
+  })
+})


### PR DESCRIPTION
Stacked on #3480 (base: `test/format-guard-pins`). Internal/doc truth pass — stops agents and maintainers being lied to about the formatting palette.

## Removed three falsely-advertised constructs from `reference/telegram-formatting-guide.md`
- **Inline math `$…$`** — deliberately neutralised by `guardDollarMath` (digit-adjacent `$` escaped in `rich-send.ts`), so it never renders.
- **Details / collapsible** — no parser/renderer support (the entry didn't even give a syntax).
- **Footnotes** — GFM `[^1]` unsupported on this path.

Also dropped "math" from the exotic-spans reach-for line. No test reads the guide (verified), so this is doc-only churn.

## Underline — rescoped per red-team F-R2
The plan called underline "dead fiction / unreachable". It is **not**: the parser folds `__…__` into a distinct `underline` IR node and round-trips it, with 5+ green tests asserting that (`parse.test.ts:256-283`, `render.test.ts`, `rich-render.test.ts`, `parse-torture.test.ts`). Removing the node would invert those green tests.

The wire renders `__…__` as **bold** (Telegram rich-message markdown has no underline token — live-verified; the guide at lines 73/113-114 is already honest). 

**Decision (option b):** keep underline parsing and preserve the author's `__` bytes faithfully rather than folding to `**` — full removal changes wire bytes for zero wire-visible benefit (both render as bold) and inverts green tests. Made the **code** honest instead:
- Truth comments at `render.ts` underline case + `SUPPORTED_INLINE`.
- New pin `underline-wire-outcome.test.ts` asserting `__x__` emits `__x__` (bold on the wire), not a distinct underline style.
- `format.ts` span pattern and `uat/driver.ts` decode mapping are left intact (correct — underline parsing stays).

## Refreshed stale HTML-era headers
`render/ir.ts:1-35` and `render/render.ts:1` described an "HTML render engine" with an HTML tag mapping that predates the Bot API 10.1 GFM-markdown migration (#2669). Now describe the real IR-node -> GFM-markdown mapping, with underline's bold-on-wire behavior noted inline.

## Tests
Full `telegram-plugin/tests/render/` dir: 264/264 green (existing underline round-trip tests unchanged). `npm run lint`: clean.

> Note: base is #3480, not `main` (stacked PR1→PR2→PR3 chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)