### PR TITLE
fix(gateway): silence-poke turn lifecycle — reap orphan state, and never kill a user turn silently (#3552, #3551)

### DIFF
--- a/telegram-plugin/gateway/disconnect-flush.ts
+++ b/telegram-plugin/gateway/disconnect-flush.ts
@@ -67,6 +67,18 @@ export interface DisconnectFlushDeps<Ctrl extends { finalize: (reason?: 'done' |
    *  No-op if no dangling keys are found. */
   onDanglingTurnsSwept?: (purgedKeys: string[]) => void
 
+  /** #3552 — called once per turn key this flush tears down (both the
+   *  controller loop and the dangling sweep). The bridge that owned those turns
+   *  just died, so every per-turn timer keyed on them is orphaned. The gateway
+   *  wires this to `silencePoke.endTurn`: without it the armed 300s silence-poke
+   *  state outlived the dead turn and was only disarmed when the fallback later
+   *  fired against the stale key and logged `turn_ended_cleanly_during_window`.
+   *  Deterministic disarm at the point the turn actually ends.
+   *
+   *  Idempotent by contract — a key may be reported by both loops below.
+   *  Optional (test harnesses). */
+  onTurnKeyEnded?: (key: string) => void
+
   /** Logger — receives the one-line decision trace. */
   log: (msg: string) => void
 }
@@ -90,6 +102,7 @@ export function flushOnAgentDisconnect<
     disposeProgressDriver,
     stopTurnTypingLoops,
     onDanglingTurnsSwept,
+    onTurnKeyEnded,
     log,
   } = deps
 
@@ -112,6 +125,8 @@ export function flushOnAgentDisconnect<
     activeStatusReactions.delete(key)
     activeReactionMsgIds.delete(key)
     activeTurnStartedAt.delete(key)
+    // #3552: disarm this turn's silence-poke state here, not 300s later.
+    onTurnKeyEnded?.(key)
   }
   clearActiveReactions()
 
