### PR TITLE
fix(skills): ownership-scoped prune for opted-out / dangling defaults (footgun E)

### DIFF
--- a/src/agents/reconcile-default-skills.test.ts
+++ b/src/agents/reconcile-default-skills.test.ts
@@ -183,12 +183,38 @@ describe("reconcileAgentDefaultSkills — ownership-scoped prune (footgun E)", (
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  /** Create a personal-pool skill dir OUTSIDE _bundled and link the agent to it. */
+  /**
+   * Create a personal-pool skill dir at a PRODUCTION-FAITHFUL path and link the
+   * agent to it. Real personal/shared-pool skills live at
+   * `~/.switchroom/skills/<name>` (verified on the live host: klanker's coolify
+   * link → `/home/kenthompson/.switchroom/skills/coolify`). Note the leading
+   * dot: `.switchroom` means the path does NOT contain the substring
+   * `/switchroom/skills/`, so `isOwnedStaleLink` returns FALSE for it — the
+   * refresh path treats it as foreign and spares it. This fixture reproduces
+   * that exact shape (a `.switchroom/skills/` root), so the test exercises the
+   * real production classification, not an accidental tmp path.
+   */
   function makePersonalLink(name: string): string {
-    const personalPool = join(tmpRoot, "personal");
+    const personalPool = join(tmpRoot, "home", "op", ".switchroom", "skills");
     const target = join(personalPool, name);
     mkdirSync(target, { recursive: true });
     writeFileSync(join(target, "SKILL.md"), `# personal ${name}\n`, "utf-8");
+    symlinkSync(target, join(skillsDir, name));
+    return target;
+  }
+
+  /**
+   * Create a link whose target sits under a DEV-CHECKOUT-shaped path
+   * (`.../switchroom/skills/<name>`, NO leading dot) — the one shape that DOES
+   * contain `/switchroom/skills/`, so `isOwnedStaleLink` returns TRUE. This is
+   * the legacy dev-checkout / cross-repo migration case (#1164) the refresh
+   * path is meant to heal, distinct from a `.switchroom` personal-pool link.
+   */
+  function makeDevCheckoutLink(name: string): string {
+    const devPool = join(tmpRoot, "home", "op", "switchroom", "skills");
+    const target = join(devPool, name);
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), `# devcheckout ${name}\n`, "utf-8");
     symlinkSync(target, join(skillsDir, name));
     return target;
   }
