### PR TITLE
chore: release v0.19.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 ## Unreleased
 
-### Telegram formatting: resident by default, deterministically repaired
+## v0.19.10 — Telegram formatting goes resident + deterministic; hostd ships bundled skills
+
+### Fixes
+
+- **hostd image now bakes the `skills/` payload so `switchroom update` syncs
+  bundled defaults** (#3493) — the `switchroom-hostd` image COPYd `profiles/`
+  and `vendor/` but never the shipped `skills/`, so inside the hostd container
+  `switchroom update`'s sync-bundled-skills step resolved
+  `source=/opt/switchroom/skills`, found it absent, hit its `!existsSync`
+  early-return and silently skipped — leaving `~/.switchroom/skills/_bundled/`
+  un-refreshed and builtin defaults (`dev-protocol`, `mental-model-curator`)
+  never reaching the pool or agents. Fix: `docker/Dockerfile.hostd` now
+  `COPY skills/ /opt/switchroom/skills/`, and `missingApplyAssets()` adds
+  `skills` so a hostd image dropping the payload is **refused up front at
+  `update_apply`/`apply`** (nothing pulled) instead of stranding mid-roll on
+  the next verify-bundled-skills throw.
+
+### Telegram formatting: resident by default, deterministically repaired (#3494)
 
 - **Thicker resident floor card** — the always-injected `## Formatting for
   Telegram` block (`TELEGRAM_FORMATTING_FLOOR_CARD`) now promotes the flagship


### PR DESCRIPTION
Consolidates the Unreleased CHANGELOG entries under **v0.19.10** for the formatting/skills cut:

- **#3493** — hostd image bakes the `skills/` payload so `switchroom update` syncs bundled defaults; `missingApplyAssets()` refuses an image lacking it.
- **#3494** — Telegram formatting promoted to the resident floor card + deterministic send-time repair; on-demand `telegram-formatting` skill retired; retired-default sweep spares role-scoped operator skills.

CHANGELOG-only (version source of truth is the git tag; `package.json` stays a placeholder per release discipline). Tag `v0.19.10` will be cut on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)