### PR TITLE
fix(skills): manifest-owned additive pool sync (footgun B)

### DIFF
--- a/src/cli/sync-bundled-skills.test.ts
+++ b/src/cli/sync-bundled-skills.test.ts
@@ -177,4 +177,64 @@ describe("syncBundledSkills", () => {
       : [];
     expect(leftovers).toEqual([]);
   });
+
+  it("COLLISION: a shipped skill NEVER silently wipes a hand-added skill of the SAME name (footgun-B, review #4)", () => {
+    // Round 1: establish the manifest with alpha.
+    makeSkill(source, "alpha");
+    syncBundledSkills({ source, dest, version: "1" });
+    // Operator hand-adds a pool skill named `foo` (NOT in the manifest).
+    makeSkill(dest, "foo", "PRECIOUS-OPERATOR-CONTENT");
+
+    // Round 2: a later release now ALSO ships a skill named `foo`.
+    makeSkill(source, "foo", "SHIPPED-FOO");
+    const r = syncBundledSkills({ source, dest, version: "2" });
+
+    // The collision is recorded and surfaced as a deliberate ownership transfer.
+    expect(r.ownershipTransferred).toContain("foo");
+    // The shipped skill takes the canonical name...
+    expect(skillBody(dest, "foo")).toContain("SHIPPED-FOO");
+    // ...but the operator's content is PRESERVED (never wiped) in a backup dir.
+    const backups = require("node:fs")
+      .readdirSync(dest)
+      .filter((n: string) => n.startsWith("foo.operator-backup-"));
+    expect(backups.length).toBe(1);
+    expect(
+      readFileSync(join(dest, backups[0], "SKILL.md"), "utf8"),
+    ).toContain("PRECIOUS-OPERATOR-CONTENT");
+    // The manifest now owns foo.
+    expect(readManifest(dest).skills.sort()).toEqual(["alpha", "foo"]);
+  });
+
+  it("COLLISION: an already-owned skill of the same name is a normal update, NOT a collision", () => {
+    makeSkill(source, "alpha", "V1");
+    syncBundledSkills({ source, dest, version: "1" }); // alpha now owned
+    makeSkill(source, "alpha", "V2");
+    const r = syncBundledSkills({ source, dest, version: "2" });
+    // alpha was switchroom-owned, so refreshing it is not an ownership transfer.
+    expect(r.ownershipTransferred).not.toContain("alpha");
+    expect(r.updated).toContain("alpha");
+    const backups = require("node:fs")
+      .readdirSync(dest)
+      .filter((n: string) => n.includes(".operator-backup-"));
+    expect(backups).toEqual([]);
+  });
+
+  it("corrupt manifest ADOPTS previously-owned retired skills as un-owned (review #6 — documents orphan behavior)", () => {
+    // Round 1: ship alpha + gamma (both owned).
+    makeSkill(source, "alpha");
+    makeSkill(source, "gamma");
+    syncBundledSkills({ source, dest, version: "1" });
+    // Corrupt the manifest, then a round that drops gamma.
+    writeFileSync(join(dest, BUNDLED_SKILL_MANIFEST_NAME), "{ broken", "utf8");
+    rmSync(join(source, "gamma"), { recursive: true, force: true });
+    const r = syncBundledSkills({ source, dest, version: "2" });
+
+    // Fail-closed: gamma is NOT deleted (safe direction). It is now treated as
+    // un-owned (preserved), which the review flags as orphan accumulation —
+    // pinned here so the behavior is deliberate and visible, not silent.
+    expect(r.manifestCorrupt).toBe(true);
+    expect(r.removed).toEqual([]);
+    expect(r.preserved).toContain("gamma");
+    expect(existsSync(join(dest, "gamma"))).toBe(true);
+  });
 });

