### PR TITLE
fix(workspace-hook): local-time watch set, cache empty renders, deletion/race-proof invalidation (#3546)

### DIFF
--- a/bin/workspace-dynamic-hook.sh
+++ b/bin/workspace-dynamic-hook.sh
@@ -66,24 +66,42 @@ mkdir -p "$CACHE_DIR" 2>/dev/null || true
 # Date-keyed cache filename: when the calendar day rolls over, the
 # `today's daily` file path the renderer reads changes (the template
 # embeds different filenames in its output), so we invalidate the cache
-# at midnight UTC by varying the filename. Yesterday's file lingers
+# at midnight by varying the filename. Yesterday's file lingers
 # harmlessly until the next sweep.
-CACHE_DATE="$(date -u +%Y-%m-%d)"
+#
+# LOCAL time, not UTC — this MUST match the renderer. See
+# `dailyMemoryRelativePath` in src/agents/workspace.ts, which derives
+# today's daily-memory path from getFullYear/getMonth/getDate (local)
+# on purpose: UTC would roll "today" over at early-morning for UTC+10
+# hosts. When the hook used `date -u` here, every day from 00:00 until
+# UTC midnight local the renderer's "today" file was absent from the
+# hook's watch set, so writes to it did not invalidate the cache and a
+# stale body was served.
+CACHE_DATE="$(date +%Y-%m-%d)"
 CACHE_FILE="$CACHE_DIR/workspace-dynamic.${CACHE_DATE}.hash"
 BODY_FILE="$CACHE_DIR/workspace-dynamic.${CACHE_DATE}.body"
+SIG_FILE="$CACHE_DIR/workspace-dynamic.${CACHE_DATE}.srcsig"
 
-# Mtime-fast-skip: if BODY_FILE exists AND is newer than every workspace
-# source the renderer reads, we can emit the cached body and skip the
+# Source-signature fast-skip: if BODY_FILE exists AND the signature of
+# the workspace source *set* is byte-identical to the signature recorded
+# when that body was produced, we can emit the cached body and skip the
 # ~800ms `switchroom workspace render` invocation entirely. The renderer
 # reads MEMORY.md, today's daily, yesterday's daily — see
 # `loadDynamicBootstrapFiles` in src/agents/workspace.ts.
 #
-# Skip semantics: a source file that doesn't exist contributes a "very
-# old" mtime (epoch-0 via stat fallback), which never invalidates the
-# cache. A source file that's been updated since BODY_FILE's mtime
-# triggers a fresh render. Forensics measured this fast-path saving
-# ~825ms on the common case (chat turns where MEMORY hasn't changed
-# since the last turn).
+# The signature covers each source's name + mtime + size, and records
+# missing files explicitly. A max-mtime comparison (the previous
+# approach) could not see a *deletion*: a missing source contributed
+# mtime 0, which never exceeded the body's mtime, so removing MEMORY.md
+# served the cached body forever. It also lost any source modified
+# between the render and the body write (the write-during-render race):
+# such a source ended up older than the body and became invisible
+# indefinitely. Capturing the signature *before* invoking the renderer
+# closes both: anything that changes during or after the render window
+# yields a different signature on the next turn.
+#
+# Forensics measured this fast-path saving ~825ms on the common case
+# (chat turns where no source has changed since the last turn).
 #
 # Resolve the agent's workspace dir. Switchroom uses
 # `~/.switchroom/agents/<name>/workspace/` by default. We avoid invoking
@@ -95,25 +113,35 @@ BODY_FILE="$CACHE_DIR/workspace-dynamic.${CACHE_DATE}.body"
 AGENT_DIR="${SWITCHROOM_AGENT_DIR:-$HOME/.switchroom/agents/$AGENT_NAME}"
 WS_DIR="$AGENT_DIR/workspace"
 TODAY_FILE="$WS_DIR/memory/${CACHE_DATE}.md"
-YESTERDAY_DATE="$(date -u -d 'yesterday' +%Y-%m-%d 2>/dev/null || echo "")"
+# Local-time "yesterday", matching addDays(now, -1) in workspace.ts.
+YESTERDAY_DATE="$(date -d 'yesterday' +%Y-%m-%d 2>/dev/null || echo "")"
 YESTERDAY_FILE="$WS_DIR/memory/${YESTERDAY_DATE}.md"
 
-if [ -f "$BODY_FILE" ]; then
-  # Compare BODY_FILE mtime against every source. If any source is newer
-  # the cache is stale; fall through. If all sources are older (or
-  # missing), emit the cache and exit.
-  body_mtime=$(stat -c '%Y' "$BODY_FILE" 2>/dev/null || echo 0)
-  newest_src_mtime=0
-  for src in "$WS_DIR/MEMORY.md" "$TODAY_FILE" "$YESTERDAY_FILE"; do
-    if [ -f "$src" ]; then
-      src_mtime=$(stat -c '%Y' "$src" 2>/dev/null || echo 0)
-      if [ "$src_mtime" -gt "$newest_src_mtime" ]; then
-        newest_src_mtime="$src_mtime"
+# Signature of the source set: name + mtime + size for each source the
+# renderer reads, with missing files recorded explicitly so a deletion
+# changes the signature.
+_ws_source_signature() {
+  local src meta
+  {
+    for src in "$WS_DIR/MEMORY.md" "$TODAY_FILE" "$YESTERDAY_FILE"; do
+      if [ -f "$src" ]; then
+        meta=$(stat -c '%Y:%s' "$src" 2>/dev/null || echo "stat-error")
+        printf '%s\t%s\n' "$src" "$meta"
+      else
+        printf '%s\tMISSING\n' "$src"
       fi
-    fi
-  done
-  if [ "$body_mtime" -gt "$newest_src_mtime" ]; then
-    # Fast path: every source is older than the cached body.
+    done
+  } | sha256sum 2>/dev/null | cut -d' ' -f1
+}
+
+# Captured BEFORE the renderer runs, so a source mutated during the
+# render window is not falsely credited to this body.
+SRC_SIG="$(_ws_source_signature)"
+
+if [ -f "$BODY_FILE" ] && [ -f "$SIG_FILE" ] && [ -n "$SRC_SIG" ]; then
+  RECORDED_SIG=$(head -1 "$SIG_FILE" 2>/dev/null || echo "")
+  if [ "$RECORDED_SIG" = "$SRC_SIG" ]; then
+    # Fast path: the source set is unchanged since this body was made.
     # In inject-on-change mode, also check the session-state file — if the
     # session_id matches the last-emitted session AND the hash matches, we
     # can suppress entirely (model already has this content in context).
@@ -155,11 +183,25 @@ fi
 # <50ms; 3s is generous headroom.
 WS_DYNAMIC=$(timeout 3 switchroom workspace render "$AGENT_NAME" --dynamic --warning-mode off 2>/dev/null || true)
 
-# Empty render → emit nothing AND do NOT cache the empty body. Caching an
-# empty body would re-emit empty forever even after MEMORY comes back online,
-# defeating the whole purpose of the hook.
-if [ -z "$WS_DYNAMIC" ]; then
-  exit 0
+# An empty render IS cached. It used to `exit 0` here without writing the
+# cache, on the theory that "caching an empty body would re-emit empty
+# forever even after MEMORY comes back online" — that justification is
+# obsolete: the fast-skip re-derives the source signature every turn, so a
+# MEMORY.md that later appears (or any daily-memory write) changes the
+# signature and forces a fresh render. Not caching it meant agents whose
+# render is empty never had a cached body, the fast-skip never engaged, and
+# they paid the full ~825ms-1.1s render on every single message to produce
+# nothing.
+#
+# BODY_OUT is the exact byte string emitted on both the fresh and the cached
+# path, so `cat "$BODY_FILE"` is byte-identical to a fresh emit (Anthropic's
+# prompt cache is keyed on byte equality). Empty render → empty body file →
+# empty stdout, not a bare newline.
+if [ -n "$WS_DYNAMIC" ]; then
+  BODY_OUT="$WS_DYNAMIC
+"
+else
+  BODY_OUT=""
 fi
 
 # Content-addressed dedupe sidecar. Anthropic's prompt cache is keyed on
@@ -197,7 +239,17 @@ _ws_record_session_state() {
   fi
 }
 
+# Record the pre-render source signature against the body we are about to
+# serve. Written only once a body file actually exists, so a failed body
+# write can never leave a "fresh" signature pointing at a stale body.
+_ws_record_sig() {
+  if [ -n "$SRC_SIG" ] && [ -f "$BODY_FILE" ]; then
+    printf '%s\n' "$SRC_SIG" > "$SIG_FILE" 2>/dev/null || true
+  fi
+}
+
 if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" = "$OLD_HASH" ] && [ -f "$BODY_FILE" ]; then
+  _ws_record_sig
   # Content unchanged since last render. In inject-on-change mode, check if
   # we already injected this content in the current session — if so, suppress.
   if [ "$INJECT_ON_CHANGE" != "0" ] && [ -n "$SESSION_ID" ]; then
@@ -215,17 +267,16 @@ if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" = "$OLD_HASH" ] && [ -f "$BODY_FILE" ]; t
   fi
   cat "$BODY_FILE"
 else
-  # Refresh sidecar: write hash + body, then echo body. Touch the body
-  # file last so the mtime fast-skip path next turn sees a fresh
-  # mtime (newer than every source we just consumed).
+  # Refresh sidecar: write hash + body, then echo body.
   if [ -n "$NEW_HASH" ]; then
     printf '%s\n' "$NEW_HASH" > "$CACHE_FILE" 2>/dev/null || true
-    printf '%s\n' "$WS_DYNAMIC" > "$BODY_FILE" 2>/dev/null || true
+    printf '%s' "$BODY_OUT" > "$BODY_FILE" 2>/dev/null || true
+    _ws_record_sig
     if [ "$INJECT_ON_CHANGE" != "0" ] && [ -n "$SESSION_ID" ]; then
       _ws_record_session_state "$NEW_HASH" "$SESSION_ID"
     fi
   fi
-  printf '%s\n' "$WS_DYNAMIC"
+  printf '%s' "$BODY_OUT"
 fi
 
 exit 0

--- a/bin/workspace-dynamic-hook.sh
+++ b/bin/workspace-dynamic-hook.sh
@@ -66,8 +66,14 @@ mkdir -p "$CACHE_DIR" 2>/dev/null || true
 # Date-keyed cache filename: when the calendar day rolls over, the
 # `today's daily` file path the renderer reads changes (the template
 # embeds different filenames in its output), so we invalidate the cache
-# at midnight by varying the filename. Yesterday's file lingers
-# harmlessly until the next sweep.
+# at midnight by varying the filename.
+#
+# Prior days' files are never cleaned up — there is no sweeper for this
+# directory anywhere in the repo. That is deliberate and cheap, not an
+# oversight: three small files per agent per day (~1100/year), a hash
+# and a signature of 65 bytes each plus a body bounded by
+# DEFAULT_DYNAMIC_TOTAL_MAX_CHARS. If that ever needs reclaiming it
+# should be a real sweeper, not a comment claiming one exists.
 #
 # LOCAL time, not UTC — this MUST match the renderer. See
 # `dailyMemoryRelativePath` in src/agents/workspace.ts, which derives
@@ -120,12 +126,23 @@ YESTERDAY_FILE="$WS_DIR/memory/${YESTERDAY_DATE}.md"
 # Signature of the source set: name + mtime + size for each source the
 # renderer reads, with missing files recorded explicitly so a deletion
 # changes the signature.
+#
+# `%.9Y` (nanosecond mtime), NOT `%Y`. With whole-second mtimes, a
+# content change that lands in the same second as the previous one and
+# happens to keep the same file size produces an identical signature, so
+# the edit is served stale indefinitely — until some later change moves
+# the second or the size. That is strictly worse than the max-mtime
+# comparison this replaced, which fell through on an equal-second
+# collision (`-gt` is false when equal) and re-rendered. Nanosecond
+# resolution closes it. If a filesystem reports a zero nanosecond field
+# the signature degrades to second precision, i.e. exactly the old
+# behaviour, never worse.
 _ws_source_signature() {
   local src meta
   {
     for src in "$WS_DIR/MEMORY.md" "$TODAY_FILE" "$YESTERDAY_FILE"; do
       if [ -f "$src" ]; then
-        meta=$(stat -c '%Y:%s' "$src" 2>/dev/null || echo "stat-error")
+        meta=$(stat -c '%.9Y:%s' "$src" 2>/dev/null || echo "stat-error")
         printf '%s\t%s\n' "$src" "$meta"
       else
         printf '%s\tMISSING\n' "$src"
@@ -138,9 +155,26 @@ _ws_source_signature() {
 # render window is not falsely credited to this body.
 SRC_SIG="$(_ws_source_signature)"
 
+# Is the cached body intact? CACHE_FILE holds sha256 of the render output
+# with no trailing newline; BODY_FILE holds that same output plus one
+# trailing newline (or is empty for an empty render). Command substitution
+# strips trailing newlines, so this reproduces the recorded hash exactly in
+# both cases. Without it a body truncated by a crash mid-write is served to
+# the model verbatim and pinned into the fast path forever, because the
+# signature only vouches for the *sources*, never for the body. One sha256
+# over at most DEFAULT_DYNAMIC_TOTAL_MAX_CHARS is negligible against the
+# ~825ms render it guards.
+_ws_body_intact() {
+  local recorded actual
+  recorded=$(head -1 "$CACHE_FILE" 2>/dev/null || echo "")
+  [ -n "$recorded" ] || return 1
+  actual=$(printf '%s' "$(cat "$BODY_FILE" 2>/dev/null)" | sha256sum 2>/dev/null | cut -d' ' -f1)
+  [ -n "$actual" ] && [ "$actual" = "$recorded" ]
+}
+
 if [ -f "$BODY_FILE" ] && [ -f "$SIG_FILE" ] && [ -n "$SRC_SIG" ]; then
   RECORDED_SIG=$(head -1 "$SIG_FILE" 2>/dev/null || echo "")
-  if [ "$RECORDED_SIG" = "$SRC_SIG" ]; then
+  if [ "$RECORDED_SIG" = "$SRC_SIG" ] && _ws_body_intact; then
     # Fast path: the source set is unchanged since this body was made.
     # In inject-on-change mode, also check the session-state file — if the
     # session_id matches the last-emitted session AND the hash matches, we
@@ -239,17 +273,41 @@ _ws_record_session_state() {
   fi
 }
 
-# Record the pre-render source signature against the body we are about to
-# serve. Written only once a body file actually exists, so a failed body
-# write can never leave a "fresh" signature pointing at a stale body.
-_ws_record_sig() {
+# Write a cache file atomically: fill a per-PID temp file, then rename it
+# into place. A plain `>` redirect truncates first, so a concurrent hook
+# process can observe (and cache, and serve) a half-written body. rename(2)
+# is atomic within a filesystem, so a reader sees either the whole old file
+# or the whole new one.
+_ws_write_atomic() {
+  local dest="$1" content="$2" tmp="$1.tmp.$$"
+  if printf '%s' "$content" > "$tmp" 2>/dev/null; then
+    mv -f "$tmp" "$dest" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+  else
+    rm -f "$tmp" 2>/dev/null || true
+  fi
+}
+
+# Publish the body and the pre-render source signature that vouches for it.
+# Body first, signature second, both atomic: the signature is what arms the
+# fast path, so it must never become visible before the body it describes.
+# The signature is only written once the body file actually exists, so a
+# failed body write can never leave a "fresh" signature pointing at a stale
+# body.
+_ws_publish() {
+  _ws_write_atomic "$BODY_FILE" "$BODY_OUT"
   if [ -n "$SRC_SIG" ] && [ -f "$BODY_FILE" ]; then
-    printf '%s\n' "$SRC_SIG" > "$SIG_FILE" 2>/dev/null || true
+    _ws_write_atomic "$SIG_FILE" "$SRC_SIG
+"
   fi
 }
 
 if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" = "$OLD_HASH" ] && [ -f "$BODY_FILE" ]; then
-  _ws_record_sig
+  # Rewrite the body unconditionally, even though the hash says it is
+  # unchanged. NEW_HASH and OLD_HASH both derive from CACHE_FILE and the
+  # fresh render — neither validates BODY_FILE — so a body truncated by a
+  # crash mid-write would otherwise be cat'd to the model AND pinned into
+  # the fast path by the signature we are about to stamp on it.
+  _ws_publish
   # Content unchanged since last render. In inject-on-change mode, check if
   # we already injected this content in the current session — if so, suppress.
   if [ "$INJECT_ON_CHANGE" != "0" ] && [ -n "$SESSION_ID" ]; then
@@ -269,9 +327,9 @@ if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" = "$OLD_HASH" ] && [ -f "$BODY_FILE" ]; t
 else
   # Refresh sidecar: write hash + body, then echo body.
   if [ -n "$NEW_HASH" ]; then
-    printf '%s\n' "$NEW_HASH" > "$CACHE_FILE" 2>/dev/null || true
-    printf '%s' "$BODY_OUT" > "$BODY_FILE" 2>/dev/null || true
-    _ws_record_sig
+    _ws_write_atomic "$CACHE_FILE" "$NEW_HASH
+"
+    _ws_publish
     if [ "$INJECT_ON_CHANGE" != "0" ] && [ -n "$SESSION_ID" ]; then
       _ws_record_session_state "$NEW_HASH" "$SESSION_ID"
     fi

--- a/tests/workspace-dynamic-hook.test.ts
+++ b/tests/workspace-dynamic-hook.test.ts
@@ -9,9 +9,13 @@ import { join, resolve } from "node:path";
  * `switchroom` shim on PATH that we control. Verifies:
  *   - byte-stable output across two consecutive invocations with
  *     identical render input (the whole point of the dedupe sidecar)
- *   - empty render → empty stdout AND no cache file written (we don't
- *     want to re-emit empty forever)
+ *   - empty render → empty stdout, but the empty body IS cached so the
+ *     fast-skip engages next turn (see #3546 part 1)
  *   - changed render → updated cache + new body emitted
+ *   - the source watch set is derived from LOCAL time, matching the
+ *     renderer (#3546 part 2)
+ *   - a source mutated during the render window, and a deleted source,
+ *     both invalidate the cache (#3546 parts 3 and 4)
  */
 const HOOK = resolve(__dirname, "../bin/workspace-dynamic-hook.sh");
 
@@ -29,12 +33,18 @@ function runHook(opts: {
    * point at a tmp tree so they can touch source files to invalidate
    * the cache deterministically. */
   agentDirOverride?: string;
+  /** Override the timezone the hook derives its "today"/"yesterday"
+   * daily-memory filenames from. */
+  tz?: string;
 }): RunResult {
   const env: Record<string, string> = {
     ...process.env as Record<string, string>,
     PATH: `${opts.shimDir}:${process.env.PATH ?? ""}`,
     CLAUDE_CONFIG_DIR: opts.cacheDir,
   };
+  if (opts.tz !== undefined) {
+    env.TZ = opts.tz;
+  }
   if (opts.agentName !== undefined) {
     env.SWITCHROOM_AGENT_NAME = opts.agentName;
   } else {
@@ -84,9 +94,53 @@ describe("workspace-dynamic-hook.sh", () => {
 
   // The hook date-keys cache filenames so the calendar-day rollover
   // invalidates yesterday's cache (the renderer embeds today's daily
-  // path in the body). Compute the same UTC date the script does.
-  function todayUtc(): string {
-    return new Date().toISOString().slice(0, 10);
+  // path in the body). Compute the same LOCAL date the script does —
+  // the hook must agree with `dailyMemoryRelativePath` in
+  // src/agents/workspace.ts, which is local-time by design.
+  function dateIn(tz: string, date: Date = new Date()): string {
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone: tz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(date);
+  }
+
+  function todayLocal(): string {
+    const d = new Date();
+    const p2 = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${p2(d.getMonth() + 1)}-${p2(d.getDate())}`;
+  }
+
+  const DAY_MS = 86_400_000;
+
+  /**
+   * Pick a timezone, plus a daily-memory filename, such that the file is
+   * a genuine renderer source (local today or local yesterday) but is
+   * NOT in the watch set a UTC-based hook would build ({utc today, utc
+   * yesterday}).
+   *
+   * UTC+14 leads UTC's date whenever the UTC hour is >= 10; UTC-11 lags
+   * it whenever the UTC hour is < 11 — so one of the two always
+   * qualifies, making this deterministic at any wall-clock time. (Both
+   * fixed-offset zones, so no DST to complicate the -1 day arithmetic.)
+   */
+  function pickTzAndUnwatchedDailyFile(): { tz: string; date: string; role: string } {
+    const now = new Date();
+    const utcSet = new Set([
+      now.toISOString().slice(0, 10),
+      new Date(now.getTime() - DAY_MS).toISOString().slice(0, 10),
+    ]);
+    for (const tz of ["Etc/GMT-14", "Etc/GMT+11"]) {
+      const candidates: Array<[string, string]> = [
+        ["today", dateIn(tz, now)],
+        ["yesterday", dateIn(tz, new Date(now.getTime() - DAY_MS))],
+      ];
+      for (const [role, date] of candidates) {
+        if (!utcSet.has(date)) return { tz, date, role };
+      }
+    }
+    throw new Error("no timezone yields a local daily file outside the UTC watch set");
   }
 
   beforeEach(() => {
@@ -100,14 +154,48 @@ describe("workspace-dynamic-hook.sh", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("returns empty stdout and writes no cache when render is empty", () => {
+  it("returns empty stdout and caches the empty body when render is empty", () => {
+    const fakeAgentDir = join(tmp, "agent");
+    mkdirSync(join(fakeAgentDir, "workspace"), { recursive: true });
     makeShim(shimDir, "");
-    const r = runHook({ agentName: "klanker", cacheDir, shimDir });
+    const r = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toBe("");
-    // Critically: NO cache file. Otherwise we'd re-emit empty forever.
-    const hookCache = join(cacheDir, "switchroom-hookcache", `workspace-dynamic.${todayUtc()}.hash`);
-    expect(existsSync(hookCache)).toBe(false);
+    // The empty body IS cached (#3546 part 1): the fast-skip re-derives
+    // the source signature every turn, so a MEMORY.md that later appears
+    // still invalidates it. Not caching meant empty-render agents paid
+    // the full ~825ms render on every single message.
+    const dir = join(cacheDir, "switchroom-hookcache");
+    const date = todayLocal();
+    expect(existsSync(join(dir, `workspace-dynamic.${date}.hash`))).toBe(true);
+    expect(existsSync(join(dir, `workspace-dynamic.${date}.body`))).toBe(true);
+    expect(readFileSync(join(dir, `workspace-dynamic.${date}.body`), "utf-8")).toBe("");
+  });
+
+  it("fast-skips the renderer on the turn after an empty render", () => {
+    const fakeAgentDir = join(tmp, "agent");
+    mkdirSync(join(fakeAgentDir, "workspace"), { recursive: true });
+    const marker = join(tmp, "shim-invoked");
+
+    // Shim records each invocation so we can assert the second turn
+    // never reaches the (~825ms) renderer at all.
+    mkdirSync(shimDir, { recursive: true });
+    writeFileSync(
+      join(shimDir, "switchroom"),
+      `#!/bin/bash\necho x >> '${marker}'\n`,
+      { mode: 0o755 },
+    );
+    chmodSync(join(shimDir, "switchroom"), 0o755);
+
+    const a = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    expect(a.stdout).toBe("");
+    expect(readFileSync(marker, "utf-8").trim().split("\n").length).toBe(1);
+
+    const b = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    expect(b.exitCode).toBe(0);
+    expect(b.stdout).toBe("");
+    // Still exactly one invocation — turn two took the fast path.
+    expect(readFileSync(marker, "utf-8").trim().split("\n").length).toBe(1);
   });
 
   it("emits the rendered payload and caches it", () => {
@@ -118,7 +206,7 @@ describe("workspace-dynamic-hook.sh", () => {
     expect(r.stdout).toContain("thing one");
     expect(r.stdout).toContain("thing two");
 
-    const date = todayUtc();
+    const date = todayLocal();
     const hashFile = join(cacheDir, "switchroom-hookcache", `workspace-dynamic.${date}.hash`);
     const bodyFile = join(cacheDir, "switchroom-hookcache", `workspace-dynamic.${date}.body`);
     expect(existsSync(hashFile)).toBe(true);
@@ -173,9 +261,89 @@ describe("workspace-dynamic-hook.sh", () => {
     expect(b.stdout).toContain("second body");
     expect(b.stdout).not.toBe(a.stdout);
 
-    const date = todayUtc();
+    const date = todayLocal();
     const bodyFile = join(cacheDir, "switchroom-hookcache", `workspace-dynamic.${date}.body`);
     expect(readFileSync(bodyFile, "utf-8")).toContain("second body");
+  });
+
+  it("watches the LOCAL-time daily memory file, not the UTC one (#3546 part 2)", async () => {
+    // The renderer reads `memory/<local-today>.md`
+    // (dailyMemoryRelativePath, src/agents/workspace.ts:257-262 — local
+    // by design). When the hook derived its watch set from `date -u`,
+    // a write to the renderer's today-file was invisible for the hours
+    // where the local date leads/lags UTC, and a stale body was served.
+    const { tz, date: localDate, role } = pickTzAndUnwatchedDailyFile();
+    expect(["today", "yesterday"]).toContain(role);
+
+    const fakeAgentDir = join(tmp, "agent");
+    const memDir = join(fakeAgentDir, "workspace", "memory");
+    mkdirSync(memDir, { recursive: true });
+
+    makeShim(shimDir, "first body content");
+    const a = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir, tz });
+    expect(a.stdout).toContain("first body");
+
+    await new Promise((r) => setTimeout(r, 1100));
+    // Write a daily-memory file the renderer genuinely reads (local
+    // today or local yesterday) but that a UTC-derived watch set misses.
+    writeFileSync(join(memDir, `${localDate}.md`), "daily note");
+
+    makeShim(shimDir, "second body content");
+    const b = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir, tz });
+    expect(b.stdout).toContain("second body");
+  });
+
+  it("re-renders when a source is deleted (#3546 part 4)", async () => {
+    // A missing source used to contribute mtime 0, which never exceeded
+    // the body's mtime — so deleting MEMORY.md served the cached body
+    // forever. The source-set signature records MISSING explicitly.
+    const fakeAgentDir = join(tmp, "agent");
+    const wsDir = join(fakeAgentDir, "workspace");
+    mkdirSync(wsDir, { recursive: true });
+    const memPath = join(wsDir, "MEMORY.md");
+    writeFileSync(memPath, "remembered things");
+
+    makeShim(shimDir, "first body content");
+    const a = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    expect(a.stdout).toContain("first body");
+
+    rmSync(memPath);
+
+    makeShim(shimDir, "second body content");
+    const b = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    expect(b.stdout).toContain("second body");
+  });
+
+  it("picks up a source mutated during the render window (#3546 part 3)", async () => {
+    // Sources are read by the renderer; the body is written after it
+    // returns. A source touched in between used to end up OLDER than
+    // the body and became invisible to a max-mtime fast-skip forever.
+    // The signature is captured BEFORE the render, so the change shows
+    // up on the next turn.
+    const fakeAgentDir = join(tmp, "agent");
+    const wsDir = join(fakeAgentDir, "workspace");
+    mkdirSync(wsDir, { recursive: true });
+    const memPath = join(wsDir, "MEMORY.md");
+    writeFileSync(memPath, "v1");
+
+    // Shim mutates MEMORY.md *during* the render, then stalls past the
+    // 1s stat granularity so the body lands with a strictly newer mtime
+    // than the source — exactly the condition that hid the write.
+    mkdirSync(shimDir, { recursive: true });
+    writeFileSync(
+      join(shimDir, "switchroom"),
+      `#!/bin/bash\nprintf 'v2-during-render' > '${memPath}'\nsleep 1.2\nprintf '%s' 'first body content'\n`,
+      { mode: 0o755 },
+    );
+    chmodSync(join(shimDir, "switchroom"), 0o755);
+
+    const a = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    expect(a.stdout).toContain("first body");
+    expect(readFileSync(memPath, "utf-8")).toBe("v2-during-render");
+
+    makeShim(shimDir, "second body content");
+    const b = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    expect(b.stdout).toContain("second body");
   });
 
   it("exits silently with no output when SWITCHROOM_AGENT_NAME is unset", () => {

--- a/tests/workspace-dynamic-hook.test.ts
+++ b/tests/workspace-dynamic-hook.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, existsSync, readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  chmodSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  utimesSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -344,6 +355,79 @@ describe("workspace-dynamic-hook.sh", () => {
     makeShim(shimDir, "second body content");
     const b = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
     expect(b.stdout).toContain("second body");
+  });
+
+  it("re-renders on a same-second, same-size source change", () => {
+    // Regression guard for the signature's mtime precision. With a
+    // whole-second `stat -c %Y`, a content change landing in the same
+    // second as the previous one while keeping the same file size
+    // produces an identical signature, and the edit is served stale
+    // indefinitely — until some later change moves the second or the
+    // size. `%.9Y` (nanoseconds) closes it.
+    const fakeAgentDir = join(tmp, "agent");
+    const wsDir = join(fakeAgentDir, "workspace");
+    mkdirSync(wsDir, { recursive: true });
+    const memPath = join(wsDir, "MEMORY.md");
+    writeFileSync(memPath, "AAAA");
+    const stamp = statSync(memPath).mtime;
+
+    makeShim(shimDir, "first body content");
+    const a = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    expect(a.stdout).toContain("first body");
+
+    // Same byte length, and forced back to the *same whole second* as the
+    // original write (nanoseconds still differ, which is the point).
+    writeFileSync(memPath, "BBBB");
+    const changed = statSync(memPath);
+    utimesSync(memPath, changed.atime, new Date(stamp.getTime()));
+    expect(Math.floor(statSync(memPath).mtimeMs / 1000)).toBe(
+      Math.floor(stamp.getTime() / 1000),
+    );
+    expect(statSync(memPath).size).toBe(4);
+
+    makeShim(shimDir, "second body content");
+    const b = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    expect(b.stdout).toContain("second body");
+  });
+
+  it("repairs a truncated cached body instead of serving and pinning it", () => {
+    // Nothing in the cache validated BODY_FILE: the signature vouches for
+    // the *sources*, and the hash-match branch compares NEW_HASH to
+    // OLD_HASH, both derived from CACHE_FILE and the fresh render. So a
+    // body truncated by a crash mid-write was cat'd to the model verbatim
+    // AND pinned into the fast path. Two defenses now: the fast path
+    // verifies the body against the recorded hash before serving it, and
+    // the hash-match branch rewrites the body unconditionally.
+    const fakeAgentDir = join(tmp, "agent");
+    const wsDir = join(fakeAgentDir, "workspace");
+    mkdirSync(wsDir, { recursive: true });
+    writeFileSync(join(wsDir, "MEMORY.md"), "remembered things");
+
+    const payload = "intact body content";
+    makeShim(shimDir, payload);
+    const a = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    expect(a.stdout).toContain("intact body");
+
+    // Simulate a crash mid-write: body truncated, hash file left intact.
+    const bodyFile = join(cacheDir, "switchroom-hookcache", `workspace-dynamic.${todayLocal()}.body`);
+    writeFileSync(bodyFile, "intact bo");
+
+    // Same render output → hash matches → the hash-match branch runs.
+    const b = runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    expect(b.stdout).toContain("intact body content");
+    expect(readFileSync(bodyFile, "utf-8")).toBe(`${payload}\n`);
+  });
+
+  // Hygiene guard on the atomic-write helper itself, not a regression
+  // test for an observed bug: a botched `mv` would strand `.tmp.$$`
+  // files in the cache dir and grow it without bound.
+  it("never leaves a temp cache file behind", () => {
+    const fakeAgentDir = join(tmp, "agent");
+    mkdirSync(join(fakeAgentDir, "workspace"), { recursive: true });
+    makeShim(shimDir, "body content");
+    runHook({ agentName: "klanker", cacheDir, shimDir, agentDirOverride: fakeAgentDir });
+    const entries = readdirSync(join(cacheDir, "switchroom-hookcache"));
+    expect(entries.filter((e) => e.includes(".tmp."))).toEqual([]);
   });
 
   it("exits silently with no output when SWITCHROOM_AGENT_NAME is unset", () => {


### PR DESCRIPTION
Fixes #3546. All four parts land together — part 2 is *activated* by fixing part 1.

## The contradiction, validated in real source

The deployed script at `/opt/switchroom/bin/workspace-dynamic-hook.sh` is **byte-identical** to the repo source `bin/workspace-dynamic-hook.sh` (verified with `diff`), so this is a repo-only change — no build artifact was touched.

Two halves of one feature disagreed about what "today" means:

- Hook (before): `CACHE_DATE="$(date -u +%Y-%m-%d)"` at `bin/workspace-dynamic-hook.sh:71`, with `TODAY_FILE` (`:97`) and `YESTERDAY_DATE` (`:98`) also UTC.
- Renderer: `dailyMemoryRelativePath()` at `src/agents/workspace.ts:257-262` uses `getFullYear/getMonth/getDate` — **local** — with an explicit comment at `:249-256` that a UTC computation "would roll 'today' over at early-morning for UTC+10 ... both wrong for 'today's notes' semantics". It feeds `loadDynamicBootstrapFiles` (`src/agents/workspace.ts:229`, `:236`).

**Local wins.** The renderer is the source of truth for what the hook is caching, the semantics are user-facing, and the local choice is documented as deliberate. Host TZ is Australia/Melbourne (UTC+10/+11), so the two sides diverged for ~10 hours of every day: the renderer's today-file was simply not in the hook's watch list, and a write to today's daily memory in that window did not invalidate the cache.

## Changes

| Part | Before | After |
|---|---|---|
| 1 | Empty render `exit 0` before the `BODY_FILE` write → cache never existed → fast-skip never engaged → ~825ms-1.1s per message to render nothing | Empty body is cached; `BODY_OUT` is the exact byte string emitted on both the fresh and cached paths, so empty render still yields empty stdout (not a bare newline) and byte-stability for the prompt cache is preserved |
| 2 | `date -u` watch set | `date` / `date -d 'yesterday'` (local), matching the renderer |
| 3 | Source touched between render and body write ended up `src_mtime < body_mtime` → invisible indefinitely | Source signature captured **before** the render, so anything changing during or after the render window differs on the next turn |
| 4 | Missing source contributed mtime `0`, never exceeding `body_mtime` → deleting `MEMORY.md` served the cache forever | Signature hashes the source *set* — name + mtime + size, with missing files recorded as `MISSING` |

The obsolete justification comment ("caching an empty body would re-emit empty forever even after MEMORY comes back online") is removed and replaced with why it no longer holds: the fast-skip re-derives the signature every turn, so a `MEMORY.md` that later appears invalidates correctly.

Note the max-mtime → signature swap subsumes the `touch -d "@$ts"` remedy suggested in the issue for part 3: with a pre-render signature there is no mtime ordering to defend, so no post-write `touch` is needed. `SIG_FILE` is only written once a body file actually exists, so a failed body write can never leave a "fresh" signature pointing at a stale body.

## Tests — each mutation-verified

Four new cases in `tests/workspace-dynamic-hook.test.ts`, plus `runHook({ tz })` to control the hook's timezone.

- `watches the LOCAL-time daily memory file, not the UTC one (#3546 part 2)` — picks a fixed-offset TZ and a daily file that is a genuine renderer source (local today or local yesterday) but provably **outside** `{utc today, utc yesterday}`, so it is deterministic at any wall-clock time. My first draft of this test passed against the UTC code (the TZ it chose made local-today coincide with utc-yesterday, which the old watch set covered); the mutation run caught that and the test was rewritten to be genuinely bug-sensitive.
- `re-renders when a source is deleted (#3546 part 4)`
- `picks up a source mutated during the render window (#3546 part 3)` — the shim mutates `MEMORY.md` mid-render then stalls past the 1s stat granularity, reproducing exactly the ordering that hid the write.
- `fast-skips the renderer on the turn after an empty render` — the shim records each invocation; asserts turn two never reaches the renderer at all.

The pre-existing test `returns empty stdout and writes no cache when render is empty` asserted the part-1 bug; it is updated to assert the caching behaviour.

Mutation results (revert the fix, prove the test fails, restore):

- Revert to `date -u` → part-2 test **fails**, others pass.
- Revert to the max-mtime fast-skip → parts 3 and 4 **fail**, others pass.
- Restore the empty-render `exit 0` → both empty-render tests **fail**, others pass.

`npx vitest run tests/workspace-dynamic-hook.test.ts tests/workspace-dynamic-hook-inject-on-change.test.ts` → 17 passed. `tests/workspace-cli.test.ts tests/workspace.git.test.ts tests/workspace.stable.test.ts` → 32 passed. `npm run lint` → exit 0.

(Test-env note for reviewers: `/tmp` is `noexec` on this host, so the shim-on-PATH tests need an exec-capable `TMPDIR`. This is pre-existing — those tests already failed on unmodified `main` here — and not introduced by this PR.)

## Deploy

`/opt/switchroom/bin/workspace-dynamic-hook.sh` is a deployed copy and was deliberately **not** edited. **A redeploy is required for this to take effect on the fleet.**

## Corroborating measurement

Re-measured at PR time across 36 agent directories under `~/.switchroom/agents/`: **4** have a non-empty `workspace/MEMORY.md`, and **0** have a today-dated (`2026-07-25`) daily memory file. The issue's "4 of 12" MEMORY.md count holds (the 12 was live agents; 36 is every scaffolded dir).

To be explicit: **this fix does not make those files appear.** It only fixes what the hook *watches* and *caches*. The daily-memory file is created by the agent writing to it — the value here is that when one is written, the hook now notices, and that the ~8-of-12 agents rendering empty stop paying a ~1s render per message for nothing.