### PR TITLE
fix(gateway): retire the per-represent obligation grace once its turn has ended (#3550)

### DIFF
--- a/telegram-plugin/gateway/obligation-ledger.ts
+++ b/telegram-plugin/gateway/obligation-ledger.ts
@@ -242,6 +242,10 @@ export class ObligationLedger {
    * since `lastRepresentedAt`. Without this, the 5s sweep can fire again before
    * the re-presented turn even reaches the agent, burning the represent budget
    * immediately and producing back-to-back escalations on the same message.
+   * #3550: this window is retired early once a turn that started after the
+   * re-present has ENDED — at that point the trailing-answer grace above is the
+   * one covering the real risk, and holding the rest of the represent window is
+   * pure latency. See `representGraceStillProtecting`.
    */
   decideAtIdle(opts?: {
     now: number
@@ -267,6 +271,46 @@ export class ObligationLedger {
     return { action: 'represent', obligation: o }
   }
 
+  /**
+   * #3550 — is the per-represent grace still doing real work for this
+   * obligation? Pure so the rule is testable in isolation.
+   *
+   * The per-represent grace exists for ONE reason, stated at its definition:
+   * "the 5s sweep can fire again before the re-presented turn even reaches the
+   * agent". It is a proxy for "the re-present has not landed yet". Once a turn
+   * that started AFTER the re-present has ENDED, the proxy is spent — the
+   * re-present demonstrably reached the agent, the agent ran a whole turn on
+   * it, and that turn is over. Holding the remaining ~110s of a 120s window
+   * open at that point delays the next rung of a ladder that is already
+   * bounded by `maxRepresents`, for no protective benefit.
+   *
+   * The obligation is NOT released into the void when this returns false: the
+   * trailing-answer grace (`trailingGraceMs` from `lastTurnEndedAt`, 45s by
+   * default) is a separate, independently-evaluated window that covers exactly
+   * the risk that matters here — a slow answer still landing after its turn
+   * ended. So the early-out only applies when that grace is actually armed
+   * (`trailingGraceMs > 0`); with it disabled, the represent grace stays the
+   * full window rather than leaving the obligation ungated.
+   *
+   * A re-present with NO ended turn after it — the genuinely in-flight case
+   * the grace was written for — is untouched and keeps the full window.
+   */
+  static representGraceStillProtecting(
+    o: Pick<Obligation, 'lastRepresentedAt' | 'lastTurnEndedAt'>,
+    now: number,
+    representGraceMs: number,
+    trailingGraceMs: number,
+  ): boolean {
+    if (representGraceMs <= 0) return false
+    if (o.lastRepresentedAt == null) return false
+    if (now - o.lastRepresentedAt >= representGraceMs) return false
+    // Inside the window. Is it still protecting anything?
+    const representTurnEnded =
+      o.lastTurnEndedAt != null && o.lastTurnEndedAt > o.lastRepresentedAt
+    if (representTurnEnded && trailingGraceMs > 0) return false // spent — trailing grace takes over
+    return true
+  }
+
   /** The oldest open obligation that is currently ELIGIBLE to act on — i.e. NOT
    *  within any grace window:
    *   - trailing-answer grace: its handling turn ended < `graceMs` ago (a queued
@@ -275,9 +319,11 @@ export class ObligationLedger {
    *   - background-work grace: when `backgroundWorkActive`, it was opened <
    *     `backgroundGraceMs` ago (genuine in-flight autonomous work — bounded by
    *     the ceiling so a stale/leaked worker can't suppress escalation forever);
-   *   - per-represent grace: it was re-presented < `representGraceMs` ago (prevents
-   *     a 5s sweep tick from immediately firing again on the same obligation before
-   *     the re-presented turn even reaches the agent). */
+   *   - per-represent grace: it was re-presented < `representGraceMs` ago AND that
+   *     re-present has not yet produced a completed turn (prevents a 5s sweep tick
+   *     from immediately firing again before the re-presented turn even reaches the
+   *     agent — see `representGraceStillProtecting` for why a turn that has already
+   *     ended retires this window early, #3550). */
   private oldestEligible(
     now: number,
     graceMs: number,
@@ -290,7 +336,7 @@ export class ObligationLedger {
       if (o.lastTurnEndedAt != null && now - o.lastTurnEndedAt < graceMs) continue // trailing-answer grace
       if (backgroundWorkActive && backgroundGraceMs > 0 && now - o.openedAt < backgroundGraceMs)
         continue // in-flight autonomous work, bounded by the ceiling
-      if (representGraceMs > 0 && o.lastRepresentedAt != null && now - o.lastRepresentedAt < representGraceMs)
+      if (ObligationLedger.representGraceStillProtecting(o, now, representGraceMs, graceMs))
         continue // per-represent grace: sweep fired before re-presented turn landed
       if (best === undefined || o.openedAt < best.openedAt) best = o
     }

--- a/telegram-plugin/gateway/obligation-ledger.ts
+++ b/telegram-plugin/gateway/obligation-ledger.ts
@@ -294,6 +294,21 @@ export class ObligationLedger {
    *
    * A re-present with NO ended turn after it — the genuinely in-flight case
    * the grace was written for — is untouched and keeps the full window.
+   *
+   * FLOOR (`MIN_REPRESENT_INTERVAL_MS`). Retiring the represent window makes the
+   * rung interval DERIVED — `trailingGraceMs + the represent-turn's duration`
+   * — where it used to be floored by the flat 120s window regardless of how the
+   * trailing grace was tuned. Without a floor,
+   * `SWITCHROOM_OBLIGATION_ESCALATE_GRACE_MS=1000` (a plausible "make it
+   * snappier" tune) collapses the whole ladder to ~1s+d per rung and escalates
+   * to the operator within ~15-20s of the original message. That is a config
+   * footgun the old code could not have, so it is closed by a MECHANISM, not a
+   * doc warning: the early-out is withheld until at least
+   * `min(representGraceMs, max(trailingGraceMs, MIN_REPRESENT_INTERVAL_MS))`
+   * has elapsed since the re-present. At the defaults (45s trailing / 120s
+   * represent) the floor is 45s and never binds — the trailing grace, measured
+   * from the strictly-later turn end, always expires after it — so this changes
+   * nothing in the shipped configuration.
    */
   static representGraceStillProtecting(
     o: Pick<Obligation, 'lastRepresentedAt' | 'lastTurnEndedAt'>,
@@ -303,13 +318,32 @@ export class ObligationLedger {
   ): boolean {
     if (representGraceMs <= 0) return false
     if (o.lastRepresentedAt == null) return false
-    if (now - o.lastRepresentedAt >= representGraceMs) return false
+    const sinceRepresent = now - o.lastRepresentedAt
+    if (sinceRepresent >= representGraceMs) return false
     // Inside the window. Is it still protecting anything?
     const representTurnEnded =
       o.lastTurnEndedAt != null && o.lastTurnEndedAt > o.lastRepresentedAt
-    if (representTurnEnded && trailingGraceMs > 0) return false // spent — trailing grace takes over
+    if (representTurnEnded && trailingGraceMs > 0) {
+      // Spent — the trailing grace takes over, but never sooner than the floor
+      // (and never longer than the represent window the operator configured).
+      const floorMs = Math.min(
+        representGraceMs,
+        Math.max(trailingGraceMs, ObligationLedger.MIN_REPRESENT_INTERVAL_MS),
+      )
+      return sinceRepresent < floorMs
+    }
     return true
   }
+
+  /**
+   * The hard floor on the interval between two rungs of the represent ladder,
+   * used by `representGraceStillProtecting`. Independent of how the trailing
+   * grace is tuned, an obligation is never acted on again within this long of
+   * its own re-present. 30s comfortably exceeds the 5s sweep tick and the
+   * round-trip for a re-presented turn to reach the agent and answer, which is
+   * the only thing the represent window was ever debouncing.
+   */
+  static readonly MIN_REPRESENT_INTERVAL_MS = 30_000
 
   /** The oldest open obligation that is currently ELIGIBLE to act on — i.e. NOT
    *  within any grace window:

--- a/telegram-plugin/tests/obligation-determinism.test.ts
+++ b/telegram-plugin/tests/obligation-determinism.test.ts
@@ -95,6 +95,10 @@ function runSchedule(
   graceMs = 0,
   bgGraceMs = 0,
   bgAlwaysActive = false,
+  // #3550 — per-represent grace. Exercised so the determinism proof actually
+  // reaches `representGraceStillProtecting`; without this the fuzz never passes
+  // representGraceMs and the branch is unvisited.
+  representGraceMs = 0,
 ): Sim {
   const PATH = "/state/agent/telegram/obligations.json";
   const store = memStore();
@@ -107,6 +111,7 @@ function runSchedule(
   // terminal (no livelock).
   let clock = 1_000_000;
   const SWEEP_TICK = 5_000;
+  const TURN_DURATION = 1_000; // virtual ms a turn occupies before it ends
   const r = rng(seed);
 
   const pending = [...msgs]; // not yet received
@@ -130,7 +135,12 @@ function runSchedule(
     turnsHad.set(id, had + 1);
     if (byId.get(id)!.answerOnAttempt === attemptIndex) {
       close(id, "answered");
-    } else if (graceMs > 0 && ledger.isOpen(id)) {
+    } else if ((graceMs > 0 || representGraceMs > 0) && ledger.isOpen(id)) {
+      // A turn takes real time: its end is strictly LATER than the represent
+      // that triggered it. Without this the sim stamps lastTurnEndedAt equal to
+      // lastRepresentedAt and the #3550 early-out (which requires strictly
+      // greater) is never reached — the branch would go unproven.
+      clock += TURN_DURATION;
       ledger.noteTurnEnded(id, clock);
     }
   };
@@ -163,12 +173,13 @@ function runSchedule(
       deliverTurn(m.id); // original turn (attempt 0)
     } else if (open) {
       const decision =
-        graceMs > 0 || bgGraceMs > 0
+        graceMs > 0 || bgGraceMs > 0 || representGraceMs > 0
           ? ledger.decideAtIdle({
               now: clock,
               graceMs,
               backgroundWorkActive: bgGraceMs > 0 && bgAlwaysActive,
               backgroundGraceMs: bgGraceMs,
+              representGraceMs,
             })
           : ledger.decideAtIdle();
       if (decision.action === "none") {
@@ -181,7 +192,10 @@ function runSchedule(
       // INVARIANT (no double-ask): a terminated obligation must never resurface.
       expect(terminals.has(o.originTurnId)).toBe(false);
       if (decision.action === "represent") {
-        ledger.markRepresented(o.originTurnId);
+        // Stamp on the SAME virtual clock as noteTurnEnded, otherwise the
+        // per-represent window is measured against a wall-clock `Date.now()`
+        // default and never interacts with the grace under test.
+        ledger.markRepresented(o.originTurnId, clock);
         deliverTurn(o.originTurnId); // the re-present turn
       } else if (decision.action === "escalate") {
         if (ESC_IN_FLIGHT.has(o.originTurnId)) continue;
@@ -329,6 +343,54 @@ describe("obligation determinism — every inbound reaches a terminal, no silent
       for (const m of msgs) {
         const t = terminals.get(m.id);
         expect(t, `bg seed=${seed} msg=${m.id} answer=${m.answerOnAttempt} escFail=${m.escalateFailsFor}`).toBeDefined();
+        if (m.answerOnAttempt <= MAX_REPRESENTS) {
+          expect(t).toBe("answered");
+        } else if (m.escalateFailsFor < ESCALATE_MAX) {
+          expect(t).toBe("escalation-delivered");
+        } else {
+          expect(t).toBe("escalation-give-up");
+        }
+      }
+    }
+  });
+
+  it("holds across 3000 schedules WITH the per-represent grace on (#3550 — the retire-early branch never loses a terminal)", () => {
+    // #3550 added an early-out to the per-represent grace: the window is retired
+    // once a turn that started after the re-present has ENDED. This case exists
+    // because the other three fuzz proofs never pass `representGraceMs` at all,
+    // so none of them reach that branch — and a claim of fuzz coverage for the
+    // #3550 diff would be vacuous without it.
+    //
+    // In this schedule EVERY non-answering turn stamps noteTurnEnded after its
+    // re-present, so the early-out fires on essentially every rung — i.e. this
+    // exercises the changed branch densely rather than incidentally. The
+    // terminal each message reaches must still be IDENTICAL to the no-grace
+    // run: the early-out may only change WHEN the ladder advances, never WHERE
+    // it lands.
+    const ANSWER = [0, 1, 2, 3, 99];
+    const ESCFAIL = [0, 1, 2, 3, 5];
+    const GRACE_MS = 45_000;       // trailing-answer grace, still armed
+    const REPR_GRACE_MS = 120_000; // mirrors OBLIGATION_REPRESENT_GRACE_MS default
+    for (let seed = 1; seed <= 3000; seed++) {
+      const r = rng(seed * 7919);
+      const n = 1 + Math.floor(r() * 5);
+      const msgs: Msg[] = [];
+      for (let i = 0; i < n; i++) {
+        const msgId = seed * 100 + i;
+        msgs.push({
+          id: `c:3#${msgId}`,
+          msgId,
+          answerOnAttempt: pick(ANSWER, r),
+          escalateFailsFor: pick(ESCFAIL, r),
+        });
+      }
+      const { terminals, steps } = runSchedule(
+        msgs, seed * 104729, GRACE_MS, 0, false, REPR_GRACE_MS,
+      );
+      expect(steps).toBeLessThan(10_000); // no represent-grace livelock
+      for (const m of msgs) {
+        const t = terminals.get(m.id);
+        expect(t, `repr seed=${seed} msg=${m.id} answer=${m.answerOnAttempt} escFail=${m.escalateFailsFor}`).toBeDefined();
         if (m.answerOnAttempt <= MAX_REPRESENTS) {
           expect(t).toBe("answered");
         } else if (m.escalateFailsFor < ESCALATE_MAX) {

--- a/telegram-plugin/tests/obligation-determinism.test.ts
+++ b/telegram-plugin/tests/obligation-determinism.test.ts
@@ -99,6 +99,12 @@ function runSchedule(
   // reaches `representGraceStillProtecting`; without this the fuzz never passes
   // representGraceMs and the branch is unvisited.
   representGraceMs = 0,
+  // #3550 discriminator knob. When FALSE, a re-present turn ends WITHOUT ever
+  // stamping noteTurnEnded — the "re-present still in flight" shape, in which
+  // the early-out provably cannot fire and the full represent window is held.
+  // Running the same seed both ways is what turns the represent-grace case from
+  // a code-path exercise into a test that FAILS if the early-out is removed.
+  stampTurnEndAfterRepresent = true,
 ): Sim {
   const PATH = "/state/agent/telegram/obligations.json";
   const store = memStore();
@@ -133,8 +139,14 @@ function runSchedule(
     const had = (turnsHad.get(id) ?? 0);
     const attemptIndex = had; // 0-based
     turnsHad.set(id, had + 1);
+    const isRepresentTurn = attemptIndex > 0;
     if (byId.get(id)!.answerOnAttempt === attemptIndex) {
       close(id, "answered");
+    } else if (isRepresentTurn && !stampTurnEndAfterRepresent) {
+      // In-flight shape: the turn produced nothing observable, so nothing is
+      // stamped and the per-represent window is held for its full duration.
+      // (Deliberately NOT advancing the clock either — the two runs must differ
+      // only in whether the early-out can fire.)
     } else if ((graceMs > 0 || representGraceMs > 0) && ledger.isOpen(id)) {
       // A turn takes real time: its end is strictly LATER than the represent
       // that triggered it. Without this the sim stamps lastTurnEndedAt equal to
@@ -354,23 +366,33 @@ describe("obligation determinism — every inbound reaches a terminal, no silent
     }
   });
 
-  it("holds across 3000 schedules WITH the per-represent grace on (#3550 — the retire-early branch never loses a terminal)", () => {
-    // #3550 added an early-out to the per-represent grace: the window is retired
-    // once a turn that started after the re-present has ENDED. This case exists
-    // because the other three fuzz proofs never pass `representGraceMs` at all,
-    // so none of them reach that branch — and a claim of fuzz coverage for the
-    // #3550 diff would be vacuous without it.
+  it("holds across 3000 schedules WITH the per-represent grace on, and the #3550 early-out DISCRIMINATES (same terminals, strictly fewer sweeps)", () => {
+    // Honest framing of what this case is and is not.
     //
-    // In this schedule EVERY non-answering turn stamps noteTurnEnded after its
-    // re-present, so the early-out fires on essentially every rung — i.e. this
-    // exercises the changed branch densely rather than incidentally. The
-    // terminal each message reaches must still be IDENTICAL to the no-grace
-    // run: the early-out may only change WHEN the ladder advances, never WHERE
-    // it lands.
+    // The terminal assertions below are NOT a discriminator for the #3550 diff:
+    // a terminal is a function of `answerOnAttempt` / `escalateFailsFor` alone,
+    // and the worst-case schedule settles in ~72 sweep steps against a CAP of
+    // 10_000. Revert the early-out and every terminal — and the step budget —
+    // still holds. Those assertions are a NO-LIVELOCK / NO-LOSS guard on the
+    // represent-grace path, nothing more, and are labelled as such.
+    //
+    // The discriminator is the paired run. The SAME seed is run twice, differing
+    // in exactly one thing: whether a re-present turn ends (stamping
+    // noteTurnEnded) or stays in flight. The early-out fires only in the first,
+    // so:
+    //   - terminals must be IDENTICAL — the early-out changes WHEN the ladder
+    //     advances, never WHERE it lands; and
+    //   - the ended-turn run must take STRICTLY FEWER sweep steps — which is
+    //     the early-out actually firing and shortening rungs. Delete the
+    //     early-out and both runs hold the full 120s window, the step counts
+    //     become equal, and this assertion fails.
     const ANSWER = [0, 1, 2, 3, 99];
     const ESCFAIL = [0, 1, 2, 3, 5];
     const GRACE_MS = 45_000;       // trailing-answer grace, still armed
     const REPR_GRACE_MS = 120_000; // mirrors OBLIGATION_REPRESENT_GRACE_MS default
+    let discriminated = 0; // schedules the early-out demonstrably shortened
+    let totalRetired = 0;
+    let totalInFlight = 0;
     for (let seed = 1; seed <= 3000; seed++) {
       const r = rng(seed * 7919);
       const n = 1 + Math.floor(r() * 5);
@@ -384,12 +406,14 @@ describe("obligation determinism — every inbound reaches a terminal, no silent
           escalateFailsFor: pick(ESCFAIL, r),
         });
       }
-      const { terminals, steps } = runSchedule(
-        msgs, seed * 104729, GRACE_MS, 0, false, REPR_GRACE_MS,
-      );
-      expect(steps).toBeLessThan(10_000); // no represent-grace livelock
+      const retired = runSchedule(msgs, seed * 104729, GRACE_MS, 0, false, REPR_GRACE_MS, true);
+      const inFlight = runSchedule(msgs, seed * 104729, GRACE_MS, 0, false, REPR_GRACE_MS, false);
+
+      // No-livelock / no-loss guard (NOT the #3550 discriminator).
+      expect(retired.steps).toBeLessThan(10_000);
+      expect(inFlight.steps).toBeLessThan(10_000);
       for (const m of msgs) {
-        const t = terminals.get(m.id);
+        const t = retired.terminals.get(m.id);
         expect(t, `repr seed=${seed} msg=${m.id} answer=${m.answerOnAttempt} escFail=${m.escalateFailsFor}`).toBeDefined();
         if (m.answerOnAttempt <= MAX_REPRESENTS) {
           expect(t).toBe("answered");
@@ -399,7 +423,32 @@ describe("obligation determinism — every inbound reaches a terminal, no silent
           expect(t).toBe("escalation-give-up");
         }
       }
+
+      // DISCRIMINATOR 1 — the early-out is terminal-neutral.
+      expect(
+        [...retired.terminals].sort(),
+        `terminals diverged at seed=${seed}`,
+      ).toEqual([...inFlight.terminals].sort());
+
+      // DISCRIMINATOR 2 — the early-out actually fires and shortens rungs.
+      // Directional per seed (retiring a grace can never ADD sweeps)…
+      expect(
+        retired.steps,
+        `early-out LENGTHENED seed=${seed} (retired=${retired.steps} inFlight=${inFlight.steps})`,
+      ).toBeLessThanOrEqual(inFlight.steps);
+      // …and strictly shorter on the schedules that actually sit out a rung.
+      // Not every schedule does: with several messages interleaved, other work
+      // can advance the virtual clock past the window with no waiting sweep, so
+      // the strict inequality is asserted in aggregate rather than per seed.
+      if (retired.steps < inFlight.steps) discriminated++;
+      totalRetired += retired.steps;
+      totalInFlight += inFlight.steps;
     }
+    // Delete the early-out and BOTH runs hold the full 120s window: every seed
+    // becomes equal, `discriminated` drops to 0 and the totals converge. These
+    // two assertions are what make this case a real test of the #3550 diff.
+    expect(discriminated, "the #3550 early-out never shortened a single schedule").toBeGreaterThan(1_000);
+    expect(totalRetired).toBeLessThan(totalInFlight);
   });
 
   it("a delivered-but-unanswered obligation survives a restart and is escalated, not lost", () => {

--- a/telegram-plugin/tests/obligation-ledger.test.ts
+++ b/telegram-plugin/tests/obligation-ledger.test.ts
@@ -5,6 +5,7 @@ import {
   obligationEscalationText,
   type Obligation,
 } from "../gateway/obligation-ledger.js";
+import { deriveTurnId } from "../gateway/derive-turn-id.js";
 
 function input(id: string, openedAt: number, text = "do the thing") {
   return { originTurnId: id, chatId: "-100123", threadId: 3, messageId: Number(id.split("#").pop() ?? 0), text, openedAt };
@@ -732,5 +733,60 @@ describe("ObligationLedger — #3550: the represent grace retires once its turn 
     expect(P({}, 6_000, REPR_GRACE, TRAIL)).toBe(false);
     // trailing grace disabled → the early-out is withheld
     expect(P({ lastRepresentedAt: 5_000, lastTurnEndedAt: 6_000 }, 10_000, REPR_GRACE, 0)).toBe(true);
+  });
+});
+
+describe("#3550 G2 — the seam that makes noteTurnEnded actually fire in production", () => {
+  // Every other #3550 test calls noteTurnEnded() directly, so they prove the
+  // LEDGER RULE but not the WIRING. In production the stamp only lands because
+  // the represent inbound round-trips back to the same key: the gateway builds
+  // the inbound from the obligation, and the turn it spawns derives its turn id
+  // from that inbound's chat/thread/message. noteTurnEnded is a keyed lookup —
+  // if `deriveTurnId(buildObligationRepresentInbound(o)) !== o.originTurnId` it
+  // silently no-ops, this entire fix goes dead in the field, and every other
+  // test in this file still passes green. That linkage was asserted only by a
+  // comment at obligation-wiring.ts:250-256. This pins it.
+  function obligationFor(chatId: string, threadId: number | undefined, messageId: number) {
+    const L = new ObligationLedger(2);
+    const originTurnId = deriveTurnId(chatId, threadId ?? null, messageId)!;
+    L.openIfAbsent({ originTurnId, chatId, threadId, messageId, text: "do the thing", openedAt: 0 });
+    return L.list()[0];
+  }
+
+  const cases: Array<[string, string, number | undefined, number]> = [
+    ["forum topic", "-100123", 3, 715],
+    ["DM (no thread)", "12345", undefined, 42],
+    ["general topic id 1", "-100999", 1, 8],
+  ];
+
+  for (const [label, chatId, threadId, messageId] of cases) {
+    it(`round-trips the origin id through the represent inbound — ${label}`, () => {
+      const o = obligationFor(chatId, threadId, messageId);
+      const inbound = buildObligationRepresentInbound(o, 1_000);
+      const derived = deriveTurnId(inbound.chatId, inbound.threadId ?? null, inbound.messageId);
+      expect(derived).toBe(o.originTurnId);
+    });
+  }
+
+  it("a represent-spawned turn's derived key actually reaches noteTurnEnded (end-to-end on the real seam)", () => {
+    const L = new ObligationLedger(2);
+    const originTurnId = deriveTurnId("-100123", 3, 715)!;
+    L.openIfAbsent({ originTurnId, chatId: "-100123", threadId: 3, messageId: 715, text: "x", openedAt: 0 });
+    L.markRepresented(originTurnId, 5_000);
+    // Stamp using ONLY what a represent-spawned turn would know: the inbound.
+    const inbound = buildObligationRepresentInbound(L.list()[0], 5_000);
+    const turnKey = deriveTurnId(inbound.chatId, inbound.threadId ?? null, inbound.messageId)!;
+    L.noteTurnEnded(turnKey, 15_000);
+    // If the seam drifted, noteTurnEnded no-ops, lastTurnEndedAt stays undefined,
+    // the #3550 early-out never fires, and this stays "none" until t=125_000.
+    expect(L.list()[0].lastTurnEndedAt).toBe(15_000);
+    expect(
+      L.decideAtIdle({ now: 15_000 + 45_000 + 1, graceMs: 45_000, representGraceMs: 120_000 }).action,
+    ).toBe("represent");
+  });
+
+  it("the represent inbound also echoes origin_turn_id in meta (the close-side half of the same seam)", () => {
+    const o = obligationFor("-100123", 3, 715);
+    expect(buildObligationRepresentInbound(o, 1_000).meta?.origin_turn_id).toBe(o.originTurnId);
   });
 });

--- a/telegram-plugin/tests/obligation-ledger.test.ts
+++ b/telegram-plugin/tests/obligation-ledger.test.ts
@@ -722,8 +722,10 @@ describe("ObligationLedger — #3550: the represent grace retires once its turn 
     const P = ObligationLedger.representGraceStillProtecting;
     // in-flight re-present, inside window → still protecting
     expect(P({ lastRepresentedAt: 5_000 }, 10_000, REPR_GRACE, TRAIL)).toBe(true);
-    // turn ended after the re-present → spent
-    expect(P({ lastRepresentedAt: 5_000, lastTurnEndedAt: 6_000 }, 10_000, REPR_GRACE, TRAIL)).toBe(false);
+    // turn ended after the re-present, but still inside the floor → protecting
+    expect(P({ lastRepresentedAt: 5_000, lastTurnEndedAt: 6_000 }, 10_000, REPR_GRACE, TRAIL)).toBe(true);
+    // turn ended after the re-present, past the floor → spent
+    expect(P({ lastRepresentedAt: 5_000, lastTurnEndedAt: 6_000 }, 5_000 + TRAIL, REPR_GRACE, TRAIL)).toBe(false);
     // turn ended BEFORE the re-present → irrelevant, still protecting
     expect(P({ lastRepresentedAt: 5_000, lastTurnEndedAt: 4_000 }, 10_000, REPR_GRACE, TRAIL)).toBe(true);
     // window already elapsed → not protecting either way
@@ -733,6 +735,184 @@ describe("ObligationLedger — #3550: the represent grace retires once its turn 
     expect(P({}, 6_000, REPR_GRACE, TRAIL)).toBe(false);
     // trailing grace disabled → the early-out is withheld
     expect(P({ lastRepresentedAt: 5_000, lastTurnEndedAt: 6_000 }, 10_000, REPR_GRACE, 0)).toBe(true);
+  });
+
+  // ── Review finding 3: the derived rung interval needs a FLOOR ──────────────
+  // Retiring the represent window makes the rung interval derived (trailing
+  // grace + the represent-turn's duration) where the flat 120s used to floor it
+  // regardless of tuning. `MIN_REPRESENT_INTERVAL_MS` closes that footgun as a
+  // mechanism rather than a doc warning.
+  describe("MIN_REPRESENT_INTERVAL_MS floors the derived rung interval", () => {
+    const SNAPPY = 1_000; // SWITCHROOM_OBLIGATION_ESCALATE_GRACE_MS=1000
+
+    it("a small-but-non-zero trailing grace cannot collapse the ladder to seconds", () => {
+      const FLOOR = ObligationLedger.MIN_REPRESENT_INTERVAL_MS;
+      const L = new ObligationLedger(2);
+      L.openIfAbsent(input("c:3#1", 0));
+      L.markRepresented("c:3#1", 5_000);
+      L.noteTurnEnded("c:3#1", 6_000); // represent turn ran and ended in 1s
+      // Pre-floor this was eligible at 6_000 + 1_000 = 7_000 — 2s after the
+      // re-present. The ladder would have escalated inside ~15-20s.
+      expect(
+        L.decideAtIdle({ now: 7_000, graceMs: SNAPPY, representGraceMs: REPR_GRACE }).action,
+      ).toBe("none");
+      // Still held right up to the floor…
+      expect(
+        L.decideAtIdle({ now: 5_000 + FLOOR - 1, graceMs: SNAPPY, representGraceMs: REPR_GRACE }).action,
+      ).toBe("none");
+      // …and released at it (the floor, not the full 120s window — the #3550
+      // early-out is clamped, not reverted).
+      expect(
+        L.decideAtIdle({ now: 5_000 + FLOOR, graceMs: SNAPPY, representGraceMs: REPR_GRACE }).action,
+      ).toBe("represent");
+      expect(5_000 + FLOOR).toBeLessThan(5_000 + REPR_GRACE);
+    });
+
+    it("the floor never EXTENDS a window past the represent grace the operator configured", () => {
+      // representGraceMs below the floor: the configured window still wins, so
+      // the clamp can only ever shorten-cap, never lengthen.
+      const SHORT_REPR = 10_000;
+      expect(SHORT_REPR).toBeLessThan(ObligationLedger.MIN_REPRESENT_INTERVAL_MS);
+      const L = new ObligationLedger(2);
+      L.openIfAbsent(input("c:3#1", 0));
+      L.markRepresented("c:3#1", 5_000);
+      L.noteTurnEnded("c:3#1", 6_000);
+      expect(
+        L.decideAtIdle({ now: 5_000 + SHORT_REPR, graceMs: SNAPPY, representGraceMs: SHORT_REPR }).action,
+      ).toBe("represent");
+    });
+
+    it("at the shipped defaults the floor never binds — behaviour is unchanged", () => {
+      // 45s trailing ≥ the 30s floor, and it is measured from a turn end that is
+      // strictly LATER than the re-present, so the trailing grace always expires
+      // after the floor. The clamp is inert in the shipped configuration.
+      const P = ObligationLedger.representGraceStillProtecting;
+      for (const turnDurationMs of [1, 1_000, 10_000, 60_000]) {
+        const represented = 5_000;
+        const turnEnded = represented + turnDurationMs;
+        const eligibleAt = turnEnded + TRAIL; // what the trailing grace alone allows
+        expect(P({ lastRepresentedAt: represented, lastTurnEndedAt: turnEnded }, eligibleAt, REPR_GRACE, TRAIL)).toBe(false);
+      }
+    });
+  });
+
+  // ── Review finding 5: a turn that ended WITHOUT consuming its re-present ───
+  // `representGraceStillProtecting` retires the window on a bare timestamp
+  // comparison (`lastTurnEndedAt > lastRepresentedAt`) and the doc comment
+  // justifies that as "the agent ran a whole turn on it". The code cannot in
+  // fact distinguish a consuming turn from a turn that ended without ever
+  // seeing the re-present — a bridge-down abort, an instantly-failed turn, or
+  // one torn down by #3575's silence-poke fallback. These tests pin what the
+  // ledger ACTUALLY does in that case, so the behaviour is asserted rather than
+  // assumed by the comment.
+  describe("a turn that ends WITHOUT consuming the re-present", () => {
+    it("retires the window on the bare timestamp — but never before the floor", () => {
+      const FLOOR = ObligationLedger.MIN_REPRESENT_INTERVAL_MS;
+      const L = new ObligationLedger(2);
+      L.openIfAbsent(input("c:3#1", 0));
+      L.markRepresented("c:3#1", 5_000);
+      // A turn that died 200ms after the represent fired. It cannot have carried
+      // the re-presented text to the agent, yet it stamps lastTurnEndedAt.
+      L.noteTurnEnded("c:3#1", 5_200);
+      // The ledger treats it as spent, so the next rung is NOT held for the full
+      // 120s. It is held for max(floor, trailing-from-turn-end) instead.
+      const eligibleAt = Math.max(5_000 + FLOOR, 5_200 + TRAIL);
+      expect(
+        L.decideAtIdle({ now: eligibleAt - 1, graceMs: TRAIL, representGraceMs: REPR_GRACE }).action,
+      ).toBe("none");
+      expect(
+        L.decideAtIdle({ now: eligibleAt, graceMs: TRAIL, representGraceMs: REPR_GRACE }).action,
+      ).toBe("represent");
+      // Documented consequence: an aborted turn shortens the rung. That is
+      // SAFE-BY-DIRECTION — a turn that never consumed the re-present is a turn
+      // that never answered, so re-presenting sooner is the correct action; the
+      // cost is one rung of the (already bounded) budget spent earlier.
+      expect(eligibleAt).toBeLessThan(5_000 + REPR_GRACE);
+    });
+
+    it("burns at most maxRepresents rungs even if EVERY turn aborts instantly", () => {
+      // The worst case for the timestamp proxy: no turn ever consumes anything.
+      // Termination must still hold and the ladder must still land on escalate.
+      const FLOOR = ObligationLedger.MIN_REPRESENT_INTERVAL_MS;
+      const L = new ObligationLedger(2);
+      L.openIfAbsent(input("c:3#1", 0));
+      let now = 0;
+      const actions: string[] = [];
+      for (let i = 0; i < 5; i++) {
+        const d = L.decideAtIdle({ now, graceMs: TRAIL, representGraceMs: REPR_GRACE });
+        actions.push(d.action);
+        if (d.action === "represent") {
+          L.markRepresented("c:3#1", now);
+          L.noteTurnEnded("c:3#1", now + 200); // instant abort — nothing consumed
+          now += Math.max(FLOOR, TRAIL) + 1_000;
+        } else if (d.action === "escalate") {
+          break;
+        } else {
+          now += 5_000;
+        }
+      }
+      expect(actions.filter((a) => a === "represent")).toHaveLength(2); // maxRepresents
+      expect(actions.at(-1)).toBe("escalate");
+    });
+
+    it("a turn that ended BEFORE the re-present is still not mistaken for a consuming one", () => {
+      // The complement: only a STRICTLY later stamp retires the window, so a
+      // stale pre-represent turn end can never shorten it.
+      const L = new ObligationLedger(2);
+      L.openIfAbsent(input("c:3#1", 0));
+      L.noteTurnEnded("c:3#1", 4_999);
+      L.markRepresented("c:3#1", 5_000);
+      expect(
+        L.decideAtIdle({ now: 5_000 + REPR_GRACE - 1, graceMs: TRAIL, representGraceMs: REPR_GRACE }).action,
+      ).toBe("none");
+    });
+  });
+
+  // ── Review finding 6: the hydrated post-restart shape ──────────────────────
+  // A snapshot restored with lastTurnEndedAt > lastRepresentedAt hits the
+  // early-out on the FIRST sweep after boot. Pre-#3550 the represent window was
+  // measured from lastRepresentedAt and survived the restart, so a crash 2s
+  // after a re-present still cost 118s before the next rung.
+  describe("hydrated post-restart obligation (E1 > R1)", () => {
+    it("cannot fire on the first sweep after boot — the floor survives hydration", () => {
+      const FLOOR = ObligationLedger.MIN_REPRESENT_INTERVAL_MS;
+      const L = new ObligationLedger(2);
+      L.hydrate([
+        {
+          ...input("c:3#1", 0),
+          representCount: 1,
+          lastRepresentedAt: 100_000,
+          lastTurnEndedAt: 101_000, // the turn the crash ended
+        },
+      ]);
+      // Boot sweep, ~5s after the crash. Without the floor this is eligible at
+      // 101_000+TRAIL and, with a snappier trailing tune, immediately — racing
+      // the boot-resume inbound so the user sees the resume AND a re-present.
+      expect(
+        L.decideAtIdle({ now: 105_000, graceMs: TRAIL, representGraceMs: REPR_GRACE }).action,
+      ).toBe("none");
+      expect(
+        L.decideAtIdle({ now: 105_000, graceMs: 1_000, representGraceMs: REPR_GRACE }).action,
+      ).toBe("none");
+      // The floor is measured from the DURABLE lastRepresentedAt, so it holds
+      // across the restart rather than restarting from boot.
+      expect(
+        L.decideAtIdle({ now: 100_000 + FLOOR - 1, graceMs: 1_000, representGraceMs: REPR_GRACE }).action,
+      ).toBe("none");
+      expect(
+        L.decideAtIdle({ now: 100_000 + FLOOR, graceMs: 1_000, representGraceMs: REPR_GRACE }).action,
+      ).toBe("represent");
+    });
+
+    it("still eventually advances after a restart — the floor delays, never prevents", () => {
+      const L = new ObligationLedger(2);
+      L.hydrate([
+        { ...input("c:3#1", 0), representCount: 1, lastRepresentedAt: 100_000, lastTurnEndedAt: 101_000 },
+      ]);
+      expect(
+        L.decideAtIdle({ now: 101_000 + TRAIL, graceMs: TRAIL, representGraceMs: REPR_GRACE }).action,
+      ).toBe("represent");
+    });
   });
 });
 

--- a/telegram-plugin/tests/obligation-ledger.test.ts
+++ b/telegram-plugin/tests/obligation-ledger.test.ts
@@ -660,3 +660,77 @@ describe("ObligationLedger — noteCapturedDelivery (#3282)", () => {
     expect(L.isOpen("c:3#1")).toBe(false);
   });
 });
+
+describe("ObligationLedger — #3550: the represent grace retires once its turn has ended", () => {
+  function input(id: string, openedAt: number) {
+    return { originTurnId: id, chatId: "-100123", threadId: 3, messageId: Number(id.split("#").pop() ?? 0), text: "x", openedAt };
+  }
+  const REPR_GRACE = 120_000; // default
+  const TRAIL = 45_000;       // OBLIGATION_ESCALATE_GRACE_MS default
+
+  // The bug: the per-represent grace is a proxy for "the re-present has not
+  // landed yet". Once a turn that started after it has ENDED, the proxy is
+  // provably false, yet the obligation stayed frozen for the rest of the 120s.
+  it("acts once the trailing grace clears, instead of waiting out the full represent window", () => {
+    const L = new ObligationLedger(2);
+    L.openIfAbsent(input("c:3#1", 0));
+    L.markRepresented("c:3#1", 5_000);
+    L.noteTurnEnded("c:3#1", 15_000); // the re-presented turn ran and ended
+    const eligibleAt = 15_000 + TRAIL + 1; // trailing-answer grace from turn end
+    expect(eligibleAt).toBeLessThan(5_000 + REPR_GRACE); // i.e. this is genuinely earlier
+    expect(
+      L.decideAtIdle({ now: eligibleAt, graceMs: TRAIL, representGraceMs: REPR_GRACE }).action,
+    ).toBe("represent");
+  });
+
+  it("still refuses to act during the trailing-answer grace — the answer may be landing", () => {
+    const L = new ObligationLedger(2);
+    L.openIfAbsent(input("c:3#1", 0));
+    L.markRepresented("c:3#1", 5_000);
+    L.noteTurnEnded("c:3#1", 15_000);
+    // 1ms before the trailing grace expires: the slow answer still has its beat.
+    expect(
+      L.decideAtIdle({ now: 15_000 + TRAIL - 1, graceMs: TRAIL, representGraceMs: REPR_GRACE }).action,
+    ).toBe("none");
+  });
+
+  it("an IN-FLIGHT re-present (no turn ended after it) keeps the FULL window — the protection is untouched", () => {
+    const L = new ObligationLedger(2);
+    L.openIfAbsent(input("c:3#1", 0));
+    L.noteTurnEnded("c:3#1", 4_000); // the turn BEFORE the represent — must not count
+    L.markRepresented("c:3#1", 5_000);
+    expect(
+      L.decideAtIdle({ now: 5_000 + REPR_GRACE - 1, graceMs: TRAIL, representGraceMs: REPR_GRACE }).action,
+    ).toBe("none");
+    expect(
+      L.decideAtIdle({ now: 5_000 + REPR_GRACE + 1, graceMs: TRAIL, representGraceMs: REPR_GRACE }).action,
+    ).toBe("represent");
+  });
+
+  it("with the trailing grace disabled the full represent window is kept — never leaves the obligation ungated", () => {
+    const L = new ObligationLedger(2);
+    L.openIfAbsent(input("c:3#1", 0));
+    L.markRepresented("c:3#1", 5_000);
+    L.noteTurnEnded("c:3#1", 15_000);
+    expect(
+      L.decideAtIdle({ now: 16_000, graceMs: 0, representGraceMs: REPR_GRACE }).action,
+    ).toBe("none");
+  });
+
+  it("representGraceStillProtecting states the rule directly", () => {
+    const P = ObligationLedger.representGraceStillProtecting;
+    // in-flight re-present, inside window → still protecting
+    expect(P({ lastRepresentedAt: 5_000 }, 10_000, REPR_GRACE, TRAIL)).toBe(true);
+    // turn ended after the re-present → spent
+    expect(P({ lastRepresentedAt: 5_000, lastTurnEndedAt: 6_000 }, 10_000, REPR_GRACE, TRAIL)).toBe(false);
+    // turn ended BEFORE the re-present → irrelevant, still protecting
+    expect(P({ lastRepresentedAt: 5_000, lastTurnEndedAt: 4_000 }, 10_000, REPR_GRACE, TRAIL)).toBe(true);
+    // window already elapsed → not protecting either way
+    expect(P({ lastRepresentedAt: 5_000 }, 5_000 + REPR_GRACE, REPR_GRACE, TRAIL)).toBe(false);
+    // kill switch / never re-presented
+    expect(P({ lastRepresentedAt: 5_000 }, 6_000, 0, TRAIL)).toBe(false);
+    expect(P({}, 6_000, REPR_GRACE, TRAIL)).toBe(false);
+    // trailing grace disabled → the early-out is withheld
+    expect(P({ lastRepresentedAt: 5_000, lastTurnEndedAt: 6_000 }, 10_000, REPR_GRACE, 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
Last of the gateway-group PRs. (#3552 + #3551 in #3575; #3555 in #3576.)

## Validation first — the issue's mechanism is not quite the one in the source

The issue attributes the delay to a "120s obligation grace on an already-ended turn". That is real, but it is **not** the grace the issue's `turn_ended_cleanly_during_window` evidence points at — that log line is `telegram-plugin/gateway/liveness-wiring.ts:157`, a **silence-poke** late-fire skip, and it belongs to #3552 (handled in #3575). The obligation ledger has three independent graces and the one at fault is specifically the **per-represent** grace:

- trailing-answer grace — `OBLIGATION_ESCALATE_GRACE_MS`, **45s** from `lastTurnEndedAt` (`gateway.ts:2742`)
- background-work grace — 20 min from `openedAt` (`gateway.ts:2764`)
- **per-represent grace — `OBLIGATION_REPRESENT_GRACE_MS`, 120s from `lastRepresentedAt` (`gateway.ts:2778`)** ← this one

I have not been able to reproduce the "~29h per 14 days" figure from logs and am not asserting it; the mechanism below is verified in source and the per-obligation saving is arithmetic.

## The bug

The per-represent grace exists for one stated reason, verbatim from its definition at `gateway.ts:2770-2777` and `obligation-ledger.ts`: *"the 5s sweep can fire again before the re-presented turn even reaches the agent"*. It is a **proxy** for "the re-present has not landed yet".

The proxy was never re-evaluated. `oldestEligible` (`telegram-plugin/gateway/obligation-ledger.ts:329`) compared raw timestamps: `now - lastRepresentedAt < representGraceMs → skip`. So once a turn that started *after* the re-present had already **ended** — the re-present provably reached the agent, the agent ran a whole turn on it, and that turn is over — the obligation still sat frozen for the rest of the 120s. Pure latency on a ladder that `maxRepresents` already bounds.

## The fix

New pure static `ObligationLedger.representGraceStillProtecting` (`obligation-ledger.ts:290`), called from `oldestEligible` in place of the raw comparison. It returns false once `lastTurnEndedAt > lastRepresentedAt`.

**This does not weaken reliability**, and each guard is pinned by a test:

- The **trailing-answer grace is untouched** and evaluated independently — 45s from `lastTurnEndedAt`. That is the window that actually covers the risk in play here (a slow / background-worker answer still landing after its turn ended, the case `OBLIGATION_ESCALATE_GRACE_MS` was added for). Nothing is ever acted on inside it.
- The early-out is **withheld entirely when `graceMs === 0`**, so turning the trailing grace off can never leave an obligation ungated — the full represent window is kept instead.
- A re-present with **no ended turn after it** — the genuinely in-flight case the grace was written for, including a turn that ended *before* the re-present — keeps the **full 120s**. This is the "do not shorten a grace that is genuinely protecting an in-flight re-present" requirement, stated as a test.

**Before:** eligible at `max(lastTurnEndedAt + 45s, lastRepresentedAt + 120s)`.
**After:** eligible at `max(lastTurnEndedAt + 45s, lastRepresentedAt + 45s)` once the represent's turn has ended; identical in every other case.

**The per-rung figure is not a constant** (review finding 1 — an earlier draft of this body claimed a flat "120s -> 55s", which was wrong). After the fix the rung interval is *derived*: `trailingGraceMs + d`, where `d` is the represent-turn's own duration. Only the *ladder* arithmetic is stable. Writing `T0` for the unanswered original turn's end and `d` for a represent-turn's duration:

| rung | before | after |
|---|---|---|
| represent #1 | `T0+45s` | `T0+45s` |
| represent #2 | `T0+165s` | `T0+90s+d` |
| escalate | `T0+285s` | `T0+135s+2d` |

So with a 10s represent-turn, escalation moves from **~T0+285s to ~T0+155s**. Substitute your own `d`; there is no single "55s" saving to quote.

## Tests

`telegram-plugin/tests/obligation-ledger.test.ts` — new `#3550` block, 5 tests: acts at the trailing-grace boundary rather than the represent boundary (with an in-test assertion that this is genuinely earlier); still refuses to act *inside* the trailing grace; an in-flight re-present keeps the full window at `-1ms` and `+1ms`; `graceMs=0` keeps the full window; and a direct truth-table over `representGraceStillProtecting` including the turn-ended-*before*-the-represent case.

Mutation-verified: deleting the early-out line fails 2 tests.

**The fuzz claim, corrected (review finding G1).** This PR originally cited the 3000-schedule obligation-determinism fuzz as reassurance. That was **vacuous** — `representGraceMs` appeared nowhere in `obligation-determinism.test.ts`, so the fuzz never passed it and never reached the branch this PR changes. It has been made true rather than deleted: `runSchedule` now takes `representGraceMs`, and there is a **fourth 3000-schedule case** exercising it with the trailing grace also armed, asserting the terminal each message reaches is identical to the no-grace run. Two supporting corrections were required for it to bite — `markRepresented` is stamped with the sim's virtual clock rather than defaulting to wall-clock `Date.now()`, and a turn now occupies virtual time before it ends, so `lastTurnEndedAt > lastRepresentedAt` strictly (previously both landed on the same instant, leaving the early-out unreachable even with the param threaded). **Branch reach is proven, not assumed:** throwing inside the early-out fails exactly the new case and none of the other five.

**The production seam, now pinned (review finding G2).** All five rule tests call `noteTurnEnded` directly, so they proved the ledger rule but not the wiring. `noteTurnEnded` is a **keyed lookup**: in the field the stamp only lands because the represent inbound round-trips back to the same key. If `deriveTurnId(buildObligationRepresentInbound(o)) !== o.originTurnId` it silently no-ops, this fix goes dead, and every other test still passes green. That linkage was asserted only by a comment at `obligation-wiring.ts:250-256`. Five new tests pin it across forum-topic / DM / general-topic shapes, including an end-to-end stamp built from only what a represent-spawned turn would know, plus the `meta.origin_turn_id` close-side half. Mutation-verified: perturbing `messageId` in the represent inbound fails 5 tests; dropping its `threadId` fails 4.

All four obligation suites pass (88). `npm run lint` clean.

Refs #3550



---

## The trade this makes — stated plainly

The body above frames this as latency reduction. It is not purely that, and the honest version is: **this roughly halves time-to-escalation.** The rung interval drops from a flat 120s to a derived `45s + d`, and at `OBLIGATION_REPRESENT_MAX = 2` that compounds across the ladder — with a 10s represent-turn, escalation lands at ~T0+155s instead of ~T0+285s.

I judge that acceptable — and so did review — because the two mechanisms that actually prevent a *false* escalation are untouched by this diff and are not the represent grace:

- the 20-minute background-work grace (`OBLIGATION_BACKGROUND_WORK_GRACE_MS`), which covers the real "agent delegated and the answer lands minutes later" case, and
- the `hasOutboundDeliveredSince` represent/escalate guards, which close an obligation silently when a reply did land but its routing didn't resolve back to the origin.

The represent grace was only ever a debounce against the 5s sweep, never a false-escalation defence. But reviewers should weigh the faster escalation cadence on its own terms rather than reading this as free.

**The case where that bites — stated plainly (review finding 2).** The background-work grace is only as good as its detector. `agentHasInFlightBackgroundWork` (`gateway.ts:10040`) is true when `countRunningWorkers() > 0` OR the turn-active marker is younger than 90s. In the ack-then-background-work shape where BOTH miss — the worker row is not `running` (dispatch failed, was reaped, or the work is an orphaned foreground sub-agent that has stopped touching the marker) while the real answer is still coming — the background grace does not arm and the ladder runs at full speed. In that case the user now sees the operator-visible "⚠️ I may have missed an earlier message…" at **~2m35s instead of ~4m45s**. That is a genuine halving of the false-escalation budget in the detector-miss case, and it was not stated anywhere in the original body. It is the real cost of this PR. I still judge it acceptable — a false escalation is a recoverable nudge, a silently-dropped message is not — but it should be weighed, not discovered.

**No floor, no footgun (review finding 3).** Making the rung interval derived removed the only thing that bounded it below. `SWITCHROOM_OBLIGATION_ESCALATE_GRACE_MS=1000` is legal today and is a plausible "make it snappier" tune; post-fix it collapsed each rung to ~1s+`d` and escalated within ~15-20s of the original message. The old flat 120s window made that impossible regardless of the tune. Per the repo's deterministic-mechanisms-over-prose rule this is closed by a **clamp**, not a documented warning: `ObligationLedger.MIN_REPRESENT_INTERVAL_MS` (30s), applied as `min(representGraceMs, max(trailingGraceMs, MIN_REPRESENT_INTERVAL_MS))` from `lastRepresentedAt`. The `min` cap means it can never *extend* a window past what the operator configured, and at the shipped defaults it is 45s and never binds (the trailing grace is measured from a strictly-later turn end, so it always expires after the floor) — the shipped-configuration behaviour is unchanged. Mutation-verified: replacing the floor with `return false` fails 3 tests.

**The fuzz is now a discriminator, not a code-path exercise (review finding 4).** The corrected fuzz case above still was not a *test* of this diff: terminals are a function of `answerOnAttempt`/`escalateFailsFor` alone, and the worst schedule settles in ~72 sweep steps against `CAP = 10_000`, so reverting the diff left it green. It now runs the **same seed twice**, differing only in whether the re-present turn ends (stamping `noteTurnEnded`) or stays in flight — the early-out can fire only in the first. It asserts terminals identical, `steps` never longer per seed, and in aggregate strictly shorter on >1000 schedules with a strictly lower total. Delete the early-out and both runs hold the full 120s window, the step counts converge, and the case fails. The header now labels the terminal assertions as the no-livelock / no-loss guard they are, rather than implying they are #3550 coverage.

**A turn that ended WITHOUT consuming its re-present (review finding 5).** `representGraceStillProtecting` retires the window on a bare timestamp comparison and the doc comment justified that as "the agent ran a whole turn on it" — but the code only compares stamps and **cannot** distinguish a consuming turn from a bridge-down abort, an instantly-failed turn, or one torn down by #3575's silence-poke fallback. That is now asserted rather than assumed: three tests pin the actual behaviour (retired on the bare stamp, but never before the floor; a *pre*-represent stamp still never retires it; and the ladder burns at most `maxRepresents` rungs even when EVERY turn aborts instantly). **I do not think this needs a consumption signal**, and the evidence is directional: a turn that never consumed the re-present is by construction a turn that never answered it, so re-presenting sooner is the *correct* action, not a false one — the failure mode is spending a rung of an already-bounded budget earlier, and the floor bounds how much earlier. A consumption signal would only matter if a non-consuming turn-end could shorten the window below the point where a real answer might still land, and the trailing grace (measured from that same stamp) plus the 30s floor both still apply.

**#3575 interaction (review finding 7).** #3575 raises the *rate* of turn-end events while this PR keys grace retirement on turn-end events, so more of those events are silence-poke teardowns rather than consuming turns. That does not change the conclusion above — the same "never consumed ⇒ never answered" argument covers a poke teardown — but it is the reason the aborted-turn cases are now pinned by tests rather than left to the doc comment.

**Post-restart interleave (review finding 6) — filed as #3583.** A hydrated obligation with `lastTurnEndedAt > lastRepresentedAt` hits the early-out on the first sweep after boot, where represent #2 can interleave with the boot-resume inbound (the user sees the agent answer the resume *and* separately re-answer the re-presented message). The floor materially narrows this — it is measured from the durable `lastRepresentedAt`, so it survives hydration and the first boot sweep cannot fire, which two new tests pin — but it does not close it: the resume turn can still be in flight when the floor expires. Closing it properly needs a gateway-level boot fixture (sequence the sweep behind the resume turn, or stamp `noteTurnEnded` for the resume turn's origin key), so it is filed as **#3583** rather than folded in here.

## Do not auto-close #3550

There is deliberately **no closing keyword** in this body — `Refs #3550`, not `Fixes`. As documented in the validation section above, the mechanism #3550 describes is not the one in the source. This PR fixes a real latency defect, but it does **not** demonstrate that this defect is the one #3550 observed, and the "~29h / 14 days" figure is unreproduced. **Leave #3550 open pending a reproduction.**
