### PR TITLE
fix(hindsight): self-heal consolidation queue from corrupt-index deadlocks

### DIFF
--- a/docker/hindsight-entrypoint.sh
+++ b/docker/hindsight-entrypoint.sh
@@ -81,6 +81,17 @@ FETCHER="${SWITCHROOM_HINDSIGHT_FETCHER:-/usr/local/lib/switchroom/hindsight-fet
 # header for the jobs + env knobs. Empty/unset path disables it.
 MAINTENANCE="${SWITCHROOM_HINDSIGHT_MAINTENANCE_SCRIPT:-/usr/local/lib/switchroom/hindsight-maintenance.sh}"
 REAP_STALE_S="${SWITCHROOM_HINDSIGHT_REAP_STALE_S:-1800}"
+# Bounded batch + concurrency guard for the reaper reset (incident
+# 2026-07-22): reset at most this many stale rows per pass, and skip any a
+# live worker currently row-locks (FOR UPDATE SKIP LOCKED) so we can never
+# steal a claim mid-flight.
+REAP_BATCH_LIMIT="${SWITCHROOM_HINDSIGHT_REAP_BATCH_LIMIT:-1000}"
+# Corrupt-index self-heal switch (incident 2026-07-22). When the reaper's
+# reset UPDATE fails with the pk_async_operations unique-violation signature
+# (a corrupt PK btree — the exact 3-day-freeze cause), REINDEX the index and
+# retry the reset. 1=on (default), 0=alarm-only (log the loud ERROR, skip the
+# automatic REINDEX DDL).
+REINDEX_SELFHEAL="${SWITCHROOM_HINDSIGHT_REINDEX_SELFHEAL:-1}"
 # pg0 instance descriptor (holds the embedded-postgres password); the
 # reaper reads it to connect. Overridable for host tests.
 PG0_INSTANCE="${SWITCHROOM_HINDSIGHT_PG0_INSTANCE:-/home/hindsight/.pg0/instances/hindsight/instance.json}"
@@ -94,18 +105,72 @@ log() { echo "switchroom-hindsight-entrypoint: $*" >&2; }
 : "${HINDSIGHT_API_WORKER_ID:=${SWITCHROOM_HINDSIGHT_WORKER_ID:-switchroom-hindsight}}"
 export HINDSIGHT_API_WORKER_ID
 
-# Lease-timeout reaper (fix B above). Resets async_operations stuck in
-# 'processing' past the threshold back to 'pending' so the live worker
-# re-claims them — mirroring upstream recover_own_tasks() but keyed on
-# claim age instead of the (ephemeral) worker_id. Best-effort: any
-# failure (pg not up yet, missing instance file, psql absent) is
-# swallowed so it can never wedge the loop or the container. No-ops
-# cleanly on hosts without the embedded pg (e.g. unit tests).
+# One reaper reset pass. Reads the (effectively global, sh has no locals)
+# connection vars set by reap_stale_processing; echoes psql's COMBINED
+# stdout+stderr and returns psql's exit status so the caller can both parse
+# the `UPDATE N` tag on success AND inspect the error text on failure.
+#
+# Bounded + concurrency-safe: the SKIP LOCKED subselect resets only stale,
+# unlocked, non-batch 'processing' rows — never a row a live worker currently
+# row-locks — at most REAP_BATCH_LIMIT per pass.
 #   - threshold (REAP_STALE_S, default 30 min) sits well above the
-#     consolidation LLM timeout + the 600s DB statement_timeout, so it
-#     only ever fires on genuinely-dead claims, never a long-but-live one.
+#     consolidation LLM timeout + the 600s DB statement_timeout, so it only
+#     ever fires on genuinely-dead claims, never a long-but-live one.
 #   - the batch_id guard mirrors upstream: batch-API ops have their own
 #     recovery path (_recover_batch_operations) and must not be reset here.
