### PR TITLE
fix(rollout): count real completions in the "N/M rolled" card footer

### DIFF
--- a/src/host-control/rollout-narrator.test.ts
+++ b/src/host-control/rollout-narrator.test.ts
@@ -170,6 +170,43 @@ describe("LogTailRolloutNarrator", () => {
     expect(final).not.toContain("switchroom webd install");
   });
 
+  it("footer 'N/M rolled' tracks real completions while entry.rolled is still empty mid-roll", async () => {
+    // REGRESSION (#2726): hostd only parses the child's result sentinel into
+    // `entry.rolled` AFTER the whole subprocess exits, so every in-flight phase
+    // reads `entry.rolled === undefined/[]`. The footer used to read that empty
+    // list directly and froze at "0/M rolled" for the entire roll even as the
+    // per-agent checklist showed agents ✓ done. The count must instead derive
+    // from the accumulated checklist. entry.rolled is DELIBERATELY never set
+    // here — that mirrors the live hostd path during the roll.
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry(); // entry.rolled stays undefined the whole time.
+
+    n.onPhase(entry, phase("apply"));
+    await vi.runAllTimersAsync();
+
+    // Canary passes — one agent is now rolled.
+    n.onPhase(entry, phase("canary-start", { agent: "test-harness", n: 1, m: 3 }));
+    n.onPhase(entry, phase("canary-pass", { agent: "test-harness", n: 1, m: 3 }));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(entry.rolled).toBeUndefined(); // hostd hasn't parsed the sentinel yet.
+    expect(relay.edits.at(-1)!.text).toContain("1/3 rolled"); // was "0/3".
+
+    // Second agent completes — footer advances to 2/3.
+    n.onPhase(entry, phase("agent-start", { agent: "clerk", n: 2, m: 3 }));
+    n.onPhase(entry, phase("agent-done", { agent: "clerk", n: 2, m: 3 }));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(relay.edits.at(-1)!.text).toContain("2/3 rolled");
+
+    // A still-running agent does NOT count until its -done phase lands.
+    n.onPhase(entry, phase("agent-start", { agent: "marko", n: 3, m: 3 }));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(relay.edits.at(-1)!.text).toContain("2/3 rolled");
+    n.onPhase(entry, phase("agent-done", { agent: "marko", n: 3, m: 3 }));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(relay.edits.at(-1)!.text).toContain("3/3 rolled");
+  });
+
   it("marks the failed agent ✗ on a terminal error", async () => {
     const relay = makeRelay(100);
     const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });

--- a/src/host-control/rollout-narrator.ts
+++ b/src/host-control/rollout-narrator.ts
@@ -269,6 +269,21 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
       // Fold the phase into the per-agent checklist (✓/⏳/·/✗ + durations).
       this.trackAgentProgress(st, phase);
 
+      // #2726 fix — during the roll, `entry.rolled` is still empty: hostd only
+      // parses the child's result sentinel into `entry.rolled` AFTER the whole
+      // subprocess exits (server.ts spawnRollout `.then()`), so an in-flight
+      // phase always reads `[]` there and the footer froze at "0/M rolled".
+      // The per-agent checklist we already accumulate (`st.agents`) is the
+      // authoritative live source: an agent flips to "done" the moment its
+      // agent-done / canary-pass phase lands. Derive the rolled list from it so
+      // the footer count tracks real completions; fall back to the terminal
+      // `entry.rolled` only when it's actually populated.
+      const doneNames = st.agents
+        .filter((a) => a.status === "done")
+        .map((a) => a.name);
+      const rolledSoFar =
+        entry.rolled && entry.rolled.length > 0 ? entry.rolled : doneNames;
+
       // Rebuild the render state from this phase (pull-shaped: each phase is a
       // projection of the latest durable row hostd just wrote).
       st.render = {
@@ -278,7 +293,7 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         ...(phase.n !== undefined ? { n: phase.n } : {}),
         ...(phase.m !== undefined ? { m: phase.m } : {}),
         ...(phase.agent !== undefined ? { agent: phase.agent } : {}),
-        rolled: entry.rolled,
+        rolled: rolledSoFar,
         agents: st.agents,
         requestId: entry.request_id,
         ...(entry.prior_pin ? { fromVersion: entry.prior_pin } : {}),


### PR DESCRIPTION
## Problem

The fleet rollout progress card in Telegram always showed **"0/12 rolled"** for the entire roll, even though agents were actually being upgraded. Confirmed by Ken during the v0.19.13 roll: card said "0/12 rolled" while `docker exec <agent> claude --version` showed agents already on 2.1.218.

## Root cause

`src/host-control/rollout-narrator.ts` — the per-phase render pulled the footer count from `entry.rolled`:

```ts
rolled: entry.rolled,
```

But hostd only parses the child's result sentinel into `entry.rolled` **after** the rollout subprocess exits (`src/host-control/server.ts` `spawnRollout` `.then()` at ~L3615). So every in-flight phase reads an empty list, and the footer `${rolledCount}/${s.m} rolled` (`render-rollout-status.ts:256`) froze at `0/M` until the terminal edit.

The per-agent checklist (✓/⏳/·) was correct throughout because it reads the accumulated `st.agents`, not `entry.rolled` — which is why the checklist showed progress while the footer didn't.

## Fix

Derive the in-flight rolled list from the accumulated per-agent checklist (agents flip to `done` as their `agent-done` / `canary-pass` phase lands), falling back to `entry.rolled` only when it's populated (terminal). Deterministic — reads the same live checklist state the ✓ glyphs already use.

**Display-only. No change to rollout behavior** — nothing about which agents roll, in what order, or the durable audit rows is touched.

## Test

Added a regression test that leaves `entry.rolled` empty (mirroring live hostd mid-roll) and asserts the footer advances `1/3 → 2/3 → 3/3` as agents complete, and that a still-running agent doesn't count until its `-done` phase. The prior checklist test masked the bug by manually setting `entry.rolled`.

Verified the test FAILS on old code (`expected … to contain '1/3 rolled'`) and passes with the fix.

## Checks

- `npx vitest run src/host-control/rollout-narrator.test.ts` — 14 passed
- `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)