### PR TITLE
litellm: land the verified live image pin (digest-qualified) + fix the shape regex

### DIFF
--- a/docker/litellm-proxy/README.md
+++ b/docker/litellm-proxy/README.md
@@ -67,10 +67,11 @@ To roll out a change:
 Single non-comment line: the exact `image:` reference the host compose file
 must use. Bump procedure: update the pin here (with changelog notes in the
 PR), merge, then the operator edits the compose `image:` to match and
-redeploys. The file currently carries an `UNVERIFIED-AGAINST-LIVE` marker —
-the operator must replace the placeholder tag with the live deployed tag on
-first reconcile. Only the host can answer *which* tag that is (the public
-registry knows which tags exist, not which one this deployment runs), so read
+redeploys. The pin was verified against the live deployment on 2026-07-25 and
+is stored digest-qualified (`<image>:<tag>@sha256:<digest>`): the tag half must
+match the host compose `image:` line verbatim, the digest half makes it
+immutable. Only the host can answer *which* tag is deployed (the public registry
+knows which tags exist, not which one this deployment runs), so on any bump read
 it there:
 
 ```sh
@@ -79,10 +80,11 @@ docker inspect --format '{{.Config.Image}}' <litellm-container-name>
 docker inspect --format '{{index .RepoDigests 0}}' <litellm-container-name>
 ```
 
-Paste the result into `litellm-image.txt` and delete its
-`UNVERIFIED-AGAINST-LIVE` notice — `src/litellm/repo-config.test.ts` couples
-the two, so a placeholder without the marker (or a real tag that kept the
-marker) fails the suite.
+Paste the result into `litellm-image.txt`. `src/litellm/repo-config.test.ts`
+enforces the shape (tag, digest, or tag@digest — never a floating tag) and
+still couples the `REPLACE-WITH-LIVE-PINNED-TAG` placeholder to an
+`UNVERIFIED-AGAINST-LIVE` marker, so a future placeholder can never ship
+silently.
 
 ## What is deliberately NOT here
 

--- a/docker/litellm-proxy/litellm-image.txt
+++ b/docker/litellm-proxy/litellm-image.txt
@@ -1,21 +1,12 @@
 # LiteLLM proxy image pin — single line, `<image>:<tag>` (comments/# lines ignored).
 # The Coolify docker-compose.yml on the host must reference EXACTLY this tag.
 #
-# UNVERIFIED-AGAINST-LIVE: authored 2026-07-25 from inside a fleet container.
-# This file records WHICH IMAGE IS DEPLOYED, so it can only be filled in from
-# the live host: the public registry can tell you which tags exist, but not
-# which one this deployment runs. Guessing a plausible upstream tag here would
-# make the file confidently wrong (worse than an obvious placeholder), so it
-# stays a placeholder until an operator reads the live value.
-#
-# OPERATOR — run ONE of these ON THE HOST (not inside an agent container) and
-# paste the result over the placeholder line at the bottom, then delete this
-# whole notice INCLUDING the UNVERIFIED-AGAINST-LIVE line above (a test asserts
-# the placeholder and the marker move together — src/litellm/repo-config.test.ts):
+# VERIFIED against the live deployment on 2026-07-25. Three sources agreed on
+# `ghcr.io/berriai/litellm-database:v1.91.0` (no floating tag is involved):
 #
 #   # 1. what the running container was actually started from (preferred):
 #   docker inspect --format '{{.Config.Image}}' <litellm-container-name>
-#   # ...and its immutable digest, if you want an @sha256 pin:
+#   # ...and its immutable digest, which is the @sha256 half of the pin below:
 #   docker inspect --format '{{index .RepoDigests 0}}' <litellm-container-name>
 #
 #   # 2. or read it straight out of the deployed compose file:
@@ -24,12 +15,16 @@
 #   # 3. don't know the container name? list them:
 #   docker ps --format '{{.Names}} {{.Image}}' | grep -i litellm
 #