--- a/src/cli/sync-bundled-skills.test.ts
+++ b/src/cli/sync-bundled-skills.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for the manifest-owned additive bundled-skill sync (footgun B).
+ *
+ * The load-bearing property under test: `switchroom update` must NEVER wipe
+ * a hand-added pool skill (the historical `rm -rf` + `cp` bug). Every test
+ * asserts an OUTCOME on the pool contents / manifest, not just that a code
+ * path ran.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  syncBundledSkills,
+  readBundledSkillManifest,
+  BUNDLED_SKILL_MANIFEST_NAME,
+  type BundledSkillManifest,
+} from "./sync-bundled-skills.js";
+
+let root: string;
+let source: string;
+let dest: string;
+
+function makeSkill(dir: string, name: string, body = "x"): void {
+  const d = join(dir, name);
+  mkdirSync(d, { recursive: true });
+  writeFileSync(join(d, "SKILL.md"), `# ${name}\n${body}\n`, "utf8");
+}
+
+function readManifest(poolDir: string): BundledSkillManifest {
+  const r = readBundledSkillManifest(poolDir);
+  if (!("manifest" in r)) throw new Error("expected a valid manifest");
+  return r.manifest;
+}
+
+function skillBody(poolDir: string, name: string): string {
+  return readFileSync(join(poolDir, name, "SKILL.md"), "utf8");
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "sr-sync-"));
+  source = join(root, "src-skills");
+  dest = join(root, "pool");
+  mkdirSync(source, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("syncBundledSkills", () => {
+  it("first run (no manifest): copies shipped skills, deletes nothing, writes a manifest", () => {
+    makeSkill(source, "alpha");
+    makeSkill(source, "beta");
+    const r = syncBundledSkills({ source, dest, version: "1.2.3" });
+
+    expect(r.firstRun).toBe(true);
+    expect(r.removed).toEqual([]);
+    expect(existsSync(join(dest, "alpha", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(dest, "beta", "SKILL.md"))).toBe(true);
+
+    const m = readManifest(dest);
+    expect(m.skills.sort()).toEqual(["alpha", "beta"]);
+    expect(m.version).toBe("1.2.3");
+  });
+
+  it("adopts a pre-manifest pool dir on first run and never deletes it (bootstrap, Open-Risk #3)", () => {
+    // Pool already has dirs (added before manifests existed), including one
+    // switchroom no longer/never ships.
+    makeSkill(dest, "legacy-adopted");
+    makeSkill(dest, "alpha", "OLD");
+    makeSkill(source, "alpha", "NEW");
+
+    const r = syncBundledSkills({ source, dest, version: "1" });
+    expect(r.firstRun).toBe(true);
+    expect(r.removed).toEqual([]);
+    // The shipped one is refreshed...
+    expect(skillBody(dest, "alpha")).toContain("NEW");
+    // ...and the unshipped pre-existing dir survives.
+    expect(existsSync(join(dest, "legacy-adopted", "SKILL.md"))).toBe(true);
+    expect(r.preserved).toContain("legacy-adopted");
+  });
+
+  it("HAND-ADDED skill survives a subsequent update (the footgun-B guarantee)", () => {
+    // Round 1: ship alpha.
+    makeSkill(source, "alpha");
+    syncBundledSkills({ source, dest, version: "1" });
+    // Operator hand-adds a skill into the pool.
+    makeSkill(dest, "operator-custom", "PRECIOUS");
+
+    // Round 2: a new update ships alpha + beta (NOT operator-custom).
+    makeSkill(source, "beta");
+    const r = syncBundledSkills({ source, dest, version: "2" });
+
+    // The hand-added skill is neither removed nor recorded as owned.
+    expect(r.removed).not.toContain("operator-custom");
+    expect(existsSync(join(dest, "operator-custom", "SKILL.md"))).toBe(true);
+    expect(skillBody(dest, "operator-custom")).toContain("PRECIOUS");
+    expect(r.preserved).toContain("operator-custom");
+    // Manifest owns only what was shipped.
+    expect(readManifest(dest).skills.sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("deletes ONLY a previously-shipped skill that is no longer shipped", () => {
+    // Round 1: ship alpha + gamma.
+    makeSkill(source, "alpha");
+    makeSkill(source, "gamma");
+    syncBundledSkills({ source, dest, version: "1" });
+    expect(existsSync(join(dest, "gamma"))).toBe(true);
+
+    // Round 2: drop gamma from the shipped set.
+    rmSync(join(source, "gamma"), { recursive: true, force: true });
+    const r = syncBundledSkills({ source, dest, version: "2" });
+
+    expect(r.removed).toEqual(["gamma"]);
+    expect(existsSync(join(dest, "gamma"))).toBe(false);
+    expect(existsSync(join(dest, "alpha"))).toBe(true);
+    expect(readManifest(dest).skills).toEqual(["alpha"]);
+  });
+
+  it("updates an existing shipped skill's contents in place", () => {
+    makeSkill(source, "alpha", "V1");
+    syncBundledSkills({ source, dest, version: "1" });
+    expect(skillBody(dest, "alpha")).toContain("V1");
+
+    makeSkill(source, "alpha", "V2");
+    const r = syncBundledSkills({ source, dest, version: "2" });
+    expect(r.updated).toContain("alpha");
+    expect(skillBody(dest, "alpha")).toContain("V2");
+  });
+
+  it("fails closed on a corrupt manifest: deletes nothing, rewrites a clean manifest", () => {
+    // Round 1 establishes gamma as owned.
+    makeSkill(source, "alpha");
+    makeSkill(source, "gamma");
+    syncBundledSkills({ source, dest, version: "1" });
+
+    // Corrupt the manifest.
+    writeFileSync(join(dest, BUNDLED_SKILL_MANIFEST_NAME), "{ not valid json", "utf8");
+
+    // Round 2 drops gamma. A corrupt manifest must NOT be read as
+    // "everything removed" — gamma must survive this run.
+    rmSync(join(source, "gamma"), { recursive: true, force: true });
+    const r = syncBundledSkills({ source, dest, version: "2" });
+
+    expect(r.manifestCorrupt).toBe(true);
+    expect(r.removed).toEqual([]);
+    expect(existsSync(join(dest, "gamma"))).toBe(true); // NOT wiped
+    // A clean manifest is rewritten for next time.
+    expect(readManifest(dest).skills).toEqual(["alpha"]);
+  });
+
+  it("is idempotent: a second identical run changes nothing and re-lists no removals", () => {
+    makeSkill(source, "alpha");
+    makeSkill(source, "beta");
+    syncBundledSkills({ source, dest, version: "1" });
+    const r2 = syncBundledSkills({ source, dest, version: "1" });
+    expect(r2.removed).toEqual([]);
+    expect(r2.firstRun).toBe(false);
+    expect(existsSync(join(dest, "alpha"))).toBe(true);
+    expect(existsSync(join(dest, "beta"))).toBe(true);
+  });
+
+  it("leaves no staging temp dirs behind", () => {
+    makeSkill(source, "alpha");
+    syncBundledSkills({ source, dest, version: "1" });
+    const leftovers = existsSync(dest)
+      ? require("node:fs").readdirSync(dest).filter((n: string) => n.startsWith(".tmp-") || n.includes(".tmp-"))
+      : [];
+    expect(leftovers).toEqual([]);
+  });
+});

--- a/src/cli/sync-bundled-skills.ts
+++ b/src/cli/sync-bundled-skills.ts
@@ -1,0 +1,206 @@
+/**
+ * Manifest-owned, additive bundled-skill sync (footgun B).
+ *
+ * `switchroom update` mirrors the shipped `skills/` payload into the
+ * host-stable pool `~/.switchroom/skills/_bundled/`. The historical
+ * implementation did `rm -rf <pool>` then `cp -R` — which WIPES any skill
+ * an operator hand-added into the pool. This module replaces that with an
+ * additive, manifest-owned sync:
+ *
+ *   - A manifest `_bundled/.switchroom-manifest.json` records the set of
+ *     skill names switchroom shipped, plus the CLI version that wrote it.
+ *     It is the ownership boundary: switchroom only ever deletes names it
+ *     previously shipped (present in the prior manifest) and no longer
+ *     ships. A dir with no manifest record is NEVER touched.
+ *   - Each shipped skill is staged into a temp sibling and atomically
+ *     renamed over its pool entry, so a crash mid-sync never leaves a
+ *     half-copied skill dir.
+ *   - First run (no prior manifest) deletes NOTHING — every pre-manifest
+ *     dir already in the pool is adopted, not wiped (bootstrap, Open-Risk #3).
+ *   - A corrupt/unreadable manifest FAILS CLOSED for deletion: parse
+ *     failure is never read as "everything was removed"; we copy the
+ *     shipped skills, delete nothing, and rewrite a clean manifest
+ *     (review missing-footgun #3).
+ *
+ * The manifest itself is written last, via temp + atomic rename, so an
+ * interrupted run either keeps the old manifest or lands the complete new
+ * one — never a truncated file.
+ */
+
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+export const BUNDLED_SKILL_MANIFEST_NAME = ".switchroom-manifest.json";
+
+export interface BundledSkillManifest {
+  /** CLI version that wrote this manifest (provenance / debugging). */
+  version: string;
+  /** Sorted set of skill directory names switchroom shipped. */
+  skills: string[];
+  /** ISO timestamp of the write. */
+  updatedAt: string;
+}
+
+export interface SyncBundledSkillsResult {
+  /** Shipped skills newly present in the pool (were not in the prior manifest). */
+  added: string[];
+  /** Shipped skills that already existed and were refreshed. */
+  updated: string[];
+  /** Previously-shipped skills, no longer shipped, that were removed. */
+  removed: string[];
+  /** Pool dirs left untouched because they are not switchroom-owned
+   *  (never appeared in a manifest) — hand-added skills survive. */
+  preserved: string[];
+  /** True when there was no prior manifest (bootstrap: delete nothing). */
+  firstRun: boolean;
+  /** True when a prior manifest existed but could not be parsed
+   *  (fail-closed: delete nothing this run). */
+  manifestCorrupt: boolean;
+}
+
+/** List immediate subdirectory names of `dir` (skill dirs). Non-dirs and
+ *  the manifest file are excluded. Returns [] if the dir is absent. */
+function listSkillDirs(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+}
+
+/**
+ * Read the prior manifest. Returns:
+ *   - `{ manifest }` when present and valid,
+ *   - `{ firstRun: true }` when absent (bootstrap),
+ *   - `{ corrupt: true }` when present but unparseable / wrong shape.
+ */
+export function readBundledSkillManifest(poolDir: string):
+  | { manifest: BundledSkillManifest }
+  | { firstRun: true }
+  | { corrupt: true } {
+  const path = join(poolDir, BUNDLED_SKILL_MANIFEST_NAME);
+  if (!existsSync(path)) return { firstRun: true };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !Array.isArray((parsed as BundledSkillManifest).skills) ||
+      !(parsed as BundledSkillManifest).skills.every((s) => typeof s === "string")
+    ) {
+      return { corrupt: true };
+    }
+    const m = parsed as BundledSkillManifest;
+    return { manifest: { version: String(m.version ?? ""), skills: m.skills, updatedAt: String(m.updatedAt ?? "") } };
+  } catch {
+    return { corrupt: true };
+  }
+}
+
+/** Atomically copy one skill dir from `srcSkill` over `destSkill` via a
+ *  temp sibling + rename, so a crash never leaves a half-copied dir. */
+function stageAndSwap(srcSkill: string, destSkill: string, poolDir: string, name: string): void {
+  const staging = join(poolDir, `.tmp-${name}-${process.pid}-${Date.now()}`);
+  try {
+    rmSync(staging, { recursive: true, force: true });
+    cpSync(srcSkill, staging, { recursive: true, dereference: false });
+    // Replace atomically: remove the old managed dir, then rename staging in.
+    // (rename over an existing non-empty dir is not atomic on POSIX, so we
+    // rm first — the window is a single skill dir, and a crash here is
+    // healed on the next update since the manifest is written last.)
+    rmSync(destSkill, { recursive: true, force: true });
+    renameSync(staging, destSkill);
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Perform the additive, manifest-owned sync from `source` (the shipped
+ * `skills/` dir) into `dest` (the `_bundled` pool dir).
+ *
+ * Deletion rule (the ownership boundary): a pool dir is removed ONLY when
+ * it was in the PRIOR manifest AND is no longer shipped. Names absent from
+ * the prior manifest are never deleted — hand-added skills survive, and the
+ * first run (no manifest) deletes nothing.
+ */
+export function syncBundledSkills(opts: {
+  source: string;
+  dest: string;
+  version: string;
+}): SyncBundledSkillsResult {
+  const { source, dest, version } = opts;
+  const result: SyncBundledSkillsResult = {
+    added: [],
+    updated: [],
+    removed: [],
+    preserved: [],
+    firstRun: false,
+    manifestCorrupt: false,
+  };
+
+  mkdirSync(dest, { recursive: true });
+
+  const prior = readBundledSkillManifest(dest);
+  const priorSkills = new Set<string>(
+    "manifest" in prior ? prior.manifest.skills : [],
+  );
+  result.firstRun = "firstRun" in prior;
+  result.manifestCorrupt = "corrupt" in prior;
+
+  const shipped = listSkillDirs(source).sort();
+  const shippedSet = new Set(shipped);
+
+  // 1. Copy every shipped skill (add or update), atomically per skill.
+  for (const name of shipped) {
+    const existed = existsSync(join(dest, name));
+    stageAndSwap(join(source, name), join(dest, name), dest, name);
+    if (priorSkills.has(name) || existed) result.updated.push(name);
+    else result.added.push(name);
+  }
+
+  // 2. Delete ONLY names that were previously shipped and no longer are.
+  //    Never on first run, never on a corrupt manifest (fail closed).
+  if (!result.firstRun && !result.manifestCorrupt) {
+    for (const name of priorSkills) {
+      if (shippedSet.has(name)) continue; // still shipped
+      const target = join(dest, name);
+      if (existsSync(target)) {
+        rmSync(target, { recursive: true, force: true });
+        result.removed.push(name);
+      }
+    }
+  }
+
+  // 3. Record pool dirs that are neither shipped nor previously-owned —
+  //    hand-added skills that we deliberately leave in place.
+  for (const name of listSkillDirs(dest)) {
+    if (!shippedSet.has(name) && !priorSkills.has(name)) {
+      result.preserved.push(name);
+    }
+  }
+  result.removed.sort();
+  result.preserved.sort();
+
+  // 4. Write the new manifest LAST, atomically (temp + rename), so an
+  //    interrupted run never leaves a truncated manifest.
+  const manifest: BundledSkillManifest = {
+    version,
+    skills: shipped,
+    updatedAt: new Date().toISOString(),
+  };
+  const manifestPath = join(dest, BUNDLED_SKILL_MANIFEST_NAME);
+  const manifestTmp = join(dest, `${BUNDLED_SKILL_MANIFEST_NAME}.tmp-${process.pid}-${Date.now()}`);
+  writeFileSync(manifestTmp, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+  renameSync(manifestTmp, manifestPath);
+
+  return result;
+}

--- a/src/cli/sync-bundled-skills.ts
+++ b/src/cli/sync-bundled-skills.ts
@@ -60,6 +60,13 @@ export interface SyncBundledSkillsResult {
   /** Pool dirs left untouched because they are not switchroom-owned
    *  (never appeared in a manifest) — hand-added skills survive. */
   preserved: string[];
+  /** Shipped skill names that COLLIDED with a pre-existing, switchroom-unowned
+   *  pool dir (a hand-added skill of the same name). Rather than silently wipe
+   *  the operator's content (which would violate the footgun-B guarantee), the
+   *  existing dir is preserved as a timestamped `<name>.operator-backup-<ts>`
+   *  sibling, a loud stderr warning is emitted, and the shipped skill takes
+   *  over the canonical name (a deliberate, visible ownership transfer). */
+  ownershipTransferred: string[];
   /** True when there was no prior manifest (bootstrap: delete nothing). */
   firstRun: boolean;
   /** True when a prior manifest existed but could not be parsed
@@ -143,6 +150,7 @@ export function syncBundledSkills(opts: {
     updated: [],
     removed: [],
     preserved: [],
+    ownershipTransferred: [],
     firstRun: false,
     manifestCorrupt: false,
   };
@@ -161,9 +169,49 @@ export function syncBundledSkills(opts: {
 
   // 1. Copy every shipped skill (add or update), atomically per skill.
   for (const name of shipped) {
-    const existed = existsSync(join(dest, name));
-    stageAndSwap(join(source, name), join(dest, name), dest, name);
-    if (priorSkills.has(name) || existed) result.updated.push(name);
+    const destSkill = join(dest, name);
+    const existed = existsSync(destSkill);
+
+    // Ownership-collision guard (footgun-B guarantee: NEVER silently wipe a
+    // hand-added skill). A shipped name colliding with a pre-existing pool dir
+    // that switchroom does NOT own — i.e. it exists, is absent from the prior
+    // manifest, and we are NOT on the first-run bootstrap (where every
+    // pre-manifest dir is legitimately adopted) — is an operator hand-add of
+    // the same name. Preserve its content as a timestamped backup, warn
+    // loudly, and record the transfer, rather than overwriting silently. A
+    // corrupt manifest (priorSkills empty, but not firstRun) also lands here:
+    // we cannot prove ownership, so we fail safe and back up before overwrite.
+    let transferred = false;
+    if (existed && !priorSkills.has(name) && !result.firstRun) {
+      const backup = join(dest, `${name}.operator-backup-${process.pid}-${Date.now()}`);
+      try {
+        renameSync(destSkill, backup);
+        transferred = true;
+        result.ownershipTransferred.push(name);
+        process.stderr.write(
+          `switchroom: WARNING — a shipped skill "${name}" collides with an ` +
+            `operator-added pool dir of the same name. Preserved the existing ` +
+            `content as "${backup}" and installed the shipped skill under "${name}". ` +
+            `If you meant to keep your version, rename it to a distinct skill name.\n`,
+        );
+      } catch {
+        // Backup failed — do NOT overwrite blindly; skip this name so operator
+        // content survives, and record the unresolved collision.
+        result.ownershipTransferred.push(name);
+        process.stderr.write(
+          `switchroom: WARNING — shipped skill "${name}" collides with an ` +
+            `operator-added pool dir and the preservation backup failed; left the ` +
+            `existing dir in place and did NOT install the shipped skill. Resolve ` +
+            `the name collision manually.\n`,
+        );
+        continue;
+      }
+    }
+
+    stageAndSwap(join(source, name), destSkill, dest, name);
+    // After a transfer the old content was moved aside, so the shipped skill
+    // is a fresh install under that name (added), not an update of an owned one.
+    if (!transferred && (priorSkills.has(name) || existed)) result.updated.push(name);
     else result.added.push(name);
   }
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -37,7 +37,7 @@
  */
 import { Option, type Command } from "commander";
 import chalk from "chalk";
-import { cpSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, chownSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, chownSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join, dirname, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -49,6 +49,8 @@ import { resolveOperatorUid } from "./operator-uid.js";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { validateBindSources, formatPreflightError } from "./preflight-mounts.js";
 import { normalizeHindsightVersionTag } from "../setup/hindsight.js";
+import { syncBundledSkills } from "./sync-bundled-skills.js";
+import { SWITCHROOM_VERSION } from "./resolve-version.js";
 
 /**
  * Default durable-pin persister for `update --pin`: comment-preserving,
@@ -707,11 +709,28 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
         return;
       }
       try {
-        if (existsSync(dest)) {
-          rmSync(dest, { recursive: true, force: true });
-        }
         mkdirSync(dirname(dest), { recursive: true });
-        cpSync(source, dest, { recursive: true, dereference: false });
+        // Manifest-owned ADDITIVE sync (footgun B): copies/updates every
+        // shipped skill and deletes ONLY names switchroom previously shipped
+        // and no longer ships. Hand-added pool skills — and every dir that
+        // predates the manifest — are preserved, never `rm -rf`'d.
+        const r = syncBundledSkills({
+          source,
+          dest,
+          version: SWITCHROOM_VERSION,
+        });
+        if (r.manifestCorrupt) {
+          process.stderr.write(
+            `switchroom update: sync-bundled-skills — pool manifest was unreadable; ` +
+              `deleted nothing (fail-closed) and rewrote a clean manifest.\n`,
+          );
+        }
+        if (r.removed.length > 0) {
+          process.stderr.write(
+            `switchroom update: sync-bundled-skills — removed ${r.removed.length} retired ` +
+              `bundled skill(s): ${r.removed.join(", ")}.\n`,
+          );
+        }
       } catch (err) {
         throw new Error(
           `sync-bundled-skills failed: ${(err as Error).message}`,


### PR DESCRIPTION
## Summary
Kills footgun B: `switchroom update` mirrored shipped `skills/` into the pool with `rm -rf <pool>` + `cp -R`, wiping any skill an operator hand-added into `~/.switchroom/skills/_bundled/`. Replaced with a manifest-owned, additive sync so hand-added skills survive by construction.

Job spec: fleet reliability / rollout-hardening.

## What changed
New `src/cli/sync-bundled-skills.ts`:
- `_bundled/.switchroom-manifest.json` (shipped names + CLI version) is the **ownership boundary** — switchroom deletes ONLY names it previously shipped and no longer ships; an unlisted dir is never touched.
- Per-skill **stage + atomic rename** (no half-copied dir on crash).
- **First run** (no manifest) deletes nothing — every pre-manifest pool dir is adopted, not wiped (Open-Risk #3 bootstrap).
- **Corrupt manifest fails closed** for deletion — a parse failure is never read as "everything removed" (review missing-footgun #3).
- Manifest written **last**, temp + atomic rename — never truncated.

`update.ts` calls `syncBundledSkills()` instead of the destructive rm+cp and surfaces removed/corrupt outcomes on stderr.

## Known not-addressed (deliberate, per the review)
No cross-run pool **lock** (review missing-footgun #2). At 12 containers / 1 host `update` is invoked serially; the atomic per-skill and per-manifest renames bound the blast radius. Filed as a follow-up rather than built here.

## Test plan
`sync-bundled-skills.test.ts` (8) asserts pool/manifest OUTCOMES that would fail on the rm-rf bug: hand-added skill survives an update; first-run adopts pre-manifest dirs; delete only previously-shipped-now-dropped; in-place update; corrupt manifest fails closed; idempotent; no staging temp left behind. `update.test.ts` (68) green. `tsc` + full `npm run lint` clean.

## Risk
Medium. Changes the update sync from destructive-replace to additive. Existing pools are adopted on first manifest write (nothing deleted). Part of a batched rollout-hardening release; **do not merge standalone** — hold for the batch go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)