### PR TITLE
refactor(telegram): consolidate outbound normalize into one shared seam (#3501 pt 1)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -443,6 +443,7 @@ import { richMessage } from '../rich-send.js'
 import { decideRedeliver, decideRedeliverCapture } from './redelivery-decision.js'
 import { scrubVoice } from '../text-voice-scrub.js'
 import {
+  normalizeOutboundBody,
   sendReplyChunks,
   sendReply,
   deliverCapturedProse as deliverCapturedProseCore,
@@ -13303,34 +13304,30 @@ async function executeEditMessage(args: Record<string, unknown>): Promise<unknow
   // Single rich-markdown path (#2669): `format:'text'` edits as a literal
   // plain string; everything else edits via the rich-markdown path.
   const editLiteralText = editFormat === 'text'
-  // Match the reply path: repair JSON-escape bungles, then promote lone prose
-  // paragraph breaks for the rich path. A literal-text edit (`format:'text'`)
-  // skips paragraph normalization — it must edit byte-for-byte as given.
-  let editRawText = repairEscapedWhitespace(args.text as string)
-  if (!editLiteralText) editRawText = normalizeParagraphBreaks(editRawText)
-  // Outbound secret scrub (#2044): an edit must not re-introduce a raw
-  // secret into a live bubble or the history row. Mask before scrub/send.
-  editRawText = redactOutboundText(editRawText, 'edit_message')
-  // Fleet-wide consistent formatting (same order as the reply path: redact
-  // first so secrets are matched literally, then normalize, then spacers on
-  // the rich path only — the rich GFM renderer renders `\n\n` tight, so the
-  // idempotent U+00A0 spacer restores a visible gap without double-spacing).
-  if (!editLiteralText) editRawText = addParagraphSpacers(stripExcessBold(normalizePunctuation(editRawText)))
-  // Voice scrub (#1683): same em-dash scrub as the reply path. Edits
-  // are how silent-anchor and progress-update mutate already-sent
-  // bubbles, so without this an edit can re-introduce dashes the
-  // original send had scrubbed out.
-  {
-    const scrub = scrubVoice(editRawText)
-    if (scrub.replaced > 0) {
-      editRawText = scrub.scrubbed
-      emitRuntimeMetric({
-        kind: 'voice_scrub_applied',
-        chatKey: statusKey(String(args.chat_id ?? ''), undefined),
-        replaced: scrub.replaced,
-        site: 'edit_message',
-      })
-    }
+  // #3501: route through the single shared outbound seam instead of the former
+  // hand-mirrored inline pipeline. `normalizeOutboundBody` runs the same order
+  // as the reply path (repair → paragraph-break → redact → punctuation/bold →
+  // voice scrub); the edit path's two deviations are expressed as options:
+  //   - literalText: a `format:'text'` edit lands byte-for-byte, so it skips
+  //     paragraph normalization + punctuation/bold/spacers (only repair, the
+  //     secret redact, and the voice scrub still run).
+  //   - addSpacers: the rich edit path folds the idempotent U+00A0 paragraph
+  //     spacer INTO the formatting step (the rich GFM renderer renders `\n\n`
+  //     tight; the spacer restores a visible gap without double-spacing).
+  const _editNorm = normalizeOutboundBody(
+    args.text as string,
+    'edit_message',
+    redactOutboundText,
+    { literalText: editLiteralText, addSpacers: !editLiteralText },
+  )
+  let editRawText = _editNorm.text
+  if (_editNorm.voiceReplaced > 0) {
+    emitRuntimeMetric({
+      kind: 'voice_scrub_applied',
+      chatKey: statusKey(String(args.chat_id ?? ''), undefined),
+      replaced: _editNorm.voiceReplaced,
+      site: 'edit_message',
+    })
   }
   const edited = await robustApiCall(
     () => lockedBot.api.editMessageText(

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -114,16 +114,47 @@ export interface NormalizeOutboundResult {
 }
 
 /**
- * Stage 1 — the deterministic outbound text transform, byte-identical to the
- * inline pipeline at the entry of executeReply (and mirrored on the
- * answer-stream + turn-flush paths):
+ * Per-site shape knobs for {@link normalizeOutboundBody}. The reply path (the
+ * canonical caller) passes none — the defaults reproduce its exact pre-#3501
+ * byte output. The edit_message and turn-flush sites, which used to hand-mirror
+ * this pipeline inline, pass these to reproduce their two small deviations:
+ *
+ *   - `literalText` (edit_message `format:'text'`): a literal edit must land
+ *     byte-for-byte as authored, so it SKIPS paragraph-break promotion and the
+ *     punctuation/bold/spacer formatting entirely — only the whitespace repair,
+ *     the secret redact, and the voice scrub still run (they are safety
+ *     transforms that must apply even to literal edits, matching the former
+ *     inline `executeEditMessage` order).
+ *   - `addSpacers` (edit_message non-literal): the edit path folds the
+ *     idempotent U+00A0 paragraph spacer INTO this transform
+ *     (`addParagraphSpacers(stripExcessBold(normalizePunctuation(…)))`),
+ *     whereas the reply/turn-flush paths add spacers separately downstream (or
+ *     not at all). Setting this reproduces that inline behaviour exactly.
+ */
+export interface NormalizeOutboundOptions {
+  /** Literal edit: skip paragraph-break + punctuation/bold/spacer formatting. */
+  literalText?: boolean
+  /** Fold `addParagraphSpacers` into the formatting step (edit_message path). */
+  addSpacers?: boolean
+}
+
+/**
+ * Stage 1 — the deterministic outbound text transform. This is the SINGLE
+ * shared seam for every outbound prose send (#3501): the reply path, the
+ * edit_message path, and the turn-flush backstop all route through it instead
+ * of hand-mirroring the pipeline inline, so a new outbound transform is added
+ * in exactly one place.
  *
  *   1. repairEscapedWhitespace  — undo LLM JSON-escape bungles
  *   2. normalizeParagraphBreaks — promote lone prose breaks to GFM hard breaks
+ *                                 (skipped for a literal edit)
  *   3. redact (injected)        — outbound secret scrub (#2044), BEFORE the
  *                                 punctuation/bold normalizers so a secret with
  *                                 an em-dash or `**` is matched literally
  *   4. stripExcessBold∘normalizePunctuation — fleet-consistent formatting
+ *                                 (optionally wrapped in addParagraphSpacers for
+ *                                 the edit path; skipped entirely for a literal
+ *                                 edit)
  *   5. scrubVoice               — em/en dash → comma/period (#1683)
  *
  * The order is load-bearing and MUST NOT change (each step's comment in the
@@ -133,10 +164,17 @@ export function normalizeOutboundBody(
   rawText: string,
   site: string,
   redact: RedactFn,
+  opts: NormalizeOutboundOptions = {},
 ): NormalizeOutboundResult {
-  let text = normalizeParagraphBreaks(repairEscapedWhitespace(rawText))
+  const { literalText = false, addSpacers = false } = opts
+  let text = repairEscapedWhitespace(rawText)
+  if (!literalText) text = normalizeParagraphBreaks(text)
   text = redact(text, site)
-  text = stripExcessBold(normalizePunctuation(text))
+  if (!literalText) {
+    let formatted = stripExcessBold(normalizePunctuation(text))
+    if (addSpacers) formatted = addParagraphSpacers(formatted)
+    text = formatted
+  }
   let voiceReplaced = 0
   const scrub = scrubVoice(text)
   if (scrub.replaced > 0) {

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -55,7 +55,7 @@
 
 import { createAnswerStream } from '../answer-stream.js'
 import { LivenessTracker, isContextExhaustionText } from '../context-exhaustion.js'
-import { normalizeParagraphBreaks, normalizePunctuation, repairEscapedWhitespace, stripExcessBold } from '../format.js'
+import { normalizeOutboundBody } from './outbound-send-path.js'
 import { hasOutboundDeliveredSince, recordOutbound } from '../history.js'
 import { isReplyTool } from '../narrative-dedup.js'
 import { NarrativeFlushController } from '../narrative-flush.js'
@@ -65,7 +65,6 @@ import { richMessage } from '../rich-send.js'
 import { emitRuntimeMetric } from '../runtime-metrics.js'
 import { CAPTURED_PROSE_MIN_CHARS, clearSilentEndState, decideCapturedProseDelivery, recordUndeliveredTurnEnd, silentEndFallbackText, writeSilentEndState } from '../silent-end.js'
 import { logStreamingEvent } from '../streaming-metrics.js'
-import { scrubVoice } from '../text-voice-scrub.js'
 import { appendActivityLabel } from '../tool-activity-summary.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { decideTurnFlush } from '../turn-flush-safety.js'
@@ -1523,19 +1522,6 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
       }
 
       if (turnEndDecision === 'flush' && flushDecision.kind === 'flush') {
-        let capturedText = flushDecision.text
-        // #2798 — turn-flush delivers the model's terminal prose when it
-        // skipped reply/stream_reply, but historically bypassed the reply
-        // path's markdown normalization entirely. Mirror executeReply's front
-        // of pipeline here so the backstop renders identically: repair LLM
-        // JSON-escape bungles (literal `\n`), then promote lone prose paragraph
-        // breaks into GFM hard breaks so the Bot API 10.1 rich path doesn't
-        // collapse them (lists/tables/code left untouched). Runs BEFORE the
-        // redact/scrub below, exactly as reply orders it (repair → normalize →
-        // redact → scrub), so masking sees the repaired text. Paragraph gaps
-        // are the plain `\n\n` normalizeParagraphBreaks guarantees — no spacer
-        // pass runs on the send side any more (removed in the #2669 follow-up).
-        capturedText = normalizeParagraphBreaks(repairEscapedWhitespace(capturedText))
         // Component 3 — origin-thread backstop. `chatId`/`threadId` are
         // captured from the turn atom (turn.sessionChatId/sessionThreadId)
         // at the top of this turn_end handler, NOT from the live
@@ -1547,41 +1533,26 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
         const backstopThreadId = threadId
         const backstopCtrl = ctrl
 
-        // Outbound secret scrub (#2044). Turn-flush delivers the model's
-        // terminal answer prose when it skipped reply/stream_reply — that
-        // is arbitrary agent free-text, sent via sendMessage/editMessageText
-        // and previewed to stderr below, so it needs the same mask as the
-        // three reply tools. Mirror the voice scrub: mask before the send,
-        // the preview, and recordOutbound.
-        capturedText = redactOutboundText(capturedText, 'turn_flush')
-
-        // #2798 reply-parity — normalize dashes/bullets and trip the over-bold
-        // guard deterministically, on code-masked text. This is the SAME chain
-        // the reply path applies (`stripExcessBold(normalizePunctuation(text))`)
-        // in the SAME order: after redact, before scrubVoice. Without it the
-        // turn-flush backstop rendered punctuation/bold differently from an
-        // identical reply. Kept inline to mirror reply exactly — a shared helper
-        // is a deliberate future refactor, not this change.
-        capturedText = stripExcessBold(normalizePunctuation(capturedText))
-
-        // Voice scrub (PR #1683 follow-up). Turn-flush is the path
-        // that fires when the model emits raw transcript text WITHOUT
-        // calling reply / stream_reply. That captured text bypasses
-        // PR #1683's executeReply scrub site entirely and is delivered
-        // via the rich-message path directly. Scrub the capturedText on the
-        // raw markdown so em-dashes never reach the wire. Kill switch:
-        // SWITCHROOM_DISABLE_VOICE_SCRUB.
-        {
-          const scrub = scrubVoice(capturedText)
-          if (scrub.replaced > 0) {
-            capturedText = scrub.scrubbed
-            emitRuntimeMetric({
-              kind: 'voice_scrub_applied',
-              chatKey: statusKey(backstopChatId, backstopThreadId),
-              replaced: scrub.replaced,
-              site: 'turn_flush',
-            })
-          }
+        // #3501: route through the single shared outbound seam. Turn-flush
+        // delivers the model's terminal prose when it skipped reply/stream_reply
+        // and used to hand-mirror the reply pipeline inline (repair → paragraph-
+        // break → redact → punctuation/bold → voice scrub). `normalizeOutboundBody`
+        // IS that pipeline with the same load-bearing order — the metric side
+        // effect (voice_scrub_applied on a non-zero replacement) is emitted here
+        // by the caller, exactly as the reply/edit sites do.
+        const _flushNorm = normalizeOutboundBody(
+          flushDecision.text,
+          'turn_flush',
+          redactOutboundText,
+        )
+        let capturedText = _flushNorm.text
+        if (_flushNorm.voiceReplaced > 0) {
+          emitRuntimeMetric({
+            kind: 'voice_scrub_applied',
+            chatKey: statusKey(backstopChatId, backstopThreadId),
+            replaced: _flushNorm.voiceReplaced,
+            site: 'turn_flush',
+          })
         }
 
         // #1664 — turn-flush only fires when !replyCalled (decideTurnFlush

--- a/telegram-plugin/tests/gateway-outbound-redact.test.ts
+++ b/telegram-plugin/tests/gateway-outbound-redact.test.ts
@@ -60,22 +60,32 @@ describe('gateway outbound secret-scrub — structural wiring', () => {
     expect(previewIdx).toBeGreaterThan(redactIdx) // mask BEFORE the preview is logged
   })
 
-  it('edit_message: scrubs at entry, before the voice scrub + send', () => {
+  it('edit_message: scrubs via the shared seam at entry, before the send (#3501)', () => {
+    // #3501: edit_message routes through normalizeOutboundBody, passing the
+    // injected redactor with the 'edit_message' site. The seam runs redact
+    // internally (pinned in outbound-send-path.ts), so the mask still fires at
+    // entry — before the editMessageText send below.
     const start = src.indexOf('async function executeEditMessage(')
-    const redactIdx = src.indexOf(`redactOutboundText(editRawText, 'edit_message')`, start)
-    const scrubIdx = src.indexOf(`site: 'edit_message'`, start)
+    const seamIdx = src.indexOf(`'edit_message',`, start)
+    const redactArgIdx = src.indexOf('redactOutboundText,', seamIdx)
+    const sendIdx = src.indexOf('editMessageText(', start)
     expect(start).toBeGreaterThan(0)
-    expect(redactIdx).toBeGreaterThan(start)
-    expect(scrubIdx).toBeGreaterThan(redactIdx)
+    expect(seamIdx).toBeGreaterThan(start)
+    expect(redactArgIdx).toBeGreaterThan(seamIdx) // redactor passed into the seam
+    expect(sendIdx).toBeGreaterThan(redactArgIdx) // mask BEFORE the send
   })
 
-  it('turn-flush backstop: scrubs the model terminal prose before send', () => {
+  it('turn-flush backstop: scrubs the model terminal prose before send (#3501)', () => {
     // Turn-flush delivers the model's answer when it skipped reply/stream_reply
-    // — arbitrary agent free-text that hits the wire + stderr preview.
-    const redactIdx = streamSrc.indexOf(`redactOutboundText(capturedText, 'turn_flush')`)
-    const scrubSiteIdx = streamSrc.indexOf(`site: 'turn_flush'`)
-    expect(redactIdx).toBeGreaterThan(0)
-    expect(scrubSiteIdx).toBeGreaterThan(redactIdx) // mask BEFORE the voice scrub + send
+    // — arbitrary agent free-text that hits the wire + stderr preview. #3501:
+    // it routes through normalizeOutboundBody('turn_flush', redactOutboundText),
+    // which redacts internally before the voice-scrub + send.
+    const seamIdx = streamSrc.indexOf('normalizeOutboundBody(')
+    const siteIdx = streamSrc.indexOf(`'turn_flush',`, seamIdx)
+    const redactArgIdx = streamSrc.indexOf('redactOutboundText,', seamIdx)
+    expect(seamIdx).toBeGreaterThan(0)
+    expect(siteIdx).toBeGreaterThan(seamIdx) // seam invoked with the turn_flush site
+    expect(redactArgIdx).toBeGreaterThan(seamIdx) // redactor passed into the seam
   })
 
   it('progress_update: scrubs at entry, BEFORE the 300-char truncation', () => {

--- a/telegram-plugin/tests/outbound-send-path.test.ts
+++ b/telegram-plugin/tests/outbound-send-path.test.ts
@@ -79,6 +79,46 @@ function referenceResplit(chunk: string): string[] {
 
 const injectedRedact = (text: string, _site: string): string => redact(text)
 
+// ── Verbatim inline reference for the FORMER edit_message pipeline ──────────
+// (executeEditMessage, pre-#3501): repair → [paragraph-break if !literal] →
+// redact → [addParagraphSpacers(stripExcessBold(normalizePunctuation)) if
+// !literal] → voice scrub. Consolidated into normalizeOutboundBody's
+// {literalText, addSpacers} options; this reference pins byte-equivalence.
+function referenceEditNormalize(
+  rawText: string,
+  literalText: boolean,
+): { text: string; voiceReplaced: number } {
+  let editRawText = repairEscapedWhitespace(rawText)
+  if (!literalText) editRawText = normalizeParagraphBreaks(editRawText)
+  editRawText = redact(editRawText)
+  if (!literalText) editRawText = addParagraphSpacers(stripExcessBold(normalizePunctuation(editRawText)))
+  let voiceReplaced = 0
+  const scrub = scrubVoice(editRawText)
+  if (scrub.replaced > 0) {
+    editRawText = scrub.scrubbed
+    voiceReplaced = scrub.replaced
+  }
+  return { text: editRawText, voiceReplaced }
+}
+
+// ── Verbatim inline reference for the FORMER turn-flush pipeline ────────────
+// (stream-render.ts turn-flush branch, pre-#3501): normalizeParagraphBreaks(
+// repairEscapedWhitespace) → redact('turn_flush') → stripExcessBold(
+// normalizePunctuation) → voice scrub. This is normalizeOutboundBody's DEFAULT
+// shape — identical to the reply pipeline. Consolidated to a single call.
+function referenceTurnFlushNormalize(rawText: string): { text: string; voiceReplaced: number } {
+  let text = normalizeParagraphBreaks(repairEscapedWhitespace(rawText))
+  text = redact(text)
+  text = stripExcessBold(normalizePunctuation(text))
+  let voiceReplaced = 0
+  const scrub = scrubVoice(text)
+  if (scrub.replaced > 0) {
+    text = scrub.scrubbed
+    voiceReplaced = scrub.replaced
+  }
+  return { text, voiceReplaced }
+}
+
 // ── Representative outbound fixtures ────────────────────────────────────────
 
 const FIXTURES: Record<string, string> = {
@@ -118,6 +158,73 @@ describe('outbound-send-path — normalizeOutboundBody parity with inline pipeli
     // prose; the exact stage that fires is an implementation detail, but no
     // raw em-dash survives the pipeline.
     expect(got.text).not.toContain('—')
+  })
+})
+
+// #3501 — the edit_message and turn-flush sites were hand-mirrored inline
+// pipelines that now route through normalizeOutboundBody. These pin that the
+// {literalText, addSpacers} options reproduce the former inline output
+// byte-for-byte, so the consolidation is provably behaviour-neutral.
+describe('outbound-send-path — edit_message option parity (#3501)', () => {
+  for (const [name, raw] of Object.entries(FIXTURES)) {
+    it(`rich edit (addSpacers) byte-identical: ${name}`, () => {
+      const ref = referenceEditNormalize(raw, false)
+      const got = normalizeOutboundBody(raw, 'edit_message', injectedRedact, {
+        literalText: false,
+        addSpacers: true,
+      })
+      expect(got.text).toBe(ref.text)
+      expect(got.voiceReplaced).toBe(ref.voiceReplaced)
+    })
+
+    it(`literal edit (literalText) byte-identical: ${name}`, () => {
+      const ref = referenceEditNormalize(raw, true)
+      const got = normalizeOutboundBody(raw, 'edit_message', injectedRedact, {
+        literalText: true,
+        addSpacers: false,
+      })
+      expect(got.text).toBe(ref.text)
+      expect(got.voiceReplaced).toBe(ref.voiceReplaced)
+    })
+  }
+
+  it('literal edit skips paragraph/punctuation/bold/spacer formatting', () => {
+    // A literal edit must NOT promote lone newlines, strip bold, or add
+    // spacers — only repair + redact + voice scrub run.
+    const raw = 'First line.\nSecond line with **bold** kept.'
+    const got = normalizeOutboundBody(raw, 'edit_message', injectedRedact, {
+      literalText: true,
+    })
+    expect(got.text).toBe(raw) // no transform touched it
+  })
+
+  it('rich edit DOES add the U+00A0 paragraph spacer that reply omits', () => {
+    const raw = FIXTURES.multiParagraph
+    const richEdit = normalizeOutboundBody(raw, 'edit_message', injectedRedact, {
+      addSpacers: true,
+    }).text
+    const reply = normalizeOutboundBody(raw, 'reply', injectedRedact).text
+    // The edit path folds addParagraphSpacers in; the reply path does not.
+    expect(richEdit).toBe(addParagraphSpacers(reply))
+    expect(richEdit).not.toBe(reply)
+  })
+})
+
+describe('outbound-send-path — turn_flush option parity (#3501)', () => {
+  for (const [name, raw] of Object.entries(FIXTURES)) {
+    it(`turn-flush default byte-identical: ${name}`, () => {
+      const ref = referenceTurnFlushNormalize(raw)
+      const got = normalizeOutboundBody(raw, 'turn_flush', injectedRedact)
+      expect(got.text).toBe(ref.text)
+      expect(got.voiceReplaced).toBe(ref.voiceReplaced)
+    })
+  }
+
+  it('turn-flush default equals the reply pipeline (same shape)', () => {
+    const raw = FIXTURES.emDashes
+    const flush = normalizeOutboundBody(raw, 'turn_flush', injectedRedact).text
+    const reply = normalizeOutboundBody(raw, 'reply', injectedRedact).text
+    expect(flush).toBe(reply)
   })
 })
 

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -302,24 +302,29 @@ describe('#2798 turn-flush punctuation/bold parity with reply', () => {
     expect(scrubIdx).toBeGreaterThan(normIdx) // ...and BEFORE the voice scrub
   })
 
-  it('turn-flush backstop: applies the SAME normalization in the SAME slot (REDS if the line is removed)', () => {
-    const redactIdx = streamSrc.indexOf(`redactOutboundText(capturedText, 'turn_flush')`)
-    // The normalization call the reply path uses, verbatim, on the turn_flush
-    // variable. This indexOf is what returns -1 (→ assertion fails) if the
-    // `stripExcessBold(normalizePunctuation(capturedText))` line is deleted
-    // from the turn_flush branch.
-    const normIdx = streamSrc.indexOf('stripExcessBold(normalizePunctuation(capturedText))', redactIdx)
-    const scrubIdx = streamSrc.indexOf('scrubVoice(capturedText)', redactIdx)
-    expect(redactIdx).toBeGreaterThan(0)
-    expect(normIdx).toBeGreaterThan(redactIdx) // normalize AFTER the turn_flush redact
-    expect(scrubIdx).toBeGreaterThan(normIdx) // ...and BEFORE the voice scrub — mirrors reply
+  it('turn-flush backstop: routes through the shared normalizeOutboundBody seam (#3501)', () => {
+    // #3501 consolidation: the turn_flush branch no longer hand-mirrors the
+    // reply pipeline inline — it calls the SINGLE shared seam
+    // `normalizeOutboundBody(flushDecision.text, 'turn_flush', redactOutboundText)`.
+    // That call IS the redact→normalize→scrub pipeline (pinned above in the
+    // module source), so the same-slot ordering guarantee now lives in ONE
+    // place. This indexOf returns -1 (→ assertion fails) if the seam call is
+    // deleted from the turn_flush branch.
+    const seamIdx = streamSrc.indexOf(`normalizeOutboundBody(`)
+    const siteIdx = streamSrc.indexOf(`'turn_flush',`, seamIdx)
+    expect(seamIdx).toBeGreaterThan(0)
+    expect(siteIdx).toBeGreaterThan(seamIdx) // the seam is invoked with the turn_flush site
+    // The former inline mirror must be GONE — no hand-rolled copy left to drift.
+    expect(streamSrc).not.toContain('stripExcessBold(normalizePunctuation(capturedText))')
   })
 
-  it('both send sites share the identical `stripExcessBold(normalizePunctuation(` wrapper', () => {
-    // Parity, structurally: the exact normalization wrapper the reply path uses
-    // is the one the turn_flush branch uses — same call, not a lookalike.
+  it('both send sites share the identical normalizeOutboundBody seam (#3501)', () => {
+    // Parity, structurally: after consolidation the reply and turn_flush sites
+    // share ONE normalization implementation — the punctuation/bold wrapper
+    // lives only inside normalizeOutboundBody, and both sites invoke it.
     expect(replyModuleSrc).toContain('stripExcessBold(normalizePunctuation(text))')
-    expect(streamSrc).toContain('stripExcessBold(normalizePunctuation(capturedText))')
+    expect(streamSrc).toContain('normalizeOutboundBody(')
+    expect(streamSrc).toContain(`'turn_flush',`)
   })
 
   // Behavioural coverage (kept from the original suite): reconstruct the


### PR DESCRIPTION
## What

PR 1 of 2 for #3501. Pure consolidation refactor that isolates the golden-snapshot churn ahead of the temporal-normalization step.

The outbound text pipeline (`repair -> paragraph-break -> redact -> punctuation/bold -> voice scrub`) was hand-mirrored inline at three prose send sites:
- the reply path (`normalizeOutboundBody` in `outbound-send-path.ts`)
- `executeEditMessage` in `gateway.ts`
- the turn-flush backstop in `stream-render.ts`

Three drifting copies meant a new outbound transform had to be added in three places and kept byte-identical by hand.

## Change

Route `edit_message` and turn-flush through the single shared `normalizeOutboundBody` seam. The seam gains a `{ literalText, addSpacers }` options object reproducing the two per-site deviations exactly:
- `literalText` (edit_message `format:'text'`): skip paragraph-break + punctuation/bold/spacers; only repair, redact, voice scrub run.
- `addSpacers` (edit_message rich): fold `addParagraphSpacers` into the formatting step.

Reply and turn-flush use the defaults (no options) and are byte-identical to before. **No behaviour change, no new outbound transform** — PR 2 adds the temporal step on this clean seam.

## Tests
- `outbound-send-path.test.ts`: golden byte-parity of the new options vs verbatim inline references for both edit variants and turn-flush; plus reply/edit spacer-difference and literal-skip assertions.
- `turn-flush-safety.test.ts` + `gateway-outbound-redact.test.ts`: structural-wiring pins updated to assert the consolidated seam and that the old inline mirror is gone.

Local: full `npm run lint` clean; scoped vitest suites (outbound/format/stream/flush/edit/redact — 350+ tests) green. CI is the full-suite authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)