### PR TITLE
fix(telegram): route reply-then-recap capture through single-writer election (#3510)

### DIFF
--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -1805,7 +1805,7 @@ export async function sendReply(
           // text differs. Gated so an interim-ack edit never journals the turn
           // nonce (which would suppress a later genuine answer for the turn).
           if (isFinalAnswerReply({ text: decision.mergedText, disableNotification: modelDisableNotification })) {
-            journalExternalDelivery({ turnNonce: turn?.turnId ?? null, text: decision.mergedText, tgMessageId: decision.messageId })
+            journalExternalDelivery({ turnNonce: turn?.turnId ?? null, text: decision.mergedText, tgMessageId: decision.messageId, replyAlreadyDeliveredThisTurn: true })
           }
 
           silentAnchorEditDone = true
@@ -2372,7 +2372,7 @@ export async function sendReply(
     // won't double-post it) while an interim ack never journals (so a later
     // genuinely-undelivered final answer is delivered by the sweep).
     if (shouldJournalReplySiteDelivery({ text: rawText, disableNotification: modelDisableNotification })) {
-      journalExternalDelivery({ turnNonce: t?.turnId ?? null, text, tgMessageId: sentIds[sentIds.length - 1] })
+      journalExternalDelivery({ turnNonce: t?.turnId ?? null, text, tgMessageId: sentIds[sentIds.length - 1], replyAlreadyDeliveredThisTurn: true })
     }
   }
   return { content: [{ type: 'text', text: result }] }

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -2483,7 +2483,13 @@ export async function deliverCapturedProse(
       outboundDedup.record(chatId, threadId, text, now, registryKey)
       // F1: captured-prose delivery journals + clears under the shared nonce
       // (`originTurnId` === turn.turnId === deriveTurnId, the hook's nonce).
-      journalExternalDelivery({ turnNonce: originTurnId, text, tgMessageId: sentIds[sentIds.length - 1] })
+      // #3510/#3511: the bridge only runs when NO genuine final answer was
+      // delivered this turn (`decideTurnEndGate` → 'reprompt' requires
+      // `finalAnswerDelivered === false`), so stamp `false` explicitly. A
+      // journal line from this site following a reply-tool line under the same
+      // nonce (replyAlreadyDeliveredThisTurn:true) is direct, journal-only
+      // proof of a bridge double-send.
+      journalExternalDelivery({ turnNonce: originTurnId, text, tgMessageId: sentIds[sentIds.length - 1], replyAlreadyDeliveredThisTurn: false })
       process.stderr.write(
         `telegram gateway: captured-prose delivery — sent ${out.length} chars recovered from ` +
           `transcript scan (chat=${chatId} origin=${originTurnId})\n`,

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -133,7 +133,13 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
         // exactly-once, independent of cache lifetime and surviving a restart
         // (the record is gone from disk, the nonce is durably journaled).
         appendDelivered(
-          { turnNonce: record.turnNonce, textSha256: record.textSha256, ts: now },
+          {
+            turnNonce: record.turnNonce,
+            textSha256: record.textSha256,
+            ts: now,
+            deliverySource: 'sweep',
+            replyAlreadyDeliveredThisTurn: record.replyAlreadyDeliveredThisTurn === true,
+          },
           deps.stateDir,
         )
         clearOutboxRecord(record.turnNonce, deps.stateDir)
@@ -156,7 +162,18 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
         decision.text ?? record.text,
       )
       appendDelivered(
-        { turnNonce: record.turnNonce, textSha256: record.textSha256, tgMessageId: messageId, ts: now },
+        {
+          turnNonce: record.turnNonce,
+          textSha256: record.textSha256,
+          tgMessageId: messageId,
+          ts: now,
+          // #3510 instrumentation: a sweep delivery journals its machine and the
+          // record's capture-time reply-already-delivered flag, so a duplicate
+          // (deliverySource:'sweep' after a reply-tool delivery of the same
+          // turn) is provable from the journal alone.
+          deliverySource: 'sweep',
+          replyAlreadyDeliveredThisTurn: record.replyAlreadyDeliveredThisTurn === true,
+        },
         deps.stateDir,
       )
       removeClaimed(record.turnNonce, deps.stateDir)
@@ -266,14 +283,35 @@ export function startOutboxSweep(deps: {
  * Best-effort; never throws. A null/empty nonce is ignored (nothing to journal).
  */
 export function journalExternalDelivery(
-  args: { turnNonce: string | null; text: string; tgMessageId?: number },
+  args: {
+    turnNonce: string | null
+    text: string
+    tgMessageId?: number
+    /**
+     * #3510 instrumentation: whether a qualifying reply had already delivered
+     * this turn at the time of this delivery. Reply-send sites pass `true`
+     * (they ARE that delivery); the captured-prose bridge omits it (its turn
+     * shape is decided upstream). Journaled so a later sweep entry under the
+     * same nonce is provably a double-send from the journal alone.
+     */
+    replyAlreadyDeliveredThisTurn?: boolean
+  },
   stateDir?: string,
   now: number = Date.now(),
 ): void {
   const nonce = args.turnNonce
   if (nonce == null || nonce === '') return
   appendDelivered(
-    { turnNonce: nonce, textSha256: sha256Hex(args.text), tgMessageId: args.tgMessageId, ts: now },
+    {
+      turnNonce: nonce,
+      textSha256: sha256Hex(args.text),
+      tgMessageId: args.tgMessageId,
+      ts: now,
+      deliverySource: 'reply-tool',
+      ...(args.replyAlreadyDeliveredThisTurn == null
+        ? {}
+        : { replyAlreadyDeliveredThisTurn: args.replyAlreadyDeliveredThisTurn }),
+    },
     stateDir,
   )
   clearOutboxRecord(nonce, stateDir)

--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -182,6 +182,11 @@ function writeOutboxRecord(stateDir, capture) {
       // F2: per-session origin chat for envelope-less routing (fail-closed).
       originChatId: capture.chatId == null ? (capture.originChatId ?? null) : undefined,
       originThreadId: capture.chatId == null ? (capture.originThreadId ?? null) : undefined,
+      // #3510 instrumentation: carried into every delivered.jsonl entry the
+      // sweep writes for this record, so a double-send is provable from the
+      // journal alone. Driven by the SAME boolean that gates capture-vs-election
+      // in main() — fix and telemetry cannot drift.
+      replyAlreadyDeliveredThisTurn: capture.replyAlreadyDeliveredThisTurn === true,
     }
     const tmpPath = join(outboxDir, `.${capture.turnNonce}.${process.pid}.tmp`)
     writeFileSync(tmpPath, JSON.stringify(record), 'utf8')
@@ -242,13 +247,34 @@ function main() {
   if (process.env.SWITCHROOM_TG_OUTBOX_DELIVERY !== '0') try {
     const capture = scanForOutboxCapture(jsonl)
     if (capture.capture === true) {
-      writeOutboxRecord(stateDir, capture)
-      process.stderr.write(
-        `[silent-end-interrupt] captured undelivered final answer to outbox ` +
-          `(nonce=${capture.turnNonce} source=${capture.source} chars=${capture.text.length}) — ` +
-          `sweep will deliver; allowing stop\n`,
-      )
-      process.exit(0)
+      if (capture.replyAlreadyDeliveredThisTurn === true) {
+        // #3510: a qualifying reply ALREADY delivered through the gateway this
+        // turn, so a gateway anchor provably exists and the single-writer
+        // election below ('trailing-text-after-reply') is reachable. Writing an
+        // outbox record + self-exiting here would create a third, uncoordinated
+        // delivery path that bypasses the #3469 election and re-sends a
+        // trailing recap of the reply as a second (unformatted) message. Do NOT
+        // capture; fall through so the election is the actual single writer.
+        // The gateway-blind backstop (#3502) is untouched: it is the
+        // replyAlreadyDeliveredThisTurn === false branch below.
+        // Log both hashes so a double-send is provable from logs alone.
+        process.stderr.write(
+          `[silent-end-interrupt] capture found trailing prose after a delivered reply ` +
+            `(nonce=${capture.turnNonce} source=${capture.source} chars=${capture.text.length} ` +
+            `replyAlreadyDeliveredThisTurn=true ` +
+            `capturedTextSha256=${createHash('sha256').update(capture.text, 'utf8').digest('hex')} ` +
+            `deliveredReplySha256=${capture.deliveredReplySha256 ?? 'unknown'}) — ` +
+            `deferring to single-writer election (#3510)\n`,
+        )
+      } else {
+        writeOutboxRecord(stateDir, capture)
+        process.stderr.write(
+          `[silent-end-interrupt] captured undelivered final answer to outbox ` +
+            `(nonce=${capture.turnNonce} source=${capture.source} chars=${capture.text.length} ` +
+            `replyAlreadyDeliveredThisTurn=false) — sweep will deliver; allowing stop\n`,
+        )
+        process.exit(0)
+      }
     }
   } catch (err) {
     process.stderr.write(`[silent-end-interrupt] outbox capture error (fail-open): ${err.message}\n`)

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -958,21 +958,35 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
   }
 
   let lastDeliverIdx = -1
+  let lastFinalReplyBlock = null
   for (let i = 0; i < blocks.length; i++) {
-    if (blocks[i].kind === 'deliver') lastDeliverIdx = i
+    if (blocks[i].kind !== 'deliver') continue
+    lastDeliverIdx = i
+    if (blocks[i].reason === 'final-reply') lastFinalReplyBlock = blocks[i]
   }
   // #3510: single source of truth for BOTH the fix's branching and the
-  // instrumentation. When true, a qualifying reply/stream_reply already went
-  // through the gateway THIS turn — so a gateway anchor provably exists and the
-  // single-writer election in the Stop hook is reachable and safe. The caller
+  // instrumentation. When true, a genuine FINAL-ANSWER reply/stream_reply
+  // already went through the gateway THIS turn — so a gateway anchor provably
+  // exists (`turn.finalAnswerDelivered` is set by the SAME `isFinalAnswerReply`
+  // classifier at outbound-send-path.ts ~2293) and the single-writer election
+  // in the Stop hook is reachable and safe. The caller
   // (silent-end-interrupt-stop.mjs) MUST NOT self-exit a capture in that case;
   // doing so creates a third, uncoordinated delivery path that re-sends a
   // trailing recap of the reply as a second message (the #3510 double-send).
-  const replyAlreadyDeliveredThisTurn = lastDeliverIdx !== -1
-  const deliveredBlock = replyAlreadyDeliveredThisTurn ? blocks[lastDeliverIdx] : null
+  //
+  // #3511 review finding 1: ONLY a `'final-reply'` deliver block counts. A
+  // `'silent-marker'` block (reply-tool NO_REPLY / HEARTBEAT_OK) delivered
+  // NOTHING to the user, and the gateway routes such turns to sentinel
+  // suppression (`decideTurnEndGate` → 'silent_end') BEFORE the captured-prose
+  // bridge ever runs — deferring to the election there would orphan the
+  // trailing answer (a drop). A silent marker still advances `lastDeliverIdx`
+  // (the trailing-prose CURSOR — H6 semantics: NO_REPLY intentionally silences
+  // what came BEFORE it), but it must keep the shape on the durable
+  // outbox/sweep path, never route it to the election.
+  const replyAlreadyDeliveredThisTurn = lastFinalReplyBlock != null
   const deliveredReplySha256 =
-    deliveredBlock != null && typeof deliveredBlock.text === 'string'
-      ? createHash('sha256').update(deliveredBlock.text, 'utf8').digest('hex')
+    lastFinalReplyBlock != null && typeof lastFinalReplyBlock.text === 'string'
+      ? createHash('sha256').update(lastFinalReplyBlock.text, 'utf8').digest('hex')
       : null
   const trailing = blocks
     .slice(lastDeliverIdx + 1)

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -894,7 +894,7 @@ function resolveSessionOriginChat(lines) {
  *
  * @param {string} jsonl
  * @param {number} [now]
- * @returns {{ capture: false, reason: string } | { capture: true, text: string, turnNonce: string, chatId: string|null, threadId: number|null, source: string, anchorContent: string }}
+ * @returns {{ capture: false, reason: string } | { capture: true, text: string, turnNonce: string, chatId: string|null, threadId: number|null, source: string, anchorContent: string, replyAlreadyDeliveredThisTurn: boolean, deliveredReplySha256: string|null }}
  */
 export function scanForOutboxCapture(jsonl, now = Date.now()) {
   const lines = jsonl.split('\n')
@@ -948,7 +948,10 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
         disableNotification: input.disable_notification === true,
         done: input.done === true,
       })) {
-        blocks.push({ kind: 'deliver', reason: 'final-reply' })
+        // #3510: keep the delivered reply's text so the caller can log its
+        // sha256 next to the captured trailing prose's sha256 — a double-send
+        // becomes provable from logs alone, without transcript reconstruction.
+        blocks.push({ kind: 'deliver', reason: 'final-reply', text })
       }
       // interim ack — neither delivery nor undelivered prose.
     }
@@ -958,6 +961,19 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
   for (let i = 0; i < blocks.length; i++) {
     if (blocks[i].kind === 'deliver') lastDeliverIdx = i
   }
+  // #3510: single source of truth for BOTH the fix's branching and the
+  // instrumentation. When true, a qualifying reply/stream_reply already went
+  // through the gateway THIS turn — so a gateway anchor provably exists and the
+  // single-writer election in the Stop hook is reachable and safe. The caller
+  // (silent-end-interrupt-stop.mjs) MUST NOT self-exit a capture in that case;
+  // doing so creates a third, uncoordinated delivery path that re-sends a
+  // trailing recap of the reply as a second message (the #3510 double-send).
+  const replyAlreadyDeliveredThisTurn = lastDeliverIdx !== -1
+  const deliveredBlock = replyAlreadyDeliveredThisTurn ? blocks[lastDeliverIdx] : null
+  const deliveredReplySha256 =
+    deliveredBlock != null && typeof deliveredBlock.text === 'string'
+      ? createHash('sha256').update(deliveredBlock.text, 'utf8').digest('hex')
+      : null
   const trailing = blocks
     .slice(lastDeliverIdx + 1)
     .filter((b) => b.kind === 'text' && typeof b.text === 'string' && b.text.length > 0)
@@ -995,5 +1011,7 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
     anchorContent: anchor.anchorContent,
     originChatId: origin.chatId,
     originThreadId: origin.threadId,
+    replyAlreadyDeliveredThisTurn,
+    deliveredReplySha256,
   }
 }

--- a/telegram-plugin/outbox.ts
+++ b/telegram-plugin/outbox.ts
@@ -104,6 +104,15 @@ export interface OutboxRecord {
   originChatId?: string | null
   /** Forum thread of the per-session origin chat (see `originChatId`). */
   originThreadId?: number | null
+  /**
+   * #3510 instrumentation: was a qualifying reply already delivered through
+   * the gateway in the turn that produced this record? Stamped by the Stop
+   * hook from the SAME boolean that gates its capture-vs-election branch.
+   * After #3510 this is always `false` for a written record (a `true` routes
+   * to the single-writer election instead of the outbox), so a `true` here —
+   * or in a sweep journal entry — is direct evidence of a regression.
+   */
+  replyAlreadyDeliveredThisTurn?: boolean
 }
 
 /** One line of the delivered-keys journal (`outbox/delivered.jsonl`). */
@@ -112,6 +121,14 @@ export interface DeliveredEntry {
   textSha256: string
   tgMessageId?: number
   ts: number
+  /**
+   * #3510 instrumentation: which machine delivered — the outbox sweep, or the
+   * gateway reply-path machinery (reply/stream_reply send, silent-anchor edit,
+   * captured-prose bridge). Absent on pre-#3510 journal lines.
+   */
+  deliverySource?: 'sweep' | 'reply-tool'
+  /** #3510 instrumentation: see `OutboxRecord.replyAlreadyDeliveredThisTurn`. */
+  replyAlreadyDeliveredThisTurn?: boolean
 }
 
 export function sha256Hex(s: string): string {

--- a/telegram-plugin/tests/outbox-reply-then-recap-e2e.test.ts
+++ b/telegram-plugin/tests/outbox-reply-then-recap-e2e.test.ts
@@ -1,0 +1,387 @@
+/**
+ * outbox-reply-then-recap-e2e.test.ts — end-to-end regression net for #3510
+ * (Telegram double-send) AND its opposite failure mode (#3502 silent drop),
+ * driven from ONE harness through the real delivery decision path:
+ *
+ *   transcript on disk
+ *     → gateway reply-site simulation (send + conditional journal, mirroring
+ *       `outbound-send-path.ts:2374-2376` — replies go out BEFORE Stop fires)
+ *     → the REAL Stop hook (`hooks/silent-end-interrupt-stop.mjs`), spawned as
+ *       a subprocess exactly as Claude Code runs it
+ *     → the REAL `sweepOutbox` against the real on-disk outbox/journal, ticked
+ *       repeatedly across the OUTBOX_QUIET_MS boundary (age-1 / age / age+1 /
+ *       past the in-memory dedup TTL) to pressure-test the one-tick race
+ *       window rather than a single happy-path tick.
+ *
+ * The oracle is deliberately FUNCTION-AGNOSTIC: assertions are on what the
+ * user observably received — how many messages, with what content, via which
+ * transport (`reply-tool` = the formatted reply; `sweep` = the plain-text
+ * outbox flush). No assertion names an internal decision function; renaming or
+ * refactoring the hook internals cannot green a real double-send or a real
+ * drop.
+ *
+ *   Duplicate direction (#3510): a turn that delivers a reply and then emits a
+ *   trailing prose recap (short / long / paraphrased — byte-exact dedup would
+ *   miss the reworded ones) must yield EXACTLY ONE user-visible message: the
+ *   formatted reply. On pre-fix main the sweep flushed the recap as a second,
+ *   unformatted message.
+ *
+ *   Silence direction (#3502 backstop): a gateway-blind turn (task-notification
+ *   handback, cron, zero-reply channel turn) whose only answer is transcript
+ *   prose must yield EXACTLY ONE delivery — never zero. This pins that the
+ *   #3510 fix did not regress the 2026-07-22 data-loss class.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import {
+  mkdtempSync,
+  writeFileSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  existsSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { createHash } from 'node:crypto'
+
+import { sweepOutbox, journalExternalDelivery } from '../gateway/outbox-sweep.js'
+import { OUTBOX_QUIET_MS, type OutboxRecord, type DeliveredEntry } from '../outbox.js'
+import { shouldJournalReplySiteDelivery } from '../final-answer-detect.js'
+
+const HOOK = resolve(__dirname, '..', 'hooks', 'silent-end-interrupt-stop.mjs')
+const REPLY_TOOL = 'mcp__switchroom-telegram__reply'
+const CHAT = '111'
+const MSG_ID = '42'
+/** The gateway's `deriveTurnId` nonce for the CHAT/MSG_ID envelope. */
+const GATEWAY_NONCE = `${CHAT}:_#${MSG_ID}`
+/** Mirrors the gateway's in-memory `outboundDedup` TTL (~60s). */
+const DEDUP_TTL_MS = 60_000
+
+const sha256 = (s: string) => createHash('sha256').update(s, 'utf8').digest('hex')
+
+interface Delivered {
+  via: 'reply-tool' | 'sweep'
+  text: string
+}
+
+/** Transcript-line builders. */
+const enqueueChannel = (body: string, source = 'telegram', messageId = MSG_ID) => ({
+  type: 'queue-operation',
+  operation: 'enqueue',
+  content: `<channel source="${source}" chat_id="${CHAT}" message_id="${messageId}">${body}</channel>`,
+  timestamp: 1000,
+})
+const enqueueTask = () => ({
+  type: 'queue-operation',
+  operation: 'enqueue',
+  content: '<task-notification><task-id>a7cc7a0fa8f</task-id> worker done</task-notification>',
+  timestamp: 2000,
+})
+const prose = (text: string) => ({
+  type: 'assistant',
+  message: { content: [{ type: 'text', text }] },
+})
+const reply = (text: string, input: Record<string, unknown> = {}) => ({
+  type: 'assistant',
+  message: {
+    content: [{ type: 'tool_use', name: REPLY_TOOL, input: { chat_id: CHAT, text, ...input } }],
+  },
+})
+
+/**
+ * Run one full turn through the real delivery path. Returns everything the
+ * user received, in order, plus the on-disk journal/outbox for forensics.
+ */
+async function runTurn(opts: {
+  dir: string
+  lines: object[]
+  gatewayAlive?: boolean
+  /** register a registry-chain hit for task anchors (default: unresolvable → origin route) */
+  registryHit?: boolean
+}): Promise<{
+  delivered: Delivered[]
+  hookStdout: string
+  hookStderr: string
+  records: OutboxRecord[]
+  journal: DeliveredEntry[]
+}> {
+  const { dir, lines, gatewayAlive = true } = opts
+  const delivered: Delivered[] = []
+
+  // 1. Gateway reply-site simulation — replies are sent (and conditionally
+  //    journaled, same gate as outbound-send-path.ts:2374) BEFORE Stop fires.
+  for (const line of lines) {
+    const content = (line as { message?: { content?: Array<Record<string, unknown>> } }).message?.content
+    if (!Array.isArray(content)) continue
+    for (const c of content) {
+      if (c.type !== 'tool_use' || c.name !== REPLY_TOOL) continue
+      const input = c.input as { text?: string; done?: boolean; disable_notification?: boolean }
+      const text = String(input.text ?? '')
+      if (/^(NO_REPLY|HEARTBEAT_OK)[\s.!?]*$/i.test(text.trim())) continue
+      delivered.push({ via: 'reply-tool', text })
+      if (
+        shouldJournalReplySiteDelivery({
+          text,
+          disableNotification: input.disable_notification === true,
+          done: input.done === true,
+        })
+      ) {
+        journalExternalDelivery(
+          { turnNonce: GATEWAY_NONCE, text, tgMessageId: 1, replyAlreadyDeliveredThisTurn: true },
+          dir,
+        )
+      }
+    }
+  }
+
+  // 2. Gateway liveness heartbeat (fresh unless the case simulates a dead gateway).
+  if (gatewayAlive) writeFileSync(join(dir, 'gateway-heartbeat'), 'hb', 'utf8')
+
+  // 3. The REAL Stop hook, as a subprocess.
+  const transcriptPath = join(dir, 'transcript.jsonl')
+  writeFileSync(transcriptPath, lines.map((l) => JSON.stringify(l)).join('\n'), 'utf8')
+  const hook = spawnSync('node', [HOOK], {
+    input: JSON.stringify({ session_id: 's', transcript_path: transcriptPath }),
+    encoding: 'utf8',
+    timeout: 5000,
+    env: { ...process.env, TELEGRAM_STATE_DIR: dir },
+  })
+  expect(hook.status).toBe(0)
+
+  // 4. The REAL sweep, ticked aggressively across the quiet-window boundary.
+  //    Tick times are anchored on the record's actual createdAt when one
+  //    exists, so the boundary (age === quietMs - 1 / quietMs / quietMs + 1)
+  //    is exercised exactly — an ordering regression is caught, not masked.
+  const recordsBefore = readOutboxRecords(dir)
+  const t0 = recordsBefore.length > 0 ? recordsBefore[0].createdAt : Date.now()
+  const tickTimes = [
+    t0, // age 0 — inside quiet window
+    t0 + OUTBOX_QUIET_MS - 1, // one ms before eligibility
+    t0 + OUTBOX_QUIET_MS, // boundary
+    t0 + OUTBOX_QUIET_MS + 1, // just past
+    t0 + DEDUP_TTL_MS + 1_000, // past the in-memory dedup TTL — journal must hold alone
+  ]
+  const sentLog: Array<{ text: string; at: number }> = []
+  for (const now of tickTimes) {
+    await sweepOutbox({
+      stateDir: dir,
+      now: () => now,
+      send: async (_chatId, _threadId, text) => {
+        delivered.push({ via: 'sweep', text })
+        sentLog.push({ text, at: now })
+        return 500
+      },
+      // Mirrors the gateway's TTL-bounded exact-text `outboundDedup` cache:
+      // anything sent (reply or sweep) within the TTL dedups; older evicts.
+      textAlreadyDelivered: (_chatId, _threadId, text) =>
+        delivered.some(
+          (d) =>
+            d.text === text &&
+            (d.via === 'reply-tool' || sentLog.some((s) => s.text === text && now - s.at < DEDUP_TTL_MS)),
+        ),
+      registryChainLookup: opts.registryHit ? () => ({ chatId: CHAT, threadId: null }) : () => null,
+    })
+  }
+
+  return {
+    delivered,
+    hookStdout: hook.stdout ?? '',
+    hookStderr: hook.stderr ?? '',
+    records: readOutboxRecords(dir),
+    journal: readJournal(dir),
+  }
+}
+
+function readOutboxRecords(dir: string): OutboxRecord[] {
+  const outbox = join(dir, 'outbox')
+  try {
+    return readdirSync(outbox)
+      .filter((f) => f.endsWith('.json') && f !== 'delivered.jsonl' && !f.startsWith('.'))
+      .map((f) => JSON.parse(readFileSync(join(outbox, f), 'utf8')) as OutboxRecord)
+  } catch {
+    return []
+  }
+}
+
+function readJournal(dir: string): DeliveredEntry[] {
+  const p = join(dir, 'outbox', 'delivered.jsonl')
+  if (!existsSync(p)) return []
+  return readFileSync(p, 'utf8')
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l) as DeliveredEntry)
+}
+
+// Reply/recap fixtures. The short reply pings (no disable_notification, no
+// done) → user-visible final answer, but under the 200-char reply-site journal
+// floor — the exact #3510 window (R1 High #1 + #2).
+const SHORT_REPLY = 'Deployed the fix to staging — all 3 checks green. ' + 'Detail: '.padEnd(100, 'x')
+const LONG_REPLY = 'Full answer with plenty of substance. '.padEnd(250, 'y')
+const RECAP_LONG = 'To recap what I just sent: the fix is deployed to staging and all checks are green. '.padEnd(300, 'z')
+const RECAP_PARAPHRASE =
+  'Summary of the work above, in different words than the reply so byte-exact dedup can never match it. '.padEnd(400, 'w')
+const RECAP_SHORT = 'Short recap under the floor.'
+const REAL_ANSWER = 'The actual final answer that never went through a reply tool call. '.padEnd(300, 'a')
+const HANDBACK_ANSWER = 'B'.repeat(1647)
+
+describe('#3510 e2e — reply-then-recap turns yield EXACTLY ONE user-visible message', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'outbox-e2e-'))
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  // Table: every duplicate-direction shape must end with exactly the formatted
+  // reply — never a second sweep flush, whatever the recap's wording/length.
+  const duplicateCases: Array<{ name: string; replyText: string; replyInput?: Record<string, unknown>; recap: string }> = [
+    { name: 'short ping-final reply + long recap', replyText: SHORT_REPLY, recap: RECAP_LONG },
+    { name: 'short ping-final reply + paraphrased recap (defeats byte-exact dedup)', replyText: SHORT_REPLY, recap: RECAP_PARAPHRASE },
+    { name: 'short ping-final reply + short recap (below capture floor)', replyText: SHORT_REPLY, recap: RECAP_SHORT },
+    { name: 'substantive journaled reply + reworded recap', replyText: LONG_REPLY, recap: RECAP_PARAPHRASE },
+    { name: 'done:true reply + long recap', replyText: SHORT_REPLY, replyInput: { done: true }, recap: RECAP_LONG },
+  ]
+
+  for (const c of duplicateCases) {
+    it(c.name, async () => {
+      const r = await runTurn({
+        dir,
+        lines: [enqueueChannel('deploy it'), reply(c.replyText, c.replyInput), prose(c.recap)],
+      })
+      // THE user outcome: one message, it is the reply (formatted transport),
+      // and no sweep flush ever fires for this turn.
+      expect(r.delivered).toEqual([{ via: 'reply-tool', text: c.replyText }])
+      // Durable state agrees: nothing pending for the sweep to resurrect later.
+      expect(r.records).toHaveLength(0)
+    })
+  }
+
+  it('dead gateway: still never a second message (worst case is a re-prompt, not a duplicate)', async () => {
+    const r = await runTurn({
+      dir,
+      lines: [enqueueChannel('deploy it'), reply(SHORT_REPLY), prose(RECAP_LONG)],
+      gatewayAlive: false,
+    })
+    expect(r.delivered).toEqual([{ via: 'reply-tool', text: SHORT_REPLY }])
+    expect(r.records).toHaveLength(0)
+  })
+
+  it('logs both SHAs when deferring, so a double-send is provable from logs alone', async () => {
+    const r = await runTurn({
+      dir,
+      lines: [enqueueChannel('deploy it'), reply(SHORT_REPLY), prose(RECAP_LONG)],
+    })
+    expect(r.hookStderr).toContain('replyAlreadyDeliveredThisTurn=true')
+    expect(r.hookStderr).toContain(`capturedTextSha256=${sha256(RECAP_LONG.trim())}`)
+    expect(r.hookStderr).toContain(`deliveredReplySha256=${sha256(SHORT_REPLY)}`)
+  })
+})
+
+describe('#3502 backstop e2e — gateway-blind turns yield EXACTLY ONE delivery, never zero', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'outbox-e2e-'))
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('task-notification handback with prose-only answer (2026-07-22 incident shape) is delivered once', async () => {
+    const r = await runTurn({
+      dir,
+      // A prior real channel inbound gives the session its origin chat (F2).
+      lines: [enqueueChannel('earlier question', 'telegram', '7'), enqueueTask(), prose(HANDBACK_ANSWER)],
+    })
+    const sweeps = r.delivered.filter((d) => d.via === 'sweep')
+    expect(sweeps).toHaveLength(1)
+    expect(sweeps[0].text).toContain(HANDBACK_ANSWER)
+    expect(r.delivered).toHaveLength(1) // and nothing else — exactly one delivery
+    expect(r.records).toHaveLength(0) // record consumed, not resurrectable
+  })
+
+  it('cron turn ending in prose is delivered once', async () => {
+    const r = await runTurn({
+      dir,
+      lines: [enqueueChannel('digest time', 'cron', '9'), prose(REAL_ANSWER)],
+    })
+    expect(r.delivered).toEqual([{ via: 'sweep', text: REAL_ANSWER.trim() }])
+  })
+
+  it('zero-reply channel turn ending in prose is delivered once', async () => {
+    const r = await runTurn({ dir, lines: [enqueueChannel('question'), prose(REAL_ANSWER)] })
+    expect(r.delivered).toEqual([{ via: 'sweep', text: REAL_ANSWER.trim() }])
+  })
+
+  it('interim ack then a real prose answer: the answer is delivered exactly once (not suppressed by the ack)', async () => {
+    const ack = 'On it — digging in now.'
+    const r = await runTurn({
+      dir,
+      lines: [
+        enqueueChannel('question'),
+        reply(ack, { disable_notification: true }), // interim ack: silent, short, not done
+        prose(REAL_ANSWER),
+      ],
+    })
+    // User sees the ack (sent live) and the recovered answer — once each.
+    expect(r.delivered).toEqual([
+      { via: 'reply-tool', text: ack },
+      { via: 'sweep', text: REAL_ANSWER.trim() },
+    ])
+  })
+
+  it('pure NO_REPLY turn delivers nothing', async () => {
+    const r = await runTurn({ dir, lines: [enqueueChannel('ping'), prose('NO_REPLY')] })
+    expect(r.delivered).toHaveLength(0)
+  })
+})
+
+describe('#3510 instrumentation — the journal alone proves who delivered what', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'outbox-e2e-'))
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('sweep deliveries journal deliverySource=sweep with the record capture-time flag', async () => {
+    const r = await runTurn({
+      dir,
+      lines: [enqueueChannel('question'), prose(REAL_ANSWER)],
+    })
+    const sweepEntries = r.journal.filter((e) => e.deliverySource === 'sweep')
+    expect(sweepEntries).toHaveLength(1)
+    expect(sweepEntries[0].replyAlreadyDeliveredThisTurn).toBe(false)
+    expect(sweepEntries[0].textSha256).toBe(sha256(REAL_ANSWER.trim()))
+  })
+
+  it('reply-site deliveries journal deliverySource=reply-tool with replyAlreadyDeliveredThisTurn=true', async () => {
+    const r = await runTurn({
+      dir,
+      lines: [enqueueChannel('question'), reply(LONG_REPLY), prose(RECAP_PARAPHRASE)],
+    })
+    const replyEntries = r.journal.filter((e) => e.deliverySource === 'reply-tool')
+    expect(replyEntries).toHaveLength(1)
+    expect(replyEntries[0].replyAlreadyDeliveredThisTurn).toBe(true)
+    expect(replyEntries[0].textSha256).toBe(sha256(LONG_REPLY))
+    // And no sweep entry exists for the turn — one writer, one journal line.
+    expect(r.journal.filter((e) => e.deliverySource === 'sweep')).toHaveLength(0)
+  })
+
+  it('a captured (gateway-blind) record carries replyAlreadyDeliveredThisTurn=false on disk', async () => {
+    // Run only the hook (no sweep) so the record is observable before delivery.
+    const transcriptPath = join(dir, 'transcript.jsonl')
+    writeFileSync(
+      transcriptPath,
+      [enqueueTask(), prose(HANDBACK_ANSWER)].map((l) => JSON.stringify(l)).join('\n'),
+      'utf8',
+    )
+    const hook = spawnSync('node', [HOOK], {
+      input: JSON.stringify({ session_id: 's', transcript_path: transcriptPath }),
+      encoding: 'utf8',
+      timeout: 5000,
+      env: { ...process.env, TELEGRAM_STATE_DIR: dir },
+    })
+    expect(hook.status).toBe(0)
+    const records = readOutboxRecords(dir)
+    expect(records).toHaveLength(1)
+    expect(records[0].replyAlreadyDeliveredThisTurn).toBe(false)
+  })
+})