-# Never use a floating tag (`latest`, `main-latest`, `main-stable`): a floating
-# tag is not a pin and silently changes under you on the next redeploy. Prefer
-# `ghcr.io/berriai/litellm-database:main-vX.Y.Z` or an `@sha256:...` digest.
+# The line at the bottom is the digest-qualified form `<image>:<tag>@sha256:...`:
+# it names EXACTLY the tag the host compose references (the contract above) AND
+# pins the immutable digest that tag resolved to, so an upstream retag can never
+# silently change what is deployed.
 #
-# Until then the gap is ASSERTED, not hidden: src/litellm/repo-config.test.ts
-# couples the placeholder to the marker above and carries a dedicated test
-# documenting the pin as unverified. Delete that test in the PR landing the
-# real tag.
-ghcr.io/berriai/litellm-database:REPLACE-WITH-LIVE-PINNED-TAG
+# Never use a floating tag (`latest`, `main-latest`, `main-stable`): a floating
+# tag is not a pin and silently changes under you on the next redeploy.
+#
+# This file records WHICH IMAGE IS DEPLOYED, so any update must be re-read from
+# the live host (commands above) — the public registry can tell you which tags
+# exist, but not which one this deployment runs. Guessing a plausible upstream
+# tag here would make the file confidently wrong.
+ghcr.io/berriai/litellm-database:v1.91.0@sha256:6151ddc97c5dc4590740bd14646d78d48267d8b7a1bf398eeaffcd6729b8f0b9

--- a/src/litellm/repo-config.test.ts
+++ b/src/litellm/repo-config.test.ts
@@ -152,11 +152,21 @@ describe("repo-managed litellm-config.yaml (KEN-125)", () => {
 
   it("declares the proxy image on exactly one non-comment line shaped <image>:<tag>", () => {
     expect(imagePinLines).toHaveLength(1);
-    expect(imagePinLines[0]).toMatch(/^[\w.\-/]+:[\w.\-]+$/);
-    // Floating tags defeat the pin.
-    expect(imagePinLines[0].endsWith(":latest")).toBe(false);
-    expect(imagePinLines[0].endsWith(":main-latest")).toBe(false);
-    expect(imagePinLines[0].endsWith(":main-stable")).toBe(false);
+    // The shape permits `@sha256:<64 hex>` because a digest is the STRONGEST
+    // pin, and the coupling test below explicitly blesses one. Three forms are
+    // legal: `<image>:<tag>`, `<image>@sha256:<digest>`, and the belt-and-braces
+    // `<image>:<tag>@sha256:<digest>` this repo ships (the tag matches the host
+    // compose line verbatim; the digest makes it immutable). A bare `<image>`
+    // with neither tag nor digest stays rejected.
+    expect(imagePinLines[0]).toMatch(
+      /^[\w.\-/]+(?::[\w.\-]+(?:@sha256:[0-9a-f]{64})?|@sha256:[0-9a-f]{64})$/,
+    );
+    // Floating tags defeat the pin — checked against the TAG portion, so a
+    // floating tag is still caught when digest-qualified (`:latest@sha256:…`).
+    const tagPart = imagePinLines[0].split("@")[0];
+    expect(tagPart.endsWith(":latest")).toBe(false);
+    expect(tagPart.endsWith(":main-latest")).toBe(false);
+    expect(tagPart.endsWith(":main-stable")).toBe(false);
   });
 
   // The shape check above deliberately does NOT prove the pin is real: the
@@ -182,11 +192,5 @@ describe("repo-managed litellm-config.yaml (KEN-125)", () => {
       // A real pin must be immutable-ish: a digest, or a tag with a version.
       expect(imagePinLines[0]).toMatch(/(@sha256:[0-9a-f]{64}|:\S*\d)/);
     }
-  });
-
-  it("is not yet a verified pin (KEN-125 follow-up: operator must supply the live tag)", () => {
-    // Documents the KNOWN, disclosed gap rather than pretending it is closed.
-    // Delete this test in the PR that lands the real tag.
-    expect(imagePinLines[0]).toContain(PLACEHOLDER_TAG);
   });
 });

--- a/src/litellm/repo-config.test.ts
+++ b/src/litellm/repo-config.test.ts
@@ -150,7 +150,7 @@ describe("repo-managed litellm-config.yaml (KEN-125)", () => {
     }
   });
 
