### PR TITLE
fix(hindsight): damp the ranking boost product, with an operator kill-switch

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -443,6 +443,247 @@ assert "entity_records=phase1.entities.entity_records" in (BASE / "retain/orches
 print("switchroom hindsight unit_entities FK-race patch: reassert_entities + entity_records threading applied (Phase-2 resurrects concurrently-pruned parent in same txn)")
 PYEOF
 
+# Cross-encoder saturation fix: `apply_combined_scoring` in
+# engine/search/reranking.py computes the ONLY final ranking score as
+#   combined_score = CE_normalized * recency_boost * temporal_boost * proof_count_boost
+# Keyword/semantic (RRF) is explicitly zeroed out and excluded. On a real bank
+# the local ms-marco cross-encoder saturates: measured live on bank `overlord`,
+# a 116-result recall had EVERY cross_encoder_score_normalized inside
+# 0.9800-0.9999 — a ~2% spread, i.e. no discriminating power left. The
+# multiplicative boosts then decide the order: their worst-case max/min ratio is
+# (1.1*1.1*1.05)/(0.9*0.9*0.95) ≈ 1.65, which dwarfs a 2% CE gap. The record
+# with the highest CE score in the entire set (0.9999) ranked 7th —
+# 0.9999 * 1.1000 = 1.0999 lost to an older consolidated record at 1.1234 whose
+# only advantage was proof_count 9 vs 1. Fresh single-source facts are
+# structurally buried under older consolidated ones on every bank.
+#
+# Fix: DAMP the boost product — combined = CE * (r_boost * t_boost * p_boost) ** k
+# — so the boosts modulate the cross-encoder decision instead of replacing it.
+# k is derived, not tuned: it is chosen so the worst-case boost ratio collapses
+# to exactly 1 + _CE_DECISIVE_RELATIVE_GAP, i.e. a candidate whose CE score is
+# >= 2% (the measured saturation spread) above another's outranks it no matter
+# how the boosts fall. k is a function of the alphas ONLY.
+#
+# HONEST SCOPE. This is a calibration change, not a defect fix, and it is
+# unconditional: at the shipped alphas k = 0.03949 on EVERY query, which
+# compresses the boost band from ~[0.81, 1.21] to ~[0.99, 1.01]. That is the
+# intent on a saturated set, but it applies identically to a healthy
+# well-spread set where there was no bug — such a set keeps its CE ordering
+# either way, but its recency/temporal/proof_count authority is cut ~20x. The
+# decisive gap is therefore an OPERATIONAL KNOB, not a baked constant:
+#
+#   HINDSIGHT_CE_DECISIVE_RELATIVE_GAP=<float>
+#
+# overrides it per-deployment, read once at import. Raising it weakens the
+# damping; any value at or above ~0.65 makes k clamp to 1.0, i.e. EXACTLY
+# upstream behaviour with this patch still baked in. So backing this change
+# out is a container restart with one env var, not an image rebuild — which
+# matters because the failure mode here is a silent recall-quality regression
+# with no telemetry that would surface it. Invalid, empty, non-finite and
+# non-positive values fall back to the 0.02 default rather than failing recall.
+#
+# What this deliberately does NOT do, and why — each of these was a defect in
+# the first version of this patch, which min-max rescaled the CE scores onto
+# [0.1, 1.0] whenever their spread was below a 0.05 threshold:
+#
+#   * It does not touch `cross_encoder_score_normalized`. That field is an
+#     ABSOLUTE, caller-visible quantity: engine/memory_engine.py applies the
+#     agent-supplied `min_scores.reranker` floor directly to it (and
+#     `min_scores` is a documented MCP recall parameter any agent can pass).
+#     Rescaling it forced the worst candidate in EVERY result set to 0.1 and
+#     the best to 1.0, silently turning `min_scores: {reranker: 0.8}` from
+#     "116 results" into a handful. The encoder's score is now passed through
+#     exactly as produced.
+#   * It is set-independent. A min-max rescale is computed over whichever
+#     candidates survived retrieval, so the same pair reordered when an
+#     unrelated third document joined the set — and this deployment sets
+#     HINDSIGHT_API_RERANKER_MAX_CANDIDATES=150, which makes set membership
+#     churny. Here a candidate's score is a pure function of its own fields.
+#   * It is noise-proportional. A min-max rescale is scale-invariant, so a
+#     spread of 1e-7 (pure float noise from a saturated encoder) was stretched
+#     to the full [0.1, 1.0] band exactly like a real spread of 0.049, letting
+#     noise decide the ranking outright. Here a 1e-7 CE difference stays 1e-7
+#     and remains subordinate to the boosts, which is the correct outcome when
+#     the encoder genuinely cannot tell two candidates apart.
+#   * It is continuous. The old threshold made spread 0.0499 stretch ~18x while
+#     0.0501 was untouched — an unjustified cliff. There is no threshold here.
+#   * It keeps combined_score on the same [0, 1] scale as CE (at the default
+#     gap the multiplier is confined to ~[0.990, 1.010]).
+#     engine/search/recall_boost.py calibrates its additive boost levels
+#     against that scale — its own comment reads "high=0.5 wins over most
+#     semantic matches; only a strong direct match (>0.5 normalized) still
+#     wins" — and `min_scores.final` floors `sr.weight`. Inflating the band
+#     toward 1.0 would have broken both.
+#
+# The transform is strictly monotone in CE, so it changes no CE ordering; it
+# only bounds how far the secondary signals may move a result. The alphas, the
+# boost formulae, and the passthrough branch are untouched.
+#
+# Named module constants, not magic numbers. Self-verifying: the build FAILS
+# LOUDLY if upstream reformats any anchor, drops `import math` (on which
+# _boost_authority depends), or reintroduces a write to the CE field in ANY
+# form. Guarded by tests/docker/dockerfile-hindsight-bakes.test.ts and
+# behaviourally by tests/docker/hindsight-search-patches.test.ts.
+RUN python3 - <<'PYEOF'
+import pathlib
+import re
+
+f = pathlib.Path("/app/api/hindsight_api/engine/search/reranking.py")
+s = f.read_text()
+
+# `os` for the operational override; the anchor doubles as the guard that
+# upstream still imports `math`, which _boost_authority depends on.
+OLD_IMPORTS = "import math\nfrom datetime import datetime, timezone\n"
+NEW_IMPORTS = "import math\nimport os\nfrom datetime import datetime, timezone\n"
+
+OLD_CONST = "# Recency decay: maps a memory's age (days) onto a freshness signal in [0, 1]"
+NEW_CONST = (
+    "# switchroom: measured cross-encoder saturation. On bank `overlord` a 116-result\n"
+    "# recall had EVERY cross_encoder_score_normalized inside 0.9800-0.9999 — a ~2%\n"
+    "# spread. This is the RELATIVE CE gap that must be DECISIVE: a candidate whose\n"
+    "# CE score is at least this much above another's outranks it regardless of how\n"
+    "# the recency / temporal / proof_count boosts fall.\n"
+    "_CE_DECISIVE_RELATIVE_GAP_DEFAULT: float = 0.02\n"
+    '_CE_DECISIVE_RELATIVE_GAP_ENV: str = "HINDSIGHT_CE_DECISIVE_RELATIVE_GAP"\n'
+    "\n"
+    "\n"
+    "def _decisive_relative_gap() -> float:\n"
+    '    """Operator override for the decisive CE gap, read once at import.\n'
+    "\n"
+    "    This damping is a calibration judgement, not a defect fix, and its failure\n"
+    "    mode is a silent recall-quality regression rather than an error. Making the\n"
+    "    gap an env var means backing it out is a container restart, not an image\n"
+    "    rebuild: any value at or above ~0.65 clamps the exponent to 1.0, which is\n"
+    "    byte-for-byte upstream scoring with this patch still baked in.\n"
+    "\n"
+    "    A bad value must never break recall, so anything unparseable, non-finite or\n"
+    "    non-positive falls back to the default.\n"
+    '    """\n'
+    '    raw = os.environ.get(_CE_DECISIVE_RELATIVE_GAP_ENV, "").strip()\n'
+    "    if not raw:\n"
+    "        return _CE_DECISIVE_RELATIVE_GAP_DEFAULT\n"
+    "    try:\n"
+    "        value = float(raw)\n"
+    "    except (TypeError, ValueError):\n"
+    "        return _CE_DECISIVE_RELATIVE_GAP_DEFAULT\n"
+    "    if not math.isfinite(value) or value <= 0.0:\n"
+    "        return _CE_DECISIVE_RELATIVE_GAP_DEFAULT\n"
+    "    return value\n"
+    "\n"
+    "\n"
+    "_CE_DECISIVE_RELATIVE_GAP: float = _decisive_relative_gap()\n"
+    "\n"
+    "\n"
+    "def _boost_authority(\n"
+    "    recency_alpha: float, temporal_alpha: float, proof_count_alpha: float\n"
+    ") -> float:\n"
+    '    """Exponent that caps how far the combined boost multiplier may reorder CE.\n'
+    "\n"
+    "    Each boost is ``1 + alpha * (signal - 0.5)`` with ``signal`` in [0, 1], so it\n"
+    "    spans ``[1 - alpha/2, 1 + alpha/2]``. Raising their product to this exponent\n"
+    "    confines the product's worst-case max/min ratio to exactly\n"
+    "    ``1 + _CE_DECISIVE_RELATIVE_GAP``. Undamped that ratio is ~1.65 at the default\n"
+    "    alphas, which is why proof_count could decide the order of a saturated set.\n"
+    "\n"
+    "    Depends ONLY on the alphas and the module-level gap — never on the candidate\n"
+    "    set — so a candidate's combined_score is a pure function of its own fields\n"
+    "    and cannot change because an unrelated document joined or left the set.\n"
+    "\n"
+    "    Returns 1.0 (exact upstream behaviour, no damping) when the boosts are\n"
+    "    disabled, already too weak to overturn the decisive gap, or when the\n"
+    "    operator has widened the gap past what the boosts can span.\n"
+    '    """\n'
+    "    hi = 1.0\n"
+    "    lo = 1.0\n"
+    "    for alpha in (recency_alpha, temporal_alpha, proof_count_alpha):\n"
+    "        hi *= 1.0 + alpha / 2.0\n"
+    "        lo *= 1.0 - alpha / 2.0\n"
+    "    if lo <= 0.0 or hi <= lo:\n"
+    "        return 1.0\n"
+    "    return min(1.0, math.log1p(_CE_DECISIVE_RELATIVE_GAP) / math.log(hi / lo))\n"
+    "\n"
+    "\n"
+    "# Recency decay: maps a memory's age (days) onto a freshness signal in [0, 1]"
+)
+
+OLD_LOOP = (
+    "    for sr in scored_results:\n"
+    "        # Recency: configurable decay (linear default; see compute_recency_decay)\n"
+)
+NEW_LOOP = (
+    "    # switchroom: derived once per call from the alphas alone — see\n"
+    "    # _boost_authority. Set-independent by construction.\n"
+    "    _boost_exponent = _boost_authority(recency_alpha, temporal_alpha, proof_count_alpha)\n"
+    "\n"
+    "    for sr in scored_results:\n"
+    "        # Recency: configurable decay (linear default; see compute_recency_decay)\n"
+)
+
+OLD_BODY = (
+    "        proof_count_boost = 1.0 + proof_count_alpha * (proof_norm - 0.5)\n"
+    "        sr.combined_score = sr.cross_encoder_score_normalized * recency_boost * temporal_boost * proof_count_boost\n"
+)
+NEW_BODY = (
+    "        proof_count_boost = 1.0 + proof_count_alpha * (proof_norm - 0.5)\n"
+    "        # switchroom: damp the boost product so it MODULATES the cross-encoder\n"
+    "        # decision instead of replacing it. Measured live: with every CE score\n"
+    "        # inside 0.9800-0.9999, the undamped boosts decided the order and the\n"
+    "        # single highest-CE memory ranked 7th behind older, more heavily-proven\n"
+    "        # ones — proof_count was deciding relevance.\n"
+    "        #\n"
+    "        # cross_encoder_score_normalized is deliberately NOT rewritten: it is an\n"
+    "        # absolute, caller-visible score that memory_engine filters against with\n"
+    "        # the agent-supplied min_scores.reranker floor.\n"
+    "        _boost = recency_boost * temporal_boost * proof_count_boost\n"
+    "        sr.combined_score = sr.cross_encoder_score_normalized * (_boost**_boost_exponent)\n"
+)
+
+for name, anchor in (
+    ("imports", OLD_IMPORTS),
+    ("constant", OLD_CONST),
+    ("loop", OLD_LOOP),
+    ("combined_score", OLD_BODY),
+):
+    n = s.count(anchor)
+    assert n == 1, (
+        f"switchroom hindsight CE-saturation patch: {name} anchor found {n}x (expected 1) "
+        "in engine/search/reranking.py — upstream reformatted apply_combined_scoring "
+        "or its imports; re-author this patch in docker/Dockerfile.hindsight"
+    )
+
+s = (
+    s.replace(OLD_IMPORTS, NEW_IMPORTS, 1)
+    .replace(OLD_CONST, NEW_CONST, 1)
+    .replace(OLD_LOOP, NEW_LOOP, 1)
+    .replace(OLD_BODY, NEW_BODY, 1)
+)
+f.write_text(s)
+
+t = f.read_text()
+assert "\nimport math\n" in t, "switchroom hindsight CE-saturation patch: `import math` is gone — _boost_authority cannot work"
+assert "\nimport os\n" in t, "switchroom hindsight CE-saturation patch: `import os` missing — the operator override cannot be read"
+assert "_CE_DECISIVE_RELATIVE_GAP_DEFAULT: float = 0.02" in t, "switchroom hindsight CE-saturation patch: decisive-gap default missing after patch"
+assert '_CE_DECISIVE_RELATIVE_GAP_ENV: str = "HINDSIGHT_CE_DECISIVE_RELATIVE_GAP"' in t, "switchroom hindsight CE-saturation patch: env-override name missing after patch"
+assert "_CE_DECISIVE_RELATIVE_GAP: float = _decisive_relative_gap()" in t, "switchroom hindsight CE-saturation patch: gap is not wired to the env override"
+assert "def _boost_authority(" in t, "switchroom hindsight CE-saturation patch: _boost_authority helper missing after patch"
+assert "_boost_exponent = _boost_authority(recency_alpha, temporal_alpha, proof_count_alpha)" in t, "switchroom hindsight CE-saturation patch: per-call exponent missing after patch"
+assert "sr.combined_score = sr.cross_encoder_score_normalized * (_boost**_boost_exponent)" in t, "switchroom hindsight CE-saturation patch: damped combined_score missing after patch"
+
+# STRUCTURAL guard, not an exact-string one: the withdrawn revision of this
+# patch min-max rescaled cross_encoder_score_normalized, which memory_engine
+# filters against with the agent-supplied min_scores.reranker floor. Matching
+# on the assignment FORM means a reformatted or renamed reintroduction trips
+# it too — the sole permitted writer is upstream's own passthrough reseed.
+_ce_writes = re.findall(r"^\s*sr\.cross_encoder_score_normalized\s*=(?!=)[^\n]*", t, re.M)
+assert _ce_writes == ["            sr.cross_encoder_score_normalized = 1.0 - (0.9 * new_rank / denom)"], (
+    "switchroom hindsight CE-saturation patch: cross_encoder_score_normalized is written "
+    f"somewhere other than upstream's is_passthrough_reranker reseed — found {_ce_writes!r}. "
+    "That field carries the absolute, agent-supplied min_scores.reranker floor and must "
+    "never be rescaled"
+)
+print("switchroom hindsight CE-saturation patch: boost product damped so proof_count can no longer decide ranking; cross_encoder_score_normalized left untouched for min_scores; gap overridable via HINDSIGHT_CE_DECISIVE_RELATIVE_GAP")
+PYEOF
+
 # BM25 compound-token fix: `tokenize_query` in engine/search/retrieval.py did
 #   re.sub(r"[^\w\s]", " ", query_text.lower()).split()
 # which SHREDS every punctuated identifier. Postgres does not: verified against

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -220,6 +220,83 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the cross-encoder saturation fix (assert-guarded, fail-loud)", () => {
+    // apply_combined_scoring makes CE * recency * temporal * proof_count the
+    // ONLY final score (RRF is explicitly zeroed). Measured live on bank
+    // `overlord`: a 116-result recall had every CE score inside 0.9800-0.9999,
+    // so the boosts — undamped worst-case ratio ~1.65 — decided the order and
+    // the single highest-CE memory ranked 7th behind older, more-proven ones.
+    // The patch DAMPS the boost product so it modulates the CE decision
+    // instead of replacing it. Behaviour is proven against the pinned upstream
+    // image in tests/docker/hindsight-search-patches.test.ts.
+
+    // The exact-once anchor guard (fail-loud on upstream drift).
+    expect(dockerfile).toMatch(
+      /switchroom hindsight CE-saturation patch: \{name\} anchor found \{n\}x/,
+    );
+    // `import math` is a load-bearing dependency of _boost_authority, so its
+    // presence is itself an anchor: if upstream drops or reorders it the build
+    // fails loudly rather than emitting a NameError at recall time.
+    expect(dockerfile).toMatch(
+      /OLD_IMPORTS = "import math\\nfrom datetime import datetime, timezone\\n"/,
+    );
+    expect(dockerfile).toMatch(
+      /assert "\\nimport math\\n" in t, "switchroom hindsight CE-saturation patch: `import math` is gone/,
+    );
+
+    // Named module constant tied to the MEASURED saturation spread, and a
+    // derivation from the alphas — not a hand-tuned exponent.
+    expect(dockerfile).toMatch(/_CE_DECISIVE_RELATIVE_GAP_DEFAULT: float = 0\.02/);
+    expect(dockerfile).toMatch(/def _boost_authority\(/);
+    expect(dockerfile).toMatch(
+      /math\.log1p\(_CE_DECISIVE_RELATIVE_GAP\) \/ math\.log\(hi \/ lo\)/,
+    );
+
+    // The gap is an OPERATOR KNOB, not a baked constant. This damping is a
+    // calibration judgement whose failure mode is a silent recall-quality
+    // regression with no telemetry behind it, so backing it out must be a
+    // container restart (one env var) rather than an image rebuild. A wide
+    // gap clamps the exponent to 1.0 = exact upstream scoring.
+    expect(dockerfile).toMatch(
+      /_CE_DECISIVE_RELATIVE_GAP_ENV: str = .HINDSIGHT_CE_DECISIVE_RELATIVE_GAP./,
+    );
+    expect(dockerfile).toMatch(
+      /_CE_DECISIVE_RELATIVE_GAP: float = _decisive_relative_gap\(\)/,
+    );
+    // A bad value must degrade to the default, never raise out of the scoring
+    // path — an unparseable env var must not take recall down.
+    expect(dockerfile).toMatch(/except \(TypeError, ValueError\):/);
+    expect(dockerfile).toMatch(
+      /if not math\.isfinite\(value\) or value <= 0\.0:/,
+    );
+    expect(dockerfile).toMatch(
+      /HINDSIGHT_CE_DECISIVE_RELATIVE_GAP=<float>/,
+    );
+
+    // The exponent is derived ONCE PER CALL from the alphas alone. That is what
+    // makes a candidate's score a pure function of its own fields — no
+    // candidate-set-relative quantity may appear.
+    expect(dockerfile).toMatch(
+      /_boost_exponent = _boost_authority\(recency_alpha, temporal_alpha, proof_count_alpha\)/,
+    );
+    expect(dockerfile).toMatch(
+      /sr\.combined_score = sr\.cross_encoder_score_normalized \* \(_boost\*\*_boost_exponent\)/,
+    );
+
+    // Post-replace re-assertions (verification-on-build), including the
+    // STRUCTURAL guard that no reformatted reintroduction of the withdrawn
+    // min-max rescale can slip past an exact-string check.
+    expect(dockerfile).toMatch(
+      /assert "_CE_DECISIVE_RELATIVE_GAP_DEFAULT: float = 0\.02" in t,/,
+    );
+    expect(dockerfile).toMatch(
+      /_ce_writes = re\.findall\(r"\^\\s\*sr\\\.cross_encoder_score_normalized\\s\*=/,
+    );
+    expect(dockerfile).toMatch(
+      /switchroom hindsight CE-saturation patch: boost product damped/,
+    );
+  });
+
   it("never rewrites the caller-visible cross_encoder_score_normalized field", () => {
     // engine/memory_engine.py applies the agent-supplied `min_scores.reranker`
     // floor DIRECTLY to cross_encoder_score_normalized, and `min_scores` is a

--- a/tests/docker/hindsight-search-patches.test.ts
+++ b/tests/docker/hindsight-search-patches.test.ts
@@ -297,7 +297,7 @@ def _probe_gap_knob():
             failures.append("decisive-gap override %r raised %s instead of falling back" % (v, type(e).__name__))
             bad_ok = False
             continue
-        if abs(got - 0.02) > 1e-12:
+        if got != got or abs(got - 0.02) > 1e-12:
             failures.append("decisive-gap override %r yielded %r instead of the 0.02 default" % (v, got))
             bad_ok = False
     print("GAP_BAD_VALUES_FALL_BACK", bad_ok)

--- a/tests/docker/hindsight-search-patches.test.ts
+++ b/tests/docker/hindsight-search-patches.test.ts
@@ -1,34 +1,44 @@
 /**
- * Behavioural proof for the two search/provider patches
+ * Behavioural proof for the three search/provider patches
  * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight
  * image. `dockerfile-hindsight-bakes.test.ts` pins the *shape* of those patch
  * blocks (grep-on-file, runs everywhere). This file proves the *outcome*: it
  * runs the same probe against unpatched upstream (must be RED on every bug)
  * and against upstream + the patch blocks applied (must be GREEN).
  *
- * The two defects, both reproduced live on bank `overlord` before the fix:
+ * The three defects, all reproduced live on bank `overlord` before the fix:
  *
- *  1. `tokenize_query` shredded `v0.19.17` into `v0`/`19`/`17`, while
+ *  1. Cross-encoder saturation. `apply_combined_scoring` makes
+ *     `CE * recency_boost * temporal_boost * proof_count_boost` the only final
+ *     score (RRF is explicitly zeroed). A 116-result recall had every CE score
+ *     inside 0.9800-0.9999, so the boosts — whose undamped worst-case ratio is
+ *     ~1.65 — decided the order and the single highest-CE memory ranked 7th
+ *     behind older, more-proven ones.
+ *  2. `tokenize_query` shredded `v0.19.17` into `v0`/`19`/`17`, while
  *     `to_tsvector` indexes it as ONE lexeme — zero overlap on the only
  *     discriminating term, and the stripped `19` then matched clock
  *     timestamps like `19:33:13`.
- *  2. Both LiteLLM timeout handlers ended in a bare `raise`, re-raising an
+ *  3. Both LiteLLM timeout handlers ended in a bare `raise`, re-raising an
  *     `asyncio.TimeoutError` whose `str()` is empty → an operator-facing
  *     "TimeoutError:" with no cause.
  *
- * (A third patch — damping the ranking boost product — was deliberately split
- * out of this PR. It is a calibration change rather than a defect fix, so it
- * ships separately with its own probe coverage in order to stay independently
- * revertible. Nothing here depends on it.)
+ * Beyond proving those three fixes, the probe pins the properties that make
+ * the fixes SAFE, because each was violated by an earlier revision of this
+ * work and none is visible from the patch text alone:
  *
- * Beyond proving those two fixes, the probe pins the property that makes the
- * BM25 change SAFE, because an earlier revision of this work violated it and
- * it is not visible from the patch text alone:
- *
+ *  - `cross_encoder_score_normalized` is never rewritten. `memory_engine.py`
+ *    applies the agent-supplied `min_scores.reranker` floor to that field as
+ *    an ABSOLUTE cutoff, so rescaling it silently drops results (measured:
+ *    a min-max rescale drops 78 of 100 results at `min_scores.reranker=0.8`
+ *    that upstream kept).
+ *  - Scores are set-independent: a candidate's `combined_score` cannot change
+ *    because an unrelated document joined the candidate set.
+ *  - CE noise does not decide: a 1e-7 CE difference must stay subordinate to
+ *    the boosts rather than being stretched into a ranking decision.
+ *  - `combined_score` stays on the [0, 1] CE scale that `recall_boost.py`'s
+ *    additive levels and `min_scores.final` are calibrated against.
  *  - `tokenize_query` stays a STRICT SUPERSET of upstream's token list, so the
  *    OR-joined query can only match more documents than upstream, never fewer.
- *    A document that never enters the BM25 candidate set can never be reranked
- *    back in, so a recall loss there is unrecoverable downstream.
  *
  * The patch blocks are extracted from the Dockerfile itself rather than
  * duplicated here, so this test cannot drift from what actually ships. It
@@ -61,7 +71,7 @@ import { randomUUID } from "node:crypto";
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const dockerfile = readFileSync(
   resolve(root, "docker/Dockerfile.hindsight"),
-  "utf8",
+  "utf8"
 );
 
 const RUN_ID = randomUUID();
@@ -75,7 +85,7 @@ const UPSTREAM_IMAGE = (() => {
 })();
 
 /**
- * The two patch blocks under test, pulled out of the Dockerfile's
+ * The three patch blocks under test, pulled out of the Dockerfile's
  * `RUN python3 - <<'PYEOF' … PYEOF` heredocs by their unique patch names.
  */
 function patchBlocks(): string[] {
@@ -83,6 +93,7 @@ function patchBlocks(): string[] {
     ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
   ].map((m) => m[1]);
   const wanted = [
+    "CE-saturation patch",
     "BM25 compound-token patch",
     "timeout-message patch",
   ];
@@ -91,7 +102,7 @@ function patchBlocks(): string[] {
     if (!b) {
       throw new Error(
         `Dockerfile.hindsight no longer contains the "${name}" RUN block — ` +
-          `if it was deliberately removed, delete this test with it.`,
+          `if it was deliberately removed, delete this test with it.`
       );
     }
     return b;
@@ -99,7 +110,7 @@ function patchBlocks(): string[] {
 }
 
 /**
- * Python probe. Exits 0 only when both fixes are in effect AND every
+ * Python probe. Exits 0 only when all three fixes are in effect AND every
  * safety property above holds; prints the offending assertions otherwise.
  *
  * Deliberately asserts OUTCOMES rather than merely calling the code or
@@ -123,12 +134,178 @@ const PROBE = String.raw`
 import asyncio
 import re
 import sys
+from datetime import datetime, timedelta, timezone
 
+from hindsight_api.engine.search.reranking import apply_combined_scoring
 from hindsight_api.engine.search.retrieval import tokenize_query
+from hindsight_api.engine.search.types import MergedCandidate, RetrievalResult, ScoredResult
 from hindsight_api.engine.sql import create_sql_dialect
 
 failures = []
+UTC = timezone.utc
+NOW = datetime(2026, 7, 25, tzinfo=UTC)
 
+
+def mk(uid, ce, proof, age_days=10):
+    r = RetrievalResult(
+        id=uid, text=uid, fact_type="observation",
+        occurred_start=NOW - timedelta(days=age_days), proof_count=proof,
+    )
+    return ScoredResult(
+        candidate=MergedCandidate(retrieval=r, rrf_score=0.0),
+        cross_encoder_score_normalized=ce,
+    )
+
+
+def order(rows):
+    apply_combined_scoring(rows, NOW)
+    return [s.id for s in sorted(rows, key=lambda s: s.combined_score, reverse=True)]
+
+
+# ------------------------------------------------------------------ fix 1
+# (a) THE BUG. Saturated CE band as measured live. Same date on both rows, so
+# recency/temporal are identical and proof_count is the only other signal.
+fresh, old = mk("fresh-high-ce", 0.9999, 1), mk("old-high-proof", 0.9800, 10)
+o = order([fresh, old])
+print("SATURATED_ORDER", o, fresh.combined_score, old.combined_score)
+if o[0] != "fresh-high-ce":
+    failures.append("saturated CE: proof_count decided the ranking")
+
+# (b) NOISE MUST NOT DECIDE. A 1e-7 CE difference is float noise from a
+# saturated encoder, not signal, so the stale/unproven row must not win on it.
+# A min-max rescale is scale-invariant and stretches exactly this noise across
+# the whole band, handing it the decision outright.
+noisy = mk("noise-stale", 0.9800001, 1, age_days=3000)
+real = mk("real-fresh", 0.9800000, 50, age_days=1)
+o = order([noisy, real])
+print("NOISE_ORDER", o, noisy.combined_score, real.combined_score)
+if o[0] != "real-fresh":
+    failures.append("CE noise (1e-7 spread) decided the ranking over recency+proof")
+
+# (c) SET-INDEPENDENCE. The same pair must score identically whether or not an
+# unrelated third document survived retrieval alongside it.
+a1, b1 = mk("A", 0.98, 1), mk("B", 0.99, 9)
+order([a1, b1])
+a2, b2, c2 = mk("A", 0.98, 1), mk("B", 0.99, 9), mk("C", 0.94, 3)
+order([a2, b2, c2])
+print("SETDEP_DELTA", abs(a1.combined_score - a2.combined_score), abs(b1.combined_score - b2.combined_score))
+if abs(a1.combined_score - a2.combined_score) > 1e-12 or abs(b1.combined_score - b2.combined_score) > 1e-12:
+    failures.append("combined_score changed when an unrelated document joined the candidate set")
+
+# (d) min_scores INTERACTION. memory_engine applies the agent-supplied
+# min_scores.reranker floor as an ABSOLUTE filter on
+# cross_encoder_score_normalized, so rewriting that field silently drops
+# results that upstream would have returned.
+band = [mk("m%d" % i, 0.9800 + i * 0.0002, 1 + i) for i in range(100)]
+before = [s.cross_encoder_score_normalized for s in band]
+order(band)
+after = [s.cross_encoder_score_normalized for s in band]
+survivors = len([x for x in after if x >= 0.8])
+print("MINSCORES_SURVIVORS", survivors, "/", len(band))
+print("CE_MUTATED", any(x != y for x, y in zip(before, after)))
+if any(x != y for x, y in zip(before, after)):
+    failures.append("cross_encoder_score_normalized was rewritten - min_scores.reranker floor silently changes meaning")
+if survivors != len(band):
+    failures.append("min_scores reranker=0.8 now drops %d of %d results that upstream kept" % (len(band) - survivors, len(band)))
+
+# (e) SCALE. recall_boost.py calibrates its additive levels against the [0, 1]
+# CE scale ("high=0.5 wins over most semantic matches"), and min_scores.final
+# floors sr.weight. combined_score must stay on that scale - the boosts may
+# modulate it by at most the decisive-gap fraction, not reshape it.
+ratios = [s.combined_score / s.cross_encoder_score_normalized for s in band]
+print("WEIGHT_RATIO_RANGE", min(ratios), max(ratios))
+if min(ratios) < 0.98 or max(ratios) > 1.02:
+    failures.append("combined_score left the [0, 1] CE scale that recall_boost/min_scores.final assume")
+
+# (f) A healthy (well-spread) encoder is still ordered by CE, absolute scores
+# untouched.
+hi, lo = mk("hi", 0.90, 1), mk("lo", 0.40, 150)
+o = order([hi, lo])
+print("HEALTHY", o, hi.cross_encoder_score_normalized, lo.cross_encoder_score_normalized)
+if o[0] != "hi" or abs(hi.cross_encoder_score_normalized - 0.90) > 1e-12 or abs(lo.cross_encoder_score_normalized - 0.40) > 1e-12:
+    failures.append("healthy CE spread was disturbed")
+
+# (g) Upstream's is_passthrough_reranker branch must still reseed CE from RRF
+# rank - the patch must not have clobbered it.
+p1, p2 = mk("p1", 0.5, 1), mk("p2", 0.5, 1)
+p1.candidate.rrf_score, p2.candidate.rrf_score = 0.9, 0.1
+apply_combined_scoring([p1, p2], NOW, is_passthrough_reranker=True)
+print("PASSTHROUGH", p1.cross_encoder_score_normalized, p2.cross_encoder_score_normalized)
+if abs(p1.cross_encoder_score_normalized - 1.0) > 1e-9 or abs(p2.cross_encoder_score_normalized - 0.1) > 1e-9:
+    failures.append("upstream is_passthrough_reranker branch was clobbered")
+
+# (h) OPERATOR OVERRIDE + (i) BAD-VALUE SAFETY. The damping is a calibration
+# judgement whose failure mode is a silent recall-quality regression, so it must
+# be backable-out with a container RESTART rather than an image rebuild. The gap
+# is read from HINDSIGHT_CE_DECISIVE_RELATIVE_GAP once at import, so a module
+# reload here is exactly what a restart does in production.
+#
+# Written as a function guarded by hasattr so that unpatched upstream - which
+# has none of these symbols - reports a clean RED failure instead of dying with
+# an AttributeError before the sentinel prints.
+import importlib
+import os as _os
+
+import hindsight_api.engine.search.reranking as _rr
+
+
+def _probe_gap_knob():
+    if not hasattr(_rr, "_CE_DECISIVE_RELATIVE_GAP"):
+        print("GAP_DEFAULT absent")
+        failures.append("no _CE_DECISIVE_RELATIVE_GAP module constant - the CE damping patch is not applied")
+        return
+
+    print("GAP_DEFAULT", _rr._CE_DECISIVE_RELATIVE_GAP)
+    if abs(_rr._CE_DECISIVE_RELATIVE_GAP - 0.02) > 1e-12:
+        failures.append("default decisive gap is not 0.02 with the env var unset")
+
+    def reload_with(value):
+        if value is None:
+            _os.environ.pop("HINDSIGHT_CE_DECISIVE_RELATIVE_GAP", None)
+        else:
+            _os.environ["HINDSIGHT_CE_DECISIVE_RELATIVE_GAP"] = value
+        return importlib.reload(_rr)
+
+    # A wide gap clamps the exponent to 1.0 - byte-for-byte upstream scoring
+    # with the patch still baked in. This is THE rollback path; if it does not
+    # hold, the only way out of a bad calibration is an image rebuild.
+    m = reload_with("1.0")
+    rows = [mk("fresh-high-ce", 0.9999, 1), mk("old-high-proof", 0.9800, 10)]
+    m.apply_combined_scoring(rows, NOW)
+    ranked = [r.id for r in sorted(rows, key=lambda r: r.combined_score, reverse=True)]
+    exp_off = m._boost_authority(0.1, 0.1, 0.05)
+    print("GAP_ROLLBACK", m._CE_DECISIVE_RELATIVE_GAP, exp_off, ranked)
+    if abs(exp_off - 1.0) > 1e-12:
+        failures.append("HINDSIGHT_CE_DECISIVE_RELATIVE_GAP=1.0 did not clamp the exponent to 1.0 - the env rollback path is broken")
+    if ranked[0] != "old-high-proof":
+        failures.append("exponent 1.0 did not reproduce upstream scoring - the high-proof row should win again, got %r" % (ranked,))
+
+    # The knob is monotone: a wider gap always damps less.
+    exps = [reload_with(v)._boost_authority(0.1, 0.1, 0.05) for v in ("0.005", "0.02", "0.10", "0.30")]
+    print("GAP_MONOTONE", exps)
+    if exps != sorted(exps) or exps[0] >= exps[-1]:
+        failures.append("decisive-gap knob is not monotone in the damping exponent: %r" % (exps,))
+
+    # (i) A BAD VALUE MUST NEVER BREAK RECALL. Unparseable / empty / non-positive
+    # / non-finite all fall back to the default rather than raising out of the
+    # scoring path.
+    bad_ok = True
+    for v in ("", "   ", "abc", "0", "-1", "nan", "inf", "1e400"):
+        try:
+            got = reload_with(v)._CE_DECISIVE_RELATIVE_GAP
+        except Exception as e:
+            failures.append("decisive-gap override %r raised %s instead of falling back" % (v, type(e).__name__))
+            bad_ok = False
+            continue
+        if abs(got - 0.02) > 1e-12:
+            failures.append("decisive-gap override %r yielded %r instead of the 0.02 default" % (v, got))
+            bad_ok = False
+    print("GAP_BAD_VALUES_FALL_BACK", bad_ok)
+
+    reload_with(None)
+
+
+_probe_gap_knob()
 
 # ------------------------------------------------------------------ fix 2
 dialect = create_sql_dialect("postgresql")
@@ -268,21 +445,31 @@ type ProbeResult = { status: number; stdout: string };
 
 /** Run the probe in a throwaway container, optionally patching first. */
 function runProbe(patched: boolean): ProbeResult {
-  const name = `sr-hs-probe-${patched ? "patched" : "upstream"}-${RUN_ID.slice(0, 8)}`;
+  const name = `sr-hs-probe-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8
+  )}`;
   try {
     execFileSync(
       "docker",
       [
-        "run", "-d",
-        "--name", name,
-        "--label", `switchroom.test=${TEST_PHASE}`,
-        "--label", `switchroom.test.run=${RUN_ID}`,
-        "--user", "root",
-        "--network", "none",
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
         UPSTREAM_IMAGE,
-        "sleep", "300",
+        "sleep",
+        "300",
       ],
-      { stdio: ["ignore", "ignore", "pipe"] },
+      { stdio: ["ignore", "ignore", "pipe"] }
     );
 
     if (patched) {
@@ -300,7 +487,7 @@ function runProbe(patched: boolean): ProbeResult {
     const res = execFileSync(
       "docker",
       ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
-      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
     );
     return { status: 0, stdout: res };
   } catch (e) {
@@ -352,18 +539,18 @@ describe("Dockerfile.hindsight search-patch probe is real, not a silent skip", (
         REQUIRED,
         "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
           "is advisory here. CI's hindsight-probe job sets it after pulling " +
-          `${UPSTREAM_IMAGE}.`,
+          `${UPSTREAM_IMAGE}.`
       ).toBe(false);
       return;
     }
     expect(
       dockerOk,
-      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable",
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable"
     ).toBe(true);
     expect(
       imageOk,
       `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
-        "locally — the workflow must pull the pinned digest before running this suite",
+        "locally — the workflow must pull the pinned digest before running this suite"
     ).toBe(true);
   });
 });
@@ -376,7 +563,7 @@ describe.skipIf(!dockerOk || !imageOk)(
       try {
         const ids = execSync(
           `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
-          { encoding: "utf8" },
+          { encoding: "utf8" }
         )
           .split("\n")
           .filter(Boolean);
@@ -388,67 +575,106 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it(
-      "unpatched upstream is RED on both defects (proves the probe bites)",
-      () => {
-        const { status, stdout } = runProbe(false);
-        expect(stdout, "probe did not run to completion").toContain("PROBE_EXECUTED");
-        expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+    it("unpatched upstream is RED on all three defects (proves the probe bites)", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED"
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
 
-        // Defect 2 — the intact compound never reaches the tsquery.
-        expect(stdout).toContain("tokenize_query destroyed the intact version token");
-        expect(stdout).toContain("TOKENS ['rollout', 'v0', '19', '17']");
-        expect(stdout).toContain("TSQUERY rollout | v0 | 19 | 17");
-        expect(stdout).toContain("intact compound '2026-07-25' missing from the tsquery");
+      // Defect 1 — the concrete inversion: the highest-CE row loses to the
+      // high-proof row.
+      expect(stdout).toContain("saturated CE: proof_count decided the ranking");
+      expect(stdout).toMatch(
+        /SATURATED_ORDER \['old-high-proof', 'fresh-high-ce'\]/
+      );
 
-        // Defect 3 — driven for real: both timeout paths raise an EMPTY message.
-        expect(stdout).toContain(
-          "call timeout raised an EMPTY message",
-        );
-        expect(stdout).toContain(
-          "call_with_tools timeout raised an EMPTY message",
-        );
-        expect(stdout).toMatch(/TIMEOUT call CAUGHT_BY_ASYNCIO_TIMEOUTERROR ''/);
-        expect(stdout).toMatch(
-          /TIMEOUT call_with_tools CAUGHT_BY_ASYNCIO_TIMEOUTERROR ''/,
-        );
-      },
-      240_000,
-    );
+      expect(stdout).toContain("GAP_DEFAULT absent");
+      expect(stdout).toContain(
+        "no _CE_DECISIVE_RELATIVE_GAP module constant - the CE damping patch is not applied"
+      );
 
-    it(
-      "upstream + the baked patch blocks is GREEN, including every safety property",
-      () => {
-        const { status, stdout } = runProbe(true);
-        expect(stdout, "probe did not run to completion").toContain("PROBE_EXECUTED");
-        expect(status, `probe failed:\n${stdout}`).toBe(0);
-        expect(stdout).toContain("FAILURES []");
+      // Defect 2 — the intact compound never reaches the tsquery.
+      expect(stdout).toContain(
+        "tokenize_query destroyed the intact version token"
+      );
+      expect(stdout).toContain("TOKENS ['rollout', 'v0', '19', '17']");
+      expect(stdout).toContain("TSQUERY rollout | v0 | 19 | 17");
+      expect(stdout).toContain(
+        "intact compound '2026-07-25' missing from the tsquery"
+      );
 
-        // Fix 2: the intact compound is APPENDED, never substituted — the
-        // fragments upstream emitted all survive as standalone OR arms, so the
-        // query can only match more documents than upstream, never fewer.
-        expect(stdout).toContain("TOKENS ['rollout', 'v0', '19', '17', 'v0.19.17']");
-        expect(stdout).toContain("TSQUERY rollout | v0 | 19 | 17 | v0.19.17");
-        expect(stdout).toContain("SUPERSET_OK True");
-        expect(stdout).toContain(
-          "COMPOUND_TSQUERY 2026-07-25 '2026 | 07 | 25 | 2026-07-25'",
-        );
-        expect(stdout).toContain(
-          "COMPOUND_TSQUERY state-of-the-art 'state | of | the | art | state-of-the-art'",
-        );
-        // Non-compound queries are byte-identical to upstream.
-        expect(stdout).toContain("PLAIN hello | world");
+      // Defect 3 — driven for real: both timeout paths raise an EMPTY message.
+      expect(stdout).toContain("call timeout raised an EMPTY message");
+      expect(stdout).toContain(
+        "call_with_tools timeout raised an EMPTY message"
+      );
+      expect(stdout).toMatch(/TIMEOUT call CAUGHT_BY_ASYNCIO_TIMEOUTERROR ''/);
+      expect(stdout).toMatch(
+        /TIMEOUT call_with_tools CAUGHT_BY_ASYNCIO_TIMEOUTERROR ''/
+      );
+    }, 240_000);
 
-        // Fix 3: both driven timeouts now carry the timeout/attempts/scope
-        // facts AND are still caught by an upstack asyncio.TimeoutError.
-        expect(stdout).toMatch(
-          /TIMEOUT call CAUGHT_BY_ASYNCIO_TIMEOUTERROR 'LiteLLM call timed out after 0\.05s on 1 attempts \(TimeoutError, scope=memory\)'/,
-        );
-        expect(stdout).toMatch(
-          /TIMEOUT call_with_tools CAUGHT_BY_ASYNCIO_TIMEOUTERROR 'LiteLLM tool call timed out after 0\.05s on 1 attempts \(TimeoutError, scope=tools\)'/,
-        );
-      },
-      240_000,
-    );
-  },
+    it("upstream + the baked patch blocks is GREEN, including every safety property", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED"
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+
+      // Fix 1: highest-CE row now wins despite proof_count 1 vs 10 …
+      expect(stdout).toMatch(
+        /SATURATED_ORDER \['fresh-high-ce', 'old-high-proof'\]/
+      );
+      // … while 1e-7 of CE noise still does NOT get to decide …
+      expect(stdout).toMatch(/NOISE_ORDER \['real-fresh', 'noise-stale'\]/);
+      // … scores are set-independent to the last bit …
+      expect(stdout).toContain("SETDEP_DELTA 0.0 0.0");
+      // … the caller-visible CE field is untouched, so an agent-supplied
+      // min_scores.reranker floor keeps upstream semantics exactly …
+      expect(stdout).toContain("CE_MUTATED False");
+      expect(stdout).toContain("MINSCORES_SURVIVORS 100 / 100");
+      // … and upstream's passthrough branch still works.
+      expect(stdout).toMatch(/PASSTHROUGH 1\.0 0\.0999999/);
+
+      // … the decisive gap defaults to the measured 0.02 but is an operator
+      // knob: a wide gap clamps the exponent to 1.0, i.e. byte-for-byte
+      // upstream scoring with the patch still baked in. That makes backing
+      // this calibration out a container restart, not an image rebuild.
+      expect(stdout).toContain("GAP_DEFAULT 0.02");
+      expect(stdout).toContain(
+        "GAP_ROLLBACK 1.0 1.0 ['old-high-proof', 'fresh-high-ce']"
+      );
+      // … the knob is monotone, and no bad value can break recall.
+      expect(stdout).toMatch(/GAP_MONOTONE \[/);
+      expect(stdout).toContain("GAP_BAD_VALUES_FALL_BACK True");
+
+      // Fix 2: the intact compound is APPENDED, never substituted — the
+      // fragments upstream emitted all survive as standalone OR arms, so the
+      // query can only match more documents than upstream, never fewer.
+      expect(stdout).toContain(
+        "TOKENS ['rollout', 'v0', '19', '17', 'v0.19.17']"
+      );
+      expect(stdout).toContain("TSQUERY rollout | v0 | 19 | 17 | v0.19.17");
+      expect(stdout).toContain("SUPERSET_OK True");
+      expect(stdout).toContain(
+        "COMPOUND_TSQUERY 2026-07-25 '2026 | 07 | 25 | 2026-07-25'"
+      );
+      expect(stdout).toContain(
+        "COMPOUND_TSQUERY state-of-the-art 'state | of | the | art | state-of-the-art'"
+      );
+      // Non-compound queries are byte-identical to upstream.
+      expect(stdout).toContain("PLAIN hello | world");
+
+      // Fix 3: both driven timeouts now carry the timeout/attempts/scope
+      // facts AND are still caught by an upstack asyncio.TimeoutError.
+      expect(stdout).toMatch(
+        /TIMEOUT call CAUGHT_BY_ASYNCIO_TIMEOUTERROR 'LiteLLM call timed out after 0\.05s on 1 attempts \(TimeoutError, scope=memory\)'/
+      );
+      expect(stdout).toMatch(
+        /TIMEOUT call_with_tools CAUGHT_BY_ASYNCIO_TIMEOUTERROR 'LiteLLM tool call timed out after 0\.05s on 1 attempts \(TimeoutError, scope=tools\)'/
+      );
+    }, 240_000);
+  }
 );

--- a/tests/docker/hindsight-search-patches.test.ts
+++ b/tests/docker/hindsight-search-patches.test.ts
@@ -137,6 +137,8 @@ function patchBlocks(): string[] {
  */
 const PROBE = String.raw`
 import asyncio
+import inspect
+import math
 import re
 import sys
 from datetime import datetime, timedelta, timezone
@@ -271,22 +273,72 @@ def _probe_gap_knob():
             _os.environ["HINDSIGHT_CE_DECISIVE_RELATIVE_GAP"] = value
         return importlib.reload(_rr)
 
+    # PRODUCTION ALPHAS. memory_engine.py calls apply_combined_scoring without
+    # passing any alpha, so the SIGNATURE DEFAULTS are what runs for all 12
+    # agents - and every number below (the damping exponent, the clamp
+    # threshold) is a function of them. Pin them: if upstream re-tunes an alpha
+    # the damping silently changes strength, so that must fail loudly here
+    # rather than ship.
+    _sig = inspect.signature(_rr.apply_combined_scoring).parameters
+    ALPHAS = tuple(
+        _sig[n].default for n in ("recency_alpha", "temporal_alpha", "proof_count_alpha")
+    )
+    print("PROD_ALPHAS", ALPHAS)
+    if ALPHAS != (0.2, 0.2, 0.1):
+        failures.append(
+            "apply_combined_scoring's default alphas moved to %r (expected (0.2, 0.2, 0.1)); "
+            "the damping exponent and the ~0.65 kill-switch threshold are both derived "
+            "from them and must be re-measured" % (ALPHAS,)
+        )
+
+    # The MEASURED damping at the production alphas. Undamped, the boost
+    # product's worst-case max/min ratio is ~1.651 - which is exactly why
+    # proof_count could outrank a higher-CE memory in a saturated set. Damped,
+    # it must land on 1 + gap = 1.02 exactly.
+    _hi = _lo = 1.0
+    for _a in ALPHAS:
+        _hi *= 1.0 + _a / 2.0
+        _lo *= 1.0 - _a / 2.0
+    k = _rr._boost_authority(*ALPHAS)
+    print("K_AT_PROD_ALPHAS", k, "UNDAMPED_RATIO", _hi / _lo, "DAMPED_RATIO", (_hi / _lo) ** k)
+    if abs(k - 0.03949271225122802) > 1e-9:
+        failures.append("damping exponent at the production alphas moved to %r (measured 0.0394927)" % (k,))
+    if abs((_hi / _lo) ** k - 1.02) > 1e-9:
+        failures.append(
+            "damped boost product worst-case ratio is %r, not the 1 + gap = 1.02 the "
+            "derivation promises" % ((_hi / _lo) ** k,)
+        )
+
     # A wide gap clamps the exponent to 1.0 - byte-for-byte upstream scoring
     # with the patch still baked in. This is THE rollback path; if it does not
-    # hold, the only way out of a bad calibration is an image rebuild.
+    # hold, the only way out of a bad calibration is an image rebuild. Driven at
+    # the PRODUCTION alphas, where the clamp threshold is exp(log(hi/lo)) - 1 =
+    # ~0.651: just below it must still damp, at/above it must be exactly 1.0.
     m = reload_with("1.0")
     rows = [mk("fresh-high-ce", 0.9999, 1), mk("old-high-proof", 0.9800, 10)]
     m.apply_combined_scoring(rows, NOW)
     ranked = [r.id for r in sorted(rows, key=lambda r: r.combined_score, reverse=True)]
-    exp_off = m._boost_authority(0.1, 0.1, 0.05)
+    exp_off = m._boost_authority(*ALPHAS)
     print("GAP_ROLLBACK", m._CE_DECISIVE_RELATIVE_GAP, exp_off, ranked)
     if abs(exp_off - 1.0) > 1e-12:
         failures.append("HINDSIGHT_CE_DECISIVE_RELATIVE_GAP=1.0 did not clamp the exponent to 1.0 - the env rollback path is broken")
     if ranked[0] != "old-high-proof":
         failures.append("exponent 1.0 did not reproduce upstream scoring - the high-proof row should win again, got %r" % (ranked,))
 
+    # The clamp threshold itself, straddled. Anything at or above it is exact
+    # upstream scoring, so this is the operator-facing "how wide is wide enough"
+    # answer and it must not drift silently.
+    _thresh = math.expm1(math.log(_hi / _lo))
+    _below = reload_with("%.12f" % (_thresh * 0.99,))._boost_authority(*ALPHAS)
+    _at = reload_with("%.12f" % (_thresh * 1.01,))._boost_authority(*ALPHAS)
+    print("GAP_CLAMP_THRESHOLD", _thresh, _below, _at)
+    if not (_below < 1.0):
+        failures.append("a gap just BELOW the ~%.3f clamp threshold already clamped to 1.0 - the knob has lost its range" % (_thresh,))
+    if abs(_at - 1.0) > 1e-12:
+        failures.append("a gap just ABOVE the ~%.3f clamp threshold did not clamp to 1.0 - the documented kill-switch is wrong" % (_thresh,))
+
     # The knob is monotone: a wider gap always damps less.
-    exps = [reload_with(v)._boost_authority(0.1, 0.1, 0.05) for v in ("0.005", "0.02", "0.10", "0.30")]
+    exps = [reload_with(v)._boost_authority(*ALPHAS) for v in ("0.005", "0.02", "0.10", "0.30")]
     print("GAP_MONOTONE", exps)
     if exps != sorted(exps) or exps[0] >= exps[-1]:
         failures.append("decisive-gap knob is not monotone in the damping exponent: %r" % (exps,))
@@ -648,8 +700,25 @@ describe.skipIf(!dockerOk || !imageOk)(
       // upstream scoring with the patch still baked in. That makes backing
       // this calibration out a container restart, not an image rebuild.
       expect(stdout).toContain("GAP_DEFAULT 0.02");
+
+      // memory_engine.py passes NO alphas, so these signature defaults are what
+      // actually runs for all 12 agents — and both numbers below are derived
+      // from them. Pinned so an upstream re-tune cannot silently change the
+      // damping strength.
+      expect(stdout).toContain("PROD_ALPHAS (0.2, 0.2, 0.1)");
+      // The measured damping: k = log1p(0.02) / log(1.651) = 0.0394927, which
+      // collapses the boost product's worst-case ratio from ~1.651 to exactly
+      // 1 + gap = 1.02.
+      expect(stdout).toMatch(
+        /^K_AT_PROD_ALPHAS 0\.03949271225122802 UNDAMPED_RATIO 1\.65107212475633\d* DAMPED_RATIO 1\.02(?:0*\d*)?$/m
+      );
       expect(stdout).toContain(
         "GAP_ROLLBACK 1.0 1.0 ['old-high-proof', 'fresh-high-ce']"
+      );
+      // The kill-switch threshold, straddled at the production alphas: just
+      // below ~0.651 still damps (<1.0), just above is exactly 1.0 = upstream.
+      expect(stdout).toMatch(
+        /GAP_CLAMP_THRESHOLD 0\.65107212475633\d+ 0\.9\d+ 1\.0$/m
       );
       // … the knob is monotone, and no bad value can break recall.
       expect(stdout).toMatch(/GAP_MONOTONE \[/);

--- a/tests/docker/hindsight-search-patches.test.ts
+++ b/tests/docker/hindsight-search-patches.test.ts
@@ -116,6 +116,11 @@ function patchBlocks(): string[] {
  * Deliberately asserts OUTCOMES rather than merely calling the code or
  * grepping its source. Concretely, this file asserts:
  *
+ *  - final rank order out of `apply_combined_scoring`, plus the scoring
+ *    safety properties that order depends on — noise subordination,
+ *    set-independence, an untouched `cross_encoder_score_normalized`, the
+ *    [0, 1] weight scale, and the operator gap knob including its
+ *    clamp-to-upstream rollback path;
  *  - the token list `tokenize_query` returns, and that it stays a strict
  *    superset of upstream's across 8 query shapes;
  *  - the exact tsquery string `prepare_bm25_text` emits — that the intact
@@ -126,9 +131,9 @@ function patchBlocks(): string[] {
  *    LiteLLM retry loops — checked for the timeout/scope facts in the message
  *    and for still being caught by an upstack `except asyncio.TimeoutError`.
  *
- * It asserts nothing about how results are finally ordered. The ranking patch
- * was split into its own PR and its ordering/scoring-safety probes went with
- * it. The test below enforces that this paragraph stays true.
+ * The test below enforces that the rank-order line above stays true in both
+ * directions — this header went stale once already when the ranking patch was
+ * split out and the claim outlived the assertions.
  */
 const PROBE = String.raw`
 import asyncio

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -690,6 +690,29 @@ def _injected_score_stats(results) -> dict:
     single malformed entry cannot drag the aggregate).
 
     Aggregates ONLY — no query text and no memory text is recorded here.
+
+    READING THESE ACROSS THE CE-DAMPING ROLLOUT (#3579). `scores.final` is the
+    engine's `combined_score`, and #3579 changes how that number is composed:
+    ``CE * boost`` becomes ``CE * boost**k`` with k ≈ 0.0395 at the engine's
+    default alphas. So these three fields SHIFT ON DEPLOY as a scale artifact,
+    not as a quality change. Measured against the pinned upstream image on a
+    saturated 100-result band (CE 0.9800-0.9999), the injected top-8 moved from
+    min/median/max 1.0822/1.0843/1.1136 (spread 0.0314) to 0.9977/0.9979/0.9981
+    (spread 0.0004): the level drops ~8% and the spread collapses ~78x as
+    combined_score converges onto the raw cross-encoder score. Two consequences:
+
+      * Any threshold or dashboard band calibrated on pre-#3579 data is invalid
+        afterwards, and a before/after comparison across the deploy boundary
+        measures the rescale, not recall quality. Re-baseline after rollout.
+      * These aggregates are PERMUTATION-INVARIANT over the injected set, so
+        they cannot see a pure re-ordering of the head-slice - which is exactly
+        what #3579 does. They move only when the head-slice MEMBERSHIP changes
+        (in the measured band it changed completely: 0 of 8 ids in common).
+        Membership churn is therefore the signal to watch, not the level.
+
+    Setting `HINDSIGHT_CE_DECISIVE_RELATIVE_GAP` at or above ~0.651 clamps k to
+    1.0 and restores the pre-#3579 scale exactly, which is also how to get a
+    like-for-like reading back.
     """
     empty = {
         "injected_score_min": None,


### PR DESCRIPTION
Stacked on #3568 — the last two commits here are this PR's content; the first three are #3568's. **Base is `main` only because CI workflows are gated on `branches: [main]` and a PR targeting a branch gets no checks at all.** Merge #3568 first; this then reduces to the patch-1 commits alone.

## Why this is separate

#3568's two patches are defect fixes with end-to-end proofs. This one is a **calibration bet**, and a broader one than its first commit message admitted.

`apply_combined_scoring` makes `CE * recency_boost * temporal_boost * proof_count_boost` the only final ranking score (RRF is explicitly zeroed). Measured live on bank `overlord`, a 116-result recall had **every** `cross_encoder_score_normalized` inside 0.9800-0.9999, so the boosts — worst-case max/min ratio ~1.65 — decided the order outright, and the single highest-CE memory ranked 7th behind an older record whose only advantage was `proof_count` 9 vs 1.

The fix damps the boost **product**: `combined = CE * boost**k`, with `k` derived from the alphas so the product's worst-case ratio collapses to exactly `1 + _CE_DECISIVE_RELATIVE_GAP`.

But `k` applies **unconditionally, on every query** — including healthy well-spread result sets that never had the bug, whose secondary-signal authority it cuts ~20x. (**Corrected on rebase — this was previously stated backwards.** Measured against the pinned upstream digest: `memory_engine.py:4822` passes no alphas, so the signature defaults `(0.2, 0.2, 0.1)` are what production runs; there the undamped worst-case boost ratio is `1.6511` and **`k = 0.0394927`**. `k = 0.0791544` is the value at `(0.1, 0.1, 0.05)` — half the defaults, and a regime nothing in the fleet uses. Both numbers are now pinned by the probe.) Those sets keep their CE ordering either way, but the failure mode here is a **silent recall-quality regression across 12 agents**, and there is no recall-quality telemetry that would surface it.

## The kill-switch

So the decisive gap is an operator knob, not a baked constant:

```
HINDSIGHT_CE_DECISIVE_RELATIVE_GAP=<float>
```

read once at import, defaulting to the measured `0.02`. **Any value at or above `0.6511` clamps `k` to 1.0 — byte-for-byte upstream scoring with the patch still baked in.** (Measured exactly at the production alphas; the probe now straddles the threshold, asserting 1% below still damps and 1% above is exactly 1.0.) Rollback is a container restart with one env var, not an image rebuild. Unparseable, empty, non-positive and non-finite values fall back to the default: a bad env var must never take recall down.

## Safety properties (probe-enforced against the pinned digest)

- `cross_encoder_score_normalized` is **never rewritten** — it carries the agent-supplied `min_scores.reranker` floor as an absolute cutoff.
- **Set-independent**: `k` depends only on the alphas, so a candidate's score cannot change because an unrelated document joined the candidate set (`SETDEP_DELTA 0.0 0.0`).
- **Noise-proportional**: a 1e-7 CE difference stays subordinate to the boosts rather than deciding the ranking.
- **Continuous**: no threshold, so no discontinuity cliff.
- `combined_score` stays on the `[0, 1]` CE scale that `recall_boost.py`'s additive levels and `min_scores.final` are calibrated against (`WEIGHT_RATIO_RANGE` bounded to `[0.98, 1.02]`).

## Guard hardening (the two LOW findings)

- The withdrawn-rescale guard is now **structural**, matching the assignment form and asserting the only writer of `cross_encoder_score_normalized` is upstream's own passthrough reseed. **Mutation-proven**: a reformatted reintroduction — `sr.cross_encoder_score_normalized  =  0.1 + (0.9 * (...))` — slips past the old exact-string check (verified: `old-guard-would-catch: False`) and is caught by this one.
- **`import math` is now an anchor.** `_boost_authority` depends on it, so upstream dropping it fails the build loudly instead of surfacing as a `NameError` at recall time. Mutation-proven against the pinned digest: `imports anchor found 0x (expected 1)`.

## Mutation verification

| Mutation | Result |
|---|---|
| Reintroduce a reformatted CE rescale | build assert trips (old guard would not have) |
| Drop `import math` from upstream | build assert trips |
| Unwire the env read (`= _CE_DECISIVE_RELATIVE_GAP_DEFAULT`) | 3 independent probe assertions fail |
| Drop the `try/except` + range check | 5 bad-value probe assertions fail |
| Drop `math.isfinite` only | `nan`, `inf`, `1e400` all fail |

## Testing

`hindsight-search-patches.test.ts` 4/4 and `dockerfile-hindsight-bakes.test.ts` 20/20 against the pinned upstream digest with `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`; `npm run lint` clean. The knob is driven through a real module **reload**, which is exactly what a container restart does in production. The production `switchroom-hindsight` container was never restarted or mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Rebase onto the merged chain (2026-07-25)

Rebased onto `origin/main` after all six chained PRs merged. The first five commits of this branch were the content of #3568, which squash-merged **byte-identically** for every file they touched, so the three damping commits replayed with **no conflicts**.

Three things checked because main moved underneath:

1. **#3568's BM25 compound-token fix and this damping patch coexist.** They are separate `RUN python3 - <<'PYEOF'` blocks patching different upstream files (`engine/search/reranking.py` vs `engine/search/retrieval.py` + the SQL dialect). Not just textually clean — the behavioural probe runs both patch blocks into one container and asserts both outcomes in the same run (`SATURATED_ORDER ['fresh-high-ce', 'old-high-proof']` **and** `TOKENS [... 'v0.19.17']` / `SUPERSET_OK True`), green against the pinned digest.

2. **The `dockerfile-hindsight-bakes.test.ts` negative guards did NOT need inverting.** What #3568 actually left behind is narrower than "assert the patch is absent" — it is two guards forbidding a *re-weighting*:
   ```
   expect(dockerfile).not.toMatch(/_(RECENCY|TEMPORAL|PROOF_COUNT)_ALPHA[^\n]*=\s*\d/);
   expect(dockerfile).not.toMatch(/(recency|temporal|proof_count)_boost\s*=\s*1\.0 \+ \d/);
   ```
   This patch re-weights nothing — it damps the *product* via an exponent, leaving the alphas and the per-boost formulae untouched. So both guards stay **as negative assertions**, unchanged, and still pass. They were mutation-proven rather than assumed: injecting `"_RECENCY_ALPHA  =  0.05\n"` (deliberately reformatted, to defeat an exact-string check) into the patched constant block **fails** the guard. The positive-form coverage for this patch is the separate `keeps the cross-encoder saturation fix` block, also mutation-proven — dropping the exponent (`* _boost` instead of `* (_boost**_boost_exponent)`), substituting a hand-tuned constant for the derivation, and baking the gap as a literal instead of reading the env var each fail it.

3. **It runs in CI.** #3568 wired `dockerfile-hindsight-bakes.test.ts` into the `hindsight-probe` job by explicit path (`docker-e2e.yml:271`), precisely because `vitest --changed` cannot see a Dockerfile read via `readFileSync`; the `hindsight` path filter (`docker-e2e.yml:100-101`) lists both test files, and this PR touches both. No "No test files found".

## Re-measured against the pinned digest

```
PROD_ALPHAS (0.2, 0.2, 0.1)              <- memory_engine passes none; these ship
K_AT_PROD_ALPHAS 0.03949271225122802
UNDAMPED_RATIO   1.6510721247563356  ->  DAMPED_RATIO 1.02   (= 1 + gap, exactly)
GAP_CLAMP_THRESHOLD 0.6510721247563356   below: k=0.99212    above: k=1.0
GAP_ROLLBACK 1.0 1.0 ['old-high-proof', 'fresh-high-ce']
GAP_BAD_VALUES_FALL_BACK True
```

Kill-switch re-confirmed through a real `importlib.reload` (what a container restart does), not assumed: `HINDSIGHT_CE_DECISIVE_RELATIVE_GAP=1.0` clamps `k` to exactly `1.0` and the high-proof row wins again — upstream ordering restored with the patch still baked in.

## Interaction with #3573's new recall telemetry

Yes, and it matters, because those fields are now the only thing that would catch a recall-quality regression from this PR.

`injected_score_{min,median,max}` aggregate `scores.final`, which **is** `combined_score` — the exact quantity this patch rescales. Measured on a saturated 100-result band (CE 0.9800–0.9999), the injected top-8 aggregates move:

| | min / median / max | spread |
|---|---|---|
| undamped (`k = 1`, kill-switch on) | 1.0822 / 1.0843 / 1.1136 | 0.0314 |
| damped (`k = 0.0395`, default) | 0.9977 / 0.9979 / 0.9981 | 0.0004 |

Two consequences an operator has to know before treating these as a quality gauge:

- **The deploy produces a step change that is a rescale artifact, not a quality change** — level down ~8%, spread down ~78x as `combined_score` converges onto the raw CE score. Any threshold or dashboard band calibrated pre-rollout is invalid afterwards, and a before/after comparison across the boundary measures the rescale. Re-baseline after rollout (or set the gap to `0.6511`+ to get a like-for-like reading back).
- **They are permutation-invariant over the injected set, so they are structurally blind to head-slice *re-ordering* — which is this patch's entire effect.** They move only when head-slice *membership* changes (in the measured band it changed completely, 0 of 8 ids in common). Membership churn is the signal to watch, not the level.

Documented in `_injected_score_stats`' docstring in `vendor/hindsight-memory/scripts/recall.py`, where an operator reading the field will find it.