--- a/telegram-plugin/tests/outbox-reply-then-recap-e2e.test.ts
+++ b/telegram-plugin/tests/outbox-reply-then-recap-e2e.test.ts
@@ -48,7 +48,11 @@ import { createHash } from 'node:crypto'
 
 import { sweepOutbox, journalExternalDelivery } from '../gateway/outbox-sweep.js'
 import { OUTBOX_QUIET_MS, type OutboxRecord, type DeliveredEntry } from '../outbox.js'
-import { shouldJournalReplySiteDelivery } from '../final-answer-detect.js'
+import { shouldJournalReplySiteDelivery, isFinalAnswerReply } from '../final-answer-detect.js'
+import { decideTurnEndGate } from '../gateway/turn-end-gate.js'
+import { deliverCapturedProse, type DeliverCapturedProseDeps } from '../gateway/outbound-send-path.js'
+import { OutboundDedupCache } from '../recent-outbound-dedup.js'
+import type { FlushDecision } from '../turn-flush-safety.js'
 
 const HOOK = resolve(__dirname, '..', 'hooks', 'silent-end-interrupt-stop.mjs')
 const REPLY_TOOL = 'mcp__switchroom-telegram__reply'
@@ -62,7 +66,7 @@ const DEDUP_TTL_MS = 60_000
 const sha256 = (s: string) => createHash('sha256').update(s, 'utf8').digest('hex')
 
 interface Delivered {
-  via: 'reply-tool' | 'sweep'
+  via: 'reply-tool' | 'sweep' | 'bridge'
   text: string
 }
 
