### PR TITLE
refactor(scaffold): single source of truth for permission-allow (footgun G)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3931,6 +3931,72 @@ export const INTEGRATION_MCP_RESOLVERS: readonly IntegrationMcpResolver[] = [
   },
 ];
 
+/**
+ * Compute the effective `permissions.allow` list for an agent's
+ * settings.json from its resolved config (footgun G — one converge engine).
+ *
+ * This is the SINGLE SOURCE OF TRUTH for the allow-list, called by BOTH the
+ * create path (`scaffoldAgent`) and the reconcile path (`reconcileAgentInner`).
+ * The two used to inline byte-identical copies with a comment demanding they
+ * "stay in lockstep" — the exact drift footgun. Extracting it makes the
+ * lockstep a compile-time fact, not a discipline, and the scaffold↔reconcile
+ * parity test pins that no caller diverges.
+ *
+ * IMPORTANT: this reads `agentConfig.tools.allow` as-is. The reconcile path's
+ * separate legacy-token strip (which mutates the persisted `tools.allow`) must
+ * run AFTER this is called, so the computed allow-list matches the historical
+ * pre-strip `baseAllow` behaviour exactly. Do not reorder.
+ *
+ * @param agentConfig      Cascade-resolved agent config.
+ * @param hindsightEnabled Result of `isHindsightEnabled(switchroomConfig)`
+ *                         (passed in so both callers share the one probe).
+ */
+export function computeDesiredPermissionAllow(
+  agentConfig: AgentConfig,
+  hindsightEnabled: boolean,
+): string[] {
+  const tools = agentConfig.tools ?? { allow: [], deny: [] };
+  const rawAllow = tools.allow ?? [];
+  const hasAllWildcard = rawAllow.includes("all");
+  const baseAllow = hasAllWildcard
+    // `[all]` means "all built-ins" — but it must ALSO keep any explicit tools
+    // the operator listed alongside it. A 🔁 "Always allow" tap persists a
+    // privileged hostd / Skill / 3rd-party-MCP rule into tools.allow as
+    // `[all, mcp__hostd__agent_logs]` (those are deliberately NOT in
+    // ALL_BUILTIN_TOOLS — the leash: even an [all] admin approves them once).
+    // Dropping the explicit entries here is why such grants never reached
+    // settings.json and the agent re-asked forever (klanker, 2026-06-15).
+    ? [...ALL_BUILTIN_TOOLS, ...rawAllow.filter((t) => t !== "all")]
+    : rawAllow.filter((t) => t !== "all");
+  // If the user didn't specify any allowed tools AND dangerous_mode is off,
+  // seed a safe read-only default set so routine tool calls don't spam the
+  // approval UI. Risky tools still prompt and hit the Telegram button flow.
+  const dangerousMode = agentConfig.dangerous_mode === true;
+  const hadExplicitAllow = rawAllow.length > 0;
+  const readOnlyDefaults =
+    !dangerousMode && !hadExplicitAllow ? DEFAULT_READ_ONLY_PREAPPROVED_TOOLS : [];
+  return dedupe([
+    ...baseAllow,
+    ...readOnlyDefaults,
+    ...(usesSwitchroomTelegramPlugin(agentConfig) ? SWITCHROOM_TELEGRAM_MCP_TOOLS : []),
+    ...(hindsightEnabled ? HINDSIGHT_MCP_TOOLS : []),
+    // agent-config + hostd are always wired into .mcp.json so the
+    // prompt fragment can claim "you have these tools available" —
+    // but Claude Code blocks the first call on a permission prompt
+    // unless the tool is on the allow list. Pre-approve unconditionally
+    // (daemon-side gates remain the real security boundary).
+    ...AGENT_CONFIG_MCP_TOOLS,
+    ...HOSTD_MCP_TOOLS,
+    // Webkite is fleet-default (resolveWebkiteMcpEntry) unless the agent
+    // opts out. Pre-approve its tools so the first web fetch doesn't
+    // wedge on a permission prompt — webkite IS the web-fetch path now
+    // (native WebFetch/WebSearch are denied). Gated on the same opt-out
+    // as the MCP entry emission, so a webkite-disabled agent doesn't
+    // carry dangling pre-approvals.
+    ...(agentConfig.mcp_servers?.["webkite"] === false ? [] : WEBKITE_MCP_TOOLS),
+  ]);
+}
+
 export function scaffoldAgent(
   name: string,
   agentConfigRaw: AgentConfig,
@@ -3994,46 +4060,12 @@ export function scaffoldAgent(
   const tools = agentConfig.tools ?? { allow: [], deny: [] };
   const rawAllow = tools.allow ?? [];
   const hasAllWildcard = rawAllow.includes("all");
-  const baseAllow = hasAllWildcard
-    // `[all]` means "all built-ins" — but it must ALSO keep any explicit tools
-    // the operator listed alongside it. A 🔁 "Always allow" tap persists a
-    // privileged hostd / Skill / 3rd-party-MCP rule into tools.allow as
-    // `[all, mcp__hostd__agent_logs]` (those are deliberately NOT in
-    // ALL_BUILTIN_TOOLS — the leash: even an [all] admin approves them once).
-    // Dropping the explicit entries here is why such grants never reached
-    // settings.json and the agent re-asked forever (klanker, 2026-06-15).
-    ? [...ALL_BUILTIN_TOOLS, ...rawAllow.filter((t) => t !== "all")]
-    : rawAllow.filter((t) => t !== "all");
-  // If the user didn't specify any allowed tools AND dangerous_mode is off,
-  // seed a safe read-only default set so routine tool calls don't spam the
-  // approval UI. Risky tools still prompt and hit the Telegram button flow.
-  const dangerousMode = agentConfig.dangerous_mode === true;
-  const hadExplicitAllow = rawAllow.length > 0;
-  const readOnlyDefaults =
-    !dangerousMode && !hadExplicitAllow ? DEFAULT_READ_ONLY_PREAPPROVED_TOOLS : [];
   // Single source of truth — honors SWITCHROOM_MEMORY_BACKEND=none
   // (install-validation 2026-05-17, R2 / prior #25).
   const hindsightEnabled = isHindsightEnabled(switchroomConfig);
-  const permissionAllow = dedupe([
-    ...baseAllow,
-    ...readOnlyDefaults,
-    ...(usesSwitchroomTelegramPlugin(agentConfig) ? SWITCHROOM_TELEGRAM_MCP_TOOLS : []),
-    ...(hindsightEnabled ? HINDSIGHT_MCP_TOOLS : []),
-    // agent-config + hostd are always wired into .mcp.json so the
-    // prompt fragment can claim "you have these tools available" —
-    // but Claude Code blocks the first call on a permission prompt
-    // unless the tool is on the allow list. Pre-approve unconditionally
-    // (daemon-side gates remain the real security boundary).
-    ...AGENT_CONFIG_MCP_TOOLS,
-    ...HOSTD_MCP_TOOLS,
-    // Webkite is fleet-default (resolveWebkiteMcpEntry) unless the agent
-    // opts out. Pre-approve its tools so the first web fetch doesn't
-    // wedge on a permission prompt — webkite IS the web-fetch path now
-    // (native WebFetch/WebSearch are denied). Gated on the same opt-out
-    // as the MCP entry emission, so a webkite-disabled agent doesn't
-    // carry dangling pre-approvals.
-    ...(agentConfig.mcp_servers?.["webkite"] === false ? [] : WEBKITE_MCP_TOOLS),
-  ]);
+  // The allow-list computation is shared with reconcileAgentInner via
+  // computeDesiredPermissionAllow (footgun G — one source of truth, no drift).
+  const permissionAllow = computeDesiredPermissionAllow(agentConfig, hindsightEnabled);
 
   // Compute Hindsight plugin context for the start.sh + settings.json
   // templates. Mirrors installHindsightPlugin's gating logic so the
@@ -6325,27 +6357,16 @@ function reconcileAgentInner(
   const tools = agentConfig.tools ?? { allow: [], deny: [] };
   const rawAllow = tools.allow ?? [];
   const hasAllWildcard = rawAllow.includes("all");
-  const baseAllow = hasAllWildcard
-    // `[all]` means "all built-ins" — but it must ALSO keep any explicit tools
-    // the operator listed alongside it. A 🔁 "Always allow" tap persists a
-    // privileged hostd / Skill / 3rd-party-MCP rule into tools.allow as
-    // `[all, mcp__hostd__agent_logs]` (those are deliberately NOT in
-    // ALL_BUILTIN_TOOLS — the leash: even an [all] admin approves them once).
-    // Dropping the explicit entries here is why such grants never reached
-    // settings.json and the agent re-asked forever (klanker, 2026-06-15).
-    ? [...ALL_BUILTIN_TOOLS, ...rawAllow.filter((t) => t !== "all")]
-    : rawAllow.filter((t) => t !== "all");
-  const reconcileDangerousMode = agentConfig.dangerous_mode === true;
-  const reconcileHadExplicitAllow = rawAllow.length > 0;
-  const reconcileReadOnlyDefaults =
-    !reconcileDangerousMode && !reconcileHadExplicitAllow
-      ? DEFAULT_READ_ONLY_PREAPPROVED_TOOLS
-      : [];
   // Single source of truth — must honor SWITCHROOM_MEMORY_BACKEND=none
   // here too: `switchroom agent restart` always reconciles first, so a
   // config-only check would re-wire Hindsight on every restart of a
   // `none` install (install-validation 2026-05-17, R2 review round 2).
   const hindsightEnabled = isHindsightEnabled(switchroomConfig);
+  // Allow-list shared with scaffoldAgent via computeDesiredPermissionAllow
+  // (footgun G — one source of truth, no lockstep drift). Computed BEFORE the
+  // legacy-token strip below, so it matches the historical pre-strip baseAllow
+  // behaviour byte-for-byte (the scaffold↔reconcile parity test pins this).
+  const desiredAllow = computeDesiredPermissionAllow(agentConfig, hindsightEnabled);
   // #235: drop legacy mcp__switchroom__* tokens from any pre-existing
   // allowlist on every reconcile so existing agents converge on the
   // same shape new ones get. #1400 link 1: same treatment for the
@@ -6359,17 +6380,6 @@ function reconcileAgentInner(
         !LEGACY_HOSTD_BLANKET_TOKENS.includes(p),
     );
   }
-  const desiredAllow = dedupe([
-    ...baseAllow,
-    ...reconcileReadOnlyDefaults,
-    ...(usesSwitchroomTelegramPlugin(agentConfig) ? SWITCHROOM_TELEGRAM_MCP_TOOLS : []),
-    ...(hindsightEnabled ? HINDSIGHT_MCP_TOOLS : []),
-    // See scaffoldAgent for the rationale — pre-approve every-agent
-    // MCP servers so first-use doesn't wedge on a permission prompt.
-    ...AGENT_CONFIG_MCP_TOOLS,
-    ...HOSTD_MCP_TOOLS,
-    ...(agentConfig.mcp_servers?.["webkite"] === false ? [] : WEBKITE_MCP_TOOLS),
-  ]);
   const desiredDeny = dedupe([
     ...(tools.deny ?? []),
     ...webkiteDenyForAgent(agentConfig),

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -5356,26 +5356,38 @@ describe("footgun G — scaffold↔reconcile permission-allow parity", () => {
     return { afterScaffold, afterReconcile, afterSecondReconcile };
   }
 
-  const cases: Array<{ label: string; config: AgentConfig; memoryNone?: boolean }> = [
-    { label: "default (no tools)", config: makeAgentConfig({}) },
-    { label: "dangerous_mode: true", config: makeAgentConfig({ dangerous_mode: true } as Partial<AgentConfig>) },
-    { label: "tools.allow: [all]", config: makeAgentConfig({ tools: { allow: ["all"], deny: [] } } as Partial<AgentConfig>) },
+  // `hindsight` toggles the memory backend so isHindsightEnabled() flips —
+  // exercising BOTH the enabled and disabled paths of the shared helper
+  // (review #8: the disabled path was never run before).
+  const cases: Array<{ label: string; config: AgentConfig; hindsight: boolean }> = [
+    { label: "default (no tools)", config: makeAgentConfig({}), hindsight: true },
+    { label: "dangerous_mode: true", config: makeAgentConfig({ dangerous_mode: true } as Partial<AgentConfig>), hindsight: true },
+    { label: "tools.allow: [all]", config: makeAgentConfig({ tools: { allow: ["all"], deny: [] } } as Partial<AgentConfig>), hindsight: true },
     {
       label: "explicit tools.allow",
       config: makeAgentConfig({ tools: { allow: ["Read", "Grep", "custom-tool"], deny: [] } } as Partial<AgentConfig>),
+      hindsight: true,
     },
     {
       label: "webkite opted out",
       config: makeAgentConfig({ mcp_servers: { webkite: false } } as Partial<AgentConfig>),
+      hindsight: true,
     },
+    // review #8 — hindsight DISABLED (memory backend none): the helper must
+    // omit the hindsight MCP tools, and scaffold≡reconcile must still hold.
+    { label: "hindsight disabled (memory backend none)", config: makeAgentConfig({}), hindsight: false },
   ];
 
-  for (const { label, config } of cases) {
+  for (const { label, config, hindsight } of cases) {
     it(`reconcile preserves scaffold's allow-list for: ${label}`, () => {
       const name = `parity-${label.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`;
       const switchroomConfig: SwitchroomConfig = {
         switchroom: { version: 1, agents_dir: tmpDir },
         telegram: telegramConfig,
+        // memory.backend drives isHindsightEnabled(), which BOTH engines and
+        // the helper read identically. "hindsight" enables it; anything else
+        // (here: absent) disables it.
+        ...(hindsight ? { memory: { backend: "hindsight" } } : {}),
         agents: { [name]: config },
       } as SwitchroomConfig;
 
@@ -5384,20 +5396,22 @@ describe("footgun G — scaffold↔reconcile permission-allow parity", () => {
 
       // The load-bearing footgun-G guarantee PR4 delivers: the create engine
       // (scaffold) and the reconcile engine converge to the IDENTICAL final
-      // settings.allow SET. Both feed the ONE shared helper
-      // computeDesiredPermissionAllow into an identical downstream write (which
-      // symmetrically strips the enumerated hindsight tools the plugin owns —
-      // see report; that is why the written set is a strict subset of the raw
-      // helper output, in BOTH engines equally). A regression that re-inlines a
-      // divergent allow computation in either engine breaks this equality.
+      // settings.allow SET, driven by the ONE shared helper
+      // computeDesiredPermissionAllow. A regression that re-inlines a divergent
+      // allow computation in either engine breaks this equality.
       const set = (a: string[]) => [...new Set(a)].sort();
       expect(set(afterReconcile)).toEqual(set(afterScaffold));
       // Idempotent across a second reconcile.
       expect(set(afterSecondReconcile)).toEqual(set(afterReconcile));
-      // Every tool the engines actually write comes from the shared helper —
-      // pins the helper as the single source that feeds both write paths.
-      const helper = new Set(computeDesiredPermissionAllow(config, /*hindsightEnabled*/ true));
+      // Every tool the engines write is present in the shared helper computed
+      // with the SAME hindsight state — pins the helper as the single source
+      // and, on the disabled case, that no hindsight tool leaks in.
+      const helper = new Set(computeDesiredPermissionAllow(config, hindsight));
       for (const tool of set(afterReconcile)) expect(helper.has(tool)).toBe(true);
+      // On the disabled case, assert no hindsight MCP tool was written at all.
+      if (!hindsight) {
+        expect(set(afterReconcile).some((t) => t.startsWith("mcp__hindsight"))).toBe(false);
+      }
     });
   }
 

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync, readlinkSync, lstatSync, readdirSync, cpSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { scaffoldAgent, reconcileAgent, installHindsightPlugin, installSwitchroomSkills, renderFleetInvariants } from "../src/agents/scaffold.js";
+import { scaffoldAgent, reconcileAgent, installHindsightPlugin, installSwitchroomSkills, renderFleetInvariants, computeDesiredPermissionAllow } from "../src/agents/scaffold.js";
 import { createVault, setStringSecret } from "../src/vault/vault.js";
 import { renderTemplate, renderProfileClaudeTemplate } from "../src/agents/profiles.js";
 import { cronScriptFilename, cronUnitName } from "../src/agents/cron-unit-name.js";
@@ -5316,5 +5316,108 @@ describe("renderProfileClaudeTemplate — scaffold wires it correctly", () => {
 
     expect(result.wrote).toBe(false);
     expect(existsSync(join(profileDir, "CLAUDE.md"))).toBe(false);
+  });
+});
+
+/**
+ * Footgun G — scaffold↔reconcile permission-allow PARITY (golden output).
+ *
+ * The create engine (scaffoldAgent) and the reconcile engine
+ * (reconcileAgentInner) used to inline byte-identical copies of the
+ * allow-list computation, kept "in lockstep" only by a comment — the exact
+ * drift footgun. PR4 extracts the computation into the single shared
+ * computeDesiredPermissionAllow. These tests pin the OUTCOME the extraction
+ * guarantees: for representative configs, reconcile writes the SAME
+ * permissions.allow that scaffold did (no drift, no churn), and both equal
+ * the shared helper's output. A regression that re-diverges the two engines
+ * fails here, not silently in production.
+ */
+describe("footgun G — scaffold↔reconcile permission-allow parity", () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-parity-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function allowAfterScaffoldThenReconcile(
+    name: string,
+    config: AgentConfig,
+    switchroomConfig: SwitchroomConfig,
+  ): { afterScaffold: string[]; afterReconcile: string[]; afterSecondReconcile: string[] } {
+    const settingsPath = join(tmpDir, name, ".claude", "settings.json");
+    scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+    const afterScaffold = JSON.parse(readFileSync(settingsPath, "utf-8")).permissions.allow;
+    reconcileAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+    const afterReconcile = JSON.parse(readFileSync(settingsPath, "utf-8")).permissions.allow;
+    reconcileAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+    const afterSecondReconcile = JSON.parse(readFileSync(settingsPath, "utf-8")).permissions.allow;
+    return { afterScaffold, afterReconcile, afterSecondReconcile };
+  }
+
+  const cases: Array<{ label: string; config: AgentConfig; memoryNone?: boolean }> = [
+    { label: "default (no tools)", config: makeAgentConfig({}) },
+    { label: "dangerous_mode: true", config: makeAgentConfig({ dangerous_mode: true } as Partial<AgentConfig>) },
+    { label: "tools.allow: [all]", config: makeAgentConfig({ tools: { allow: ["all"], deny: [] } } as Partial<AgentConfig>) },
+    {
+      label: "explicit tools.allow",
+      config: makeAgentConfig({ tools: { allow: ["Read", "Grep", "custom-tool"], deny: [] } } as Partial<AgentConfig>),
+    },
+    {
+      label: "webkite opted out",
+      config: makeAgentConfig({ mcp_servers: { webkite: false } } as Partial<AgentConfig>),
+    },
+  ];
+
+  for (const { label, config } of cases) {
+    it(`reconcile preserves scaffold's allow-list for: ${label}`, () => {
+      const name = `parity-${label.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`;
+      const switchroomConfig: SwitchroomConfig = {
+        switchroom: { version: 1, agents_dir: tmpDir },
+        telegram: telegramConfig,
+        agents: { [name]: config },
+      } as SwitchroomConfig;
+
+      const { afterScaffold, afterReconcile, afterSecondReconcile } =
+        allowAfterScaffoldThenReconcile(name, config, switchroomConfig);
+
+      // The load-bearing footgun-G guarantee PR4 delivers: the create engine
+      // (scaffold) and the reconcile engine converge to the IDENTICAL final
+      // settings.allow SET. Both feed the ONE shared helper
+      // computeDesiredPermissionAllow into an identical downstream write (which
+      // symmetrically strips the enumerated hindsight tools the plugin owns —
+      // see report; that is why the written set is a strict subset of the raw
+      // helper output, in BOTH engines equally). A regression that re-inlines a
+      // divergent allow computation in either engine breaks this equality.
+      const set = (a: string[]) => [...new Set(a)].sort();
+      expect(set(afterReconcile)).toEqual(set(afterScaffold));
+      // Idempotent across a second reconcile.
+      expect(set(afterSecondReconcile)).toEqual(set(afterReconcile));
+      // Every tool the engines actually write comes from the shared helper —
+      // pins the helper as the single source that feeds both write paths.
+      const helper = new Set(computeDesiredPermissionAllow(config, /*hindsightEnabled*/ true));
+      for (const tool of set(afterReconcile)) expect(helper.has(tool)).toBe(true);
+    });
+  }
+
+  it("helper: dangerous_mode drops the read-only default seeding", () => {
+    const safe = computeDesiredPermissionAllow(makeAgentConfig({}), true);
+    const dangerous = computeDesiredPermissionAllow(
+      makeAgentConfig({ dangerous_mode: true } as Partial<AgentConfig>),
+      true,
+    );
+    // The safe (no explicit allow) config seeds read-only defaults; dangerous
+    // does not. So the safe set must be strictly larger on at least one
+    // read-only tool that dangerous omits.
+    expect(safe.length).toBeGreaterThan(dangerous.length);
+  });
+
+  it("helper: hindsight flag toggles the hindsight MCP tools deterministically", () => {
+    const on = computeDesiredPermissionAllow(makeAgentConfig({}), true);
+    const off = computeDesiredPermissionAllow(makeAgentConfig({}), false);
+    const hindsightOnly = on.filter((t) => !off.includes(t));
+    expect(hindsightOnly.length).toBeGreaterThan(0);
+    expect(hindsightOnly.every((t) => t.includes("hindsight"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Retires the concrete, code-flagged harm of footgun G: `scaffoldAgent` (create) and `reconcileAgentInner` (reconcile) each inlined a **byte-identical** copy of the `permissions.allow` computation, kept "in lockstep" only by a comment. Extracted into ONE shared exported helper `computeDesiredPermissionAllow` both engines call — lockstep is now a compile-time fact.

Job spec: fleet reliability / rollout-hardening.

## Behaviour-preserving by construction
- Helper body = the two former inline blocks verbatim.
- In reconcile, the helper is called **before** the legacy-token strip that mutates persisted `tools.allow`, matching the historical pre-strip `baseAllow` byte-for-byte.
- `hasAllWildcard` / `hindsightEnabled` (used downstream) preserved in both.

## Golden parity tests (new)
For representative configs (default, dangerous_mode, `[all]`, explicit allow, webkite opt-out): assert the two engines converge to the **identical final `settings.allow` set**, reconcile is idempotent, and every written tool comes from the shared helper. Plus unit tests for the helper's dangerous-mode and hindsight-toggle branches. A regression that re-inlines a divergent computation fails these.

## Deliberate scope decision (needs a nod)
This ships the **safe, durable core** of footgun G — the single source of truth for the drift-prone allow computation. It does **NOT** attempt the full "scaffoldAgent becomes create-mode of the reconcile engine" big-bang merge of the two ~1300-line functions (6 callers: grant/dangerous/rename/doctor --fix/agent-restart/hostd `--compose-only`). Evidence-based reasons:
- The two functions are ~1300 lines each; a full merge is a multi-day, all-callers-at-risk rewrite — the omnibus change the dev protocol warns against.
- The parity tests prove the two engines **already converge** on `settings.allow`, so the *concrete* drift risk is what's retired here.
- Recommend the full merge as a separate dedicated effort with its own review, not forced into this batch.

The auto-restart→print-and-decide behavior change lives in the verb/restart surface (PR6), not this function-merge, so it is not in scope here either.

## Test plan
`tests/scaffold.test.ts` (219) + `hindsight-permission-surface` (6) + full agents area (454) green; `tsc` + full `npm run lint` clean.

## Risk
Low. Pure internal extraction; no caller control flow changed; every existing scaffold/reconcile/rename/singleton test green. Part of a batched rollout-hardening release; **do not merge standalone** — hold for the batch go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)