### PR TITLE
chore: release v0.19.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+## v0.19.14 — Telegram double-send fix + rollout-card counter fix
+
+### Telegram delivery (#3510, #3511)
+
+- **Fixed the double-send regression: one answer no longer posts twice (#3511)** —
+  reply-then-recap capture is now routed through a single-writer election, so a
+  single answer is delivered once instead of being posted twice (the formatted
+  reply plus a raw duplicate). The fix preserves the silent-drop backstop — the
+  guarantee that a final answer is never lost is not regressed. Adversarially
+  reviewed and re-reviewed with all findings fixed.
+
+### Fleet rollout (#3509)
+
+- **Rollout progress card counts real completions (#3509)** — the "N/M rolled"
+  footer on the rollout progress card now counts actual completed rollouts
+  instead of showing a stuck `0/12 rolled`.
+
 ## v0.19.13 — Memory self-heal + guaranteed message delivery + temporal normalization + CLI 2.1.218
 
 ### Memory / Hindsight (#3500)


### PR DESCRIPTION
## Summary

Release v0.19.14 — CHANGELOG consolidation only (no `package.json` bump; tag is the version source of truth).

Consolidates the two fixes merged since v0.19.13:

- **#3511** — fix(telegram): route reply-then-recap capture through single-writer election. Headline user-facing fix: kills the Telegram double-send regression (one answer posting twice, formatted + raw) without regressing the silent-drop backstop. Adversarially reviewed + re-reviewed, all findings fixed.
- **#3509** — fix(rollout): count real completions in the "N/M rolled" card footer. Fixes the rollout progress card showing a stuck `0/12 rolled`.

## Why

Ship the merged double-send delivery fix and the rollout-card counter fix to the fleet.

## Test plan

CHANGELOG-only change; CI required checks (lint / bun-test / vitest / images-ok) gate the merge.

## Risk

None — docs-only commit. Content already merged + reviewed on main.

Job spec: reference/jobs — always-available delivery (double-send fix) + on-the-leash rollout visibility (card counter).