### PR TITLE
perf(hooks): fan out secret-guard's vault reads; add duration_ms to run-hook.sh

### DIFF
--- a/bin/run-hook.sh
+++ b/bin/run-hook.sh
@@ -16,6 +16,8 @@
 #     claude on stdout still work.
 #   - Stderr is teed: visible in journald as before AND captured to a
 #     buffer so we can attach the tail to the issue detail.
+#   - On EVERY invocation, success or failure: append one JSON line
+#     carrying `duration_ms` to the hook-timing log (#3564).
 #   - On exit 0: auto-resolve any prior unresolved issue with the same
 #     fingerprint. So a transient flake clears itself on next success.
 #   - On non-zero exit: record an issue with severity=error, code = the
@@ -27,6 +29,45 @@
 #
 # The wrapper exits with the original command's exit code, so claude
 # code's hook contract (block / allow / non-zero behaviour) is preserved.
+#
+# ── Timing log (#3564) ──────────────────────────────────────────────────
+#
+# Before this, the wrapper logged ONLY failures — no timestamps, no
+# durations. That is why `secret-guard-pretool` could sit at ~145ms per
+# tool call for months (#3543) and `workspace-dynamic-hook` at ~825ms-1.1s
+# per message (#3546) without producing a single log line: neither was
+# FAILING, merely slow, and slow-but-successful was invisible.
+#
+# So every invocation now appends one JSON line to
+#   ${TELEGRAM_STATE_DIR}/hook-timings-<Ddd>.log        (Mon..Sun)
+# shaped as:
+#   {"ts":"...","date":"YYYY-MM-DD","source":"hook:x","code":"x.mjs",
+#    "duration_ms":142,"status":0}
+# so `grep duration_ms` answers any future hook-cost question.
+#
+# Cost discipline — the wrapper's own overhead was measured at 0-2ms and
+# must stay there, so the whole timing path is FORK-FREE:
+#   - `EPOCHREALTIME` (bash 5 builtin) for start/end, integer arithmetic
+#     for the delta. No `date`, no `stat`, no subshell.
+#   - The file name embeds the weekday, giving a self-truncating 7-day
+#     ring: on the first write of a new day the existing file's first line
+#     carries last week's date, so we truncate instead of appending. The
+#     staleness check is a builtin `read` from the file — measured
+#     0.024ms/append vs 0.81ms for a single `stat` fork, which is why
+#     size-based rotation was rejected here.
+# Measured net cost of `log_timing` (2000-iteration in-shell loop, a busy
+# build host): 0.40-0.78ms per invocation, dominated by the append's
+# open/write/close. That fits inside the stated 0-2ms wrapper budget with
+# room to spare; a `date` + `stat` implementation would not.
+#
+# Env:
+#   SWITCHROOM_HOOK_TIMING=0        disable timing log entirely
+#   SWITCHROOM_HOOK_TIMING_DIR      override the log directory
+#   SWITCHROOM_HOOK_TIMING_MIN_MS   only log invocations at/above this
+#                                   duration (default 0 = log everything;
+#                                   the whole failure mode here is that
+#                                   slow-but-successful is invisible, so
+#                                   the default must not filter).
 
 set -u
 
@@ -82,8 +123,14 @@ STATE_DIR="${TELEGRAM_STATE_DIR:-}"
 STDERR_TMP="$(mktemp -t run-hook-stderr.XXXXXX 2>/dev/null || mktemp)"
 trap 'rm -f "$STDERR_TMP" 2>/dev/null || true' EXIT
 
+# Fork-free monotonic-ish start stamp. EPOCHREALTIME is a bash 5 builtin;
+# on bash 4 it is unset and timing degrades to a silent no-op.
+TIMING_START="${EPOCHREALTIME:-}"
+
 "$COMMAND" "$@" 2>"$STDERR_TMP"
 STATUS=$?
+
+TIMING_END="${EPOCHREALTIME:-}"
 
 # Replay captured stderr to our own stderr now that the command has
 # fully exited — preserves journald visibility without the streaming
@@ -94,6 +141,102 @@ fi
 
 emit_warn() {
   echo "run-hook.sh: $1" >&2
+}
+
+# ── Timing log (#3564) ────────────────────────────────────────────────────
+#
+# Everything below is deliberately FORK-FREE: no command substitution (which
+# forks a subshell), no `date`, no `stat`. Helpers return values by assigning
+# to a caller-visible global rather than via `$(...)`.
+
+# Split EPOCHREALTIME ("1753412345.123456") into whole milliseconds.
+# LC_NUMERIC can make the separator a comma, so accept either.
+# Sets `_EPOCH_MS`; returns 1 (and leaves _EPOCH_MS empty) on a bad shape.
+_EPOCH_MS=""
+_epoch_to_ms() {
+  local raw="$1" secs usecs
+  _EPOCH_MS=""
+  case "$raw" in
+    *[.,]*) secs="${raw%%[.,]*}"; usecs="${raw#*[.,]}" ;;
+    *)      secs="$raw"; usecs="0" ;;
+  esac
+  case "$secs" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  case "$usecs" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  # Pad/truncate the fractional part to exactly 6 digits, then force base 10
+  # so a leading zero is not read as octal.
+  usecs="${usecs}000000"
+  usecs="${usecs:0:6}"
+  _EPOCH_MS=$(( secs * 1000 + (10#$usecs) / 1000 ))
+  return 0
+}
+
+# JSON-escape into `_JSON_ESCAPED`. Hook sources and command basenames are
+# operator-authored and tame, but a backslash or quote in one must not be
+# able to emit a malformed line (or inject extra fields) into a log that
+# other tooling parses.
+_JSON_ESCAPED=""
+_json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  _JSON_ESCAPED="$s"
+}
+
+log_timing() {
+  [ "${SWITCHROOM_HOOK_TIMING:-1}" = "0" ] && return 0
+  [ -n "$TIMING_START" ] || return 0
+  [ -n "$TIMING_END" ] || return 0
+
+  local timing_dir="${SWITCHROOM_HOOK_TIMING_DIR:-$STATE_DIR}"
+  [ -n "$timing_dir" ] || return 0
+  [ -d "$timing_dir" ] || return 0
+
+  local start_ms end_ms duration_ms
+  _epoch_to_ms "$TIMING_START" || return 0
+  start_ms="$_EPOCH_MS"
+  _epoch_to_ms "$TIMING_END" || return 0
+  end_ms="$_EPOCH_MS"
+  duration_ms=$(( end_ms - start_ms ))
+  # A clock step backwards must not emit a negative duration.
+  [ "$duration_ms" -lt 0 ] && duration_ms=0
+
+  local min_ms="${SWITCHROOM_HOOK_TIMING_MIN_MS:-0}"
+  case "$min_ms" in
+    ''|*[!0-9]*) min_ms=0 ;;
+  esac
+  [ "$duration_ms" -lt "$min_ms" ] && return 0
+
+  # Builtin date formatting — no `date` fork.
+  local today dow ts
+  printf -v today '%(%Y-%m-%d)T' -1
+  printf -v dow '%(%a)T' -1
+  printf -v ts '%(%Y-%m-%dT%H:%M:%S%z)T' -1
+
+  local logfile="${timing_dir}/hook-timings-${dow}.log"
+
+  # 7-day self-truncating ring: the weekday-named file is either today's or
+  # exactly a week stale, so if its first line does not carry today's date,
+  # reset it. `read` from a file is a builtin — no fork.
+  if [ -s "$logfile" ]; then
+    local first=''
+    read -r first < "$logfile" 2>/dev/null || first=''
+    case "$first" in
+      *"\"date\":\"${today}\""*) : ;;
+      *) : > "$logfile" 2>/dev/null || return 0 ;;
+    esac
+  fi
+
+  local esc_source esc_code
+  _json_escape "$SOURCE"; esc_source="$_JSON_ESCAPED"
+  _json_escape "$CODE";   esc_code="$_JSON_ESCAPED"
+
+  printf '{"ts":"%s","date":"%s","source":"%s","code":"%s","duration_ms":%s,"status":%s}\n' \
+    "$ts" "$today" "$esc_source" "$esc_code" "$duration_ms" "$STATUS" \
+    >> "$logfile" 2>/dev/null || true
 }
 
 # When RUN_HOOK_DEBUG=1 is set, drop the stderr redirect on the
@@ -227,6 +370,11 @@ resolve_success() {
       >/dev/null 2>&1 || true
   fi
 }
+
+# Timing is emitted on EVERY path, including the degraded no-CLI path below
+# — it writes a file directly and does not need the switchroom CLI, so hook
+# cost stays observable even when issue tracking is off (#3564).
+log_timing
 
 if [ -z "$SWITCHROOM_CLI" ]; then
   # Degraded path. Emit a single warning so the operator knows visibility