+_reap_reset_pass() {
+  PGPASSWORD="${_pgpw}" "${_psql}" -U "${_pguser}" -h /tmp -p "${_pgport}" -d "${_pgdb}" -v ON_ERROR_STOP=1 -c \
+    "UPDATE async_operations SET status='pending', worker_id=NULL, claimed_at=NULL, updated_at=now() WHERE operation_id IN (SELECT operation_id FROM async_operations WHERE status='processing' AND claimed_at < now() - make_interval(secs => ${REAP_STALE_S}) AND coalesce(result_metadata->>'batch_id','') = '' ORDER BY claimed_at FOR UPDATE SKIP LOCKED LIMIT ${REAP_BATCH_LIMIT})" \
+    2>&1
+}
+
+# Log the reset count from psql's own `UPDATE N` tag (ROW_COUNT of THIS
+# statement) — NEVER a follow-up `SELECT count(*) … updated_at > now()-5s`,
+# which counted fresh enqueues and inflated the reaper log (#3421).
+_reap_log_count() {
+  _n="$(printf '%s\n' "$1" | awk '/^UPDATE[[:space:]]+[0-9]+/ { print $2; exit }')"
+  _n="$(echo "${_n}" | tr -d '[:space:]')"
+  if [ "${_n:-0}" -gt 0 ] 2>/dev/null; then
+    log "stale-claim reaper reset ${_n} stuck 'processing' op(s) older than ${REAP_STALE_S}s -> pending"
+  fi
+}
+
+# Rebuild the pk_async_operations PK btree from the (dup-free) heap. Echoes
+# combined output, returns status. CONCURRENTLY first (no table lock, but can
+# fail leaving an INVALID index); plain REINDEX as an atomic fallback (brief
+# ACCESS EXCLUSIVE lock — acceptable: the queue is already wedged).
+_reap_reindex_pk() {
+  if _rout="$(PGPASSWORD="${_pgpw}" "${_psql}" -U "${_pguser}" -h /tmp -p "${_pgport}" -d "${_pgdb}" -v ON_ERROR_STOP=1 -c 'REINDEX INDEX CONCURRENTLY pk_async_operations' 2>&1)"; then
+    printf '%s' "${_rout}"; return 0
+  fi
+  log "hindsight-reaper reindex_selfheal=concurrent-failed falling-back-to-plain detail: $(printf '%s' "${_rout}" | tr '\n' ' ' | cut -c1-200)"
+  if _rout="$(PGPASSWORD="${_pgpw}" "${_psql}" -U "${_pguser}" -h /tmp -p "${_pgport}" -d "${_pgdb}" -v ON_ERROR_STOP=1 -c 'REINDEX INDEX pk_async_operations' 2>&1)"; then
+    printf '%s' "${_rout}"; return 0
+  fi
+  printf '%s' "${_rout}"; return 1
+}
+
+# Lease-timeout reaper (fix B above) — HARDENED for corrupt-index self-heal
+# (incident 2026-07-22). Resets async_operations stuck in 'processing' past
+# the threshold back to 'pending' so the live worker re-claims them —
+# mirroring upstream recover_own_tasks() but keyed on claim age instead of the
+# (ephemeral) worker_id.
+#
+# CORRUPT-INDEX SELF-HEAL (the 3-day freeze this closes): when the
+# pk_async_operations btree is corrupt, the reset UPDATE itself throws
+# `duplicate key value violates unique constraint "pk_async_operations"`
+# (writing the updated rows' index tuples collides with a phantom entry) —
+# EXACTLY like upstream recover_own_tasks. The PRIOR reaper piped that failure
+# into `2>/dev/null) || return 0` and silently no-oped, so stuck ops were
+# never reset and NOTHING alarmed → per-bank consolidation deadlocked for
+# days. Now: on ANY reset failure we (1) log a LOUD structured ERROR (never
+# swallow again), and (2) if the failure carries the pk_async_operations
+# signature and REINDEX_SELFHEAL != 0, REINDEX the index and retry the reset
+# once — the same REINDEX that manually cleared the live incident, automated.
+#
+# Still best-effort on the benign no-op paths (pg not up yet, missing instance
+# file, psql absent) so it can never wedge the loop or the container. No-ops
+# cleanly on hosts without the embedded pg (e.g. unit tests).
 reap_stale_processing() {
   [ "${REAP_STALE_S}" -gt 0 ] || return 0
   [ -r "${PG0_INSTANCE}" ] || return 0
@@ -119,23 +184,36 @@ EOF
     return 0
   fi
   [ -n "${_pgpw}" ] || return 0
-  # NOTE (2026-07-19 dual-writer recovery): never count via an UPDATE that
-  # returns rows piped into a line-counter (the recovery-title form aborted
-  # under concurrent activity with a spurious unique-constraint error on
-  # pk_async_operations, so the reaper silently no-oped and crash-orphaned
-  # consolidations stayed processing, blocking every new claim for that bank).
-  #
-  # Count comes from psql's own `UPDATE N` tag (ROW_COUNT of THIS statement).
-  # A post-UPDATE `SELECT count(*) … updated_at > now()-5s` inflated the
-  # log with fresh enqueues that never matched the stale-processing WHERE.
-  _out="$(PGPASSWORD="${_pgpw}" "${_psql}" -U "${_pguser}" -h /tmp -p "${_pgport}" -d "${_pgdb}" -v ON_ERROR_STOP=1 -c \
-    "UPDATE async_operations SET status='pending', worker_id=NULL, claimed_at=NULL, updated_at=now() WHERE status='processing' AND claimed_at < now() - make_interval(secs => ${REAP_STALE_S}) AND coalesce(result_metadata->>'batch_id','') = ''" \
-    2>/dev/null)" || return 0
-  _n="$(printf '%s\n' "${_out}" | awk '/^UPDATE[[:space:]]+[0-9]+/ { print $2; exit }')"
-  _n="$(echo "${_n}" | tr -d '[:space:]')"
-  if [ "${_n:-0}" -gt 0 ] 2>/dev/null; then
-    log "stale-claim reaper reset ${_n} stuck 'processing' op(s) older than ${REAP_STALE_S}s -> pending"
+
+  # First reset pass. `if var=$(...)` keeps this set -e-safe (a failing
+  # command substitution in an if-condition does NOT abort the shell) and,
+  # crucially, does NOT swallow the error — _out carries psql's stderr.
+  if _out="$(_reap_reset_pass)"; then
+    _reap_log_count "${_out}"
+    return 0
   fi
+
+  # Reset FAILED — never swallow (that silent no-op WAS the 3-day freeze).
+  # Loud structured ERROR the fleet log monitor / `switchroom doctor` can grep.
+  log "ERROR: hindsight-reaper reset_failed — stuck 'processing' ops NOT reset; consolidation may deadlock. detail: $(printf '%s' "${_out}" | tr '\n' ' ' | cut -c1-300)"
+
+  # Corrupt-index self-heal: the reset UPDATE hit the pk_async_operations
+  # unique-violation signature => the PK btree is corrupt. REINDEX + retry.
+  if printf '%s' "${_out}" | grep -q 'pk_async_operations' && [ "${REINDEX_SELFHEAL}" != "0" ]; then
+    log "ERROR: hindsight-reaper reindex_selfheal=attempting index=pk_async_operations reason=corrupt-index-blocks-reset"
+    if _rout="$(_reap_reindex_pk)"; then
+      log "hindsight-reaper reindex_selfheal=ok index=pk_async_operations — retrying reset"
+      if _out2="$(_reap_reset_pass)"; then
+        _reap_log_count "${_out2}"
+        log "hindsight-reaper reindex_selfheal=recovered reset retried successfully after REINDEX"
+      else
+        log "ERROR: hindsight-reaper reindex_selfheal=reset-still-failing after REINDEX — manual intervention needed. detail: $(printf '%s' "${_out2}" | tr '\n' ' ' | cut -c1-300)"
+      fi
+    else
+      log "ERROR: hindsight-reaper reindex_selfheal=failed index=pk_async_operations — manual 'REINDEX INDEX CONCURRENTLY pk_async_operations' needed. detail: $(printf '%s' "${_rout}" | tr '\n' ' ' | cut -c1-300)"
+    fi
+  fi
+  return 0
 }
 
 # Boot-deferred reaper (2026-07-19): the refresh-loop reaper only fires after

