### PR TITLE
fix(hindsight): recall overlap gate must not be decided by prompt length (#3541)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@
 
 ### Hindsight recall (#3541)
 
-- **The lexical-overlap gate scored with the wrong metric and emptied ~88% of
-  recalls (#3541)** — the `recallMinOverlap` gate in
+- **The lexical-overlap gate scored with the wrong metric, emptying about a
+  third of recalls (#3541)** — the `recallMinOverlap` gate in
   `vendor/hindsight-memory/scripts/recall.py` used Jaccard similarity,
   `|Q ∩ M| / |Q ∪ M|`, to compare a long recall query (production p50 778
   chars of prior-context preamble) against a short memory. The union term is
@@ -37,20 +37,61 @@
   `recall_log.jsonl` (1548 rows, ts >= 2026-07-18): survival through the gate
   fell monotonically from 7.3% at <200 query chars to 0.9% at 600-750 chars,
   the zero-result rate rose from 23% to 93%, and 22447 of 23124 already-
-  reranked candidates (97.1%) were discarded. 440 of the 526 turns that had a
-  bank return successfully still delivered zero memories. The metric is now
-  the overlap coefficient (containment), `|Q ∩ M| / min(|Q|, |M|)` — in
-  practice "what fraction of this memory's terms appear in the prompt",
-  invariant to preamble length, which is the query-independent absolute floor
-  the gate was always documented to be. Safe to run permissively because the
-  gate is a floor, not a ranker: `_sort_by_final_score` orders survivors by the
-  engine's reranked relevance immediately afterwards and only then does
-  `recallMaxMemories` head-slice, so admitting more candidates can only give
-  the score-sort a non-empty set to pick the top-N from. The default threshold
-  (0.10) and the `memory.recall.min_overlap` knob are unchanged. Guarded by
-  four mutation-verified regression tests pinning length-invariance, survival
-  at production prompt length, and that the floor still drops irrelevant
-  memories.
+  reranked candidates (97.1%) were discarded. Where the gate actually ran it
+  was decisive — of the 526 turns with at least one bank returning
+  successfully, 440 (83.7%) still delivered zero memories. The metric is now
+  containment, `|Q ∩ M| / |M|` — "what fraction of this memory's terms appear
+  in the prompt", invariant to preamble length. Safe to run permissively
+  because the gate is a floor, not a ranker: `_sort_by_final_score` orders
+  survivors by the engine's reranked relevance immediately afterwards and only
+  then does `recallMaxMemories` head-slice, so admitting more candidates can
+  only give the score-sort a non-empty set to pick the top-N from. And because
+  `|Q ∪ M| >= |M|`, containment >= Jaccard for every pair, so at a fixed
+  threshold this admits a superset of what production keeps today — no memory
+  that survives now can be dropped by this change.
+
+- **Scope: this fixes the gate, NOT the 8s recall deadline.** Partitioning the
+  zero-result recalls in `recall_log.jsonl` by cause: 448 (~32%) had a bank
+  return successfully with `overlap_dropped > 0` (this gate), while 565 (~41%)
+  had *every* bank time out or error, where the gate never ran and the deadline
+  is the cause. `deadline_hit` is set on 991 of 18656 logged recalls and those
+  rows sit at the 8s ceiling. The latency half of #3541 — local cross-encoder
+  rerank at the 150-candidate cap dominating a p50 4.49s handler — remains open
+  and is deliberately untouched here.
+
+- **The 0.10 default is retained, and it is close to a passthrough — say so.**
+  Because the denominator is the memory's own token count, a memory of ≤10
+  content tokens clears 0.10 on a single shared word. The threshold was
+  re-derived rather than inherited from the Jaccard era: replaying 31 real
+  production queries against the live engine and rescoring the 202 returned
+  candidates gives 86.1% survival / 6.5% zero-result at 0.10, versus 65.8% /
+  41.9% at 0.20, 58.4% / 41.9% at 0.30 and 52.5% / 54.8% at 0.40 (Jaccard at
+  0.10 on the same candidates: 70.3% / 32.3%). Thresholds above 0.10
+  leave nearly half of turns with no memories at all — re-creating the exact
+  failure this fixes. Raising it would not buy precision either: on a
+  preamble-heavy prompt containment is *not* monotone in relevance (a
+  measured off-topic memory that merely reuses preamble words scores 0.857
+  against the genuinely relevant memory's 0.571), so a higher threshold drops
+  the good memory first. **The effective precision control after this change
+  is the engine rerank plus the `recallMaxMemories` head-slice; this gate is
+  now only a cheap floor removing candidates with near-zero lexical
+  relationship to the prompt.** Excluding low-signal top-N results — the
+  original #475 goal — would need a `scores.final` relevance floor, which is
+  out of scope here.
+
+- **Denominator is `|M|`, not the textbook `min(|Q|, |M|)`.** With `min()`, a
+  prompt shorter than the memory flips the denominator to the query and the
+  metric silently inverts into "what fraction of the prompt is in the memory"
+  — a one-word prompt then scores 1.0 against any memory containing that word,
+  re-introducing the query-length dependence this fix exists to remove. That
+  regime is not a corner case: `|Q| < |M|` held for 87 of 202 replayed
+  candidate pairs (43%). The `memory.recall.min_overlap` knob is unchanged.
+
+- Guarded by eight mutation-verified regression tests pinning length
+  invariance, survival at production prompt length, the `|Q| < |M|` regime,
+  the never-stricter-than-Jaccard safety property, and both what the floor
+  does drop (a long memory with only incidental overlap) and what it
+  knowingly does not (an off-topic memory reusing preamble words).
 
 ## v0.19.16 — Telegram: forwarded-message coalescing, Listen button, quieter progress cards, cleaner voice
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,34 @@
   `src/gateway/gateway.ts`) is spoken as just its last segment — or "a path"
   when that segment is a hex blob. A single `word/word` is still prose.
 
+### Hindsight recall (#3541)
+
+- **The lexical-overlap gate scored with the wrong metric and emptied ~88% of
+  recalls (#3541)** — the `recallMinOverlap` gate in
+  `vendor/hindsight-memory/scripts/recall.py` used Jaccard similarity,
+  `|Q ∩ M| / |Q ∪ M|`, to compare a long recall query (production p50 778
+  chars of prior-context preamble) against a short memory. The union term is
+  dominated by the query, so the same memory with the same real overlap scored
+  lower purely because the prompt was longer — prompt length, not relevance,
+  decided whether memory was delivered. Measured on production
+  `recall_log.jsonl` (1548 rows, ts >= 2026-07-18): survival through the gate
+  fell monotonically from 7.3% at <200 query chars to 0.9% at 600-750 chars,
+  the zero-result rate rose from 23% to 93%, and 22447 of 23124 already-
+  reranked candidates (97.1%) were discarded. 440 of the 526 turns that had a
+  bank return successfully still delivered zero memories. The metric is now
+  the overlap coefficient (containment), `|Q ∩ M| / min(|Q|, |M|)` — in
+  practice "what fraction of this memory's terms appear in the prompt",
+  invariant to preamble length, which is the query-independent absolute floor
+  the gate was always documented to be. Safe to run permissively because the
+  gate is a floor, not a ranker: `_sort_by_final_score` orders survivors by the
+  engine's reranked relevance immediately afterwards and only then does
+  `recallMaxMemories` head-slice, so admitting more candidates can only give
+  the score-sort a non-empty set to pick the top-N from. The default threshold
+  (0.10) and the `memory.recall.min_overlap` knob are unchanged. Guarded by
+  four mutation-verified regression tests pinning length-invariance, survival
+  at production prompt length, and that the floor still drops irrelevant
+  memories.
+
 ## v0.19.16 — Telegram: forwarded-message coalescing, Listen button, quieter progress cards, cleaner voice
 
 ### Telegram forwarding (#3523)

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -591,8 +591,9 @@ export HINDSIGHT_RECALL_MAX_MEMORIES={{hindsightRecallMaxMemories}}
 {{#if (isNumber hindsightRecallCacheTtlSecs)}}
 export HINDSIGHT_RECALL_CACHE_TTL_SECS={{hindsightRecallCacheTtlSecs}}
 {{/if}}
-# Lexical-overlap relevance gate (#475). Drops memories whose Jaccard
-# overlap with the user's query is below this threshold (range 0.0–1.0).
+# Lexical-overlap relevance gate (#475). Drops memories whose containment
+# overlap (|Q n M| / min(|Q|, |M|), see #3541) with the user's query is
+# below this threshold (range 0.0–1.0).
 # Plugin default is 0.0 (gate disabled); export only when the operator
 # overrode it via memory.recall.min_overlap in switchroom.yaml. Try
 # 0.10–0.20 to start; observe `overlap_dropped` via

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -595,8 +595,11 @@ export HINDSIGHT_RECALL_CACHE_TTL_SECS={{hindsightRecallCacheTtlSecs}}
 # overlap (|Q n M| / |M|, see #3541) with the user's query is
 # below this threshold (range 0.0–1.0).
 # Plugin default is 0.0 (gate disabled); export only when the operator
-# overrode it via memory.recall.min_overlap in switchroom.yaml. Try
-# 0.10–0.20 to start; observe `overlap_dropped` via
+# overrode it via memory.recall.min_overlap in switchroom.yaml. Use 0.10:
+# it is a near-passthrough floor, not a precision control. Values at or
+# above 0.20 measurably starve recall — on production replay 0.20 leaves
+# ~41.9% of turns with NO memories at all, re-creating the bug #3541
+# fixed. Observe `overlap_dropped` via
 # `switchroom memory recall-log <agent>`.
 {{#if (isNumber hindsightRecallMinOverlap)}}
 export HINDSIGHT_RECALL_MIN_OVERLAP={{hindsightRecallMinOverlap}}

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -592,7 +592,7 @@ export HINDSIGHT_RECALL_MAX_MEMORIES={{hindsightRecallMaxMemories}}
 export HINDSIGHT_RECALL_CACHE_TTL_SECS={{hindsightRecallCacheTtlSecs}}
 {{/if}}
 # Lexical-overlap relevance gate (#475). Drops memories whose containment
-# overlap (|Q n M| / min(|Q|, |M|), see #3541) with the user's query is
+# overlap (|Q n M| / |M|, see #3541) with the user's query is
 # below this threshold (range 0.0–1.0).
 # Plugin default is 0.0 (gate disabled); export only when the operator
 # overrode it via memory.recall.min_overlap in switchroom.yaml. Try

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3119,8 +3119,11 @@ function renderHindsightSettingsOverrides(
   // the gate is already implemented (#475) and the export wiring exists
   // in profiles/_base/start.sh.hbs:226 — we just opt into a non-zero
   // floor so weak containment-overlap hits drop silently. The metric is
-  // the overlap coefficient, not Jaccard (#3541) — Jaccard made survival a
-  // function of prompt length and emptied ~88% of recalls. Operators can
+  // containment |Q n M| / |M|, not Jaccard (#3541) — Jaccard made survival
+  // a function of prompt length and emptied ~a third of recalls. Note 0.10
+  // is close to a passthrough by design: precision comes from the engine
+  // rerank plus the recallMaxMemories head-slice, and measured survival
+  // collapses (45-60% of turns get nothing) above 0.10. Operators can
   // override via memory.recall.min_overlap in switchroom.yaml.
   settings.recallMinOverlap = 0.10;
   // Phase 1 (RFC reference/rfcs/hindsight-synthesis-layers.md): consume

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4279,7 +4279,9 @@ export function scaffoldAgent(
   const hindsightRecallCacheTtlSecs = agentConfig.memory?.recall?.cache_ttl_secs;
   // Lexical-overlap relevance gate (#475). Same cascade. `undefined`
   // means "use the plugin's settings.json default of 0.0" (i.e. gate
-  // disabled, current behaviour). Set 0.10–0.20 to start filtering.
+  // disabled, current behaviour). Set 0.10 — a near-passthrough floor.
+  // Values at or above 0.20 measurably starve recall (~41.9% of turns
+  // end up with no memories at all on production replay, #3541).
   const hindsightRecallMinOverlap = agentConfig.memory?.recall?.min_overlap;
   // Phase 1 / 6a opt-out: undefined unless the operator overrode the
   // switchroom default (observations on, trivial-skip on). Exported only

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3031,7 +3031,7 @@ function resolveHindsightRetainConfig(
  *     transcript, re-consolidated per fire; paired with the vendor
  *     retain.py divergence)
  *   - `recallMaxMemories`: 12 → 8 (tighter prompt, less model noise)
- *   - `recallMinOverlap`: 0.0 → 0.10 (drop weak Jaccard-overlap matches)
+ *   - `recallMinOverlap`: 0.0 → 0.10 (drop weak containment-overlap matches)
  *
  * Future overrides go here, NOT in the vendor file. The vendor is
  * third-party code and must remain untouched for clean upstream
@@ -3118,7 +3118,9 @@ function renderHindsightSettingsOverrides(
   // Lexical-overlap gate at 0.10. Vendor default 0.0 (gate disabled);
   // the gate is already implemented (#475) and the export wiring exists
   // in profiles/_base/start.sh.hbs:226 — we just opt into a non-zero
-  // floor so weak Jaccard-overlap hits drop silently. Operators can
+  // floor so weak containment-overlap hits drop silently. The metric is
+  // the overlap coefficient, not Jaccard (#3541) — Jaccard made survival a
+  // function of prompt length and emptied ~88% of recalls. Operators can
   // override via memory.recall.min_overlap in switchroom.yaml.
   settings.recallMinOverlap = 0.10;
   // Phase 1 (RFC reference/rfcs/hindsight-synthesis-layers.md): consume

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -166,6 +166,20 @@ interface RecallLogEntry {
   capped?: boolean;
   pre_cap_count?: number;
   memory_ids?: string[];
+  /**
+   * Recall QUALITY telemetry (#3541): min/median/max of the engine's
+   * `scores.final` across the memories actually INJECTED (post-head-slice).
+   * Every other field on this row measures VOLUME, and volume alone cannot
+   * distinguish "the reranker is working" from "the agent is being fed
+   * `max_memories` mediocre memories every turn" — a distinction that
+   * matters now that the overlap gate is a near-passthrough floor at 0.10
+   * and precision rests entirely on `scores.final` plus the head-slice.
+   * `null` on cache-hit rows (no result set) and when no result carried a
+   * usable score. Written by `_injected_score_stats` in recall.py.
+   */
+  injected_score_min?: number | null;
+  injected_score_median?: number | null;
+  injected_score_max?: number | null;
   cache_hit?: boolean;
 }
 
@@ -243,10 +257,22 @@ export function formatRecallLogView(
       ? Math.round((memCounts.reduce((s, n) => s + n, 0) / memCounts.length) * 10) / 10
       : null;
   const max = memCounts.length > 0 ? Math.max(...memCounts) : null;
+  // #3541 — mean of the per-turn MEDIAN injected relevance score. The volume
+  // stats above (`avg`/`max`) rise identically whether recall got better or
+  // just fuller, so a summary without a quality number is exactly the blind
+  // spot that let the overlap-gate regression read as healthy.
+  const medians = entries
+    .map((e) => e.injected_score_median)
+    .filter((n): n is number => typeof n === "number");
+  const avgScore =
+    medians.length > 0
+      ? Math.round((medians.reduce((s, n) => s + n, 0) / medians.length) * 100) / 100
+      : null;
   lines.push(
     chalk.gray(
       `  last ${total} turn${total === 1 ? "" : "s"}: ` +
       `avg=${avg ?? "—"} max=${max ?? "—"} ` +
+      `avg_score=${avgScore ?? "—"} ` +
       `cache_hits=${hits} capped=${cappedTurns}` +
       (omittedTurns > 0 ? ` directives_omitted_turns=${omittedTurns}` : ""),
     ),
@@ -268,10 +294,22 @@ export function formatRecallLogView(
     const ids = e.memory_ids && e.memory_ids.length > 0
       ? chalk.dim(` ids=${e.memory_ids.slice(0, 3).join(",")}${e.memory_ids.length > 3 ? `…+${e.memory_ids.length - 3}` : ""}`)
       : "";
+    // #3541 — the quality half of the row. Volume without score range reads
+    // as success whether the injected memories are relevant or not.
+    const score =
+      typeof e.injected_score_min === "number" &&
+      typeof e.injected_score_median === "number" &&
+      typeof e.injected_score_max === "number"
+        ? chalk.dim(
+            ` score=${e.injected_score_min.toFixed(2)}/` +
+            `${e.injected_score_median.toFixed(2)}/` +
+            `${e.injected_score_max.toFixed(2)}`,
+          )
+        : "";
     lines.push(
       `  ${chalk.gray(e.ts)} ${flag} ` +
       `n=${e.result_count ?? "—"}${e.pre_cap_count != null && e.pre_cap_count !== e.result_count ? `/${e.pre_cap_count}` : ""}` +
-      `${dem}${omitted}${ids}`,
+      `${dem}${omitted}${score}${ids}`,
     );
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -535,7 +535,7 @@ export const AgentMemorySchema = z
           .max(1)
           .optional()
           .describe(
-            "Minimum Jaccard token overlap [0.0–1.0] between the user " +
+            "Minimum containment token overlap [0.0–1.0] between the user " +
             "prompt and a memory's text for the memory to be injected. " +
             "Drops low-relevance matches before the count cap so weak hits " +
             "don't fill the slot on real queries. 0.0 disables (default — " +

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -537,10 +537,16 @@ export const AgentMemorySchema = z
           .describe(
             "Minimum containment token overlap [0.0–1.0] between the user " +
             "prompt and a memory's text for the memory to be injected. " +
-            "Drops low-relevance matches before the count cap so weak hits " +
-            "don't fill the slot on real queries. 0.0 disables (default — " +
-            "current behaviour). Try 0.10–0.20 to start; observe the " +
-            "`overlap_dropped` field via `switchroom memory recall-log`.",
+            "A cheap FLOOR that removes candidates with (near-)zero lexical " +
+            "relationship to the prompt — NOT a precision control: at the " +
+            "recommended 0.10 the gate is near-passthrough, and the " +
+            "effective precision control is the engine rerank plus the " +
+            "max_memories head-slice. 0.0 disables (default — current " +
+            "behaviour). Use 0.10; values at or above 0.20 measurably " +
+            "starve recall — on production replay 0.20 leaves ~41.9% of " +
+            "turns with NO memories at all, re-creating the bug #3541 " +
+            "fixed. Observe the `overlap_dropped` field via " +
+            "`switchroom memory recall-log`.",
           ),
         types: z
           .array(z.string())

--- a/tests/cli.memory.recall-log.test.ts
+++ b/tests/cli.memory.recall-log.test.ts
@@ -139,3 +139,64 @@ describe("formatRecallLogView — directives_omitted", () => {
     expect(out.join("\n")).not.toContain("omitted");
   });
 });
+
+// Switchroom #3541 — recall QUALITY telemetry. Every pre-existing field on a
+// recall_log row measures VOLUME. Once the overlap gate became a
+// near-passthrough floor at 0.10, precision rested entirely on the engine's
+// `scores.final` plus the max_memories head-slice — so a rollout that fed each
+// agent `max_memories` mediocre memories per turn would raise `avg`/`max` and
+// zero out `overlap_dropped`, i.e. read as unambiguous success. These assert
+// the score range actually reaches the operator.
+describe("formatRecallLogView — injected relevance scores", () => {
+  const ANSI = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+  const strip = (s: string) => s.replace(ANSI, "");
+
+  it("prints the per-row min/median/max and a mean-of-medians summary", () => {
+    const out = formatRecallLogView("clerk", [
+      {
+        ts: "2026-07-25T10:00:00Z",
+        result_count: 3,
+        injected_score_min: 0.8,
+        injected_score_median: 0.85,
+        injected_score_max: 0.9,
+      },
+      {
+        ts: "2026-07-25T10:01:00Z",
+        result_count: 3,
+        injected_score_min: 0.1,
+        injected_score_median: 0.15,
+        injected_score_max: 0.2,
+      },
+    ]).map(strip);
+
+    expect(out[2]).toContain("score=0.80/0.85/0.90");
+    expect(out[3]).toContain("score=0.10/0.15/0.20");
+    // Mean of the two medians: (0.85 + 0.15) / 2 = 0.5.
+    expect(out[1]).toContain("avg_score=0.5");
+  });
+
+  it("distinguishes a full-but-weak turn from a full-and-strong one", () => {
+    const weak = formatRecallLogView("clerk", [
+      { ts: "t", result_count: 8, injected_score_min: 0.02, injected_score_median: 0.05, injected_score_max: 0.09 },
+    ]).map(strip);
+    const strong = formatRecallLogView("clerk", [
+      { ts: "t", result_count: 8, injected_score_min: 0.70, injected_score_median: 0.80, injected_score_max: 0.95 },
+    ]).map(strip);
+
+    // Identical volume — the old summary line could not tell these apart.
+    expect(weak[1]).toContain("avg=8 max=8");
+    expect(strong[1]).toContain("avg=8 max=8");
+    // The quality number does.
+    expect(weak[1]).toContain("avg_score=0.05");
+    expect(strong[1]).toContain("avg_score=0.8");
+  });
+
+  it("renders an em dash rather than 0 when no row carries a score", () => {
+    const out = formatRecallLogView("clerk", [
+      { ts: "2026-07-25T10:00:00Z", result_count: 2 },
+      { ts: "2026-07-25T10:01:00Z", cache_hit: true, injected_score_median: null },
+    ]).map(strip);
+    expect(out[1]).toContain("avg_score=—");
+    expect(out.join("\n")).not.toContain("score=0.00");
+  });
+});

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -38,9 +38,11 @@ DEFAULTS = {
     # `.reranker`) — verified at runtime — and recall.py now reads and
     # sorts the merged set by `scores.final`. This lexical gate is a
     # separate quality filter layered on top — see #475. The metric is
-    # the overlap coefficient `|Q n M| / min(|Q|, |M|)`, not Jaccard:
-    # dividing by the union made the score a function of prompt length
-    # rather than relevance — see #3541 and recall.py's design note.
+    # containment, `|Q n M| / |M|`, not Jaccard: dividing by the union made
+    # the score a function of prompt length rather than relevance — see
+    # #3541 and recall.py's design note. At the 0.10 fleet default this is
+    # close to a passthrough (a <=10-token memory clears it on one shared
+    # word); precision is the engine rerank's job, not this gate's.
     "recallMinOverlap": 0.0,
     "recallTypes": ["world", "experience"],
     # Switchroom-local: when True (default; Ken-approved ON) recall biases

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -29,15 +29,18 @@ DEFAULTS = {
     # formatting. Set to 0 (or any non-positive value) to disable the cap
     # and inject everything Hindsight returns.
     "recallMaxMemories": 12,
-    # Switchroom-local: minimum lexical (Jaccard) overlap between the
+    # Switchroom-local: minimum lexical (containment) overlap between the
     # user's query terms and a memory's text terms. Memories below this
     # threshold are dropped before formatting. 0.0 disables the gate
     # (current behaviour: inject everything Hindsight returns up to the
     # count cap). NOTE: Hindsight's HTTP recall API DOES return per-result
     # relevance scores (`scores.final`, plus `.semantic`/`.keyword`/
     # `.reranker`) — verified at runtime — and recall.py now reads and
-    # sorts the merged set by `scores.final`. This Jaccard gate is a
-    # separate lexical-overlap quality filter layered on top — see #475.
+    # sorts the merged set by `scores.final`. This lexical gate is a
+    # separate quality filter layered on top — see #475. The metric is
+    # the overlap coefficient `|Q n M| / min(|Q|, |M|)`, not Jaccard:
+    # dividing by the union made the score a function of prompt length
+    # rather than relevance — see #3541 and recall.py's design note.
     "recallMinOverlap": 0.0,
     "recallTypes": ["world", "experience"],
     # Switchroom-local: when True (default; Ken-approved ON) recall biases

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -669,6 +669,51 @@ def _result_final_score(m) -> float:
     return float("-inf")
 
 
+def _injected_score_stats(results) -> dict:
+    """Relevance-score aggregates for the INJECTED set (post-head-slice).
+
+    Switchroom #3541 review finding — recall-quality telemetry.
+    `recall_log.jsonl` records volume and plumbing only (`overlap_dropped`,
+    `capped`, `pre_cap_count`, `memory_ids`, `deadline_hit`). With the
+    overlap gate deliberately near-passthrough at 0.10, 100% of precision now
+    rests on the engine's `scores.final` plus the `recallMaxMemories`
+    head-slice — and no field observes that. Post-rollout, `overlap_dropped`
+    collapsing to 0 while `result_count` rises to the cap reads as
+    unambiguous success on every existing dashboard whether the reranker is
+    good OR whether every agent is being fed 8 mediocre memories per turn.
+    These three fields are what distinguishes those two worlds.
+
+    Returns ``{"injected_score_min", "injected_score_median",
+    "injected_score_max"}``. Values are floats rounded to 4dp, or None when
+    the set is empty or no result carried a usable score (results missing
+    `scores.final` are excluded rather than counted as a sentinel, so a
+    single malformed entry cannot drag the aggregate).
+
+    Aggregates ONLY — no query text and no memory text is recorded here.
+    """
+    empty = {
+        "injected_score_min": None,
+        "injected_score_median": None,
+        "injected_score_max": None,
+    }
+    try:
+        scores = [s for s in (_result_final_score(m) for m in results or []) if s != float("-inf")]
+        if not scores:
+            return empty
+        scores.sort()
+        n = len(scores)
+        mid = n // 2
+        median = scores[mid] if n % 2 else (scores[mid - 1] + scores[mid]) / 2.0
+        return {
+            "injected_score_min": round(scores[0], 4),
+            "injected_score_median": round(median, 4),
+            "injected_score_max": round(scores[-1], 4),
+        }
+    except Exception:
+        # Telemetry must never take recall down.
+        return empty
+
+
 def _sort_by_final_score(results):
     """Sort merged multi-bank results by `scores.final` descending, in place.
 
@@ -1435,6 +1480,12 @@ def main():
                 "directives_omitted": None,
                 "demoted_count": 0,
                 "capped": False,
+                # #3541 quality telemetry — present for a uniformly queryable
+                # schema. A cache hit replays a formatted context block, not a
+                # result set, so no per-memory scores exist to aggregate.
+                "injected_score_min": None,
+                "injected_score_median": None,
+                "injected_score_max": None,
                 "cache_hit": True,
                 # A3 stage-1 telemetry keys kept present for a uniformly
                 # queryable schema; a cache hit issues no bank HTTP, so there
@@ -1985,6 +2036,12 @@ def main():
             m.get("id") for m in results
             if isinstance(m, dict) and m.get("id")
         ],
+        # Switchroom #3541 — recall QUALITY telemetry, alongside the volume
+        # fields above. min/median/max of `scores.final` over the injected
+        # (post-head-slice) set. See `_injected_score_stats` for why volume
+        # alone can't distinguish "reranker is working" from "8 mediocre
+        # memories per turn" now that the overlap gate is near-passthrough.
+        **_injected_score_stats(results),
         "cache_hit": False,
         # Switchroom A3 stage-1 telemetry (hindsight-leverage PR 1) — per-bank
         # latency + timeout breakdown, directives-fetch latency, total

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -406,10 +406,52 @@ def _is_demoted_memory(memory) -> bool:
 # regardless of which bank they came from. This gate is a *complementary*,
 # opt-in absolute precision floor: `scores.final` is a relative rank that
 # still orders weakly-matching memories rather than excluding them, so on a
-# low-relevance prompt the top-N could still be low-signal. The Jaccard
+# low-relevance prompt the top-N could still be low-signal. The lexical
 # overlap between the user's query terms and each memory's text terms is a
-# query-independent absolute measure that drops memories below a
+# rank-independent absolute measure that drops memories below a
 # configurable threshold outright — something the relative sort does not do.
+#
+# --- switchroom #3541: the metric is CONTAINMENT, not Jaccard ---
+#
+# This gate originally scored with Jaccard similarity,
+# `|Q ∩ M| / |Q ∪ M|`. That is the wrong metric here, because the two
+# sides have wildly asymmetric lengths: the recall query is the whole
+# prior-context preamble (production p50 778 chars) while a memory is a
+# single fact (tens of tokens). The union term is dominated by |Q|, so the
+# SAME memory with the SAME real overlap scores lower purely because the
+# prompt was longer. Query length, not relevance, decided the outcome.
+#
+# Measured on production recall telemetry (1548 rows, 646 of which put
+# candidates through the gate, ts >= 2026-07-18, all fleet agents'
+# `recall_log.jsonl`), at the fleet default threshold of 0.10:
+#
+#   query_chars    rows   candidates   survived   survival%   zero-result%
+#      0- 200        30        1364          99       7.3%          23.3%
+#    200- 400       110        4199         238       5.7%          17.3%
+#    400- 600       143        5305         293       5.5%          72.7%
+#    600- 750       213        7288          67       0.9%          93.0%
+#    750-1000       150        4968          70       1.4%          90.0%
+#
+# 22447 of 23124 candidate memories (97.1%) were discarded, and the
+# discard rate rose monotonically with prompt length — the signature of
+# the union-term artifact, not of a relevance judgement. Fleet-wide this
+# produced an ~88% empty-recall rate: 440 of 526 turns that had at least
+# one bank return successfully still delivered zero memories.
+#
+# The correct metric for asymmetric-length comparison is the overlap
+# coefficient (containment): `|Q ∩ M| / min(|Q|, |M|)`. Since the memory
+# is essentially always the shorter side, this reads as "what fraction of
+# THIS MEMORY's terms are present in the prompt" — invariant to how much
+# unrelated preamble the prompt carries, which is exactly the
+# "query-independent absolute measure" the gate was always documented to
+# be. See `containment_overlap` below.
+#
+# This is safe to run permissively: the gate is a FLOOR, not a ranker.
+# `_sort_by_final_score` orders the survivors by the engine's reranked
+# relevance score immediately afterwards, and only then does
+# `recallMaxMemories` head-slice. So admitting more candidates cannot
+# lower the quality of what is injected — it can only give the
+# score-sort a non-empty set to choose the top-N from.
 #
 # Threshold default is 0.0 (disabled) so the gate is opt-in initially.
 # Operators tune via `memory.recall.min_overlap` in switchroom.yaml or
@@ -466,22 +508,34 @@ def _overlap_tokens(text) -> set:
     return out
 
 
-def jaccard_overlap(query: str, memory_text: str) -> float:
-    """Jaccard similarity between two texts, after stop-word + punctuation
-    stripping. Returns a float in [0.0, 1.0]. Empty/degenerate inputs
-    return 0.0 — it's safer to drop than retain when we can't compute.
+def containment_overlap(query: str, memory_text: str) -> float:
+    """Overlap coefficient (containment) between two texts, after stop-word
+    + punctuation stripping: ``|Q ∩ M| / min(|Q|, |M|)``.
+
+    Returns a float in [0.0, 1.0]. Empty/degenerate inputs return 0.0 —
+    it's safer to drop than retain when we can't compute.
+
+    Unlike Jaccard (`|Q ∩ M| / |Q ∪ M|`, used until switchroom #3541) this
+    is INVARIANT TO QUERY LENGTH. The recall query is a long prior-context
+    preamble and a memory is a short fact; dividing by the union made the
+    score collapse as the prompt grew, so the gate discarded 97.1% of
+    already-reranked candidates and did so monotonically in prompt length.
+    Dividing by the shorter side (in practice the memory) asks the question
+    the gate actually means: what fraction of this memory's terms appear in
+    the prompt. See the design note above `_OVERLAP_STOPWORDS` for the
+    production measurement that motivated the change.
     """
     a = _overlap_tokens(query)
     b = _overlap_tokens(memory_text)
     if not a or not b:
         return 0.0
     inter = len(a & b)
-    union = len(a | b)
-    return inter / union if union else 0.0
+    denom = min(len(a), len(b))
+    return inter / denom if denom else 0.0
 
 
 def _filter_by_overlap(results, query: str, threshold: float):
-    """Drop memories whose Jaccard overlap with the query is below the
+    """Drop memories whose containment overlap with the query is below the
     threshold. Threshold <= 0 short-circuits to passthrough (no
     iteration cost).
 
@@ -493,7 +547,7 @@ def _filter_by_overlap(results, query: str, threshold: float):
     dropped = 0
     for m in results:
         text = m.get("text", "") if isinstance(m, dict) else ""
-        if jaccard_overlap(query, text) >= threshold:
+        if containment_overlap(query, text) >= threshold:
             kept.append(m)
         else:
             dropped += 1
@@ -1634,9 +1688,12 @@ def main():
             )
 
     # Switchroom #475 — lexical-overlap relevance gate. Drops memories
-    # whose Jaccard overlap with the query is below
+    # whose containment overlap with the query is below
     # `recallMinOverlap` (default 0.0 = disabled). Runs after the
     # demote filter so the threshold sees the operator-curated set.
+    # #3541: the metric is containment, NOT Jaccard — see the design
+    # note above `_OVERLAP_STOPWORDS`. Jaccard made the gate a function
+    # of prompt length and it discarded 97.1% of reranked candidates.
     overlap_threshold = config.get("recallMinOverlap", 0.0)
     if isinstance(overlap_threshold, (int, float)) and overlap_threshold > 0:
         pre_overlap_count = len(results)

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -595,6 +595,15 @@ def containment_overlap(query: str, memory_text: str) -> float:
     fraction of this memory's terms appear in the prompt. See the design
     note above `_OVERLAP_STOPWORDS` for the production measurement.
 
+    That invariance is specifically against growth of NON-OVERLAPPING
+    preamble in the query — the failure mode #3541 hit — and is not
+    unqualified: a short query still scores low against a long memory
+    (whenever `|Q| < threshold * |M|` the memory is dropped however
+    relevant it is), and where `Q ⊆ M` the metric degenerates to exactly
+    Jaccard. So `|M|` is a trade against `min(|Q|, |M|)`, not a strict
+    improvement over it; the paragraph below is the argument for which
+    side of that trade is safer here.
+
     Why ``|M|`` and not ``min(|Q|, |M|)`` (the textbook overlap coefficient):
     the two agree only where the memory is the shorter side, and that is NOT
     a safe assumption here. Replaying real production queries against the

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -434,24 +434,95 @@ def _is_demoted_memory(memory) -> bool:
 #
 # 22447 of 23124 candidate memories (97.1%) were discarded, and the
 # discard rate rose monotonically with prompt length — the signature of
-# the union-term artifact, not of a relevance judgement. Fleet-wide this
-# produced an ~88% empty-recall rate: 440 of 526 turns that had at least
-# one bank return successfully still delivered zero memories.
+# the union-term artifact, not of a relevance judgement. Where the gate
+# actually got to run, it was decisive: of the 526 turns that had at least
+# one bank return successfully, 440 (83.7%) still delivered zero memories.
 #
-# The correct metric for asymmetric-length comparison is the overlap
-# coefficient (containment): `|Q ∩ M| / min(|Q|, |M|)`. Since the memory
-# is essentially always the shorter side, this reads as "what fraction of
-# THIS MEMORY's terms are present in the prompt" — invariant to how much
-# unrelated preamble the prompt carries, which is exactly the
-# "query-independent absolute measure" the gate was always documented to
-# be. See `containment_overlap` below.
+# How much of the empty-recall problem is this? Roughly a third — NOT all
+# of it. Partitioning the zero-result recalls by why they were empty:
+#
+#   >=1 bank returned OK, and overlap_dropped > 0   448  (~32%)  <- this gate
+#   ALL banks timed out or errored                  565  (~41%)  <- the deadline
+#   >=1 bank returned OK, nothing dropped             7
+#
+# So the 8s outer deadline accounts for MORE empty recalls than the gate
+# does, and it is still live after this change: `deadline_hit` is set on
+# 991 of 18656 logged recalls and the p50 `total_elapsed_ms` on the
+# deadline-hitting rows sits at the 8s ceiling. Fixing the metric does not
+# close #3541's latency half — see the reranker analysis in that issue.
+# This change fixes the gate; it does not fix the timeout.
+#
+# The correct metric for asymmetric-length comparison is containment:
+# `|Q ∩ M| / |M|` — "what fraction of THIS MEMORY's terms are present in
+# the prompt", invariant to how much unrelated preamble the prompt
+# carries. (Not `min(|Q|, |M|)`; see `containment_overlap` for why the
+# textbook overlap coefficient's short-prompt regime flip is undesirable
+# here.)
+#
+# --- what the 0.10 threshold does, and does not, buy ---
+#
+# Be honest about the retained default: at 0.10, containment is close to a
+# PASSTHROUGH. Because the denominator is the memory's own token count, a
+# memory of <= 10 content tokens clears 0.10 on a SINGLE shared word. Only
+# longer memories are meaningfully filtered (a 40-token memory still needs
+# 4 shared terms). Measured on the production-shaped prompt used in the
+# regression tests, a wholly off-topic memory that merely reuses words
+# from the prior-context preamble scores 0.857 — HIGHER than the genuinely
+# relevant memory at 0.571.
+#
+# That inversion is the reason the threshold is NOT being raised to
+# compensate. Raising it would drop the relevant memory before the
+# off-topic one, because on a preamble-heavy prompt containment is not
+# monotone in relevance. Lexical overlap cannot make that distinction at
+# any threshold; the engine's reranker can, and does.
+#
+# The threshold was nevertheless re-derived from data rather than inherited
+# from the Jaccard era. 31 real production queries (reconstructed from
+# transcripts with the hook's own compose+truncate, validated by matching
+# 320 of them verbatim against logged recall rows) were replayed against
+# the live engine; the 202 returned candidates were rescored offline:
+#
+#   containment    survival%   zero-result%   mean kept/query
+#      0.05           99.5%          0.0%           6.5
+#      0.10           86.1%          6.5%           5.6   <- shipped
+#      0.20           65.8%         41.9%           4.3
+#      0.30           58.4%         41.9%           3.8
+#      0.40           52.5%         54.8%           3.4
+#
+# (Jaccard @0.10 on the same candidates: 70.3% survival, 32.3%
+# zero-result — i.e. the fix cuts empty recalls from ~1 turn in 3 to
+# ~1 in 15 on this sample.)
+#
+# 0.30 and 0.40 leave 42-55% of turns with NO memories at all — they
+# re-create the exact failure #3541 is about, for a precision gain the
+# inversion above says is illusory. 0.10 is the shipped value.
+#
+# Sample caveat, stated plainly: these are single-bank (overlord) replays
+# and the engine returned ~6.5 already-top-ranked candidates per query,
+# not the ~35-candidate pools seen in the fleet logs. The ABSOLUTE
+# survival percentages are therefore optimistic versus production; the
+# RANKING of the thresholds, and the zero-result cliff above 0.10, are the
+# load-bearing results.
+#
+# So the honest statement of the design after #3541 is: the effective
+# precision control is the engine rerank plus the `recallMaxMemories`
+# head-slice, and this gate is a cheap floor that removes only candidates
+# with (near-)zero lexical relationship to the prompt. It is no longer
+# doing the job the #475 note above describes — "on a low-relevance prompt
+# the top-N could still be low-signal" is a real concern that this gate
+# does not actually address. Doing so needs a relevance-score floor
+# (`scores.final`), not a lexical one; that is deliberately out of scope
+# here and wants its own measured change.
 #
 # This is safe to run permissively: the gate is a FLOOR, not a ranker.
 # `_sort_by_final_score` orders the survivors by the engine's reranked
 # relevance score immediately afterwards, and only then does
 # `recallMaxMemories` head-slice. So admitting more candidates cannot
 # lower the quality of what is injected — it can only give the
-# score-sort a non-empty set to choose the top-N from.
+# score-sort a non-empty set to choose the top-N from. And because
+# `|Q ∩ M| / |M| >= |Q ∩ M| / |Q ∪ M|` always, at a fixed threshold this
+# metric admits a superset of what the deployed Jaccard gate admits: no
+# memory that survives in production today can be dropped by this change.
 #
 # Threshold default is 0.0 (disabled) so the gate is opt-in initially.
 # Operators tune via `memory.recall.min_overlap` in switchroom.yaml or
@@ -509,8 +580,8 @@ def _overlap_tokens(text) -> set:
 
 
 def containment_overlap(query: str, memory_text: str) -> float:
-    """Overlap coefficient (containment) between two texts, after stop-word
-    + punctuation stripping: ``|Q ∩ M| / min(|Q|, |M|)``.
+    """Containment of the MEMORY in the query, after stop-word + punctuation
+    stripping: ``|Q ∩ M| / |M|``.
 
     Returns a float in [0.0, 1.0]. Empty/degenerate inputs return 0.0 —
     it's safer to drop than retain when we can't compute.
@@ -520,18 +591,35 @@ def containment_overlap(query: str, memory_text: str) -> float:
     preamble and a memory is a short fact; dividing by the union made the
     score collapse as the prompt grew, so the gate discarded 97.1% of
     already-reranked candidates and did so monotonically in prompt length.
-    Dividing by the shorter side (in practice the memory) asks the question
-    the gate actually means: what fraction of this memory's terms appear in
-    the prompt. See the design note above `_OVERLAP_STOPWORDS` for the
-    production measurement that motivated the change.
+    Dividing by the memory asks the question the gate actually means: what
+    fraction of this memory's terms appear in the prompt. See the design
+    note above `_OVERLAP_STOPWORDS` for the production measurement.
+
+    Why ``|M|`` and not ``min(|Q|, |M|)`` (the textbook overlap coefficient):
+    the two agree only where the memory is the shorter side, and that is NOT
+    a safe assumption here. Replaying real production queries against the
+    live engine, `|Q| < |M|` held for 87 of 202 candidate pairs — 43%.
+    Memories are routinely LONGER than the prompt that retrieves them.
+    Wherever that happens `min()` selects the QUERY and the metric silently
+    becomes the converse measure: what fraction of the *prompt* appears in
+    the memory. That regime flip re-introduces exactly the query-length
+    dependence #3541 is about — a one-word prompt scores 1.0 against any
+    memory containing that word. Dividing by `|M|` unconditionally has no
+    such discontinuity.
+
+    Safety, relative to what production runs today: for any Q and M,
+
+        |Q ∩ M| / |Q ∪ M|  <=  |Q ∩ M| / |M|  <=  |Q ∩ M| / min(|Q|, |M|)
+
+    because `|Q ∪ M| >= |M| >= min(|Q|, |M|)`. So at a fixed threshold this
+    metric admits a SUPERSET of what the deployed Jaccard gate admits: no
+    memory that survives the gate today can be dropped by this change.
     """
     a = _overlap_tokens(query)
     b = _overlap_tokens(memory_text)
     if not a or not b:
         return 0.0
-    inter = len(a & b)
-    denom = min(len(a), len(b))
-    return inter / denom if denom else 0.0
+    return len(a & b) / len(b)
 
 
 def _filter_by_overlap(results, query: str, threshold: float):

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -531,14 +531,14 @@ class ContainmentOverlapUnitTests(unittest.TestCase):
             "deploy production server",
         )
         # {deploy, staging, server} vs {deploy, production, server}
-        # → intersection 2, min(|Q|, |M|) = 3 → 0.666…
+        # → intersection 2, |M| = 3 → 0.666…
         self.assertAlmostEqual(score, 2 / 3, places=2)
 
     def test_stopwords_dont_inflate_overlap(self):
         # "the" / "is" / "a" present in both shouldn't count.
         score = recall.containment_overlap("the cat is a pet", "the dog is a pet")
         # Real tokens after stopword strip: {cat, pet} vs {dog, pet}
-        # → intersection 1, min(|Q|, |M|) = 2 → 0.5
+        # → intersection 1, |M| = 2 → 0.5
         self.assertAlmostEqual(score, 0.5, places=2)
 
     def test_empty_text_yields_zero(self):
@@ -680,6 +680,135 @@ class OverlapGateQueryLengthInvarianceTests(unittest.TestCase):
         )
         self.assertEqual(len(kept), 0, "gate no longer filters — floor is dead")
         self.assertEqual(dropped, 1)
+
+    # --- switchroom #3541 review F4: what the floor does and does NOT do ---
+    #
+    # `test_gate_still_drops_irrelevant_memories_on_a_long_prompt` above uses a
+    # memory with ZERO shared terms, so it scores 0.000 and would pass at a
+    # threshold of 0.001. It proves the gate is not a total no-op; it does not
+    # characterise the floor. These two do.
+
+    IRRELEVANT_BUT_OVERLAPPING = (
+        "The nightly digest schedule and the reaction dispatch wiring "
+        "were changed."
+    )
+
+    def test_partially_overlapping_irrelevant_memory_is_KEPT_at_the_default(self):
+        """Characterisation, not aspiration: at the 0.10 fleet default the gate
+        KEEPS an off-topic memory that merely reuses words from the prompt's
+        prior-context preamble.
+
+        This memory has nothing to do with the actual question (postgres pool
+        sizing) but shares most of its content tokens with the preamble, so it
+        scores ~0.857 — HIGHER than the genuinely relevant memory (~0.571).
+        Containment is therefore NOT monotone in relevance on a preamble-heavy
+        prompt, which is precisely why the threshold is not raised to try to
+        exclude this: any threshold that drops it drops the relevant memory
+        first. Precision here is the engine reranker's job, not the gate's.
+
+        If this test ever starts failing because the memory is now dropped,
+        the gate's selectivity changed — re-measure before accepting it.
+        """
+        query = self.PREAMBLE + self.CORE_QUERY
+        off_topic = recall.containment_overlap(query, self.IRRELEVANT_BUT_OVERLAPPING)
+        relevant = recall.containment_overlap(query, self.MEMORY)
+        self.assertGreater(
+            off_topic,
+            relevant,
+            "the relevance inversion this test documents is gone — "
+            "re-derive the threshold recommendation",
+        )
+        kept, dropped = recall._filter_by_overlap(
+            [_memory(self.IRRELEVANT_BUT_OVERLAPPING)], query, 0.10
+        )
+        self.assertEqual(len(kept), 1, "gate selectivity changed — re-measure")
+        self.assertEqual(dropped, 0)
+
+    def test_floor_drops_a_long_memory_with_only_incidental_overlap(self):
+        """Where the floor DOES bite: because the denominator is the memory's
+        own token count, a long memory sharing a single incidental term with
+        the prompt scores below 0.10 and is dropped.
+
+        This is the real content of the floor after #3541 — it removes
+        candidates with near-zero lexical relationship to the prompt, and
+        (deliberately) little else.
+        """
+        query = self.PREAMBLE + self.CORE_QUERY
+        # Exactly 1 shared content token ("docker") out of 17 -> 0.059 < 0.10
+        long_incidental = (
+            "docker buildx bake emits oci manifests whose provenance "
+            "attestations confuse older registries during garbage collection "
+            "sweeps"
+        )
+        score = recall.containment_overlap(query, long_incidental)
+        self.assertLess(score, 0.10, "fixture no longer scores below the floor")
+        self.assertGreater(score, 0.0, "sanity: there IS some incidental overlap")
+        kept, dropped = recall._filter_by_overlap(
+            [_memory(long_incidental)], query, 0.10
+        )
+        self.assertEqual(len(kept), 0, "floor is dead — nothing is being dropped")
+        self.assertEqual(dropped, 1)
+
+    # --- switchroom #3541 review F5: the |Q| < |M| regime ---
+
+    def test_short_prompt_uses_the_memory_as_denominator(self):
+        """A short prompt must NOT be scored against itself.
+
+        With the textbook overlap coefficient (`min(|Q|, |M|)`) a prompt
+        shorter than the memory flips the denominator to the QUERY, and the
+        metric silently becomes "what fraction of the prompt is in the
+        memory" — a one-word prompt then scores 1.0 against any memory
+        containing that word, re-introducing the query-length dependence
+        #3541 exists to remove. Dividing by `|M|` unconditionally has no such
+        discontinuity.
+        """
+        memory = "Postgres connection pool sizing was settled at min 5 max 100."
+        n_mem = len(recall._overlap_tokens(memory))
+        query = "docker"  # 1 content token, far shorter than the memory
+        self.assertLess(
+            len(recall._overlap_tokens(query)),
+            n_mem,
+            "sanity: this is the |Q| < |M| regime",
+        )
+        # A min()-denominator would score this 1.0 (1 shared token / |Q| = 1);
+        # dividing by the memory gives 1/2.
+        self.assertEqual(recall.containment_overlap(query, "docker image"), 0.5)
+
+        # And a short prompt overlapping the memory scores by the memory:
+        q2 = "postgres pool"
+        expected = len(
+            recall._overlap_tokens(q2) & recall._overlap_tokens(memory)
+        ) / n_mem
+        self.assertAlmostEqual(
+            recall.containment_overlap(q2, memory), expected, places=6
+        )
+
+    def test_never_stricter_than_the_jaccard_gate_it_replaces(self):
+        """Safety property vs what production runs today: because
+        `|Q u M| >= |M|`, containment >= Jaccard for every pair. At a fixed
+        threshold this gate admits a SUPERSET of what the deployed Jaccard
+        gate admits, so no memory that survives today can be dropped by this
+        change. Asserted over the fixtures rather than argued in prose.
+        """
+        query = self.PREAMBLE + self.CORE_QUERY
+        cases = [
+            self.MEMORY,
+            self.IRRELEVANT_BUT_OVERLAPPING,
+            "Ken prefers oat milk in his flat white.",
+            "docker",
+            "postgres pool sizing",
+            self.PREAMBLE,
+        ]
+        for mem in cases:
+            a = recall._overlap_tokens(query)
+            b = recall._overlap_tokens(mem)
+            jac = (len(a & b) / len(a | b)) if (a and b) else 0.0
+            self.assertGreaterEqual(
+                recall.containment_overlap(query, mem) + 1e-12,
+                jac,
+                f"containment scored BELOW jaccard for {mem[:40]!r} — "
+                f"this change could drop a memory production keeps",
+            )
 
     def test_survival_does_not_degrade_as_the_prompt_grows(self):
         """Sweep prompt length the way production does and assert the relevant

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -509,55 +509,55 @@ class AckShortCircuitTests(unittest.TestCase):
         self.assertIsNotNone(ctx)
 
 
-class JaccardOverlapUnitTests(unittest.TestCase):
-    """Switchroom #475: pure-function tests for the relevance helpers."""
+class ContainmentOverlapUnitTests(unittest.TestCase):
+    """Switchroom #475 / #3541: pure-function tests for the relevance helpers."""
 
     def test_identical_text_is_full_overlap(self):
         # Modulo stop-word stripping (`is`, `the`, `a`, `to` removed).
         self.assertEqual(
-            recall.jaccard_overlap("deploy the staging server", "deploy the staging server"),
+            recall.containment_overlap("deploy the staging server", "deploy the staging server"),
             1.0,
         )
 
     def test_disjoint_text_is_zero(self):
         self.assertEqual(
-            recall.jaccard_overlap("deploy staging server", "vegan dinner recipes"),
+            recall.containment_overlap("deploy staging server", "vegan dinner recipes"),
             0.0,
         )
 
     def test_partial_overlap_is_between(self):
-        score = recall.jaccard_overlap(
+        score = recall.containment_overlap(
             "deploy staging server",
             "deploy production server",
         )
         # {deploy, staging, server} vs {deploy, production, server}
-        # → intersection 2, union 4 → 0.5
-        self.assertAlmostEqual(score, 0.5, places=2)
+        # → intersection 2, min(|Q|, |M|) = 3 → 0.666…
+        self.assertAlmostEqual(score, 2 / 3, places=2)
 
     def test_stopwords_dont_inflate_overlap(self):
         # "the" / "is" / "a" present in both shouldn't count.
-        score = recall.jaccard_overlap("the cat is a pet", "the dog is a pet")
+        score = recall.containment_overlap("the cat is a pet", "the dog is a pet")
         # Real tokens after stopword strip: {cat, pet} vs {dog, pet}
-        # → intersection 1, union 3 → 0.333…
-        self.assertAlmostEqual(score, 1 / 3, places=2)
+        # → intersection 1, min(|Q|, |M|) = 2 → 0.5
+        self.assertAlmostEqual(score, 0.5, places=2)
 
     def test_empty_text_yields_zero(self):
-        self.assertEqual(recall.jaccard_overlap("", "anything at all"), 0.0)
-        self.assertEqual(recall.jaccard_overlap("query", ""), 0.0)
+        self.assertEqual(recall.containment_overlap("", "anything at all"), 0.0)
+        self.assertEqual(recall.containment_overlap("query", ""), 0.0)
 
     def test_non_string_inputs_yield_zero(self):
-        self.assertEqual(recall.jaccard_overlap(None, "x"), 0.0)
-        self.assertEqual(recall.jaccard_overlap("x", None), 0.0)
+        self.assertEqual(recall.containment_overlap(None, "x"), 0.0)
+        self.assertEqual(recall.containment_overlap("x", None), 0.0)
 
     def test_case_insensitive(self):
         self.assertEqual(
-            recall.jaccard_overlap("DEPLOY Server", "deploy server"),
+            recall.containment_overlap("DEPLOY Server", "deploy server"),
             1.0,
         )
 
     def test_punctuation_stripped(self):
         self.assertEqual(
-            recall.jaccard_overlap("deploy, server!", "deploy server"),
+            recall.containment_overlap("deploy, server!", "deploy server"),
             1.0,
         )
 
@@ -584,15 +584,117 @@ class OverlapFilterUnitTests(unittest.TestCase):
     def test_threshold_keeps_partial_match_at_or_above(self):
         results = [_memory("deploy production server")]
         kept, dropped = recall._filter_by_overlap(results, "deploy staging server", 0.5)
-        # 2/4 = 0.5 ≥ 0.5 → kept
+        # 2/min(3, 3) = 0.666… ≥ 0.5 → kept
         self.assertEqual(len(kept), 1)
         self.assertEqual(dropped, 0)
 
     def test_threshold_drops_partial_match_below(self):
         results = [_memory("deploy production server")]
-        kept, dropped = recall._filter_by_overlap(results, "deploy staging server", 0.51)
+        # 2/min(3, 3) = 0.666… < 0.7 → dropped
+        kept, dropped = recall._filter_by_overlap(results, "deploy staging server", 0.7)
         self.assertEqual(len(kept), 0)
         self.assertEqual(dropped, 1)
+
+
+class OverlapGateQueryLengthInvarianceTests(unittest.TestCase):
+    """Switchroom #3541 regression: the gate must not be decided by prompt length.
+
+    Production telemetry (1548 recall_log.jsonl rows, ts >= 2026-07-18) showed
+    the survival rate through this gate collapsing monotonically as the prompt
+    grew — 7.3% at <200 query chars down to 0.9% at 600-750 chars — with a
+    93% zero-result rate at the long end. That is the Jaccard union term, not a
+    relevance judgement. These tests pin the containment metric that fixes it.
+    """
+
+    # A realistic recall query: the memory-bearing sentence plus the long
+    # unrelated prior-context preamble the UserPromptSubmit hook prepends.
+    CORE_QUERY = "where did we land on the postgres connection pool sizing"
+    PREAMBLE = (
+        "Prior context: the operator asked about telegram card rendering, then "
+        "about vault broker grants, then about the nightly digest schedule and "
+        "the reaction dispatch wiring, and separately about docker image "
+        "promotion, canary holdback, worktree hygiene, changelog discipline, "
+        "eval harness thresholds, skill authoring quotas and mental model "
+        "refresh cadence across the whole fleet of agents on this host. "
+    )
+    MEMORY = "Postgres connection pool sizing was settled at min 5 max 100."
+
+    @staticmethod
+    def _filler(n_words):
+        """Generate `n_words` DISTINCT unrelated content words.
+
+        Distinctness matters: the metrics operate on token *sets*, so
+        repeating the same paragraph would not grow ``|Q|`` and a
+        length-sensitivity test built on it would silently pass even under
+        the buggy Jaccard metric.
+
+        The words must also be purely alphabetic — ``_overlap_tokens``
+        splits on every non-alpha character, so a digit-suffixed word like
+        ``filler7word`` collapses to the two tokens ``filler``/``word`` no
+        matter how many are emitted.
+        """
+        letters = "abcdefghijklmnopqrstuvwxyz"
+        return " ".join(
+            "zz" + letters[i // 26 % 26] + letters[i % 26] for i in range(n_words)
+        )
+
+    def test_extra_preamble_does_not_change_the_score(self):
+        """In the production regime (query longer than the memory — always
+        true for the UserPromptSubmit preamble), piling on more unrelated
+        preamble must NOT move the score. Under Jaccard these two differ,
+        because the union term grows with the prompt; under containment the
+        denominator is the memory, so they are identical."""
+        short = recall.containment_overlap(
+            self._filler(20) + " " + self.CORE_QUERY, self.MEMORY
+        )
+        long_ = recall.containment_overlap(
+            self._filler(200) + " " + self.CORE_QUERY, self.MEMORY
+        )
+        self.assertGreater(short, 0.0, "sanity: the memory does overlap the query")
+        self.assertAlmostEqual(
+            short,
+            long_,
+            places=6,
+            msg="prompt length changed the gate score — the union-term artifact is back",
+        )
+
+    def test_relevant_memory_survives_a_production_length_prompt(self):
+        """At the fleet default threshold (0.10, scaffold.ts), a clearly
+        relevant memory must survive a production-p50-length prompt."""
+        query = self.PREAMBLE + self.CORE_QUERY
+        self.assertGreater(
+            len(query), 400, "sanity: this is a production-shaped long prompt"
+        )
+        kept, dropped = recall._filter_by_overlap([_memory(self.MEMORY)], query, 0.10)
+        self.assertEqual(
+            len(kept), 1, "relevant memory was dropped from a long prompt"
+        )
+        self.assertEqual(dropped, 0)
+
+    def test_gate_still_drops_irrelevant_memories_on_a_long_prompt(self):
+        """The floor must still bite: a length-invariant metric must not
+        become a passthrough. An unrelated memory is still dropped."""
+        query = self.PREAMBLE + self.CORE_QUERY
+        kept, dropped = recall._filter_by_overlap(
+            [_memory("Ken prefers oat milk in his flat white.")], query, 0.10
+        )
+        self.assertEqual(len(kept), 0, "gate no longer filters — floor is dead")
+        self.assertEqual(dropped, 1)
+
+    def test_survival_does_not_degrade_as_the_prompt_grows(self):
+        """Sweep prompt length the way production does and assert the relevant
+        memory survives at every length — the monotonic collapse is the bug."""
+        for n_filler in (0, 20, 50, 100, 200, 400):
+            query = self._filler(n_filler) + " " + self.CORE_QUERY
+            kept, _ = recall._filter_by_overlap(
+                [_memory(self.MEMORY)], query, 0.10
+            )
+            self.assertEqual(
+                len(kept),
+                1,
+                f"relevant memory dropped at {n_filler} filler words "
+                f"({len(query)} query chars)",
+            )
 
 
 class OverlapGateIntegrationTests(unittest.TestCase):

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -433,6 +433,43 @@ class RecallTelemetryLogTests(unittest.TestCase):
         self.assertEqual(entries[0]["demoted_count"], 1)
         self.assertEqual(entries[0]["memory_ids"], ["k1"])
 
+    def test_logs_injected_score_aggregates_post_slice(self):
+        """#3541 recall-QUALITY telemetry: the row must carry min/median/max
+        of `scores.final` for the memories actually INJECTED — i.e. after the
+        head-slice, not the pre-gate candidate pool. Without this, a rollout
+        where the gate stops dropping and the cap fills every turn is
+        indistinguishable from one feeding 8 mediocre memories per turn.
+        """
+        def _scored(text, mem_id, final):
+            m = _memory(text, mem_id=mem_id)
+            m["scores"] = {"final": final}
+            return m
+
+        memories = [
+            _scored("low", "id-low", 0.10),
+            _scored("high", "id-high", 0.90),
+            _scored("mid", "id-mid", 0.80),
+        ]
+        client = _FakeClient(directives=[], memories=memories)
+        _run_main_with(client, config_extra={"recallMaxMemories": 2})
+        e = self._read_log()[0]
+        # Sorted desc then sliced → the 0.10 memory is NOT injected, and must
+        # not appear in the aggregates.
+        self.assertEqual(e["memory_ids"], ["id-high", "id-mid"])
+        self.assertAlmostEqual(e["injected_score_max"], 0.90, places=6)
+        self.assertAlmostEqual(e["injected_score_min"], 0.80, places=6)
+        self.assertAlmostEqual(e["injected_score_median"], 0.85, places=6)
+
+    def test_injected_score_aggregates_are_null_without_scores(self):
+        """Score-less results (or an empty set) must log nulls, never a
+        sentinel like -inf that would corrupt a dashboard average."""
+        client = _FakeClient(directives=[], memories=[_memory("x", mem_id="x1")])
+        _run_main_with(client)
+        e = self._read_log()[0]
+        self.assertIsNone(e["injected_score_min"])
+        self.assertIsNone(e["injected_score_median"])
+        self.assertIsNone(e["injected_score_max"])
+
     def test_no_log_when_plugin_data_unset(self):
         # If CLAUDE_PLUGIN_DATA isn't set, the writer no-ops silently —
         # we don't want a stray log file in the working directory.
@@ -559,6 +596,53 @@ class ContainmentOverlapUnitTests(unittest.TestCase):
         self.assertEqual(
             recall.containment_overlap("deploy, server!", "deploy server"),
             1.0,
+        )
+
+
+class InjectedScoreStatsUnitTests(unittest.TestCase):
+    """#3541 — aggregates for the injected set. Must be total and non-fatal:
+    telemetry can never take recall down."""
+
+    @staticmethod
+    def _m(final):
+        return {"text": "t", "scores": {"final": final}}
+
+    def test_odd_count_uses_middle_value(self):
+        s = recall._injected_score_stats([self._m(0.1), self._m(0.9), self._m(0.5)])
+        self.assertEqual(s["injected_score_min"], 0.1)
+        self.assertEqual(s["injected_score_median"], 0.5)
+        self.assertEqual(s["injected_score_max"], 0.9)
+
+    def test_even_count_averages_the_two_middles(self):
+        s = recall._injected_score_stats(
+            [self._m(0.2), self._m(0.4), self._m(0.6), self._m(0.8)]
+        )
+        self.assertEqual(s["injected_score_median"], 0.5)
+
+    def test_empty_set_is_all_none(self):
+        self.assertEqual(
+            recall._injected_score_stats([]),
+            {
+                "injected_score_min": None,
+                "injected_score_median": None,
+                "injected_score_max": None,
+            },
+        )
+
+    def test_scoreless_entries_are_excluded_not_treated_as_negative_infinity(self):
+        s = recall._injected_score_stats([self._m(0.6), {"text": "no scores"}])
+        self.assertEqual(s["injected_score_min"], 0.6)
+        self.assertEqual(s["injected_score_max"], 0.6)
+
+    def test_malformed_input_returns_nulls_instead_of_raising(self):
+        # A telemetry error must never propagate into the recall path.
+        self.assertEqual(
+            recall._injected_score_stats(object()),
+            {
+                "injected_score_min": None,
+                "injected_score_median": None,
+                "injected_score_max": None,
+            },
         )
 
 
@@ -803,12 +887,41 @@ class OverlapGateQueryLengthInvarianceTests(unittest.TestCase):
             a = recall._overlap_tokens(query)
             b = recall._overlap_tokens(mem)
             jac = (len(a & b) / len(a | b)) if (a and b) else 0.0
+            score = recall.containment_overlap(query, mem)
             self.assertGreaterEqual(
-                recall.containment_overlap(query, mem) + 1e-12,
+                score + 1e-12,
                 jac,
                 f"containment scored BELOW jaccard for {mem[:40]!r} — "
                 f"this change could drop a memory production keeps",
             )
+            # Upper bound + exact value. Review finding: the lower bound
+            # alone is unfalsifiable for ANY implementation dividing by |M|
+            # (a constant `return 1.0` satisfies it), so it survived every
+            # mutation and proved nothing. These two pin the metric.
+            self.assertLessEqual(score, 1.0, f"containment exceeded 1.0 for {mem[:40]!r}")
+            expected = (len(a & b) / len(b)) if b else 0.0
+            self.assertAlmostEqual(
+                score, expected, places=9,
+                msg=f"containment is not |Q n M| / |M| for {mem[:40]!r}",
+            )
+
+    def test_strict_subset_memory_scores_strictly_below_one(self):
+        """A memory carrying a term the query does NOT have must score < 1.0.
+
+        The companion upper bound to the superset property above: it is what
+        actually falsifies a degenerate `return 1.0` implementation.
+        """
+        query = self.PREAMBLE + self.CORE_QUERY
+        # Every token of this memory except `quokka` appears in the query.
+        mem = self.CORE_QUERY + " quokka"
+        score = recall.containment_overlap(query, mem)
+        self.assertLess(score, 1.0)
+        self.assertGreater(score, 0.0)
+        # And a fully-contained memory reaches exactly 1.0, so the < 1.0
+        # above is a property of the missing term, not a ceiling artefact.
+        self.assertAlmostEqual(
+            recall.containment_overlap(query, self.CORE_QUERY), 1.0, places=9
+        )
 
     def test_survival_does_not_degrade_as_the_prompt_grows(self):
         """Sweep prompt length the way production does and assert the relevant

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -584,13 +584,13 @@ class OverlapFilterUnitTests(unittest.TestCase):
     def test_threshold_keeps_partial_match_at_or_above(self):
         results = [_memory("deploy production server")]
         kept, dropped = recall._filter_by_overlap(results, "deploy staging server", 0.5)
-        # 2/min(3, 3) = 0.666… ≥ 0.5 → kept
+        # 2/|M| = 2/3 = 0.666… ≥ 0.5 → kept
         self.assertEqual(len(kept), 1)
         self.assertEqual(dropped, 0)
 
     def test_threshold_drops_partial_match_below(self):
         results = [_memory("deploy production server")]
-        # 2/min(3, 3) = 0.666… < 0.7 → dropped
+        # 2/|M| = 2/3 = 0.666… < 0.7 → dropped
         kept, dropped = recall._filter_by_overlap(results, "deploy staging server", 0.7)
         self.assertEqual(len(kept), 0)
         self.assertEqual(dropped, 1)


### PR DESCRIPTION
Closes the zero-result half of #3541. Also carries the validated root-cause finding for #3547, which is **not fixable in this repo** — see below.

## What I validated (and what contradicted the issues)

Everything below was measured this task against live production, not assumed.

### #3541 — the symptom reproduces, the stated root cause does not

Re-measured `recall_log.jsonl` across all fleet agents, `ts >= 2026-07-18`, n=1548: `total_elapsed_ms` p50/p90/p99 = **8022/8032/8069**, `deadline_hit` **954/1069 (89.2%)**, `result_count == 0` **1359/1548 (87.9%)**. The issue's numbers reproduce exactly.

The reranker hypothesis is **partly true but is not the cause of the empty results.** Server-side stage timings (`docker logs switchroom-hindsight`) confirm the cross-encoder dominates latency — 112 of 117 rerank calls run at the full `MAX_CANDIDATES=150` cap, rerank p50 3.46s / p90 6.36s against handler_total p50 4.49s / p90 7.74s, i.e. ~80% of request time. But bucketing rerank duration by concurrent consolidation count shows the baseline cost is ~3s **even at zero background concurrency**, so contention is not the driver either.

The decisive measurement is client-side. `bank_timings` shows that on **526 turns at least one bank returned successfully** (successful-bank elapsed p50 3941ms — comfortably inside the deadline), and **440 of those (83.7%) still delivered `result_count == 0`**. Empty recall is therefore *not* the timeout. This directly contradicts the triage comment's conclusion that "the empty results **are** the timeouts, not a retrieval-quality problem".

On those 440 rows the telemetry names the culprit unambiguously: `pre_cap_count == 0` on all 440, with `overlap_dropped` 33–36. Every memory the reranked server returned was discarded client-side by the `recallMinOverlap` gate.

### Root cause: the gate uses the wrong similarity metric

`vendor/hindsight-memory/scripts/recall.py:469-480` (pre-fix) scored with **Jaccard**, `|Q ∩ M| / |Q ∪ M|`, comparing a long recall query against a short memory. The recall query is the whole prior-context preamble (production `query_chars` p50 **778**); a memory is a single fact. The union term is dominated by `|Q|`, so the same memory with the same real overlap scores lower purely because the prompt was longer.

Production ground truth (646 rows that put candidates through the gate, 23124 candidates, threshold 0.10):

| query_chars | rows | candidates | survived | survival% | zero-result% |
|---|---|---|---|---|---|
| 0–200 | 30 | 1364 | 99 | 7.3% | 23.3% |
| 200–400 | 110 | 4199 | 238 | 5.7% | 17.3% |
| 400–600 | 143 | 5305 | 293 | 5.5% | 72.7% |
| 600–750 | 213 | 7288 | 67 | **0.9%** | **93.0%** |
| 750–1000 | 150 | 4968 | 70 | **1.4%** | **90.0%** |

**22447 of 23124 candidates (97.1%) discarded**, with the discard rate rising monotonically in prompt length. That is the union-term artifact, not a relevance judgement.

## The fix

Replace Jaccard with **containment of the memory in the query**, `|Q ∩ M| / |M|` — `containment_overlap`, `recall.py:582`. The denominator is `|M|` **unconditionally**. This reads as "what fraction of *this memory's* terms appear in the prompt", which is the "query-independent absolute measure" the gate was already documented to be at `recall.py:399-412`.

**Why `|M|` and not `min(|Q|, |M|)`** (the textbook overlap coefficient). An earlier draft of this PR used `min()` on the assumption that "the memory is essentially always the shorter side". That assumption is **false and was measured, not assumed**: replaying real production queries against the live engine, `|Q| < |M|` held for **87 of 202 candidate pairs (43%)** — memories are routinely longer than the prompt that retrieves them. In that 43% `min()` selects the QUERY and the metric silently flips to the converse measure (what fraction of the *prompt* appears in the memory), which re-introduces exactly the query-length dependence #3541 is about — a one-word prompt would score 1.0 against any memory containing that word. Dividing by `|M|` has no such discontinuity, so `min()` was rejected.

**The invariance claim, stated honestly.** `|M|` is invariant to growth of *non-overlapping preamble* in the query — the production failure mode above. It is not unqualified invariance: where `|Q| < threshold · |M|` a short query drops a long memory however relevant it is, and where `Q ⊆ M` the metric degenerates to exactly Jaccard. So `|M|` is a **trade** against `min()`, not a strict improvement; the 43% figure is the reason this side of the trade is the safer one here.

### No quality regression — the gate is a floor, not a ranker

This was the binding constraint on the task, so stating the mechanism explicitly. After the gate, `_sort_by_final_score(results)` (`recall.py:1673`) orders survivors by the engine's reranked `scores.final`, and only then does `recallMaxMemories` head-slice (`recall.py:1684`). Admitting more candidates therefore **cannot** lower the quality of what is injected — it can only give the score-sort a non-empty set to pick the top-N from. Today the gate is deleting the ranked set outright and the model gets nothing.

Threshold default (0.10, `src/agents/scaffold.ts:3128`) and the `memory.recall.min_overlap` knob are unchanged.

## Tests

Four regression tests in `vendor/hindsight-memory/scripts/tests/test_recall_integration.py` (`OverlapGateQueryLengthInvarianceTests`), all asserting outcomes:

- extra preamble does not move the score (production regime)
- a relevant memory survives a production-length prompt at the 0.10 default
- survival does not degrade across a prompt-length sweep
- the floor still bites: an irrelevant memory is still dropped

**Mutation-verified** (revert fix → prove fail → restore):
- Mutation A, revert to Jaccard: **3 of 4 fail**.
- Mutation B, gate becomes passthrough: **the 4th fails**.

Two pre-existing assertions were rebased onto the new metric (2/3 and 0.5 instead of 0.5 and 1/3) and `test_threshold_drops_partial_match_below` moved 0.51 → 0.7; these are metric-definition changes, not weakened assertions.

## Recall-quality telemetry (new)

Raised by the outcome-regression audit and fixed here. `recall_log.jsonl` recorded volume and plumbing only — `overlap_dropped`, `capped`, `pre_cap_count`, `memory_ids`, `deadline_hit`. With the gate now a near-passthrough floor and `recallMaxMemories: 8`, 100% of precision rests on `scores.final` plus the head-slice, and **nothing observed it**. Post-rollout `overlap_dropped` collapses to 0 while `result_count` rises to the cap — which reads as unambiguous success on every existing dashboard whether the reranker is good OR whether twelve agents are now being fed 8 mediocre memories per turn.

Three new fields on every recall row, from `_injected_score_stats` (`recall.py`): **`injected_score_min`**, **`injected_score_median`**, **`injected_score_max`** — over the memories actually INJECTED (post-head-slice, not the pre-gate pool). Aggregates only; no query text, no memory text. Score-less results are excluded rather than folded in as a `-inf` sentinel, the helper is wrapped so a telemetry error can never take recall down, and cache-hit rows carry the keys as `null` for a uniformly queryable schema.

Surfaced in `switchroom memory recall-log` as well — telemetry no dashboard shows doesn't close the blind spot: `score=min/median/max` per row, and `avg_score` (mean of per-turn medians) on the summary line beside the existing volume stats.

## Test hardening

`test_never_stricter_than_the_jaccard_gate_it_replaces` was a **tautology** — it asserted only the lower bound `containment >= jaccard`, which is unfalsifiable for any implementation dividing by `|M|`, and it survived a `return 1.0` mutation. It now also asserts `containment <= 1.0` and the exact value `|Q ∩ M| / |M|`, with a new `test_strict_subset_memory_scores_strictly_below_one` for the strict-subset case. Re-mutating `containment_overlap` to `return 1.0` now fails **15** tests including both of these.

## Follow-up filed

#3581 — the load-bearing empirical claims here (87/202, the 31-query replay, the 320 verbatim rows, the five-row threshold table) exist only as prose in comments; no committed script regenerates them. Recommends committing the replay script under `vendor/hindsight-memory/scripts/tests/`. Out of scope for this PR.

## Operator guidance: use 0.10, not "0.10–0.20"

The threshold sweep in `recall.py:485-489` measures **41.9% zero-result turns at 0.20** — i.e. 0.20 re-creates the starvation this PR fixes. All operator-facing guidance (`src/config/schema.ts`, `src/agents/scaffold.ts`, `profiles/_base/start.sh.hbs`) now recommends **0.10** and warns that values at or above 0.20 measurably starve recall. The schema description no longer claims the gate "drops low-relevance matches so weak hits don't fill the slot" — `recall.py:504-513` explicitly retracts that; at 0.10 the gate is near-passthrough and the effective precision control is the engine rerank plus the `max_memories` head-slice.

Note on test hygiene: the first draft of the invariance test padded the prompt by repeating one paragraph, and passed *even under the Jaccard mutation* — the metrics operate on token **sets**, so repetition doesn't grow `|Q|`. A second draft used `filler7word`, which `_overlap_tokens` splits on the digit into `filler`/`word`. Both weaknesses were caught by mutation testing and are documented in the test helper.

Local: vendor `python3 -m pytest scripts/tests` **439 passed, 173 subtests**; scoped vitest (`tests/cli.memory.recall-log.test.ts`) **12 passed**; `npm run lint` **clean**.

## #3547 — root cause found, and it disproves the issue's premise

Not fixed here, because the defect is not in this repo. Recording the evidence so nobody re-investigates.

Both cheap operational explanations from the triage comment are **ruled out**: exactly one container mounts `switchroom-hindsight-data`, and `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=1` **is** present in the running container's env. The over-admission is real and worse than filed — live `[WORKER_STATS]` shows `consolidation=3/1` and `consolidation=4/1`, with `my_active` listing four *distinct banks* consolidating at once, i.e. precisely the cross-bank fan-out the guardrail at `src/setup/hindsight.ts:372` was installed to prevent.

But the issue's framing — "a reservation that can be exceeded is not a safety mechanism", implying a leaking semaphore — is wrong. **The knob is a floor, not a ceiling, by design.** In the hindsight server image (`ghcr.io/switchroom/switchroom-hindsight:v0.19.17`):

- `config.py:608` maps `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` into `worker_slot_reservations` — a **reservation**, documented at `worker/poller.py:164-167` as "Reserved slots guarantee capacity for that operation type", with `poller.py:290-292` stating outright that "when an operation type's in-flight count exceeds its reservation, the excess tasks are considered to be using shared pool slots".
- The over-admission path is `engine/db/ops_postgresql.py:1273-1291` — **Phase 2b**, which claims consolidation tasks from the **shared pool** (`max_slots - sum(reservations)` = 10 − 1 = **9**) after the reserved pool is exhausted. The admission accounting itself is sound; there is no bypass and no leak.
- There is **no per-type cap mechanism anywhere in the server** — grep for `slot_limit`/`max_per_type`/`slot_caps` returns zero hits. Switchroom sets a value expecting a ceiling and the server can only interpret it as a floor.

So the guardrail genuinely is not enforced, but the cause is a name/semantics mismatch plus a shared-pool claim path in server code, not a defect in `switchroom/switchroom`. Two follow-ups, deliberately **not** taken unilaterally here:

1. Upstream fix in the hindsight repo: either honour the reservation as a cap, or add a distinct per-type ceiling knob.
2. A switchroom-side deterministic workaround exists: drive `shared_pool_size` to **0** by making the per-type reservations sum to `worker_max_slots`. Phase 2 is skipped entirely when `remaining_shared == 0` (`ops_postgresql.py:1234`), so consolidation would then be structurally incapable of exceeding 1. This is a real, non-bypassable mechanism, but it removes elastic capacity for `retain`/`graph_maintenance` fleet-wide and deserves its own measured PR and operator sign-off rather than riding along here.

## Not done

- **No change to `timeout=8`** (`recall.py:1428`). Concur with the triage: server p50 handler is 4.5s, so raising the deadline would add dead wall-clock on the slow tail without adding memories. The latency half of #3541 is server-side and remains open.
- **No change to `RERANKER_MAX_CANDIDATES`.** Cutting 150 → 75 would trade answer quality for speed, which the task forbade. The reranker measurements above are recorded for whoever takes the latency half.
- **Nothing mutated on the live host.** All container access was read-only `docker exec` / `docker logs`; `switchroom-hindsight` was not restarted or recreated.
- Not merged, auto-merge not enabled.

Refs #3541, #3547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

