### PR TITLE
fix(litellm): allowlist the bare `opus` group in the I2 header guard

### DIFF
--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -69,11 +69,19 @@ These must always hold.
   `openrouter/*` `model_group_settings` entry, would forward the subscription
   OAuth `Authorization: Bearer` token to OpenRouter (a third party). The live
   config currently does this correctly — the flag appears only under Claude
-  model groups (`claude-opus-*`, `claude-sonnet-*`, `sonnet`, `claude-haiku-*`,
-  `claude-fable-5`, `fable`), never in `litellm_settings` or under any
+  model groups (`claude-opus-*`, `claude-sonnet-*`, `claude-haiku-*`,
+  `claude-fable-5`, plus the bare family aliases `opus`, `sonnet`, `fable`),
+  never in `litellm_settings` or under any
   OpenRouter/OpenAI entry, and the config's own comments warn against the
   global form — but I2 holds **only** as long as that operator convention is
   maintained. It is not automatically guaranteed.
+  The allowlist the guard enforces is `claude-*` (minus any `*-openrouter`
+  suffix) plus the exact bare aliases in `BARE_ANTHROPIC_FAMILY_ALIASES`
+  (`src/litellm/header-passthrough-guard.ts`). **Registering a new bare
+  Anthropic family alias in `model_list` means adding it to that set in the
+  same change** — otherwise the guard reports it as a non-Claude group and
+  lint / the fleet-health sensor raise a false-positive OAuth-leak violation
+  (this is what happened when the bare `opus` group was added 2026-07-25).
 - **I3 — The auth broker owns OAuth.** The `switchroom-auth-broker` singleton
   is the sole writer of every consumer's `.claude/credentials.json` (agents and
   Hindsight alike) and owns the refresh loop; this is what enables account

--- a/scripts/check-litellm-config-guard.mjs
+++ b/scripts/check-litellm-config-guard.mjs
@@ -28,7 +28,8 @@
  *   - `forward_client_headers_to_llm_api: true` under `litellm_settings`
  *     (the global master switch), OR
  *   - the same flag on any `model_group_settings` group NOT in the Claude
