### PR TITLE
fix(gateway): arm the turn typing loop for EVERY turn, not just adopting handbacks (#3544)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -13819,6 +13819,23 @@ const handbackPreturnSignal = createHandbackPreturnSignal({
     const live = currentTurnMap.get(key)
     return live != null && (live.finalAnswerDelivered || live.endedAt != null)
   },
+  // #3544: a turn that is still LIVE on this topic owns the typing loop for the
+  // key — the seam's age-based orphan reap must not stop it out from under the
+  // composing turn (its canonical turn-end is the stop-owner). Deliberately NOT
+  // `isTurnSettled`'s condition: a turn that already delivered its answer is
+  // "settled" for card purposes but may still be mid-turn, and `endedAt != null`
+  // is the only signal that the turn-end stop has run.
+  hasLiveTurn: (key) => {
+    const live = currentTurnMap.get(key)
+    if (live == null || live.endedAt != null) return false
+    // Under the emission-authority kill-switch OFF (the default) `get(key)`
+    // returns the most-recent-set SINGLETON regardless of key — so verify the
+    // live turn actually belongs to THIS topic before suppressing the stop.
+    // Without this check a live turn on chat B would keep a stale chat-A pre-turn
+    // typing loop running forever (a leaked interval — strictly worse than the
+    // dark-indicator bug). Flag-ON is already per-key; the check is a no-op there.
+    return statusKey(live.sessionChatId, live.sessionThreadId) === key
+  },
 })
 
 /**

--- a/telegram-plugin/gateway/handback-preturn-signal.ts
+++ b/telegram-plugin/gateway/handback-preturn-signal.ts
@@ -10,8 +10,11 @@
  * `typing…` indicator and no activity card. The user — who dispatched the work
  * and is waiting — sees nothing until the turn is well underway. Worse, a
  * handback turn historically never even got a turn-long typing loop
- * (`startTurnTypingLoop` has a single caller on the real-inbound path), so the
- * dark stretch extended past turn start.
+ * (`startTurnTypingLoop` had a single caller on the real-inbound path), so the
+ * dark stretch extended past turn start. That second half is now closed
+ * independently of this seam: the `enqueue` seam arms the loop for EVERY minted
+ * turn (#3544), so an un-adopted handback turn is lit for its whole compose
+ * window. This seam still covers the pre-turn stretch (release → enqueue).
  *
  * THE FIX (one continuous card lifecycle, NOT an orphan). The moment the
  * buffered handback is RELEASED, emit a pre-turn signal for its topic:
@@ -63,6 +66,10 @@
  *     gateway's mid-session + boot reapers are the crash backstop (the complete
  *     record lets them finalize an orphan across a restart), and a reap hook
  *     lets them stop the typing loop + drop the map entry too.
+ *     The typing stop on EITHER reap path is SKIPPED when a real turn is live
+ *     on that key (`hasLiveTurn`, #3544): the loop is keyed on (chat, thread),
+ *     so reaping a stale pre-turn entry must never darken a turn that is still
+ *     composing — that turn's canonical turn-end owns the stop.
  *
  *   • DEBOUNCE (~700ms) kills sub-second-worker flicker: a worker that finishes
  *     and whose turn mints within the debounce window never paints a pre-turn
@@ -155,6 +162,15 @@ export interface HandbackPreturnSignalDeps {
    *  entirely (design lever 5: never paint beneath a settled turn). Optional;
    *  defaults to "not settled". */
   isTurnSettled?: (statusKey: string) => boolean
+  /** True IFF a turn is CURRENTLY live (minted, not yet ended) on this topic
+   *  key. Consulted before the orphan reap stops the typing loop: that loop is
+   *  keyed on (chat, thread), NOT on this seam's entry, so stopping it while a
+   *  real turn is composing darkens that turn's indicator for the rest of its
+   *  life (#3544 — the 30 s reap killing a healthy loop). The stop is only
+   *  ours to make when nothing else owns the key; when a turn IS live, its
+   *  canonical turn-end owns the stop. Optional; defaults to "no live turn"
+   *  (the pre-#3544 behaviour). */
+  hasLiveTurn?: (statusKey: string) => boolean
   now?: () => number
   /** Debounce before painting the pre-turn card (kills sub-second flicker). */
   debounceMs?: number
