### PR TITLE
chore: bump Claude Code CLI 2.1.216 → 2.1.218 (+ preserve nested-subagent depth)

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.216
+ARG CLAUDE_CODE_VERSION=2.1.218
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -51,7 +51,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.216
+ARG CLAUDE_CODE_VERSION=2.1.218
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 

--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -69,6 +69,11 @@ fi
 export SWITCHROOM_AGENT_NAME="$CRON_NAME"
 export CLAUDE_CONFIG_DIR="$CRON_CONFIG_DIR"
 
+# Preserve pre-2.1.217 nested sub-agent behaviour for cron-fired sessions too.
+# Normally inherited from start.sh's env; set here as a belt-and-braces default
+# (honouring any value already in the env). See start.sh.hbs for rationale.
+export CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH="${CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH:-2}"
+
 # Defer the (now full) MCP schema set via tool-search so the cron session keeps
 # its low-context cost — the heavy servers load on demand; switchroom-telegram
 # + hindsight stay alwaysLoad. Normally inherited from start.sh's env; set here

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -532,6 +532,17 @@ export CLAUDE_CONFIG_DIR="{{agentDir}}/.claude"
 # Claude reads .credentials.json directly; the broker is the sole writer
 # of that file and updates it before claude's own refresh window opens.
 unset CLAUDE_CODE_OAUTH_TOKEN
+# Claude Code 2.1.217 turned NESTED sub-agent spawning OFF by default: a
+# sub-agent can no longer spawn its own sub-agent unless this env is set.
+# The fleet relies on multi-level worker delegation (the main session
+# dispatches @worker/@researcher, and a dispatched worker may in turn fan
+# out its own sub-agents), so we restore the pre-2.1.217 behaviour. Depth 2
+# = main → sub-agent → grandchild, which covers the one extra level the
+# fleet actually uses; there is no evidence of deeper nesting, so we don't
+# raise it further. (The companion 2.1.217 change — CLAUDE_CODE_MAX_
+# CONCURRENT_SUBAGENTS defaulting to 20 — is already compatible: our fleet
+# self-caps at 15 parallel sub-agents, so the 20 default is left untouched.)
+export CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH="${CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH:-2}"
 export TELEGRAM_STATE_DIR="{{agentDir}}/telegram"
 # SWITCHROOM_AGENT_NAME is the canonical "which agent am I" identifier the
 # telegram-plugin reads to detect self-restart commands. We can't rely on


### PR DESCRIPTION
## What

Bumps the pinned Claude Code CLI across the fleet, **2.1.216 → 2.1.218**, in lockstep between the base and hindsight images (#1978), and neutralizes two sub-agent default changes 2.1.217 introduced so fleet behaviour is preserved.

### Version bumps (lockstep)
- `docker/Dockerfile.base` — `ARG CLAUDE_CODE_VERSION` `2.1.216 → 2.1.218`
- `docker/Dockerfile.hindsight` — same ARG, lockstep (the base/hindsight bundle must stay identical or memory reflection can regress on the thinking-block class of failures — #1978)

Stray-pin sweep across `docker/ .github/ profiles/ scripts/ bin/ src/`: only the two Dockerfile ARGs held `2.1.216`. Remaining hits are historical `CHANGELOG.md` entries (left untouched). No CI/workflow or docs pin exists.

## Why (2.1.217 + 2.1.218)
Stability fixes relevant to us:
- phantom-turn teardown race
- resume-crash-on-malformed-attachment
- runaway context-overflow retry loop
- heartbeat-after-worker-replaced
- long-session memory leak

## Behaviour changes neutralized (2.1.217)
2.1.217 changed two sub-agent defaults:

1. **Nested sub-agents now OFF by default** — a sub-agent can't spawn its own sub-agent unless `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` is set. The fleet uses multi-level worker delegation (main → `@worker`/`@researcher`, and a dispatched worker may fan out its own sub-agents), so this PR exports `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=2` in the agent runtime env:
   - `profiles/_base/start.sh.hbs` inner pass (where the agent's claude process env is assembled, next to `CLAUDE_CONFIG_DIR`) — inherited by every Agent-tool sub-agent.
   - `profiles/_base/cron-session.sh.hbs` belt-and-braces default (cron Tier-1 sessions can also dispatch sub-agents; matches that file's existing "normally inherited, set as default" pattern).
   - **Depth = 2**: main → worker → grandchild — the one nesting level the fleet actually uses. No evidence of deeper (3+) nesting in CLAUDE.md/docs/config. Both use `${VAR:-2}` so an operator override wins.

2. **Concurrent sub-agents capped at 20 by default** (`CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS`) — the fleet self-caps at **15** parallel sub-agents (CLAUDE.md), so the 20 default is compatible. **Not set / not lowered**; documented in the start.sh comment.

## Validation (scoped — CI is full-suite authority; it path-triggers the image builds)
- `npm run lint` → green
- Scaffold render tests (`scaffold.regenerate-start-sh`, `cheap-cron-session-render`, `claude-cli-contract`) → 29 passed / 1 skipped; template edits don't break scaffold snapshots.
- `docker build --check` unavailable in the dev sandbox (buildkit); ARG wiring verified by grep. CI builds the images.

Do not merge yet — folding into the consolidated release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)