### PR TITLE
fix(voice): list pacing, HH:MM:SS, thousands separators, acronyms & file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Voice out — pacing & misreadings
+
+- **Lists and headings are spoken as separate sentences** — stripping a bullet
+  or `1.` marker left nothing behind, and the newline-collapse then joined a
+  whole markdown list into one breathless run-on sentence. Block boundaries now
+  emit sentence-terminating punctuation (without doubling `..` when the item
+  already ends in `.`/`!`/`?`), and a wrapped list item is terminated only at
+  the end of the unit so a sentence split across two source lines isn't chopped
+  mid-clause.
+- **`14:30:46` is no longer half-read** — `normalizeForSpeech` lacked the
+  `(?!:?\d)` HH:MM:SS guard that `normalizeForTts` already had. It also had a
+  deeper cause: the `:shortcode:` emoji pass ate the colons out of a timestamp
+  (`14:30:46` → "14 46") before any time pass could see it. The shortcode body
+  must now start with a letter.
+- **`$1,000` reads as "one thousand dollars"** (was "one dollar,000") — the
+  thousands-separator currency pattern is backported from `normalizeForTts`.
+- **More acronyms, and file paths stop being spelled out** — HTTPS/SSH/DNS/CLI/
+  AWS/UTC/MCP/PDF/ID/OK/VM/LLM/YAML/RAM/USB join the letter-by-letter set, and
+  a multi-segment path (`/var/log/syslog`, `~/.config/nvim/init.lua`,
+  `src/gateway/gateway.ts`) is spoken as just its last segment — or "a path"
+  when that segment is a hex blob. A single `word/word` is still prose.
+
 ## v0.19.16 — Telegram: forwarded-message coalescing, Listen button, quieter progress cards, cleaner voice
 
 ### Telegram forwarding (#3523)

--- a/telegram-plugin/tests/tts-normalize.test.ts
+++ b/telegram-plugin/tests/tts-normalize.test.ts
@@ -306,3 +306,35 @@ describe('normalizeForTts — review findings (fixpoint decode, metachar, nits)'
     expect(normalizeForTts('X&#92;Y')).not.toContain('\\')
   })
 })
+
+describe('voice-out pipeline: normalizeForSpeech → normalizeForTts', () => {
+  const speak = (s: string) => normalizeForTts(normalizeForSpeech(s))
+
+  test('a mixed markdown list survives both passes as paced sentences', () => {
+    expect(
+      speak(
+        '- Check /var/log/syslog\n' +
+          '- Cost was $1,000\n' +
+          '- Ran at 14:30:46\n' +
+          '- Use HTTPS and/or SSH',
+      ),
+    ).toBe(
+      'Check syslog. Cost was one thousand dollars. Ran at 14:30:46. ' +
+        'Use H T T P S and slash or S S H.',
+    )
+  })
+
+  test('the HH:MM:SS guard holds in both normalizers', () => {
+    expect(normalizeForTts('Done at 14:30:46 today')).toBe('Done at 14:30:46 today')
+    expect(normalizeForSpeech('Done at 14:30:46 today')).toBe(
+      'Done at 14:30:46 today',
+    )
+  })
+
+  test('thousands separators are spoken identically by both normalizers', () => {
+    expect(normalizeForTts('It costs $1,000')).toBe('It costs one thousand dollars')
+    expect(normalizeForSpeech('It costs $1,000')).toBe(
+      'It costs one thousand dollars',
+    )
+  })
+})

--- a/telegram-plugin/tests/tts-normalize.test.ts
+++ b/telegram-plugin/tests/tts-normalize.test.ts
@@ -331,6 +331,17 @@ describe('voice-out pipeline: normalizeForSpeech → normalizeForTts', () => {
     )
   })
 
