### PR TITLE
chore: bump Claude Code CLI 2.1.215 → 2.1.216

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.215
+ARG CLAUDE_CODE_VERSION=2.1.216
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -51,7 +51,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.215
+ARG CLAUDE_CODE_VERSION=2.1.216
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 


### PR DESCRIPTION
## Summary

Bumps the pinned Claude Code CLI from **2.1.215 → 2.1.216**, updating the `CLAUDE_CODE_VERSION` build-arg default in lockstep across both Dockerfiles (per #1978 — the agent bundle and the hindsight reflection bundle must not skew, or the thinking-block failure class can reappear).

## Changed pin locations

- `docker/Dockerfile.base:157` — `ARG CLAUDE_CODE_VERSION=2.1.216` (propagates to agent / broker / kernel / auth-broker / hostd)
- `docker/Dockerfile.hindsight:54` — `ARG CLAUDE_CODE_VERSION=2.1.216` (hindsight installs claude separately)

These are the only two authoritative version pins in the repo. Other `2.1.215` mentions are historical probe records (`vendor/hindsight-memory/scripts/subagent_retain.py`) and docs, not pins — left untouched.

## Fleet-relevant changelog highlights (2.1.216)

- Fixed a long-session quadratic-normalization slowdown.
- Fixed auto-mode returning HTTP 401 after OAuth token expiry.
- Fixed agent restoration when resuming a background-agent session.
- Fixed background sub-agent cancellation when a high-priority message arrives.

## Compatibility

No breaking changes.

## Testing

- `npm run lint` — clean.
- `npx vitest run tests/docker/dockerfile-hindsight-bakes.test.ts` — 16 passed.

Scoped checks only; CI is the full-suite authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)