--- a/docker/hindsight-maintenance.sh
+++ b/docker/hindsight-maintenance.sh
@@ -36,6 +36,11 @@
 #   SWITCHROOM_HINDSIGHT_RETENTION_DAYS       completed-op prune age. default 30
 #   SWITCHROOM_HINDSIGHT_QUEUE_LAG_WARN_S     warn if oldest pending/processing
 #                                             op older than this. default 7200 (2h). 0=off
+#   SWITCHROOM_HINDSIGHT_INDEX_HEALTH_CHECK   bt_index_check pk_async_operations
+#                                             + stuck-op alarm. default 1 (on). 0=off
+#   SWITCHROOM_HINDSIGHT_STUCK_OP_WARN_S      alarm if any 'processing' op is
+#                                             claimed older than this (the reaper
+#                                             should have reset it). default 3600 (1h)
 set -u
 
 MAINT_ENABLED="${SWITCHROOM_HINDSIGHT_MAINTENANCE:-1}"
@@ -49,9 +54,21 @@ RETENTION_DAYS="${SWITCHROOM_HINDSIGHT_RETENTION_DAYS:-30}"
 # wedged (the 26-day strand of 2026-05-23 went unseen because nothing
 # watched this). Default 2h — well above ~510s/op + the 30-min lease
 # reaper. 0 disables. Logs a loud WARNING (picked up by docker logs /
-# any log monitoring); the reaper still auto-heals stuck *processing*
-# ops, so this is visibility, not the heal.
+# any log monitoring). The reaper auto-heals stuck *processing* ops ONLY
+# when the pk_async_operations index is healthy — a corrupt index made its
+# reset UPDATE silently no-op for 3 days (2026-07-22). Job #5 below alarms on
+# that index-corruption / persistent-stuck-op condition directly.
 QUEUE_LAG_WARN_S="${SWITCHROOM_HINDSIGHT_QUEUE_LAG_WARN_S:-7200}"
+# Index-health + stuck-op alarm (incident 2026-07-22). The reaper's reset
+# UPDATE silently no-oped for 3 days when pk_async_operations was corrupt,
+# deadlocking consolidation per-bank with NO alarm. This probe surfaces BOTH
+# a corrupt index (bt_index_check) and a persistent stuck-op count LOUDLY so
+# neither can hide again. 1=on (default), 0=off.
+INDEX_HEALTH_CHECK="${SWITCHROOM_HINDSIGHT_INDEX_HEALTH_CHECK:-1}"
+# A healthy reaper keeps 'processing' ops younger than its 30-min window; a
+# 'processing' op still claimed past this threshold means the heal isn't
+# landing (corrupt index / disabled reaper) and the deadlock is ACTIVE.
+STUCK_OP_WARN_S="${SWITCHROOM_HINDSIGHT_STUCK_OP_WARN_S:-3600}"
 
 log() { echo "switchroom-hindsight-maintenance: $*" >&2; }
 
