### PR TITLE
chore: remove deployment-identifying litellm config path from tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,11 +146,15 @@ Traps that bite repeatedly:
 - **`check-litellm-config-guard` SKIPS off-host** — the operator-maintained
   LiteLLM config path comes from `LITELLM_CONFIG_PATH` (no hard-coded
   default — the real path embeds a deployment-identifying Coolify service
-  id), which is unset in CI/dev, so the lint step is a near-vacuous belt. The load-bearing
-  I2 OAuth-leak enforcement is the fleet-health sensor
+  id), which is unset in CI/dev, so the lint step is a near-vacuous belt. The
+  load-bearing I2 OAuth-leak enforcement is the fleet-health sensor
   (`src/fleet-health/litellm-config-sensor.ts`), which runs where the file
-  lives and escalates a violation into the priority ledger. Point
-  `LITELLM_CONFIG_PATH` at a real config to exercise the lint locally.
+  lives and escalates a violation into the priority ledger. That sensor takes
+  its path from **`fleet_health.litellm_config_path` in the host-local
+  `switchroom.yaml`** (env `LITELLM_CONFIG_PATH` as the fallback) — set the
+  config field on the host, or the sensor logs `SKIPPED — no config path` and
+  the check does not run. Point `LITELLM_CONFIG_PATH` at a real config to
+  exercise the lint locally.
 
 ### Secrets in tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,9 @@ Traps that bite repeatedly:
   ranges in the same PR. New Telegram API calls go through
   `retryApiCall`/`robustApiCall`, not raw.
 - **`check-litellm-config-guard` SKIPS off-host** — the operator-maintained
-  LiteLLM config (default `/data/coolify/services/…/litellm-config.yaml`) is
-  absent in CI/dev, so the lint step is a near-vacuous belt. The load-bearing
+  LiteLLM config path comes from `LITELLM_CONFIG_PATH` (no hard-coded
+  default — the real path embeds a deployment-identifying Coolify service
+  id), which is unset in CI/dev, so the lint step is a near-vacuous belt. The load-bearing
   I2 OAuth-leak enforcement is the fleet-health sensor
   (`src/fleet-health/litellm-config-sensor.ts`), which runs where the file
   lives and escalates a violation into the priority ledger. Point

--- a/docker/litellm-pacer/README.md
+++ b/docker/litellm-pacer/README.md
@@ -28,7 +28,7 @@ back-ported.
 The live copy is bind-mounted into the LiteLLM proxy container:
 
 ```
-host:  /host/data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/custom_pacing.py
+host:  /host/data/coolify/services/<litellm-service-id>/custom_pacing.py
        (Coolify service dir; from inside this repo's root agent it is
         /host/data/... , on the raw host /data/coolify/services/...)
 container: /app/custom_pacing.py   (the config dir is on the proxy's sys.path)
@@ -45,7 +45,7 @@ Bind mount in the sibling `docker-compose.yml`:
 
 ```yaml
 volumes:
-  - '/data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/custom_pacing.py:/app/custom_pacing.py'
+  - '/data/coolify/services/<litellm-service-id>/custom_pacing.py:/app/custom_pacing.py'
 ```
 
 ## Code defaults vs. live env overrides
@@ -120,7 +120,7 @@ After changing `custom_pacing.py` here (and getting it merged):
 1. Copy the vendored file to the host deploy path:
    ```
    cp docker/litellm-pacer/custom_pacing.py \
