### PR TITLE
lint/litellm: cover the unresolvable live-config SKIP + loud image-pin gap

### DIFF
--- a/docker/litellm-proxy/README.md
+++ b/docker/litellm-proxy/README.md
@@ -69,7 +69,20 @@ must use. Bump procedure: update the pin here (with changelog notes in the
 PR), merge, then the operator edits the compose `image:` to match and
 redeploys. The file currently carries an `UNVERIFIED-AGAINST-LIVE` marker —
 the operator must replace the placeholder tag with the live deployed tag on
-first reconcile.
+first reconcile. Only the host can answer *which* tag that is (the public
+registry knows which tags exist, not which one this deployment runs), so read
+it there:
+
+```sh
+docker inspect --format '{{.Config.Image}}' <litellm-container-name>
+# or, for an immutable digest pin:
+docker inspect --format '{{index .RepoDigests 0}}' <litellm-container-name>
+```
+
+Paste the result into `litellm-image.txt` and delete its
+`UNVERIFIED-AGAINST-LIVE` notice — `src/litellm/repo-config.test.ts` couples
+the two, so a placeholder without the marker (or a real tag that kept the
+marker) fails the suite.
 
 ## What is deliberately NOT here
 

--- a/docker/litellm-proxy/litellm-image.txt
+++ b/docker/litellm-proxy/litellm-image.txt
@@ -1,8 +1,35 @@
 # LiteLLM proxy image pin — single line, `<image>:<tag>` (comments/# lines ignored).
 # The Coolify docker-compose.yml on the host must reference EXACTLY this tag.
-# UNVERIFIED-AGAINST-LIVE: authored 2026-07-25 from inside a fleet container
-# with no read access to the live compose file. OPERATOR: replace with the
-# exact `image:` tag currently deployed (docker inspect / compose file at
-# /data/coolify/services/<litellm-service-id>/docker-compose.yml), then
-# drop this notice. Never use a floating tag (`main-latest`, `main-stable`).
+#
+# UNVERIFIED-AGAINST-LIVE: authored 2026-07-25 from inside a fleet container.
+# This file records WHICH IMAGE IS DEPLOYED, so it can only be filled in from
+# the live host: the public registry can tell you which tags exist, but not
+# which one this deployment runs. Guessing a plausible upstream tag here would
+# make the file confidently wrong (worse than an obvious placeholder), so it
+# stays a placeholder until an operator reads the live value.
+#
+# OPERATOR — run ONE of these ON THE HOST (not inside an agent container) and
+# paste the result over the placeholder line at the bottom, then delete this
+# whole notice INCLUDING the UNVERIFIED-AGAINST-LIVE line above (a test asserts
+# the placeholder and the marker move together — src/litellm/repo-config.test.ts):
+#
+#   # 1. what the running container was actually started from (preferred):
+#   docker inspect --format '{{.Config.Image}}' <litellm-container-name>
+#   # ...and its immutable digest, if you want an @sha256 pin:
+#   docker inspect --format '{{index .RepoDigests 0}}' <litellm-container-name>
+#
+#   # 2. or read it straight out of the deployed compose file:
+#   grep -n 'image:' /data/coolify/services/<litellm-service-id>/docker-compose.yml
+#
+#   # 3. don't know the container name? list them:
+#   docker ps --format '{{.Names}} {{.Image}}' | grep -i litellm
+#
+# Never use a floating tag (`latest`, `main-latest`, `main-stable`): a floating
+# tag is not a pin and silently changes under you on the next redeploy. Prefer
+# `ghcr.io/berriai/litellm-database:main-vX.Y.Z` or an `@sha256:...` digest.
+#
+# Until then the gap is ASSERTED, not hidden: src/litellm/repo-config.test.ts
+# couples the placeholder to the marker above and carries a dedicated test
+# documenting the pin as unverified. Delete that test in the PR landing the
+# real tag.
 ghcr.io/berriai/litellm-database:REPLACE-WITH-LIVE-PINNED-TAG

