### PR TITLE
test(lint): surface the offending file:line when the bot-api gate fails

### DIFF
--- a/tests/check-bot-api-wrapping.test.ts
+++ b/tests/check-bot-api-wrapping.test.ts
@@ -53,7 +53,16 @@ describe('scripts/check-bot-api-wrapping.sh (#1075)', () => {
     'passes against the live repo (regression gate)',
     () => {
       const result = runScript(REPO)
-      expect(result.ok).toBe(true)
+      // Surface the script's own output as the assertion message: it
+      // prints the offending file:line, and without this the only thing
+      // CI logs is `expected false to be true`. That is exactly what
+      // happened on main run 30061831999 (2026-07-24) — the gate caught
+      // a real unwrapped call and the log named neither the file nor the
+      // line, so triage started from zero. `runScript` already captures
+      // both streams; this stops discarding them. (The synthetic breach
+      // tests below already assert on message content — only this
+      // live-repo gate was blind.)
+      expect(result.ok, `${result.stdout}${result.stderr}`).toBe(true)
       expect(result.stdout).toMatch(/clean/)
     },
     // Local runs finish in ~1.5s; hosted Buildkite agents have slower I/O


### PR DESCRIPTION
## Problem

`tests/check-bot-api-wrapping.test.ts:55-57` — the live-repo regression gate asserted `expect(result.ok).toBe(true)` and threw away the captured output, even though `runScript` (`:32-49`) already collects both streams.

On main run [30061831999](https://github.com/switchroom/switchroom/actions/runs/30061831999) (2026-07-24) the gate correctly caught a real unwrapped `bot.api.*` call. The entire CI log was:

```
AssertionError: expected false to be true // Object.is equality
```

No file, no line, no hint. Triage started from scratch on a gate that already knew the answer.

## Fix

One line — pass the captured output as vitest's assertion message:

```ts
expect(result.ok, `${result.stdout}${result.stderr}`).toBe(true)
```

## Verification

Appended a synthetic unwrapped call to `gateway.ts` and re-ran. The failure now reads:

```
AssertionError: check-bot-api-wrapping: 1 raw bot.api.* call(s) outside the retry policy:
  telegram-plugin/gateway/gateway.ts:24908: await bot.api.sendMessage(1, "x")
```

`gateway.ts` was restored immediately — the probe was local only, and the diff here touches one test file.

## Scope

Only the live-repo gate was blind; the synthetic breach tests at `:86-90` already assert on message content. No behaviour change and no assertion loosened — the gate fails on exactly the same condition, it just says why. `npm run lint` clean, 3/3 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)