### PR TITLE
fix(telegram): stop agent intent-narration leaking into the final reply (#3513)

### DIFF
--- a/telegram-plugin/gateway/narrative-lane.ts
+++ b/telegram-plugin/gateway/narrative-lane.ts
@@ -49,6 +49,7 @@
 import { runSilentTurnHeartbeatTick } from '../feed-heartbeat-climb.js'
 import { NarrativeFlushController, PENDING_NARRATIVE_FLUSH_MS } from '../narrative-flush.js'
 import { richMessage } from '../rich-send.js'
+import { appendShownBlock } from '../shown-ledger.js'
 import {
   appendActivityLabel, clipNarrative, formatStepSuffix, renderActivityFeedWithNested,
 } from '../tool-activity-summary.js'
@@ -186,6 +187,16 @@ export function createNarrativeLane(deps: NarrativeLaneDeps) {
       {
         show: (text) => showNarrativeStep(turn, text),
         retractShown: (text) => retractNarrativeLine(turn, text),
+        // #3513 (correction 4): persist the ephemeral-shown mark keyed by the
+        // per-turn nonce so the out-of-process backstops (E3/E4) refuse to
+        // re-deliver this card-only narration. Envelope-bearing turns only —
+        // `turnId` is null for handback/background/cron, where the structural
+        // rule in the shared classifier is the sole guard (should-fix noted in
+        // shown-ledger.ts). Skip when null.
+        markDurableNarration: (text) => {
+          if (turn.turnId == null) return
+          appendShownBlock(turn.turnId, text)
+        },
       },
       {
         arm: (fn, ms) => {

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -42,6 +42,7 @@ import {
   sha256Hex,
   type OutboxRecord,
 } from '../outbox.js'
+import { isShownBlock } from '../shown-ledger.js'
 import { resolveSubagentOriginTurnKey } from '../registry/subagents-schema.js'
 import { createRetryApiCall, retryWithThreadFallback } from '../retry-api-call.js'
 
@@ -115,11 +116,32 @@ export async function sweepOutbox(deps: OutboxSweepDeps): Promise<OutboxSweepSum
       routable: resolved != null,
       routePrefix,
       quietMs: deps.quietMs ?? OUTBOX_QUIET_MS,
+      // #3513: suppress a record whose text was already surfaced on the ephemeral
+      // progress card for this turn (durable shown-ledger). The invariant forbids
+      // a second, out-of-process delivery of an ephemeral-shown block.
+      shownLedgerHit: isShownBlock(record.turnNonce, record.text, deps.stateDir),
     })
 
     if (decision.action !== 'send' && decision.action !== 'send-delayed') {
       summary.skipped++
-      if (decision.action === 'skip-journaled') {
+      if (decision.action === 'skip-ephemeral-shown') {
+        // Ephemeral-shown (#3513): the block already lives on the progress card.
+        // Journal the nonce and drop the record so the sweep never re-scans it
+        // and a racing machine also skips — same terminal bookkeeping as a dedup
+        // hit, but the reason is "assigned to the ephemeral surface".
+        appendDelivered(
+          {
+            turnNonce: record.turnNonce,
+            textSha256: record.textSha256,
+            ts: now,
+            deliverySource: 'sweep',
+            replyAlreadyDeliveredThisTurn: record.replyAlreadyDeliveredThisTurn === true,
+          },
+          deps.stateDir,
+        )
+        clearOutboxRecord(record.turnNonce, deps.stateDir)
+        log(`outbox-sweep: suppressed ephemeral-shown nonce=${record.turnNonce}\n`)
+      } else if (decision.action === 'skip-journaled') {
         // Already delivered under this nonce by another machine → drop the
         // pending record. clearOutboxRecord unlinks the `.json` (the pending
         // file) AND any `.sending` — the pre-fix `removeClaimed` only unlinked

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -827,6 +827,20 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
         // negation is the draft-then-send narration signal the turn-flush strip
         // uses (`selectFlushDeliveryText`) to keep a real answer intact instead
         // of truncating a paragraph that merely opens with "Let me explain…".
+        //
+        // NOTE (naming/approximation, #3515 review nit): downstream this value is
+        // consumed as `followedByToolUse`, but `!ev.lastInMessage` is a CONSERVATIVE
+        // APPROXIMATION of that predicate, not an exact match. It is true when the
+        // block is not the last block in its assistant message OR when a tool_use
+        // follows it in the same turn — i.e. it can over-flag: a block that is
+        // genuinely last-in-message may still be marked true. Over-approximation is
+        // SAFE here by construction: a `true` flag only ever makes a block a
+        // candidate for structural-narration suppression (selectFlushDeliveryText /
+        // isStructuralNarration), so the worst case is suppressing MORE narration —
+        // it can never promote an answer into the drop path. A real terminal answer
+        // is protected independently (it is never followed by a tool and survives
+        // the strip). Do not "tighten" this to the exact predicate expecting a
+        // behavioural change: the runtime value is deliberately conservative.
         turn.capturedBlockMeta.push(!ev.lastInMessage)
         // Narrative-dedup gate step 1 (JSONL-text-narrative primitive):
         // stage this text block for one lookahead step. If a previous block

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -64,6 +64,7 @@ import { recordTurnEnd, recordTurnStart } from '../registry/turns-schema.js'
 import { retryWithThreadFallback } from '../retry-api-call.js'
 import { richMessage } from '../rich-send.js'
 import { emitRuntimeMetric } from '../runtime-metrics.js'
+import { isShownBlock } from '../shown-ledger.js'
 import { CAPTURED_PROSE_MIN_CHARS, clearSilentEndState, decideCapturedProseDelivery, recordUndeliveredTurnEnd, silentEndFallbackText, writeSilentEndState } from '../silent-end.js'
 import { logStreamingEvent } from '../streaming-metrics.js'
 import { appendActivityLabel } from '../tool-activity-summary.js'
@@ -2012,14 +2013,21 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
           const proseMinChars =
             !turn.replyCalled && gatewayCapturedEmpty ? 1 : CAPTURED_PROSE_MIN_CHARS
           const proseDecision = CAPTURED_PROSE_DELIVERY_ENABLED
-            ? decideCapturedProseDelivery({
-                turnKey: tKey,
-                // Per-turn nonce (#3228 Finding 3) — the persisted record must
-                // belong to THIS turn, not a stale carryover from a prior turn
-                // on the same chat/thread (tKey is not per-turn unique).
-                turnId: turn.turnId,
-                minChars: proseMinChars,
-              })
+            ? decideCapturedProseDelivery(
+                {
+                  turnKey: tKey,
+                  // Per-turn nonce (#3228 Finding 3) — the persisted record must
+                  // belong to THIS turn, not a stale carryover from a prior turn
+                  // on the same chat/thread (tKey is not per-turn unique).
+                  turnId: turn.turnId,
+                  minChars: proseMinChars,
+                },
+                {
+                  // #3513 (correction 1): refuse to bridge a block already
+                  // surfaced on the ephemeral card for this turn (shown-ledger).
+                  isBlockShown: (nonce, text) => isShownBlock(nonce ?? null, text),
+                },
+              )
             : { deliver: false as const, reason: 'no-state' as const }
           if (proseDecision.deliver && proseDecision.text != null) {
             // Deliver the recovered answer directly. This runs async and owns

--- a/telegram-plugin/hooks/narration-classify.d.mts
+++ b/telegram-plugin/hooks/narration-classify.d.mts
@@ -1,0 +1,18 @@
+/**
+ * Type declarations for the shared trailing-text narration classifier
+ * (switchroom#3513) so the bundled TypeScript surfaces — `turn-flush-safety.ts`,
+ * `shown-ledger.ts`, `narrative-flush.ts` — can import the ONE classifier from
+ * `narration-classify.mjs` without tsc resolution errors. The runtime module is
+ * plain ESM (it is also imported by the unbundled Stop-hook `.mjs`, which can
+ * only import sibling `.mjs` + node builtins), so it cannot be authored in TS.
+ */
+export const SUBSTANTIVE_MIN_CHARS: number
+export const NARRATION_OPENER: RegExp
+export const NARRATION_TRAILER: RegExp
+export function isTrailingNarrationLine(block: string): boolean
+export function isNarrationBlock(block: string): boolean
+export function isStructuralNarration(
+  text: string,
+  followedByToolUse: boolean | undefined,
+): boolean
+export function ledgerHashHex(text: string): string

--- a/telegram-plugin/hooks/narration-classify.mjs
+++ b/telegram-plugin/hooks/narration-classify.mjs
@@ -1,0 +1,116 @@
+/**
+ * narration-classify.mjs — the ONE shared trailing-text narration classifier
+ * (switchroom#3513).
+ *
+ * ## Why this file exists (correction 2)
+ * Before #3513 the narration heuristic existed as TWO hand-synced copies — the
+ * TS gateway side (`turn-flush-safety.ts` `NARRATION_OPENER` / `isNarrationBlock`
+ * / `selectFlushDeliveryText`) and the unbundled Stop-hook `.mjs` side
+ * (`silent-end-scan.mjs`, with a "MUST stay in sync" comment). Two independent
+ * classifiers judging the SAME trailing assistant text is exactly the drift
+ * hazard that let intent-narration ("Now checking the gateway logs…") leak into
+ * a delivered Telegram message. This module is the single source of truth,
+ * authored as a raw `.mjs` (JS + JSDoc types) so it can be imported by BOTH:
+ *   - the unbundled Stop-hook `.mjs` (which can only import sibling `.mjs` +
+ *     node builtins — see `silent-end-scan.mjs`), and
+ *   - the bundled gateway TS (`turn-flush-safety.ts`) via `.mjs` interop (the
+ *     same pattern `tool-activity-summary.ts` already uses to import
+ *     `hooks/tool-label-pretool.mjs`).
+ *
+ * ## The primary rule — STRUCTURAL, substance-gated (corrections 3 + 4)
+ * The wording heuristic (`isNarrationBlock`) is provably incomplete (this bug is
+ * its counterexample). The deterministic, wording-independent discriminator is
+ * STRUCTURAL: did a `tool_use` follow this text block in the model's message?
+ * A narration preamble is drafted, then the model ACTS (a tool follows it); a
+ * terminal answer is not followed by a tool. `followedByToolUse === true` is a
+ * DEMOTION signal, NOT an unconditional narration verdict — it is gated by the
+ * substantive floor / opener heuristic so a SUBSTANTIVE real answer that merely
+ * precedes a tool call (the model answers, then reacts / pins / edits) still
+ * delivers. Only a short OR narration-shaped block that a tool followed is
+ * treated as non-deliverable. `followedByToolUse !== true` (false or absent) is
+ * never structural narration here — the caller applies the opener heuristic as a
+ * residual tie-breaker where it has no provenance.
+ */
+
+import { createHash } from 'node:crypto'
+
+/**
+ * Substantive-answer floor (chars, trimmed). The same bar the codebase uses
+ * everywhere (`final-answer-detect.ts` `FINAL_ANSWER_MIN_CHARS`,
+ * `turn-flush-safety.ts` `FLUSH_SUBSTANTIVE_MIN_CHARS`) to recognise "this block
+ * is a real answer, not a short narration/closer".
+ */
+export const SUBSTANTIVE_MIN_CHARS = 200
+
+/**
+ * Narration heuristic: a block that OPENS with a first-person "about to do X"
+ * phrase the model emits BEFORE composing its real answer ("Let me check…",
+ * "I'll look it up…", "Now let me…"). Deliberately NOT length-based.
+ */
+export const NARRATION_OPENER =
+  /^(let me\b|lemme\b|i'?ll\b|i will\b|i am going to\b|i'?m going to\b|i'?m about to\b|going to\b|first,?\s+(?:let me|i'?ll|i will)\b|now,?\s+(?:let me|i'?ll|i will)\b|next,?\s+(?:let me|i'?ll|i will)\b|let'?s\b)/i
+
+/**
+ * A NON-terminal progress line that opens with a gerund and trails into an
+ * ellipsis/colon: "Checking now…", "Pulling the numbers:". A single short line
+ * (under the substantive floor, no internal paragraph) ending in `…`/`...`/`:`.
+ */
+export const NARRATION_TRAILER = /(?:\.{3}|…|:)\s*$/
+
+/**
+ * @param {string} block
+ * @returns {boolean}
+ */
+export function isTrailingNarrationLine(block) {
+  const t = typeof block === 'string' ? block.trim() : ''
+  if (t.length === 0 || t.length >= SUBSTANTIVE_MIN_CHARS) return false
+  if (t.includes('\n')) return false
+  return NARRATION_TRAILER.test(t)
+}
+
+/**
+ * The wording heuristic (residual tie-breaker for provenance-less callers).
+ * @param {string} block
+ * @returns {boolean}
+ */
+export function isNarrationBlock(block) {
+  const s = typeof block === 'string' ? block : ''
+  return NARRATION_OPENER.test(s.trimStart()) || isTrailingNarrationLine(s)
+}
+
+/**
+ * The #3513 PRIMARY rule: is this block structural intra-turn narration?
+ *
+ * TRUE only when a `tool_use` followed the block in the model's message
+ * (`followedByToolUse === true`) AND the block also reads as narration OR falls
+ * below the substantive floor. This preserves the #3237 asymmetry:
+ *   - `followedByToolUse === true`  → demotion, GATED by substance/heuristic
+ *     (a substantive non-narration block followed by react/pin/typing/edit is
+ *     NOT structural narration → still delivers).
+ *   - `followedByToolUse === false` → never structural narration (a terminal
+ *     block; nothing followed it).
+ *   - `followedByToolUse` absent    → never structural narration here; the
+ *     caller applies `isNarrationBlock` as a residual tie-breaker.
+ *
+ * @param {string} text
+ * @param {boolean | undefined} followedByToolUse
+ * @returns {boolean}
+ */
+export function isStructuralNarration(text, followedByToolUse) {
+  if (followedByToolUse !== true) return false
+  const t = typeof text === 'string' ? text.trim() : ''
+  if (t.length === 0) return true
+  return isNarrationBlock(t) || t.length < SUBSTANTIVE_MIN_CHARS
+}
+
+/**
+ * The durable shown-ledger key for a block: sha256 of its trimmed text. Matches
+ * the hash both the ephemeral-paint writer and the backstop-delivery readers
+ * compute, so a marked block is recognised across processes (#3513 §4).
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function ledgerHashHex(text) {
+  return createHash('sha256').update(String(text ?? '').trim(), 'utf8').digest('hex')
+}

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -58,12 +58,17 @@
 import { statSync } from 'node:fs'
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
+import {
+  isNarrationBlock,
+  isStructuralNarration,
+  SUBSTANTIVE_MIN_CHARS,
+} from './narration-classify.mjs'
 
 const REPLY_TOOLS = new Set([
   'mcp__switchroom-telegram__reply',
   'mcp__switchroom-telegram__stream_reply',
 ])
-const FINAL_ANSWER_MIN_CHARS = 200
+const FINAL_ANSWER_MIN_CHARS = SUBSTANTIVE_MIN_CHARS
 // Match the gateway's silent-marker classifier (gateway.ts:6692 — the
 // `isSilentFlushMarker` helper accepts trailing punctuation + case
 // variants like "NO_REPLY." / "no_reply").
@@ -101,29 +106,13 @@ export function endsWithSilentMarker(text) {
   return SILENT_MARKER_RE.test(lines[lines.length - 1])
 }
 
-// ── Narration heuristics — ported from `turn-flush-safety.ts:198-274` ──
-//
-// Kept byte-parallel with `selectFlushDeliveryText` / `isNarrationBlock` so
-// the JOINED multi-block prose the scan persists as `pendingText` (for the
-// capture-divergence corner) matches what the gateway flush would itself have
-// delivered. The scan has no structural `followedByToolUse` provenance, so it
-// uses the opener/trailer heuristic fallback (the same branch the TS side
-// takes when the flag is absent). MUST stay in sync with the TS source; a
-// drift only affects the rare capture-empty corner, never the primary flush.
-const NARRATION_OPENER =
-  /^(let me\b|lemme\b|i'?ll\b|i will\b|i am going to\b|i'?m going to\b|i'?m about to\b|going to\b|first,?\s+(?:let me|i'?ll|i will)\b|now,?\s+(?:let me|i'?ll|i will)\b|next,?\s+(?:let me|i'?ll|i will)\b|let'?s\b)/i
-const NARRATION_TRAILER = /(?:\.{3}|…|:)\s*$/
-
-function isTrailingNarrationLine(block) {
-  const t = block.trim()
-  if (t.length === 0 || t.length >= FINAL_ANSWER_MIN_CHARS) return false
-  if (t.includes('\n')) return false
-  return NARRATION_TRAILER.test(t)
-}
-
-function isNarrationBlock(block) {
-  return NARRATION_OPENER.test(block.trimStart()) || isTrailingNarrationLine(block)
-}
+// The narration heuristic (`isNarrationBlock`) and the STRUCTURAL rule
+// (`isStructuralNarration`) live in the ONE shared classifier
+// `./narration-classify.mjs`, imported at the top. Before switchroom#3513 this
+// `.mjs` carried a byte-parallel COPY of the TS heuristic with a "MUST stay in
+// sync" comment — the exact hand-synced drift that let intent-narration leak.
+// Both the bundled gateway TS (`turn-flush-safety.ts`) and this unbundled hook
+// now import the same module, so a single edit governs every classifier.
 
 /**
  * Choose the prose the captured-prose bridge should deliver from the trailing
@@ -403,7 +392,8 @@ export function scanTurnForFinalReply(jsonl) {
     if (obj?.type !== 'assistant') continue
     const content = obj?.message?.content
     if (!Array.isArray(content)) continue
-    for (const c of content) {
+    for (let ci = 0; ci < content.length; ci++) {
+      const c = content[ci]
       if (c?.type === 'text') {
         // Plain assistant text carve-out (#2053): a turn that ends with
         // a trailing bare NO_REPLY / HEARTBEAT_OK line — emitted as
@@ -428,10 +418,19 @@ export function scanTurnForFinalReply(jsonl) {
           // bridge): when this turn ends up blocked, the joined undelivered
           // text becomes `pendingText` so the gateway can deliver the model's
           // real answer directly. Trimmed per-block; joined below.
+          //
+          // #3513: also carry the STRUCTURAL provenance `followedByToolUse`
+          // (mirrors the gateway's `capturedBlockMeta` / `!lastInMessage`): a
+          // `tool_use` later in this SAME assistant message means the model
+          // kept acting after writing this text → intra-turn narration, never
+          // the terminal answer. Computed here so the `.mjs` scans apply the
+          // same primary rule as the TS flush (no more provenance-less blind
+          // spot on the out-of-process bridge/sweep paths).
           blocks.push({
             kind: 'text',
             chars: String(c.text ?? '').trim().length,
             text: String(c.text ?? '').trim(),
+            followedByToolUse: content.slice(ci + 1).some((x) => x?.type === 'tool_use'),
           })
         }
         continue
@@ -478,8 +477,15 @@ export function scanTurnForFinalReply(jsonl) {
     }
   }
   const undeliveredSlice = blocks.slice(lastAllowBlockIdx + 1)
+  // #3513: a trailing text block that a `tool_use` FOLLOWED (in its message) is
+  // structural intra-turn narration, never the terminal answer — so it must not
+  // trigger the interim-ack re-prompt/bridge (`trailing-text-after-reply`) nor
+  // be selected as deliverable prose. Substance-gated (correction 3): a
+  // substantive, non-narration trailing block is NOT structural narration and
+  // still counts as an undelivered answer.
+  const isStructuralNarr = (b) => isStructuralNarration(b.text, b.followedByToolUse)
   const sawUndeliveredTextAfterAllow = undeliveredSlice
-    .some((b) => b.kind === 'text' && (b.chars ?? 0) >= FINAL_ANSWER_MIN_CHARS)
+    .some((b) => b.kind === 'text' && (b.chars ?? 0) >= FINAL_ANSWER_MIN_CHARS && !isStructuralNarr(b))
 
   // Option A transcript-prose bridge: isolate the undelivered final-answer
   // prose so the gateway can deliver it directly.
@@ -500,15 +506,24 @@ export function scanTurnForFinalReply(jsonl) {
     (b) =>
       b.kind === 'text' &&
       typeof b.text === 'string' &&
-      (b.chars ?? 0) >= FINAL_ANSWER_MIN_CHARS,
+      (b.chars ?? 0) >= FINAL_ANSWER_MIN_CHARS &&
+      !isStructuralNarr(b),
   )
   const pendingText =
     substantiveBlocks.length > 0
       ? substantiveBlocks[substantiveBlocks.length - 1].text
       : undefined
+  // #3513: the deliverable-prose selection drops structural-narration trailing
+  // blocks so the capture-divergence bridge never delivers a lone narration
+  // line. `hasTrailingProse` INTENTIONALLY still counts any non-empty trailing
+  // prose (narration included): in the zero-reply case it gates the single-writer
+  // election to ALLOW the stop (`flush-will-deliver`) rather than BLOCK+nag — the
+  // flush then suppresses the narration structurally, so the turn ends silently
+  // (no leak, no nag loop). Only the DELIVERED text is narrowed.
   const trailingTextBlocks = undeliveredSlice.filter(
     (b) => b.kind === 'text' && typeof b.text === 'string' && b.text.length > 0,
   )
+  const deliverableTrailingBlocks = trailingTextBlocks.filter((b) => !isStructuralNarr(b))
   const hasTrailingProse = trailingTextBlocks.length > 0
   // Capture-divergence bridge (#duplicate-message fix): in the ZERO-reply
   // case, persist the last trailing block even when no single block clears
@@ -531,7 +546,7 @@ export function scanTurnForFinalReply(jsonl) {
   // joined prose (with the lowered `minChars`) instead of dropping. The #3228
   // Finding 2 guard is preserved: a pure narration run still yields undefined.
   const zeroReplyPendingText =
-    pendingText ?? selectBridgePendingText(trailingTextBlocks.map((b) => b.text))
+    pendingText ?? selectBridgePendingText(deliverableTrailingBlocks.map((b) => b.text))
 
   if (lastAllowBlockIdx === -1) {
     // No qualifying delivery/silence event anywhere in the turn.
@@ -911,7 +926,11 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
     if (obj?.type !== 'assistant') continue
     const content = obj?.message?.content
     if (!Array.isArray(content)) continue
-    for (const c of content) {
+    for (let ci = 0; ci < content.length; ci++) {
+      const c = content[ci]
+      // #3513: a `tool_use` later in this SAME assistant message means the model
+      // kept acting after this text → structural intra-turn narration.
+      const followedByToolUse = content.slice(ci + 1).some((x) => x?.type === 'tool_use')
       if (c?.type === 'text') {
         const raw = String(c.text ?? '')
         // H6: strip a trailing bare marker; if substantive non-narration prose
@@ -928,10 +947,10 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
           // last-delivery cursor past that prose and mask it (multi-block H6).
           // A bare/narration marker is simply not a delivery — push nothing.
           if (prose.length > 0 && !isNarrationBlock(prose)) {
-            blocks.push({ kind: 'text', chars: prose.length, text: prose })
+            blocks.push({ kind: 'text', chars: prose.length, text: prose, followedByToolUse })
           }
         } else if (prose.length > 0) {
-          blocks.push({ kind: 'text', chars: prose.length, text: prose })
+          blocks.push({ kind: 'text', chars: prose.length, text: prose, followedByToolUse })
         }
         continue
       }
@@ -991,6 +1010,11 @@ export function scanForOutboxCapture(jsonl, now = Date.now()) {
   const trailing = blocks
     .slice(lastDeliverIdx + 1)
     .filter((b) => b.kind === 'text' && typeof b.text === 'string' && b.text.length > 0)
+    // #3513: drop structural-narration trailing blocks (a `tool_use` followed
+    // them → intra-turn narration, never the terminal answer) so the durable
+    // outbox never captures a lone narration line for the sweep to deliver.
+    // Substance-gated: a substantive non-narration block is kept.
+    .filter((b) => !isStructuralNarration(b.text, b.followedByToolUse))
     .map((b) => b.text)
 
   const text = selectBridgePendingText(trailing)

--- a/telegram-plugin/narrative-flush.ts
+++ b/telegram-plugin/narrative-flush.ts
@@ -40,6 +40,7 @@
  */
 
 import { isReplyTool, isDraftOfReply } from './narrative-dedup.js'
+import { isStructuralNarration } from './hooks/narration-classify.mjs'
 
 /**
  * Time-box for the parked-narrative early-paint (the kernel's home for the
@@ -70,6 +71,18 @@ export interface NarrativeFlushEffects {
    * Caller removes it from the feed. No-op-safe if already gone.
    */
   retractShown(text: string): void
+  /**
+   * #3513 (correction 4): durably mark a block that has surfaced ONLY on the
+   * ephemeral card as structural narration, so the out-of-process turn-end
+   * backstops (E3 captured-prose bridge, E4 outbox sweep) refuse to re-emit it
+   * as a real chat message. Called ONLY from the mid-turn SHOW paths (`stage`,
+   * `resolveOnTool`), where the block is provably followed by more content
+   * (another text block / a tool_use) and is therefore structural narration —
+   * NEVER from `onTimerFire` (the timer paints the LAST/terminal block, which
+   * could still be the genuine unsent answer) nor from `flushAtTurnEnd`. The
+   * effect is optional; callers without a durable ledger omit it.
+   */
+  markDurableNarration?(text: string): void
 }
 
 /** Arms / disarms the real early-paint timer. Injected so tests can fake it. */
@@ -113,6 +126,10 @@ export class NarrativeFlushController {
     this.scheduler.disarm()
     if (this.pending != null) {
       this.effects.show(this.pending)
+      // The just-shown block is provably followed by MORE narration text (this
+      // new block is its lookahead) → structural narration. Mark it durably so
+      // the turn-end backstops never re-deliver it (#3513, correction 4).
+      this.markShown(this.pending)
     }
     this.pending = text
     this.scheduler.arm(() => this.onTimerFire(), this.flushMs)
@@ -146,6 +163,10 @@ export class NarrativeFlushController {
     this.pending = null
     if (replyText != null && isDraftOfReply(pending, replyText)) return // draft → SUPPRESS
     this.effects.show(pending)
+    // The just-shown block is provably followed by a tool_use (this lookahead) →
+    // structural narration. Mark it durably so the turn-end backstops never
+    // re-deliver it as a real chat message (#3513, correction 4).
+    this.markShown(pending)
   }
 
   /**
@@ -168,6 +189,20 @@ export class NarrativeFlushController {
     this.scheduler.disarm()
     this.pending = null
     this.timerShown = null
+  }
+
+  /**
+   * Durably mark a card-only block as narration — but ONLY when it is
+   * structurally narration under the shared classifier (substance-gated:
+   * `isNarrationBlock || < SUBSTANTIVE_MIN_CHARS`). This is the belt-and-braces
+   * guard: a substantive real message that happens to precede a non-delivering
+   * tool (react / pin / typing) is NOT marked, so it can still be delivered by a
+   * backstop if it was the genuine unsent answer (#3513, corrections 3 & 4).
+   */
+  private markShown(text: string): void {
+    if (this.effects.markDurableNarration == null) return
+    if (!isStructuralNarration(text, true)) return
+    this.effects.markDurableNarration(text)
   }
 
   /** Retract the timer-painted block iff this reply is its draft-then-send. */

--- a/telegram-plugin/outbox.ts
+++ b/telegram-plugin/outbox.ts
@@ -378,6 +378,7 @@ export type OutboxSweepAction =
   | 'skip-quiet'
   | 'skip-dedup'
   | 'skip-unroutable'
+  | 'skip-ephemeral-shown'
 
 export interface OutboxSweepDecision {
   action: OutboxSweepAction
@@ -408,6 +409,18 @@ export function decideOutboxSweep(input: {
   routePrefix?: string
   quietMs?: number
   maxAgeMs?: number
+  /**
+   * #3513 (correction 1): was this record's text marked ephemeral-shown on the
+   * progress card for its turnNonce (the durable shown-ledger)? A hit means the
+   * block was already assigned to the ephemeral surface — the single-surface
+   * invariant forbids ANY delivery machine, including this out-of-process late
+   * sweep, from ALSO delivering it to chat. The ledger only ever contains
+   * STRUCTURAL narration (correction 4: never a possibly-terminal answer), so
+   * this can never suppress a genuine answer. Checked here (in the backstop
+   * decision itself) rather than only at a send seam, because the sweep bypasses
+   * `normalizeOutboundBody` (it sends via `bot.api.sendMessage` directly).
+   */
+  shownLedgerHit?: boolean
 }): OutboxSweepDecision {
   const {
     record,
@@ -418,8 +431,10 @@ export function decideOutboxSweep(input: {
     routePrefix = '',
     quietMs = OUTBOX_QUIET_MS,
     maxAgeMs = OUTBOX_MAX_AGE_MS,
+    shownLedgerHit = false,
   } = input
   if (deliveredNonces.has(record.turnNonce)) return { action: 'skip-journaled' }
+  if (shownLedgerHit) return { action: 'skip-ephemeral-shown' }
   const age = now - record.createdAt
   if (age < quietMs) return { action: 'skip-quiet' }
   if (textAlreadyDelivered) return { action: 'skip-dedup' }

--- a/telegram-plugin/shown-ledger.ts
+++ b/telegram-plugin/shown-ledger.ts
@@ -1,0 +1,145 @@
+/**
+ * shown-ledger.ts — the durable "this block was surfaced on the ephemeral
+ * progress card, never deliver it to chat" mark (switchroom#3513 §4).
+ *
+ * ## Role in the single-surface invariant
+ * Every trailing plain-text block a turn produces is assigned to exactly one
+ * surface: the delivered chat answer, the ephemeral progress card, or
+ * suppression. In-process (E1/E2 turn-flush, the card) that assignment is made
+ * once by the shared structural classifier (`hooks/narration-classify.mjs`).
+ * But the out-of-process backstops — the Stop-hook captured-prose bridge (E3)
+ * and the durable outbox heartbeat sweep (E4) — run in a separate process / on
+ * a later tick and cannot share an in-memory decision. So the component that
+ * paints a block as ephemeral narration appends `{turnNonce, hash}` here, and
+ * E3/E4 treat a ledger hit exactly like a silent marker: not deliverable.
+ *
+ * ## Correction 4 — only structural narration is ever marked
+ * The writer (the mid-turn narrative paint in `gateway/narrative-lane.ts`) marks
+ * ONLY blocks that are provably followed by more turn activity (a new narrative
+ * block or a tool call), i.e. structural narration — NEVER a possibly-terminal
+ * block (the timer-paint / turn-end paint that could turn out to be the real
+ * answer). This keeps the invariant fail-open for answers: a genuine unsent
+ * answer is never in the ledger, so a ledger check can never suppress it (a drop
+ * is worse than a duplicate). The structural rule, not the ledger, is the sole
+ * guard for the answer path.
+ *
+ * ## Envelope-bearing-only (documented should-fix, #3513 §8)
+ * The ledger is keyed by the turnNonce (`deriveTurnId` → `${chatKey}#${msgId}`),
+ * which is reachable-matching ONLY for envelope-bearing turns — `deriveTurnId`
+ * returns null without a message_id (`gateway/derive-turn-id.ts`), and the
+ * outbox falls back to a sha nonce. So the ledger is a best-effort belt for
+ * envelope-bearing turns (the common Telegram-inbound shape); for envelope-less
+ * turns (handback / background / cron) the structural classifier is the sole
+ * guard. The writer skips a null turnId; the readers simply miss and fall
+ * through to the structural rule — never a false suppression.
+ *
+ * Best-effort throughout: a missing / unwritable ledger degrades to the
+ * structural-rule-only behaviour (leak possible, drop impossible).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+  appendFileSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { resolveOutboxDir } from './outbox.js'
+import { ledgerHashHex } from './hooks/narration-classify.mjs'
+
+const SHOWN_LEDGER_FILE = 'shown-ledger.jsonl'
+
+/** Bounded growth — compact to the newest KEEP entries past ROTATE_AT lines. */
+export const SHOWN_LEDGER_KEEP = 2_000
+export const SHOWN_LEDGER_ROTATE_AT = 4_000
+
+/** One appended shown-block entry. */
+export interface ShownLedgerEntry {
+  turnNonce: string
+  hash: string
+  ts: number
+}
+
+export function shownLedgerPath(stateDir?: string): string {
+  return join(resolveOutboxDir(stateDir), SHOWN_LEDGER_FILE)
+}
+
+/**
+ * Mark a block as ephemeral-shown for `turnNonce`. Correction 4: callers MUST
+ * only pass blocks that are structural narration (followed by more turn
+ * activity), never a possibly-terminal block. A null/empty turnNonce is ignored
+ * (envelope-less turn — the structural rule is the sole guard there).
+ * Best-effort; never throws.
+ */
+export function appendShownBlock(
+  turnNonce: string | null,
+  text: string,
+  stateDir?: string,
+  now: number = Date.now(),
+): void {
+  if (turnNonce == null || turnNonce === '') return
+  const trimmed = typeof text === 'string' ? text.trim() : ''
+  if (trimmed.length === 0) return
+  const dir = resolveOutboxDir(stateDir)
+  const path = shownLedgerPath(stateDir)
+  try {
+    mkdirSync(dir, { recursive: true })
+    const entry: ShownLedgerEntry = { turnNonce, hash: ledgerHashHex(trimmed), ts: now }
+    appendFileSync(path, JSON.stringify(entry) + '\n', { mode: 0o600 })
+    compactIfLarge(path)
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** The set of block hashes marked ephemeral-shown for `turnNonce`. */
+export function readShownHashes(turnNonce: string | null, stateDir?: string): Set<string> {
+  const set = new Set<string>()
+  if (turnNonce == null || turnNonce === '') return set
+  const path = shownLedgerPath(stateDir)
+  if (!existsSync(path)) return set
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue
+      try {
+        const e = JSON.parse(line) as ShownLedgerEntry
+        if (e.turnNonce === turnNonce && typeof e.hash === 'string') set.add(e.hash)
+      } catch {
+        /* skip corrupt line */
+      }
+    }
+  } catch {
+    /* best-effort */
+  }
+  return set
+}
+
+/**
+ * Was `text` marked ephemeral-shown for `turnNonce`? The out-of-process
+ * suppression check consumed by the E3 captured-prose decision and the E4 sweep.
+ */
+export function isShownBlock(
+  turnNonce: string | null,
+  text: string,
+  stateDir?: string,
+): boolean {
+  if (turnNonce == null || turnNonce === '') return false
+  const trimmed = typeof text === 'string' ? text.trim() : ''
+  if (trimmed.length === 0) return false
+  return readShownHashes(turnNonce, stateDir).has(ledgerHashHex(trimmed))
+}
+
+function compactIfLarge(path: string): void {
+  try {
+    const lines = readFileSync(path, 'utf8').split('\n').filter((l) => l.length > 0)
+    if (lines.length <= SHOWN_LEDGER_ROTATE_AT) return
+    const kept = lines.slice(lines.length - SHOWN_LEDGER_KEEP)
+    const tmp = `${path}.${process.pid}.compact`
+    writeFileSync(tmp, kept.join('\n') + '\n', { mode: 0o600 })
+    renameSync(tmp, path)
+  } catch {
+    /* best-effort */
+  }
+}

--- a/telegram-plugin/silent-end.ts
+++ b/telegram-plugin/silent-end.ts
@@ -86,6 +86,17 @@ export interface SilentEndDeps {
   hasOutboundDeliveredSince?: (chatId: string, sinceMs: number, threadId?: number | null) => boolean
   /** Wall-clock now, ms. Defaults to `Date.now`; injectable for tests. */
   now?: () => number
+  /**
+   * #3513 (correction 1): was `text` marked ephemeral-shown on the progress card
+   * for `turnNonce` (the durable shown-ledger)? Injected so the captured-prose
+   * bridge (E3) — which sends via `bot.api.sendMessage` directly, bypassing
+   * `normalizeOutboundBody` — refuses to deliver a block that was already
+   * assigned to the ephemeral surface. The ledger only ever holds STRUCTURAL
+   * narration (correction 4: never a possibly-terminal answer), so this can
+   * never suppress a genuine answer. Omitted → the check is skipped (the
+   * structural classifier remains the guard).
+   */
+  isBlockShown?: (turnNonce: string | null | undefined, text: string) => boolean
 }
 
 /**
@@ -306,6 +317,7 @@ export interface CapturedProseDecision {
     | 'turnkey-mismatch'
     | 'turnid-mismatch'
     | 'no-substantive-prose'
+    | 'ephemeral-shown'
 }
 
 /**
@@ -352,6 +364,14 @@ export function decideCapturedProseDelivery(
   }
   const text = typeof state.pendingText === 'string' ? state.pendingText : ''
   if (text.trim().length < minChars) return { deliver: false, reason: 'no-substantive-prose' }
+  // #3513: the persisted prose was already surfaced on the ephemeral progress
+  // card for this turn (durable shown-ledger) — the single-surface invariant
+  // forbids the bridge from ALSO delivering it to chat. The ledger only holds
+  // structural narration (never a possibly-terminal answer), so this can never
+  // suppress a genuine answer.
+  if (deps?.isBlockShown?.(state.turnId, text) === true) {
+    return { deliver: false, reason: 'ephemeral-shown' }
+  }
   return { deliver: true, text, reason: 'captured-prose' }
 }
 

--- a/telegram-plugin/tests/narration-leak-3513.test.ts
+++ b/telegram-plugin/tests/narration-leak-3513.test.ts
@@ -1,0 +1,291 @@
+/**
+ * narration-leak-3513.test.ts — outcome-asserting regression suite for
+ * switchroom#3513 ("agent intent-narration leaks into the final Telegram reply
+ * as a real chat message").
+ *
+ * The single-surface invariant: every trailing plain-text block is assigned once
+ * to exactly one surface — delivered chat answer / ephemeral progress card /
+ * suppressed — by ONE shared classifier, and NO delivery path (E1 turn-flush,
+ * E2 quiescence, E3 captured-prose bridge, E4 outbox sweep) ever emits a block
+ * classified as structural narration; the one genuine unsent answer still
+ * delivers exactly once.
+ *
+ * Every test here asserts an OUTCOME (was the narration delivered? was the real
+ * answer delivered?), not merely that a code path ran, and each is written to be
+ * RED on the pre-fix code (which had two hand-synced regex classifiers and no
+ * structural/ledger guard).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  isStructuralNarration,
+  isNarrationBlock,
+  ledgerHashHex,
+  SUBSTANTIVE_MIN_CHARS,
+} from '../hooks/narration-classify.mjs'
+import { selectFlushDeliveryText, FLUSH_SUBSTANTIVE_MIN_CHARS } from '../turn-flush-safety.js'
+import { decideOutboxSweep } from '../outbox.js'
+import { decideCapturedProseDelivery } from '../silent-end.js'
+import { appendShownBlock, isShownBlock, readShownHashes } from '../shown-ledger.js'
+import { NarrativeFlushController } from '../narrative-flush.js'
+
+const NARRATION = 'Now let me check the gateway logs to see what happened.'
+const REAL_ANSWER =
+  'The gateway crashed because the outbox sweep tried to deliver a record whose ' +
+  'turnNonce had already been journaled, and the dedup cache had been evicted, so ' +
+  'the exactly-once guard fell back to the text-dedup path which returned false. ' +
+  'The fix is to check the shown-ledger before the quiet window, not after.'
+
+// A substantive real message that the model happens to precede a NON-delivering
+// tool with (react / pin / typing). Must NOT be treated as narration.
+const SUBSTANTIVE_BEFORE_REACT = REAL_ANSWER
+
+describe('shared classifier — the ONE source of truth (correction 2 + 3)', () => {
+  it('short/narration-shaped block followed by a tool IS structural narration', () => {
+    expect(isStructuralNarration(NARRATION, true)).toBe(true)
+    expect(isStructuralNarration('On it — pulling the numbers…', true)).toBe(true)
+    expect(isStructuralNarration('', true)).toBe(true)
+  })
+
+  it('SUBSTANTIVE block followed by a tool is NOT narration (react/pin/typing still delivers)', () => {
+    // The #3237 asymmetry: a real answer preceding react/pin/typing must deliver.
+    expect(SUBSTANTIVE_BEFORE_REACT.length).toBeGreaterThan(SUBSTANTIVE_MIN_CHARS)
+    expect(isStructuralNarration(SUBSTANTIVE_BEFORE_REACT, true)).toBe(false)
+  })
+
+  it('a terminal block (nothing followed it) is NEVER structural narration', () => {
+    // followedByToolUse false OR absent → never structural (could be the answer).
+    expect(isStructuralNarration(NARRATION, false)).toBe(false)
+    expect(isStructuralNarration(NARRATION, undefined)).toBe(false)
+    expect(isStructuralNarration('Yes.', false)).toBe(false)
+  })
+
+  it('FLUSH_SUBSTANTIVE_MIN_CHARS is wired to the shared constant (no drift)', () => {
+    expect(FLUSH_SUBSTANTIVE_MIN_CHARS).toBe(SUBSTANTIVE_MIN_CHARS)
+  })
+})
+
+describe('E1/E2 turn-flush — narration never becomes the delivered answer', () => {
+  it('drops a trailing narration block that a tool followed, keeps the real answer', () => {
+    const out = selectFlushDeliveryText([REAL_ANSWER, NARRATION], [false, true])
+    expect(out).toContain(REAL_ANSWER)
+    expect(out).not.toContain(NARRATION)
+  })
+
+  it('drops a SHORT non-regex block a tool followed (the class the old regex missed)', () => {
+    // "The logs show three errors." matches NO wording heuristic (no opener, no
+    // trailing ellipsis/colon) — the pre-fix regex-only classifier would have
+    // DELIVERED it. It is structural narration only because a tool followed it
+    // AND it is under the substantive floor. This is the core #3513 discriminator.
+    const shortNonRegex = 'The logs show three errors.'
+    expect(isNarrationBlock(shortNonRegex)).toBe(false)
+    expect(shortNonRegex.length).toBeLessThan(SUBSTANTIVE_MIN_CHARS)
+    const out = selectFlushDeliveryText([REAL_ANSWER, shortNonRegex], [false, true])
+    expect(out).toContain(REAL_ANSWER)
+    expect(out).not.toContain(shortNonRegex)
+  })
+
+  it('zero-reply, narration-only turn (all blocks followed by tools) flushes NOTHING', () => {
+    const out = selectFlushDeliveryText(['Let me pull the logs.', NARRATION], [true, true])
+    expect(out).toBe('')
+  })
+
+  it('a genuine terminal answer with no provenance still flushes (fail-open)', () => {
+    // Provenance-less single block — conservative: deliver it.
+    expect(selectFlushDeliveryText(['Here are the results:'])).toBe('Here are the results:')
+  })
+
+  it('a SUBSTANTIVE answer followed by a non-delivering tool STILL flushes', () => {
+    const out = selectFlushDeliveryText([SUBSTANTIVE_BEFORE_REACT], [true])
+    expect(out).toBe(SUBSTANTIVE_BEFORE_REACT)
+  })
+})
+
+describe('E4 outbox sweep — a ledger-marked block is never re-delivered (correction 1)', () => {
+  const base = {
+    now: 10_000_000,
+    deliveredNonces: new Set<string>(),
+    textAlreadyDelivered: false,
+    routable: true,
+    quietMs: 0,
+  }
+
+  it('skips a record whose text was shown on the ephemeral card', () => {
+    const d = decideOutboxSweep({
+      ...base,
+      record: { turnNonce: 'c:_#5', text: NARRATION, createdAt: 0 },
+      shownLedgerHit: true,
+    })
+    expect(d.action).toBe('skip-ephemeral-shown')
+    expect(d.text).toBeUndefined()
+  })
+
+  it('delivers a real answer that was NOT shown on the card', () => {
+    const d = decideOutboxSweep({
+      ...base,
+      record: { turnNonce: 'c:_#5', text: REAL_ANSWER, createdAt: base.now },
+      shownLedgerHit: false,
+    })
+    expect(d.action).toBe('send')
+    expect(d.text).toContain(REAL_ANSWER)
+  })
+
+  it('the ledger hit is checked AFTER journaled (exactly-once wins) but BEFORE quiet', () => {
+    // Already-journaled record short-circuits regardless of ledger state.
+    const journaled = decideOutboxSweep({
+      ...base,
+      deliveredNonces: new Set(['c:_#5']),
+      record: { turnNonce: 'c:_#5', text: NARRATION, createdAt: 0 },
+      shownLedgerHit: true,
+    })
+    expect(journaled.action).toBe('skip-journaled')
+  })
+})
+
+describe('E3 captured-prose bridge — a shown block is refused (correction 1)', () => {
+  /** Write a real silent-end-pending.json into a temp stateDir. */
+  function withState(text: string, run: (deps: { stateDir: string }) => void): void {
+    const dir = mkdtempSync(join(tmpdir(), 'silent-end-'))
+    try {
+      writeFileSync(
+        join(dir, 'silent-end-pending.json'),
+        JSON.stringify({
+          chatId: 'c',
+          threadId: null,
+          turnKey: 'c:_',
+          turnId: 'c:_#5',
+          pendingText: text,
+          retryCount: 0,
+          timestamp: Date.now(),
+        }),
+      )
+      run({ stateDir: dir })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  it('refuses to bridge prose already surfaced on the card', () => {
+    withState(REAL_ANSWER, ({ stateDir }) => {
+      const d = decideCapturedProseDelivery(
+        { turnKey: 'c:_', turnId: 'c:_#5', minChars: 10 },
+        { stateDir, isBlockShown: () => true },
+      )
+      expect(d.deliver).toBe(false)
+      expect(d.reason).toBe('ephemeral-shown')
+    })
+  })
+
+  it('bridges a genuine unsent answer that was NOT shown (empty-capture divergence)', () => {
+    withState(REAL_ANSWER, ({ stateDir }) => {
+      const d = decideCapturedProseDelivery(
+        { turnKey: 'c:_', turnId: 'c:_#5', minChars: 10 },
+        { stateDir, isBlockShown: () => false },
+      )
+      expect(d.deliver).toBe(true)
+      if (d.deliver) expect(d.text).toContain(REAL_ANSWER)
+    })
+  })
+})
+
+describe('durable shown-ledger — round trip + envelope-less no-op (correction 4)', () => {
+  it('marks then recognises a structural narration block for its turnNonce', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'shown-ledger-'))
+    try {
+      appendShownBlock('c:_#7', NARRATION, dir)
+      expect(isShownBlock('c:_#7', NARRATION, dir)).toBe(true)
+      // A different turn's nonce must NOT match (no cross-turn suppression).
+      expect(isShownBlock('c:_#8', NARRATION, dir)).toBe(false)
+      // The stored hash matches the shared classifier hash.
+      expect(readShownHashes('c:_#7', dir).has(ledgerHashHex(NARRATION))).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('a null turnNonce (envelope-less handback/cron) is never written', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'shown-ledger-'))
+    try {
+      appendShownBlock(null, NARRATION, dir)
+      expect(isShownBlock(null, NARRATION, dir)).toBe(false)
+      expect(readShownHashes(null, dir).size).toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+/** Fake at-most-one scheduler mirroring the real unref'd setTimeout wiring. */
+class FakeScheduler {
+  private fn: (() => void) | null = null
+  arm(fn: () => void): void {
+    this.fn = fn
+  }
+  disarm(): void {
+    this.fn = null
+  }
+  fire(): void {
+    const fn = this.fn
+    this.fn = null
+    fn?.()
+  }
+}
+
+describe('narrative controller — durable-mark ONLY mid-turn narration (correction 4)', () => {
+  function make() {
+    const show = vi.fn<[string], void>()
+    const retractShown = vi.fn<[string], void>()
+    const markDurableNarration = vi.fn<[string], void>()
+    const scheduler = new FakeScheduler()
+    const ctrl = new NarrativeFlushController(
+      { show, retractShown, markDurableNarration },
+      scheduler,
+      250,
+    )
+    return { ctrl, show, markDurableNarration, scheduler }
+  }
+
+  it('marks a block SHOWN mid-turn because another narration block followed it (stage)', () => {
+    const { ctrl, show, markDurableNarration } = make()
+    ctrl.stage('First, let me check the logs…')
+    ctrl.stage('Now scanning the outbox…') // lookahead → shows + marks the first
+    expect(show).toHaveBeenCalledWith('First, let me check the logs…')
+    expect(markDurableNarration).toHaveBeenCalledWith('First, let me check the logs…')
+  })
+
+  it('marks a block SHOWN mid-turn because a tool followed it (resolveOnTool)', () => {
+    const { ctrl, markDurableNarration } = make()
+    ctrl.stage(NARRATION)
+    ctrl.resolveOnTool('Bash', { command: 'grep' }) // non-reply tool lookahead
+    expect(markDurableNarration).toHaveBeenCalledWith(NARRATION)
+  })
+
+  it('NEVER marks the timer-painted terminal block (could be the real answer)', () => {
+    const { ctrl, show, markDurableNarration, scheduler } = make()
+    ctrl.stage(REAL_ANSWER)
+    scheduler.fire() // timer paints the LAST block early
+    expect(show).toHaveBeenCalledWith(REAL_ANSWER)
+    expect(markDurableNarration).not.toHaveBeenCalled()
+  })
+
+  it('NEVER marks the turn-end paint (terminal, could be the real answer)', () => {
+    const { ctrl, show, markDurableNarration } = make()
+    ctrl.stage(REAL_ANSWER)
+    ctrl.flushAtTurnEnd('') // no reply delivered → shows trailing prose, but never marks
+    expect(show).toHaveBeenCalledWith(REAL_ANSWER)
+    expect(markDurableNarration).not.toHaveBeenCalled()
+  })
+
+  it('does NOT mark a SUBSTANTIVE block even mid-turn (substance-gated, correction 3)', () => {
+    const { ctrl, markDurableNarration } = make()
+    ctrl.stage(SUBSTANTIVE_BEFORE_REACT)
+    ctrl.resolveOnTool('react', { emoji: '👍' }) // non-delivering tool
+    // Followed by a tool, but substantive → not structural narration → not marked,
+    // so a backstop could still deliver it if it were the genuine unsent answer.
+    expect(markDurableNarration).not.toHaveBeenCalled()
+  })
+})

--- a/telegram-plugin/tests/narration-leak-3513.test.ts
+++ b/telegram-plugin/tests/narration-leak-3513.test.ts
@@ -146,6 +146,67 @@ describe('E4 outbox sweep — a ledger-marked block is never re-delivered (corre
   })
 })
 
+describe('E4 outbox sweep × durable shown-ledger — end-to-end wiring (correction 1 + 4)', () => {
+  // Integration test: exercise the REAL ledger round-trip (append/markShown +
+  // isShownBlock/isBlockShown) keyed by turnNonce THROUGH the outbox-sweep
+  // decision, mirroring the production composition at
+  // gateway/outbox-sweep.ts:122 (`shownLedgerHit: isShownBlock(record.turnNonce,
+  // record.text, deps.stateDir)`). Unlike the unit tests above that pass a
+  // hand-set `shownLedgerHit` boolean, this drives the flag FROM the durable
+  // ledger file — so if the ledger wiring is removed (append becomes a no-op, or
+  // decideOutboxSweep stops consulting the hit), the skip assertion goes RED.
+  const base = {
+    now: 10_000_000,
+    deliveredNonces: new Set<string>(),
+    textAlreadyDelivered: false,
+    routable: true,
+    quietMs: 0,
+  }
+
+  it('a block marked shown for its turnNonce is skipped; a non-shown block delivers', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'outbox-ledger-'))
+    try {
+      const nonce = 'c:_#42'
+      // markShown: the mid-turn narrative paint appended this block to the
+      // durable ledger for THIS turn's nonce.
+      appendShownBlock(nonce, NARRATION, dir)
+
+      // Sweep the SAME (nonce, text): the production wiring derives the flag from
+      // the ledger, so the record must be skipped as ephemeral-shown.
+      const shown = decideOutboxSweep({
+        ...base,
+        record: { turnNonce: nonce, text: NARRATION, createdAt: 0 },
+        shownLedgerHit: isShownBlock(nonce, NARRATION, dir),
+      })
+      expect(isShownBlock(nonce, NARRATION, dir)).toBe(true)
+      expect(shown.action).toBe('skip-ephemeral-shown')
+      expect(shown.text).toBeUndefined()
+
+      // A NON-shown block (the genuine unsent answer, never appended) still
+      // delivers exactly once — the ledger miss falls through to send.
+      const notShown = decideOutboxSweep({
+        ...base,
+        record: { turnNonce: nonce, text: REAL_ANSWER, createdAt: base.now },
+        shownLedgerHit: isShownBlock(nonce, REAL_ANSWER, dir),
+      })
+      expect(isShownBlock(nonce, REAL_ANSWER, dir)).toBe(false)
+      expect(notShown.action).toBe('send')
+      expect(notShown.text).toContain(REAL_ANSWER)
+
+      // Cross-turn isolation: the SAME text under a DIFFERENT turnNonce is not a
+      // ledger hit, so it delivers (no cross-turn suppression through the sweep).
+      const otherTurn = decideOutboxSweep({
+        ...base,
+        record: { turnNonce: 'c:_#43', text: NARRATION, createdAt: base.now },
+        shownLedgerHit: isShownBlock('c:_#43', NARRATION, dir),
+      })
+      expect(otherTurn.action).toBe('send')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('E3 captured-prose bridge — a shown block is refused (correction 1)', () => {
   /** Write a real silent-end-pending.json into a temp stateDir. */
   function withState(text: string, run: (deps: { stateDir: string }) => void): void {

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -19,6 +19,12 @@
  * and can be set to `0` / `false` / `off` to disable without a rebuild.
  */
 
+import {
+  isNarrationBlock,
+  isStructuralNarration,
+  SUBSTANTIVE_MIN_CHARS,
+} from './hooks/narration-classify.mjs'
+
 const SILENT_MARKERS = new Set(['NO_REPLY', 'HEARTBEAT_OK'])
 // Small buffer so `NO_REPLY.` with a stray period still counts as silent.
 const SILENT_MARKER_MAX_LEN = Math.max(
@@ -134,7 +140,7 @@ export function endsWithSilentMarker(text: string | undefined): boolean {
  * `hooks/silent-end-scan.mjs` — the same bar the codebase uses everywhere to
  * recognise "this text block is a real answer, not a short narration/closer".
  */
-export const FLUSH_SUBSTANTIVE_MIN_CHARS = 200
+export const FLUSH_SUBSTANTIVE_MIN_CHARS = SUBSTANTIVE_MIN_CHARS
 
 /**
  * Pick the text a turn-flush should actually DELIVER from the captured
@@ -203,9 +209,33 @@ export function selectFlushDeliveryText(
     .map((b, i) => ({ text: b.trim(), followedByToolUse: followedByToolUse?.[i] }))
     .filter(c => c.text.length > 0)
   if (candidates.length === 0) return ''
-  if (candidates.length === 1) return candidates[0].text
-  const answer = candidates[candidates.length - 1].text
-  const preceding = candidates.slice(0, -1)
+
+  // #3513 — the STRUCTURAL rule now applies to the TERMINAL block too, not only
+  // preceding blocks. A lone trailing block that a `tool_use` FOLLOWED (the
+  // model kept acting after writing it) is intra-turn narration by construction,
+  // never the terminal answer — so it must not be delivered as one. This is the
+  // primary fix for the observed leak ("Now checking the gateway logs…"),
+  // wording-independent where the opener regex fails. It stays substance-gated
+  // (correction 3): only a SHORT or narration-shaped block that a tool followed
+  // is suppressed — a SUBSTANTIVE, non-narration block followed by a
+  // non-delivering tool (react / pin / typing / edit) is NOT structural
+  // narration and still delivers.
+  //
+  // Only the STRUCTURAL signal (`followedByToolUse === true`) may strip the
+  // terminal block; the opener/trailer heuristic remains a residual tie-breaker
+  // for PRECEDING blocks only, so a provenance-less single block still delivers
+  // verbatim (#3276 finding 7 — a colon-terminated line that IS the whole answer
+  // is never dropped).
+  let cs = candidates
+  while (cs.length > 1 && isStructuralNarration(cs[cs.length - 1].text, cs[cs.length - 1].followedByToolUse)) {
+    cs = cs.slice(0, -1)
+  }
+  if (cs.length === 1) {
+    return isStructuralNarration(cs[0].text, cs[0].followedByToolUse) ? '' : cs[0].text
+  }
+
+  const answer = cs[cs.length - 1].text
+  const preceding = cs.slice(0, -1)
   // Deliver only the terminal answer when every earlier block is
   // intent-narration. Per block:
   //   - structural flag TRUE ⇒ a tool_use followed this block, but that alone
@@ -228,50 +258,15 @@ export function selectFlushDeliveryText(
         ? false
         : isNarrationBlock(c.text),
   )
-  return allNarration ? answer : candidates.map(c => c.text).join('\n\n')
+  return allNarration ? answer : cs.map(c => c.text).join('\n\n')
 }
 
-/**
- * Narration heuristic: a block that opens with a first-person "about to do X"
- * phrase the model emits BEFORE composing its real answer ("Let me check…",
- * "I'll look it up…", "Now let me…"). Deliberately NOT length-based — the
- * narration that shadowed the real answer in the observed bug was a LONG
- * (≥200-char) "Let me pull the numbers…" block, and short blocks are frequently
- * legitimate multi-paragraph answer content — so gating on length either drops a
- * short real answer or keeps a long narration. When earlier blocks don't match
- * this opener we keep the full joined text (never drop content we can't
- * confidently attribute to narration).
- */
-const NARRATION_OPENER =
-  /^(let me\b|lemme\b|i'?ll\b|i will\b|i am going to\b|i'?m going to\b|i'?m about to\b|going to\b|first,?\s+(?:let me|i'?ll|i will)\b|now,?\s+(?:let me|i'?ll|i will)\b|next,?\s+(?:let me|i'?ll|i will)\b|let'?s\b)/i
-
-/**
- * #3276 guard 8 — the `NARRATION_OPENER` regex alone misses common progress
- * narration that opens with a gerund/present-continuous verb and trails off
- * into an ellipsis or colon: "Checking now…", "Pulling the numbers:",
- * "Looking into that…". Relying on the opener regex leaked those blocks into
- * the delivered answer. This recognises a NON-terminal narration line
- * deterministically, WITHOUT re-gating on a min-char floor (a short real
- * answer like "Yes, done." must still deliver): a single short line that ends
- * with an ellipsis or a colon is progress narration, not the terminal answer.
- *
- * Kept conservative on purpose — only a SINGLE-line block (no internal
- * paragraph) under the substantive floor, ending in `…` / `...` / `:`, so a
- * genuine multi-paragraph answer that happens to end a paragraph with a colon
- * is never mistaken for narration.
- */
-const NARRATION_TRAILER = /(?:\.{3}|…|:)\s*$/
-
-function isTrailingNarrationLine(block: string): boolean {
-  const t = block.trim()
-  if (t.length === 0 || t.length >= FLUSH_SUBSTANTIVE_MIN_CHARS) return false
-  if (t.includes('\n')) return false
-  return NARRATION_TRAILER.test(t)
-}
-
-function isNarrationBlock(block: string): boolean {
-  return NARRATION_OPENER.test(block.trimStart()) || isTrailingNarrationLine(block)
-}
+// The narration heuristic (`isNarrationBlock` / openers / trailer) and the
+// structural rule (`isStructuralNarration`) now live in the ONE shared
+// classifier `hooks/narration-classify.mjs`, imported at the top of this file
+// and by the unbundled Stop hook (`hooks/silent-end-scan.mjs`) alike — so the
+// TS gateway side and the `.mjs` side can never drift (switchroom#3513
+// correction 2; retires the old "MUST stay in sync" hand-synced copies).
 
 export type FlushDecision =
   | { kind: 'flush'; text: string }


### PR DESCRIPTION
## Problem

Agent intent-narration ("Now let me check the gateway logs…") could leak into the final Telegram reply as a real chat message. Root cause: two hand-synced regex classifiers judged trailing assistant text, and ~6 delivery paths decided "unsent final answer?" independently, without a shared decision or any consultation of the ephemeral progress card.

## The invariant

Every trailing plain-text block is assigned **once to exactly one surface** — delivered chat answer / ephemeral progress card / suppressed — by **ONE shared classifier**. No delivery path (E1 turn-flush, E2 quiescence, E3 captured-prose bridge, E4 outbox sweep) ever emits a block classified as structural narration; the one genuine unsent answer still delivers **exactly once**. The structural signal (a text block that a `tool_use` *followed* in the same assistant message) is primary and wording-independent; the regex heuristic is demoted to a residual tie-breaker.

## The four corrections

1. **No single-chokepoint assumption.** The suppression check lives INSIDE each backstop decision — `decideOutboxSweep` (E4) and `decideCapturedProseDelivery` (E3) — plus the in-process flush, because E3/E4 send via `bot.api.sendMessage` directly and bypass `normalizeOutboundBody`.
2. **One shared classifier as raw `.mjs`** (`hooks/narration-classify.mjs` + `.d.mts` for TS interop), imported by BOTH the unbundled Stop hook (`silent-end-scan.mjs`) and the bundled gateway TS (`turn-flush-safety.ts` / `shown-ledger.ts` / `narrative-flush.ts`). Retires the two hand-synced regex copies.
3. **Structural rule is substance-gated, not absolute.** `followedByToolUse === true` is a DEMOTION signal gated by the substantive floor / heuristic. A substantive real message followed by a non-delivering tool (react/pin/typing/edit) still delivers; only a short OR narration-shaped block a tool followed is suppressed. Preserves the #3237 asymmetry.
4. **Never ledger-mark a block that could be the real answer.** The durable shown-ledger (keyed by turnNonce, sibling of the outbox) is written ONLY from the mid-turn SHOW paths (`stage`/`resolveOnTool`), never the timer-paint or turn-end paint, and only for structurally-narration blocks. A drop is worse than a duplicate — a genuine answer is never in the ledger, so a ledger check can never suppress it.

**Documented should-fix:** the ledger is envelope-bearing-only (best-effort belt); the structural rule is the sole guard for envelope-less turns (handback/background/cron). Noted in `shown-ledger.ts`.

## Test plan

New `tests/narration-leak-3513.test.ts` (21 outcome-asserting cases):
- Shared classifier: short/narration blocks a tool followed ARE structural narration; substantive blocks a tool followed are NOT; terminal blocks are never narration.
- E1/E2 flush: drops trailing narration (including the short non-regex class the old classifier missed), keeps the real answer, delivers a provenance-less single block, delivers a substantive answer followed by a non-delivering tool.
- E4 sweep: `skip-ephemeral-shown` on ledger hit; delivers a non-shown answer; journaled short-circuits before the ledger.
- E3 bridge: refuses a shown block; bridges a genuine unsent answer (empty-capture divergence).
- Durable ledger: round-trip + envelope-less no-op.
- Narrative controller: marks mid-turn narration, NEVER the timer/turn-end terminal paint, NEVER a substantive block.

Scoped suites green locally (turn-flush-safety, silent-end*, outbox*, narrative*, reaction-flush, etc.). `npm run lint` clean (including the strict plugin-references tsc and gateway line ratchet). The 23 unrelated full-suite failures (CLI/docker/host-control/install/scheduler) pre-exist on clean origin/main in this environment and are not touched by this change.

Closes #3513

🤖 Generated with [Claude Code](https://claude.com/claude-code)