@@ -312,12 +328,30 @@ export function createHandbackPreturnSignal(
       })
   }
 
+  /**
+   * Stop the typing loop for an entry ONLY when no real turn owns that key
+   * (#3544). The loop is keyed on (chat, thread); a live turn's indicator would
+   * otherwise be killed mid-compose by this seam's age-based reap, and nothing
+   * re-arms it. When a turn IS live the canonical turn-end owns the stop, so
+   * skipping here cannot leak an interval.
+   */
+  function stopTypingUnlessTurnLive(entry: PreTurnEntry, reason: string): void {
+    if (deps.hasLiveTurn?.(entry.statusKey) === true) {
+      log(
+        `handback-preturn-signal: ${reason} key=${entry.statusKey} ` +
+          `typing=kept (live turn owns the stop)\n`,
+      )
+      return
+    }
+    deps.stopTypingLoop(entry.chatId, entry.threadId)
+  }
+
   function reap(entry: PreTurnEntry): void {
     entry.reapTimer = null
     if (entry.consumed) return
     entry.consumed = true
     // Stop the forever-running typing loop and finalize the frozen card.
-    deps.stopTypingLoop(entry.chatId, entry.threadId)
+    stopTypingUnlessTurnLive(entry, 'orphan reap')
     if (entry.activityMessageId != null) {
       const record: PreTurnCardRecord = {
         turnKey: entry.syntheticTurnKey,
@@ -347,11 +381,31 @@ export function createHandbackPreturnSignal(
       if (chatId == null || chatId === '') return
       const threadId = inbound.threadId ?? null
       const adoptTurnId = deps.deriveTurnId(chatId, threadId, inbound.messageId)
-      if (adoptTurnId == null) return // no stable identity → can't be adopted
-      const statusKey = deps.chatKey(chatId, threadId)
+      // Observability (#3544): one line per handback RELEASE — the event that
+      // was previously invisible in the gateway log (zero `subagent_handback`
+      // lines were ever captured), so the next occurrence of a dark handback
+      // turn is diagnosable. Bounded by worker completions, not by turn volume.
+      const releaseKey = deps.chatKey(chatId, threadId)
+      if (adoptTurnId == null) {
+        log(`handback-preturn-signal: release key=${releaseKey} armed=no (no derivable turnId)\n`)
+        return // no stable identity → can't be adopted
+      }
+      const statusKey = releaseKey
       // Dedupe: a live entry already covers this topic (e.g. two handbacks for
       // the same topic released together — the first owns the pre-turn signal).
-      if (byKey.has(statusKey)) return
+      if (byKey.has(statusKey)) {
+        // NOT a dark turn any more: the enqueue seam arms the typing loop
+        // unconditionally for every minted turn (#3544), so a deduped handback
+        // still lights up — it just doesn't own the pre-turn card.
+        log(
+          `handback-preturn-signal: release key=${statusKey} turnId=${adoptTurnId} ` +
+            `armed=no (deduped: topic already has a live pre-turn entry)\n`,
+        )
+        return
+      }
+      log(
+        `handback-preturn-signal: release key=${statusKey} turnId=${adoptTurnId} armed=yes\n`,
+      )
       const startedAt = now()
       const syntheticTurnKey = `${PRETURN_TURNKEY_PREFIX}${statusKey}:${startedAt}`
       const entry: PreTurnEntry = {
@@ -423,7 +477,7 @@ export function createHandbackPreturnSignal(
       const entry = byKey.get(statusKey)
       if (entry == null) return
       entry.consumed = true
-      deps.stopTypingLoop(entry.chatId, entry.threadId)
+      stopTypingUnlessTurnLive(entry, 'reaped record')
       dropEntry(entry)
     },
 

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -372,10 +372,6 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
         // `activityMessageId` + `activityEverOpened` so `renderActivityFeed`
         // EDITS the existing card instead of opening a second one, and so the
         // turn's own end-of-turn `clearActivitySummary` finalizes it (lever 3).
-        // The handback turn also gets the turn-long typing loop it never had —
-        // whether or not a card was painted (the debounce may not have fired) —
-        // stopped by the canonical turn-end (`purgeReactionTracking →
-        // stopTurnTypingLoop`).
         if (HANDBACK_PRETURN_ENABLED) {
           const handbackAdoption = handbackPreturnSignal.tryAdopt(turnId)
           if (handbackAdoption != null) {
@@ -383,9 +379,32 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
               next.activityMessageId = handbackAdoption.activityMessageId
               next.activityEverOpened = true
             }
-            startTurnTypingLoop(ev.chatId, enqThreadIdNum ?? null)
+            // Observability (#3544): adoption is the rare, previously-silent
+            // branch — one line per adopted handback turn, not per turn.
+            process.stderr.write(
+              `telegram gateway: handback pre-turn adopted turnId=${turnId} ` +
+                `key=${handbackAdoption.statusKey} card=${handbackAdoption.activityMessageId ?? 'none'}\n`,
+            )
           }
         }
+        // #3544 — arm the turn-long `typing…` loop for EVERY minted turn,
+        // unconditionally. It used to hang off the handback ADOPTION above,
+        // which misses whenever the pre-turn entry was deduped (parallel
+        // workers on one topic), had no derivable turn id, or was already
+        // reaped — and the whole compose window went dark. Only the real-inbound
+        // path (`turn-start-surfaces.ts`) armed a loop, so a synthetic turn
+        // (handback / cron / wake) could have none at all. Unconditional is safe
+        // and costs nothing extra on the wire:
+        //   - `turnTypingLoop.start` is restart-safe (stops any prior loop on
+        //     the key first, so a real inbound's loop is replaced, not doubled);
+        //   - every send goes through the SHARED per-chat-key emitter floor
+        //     (`typing-emitter.ts`, TYPING_FLOOR_MS) so N arms on one chat still
+        //     cost at most one chat action per floor window — the 2026-07-11
+        //     flood-ban guard is what makes arming more loops free;
+        //   - `turn-end.ts` (`purgeReactionTracking → stopTurnTypingLoop`) is
+        //     already the single stop-owner for ALL turns, and a start is
+        //     self-healing anyway, so this cannot leak an interval.
+        startTurnTypingLoop(ev.chatId, enqThreadIdNum ?? null)
         // PR-4e — route the turn-SET through the keyed accessor: flag-OFF assigns
         // the singleton (byte-identical to `currentTurn = next`); flag-ON sets the
         // per-topic `byKey[statusKey]` entry AND the most-recent mirror. The key is

--- a/telegram-plugin/tests/handback-preturn-signal.test.ts
+++ b/telegram-plugin/tests/handback-preturn-signal.test.ts
@@ -333,6 +333,68 @@ describe('handback-preturn-signal — dead-air pre-turn emit→adopt→reap', ()
     expect(h.openCard).toHaveBeenCalledTimes(1)
   })
 
+  // ── #3544 ──────────────────────────────────────────────────────────────
+  // The 30 s orphan reap used to call `stopTypingLoop` unconditionally. That
+  // loop is keyed on (chat, thread), NOT on this seam's entry — so a handback
+  // turn still composing at 30 s had its indicator killed mid-turn, and nothing
+  // re-armed it. Outcome assertion: chat actions are still landing at 45 s.
+  it('#3544 — the orphan reap keeps typing alive when a real turn is live on the key (still emitting at 45s)', async () => {
+    vi.useFakeTimers()
+    try {
+      const liveKeys = new Set<string>()
+      const h = makeHarness({ hasLiveTurn: (k) => liveKeys.has(k) })
+      h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatH', messageId: 900 }))
+      await h.sched.advance(700) // debounce fires: typing armed, card painted
+      expect(h.typing.activeCount()).toBe(1)
+
+      // The handback's turn mints and is composing (a long one — worker results
+      // to read, a reply to write).
+      liveKeys.add('chatH:_')
+      const beforeReap = h.sendChatAction.mock.calls.length
+
+      await h.sched.advance(30_000) // the age-based orphan reap fires
+      // Pre-#3544 this was 0 and the chat went dark for the rest of the turn.
+      expect(h.typing.activeCount()).toBe(1)
+
+      // …and it is genuinely still EMITTING (not merely registered) at 45 s.
+      vi.advanceTimersByTime(15_000) // 15 s of the loop's 4 s refresh
+      expect(h.sendChatAction.mock.calls.length).toBeGreaterThan(beforeReap + 2)
+      expect(h.sendChatAction).toHaveBeenLastCalledWith('chatH', null)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('#3544 — the orphan reap still stops typing when NO turn is live (no leaked interval)', async () => {
+    const h = makeHarness({ hasLiveTurn: () => false })
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatI', messageId: 901 }))
+    await h.sched.advance(700)
+    expect(h.typing.activeCount()).toBe(1)
+    await h.sched.advance(30_000)
+    expect(h.typing.activeCount()).toBe(0)
+    expect(h.signal.pendingCount()).toBe(0)
+  })
+
+  it('#3544 — handleReaped keeps typing alive for a live turn, stops it otherwise', async () => {
+    const liveKeys = new Set<string>()
+    const h = makeHarness({ hasLiveTurn: (k) => liveKeys.has(k) })
+    h.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatJ', messageId: 902 }))
+    await h.sched.advance(700)
+    const syntheticKey = [...h.records.keys()][0]!
+    expect(syntheticKey.startsWith(PRETURN_TURNKEY_PREFIX)).toBe(true)
+    liveKeys.add('chatJ:_')
+    h.signal.handleReaped(syntheticKey)
+    expect(h.typing.activeCount()).toBe(1) // live turn owns the stop
+    expect(h.signal.pendingCount()).toBe(0) // entry still dropped
+
+    // Same hook with no live turn DOES stop the loop.
+    const h2 = makeHarness({ hasLiveTurn: () => false })
+    h2.signal.noteHandbackRelease(handbackInbound({ chatId: 'chatK', messageId: 903 }))
+    await h2.sched.advance(700)
+    h2.signal.handleReaped([...h2.records.keys()][0]!)
+    expect(h2.typing.activeCount()).toBe(0)
+  })
+
   it('skips the emit when the adopting turn already settled before the debounce fires', async () => {
     const settled = new Set<string>()
     const h = makeHarness({ isTurnSettled: (k) => settled.has(k) })

--- a/telegram-plugin/tests/stream-render-golden.test.ts
+++ b/telegram-plugin/tests/stream-render-golden.test.ts
@@ -32,6 +32,12 @@ import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import { FlushedTurnSupersedeRegistry } from '../flushed-turn-supersede.js'
 import { BackstopDeliveryLedger } from '../gateway/backstop-delivery.js'
 import { redact } from '../secret-detect/redact.js'
+import { createTurnTypingLoop } from '../gateway/turn-typing-loop.js'
+import {
+  createTypingEmitter,
+  TYPING_FLOOR_MS,
+  TYPING_REFRESH_MS,
+} from '../typing-emitter.js'
 import type { CurrentTurn } from '../gateway/gateway.js'
 
 const CHAT = '1001'
@@ -190,7 +196,8 @@ function makeStreamDeps(opts?: {
     handlePtyPartial: noop,
     isDmChatId: () => true,
     isLegitimatelyWorking: () => false,
-    makeNarrativeGate: () => ({ show: noop, stage: noop, resolveOnTool: noop, flushAtTurnEnd: noop }),
+    // `teardown` is exercised when a SECOND enqueue supersedes a prior turn.
+    makeNarrativeGate: () => ({ show: noop, stage: noop, resolveOnTool: noop, flushAtTurnEnd: noop, teardown: noop }),
     promoteQueuedStatus: noop,
     purgeReactionTracking: noop,
     redactOutboundText: (t: string) => redact(t),
@@ -547,6 +554,18 @@ describe('structural — the singleton lives once in gateway, never in the modul
     expect(body).toContain('handleSessionEventCore(gatewayStreamRenderDeps(), ev)')
   })
 
+  it('#3544 — the handback seam\'s hasLiveTurn wiring verifies the live turn OWNS the key', () => {
+    // Under the emission-authority flag OFF (default) `currentTurnMap.get(key)`
+    // returns the most-recent singleton regardless of key. Without the
+    // statusKey ownership check, a live turn on ANOTHER chat would suppress the
+    // orphan reap's stop and leak a typing interval forever.
+    const after = gatewaySrc.split('hasLiveTurn: (key) => {')[1] ?? ''
+    const body = after.split('\n  },')[0] ?? after
+    expect(body).toContain('currentTurnMap.get(key)')
+    expect(body).toContain('live.endedAt != null')
+    expect(body).toMatch(/statusKey\(live\.sessionChatId, live\.sessionThreadId\) === key/)
+  })
+
   it('the module never reads the currentTurn global — only getCurrentTurn() (Amendment 9)', () => {
     const fnBody = streamSrc.split('export function handleSessionEvent(')[1] ?? ''
     // No bare `currentTurn` value reads survive outside comments; the live-read
@@ -557,5 +576,88 @@ describe('structural — the singleton lives once in gateway, never in the modul
       .join('\n')
     expect(codeOnly).not.toMatch(/[^.\w]currentTurn\b(?!\s*[:,)])/)
     expect(codeOnly).toMatch(/getCurrentTurn\(\)/)
+  })
+})
+
+// ── #3544: every minted turn is lit, not just an ADOPTING handback turn ─────
+// The defect: the turn-long `typing…` loop was armed only inside
+// `if (handbackAdoption != null)`. A handback whose pre-turn entry was deduped
+// (parallel workers on one topic), had no derivable turn id, or was already
+// reaped adopts NOTHING — and, being a synthetic turn, never went through the
+// real-inbound arm in turn-start-surfaces either. Result: zero typing for the
+// whole compose window. These drive the REAL `handleSessionEvent` enqueue seam
+// against a REAL `createTurnTypingLoop` over the REAL `createTypingEmitter`, so
+// the assertion is the OUTCOME the user sees — chat actions on the wire — not
+// the call.
+describe('#3544 — turn-start typing is unconditional at the enqueue seam', () => {
+  interface TypingRig {
+    h: StreamHarness
+    sent: Array<{ chatId: string; threadId: number | null }>
+    emitter: ReturnType<typeof createTypingEmitter>
+    loop: ReturnType<typeof createTurnTypingLoop>
+    clock: { t: number }
+  }
+  function makeTypingRig(opts?: { adopts?: boolean }): TypingRig {
+    const h = makeStreamDeps({ turn: null })
+    const sent: Array<{ chatId: string; threadId: number | null }> = []
+    const clock = { t: 1_000_000 }
+    const tKey = (c: string, t: number | null) => `${c}:${t ?? '_'}`
+    // The REAL shared floor — the 2026-07-11 flood-ban guard.
+    const emitter = createTypingEmitter({
+      chatKey: tKey,
+      now: () => clock.t,
+      send: (chatId, threadId) => { sent.push({ chatId, threadId }) },
+    })
+    const loop = createTurnTypingLoop({
+      sendChatAction: (c, t) => { emitter.emit(c, t, 'typing') },
+      chatKey: tKey,
+      refreshMs: TYPING_REFRESH_MS,
+    })
+    const d = h.deps as unknown as Record<string, unknown>
+    d.HANDBACK_PRETURN_ENABLED = true
+    // Adoption MISSES — the deduped-parallel-worker case from #3544.
+    d.handbackPreturnSignal = { tryAdopt: () => (opts?.adopts === true ? { statusKey: `${CHAT}:main`, chatId: CHAT, threadId: null, activityMessageId: null, startedAt: clock.t, pinned: false } : null) }
+    d.startTurnTypingLoop = (c: string, t: number | null) => loop.start(c, t)
+    return { h, sent, emitter, loop, clock }
+  }
+  const enqueue = (chatId = CHAT) => ({
+    kind: 'enqueue' as const,
+    chatId,
+    messageId: null,
+    threadId: null,
+    rawContent: '🤝 A background worker you dispatched has finished.',
+  })
+
+  it('a handback turn whose pre-turn entry was DEDUPED (adoption misses) still emits typing', () => {
+    const rig = makeTypingRig({ adopts: false })
+    handleSessionEvent(rig.h.deps, enqueue())
+    // Pre-fix this was []: no adoption ⇒ no loop ⇒ a dark compose window.
+    expect(rig.sent).toEqual([{ chatId: CHAT, threadId: null }])
+    expect(rig.loop.activeCount()).toBe(1)
+    rig.loop.stopAll()
+  })
+
+  it('an ADOPTING handback turn is unchanged — still exactly one arm, one action', () => {
+    const rig = makeTypingRig({ adopts: true })
+    handleSessionEvent(rig.h.deps, enqueue())
+    expect(rig.sent).toHaveLength(1)
+    expect(rig.loop.activeCount()).toBe(1)
+    rig.loop.stopAll()
+  })
+
+  it('FLOOD GUARD: N turns arming on ONE chat inside the floor cost at most ONE chat action', () => {
+    const rig = makeTypingRig({ adopts: false })
+    // 12 arms on one chat inside a single floor window: a real-inbound arm
+    // (turn-start-surfaces) plus repeated enqueue seams / restarts.
+    rig.loop.start(CHAT, null) // stand-in for the real-inbound path's arm
+    for (let i = 0; i < 11; i++) handleSessionEvent(rig.h.deps, enqueue())
+    expect(rig.sent).toHaveLength(1) // the floor coalesced all 12
+    expect(rig.loop.activeCount()).toBe(1) // restart-safe: no interval pile-up
+    // Crossing the floor lets exactly one more through, then the floor holds again.
+    rig.clock.t += TYPING_FLOOR_MS
+    for (let i = 0; i < 5; i++) handleSessionEvent(rig.h.deps, enqueue())
+    expect(rig.sent).toHaveLength(2)
+    rig.loop.stopAll()
+    rig.emitter.reset()
   })
 })


### PR DESCRIPTION
Fixes #3544

## The defect

A real user inbound arms the turn-long `typing…` loop unconditionally
(`telegram-plugin/gateway/turn-start-surfaces.ts:251`). A **sub-agent handback**
is a synthetic turn that never goes through that path — its only source of
typing was the *conditional* adoption at `gateway/stream-render.ts:379-387`:

```ts
const handbackAdoption = handbackPreturnSignal.tryAdopt(turnId)
if (handbackAdoption != null) { … startTurnTypingLoop(…) }
```

When adoption misses, the turn is dark for its whole compose window. It misses
on the parallel-worker fan-out dedupe (`handback-preturn-signal.ts:354`), on a
missing turn id, and after the 30 s adopt timeout whose `reap()` **actively
stops a healthy loop** (`:320`, `:426`).

I re-verified every anchor cited in the issue against `origin/main` before
touching it; all four still said what the issue claims.

## The fix

1. **`stream-render.ts`** — `startTurnTypingLoop(ev.chatId, enqThreadIdNum ?? null)`
   is hoisted out of the adoption branch: **every minted turn** gets a loop.
   Safe because `turnTypingLoop.start` is restart-safe (`turn-typing-loop.ts:83`)
   and `turn-end.ts:237` (`purgeReactionTracking`) is already the single
   stop-owner for all turns. It stays inside the `if (ev.chatId)` guard.
2. **`handback-preturn-signal.ts`** — `reap` / `handleReaped` route the stop
   through `stopTypingUnlessTurnLive()`: when a real turn is live on that key,
   the stop belongs to that turn's canonical turn-end, not to this seam.
   New optional `hasLiveTurn` dep (defaults to the old behaviour).
3. **gateway wiring** — `hasLiveTurn` additionally checks the live turn OWNS the
   key. Under the emission-authority kill-switch OFF (the default),
   `currentTurnMap.get(key)` returns the most-recent-set **singleton regardless
   of key**; without the ownership check, a live turn on chat B would suppress
   chat A's reap-time stop and leak an interval forever — strictly worse than
   the bug being fixed. Pinned by a structural test.
4. **Observability** — one bounded line per handback RELEASE
   (`armed=yes` / `armed=no (deduped …)` / `no derivable turnId`) and one per
   adoption. The affected agent's `gateway-supervisor.log` contained **zero**
   `subagent_handback` lines; the next occurrence is now traceable. Bounded by
   worker completions, not turn volume.

## Tests — outcomes, not code paths

Each was verified RED by reverting the corresponding production line:

- `stream-render-golden.test.ts` drives the **real** `handleSessionEvent`
  enqueue seam against a **real** `createTurnTypingLoop` over the **real**
  `createTypingEmitter`, asserting chat actions on the wire:
  - adoption **misses** (the deduped parallel-worker case) → typing still emitted
    (pre-fix: `[]`);
  - an **adopting** handback turn → unchanged, one arm / one action;
  - **FLOOD GUARD**: 12 arms on one chat inside the floor window cost **exactly
    one** chat action; crossing `TYPING_FLOOR_MS` lets exactly one more through.
- `handback-preturn-signal.test.ts`: a handback turn live at the 30 s reap is
  **still emitting at 45 s** (pre-fix `activeCount()` went to 0); the reap still
  stops the loop when nothing is live (no leaked interval); `handleReaped` has
  both behaviours.

**Flood-guard conclusion:** this change cannot multiply outbound Bot API calls.
Every send goes through the shared per-chat-key emitter floor
(`typing-emitter.ts`, `TYPING_FLOOR_MS = 3500`, `5584bf20`), and the loop map
holds at most one interval per key. The added arm is a *restart* of an existing
key's loop, whose immediate send is floor-gated.

## Verification

```
vitest run <17 files touching stream-render / handback / typing>  → 340 passed
vitest run stream-render-golden + handback + turn-typing + typing-emitter
          + handback-preturn-adoption-roundtrip                   →  55 passed
bun test telegram-plugin/tests/per-topic-current-turn.test.ts     →  19 pass
npm run lint                                                      → clean
```

(`check-gateway-line-ratchet`: gateway.ts 24880 vs ratchet 24867, within slack 50.)

## Honesty / caveats

- The issue's diagnosis is a **code read, not a captured trace**, and it says so.
  I confirmed the four miss paths exist in source but could **not** confirm from
  logs that they are what the operator hit — there is no captured
  `subagent_handback` evidence. That is exactly why item 4 (observability) is in
  this PR. The fix is correct regardless (unconditional beats conditional), but
  a fix is not proof of cause.
- **Behaviour change beyond handbacks:** the hoist lights typing for *every*
  minted turn, including cron / wake turns that previously had none if they never
  went through the inbound path. A cron turn that ends in `NO_REPLY` will now
  briefly show typing. Judged correct ("something is happening" is true) and free
  on the wire, but it is a deliberate widening, not an accident.
- One correction to the dispatch brief, not the issue: `origin/main` tip is
  `06c12bc8`, with `398f4b13` as an ancestor (not the other way round). Branched
  off the real tip.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md` — "stays present from
receipt to turn end".