- *     allowlist (`claude-*`, `sonnet`, `fable`; `*-openrouter` EXCLUDED).
+ *     allowlist (`claude-*`, plus the bare aliases `opus`/`sonnet`/`fable`;
+ *     `*-openrouter` EXCLUDED).
  *
  * Also emits a NON-FATAL 4b advisory when a Claude group sets `num_retries > 1`
  * with no `fallbacks` chain (the broker owns failover — see model-routing.md
@@ -119,9 +120,15 @@ function resolveLivePath() {
 
 const path = resolveLivePath();
 
+// Mirrors BARE_ANTHROPIC_FAMILY_ALIASES in src/litellm/header-passthrough-guard.ts
+// (the reference implementation — keep the two in sync). Every bare Anthropic
+// family alias registered in the proxy's model_list must be listed here, or this
+// guard FAILs on a group that is in fact an Anthropic OAuth passthrough.
+const BARE_ANTHROPIC_FAMILY_ALIASES = new Set(["opus", "sonnet", "fable"]);
+
 function isClaudeAllowlistedGroup(name) {
   if (name.endsWith("-openrouter")) return false;
-  return name.startsWith("claude-") || name === "sonnet" || name === "fable";
+  return name.startsWith("claude-") || BARE_ANTHROPIC_FAMILY_ALIASES.has(name);
 }
 
 function flagTruthy(v) {
@@ -243,7 +250,7 @@ function checkConfig(path, { required }) {
     console.error(`check-litellm-config-guard: FAIL — OAuth-leak header scoping in ${path}:`);
     for (const v of violations) console.error(`  - ${v}`);
     console.error(
-      `\n  Fix: scope ${FLAG} to Claude model groups only (claude-*, sonnet, fable);\n` +
+      `\n  Fix: scope ${FLAG} to Claude model groups only (claude-*, opus, sonnet, fable);\n` +
         `  never global under litellm_settings, never on a non-Claude/*-openrouter group.`,
     );
     return false;

--- a/src/fleet-health/litellm-config-sensor.test.ts
+++ b/src/fleet-health/litellm-config-sensor.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from "vitest";
 
+import type { DiscoverFn } from "./litellm-config-sensor.js";
 import {
   scanLitellmConfig,
   resolveLitellmConfigPath,
@@ -18,6 +19,15 @@ import {
 import { mapSignal } from "./mapping.js";
 
 const PATH = "/fake/litellm-config.yaml";
+
+/** Hermetic stand-in for live-config discovery on a host with no live proxy.
+ *  Injected wherever a test exercises path RESOLUTION, so the assertion never
+ *  depends on whether this machine happens to run the real LiteLLM proxy. */
+const NO_LIVE_CONFIG: DiscoverFn = () => ({
+  path: null,
+  reason: "no-services-dir",
+  candidates: [],
+});
 
 function withYaml(yaml: string, log?: (m: string) => void) {
   return scanLitellmConfig({
@@ -42,9 +52,20 @@ describe("resolveLitellmConfigPath", () => {
   });
   it("falls through to discovery, which returns null off-host (never a bogus path)", () => {
     delete process.env.LITELLM_CONFIG_PATH;
-    // In CI/dev the Coolify services dir does not exist, so this must resolve
-    // to null (→ a visible skip) rather than a fabricated path.
-    expect(resolveLitellmConfigPath()).toBe(null);
+    // Discovery is INJECTED, not read from the host: on a machine that really
+    // does run the live proxy, the real scan finds a config and this assertion
+    // would fail for reasons that have nothing to do with the logic under test.
+    expect(resolveLitellmConfigPath(undefined, NO_LIVE_CONFIG)).toBe(null);
+  });
+  it("uses the discovered path when discovery finds exactly one live config", () => {
+    delete process.env.LITELLM_CONFIG_PATH;
+    expect(
+      resolveLitellmConfigPath(undefined, () => ({
+        path: "/svc/theproxy/litellm-config.yaml",
+        reason: "found",
+        candidates: ["/svc/theproxy/litellm-config.yaml"],
+      })),
+    ).toBe("/svc/theproxy/litellm-config.yaml");
   });
 });
 
@@ -133,6 +154,7 @@ describe("scanLitellmConfig", () => {
     delete process.env.LITELLM_CONFIG_PATH;
     const logs: string[] = [];
     const res = scanLitellmConfig({
+      discoverFn: NO_LIVE_CONFIG, // hermetic: never consults the host's real fs
       existsFn: () => true, // would pass if the null path were not short-circuited
       readFn: () => "litellm_settings:\n  forward_client_headers_to_llm_api: true\n",
       log: (m) => logs.push(m),
@@ -153,6 +175,33 @@ model_group_settings:
 `);
     expect(res.status).toBe("ok");
     expect(res.findings).toEqual([]);
+  });
+
+  it("bare `opus` group with the flag → ok, no findings (Anthropic OAuth passthrough)", () => {
+    // Regression: the live proxy gained a bare `opus` group routing to
+    // anthropic/claude-opus-5 (2026-07-25). It was missing from the allowlist,
+    // so the sensor reported a violation and would have escalated a bogus L0
+    // finding into the priority ledger.
+    const res = withYaml(`
+model_group_settings:
+  opus:
+    forward_client_headers_to_llm_api: true
+  claude-opus-5:
+    forward_client_headers_to_llm_api: true
+`);
+    expect(res.findings).toEqual([]);
+    expect(res.status).toBe("ok");
+  });
+
+  it("`opus-openrouter` with the flag → violation (the suffix hole stays closed)", () => {
+    const res = withYaml(`
+model_group_settings:
+  opus-openrouter:
+    forward_client_headers_to_llm_api: true
+`);
+    expect(res.status).toBe("violation");
+    expect(res.findings).toHaveLength(1);
+    expect(res.findings[0].turn_id).toContain("opus-openrouter");
   });
 
   it("global flag → violation finding attributed to the proxy pseudo-agent", () => {

--- a/src/fleet-health/litellm-config-sensor.ts
+++ b/src/fleet-health/litellm-config-sensor.ts
@@ -18,6 +18,7 @@
 import { readFileSync, existsSync } from "node:fs";
 
 import type { Finding } from "./detect.js";
+import type { LiveConfigDiscovery } from "../litellm/header-passthrough-guard.js";
 import {
   COOLIFY_SERVICES_DIR,
   detectHeaderMisconfig,
@@ -39,6 +40,9 @@ export interface LitellmSensorOptions {
   /** Injectable for tests. */
   existsFn?: (p: string) => boolean;
   readFn?: (p: string) => string;
+  /** Live-config discovery, injectable so tests never depend on the host's
+   *  real `/data/coolify/services` tree (see `DiscoverFn`). */
+  discoverFn?: DiscoverFn;
   log?: (msg: string) => void;
   /** Timestamp for the finding (ISO). Defaults to now. */
   nowIso?: string;
@@ -53,15 +57,27 @@ export interface LitellmSensorResult {
 }
 
 /**
+ * Live-config discovery seam. Defaults to the real filesystem scan; tests
+ * inject a stub so they assert the resolution LOGIC instead of the host's
+ * filesystem. A test that reads the real `/data/coolify/services` passes in
+ * hermetic CI and FAILS on any host where a live proxy config genuinely
+ * exists — a host-dependent test is a real defect, fixed by injecting here.
+ */
+export type DiscoverFn = () => LiveConfigDiscovery;
+
+/**
  * Resolve the live config path: explicit arg → `LITELLM_CONFIG_PATH` env →
  * discovery under the Coolify services dir. Returns null when the live copy is
  * not resolvable, which the caller treats as a visible skip — never a pass.
  */
-export function resolveLitellmConfigPath(explicit?: string): string | null {
+export function resolveLitellmConfigPath(
+  explicit?: string,
+  discoverFn: DiscoverFn = () => discoverLiveLitellmConfigPath(),
+): string | null {
   if (explicit) return explicit;
   const fromEnv = process.env.LITELLM_CONFIG_PATH;
   if (fromEnv) return fromEnv;
-  return discoverLiveLitellmConfigPath().path;
+  return discoverFn().path;
 }
 
 /**
@@ -73,7 +89,7 @@ export function resolveLitellmConfigPath(explicit?: string): string | null {
 export function scanLitellmConfig(
   opts: LitellmSensorOptions = {},
 ): LitellmSensorResult {
-  const path = resolveLitellmConfigPath(opts.path);
+  const path = resolveLitellmConfigPath(opts.path, opts.discoverFn);
   const exists = opts.existsFn ?? existsSync;
   const read = opts.readFn ?? ((p: string) => readFileSync(p, "utf-8"));
   const log = opts.log ?? (() => {});

--- a/src/litellm/header-passthrough-guard.test.ts
+++ b/src/litellm/header-passthrough-guard.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from "vitest";
 import {
   detectHeaderMisconfig,
   detectRetryFallbackGaps,
+  BARE_ANTHROPIC_FAMILY_ALIASES,
   isClaudeAllowlistedGroup,
   parseLitellmConfig,
 } from "./header-passthrough-guard.js";
@@ -59,14 +60,38 @@ model_group_settings:
 `;
 
 describe("isClaudeAllowlistedGroup", () => {
-  it("allows claude-* and the bare sonnet/fable aliases", () => {
-    for (const g of ["claude-opus-4", "claude-sonnet-5", "claude-haiku-4", "claude-fable-5", "sonnet", "fable"]) {
+  it("allows claude-* and the bare opus/sonnet/fable aliases", () => {
+    for (const g of [
+      "claude-opus-4",
+      "claude-opus-5",
+      "claude-sonnet-5",
+      "claude-haiku-4",
+      "claude-fable-5",
+      "opus",
+      "sonnet",
+      "fable",
+    ]) {
       expect(isClaudeAllowlistedGroup(g)).toBe(true);
     }
   });
-  it("EXCLUDES *-openrouter even when it matches claude-*", () => {
+  it("allows every member of BARE_ANTHROPIC_FAMILY_ALIASES (the maintenance contract)", () => {
+    expect(BARE_ANTHROPIC_FAMILY_ALIASES.has("opus")).toBe(true);
+    for (const alias of BARE_ANTHROPIC_FAMILY_ALIASES) {
+      expect(isClaudeAllowlistedGroup(alias)).toBe(true);
+    }
+  });
+  it("EXCLUDES *-openrouter even when it matches claude-* or a bare alias", () => {
     expect(isClaudeAllowlistedGroup("claude-sonnet-5-openrouter")).toBe(false);
     expect(isClaudeAllowlistedGroup("sonnet-openrouter")).toBe(false);
+    expect(isClaudeAllowlistedGroup("opus-openrouter")).toBe(false);
+    for (const alias of BARE_ANTHROPIC_FAMILY_ALIASES) {
+      expect(isClaudeAllowlistedGroup(`${alias}-openrouter`)).toBe(false);
+    }
+  });
+  it("does not allowlist a bare alias by prefix/substring (exact match only)", () => {
+    for (const g of ["opusx", "myopus", "opus-oss", "sonnetish"]) {
+      expect(isClaudeAllowlistedGroup(g)).toBe(false);
+    }
   });
   it("rejects non-Claude groups", () => {
     for (const g of ["gpt-oss", "glm", "openrouter/z-ai/glm-5.2", "gemini"]) {

--- a/src/litellm/header-passthrough-guard.ts
+++ b/src/litellm/header-passthrough-guard.ts
@@ -106,16 +106,42 @@ export function discoverLiveLitellmConfigPath(opts?: {
 }
 
 /**
+ * Bare (unversioned) Anthropic family aliases registered in the proxy's
+ * `model_list` — model groups whose name does NOT start with `claude-` but that
+ * still route to `anthropic/…` on the subscription OAuth.
+ *
+ * MAINTENANCE CONTRACT: every bare Anthropic family alias registered in the
+ * proxy's `model_list` MUST appear here, or the I2 guard raises a
+ * false-positive OAuth-leak violation against it — `npm run lint` fails on any
+ * host where the live config is discoverable, and the fleet-health sensor
+ * escalates a bogus L0 finding into the priority ledger. `opus` was added
+ * 2026-07-25 after exactly that drift; `sonnet` and `fable` had each been
+ * hand-added the same way before it. When you register a bare alias in
+ * `docker/litellm-proxy/litellm-config.yaml` (or the live host copy), add it
+ * here in the same change. See `docs/model-routing.md` § I1/I2.
+ *
+ * Membership is exact-match only, so an OpenRouter suffix variant of any of
+ * these (e.g. `sonnet-openrouter`) is a different group name, is NOT a member,
+ * and is additionally rejected by the explicit suffix check below.
+ */
+export const BARE_ANTHROPIC_FAMILY_ALIASES: ReadonlySet<string> = new Set([
+  "opus",
+  "sonnet",
+  "fable",
+]);
+
+/**
  * A subscription-Claude group is allowed to forward the OAuth header. Mirrors
- * `docs/model-routing.md:66-68`: `claude-*` (covers `claude-opus-*`,
- * `claude-sonnet-*`, `claude-haiku-*`, `claude-fable-5`), plus the bare aliases
- * `sonnet` and `fable`. `*-openrouter` groups are EXCLUDED even though they may
- * match `claude-*` (e.g. `claude-sonnet-5-openrouter`) — those route to
- * OpenRouter, a third party that must never see the subscription token.
+ * `docs/model-routing.md` § I2: `claude-*` (covers `claude-opus-*`,
+ * `claude-sonnet-*`, `claude-haiku-*`, `claude-fable-5`), plus the bare family
+ * aliases in `BARE_ANTHROPIC_FAMILY_ALIASES`. `*-openrouter` groups are
+ * EXCLUDED even though they may match `claude-*` (e.g.
+ * `claude-sonnet-5-openrouter`) — those route to OpenRouter, a third party that
+ * must never see the subscription token.
  */
 export function isClaudeAllowlistedGroup(name: string): boolean {
   if (name.endsWith("-openrouter")) return false;
-  return name.startsWith("claude-") || name === "sonnet" || name === "fable";
+  return name.startsWith("claude-") || BARE_ANTHROPIC_FAMILY_ALIASES.has(name);
 }
 
 /** A header-passthrough scoping violation (an OAuth-leak surface). */

--- a/tests/check-litellm-config-guard.test.ts
+++ b/tests/check-litellm-config-guard.test.ts
@@ -16,7 +16,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-import { discoverLiveLitellmConfigPath } from "../src/litellm/header-passthrough-guard.js";
+import {
+  BARE_ANTHROPIC_FAMILY_ALIASES,
+  discoverLiveLitellmConfigPath,
+} from "../src/litellm/header-passthrough-guard.js";
 
 const REPO = resolve(import.meta.dirname, "..");
 const SCRIPT = resolve(REPO, "scripts/check-litellm-config-guard.mjs");
@@ -201,6 +204,39 @@ model_group_settings:
           expect(r.stdout).not.toMatch(/SKIP \(live\)/);
           expect(r.stdout).toContain(ts.path);
         }
+      });
+    }
+  });
+
+  // Allowlist parity: the .mjs guard re-implements `isClaudeAllowlistedGroup`
+  // because it cannot import the TS core. Drive BOTH from the TS set so adding a
+  // bare alias to one copy and not the other fails CI instead of producing a
+  // false-positive OAuth-leak FAIL on-host (the bare `opus` regression).
+  describe("bare Anthropic family aliases are allowlisted in both copies", () => {
+    for (const alias of BARE_ANTHROPIC_FAMILY_ALIASES) {
+      it(`'${alias}' with the flag → exit 0, OK`, () => {
+        const r = runWith(
+          fixture(`
+model_group_settings:
+  ${alias}:
+    forward_client_headers_to_llm_api: true
+`),
+        );
+        expect(r.stderr).not.toMatch(/FAIL/);
+        expect(r.ok).toBe(true);
+        expect(r.stdout).toMatch(/OK/);
+      });
+
+      it(`'${alias}-openrouter' with the flag → exit 1, FAIL (no suffix hole)`, () => {
+        const r = runWith(
+          fixture(`
+model_group_settings:
+  ${alias}-openrouter:
+    forward_client_headers_to_llm_api: true
+`),
+        );
+        expect(r.ok).toBe(false);
+        expect(r.stderr).toMatch(new RegExp(`${alias}-openrouter`));
       });
     }
   });


### PR DESCRIPTION
## Summary

`isClaudeAllowlistedGroup` allowlisted `claude-*` plus the bare family aliases `sonnet` and `fable`, but **not `opus`**. The live proxy gained a bare `opus` model group on 2026-07-25 routing to `anthropic/claude-opus-5` — an Anthropic subscription-OAuth group, exactly the same class as `sonnet`/`fable`. Because the allowlist omitted it, `detectHeaderMisconfig` raised a false-positive I2 violation: `forward_client_headers_to_llm_api: true on non-Claude group 'opus'`.

There is **no actual OAuth leak** — every group carrying the flag routes to Anthropic.

## Why

Two real consequences, both verified on a host where the live config is discoverable:

1. `npm run lint` → `check-litellm-config-guard` **FAILs**.
2. The fleet-health litellm sensor returns `status: "violation"` instead of `"ok"`, escalating a bogus L0 finding into the priority ledger → a GitHub issue.

## What changed

- **`src/litellm/header-passthrough-guard.ts`** — bare aliases are now one named exported constant `BARE_ANTHROPIC_FAMILY_ALIASES` (`opus`, `sonnet`, `fable`) carrying the maintenance contract in its doc comment, instead of a chain of `name === "..."` literals hand-extended once per alias (this was the third such extension). Membership is exact-match; the `*-openrouter` exclusion is unchanged and still evaluated first, so `opus-openrouter` / `sonnet-openrouter` remain rejected.
- **`scripts/check-litellm-config-guard.mjs`** — the .mjs mirror (it cannot import the TS core) is driven by the same list, plus its FAIL/doc text updated.
- **Tests** — `opus` allowlisted, `opus-openrouter` NOT, no substring/prefix hole (`opusx`, `myopus`), a config with the flag on `opus` produces zero violations / sensor `ok`, and a **parity test** in `tests/check-litellm-config-guard.test.ts` that iterates the TS set and runs the real .mjs script for each member (+ its `-openrouter` variant). Adding an alias to one copy and not the other now fails CI rather than resurfacing as a false-positive on-host.
- **`docs/model-routing.md`** — allowlist enumeration corrected and the "register a bare alias → add it to the set in the same change" rule written down.

### Also: two pre-existing non-hermetic tests

`src/fleet-health/litellm-config-sensor.test.ts` had two cases (the discovery fall-through and "unresolvable live path → skipped") that injected `existsFn`/`readFn` but **not** discovery, so they read the real `/data/coolify/services/*/litellm-config.yaml`. They pass in hermetic CI and **fail on any machine that actually runs the live proxy** — a host-dependent test is a real defect, and it blocked local verification of this fix. Discovery is now an injectable seam (`DiscoverFn`, `LitellmSensorOptions.discoverFn`, an optional 2nd arg to `resolveLitellmConfigPath`, defaulting to the real scan) and both tests stub it. Same subsystem, same PR.

## Scope note

Considered deriving the allowlist from `model_list` routing (allowlist a group iff its `litellm_params.model` starts with `anthropic/`). That is the structurally better fix — it would make drift impossible rather than merely loud — but it changes what the guard means (routing-derived vs name-derived), needs care for groups present in `model_group_settings` but absent from `model_list`, and would have to be mirrored into the .mjs copy. Out of scope here; this PR ships the minimal correct change plus a CI-enforced parity/maintenance mechanism.

Separately noted, not changed: the repo-managed `docker/litellm-proxy/litellm-config.yaml` has no `opus`/`claude-opus-5` group while the live copy does — the repo copy has drifted behind live. That is an operator reconciliation task, not a repo-code fix, and touching it would change proxy routing on next sync.

## Test plan

- `vitest run src/litellm/header-passthrough-guard.test.ts src/fleet-health/litellm-config-sensor.test.ts src/litellm/repo-config.test.ts tests/check-litellm-config-guard.test.ts` → **64 passed**.
- Confirmed the two sensor tests **fail on pristine `origin/main`** on this host (`expected 'violation' to be 'skipped'`) and pass with this diff — bucket 2 (pre-existing), fixed here rather than footnoted.
- `npm run lint` → fully green, including `check-litellm-config-guard: OK` for **both** the repo copy and the live copy. Before this diff the same command emitted `FAIL — ... non-Claude group 'opus'`.
- No deployment service id appears anywhere in the diff (`check-no-pii-secrets: clean`).

## Risk

Low. The change widens the allowlist by exactly one exact-match name that is an Anthropic OAuth passthrough, and narrows nothing. The `*-openrouter` exclusion is unchanged and now has explicit per-alias coverage. Repo-only: no live host config or Coolify compose was touched.

Job spec: `reference/jobs/keep-my-subscription-honest.md` — the I2 guard is the enforcement point for that job, and a guard that cries wolf on a compliant config degrades it (noise in the ledger, a red lint that trains people to ignore it).