### PR TITLE
fix(ci): ci-infra-watchdog no longer reddens main on a transient GitHub 503

### DIFF
--- a/.github/workflows/ci-infra-watchdog.yml
+++ b/.github/workflows/ci-infra-watchdog.yml
@@ -27,6 +27,30 @@
 # classification read degrades to a `::warning` + exit 0 instead of
 # reddening main — see the script header for the three 2026-07-20 runs
 # that motivated it.
+#
+# RESIDUAL RISK, stated plainly: a genuine infra force-fail that
+# COINCIDES with a REST API brownout now produces no issue, no red, and
+# no notification — only a `::warning` annotation on a workflow run
+# nobody is watching. That is a real hole. It is accepted because both
+# alternatives are worse: guessing a classification fabricates alerts,
+# and failing the job reports a GitHub outage as a red on the commit,
+# which is the false signal this workflow exists to eliminate. If the
+# correlated case ever bites, the fix is to make the alert path not
+# depend on the read (e.g. always open a low-confidence issue on any
+# unclassifiable main red) — not to re-enable the red.
+#
+# Scope of the hardening, honestly: only the CLASSIFICATION READ is
+# outage-tolerant. The job as a whole is not, and cannot be — it runs on
+# a GitHub-hosted runner, is triggered by a GitHub `workflow_run` event,
+# and checks out from github.com. If GitHub is down hard enough, this
+# workflow does not execute at all. Retry-wrapping the checkout below
+# was considered and rejected: `actions/checkout` already retries its
+# own git operations with backoff, reimplementing that around a
+# composite action adds failure surface rather than removing it, and it
+# would not move the floor set by the runner and the trigger both being
+# GitHub. The checkout is a new dependency this change introduced; it is
+# documented here rather than papered over with `continue-on-error`,
+# which would silently run the watchdog against a missing script.
 name: ci-infra-watchdog
 
 on:

--- a/.github/workflows/ci-infra-watchdog.yml
+++ b/.github/workflows/ci-infra-watchdog.yml
@@ -19,6 +19,14 @@
 # Known gap: the watchdog itself runs on hosted runners and could
 # also be starved in a severe outage. Accepted — this is a backstop,
 # not a guarantee. Auto-requeue was explicitly out of scope.
+#
+# The classification logic lives in `scripts/ci/infra-watchdog.sh`
+# (unit-tested by `tests/ci-infra-watchdog.test.ts`) rather than inline
+# here, so its retry/degrade behaviour is actually asserted. Consistent
+# with the accepted gap above, a GitHub REST API outage that defeats the
+# classification read degrades to a `::warning` + exit 0 instead of
+# reddening main — see the script header for the three 2026-07-20 runs
+# that motivated it.
 name: ci-infra-watchdog
 
 on:
@@ -56,6 +64,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # The classifier lives in scripts/ci/infra-watchdog.sh (extracted
+      # from this yaml so it is unit-testable — see
+      # tests/ci-infra-watchdog.test.ts). Checkout at `main`, not at the
+      # failing run's head_sha: this is repo TOOLING, and pinning it to
+      # the (possibly broken) commit under investigation would let a bad
+      # commit disable its own watchdog.
+      - name: Checkout watchdog tooling (main)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
       - name: Classify failure and alert if infra signature
         env:
           GH_TOKEN: ${{ github.token }}
