### PR TITLE
feat: auto-reconcile — update-check card, drift detection, auto-update (KEN-128: KEN-129/130/131)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -61,12 +61,19 @@ host_control:
     enabled: true
     interval_minutes: 5            # floor 5, ceiling 1440
     apply_on_detect: true          # false → log-only (dogfood mode)
+    notify_on_detect: false        # KEN-129 — operator approval card, see below
     image_ref: ghcr.io/switchroom/switchroom-agent:latest
 ```
 
 When `enabled: true`, hostd polls `docker manifest inspect <image_ref>` every `interval_minutes`. If the remote digest diverges from the local image's `RepoDigests`, it runs `switchroom update` then `switchroom restart all` (graceful — drains in-flight Telegram turns via the existing `decideRestart` path). Events land at `~/.switchroom/release-watcher-events.jsonl` (`release_detected` → `apply_started/succeeded/failed` → `restart_started` → `fleet_caught_up`), with `duration_ms` on `fleet_caught_up` giving the AC's `time_from_release_to_fleet_caught_up_seconds` counter. Failures log and drop the tick — no retry-storm.
 
 Default is `enabled: false` so existing deployments don't suddenly self-roll. Pair with `apply_on_detect: false` to dogfood the detector without rolling the fleet.
+
+### Operator-in-the-loop update card (KEN-129, stage 1 of KEN-128)
+
+With `apply_on_detect: false` and `notify_on_detect: true`, a detected release doesn't roll the fleet — instead hostd posts **one operator approval card** ("⬆️ Switchroom update available — fleet is behind", with the `switchroom update --check` plan in the body) through an admin agent's Telegram gateway. Tapping ✅ Approve starts the standard hostd `update_apply` path (fleet-mutation-locked, durable status rows, `get_status`-pollable, in-chat rollout narration). Deny / timeout simply dismisses the card.
+
+Guarantees: **one card per release id** — the last-notified digest persists at `~/.switchroom/release-notify-state.json`, so restarts and repeat ticks never re-card the same release (a card that failed to *reach* the operator is retried next tick); no card posts while a fleet mutation is already in flight; no card when the fleet is current.
 
 ## Guardrails on agent-authored entries
 

--- a/src/agents/drift.test.ts
+++ b/src/agents/drift.test.ts
@@ -1,0 +1,242 @@
+/**
+ * KEN-130 — per-surface drift detectors. Outcome-asserting: every test
+ * intentionally stales (or keeps clean) a real on-disk surface and
+ * asserts the NAMED finding appears (or that a clean surface yields
+ * none), matching the issue's acceptance criteria.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import { resolveAgentConfig } from "../config/merge.js";
+import { buildSettingsHooksBlock } from "./scaffold.js";
+import { sha256Text } from "./generation-stamp.js";
+import {
+  detectComposeDrift,
+  detectHookScriptDrift,
+  detectHooksSurfaceDrift,
+  detectSkillsDrift,
+} from "./drift.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "drift-test-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// ─── Surface 1: compose ─────────────────────────────────────────────────────
+
+describe("detectComposeDrift", () => {
+  const base = {
+    imageTag: "v1.0.0",
+    previousImageTag: "v1.0.0" as string | null,
+  };
+
+  it("deployed == rendered → no findings", async () => {
+    const r = await detectComposeDrift({
+      compute: async () => ({ ...base, content: "services: {}\n", previous: "services: {}\n" }),
+    });
+    expect(r).toEqual([]);
+  });
+
+  it("stale deployed compose → named compose finding", async () => {
+    const r = await detectComposeDrift({
+      compute: async () => ({
+        content: "services: {new: true}\n",
+        previous: "services: {old: true}\n",
+        imageTag: "v1.1.0",
+        previousImageTag: "v1.0.0",
+      }),
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0].surface).toBe("compose");
+    expect(r[0].detail).toContain("differs from current config render");
+    expect(r[0].detail).toContain("v1.0.0 → v1.1.0");
+  });
+
+  it("no deployed compose (apply never ran) → not drift", async () => {
+    const r = await detectComposeDrift({
+      compute: async () => ({ ...base, content: "x", previous: null, previousImageTag: null }),
+    });
+    expect(r).toEqual([]);
+  });
+
+  it("render error → no findings (doctor surfaces render errors elsewhere)", async () => {
+    const r = await detectComposeDrift({
+      compute: async () => {
+        throw new Error("vault locked");
+      },
+    });
+    expect(r).toEqual([]);
+  });
+});
+
+// ─── Surface 2: settings.json hooks ─────────────────────────────────────────
+
+describe("detectHooksSurfaceDrift", () => {
+  const config = {
+    telegram: { bot_token: "tok", forum_chat_id: "-100" },
+    agents: { bot: { channels: { telegram: { plugin: "switchroom" } } } },
+  } as unknown as SwitchroomConfig;
+
+  function resolved() {
+    return resolveAgentConfig(config.defaults, config.profiles, config.agents["bot"]);
+  }
+
+  function writeSettings(hooks: Record<string, unknown>): void {
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+    writeFileSync(
+      join(dir, ".claude", "settings.json"),
+      JSON.stringify({ hooks }, null, 2),
+    );
+  }
+
+  it("settings hooks matching the current render → no findings", () => {
+    const agentConfig = resolved();
+    const expected = buildSettingsHooksBlock({
+      agentName: "bot",
+      agentConfig,
+      hindsightEnabled: false,
+      useSwitchroomPlugin: true,
+      configPath: "/cfg/switchroom.yaml",
+    });
+    writeSettings(expected);
+    const r = detectHooksSurfaceDrift("bot", agentConfig, dir, config, "/cfg/switchroom.yaml");
+    expect(r).toEqual([]);
+  });
+
+  it("tampered hooks block → named hooks finding", () => {
+    const agentConfig = resolved();
+    const expected = buildSettingsHooksBlock({
+      agentName: "bot",
+      agentConfig,
+      hindsightEnabled: false,
+      useSwitchroomPlugin: true,
+      configPath: "/cfg/switchroom.yaml",
+    });
+    writeSettings({ ...expected, UserPromptSubmit: [] });
+    const r = detectHooksSurfaceDrift("bot", agentConfig, dir, config, "/cfg/switchroom.yaml");
+    expect(r).toHaveLength(1);
+    expect(r[0].surface).toBe("hooks");
+    expect(r[0].agent).toBe("bot");
+    expect(r[0].detail).toContain("DRIFTED");
+  });
+
+  it("missing settings.json → named finding", () => {
+    const r = detectHooksSurfaceDrift("bot", resolved(), dir, config, undefined);
+    expect(r).toHaveLength(1);
+    expect(r[0].detail).toContain("settings.json missing");
+  });
+});
+
+// ─── Surface 4: skills sync ─────────────────────────────────────────────────
+
+describe("detectSkillsDrift", () => {
+  it("healthy skills tree → no findings", () => {
+    const pool = join(dir, "pool", "good-skill");
+    mkdirSync(pool, { recursive: true });
+    writeFileSync(join(pool, "SKILL.md"), "# skill");
+    const skillsDir = join(dir, "agent", ".claude", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    symlinkSync(pool, join(skillsDir, "good-skill"));
+    expect(detectSkillsDrift("bot", join(dir, "agent"))).toEqual([]);
+  });
+
+  it("dangling symlink (pool skill removed) → named finding", () => {
+    const skillsDir = join(dir, "agent", ".claude", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    symlinkSync(join(dir, "gone", "removed-skill"), join(skillsDir, "removed-skill"));
+    const r = detectSkillsDrift("bot", join(dir, "agent"));
+    expect(r).toHaveLength(1);
+    expect(r[0].surface).toBe("skills");
+    expect(r[0].detail).toContain("removed-skill");
+    expect(r[0].detail).toContain("dangling");
+  });
+
+  it("overlay-declared slug with no installed entry → named finding", () => {
+    const agentDir = join(dir, "agent");
+    mkdirSync(join(agentDir, "skills.d"), { recursive: true });
+    writeFileSync(join(agentDir, "skills.d", "my-skill.yaml"), "source: bundled:my-skill\n");
+    const r = detectSkillsDrift("bot", agentDir);
+    expect(r).toHaveLength(1);
+    expect(r[0].detail).toContain("my-skill");
+    expect(r[0].detail).toContain("not installed");
+  });
+
+  it("overlay slug with live entry → clean", () => {
+    const agentDir = join(dir, "agent");
+    mkdirSync(join(agentDir, "skills.d"), { recursive: true });
+    writeFileSync(join(agentDir, "skills.d", "my-skill.yaml"), "x: 1\n");
+    mkdirSync(join(agentDir, ".claude", "skills", "my-skill"), { recursive: true });
+    expect(detectSkillsDrift("bot", agentDir)).toEqual([]);
+  });
+});
+
+// ─── Surface 6: image hook scripts ──────────────────────────────────────────
+
+describe("detectHookScriptDrift", () => {
+  function seedBin(): string {
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir);
+    writeFileSync(join(binDir, "run-hook.sh"), "#!/bin/sh\necho run\n");
+    writeFileSync(join(binDir, "timezone-hook.sh"), "#!/bin/sh\necho tz\n");
+    return binDir;
+  }
+  const h = (s: string) => sha256Text(s);
+
+  it("image scripts matching installed bin/ → no findings", () => {
+    const binDir = seedBin();
+    const r = detectHookScriptDrift("bot", {
+      binDir,
+      execImpl: () =>
+        `${h("#!/bin/sh\necho run\n")}  /opt/switchroom/bin/run-hook.sh\n` +
+        `${h("#!/bin/sh\necho tz\n")}  /opt/switchroom/bin/timezone-hook.sh\n`,
+    });
+    expect(r).toEqual([]);
+  });
+
+  it("stale image script → finding naming the script", () => {
+    const binDir = seedBin();
+    const r = detectHookScriptDrift("bot", {
+      binDir,
+      execImpl: () =>
+        `${h("OLD CONTENT")}  /opt/switchroom/bin/run-hook.sh\n` +
+        `${h("#!/bin/sh\necho tz\n")}  /opt/switchroom/bin/timezone-hook.sh\n`,
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0].surface).toBe("hook-scripts");
+    expect(r[0].detail).toContain("run-hook.sh");
+    expect(r[0].detail).not.toContain("timezone-hook.sh");
+  });
+
+  it("script missing from image entirely → finding names it", () => {
+    const binDir = seedBin();
+    const r = detectHookScriptDrift("bot", {
+      binDir,
+      execImpl: () => `${h("#!/bin/sh\necho run\n")}  /opt/switchroom/bin/run-hook.sh\n`,
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0].detail).toContain("timezone-hook.sh");
+  });
+
+  it("container not running (docker exec throws) → not checkable, no findings", () => {
+    const binDir = seedBin();
+    const r = detectHookScriptDrift("bot", {
+      binDir,
+      execImpl: () => {
+        throw new Error("No such container: switchroom-bot");
+      },
+    });
+    expect(r).toEqual([]);
+  });
+});

--- a/src/agents/drift.test.ts
+++ b/src/agents/drift.test.ts
@@ -5,6 +5,7 @@
  * none), matching the issue's acceptance criteria.
  */
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { createHash } from "node:crypto";
 import {
   mkdirSync,
   mkdtempSync,
@@ -67,6 +68,21 @@ describe("detectComposeDrift", () => {
   it("no deployed compose (apply never ran) → not drift", async () => {
     const r = await detectComposeDrift({
       compute: async () => ({ ...base, content: "x", previous: null, previousImageTag: null }),
+    });
+    expect(r).toEqual([]);
+  });
+
+  it("build-local deployed compose (contains build: blocks) → skipped, never drift", async () => {
+    // `switchroom apply --build-local` renders `build:` blocks instead of
+    // `image:` lines; the doctor-side fresh render is always pull-mode, so
+    // a byte compare would flag every locally-built fleet forever.
+    const r = await detectComposeDrift({
+      compute: async () => ({
+        ...base,
+        content: "services:\n  agent:\n    image: ghcr.io/x/switchroom-agent:v1\n",
+        previous:
+          "services:\n  agent:\n    build:\n      context: /home/op/switchroom\n      dockerfile: docker/Dockerfile.agent\n",
+      }),
     });
     expect(r).toEqual([]);
   });
@@ -227,6 +243,21 @@ describe("detectHookScriptDrift", () => {
     });
     expect(r).toHaveLength(1);
     expect(r[0].detail).toContain("timezone-hook.sh");
+  });
+
+  it("script with non-UTF8 bytes hashes raw (matches sha256sum) → no phantom drift", () => {
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir);
+    // 0xC3 alone is an invalid UTF-8 sequence — a utf-8 decode/re-encode
+    // round-trip would replace it and permanently mismatch sha256sum.
+    const bytes = Buffer.concat([Buffer.from("#!/bin/sh\n"), Buffer.from([0xc3, 0x28, 0x0a])]);
+    writeFileSync(join(binDir, "raw.sh"), bytes);
+    const byteHash = createHash("sha256").update(bytes).digest("hex");
+    const r = detectHookScriptDrift("bot", {
+      binDir,
+      execImpl: () => `${byteHash}  /opt/switchroom/bin/raw.sh\n`,
+    });
+    expect(r).toEqual([]);
   });
 
   it("container not running (docker exec throws) → not checkable, no findings", () => {

--- a/src/agents/drift.ts
+++ b/src/agents/drift.ts
@@ -27,6 +27,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   existsSync,
   lstatSync,
@@ -46,11 +47,7 @@ import { isHindsightEnabled } from "../memory/hindsight.js";
 import { VERSION } from "../build-info.js";
 import { buildSettingsHooksBlock, detectHooksDrift } from "./scaffold.js";
 import { containerName } from "./lifecycle.js";
-import {
-  computeConfigHash,
-  detectStampDrift,
-  sha256Text,
-} from "./generation-stamp.js";
+import { computeConfigHash, detectStampDrift } from "./generation-stamp.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -91,6 +88,16 @@ export async function detectComposeDrift(opts: {
   }
   if (result.previous === null) return [];
   if (result.content === result.previous) return [];
+  // A deployed compose containing a `build:` block was rendered with
+  // `switchroom apply --build-local` (emitImageOrBuild emits `image:`
+  // in pull mode, `build:` in local mode — never both for the same
+  // service). A fresh default render here uses pull mode, so a byte
+  // compare would flag EVERY locally-built fleet as drifted forever.
+  // Not checkable from here → silently skip (false-positive avoidance
+  // beats coverage for a warn-only signal).
+  if (/^\s+build:\s*$/m.test(result.previous) || /^\s+build:\s+\S/m.test(result.previous)) {
+    return [];
+  }
   const imageNote =
     result.previousImageTag && result.previousImageTag !== result.imageTag
       ? ` (image ${result.previousImageTag} → ${result.imageTag})`
@@ -333,7 +340,13 @@ export function detectHookScriptDrift(
   }
   for (const f of names) {
     try {
-      expected.set(f, sha256Text(readFileSync(join(binDir, f), "utf-8")));
+      // Hash the RAW bytes — the container side is `sha256sum` (byte
+      // hash). A utf-8 decode/re-encode round-trip would corrupt any
+      // non-UTF8 byte and read as permanent phantom drift.
+      expected.set(
+        f,
+        createHash("sha256").update(readFileSync(join(binDir, f))).digest("hex"),
+      );
     } catch {
       /* unreadable local script — skip */
     }

--- a/src/agents/drift.ts
+++ b/src/agents/drift.ts
@@ -1,0 +1,461 @@
+/**
+ * Fleet-wide generated-surface drift detection (KEN-130, stage 2 of
+ * KEN-128).
+ *
+ * Host-side detectors that compare each generated/synced surface against
+ * what a fresh render of the current config + installed switchroom would
+ * produce. Hash comparison throughout — nothing here writes to a managed
+ * surface. Surfaces covered:
+ *
+ *   1. compose        — deployed docker-compose.yml vs a fresh
+ *                       `computeComposeContent` render (byte compare).
+ *   2. hooks          — settings.json hooks block vs
+ *                       `buildSettingsHooksBlock` (via `detectHooksDrift`).
+ *   3. templates      — start.sh + managed CLAUDE.md section vs the
+ *                       generation stamp written at last reconcile, plus
+ *                       config/version staleness (generation-stamp.ts).
+ *   4. skills         — `.claude/skills` entries vs the host bundled pool
+ *                       + `skills.d` overlay declarations.
+ *   5. mcp            — .mcp.json vs the generation stamp (same mechanism
+ *                       as templates; yaml drift is caught by configHash).
+ *   6. hook-scripts   — /opt/switchroom/bin/*.sh inside the running
+ *                       container vs the installed repo's bin/*.sh.
+ *
+ * Consumers: `switchroom doctor` (src/cli/doctor-drift.ts) and, via the
+ * per-agent report file this module writes, the gateway boot-card probe
+ * (telegram-plugin/gateway/boot-probes.ts probeDrift).
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
+import {
+  resolveAgentConfig,
+  usesSwitchroomTelegramPlugin,
+} from "../config/merge.js";
+import { isHindsightEnabled } from "../memory/hindsight.js";
+import { VERSION } from "../build-info.js";
+import { buildSettingsHooksBlock, detectHooksDrift } from "./scaffold.js";
+import { containerName } from "./lifecycle.js";
+import {
+  computeConfigHash,
+  detectStampDrift,
+  sha256Text,
+} from "./generation-stamp.js";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface DriftFinding {
+  /** Named surface class (compose | hooks | start.sh | CLAUDE.md | .mcp.json
+   *  | config | version | skills | hook-scripts). */
+  surface: string;
+  /** Agent slug when the finding is per-agent; absent for fleet surfaces. */
+  agent?: string;
+  detail: string;
+  fix?: string;
+}
+
+// ─── Surface 1: compose ─────────────────────────────────────────────────────
+
+/**
+ * Compare the deployed compose file against a fresh render of the current
+ * config. The render is injected so doctor can pass the real
+ * `computeComposeContent` while tests inject a stub (the real one touches
+ * vault/broker state).
+ *
+ * A missing deployed compose is NOT drift (apply never ran); a render
+ * error yields no finding (doctor surfaces render errors elsewhere).
+ */
+export async function detectComposeDrift(opts: {
+  compute: () => Promise<{
+    content: string;
+    previous: string | null;
+    imageTag: string;
+    previousImageTag: string | null;
+  }>;
+}): Promise<DriftFinding[]> {
+  let result;
+  try {
+    result = await opts.compute();
+  } catch {
+    return [];
+  }
+  if (result.previous === null) return [];
+  if (result.content === result.previous) return [];
+  const imageNote =
+    result.previousImageTag && result.previousImageTag !== result.imageTag
+      ? ` (image ${result.previousImageTag} → ${result.imageTag})`
+      : "";
+  return [
+    {
+      surface: "compose",
+      detail: `deployed docker-compose.yml differs from current config render${imageNote}`,
+      fix: "Run `switchroom apply`",
+    },
+  ];
+}
+
+// ─── Surface 2: settings.json hooks ─────────────────────────────────────────
+
+/**
+ * Reuses the existing `buildSettingsHooksBlock` + `detectHooksDrift` pair
+ * (the same comparison `switchroom agent reconcile --check` runs).
+ * `agentConfig` must already be cascade-resolved.
+ */
+export function detectHooksSurfaceDrift(
+  name: string,
+  agentConfig: AgentConfig,
+  agentDir: string,
+  config: SwitchroomConfig,
+  configPath: string | undefined,
+): DriftFinding[] {
+  const hindsightEnabled =
+    isHindsightEnabled(config) && agentConfig.memory?.auto_recall !== false;
+  const expected = buildSettingsHooksBlock({
+    agentName: name,
+    agentConfig,
+    hindsightEnabled,
+    useSwitchroomPlugin: usesSwitchroomTelegramPlugin(agentConfig),
+    configPath,
+  });
+
+  const settingsPath = join(agentDir, ".claude", "settings.json");
+  if (!existsSync(settingsPath)) {
+    return [
+      {
+        surface: "hooks",
+        agent: name,
+        detail: ".claude/settings.json missing",
+        fix: `Run \`switchroom agent reconcile ${name}\``,
+      },
+    ];
+  }
+  let actual: Record<string, unknown>;
+  try {
+    const raw = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    actual = (raw.hooks as Record<string, unknown>) ?? {};
+  } catch {
+    return [
+      {
+        surface: "hooks",
+        agent: name,
+        detail: ".claude/settings.json unparseable",
+        fix: `Run \`switchroom agent reconcile ${name}\``,
+      },
+    ];
+  }
+  const { drifted, summary } = detectHooksDrift(expected, actual);
+  if (!drifted) return [];
+  return [
+    {
+      surface: "hooks",
+      agent: name,
+      detail: `settings.json hooks ${summary}`,
+      fix: `Run \`switchroom agent reconcile ${name} --restart\``,
+    },
+  ];
+}
+
+// ─── Surfaces 3 + 5: template stamp (start.sh, CLAUDE.md, .mcp.json) ────────
+
+/**
+ * Hash-compare the deployed generated files against the generation stamp
+ * (see generation-stamp.ts), plus config-hash and version staleness.
+ * No stamp yet → no findings (fresh agent / pre-KEN-130; the stamp
+ * appears on the next `switchroom apply`).
+ */
+export function detectTemplateStampDrift(
+  name: string,
+  agentConfig: AgentConfig,
+  agentDir: string,
+  opts: { currentVersion?: string } = {},
+): DriftFinding[] {
+  const result = detectStampDrift(agentDir, {
+    currentConfigHash: computeConfigHash(agentConfig),
+    currentVersion: opts.currentVersion ?? VERSION,
+  });
+  if (!result.hasStamp) return [];
+  return result.findings.map((f) => ({
+    surface: f.surface,
+    agent: name,
+    detail: f.detail,
+    fix: `Run \`switchroom apply\` (or \`switchroom agent reconcile ${name} --restart\`)`,
+  }));
+}
+
+// ─── Surface 4: skills sync ─────────────────────────────────────────────────
+
+const BUNDLED_POOL_SEGMENT = "/.switchroom/skills/_bundled/";
+
+/**
+ * Check the agent's `.claude/skills` tree against the host bundled pool
+ * and the agent's `skills.d` overlay declarations:
+ *
+ *   - a skills entry whose symlink target no longer exists (dangling —
+ *     the pool skill was removed or renamed);
+ *   - an overlay-declared slug (`skills.d/<slug>.yaml`) with no live
+ *     entry under `.claude/skills/<slug>` (install never reconciled).
+ */
+export function detectSkillsDrift(name: string, agentDir: string): DriftFinding[] {
+  const findings: DriftFinding[] = [];
+  const skillsDir = join(agentDir, ".claude", "skills");
+
+  const liveEntries = new Set<string>();
+  if (existsSync(skillsDir)) {
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(skillsDir);
+    } catch {
+      entries = [];
+    }
+    for (const entry of entries) {
+      const p = join(skillsDir, entry);
+      let st;
+      try {
+        st = lstatSync(p);
+      } catch {
+        continue;
+      }
+      if (st.isSymbolicLink()) {
+        let target: string | null = null;
+        try {
+          target = readlinkSync(p);
+        } catch {
+          /* unreadable link */
+        }
+        const resolved =
+          target === null
+            ? null
+            : isAbsolute(target)
+              ? target
+              : resolve(dirname(p), target);
+        if (resolved === null || !existsSync(resolved)) {
+          const poolNote =
+            resolved && resolved.includes(BUNDLED_POOL_SEGMENT)
+              ? " (bundled pool target removed)"
+              : "";
+          findings.push({
+            surface: "skills",
+            agent: name,
+            detail: `skill \`${entry}\` is a dangling symlink${poolNote}`,
+            fix: `Run \`switchroom agent reconcile ${name}\` or remove the entry`,
+          });
+          continue;
+        }
+      }
+      liveEntries.add(entry);
+    }
+  }
+
+  // Overlay-declared skills must have a live entry.
+  const overlayDir = join(agentDir, "skills.d");
+  if (existsSync(overlayDir)) {
+    let overlayEntries: string[] = [];
+    try {
+      overlayEntries = readdirSync(overlayDir);
+    } catch {
+      overlayEntries = [];
+    }
+    for (const f of overlayEntries) {
+      const m = /^(.+)\.ya?ml$/i.exec(f);
+      if (!m) continue;
+      if (!liveEntries.has(m[1])) {
+        findings.push({
+          surface: "skills",
+          agent: name,
+          detail: `overlay skill \`${m[1]}\` declared in skills.d but not installed under .claude/skills`,
+          fix: `Run \`switchroom agent reconcile ${name}\``,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+// ─── Surface 6: hook scripts baked into the agent image ─────────────────────
+
+export type ExecImpl = (cmd: string, args: string[]) => string;
+
+const defaultExec: ExecImpl = (cmd, args) =>
+  execFileSync(cmd, args, {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 10_000,
+  });
+
+/** Walk up from this module to the install root containing `bin/`. */
+export function locateInstallBinDir(): string | null {
+  let dir: string | undefined = import.meta.dirname;
+  for (let i = 0; i < 10 && dir && dir !== "/"; i++) {
+    if (existsSync(join(dir, "dependencies.json")) && existsSync(join(dir, "bin"))) {
+      return join(dir, "bin");
+    }
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+/**
+ * Compare the hook scripts baked into the agent image
+ * (`/opt/switchroom/bin/*.sh`, COPY'd from repo `bin/*.sh` at image
+ * build) against the installed repo's `bin/*.sh`. Deployed side is read
+ * via `docker exec` on the running container; when docker / the
+ * container / the install bin dir is unavailable the check silently
+ * yields no findings (doctor's docker section owns those failures).
+ */
+export function detectHookScriptDrift(
+  name: string,
+  opts: { binDir?: string; execImpl?: ExecImpl } = {},
+): DriftFinding[] {
+  const binDir = opts.binDir ?? locateInstallBinDir();
+  if (!binDir || !existsSync(binDir)) return [];
+  const exec = opts.execImpl ?? defaultExec;
+
+  const expected = new Map<string, string>();
+  let names: string[] = [];
+  try {
+    names = readdirSync(binDir).filter((f) => f.endsWith(".sh"));
+  } catch {
+    return [];
+  }
+  for (const f of names) {
+    try {
+      expected.set(f, sha256Text(readFileSync(join(binDir, f), "utf-8")));
+    } catch {
+      /* unreadable local script — skip */
+    }
+  }
+  if (expected.size === 0) return [];
+
+  let out: string;
+  try {
+    out = exec("docker", [
+      "exec",
+      containerName(name),
+      "sh",
+      "-c",
+      "sha256sum /opt/switchroom/bin/*.sh 2>/dev/null",
+    ]);
+  } catch {
+    return []; // docker unavailable / container not running — not checkable
+  }
+
+  const deployed = new Map<string, string>();
+  for (const line of out.split("\n")) {
+    const m = /^([0-9a-f]{64})\s+(?:\*)?(.+)$/.exec(line.trim());
+    if (!m) continue;
+    const base = m[2].split("/").pop();
+    if (base) deployed.set(base, m[1]);
+  }
+  if (deployed.size === 0) return []; // exec gave nothing useful — skip
+
+  const drifted: string[] = [];
+  for (const [file, hash] of expected) {
+    const dep = deployed.get(file);
+    if (dep === undefined || dep !== hash) drifted.push(file);
+  }
+  if (drifted.length === 0) return [];
+  return [
+    {
+      surface: "hook-scripts",
+      agent: name,
+      detail: `image hook script(s) differ from installed version: ${drifted.sort().join(", ")}`,
+      fix: "Run `switchroom update` (rebuild/pull the agent image), then restart the agent",
+    },
+  ];
+}
+
+// ─── Aggregation + per-agent report file (boot-card handoff) ────────────────
+
+/** Basename of the per-agent drift report the boot-card probe reads. */
+export const DRIFT_REPORT_FILE = ".switchroom-drift.json";
+
+export interface DriftReport {
+  version: 1;
+  generatedAt: string;
+  findings: Array<Pick<DriftFinding, "surface" | "detail">>;
+}
+
+/**
+ * Persist the host-side findings for one agent so the in-container
+ * boot-card probe can surface them (the container can't render compose
+ * or reach the host skills pool itself). ALWAYS written — an empty
+ * findings array is how a previously-drifted agent reads clean again.
+ * Best-effort: report IO must never fail a doctor run.
+ */
+export function writeDriftReport(agentDir: string, findings: DriftFinding[]): void {
+  try {
+    const report: DriftReport = {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      findings: findings.map(({ surface, detail }) => ({ surface, detail })),
+    };
+    writeFileSync(
+      join(agentDir, DRIFT_REPORT_FILE),
+      JSON.stringify(report, null, 2) + "\n",
+      "utf-8",
+    );
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Run every per-agent detector (surfaces 2-6) for one agent. The raw
+ * (unresolved) agent config is cascade-resolved here so callers pass
+ * `config.agents[name]` directly.
+ */
+export function detectAgentDrift(
+  name: string,
+  agentConfigRaw: AgentConfig,
+  agentsDir: string,
+  config: SwitchroomConfig,
+  configPath: string | undefined,
+  opts: {
+    execImpl?: ExecImpl;
+    binDir?: string;
+    currentVersion?: string;
+    /** Skip the docker-exec hook-script probe (doctor --fast). */
+    skipContainerProbes?: boolean;
+  } = {},
+): DriftFinding[] {
+  const agentDir = resolve(agentsDir, name);
+  if (!existsSync(agentDir)) return [];
+  const agentConfig = resolveAgentConfig(
+    config.defaults,
+    config.profiles,
+    agentConfigRaw,
+  );
+  const findings: DriftFinding[] = [];
+  findings.push(
+    ...detectHooksSurfaceDrift(name, agentConfig, agentDir, config, configPath),
+  );
+  findings.push(
+    ...detectTemplateStampDrift(name, agentConfig, agentDir, {
+      currentVersion: opts.currentVersion,
+    }),
+  );
+  findings.push(...detectSkillsDrift(name, agentDir));
+  if (!opts.skipContainerProbes) {
+    findings.push(
+      ...detectHookScriptDrift(name, {
+        binDir: opts.binDir,
+        execImpl: opts.execImpl,
+      }),
+    );
+  }
+  return findings;
+}

--- a/src/agents/generation-stamp.test.ts
+++ b/src/agents/generation-stamp.test.ts
@@ -1,0 +1,167 @@
+/**
+ * KEN-130 — generation stamp: the hash anchor for template-surface drift
+ * detection. Outcome-asserting: each test stages a real agent-dir state
+ * and asserts the named finding (or its absence), not just code paths.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  CLAUDE_MD_YOURS_MARKER,
+  computeConfigHash,
+  computeStampFilesFromDisk,
+  detectStampDrift,
+  hashManagedClaudeMd,
+  readGenerationStamp,
+  stableStringify,
+  writeGenerationStamp,
+} from "./generation-stamp.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "stamp-test-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function seedAgentDir(): void {
+  writeFileSync(join(dir, "start.sh"), "#!/bin/bash\necho hi\n");
+  writeFileSync(
+    join(dir, "CLAUDE.md"),
+    `# Agent\nmanaged text\n\n${CLAUDE_MD_YOURS_MARKER}\n\noperator text\n`,
+  );
+  writeFileSync(join(dir, ".mcp.json"), '{"mcpServers":{}}\n');
+}
+
+function stampNow(config: unknown = { model: "opus" }, version = "1.0.0"): void {
+  writeGenerationStamp(dir, {
+    switchroomVersion: version,
+    configHash: computeConfigHash(config),
+    files: computeStampFilesFromDisk(dir),
+  });
+}
+
+describe("stableStringify / computeConfigHash", () => {
+  it("is key-order independent at every level", () => {
+    const a = { b: 1, a: { z: 2, y: [1, 2] } };
+    const b = { a: { y: [1, 2], z: 2 }, b: 1 };
+    expect(stableStringify(a)).toBe(stableStringify(b));
+    expect(computeConfigHash(a)).toBe(computeConfigHash(b));
+  });
+
+  it("differs when values differ", () => {
+    expect(computeConfigHash({ m: 1 })).not.toBe(computeConfigHash({ m: 2 }));
+  });
+});
+
+describe("hashManagedClaudeMd", () => {
+  it("ignores operator edits below the Yours marker", () => {
+    const managed = `top\n${CLAUDE_MD_YOURS_MARKER}`;
+    expect(hashManagedClaudeMd(`${managed}\nfoo`)).toBe(
+      hashManagedClaudeMd(`${managed}\ntotally different operator section`),
+    );
+  });
+
+  it("changes when the managed section changes", () => {
+    expect(hashManagedClaudeMd(`a\n${CLAUDE_MD_YOURS_MARKER}\nx`)).not.toBe(
+      hashManagedClaudeMd(`b\n${CLAUDE_MD_YOURS_MARKER}\nx`),
+    );
+  });
+});
+
+describe("detectStampDrift", () => {
+  it("clean agent dir → no findings", () => {
+    seedAgentDir();
+    stampNow();
+    const r = detectStampDrift(dir, {
+      currentConfigHash: computeConfigHash({ model: "opus" }),
+      currentVersion: "1.0.0",
+    });
+    expect(r.hasStamp).toBe(true);
+    expect(r.findings).toEqual([]);
+  });
+
+  it("no stamp → hasStamp false and zero findings (never false-drift)", () => {
+    seedAgentDir();
+    const r = detectStampDrift(dir);
+    expect(r.hasStamp).toBe(false);
+    expect(r.findings).toEqual([]);
+  });
+
+  it("edited start.sh → finding named start.sh", () => {
+    seedAgentDir();
+    stampNow();
+    writeFileSync(join(dir, "start.sh"), "#!/bin/bash\necho TAMPERED\n");
+    const r = detectStampDrift(dir);
+    expect(r.findings.map((f) => f.surface)).toEqual(["start.sh"]);
+    expect(r.findings[0].detail).toMatch(/modified since last apply/);
+  });
+
+  it("edited managed CLAUDE.md section → finding; below-marker edit → none", () => {
+    seedAgentDir();
+    stampNow();
+    // Below-marker edit: operator-owned, must NOT drift.
+    writeFileSync(
+      join(dir, "CLAUDE.md"),
+      `# Agent\nmanaged text\n\n${CLAUDE_MD_YOURS_MARKER}\n\nNEW operator prose\n`,
+    );
+    expect(detectStampDrift(dir).findings).toEqual([]);
+    // Managed edit: must drift, named.
+    writeFileSync(
+      join(dir, "CLAUDE.md"),
+      `# Agent\nTAMPERED managed\n\n${CLAUDE_MD_YOURS_MARKER}\n\nNEW operator prose\n`,
+    );
+    expect(detectStampDrift(dir).findings.map((f) => f.surface)).toEqual([
+      "CLAUDE.md",
+    ]);
+  });
+
+  it("edited .mcp.json → finding named .mcp.json", () => {
+    seedAgentDir();
+    stampNow();
+    writeFileSync(join(dir, ".mcp.json"), '{"mcpServers":{"evil":{}}}\n');
+    expect(detectStampDrift(dir).findings.map((f) => f.surface)).toEqual([
+      ".mcp.json",
+    ]);
+  });
+
+  it("deleted stamped file → 'missing' finding", () => {
+    seedAgentDir();
+    stampNow();
+    rmSync(join(dir, "start.sh"));
+    const r = detectStampDrift(dir);
+    expect(r.findings).toEqual([
+      { surface: "start.sh", detail: "missing (was present at last apply)" },
+    ]);
+  });
+
+  it("config changed since apply → 'config' finding", () => {
+    seedAgentDir();
+    stampNow({ model: "opus" });
+    const r = detectStampDrift(dir, {
+      currentConfigHash: computeConfigHash({ model: "sonnet" }),
+    });
+    expect(r.findings.map((f) => f.surface)).toEqual(["config"]);
+  });
+
+  it("switchroom updated since apply → 'version' finding naming both versions", () => {
+    seedAgentDir();
+    stampNow({ model: "opus" }, "1.0.0");
+    const r = detectStampDrift(dir, { currentVersion: "1.1.0" });
+    expect(r.findings.map((f) => f.surface)).toEqual(["version"]);
+    expect(r.findings[0].detail).toContain("1.0.0");
+    expect(r.findings[0].detail).toContain("1.1.0");
+  });
+
+  it("corrupt stamp file reads as no-stamp, not drift", () => {
+    seedAgentDir();
+    writeFileSync(join(dir, ".switchroom-generated.json"), "not json");
+    const r = detectStampDrift(dir);
+    expect(r.hasStamp).toBe(false);
+    expect(r.findings).toEqual([]);
+    expect(readGenerationStamp(dir)).toBeNull();
+  });
+});

--- a/src/agents/generation-stamp.test.ts
+++ b/src/agents/generation-stamp.test.ts
@@ -156,6 +156,27 @@ describe("detectStampDrift", () => {
     expect(r.findings[0].detail).toContain("1.1.0");
   });
 
+  it("stamp with files:null (partial write) reads as no-stamp, never crashes", () => {
+    seedAgentDir();
+    writeFileSync(
+      join(dir, ".switchroom-generated.json"),
+      '{"version":1,"generatedAt":"2026-01-01T00:00:00Z","switchroomVersion":"1.0.0","configHash":"x","files":null}',
+    );
+    const r = detectStampDrift(dir, { currentVersion: "9.9.9" });
+    expect(r.hasStamp).toBe(false);
+    expect(r.findings).toEqual([]);
+    expect(readGenerationStamp(dir)).toBeNull();
+  });
+
+  it("stamp with files as an array reads as no-stamp", () => {
+    seedAgentDir();
+    writeFileSync(
+      join(dir, ".switchroom-generated.json"),
+      '{"version":1,"switchroomVersion":"1.0.0","configHash":"x","files":[]}',
+    );
+    expect(detectStampDrift(dir).hasStamp).toBe(false);
+  });
+
   it("corrupt stamp file reads as no-stamp, not drift", () => {
     seedAgentDir();
     writeFileSync(join(dir, ".switchroom-generated.json"), "not json");

--- a/src/agents/generation-stamp.ts
+++ b/src/agents/generation-stamp.ts
@@ -154,7 +154,16 @@ export function readGenerationStamp(agentDir: string): GenerationStamp | null {
   if (!existsSync(p)) return null;
   try {
     const parsed = JSON.parse(readFileSync(p, "utf-8")) as GenerationStamp;
-    if (parsed?.version !== 1 || typeof parsed.files !== "object") return null;
+    // `typeof null === "object"` — a stamp with `"files": null` (partial
+    // write / hand-edit) must read as no-stamp, not crash the comparer.
+    if (
+      parsed?.version !== 1 ||
+      typeof parsed.files !== "object" ||
+      parsed.files === null ||
+      Array.isArray(parsed.files)
+    ) {
+      return null;
+    }
     return parsed;
   } catch {
     return null;

--- a/src/agents/generation-stamp.ts
+++ b/src/agents/generation-stamp.ts
@@ -1,0 +1,217 @@
+/**
+ * Generation stamp — the drift-detection anchor for scaffold-generated
+ * agent files (KEN-130, stage 2 of KEN-128).
+ *
+ * On every host-side reconcile (`switchroom apply`, `switchroom agent
+ * reconcile/restart`) the scaffolder records, into
+ * `<agentDir>/.switchroom-generated.json`:
+ *
+ *   - a sha256 per managed file it just enforced on disk
+ *     (start.sh, the Switchroom-managed section of CLAUDE.md, .mcp.json),
+ *   - a canonical hash of the RESOLVED agent config the render used, and
+ *   - the switchroom version that did the rendering.
+ *
+ * Drift detection is then a pure hash comparison — no re-render needed:
+ *
+ *   - deployed file hash ≠ stamped hash   → the file was modified (or
+ *     partially written) since the last apply;
+ *   - current resolved-config hash ≠ stamped configHash → switchroom.yaml
+ *     changed but was never applied (stale generation);
+ *   - installed VERSION ≠ stamped switchroomVersion → switchroom was
+ *     updated but the agent was never re-applied.
+ *
+ * The stamp lives inside the (bind-mounted) agent dir so BOTH the host
+ * (`switchroom doctor`) and the in-container gateway boot-card probe can
+ * run the same comparison. This module is intentionally dependency-free
+ * (node:fs / node:crypto / node:path only) so the telegram-plugin gateway
+ * can import it without dragging in the 7k-line scaffolder.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Basename of the stamp file inside an agent dir. */
+export const GENERATION_STAMP_FILE = ".switchroom-generated.json";
+
+/**
+ * Visible boundary between the Switchroom-managed (scaffold-regenerated)
+ * top of `<agentDir>/CLAUDE.md` and the operator-owned bottom that survives
+ * every `switchroom apply`.
+ *
+ * STRUCTURAL PROMISE — never change this text or its semantics again
+ * (see scaffold.ts #1857). Canonical home moved here (KEN-130) so the
+ * gateway-side drift probe can split without importing scaffold.ts;
+ * scaffold.ts re-exports it for its existing importers.
+ */
+export const CLAUDE_MD_YOURS_MARKER = "# --- Yours (preserved across apply) ---";
+
+/** The managed files a stamp tracks, relative to the agent dir. */
+export const STAMPED_FILES = ["start.sh", "CLAUDE.md", ".mcp.json"] as const;
+export type StampedFile = (typeof STAMPED_FILES)[number];
+
+export interface GenerationStamp {
+  version: 1;
+  /** ISO timestamp of the reconcile that wrote this stamp. */
+  generatedAt: string;
+  /** Switchroom VERSION that performed the render. */
+  switchroomVersion: string;
+  /** sha256 of the canonical JSON of the RESOLVED agent config. */
+  configHash: string;
+  /** relative path → sha256 of the managed content at stamp time. */
+  files: Partial<Record<StampedFile, string>>;
+}
+
+export function sha256Text(s: string): string {
+  return createHash("sha256").update(s, "utf-8").digest("hex");
+}
+
+/**
+ * Deterministic JSON: object keys sorted at every level so semantically
+ * identical configs always hash identically regardless of yaml key order.
+ */
+export function stableStringify(v: unknown): string {
+  return JSON.stringify(v, (_key, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      return Object.fromEntries(
+        Object.entries(val as Record<string, unknown>).sort(([a], [b]) =>
+          a.localeCompare(b),
+        ),
+      );
+    }
+    return val;
+  });
+}
+
+/** Canonical hash of a resolved agent config (post-cascade). */
+export function computeConfigHash(resolvedAgentConfig: unknown): string {
+  return sha256Text(stableStringify(resolvedAgentConfig));
+}
+
+/**
+ * Hash only the Switchroom-managed section of a CLAUDE.md — everything
+ * above (and including) the `# --- Yours ---` marker. Edits BELOW the
+ * marker are operator-owned by contract and must never read as drift.
+ * Files without a marker (legacy single-section) hash whole.
+ */
+export function hashManagedClaudeMd(content: string): string {
+  const idx = content.indexOf(CLAUDE_MD_YOURS_MARKER);
+  const managed =
+    idx === -1 ? content : content.slice(0, idx + CLAUDE_MD_YOURS_MARKER.length);
+  return sha256Text(managed);
+}
+
+/** Hash the managed content of one stamped file as read from disk. */
+function hashStampedFileOnDisk(agentDir: string, rel: StampedFile): string | null {
+  const p = join(agentDir, rel);
+  if (!existsSync(p)) return null;
+  let content: string;
+  try {
+    content = readFileSync(p, "utf-8");
+  } catch {
+    return null;
+  }
+  return rel === "CLAUDE.md" ? hashManagedClaudeMd(content) : sha256Text(content);
+}
+
+/**
+ * Read the current on-disk state of every stamped file and return the
+ * hash map. Missing/unreadable files are omitted (a stamp never claims a
+ * file it couldn't read).
+ */
+export function computeStampFilesFromDisk(
+  agentDir: string,
+): Partial<Record<StampedFile, string>> {
+  const files: Partial<Record<StampedFile, string>> = {};
+  for (const rel of STAMPED_FILES) {
+    const h = hashStampedFileOnDisk(agentDir, rel);
+    if (h !== null) files[rel] = h;
+  }
+  return files;
+}
+
+export function writeGenerationStamp(
+  agentDir: string,
+  stamp: Omit<GenerationStamp, "version" | "generatedAt"> &
+    Partial<Pick<GenerationStamp, "generatedAt">>,
+): void {
+  const full: GenerationStamp = {
+    version: 1,
+    generatedAt: stamp.generatedAt ?? new Date().toISOString(),
+    switchroomVersion: stamp.switchroomVersion,
+    configHash: stamp.configHash,
+    files: stamp.files,
+  };
+  writeFileSync(
+    join(agentDir, GENERATION_STAMP_FILE),
+    JSON.stringify(full, null, 2) + "\n",
+    "utf-8",
+  );
+}
+
+export function readGenerationStamp(agentDir: string): GenerationStamp | null {
+  const p = join(agentDir, GENERATION_STAMP_FILE);
+  if (!existsSync(p)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf-8")) as GenerationStamp;
+    if (parsed?.version !== 1 || typeof parsed.files !== "object") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** One drifted surface, named. */
+export interface StampDriftFinding {
+  /** Surface name shown to the operator (e.g. "start.sh", "CLAUDE.md"). */
+  surface: string;
+  detail: string;
+}
+
+export interface StampDriftResult {
+  /** False when no stamp exists yet (fresh agent / pre-KEN-130 install) —
+   *  callers must treat that as "not checkable", never as drift. */
+  hasStamp: boolean;
+  findings: StampDriftFinding[];
+}
+
+/**
+ * Pure hash comparison of the deployed managed files against the stamp,
+ * plus optional stale-generation checks when the caller can supply the
+ * current resolved-config hash and/or installed version (host-side only —
+ * the in-container gateway probe omits both).
+ */
+export function detectStampDrift(
+  agentDir: string,
+  opts: { currentConfigHash?: string; currentVersion?: string } = {},
+): StampDriftResult {
+  const stamp = readGenerationStamp(agentDir);
+  if (!stamp) return { hasStamp: false, findings: [] };
+
+  const findings: StampDriftFinding[] = [];
+  for (const rel of STAMPED_FILES) {
+    const stamped = stamp.files[rel];
+    if (!stamped) continue; // file wasn't managed at stamp time
+    const current = hashStampedFileOnDisk(agentDir, rel);
+    if (current === null) {
+      findings.push({ surface: rel, detail: "missing (was present at last apply)" });
+    } else if (current !== stamped) {
+      findings.push({ surface: rel, detail: "modified since last apply" });
+    }
+  }
+
+  if (opts.currentConfigHash && opts.currentConfigHash !== stamp.configHash) {
+    findings.push({
+      surface: "config",
+      detail: "switchroom.yaml changed since last apply (generated files are stale)",
+    });
+  }
+  if (opts.currentVersion && opts.currentVersion !== stamp.switchroomVersion) {
+    findings.push({
+      surface: "version",
+      detail: `generated by switchroom ${stamp.switchroomVersion}, installed ${opts.currentVersion} — re-apply to refresh`,
+    });
+  }
+
+  return { hasStamp: true, findings };
+}

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -5321,7 +5321,16 @@ export function scaffoldAgent(
   }
   // Generation stamp (KEN-130) — fresh agents are stamped at scaffold so
   // drift detection is meaningful before the first reconcile too.
-  stampGeneratedSurfaces(agentDir, agentConfig);
+  //
+  // Skipped when the caller passed no `switchroomConfig`: the cascade above
+  // then degraded to the RAW agent config, while the drift detector always
+  // resolves defaults → profile → agent. Stamping an unresolved configHash
+  // would make every agent on a fleet that uses `defaults:` / `profiles:`
+  // report a phantom "switchroom.yaml changed since last apply". No stamp
+  // reads as "not checkable", which is the safe direction; the first
+  // reconcile (which always has the full config) writes the real one. Every
+  // production callsite passes it — this only guards internal/test callers.
+  if (switchroomConfig) stampGeneratedSurfaces(agentDir, agentConfig);
 
   return { agentDir, created, skipped };
 }

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -28,6 +28,13 @@ import {
   findAgentUnreadablePaths,
   scopedAssertCandidates,
 } from "./agent-owned-tree.js";
+import {
+  CLAUDE_MD_YOURS_MARKER,
+  computeConfigHash,
+  computeStampFilesFromDisk,
+  writeGenerationStamp,
+} from "./generation-stamp.js";
+import { VERSION as SWITCHROOM_VERSION } from "../build-info.js";
 
 // Repo root for referencing bin/ scripts in hooks
 const REPO_ROOT = resolve(import.meta.dirname, "../..");
@@ -1546,8 +1553,12 @@ function composeWithSidecar(renderedBase: string, sidecarPath: string): string {
  * STRUCTURAL PROMISE — never change this text or its semantics again.
  * Operators edit below this line; the scaffold rewrites everything above it
  * on every reconcile and preserves everything below it verbatim. See #1857.
+ *
+ * Canonical definition lives in generation-stamp.ts (KEN-130) so the
+ * gateway-side drift probe can split CLAUDE.md without importing this
+ * module; re-exported above (import block) for existing importers.
  */
-export const CLAUDE_MD_YOURS_MARKER = "# --- Yours (preserved across apply) ---";
+export { CLAUDE_MD_YOURS_MARKER };
 
 /**
  * Placeholder written below the marker for a fresh agent that has neither an
@@ -5308,6 +5319,10 @@ export function scaffoldAgent(
       + `manually if needed.\n`,
     );
   }
+  // Generation stamp (KEN-130) — fresh agents are stamped at scaffold so
+  // drift detection is meaningful before the first reconcile too.
+  stampGeneratedSurfaces(agentDir, agentConfig);
+
   return { agentDir, created, skipped };
 }
 
@@ -6246,6 +6261,31 @@ export function detectHooksDrift(
 
   const summary = `DRIFTED (categories: ${driftedKeys.join(", ")})`;
   return { drifted: true, summary };
+}
+
+/**
+ * Record the generation stamp for drift detection (KEN-130). Called at
+ * the end of scaffold + host-side reconcile, AFTER every managed write,
+ * so the stamped hashes describe exactly what this run left on disk.
+ * The resolved (post-cascade) agent config is hashed so a later
+ * yaml-edit-without-apply reads as named drift. Best-effort — a stamp
+ * IO failure must never fail a scaffold/reconcile.
+ *
+ * Deliberately NOT written on the in-container cron-only reconcile
+ * (skipProfileTemplates): that path renders no templates and its
+ * in-image VERSION can differ from the host install, which would
+ * poison the version-staleness comparison.
+ */
+function stampGeneratedSurfaces(agentDir: string, resolvedAgentConfig: AgentConfig): void {
+  try {
+    writeGenerationStamp(agentDir, {
+      switchroomVersion: SWITCHROOM_VERSION,
+      configHash: computeConfigHash(resolvedAgentConfig),
+      files: computeStampFilesFromDisk(agentDir),
+    });
+  } catch {
+    /* best-effort — drift detection just reports "no stamp" */
+  }
 }
 
 /**
@@ -7402,6 +7442,13 @@ function reconcileAgentInner(
       symlinkSync("workspace/SOUL.md", agentSoulPath);
       changes.push(agentSoulPath);
     }
+  }
+
+  // --- Generation stamp (KEN-130): record what this reconcile left on disk ---
+  // Written BEFORE the ownership sweep below so a root-run reconcile
+  // sweeps the stamp back to the agent UID with everything else.
+  if (!options.skipProfileTemplates) {
+    stampGeneratedSurfaces(agentDir, agentConfig);
   }
 
   // --- Ownership invariant (#3168): root-written files must land agent-owned ---

--- a/src/cli/doctor-drift.test.ts
+++ b/src/cli/doctor-drift.test.ts
@@ -1,0 +1,186 @@
+/**
+ * KEN-130 — doctor wiring for generated-surface drift. Outcome asserts:
+ * a staled surface of each class produces a named WARN row; a clean
+ * fleet produces none (a single ok summary); statuses are never `fail`
+ * so doctor's exit code for an otherwise-OK install is unchanged.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import { resolveAgentConfig } from "../config/merge.js";
+import { buildSettingsHooksBlock } from "../agents/scaffold.js";
+import {
+  computeConfigHash,
+  computeStampFilesFromDisk,
+  writeGenerationStamp,
+} from "../agents/generation-stamp.js";
+import { VERSION } from "../build-info.js";
+import { DRIFT_REPORT_FILE } from "../agents/drift.js";
+import { runGeneratedSurfaceDriftChecks } from "./doctor-drift.js";
+
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "doctor-drift-"));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+const CONFIG_PATH = "/cfg/switchroom.yaml";
+
+function mkConfig(): SwitchroomConfig {
+  return {
+    telegram: { bot_token: "tok", forum_chat_id: "-100" },
+    switchroom: { agents_dir: join(root, "agents") },
+    agents: { bot: { channels: { telegram: { plugin: "switchroom" } } } },
+  } as unknown as SwitchroomConfig;
+}
+
+/** Scaffold a fully in-sync agent dir for `bot` under the config above. */
+function seedCleanAgent(config: SwitchroomConfig): string {
+  const agentDir = join(root, "agents", "bot");
+  mkdirSync(join(agentDir, ".claude"), { recursive: true });
+  const agentConfig = resolveAgentConfig(config.defaults, config.profiles, config.agents["bot"]);
+  const hooks = buildSettingsHooksBlock({
+    agentName: "bot",
+    agentConfig,
+    hindsightEnabled: false,
+    useSwitchroomPlugin: true,
+    configPath: CONFIG_PATH,
+  });
+  writeFileSync(join(agentDir, ".claude", "settings.json"), JSON.stringify({ hooks }));
+  writeFileSync(join(agentDir, "start.sh"), "#!/bin/bash\n");
+  writeFileSync(join(agentDir, ".mcp.json"), "{}\n");
+  writeGenerationStamp(agentDir, {
+    switchroomVersion: VERSION,
+    configHash: computeConfigHash(agentConfig),
+    files: computeStampFilesFromDisk(agentDir),
+  });
+  return agentDir;
+}
+
+const cleanCompose = async () => ({
+  content: "services: {}\n",
+  previous: "services: {}\n" as string | null,
+  imageTag: "v1",
+  previousImageTag: "v1" as string | null,
+});
+
+describe("runGeneratedSurfaceDriftChecks", () => {
+  it("clean fleet → no WARN rows, single ok summary, report written empty", async () => {
+    const config = mkConfig();
+    const agentDir = seedCleanAgent(config);
+    const results = await runGeneratedSurfaceDriftChecks(config, CONFIG_PATH, {
+      composeCompute: cleanCompose,
+      execImpl: () => {
+        throw new Error("no docker in tests");
+      },
+    });
+    expect(results.filter((r) => r.status === "warn")).toEqual([]);
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("ok");
+    // Report persisted for the boot card, and reads clean.
+    const report = JSON.parse(readFileSync(join(agentDir, DRIFT_REPORT_FILE), "utf-8"));
+    expect(report.findings).toEqual([]);
+  });
+
+  it("each staled surface class → a named WARN row", async () => {
+    const config = mkConfig();
+    const agentDir = seedCleanAgent(config);
+    // Stale surface 2 (hooks): tamper the settings hooks block.
+    writeFileSync(join(agentDir, ".claude", "settings.json"), JSON.stringify({ hooks: {} }));
+    // Stale surface 3 (templates): tamper start.sh after the stamp.
+    writeFileSync(join(agentDir, "start.sh"), "#!/bin/bash\nTAMPERED\n");
+    // Stale surface 5 (mcp): tamper .mcp.json after the stamp.
+    writeFileSync(join(agentDir, ".mcp.json"), '{"mcpServers":{"x":{}}}\n');
+    // Stale surface 4 (skills): overlay-declared but uninstalled skill.
+    mkdirSync(join(agentDir, "skills.d"), { recursive: true });
+    writeFileSync(join(agentDir, "skills.d", "lost-skill.yaml"), "x: 1\n");
+
+    const results = await runGeneratedSurfaceDriftChecks(config, CONFIG_PATH, {
+      // Stale surface 1 (compose).
+      composeCompute: async () => ({
+        content: "services: {new: 1}\n",
+        previous: "services: {old: 1}\n",
+        imageTag: "v2",
+        previousImageTag: "v1",
+      }),
+      // Stale surface 6 (hook-scripts): image hash differs from bin/.
+      binDir: (() => {
+        const b = join(root, "bin");
+        mkdirSync(b);
+        writeFileSync(join(b, "run-hook.sh"), "current content");
+        return b;
+      })(),
+      execImpl: () =>
+        "0000000000000000000000000000000000000000000000000000000000000000  /opt/switchroom/bin/run-hook.sh\n",
+    });
+
+    const warnNames = results.filter((r) => r.status === "warn").map((r) => r.name);
+    expect(warnNames).toContain("drift: compose");
+    expect(warnNames).toContain("drift: bot: hooks");
+    expect(warnNames).toContain("drift: bot: start.sh");
+    expect(warnNames).toContain("drift: bot: .mcp.json");
+    expect(warnNames).toContain("drift: bot: skills");
+    expect(warnNames).toContain("drift: bot: hook-scripts");
+    // Exit-code invariant: drift is warn-only, never fail.
+    expect(results.every((r) => r.status !== "fail")).toBe(true);
+    // Report carries the findings (incl. fleet-level compose) for the boot card.
+    const report = JSON.parse(readFileSync(join(agentDir, DRIFT_REPORT_FILE), "utf-8"));
+    const surfaces = report.findings.map((f: { surface: string }) => f.surface);
+    expect(surfaces).toContain("compose");
+    expect(surfaces).toContain("hooks");
+    expect(surfaces).toContain("hook-scripts");
+  });
+
+  it("yaml edited without apply → named config-staleness WARN", async () => {
+    const config = mkConfig();
+    seedCleanAgent(config);
+    // Simulate a config edit after the stamp was written.
+    (config.agents["bot"] as Record<string, unknown>).model = "different-model";
+    const results = await runGeneratedSurfaceDriftChecks(config, CONFIG_PATH, {
+      composeCompute: cleanCompose,
+      execImpl: () => {
+        throw new Error("no docker");
+      },
+    });
+    const warns = results.filter((r) => r.status === "warn");
+    expect(warns.map((r) => r.name)).toContain("drift: bot: config");
+  });
+
+  it("never-scaffolded agent dir → skipped silently, not drift", async () => {
+    const config = mkConfig();
+    // no agent dir on disk at all
+    const results = await runGeneratedSurfaceDriftChecks(config, CONFIG_PATH, {
+      composeCompute: cleanCompose,
+    });
+    expect(results.filter((r) => r.status === "warn")).toEqual([]);
+    expect(existsSync(join(root, "agents", "bot"))).toBe(false);
+  });
+
+  it("fast mode skips the container hook-script probe", async () => {
+    const config = mkConfig();
+    seedCleanAgent(config);
+    let execCalled = false;
+    const results = await runGeneratedSurfaceDriftChecks(config, CONFIG_PATH, {
+      composeCompute: cleanCompose,
+      fast: true,
+      execImpl: () => {
+        execCalled = true;
+        return "";
+      },
+    });
+    expect(execCalled).toBe(false);
+    expect(results.filter((r) => r.status === "warn")).toEqual([]);
+  });
+});

--- a/src/cli/doctor-drift.ts
+++ b/src/cli/doctor-drift.ts
@@ -1,0 +1,141 @@
+/**
+ * `switchroom doctor` section: generated-surface drift (KEN-130).
+ *
+ * Compares every generated/synced surface against what the current
+ * config + installed switchroom would render — compose file, settings
+ * hooks, template stamp (start.sh / CLAUDE.md / .mcp.json + config &
+ * version staleness), skills sync, and the hook scripts baked into the
+ * agent image. Detectors live in src/agents/drift.ts; this module maps
+ * findings to doctor rows and persists the per-agent report file the
+ * gateway boot-card probe reads.
+ *
+ * Status contract: rows are `ok` / `warn` / `skip` ONLY — drift never
+ * fails doctor, so exit codes for an otherwise-OK install are unchanged.
+ */
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import { resolveAgentsDir } from "../config/loader.js";
+import { DEFAULT_COMPOSE_PATH } from "./apply.js";
+import type { CheckResult } from "./doctor.js";
+import {
+  detectAgentDrift,
+  detectComposeDrift,
+  writeDriftReport,
+  type DriftFinding,
+  type ExecImpl,
+} from "../agents/drift.js";
+import { computeComposeContent } from "./write-compose.js";
+
+export interface DriftCheckOpts {
+  /** Skip docker-exec container probes (doctor --fast). */
+  fast?: boolean;
+  /** Suppress writing per-agent .switchroom-drift.json reports (tests). */
+  writeReports?: boolean;
+  /** Test injection: compose render. */
+  composeCompute?: Parameters<typeof detectComposeDrift>[0]["compute"];
+  /** Test injection: docker exec for the hook-script probe. */
+  execImpl?: ExecImpl;
+  /** Test injection: installed bin/ dir for the hook-script probe. */
+  binDir?: string;
+  /** Test injection: report writer. */
+  reportWriter?: (agentDir: string, findings: DriftFinding[]) => void;
+}
+
+/** Render one finding as a doctor WARN row. */
+function toRow(f: DriftFinding): CheckResult {
+  const scope = f.agent ? `${f.agent}: ` : "";
+  return {
+    name: `drift: ${scope}${f.surface}`,
+    status: "warn",
+    detail: f.detail,
+    ...(f.fix ? { fix: f.fix } : {}),
+  };
+}
+
+export async function runGeneratedSurfaceDriftChecks(
+  config: SwitchroomConfig,
+  configPath: string | undefined,
+  opts: DriftCheckOpts = {},
+): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+  const agentsDir = resolveAgentsDir(config);
+  const writeReports = opts.writeReports ?? true;
+  const reportWriter = opts.reportWriter ?? writeDriftReport;
+
+  // Surface 1 — compose (fleet-level).
+  const composePath = DEFAULT_COMPOSE_PATH;
+  const composeCompute =
+    opts.composeCompute ??
+    (async () => {
+      const r = await computeComposeContent({
+        config,
+        composePath,
+        switchroomConfigPath: configPath,
+      });
+      return {
+        content: r.content,
+        previous: r.previous,
+        imageTag: r.imageTag,
+        previousImageTag: r.previousImageTag,
+      };
+    });
+  let composeFindings: DriftFinding[] = [];
+  if (existsSync(composePath) || opts.composeCompute) {
+    composeFindings = await detectComposeDrift({ compute: composeCompute });
+    results.push(...composeFindings.map(toRow));
+  }
+
+  // Surfaces 2-6 — per agent.
+  let cleanAgents = 0;
+  const agentNames = Object.keys(config.agents ?? {});
+  for (const name of agentNames) {
+    const agentDir = resolve(agentsDir, name);
+    if (!existsSync(agentDir)) continue; // never scaffolded — not drift
+    let findings: DriftFinding[] = [];
+    try {
+      findings = detectAgentDrift(
+        name,
+        config.agents[name],
+        agentsDir,
+        config,
+        configPath,
+        {
+          execImpl: opts.execImpl,
+          binDir: opts.binDir,
+          skipContainerProbes: opts.fast === true,
+        },
+      );
+    } catch (err) {
+      results.push({
+        name: `drift: ${name}`,
+        status: "skip",
+        detail: `not checkable: ${(err as Error).message}`,
+      });
+      continue;
+    }
+    // Persist for the boot-card probe — ALWAYS, so a healed agent's
+    // stale report reads clean again. Compose drift is fleet-level but
+    // affects every agent's env, so it rides along in each report.
+    if (writeReports) {
+      reportWriter(agentDir, [...composeFindings, ...findings]);
+    }
+    if (findings.length === 0) {
+      cleanAgents++;
+    } else {
+      results.push(...findings.map(toRow));
+    }
+  }
+
+  if (results.length === 0) {
+    results.push({
+      name: "generated surfaces",
+      status: "ok",
+      detail: `in sync (${cleanAgents} agent${cleanAgents === 1 ? "" : "s"} checked)`,
+    });
+  }
+
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -41,6 +41,7 @@ import { runHostdChecks } from "./doctor-hostd.js";
 import { runDriveChecks, runDriveBrokerReachabilityChecks } from "./doctor-drive.js";
 import { runWebkiteChecks } from "./doctor-webkite.js";
 import { runCronSessionChecks } from "./doctor-cron-session.js";
+import { runGeneratedSurfaceDriftChecks } from "./doctor-drift.js";
 import { runMicrosoftChecks } from "./doctor-microsoft.js";
 import { runNotionChecks } from "./doctor-notion.js";
 import { runMcpSecretChecks } from "./doctor-mcp-secrets.js";
@@ -3279,6 +3280,17 @@ export function registerDoctorCommand(program: Command): void {
           // the fleet today — only agents the value-gate routes to a cron
           // session produce a line.
           { title: "Cron Session", results: runCronSessionChecks(config) },
+          {
+            // KEN-130: every generated/synced surface (compose, hooks,
+            // start.sh/CLAUDE.md/.mcp.json stamp, skills, image hook
+            // scripts) compared against a current render. warn-only —
+            // drift never changes doctor's exit code. Also persists the
+            // per-agent .switchroom-drift.json the boot card reads.
+            title: "Generated-surface drift (KEN-130)",
+            results: await runGeneratedSurfaceDriftChecks(config, configPath, {
+              fast: opts.fast,
+            }),
+          },
         ];
 
         // Repo Hygiene (#1072): only when doctor runs from a switchroom

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3287,9 +3287,20 @@ export function registerDoctorCommand(program: Command): void {
             // drift never changes doctor's exit code. Also persists the
             // per-agent .switchroom-drift.json the boot card reads.
             title: "Generated-surface drift (KEN-130)",
+            // Belt-and-braces: this warn-only advisory section must never
+            // crash the doctor run (that would change behavior for an
+            // otherwise-OK install) — degrade to a single skip row.
             results: await runGeneratedSurfaceDriftChecks(config, configPath, {
               fast: opts.fast,
-            }),
+            }).catch(
+              (err: unknown): CheckResult[] => [
+                {
+                  name: "generated surfaces",
+                  status: "skip",
+                  detail: `not checkable: ${(err as Error)?.message ?? String(err)}`,
+                },
+              ],
+            ),
           },
         ];
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -18,6 +18,8 @@ import {
   DriveConfigSchema,
   GoogleWorkspaceConfigSchema,
   GoogleWorkspaceTierSchema,
+  ReleaseBlock,
+  RootReleaseBlock,
   ScheduleEntrySchema,
   SwitchroomConfigSchema,
   TelegramChannelSchema,
@@ -1412,5 +1414,52 @@ describe("AgentSoulSchema — first-class persona fields + shape (#1856)", () =>
     };
     const r = SwitchroomConfigSchema.parse(cfg);
     expect(r.agents.bare.soul).toBeUndefined();
+  });
+});
+
+describe("release.auto_update (KEN-131) — root-only opt-in", () => {
+  it("root release block accepts auto_update: true alongside channel/pin rules", () => {
+    expect(RootReleaseBlock.parse({ auto_update: true })).toEqual({
+      auto_update: true,
+    });
+    expect(
+      RootReleaseBlock.parse({ pin: "v1.2.3", auto_update: true }),
+    ).toEqual({ pin: "v1.2.3", auto_update: true });
+  });
+
+  it("defaults OFF — an ordinary release block parses with auto_update undefined", () => {
+    const r = RootReleaseBlock.parse({ pin: "v1.2.3" });
+    expect(r.auto_update).toBeUndefined();
+  });
+
+  it("channel/pin mutual exclusion still holds on the root block", () => {
+    expect(() =>
+      RootReleaseBlock.parse({ channel: "latest", pin: "v1.2.3" }),
+    ).toThrow();
+  });
+
+  it("per-agent / profile release blocks REJECT auto_update (fleet-only knob)", () => {
+    expect(() => ReleaseBlock.parse({ auto_update: true })).toThrow();
+    expect(() =>
+      AgentSchema.parse({ release: { auto_update: true } }),
+    ).toThrow();
+  });
+
+  it("full config: root release.auto_update parses; omitted stays undefined", () => {
+    const base = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "x", forum_chat_id: "1" },
+      agents: {},
+    };
+    const off = SwitchroomConfigSchema.parse({
+      ...base,
+      release: { pin: "v1.2.3" },
+    });
+    expect(off.release?.auto_update).toBeUndefined();
+    const on = SwitchroomConfigSchema.parse({
+      ...base,
+      release: { pin: "v1.2.3", auto_update: true },
+    });
+    expect(on.release?.auto_update).toBe(true);
   });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3754,6 +3754,20 @@ export const AutoReleaseCheckSchema = z.object({
       "update_apply / restart all. Useful for dogfooding the detector " +
       "without rolling the fleet.",
     ),
+  notify_on_detect: z
+    .boolean()
+    .default(false)
+    .describe(
+      "KEN-129 — operator-in-the-loop update prompt. Only consulted " +
+      "when apply_on_detect is false (auto-apply supersedes notify): " +
+      "a newly detected release posts ONE operator approval card " +
+      "('fleet is behind — tap to apply') via an admin agent's " +
+      "gateway; Approve runs hostd's update_apply path (fleet-" +
+      "mutation-locked, durable status rows, get_status-pollable). " +
+      "Dedup on release id: the last-notified id persists in " +
+      "~/.switchroom/release-notify-state.json, so a card that " +
+      "reached the operator is never re-posted for the same release.",
+    ),
   image_ref: z
     .string()
     .default("ghcr.io/switchroom/switchroom-agent:latest")

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2572,13 +2572,46 @@ export const ReactionDispatchSchema = z
  * merged (a pinned agent should not silently inherit a channel from
  * the root, and vice versa).
  */
+const releaseBlockFields = {
+  channel: z.enum(["dev", "rc", "latest"]).optional(),
+  pin: z
+    .string()
+    .regex(/^(sha-[0-9a-f]{7,40}|v\d+\.\d+\.\d+)$/)
+    .optional(),
+};
+
 export const ReleaseBlock = z
+  .object(releaseBlockFields)
+  .strict()
+  .refine((r) => !(r.channel && r.pin), {
+    message: "release.channel and release.pin are mutually exclusive",
+  });
+
+/**
+ * Root-only release block (KEN-131, stage 3 of KEN-128): the shared
+ * channel/pin fields PLUS the opt-in `auto_update` flag. Root-only on
+ * purpose — auto-update is a FLEET property consumed by hostd's release
+ * watcher; a per-agent `auto_update` would be meaningless (the staggered
+ * canary rollout always rolls the fleet), so the per-agent / profile-level
+ * `release` blocks stay on the plain ReleaseBlock and reject the key via
+ * `.strict()`.
+ */
+export const RootReleaseBlock = z
   .object({
-    channel: z.enum(["dev", "rc", "latest"]).optional(),
-    pin: z
-      .string()
-      .regex(/^(sha-[0-9a-f]{7,40}|v\d+\.\d+\.\d+)$/)
-      .optional(),
+    ...releaseBlockFields,
+    auto_update: z
+      .boolean()
+      .optional()
+      .describe(
+        "Opt-in unattended fleet auto-update (KEN-131). When true, hostd's " +
+        "release watcher polls the published release version and, on a new " +
+        "release, drives the EXISTING staggered canary rollout " +
+        "(`switchroom rollout --pin vX.Y.Z`) unattended: canary-first, " +
+        "per-agent version assert, durable pin persisted only after the " +
+        "canary is green, abort + operator alert card on canary failure, " +
+        "and compose rollback on a failed apply. Default false — with it " +
+        "unset/false, behaviour is unchanged.",
+      ),
   })
   .strict()
   .refine((r) => !(r.channel && r.pin), {
@@ -4038,10 +4071,12 @@ export const SwitchroomConfigSchema = z.object({
       ),
   }),
   telegram: TelegramConfigSchema,
-  release: ReleaseBlock.optional().describe(
+  release: RootReleaseBlock.optional().describe(
     "Fleet-wide default release-channel pin / pointer for the update " +
     "flow. Either `channel` (dev|rc|latest) or `pin` (sha-<hex>|v<semver>) " +
-    "— mutually exclusive. Per-agent `release` REPLACES this entirely.",
+    "— mutually exclusive. Per-agent `release` REPLACES this entirely " +
+    "(except `auto_update`, which is root-only — a fleet property read by " +
+    "hostd's release watcher, never per-agent).",
   ),
   memory: MemoryBackendConfigSchema.optional(),
   hindsight: HindsightConfigSchema.optional().describe(

--- a/src/host-control/approval-gateway.ts
+++ b/src/host-control/approval-gateway.ts
@@ -12,6 +12,15 @@ export interface ApprovalRequest {
   reason: string;
   unifiedDiff: string;
   timeoutMs: number;
+  /**
+   * Optional card header override (KEN-129). Default renders the
+   * config-edit header ("🛠 Config edit proposed"); the update-check
+   * drift card passes its own so the operator isn't told a fleet
+   * update is a config edit. Old gateways ignore the field and fall
+   * back to the default header — graceful degrade in mixed-version
+   * rolls.
+   */
+  title?: string;
 }
 
 export interface ApprovalResult {
@@ -241,6 +250,7 @@ export class SocketApprovalGateway implements ApprovalGateway {
               reason: req.reason,
               unifiedDiff: req.unifiedDiff,
               timeoutMs: req.timeoutMs,
+              ...(req.title ? { title: req.title } : {}),
             }) + "\n",
           );
         } catch (err) {

--- a/src/host-control/auto-update-check.ts
+++ b/src/host-control/auto-update-check.ts
@@ -115,8 +115,21 @@ export function makeAutoUpdateCheck(
   const fetchLatest = opts.fetchLatestVersion ?? fetchNpmLatestVersion;
   const imageExists =
     opts.imageExists ??
-    (async (ref: string) =>
-      (await probeRemoteDigest(ref)).digest !== null);
+    (async (ref: string) => {
+      const probe = await probeRemoteDigest(ref);
+      // A transient registry ERROR and a genuinely missing manifest both
+      // yield digest=null and are treated identically — fail-CLOSED (defer,
+      // never roll on ambiguity; the next tick retries). Log the probe
+      // error so an operator can tell the two apart in hostd's stderr.
+      if (probe.digest === null && probe.error) {
+        log(
+          `auto-update: manifest probe for ${ref} returned no digest ` +
+            `(missing image OR registry error — deferring either way): ` +
+            probe.error,
+        );
+      }
+      return probe.digest !== null;
+    });
   return async () => {
     const latest = `v${(await fetchLatest()).trim().replace(/^v/, "")}`;
     const pin = opts.getCurrentPin();

--- a/src/host-control/auto-update-check.ts
+++ b/src/host-control/auto-update-check.ts
@@ -1,0 +1,177 @@
+/**
+ * Auto-update release check (KEN-131, stage 3 of KEN-128).
+ *
+ * Opt-in via root `release.auto_update: true`. Unlike the legacy
+ * `host_control.auto_release_check` digest probe (#1743 — compares the
+ * remote `:latest` digest to the LOCAL `:latest` image and then runs
+ * `switchroom update` + `restart all`), the auto-update path must drive
+ * the EXISTING staggered canary rollout, and `switchroom rollout` needs a
+ * concrete, version-assertable `vX.Y.Z` target. A digest can't provide
+ * that — and worse, a rollout pulls the `:vX.Y.Z` tag, so the local
+ * `:latest` digest never advances and a digest check would re-fire
+ * forever after every successful roll.
+ *
+ * Detection strategy here is therefore VERSION-based:
+ *   1. Latest published version ← the npm registry's `latest` dist-tag
+ *      for the `switchroom` package. This is the canonical "release is
+ *      live" gate (the npm-publish workflow verifies `npm view
+ *      switchroom version` post-publish, and the rollout skill checks
+ *      the same signal).
+ *   2. Currently-deployed version ← the live `release.pin` in
+ *      switchroom.yaml (re-read every tick — the rollout persists the
+ *      pin after a green canary, which is exactly what stops re-fires).
+ *   3. Release available ⇔ latest is STRICTLY newer than the pin
+ *      (`compareReleaseTags` — conservative: a sha pin / unorderable
+ *      value never triggers an unattended roll) AND the `:vX.Y.Z` agent
+ *      image manifest is already pullable (a publish can beat the
+ *      docker-images workflow; probing first avoids a canary-fail on a
+ *      not-yet-promoted image — the next tick retries).
+ *
+ * Dependency-injection-shaped like the rest of the watcher stack: the
+ * real fetch / config / docker probes are wired in `main.ts`; tests
+ * exercise the decision logic with stubs.
+ */
+
+import { compareReleaseTags } from "../config/release-resolve.js";
+import type { ReleaseCheckResult } from "./release-watcher.js";
+import { probeRemoteDigest } from "./release-watcher-shellouts.js";
+
+/** npm registry endpoint for the `latest` dist-tag of the CLI package. */
+export const NPM_LATEST_URL = "https://registry.npmjs.org/switchroom/latest";
+
+/** Fetch timeout for the registry round-trip. */
+const FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Replace the tag of `imageRef` with `version` (e.g.
+ * `ghcr.io/switchroom/switchroom-agent:latest` + `v0.19.2` →
+ * `ghcr.io/switchroom/switchroom-agent:v0.19.2`). Registry ports
+ * (`host:5000/repo`) are handled: only a colon AFTER the last slash is a
+ * tag separator.
+ */
+export function versionedImageRef(imageRef: string, version: string): string {
+  const lastSlash = imageRef.lastIndexOf("/");
+  const colon = imageRef.indexOf(":", lastSlash + 1);
+  const repo = colon === -1 ? imageRef : imageRef.slice(0, colon);
+  return `${repo}:${version}`;
+}
+
+/**
+ * Default latest-published-version prober: GET the npm registry's
+ * `latest` dist-tag document and return its `version` (bare semver,
+ * no `v` prefix). Throws on network / shape errors — the watcher
+ * surfaces that as a `check_failed` event and retries next tick.
+ */
+export async function fetchNpmLatestVersion(
+  url: string = NPM_LATEST_URL,
+): Promise<string> {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`npm registry responded ${res.status} for ${url}`);
+  }
+  const body = (await res.json()) as { version?: unknown };
+  if (typeof body.version !== "string" || !/^\d+\.\d+\.\d+$/.test(body.version)) {
+    throw new Error(
+      `npm registry document at ${url} has no clean semver version field`,
+    );
+  }
+  return body.version;
+}
+
+export interface AutoUpdateCheckOptions {
+  /**
+   * Live view of the fleet's current `release.pin` (re-read per tick —
+   * a successful roll persists the new pin, which is what makes the
+   * check quiesce). Undefined when the config has no pin (bootstrap:
+   * the first auto-roll establishes one). Throws on a malformed config
+   * — surfaced as `check_failed`, tick dropped.
+   */
+  getCurrentPin: () => string | undefined;
+  /** Agent image ref whose `:vX.Y.Z` sibling must be pullable before a
+   *  roll is attempted (tag portion, if any, is replaced). */
+  imageRef: string;
+  /** Test seam — latest published version (bare semver). Default:
+   *  {@link fetchNpmLatestVersion}. */
+  fetchLatestVersion?: () => Promise<string>;
+  /** Test seam — is the given image ref pullable? Default: `docker
+   *  manifest inspect` via {@link probeRemoteDigest}. */
+  imageExists?: (imageRef: string) => Promise<boolean>;
+  log?: (m: string) => void;
+}
+
+/**
+ * Build the auto-update `checkFn`. Returns `available: true` with
+ * `version: "vX.Y.Z"` ONLY when the published version is strictly newer
+ * than the live pin (or no pin exists yet) AND the pinned agent image is
+ * already pullable.
+ */
+export function makeAutoUpdateCheck(
+  opts: AutoUpdateCheckOptions,
+): () => Promise<ReleaseCheckResult> {
+  const log = opts.log ?? (() => {});
+  const fetchLatest = opts.fetchLatestVersion ?? fetchNpmLatestVersion;
+  const imageExists =
+    opts.imageExists ??
+    (async (ref: string) =>
+      (await probeRemoteDigest(ref)).digest !== null);
+  return async () => {
+    const latest = `v${(await fetchLatest()).trim().replace(/^v/, "")}`;
+    const pin = opts.getCurrentPin();
+    if (pin !== undefined) {
+      const cmp = compareReleaseTags(latest, pin);
+      if (cmp === null) {
+        // Unorderable pin (sha-… / channel-ish garbage). An explicit
+        // non-semver pin is an operator decision — never fight it
+        // unattended.
+        log(
+          `auto-update: current release.pin "${pin}" is not a vX.Y.Z tag — ` +
+            `skipping unattended roll (latest published: ${latest})`,
+        );
+        return { available: false, version: latest };
+      }
+      if (cmp <= 0) return { available: false, version: latest };
+    }
+    const target = versionedImageRef(opts.imageRef, latest);
+    if (!(await imageExists(target))) {
+      // Publish beat the image build — retry next tick, roll nothing.
+      log(
+        `auto-update: ${latest} is published but ${target} is not pullable ` +
+          `yet (docker-images workflow may still be building) — deferring`,
+      );
+      return { available: false, version: latest };
+    }
+    return { available: true, version: latest };
+  };
+}
+
+/** What the release watcher should do, resolved from config (pure —
+ *  unit-testable so "default OFF ⇒ behaviour unchanged" is asserted,
+ *  not assumed). */
+export type ReleaseWatcherMode =
+  /** No watcher at all (both knobs off — the default). */
+  | { mode: "off" }
+  /** Legacy #1743 digest watcher: `switchroom update` + `restart all`. */
+  | { mode: "legacy" }
+  /** KEN-131 auto-update: version check → staggered canary rollout. */
+  | { mode: "auto_update" };
+
+/**
+ * Resolve which watcher (if any) hostd should run. `release.auto_update`
+ * wins over `host_control.auto_release_check.enabled` when both are set —
+ * the canary rollout path is a strict safety superset of the legacy
+ * update+restart-all path, so an operator who opted into both gets the
+ * safer pipeline.
+ */
+export function resolveReleaseWatcherMode(config: {
+  release?: { auto_update?: boolean };
+  host_control?: { auto_release_check?: { enabled?: boolean } };
+}): ReleaseWatcherMode {
+  if (config.release?.auto_update === true) return { mode: "auto_update" };
+  if (config.host_control?.auto_release_check?.enabled === true) {
+    return { mode: "legacy" };
+  }
+  return { mode: "off" };
+}

--- a/src/host-control/auto-update-check.ts
+++ b/src/host-control/auto-update-check.ts
@@ -90,6 +90,27 @@ export interface AutoUpdateCheckOptions {
    * — surfaced as `check_failed`, tick dropped.
    */
   getCurrentPin: () => string | undefined;
+  /**
+   * Live view of the fleet's current `release.channel` (re-read per tick,
+   * like the pin). An operator on a NON-`latest` channel (`dev` / `rc`) has
+   * made an explicit release-policy choice that the auto-update path cannot
+   * honour: it tracks the npm `latest` dist-tag, and persisting a pin
+   * DELETES `release.channel` (schema mutual exclusion — see
+   * `setReleasePinInConfig`). Rolling anyway would silently yank a dev/rc
+   * fleet onto stable and erase the operator's channel. So a non-`latest`
+   * channel suppresses the unattended roll instead.
+   */
+  getCurrentChannel?: () => string | undefined;
+  /**
+   * Live view of hostd's durable auto-rollout latch pin, when one is set
+   * (a previous unattended roll to that version failed or died mid-flight).
+   * The pin never advanced, so `checkFn` would otherwise keep reporting
+   * "available" every tick forever — each tick re-entering `applyFn`, being
+   * refused by the latch, and appending an `apply_failed` telemetry row.
+   * Reporting NOT-available for a latched target quiesces that loop; a
+   * newer publish (or a manual roll) clears/supersedes the latch.
+   */
+  getLatchedPin?: () => string | null;
   /** Agent image ref whose `:vX.Y.Z` sibling must be pullable before a
    *  roll is attempted (tag portion, if any, is replaced). */
   imageRef: string;
@@ -130,8 +151,40 @@ export function makeAutoUpdateCheck(
       }
       return probe.digest !== null;
     });
+  // The watcher ticks every few minutes forever; a suppression reason that
+  // holds indefinitely (non-latest channel, latched failed pin) must not
+  // reprint on every tick. Log once per distinct reason instead.
+  let lastSuppressed = "";
+  const logOnce = (key: string, m: string): void => {
+    if (lastSuppressed === key) return;
+    lastSuppressed = key;
+    log(m);
+  };
   return async () => {
     const latest = `v${(await fetchLatest()).trim().replace(/^v/, "")}`;
+    const channel = opts.getCurrentChannel?.();
+    if (channel !== undefined && channel !== "latest") {
+      logOnce(
+        `channel:${channel}`,
+        `auto-update: release.channel is "${channel}" (not "latest") — the ` +
+          `auto-update path tracks the npm latest dist-tag and persisting a ` +
+          `pin would delete your channel, so no unattended roll will happen. ` +
+          `Remove release.channel (or set it to "latest") to enable it. ` +
+          `Latest published: ${latest}`,
+      );
+      return { available: false, version: latest };
+    }
+    const latched = opts.getLatchedPin?.() ?? null;
+    if (latched !== null && latched === latest) {
+      logOnce(
+        `latch:${latched}`,
+        `auto-update: ${latest} is latched from a previous unattended roll ` +
+          `that failed or died mid-flight — not re-reporting it as available. ` +
+          `Fix the cause and roll manually (\`switchroom rollout --pin ` +
+          `${latest}\`), or wait for a newer release.`,
+      );
+      return { available: false, version: latest };
+    }
     const pin = opts.getCurrentPin();
     if (pin !== undefined) {
       const cmp = compareReleaseTags(latest, pin);

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -41,7 +41,10 @@ import {
   makeReleaseCheck,
   makeApply,
   makeRestart,
+  makeUpdatePlan,
 } from "./release-watcher-shellouts.js";
+import { UpdateNotifier, short } from "./update-notifier.js";
+import type { ApprovalResult } from "./approval-gateway.js";
 import { appendFile } from "node:fs/promises";
 
 /**
@@ -251,6 +254,66 @@ async function main(): Promise<void> {
       ".switchroom",
       "release-watcher-events.jsonl",
     );
+    // KEN-129 — operator-in-the-loop drift card. Only wired when
+    // auto-apply is OFF (apply_on_detect supersedes notify: a fleet
+    // that self-applies has nothing to ask the operator).
+    let notifier: UpdateNotifier | null = null;
+    if (!autoRel.apply_on_detect && autoRel.notify_on_detect) {
+      // Card targets: admin (or root-tier) agents' gateways, in
+      // stable order. The first gateway that actually accepts the
+      // card wins; dispatch failures fall through to the next.
+      const adminAgents = Object.keys(config.agents)
+        .filter((n) => {
+          const a = config.agents[n] as { admin?: boolean; root?: boolean };
+          return a.admin === true || a.root === true;
+        })
+        .sort();
+      notifier = new UpdateNotifier({
+        statePath: join(homedir(), ".switchroom", "release-notify-state.json"),
+        isFleetMutationInFlight: () => server.isFleetMutationLocked(),
+        startApply: (requestId) => {
+          const res = server.startOperatorApprovedUpdateApply(requestId);
+          return { result: res.result, ...(res.error ? { error: res.error } : {}) };
+        },
+        planFn: makeUpdatePlan("switchroom"),
+        requestApproval: async ({ requestId, version, plan }) => {
+          let last: ApprovalResult = {
+            verdict: "deny",
+            reason: "no admin agent with a reachable gateway socket",
+            denySource: "dispatch_failure",
+            finalize: async () => {},
+          };
+          for (const agent of adminAgents) {
+            const res = await approvalGateway.requestApproval({
+              requestId,
+              agentName: agent,
+              title: "⬆️ **Switchroom update available — fleet is behind**",
+              // NOTE: plain text — the card handler escapes markdown in
+              // the reason line, so backticks/bold here would render as
+              // escaped literals.
+              reason:
+                `New release detected for ${autoRel.image_ref} ` +
+                `(digest ${short(version)}). Approve to run ` +
+                `switchroom update (the hostd update_apply path).`,
+              unifiedDiff:
+                plan.length > 0
+                  ? plan
+                  : `switchroom update --check produced no plan output;\n` +
+                    `remote digest: ${version}`,
+              timeoutMs: 60 * 60_000,
+            });
+            if (res.verdict === "deny" && res.denySource === "dispatch_failure") {
+              last = res;
+              continue; // this agent's gateway is unreachable — try next
+            }
+            return res;
+          }
+          return last;
+        },
+        log: (m) => process.stderr.write(`hostd: ${m}\n`),
+      });
+    }
+    const notifierRef = notifier;
     releaseWatcher = new ReleaseWatcher({
       intervalMs: autoRel.interval_minutes * 60_000,
       checkFn: makeReleaseCheck({
@@ -260,6 +323,13 @@ async function main(): Promise<void> {
       applyFn: makeApply("switchroom"),
       restartFn: makeRestart("switchroom"),
       applyOnDetect: autoRel.apply_on_detect,
+      ...(notifierRef
+        ? {
+            notifyFn: async (version: string) => {
+              await notifierRef.notifyIfNew(version);
+            },
+          }
+        : {}),
       log: (m) => process.stderr.write(`hostd: ${m}\n`),
       onEvent: (e) => {
         // Telemetry sink — JSONL append. The
@@ -273,7 +343,8 @@ async function main(): Promise<void> {
     process.stderr.write(
       `hostd: release-watcher started — polling ${autoRel.image_ref} ` +
         `every ${autoRel.interval_minutes}m ` +
-        `(apply_on_detect=${autoRel.apply_on_detect})\n`,
+        `(apply_on_detect=${autoRel.apply_on_detect}, ` +
+        `notify_on_detect=${autoRel.notify_on_detect})\n`,
     );
   }
 

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -42,6 +42,10 @@ import {
   makeApply,
   makeRestart,
 } from "./release-watcher-shellouts.js";
+import {
+  makeAutoUpdateCheck,
+  resolveReleaseWatcherMode,
+} from "./auto-update-check.js";
 import { appendFile } from "node:fs/promises";
 
 /**
@@ -245,36 +249,88 @@ async function main(): Promise<void> {
   // (RFC C §5.1).
   let releaseWatcher: ReleaseWatcher | null = null;
   const autoRel = config.host_control?.auto_release_check;
-  if (autoRel?.enabled === true) {
+  const watcherMode = resolveReleaseWatcherMode(config);
+  if (watcherMode.mode !== "off") {
     const eventsLog = join(
       homedir(),
       ".switchroom",
       "release-watcher-events.jsonl",
     );
-    releaseWatcher = new ReleaseWatcher({
-      intervalMs: autoRel.interval_minutes * 60_000,
-      checkFn: makeReleaseCheck({
-        imageRef: autoRel.image_ref,
-        log: (m) => process.stderr.write(`hostd: ${m}\n`),
-      }),
-      applyFn: makeApply("switchroom"),
-      restartFn: makeRestart("switchroom"),
-      applyOnDetect: autoRel.apply_on_detect,
-      log: (m) => process.stderr.write(`hostd: ${m}\n`),
-      onEvent: (e) => {
-        // Telemetry sink — JSONL append. The
-        // `time_from_release_to_fleet_caught_up_seconds` AC counter
-        // is the `duration_ms` field of the `fleet_caught_up` row
-        // (delta from the matching `release_detected` row).
-        void appendFile(eventsLog, JSON.stringify(e) + "\n").catch(() => {});
-      },
-    });
-    releaseWatcher.start();
-    process.stderr.write(
-      `hostd: release-watcher started — polling ${autoRel.image_ref} ` +
-        `every ${autoRel.interval_minutes}m ` +
-        `(apply_on_detect=${autoRel.apply_on_detect})\n`,
-    );
+    const log = (m: string): void => {
+      process.stderr.write(`hostd: ${m}\n`);
+    };
+    const onEvent = (e: object): void => {
+      // Telemetry sink — JSONL append. The
+      // `time_from_release_to_fleet_caught_up_seconds` AC counter
+      // is the `duration_ms` field of the `fleet_caught_up` row
+      // (delta from the matching `release_detected` row).
+      void appendFile(eventsLog, JSON.stringify(e) + "\n").catch(() => {});
+    };
+    const intervalMinutes = autoRel?.interval_minutes ?? 5;
+    const imageRef =
+      autoRel?.image_ref ?? "ghcr.io/switchroom/switchroom-agent:latest";
+    if (watcherMode.mode === "auto_update") {
+      // KEN-131 — `release.auto_update: true`: version-based check, and on
+      // detection the UNATTENDED staggered canary rollout via the server's
+      // own launch path (fleet-mutation lock, self-bump, audit, narration,
+      // rollback + alert hardening). NOT the legacy update+restart-all.
+      releaseWatcher = new ReleaseWatcher({
+        intervalMs: intervalMinutes * 60_000,
+        checkFn: makeAutoUpdateCheck({
+          imageRef,
+          // Live pin per tick — a green roll persists the pin, which is
+          // what quiesces the check. Throws on malformed config (tick
+          // dropped as check_failed, retried next interval).
+          getCurrentPin: () =>
+            (loadConfig() as { release?: { pin?: string } }).release?.pin,
+          log,
+        }),
+        applyFn: async (version) => {
+          if (!version) {
+            throw new Error("auto-update check reported no target version");
+          }
+          const r = await server.startAutoRollout(version);
+          if (!r.started) {
+            throw new Error(`auto rollout not started: ${r.reason}`);
+          }
+          log(
+            `auto-update: unattended rollout to ${version} started ` +
+              `(request_id ${r.request_id})`,
+          );
+        },
+        // The rollout restarts agents itself (staggered, canary-first) —
+        // a fleet-wide `restart all` here would double-bounce every agent.
+        restartFn: async () => {},
+        applyOnDetect: true,
+        log,
+        onEvent,
+      });
+      releaseWatcher.start();
+      process.stderr.write(
+        `hostd: auto-update watcher started (release.auto_update) — ` +
+          `checking the published release every ${intervalMinutes}m; new ` +
+          `releases roll via the staggered canary rollout\n`,
+      );
+    } else {
+      releaseWatcher = new ReleaseWatcher({
+        intervalMs: intervalMinutes * 60_000,
+        checkFn: makeReleaseCheck({
+          imageRef,
+          log,
+        }),
+        applyFn: makeApply("switchroom"),
+        restartFn: makeRestart("switchroom"),
+        applyOnDetect: autoRel?.apply_on_detect ?? true,
+        log,
+        onEvent,
+      });
+      releaseWatcher.start();
+      process.stderr.write(
+        `hostd: release-watcher started — polling ${imageRef} ` +
+          `every ${intervalMinutes}m ` +
+          `(apply_on_detect=${autoRel?.apply_on_detect ?? true})\n`,
+      );
+    }
   }
 
   // Wait for SIGTERM / SIGINT. `docker stop` sends SIGTERM after

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -268,8 +268,22 @@ async function main(): Promise<void> {
           return a.admin === true || a.root === true;
         })
         .sort();
-      notifier = new UpdateNotifier({
+      // Card timeout — shared with the notifier's re-post suppress
+      // window (a pre-restart pending card is honoured for exactly as
+      // long as it could still be live in the operator's chat).
+      const cardTimeoutMs = 60 * 60_000;
+      if (adminAgents.length === 0) {
+        // No admin agent → no gateway to carry the card. Every tick
+        // would run the (slow) plan probe and then dispatch-fail; skip
+        // wiring the notifier and say so once at startup instead.
+        process.stderr.write(
+          "hostd: notify_on_detect is enabled but no agent has " +
+            "admin/root — update approval cards have nowhere to go; " +
+            "notifier disabled\n",
+        );
+      } else notifier = new UpdateNotifier({
         statePath: join(homedir(), ".switchroom", "release-notify-state.json"),
+        repostSuppressMs: cardTimeoutMs,
         isFleetMutationInFlight: () => server.isFleetMutationLocked(),
         startApply: (requestId) => {
           const res = server.startOperatorApprovedUpdateApply(requestId);
@@ -300,7 +314,7 @@ async function main(): Promise<void> {
                   ? plan
                   : `switchroom update --check produced no plan output;\n` +
                     `remote digest: ${version}`,
-              timeoutMs: 60 * 60_000,
+              timeoutMs: cardTimeoutMs,
             });
             if (res.verdict === "deny" && res.denySource === "dispatch_failure") {
               last = res;

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -277,15 +277,30 @@ async function main(): Promise<void> {
       // detection the UNATTENDED staggered canary rollout via the server's
       // own launch path (fleet-mutation lock, self-bump, audit, narration,
       // rollback + alert hardening). NOT the legacy update+restart-all.
+      // A `notify_on_detect` the auto-update path can't honour must not fail
+      // silently — the operator asked for a card and would otherwise get
+      // neither a card nor an explanation.
+      if (autoRel?.notify_on_detect === true) {
+        process.stderr.write(
+          "hostd: release.auto_update is on, so notify_on_detect is " +
+            "ignored — new releases roll unattended via the canary path and " +
+            "only FAILURES post an operator alert. Turn off " +
+            "release.auto_update if you want the tap-to-apply card instead.\n",
+        );
+      }
+      // Live release block per tick — a green roll persists the pin, which
+      // is what quiesces the check. Throws on malformed config (tick
+      // dropped as check_failed, retried next interval).
+      const liveRelease = (): { pin?: string; channel?: string } =>
+        (loadConfig() as { release?: { pin?: string; channel?: string } })
+          .release ?? {};
       releaseWatcher = new ReleaseWatcher({
         intervalMs: intervalMinutes * 60_000,
         checkFn: makeAutoUpdateCheck({
           imageRef,
-          // Live pin per tick — a green roll persists the pin, which is
-          // what quiesces the check. Throws on malformed config (tick
-          // dropped as check_failed, retried next interval).
-          getCurrentPin: () =>
-            (loadConfig() as { release?: { pin?: string } }).release?.pin,
+          getCurrentPin: () => liveRelease().pin,
+          getCurrentChannel: () => liveRelease().channel,
+          getLatchedPin: () => server.autoRolloutLatchedPin(),
           log,
         }),
         applyFn: async (version) => {
@@ -315,108 +330,108 @@ async function main(): Promise<void> {
           `releases roll via the staggered canary rollout\n`,
       );
     } else {
-    const applyOnDetect = autoRel?.apply_on_detect ?? true;
-    const notifyOnDetect = autoRel?.notify_on_detect ?? false;
-    // KEN-129 — operator-in-the-loop drift card. Only wired when
-    // auto-apply is OFF (apply_on_detect supersedes notify: a fleet
-    // that self-applies has nothing to ask the operator).
-    let notifier: UpdateNotifier | null = null;
-    if (!applyOnDetect && notifyOnDetect) {
-      // Card targets: admin (or root-tier) agents' gateways, in
-      // stable order. The first gateway that actually accepts the
-      // card wins; dispatch failures fall through to the next.
-      const adminAgents = Object.keys(config.agents)
-        .filter((n) => {
-          const a = config.agents[n] as { admin?: boolean; root?: boolean };
-          return a.admin === true || a.root === true;
-        })
-        .sort();
-      // Card timeout — shared with the notifier's re-post suppress
-      // window (a pre-restart pending card is honoured for exactly as
-      // long as it could still be live in the operator's chat).
-      const cardTimeoutMs = 60 * 60_000;
-      if (adminAgents.length === 0) {
-        // No admin agent → no gateway to carry the card. Every tick
-        // would run the (slow) plan probe and then dispatch-fail; skip
-        // wiring the notifier and say so once at startup instead.
-        process.stderr.write(
-          "hostd: notify_on_detect is enabled but no agent has " +
-            "admin/root — update approval cards have nowhere to go; " +
-            "notifier disabled\n",
-        );
-      } else notifier = new UpdateNotifier({
-        statePath: join(homedir(), ".switchroom", "release-notify-state.json"),
-        repostSuppressMs: cardTimeoutMs,
-        isFleetMutationInFlight: () => server.isFleetMutationLocked(),
-        startApply: (requestId) => {
-          const res = server.startOperatorApprovedUpdateApply(requestId);
-          return { result: res.result, ...(res.error ? { error: res.error } : {}) };
-        },
-        planFn: makeUpdatePlan("switchroom"),
-        requestApproval: async ({ requestId, version, plan }) => {
-          let last: ApprovalResult = {
-            verdict: "deny",
-            reason: "no admin agent with a reachable gateway socket",
-            denySource: "dispatch_failure",
-            finalize: async () => {},
-          };
-          for (const agent of adminAgents) {
-            const res = await approvalGateway.requestApproval({
-              requestId,
-              agentName: agent,
-              title: "⬆️ **Switchroom update available — fleet is behind**",
-              // NOTE: plain text — the card handler escapes markdown in
-              // the reason line, so backticks/bold here would render as
-              // escaped literals.
-              reason:
-                `New release detected for ${imageRef} ` +
-                `(digest ${short(version)}). Approve to run ` +
-                `switchroom update (the hostd update_apply path).`,
-              unifiedDiff:
-                plan.length > 0
-                  ? plan
-                  : `switchroom update --check produced no plan output;\n` +
-                    `remote digest: ${version}`,
-              timeoutMs: cardTimeoutMs,
-            });
-            if (res.verdict === "deny" && res.denySource === "dispatch_failure") {
-              last = res;
-              continue; // this agent's gateway is unreachable — try next
+      const applyOnDetect = autoRel?.apply_on_detect ?? true;
+      const notifyOnDetect = autoRel?.notify_on_detect ?? false;
+      // KEN-129 — operator-in-the-loop drift card. Only wired when
+      // auto-apply is OFF (apply_on_detect supersedes notify: a fleet
+      // that self-applies has nothing to ask the operator).
+      let notifier: UpdateNotifier | null = null;
+      if (!applyOnDetect && notifyOnDetect) {
+        // Card targets: admin (or root-tier) agents' gateways, in
+        // stable order. The first gateway that actually accepts the
+        // card wins; dispatch failures fall through to the next.
+        const adminAgents = Object.keys(config.agents)
+          .filter((n) => {
+            const a = config.agents[n] as { admin?: boolean; root?: boolean };
+            return a.admin === true || a.root === true;
+          })
+          .sort();
+        // Card timeout — shared with the notifier's re-post suppress
+        // window (a pre-restart pending card is honoured for exactly as
+        // long as it could still be live in the operator's chat).
+        const cardTimeoutMs = 60 * 60_000;
+        if (adminAgents.length === 0) {
+          // No admin agent → no gateway to carry the card. Every tick
+          // would run the (slow) plan probe and then dispatch-fail; skip
+          // wiring the notifier and say so once at startup instead.
+          process.stderr.write(
+            "hostd: notify_on_detect is enabled but no agent has " +
+              "admin/root — update approval cards have nowhere to go; " +
+              "notifier disabled\n",
+          );
+        } else notifier = new UpdateNotifier({
+          statePath: join(homedir(), ".switchroom", "release-notify-state.json"),
+          repostSuppressMs: cardTimeoutMs,
+          isFleetMutationInFlight: () => server.isFleetMutationLocked(),
+          startApply: (requestId) => {
+            const res = server.startOperatorApprovedUpdateApply(requestId);
+            return { result: res.result, ...(res.error ? { error: res.error } : {}) };
+          },
+          planFn: makeUpdatePlan("switchroom"),
+          requestApproval: async ({ requestId, version, plan }) => {
+            let last: ApprovalResult = {
+              verdict: "deny",
+              reason: "no admin agent with a reachable gateway socket",
+              denySource: "dispatch_failure",
+              finalize: async () => {},
+            };
+            for (const agent of adminAgents) {
+              const res = await approvalGateway.requestApproval({
+                requestId,
+                agentName: agent,
+                title: "⬆️ **Switchroom update available — fleet is behind**",
+                // NOTE: plain text — the card handler escapes markdown in
+                // the reason line, so backticks/bold here would render as
+                // escaped literals.
+                reason:
+                  `New release detected for ${imageRef} ` +
+                  `(digest ${short(version)}). Approve to run ` +
+                  `switchroom update (the hostd update_apply path).`,
+                unifiedDiff:
+                  plan.length > 0
+                    ? plan
+                    : `switchroom update --check produced no plan output;\n` +
+                      `remote digest: ${version}`,
+                timeoutMs: cardTimeoutMs,
+              });
+              if (res.verdict === "deny" && res.denySource === "dispatch_failure") {
+                last = res;
+                continue; // this agent's gateway is unreachable — try next
+              }
+              return res;
             }
-            return res;
-          }
-          return last;
-        },
-        log: (m) => process.stderr.write(`hostd: ${m}\n`),
-      });
-    }
-    const notifierRef = notifier;
-    releaseWatcher = new ReleaseWatcher({
-      intervalMs: intervalMinutes * 60_000,
-      checkFn: makeReleaseCheck({
-        imageRef,
+            return last;
+          },
+          log: (m) => process.stderr.write(`hostd: ${m}\n`),
+        });
+      }
+      const notifierRef = notifier;
+      releaseWatcher = new ReleaseWatcher({
+        intervalMs: intervalMinutes * 60_000,
+        checkFn: makeReleaseCheck({
+          imageRef,
+          log,
+        }),
+        applyFn: makeApply("switchroom"),
+        restartFn: makeRestart("switchroom"),
+        applyOnDetect,
+        ...(notifierRef
+          ? {
+              notifyFn: async (version: string) => {
+                await notifierRef.notifyIfNew(version);
+              },
+            }
+          : {}),
         log,
-      }),
-      applyFn: makeApply("switchroom"),
-      restartFn: makeRestart("switchroom"),
-      applyOnDetect,
-      ...(notifierRef
-        ? {
-            notifyFn: async (version: string) => {
-              await notifierRef.notifyIfNew(version);
-            },
-          }
-        : {}),
-      log,
-      onEvent,
-    });
-    releaseWatcher.start();
-    process.stderr.write(
-      `hostd: release-watcher started — polling ${imageRef} ` +
-        `every ${intervalMinutes}m ` +
-        `(apply_on_detect=${applyOnDetect}, ` +
-        `notify_on_detect=${notifyOnDetect})\n`,
-    );
+        onEvent,
+      });
+      releaseWatcher.start();
+      process.stderr.write(
+        `hostd: release-watcher started — polling ${imageRef} ` +
+          `every ${intervalMinutes}m ` +
+          `(apply_on_detect=${applyOnDetect}, ` +
+          `notify_on_detect=${notifyOnDetect})\n`,
+      );
     }
   }
 

--- a/src/host-control/release-watcher-shellouts.ts
+++ b/src/host-control/release-watcher-shellouts.ts
@@ -166,6 +166,23 @@ export function makeApply(switchroomBin: string) {
   };
 }
 
+/**
+ * Build a plan probe for the update-notifier card body (KEN-129):
+ * `switchroom update --check` — the read-only dry-run that prints
+ * what an update would do (versions behind, images to pull). Best-
+ * effort: a non-zero exit still returns whatever stdout was produced
+ * (the caller falls back to the raw digest when empty). Tail-clipped
+ * so a chatty plan can't blow the card body (the gateway truncates
+ * again anyway).
+ */
+export function makeUpdatePlan(switchroomBin: string) {
+  return async (): Promise<string> => {
+    const r = await run(switchroomBin, ["update", "--check"], 2 * 60_000);
+    const out = r.stdout.trim();
+    return out.length > 4000 ? out.slice(-4000) : out;
+  };
+}
+
 /** Build a `restartFn` that runs `switchroom restart all` (graceful). */
 export function makeRestart(switchroomBin: string) {
   return async () => {

--- a/src/host-control/release-watcher.ts
+++ b/src/host-control/release-watcher.ts
@@ -53,8 +53,11 @@ export interface ReleaseWatcherOptions {
    *  remote tag's digest no longer matches the deployed digest. */
   checkFn: () => Promise<ReleaseCheckResult>;
   /** Run the equivalent of `switchroom update` end-to-end. Resolves
-   *  when the apply completes (or rejects on failure). */
-  applyFn: () => Promise<void>;
+   *  when the apply completes (or rejects on failure). Receives the
+   *  check's `version` identifier when one was reported (KEN-131 —
+   *  the auto-update path needs the concrete `vX.Y.Z` target to drive
+   *  `switchroom rollout --pin`; the legacy digest path ignores it). */
+  applyFn: (version?: string) => Promise<void>;
   /** Run the equivalent of `switchroom restart all` (graceful by
    *  default — drains in-flight turns). Resolves when scheduling
    *  completes; the per-agent drain happens asynchronously. */
@@ -144,7 +147,7 @@ export class ReleaseWatcher {
         ...(check.version ? { version: check.version } : {}),
       });
       try {
-        await this.opts.applyFn();
+        await this.opts.applyFn(check.version);
       } catch (err) {
         this.emit({
           at: this.now(),

--- a/src/host-control/release-watcher.ts
+++ b/src/host-control/release-watcher.ts
@@ -63,6 +63,14 @@ export interface ReleaseWatcherOptions {
    *  stop short of calling applyFn / restartFn. Use to dogfood the
    *  check loop without auto-rolling the fleet. */
   applyOnDetect: boolean;
+  /** KEN-129 — optional notify hook, consulted only when
+   *  `applyOnDetect` is false. Receives the detected release id so
+   *  the update notifier can post a "fleet is behind — tap to apply"
+   *  operator approval card. Awaited inside the tick (the in-flight
+   *  guard then naturally prevents a second card racing the first);
+   *  errors are logged and dropped — a notify failure never breaks
+   *  the watch loop. */
+  notifyFn?: (version: string) => Promise<void>;
   /** Receives one event per state transition for telemetry / audit. */
   onEvent?: (e: ReleaseWatcherEvent) => void;
   /** Diagnostic log sink. */
@@ -135,7 +143,16 @@ export class ReleaseWatcher {
             ? ", auto-applying"
             : " (apply_on_detect=false; not rolling)"),
       );
-      if (!this.opts.applyOnDetect) return;
+      if (!this.opts.applyOnDetect) {
+        if (this.opts.notifyFn) {
+          try {
+            await this.opts.notifyFn(check.version ?? "");
+          } catch (err) {
+            this.log(`notify_failed: ${errMsg(err)}`);
+          }
+        }
+        return;
+      }
 
       const applyStarted = this.now();
       this.emit({

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -609,6 +609,35 @@ export function isAutoRolloutRequestId(requestId: string): boolean {
   return requestId.startsWith(AUTO_ROLLOUT_REQUEST_PREFIX);
 }
 
+/**
+ * KEN-131 — durable failed/attempted latch for unattended auto-update
+ * rolls, persisted under the hostd state dir. An in-memory-only latch is
+ * structurally insufficient: hostd restarts are ROUTINE on this path (the
+ * self-bump recreates hostd's own container on essentially every auto
+ * roll, and crash-loops / host reboots clear process memory), so a broken
+ * release plus any restart would re-roll the same failed pin every
+ * watcher tick — bouncing the canary agent indefinitely with no operator
+ * in the loop. The latch is therefore written to disk AT LAUNCH
+ * (`outcome: "attempting"`) and cleared only on a confirmed green roll;
+ * a failure updates it to `"failed"`. Either state refuses an unattended
+ * retry of the SAME pin across restarts and crash windows (a roll that
+ * died mid-flight leaves `"attempting"` behind — exactly the case where
+ * an unattended retry is least safe). A NEWER published release
+ * supersedes the latch; the operator recovers by fixing the cause and
+ * rolling manually (`switchroom rollout --pin <target>`), which advances
+ * the durable pin and quiesces the check.
+ */
+export const AUTO_ROLLOUT_LATCH_FILENAME = "auto-rollout-latch.json";
+
+interface AutoRolloutLatch {
+  v: 1;
+  pin: string;
+  request_id: string;
+  outcome: "attempting" | "failed";
+  at: string;
+  reason?: string;
+}
+
 export class HostdServer {
   // One Server per bound socket path. `node:net.Server.listen` can
   // only be called once per instance — to bind N agent sockets we
@@ -660,11 +689,66 @@ export class HostdServer {
    * An unattended canary failure must NOT retry-loop every watcher tick
    * (each retry bounces the canary onto the same broken build); the
    * watcher's checkFn keeps reporting "available" until the durable pin
-   * advances, so this in-memory latch refuses re-rolls of the same
-   * target. Cleared implicitly by a hostd restart (one deliberate retry
-   * per daemon lifetime) or by a NEWER release superseding the target.
+   * advances, so this latch refuses re-rolls of the same target. This
+   * field is only the in-memory fast path / disk-write-failure fallback;
+   * the AUTHORITATIVE latch is the on-disk file
+   * ({@link AUTO_ROLLOUT_LATCH_FILENAME}) — see its doc comment for why
+   * an in-memory latch alone would retry-loop across the routine hostd
+   * restarts on this path (self-bump container recreate, crash-loops,
+   * host reboots). Superseded by a NEWER target pin.
    */
   private lastAutoRolloutFailedPin: string | null = null;
+
+  /** Path of the durable auto-rollout latch file. */
+  private autoRolloutLatchPath(): string {
+    return join(this.hostdDirPath(), AUTO_ROLLOUT_LATCH_FILENAME);
+  }
+
+  /** Read + validate the durable latch; null when absent/malformed. */
+  private readAutoRolloutLatch(): AutoRolloutLatch | null {
+    try {
+      const raw = readFileSync(this.autoRolloutLatchPath(), "utf-8");
+      const parsed = JSON.parse(raw) as AutoRolloutLatch;
+      if (
+        parsed &&
+        parsed.v === 1 &&
+        typeof parsed.pin === "string" &&
+        parsed.pin.length > 0 &&
+        (parsed.outcome === "attempting" || parsed.outcome === "failed")
+      ) {
+        return parsed;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Best-effort durable latch write — must NEVER throw into a roll path.
+   *  A write failure degrades to the in-memory latch (logged). */
+  private writeAutoRolloutLatch(latch: AutoRolloutLatch): void {
+    try {
+      mkdirSync(this.hostdDirPath(), { recursive: true });
+      writeFileSync(this.autoRolloutLatchPath(), JSON.stringify(latch, null, 2), {
+        mode: 0o600,
+      });
+    } catch (e) {
+      process.stderr.write(
+        `hostd: auto-rollout latch write failed (falling back to in-memory ` +
+          `latch for this process lifetime): ${(e as Error).message}\n`,
+      );
+    }
+  }
+
+  /** Best-effort durable latch clear (green roll / superseded target). */
+  private clearAutoRolloutLatch(): void {
+    try {
+      unlinkSync(this.autoRolloutLatchPath());
+    } catch {
+      // Absent or unremovable — absent is the common case; unremovable
+      // only ever over-blocks (fail-safe direction).
+    }
+  }
 
   /**
    * #2726 Part 2 — optional in-chat narration renderer. When wired (via
@@ -1844,14 +1928,20 @@ export class HostdServer {
   ): Promise<{ started: boolean; request_id?: string; reason?: string }> {
     const started = Date.now();
     const request_id = `${AUTO_ROLLOUT_REQUEST_PREFIX}${started}`;
-    if (this.lastAutoRolloutFailedPin === pin) {
+    const diskLatch = this.readAutoRolloutLatch();
+    if (this.lastAutoRolloutFailedPin === pin || diskLatch?.pin === pin) {
+      const why =
+        diskLatch?.pin === pin && diskLatch.outcome === "attempting"
+          ? `a previous unattended roll to ${pin} did not complete (hostd ` +
+            `restarted or crashed mid-roll — the fleet state is unverified)`
+          : `a previous unattended roll to ${pin} FAILED`;
       return {
         started: false,
         reason:
-          `a previous unattended roll to ${pin} FAILED — refusing to retry ` +
-          `unattended (fix the cause, then roll manually via \`switchroom ` +
-          `rollout --pin ${pin}\`; a newer release or a hostd restart also ` +
-          `clears this latch)`,
+          `${why} — refusing to retry unattended (the latch is durable ` +
+          `across hostd restarts; fix the cause, then roll manually via ` +
+          `\`switchroom rollout --pin ${pin}\`; a newer release supersedes ` +
+          `the latch)`,
       };
     }
     const inFlight = this.fleetMutationInFlight;
@@ -1863,6 +1953,11 @@ export class HostdServer {
           `"${inFlight.request_id}") — will re-check next tick`,
       };
     }
+    // A DIFFERENT (newer) target supersedes any stale latch. Ordered AFTER
+    // the fleet-lock check: while a roll is in flight its launch-time
+    // "attempting" latch must not be stripped by a superseding tick that
+    // the lock is about to refuse anyway.
+    if (diskLatch && diskLatch.pin !== pin) this.clearAutoRolloutLatch();
     const caller: SocketIdentity = { kind: "operator" };
     // hostd's baked-in CLI is older than EVERY fresh release, so the
     // self-bump branch is the COMMON path here: bump hostd's own compose,
@@ -1876,8 +1971,21 @@ export class HostdServer {
         op: "rollout",
         args: { pin },
       } as Extract<HostdRequest, { op: "rollout" }>;
+      // Latch BEFORE committing: the self-bump recreates hostd's own
+      // container, so only a durable marker written now can stop a fresh
+      // daemon from re-launching this same target if the bump/resume dies
+      // mid-flight. beginSelfBump's clean refusals ("nothing was changed")
+      // clear it again — those are safe to retry next tick.
+      this.writeAutoRolloutLatch({
+        v: 1,
+        pin,
+        request_id,
+        outcome: "attempting",
+        at: new Date().toISOString(),
+      });
       const resp = await this.beginSelfBump(req, caller, started);
       if (resp.result !== "started") {
+        this.clearAutoRolloutLatch();
         return {
           started: false,
           reason: resp.error ?? `self-bump refused (result=${resp.result})`,
@@ -1892,6 +2000,16 @@ export class HostdServer {
         reason: assetDenied.error ?? "apply-asset preflight refused",
       };
     }
+    // Durable "attempting" latch at launch: a roll that dies without a
+    // terminal row (hostd SIGKILLed mid-canary) must NOT be silently
+    // retried by the next daemon — cleared only on a confirmed green roll.
+    this.writeAutoRolloutLatch({
+      v: 1,
+      pin,
+      request_id,
+      outcome: "attempting",
+      at: new Date().toISOString(),
+    });
     this.launchRollout({ pin }, request_id, caller, started);
     return { started: true, request_id };
   }
@@ -2283,6 +2401,21 @@ export class HostdServer {
       };
       this.recordStatus(entry);
       process.stderr.write(`hostd: self-bump resume failed: ${why}\n`);
+      // KEN-131 — an UNATTENDED roll that died at the self-bump must latch
+      // durably too, or the watcher's next tick re-runs the whole
+      // bump-and-fail cycle forever (the pin never advanced, so the check
+      // keeps reporting "available").
+      if (isAutoRolloutRequestId(marker.request_id)) {
+        this.lastAutoRolloutFailedPin = marker.pin;
+        this.writeAutoRolloutLatch({
+          v: 1,
+          pin: marker.pin,
+          request_id: marker.request_id,
+          outcome: "failed",
+          at: new Date().toISOString(),
+          reason: "self-bump",
+        });
+      }
       await this.writeTerminalAudit(entry);
       this.pushRolloutTerminal(entry);
     };
@@ -3756,8 +3889,27 @@ export class HostdServer {
         // alert the operator and release the lock.
         if (isAutoRolloutRequestId(entry.request_id) && entry.result !== "completed") {
           this.lastAutoRolloutFailedPin = entry.pin ?? null;
+          if (entry.pin) {
+            // Upgrade the launch-time "attempting" latch to a durable
+            // "failed" — survives hostd restarts (self-bump recreate,
+            // crash-loops), so the same broken pin is never re-rolled
+            // unattended by a fresh daemon.
+            this.writeAutoRolloutLatch({
+              v: 1,
+              pin: entry.pin,
+              request_id: entry.request_id,
+              outcome: "failed",
+              at: new Date().toISOString(),
+              ...(entry.failed_step ? { reason: entry.failed_step } : {}),
+            });
+          }
           void this.finishFailedAutoRollout(entry, priorPinAtStart);
           return;
+        }
+        // Green unattended roll — release the durable launch latch so the
+        // NEXT release can auto-roll.
+        if (isAutoRolloutRequestId(entry.request_id)) {
+          this.clearAutoRolloutLatch();
         }
         // #2726 — terminal effects. All fire-and-forget and defensively
         // wrapped: a chat push / narrator finalize must NEVER block the lock
@@ -3850,10 +4002,17 @@ export class HostdServer {
       (entry.failed_step === "restart-agent" && rolledCount === 0);
     if (!beforeAnyAgent) {
       notes.push(
-        `No automatic rollback: ${rolledCount} agent(s) already confirmed on ` +
-          `${entry.pin ?? "the target"} past a green canary ` +
-          `(${(entry.rolled ?? []).join(", ") || "none"}). The fleet is mixed — ` +
-          `finish the roll or roll back manually.`,
+        rolledCount > 0
+          ? `No automatic rollback: ${rolledCount} agent(s) already confirmed on ` +
+              `${entry.pin ?? "the target"} past a green canary ` +
+              `(${(entry.rolled ?? []).join(", ")}). The fleet is mixed — ` +
+              `finish the roll or roll back manually.`
+          : // rolled=0 but failed_step isn't apply/restart-agent — the roll
+            // was refused BEFORE apply (e.g. preflight-stale-cli) or died
+            // without a step label: nothing was changed, nothing to revert.
+            `No automatic rollback: the roll stopped at ` +
+              `${entry.failed_step ?? "an unknown step"} before any change ` +
+              `landed — nothing to revert. Verify host-side if unsure.`,
       );
       return notes;
     }

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1598,7 +1598,18 @@ export class HostdServer {
       request_id: requestId,
       op: "update_apply" as const,
     };
-    return this.handleUpdateApply(req, { kind: "operator" }, Date.now());
+    const caller: SocketIdentity = { kind: "operator" };
+    const resp = this.handleUpdateApply(req, caller, Date.now());
+    // This path doesn't come through handleConnection, so it writes its
+    // own audit row — an operator-approved fleet mutation with no audit
+    // trail would be a forensic gap.
+    void this.writeAudit({ caller, req, resp }).catch((err) => {
+      process.stderr.write(
+        `hostd: audit write failed for operator-approved update_apply ` +
+          `(request_id=${requestId}): ${(err as Error).message}\n`,
+      );
+    });
+    return resp;
   }
 
   private handleUpdateApply(

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -724,6 +724,20 @@ export class HostdServer {
     }
   }
 
+  /**
+   * KEN-131 — public read of the currently-latched auto-rollout target (the
+   * durable file first, the in-memory fallback second), or null when none.
+   *
+   * Wired into the auto-update `checkFn` so a latched version stops being
+   * reported as "available": without it, the pin never advances, so every
+   * watcher tick re-enters `applyFn`, gets refused by this same latch, and
+   * appends another `apply_failed` row to the telemetry log — forever, until
+   * an operator intervenes.
+   */
+  autoRolloutLatchedPin(): string | null {
+    return this.readAutoRolloutLatch()?.pin ?? this.lastAutoRolloutFailedPin;
+  }
+
   /** Best-effort durable latch write — must NEVER throw into a roll path.
    *  A write failure degrades to the in-memory latch (logged). */
   private writeAutoRolloutLatch(latch: AutoRolloutLatch): void {
@@ -4153,11 +4167,24 @@ export class HostdServer {
     }
   }
 
-  /** First configured agent with `admin: true`, or null (KEN-131 — relay
-   *  target for unattended-rollout alerts, which have no caller agent). */
+  /**
+   * First configured admin-tier agent, or null (KEN-131 — relay target for
+   * unattended-rollout alerts, which have no caller agent).
+   *
+   * Matches `admin: true` OR `root: true` and iterates in SORTED key order —
+   * the same rule and the same deterministic order the KEN-129 update-card
+   * dispatch uses in main.ts. Matching only `admin` would silently drop the
+   * alert on a fleet whose sole privileged agent is `root: true`, and object
+   * insertion order would make the target depend on yaml key order.
+   */
   private firstAdminAgentName(): string | null {
-    for (const [name, a] of Object.entries(this.opts.config.agents ?? {})) {
-      if (a?.admin === true) return name;
+    const agents = (this.opts.config.agents ?? {}) as Record<
+      string,
+      { admin?: boolean; root?: boolean } | undefined
+    >;
+    for (const name of Object.keys(agents).sort()) {
+      const a = agents[name];
+      if (a?.admin === true || a?.root === true) return name;
     }
     return null;
   }

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1572,6 +1572,35 @@ export class HostdServer {
     );
   }
 
+  /**
+   * KEN-129 — read-only lock probe for the update-check drift
+   * notifier: it must not post a "tap to apply" card while a fleet
+   * mutation is already rolling (the running mutation likely IS the
+   * catch-up the card would ask for).
+   */
+  isFleetMutationLocked(): boolean {
+    return this.fleetMutationInFlight !== null;
+  }
+
+  /**
+   * KEN-129 — entry point for the update-check drift notifier's
+   * Approve tap. Reuses the EXACT `update_apply` verb path
+   * (fleet-mutation lock, apply-asset preflight, durable status
+   * rows, get_status pollability) with a synthetic operator caller:
+   * the authorization here is the operator's tap on the approval
+   * card, the same human-in-the-loop that gates the agent-invoked
+   * verb. Returns the verb's HostdResponse — `result: "started"` on
+   * success, `denied` with an operator-facing `error` otherwise.
+   */
+  startOperatorApprovedUpdateApply(requestId: string): HostdResponse {
+    const req = {
+      v: 1 as const,
+      request_id: requestId,
+      op: "update_apply" as const,
+    };
+    return this.handleUpdateApply(req, { kind: "operator" }, Date.now());
+  }
+
   private handleUpdateApply(
     req: Extract<HostdRequest, { op: "update_apply" }>,
     caller: SocketIdentity,

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -594,6 +594,21 @@ const TAIL_BYTES = 4096;
  */
 export const ORPHAN_RECONCILE_AGE_MS = 15 * 60 * 1000;
 
+/**
+ * Request-id prefix for watcher-initiated unattended rollouts (KEN-131,
+ * `release.auto_update`). The prefix is the durable marker for "no
+ * operator/agent is driving this roll": it survives the self-bump
+ * resume marker (which round-trips only the request_id + args), so the
+ * hardened no-operator failure path (rollback + alert card, no silent
+ * retry) applies identically to a roll resumed after a hostd self-bump.
+ */
+export const AUTO_ROLLOUT_REQUEST_PREFIX = "auto-rollout-";
+
+/** True when a request_id names an unattended auto-update rollout. */
+export function isAutoRolloutRequestId(requestId: string): boolean {
+  return requestId.startsWith(AUTO_ROLLOUT_REQUEST_PREFIX);
+}
+
 export class HostdServer {
   // One Server per bound socket path. `node:net.Server.listen` can
   // only be called once per instance — to bind N agent sockets we
@@ -639,6 +654,17 @@ export class HostdServer {
         started_at: number;
       }
     | null = null;
+
+  /**
+   * KEN-131 — pin of the most recent FAILED unattended auto-update roll.
+   * An unattended canary failure must NOT retry-loop every watcher tick
+   * (each retry bounces the canary onto the same broken build); the
+   * watcher's checkFn keeps reporting "available" until the durable pin
+   * advances, so this in-memory latch refuses re-rolls of the same
+   * target. Cleared implicitly by a hostd restart (one deliberate retry
+   * per daemon lifetime) or by a NEWER release superseding the target.
+   */
+  private lastAutoRolloutFailedPin: string | null = null;
 
   /**
    * #2726 Part 2 — optional in-chat narration renderer. When wired (via
@@ -1797,6 +1823,77 @@ export class HostdServer {
       exit_code: null,
       duration_ms: Date.now() - started,
     };
+  }
+
+  /**
+   * KEN-131 — entry point for the unattended auto-update path
+   * (`release.auto_update: true`). Called by hostd's release watcher when
+   * a new published release is detected; drives the SAME staggered canary
+   * rollout pipeline as an operator/agent `rollout` request (fleet-
+   * mutation lock, self-bump, apply-asset preflight, durable audit +
+   * narration, structured status), differing only in caller identity
+   * ({kind:"operator"} — the daemon acting host-side) and in the hardened
+   * no-operator failure handling (see finishFailedAutoRollout).
+   *
+   * Returns `{started:false, reason}` instead of a wire denial — the
+   * caller is the in-process watcher, which logs the reason and retries
+   * (or not) on its own schedule.
+   */
+  public async startAutoRollout(
+    pin: string,
+  ): Promise<{ started: boolean; request_id?: string; reason?: string }> {
+    const started = Date.now();
+    const request_id = `${AUTO_ROLLOUT_REQUEST_PREFIX}${started}`;
+    if (this.lastAutoRolloutFailedPin === pin) {
+      return {
+        started: false,
+        reason:
+          `a previous unattended roll to ${pin} FAILED — refusing to retry ` +
+          `unattended (fix the cause, then roll manually via \`switchroom ` +
+          `rollout --pin ${pin}\`; a newer release or a hostd restart also ` +
+          `clears this latch)`,
+      };
+    }
+    const inFlight = this.fleetMutationInFlight;
+    if (inFlight) {
+      return {
+        started: false,
+        reason:
+          `fleet-mutation lock held by ${inFlight.op} (request_id ` +
+          `"${inFlight.request_id}") — will re-check next tick`,
+      };
+    }
+    const caller: SocketIdentity = { kind: "operator" };
+    // hostd's baked-in CLI is older than EVERY fresh release, so the
+    // self-bump branch is the COMMON path here: bump hostd's own compose,
+    // hand off to the helper, and let the new hostd resume this very
+    // request_id from the marker at boot (the auto- prefix survives the
+    // marker round-trip, keeping the hardened failure handling attached).
+    if (needsSelfBump(this.opts.selfVersion ?? SWITCHROOM_VERSION, pin)) {
+      const req = {
+        v: 1,
+        request_id,
+        op: "rollout",
+        args: { pin },
+      } as Extract<HostdRequest, { op: "rollout" }>;
+      const resp = await this.beginSelfBump(req, caller, started);
+      if (resp.result !== "started") {
+        return {
+          started: false,
+          reason: resp.error ?? `self-bump refused (result=${resp.result})`,
+        };
+      }
+      return { started: true, request_id };
+    }
+    const assetDenied = this.applyAssetPreflight(request_id, started);
+    if (assetDenied) {
+      return {
+        started: false,
+        reason: assetDenied.error ?? "apply-asset preflight refused",
+      };
+    }
+    this.launchRollout({ pin }, request_id, caller, started);
+    return { started: true, request_id };
   }
 
   /**
@@ -3595,6 +3692,11 @@ export class HostdServer {
    * tail. Releases the fleet-mutation lock on completion (success/fail).
    */
   private spawnRollout(args: string[], entry: StatusEntry): void {
+    // KEN-131 — capture the prior pin NOW: the terminal handler below
+    // deletes entry.prior_pin on failure (correct for --allow-downgrade
+    // defaulting), but the unattended-failure recovery still needs it as
+    // the rollback target.
+    const priorPinAtStart = entry.prior_pin;
     // #2726 — tap the child's stdout line-by-line so each rollout PHASE
     // sentinel becomes a durable, hash-chained audit row AS the roll runs
     // (the log is the single source of truth; the narration surface in Part 2
@@ -3645,6 +3747,18 @@ export class HostdServer {
       })
       .finally(() => {
         void this.writeTerminalAudit(entry);
+        // KEN-131 — unattended (auto-update) roll that FAILED: no operator
+        // is watching, so the hardened no-operator path runs instead of the
+        // plain terminal push: latch the failed pin (no unattended retry
+        // loop), attempt rollback of pre-canary damage WHILE STILL HOLDING
+        // the fleet-mutation lock (recovery runs `apply`/`agent restart` —
+        // racing another mutation would interleave compose writes), then
+        // alert the operator and release the lock.
+        if (isAutoRolloutRequestId(entry.request_id) && entry.result !== "completed") {
+          this.lastAutoRolloutFailedPin = entry.pin ?? null;
+          void this.finishFailedAutoRollout(entry, priorPinAtStart);
+          return;
+        }
         // #2726 — terminal effects. All fire-and-forget and defensively
         // wrapped: a chat push / narrator finalize must NEVER block the lock
         // release or the roll's completion (a throwing narrator/relay can't
@@ -3667,15 +3781,150 @@ export class HostdServer {
   }
 
   /**
+   * KEN-131 — terminal handling for a FAILED unattended auto-update roll.
+   * Runs (and awaits) the rollback recovery while the fleet-mutation lock
+   * is STILL HELD, then alerts the operator via the existing rollout
+   * terminal relay (with the recovery outcome appended), and only then
+   * releases the lock. Every step is defensively wrapped — nothing here
+   * may strand the lock.
+   */
+  private async finishFailedAutoRollout(
+    entry: StatusEntry,
+    priorPin: string | undefined,
+  ): Promise<void> {
+    const notes: string[] = [
+      `Unattended auto-update roll to ${entry.pin ?? "?"} FAILED at ` +
+        `${entry.failed_step ?? "unknown step"}` +
+        `${entry.failed_agent ? ` (agent ${entry.failed_agent})` : ""}. ` +
+        `Unattended retries of this version are disabled; fix the cause, ` +
+        `then roll manually (\`switchroom rollout --pin ${entry.pin ?? "vX.Y.Z"}\`).`,
+    ];
+    try {
+      notes.push(...(await this.recoverFailedAutoRollout(entry, priorPin)));
+    } catch (e) {
+      notes.push(
+        `Automatic rollback THREW: ${(e as Error).message} — verify compose/` +
+          `canary state host-side.`,
+      );
+    } finally {
+      this.pushRolloutTerminal(entry, notes);
+      try {
+        this.rolloutNarrator?.onTerminal(entry);
+      } catch (e) {
+        process.stderr.write(
+          `hostd: rollout narrator onTerminal threw (non-fatal): ${(e as Error).message}\n`,
+        );
+      }
+      if (
+        this.fleetMutationInFlight &&
+        this.fleetMutationInFlight.request_id === entry.request_id
+      ) {
+        this.fleetMutationInFlight = null;
+      }
+    }
+  }
+
+  /**
+   * KEN-131 — rollback for an unattended roll that failed BEFORE any agent
+   * reached the target (failed `apply`, or a failed canary with nothing
+   * rolled). In that window the durable pin was never persisted (hostd-
+   * context rollouts persist AFTER the canary), so config still names the
+   * prior pin — but the one-shot `apply --pin <target>` DID rewrite the
+   * compose file, and a failed canary may have left the canary agent
+   * restarted onto (or wedged against) the broken target image. Recovery:
+   * regenerate compose on the prior pin, and restart the canary back onto
+   * it. Past-canary failures are NOT auto-rolled-back: the canary proved
+   * the build green, the fleet is mixed-but-functional, and an unattended
+   * mass rollback is riskier than alerting the operator.
+   *
+   * Returns human-readable outcome notes for the alert message.
+   */
+  private async recoverFailedAutoRollout(
+    entry: StatusEntry,
+    priorPin: string | undefined,
+  ): Promise<string[]> {
+    const notes: string[] = [];
+    const rolledCount = (entry.rolled ?? []).length;
+    const beforeAnyAgent =
+      entry.failed_step === "apply" ||
+      (entry.failed_step === "restart-agent" && rolledCount === 0);
+    if (!beforeAnyAgent) {
+      notes.push(
+        `No automatic rollback: ${rolledCount} agent(s) already confirmed on ` +
+          `${entry.pin ?? "the target"} past a green canary ` +
+          `(${(entry.rolled ?? []).join(", ") || "none"}). The fleet is mixed — ` +
+          `finish the roll or roll back manually.`,
+      );
+      return notes;
+    }
+    if (!priorPin) {
+      notes.push(
+        `No automatic rollback: no prior version-assertable release.pin was ` +
+          `recorded before this roll. Verify compose host-side ` +
+          `(\`switchroom apply\`).`,
+      );
+      return notes;
+    }
+    // Compose restore: the failed roll's `apply --pin <target>` rewrote the
+    // compose file while the durable pin still names <prior>. Regenerating on
+    // the prior pin realigns compose with config so the next reconcile/restart
+    // cannot silently pull agents onto the broken target.
+    const applyRes = await this.runSwitchroom(
+      ["apply", "--pin", priorPin, "--compose-only", "--non-interactive"],
+      { SWITCHROOM_HOSTD_CONTEXT: "1" },
+    );
+    notes.push(
+      applyRes.exit_code === 0
+        ? `Rollback: compose restored to ${priorPin}.`
+        : `Rollback FAILED: compose restore to ${priorPin} exited ` +
+            `${applyRes.exit_code} — run \`switchroom apply\` host-side ` +
+            `(${tail(applyRes.stderr).trim().slice(-300) || "no stderr"}).`,
+    );
+    if (entry.failed_step === "restart-agent" && entry.failed_agent) {
+      const restartRes = await this.runSwitchroom(
+        [
+          "agent",
+          "restart",
+          entry.failed_agent,
+          "--wait",
+          "--force",
+          "--pin",
+          priorPin,
+        ],
+        { SWITCHROOM_HOSTD_CONTEXT: "1" },
+      );
+      notes.push(
+        restartRes.exit_code === 0
+          ? `Rollback: canary ${entry.failed_agent} restarted back on ${priorPin}.`
+          : `Rollback FAILED: canary ${entry.failed_agent} did not restart ` +
+              `cleanly on ${priorPin} (exit ${restartRes.exit_code}) — restart ` +
+              `it manually.`,
+      );
+    }
+    return notes;
+  }
+
+  /**
    * #2726 Part 1 — push ONE ordinary operator-DM message on the rollout
    * terminal row via the gateway relay. Fire-and-forget: `postTerminal` never
    * throws and never awaits a reply, so the roll can't stall on a slow/absent
    * gateway. No-op when no relay is wired or the caller isn't an agent (the
    * relay routes through the caller agent's gateway, like the approval card).
    */
-  private pushRolloutTerminal(entry: StatusEntry): void {
+  private pushRolloutTerminal(entry: StatusEntry, extraNotes?: string[]): void {
     if (!this.opts.rolloutRelay) return;
-    if (entry.caller.kind !== "agent") return;
+    // Relay routing: an agent-invoked roll pings through the CALLER agent's
+    // gateway (unchanged). An unattended auto-update roll (KEN-131) has no
+    // caller agent — route the alert through the FIRST admin agent's gateway
+    // (the same class of agent whose gateway carries approval cards); when
+    // no admin agent exists, drop (the durable audit row remains).
+    const relayAgent =
+      entry.caller.kind === "agent"
+        ? entry.caller.name
+        : isAutoRolloutRequestId(entry.request_id)
+          ? this.firstAdminAgentName()
+          : null;
+    if (relayAgent === null) return;
     try {
       const text = renderRolloutStatus({
         target: entry.pin ?? "",
@@ -3692,14 +3941,26 @@ export class HostdServer {
       });
       this.opts.rolloutRelay.postTerminal({
         requestId: entry.request_id,
-        agentName: entry.caller.name,
-        text,
+        agentName: relayAgent,
+        text:
+          extraNotes && extraNotes.length > 0
+            ? text + "\n\n" + extraNotes.map((n) => `- ${n}`).join("\n")
+            : text,
       });
     } catch (e) {
       process.stderr.write(
         `hostd: rollout terminal push failed (non-fatal): ${(e as Error).message}\n`,
       );
     }
+  }
+
+  /** First configured agent with `admin: true`, or null (KEN-131 — relay
+   *  target for unattended-rollout alerts, which have no caller agent). */
+  private firstAdminAgentName(): string | null {
+    for (const [name, a] of Object.entries(this.opts.config.agents ?? {})) {
+      if (a?.admin === true) return name;
+    }
+    return null;
   }
 
   private handleGetStatus(

--- a/src/host-control/update-notifier.test.ts
+++ b/src/host-control/update-notifier.test.ts
@@ -123,6 +123,21 @@ describe("UpdateNotifier", () => {
     expect(h.cards).toHaveLength(1);
   });
 
+  it("re-checks the lock AFTER the plan probe: a mutation starting mid-probe suppresses the card", async () => {
+    let locked = false;
+    const h = makeHarness({
+      locked: () => locked,
+      plan: async () => {
+        // Simulate a fleet mutation starting while `update --check` runs.
+        locked = true;
+        return "plan text";
+      },
+    });
+    expect(await h.notifier.notifyIfNew("sha256:cafe11")).toBe("locked");
+    expect(h.cards).toHaveLength(0);
+    expect(existsSync(h.statePath)).toBe(false);
+  });
+
   it("dispatch failure does NOT mark notified — the next tick re-cards", async () => {
     const h = makeHarness({
       verdicts: [
@@ -131,10 +146,64 @@ describe("UpdateNotifier", () => {
       ],
     });
     expect(await h.notifier.notifyIfNew("sha256:ddd444")).toBe("dispatch_failed");
-    expect(existsSync(h.statePath)).toBe(false);
+    // Pending marker is cleared on a resolved dispatch failure so the
+    // retry is prompt — nothing marks the release notified.
+    const st = JSON.parse(readFileSync(h.statePath, "utf8"));
+    expect(st.last_notified_version).toBeUndefined();
+    expect(st.pending_version).toBeUndefined();
     expect(await h.notifier.notifyIfNew("sha256:ddd444")).toBe("apply_started");
     expect(h.cards).toHaveLength(2);
     expect(h.applies).toHaveLength(1);
+  });
+
+  it("restart-loop storm guard: a crash while the card is outstanding does NOT re-card within the suppress window", async () => {
+    // First instance posts a card that never resolves (hostd "crashes").
+    const statePath = join(dir, "state.json");
+    const cards: string[] = [];
+    const hung = new UpdateNotifier({
+      statePath,
+      isFleetMutationInFlight: () => false,
+      requestApproval: async ({ version }) => {
+        cards.push(version);
+        return new Promise(() => {}); // card never resolves
+      },
+      startApply: () => ({ result: "started" }),
+    });
+    void hung.notifyIfNew("sha256:feed99");
+    await new Promise((r) => setTimeout(r, 0)); // let the card post
+    expect(cards).toHaveLength(1);
+    // "Rebooted" instance, same state file: must suppress the re-post.
+    const h2 = makeHarness();
+    expect(await h2.notifier.notifyIfNew("sha256:feed99")).toBe(
+      "pending_recent",
+    );
+    expect(h2.cards).toHaveLength(0);
+    // …but a DIFFERENT release id is not suppressed.
+    expect(await h2.notifier.notifyIfNew("sha256:aab000")).toBe(
+      "apply_started",
+    );
+  });
+
+  it("restart-loop storm guard expires: after the suppress window a fresh card is posted", async () => {
+    const statePath = join(dir, "state.json");
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        pending_version: "sha256:feed99",
+        pending_posted_at: Date.now() - 2 * 60 * 60_000, // 2h ago
+      }),
+      "utf8",
+    );
+    const h = makeHarness(); // default suppress window = 1h
+    expect(await h.notifier.notifyIfNew("sha256:feed99")).toBe("apply_started");
+    expect(h.cards).toHaveLength(1);
+  });
+
+  it("skips (no card, no persist) when the watcher passes an empty release id", async () => {
+    const h = makeHarness();
+    expect(await h.notifier.notifyIfNew("")).toBe("skipped_no_version");
+    expect(h.cards).toHaveLength(0);
+    expect(existsSync(h.statePath)).toBe(false);
   });
 
   it("operator deny persists (one card per release) and never starts the apply", async () => {
@@ -200,8 +269,47 @@ describe("UpdateNotifier", () => {
       startApply: () => ({ result: "started" }),
     });
     expect(await notifier.notifyIfNew("sha256:boom")).toBe("dispatch_failed");
-    // A thrown approval must not mark the release notified.
-    expect(existsSync(statePath)).toBe(false);
+    // A thrown approval must not mark the release notified, and must
+    // clear the pending marker so the next tick retries.
+    const st = JSON.parse(readFileSync(statePath, "utf8"));
+    expect(st.last_notified_version).toBeUndefined();
+    expect(st.pending_version).toBeUndefined();
+  });
+
+  it("clips an over-long refusal detail under the gateway's 500-char finalize cap", async () => {
+    const h = makeHarness({
+      startResult: { result: "denied", error: "x".repeat(600) },
+    });
+    expect(await h.notifier.notifyIfNew("sha256:b1gerr")).toBe("apply_refused");
+    expect(h.finalizes).toHaveLength(1);
+    const detail = h.finalizes[0].detail ?? "";
+    expect(detail.length).toBeLessThanOrEqual(450);
+    expect(detail.startsWith("update did not start: ")).toBe(true);
+  });
+
+  it("a THROWING startApply after approval still finalizes honestly (apply_refused)", async () => {
+    const statePath = join(dir, "state.json");
+    const finalizes: { outcome: string; detail?: string }[] = [];
+    const notifier = new UpdateNotifier({
+      statePath,
+      isFleetMutationInFlight: () => false,
+      requestApproval: async () => ({
+        verdict: "approve",
+        finalize: async (o) => {
+          finalizes.push({ outcome: o.outcome, ...(o.detail ? { detail: o.detail } : {}) });
+        },
+      }),
+      startApply: () => {
+        throw new Error("spawn exploded");
+      },
+    });
+    expect(await notifier.notifyIfNew("sha256:thr0w1")).toBe("apply_refused");
+    expect(finalizes).toEqual([
+      expect.objectContaining({
+        outcome: "reconcile_failed_rolled_back",
+        detail: expect.stringContaining("spawn exploded"),
+      }),
+    ]);
   });
 });
 

--- a/src/host-control/update-notifier.test.ts
+++ b/src/host-control/update-notifier.test.ts
@@ -1,0 +1,213 @@
+// KEN-129 — update-check drift notifier: one card per release id,
+// fleet-lock respect, dispatch-failure retry, approve → update_apply.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  UpdateNotifier,
+  short,
+  type UpdateNotifierOptions,
+} from "./update-notifier.js";
+import type { ApprovalResult } from "./approval-gateway.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "update-notifier-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+interface Harness {
+  notifier: UpdateNotifier;
+  cards: { requestId: string; version: string; plan: string }[];
+  applies: string[];
+  finalizes: { outcome: string; detail?: string }[];
+  statePath: string;
+}
+
+function makeHarness(over: {
+  verdict?: ApprovalResult["verdict"];
+  denySource?: "operator" | "dispatch_failure";
+  locked?: () => boolean;
+  startResult?: { result: string; error?: string };
+  plan?: () => Promise<string>;
+  // Per-call verdict override: sequence of results, last repeats.
+  verdicts?: Partial<ApprovalResult>[];
+} = {}): Harness {
+  const statePath = join(dir, "state.json");
+  const cards: Harness["cards"] = [];
+  const applies: string[] = [];
+  const finalizes: Harness["finalizes"] = [];
+  let call = 0;
+  const opts: UpdateNotifierOptions = {
+    statePath,
+    isFleetMutationInFlight: over.locked ?? (() => false),
+    ...(over.plan ? { planFn: over.plan } : {}),
+    requestApproval: async (args) => {
+      cards.push(args);
+      const seq = over.verdicts;
+      const pick = seq ? seq[Math.min(call, seq.length - 1)] : undefined;
+      call++;
+      return {
+        verdict: over.verdict ?? "approve",
+        ...(over.denySource ? { denySource: over.denySource } : {}),
+        ...pick,
+        finalize: async (o) => {
+          finalizes.push({ outcome: o.outcome, ...(o.detail ? { detail: o.detail } : {}) });
+        },
+      } as ApprovalResult;
+    },
+    startApply: (requestId) => {
+      applies.push(requestId);
+      return over.startResult ?? { result: "started" };
+    },
+    mintRequestId: () => `req-${cards.length}`,
+  };
+  return { notifier: new UpdateNotifier(opts), cards, applies, finalizes, statePath };
+}
+
+describe("UpdateNotifier", () => {
+  it("approve → posts one card, starts update_apply, finalizes applied, persists release id", async () => {
+    const h = makeHarness();
+    const out = await h.notifier.notifyIfNew("sha256:aaa111");
+    expect(out).toBe("apply_started");
+    expect(h.cards).toHaveLength(1);
+    expect(h.applies).toEqual(["req-0"]);
+    expect(h.finalizes).toEqual([
+      expect.objectContaining({ outcome: "applied" }),
+    ]);
+    const state = JSON.parse(readFileSync(h.statePath, "utf8"));
+    expect(state.last_notified_version).toBe("sha256:aaa111");
+  });
+
+  it("dedups: a second detection of the SAME release posts no second card", async () => {
+    const h = makeHarness();
+    await h.notifier.notifyIfNew("sha256:aaa111");
+    const out = await h.notifier.notifyIfNew("sha256:aaa111");
+    expect(out).toBe("deduped");
+    expect(h.cards).toHaveLength(1);
+    expect(h.applies).toHaveLength(1);
+  });
+
+  it("a NEW release id gets a fresh card after a previous one was notified", async () => {
+    const h = makeHarness({ verdict: "deny", denySource: "operator" });
+    await h.notifier.notifyIfNew("sha256:aaa111");
+    const out = await h.notifier.notifyIfNew("sha256:bbb222");
+    expect(out).toBe("denied");
+    expect(h.cards).toHaveLength(2);
+    const state = JSON.parse(readFileSync(h.statePath, "utf8"));
+    expect(state.last_notified_version).toBe("sha256:bbb222");
+  });
+
+  it("dedup survives a restart (state read from disk by a fresh instance)", async () => {
+    const h1 = makeHarness();
+    await h1.notifier.notifyIfNew("sha256:aaa111");
+    const h2 = makeHarness();
+    // Same statePath (same dir) — fresh instance must see the persisted id.
+    const out = await h2.notifier.notifyIfNew("sha256:aaa111");
+    expect(out).toBe("deduped");
+    expect(h2.cards).toHaveLength(0);
+  });
+
+  it("respects the fleet-mutation lock: no card, no persist, retried after unlock", async () => {
+    let locked = true;
+    const h = makeHarness({ locked: () => locked });
+    expect(await h.notifier.notifyIfNew("sha256:ccc333")).toBe("locked");
+    expect(h.cards).toHaveLength(0);
+    expect(existsSync(h.statePath)).toBe(false);
+    locked = false;
+    expect(await h.notifier.notifyIfNew("sha256:ccc333")).toBe("apply_started");
+    expect(h.cards).toHaveLength(1);
+  });
+
+  it("dispatch failure does NOT mark notified — the next tick re-cards", async () => {
+    const h = makeHarness({
+      verdicts: [
+        { verdict: "deny", denySource: "dispatch_failure", reason: "gateway down" },
+        { verdict: "approve" },
+      ],
+    });
+    expect(await h.notifier.notifyIfNew("sha256:ddd444")).toBe("dispatch_failed");
+    expect(existsSync(h.statePath)).toBe(false);
+    expect(await h.notifier.notifyIfNew("sha256:ddd444")).toBe("apply_started");
+    expect(h.cards).toHaveLength(2);
+    expect(h.applies).toHaveLength(1);
+  });
+
+  it("operator deny persists (one card per release) and never starts the apply", async () => {
+    const h = makeHarness({ verdict: "deny", denySource: "operator" });
+    expect(await h.notifier.notifyIfNew("sha256:eee555")).toBe("denied");
+    expect(h.applies).toHaveLength(0);
+    expect(await h.notifier.notifyIfNew("sha256:eee555")).toBe("deduped");
+    expect(h.cards).toHaveLength(1);
+  });
+
+  it("timeout persists (card reached the operator) and never starts the apply", async () => {
+    const h = makeHarness({ verdict: "timeout" });
+    expect(await h.notifier.notifyIfNew("sha256:fff666")).toBe("timed_out");
+    expect(h.applies).toHaveLength(0);
+    expect(await h.notifier.notifyIfNew("sha256:fff666")).toBe("deduped");
+  });
+
+  it("approve but update_apply refused (lock raced) finalizes with the honest reason", async () => {
+    const h = makeHarness({
+      startResult: { result: "denied", error: "fleet-mutation lock held by apply" },
+    });
+    expect(await h.notifier.notifyIfNew("sha256:abc999")).toBe("apply_refused");
+    expect(h.finalizes).toEqual([
+      expect.objectContaining({
+        outcome: "reconcile_failed_rolled_back",
+        detail: expect.stringContaining("fleet-mutation lock held by apply"),
+      }),
+    ]);
+  });
+
+  it("plan probe failure still posts the card (plan is best-effort)", async () => {
+    const h = makeHarness({
+      plan: async () => {
+        throw new Error("update --check exploded");
+      },
+    });
+    expect(await h.notifier.notifyIfNew("sha256:0a0b0c")).toBe("apply_started");
+    expect(h.cards[0].plan).toBe("");
+  });
+
+  it("passes the plan text through to the card", async () => {
+    const h = makeHarness({ plan: async () => "2 releases behind: v1.2 → v1.4" });
+    await h.notifier.notifyIfNew("sha256:1a2b3c");
+    expect(h.cards[0].plan).toBe("2 releases behind: v1.2 → v1.4");
+  });
+
+  it("tolerates a corrupt state file (treated as never-notified, no crash)", async () => {
+    const h = makeHarness();
+    writeFileSync(h.statePath, "not json {{{", "utf8");
+    expect(await h.notifier.notifyIfNew("sha256:c0ffee")).toBe("apply_started");
+    const state = JSON.parse(readFileSync(h.statePath, "utf8"));
+    expect(state.last_notified_version).toBe("sha256:c0ffee");
+  });
+
+  it("never throws when requestApproval rejects", async () => {
+    const statePath = join(dir, "state.json");
+    const notifier = new UpdateNotifier({
+      statePath,
+      isFleetMutationInFlight: () => false,
+      requestApproval: async () => {
+        throw new Error("socket exploded");
+      },
+      startApply: () => ({ result: "started" }),
+    });
+    expect(await notifier.notifyIfNew("sha256:boom")).toBe("dispatch_failed");
+    // A thrown approval must not mark the release notified.
+    expect(existsSync(statePath)).toBe(false);
+  });
+});
+
+describe("short", () => {
+  it("abbreviates sha256 digests for card/log display", () => {
+    expect(short("sha256:0123456789abcdef0123")).toBe("0123456789ab");
+    expect(short("v1.2.3")).toBe("v1.2.3");
+  });
+});

--- a/src/host-control/update-notifier.ts
+++ b/src/host-control/update-notifier.ts
@@ -1,0 +1,220 @@
+/**
+ * Update-check drift notifier (KEN-129 — stage 1 of the KEN-128
+ * auto-reconcile plan).
+ *
+ * When the release watcher (`release-watcher.ts`) detects that the
+ * fleet is behind the published release but `apply_on_detect` is
+ * false, this module posts ONE operator approval card ("fleet is
+ * behind — tap to apply") through the existing hostd approval-card
+ * surface (`approval-gateway.ts`, the same request_config_approval
+ * IPC used by config_propose_edit). On Approve it starts the exact
+ * same `update_apply` path the hostd verb uses — fleet-mutation
+ * lock, apply-asset preflight, durable status rows and all.
+ *
+ * Invariants (the KEN-129 acceptance criteria):
+ *   - ONE card per release id. The last-notified release id is
+ *     persisted to `statePath` so a hostd restart cannot re-card the
+ *     same release. A card that *reached* the operator (approve,
+ *     operator deny, or timeout) marks the release notified; a
+ *     dispatch failure (gateway unreachable / send failed) does NOT,
+ *     so the next tick retries.
+ *   - Respect the fleet-mutation lock: while an update_apply / apply
+ *     / rollout is in flight we post nothing (the tick is skipped and
+ *     retried on the next interval — the running mutation likely IS
+ *     the catch-up).
+ *   - No card when current: the watcher only calls us when a release
+ *     is actually available, and dedup covers the steady "behind but
+ *     already asked" state.
+ *
+ * Dependency-injection-shaped like the watcher: production wiring
+ * lives in `main.ts`; tests drive the state machine with stubs.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { dirname } from "node:path";
+import type { ApprovalResult } from "./approval-gateway.js";
+
+/** Minimal slice of HostdResponse the notifier needs from the apply hook. */
+export interface StartApplyResult {
+  /** "started" when the fleet mutation was accepted; anything else
+   *  ("denied", "error") means it did not start. */
+  result: string;
+  /** Operator-facing refusal/error detail when result !== "started". */
+  error?: string;
+}
+
+/** Terminal outcome of one notify attempt — asserted by tests and logged. */
+export type NotifyOutcome =
+  | "deduped" // already notified for this release id
+  | "locked" // fleet mutation in flight — skipped, retry next tick
+  | "dispatch_failed" // card never reached the operator — retry next tick
+  | "denied" // operator tapped Deny
+  | "timed_out" // card expired unanswered
+  | "apply_started" // operator approved; update_apply started
+  | "apply_refused"; // operator approved but the apply hook refused
+
+export interface UpdateNotifierOptions {
+  /** JSON file persisting `{ last_notified_version }` across restarts. */
+  statePath: string;
+  /** Post the approval card; resolves with the operator's verdict.
+   *  Production wiring iterates admin agents' gateway sockets. */
+  requestApproval: (args: {
+    requestId: string;
+    version: string;
+    plan: string;
+  }) => Promise<ApprovalResult>;
+  /** Start the hostd update_apply path (fleet-lock + preflight +
+   *  status rows included). Must NOT throw — refusals come back as
+   *  `result !== "started"`. */
+  startApply: (requestId: string) => StartApplyResult;
+  /** True while hostd's fleet-mutation lock is held. */
+  isFleetMutationInFlight: () => boolean;
+  /** Best-effort `switchroom update --check` plan text for the card
+   *  body. Failures resolve to "" — the card still posts. */
+  planFn?: () => Promise<string>;
+  log?: (m: string) => void;
+  /** Test seam — request-id mint. */
+  mintRequestId?: () => string;
+}
+
+interface NotifierState {
+  last_notified_version: string;
+  notified_at: number;
+}
+
+export class UpdateNotifier {
+  constructor(private readonly opts: UpdateNotifierOptions) {}
+
+  /**
+   * Called by the release watcher with the detected remote release id
+   * (digest). Never throws — every failure path logs and returns an
+   * outcome so the watcher's tick can't be broken by notify errors.
+   */
+  async notifyIfNew(version: string): Promise<NotifyOutcome> {
+    try {
+      return await this.run(version);
+    } catch (err) {
+      this.log(`notify failed: ${errMsg(err)}`);
+      return "dispatch_failed";
+    }
+  }
+
+  private async run(version: string): Promise<NotifyOutcome> {
+    const state = this.readState();
+    if (state?.last_notified_version === version) {
+      return "deduped";
+    }
+    if (this.opts.isFleetMutationInFlight()) {
+      this.log(
+        `release ${short(version)} detected but a fleet mutation is in flight — not posting a card this tick`,
+      );
+      return "locked";
+    }
+
+    let plan = "";
+    if (this.opts.planFn) {
+      try {
+        plan = await this.opts.planFn();
+      } catch (err) {
+        this.log(`update --check plan probe failed: ${errMsg(err)}`);
+      }
+    }
+
+    const requestId = this.opts.mintRequestId
+      ? this.opts.mintRequestId()
+      : `relnotify-${randomBytes(4).toString("hex")}`;
+    this.log(
+      `posting update approval card for release ${short(version)} (requestId=${requestId})`,
+    );
+    const res = await this.opts.requestApproval({ requestId, version, plan });
+
+    if (res.verdict === "deny" && res.denySource === "dispatch_failure") {
+      // The card never reached the operator — do NOT mark notified;
+      // the next watcher tick retries.
+      this.log(
+        `update approval card dispatch failed (${res.reason ?? "unknown"}) — will retry next tick`,
+      );
+      return "dispatch_failed";
+    }
+
+    // The card reached the operator: whatever the verdict, this
+    // release id is now "asked" — one card per release.
+    this.writeState({ last_notified_version: version, notified_at: Date.now() });
+
+    if (res.verdict === "deny") {
+      this.log(`operator denied update for release ${short(version)}`);
+      return "denied";
+    }
+    if (res.verdict === "timeout") {
+      this.log(`update approval card expired for release ${short(version)}`);
+      return "timed_out";
+    }
+
+    // Approved — start the real update_apply path.
+    const start = this.opts.startApply(requestId);
+    if (start.result === "started") {
+      this.log(`update_apply started (requestId=${requestId})`);
+      await res.finalize({
+        outcome: "applied",
+        detail: `switchroom update started (request_id ${requestId}) — track progress via get_status / the rollout narration message.`,
+      });
+      return "apply_started";
+    }
+    const why = start.error ?? `unexpected result "${start.result}"`;
+    this.log(`update_apply refused after approval: ${why}`);
+    // Closest available terminal card state — the detail carries the
+    // honest reason (nothing was rolled back; the apply never started).
+    await res.finalize({
+      outcome: "reconcile_failed_rolled_back",
+      detail: `update did not start: ${why}`,
+    });
+    return "apply_refused";
+  }
+
+  private readState(): NotifierState | null {
+    try {
+      const raw = readFileSync(this.opts.statePath, "utf8");
+      const parsed = JSON.parse(raw) as Partial<NotifierState>;
+      if (typeof parsed?.last_notified_version === "string") {
+        return {
+          last_notified_version: parsed.last_notified_version,
+          notified_at:
+            typeof parsed.notified_at === "number" ? parsed.notified_at : 0,
+        };
+      }
+      return null;
+    } catch {
+      // Missing or corrupt state → treat as never-notified. Worst case
+      // is one duplicate card after a corrupt file, never a crash.
+      return null;
+    }
+  }
+
+  private writeState(state: NotifierState): void {
+    try {
+      mkdirSync(dirname(this.opts.statePath), { recursive: true });
+      const tmp = `${this.opts.statePath}.tmp`;
+      writeFileSync(tmp, JSON.stringify(state) + "\n", "utf8");
+      renameSync(tmp, this.opts.statePath);
+    } catch (err) {
+      // Non-fatal: dedup degrades to in-process only until the next
+      // successful write (a restart could re-card once).
+      this.log(`failed to persist notify state: ${errMsg(err)}`);
+    }
+  }
+
+  private log(m: string): void {
+    if (this.opts.log) this.opts.log(`update-notifier: ${m}`);
+  }
+}
+
+/** Abbreviate a sha256 digest for logs/cards. */
+export function short(version: string): string {
+  const hex = version.startsWith("sha256:") ? version.slice(7) : version;
+  return hex.length > 12 ? hex.slice(0, 12) : hex;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/host-control/update-notifier.ts
+++ b/src/host-control/update-notifier.ts
@@ -18,10 +18,19 @@
  *     operator deny, or timeout) marks the release notified; a
  *     dispatch failure (gateway unreachable / send failed) does NOT,
  *     so the next tick retries.
+ *   - Restart-loop storm guard: a `pending` marker is persisted just
+ *     BEFORE the card posts and cleared when the card resolves. If
+ *     hostd dies while the card is outstanding (crash loop, operator
+ *     restart), the next boot suppresses a re-post of the same
+ *     release until the original card's timeout window has elapsed —
+ *     so a restart loop cannot storm the operator with duplicate
+ *     cards. A resolved dispatch failure clears the marker so the
+ *     next tick retries promptly.
  *   - Respect the fleet-mutation lock: while an update_apply / apply
  *     / rollout is in flight we post nothing (the tick is skipped and
  *     retried on the next interval — the running mutation likely IS
- *     the catch-up).
+ *     the catch-up). Re-checked after the (slow) plan probe so a
+ *     mutation that started during the probe also suppresses the card.
  *   - No card when current: the watcher only calls us when a release
  *     is actually available, and dedup covers the steady "behind but
  *     already asked" state.
@@ -47,6 +56,8 @@ export interface StartApplyResult {
 /** Terminal outcome of one notify attempt — asserted by tests and logged. */
 export type NotifyOutcome =
   | "deduped" // already notified for this release id
+  | "pending_recent" // a card for this release was posted before a restart and may still be live
+  | "skipped_no_version" // watcher passed an empty release id — nothing to card
   | "locked" // fleet mutation in flight — skipped, retry next tick
   | "dispatch_failed" // card never reached the operator — retry next tick
   | "denied" // operator tapped Deny
@@ -54,8 +65,16 @@ export type NotifyOutcome =
   | "apply_started" // operator approved; update_apply started
   | "apply_refused"; // operator approved but the apply hook refused
 
+/**
+ * The gateway's `request_config_finalize` validator rejects `detail`
+ * over 500 chars (ipc-server.ts) — an over-long detail would silently
+ * drop the finalize and leave the card's buttons live forever. Clip
+ * with headroom.
+ */
+const FINALIZE_DETAIL_MAX = 450;
+
 export interface UpdateNotifierOptions {
-  /** JSON file persisting `{ last_notified_version }` across restarts. */
+  /** JSON file persisting notify/pending state across restarts. */
   statePath: string;
   /** Post the approval card; resolves with the operator's verdict.
    *  Production wiring iterates admin agents' gateway sockets. */
@@ -65,23 +84,33 @@ export interface UpdateNotifierOptions {
     plan: string;
   }) => Promise<ApprovalResult>;
   /** Start the hostd update_apply path (fleet-lock + preflight +
-   *  status rows included). Must NOT throw — refusals come back as
-   *  `result !== "started"`. */
+   *  status rows included). Refusals come back as
+   *  `result !== "started"`; a throw is treated as a refusal. */
   startApply: (requestId: string) => StartApplyResult;
   /** True while hostd's fleet-mutation lock is held. */
   isFleetMutationInFlight: () => boolean;
   /** Best-effort `switchroom update --check` plan text for the card
    *  body. Failures resolve to "" — the card still posts. */
   planFn?: () => Promise<string>;
+  /** How long a pre-restart pending card suppresses a re-post of the
+   *  same release (should match the card's timeoutMs). Default 1h. */
+  repostSuppressMs?: number;
   log?: (m: string) => void;
   /** Test seam — request-id mint. */
   mintRequestId?: () => string;
+  /** Test seam — wall clock. */
+  now?: () => number;
 }
 
 interface NotifierState {
-  last_notified_version: string;
-  notified_at: number;
+  last_notified_version?: string;
+  notified_at?: number;
+  /** Release id of a card posted but not yet resolved (crash guard). */
+  pending_version?: string;
+  pending_posted_at?: number;
 }
+
+const DEFAULT_REPOST_SUPPRESS_MS = 60 * 60_000;
 
 export class UpdateNotifier {
   constructor(private readonly opts: UpdateNotifierOptions) {}
@@ -101,9 +130,30 @@ export class UpdateNotifier {
   }
 
   private async run(version: string): Promise<NotifyOutcome> {
+    if (version === "") {
+      // The watcher's checkFn contract makes version optional; an
+      // empty id would render a blank card and dedup on "" forever.
+      this.log(
+        "release detected but no release id was provided — skipping card",
+      );
+      return "skipped_no_version";
+    }
     const state = this.readState();
     if (state?.last_notified_version === version) {
       return "deduped";
+    }
+    const suppressMs = this.opts.repostSuppressMs ?? DEFAULT_REPOST_SUPPRESS_MS;
+    if (
+      state?.pending_version === version &&
+      typeof state.pending_posted_at === "number" &&
+      this.now() - state.pending_posted_at < suppressMs
+    ) {
+      // A card for this release was posted before a restart and may
+      // still be live in the operator's chat — do not double-card.
+      this.log(
+        `release ${short(version)} has a possibly-live card from before a restart — suppressing re-post`,
+      );
+      return "pending_recent";
     }
     if (this.opts.isFleetMutationInFlight()) {
       this.log(
@@ -120,6 +170,14 @@ export class UpdateNotifier {
         this.log(`update --check plan probe failed: ${errMsg(err)}`);
       }
     }
+    // The plan probe shells out (up to minutes) — a mutation may have
+    // started meanwhile. Re-check so we never card mid-mutation.
+    if (this.opts.isFleetMutationInFlight()) {
+      this.log(
+        `fleet mutation started during the plan probe for ${short(version)} — not posting a card this tick`,
+      );
+      return "locked";
+    }
 
     const requestId = this.opts.mintRequestId
       ? this.opts.mintRequestId()
@@ -127,20 +185,44 @@ export class UpdateNotifier {
     this.log(
       `posting update approval card for release ${short(version)} (requestId=${requestId})`,
     );
-    const res = await this.opts.requestApproval({ requestId, version, plan });
+    // Crash guard: mark the card pending BEFORE posting so a hostd
+    // restart while the card is outstanding cannot re-card this
+    // release inside the suppress window.
+    this.writeState({
+      ...this.carryNotified(state),
+      pending_version: version,
+      pending_posted_at: this.now(),
+    });
+
+    let res: ApprovalResult;
+    try {
+      res = await this.opts.requestApproval({ requestId, version, plan });
+    } catch (err) {
+      res = {
+        verdict: "deny",
+        reason: `requestApproval threw: ${errMsg(err)}`,
+        denySource: "dispatch_failure",
+        finalize: async () => {},
+      };
+    }
 
     if (res.verdict === "deny" && res.denySource === "dispatch_failure") {
       // The card never reached the operator — do NOT mark notified;
-      // the next watcher tick retries.
+      // clear the pending marker so the next watcher tick retries.
       this.log(
         `update approval card dispatch failed (${res.reason ?? "unknown"}) — will retry next tick`,
       );
+      this.writeState(this.carryNotified(state));
       return "dispatch_failed";
     }
 
     // The card reached the operator: whatever the verdict, this
-    // release id is now "asked" — one card per release.
-    this.writeState({ last_notified_version: version, notified_at: Date.now() });
+    // release id is now "asked" — one card per release. (Also clears
+    // the pending marker.)
+    this.writeState({
+      last_notified_version: version,
+      notified_at: this.now(),
+    });
 
     if (res.verdict === "deny") {
       this.log(`operator denied update for release ${short(version)}`);
@@ -152,38 +234,68 @@ export class UpdateNotifier {
     }
 
     // Approved — start the real update_apply path.
-    const start = this.opts.startApply(requestId);
+    let start: StartApplyResult;
+    try {
+      start = this.opts.startApply(requestId);
+    } catch (err) {
+      start = { result: "error", error: errMsg(err) };
+    }
     if (start.result === "started") {
       this.log(`update_apply started (requestId=${requestId})`);
       await res.finalize({
         outcome: "applied",
-        detail: `switchroom update started (request_id ${requestId}) — track progress via get_status / the rollout narration message.`,
+        detail: clipDetail(
+          `switchroom update started (request_id ${requestId}) — track progress via get_status / the rollout narration message.`,
+        ),
       });
       return "apply_started";
     }
     const why = start.error ?? `unexpected result "${start.result}"`;
     this.log(`update_apply refused after approval: ${why}`);
-    // Closest available terminal card state — the detail carries the
-    // honest reason (nothing was rolled back; the apply never started).
+    // Closest available terminal card state — `reconcile_failed_rolled_back`
+    // is reused because old gateways reject unknown outcomes (mixed-version
+    // safety); the detail carries the honest reason (nothing was rolled
+    // back; the apply never started).
     await res.finalize({
       outcome: "reconcile_failed_rolled_back",
-      detail: `update did not start: ${why}`,
+      detail: clipDetail(`update did not start: ${why}`),
     });
     return "apply_refused";
+  }
+
+  /** Preserve any prior last-notified fields when rewriting state. */
+  private carryNotified(state: NotifierState | null): NotifierState {
+    return state?.last_notified_version !== undefined
+      ? {
+          last_notified_version: state.last_notified_version,
+          notified_at: state.notified_at ?? 0,
+        }
+      : {};
+  }
+
+  private now(): number {
+    return this.opts.now ? this.opts.now() : Date.now();
   }
 
   private readState(): NotifierState | null {
     try {
       const raw = readFileSync(this.opts.statePath, "utf8");
-      const parsed = JSON.parse(raw) as Partial<NotifierState>;
-      if (typeof parsed?.last_notified_version === "string") {
-        return {
-          last_notified_version: parsed.last_notified_version,
-          notified_at:
-            typeof parsed.notified_at === "number" ? parsed.notified_at : 0,
-        };
+      const parsed = JSON.parse(raw) as Partial<NotifierState> | null;
+      if (parsed === null || typeof parsed !== "object") return null;
+      const out: NotifierState = {};
+      if (typeof parsed.last_notified_version === "string") {
+        out.last_notified_version = parsed.last_notified_version;
+        out.notified_at =
+          typeof parsed.notified_at === "number" ? parsed.notified_at : 0;
       }
-      return null;
+      if (typeof parsed.pending_version === "string") {
+        out.pending_version = parsed.pending_version;
+        out.pending_posted_at =
+          typeof parsed.pending_posted_at === "number"
+            ? parsed.pending_posted_at
+            : 0;
+      }
+      return Object.keys(out).length > 0 ? out : null;
     } catch {
       // Missing or corrupt state → treat as never-notified. Worst case
       // is one duplicate card after a corrupt file, never a crash.
@@ -207,6 +319,13 @@ export class UpdateNotifier {
   private log(m: string): void {
     if (this.opts.log) this.opts.log(`update-notifier: ${m}`);
   }
+}
+
+/** Clip a finalize detail line under the gateway's 500-char validator cap. */
+function clipDetail(detail: string): string {
+  return detail.length > FINALIZE_DETAIL_MAX
+    ? detail.slice(0, FINALIZE_DETAIL_MAX - 1) + "…"
+    : detail;
 }
 
 /** Abbreviate a sha256 digest for logs/cards. */

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -47,6 +47,7 @@ import {
   probeKernel,
   probeSkills,
   probeConnections,
+  probeDrift,
   watchAgentProcess,
   AGENT_LIVE_WINDOW_MS,
   AGENT_LIVE_POLL_INTERVAL_MS,
@@ -124,6 +125,7 @@ export type ProbeKey =
   | 'kernel'
   | 'skills'
   | 'connections'
+  | 'drift'
 
 export type ProbeMap = Partial<Record<ProbeKey, ProbeResult | null>>
 
@@ -258,11 +260,12 @@ const PROBE_LABELS: Record<ProbeKey, string> = {
   kernel:    'Kernel',
   skills:    'Skills',
   connections: 'Connections',
+  drift:     'Drift',
 }
 
 const PROBE_KEYS: ReadonlyArray<ProbeKey> = [
   'account', 'agent', 'gateway', 'quota', 'hindsight',
-  'scheduler', 'broker', 'kernel', 'skills', 'connections',
+  'scheduler', 'broker', 'kernel', 'skills', 'connections', 'drift',
 ]
 
 const REASON_EMOJI: Record<RestartReason, string> = {
@@ -787,6 +790,7 @@ export async function runAllProbes(opts: RunProbesOpts): Promise<ProbeMap> {
     probeKernel(undefined, { dockerMode: opts.dockerMode }).then(r => { probes.kernel = r }),
     probeSkills(opts.agentDir, { agentName: opts.agentSlug ?? opts.agentName }).then(r => { probes.skills = r }),
     probeConnections(opts.agentDir).then(r => { probes.connections = r }),
+    probeDrift(opts.agentDir, { agentName: opts.agentSlug ?? opts.agentName }).then(r => { probes.drift = r }),
   ])
 
   return probes

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -1492,3 +1492,90 @@ const realSkillsFs: SkillsFsImpl = {
   readdir: (p) => readdirSync(p),
   exists: (p) => existsSync(p),
 }
+
+// ─── Probe: Generated-surface drift (KEN-130) ────────────────────────────────
+
+/**
+ * Surfaces two drift signals on the boot card:
+ *
+ *   1. Live stamp comparison — the generation stamp written by the last
+ *      host-side reconcile (`<agentDir>/.switchroom-generated.json`)
+ *      vs the deployed start.sh / managed CLAUDE.md section / .mcp.json.
+ *      Pure fs hash compare via src/agents/generation-stamp.ts (which is
+ *      dependency-free by design), so it runs at every boot without any
+ *      host involvement.
+ *   2. The host-side drift report (`<agentDir>/.switchroom-drift.json`)
+ *      written by `switchroom doctor` — covers the surfaces only the
+ *      host can render (compose, hooks re-render, skills pool, image
+ *      hook scripts). Rendered with its age so a stale report is
+ *      readable as such; doctor rewrites it (empty when clean) on every
+ *      run and reconcile refreshes the stamp, so staleness windows are
+ *      short.
+ *
+ * No stamp AND no report → ok (fresh agent / pre-KEN-130 host): the
+ * silent-when-healthy contract means clean fleets never grow a row.
+ */
+export async function probeDrift(
+  agentDir: string,
+  opts: { agentName?: string; nowMs?: () => number } = {},
+): Promise<ProbeResult> {
+  return withTimeout('Drift', (async (): Promise<ProbeResult> => {
+    const surfaces: string[] = []
+
+    // 1. Stamp comparison (in-container checkable surfaces).
+    try {
+      const { detectStampDrift } = await import(
+        '../../src/agents/generation-stamp.js'
+      )
+      const stamp = detectStampDrift(agentDir)
+      for (const f of stamp.findings) {
+        surfaces.push(`${f.surface} (${f.detail})`)
+      }
+    } catch {
+      /* generation-stamp unavailable (unbundled build) — skip signal 1 */
+    }
+
+    // 2. Host-written doctor report.
+    try {
+      const raw = readFileSync(join(agentDir, '.switchroom-drift.json'), 'utf8')
+      const report = JSON.parse(raw) as {
+        version?: number
+        generatedAt?: string
+        findings?: Array<{ surface?: string; detail?: string }>
+      }
+      if (report?.version === 1 && Array.isArray(report.findings)) {
+        const seen = new Set(surfaces.map((s) => s.split(' ')[0]))
+        let ageNote = ''
+        const gen = report.generatedAt ? Date.parse(report.generatedAt) : NaN
+        if (Number.isFinite(gen)) {
+          const ageMs = (opts.nowMs?.() ?? Date.now()) - gen
+          if (ageMs > 3_600_000) {
+            const hours = Math.round(ageMs / 3_600_000)
+            const human = hours >= 48 ? `${Math.round(hours / 24)}d` : `${hours}h`
+            ageNote = ` — as of ${human} ago`
+          }
+        }
+        for (const f of report.findings) {
+          if (!f?.surface || seen.has(f.surface)) continue
+          seen.add(f.surface)
+          surfaces.push(`${f.surface}${ageNote}`)
+        }
+      }
+    } catch {
+      /* no report / unreadable — fine, doctor hasn't run */
+    }
+
+    if (surfaces.length === 0) {
+      return { status: 'ok', label: 'Drift', detail: 'generated surfaces in sync' }
+    }
+    const shown = surfaces.slice(0, 4).join(', ')
+    const more = surfaces.length > 4 ? ` +${surfaces.length - 4} more` : ''
+    const target = opts.agentName ? ` ${opts.agentName}` : ''
+    return {
+      status: 'degraded',
+      label: 'Drift',
+      detail: `${surfaces.length} drifted surface(s): ${shown}${more}`,
+      nextStep: `Run \`switchroom apply\` (or \`switchroom agent reconcile${target} --restart\`); see \`switchroom doctor\` for detail`,
+    }
+  })())
+}

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -17,6 +17,16 @@ import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
 
 import { readQuotaCache, writeQuotaCache } from './quota-cache.js'
+// Static cross-boundary import (same pattern as model-command.ts /
+// auth-broker-client.ts — the plugin bundler resolves ../../src/*
+// statically). generation-stamp.ts is dependency-free by design, so
+// this drags nothing else in. A dynamic import here would silently
+// no-op if the bundler missed it, killing the probe in production
+// while unit tests (which run unbundled) stayed green.
+import {
+  detectStampDrift,
+  readGenerationStamp,
+} from '../../src/agents/generation-stamp.js'
 import { fetchQuota, formatQuotaLine, type QuotaResult } from '../quota-check.js'
 
 const execFile = promisify(execFileCb)
@@ -1523,16 +1533,18 @@ export async function probeDrift(
     const surfaces: string[] = []
 
     // 1. Stamp comparison (in-container checkable surfaces).
+    let stampGeneratedAtMs = NaN
     try {
-      const { detectStampDrift } = await import(
-        '../../src/agents/generation-stamp.js'
-      )
-      const stamp = detectStampDrift(agentDir)
-      for (const f of stamp.findings) {
+      const stampResult = detectStampDrift(agentDir)
+      for (const f of stampResult.findings) {
         surfaces.push(`${f.surface} (${f.detail})`)
       }
+      if (stampResult.hasStamp) {
+        const raw = readGenerationStamp(agentDir)
+        if (raw?.generatedAt) stampGeneratedAtMs = Date.parse(raw.generatedAt)
+      }
     } catch {
-      /* generation-stamp unavailable (unbundled build) — skip signal 1 */
+      /* unexpected fs failure — skip signal 1, never break the boot card */
     }
 
     // 2. Host-written doctor report.
@@ -1544,21 +1556,35 @@ export async function probeDrift(
         findings?: Array<{ surface?: string; detail?: string }>
       }
       if (report?.version === 1 && Array.isArray(report.findings)) {
-        const seen = new Set(surfaces.map((s) => s.split(' ')[0]))
-        let ageNote = ''
         const gen = report.generatedAt ? Date.parse(report.generatedAt) : NaN
-        if (Number.isFinite(gen)) {
-          const ageMs = (opts.nowMs?.() ?? Date.now()) - gen
-          if (ageMs > 3_600_000) {
-            const hours = Math.round(ageMs / 3_600_000)
-            const human = hours >= 48 ? `${Math.round(hours / 24)}d` : `${hours}h`
-            ageNote = ` — as of ${human} ago`
+        // A report OLDER than the generation stamp predates the last
+        // `switchroom apply` — that apply re-enforced every surface the
+        // report describes (compose rewrite + full reconcile), so its
+        // findings are stale. Without this guard a freshly-applied fleet
+        // keeps showing a degraded Drift row on every boot until the
+        // operator happens to rerun doctor (doctor rewrites the report;
+        // apply does not). Any still-real drift resurfaces on the next
+        // doctor run.
+        const supersededByApply =
+          Number.isFinite(stampGeneratedAtMs) &&
+          Number.isFinite(gen) &&
+          gen < stampGeneratedAtMs
+        if (!supersededByApply) {
+          const seen = new Set(surfaces.map((s) => s.split(' ')[0]))
+          let ageNote = ''
+          if (Number.isFinite(gen)) {
+            const ageMs = (opts.nowMs?.() ?? Date.now()) - gen
+            if (ageMs > 3_600_000) {
+              const hours = Math.round(ageMs / 3_600_000)
+              const human = hours >= 48 ? `${Math.round(hours / 24)}d` : `${hours}h`
+              ageNote = ` — as of ${human} ago`
+            }
           }
-        }
-        for (const f of report.findings) {
-          if (!f?.surface || seen.has(f.surface)) continue
-          seen.add(f.surface)
-          surfaces.push(`${f.surface}${ageNote}`)
+          for (const f of report.findings) {
+            if (!f?.surface || seen.has(f.surface)) continue
+            seen.add(f.surface)
+            surfaces.push(`${f.surface}${ageNote}`)
+          }
         }
       }
     } catch {

--- a/telegram-plugin/gateway/config-approval-handler.test.ts
+++ b/telegram-plugin/gateway/config-approval-handler.test.ts
@@ -87,6 +87,28 @@ afterEach(() => {
 // 32768-char wire limit (RENDERED_BODY_CAP=32000), not the old 4096.
 const RICH_LIMIT = 32768;
 describe("buildConfigApprovalCardBody", () => {
+  it("renders the default config-edit header when no title is passed", () => {
+    const { body } = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: "a_reason",
+      unifiedDiff: "diff",
+    });
+    expect(body.startsWith("🛠 **Config edit proposed**\n")).toBe(true);
+  });
+
+  it("KEN-129: an explicit title overrides the config-edit header", () => {
+    const { body } = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: "fleet is behind",
+      unifiedDiff: "update plan",
+      title: "⬆️ **Switchroom update available — fleet is behind**",
+    });
+    expect(
+      body.startsWith("⬆️ **Switchroom update available — fleet is behind**\n"),
+    ).toBe(true);
+    expect(body).not.toContain("Config edit proposed");
+  });
+
   it("ships the diff verbatim inside a fenced code block (< / & stay literal)", () => {
     const { body } = buildConfigApprovalCardBody({
       agentName: "klanker",

--- a/telegram-plugin/gateway/config-approval-handler.test.ts
+++ b/telegram-plugin/gateway/config-approval-handler.test.ts
@@ -109,6 +109,38 @@ describe("buildConfigApprovalCardBody", () => {
     expect(body).not.toContain("Config edit proposed");
   });
 
+  // Defence in depth behind the ipc-server validator: the title is the card's
+  // FIRST line and is rendered verbatim (it carries intentional markdown), so
+  // a multi-line title would let the caller forge the `Agent:` / `Reason:`
+  // lines — or unbalance the diff fence — on a card the operator is about to
+  // approve. Flatten control characters and hard-cap the length here too.
+  it("flattens a multi-line title so it cannot forge the card body", () => {
+    const { body } = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: "routine",
+      unifiedDiff: "noop",
+      title: "⬆️ **Update**\nAgent: `root`\nReason: harmless\n```\nrm -rf /\n```",
+    });
+    // Everything the caller supplied stays on ONE line — it cannot become the
+    // card's own Agent:/Reason:/fence lines.
+    expect(body.split("\n")[0]).toBe(
+      "⬆️ **Update** Agent: `root` Reason: harmless ``` rm -rf / ```",
+    );
+    // The authoritative Agent line is still the handler's, and it names the
+    // real requesting agent, not the forged one.
+    expect(body.split("\n")[1]).toContain("klanker");
+  });
+
+  it("caps an oversize title at 200 chars", () => {
+    const { body } = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: "routine",
+      unifiedDiff: "noop",
+      title: "x".repeat(500),
+    });
+    expect(body.split("\n")[0]!).toHaveLength(200);
+  });
+
   it("ships the diff verbatim inside a fenced code block (< / & stay literal)", () => {
     const { body } = buildConfigApprovalCardBody({
       agentName: "klanker",

--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -206,10 +206,14 @@ export function buildConfigApprovalCardBody(args: {
   agentName: string;
   reason: string;
   unifiedDiff: string;
+  /** Optional header override (KEN-129 — e.g. the update-check drift
+   *  card). Rendered verbatim as the first line; absent → the default
+   *  config-edit header. */
+  title?: string;
 }): { body: string; truncated: boolean } {
   const safeReason = clipReason(args.reason);
   const render = (diff: string): string =>
-    `🛠 **Config edit proposed**\n` +
+    `${args.title ?? "🛠 **Config edit proposed**"}\n` +
     `Agent: \`${args.agentName}\`\n` +
     `Reason: ${escapeMarkdown(safeReason)}\n\n` +
     "```\n" + diff + "\n```";
@@ -297,6 +301,7 @@ export async function handleRequestConfigApproval(
     agentName: msg.agentName,
     reason: msg.reason,
     unifiedDiff: prelim,
+    ...(msg.title !== undefined ? { title: msg.title } : {}),
   });
   const body = built.body;
   // Oversize iff EITHER the cheap raw fast-path trimmed lines OR the

--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -207,13 +207,23 @@ export function buildConfigApprovalCardBody(args: {
   reason: string;
   unifiedDiff: string;
   /** Optional header override (KEN-129 — e.g. the update-check drift
-   *  card). Rendered verbatim as the first line; absent → the default
+   *  card). Rendered verbatim as the FIRST LINE (it carries intentional
+   *  markdown, so it is not escaped) — hence single-line only, enforced
+   *  at the IPC validator and re-enforced here; absent → the default
    *  config-edit header. */
   title?: string;
 }): { body: string; truncated: boolean } {
   const safeReason = clipReason(args.reason);
+  // Defence in depth against a forged card: a multi-line title could fake
+  // the `Agent:` / `Reason:` lines below it, or unbalance the diff's ```
+  // fence. `validateClientMessage` already rejects those, so this only ever
+  // fires for a direct caller that skipped the validator.
+  const safeTitle = args.title
+    ? // eslint-disable-next-line no-control-regex
+      args.title.replace(/[\u0000-\u001f\u007f]+/g, " ").slice(0, 200)
+    : undefined;
   const render = (diff: string): string =>
-    `${args.title ?? "🛠 **Config edit proposed**"}\n` +
+    `${safeTitle ?? "🛠 **Config edit proposed**"}\n` +
     `Agent: \`${args.agentName}\`\n` +
     `Reason: ${escapeMarkdown(safeReason)}\n\n` +
     "```\n" + diff + "\n```";

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -427,6 +427,11 @@ export interface RequestConfigApprovalMessage {
   unifiedDiff: string;
   /** Card timeout in milliseconds (gateway-enforced). */
   timeoutMs: number;
+  /**
+   * Optional card header override (KEN-129 — update-check drift card).
+   * Absent → the default "🛠 Config edit proposed" header. ≤200 chars.
+   */
+  title?: string;
 }
 
 /**

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -391,6 +391,12 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
       if (typeof m.timeoutMs !== "number"
         || !Number.isFinite(m.timeoutMs)
         || (m.timeoutMs as number) <= 0) return false;
+      // Optional header override (KEN-129) — absent falls back to the
+      // default config-edit header.
+      if (m.title !== undefined
+        && (typeof m.title !== "string"
+          || (m.title as string).length === 0
+          || (m.title as string).length > 200)) return false;
       return true;
     }
     case "request_config_finalize": {

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -392,11 +392,18 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
         || !Number.isFinite(m.timeoutMs)
         || (m.timeoutMs as number) <= 0) return false;
       // Optional header override (KEN-129) — absent falls back to the
-      // default config-edit header.
+      // default config-edit header. SINGLE LINE ONLY: the header renders
+      // VERBATIM as the card's first line (it carries intentional markdown,
+      // so it can't be escaped), which means a newline would let a caller
+      // forge the `Agent:` / `Reason:` lines beneath it — or unbalance the
+      // diff's ``` fence — on a card the operator is about to approve.
+      // Control characters are rejected for the same reason.
       if (m.title !== undefined
         && (typeof m.title !== "string"
           || (m.title as string).length === 0
-          || (m.title as string).length > 200)) return false;
+          || (m.title as string).length > 200
+          // eslint-disable-next-line no-control-regex
+          || /[\u0000-\u001f\u007f]/.test(m.title as string))) return false;
       return true;
     }
     case "request_config_finalize": {

--- a/telegram-plugin/tests/boot-probe-drift.test.ts
+++ b/telegram-plugin/tests/boot-probe-drift.test.ts
@@ -1,0 +1,111 @@
+/**
+ * KEN-130 — boot-card drift probe. Outcome-asserting: a staled stamped
+ * surface or a host-written drift report produces a degraded probe row
+ * naming the surfaces; a clean agent dir stays ok (silent-when-healthy —
+ * ok probes never render a boot-card row).
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { probeDrift } from '../gateway/boot-probes.js'
+import {
+  CLAUDE_MD_YOURS_MARKER,
+  computeConfigHash,
+  computeStampFilesFromDisk,
+  writeGenerationStamp,
+} from '../../src/agents/generation-stamp.js'
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'boot-drift-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function seedAndStamp(): void {
+  writeFileSync(join(dir, 'start.sh'), '#!/bin/bash\necho hi\n')
+  writeFileSync(
+    join(dir, 'CLAUDE.md'),
+    `# Agent\nmanaged\n\n${CLAUDE_MD_YOURS_MARKER}\n\nyours\n`,
+  )
+  writeFileSync(join(dir, '.mcp.json'), '{"mcpServers":{}}\n')
+  writeGenerationStamp(dir, {
+    switchroomVersion: '1.0.0',
+    configHash: computeConfigHash({ model: 'opus' }),
+    files: computeStampFilesFromDisk(dir),
+  })
+}
+
+describe('probeDrift', () => {
+  it('clean agent dir with stamp → ok (no boot-card row)', async () => {
+    seedAndStamp()
+    const r = await probeDrift(dir)
+    expect(r.status).toBe('ok')
+  })
+
+  it('no stamp and no report (fresh agent / pre-KEN-130) → ok', async () => {
+    const r = await probeDrift(dir)
+    expect(r.status).toBe('ok')
+  })
+
+  it('tampered start.sh → degraded row naming start.sh with a next step', async () => {
+    seedAndStamp()
+    writeFileSync(join(dir, 'start.sh'), '#!/bin/bash\nTAMPERED\n')
+    const r = await probeDrift(dir, { agentName: 'bot' })
+    expect(r.status).toBe('degraded')
+    expect(r.detail).toContain('start.sh')
+    expect(r.nextStep).toContain('switchroom apply')
+    expect(r.nextStep).toContain('reconcile bot')
+  })
+
+  it('operator edit BELOW the CLAUDE.md marker → still ok', async () => {
+    seedAndStamp()
+    writeFileSync(
+      join(dir, 'CLAUDE.md'),
+      `# Agent\nmanaged\n\n${CLAUDE_MD_YOURS_MARKER}\n\ncompletely new operator prose\n`,
+    )
+    const r = await probeDrift(dir)
+    expect(r.status).toBe('ok')
+  })
+
+  it('host drift report findings surface on the row (with age when stale)', async () => {
+    seedAndStamp()
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString()
+    writeFileSync(
+      join(dir, '.switchroom-drift.json'),
+      JSON.stringify({
+        version: 1,
+        generatedAt: twoDaysAgo,
+        findings: [
+          { surface: 'compose', detail: 'deployed compose differs' },
+          { surface: 'hook-scripts', detail: 'image scripts stale' },
+        ],
+      }),
+    )
+    const r = await probeDrift(dir)
+    expect(r.status).toBe('degraded')
+    expect(r.detail).toContain('compose')
+    expect(r.detail).toContain('hook-scripts')
+    expect(r.detail).toContain('ago') // stale-report age annotation
+  })
+
+  it('empty host report (doctor ran clean) → ok', async () => {
+    seedAndStamp()
+    writeFileSync(
+      join(dir, '.switchroom-drift.json'),
+      JSON.stringify({ version: 1, generatedAt: new Date().toISOString(), findings: [] }),
+    )
+    const r = await probeDrift(dir)
+    expect(r.status).toBe('ok')
+  })
+
+  it('corrupt report is ignored, never degrades the boot card', async () => {
+    seedAndStamp()
+    writeFileSync(join(dir, '.switchroom-drift.json'), 'not json at all')
+    const r = await probeDrift(dir)
+    expect(r.status).toBe('ok')
+  })
+})

--- a/telegram-plugin/tests/boot-probe-drift.test.ts
+++ b/telegram-plugin/tests/boot-probe-drift.test.ts
@@ -73,6 +73,15 @@ describe('probeDrift', () => {
 
   it('host drift report findings surface on the row (with age when stale)', async () => {
     seedAndStamp()
+    // Backdate the stamp so the report post-dates the last apply (a
+    // report older than the stamp is legitimately suppressed — see the
+    // superseded-by-apply test below).
+    writeGenerationStamp(dir, {
+      generatedAt: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+      switchroomVersion: '1.0.0',
+      configHash: computeConfigHash({ model: 'opus' }),
+      files: computeStampFilesFromDisk(dir),
+    })
     const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString()
     writeFileSync(
       join(dir, '.switchroom-drift.json'),
@@ -90,6 +99,38 @@ describe('probeDrift', () => {
     expect(r.detail).toContain('compose')
     expect(r.detail).toContain('hook-scripts')
     expect(r.detail).toContain('ago') // stale-report age annotation
+  })
+
+  it('report older than the stamp (apply healed it) → ok, findings suppressed', async () => {
+    // Doctor found drift, then the operator ran `switchroom apply` — the
+    // reconcile rewrote the stamp but NOT the doctor report. A freshly
+    // applied fleet must be silent; the stale report is superseded.
+    writeFileSync(
+      join(dir, '.switchroom-drift.json'),
+      JSON.stringify({
+        version: 1,
+        generatedAt: new Date(Date.now() - 3_600_000).toISOString(),
+        findings: [{ surface: 'compose', detail: 'was drifted before apply' }],
+      }),
+    )
+    seedAndStamp() // stamp written AFTER the report
+    const r = await probeDrift(dir)
+    expect(r.status).toBe('ok')
+  })
+
+  it('report newer than the stamp still surfaces (drift found after apply)', async () => {
+    seedAndStamp()
+    writeFileSync(
+      join(dir, '.switchroom-drift.json'),
+      JSON.stringify({
+        version: 1,
+        generatedAt: new Date(Date.now() + 1000).toISOString(),
+        findings: [{ surface: 'hook-scripts', detail: 'image scripts stale' }],
+      }),
+    )
+    const r = await probeDrift(dir)
+    expect(r.status).toBe('degraded')
+    expect(r.detail).toContain('hook-scripts')
   })
 
   it('empty host report (doctor ran clean) → ok', async () => {

--- a/telegram-plugin/tests/ipc-server-validate-config-approval.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-config-approval.test.ts
@@ -59,6 +59,28 @@ describe('validateClientMessage — request_config_approval', () => {
     expect(validateClientMessage({ ...base(), title: null })).toBe(false)
   })
 
+  // The title is rendered VERBATIM as the card's first line (it carries
+  // intentional markdown, so it cannot be escaped). A multi-line title
+  // would let a caller forge the `Agent:` / `Reason:` lines beneath it, or
+  // unbalance the diff's ``` fence, on a card the operator is about to
+  // approve. Newlines and control characters are therefore rejected.
+  it('rejects a multi-line title that could forge the card body', () => {
+    expect(
+      validateClientMessage({
+        ...base(),
+        title:
+          '🛠 **Config edit proposed**\nAgent: `root`\nReason: routine\n```\nnoop\n```',
+      }),
+    ).toBe(false)
+    expect(validateClientMessage({ ...base(), title: 'a\rb' })).toBe(false)
+  })
+
+  it('rejects control characters in the title', () => {
+    expect(validateClientMessage({ ...base(), title: 'a\u0000b' })).toBe(false)
+    expect(validateClientMessage({ ...base(), title: 'a\u001bb' })).toBe(false)
+    expect(validateClientMessage({ ...base(), title: 'a\u007fb' })).toBe(false)
+  })
+
   it('ignores extra unknown fields (forward-compat for future hostds)', () => {
     expect(
       validateClientMessage({ ...base(), someFutureField: 'ignored' }),

--- a/telegram-plugin/tests/ipc-server-validate-config-approval.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-config-approval.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Validation contract for the `request_config_approval` IPC message —
+ * hostd's approval-card request — with focus on the KEN-129 optional
+ * `title` header override.
+ *
+ * Mixed-version safety pins:
+ *   - `title` absent must validate (old hostd → new gateway).
+ *   - a valid `title` must validate (new hostd → new gateway).
+ *   - malformed titles (empty / oversize / non-string) are rejected —
+ *     the validator is the security boundary on the client→gateway
+ *     direction.
+ *
+ * (The reverse direction — new hostd → OLD gateway — is safe because
+ * the old validator checks only known fields' types and ignores extra
+ * keys; pinned by the "extra unknown fields" case below matching that
+ * permissive behaviour on the current validator too.)
+ *
+ * Companion to ipc-server-validate-{operator,inject-inbound}.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { validateClientMessage } from '../gateway/ipc-server.js'
+
+function base() {
+  return {
+    type: 'request_config_approval' as const,
+    requestId: 'relnotify-abc123',
+    agentName: 'klanker',
+    reason: 'fleet is behind',
+    unifiedDiff: 'plan text',
+    timeoutMs: 3_600_000,
+  }
+}
+
+describe('validateClientMessage — request_config_approval', () => {
+  it('accepts the base message without a title (old-hostd compat)', () => {
+    expect(validateClientMessage(base())).toBe(true)
+  })
+
+  it('accepts a valid title (KEN-129 update-check card)', () => {
+    expect(
+      validateClientMessage({
+        ...base(),
+        title: '⬆️ **Switchroom update available — fleet is behind**',
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects an empty title', () => {
+    expect(validateClientMessage({ ...base(), title: '' })).toBe(false)
+  })
+
+  it('rejects a title over 200 chars', () => {
+    expect(validateClientMessage({ ...base(), title: 'x'.repeat(201) })).toBe(false)
+  })
+
+  it('rejects a non-string title', () => {
+    expect(validateClientMessage({ ...base(), title: 42 })).toBe(false)
+    expect(validateClientMessage({ ...base(), title: null })).toBe(false)
+  })
+
+  it('ignores extra unknown fields (forward-compat for future hostds)', () => {
+    expect(
+      validateClientMessage({ ...base(), someFutureField: 'ignored' }),
+    ).toBe(true)
+  })
+
+  it('still rejects a malformed base message (missing diff)', () => {
+    const m: Record<string, unknown> = { ...base() }
+    delete m.unifiedDiff
+    expect(validateClientMessage(m)).toBe(false)
+  })
+})

--- a/tests/host-control/auto-rollout.test.ts
+++ b/tests/host-control/auto-rollout.test.ts
@@ -324,6 +324,47 @@ describe("startAutoRollout — latch durability across hostd restarts (KEN-131)"
   });
 });
 
+// A watcher-initiated roll has no caller agent, so the failure alert can only
+// reach the operator through a privileged agent's gateway relay. If that
+// lookup returns null the alert is DROPPED — an unattended rollback with no
+// human notified. Two ways that used to happen: a fleet whose sole privileged
+// agent is declared `root: true` (the newer tier) rather than `admin: true`,
+// and yaml key order deciding the target non-deterministically.
+describe("privileged-agent alert target resolution", () => {
+  function target(agents: Record<string, unknown>): string | null {
+    const dir = mkdtempSync(join(tmpdir(), "auto-rollout-admin-"));
+    const server = new HostdServer({
+      homeDir: dir,
+      agentUids: {},
+      config: { agents },
+      auditLogPath: join(dir, "audit.log"),
+      selfVersion: "v99.0.0",
+      allowNonLinux: true,
+    } as unknown as ServerOptions);
+    return (
+      server as unknown as { firstAdminAgentName: () => string | null }
+    ).firstAdminAgentName();
+  }
+
+  it("resolves an admin agent", () => {
+    expect(target({ plain: {}, overlord: { admin: true } })).toBe("overlord");
+  });
+
+  it("also accepts a root-tier agent (alert is not dropped on a root-only fleet)", () => {
+    expect(target({ plain: {}, boss: { root: true } })).toBe("boss");
+  });
+
+  it("is deterministic — name order, not yaml key order", () => {
+    expect(target({ zeta: { admin: true }, alpha: { admin: true } })).toBe("alpha");
+    expect(target({ alpha: { admin: true }, zeta: { admin: true } })).toBe("alpha");
+  });
+
+  it("returns null when no agent is privileged", () => {
+    expect(target({ a: {}, b: { admin: false } })).toBeNull();
+    expect(target({})).toBeNull();
+  });
+});
+
 describe("startAutoRollout — fleet-mutation lock", () => {
   it("refuses while a roll is already in flight", async () => {
     let release!: (r: RunResult) => void;

--- a/tests/host-control/auto-rollout.test.ts
+++ b/tests/host-control/auto-rollout.test.ts
@@ -1,0 +1,277 @@
+/**
+ * KEN-131 (stage 3 of KEN-128) — unattended auto-update rollout via
+ * HostdServer.startAutoRollout. Outcome-asserting tests:
+ *
+ *   - happy path: the watcher-initiated roll runs the staggered canary
+ *     rollout child, completes, releases the fleet-mutation lock, and
+ *     alerts the operator through the first ADMIN agent's gateway relay;
+ *   - canary failure HALTS: no further rollout, the failed pin is latched
+ *     (no unattended retry loop), compose is rolled back to the prior pin,
+ *     the canary is restarted back on it, and the operator gets an alert
+ *     card naming the failure + the rollback outcome;
+ *   - the fleet-mutation lock refuses a concurrent auto roll.
+ *
+ * Same private-method cast pattern as rollout-agent-validation.test.ts;
+ * `runSwitchroom` is stubbed so no child process ever spawns.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const loadConfigMock = vi.fn();
+vi.mock("../../src/config/loader.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/config/loader.js")
+  >("../../src/config/loader.js");
+  return {
+    ...actual,
+    loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+  };
+});
+
+const { HostdServer, isAutoRolloutRequestId, AUTO_ROLLOUT_REQUEST_PREFIX } =
+  await import("../../src/host-control/server.js");
+import type { ServerOptions } from "../../src/host-control/server.js";
+import { encodeRolloutResultLine } from "../../src/cli/rollout.js";
+import type { RolloutTerminalNotice } from "../../src/host-control/rollout-relay.js";
+
+type RunResult = { exit_code: number; stdout: string; stderr: string };
+
+interface Harness {
+  server: InstanceType<typeof HostdServer>;
+  calls: string[][];
+  posted: RolloutTerminalNotice[];
+  startAutoRollout: (
+    pin: string,
+  ) => Promise<{ started: boolean; request_id?: string; reason?: string }>;
+}
+
+/**
+ * Bare server with a stubbed `runSwitchroom`. `onRun` maps the spawned
+ * argv to a fake result; every invocation is recorded in `calls`.
+ */
+function makeServer(onRun: (args: string[]) => RunResult): Harness {
+  const posted: RolloutTerminalNotice[] = [];
+  const dir = mkdtempSync(join(tmpdir(), "auto-rollout-test-"));
+  const server = new HostdServer({
+    homeDir: dir,
+    agentUids: {},
+    config: {
+      // First ADMIN agent is "overlord" — the expected alert relay target
+      // for watcher-initiated rolls (which have no caller agent).
+      agents: { "test-harness": {}, overlord: { admin: true }, clerk: {} },
+    },
+    auditLogPath: join(dir, "audit.log"),
+    // High selfVersion so needsSelfBump never triggers in these tests.
+    selfVersion: "v99.0.0",
+    allowNonLinux: true,
+    rolloutRelay: {
+      postTerminal: (n) => {
+        posted.push(n);
+      },
+    },
+  } as unknown as ServerOptions);
+  const calls: string[][] = [];
+  const s = server as unknown as {
+    missingApplyAssets: () => string[];
+    runSwitchroom: (
+      args: string[],
+      env?: Record<string, string>,
+      onLine?: (l: string) => void,
+    ) => Promise<RunResult>;
+    startAutoRollout: Harness["startAutoRollout"];
+  };
+  s.missingApplyAssets = () => [];
+  s.runSwitchroom = async (args) => {
+    calls.push(args);
+    return onRun(args);
+  };
+  return {
+    server,
+    calls,
+    posted,
+    startAutoRollout: (pin) => s.startAutoRollout(pin),
+  };
+}
+
+const PRIOR_PIN = "v1.0.0";
+
+beforeEach(() => {
+  loadConfigMock.mockReset();
+  loadConfigMock.mockReturnValue({
+    agents: { "test-harness": {}, overlord: { admin: true }, clerk: {} },
+    release: { pin: PRIOR_PIN },
+  });
+});
+
+async function waitForTerminal(h: Harness): Promise<void> {
+  await vi.waitFor(() => {
+    expect(h.posted.length).toBeGreaterThan(0);
+  });
+}
+
+describe("startAutoRollout — happy path", () => {
+  it("runs the canary rollout child, completes, releases the lock, and alerts via the admin agent", async () => {
+    const h = makeServer((args) => {
+      expect(args.slice(0, 3)).toEqual(["rollout", "--pin", "v1.0.1"]);
+      return {
+        exit_code: 0,
+        stdout:
+          encodeRolloutResultLine({
+            ok: true,
+            rolled: ["test-harness", "overlord", "clerk"],
+            warnings: [],
+          }) + "\n",
+        stderr: "",
+      };
+    });
+    const r = await h.startAutoRollout("v1.0.1");
+    expect(r.started).toBe(true);
+    expect(r.request_id).toMatch(new RegExp(`^${AUTO_ROLLOUT_REQUEST_PREFIX}`));
+    expect(isAutoRolloutRequestId(r.request_id!)).toBe(true);
+    await waitForTerminal(h);
+    // Exactly ONE child spawned — the rollout itself; no recovery commands.
+    expect(h.calls).toHaveLength(1);
+    // Alert routed via the FIRST ADMIN agent (no caller agent exists).
+    expect(h.posted[0]!.agentName).toBe("overlord");
+    expect(h.posted[0]!.requestId).toBe(r.request_id);
+    // Lock released: a follow-up auto roll to a newer pin starts cleanly.
+    const again = await h.startAutoRollout("v1.0.2");
+    expect(again.started).toBe(true);
+  });
+});
+
+describe("startAutoRollout — canary failure halts (hardened no-operator path)", () => {
+  function failingHarness(): Harness {
+    return makeServer((args) => {
+      if (args[0] === "rollout") {
+        return {
+          exit_code: 1,
+          stdout:
+            encodeRolloutResultLine({
+              ok: false,
+              rolled: [],
+              failedStep: "restart-agent",
+              failedAgent: "test-harness",
+              got: null,
+              warnings: [],
+            }) + "\n",
+          stderr: "",
+        };
+      }
+      // Recovery commands (apply / agent restart) succeed.
+      return { exit_code: 0, stdout: "", stderr: "" };
+    });
+  }
+
+  it("rolls compose back to the prior pin, restarts the canary on it, and alerts", async () => {
+    const h = failingHarness();
+    const r = await h.startAutoRollout("v1.0.1");
+    expect(r.started).toBe(true);
+    await waitForTerminal(h);
+    // Recovery: compose restore + canary restart back on the PRIOR pin.
+    expect(h.calls).toContainEqual([
+      "apply",
+      "--pin",
+      PRIOR_PIN,
+      "--compose-only",
+      "--non-interactive",
+    ]);
+    expect(h.calls).toContainEqual([
+      "agent",
+      "restart",
+      "test-harness",
+      "--wait",
+      "--force",
+      "--pin",
+      PRIOR_PIN,
+    ]);
+    // Alert card: routed via the admin agent, naming failure + rollback.
+    expect(h.posted[0]!.agentName).toBe("overlord");
+    expect(h.posted[0]!.text).toMatch(/FAILED/);
+    expect(h.posted[0]!.text).toMatch(/compose restored to v1\.0\.0/);
+    expect(h.posted[0]!.text).toMatch(/test-harness restarted back on v1\.0\.0/);
+  });
+
+  it("latches the failed pin — the SAME version is never retried unattended, a NEWER one is", async () => {
+    const h = failingHarness();
+    await h.startAutoRollout("v1.0.1");
+    await waitForTerminal(h);
+    const retry = await h.startAutoRollout("v1.0.1");
+    expect(retry.started).toBe(false);
+    expect(retry.reason).toMatch(/FAILED/);
+    // No second rollout child was spawned for the retry.
+    expect(h.calls.filter((c) => c[0] === "rollout")).toHaveLength(1);
+    // A newer release supersedes the latch.
+    const newer = await h.startAutoRollout("v1.0.2");
+    expect(newer.started).toBe(true);
+  });
+
+  it("does NOT auto-roll-back past a green canary (mixed fleet is alerted, not mass-reverted)", async () => {
+    const h = makeServer((args) => {
+      if (args[0] === "rollout") {
+        return {
+          exit_code: 1,
+          stdout:
+            encodeRolloutResultLine({
+              ok: false,
+              rolled: ["test-harness"],
+              failedStep: "restart-agent",
+              failedAgent: "clerk",
+              got: "1.0.0",
+              warnings: [],
+            }) + "\n",
+          stderr: "",
+        };
+      }
+      return { exit_code: 0, stdout: "", stderr: "" };
+    });
+    await h.startAutoRollout("v1.0.1");
+    await waitForTerminal(h);
+    // Only the rollout child ran — no apply / restart recovery spawns.
+    expect(h.calls).toHaveLength(1);
+    expect(h.posted[0]!.text).toMatch(/No automatic rollback/);
+  });
+});
+
+describe("startAutoRollout — fleet-mutation lock", () => {
+  it("refuses while a roll is already in flight", async () => {
+    let release!: (r: RunResult) => void;
+    const pending = new Promise<RunResult>((res) => {
+      release = res;
+    });
+    const posted: RolloutTerminalNotice[] = [];
+    const dir = mkdtempSync(join(tmpdir(), "auto-rollout-lock-"));
+    const server = new HostdServer({
+      homeDir: dir,
+      agentUids: {},
+      config: { agents: { overlord: { admin: true } } },
+      auditLogPath: join(dir, "audit.log"),
+      selfVersion: "v99.0.0",
+      allowNonLinux: true,
+      rolloutRelay: { postTerminal: (n: RolloutTerminalNotice) => posted.push(n) },
+    } as unknown as ServerOptions);
+    const s = server as unknown as {
+      missingApplyAssets: () => string[];
+      runSwitchroom: () => Promise<RunResult>;
+      startAutoRollout: Harness["startAutoRollout"];
+    };
+    s.missingApplyAssets = () => [];
+    s.runSwitchroom = () => pending;
+    const first = await s.startAutoRollout("v1.0.1");
+    expect(first.started).toBe(true);
+    const second = await s.startAutoRollout("v1.0.2");
+    expect(second.started).toBe(false);
+    expect(second.reason).toMatch(/fleet-mutation lock/);
+    release({
+      exit_code: 0,
+      stdout: encodeRolloutResultLine({ ok: true, rolled: [], warnings: [] }) + "\n",
+      stderr: "",
+    });
+    await vi.waitFor(() => {
+      expect(posted.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/host-control/auto-rollout.test.ts
+++ b/tests/host-control/auto-rollout.test.ts
@@ -52,9 +52,12 @@ interface Harness {
  * Bare server with a stubbed `runSwitchroom`. `onRun` maps the spawned
  * argv to a fake result; every invocation is recorded in `calls`.
  */
-function makeServer(onRun: (args: string[]) => RunResult): Harness {
+function makeServer(
+  onRun: (args: string[]) => RunResult,
+  homeDir?: string,
+): Harness {
   const posted: RolloutTerminalNotice[] = [];
-  const dir = mkdtempSync(join(tmpdir(), "auto-rollout-test-"));
+  const dir = homeDir ?? mkdtempSync(join(tmpdir(), "auto-rollout-test-"));
   const server = new HostdServer({
     homeDir: dir,
     agentUids: {},
@@ -233,6 +236,91 @@ describe("startAutoRollout — canary failure halts (hardened no-operator path)"
     // Only the rollout child ran — no apply / restart recovery spawns.
     expect(h.calls).toHaveLength(1);
     expect(h.posted[0]!.text).toMatch(/No automatic rollback/);
+  });
+});
+
+describe("startAutoRollout — latch durability across hostd restarts (KEN-131)", () => {
+  // hostd restarts are ROUTINE on the auto-update path (the self-bump
+  // recreates hostd's own container on essentially every roll; crash-loops
+  // and host reboots also clear process memory). These tests construct a
+  // SECOND HostdServer over the same home dir — the "restarted daemon" —
+  // and assert the failed-pin latch still refuses an unattended retry.
+  // With an in-memory-only latch each of these would retry the broken
+  // pin, bouncing the canary forever with no operator in the loop.
+
+  function failingRun(args: string[]): RunResult {
+    if (args[0] === "rollout") {
+      return {
+        exit_code: 1,
+        stdout:
+          encodeRolloutResultLine({
+            ok: false,
+            rolled: [],
+            failedStep: "restart-agent",
+            failedAgent: "test-harness",
+            got: null,
+            warnings: [],
+          }) + "\n",
+        stderr: "",
+      };
+    }
+    return { exit_code: 0, stdout: "", stderr: "" };
+  }
+
+  it("a FAILED pin is refused by a fresh daemon (restart does not clear the latch)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "auto-rollout-restart-"));
+    const h1 = makeServer(failingRun, dir);
+    await h1.startAutoRollout("v1.0.1");
+    await waitForTerminal(h1);
+    // "Restart": brand-new server instance, same home dir, empty memory.
+    const h2 = makeServer(failingRun, dir);
+    const retry = await h2.startAutoRollout("v1.0.1");
+    expect(retry.started).toBe(false);
+    expect(retry.reason).toMatch(/FAILED/);
+    expect(h2.calls.filter((c) => c[0] === "rollout")).toHaveLength(0);
+    // A NEWER release still supersedes the durable latch after restart.
+    const newer = await h2.startAutoRollout("v1.0.2");
+    expect(newer.started).toBe(true);
+  });
+
+  it("a roll interrupted WITHOUT a terminal row (hostd killed mid-roll) is not retried after restart", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "auto-rollout-crash-"));
+    // Roll child never resolves — simulates hostd dying mid-canary (no
+    // terminal handler ever runs, only the launch-time latch exists).
+    const h1 = makeServer(failingRun, dir);
+    (h1.server as unknown as { runSwitchroom: () => Promise<RunResult> }).runSwitchroom =
+      () => new Promise<RunResult>(() => {});
+    const first = await h1.startAutoRollout("v1.0.1");
+    expect(first.started).toBe(true);
+    const h2 = makeServer(failingRun, dir);
+    const retry = await h2.startAutoRollout("v1.0.1");
+    expect(retry.started).toBe(false);
+    expect(retry.reason).toMatch(/did not complete/);
+    expect(h2.calls).toHaveLength(0);
+  });
+
+  it("a GREEN roll clears the durable latch (next daemon can roll again)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "auto-rollout-green-"));
+    const green = (args: string[]): RunResult => ({
+      exit_code: 0,
+      stdout:
+        args[0] === "rollout"
+          ? encodeRolloutResultLine({
+              ok: true,
+              rolled: ["test-harness", "overlord", "clerk"],
+              warnings: [],
+            }) + "\n"
+          : "",
+      stderr: "",
+    });
+    const h1 = makeServer(green, dir);
+    await h1.startAutoRollout("v1.0.1");
+    await waitForTerminal(h1);
+    const h2 = makeServer(green, dir);
+    // Same pin again from a fresh daemon: no latch left behind, so the
+    // roll STARTS (the version-compare quiesce lives upstream in checkFn).
+    const again = await h2.startAutoRollout("v1.0.1");
+    expect(again.started).toBe(true);
   });
 });
 

--- a/tests/host-control/auto-update-check.test.ts
+++ b/tests/host-control/auto-update-check.test.ts
@@ -16,17 +16,22 @@ const IMAGE = "ghcr.io/switchroom/switchroom-agent:latest";
 function makeCheck(opts: {
   latest?: string;
   pin?: string | undefined;
+  channel?: string | undefined;
+  latchedPin?: string | null;
   imageExists?: boolean;
 }) {
   const imageExists = vi.fn(async () => opts.imageExists ?? true);
+  const logs: string[] = [];
   const check = makeAutoUpdateCheck({
     imageRef: IMAGE,
     getCurrentPin: () => opts.pin,
+    getCurrentChannel: () => opts.channel,
+    getLatchedPin: () => opts.latchedPin ?? null,
     fetchLatestVersion: async () => opts.latest ?? "1.2.3",
     imageExists,
-    log: () => {},
+    log: (m) => logs.push(m),
   });
-  return { check, imageExists };
+  return { check, imageExists, logs };
 }
 
 describe("versionedImageRef", () => {
@@ -87,6 +92,76 @@ describe("makeAutoUpdateCheck", () => {
     const { check, imageExists } = makeCheck({ latest: "1.2.3", pin: "v1.2.3" });
     await check();
     expect(imageExists).not.toHaveBeenCalled();
+  });
+
+  // Persisting a pin DELETES release.channel (schema mutual exclusion), so
+  // an unattended roll on a dev/rc fleet would silently move it to stable
+  // AND erase the operator's channel choice. Suppress instead.
+  it("never rolls unattended while a non-latest release.channel is set", async () => {
+    for (const channel of ["dev", "rc"]) {
+      const { check, imageExists } = makeCheck({
+        latest: "1.2.3",
+        pin: undefined,
+        channel,
+      });
+      await expect(check()).resolves.toEqual({
+        available: false,
+        version: "v1.2.3",
+      });
+      expect(imageExists).not.toHaveBeenCalled();
+    }
+  });
+
+  it("channel: latest does not suppress (it is what the auto-update path tracks)", async () => {
+    const { check } = makeCheck({
+      latest: "1.2.3",
+      pin: undefined,
+      channel: "latest",
+    });
+    await expect(check()).resolves.toEqual({
+      available: true,
+      version: "v1.2.3",
+    });
+  });
+
+  // Without this the pin never advances after a failed roll, so every tick
+  // re-reports "available", re-enters applyFn, is refused by the latch, and
+  // appends another apply_failed telemetry row — forever.
+  it("does not re-report a LATCHED failed version as available", async () => {
+    const { check, imageExists } = makeCheck({
+      latest: "1.2.3",
+      pin: "v1.2.2",
+      latchedPin: "v1.2.3",
+    });
+    await expect(check()).resolves.toEqual({
+      available: false,
+      version: "v1.2.3",
+    });
+    expect(imageExists).not.toHaveBeenCalled();
+  });
+
+  it("a latch on an OLDER version does not block a newer release", async () => {
+    const { check } = makeCheck({
+      latest: "1.2.4",
+      pin: "v1.2.2",
+      latchedPin: "v1.2.3",
+    });
+    await expect(check()).resolves.toEqual({
+      available: true,
+      version: "v1.2.4",
+    });
+  });
+
+  it("logs an indefinite suppression reason ONCE, not on every tick", async () => {
+    const { check, logs } = makeCheck({
+      latest: "1.2.3",
+      pin: undefined,
+      channel: "dev",
+    });
+    await check();
+    await check();
+    await check();
+    expect(logs.filter((m) => m.includes("release.channel"))).toHaveLength(1);
   });
 
   it("propagates a fetch failure (watcher surfaces it as check_failed)", async () => {

--- a/tests/host-control/auto-update-check.test.ts
+++ b/tests/host-control/auto-update-check.test.ts
@@ -1,0 +1,141 @@
+/**
+ * KEN-131 (stage 3 of KEN-128) — auto-update release check + watcher-mode
+ * resolution. Pure decision logic with stubbed fetch / config / image
+ * probes; no docker, no network.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  makeAutoUpdateCheck,
+  resolveReleaseWatcherMode,
+  versionedImageRef,
+} from "../../src/host-control/auto-update-check.js";
+
+const IMAGE = "ghcr.io/switchroom/switchroom-agent:latest";
+
+function makeCheck(opts: {
+  latest?: string;
+  pin?: string | undefined;
+  imageExists?: boolean;
+}) {
+  const imageExists = vi.fn(async () => opts.imageExists ?? true);
+  const check = makeAutoUpdateCheck({
+    imageRef: IMAGE,
+    getCurrentPin: () => opts.pin,
+    fetchLatestVersion: async () => opts.latest ?? "1.2.3",
+    imageExists,
+    log: () => {},
+  });
+  return { check, imageExists };
+}
+
+describe("versionedImageRef", () => {
+  it("replaces the tag", () => {
+    expect(versionedImageRef(IMAGE, "v1.2.3")).toBe(
+      "ghcr.io/switchroom/switchroom-agent:v1.2.3",
+    );
+  });
+  it("appends when no tag present", () => {
+    expect(versionedImageRef("ghcr.io/x/y", "v1.2.3")).toBe("ghcr.io/x/y:v1.2.3");
+  });
+  it("does not mistake a registry port for a tag", () => {
+    expect(versionedImageRef("reg.local:5000/x/y:latest", "v9.9.9")).toBe(
+      "reg.local:5000/x/y:v9.9.9",
+    );
+  });
+});
+
+describe("makeAutoUpdateCheck", () => {
+  it("reports available with the vX.Y.Z target when latest is newer than the pin", async () => {
+    const { check } = makeCheck({ latest: "1.2.3", pin: "v1.2.2" });
+    await expect(check()).resolves.toEqual({ available: true, version: "v1.2.3" });
+  });
+
+  it("is NOT available when the pin already equals latest (quiesces after a green roll)", async () => {
+    const { check } = makeCheck({ latest: "1.2.3", pin: "v1.2.3" });
+    await expect(check()).resolves.toMatchObject({ available: false });
+  });
+
+  it("is NOT available on a downgrade (pin newer than published)", async () => {
+    const { check } = makeCheck({ latest: "1.2.3", pin: "v1.3.0" });
+    await expect(check()).resolves.toMatchObject({ available: false });
+  });
+
+  it("never fights an explicit non-semver (sha) pin", async () => {
+    const { check } = makeCheck({ latest: "1.2.3", pin: "sha-abcdef1" });
+    await expect(check()).resolves.toMatchObject({ available: false });
+  });
+
+  it("bootstraps when no pin exists yet", async () => {
+    const { check } = makeCheck({ latest: "1.2.3", pin: undefined });
+    await expect(check()).resolves.toEqual({ available: true, version: "v1.2.3" });
+  });
+
+  it("defers when the vX.Y.Z image is not pullable yet (publish beat the image build)", async () => {
+    const { check, imageExists } = makeCheck({
+      latest: "1.2.3",
+      pin: "v1.2.2",
+      imageExists: false,
+    });
+    await expect(check()).resolves.toMatchObject({ available: false });
+    expect(imageExists).toHaveBeenCalledWith(
+      "ghcr.io/switchroom/switchroom-agent:v1.2.3",
+    );
+  });
+
+  it("does not even probe the image when nothing is newer", async () => {
+    const { check, imageExists } = makeCheck({ latest: "1.2.3", pin: "v1.2.3" });
+    await check();
+    expect(imageExists).not.toHaveBeenCalled();
+  });
+
+  it("propagates a fetch failure (watcher surfaces it as check_failed)", async () => {
+    const check = makeAutoUpdateCheck({
+      imageRef: IMAGE,
+      getCurrentPin: () => "v1.0.0",
+      fetchLatestVersion: async () => {
+        throw new Error("registry down");
+      },
+      imageExists: async () => true,
+    });
+    await expect(check()).rejects.toThrow("registry down");
+  });
+});
+
+describe("resolveReleaseWatcherMode", () => {
+  it("is OFF by default — no release block, no host_control block", () => {
+    expect(resolveReleaseWatcherMode({})).toEqual({ mode: "off" });
+  });
+
+  it("is OFF with a release block that does not set auto_update (default-off, behaviour unchanged)", () => {
+    expect(
+      resolveReleaseWatcherMode({ release: { pin: "v1.2.3" } as never }),
+    ).toEqual({ mode: "off" });
+    expect(
+      resolveReleaseWatcherMode({ release: { auto_update: false } }),
+    ).toEqual({ mode: "off" });
+  });
+
+  it("selects auto_update when release.auto_update is true", () => {
+    expect(
+      resolveReleaseWatcherMode({ release: { auto_update: true } }),
+    ).toEqual({ mode: "auto_update" });
+  });
+
+  it("keeps the legacy #1743 watcher when only auto_release_check is enabled", () => {
+    expect(
+      resolveReleaseWatcherMode({
+        host_control: { auto_release_check: { enabled: true } },
+      }),
+    ).toEqual({ mode: "legacy" });
+  });
+
+  it("auto_update wins when both knobs are set (safer pipeline)", () => {
+    expect(
+      resolveReleaseWatcherMode({
+        release: { auto_update: true },
+        host_control: { auto_release_check: { enabled: true } },
+      }),
+    ).toEqual({ mode: "auto_update" });
+  });
+});

--- a/tests/host-control/release-watcher.test.ts
+++ b/tests/host-control/release-watcher.test.ts
@@ -179,3 +179,31 @@ describe("ReleaseWatcher", () => {
     w.stop();
   });
 });
+
+describe("ReleaseWatcher — applyFn receives the check's version (KEN-131)", () => {
+  it("passes the detected version through so the auto-update path can pin the rollout", async () => {
+    const applyFn = vi.fn().mockResolvedValue(undefined);
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: true, version: "v1.2.3" }),
+      applyFn,
+      restartFn: vi.fn().mockResolvedValue(undefined),
+      applyOnDetect: true,
+    });
+    await w.tick();
+    expect(applyFn).toHaveBeenCalledWith("v1.2.3");
+  });
+
+  it("passes undefined when the check reports no version (legacy digest path unchanged)", async () => {
+    const applyFn = vi.fn().mockResolvedValue(undefined);
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: true }),
+      applyFn,
+      restartFn: vi.fn().mockResolvedValue(undefined),
+      applyOnDetect: true,
+    });
+    await w.tick();
+    expect(applyFn).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/tests/host-control/release-watcher.test.ts
+++ b/tests/host-control/release-watcher.test.ts
@@ -178,4 +178,73 @@ describe("ReleaseWatcher", () => {
     expect(checkFn).not.toHaveBeenCalled();
     w.stop();
   });
+
+  // KEN-129 — notifyFn hook (update-check drift card).
+
+  it("calls notifyFn with the release id when applyOnDetect=false", async () => {
+    const applyFn = vi.fn();
+    const restartFn = vi.fn();
+    const notifyFn = vi.fn().mockResolvedValue(undefined);
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: true, version: "sha256:abc" }),
+      applyFn,
+      restartFn,
+      applyOnDetect: false,
+      notifyFn,
+    });
+    await w.tick();
+    expect(notifyFn).toHaveBeenCalledTimes(1);
+    expect(notifyFn).toHaveBeenCalledWith("sha256:abc");
+    expect(applyFn).not.toHaveBeenCalled();
+    expect(restartFn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call notifyFn when no release is available", async () => {
+    const notifyFn = vi.fn();
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: false }),
+      applyFn: vi.fn(),
+      restartFn: vi.fn(),
+      applyOnDetect: false,
+      notifyFn,
+    });
+    await w.tick();
+    expect(notifyFn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call notifyFn when applyOnDetect=true (auto-apply supersedes notify)", async () => {
+    const notifyFn = vi.fn();
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: true, version: "sha256:abc" }),
+      applyFn: vi.fn().mockResolvedValue(undefined),
+      restartFn: vi.fn().mockResolvedValue(undefined),
+      applyOnDetect: true,
+      notifyFn,
+    });
+    await w.tick();
+    expect(notifyFn).not.toHaveBeenCalled();
+  });
+
+  it("a throwing notifyFn is logged and does not break the tick (next tick still runs)", async () => {
+    const notifyFn = vi.fn().mockRejectedValue(new Error("card exploded"));
+    const logs: string[] = [];
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: true, version: "sha256:abc" }),
+      applyFn: vi.fn(),
+      restartFn: vi.fn(),
+      applyOnDetect: false,
+      notifyFn,
+      log: (m) => logs.push(m),
+    });
+    await w.tick();
+    await w.tick();
+    expect(notifyFn).toHaveBeenCalledTimes(2);
+    expect(
+      logs.some((m) => m.includes("notify_failed") && m.includes("card exploded")),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
Integration of three reviewed branches for the auto-reconcile epic (KEN-128), each based on `origin/main@75114a8a` and merged 130 → 129 → 131.

## Per-branch summary

### KEN-130 — drift detection (`feat/ken-130-drift-detection`, 09111ff6)
- All-surface drift detection with a generation stamp (`src/agents/generation-stamp.ts`)
- `switchroom doctor` warn-only drift section (`src/cli/doctor-drift.ts`) + boot-probe wiring (`telegram-plugin/tests/boot-probe-drift.test.ts`)
- Build-local skip and stamp-chronology suppression to kill false positives (adversarial-review fixes in 09111ff6)

### KEN-129 — update-check approval card (`feat/ken-129-update-check-card`, b9a321c8)
- `UpdateNotifier` (`src/host-control/update-notifier.ts`): operator-in-the-loop card when a new release is detected and `notify_on_detect` is on
- IPC `title` field, durable dedup + pending-card suppression, fleet-lock TOCTOU recheck, audit row, finalize detail clipping (review fixes in b9a321c8)

### KEN-131 — auto-update (`feat/ken-131-auto-update`, 4f3072f2)
- Root-only `release.auto_update` config; canary-gated unattended rollout via `server.startAutoRollout`
- Durable `auto-rollout-latch.json` failed-pin latch + resume-failure latching (review fix in 4f3072f2)

## Merge conflicts & resolution

Only `src/host-control/main.ts` conflicted (129 vs 131 release-watcher wiring). Resolved semantically, not textually: `resolveReleaseWatcherMode` (131) picks the mode — `auto_update` wins and uses the canary rollout path; the `legacy` branch keeps 129's notifier wiring (card only when `!apply_on_detect && notify_on_detect`); default remains off. `server.ts` auto-merged cleanly keeping both `startOperatorApprovedUpdateApply` (129) and `startAutoRollout`/latch logic (131); `tests/host-control/release-watcher.test.ts` auto-merged keeping both suites.

## Test evidence (combined tree)

- `tests/host-control/*` + `src/host-control/*` + drift tests: 453 passed, 1 skipped; 49 failures in `server.test.ts`/`config-propose-edit-idempotency.test.ts` are byte-identical to the pristine `origin/main@75114a8a` baseline in this sandbox (EROFS mkdtemp `/var/tmp`) — environmental, not merge regressions.
- `release-watcher` / `update-notifier` / `auto-update-check` / `generation-stamp` / `doctor-drift`: 54/54 passed.
- telegram-plugin scoped (ipc-server-validate-config-approval, boot-probe-drift, boot-card-*, config-approval-handler): 143/143 vitest + 93/93 bun test.
- `npm run lint` (tsc + all guard scripts): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
