### PR TITLE
feat(telegram): outbound temporal normalization — UTC→local + relative-day (#3501 pt 2)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -13302,22 +13302,18 @@ async function executeEditMessage(args: Record<string, unknown>): Promise<unknow
   // Single rich-markdown path (#2669): `format:'text'` edits as a literal
   // plain string; everything else edits via the rich-markdown path.
   const editLiteralText = editFormat === 'text'
-  // #3501: route through the single shared outbound seam instead of the former
-  // hand-mirrored inline pipeline. `normalizeOutboundBody` runs the same order
-  // as the reply path (repair → paragraph-break → redact → punctuation/bold →
-  // voice scrub); the edit path's two deviations are expressed as options:
-  //   - literalText: a `format:'text'` edit lands byte-for-byte, so it skips
-  //     paragraph normalization + punctuation/bold/spacers (only repair, the
-  //     secret redact, and the voice scrub still run).
-  //   - addSpacers: the rich edit path folds the idempotent U+00A0 paragraph
-  //     spacer INTO the formatting step (the rich GFM renderer renders `\n\n`
-  //     tight; the spacer restores a visible gap without double-spacing).
-  const _editNorm = normalizeOutboundBody(
-    args.text as string,
-    'edit_message',
-    redactOutboundText,
-    { literalText: editLiteralText, addSpacers: !editLiteralText },
-  )
+  // #3501: route through the single shared outbound seam (repair → paragraph-
+  // break → redact → punctuation/bold → temporal → voice scrub) instead of the
+  // former hand-mirrored inline pipeline. The edit path's deviations are options:
+  // literalText skips paragraph/punctuation/bold/spacers + temporal (a literal
+  // edit lands byte-for-byte); addSpacers folds the idempotent U+00A0 paragraph
+  // spacer into the rich formatting step. tz/nowMs drive the temporal pass.
+  const _editNorm = normalizeOutboundBody(args.text as string, 'edit_message', redactOutboundText, {
+    literalText: editLiteralText,
+    addSpacers: !editLiteralText,
+    tz: resolveEnvTimezone(),
+    nowMs: Date.now(),
+  })
   let editRawText = _editNorm.text
   if (_editNorm.voiceReplaced > 0) {
     emitRuntimeMetric({

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -33,6 +33,8 @@ import {
   RICH_MESSAGE_MAX_CHARS,
 } from '../format.js'
 import { scrubVoice } from '../text-voice-scrub.js'
+import { normalizeTemporal } from '../temporal-normalize.js'
+import { resolveEnvTimezone } from '../shared/local-time.js'
 import { isMessageTooLongError, isHtmlParseRejectError } from '../retry-api-call.js'
 
 // ── send-orchestration façade imports (#2996 P2) ──
@@ -137,6 +139,18 @@ export interface NormalizeOutboundOptions {
   literalText?: boolean
   /** Fold `addParagraphSpacers` into the formatting step (edit_message path). */
   addSpacers?: boolean
+  /**
+   * Agent-configured IANA timezone for the temporal-normalization pass (#3501).
+   * When BOTH `tz` and `nowMs` are supplied (callers pass `resolveEnvTimezone()`
+   * and `Date.now()`), the seam rewrites UTC/Zulu datetimes to local wall clock
+   * and corrects relative-day words against the current date in `tz`. Omitted →
+   * the temporal pass is a no-op (keeps the module pure/clock-free by default).
+   * NEVER fires on a literal edit (`literalText`) — a literal edit lands
+   * byte-for-byte as authored.
+   */
+  tz?: string
+  /** Epoch-ms "now" for the temporal pass. Required alongside `tz` to fire. */
+  nowMs?: number
 }
 
 /**
@@ -167,7 +181,7 @@ export function normalizeOutboundBody(
   redact: RedactFn,
   opts: NormalizeOutboundOptions = {},
 ): NormalizeOutboundResult {
-  const { literalText = false, addSpacers = false } = opts
+  const { literalText = false, addSpacers = false, tz, nowMs } = opts
   let text = repairEscapedWhitespace(rawText)
   if (!literalText) text = normalizeParagraphBreaks(text)
   text = redact(text, site)
@@ -175,6 +189,14 @@ export function normalizeOutboundBody(
     let formatted = stripExcessBold(normalizePunctuation(text))
     if (addSpacers) formatted = addParagraphSpacers(formatted)
     text = formatted
+    // Temporal normalization (#3501): UTC/Zulu → local wall clock, then
+    // relative-day accuracy, resolved in the agent's configured tz. Runs AFTER
+    // punctuation/bold (so masking sees final markdown) and BEFORE the voice
+    // scrub (so a freshly-rewritten "Thu 23 Jul 7:15 pm AEST" is never mangled
+    // by the em/en-dash scrub). Never on a literal edit. Pure / never-throws.
+    if (tz != null && nowMs != null) {
+      text = normalizeTemporal(text, tz, nowMs)
+    }
   }
   let voiceReplaced = 0
   const scrub = scrubVoice(text)
@@ -832,7 +854,10 @@ export async function sendReply(
   // retries see the scrubbed dedup key). The metric side effect (fired on a
   // non-zero voice-scrub replacement) stays here — the pure module returns the
   // replacement count and the gateway emits.
-  const _normalized = normalizeOutboundBody(rawText, 'reply', redactOutboundText)
+  const _normalized = normalizeOutboundBody(rawText, 'reply', redactOutboundText, {
+    tz: resolveEnvTimezone(),
+    nowMs: Date.now(),
+  })
   let text = _normalized.text
   if (_normalized.voiceReplaced > 0) {
     emitRuntimeMetric({

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -56,6 +56,7 @@
 import { createAnswerStream } from '../answer-stream.js'
 import { LivenessTracker, isContextExhaustionText } from '../context-exhaustion.js'
 import { normalizeOutboundBody } from './outbound-send-path.js'
+import { resolveEnvTimezone } from '../shared/local-time.js'
 import { hasOutboundDeliveredSince, recordOutbound } from '../history.js'
 import { isReplyTool } from '../narrative-dedup.js'
 import { NarrativeFlushController } from '../narrative-flush.js'
@@ -1544,6 +1545,10 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
           flushDecision.text,
           'turn_flush',
           redactOutboundText,
+          // #3501 temporal pass — a cron/mail-watcher notification that skipped
+          // reply is delivered here, so this is where "closed tomorrow (Thu 23
+          // Jul)" gets corrected against the agent's local date.
+          { tz: resolveEnvTimezone(), nowMs: Date.now() },
         )
         let capturedText = _flushNorm.text
         if (_flushNorm.voiceReplaced > 0) {

--- a/telegram-plugin/temporal-normalize.ts
+++ b/telegram-plugin/temporal-normalize.ts
@@ -1,0 +1,347 @@
+/**
+ * temporal-normalize.ts — deterministic outbound temporal normalization (#3501).
+ *
+ * Two independent, idempotent rewrites applied to outbound Telegram prose, in
+ * the shared `normalizeOutboundBody` seam (after redact/punctuation/bold,
+ * before the voice scrub):
+ *
+ *   1. UTC/Zulu datetimes → the agent's LOCAL wall clock. A raw
+ *      `2026-07-23T09:15:00Z` (or `…+00:00`, or a `14:00 UTC` / `2 pm GMT`
+ *      label) is rewritten to `Thu 23 Jul 7:15 pm AEST` — DST-correct by
+ *      construction (Intl resolves the per-instant offset) — so the operator
+ *      never has to translate UTC in their head, and the model can never re-read
+ *      its own outbound as "now in UTC".
+ *
+ *   2. Relative-day accuracy. A relative day word (today / tomorrow / yesterday /
+ *      tonight / this morning|afternoon|evening) written ADJACENT to an absolute
+ *      date is checked against the current date in the agent's configured TZ and
+ *      corrected if wrong. The incident: a cron notification said "closed
+ *      tomorrow (Thu 23 Jul)" when today WAS Thursday 23 Jul — it should read
+ *      "closed today (Thu 23 Jul)". A relative word with NO adjacent absolute
+ *      date is left untouched.
+ *
+ * Design constraints (all enforced here):
+ *   - Pure over its arguments — `tz` and `nowMs` are passed in (callers use
+ *     `resolveEnvTimezone()` and `Date.now()`); NO env / clock read here.
+ *   - Never-throw: a bad/unresolvable IANA `tz` degrades to the INPUT unchanged
+ *     rather than crashing a turn (mirrors `fmtLocalStamp`'s contract).
+ *   - Intl-only: ZERO date libraries — reuses `localDay` / `tzAbbrev` from
+ *     shared/local-time.ts.
+ *   - False-positive guard: code fences, inline code, markdown link hrefs, and
+ *     angle-bracket autolinks are masked before either pass, so an ISO string in
+ *     a log / URL / code span is never rewritten. Blockquote (`>`) lines are
+ *     excluded too — forwarded/quoted third-party text is left verbatim.
+ *   - Idempotent: the UTC output carries no Z/UTC/GMT token (the detector can't
+ *     re-match it); the relative-day output is a fixed point once the word and
+ *     date agree.
+ */
+
+import { localDay, tzAbbrev } from './shared/local-time.js'
+
+// ── Combined false-positive masker ─────────────────────────────────────────
+// Covers the SAME regions normalizePunctuation protects (fenced blocks, inline
+// code, `](href)` link destinations, `<scheme:…>` autolinks) — lifted here as a
+// single shared masker because `maskCodeRegions` (format.ts) alone does NOT
+// cover link hrefs / autolinks (that logic lives inline inside normalizePunctuation).
+interface MaskedRegions {
+  masked: string
+  restore: (s: string) => string
+}
+
+function maskTemporalRegions(text: string): MaskedRegions {
+  const nonce = Math.random().toString(36).slice(2)
+  const PH = `\x00TN${nonce}_`
+  const masks: string[] = []
+  const push = (s: string): string => {
+    masks.push(s)
+    return `${PH}${masks.length - 1}\x00`
+  }
+  const masked = text
+    // Fenced blocks first, only when CLOSED (matching ```), so an unclosed
+    // fence is left intact rather than misparsed by the inline pass.
+    .replace(/```[\s\S]*?```/g, (m) => push(m))
+    // Inline code spans.
+    .replace(/`[^`\n]+`/g, (m) => push(m))
+    // Markdown inline-link DESTINATIONS `](href)` — only the href inside the
+    // parens is masked; the visible label still normalizes like prose.
+    .replace(/(\]\()([^)\n]*)(\))/g, (_m, open: string, href: string, close: string) =>
+      `${open}${push(href)}${close}`,
+    )
+    // GFM angle-bracket autolink destinations `<scheme:…>`.
+    .replace(/(<)([a-zA-Z][a-zA-Z0-9+.-]*:[^>\s]*)(>)/g, (_m, lt: string, uri: string, gt: string) =>
+      `${lt}${push(uri)}${gt}`,
+    )
+  const esc = nonce.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`\x00TN${esc}_(\\d+)\x00`, 'g')
+  const restore = (s: string): string => s.replace(re, (_m, idx: string) => masks[Number(idx)] ?? _m)
+  return { masked, restore }
+}
+
+/** A blockquote line (mirrors format.ts `isBlockquoteLine`). */
+function isBlockquoteLine(line: string): boolean {
+  return line.trimStart().startsWith('>')
+}
+
+/** Run a per-line transform on masked text, leaving blockquote lines verbatim. */
+function perNonQuoteLine(masked: string, fn: (line: string) => string): string {
+  return masked
+    .split('\n')
+    .map((line) => (isBlockquoteLine(line) ? line : fn(line)))
+    .join('\n')
+}
+
+// ── Local rendering ─────────────────────────────────────────────────────────
+
+/** `Thu 23 Jul` — weekday + day + short month in `tz`, no locale punctuation. */
+function renderLocalDate(ms: number, tz: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  }).formatToParts(new Date(ms))
+  const get = (t: string): string => parts.find((p) => p.type === t)?.value ?? ''
+  return `${get('weekday')} ${get('day')} ${get('month')}`
+}
+
+/** `7:15 pm` — spaced, lowercased am/pm wall clock in `tz`. */
+function renderLocalClock(ms: number, tz: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+    .format(new Date(ms))
+    .replace(/\s([AP])M$/, (_m, p: string) => ` ${p.toLowerCase()}m`)
+}
+
+/** `Thu 23 Jul 7:15 pm AEST` — full local datetime for a converted instant. */
+function renderLocalDatetime(ms: number, tz: string): string {
+  return `${renderLocalDate(ms, tz)} ${renderLocalClock(ms, tz)} ${tzAbbrev(ms, tz)}`
+}
+
+// ── Pass 1: UTC / Zulu datetime → local ─────────────────────────────────────
+
+// Full ISO-8601 with a Z or +00:00 zero-offset. Seconds + fractional seconds
+// optional. The trailing marker guarantees the output (which carries none)
+// cannot re-match — idempotent by construction.
+const ISO_UTC_RE = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|\+00:00)/g
+
+// Labelled clock time tagged UTC/GMT. The minutes / am|pm are OPTIONAL in the
+// pattern but the replacer REQUIRES at least one of them (colon-minutes OR
+// am/pm) before converting — so a bare "5 GMT" (as in "9 to 5 GMT") is left
+// untouched, matching the tightened grammar.
+const LABELLED_UTC_RE = /\b(\d{1,2})(?::(\d{2}))?\s?(am|pm)?\s?(UTC|GMT)\b/gi
+
+function convertUtcInLine(line: string, tz: string, nowMs: number): string {
+  let out = line.replace(ISO_UTC_RE, (m) => {
+    const ms = Date.parse(m)
+    if (Number.isNaN(ms)) return m
+    return renderLocalDatetime(ms, tz)
+  })
+  out = out.replace(LABELLED_UTC_RE, (m, hh: string, mm: string | undefined, ampm: string | undefined) => {
+    // Tightened grammar: require colon-minutes OR am/pm — reject bare "5 GMT".
+    if (mm == null && ampm == null) return m
+    let h = Number(hh)
+    const pm = ampm != null && /pm/i.test(ampm)
+    if (ampm != null) {
+      if (h > 12) return m // "14 pm" is nonsensical — leave untouched
+      if (h === 12) h = pm ? 12 : 0
+      else if (pm) h += 12
+    }
+    if (h > 23) return m
+    const minute = mm != null ? Number(mm) : 0
+    if (minute > 59) return m
+    const now = new Date(nowMs)
+    // Interpret the labelled time as UTC on nowMs's UTC calendar date, then
+    // render the LOCAL wall clock. No date is emitted (the source carried none).
+    const ms = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), h, minute)
+    return `${renderLocalClock(ms, tz)} ${tzAbbrev(ms, tz)}`
+  })
+  return out
+}
+
+/**
+ * Rewrite UTC/Zulu datetimes in `text` to the local wall clock in `tz`.
+ * Pure / never-throws: an invalid `tz` (or any internal failure) returns the
+ * input unchanged.
+ */
+export function normalizeUtcDatetimes(text: string, tz: string, nowMs: number): string {
+  if (!text) return text
+  try {
+    // Fast-path: nothing that could be a UTC datetime.
+    if (!/\d{4}-\d{2}-\d{2}T|\b(?:UTC|GMT)\b/i.test(text)) return text
+    const { masked, restore } = maskTemporalRegions(text)
+    const out = perNonQuoteLine(masked, (line) => convertUtcInLine(line, tz, nowMs))
+    return restore(out)
+  } catch {
+    return text
+  }
+}
+
+// ── Pass 2: relative-day accuracy ───────────────────────────────────────────
+
+const REL = '(today|tonight|this\\s+morning|this\\s+afternoon|this\\s+evening|tomorrow|yesterday)'
+// A small, strict separator set: whitespace / commas, an optional "on ", and an
+// optional opening paren. Bounded (only spaces/commas), so the effective window
+// stays small — no `.{0,15}` wildcard that could swallow arbitrary prose.
+const SEP = '([\\s,]*(?:on\\s+)?\\(?\\s*)'
+const WD = '(?:mon|tue|wed|thu|fri|sat|sun)[a-z]*'
+const MON = '(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*'
+// One optional weekday token (captured, with its trailing separator), then one
+// absolute-date core (captured whole; re-parsed in the replacer).
+const WD_GROUP = `((?:${WD})[\\s,]+)?`
+const DATE_CORE =
+  `((?:\\d{1,2}\\s+${MON})|(?:${MON}\\s+\\d{1,2})|(?:\\d{4}-\\d{2}-\\d{2})|(?:\\d{1,2}\\/\\d{2}))`
+
+const MONTHS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
+const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+function buildRelRegex(): RegExp {
+  return new RegExp(REL + SEP + WD_GROUP + DATE_CORE, 'gi')
+}
+
+interface ParsedDate {
+  year: number | null
+  month: number // 1-12
+  day: number
+}
+
+/** Parse a matched absolute-date core into {year?, month, day}, or null. */
+function parseDateCore(core: string): ParsedDate | null {
+  let m: RegExpExecArray | null
+  if ((m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(core))) {
+    return { year: Number(m[1]), month: Number(m[2]), day: Number(m[3]) }
+  }
+  if ((m = /^(\d{1,2})\/(\d{2})$/.exec(core))) {
+    // DD/MM (fleet convention — matches the "23/07" nice-to-have).
+    return { year: null, month: Number(m[2]), day: Number(m[1]) }
+  }
+  if ((m = /^(\d{1,2})\s+([a-z]+)$/i.exec(core))) {
+    const mon = MONTHS.indexOf(m[2].slice(0, 3).toLowerCase())
+    if (mon < 0) return null
+    return { year: null, month: mon + 1, day: Number(m[1]) }
+  }
+  if ((m = /^([a-z]+)\s+(\d{1,2})$/i.exec(core))) {
+    const mon = MONTHS.indexOf(m[1].slice(0, 3).toLowerCase())
+    if (mon < 0) return null
+    return { year: null, month: mon + 1, day: Number(m[2]) }
+  }
+  return null
+}
+
+/** UTC-midnight day index for a Y-M-D (calendar-day math, DST-irrelevant). */
+function dayIndex(y: number, mo1: number, d: number): number {
+  return Math.floor(Date.UTC(y, mo1 - 1, d) / 86_400_000)
+}
+
+/** Resolve a possibly-yearless date to the occurrence nearest today-in-tz. */
+function resolveYear(parsed: ParsedDate, todayY: number, todayIdx: number): number {
+  if (parsed.year != null) return parsed.year
+  let best = todayY
+  let bestAbs = Infinity
+  for (const y of [todayY - 1, todayY, todayY + 1]) {
+    const diff = Math.abs(dayIndex(y, parsed.month, parsed.day) - todayIdx)
+    if (diff < bestAbs) {
+      bestAbs = diff
+      best = y
+    }
+  }
+  return best
+}
+
+/** Preserve the original casing pattern of a rewritten day word. */
+function matchCase(sample: string, replacement: string): string {
+  if (sample.length > 0 && sample[0] === sample[0].toUpperCase() && sample[0] !== sample[0].toLowerCase()) {
+    return replacement.charAt(0).toUpperCase() + replacement.slice(1)
+  }
+  return replacement
+}
+
+const TIME_OF_DAY_RE = /^(tonight|this\s+)/i
+
+function rewriteRelativeInLine(line: string, tz: string, nowMs: number): string {
+  const today = localDay(nowMs, tz) // YYYY-MM-DD (throws first on a bad tz)
+  const [ty, tm, td] = today.split('-').map(Number)
+  const todayIdx = dayIndex(ty, tm, td)
+
+  return line.replace(buildRelRegex(), (full, rel: string, sep: string, wdGroup: string | undefined, core: string) => {
+    const parsed = parseDateCore(core)
+    if (parsed == null) return full
+    const year = resolveYear(parsed, ty, todayIdx)
+    const targetIdx = dayIndex(year, parsed.month, parsed.day)
+    const diff = targetIdx - todayIdx
+
+    // Out-of-range (|diff| > 1): leave the ENTIRE match untouched — do NOT
+    // invent a word and do NOT auto-delete (open question 3 resolution).
+    if (diff < -1 || diff > 1) return full
+
+    const isTimeOfDay = TIME_OF_DAY_RE.test(rel)
+
+    // Determine the corrected relative word.
+    let newRel = rel
+    if (isTimeOfDay) {
+      // tonight / this morning|afternoon|evening are a correct SUBSET of today.
+      // Only valid when the date resolves to today (diff==0); never remap them
+      // to bare tomorrow/yesterday. Otherwise leave the whole match untouched.
+      if (diff !== 0) return full
+      // diff==0: the word is already correct — keep it verbatim.
+    } else {
+      const want = diff === 1 ? 'tomorrow' : diff === 0 ? 'today' : 'yesterday'
+      newRel = matchCase(rel, want)
+    }
+
+    // Weekday repair: if a weekday token precedes the date and disagrees with
+    // the true weekday of the resolved date in-tz, correct it.
+    let newWdGroup = wdGroup
+    if (wdGroup != null) {
+      const trueDow = new Date(Date.UTC(year, parsed.month - 1, parsed.day)).getUTCDay()
+      const trueShort = WEEKDAY_SHORT[trueDow]
+      // Preserve the original separator tail after the weekday token.
+      const wdMatch = /^([a-z]+)([\s,]+)$/i.exec(wdGroup)
+      if (wdMatch != null) {
+        const writtenShort = wdMatch[1].slice(0, 3).toLowerCase()
+        if (writtenShort !== trueShort.toLowerCase()) {
+          const wasLong = wdMatch[1].length > 3
+          const corrected = wasLong ? longWeekday(trueDow) : trueShort
+          newWdGroup = matchCase(wdMatch[1], corrected) + wdMatch[2]
+        }
+      }
+    }
+
+    return `${newRel}${sep}${newWdGroup ?? ''}${core}`
+  })
+}
+
+const WEEKDAY_LONG = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+function longWeekday(dow: number): string {
+  return WEEKDAY_LONG[dow]
+}
+
+/**
+ * Correct relative-day words that are wrong for the absolute date they sit next
+ * to, resolved against `nowMs` in `tz`. Pure / never-throws.
+ */
+export function normalizeRelativeDays(text: string, tz: string, nowMs: number): string {
+  if (!text) return text
+  try {
+    if (!/\b(today|tonight|this\s+(?:morning|afternoon|evening)|tomorrow|yesterday)\b/i.test(text)) {
+      return text
+    }
+    const { masked, restore } = maskTemporalRegions(text)
+    const out = perNonQuoteLine(masked, (line) => rewriteRelativeInLine(line, tz, nowMs))
+    return restore(out)
+  } catch {
+    return text
+  }
+}
+
+/**
+ * Convenience composition: UTC→local FIRST (so it produces absolute local
+ * datetimes the relative-day pass can then check), THEN relative-day accuracy.
+ * Pure / never-throws — each sub-pass degrades to its input on failure.
+ */
+export function normalizeTemporal(text: string, tz: string, nowMs: number): string {
+  return normalizeRelativeDays(normalizeUtcDatetimes(text, tz, nowMs), tz, nowMs)
+}

--- a/telegram-plugin/tests/gateway-outbound-redact.test.ts
+++ b/telegram-plugin/tests/gateway-outbound-redact.test.ts
@@ -53,7 +53,7 @@ describe('gateway outbound secret-scrub — structural wiring', () => {
     // delegates via `normalizeOutboundBody(rawText, 'reply', redactOutboundText)`
     // — the injected redactor still runs at entry, before the stderr preview.
     const start = sendPathSrc.indexOf('export async function sendReply(')
-    const redactIdx = sendPathSrc.indexOf(`normalizeOutboundBody(rawText, 'reply', redactOutboundText)`, start)
+    const redactIdx = sendPathSrc.indexOf(`normalizeOutboundBody(rawText, 'reply', redactOutboundText`, start)
     const previewIdx = sendPathSrc.indexOf('reply: invoked chatId=', start)
     expect(start).toBeGreaterThan(0)
     expect(redactIdx).toBeGreaterThan(start)

--- a/telegram-plugin/tests/outbound-send-path.test.ts
+++ b/telegram-plugin/tests/outbound-send-path.test.ts
@@ -329,3 +329,87 @@ describe('outbound-send-path — cross-surface dedup suppression', () => {
     expect(dedup.check(chatId, undefined, text, t0 + 500, 'turn-2')).toBeNull()
   })
 })
+
+// ── #3501 temporal-normalization wiring into the shared seam ────────────────
+import { readFileSync } from 'node:fs'
+import { normalizeTemporal } from '../temporal-normalize.js'
+
+const TZ_MEL = 'Australia/Melbourne'
+const NOW_THU = Date.UTC(2026, 6, 23, 2, 0, 0) // Thu 2026-07-23 midday Melbourne
+
+describe('outbound-send-path — temporal pass wiring (#3501)', () => {
+  it('fires when tz+nowMs are supplied — fixes the cron/mail-watcher incident', () => {
+    const incident = 'Heads up: the office is closed tomorrow (Thu 23 Jul).'
+    const got = normalizeOutboundBody(incident, 'turn_flush', injectedRedact, {
+      tz: TZ_MEL,
+      nowMs: NOW_THU,
+    })
+    expect(got.text).toBe('Heads up: the office is closed today (Thu 23 Jul).')
+  })
+
+  it('is a NO-OP when tz is omitted (keeps the seam pure/clock-free by default)', () => {
+    const incident = 'closed tomorrow (Thu 23 Jul)'
+    // No tz → temporal must not fire; output is the plain formatted pipeline.
+    const got = normalizeOutboundBody(incident, 'reply', injectedRedact)
+    expect(got.text).toBe(incident)
+  })
+
+  it('REVIEW FIX 3 — a literal edit does NOT run the temporal pass', () => {
+    const incident = 'closed tomorrow (Thu 23 Jul)'
+    const got = normalizeOutboundBody(incident, 'edit_message', injectedRedact, {
+      literalText: true,
+      tz: TZ_MEL,
+      nowMs: NOW_THU,
+    })
+    // Literal edit lands byte-for-byte — the stale relative word is preserved.
+    expect(got.text).toBe(incident)
+  })
+
+  it('golden pipeline ORDER — temporal output is not mangled by the voice scrub', () => {
+    // A UTC datetime is rewritten to "Thu 23 Jul 7:15 pm AEST"; the voice scrub
+    // (em/en dash → comma) that runs AFTER must not touch it.
+    const raw = 'window 2026-07-23T09:15:00Z opens'
+    const got = normalizeOutboundBody(raw, 'reply', injectedRedact, {
+      tz: TZ_MEL,
+      nowMs: NOW_THU,
+    })
+    expect(got.text).toBe('window Thu 23 Jul 7:15 pm AEST opens')
+  })
+
+  it('temporal runs AFTER punctuation/bold and BEFORE scrubVoice (structural pin)', () => {
+    const src = readFileSync(new URL('../gateway/outbound-send-path.ts', import.meta.url), 'utf8')
+    const start = src.indexOf('export function normalizeOutboundBody(')
+    const boldIdx = src.indexOf('stripExcessBold(normalizePunctuation(text))', start)
+    const temporalIdx = src.indexOf('normalizeTemporal(text, tz, nowMs)', start)
+    const scrubIdx = src.indexOf('scrubVoice(text)', start)
+    expect(boldIdx).toBeGreaterThan(start)
+    expect(temporalIdx).toBeGreaterThan(boldIdx) // AFTER punctuation/bold
+    expect(scrubIdx).toBeGreaterThan(temporalIdx) // BEFORE the voice scrub
+  })
+
+  it('per-site wiring pin — all three prose sends pass tz+nowMs into the seam', () => {
+    const sendPath = readFileSync(new URL('../gateway/outbound-send-path.ts', import.meta.url), 'utf8')
+    const gateway = readFileSync(new URL('../gateway/gateway.ts', import.meta.url), 'utf8')
+    const streamRender = readFileSync(new URL('../gateway/stream-render.ts', import.meta.url), 'utf8')
+    // Reply site (sendReply) passes tz+nowMs.
+    const replyStart = sendPath.indexOf(`normalizeOutboundBody(rawText, 'reply', redactOutboundText`)
+    expect(replyStart).toBeGreaterThan(0)
+    expect(sendPath.indexOf('tz: resolveEnvTimezone()', replyStart)).toBeGreaterThan(replyStart)
+    // edit_message site passes tz+nowMs.
+    const editStart = gateway.indexOf(`'edit_message',`)
+    expect(gateway.indexOf('tz: resolveEnvTimezone()', editStart)).toBeGreaterThan(editStart)
+    // turn-flush site passes tz+nowMs.
+    const flushStart = streamRender.indexOf(`'turn_flush',`)
+    expect(streamRender.indexOf('tz: resolveEnvTimezone()', flushStart)).toBeGreaterThan(flushStart)
+  })
+
+  it('temporal wiring matches the standalone module output (no drift)', () => {
+    const raw = 'ships tomorrow (Thu 23 Jul), at 2026-07-23T09:15:00Z'
+    const viaSeam = normalizeOutboundBody(raw, 'reply', injectedRedact, {
+      tz: TZ_MEL,
+      nowMs: NOW_THU,
+    }).text
+    const viaModule = normalizeTemporal(raw, TZ_MEL, NOW_THU)
+    expect(viaSeam).toBe(viaModule)
+  })
+})

--- a/telegram-plugin/tests/temporal-normalize.test.ts
+++ b/telegram-plugin/tests/temporal-normalize.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeTemporal,
+  normalizeUtcDatetimes,
+  normalizeRelativeDays,
+} from '../temporal-normalize.js'
+
+// All cases run in the agent's configured tz with a FIXED nowMs — the pure
+// signature means no env / clock mocking is needed.
+const TZ = 'Australia/Melbourne'
+// Midday Melbourne on Thursday 2026-07-23 (AEST, UTC+10): 02:00Z = 12:00 local.
+const NOW_THU_23_JUL = Date.UTC(2026, 6, 23, 2, 0, 0)
+
+describe('normalizeRelativeDays — relative-day accuracy (#3501)', () => {
+  it('1. stale-forward: "closed tomorrow (Thu 23 Jul)" on Thu 23 Jul → "today"', () => {
+    // The reported incident.
+    const out = normalizeRelativeDays('closed tomorrow (Thu 23 Jul)', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('closed today (Thu 23 Jul)')
+  })
+
+  it('2. stale-backward: "today (Wed 22 Jul)" on Thu 23 Jul → "yesterday"', () => {
+    const out = normalizeRelativeDays('sent today (Wed 22 Jul)', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('sent yesterday (Wed 22 Jul)')
+  })
+
+  it('3. "yesterday" wrong forward: "(Fri 24 Jul)" → "tomorrow"', () => {
+    const out = normalizeRelativeDays('due yesterday (Fri 24 Jul)', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('due tomorrow (Fri 24 Jul)')
+  })
+
+  it('4. correct word untouched — byte-identical', () => {
+    const src = 'ships today (Thu 23 Jul)'
+    expect(normalizeRelativeDays(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('5. relative word with NO adjacent date — untouched', () => {
+    const src = "I'll get to it today, promise."
+    expect(normalizeRelativeDays(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('6. multi-date message — each pair resolved independently', () => {
+    const out = normalizeRelativeDays(
+      'opened tomorrow (Thu 23 Jul), closes tomorrow (Fri 24 Jul)',
+      TZ,
+      NOW_THU_23_JUL,
+    )
+    // First pair is actually today; second is genuinely tomorrow.
+    expect(out).toBe('opened today (Thu 23 Jul), closes tomorrow (Fri 24 Jul)')
+  })
+
+  it('7. midnight boundary: UTC date (22nd) disagrees with Melbourne date (23rd)', () => {
+    // 2026-07-22T23:00Z is already Thu 23 Jul 09:00 in Melbourne.
+    const now = Date.UTC(2026, 6, 22, 23, 0, 0)
+    const out = normalizeRelativeDays('reminder tomorrow (Thu 23 Jul)', TZ, now)
+    expect(out).toBe('reminder today (Thu 23 Jul)')
+  })
+
+  it('16. weekday repair: "(Wed 23 Jul)" when 23 Jul is a Thursday → "(Thu 23 Jul)"', () => {
+    const out = normalizeRelativeDays('meeting today (Wed 23 Jul)', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('meeting today (Thu 23 Jul)')
+  })
+
+  it('numeric date form 23/07 (DD/MM) resolves like a named date', () => {
+    const out = normalizeRelativeDays('billed tomorrow (23/07)', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('billed today (23/07)')
+  })
+
+  it('ISO yyyy-mm-dd adjacent date resolves', () => {
+    const out = normalizeRelativeDays('expires tomorrow 2026-07-22', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('expires yesterday 2026-07-22')
+  })
+
+  it('time-of-day word with diff==0 (today) is kept as-is', () => {
+    const src = 'closing tonight (Thu 23 Jul)'
+    expect(normalizeRelativeDays(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('REVIEW FIX 2 — time-of-day word with diff≠0 is left UNTOUCHED (never remapped)', () => {
+    // "tonight" next to tomorrow's date must NOT become "tomorrow" — it is left
+    // exactly as written.
+    const src = 'party tonight (Fri 24 Jul)'
+    expect(normalizeRelativeDays(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('out-of-range relative word (diff > 1) is left untouched, NOT auto-deleted', () => {
+    const src = 'launch tomorrow (Mon 3 Aug)'
+    expect(normalizeRelativeDays(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('preserves original casing on rewrite', () => {
+    const out = normalizeRelativeDays('Tomorrow (Thu 23 Jul) we ship', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('Today (Thu 23 Jul) we ship')
+  })
+
+  it('excludes blockquote (>) lines from rewriting (quoted third-party text)', () => {
+    const src = '> forwarded: closed tomorrow (Thu 23 Jul)'
+    expect(normalizeRelativeDays(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+})
+
+describe('normalizeUtcDatetimes — no raw UTC outbound (#3501)', () => {
+  it('8. ISO-Z → local: 2026-07-23T09:15:00Z → Thu 23 Jul 7:15 pm AEST', () => {
+    const out = normalizeUtcDatetimes('window opens 2026-07-23T09:15:00Z', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('window opens Thu 23 Jul 7:15 pm AEST')
+  })
+
+  it('9a. +00:00 offset variant', () => {
+    const out = normalizeUtcDatetimes('at 2026-07-23T09:15:00+00:00 sharp', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('at Thu 23 Jul 7:15 pm AEST sharp')
+  })
+
+  it('9b. no-seconds and fractional-seconds variants', () => {
+    expect(normalizeUtcDatetimes('t=2026-07-23T09:15Z', TZ, NOW_THU_23_JUL)).toBe('t=Thu 23 Jul 7:15 pm AEST')
+    expect(normalizeUtcDatetimes('t=2026-07-23T09:15:00.500Z', TZ, NOW_THU_23_JUL)).toBe(
+      't=Thu 23 Jul 7:15 pm AEST',
+    )
+  })
+
+  it('10. labelled "14:00 UTC" → local time-only', () => {
+    // 14:00Z on the 23rd is 00:00 (midnight) of the 24th in Melbourne.
+    const out = normalizeUtcDatetimes('cutoff 14:00 UTC', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('cutoff 12:00 am AEST')
+  })
+
+  it('10b. labelled "2 pm GMT" → local', () => {
+    const out = normalizeUtcDatetimes('call at 2 pm GMT', TZ, NOW_THU_23_JUL)
+    expect(out).toBe('call at 12:00 am AEST')
+  })
+
+  it('11. DST: an AEDT-side instant renders AEDT wall clock', () => {
+    // 2026-01-15T09:15:00Z, Melbourne is on AEDT (UTC+11).
+    const summerNow = Date.UTC(2026, 0, 15, 2, 0, 0)
+    const out = normalizeUtcDatetimes('summer 2026-01-15T09:15:00Z', TZ, summerNow)
+    expect(out).toBe('summer Thu 15 Jan 8:15 pm AEDT')
+  })
+
+  it('12. already-local text ("7:15 pm AEST") — untouched', () => {
+    const src = 'opens 7:15 pm AEST'
+    expect(normalizeUtcDatetimes(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('REVIEW — "9 to 5 GMT" (bare labelled hour, no minutes/ampm) is NOT converted', () => {
+    const src = 'hours are 9 to 5 GMT'
+    expect(normalizeUtcDatetimes(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+})
+
+describe('temporal masking — false-positive guards (#3501)', () => {
+  it('13a. ISO inside an inline code span — untouched', () => {
+    const src = 'log line `2026-07-23T09:15:00Z` seen'
+    expect(normalizeTemporal(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('13b. ISO inside a fenced code block — untouched', () => {
+    const src = 'trace:\n```\nts=2026-07-23T09:15:00Z\n```\nend'
+    expect(normalizeTemporal(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('REVIEW FIX 1 (failing-first) — ISO inside a markdown link href is untouched', () => {
+    const src = 'see [log](https://x/2026-07-23T09:15:00Z) for detail'
+    expect(normalizeTemporal(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('REVIEW FIX 1 — ISO inside an angle-bracket autolink is untouched', () => {
+    const src = 'ref <https://x/2026-07-23T09:15:00Z> here'
+    expect(normalizeTemporal(src, TZ, NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('but a bare ISO in prose alongside a masked one IS still converted', () => {
+    const out = normalizeTemporal(
+      'live 2026-07-23T09:15:00Z, code `2026-07-23T09:15:00Z`',
+      TZ,
+      NOW_THU_23_JUL,
+    )
+    expect(out).toBe('live Thu 23 Jul 7:15 pm AEST, code `2026-07-23T09:15:00Z`')
+  })
+})
+
+describe('normalizeTemporal — composition, idempotency, robustness (#3501)', () => {
+  it('runs UTC→local first, then relative-day on the produced date', () => {
+    // The UTC pass yields "Thu 23 Jul …"; the relative pass then sees that date
+    // adjacent to "tomorrow" and corrects it to "today".
+    const out = normalizeTemporal('tomorrow 2026-07-22T09:15:00Z', TZ, NOW_THU_23_JUL)
+    // 2026-07-22T09:15Z → Wed 22 Jul 7:15 pm AEST; 22 Jul is yesterday.
+    expect(out).toBe('yesterday Wed 22 Jul 7:15 pm AEST')
+  })
+
+  it('14. idempotent: f(f(x)) === f(x) for every representative fixture', () => {
+    const fixtures = [
+      'closed tomorrow (Thu 23 Jul)',
+      'window opens 2026-07-23T09:15:00Z',
+      'cutoff 14:00 UTC',
+      'meeting today (Wed 23 Jul)',
+      'plain prose with no temporal content at all',
+      'see [log](https://x/2026-07-23T09:15:00Z)',
+    ]
+    for (const f of fixtures) {
+      const once = normalizeTemporal(f, TZ, NOW_THU_23_JUL)
+      const twice = normalizeTemporal(once, TZ, NOW_THU_23_JUL)
+      expect(twice).toBe(once)
+    }
+  })
+
+  it('15. invalid tz — no-op, never throws (both passes)', () => {
+    const src = 'closed tomorrow (Thu 23 Jul), at 2026-07-23T09:15:00Z'
+    expect(() => normalizeTemporal(src, 'Not/AZone', NOW_THU_23_JUL)).not.toThrow()
+    expect(normalizeTemporal(src, 'Not/AZone', NOW_THU_23_JUL)).toBe(src)
+  })
+
+  it('empty / whitespace input is returned unchanged', () => {
+    expect(normalizeTemporal('', TZ, NOW_THU_23_JUL)).toBe('')
+    expect(normalizeUtcDatetimes('', TZ, NOW_THU_23_JUL)).toBe('')
+    expect(normalizeRelativeDays('', TZ, NOW_THU_23_JUL)).toBe('')
+  })
+
+  it('reproduces the cron/mail-watcher incident end-to-end', () => {
+    // The exact shape of the reported cron notification.
+    const incident = 'Heads up: the office is closed tomorrow (Thu 23 Jul).'
+    const out = normalizeTemporal(incident, TZ, NOW_THU_23_JUL)
+    expect(out).toBe('Heads up: the office is closed today (Thu 23 Jul).')
+  })
+})

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -287,7 +287,7 @@ describe('#2798 turn-flush punctuation/bold parity with reply', () => {
     // #2996 P2: the reply orchestration itself now lives in the module
     // (`sendReply`); the delegation line is pinned there.
     const replyDelegates = moduleSrc.indexOf(
-      `normalizeOutboundBody(rawText, 'reply', redactOutboundText)`,
+      `normalizeOutboundBody(rawText, 'reply', redactOutboundText`,
       moduleSrc.indexOf('export async function sendReply('),
     )
     expect(replyDelegates).toBeGreaterThan(0)


### PR DESCRIPTION
## Outbound temporal normalization (#3501 pt 2)

Rewrites machine timestamps in outbound Telegram text into the user's local timezone with relative-day phrasing (e.g. `2026-01-15T09:15:00Z` → `Thu 15 Jan 8:15 pm AEDT`, and a same-local-day time gets "today"/"tomorrow"/"yesterday" corrected against the real send moment).

**Supersedes the auto-closed #3504.** Same reviewed content — #3504 was auto-closed when its stacked base branch `feat/3501-outbound-normalize-consolidation` (#3503) was deleted on merge, and GitHub won't reopen it. This is a clean rebase of the identical work onto current `main` after #3502 (durable outbox) and #3503 (shared outbound-normalize seam) landed.

### What changed
- New pure module `telegram-plugin/temporal-normalize.ts` (Intl/tz-based, deterministic — `nowMs` + `tz` injected, never reads clock/env).
- Hooked into the shared `normalizeOutboundBody` seam: temporal fires only when both `tz` and `nowMs` are supplied, so #3503 callers that don't pass them are byte-for-byte unchanged and literal edits never run temporal.
- Wired at the reply / edit_message / turn_flush send sites, ordered **after** bold/punctuation normalization and **before** the voice scrub (so a freshly-rendered `Thu 23 Jul 7:15 pm AEST` isn't mangled by the em/en-dash scrub).
- Does not touch #3502's outbox journaling/dedup logic.

### Rebase note
`git rebase --onto origin/main <#3503-seam-commit> feat/3501-temporal-normalize` replayed only the single temporal commit; it applied with **zero conflicts** (main's squash-merge of #3503 carries byte-identical seam content, and #3502 already sat beneath #3503 in the original stack). The rebased diff is content-identical to the reviewed `f42c21a7`.

### Verification
- Adversarial review: RELEASE-READY, no must-fix (DST, midnight boundaries, over-eager matching, determinism, seam/stacking all verified).
- Scoped tests: 194 passed across the 4 touched test files (temporal 33, outbound-send-path 80, turn-flush 68, redact 13).
- Merged-feature regression: outbox delivery + normalize-seam tests pass (143).
- `npm run lint` green; gateway line ratchet intact.