### PR TITLE
ci: add e2e-ok and python-ok sentinel gates (#3566)

### DIFF
--- a/.github/workflows/ci-tests-python.yml
+++ b/.github/workflows/ci-tests-python.yml
@@ -4,7 +4,11 @@ name: ci-tests-python
 # :snake: Python tests (Hindsight scripts). No bun, no node — pure
 # python3 stdlib unittest.
 #
-# Skip-as-pass pattern (#1320 followup): see ci-lint.yml header.
+# Sentinel pattern: see ci-lint.yml header. The real `unittest` job is
+# path-gated and legitimately reports `skipped` on unrelated PRs, so it
+# cannot be a required check (a skipped required check hard-BLOCKS —
+# #1343 / #2237). The always-running `python-ok` sentinel below is the
+# context ruleset 16470166 should require for this workflow.
 
 on:
   pull_request:
@@ -71,3 +75,30 @@ jobs:
       - name: Run litellm-pacer unittests
         working-directory: docker/litellm-pacer
         run: python3 -m unittest discover -s . -p 'test_*.py'
+
+  # ─── Sentinel ─────────────────────────────────────────────────────
+  # Branch-protection-required context (see ci-lint.yml header for the
+  # pattern). ALWAYS runs: passes when `unittest` succeeded OR was
+  # legitimately path-skipped (PR touching no python), fails on a real
+  # test failure/cancellation, and fails when the `changes` filter job
+  # itself broke — a broken filter must not read as "nothing relevant
+  # changed" and silently disable the gate.
+  python-ok:
+    needs: [changes, unittest]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verdict
+        run: |
+          c='${{ needs.changes.result }}'
+          r='${{ needs.unittest.result }}'
+          if [ "$c" = "failure" ] || [ "$c" = "cancelled" ]; then
+            echo "::error::changes=$c — path-filter infra failed; can't trust the skip"
+            exit 1
+          fi
+          if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+            echo "::error::unittest=$r — real python test failure, blocking"
+            exit 1
+          fi
+          echo "changes=$c unittest=$r → pass (ran=success, or skipped on irrelevant PR)"

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -51,10 +51,21 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
-  # ─── Path-change filter (skip-as-pass pattern, #1320 followup) ────
-  # Workflow ALWAYS runs so the required `e2e` check fires on every
-  # PR. Real job is if:-gated and reports `skipped` (= success for
-  # branch protection) on PRs that don't touch image-affecting paths.
+  # ─── Path-change filter (sentinel pattern; see ci-lint.yml header) ─
+  # This filter job always runs; the real work jobs (`e2e`,
+  # `hindsight-probe`) are `if:`-gated on its outputs and report
+  # `skipped` on PRs that don't touch the paths they cover.
+  #
+  # A `skipped` check is NOT success for branch protection — it BLOCKS
+  # (proven by #1343, a docs-only PR hard-blocked; same deadlock as
+  # #2237). So neither `e2e` nor `hindsight-probe` can be a required
+  # context, and in fact neither has ever been in ruleset 16470166.
+  # The `e2e-ok` sentinel at the bottom of this file exists for exactly
+  # that reason: it ALWAYS runs, so it is the one context here that can
+  # safely be marked required, and it converts "path-skipped" into pass
+  # while still failing on a real failure/cancellation — including a
+  # failure of this `changes` job itself, since a broken path filter
+  # would otherwise silently disable the whole gate.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -289,3 +300,42 @@ jobs:
         run: |
           ids=$(docker ps -aq --filter label=switchroom.test=hindsight-search-patches 2>/dev/null || true)
           if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
+
+  # ─── Sentinel ─────────────────────────────────────────────────────
+  # Branch-protection-required context (see ci-lint.yml header for the
+  # pattern). ALWAYS runs and aggregates the path-gated jobs above:
+  # pass when every one succeeded OR was legitimately path-skipped;
+  # fail when any failed/was cancelled, or when the `changes` filter
+  # job itself broke (can't trust a skip produced by broken infra).
+  # Ruleset 16470166 should require `e2e-ok` as THE single required
+  # context for this workflow — `e2e` and `hindsight-probe` themselves
+  # cannot be required (they legitimately skip, and a skipped required
+  # check hard-blocks: #1343 / #2237). hindsight-probe in particular
+  # exists so the behavioural patch probe can never silently skip; it
+  # only actually gates via this sentinel. Keep this `needs` list
+  # complete when adding jobs.
+  e2e-ok:
+    needs: [changes, e2e, hindsight-probe]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verdict
+        run: |
+          c='${{ needs.changes.result }}'
+          if [ "$c" = "failure" ] || [ "$c" = "cancelled" ]; then
+            echo "::error::changes=$c — path-filter infra failed; can't trust the skip"
+            exit 1
+          fi
+          fail=0
+          for pair in \
+            "e2e=${{ needs.e2e.result }}" \
+            "hindsight-probe=${{ needs.hindsight-probe.result }}"; do
+            job="${pair%%=*}"; r="${pair#*=}"
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "::error::${job}=${r} — real e2e failure, blocking"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1
+          echo "changes=$c → pass (e2e jobs green or path-skipped)"


### PR DESCRIPTION
Refs #3566.

## Problem

`main` is protected by ruleset 16470166 (enforcement active), requiring exactly four contexts: `lint`, `bun-test`, `vitest`, `images-ok`.

Two workflows have real gating jobs that **nothing requires**. `docker-e2e.yml`'s `e2e` / `hindsight-probe` and `ci-tests-python.yml`'s `unittest` are all job-level `if:`-gated on a `changes` path filter, so on an unrelated PR they report `skipped`, not `success`. A skipped required context hard-BLOCKS (#1343, a docs-only PR; same deadlock as #2237), so none of them can be marked required — and none ever have been.

Net effect: `hindsight-probe`, added specifically so the behavioural patch probe can never silently skip, gates nothing. That is exactly the failure it was meant to prevent. And Python under `vendor/hindsight-memory/scripts`, `docker/voice-sidecar`, `docker/litellm-pacer` is untested at merge time.

## Changes

1. **`docker-e2e.yml`** — new `e2e-ok` sentinel, `needs: [changes, e2e, hindsight-probe]`.
2. **`ci-tests-python.yml`** — new `python-ok` sentinel, `needs: [changes, unittest]`.
3. **`docker-e2e.yml` header comment** — a comment claimed `skipped` counts as "success for branch protection" and referred to "the required `e2e` check". Both halves are false, and the skipped-is-success claim is the precise mistake #1343/#2237 were filed about. Rewritten to state the real reason the sentinel exists. A grep of the whole `.github/` tree found no other comment making the same claim (the `Skip-as-pass pattern: see ci-lint.yml header` one-liners in `ci-tests-plugin.yml` / `ci-tests-python.yml` are pointers to the *correct* explanation in `ci-lint.yml`, not restatements of the error).

Both sentinels are modelled directly on the two existing aggregators in this repo — `images-ok` (`docker-images.yml`) and `uat-gate` (`ci-uat.yml`): same `if: always()`, same failure/cancelled verdict logic, same treatment of the `changes` job's own result. No new style invented.

## Correctness proof

The verdict scripts were extracted and executed locally under GitHub's actual step shell (`bash --noprofile --norc -e -o pipefail`) with every `${{ needs.*.result }}` substituted, across the **full** cross-product. Observed results:

`python-ok` — 16/16 combinations:

| changes | unittest | verdict |
|---|---|---|
| success | success | PASS |
| success | skipped | PASS |
| skipped | success | PASS |
| skipped | skipped | PASS |
| success/skipped | failure | **FAIL** |
| success/skipped | cancelled | **FAIL** |
| failure | *(any)* | **FAIL** |
| cancelled | *(any)* | **FAIL** |

`e2e-ok` — 64/64 combinations:

| changes | e2e | hindsight-probe | verdict |
|---|---|---|---|
| success/skipped | success/skipped | success/skipped | PASS (4x2x2 = all 8 pass) |
| success/skipped | *any* | failure or cancelled | **FAIL** |
| success/skipped | failure or cancelled | *any* | **FAIL** |
| failure | *(any)* | *(any)* | **FAIL** |
| cancelled | *(any)* | *(any)* | **FAIL** |

The three required properties hold in the actual run, not just on paper:

- a dependency that legitimately `skipped` (the common case on an unrelated PR) yields **success**;
- a dependency that `failure`d or was `cancelled` yields **failure**;
- `changes` itself failing/cancelled yields **failure** rather than being read as "nothing relevant changed" — a broken filter cannot silently disable the gate.

The `set -e` traps were specifically checked: `e2e-ok`'s `[ "$fail" -eq 0 ] || exit 1` is the safe `||`-guarded form (a false test does not abort the step), and no failure is swallowed by a trailing command's status, since every failure path `exit 1`s before the final `echo`.

## Lint

- `actionlint` 1.7.7 with `-shellcheck`: **clean on all new steps**. The two `SC2086` infos it reports in `docker-e2e.yml` are pre-existing on `origin/main` (verified by re-running against the stashed baseline: same count, same locations, both in the untouched `Label-scoped teardown` steps). Left alone to keep this PR single-concern.
- The repo has no actionlint/workflow-lint step of its own, and no `npm run lint` check reads `.github/` — verified by grepping `package.json` and `scripts/`.
- Both files parse as valid YAML with the expected job sets.

## Follow-up (NOT part of this PR)

Adding `e2e-ok` and `python-ok` to ruleset 16470166 is a **separate step applied by hand by the operator**, once both sentinels have reported on `main` at least once. No repo settings, rulesets, or branch protection are touched here, and auto-merge is not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)