-      /data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/custom_pacing.py
+      /data/coolify/services/<litellm-service-id>/custom_pacing.py
    ```
    (Keep a timestamped `.bak` first, matching the existing host convention.)
 2. **Redeploy / restart the LiteLLM service** so the proxy re-imports the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1086,13 +1086,13 @@ page (design: [`reference/rfcs/fleet-health.md`](../reference/rfcs/fleet-health.
 serves the job spec `fleet-stays-healthy`).
 
 It is **top-level and operator-owned** — not part of the per-agent
-`defaults → profiles → agents` cascade. The one field assigns WHICH agent
-owns the detection work, so every scan and deep-dive is attributable and
-on-leash.
+`defaults → profiles → agents` cascade. `owner_agent` assigns WHICH agent owns
+the detection work, so every scan and deep-dive is attributable and on-leash.
 
 | Field | Cascade | Description |
 |-------|---------|-------------|
 | `fleet_health.owner_agent` | override (top-level only) | The admin agent that runs the nightly model-free sensor + weekly budgeted deep-dive that populate `~/.switchroom/fleet-health/ledger.json`. Default **unset** → the feature is inert: no crons scheduled, the admin page renders its empty state. The named agent must be `admin: true`. A dedicated owner (not any admin) keeps the fleet-health memory scoped and the token spend accountable. The detection runs **only** as operator-set schedules on this agent — never a self-authored loop. |
+| `fleet_health.litellm_config_path` | override (top-level only) | Absolute path to the operator-maintained LiteLLM proxy config that the I2 header-passthrough sensor reads. It is operator-supplied because the real path embeds a deployment-identifying Coolify service id, which must not live in the public repo. Precedence: this field → `LITELLM_CONFIG_PATH` env → **unset**, in which case the sensor logs `SKIPPED — no config path` and the OAuth-leak check does not run (the expected state in CI/dev). Set it on any host running a real LiteLLM proxy. |
 
 The ledger at `~/.switchroom/fleet-health/ledger.json` is per-deployment state
 written by the owner agent; it is **never committed to the repo** (same rule
@@ -1103,6 +1103,9 @@ read-only and ranks the 22 job records worst-first by `priority_score`
 ```yaml
 fleet_health:
   owner_agent: klanker   # admin: true; runs the sensor + deep-dive crons
+  # Host-local path to the live LiteLLM proxy config (I2 OAuth-leak sensor).
+  # Omit off-host; the sensor then skips with a visible notice.
+  litellm_config_path: /data/coolify/services/<litellm-service-id>/litellm-config.yaml
 ```
 
 The live detection pipeline (the `switchroom fleet-health` CLI, the scoring, the

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -52,7 +52,7 @@ These must always hold.
   **This scoping is enforced by convention in the operator-maintained LiteLLM
   proxy config, not by any switchroom code.** That config is a Coolify-hosted
   file at
-  `/host/data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/litellm-config.yaml`;
+  `/host/data/coolify/services/<litellm-service-id>/litellm-config.yaml`;
   switchroom emits **no** `litellm_settings` or `model_list` (grep the tree —
   the only occurrences are documentation comments), so it neither writes nor
   validates this flag. The operator places
@@ -276,7 +276,7 @@ inspected to confirm the routing env. That check verified non-Claude models
 OpenRouter through LiteLLM** — `api.anthropic.com` cannot serve
 `gpt-oss-120b`, so a successful response to that model is proof the request
 did not touch the Anthropic subscription endpoint. The live LiteLLM config
-(`/host/data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/litellm-config.yaml`)
+(`/host/data/coolify/services/<litellm-service-id>/litellm-config.yaml`)
 and Hindsight's live container env (`ANTHROPIC_BASE_URL=http://127.0.0.1:4010`,
 global model `openrouter/z-ai/glm-5.2`) were also read directly for the I2 and
 Hindsight-credential claims above.

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -69,6 +69,12 @@ These must always hold.
   OpenRouter/OpenAI entry, and the config's own comments warn against the
   global form — but I2 holds **only** as long as that operator convention is
   maintained. It is not automatically guaranteed.
+  The service id above is deliberately a `<litellm-service-id>` placeholder —
+  it identifies a live deployment and does not belong in a public repo. The
+  fleet-health sensor that checks the live file gets the real path from
+  `fleet_health.litellm_config_path` in the host-local `switchroom.yaml` (or
+  the `LITELLM_CONFIG_PATH` env); with neither set it logs
+  `SKIPPED — no config path` and the check does not run.
 - **I3 — The auth broker owns OAuth.** The `switchroom-auth-broker` singleton
   is the sole writer of every consumer's `.claude/credentials.json` (agents and
   Hindsight alike) and owns the refresh loop; this is what enables account

