### PR TITLE
chore: release v0.19.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.19.9 — Rollout hardening: bundled skills stay put, opt-outs take effect, no ghost skills
+
 ### Fixes
 
 - **Bundled skills no longer silently vanish in some containers** (#3485) —


### PR DESCRIPTION
CHANGELOG-only release commit consolidating the rollout-hardening batch (footguns A-G, landed via #3491 / commit 64e36167) from `## Unreleased` into `## v0.19.9`.

Per the release convention: no `package.json` version bump (the git tag is the version source of truth; package.json version is a stale placeholder). Once merged, `v0.19.9` is tagged on the merge commit, which fires `npm-publish` + `docker-images`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)