+  // `14:30:46` survives even an unguarded scan because `30` is not a legal
+  // HH — so on its own it certifies nothing. These are the timestamps whose
+  // TAIL is itself a legal HH:MM, i.e. the ones a missing lookbehind
+  // actually half-reads ("09:zero o'clock").
+  test('an on-the-hour timestamp is not half-read (lookbehind guard)', () => {
+    for (const t of ['09:00:00', '12:00:15', '01:02:03']) {
+      expect(normalizeForTts(`ran at ${t} ok`)).toBe(`ran at ${t} ok`)
+      expect(normalizeForSpeech(`ran at ${t} ok`)).toBe(`ran at ${t} ok`)
+    }
+  })
+
   test('thousands separators are spoken identically by both normalizers', () => {
     expect(normalizeForTts('It costs $1,000')).toBe('It costs one thousand dollars')
     expect(normalizeForSpeech('It costs $1,000')).toBe(

--- a/telegram-plugin/tests/voice-normalize-text.test.ts
+++ b/telegram-plugin/tests/voice-normalize-text.test.ts
@@ -120,6 +120,18 @@ describe('normalizeForSpeech — emoji & pictographs', () => {
     expect(normalizeForSpeech('nice :rocket: work')).toBe('nice work')
   })
 
+  // Digit-bodied shortcodes are real. A letter-only body left them in the
+  // text AND glued them to the previous word ("Nice:100: work").
+  it('drops a DIGIT-bodied :shortcode: without eating the space', () => {
+    expect(normalizeForSpeech('Nice :100: work')).toBe('Nice work')
+    expect(normalizeForSpeech('a :8ball: b')).toBe('a b')
+    expect(normalizeForSpeech('a :1st_place_medal: b')).toBe('a b')
+  })
+
+  it('the digit-bodied form still cannot eat a timestamp colon', () => {
+    expect(normalizeForSpeech('Ran at 14:30:46 ok')).toBe('Ran at 14:30:46 ok')
+  })
+
   it('leaves ordinary colon usage alone', () => {
     expect(normalizeForSpeech('note: this is fine')).toBe('note: this is fine')
   })
@@ -403,6 +415,15 @@ describe('normalizeForSpeech — time guard (HH:MM:SS)', () => {
     )
   })
 
+  // `14:30:46` survives even an unguarded scan because `30` is not a legal
+  // HH. These are the timestamps whose TAIL is itself a legal HH:MM — the
+  // ones a missing lookbehind half-reads ("09:zero o'clock").
+  it('leaves an on-the-hour timestamp alone (lookbehind guard)', () => {
+    expect(normalizeForSpeech('t 09:00:00 z')).toBe('t 09:00:00 z')
+    expect(normalizeForSpeech('t 12:00:15 z')).toBe('t 12:00:15 z')
+    expect(normalizeForSpeech('t 01:02:03 y')).toBe('t 01:02:03 y')
+  })
+
   it('still speaks a plain HH:MM clock time', () => {
     expect(normalizeForSpeech('Meeting at 14:30 today')).toBe(
       'Meeting at fourteen thirty today',
@@ -432,6 +453,22 @@ describe('normalizeForSpeech — thousands separators', () => {
     expect(normalizeForSpeech('We saw 12,500 requests')).toBe(
       'We saw 12,500 requests',
     )
+  })
+
+  // The thousands guard must not mistake an ordinary SENTENCE comma for a
+  // partial digit group — that left a raw "$" unspoken.
+  it('still speaks currency followed by a sentence comma', () => {
+    expect(normalizeForSpeech('It costs $500, plus tax')).toBe(
+      'It costs five hundred dollars, plus tax',
+    )
+    expect(normalizeForSpeech('We paid $1,000, then left')).toBe(
+      'We paid one thousand dollars, then left',
+    )
+  })
+
+  it('still bails on a genuinely malformed amount', () => {
+    expect(normalizeForSpeech('$1,00 partial')).toBe('$1,00 partial')
+    expect(normalizeForSpeech('$5.203 odd')).toBe('$5.203 odd')
   })
 })
 
@@ -464,6 +501,29 @@ describe('normalizeForSpeech — file paths', () => {
   it('does not treat an all-numeric date as a path', () => {
     expect(normalizeForSpeech('the date 12/25/2026 works')).toBe(
       'the date 12/25/2026 works',
+    )
+  })
+
+  // "Two or more slashes ⇒ path" is false in English. Without a path-ish
+  // anchor the pass DELETES words from ordinary prose ("yes/no/maybe" →
+  // "maybe"). Each of these must survive verbatim for the downstream
+  // "word slash word" pass to speak.
+  it('never swallows a multi-slash PROSE run (no path anchor)', () => {
+    expect(normalizeForSpeech('yes/no/maybe')).toBe('yes/no/maybe')
+    expect(normalizeForSpeech('read/write/exec perms')).toBe(
+      'read/write/exec perms',
+    )
+    expect(normalizeForSpeech('he/she/they pronouns')).toBe(
+      'he/she/they pronouns',
+    )
+    expect(normalizeForSpeech('a client/server/proxy split')).toBe(
+      'a client/server/proxy split',
+    )
+    expect(normalizeForSpeech('reading input/output/error')).toBe(
+      'reading input/output/error',
+    )
+    expect(normalizeForSpeech('tests in unit/integration/e2e are green')).toBe(
+      'tests in unit/integration/e2e are green',
     )
   })
 })

--- a/telegram-plugin/tests/voice-normalize-text.test.ts
+++ b/telegram-plugin/tests/voice-normalize-text.test.ts
@@ -29,9 +29,11 @@ describe('normalizeForSpeech — reported markdown/symbol cases', () => {
     expect(normalizeForSpeech('run `npm test` now')).toBe('run npm test now')
   })
 
-  it('strips headings markers', () => {
-    expect(normalizeForSpeech('# Summary\nAll good')).toBe('Summary All good')
-    expect(normalizeForSpeech('### Deep heading')).toBe('Deep heading')
+  it('strips headings markers and gives the heading a spoken full stop', () => {
+    // The heading is its own spoken sentence — without the terminator the
+    // newline-collapse ran the heading straight into the body text.
+    expect(normalizeForSpeech('# Summary\nAll good')).toBe('Summary. All good')
+    expect(normalizeForSpeech('### Deep heading')).toBe('Deep heading.')
   })
 
   it('speaks link text and drops the URL', () => {
@@ -333,5 +335,152 @@ describe('normalizeForSpeech — review findings (fixpoint decode, metachar, nit
 
   it('fixpoint does not over-decode entity-less text (Q&A stays literal)', () => {
     expect(decodeHtmlEntities('Q&A test')).toBe('Q&A test')
+  })
+})
+
+describe('normalizeForSpeech — list & heading pacing', () => {
+  it('speaks a 4-bullet list as 4 separate sentences', () => {
+    const out = normalizeForSpeech(
+      'Here are the steps:\n' +
+        '- Check the logs\n' +
+        '- Restart the container\n' +
+        '- Verify health\n' +
+        '- Report back',
+    )
+    expect(out).toBe(
+      'Here are the steps: Check the logs. Restart the container. ' +
+        'Verify health. Report back.',
+    )
+    // Four sentence-terminated spoken units after the lead-in.
+    const units = out
+      .split(/(?<=[.:])\s+/)
+      .filter((u) => u.trim().length > 0)
+    expect(units).toEqual([
+      'Here are the steps:',
+      'Check the logs.',
+      'Restart the container.',
+      'Verify health.',
+      'Report back.',
+    ])
+  })
+
+  it('separates ordered-list items into sentences', () => {
+    expect(normalizeForSpeech('1. first\n2. second\n3. third')).toBe(
+      'first. second. third.',
+    )
+  })
+
+  it('does not double punctuation when the item already ends in . ! or ?', () => {
+    const out = normalizeForSpeech('- Done.\n- Really?\n- Ship it!')
+    expect(out).toBe('Done. Really? Ship it!')
+    expect(out).not.toContain('..')
+    expect(out).not.toContain('. .')
+    expect(out).not.toContain('?.')
+    expect(out).not.toContain('!.')
+  })
+
+  it('terminates the line that introduces a list when it lacks punctuation', () => {
+    expect(normalizeForSpeech('Steps\n- one\n- two')).toBe('Steps. one. two.')
+  })
+
+  it('does not chop a wrapped list item mid-clause', () => {
+    expect(normalizeForSpeech('- a long item that\ncontinues here\n- second')).toBe(
+      'a long item that continues here. second.',
+    )
+  })
+
+  it('separates heading sections into sentences', () => {
+    expect(normalizeForSpeech('# One\nbody one\n\n# Two\nbody two')).toBe(
+      'One. body one. Two. body two',
+    )
+  })
+})
+
+describe('normalizeForSpeech — time guard (HH:MM:SS)', () => {
+  it('leaves a full HH:MM:SS timestamp as digits rather than half-reading it', () => {
+    expect(normalizeForSpeech('Done at 14:30:46 today')).toBe(
+      'Done at 14:30:46 today',
+    )
+  })
+
+  it('still speaks a plain HH:MM clock time', () => {
+    expect(normalizeForSpeech('Meeting at 14:30 today')).toBe(
+      'Meeting at fourteen thirty today',
+    )
+    expect(normalizeForSpeech('at 9:05')).toBe("at nine oh five")
+  })
+})
+
+describe('normalizeForSpeech — thousands separators', () => {
+  it('speaks $1,000 as one thousand dollars (not "one dollar,000")', () => {
+    expect(normalizeForSpeech('It costs $1,000 up front')).toBe(
+      'It costs one thousand dollars up front',
+    )
+  })
+
+  it('speaks a millions-scale amount', () => {
+    expect(normalizeForSpeech('Budget $1,234,567 total')).toBe(
+      'Budget one million two hundred thirty-four thousand five hundred ' +
+        'sixty-seven dollars total',
+    )
+  })
+
+  it('does not regress plain currency or ordinary comma prose', () => {
+    expect(normalizeForSpeech('It costs $500')).toBe('It costs five hundred dollars')
+    expect(normalizeForSpeech('$5.50 each')).toBe('five dollars fifty each')
+    expect(normalizeForSpeech('a, b, 3')).toBe('a, b, 3')
+    expect(normalizeForSpeech('We saw 12,500 requests')).toBe(
+      'We saw 12,500 requests',
+    )
+  })
+})
+
+describe('normalizeForSpeech — file paths', () => {
+  it('speaks an absolute path as its last segment', () => {
+    expect(normalizeForSpeech('Check /var/log/syslog now')).toBe(
+      'Check syslog now',
+    )
+  })
+
+  it('handles ~/ and relative multi-segment paths', () => {
+    expect(normalizeForSpeech('Edit ~/.config/nvim/init.lua please')).toBe(
+      'Edit init.lua please',
+    )
+    expect(normalizeForSpeech('See src/telegram-plugin/gateway.ts')).toBe(
+      'See gateway.ts',
+    )
+  })
+
+  it('says "a path" when the final segment is unspeakable noise', () => {
+    expect(normalizeForSpeech('Path /tmp/a1b2c3d4e5f6a7b8 there')).toBe(
+      'Path a path there',
+    )
+  })
+
+  it('leaves a single-slash word/word pair for the downstream slash pass', () => {
+    expect(normalizeForSpeech('and/or maybe')).toBe('and/or maybe')
+  })
+
+  it('does not treat an all-numeric date as a path', () => {
+    expect(normalizeForSpeech('the date 12/25/2026 works')).toBe(
+      'the date 12/25/2026 works',
+    )
+  })
+})
+
+describe('normalizeForSpeech — extended acronym set', () => {
+  it('spells the newly-added initialisms letter-by-letter', () => {
+    expect(normalizeForSpeech('use HTTPS not HTTP')).toBe('use H T T P S not H T T P')
+    expect(normalizeForSpeech('over SSH via DNS')).toBe('over S S H via D N S')
+    expect(normalizeForSpeech('the CLI on AWS at UTC')).toBe(
+      'the C L I on A W S at U T C',
+    )
+    expect(normalizeForSpeech('MCP PDF VM LLM YAML RAM USB ID OK')).toBe(
+      'M C P P D F V M L L M Y A M L R A M U S B I D O K',
+    )
+  })
+
+  it('still leaves word-style all-caps tokens alone', () => {
+    expect(normalizeForSpeech('NASA ALWAYS SHOUTING')).toBe('NASA ALWAYS SHOUTING')
   })
 })

--- a/telegram-plugin/tts-normalize.ts
+++ b/telegram-plugin/tts-normalize.ts
@@ -292,10 +292,12 @@ export function normalizeForTts(text: string): string {
     return words.join(' ')
   })
 
-  // -- Times HH:MM (24h) → spoken. The (?!:?\d) guard skips HH:MM:SS
-  //    entirely — a half-spoken time with a dangling ":46" reads worse
-  //    than leaving the digits as-is.
-  s = s.replace(/\b([01]?\d|2[0-3]):([0-5]\d)(?!:?\d)/g, (_m, hh: string, mm: string) => {
+  // -- Times HH:MM (24h) → spoken. The (?<![\d:]) / (?!:?\d) guards skip
+  //    HH:MM:SS entirely — a half-spoken time with a dangling ":46" reads
+  //    worse than leaving the digits as-is. The LOOKBEHIND is load-bearing:
+  //    without it the scan re-anchors INSIDE the timestamp (`09:00:00` →
+  //    "09:zero o'clock") because the trailing `00` is itself a legal HH:MM.
+  s = s.replace(/(?<![\d:])\b([01]?\d|2[0-3]):([0-5]\d)(?!:?\d)/g, (_m, hh: string, mm: string) => {
     const h = Number(hh)
     const min = Number(mm)
     const hw = belowThousand(h)

--- a/telegram-plugin/voice-normalize-text.ts
+++ b/telegram-plugin/voice-normalize-text.ts
@@ -274,6 +274,24 @@ const ACRONYM_MAX_LEN = Math.max(...[...ACRONYMS].map((a) => a.length))
 const PATH_TOKEN_RE =
   /(?<![\w~./-])(?:~|\.{1,2}|[A-Za-z0-9_.@-]+)?(?:\/[A-Za-z0-9_.@+-]+){2,}\/?(?![\w/-])/g
 
+/**
+ * A path-shaped token needs an ANCHOR before we may swallow it: a leading
+ * `/`, `./`, `../` or `~/`, or a final segment carrying a file extension.
+ * "Two or more slashes ⇒ path" is false in English — `yes/no/maybe`,
+ * `read/write/exec`, `he/she/they`, `client/server/proxy` and
+ * `unit/integration/e2e` are all prose, and swallowing them DELETES words
+ * from the reply. Anything that is only a run of ordinary lowercase
+ * word-shaped segments is left for the downstream "word slash word" pass.
+ */
+function looksLikePath(m: string, segs: string[]): boolean {
+  if (/^(?:\/|\.{1,2}\/|~\/)/.test(m)) return true
+  const last = segs[segs.length - 1]!
+  if (/\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(last)) return true
+  // Every segment an ordinary lowercase word (letters, then optional digits)
+  // ⇒ prose, not a path.
+  return !segs.every((sg) => /^[a-z][a-z0-9]*$/.test(sg))
+}
+
 /** True when a path segment is worth speaking (a real name, not a blob). */
 function isSpeakableSegment(seg: string): boolean {
   if (!/[A-Za-z]/.test(seg)) return false
@@ -295,6 +313,7 @@ function speakPaths(input: string): string {
     const segs = m.split('/').filter((sg) => sg.length > 0)
     if (segs.length < 2) return m
     if (segs.every((sg) => /^\d+$/.test(sg))) return m
+    if (!looksLikePath(m, segs)) return m
     const last = segs[segs.length - 1]!
     return isSpeakableSegment(last) ? last : 'a path'
   })
@@ -395,10 +414,12 @@ export function normalizeForSpeech(input: string): string {
     /[\u{1F000}-\u{1FAFF}\u{1F1E6}-\u{1F1FF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE00}-\u{FE0F}\u{200D}\u{2B50}\u{3030}\u{303D}\u{3297}\u{3299}\u{24C2}]/gu,
     '',
   )
-  //    The shortcode body must START WITH A LETTER: without that guard the
-  //    pass ate the colons out of a clock timestamp (`14:30:46` → "14 46"),
-  //    which no time pass could then recover.
-  s = s.replace(/:([a-z][a-z0-9_+-]*):/gi, ' ')
+  //    Digit-bodied shortcodes are real (`:100:`, `:8ball:`,
+  //    `:1st_place_medal:`), so the body may start with a digit — the
+  //    timestamp protection is positional instead: the opening colon may not
+  //    follow a digit/colon and the closing colon may not precede a digit, so
+  //    the pass can never eat the colons out of `14:30:46`.
+  s = s.replace(/(?<![\w:]):([a-z0-9][a-z0-9_+-]*):(?!\d)/gi, ' ')
 
   // 1. Fenced code blocks first (```lang … ``` or ~~~ … ~~~) — drop the
   //    whole block before any inline processing can see its contents.
@@ -484,10 +505,12 @@ export function normalizeForSpeech(input: string): string {
   })
   //     Clock time HH:MM (24h ok) → spoken. Guarded by word boundaries so a
   //     ratio like "3:2" or a bare number isn't caught (needs 2-digit MM).
-  //     The (?!:?\d) guard skips HH:MM:SS entirely (parity with
+  //     The (?<![\d:]) / (?!:?\d) guards skip HH:MM:SS entirely (parity with
   //     normalizeForTts) — a half-spoken time with a dangling ":46" reads
-  //     worse than leaving the digits as-is.
-  s = s.replace(/\b([01]?\d|2[0-3]):([0-5]\d)(?!:?\d)/g, (m, hh, mm) => {
+  //     worse than leaving the digits as-is. The LOOKBEHIND is load-bearing:
+  //     without it the scan re-anchors INSIDE the timestamp (`09:00:00` →
+  //     "09:zero o'clock") because the trailing `00` is itself a legal HH:MM.
+  s = s.replace(/(?<![\d:])\b([01]?\d|2[0-3]):([0-5]\d)(?!:?\d)/g, (m, hh, mm) => {
     const h = Number(hh)
     const min = Number(mm)
     const hw = belowThousand(h)
@@ -502,7 +525,9 @@ export function normalizeForSpeech(input: string): string {
   //     the old "one dollar,000" misreading is impossible). The trailing
   //     lookahead bails on odd cents ("$5.203") and partial thousands
   //     ("$1,00") — the whole token is left unchanged rather than half-read.
-  s = s.replace(/\$(\d{1,3}(?:,\d{3})+|\d{1,9})(?:\.(\d{2}))?(?![\d,]|\.\d)/g, (m, dollarsRaw, cents) => {
+  //     The guard must NOT fire on an ordinary sentence comma ("$500, plus
+  //     tax") — only on a comma/period that STARTS another digit group.
+  s = s.replace(/\$(\d{1,3}(?:,\d{3})+|\d{1,9})(?:\.(\d{2}))?(?!\d|[.,]\d)/g, (m, dollarsRaw, cents) => {
     const dollars = Number(String(dollarsRaw).replace(/,/g, ''))
     const dw = numberToWords(dollars)
     if (!dw) return m

--- a/telegram-plugin/voice-normalize-text.ts
+++ b/telegram-plugin/voice-normalize-text.ts
@@ -29,6 +29,14 @@
  *     ambiguous (strikethrough marker vs. approx) and dropping is the safest
  *     choice that never mangles a real word.
  *   - `->` / `=>` / `→` become the spoken word "to".
+ *   - Block boundaries (headings, bullets, ordered items) become SENTENCE
+ *     boundaries: the marker is replaced with terminating punctuation so a
+ *     multi-bullet reply is spoken as separate sentences with breath between
+ *     them, instead of the newline-collapse fusing it into one run-on.
+ *   - A multi-segment filesystem path (`/var/log/syslog`, `~/.config/x/y`,
+ *     `a/b/c`) is spoken as its LAST segment, or "a path" when that segment
+ *     is unspeakable noise. A single `word/word` is prose and is left for the
+ *     downstream "word slash word" pass in normalizeForTts.
  *   - A tiny, well-tested set of trivially-safe abbreviations is expanded
  *     ("e.g." → "for example", "i.e." → "that is", "etc." → "and so on",
  *     "vs" → "versus", "approx" → "approximately", "w/" → "with").
@@ -237,11 +245,121 @@ const UNIT_MAP: Record<string, { s: string; p: string }> = {
   tb: { s: 'terabyte', p: 'terabytes' },
 }
 
-/** Curated initialisms spoken letter-by-letter. Uppercase keys only. */
+/**
+ * Curated initialisms spoken letter-by-letter. Uppercase keys only.
+ *
+ * Only tokens in this set are ever expanded, so widening the set is safe:
+ * word-style acronyms (NASA, ALWAYS) still fall through untouched because the
+ * generic all-caps matcher consults this map before doing anything.
+ */
 const ACRONYMS = new Set([
   'CI', 'PR', 'API', 'URL', 'GPU', 'CPU', 'TTS', 'STT', 'HTTP', 'JSON',
   'SQL', 'UI',
+  // Common in agent replies; previously read as nonsense words ("hoops",
+  // "duh-ness", "mick-p") by the engine.
+  'HTTPS', 'SSH', 'DNS', 'CLI', 'AWS', 'UTC', 'MCP', 'PDF', 'ID', 'OK',
+  'VM', 'LLM', 'YAML', 'RAM', 'USB',
 ])
+
+/** Longest key in ACRONYMS — the all-caps matcher's upper length bound. */
+const ACRONYM_MAX_LEN = Math.max(...[...ACRONYMS].map((a) => a.length))
+
+/**
+ * A filesystem-path-shaped token: two or more `/`-separated segments, with an
+ * optional leading segment (`a/b/c`), `~` (`~/.config/foo`) or nothing
+ * (`/var/log/syslog`). Requiring TWO separators is deliberate — a single
+ * `word/word` is prose ("and/or") and is left for the downstream
+ * "word slash word" pass in tts-normalize.
+ */
+const PATH_TOKEN_RE =
+  /(?<![\w~./-])(?:~|\.{1,2}|[A-Za-z0-9_.@-]+)?(?:\/[A-Za-z0-9_.@+-]+){2,}\/?(?![\w/-])/g
+
+/** True when a path segment is worth speaking (a real name, not a blob). */
+function isSpeakableSegment(seg: string): boolean {
+  if (!/[A-Za-z]/.test(seg)) return false
+  if (seg.length > 32) return false
+  // A hex blob (sha, uuid chunk) reads as noise; prefer "a path".
+  if (/^[0-9a-f]{8,}$/i.test(seg)) return false
+  return true
+}
+
+/**
+ * Speak a filesystem path as just its final segment ("/var/log/syslog" →
+ * "syslog"), or "a path" when that segment carries no speakable name. Reading
+ * a full path aloud is the worst kind of TTS noise — a long run of "slash"
+ * between unpronounceable fragments. An all-numeric token run (a date like
+ * `12/25/2026`) is explicitly NOT a path and is returned untouched.
+ */
+function speakPaths(input: string): string {
+  return input.replace(PATH_TOKEN_RE, (m) => {
+    const segs = m.split('/').filter((sg) => sg.length > 0)
+    if (segs.length < 2) return m
+    if (segs.every((sg) => /^\d+$/.test(sg))) return m
+    const last = segs[segs.length - 1]!
+    return isSpeakableSegment(last) ? last : 'a path'
+  })
+}
+
+/** A line whose leading markup starts a new block (heading / list item). */
+const BLOCK_MARKER_RE = /^[ \t]{0,3}(?:#{1,6}[ \t]+|[-*+][ \t]+|\d+[.)][ \t]+)/
+/** Heading subset — a heading never has continuation lines. */
+const HEADING_MARKER_RE = /^[ \t]{0,3}#{1,6}[ \t]+/
+
+/** Give a line sentence-terminating punctuation without doubling it. */
+function ensureTerminated(line: string): string {
+  const t = line.replace(/[ \t]+$/, '')
+  if (!t.trim()) return t
+  // Already terminal (or a natural pause) — leave it, never emit ".." / ". .".
+  if (/[.!?:;]$/.test(t)) return t
+  // A trailing comma at a block boundary is an artifact of list formatting.
+  if (/,$/.test(t)) return `${t.slice(0, -1)}.`
+  return `${t}.`
+}
+
+/**
+ * Strip heading / list markers AND turn each block boundary into a sentence
+ * boundary. Without this the later newline-collapse joins every bullet into
+ * one breathless run-on sentence — the single biggest voice-pacing complaint.
+ *
+ * A wrapped list item (a continuation line carrying no marker of its own) is
+ * terminated only at the END of the unit, so a sentence split across two
+ * source lines is not chopped mid-clause. The line immediately BEFORE a block
+ * starts is terminated too, so "Steps" + bullets doesn't read as
+ * "Steps first".
+ */
+function applyBlockPauses(input: string): string {
+  const lines = input.split('\n')
+  const isBlock = lines.map((l) => BLOCK_MARKER_RE.test(l))
+  const isHeading = lines.map((l) => HEADING_MARKER_RE.test(l))
+  const stripped = lines.map((l, i) =>
+    isBlock[i] ? l.slice(l.match(BLOCK_MARKER_RE)![0].length) : l,
+  )
+  // A line is "inside a block unit" if it starts one, or continues one. A
+  // heading owns exactly its own line — the prose under it is a new unit.
+  const inUnit: boolean[] = []
+  for (let i = 0; i < stripped.length; i++) {
+    inUnit[i] =
+      isBlock[i] === true ||
+      (i > 0 &&
+        inUnit[i - 1] === true &&
+        isHeading[i - 1] !== true &&
+        stripped[i]!.trim() !== '')
+  }
+  return stripped
+    .map((line, i) => {
+      const next = stripped[i + 1]
+      const nextIsBlock = isBlock[i + 1] === true
+      const unitEndsHere =
+        isHeading[i] === true ||
+        next === undefined ||
+        next.trim() === '' ||
+        nextIsBlock
+      if (inUnit[i] && unitEndsHere) return ensureTerminated(line)
+      if (nextIsBlock && line.trim() !== '') return ensureTerminated(line)
+      return line
+    })
+    .join('\n')
+}
 
 /**
  * Convert a Markdown/plain reply into clean text for a TTS engine.
@@ -277,7 +395,10 @@ export function normalizeForSpeech(input: string): string {
     /[\u{1F000}-\u{1FAFF}\u{1F1E6}-\u{1F1FF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE00}-\u{FE0F}\u{200D}\u{2B50}\u{3030}\u{303D}\u{3297}\u{3299}\u{24C2}]/gu,
     '',
   )
-  s = s.replace(/:([a-z0-9][a-z0-9_+-]*):/gi, ' ')
+  //    The shortcode body must START WITH A LETTER: without that guard the
+  //    pass ate the colons out of a clock timestamp (`14:30:46` → "14 46"),
+  //    which no time pass could then recover.
+  s = s.replace(/:([a-z][a-z0-9_+-]*):/gi, ' ')
 
   // 1. Fenced code blocks first (```lang … ``` or ~~~ … ~~~) — drop the
   //    whole block before any inline processing can see its contents.
@@ -301,6 +422,11 @@ export function normalizeForSpeech(input: string): string {
   // Any residual backticks → drop.
   s = s.replace(/`/g, '')
 
+  // 5b. Filesystem paths → their last segment. Runs before the block/symbol
+  //     passes (and before the downstream "word slash word" pass in
+  //     normalizeForTts) so a path is never spelled out slash-by-slash.
+  s = speakPaths(s)
+
   // 6. Emphasis markers. Paired forms first (longest marker first), then
   //    strip residual markup-by-construction doubles. A LONE `*` or `_` in
   //    the middle of maths/words is left alone (see step 11).
@@ -316,10 +442,8 @@ export function normalizeForSpeech(input: string): string {
   // 7. Leading block markup, per line: headings, blockquotes, list markers.
   //    List bullets/numbers become a natural sentence pause rather than a
   //    spoken "dash" / "1 dot".
-  s = s.replace(/^[ \t]{0,3}#{1,6}[ \t]+/gm, '')
   s = s.replace(/^[ \t]{0,3}>[ \t]?/gm, '')
-  s = s.replace(/^[ \t]{0,3}[-*+][ \t]+/gm, '')
-  s = s.replace(/^[ \t]{0,3}\d+[.)][ \t]+/gm, '')
+  s = applyBlockPauses(s)
 
   // 8. Horizontal rules (---, ___, ***) on their own line → drop.
   s = s.replace(/^[ \t]{0,3}([-_*])\1{2,}[ \t]*$/gm, '')
@@ -360,7 +484,10 @@ export function normalizeForSpeech(input: string): string {
   })
   //     Clock time HH:MM (24h ok) → spoken. Guarded by word boundaries so a
   //     ratio like "3:2" or a bare number isn't caught (needs 2-digit MM).
-  s = s.replace(/\b([01]?\d|2[0-3]):([0-5]\d)\b/g, (m, hh, mm) => {
+  //     The (?!:?\d) guard skips HH:MM:SS entirely (parity with
+  //     normalizeForTts) — a half-spoken time with a dangling ":46" reads
+  //     worse than leaving the digits as-is.
+  s = s.replace(/\b([01]?\d|2[0-3]):([0-5]\d)(?!:?\d)/g, (m, hh, mm) => {
     const h = Number(hh)
     const min = Number(mm)
     const hw = belowThousand(h)
@@ -370,11 +497,16 @@ export function normalizeForSpeech(input: string): string {
 
   // 14. Numbers, units & symbols → spoken words. Each sub-pass is guarded so
   //     it only fires on a clear number+token, never mid-word.
-  //     Currency: $5 / $5.50 → "five dollars" / "five dollars fifty".
-  s = s.replace(/\$(\d{1,9})(?:\.(\d{2}))?\b/g, (m, dollars, cents) => {
-    const dw = numberToWords(Number(dollars))
+  //     Currency: $5 / $5.50 → "five dollars" / "five dollars fifty";
+  //     $1,000 → "one thousand dollars" (thousands separators consumed, so
+  //     the old "one dollar,000" misreading is impossible). The trailing
+  //     lookahead bails on odd cents ("$5.203") and partial thousands
+  //     ("$1,00") — the whole token is left unchanged rather than half-read.
+  s = s.replace(/\$(\d{1,3}(?:,\d{3})+|\d{1,9})(?:\.(\d{2}))?(?![\d,]|\.\d)/g, (m, dollarsRaw, cents) => {
+    const dollars = Number(String(dollarsRaw).replace(/,/g, ''))
+    const dw = numberToWords(dollars)
     if (!dw) return m
-    const noun = Number(dollars) === 1 && !cents ? 'dollar' : 'dollars'
+    const noun = dollars === 1 && !cents ? 'dollar' : 'dollars'
     if (cents && cents !== '00') {
       const cw = numberToWords(Number(cents))
       return `${dw} ${noun} ${cw}`
@@ -419,7 +551,7 @@ export function normalizeForSpeech(input: string): string {
   // 15. Acronyms → letter-by-letter for a curated set of initialisms. Only a
   //     standalone all-caps token that exactly matches the map is expanded;
   //     word-style acronyms (NASA) and sub-tokens of larger words are left.
-  s = s.replace(/\b[A-Z]{2,5}\b/g, (tok) =>
+  s = s.replace(new RegExp(`\\b[A-Z]{2,${ACRONYM_MAX_LEN}}\\b`, 'g'), (tok) =>
     ACRONYMS.has(tok) ? tok.split('').join(' ') : tok,
   )
 


### PR DESCRIPTION
Four scoped fixes to `normalizeForSpeech` (`telegram-plugin/voice-normalize-text.ts`) — the voice-out normalization pass that runs FIRST and therefore wins over `normalizeForTts`. The sidecar (`docker/voice-sidecar/server.py`) is untouched and the two normalizers are deliberately NOT merged — both are separate, larger pieces of work.

## 1. List / heading pauses (the big one)

Stripping a bullet or `1.` marker left nothing behind, and the newline-collapse then joined the whole list into one breathless run-on sentence. Block boundaries now emit sentence-terminating punctuation.

| | spoken |
|---|---|
| before | `Here are the steps: Check the logs Restart the container Verify health Report back` |
| after | `Here are the steps: Check the logs. Restart the container. Verify health. Report back.` |

Details:
- No doubled punctuation — an item already ending in `.`/`!`/`?`/`:` is left alone (`- Done.\n- Really?\n- Ship it!` → `Done. Really? Ship it!`).
- A wrapped list item is terminated only at the END of the unit, so a sentence split across two source lines is not chopped mid-clause.
- The line that introduces a list is terminated too (`Steps` + bullets → `Steps. one. two.`), and a heading is its own sentence (`# Summary\nAll good` → `Summary. All good`).

## 2. HH:MM:SS guard

`normalizeForSpeech` lacked the `(?!:?\d)` lookahead that `tts-normalize.ts:298` already had — backported.

**It also had a deeper root cause the audit didn't name:** the `:shortcode:` emoji pass (`/:([a-z0-9][a-z0-9_+-]*):/gi`) ate the colons out of a timestamp before any time pass could see it — `14:30:46` → `14 46`. Shortcode bodies must now start with a letter (`:rocket:` still drops; `:30:` no longer does).

| | spoken |
|---|---|
| before | `Done at 14 46 today` |
| after | `Done at 14:30:46 today` |

`14:30` on its own still speaks as `fourteen thirty`.

## 3. Thousands separators

Backported the pattern from `tts-normalize.ts:313`.

| | spoken |
|---|---|
| before | `It costs one dollar,000 up front` |
| after | `It costs one thousand dollars up front` |

`$1,234,567` → `one million two hundred thirty-four thousand five hundred sixty-seven dollars`. No regression on `$500`, `$5.50`, `a, b, 3`, or bare `12,500`.

## 4. Acronyms + file paths

- Added HTTPS, SSH, DNS, CLI, AWS, UTC, MCP, PDF, ID, OK, VM, LLM, YAML, RAM, USB to the letter-by-letter set. The all-caps matcher's length bound is now DERIVED from the set (`ACRONYM_MAX_LEN`) instead of a hard-coded `{2,5}`, so widening the set can't silently outgrow the matcher again. Word-style caps (`NASA`, `ALWAYS`) are still untouched — only exact set members expand.
- New path pass, running before the block/symbol passes (and therefore before the `word/word` → "word slash word" pass in `normalizeForTts`): a multi-segment path speaks as its last segment.

| input | spoken |
|---|---|
| `Check /var/log/syslog now` | `Check syslog now` |
| `Edit ~/.config/nvim/init.lua please` | `Edit init.lua please` |
| `See src/telegram-plugin/gateway.ts` | `See gateway.ts` |
| `Path /tmp/a1b2c3d4e5f6a7b8 there` | `Path a path there` |
| `and/or maybe` | `and/or maybe` (single slash = prose, untouched) |
| `the date 12/25/2026 works` | unchanged (all-numeric ≠ path) |

## Anchor drift (reported, not force-fitted)

Every line anchor in the task had drifted; the real ones on `main@75114a8a` were list markers `:321-322` (not 276-279), time `:363` (not 320), currency `:374` (not 331), acronym set `:241-244` (not 198-201), cap `:422` (not 379), newline-collapse `:432-433` (not 389-390). Also: `voice-normalize-text.ts` has **no** `word/word` → "word slash word" pass at all — that lives only in `tts-normalize.ts:370`. Since `normalizeForSpeech` runs first, adding the path rule there does satisfy "fires before the symbol/slash pass", and a composed pipeline test pins that.

## Tests / lint

All new tests assert the resulting spoken STRING (`toBe`), not just that the function ran.

- `bun test telegram-plugin/tests/{voice-normalize-text,tts-normalize,voice-out-one-send}.test.ts` → **125 pass / 0 fail**, incl. the 4-bullet list splitting into 4 sentence units and a composed `normalizeForSpeech` → `normalizeForTts` case.
- Wider voice suite (8 files: text-voice-scrub, paragraph-normalizer, temporal-normalize, voice-message-handler/send/presynth/ondemand) → 264 pass / 0 fail.
- `npm run lint` → clean (litellm guard SKIPs off-host as documented).
- One existing expectation was intentionally updated: `# Summary\nAll good` now yields `Summary. All good` — that's fix #1's point.

---

## Review round 2 — four confirmed findings fixed (commit `1083255d3`)

An adversarial re-review executed against the PR head and found four real defects. All are now fixed, and **each fix ships a test in the previously-uncovered class and was mutation-verified** (revert the fix → the new test fails; all four confirmed failing on revert, restored after).

**F1 (HIGH) — the headline HH:MM:SS fix did not work.** The guard was a lookahead only, so the scan **re-anchors inside** the timestamp. Confirmed against the PR head: `normalizeForSpeech('t 09:00:00 z')` → `"t 09:zero o'clock z"`, `'t 12:00:15 z'` → `"t 12:zero fifteen z"`, `'t 01:02:03 y'` → `"t 01:two oh three y"`; `normalizeForTts` had the identical hole. `14:30:46` only survived because `30` is not a legal `HH` — so **the existing tests were certifying the bug**. Fixed with a `(?<![\d:])` lookbehind in **both** normalizers; new tests cover `09:00:00` / `12:00:15` / `01:02:03` in both.

**F2 (HIGH) — the path pass silently deleted words from prose.** "Two or more slashes ⇒ path" is false in English. Regressions vs `main`: `yes/no/maybe` → `maybe`, `read/write/exec perms` → `exec perms`, `he/she/they pronouns` → `they pronouns`, `a client/server/proxy split` → `a proxy split`, `reading input/output/error` → `reading error`, `tests in unit/integration/e2e are green` → `tests in e2e are green`. `speakPaths` now requires a **path anchor** — leading `/`, `./`, `../`, `~/`, or a final segment with a file extension — and bails when every segment is an ordinary lowercase word-shaped token. The prose class (previously entirely uncovered) now has tests; the existing path tests are unaffected.

**F3 (MEDIUM) — currency before a comma stopped being spoken (regression vs `main`).** The `(?![\d,]|\.\d)` guard fired on a plain sentence comma: `"It costs $500, plus tax"` left a raw `$`, as did `"We paid $1,000, then left"`. Guard is now `(?!\d|[.,]\d)`, which still bails on the malformed `$1,00` and `$5.203`. Tests added for both the fixed and the still-bailing cases.

**F4 (LOW) — numeric emoji shortcodes regressed and glued to the previous word.** Tightening the body to `[a-z]` dropped `:100:`, `:8ball:`, `:1st_place_medal:`, and `'Nice :100: work'` came out as `"Nice:100: work"` (the later `\s+([,.!?;:])` cleanup ate the space too). The body accepts digits again; the timestamp protection is now **positional** — `(?<![\w:])` before the opening colon, `(?!\d)` after the closing one — so `14:30:46` still cannot be eaten.

### Two notes for the operator (no behaviour changed)

- **`ACRONYM_MAX_LEN` is cosmetic today.** It computes to `5`, identical to the old hard-coded `{2,5}`. Kept as-is — it's a self-maintaining bound, not a behaviour change.
- **`OK` → "O K" is a debatable call.** Spelling `OK` letter-by-letter is right for an acronym list but arguably wrong for common prose ("OK, shipping it"). Left as the PR authored it — flagging it so you can confirm or ask for it to be dropped from `ACRONYMS`.

### Verification (round 2)

- `bun test telegram-plugin/tests/voice-normalize-text.test.ts telegram-plugin/tests/tts-normalize.test.ts` → **125 pass, 0 fail, 249 expect() calls**.
- Mutation runs (one fix reverted at a time): F1 → 123 pass / **2 fail**; F2 → 124 / **1 fail**; F3 → 124 / **1 fail**; F4 → 124 / **1 fail**. Every new test fails without its fix.
- `npm run lint` → clean (`tsc --noEmit` plus all 11 repo guards; the litellm guard SKIPs off-host as documented).
- Rebased onto fresh `origin/main` (`06c12bc81`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