--- a/src/vault/grants.test.ts
+++ b/src/vault/grants.test.ts
@@ -22,6 +22,7 @@ import {
   validateGrant,
   revokeGrant,
   listGrants,
+  __clearGrantCompareMemo,
 } from "./grants.js";
 
 function makeDb(): Database {
@@ -188,6 +189,121 @@ describe("validateGrant", () => {
     const result = await validateGrant(db, badToken, "KEY");
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("grant-invalid");
+  });
+});
+
+describe("validateGrant bcrypt-compare memo (#3574)", () => {
+  beforeEach(() => {
+    __clearGrantCompareMemo();
+  });
+
+  it("collapses repeat validation cost to well under one bcrypt compare", async () => {
+    // WHY THIS EXISTS: the broker calls validateGrant once per `get`
+    // (server.ts:1284) and once per `list` (:1105), and bcryptjs is pure JS
+    // that BLOCKS the broker's single shared event loop. Measured on the
+    // fleet host: ~57ms per compare, and 8 "concurrent" compares took 459ms
+    // (fully serialized). N-key hooks like secret-guard-pretool.mjs
+    // therefore cost the broker (N+1) compares of serialized CPU, which no
+    // client-side concurrency can shorten — and when that blows a client's
+    // deadline the hook scans a PARTIAL key set, silently unguarding
+    // secrets. Hence the memo.
+    //
+    // Self-baselining: measure ONE cold compare in-test rather than
+    // hardcoding a millisecond figure, so the assertion holds on any CPU.
+    const db = makeDb();
+    const { token } = await mintGrant(db, "myagent", ["KEY"], 3600);
+
+    const coldStart = performance.now();
+    expect((await validateGrant(db, token, "KEY")).ok).toBe(true);
+    const coldMs = performance.now() - coldStart;
+
+    const REPEATS = 20;
+    const warmStart = performance.now();
+    for (let i = 0; i < REPEATS; i++) {
+      expect((await validateGrant(db, token, "KEY")).ok).toBe(true);
+    }
+    const warmMs = performance.now() - warmStart;
+
+    // 20 memoized validations must cost less than a SINGLE cold compare.
+    // Un-memoized that loop is 20 × coldMs, so the margin is ~20×.
+    expect(warmMs).toBeLessThan(coldMs);
+  });
+
+  it("still honours revocation immediately after a memoized success", async () => {
+    // THE security property. The memo covers only the immutable
+    // "secret hashes to this digest" fact; revoked_at is re-read from
+    // SQLite on every call, so a kill-switch must take effect on the very
+    // next request — no TTL wait.
+    const db = makeDb();
+    const { token, id } = await mintGrant(db, "myagent", ["KEY"], 3600);
+    expect((await validateGrant(db, token, "KEY")).ok).toBe(true); // memoize
+
+    revokeGrant(db, id);
+
+    const after = await validateGrant(db, token, "KEY");
+    expect(after.ok).toBe(false);
+    if (!after.ok) expect(after.reason).toBe("grant-revoked");
+  });
+
+  it("still honours expiry after a memoized success", async () => {
+    const db = makeDb();
+    const { token, id } = await mintGrant(db, "myagent", ["KEY"], 3600);
+    expect((await validateGrant(db, token, "KEY")).ok).toBe(true); // memoize
+
+    db.run("UPDATE vault_grants SET expires_at = ? WHERE id = ?", [
+      Math.floor(Date.now() / 1000) - 10,
+      id,
+    ]);
+
+    const after = await validateGrant(db, token, "KEY");
+    expect(after.ok).toBe(false);
+    if (!after.ok) expect(after.reason).toBe("grant-expired");
+  });
+
+  it("still honours key_allow after a memoized success", async () => {
+    const db = makeDb();
+    const { token } = await mintGrant(db, "myagent", ["ALLOWED_KEY"], 3600);
+    expect((await validateGrant(db, token, "ALLOWED_KEY")).ok).toBe(true); // memoize
+
+    // Same token, different key — the memo is keyed on the secret, NOT on
+    // the requested key, so scope must still be evaluated per call.
+    const other = await validateGrant(db, token, "OTHER_KEY");
+    expect(other.ok).toBe(false);
+    if (!other.ok) expect(other.reason).toBe("grant-key-not-allowed");
+  });
+
+  it("does not accept a wrong secret for a grant whose real secret is memoized", async () => {
+    // A cache that keyed on grant id alone would turn one successful
+    // validation into a bypass for every other secret. The memo key
+    // includes sha256(secret), so it cannot.
+    const db = makeDb();
+    const { token, id } = await mintGrant(db, "myagent", ["KEY"], 3600);
+    expect((await validateGrant(db, token, "KEY")).ok).toBe(true); // memoize
+
+    const forged = `${id}.ffffffffffffffffffffffffffffffff`;
+    const result = await validateGrant(db, forged, "KEY");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("grant-invalid");
+  });
+
+  it("does not accept the old secret after the stored hash is rotated", async () => {
+    // The memo key includes secret_hash, so rotating the row's hash
+    // invalidates the entry structurally — no TTL wait, no explicit flush.
+    const db = makeDb();
+    const { token, id } = await mintGrant(db, "myagent", ["KEY"], 3600);
+    expect((await validateGrant(db, token, "KEY")).ok).toBe(true); // memoize
+
+    const { id: otherId } = await mintGrant(db, "myagent", ["KEY"], 3600);
+    const otherHash = db
+      .query<{ secret_hash: string }, [string]>(
+        "SELECT secret_hash FROM vault_grants WHERE id = ?",
+      )
+      .get(otherId)!.secret_hash;
+    db.run("UPDATE vault_grants SET secret_hash = ? WHERE id = ?", [otherHash, id]);
+
+    const after = await validateGrant(db, token, "KEY");
+    expect(after.ok).toBe(false);
+    if (!after.ok) expect(after.reason).toBe("grant-invalid");
   });
 });
 

--- a/src/vault/grants.ts
+++ b/src/vault/grants.ts
@@ -15,7 +15,7 @@
  *     string reasons; use the exported `DenyReason` union instead.
  */
 
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import * as bcrypt from "bcryptjs";
 import type { Database } from "bun:sqlite";
 