--- a/scripts/check-litellm-config-guard.mjs
+++ b/scripts/check-litellm-config-guard.mjs
@@ -14,8 +14,8 @@
  * Coolify), so this scoping had zero code enforcement.
  *
  * IMPORTANT — this lint step is a cheap belt, NOT the load-bearing check. The
- * config file lives on the switchroom host (default
- * `/data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/litellm-config.yaml`) and is
+ * config file lives on the switchroom host (e.g.
+ * `/data/coolify/services/<litellm-service-id>/litellm-config.yaml`) and is
  * absent in CI/dev, where this guard SKIPS with a visible notice. The
  * load-bearing enforcement is the fleet-health sensor
  * (`src/fleet-health/litellm-config-sensor.ts`), which runs where the file
@@ -31,7 +31,8 @@
  * with no `fallbacks` chain (the broker owns failover — see model-routing.md
  * Known Gaps).
  *
- * Override the path with `LITELLM_CONFIG_PATH`.
+ * The path comes from `LITELLM_CONFIG_PATH` (no hard-coded default — the real
+ * path embeds a deployment-identifying Coolify service id); unset → SKIP.
  *
  * Run: `npm run lint:litellm-config-guard` (also part of `npm run lint`).
  */
@@ -39,11 +40,20 @@
 import { existsSync, readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
 
-const DEFAULT_LITELLM_CONFIG_PATH =
-  "/data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/litellm-config.yaml";
 const FLAG = "forward_client_headers_to_llm_api";
 
-const path = process.env.LITELLM_CONFIG_PATH ?? DEFAULT_LITELLM_CONFIG_PATH;
+const path = process.env.LITELLM_CONFIG_PATH;
+
+if (!path) {
+  console.log(
+    `check-litellm-config-guard: SKIP — LITELLM_CONFIG_PATH unset\n` +
+      `  (no hard-coded default: the real path embeds a deployment-identifying\n` +
+      `   Coolify service id. Set LITELLM_CONFIG_PATH to point at the live\n` +
+      `   config; the load-bearing check is the fleet-health litellm-config\n` +
+      `   sensor that runs on the host.)`,
+  );
+  process.exit(0);
+}
 
 function isClaudeAllowlistedGroup(name) {
   if (name.endsWith("-openrouter")) return false;

--- a/scripts/check-no-pii-secrets.mjs
+++ b/scripts/check-no-pii-secrets.mjs
@@ -79,6 +79,24 @@ const RULES = [
   { id: 'real Telegram id (user)', re: new RegExp('\\b' + '82487' + '03757\\b') },
   { id: 'real Telegram id (alt)', re: new RegExp('\\b' + '82881' + '44562\\b') },
   { id: 'real Telegram id (group)', re: new RegExp('\\b' + '38527' + '47971\\b') },
+  // Live Coolify service id for the LiteLLM proxy, scrubbed in PR #3530. It
+  // identifies a real deployment (and the exact host path of the
+  // operator-maintained proxy config). Docs use the `<litellm-service-id>`
+  // placeholder; the sensor and lint guard read the real path from
+  // `fleet_health.litellm_config_path` / `LITELLM_CONFIG_PATH`. Without this
+  // rule nothing stopped an agent pasting the id straight back into a doc or a
+  // default — the scrub would silently un-do itself.
+  {
+    id: 'live Coolify litellm service id (use <litellm-service-id>)',
+    re: new RegExp('vhz4' + 'jc1tzvk6' + 'gdql8jue' + 'iwq4', 'i'),
+  },
+  // Any other long Coolify service-dir slug is deployment-identifying for the
+  // same reason. The placeholder form `<litellm-service-id>` does not match
+  // (angle brackets + hyphens are outside the char class).
+  {
+    id: 'deployment-identifying Coolify service dir (use <litellm-service-id>)',
+    re: new RegExp('coolify/' + 'services/' + '[a-z0-9]{20,}'),
+  },
   // Contiguous Anthropic-token-shaped literal. Real tokens were never
   // committed; this enforces the CLAUDE.md "Secrets in tests" rule —
   // token-shaped fixtures must be runtime-assembled, never a contiguous

--- a/src/cli/fleet-health.ts
+++ b/src/cli/fleet-health.ts
@@ -65,7 +65,19 @@ export function registerFleetHealthCommand(program: Command): void {
         const windowDays = Number(opts.windowDays) || 30;
         const log = (m: string) => console.error(chalk.gray(m));
 
-        const result = runScan({ ownerAgent, windowDays, log });
+        // The I2 sensor's config path is operator-supplied (the real path
+        // embeds a deployment-identifying Coolify service id, so it cannot be
+        // defaulted in this repo). Prefer switchroom.yaml over the env so the
+        // load-bearing OAuth-leak check is on for every scan without relying
+        // on the cron shell exporting LITELLM_CONFIG_PATH.
+        const litellmConfigPath = cfg.fleet_health?.litellm_config_path;
+
+        const result = runScan({
+          ownerAgent,
+          windowDays,
+          log,
+          litellmConfigPath,
+        });
         const ledger = result.ledger;
 
         log(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3861,6 +3861,22 @@ export const FleetHealthConfigSchema = z.object({
       "on this agent — never a self-authored loop (on-leash, " +
       "no-self-escalation).",
     ),
+  litellm_config_path: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Absolute path to the operator-maintained LiteLLM proxy config that the " +
+      "I2 header-passthrough sensor reads " +
+      "(`src/fleet-health/litellm-config-sensor.ts`). Operator-supplied " +
+      "because the real path embeds a deployment-identifying Coolify service " +
+      "id that must not live in the public repo — set it here (host-local " +
+      "switchroom.yaml) so the load-bearing OAuth-leak check is on by default " +
+      "for every scan, instead of depending on a LITELLM_CONFIG_PATH env var " +
+      "being exported into the cron's shell. Precedence: this field → " +
+      "LITELLM_CONFIG_PATH env → unset, in which case the sensor SKIPS with a " +
+      "visible notice.",
+    ),
 });
 
 /**

--- a/src/fleet-health/litellm-config-sensor.test.ts
+++ b/src/fleet-health/litellm-config-sensor.test.ts
@@ -54,7 +54,15 @@ describe("scanLitellmConfig", () => {
     });
     expect(res.status).toBe("skipped");
     expect(res.findings).toEqual([]);
-    expect(logs.some((l) => /SKIPPED.*LITELLM_CONFIG_PATH unset/.test(l))).toBe(true);
+    // `null`, not "" — a consumer must not mistake a sentinel for a real path.
+    expect(res.path).toBeNull();
+    // The notice must name BOTH knobs and say the check did not run, so the
+    // operator can tell "did not check" from "checked and clean".
+    const notice = logs.find((l) => /SKIPPED — no config path/.test(l));
+    expect(notice).toBeDefined();
+    expect(notice).toContain("fleet_health.litellm_config_path");
+    expect(notice).toContain("LITELLM_CONFIG_PATH");
+    expect(notice).toMatch(/does NOT run/);
   });
 
   it("absent file → skipped with a VISIBLE notice, no findings", () => {

--- a/src/fleet-health/litellm-config-sensor.test.ts
+++ b/src/fleet-health/litellm-config-sensor.test.ts
@@ -11,7 +11,6 @@ import {
   resolveLitellmConfigPath,
   LITELLM_PROXY_PSEUDO_AGENT,
 } from "./litellm-config-sensor.js";
-import { DEFAULT_LITELLM_CONFIG_PATH } from "../litellm/header-passthrough-guard.js";
 import { mapSignal } from "./mapping.js";
 
 const PATH = "/fake/litellm-config.yaml";
@@ -27,11 +26,14 @@ function withYaml(yaml: string, log?: (m: string) => void) {
 }
 
 describe("resolveLitellmConfigPath", () => {
-  it("falls back to the host-correct default (no /host prefix)", () => {
+  it("returns null when neither arg nor env is set (no hard-coded default)", () => {
     delete process.env.LITELLM_CONFIG_PATH;
-    expect(resolveLitellmConfigPath()).toBe(DEFAULT_LITELLM_CONFIG_PATH);
-    expect(DEFAULT_LITELLM_CONFIG_PATH.startsWith("/data/coolify/")).toBe(true);
-    expect(DEFAULT_LITELLM_CONFIG_PATH.startsWith("/host/")).toBe(false);
+    expect(resolveLitellmConfigPath()).toBeNull();
+  });
+  it("reads the LITELLM_CONFIG_PATH env when set", () => {
+    process.env.LITELLM_CONFIG_PATH = "/env/path.yaml";
+    expect(resolveLitellmConfigPath()).toBe("/env/path.yaml");
+    delete process.env.LITELLM_CONFIG_PATH;
   });
   it("honors an explicit override arg over the env", () => {
     process.env.LITELLM_CONFIG_PATH = "/env/path.yaml";
@@ -41,6 +43,20 @@ describe("resolveLitellmConfigPath", () => {
 });
 
 describe("scanLitellmConfig", () => {
+  it("no path (env unset, no override) → skipped with a VISIBLE notice", () => {
+    delete process.env.LITELLM_CONFIG_PATH;
+    const logs: string[] = [];
+    const res = scanLitellmConfig({
+      existsFn: () => {
+        throw new Error("existsFn must not be called when no path resolves");
+      },
+      log: (m) => logs.push(m),
+    });
+    expect(res.status).toBe("skipped");
+    expect(res.findings).toEqual([]);
+    expect(logs.some((l) => /SKIPPED.*LITELLM_CONFIG_PATH unset/.test(l))).toBe(true);
+  });
+
   it("absent file → skipped with a VISIBLE notice, no findings", () => {
     const logs: string[] = [];
     const res = scanLitellmConfig({

--- a/src/fleet-health/litellm-config-sensor.ts
+++ b/src/fleet-health/litellm-config-sensor.ts
@@ -43,20 +43,30 @@ export interface LitellmSensorOptions {
 
 export interface LitellmSensorResult {
   status: "ok" | "violation" | "skipped";
-  path: string;
+  /** The path scanned, or `null` when no path resolved at all (env unset and
+   *  no explicit override) — distinct from a resolved-but-absent file, so a
+   *  consumer can never mistake an empty string for a real path. */
+  path: string | null;
   findings: Finding[];
 }
 
-/** Resolve the config path: explicit arg → `LITELLM_CONFIG_PATH` env → null.
- *  There is no hard-coded default (the real path embeds a deployment-
- *  identifying Coolify service id); the operator sets the env on the host. */
+/** Resolve the config path: explicit arg (the CLI passes
+ *  `fleet_health.litellm_config_path` from switchroom.yaml) → the
+ *  `LITELLM_CONFIG_PATH` env → null. There is no hard-coded default (the real
+ *  path embeds a deployment-identifying Coolify service id); the operator
+ *  supplies it in host-local config, or via the env for a one-off run. */
 export function resolveLitellmConfigPath(explicit?: string): string | null {
   return explicit ?? process.env[LITELLM_CONFIG_PATH_ENV] ?? null;
 }
 
 /**
- * Run the LiteLLM header-passthrough sensor. Absent file → `skipped` with a
- * VISIBLE log notice (hermetic CI/dev, or a host where the path moved). Present
+ * Run the LiteLLM header-passthrough sensor. No configured path (neither
+ * `fleet_health.litellm_config_path` nor the `LITELLM_CONFIG_PATH` env) →
+ * `skipped` with a VISIBLE log notice naming what to set; an absent, unreadable
+ * or unparseable file → likewise `skipped` with a VISIBLE notice (hermetic
+ * CI/dev, or a host where the path moved). Neither case ever reports a silent
+ * pass: `status` is `skipped`, never `ok`, so the difference between "checked
+ * and clean" and "did not check" stays legible to the caller. Present
  * file with a scoping violation → one `Finding` per violation, attributed to
  * the litellm-proxy pseudo-agent, so it escalates into the ledger.
  */
@@ -71,11 +81,13 @@ export function scanLitellmConfig(
 
   if (path == null) {
     log(
-      `fleet-health: litellm-config sensor SKIPPED — ${LITELLM_CONFIG_PATH_ENV} unset ` +
-        `(set it on the host to the operator-maintained LiteLLM config path; ` +
-        `hermetic CI/dev expected to skip)`,
+      `fleet-health: litellm-config sensor SKIPPED — no config path: set ` +
+        `fleet_health.litellm_config_path in switchroom.yaml (or the ` +
+        `${LITELLM_CONFIG_PATH_ENV} env) to the operator-maintained LiteLLM ` +
+        `config path; the I2 OAuth-leak check does NOT run until you do. ` +
+        `Hermetic CI/dev expected to skip.`,
     );
-    return { status: "skipped", path: "", findings: [] };
+    return { status: "skipped", path: null, findings: [] };
   }
 
   if (!exists(path)) {

--- a/src/fleet-health/litellm-config-sensor.ts
+++ b/src/fleet-health/litellm-config-sensor.ts
@@ -5,8 +5,8 @@
  * The `scripts/check-litellm-config-guard.mjs` lint step is near-vacuous:
  * off-host the operator-maintained config file is absent (CI/dev), so lint
  * skips. This sensor is where enforcement actually bites — it runs inside the
- * fleet-health scan, which executes where the config file lives and can read
- * `/data/coolify/services/…/litellm-config.yaml`. A violation escalates into
+ * fleet-health scan, which executes where the config file lives and reads the
+ * path named by the `LITELLM_CONFIG_PATH` env var. A violation escalates into
  * the priority ledger (→ GitHub issue) exactly like any other L0 finding.
  *
  * STRICTLY MODEL-FREE: reads one YAML file, runs the pure detection core, emits
@@ -17,7 +17,7 @@ import { readFileSync, existsSync } from "node:fs";
 
 import type { Finding } from "./detect.js";
 import {
-  DEFAULT_LITELLM_CONFIG_PATH,
+  LITELLM_CONFIG_PATH_ENV,
   detectHeaderMisconfig,
   parseLitellmConfig,
 } from "../litellm/header-passthrough-guard.js";
@@ -30,8 +30,8 @@ import {
 export const LITELLM_PROXY_PSEUDO_AGENT = "litellm-proxy";
 
 export interface LitellmSensorOptions {
-  /** Config path override. Defaults to `LITELLM_CONFIG_PATH` env → the
-   *  host-correct default. */
+  /** Config path override. Defaults to the `LITELLM_CONFIG_PATH` env var;
+   *  the sensor skips when neither is set. */
   path?: string;
   /** Injectable for tests. */
   existsFn?: (p: string) => boolean;
@@ -47,10 +47,11 @@ export interface LitellmSensorResult {
   findings: Finding[];
 }
 
-/** Resolve the config path: explicit arg → `LITELLM_CONFIG_PATH` env → the
- *  host-correct default. */
-export function resolveLitellmConfigPath(explicit?: string): string {
-  return explicit ?? process.env.LITELLM_CONFIG_PATH ?? DEFAULT_LITELLM_CONFIG_PATH;
+/** Resolve the config path: explicit arg → `LITELLM_CONFIG_PATH` env → null.
+ *  There is no hard-coded default (the real path embeds a deployment-
+ *  identifying Coolify service id); the operator sets the env on the host. */
+export function resolveLitellmConfigPath(explicit?: string): string | null {
+  return explicit ?? process.env[LITELLM_CONFIG_PATH_ENV] ?? null;
 }
 
 /**
@@ -67,6 +68,15 @@ export function scanLitellmConfig(
   const read = opts.readFn ?? ((p: string) => readFileSync(p, "utf-8"));
   const log = opts.log ?? (() => {});
   const nowIso = opts.nowIso ?? new Date().toISOString();
+
+  if (path == null) {
+    log(
+      `fleet-health: litellm-config sensor SKIPPED — ${LITELLM_CONFIG_PATH_ENV} unset ` +
+        `(set it on the host to the operator-maintained LiteLLM config path; ` +
+        `hermetic CI/dev expected to skip)`,
+    );
+    return { status: "skipped", path: "", findings: [] };
+  }
 
   if (!exists(path)) {
     log(

--- a/src/fleet-health/scan.ts
+++ b/src/fleet-health/scan.ts
@@ -47,9 +47,12 @@ export interface ScanOptions {
   /** Override the silent-no-op windowing floor (unix seconds). Defaults to
    *  `SILENT_NOOP_FLOOR_TS`. Exposed for tests / future re-baselining. */
   silentNoopFloorTs?: number;
-  /** Override the LiteLLM config path the I2 header-passthrough sensor reads.
-   *  Defaults to `LITELLM_CONFIG_PATH` env → the host-correct default. Exposed
-   *  for tests; absent file → the sensor skips with a visible notice. */
+  /** The LiteLLM config path the I2 header-passthrough sensor reads. The CLI
+   *  passes `fleet_health.litellm_config_path` from switchroom.yaml; falling
+   *  back to the `LITELLM_CONFIG_PATH` env when unset. There is no hard-coded
+   *  default (the real path embeds a deployment-identifying Coolify service
+   *  id), so unset → the sensor skips with a visible notice, as does an
+   *  absent file. */
   litellmConfigPath?: string;
 }
 

--- a/src/litellm/header-passthrough-guard.ts
+++ b/src/litellm/header-passthrough-guard.ts
@@ -27,16 +27,20 @@ import { parse as parseYaml } from "yaml";
 export const FORWARD_HEADERS_FLAG = "forward_client_headers_to_llm_api";
 
 /**
- * The host-correct default path to the operator-maintained LiteLLM config.
+ * Env var naming the operator-maintained LiteLLM config path on the host
+ * (e.g. `/data/coolify/services/<litellm-service-id>/litellm-config.yaml`).
  *
- * NOTE (red-team item 2): `docs/model-routing.md` cites `/host/data/coolify/…`
- * — but that `/host` prefix is ONLY valid inside the root-agent debugging
- * container (which bind-mounts the host root at `/host`). The real switchroom
- * host path — where the fleet-health sensor actually runs — has no `/host`
- * prefix. Override with `LITELLM_CONFIG_PATH` when it moves.
+ * There is deliberately NO hard-coded default: the path embeds a
+ * deployment-identifying Coolify service id, so it is operator-supplied via
+ * this env var (set on the switchroom host). Consumers — the fleet-health
+ * sensor and the lint guard — SKIP with a visible notice when it is unset.
+ *
+ * NOTE (red-team item 2): inside the root-agent debugging container the host
+ * root is bind-mounted at `/host`, so the same file appears with a `/host`
+ * prefix there. Set `LITELLM_CONFIG_PATH` to whichever path is real for the
+ * process reading it.
  */
-export const DEFAULT_LITELLM_CONFIG_PATH =
-  "/data/coolify/services/vhz4jc1tzvk6gdql8jueiwq4/litellm-config.yaml";
+export const LITELLM_CONFIG_PATH_ENV = "LITELLM_CONFIG_PATH";
 
 /**
  * A subscription-Claude group is allowed to forward the OAuth header. Mirrors

--- a/tests/check-litellm-config-guard.test.ts
+++ b/tests/check-litellm-config-guard.test.ts
@@ -37,7 +37,26 @@ function fixture(yaml: string): string {
   return p;
 }
 
+/** Run the script with LITELLM_CONFIG_PATH explicitly removed from the env. */
+function runWithoutEnv(): { ok: boolean; stdout: string; stderr: string } {
+  const env = { ...process.env };
+  delete env.LITELLM_CONFIG_PATH;
+  const r = spawnSync("node", [SCRIPT], { cwd: REPO, encoding: "utf8", env });
+  return { ok: r.status === 0, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
 describe("check-litellm-config-guard.mjs", () => {
+  it("LITELLM_CONFIG_PATH unset → exit 0 with a visible SKIP notice (no hard-coded default)", () => {
+    const r = runWithoutEnv();
+    // Must SKIP cleanly, not crash on an undefined path and not silently PASS.
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toMatch(/SKIP — LITELLM_CONFIG_PATH unset/);
+    expect(r.stdout).toMatch(/LITELLM_CONFIG_PATH/);
+    // A skip is not an OK: the "correctly scoped" success line must be absent.
+    expect(r.stdout).not.toMatch(/OK/);
+    expect(r.stderr).not.toMatch(/FAIL/);
+  });
+
   it("absent file → exit 0 with a visible SKIP notice", () => {
     const r = runWith("/definitely/not/here/litellm-config.yaml");
     expect(r.ok).toBe(true);


### PR DESCRIPTION
The live Coolify service id `vhz4...iwq4` and its `/data/coolify` config path were hard-coded at HEAD in `src/litellm/header-passthrough-guard.ts` (exported `DEFAULT_LITELLM_CONFIG_PATH`), `scripts/check-litellm-config-guard.mjs`, and cited verbatim in `docs/model-routing.md` and `docker/litellm-pacer/README.md`.

## Changes
- **header-passthrough-guard.ts** — `DEFAULT_LITELLM_CONFIG_PATH` removed; exports `LITELLM_CONFIG_PATH_ENV` instead. Env-driven, same pattern #3527 applied to the guard script.
- **litellm-config-sensor.ts** — `resolveLitellmConfigPath` now returns `null` when neither an explicit path nor `LITELLM_CONFIG_PATH` is set; `scanLitellmConfig` degrades to `skipped` with a visible log notice. On the host the operator sets `LITELLM_CONFIG_PATH` and the sensor keeps working unchanged.
- **check-litellm-config-guard.mjs** — path from `LITELLM_CONFIG_PATH` only; unset → SKIP with a visible notice (was: hard-coded default).
- **docs/model-routing.md, docker/litellm-pacer/README.md** — service id replaced with `<litellm-service-id>` placeholder.
- **CLAUDE.md** — lint-gate note updated to the env-driven behavior.
- **Tests** — sensor test updated: null resolution when unset, env resolution, unset→skipped scan (asserts `existsFn` is never called), plus existing fixtures.

## Deployment note
`LITELLM_CONFIG_PATH` must be set wherever the fleet-health scan / lint guard should actually read the live config; unset means skip (identical to today's absent-file behavior in CI/dev).

Repo-wide sweep at origin/main found no other occurrences of the service id. Git history still contains it — rewriting history is out of scope; this stops it living at HEAD.

Tests: 57 passed (src/fleet-health + src/litellm scoped). Lint: full `npm run lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review pass (adversarial, commit `574a2811`)

The first cut left the load-bearing check off by default and left the scrub
ungated. Both fixed here — **this supersedes the Deployment note above.**

- **Enforcement gap (HIGH).** Requiring `LITELLM_CONFIG_PATH` in the scan
  cron's shell meant the I2 OAuth-leak sensor silently stopped running in
  production (nothing in the tree sets it). Added
  **`fleet_health.litellm_config_path`** to the schema, passed from
  `src/cli/fleet-health.ts` → `runScan`. The operator sets it once in the
  host-local `switchroom.yaml` — which is not in this repo, so the id stays
  scrubbed — and the check is on for every scan. Precedence:
  config field → `LITELLM_CONFIG_PATH` env → unset (skip).
- **Regression gate (HIGH).** `scripts/check-no-pii-secrets.mjs` is this
  repo's existing gate for scrubbed identifiers and had no rule for the
  service id, so a paste-back would have merged green. Added two
  fragment-assembled rules (the literal id; any long `coolify/services/<slug>`
  dir). Verified it fires by probing the id back in, then reverting.
- **Untested branch (LOW).** Added a lint-script case for `LITELLM_CONFIG_PATH`
  unset: exit 0, SKIP notice, and not reported as OK/FAIL.
- **Sentinel (LOW).** `path: ""` on the no-path skip → `string | null`, returns
  `null`.
- **Stale comments (LOW).** `ScanOptions.litellmConfigPath` and the
  `scanLitellmConfig` doc block still said "the host-correct default".

**Deployment (revised):** set `fleet_health.litellm_config_path` in the host
`switchroom.yaml`. Unset (CI/dev, and any host without a LiteLLM proxy) → the
sensor logs `SKIPPED — no config path` and the check does not run; it never
reports a skip as `ok`.
