### PR TITLE
fix(ci): self-recover the flaky Bun fs.watch hang in bun-test-run

### DIFF
--- a/.github/workflows/ci-tests-plugin.yml
+++ b/.github/workflows/ci-tests-plugin.yml
@@ -56,7 +56,11 @@ jobs:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    # Was 8 (single attempt). The hang-watchdog wrapper (scripts/bun-test-ci.sh)
+    # retries a wedged run up to BUN_TEST_MAX_ATTEMPTS times; a healthy run is
+    # ~50s on the 2-vCPU runner, so 15 min covers up to 3 attempts (each capped
+    # at BUN_TEST_ATTEMPT_TIMEOUT=180s) plus checkout/install overhead.
+    timeout-minutes: 15
     env:
       TELEGRAM_BOT_TOKEN: "123456:stub-for-tests"
     steps:
@@ -67,15 +71,15 @@ jobs:
         uses: ./.github/actions/setup-switchroom
 
       - name: Bun test (telegram-plugin)
-        # Same explicit dir list as Buildkite — running `bun test` with no
-        # args recurses into telegram-plugin/uat/scenarios/ which fail
-        # without TELEGRAM_API_ID/HASH. The dir list scopes to the unit
-        # surface only.
+        # Runs the same explicit dir list as Buildkite (bun test with no
+        # args recurses into uat/scenarios/, which need live creds) through
+        # a hang-watchdog wrapper. The wrapper kills + retries a run wedged
+        # by the pre-existing Bun fs.watch deadlock in the subagent-watcher
+        # tests, but passes REAL assertion failures straight through without
+        # retry. See scripts/bun-test-ci.sh for the full rationale. The test
+        # arg list lives in that script — keep the two in sync.
         working-directory: telegram-plugin
-        run: |
-          bun test \
-            admin-commands gateway registry secret-detect tests \
-            channel-envelope-safety.test.ts
+        run: ./scripts/bun-test-ci.sh
 
   # ─── Sentinel ─────────────────────────────────────────────────────
   # Branch-protection-required context. ALWAYS runs so it always

--- a/telegram-plugin/scripts/bun-test-ci.sh
+++ b/telegram-plugin/scripts/bun-test-ci.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# bun-test-ci.sh — hang-watchdog + automatic retry wrapper for the
+# telegram-plugin Bun test suite (the `bun-test-run` CI job).
+#
+# WHY THIS EXISTS
+# ---------------
+# The `telegram-plugin/tests/subagent-watcher*` tests exercise the real
+# Node/Bun `fs.watch` API. Under CPU contention (the hosted 2-vCPU GitHub
+# runner) Bun's runtime intermittently DEADLOCKS inside `fs.watch` — the
+# `bun` process wedges in `futex_do_wait` with ZERO child processes, so it
+# is not a stuck subprocess or a leaked user handle but an internal Bun
+# scheduler deadlock. Symptom: the suite prints a few thousand of ~8970
+# tests, then goes idle for minutes until the job's hard timeout cancels
+# the whole run — turning an unrelated flake into a red required check on
+# every telegram-plugin PR. It reproduces locally ~1-in-7 runs under
+# `taskset -c 0`; it is NOT an assertion failure (zero `(fail)` lines).
+#
+# Bun's own `--timeout` does NOT preempt it (the deadlocked thread IS the
+# scheduler), so the recovery has to happen one level up: an external
+# watchdog that KILLS a wedged attempt and retries. Because the deadlock
+# is nondeterministic, a retry almost always clears it.
+#
+# HANG vs REAL FAILURE
+# --------------------
+# We must never mask a genuine test failure by retrying it. A real Bun
+# assertion failure exits non-zero WITHOUT the watchdog having to kill
+# anything, so `timeout` reports the command's own exit code and we do NOT
+# retry. Only a watchdog-initiated kill (GNU `timeout` exit status 124, or
+# 128+signal when `--kill-after` escalates to SIGKILL) is treated as a
+# hang and retried.
+#
+# Env overrides (defaults tuned for the 2-vCPU runner; healthy run ~50s):
+#   BUN_TEST_ATTEMPT_TIMEOUT  per-attempt wall-clock budget, seconds (180)
+#   BUN_TEST_KILL_AFTER       grace before SIGKILL escalation, seconds (30)
+#   BUN_TEST_MAX_ATTEMPTS     total attempts before giving up (3)
+set -uo pipefail
+
+ATTEMPT_TIMEOUT="${BUN_TEST_ATTEMPT_TIMEOUT:-180}"
+KILL_AFTER="${BUN_TEST_KILL_AFTER:-30}"
+MAX_ATTEMPTS="${BUN_TEST_MAX_ATTEMPTS:-3}"
+
+# Same explicit dir list as the Buildkite/CI invocation — running `bun
+# test` with no args recurses into telegram-plugin/uat/scenarios/ which
+# need live Telegram creds. Keep this in sync with ci-tests-plugin.yml if
+# the surface changes. BUN_TEST_TARGETS (space-separated) overrides the
+# list — used only to exercise the watchdog against a narrow subset.
+if [ -n "${BUN_TEST_TARGETS:-}" ]; then
+  # shellcheck disable=SC2206
+  BUN_TEST_ARGS=(${BUN_TEST_TARGETS})
+else
+  BUN_TEST_ARGS=(
+    admin-commands gateway registry secret-detect tests
+    channel-envelope-safety.test.ts
+  )
+fi
+
+attempt=1
+while :; do
+  echo "::group::bun test — attempt ${attempt}/${MAX_ATTEMPTS} (per-attempt timeout ${ATTEMPT_TIMEOUT}s, kill-after ${KILL_AFTER}s)"
+  set +e
+  timeout --kill-after="${KILL_AFTER}s" "${ATTEMPT_TIMEOUT}s" \
+    bun test "${BUN_TEST_ARGS[@]}"
+  rc=$?
+  set -e
+  echo "::endgroup::"
+
+  if [ "$rc" -eq 0 ]; then
+    echo "bun test passed on attempt ${attempt}/${MAX_ATTEMPTS}"
+    exit 0
+  fi
+
+  # GNU timeout: 124 = timed out (SIGTERM sent); 137 = 128+9, SIGKILL from
+  # --kill-after escalation; 143 = 128+15, killed by SIGTERM. All three
+  # mean the watchdog had to kill a wedged attempt → a hang, not a failure.
+  case "$rc" in
+    124 | 137 | 143)
+      echo "::warning::bun test attempt ${attempt} HUNG (watchdog killed after ${ATTEMPT_TIMEOUT}s) — known pre-existing Bun fs.watch deadlock in subagent-watcher tests. See telegram-plugin/scripts/bun-test-ci.sh."
+      if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+        echo "::error::bun test hung on all ${MAX_ATTEMPTS} attempts — not a clean pass; failing the job."
+        exit 1
+      fi
+      attempt=$((attempt + 1))
+      continue
+      ;;
+    *)
+      echo "::error::bun test failed on attempt ${attempt} with exit code ${rc} — a real test failure (not a hang), NOT retrying."
+      exit "$rc"
+      ;;
+  esac
+done


