### PR TITLE
fix(ci): drop Docker Hub dependency from manifest-only docker-images jobs

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -271,7 +271,14 @@ jobs:
       # build-hindsight / build-voice) still set up buildx — they need
       # the docker-container driver for multi-platform + cache export.
       # Only the four manifest-only jobs (merge-base, merge-dependents,
-      # retag-unchanged, promote-to-dev) drop it.
+      # retag-unchanged, promote-to-dev) drop it. The same fix applies
+      # to promote.yml's `promote` job, which had the identical bug on
+      # the RELEASE path.
+      #
+      # Enforced by tests/docker/manifest-jobs-no-buildx.test.ts: these
+      # jobs never run on a PR, so a test is the only thing that stops a
+      # future edit from silently re-adding the action and reintroducing
+      # a post-merge-only red.
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
@@ -436,26 +443,9 @@ jobs:
       matrix:
         image: [agent, broker, kernel, hostd, auth-broker, web]
     steps:
-      # NO `docker/setup-buildx-action` here, deliberately. This job is
-      # manifest-only: `docker buildx imagetools inspect|create` are pure
-      # registry operations that never touch BuildKit, and the buildx CLI
-      # is preinstalled on GitHub-hosted runners with a `default` builder
-      # on the `docker` driver. setup-buildx-action defaults to the
-      # `docker-container` driver, which boots a BuildKit container by
-      # pulling `moby/buildkit:buildx-stable-1` from DOCKER HUB — a hard
-      # docker.io dependency (unauthenticated, rate-limited, and outside
-      # GHCR) for a capability these jobs never use. That pull is what
-      # reddened main twice: run 30138853707 (retag-unchanged,
-      # 2026-07-25) and run 29977369227 (promote-to-dev, 2026-07-23),
-      # both `ERROR: ... registry-1.docker.io/v2/: ... Client.Timeout
-      # exceeded` while "booting buildkit". Dropping the step removes the
-      # dependency outright rather than retrying around it.
-      #
-      # NOTE: the real BUILD jobs (build-base / build-dependents /
-      # build-hindsight / build-voice) still set up buildx — they need
-      # the docker-container driver for multi-platform + cache export.
-      # Only the four manifest-only jobs (merge-base, merge-dependents,
-      # retag-unchanged, promote-to-dev) drop it.
+      # NO `docker/setup-buildx-action` here, deliberately — manifest-only
+      # job; see the full rationale on merge-base above. Enforced by
+      # tests/docker/manifest-jobs-no-buildx.test.ts.
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
@@ -692,26 +682,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # NO `docker/setup-buildx-action` here, deliberately. This job is
-      # manifest-only: `docker buildx imagetools inspect|create` are pure
-      # registry operations that never touch BuildKit, and the buildx CLI
-      # is preinstalled on GitHub-hosted runners with a `default` builder
-      # on the `docker` driver. setup-buildx-action defaults to the
-      # `docker-container` driver, which boots a BuildKit container by
-      # pulling `moby/buildkit:buildx-stable-1` from DOCKER HUB — a hard
-      # docker.io dependency (unauthenticated, rate-limited, and outside
-      # GHCR) for a capability these jobs never use. That pull is what
-      # reddened main twice: run 30138853707 (retag-unchanged,
-      # 2026-07-25) and run 29977369227 (promote-to-dev, 2026-07-23),
-      # both `ERROR: ... registry-1.docker.io/v2/: ... Client.Timeout
-      # exceeded` while "booting buildkit". Dropping the step removes the
-      # dependency outright rather than retrying around it.
-      #
-      # NOTE: the real BUILD jobs (build-base / build-dependents /
-      # build-hindsight / build-voice) still set up buildx — they need
-      # the docker-container driver for multi-platform + cache export.
-      # Only the four manifest-only jobs (merge-base, merge-dependents,
-      # retag-unchanged, promote-to-dev) drop it.
+      # NO `docker/setup-buildx-action` here, deliberately — manifest-only
+      # job; see the full rationale on merge-base above. Enforced by
+      # tests/docker/manifest-jobs-no-buildx.test.ts.
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
@@ -843,26 +816,9 @@ jobs:
         # advancing (web was missing until #2818's follow-up).
         image: [base, agent, broker, kernel, hostd, auth-broker, web, hindsight, voice]
     steps:
-      # NO `docker/setup-buildx-action` here, deliberately. This job is
-      # manifest-only: `docker buildx imagetools inspect|create` are pure
-      # registry operations that never touch BuildKit, and the buildx CLI
-      # is preinstalled on GitHub-hosted runners with a `default` builder
-      # on the `docker` driver. setup-buildx-action defaults to the
-      # `docker-container` driver, which boots a BuildKit container by
-      # pulling `moby/buildkit:buildx-stable-1` from DOCKER HUB — a hard
-      # docker.io dependency (unauthenticated, rate-limited, and outside
-      # GHCR) for a capability these jobs never use. That pull is what
-      # reddened main twice: run 30138853707 (retag-unchanged,
-      # 2026-07-25) and run 29977369227 (promote-to-dev, 2026-07-23),
-      # both `ERROR: ... registry-1.docker.io/v2/: ... Client.Timeout
-      # exceeded` while "booting buildkit". Dropping the step removes the
-      # dependency outright rather than retrying around it.
-      #
-      # NOTE: the real BUILD jobs (build-base / build-dependents /
-      # build-hindsight / build-voice) still set up buildx — they need
-      # the docker-container driver for multi-platform + cache export.
-      # Only the four manifest-only jobs (merge-base, merge-dependents,
-      # retag-unchanged, promote-to-dev) drop it.
+      # NO `docker/setup-buildx-action` here, deliberately — manifest-only
+      # job; see the full rationale on merge-base above. Enforced by
+      # tests/docker/manifest-jobs-no-buildx.test.ts.
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -252,9 +252,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
-
+      # NO `docker/setup-buildx-action` here, deliberately. This job is
+      # manifest-only: `docker buildx imagetools inspect|create` are pure
+      # registry operations that never touch BuildKit, and the buildx CLI
+      # is preinstalled on GitHub-hosted runners with a `default` builder
+      # on the `docker` driver. setup-buildx-action defaults to the
+      # `docker-container` driver, which boots a BuildKit container by
+      # pulling `moby/buildkit:buildx-stable-1` from DOCKER HUB — a hard
+      # docker.io dependency (unauthenticated, rate-limited, and outside
+      # GHCR) for a capability these jobs never use. That pull is what
+      # reddened main twice: run 30138853707 (retag-unchanged,
+      # 2026-07-25) and run 29977369227 (promote-to-dev, 2026-07-23),
+      # both `ERROR: ... registry-1.docker.io/v2/: ... Client.Timeout
+      # exceeded` while "booting buildkit". Dropping the step removes the
+      # dependency outright rather than retrying around it.
+      #
+      # NOTE: the real BUILD jobs (build-base / build-dependents /
+      # build-hindsight / build-voice) still set up buildx — they need
+      # the docker-container driver for multi-platform + cache export.
+      # Only the four manifest-only jobs (merge-base, merge-dependents,
+      # retag-unchanged, promote-to-dev) drop it.
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
@@ -419,9 +436,26 @@ jobs:
       matrix:
         image: [agent, broker, kernel, hostd, auth-broker, web]
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
-
+      # NO `docker/setup-buildx-action` here, deliberately. This job is
+      # manifest-only: `docker buildx imagetools inspect|create` are pure
+      # registry operations that never touch BuildKit, and the buildx CLI
+      # is preinstalled on GitHub-hosted runners with a `default` builder
+      # on the `docker` driver. setup-buildx-action defaults to the
+      # `docker-container` driver, which boots a BuildKit container by
+      # pulling `moby/buildkit:buildx-stable-1` from DOCKER HUB — a hard
+      # docker.io dependency (unauthenticated, rate-limited, and outside
+      # GHCR) for a capability these jobs never use. That pull is what
+      # reddened main twice: run 30138853707 (retag-unchanged,
+      # 2026-07-25) and run 29977369227 (promote-to-dev, 2026-07-23),
+      # both `ERROR: ... registry-1.docker.io/v2/: ... Client.Timeout
+      # exceeded` while "booting buildkit". Dropping the step removes the
+      # dependency outright rather than retrying around it.
+      #
+      # NOTE: the real BUILD jobs (build-base / build-dependents /
+      # build-hindsight / build-voice) still set up buildx — they need
+      # the docker-container driver for multi-platform + cache export.
+      # Only the four manifest-only jobs (merge-base, merge-dependents,
+      # retag-unchanged, promote-to-dev) drop it.
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
@@ -658,9 +692,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
-
+      # NO `docker/setup-buildx-action` here, deliberately. This job is
+      # manifest-only: `docker buildx imagetools inspect|create` are pure
+      # registry operations that never touch BuildKit, and the buildx CLI
+      # is preinstalled on GitHub-hosted runners with a `default` builder
+      # on the `docker` driver. setup-buildx-action defaults to the
+      # `docker-container` driver, which boots a BuildKit container by
+      # pulling `moby/buildkit:buildx-stable-1` from DOCKER HUB — a hard
+      # docker.io dependency (unauthenticated, rate-limited, and outside
+      # GHCR) for a capability these jobs never use. That pull is what
+      # reddened main twice: run 30138853707 (retag-unchanged,
+      # 2026-07-25) and run 29977369227 (promote-to-dev, 2026-07-23),
+      # both `ERROR: ... registry-1.docker.io/v2/: ... Client.Timeout
+      # exceeded` while "booting buildkit". Dropping the step removes the
+      # dependency outright rather than retrying around it.
+      #
+      # NOTE: the real BUILD jobs (build-base / build-dependents /
+      # build-hindsight / build-voice) still set up buildx — they need
+      # the docker-container driver for multi-platform + cache export.
+      # Only the four manifest-only jobs (merge-base, merge-dependents,
+      # retag-unchanged, promote-to-dev) drop it.
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
@@ -792,9 +843,26 @@ jobs:
         # advancing (web was missing until #2818's follow-up).
         image: [base, agent, broker, kernel, hostd, auth-broker, web, hindsight, voice]
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
-
+      # NO `docker/setup-buildx-action` here, deliberately. This job is
+      # manifest-only: `docker buildx imagetools inspect|create` are pure
+      # registry operations that never touch BuildKit, and the buildx CLI
+      # is preinstalled on GitHub-hosted runners with a `default` builder
+      # on the `docker` driver. setup-buildx-action defaults to the
+      # `docker-container` driver, which boots a BuildKit container by
+      # pulling `moby/buildkit:buildx-stable-1` from DOCKER HUB — a hard
+      # docker.io dependency (unauthenticated, rate-limited, and outside
+      # GHCR) for a capability these jobs never use. That pull is what
+      # reddened main twice: run 30138853707 (retag-unchanged,
+      # 2026-07-25) and run 29977369227 (promote-to-dev, 2026-07-23),
+      # both `ERROR: ... registry-1.docker.io/v2/: ... Client.Timeout
+      # exceeded` while "booting buildkit". Dropping the step removes the
+      # dependency outright rather than retrying around it.
+      #
+      # NOTE: the real BUILD jobs (build-base / build-dependents /
+      # build-hindsight / build-voice) still set up buildx — they need
+      # the docker-container driver for multi-platform + cache export.
+      # Only the four manifest-only jobs (merge-base, merge-dependents,
+      # retag-unchanged, promote-to-dev) drop it.
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -57,9 +57,20 @@ jobs:
       matrix:
         image: [base, agent, broker, kernel, hostd, auth-broker, hindsight, voice]
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
-
+      # NO `docker/setup-buildx-action` here, deliberately. Every step in
+      # this job is manifest-only (`imagetools inspect` / `imagetools
+      # create`) — pure GHCR registry operations that never touch
+      # BuildKit. setup-buildx-action defaults to the `docker-container`
+      # driver, which boots BuildKit by pulling
+      # `moby/buildkit:buildx-stable-1` from DOCKER HUB, giving this job
+      # a hard docker.io dependency it never uses. The identical bug in
+      # docker-images.yml reddened main twice (runs 30138853707 and
+      # 29977369227) with `ERROR: ... registry-1.docker.io/v2/: ...
+      # Client.Timeout exceeded` while "booting buildkit" — and here the
+      # blast radius is worse, because this is the RELEASE promotion
+      # path: a docker.io blip breaks a release, not just a main push.
+      #
+      # Enforced by tests/docker/manifest-jobs-no-buildx.test.ts.
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:

--- a/tests/docker/manifest-jobs-no-buildx.test.ts
+++ b/tests/docker/manifest-jobs-no-buildx.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Guard: a manifest-only workflow job must never set up buildx.
+ *
+ * `docker buildx imagetools inspect|create` are pure registry
+ * operations. `docker/setup-buildx-action` defaults to the
+ * `docker-container` driver, which boots BuildKit by pulling
+ * `moby/buildkit:buildx-stable-1` from **Docker Hub** — a hard,
+ * unauthenticated, rate-limited docker.io dependency for a capability
+ * those jobs never use.
+ *
+ * It reddened main twice: run 30138853707 (2026-07-25, `retag-unchanged`)
+ * and run 29977369227 (2026-07-23, `promote-to-dev`), both with
+ * `ERROR: ... Get "https://registry-1.docker.io/v2/": ... Client.Timeout
+ * exceeded while awaiting headers` under `> [internal] booting buildkit`.
+ *
+ * Why this test has to exist: every one of these jobs is gated off
+ * `pull_request` (or is `workflow_dispatch`-only), so NONE of them run on
+ * a PR. A future edit re-adding `setup-buildx-action` to a manifest-only
+ * job is invisible until main goes red again. This test is the only
+ * deterministic thing standing between that edit and a post-merge red.
+ *
+ * The rule is derived from the job's own content, not a hardcoded job
+ * list, so a NEW manifest-only job is covered the day it is added.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { parse } from 'yaml'
+
+const REPO = resolve(import.meta.dirname, '../..')
+const WORKFLOWS = ['docker-images.yml', 'promote.yml']
+
+const BUILDX_ACTION = 'docker/setup-buildx-action'
+const BUILD_ACTION = 'docker/build-push-action'
+
+interface Step {
+  uses?: string
+  run?: string
+  name?: string
+}
+interface Job {
+  steps?: Step[]
+}
+
+function loadJobs(file: string): Array<[string, Job]> {
+  const raw = readFileSync(join(REPO, '.github/workflows', file), 'utf8')
+  const doc = parse(raw) as { jobs?: Record<string, Job> }
+  return Object.entries(doc.jobs ?? {})
+}
+
+function stepsOf(job: Job): Step[] {
+  return Array.isArray(job.steps) ? job.steps : []
+}
+
+/** A job is "manifest-only" if it runs imagetools and never builds. */
+function isManifestOnly(job: Job): boolean {
+  const steps = stepsOf(job)
+  const usesImagetools = steps.some((s) => (s.run ?? '').includes('imagetools'))
+  const buildsImages = steps.some((s) => (s.uses ?? '').includes(BUILD_ACTION))
+  return usesImagetools && !buildsImages
+}
+
+function usesBuildx(job: Job): boolean {
+  return stepsOf(job).some((s) => (s.uses ?? '').includes(BUILDX_ACTION))
+}
+
+describe('manifest-only workflow jobs never set up buildx (no docker.io dependency)', () => {
+  const all = WORKFLOWS.flatMap((f) =>
+    loadJobs(f).map(([name, job]) => ({ file: f, name, job })),
+  )
+
+  it('finds the manifest-only jobs it is meant to guard (the rule matches reality)', () => {
+    // Sanity floor: if a refactor renames or restructures these jobs so
+    // the heuristic stops matching anything, the assertions below would
+    // pass vacuously. Pin the known set so that regression is loud.
+    const found = all.filter((j) => isManifestOnly(j.job)).map((j) => `${j.file}:${j.name}`)
+    expect(found.sort()).toEqual([
+      'docker-images.yml:merge-base',
+      'docker-images.yml:merge-dependents',
+      'docker-images.yml:promote-to-dev',
+      'docker-images.yml:retag-unchanged',
+      'promote.yml:promote',
+    ])
+  })
+
+  it.each(WORKFLOWS)('%s — no manifest-only job references setup-buildx-action', (file) => {
+    const offenders = loadJobs(file)
+      .filter(([, job]) => isManifestOnly(job) && usesBuildx(job))
+      .map(([name]) => name)
+
+    expect(
+      offenders,
+      `${file}: job(s) [${offenders.join(', ')}] only run \`imagetools\` but set up ` +
+        `${BUILDX_ACTION}. Its default docker-container driver pulls ` +
+        `moby/buildkit from Docker Hub — a docker.io dependency these jobs ` +
+        `never use, and a post-merge-only red when Docker Hub is slow ` +
+        `(runs 30138853707, 29977369227). Drop the step; imagetools needs no builder.`,
+    ).toEqual([])
+  })
+
+  it('real BUILD jobs still set up buildx (the guard is not over-broad)', () => {
+    // The rule must NOT push anyone to strip buildx from jobs that
+    // genuinely need the docker-container driver for multi-platform
+    // builds and cache export.
+    const builders = all
+      .filter((j) => stepsOf(j.job).some((s) => (s.uses ?? '').includes(BUILD_ACTION)))
+      .map((j) => j.name)
+    expect(builders.length).toBeGreaterThan(0)
+    for (const name of builders) {
+      const job = all.find((j) => j.name === name)!.job
+      expect(usesBuildx(job), `build job ${name} must still set up buildx`).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Root cause

`merge-base`, `merge-dependents`, `retag-unchanged` and `promote-to-dev` in `.github/workflows/docker-images.yml` only run `docker buildx imagetools inspect|create` — pure registry operations against GHCR. They never build. Yet each opened with `docker/setup-buildx-action`, whose default `docker-container` driver boots a BuildKit container by pulling `moby/buildkit:buildx-stable-1` from **docker.io**.

That gave four otherwise-GHCR-only jobs a hard, unauthenticated, rate-limited Docker Hub dependency they don't use — and it reddened `main` twice:

- **run [30138853707](https://github.com/switchroom/switchroom/actions/runs/30138853707)** (2026-07-25, `retag-unchanged`, the most recent main failure): `#1 pulling image moby/buildkit:buildx-stable-1 15.0s done` then `ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)` under `> [internal] booting buildkit`.
- **run [29977369227](https://github.com/switchroom/switchroom/actions/runs/29977369227)** (2026-07-23, `promote-to-dev`): same error, `context deadline exceeded`.

## Why post-merge only

All four jobs are gated on `github.event_name != 'pull_request'` / `refs/heads/main`. PR CI never executes them, so the required contexts stay green and the failure only appears after merge — exactly the class of failure this is about.

## Fix: removal, not retry

The buildx CLI is preinstalled on GitHub-hosted runners with a `default` builder on the `docker` driver, and `imagetools` talks to registries directly with no builder at all. Verified against a clean `DOCKER_CONFIG` with no builder configured and none created on the daemon:

```
$ DOCKER_CONFIG=$(mktemp -d) buildx imagetools inspect ghcr.io/actions/actions-runner:latest
Name:      ghcr.io/actions/actions-runner:latest
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:0cfdcc701ce933c6d243c6b0b2da767366dc9f2e99961d4c3754b0b78084cdda
Manifests:
  ... linux/amd64, linux/arm64
$ buildx ls
NAME/NODE   DRIVER/ENDPOINT   STATUS    BUILDKIT   PLATFORMS
default*    docker            running   v0.29.0    linux/amd64 (+3)
```

The real build jobs (`build-base`, `build-dependents`, `build-hindsight`, `build-voice`) **keep** `setup-buildx-action` — they genuinely need the docker-container driver for multi-platform builds and cache export.

## Verification

- `tests/docker/ci-image-matrix.test.ts` — 5 passed
- `npm run lint` — clean
- No test skipped, no `continue-on-error`, no assertion loosened

## Note for the reviewer

These four jobs don't run on `pull_request`, so this PR's own CI cannot exercise them. The behavioural claim is backed by the `buildx` transcript above rather than by a green check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)