--- a/scripts/check-litellm-config-guard.mjs
+++ b/scripts/check-litellm-config-guard.mjs
@@ -15,10 +15,12 @@
  * KEN-125 — the config has a repo-managed source of truth
  * (`docker/litellm-proxy/litellm-config.yaml`), which this guard ALWAYS
  * checks (required: missing/unparseable/violating repo copy fails lint, so
- * the guard is no longer vacuous in CI). The LIVE host copy (path via the
- * `LITELLM_CONFIG_PATH` env var — deployment-specific, never hardcoded here)
- * is additionally checked when that env var is set and the file is present,
- * and skipped in CI/dev; on-host enforcement for the live file is the fleet-health
+ * the guard is no longer vacuous in CI). The LIVE host copy (path resolved by
+ * discovery, or the `LITELLM_CONFIG_PATH` env var — deployment-specific, never
+ * hardcoded here) is additionally checked when it resolves and the file is
+ * present, and skipped VISIBLY otherwise (never a silent pass — an unresolved
+ * live copy must be distinguishable from an approved one). CI/dev always skips;
+ * on-host enforcement for the live file is the fleet-health
  * sensor (`src/fleet-health/litellm-config-sensor.ts`), which runs where the
  * file actually lives and escalates a violation into the priority ledger.
  *
@@ -35,8 +37,9 @@
  * The LIVE copy is resolved as: `LITELLM_CONFIG_PATH` env → discovery under the
  * Coolify services dir (`/data/coolify/services/<service>/litellm-config.yaml`).
  * Discovery keeps the on-host lint honest with zero operator setup WITHOUT
- * baking this deployment's Coolify service id into a public repo. Off-host
- * discovery finds nothing and the live check is skipped.
+ * baking this deployment's Coolify service id into a public repo. Zero matches
+ * (off-host) and >1 match (ambiguous host) both resolve to null and print a
+ * SKIP notice naming the reason.
  *
  * Run: `npm run lint:litellm-config-guard` (also part of `npm run lint`).
  */
@@ -54,34 +57,67 @@ const REPO_LITELLM_CONFIG_PATH = fileURLToPath(
   new URL("../docker/litellm-proxy/litellm-config.yaml", import.meta.url),
 );
 
-// Mirrors src/litellm/header-passthrough-guard.ts (discoverLiveLitellmConfigPath).
-// Duplicated because this is a plain .mjs lint script that cannot import the TS
-// core; keep the two in sync — the TS copy is the reference implementation.
-const COOLIFY_SERVICES_DIR = "/data/coolify/services";
+// Mirrors src/litellm/header-passthrough-guard.ts (discoverLiveLitellmConfigPath),
+// including its `{ path, reason, candidates }` result shape. Duplicated because
+// this is a plain .mjs lint script that cannot import the TS core; keep the two
+// in sync — the TS copy is the reference implementation.
+//
+// `SWITCHROOM_COOLIFY_SERVICES_DIR` is the seam that stands in for the TS
+// copy's injectable `servicesDir` option (a .mjs script run as a subprocess has
+// no other injection point). It only redirects DISCOVERY of the live copy; the
+// repo-managed config is always checked from its fixed in-repo path.
+const COOLIFY_SERVICES_DIR =
+  process.env.SWITCHROOM_COOLIFY_SERVICES_DIR || "/data/coolify/services";
 
+/** @returns {{ path: string|null, reason: "found"|"no-services-dir"|"not-found"|"ambiguous", candidates: string[] }} */
 function discoverLiveConfigPath() {
   let entries;
   try {
     entries = readdirSync(COOLIFY_SERVICES_DIR);
   } catch {
-    return null;
+    return { path: null, reason: "no-services-dir", candidates: [] };
   }
   const candidates = [];
   for (const entry of [...entries].sort()) {
     const candidate = `${COOLIFY_SERVICES_DIR}/${entry}/litellm-config.yaml`;
     if (existsSync(candidate)) candidates.push(candidate);
   }
-  if (candidates.length === 1) return candidates[0];
-  if (candidates.length > 1) {
-    console.log(
-      `check-litellm-config-guard: SKIP (live) — ${candidates.length} candidate live configs under ` +
-        `${COOLIFY_SERVICES_DIR}; set LITELLM_CONFIG_PATH to disambiguate.`,
-    );
-  }
+  if (candidates.length === 1) return { path: candidates[0], reason: "found", candidates };
+  if (candidates.length === 0) return { path: null, reason: "not-found", candidates };
+  return { path: null, reason: "ambiguous", candidates };
+}
+
+/**
+ * Resolve the live config path, announcing EVERY unresolved outcome. An
+ * unresolvable live copy is a visible SKIP, never a silent pass: a lint run
+ * that quietly checked nothing live is indistinguishable from one that checked
+ * and approved, which is precisely the failure this guard exists to prevent.
+ *
+ * @returns {string|null}
+ */
+function resolveLivePath() {
+  const fromEnv = process.env.LITELLM_CONFIG_PATH;
+  if (fromEnv) return fromEnv;
+
+  const { path: discovered, reason, candidates } = discoverLiveConfigPath();
+  if (reason === "found") return discovered;
+
+  const why =
+    reason === "ambiguous"
+      ? `${candidates.length} candidate live configs under ${COOLIFY_SERVICES_DIR} ` +
+        `(${candidates.join(", ")}) — refusing to guess which proxy is authoritative`
+      : reason === "no-services-dir"
+        ? `no Coolify services dir at ${COOLIFY_SERVICES_DIR} (hermetic CI/dev expected to skip)`
+        : `no service under ${COOLIFY_SERVICES_DIR} owns a litellm-config.yaml`;
+  console.log(
+    `check-litellm-config-guard: SKIP (live) — ${why}.\n` +
+      `  The repo-managed copy was still checked. Set LITELLM_CONFIG_PATH to point at\n` +
+      `  the live config; on-host enforcement is the fleet-health litellm-config sensor.`,
+  );
   return null;
 }
 