### PR DESCRIPTION
## Summary

The `telegram-plugin/tests/subagent-watcher*` tests intermittently **deadlock Bun's runtime inside `fs.watch`** under CPU contention — the `bun` process wedges in `futex_do_wait` with zero children (an internal Bun scheduler bug), so the `bun-test-run` job prints a few thousand of ~8970 tests, then idles until the 8-min job timeout cancels the whole run. That reds the branch-protection-required `bun-test` check on *any* telegram-plugin PR, unrelated to the PR's own changes. Reproduces ~1-in-7 locally under `taskset -c 0` (single-core, mimicking the 2-vCPU hosted runner); clean on 16 cores.

This is **not** an assertion failure (0 `(fail)` lines) and **not** leaked handles — the watcher impl already closes every `FSWatcher` (`stop()` at `subagent-watcher.ts:3229`, terminal/dir cleanup at `:2465`/`:2935`), and the main harness test uses a mock `fs`. It is a nondeterministic Bun-internal `fs.watch` deadlock under aggregate watch churn + contention.

## Why

Bun's own `--timeout` can't preempt it (the deadlocked thread *is* the scheduler), so recovery has to happen one level up. `telegram-plugin/scripts/bun-test-ci.sh` wraps the same explicit test dir list in an external `timeout --kill-after` watchdog that **kills a wedged attempt and retries** (up to `BUN_TEST_MAX_ATTEMPTS=3`, each capped at `BUN_TEST_ATTEMPT_TIMEOUT=180s`). Because the deadlock is intermittent, a retry clears it — a flake that self-recovers deterministically beats one that needs a human `gh run rerun` (deterministic-controls directive).

**Real failures are never masked:** a genuine assertion failure exits non-zero on its own, so only a watchdog-initiated kill (`timeout` rc 124/137/143 = hang) is retried; any other non-zero rc fails fast. Job `timeout-minutes` 8 → 15 to fit up to 3 attempts (healthy run ~50s) plus checkout/install.

Rejected alternatives (see `work/flaky-ci-fix/notes.md`): closing watchers in `afterEach` (already done — not the cause); mocking the REAL-`fs.watch` tests (drops real coverage); isolating the watcher tests into their own bun invocation (doesn't fix the hang, adds glob complexity for a 49s suite); Bun upgrade (fleet-wide, unverified — noted as a follow-up).

## Test plan

- **Real flake reproduced:** HANG at run 7/10, `taskset -c 0 bun test tests/subagent-watcher`.
- **Watchdog kill+retry proven deterministically:** a synthetic process-wedge test (`while(true){}`, which like the fs.watch deadlock ignores bun's own timeout) → 3× `HUNG`, SIGKILL each, retried, clean fail after MAX (15s = 3×5s) — the identical 124/137→kill→retry path.
- **No false retry:** a failing-assertion test → wrapper exits 1 on attempt 1, no retry.
- **No regression on healthy runs:** 53 wrapper runs over the real watcher subset all exit 0.
- `npm run lint` green; clean full 2-core bun suite = 49s.

## Risk

Low. CI-only change (one new shell script + workflow wiring); touches no product/test code and weakens no assertion. Worst case a real failure that happens to also blow the 180s per-attempt budget would be retried, but the budget is ~3.6× a healthy run so that only happens on a genuinely wedged/hung failure — exactly what we want retried.

## Release

Independent of #3500/#3502 (branched off the merged #3502 tip `1a531ebb`). Can ship standalone or fold into the consolidated release — Ken's call.

Job spec: infra/CI reliability (no `reference/jobs/` UX surface touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)