### PR TITLE
fix(hostd): bake skills/ into the hostd image so update syncs bundled defaults

### DIFF
--- a/docker/Dockerfile.hostd
+++ b/docker/Dockerfile.hostd
@@ -100,6 +100,24 @@ COPY dist/host-control/main.js /opt/switchroom/dist/host-control/main.js
 COPY profiles/ /opt/switchroom/profiles/
 COPY vendor/hindsight-memory/ /opt/switchroom/vendor/hindsight-memory/
 
+# The `update` flow's sync-bundled-skills step resolves the shipped
+# skills/ payload the same package-relative way and mirrors it into the
+# host-stable pool `~/.switchroom/skills/_bundled/`:
+#   src/cli/update.ts:  resolve(import.meta.dirname,"../../skills")
+# Without this, /opt/switchroom/skills is absent, sync-bundled-skills
+# hits its `!existsSync(source)` guard and SILENTLY SKIPS — so builtin
+# default skills (dev-protocol, mental-model-curator, telegram-
+# formatting, …) never reach the pool and never symlink into agents —
+# and the subsequent verify-bundled-skills step then throws, stranding
+# the fleet on the old image (the ghost-skills incident). Same failure
+# class as the profiles/vendor omission above, one asset over. hostd is
+# the ONE container that runs update, so it alone needs this tree; agent
+# images read the already-synced host pool via bind mount and do NOT
+# bake it. Keep in sync with missingApplyAssets() in
+# src/host-control/server.ts (the up-front preflight that now refuses an
+# update_apply when this tree is missing rather than stranding a fleet).
+COPY skills/ /opt/switchroom/skills/
+
 # hindsight autoheal loop (#2910). The hostd compose adds a tiny
 # `switchroom-hindsight-autoheal` sidecar that runs THIS script on the hostd
 # image (chosen because it already carries the docker CLI + routes through the

--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -462,3 +462,23 @@ describe("Dockerfile.hostd bakes the autoheal script (#2910)", () => {
     expect(df).toMatch(/chmod 0755 \/opt\/switchroom\/docker\/hindsight-autoheal\.sh/);
   });
 });