@@ -218,15 +244,45 @@ describe("reconcileAgentDefaultSkills — ownership-scoped prune (footgun E)", (
   });
 
   it("CRITICAL: a personal-pool link SURVIVES a converge where its target is transiently missing", () => {
-    // Personal link whose target dir has vanished mid-sync (dangling), name
-    // NOT opted out. The broad isOwnedStaleLink would delete it; the strict
-    // _bundled-scoped prune must not — its target is not under the pool.
+    // Production-shaped personal link (target under `.switchroom/skills/`) at a
+    // default-key name, NOT opted out, whose target dir has vanished mid-sync.
+    // src (poolDir/skill-a) exists, so this hits the refresh path, not the
+    // prune. isOwnedStaleLink is FALSE for a `.switchroom/skills/` target (the
+    // dot breaks the `/switchroom/skills/` substring — verified on the live
+    // host), so the link is classified foreign and spared.
     const target = makePersonalLink("skill-a");
     rmSync(target, { recursive: true, force: true }); // transiently missing
     const r = reconcileAgentDefaultSkills(agentDir, {}, FIXTURE_DEFAULTS, poolDir);
     expect(r.pruned).not.toContain("skill-a");
-    // Still a symlink (not deleted), even though it currently dangles.
+    // Still a symlink (not deleted / not reclaimed), even though it dangles.
     expect(lstatSync(join(skillsDir, "skill-a")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(target);
+  });
+
+  it("REFRESH PATH: a production `.switchroom/skills/` personal link at a default-key name is SPARED (not reclaimed)", () => {
+    // The refresh path (review #5): src present, non-opt-out, dest is a
+    // personal link named like a default key. On the live host the target is
+    // `~/.switchroom/skills/<name>` which does NOT match isOwnedStaleLink, so
+    // production spares it (conflict). This fixture reproduces that shape and
+    // asserts the real outcome — no ownership clobber.
+    const target = makePersonalLink("skill-a");
+    const r = reconcileAgentDefaultSkills(agentDir, {}, FIXTURE_DEFAULTS, poolDir);
+    expect(r.conflicts).toContain("skill-a");
+    expect(r.added).not.toContain("skill-a");
+    // Still points at the operator's personal skill, NOT the bundled pool.
+    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(target);
+  });
+
+  it("REFRESH PATH: a legacy DEV-CHECKOUT `/switchroom/skills/` link at a default-key name IS reclaimed to the pool (#1164 heal)", () => {
+    // The one shape that DOES contain `/switchroom/skills/` (no leading dot) —
+    // a legacy dev-checkout link. isOwnedStaleLink returns TRUE, so the refresh
+    // path heals it to the bundled link. This documents the deliberate migration
+    // reclaim and distinguishes it from the `.switchroom` personal-pool case.
+    makeDevCheckoutLink("skill-a");
+    const r = reconcileAgentDefaultSkills(agentDir, {}, FIXTURE_DEFAULTS, poolDir);
+    expect(r.added).toContain("skill-a");
+    // Now points into the bundled pool (reclaimed).
+    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(join(poolDir, "skill-a"));
   });
 
   it("opt-out NEVER removes a real dir/file at the skill path", () => {

--- a/src/agents/reconcile-default-skills.test.ts
+++ b/src/agents/reconcile-default-skills.test.ts
@@ -186,8 +186,8 @@ describe("reconcileAgentDefaultSkills — ownership-scoped prune (footgun E)", (
   /**
    * Create a personal-pool skill dir at a PRODUCTION-FAITHFUL path and link the
    * agent to it. Real personal/shared-pool skills live at
-   * `~/.switchroom/skills/<name>` (verified on the live host: klanker's coolify
-   * link → `/home/kenthompson/.switchroom/skills/coolify`). Note the leading
+   * `~/.switchroom/skills/<name>` (verified on the live host: an agent's
+   * coolify link → `~/.switchroom/skills/coolify`). Note the leading
    * dot: `.switchroom` means the path does NOT contain the substring
    * `/switchroom/skills/`, so `isOwnedStaleLink` returns FALSE for it — the
    * refresh path treats it as foreign and spares it. This fixture reproduces
@@ -195,7 +195,7 @@ describe("reconcileAgentDefaultSkills — ownership-scoped prune (footgun E)", (
    * real production classification, not an accidental tmp path.
    */
   function makePersonalLink(name: string): string {
-    const personalPool = join(tmpRoot, "home", "op", ".switchroom", "skills");
+    const personalPool = join(tmpRoot, ".switchroom", "skills");
     const target = join(personalPool, name);
     mkdirSync(target, { recursive: true });
     writeFileSync(join(target, "SKILL.md"), `# personal ${name}\n`, "utf-8");
@@ -211,7 +211,7 @@ describe("reconcileAgentDefaultSkills — ownership-scoped prune (footgun E)", (
    * path is meant to heal, distinct from a `.switchroom` personal-pool link.
    */
   function makeDevCheckoutLink(name: string): string {
-    const devPool = join(tmpRoot, "home", "op", "switchroom", "skills");
+    const devPool = join(tmpRoot, "switchroom", "skills");
     const target = join(devPool, name);
     mkdirSync(target, { recursive: true });
     writeFileSync(join(target, "SKILL.md"), `# devcheckout ${name}\n`, "utf-8");

--- a/src/agents/reconcile-default-skills.test.ts
+++ b/src/agents/reconcile-default-skills.test.ts
@@ -25,7 +25,7 @@ import {
   lstatSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname, relative } from "node:path";
 import { homedir } from "node:os";
 import {
   reconcileAgentDefaultSkills,
@@ -163,6 +163,96 @@ describe("reconcileAgentDefaultSkills", () => {
     const result = reconcileAgentDefaultSkills(agentDir, {}, FIXTURE_DEFAULTS, poolDir);
     expect(result.added.sort()).toEqual(["skill-a", "skill-b"]);
     expect(result.added).not.toContain("skill-c");
+  });
+});
+
+describe("reconcileAgentDefaultSkills — ownership-scoped prune (footgun E)", () => {
+  let tmpRoot: string;
+  let poolDir: string;
+  let agentDir: string;
+  let skillsDir: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "sr-prune-"));
+    poolDir = makePool(tmpRoot, ["skill-a", "skill-b", "skill-c"]);
+    agentDir = makeAgentDir(tmpRoot, "ag1");
+    skillsDir = join(agentDir, ".claude", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  /** Create a personal-pool skill dir OUTSIDE _bundled and link the agent to it. */
+  function makePersonalLink(name: string): string {
+    const personalPool = join(tmpRoot, "personal");
+    const target = join(personalPool, name);
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), `# personal ${name}\n`, "utf-8");
+    symlinkSync(target, join(skillsDir, name));
+    return target;
+  }
+
+  it("opt-out REMOVES an existing owned _bundled link", () => {
+    // Install the owned link first.
+    symlinkSync(join(poolDir, "skill-a"), join(skillsDir, "skill-a"));
+    const r = reconcileAgentDefaultSkills(agentDir, { "skill-a": false }, FIXTURE_DEFAULTS, poolDir);
+    expect(r.pruned).toContain("skill-a");
+    expect(r.optedOut).toContain("skill-a");
+    expect(existsSync(join(skillsDir, "skill-a"))).toBe(false);
+  });
+
+  it("opt-out with no existing link prunes nothing (no phantom removal)", () => {
+    const r = reconcileAgentDefaultSkills(agentDir, { "skill-a": false }, FIXTURE_DEFAULTS, poolDir);
+    expect(r.pruned).not.toContain("skill-a");
+    expect(r.optedOut).toContain("skill-a");
+  });
+
+  it("CRITICAL: opt-out NEVER removes a personal-pool link at the same name", () => {
+    // A personal skill link named like a default key, target OUTSIDE _bundled.
+    makePersonalLink("skill-a");
+    const r = reconcileAgentDefaultSkills(agentDir, { "skill-a": false }, FIXTURE_DEFAULTS, poolDir);
+    expect(r.pruned).not.toContain("skill-a");
+    // The personal link survives.
+    expect(lstatSync(join(skillsDir, "skill-a")).isSymbolicLink()).toBe(true);
+  });
+
+  it("CRITICAL: a personal-pool link SURVIVES a converge where its target is transiently missing", () => {
+    // Personal link whose target dir has vanished mid-sync (dangling), name
+    // NOT opted out. The broad isOwnedStaleLink would delete it; the strict
+    // _bundled-scoped prune must not — its target is not under the pool.
+    const target = makePersonalLink("skill-a");
+    rmSync(target, { recursive: true, force: true }); // transiently missing
+    const r = reconcileAgentDefaultSkills(agentDir, {}, FIXTURE_DEFAULTS, poolDir);
+    expect(r.pruned).not.toContain("skill-a");
+    // Still a symlink (not deleted), even though it currently dangles.
+    expect(lstatSync(join(skillsDir, "skill-a")).isSymbolicLink()).toBe(true);
+  });
+
+  it("opt-out NEVER removes a real dir/file at the skill path", () => {
+    mkdirSync(join(skillsDir, "skill-a"), { recursive: true });
+    writeFileSync(join(skillsDir, "skill-a", "SKILL.md"), "operator content\n", "utf-8");
+    const r = reconcileAgentDefaultSkills(agentDir, { "skill-a": false }, FIXTURE_DEFAULTS, poolDir);
+    expect(r.pruned).not.toContain("skill-a");
+    expect(lstatSync(join(skillsDir, "skill-a")).isDirectory()).toBe(true);
+  });
+
+  it("prunes a DANGLING owned _bundled link when the pool drops the skill", () => {
+    // Owned link into the pool, then the pool loses skill-c.
+    symlinkSync(join(poolDir, "skill-c"), join(skillsDir, "skill-c"));
+    rmSync(join(poolDir, "skill-c"), { recursive: true, force: true });
+    const r = reconcileAgentDefaultSkills(agentDir, {}, FIXTURE_DEFAULTS, poolDir);
+    expect(r.pruned).toContain("skill-c");
+    expect(existsSync(join(skillsDir, "skill-c"))).toBe(false);
+  });
+
+  it("does not touch a relative owned _bundled link that is still current (no over-prune)", () => {
+    // Relative link (post-footgun-A form) that correctly resolves into the pool.
+    const rel = relative(dirname(join(skillsDir, "skill-a")), join(poolDir, "skill-a"));
+    symlinkSync(rel, join(skillsDir, "skill-a"));
+    const r = reconcileAgentDefaultSkills(agentDir, {}, FIXTURE_DEFAULTS, poolDir);
+    expect(r.pruned).not.toContain("skill-a");
+    expect(existsSync(join(skillsDir, "skill-a"))).toBe(true);
   });
 });
 

--- a/src/agents/reconcile-default-skills.ts
+++ b/src/agents/reconcile-default-skills.ts
@@ -24,7 +24,7 @@
 
 import { existsSync, lstatSync, mkdirSync, readdirSync, readlinkSync, rmSync, symlinkSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { getBuiltinDefaultSkillEntries, type BuiltinSkillEntry } from "../memory/scaffold-integration.js";
 
 /** Track which missing-pool-dir warnings we've already emitted so the
@@ -52,6 +52,13 @@ export interface AgentSkillReconcileResult {
   optedOut: string[];
   /** Which skill keys were skipped because a real file/dir is in the way */
   conflicts: string[];
+  /** Which owned _bundled links were REMOVED by the ownership-scoped prune
+   *  (footgun E): a default that is now opted-out, or an owned link whose
+   *  pool target has gone missing (dangling). Strictly scoped — a prune here
+   *  can only ever touch a link at `<key>` (a current builtin-default key)
+   *  whose target resolves under `.../skills/_bundled/`. Personal-pool links
+   *  and operator hand-links are structurally out of scope. */
+  pruned: string[];
   /** True when at least one symlink was added or refreshed */
   changed: boolean;
 }
@@ -88,6 +95,37 @@ function isOwnedStaleLink(target: string, poolDir: string): boolean {
 }
 
 /**
+ * STRICT ownership test for the prune (footgun E, review CRITICAL).
+ *
+ * Returns true ONLY when `dest` is a symlink whose target resolves into the
+ * bundled pool dir `<poolDir>` (`.../skills/_bundled/`). This is deliberately
+ * NARROWER than `isOwnedStaleLink` (which matches any `/switchroom/skills/`
+ * target, INCLUDING personal-pool links `skills/<name>` — reusing it for the
+ * prune would delete operator/personal skills). A prune must never remove a
+ * personal-pool link (target `skills/<name>`) or an operator hand-link, so the
+ * prune scope is: name ∈ current builtin-default keys AND this predicate.
+ *
+ * Relative targets (the form switchroom writes post-footgun-A) are resolved
+ * against the link's own directory, exactly as the kernel does on traversal,
+ * so this works for both relative and legacy-absolute owned links.
+ */
+function isOwnedBundledLink(dest: string, poolDir: string): boolean {
+  let stored: string | null = null;
+  try {
+    if (!lstatSync(dest).isSymbolicLink()) return false;
+    stored = readlinkSync(dest);
+  } catch {
+    return false;
+  }
+  if (!stored) return false;
+  const resolved = isAbsolute(stored) ? stored : resolve(dirname(dest), stored);
+  // Normalize both to a trailing-slash boundary so `_bundled` can't match a
+  // sibling like `_bundledX`.
+  const poolPrefix = poolDir.endsWith("/") ? poolDir : poolDir + "/";
+  return resolved === poolDir || resolved.startsWith(poolPrefix);
+}
+
+/**
  * Reconcile the bundled-default skill set into a single agent.
  *
  * Rules:
@@ -117,6 +155,7 @@ export function reconcileAgentDefaultSkills(
     alreadyPresent: [],
     optedOut: [],
     conflicts: [],
+    pruned: [],
     changed: false,
   };
 
@@ -136,19 +175,43 @@ export function reconcileAgentDefaultSkills(
   }
 
   for (const entry of defaults) {
+    const dest = join(targetDir, entry.key);
+
     if (optOuts[entry.optOutKey] === false) {
       result.optedOut.push(entry.key);
+      // Ownership-scoped prune (footgun E): an opted-out default must not
+      // leave a stale owned link behind. Remove the link ONLY when it is an
+      // owned _bundled link (target resolves under the pool). A real dir, a
+      // personal-pool link, or an operator hand-link at this path is left
+      // untouched — the strict `isOwnedBundledLink` scope is what makes this
+      // safe (the review CRITICAL: never reuse the broad isOwnedStaleLink).
+      if (isOwnedBundledLink(dest, poolDir)) {
+        try {
+          rmSync(dest, { force: true });
+          result.pruned.push(entry.key);
+          result.changed = true;
+        } catch { /* best effort */ }
+      }
       continue;
     }
 
     const src = join(poolDir, entry.key);
     if (!existsSync(src)) {
-      // Pool missing this skill (e.g. trimmed install). Don't fail the
-      // whole reconcile — just skip silently.
+      // Pool missing this skill (e.g. trimmed install). Don't fail the whole
+      // reconcile. But if we're holding a now-DANGLING owned _bundled link
+      // for this default (target vanished), prune it — a dangling owned link
+      // is dead weight and confuses doctor. Same strict ownership scope: only
+      // an owned _bundled link, never a personal/real entry.
+      if (isOwnedBundledLink(dest, poolDir)) {
+        try {
+          rmSync(dest, { force: true });
+          result.pruned.push(entry.key);
+          result.changed = true;
+        } catch { /* best effort */ }
+      }
       continue;
     }
 
-    const dest = join(targetDir, entry.key);
     let existing;
     try {
       existing = lstatSync(dest);


### PR DESCRIPTION
## Summary
Kills footgun E: opting a bundled default out (`bundled_skills: { pdf: false }`) never removed the existing owned link, so the opt-out silently didn't take effect and dangling owned links accumulated as drift. Adds an ownership-scoped prune to `reconcileAgentDefaultSkills`.

Job spec: fleet reliability / rollout-hardening.

## The review CRITICAL, honored structurally
The design said "prune reuses `isOwnedStaleLink`". The review flagged this as a **Critical**: `isOwnedStaleLink` matches ANY target containing `/switchroom/skills/` — including personal-pool links (`skills/<name>`) — so a prune reusing it would **delete operator/personal skills**.

This PR does **NOT** reuse it. New strict `isOwnedBundledLink` returns true ONLY when the link target **resolves under `.../skills/_bundled/`** (relative targets resolved against the link dir; trailing-slash boundary so `_bundled` can't match `_bundledX`). Prune scope = `name ∈ current builtin-default keys` AND `isOwnedBundledLink`. Personal-pool links, real dirs, and foreign operator links are structurally out of scope.

## Behaviour
- Opted-out default with an owned `_bundled` link → removed.
- Default whose pool target vanished, leaving a dangling owned `_bundled` link → removed.
- Everything else untouched.

## Test plan (asserts on-disk OUTCOMES)
opt-out removes an owned link; opt-out with no link prunes nothing; **CRITICAL** opt-out never removes a personal-pool link at the same name; **CRITICAL** a personal-pool link survives a converge where its target is transiently missing (the exact case the broad helper would delete); opt-out never removes a real dir; a dangling owned link is pruned when the pool drops the skill; a current relative owned link is not over-pruned. `reconcile-default-skills.test.ts` (23) + full agents area & scaffold (661) green; `tsc` + full lint clean.

## Deliberate scope
- The **manifest-removed** prune dimension (`{prev manifest} \ {current}`) layers on at batch-merge with the manifest from the manifest-additive-sync PR (not on this branch's base).
- The 3 advisory **doctor drift WARNs** are deferred to a small follow-up to keep this PR single-concern for the independent review. The prune is the load-bearing deterministic fix; the WARNs are read-only diagnostics, and opt-outs now take effect so the "opt-out not pruned" WARN is largely moot.

## Risk
Medium — introduces deletion. Bounded by the strict ownership test + comprehensive personal-skill-survival tests. Part of a batched rollout-hardening release; **do not merge standalone** — hold for the batch go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)