### PR TITLE
fix(gateway): keyed current-turn reads in the three liveness predicates (#3580)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9705,6 +9705,11 @@ function gatewayLivenessWiringDeps() {
     STATE_DIR,
     isLegitimatelyWorking,
     getCurrentTurn: (): CurrentTurn | null => currentTurn,
+    // #3580 — the KEYED read the three liveness predicates in liveness-wiring.ts
+    // use. Flag-OFF this IS the singleton (byte-equivalent to getCurrentTurn());
+    // flag-ON it is THIS topic's own turn, not the most-recent-set mirror, which
+    // answers about whichever topic started a turn last and so false-reaps.
+    getCurrentTurnForKey: (key: string): CurrentTurn | null => currentTurnMap.get(key),
     getInFlightUpdate: () => inFlightUpdate,
     getTurnsDb: () => turnsDb,
     getInboundSpool: (): ReturnType<typeof createInboundSpool> | undefined => inboundSpool,

--- a/telegram-plugin/gateway/liveness-wiring.ts
+++ b/telegram-plugin/gateway/liveness-wiring.ts
@@ -43,6 +43,7 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     STATE_DIR,
     isLegitimatelyWorking,
     getCurrentTurn,
+    getCurrentTurnForKey,
     getInFlightUpdate,
     getTurnsDb,
     getInboundSpool,
@@ -75,7 +76,17 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
   // `activeTurnStartedAt` alone is NOT sufficient — `releaseTurnBufferGate`
   // clears it mid-turn on every final-answer reply while the turn keeps running
   // (post-answer housekeeping), and silence-poke must keep watching that turn.
-  isTurnLive: (key) => !(activeTurnStartedAt.get(key) == null && getCurrentTurn() == null),
+  //
+  // #3580 — the second clause is read KEYED (`getCurrentTurnForKey(key)`, i.e.
+  // `currentTurnMap.get(key)`), never the bare `getCurrentTurn()` singleton.
+  // Under `SWITCHROOM_EMISSION_AUTHORITY=1` that singleton is a MOST-RECENT-SET
+  // MIRROR, so an unkeyed read answers about whichever topic started a turn last
+  // — not about `key`. Combined with the buffer-gate release above, topic A
+  // (live, gate cleared mid-turn) read DEAD as soon as topic B started and ended
+  // a turn, and the tick false-reaped A: permanent and silent, nothing re-arms
+  // until the next `startTurn`, so A loses both its mid-turn beat and its 300 s
+  // #1122 unwedge. Flag-OFF the keyed read IS the singleton, byte-for-byte.
+  isTurnLive: (key) => !(activeTurnStartedAt.get(key) == null && getCurrentTurnForKey(key) == null),
   emitMetric: (event) => {
     // Re-emit through the unified runtime-metrics fan-out (PostHog + JSONL).
     emitRuntimeMetric(event)
@@ -104,8 +115,10 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
   // retired in #2667.
   onMidTurnFloor: async (ctx) => {
     // Late-fire guard, mirroring the fallback: a clean turn-end can race the
-    // tick. If the turn is gone, stay silent.
-    if (activeTurnStartedAt.get(ctx.key) == null && getCurrentTurn() == null) return
+    // tick. If the turn is gone, stay silent. #3580 — keyed read; an unkeyed
+    // `getCurrentTurn()` here answers about another topic's turn (see the
+    // `isTurnLive` note above) and silences a live turn's approval re-ping.
+    if (activeTurnStartedAt.get(ctx.key) == null && getCurrentTurnForKey(ctx.key) == null) return
     const blockedOnApproval = activeStatusReactions
       .get(statusKey(ctx.chatId, ctx.threadId))
       ?.isAwaiting() ?? false
@@ -157,7 +170,11 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     // state armed for the full 300s against a turn that ended minutes earlier,
     // 504 events in 14 days vs 110 real fires — is reaped at the tick instead,
     // so this counter finally reads as the genuine race it names.
-    if (activeTurnStartedAt.get(ctx.key) == null && getCurrentTurn() == null) {
+    //
+    // #3580 — keyed read, same reason as `isTurnLive`: unkeyed, a sibling
+    // topic's turn flip made this guard skip the 300 s unwedge for a genuinely
+    // wedged turn (the #1122 permanent-wedge class) and log it as a clean race.
+    if (activeTurnStartedAt.get(ctx.key) == null && getCurrentTurnForKey(ctx.key) == null) {
       process.stderr.write(
         `telegram gateway: silence-poke framework-fallback late-fire skipped — ` +
         `turn ended cleanly during silence window ` +
@@ -330,6 +347,18 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
       wedgedTurn != null &&
       wedgedTurn.sessionChatId === fbChatId &&
       wedgedTurn.sessionThreadId === fbThreadId
+    // #3580 L3 — the ONE liveness decision this fire makes about the wedged
+    // turn. It gates the teardown below AND is what `decideFallbackTeardownNotice`
+    // is told as `tearsDownLiveTurn`, so the notice can never claim a teardown
+    // the gate skipped (previously the notice got the looser bare
+    // `turnMatchesFallback`, and a user could be told "the framework ended that
+    // stalled turn" about a turn that never ended). Evaluated HERE — before the
+    // `purgeChatStale` self-heal and before `endCurrentTurnForKey`, both of
+    // which drop the very entry `turnLiveForItsTopic` reads — so it answers
+    // "was this turn live when the fallback fired", the question both the
+    // teardown and the notice actually mean.
+    const tearsDownLiveTurn =
+      turnMatchesFallback && wedgedTurn != null && turnLiveForItsTopic(wedgedTurn)
     const turnStartedAt = activeTurnStartedAt.get(fbKey)
     if (turnStartedAt != null) {
       const turnDurationMs = Date.now() - turnStartedAt
@@ -455,7 +484,14 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     // Flag-ON: `byKey.get(fbKey) === wedgedTurn`, so the keyed delete still
     // fires when the LIVE mirror has already flipped to another topic B (a bare
     // `currentTurn === wedgedTurn` would falsely skip and leak A's byKey entry).
-    if (turnMatchesFallback && wedgedTurn != null && turnLiveForItsTopic(wedgedTurn)) {
+    //
+    // #3580 L3 — the gate is the `tearsDownLiveTurn` const computed above, the
+    // SAME value handed to `decideFallbackTeardownNotice`. Do not re-inline the
+    // condition here: it must be evaluated before the `purgeChatStale` sweep
+    // above (which can drop this key's entry and so flip
+    // `turnLiveForItsTopic`), and the notice must speak for exactly what this
+    // gate did.
+    if (tearsDownLiveTurn && wedgedTurn != null) {
       // Status-surface observability: emit the lifecycle CLEAR for the
       // silence-poke teardown so a fallback-nulled turn has a turn-lifecycle
       // line like every other clear path (the framework-fallback line below is
@@ -484,7 +520,7 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     // fire actually killed — at most once, since `endTurn(fbKey)` above dropped
     // the key.
     const teardownNotice = silencePoke.decideFallbackTeardownNotice({
-      tearsDownLiveTurn: turnMatchesFallback,
+      tearsDownLiveTurn,
       role: wedgedTurn?.role ?? null,
       finalAnswerDelivered: wedgedTurn?.finalAnswerDelivered ?? false,
       userAddressedTextDelivered,
@@ -545,7 +581,10 @@ export function buildSilencePokeOptions(deps: LivenessWiringDeps): Parameters<ty
     process.stderr.write(
       `telegram gateway: silence-poke framework-fallback ended wedged turn ` +
       `chat=${fbChatId} thread=${ctx.threadId ?? '-'} silence_ms=${ctx.silenceMs} ` +
-      `currentTurn_nulled=${turnMatchesFallback} ` +
+      // #3580 L3 — report the gate that actually ran, not the looser
+      // chat/thread match: `turnMatchesFallback` was true in cases where the
+      // keyed liveness check skipped the teardown, so the field lied.
+      `currentTurn_nulled=${tearsDownLiveTurn} ` +
       `drained_buffered=${fbRedeliver.redelivered}/${fbRedeliver.drained}` +
       `${fbRedeliver.rebuffered > 0 ? ` rebuffered=${fbRedeliver.rebuffered}` : ''}` +
       `${fbExtraPurge.purged.length > 0 ? ` extra_keys_purged=${fbExtraPurge.purged.length}` : ''}\n`,

--- a/telegram-plugin/tests/helpers/liveness-wiring-fixture.ts
+++ b/telegram-plugin/tests/helpers/liveness-wiring-fixture.ts
@@ -37,8 +37,30 @@ export interface LivenessFixture {
   activeTurnStartedAt: Map<string, number>
   /** Swap the "current turn" the wiring reads. */
   setCurrentTurn: (t: unknown) => void
+  /**
+   * Start a turn FOR A TOPIC KEY. With a `turnMap` supplied (the flag-ON
+   * `CurrentTurnMap`), this is the gateway's `setCurrentTurn(turn, key)`: it
+   * writes the per-topic entry AND flips the most-recent-set mirror. Without
+   * one, it degrades to the flag-OFF singleton assignment.
+   */
+  setCurrentTurnForKey: (key: string, t: unknown) => void
   /** Open obligation ids the per-turn `representWillFollow` lookup consults. */
   openObligations: Set<string>
+}
+
+/**
+ * The subset of the REAL `CurrentTurnMap` (gateway/current-turn-map.ts) the
+ * liveness wiring touches. #3580 tests pass a genuine instance, re-imported
+ * under `SWITCHROOM_EMISSION_AUTHORITY=1` via the module's read-once seam, so
+ * the flag-ON mirror-vs-keyed semantics under test are the production ones and
+ * not a hand-retyped model of them.
+ */
+export interface TurnMapLike {
+  get(key?: string): unknown
+  set(turn: never, key: string): void
+  isLiveForKey(turn: never, key: string): boolean
+  endTurnForKey(turn: never, key: string): boolean
+  purgeChatStale(chatId: string, isStale?: (key: string) => boolean): string[]
 }
 
 export function statusKeyForTests(chatId: string, threadId: number | null | undefined): string {
@@ -62,12 +84,48 @@ export function makeTurn(over: Record<string, unknown> = {}): Record<string, unk
   }
 }
 
-export function makeLivenessFixture(over: Partial<Record<string, unknown>> = {}): LivenessFixture {
+export function makeLivenessFixture(
+  over: Partial<Record<string, unknown>> = {},
+  turnMap?: TurnMapLike,
+): LivenessFixture {
   const sent: SentText[] = []
   const endedKeys: string[] = []
   const activeTurnStartedAt = new Map<string, number>()
   const openObligations = new Set<string>()
   let currentTurn: unknown = null
+
+  // Mirrors gateway.ts's `gatewayLivenessWiringDeps()` exactly. Without a
+  // `turnMap` the fixture models the flag-OFF gateway, where `currentTurnMap`
+  // holds only the singleton and the keyed read `currentTurnMap.get(key)`
+  // returns it — hence `getCurrentTurnForKey` ignoring the key here is the
+  // production flag-OFF behaviour, not a shortcut. With a `turnMap` it is the
+  // real keyed store and every accessor delegates to it.
+  const turnMapDeps = turnMap == null
+    ? {
+        getCurrentTurn: () => currentTurn,
+        getCurrentTurnForKey: (_key: string) => currentTurn,
+        currentTurnMap: { purgeChatStale: () => {} },
+        turnLiveForItsTopic: () => true,
+        endCurrentTurnForKey: (_turn: unknown, key: string) => {
+          endedKeys.push(key)
+          currentTurn = null
+          return true
+        },
+      }
+    : {
+        getCurrentTurn: () => turnMap.get() ?? null,
+        getCurrentTurnForKey: (key: string) => turnMap.get(key) ?? null,
+        currentTurnMap: turnMap,
+        turnLiveForItsTopic: (turn: { sessionChatId: string; sessionThreadId?: number | null }) =>
+          turnMap.isLiveForKey(
+            turn as never,
+            statusKeyForTests(turn.sessionChatId, turn.sessionThreadId),
+          ),
+        endCurrentTurnForKey: (turn: unknown, key: string) => {
+          endedKeys.push(key)
+          return turnMap.endTurnForKey(turn as never, key)
+        },
+      }
 
   const deps = {
     SILENCE_FALLBACK_MS: 300_000,
@@ -79,7 +137,7 @@ export function makeLivenessFixture(over: Partial<Record<string, unknown>> = {})
     TURN_PREVIEW_MAX: 200,
     STATE_DIR: mkdtempSync(join(tmpdir(), 'liveness-wiring-')),
     isLegitimatelyWorking: () => false,
-    getCurrentTurn: () => currentTurn,
+    ...turnMapDeps,
     getInFlightUpdate: () => null,
     getTurnsDb: () => null,
     getInboundSpool: () => undefined,
@@ -94,13 +152,6 @@ export function makeLivenessFixture(over: Partial<Record<string, unknown>> = {})
     lastPtyPreviewByChat: new Map(),
     preambleSuppressor: { dropNow: () => {} },
     purgeReactionTracking: () => {},
-    currentTurnMap: { purgeChatStale: () => {} },
-    turnLiveForItsTopic: () => true,
-    endCurrentTurnForKey: (_turn: unknown, key: string) => {
-      endedKeys.push(key)
-      currentTurn = null
-      return true
-    },
     getPendingInboundBuffer: () => ({ drain: () => [] }),
     trackRedeliveredInbound: () => {},
     closeActivityLane: () => {},
@@ -114,7 +165,14 @@ export function makeLivenessFixture(over: Partial<Record<string, unknown>> = {})
     sent,
     endedKeys,
     activeTurnStartedAt,
-    setCurrentTurn: (t: unknown) => { currentTurn = t },
+    setCurrentTurn: (t: unknown) => {
+      if (turnMap != null) throw new Error('use setCurrentTurnForKey with a keyed turnMap')
+      currentTurn = t
+    },
+    setCurrentTurnForKey: (key: string, t: unknown) => {
+      if (turnMap == null) { currentTurn = t; return }
+      turnMap.set(t as never, key)
+    },
     openObligations,
   }
 }

--- a/telegram-plugin/tests/silence-poke-orphan-reap.test.ts
+++ b/telegram-plugin/tests/silence-poke-orphan-reap.test.ts
@@ -13,7 +13,7 @@
  * These tests assert the OUTCOME (state gone, no fallback delivered, real fires
  * unaffected), not merely that the code path runs.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import {
@@ -28,7 +28,7 @@ import {
   type FrameworkFallbackContext,
 } from '../silence-poke.js'
 import { buildSilencePokeOptions } from '../gateway/liveness-wiring.js'
-import { makeLivenessFixture } from './helpers/liveness-wiring-fixture.js'
+import { makeLivenessFixture, type TurnMapLike } from './helpers/liveness-wiring-fixture.js'
 
 const ORIGINAL_KILL_SWITCH = process.env.SWITCHROOM_DISABLE_SILENCE_POKE
 
@@ -148,8 +148,14 @@ describe('#3552 — the production isTurnLive predicate', () => {
   const src = readFileSync(join(__dirname, '..', 'gateway', 'liveness-wiring.ts'), 'utf8')
   const KEY = '-100999:11'
 
+  /** Source lines with comments stripped — a canonical string in a comment must never pay for a code site. */
+  const codeLines = src.split('\n').filter((l) => {
+    const t = l.trim()
+    return !(t.startsWith('//') || t.startsWith('*') || t.startsWith('/*'))
+  })
+
   it('is wired with BOTH clauses ANDed — the near-miss this fix turns on', () => {
-    const line = src.split('\n').find((l) => l.includes('isTurnLive:'))
+    const line = codeLines.find((l) => l.includes('isTurnLive:'))
     expect(line, 'isTurnLive must be wired in liveness-wiring.ts').toBeDefined()
     // EXACT text, not a bag of fragments. #3575 review: the previous form
     // asserted four independent regexes that each had to match SOMEWHERE on the
@@ -164,9 +170,33 @@ describe('#3552 — the production isTurnLive predicate', () => {
     // `releaseTurnBufferGate` clears it mid-turn on every final-answer reply,
     // so a predicate missing (or effectively cancelling) the `getCurrentTurn()`
     // clause silently reaps live turns doing post-answer work.
+    //
+    // #3580: the second clause is the KEYED read. `getCurrentTurn()` is the
+    // most-recent-set MIRROR under SWITCHROOM_EMISSION_AUTHORITY=1, so an
+    // unkeyed read answers about whichever topic started a turn LAST — not
+    // about `key` — and false-reaps a live turn whose buffer gate was released.
     expect(line!.trim()).toBe(
-      'isTurnLive: (key) => !(activeTurnStartedAt.get(key) == null && getCurrentTurn() == null),',
+      'isTurnLive: (key) => !(activeTurnStartedAt.get(key) == null && getCurrentTurnForKey(key) == null),',
     )
+    // Belt and braces on the mutation the exact-equality pin exists for: the
+    // reaper must not read the unkeyed singleton at all.
+    expect(line!).not.toMatch(/getCurrentTurn\(\)/)
+  })
+
+  it('the two late-fire guards read keyed too — exact lines, so no site can drift back', () => {
+    // #3580 M1: all three sites change TOGETHER. One keyed + two unkeyed leaves
+    // the reaper and the guards disagreeing about liveness, which is worse than
+    // the consistent-but-wrong state it replaces. Exact trimmed equality (not
+    // fragment regexes) is the only form that forbids an extra conjunct.
+    const guards = codeLines
+      .map((l) => l.trim())
+      .filter((t) => t.includes('activeTurnStartedAt.get(ctx.key)'))
+    expect(guards).toEqual([
+      // onMidTurnFloor
+      'if (activeTurnStartedAt.get(ctx.key) == null && getCurrentTurnForKey(ctx.key) == null) return',
+      // onFrameworkFallback
+      'if (activeTurnStartedAt.get(ctx.key) == null && getCurrentTurnForKey(ctx.key) == null) {',
+    ])
   })
 
   it('matches the late-fire guard it was deliberately copied from', () => {
@@ -177,15 +207,12 @@ describe('#3552 — the production isTurnLive predicate', () => {
     // #3575 review: scan CODE only. Counting occurrences across the raw file let
     // an OR-for-AND swap survive by leaving the canonical text behind in a stale
     // comment — the comment paid for the missing code site.
-    const code = src
-      .split('\n')
-      .filter((l) => {
-        const t = l.trim()
-        return !(t.startsWith('//') || t.startsWith('*') || t.startsWith('/*'))
-      })
-      .join('\n')
-    const predicate = /activeTurnStartedAt\.get\([\w.]+\) == null && getCurrentTurn\(\) == null/g
-    expect((code.match(predicate) ?? []).length).toBeGreaterThanOrEqual(3)
+    const code = codeLines.join('\n')
+    const predicate = /activeTurnStartedAt\.get\(([\w.]+)\) == null && getCurrentTurnForKey\(\1\) == null/g
+    expect((code.match(predicate) ?? []).length).toBe(3)
+    // ...and no site may drift BACK to the unkeyed singleton read (#3580).
+    const unkeyed = /activeTurnStartedAt\.get\([\w.]+\) == null && getCurrentTurn\(\) == null/g
+    expect(code.match(unkeyed) ?? []).toEqual([])
   })
 
   // #3575 review B3 — EXECUTE the real predicate. The previous version of this
@@ -226,27 +253,50 @@ describe('#3552 — the production isTurnLive predicate', () => {
     expect(realPredicate(m, null)(KEY)).toBe(true)
   })
 
-  // The dangerous case, end to end through silence-poke's own tick, with the
-  // REAL predicate wired as the reaper. `releaseTurnBufferGate` (turn-end.ts:371)
-  // deletes the `activeTurnStartedAt` entry on EVERY reply finalize — including
-  // a mid-turn interim ack — while the turn keeps running; `getCurrentTurn()` is
-  // the UNKEYED singleton mirror. So a still-running turn whose gate was
-  // released AND whose mirror has been nulled by another topic reads dead on
-  // BOTH clauses, and IS reaped. This test states that residual honestly rather
-  // than pretending the conjunction covers it: a false reap is permanent and
-  // silent (nothing re-arms until the next `startTurn`), costing the turn both
-  // its mid-turn beat and its 300s unwedge. The durable fix is a keyed liveness
-  // read (or a re-arm safety), NOT a wider predicate — see #3580.
-  it('documents the residual: with BOTH signals dead the tick reaps, even mid-turn', async () => {
+  // #3580 — the case #3575 could only DOCUMENT (as "with BOTH signals dead the
+  // tick reaps, even mid-turn") is now FIXED, so this asserts the opposite
+  // outcome. `releaseTurnBufferGate` (turn-end.ts) deletes the
+  // `activeTurnStartedAt` entry on EVERY reply finalize — including a mid-turn
+  // interim ack — while the turn keeps running. Under
+  // SWITCHROOM_EMISSION_AUTHORITY=1 the singleton is a most-recent-set MIRROR,
+  // so once topic B started and ended a turn the UNKEYED read said null for
+  // topic A too: A read dead on BOTH clauses and was false-reaped — permanent
+  // and silent (nothing re-arms until the next `startTurn`), costing A its
+  // mid-turn beat and its 300 s #1122 unwedge. The keyed read resolves A's OWN
+  // entry, so A stays armed.
+  //
+  // The `CurrentTurnMap` here is the REAL production class, re-imported with
+  // the flag ON through its read-once seam (mirroring per-topic-current-turn's
+  // `loadMap`) — not a hand-modelled stand-in of the mirror semantics.
+  async function loadFlagOnTurnMap(): Promise<TurnMapLike> {
+    const prev = process.env.SWITCHROOM_EMISSION_AUTHORITY
+    process.env.SWITCHROOM_EMISSION_AUTHORITY = '1'
+    try {
+      vi.resetModules()
+      const mod = await import('../gateway/current-turn-map.js')
+      expect(mod.EMISSION_AUTHORITY_ENABLED, 'the re-import seam must observe the flag').toBe(true)
+      return new mod.CurrentTurnMap<unknown>() as unknown as TurnMapLike
+    } finally {
+      if (prev == null) delete process.env.SWITCHROOM_EMISSION_AUTHORITY
+      else process.env.SWITCHROOM_EMISSION_AUTHORITY = prev
+    }
+  }
+
+  const KEY_B = '-100999:22'
+
+  it('flag-ON: a mid-turn topic A survives topic B starting AND ending a turn (the false reap #3580 closes)', async () => {
     const emitted: SilencePokeMetric[] = []
     const fallbacks: FrameworkFallbackContext[] = []
-    const fx = makeLivenessFixture()
-    // Turn A is live for THIS key...
+    const turnMap = await loadFlagOnTurnMap()
+    const fx = makeLivenessFixture({}, turnMap)
+    const turnA = { turnId: 'a#1', sessionChatId: '-100999', sessionThreadId: 11 }
+    const turnB = { turnId: 'b#1', sessionChatId: '-100999', sessionThreadId: 22 }
+
+    // Topic A is live for THIS key.
     fx.activeTurnStartedAt.set(KEY, 0)
-    fx.setCurrentTurn({ turnId: 'a#1' })
-    const opts = buildSilencePokeOptions(fx.deps)
+    fx.setCurrentTurnForKey(KEY, turnA)
     __setDepsForTests({
-      ...opts,
+      ...buildSilencePokeOptions(fx.deps),
       emitMetric: (e) => emitted.push(e),
       onFrameworkFallback: async (ctx) => { fallbacks.push(ctx) },
     })
@@ -254,22 +304,58 @@ describe('#3552 — the production isTurnLive predicate', () => {
     __tickForTests(5_000)
     expect(__getStateForTests(KEY)).toBeDefined()
 
-    // ...then the final answer lands: releaseTurnBufferGate drops the
-    // activeTurnStartedAt entry, and currentTurn is nulled — while the turn
-    // keeps doing post-answer work.
+    // A's final answer lands: releaseTurnBufferGate drops A's activeTurnStartedAt
+    // entry while A keeps doing post-answer work.
     fx.activeTurnStartedAt.delete(KEY)
-    fx.setCurrentTurn(null)
-    __tickForTests(10_000)
+    // Then topic B starts (flipping the most-recent-set mirror off A) and ends.
+    fx.setCurrentTurnForKey(KEY_B, turnB)
+    fx.deps.endCurrentTurnForKey(turnB as never, KEY_B)
 
-    // Ground truth of the near-miss: BOTH naive readings say "dead" here.
+    // Ground truth of the trap: BOTH signals a naive/unkeyed reader consults
+    // now say "dead" for A, even though A is running.
     expect(fx.activeTurnStartedAt.get(KEY) == null).toBe(true)
     expect(fx.deps.getCurrentTurn() == null).toBe(true)
-    // ...and the real wiring still reaps it, because the conjunction is what
-    // the predicate negates. (Documented outcome: this IS a reap. See the
-    // re-arm note in the test below.)
+    // ...but the keyed read still resolves A's own topic.
+    expect(fx.deps.getCurrentTurnForKey(KEY)).toBe(turnA)
+
+    __tickForTests(10_000)
+
+    // The outcome that matters: A is NOT reaped, so it keeps its mid-turn beat.
+    expect(__getStateForTests(KEY)).toBeDefined()
+    expect(emitted.some((e) => e.kind === 'silence_poke_orphan_reaped')).toBe(false)
+    // ...and its 300 s unwedge still fires — the #1122 protection survives.
+    __tickForTests(310_000)
+    expect(fallbacks.map((f) => f.key)).toEqual([KEY])
+  })
+
+  it('flag-ON: a topic whose OWN turn ended is still reaped (the keyed read did not disable the reaper)', async () => {
+    const emitted: SilencePokeMetric[] = []
+    const turnMap = await loadFlagOnTurnMap()
+    const fx = makeLivenessFixture({}, turnMap)
+    const turnA = { turnId: 'a#1', sessionChatId: '-100999', sessionThreadId: 11 }
+    const turnB = { turnId: 'b#1', sessionChatId: '-100999', sessionThreadId: 22 }
+
+    fx.activeTurnStartedAt.set(KEY, 0)
+    fx.setCurrentTurnForKey(KEY, turnA)
+    // A live sibling B exists the whole time — under an unkeyed read its
+    // presence would have kept the dead A armed forever.
+    fx.setCurrentTurnForKey(KEY_B, turnB)
+    __setDepsForTests({
+      ...buildSilencePokeOptions(fx.deps),
+      emitMetric: (e) => emitted.push(e),
+      onFrameworkFallback: async () => {},
+    })
+    startTurn(KEY, 0)
+    __tickForTests(5_000)
+    expect(__getStateForTests(KEY)).toBeDefined()
+
+    // A ends via a path that forgot endTurn(): gate cleared, keyed entry gone.
+    fx.activeTurnStartedAt.delete(KEY)
+    fx.deps.endCurrentTurnForKey(turnA as never, KEY)
+    __tickForTests(10_000)
+
     expect(__getStateForTests(KEY)).toBeUndefined()
-    expect(emitted.some((e) => e.kind === 'silence_poke_orphan_reaped')).toBe(true)
-    expect(fallbacks).toHaveLength(0)
+    expect(emitted.filter((e) => e.kind === 'silence_poke_orphan_reaped')).toHaveLength(1)
   })
 
   it('keeps a live turn armed whenever EITHER liveness signal survives (the conjunction is load-bearing)', () => {

--- a/telegram-plugin/tests/silence-poke-orphan-reap.test.ts
+++ b/telegram-plugin/tests/silence-poke-orphan-reap.test.ts
@@ -13,7 +13,7 @@
  * These tests assert the OUTCOME (state gone, no fallback delivered, real fires
  * unaffected), not merely that the code path runs.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import {
@@ -268,14 +268,25 @@ describe('#3552 — the production isTurnLive predicate', () => {
   // The `CurrentTurnMap` here is the REAL production class, re-imported with
   // the flag ON through its read-once seam (mirroring per-topic-current-turn's
   // `loadMap`) — not a hand-modelled stand-in of the mirror semantics.
+  // The re-import-per-flag seam is the query-string idiom from
+  // per-topic-current-turn.test.ts's `loadMap`: the flag is read ONCE at module
+  // top, and a fresh query string forces a fresh evaluation against the env we
+  // set here. Deliberately NOT `vi.resetModules()` — this suite runs under BOTH
+  // vitest and `bun test` in CI, and bun ignores it (the flag-ON tests then
+  // silently ran flag-OFF and failed there while passing locally).
   async function loadFlagOnTurnMap(): Promise<TurnMapLike> {
     const prev = process.env.SWITCHROOM_EMISSION_AUTHORITY
     process.env.SWITCHROOM_EMISSION_AUTHORITY = '1'
     try {
-      vi.resetModules()
-      const mod = await import('../gateway/current-turn-map.js')
+      // A STATIC specifier with a distinguishing query — the module is
+      // evaluated once, under the flag we just set, and both flag-ON tests
+      // share that evaluation (each still builds its own map instance). A
+      // template-literal specifier is not statically analyzable and Vite
+      // rejects it ("Unknown variable dynamic import"); `vi.resetModules()`
+      // is a no-op under bun. This form works under both runners.
+      const mod = await import('../gateway/current-turn-map.js?emissionAuthorityOn')
       expect(mod.EMISSION_AUTHORITY_ENABLED, 'the re-import seam must observe the flag').toBe(true)
-      return new mod.CurrentTurnMap<unknown>() as unknown as TurnMapLike
+      return new mod.CurrentTurnMap() as TurnMapLike
     } finally {
       if (prev == null) delete process.env.SWITCHROOM_EMISSION_AUTHORITY
       else process.env.SWITCHROOM_EMISSION_AUTHORITY = prev

--- a/telegram-plugin/tests/silence-poke-teardown-notice.test.ts
+++ b/telegram-plugin/tests/silence-poke-teardown-notice.test.ts
@@ -170,6 +170,72 @@ describe('#3551 — the teardown notice actually reaches the user (integration)'
   })
 })
 
+/**
+ * #3580 L3 — `tearsDownLiveTurn` must be the SAME predicate as the teardown
+ * gate, not a looser restatement of it.
+ *
+ * The old wiring passed the bare `turnMatchesFallback` (chat + thread equality)
+ * while the teardown itself additionally required `turnLiveForItsTopic`. When
+ * those disagree the decider is told a live turn was torn down when it was not,
+ * and the user gets a terminal "the framework ended that stalled turn" notice
+ * about a turn that never ended.
+ */
+describe('#3580 L3 — the notice speaks for exactly the teardown that ran', () => {
+  const CHAT = '-100999'
+  const THREAD = 11
+  const KEY = `${CHAT}:${THREAD}`
+
+  afterEach(() => {
+    __resetAllForTests()
+    __setDepsForTests(null)
+  })
+
+  async function fire(turnLiveForItsTopic: () => boolean) {
+    const fx = makeLivenessFixture({ turnLiveForItsTopic })
+    const turn = makeTurn({ sessionChatId: CHAT, sessionThreadId: THREAD, turnId: `${KEY}#42` })
+    fx.activeTurnStartedAt.set(KEY, 0)
+    fx.setCurrentTurn(turn)
+    fx.openObligations.add(`${KEY}#42`)
+    __setDepsForTests(buildSilencePokeOptions(fx.deps))
+    startTurn(KEY, 0)
+    __tickForTests(301_000)
+    await new Promise((r) => setTimeout(r, 0))
+    return fx
+  }
+
+  it('stays quiet when the keyed liveness check SKIPPED the teardown', async () => {
+    // chat + thread match (so the loose `turnMatchesFallback` is true), but the
+    // keyed read says this turn is no longer live for its own topic — so no
+    // teardown happens. The user must not be told their turn was ended.
+    const fx = await fire(() => false)
+    expect(fx.endedKeys, 'no teardown must have run').toEqual([])
+    expect(fx.sent.filter((s) => s.text.includes('framework ended')), 'no teardown notice').toEqual([])
+  })
+
+  it('still speaks when the teardown DID run (the guard did not mute the honest case)', async () => {
+    const fx = await fire(() => true)
+    expect(fx.endedKeys).toContain(KEY)
+    expect(fx.sent.some((s) => s.text.includes('the framework ended that stalled turn'))).toBe(true)
+  })
+
+  it('the decider is fed the gate ITSELF — exactly one evaluation, no restatement', () => {
+    const code = readFileSync(join(__dirname, '..', 'gateway', 'liveness-wiring.ts'), 'utf8')
+      .split('\n')
+      .filter((l) => {
+        const t = l.trim()
+        return !(t.startsWith('//') || t.startsWith('*') || t.startsWith('/*'))
+      })
+    // Declared once...
+    expect(code.filter((l) => l.trim().startsWith('const tearsDownLiveTurn')).length).toBe(1)
+    // ...passed by shorthand (a `tearsDownLiveTurn: <anything>` restatement is
+    // exactly the L3 divergence, and would re-admit `: turnMatchesFallback`)...
+    expect(code.map((l) => l.trim())).toContain('tearsDownLiveTurn,')
+    expect(code.join('\n')).not.toMatch(/tearsDownLiveTurn:/)
+    // ...and it is the gate on the teardown block, not a parallel condition.
+    expect(code.map((l) => l.trim())).toContain('if (tearsDownLiveTurn && wedgedTurn != null) {')
+  })
+})
+
 describe('#3551 — wiring: the teardown path actually sends the notice', () => {
   // buildSilencePokeOptions needs the whole gateway module's dep object, which
   // cannot be instantiated in a unit test (module-load side effects). Pin the


### PR DESCRIPTION
Closes #3580.

## The bug

`getCurrentTurn()` is the process-wide singleton. Under `SWITCHROOM_EMISSION_AUTHORITY=1` it is a **most-recent-set MIRROR**, not a per-topic read, so the three unkeyed calls in `telegram-plugin/gateway/liveness-wiring.ts` answered about whichever topic started a turn last — not about the `key` they were asked about.

`releaseTurnBufferGate` (turn-end.ts) deletes the `activeTurnStartedAt` entry on **every** reply finalize, including a mid-turn interim ack, while the turn keeps running. So topic A (live, gate released) read DEAD on *both* clauses the moment topic B started and ended a turn:

- **`isTurnLive` reaper** — false reap. Permanent and silent: nothing re-arms until the next `startTurn`, so A loses its mid-turn beat **and** its 300 s #1122 unwedge. That is the #1122 permanent-wedge class.
- **the two late-fire guards** — mis-claim: a genuinely wedged turn gets logged as `turn_ended_cleanly_during_window` and the unwedge is skipped.

## The fix

New dep `getCurrentTurnForKey(key)` = `currentTurnMap.get(key)`. Flag-OFF that IS the singleton, so all three sites are byte-equivalent to before; flag-ON it resolves the topic's own `byKey` entry. **All three change together** — one keyed site with two unkeyed ones leaves the reaper and the guards disagreeing about liveness, which is worse than the consistent-but-wrong state.

**L3.** `tearsDownLiveTurn` passed the loose `turnMatchesFallback` while the teardown gate also required `turnLiveForItsTopic`, so `decideFallbackTeardownNotice` could tell a user "the framework ended that stalled turn" about a turn that never ended. Both now read ONE const, evaluated **before** the `purgeChatStale` self-heal and `endCurrentTurnForKey` (either of which flips `turnLiveForItsTopic`), so it answers the question both the teardown and the notice actually mean. The `currentTurn_nulled=` log field now reports that same value instead of the looser match.

## Tests — the issue's amended obligation

1. **Exact trimmed-string equality on whole lines**, not fragment regexes — for the reaper *and* both guards (`toEqual` on the exact two guard lines, so an extra conjunct cannot hide).
2. **Drift scan over COMMENT-STRIPPED code**, with a backreference (`\1`) tying both clauses to the same key expression, `toBe(3)` (not `>=`), plus an explicit "no site drifted back to `getCurrentTurn()`" assertion.
3. **The REAL predicate executes** — via `tests/helpers/liveness-wiring-fixture.ts` (#3575), extended to optionally carry a **genuine flag-ON `CurrentTurnMap`** re-imported through the module's read-once seam. No hand-modelled mirror semantics.
4. **The #3575 residual is gone, not restated as still-true.** "documents the residual: with BOTH signals dead the tick reaps, even mid-turn" is replaced by the two-topic interleaving, asserting A stays armed and *still* gets its 300 s fallback, plus a counterpart proving a genuinely-dead topic is still reaped with a live sibling present.

### Mutation kill table (12/12 killed)

| # | mutant | result |
|---|---|---|
| M1 | `isTurnLive` inverted (drop the `!`) | KILLED |
| M2 | `isTurnLive` dropped `getCurrentTurnForKey` clause | KILLED |
| M3 | `isTurnLive` OR-for-AND | KILLED |
| M4 | `isTurnLive` naive reduction (`&& activeTurnStartedAt.get(key) != null`) | KILLED |
| M5 | `isTurnLive` `&& false` (reaper disabled for every key) | KILLED |
| M6 | `isTurnLive` regressed to unkeyed `getCurrentTurn()` | KILLED |
| M7 | `onMidTurnFloor` guard regressed to unkeyed | KILLED |
| M8 | `onFrameworkFallback` guard regressed to unkeyed | KILLED |
| M9 | `onFrameworkFallback` guard OR-for-AND | KILLED |
| M10 | L3 notice restated as loose `turnMatchesFallback` | KILLED |
| M11 | L3 teardown gate diverges from the notice value | KILLED |
| M12 | L3 predicate loosened (drop `turnLiveForItsTopic`) | KILLED |

## Not in scope (reported, not fixed)

Two further unkeyed `getCurrentTurn()` reads remain in this file. Both are *guarded*, so neither can act on the wrong topic, and the issue enumerated exactly three sites — flagging rather than silently widening the change-set:

- `floorState` reads unkeyed then rejects on a `statusKey` mismatch, so flag-ON it returns `null` for topic A when the mirror points at B — the mid-turn floor goes *silent* for A rather than firing wrongly.
- `const wedgedTurn = getCurrentTurn()` in `onFrameworkFallback` is likewise filtered by `turnMatchesFallback`; flag-ON it can miss A's teardown (leaking A's `byKey` entry until the `purgeChatStale` self-heal) but never tears down the wrong turn.

Local: scoped suites green; `npm run lint` clean. (`approval-hold-record.test.ts` fails in this container both with and without the change — it models an unwritable dir, which uid 0 can write anyway. Unrelated.)