-  it("declares the proxy image on exactly one non-comment line shaped <image>:<tag>", () => {
+  it("declares the proxy image on exactly one non-comment line shaped <image>:<tag>[@sha256:<digest>]", () => {
     expect(imagePinLines).toHaveLength(1);
     // The shape permits `@sha256:<64 hex>` because a digest is the STRONGEST
     // pin, and the coupling test below explicitly blesses one. Three forms are
@@ -170,8 +170,9 @@ describe("repo-managed litellm-config.yaml (KEN-125)", () => {
   });
 
   // The shape check above deliberately does NOT prove the pin is real: the
-  // placeholder tag this file ships with is shape-valid but names no existing
-  // image. So the two states are coupled here — a placeholder pin MUST carry
+  // placeholder tag (which this file shipped with before the live pin landed,
+  // and could regress to) is shape-valid but names no existing image. So the
+  // two states are coupled here — a placeholder pin MUST carry
   // the UNVERIFIED marker, and a pin without the marker MUST be a real tag.
   // Without this, dropping the marker (or "fixing" the tag to a floating one)
   // silently leaves a green test claiming a pin that would fail to pull.


### PR DESCRIPTION
## What

Replaces the `REPLACE-WITH-LIVE-PINNED-TAG` placeholder in `docker/litellm-proxy/litellm-image.txt` with the real, live-verified pin.

## Verified host truth (2026-07-25)

Three independent sources agree; **no floating tag is involved**:

| source | value |
|---|---|
| `docker inspect --format '{{.Config.Image}}'` on the running container | `ghcr.io/berriai/litellm-database:v1.91.0` |
| `RepoDigests` of that image | `ghcr.io/berriai/litellm-database@sha256:6151ddc9…b8f0b9` |
| deployed Coolify compose, line 3 | `image: 'ghcr.io/berriai/litellm-database:v1.91.0'` |

The pin lands **digest-qualified**:

```
ghcr.io/berriai/litellm-database:v1.91.0@sha256:6151ddc97c5dc4590740bd14646d78d48267d8b7a1bf398eeaffcd6729b8f0b9
```

That is simultaneously (a) EXACTLY the tag the host compose references — the contract the file states — and (b) an immutable digest pin, so an upstream retag of `v1.91.0` can never silently change what is deployed.

## The contradiction this fixes

`src/litellm/repo-config.test.ts` from #3534 carried two mutually inconsistent assertions:

- shape: `expect(imagePinLines[0]).toMatch(/^[\w.\-/]+:[\w.\-]+$/)` — the char class excludes `@`, so **any** digest form fails;
- coupling: `expect(imagePinLines[0]).toMatch(/(@sha256:[0-9a-f]{64}|:\S*\d)/)` — explicitly blesses a digest.

So the suite demanded a strong pin and then rejected the strongest one. The shape regex is widened to `^[\w.\-/]+(?::[\w.\-]+(?:@sha256:[0-9a-f]{64})?|@sha256:[0-9a-f]{64})$`, which accepts `tag`, bare `@digest`, and `tag@digest`, while a bare `<image>` with neither stays rejected. A comment in the test explains why `@sha256:` is permitted.

The floating-tag rejections are now checked against the **tag portion** (`line.split("@")[0]`), so `:latest@sha256:…` / `:main-latest@…` / `:main-stable@…` are still caught — previously `endsWith(":latest")` would have missed them once digests became legal.

## Removed together (as the suite requires)

- the `UNVERIFIED-AGAINST-LIVE:` notice in `litellm-image.txt`, and
- the `it("is not yet a verified pin (KEN-125 follow-up …)")` test.

The coupling test fails loudly if only one moves; both move here. The placeholder↔marker coupling itself is retained, so a future placeholder still cannot ship silently.

`docker/litellm-proxy/README.md` is updated so its "Version pin" section describes reality instead of the removed marker.

No host identifiers: the Coolify service id appears nowhere — service paths stay `<litellm-service-id>` (test enforced).

## Verification

- `vitest run src/litellm/` → 4 files, **64 tests passed**
- `npm run lint` → `tsc --noEmit` clean; all guard scripts clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