@@ -113,6 +113,101 @@ export function migrateGrantsSchema(db: Database): void {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 const BCRYPT_COST = 10;
+
+// ─── bcrypt-compare memo (#3574) ─────────────────────────────────────────────
+//
+// WHY: `bcryptjs` is pure JS. Measured on the fleet host, one
+// `bcrypt.compare` at BCRYPT_COST=10 costs ~57ms and BLOCKS the event loop
+// (8 concurrent compares took 459ms — i.e. fully serialized — and let
+// exactly ONE 1ms timer tick fire during that window). The broker is a
+// single process shared by every agent, and it calls validateGrant once per
+// `get` (server.ts:1284) plus once per `list` (server.ts:1105). So a hook
+// that reads N keys costs the broker N+1 × 57ms of SERIALIZED CPU, which no
+// amount of client-side concurrency can reduce. Under fleet load that
+// starves clients with short deadlines — for secret-guard-pretool.mjs the
+// result is a partial, nondeterministic key set and therefore SILENTLY
+// UNGUARDED secrets. That is a security bug, not just a latency bug.
+//
+// WHAT IS MEMOIZED — only the bcrypt comparison, nothing else:
+//
+//   key   = grantId : secret_hash : sha256(secret)
+//   value = the boolean `hashMatches`
+//
+// This is EXACT, not approximate. "Does this secret hash to this digest" is
+// an immutable mathematical fact for a fixed (secret, secret_hash) pair, so
+// a hit returns the same answer bcrypt would. The secret_hash is IN the key,
+// so rotating a grant's secret produces a different key and can never hit a
+// stale entry.
+//
+// WHAT IS NOT MEMOIZED — everything that can change: the row lookup,
+// revoked_at, expires_at, key_allow and write_allow are re-read from SQLite
+// on EVERY call, exactly as before. Revocation therefore still takes effect
+// on the very next request; the memo cannot keep a killed grant alive.
+//
+// Only POSITIVE results are stored: a cached negative would be a free
+// oracle for an attacker probing tokens, and rejects are not the hot path.
+// The raw secret is never stored — the key holds sha256(secret).
+//
+// The TTL and size cap are belt-and-braces (bound memory, bound the blast
+// radius of any assumption above being wrong), not the correctness argument.
+const COMPARE_MEMO_TTL_MS = 60_000;
+const COMPARE_MEMO_MAX_ENTRIES = 512;
+const compareMemo = new Map<string, number>(); // key → expiry epoch ms
+
+function memoKey(id: string, secretHash: string, secret: string): string {
+  return `${id}:${secretHash}:${createHash("sha256").update(secret).digest("hex")}`;
+}
+
+/**
+ * bcrypt.compare with an exact positive-result memo. See the block comment
+ * above for the (non-obvious) reason this is safe.
+ */
+async function compareSecret(
+  id: string,
+  secret: string,
+  secretHash: string,
+): Promise<boolean> {
+  const k = memoKey(id, secretHash, secret);
+  const now = Date.now();
+  const expiry = compareMemo.get(k);
+  if (expiry !== undefined) {
+    if (expiry > now) return true;
+    compareMemo.delete(k);
+  }
+
+  let hashMatches: boolean;
+  try {
+    hashMatches = await bcrypt.compare(secret, secretHash);
+  } catch {
+    hashMatches = false;
+  }
+
+  if (hashMatches) {
+    // Evict expired entries first; if still full, drop the oldest-inserted
+    // (Map preserves insertion order) so the memo can never grow unbounded.
+    if (compareMemo.size >= COMPARE_MEMO_MAX_ENTRIES) {
+      for (const [ck, cexp] of compareMemo) {
+        if (cexp <= now) compareMemo.delete(ck);
+      }
+      while (compareMemo.size >= COMPARE_MEMO_MAX_ENTRIES) {
+        const oldest = compareMemo.keys().next();
+        if (oldest.done) break;
+        compareMemo.delete(oldest.value);
+      }
+    }
+    compareMemo.set(k, now + COMPARE_MEMO_TTL_MS);
+  }
+  return hashMatches;
+}
+
+/**
+ * Drop every memoized comparison. Exported for tests and for any future
+ * operator-facing "flush credentials" path — production correctness does
+ * NOT depend on calling this (revocation is read live from SQLite).
+ */
+export function __clearGrantCompareMemo(): void {
+  compareMemo.clear();
+}
 
 function generateId(): string {
   // "vg_" + 6 random hex chars
@@ -286,14 +381,11 @@ export async function validateGrant(
     return { ok: false, reason: "grant-invalid" };
   }
 
-  // bcrypt compare (timing-safe)
+  // bcrypt compare (timing-safe), memoized on (id, secret_hash, secret) —
+  // see the COMPARE_MEMO block comment. Revocation/expiry/key_allow below
+  // are still evaluated from the row we just read, every single call.
   const secretHash = row.secret_hash as string;
-  let hashMatches: boolean;
-  try {
-    hashMatches = await bcrypt.compare(secret, secretHash);
-  } catch {
-    hashMatches = false;
-  }
+  const hashMatches = await compareSecret(id, secret, secretHash);
 
   if (!hashMatches) {
     return { ok: false, reason: "grant-invalid" };
@@ -358,12 +450,7 @@ export async function validateGrantForWrite(
   if (!row) return { ok: false, reason: "grant-invalid" };
 
   const secretHash = row.secret_hash as string;
-  let hashMatches: boolean;
-  try {
-    hashMatches = await bcrypt.compare(secret, secretHash);
-  } catch {
-    hashMatches = false;
-  }
+  const hashMatches = await compareSecret(id, secret, secretHash);
   if (!hashMatches) return { ok: false, reason: "grant-invalid" };
 
   const grant = rowToGrant(row);

--- a/telegram-plugin/hooks/secret-guard-pretool.mjs
+++ b/telegram-plugin/hooks/secret-guard-pretool.mjs
@@ -24,8 +24,38 @@
  *   below are measured, not assumed.
  *
  *   Generation 3 (this one) keeps the same two logical phases but fans the
- *   `get` phase out CONCURRENTLY, one request per connection, so wall time
- *   is ~2 round trips regardless of key count instead of 1 + N.
+ *   `get` phase out CONCURRENTLY, one request per connection, so the CLIENT
+ *   issues ~2 round trips' worth of requests instead of 1 + N serialized
+ *   ones.
+ *
+ *   ⚠ READ THIS BEFORE QUOTING A NUMBER. Client concurrency is NOT the
+ *   whole cost, and an earlier draft of this header claimed "~2 round trips
+ *   regardless of key count" — which was false against the real broker, for
+ *   the same reason generation 2's "sub-10ms" claim was false. Whenever the
+ *   request carries a token (which is ALWAYS, in an agent container:
+ *   readVaultToken() below always finds `.vault-token`), the broker runs
+ *   `validateGrant` per request — `list` at src/vault/broker/server.ts:1105
+ *   and every `get` at :1284 — and that awaits a `bcryptjs.compare`
+ *   (src/vault/grants.ts, BCRYPT_COST=10). bcryptjs is pure JS and BLOCKS
+ *   the broker's single event loop: measured 2026-07-25, one compare is
+ *   ~57ms on the fleet host and 8 "concurrent" compares took 459ms — fully
+ *   serialized. The broker is shared by every agent, so N keys cost the
+ *   broker (N+1) × compare of serialized CPU that no amount of client
+ *   fan-out can shorten.
+ *
+ *   That is why #3574 also added an exact positive-result memo for the
+ *   bcrypt comparison in src/vault/grants.ts (revocation/expiry/key_allow
+ *   are still read live from SQLite on every call — only the immutable
+ *   "does this secret hash to this digest" fact is memoized). With it, the
+ *   per-request broker CPU collapses to a Map lookup after the first
+ *   request and the fan-out delivers what it promises. Without it, this
+ *   hook's real cost is dominated by broker CPU, not by round trips.
+ *
+ *   The failure mode when broker CPU DOES saturate is a security
+ *   degradation, not a hang: on deadline expiry we keep whatever arrived
+ *   and scan a PARTIAL key set, so a secret can be guarded on one tool call
+ *   and unguarded on the next. `warnOnUnreachableGets` below exists so that
+ *   can never happen silently.
  *
  *   Why one request per connection rather than pipelining N gets down the
  *   single connection: the broker dispatches each line to an async handler
@@ -44,8 +74,11 @@
  *   go unguarded for the cache lifetime — i.e. it would make the guard fail
  *   open in a case where it currently blocks. Rejected on those grounds.
  *
- *   Measured (fake broker, 6 keys, 19ms service delay, median of 5):
- *     sequential  167.7ms  →  concurrent  ~59ms.
+ *   Measured client-side only (fake broker with an ASYNC 19ms service delay,
+ *   6 keys, median of 5): sequential 167.7ms → concurrent ~59ms. Treat this
+ *   as an upper bound on what the fan-out alone buys — a fake broker that
+ *   sleeps does not model the real broker's synchronous bcrypt CPU. See the
+ *   CPU-bound fake-broker test in the sibling test file.
  *
  *   When the broker is unreachable (not running, socket missing, denied)
  *   the hook fails open — same behavior as before. Vault security is owned
@@ -70,6 +103,26 @@ const MIN_VALUE_LENGTH_TO_GUARD = 8
  * fan-out on a large vault would open one unix socket per key at once. 32
  * keeps a typical vault (single digits to low tens of keys) at a single
  * round trip while capping the worst case at ceil(N/32) rounds.
+ *
+ * ⚠ COUPLING — this hook now needs up to MAX_CONCURRENT_GETS + 1 broker
+ * connections where generation 2 needed exactly ONE. That makes the guard
+ * sensitive to a limit the broker does not currently impose. Verified as of
+ * 2026-07-25: src/vault/broker/server.ts sets no `maxConnections`, no rate
+ * limit and no per-connection mutex, `validateGrant` is a read-only SQLite
+ * lookup, and the socket is bind-mounted into agent containers with no
+ * relay in between — so nothing caps us today.
+ *
+ * But if a future operator adds DoS hardening (server.maxConnections, a
+ * connection rate limiter, an inetd-style relay), the surplus `get`
+ * connections would be refused, `brokerRequest` would resolve null for
+ * those keys, and a tool call carrying one of their secrets would turn
+ * from BLOCK into a silent allow. Reproduced against a 1-connection and a
+ * 3-connection fake broker: old = BLOCK, new = allow.
+ *
+ * The deterministic guard for that is `warnOnUnreachableGets` below — a
+ * connection cap can no longer degrade the guard silently; it always
+ * leaves a line on stderr (captured by bin/run-hook.sh). If you ever cap
+ * broker connections, lower MAX_CONCURRENT_GETS below that cap.
  */
 const MAX_CONCURRENT_GETS = 32
 
@@ -217,6 +270,11 @@ async function loadVaultValuesViaBroker() {
 
   // 2. fetch every value concurrently — one round trip regardless of N
   //    (up to MAX_CONCURRENT_GETS in flight).
+  //    `unreachable` counts keys whose `get` produced NO response at all
+  //    (connect refused, socket error, deadline) as opposed to a broker
+  //    reply of DENIED/UNKNOWN_KEY. That distinction is the connection-cap
+  //    signal — see the MAX_CONCURRENT_GETS note above.
+  let unreachable = 0
   const fetched = await mapWithConcurrency(
     listRsp.keys,
     MAX_CONCURRENT_GETS,
@@ -225,6 +283,7 @@ async function loadVaultValuesViaBroker() {
         token ? { v: 1, op: 'get', key: k, token } : { v: 1, op: 'get', key: k },
         deadline,
       )
+      if (getRsp === null) unreachable++
       if (!getRsp || getRsp.ok !== true || !getRsp.entry) return null
       // Only string-kind entries are scannable haystack candidates;
       // binary/files entries can't be substring-matched against a
@@ -238,7 +297,38 @@ async function loadVaultValuesViaBroker() {
     },
   )
 
+  warnOnUnreachableGets(unreachable, listRsp.keys.length)
+
   return fetched.filter((v) => v !== null)
+}
+
+/**
+ * Deterministic degradation signal (#3574 review).
+ *
+ * The fan-out silently drops any key whose `get` never came back, and a
+ * dropped key is an UNGUARDED secret — exactly the failure a broker
+ * connection cap would produce. Prose in a comment cannot catch that at
+ * runtime, so emit one line on stderr instead. bin/run-hook.sh captures
+ * hook stderr, so `grep secret-guard ...` answers "is the guard degraded?"
+ * without anyone having to reason about connection budgets.
+ *
+ * One aggregate line, not one per key: bounded output regardless of vault
+ * size. stderr only — stdout is the hook's decision channel and must stay
+ * empty on allow.
+ */
+function warnOnUnreachableGets(unreachable, total) {
+  if (unreachable <= 0) return
+  try {
+    process.stderr.write(
+      `secret-guard-pretool: DEGRADED — ${unreachable}/${total} vault `
+      + `key(s) unresolved within the ${BROKER_TIMEOUT_MS}ms deadline `
+      + `(no broker response: deadline expired, connection refused, or `
+      + `socket error). Those secrets are NOT guarded for this tool call. `
+      + `Likely causes: broker CPU saturation (per-request bcrypt in `
+      + `validateGrant), or a broker connection cap below `
+      + `MAX_CONCURRENT_GETS (currently ${MAX_CONCURRENT_GETS}).\n`,
+    )
+  } catch { /* stderr closed — never let logging change the decision */ }
 }
 
 // ─── Scan ─────────────────────────────────────────────────────────────────

--- a/telegram-plugin/hooks/secret-guard-pretool.mjs
+++ b/telegram-plugin/hooks/secret-guard-pretool.mjs
@@ -10,15 +10,42 @@
  *   Output: exit 0 + empty stdout → allow.
  *           exit 0 + JSON on stdout with `decision: "block"` + `reason` → block.
  *
- * Performance note (closes #472 finding #7):
- *   Earlier versions forked `switchroom vault list` + `switchroom vault get`
- *   per key — each fork paid ~785ms of CLI cold-start cost. With N vault
- *   keys × every tool call, that compounded to seconds of overhead per turn.
+ * Performance note (#472 finding #7, then #3543):
+ *   Generation 1 forked `switchroom vault list` + `switchroom vault get` per
+ *   key — each fork paid ~785ms of CLI cold-start. Seconds per turn.
  *
- *   This version connects directly to the running vault-broker daemon via
- *   its NDJSON unix socket protocol (see src/vault/broker/protocol.ts) and
- *   issues sequential list+get requests over a single connection. Sub-10ms
- *   total even with several keys, vs 800ms × (1 + N) before.
+ *   Generation 2 spoke the broker's NDJSON unix-socket protocol directly
+ *   (see src/vault/broker/protocol.ts) but issued `list` + N `get` requests
+ *   SEQUENTIALLY over one connection. Its header claimed "sub-10ms total
+ *   even with several keys". That claim was wrong by ~15×: measured
+ *   in-container on 2026-07-25 the hook cost ~145ms per tool call, of which
+ *   ~132ms was 1 + N sequential round trips at ~19ms each (#3543). A false
+ *   perf claim in a header comment is how that stayed invisible; the numbers
+ *   below are measured, not assumed.
+ *
+ *   Generation 3 (this one) keeps the same two logical phases but fans the
+ *   `get` phase out CONCURRENTLY, one request per connection, so wall time
+ *   is ~2 round trips regardless of key count instead of 1 + N.
+ *
+ *   Why one request per connection rather than pipelining N gets down the
+ *   single connection: the broker dispatches each line to an async handler
+ *   WITHOUT awaiting it (src/vault/broker/server.ts:924), and the `get`
+ *   handler awaits `validateGrant` before replying (server.ts:1284). So
+ *   pipelined responses are not guaranteed to come back in request order,
+ *   and the wire format carries no request id to correlate them by
+ *   (protocol.ts:452 OkEntryResponseSchema is `{ ok, entry }` — no key, no
+ *   id). One request per connection is exactly the shape the protocol
+ *   documents ("one request per connection turn, one response") and needs
+ *   no broker change, so it ships without a broker restart.
+ *
+ *   Why not a TTL cache of vault values: values rotate at runtime through
+ *   the broker's `put` op, and this hook cannot see the vault file to key an
+ *   invalidation off its mtime. A cache would let a freshly-rotated secret
+ *   go unguarded for the cache lifetime — i.e. it would make the guard fail
+ *   open in a case where it currently blocks. Rejected on those grounds.
+ *
+ *   Measured (fake broker, 6 keys, 19ms service delay, median of 5):
+ *     sequential  167.7ms  →  concurrent  ~59ms.
  *
  *   When the broker is unreachable (not running, socket missing, denied)
  *   the hook fails open — same behavior as before. Vault security is owned
@@ -37,6 +64,14 @@ const BROKER_SOCKET =
   ?? join(homedir(), '.switchroom', 'vault-broker.sock')
 const BROKER_TIMEOUT_MS = 1500
 const MIN_VALUE_LENGTH_TO_GUARD = 8
+/**
+ * Max concurrent `get` connections to the broker (#3543). The fan-out is
+ * what makes this hook O(1) round trips instead of O(N), but an unbounded
+ * fan-out on a large vault would open one unix socket per key at once. 32
+ * keeps a typical vault (single digits to low tens of keys) at a single
+ * round trip while capping the worst case at ceil(N/32) rounds.
+ */
+const MAX_CONCURRENT_GETS = 32
 
 // ─── Stdin ────────────────────────────────────────────────────────────────
 
@@ -72,90 +107,138 @@ function readVaultToken() {
 // ─── Inline NDJSON broker client ──────────────────────────────────────────
 
 /**
- * Open a connection, run sequential request/response pairs, close.
- * Fails open (returns []) on any error — connection refused, timeout,
- * malformed response, broker locked, etc.
+ * Run exactly ONE request/response turn on a fresh connection, then close.
+ *
+ * This is the unit the broker protocol documents (protocol.ts:8-11 — "one
+ * request per connection turn, one response"). Keeping it to one request per
+ * socket is what makes it safe to run many of these concurrently: no
+ * response-ordering assumption is needed, because each socket only ever
+ * carries one response.
+ *
+ * Never rejects. Resolves `null` on ANY failure — connect refused, socket
+ * error, deadline passed, short read, malformed JSON. Callers treat `null`
+ * as "this key contributed nothing", which is the same fail-open posture the
+ * sequential implementation had.
+ *
+ * @param {object} req  request object to serialize
+ * @param {number} deadline  absolute `Date.now()` ms after which we give up
+ * @returns {Promise<object|null>} parsed response object, or null
  */
-function loadVaultValuesViaBroker() {
+function brokerRequest(req, deadline) {
   return new Promise((resolve) => {
-    const token = readVaultToken()
-    const sock = connect(BROKER_SOCKET)
-    let buf = ''
-    let done = false
-    let pending = null   // { resolve(line) }
+    let settled = false
+    let sock
+    let timer
     const finish = (result) => {
-      if (done) return
-      done = true
-      try { sock.destroy() } catch { /* best-effort */ }
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try { sock?.destroy() } catch { /* best-effort */ }
       resolve(result)
     }
 
-    const timer = setTimeout(() => finish([]), BROKER_TIMEOUT_MS)
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) return finish(null)
+    timer = setTimeout(() => finish(null), remaining)
 
-    sock.on('error', () => finish([]))
-    sock.on('close', () => {
-      clearTimeout(timer)
-      if (!done) finish([])
-    })
-
-    sock.on('data', (chunk) => {
-      buf += chunk.toString('utf8')
-      // Split on newlines; emit complete lines through the pending request.
-      let idx
-      while ((idx = buf.indexOf('\n')) >= 0) {
-        const line = buf.slice(0, idx)
-        buf = buf.slice(idx + 1)
-        if (pending) {
-          const p = pending
-          pending = null
-          p.resolve(line)
-        }
-      }
-    })
-
-    function send(req) {
-      return new Promise((respond) => {
-        pending = { resolve: respond }
-        sock.write(JSON.stringify(req) + '\n')
-      })
+    try {
+      sock = connect(BROKER_SOCKET)
+    } catch {
+      return finish(null)
     }
 
-    sock.on('connect', async () => {
+    let buf = ''
+    sock.on('error', () => finish(null))
+    // A close before we saw a full line is a failure, not an empty success.
+    sock.on('close', () => finish(null))
+    sock.on('data', (chunk) => {
+      buf += chunk.toString('utf8')
+      const idx = buf.indexOf('\n')
+      if (idx < 0) return
+      const line = buf.slice(0, idx)
+      let parsed
+      try { parsed = JSON.parse(line) } catch { return finish(null) }
+      finish(parsed)
+    })
+    sock.on('connect', () => {
       try {
-        // 1. list keys
-        const listReq = token ? { v: 1, op: 'list', token } : { v: 1, op: 'list' }
-        const listLine = await send(listReq)
-        let listRsp
-        try { listRsp = JSON.parse(listLine) } catch { return finish([]) }
-        if (!listRsp || listRsp.ok !== true || !Array.isArray(listRsp.keys)) {
-          // LOCKED / DENIED / etc. — fall through, no values.
-          return finish([])
-        }
-        // 2. fetch each value
-        const values = []
-        for (const k of listRsp.keys) {
-          const getReq = token
-            ? { v: 1, op: 'get', key: k, token }
-            : { v: 1, op: 'get', key: k }
-          const getLine = await send(getReq)
-          let getRsp
-          try { getRsp = JSON.parse(getLine) } catch { continue }
-          if (!getRsp || getRsp.ok !== true || !getRsp.entry) continue
-          // Only string-kind entries are scannable haystack candidates;
-          // binary/files entries can't be substring-matched against a
-          // tool-input string in any meaningful way.
-          if (getRsp.entry.kind === 'string'
-              && typeof getRsp.entry.value === 'string'
-              && getRsp.entry.value.length >= MIN_VALUE_LENGTH_TO_GUARD) {
-            values.push({ key: k, value: getRsp.entry.value })
-          }
-        }
-        finish(values)
+        sock.write(JSON.stringify(req) + '\n')
       } catch {
-        finish([])
+        finish(null)
       }
     })
   })
+}
+
+/**
+ * Map `worker` over `items` with at most `limit` in flight at once.
+ * Preserves input order in the result array.
+ */
+async function mapWithConcurrency(items, limit, worker) {
+  const results = new Array(items.length)
+  let cursor = 0
+  const runners = new Array(Math.min(limit, items.length)).fill(0).map(async () => {
+    for (;;) {
+      const i = cursor++
+      if (i >= items.length) return
+      results[i] = await worker(items[i], i)
+    }
+  })
+  await Promise.all(runners)
+  return results
+}
+
+/**
+ * Load every guardable vault value: one `list` turn, then a CONCURRENT fan-out
+ * of `get` turns (#3543 — this replaces a sequential 1 + N round-trip loop).
+ *
+ * Fail-open contract, unchanged from the sequential version except where
+ * noted:
+ *   - `list` fails / is denied / broker locked  → `[]` (hook allows).
+ *   - an individual `get` fails or is denied    → that key is skipped, the
+ *     remaining keys are still guarded.
+ *   - overall deadline expires                  → whatever HAS been fetched
+ *     is returned and still scanned. The sequential version discarded
+ *     everything on timeout, so this is strictly MORE coverage, never less.
+ */
+async function loadVaultValuesViaBroker() {
+  const deadline = Date.now() + BROKER_TIMEOUT_MS
+  const token = readVaultToken()
+
+  // 1. list keys — one round trip.
+  const listRsp = await brokerRequest(
+    token ? { v: 1, op: 'list', token } : { v: 1, op: 'list' },
+    deadline,
+  )
+  if (!listRsp || listRsp.ok !== true || !Array.isArray(listRsp.keys)) {
+    // LOCKED / DENIED / unreachable / malformed — no values.
+    return []
+  }
+
+  // 2. fetch every value concurrently — one round trip regardless of N
+  //    (up to MAX_CONCURRENT_GETS in flight).
+  const fetched = await mapWithConcurrency(
+    listRsp.keys,
+    MAX_CONCURRENT_GETS,
+    async (k) => {
+      const getRsp = await brokerRequest(
+        token ? { v: 1, op: 'get', key: k, token } : { v: 1, op: 'get', key: k },
+        deadline,
+      )
+      if (!getRsp || getRsp.ok !== true || !getRsp.entry) return null
+      // Only string-kind entries are scannable haystack candidates;
+      // binary/files entries can't be substring-matched against a
+      // tool-input string in any meaningful way.
+      if (getRsp.entry.kind === 'string'
+          && typeof getRsp.entry.value === 'string'
+          && getRsp.entry.value.length >= MIN_VALUE_LENGTH_TO_GUARD) {
+        return { key: k, value: getRsp.entry.value }
+      }
+      return null
+    },
+  )
+
+  return fetched.filter((v) => v !== null)
 }
 
 // ─── Scan ─────────────────────────────────────────────────────────────────

--- a/telegram-plugin/tests/secret-guard-pretool.test.ts
+++ b/telegram-plugin/tests/secret-guard-pretool.test.ts
@@ -17,7 +17,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { spawn, spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync, unlinkSync, existsSync } from 'node:fs'
+import { mkdtempSync, rmSync, unlinkSync, existsSync, writeFileSync, chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { createServer, type Server, type Socket } from 'node:net'
@@ -39,10 +39,18 @@ interface FakeBroker {
 function startFakeBroker(
   values: Record<string, string>,
   opts: {
-    /** Artificial per-request service delay, ms. Models the real broker's
-     *  round-trip cost so a sequential implementation is distinguishable
-     *  from a concurrent one by wall clock. */
+    /** Artificial per-request service delay, ms, implemented with
+     *  setTimeout. This models NETWORK/IO latency only — it does NOT occupy
+     *  the broker's event loop, so it makes client-side fan-out look like a
+     *  pure win. Use `cpuMs` for the honest model of the real broker. */
     delayMs?: number
+    /** Artificial per-request SYNCHRONOUS CPU cost, ms. This is what the
+     *  real broker actually does: every tokened request awaits a
+     *  `bcryptjs.compare` (src/vault/grants.ts, BCRYPT_COST=10), and
+     *  bcryptjs is pure JS that blocks the event loop — measured ~57ms per
+     *  compare, with 8 "concurrent" compares taking 459ms (fully
+     *  serialized). A busy-wait reproduces that; a setTimeout does not. */
+    cpuMs?: number
     /** Keys whose `get` should return DENIED instead of a value. */
     denyKeys?: string[]
     /** Keys whose `get` should never be answered at all (socket left open). */
@@ -53,6 +61,13 @@ function startFakeBroker(
     const dir = mkdtempSync(join(tmpdir(), 'fake-broker-'))
     const socketPath = join(dir, 'broker.sock')
     const delayMs = opts.delayMs ?? 0
+    const cpuMs = opts.cpuMs ?? 0
+    /** Block the event loop for `cpuMs`, the way bcryptjs.compare does. */
+    const burnCpu = () => {
+      if (cpuMs <= 0) return
+      const until = Date.now() + cpuMs
+      while (Date.now() < until) { /* deliberate busy-wait */ }
+    }
     const denyKeys = new Set(opts.denyKeys ?? [])
     const hangKeys = new Set(opts.hangKeys ?? [])
     let connectionCount = 0
@@ -75,6 +90,10 @@ function startFakeBroker(
             inFlightGets++
             if (inFlightGets > maxConcurrentGets) maxConcurrentGets = inFlightGets
           }
+          // The real broker awaits validateGrant -> bcryptjs.compare BEFORE
+          // it can reply, and that call blocks its single event loop. Burn
+          // here, synchronously, for the same reason and at the same point.
+          burnCpu()
           const reply = (obj: unknown) => {
             setTimeout(() => {
               if (isGet) inFlightGets--
@@ -122,9 +141,12 @@ function startFakeBroker(
 function runHook(opts: {
   toolInput: unknown
   brokerSocket?: string | null
+  /** Prepended to the child's PATH — used to plant a `switchroom` shim. */
+  pathPrefix?: string
 }): Promise<{ stdout: string; stderr: string; status: number; elapsedMs: number }> {
+  const basePath = process.env.PATH ?? ''
   const env: Record<string, string> = {
-    PATH: process.env.PATH ?? '',
+    PATH: opts.pathPrefix ? `${opts.pathPrefix}:${basePath}` : basePath,
     NODE_PATH: process.env.NODE_PATH ?? '',
     HOME: process.env.HOME ?? '',
   }
@@ -148,6 +170,47 @@ function runHook(opts: {
     })
     child.stdin.end(stdinJson)
   })
+}
+
+/**
+ * Plant an executable `switchroom` on a fresh directory that records every
+ * invocation by touching a sentinel file, then returns a plausible-looking
+ * success so a forking implementation would appear to work (and therefore
+ * would NOT be caught by the block/allow assertions alone).
+ *
+ * Returns the directory to prepend to PATH and the sentinel path.
+ */
+function plantSwitchroomShim(): { dir: string; sentinel: string } {
+  // NOT under os.tmpdir(): /tmp is mounted `noexec` in the agent containers
+  // this suite runs in (verified 2026-07-25 — `findmnt -no OPTIONS /tmp` =>
+  // `rw,nosuid,nodev,noexec`). A shim planted there is silently unrunnable,
+  // which would make the no-fork assertion below vacuously true — the exact
+  // class of bug this test exists to close. Plant it beside the test file,
+  // on the repo filesystem, which is executable.
+  const dir = mkdtempSync(join(__dirname, '.shim-'))
+  const sentinel = join(dir, 'FORKED')
+  const shim = join(dir, 'switchroom')
+  writeFileSync(shim, `#!/bin/sh\nprintf '%s\\n' "$*" >> "${sentinel}"\nexit 0\n`)
+  chmodSync(shim, 0o755)
+
+  // Self-check: prove the shim is REACHABLE and RECORDS, so "sentinel
+  // absent" can only ever mean "the hook did not fork" — never "the shim
+  // could not run". Without this the test can go vacuous again the moment
+  // it runs on a noexec mount.
+  const probe = spawnSync('switchroom', ['self-check'], {
+    env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ''}` },
+  })
+  if (probe.status !== 0 || !existsSync(sentinel)) {
+    rmSync(dir, { recursive: true, force: true })
+    throw new Error(
+      `no-fork shim is not executable (status=${probe.status}, `
+      + `error=${probe.error?.message ?? 'none'}) — the no-fork assertion `
+      + `would be vacuous. Fix the shim location, do not skip this test.`,
+    )
+  }
+  unlinkSync(sentinel)
+
+  return { dir, sentinel }
 }
 
 let broker: FakeBroker | null = null
@@ -216,10 +279,17 @@ describe('secret-guard-pretool.mjs (broker-direct)', () => {
   })
 
   it('total cost is ~2 round trips, not 1 + N (#3543)', async () => {
-    // 8 keys at a 40ms service delay. Sequential => >= 9 * 40 = 360ms of
-    // broker time. Concurrent => ~2 * 40 = 80ms. The 250ms ceiling sits far
-    // below the sequential floor and far above the concurrent cost plus
-    // node startup, so it discriminates the two without being flaky.
+    // Deliberately NOT a wall-clock assertion. The earlier version of this
+    // test asserted elapsedMs < 250; measured node cold start for this hook
+    // is 104-127ms on an idle box and this suite runs under `bun test` on a
+    // 2-vCPU CI runner alongside the rest of telegram-plugin/tests, so a
+    // 250ms ceiling had ~65ms of headroom and would have flaked (#3574
+    // review F3).
+    //
+    // `maxConcurrentGets` is the timing-INDEPENDENT discriminator for the
+    // same property: the sequential 1 + N implementation could never exceed
+    // 1 in flight no matter how fast or slow the box is, while the fan-out
+    // has all 8 outstanding at once. Same guarantee, zero clock dependence.
     const values: Record<string, string> = {}
     for (let i = 0; i < 8; i++) values['k' + i] = `secret-value-number-${i}-xxxxxxxx`
     broker = await startFakeBroker(values, { delayMs: 40 })
@@ -228,27 +298,156 @@ describe('secret-guard-pretool.mjs (broker-direct)', () => {
       brokerSocket: broker.socketPath,
     })
     expect(r.status).toBe(0)
-    expect(r.elapsedMs).toBeLessThan(250)
+    expect(broker.maxConcurrentGets).toBe(8)
+    // 1 list + 8 gets, one request per connection.
+    expect(broker.connectionCount).toBe(9)
   })
 
-  it('does not fork a child process per key', async () => {
-    // The generation-1 shape forked `switchroom vault get` per key. The
-    // broker must see exactly one connection per request turn and the hook
-    // must speak the socket itself — so connections are bounded by 1 + N,
-    // and no `switchroom` binary is required on PATH at all (the env we
-    // hand the child has no SWITCHROOM_CLI_PATH).
-    broker = await startFakeBroker({
-      'a': 'aaaaaaaa-secret-value-aaaaaaaa',
-      'b': 'bbbbbbbb-secret-value-bbbbbbbb',
-      'c': 'cccccccc-secret-value-cccccccc',
-    })
-    await runHook({
+  it('client fan-out does NOT reduce wall time against a CPU-bound broker (#3574)', async () => {
+    // The honest counterpart to the test above. The `delayMs` fake sleeps,
+    // so it credits the fan-out with a speedup that CANNOT exist against
+    // the real broker, whose per-request cost is a synchronous, event-loop-
+    // blocking `bcryptjs.compare` inside validateGrant. `cpuMs` reproduces
+    // that.
+    //
+    // Asserted property: with a CPU-bound broker the client's concurrency
+    // is irrelevant to wall time — total cost is still ~(N+1) × cpuMs,
+    // i.e. STRICTLY MORE than the serialized floor. This is a lower bound
+    // (>=), so it cannot flake upward on a loaded runner; it fails only if
+    // someone re-introduces the false "concurrency makes it O(1)" model.
+    // This is a DIFFERENTIAL, not an absolute budget, for the reason F3
+    // flagged: an absolute wall-clock ceiling has to leave room for node
+    // cold start (measured 104-127ms for this hook on an idle box) and
+    // flakes on a loaded CI runner. Running the SAME hook against both
+    // broker models subtracts node startup and every other fixed cost
+    // automatically — the baseline is measured, not assumed.
+    //
+    //   sleeping broker (delayMs): fan-out wins   => ~startup + 2 × COST
+    //   CPU-bound broker (cpuMs):  fan-out cannot => ~startup + (N+1) × COST
+    //
+    // so the gap should be ~(N-1) × COST = 160ms. We assert only that it
+    // exceeds 2 × COST (80ms): if concurrency helped a CPU-bound broker the
+    // way it helps a sleeping one, the gap would be ~0. Load inflates both
+    // runs, so the LOWER bound on a difference is what stays stable.
+    const N = 5
+    const COST_MS = 40
+    const values: Record<string, string> = {}
+    for (let i = 0; i < N; i++) values['c' + i] = `cpu-secret-value-${i}-xxxxxxxx`
+
+    const sleepy = await startFakeBroker(values, { delayMs: COST_MS })
+    let sleepyMs: number
+    try {
+      const rs = await runHook({ toolInput: { command: 'echo hi' }, brokerSocket: sleepy.socketPath })
+      expect(rs.status).toBe(0)
+      sleepyMs = rs.elapsedMs
+    } finally {
+      await sleepy.stop()
+    }
+
+    broker = await startFakeBroker(values, { cpuMs: COST_MS })
+    const r = await runHook({
       toolInput: { command: 'echo hi' },
       brokerSocket: broker.socketPath,
     })
-    // 1 list + 3 gets, one request per connection (the shape the broker
-    // protocol documents; see protocol.ts:8-11).
-    expect(broker.connectionCount).toBe(4)
+    expect(r.status).toBe(0)
+    expect(r.elapsedMs - sleepyMs).toBeGreaterThan(2 * COST_MS)
+    // And the guard must still be COMPLETE despite that cost: every key
+    // resolved within the deadline, including the last. Partial coverage is
+    // the security failure mode this whole area is about.
+    expect(broker.connectionCount).toBe(N + 1)
+    expect(r.stderr).not.toContain('DEGRADED')
+  }, 20_000)
+
+  it('caps the fan-out at MAX_CONCURRENT_GETS and still guards every key past the cap', async () => {
+    // Two properties the fan-out owes us on a vault larger than the cap
+    // (MAX_CONCURRENT_GETS = 32), both timing-independent:
+    //   1. the cap is real — 40 keys must never put more than 32 gets in
+    //      flight (an unbounded fan-out would show 40);
+    //   2. the batch loop drains the remainder — key #40, which can only be
+    //      fetched in the second batch, is still guarded.
+    const values: Record<string, string> = {}
+    for (let i = 0; i < 40; i++) values['k' + i] = `secret-value-number-${i}-xxxxxxxxxx`
+    broker = await startFakeBroker(values, { delayMs: 40 })
+    const r = await runHook({
+      // k39 is the 40th key — past the first batch of 32.
+      toolInput: { command: 'echo secret-value-number-39-xxxxxxxxxx' },
+      brokerSocket: broker.socketPath,
+    })
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('"decision":"block"')
+    expect(r.stdout).toContain('k39')
+    expect(broker.maxConcurrentGets).toBeLessThanOrEqual(32)
+    expect(broker.maxConcurrentGets).toBeGreaterThan(1)
+    expect(broker.connectionCount).toBe(41)
+  }, 10_000)
+
+  it('does not fork a child process per key', async () => {
+    // The generation-1 shape forked `switchroom vault get` per key. Asserting
+    // a connection COUNT cannot prove that — a fork-per-key implementation
+    // produces the same 1 + N connections, because each forked CLI opens its
+    // own (#3574 review F2). So plant an executable `switchroom` on PATH that
+    // records every invocation and assert it was never invoked.
+    const { dir, sentinel } = plantSwitchroomShim()
+    try {
+      broker = await startFakeBroker({
+        'a': 'aaaaaaaa-secret-value-aaaaaaaa',
+        'b': 'bbbbbbbb-secret-value-bbbbbbbb',
+        'c': 'cccccccc-secret-value-cccccccc',
+      })
+      await runHook({
+        toolInput: { command: 'echo hi' },
+        brokerSocket: broker.socketPath,
+        pathPrefix: dir,
+      })
+      // The shim is genuinely reachable and would have fired — the hook
+      // simply never shells out. (It exits 0 with plausible output, so a
+      // forking implementation would still allow/block correctly and could
+      // only be caught here.)
+      expect(existsSync(sentinel)).toBe(false)
+      // Secondary: the hook speaks the socket itself, one request per
+      // connection turn (the shape protocol.ts:8-11 documents).
+      expect(broker.connectionCount).toBe(4)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('logs a DEGRADED line when a `get` gets no broker response (#3574)', async () => {
+    // The fan-out silently drops any key whose `get` never returns, and a
+    // dropped key is an unguarded secret. That is exactly what a broker
+    // connection cap would cause (this hook needs N+1 connections where the
+    // sequential version needed 1). Prose in a comment can't catch it, so
+    // the hook must leave a deterministic trace on stderr.
+    broker = await startFakeBroker({
+      'hung-key': 'hung-secret-value-aaaaaaaa',
+      'live-key': 'live-secret-value-bbbbbbbb',
+    }, { hangKeys: ['hung-key'] })
+    const r = await runHook({
+      toolInput: { command: 'echo hi' },
+      brokerSocket: broker.socketPath,
+    })
+    expect(r.status).toBe(0)
+    expect(r.stderr).toContain('DEGRADED')
+    expect(r.stderr).toContain('1/2')
+    // Decision channel stays clean — the warning must not leak to stdout,
+    // where Claude Code parses the block decision.
+    expect(r.stdout).toBe('')
+  }, 10_000)
+
+  it('does not log DEGRADED when every key resolves', async () => {
+    // Guards the inverse: a DENIED reply is a broker ANSWER, not an
+    // unreachable connection, so it must not raise the degradation signal
+    // (otherwise the line is noise and gets ignored).
+    broker = await startFakeBroker({
+      'denied-key': 'denied-secret-value-aaaaaaaa',
+      'live-key': 'live-secret-value-bbbbbbbb',
+    }, { denyKeys: ['denied-key'] })
+    const r = await runHook({
+      toolInput: { command: 'echo hi' },
+      brokerSocket: broker.socketPath,
+    })
+    expect(r.status).toBe(0)
+    expect(r.stderr).not.toContain('DEGRADED')
   })
 
   it('still blocks on the other keys when one key is DENIED', async () => {

--- a/telegram-plugin/tests/secret-guard-pretool.test.ts
+++ b/telegram-plugin/tests/secret-guard-pretool.test.ts
@@ -28,20 +28,40 @@ interface FakeBroker {
   socketPath: string
   stop: () => Promise<void>
   connectionCount: number
+  /** High-water mark of `get` requests being serviced simultaneously. */
+  maxConcurrentGets: number
 }
 
 /**
  * Stand up a minimal NDJSON broker. Responds to `list` with the supplied
  * keys, and to `get` requests with the entry shape Telegram-plugin expects.
  */
-function startFakeBroker(values: Record<string, string>): Promise<FakeBroker> {
+function startFakeBroker(
+  values: Record<string, string>,
+  opts: {
+    /** Artificial per-request service delay, ms. Models the real broker's
+     *  round-trip cost so a sequential implementation is distinguishable
+     *  from a concurrent one by wall clock. */
+    delayMs?: number
+    /** Keys whose `get` should return DENIED instead of a value. */
+    denyKeys?: string[]
+    /** Keys whose `get` should never be answered at all (socket left open). */
+    hangKeys?: string[]
+  } = {},
+): Promise<FakeBroker> {
   return new Promise((resolveStart) => {
     const dir = mkdtempSync(join(tmpdir(), 'fake-broker-'))
     const socketPath = join(dir, 'broker.sock')
+    const delayMs = opts.delayMs ?? 0
+    const denyKeys = new Set(opts.denyKeys ?? [])
+    const hangKeys = new Set(opts.hangKeys ?? [])
     let connectionCount = 0
+    let inFlightGets = 0
+    let maxConcurrentGets = 0
     const server: Server = createServer((sock: Socket) => {
       connectionCount++
       let buf = ''
+      sock.on('error', () => { /* client destroys sockets after one turn */ })
       sock.on('data', (chunk) => {
         buf += chunk.toString('utf8')
         let idx
@@ -50,14 +70,28 @@ function startFakeBroker(values: Record<string, string>): Promise<FakeBroker> {
           buf = buf.slice(idx + 1)
           let req
           try { req = JSON.parse(line) } catch { continue }
+          const isGet = req?.op === 'get'
+          if (isGet) {
+            inFlightGets++
+            if (inFlightGets > maxConcurrentGets) maxConcurrentGets = inFlightGets
+          }
+          const reply = (obj: unknown) => {
+            setTimeout(() => {
+              if (isGet) inFlightGets--
+              try { sock.write(JSON.stringify(obj) + '\n') } catch { /* closed */ }
+            }, delayMs)
+          }
           if (req?.op === 'list') {
-            sock.write(JSON.stringify({ ok: true, keys: Object.keys(values) }) + '\n')
-          } else if (req?.op === 'get' && typeof req.key === 'string') {
+            reply({ ok: true, keys: Object.keys(values) })
+          } else if (isGet && typeof req.key === 'string') {
+            if (hangKeys.has(req.key)) continue // never reply, never decrement
             const v = values[req.key]
-            if (v !== undefined) {
-              sock.write(JSON.stringify({ ok: true, entry: { kind: 'string', value: v } }) + '\n')
+            if (denyKeys.has(req.key)) {
+              reply({ ok: false, code: 'DENIED', msg: req.key })
+            } else if (v !== undefined) {
+              reply({ ok: true, entry: { kind: 'string', value: v } })
             } else {
-              sock.write(JSON.stringify({ ok: false, code: 'UNKNOWN_KEY', msg: req.key }) + '\n')
+              reply({ ok: false, code: 'UNKNOWN_KEY', msg: req.key })
             }
           }
         }
@@ -67,6 +101,7 @@ function startFakeBroker(values: Record<string, string>): Promise<FakeBroker> {
       resolveStart({
         socketPath,
         get connectionCount() { return connectionCount },
+        get maxConcurrentGets() { return maxConcurrentGets },
         stop: () => new Promise<void>((stopResolve) => {
           server.close(() => {
             try { rmSync(dir, { recursive: true, force: true }) } catch { /* best-effort */ }
@@ -87,7 +122,7 @@ function startFakeBroker(values: Record<string, string>): Promise<FakeBroker> {
 function runHook(opts: {
   toolInput: unknown
   brokerSocket?: string | null
-}): Promise<{ stdout: string; stderr: string; status: number }> {
+}): Promise<{ stdout: string; stderr: string; status: number; elapsedMs: number }> {
   const env: Record<string, string> = {
     PATH: process.env.PATH ?? '',
     NODE_PATH: process.env.NODE_PATH ?? '',
@@ -102,13 +137,14 @@ function runHook(opts: {
     tool_input: opts.toolInput,
   })
   return new Promise((resolveRun) => {
+    const t0 = Date.now()
     const child = spawn('node', [HOOK_PATH], { env })
     let stdout = ''
     let stderr = ''
     child.stdout.on('data', (d) => { stdout += d.toString() })
     child.stderr.on('data', (d) => { stderr += d.toString() })
     child.on('close', (status) => {
-      resolveRun({ stdout, stderr, status: status ?? 1 })
+      resolveRun({ stdout, stderr, status: status ?? 1, elapsedMs: Date.now() - t0 })
     })
     child.stdin.end(stdinJson)
   })
@@ -160,7 +196,47 @@ describe('secret-guard-pretool.mjs (broker-direct)', () => {
     expect(r.stdout).toBe('')
   })
 
-  it('opens a single broker connection per invocation (no per-key forks)', async () => {
+  it('issues the per-key gets concurrently, not one at a time (#3543)', async () => {
+    // The old implementation awaited each `get` before sending the next, so
+    // its cost was 1 + N round trips. The fan-out must have several gets in
+    // flight at the same time. This asserts the OUTCOME (overlapping
+    // in-flight requests observed by the broker), not that a particular
+    // function was called.
+    broker = await startFakeBroker({
+      'a': 'aaaaaaaa-secret-value-aaaaaaaa',
+      'b': 'bbbbbbbb-secret-value-bbbbbbbb',
+      'c': 'cccccccc-secret-value-cccccccc',
+      'd': 'dddddddd-secret-value-dddddddd',
+    }, { delayMs: 40 })
+    await runHook({
+      toolInput: { command: 'echo hi' },
+      brokerSocket: broker.socketPath,
+    })
+    expect(broker.maxConcurrentGets).toBe(4)
+  })
+
+  it('total cost is ~2 round trips, not 1 + N (#3543)', async () => {
+    // 8 keys at a 40ms service delay. Sequential => >= 9 * 40 = 360ms of
+    // broker time. Concurrent => ~2 * 40 = 80ms. The 250ms ceiling sits far
+    // below the sequential floor and far above the concurrent cost plus
+    // node startup, so it discriminates the two without being flaky.
+    const values: Record<string, string> = {}
+    for (let i = 0; i < 8; i++) values['k' + i] = `secret-value-number-${i}-xxxxxxxx`
+    broker = await startFakeBroker(values, { delayMs: 40 })
+    const r = await runHook({
+      toolInput: { command: 'echo hi' },
+      brokerSocket: broker.socketPath,
+    })
+    expect(r.status).toBe(0)
+    expect(r.elapsedMs).toBeLessThan(250)
+  })
+
+  it('does not fork a child process per key', async () => {
+    // The generation-1 shape forked `switchroom vault get` per key. The
+    // broker must see exactly one connection per request turn and the hook
+    // must speak the socket itself — so connections are bounded by 1 + N,
+    // and no `switchroom` binary is required on PATH at all (the env we
+    // hand the child has no SWITCHROOM_CLI_PATH).
     broker = await startFakeBroker({
       'a': 'aaaaaaaa-secret-value-aaaaaaaa',
       'b': 'bbbbbbbb-secret-value-bbbbbbbb',
@@ -170,10 +246,66 @@ describe('secret-guard-pretool.mjs (broker-direct)', () => {
       toolInput: { command: 'echo hi' },
       brokerSocket: broker.socketPath,
     })
-    // The hook must keep one socket connection open and pipeline list +
-    // N get requests over it. Forking a child per key was the old shape
-    // and is what this PR fixes.
-    expect(broker.connectionCount).toBe(1)
+    // 1 list + 3 gets, one request per connection (the shape the broker
+    // protocol documents; see protocol.ts:8-11).
+    expect(broker.connectionCount).toBe(4)
+  })
+
+  it('still blocks on the other keys when one key is DENIED', async () => {
+    // Security posture: a per-key failure must not disable the guard for
+    // the keys that DID resolve. This is the case the sequential version
+    // handled with `continue`; the fan-out must preserve it.
+    broker = await startFakeBroker({
+      'denied-key': 'denied-secret-value-aaaaaaaa',
+      'live-key': 'live-secret-value-bbbbbbbb',
+    }, { denyKeys: ['denied-key'] })
+    const r = await runHook({
+      toolInput: { command: 'echo live-secret-value-bbbbbbbb' },
+      brokerSocket: broker.socketPath,
+    })
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('"decision":"block"')
+    expect(r.stdout).toContain('live-key')
+  })
+
+  it('still blocks on resolved keys when another key never responds', async () => {
+    // A hung `get` used to stall the whole sequential loop until the 1500ms
+    // deadline and then discard EVERY value (fail open). Now the other keys
+    // resolve independently and are still guarded.
+    broker = await startFakeBroker({
+      'hung-key': 'hung-secret-value-aaaaaaaa',
+      'live-key': 'live-secret-value-bbbbbbbb',
+    }, { hangKeys: ['hung-key'] })
+    const r = await runHook({
+      toolInput: { command: 'echo live-secret-value-bbbbbbbb' },
+      brokerSocket: broker.socketPath,
+    })
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('"decision":"block"')
+    expect(r.stdout).toContain('live-key')
+  }, 10_000)
+
+  it('fails open when the broker denies `list`', async () => {
+    // No key set is knowable => nothing to guard against => allow. Same as
+    // the sequential version; asserted so a refactor cannot silently turn
+    // this into a hard block that wedges every session.
+    const dir = mkdtempSync(join(tmpdir(), 'deny-broker-'))
+    const socketPath = join(dir, 'broker.sock')
+    const server = createServer((sock: Socket) => {
+      sock.on('error', () => {})
+      sock.on('data', () => {
+        sock.write(JSON.stringify({ ok: false, code: 'LOCKED', msg: 'locked' }) + '\n')
+      })
+    })
+    await new Promise<void>((r) => server.listen(socketPath, () => r()))
+    try {
+      const res = await runHook({ toolInput: { command: 'echo hi' }, brokerSocket: socketPath })
+      expect(res.status).toBe(0)
+      expect(res.stdout).toBe('')
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()))
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   it('skips values shorter than the minimum guard length', async () => {

--- a/tests/run-hook.test.ts
+++ b/tests/run-hook.test.ts
@@ -393,6 +393,22 @@ describe("run-hook.sh", () => {
     expect(readTimingLines()).toHaveLength(0);
   });
 
+  it("SWITCHROOM_HOOK_TIMING_MIN_MS still logs invocations at or above the floor", () => {
+    // Paired with the test above on purpose (#3574 review, LOW). A filter
+    // that is merely "drop everything whenever MIN_MS is set" passes the
+    // 100000ms case perfectly while silently discarding the SLOW hooks the
+    // whole feature exists to surface. Only the over-the-floor half of the
+    // pair can catch that, so both halves must exist.
+    const script = makeScript("slow.sh", "sleep 0.3\nexit 0");
+    runHook("hook:timing-over", script, [], {
+      SWITCHROOM_HOOK_TIMING_MIN_MS: "50",
+    });
+    const lines = readTimingLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].source).toBe("hook:timing-over");
+    expect(lines[0].duration_ms).toBeGreaterThanOrEqual(50);
+  });
+
   it("escapes quotes and backslashes in the source so the line stays valid JSON", () => {
     const script = makeScript("ok.sh", "exit 0");
     const nasty = 'hook:"quo\\ted"';

--- a/tests/run-hook.test.ts
+++ b/tests/run-hook.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+  readdirSync,
+  readFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -297,6 +304,130 @@ describe("run-hook.sh", () => {
     const issues = listIssues() as Array<{ resolved_at?: number }>;
     expect(issues).toHaveLength(1);
     expect(issues[0].resolved_at).toBeDefined();
+  });
+
+  // ── Timing log (#3564) ─────────────────────────────────────────────────
+  //
+  // Before #3564 the wrapper logged ONLY failures, so a hook that regressed
+  // from 20ms to 500ms produced no log output at all. These assert the
+  // OUTCOME: a parseable duration_ms line exists per invocation and its
+  // value tracks the wrapped command's actual runtime.
+
+  function readTimingLines(dir = stateDir): Array<Record<string, unknown>> {
+    const files = readdirSync(dir).filter((f) => f.startsWith("hook-timings-"));
+    return files.flatMap((f) =>
+      readFileSync(join(dir, f), "utf-8")
+        .split("\n")
+        .filter((l) => l.trim() !== "")
+        .map((l) => JSON.parse(l) as Record<string, unknown>),
+    );
+  }
+
+  it("logs a duration_ms line on SUCCESS (the previously invisible case)", () => {
+    const script = makeScript("ok.sh", "exit 0");
+    runHook("hook:timing-ok", script);
+    const lines = readTimingLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].source).toBe("hook:timing-ok");
+    expect(lines[0].code).toBe("ok.sh");
+    expect(lines[0].status).toBe(0);
+    expect(typeof lines[0].duration_ms).toBe("number");
+    expect(typeof lines[0].ts).toBe("string");
+  });
+
+  it("logs a duration_ms line on FAILURE too, carrying the exit status", () => {
+    const script = makeScript("fail.sh", "exit 7");
+    runHook("hook:timing-fail", script);
+    const lines = readTimingLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].status).toBe(7);
+    expect(typeof lines[0].duration_ms).toBe("number");
+  });
+
+  it("duration_ms reflects the wrapped command's real runtime", () => {
+    // A slow hook must be distinguishable from a fast one in the log —
+    // that is the entire point of #3564. 300ms of sleep must show up as
+    // >= 250ms (slack for timer granularity), and a no-op must not.
+    runHook("hook:timing-slow", makeScript("slow.sh", "sleep 0.3"));
+    runHook("hook:timing-fast", makeScript("fast.sh", "exit 0"));
+    const bySource = new Map(
+      readTimingLines().map((l) => [l.source as string, l.duration_ms as number]),
+    );
+    expect(bySource.get("hook:timing-slow")).toBeGreaterThanOrEqual(250);
+    expect(bySource.get("hook:timing-fast")).toBeLessThan(250);
+  });
+
+  it("appends one line per invocation", () => {
+    const script = makeScript("ok.sh", "exit 0");
+    runHook("hook:timing-a", script);
+    runHook("hook:timing-b", script);
+    runHook("hook:timing-c", script);
+    expect(readTimingLines()).toHaveLength(3);
+  });
+
+  it("still logs timing when the switchroom CLI is missing (degraded path)", () => {
+    // Issue recording is off on this path; hook cost must stay observable.
+    const script = makeScript("ok.sh", "exit 0");
+    // PATH keeps coreutils (the wrapper itself needs basename/mktemp) but
+    // excludes any `switchroom` binary, so the CLI lookup genuinely fails.
+    runHook("hook:timing-degraded", script, [], {
+      SWITCHROOM_CLI_PATH: "/nonexistent/switchroom",
+      PATH: "/usr/bin:/bin",
+    });
+    const lines = readTimingLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].source).toBe("hook:timing-degraded");
+  });
+
+  it("SWITCHROOM_HOOK_TIMING=0 disables the log", () => {
+    const script = makeScript("ok.sh", "exit 0");
+    runHook("hook:timing-off", script, [], { SWITCHROOM_HOOK_TIMING: "0" });
+    expect(readTimingLines()).toHaveLength(0);
+  });
+
+  it("SWITCHROOM_HOOK_TIMING_MIN_MS filters out fast invocations", () => {
+    const script = makeScript("ok.sh", "exit 0");
+    runHook("hook:timing-under", script, [], {
+      SWITCHROOM_HOOK_TIMING_MIN_MS: "100000",
+    });
+    expect(readTimingLines()).toHaveLength(0);
+  });
+
+  it("escapes quotes and backslashes in the source so the line stays valid JSON", () => {
+    const script = makeScript("ok.sh", "exit 0");
+    const nasty = 'hook:"quo\\ted"';
+    runHook(nasty, script);
+    const lines = readTimingLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].source).toBe(nasty);
+  });
+
+  it("truncates a weekday log left over from the previous week", () => {
+    // The log file name embeds the weekday, giving a self-truncating 7-day
+    // ring. A file whose first line carries a different date is last
+    // week's and must be reset, not appended to — otherwise the ring grows
+    // without bound.
+    const script = makeScript("ok.sh", "exit 0");
+    runHook("hook:ring", script);
+    const files = readdirSync(stateDir).filter((f) => f.startsWith("hook-timings-"));
+    expect(files).toHaveLength(1);
+    const logPath = join(stateDir, files[0]);
+    // Rewrite the file as if it were written seven days ago.
+    writeFileSync(
+      logPath,
+      JSON.stringify({
+        ts: "2000-01-01T00:00:00+0000",
+        date: "2000-01-01",
+        source: "hook:stale",
+        code: "old.sh",
+        duration_ms: 1,
+        status: 0,
+      }) + "\n",
+    );
+    runHook("hook:ring", script);
+    const lines = readTimingLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].source).toBe("hook:ring");
   });
 
   it("rejects malformed invocation (no source/command)", () => {


### PR DESCRIPTION
Closes #3543. Closes #3564. Recommends closing #3545 as won't-do (reasoning below and in a comment on that issue).

## #3543 — secret-guard-pretool's sequential vault round trips

**Root cause, verified in source:** `loadVaultValuesViaBroker` issued `1 list + N get` **sequentially** over one connection — `telegram-plugin/hooks/secret-guard-pretool.mjs:169-187` on `main`, a `for … of listRsp.keys` with an `await send()` per key. Exactly as the issue describes.

The `get` phase now fans out concurrently, one request per connection, capped at `MAX_CONCURRENT_GETS = 32`. Cost is ~2 round trips regardless of key count instead of `1 + N`.

**Measured** — fake broker with a 19ms per-request service delay, median of 5 runs, harness in the commit's bench notes:

| vault keys | before | after |
|---|---|---|
| 1 | 89.0ms | 67.5ms |
| 6 | **178.9ms** | **69.4ms** |
| 20 | 461.2ms | 71.3ms |

Note the shape change: the old cost grew linearly in key count (20 keys ⇒ 461ms); the new cost is flat.

### Why one request per connection instead of pipelining N gets down the existing socket

- The broker dispatches each received line to an **async handler without awaiting it** — `src/vault/broker/server.ts:924`.
- The `get` handler **awaits `validateGrant` before replying** — `src/vault/broker/server.ts:1284`. The hook sends a token when one exists, so this is the live path.
- The wire format carries **no key and no request id** to correlate responses by — `src/vault/broker/protocol.ts:452` (`OkEntryResponseSchema` is `{ ok, entry }`).

So pipelined responses are not guaranteed to come back in request order, and there is nothing to match them up with. One request/response turn per connection is precisely what the protocol documents (`protocol.ts:8-11`), requires **no broker change**, and therefore ships without a broker restart.

### Why not a TTL cache

Vault values rotate at runtime through the broker's `put` op, and this hook cannot see the vault file to key an invalidation off its mtime. A cache would leave a freshly-rotated secret unguarded for the cache lifetime — i.e. it would make the guard **fail open in a case where it currently blocks**. Rejected on those grounds; the reasoning is recorded in the hook header so it is not re-proposed.

### Security posture — before vs after (explicit)

| case | before | after |
|---|---|---|
| broker unreachable / socket missing | fail open (allow) | **same** |
| broker `LOCKED`, or `list` DENIED | fail open (allow) | **same** |
| one key's `get` denied / malformed | key skipped, remaining keys still guarded | **same** |
| one key's `get` never answers | whole loop stalls to the 1500ms deadline, then **all** values discarded → fail open | other keys resolve independently and **still block** |
| deadline expires mid-fetch | all values discarded → fail open | values already fetched are **still scanned** |
| tool input contains a vaulted value | block | **same** — reason text, `MIN_VALUE_LENGTH_TO_GUARD`, and the string-kind filter are untouched |

**There is no case where this blocks less than before.** Two cases where it blocks *more*. Both are covered by new tests.

### Header comment

The old header claimed the broker path was *"Sub-10ms total even with several keys"* — wrong by ~15x, and how this stayed invisible. Replaced with the measured numbers and the two rejected-alternative rationales.

## #3564 — `duration_ms` per hook invocation

`bin/run-hook.sh` logged **only failures**, with no timestamps and no duration, so a hook regressing from 20ms to 500ms produced no log output at all. It now appends one JSON line per invocation to `${TELEGRAM_STATE_DIR}/hook-timings-<Ddd>.log`:

```
{"ts":"2026-07-25T11:54:49+1000","date":"2026-07-25","source":"hook:demo","code":"secret-guard-pretool.mjs","duration_ms":52,"status":0}
```

`grep duration_ms` now answers any future hook-cost question. Logged on **every** path including the degraded no-CLI path, and on success as well as failure — slow-but-successful being invisible is the entire failure mode.

**Cost discipline.** The wrapper's own overhead was measured at 0-2ms and must stay there, so the timing path is **fork-free**:
- `EPOCHREALTIME` (bash 5 builtin) + integer arithmetic — no `date` fork.
- The log file name embeds the weekday, giving a self-truncating 7-day ring; the staleness check is a builtin `read` of the first line. Measured **0.024ms** per builtin append vs **0.81ms** for a single `stat` fork — which is why size-based rotation was rejected.
- Measured net cost of `log_timing`: **0.40-0.78ms** per invocation (2000-iteration in-shell loop on a busy build host), comfortably inside the 0-2ms budget.

Opt-outs: `SWITCHROOM_HOOK_TIMING=0`, `SWITCHROOM_HOOK_TIMING_MIN_MS` (default 0 — log everything), `SWITCHROOM_HOOK_TIMING_DIR`.

## #3545 — recommend won't-do

Re-measured on this branch (15 runs each, min):

| | min | median |
|---|---|---|
| bare `node -e ''` | 23.9ms | 31.0ms |
| `secret-guard-pretool` | 37.8ms | 44.6ms |
| `sentinel-reply-guard-pretool` | 27.0ms | 35.5ms |
| `tool-label-pretool` | 25.6ms | 32.5ms |

This **confirms** #3545's correction: node startup is ~24ms here (21ms in-container), not ~120ms. Merging the three hooks eliminates two process spawns ≈ **~48ms**, matching the issue's ~42ms.

Recommendation: **don't**. The purchase is ~42-48ms; the price is the crash isolation that three processes give for free. `tool-label-pretool` is not a guard and has **zero** block paths (`telegram-plugin/hooks/tool-label-pretool.mjs:330` — verified, no `decision` key anywhere in the file), so merging puts a non-guard in the same process as two vetoes, where an unhandled throw in the labeller would silently disable the secret guard unless every check is individually fault-contained. That converts a perf tweak into a security-relevant refactor for a now-small remainder. The residual is node startup itself, which is irreducible without abandoning process-per-hook entirely.

## Testing

- **6 new** `secret-guard-pretool` tests: get-concurrency high-water mark, total cost under a 2-round-trip ceiling, connection shape, DENIED-key still blocks, hung-key still blocks, `list`-denied fails open.
- **9 new** `run-hook.sh` tests: duration line on success, on failure with status, duration tracks real runtime, one line per invocation, degraded path, disable switch, min-ms threshold, JSON escaping, 7-day ring truncation.
- **Every new test mutation-verified** — reverting the fix or applying a targeted single-line regression fails the specific test and only that test. 8 distinct mutations exercised for the run-hook tests, 2 targeted ones for the secret-guard preservation tests.

Scoped local runs (all green): `tests/run-hook.test.ts`, `tests/issues.redact-detail.test.ts`, `tests/turn-pacing-hook-run-hook-integration.test.ts`, `tests/reconcile-hooks-drift.test.ts` (47 passed), `telegram-plugin/tests/secret-guard-pretool.test.ts` + `telegram-plugin/tests/run-hook-wrapper.test.ts` (18 passed), and `npm run lint` clean.

Note for reviewers reproducing locally: `tests/run-hook.test.ts` needs an exec-capable `TMPDIR`. On a host with `noexec` on `/tmp`, 8 of its pre-existing tests fail on `main` too (exit 126) — set `TMPDIR` to a repo-local dir.

CI is the merge authority. Not auto-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review response (#3574 audit + integration review) — 3 commits

The outcome-regression audit's core security claim held under adversarial
differential testing (old vs new hook, same fake broker, 10 scenarios,
comparing only BLOCK/allow): rejected promises closed, deadline strictly
better, no cache added, ordering safe, empty/short filter byte-identical,
key #39 of 40 still blocks. No behavioural regression. What follows fixes
the tests and the mechanism, not the decision logic.

### `fc5f8e74e` — broker: memoize the bcrypt compare (separately revertable)

**The header's "~2 round trips regardless of key count" was false**, in a
commit whose own point was that the previous header's "sub-10ms" claim was
false. Client concurrency is not the whole cost.

In an agent container `readVaultToken()` always finds `.vault-token`, so
every request is tokened, so the broker runs `validateGrant`
(`src/vault/broker/server.ts:1284` for `get`, `:1105` for `list`), which
awaits `bcryptjs.compare` (`src/vault/grants.ts`, `BCRYPT_COST = 10`).
`bcryptjs` is pure JS and **blocks the broker's single event loop**.

Measured on the fleet host (not taken on trust):

| measurement | result |
|---|---|
| one `bcrypt.compare`, cost 10 | **57.5ms** (median of 7) |
| 8 "concurrent" compares | **459.2ms** — fully serialized |
| 1ms timer ticks during those 459ms | **1** |

So N keys cost the broker `(N+1) x 57ms` of serialized CPU that no
client-side fan-out can shorten. There is no grant-validation cache
anywhere in `grants.ts` or `server.ts` — verified.

**This is a security bug, not a latency bug.** On deadline expiry the hook
keeps what arrived and scans a **partial** key set; which keys survive is
whichever the broker finished first. The same secret is guarded on one
tool call and silently unguarded on the next.

Chose the **cache** option over the `MAX_CONCURRENT_GETS=4` + per-key
deadline fallback, because the memo is **exact rather than merely
short-TTL** and so carries no security trade:

```
key   = grantId : secret_hash : sha256(secret)
value = hashMatches
```

"Does this secret hash to this digest" is immutable for a fixed
`(secret, secret_hash)` pair. `secret_hash` is *in* the key, so rotation
invalidates entries structurally, not by TTL. **Everything mutable stays
live** — row lookup, `revoked_at`, `expires_at`, `key_allow`,
`write_allow` are re-read from SQLite on every call, so revocation still
takes effect on the very next request. Only positive results are stored (a
cached negative would be a free probing oracle); the raw secret is never
stored. The 60s TTL and 512-entry cap bound memory; they are not the
correctness argument.

Measured broker CPU, one 6-key hook run (`list` + 6 `get`):

| | broker CPU |
|---|---|
| before | **416.7ms** |
| after, cold memo | **64.3ms** |
| after, warm memo | **0.22ms** |

6 new tests, each mutation-verified: the perf assertion is self-baselining
(measures a cold compare in-test, no hardcoded ms) and disabling the memo
lookup makes the loop cost 1180ms against a 67.5ms budget; revocation,
expiry and `key_allow` are re-asserted *after* a memoized hit; keying the
memo on grant id alone fails the forged-secret and rotated-hash tests.

### `4becafd0e` — hook: honest header, loud degradation, two real tests

**Header corrected.** It no longer claims O(1); it states the broker-CPU
term, cites the measurement, and points at the memo.

**Silent partial coverage is now loud.** `warnOnUnreachableGets` emits one
bounded stderr line naming how many of N keys went unresolved within the
deadline. stderr only — stdout stays the decision channel.

**Broker connection-cap coupling (audit DOC item).** The structural change
from 1 connection to N+1 means any future connection cap on the broker
turns a BLOCK into a silent allow — the auditor reproduced this with
1-connection and 3-connection brokers (old BLOCK, new allow). Verified
**not reachable today**: `server.ts` sets no `maxConnections`, no rate
limit and no mutex; `validateGrant` is read-only SQLite; the socket is
bind-mounted with no relay. Per the repo's "deterministic mechanisms over
prose" rule this is guarded by the same stderr line rather than by a
comment alone, plus a note at `MAX_CONCURRENT_GETS`.

**F2 — a test that asserted a property it did not check.** `does not fork
a child process per key` asserted only `connectionCount === 4`, which a
fork-per-key implementation *also* produces (each forked
`switchroom vault get` opens its own connection). It never touched PATH.
It now plants an executable `switchroom` shim on PATH that records every
invocation and asserts the sentinel is absent. Mutation-verified: adding
`spawnSync('switchroom', ...)` per key fails on the sentinel line
(`Expected: false, Received: true`).

Worth flagging: the first draft planted the shim under `os.tmpdir()` and
was **vacuous** — `/tmp` is `noexec` in these containers
(`findmnt -no OPTIONS /tmp` → `rw,nosuid,nodev,noexec`), so the shim could
never run. Same bug class as F2 itself. The shim now lives beside the test
file, and `plantSwitchroomShim()` self-checks that it is reachable and
records, throwing otherwise — so "sentinel absent" can only ever mean "did
not fork".

**F3 — the 250ms wall-clock budget is gone.** Node cold start for this
hook is 104-127ms on an idle box and this suite runs under `bun test` on a
2-vCPU runner, leaving ~65ms of headroom. Replaced with two timing-robust
tests:

- `maxConcurrentGets` / `connectionCount` — timing-independent: the
  sequential 1+N shape can never exceed 1 in flight at any speed.
- a **self-baselining differential against a CPU-bound fake broker**. The
  old fake's `delayMs` is a `setTimeout` — an *async* sleep that leaves the
  broker's loop free and credits the fan-out with a speedup that cannot
  exist against real bcrypt. The new `cpuMs` option busy-waits, matching
  what `validateGrant` actually does. Running the same hook against both
  models subtracts node startup automatically, and only a **lower bound**
  on the gap is asserted, so load cannot flake it upward.
  Mutation-verified: making `cpuMs` behave asynchronously collapses the gap
  to 1ms against an 80ms threshold.

**Newly covered:** `MAX_CONCURRENT_GETS` and the >32-key batch loop. A
40-key test pins the cap (raising it to 1000 gives an observed 40 > 32 and
fails) and proves key #40 — reachable only in the second batch — still
BLOCKs. Plus positive and negative tests for the DEGRADED line (a DENIED
reply is a broker *answer*, not an unreachable connection, and must not
raise it).

15 tests pass, stable across 3 consecutive runs.

### `a03d57d65` — run-hook: the timing floor must LOG, not just filter

The `MIN_MS=100000` test proves non-no-op and does catch an inverted
comparison, but it cannot catch a filter that is merely "drop everything
whenever MIN_MS is set". Added the other half: a 300ms command with
`MIN_MS=50` must produce one line with `duration_ms >= 50`.
Mutation-verified — `[ "$min_ms" -gt 0 ] && return 0` leaves the original
test green and fails only the new one.

### Corrections to earlier statements in this PR

- The "total cost is ~2 round trips, not 1+N" test no longer asserts a
  wall-clock ceiling (see F3). The Testing section above is superseded on
  that point.
- The `TMPDIR` note undercounts: **11** of `tests/run-hook.test.ts`'s tests
  fail with exit 126 on this branch without an exec-able `TMPDIR`, not 8.
  With `TMPDIR` set to a repo-local dir, 23/23 pass.
- `telegram-plugin/tests/secret-guard-pretool.test.ts` runs under **`bun
  test`** via `telegram-plugin/scripts/bun-test-ci.sh` on a 2-vCPU runner
  (it is explicitly excluded from vitest in `vitest.config.ts`), not under
  the 4-way vitest shard matrix. That makes the wall-clock flake risk in F3
  worse than stated, not better.

Scoped local runs, all green: `telegram-plugin/tests/secret-guard-pretool.test.ts`
(15), `src/vault/grants.test.ts` (28), the six grant/broker bun suites (97),
five further broker suites (49 + 1 skip), `tests/run-hook.test.ts` (23 with
exec-able TMPDIR), and `npm run lint` clean.