@@ -149,6 +153,99 @@ async function runTurn(opts: {
     env: { ...process.env, TELEGRAM_STATE_DIR: dir },
   })
   expect(hook.status).toBe(0)
+
+  // 3.5 Gateway turn-end — the REAL gate + the REAL captured-prose bridge
+  //     (#3511 review finding 2). `finalAnswerDelivered` is computed with the
+  //     REAL `isFinalAnswerReply` classifier at the reply site — the exact code
+  //     the gateway runs at outbound-send-path.ts ~2293 — and the disposition
+  //     comes from the REAL `decideTurnEndGate`. When (and only when) the gate
+  //     says 'reprompt' and the hook persisted `pendingText`, the REAL
+  //     `deliverCapturedProse` runs against the same state dir/journal. This
+  //     makes the load-bearing `isFinalAnswerReply` ⇔ `finalAnswerDelivered`
+  //     agreement an asserted outcome: if the hook defers a shape the gateway
+  //     does not consider delivered (or vice versa), the bridge fires and the
+  //     exactly-one-message assertions go red.
+  //     Only simulated for reply-called turns — a gateway-blind turn (no
+  //     CurrentTurn) has no turn_end at all, which is the whole point of the
+  //     outbox path.
+  const replyInputs: Array<{ text: string; done: boolean; disableNotification: boolean }> = []
+  for (const line of lines) {
+    const content = (line as { message?: { content?: Array<Record<string, unknown>> } }).message?.content
+    if (!Array.isArray(content)) continue
+    for (const c of content) {
+      if (c.type !== 'tool_use' || c.name !== REPLY_TOOL) continue
+      const input = c.input as { text?: string; done?: boolean; disable_notification?: boolean }
+      replyInputs.push({
+        text: String(input.text ?? ''),
+        done: input.done === true,
+        disableNotification: input.disable_notification === true,
+      })
+    }
+  }
+  const isSentinel = (t: string) => /^(NO_REPLY|HEARTBEAT_OK)[\s.!?]*$/i.test(t.trim())
+  const nonSentinelReplies = replyInputs.filter((r) => !isSentinel(r.text))
+  if (replyInputs.length > 0) {
+    // Same classifier + same site semantics as outbound-send-path.ts ~2293.
+    const finalAnswerDelivered = nonSentinelReplies.some((r) =>
+      isFinalAnswerReply({ text: r.text, disableNotification: r.disableNotification, done: r.done }),
+    )
+    // Sentinel-only turns take the gateway's sentinel-suppression path and
+    // return before the bridge (stream-render.ts ~1977 comment; verified live
+    // in the #3511 review). Reply-called turns take the 'reply-called' skip.
+    const flushDecision: FlushDecision =
+      nonSentinelReplies.length === 0
+        ? { kind: 'skip', reason: 'silent-marker' }
+        : { kind: 'skip', reason: 'reply-called' }
+    const gate = decideTurnEndGate({ flushDecision, finalAnswerDelivered })
+    if (gate === 'reprompt') {
+      const statePath = join(dir, 'silent-end-pending.json')
+      const pendingText = existsSync(statePath)
+        ? (JSON.parse(readFileSync(statePath, 'utf8')) as { pendingText?: string }).pendingText
+        : undefined
+      if (typeof pendingText === 'string' && pendingText.length > 0) {
+        // The gateway's silent-end machinery hands pendingText to the REAL bridge.
+        const dedup = new OutboundDedupCache()
+        for (const r of nonSentinelReplies) dedup.record(CHAT, undefined, r.text, Date.now(), null)
+        const bridgeDeps: DeliverCapturedProseDeps = {
+          outboundDedup: dedup,
+          bot: {
+            api: {
+              sendRichMessage: async (_chatId: string, rich: { markdown?: string }, _opts: object) => {
+                delivered.push({ via: 'bridge', text: rich.markdown ?? '' })
+                return { message_id: 2000 }
+              },
+            },
+          } as unknown as DeliverCapturedProseDeps['bot'],
+          robustApiCall: (fn) => fn(),
+          redactOutboundText: (text) => text,
+          recordOutbound: () => {},
+          HISTORY_ENABLED: false,
+          OBLIGATION_LEDGER_ENABLED: false,
+          obligationLedger: { close: () => {} },
+          clearSilentEndState: () => {},
+          recordUndeliveredTurnEnd: () => ({ exhausted: false }),
+          hasOutboundDeliveredSince: () => false,
+        }
+        // deliverCapturedProse journals via TELEGRAM_STATE_DIR — point it at
+        // this test's isolated state dir for the duration of the call.
+        const prevStateDir = process.env.TELEGRAM_STATE_DIR
+        process.env.TELEGRAM_STATE_DIR = dir
+        try {
+          await deliverCapturedProse(bridgeDeps, {
+            chatId: CHAT,
+            threadId: undefined,
+            statusKeyStr: `${CHAT}:main`,
+            registryKey: null,
+            originTurnId: GATEWAY_NONCE,
+            text: pendingText,
+          })
+        } finally {
+          if (prevStateDir == null) delete process.env.TELEGRAM_STATE_DIR
+          else process.env.TELEGRAM_STATE_DIR = prevStateDir
+        }
+      }
+    }
+  }
 
   // 4. The REAL sweep, ticked aggressively across the quiet-window boundary.
   //    Tick times are anchored on the record's actual createdAt when one