+
+describe("Dockerfile.hostd bakes the package-relative asset trees (ghost-skills)", () => {
+  it("COPYs profiles/, vendor/hindsight-memory/, AND skills/ into the image", () => {
+    const df = readFileSync(
+      resolve(__dirname, "..", "..", "docker", "Dockerfile.hostd"),
+      "utf-8",
+    );
+    // Every asset the apply/update path resolves via
+    // resolve(import.meta.dirname,"../../<asset>") must be baked into the
+    // hostd image, or the corresponding step silently skips / strands the
+    // fleet. skills/ is the one that was missing (ghost-skills incident):
+    // sync-bundled-skills sourced /opt/switchroom/skills, which never
+    // existed, so builtin default skills never reached the host pool.
+    expect(df).toMatch(/COPY profiles\/ \/opt\/switchroom\/profiles\//);
+    expect(df).toMatch(
+      /COPY vendor\/hindsight-memory\/ \/opt\/switchroom\/vendor\/hindsight-memory\//,
+    );
+    expect(df).toMatch(/COPY skills\/ \/opt\/switchroom\/skills\//);
+  });
+});

--- a/src/host-control/apply-asset-preflight.test.ts
+++ b/src/host-control/apply-asset-preflight.test.ts
@@ -1,0 +1,78 @@
+/**
+ * ghost-skills incident — the hostd image must carry every package-relative
+ * asset tree the apply AND update paths resolve via
+ * `resolve(import.meta.dirname, "../../<asset>")`. profiles/ + vendor/ were
+ * already guarded (the klanker incident); skills/ was NOT, so a hostd image
+ * built without the shipped skills/ payload passed the preflight, then
+ * `switchroom update`'s sync-bundled-skills step silently skipped (its
+ * `!existsSync(source)` guard) and the builtin default skills never reached
+ * the host pool. This test pins skills/ into the required-asset set so a
+ * future hostd image that drops it is refused up front instead of stranding
+ * the fleet mid-roll.
+ *
+ * We call the private `missingApplyAssets()` against a temp `applyAssetsRoot`
+ * so the assertion is about the REAL required-asset list, not a stub.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { HostdServer } = await import("./server.js");
+import type { ServerOptions } from "./server.js";
+
+function serverWithRoot(root: string) {
+  return new HostdServer({
+    applyAssetsRoot: root,
+  } as unknown as ServerOptions) as unknown as {
+    missingApplyAssets: () => string[];
+  };
+}
+
+/** Build a root that has every required asset EXCEPT the ones named. */
+function makeRoot(omit: string[] = []): string {
+  const root = mkdtempSync(join(tmpdir(), "hostd-assets-"));
+  const all: Array<[string, string[]]> = [
+    ["profiles", ["profiles"]],
+    ["profiles/default", ["profiles", "default"]],
+    ["vendor/hindsight-memory", ["vendor", "hindsight-memory"]],
+    ["skills", ["skills"]],
+  ];
+  for (const [name, parts] of all) {
+    if (omit.includes(name)) continue;
+    mkdirSync(join(root, ...parts), { recursive: true });
+  }
+  return root;
+}
+
+describe("missingApplyAssets — hostd image asset preflight", () => {
+  it("passes when profiles, vendor, AND skills are all present", () => {
+    const root = makeRoot();
+    try {
+      expect(serverWithRoot(root).missingApplyAssets()).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a missing skills/ payload (the ghost-skills regression)", () => {
+    const root = makeRoot(["skills"]);
+    try {
+      const missing = serverWithRoot(root).missingApplyAssets();
+      expect(missing).toContain(join(root, "skills"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("still flags a missing profiles/ payload (the klanker regression)", () => {
+    const root = makeRoot(["profiles", "profiles/default"]);
+    try {
+      const missing = serverWithRoot(root).missingApplyAssets();
+      expect(missing).toContain(join(root, "profiles"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1520,12 +1520,20 @@ export class HostdServer {
    * hindsight plugin RELATIVE TO ITSELF (no path arg):
    *   profiles.ts:  resolve(import.meta.dirname,"../../profiles")
    *   scaffold.ts:  resolve(import.meta.dirname,"../../vendor/hindsight-memory")
-   * If the hostd image was built without those (the klanker incident),
-   * `update_apply` pulls images then dies at apply-config, stranding
-   * the fleet on the old image. We refuse BEFORE anything is pulled
-   * or changed — same fail-fast principle as the `--rebuild` guard.
+   * The `update` flow ALSO resolves a package-relative asset the same
+   * way — `sync-bundled-skills` mirrors the shipped `skills/` payload
+   * into the host pool:
+   *   update.ts:  resolve(import.meta.dirname,"../../skills")
+   * If the hostd image was built without those (the klanker incident
+   * for profiles/vendor; the ghost-skills incident #3492-follow-up for
+   * skills/), `update_apply` pulls images then either dies at
+   * apply-config or silently skips the skills sync and later throws at
+   * verify-bundled-skills — stranding the fleet on the old image, or
+   * leaving every agent's CLAUDE.md referencing default skills that
+   * never reach the pool. We refuse BEFORE anything is pulled or
+   * changed — same fail-fast principle as the `--rebuild` guard.
    * Future-proofs the per-asset fragility: any new package-relative
-   * apply asset added here can't silently strand a fleet again.
+   * apply/update asset added here can't silently strand a fleet again.
    */
   private missingApplyAssets(): string[] {
     const root =
@@ -1534,6 +1542,11 @@ export class HostdServer {
       join(root, "profiles"),
       join(root, "profiles", "default"),
       join(root, "vendor", "hindsight-memory"),
+      // sync-bundled-skills (update.ts) mirrors this tree into the host
+      // pool; a hostd image without it silently skips the sync and then
+      // fails verify-bundled-skills. Guard it here so update_apply is
+      // refused up front instead of stranding the fleet mid-roll.
+      join(root, "skills"),
     ].filter((p) => !existsSync(p));
   }
 

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -1699,6 +1699,7 @@ describe("hostd server — apply-asset preflight (klanker incident)", () => {
     const ok = join(tmp, "assets-ok");
     mkdirSync(join(ok, "profiles", "default"), { recursive: true });
     mkdirSync(join(ok, "vendor", "hindsight-memory"), { recursive: true });
+    mkdirSync(join(ok, "skills"), { recursive: true });
     await freshServer(ok);
     const resp = await hostdRequest(
       { socketPath: adminSock() },
@@ -2111,6 +2112,7 @@ describe("hostd server — update_apply hostd-context deferral (#2458)", () => {
     const assets = join(tmp, `assets-deferral-${Date.now()}`);
     mkdirSync(join(assets, "profiles", "default"), { recursive: true });
     mkdirSync(join(assets, "vendor", "hindsight-memory"), { recursive: true });
+    mkdirSync(join(assets, "skills"), { recursive: true });
 
     // The stub SCRIPT and its recording file must live on a filesystem that
     // allows exec — /tmp is noexec in this container, but /var/tmp is exec.
@@ -2283,6 +2285,7 @@ describe("hostd server — rollout got-field gap fix (BONUS #2458)", () => {
     const assets = join(tmp, `assets-rollout-got-${Date.now()}`);
     mkdirSync(join(assets, "profiles", "default"), { recursive: true });
     mkdirSync(join(assets, "vendor", "hindsight-memory"), { recursive: true });
+    mkdirSync(join(assets, "skills"), { recursive: true });
 
     if (server) await server.stop();
     server = new (await import("../../src/host-control/server.js")).HostdServer({
@@ -2347,6 +2350,7 @@ describe("hostd server — rollout phase observability (#2726)", () => {
     const assets = join(tmp, `assets-phase-${Date.now()}-${Math.random().toString(16).slice(2)}`);
     mkdirSync(join(assets, "profiles", "default"), { recursive: true });
     mkdirSync(join(assets, "vendor", "hindsight-memory"), { recursive: true });
+    mkdirSync(join(assets, "skills"), { recursive: true });
     return assets;
   }
 
@@ -2582,6 +2586,7 @@ describe("hostd server — rollout narrator feed (#2726 Part 2)", () => {
     const assets = join(tmp, `assets-narrator-${Date.now()}`);
     mkdirSync(join(assets, "profiles", "default"), { recursive: true });
     mkdirSync(join(assets, "vendor", "hindsight-memory"), { recursive: true });
+    mkdirSync(join(assets, "skills"), { recursive: true });
 
     const seenPhases: string[] = [];
     let terminalResult: string | null = null;
@@ -2632,6 +2637,7 @@ describe("hostd server — rollout narrator feed (#2726 Part 2)", () => {
     const assets = join(tmp, `assets-narrator-throw-${Date.now()}`);
     mkdirSync(join(assets, "profiles", "default"), { recursive: true });
     mkdirSync(join(assets, "vendor", "hindsight-memory"), { recursive: true });
+    mkdirSync(join(assets, "skills"), { recursive: true });
 
     if (server) await server.stop();
     server = new HostdServer({


### PR DESCRIPTION
Root cause: the switchroom-hostd Docker image copies profiles/ and vendor/ but never COPYs the shipped skills/ payload. So inside the hostd container, `switchroom update`'s sync-bundled-skills step resolves source=/opt/switchroom/skills (import.meta.dirname/../../skills), finds it absent, hits its `!existsSync(source)` early-return and silently skips — leaving ~/.switchroom/skills/_bundled/ un-refreshed. Builtin defaults dev-protocol and mental-model-curator never reach the pool or symlink into agents. Same class as the klanker profiles/vendor incident, one asset over. Verified live: /opt/switchroom/skills absent in the running v0.19.9 hostd image; pool has neither skill; package.json files lists skills (npm packages have it) — the Docker build drops it.

Latent strand: verify-bundled-skills (added #3491, now in the image) would throw on the NEXT update since the pool still can't be populated, stranding the fleet on the old image before recreate-containers.

Fix (two deterministic changes):
1. docker/Dockerfile.hostd: add `COPY skills/ /opt/switchroom/skills/`.
2. src/host-control/server.ts missingApplyAssets(): add `skills` so a hostd image dropping skills/ is refused up front at update_apply/apply (nothing pulled) instead of stranding mid-roll.

Tests (fail on bug, pass on fix; anti-tautology verified by stash; tsc clean):
- src/host-control/apply-asset-preflight.test.ts (new): missingApplyAssets() flags missing skills/ against a temp applyAssetsRoot.
- src/cli/hostd.test.ts: assert Dockerfile.hostd COPYs profiles/, vendor/, AND skills/.

Post-merge the hostd image must be rebuilt + redeployed; then the next `switchroom update` mirrors the payload and agents symlink the skills on reconcile. telegram-formatting (hand-placed) is NOT at risk — the sync is additive/manifest-owned and never deletes hand-added dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)