@@ -65,67 +85,4 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-        run: |
-          set -euo pipefail
-
-          # --paginate --slurp walks every page and wraps them as
-          # [{page1},{page2},...]; flatten .[].jobs[] so a run with
-          # >100 jobs whose failures land on page 2+ is still counted.
-          # Without this a large matrix could undercount failures to 0
-          # and mis-classify a genuine red as an infra force-fail —
-          # the exact false-positive that defeats this watchdog.
-          jobs_json="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --paginate --slurp)"
-          failed_jobs="$(echo "$jobs_json" | jq '[.[].jobs[] | select(.conclusion=="failure")] | length')"
-
-          if [ "${failed_jobs:-0}" -ne 0 ]; then
-            echo "Run $RUN_ID ($WF_NAME): $failed_jobs job(s) reported failure — genuine red, not an infra force-fail. No alert."
-            exit 0
-          fi
-
-          echo "Infra signature: $WF_NAME @ $HEAD_SHA concluded '$RUN_CONCLUSION' with 0 failing jobs (jobs skipped/queued/never-scheduled)."
-
-          # Idempotent label.
-          gh label create ci-infra-failure \
-            --repo "$REPO" \
-            --color B60205 \
-            --description "Main CI red from infra/queue force-fail, not a code regression" \
-            2>/dev/null || true
-
-          existing="$(gh issue list --repo "$REPO" --state open --label ci-infra-failure \
-            --json number,title \
-            --jq "[.[] | select(.title | contains(\"$HEAD_SHA\"))][0].number // empty")"
-
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --repo "$REPO" \
-              --body "Another infra/queue force-fail on the same commit: **$WF_NAME** — run: $RUN_URL"
-            echo "Commented on existing issue #$existing"
-            exit 0
-          fi
-
-          {
-            printf '%s\n' "Automated infra alert — this is NOT a code or test regression."
-            printf '%s\n' ""
-            printf '%s\n' "Workflow \"$WF_NAME\" failed on main @ $HEAD_SHA, but no job reported"
-            printf '%s\n' "a failure — every job was skipped, cancelled, or never scheduled."
-            printf '%s\n' "That is the GitHub hosted-runner queue force-fail signature (jobs"
-            printf '%s\n' "sit queued past the scheduling window and GHA fails the run before"
-            printf '%s\n' "tests execute), or a workflow startup error. Either way, the test"
-            printf '%s\n' "code never ran, so main is red on infra, not on the commit."
-            printf '%s\n' ""
-            printf '%s\n' "Failed run: $RUN_URL"
-            printf '%s\n' ""
-            printf '%s\n' "Recovery (workflow_dispatch was wired in #1340):"
-            printf '%s\n' "    gh workflow run <workflow-file>.yml --ref main"
-            printf '%s\n' "Re-dispatch the affected workflow(s), confirm green, then close"
-            printf '%s\n' "this issue. If it recurs immediately, suspect a real GHA outage"
-            printf '%s\n' "(check https://www.githubstatus.com) rather than re-dispatching"
-            printf '%s\n' "in a loop."
-            printf '%s\n' ""
-            printf '%s\n' "cc @mekenthompson"
-          } > /tmp/ci-infra-alert.md
-
-          gh issue create --repo "$REPO" \
-            --title "CI infra: main red without job execution @ $HEAD_SHA" \
-            --label ci-infra-failure \
-            --body-file /tmp/ci-infra-alert.md
-          echo "Opened new infra-alert issue."
+        run: bash scripts/ci/infra-watchdog.sh

--- a/scripts/ci/infra-watchdog.sh
+++ b/scripts/ci/infra-watchdog.sh
@@ -50,18 +50,34 @@ WATCHDOG_BASE_DELAY="${WATCHDOG_BASE_DELAY:-2}"
 # failures land on page 2+ is still counted. Without this a large matrix
 # could undercount failures to 0 and mis-classify a genuine red as an
 # infra force-fail — the exact false-positive that defeats this watchdog.
+# NOTE on the stderr handling below — do NOT "simplify" it back to
+# `2>&1`. Capturing stderr into the same variable as stdout looks
+# harmless because we only read it on the failure path, but command
+# substitution merges the streams on the SUCCESS path too. Any benign
+# diagnostic `gh` writes to stderr while still exiting 0 — an OAuth
+# scope warning, a deprecation notice, pagination progress — would be
+# prepended to the JSON, and `jq` below would then die with
+# `parse error: Invalid numeric literal` under `set -euo pipefail`.
+# That is precisely the "watchdog reddens main for a non-reason" bug
+# this script exists to prevent, so keep the streams separate: stdout
+# is data, stderr is diagnostics, and only diagnostics reach the
+# warning message.
 jobs_json=""
+gh_err_file="$(mktemp)"
+gh_err=""
+trap 'rm -f "$gh_err_file"' EXIT
 attempt=1
 delay="$WATCHDOG_BASE_DELAY"
 while :; do
-  if jobs_json="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --paginate --slurp 2>&1)"; then
+  if jobs_json="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --paginate --slurp 2>"$gh_err_file")"; then
     break
   fi
+  gh_err="$(cat "$gh_err_file")"
   if [ "$attempt" -ge "$WATCHDOG_MAX_ATTEMPTS" ]; then
-    echo "::warning title=ci-infra-watchdog could not classify::Reading jobs for run $RUN_ID failed $WATCHDOG_MAX_ATTEMPTS times (GitHub REST API unavailable). Skipping classification for $WF_NAME @ $HEAD_SHA — no alert raised, and no red reported for a GitHub-side outage. Last error: ${jobs_json}"
+    echo "::warning title=ci-infra-watchdog could not classify::Reading jobs for run $RUN_ID failed $WATCHDOG_MAX_ATTEMPTS times (GitHub REST API unavailable). Skipping classification for $WF_NAME @ $HEAD_SHA — no alert raised, and no red reported for a GitHub-side outage. Last error: ${gh_err}"
     exit 0
   fi
-  echo "gh api attempt ${attempt}/${WATCHDOG_MAX_ATTEMPTS} failed; retrying in ${delay}s. Error: ${jobs_json}"
+  echo "gh api attempt ${attempt}/${WATCHDOG_MAX_ATTEMPTS} failed; retrying in ${delay}s. Error: ${gh_err}"
   sleep "$delay"
   attempt=$((attempt + 1))
   delay=$((delay * 2))

--- a/scripts/ci/infra-watchdog.sh
+++ b/scripts/ci/infra-watchdog.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# ci-infra-watchdog classifier — extracted from
+# .github/workflows/ci-infra-watchdog.yml so it can be tested with a
+# stubbed `gh` on PATH (the yaml-embedded version had no test at all).
+#
+# Contract (all inputs via env):
+#   GH_TOKEN, REPO, RUN_ID, WF_NAME, HEAD_SHA, RUN_URL, RUN_CONCLUSION
+#
+# Outcomes:
+#   - >=1 job with conclusion "failure"  -> genuine red, no alert, exit 0.
+#   - 0 failing jobs                     -> infra force-fail signature,
+#                                           open/de-dupe an issue, exit 0.
+#   - classification read unavailable    -> ::warning + exit 0 (see below).
+#
+# Why the classification read retries, and why exhausting the retries is
+# a warning rather than a failure:
+#
+# The read is a single idempotent GET. On 2026-07-20 the GitHub REST API
+# brownouted and returned `HTTP 503 No server is currently available to
+# service your request` to this step in three consecutive watchdog runs
+# — 29709703593 (00:35Z), 29710301287 (01:01Z), 29710576955 (01:12Z).
+# With `set -euo pipefail` and no retry, each 503 killed the step and
+# painted `main` red. In all three the underlying workflow was a GENUINE
+# red (the `scaffold.persona` byte-ceiling regression), so the correct
+# outcome was the silent `exit 0` path — the watchdog reported a failure
+# it was explicitly built NOT to report.
+#
+# Retrying the GET recovers the common single-blip case. Exhausting the
+# retries means GitHub's own API is unavailable, which is precisely the
+# gap this workflow's header already documents as accepted ("this is a
+# backstop, not a guarantee"). Turning a GitHub outage into a red main
+# is a false signal about the commit, so we degrade to a loud
+# `::warning` annotation (visible on the run) and exit 0. We never
+# *guess* a classification: no read, no alert.
+set -euo pipefail
+
+: "${REPO:?REPO required}"
+: "${RUN_ID:?RUN_ID required}"
+: "${WF_NAME:?WF_NAME required}"
+: "${HEAD_SHA:?HEAD_SHA required}"
+: "${RUN_URL:?RUN_URL required}"
+: "${RUN_CONCLUSION:?RUN_CONCLUSION required}"
+
+# Bounded retry knobs (overridable so the tests don't sleep for a minute).
+WATCHDOG_MAX_ATTEMPTS="${WATCHDOG_MAX_ATTEMPTS:-5}"
+WATCHDOG_BASE_DELAY="${WATCHDOG_BASE_DELAY:-2}"
+
+# --paginate --slurp walks every page and wraps them as
+# [{page1},{page2},...]; flatten .[].jobs[] so a run with >100 jobs whose
+# failures land on page 2+ is still counted. Without this a large matrix
+# could undercount failures to 0 and mis-classify a genuine red as an
+# infra force-fail — the exact false-positive that defeats this watchdog.
+jobs_json=""
+attempt=1
+delay="$WATCHDOG_BASE_DELAY"
+while :; do
+  if jobs_json="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --paginate --slurp 2>&1)"; then
+    break
+  fi
+  if [ "$attempt" -ge "$WATCHDOG_MAX_ATTEMPTS" ]; then
+    echo "::warning title=ci-infra-watchdog could not classify::Reading jobs for run $RUN_ID failed $WATCHDOG_MAX_ATTEMPTS times (GitHub REST API unavailable). Skipping classification for $WF_NAME @ $HEAD_SHA — no alert raised, and no red reported for a GitHub-side outage. Last error: ${jobs_json}"
+    exit 0
+  fi
+  echo "gh api attempt ${attempt}/${WATCHDOG_MAX_ATTEMPTS} failed; retrying in ${delay}s. Error: ${jobs_json}"
+  sleep "$delay"
+  attempt=$((attempt + 1))
+  delay=$((delay * 2))
+done
+
+failed_jobs="$(echo "$jobs_json" | jq '[.[].jobs[] | select(.conclusion=="failure")] | length')"
+
+if [ "${failed_jobs:-0}" -ne 0 ]; then
+  echo "Run $RUN_ID ($WF_NAME): $failed_jobs job(s) reported failure — genuine red, not an infra force-fail. No alert."
+  exit 0
+fi
+
+echo "Infra signature: $WF_NAME @ $HEAD_SHA concluded '$RUN_CONCLUSION' with 0 failing jobs (jobs skipped/queued/never-scheduled)."
+
+# Idempotent label.
+gh label create ci-infra-failure \
+  --repo "$REPO" \
+  --color B60205 \
+  --description "Main CI red from infra/queue force-fail, not a code regression" \
+  2>/dev/null || true
+
+existing="$(gh issue list --repo "$REPO" --state open --label ci-infra-failure \
+  --json number,title \
+  --jq "[.[] | select(.title | contains(\"$HEAD_SHA\"))][0].number // empty")"
+
+if [ -n "$existing" ]; then
+  gh issue comment "$existing" --repo "$REPO" \
+    --body "Another infra/queue force-fail on the same commit: **$WF_NAME** — run: $RUN_URL"
+  echo "Commented on existing issue #$existing"
+  exit 0
+fi
+
+body_file="$(mktemp)"
+{
+  printf '%s\n' "Automated infra alert — this is NOT a code or test regression."
+  printf '%s\n' ""
+  printf '%s\n' "Workflow \"$WF_NAME\" failed on main @ $HEAD_SHA, but no job reported"
+  printf '%s\n' "a failure — every job was skipped, cancelled, or never scheduled."
+  printf '%s\n' "That is the GitHub hosted-runner queue force-fail signature (jobs"
+  printf '%s\n' "sit queued past the scheduling window and GHA fails the run before"
+  printf '%s\n' "tests execute), or a workflow startup error. Either way, the test"
+  printf '%s\n' "code never ran, so main is red on infra, not on the commit."
+  printf '%s\n' ""
+  printf '%s\n' "Failed run: $RUN_URL"
+  printf '%s\n' ""
+  printf '%s\n' "Recovery (workflow_dispatch was wired in #1340):"
+  printf '%s\n' "    gh workflow run <workflow-file>.yml --ref main"
+  printf '%s\n' "Re-dispatch the affected workflow(s), confirm green, then close"
+  printf '%s\n' "this issue. If it recurs immediately, suspect a real GHA outage"
+  printf '%s\n' "(check https://www.githubstatus.com) rather than re-dispatching"
+  printf '%s\n' "in a loop."
+  printf '%s\n' ""
+  printf '%s\n' "cc @mekenthompson"
+} > "$body_file"
+
+gh issue create --repo "$REPO" \
+  --title "CI infra: main red without job execution @ $HEAD_SHA" \
+  --label ci-infra-failure \
+  --body-file "$body_file"
+echo "Opened new infra-alert issue."

--- a/tests/ci-infra-watchdog.test.ts
+++ b/tests/ci-infra-watchdog.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Outcome tests for `scripts/ci/infra-watchdog.sh` — the classifier
+ * behind `.github/workflows/ci-infra-watchdog.yml`.
+ *
+ * The watchdog's whole job is to tell an infra force-fail (no job ever
+ * reported "failure") apart from a genuine red, and to alert ONLY on the
+ * former. The logic used to live inline in the workflow yaml with no
+ * test, and it shipped a bug: the classification `gh api` read had no
+ * retry, so a transient `HTTP 503` from GitHub's REST API killed the step
+ * under `set -euo pipefail` and painted main red. That happened three
+ * times on 2026-07-20 (runs 29709703593, 29710301287, 29710576955) — and
+ * in every one the underlying workflow was a genuine red, i.e. the
+ * correct outcome was a silent exit 0.
+ *
+ * Each test drives the real script with a stub `gh` on PATH that records
+ * its argv and replays scripted responses, then asserts on OUTCOMES:
+ * exit status, and whether an issue/comment was actually created.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync, chmodSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const REPO = resolve(import.meta.dirname, '..')
+const SCRIPT = join(REPO, 'scripts/ci/infra-watchdog.sh')
+
+// The stub `gh` must be EXECUTABLE (it is resolved off PATH). Some
+// sandboxes/containers mount the system temp dir `noexec`, which would
+// silently fall through to the real `gh` and make every assertion here
+// test GitHub instead of the script. Stage under node_modules/ (git-
+// ignored, same filesystem as the checkout) so the exec bit is honoured.
+const SANDBOX_ROOT = join(REPO, 'node_modules', '.tmp-tests')
+
+let sandbox: string
+
+beforeEach(() => {
+  mkdirSync(SANDBOX_ROOT, { recursive: true })
+  sandbox = mkdtempSync(join(SANDBOX_ROOT, 'infra-watchdog-'))
+})
+afterEach(() => {
+  rmSync(sandbox, { recursive: true, force: true })
+})
+
+/**
+ * Install a stub `gh` that:
+ *  - appends every invocation's argv to `$GH_CALLS` (one line per call);
+ *  - for `gh api ...`, fails with a 503 for the first `apiFailures`
+ *    calls, then prints `apiJobsJson`;
+ *  - for `gh issue list`, prints `issueListOut` (empty = no dedupe hit);
+ *  - succeeds silently for everything else.
+ */
+function installGhStub(opts: {
+  apiFailures?: number
+  apiJobsJson?: string
+  issueListOut?: string
+}): { bin: string; calls: () => string[] } {
+  const bin = join(sandbox, 'bin')
+  const callLog = join(sandbox, 'gh-calls.log')
+  const counter = join(sandbox, 'api-attempts')
+  mkdirSync(bin, { recursive: true })
+
+  const gh = join(bin, 'gh')
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> ${JSON.stringify(callLog)}
+if [ "\$1" = "api" ]; then
+  n=0
+  [ -f ${JSON.stringify(counter)} ] && n=\$(cat ${JSON.stringify(counter)})
+  n=\$((n + 1)); echo "\$n" > ${JSON.stringify(counter)}
+  if [ "\$n" -le ${opts.apiFailures ?? 0} ]; then
+    echo "gh: No server is currently available to service your request. (HTTP 503)" >&2
+    exit 1
+  fi
+  cat <<'JSONEOF'
+${opts.apiJobsJson ?? '[{"jobs":[]}]'}
+JSONEOF
+  exit 0
+fi
+if [ "\$1" = "issue" ] && [ "\$2" = "list" ]; then
+  printf '%s' ${JSON.stringify(opts.issueListOut ?? '')}
+  exit 0
+fi
+exit 0
+`,
+    'utf8',
+  )
+  chmodSync(gh, 0o755)
+
+  return {
+    bin,
+    calls: () =>
+      existsSync(callLog)
+        ? readFileSync(callLog, 'utf8').split('\n').filter(Boolean)
+        : [],
+  }
+}
+
+function runWatchdog(bin: string): { code: number; out: string } {
+  try {
+    const out = execFileSync('bash', [SCRIPT], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        GH_TOKEN: 'stub',
+        REPO: 'switchroom/switchroom',
+        RUN_ID: '29710576955',
+        WF_NAME: 'ci-tests-core',
+        HEAD_SHA: '7cdf5428a27701996ba962a546871bfffd90d53e',
+        RUN_URL: 'https://github.com/switchroom/switchroom/actions/runs/29710505937',
+        RUN_CONCLUSION: 'failure',
+        // Keep the retry backoff sub-second so the suite doesn't sleep.
+        WATCHDOG_MAX_ATTEMPTS: '3',
+        WATCHDOG_BASE_DELAY: '0',
+      },
+    })
+    return { code: 0, out }
+  } catch (err: unknown) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string }
+    return {
+      code: e.status ?? 1,
+      out: `${e.stdout?.toString?.() ?? ''}${e.stderr?.toString?.() ?? ''}`,
+    }
+  }
+}
+
+/**
+ * Guard: if the stub were ever bypassed (PATH not honoured, `noexec`
+ * temp, etc.) the negative assertions below would all trivially pass
+ * against a real `gh`. Every test proves the stub actually ran.
+ */
+function assertStubUsed(calls: string[]): void {
+  expect(calls.length).toBeGreaterThan(0)
+  expect(calls[0].startsWith('api ')).toBe(true)
+}
+
+const GENUINE_RED = '[{"jobs":[{"conclusion":"success"},{"conclusion":"failure"}]}]'
+const INFRA_SIGNATURE = '[{"jobs":[{"conclusion":"skipped"},{"conclusion":"cancelled"}]}]'
+// Failure lands on page 2 — the --paginate --slurp flattening must see it.
+const GENUINE_RED_PAGE_2 =
+  '[{"jobs":[{"conclusion":"success"}]},{"jobs":[{"conclusion":"failure"}]}]'
+
+describe('scripts/ci/infra-watchdog.sh', () => {
+  it('genuine red (a job reported failure) → exit 0 and NO issue is opened', () => {
+    const stub = installGhStub({ apiJobsJson: GENUINE_RED })
+    const { code, out } = runWatchdog(stub.bin)
+    assertStubUsed(stub.calls())
+    expect(code).toBe(0)
+    expect(out).toMatch(/genuine red/)
+    expect(stub.calls().some((c) => c.startsWith('issue create'))).toBe(false)
+    expect(stub.calls().some((c) => c.startsWith('issue comment'))).toBe(false)
+  })
+
+  it('counts failures on page 2+ as a genuine red (pagination flattening)', () => {
+    const stub = installGhStub({ apiJobsJson: GENUINE_RED_PAGE_2 })
+    const { code, out } = runWatchdog(stub.bin)
+    assertStubUsed(stub.calls())
+    expect(code).toBe(0)
+    expect(out).toMatch(/1 job\(s\) reported failure/)
+    expect(stub.calls().some((c) => c.startsWith('issue create'))).toBe(false)
+  })
+
+  it('infra signature (zero failing jobs) → opens an alert issue', () => {
+    const stub = installGhStub({ apiJobsJson: INFRA_SIGNATURE })
+    const { code, out } = runWatchdog(stub.bin)
+    assertStubUsed(stub.calls())
+    expect(code).toBe(0)
+    expect(out).toMatch(/Infra signature/)
+    const created = stub.calls().filter((c) => c.startsWith('issue create'))
+    expect(created).toHaveLength(1)
+    expect(created[0]).toContain('CI infra: main red without job execution @ 7cdf5428')
+  })
+
+  it('infra signature with an existing open issue → comments, does not re-create', () => {
+    const stub = installGhStub({ apiJobsJson: INFRA_SIGNATURE, issueListOut: '4242' })
+    const { code, out } = runWatchdog(stub.bin)
+    assertStubUsed(stub.calls())
+    expect(code).toBe(0)
+    expect(out).toMatch(/Commented on existing issue #4242/)
+    expect(stub.calls().some((c) => c.startsWith('issue create'))).toBe(false)
+    expect(stub.calls().some((c) => c.startsWith('issue comment 4242'))).toBe(true)
+  })
+
+  it('transient 503s on the classification read are retried, then classified correctly', () => {
+    // This is the 2026-07-20 regression: without a retry the first 503
+    // killed the step and reddened main.
+    const stub = installGhStub({ apiFailures: 2, apiJobsJson: GENUINE_RED })
+    const { code, out } = runWatchdog(stub.bin)
+    assertStubUsed(stub.calls())
+    expect(code).toBe(0)
+    expect(out).toMatch(/genuine red/)
+    // 3 api attempts: two 503s + the success.
+    expect(stub.calls().filter((c) => c.startsWith('api ')).length).toBe(3)
+    expect(stub.calls().some((c) => c.startsWith('issue create'))).toBe(false)
+  })
+
+  it('a sustained API outage warns and exits 0 — it never guesses a classification', () => {
+    const stub = installGhStub({ apiFailures: 99 })
+    const { code, out } = runWatchdog(stub.bin)
+    assertStubUsed(stub.calls())
+    expect(code).toBe(0)
+    expect(out).toMatch(/::warning title=ci-infra-watchdog could not classify::/)
+    // Bounded: exactly WATCHDOG_MAX_ATTEMPTS reads, not an unbounded loop.
+    expect(stub.calls().filter((c) => c.startsWith('api ')).length).toBe(3)
+    // Critically: no alert is fabricated from an unread classification.
+    expect(stub.calls().some((c) => c.startsWith('issue create'))).toBe(false)
+    expect(stub.calls().some((c) => c.startsWith('issue comment'))).toBe(false)
+  })
+})

--- a/tests/ci-infra-watchdog.test.ts
+++ b/tests/ci-infra-watchdog.test.ts
@@ -54,6 +54,8 @@ function installGhStub(opts: {
   apiFailures?: number
   apiJobsJson?: string
   issueListOut?: string
+  /** Benign diagnostic written to stderr while STILL exiting 0. */
+  apiStderrOnSuccess?: string
 }): { bin: string; calls: () => string[] } {
   const bin = join(sandbox, 'bin')
   const callLog = join(sandbox, 'gh-calls.log')
@@ -72,6 +74,9 @@ if [ "\$1" = "api" ]; then
   if [ "\$n" -le ${opts.apiFailures ?? 0} ]; then
     echo "gh: No server is currently available to service your request. (HTTP 503)" >&2
     exit 1
+  fi
+  if [ -n ${JSON.stringify(opts.apiStderrOnSuccess ?? '')} ]; then
+    printf '%s\n' ${JSON.stringify(opts.apiStderrOnSuccess ?? '')} >&2
   fi
   cat <<'JSONEOF'
 ${opts.apiJobsJson ?? '[{"jobs":[]}]'}
@@ -194,6 +199,27 @@ describe('scripts/ci/infra-watchdog.sh', () => {
     expect(out).toMatch(/genuine red/)
     // 3 api attempts: two 503s + the success.
     expect(stub.calls().filter((c) => c.startsWith('api ')).length).toBe(3)
+    expect(stub.calls().some((c) => c.startsWith('issue create'))).toBe(false)
+  })
+
+  it('benign stderr on a SUCCESSFUL read never reaches the JSON (no 2>&1 stream merge)', () => {
+    // Regression pin for the review finding on this PR's first cut: the
+    // retry loop captured `2>&1`, which merges stderr into stdout on the
+    // SUCCESS path too. `gh` can exit 0 while writing an OAuth-scope
+    // warning / deprecation notice / pagination progress to stderr; that
+    // text lands in front of the JSON, `jq` dies with `parse error:
+    // Invalid numeric literal`, and `set -euo pipefail` reddens main —
+    // reintroducing the exact bug this script exists to prevent.
+    const stub = installGhStub({
+      apiJobsJson: GENUINE_RED,
+      apiStderrOnSuccess:
+        'Warning: your authentication token is missing required scopes [read:org]',
+    })
+    const { code, out } = runWatchdog(stub.bin)
+    assertStubUsed(stub.calls())
+    expect(code).toBe(0)
+    expect(out).not.toMatch(/parse error|Invalid numeric literal/)
+    expect(out).toMatch(/genuine red/)
     expect(stub.calls().some((c) => c.startsWith('issue create'))).toBe(false)
   })
 


### PR DESCRIPTION
## Root cause

`.github/workflows/ci-infra-watchdog.yml` ran a single un-retried `gh api repos/.../actions/runs/$RUN_ID/jobs` under `set -euo pipefail`. On 2026-07-20 the GitHub REST API brownouted and returned

```
gh: No server is currently available to service your request. Sorry about that.
Please try resubmitting your request and contact us if the problem persists. (HTTP 503)
```

to that GET in three consecutive watchdog runs — [29709703593](https://github.com/switchroom/switchroom/actions/runs/29709703593) (00:35Z), [29710301287](https://github.com/switchroom/switchroom/actions/runs/29710301287) (01:01Z), [29710576955](https://github.com/switchroom/switchroom/actions/runs/29710576955) (01:12Z). Each 503 killed the step and painted `main` red.

The irony is the point: in all three the workflow under investigation was a **genuine** red (the `scaffold.persona` byte-ceiling regression), so the correct outcome was the silent `exit 0` "genuine red, no alert" path. A workflow whose entire job is to distinguish infra noise from real regressions was itself emitting infra noise as a main-branch red.

Proof it's the same job across runs with an external cause (not a code defect): three runs, identical step, identical `HTTP 503`, 37 minutes apart, all on already-red commits.

## Changes

1. **Extract** the classifier from the workflow yaml into `scripts/ci/infra-watchdog.sh`. The inline version had zero tests, which is how an un-retried network call shipped.
2. **Bounded retry** (5 attempts, exponential backoff) on the classification read. It is a single idempotent GET.
3. **Degrade, don't lie.** If the read is still unavailable after the retries, emit a loud `::warning` annotation and `exit 0` rather than failing. The read being unavailable means GitHub's API is down — exactly the gap this workflow's own header already documents as accepted ("this is a backstop, not a guarantee"). Reporting a GitHub outage as a red *on the commit* is a false signal. Critically the script never **guesses** a classification: no read means no alert either, and the test pins that.
4. **Checkout `main`** for the tooling rather than the failing run's `head_sha`, so a bad commit cannot disable its own watchdog.

The 3-attempt-then-warn behaviour is deliberately not "a retry that hides the problem": the brownout above lasted 37+ minutes, so no retry budget would have covered it. The retry handles the single blip; the warning handles the outage; neither fabricates a verdict.

## Tests — `tests/ci-infra-watchdog.test.ts`

Drives the real script with a stub `gh` on PATH and asserts **outcomes** (exit status + whether an issue was actually created/commented), across:

- genuine red -> exit 0, no issue
- failing job on pagination page 2+ -> still a genuine red
- infra signature -> opens exactly one alert issue
- existing open issue for the same sha -> comments, does not re-create
- transient 503 then success -> retried, classified correctly
- sustained outage -> bounded attempts, `::warning`, exit 0, **no** issue

Includes a guard that the stub was actually invoked, so a PATH/`noexec` fallthrough to a real `gh` can't make them vacuously green.

**Mutation-checked** — reverting the retry to fail-on-first-error turns exactly the two new behavioural tests red:

```
FAIL tests/ci-infra-watchdog.test.ts > transient 503s ... are retried, then classified correctly
FAIL tests/ci-infra-watchdog.test.ts > a sustained API outage warns and exits 0 ...
Tests  2 failed | 4 passed (6)
```

`npm run lint` clean; 6/6 tests pass on the real script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)