@@ -332,6 +429,80 @@ describe('#3502 backstop e2e — gateway-blind turns yield EXACTLY ONE delivery,
     const r = await runTurn({ dir, lines: [enqueueChannel('ping'), prose('NO_REPLY')] })
     expect(r.delivered).toHaveLength(0)
   })
+
+  it('reply-tool NO_REPLY then a substantive prose answer: the answer is delivered exactly once (#3511 finding 1)', async () => {
+    // The silence regression the #3511 review caught: a `reply("NO_REPLY")`
+    // delivered NOTHING to the user, and the gateway suppresses sentinel turns
+    // BEFORE the bridge can run — so if the hook treats the sentinel as
+    // "reply already delivered" and defers to the election, the trailing
+    // answer is orphaned and DROPPED. The discriminator must count only
+    // genuine final-reply deliveries, keeping this shape on the durable
+    // outbox/sweep path.
+    const r = await runTurn({
+      dir,
+      lines: [enqueueChannel('question'), reply('NO_REPLY'), prose(REAL_ANSWER)],
+    })
+    expect(r.delivered).toEqual([{ via: 'sweep', text: REAL_ANSWER.trim() }])
+    // Durable path was used: the record existed and was consumed, not elected.
+    expect(r.journal.filter((e) => e.deliverySource === 'sweep')).toHaveLength(1)
+    expect(r.journal[r.journal.length - 1].replyAlreadyDeliveredThisTurn).toBe(false)
+  })
+
+  it('reply-tool NO_REPLY then prose survives a dead gateway (outbox is gateway-liveness-independent)', async () => {
+    // The old capture path's durability property must hold for this shape:
+    // no heartbeat, no election — the record is still written and swept.
+    const r = await runTurn({
+      dir,
+      lines: [enqueueChannel('question'), reply('NO_REPLY'), prose(REAL_ANSWER)],
+      gatewayAlive: false,
+    })
+    expect(r.delivered).toEqual([{ via: 'sweep', text: REAL_ANSWER.trim() }])
+  })
+})
+
+describe('#3511 finding 2 — the gateway BRIDGE path agrees with the hook (paraphrase safe end to end)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'outbox-e2e-'))
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('genuine reply + paraphrased recap: pendingText IS persisted for the bridge, yet the bridge never fires — exactly one message', async () => {
+    // The load-bearing invariant: the hook's fall-through classifier
+    // (isFinalAnswerReply on the deliver block) and the gateway's bridge gate
+    // (turn.finalAnswerDelivered, set by the SAME classifier) must agree. The
+    // harness computes finalAnswerDelivered with the real classifier and runs
+    // the real decideTurnEndGate + real deliverCapturedProse when it says
+    // 'reprompt' — so if either side of the agreement breaks, the paraphrased
+    // recap goes out via the bridge and this goes red with 2 messages.
+    const r = await runTurn({
+      dir,
+      lines: [enqueueChannel('deploy it'), reply(SHORT_REPLY), prose(RECAP_PARAPHRASE)],
+    })
+    // The election really did elect the bridge as the would-be single writer…
+    const state = JSON.parse(readFileSync(join(dir, 'silent-end-pending.json'), 'utf8'))
+    expect(state.pendingText).toBe(RECAP_PARAPHRASE.trim())
+    // …but the gateway's gate (finalAnswerDelivered=true, same classifier)
+    // keeps the bridge off: the user got exactly the formatted reply.
+    expect(r.delivered).toEqual([{ via: 'reply-tool', text: SHORT_REPLY }])
+    expect(r.delivered.filter((d) => d.via === 'bridge')).toHaveLength(0)
+  })
+
+  it('interim ack + real answer: the bridge-eligible turn still yields the answer exactly once', async () => {
+    // Counter-case proving the bridge stage in the harness is live, not inert:
+    // an ack-only turn has finalAnswerDelivered=false (real classifier), the
+    // gate says reprompt — but the hook put the answer on the OUTBOX path
+    // (no pendingText persisted), so the sweep delivers and the bridge stays
+    // quiet. One ack + one answer, no third copy from any machine.
+    const ack = 'On it.'
+    const r = await runTurn({
+      dir,
+      lines: [enqueueChannel('question'), reply(ack, { disable_notification: true }), prose(REAL_ANSWER)],
+    })
+    const answers = r.delivered.filter((d) => d.text.includes(REAL_ANSWER.trim()))
+    expect(answers).toHaveLength(1)
+    expect(answers[0].via).toBe('sweep')
+  })
 })
 
 describe('#3510 instrumentation — the journal alone proves who delivered what', () => {
@@ -363,6 +534,48 @@ describe('#3510 instrumentation — the journal alone proves who delivered what'
     expect(replyEntries[0].textSha256).toBe(sha256(LONG_REPLY))
     // And no sweep entry exists for the turn — one writer, one journal line.
     expect(r.journal.filter((e) => e.deliverySource === 'sweep')).toHaveLength(0)
+  })
+
+  it('a bridge delivery journals replyAlreadyDeliveredThisTurn=false (#3511 finding 3)', async () => {
+    // The bridge only runs when no genuine final answer was delivered
+    // (decideTurnEndGate 'reprompt' requires finalAnswerDelivered === false),
+    // so its journal line must stamp the flag false — making a bridge
+    // double-send after a reply provable from the journal alone.
+    const dedup = new OutboundDedupCache()
+    const deps: DeliverCapturedProseDeps = {
+      outboundDedup: dedup,
+      bot: {
+        api: { sendRichMessage: async () => ({ message_id: 3000 }) },
+      } as unknown as DeliverCapturedProseDeps['bot'],
+      robustApiCall: (fn) => fn(),
+      redactOutboundText: (text) => text,
+      recordOutbound: () => {},
+      HISTORY_ENABLED: false,
+      OBLIGATION_LEDGER_ENABLED: false,
+      obligationLedger: { close: () => {} },
+      clearSilentEndState: () => {},
+      recordUndeliveredTurnEnd: () => ({ exhausted: false }),
+      hasOutboundDeliveredSince: () => false,
+    }
+    const prevStateDir = process.env.TELEGRAM_STATE_DIR
+    process.env.TELEGRAM_STATE_DIR = dir
+    try {
+      await deliverCapturedProse(deps, {
+        chatId: CHAT,
+        threadId: undefined,
+        statusKeyStr: `${CHAT}:main`,
+        registryKey: null,
+        originTurnId: GATEWAY_NONCE,
+        text: REAL_ANSWER,
+      })
+    } finally {
+      if (prevStateDir == null) delete process.env.TELEGRAM_STATE_DIR
+      else process.env.TELEGRAM_STATE_DIR = prevStateDir
+    }
+    const journal = readJournal(dir)
+    expect(journal).toHaveLength(1)
+    expect(journal[0].deliverySource).toBe('reply-tool')
+    expect(journal[0].replyAlreadyDeliveredThisTurn).toBe(false)
   })
 
   it('a captured (gateway-blind) record carries replyAlreadyDeliveredThisTurn=false on disk', async () => {

--- a/telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts
+++ b/telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts
@@ -201,12 +201,18 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
     expect(state.retryCount).toBe(SILENT_END_MAX_RETRIES)
   })
 
-  it('captures the trailing verdict to the outbox + allows when an early qualifying reply is followed by an undelivered verdict (trailing-content bug repro, collapsed design)', () => {
-    // Confirmed-incident shape: (1) a background-task notification arrives,
-    // (2) the agent calls reply ONCE early with a notification-bearing ack,
-    // (3) it then writes a large substantive verdict as plain assistant text
-    // with NO second reply call. The trailing verdict is now CAPTURED to the
-    // outbox and the stop is ALLOWED — the sweep delivers it deterministically.
+  it('routes the trailing verdict through the single-writer election (NOT the outbox) when an early qualifying reply already delivered (#3510)', () => {
+    // Pre-#3510 this shape — (1) inbound, (2) an early notification-bearing
+    // (ping-final) reply, (3) a large trailing verdict as plain text — was
+    // CAPTURED to the outbox and self-exited, bypassing the #3469 election.
+    // Because the ping-final reply is delivered by the gateway but sits under
+    // the reply-site journal floor, the sweep then flushed the trailing prose
+    // as a SECOND message (the #3510 double-send). Now: a reply already
+    // delivered this turn ⇒ NO outbox record; the trailing prose goes through
+    // `decideStopHookDisposition`'s 'trailing-text-after-reply' branch, whose
+    // captured-prose bridge is the single writer (fresh heartbeat ⇒ elected
+    // allow, pendingText persisted as the bridge's input).
+    writeFileSync(join(stateDir, 'gateway-heartbeat'), 'hb', 'utf8')
     const transcript = writeTranscript(tmp, [
       ENQUEUE,
       reply('running now'),
@@ -222,11 +228,13 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
       stateDir,
     })
     expect(r.status).toBe(0)
-    expect(r.stdout.trim()).toBe('')
-    const rec = readOutboxRecord(stateDir)
-    expect(rec).not.toBeNull()
-    expect(rec!.text).toBe('Here is the actual verdict: ' + 'X'.repeat(300))
-    expect(rec!.turnNonce).toBe('111:_#42')
+    expect(r.stdout.trim()).toBe('') // elected allow — no re-prompt
+    expect(r.stderr).toMatch(/replyAlreadyDeliveredThisTurn=true/)
+    // No outbox record: the sweep must have nothing to flush as a second message.
+    expect(readOutboxRecord(stateDir)).toBeNull()
+    // The verdict is handed to the bridge (single writer) via the state file.
+    const state = JSON.parse(readFileSync(join(stateDir, 'silent-end-pending.json'), 'utf8'))
+    expect(state.pendingText).toBe('Here is the actual verdict: ' + 'X'.repeat(300))
   })
 
   it('does NOT false-positive on a normal single-reply turn ending on the reply tool_use', () => {


### PR DESCRIPTION
## Summary
Fixes the #3510 Telegram double-send: a turn that delivered a `reply` and then emitted >=200 chars of trailing prose had that prose captured by the Stop hook's outbox block and `process.exit(0)`'d **before** the #3469 single-writer election ever ran (`silent-end-interrupt-stop.mjs` capture block vs the election below it). `scanForOutboxCapture` never deduped the trailing prose against the already-delivered reply, so the sweep flushed the recap as a second, unformatted message.

**Fix (deterministic, control-flow-enforced):** `scanForOutboxCapture` now returns `replyAlreadyDeliveredThisTurn` (`lastDeliverIdx !== -1`). When true, the hook does NOT write a record / self-exit; it falls through to `decideStopHookDisposition`'s existing, purpose-built `'trailing-text-after-reply'` branch (retry / captured-prose-flag / gateway-liveness gated), making the election the actual single writer. Safe because a reply just went through the gateway ⇒ a gateway anchor provably exists.

**Backstop preserved (#3502 / 2026-07-22 incident):** when NO reply delivered this turn (`lastDeliverIdx === -1` — task-notification handbacks, cron, zero-reply, unknown anchors), capture keeps its exact current self-exit + sweep-delivery behavior. Pinned by e2e tests.

## Instrumentation (issue ask — journal-provable double-sends)
Driven by the SAME boolean as the fix, so telemetry and behavior can't drift:
- `OutboxRecord` + every `delivered.jsonl` entry: `deliverySource` ('sweep' | 'reply-tool') and `replyAlreadyDeliveredThisTurn`. A `deliverySource:'sweep'` entry with `replyAlreadyDeliveredThisTurn:true` (or after a 'reply-tool' entry for the same nonce) is direct journal evidence of a regression.
- Hook stderr logs `capturedTextSha256` + `deliveredReplySha256` when deferring.

## Test plan
- **New e2e harness** `telegram-plugin/tests/outbox-reply-then-recap-e2e.test.ts`: real Stop-hook subprocess → real on-disk outbox → real `sweepOutbox`, ticked across the `OUTBOX_QUIET_MS` boundary (age 0 / quiet-1 / quiet / quiet+1 / past dedup-TTL). Oracle is function-agnostic user outcomes: message count + content + transport.
  - Duplicate direction (table-driven: short/long/paraphrased/below-floor recaps, done:true, dead-gateway): exactly ONE message, the formatted reply. **RED on pre-fix hooks** (verified: 5 failures with origin/main hook files, all pass with fix).
  - Silence direction: task-notification handback (incident shape), cron, zero-reply, interim-ack-then-answer: exactly ONE delivery, never zero — proves no #3502 regression.
  - Instrumentation fields asserted from the journal and record files.
- Updated `silent-end-interrupt-stop-integration.test.ts` case that pinned the pre-#3510 capture-on-reply-delivered behavior to the new contract (elected allow, pendingText handed to the bridge, no outbox record).
- Scoped suites: 8 files / 156 tests green. `npm run lint` clean.

## Risk
- If `scanTurnForFinalReply` and `scanForOutboxCapture` ever disagree on 'reply delivered' for the same transcript, the trailing prose could be neither captured nor elected; the e2e suite pins agreement for all covered shapes, and the worst case is the pre-#3502 block/re-prompt, not a silent drop.

## Recommended follow-ups (adjacent, deliberately NOT in this PR — from the #3510 writer inventory)
1. **Reply-site journal gate narrower than capture detection remains for OTHER writers**: `shouldJournalReplySiteDelivery` (done || len>=200) vs `isFinalAnswerReply` (ping clause) — a <200-char ping-final reply is delivered but never journaled. This PR removes the double-send it enabled, but the asymmetry itself deserves an audit.
2. **`OUTBOX_QUIET_MS` (5s) vs sweep interval (5s)**: the race window is exactly one tick wide; a slow legacy flush can lose to the first eligible sweep pass.
3. **`deriveTurnNonce` hand-duplication** (.ts vs .mjs) drift risk — parity is test-pinned but the duplication remains.
4. **63 direct `bot.api.send*` sites in gateway.ts** outside the reply/outbox machinery — out of scope for this regression class but a large surface for a future final-answer refactor to audit.
5. **Journal compaction × crash boundary**: delivered + compacted-out + reclaimed-stale interaction in one window deserves an explicit test.

Job spec: `reference/jobs/` — always-delivered final answers (guaranteed final-message delivery; this PR restores the exactly-once half of that job without regressing the never-zero half).

Closes #3510

🤖 Generated with [Claude Code](https://claude.com/claude-code)