### PR TITLE
chore(privacy): gate the scrubbed Coolify service id from returning

### DIFF
--- a/scripts/check-no-pii-secrets.mjs
+++ b/scripts/check-no-pii-secrets.mjs
@@ -79,6 +79,27 @@ const RULES = [
   { id: 'real Telegram id (user)', re: new RegExp('\\b' + '82487' + '03757\\b') },
   { id: 'real Telegram id (alt)', re: new RegExp('\\b' + '82881' + '44562\\b') },
   { id: 'real Telegram id (group)', re: new RegExp('\\b' + '38527' + '47971\\b') },
+  // Live Coolify service id for the LiteLLM proxy, scrubbed in #3527. It
+  // identifies a real deployment (and the exact host path of the
+  // operator-maintained proxy config). Docs use the `<litellm-service-id>`
+  // placeholder; on-host code discovers the real path at runtime
+  // (`discoverLiveLitellmConfigPath`) or takes `LITELLM_CONFIG_PATH`, so the
+  // id itself never needs to appear in the tree. Without this rule nothing
+  // stopped an agent pasting it back into a doc or a default and the scrub
+  // would silently un-do itself — exactly the failure mode this gate exists
+  // for.
+  {
+    id: 'live Coolify litellm service id (use <litellm-service-id>)',
+    re: new RegExp('vhz4' + 'jc1tzvk6' + 'gdql8jue' + 'iwq4', 'i'),
+  },
+  // Any other long Coolify service-dir slug is deployment-identifying for the
+  // same reason. The placeholder form `<litellm-service-id>` does not match
+  // (angle brackets and hyphens are outside the char class), and neither does
+  // the bare `COOLIFY_SERVICES_DIR` constant (no slug follows it).
+  {
+    id: 'deployment-identifying Coolify service dir (use <litellm-service-id>)',
+    re: new RegExp('coolify/' + 'services/' + '[a-z0-9]{20,}'),
+  },
   // Contiguous Anthropic-token-shaped literal. Real tokens were never
   // committed; this enforces the CLAUDE.md "Secrets in tests" rule —
   // token-shaped fixtures must be runtime-assembled, never a contiguous


### PR DESCRIPTION
Follow-up finding from the adversarial review of #3530.

#3527 scrubbed the live LiteLLM Coolify service id from the tree (and replaced the hard-coded host path with runtime discovery + `LITELLM_CONFIG_PATH`), but it added **no regression gate**. `scripts/check-no-pii-secrets.mjs` exists for exactly this — it is the always-running `lint` sentinel that stops a completed scrub from silently un-doing itself (#1486) — and it had no rule for this identifier. An agent pasting the id back into a doc or a default would have merged green.

## Change
Two fragment-assembled rules (same self-flagging discipline as every other rule in that file, so the gate never flags itself and never trips Push Protection):

- the literal service id;
- any long `coolify/services/<slug>` dir, which is deployment-identifying for the same reason.

Neither matches the `<litellm-service-id>` placeholder (angle brackets and hyphens fall outside the char class) nor the bare `COOLIFY_SERVICES_DIR` constant (no slug follows it).

## Verification — both directions
A gate that cannot fail is not a gate, so this was checked in both directions:

- **Clean on main:** `check-no-pii-secrets: clean (2894 tracked files scanned)`.
- **Fires on regression:** probing the id back into `docs/model-routing.md` exits 1 and names `docs/model-routing.md:320` for both rules. Reverted after.

Full `npm run lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)