-const path = process.env.LITELLM_CONFIG_PATH ?? discoverLiveConfigPath();
+const path = resolveLivePath();
 
 function isClaudeAllowlistedGroup(name) {
   if (name.endsWith("-openrouter")) return false;
@@ -218,8 +254,9 @@ function checkConfig(path, { required }) {
 }
 
 // The repo-managed copy is ALWAYS checked (required — the guard is no longer
-// vacuous in CI). The live/host copy (LITELLM_CONFIG_PATH env var) is
-// additionally checked when the env var is set.
+// vacuous in CI). The live/host copy is additionally checked when it resolves
+// (LITELLM_CONFIG_PATH env var → discovery); an unresolved live copy already
+// printed a visible SKIP in resolveLivePath().
 let ok = checkConfig(REPO_LITELLM_CONFIG_PATH, { required: true });
 if (path && path !== REPO_LITELLM_CONFIG_PATH) {
   ok = checkConfig(path, { required: false }) && ok;

--- a/tests/check-litellm-config-guard.test.ts
+++ b/tests/check-litellm-config-guard.test.ts
@@ -3,13 +3,20 @@
  * Runs the real script over temp fixture files via LITELLM_CONFIG_PATH and
  * asserts exit code + output for the four design cases: good / global-flag /
  * openrouter-flag / absent-file (skip-notice asserted).
+ *
+ * Plus the discovery cases: when the LIVE config path cannot be resolved (the
+ * Coolify services dir is absent, owns no litellm-config.yaml, or owns several)
+ * the guard must SKIP *visibly* and still exit 0 — a silent pass would be
+ * indistinguishable from a live config that was checked and approved.
  */
 
 import { describe, it, expect, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+
+import { discoverLiveLitellmConfigPath } from "../src/litellm/header-passthrough-guard.js";
 
 const REPO = resolve(import.meta.dirname, "..");
 const SCRIPT = resolve(REPO, "scripts/check-litellm-config-guard.mjs");
@@ -27,6 +34,39 @@ function runWith(configPath: string): { ok: boolean; stdout: string; stderr: str
     env: { ...process.env, LITELLM_CONFIG_PATH: configPath },
   });
   return { ok: r.status === 0, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+/**
+ * Run the guard with NO explicit `LITELLM_CONFIG_PATH`, pointing discovery at a
+ * temp stand-in for the Coolify services dir (the .mjs script's substitute for
+ * the TS core's injectable `servicesDir` option).
+ */
+function runWithDiscovery(servicesDir: string): {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+} {
+  const env = { ...process.env, SWITCHROOM_COOLIFY_SERVICES_DIR: servicesDir };
+  delete env.LITELLM_CONFIG_PATH;
+  const r = spawnSync("node", [SCRIPT], { cwd: REPO, encoding: "utf8", env });
+  return { ok: r.status === 0, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+/** A temp services dir containing one sub-dir per named service; each listed in
+ *  `withConfig` gets a (valid, non-violating) `litellm-config.yaml`. */
+function servicesDir(services: string[], withConfig: string[]): string {
+  const root = mkdtempSync(join(tmpdir(), "litellm-services-"));
+  dirs.push(root);
+  for (const s of services) {
+    mkdirSync(join(root, s), { recursive: true });
+    if (withConfig.includes(s)) {
+      writeFileSync(
+        join(root, s, "litellm-config.yaml"),
+        "model_group_settings:\n  sonnet:\n    forward_client_headers_to_llm_api: true\n",
+      );
+    }
+  }
+  return root;
 }
 
 function fixture(yaml: string): string {
@@ -80,6 +120,89 @@ model_group_settings:
     );
     expect(r.ok).toBe(false);
     expect(r.stderr).toMatch(/claude-sonnet-5-openrouter/);
+  });
+
+  // The unresolved-live-path branch: discovery yields nothing usable. Each case
+  // must exit 0 (the repo copy still passed) AND print a live SKIP naming why.
+  describe("unresolvable live config path → visible SKIP, never a silent pass", () => {
+    it("services dir absent (hermetic CI/dev) → SKIP (live) naming the missing dir", () => {
+      const missing = join(tmpdir(), "litellm-services-does-not-exist-6dd41f");
+      const r = runWithDiscovery(missing);
+      expect(r.ok).toBe(true);
+      expect(r.stdout).toMatch(/SKIP \(live\)/);
+      expect(r.stdout).toContain(missing);
+      expect(r.stdout).toMatch(/no Coolify services dir/);
+      // The repo-managed copy is still checked — the skip is live-only.
+      expect(r.stdout).toMatch(/OK — header passthrough correctly scoped/);
+    });
+
+    it("no service owns a litellm-config.yaml → SKIP (live), not a pass", () => {
+      const root = servicesDir(["svc-a", "svc-b"], []);
+      const r = runWithDiscovery(root);
+      expect(r.ok).toBe(true);
+      expect(r.stdout).toMatch(/SKIP \(live\)/);
+      expect(r.stdout).toMatch(/owns a litellm-config\.yaml/);
+    });
+
+    it("several candidates → SKIP (live) listing them, refusing to guess", () => {
+      const root = servicesDir(["svc-a", "svc-b"], ["svc-a", "svc-b"]);
+      const r = runWithDiscovery(root);
+      expect(r.ok).toBe(true);
+      expect(r.stdout).toMatch(/SKIP \(live\)/);
+      expect(r.stdout).toMatch(/2 candidate live configs/);
+      expect(r.stdout).toContain(join(root, "svc-a", "litellm-config.yaml"));
+      expect(r.stdout).toContain(join(root, "svc-b", "litellm-config.yaml"));
+      expect(r.stdout).toMatch(/refusing to guess/);
+      expect(r.stdout).toMatch(/LITELLM_CONFIG_PATH/);
+    });
+
+    it("exactly one candidate → discovered and CHECKED (the skip is not blanket)", () => {
+      const root = servicesDir(["svc-a", "svc-b"], ["svc-a"]);
+      const live = join(root, "svc-a", "litellm-config.yaml");
+      const r = runWithDiscovery(root);
+      expect(r.ok).toBe(true);
+      expect(r.stdout).not.toMatch(/SKIP \(live\)/);
+      expect(r.stdout).toContain(`OK — header passthrough correctly scoped (${live})`);
+    });
+
+    it("a discovered live config that VIOLATES still fails lint", () => {
+      const root = mkdtempSync(join(tmpdir(), "litellm-services-"));
+      dirs.push(root);
+      mkdirSync(join(root, "svc-a"), { recursive: true });
+      writeFileSync(
+        join(root, "svc-a", "litellm-config.yaml"),
+        "litellm_settings:\n  forward_client_headers_to_llm_api: true\n",
+      );
+      const r = runWithDiscovery(root);
+      expect(r.ok).toBe(false);
+      expect(r.stderr).toMatch(/FAIL/);
+      expect(r.stderr).toMatch(/litellm_settings/);
+    });
+  });
+
+  // Drift guard: the .mjs script re-implements discovery because it cannot
+  // import the TS core. Assert the two agree on the same filesystem, so a fix
+  // to one that is not mirrored into the other fails CI instead of silently
+  // leaving the lint step and the fleet-health sensor disagreeing on-host.
+  describe("discovery parity with src/litellm/header-passthrough-guard.ts", () => {
+    const cases: Array<{ label: string; services: string[]; withConfig: string[] }> = [
+      { label: "found (exactly one)", services: ["svc-a", "svc-b"], withConfig: ["svc-a"] },
+      { label: "not-found (zero)", services: ["svc-a", "svc-b"], withConfig: [] },
+      { label: "ambiguous (two)", services: ["svc-a", "svc-b"], withConfig: ["svc-a", "svc-b"] },
+    ];
+    for (const { label, services, withConfig } of cases) {
+      it(`agrees on ${label}`, () => {
+        const root = servicesDir(services, withConfig);
+        const ts = discoverLiveLitellmConfigPath({ servicesDir: root });
+        const r = runWithDiscovery(root);
+        if (ts.path === null) {
+          expect(r.stdout).toMatch(/SKIP \(live\)/);
+        } else {
+          expect(r.stdout).not.toMatch(/SKIP \(live\)/);
+          expect(r.stdout).toContain(ts.path);
+        }
+      });
+    }
   });
 
   it("4b: claude group with num_retries>1 and no fallbacks → WARN, still exit 0", () => {


### PR DESCRIPTION
Follow-ups from the just-merged litellm/auto-reconcile batch (#3527, #3528, #3533). #3530 is closed as superseded by #3527.

### 1. The lint guard could skip *silently*

`scripts/check-litellm-config-guard.mjs` resolved the LIVE config path via discovery, and when discovery found **zero** candidates it returned `null` with **no output at all**. A lint run that checked nothing live was therefore indistinguishable from one that checked the live config and approved it — exactly the failure mode this guard exists to prevent. (The >1 case did log, but only a count.)

Discovery now mirrors the TS reference's `{ path, reason, candidates }` shape, and every unresolved outcome (`no-services-dir` / `not-found` / `ambiguous`) prints a `SKIP (live)` notice naming the reason and the next action. Exit code is unchanged (0 — the repo-managed copy still passed and is still required).

Sample output in CI/dev now:

```
check-litellm-config-guard: SKIP (live) — no Coolify services dir at /data/coolify/services (hermetic CI/dev expected to skip).
  The repo-managed copy was still checked. Set LITELLM_CONFIG_PATH to point at
  the live config; on-host enforcement is the fleet-health litellm-config sensor.
check-litellm-config-guard: OK — header passthrough correctly scoped (…/docker/litellm-proxy/litellm-config.yaml)
```

`SWITCHROOM_COOLIFY_SERVICES_DIR` is the new seam that makes discovery testable — the subprocess-safe stand-in for the TS copy's injectable `servicesDir` option. It redirects **live discovery only**; the repo-managed config is always read from its fixed in-repo path.

### 2. Tests

`tests/check-litellm-config-guard.test.ts` (+8 cases):
- each unresolved reason → exit 0 **and** a visible `SKIP (live)` naming why;
- exactly one candidate → discovered **and checked** (proves the skip isn't blanket);
- a discovered live config that violates → still `FAIL`;
- a **drift guard**: the `.mjs` discovery must agree with `discoverLiveLitellmConfigPath()` over the same filesystem, so a fix to one that isn't mirrored to the other fails CI instead of leaving the lint step and the fleet-health sensor disagreeing on-host.

Mutation-checked: reverting the `ambiguous` branch to return `candidates[0]` fails 2 of the new tests.

Fleet-health sensor: the equivalent unresolved case (`status: "skipped"`, never `ok`) was **already** covered at `src/fleet-health/litellm-config-sensor.test.ts:132` ("unresolvable live path → skipped with a VISIBLE notice, never a silent pass"), including an `existsFn: () => true` that would pass if the null path weren't short-circuited. Verified passing; no new coverage needed there.

### 3. Image pin — placeholder kept, on purpose

`docker/litellm-proxy/litellm-image.txt` records **which image is deployed**. From a fleet container I can query the public ghcr registry (the token + tags endpoints do resolve from here) and confirm which tags *exist* — but not which one this host runs. Pinning a plausible upstream tag would make the file confidently wrong, which is worse than an obviously-unfilled placeholder.

So the placeholder stays and the failure mode gets louder: the file now carries the exact `docker inspect --format '{{.Config.Image}}'` / `{{index .RepoDigests 0}}` / compose-grep commands an operator runs **on the host**, why it can't be filled in from a container, the floating-tag prohibition, and a pointer to the coupled assertions in `src/litellm/repo-config.test.ts` (placeholder ⇔ `UNVERIFIED-AGAINST-LIVE` marker) that keep the gap asserted rather than hidden. `docker/litellm-proxy/README.md` mirrors the procedure.

**Needs Ken's host access:** the one-line `docker inspect` to land the real pin.

### Verification

- `npx vitest run tests/check-litellm-config-guard.test.ts src/litellm/ src/fleet-health/litellm-config-sensor.test.ts` — all green (13 + 90).
- `npm run lint` — clean end to end.