### PR TITLE
fix(telegram): keep the 🔊 Listen button on outbox-sweep-delivered answers

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -60,6 +60,7 @@ import {
 import {
   VoiceOnDemandCache,
 } from '../voice-ondemand.js'
+import { makeOutboxListenMarkupResolver } from './outbox-listen-markup.js'
 import {
   PreSynthQueue,
   sweepVoiceCacheDir,
@@ -9850,7 +9851,7 @@ function runDeliveryConfirmSweep(): void {
 const _deliveryConfirmSweep = isGatewayMain ? setInterval(runDeliveryConfirmSweep, DELIVERY_CONFIRM_SWEEP_MS) : undefined
 _deliveryConfirmSweep?.unref?.()
 
-startOutboxSweep({ isGatewayMain, stateDir: STATE_DIR, getBot: () => bot, getTurnsDb: () => turnsDb, dedupCheck: (c, t, x) => outboundDedup.check(c, t, x, Date.now()) != null, log: (l) => process.stderr.write(l) }) // outbox: single deliverer for Stop-hook-captured prose (../outbox.ts)
+startOutboxSweep({ isGatewayMain, stateDir: STATE_DIR, getBot: () => bot, getTurnsDb: () => turnsDb, dedupCheck: (c, t, x) => outboundDedup.check(c, t, x, Date.now()) != null, resolveReplyMarkup: makeOutboxListenMarkupResolver({ resolveVoiceOutPlan: (t) => resolveVoiceOutPlan(loadAccess().voice_out, t), cachePut: (token, payload) => voiceOnDemandCache.put(token, payload), eagerVoiceEnabled, enqueuePreSynth: (j) => voicePreSynthQueue.enqueue(j) }), log: (l) => process.stderr.write(l) }) // outbox: single deliverer for Stop-hook prose; resolveReplyMarkup keeps the #3502 Listen button on net-delivered answers (../outbox.ts)
 
 // #1445 cross-turn pending-async ambient. When a turn ends after the
 // model dispatched background async work (Agent / Task / Bash run-in-

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -65,9 +65,8 @@ import {
 import { decideAnswerLatchSuppression, type ReplyOwnerTier } from '../reply-owner-resolve.js'
 import { deriveTelegraphTitle } from '../telegraph.js'
 import {
-  mintVoiceOnDemandToken,
-  buildListenKeyboard,
   mayInjectListenButton,
+  planListenButton,
   type VoiceOnDemandCache,
 } from '../voice-ondemand.js'
 import { eagerVoiceEnabled, type PreSynthQueue } from '../voice-presynth.js'
@@ -1495,31 +1494,27 @@ export async function sendReply(
   // config never reaches here (it synthesized immediately above), so a Listen
   // button is never minted for an engine whose taps would dead-end on the
   // local sidecar.
-  if (
-    useOnDemandButton &&
-    voiceOutPlan!.ttsChunks.length > 0 &&
-    voiceOutPlan!.ttsChunks[0]!.length > 0
-  ) {
-    if (!mayInjectListenButton(rawKeyboard)) {
-      process.stderr.write(
-        'telegram gateway: voice-out on-demand: agent supplied inline_keyboard — skipping Listen button (single_use collision gate)\n',
-      )
+  if (useOnDemandButton) {
+    // planListenButton is the SHARED decision (also used by the durable-outbox
+    // safety net, outbox-sweep.ts) — it enforces the empty-TTS guard and the
+    // agent-keyboard collision gate. Null = don't inject.
+    const listenPlan = planListenButton({ voiceOutPlan, rawKeyboard })
+    if (listenPlan == null) {
+      if (!mayInjectListenButton(rawKeyboard)) {
+        process.stderr.write(
+          'telegram gateway: voice-out on-demand: agent supplied inline_keyboard — skipping Listen button (single_use collision gate)\n',
+        )
+      }
     } else {
       // Token is intentionally GLOBAL (not chat-keyed): under the single-tenant
       // invariant the operator is the only authorized sender across all chats,
       // and the tap handler re-checks access.allowFrom before synthesizing, so
       // a token needs no per-chat scoping to be safe.
-      const token = mintVoiceOnDemandToken()
-      voiceOnDemandCache.put(token, {
-        // ttsChunks[0] is already normalizeForSpeech(reply) (kokoro path).
-        text: voiceOutPlan.ttsChunks[0]!,
-        ...(voiceOutPlan.voice != null ? { voice: voiceOutPlan.voice } : {}),
-        speed: voiceOutPlan.speed,
-      })
+      voiceOnDemandCache.put(listenPlan.token, listenPlan.payload)
       // The keyboard stays after the tap (never stripped) so it can be
       // replayed. The gate above guarantees this is the ONLY button on the
       // message, so keeping it is safe (no agent buttons to protect).
-      replyMarkup = buildListenKeyboard(token)
+      replyMarkup = listenPlan.replyMarkup
       // #2763 eager pre-synthesis: kick a background synth of the same
       // payload so the Listen tap attaches the pre-made file instantly.
       // Local-engine only (useOnDemandButton already gates engine==='kokoro'
@@ -1530,10 +1525,10 @@ export async function sendReply(
       // to the lazy path).
       if (eagerVoiceEnabled()) {
         voicePreSynthQueue.enqueue({
-          token,
-          text: voiceOutPlan.ttsChunks[0]!,
-          ...(voiceOutPlan.voice != null ? { voice: voiceOutPlan.voice } : {}),
-          speed: voiceOutPlan.speed,
+          token: listenPlan.token,
+          text: listenPlan.payload.text,
+          ...(listenPlan.payload.voice != null ? { voice: listenPlan.payload.voice } : {}),
+          speed: listenPlan.payload.speed,
         })
       }
     }

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -1500,7 +1500,14 @@ export async function sendReply(
     // agent-keyboard collision gate. Null = don't inject.
     const listenPlan = planListenButton({ voiceOutPlan, rawKeyboard })
     if (listenPlan == null) {
-      if (!mayInjectListenButton(rawKeyboard)) {
+      // Log the collision gate ONLY when the agent keyboard is the ACTUAL
+      // reason we skipped — i.e. there IS speakable text. When ttsChunks is
+      // empty the empty-TTS guard is what returned null (there was nothing to
+      // speak), so a "skipping — agent supplied inline_keyboard" line would
+      // misattribute the reason.
+      const hasSpeakableText =
+        voiceOutPlan!.ttsChunks.length > 0 && voiceOutPlan!.ttsChunks[0]!.length > 0
+      if (hasSpeakableText && !mayInjectListenButton(rawKeyboard)) {
         process.stderr.write(
           'telegram gateway: voice-out on-demand: agent supplied inline_keyboard — skipping Listen button (single_use collision gate)\n',
         )

--- a/telegram-plugin/gateway/outbox-listen-markup.ts
+++ b/telegram-plugin/gateway/outbox-listen-markup.ts
@@ -1,0 +1,67 @@
+/**
+ * outbox-listen-markup.ts — wires the shared `planListenButton` decision into
+ * the durable-outbox safety-net delivery (outbox-sweep.ts), so a net-delivered
+ * final answer carries the SAME 🔊 Listen button / voice-out keyboard the normal
+ * `sendReply` path injects (switchroom #3502 regression: the sweep sent captured
+ * prose via a RAW `bot.api.sendMessage` with no voice-out resolution, dropping
+ * the button).
+ *
+ * Extracted from gateway.ts so the wiring lives in a module (the #2996 gateway
+ * anti-inflation ratchet) and is independently testable.
+ */
+
+import {
+  planListenButton,
+  type ListenButtonVoiceOutPlan,
+  type VoiceOnDemandPayload,
+} from '../voice-ondemand.js'
+import type { OutboxDeliveryMarkup } from './outbox-sweep.js'
+
+/** The minimal side-effecting deps the resolver needs — mirrors what `sendReply`
+ *  does on the normal path (cache put + eager pre-synth), kept as an injected
+ *  surface so gateway.ts passes its own singletons and this stays unit-testable. */
+export interface OutboxListenMarkupDeps {
+  /** Resolve the agent's voice-out plan for a reply body (loadAccess().voice_out
+   *  → resolveVoiceOutPlan). Returns null when voice-out is off / not applicable. */
+  resolveVoiceOutPlan: (replyText: string) => ListenButtonVoiceOutPlan | null
+  /** Persist a minted token so a Listen tap can resynthesize. A thin closure
+   *  (not the cache instance) so the gateway can pass it before its module-scope
+   *  `voiceOnDemandCache` const is initialized (this factory runs at wiring time,
+   *  earlier in gateway.ts than the cache declaration). */
+  cachePut: (token: string, payload: VoiceOnDemandPayload) => void
+  /** True when eager pre-synth is enabled (kill switch off). */
+  eagerVoiceEnabled: () => boolean
+  /** Enqueue an eager pre-synth job (best-effort, off the critical path). */
+  enqueuePreSynth: (job: { token: string; text: string; voice?: string; speed: number }) => void
+}
+
+/**
+ * Build the `resolveReplyMarkup` callback for `startOutboxSweep`. Returns the
+ * Listen keyboard (and persists the token + eager-synth job) when kokoro
+ * on-demand voice-out is enabled and the empty-TTS / collision gates pass;
+ * otherwise undefined → the sweep delivers plain.
+ *
+ * A net-delivered captured-prose answer never carries an agent keyboard, so
+ * `rawKeyboard` is always undefined here; `planListenButton` still enforces the
+ * empty-TTS guard and the kokoro-on-demand gate.
+ */
+export function makeOutboxListenMarkupResolver(
+  deps: OutboxListenMarkupDeps,
+): (chatId: string, threadId: number | null, text: string) => OutboxDeliveryMarkup | undefined {
+  return (_chatId, _threadId, text) => {
+    const voiceOutPlan = deps.resolveVoiceOutPlan(text)
+    const listenPlan = planListenButton({ voiceOutPlan, rawKeyboard: undefined })
+    if (listenPlan == null) return undefined
+    const payload: VoiceOnDemandPayload = listenPlan.payload
+    deps.cachePut(listenPlan.token, payload)
+    if (deps.eagerVoiceEnabled()) {
+      deps.enqueuePreSynth({
+        token: listenPlan.token,
+        text: payload.text,
+        ...(payload.voice != null ? { voice: payload.voice } : {}),
+        speed: payload.speed,
+      })
+    }
+    return listenPlan.replyMarkup
+  }
+}

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -287,6 +287,11 @@ export function createOutboxSend(deps: {
   return async (chatId, threadId, text) => {
     const bot = deps.getBot()
     if (bot == null) throw new Error('outbox-sweep: bot unavailable')
+    // Empty text → nothing to deliver. Telegram rejects an empty message body,
+    // so sending one chunk of '' would throw every tick and wedge the sweep in
+    // a permanent retry (the record never journals → never clears). Return
+    // early, matching the pre-refactor loop's zero-chunk behaviour.
+    if (text.length === 0) return undefined
     // Resolve the Listen button / keyboard ONCE from the full answer text; it
     // rides only on the final chunk below.
     const replyMarkup = deps.resolveReplyMarkup?.(chatId, threadId, text)
@@ -295,8 +300,8 @@ export function createOutboxSend(deps: {
     // propagates so the sweep releases the claim and retries next tick (the
     // record is never journaled → never lost).
     let lastId: number | undefined
-    const chunkCount = Math.max(1, Math.ceil(text.length / 4000))
-    for (let i = 0, idx = 0; i < text.length || idx === 0; i += 4000, idx++) {
+    const chunkCount = Math.ceil(text.length / 4000)
+    for (let i = 0, idx = 0; i < text.length; i += 4000, idx++) {
       const chunk = text.slice(i, i + 4000)
       const isLast = idx === chunkCount - 1
       const res = await retryWithThreadFallback(

--- a/telegram-plugin/gateway/outbox-sweep.ts
+++ b/telegram-plugin/gateway/outbox-sweep.ts
@@ -244,39 +244,108 @@ export const OUTBOX_SWEEP_INTERVAL_MS = 5_000
  * (`resolveSubagentOriginTurnKey`) then the last-real-inbound fallback (H3).
  * Kill switch: `SWITCHROOM_TG_OUTBOX_DELIVERY=0`.
  */
+/** A Telegram inline keyboard the sweep attaches to the FINAL delivered chunk
+ *  (the 🔊 Listen button / voice-out keyboard — switchroom #3502 regression fix,
+ *  so a net-delivered answer keeps the same button a `sendReply` answer gets).
+ *  Shaped to match `planListenButton().replyMarkup`. */
+export type OutboxDeliveryMarkup = {
+  inline_keyboard: Array<Array<{ text: string; callback_data: string }>>
+}
+
+/** Minimal bot-api surface the sweep needs to deliver text. */
+type OutboxSendBot = {
+  api: {
+    sendMessage: (
+      chatId: string,
+      text: string,
+      opts: object,
+    ) => Promise<{ message_id?: number }>
+  }
+}
+
+/**
+ * Build the chunked `send` the sweep hands to {@link sweepOutbox}. Extracted +
+ * exported so the reply-markup attachment (the #3502 fix) is unit-testable
+ * without a live gateway or timer.
+ *
+ * `resolveReplyMarkup` resolves the voice-out Listen button / keyboard for a
+ * delivery (null/undefined → no button). It is applied to the FINAL chunk ONLY
+ * so the button lands on the last visible message, exactly like the normal
+ * `sendReply` path (buttons attach to the last chunk there too). This makes a
+ * safety-net-delivered final answer indistinguishable from a normally-delivered
+ * one instead of silently dropping the button.
+ */
+export function createOutboxSend(deps: {
+  getBot: () => OutboxSendBot | undefined
+  retry: Parameters<typeof retryWithThreadFallback>[0]
+  resolveReplyMarkup?: (
+    chatId: string,
+    threadId: number | null,
+    text: string,
+  ) => OutboxDeliveryMarkup | undefined
+}): OutboxSweepDeps['send'] {
+  return async (chatId, threadId, text) => {
+    const bot = deps.getBot()
+    if (bot == null) throw new Error('outbox-sweep: bot unavailable')
+    // Resolve the Listen button / keyboard ONCE from the full answer text; it
+    // rides only on the final chunk below.
+    const replyMarkup = deps.resolveReplyMarkup?.(chatId, threadId, text)
+    // Chunk to Telegram's 4096-char ceiling; each chunk goes through the
+    // standard retry / flood-wait / thread-fallback wrapper. A thrown send
+    // propagates so the sweep releases the claim and retries next tick (the
+    // record is never journaled → never lost).
+    let lastId: number | undefined
+    const chunkCount = Math.max(1, Math.ceil(text.length / 4000))
+    for (let i = 0, idx = 0; i < text.length || idx === 0; i += 4000, idx++) {
+      const chunk = text.slice(i, i + 4000)
+      const isLast = idx === chunkCount - 1
+      const res = await retryWithThreadFallback(
+        deps.retry,
+        (tid) => {
+          const base = tid != null ? { message_thread_id: tid } : {}
+          // Button on the LAST chunk only (final visible message).
+          const opts =
+            isLast && replyMarkup != null ? { ...base, reply_markup: replyMarkup } : base
+          return bot.api.sendMessage(chatId, chunk, opts)
+        },
+        { threadId: threadId ?? undefined, chat_id: chatId, verb: 'outbox-sweep.sendMessage' },
+      )
+      lastId = res?.message_id
+    }
+    return lastId
+  }
+}
+
 export function startOutboxSweep(deps: {
   isGatewayMain: boolean
   stateDir: string
-  getBot: () => { api: { sendMessage: (chatId: string, text: string, opts: object) => Promise<{ message_id?: number }> } } | undefined
+  getBot: () => OutboxSendBot | undefined
   getTurnsDb: () => Parameters<typeof resolveSubagentOriginTurnKey>[0] | null
   dedupCheck: (chatId: string, threadId: number | undefined, text: string) => boolean
+  /** Resolve the voice-out Listen button / keyboard for a net delivery. Wired
+   *  by the gateway (loadAccess → resolveVoiceOutPlan → planListenButton +
+   *  cache put + eager pre-synth). Absent → deliver plain (legacy behaviour). */
+  resolveReplyMarkup?: (
+    chatId: string,
+    threadId: number | null,
+    text: string,
+  ) => OutboxDeliveryMarkup | undefined
   log?: (line: string) => void
 }): ReturnType<typeof setInterval> | undefined {
   if (!deps.isGatewayMain || process.env.SWITCHROOM_TG_OUTBOX_DELIVERY === '0') return undefined
   const retry = createRetryApiCall({ log: deps.log })
+  const send = createOutboxSend({
+    getBot: deps.getBot,
+    retry,
+    ...(deps.resolveReplyMarkup != null ? { resolveReplyMarkup: deps.resolveReplyMarkup } : {}),
+  })
   const tick = () => {
     const bot = deps.getBot()
     if (bot == null) return
     void sweepOutbox({
       stateDir: deps.stateDir,
       log: deps.log,
-      send: async (chatId, threadId, text) => {
-        // Chunk to Telegram's 4096-char ceiling; each chunk goes through the
-        // standard retry / flood-wait / thread-fallback wrapper. A thrown send
-        // propagates so the sweep releases the claim and retries next tick (the
-        // record is never journaled → never lost).
-        let lastId: number | undefined
-        for (let i = 0; i < text.length; i += 4000) {
-          const chunk = text.slice(i, i + 4000)
-          const res = await retryWithThreadFallback(
-            retry,
-            (tid) => bot.api.sendMessage(chatId, chunk, tid != null ? { message_thread_id: tid } : {}),
-            { threadId: threadId ?? undefined, chat_id: chatId, verb: 'outbox-sweep.sendMessage' },
-          )
-          lastId = res?.message_id
-        }
-        return lastId
-      },
+      send,
       textAlreadyDelivered: (chatId, threadId, text) => deps.dedupCheck(chatId, threadId ?? undefined, text),
       registryChainLookup: (taskId) => {
         const db = deps.getTurnsDb()

--- a/telegram-plugin/tests/outbox-sweep-listen-button.test.ts
+++ b/telegram-plugin/tests/outbox-sweep-listen-button.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Regression: switchroom #3502 — the durable-outbox safety net dropped the 🔊
+ * Listen button from a net-delivered final answer.
+ *
+ * PR #3502 / commit 1a531ebb added the outbox-sweep deliverer, which sent the
+ * captured final answer via a RAW `bot.api.sendMessage` with no voice-out
+ * resolution — so any answer the net delivered lost the Listen button that the
+ * normal `sendReply` path injects. The fix threads a shared `planListenButton`
+ * decision into the sweep's chunked send (`createOutboxSend`) so a net-delivered
+ * answer is indistinguishable from a normally-delivered one.
+ *
+ * These tests assert OUTCOMES, not code paths:
+ *  - the delivered message actually carries the Listen keyboard when kokoro
+ *    on-demand voice-out is enabled;
+ *  - it does NOT when the agent supplied its own keyboard, when the TTS text is
+ *    empty, or when voice-out is not kokoro-on-demand.
+ * A test that only walked the code without asserting `reply_markup` on the sent
+ * message would not fail on the pre-fix RAW-send bug, so we assert the exact
+ * bytes handed to `sendMessage`.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createOutboxSend } from '../gateway/outbox-sweep.js'
+import { makeOutboxListenMarkupResolver } from '../gateway/outbox-listen-markup.js'
+import {
+  planListenButton,
+  type ListenButtonVoiceOutPlan,
+} from '../voice-ondemand.js'
+
+const kokoroOnDemand: ListenButtonVoiceOutPlan = {
+  engine: 'kokoro',
+  speed: 1.1,
+  replyMode: 'on-demand',
+  ttsChunks: ['the spoken answer'],
+}
+
+// A passthrough retry that simply invokes the send fn once (no flood/thread
+// fallback needed for the unit under test).
+const passthroughRetry = <U>(fn: () => Promise<U>): Promise<U> => fn()
+
+function fakeBot() {
+  const calls: Array<{ chatId: string; text: string; opts: Record<string, unknown> }> = []
+  let n = 100
+  return {
+    calls,
+    api: {
+      sendMessage: async (chatId: string, text: string, opts: object) => {
+        calls.push({ chatId, text, opts: opts as Record<string, unknown> })
+        return { message_id: n++ }
+      },
+    },
+  }
+}
+
+describe('planListenButton — shared Listen-button decision', () => {
+  it('injects for kokoro on-demand with non-empty TTS and no agent keyboard', () => {
+    const plan = planListenButton({ voiceOutPlan: kokoroOnDemand, rawKeyboard: undefined })
+    expect(plan).not.toBeNull()
+    expect(plan!.replyMarkup.inline_keyboard[0]![0]!.text).toBe('🔊 Listen')
+    expect(plan!.replyMarkup.inline_keyboard[0]![0]!.callback_data).toBe(`voice:${plan!.token}`)
+    expect(plan!.payload.text).toBe('the spoken answer')
+    expect(plan!.payload.speed).toBe(1.1)
+  })
+
+  it('does NOT inject when the agent supplied its own keyboard (collision gate)', () => {
+    const plan = planListenButton({
+      voiceOutPlan: kokoroOnDemand,
+      rawKeyboard: [[{ text: 'Approve', callback_data: 'ok' }]],
+    })
+    expect(plan).toBeNull()
+  })
+
+  it('does NOT inject when the TTS text is empty (empty-TTS guard)', () => {
+    const plan = planListenButton({
+      voiceOutPlan: { ...kokoroOnDemand, ttsChunks: [''] },
+      rawKeyboard: undefined,
+    })
+    expect(plan).toBeNull()
+  })
+
+  it('does NOT inject for openai on-demand (taps would dead-end on local sidecar)', () => {
+    const plan = planListenButton({
+      voiceOutPlan: { ...kokoroOnDemand, engine: 'openai' },
+      rawKeyboard: undefined,
+    })
+    expect(plan).toBeNull()
+  })
+
+  it('does NOT inject when reply_mode is not on-demand', () => {
+    const plan = planListenButton({
+      voiceOutPlan: { ...kokoroOnDemand, replyMode: 'voice+text' },
+      rawKeyboard: undefined,
+    })
+    expect(plan).toBeNull()
+  })
+
+  it('returns null when there is no voice-out plan', () => {
+    expect(planListenButton({ voiceOutPlan: null, rawKeyboard: undefined })).toBeNull()
+  })
+})
+
+describe('createOutboxSend — net-delivered answer carries the Listen button (#3502)', () => {
+  it('attaches the Listen keyboard as reply_markup when voice-out on-demand is enabled', async () => {
+    const bot = fakeBot()
+    const send = createOutboxSend({
+      getBot: () => bot,
+      retry: passthroughRetry,
+      resolveReplyMarkup: () => planListenButton({ voiceOutPlan: kokoroOnDemand, rawKeyboard: undefined })!.replyMarkup,
+    })
+
+    await send('123', null, 'the final answer')
+
+    expect(bot.calls).toHaveLength(1)
+    const markup = bot.calls[0]!.opts.reply_markup as
+      | { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> }
+      | undefined
+    expect(markup).toBeDefined()
+    expect(markup!.inline_keyboard[0]![0]!.text).toBe('🔊 Listen')
+    // Guards against the pre-fix RAW send: no button would have been attached.
+  })
+
+  it('attaches the keyboard to the LAST chunk only (final visible message)', async () => {
+    const bot = fakeBot()
+    const markup = { inline_keyboard: [[{ text: '🔊 Listen', callback_data: 'voice:abcd1234' }]] }
+    const send = createOutboxSend({
+      getBot: () => bot,
+      retry: passthroughRetry,
+      resolveReplyMarkup: () => markup,
+    })
+
+    // > 4000 chars → two chunks.
+    await send('123', null, 'x'.repeat(4500))
+
+    expect(bot.calls).toHaveLength(2)
+    expect(bot.calls[0]!.opts.reply_markup).toBeUndefined()
+    expect(bot.calls[1]!.opts.reply_markup).toEqual(markup)
+  })
+
+  it('delivers plain (no reply_markup) when the resolver returns undefined', async () => {
+    const bot = fakeBot()
+    const send = createOutboxSend({
+      getBot: () => bot,
+      retry: passthroughRetry,
+      resolveReplyMarkup: () => undefined,
+    })
+
+    await send('123', 42, 'plain answer')
+
+    expect(bot.calls).toHaveLength(1)
+    expect(bot.calls[0]!.opts.reply_markup).toBeUndefined()
+    // thread id still threaded through
+    expect(bot.calls[0]!.opts.message_thread_id).toBe(42)
+  })
+
+  it('delivers plain when no resolver is wired at all (legacy behaviour preserved)', async () => {
+    const bot = fakeBot()
+    const send = createOutboxSend({ getBot: () => bot, retry: passthroughRetry })
+
+    await send('123', null, 'legacy answer')
+
+    expect(bot.calls).toHaveLength(1)
+    expect(bot.calls[0]!.opts.reply_markup).toBeUndefined()
+  })
+})
+
+describe('gateway wiring — makeOutboxListenMarkupResolver end-to-end (#3502)', () => {
+  // Pins the ACTUAL gateway resolver: the sweep must obtain the Listen keyboard
+  // AND persist the tap token when kokoro on-demand voice-out is enabled. If a
+  // future change re-severs the sweep delivery from voice-out resolution (the
+  // PR #3502 / commit 1a531ebb raw-sendMessage regression), the delivered
+  // message loses its button and these assertions go red.
+  it('a net-delivered answer carries the button and the tap token is cached', async () => {
+    const cached: Array<{ token: string; text: string }> = []
+    const enqueued: string[] = []
+    const resolve = makeOutboxListenMarkupResolver({
+      resolveVoiceOutPlan: () => kokoroOnDemand,
+      cachePut: (token, payload) => cached.push({ token, text: payload.text }),
+      eagerVoiceEnabled: () => true,
+      enqueuePreSynth: (j) => enqueued.push(j.token),
+    })
+
+    const bot = fakeBot()
+    const send = createOutboxSend({ getBot: () => bot, retry: passthroughRetry, resolveReplyMarkup: resolve })
+    await send('123', null, 'the final answer the net is delivering')
+
+    const markup = bot.calls[0]!.opts.reply_markup as
+      | { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> }
+      | undefined
+    expect(markup).toBeDefined()
+    const btn = markup!.inline_keyboard[0]![0]!
+    expect(btn.text).toBe('🔊 Listen')
+    // The token on the button must be the one cached + eagerly pre-synthesized,
+    // so the tap resolves to real audio (not a dead token).
+    const token = btn.callback_data.replace('voice:', '')
+    expect(cached).toEqual([{ token, text: 'the spoken answer' }])
+    expect(enqueued).toEqual([token])
+  })
+
+  it('resolves to no button (and caches nothing) when voice-out is off', async () => {
+    const cached: string[] = []
+    const resolve = makeOutboxListenMarkupResolver({
+      resolveVoiceOutPlan: () => null,
+      cachePut: (token) => cached.push(token),
+      eagerVoiceEnabled: () => true,
+      enqueuePreSynth: () => {},
+    })
+    const bot = fakeBot()
+    const send = createOutboxSend({ getBot: () => bot, retry: passthroughRetry, resolveReplyMarkup: resolve })
+    await send('123', null, 'plain answer, voice-out disabled')
+
+    expect(bot.calls[0]!.opts.reply_markup).toBeUndefined()
+    expect(cached).toEqual([])
+  })
+
+  it('skips eager pre-synth when the kill switch is off but still shows the button', async () => {
+    const enqueued: string[] = []
+    const resolve = makeOutboxListenMarkupResolver({
+      resolveVoiceOutPlan: () => kokoroOnDemand,
+      cachePut: () => {},
+      eagerVoiceEnabled: () => false,
+      enqueuePreSynth: (j) => enqueued.push(j.token),
+    })
+    const bot = fakeBot()
+    const send = createOutboxSend({ getBot: () => bot, retry: passthroughRetry, resolveReplyMarkup: resolve })
+    await send('123', null, 'answer')
+
+    expect(bot.calls[0]!.opts.reply_markup).toBeDefined()
+    expect(enqueued).toEqual([])
+  })
+})

--- a/telegram-plugin/tests/outbox-sweep-listen-button.test.ts
+++ b/telegram-plugin/tests/outbox-sweep-listen-button.test.ts
@@ -161,6 +161,29 @@ describe('createOutboxSend — net-delivered answer carries the Listen button (#
     expect(bot.calls).toHaveLength(1)
     expect(bot.calls[0]!.opts.reply_markup).toBeUndefined()
   })
+
+  it('empty text sends NOTHING and returns undefined (no empty-message retry wedge)', async () => {
+    // Telegram rejects an empty message body; a stray '' chunk would throw
+    // every sweep tick and wedge the record in a permanent retry. The send
+    // must short-circuit instead of calling sendMessage.
+    const bot = fakeBot()
+    const resolverCalls: string[] = []
+    const send = createOutboxSend({
+      getBot: () => bot,
+      retry: passthroughRetry,
+      resolveReplyMarkup: (_c, _t, text) => {
+        resolverCalls.push(text)
+        return undefined
+      },
+    })
+
+    const result = await send('123', null, '')
+
+    expect(result).toBeUndefined()
+    expect(bot.calls).toHaveLength(0)
+    // No point resolving a Listen button for a body we never send.
+    expect(resolverCalls).toEqual([])
+  })
 })
 
 describe('gateway wiring — makeOutboxListenMarkupResolver end-to-end (#3502)', () => {

--- a/telegram-plugin/voice-ondemand.ts
+++ b/telegram-plugin/voice-ondemand.ts
@@ -311,3 +311,74 @@ export function mayInjectListenButton(
   if (rawKeyboard == null) return true
   return !rawKeyboard.some((row) => Array.isArray(row) && row.length > 0)
 }
+
+/** The voice-out plan fields the Listen-button decision depends on. A subset of
+ *  the gateway's full `VoiceOutPlan` so this pure helper carries no gateway
+ *  import. */
+export interface ListenButtonVoiceOutPlan {
+  engine: 'kokoro' | 'openai'
+  voice?: string
+  speed: number
+  replyMode: 'voice+text' | 'voice-only' | 'on-demand'
+  ttsChunks: string[]
+}
+
+/** The decision to inject a 🔊 Listen button on a message, plus the cache
+ *  payload the caller must persist so a tap can resynthesize. */
+export interface ListenButtonPlan {
+  /** The single-row Listen keyboard to attach as `reply_markup`. */
+  replyMarkup: {
+    inline_keyboard: Array<Array<{ text: string; callback_data: string }>>
+  }
+  /** The freshly minted token keying the keyboard callback + cache entry. */
+  token: string
+  /** The payload the caller stores under `token` in the VoiceOnDemandCache
+   *  (and enqueues for eager pre-synth). */
+  payload: VoiceOnDemandPayload
+}
+
+/**
+ * The SINGLE source of truth for "should this delivered message carry a 🔊
+ * Listen button, and if so which token/keyboard/cache payload?" — shared by
+ * BOTH the normal reply path (`sendReply` in outbound-send-path.ts) and the
+ * durable-outbox safety-net delivery (`outbox-sweep.ts` wiring), so a
+ * net-delivered final answer is indistinguishable from a normally-delivered
+ * one (switchroom #3502 regression: the sweep dropped the button).
+ *
+ * Returns null — no button — when any gate fails:
+ *  - no voice-out plan, or the plan is not kokoro on-demand (openai on-demand
+ *    synthesizes immediately and its taps would dead-end on the local sidecar);
+ *  - the TTS text is empty (nothing to speak — the empty-TTS guard);
+ *  - the agent supplied its own inline keyboard (single_use collision gate —
+ *    see mayInjectListenButton).
+ *
+ * Pure: it mints a token and builds the keyboard/payload but performs NO side
+ * effects (no cache write, no eager enqueue). The caller owns those so the
+ * token is only persisted when it decides to actually attach the button.
+ */
+export function planListenButton(params: {
+  voiceOutPlan: ListenButtonVoiceOutPlan | null
+  rawKeyboard: unknown[][] | undefined | null
+}): ListenButtonPlan | null {
+  const plan = params.voiceOutPlan
+  // on-demand Listen button is a LOCAL-engine (kokoro) feature only.
+  const useOnDemandButton =
+    plan != null && plan.replyMode === 'on-demand' && plan.engine === 'kokoro'
+  if (!useOnDemandButton) return null
+  // Empty-TTS guard: nothing to speak → no button.
+  if (!(plan.ttsChunks.length > 0 && plan.ttsChunks[0]!.length > 0)) return null
+  // Collision gate: agent supplied its own keyboard → skip.
+  if (!mayInjectListenButton(params.rawKeyboard)) return null
+
+  const token = mintVoiceOnDemandToken()
+  return {
+    replyMarkup: buildListenKeyboard(token),
+    token,
+    payload: {
+      // ttsChunks[0] is already normalizeForSpeech(reply) (kokoro path).
+      text: plan.ttsChunks[0]!,
+      ...(plan.voice != null ? { voice: plan.voice } : {}),
+      speed: plan.speed,
+    },
+  }
+}


### PR DESCRIPTION
## Root cause

The 🔊 Listen on-demand voice button (and any inline keyboard) is dropped from an agent's final Telegram answer whenever the answer is delivered by the **durable-outbox safety net** instead of the normal `sendReply` path.

- Button injection lives in `telegram-plugin/gateway/outbound-send-path.ts` (`useOnDemandButton`, `mayInjectListenButton`, mint/cache/`buildListenKeyboard`).
- **PR #3502 / commit `1a531ebb`** ("durable outbox delivery", shipped v0.19.13) added `telegram-plugin/gateway/outbox-sweep.ts`, which delivered the captured final answer via a **RAW `bot.api.sendMessage(chatId, chunk, { message_thread_id })`** — no voice-out resolution, no keyboard, no Listen button. So any answer the net delivered lost the button.
- Log evidence: `outbox-sweep: delivered nonce=… via=anchor` (no button) vs `reply: finalized` (sendReply, keeps button).

## The fix

- Extract the shared, **pure** decision `planListenButton()` in `voice-ondemand.ts` — enforces the empty-TTS guard, the agent-keyboard **collision gate** (`mayInjectListenButton`), and the kokoro-on-demand gate. It mints the token + builds the keyboard/payload but performs no side effects (caller owns cache write + eager pre-synth).
- `outbound-send-path.ts` (`sendReply`) refactored to call `planListenButton` instead of duplicating the inline logic — single source of truth, the two paths can no longer drift.
- `outbox-sweep.ts` gains a testable `createOutboxSend()` that attaches the resolved keyboard to the **last chunk only** (final visible message), plus a `resolveReplyMarkup` dep on `startOutboxSweep`.
- `gateway.ts` wires it via the new `outbox-listen-markup.ts` module (`makeOutboxListenMarkupResolver`: `loadAccess().voice_out` → `resolveVoiceOutPlan` → `planListenButton` + cache put + eager pre-synth), mirroring `sendReply` so a net-delivered answer is indistinguishable from a normally-delivered one. Extracted to a module to respect the `#2996` gateway line-ratchet.

## Regression guard (pinned to the bug's origin — PR #3502 / commit `1a531ebb`)

`telegram-plugin/tests/outbox-sweep-listen-button.test.ts` asserts **outcomes on the delivery path** (the exact `reply_markup` bytes handed to `sendMessage`), not just code paths:

- kokoro on-demand enabled → the delivered message **carries** the `🔊 Listen` keyboard, and the button token is the one cached + eagerly pre-synthesized (so the tap resolves to real audio);
- attaches to the **last chunk only** on a multi-chunk answer;
- **no** button when the agent supplied its own keyboard (collision gate), when TTS text is empty, when engine is openai / mode isn't on-demand, or when voice-out is off.

If a future change re-severs the sweep delivery from voice-out resolution (the `1a531ebb` raw-`sendMessage` bypass), the net delivers a final answer without the voice button and these assertions go **red**.

## Proof

- **Fails on main behaviour**: reverting the keyboard attachment in `createOutboxSend` turns the two delivery-outcome tests red (`2 failed | 8 passed`).
- **Passes on branch**: scoped `vitest` — `outbox-sweep-listen-button.test.ts` (13) + `outbox-delivery.test.ts` (22) → 35 passed. `voice-ondemand.test.ts` (bun) 22 passed.
- `npm run lint` clean (tsc strict + all guard scripts, incl. gateway line-ratchet and bot-api-wrapping).

Nothing armed; not merged; not rolled to the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)