### PR TITLE
feat(telegram): deterministic guaranteed final-message delivery via durable outbox

### DIFF
--- a/telegram-plugin/final-answer-detect.ts
+++ b/telegram-plugin/final-answer-detect.ts
@@ -120,3 +120,26 @@ export function isSubstantiveFinalReply(input: FinalAnswerReplyInput): boolean {
   if (input.text.length >= FINAL_ANSWER_MIN_CHARS) return true
   return false
 }
+
+/**
+ * F3 gate: should the legacy reply-site (`outbound-send-path.ts` sendReply)
+ * journal THIS reply's delivery under the turn nonce for the outbox sweep?
+ *
+ * This is deliberately `isSubstantiveFinalReply`, NOT `isFinalAnswerReply`.
+ * At the reply site the journaled text is the REPLY text — a DIFFERENT string
+ * from the trailing prose the Stop hook may capture under the SAME turn nonce
+ * (unlike the silent-anchor flush / captured-prose bridge, where the journaled
+ * text IS the turn's trailing content and a loose gate is loss-safe).
+ *
+ * `isFinalAnswerReply`'s ping clause classifies a short pinging interim ack
+ * ("On it — digging in", `disable_notification` omitted) as final. If such an
+ * ack journaled the turn nonce, and the model then ended the turn with
+ * gateway-invisible trailing prose (the real answer) captured under that same
+ * nonce, the sweep would hit `skip-journaled` and delete the real answer —
+ * silent loss, the exact incident this outbox exists to prevent. Requiring a
+ * SUBSTANTIVE reply (`done` or ≥200 chars) to journal keeps the double-post
+ * guard for genuine answers while never letting a pinging ack poison the nonce.
+ */
+export function shouldJournalReplySiteDelivery(input: FinalAnswerReplyInput): boolean {
+  return isSubstantiveFinalReply(input)
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -904,7 +904,7 @@ import {
   TURN_ACTIVE_IDLE_SWEEP_MS,
 } from './turn-active-marker.js'
 import { startGatewayHeartbeat } from './gateway-heartbeat.js'
-import { startOutboxSweep, writeLastInboundChat } from './outbox-sweep.js'
+import { startOutboxSweep } from './outbox-sweep.js'
 import {
   VERSION,
   COMMIT_SHA,
@@ -14793,8 +14793,8 @@ export async function handleInbound(
   {
     const inboundChatId = ctx.chat?.id
     if (inboundChatId != null) void dmPinSweeper.sweep(String(inboundChatId))
-    // Outbox H3 fallback: stamp the last real inbound chat for envelope-less handback routing.
-    if (inboundChatId != null) writeLastInboundChat({ chatId: String(inboundChatId), threadId: messageThreadId ?? null })
+    // Outbox envelope-less routing (F2) is scoped to each record's OWN stamped
+    // per-session origin chat (captured at Stop), not a gateway-global stamp.
   }
 
   // Capture wall-clock receive time for inbound_ack metric (#203).

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -904,6 +904,7 @@ import {
   TURN_ACTIVE_IDLE_SWEEP_MS,
 } from './turn-active-marker.js'
 import { startGatewayHeartbeat } from './gateway-heartbeat.js'
+import { startOutboxSweep, writeLastInboundChat } from './outbox-sweep.js'
 import {
   VERSION,
   COMMIT_SHA,
@@ -9822,20 +9823,15 @@ function trackRedeliveredInbound(merged: InboundMessage): void {
 // `runDeliveryConfirmSweep` / `redeliverStrandedInbound` / `sweepSuspendedTargets`
 // moved VERBATIM; the gateway keeps the deps builder, thin wrappers, and the
 // `setInterval` registration below (P0c: modules export the tick body; the
-// gateway owns the timer). The idle gate crosses as `getCurrentTurnNull` ONLY
-// (the design's C1 deps shape — never the machine's eager in-turn state).
+// gateway owns the timer). Idle gate crosses as `getCurrentTurnNull` ONLY.
 
 /** Live gateway deps for the extracted delivery-confirm sweep wiring. */
 function gatewayDeliveryConfirmDeps() {
   return {
-    DELIVERY_CONFIRM_ENABLED,
-    DELIVERY_CONFIRM_TIMEOUT_MS,
+    DELIVERY_CONFIRM_ENABLED, DELIVERY_CONFIRM_TIMEOUT_MS,
     getCurrentTurnNull: (): boolean => currentTurn == null,
     sendToAgent: (agent: string, m: InboundMessage): boolean => ipcServer.sendToAgent(agent, m),
-    deliveryQueue,
-    pendingInboundBuffer,
-    pendingPermissions,
-    pendingAskUser,
+    deliveryQueue, pendingInboundBuffer, pendingPermissions, pendingAskUser,
   }
 }
 export type DeliveryConfirmWiringDeps = ReturnType<typeof gatewayDeliveryConfirmDeps>
@@ -9851,6 +9847,8 @@ function runDeliveryConfirmSweep(): void {
 
 const _deliveryConfirmSweep = isGatewayMain ? setInterval(runDeliveryConfirmSweep, DELIVERY_CONFIRM_SWEEP_MS) : undefined
 _deliveryConfirmSweep?.unref?.()
+
+startOutboxSweep({ isGatewayMain, stateDir: STATE_DIR, getBot: () => bot, getTurnsDb: () => turnsDb, dedupCheck: (c, t, x) => outboundDedup.check(c, t, x, Date.now()) != null, log: (l) => process.stderr.write(l) }) // outbox: single deliverer for Stop-hook-captured prose (../outbox.ts)
 
 // #1445 cross-turn pending-async ambient. When a turn ends after the
 // model dispatched background async work (Agent / Task / Bash run-in-
@@ -14795,6 +14793,8 @@ export async function handleInbound(
   {
     const inboundChatId = ctx.chat?.id
     if (inboundChatId != null) void dmPinSweeper.sweep(String(inboundChatId))
+    // Outbox H3 fallback: stamp the last real inbound chat for envelope-less handback routing.
+    if (inboundChatId != null) writeLastInboundChat({ chatId: String(inboundChatId), threadId: messageThreadId ?? null })
   }
 
   // Capture wall-clock receive time for inbound_ack metric (#203).

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -51,7 +51,7 @@ import {
 import { richMessage } from '../rich-send.js'
 import { journalExternalDelivery } from './outbox-sweep.js'
 import { resolveChatIdFallback } from './chat-id-fallback.js'
-import { isFinalAnswerReply, isSubstantiveFinalReply } from '../final-answer-detect.js'
+import { isFinalAnswerReply, isSubstantiveFinalReply, shouldJournalReplySiteDelivery } from '../final-answer-detect.js'
 import { decideOverPing, type OverPingDecision } from '../over-ping-safety-net.js'
 import { decideSilentReplyAnchor } from '../silent-reply-anchor.js'
 import {
@@ -2288,13 +2288,27 @@ export async function sendReply(
   if (sentIds.length > 0) {
     const t = getCurrentTurn()
     outboundDedup.record(chat_id, threadId, text, Date.now(), t?.registryKey ?? null)
-    // F1: a FINAL-answer reply journals + clears under the shared nonce
+    // F1: a SUBSTANTIVE-final reply journals + clears under the shared nonce
     // (turn.turnId === deriveTurnId, the hook's deriveTurnNonce), so the sweep
-    // never re-posts this turn's answer. Gated on isFinalAnswerReply: an interim
-    // ack is NOT the turn's answer, so it must not journal the turn nonce (that
-    // would suppress a later genuinely-undelivered final answer for the same
-    // gateway turn).
-    if (isFinalAnswerReply({ text: rawText, disableNotification: modelDisableNotification })) {
+    // never re-posts this turn's answer.
+    //
+    // F3: gate on `isSubstantiveFinalReply`, NOT `isFinalAnswerReply`. Unlike
+    // the flush site (~1741) and the captured-prose bridge (~2407) — where the
+    // journaled text IS this turn's trailing content, so a loose gate is
+    // loss-safe — here the journaled text is the REPLY text, a DIFFERENT string
+    // from the trailing prose the hook captures under the same turn nonce.
+    // `isFinalAnswerReply`'s ping clause (`disableNotification` falsy — the
+    // tool's default, routinely omitted by models) classifies a short pinging
+    // interim ack ("On it — digging in") as final. Journaling on that ack would
+    // poison the turn nonce: the model then ends the turn with gateway-invisible
+    // trailing prose (the real answer), the Stop hook captures it under the SAME
+    // nonce, and the sweep hits `skip-journaled` → `clearOutboxRecord` → the
+    // real answer is silently destroyed — the exact incident class this outbox
+    // exists to prevent. `isSubstantiveFinalReply` (`done === true ||
+    // length ≥ 200`, no ping path) still journals a genuine answer (so the sweep
+    // won't double-post it) while an interim ack never journals (so a later
+    // genuinely-undelivered final answer is delivered by the sweep).
+    if (shouldJournalReplySiteDelivery({ text: rawText, disableNotification: modelDisableNotification })) {
       journalExternalDelivery({ turnNonce: t?.turnId ?? null, text, tgMessageId: sentIds[sentIds.length - 1] })
     }
   }

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -49,6 +49,7 @@ import {
   escapeMarkdown,
 } from '../format.js'
 import { richMessage } from '../rich-send.js'
+import { journalExternalDelivery } from './outbox-sweep.js'
 import { resolveChatIdFallback } from './chat-id-fallback.js'
 import { isFinalAnswerReply, isSubstantiveFinalReply } from '../final-answer-detect.js'
 import { decideOverPing, type OverPingDecision } from '../over-ping-safety-net.js'
@@ -1733,6 +1734,16 @@ export async function sendReply(
             Date.now(),
             turn?.registryKey ?? null,
           )
+          // F1: a FINAL-answer silent-anchor edit journals this legacy delivery
+          // under the shared nonce (turn.turnId === deriveTurnId === the hook's
+          // deriveTurnNonce `${chatKey}#${messageId}` for a gateway-visible turn)
+          // and drops any hook-captured record, so the sweep never re-sends after
+          // the in-memory dedup TTL evicts / a restart clears it / the captured
+          // text differs. Gated so an interim-ack edit never journals the turn
+          // nonce (which would suppress a later genuine answer for the turn).
+          if (isFinalAnswerReply({ text: decision.mergedText, disableNotification: modelDisableNotification })) {
+            journalExternalDelivery({ turnNonce: turn?.turnId ?? null, text: decision.mergedText, tgMessageId: decision.messageId })
+          }
 
           silentAnchorEditDone = true
         } catch (err) {
@@ -2275,7 +2286,17 @@ export async function sendReply(
   // calls with this same content within DEFAULT_DEDUP_TTL_MS will
   // be suppressed.
   if (sentIds.length > 0) {
-    outboundDedup.record(chat_id, threadId, text, Date.now(), getCurrentTurn()?.registryKey ?? null)
+    const t = getCurrentTurn()
+    outboundDedup.record(chat_id, threadId, text, Date.now(), t?.registryKey ?? null)
+    // F1: a FINAL-answer reply journals + clears under the shared nonce
+    // (turn.turnId === deriveTurnId, the hook's deriveTurnNonce), so the sweep
+    // never re-posts this turn's answer. Gated on isFinalAnswerReply: an interim
+    // ack is NOT the turn's answer, so it must not journal the turn nonce (that
+    // would suppress a later genuinely-undelivered final answer for the same
+    // gateway turn).
+    if (isFinalAnswerReply({ text: rawText, disableNotification: modelDisableNotification })) {
+      journalExternalDelivery({ turnNonce: t?.turnId ?? null, text, tgMessageId: sentIds[sentIds.length - 1] })
+    }
   }
   return { content: [{ type: 'text', text: result }] }
 }
@@ -2383,6 +2404,9 @@ export async function deliverCapturedProse(
       // Record what we just sent so a late reply / stream_reply retry with the
       // same content is deduped at its send site (the #546 dedup cache).
       outboundDedup.record(chatId, threadId, text, now, registryKey)
+      // F1: captured-prose delivery journals + clears under the shared nonce
+      // (`originTurnId` === turn.turnId === deriveTurnId, the hook's nonce).
+      journalExternalDelivery({ turnNonce: originTurnId, text, tgMessageId: sentIds[sentIds.length - 1] })
       process.stderr.write(
         `telegram gateway: captured-prose delivery — sent ${out.length} chars recovered from ` +
           `transcript scan (chat=${chatId} origin=${originTurnId})\n`,

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -1,0 +1,249 @@
+/**
+ * outbox-sweep.ts — the single deliverer for the guaranteed-final-message
+ * outbox. Runs on the gateway heartbeat tick, independent of turn lifecycle,
+ * so it covers turn CLASSES the gateway never sees a CurrentTurn for
+ * (`<task-notification>` handbacks, background-worker completions, unknown
+ * future wake shapes). See `../outbox.ts` for the record/nonce/journal model.
+ *
+ * Exactly-once (H1): every record is claimed with a rename-mutex, guarded by the
+ * shared delivered-keys journal (same turnNonce every delivering machine uses),
+ * and by the existing text `outboundDedup`. Delivered nonce is journaled AFTER a
+ * successful send; a crash between send and journal is caught next boot by the
+ * text-dedup backstop (never a loss, at most one duplicate).
+ *
+ * Routing (H3): `resolveOutboxChat` runs the injected transitive registry-chain
+ * lookup then the last-real-inbound fallback for envelope-less records.
+ *
+ * The orchestration takes injected IO deps so it is unit-testable without a live
+ * gateway; `gateway.ts` wires the real send / dedup / registry lookups.
+ */
+
+import {
+  OUTBOX_QUIET_MS,
+  appendDelivered,
+  claimRecord,
+  decideOutboxSweep,
+  extractTaskId,
+  listPendingRecords,
+  readDeliveredNonces,
+  readLastInboundChat,
+  readOutboxRecord,
+  reclaimStaleSending,
+  releaseClaim,
+  removeClaimed,
+  resolveOutboxChat,
+  sha256Hex,
+  type OutboxRecord,
+} from '../outbox.js'
+import { resolveSubagentOriginTurnKey } from '../registry/subagents-schema.js'
+import { createRetryApiCall, retryWithThreadFallback } from '../retry-api-call.js'
+
+export interface OutboxSweepDeps {
+  /** Deliver `text` to the chat. Resolves to the primary message id (best-effort). */
+  send: (
+    chatId: string,
+    threadId: number | null,
+    text: string,
+  ) => Promise<number | undefined>
+  /** Has this exact text already been delivered to this chat/thread recently? */
+  textAlreadyDelivered: (chatId: string, threadId: number | null, text: string) => boolean
+  /**
+   * Transitive registry-chain lookup (H3): resolve the originating chat for a
+   * task-notification / chained-dispatch anchor from its `<task-id>`. Null when
+   * the chain doesn't resolve.
+   */
+  registryChainLookup?: (
+    taskId: string,
+  ) => { chatId: string; threadId: number | null } | null
+  stateDir?: string
+  now?: () => number
+  log?: (line: string) => void
+  quietMs?: number
+}
+
+export interface OutboxSweepSummary {
+  scanned: number
+  delivered: number
+  skipped: number
+}
+
+/**
+ * Sweep the outbox once. Idempotent; safe to call every heartbeat tick.
+ */
+export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSummary> {
+  const now = deps.now?.() ?? Date.now()
+  const log = deps.log ?? (() => {})
+  const summary: OutboxSweepSummary = { scanned: 0, delivered: 0, skipped: 0 }
+
+  // Re-queue crashed claims first (claim-then-crash before send).
+  reclaimStaleSending(deps.stateDir, now)
+
+  const pending = listPendingRecords(deps.stateDir)
+  if (pending.length === 0) return summary
+  const deliveredNonces = readDeliveredNonces(deps.stateDir)
+
+  for (const fileName of pending) {
+    const record = readOutboxRecord(fileName, deps.stateDir)
+    if (record == null) continue
+    summary.scanned++
+
+    // Resolve destination (anchor → registry chain → last-inbound fallback).
+    const resolved = resolveOutboxChat(record, {
+      registryChainLookup: (anchorContent) => {
+        const taskId = extractTaskId(anchorContent)
+        if (taskId == null || deps.registryChainLookup == null) return null
+        return deps.registryChainLookup(taskId)
+      },
+      lastInboundChat: () => readLastInboundChat(deps.stateDir),
+    })
+
+    const routePrefix = resolved?.via === 'last-inbound' ? '(from background task) ' : ''
+    const decision = decideOutboxSweep({
+      record,
+      now,
+      deliveredNonces,
+      textAlreadyDelivered:
+        resolved != null &&
+        deps.textAlreadyDelivered(resolved.chatId, resolved.threadId, record.text),
+      routable: resolved != null,
+      routePrefix,
+      quietMs: deps.quietMs ?? OUTBOX_QUIET_MS,
+    })
+
+    if (decision.action !== 'send' && decision.action !== 'send-delayed') {
+      summary.skipped++
+      if (decision.action === 'skip-journaled') removeClaimed(record.turnNonce, deps.stateDir)
+      continue
+    }
+
+    // Claim (rename mutex). If lost, another sweep/machine has it.
+    const claimed = claimRecord(record.turnNonce, deps.stateDir)
+    if (claimed == null) {
+      summary.skipped++
+      continue
+    }
+    const resolvedChat = resolved! // routable implies non-null
+
+    try {
+      const messageId = await deps.send(
+        resolvedChat.chatId,
+        resolvedChat.threadId,
+        decision.text ?? record.text,
+      )
+      appendDelivered(
+        { turnNonce: record.turnNonce, textSha256: record.textSha256, tgMessageId: messageId, ts: now },
+        deps.stateDir,
+      )
+      removeClaimed(record.turnNonce, deps.stateDir)
+      summary.delivered++
+      log(
+        `outbox-sweep: delivered nonce=${record.turnNonce} via=${resolvedChat.via} ` +
+          `source=${record.source} chars=${record.text.length}${decision.action === 'send-delayed' ? ' (delayed)' : ''}\n`,
+      )
+    } catch (err) {
+      // Send failed — release the claim so the next tick retries. The record is
+      // preserved on disk; no loss.
+      releaseClaim(record.turnNonce, deps.stateDir)
+      summary.skipped++
+      log(`outbox-sweep: send failed nonce=${record.turnNonce}: ${(err as Error).message} — will retry\n`)
+    }
+  }
+  return summary
+}
+
+/**
+ * Parse a registry `turn_key` (`chatId:threadId`, `_` → null thread) into a
+ * routable chat. Exported for the gateway wiring + tests.
+ */
+export function chatFromTurnKey(turnKey: string): { chatId: string; threadId: number | null } {
+  const idx = turnKey.indexOf(':')
+  const chatId = idx === -1 ? turnKey : turnKey.slice(0, idx)
+  const tRaw = idx === -1 ? '_' : turnKey.slice(idx + 1)
+  const t = tRaw === '_' || tRaw === '' ? null : Number(tRaw)
+  return { chatId, threadId: Number.isFinite(t as number) ? t : null }
+}
+
+/** How often the sweep ticks (aligned with the delivery-confirm sweep cadence). */
+export const OUTBOX_SWEEP_INTERVAL_MS = 5_000
+
+/**
+ * Own the heartbeat-tick outbox sweep entirely, keeping the timer / chunking /
+ * turn-key parse / dedup / registry-chain wiring OUT of `gateway.ts` (the line
+ * ratchet). The gateway passes only the primitives that must come from its
+ * scope: lazy getters for `bot` / `turnsDb` (both assigned late), its live
+ * `OutboundDedupCache`, and the state dir. Returns the interval handle (unref'd)
+ * or `undefined` when disabled / not the main process.
+ *
+ * Delivery reuses `bot.api.sendMessage` and chunks to Telegram's 4096-char
+ * ceiling so an oversized record can never wedge the sweep in a permanent
+ * retry loop. Routing runs the transitive registry chain
+ * (`resolveSubagentOriginTurnKey`) then the last-real-inbound fallback (H3).
+ * Kill switch: `SWITCHROOM_TG_OUTBOX_DELIVERY=0`.
+ */
+export function startOutboxSweep(deps: {
+  isGatewayMain: boolean
+  stateDir: string
+  getBot: () => { api: { sendMessage: (chatId: string, text: string, opts: object) => Promise<{ message_id?: number }> } } | undefined
+  getTurnsDb: () => Parameters<typeof resolveSubagentOriginTurnKey>[0] | null
+  dedupCheck: (chatId: string, threadId: number | undefined, text: string) => boolean
+  log?: (line: string) => void
+}): ReturnType<typeof setInterval> | undefined {
+  if (!deps.isGatewayMain || process.env.SWITCHROOM_TG_OUTBOX_DELIVERY === '0') return undefined
+  const retry = createRetryApiCall({ log: deps.log })
+  const tick = () => {
+    const bot = deps.getBot()
+    if (bot == null) return
+    void sweepOutbox({
+      stateDir: deps.stateDir,
+      log: deps.log,
+      send: async (chatId, threadId, text) => {
+        // Chunk to Telegram's 4096-char ceiling; each chunk goes through the
+        // standard retry / flood-wait / thread-fallback wrapper. A thrown send
+        // propagates so the sweep releases the claim and retries next tick (the
+        // record is never journaled → never lost).
+        let lastId: number | undefined
+        for (let i = 0; i < text.length; i += 4000) {
+          const chunk = text.slice(i, i + 4000)
+          const res = await retryWithThreadFallback(
+            retry,
+            (tid) => bot.api.sendMessage(chatId, chunk, tid != null ? { message_thread_id: tid } : {}),
+            { threadId: threadId ?? undefined, chat_id: chatId, verb: 'outbox-sweep.sendMessage' },
+          )
+          lastId = res?.message_id
+        }
+        return lastId
+      },
+      textAlreadyDelivered: (chatId, threadId, text) => deps.dedupCheck(chatId, threadId ?? undefined, text),
+      registryChainLookup: (taskId) => {
+        const db = deps.getTurnsDb()
+        if (db == null) return null
+        const turnKey = resolveSubagentOriginTurnKey(db, taskId)
+        return turnKey == null ? null : chatFromTurnKey(turnKey)
+      },
+    }).catch((err) => deps.log?.(`outbox-sweep: tick failed: ${(err as Error).message}\n`))
+  }
+  const timer = setInterval(tick, OUTBOX_SWEEP_INTERVAL_MS)
+  timer.unref?.()
+  return timer
+}
+
+/**
+ * Journal a delivery made by a NON-sweep machine (legacy turn-flush /
+ * captured-prose bridge / exhausted fallback / final-answer reply send) under
+ * the shared nonce, and drop any pending outbox record for it — the reply-path
+ * clear-by-nonce (H1). Call this at every existing delivery site with the
+ * gateway's own `deriveTurnId` nonce so the sweep never double-posts.
+ */
+export function journalExternalDelivery(
+  args: { turnNonce: string; text: string; tgMessageId?: number },
+  stateDir?: string,
+  now: number = Date.now(),
+): void {
+  appendDelivered(
+    { turnNonce: args.turnNonce, textSha256: sha256Hex(args.text), tgMessageId: args.tgMessageId, ts: now },
+    stateDir,
+  )
+}
+
+export { writeLastInboundChat } from '../outbox.js'
+export type { OutboxRecord }

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -7,12 +7,19 @@
  *
  * Exactly-once (H1): every record is claimed with a rename-mutex, guarded by the
  * shared delivered-keys journal (same turnNonce every delivering machine uses),
- * and by the existing text `outboundDedup`. Delivered nonce is journaled AFTER a
- * successful send; a crash between send and journal is caught next boot by the
- * text-dedup backstop (never a loss, at most one duplicate).
+ * and by the in-memory text `outboundDedup` cache. Delivered nonce is journaled
+ * AFTER a successful send. When a legacy machine (turn-flush / reply / captured
+ * prose) delivered the same turn's answer first, its journal write under the
+ * SAME nonce makes the sweep skip-journaled; and the sweep's own skip-dedup
+ * branch JOURNALS the nonce and DELETES the record (see below) so a text-dedup
+ * hit can never re-fire after the in-memory cache's TTL evicts. A crash between
+ * send and journal is caught next boot by the journal + text-dedup (never a
+ * loss, at most one duplicate).
  *
- * Routing (H3): `resolveOutboxChat` runs the injected transitive registry-chain
- * lookup then the last-real-inbound fallback for envelope-less records.
+ * Routing (H3/F2): `resolveOutboxChat` runs the injected transitive registry-chain
+ * lookup then the record's OWN stamped per-session origin chat for envelope-less
+ * records — never a gateway-global last-inbound fallback (cross-chat leak). It
+ * FAILS CLOSED (holds the record) when neither resolves.
  *
  * The orchestration takes injected IO deps so it is unit-testable without a live
  * gateway; `gateway.ts` wires the real send / dedup / registry lookups.
@@ -22,11 +29,11 @@ import {
   OUTBOX_QUIET_MS,
   appendDelivered,
   claimRecord,
+  clearOutboxRecord,
   decideOutboxSweep,
   extractTaskId,
   listPendingRecords,
   readDeliveredNonces,
-  readLastInboundChat,
   readOutboxRecord,
   reclaimStaleSending,
   releaseClaim,
@@ -87,17 +94,17 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
     if (record == null) continue
     summary.scanned++
 
-    // Resolve destination (anchor → registry chain → last-inbound fallback).
+    // Resolve destination (anchor → registry chain → per-session origin). Fails
+    // CLOSED (null → held) rather than routing to an arbitrary chat (F2).
     const resolved = resolveOutboxChat(record, {
       registryChainLookup: (anchorContent) => {
         const taskId = extractTaskId(anchorContent)
         if (taskId == null || deps.registryChainLookup == null) return null
         return deps.registryChainLookup(taskId)
       },
-      lastInboundChat: () => readLastInboundChat(deps.stateDir),
     })
 
-    const routePrefix = resolved?.via === 'last-inbound' ? '(from background task) ' : ''
+    const routePrefix = resolved?.via === 'origin' ? '(from background task) ' : ''
     const decision = decideOutboxSweep({
       record,
       now,
@@ -112,7 +119,25 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
 
     if (decision.action !== 'send' && decision.action !== 'send-delayed') {
       summary.skipped++
-      if (decision.action === 'skip-journaled') removeClaimed(record.turnNonce, deps.stateDir)
+      if (decision.action === 'skip-journaled') {
+        // Already delivered under this nonce by another machine → drop the
+        // pending record. clearOutboxRecord unlinks the `.json` (the pending
+        // file) AND any `.sending` — the pre-fix `removeClaimed` only unlinked
+        // `.sending`, leaking the `.json` to be rescanned forever (S4).
+        clearOutboxRecord(record.turnNonce, deps.stateDir)
+      } else if (decision.action === 'skip-dedup') {
+        // F1: the identical text was already delivered by the legacy flush/reply
+        // (in-memory `outboundDedup` hit). JOURNAL the nonce and DELETE the
+        // record NOW, so once that in-memory cache's TTL evicts (~60s) the sweep
+        // cannot resurrect and re-send this turn's answer. Deterministic
+        // exactly-once, independent of cache lifetime and surviving a restart
+        // (the record is gone from disk, the nonce is durably journaled).
+        appendDelivered(
+          { turnNonce: record.turnNonce, textSha256: record.textSha256, ts: now },
+          deps.stateDir,
+        )
+        clearOutboxRecord(record.turnNonce, deps.stateDir)
+      }
       continue
     }
 
@@ -230,20 +255,28 @@ export function startOutboxSweep(deps: {
 /**
  * Journal a delivery made by a NON-sweep machine (legacy turn-flush /
  * captured-prose bridge / exhausted fallback / final-answer reply send) under
- * the shared nonce, and drop any pending outbox record for it — the reply-path
- * clear-by-nonce (H1). Call this at every existing delivery site with the
- * gateway's own `deriveTurnId` nonce so the sweep never double-posts.
+ * the shared nonce, AND drop any pending outbox record for it — the reply-path
+ * clear-by-nonce (H1/F1). Wired at every legacy delivery site with the gateway's
+ * own `deriveTurnId` nonce (`turn.turnId`), which is byte-identical to the
+ * hook's `deriveTurnNonce` `${chatKey}#${messageId}` for a gateway-visible turn, so:
+ *   - the journal write makes a later sweep skip-journaled even after the
+ *     in-memory `outboundDedup` TTL has evicted or the gateway restarted, and
+ *   - `clearOutboxRecord` removes the hook's captured record immediately when
+ *     the flush text differs from the captured text (text-dedup would miss).
+ * Best-effort; never throws. A null/empty nonce is ignored (nothing to journal).
  */
 export function journalExternalDelivery(
-  args: { turnNonce: string; text: string; tgMessageId?: number },
+  args: { turnNonce: string | null; text: string; tgMessageId?: number },
   stateDir?: string,
   now: number = Date.now(),
 ): void {
+  const nonce = args.turnNonce
+  if (nonce == null || nonce === '') return
   appendDelivered(
-    { turnNonce: args.turnNonce, textSha256: sha256Hex(args.text), tgMessageId: args.tgMessageId, ts: now },
+    { turnNonce: nonce, textSha256: sha256Hex(args.text), tgMessageId: args.tgMessageId, ts: now },
     stateDir,
   )
+  clearOutboxRecord(nonce, stateDir)
 }
 
-export { writeLastInboundChat } from '../outbox.js'
 export type { OutboxRecord }

--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -54,12 +54,16 @@
  * every session close.
  */
 
-import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 
+import { createHash } from 'node:crypto'
+import { renameSync } from 'node:fs'
+
 import {
   scanTurnForFinalReply,
+  scanForOutboxCapture,
   decideStopHookDisposition,
   isTurnFlushSafetyEnabledEnv,
   isCapturedProseDeliveryEnabledEnv,
@@ -131,6 +135,61 @@ function writeElectedState(statePath, base, decision) {
   }
 }
 
+const JOURNAL_FILE = 'delivered.jsonl'
+
+/** Is `nonce` already in the outbox delivered-keys journal? (best-effort) */
+function outboxAlreadyDelivered(outboxDir, nonce) {
+  const path = join(outboxDir, JOURNAL_FILE)
+  if (!existsSync(path)) return false
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue
+      try {
+        if (JSON.parse(line)?.turnNonce === nonce) return true
+      } catch {
+        /* skip corrupt */
+      }
+    }
+  } catch {
+    /* best-effort */
+  }
+  return false
+}
+
+/**
+ * Write the durable outbox record for a captured undelivered final answer
+ * (atomic tmp+rename), mirroring `writeOutboxRecordAtomic` in `../outbox.ts`.
+ * The gateway heartbeat sweep is the single deliverer. Best-effort; never
+ * throws. Returns true when a record exists on disk for the nonce afterward.
+ */
+function writeOutboxRecord(stateDir, capture) {
+  const outboxDir = join(stateDir, 'outbox')
+  try {
+    mkdirSync(outboxDir, { recursive: true })
+    const finalPath = join(outboxDir, `${capture.turnNonce}.json`)
+    if (existsSync(finalPath)) return true
+    // Already delivered by another machine (reply/flush) under this nonce.
+    if (outboxAlreadyDelivered(outboxDir, capture.turnNonce)) return true
+    const record = {
+      turnNonce: capture.turnNonce,
+      chatId: capture.chatId,
+      threadId: capture.threadId,
+      text: capture.text,
+      textSha256: createHash('sha256').update(capture.text, 'utf8').digest('hex'),
+      createdAt: Date.now(),
+      source: capture.source,
+      anchorContent: capture.chatId == null ? capture.anchorContent : undefined,
+    }
+    const tmpPath = join(outboxDir, `.${capture.turnNonce}.${process.pid}.tmp`)
+    writeFileSync(tmpPath, JSON.stringify(record), 'utf8')
+    renameSync(tmpPath, finalPath)
+    return true
+  } catch (err) {
+    process.stderr.write(`[silent-end-interrupt] failed to write outbox record: ${err.message}\n`)
+    return false
+  }
+}
+
 function main() {
   const raw = readStdin().trim()
   if (!raw) process.exit(0)
@@ -161,6 +220,31 @@ function main() {
     process.exit(0)
   }
 
+  const stateDir = getStateDir()
+
+  // ── Outbox capture (guaranteed final-message delivery) ────────────────
+  // Class-agnostic: fires on EVERY main-session turn end. When the turn ended
+  // with substantive undelivered trailing prose (Telegram inbound,
+  // task-notification handback, cron, or a future/unknown wake shape), write a
+  // durable outbox record. The gateway heartbeat sweep is the single deliverer
+  // — no CurrentTurn, no election, no re-prompt needed. This is the deterministic
+  // guarantee: the model calling `reply` is no longer required. Fail-open on any
+  // error (never loop the session).
+  try {
+    const capture = scanForOutboxCapture(jsonl)
+    if (capture.capture === true) {
+      writeOutboxRecord(stateDir, capture)
+      process.stderr.write(
+        `[silent-end-interrupt] captured undelivered final answer to outbox ` +
+          `(nonce=${capture.turnNonce} source=${capture.source} chars=${capture.text.length}) — ` +
+          `sweep will deliver; allowing stop\n`,
+      )
+      process.exit(0)
+    }
+  } catch (err) {
+    process.stderr.write(`[silent-end-interrupt] outbox capture error (fail-open): ${err.message}\n`)
+  }
+
   const decision = scanTurnForFinalReply(jsonl)
 
   // 'allow' (qualifying reply or silent marker) and 'unknown' (no
@@ -175,7 +259,6 @@ function main() {
   // transcript above. If a state file exists from a prior turn that
   // never got cleared (clean shutdown not perfect), this read still
   // works; if absent, retryCount defaults to 0.
-  const stateDir = getStateDir()
   const statePath = join(stateDir, 'silent-end-pending.json')
 
   let state = {}

--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -179,6 +179,9 @@ function writeOutboxRecord(stateDir, capture) {
       createdAt: Date.now(),
       source: capture.source,
       anchorContent: capture.chatId == null ? capture.anchorContent : undefined,
+      // F2: per-session origin chat for envelope-less routing (fail-closed).
+      originChatId: capture.chatId == null ? (capture.originChatId ?? null) : undefined,
+      originThreadId: capture.chatId == null ? (capture.originThreadId ?? null) : undefined,
     }
     const tmpPath = join(outboxDir, `.${capture.turnNonce}.${process.pid}.tmp`)
     writeFileSync(tmpPath, JSON.stringify(record), 'utf8')
@@ -230,7 +233,13 @@ function main() {
   // — no CurrentTurn, no election, no re-prompt needed. This is the deterministic
   // guarantee: the model calling `reply` is no longer required. Fail-open on any
   // error (never loop the session).
-  try {
+  //
+  // Kill switch symmetry: `SWITCHROOM_TG_OUTBOX_DELIVERY=0` disables the gateway
+  // sweep (the deliverer). Capture MUST honour the SAME gate — otherwise, with
+  // the flag off, capture would write records that nothing delivers AND
+  // short-circuit the legacy re-prompt path below = silent loss. Flag off ⇒ skip
+  // capture entirely and fall through to the legacy block/re-prompt behaviour.
+  if (process.env.SWITCHROOM_TG_OUTBOX_DELIVERY !== '0') try {
     const capture = scanForOutboxCapture(jsonl)
     if (capture.capture === true) {
       writeOutboxRecord(stateDir, capture)

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -857,6 +857,36 @@ function resolveCaptureAnchor(lines) {
 }
 
 /**
+ * Resolve THIS session's origin chat — the most-recent non-sidechain enqueue
+ * line whose content carries a real Telegram `<channel>` envelope with a
+ * chatId. Scoped to the session's OWN transcript, this is the conversation of
+ * record for an envelope-less handback turn (F2): the sweep routes an
+ * unresolved-registry record here instead of a gateway-global "last chat anyone
+ * messaged" fallback, so a DM-origin handback can never leak into an unrelated
+ * chat. Null when the session has no prior channel inbound → the record fails
+ * CLOSED (held, never delivered to an arbitrary chat).
+ *
+ * @param {string[]} lines
+ * @returns {{ chatId: string | null, threadId: number | null }}
+ */
+function resolveSessionOriginChat(lines) {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]
+    if (!line || line[0] !== '{') continue
+    let obj
+    try { obj = JSON.parse(line) } catch { continue }
+    if (obj?.isSidechain === true) continue
+    if (obj?.type !== 'queue-operation') continue
+    const content = typeof obj.content === 'string' ? obj.content : ''
+    const env = parseChannelEnvelope(content)
+    if (env.chatId != null && env.chatId !== '') {
+      return { chatId: env.chatId, threadId: env.threadId ?? null }
+    }
+  }
+  return { chatId: null, threadId: null }
+}
+
+/**
  * Class-agnostic capture scan. Walks the turn from its anchor, tracking the last
  * delivery event (qualifying reply / silent marker) and the substantive prose
  * blocks that trail it. Returns a capture descriptor when the turn ended with
@@ -891,12 +921,14 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
         if (hadMarker) {
           // H6: a block ending "…real answer…\nNO_REPLY" carries a genuine
           // answer — capture the prose and do NOT treat the block as a silence
-          // event (which would mask the answer). Only when the prose is empty or
-          // pure narration does the trailing marker mean "intentionally silent".
+          // event (which would mask the answer). When the prose is empty or pure
+          // narration the marker is an intentional silence, but it must NOT emit
+          // a 'deliver' event: a *separate* bare-`NO_REPLY` block arriving AFTER
+          // a real (undelivered) prose block would otherwise move the
+          // last-delivery cursor past that prose and mask it (multi-block H6).
+          // A bare/narration marker is simply not a delivery — push nothing.
           if (prose.length > 0 && !isNarrationBlock(prose)) {
             blocks.push({ kind: 'text', chars: prose.length, text: prose })
-          } else {
-            blocks.push({ kind: 'deliver', reason: 'silent-marker-text' })
           }
         } else if (prose.length > 0) {
           blocks.push({ kind: 'text', chars: prose.length, text: prose })
@@ -949,6 +981,10 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
     else if (/task-notification|task-id/.test(anchor.anchorContent)) source = 'task-notification'
     else source = 'channel'
   }
+  // F2: for an envelope-less record, stamp THIS session's own origin chat so the
+  // sweep can route it without a gateway-global fallback. For an envelope-
+  // bearing record the anchor chatId already routes it (origin is redundant).
+  const origin = envelope.chatId != null ? { chatId: null, threadId: null } : resolveSessionOriginChat(lines)
   return {
     capture: true,
     text: text.trim(),
@@ -957,5 +993,7 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
     threadId: envelope.threadId ?? null,
     source,
     anchorContent: anchor.anchorContent,
+    originChatId: origin.chatId,
+    originThreadId: origin.threadId,
   }
 }

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -57,6 +57,7 @@
 // re-verify only if a new outbound-delivery tool is added to bridge.ts.
 import { statSync } from 'node:fs'
 import { join } from 'node:path'
+import { createHash } from 'node:crypto'
 
 const REPLY_TOOLS = new Set([
   'mcp__switchroom-telegram__reply',
@@ -716,5 +717,245 @@ export function isGatewayHeartbeatFresh(stateDir, now = Date.now()) {
     return now - st.mtimeMs <= GATEWAY_HEARTBEAT_FRESH_MS
   } catch {
     return false
+  }
+}
+
+// ── Outbox capture (guaranteed final-message delivery) ───────────────────────
+//
+// The Stop hook fires on EVERY main-session turn end, regardless of what woke
+// the turn (Telegram inbound, `<task-notification>` handback, cron, or a future
+// harness wake type). `scanForOutboxCapture` decides — class-agnostically —
+// whether this turn ended with substantive undelivered trailing prose that must
+// be captured into the durable outbox for the gateway sweep to deliver.
+//
+// Fail CLOSED (H4): capture keys on "a turn ended with unsent trailing prose",
+// never on recognising the wake shape. An anchor-less transcript tail still
+// captures (source='unknown') rather than silently allowing a lost answer.
+//
+// Cron (H5): NOT exempted — a cron turn that ends with prose is captured and
+// guaranteed-delivered, same as any other class. Only NO_REPLY stays silent.
+//
+// H6: a turn ending with real prose followed by a stray bare `NO_REPLY` still
+// captures the prose (the marker doesn't suppress a genuine answer), while a
+// legitimately-silent turn (pure NO_REPLY / narration-only) writes no record.
+
+/** Mirror of `deriveTurnNonce` in `../outbox.ts` — MUST stay in sync (a .mjs
+ * can't import the .ts). Test `outbox-nonce-parity` pins the equality. */
+export function deriveTurnNonce({ chatId, threadId, messageId, anchorTimestampMs, anchorContent }) {
+  if (chatId != null && messageId != null && messageId !== '' && String(messageId) !== '0') {
+    const key = `${chatId}:${threadId == null || threadId === 0 ? '_' : threadId}`
+    return `${key}#${messageId}`
+  }
+  return createHash('sha256').update(`${anchorTimestampMs}\n${anchorContent}`, 'utf8').digest('hex')
+}
+
+/**
+ * Strip a trailing bare silent-marker line (NO_REPLY / HEARTBEAT_OK) from a text
+ * block, returning the prose that precedes it (H6). If the whole block is the
+ * marker, prose is ''. If there is no trailing marker, `hadMarker` is false and
+ * prose is the block unchanged.
+ *
+ * @param {string} text
+ * @returns {{ prose: string, hadMarker: boolean }}
+ */
+export function stripTrailingSilentMarker(text) {
+  if (typeof text !== 'string') return { prose: '', hadMarker: false }
+  const rawLines = text.split('\n')
+  // Find the last non-empty line.
+  let lastIdx = -1
+  for (let i = rawLines.length - 1; i >= 0; i--) {
+    if (rawLines[i].trim().length > 0) {
+      lastIdx = i
+      break
+    }
+  }
+  if (lastIdx === -1) return { prose: '', hadMarker: false }
+  if (!SILENT_MARKER_RE.test(rawLines[lastIdx].trim())) {
+    return { prose: text.trim(), hadMarker: false }
+  }
+  const prose = rawLines.slice(0, lastIdx).join('\n').trim()
+  return { prose, hadMarker: true }
+}
+
+/**
+ * Resolve the turn-start anchor for capture. Primary: the most-recent
+ * `queue-operation`/`enqueue` line. H4 fallbacks (fail closed) when none is
+ * found: the last non-sidechain `user`-type line, else the last
+ * `queue-operation` of any operation, else the whole scanned range (startIdx=-1
+ * → scan from the top). `degraded` marks a non-primary anchor (source unknown).
+ *
+ * @param {string[]} lines
+ * @returns {{ startIdx: number, envelope: ReturnType<typeof parseChannelEnvelope>, anchorTimestampMs: number, anchorContent: string, degraded: boolean }}
+ */
+function resolveCaptureAnchor(lines) {
+  let enqueueIdx = -1
+  let anyQueueIdx = -1
+  let userIdx = -1
+  const parsed = new Array(lines.length)
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]
+    if (!line || line[0] !== '{') continue
+    let obj
+    try { obj = JSON.parse(line) } catch { continue }
+    parsed[i] = obj
+    if (obj?.type === 'queue-operation') {
+      if (obj.operation === 'enqueue' && enqueueIdx === -1) enqueueIdx = i
+      if (anyQueueIdx === -1) anyQueueIdx = i
+    }
+    if (obj?.type === 'user' && obj?.isSidechain !== true && userIdx === -1) userIdx = i
+  }
+  const anchorTs = (obj) => {
+    const t = obj?.timestamp
+    if (typeof t === 'number' && Number.isFinite(t)) return t
+    if (typeof t === 'string') {
+      const ms = Date.parse(t)
+      if (Number.isFinite(ms)) return ms
+    }
+    return Date.now()
+  }
+  if (enqueueIdx !== -1) {
+    const obj = parsed[enqueueIdx]
+    const content = typeof obj.content === 'string' ? obj.content : ''
+    return {
+      startIdx: enqueueIdx,
+      envelope: parseChannelEnvelope(content),
+      anchorTimestampMs: anchorTs(obj),
+      anchorContent: content,
+      degraded: false,
+    }
+  }
+  if (userIdx !== -1) {
+    const obj = parsed[userIdx]
+    const content = typeof obj?.message?.content === 'string' ? obj.message.content : JSON.stringify(obj?.message?.content ?? '')
+    return {
+      startIdx: userIdx,
+      envelope: { chatId: null, threadId: null, messageId: null, source: 'unknown' },
+      anchorTimestampMs: anchorTs(obj),
+      anchorContent: content,
+      degraded: true,
+    }
+  }
+  if (anyQueueIdx !== -1) {
+    const obj = parsed[anyQueueIdx]
+    const content = typeof obj.content === 'string' ? obj.content : ''
+    return {
+      startIdx: anyQueueIdx,
+      envelope: parseChannelEnvelope(content),
+      anchorTimestampMs: anchorTs(obj),
+      anchorContent: content,
+      degraded: true,
+    }
+  }
+  // No anchor at all — scan the whole range (fail closed on unknown shape).
+  return {
+    startIdx: -1,
+    envelope: { chatId: null, threadId: null, messageId: null, source: 'unknown' },
+    anchorTimestampMs: Date.now(),
+    anchorContent: '',
+    degraded: true,
+  }
+}
+
+/**
+ * Class-agnostic capture scan. Walks the turn from its anchor, tracking the last
+ * delivery event (qualifying reply / silent marker) and the substantive prose
+ * blocks that trail it. Returns a capture descriptor when the turn ended with
+ * undelivered final-answer prose, else `{ capture: false }`.
+ *
+ * @param {string} jsonl
+ * @param {number} [now]
+ * @returns {{ capture: false, reason: string } | { capture: true, text: string, turnNonce: string, chatId: string|null, threadId: number|null, source: string, anchorContent: string }}
+ */
+export function scanForOutboxCapture(jsonl, now = Date.now()) {
+  const lines = jsonl.split('\n')
+  const anchor = resolveCaptureAnchor(lines)
+  const { envelope } = anchor
+
+  const blocks = []
+  for (let i = anchor.startIdx + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (!line || line[0] !== '{') continue
+    let obj
+    try { obj = JSON.parse(line) } catch { continue }
+    if (obj?.isSidechain === true) continue
+    if (obj?.type !== 'assistant') continue
+    const content = obj?.message?.content
+    if (!Array.isArray(content)) continue
+    for (const c of content) {
+      if (c?.type === 'text') {
+        const raw = String(c.text ?? '')
+        // H6: strip a trailing bare marker; if substantive non-narration prose
+        // remains, it is a genuine (undelivered) answer — capture it. If nothing
+        // but the marker (or narration) remains, the block is a silence event.
+        const { prose, hadMarker } = stripTrailingSilentMarker(raw)
+        if (hadMarker) {
+          // H6: a block ending "…real answer…\nNO_REPLY" carries a genuine
+          // answer — capture the prose and do NOT treat the block as a silence
+          // event (which would mask the answer). Only when the prose is empty or
+          // pure narration does the trailing marker mean "intentionally silent".
+          if (prose.length > 0 && !isNarrationBlock(prose)) {
+            blocks.push({ kind: 'text', chars: prose.length, text: prose })
+          } else {
+            blocks.push({ kind: 'deliver', reason: 'silent-marker-text' })
+          }
+        } else if (prose.length > 0) {
+          blocks.push({ kind: 'text', chars: prose.length, text: prose })
+        }
+        continue
+      }
+      if (c?.type !== 'tool_use') continue
+      if (!REPLY_TOOLS.has(c.name)) continue
+      const input = c.input ?? {}
+      const text = String(input.text ?? '')
+      if (SILENT_MARKER_RE.test(text.trim()) || endsWithSilentMarker(text)) {
+        blocks.push({ kind: 'deliver', reason: 'silent-marker' })
+        continue
+      }
+      if (isFinalAnswerReply({
+        text,
+        disableNotification: input.disable_notification === true,
+        done: input.done === true,
+      })) {
+        blocks.push({ kind: 'deliver', reason: 'final-reply' })
+      }
+      // interim ack — neither delivery nor undelivered prose.
+    }
+  }
+
+  let lastDeliverIdx = -1
+  for (let i = 0; i < blocks.length; i++) {
+    if (blocks[i].kind === 'deliver') lastDeliverIdx = i
+  }
+  const trailing = blocks
+    .slice(lastDeliverIdx + 1)
+    .filter((b) => b.kind === 'text' && typeof b.text === 'string' && b.text.length > 0)
+    .map((b) => b.text)
+
+  const text = selectBridgePendingText(trailing)
+  if (text == null || text.trim().length < FINAL_ANSWER_MIN_CHARS) {
+    return { capture: false, reason: trailing.length === 0 ? 'no-trailing-prose' : 'below-floor' }
+  }
+
+  const turnNonce = deriveTurnNonce({
+    chatId: envelope.chatId,
+    threadId: envelope.threadId,
+    messageId: envelope.messageId,
+    anchorTimestampMs: anchor.anchorTimestampMs,
+    anchorContent: anchor.anchorContent,
+  })
+  let source = envelope.source
+  if (source == null) {
+    if (anchor.degraded) source = 'unknown'
+    else if (/task-notification|task-id/.test(anchor.anchorContent)) source = 'task-notification'
+    else source = 'channel'
+  }
+  return {
+    capture: true,
+    text: text.trim(),
+    turnNonce,
+    chatId: envelope.chatId,
+    threadId: envelope.threadId ?? null,
+    source,
+    anchorContent: anchor.anchorContent,
   }
 }

--- a/telegram-plugin/outbox.ts
+++ b/telegram-plugin/outbox.ts
@@ -1,0 +1,456 @@
+/**
+ * outbox.ts — durable per-turn outbox for guaranteed final-message delivery.
+ *
+ * Root defect (2026-07-22 incident, see
+ * `work/final-message-delivery/investigation.md`): every content-delivering
+ * machine in the gateway is anchored on a `CurrentTurn` created at gateway
+ * ENQUEUE of a Telegram inbound. Whole turn CLASSES never wake the gateway —
+ * `<task-notification>` sub-agent handbacks, background-worker completions,
+ * and any future harness wake type — so a real final answer written as plain
+ * transcript prose (never sent via the `reply` tool) was silently lost.
+ *
+ * The fix collapses delivery to ONE capture path and ONE delivery path:
+ *
+ *   CAPTURE  — the Stop hook (`hooks/silent-end-interrupt-stop.mjs`) fires on
+ *              EVERY main-session turn end regardless of what woke the turn.
+ *              When the turn ended with substantive undelivered trailing
+ *              prose, it atomically writes an outbox record here. Capture keys
+ *              on "a turn ended with unsent trailing prose", NOT on
+ *              recognising the wake shape, so unknown/future turn classes are
+ *              covered by construction and fail CLOSED.
+ *
+ *   DELIVER  — the gateway heartbeat sweep (`sweepOutbox`, wired on the
+ *              existing ~15s tick, independent of turn lifecycle) claims each
+ *              record with a rename-mutex, delivers it exactly once (guarded by
+ *              a persistent delivered-keys journal keyed by the SAME turnNonce
+ *              every delivering machine uses, plus the existing text
+ *              `outboundDedup`), and clears it.
+ *
+ * Exactly-once (H1): every delivering machine — the sweep AND the legacy
+ * turn-flush / captured-prose bridge / exhausted-fallback / reply send — writes
+ * the delivered-keys journal under the turnNonce and checks it before sending.
+ * One namespace, one nonce end to end → no double-post.
+ *
+ * Nonce (H2): `deriveTurnNonce` uses the gateway's `deriveTurnId`
+ * (`${chatKey}#${messageId}`) shape whenever the anchor envelope carries a real
+ * message_id (unique per inbound), else `sha256(anchorTimestampMs + '\n' +
+ * content)`. The ms timestamp makes a re-notifying task (byte-identical
+ * `<task-notification>` content) collision-free, and serialized concurrent
+ * sibling handbacks get distinct enqueue timestamps → distinct nonces.
+ *
+ * Routing (H3): a record captured off an envelope-less anchor (task-notification
+ * handback, chained/background-spawned dispatch) carries no chatId. `resolveOutboxChat`
+ * resolves it via a transitive registry-chain lookup first, then a per-session
+ * last-real-inbound chatKey fallback.
+ *
+ * Pure cores (`deriveTurnNonce`, `decideOutboxSweep`, `resolveOutboxChat`) are
+ * side-effect-free and unit-tested; the IO helpers are thin and best-effort.
+ */
+
+import { createHash } from 'node:crypto'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+  appendFileSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+
+/** One captured, not-yet-delivered final message for a single main-session turn. */
+export interface OutboxRecord {
+  /** Unique per-turn nonce — the shared delivery key (see `deriveTurnNonce`). */
+  turnNonce: string
+  /**
+   * Destination chat. May be `null` at capture time for an envelope-less anchor
+   * (task-notification handback); resolved at sweep via `resolveOutboxChat`.
+   */
+  chatId: string | null
+  /** Optional forum thread id. */
+  threadId: number | null
+  /** The undelivered final-answer prose. */
+  text: string
+  /** sha256 of `text` — the text-dedup key, matches the gateway's `outboundDedup`. */
+  textSha256: string
+  /** Wall-clock ms of capture. */
+  createdAt: number
+  /** Wake/anchor class: 'channel' | 'task-notification' | 'cron' | 'unknown' | … (diagnostic). */
+  source: string
+  /**
+   * Raw anchor content (the enqueue line's `content`) — kept so the sweep's
+   * transitive registry lookup can extract a `<task-id>` for chained-dispatch
+   * routing (H3). Absent for envelope-carrying anchors that already routed.
+   */
+  anchorContent?: string
+}
+
+/** One line of the delivered-keys journal (`outbox/delivered.jsonl`). */
+export interface DeliveredEntry {
+  turnNonce: string
+  textSha256: string
+  tgMessageId?: number
+  ts: number
+}
+
+export function sha256Hex(s: string): string {
+  return createHash('sha256').update(s, 'utf8').digest('hex')
+}
+
+/**
+ * Build the shared per-turn delivery nonce (H1 + H2).
+ *
+ * - `messageId` present  → `${chatKey}#${messageId}` — byte-identical to the
+ *   gateway's `deriveTurnId`, so the sweep and the legacy flush/bridge journal
+ *   under the SAME key for a gateway-visible turn (no double-post).
+ * - `messageId` absent   → `sha256(anchorTimestampMs + '\n' + content)`. The ms
+ *   timestamp guarantees uniqueness for a re-notifying task (identical content)
+ *   and for serialized concurrent siblings (distinct enqueue timestamps).
+ */
+export function deriveTurnNonce(args: {
+  chatId: string | null
+  threadId: number | null
+  messageId: string | null
+  anchorTimestampMs: number
+  anchorContent: string
+}): string {
+  const { chatId, threadId, messageId, anchorTimestampMs, anchorContent } = args
+  if (chatId != null && messageId != null && messageId !== '' && String(messageId) !== '0') {
+    const key = `${chatId}:${threadId == null || threadId === 0 ? '_' : threadId}`
+    return `${key}#${messageId}`
+  }
+  return sha256Hex(`${anchorTimestampMs}\n${anchorContent}`)
+}
+
+export function resolveStateDir(explicit?: string): string {
+  if (explicit != null && explicit !== '') return explicit
+  const env = process.env.TELEGRAM_STATE_DIR
+  if (env != null && env !== '') return env
+  const home = process.env.HOME ?? homedir()
+  return join(home, '.claude', 'channels', 'telegram')
+}
+
+export function resolveOutboxDir(stateDir?: string): string {
+  return join(resolveStateDir(stateDir), 'outbox')
+}
+
+const JOURNAL_FILE = 'delivered.jsonl'
+/** Records older than this are delivered with a "(delayed)" prefix, never dropped. */
+export const OUTBOX_MAX_AGE_MS = 30 * 60_000
+/** Quiet period before a record is eligible for sweep — lets a same-turn legacy flush land first. */
+export const OUTBOX_QUIET_MS = 5_000
+/** A `.sending` claim older than this is presumed crashed and re-queued. */
+export const OUTBOX_SENDING_TIMEOUT_MS = 60_000
+
+/** Atomically write an outbox record (tmp + rename). Best-effort; never throws. */
+export function writeOutboxRecordAtomic(record: OutboxRecord, stateDir?: string): boolean {
+  const dir = resolveOutboxDir(stateDir)
+  try {
+    mkdirSync(dir, { recursive: true })
+    const finalPath = join(dir, `${record.turnNonce}.json`)
+    // Idempotent capture: if a record for this nonce already exists (Stop hook
+    // re-fired, or gateway already captured), do not clobber — the first
+    // capture wins and the sweep is the single deliverer.
+    if (existsSync(finalPath)) return true
+    const tmpPath = join(dir, `.${record.turnNonce}.${process.pid}.tmp`)
+    writeFileSync(tmpPath, JSON.stringify(record), { mode: 0o600 })
+    renameSync(tmpPath, finalPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** List pending (unclaimed) record filenames — `*.json` excluding the journal. */
+export function listPendingRecords(stateDir?: string): string[] {
+  const dir = resolveOutboxDir(stateDir)
+  try {
+    return readdirSync(dir).filter(
+      (f) => f.endsWith('.json') && f !== JOURNAL_FILE && !f.startsWith('.'),
+    )
+  } catch {
+    return []
+  }
+}
+
+/** Read + parse a record file. Null on missing/corrupt. */
+export function readOutboxRecord(fileName: string, stateDir?: string): OutboxRecord | null {
+  try {
+    const raw = readFileSync(join(resolveOutboxDir(stateDir), fileName), 'utf8')
+    return JSON.parse(raw) as OutboxRecord
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Claim a record by renaming `<nonce>.json` → `<nonce>.sending`. Rename is the
+ * mutex: two concurrent sweeps cannot both claim the same record. Returns the
+ * claimed path, or null if the claim lost the race.
+ */
+export function claimRecord(nonce: string, stateDir?: string): string | null {
+  const dir = resolveOutboxDir(stateDir)
+  const from = join(dir, `${nonce}.json`)
+  const to = join(dir, `${nonce}.sending`)
+  try {
+    renameSync(from, to)
+    return to
+  } catch {
+    return null
+  }
+}
+
+/** Release a lost/failed claim back to pending (`<nonce>.sending` → `<nonce>.json`). */
+export function releaseClaim(nonce: string, stateDir?: string): void {
+  const dir = resolveOutboxDir(stateDir)
+  try {
+    renameSync(join(dir, `${nonce}.sending`), join(dir, `${nonce}.json`))
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Delete a delivered record's claimed file. */
+export function removeClaimed(nonce: string, stateDir?: string): void {
+  try {
+    unlinkSync(join(resolveOutboxDir(stateDir), `${nonce}.sending`))
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Re-queue `.sending` claims older than the crash timeout — covers a crash
+ * after claim but before send. Idempotent; safe to run every sweep.
+ */
+export function reclaimStaleSending(stateDir?: string, now: number = Date.now()): void {
+  const dir = resolveOutboxDir(stateDir)
+  let files: string[]
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith('.sending'))
+  } catch {
+    return
+  }
+  for (const f of files) {
+    try {
+      const st = statSync(join(dir, f))
+      if (now - st.mtimeMs > OUTBOX_SENDING_TIMEOUT_MS) {
+        renameSync(join(dir, f), join(dir, f.replace(/\.sending$/, '.json')))
+      }
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/** Read the set of already-delivered turnNonces from the journal. */
+export function readDeliveredNonces(stateDir?: string): Set<string> {
+  const set = new Set<string>()
+  const path = join(resolveOutboxDir(stateDir), JOURNAL_FILE)
+  if (!existsSync(path)) return set
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue
+      try {
+        const e = JSON.parse(line) as DeliveredEntry
+        if (e.turnNonce) set.add(e.turnNonce)
+      } catch {
+        /* skip corrupt line */
+      }
+    }
+  } catch {
+    /* best-effort */
+  }
+  return set
+}
+
+/** True iff `nonce` is already journaled as delivered. */
+export function outboxAlreadyDelivered(nonce: string, stateDir?: string): boolean {
+  return readDeliveredNonces(stateDir).has(nonce)
+}
+
+/**
+ * Append a delivered entry to the journal (intent/outcome). Called by EVERY
+ * delivering machine (sweep, legacy flush, captured-prose bridge, exhausted
+ * fallback, final-answer reply send) under the SAME nonce — the shared
+ * exactly-once namespace (H1). Best-effort; never throws.
+ */
+export function appendDelivered(entry: DeliveredEntry, stateDir?: string): void {
+  const dir = resolveOutboxDir(stateDir)
+  try {
+    mkdirSync(dir, { recursive: true })
+    appendFileSync(join(dir, JOURNAL_FILE), JSON.stringify(entry) + '\n', { mode: 0o600 })
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Delete any pending outbox record for `nonce` (the reply-path clear-by-nonce,
+ * plus the journal write so a race-in-flight sweep also skips). Called when a
+ * genuine reply/flush delivered this turn's answer, so the sweep never
+ * re-sends. Best-effort.
+ */
+export function clearOutboxRecord(nonce: string, stateDir?: string): void {
+  const dir = resolveOutboxDir(stateDir)
+  for (const suffix of ['.json', '.sending']) {
+    try {
+      unlinkSync(join(dir, `${nonce}${suffix}`))
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+export type OutboxSweepAction =
+  | 'send'
+  | 'send-delayed'
+  | 'skip-journaled'
+  | 'skip-quiet'
+  | 'skip-dedup'
+  | 'skip-unroutable'
+
+export interface OutboxSweepDecision {
+  action: OutboxSweepAction
+  /** The text to deliver (with any "(delayed)"/"(from background task)" prefix). */
+  text?: string
+}
+
+/**
+ * Pure sweep decision for one record. No IO — the caller injects the journal
+ * set, the text-dedup verdict, and the resolved chat.
+ *
+ *   skip-journaled  — nonce already delivered (exactly-once, H1).
+ *   skip-quiet      — inside the quiet period; let a same-turn legacy flush land.
+ *   skip-dedup      — identical text already delivered (outboundDedup / SQLite backstop).
+ *   skip-unroutable — no chat could be resolved (H3 exhausted) — keep the record.
+ *   send            — deliver now.
+ *   send-delayed    — older than max-age; deliver with a "(delayed)" prefix, never drop.
+ */
+export function decideOutboxSweep(input: {
+  record: Pick<OutboxRecord, 'turnNonce' | 'text' | 'createdAt'>
+  now: number
+  deliveredNonces: Set<string>
+  textAlreadyDelivered: boolean
+  routable: boolean
+  routePrefix?: string
+  quietMs?: number
+  maxAgeMs?: number
+}): OutboxSweepDecision {
+  const {
+    record,
+    now,
+    deliveredNonces,
+    textAlreadyDelivered,
+    routable,
+    routePrefix = '',
+    quietMs = OUTBOX_QUIET_MS,
+    maxAgeMs = OUTBOX_MAX_AGE_MS,
+  } = input
+  if (deliveredNonces.has(record.turnNonce)) return { action: 'skip-journaled' }
+  const age = now - record.createdAt
+  if (age < quietMs) return { action: 'skip-quiet' }
+  if (textAlreadyDelivered) return { action: 'skip-dedup' }
+  if (!routable) return { action: 'skip-unroutable' }
+  const delayed = age > maxAgeMs
+  const prefix = (delayed ? '(delayed) ' : '') + routePrefix
+  return { action: delayed ? 'send-delayed' : 'send', text: prefix + record.text }
+}
+
+export interface ResolvedChat {
+  chatId: string
+  threadId: number | null
+  /** How the chat was resolved — 'anchor' (envelope), 'registry' (H3 chain), 'last-inbound' (fallback). */
+  via: 'anchor' | 'registry' | 'last-inbound'
+}
+
+/**
+ * Resolve the destination chat for a record (H3).
+ *
+ *   1. anchor      — the record already carries a chatId (envelope-bearing turn).
+ *   2. registry    — transitive `<task-id>` → registry-row → originating chatKey
+ *                    lookup, recursing up a chained/background-spawned dispatch.
+ *   3. last-inbound— per-session last-real-inbound chatKey fallback (single-chat
+ *                    correct always; forum-correct unless the user switched
+ *                    topics mid-chain — the caller adds a "(from background
+ *                    task)" prefix in that case).
+ *
+ * Pure — the caller injects `registryChainLookup` and `lastInboundChat`.
+ */
+export function resolveOutboxChat(
+  record: Pick<OutboxRecord, 'chatId' | 'threadId' | 'anchorContent'>,
+  deps: {
+    registryChainLookup?: (anchorContent: string) => { chatId: string; threadId: number | null } | null
+    lastInboundChat?: () => { chatId: string; threadId: number | null } | null
+  },
+): ResolvedChat | null {
+  if (record.chatId != null && record.chatId !== '') {
+    return { chatId: record.chatId, threadId: record.threadId ?? null, via: 'anchor' }
+  }
+  if (record.anchorContent && deps.registryChainLookup) {
+    const hit = deps.registryChainLookup(record.anchorContent)
+    if (hit != null) return { chatId: hit.chatId, threadId: hit.threadId, via: 'registry' }
+  }
+  if (deps.lastInboundChat) {
+    const hit = deps.lastInboundChat()
+    if (hit != null) return { chatId: hit.chatId, threadId: hit.threadId, via: 'last-inbound' }
+  }
+  return null
+}
+
+// ── Last-real-inbound chat (H3 fallback) ─────────────────────────────────────
+// The gateway writes this on every real Telegram-inbound enqueue; the sweep
+// reads it to route an envelope-less handback to the conversation of record.
+
+const LAST_INBOUND_FILE = 'last-inbound-chat.json'
+
+export function writeLastInboundChat(
+  chat: { chatId: string; threadId: number | null },
+  stateDir?: string,
+): void {
+  const dir = resolveOutboxDir(stateDir)
+  try {
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, LAST_INBOUND_FILE),
+      JSON.stringify({ ...chat, ts: Date.now() }),
+      { mode: 0o600 },
+    )
+  } catch {
+    /* best-effort */
+  }
+}
+
+export function readLastInboundChat(
+  stateDir?: string,
+): { chatId: string; threadId: number | null } | null {
+  const path = join(resolveOutboxDir(stateDir), LAST_INBOUND_FILE)
+  if (!existsSync(path)) return null
+  try {
+    const o = JSON.parse(readFileSync(path, 'utf8')) as {
+      chatId?: string
+      threadId?: number | null
+    }
+    if (o.chatId == null || o.chatId === '') return null
+    return { chatId: o.chatId, threadId: o.threadId ?? null }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extract a `<task-id>` (or `task_id="…"`/`taskId`) from a task-notification
+ * anchor's content, for the H3 registry-chain lookup. Null if none.
+ */
+export function extractTaskId(anchorContent: string): string | null {
+  if (typeof anchorContent !== 'string') return null
+  const m =
+    anchorContent.match(/<task-id>\s*([^<\s]+)\s*<\/task-id>/) ??
+    anchorContent.match(/task[_-]?id="([^"]+)"/i) ??
+    anchorContent.match(/task[_-]?id:\s*([^\s,}"']+)/i)
+  return m ? m[1] : null
+}

--- a/telegram-plugin/outbox.ts
+++ b/telegram-plugin/outbox.ts
@@ -38,10 +38,14 @@
  * `<task-notification>` content) collision-free, and serialized concurrent
  * sibling handbacks get distinct enqueue timestamps → distinct nonces.
  *
- * Routing (H3): a record captured off an envelope-less anchor (task-notification
+ * Routing (H3/F2): a record captured off an envelope-less anchor (task-notification
  * handback, chained/background-spawned dispatch) carries no chatId. `resolveOutboxChat`
- * resolves it via a transitive registry-chain lookup first, then a per-session
- * last-real-inbound chatKey fallback.
+ * resolves it via a transitive registry-chain lookup first, then the record's OWN
+ * stamped per-session origin chat (`originChatId`, captured at Stop from this
+ * session's most recent real `<channel>` inbound). It never consults a
+ * gateway-global "last chat anyone messaged" fallback (that could leak private
+ * content cross-chat), and FAILS CLOSED — holding the record — if neither
+ * resolves.
  *
  * Pure cores (`deriveTurnNonce`, `decideOutboxSweep`, `resolveOutboxChat`) are
  * side-effect-free and unit-tested; the IO helpers are thin and best-effort.
@@ -87,6 +91,19 @@ export interface OutboxRecord {
    * routing (H3). Absent for envelope-carrying anchors that already routed.
    */
   anchorContent?: string
+  /**
+   * Per-session ORIGIN chat, stamped at capture time from THIS session's own
+   * transcript (its most-recent real Telegram `<channel>` inbound) — the
+   * conversation of record for the session that produced this handback. Used as
+   * the scoped routing fallback for an envelope-less record whose registry chain
+   * fails (H3/F2), REPLACING the old gateway-global "last chat anyone messaged"
+   * fallback that could leak private content into an unrelated chat. Absent when
+   * the session has no prior channel inbound → the record fails CLOSED (held,
+   * never delivered to an arbitrary chat).
+   */
+  originChatId?: string | null
+  /** Forum thread of the per-session origin chat (see `originChatId`). */
+  originThreadId?: number | null
 }
 
 /** One line of the delivered-keys journal (`outbox/delivered.jsonl`). */
@@ -274,16 +291,47 @@ export function outboxAlreadyDelivered(nonce: string, stateDir?: string): boolea
 }
 
 /**
+ * Max delivered-keys kept in the journal. On exceeding `JOURNAL_ROTATE_AT` lines
+ * the journal is compacted down to the newest `JOURNAL_KEEP` entries — bounding
+ * on-disk growth and per-tick read cost. A duplicate arriving after its nonce
+ * has aged out of the kept window is still caught by the record having been
+ * deleted at delivery (the pending file is gone), so compaction never
+ * reintroduces a double-post for any live record.
+ */
+export const JOURNAL_KEEP = 2_000
+export const JOURNAL_ROTATE_AT = 4_000
+
+/**
  * Append a delivered entry to the journal (intent/outcome). Called by EVERY
  * delivering machine (sweep, legacy flush, captured-prose bridge, exhausted
  * fallback, final-answer reply send) under the SAME nonce — the shared
- * exactly-once namespace (H1). Best-effort; never throws.
+ * exactly-once namespace (H1). Best-effort; never throws. Compacts the journal
+ * in place once it grows past `JOURNAL_ROTATE_AT` lines.
  */
 export function appendDelivered(entry: DeliveredEntry, stateDir?: string): void {
   const dir = resolveOutboxDir(stateDir)
+  const path = join(dir, JOURNAL_FILE)
   try {
     mkdirSync(dir, { recursive: true })
-    appendFileSync(join(dir, JOURNAL_FILE), JSON.stringify(entry) + '\n', { mode: 0o600 })
+    appendFileSync(path, JSON.stringify(entry) + '\n', { mode: 0o600 })
+    compactJournalIfLarge(path)
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Rewrite the journal keeping only its newest `JOURNAL_KEEP` non-empty lines
+ * once it exceeds `JOURNAL_ROTATE_AT`. Atomic (tmp + rename); best-effort.
+ */
+function compactJournalIfLarge(path: string): void {
+  try {
+    const lines = readFileSync(path, 'utf8').split('\n').filter((l) => l.length > 0)
+    if (lines.length <= JOURNAL_ROTATE_AT) return
+    const kept = lines.slice(lines.length - JOURNAL_KEEP)
+    const tmp = `${path}.${process.pid}.compact`
+    writeFileSync(tmp, kept.join('\n') + '\n', { mode: 0o600 })
+    renameSync(tmp, path)
   } catch {
     /* best-effort */
   }
@@ -326,7 +374,10 @@ export interface OutboxSweepDecision {
  *
  *   skip-journaled  — nonce already delivered (exactly-once, H1).
  *   skip-quiet      — inside the quiet period; let a same-turn legacy flush land.
- *   skip-dedup      — identical text already delivered (outboundDedup / SQLite backstop).
+ *   skip-dedup      — identical text already delivered (the in-memory
+ *                     `outboundDedup` cache; NOT a persistent/SQLite store —
+ *                     the durable exactly-once guard is the delivered-keys
+ *                     journal keyed by turnNonce, checked above).
  *   skip-unroutable — no chat could be resolved (H3 exhausted) — keep the record.
  *   send            — deliver now.
  *   send-delayed    — older than max-age; deliver with a "(delayed)" prefix, never drop.
@@ -364,28 +415,34 @@ export function decideOutboxSweep(input: {
 export interface ResolvedChat {
   chatId: string
   threadId: number | null
-  /** How the chat was resolved — 'anchor' (envelope), 'registry' (H3 chain), 'last-inbound' (fallback). */
-  via: 'anchor' | 'registry' | 'last-inbound'
+  /** How the chat was resolved — 'anchor' (envelope), 'registry' (H3 chain), 'origin' (per-session fallback). */
+  via: 'anchor' | 'registry' | 'origin'
 }
 
 /**
- * Resolve the destination chat for a record (H3).
+ * Resolve the destination chat for a record (H3 / F2).
  *
- *   1. anchor      — the record already carries a chatId (envelope-bearing turn).
- *   2. registry    — transitive `<task-id>` → registry-row → originating chatKey
- *                    lookup, recursing up a chained/background-spawned dispatch.
- *   3. last-inbound— per-session last-real-inbound chatKey fallback (single-chat
- *                    correct always; forum-correct unless the user switched
- *                    topics mid-chain — the caller adds a "(from background
- *                    task)" prefix in that case).
+ *   1. anchor    — the record already carries a chatId (envelope-bearing turn).
+ *   2. registry  — transitive `<task-id>` → registry-row → originating chatKey
+ *                  lookup, recursing up a chained/background-spawned dispatch.
+ *   3. origin    — the record's OWN stamped per-session origin chat
+ *                  (`originChatId`), captured at Stop from this session's most
+ *                  recent real `<channel>` inbound. This is SCOPED to the record
+ *                  (F2): it can never route to "whatever chat messaged the
+ *                  gateway last" the way the retired global last-inbound file
+ *                  could, so a DM-origin handback can never leak into an
+ *                  unrelated group. The caller adds a "(from background task)"
+ *                  prefix for this route.
  *
- * Pure — the caller injects `registryChainLookup` and `lastInboundChat`.
+ * FAIL CLOSED: if none of the three resolves, returns null — the sweep HOLDS the
+ * record (skip-unroutable) rather than delivering to an arbitrary chat.
+ *
+ * Pure — the caller injects `registryChainLookup`.
  */
 export function resolveOutboxChat(
-  record: Pick<OutboxRecord, 'chatId' | 'threadId' | 'anchorContent'>,
+  record: Pick<OutboxRecord, 'chatId' | 'threadId' | 'anchorContent' | 'originChatId' | 'originThreadId'>,
   deps: {
     registryChainLookup?: (anchorContent: string) => { chatId: string; threadId: number | null } | null
-    lastInboundChat?: () => { chatId: string; threadId: number | null } | null
   },
 ): ResolvedChat | null {
   if (record.chatId != null && record.chatId !== '') {
@@ -395,51 +452,10 @@ export function resolveOutboxChat(
     const hit = deps.registryChainLookup(record.anchorContent)
     if (hit != null) return { chatId: hit.chatId, threadId: hit.threadId, via: 'registry' }
   }
-  if (deps.lastInboundChat) {
-    const hit = deps.lastInboundChat()
-    if (hit != null) return { chatId: hit.chatId, threadId: hit.threadId, via: 'last-inbound' }
+  if (record.originChatId != null && record.originChatId !== '') {
+    return { chatId: record.originChatId, threadId: record.originThreadId ?? null, via: 'origin' }
   }
   return null
-}
-
-// ── Last-real-inbound chat (H3 fallback) ─────────────────────────────────────
-// The gateway writes this on every real Telegram-inbound enqueue; the sweep
-// reads it to route an envelope-less handback to the conversation of record.
-
-const LAST_INBOUND_FILE = 'last-inbound-chat.json'
-
-export function writeLastInboundChat(
-  chat: { chatId: string; threadId: number | null },
-  stateDir?: string,
-): void {
-  const dir = resolveOutboxDir(stateDir)
-  try {
-    mkdirSync(dir, { recursive: true })
-    writeFileSync(
-      join(dir, LAST_INBOUND_FILE),
-      JSON.stringify({ ...chat, ts: Date.now() }),
-      { mode: 0o600 },
-    )
-  } catch {
-    /* best-effort */
-  }
-}
-
-export function readLastInboundChat(
-  stateDir?: string,
-): { chatId: string; threadId: number | null } | null {
-  const path = join(resolveOutboxDir(stateDir), LAST_INBOUND_FILE)
-  if (!existsSync(path)) return null
-  try {
-    const o = JSON.parse(readFileSync(path, 'utf8')) as {
-      chatId?: string
-      threadId?: number | null
-    }
-    if (o.chatId == null || o.chatId === '') return null
-    return { chatId: o.chatId, threadId: o.threadId ?? null }
-  } catch {
-    return null
-  }
 }
 
 /**

--- a/telegram-plugin/tests/outbox-capture-scan.test.ts
+++ b/telegram-plugin/tests/outbox-capture-scan.test.ts
@@ -118,8 +118,21 @@ describe('H5 — cron turns are captured (no silent-loss carve-out)', () => {
 })
 
 describe('H6 — prose + trailing NO_REPLY must not suppress a real answer', () => {
-  it('captures the prose that precedes a stray trailing NO_REPLY', () => {
+  it('captures the prose that precedes a stray trailing NO_REPLY (same block)', () => {
     const cap = scanForOutboxCapture(jsonl([channel('1', '2'), assistantText(`${A_LONG}\nNO_REPLY`)]))
+    expect(cap.capture).toBe(true)
+    if (cap.capture) expect(cap.text).toBe(A_LONG)
+  })
+
+  it('captures a real answer in one block followed by a SEPARATE bare NO_REPLY block (multi-block)', () => {
+    // The multi-block masking case: a genuine undelivered answer, then a later
+    // standalone NO_REPLY block. The bare marker must NOT move the delivery
+    // cursor past the answer and suppress it.
+    const cap = scanForOutboxCapture(jsonl([
+      channel('1', '2'),
+      assistantText(A_LONG),
+      assistantText('NO_REPLY'),
+    ]))
     expect(cap.capture).toBe(true)
     if (cap.capture) expect(cap.text).toBe(A_LONG)
   })
@@ -140,6 +153,27 @@ describe('H6 — prose + trailing NO_REPLY must not suppress a real answer', () 
 
   it('does NOT capture narration-only trailing text', () => {
     expect(scanForOutboxCapture(jsonl([channel('1', '2'), assistantText('Let me check that…')])).capture).toBe(false)
+  })
+})
+
+describe('F2 — per-session origin chat stamped for envelope-less routing', () => {
+  it('stamps the session origin chat on a task-notification handback captured after a DM inbound', () => {
+    const cap = scanForOutboxCapture(jsonl([
+      channel('777', '5', 'do the thing'), // the DM the user spawned the task from
+      taskNotification('worker done'),      // envelope-less handback wake
+      assistantText(A_LONG),
+    ]))
+    expect(cap.capture).toBe(true)
+    if (cap.capture) {
+      expect(cap.chatId).toBeNull()        // envelope-less
+      expect((cap as { originChatId?: string | null }).originChatId).toBe('777')
+    }
+  })
+
+  it('leaves origin null when the session has no prior channel inbound (fail-closed)', () => {
+    const cap = scanForOutboxCapture(jsonl([taskNotification('worker done'), assistantText(A_LONG)]))
+    expect(cap.capture).toBe(true)
+    if (cap.capture) expect((cap as { originChatId?: string | null }).originChatId ?? null).toBeNull()
   })
 })
 

--- a/telegram-plugin/tests/outbox-capture-scan.test.ts
+++ b/telegram-plugin/tests/outbox-capture-scan.test.ts
@@ -1,0 +1,188 @@
+/**
+ * outbox-capture-scan.test.ts — the capture half of guaranteed final-message
+ * delivery (`work/final-message-delivery/`).
+ *
+ * Exercises the class-agnostic Stop-hook capture scan (`scanForOutboxCapture`)
+ * and the shared nonce (`deriveTurnNonce`) against the adversarial-review
+ * oracles: the incident replay (task-notification handback with trailing prose
+ * and no reply), same-content re-notification (H2, no nonce collision), cron
+ * capture (H5), unknown-anchor fail-closed (H4), and prose + trailing NO_REPLY
+ * (H6). Pure functions — no subprocess needed.
+ *
+ * RED-then-green: these functions are new; against pre-fix code the import
+ * resolves to `undefined` and every assertion throws. The hook-subprocess
+ * outcome test (`outbox-hook-capture.test.ts`) is the behavioural RED replay.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  scanForOutboxCapture,
+  deriveTurnNonce,
+  stripTrailingSilentMarker,
+} from '../hooks/silent-end-scan.mjs'
+
+const A_LONG = 'x'.repeat(1647) // the incident's 1,647-char final answer shape
+
+function jsonl(lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n')
+}
+
+function taskNotification(content = 'worker done', taskId = 'a7cc7a0fa8f', ts = 1000): object {
+  return {
+    type: 'queue-operation',
+    operation: 'enqueue',
+    content: `<task-notification><task-id>${taskId}</task-id> ${content}</task-notification>`,
+    timestamp: ts,
+  }
+}
+
+function channel(chatId: string, messageId: string, body = 'hi', ts = 1000, source = 'telegram'): object {
+  return {
+    type: 'queue-operation',
+    operation: 'enqueue',
+    content: `<channel source="${source}" chat_id="${chatId}" message_id="${messageId}">${body}</channel>`,
+    timestamp: ts,
+  }
+}
+
+function assistantText(text: string): object {
+  return { type: 'assistant', message: { content: [{ type: 'text', text }] } }
+}
+
+function reply(text: string, opts: Record<string, unknown> = {}): object {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{ type: 'tool_use', name: 'mcp__switchroom-telegram__reply', input: { text, ...opts } }],
+    },
+  }
+}
+
+describe('scanForOutboxCapture — incident replay (task-notification handback)', () => {
+  it('captures the trailing final answer of a task-notification turn with no reply', () => {
+    const t = jsonl([taskNotification(), assistantText(A_LONG)])
+    const cap = scanForOutboxCapture(t)
+    expect(cap.capture).toBe(true)
+    if (cap.capture) {
+      expect(cap.text).toBe(A_LONG)
+      expect(cap.chatId).toBeNull() // envelope-less → routed at sweep (H3)
+      expect(cap.source).toBe('task-notification')
+      expect(cap.turnNonce).toBeTruthy()
+    }
+  })
+})
+
+describe('H2 — nonce uniqueness on same-content re-notification', () => {
+  it('two identical task-notifications at different timestamps get distinct nonces', () => {
+    const c1 = scanForOutboxCapture(jsonl([taskNotification('done', 'task-A', 1000), assistantText(A_LONG)]))
+    const c2 = scanForOutboxCapture(jsonl([taskNotification('done', 'task-A', 2000), assistantText('y'.repeat(500))]))
+    expect(c1.capture && c2.capture).toBe(true)
+    if (c1.capture && c2.capture) expect(c1.turnNonce).not.toBe(c2.turnNonce)
+  })
+
+  it('a gateway-visible turn keeps the deriveTurnId nonce shape', () => {
+    const cap = scanForOutboxCapture(jsonl([channel('999', '77'), assistantText(A_LONG)]))
+    expect(cap.capture).toBe(true)
+    if (cap.capture) expect(cap.turnNonce).toBe('999:_#77')
+  })
+})
+
+describe('H4 — unknown anchor fails CLOSED (still captures)', () => {
+  it('captures trailing prose when there is NO queue-operation anchor at all', () => {
+    // A future/unknown wake shape: no enqueue line, only a user boundary + prose.
+    const t = jsonl([
+      { type: 'user', message: { content: 'resume' } },
+      assistantText(A_LONG),
+    ])
+    const cap = scanForOutboxCapture(t)
+    expect(cap.capture).toBe(true)
+    if (cap.capture) {
+      expect(cap.text).toBe(A_LONG)
+      expect(cap.source).toBe('unknown')
+    }
+  })
+
+  it('still captures with no anchor line whatsoever (bare tail)', () => {
+    const cap = scanForOutboxCapture(jsonl([assistantText(A_LONG)]))
+    expect(cap.capture).toBe(true)
+  })
+})
+
+describe('H5 — cron turns are captured (no silent-loss carve-out)', () => {
+  it('captures a cron turn that ends with substantive prose and no reply', () => {
+    const cron = channel('555', '0', 'digest', 3000, 'cron')
+    const cap = scanForOutboxCapture(jsonl([cron, assistantText(A_LONG)]))
+    expect(cap.capture).toBe(true)
+    if (cap.capture) expect(cap.source).toBe('cron')
+  })
+})
+
+describe('H6 — prose + trailing NO_REPLY must not suppress a real answer', () => {
+  it('captures the prose that precedes a stray trailing NO_REPLY', () => {
+    const cap = scanForOutboxCapture(jsonl([channel('1', '2'), assistantText(`${A_LONG}\nNO_REPLY`)]))
+    expect(cap.capture).toBe(true)
+    if (cap.capture) expect(cap.text).toBe(A_LONG)
+  })
+
+  it('does NOT capture a pure NO_REPLY turn (legitimately silent)', () => {
+    expect(scanForOutboxCapture(jsonl([channel('1', '2'), assistantText('NO_REPLY')])).capture).toBe(false)
+  })
+
+  it('does NOT capture a HEARTBEAT_OK-only cron turn', () => {
+    expect(
+      scanForOutboxCapture(jsonl([channel('5', '0', 'x', 1, 'cron'), assistantText('HEARTBEAT_OK')])).capture,
+    ).toBe(false)
+  })
+
+  it('does NOT capture when the final answer was delivered via reply', () => {
+    expect(scanForOutboxCapture(jsonl([channel('1', '2'), reply(A_LONG)])).capture).toBe(false)
+  })
+
+  it('does NOT capture narration-only trailing text', () => {
+    expect(scanForOutboxCapture(jsonl([channel('1', '2'), assistantText('Let me check that…')])).capture).toBe(false)
+  })
+})
+
+describe('interim-ack then undelivered answer (at-least-once)', () => {
+  it('captures the substantive answer written after a short interim ack reply', () => {
+    const t = jsonl([
+      channel('1', '2'),
+      reply('on it', { disable_notification: true }),
+      assistantText(A_LONG),
+    ])
+    const cap = scanForOutboxCapture(t)
+    expect(cap.capture).toBe(true)
+    if (cap.capture) expect(cap.text).toBe(A_LONG)
+  })
+})
+
+describe('stripTrailingSilentMarker', () => {
+  it('strips a trailing bare marker and returns preceding prose', () => {
+    expect(stripTrailingSilentMarker('the answer\nNO_REPLY')).toEqual({ prose: 'the answer', hadMarker: true })
+  })
+  it('reports no marker for plain prose', () => {
+    expect(stripTrailingSilentMarker('just prose')).toEqual({ prose: 'just prose', hadMarker: false })
+  })
+  it('handles a marker-only block', () => {
+    expect(stripTrailingSilentMarker('NO_REPLY')).toEqual({ prose: '', hadMarker: true })
+  })
+})
+
+describe('deriveTurnNonce', () => {
+  it('uses the deriveTurnId shape when a message_id is present', () => {
+    expect(
+      deriveTurnNonce({ chatId: '9', threadId: null, messageId: '3', anchorTimestampMs: 1, anchorContent: 'x' }),
+    ).toBe('9:_#3')
+  })
+  it('threads the thread id into the key', () => {
+    expect(
+      deriveTurnNonce({ chatId: '9', threadId: 44, messageId: '3', anchorTimestampMs: 1, anchorContent: 'x' }),
+    ).toBe('9:44#3')
+  })
+  it('falls back to a timestamped content hash without a message_id', () => {
+    const a = deriveTurnNonce({ chatId: null, threadId: null, messageId: null, anchorTimestampMs: 1, anchorContent: 'x' })
+    const b = deriveTurnNonce({ chatId: null, threadId: null, messageId: null, anchorTimestampMs: 2, anchorContent: 'x' })
+    expect(a).not.toBe(b)
+    expect(a).toMatch(/^[0-9a-f]{64}$/)
+  })
+})

--- a/telegram-plugin/tests/outbox-delivery.test.ts
+++ b/telegram-plugin/tests/outbox-delivery.test.ts
@@ -28,7 +28,8 @@ import {
   OUTBOX_MAX_AGE_MS,
 } from '../outbox.js'
 import { deriveTurnNonce as deriveTurnNonceMjs } from '../hooks/silent-end-scan.mjs'
-import { sweepOutbox } from '../gateway/outbox-sweep.js'
+import { sweepOutbox, journalExternalDelivery } from '../gateway/outbox-sweep.js'
+import { shouldJournalReplySiteDelivery } from '../final-answer-detect.js'
 
 function rec(over: Partial<OutboxRecord>): OutboxRecord {
   const text = over.text ?? 'x'.repeat(300)
@@ -173,6 +174,56 @@ describe('sweepOutbox — end to end (exactly-once, siblings, dedup)', () => {
     const s2 = sink()
     await sweepOutbox({ ...s2, textAlreadyDelivered: () => false, stateDir: dir, now: () => 65_000 })
     expect(s2.sent).toHaveLength(0) // journal (durable) suppresses — no double-post
+    expect(listPendingRecords(dir)).toHaveLength(0)
+  })
+
+  it('F3: a PINGING interim ack does NOT poison the turn nonce — the real answer is still delivered exactly once', async () => {
+    // The exact F3 loss scenario, end-to-end through the production reply-site
+    // journal gate (`shouldJournalReplySiteDelivery`) + the sweep:
+    //   1. DM inbound → turn nonce N.
+    //   2. Model calls reply("On it — digging in") WITHOUT disable_notification
+    //      (a PINGING interim ack — the tool's default; models routinely omit
+    //      the flag). `isFinalAnswerReply` would classify this "final" (ping
+    //      clause), so the pre-fix reply site journaled N here.
+    //   3. Model ends the turn with gateway-invisible trailing prose (the real
+    //      answer) → the Stop hook captures it as a pending outbox record under
+    //      the SAME nonce N.
+    //   4. The sweep must DELIVER the real answer.
+    // Pre-fix (gate === isFinalAnswerReply) the ack journaled N → the sweep hits
+    // skip-journaled → clearOutboxRecord → 0 sent → the real answer is silently
+    // destroyed (RED). Post-fix (gate === isSubstantiveFinalReply) the pinging
+    // ack does NOT journal → the sweep delivers the real answer exactly once.
+    const nonce = deriveTurnNonce({ chatId: '8', threadId: null, messageId: '5', anchorTimestampMs: 1, anchorContent: 'c' })
+    const pingingAck = { text: 'On it — digging in', disableNotification: false }
+    // Model the reply site EXACTLY: journal via journalExternalDelivery iff the
+    // production gate says to (same call shape as outbound-send-path.ts sendReply).
+    if (shouldJournalReplySiteDelivery(pingingAck)) {
+      journalExternalDelivery({ turnNonce: nonce, text: pingingAck.text }, dir)
+    }
+    // The Stop hook captured the real (undelivered) answer under the same nonce.
+    const realAnswer = 'The root cause is a race in the flush path — here is the full write-up. '.repeat(4)
+    writeOutboxRecordAtomic(rec({ turnNonce: nonce, chatId: '8', text: realAnswer, createdAt: 0 }), dir)
+    const s = sink()
+    await sweepOutbox({ ...s, textAlreadyDelivered: () => false, stateDir: dir, now: () => 10_000 })
+    expect(s.sent).toHaveLength(1)
+    expect(s.sent[0].text).toBe(realAnswer)
+    expect(listPendingRecords(dir)).toHaveLength(0)
+  })
+
+  it('F3: a SUBSTANTIVE final reply STILL journals so the sweep does not double-post the same answer', async () => {
+    // The counterpart guard — the fix must not reopen F1. A genuine substantive
+    // answer delivered at the reply site journals the nonce, so a captured
+    // record for the same turn is suppressed (no duplicate).
+    const nonce = deriveTurnNonce({ chatId: '8', threadId: null, messageId: '6', anchorTimestampMs: 1, anchorContent: 'c' })
+    const realReply = { text: 'x'.repeat(300), disableNotification: false }
+    expect(shouldJournalReplySiteDelivery(realReply)).toBe(true)
+    if (shouldJournalReplySiteDelivery(realReply)) {
+      journalExternalDelivery({ turnNonce: nonce, text: realReply.text }, dir)
+    }
+    writeOutboxRecordAtomic(rec({ turnNonce: nonce, chatId: '8', text: realReply.text, createdAt: 0 }), dir)
+    const s = sink()
+    await sweepOutbox({ ...s, textAlreadyDelivered: () => false, stateDir: dir, now: () => 10_000 })
+    expect(s.sent).toHaveLength(0) // journaled → sweep suppresses → no double-post
     expect(listPendingRecords(dir)).toHaveLength(0)
   })
 

--- a/telegram-plugin/tests/outbox-delivery.test.ts
+++ b/telegram-plugin/tests/outbox-delivery.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
 import {
   decideOutboxSweep,
   deriveTurnNonce,
@@ -18,7 +19,10 @@ import {
   writeOutboxRecordAtomic,
   readDeliveredNonces,
   listPendingRecords,
-  writeLastInboundChat,
+  appendDelivered,
+  resolveOutboxDir,
+  JOURNAL_ROTATE_AT,
+  JOURNAL_KEEP,
   sha256Hex,
   type OutboxRecord,
   OUTBOX_MAX_AGE_MS,
@@ -79,27 +83,25 @@ describe('decideOutboxSweep', () => {
   })
 })
 
-describe('resolveOutboxChat (H3)', () => {
+describe('resolveOutboxChat (H3/F2)', () => {
   it('routes via the anchor envelope when chatId is present', () => {
     const r = resolveOutboxChat(rec({ chatId: '111', threadId: 5 }), {})
     expect(r).toEqual({ chatId: '111', threadId: 5, via: 'anchor' })
   })
-  it('routes an envelope-less record via the transitive registry chain', () => {
-    const r = resolveOutboxChat(rec({ chatId: null, anchorContent: '<task-id>T1</task-id>' }) as any, {
+  it('routes an envelope-less record via the transitive registry chain (preferred over origin)', () => {
+    const r = resolveOutboxChat({ chatId: null, threadId: null, anchorContent: '<task-id>T1</task-id>', originChatId: 'WRONG', originThreadId: null }, {
       registryChainLookup: (c) => (c.includes('T1') ? { chatId: '222', threadId: 9 } : null),
-      lastInboundChat: () => ({ chatId: 'WRONG', threadId: null }),
     })
     expect(r).toEqual({ chatId: '222', threadId: 9, via: 'registry' })
   })
-  it('falls back to last-inbound when the chain does not resolve', () => {
-    const r = resolveOutboxChat(rec({ chatId: null, anchorContent: 'no-task-id-here' }) as any, {
+  it('falls back to the record OWN per-session origin when the chain does not resolve', () => {
+    const r = resolveOutboxChat({ chatId: null, threadId: null, anchorContent: 'no-task-id-here', originChatId: '333', originThreadId: 4 }, {
       registryChainLookup: () => null,
-      lastInboundChat: () => ({ chatId: '333', threadId: null }),
     })
-    expect(r).toEqual({ chatId: '333', threadId: null, via: 'last-inbound' })
+    expect(r).toEqual({ chatId: '333', threadId: 4, via: 'origin' })
   })
-  it('returns null when nothing resolves', () => {
-    expect(resolveOutboxChat(rec({ chatId: null }) as any, {})).toBeNull()
+  it('FAILS CLOSED (null) when neither the chain nor a stamped origin resolves — never a global fallback', () => {
+    expect(resolveOutboxChat({ chatId: null, threadId: null, anchorContent: 'no-task', originChatId: null, originThreadId: null }, { registryChainLookup: () => null })).toBeNull()
   })
 })
 
@@ -146,16 +148,36 @@ describe('sweepOutbox — end to end (exactly-once, siblings, dedup)', () => {
     expect(new Set(s.sent.map((x) => x.text)).size).toBe(2)
   })
 
-  it('skips when the text was already delivered by the legacy flush (dedup)', async () => {
+  it('F1: on a text-dedup hit, journals the nonce AND deletes the record so it cannot re-fire', async () => {
+    // The legacy flush delivered this turn's text; the in-memory dedup reports a
+    // hit on the first eligible sweep. The record must be journaled + removed —
+    // NOT left pending (the pre-fix bug), which re-sent once the 60s TTL evicted.
     writeOutboxRecordAtomic(rec({ turnNonce: 'n1', text: 'dup', createdAt: 0 }), dir)
     const s = sink()
     await sweepOutbox({ ...s, textAlreadyDelivered: () => true, stateDir: dir, now: () => 10_000 })
     expect(s.sent).toHaveLength(0)
+    expect(readDeliveredNonces(dir).has('n1')).toBe(true)
+    expect(listPendingRecords(dir)).toHaveLength(0)
   })
 
-  it('routes an envelope-less record through last-inbound with a prefix', async () => {
-    writeLastInboundChat({ chatId: '888', threadId: null }, dir)
-    writeOutboxRecordAtomic(rec({ turnNonce: 'nx', chatId: null, text: 'z'.repeat(300), anchorContent: 'no-task' }), dir)
+  it('F1: NO second send after the in-memory dedup TTL evicts and the gateway restarts', async () => {
+    // Simulate the exact review failure: flush delivers (+0.5s), sweep at +5s
+    // hits the dedup and settles the record. Then the process "restarts" (fresh
+    // deps, in-memory dedup CLEARED → reports false) and the sweep runs again at
+    // +65s. With the pre-fix code the record was still pending and re-sent here.
+    writeOutboxRecordAtomic(rec({ turnNonce: 'n1', text: 'dup', createdAt: 0 }), dir)
+    const s1 = sink()
+    await sweepOutbox({ ...s1, textAlreadyDelivered: () => true, stateDir: dir, now: () => 5_000 })
+    expect(s1.sent).toHaveLength(0)
+    // Restart: brand-new sink + a dedup that no longer remembers the text.
+    const s2 = sink()
+    await sweepOutbox({ ...s2, textAlreadyDelivered: () => false, stateDir: dir, now: () => 65_000 })
+    expect(s2.sent).toHaveLength(0) // journal (durable) suppresses — no double-post
+    expect(listPendingRecords(dir)).toHaveLength(0)
+  })
+
+  it('routes an envelope-less record through its OWN per-session origin with a prefix', async () => {
+    writeOutboxRecordAtomic({ ...rec({ turnNonce: 'nx', chatId: null, text: 'z'.repeat(300), anchorContent: 'no-task' }), originChatId: '888', originThreadId: null }, dir)
     const s = sink()
     await sweepOutbox({ ...s, textAlreadyDelivered: () => false, stateDir: dir, now: () => 10_000 })
     expect(s.sent).toHaveLength(1)
@@ -163,11 +185,43 @@ describe('sweepOutbox — end to end (exactly-once, siblings, dedup)', () => {
     expect(s.sent[0].text.startsWith('(from background task) ')).toBe(true)
   })
 
-  it('holds (does not drop) an unroutable envelope-less record for a later tick', async () => {
+  it('F2: a DM-origin handback whose registry chain fails does NOT deliver to a different (group) chat', async () => {
+    // Record stamped with the DM origin (777). A group chat (999) is the most
+    // recent gateway inbound — but the sweep has NO global last-inbound fallback,
+    // so it must route to the DM origin, never the group.
+    writeOutboxRecordAtomic({ ...rec({ turnNonce: 'dm', chatId: null, text: 'private answer '.repeat(20), anchorContent: '<task-id>MISS</task-id>' }), originChatId: '777', originThreadId: null }, dir)
+    const s = sink()
+    await sweepOutbox({
+      ...s,
+      textAlreadyDelivered: () => false,
+      registryChainLookup: () => null, // chain fails
+      stateDir: dir,
+      now: () => 10_000,
+    })
+    expect(s.sent).toHaveLength(1)
+    expect(s.sent[0].chatId).toBe('777') // DM origin, NOT any group
+  })
+
+  it('F2: an envelope-less handback with NO stamped origin and a failed chain FAILS CLOSED (held, not misrouted)', async () => {
     writeOutboxRecordAtomic(rec({ turnNonce: 'held', chatId: null, anchorContent: 'no-task' }), dir)
     const s = sink()
-    await sweepOutbox({ ...s, textAlreadyDelivered: () => false, stateDir: dir, now: () => 10_000 })
+    await sweepOutbox({ ...s, textAlreadyDelivered: () => false, registryChainLookup: () => null, stateDir: dir, now: () => 10_000 })
     expect(s.sent).toHaveLength(0)
     expect(listPendingRecords(dir)).toContain('held.json')
+  })
+
+  it('S5: the delivered-keys journal is compacted once it exceeds the rotate threshold (bounded growth)', () => {
+    for (let i = 0; i < JOURNAL_ROTATE_AT + 5; i++) {
+      appendDelivered({ turnNonce: `k${i}`, textSha256: 'h', ts: i }, dir)
+    }
+    const lines = readFileSync(join(resolveOutboxDir(dir), 'delivered.jsonl'), 'utf8')
+      .split('\n')
+      .filter((l) => l.length > 0)
+    // Bounded: compaction keeps the file under the rotate threshold rather than
+    // growing without limit (it drops to ~JOURNAL_KEEP each time it trips).
+    expect(lines.length).toBeLessThanOrEqual(JOURNAL_ROTATE_AT)
+    expect(lines.length).toBeLessThan(JOURNAL_KEEP + 100)
+    // The most-recent nonces survive compaction (still suppress a re-send).
+    expect(readDeliveredNonces(dir).has(`k${JOURNAL_ROTATE_AT + 4}`)).toBe(true)
   })
 })

--- a/telegram-plugin/tests/outbox-delivery.test.ts
+++ b/telegram-plugin/tests/outbox-delivery.test.ts
@@ -1,0 +1,173 @@
+/**
+ * outbox-delivery.test.ts — the delivery half of guaranteed final-message
+ * delivery. Exercises the pure sweep decision (`decideOutboxSweep`), routing
+ * (`resolveOutboxChat`, H3), the shared-nonce parity between the .mjs hook and
+ * the .ts gateway, and an end-to-end `sweepOutbox` run against injected IO deps
+ * on a real temp state dir: exactly-once (H1), concurrent siblings → two
+ * distinct deliveries, text-dedup skip, and delivered-journal suppression.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  decideOutboxSweep,
+  deriveTurnNonce,
+  resolveOutboxChat,
+  writeOutboxRecordAtomic,
+  readDeliveredNonces,
+  listPendingRecords,
+  writeLastInboundChat,
+  sha256Hex,
+  type OutboxRecord,
+  OUTBOX_MAX_AGE_MS,
+} from '../outbox.js'
+import { deriveTurnNonce as deriveTurnNonceMjs } from '../hooks/silent-end-scan.mjs'
+import { sweepOutbox } from '../gateway/outbox-sweep.js'
+
+function rec(over: Partial<OutboxRecord>): OutboxRecord {
+  const text = over.text ?? 'x'.repeat(300)
+  return {
+    turnNonce: over.turnNonce ?? 'n1',
+    chatId: 'chatId' in over ? (over.chatId ?? null) : '111',
+    threadId: over.threadId ?? null,
+    text,
+    textSha256: over.textSha256 ?? sha256Hex(text),
+    createdAt: over.createdAt ?? 0,
+    source: over.source ?? 'channel',
+    anchorContent: over.anchorContent,
+  }
+}
+
+describe('deriveTurnNonce — .mjs / .ts parity (shared namespace, H1)', () => {
+  it('produces byte-identical nonces for the message_id shape', () => {
+    const args = { chatId: '111', threadId: 7, messageId: '42', anchorTimestampMs: 5, anchorContent: 'c' }
+    expect(deriveTurnNonceMjs(args)).toBe(deriveTurnNonce(args))
+  })
+  it('produces byte-identical nonces for the content-hash shape', () => {
+    const args = { chatId: null, threadId: null, messageId: null, anchorTimestampMs: 5, anchorContent: 'c' }
+    expect(deriveTurnNonceMjs(args)).toBe(deriveTurnNonce(args))
+  })
+})
+
+describe('decideOutboxSweep', () => {
+  const base = { deliveredNonces: new Set<string>(), textAlreadyDelivered: false, routable: true }
+  it('sends a routable, un-journaled, past-quiet record', () => {
+    expect(decideOutboxSweep({ record: rec({}), now: 10_000, ...base }).action).toBe('send')
+  })
+  it('skips a nonce already in the journal (exactly-once)', () => {
+    expect(
+      decideOutboxSweep({ record: rec({ turnNonce: 'd' }), now: 10_000, ...base, deliveredNonces: new Set(['d']) }).action,
+    ).toBe('skip-journaled')
+  })
+  it('skips inside the quiet period', () => {
+    expect(decideOutboxSweep({ record: rec({ createdAt: 9999 }), now: 10_000, ...base }).action).toBe('skip-quiet')
+  })
+  it('skips on text-dedup', () => {
+    expect(decideOutboxSweep({ record: rec({}), now: 10_000, ...base, textAlreadyDelivered: true }).action).toBe(
+      'skip-dedup',
+    )
+  })
+  it('holds an unroutable record rather than dropping', () => {
+    expect(decideOutboxSweep({ record: rec({}), now: 10_000, ...base, routable: false }).action).toBe('skip-unroutable')
+  })
+  it('delivers a beyond-max-age record with a (delayed) prefix, never drops', () => {
+    const d = decideOutboxSweep({ record: rec({ text: 'answer' }), now: OUTBOX_MAX_AGE_MS + 10_000, ...base })
+    expect(d.action).toBe('send-delayed')
+    expect(d.text).toBe('(delayed) answer')
+  })
+})
+
+describe('resolveOutboxChat (H3)', () => {
+  it('routes via the anchor envelope when chatId is present', () => {
+    const r = resolveOutboxChat(rec({ chatId: '111', threadId: 5 }), {})
+    expect(r).toEqual({ chatId: '111', threadId: 5, via: 'anchor' })
+  })
+  it('routes an envelope-less record via the transitive registry chain', () => {
+    const r = resolveOutboxChat(rec({ chatId: null, anchorContent: '<task-id>T1</task-id>' }) as any, {
+      registryChainLookup: (c) => (c.includes('T1') ? { chatId: '222', threadId: 9 } : null),
+      lastInboundChat: () => ({ chatId: 'WRONG', threadId: null }),
+    })
+    expect(r).toEqual({ chatId: '222', threadId: 9, via: 'registry' })
+  })
+  it('falls back to last-inbound when the chain does not resolve', () => {
+    const r = resolveOutboxChat(rec({ chatId: null, anchorContent: 'no-task-id-here' }) as any, {
+      registryChainLookup: () => null,
+      lastInboundChat: () => ({ chatId: '333', threadId: null }),
+    })
+    expect(r).toEqual({ chatId: '333', threadId: null, via: 'last-inbound' })
+  })
+  it('returns null when nothing resolves', () => {
+    expect(resolveOutboxChat(rec({ chatId: null }) as any, {})).toBeNull()
+  })
+})
+
+describe('sweepOutbox — end to end (exactly-once, siblings, dedup)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'outbox-'))
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  function sink() {
+    const sent: Array<{ chatId: string; threadId: number | null; text: string }> = []
+    return {
+      sent,
+      send: async (chatId: string, threadId: number | null, text: string) => {
+        sent.push({ chatId, threadId, text })
+        return sent.length
+      },
+    }
+  }
+
+  it('delivers a record exactly once across repeated sweeps (H1)', async () => {
+    writeOutboxRecordAtomic(rec({ turnNonce: 'n1', createdAt: 0 }), dir)
+    const s = sink()
+    const deps = { ...s, textAlreadyDelivered: () => false, stateDir: dir, now: () => 10_000 }
+    await sweepOutbox(deps)
+    await sweepOutbox(deps) // journal now suppresses
+    await sweepOutbox(deps)
+    expect(s.sent).toHaveLength(1)
+    expect(readDeliveredNonces(dir).has('n1')).toBe(true)
+    expect(listPendingRecords(dir)).toHaveLength(0)
+  })
+
+  it('two concurrent sibling handbacks with distinct nonces both deliver, no clobber', async () => {
+    // Same content, distinct enqueue timestamps → distinct nonces (H2).
+    const n1 = deriveTurnNonce({ chatId: null, threadId: null, messageId: null, anchorTimestampMs: 1000, anchorContent: 'sib' })
+    const n2 = deriveTurnNonce({ chatId: null, threadId: null, messageId: null, anchorTimestampMs: 2000, anchorContent: 'sib' })
+    expect(n1).not.toBe(n2)
+    writeOutboxRecordAtomic(rec({ turnNonce: n1, chatId: '111', text: 'answer one xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' }), dir)
+    writeOutboxRecordAtomic(rec({ turnNonce: n2, chatId: '111', text: 'answer two yyyyyyyyyyyyyyyyyyyyyyyyyyyyyy' }), dir)
+    const s = sink()
+    await sweepOutbox({ ...s, textAlreadyDelivered: () => false, stateDir: dir, now: () => 10_000 })
+    expect(s.sent).toHaveLength(2)
+    expect(new Set(s.sent.map((x) => x.text)).size).toBe(2)
+  })
+
+  it('skips when the text was already delivered by the legacy flush (dedup)', async () => {
+    writeOutboxRecordAtomic(rec({ turnNonce: 'n1', text: 'dup', createdAt: 0 }), dir)
+    const s = sink()
+    await sweepOutbox({ ...s, textAlreadyDelivered: () => true, stateDir: dir, now: () => 10_000 })
+    expect(s.sent).toHaveLength(0)
+  })
+
+  it('routes an envelope-less record through last-inbound with a prefix', async () => {
+    writeLastInboundChat({ chatId: '888', threadId: null }, dir)
+    writeOutboxRecordAtomic(rec({ turnNonce: 'nx', chatId: null, text: 'z'.repeat(300), anchorContent: 'no-task' }), dir)
+    const s = sink()
+    await sweepOutbox({ ...s, textAlreadyDelivered: () => false, stateDir: dir, now: () => 10_000 })
+    expect(s.sent).toHaveLength(1)
+    expect(s.sent[0].chatId).toBe('888')
+    expect(s.sent[0].text.startsWith('(from background task) ')).toBe(true)
+  })
+
+  it('holds (does not drop) an unroutable envelope-less record for a later tick', async () => {
+    writeOutboxRecordAtomic(rec({ turnNonce: 'held', chatId: null, anchorContent: 'no-task' }), dir)
+    const s = sink()
+    await sweepOutbox({ ...s, textAlreadyDelivered: () => false, stateDir: dir, now: () => 10_000 })
+    expect(s.sent).toHaveLength(0)
+    expect(listPendingRecords(dir)).toContain('held.json')
+  })
+})

--- a/telegram-plugin/tests/outbox-hook-capture.test.ts
+++ b/telegram-plugin/tests/outbox-hook-capture.test.ts
@@ -1,0 +1,95 @@
+/**
+ * outbox-hook-capture.test.ts — behavioural RED replay of the 2026-07-22
+ * incident at the real Stop-hook boundary. Spawns
+ * `hooks/silent-end-interrupt-stop.mjs` as a subprocess with a synthetic
+ * task-notification-shaped transcript that ends with a 1,647-char plain-text
+ * final answer and no reply tool call — the exact shape whose answer was
+ * silently lost — and asserts the hook writes exactly one durable outbox record
+ * to `$TELEGRAM_STATE_DIR/outbox/` and allows the stop.
+ *
+ * Against pre-fix code the hook wrote NO outbox record (the mechanism did not
+ * exist) → this test's record-count assertion fails RED. Post-fix → green.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const HOOK = resolve(__dirname, '..', 'hooks', 'silent-end-interrupt-stop.mjs')
+
+function runHook(event: object, stateDir: string) {
+  return spawnSync('node', [HOOK], {
+    input: JSON.stringify(event),
+    encoding: 'utf8',
+    timeout: 5000,
+    env: { ...process.env, TELEGRAM_STATE_DIR: stateDir },
+  })
+}
+
+function transcript(dir: string, lines: object[]): string {
+  const p = join(dir, 'transcript.jsonl')
+  writeFileSync(p, lines.map((l) => JSON.stringify(l)).join('\n'), 'utf8')
+  return p
+}
+
+function outboxRecords(dir: string): object[] {
+  const outbox = join(dir, 'outbox')
+  let files: string[]
+  try {
+    files = readdirSync(outbox).filter((f) => f.endsWith('.json'))
+  } catch {
+    return []
+  }
+  return files.map((f) => JSON.parse(readFileSync(join(outbox, f), 'utf8')))
+}
+
+describe('Stop hook — outbox capture (incident replay)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'hook-outbox-'))
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  const answer = 'B'.repeat(1647)
+
+  it('captures the lost final answer of a task-notification turn to exactly one record', () => {
+    const t = transcript(dir, [
+      {
+        type: 'queue-operation',
+        operation: 'enqueue',
+        content: '<task-notification><task-id>a7cc7a0fa8f</task-id> worker done</task-notification>',
+        timestamp: 1000,
+      },
+      { type: 'assistant', message: { content: [{ type: 'text', text: answer }] } },
+    ])
+    const r = runHook({ session_id: 's', transcript_path: t }, dir)
+    expect(r.status).toBe(0)
+    const records = outboxRecords(dir) as Array<{ text: string; chatId: string | null; source: string }>
+    expect(records).toHaveLength(1)
+    expect(records[0].text).toBe(answer)
+    expect(records[0].chatId).toBeNull()
+    expect(records[0].source).toBe('task-notification')
+  })
+
+  it('writes NO record for a pure NO_REPLY turn', () => {
+    const t = transcript(dir, [
+      { type: 'queue-operation', operation: 'enqueue', content: '<channel source="telegram" chat_id="1" message_id="2">hi</channel>' },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'NO_REPLY' }] } },
+    ])
+    const r = runHook({ session_id: 's', transcript_path: t }, dir)
+    expect(r.status).toBe(0)
+    expect(outboxRecords(dir)).toHaveLength(0)
+  })
+
+  it('capture is idempotent — a second hook run does not write a duplicate', () => {
+    const t = transcript(dir, [
+      { type: 'queue-operation', operation: 'enqueue', content: '<channel source="telegram" chat_id="9" message_id="3">q</channel>', timestamp: 1000 },
+      { type: 'assistant', message: { content: [{ type: 'text', text: answer }] } },
+    ])
+    runHook({ session_id: 's', transcript_path: t }, dir)
+    runHook({ session_id: 's', transcript_path: t }, dir)
+    expect(outboxRecords(dir)).toHaveLength(1)
+  })
+})

--- a/telegram-plugin/tests/outbox-hook-capture.test.ts
+++ b/telegram-plugin/tests/outbox-hook-capture.test.ts
@@ -19,12 +19,12 @@ import { join, resolve } from 'node:path'
 
 const HOOK = resolve(__dirname, '..', 'hooks', 'silent-end-interrupt-stop.mjs')
 
-function runHook(event: object, stateDir: string) {
+function runHook(event: object, stateDir: string, extraEnv: Record<string, string> = {}) {
   return spawnSync('node', [HOOK], {
     input: JSON.stringify(event),
     encoding: 'utf8',
     timeout: 5000,
-    env: { ...process.env, TELEGRAM_STATE_DIR: stateDir },
+    env: { ...process.env, TELEGRAM_STATE_DIR: stateDir, ...extraEnv },
   })
 }
 
@@ -81,6 +81,23 @@ describe('Stop hook — outbox capture (incident replay)', () => {
     const r = runHook({ session_id: 's', transcript_path: t }, dir)
     expect(r.status).toBe(0)
     expect(outboxRecords(dir)).toHaveLength(0)
+  })
+
+  it('kill-switch symmetry: SWITCHROOM_TG_OUTBOX_DELIVERY=0 disables capture too (no orphaned records)', () => {
+    // With delivery off, capture MUST also be off — otherwise the hook would
+    // write records that the (disabled) sweep never delivers = silent loss.
+    const t = transcript(dir, [
+      {
+        type: 'queue-operation',
+        operation: 'enqueue',
+        content: '<task-notification><task-id>a7cc7a0fa8f</task-id> worker done</task-notification>',
+        timestamp: 1000,
+      },
+      { type: 'assistant', message: { content: [{ type: 'text', text: answer }] } },
+    ])
+    const r = runHook({ session_id: 's', transcript_path: t }, dir, { SWITCHROOM_TG_OUTBOX_DELIVERY: '0' })
+    expect(r.status).toBe(0)
+    expect(outboxRecords(dir)).toHaveLength(0) // no capture ⇒ no orphaned record
   })
 
   it('capture is idempotent — a second hook run does not write a duplicate', () => {

--- a/telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts
+++ b/telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts
@@ -24,11 +24,28 @@ import {
   mkdirSync,
   writeFileSync,
   readFileSync,
+  readdirSync,
   existsSync,
   rmSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+
+/**
+ * Read the single outbox record the guaranteed-delivery capture writes for a
+ * turn that ended with substantive undelivered prose. Returns null when none.
+ */
+function readOutboxRecord(stateDir: string): { text: string; chatId: string | null; turnNonce: string } | null {
+  const dir = join(stateDir, 'outbox')
+  let files: string[]
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith('.json') && f !== 'delivered.jsonl')
+  } catch {
+    return null
+  }
+  if (files.length !== 1) return null
+  return JSON.parse(readFileSync(join(dir, files[0]), 'utf8'))
+}
 
 const HOOK_PATH = resolve(
   __dirname,
@@ -108,7 +125,12 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
     expect(existsSync(join(stateDir, 'silent-end-pending.json'))).toBe(false)
   })
 
-  it("blocks + writes retryCount=1 when transcript shows ack-only (Ken's repro)", () => {
+  it('captures the trailing answer to the outbox + allows when transcript shows ack-only + undelivered verdict (Ken\'s repro, collapsed design)', () => {
+    // Collapsed guaranteed-delivery design: an ack followed by a substantive
+    // plain-text verdict is now CAPTURED to the durable outbox and the stop is
+    // ALLOWED — the gateway sweep is the single deterministic deliverer. The old
+    // block/re-prompt (which depended on the model re-replying) is superseded
+    // for capturable prose.
     const transcript = writeTranscript(tmp, [
       ENQUEUE,
       reply('on it — checking now', { disable_notification: true }),
@@ -124,23 +146,12 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
       stateDir,
     })
     expect(r.status).toBe(0)
-    const out = JSON.parse(r.stdout)
-    expect(out.decision).toBe('block')
-    expect(out.reason).toMatch(/Send your final answer/)
-    expect(out.reason).toMatch(/NO_REPLY/)
-    // Retry-count file was written.
-    const statePath = join(stateDir, 'silent-end-pending.json')
-    expect(existsSync(statePath)).toBe(true)
-    const state = JSON.parse(readFileSync(statePath, 'utf8'))
-    expect(state.retryCount).toBe(1)
-    // Reviewer-flagged regression: the hook's state-file write MUST
-    // include turnKey + chatId derived from the enqueue envelope. Without
-    // these, the gateway's later `recordSilentTurnEnd` write (~175ms after
-    // the hook) sees a turnKey mismatch and resets retryCount to 0,
-    // doubling the effective re-prompt budget. The shape here must match
-    // `chatKey(chatId, threadId)` at telegram-plugin/gateway/chat-key.ts:46.
-    expect(state.chatId).toBe('111')
-    expect(state.turnKey).toBe('111:_')
+    expect(r.stdout.trim()).toBe('') // ALLOW — no block re-prompt
+    const rec = readOutboxRecord(stateDir)
+    expect(rec).not.toBeNull()
+    expect(rec!.text).toBe('A'.repeat(2237))
+    expect(rec!.chatId).toBe('111')
+    expect(rec!.turnNonce).toBe('111:_#42') // shared deriveTurnId nonce (H1)
   })
 
   it('preserves retryCount across the hook→gateway write order (reviewer regression)', () => {
@@ -190,17 +201,12 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
     expect(state.retryCount).toBe(SILENT_END_MAX_RETRIES)
   })
 
-  it('blocks + writes retryCount=1 when an early qualifying reply is followed by an undelivered verdict (trailing-content bug repro)', () => {
-    // Confirmed-incident shape: (1) a background-task notification
-    // arrives, (2) the agent calls reply ONCE early with a stale,
-    // notification-bearing ack ("running now" — disable_notification
-    // unset, so it satisfies isFinalAnswerReply regardless of length),
-    // (3) the agent then does more work and writes a large substantive
-    // verdict as plain assistant text with NO second reply call. Pre-fix,
-    // the hook's "reply called at least once this turn" check allowed
-    // this to slip through silently — the trailing verdict never reached
-    // the user. Post-fix the hook must block on this shape exactly like
-    // the zero-reply case.
+  it('captures the trailing verdict to the outbox + allows when an early qualifying reply is followed by an undelivered verdict (trailing-content bug repro, collapsed design)', () => {
+    // Confirmed-incident shape: (1) a background-task notification arrives,
+    // (2) the agent calls reply ONCE early with a notification-bearing ack,
+    // (3) it then writes a large substantive verdict as plain assistant text
+    // with NO second reply call. The trailing verdict is now CAPTURED to the
+    // outbox and the stop is ALLOWED — the sweep delivers it deterministically.
     const transcript = writeTranscript(tmp, [
       ENQUEUE,
       reply('running now'),
@@ -216,15 +222,11 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
       stateDir,
     })
     expect(r.status).toBe(0)
-    const out = JSON.parse(r.stdout)
-    expect(out.decision).toBe('block')
-    expect(out.reason).toMatch(/Send your final answer/)
-    const statePath = join(stateDir, 'silent-end-pending.json')
-    expect(existsSync(statePath)).toBe(true)
-    const state = JSON.parse(readFileSync(statePath, 'utf8'))
-    expect(state.retryCount).toBe(1)
-    expect(state.chatId).toBe('111')
-    expect(state.turnKey).toBe('111:_')
+    expect(r.stdout.trim()).toBe('')
+    const rec = readOutboxRecord(stateDir)
+    expect(rec).not.toBeNull()
+    expect(rec!.text).toBe('Here is the actual verdict: ' + 'X'.repeat(300))
+    expect(rec!.turnNonce).toBe('111:_#42')
   })
 
   it('does NOT false-positive on a normal single-reply turn ending on the reply tool_use', () => {
@@ -303,10 +305,10 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
       writeFileSync(join(stateDir, 'gateway-heartbeat'), String(Date.now()), 'utf8')
     }
 
-    it('zero-reply ≥200 + FRESH gateway heartbeat → ALLOW (no block re-prompt), state file still written for the flush', () => {
-      // The duplicate repro: today this BLOCKS *and* the gateway flush fires →
-      // two messages. With a fresh heartbeat the election ALLOWS the stop so
-      // the gateway flush is the single writer.
+    it('zero-reply ≥200 + FRESH gateway heartbeat → CAPTURE + ALLOW (sweep is the single writer)', () => {
+      // Collapsed design: the duplicate repro is killed structurally — the
+      // trailing prose is captured to the outbox and the stop is allowed. The
+      // sweep is the single deterministic deliverer; no election, no re-prompt.
       writeFreshHeartbeat()
       const transcript = writeTranscript(tmp, [
         ENQUEUE,
@@ -314,35 +316,31 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
       ])
       const r = runHook({ event: { session_id: 's1', transcript_path: transcript }, stateDir })
       expect(r.status).toBe(0)
-      // ALLOW → no block JSON on stdout.
+      expect(r.stdout.trim()).toBe('') // ALLOW
+      const rec = readOutboxRecord(stateDir)
+      expect(rec).not.toBeNull()
+      expect(rec!.text).toBe('A'.repeat(300))
+      expect(rec!.turnNonce).toBe('111:_#42')
+    })
+
+    it('zero-reply ≥200 + STALE/missing heartbeat → STILL CAPTURE + ALLOW (record persists on disk; swept at next boot — strictly better than block-and-hope)', () => {
+      // Capture no longer depends on gateway liveness: even into a possibly-dead
+      // gateway the answer is durably captured and swept whenever the gateway is
+      // next alive — strictly stronger than the old block-and-hope re-prompt.
+      const transcript = writeTranscript(tmp, [
+        ENQUEUE,
+        { type: 'assistant', message: { content: [{ type: 'text', text: 'A'.repeat(300) }] } },
+      ])
+      const r = runHook({ event: { session_id: 's1', transcript_path: transcript }, stateDir })
+      expect(r.status).toBe(0)
       expect(r.stdout.trim()).toBe('')
-      expect(r.stderr).toMatch(/single-writer election ALLOWED/)
-      // State file IS written so the gateway's captured-prose bridge has its
-      // input (turnKey/turnId/pendingText); retryCount stays 0 (not a re-prompt).
-      const statePath = join(stateDir, 'silent-end-pending.json')
-      expect(existsSync(statePath)).toBe(true)
-      const state = JSON.parse(readFileSync(statePath, 'utf8'))
-      expect(state.retryCount).toBe(0)
-      expect(state.turnKey).toBe('111:_')
-      expect(state.pendingText).toBe('A'.repeat(300))
+      expect(readOutboxRecord(stateDir)!.text).toBe('A'.repeat(300))
     })
 
-    it('zero-reply ≥200 + STALE/missing heartbeat → BLOCK (never allow into a possibly-dead gateway)', () => {
-      // No heartbeat file → the liveness gate forces today's BLOCK behaviour.
-      const transcript = writeTranscript(tmp, [
-        ENQUEUE,
-        { type: 'assistant', message: { content: [{ type: 'text', text: 'A'.repeat(300) }] } },
-      ])
-      const r = runHook({ event: { session_id: 's1', transcript_path: transcript }, stateDir })
-      expect(r.status).toBe(0)
-      expect(JSON.parse(r.stdout).decision).toBe('block')
-      const state = JSON.parse(readFileSync(join(stateDir, 'silent-end-pending.json'), 'utf8'))
-      expect(state.retryCount).toBe(1)
-    })
-
-    it('retryCount>0 (prior failed delivery) + fresh heartbeat → BLOCK (preserve #3228 send-failure net)', () => {
+    it('retryCount>0 (prior state) + capturable prose → CAPTURE + ALLOW (nonce-scoped; the outbox journal handles redelivery, not the chat-global counter)', () => {
       writeFreshHeartbeat()
-      // Seed a prior state file with retryCount=1 (a delivery already failed).
+      // A stale chat-global silent-end record must NOT poison the capture of a
+      // genuine trailing answer (Defect B fix — retry state no longer gates it).
       writeFileSync(
         join(stateDir, 'silent-end-pending.json'),
         JSON.stringify({ chatId: '111', threadId: null, turnKey: '111:_', retryCount: 1, timestamp: Date.now() }),
@@ -354,9 +352,8 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
       ])
       const r = runHook({ event: { session_id: 's1', transcript_path: transcript }, stateDir })
       expect(r.status).toBe(0)
-      // retryCount was 1 → not the exhaustion boundary (MAX=2) → still blocks,
-      // and the election does NOT allow (retry-ladder-in-flight).
-      expect(JSON.parse(r.stdout).decision).toBe('block')
+      expect(r.stdout.trim()).toBe('')
+      expect(readOutboxRecord(stateDir)!.text).toBe('A'.repeat(300))
     })
   })
 })

--- a/telegram-plugin/tests/silent-end.test.ts
+++ b/telegram-plugin/tests/silent-end.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, readFileSync, existsSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+import { mkdtempSync, readFileSync, readdirSync, existsSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { execFileSync } from 'node:child_process'
@@ -570,7 +570,7 @@ describe('silent-end-interrupt-stop hook — integration (#1775: transcript-scan
     expect(r.stdout.trim()).toBe('')
   })
 
-  it('blocks the stop when transcript shows ack-only (no final reply) — Ken-2026-05-25 repro', () => {
+  it('captures the trailing answer to the outbox + allows on ack-only (no final reply) — Ken-2026-05-25 repro, collapsed design', () => {
     const transcript = writeTranscript([
       ENQUEUE,
       replyToolUse('on it — checking now', { disable_notification: true }),
@@ -579,14 +579,14 @@ describe('silent-end-interrupt-stop hook — integration (#1775: transcript-scan
     ])
     const r = runHook({ session_id: 's', transcript_path: transcript, hook_event_name: 'Stop' })
     expect(r.exit).toBe(0)
-    const out = JSON.parse(r.stdout.trim())
-    expect(out.decision).toBe('block')
-    expect(out.reason).toContain('reply')
-    // #1664 — the re-prompt must offer the NO_REPLY escape hatch.
-    expect(out.reason).toContain('NO_REPLY')
-    // retryCount incremented to 1 (the budget bookkeeping still
-    // uses the state file).
-    expect(readSilentEndState()!.retryCount).toBe(1)
+    // Collapsed design: the substantive trailing answer is CAPTURED to the
+    // outbox and the stop is ALLOWED (the sweep is the single deliverer).
+    expect(r.stdout.trim()).toBe('')
+    const recs = readdirSync(join(stateDir, 'outbox')).filter((f) => f.endsWith('.json') && f !== 'delivered.jsonl')
+    expect(recs).toHaveLength(1)
+    const rec = JSON.parse(readFileSync(join(stateDir, 'outbox', recs[0]), 'utf8'))
+    expect(rec.text).toBe('A'.repeat(2237))
+    expect(rec.chatId).toBe('c')
   })
 
   it('allows the stop when retryCount >= MAX_RETRIES, even if transcript still shows no reply', () => {
@@ -694,10 +694,12 @@ describe('silent-end-interrupt-stop hook — integration (#1775: transcript-scan
   describe('captured-prose delivery bridge (#3227)', () => {
     const ANSWER = 'That was actually your FY25 NOA, not Bloomfield. ' + 'A'.repeat(2200)
 
-    it('FIRST silent-end with a genuine plain-text answer → hook persists pendingText and decide → deliver', () => {
+    it('FIRST silent-end with a genuine plain-text answer → hook captures it to the outbox + allows (collapsed design supersedes the pendingText bridge)', () => {
       // A turn that ended with a substantive answer written as plain text
-      // (never sent via the reply tool). The Stop hook scans, blocks, and now
-      // persists the answer prose into silent-end-pending.json.
+      // (never sent via the reply tool). Under the collapsed guaranteed-delivery
+      // design the Stop hook captures the answer to the durable outbox and
+      // allows the stop — the sweep delivers it. This supersedes the legacy
+      // silent-end-pending.json pendingText bridge for capturable prose.
       const transcript = writeTranscript([
         ENQUEUE,
         replyToolUse('on it — checking now', { disable_notification: true }),
@@ -706,21 +708,12 @@ describe('silent-end-interrupt-stop hook — integration (#1775: transcript-scan
       ])
       const r = runHook({ session_id: 's', transcript_path: transcript, hook_event_name: 'Stop' })
       expect(r.exit).toBe(0)
-      expect(JSON.parse(r.stdout.trim()).decision).toBe('block')
-
-      // The bridge: the hook wrote the answer prose into the state file...
-      const state = readSilentEndState()!
-      expect(state.pendingText).toBe(ANSWER)
-      expect(state.turnKey).toBe('c:_')
-
-      // ...and the gateway's pure decision core reads it back and decides to
-      // deliver directly on this FIRST silent-end (retryCount just went to 1).
-      const decision = decideCapturedProseDelivery({ turnKey: 'c:_' })
-      expect(decision.deliver).toBe(true)
-      expect(decision.text).toBe(ANSWER)
-      expect(decision.reason).toBe('captured-prose')
-      // FIRST silent-end: this is the retry-budget's first block, not exhaustion.
-      expect(state.retryCount).toBe(1)
+      expect(r.stdout.trim()).toBe('') // ALLOW
+      const recs = readdirSync(join(stateDir, 'outbox')).filter((f) => f.endsWith('.json') && f !== 'delivered.jsonl')
+      expect(recs).toHaveLength(1)
+      const rec = JSON.parse(readFileSync(join(stateDir, 'outbox', recs[0]), 'utf8'))
+      expect(rec.text).toBe(ANSWER)
+      expect(rec.chatId).toBe('c')
     })
 
     it('a turn that DID call a final reply → no state, no pendingText, decide → no synthetic send', () => {


### PR DESCRIPTION
## Held for consolidated release — do NOT merge yet
Ship together with **PR #3500** per Ken's ship-together rule.

## Problem
The runtime's guaranteed-delivery backstop is blind to whole turn **classes**. Every content-delivering machine is anchored on a gateway `CurrentTurn` created at enqueue of a Telegram inbound — but `<task-notification>` sub-agent handbacks / background-worker completions never wake the gateway. On 2026-07-22 a background handback turn ended with a 1,647-char plain-text final answer (no `reply` tool call): no turn-flush, no captured-prose bridge, no fallback fired, and a **chat-global** retry budget poisoned by earlier silent turns converted the Stop-hook block into a silent allow. The answer was lost with zero delivery-machine log output.

## Design (collapsed single-path, agreed + adversarially reviewed)
- **Stop hook = pure capturer.** `scanForOutboxCapture` runs on every main-session turn end, **class-agnostically**, keyed on "a turn ended with substantive unsent trailing prose" — not on recognising the wake shape. On capture it atomically writes a durable per-turn outbox record and **always allows** the stop. The model calling `reply` is no longer required. The legacy re-prompt/election survives only as the fall-through for un-capturable (tool-calls-only / transcript-flush-race) turns.
- **Gateway heartbeat sweep = the single deliverer.** On the existing tick, independent of turn lifecycle: rename-mutex claim, exactly-once via a shared `turnNonce` delivered-keys journal + the existing text `outboundDedup`, crash-safe reclaim, `(delayed)` prefix past max-age instead of dropping. Kill switch `SWITCHROOM_TG_OUTBOX_DELIVERY=0`.

## Adversarial holes fixed
- **H1 double-post** — sweep is sole deliverer for gateway-blind classes (structural); quiet-period + text-dedup for the gateway-visible overlap; the hook never re-prompts a reworded duplicate.
- **H2 nonce collision** — nonce = `${chatKey}#${messageId}` when present, else `sha256(anchorTimestampMs + '\n' + content)`; the ms timestamp defeats same-content re-notifications and concurrent siblings.
- **H3 chained dispatch routing** — transitive registry-chain lookup (`resolveSubagentOriginTurnKey`) then per-session last-real-inbound fallback.
- **H4 unknown anchor** — fails CLOSED: anchor-less transcript tail still captures.
- **H5 cron** — guaranteed-delivered (no silent carve-out); only NO_REPLY stays silent.
- **H6 prose + trailing NO_REPLY** — captures the real answer; pure NO_REPLY writes no record.

## Tests (RED-then-green)
New: `outbox-capture-scan` (35), `outbox-delivery` (17), `outbox-hook-capture` (3). The incident replay in `outbox-hook-capture` FAILS RED with the hook/scan changes stashed (0 records) and passes restored. 7 pre-existing silent-end tests updated from the superseded block/re-prompt contract to the stronger capture-and-allow contract. Full `npm run lint` (tsc + all guards incl. gateway line ratchet + bot-api-wrapping) green locally.

## Follow-ups (see work/final-message-delivery/implementation.md)
Legacy turn-flush kept (deduped by the sweep) rather than ripped out — the gateway line ratchet is frozen at the +50 ceiling and disabling the flush would make correctness depend on the hook never under-capturing on the transcript-flush race. Shared-nonce journal is implemented + used by the sweep; wiring the legacy send sites into it (to retire the flush behind the kill switch) + `delivered.jsonl` rotation are staged follow-ups. The LOSS guarantee is fully closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)