@@ -131,6 +146,8 @@ export function flushOnAgentDisconnect<
     for (const k of danglingKeys) {
       activeTurnStartedAt.delete(k)
       activeReactionMsgIds.delete(k)
+      // #3552: same deterministic disarm for the keys the controller loop missed.
+      onTurnKeyEnded?.(k)
     }
     log(
       `telegram gateway: disconnect-flush swept ${danglingKeys.length} dangling turn key(s) ` +

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9688,6 +9688,9 @@ function gatewayLivenessWiringDeps() {
     SILENCE_FALLBACK_HARD_MS,
     SILENCE_FLOOR_MS,
     SILENCE_DEFER_INFLIGHT_TOOLS,
+    // #3551 — governs the teardown notice's tail sentence: only promise a
+    // re-ask when the obligation ledger is actually on to deliver one.
+    OBLIGATION_LEDGER_ENABLED,
     TURN_PREVIEW_MAX,
     STATE_DIR,
     isLegitimatelyWorking,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9689,8 +9689,18 @@ function gatewayLivenessWiringDeps() {
     SILENCE_FLOOR_MS,
     SILENCE_DEFER_INFLIGHT_TOOLS,
     // #3551 — governs the teardown notice's tail sentence: only promise a
-    // re-ask when the obligation ledger is actually on to deliver one.
-    OBLIGATION_LEDGER_ENABLED,
+    // re-ask when one will ACTUALLY follow. #3575 review B1: this used to be
+    // the static `OBLIGATION_LEDGER_ENABLED` env boolean, which is true for the
+    // whole process and so promised a re-ask for turns whose obligation was
+    // already closed (represent cap reached then escalated, or closed silently
+    // by an outbound-since-open — obligation-wiring.ts:230/:294) or never
+    // opened at all (synthetic / steering / interrupt inbound). It is now a
+    // live per-turn lookup keyed on the turn's own origin id: `turn.turnId` is
+    // `deriveTurnId(chat, thread, messageId)` for a real inbound
+    // (stream-render.ts:273), the SAME identity the ledger keys on
+    // (obligation-wiring.ts:118).
+    isObligationOpenForTurn: (originTurnId: string | null): boolean =>
+      OBLIGATION_LEDGER_ENABLED && originTurnId != null && obligationLedger.isOpen(originTurnId),
     TURN_PREVIEW_MAX,
     STATE_DIR,
     isLegitimatelyWorking,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10780,6 +10780,13 @@ if (isGatewayMain) ipcServer = createIpcServer({
         // fires after the gateway has stopped.
         typingEmitter.reset()
       },
+      // #3552 — the bridge died with turns in flight; disarm each dead turn's
+      // silence-poke state HERE. Before this, the armed 300s timer outlived the
+      // turn and was only dropped when the fallback eventually fired against the
+      // stale key and logged `turn_ended_cleanly_during_window` (504 events in
+      // 14 days vs 110 real fires). `endTurn` is idempotent, so being called for
+      // a key reported by both flush loops is safe.
+      onTurnKeyEnded: (key) => silencePoke.endTurn(key),
       // When dangling activeTurnStartedAt keys were swept (setDone raced
       // disconnect), the module-scope `currentTurn` may also point at the
       // dead bridge's turn. Null it so the next inbound starts a fresh

--- a/telegram-plugin/gateway/liveness-wiring.ts
+++ b/telegram-plugin/gateway/liveness-wiring.ts
@@ -274,6 +274,21 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     // stays null and we skip the send. The turn-teardown below (the unwedge —
     // the one job the live draft can't do, per the conversational-pacing RFC)
     // still runs unconditionally.
+    // #3551 L1/L2 — the teardown-notice suppression signal. It must be narrower
+    // than "some text went out", and it must mean DELIVERED.
+    //
+    // L1: `text` has two sources with opposite meanings. The approval re-ping is
+    // a LOUD, user-addressed message that explains why nothing is happening and
+    // asks the user to act — stacking a teardown notice on it is noise. The
+    // deterministic `formatUpdateStatusLine` is a SILENT status surface about an
+    // unrelated in-flight `update_apply`; it says nothing about this turn ending.
+    // A user who asked a question during an update and got killed anyway is
+    // EXACTLY the #3551 case, so that line must not suppress the notice.
+    //
+    // L2: computed from send SUCCESS, not from `text != null`. The send sits in a
+    // try/catch that only logs, so a throwing approval re-ping would otherwise
+    // suppress the notice while the user received nothing at all.
+    let userAddressedTextDelivered = false
     if (text != null) {
       try {
         // Conditional: when the turn is parked on an approval card, this
@@ -283,6 +298,7 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
         // line stays SILENT (a status surface). Gate on `blockedOnApproval`.
         // The send stays in gateway.ts behind the bot-api retry policy.
         await sendSilenceText(ctx.chatId, ctx.threadId ?? null, text, blockedOnApproval ? false : true)
+        userAddressedTextDelivered = blockedOnApproval
       } catch (err) {
         process.stderr.write(
           `silence-poke fallback sendMessage failed chat=${ctx.chatId} thread=${ctx.threadId}: ${err}\n`,
@@ -471,7 +487,7 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
       tearsDownLiveTurn: turnMatchesFallback,
       role: wedgedTurn?.role ?? null,
       finalAnswerDelivered: wedgedTurn?.finalAnswerDelivered ?? false,
-      otherTextSent: text != null,
+      userAddressedTextDelivered,
       representWillFollow: OBLIGATION_LEDGER_ENABLED,
       silenceMs: ctx.silenceMs,
     })

--- a/telegram-plugin/gateway/liveness-wiring.ts
+++ b/telegram-plugin/gateway/liveness-wiring.ts
@@ -38,6 +38,7 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     SILENCE_FALLBACK_HARD_MS,
     SILENCE_FLOOR_MS,
     SILENCE_DEFER_INFLIGHT_TOOLS,
+    OBLIGATION_LEDGER_ENABLED,
     TURN_PREVIEW_MAX,
     STATE_DIR,
     isLegitimatelyWorking,
@@ -452,6 +453,44 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
       // singleton, verbatim; flag-ON deletes only this topic's entry and clears
       // the mirror iff it still points here — a live sibling topic is untouched.
       endCurrentTurnForKey(wedgedTurn, fbKey)
+    }
+    // #3551 — the teardown NOTICE. Everything above just ENDED a live turn. On
+    // the non-approval branch `text` is null (`formatFrameworkFallbackText`
+    // returns a string only when parked on an approval card), so before this
+    // the user saw literally nothing: N minutes of silence, then the agent
+    // apparently starting the same request over. Killing a user's turn with no
+    // user-visible signal is a correctness bug, not a tuning knob — 110 fires /
+    // 14 days, ~9h of dead air (#3551). The teardown itself is NOT removed (it
+    // is the #1122 unwedge, the fallback's one load-bearing job); it is made
+    // observable. Sent AFTER the teardown so the notice cannot itself be
+    // clobbered by the state purge, and gated by `decideFallbackTeardownNotice`
+    // so it can only ever speak for a human-waiting, undelivered turn that this
+    // fire actually killed — at most once, since `endTurn(fbKey)` above dropped
+    // the key.
+    const teardownNotice = silencePoke.decideFallbackTeardownNotice({
+      tearsDownLiveTurn: turnMatchesFallback,
+      role: wedgedTurn?.role ?? null,
+      finalAnswerDelivered: wedgedTurn?.finalAnswerDelivered ?? false,
+      otherTextSent: text != null,
+      representWillFollow: OBLIGATION_LEDGER_ENABLED,
+      silenceMs: ctx.silenceMs,
+    })
+    if (teardownNotice.send) {
+      try {
+        // LOUD (disable_notification: false). The user asked a question and is
+        // being told their attempt was killed — that is exactly the case where
+        // silence would train them to distrust the channel.
+        await sendSilenceText(fbChatId, ctx.threadId ?? null, teardownNotice.text, false)
+      } catch (err) {
+        process.stderr.write(
+          `silence-poke teardown notice sendMessage failed chat=${fbChatId} thread=${ctx.threadId}: ${err}\n`,
+        )
+      }
+    } else {
+      process.stderr.write(
+        `telegram gateway: silence-poke teardown notice skipped reason=${teardownNotice.reason} ` +
+        `chat=${fbChatId} thread=${ctx.threadId ?? '-'}\n`,
+      )
     }
     // Best-effort: clear any pending silent-end marker so the Stop hook
     // doesn't double-block when claude eventually exits the wedged turn.

--- a/telegram-plugin/gateway/liveness-wiring.ts
+++ b/telegram-plugin/gateway/liveness-wiring.ts
@@ -38,7 +38,7 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     SILENCE_FALLBACK_HARD_MS,
     SILENCE_FLOOR_MS,
     SILENCE_DEFER_INFLIGHT_TOOLS,
-    OBLIGATION_LEDGER_ENABLED,
+    isObligationOpenForTurn,
     TURN_PREVIEW_MAX,
     STATE_DIR,
     isLegitimatelyWorking,
@@ -488,7 +488,19 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
       role: wedgedTurn?.role ?? null,
       finalAnswerDelivered: wedgedTurn?.finalAnswerDelivered ?? false,
       userAddressedTextDelivered,
-      representWillFollow: OBLIGATION_LEDGER_ENABLED,
+      // #3575 review B1 — this must be a question about THIS turn, not a static
+      // env flag. `OBLIGATION_LEDGER_ENABLED` is true for the whole process, so
+      // it promised "being re-asked now" in cases where no re-ask can ever
+      // happen: the obligation already hit OBLIGATION_REPRESENT_MAX (2) and
+      // escalated+closed, or it was closed silently by an outbound-since-open
+      // (obligation-wiring.ts:230/:294), or the inbound never opened one at all
+      // (synthetic / steering / interrupt). The user was then told to wait for a
+      // re-ask that never comes. Ask the ledger about this turn's own origin id
+      // instead, so the honest "please re-send it" branch fires when there is no
+      // open obligation. The lookup is deliberately made HERE, after the
+      // teardown above (which does not touch the ledger), so it reflects the
+      // ledger state at the moment we speak.
+      representWillFollow: isObligationOpenForTurn(wedgedTurn?.turnId ?? null),
       silenceMs: ctx.silenceMs,
     })
     if (teardownNotice.send) {

--- a/telegram-plugin/gateway/liveness-wiring.ts
+++ b/telegram-plugin/gateway/liveness-wiring.ts
@@ -68,6 +68,13 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
   thresholdsMs: { fallback: SILENCE_FALLBACK_MS, fallbackHardCeiling: SILENCE_FALLBACK_HARD_MS, floor: SILENCE_FLOOR_MS },
   deferFallbackWhileToolInFlight: SILENCE_DEFER_INFLIGHT_TOOLS,
   isLegitimatelyWorking: (key) => isLegitimatelyWorking(key),
+  // #3552 — orphan-state reaper predicate. Deliberately the SAME condition the
+  // `onFrameworkFallback` late-fire guard below uses: no `activeTurnStartedAt`
+  // entry AND no current turn ⇒ the turn this state belongs to is over. Note
+  // `activeTurnStartedAt` alone is NOT sufficient — `releaseTurnBufferGate`
+  // clears it mid-turn on every final-answer reply while the turn keeps running
+  // (post-answer housekeeping), and silence-poke must keep watching that turn.
+  isTurnLive: (key) => !(activeTurnStartedAt.get(key) == null && getCurrentTurn() == null),
   emitMetric: (event) => {
     // Re-emit through the unified runtime-metrics fan-out (PostHog + JSONL).
     emitRuntimeMetric(event)
@@ -142,6 +149,13 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     // events (124 of 138 `currentTurn_nulled=false` cases). Distinct
     // log line so observability still tracks the fact that the silence
     // crossed threshold; the wedge counter is no longer polluted.
+    //
+    // #3552: with the `isTurnLive` reaper wired above, this branch is now only
+    // the sub-poll-interval race (the turn ends between the tick's reap check
+    // and this handler running). The steady-state case it used to absorb —
+    // state armed for the full 300s against a turn that ended minutes earlier,
+    // 504 events in 14 days vs 110 real fires — is reaped at the tick instead,
+    // so this counter finally reads as the genuine race it names.
     if (activeTurnStartedAt.get(ctx.key) == null && getCurrentTurn() == null) {
       process.stderr.write(
         `telegram gateway: silence-poke framework-fallback late-fire skipped — ` +

--- a/telegram-plugin/runtime-metrics.ts
+++ b/telegram-plugin/runtime-metrics.ts
@@ -78,6 +78,20 @@ export type RuntimeMetricEvent =
       silence_ms: number
     }
   /**
+   * #3552 — per-turn silence-poke state dropped by the orphan reaper: the turn
+   * behind `key` is provably over (no `activeTurnStartedAt` entry AND no
+   * current turn) yet its state was still armed, so it is disarmed on the poll
+   * tick rather than 300s later at fire time. A healthy fleet trends this
+   * toward zero; a persistent stream of it names a turn-end path that is
+   * failing to call `silencePoke.endTurn`. `silence_ms` is how long the state
+   * had already been orphaned when the reaper caught it.
+   */
+  | {
+      kind: 'silence_poke_orphan_reaped'
+      key: string
+      silence_ms: number
+    }
+  /**
    * #2527 — mid-turn liveness floor decision. `decision: 'fire'` when the
    * quiet "still on it" beat was sent; otherwise the machine-readable skip
    * reason for a declined forced ("Status?") poke. `forced` distinguishes

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -193,6 +193,8 @@ export interface MidTurnFloorContext {
 export type SilencePokeMetric =
   | { kind: 'silence_fallback_sent'; key: string; fallback_kind: 'working' | 'thinking'; silence_ms: number }
   | { kind: 'mid_turn_floor'; key: string; silence_ms: number; forced: boolean; decision: 'fire' | string }
+  /** #3552 — per-turn state dropped because its turn is provably over. */
+  | { kind: 'silence_poke_orphan_reaped'; key: string; silence_ms: number }
 
 export interface SilencePokeDeps {
   /** Called when the 300s fallback fires. Caller sends the user-visible
@@ -239,6 +241,30 @@ export interface SilencePokeDeps {
    * combines both. Returns null when there is no live turn for `key`.
    */
   floorState?: (key: string) => { role: LoopRole; finalAnswerDelivered: boolean } | null
+  /**
+   * #3552 — orphan-state reaper predicate. Returns true while `key` still has a
+   * LIVE turn behind it, false once the turn is provably over.
+   *
+   * Why: `startTurn(key)` arms per-turn state that only `endTurn(key)` drops,
+   * and several turn-end paths never reach an `endTurn` call — a bridge death
+   * (`disconnect-flush`), a keyed teardown that bypasses the `turn_end` handler,
+   * or any future path that nulls the turn without the cleanup tail. The state
+   * then survives its turn and sits in the Map until the 300s fallback fires
+   * against a dead key, is recognised as a late fire, logs
+   * `turn_ended_cleanly_during_window` and only THEN calls `endTurn`. Measured:
+   * 504 such skips vs 110 real fires in 14 days (switchroom#3552).
+   *
+   * Wiring this callback moves that cleanup from "300s later, at fire time" to
+   * "the next poll tick", deterministically and independent of which path ended
+   * the turn. The predicate MUST be the same one the fallback's late-fire guard
+   * uses (`activeTurnStartedAt` empty AND no current turn) so a turn that has
+   * merely released its buffer gate mid-turn — the normal post-final-answer
+   * state, where silence-poke must keep watching — is never reaped.
+   *
+   * Optional: when absent (test harnesses) the reaper is off and behaviour is
+   * exactly as before.
+   */
+  isTurnLive?: (key: string) => boolean
 }
 
 const state = new Map<string, SilencePokeState>()
@@ -602,6 +628,19 @@ function tick(now: number): void {
     const zeroAt = s.lastOutboundAt ?? s.turnStartedAt
     const silence = now - zeroAt
     if (silence < 0) continue
+
+    // #3552 — orphan reap. Drop per-turn state the moment its turn is provably
+    // over, instead of leaving it armed until the 300s fallback fires against a
+    // dead key and disarms it as a "late fire". Deterministic and path-agnostic:
+    // it does not matter WHICH turn-end path forgot to call `endTurn`, the state
+    // cannot outlive the turn by more than one poll interval. Same predicate as
+    // the fallback's late-fire guard, so a mid-turn buffer-gate release (the
+    // normal post-final-answer state, turn still live) is never reaped.
+    if (activeDeps.isTurnLive != null && !activeDeps.isTurnLive(key)) {
+      state.delete(key)
+      activeDeps.emitMetric({ kind: 'silence_poke_orphan_reaped', key, silence_ms: silence })
+      continue
+    }
 
     // #2527 — the early, quiet mid-turn liveness beat (below the fallback
     // window). Evaluated every tick; fires at most once per turn.

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -549,9 +549,19 @@ export interface FallbackTeardownNoticeInput {
   role: LoopRole | null
   /** A final answer already landed on this turn. */
   finalAnswerDelivered: boolean
-  /** This fire is ALREADY sending user-visible text (the approval re-ping, or
-   *  the deterministic update_apply status line). Never stack a second message. */
-  otherTextSent: boolean
+  /** This fire ALREADY DELIVERED a LOUD, user-addressed message about why
+   *  nothing is happening — in practice the approval re-ping ("waiting for your
+   *  approval — tap Approve or Deny"). Never stack a second message on that.
+   *
+   *  #3551 L1: deliberately NARROWER than "some text went out". The other text
+   *  this fire can emit is `formatUpdateStatusLine`, a SILENT status surface
+   *  about an unrelated in-flight `update_apply` that says nothing about this
+   *  turn ending — a user who asked a question during an update and got killed
+   *  anyway is exactly the case this notice exists for, so that line must NOT
+   *  suppress it.
+   *  #3551 L2: means DELIVERED, not "attempted". The caller's send is wrapped in
+   *  a log-only try/catch, so a throwing re-ping must not buy silence. */
+  userAddressedTextDelivered: boolean
   /** The obligation ledger is on, so the killed turn's unanswered inbound will
    *  be re-presented. Governs the tail sentence — never claim a re-ask that
    *  cannot happen. */
@@ -560,7 +570,14 @@ export interface FallbackTeardownNoticeInput {
 }
 
 export type FallbackTeardownNoticeDecision =
-  | { send: false; reason: 'other-text-sent' | 'no-live-turn-torn-down' | 'non-user-turn' | 'answer-already-delivered' }
+  | {
+      send: false
+      reason:
+        | 'user-addressed-text-delivered'
+        | 'no-live-turn-torn-down'
+        | 'non-user-turn'
+        | 'answer-already-delivered'
+    }
   | { send: true; text: string }
 
 /**
@@ -580,7 +597,10 @@ export type FallbackTeardownNoticeDecision =
  *
  * This is deliberately NOT a re-introduction of the retired stall notice, and
  * the gates below are what keep it that way:
- *   - `otherTextSent` — never stack on the approval re-ping / update-status line.
+ *   - `userAddressedTextDelivered` — never stack on a delivered approval
+ *     re-ping. Narrow by design: a SILENT, unrelated update-status line does
+ *     not buy silence here (#3551 L1), and an approval re-ping that threw on
+ *     send does not either (#3551 L2).
  *   - `tearsDownLiveTurn` — a late-fire against an already-dead key says nothing.
  *   - `role !== 'user'` — a cron/system turn's silence is legitimate; nobody is
  *     waiting, so its teardown is housekeeping, not news.
@@ -595,7 +615,8 @@ export type FallbackTeardownNoticeDecision =
 export function decideFallbackTeardownNotice(
   input: FallbackTeardownNoticeInput,
 ): FallbackTeardownNoticeDecision {
-  if (input.otherTextSent) return { send: false, reason: 'other-text-sent' }
+  if (input.userAddressedTextDelivered)
+    return { send: false, reason: 'user-addressed-text-delivered' }
   if (!input.tearsDownLiveTurn) return { send: false, reason: 'no-live-turn-torn-down' }
   if (input.role !== 'user') return { send: false, reason: 'non-user-turn' }
   if (input.finalAnswerDelivered) return { send: false, reason: 'answer-already-delivered' }

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -532,6 +532,84 @@ export function formatFrameworkFallbackText(
 }
 
 /**
+ * #3551 — inputs to the silence-fallback TEARDOWN NOTICE decision.
+ *
+ * Distinct from `formatFrameworkFallbackText`, which answers "is anything
+ * happening worth narrating?" (and, since the stall-notice was retired,
+ * answers `null` on every branch but `blockedOnApproval`). This one answers a
+ * different, terminal question: "the framework is about to END this live turn
+ * — does the user need to be told?"
+ */
+export interface FallbackTeardownNoticeInput {
+  /** This fire is genuinely tearing down a live turn for THIS chat/thread.
+   *  False on the multi-chat case where the current turn belongs elsewhere, or
+   *  when there was no turn left to end. */
+  tearsDownLiveTurn: boolean
+  /** Loop role of the turn being torn down; null when unknown. */
+  role: LoopRole | null
+  /** A final answer already landed on this turn. */
+  finalAnswerDelivered: boolean
+  /** This fire is ALREADY sending user-visible text (the approval re-ping, or
+   *  the deterministic update_apply status line). Never stack a second message. */
+  otherTextSent: boolean
+  /** The obligation ledger is on, so the killed turn's unanswered inbound will
+   *  be re-presented. Governs the tail sentence — never claim a re-ask that
+   *  cannot happen. */
+  representWillFollow: boolean
+  silenceMs: number
+}
+
+export type FallbackTeardownNoticeDecision =
+  | { send: false; reason: 'other-text-sent' | 'no-live-turn-torn-down' | 'non-user-turn' | 'answer-already-delivered' }
+  | { send: true; text: string }
+
+/**
+ * #3551 — decide whether a silence-poke fire that ENDS a live turn must say so.
+ *
+ * The bug this closes: on the non-approval branch the 300s fallback delivered
+ * NO text (`formatFrameworkFallbackText` returns null) while still tearing the
+ * turn down and redelivering buffered inbound. From the user's seat: five
+ * minutes of nothing, then the agent inexplicably restarting the same request,
+ * with no signal that the framework — not the agent — made that happen.
+ * Measured: 110 fires / 14 days, p50 silence 302s, ~9h of dead air.
+ *
+ * The fix is NOT to stop killing the turn. The teardown is the fallback's one
+ * genuinely load-bearing job (`#1122`: without it every later inbound queues
+ * behind a dead turn forever), and removing it would trade a silent turn for a
+ * permanently wedged conversation. The fix is to make the kill OBSERVABLE.
+ *
+ * This is deliberately NOT a re-introduction of the retired stall notice, and
+ * the gates below are what keep it that way:
+ *   - `otherTextSent` — never stack on the approval re-ping / update-status line.
+ *   - `tearsDownLiveTurn` — a late-fire against an already-dead key says nothing.
+ *   - `role !== 'user'` — a cron/system turn's silence is legitimate; nobody is
+ *     waiting, so its teardown is housekeeping, not news.
+ *   - `finalAnswerDelivered` — the user already has their answer; ending the
+ *     residual housekeeping turn is invisible to them and needs no notice.
+ * What remains is exactly one case: a HUMAN asked something, got nothing for
+ * N minutes, and the framework just ended that attempt. That is a terminal
+ * event, fired at most once per turn (the caller drops the key immediately
+ * after), not a cadence-based progress ping — the thing
+ * `reference/rfcs/conversational-pacing.md` § Anti-patterns bans.
+ */
+export function decideFallbackTeardownNotice(
+  input: FallbackTeardownNoticeInput,
+): FallbackTeardownNoticeDecision {
+  if (input.otherTextSent) return { send: false, reason: 'other-text-sent' }
+  if (!input.tearsDownLiveTurn) return { send: false, reason: 'no-live-turn-torn-down' }
+  if (input.role !== 'user') return { send: false, reason: 'non-user-turn' }
+  if (input.finalAnswerDelivered) return { send: false, reason: 'answer-already-delivered' }
+  const minutes = Math.max(1, Math.round(input.silenceMs / 60_000))
+  const tail = input.representWillFollow
+    ? 'Your message is still tracked and is being re-asked now.'
+    : 'Your message was not answered — please re-send it.'
+  return {
+    send: true,
+    text: `⚠️ no output for ${minutes} min — the framework ended that stalled turn. ${tail}`,
+  }
+}
+
+/**
  * #2995 — the LONGEST-running in-flight tool for a turn key, or null when
  * none is tracked. Read-only accessor over `inFlightTools` for the
  * mid-flight busy-ack: the gateway needs the blocking step's name/label

--- a/telegram-plugin/tests/gateway-disconnect-flush.test.ts
+++ b/telegram-plugin/tests/gateway-disconnect-flush.test.ts
@@ -282,3 +282,35 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
     expect(deps.activeTurnStartedAt.size).toBe(0)
   })
 })
+
+describe('#3552 — onTurnKeyEnded disarms per-turn timers on bridge death', () => {
+  it('reports EVERY torn-down turn key, from both the controller loop and the dangling sweep', () => {
+    const { deps } = makeDeps('clerk')
+    // A third key that the controller loop does not cover — it only lives in
+    // activeTurnStartedAt (finalize already ran on the canonical reply path),
+    // so it is picked up by the dangling sweep.
+    deps.activeTurnStartedAt.set('chat3:thr3:msg3', 300)
+    const ended: string[] = []
+
+    flushOnAgentDisconnect({ ...deps, onTurnKeyEnded: (k: string) => ended.push(k) })
+
+    // Outcome: no turn key survives the flush without being reported, so no
+    // silence-poke state can outlive the dead bridge's turns.
+    expect(new Set(ended)).toEqual(
+      new Set(['chat1:thr1:msg1', 'chat2:thr2:msg2', 'chat3:thr3:msg3']),
+    )
+    expect(deps.activeTurnStartedAt.size).toBe(0)
+  })
+
+  it('is never called for an anonymous disconnect (no turns were owned)', () => {
+    const { deps } = makeDeps(null)
+    const ended: string[] = []
+    flushOnAgentDisconnect({ ...deps, onTurnKeyEnded: (k: string) => ended.push(k) })
+    expect(ended).toEqual([])
+  })
+
+  it('omitting onTurnKeyEnded is safe (optional callback)', () => {
+    const { deps } = makeDeps('clerk')
+    expect(() => flushOnAgentDisconnect(deps)).not.toThrow()
+  })
+})

--- a/telegram-plugin/tests/helpers/liveness-wiring-fixture.ts
+++ b/telegram-plugin/tests/helpers/liveness-wiring-fixture.ts
@@ -1,0 +1,120 @@
+/**
+ * Test fixture for the REAL `buildSilencePokeOptions` wiring (#3575 review B3).
+ *
+ * The two highest-blast-radius pieces of `liveness-wiring.ts` — the `isTurnLive`
+ * reaper predicate and the `onFrameworkFallback` teardown + notice — had NO
+ * executing coverage: `buildSilencePokeOptions` has exactly one caller (the
+ * gateway's module-load `startTimer`) and no test imported it, so the suite
+ * either stubbed the predicate or asserted regexes against the function's own
+ * SOURCE TEXT. A hand-retyped copy of a predicate cannot detect divergence, and
+ * a source regex passes even if the handler is never invoked.
+ *
+ * `buildSilencePokeOptions` is a pure function of its deps object (its only
+ * gateway import is `import type`), so the whole options object CAN be built in
+ * a unit test. This fixture supplies the collaborators the fallback actually
+ * touches, with spies on the two observable effects (`sendSilenceText`,
+ * `endCurrentTurnForKey`).
+ */
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { buildSilencePokeOptions } from '../../gateway/liveness-wiring.js'
+
+type Deps = Parameters<typeof buildSilencePokeOptions>[0]
+
+export interface SentText {
+  chatId: string
+  threadId: number | null
+  text: string
+  silent: boolean
+}
+
+export interface LivenessFixture {
+  deps: Deps
+  sent: SentText[]
+  endedKeys: string[]
+  /** The gateway's `activeTurnStartedAt` map, writable by the test. */
+  activeTurnStartedAt: Map<string, number>
+  /** Swap the "current turn" the wiring reads. */
+  setCurrentTurn: (t: unknown) => void
+  /** Open obligation ids the per-turn `representWillFollow` lookup consults. */
+  openObligations: Set<string>
+}
+
+export function statusKeyForTests(chatId: string, threadId: number | null | undefined): string {
+  return `${chatId}:${threadId ?? '_'}`
+}
+
+/** Minimal but REAL-shaped CurrentTurn for the fields the fallback reads. */
+export function makeTurn(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    sessionChatId: '-100999',
+    sessionThreadId: undefined,
+    turnId: '-100999#42',
+    registryKey: null,
+    role: 'user',
+    finalAnswerDelivered: false,
+    capturedText: [],
+    lastAssistantMsgId: null,
+    lastAssistantDone: false,
+    toolCallCount: 0,
+    ...over,
+  }
+}
+
+export function makeLivenessFixture(over: Partial<Record<string, unknown>> = {}): LivenessFixture {
+  const sent: SentText[] = []
+  const endedKeys: string[] = []
+  const activeTurnStartedAt = new Map<string, number>()
+  const openObligations = new Set<string>()
+  let currentTurn: unknown = null
+
+  const deps = {
+    SILENCE_FALLBACK_MS: 300_000,
+    SILENCE_FALLBACK_HARD_MS: 900_000,
+    SILENCE_FLOOR_MS: 90_000,
+    SILENCE_DEFER_INFLIGHT_TOOLS: false,
+    isObligationOpenForTurn: (originTurnId: string | null): boolean =>
+      originTurnId != null && openObligations.has(originTurnId),
+    TURN_PREVIEW_MAX: 200,
+    STATE_DIR: mkdtempSync(join(tmpdir(), 'liveness-wiring-')),
+    isLegitimatelyWorking: () => false,
+    getCurrentTurn: () => currentTurn,
+    getInFlightUpdate: () => null,
+    getTurnsDb: () => null,
+    getInboundSpool: () => undefined,
+    sendToAgent: () => true,
+    sendSilenceText: async (chatId: string, threadId: number | null, text: string, silent: boolean) => {
+      sent.push({ chatId, threadId, text, silent })
+    },
+    getMyAgentName: () => 'test-agent',
+    statusKey: statusKeyForTests,
+    activeTurnStartedAt,
+    activeStatusReactions: new Map(),
+    lastPtyPreviewByChat: new Map(),
+    preambleSuppressor: { dropNow: () => {} },
+    purgeReactionTracking: () => {},
+    currentTurnMap: { purgeChatStale: () => {} },
+    turnLiveForItsTopic: () => true,
+    endCurrentTurnForKey: (_turn: unknown, key: string) => {
+      endedKeys.push(key)
+      currentTurn = null
+      return true
+    },
+    getPendingInboundBuffer: () => ({ drain: () => [] }),
+    trackRedeliveredInbound: () => {},
+    closeActivityLane: () => {},
+    closeProgressLane: () => {},
+    hangRestart: null,
+    ...over,
+  } as unknown as Deps
+
+  return {
+    deps,
+    sent,
+    endedKeys,
+    activeTurnStartedAt,
+    setCurrentTurn: (t: unknown) => { currentTurn = t },
+    openObligations,
+  }
+}

--- a/telegram-plugin/tests/silence-poke-orphan-reap.test.ts
+++ b/telegram-plugin/tests/silence-poke-orphan-reap.test.ts
@@ -1,0 +1,132 @@
+/**
+ * switchroom#3552 — the silence-poke timer leak.
+ *
+ * `startTurn(key)` arms per-turn state that only `endTurn(key)` drops. Several
+ * turn-end paths never reached an `endTurn` call (bridge death via
+ * `disconnect-flush`, keyed teardowns that bypass the `turn_end` handler), so
+ * the state outlived its turn and was disarmed only when the 300s fallback
+ * eventually fired against the dead key, recognised the late fire and logged
+ * `turn_ended_cleanly_during_window` — 504 such skips vs 110 real fires in 14
+ * days on the fleet.
+ *
+ * The fix is the `isTurnLive` reaper predicate consulted on every poll tick.
+ * These tests assert the OUTCOME (state gone, no fallback delivered, real fires
+ * unaffected), not merely that the code path runs.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  startTurn,
+  noteOutbound,
+  __tickForTests,
+  __setDepsForTests,
+  __getStateForTests,
+  __resetAllForTests,
+  DEFAULT_THRESHOLDS,
+  type SilencePokeMetric,
+  type FrameworkFallbackContext,
+} from '../silence-poke.js'
+
+const ORIGINAL_KILL_SWITCH = process.env.SWITCHROOM_DISABLE_SILENCE_POKE
+
+interface Fixtures {
+  emitted: SilencePokeMetric[]
+  fallbacks: FrameworkFallbackContext[]
+  live: Set<string>
+}
+
+function setup(opts?: { wireReaper?: boolean }): Fixtures {
+  const f: Fixtures = { emitted: [], fallbacks: [], live: new Set<string>() }
+  __setDepsForTests({
+    emitMetric: (e) => f.emitted.push(e),
+    onFrameworkFallback: (ctx) => { f.fallbacks.push(ctx) },
+    thresholdsMs: { ...DEFAULT_THRESHOLDS },
+    ...(opts?.wireReaper === false ? {} : { isTurnLive: (key: string) => f.live.has(key) }),
+  })
+  return f
+}
+
+beforeEach(() => {
+  __resetAllForTests()
+  delete process.env.SWITCHROOM_DISABLE_SILENCE_POKE
+})
+
+afterEach(() => {
+  __resetAllForTests()
+  if (ORIGINAL_KILL_SWITCH == null) delete process.env.SWITCHROOM_DISABLE_SILENCE_POKE
+  else process.env.SWITCHROOM_DISABLE_SILENCE_POKE = ORIGINAL_KILL_SWITCH
+})
+
+describe('#3552 silence-poke orphan reap', () => {
+  const KEY = '-100999:_'
+
+  it('drops state on the next tick once the turn is no longer live — no 300s wait', () => {
+    const f = setup()
+    f.live.add(KEY)
+    startTurn(KEY, 0)
+    __tickForTests(5_000)
+    expect(__getStateForTests(KEY)).toBeDefined()
+
+    // The turn ends via a path that forgot to call endTurn().
+    f.live.delete(KEY)
+    __tickForTests(10_000)
+
+    expect(__getStateForTests(KEY)).toBeUndefined()
+    expect(f.emitted.filter((e) => e.kind === 'silence_poke_orphan_reaped')).toHaveLength(1)
+    // The outcome that matters: the 300s fallback can never fire for this key.
+    __tickForTests(400_000)
+    expect(f.fallbacks).toHaveLength(0)
+  })
+
+  it('does NOT reap a turn that is still live but silent — the real fire still happens', () => {
+    const f = setup()
+    f.live.add(KEY)
+    startTurn(KEY, 0)
+
+    __tickForTests(299_000)
+    expect(f.fallbacks).toHaveLength(0)
+    expect(__getStateForTests(KEY)).toBeDefined()
+
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(1)
+    expect(f.fallbacks[0]!.key).toBe(KEY)
+    expect(f.emitted.some((e) => e.kind === 'silence_poke_orphan_reaped')).toBe(false)
+  })
+
+  it('does NOT reap a live turn that merely released its buffer gate mid-turn', () => {
+    // `releaseTurnBufferGate` clears `activeTurnStartedAt` on every final-answer
+    // reply while the turn keeps running. The production predicate ANDs that
+    // with "no current turn", so the key stays live here — silence-poke must
+    // keep watching the post-answer housekeeping work.
+    const f = setup()
+    f.live.add(KEY)
+    startTurn(KEY, 0)
+    noteOutbound(KEY, 1_000) // the final answer landed; gate released, turn alive
+    __tickForTests(60_000)
+    expect(__getStateForTests(KEY)).toBeDefined()
+    expect(f.emitted.some((e) => e.kind === 'silence_poke_orphan_reaped')).toBe(false)
+  })
+
+  it('reaps only the dead key, leaving a live sibling topic armed', () => {
+    const f = setup()
+    const DEAD = '-100999:11'
+    const LIVE = '-100999:22'
+    f.live.add(DEAD)
+    f.live.add(LIVE)
+    startTurn(DEAD, 0)
+    startTurn(LIVE, 0)
+
+    f.live.delete(DEAD)
+    __tickForTests(10_000)
+
+    expect(__getStateForTests(DEAD)).toBeUndefined()
+    expect(__getStateForTests(LIVE)).toBeDefined()
+  })
+
+  it('is inert when the predicate is not wired (back-compat harnesses)', () => {
+    const f = setup({ wireReaper: false })
+    startTurn(KEY, 0)
+    __tickForTests(10_000)
+    expect(__getStateForTests(KEY)).toBeDefined()
+    expect(f.emitted.some((e) => e.kind === 'silence_poke_orphan_reaped')).toBe(false)
+  })
+})

--- a/telegram-plugin/tests/silence-poke-orphan-reap.test.ts
+++ b/telegram-plugin/tests/silence-poke-orphan-reap.test.ts
@@ -14,6 +14,8 @@
  * unaffected), not merely that the code path runs.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
 import {
   startTurn,
   noteOutbound,
@@ -92,15 +94,17 @@ describe('#3552 silence-poke orphan reap', () => {
     expect(f.emitted.some((e) => e.kind === 'silence_poke_orphan_reaped')).toBe(false)
   })
 
-  it('does NOT reap a live turn that merely released its buffer gate mid-turn', () => {
-    // `releaseTurnBufferGate` clears `activeTurnStartedAt` on every final-answer
-    // reply while the turn keeps running. The production predicate ANDs that
-    // with "no current turn", so the key stays live here — silence-poke must
-    // keep watching the post-answer housekeeping work.
+  it('the stubbed-live case: state survives while the predicate reports live (rule only, NOT the predicate)', () => {
+    // NAMING IS DELIBERATE. This test stubs `isTurnLive`, so it asserts the
+    // silence-poke RULE ("never reap a key the predicate calls live") and
+    // nothing about the production predicate itself — it would pass identically
+    // against a wrong predicate. The predicate is covered separately below, in
+    // '#3552 — the production isTurnLive predicate'; do not read this one as
+    // coverage of the buffer-gate near-miss.
     const f = setup()
     f.live.add(KEY)
     startTurn(KEY, 0)
-    noteOutbound(KEY, 1_000) // the final answer landed; gate released, turn alive
+    noteOutbound(KEY, 1_000)
     __tickForTests(60_000)
     expect(__getStateForTests(KEY)).toBeDefined()
     expect(f.emitted.some((e) => e.kind === 'silence_poke_orphan_reaped')).toBe(false)
@@ -128,5 +132,68 @@ describe('#3552 silence-poke orphan reap', () => {
     __tickForTests(10_000)
     expect(__getStateForTests(KEY)).toBeDefined()
     expect(f.emitted.some((e) => e.kind === 'silence_poke_orphan_reaped')).toBe(false)
+  })
+})
+
+describe('#3552 — the production isTurnLive predicate', () => {
+  // The highest-blast-radius line in this PR is the predicate wired at
+  // liveness-wiring.ts, and every behavioural test above STUBS it. A false reap
+  // is permanent and silent — nothing re-arms until the next `startTurn` — so
+  // the predicate gets its own coverage: a structural pin on the real source
+  // (the technique this repo already uses for gateway-resident callbacks that
+  // cannot be instantiated in a unit test), plus a behavioural model of the two
+  // gateway maps it reads.
+  const src = readFileSync(join(__dirname, '..', 'gateway', 'liveness-wiring.ts'), 'utf8')
+  const KEY = '-100999:11'
+
+  it('is wired with BOTH clauses ANDed — the near-miss this fix turns on', () => {
+    const line = src.split('\n').find((l) => l.includes('isTurnLive:'))
+    expect(line, 'isTurnLive must be wired in liveness-wiring.ts').toBeDefined()
+    // Both halves must be present, negated together. `activeTurnStartedAt`
+    // ALONE is the wrong predicate: `releaseTurnBufferGate` clears it mid-turn
+    // on every final-answer reply, so a predicate missing the `getCurrentTurn()`
+    // clause silently reaps live turns doing post-answer work.
+    expect(line!).toMatch(/activeTurnStartedAt\.get\(key\) == null/)
+    expect(line!).toMatch(/getCurrentTurn\(\) == null/)
+    expect(line!).toMatch(/&&/)
+    expect(line!).toMatch(/^\s*isTurnLive: \(key\) => !\(/)
+  })
+
+  it('matches the late-fire guard it was deliberately copied from', () => {
+    // Same condition, so a mid-turn buffer-gate release can never be reaped by
+    // one and treated as live by the other. If someone tightens/loosens one
+    // site only, the two drift and the reaper starts disagreeing with the guard.
+    const predicate = /activeTurnStartedAt\.get\([\w.]+\) == null && getCurrentTurn\(\) == null/g
+    expect((src.match(predicate) ?? []).length).toBeGreaterThanOrEqual(3)
+  })
+
+  // Behavioural model of the SAME expression over the two gateway maps, so the
+  // buffer-gate case is asserted as an outcome rather than by stubbing.
+  const productionPredicate = (
+    activeTurnStartedAt: Map<string, number>,
+    currentTurn: object | null,
+  ) => (key: string) => !(activeTurnStartedAt.get(key) == null && currentTurn == null)
+
+  it('calls a mid-turn buffer-gate release LIVE (the near-miss), where the naive predicate would not', () => {
+    const m = new Map<string, number>()
+    m.set(KEY, 0)
+    const liveTurn = { turnId: 'c:3#1' }
+    // `releaseTurnBufferGate` / `finalizeStatusReaction('done')` fire mid-turn
+    // on every final-answer reply and clear this entry while the turn runs on.
+    m.delete(KEY)
+    expect(productionPredicate(m, liveTurn)(KEY)).toBe(true)
+    // The predicate I nearly shipped — activeTurnStartedAt alone — would have
+    // reaped this live turn, permanently and silently.
+    const naive = (key: string) => m.get(key) != null
+    expect(naive(KEY)).toBe(false)
+  })
+
+  it('calls a genuinely finished turn DEAD (so the reap still happens)', () => {
+    expect(productionPredicate(new Map(), null)(KEY)).toBe(false)
+  })
+
+  it('calls a turn with its gate still set LIVE even when the singleton is null', () => {
+    const m = new Map<string, number>([[KEY, 0]])
+    expect(productionPredicate(m, null)(KEY)).toBe(true)
   })
 })

--- a/telegram-plugin/tests/silence-poke-orphan-reap.test.ts
+++ b/telegram-plugin/tests/silence-poke-orphan-reap.test.ts
@@ -27,6 +27,8 @@ import {
   type SilencePokeMetric,
   type FrameworkFallbackContext,
 } from '../silence-poke.js'
+import { buildSilencePokeOptions } from '../gateway/liveness-wiring.js'
+import { makeLivenessFixture } from './helpers/liveness-wiring-fixture.js'
 
 const ORIGINAL_KILL_SWITCH = process.env.SWITCHROOM_DISABLE_SILENCE_POKE
 
@@ -149,30 +151,57 @@ describe('#3552 — the production isTurnLive predicate', () => {
   it('is wired with BOTH clauses ANDed — the near-miss this fix turns on', () => {
     const line = src.split('\n').find((l) => l.includes('isTurnLive:'))
     expect(line, 'isTurnLive must be wired in liveness-wiring.ts').toBeDefined()
-    // Both halves must be present, negated together. `activeTurnStartedAt`
-    // ALONE is the wrong predicate: `releaseTurnBufferGate` clears it mid-turn
-    // on every final-answer reply, so a predicate missing the `getCurrentTurn()`
+    // EXACT text, not a bag of fragments. #3575 review: the previous form
+    // asserted four independent regexes that each had to match SOMEWHERE on the
+    // line, with nothing anchoring the end of the arrow body and nothing
+    // forbidding extra conjuncts — so mutants SURVIVED it, including
+    //   `!(A == null && B == null) && activeTurnStartedAt.get(key) != null`
+    // which boolean-reduces to exactly the naive `activeTurnStartedAt`-only
+    // predicate this test is NAMED after, plus `&& false` (reaper disabled for
+    // every key) and an inverted `=== false`. Both halves must be present,
+    // negated TOGETHER, and nothing else may be ANDed on:
+    // `activeTurnStartedAt` ALONE is the wrong predicate, because
+    // `releaseTurnBufferGate` clears it mid-turn on every final-answer reply,
+    // so a predicate missing (or effectively cancelling) the `getCurrentTurn()`
     // clause silently reaps live turns doing post-answer work.
-    expect(line!).toMatch(/activeTurnStartedAt\.get\(key\) == null/)
-    expect(line!).toMatch(/getCurrentTurn\(\) == null/)
-    expect(line!).toMatch(/&&/)
-    expect(line!).toMatch(/^\s*isTurnLive: \(key\) => !\(/)
+    expect(line!.trim()).toBe(
+      'isTurnLive: (key) => !(activeTurnStartedAt.get(key) == null && getCurrentTurn() == null),',
+    )
   })
 
   it('matches the late-fire guard it was deliberately copied from', () => {
     // Same condition, so a mid-turn buffer-gate release can never be reaped by
     // one and treated as live by the other. If someone tightens/loosens one
     // site only, the two drift and the reaper starts disagreeing with the guard.
+    //
+    // #3575 review: scan CODE only. Counting occurrences across the raw file let
+    // an OR-for-AND swap survive by leaving the canonical text behind in a stale
+    // comment — the comment paid for the missing code site.
+    const code = src
+      .split('\n')
+      .filter((l) => {
+        const t = l.trim()
+        return !(t.startsWith('//') || t.startsWith('*') || t.startsWith('/*'))
+      })
+      .join('\n')
     const predicate = /activeTurnStartedAt\.get\([\w.]+\) == null && getCurrentTurn\(\) == null/g
-    expect((src.match(predicate) ?? []).length).toBeGreaterThanOrEqual(3)
+    expect((code.match(predicate) ?? []).length).toBeGreaterThanOrEqual(3)
   })
 
-  // Behavioural model of the SAME expression over the two gateway maps, so the
-  // buffer-gate case is asserted as an outcome rather than by stubbing.
-  const productionPredicate = (
-    activeTurnStartedAt: Map<string, number>,
-    currentTurn: object | null,
-  ) => (key: string) => !(activeTurnStartedAt.get(key) == null && currentTurn == null)
+  // #3575 review B3 — EXECUTE the real predicate. The previous version of this
+  // block re-typed the expression by hand into a local `productionPredicate`,
+  // which by construction cannot detect divergence from the wiring it claims to
+  // cover. `buildSilencePokeOptions` is a pure function of its deps (its only
+  // gateway import is `import type`), so the real options object — including the
+  // real `isTurnLive` closure — can be built here.
+  function realPredicate(activeTurnStartedAt: Map<string, number>, currentTurn: object | null) {
+    const fx = makeLivenessFixture()
+    for (const [k, v] of activeTurnStartedAt) fx.activeTurnStartedAt.set(k, v)
+    fx.setCurrentTurn(currentTurn)
+    const isTurnLive = buildSilencePokeOptions(fx.deps).isTurnLive
+    expect(isTurnLive, 'the wiring must supply isTurnLive').toBeTypeOf('function')
+    return isTurnLive!
+  }
 
   it('calls a mid-turn buffer-gate release LIVE (the near-miss), where the naive predicate would not', () => {
     const m = new Map<string, number>()
@@ -181,7 +210,7 @@ describe('#3552 — the production isTurnLive predicate', () => {
     // `releaseTurnBufferGate` / `finalizeStatusReaction('done')` fire mid-turn
     // on every final-answer reply and clear this entry while the turn runs on.
     m.delete(KEY)
-    expect(productionPredicate(m, liveTurn)(KEY)).toBe(true)
+    expect(realPredicate(m, liveTurn)(KEY)).toBe(true)
     // The predicate I nearly shipped — activeTurnStartedAt alone — would have
     // reaped this live turn, permanently and silently.
     const naive = (key: string) => m.get(key) != null
@@ -189,11 +218,78 @@ describe('#3552 — the production isTurnLive predicate', () => {
   })
 
   it('calls a genuinely finished turn DEAD (so the reap still happens)', () => {
-    expect(productionPredicate(new Map(), null)(KEY)).toBe(false)
+    expect(realPredicate(new Map(), null)(KEY)).toBe(false)
   })
 
   it('calls a turn with its gate still set LIVE even when the singleton is null', () => {
     const m = new Map<string, number>([[KEY, 0]])
-    expect(productionPredicate(m, null)(KEY)).toBe(true)
+    expect(realPredicate(m, null)(KEY)).toBe(true)
+  })
+
+  // The dangerous case, end to end through silence-poke's own tick, with the
+  // REAL predicate wired as the reaper. `releaseTurnBufferGate` (turn-end.ts:371)
+  // deletes the `activeTurnStartedAt` entry on EVERY reply finalize — including
+  // a mid-turn interim ack — while the turn keeps running; `getCurrentTurn()` is
+  // the UNKEYED singleton mirror. So a still-running turn whose gate was
+  // released AND whose mirror has been nulled by another topic reads dead on
+  // BOTH clauses, and IS reaped. This test states that residual honestly rather
+  // than pretending the conjunction covers it: a false reap is permanent and
+  // silent (nothing re-arms until the next `startTurn`), costing the turn both
+  // its mid-turn beat and its 300s unwedge. The durable fix is a keyed liveness
+  // read (or a re-arm safety), NOT a wider predicate — see #3580.
+  it('documents the residual: with BOTH signals dead the tick reaps, even mid-turn', async () => {
+    const emitted: SilencePokeMetric[] = []
+    const fallbacks: FrameworkFallbackContext[] = []
+    const fx = makeLivenessFixture()
+    // Turn A is live for THIS key...
+    fx.activeTurnStartedAt.set(KEY, 0)
+    fx.setCurrentTurn({ turnId: 'a#1' })
+    const opts = buildSilencePokeOptions(fx.deps)
+    __setDepsForTests({
+      ...opts,
+      emitMetric: (e) => emitted.push(e),
+      onFrameworkFallback: async (ctx) => { fallbacks.push(ctx) },
+    })
+    startTurn(KEY, 0)
+    __tickForTests(5_000)
+    expect(__getStateForTests(KEY)).toBeDefined()
+
+    // ...then the final answer lands: releaseTurnBufferGate drops the
+    // activeTurnStartedAt entry, and currentTurn is nulled — while the turn
+    // keeps doing post-answer work.
+    fx.activeTurnStartedAt.delete(KEY)
+    fx.setCurrentTurn(null)
+    __tickForTests(10_000)
+
+    // Ground truth of the near-miss: BOTH naive readings say "dead" here.
+    expect(fx.activeTurnStartedAt.get(KEY) == null).toBe(true)
+    expect(fx.deps.getCurrentTurn() == null).toBe(true)
+    // ...and the real wiring still reaps it, because the conjunction is what
+    // the predicate negates. (Documented outcome: this IS a reap. See the
+    // re-arm note in the test below.)
+    expect(__getStateForTests(KEY)).toBeUndefined()
+    expect(emitted.some((e) => e.kind === 'silence_poke_orphan_reaped')).toBe(true)
+    expect(fallbacks).toHaveLength(0)
+  })
+
+  it('keeps a live turn armed whenever EITHER liveness signal survives (the conjunction is load-bearing)', () => {
+    // The two survivable shapes of the buffer-gate window, through the real
+    // predicate on the real tick. Either signal alone must hold the state.
+    for (const shape of ['gate-only', 'singleton-only'] as const) {
+      __resetAllForTests()
+      const emitted: SilencePokeMetric[] = []
+      const fx = makeLivenessFixture()
+      if (shape === 'gate-only') fx.activeTurnStartedAt.set(KEY, 0)
+      else fx.setCurrentTurn({ turnId: 'a#1' })
+      __setDepsForTests({
+        ...buildSilencePokeOptions(fx.deps),
+        emitMetric: (e) => emitted.push(e),
+        onFrameworkFallback: async () => {},
+      })
+      startTurn(KEY, 0)
+      __tickForTests(10_000)
+      expect(__getStateForTests(KEY), shape).toBeDefined()
+      expect(emitted.some((e) => e.kind === 'silence_poke_orphan_reaped'), shape).toBe(false)
+    }
   })
 })

--- a/telegram-plugin/tests/silence-poke-teardown-notice.test.ts
+++ b/telegram-plugin/tests/silence-poke-teardown-notice.test.ts
@@ -13,14 +13,20 @@
  * OUTCOMES — which real situations speak and which stay quiet — plus the
  * structural guarantee that the wiring actually sends on a speaking decision.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   decideFallbackTeardownNotice,
   formatFrameworkFallbackText,
+  startTurn,
+  __setDepsForTests,
+  __tickForTests,
+  __resetAllForTests,
   type FallbackTeardownNoticeInput,
 } from '../silence-poke.js'
+import { buildSilencePokeOptions } from '../gateway/liveness-wiring.js'
+import { makeLivenessFixture, makeTurn } from './helpers/liveness-wiring-fixture.js'
 
 /** The situation the issue is about: a human asked, got nothing, turn killed. */
 function killedUserTurn(over: Partial<FallbackTeardownNoticeInput> = {}): FallbackTeardownNoticeInput {
@@ -94,6 +100,73 @@ describe('#3551 — the gates that keep this from becoming the retired stall pin
   it('stays quiet when the user already has their answer', () => {
     const d = decideFallbackTeardownNotice(killedUserTurn({ finalAnswerDelivered: true }))
     expect(d).toEqual({ send: false, reason: 'answer-already-delivered' })
+  })
+})
+
+/**
+ * #3575 review — BEHAVIOURAL wiring coverage.
+ *
+ * The three describe blocks below assert regexes against `liveness-wiring.ts`'s
+ * own SOURCE TEXT. They pass if `onFrameworkFallback` is never invoked, if the
+ * notice goes to the wrong chat, or if `sendSilenceText` throws. This block
+ * drives the REAL wiring through silence-poke's REAL tick: arm a turn, step the
+ * fake clock past the 300 s threshold, and assert on the send that happens.
+ */
+describe('#3551 — the teardown notice actually reaches the user (integration)', () => {
+  const CHAT = '-100999'
+  const THREAD = 11
+  const KEY = `${CHAT}:${THREAD}`
+  const TURN_ID = '-100999:11#42'
+
+  afterEach(() => {
+    __resetAllForTests()
+    __setDepsForTests(null)
+  })
+
+  async function fireFallback(opts: { obligationOpen: boolean }) {
+    const fx = makeLivenessFixture()
+    const turn = makeTurn({ sessionChatId: CHAT, sessionThreadId: THREAD, turnId: TURN_ID })
+    fx.activeTurnStartedAt.set(KEY, 0)
+    fx.setCurrentTurn(turn)
+    if (opts.obligationOpen) fx.openObligations.add(TURN_ID)
+    __setDepsForTests(buildSilencePokeOptions(fx.deps))
+    startTurn(KEY, 0)
+    __tickForTests(301_000)
+    // onFrameworkFallback is async; let its awaits settle.
+    await new Promise((r) => setTimeout(r, 0))
+    return fx
+  }
+
+  it('sends the notice — right chat, right thread, LOUD — after 300s of silence', async () => {
+    const fx = await fireFallback({ obligationOpen: true })
+    const notice = fx.sent.find((s) => s.text.includes('the framework ended that stalled turn'))
+    expect(notice, 'the teardown notice must actually be sent').toBeDefined()
+    expect(notice!.chatId).toBe(CHAT)
+    expect(notice!.threadId).toBe(THREAD)
+    // LOUD: a killed question is not a silent status surface.
+    expect(notice!.silent).toBe(false)
+    // ...and the load-bearing unwedge still ran.
+    expect(fx.endedKeys).toContain(KEY)
+  })
+
+  it('promises the re-ask only when THIS turn has an open obligation', async () => {
+    // #3575 review B2. `representWillFollow` used to be the STATIC
+    // `OBLIGATION_LEDGER_ENABLED` env boolean, so the notice promised "being
+    // re-asked now" even when no re-ask could ever happen — the obligation
+    // already hit OBLIGATION_REPRESENT_MAX and escalated+closed, or was closed
+    // by an outbound-since-open, or was never opened. The user was told to wait,
+    // and waited forever.
+    //
+    // These two runs differ ONLY in whether this turn's obligation is open. Any
+    // process-wide constant fails one of them, so restoring the static flag
+    // cannot pass.
+    const open = await fireFallback({ obligationOpen: true })
+    const closed = await fireFallback({ obligationOpen: false })
+    const openText = open.sent.find((s) => s.text.includes('framework ended'))!.text
+    const closedText = closed.sent.find((s) => s.text.includes('framework ended'))!.text
+    expect(openText).toContain('being re-asked now')
+    expect(closedText).toContain('please re-send it')
+    expect(closedText).not.toContain('re-asked')
   })
 })
 

--- a/telegram-plugin/tests/silence-poke-teardown-notice.test.ts
+++ b/telegram-plugin/tests/silence-poke-teardown-notice.test.ts
@@ -28,7 +28,7 @@ function killedUserTurn(over: Partial<FallbackTeardownNoticeInput> = {}): Fallba
     tearsDownLiveTurn: true,
     role: 'user',
     finalAnswerDelivered: false,
-    otherTextSent: false,
+    userAddressedTextDelivered: false,
     representWillFollow: true,
     silenceMs: 302_000,
     ...over,
@@ -51,7 +51,7 @@ describe('#3551 — a fire that ends a user turn is never silent', () => {
     // formatter yields nothing; before the fix, that meant the whole fire was
     // user-invisible.
     expect(formatFrameworkFallbackText('working', 302_000, [], false)).toBeNull()
-    expect(decideFallbackTeardownNotice(killedUserTurn({ otherTextSent: false })).send).toBe(true)
+    expect(decideFallbackTeardownNotice(killedUserTurn({ userAddressedTextDelivered: false })).send).toBe(true)
   })
 
   it('derives the minute count from the real silence, not the nominal threshold', () => {
@@ -72,9 +72,9 @@ describe('#3551 — a fire that ends a user turn is never silent', () => {
 })
 
 describe('#3551 — the gates that keep this from becoming the retired stall ping', () => {
-  it('stays quiet when the approval re-ping (or update-status line) already spoke', () => {
-    const d = decideFallbackTeardownNotice(killedUserTurn({ otherTextSent: true }))
-    expect(d).toEqual({ send: false, reason: 'other-text-sent' })
+  it('stays quiet when a delivered approval re-ping already addressed the user', () => {
+    const d = decideFallbackTeardownNotice(killedUserTurn({ userAddressedTextDelivered: true }))
+    expect(d).toEqual({ send: false, reason: 'user-addressed-text-delivered' })
   })
 
   it('stays quiet on a late fire that tore down nothing', () => {
@@ -121,5 +121,42 @@ describe('#3551 — wiring: the teardown path actually sends the notice', () => 
 
   it('sends the notice LOUD — a killed question is not a silent status surface', () => {
     expect(fallbackBody).toMatch(/sendSilenceText\(fbChatId, ctx\.threadId \?\? null, teardownNotice\.text, false\)/)
+  })
+})
+
+describe('#3551 L1/L2 — the suppression signal is narrow, and means DELIVERED', () => {
+  // L1. `text` in onFrameworkFallback has TWO sources. Treating them alike
+  // reproduced the very bug #3551 closes: user asks something during an
+  // `update_apply`, gets no answer, the fallback emits a SILENT status line
+  // about the update, the turn is torn down — and the notice was suppressed as
+  // "other text sent". Silent kill, again.
+  it('a silent, unrelated update-status line does NOT buy silence — that IS the #3551 case', () => {
+    const d = decideFallbackTeardownNotice(killedUserTurn({ userAddressedTextDelivered: false }))
+    expect(d.send).toBe(true)
+  })
+
+  const src = readFileSync(join(__dirname, '..', 'gateway', 'liveness-wiring.ts'), 'utf8')
+  const fallbackBody = src.slice(src.indexOf('onFrameworkFallback:'))
+
+  it('the wiring feeds the decider the DELIVERY flag, never `text != null`', () => {
+    // The regression this pins: reverting to `otherTextSent: text != null`
+    // silently re-couples the silent status line (L1) and the failed send (L2).
+    expect(fallbackBody).toMatch(/userAddressedTextDelivered,/)
+    expect(fallbackBody).not.toMatch(/otherTextSent:\s*text != null/)
+  })
+
+  it('L2 — the flag is set only AFTER a successful send, inside the try', () => {
+    // A throwing approval re-ping must not buy silence: the catch only logs, so
+    // assigning before/outside the await would leave the user with nothing at
+    // all while the turn was torn down.
+    expect(fallbackBody).toMatch(
+      /await sendSilenceText\(ctx\.chatId[^\n]*\n\s*userAddressedTextDelivered = blockedOnApproval/,
+    )
+    // and it is initialised false, so the catch path leaves it false
+    expect(fallbackBody).toMatch(/let userAddressedTextDelivered = false/)
+  })
+
+  it('L1 — the flag is gated on blockedOnApproval, which is what makes it user-addressed', () => {
+    expect(fallbackBody).toMatch(/userAddressedTextDelivered = blockedOnApproval/)
   })
 })

--- a/telegram-plugin/tests/silence-poke-teardown-notice.test.ts
+++ b/telegram-plugin/tests/silence-poke-teardown-notice.test.ts
@@ -1,0 +1,125 @@
+/**
+ * switchroom#3551 — the 5-minute silence poke killed turns silently.
+ *
+ * `formatFrameworkFallbackText` returns a string on exactly one branch
+ * (`blockedOnApproval`); the stall-notice path was retired and every other
+ * branch returns null. So on a normal fire the gateway delivered NO text while
+ * still tearing the turn down and redelivering buffered inbound — from the
+ * user's seat, five minutes of nothing followed by the agent apparently
+ * restarting the same request. 110 fires / 14 days, p50 silence 302s.
+ *
+ * `decideFallbackTeardownNotice` makes that kill observable without
+ * re-introducing the banned cadence ping. These tests assert the decision
+ * OUTCOMES — which real situations speak and which stay quiet — plus the
+ * structural guarantee that the wiring actually sends on a speaking decision.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  decideFallbackTeardownNotice,
+  formatFrameworkFallbackText,
+  type FallbackTeardownNoticeInput,
+} from '../silence-poke.js'
+
+/** The situation the issue is about: a human asked, got nothing, turn killed. */
+function killedUserTurn(over: Partial<FallbackTeardownNoticeInput> = {}): FallbackTeardownNoticeInput {
+  return {
+    tearsDownLiveTurn: true,
+    role: 'user',
+    finalAnswerDelivered: false,
+    otherTextSent: false,
+    representWillFollow: true,
+    silenceMs: 302_000,
+    ...over,
+  }
+}
+
+describe('#3551 — a fire that ends a user turn is never silent', () => {
+  it('speaks when the framework kills an undelivered user turn', () => {
+    const d = decideFallbackTeardownNotice(killedUserTurn())
+    expect(d.send).toBe(true)
+    if (!d.send) throw new Error('unreachable')
+    // Honest about WHAT happened (the turn was ended) and WHO did it (the
+    // framework, not the agent) — the two facts the user had no way to know.
+    expect(d.text).toContain('the framework ended that stalled turn')
+    expect(d.text).toContain('5 min')
+  })
+
+  it('closes the exact gap: the branch where formatFrameworkFallbackText is null still produces a message', () => {
+    // This is the bug, stated as a test. On the non-approval branch the
+    // formatter yields nothing; before the fix, that meant the whole fire was
+    // user-invisible.
+    expect(formatFrameworkFallbackText('working', 302_000, [], false)).toBeNull()
+    expect(decideFallbackTeardownNotice(killedUserTurn({ otherTextSent: false })).send).toBe(true)
+  })
+
+  it('derives the minute count from the real silence, not the nominal threshold', () => {
+    const d = decideFallbackTeardownNotice(killedUserTurn({ silenceMs: 904_000 }))
+    if (!d.send) throw new Error('expected a notice')
+    expect(d.text).toContain('for 15 min')
+    expect(d.text).not.toContain('for 5 min')
+  })
+
+  it('never promises a re-ask the obligation ledger cannot deliver', () => {
+    const on = decideFallbackTeardownNotice(killedUserTurn({ representWillFollow: true }))
+    const off = decideFallbackTeardownNotice(killedUserTurn({ representWillFollow: false }))
+    if (!on.send || !off.send) throw new Error('expected notices')
+    expect(on.text).toContain('being re-asked now')
+    expect(off.text).toContain('please re-send it')
+    expect(off.text).not.toContain('re-asked')
+  })
+})
+
+describe('#3551 — the gates that keep this from becoming the retired stall ping', () => {
+  it('stays quiet when the approval re-ping (or update-status line) already spoke', () => {
+    const d = decideFallbackTeardownNotice(killedUserTurn({ otherTextSent: true }))
+    expect(d).toEqual({ send: false, reason: 'other-text-sent' })
+  })
+
+  it('stays quiet on a late fire that tore down nothing', () => {
+    const d = decideFallbackTeardownNotice(killedUserTurn({ tearsDownLiveTurn: false }))
+    expect(d).toEqual({ send: false, reason: 'no-live-turn-torn-down' })
+  })
+
+  it('stays quiet on cron / system / sub-agent turns — nobody is waiting', () => {
+    expect(decideFallbackTeardownNotice(killedUserTurn({ role: 'system' })))
+      .toEqual({ send: false, reason: 'non-user-turn' })
+    expect(decideFallbackTeardownNotice(killedUserTurn({ role: 'sub-agent' })))
+      .toEqual({ send: false, reason: 'non-user-turn' })
+    expect(decideFallbackTeardownNotice(killedUserTurn({ role: null })))
+      .toEqual({ send: false, reason: 'non-user-turn' })
+  })
+
+  it('stays quiet when the user already has their answer', () => {
+    const d = decideFallbackTeardownNotice(killedUserTurn({ finalAnswerDelivered: true }))
+    expect(d).toEqual({ send: false, reason: 'answer-already-delivered' })
+  })
+})
+
+describe('#3551 — wiring: the teardown path actually sends the notice', () => {
+  // buildSilencePokeOptions needs the whole gateway module's dep object, which
+  // cannot be instantiated in a unit test (module-load side effects). Pin the
+  // wiring structurally instead — the same technique the repo uses for other
+  // gateway-resident callbacks.
+  const src = readFileSync(join(__dirname, '..', 'gateway', 'liveness-wiring.ts'), 'utf8')
+  const fallbackBody = src.slice(src.indexOf('onFrameworkFallback:'))
+
+  it('calls the decider inside onFrameworkFallback and sends on a speaking decision', () => {
+    expect(fallbackBody).toMatch(/decideFallbackTeardownNotice\(/)
+    expect(fallbackBody).toMatch(/if \(teardownNotice\.send\)[\s\S]{0,400}?sendSilenceText\(/)
+  })
+
+  it('keeps the load-bearing unwedge — the notice does not replace the teardown', () => {
+    // The whole point of the 300s fallback is #1122: end the wedged turn so
+    // later inbound is not queued behind a dead turn forever. A "fix" that
+    // stopped killing the turn would trade dead air for a wedged conversation.
+    expect(fallbackBody).toMatch(/silencePoke\.endTurn\(fbKey\)/)
+    expect(fallbackBody).toMatch(/endCurrentTurnForKey\(wedgedTurn, fbKey\)/)
+    expect(fallbackBody).toMatch(/redeliverBufferedInbound\(/)
+  })
+
+  it('sends the notice LOUD — a killed question is not a silent status surface', () => {
+    expect(fallbackBody).toMatch(/sendSilenceText\(fbChatId, ctx\.threadId \?\? null, teardownNotice\.text, false\)/)
+  })
+})


### PR DESCRIPTION
Fixes the two silence-poke turn-lifecycle bugs in the gateway group: **#3552** (leaked per-turn state) and **#3551** (a fire that kills a user's turn while delivering nothing).

Both live in the same state machine, so they ship together; #3550 and #3555 follow in separate PRs.

## #3552 — orphaned silence-poke state is reaped on the tick, not 300s later

Per-turn state in `telegram-plugin/silence-poke.ts` is created by `startTurn` and only dropped by `endTurn` or by a fallback fire. Two turn-end paths never called `endTurn`:

- `telegram-plugin/gateway/disconnect-flush.ts` — on bridge death it deletes `activeStatusReactions`, `activeReactionMsgIds` and `activeTurnStartedAt`, and never touched silence-poke. Proven source-side leak.
- any other path that clears the turn without routing through `endTurn`.

The orphan then sat armed until the 300s fallback fired against a dead key and disarmed it as a "late fire" — five minutes of a timer whose turn had been over the whole time (~500 observed).

**Fix (two parts, both narrow):**

1. `silence-poke.ts` `tick()` — new optional dep `isTurnLive(key)`. Immediately after the `silence < 0` guard, state whose turn is provably over is deleted and a `silence_poke_orphan_reaped` metric is emitted. Wired in `telegram-plugin/gateway/liveness-wiring.ts` as `!(activeTurnStartedAt.get(key) == null && getCurrentTurn() == null)` — deliberately the **same predicate as the existing late-fire guard**, because `activeTurnStartedAt` alone is cleared mid-turn by `releaseTurnBufferGate` on every final-answer reply. A mid-turn buffer-gate release (turn still live, post-answer work in progress) is therefore never reaped; the test suite pins that case.
2. `disconnect-flush.ts` — new optional `onTurnKeyEnded(key)` dep, called for every key torn down by both the controller loop and the dangling sweep; `gateway.ts` passes `(key) => silencePoke.endTurn(key)`. Idempotent by contract.

`silence_poke_orphan_reaped` was added to `RuntimeMetricEvent` in `telegram-plugin/runtime-metrics.ts`. A persistent stream of it names a turn-end path that is still failing to call `endTurn` — it is a diagnostic, not just a counter.

**Before:** orphan state stayed armed up to 300s past turn end, then self-cleared as a late fire.
**After:** dropped on the next 5s tick, with a metric; bridge death disarms directly. No change to any live turn's fallback — a live-but-silent turn still gets its real 300s fire (pinned by test).

## #3551 — a fire that kills a user turn must say so

`formatFrameworkFallbackText` (`telegram-plugin/silence-poke.ts:480`) returns a string on exactly **one** branch, `blockedOnApproval`. The stall-notice path was retired per `reference/rfcs/conversational-pacing.md` and every other branch returns null. So on a normal fire the gateway delivered **no user-visible text** while still tearing down the live turn, stamping the registry row `ended_via='timeout'`, and redelivering buffered inbound. From the user's seat: N minutes of nothing, then the agent apparently restarting the same request, with no signal that the *framework* — not the agent — did that. 110 fires / 14 days, silenceMs p50 302s / max 904s, corroborated by 57 `ended_via='timeout'` rows; ≈9h of dead air.

**The teardown is not removed.** It is the fallback's one load-bearing job (#1122): without it `activeTurnStartedAt` stays set and every later inbound queues behind a dead turn forever. Trading dead air for a permanently wedged conversation would be strictly worse. Instead the kill is made **observable**.

New pure decider `decideFallbackTeardownNotice` in `silence-poke.ts`, called in `liveness-wiring.ts` **after** the teardown (so the notice can't be clobbered by the state purge). Four gates keep it a terminal event rather than a re-introduction of the banned cadence ping:

- `userAddressedTextDelivered` — never stacks on the approval re-ping. Deliberately **narrower** than "some text went out": see the L1 note below.
- `tearsDownLiveTurn` — a late fire that ended nothing says nothing
- `role !== 'user'` — cron/system/sub-agent silence is legitimate; nobody is waiting
- `finalAnswerDelivered` — the user already has their answer

What survives is exactly one case: a human asked, got nothing for N minutes, and the framework just ended that attempt. At most once per turn (the key is dropped right after), sent LOUD, minute count derived from real `silenceMs` rather than the nominal threshold, and the follow-up sentence only promises a re-ask when `OBLIGATION_LEDGER_ENABLED` is on to deliver one.

**Before:** non-approval fire → zero text, turn killed, user sees a silent restart.
**After:** identical teardown/unwedge/redelivery, plus one terminal message naming what happened and what comes next.

## Review remediation (round 2)

**L1 — this path still exhibited the bug #3551 exists to close.** The suppression input was originally `otherTextSent: text != null`, but `text` has two sources: the approval re-ping (loud, user-addressed, explains the stall) and `formatUpdateStatusLine` (`liveness-wiring.ts:238-244`, silent, reports an unrelated in-flight `update_apply`). The second says nothing about this turn ending, so *user asks during an `update_apply` → no answer → fallback fires → quiet status line goes out → turn torn down → notice suppressed* was a silent kill. The signal is now `userAddressedTextDelivered`, true only on the `blockedOnApproval` branch; the decider's reason string is `'user-addressed-text-delivered'`.

**L2.** It is also computed from send **success**, not from `text != null`. The send sits in a try/catch that only logs, so a throwing approval re-ping previously bought silence while the user received nothing at all. The flag initialises `false` and is assigned only after the `await` returns.

**M2 — the coverage claim in the first revision of this body was wrong.** The `isTurnLive` predicate — the highest-blast-radius line here — was executed by no test: every behavioural test *stubs* it. Worse, the test that claimed to guard the near-miss ("does NOT reap a live turn that merely released its buffer gate") was tautological — it put the key in the stub's live set and asserted survival, so it would have passed identically against the exact mutation it claimed to catch. That matters more than an ordinary coverage gap because a false reap is permanent and silent: nothing re-arms until the next `startTurn`. Fixed by renaming that test to say what it actually asserts (the rule, not the predicate), and adding a `#3552 — the production isTurnLive predicate` block with a source-level structural pin that both clauses are present and ANDed, a drift pin that the reaper and the two late-fire guards share one expression, and a behavioural model over the two gateway maps showing a mid-turn buffer-gate release reads LIVE where the naive `activeTurnStartedAt`-only predicate would have reaped it.

**Known, deferred: #3580.** `getCurrentTurn()` is read **unkeyed** at all three sites (`:78`, `:108`, `:160`). Under `SWITCHROOM_EMISSION_AUTHORITY=1` that singleton is a most-recent-set mirror, so a topic that released its buffer gate mid-turn can be reaped while live once another topic starts and ends. `tearsDownLiveTurn` (`:471`) is likewise looser than the actual teardown gate (`:442`). Both are **pre-existing** — this PR propagated the existing expression rather than introducing the bug — and the flag defaults OFF with no non-test setter. They want fixing keyed, all four sites together, before that flag ever rolls. Tracked in #3580.

## Tests

- `telegram-plugin/tests/silence-poke-orphan-reap.test.ts` (new, 10) — state dropped on the next tick and no 300s fire ever happens; a live-but-silent turn still fires; a mid-turn buffer-gate release is not reaped; a live sibling topic survives; inert when the predicate is unwired; plus the M2 structural + drift + model pins on the production predicate.
- `telegram-plugin/tests/gateway-disconnect-flush.test.ts` (+3) — every torn-down key reported from both loops; never called for an anonymous disconnect; omitting the callback is safe.
- `telegram-plugin/tests/silence-poke-teardown-notice.test.ts` (new, 15) — decision outcomes for each gate, plus structural pins on `liveness-wiring.ts` that the decider is called inside `onFrameworkFallback`, that the speaking branch reaches `sendSilenceText`, that the notice is LOUD, and that `silencePoke.endTurn` / `endCurrentTurnForKey` / `redeliverBufferedInbound` are all still there, and the L1/L2 pins that the suppression input is `userAddressedTextDelivered` and is assigned only after a successful send.

Mutation-verified: removing the `role !== 'user'` gate and neutering the `sendSilenceText` call fails 3; removing the reap fails the orphan suite; dropping the `getCurrentTurn()` clause from `isTurnLive` fails 2; reverting to `otherTextSent: text != null` fails 1; hoisting the delivery flag above the `await` fails 1. Note the scope honestly: the `isTurnLive` **predicate** is covered structurally and by model, not by executing the production closure — see M2 above. `npm run lint` clean, including `check-gateway-line-ratchet` (gateway.ts 24873, ratchet 24867 + slack 50).

Refs #3551, #3552

