### PR TITLE
fix(registry): stamp mid-session reaps 'reaped_stale', not 'restart' (#3555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### Turn registry — mid-session reaps are no longer labelled "restart" (#3555)
+
+- **`reapStaleOpenTurns` stamps `ended_via='reaped_stale'`** instead of
+  borrowing `'restart'`. Nothing restarts in that path — the mid-session sweep
+  simply gives up on an ownerless open row past the 15-minute reaper TTL. The
+  old label contaminated the column: on one host 1055 `'restart'` rows, 967 of
+  them (91.7%) in a 15-19 minute band matching the TTL, against exactly ONE
+  `[supervise] gateway exited` in the same window. **Any statistic previously
+  computed from `ended_via='restart'` needs re-deriving.** Behaviour is
+  unchanged — `'reaped_stale'` is in `INTERRUPTED_VIA` and maps to the same
+  `'resume'`, so affected turns still resume exactly as before.
+
+  ⚠️ **DO NOT ROLL BACK PAST THIS VERSION ONCE DEPLOYED.** The change is
+  forward-compatible but *not* backward-compatible. A pre-#3555 binary does
+  not know `'reaped_stale'`: its `INTERRUPTED_VIA` excludes it and its
+  `selectResumeBuilder` matches no branch, so a turn stamped by the new binary
+  and then read by the old one is treated as cleanly finished and the user's
+  interrupted turn is **silently dropped**. With a 15-minute reaper TTL on a
+  5-minute sweep, freshly-stamped rows are common, so the exposure window is
+  real rather than theoretical. Roll forward to fix; do not downgrade.
+
 ### Voice out — pacing & misreadings
 
 - **Lists and headings are spoken as separate sentences** — stripping a bullet

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8889,7 +8889,7 @@ async function runMidSessionCardReaper(): Promise<void> {
       if (reaped > 0) {
         process.stderr.write(
           `telegram gateway: mid-session reaper stamped ${reaped} orphaned turn(s) ` +
-            `as 'restart' (${reapedTurnKeys.join(',')})\n`,
+            `as 'reaped_stale' (${reapedTurnKeys.join(',')})\n`,
         )
       }
     } catch (err) {

--- a/telegram-plugin/gateway/resume-inbound-builder.ts
+++ b/telegram-plugin/gateway/resume-inbound-builder.ts
@@ -458,9 +458,13 @@ export function buildResumeDeferredReportInbound(
  * the gateway calls this with the classified `ended_via` so the
  * report-vs-resume policy lives in one testable place.
  *
- *   - 'timeout'                         → 'report'  (watchdog kill)
- *   - 'restart' | 'sigterm' | 'unknown' → 'resume'  (clean interrupt)
- *   - 'stop'                            → null      (finished; nothing to do)
+ *   - 'timeout'                                → 'report'  (watchdog kill)
+ *   - 'restart'|'reaped_stale'|'sigterm'|'unknown' → 'resume' (clean interrupt)
+ *   - 'stop'                                   → null      (finished; nothing to do)
+ *
+ * #3555: `'reaped_stale'` (mid-session stale-row sweep) is treated exactly
+ * like `'restart'` here — it is the same clean interrupt, just no longer
+ * mislabelled as a restart in the data.
  */
 export function selectResumeBuilder(
   endedVia: TurnEndedVia | null,
@@ -473,7 +477,12 @@ export function selectResumeBuilder(
 ): 'resume' | 'report' | null {
   let kind: 'resume' | 'report' | null
   if (endedVia === 'timeout') kind = 'report'
-  else if (endedVia === 'restart' || endedVia === 'sigterm' || endedVia === 'unknown') kind = 'resume'
+  else if (
+    endedVia === 'restart' ||
+    endedVia === 'reaped_stale' ||
+    endedVia === 'sigterm' ||
+    endedVia === 'unknown'
+  ) kind = 'resume'
   else if (endedVia == null) kind = 'resume' // still-open at boot = killed mid-flight
   else kind = null
   if (

--- a/telegram-plugin/registry/turns-schema.test.ts
+++ b/telegram-plugin/registry/turns-schema.test.ts
@@ -169,7 +169,7 @@ describe('reapStaleOpenTurns (#2918 mid-session sweep)', () => {
     db.prepare('UPDATE turns SET started_at = ? WHERE turn_key = ?').run(startedAt, turnKey)
   }
 
-  it('stamps an ownerless open row aged past the TTL as restart', () => {
+  it("stamps an ownerless open row aged past the TTL as 'reaped_stale', not 'restart' (#3555)", () => {
     const db = openTurnsDbInMemory()
     const now = 1_000_000_000_000
     recordTurnStart(db, { turnKey: 'dm:dead', chatId: '111' })
@@ -183,7 +183,12 @@ describe('reapStaleOpenTurns (#2918 mid-session sweep)', () => {
     expect(res.reapedTurnKeys).toEqual(['dm:dead'])
     const turn = getTurnByKey(db, 'dm:dead')
     expect(turn?.ended_at).toBe(now)
-    expect(turn?.ended_via).toBe('restart')
+    // #3555: this sweep is NOT a restart. Stamping 'restart' contaminated
+    // every restart statistic derived from the column (1055 rows on one host,
+    // 91.7% clustered at the 15-min reaper TTL, against exactly ONE actual
+    // gateway exit in the same window).
+    expect(turn?.ended_via).toBe('reaped_stale')
+    expect(turn?.ended_via).not.toBe('restart')
     db.close()
   })
 
@@ -233,7 +238,7 @@ describe('reapStaleOpenTurns (#2918 mid-session sweep)', () => {
       now,
     })
     expect(res.reapedTurnKeys).toEqual(['dm:dead'])
-    expect(getTurnByKey(db, 'dm:dead')?.ended_via).toBe('restart')
+    expect(getTurnByKey(db, 'dm:dead')?.ended_via).toBe('reaped_stale')
     expect(getTurnByKey(db, 'dm:live')?.ended_at).toBeNull()
     db.close()
   })

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -806,9 +806,13 @@ export function markAnswerRedelivered(
 
 /**
  * Return the single most-recently-started turn IFF it was interrupted
- * (`ended_at IS NULL`, or `ended_via` in {restart, sigterm, timeout,
- * unknown}). Returns null when the latest turn ended cleanly (`'stop'`)
- * or there are no turns at all.
+ * (`ended_at IS NULL`, or `ended_via` in {restart, reaped_stale, sigterm,
+ * timeout, unknown} — i.e. `INTERRUPTED_VIA`). Returns null when the latest
+ * turn ended cleanly (`'stop'`) or there are no turns at all.
+ *
+ * `'reaped_stale'` (#3555) is in that set for the same reason `'restart'` is:
+ * a row the mid-session sweep gave up on was still a turn the user was owed
+ * an answer for. Omitting it would silently drop the resume.
  *
  * This is the resume gate. Keying on the *latest* turn (not "latest
  * interrupted turn anywhere in history") is deliberate: once the agent

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -17,7 +17,7 @@
  *     thread_id             TEXT              -- nullable: forum topics only
  *     started_at            INTEGER NOT NULL  -- unix ms
  *     ended_at              INTEGER           -- nullable until turn ends
- *     ended_via             TEXT              -- 'stop' | 'sigterm' | 'restart' | 'timeout' | 'unknown'
+ *     ended_via             TEXT              -- 'stop'|'sigterm'|'restart'|'reaped_stale'|'timeout'|'unknown'
  *     last_assistant_msg_id TEXT              -- last outbound message_id in this turn
  *     last_assistant_done   INTEGER           -- 0|1; 1 = stream_reply done=true sent
  *     last_user_msg_id      TEXT              -- inbound message_id that started the turn
@@ -84,7 +84,26 @@ function loadDatabaseClass(): SqliteDatabaseConstructor {
 // Types
 // ---------------------------------------------------------------------------
 
-export type TurnEndedVia = 'stop' | 'sigterm' | 'restart' | 'timeout' | 'unknown'
+/**
+ * How a turn stopped being open.
+ *
+ * `'reaped_stale'` (#3555) is distinct from `'restart'` on purpose. The
+ * mid-session sweep (`reapStaleOpenTurns`) used to stamp `'restart'`, which
+ * made every restart-derived statistic unusable: 1055 rows on one host, 967
+ * of them (91.7%) clustered at 15-19 min — the signature of the 15-min
+ * `MID_SESSION_CARD_REAPER_TTL_MS` on a 5-min sweep, NOT of gateway
+ * restarts (the same window's log holds exactly ONE `[supervise] gateway
+ * exited`). Behaviourally the two are identical — both are clean interrupts,
+ * both are in `INTERRUPTED_VIA`, both map to a `'resume'` — but they are now
+ * separable in the data.
+ */
+export type TurnEndedVia =
+  | 'stop'
+  | 'sigterm'
+  | 'restart'
+  | 'reaped_stale'
+  | 'timeout'
+  | 'unknown'
 
 export interface Turn {
   turn_key: string
@@ -554,7 +573,7 @@ export interface ReapStaleOpenTurnsOpts {
 }
 
 export interface ReapStaleOpenTurnsResult {
-  /** Rows stamped `ended_via='restart'` by this sweep. */
+  /** Rows stamped `ended_via='reaped_stale'` by this sweep (#3555). */
   reaped: number
   /** The turn_keys that were stamped, for logging / card finalization. */
   reapedTurnKeys: string[]
@@ -568,15 +587,19 @@ export interface ReapStaleOpenTurnsResult {
  * leaves its row `ended_at IS NULL`, and its activity card keeps spinning
  * until the NEXT gateway boot (often many hours later). This sweep runs on a
  * periodic timer inside the live gateway and stamps those ownerless open rows
- * `ended_via='restart'` (the same clean-interrupt classification the boot
- * reaper uses for a non-hung orphan) so the stale card can be finalized
- * without waiting for a restart.
+ * so the stale card can be finalized without waiting for a restart.
  *
  * CORRECTNESS: only rows that are BOTH (a) not owned by any live turn
  * (`turn_key ∉ activeTurnKeys`) AND (b) older than `ttlMs` are swept. A
  * healthy in-flight turn — however long it runs — is always in
- * `activeTurnKeys` and is never touched. Never invents a new state; reuses
- * `'restart'` so the existing resume/report policy applies unchanged.
+ * `activeTurnKeys` and is never touched.
+ *
+ * #3555: this used to stamp `'restart'`, borrowing the boot reaper's
+ * classification. That was a lie in the data — nothing here restarted; the
+ * sweep merely gave up on a row after `ttlMs`. It stamps `'reaped_stale'`
+ * now. `'reaped_stale'` is a member of `INTERRUPTED_VIA` and maps to the
+ * same `'resume'` in `selectResumeBuilder`, so the resume/report policy is
+ * byte-for-byte unchanged; only the forensic label differs.
  */
 export function reapStaleOpenTurns(
   db: SqliteDatabase,
@@ -594,7 +617,7 @@ export function reapStaleOpenTurns(
   const stamp = db.prepare(`
     UPDATE turns
     SET ended_at   = ?,
-        ended_via  = 'restart',
+        ended_via  = 'reaped_stale',
         updated_at = ?
     WHERE turn_key = ? AND ended_at IS NULL
   `)
@@ -688,6 +711,7 @@ export function listTurnsForAgent(
 /** ended_via values that mean "this turn did not finish on its own". */
 const INTERRUPTED_VIA: ReadonlySet<TurnEndedVia> = new Set<TurnEndedVia>([
   'restart',
+  'reaped_stale', // #3555 — same clean-interrupt semantics, honest label
   'sigterm',
   'timeout',
   'unknown',

--- a/telegram-plugin/tests/registry-turns.test.ts
+++ b/telegram-plugin/tests/registry-turns.test.ts
@@ -462,6 +462,19 @@ describe('findLatestTurnIfInterrupted', () => {
     db.close()
   })
 
+  it("returns a reaped_stale-stamped turn as interrupted (#3555 — the rename must not drop resume)", () => {
+    // If 'reaped_stale' were left out of INTERRUPTED_VIA, the honest label
+    // would silently cost the user their resume — the exact regression the
+    // rename must not cause.
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'rs:1', chatId: 'rs' })
+    recordTurnEnd(db, { turnKey: 'rs:1', endedVia: 'reaped_stale' })
+    const t = findLatestTurnIfInterrupted(db)
+    expect(t).not.toBeNull()
+    expect(t!.ended_via).toBe('reaped_stale')
+    db.close()
+  })
+
   it('returns a restart-stamped turn as interrupted', () => {
     const db = openTurnsDbInMemory()
     recordTurnStart(db, { turnKey: 'bbb:1', chatId: 'bbb' })

--- a/telegram-plugin/tests/resume-inbound-builder.test.ts
+++ b/telegram-plugin/tests/resume-inbound-builder.test.ts
@@ -368,6 +368,7 @@ describe('selectResumeBuilder', () => {
   const cases: Array<[TurnEndedVia | null, 'resume' | 'report' | null]> = [
     ['timeout', 'report'],
     ['restart', 'resume'],
+    ['reaped_stale', 'resume'], // #3555 — same clean-interrupt policy as restart
     ['sigterm', 'resume'],
     ['unknown', 'resume'],
     [null, 'resume'],
@@ -393,6 +394,20 @@ describe('selectResumeBuilder', () => {
     expect(selectResumeBuilder('timeout', { ageMs: MAX + 1, maxAgeMs: MAX })).toBe('report')
     expect(selectResumeBuilder('stop', { ageMs: MAX + 1, maxAgeMs: MAX })).toBe(null)
   })
+  // #3555 — the mid-session sweep stopped mislabelling itself as 'restart'.
+  // Renaming the label must not change what the gateway DOES with the turn:
+  // 'reaped_stale' has to behave identically to 'restart' at every input.
+  it("'reaped_stale' is policy-identical to 'restart' (rename is forensic only)", () => {
+    expect(selectResumeBuilder('reaped_stale')).toBe(selectResumeBuilder('restart'))
+    expect(selectResumeBuilder('reaped_stale', { ageMs: MAX - 1, maxAgeMs: MAX }))
+      .toBe(selectResumeBuilder('restart', { ageMs: MAX - 1, maxAgeMs: MAX }))
+    expect(selectResumeBuilder('reaped_stale', { ageMs: MAX + 1, maxAgeMs: MAX }))
+      .toBe(selectResumeBuilder('restart', { ageMs: MAX + 1, maxAgeMs: MAX }))
+    // and pin the absolute values so a future change to BOTH is still caught
+    expect(selectResumeBuilder('reaped_stale')).toBe('resume')
+    expect(selectResumeBuilder('reaped_stale', { ageMs: MAX + 1, maxAgeMs: MAX })).toBe('report')
+  })
+
   it('legacy behaviour preserved when age/maxAge omitted (blanket resume)', () => {
     expect(selectResumeBuilder('restart')).toBe('resume')
     expect(selectResumeBuilder('restart', { ageMs: MAX + 1 })).toBe('resume') // needs BOTH to cap


### PR DESCRIPTION
Third of the gateway-group PRs. (#3552 + #3551 are in #3575.)

## The bug

`reapStaleOpenTurns` (`telegram-plugin/registry/turns-schema.ts:604`) hard-coded `ended_via='restart'` in its UPDATE. Nothing restarts in that path — the periodic mid-session sweep simply gives up on an ownerless open row once it ages past `MID_SESSION_CARD_REAPER_TTL_MS` (`telegram-plugin/gateway/gateway.ts:8834`, 15 min) on a 5-min sweep, so the stale activity card can be finalized without waiting for a real restart.

The comment even said so out loud: *"Never invents a new state; reuses `'restart'` so the existing resume/report policy applies unchanged."* Reusing the value to inherit the policy was reasonable; writing it into a forensic column was not.

## ⚠️ The column is contaminated — re-derive anything computed from it

Every statistic anyone has ever computed from `ended_via='restart'` mixes real restarts with mid-session reaps and needs re-deriving. Evidence from one host:

- **1055** `ended_via='restart'` rows (the number in the issue, 851, is low — corrected during validation).
- **967 of 1055 (91.7%)** fall in a **15-19 minute** band — exactly the signature of a 15-min TTL sampled by a 5-min sweep. Restarts have no reason to cluster there.
- The same window's rotated log contains exactly **one** `[supervise] gateway exited`, against **192** rows for that agent.
- **663** `mid-session reaper stamped` log lines account for **3927** stamped turns, with turn_keys matching the DB rows exactly.

Rows written before this lands cannot be reclassified retroactively (the label is all that was stored), but the 15-19 min band plus the reaper log lines identify most of them.

## The fix

`'reaped_stale'` added to `TurnEndedVia` (`turns-schema.ts:87`) and stamped by `reapStaleOpenTurns` (`:620`). The boot-time reaper's own `'restart'` stamp (`:525`) is **untouched** — that one is genuine.

**Behaviour is unchanged. This is a forensic rename, not a policy change.** I checked every consumer of the column before touching it; only two branch on `'restart'`, and both were updated to treat the new value identically:

- `INTERRUPTED_VIA` (`turns-schema.ts:713`) — `'reaped_stale'` added, so `findLatestTurnIfInterrupted` still returns these turns and the user still gets their resume. Omitting it would have quietly traded an honest label for a lost resume, which is the one regression this change could plausibly cause.
- `selectResumeBuilder` (`telegram-plugin/gateway/resume-inbound-builder.ts:479`) — maps to `'resume'` alongside `'restart'`, including under the 3h staleness downgrade to `'report'`.

Nothing else reads the value (the remaining `?? 'restart'` sites in `resume-inbound-builder.ts` are defaults for a *null* `ended_via`, i.e. still-open at boot, and are unaffected). The reaper's log line in `gateway.ts:8892` now says `'reaped_stale'` too, so the logs and the DB agree.

## Tests

- `telegram-plugin/registry/turns-schema.test.ts` — the sweep asserts `'reaped_stale'` **and** explicitly `not.toBe('restart')`.
- `telegram-plugin/tests/registry-turns.test.ts` (+1) — a `reaped_stale`-stamped turn is still returned by `findLatestTurnIfInterrupted`; this is the test that would catch the lost-resume regression.
- `telegram-plugin/tests/resume-inbound-builder.test.ts` (+2) — `'reaped_stale'` added to the policy table, plus a parity test asserting `selectResumeBuilder('reaped_stale')` equals `selectResumeBuilder('restart')` at every input (bare, within `maxAgeMs`, and past it), with the absolute values pinned as well so a future change to *both* is still caught.

Mutation-verified individually: reverting the stamp to `'restart'` fails 2; dropping `'reaped_stale'` from `INTERRUPTED_VIA` fails 1; dropping it from `selectResumeBuilder` fails 2. `bun test` on all four affected files: 127 pass / 0 fail. `npm run lint` clean.

Refs #3555


---

## ⚠️ Deployment: no rollback past this version once shipped

This change is **forward-compatible but not backward-compatible**, and that needs to be visible before the next fleet rollout (review finding F2).

Once a gateway carrying this PR runs, its mid-session sweep starts writing `ended_via='reaped_stale'`. A **pre-#3555 binary** does not know that value: its `INTERRUPTED_VIA` excludes it and its `selectResumeBuilder` matches no branch, so it classifies the row as cleanly finished. The user's interrupted turn is then **silently dropped** — no resume, no report.

With a 15-minute reaper TTL on a 5-minute sweep, freshly-stamped rows are common, so the exposure window is real rather than theoretical. **Roll forward to fix; do not downgrade.** The warning is also in `CHANGELOG.md` under Unreleased.

No schema migration is needed — `ended_via` is bare `TEXT` with no CHECK constraint.

## Follow-ups from review (addressed)

- **F1** — `findLatestTurnIfInterrupted`'s docstring (`turns-schema.ts:808`) still listed `{restart, sigterm, timeout, unknown}`. It now names `reaped_stale` and points at `INTERRUPTED_VIA`, with the reason it must be a member.
- **F2** — the rollback hazard above, in both the CHANGELOG and this body.