@@ -107,6 +124,37 @@ if [ "${QUEUE_LAG_WARN_S}" -gt 0 ] 2>/dev/null; then
   _qage="${_q##*|}"
   if [ "${_qage:-0}" -gt "${QUEUE_LAG_WARN_S}" ] 2>/dev/null; then
     log "WARNING: queue may be wedged — ${_qn} pending/processing async op(s), oldest $((_qage/60))m old (> $((QUEUE_LAG_WARN_S/60))m). Consolidation/retain pipeline not draining; inspect async_operations + 'docker logs switchroom-hindsight'."
+  fi
+fi
+
+# --- 5. Index-health + stuck-op alarm (incident 2026-07-22) ---
+# The reaper's reset UPDATE silently no-oped for 3 days when
+# pk_async_operations was corrupt, deadlocking consolidation per-bank with no
+# alarm. This probe surfaces BOTH conditions LOUDLY (structured ERROR the
+# fleet log monitor / `switchroom doctor` can grep) so neither can hide again.
+# Read-only: bt_index_check takes only an AccessShareLock (non-blocking); the
+# stuck-op metric is a SELECT. The reaper does the heal; this is the alarm.
+if [ "${INDEX_HEALTH_CHECK}" = "1" ]; then
+  # amcheck ships with pg but its extension may not be created yet; best-effort.
+  _sql "CREATE EXTENSION IF NOT EXISTS amcheck" >/dev/null 2>&1
+  # bt_index_check(..., true) = heapallindexed: detects a phantom index tuple
+  # pointing at the wrong heap ctid (the exact 2026-07-22 corruption). It
+  # RAISEs on corruption; ON_ERROR_STOP=1 => nonzero exit + the error text.
+  _ic="$(PGPASSWORD="${PGPW_}" "${PSQL}" -U "${PGUSER_}" -h /tmp -p "${PGPORT_}" -d "${PGDB_}" \
+    -v ON_ERROR_STOP=1 -tAc "SELECT bt_index_check('pk_async_operations'::regclass, true)" 2>&1)"
+  if [ $? -ne 0 ]; then
+    # A genuine corruption reports btree/heap/index-tuple/duplicate text; an
+    # amcheck-absent / index-missing environment reads as a skip, not an alarm.
+    if printf '%s' "${_ic}" | grep -qiE 'corrupt|not.*ordered|heap tuple|index tuple|duplicate|not equal'; then
+      log "ERROR: index health check FAILED for pk_async_operations — btree corruption; consolidation queue can deadlock. Heal: REINDEX INDEX CONCURRENTLY pk_async_operations (the reaper self-heals on its next reset). detail: $(printf '%s' "${_ic}" | tr '\n' ' ' | cut -c1-300)"
+    fi
+  fi
+  # Stuck-op count: 'processing' ops still claimed past the alarm window. A
+  # working reaper keeps this at 0; a persistent nonzero means the heal isn't
+  # landing (corrupt index / disabled reaper) — the deadlock is ACTIVE.
+  _stuck="$(_sql "SELECT count(*) FROM async_operations WHERE status='processing' AND claimed_at < now() - make_interval(secs => ${STUCK_OP_WARN_S})")"
+  if [ "${_stuck:-0}" -gt 0 ] 2>/dev/null; then
+    log "ERROR: ${_stuck} async op(s) stuck in 'processing' older than $((STUCK_OP_WARN_S/60))m — the stale-claim reaper is not clearing them (corrupt pk_async_operations index or reaper disabled); per-bank consolidation is deadlocked. Inspect async_operations + 'docker logs switchroom-hindsight'."
   fi
 fi
 

--- a/tests/docker/hindsight-entrypoint.test.ts
+++ b/tests/docker/hindsight-entrypoint.test.ts
@@ -19,6 +19,9 @@ import {
   existsSync,
   chmodSync,
   writeFileSync,
+  mkdirSync,
+  accessSync,
+  constants as fsConstants,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -509,6 +512,208 @@ describe("hindsight-entrypoint.sh (#1245)", () => {
       try { child.kill("SIGKILL"); } catch { /* ignore */ }
     }
   }, 10_000);
