### PR TITLE
fix(skills): relative skill symlinks + owned-link migration (footgun A)

### DIFF
--- a/src/agents/reconcile-default-skills.test.ts
+++ b/src/agents/reconcile-default-skills.test.ts
@@ -25,8 +25,23 @@ import {
   lstatSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname, isAbsolute, resolve } from "node:path";
 import { homedir } from "node:os";
+
+/**
+ * Assert `dest` is a switchroom-written skill link (footgun A):
+ *   - the stored target is RELATIVE (never absolute — an absolute link
+ *     baked with `homedir()` dangles across container mount contexts), and
+ *   - it RESOLVES to `expectedPoolTarget` from the link's own directory
+ *     (readlink + resolve lands on the pool file — the real invariant).
+ * Reading the raw target and resolving it is the only test that would have
+ * caught the absolute-link regression.
+ */
+function expectRelativeLinkResolvingTo(dest: string, expectedPoolTarget: string): void {
+  const stored = readlinkSync(dest);
+  expect(isAbsolute(stored)).toBe(false);
+  expect(resolve(dirname(dest), stored)).toBe(resolve(expectedPoolTarget));
+}
 import {
   reconcileAgentDefaultSkills,
   reconcileAllAgentDefaultSkills,
@@ -80,7 +95,7 @@ describe("reconcileAgentDefaultSkills", () => {
     for (const name of ["skill-a", "skill-b", "skill-c"]) {
       const dest = join(agentDir, ".claude", "skills", name);
       expect(lstatSync(dest).isSymbolicLink()).toBe(true);
-      expect(readlinkSync(dest)).toBe(join(poolDir, name));
+      expectRelativeLinkResolvingTo(dest, join(poolDir, name));
     }
   });
 
@@ -91,6 +106,31 @@ describe("reconcileAgentDefaultSkills", () => {
     expect(second.added).toEqual([]);
     expect(second.alreadyPresent.sort()).toEqual(["skill-a", "skill-b", "skill-c"]);
     expect(second.changed).toBe(false);
+  });
+
+  it("migrates an existing ABSOLUTE owned link to a relative link (footgun A one-time heal)", () => {
+    const agentDir = makeAgentDir(tmpRoot, "ag1");
+    const skillsDir = join(agentDir, ".claude", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    // Simulate a link baked by the old absolute-target code: it points at
+    // the correct pool file but via an ABSOLUTE path — the class that
+    // dangles across container mount contexts.
+    const dest = join(skillsDir, "skill-a");
+    symlinkSync(join(poolDir, "skill-a"), dest);
+    expect(isAbsolute(readlinkSync(dest))).toBe(true); // precondition
+
+    const result = reconcileAgentDefaultSkills(agentDir, {}, FIXTURE_DEFAULTS, poolDir);
+    // The migration rewrites it; it is reported as changed (added), and the
+    // stored target is now relative but still resolves to the pool file.
+    expect(result.added).toContain("skill-a");
+    expect(result.changed).toBe(true);
+    expectRelativeLinkResolvingTo(dest, join(poolDir, "skill-a"));
+
+    // And it is idempotent afterwards — a second pass sees the relative link
+    // as already-correct and does not rewrite it.
+    const second = reconcileAgentDefaultSkills(agentDir, {}, FIXTURE_DEFAULTS, poolDir);
+    expect(second.added).not.toContain("skill-a");
+    expect(second.alreadyPresent).toContain("skill-a");
   });
 
   it("refreshes a stale symlink whose target is inside the pool dir", () => {
@@ -105,7 +145,7 @@ describe("reconcileAgentDefaultSkills", () => {
 
     const result = reconcileAgentDefaultSkills(agentDir, {}, FIXTURE_DEFAULTS, poolDir);
     expect(result.added).toContain("skill-a");
-    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(join(poolDir, "skill-a"));
+    expectRelativeLinkResolvingTo(join(skillsDir, "skill-a"), join(poolDir, "skill-a"));
   });
 
   it("leaves a foreign symlink alone and marks it as a conflict", () => {
@@ -249,7 +289,7 @@ describe("reconcileAgentDefaultSkills — legacy-prefix migration (#1164)", () =
       poolDir,
     );
     expect(result.added).toContain("skill-a");
-    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(join(poolDir, "skill-a"));
+    expectRelativeLinkResolvingTo(join(skillsDir, "skill-a"), join(poolDir, "skill-a"));
   });
 
   it("repoints a symlink whose target was a legacy */switchroom/skills/* dev-checkout path", () => {
@@ -265,7 +305,7 @@ describe("reconcileAgentDefaultSkills — legacy-prefix migration (#1164)", () =
       poolDir,
     );
     expect(result.added).toContain("skill-a");
-    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(join(poolDir, "skill-a"));
+    expectRelativeLinkResolvingTo(join(skillsDir, "skill-a"), join(poolDir, "skill-a"));
   });
 
   it("repoints a symlink whose target was the retired bun-global switchroom-ai/skills path (carrie RCA)", () => {
@@ -289,7 +329,7 @@ describe("reconcileAgentDefaultSkills — legacy-prefix migration (#1164)", () =
     // Owned-stale: link is deleted and recreated pointing into the current pool.
     expect(result.added).toContain("skill-a");
     expect(result.conflicts).not.toContain("skill-a");
-    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(join(poolDir, "skill-a"));
+    expectRelativeLinkResolvingTo(join(skillsDir, "skill-a"), join(poolDir, "skill-a"));
   });
 
   it("leaves a genuinely foreign switchroom-ai-like path alone (no over-match)", () => {

--- a/src/agents/reconcile-default-skills.ts
+++ b/src/agents/reconcile-default-skills.ts
@@ -24,7 +24,7 @@
 
 import { existsSync, lstatSync, mkdirSync, readdirSync, readlinkSync, rmSync, symlinkSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { getBuiltinDefaultSkillEntries, type BuiltinSkillEntry } from "../memory/scaffold-integration.js";
 
 /** Track which missing-pool-dir warnings we've already emitted so the
@@ -85,6 +85,34 @@ function isOwnedStaleLink(target: string, poolDir: string): boolean {
   if (target.startsWith("/opt/skills/")) return true;
   if (target.includes("/switchroom-ai/skills/")) return true;
   return false;
+}
+
+/**
+ * Resolve a symlink's stored target to an absolute path. Relative link
+ * targets (the format switchroom now writes — see `linkTargetFor`) are
+ * resolved against the link's own directory, exactly as the kernel does
+ * on traversal. Absolute targets (legacy links baked with `homedir()`)
+ * pass through unchanged. Used for the owned/stale/foreign classification
+ * so it works identically for relative and absolute links.
+ */
+function absoluteLinkTarget(linkPath: string, storedTarget: string): string {
+  return isAbsolute(storedTarget)
+    ? storedTarget
+    : resolve(dirname(linkPath), storedTarget);
+}
+
+/**
+ * The symlink target switchroom writes for `dest` → `src`: a path RELATIVE
+ * to the link's own directory (footgun A). Relative links are invariant
+ * under the mount-prefix, so a link written from hostd's `/host-home/...`
+ * view resolves correctly in an agent's `/home/<op>/...` view — both share
+ * one `~/.switchroom` root. Depth is computed via `path.relative`, never a
+ * hardcoded `../` literal, so the correct prefix follows the layout
+ * automatically (agents/<name>/.claude/skills → pool is 4 up; a personal
+ * pool link would be 3 — a single constant would be wrong for both).
+ */
+function linkTargetFor(dest: string, src: string): string {
+  return relative(dirname(dest), src);
 }
 
 /**
@@ -149,6 +177,7 @@ export function reconcileAgentDefaultSkills(
     }
 
     const dest = join(targetDir, entry.key);
+    const relTarget = linkTargetFor(dest, src);
     let existing;
     try {
       existing = lstatSync(dest);
@@ -161,18 +190,26 @@ export function reconcileAgentDefaultSkills(
         try {
           currentTarget = readlinkSync(dest);
         } catch { /* unreadable */ }
-        if (currentTarget === src) {
+        if (currentTarget === relTarget) {
+          // Already the correct RELATIVE link — nothing to do (idempotent).
           result.alreadyPresent.push(entry.key);
           continue;
         }
-        // Stale symlink — refresh if it points inside the current pool
-        // OR matches a legacy switchroom-owned prefix (dev-checkout
-        // `*/switchroom/skills/*` or packaged `/opt/skills/*`). This
-        // is the migration path that heals broken symlinks on user
-        // machines after the pool-dir relocation (RCA: #1164). A
-        // foreign symlink (operator pointed to a custom location)
-        // is left alone.
-        if (currentTarget && isOwnedStaleLink(currentTarget, poolDir)) {
+        // Any other switchroom-owned link is refreshed to the relative
+        // form. This covers three cases with one rule:
+        //   1. A correct-but-ABSOLUTE link (currentTarget === src) — the
+        //      one-time footgun-A migration: rewrite absolute → relative.
+        //   2. A stale link inside the current pool after a pool-dir move.
+        //   3. A legacy switchroom-owned prefix (dev-checkout
+        //      `*/switchroom/skills/*`, packaged `/opt/skills/*`, retired
+        //      bun-global — RCA #1164).
+        // A FOREIGN link (operator pointed at a custom location) is left
+        // alone. Classification resolves relative targets against the
+        // link dir first so it is identical for relative and absolute links.
+        const resolvedTarget = currentTarget
+          ? absoluteLinkTarget(dest, currentTarget)
+          : null;
+        if (resolvedTarget && isOwnedStaleLink(resolvedTarget, poolDir)) {
           try { rmSync(dest, { force: true }); } catch { /* best effort */ }
         } else {
           result.conflicts.push(entry.key);
@@ -186,7 +223,7 @@ export function reconcileAgentDefaultSkills(
     }
 
     try {
-      symlinkSync(src, dest);
+      symlinkSync(relTarget, dest);
       result.added.push(entry.key);
       result.changed = true;
     } catch (err) {

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -17,7 +17,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { execSync, execFileSync } from "node:child_process";
-import { join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { createHash } from "node:crypto";
 import chalk from "chalk";
 import type { AgentConfig, QuotaConfig, SwitchroomConfig, TelegramConfig } from "../config/schema.js";
@@ -1720,7 +1720,12 @@ function migrateLegacySkillsDir(agentDir: string, skillsPool: string): void {
     } catch {
       continue; // not a symlink — leave it
     }
-    if (target && target.startsWith(skillsPool)) {
+    // Resolve relative targets against the link dir so both the current
+    // RELATIVE link form and the legacy ABSOLUTE form are recognized (footgun A).
+    const resolved = target
+      ? (isAbsolute(target) ? target : resolve(dirname(entryPath), target))
+      : null;
+    if (resolved && resolved.startsWith(skillsPool)) {
       try {
         rmSync(entryPath, { force: true });
       } catch { /* best effort */ }
@@ -1772,6 +1777,11 @@ function syncGlobalSkills(
       );
       continue;
     }
+    // Relative link target (footgun A): a path relative to the link's own
+    // directory, so it resolves identically across container mount contexts
+    // (hostd's /host-home view vs the agent's /home view share one
+    // ~/.switchroom root). Depth is computed, never hardcoded.
+    const relTarget = relative(dirname(dest), src);
     // If dest exists and is a symlink to the right target, leave it.
     // If dest exists as a real file/dir (e.g. from profile copySkills),
     // also leave it — profile-bundled skills take priority over the
@@ -1785,14 +1795,23 @@ function syncGlobalSkills(
       linkStat = null;
     }
     if (linkStat) {
-      // Broken symlink into the pool: replace it (the old target is
-      // gone, so we can safely recreate). Anything else: leave alone.
       if (linkStat.isSymbolicLink()) {
         let target: string | null = null;
         try {
           target = readlinkSync(dest);
         } catch { /* unreadable; leave alone */ }
-        if (target && target.startsWith(skillsPool)) {
+        // Already the correct RELATIVE link — idempotent no-op.
+        if (target === relTarget) {
+          continue;
+        }
+        // A link pointing into the pool (resolved against the link dir so
+        // a legacy ABSOLUTE target is handled too): replace it — this both
+        // heals a stale/broken pool link and migrates an absolute link to
+        // the relative form. Anything foreign: leave alone.
+        const resolved = target
+          ? (isAbsolute(target) ? target : resolve(dirname(dest), target))
+          : null;
+        if (resolved && resolved.startsWith(skillsPool)) {
           try {
             rmSync(dest, { force: true });
           } catch { /* best effort */ }
@@ -1804,7 +1823,7 @@ function syncGlobalSkills(
       }
     }
     try {
-      symlinkSync(src, dest);
+      symlinkSync(relTarget, dest);
     } catch (err) {
       console.warn(
         `  WARNING: failed to symlink skill "${name}": ${(err as Error).message}`,
@@ -1828,10 +1847,16 @@ function syncGlobalSkills(
     } catch {
       continue; // not a symlink
     }
-    if (linkTarget && linkTarget.includes("/.switchroom/skills/_bundled/")) {
+    // Resolve relative targets against the link dir before classifying, so
+    // the current RELATIVE link form is recognized as well as the legacy
+    // ABSOLUTE form (footgun A).
+    const resolved = linkTarget
+      ? (isAbsolute(linkTarget) ? linkTarget : resolve(dirname(entryPath), linkTarget))
+      : null;
+    if (resolved && resolved.includes("/.switchroom/skills/_bundled/")) {
       continue; // owned by reconcile-default-skills
     }
-    if (linkTarget && linkTarget.startsWith(skillsPool)) {
+    if (resolved && resolved.startsWith(skillsPool)) {
       rmSync(entryPath, { force: true });
     }
   }
@@ -1921,7 +1946,14 @@ export function installSwitchroomSkills(
       try {
         currentTarget = readlinkSync(dest);
       } catch { /* unreadable — assume foreign, leave alone */ }
-      if (currentTarget !== join(builtinSkillsDir, name)) continue;
+      // Retract a link we plausibly installed — in either the RELATIVE
+      // form (current) or the legacy ABSOLUTE form (pre-footgun-A). Resolve
+      // relative targets against the link dir before comparing.
+      if (!currentTarget) continue;
+      const resolvedTarget = isAbsolute(currentTarget)
+        ? currentTarget
+        : resolve(dirname(dest), currentTarget);
+      if (resolvedTarget !== join(builtinSkillsDir, name)) continue;
       try {
         rmSync(dest, { force: true });
       } catch { /* best effort */ }
@@ -1933,10 +1965,13 @@ export function installSwitchroomSkills(
   for (const name of switchroomSkillNames) {
     const src = join(builtinSkillsDir, name);
     const dest = join(targetDir, name);
+    // Relative link target (footgun A) — mount-context-invariant, computed
+    // depth (never a hardcoded `../` literal).
+    const relTarget = relative(dirname(dest), src);
     // Idempotent: leave correctly-pointing symlinks and real dirs alone.
     // But refresh stale symlinks whose target is a different switchroom-
     // lookalike path (e.g. old clerk/skills/ after the clerk→switchroom
-    // rename). Otherwise reconcile can't heal a botched cross-repo state.
+    // rename), AND migrate a correct-but-absolute legacy link to relative.
     let existing;
     try {
       existing = lstatSync(dest);
@@ -1949,7 +1984,7 @@ export function installSwitchroomSkills(
         try {
           currentTarget = readlinkSync(dest);
         } catch { /* unreadable */ }
-        if (currentTarget === src) continue; // already correct
+        if (currentTarget === relTarget) continue; // already correct (relative)
         try {
           rmSync(dest, { force: true });
         } catch { /* best effort; symlinkSync below will error cleanly */ }
@@ -1958,7 +1993,7 @@ export function installSwitchroomSkills(
       }
     }
     try {
-      symlinkSync(src, dest);
+      symlinkSync(relTarget, dest);
     } catch (err) {
       console.warn(
         `  WARNING: failed to symlink switchroom skill "${name}": ${(err as Error).message}`,

--- a/tests/reconcile.scoped-sweep.test.ts
+++ b/tests/reconcile.scoped-sweep.test.ts
@@ -123,6 +123,34 @@ describe("chownScopedTree — call shape (#3333 stage 2)", () => {
     }
   });
 
+  it("re-owns bundled-skill symlinks under .claude/skills/ (footgun A migration is UID-safe)", () => {
+    // The relative-symlink migration (footgun A) rm+re-creates links under
+    // .claude/skills/ from a root reconcile writer. Those links must be
+    // re-owned to the agent UID, or the agent can't traverse them and the
+    // permission allowlist wedges (#3168). The guarantee is that .claude is a
+    // recursion root of the scoped sweep — chown -h -R re-owns the link
+    // itself (via -h, WITHOUT dereferencing into the shared pool). This test
+    // fails loudly if skills are ever moved out of the .claude subtree.
+    const dir = makeTree();
+    try {
+      const skillsDir = join(dir, ".claude", "skills");
+      mkdirSync(skillsDir, { recursive: true });
+      symlinkSync("../../../../skills/_bundled/dev-protocol", join(skillsDir, "dev-protocol"));
+
+      const recursed: string[] = [];
+      ownershipRuntime.chownShallow = () => {};
+      ownershipRuntime.chownTree = (_u, _g, root) => recursed.push(root);
+
+      const uid = allocateAgentUid(AGENT);
+      chownScopedTree(uid, uid, dir);
+
+      // .claude is a recursion root, so `chown -h -R` covers the skill link.
+      expect(recursed).toContain(join(dir, ".claude"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("skips a scoped subdir that does not exist", () => {
     const dir = mkdtempSync(join(tmpdir(), "switchroom-scoped-"));
     try {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1,6 +1,20 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync, readlinkSync, lstatSync, readdirSync, cpSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+/**
+ * Assert `linkPath` is a switchroom-written pool skill link (footgun A):
+ * the stored target is RELATIVE (never absolute — absolute links baked with
+ * homedir() dangle across container mount contexts) and resolves, from the
+ * link's own directory, to `expectedPoolTarget`.
+ */
+function expectRelativePoolLink(linkPath: string, expectedPoolTarget: string): void {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { readlinkSync: rl } = require("node:fs");
+  const stored: string = rl(linkPath);
+  expect(isAbsolute(stored)).toBe(false);
+  expect(resolve(dirname(linkPath), stored)).toBe(resolve(expectedPoolTarget));
+}
 import { tmpdir } from "node:os";
 import { scaffoldAgent, reconcileAgent, installHindsightPlugin, installSwitchroomSkills, renderFleetInvariants } from "../src/agents/scaffold.js";
 import { createVault, setStringSecret } from "../src/vault/vault.js";
@@ -3774,7 +3788,7 @@ describe("scaffoldAgent global skills pool", () => {
     expect(existsSync(retainPath)).toBe(true);
     // Verify they're symlinks pointing into the pool
     const { readlinkSync } = require("node:fs");
-    expect(readlinkSync(checkinPath)).toBe(join(skillsPool, "checkin"));
+    expectRelativePoolLink(checkinPath, join(skillsPool, "checkin"));
   });
 
   it("unions defaults.skills with agent.skills in the symlink pass", () => {
@@ -4989,7 +5003,10 @@ describe("installSwitchroomSkills", () => {
       if (!existsSync(join(src, "SKILL.md"))) continue;
       const dest = join(targetSkillsDir, name);
       try { lstatSync(dest); continue; } catch { /* not found — create */ }
-      try { require("node:fs").symlinkSync(src, dest); } catch { /* ignore */ }
+      // Mirror production installSwitchroomSkills: write a RELATIVE link
+      // (footgun A), computed via path.relative, not an absolute src.
+      const relTarget = require("node:path").relative(dirname(dest), src);
+      try { require("node:fs").symlinkSync(relTarget, dest); } catch { /* ignore */ }
     }
   }
 
@@ -5000,8 +5017,8 @@ describe("installSwitchroomSkills", () => {
     expect(existsSync(join(skillsDir, "switchroom-manage"))).toBe(true);
     expect(existsSync(join(skillsDir, "switchroom-health"))).toBe(true);
     // Verify they are symlinks pointing into fakeSkillsDir
-    expect(readlinkSync(join(skillsDir, "switchroom-manage"))).toBe(join(fakeSkillsDir, "switchroom-manage"));
-    expect(readlinkSync(join(skillsDir, "switchroom-health"))).toBe(join(fakeSkillsDir, "switchroom-health"));
+    expectRelativePoolLink(join(skillsDir, "switchroom-manage"), join(fakeSkillsDir, "switchroom-manage"));
+    expectRelativePoolLink(join(skillsDir, "switchroom-health"), join(fakeSkillsDir, "switchroom-health"));
   });
 
   it("skips switchroom-* directories that have no SKILL.md", () => {
@@ -5022,7 +5039,7 @@ describe("installSwitchroomSkills", () => {
     expect(() => runWithFakeSkills(agentDir)).not.toThrow();
     const skillsDir = join(agentDir, ".claude", "skills");
     expect(existsSync(join(skillsDir, "switchroom-manage"))).toBe(true);
-    expect(readlinkSync(join(skillsDir, "switchroom-manage"))).toBe(join(fakeSkillsDir, "switchroom-manage"));
+    expectRelativePoolLink(join(skillsDir, "switchroom-manage"), join(fakeSkillsDir, "switchroom-manage"));
   });
 
   it("does not disturb pre-existing non-switchroom skills in .claude/skills/", () => {


### PR DESCRIPTION
## Summary
Kills footgun A (the recurring "bundled skills vanished in some containers" incident): skill symlinks were baked with **absolute** pool targets computed from `homedir()` in whichever container ran the scaffold. A link written from hostd (`HOME=/host-home`) baked `/host-home/...`, which does not exist in an agent's `/home/<op>/...` mount view, so the link dangled.

## Why
`agents/<name>/.claude/skills/` and `skills/` share one `~/.switchroom` root in **every** mount view, so a **relative** link is invariant under the mount-prefix — the path-context bug becomes unrepresentable. Depth is computed via `path.relative`, never a hardcoded `../` literal (per the review's HIGH finding: 4-deep for `_bundled` defaults, 3-deep for personal-pool links — a single constant would be wrong for both).

Job spec: fleet reliability / rollout-hardening.

## What changed
All pool→agent link sites now write relative targets and resolve stored targets before owned/stale classification (recognizing both the new relative form and the legacy absolute form):
- `reconcile-default-skills.ts` — builtin defaults; existing absolute owned links are rewritten to relative on converge (one-time heal), then idempotent.
- `scaffold.ts` — `syncGlobalSkills`, `migrateLegacySkillsDir`, stale-cleanup, `installSwitchroomSkills` (install + retract).

**UID-safety** (review missing-footgun #6): the rm+re-create migration runs from a root reconcile writer, so links must be re-owned to the agent UID or the agent can't traverse them (#3168). Guaranteed by the existing end-of-reconcile ownership sweep (`chown -h -R` over `.claude`, `-h` re-owns the link inode without dereferencing into the shared pool). New test pins that `.claude/skills` is inside the swept scope.

## Test plan
- Migration test: absolute→relative rewrite, then idempotent.
- Link resolution asserted via `readlink` + `resolve` landing on the pool file (the only assertion that would catch an absolute-link regression).
- Scoped-sweep skill-link coverage test.
- reconcile-default-skills + scaffold + scoped-sweep green (238); full agents area 456 green; `tsc` + full `npm run lint` clean.

## Risk
Medium. Rewrites existing links on next converge. Foreign (operator-custom) links are left untouched; real dirs/files never touched. Part of a batched rollout-hardening release; **do not merge standalone** — hold for the batch go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)