+
+  // ── Corrupt-index self-heal (incident 2026-07-22) ──────────────────────
+  //
+  // The 3-day consolidation freeze: a corrupt pk_async_operations btree made
+  // the reaper's reset UPDATE throw `duplicate key ... pk_async_operations`,
+  // and the OLD reaper piped that into `2>/dev/null) || return 0` — silently
+  // no-oping with no alarm and no heal, so stuck 'processing' ops were never
+  // reset and every affected bank deadlocked. These tests drive the reaper
+  // with a FAKE psql that reproduces the corrupt-index scenario and assert
+  // the OUTCOME: a loud alarm + REINDEX self-heal + successful retry. They
+  // FAIL against the old swallow-and-return behavior (no alarm/heal ever
+  // emitted), so they actually pin the bug, not just the code path.
+
+  /**
+   * Return an EXEC-capable temp dir. Some sandboxes mount os.tmpdir() noexec,
+   * which would make `[ -x fake_psql ]` false and no-op the reaper; fall back
+   * to a repo-local cache dir. CI's tmpdir is exec, so it uses that.
+   */
+  function execTmpDir(prefix: string): string {
+    const bases = [
+      tmpdir(),
+      resolve(__dirname, "..", "..", "node_modules", ".cache"),
+    ];
+    for (const base of bases) {
+      try {
+        mkdirSync(base, { recursive: true });
+        const d = mkdtempSync(join(base, prefix));
+        const probe = join(d, "probe.sh");
+        writeFileSync(probe, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+        accessSync(probe, fsConstants.X_OK);
+        return d;
+      } catch {
+        /* try next base */
+      }
+    }
+    throw new Error("no exec-capable tmp base for fake-psql");
+  }
+
+  /** Write a fake `psql` into an exec-capable dir; return that bin dir. */
+  function installFakePsql(stateDir: string): string {
+    const binDir = execTmpDir("swr-fakebin-");
+    mkdirSync(stateDir, { recursive: true });
+    const psql = join(binDir, "psql");
+    writeFileSync(
+      psql,
+      `#!/bin/sh
+# Fake psql for hindsight reaper/maintenance outcome tests.
+sql=""; prev=""
+for a in "$@"; do
+  case "$prev" in -c|-tAc) sql="$a" ;; esac
+  prev="$a"
+done
+[ -n "\${FAKE_PSQL_LOG:-}" ] && printf '%s\\n' "$sql" >> "$FAKE_PSQL_LOG"
+mode="\${FAKE_PSQL_MODE:-healthy}"
+state="\${FAKE_PSQL_STATE:-/tmp}"
+case "$sql" in
+  "SELECT 1") echo 1; exit 0 ;;
+  "CREATE EXTENSION"*) exit 0 ;;
+  "REINDEX INDEX"*) echo REINDEX; touch "$state/reindexed" 2>/dev/null; exit 0 ;;
+  *bt_index_check*)
+    if [ "$mode" = corrupt ]; then
+      echo 'ERROR:  heap tuple (172,11) lacks matching index tuple within index "pk_async_operations"' >&2
+      exit 1
+    fi
+    exit 0 ;;
+  *"count(*)"*"status='processing'"*)
+    if [ "$mode" = corrupt ] || [ "$mode" = stuck ]; then echo 4; else echo 0; fi
+    exit 0 ;;
+  "UPDATE async_operations SET status='pending'"*)
+    if [ "$mode" = corrupt ] && [ ! -f "$state/reindexed" ]; then
+      echo 'ERROR:  duplicate key value violates unique constraint "pk_async_operations"' >&2
+      echo 'DETAIL:  Key (operation_id)=(6cade4c3) already exists.' >&2
+      exit 1
+    fi
+    echo 'UPDATE 3'; exit 0 ;;
+  *) exit 0 ;;
+esac
+`,
+      { mode: 0o755 },
+    );
+    return binDir;
+  }
+
+  function writePgInstance(path: string): void {
+    writeFileSync(
+      path,
+      JSON.stringify({
+        username: "hindsight",
+        database: "hindsight",
+        port: 5432,
+        password: "testpw",
+      }),
+    );
+  }
+
+  it("reaper self-heals a corrupt pk_async_operations index: alarms LOUDLY, REINDEXes, and retries the reset (incident 2026-07-22)", async () => {
+    stopBroker = await startFakeBroker(socketPath);
+    const stateDir = join(dir, "fakestate");
+    const sqlLog = join(dir, "psql-sql.log");
+    const pgInstance = join(dir, "instance.json");
+    const binDir = installFakePsql(stateDir);
+    writePgInstance(pgInstance);
+
+    const child = spawn("sh", [ENTRYPOINT, "sleep", "6"], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        SWITCHROOM_AUTH_BROKER_SOCKET: socketPath,
+        SWITCHROOM_HINDSIGHT_CRED_DIR: credDir,
+        SWITCHROOM_HINDSIGHT_WAIT_S: "5",
+        SWITCHROOM_HINDSIGHT_REFRESH_S: "1",
+        SWITCHROOM_HINDSIGHT_FETCHER: FETCHER,
+        SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+        SWITCHROOM_HINDSIGHT_REAP_STALE_S: "1800",
+        FAKE_PSQL_MODE: "corrupt",
+        FAKE_PSQL_STATE: stateDir,
+        FAKE_PSQL_LOG: sqlLog,
+      },
+    });
+    let stderr = "";
+    child.stderr.on("data", (d) => (stderr += d.toString("utf8")));
+    try {
+      await new Promise((r) => setTimeout(r, 3000));
+      // 1. It ALARMED (never silently swallowed) on the failed reset.
+      expect(stderr).toMatch(/ERROR: hindsight-reaper reset_failed/);
+      // 2. It recognized the corrupt-index signature and self-healed.
+      expect(stderr).toMatch(/reindex_selfheal=attempting/);
+      expect(stderr).toMatch(/reindex_selfheal=ok/);
+      // 3. The retry after REINDEX actually reset the stuck ops.
+      expect(stderr).toMatch(/stale-claim reaper reset 3 stuck 'processing' op/);
+      expect(stderr).toMatch(/reindex_selfheal=recovered/);
+      // 4. The SQL trace proves the sequence: reset -> REINDEX -> reset.
+      const log = readFileSync(sqlLog, "utf-8").trim().split("\n");
+      const firstReset = log.findIndex((l) => /^UPDATE async_operations SET status='pending'/.test(l));
+      const reindex = log.findIndex((l) => /^REINDEX INDEX .*pk_async_operations/.test(l));
+      const retry = log.findIndex(
+        (l, i) => i > reindex && /^UPDATE async_operations SET status='pending'/.test(l),
+      );
+      expect(firstReset).toBeGreaterThanOrEqual(0);
+      expect(reindex).toBeGreaterThan(firstReset);
+      expect(retry).toBeGreaterThan(reindex);
+      // The reset is bounded + concurrency-safe (never steal a live claim).
+      expect(log.some((l) => /FOR UPDATE SKIP LOCKED LIMIT/.test(l))).toBe(true);
+    } finally {
+      try { child.kill("SIGKILL"); } catch { /* ignore */ }
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  }, 12_000);
+
+  it("reaper does NOT alarm or REINDEX when the reset succeeds (no false positives)", async () => {
+    stopBroker = await startFakeBroker(socketPath);
+    const stateDir = join(dir, "fakestate");
+    const sqlLog = join(dir, "psql-sql.log");
+    const pgInstance = join(dir, "instance.json");
+    const binDir = installFakePsql(stateDir);
+    writePgInstance(pgInstance);
+
+    const child = spawn("sh", [ENTRYPOINT, "sleep", "5"], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        SWITCHROOM_AUTH_BROKER_SOCKET: socketPath,
+        SWITCHROOM_HINDSIGHT_CRED_DIR: credDir,
+        SWITCHROOM_HINDSIGHT_WAIT_S: "5",
+        SWITCHROOM_HINDSIGHT_REFRESH_S: "1",
+        SWITCHROOM_HINDSIGHT_FETCHER: FETCHER,
+        SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+        FAKE_PSQL_MODE: "healthy",
+        FAKE_PSQL_STATE: stateDir,
+        FAKE_PSQL_LOG: sqlLog,
+      },
+    });
+    let stderr = "";
+    child.stderr.on("data", (d) => (stderr += d.toString("utf8")));
+    try {
+      await new Promise((r) => setTimeout(r, 2500));
+      expect(stderr).toMatch(/stale-claim reaper reset 3 stuck/);
+      expect(stderr).not.toMatch(/reset_failed/);
+      expect(stderr).not.toMatch(/reindex_selfheal/);
+      const log = readFileSync(sqlLog, "utf-8");
+      expect(log).not.toMatch(/REINDEX INDEX/);
+    } finally {
+      try { child.kill("SIGKILL"); } catch { /* ignore */ }
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+
+  it("reaper reset is bounded + concurrency-safe and never swallows the failure (static guard)", () => {
+    const raw = readFileSync(ENTRYPOINT, "utf-8");
+    // Bounded batch + skip rows a live worker holds (never steal a claim).
+    expect(raw).toMatch(/FOR UPDATE SKIP LOCKED LIMIT \$\{REAP_BATCH_LIMIT\}/);
+    // The old silent-swallow shape MUST be gone: no reset psql piped into
+    // `2>/dev/null) ... || return 0`. The reset now captures stderr (2>&1)
+    // and branches on failure with a loud ERROR.
+    expect(raw).not.toMatch(/UPDATE async_operations SET status='pending'[\s\S]{0,400}2>\/dev\/null\)"\s*\|\|\s*return 0/);
+    expect(raw).toMatch(/ERROR: hindsight-reaper reset_failed/);
+    // Self-heal is gated (alarm-only when disabled) and keyed on the exact
+    // corrupt-index signature, not any failure.
+    expect(raw).toMatch(/REINDEX_SELFHEAL/);
+    expect(raw).toMatch(/grep -q 'pk_async_operations'/);
+    expect(raw).toMatch(/REINDEX INDEX CONCURRENTLY pk_async_operations/);
+  });
 
   it("Dockerfile pins UID 11000 to match HINDSIGHT_DEFAULT_UID", () => {
     // The broker chowns the per-consumer socket to consumer.uid (mode 0600).

--- a/tests/docker/hindsight-maintenance.test.ts
+++ b/tests/docker/hindsight-maintenance.test.ts
@@ -7,10 +7,80 @@
  */
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  accessSync,
+  constants as fsConstants,
+} from "node:fs";
+import { resolve, join } from "node:path";
+import { tmpdir } from "node:os";
 
 const SCRIPT = resolve(__dirname, "..", "..", "docker", "hindsight-maintenance.sh");
+
+/**
+ * Return an EXEC-capable temp dir. Some sandboxes mount os.tmpdir() noexec,
+ * which would make the maintenance script's `[ -x psql ]` false and skip the
+ * probe; fall back to a repo-local cache dir. CI's tmpdir is exec.
+ */
+function execTmpDir(prefix: string): string {
+  const bases = [tmpdir(), resolve(__dirname, "..", "..", "node_modules", ".cache")];
+  for (const base of bases) {
+    try {
+      mkdirSync(base, { recursive: true });
+      const d = mkdtempSync(join(base, prefix));
+      const probe = join(d, "probe.sh");
+      writeFileSync(probe, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      accessSync(probe, fsConstants.X_OK);
+      return d;
+    } catch {
+      /* try next base */
+    }
+  }
+  throw new Error("no exec-capable tmp base for fake-psql");
+}
+
+/** Write a fake `psql` into an exec-capable dir; return that bin dir. */
+function installFakePsql(): string {
+  const binDir = execTmpDir("swr-maint-fakebin-");
+  writeFileSync(
+    join(binDir, "psql"),
+    `#!/bin/sh
+sql=""; prev=""
+for a in "$@"; do
+  case "$prev" in -c|-tAc) sql="$a" ;; esac
+  prev="$a"
+done
+[ -n "\${FAKE_PSQL_LOG:-}" ] && printf '%s\\n' "$sql" >> "$FAKE_PSQL_LOG"
+mode="\${FAKE_PSQL_MODE:-healthy}"
+case "$sql" in
+  "SELECT 1") echo 1; exit 0 ;;
+  "CREATE EXTENSION"*) exit 0 ;;
+  *bt_index_check*)
+    if [ "$mode" = corrupt ]; then
+      echo 'ERROR:  heap tuple (172,11) lacks matching index tuple within index "pk_async_operations"' >&2
+      exit 1
+    fi
+    exit 0 ;;
+  *"count(*)"*"status='processing'"*)
+    if [ "$mode" = corrupt ]; then echo 4; else echo 0; fi; exit 0 ;;
+  *) exit 0 ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  return binDir;
+}
+
+function writePgInstance(path: string): void {
+  writeFileSync(
+    path,
+    JSON.stringify({ username: "hindsight", database: "hindsight", port: 5432, password: "testpw" }),
+  );
+}
 
 describe("hindsight-maintenance.sh", () => {
   it("exits 0 and silently when the embedded pg descriptor is absent (host/test)", () => {
@@ -63,6 +133,84 @@ describe("hindsight-maintenance.sh", () => {
     expect(raw).toMatch(/SELECT 1.*\|\| exit 0/);
     // Interval gate so it backs up at most once per window.
     expect(raw).toMatch(/-mmin "?-?\$\{BACKUP_INTERVAL_MIN\}/);
+  });
+
+  // ── Index-health + stuck-op alarm, job #5 (incident 2026-07-22) ─────────
+  //
+  // These drive the probe with a FAKE psql and assert the OUTCOME: a corrupt
+  // pk_async_operations index AND a persistent stuck-op count each raise a
+  // LOUD structured ERROR. They FAIL if job #5 is absent or downgraded to a
+  // silent path, so they pin the alarm, not just the code path.
+  it("job #5 ALARMS loudly on a corrupt pk_async_operations index and on stuck ops", () => {
+    const dir = mkdtempSync(join(tmpdir(), "swr-hsi-maint-"));
+    const binDir = installFakePsql();
+    try {
+      const pgInstance = join(dir, "instance.json");
+      const sqlLog = join(dir, "psql-sql.log");
+      writePgInstance(pgInstance);
+      const r = spawnSync("sh", [SCRIPT], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+          FAKE_PSQL_MODE: "corrupt",
+          FAKE_PSQL_LOG: sqlLog,
+        },
+        encoding: "utf-8",
+        timeout: 15_000,
+      });
+      expect(r.status).toBe(0);
+      // Corruption alarm (bt_index_check failed with a heap/index-tuple error).
+      expect(r.stderr).toMatch(/ERROR: index health check FAILED for pk_async_operations/);
+      // Stuck-op alarm (the reaper isn't clearing 'processing' ops).
+      expect(r.stderr).toMatch(/ERROR: 4 async op\(s\) stuck in 'processing'/);
+      // It is READ-ONLY — the probe must issue no UPDATE/DELETE/REINDEX against
+      // the queue table (asserted on the ACTUAL SQL psql was called with, not
+      // the alarm text — whose heal hint legitimately mentions REINDEX).
+      const sql = readFileSync(sqlLog, "utf-8");
+      expect(sql).not.toMatch(/^\s*(UPDATE|DELETE|REINDEX)\b/mi);
+      // ...and the probe SQL it DID issue was the index check + a count.
+      expect(sql).toMatch(/bt_index_check/);
+      expect(sql).toMatch(/count\(\*\)[^\n]*status='processing'/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("job #5 stays SILENT on a healthy index with no stuck ops (no false positives)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "swr-hsi-maint-"));
+    const binDir = installFakePsql();
+    try {
+      const pgInstance = join(dir, "instance.json");
+      writePgInstance(pgInstance);
+      const r = spawnSync("sh", [SCRIPT], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: pgInstance,
+          FAKE_PSQL_MODE: "healthy",
+        },
+        encoding: "utf-8",
+        timeout: 15_000,
+      });
+      expect(r.status).toBe(0);
+      expect(r.stderr).not.toMatch(/index health check FAILED/);
+      expect(r.stderr).not.toMatch(/stuck in 'processing'/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("job #5 index-health probe is gated + read-only (static guard)", () => {
+    const raw = readFileSync(SCRIPT, "utf-8");
+    expect(raw).toMatch(/INDEX_HEALTH_CHECK/);
+    expect(raw).toMatch(/bt_index_check\('pk_async_operations'::regclass, true\)/);
+    // Stuck-op metric scoped to processing rows past the alarm window.
+    expect(raw).toMatch(/status='processing' AND claimed_at < now\(\) - make_interval\(secs => \$\{STUCK_OP_WARN_S\}\)/);
+    // Read-only: the probe SELECTs / checks; it must not mutate the queue.
+    expect(raw).not.toMatch(/(UPDATE|DELETE)[^\n]*status='processing'/);
   });
 
   it("runs a queue-liveness probe that warns (read-only) when the pipeline is wedged", () => {


### PR DESCRIPTION
## Problem

The 2026-07-22 incident froze memory consolidation for **3 days**. Root cause (evidence-backed, root-tier investigation): the `pk_async_operations` primary-key btree became **corrupt** (a phantom index tuple pointing at the wrong heap ctid). That made the stale-claim reaper's reset `UPDATE` throw `duplicate key value violates unique constraint "pk_async_operations"` — and the reaper piped that into `2>/dev/null) || return 0`, **silently no-oping with no alarm**. Stuck `processing` ops were never reset, and since both the claim path and `banks_needing_consolidation()` exclude any bank with a `processing` consolidation op, every affected bank (overlord/klanker/assistant/finn) deadlocked. Same swallow-and-continue class as upstream `recover_own_tasks`.

The live incident was already remediated by hand (`REINDEX INDEX CONCURRENTLY pk_async_operations` + resetting the 31 orphaned ops). This PR is the **code fix** so it can't silently recur.

## Contradiction with the premise (surfaced)

The task framed part 1 as "build a periodic reconcile-side stuck-op reset." That reset **already exists** — `reap_stale_processing` (entrypoint, added incident-day 2026-07-19), on both the refresh loop and a boot-deferred path. It had the *identical* swallow bug. So this **hardens the existing reaper** rather than adding a redundant second one. The hindsight server (`poller.py` / `ops_postgresql.py` / `maintenance.py`) is upstream `vectorize-io/hindsight`, not switchroom source; switchroom's durable lever is its own entrypoint/maintenance shell (also avoids upstream-anchor drift).

## Changes

**`docker/hindsight-entrypoint.sh` — reaper hardening**
- Never swallow: capture psql stderr; on reset failure emit a LOUD structured `ERROR: hindsight-reaper reset_failed`.
- Corrupt-index self-heal (gated `SWITCHROOM_HINDSIGHT_REINDEX_SELFHEAL`, default on): on the `pk_async_operations` unique-violation signature, `REINDEX INDEX CONCURRENTLY` (plain fallback) then retry the reset once.
- Bound + concurrency-guard the reset: `FOR UPDATE SKIP LOCKED` + `LIMIT` (default 1000) — never steals a live worker's claim, never resets unboundedly.

**`docker/hindsight-maintenance.sh` — new job #5 index/stuck-op alarm** (gated `SWITCHROOM_HINDSIGHT_INDEX_HEALTH_CHECK`, default on)
- Read-only `bt_index_check(pk_async_operations, heapallindexed)` + a count of `processing` ops past `SWITCHROOM_HINDSIGHT_STUCK_OP_WARN_S` (default 1h). Either condition raises a LOUD structured `ERROR` the fleet log monitor / `switchroom doctor` can grep, instead of a silent deadlock.
- Fixes the now-false comment claiming the reaper always auto-heals.

## Tests (assert outcomes, not code paths)

New tests drive both scripts with a fake `psql` that reproduces the corrupt-index scenario:
- Reaper: alarms → REINDEXes → retries the reset (SQL trace asserts `reset → REINDEX → reset`; bounded SKIP LOCKED verified). **Verified RED against the old swallow behavior.**
- Job #5: alarms loudly on corruption + stuck ops. **Verified RED without the job.**
- Both assert **no false positives** on a healthy DB, and the probe issues no mutating SQL.

Scoped locally: `vitest run tests/docker/hindsight-entrypoint.test.ts tests/docker/hindsight-maintenance.test.ts` → 27 passed. `npm run lint` clean. `sh -n` clean on both scripts. Full suite left to CI.

## Not merging

Per standing rule, holding for the validated consolidated release. No live DB/config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)