### PR TITLE
fix(hindsight): the pending-retains backlog was a re-post loop, not lost memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,30 @@ extracted. Only 1,703 (29.6%) were genuinely absent.
   case gets a loud stderr line plus a durable `pending-drops.json` ledger — a
   **sibling** of the queue dir, so it can never be listed as an entry, drained,
   or counted against the caps.
+- **The reconcile runs in the automatic path too, not only in `--backlog`.**
+  `session_start.py` calls `drain()` on every boot, so fixing the re-post loop
+  only in the operator-invoked mode would have changed nothing operationally.
+  The sequential drain now GETs before it POSTs: a sub-second GET *replaces* a
+  doomed 30-90s server-side extraction, so this reduces both hook latency and
+  upstream load rather than adding to either.
+- **Dedupe is keyed on the filename, not on the serialized size.** The queued
+  copy is always post-`update_attempt` by the time `reconcile_tail` re-enqueues
+  (the SessionStart drain attempts every entry on every boot), so a
+  size-indexed pre-filter matched nothing in steady state and the queue grew by
+  one duplicate per boot; a differing error string defeated it too. The key now
+  lives in the name (`<unix-ms>-<key>-<uuid>.json`), so a lookup is a prefix
+  match over the directory listing with zero file reads. (The measured 63% /
+  84.7 MB collapse on the fleet came from `dedupe_queue.py`, a one-shot
+  out-of-band sweep — this is the preventive guard, a different mechanism.)
+- **An oversized entry no longer costs the whole queue.** If a payload exceeds
+  `HINDSIGHT_PENDING_MAX_BYTES` the eviction loop could never satisfy its
+  condition: it evicted every entry and wrote the incoming one anyway, and the
+  bounded archive then discarded most of what it had just shed. That single
+  entry is now refused and recorded as a drop.
+- **Corrupt entries are quarantined instead of skipped.** A malformed entry was
+  immortal — never reconciled, never drained, never aged to `.dead`, but still
+  holding a slot and still counted in the depth doctor reports. It now moves to
+  `pending-corrupt/`, matching the out-of-band drainer.
 - **`switchroom doctor` told the operator two false things.** It claimed a live
   backlog "drains automatically on the agent's next SessionStart" (it cannot —
   that drain is what built it), and it hardcoded the cap at 1000 while the live
@@ -61,8 +85,12 @@ extracted. Only 1,703 (29.6%) were genuinely absent.
   agent's **live** cap out of the container, describes a full queue accurately
   (`warn`: at the eviction threshold — nothing lost yet, the next entry sheds
   the oldest), and reserves `fail` for actual loss: `.dead` markers, residual
-  drops, or recorded evictions. The remediation names the reconcile phase first
-  and spells out the pacing.
+  drops, or evictions **in the last 7 days** — windowed, because eviction is
+  deliberate policy under this design and a cumulative count over an
+  append-only ledger would pin the row red forever after one legitimate
+  eviction. The remediation names the reconcile phase first, spells out the
+  pacing, and ships the actual p95 query rather than telling the operator to
+  set `HINDSIGHT_DRAIN_P95_CMD` to something it never names.
 
 ## v0.19.18 — MCP instructions truncation (security), turn-liveness fixes, hindsight ranking & recall, CI hardening
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,21 +79,57 @@ extracted. Only 1,703 (29.6%) were genuinely absent.
   (`HINDSIGHT_PENDING_RECONCILED_MAX_ENTRIES` / `_MAX_BYTES`, trimmed
   oldest-first like `pending-evicted/`), which is what the out-of-band tooling
   this design was ported from always did. One rule covers both paths: the
-  in-hook drain retires on a bare 200 because the hook has no budget for a
-  confirming GET, the backlog drain re-GETs first — and neither can
-  irreversibly remove the last on-disk copy of a turn. When the archive
-  itself cannot be written (ENOSPC, EACCES, a read-only mount) the entry
-  STAYS QUEUED and the failure is logged; an earlier revision fell back to
-  deleting it, which made this claim false in exactly the disk-pressure
-  case it was written for. The queue module now exposes no delete
-  primitive at all, so the invariant is structural rather than asserted.
-  Retiring an unarchivable entry is reported as `archive_failed` rather
-  than counted as `drained`/`reconciled`, so the summary can't claim a
-  retire that did not happen. The bounded archives are trimmed
-  oldest-first as before, and the trim now names what it dropped on
-  stderr — those are redundant copies of documents already confirmed
-  upstream, but "reversible" has a horizon and the operator gets to see
-  it pass.
+  in-hook drain retires on the POST's own 200 because a 5s hook budget has no
+  room for a confirming GET, the backlog drain re-GETs first — and nothing on
+  the drain path irreversibly removes the last on-disk copy of a turn. That
+  in-hook 200 is not a bare ack: `_retry_one` posts `async_processing=False`,
+  so it is the daemon's commit-before-ack (#3244 §1.1). It is still the
+  daemon's word rather than an independent read, which is why that path
+  archives instead of deleting. When the archive itself cannot be written
+  (ENOSPC, EACCES, a read-only mount) the entry STAYS QUEUED and the failure
+  is logged; an earlier revision fell back to deleting it, which made this
+  claim false in exactly the disk-pressure case it was written for. The queue
+  module now exposes no delete primitive reachable from the drain, so that
+  invariant is structural rather than asserted. Retiring an unarchivable
+  entry is reported as `archive_failed` rather than counted as
+  `drained`/`reconciled`, so the summary can't claim a retire that did not
+  happen.
+- **"Stays queued" is bounded, and the bound is dropping the oldest turns.**
+  Said plainly because the paragraph above reads like an unconditional
+  promise and it is not one. Under *sustained* ENOSPC the chain is: the drain
+  keeps entries queued → the queue reaches `HINDSIGHT_PENDING_MAX_ENTRIES` /
+  `_MAX_BYTES` → `enqueue()` evicts oldest-first → those evictions' own
+  archive move fails for the same reason → the oldest live entries are
+  removed outright. So the queue never grows without limit, and what pays for
+  that is the oldest queued memory. It is deliberate (the newest turn is the
+  one most likely to still matter) and it is never quiet: stderr, a
+  `reason=...+archive-failed` line in `pending-evictions.log` marking exactly
+  the evictions whose payload was NOT kept, and a `switchroom doctor` row that
+  fails on any eviction in the window. Free the disk and the chain stops at
+  step one.
+- **The bounded archives are trimmed oldest-first, and the trim names what it
+  dropped.** Three of the four ways into `pending-reconciled/` are backed by a
+  GET that confirmed the document (in-hook reconcile, backlog phase 1, backlog
+  phase 2's re-GET). The fourth — the in-hook drain's success path, which runs
+  on every boot — is backed by the commit-before-ack POST alone, so for that
+  population the archived file is the last on-disk copy if the daemon ever
+  fails to honour `async=false`. The caps (500 / 64 MB, 4x smaller than the
+  queue's, to keep three full-queue copies off a container filesystem) are
+  therefore a recovery horizon, not a durability guarantee; the durability
+  guarantee is commit-before-ack. An earlier draft of this entry called the
+  trimmed files "redundant copies of documents already confirmed upstream",
+  which is true of three paths out of four and false for the commonest one.
+  The trim lists every file it drops on stderr, because "reversible" has a
+  horizon and the operator gets to see it pass.
+- **A partially rolled-out plugin tree now fails loudly.** The plugin ships as
+  loose files under `scripts/`, and this change removes a symbol
+  (`lib/pending.py`'s `delete_entry`) whose only importer was
+  `drain_pending.py`. A rollout landing one file without the other made
+  `session_start.py`'s import raise `ImportError` into a bare `except` that
+  logged to a debug channel which is off by default — the whole drain and boot
+  reconciliation would stop, on every boot, silently. Any import-level skew in
+  the tree now prints a stderr line naming the module, the missing symbol,
+  what it costs, and the fix (re-deploy `scripts/` whole, never file by file).
 - **A broken p95 probe is no longer silent.** `HINDSIGHT_DRAIN_P95_CMD`'s exit
   status was ignored, so a typo'd or unauthorized command produced an
   unparsable figure, fell into the bare `except`, and disabled backoff exactly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 ## Unreleased
 
+### Hindsight — the pending-retains backlog was a re-post loop, not lost memory (#3596)
+
+The queue on this fleet grew to 5,751 entries. The cause was **not** that
+memory was being lost — a full sweep on 2026-07-25 found **4,048 (70.4%)
+already existed as documents** in their bank, 3,815 of them with facts
+extracted. Only 1,703 (29.6%) were genuinely absent.
+
+- **Root cause: the SessionStart drain built the backlog it was supposed to
+  clear.** `drain_pending.py` runs inside the hook and clamps each entry's
+  HTTP timeout to the remaining hook budget (1-8s), while `_retry_one` posts
+  `async_processing=False` — a synchronous retain that takes 30-90s. So the
+  server committed the document and the client *always* gave up before the
+  ack. The entry was never deleted, was re-posted on every session start
+  forever, and aged toward `.dead` while the memory it carried was already
+  durable.
+- **`--backlog` is now a two-phase, out-of-hook replay.** Phase 1 (reconcile)
+  GETs the document and drops the entry if it already exists: no POST, no LLM
+  work, no cost, resumable at any point — on the measured fleet that is 70% of
+  the queue for free. Phase 2 posts only genuinely-absent entries with a
+  realistic timeout (`HINDSIGHT_DRAIN_BACKLOG_TIMEOUT`, 180s) and then
+  **re-GETs to confirm the document before deleting the entry** —
+  commit-before-delete, because a 200 is an ack and not proof (#3244). It is
+  still `async_processing=False` for exactly that reason: deleting the queue
+  entry on an async ack is the #3244 silent-loss bug.
+- **Replay is paced, because the model pool is fleet-shared.**
+  `HINDSIGHT_DRAIN_CONCURRENCY` now defaults to **1**, not 4: the group
+  serving retain has 4 lanes shared with live retains, reflect and
+  consolidation, so 11 agents at width 4 is 44 lanes of demand against 4.
+  Phase 2 sleeps between entries (`HINDSIGHT_DRAIN_SLEEP_S`) and pauses
+  entirely while an operator-supplied probe (`HINDSIGHT_DRAIN_P95_CMD`,
+  threshold `HINDSIGHT_DRAIN_P95_BACKOFF_MS`) reports the upstream is already
+  slow, so the replay can never be what trips a latency alarm.
+- **A full queue now evicts the OLDEST entry instead of refusing the newest.**
+  `lib/pending.py` previously returned `None` at `MAX_ENTRIES`, throwing away
+  the turn that had just happened — the one most likely to still matter — and
+  three of six call sites discarded that return, so it was silent. It now
+  sheds oldest-first into a bounded `pending-evicted/` archive with an
+  append-only `pending-evictions.log`, and dedupes on
+  `(bank, document_id, sha256(content))` (`reconcile_tail` re-enqueues the same
+  slice every boot until its watermark is confirmed; 63% of one measured fleet
+  queue was duplicates). Both caps are env-driven
+  (`HINDSIGHT_PENDING_MAX_ENTRIES`, `HINDSIGHT_PENDING_MAX_BYTES`), because a
+  count cap alone bounds disk only to within ~1500x at the measured content
+  spread (499 B .. 744 KB). This ports the design already validated and running
+  out of band on the fleet — file patches to the vendored plugin do not survive
+  `switchroom apply`, which is why it belongs in-repo.
+- **Residual drops are still recorded.** With eviction in place, a *drop* now
+  means the entry could not be written at all (disk full, permissions). That
+  case gets a loud stderr line plus a durable `pending-drops.json` ledger — a
+  **sibling** of the queue dir, so it can never be listed as an entry, drained,
+  or counted against the caps.
+- **`switchroom doctor` told the operator two false things.** It claimed a live
+  backlog "drains automatically on the agent's next SessionStart" (it cannot —
+  that drain is what built it), and it hardcoded the cap at 1000 while the live
+  cap is env-driven at 2000, so it reported "at cap, dropping new failures"
+  against containers that were happily accepting entries. The row now reads the
+  agent's **live** cap out of the container, describes a full queue accurately
+  (`warn`: at the eviction threshold — nothing lost yet, the next entry sheds
+  the oldest), and reserves `fail` for actual loss: `.dead` markers, residual
+  drops, or recorded evictions. The remediation names the reconcile phase first
+  and spells out the pacing.
+
 ## v0.19.18 — MCP instructions truncation (security), turn-liveness fixes, hindsight ranking & recall, CI hardening
 
 ### Telegram — the MCP `instructions` string was silently truncated, disabling a security guardrail (#3587)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,38 @@ extracted. Only 1,703 (29.6%) were genuinely absent.
 - **The reconcile runs in the automatic path too, not only in `--backlog`.**
   `session_start.py` calls `drain()` on every boot, so fixing the re-post loop
   only in the operator-invoked mode would have changed nothing operationally.
-  The sequential drain now GETs before it POSTs: a sub-second GET *replaces* a
-  doomed 30-90s server-side extraction, so this reduces both hook latency and
-  upstream load rather than adding to either.
+  The sequential drain now GETs before it POSTs: for an already-durable entry
+  the sub-second GET *replaces* a doomed 30-90s server-side extraction, which
+  is where the latency and upstream-load win comes from. For an entry that
+  still needs POSTing the GET is an extra call, so the per-request timeout is
+  re-clamped against the budget **remaining at that moment** — computing the
+  clamp once per entry and spending it on both requests made the cost additive
+  (measured 16.0s against the fleet's own 9s budget with an 8s timeout).
+- **A presence GET only retires an entry whose `document_id` proves its own
+  content.** Post-#3244 the id is content-derived
+  (`retain.slice_document_id`: `{session}-r{start_uuid}-{end_uuid}`), so a 200
+  proves *that slice* was committed. A pre-#3244 entry carries a bare session
+  id, for which the bank answers 200 after ANY successful retain in that
+  session — reconciling on it would retire a turn that was never committed
+  (confirmed against a live 525 KB entry on this fleet whose `document_id` is a
+  bare uuid and whose GET returns 200). Those entries skip the free pass and go
+  to the POST, which is the only thing that can make them durable.
+- **The drain archives an entry instead of deleting it.** Every "stop queueing
+  this" decision on the drain path rests on an HTTP 200 — a presence GET or a
+  synchronous retain ack — and a 200 is evidence, not proof (#3244). Entries
+  now MOVE into a bounded `pending-reconciled/` sibling
+  (`HINDSIGHT_PENDING_RECONCILED_MAX_ENTRIES` / `_MAX_BYTES`, trimmed
+  oldest-first like `pending-evicted/`), which is what the out-of-band tooling
+  this design was ported from always did. One rule covers both paths: the
+  in-hook drain retires on a bare 200 because the hook has no budget for a
+  confirming GET, the backlog drain re-GETs first — and neither can
+  irreversibly remove the last on-disk copy of a turn.
+- **A broken p95 probe is no longer silent.** `HINDSIGHT_DRAIN_P95_CMD`'s exit
+  status was ignored, so a typo'd or unauthorized command produced an
+  unparsable figure, fell into the bare `except`, and disabled backoff exactly
+  like an unset probe. It still degrades to "no backoff" (a replay that halts
+  because its probe broke is worse than one that runs unpaced), but it now says
+  so on stderr with the exit status and stderr tail.
 - **Dedupe is keyed on the filename, not on the serialized size.** The queued
   copy is always post-`update_attempt` by the time `reconcile_tail` re-enqueues
   (the SessionStart drain attempts every entry on every boot), so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,19 @@ extracted. Only 1,703 (29.6%) were genuinely absent.
   this design was ported from always did. One rule covers both paths: the
   in-hook drain retires on a bare 200 because the hook has no budget for a
   confirming GET, the backlog drain re-GETs first — and neither can
-  irreversibly remove the last on-disk copy of a turn.
+  irreversibly remove the last on-disk copy of a turn. When the archive
+  itself cannot be written (ENOSPC, EACCES, a read-only mount) the entry
+  STAYS QUEUED and the failure is logged; an earlier revision fell back to
+  deleting it, which made this claim false in exactly the disk-pressure
+  case it was written for. The queue module now exposes no delete
+  primitive at all, so the invariant is structural rather than asserted.
+  Retiring an unarchivable entry is reported as `archive_failed` rather
+  than counted as `drained`/`reconciled`, so the summary can't claim a
+  retire that did not happen. The bounded archives are trimmed
+  oldest-first as before, and the trim now names what it dropped on
+  stderr — those are redundant copies of documents already confirmed
+  upstream, but "reversible" has a horizon and the operator gets to see
+  it pass.
 - **A broken p95 probe is no longer silent.** `HINDSIGHT_DRAIN_P95_CMD`'s exit
   status was ignored, so a typo'd or unauthorized command produced an
   unparsable figure, fell into the bare `except`, and disabled backoff exactly

--- a/src/cli/doctor-pending-retains.test.ts
+++ b/src/cli/doctor-pending-retains.test.ts
@@ -24,6 +24,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildPendingRetainsProbeScript,
   checkPendingRetainsQueues,
+  parsePendingRetainsProbeOutput,
   PENDING_RETAINS_EVICTION_WINDOW_DAYS,
   type PendingRetainsProbeResult,
 } from "./doctor.js";
@@ -497,5 +498,150 @@ describe("buildPendingRetainsProbeScript — eviction window arithmetic", () => 
   it("reports the live cap, falling back to the plugin default", () => {
     expect(runProbe().C).toBe(2000);
     expect(runProbe({ HINDSIGHT_PENDING_MAX_ENTRIES: "500" }).C).toBe(500);
+  });
+});
+
+/**
+ * The OTHER half of the probe (#3599 review R4-B2).
+ *
+ * The B3 split made the shell arithmetic testable and left the parser with
+ * zero tests while its comment still said "exported for testing" — it was
+ * not even exported. Four mutations survived the whole doctor suite, and
+ * each of them is a fleet-visible failure, not a nicety:
+ *
+ *   - `r.status !== 0` → `=== 0`: every SUCCESSFUL probe reads
+ *     `unreachable` and every failure gets parsed. doctor goes permanently
+ *     blind to the queue it exists to watch.
+ *   - `dead > 0` → `>= 0`: every reachable agent reports `dead`, so the row
+ *     is pinned to `fail` forever — the exact "trains operators to ignore
+ *     it" failure the eviction window was designed to avoid.
+ *   - `pending > 0` → `>= 0`: no agent can ever read `ok`.
+ *   - `cap > 0` → `>= 0`: a `C=0` read (older image, or a garbage env
+ *     value) becomes a cap of 0 instead of the 2000 default, and every
+ *     backlog is then reported as "at the eviction threshold".
+ *
+ * Driven from synthetic `{status, stdout}` records — the parser takes that
+ * shape rather than a `SpawnSyncReturns` precisely so no container is
+ * needed.
+ */
+describe("parsePendingRetainsProbeOutput — probe verdict", () => {
+  const out = (s: string, status: number | null = 0) =>
+    parsePendingRetainsProbeOutput({ status, stdout: s });
+
+  const full = (
+    p: number,
+    d: number,
+    x = 0,
+    e = 0,
+    c = 2000,
+  ) => `P=${p} D=${d} X=${x} E=${e} C=${c}\n`;
+
+  describe("exit status decides whether stdout is trusted at all", () => {
+    it("status 0 is parsed", () => {
+      expect(out(full(0, 0)).state).toBe("ok");
+    });
+
+    it("a NON-zero status is unreachable even when stdout parses", () => {
+      // Kills `r.status !== 0` → `=== 0`: under the mutant this record
+      // parses to `backlog` with 7 pending.
+      const r = out(full(7, 0), 125);
+      expect(r.state).toBe("unreachable");
+      expect(r.pending).toBe(0);
+    });
+
+    it("a null status (spawn timeout) is unreachable", () => {
+      expect(out(full(7, 0), null).state).toBe("unreachable");
+    });
+
+    it("a spawn error is unreachable even at status 0", () => {
+      expect(
+        parsePendingRetainsProbeOutput({
+          error: new Error("docker: not found"),
+          status: 0,
+          stdout: full(7, 0),
+        }).state,
+      ).toBe("unreachable");
+    });
+
+    it("unreachable carries zeroed counters and the default cap", () => {
+      const r = out(full(9, 9, 9, 9, 17), 1);
+      expect(r).toEqual({
+        state: "unreachable",
+        pending: 0,
+        dead: 0,
+        dropped: 0,
+        evicted: 0,
+        cap: 2000,
+      });
+    });
+
+    it("unparsable stdout at status 0 is unreachable, not ok", () => {
+      expect(out("sh: syntax error\n").state).toBe("unreachable");
+      expect(out("P=3\n").state).toBe("unreachable"); // D= missing
+    });
+  });
+
+  describe("state precedence", () => {
+    it("an empty queue is ok", () => {
+      expect(out(full(0, 0)).state).toBe("ok");
+    });
+
+    it("ONE dead marker is dead", () => {
+      // Kills `dead > 0` → `>= 0` from the other side: paired with the
+      // `ok` case above, no single comparison satisfies both.
+      expect(out(full(0, 1)).state).toBe("dead");
+    });
+
+    it("ONE queued entry with no dead markers is backlog", () => {
+      // Kills `pending > 0` → `>= 0` together with the `ok` case.
+      expect(out(full(1, 0)).state).toBe("backlog");
+    });
+
+    it("dead wins over a live backlog", () => {
+      expect(out(full(40, 2)).state).toBe("dead");
+    });
+
+    it("counters survive the classification", () => {
+      expect(out(full(12, 3, 4, 5, 750))).toEqual({
+        state: "dead",
+        pending: 12,
+        dead: 3,
+        dropped: 4,
+        evicted: 5,
+        cap: 750,
+      });
+    });
+  });
+
+  describe("cap fallback", () => {
+    it("a positive cap is taken verbatim", () => {
+      expect(out(full(0, 0, 0, 0, 500)).cap).toBe(500);
+    });
+
+    it("C=0 falls back to the default, it is not a cap of zero", () => {
+      // Kills `cap > 0` → `>= 0`. A cap of 0 makes every backlog read as
+      // "at the eviction threshold".
+      expect(out(full(3, 0, 0, 0, 0)).cap).toBe(2000);
+      expect(out(full(3, 0, 0, 0, 0)).state).toBe("backlog");
+    });
+
+    it("C=1 is honoured — the fallback is for 0, not for 'small'", () => {
+      expect(out(full(0, 0, 0, 0, 1)).cap).toBe(1);
+    });
+  });
+
+  describe("older agent images", () => {
+    // The forward-compat contract: an image emitting only P=/D= must read
+    // as a real verdict, not as unreachable and not as a crash.
+    it("absent X=/E=/C= read as zero and the default cap", () => {
+      expect(out("P=2 D=0\n")).toEqual({
+        state: "backlog",
+        pending: 2,
+        dead: 0,
+        dropped: 0,
+        evicted: 0,
+        cap: 2000,
+      });
+    });
   });
 });

--- a/src/cli/doctor-pending-retains.test.ts
+++ b/src/cli/doctor-pending-retains.test.ts
@@ -148,6 +148,18 @@ describe("checkPendingRetainsQueues (#1071/#1094)", () => {
     expect(fix).toContain("HINDSIGHT_DRAIN_P95_CMD");
   });
 
+  // An operator who has just been told to run a drain needs to know where a
+  // retired entry went -- the drain moves it, it does not delete it, and that
+  // is the whole reason a wrong reconcile is recoverable.
+  it("warn: the remediation says retired entries are archived, not deleted", () => {
+    const r = checkPendingRetainsQueues(cfg(["ziggy"]), {
+      probe: probeFrom({ ziggy: backlog(400) }),
+    });
+    const fix = r.fix ?? "";
+    expect(fix).toContain(".hindsight/pending-reconciled/");
+    expect(fix).toMatch(/never deleted/i);
+  });
+
   it("fail: residual drops fail even with a healthy queue", () => {
     // The queue has since drained, but 37 turns could not be written at
     // all -- that memory is gone and must not read as "ok".

--- a/src/cli/doctor-pending-retains.test.ts
+++ b/src/cli/doctor-pending-retains.test.ts
@@ -32,24 +32,47 @@ function probeFrom(
   states: Record<string, PendingRetainsProbeResult>,
 ): (name: string) => PendingRetainsProbeResult {
   return (name: string) =>
-    states[name] ?? { state: "unreachable", pending: 0, dead: 0 };
+    states[name] ?? down();
 }
 
-const ok = (): PendingRetainsProbeResult => ({ state: "ok", pending: 0, dead: 0 });
-const backlog = (n: number): PendingRetainsProbeResult => ({
+/** Default cap; overridden per-case where the threshold is the point. */
+const CAP = 2000;
+
+const ok = (): PendingRetainsProbeResult => ({
+  state: "ok",
+  pending: 0,
+  dead: 0,
+  dropped: 0,
+  evicted: 0,
+  cap: CAP,
+});
+const backlog = (
+  n: number,
+  extra: Partial<PendingRetainsProbeResult> = {},
+): PendingRetainsProbeResult => ({
   state: "backlog",
   pending: n,
   dead: 0,
+  dropped: 0,
+  evicted: 0,
+  cap: CAP,
+  ...extra,
 });
 const dead = (d: number, p = 0): PendingRetainsProbeResult => ({
   state: "dead",
   pending: p,
   dead: d,
+  dropped: 0,
+  evicted: 0,
+  cap: CAP,
 });
 const down = (): PendingRetainsProbeResult => ({
   state: "unreachable",
   pending: 0,
   dead: 0,
+  dropped: 0,
+  evicted: 0,
+  cap: CAP,
 });
 
 describe("checkPendingRetainsQueues (#1071/#1094)", () => {
@@ -74,7 +97,103 @@ describe("checkPendingRetainsQueues (#1071/#1094)", () => {
     });
     expect(r.status).toBe("warn");
     expect(r.detail).toContain("ziggy (4)");
-    expect(r.detail).toContain("next SessionStart");
+  });
+
+  // #3596: the old remediation said a live backlog "drains automatically
+  // on the agent's next SessionStart". It does not -- that drain clamps
+  // each entry's HTTP timeout to the remaining hook budget (1-8s) while
+  // the retain POSTs synchronously and takes 30-90s, so the server commits
+  // and the client always gives up before the ack. The entry is never
+  // deleted and is re-posted every session, forever. The hook drain is
+  // what BUILT the backlog; telling the operator to wait for it is the
+  // single worst thing this row could say.
+  it("never tells the operator a backlog drains itself on SessionStart", () => {
+    const rows = [
+      checkPendingRetainsQueues(cfg(["ziggy"]), {
+        probe: probeFrom({ ziggy: backlog(400) }),
+      }),
+      checkPendingRetainsQueues(cfg(["ziggy"]), {
+        probe: probeFrom({ ziggy: dead(2, 400) }),
+      }),
+    ];
+    for (const r of rows) {
+      const text = `${r.detail ?? ""} ${r.fix ?? ""}`;
+      expect(text).not.toMatch(/drains automatically/i);
+      expect(text).not.toMatch(/drains on next SessionStart/i);
+      // ...and it must name the path that actually works.
+      expect(r.fix).toContain("drain_pending.py --backlog");
+    }
+  });
+
+  it("warn: a backlog carries the explicit backlog-drain remediation", () => {
+    const r = checkPendingRetainsQueues(cfg(["ziggy"]), {
+      probe: probeFrom({ ziggy: backlog(400) }),
+    });
+    expect(r.status).toBe("warn");
+    expect(r.fix).toContain("drain_pending.py --backlog");
+    expect(r.fix).toContain("HINDSIGHT_DRAIN_CONCURRENCY");
+  });
+
+  // The retain model pool is small and shared with live traffic, so a
+  // remediation that says "drain it" without saying "slowly, one agent at
+  // a time" converts a memory backlog into a latency incident.
+  it("warn: the remediation paces the drain instead of just starting one", () => {
+    const r = checkPendingRetainsQueues(cfg(["ziggy"]), {
+      probe: probeFrom({ ziggy: backlog(400) }),
+    });
+    const fix = r.fix ?? "";
+    expect(fix).toContain("--phase reconcile");
+    expect(fix).toMatch(/ONE agent at a time/i);
+    expect(fix).toContain("HINDSIGHT_DRAIN_SLEEP_S");
+    expect(fix).toContain("HINDSIGHT_DRAIN_P95_CMD");
+  });
+
+  it("fail: residual drops fail even with a healthy queue", () => {
+    // The queue has since drained, but 37 turns could not be written at
+    // all -- that memory is gone and must not read as "ok".
+    const r = checkPendingRetainsQueues(cfg(["overlord", "clerk"]), {
+      probe: probeFrom({ overlord: { ...ok(), dropped: 37 }, clerk: ok() }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("permanently dropped");
+    expect(r.detail).toContain("overlord (37)");
+    // The ledger is a SIBLING of the queue dir, not the old in-dir path.
+    expect(r.fix).toContain(".hindsight/pending-drops.json");
+    expect(r.fix).not.toContain("pending-retains/.drops.json");
+  });
+
+  it("fail: drops are reported alongside a live backlog", () => {
+    const r = checkPendingRetainsQueues(cfg(["overlord"]), {
+      probe: probeFrom({ overlord: backlog(158, { dropped: 12 }) }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain(
+      "permanently dropped (could not be written): overlord (12)",
+    );
+    expect(r.detail).toContain("backlog: overlord (158)");
+  });
+
+  // Eviction is deliberate and bounded, but it is still memory shed, and
+  // it must never be inferable only from a depth reading.
+  it("fail: recorded evictions fail even once the queue has drained", () => {
+    const r = checkPendingRetainsQueues(cfg(["marko"]), {
+      probe: probeFrom({ marko: { ...ok(), evicted: 413 } }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("evicted to make room for newer entries");
+    expect(r.detail).toContain("marko (413)");
+    expect(r.fix).toContain("pending-evicted/");
+    expect(r.fix).toContain("HINDSIGHT_PENDING_MAX_ENTRIES");
+  });
+
+  it("ok: zero drops and zero evictions never mention either", () => {
+    const r = checkPendingRetainsQueues(cfg(["clerk"]), {
+      probe: probeFrom({ clerk: ok() }),
+    });
+    expect(r.status).toBe("ok");
+    const text = `${r.detail ?? ""} ${r.fix ?? ""}`;
+    expect(text).not.toContain("dropped");
+    expect(text).not.toContain("evicted");
   });
 
   it("fail: a .dead marker escalates past a warn and points at inspection", () => {
@@ -87,13 +206,36 @@ describe("checkPendingRetainsQueues (#1071/#1094)", () => {
     expect(r.fix).toContain("docker exec switchroom-<agent>");
   });
 
-  it("fail: a queue at the cap is a distinct, dropping-failures signal", () => {
+  // Depth alone is NOT loss: a full queue evicts the oldest entry rather
+  // than refusing the incoming one. Failing the row on depth told the
+  // operator memory was being dropped when none had been.
+  it("warn (not fail): a queue at the threshold has not lost anything yet", () => {
     const r = checkPendingRetainsQueues(cfg(["clerk"]), {
-      probe: probeFrom({ clerk: backlog(1000) }),
+      probe: probeFrom({ clerk: backlog(2000) }),
     });
-    expect(r.status).toBe("fail");
-    expect(r.detail).toContain("at cap of 1000");
-    expect(r.detail).toContain("clerk (1000)");
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("at the eviction threshold");
+    expect(r.detail).toContain("clerk (2000/2000)");
+    expect(r.detail).not.toMatch(/dropping new failures/i);
+  });
+
+  // The cap is env-driven and already retuned fleet-wide, so a hardcoded
+  // constant made doctor cry "at cap" at a container happily accepting
+  // entries -- and stay silent at one that really was evicting.
+  it("compares depth against the agent's OWN cap, not a constant", () => {
+    const under = checkPendingRetainsQueues(cfg(["clerk"]), {
+      probe: probeFrom({ clerk: backlog(1200, { cap: 5000 }) }),
+    });
+    expect(under.status).toBe("warn");
+    expect(under.detail).toContain("queued: clerk (1200)");
+    expect(under.detail).not.toContain("threshold");
+
+    const over = checkPendingRetainsQueues(cfg(["clerk"]), {
+      probe: probeFrom({ clerk: backlog(600, { cap: 500 }) }),
+    });
+    expect(over.status).toBe("warn");
+    expect(over.detail).toContain("at the eviction threshold");
+    expect(over.detail).toContain("clerk (600/500)");
   });
 
   it("fail: dead on one agent, backlog on another — both surfaced, fail wins", () => {

--- a/src/cli/doctor-pending-retains.test.ts
+++ b/src/cli/doctor-pending-retains.test.ts
@@ -14,10 +14,17 @@
  * vault-broker socket-pair test seam).
  */
 
-import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  buildPendingRetainsProbeScript,
   checkPendingRetainsQueues,
+  PENDING_RETAINS_EVICTION_WINDOW_DAYS,
   type PendingRetainsProbeResult,
 } from "./doctor.js";
 import type { SwitchroomConfig } from "../config/schema.js";
@@ -318,5 +325,177 @@ describe("checkPendingRetainsQueues (#1071/#1094)", () => {
     // alpha before zeta in the joined list.
     const detail = r.detail ?? "";
     expect(detail.indexOf("alpha")).toBeLessThan(detail.indexOf("zeta"));
+  });
+});
+
+/**
+ * The probe's SHELL ARITHMETIC, run for real.
+ *
+ * Before this block, `probePendingRetainsQueue` had no test at all: the
+ * suite injected a fake probe and exercised only aggregation. The one case
+ * that mentioned the window ("the eviction count is windowed, and says
+ * so") asserted the message wording, so deleting the `$1 >= c` filter from
+ * the awk clause — making the count cumulative for all time — kept all 21
+ * tests green while pinning the doctor row to `fail` forever after a
+ * single legitimate eviction (#3599 review R3-B3).
+ *
+ * These run the generated one-liner with `sh -c` against a tmpdir instead
+ * of a container, and assert the NUMBER.
+ */
+describe("buildPendingRetainsProbeScript — eviction window arithmetic", () => {
+  const NOW = Date.parse("2026-07-25T12:00:00Z");
+  const iso = (daysAgo: number) =>
+    new Date(NOW - daysAgo * 86400_000).toISOString().replace(/\.\d+Z$/, "Z");
+
+  let base: string;
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "doctor-pending-probe-"));
+    mkdirSync(join(base, "pending-retains"), { recursive: true });
+  });
+  afterEach(() => rmSync(base, { recursive: true, force: true }));
+
+  /** Run the real probe script and parse its counters out of it. */
+  function runProbe(env: Record<string, string> = {}): {
+    P: number;
+    D: number;
+    X: number;
+    E: number;
+    C: number;
+  } {
+    const script = buildPendingRetainsProbeScript(base, NOW);
+    const r = spawnSync("sh", ["-c", script], {
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+    });
+    expect(r.status, r.stderr).toBe(0);
+    const grab = (k: string) =>
+      parseInt(new RegExp(`${k}=(\\d+)`).exec(r.stdout)?.[1] ?? "-1", 10);
+    return {
+      P: grab("P"),
+      D: grab("D"),
+      X: grab("X"),
+      E: grab("E"),
+      C: grab("C"),
+    };
+  }
+
+  function writeEvictionLog(daysAgo: number[]) {
+    writeFileSync(
+      join(base, "pending-evictions.log"),
+      daysAgo
+        .map(
+          (d, i) =>
+            `${iso(d)} evicted=1000-${i}.json bytes=99 reason=count ` +
+            `queue_depth=2000 queue_bytes=1234`,
+        )
+        .join("\n") + "\n",
+    );
+  }
+
+  it("counts ONLY the evictions inside the window, not every one ever", () => {
+    // 3 inside 7d (0.5/3/6.9 days ago), 4 outside (7.1/30/90/400).
+    writeEvictionLog([0.5, 3, 6.9, 7.1, 30, 90, 400]);
+    expect(runProbe().E).toBe(3);
+  });
+
+  it("an all-historic ledger reads as zero, so the row can clear", () => {
+    // The whole point: eviction is designed behaviour, so a row that can
+    // never go back to ok trains the operator to ignore it.
+    writeEvictionLog([8, 9, 60, 365]);
+    expect(runProbe().E).toBe(0);
+  });
+
+  it("an entirely recent ledger counts every line", () => {
+    writeEvictionLog([0, 1, 2, 3, 4, 5, 6]);
+    expect(runProbe().E).toBe(7);
+  });
+
+  it("the boundary is the cutoff itself, and it is inclusive", () => {
+    const cutoff = iso(PENDING_RETAINS_EVICTION_WINDOW_DAYS);
+    writeFileSync(
+      join(base, "pending-evictions.log"),
+      `${cutoff} evicted=a.json bytes=1 reason=count queue_depth=1 queue_bytes=1\n`,
+    );
+    expect(runProbe().E).toBe(1);
+  });
+
+  it("non-eviction lines in the ledger are not counted", () => {
+    writeFileSync(
+      join(base, "pending-evictions.log"),
+      [
+        `${iso(1)} evicted=a.json bytes=1 reason=count queue_depth=1 queue_bytes=1`,
+        `${iso(1)} rotated log lines=500`,
+        `${iso(2)} evicted=b.json bytes=1 reason=bytes queue_depth=1 queue_bytes=1`,
+      ].join("\n") + "\n",
+    );
+    expect(runProbe().E).toBe(2);
+  });
+
+  it("a missing ledger is zero, not an error", () => {
+    expect(runProbe().E).toBe(0);
+  });
+
+  it("counts queued and dead entries without overlap", () => {
+    const dir = join(base, "pending-retains");
+    for (const n of ["1-a.json", "2-b.json", "3-c.json"])
+      writeFileSync(join(dir, n), "{}");
+    for (const n of ["4-d.json.dead", "5-e.json.dead"])
+      writeFileSync(join(dir, n), "{}");
+    const r = runProbe();
+    expect(r.P).toBe(3);
+    expect(r.D).toBe(2);
+  });
+
+  it("reads the residual-drop count from the sibling ledger", () => {
+    writeFileSync(
+      join(base, "pending-drops.json"),
+      JSON.stringify({ count: 37, last: "x" }),
+    );
+    expect(runProbe().X).toBe(37);
+  });
+
+  // DEFENSIVE, and labelled as such. `grep -o` emits every
+  // `"count"…<digits>` match and `head -n1` takes the first. A well-formed
+  // ledger has exactly one — `lib/pending.py:_record_drop` writes a single
+  // JSON object via tmp+os.replace, and a "count" quoted inside
+  // `last_error_message` is backslash-escaped, so it cannot match. This
+  // pins the behaviour for a ledger that is NOT well formed (a truncated
+  // or doubly-written legacy file): the first, i.e. current, record wins
+  // rather than whatever trailing garbage the file ends with.
+  it("takes the FIRST count when a malformed ledger carries several", () => {
+    writeFileSync(
+      join(base, "pending-drops.json"),
+      '{"schema": 1, "count": 12}\n{"schema": 1, "count": 999999}\n',
+    );
+    expect(runProbe().X).toBe(12);
+  });
+
+  // The sibling `pending-drops.json` is the current location; the
+  // in-directory `.drops.json` is only a fallback for agents still on an
+  // older plugin build. Reading the stale one in preference would report a
+  // frozen count forever.
+  it("prefers the sibling ledger over the legacy in-directory one", () => {
+    writeFileSync(join(base, "pending-drops.json"), JSON.stringify({ count: 3 }));
+    writeFileSync(
+      join(base, "pending-retains", ".drops.json"),
+      JSON.stringify({ count: 91 }),
+    );
+    expect(runProbe().X).toBe(3);
+  });
+
+  it("falls back to the legacy in-directory ledger when the sibling is absent", () => {
+    writeFileSync(
+      join(base, "pending-retains", ".drops.json"),
+      JSON.stringify({ count: 91 }),
+    );
+    expect(runProbe().X).toBe(91);
+  });
+
+  // The cap is read from the agent's LIVE env because it is retuned via
+  // switchroom.yaml; the compiled-in number is only the fallback, and it
+  // must match the plugin's own default (lib/pending.py MAX_ENTRIES).
+  it("reports the live cap, falling back to the plugin default", () => {
+    expect(runProbe().C).toBe(2000);
+    expect(runProbe({ HINDSIGHT_PENDING_MAX_ENTRIES: "500" }).C).toBe(500);
   });
 });

--- a/src/cli/doctor-pending-retains.test.ts
+++ b/src/cli/doctor-pending-retains.test.ts
@@ -186,6 +186,32 @@ describe("checkPendingRetainsQueues (#1071/#1094)", () => {
     expect(r.fix).toContain("HINDSIGHT_PENDING_MAX_ENTRIES");
   });
 
+  // Eviction is DESIGNED behaviour here and the ledger is append-only, so a
+  // cumulative count would pin this row to fail forever after one legitimate
+  // eviction. A check that trains operators to ignore it is worse than none.
+  it("the eviction count is windowed, and says so", () => {
+    const r = checkPendingRetainsQueues(cfg(["marko"]), {
+      probe: probeFrom({ marko: { ...ok(), evicted: 5 } }),
+    });
+    expect(r.detail).toMatch(/in the last \d+d/);
+    expect(r.fix).toMatch(/clears on its own/i);
+    // …and must NOT tell the operator to delete the record of what was shed.
+    expect(r.fix).not.toMatch(/reset it by deleting/i);
+  });
+
+  // "Set HINDSIGHT_DRAIN_P95_CMD" without a command is unactionable — the
+  // operator has to go find the query the watchdog uses.
+  it("warn: the p95 guidance ships a copy-pasteable command", () => {
+    const r = checkPendingRetainsQueues(cfg(["ziggy"]), {
+      probe: probeFrom({ ziggy: backlog(400) }),
+    });
+    const fix = r.fix ?? "";
+    expect(fix).toContain("HINDSIGHT_DRAIN_P95_CMD");
+    expect(fix).toContain("percentile_cont(0.95)");
+    expect(fix).toContain("LiteLLM_SpendLogs");
+    expect(fix).toMatch(/millisecond integer on stdout/);
+  });
+
   it("ok: zero drops and zero evictions never mention either", () => {
     const r = checkPendingRetainsQueues(cfg(["clerk"]), {
       probe: probeFrom({ clerk: ok() }),

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1399,6 +1399,15 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
 const PENDING_RETAINS_DEFAULT_MAX_ENTRIES = 2000;
 
 /**
+ * How far back the eviction ledger is counted. Eviction is deliberate
+ * policy here (a full queue sheds its oldest entry rather than refusing
+ * the newest), and ``pending-evictions.log`` is append-only, so counting
+ * it cumulatively would pin the row to `fail` forever after the first
+ * legitimate eviction. Recent evictions are the actionable signal.
+ */
+const PENDING_RETAINS_EVICTION_WINDOW_DAYS = 7;
+
+/**
  * Per-agent probe result for the pending-retains queue.
  *   - "ok"          — directory missing or empty (no failed retains)
  *   - "backlog"     — queued ``.json`` entries, none dead (will retry)
@@ -1425,8 +1434,15 @@ export interface PendingRetainsProbeResult {
    */
   dropped: number;
   /**
-   * Cumulative count of entries EVICTED to make room for newer ones,
-   * one line per eviction in the ``pending-evictions.log`` ledger.
+   * Count of entries EVICTED to make room for newer ones **within the
+   * last ``PENDING_RETAINS_EVICTION_WINDOW_DAYS``**, from the
+   * ``pending-evictions.log`` ledger (one line per eviction).
+   *
+   * Windowed, not cumulative, and deliberately so: eviction is the
+   * DESIGNED behaviour of a full queue under this scheme, and the ledger
+   * is append-only, so a cumulative count would leave the row red forever
+   * after one legitimate eviction. A check that trains operators to
+   * ignore it is worse than no check.
    *
    * Eviction is the deliberate policy (shed the oldest, never refuse the
    * newest — see ``lib/pending.py``), and the evicted payload is kept in
@@ -1473,6 +1489,13 @@ export function probePendingRetainsQueue(
   //
   // `C` is the agent's LIVE cap. Reading it here rather than assuming a
   // constant is the point: it is env-driven and retuned via switchroom.yaml.
+  // Ledger lines start with an ISO-8601 UTC timestamp, which sorts
+  // lexicographically, so awk can window them with a plain string compare.
+  const cutoff = new Date(
+    Date.now() - PENDING_RETAINS_EVICTION_WINDOW_DAYS * 86400_000,
+  )
+    .toISOString()
+    .replace(/\.\d+Z$/, "Z");
   const script =
     `P=0; D=0; X=0; E=0; C=\${HINDSIGHT_PENDING_MAX_ENTRIES:-${PENDING_RETAINS_DEFAULT_MAX_ENTRIES}}; ` +
     `if [ -d '${dir}' ]; then ` +
@@ -1486,7 +1509,9 @@ export function probePendingRetainsQueue(
     `[ -n "$X" ] || X=0; ` +
     `fi; done; ` +
     `if [ -f '${base}/pending-evictions.log' ]; then ` +
-    `E=$(grep -c 'evicted=' '${base}/pending-evictions.log' 2>/dev/null || true); ` +
+    `E=$(awk -v c='${cutoff}' '$1 >= c && /evicted=/ {n++} END {print n+0}' ` +
+    `'${base}/pending-evictions.log' 2>/dev/null || echo 0); ` +
+    `[ -n "$E" ] || E=0; ` +
     `fi; ` +
     `echo "P=$P D=$D X=$X E=$E C=$C"`;
   const r = spawnSync(
@@ -1631,10 +1656,16 @@ export function checkPendingRetainsQueues(
     `Run \`--phase reconcile\` first — it costs nothing and typically clears most of ` +
     `the queue by confirming those documents already exist. PACE THE REST: the retain ` +
     `model pool is small and shared with live traffic, so drain ONE agent at a time at ` +
-    `the default HINDSIGHT_DRAIN_CONCURRENCY=1, keep HINDSIGHT_DRAIN_SLEEP_S set, and ` +
-    `set HINDSIGHT_DRAIN_P95_CMD so the replay backs off instead of tripping the ` +
-    `latency alarm. Fix the upstream first (bank health rows above), or every retry ` +
-    `just ages entries toward .dead.`;
+    `the default HINDSIGHT_DRAIN_CONCURRENCY=1, and keep HINDSIGHT_DRAIN_SLEEP_S set. ` +
+    `Point HINDSIGHT_DRAIN_P95_CMD at the same figure the latency watchdog alarms on so ` +
+    `the replay backs off instead of causing the alarm — on a LiteLLM deployment that is ` +
+    `\`docker exec -i <postgres> psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -c ` +
+    `"select coalesce((select round(percentile_cont(0.95) within group (order by ` +
+    `request_duration_ms)) from \\"LiteLLM_SpendLogs\\" where \\"startTime\\" > now() ` +
+    `- interval '10 minutes' and metadata->>'user_api_key_alias' like 'hindsight-%' and ` +
+    `status='success' and request_duration_ms is not null), -1)"\` (must print a ` +
+    `millisecond integer on stdout; unset = no backoff). Fix the upstream first (bank ` +
+    `health rows above), or every retry just ages entries toward .dead.`;
 
   // fail: dead markers, residual drops, or recorded evictions. NOT depth:
   // a full queue evicts rather than refusing, so depth alone is a symptom.
@@ -1645,7 +1676,10 @@ export function checkPendingRetainsQueues(
       parts.push(`permanently dropped (could not be written): ${dropped.join(", ")}`);
     }
     if (evicted.length > 0) {
-      parts.push(`evicted to make room for newer entries: ${evicted.join(", ")}`);
+      parts.push(
+        `evicted to make room for newer entries in the last ` +
+          `${PENDING_RETAINS_EVICTION_WINDOW_DAYS}d: ${evicted.join(", ")}`,
+      );
     }
     if (atThreshold.length > 0) {
       parts.push(`at the eviction threshold: ${atThreshold.join(", ")}`);
@@ -1674,7 +1708,10 @@ export function checkPendingRetainsQueues(
           `queued — the payloads are in \`.hindsight/pending-evicted/\` (itself bounded, ` +
           `so they expire) and the ledger is \`.hindsight/pending-evictions.log\`. Drain ` +
           `the backlog and raise HINDSIGHT_PENDING_MAX_ENTRIES / ` +
-          `HINDSIGHT_PENDING_MAX_BYTES if this recurs.`,
+          `HINDSIGHT_PENDING_MAX_BYTES if this recurs. This count covers the last ` +
+          `${PENDING_RETAINS_EVICTION_WINDOW_DAYS} days only, so the row clears on its ` +
+          `own once evictions stop — no ledger reset needed, and don't delete it (it is ` +
+          `the record of what was shed).`,
       );
     }
     fixParts.push(backlogFix);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1665,7 +1665,10 @@ export function checkPendingRetainsQueues(
     `- interval '10 minutes' and metadata->>'user_api_key_alias' like 'hindsight-%' and ` +
     `status='success' and request_duration_ms is not null), -1)"\` (must print a ` +
     `millisecond integer on stdout; unset = no backoff). Fix the upstream first (bank ` +
-    `health rows above), or every retry just ages entries toward .dead.`;
+    `health rows above), or every retry just ages entries toward .dead. Entries the ` +
+    `drain retires are MOVED to \`.hindsight/pending-reconciled/\` (bounded, so they ` +
+    `expire), never deleted — every retire rests on an HTTP 200, which is an ack and ` +
+    `not proof, so the payload stays recoverable.`;
 
   // fail: dead markers, residual drops, or recorded evictions. NOT depth:
   // a full queue evicts rather than refusing, so depth alone is a symptom.

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1448,9 +1448,12 @@ export interface PendingRetainsProbeResult {
    * ignore it is worse than no check.
    *
    * Eviction is the deliberate policy (shed the oldest, never refuse the
-   * newest — see ``lib/pending.py``), and the evicted payload is kept in
-   * the bounded ``pending-evicted/`` archive, so this is not the same
-   * category of loss as ``dropped``. But it IS loss, and it must never
+   * newest — see ``lib/pending.py``), and the evicted payload is normally
+   * kept in the bounded ``pending-evicted/`` archive, so this is usually
+   * not the same category of loss as ``dropped``. Usually, not always: an
+   * eviction whose own archive move failed (ENOSPC — the ledger line reads
+   * ``reason=...+archive-failed``) removed the entry outright and IS the
+   * same category as ``dropped``. Either way it is loss, and it must never
    * be inferable only from a depth reading — hence a distinct counter.
    */
   evicted: number;
@@ -1553,15 +1556,26 @@ export function buildPendingRetainsProbeScript(
 /**
  * Parse the probe one-liner's stdout into a verdict.
  *
+ * The B3 split gave `buildPendingRetainsProbeScript` its own tests and left
+ * this half with none while still carrying "exported for testing" — and it
+ * was not even exported (#3599 review R4-B2). Four mutations survived the
+ * whole doctor suite: `r.status !== 0` → `=== 0` (every successful probe
+ * reads `unreachable`), `dead > 0` → `>= 0` (every reachable agent reports
+ * dead, the row pinned to `fail` forever), `pending > 0` → `>= 0` (no agent
+ * can ever read `ok`), and `cap > 0` → `>= 0` (a `C=0` read becomes a cap of
+ * 0 instead of the default). It takes a plain `{status, stdout}` record
+ * precisely so it can be driven from synthetic inputs with no container.
+ *
  * @internal exported for testing
  */
-function parsePendingRetainsProbeOutput(r: {
+export function parsePendingRetainsProbeOutput(r: {
   error?: Error;
   status: number | null;
   stdout: Buffer | string;
 }): PendingRetainsProbeResult {
   // docker/daemon failure, container absent (exit ≥125), or timeout
-  // (status null) → skip this agent, don't false-alarm.
+  // (`status` is null, which is `!== 0`) → skip this agent, don't
+  // false-alarm.
   const unreachable: PendingRetainsProbeResult = {
     state: "unreachable",
     pending: 0,
@@ -1570,7 +1584,7 @@ function parsePendingRetainsProbeOutput(r: {
     evicted: 0,
     cap: PENDING_RETAINS_DEFAULT_MAX_ENTRIES,
   };
-  if (r.error || r.status === null || r.status !== 0) return unreachable;
+  if (r.error || r.status !== 0) return unreachable;
   const out = r.stdout.toString();
   const pm = out.match(/P=(\d+)/);
   const dm = out.match(/D=(\d+)/);
@@ -1711,7 +1725,13 @@ export function checkPendingRetainsQueues(
     `expire), never deleted — every retire rests on an HTTP 200, which is an ack and ` +
     `not proof, so the payload stays recoverable. If that archive cannot be written ` +
     `(disk full, permissions) the entry STAYS QUEUED and the drain says so on stderr; ` +
-    `a failure to archive is never a reason to delete.`;
+    `a failure to archive is never a reason to delete. FIX THE DISK ANYWAY — "stays ` +
+    `queued" is bounded: entries pile up, the queue hits ` +
+    `HINDSIGHT_PENDING_MAX_ENTRIES/MAX_BYTES, and enqueue then sheds the OLDEST ` +
+    `entries to keep accepting the newest. While the disk is full their archive move ` +
+    `fails too, so those oldest turns are removed outright (the ledger line reads ` +
+    `\`reason=...+archive-failed\`). Under sustained ENOSPC "keep it queued" degrades ` +
+    `to "keep the newest, drop the oldest".`;
 
   // fail: dead markers, residual drops, or recorded evictions. NOT depth:
   // a full queue evicts rather than refusing, so depth alone is a symptom.
@@ -1752,7 +1772,10 @@ export function checkPendingRetainsQueues(
       fixParts.push(
         `Evicted entries were shed OLDEST-first so the newest memory could still be ` +
           `queued — the payloads are in \`.hindsight/pending-evicted/\` (itself bounded, ` +
-          `so they expire) and the ledger is \`.hindsight/pending-evictions.log\`. Drain ` +
+          `so they expire) and the ledger is \`.hindsight/pending-evictions.log\`. Check ` +
+          `that ledger for \`+archive-failed\`: those evictions could not be archived ` +
+          `either (disk full / permissions), so the payload is GONE, not shed — treat ` +
+          `them like drops and fix the disk first. Drain ` +
           `the backlog and raise HINDSIGHT_PENDING_MAX_ENTRIES / ` +
           `HINDSIGHT_PENDING_MAX_BYTES if this recurs. This count covers the last ` +
           `${PENDING_RETAINS_EVICTION_WINDOW_DAYS} days only, so the row clears on its ` +

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1385,11 +1385,18 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
 }
 
 /**
- * The bounded queue cap — keep in sync with MAX_ENTRIES in
- * ``vendor/hindsight-memory/scripts/lib/pending.py``. At the cap the
- * drainer starts dropping new failures, so it escalates warn → fail.
+ * Fallback queue cap, used only when the probe cannot read the agent's
+ * own ``HINDSIGHT_PENDING_MAX_ENTRIES``.
+ *
+ * Keep in sync with the default of ``MAX_ENTRIES`` in
+ * ``vendor/hindsight-memory/scripts/lib/pending.py``. The cap is
+ * env-driven there and is already retuned fleet-wide via
+ * ``switchroom.yaml``, so hardcoding a number here made doctor report
+ * "at cap" against a container that was happily accepting entries. The
+ * probe therefore reads the LIVE value out of the container and only
+ * falls back to this constant.
  */
-const PENDING_RETAINS_MAX_ENTRIES = 1000;
+const PENDING_RETAINS_DEFAULT_MAX_ENTRIES = 2000;
 
 /**
  * Per-agent probe result for the pending-retains queue.
@@ -1407,6 +1414,34 @@ export interface PendingRetainsProbeResult {
   pending: number;
   /** count of ``*.json.dead`` markers */
   dead: number;
+  /**
+   * Cumulative count of RESIDUAL drops — retains that could not be
+   * written at all (disk full, permissions) even after eviction made
+   * room. Read from the ``pending-drops.json`` ledger written by
+   * ``lib/pending.py:record_drop()``, which is a SIBLING of the queue
+   * directory so it can never be counted as an entry. Each drop is a
+   * turn's memory that is permanently gone, so a non-zero value fails
+   * the row even after the live queue has drained.
+   */
+  dropped: number;
+  /**
+   * Cumulative count of entries EVICTED to make room for newer ones,
+   * one line per eviction in the ``pending-evictions.log`` ledger.
+   *
+   * Eviction is the deliberate policy (shed the oldest, never refuse the
+   * newest — see ``lib/pending.py``), and the evicted payload is kept in
+   * the bounded ``pending-evicted/`` archive, so this is not the same
+   * category of loss as ``dropped``. But it IS loss, and it must never
+   * be inferable only from a depth reading — hence a distinct counter.
+   */
+  evicted: number;
+  /**
+   * The agent's live ``HINDSIGHT_PENDING_MAX_ENTRIES``, i.e. the depth
+   * at which the next enqueue starts evicting. Read from inside the
+   * container rather than assumed, because it is retuned via
+   * ``switchroom.yaml``.
+   */
+  cap: number;
 }
 
 /**
@@ -1425,16 +1460,35 @@ export function probePendingRetainsQueue(
   // Container HOME per compose.ts (`HOME: "/state/agent/home"`). Same
   // default relative path as lib/pending.py: $HOME/.hindsight/pending-retains.
   const dir = "/state/agent/home/.hindsight/pending-retains";
+  const base = "/state/agent/home/.hindsight";
   // `.json$` matches queued entries but NOT `.json.dead` (which ends in
   // `.dead`), so the two counts don't overlap. grep -c on empty input
   // prints 0 and exits 1, so guard with the -d test and swallow status.
+  //
+  // `X` is the residual-drop count from `pending-drops.json` and `E` the
+  // eviction count from `pending-evictions.log`. BOTH are siblings of the
+  // queue directory, not inside it (`lib/pending.py:_sibling()`), so they
+  // can never inflate P — the older in-directory `.drops.json` location is
+  // still read as a fallback for agents on an older plugin build.
+  //
+  // `C` is the agent's LIVE cap. Reading it here rather than assuming a
+  // constant is the point: it is env-driven and retuned via switchroom.yaml.
   const script =
-    `P=0; D=0; ` +
+    `P=0; D=0; X=0; E=0; C=\${HINDSIGHT_PENDING_MAX_ENTRIES:-${PENDING_RETAINS_DEFAULT_MAX_ENTRIES}}; ` +
     `if [ -d '${dir}' ]; then ` +
     `P=$(ls -1 '${dir}' 2>/dev/null | grep -c '\\.json$' || true); ` +
     `D=$(ls -1 '${dir}' 2>/dev/null | grep -c '\\.json\\.dead$' || true); ` +
     `fi; ` +
-    `echo "P=$P D=$D"`;
+    `for L in '${base}/pending-drops.json' '${dir}/.drops.json'; do ` +
+    `if [ "$X" = 0 ] && [ -f "$L" ]; then ` +
+    `X=$(grep -o '"count"[^0-9]*[0-9][0-9]*' "$L" 2>/dev/null ` +
+    `| grep -o '[0-9][0-9]*$' | head -n1); ` +
+    `[ -n "$X" ] || X=0; ` +
+    `fi; done; ` +
+    `if [ -f '${base}/pending-evictions.log' ]; then ` +
+    `E=$(grep -c 'evicted=' '${base}/pending-evictions.log' 2>/dev/null || true); ` +
+    `fi; ` +
+    `echo "P=$P D=$D X=$X E=$E C=$C"`;
   const r = spawnSync(
     "docker",
     ["exec", `switchroom-${agentName}`, "sh", "-c", script],
@@ -1442,18 +1496,36 @@ export function probePendingRetainsQueue(
   );
   // docker/daemon failure, container absent (exit ≥125), or timeout
   // (status null) → skip this agent, don't false-alarm.
-  if (r.error || r.status === null || r.status !== 0) {
-    return { state: "unreachable", pending: 0, dead: 0 };
-  }
+  const unreachable: PendingRetainsProbeResult = {
+    state: "unreachable",
+    pending: 0,
+    dead: 0,
+    dropped: 0,
+    evicted: 0,
+    cap: PENDING_RETAINS_DEFAULT_MAX_ENTRIES,
+  };
+  if (r.error || r.status === null || r.status !== 0) return unreachable;
   const out = r.stdout.toString();
   const pm = out.match(/P=(\d+)/);
   const dm = out.match(/D=(\d+)/);
-  if (!pm || !dm) return { state: "unreachable", pending: 0, dead: 0 };
+  if (!pm || !dm) return unreachable;
   const pending = parseInt(pm[1], 10);
   const dead = parseInt(dm[1], 10);
-  if (dead > 0) return { state: "dead", pending, dead };
-  if (pending > 0) return { state: "backlog", pending, dead };
-  return { state: "ok", pending, dead };
+  // Older agent images emit no X=/E=/C= at all; absent reads as 0 (and
+  // the default cap) rather than "unreachable".
+  const xm = out.match(/X=(\d+)/);
+  const em = out.match(/E=(\d+)/);
+  const cm = out.match(/C=(\d+)/);
+  const dropped = xm ? parseInt(xm[1], 10) : 0;
+  const evicted = em ? parseInt(em[1], 10) : 0;
+  const cap =
+    cm && parseInt(cm[1], 10) > 0
+      ? parseInt(cm[1], 10)
+      : PENDING_RETAINS_DEFAULT_MAX_ENTRIES;
+  const common = { pending, dead, dropped, evicted, cap };
+  if (dead > 0) return { state: "dead", ...common };
+  if (pending > 0) return { state: "backlog", ...common };
+  return { state: "ok", ...common };
 }
 
 /**
@@ -1464,9 +1536,15 @@ export function probePendingRetainsQueue(
  * verdict and name the specific agents that are off.
  *
  * Verdict precedence:
- *   - fail  — any agent has ``.dead`` markers (permanently-failed retains)
- *             OR any queue is at/over the bounded cap (dropping failures)
- *   - warn  — any agent has a live backlog (drains on next SessionStart)
+ *   - fail  — any agent has ``.dead`` markers (permanently-failed retains),
+ *             any residual drop (a turn's memory that could not be written
+ *             at all), or any recorded eviction (older memories shed to
+ *             keep newer ones)
+ *   - warn  — any agent has a live backlog. A backlog does NOT fail on
+ *             depth alone: a full queue evicts rather than refusing, so
+ *             depth by itself is a symptom, not loss. Depth at/over the
+ *             agent's live cap is called out inside the warn as "at the
+ *             eviction threshold", which is what is actually true.
  *   - skip  — every agent container is unreachable (fleet down)
  *   - ok    — all reachable agents have an empty/missing queue
  *
@@ -1505,17 +1583,25 @@ export function checkPendingRetainsQueues(
   }
 
   const dead: string[] = [];
-  const capped: string[] = [];
+  const atThreshold: string[] = [];
   const backlog: string[] = [];
   const unreachable: string[] = [];
+  const dropped: string[] = [];
+  const evicted: string[] = [];
   let okCount = 0;
   for (const [a, r] of results) {
+    // Drops and evictions are cumulative and independent of the current
+    // depth: an agent whose queue has since drained still shed those
+    // turns, so report them from any state.
+    if (r.dropped > 0) dropped.push(`${a} (${r.dropped})`);
+    if (r.evicted > 0) evicted.push(`${a} (${r.evicted})`);
     if (r.state === "dead") {
       dead.push(
         `${a} (${r.dead} dead${r.pending > 0 ? `, ${r.pending} queued` : ""})`,
       );
     } else if (r.state === "backlog") {
-      if (r.pending >= PENDING_RETAINS_MAX_ENTRIES) capped.push(`${a} (${r.pending})`);
+      // Compare against the agent's OWN cap, not a constant.
+      if (r.pending >= r.cap) atThreshold.push(`${a} (${r.pending}/${r.cap})`);
       else backlog.push(`${a} (${r.pending})`);
     } else if (r.state === "unreachable") {
       unreachable.push(a);
@@ -1526,33 +1612,95 @@ export function checkPendingRetainsQueues(
   const skippedNote =
     unreachable.length > 0 ? `; skipped (unreachable): ${unreachable.join(", ")}` : "";
 
-  // fail: dead markers or a capped queue.
-  if (dead.length > 0 || capped.length > 0) {
+  // The SessionStart drain cannot clear a backlog, and in fact CREATES
+  // one: it clamps each entry's HTTP timeout to the remaining hook budget
+  // (1-8s) while the retain posts synchronously and takes 30-90s, so the
+  // server commits and the client always gives up before the ack. Telling
+  // the operator a backlog "drains automatically on the next SessionStart"
+  // was false at any real scale — point them at the explicit replay.
+  //
+  // The pacing guidance is not decoration. The model group behind retain
+  // has a small, fixed number of lanes shared with live retains, reflect
+  // and consolidation; a fleet-wide replay at default width is the fastest
+  // way to turn a memory backlog into a latency incident.
+  const backlogFix =
+    `Clear a backlog explicitly (the SessionStart drain cannot — its per-entry ` +
+    `timeout is clamped to the hook budget, far below a real retain): ` +
+    `\`docker exec switchroom-<agent> python3 ` +
+    `/state/agent/.claude/plugins/hindsight-memory/scripts/drain_pending.py --backlog\`. ` +
+    `Run \`--phase reconcile\` first — it costs nothing and typically clears most of ` +
+    `the queue by confirming those documents already exist. PACE THE REST: the retain ` +
+    `model pool is small and shared with live traffic, so drain ONE agent at a time at ` +
+    `the default HINDSIGHT_DRAIN_CONCURRENCY=1, keep HINDSIGHT_DRAIN_SLEEP_S set, and ` +
+    `set HINDSIGHT_DRAIN_P95_CMD so the replay backs off instead of tripping the ` +
+    `latency alarm. Fix the upstream first (bank health rows above), or every retry ` +
+    `just ages entries toward .dead.`;
+
+  // fail: dead markers, residual drops, or recorded evictions. NOT depth:
+  // a full queue evicts rather than refusing, so depth alone is a symptom.
+  if (dead.length > 0 || dropped.length > 0 || evicted.length > 0) {
     const parts: string[] = [];
     if (dead.length > 0) parts.push(`dead markers: ${dead.join(", ")}`);
-    if (capped.length > 0) {
-      parts.push(`at cap of ${PENDING_RETAINS_MAX_ENTRIES} (dropping new failures): ${capped.join(", ")}`);
+    if (dropped.length > 0) {
+      parts.push(`permanently dropped (could not be written): ${dropped.join(", ")}`);
+    }
+    if (evicted.length > 0) {
+      parts.push(`evicted to make room for newer entries: ${evicted.join(", ")}`);
+    }
+    if (atThreshold.length > 0) {
+      parts.push(`at the eviction threshold: ${atThreshold.join(", ")}`);
     }
     if (backlog.length > 0) parts.push(`backlog: ${backlog.join(", ")}`);
+    const fixParts: string[] = [];
+    if (dead.length > 0) {
+      fixParts.push(
+        `Dead entries mean Hindsight was unreachable long enough that retries gave up. ` +
+          `Inspect them per agent: ` +
+          `\`docker exec switchroom-<agent> ls /state/agent/home/.hindsight/pending-retains/*.json.dead\`. ` +
+          `Fix the upstream, then re-enqueue (rename .dead → .json) or discard.`,
+      );
+    }
+    if (dropped.length > 0) {
+      fixParts.push(
+        `Dropped retains are GONE — the entry could not be written even after eviction ` +
+          `made room (check disk and permissions), and no payload was kept. Details in ` +
+          `\`.hindsight/pending-drops.json\` per agent; the counter is cumulative, reset ` +
+          `it by deleting that file once you've acknowledged the loss.`,
+      );
+    }
+    if (evicted.length > 0) {
+      fixParts.push(
+        `Evicted entries were shed OLDEST-first so the newest memory could still be ` +
+          `queued — the payloads are in \`.hindsight/pending-evicted/\` (itself bounded, ` +
+          `so they expire) and the ledger is \`.hindsight/pending-evictions.log\`. Drain ` +
+          `the backlog and raise HINDSIGHT_PENDING_MAX_ENTRIES / ` +
+          `HINDSIGHT_PENDING_MAX_BYTES if this recurs.`,
+      );
+    }
+    fixParts.push(backlogFix);
     return {
       name,
       status: "fail",
       detail: `${parts.join("; ")}${skippedNote}`,
-      fix:
-        `Dead entries mean Hindsight was unreachable long enough that retries gave up. ` +
-        `Inspect them per agent: ` +
-        `\`docker exec switchroom-<agent> ls /state/agent/home/.hindsight/pending-retains/*.json.dead\`. ` +
-        `Fix the upstream (bank health rows above), then re-enqueue (rename .dead → .json) or discard. ` +
-        `Live backlog drains automatically on the agent's next SessionStart.`,
+      fix: fixParts.join(" "),
     };
   }
 
-  // warn: live backlog only.
-  if (backlog.length > 0) {
+  // warn: live backlog only — nothing has actually been lost yet.
+  if (backlog.length > 0 || atThreshold.length > 0) {
+    const parts: string[] = [];
+    if (atThreshold.length > 0) {
+      parts.push(
+        `at the eviction threshold (the next failed retain sheds the oldest ` +
+          `entry, it is NOT refused): ${atThreshold.join(", ")}`,
+      );
+    }
+    if (backlog.length > 0) parts.push(`queued: ${backlog.join(", ")}`);
     return {
       name,
       status: "warn",
-      detail: `queued (drains on next SessionStart): ${backlog.join(", ")}${skippedNote}`,
+      detail: `${parts.join("; ")}${skippedNote}`,
+      fix: backlogFix,
     };
   }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1404,8 +1404,11 @@ const PENDING_RETAINS_DEFAULT_MAX_ENTRIES = 2000;
  * the newest), and ``pending-evictions.log`` is append-only, so counting
  * it cumulatively would pin the row to `fail` forever after the first
  * legitimate eviction. Recent evictions are the actionable signal.
+ *
+ * @internal exported so the probe's window arithmetic can be tested
+ * against the same number the probe uses, not a duplicated literal.
  */
-const PENDING_RETAINS_EVICTION_WINDOW_DAYS = 7;
+export const PENDING_RETAINS_EVICTION_WINDOW_DAYS = 7;
 
 /**
  * Per-agent probe result for the pending-retains queue.
@@ -1475,8 +1478,38 @@ export function probePendingRetainsQueue(
 ): PendingRetainsProbeResult {
   // Container HOME per compose.ts (`HOME: "/state/agent/home"`). Same
   // default relative path as lib/pending.py: $HOME/.hindsight/pending-retains.
-  const dir = "/state/agent/home/.hindsight/pending-retains";
   const base = "/state/agent/home/.hindsight";
+  const script = buildPendingRetainsProbeScript(base);
+  const r = spawnSync(
+    "docker",
+    ["exec", `switchroom-${agentName}`, "sh", "-c", script],
+    { stdio: "pipe", timeout: 3000 },
+  );
+  return parsePendingRetainsProbeOutput(r);
+}
+
+/**
+ * Build the `sh -c` one-liner the probe runs inside an agent container.
+ *
+ * Split out from `probePendingRetainsQueue` so the SHELL ARITHMETIC is
+ * testable without a container (#3599 review R3-B3). It was not, and the
+ * test named "the eviction count is windowed, and says so" asserted only
+ * that the message says "in the last 7d" — deleting the `$1 >= c` awk
+ * filter, i.e. counting every eviction ever recorded, left all 21 doctor
+ * tests green. A cumulative count pins the row to `fail` permanently after
+ * one legitimate eviction, which is the exact failure the window exists to
+ * prevent.
+ *
+ * `base` is parameterised for that test; production passes the container
+ * path. `now` is injectable so the window boundary is deterministic.
+ *
+ * @internal exported for testing
+ */
+export function buildPendingRetainsProbeScript(
+  base: string,
+  now: number = Date.now(),
+): string {
+  const dir = `${base}/pending-retains`;
   // `.json$` matches queued entries but NOT `.json.dead` (which ends in
   // `.dead`), so the two counts don't overlap. grep -c on empty input
   // prints 0 and exits 1, so guard with the -d test and swallow status.
@@ -1492,11 +1525,11 @@ export function probePendingRetainsQueue(
   // Ledger lines start with an ISO-8601 UTC timestamp, which sorts
   // lexicographically, so awk can window them with a plain string compare.
   const cutoff = new Date(
-    Date.now() - PENDING_RETAINS_EVICTION_WINDOW_DAYS * 86400_000,
+    now - PENDING_RETAINS_EVICTION_WINDOW_DAYS * 86400_000,
   )
     .toISOString()
     .replace(/\.\d+Z$/, "Z");
-  const script =
+  return (
     `P=0; D=0; X=0; E=0; C=\${HINDSIGHT_PENDING_MAX_ENTRIES:-${PENDING_RETAINS_DEFAULT_MAX_ENTRIES}}; ` +
     `if [ -d '${dir}' ]; then ` +
     `P=$(ls -1 '${dir}' 2>/dev/null | grep -c '\\.json$' || true); ` +
@@ -1513,12 +1546,20 @@ export function probePendingRetainsQueue(
     `'${base}/pending-evictions.log' 2>/dev/null || echo 0); ` +
     `[ -n "$E" ] || E=0; ` +
     `fi; ` +
-    `echo "P=$P D=$D X=$X E=$E C=$C"`;
-  const r = spawnSync(
-    "docker",
-    ["exec", `switchroom-${agentName}`, "sh", "-c", script],
-    { stdio: "pipe", timeout: 3000 },
+    `echo "P=$P D=$D X=$X E=$E C=$C"`
   );
+}
+
+/**
+ * Parse the probe one-liner's stdout into a verdict.
+ *
+ * @internal exported for testing
+ */
+function parsePendingRetainsProbeOutput(r: {
+  error?: Error;
+  status: number | null;
+  stdout: Buffer | string;
+}): PendingRetainsProbeResult {
   // docker/daemon failure, container absent (exit ≥125), or timeout
   // (status null) → skip this agent, don't false-alarm.
   const unreachable: PendingRetainsProbeResult = {
@@ -1668,7 +1709,9 @@ export function checkPendingRetainsQueues(
     `health rows above), or every retry just ages entries toward .dead. Entries the ` +
     `drain retires are MOVED to \`.hindsight/pending-reconciled/\` (bounded, so they ` +
     `expire), never deleted — every retire rests on an HTTP 200, which is an ack and ` +
-    `not proof, so the payload stays recoverable.`;
+    `not proof, so the payload stays recoverable. If that archive cannot be written ` +
+    `(disk full, permissions) the entry STAYS QUEUED and the drain says so on stderr; ` +
+    `a failure to archive is never a reason to delete.`;
 
   // fail: dead markers, residual drops, or recorded evictions. NOT depth:
   // a full queue evicts rather than refusing, so depth alone is a symptom.

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -334,6 +334,26 @@ def drain(
         remaining = budget - elapsed
         effective_timeout = max(1, min(timeout, int(remaining) if remaining >= 1 else 1))
 
+        # RECONCILE BEFORE RETRY — this is the fix for the re-post loop in
+        # the path that actually runs on every boot, not just in --backlog.
+        # 70.4% of the measured fleet backlog already existed as documents;
+        # re-POSTing those inside the hook is a guaranteed client timeout
+        # (the clamp above is far below a 30-90s synchronous retain), 30-90s
+        # of wasted server-side extraction, and one more step toward .dead
+        # for a memory that was never actually lost.
+        #
+        # A GET is sub-second and it REPLACES that doomed POST, so this
+        # strictly reduces both hook latency and upstream load. Only a
+        # definite True drops the entry: False and None (unknown) fall
+        # through to the retry, because guessing "present" would delete the
+        # last on-disk copy of a turn.
+        if _document_state(entry, timeout=effective_timeout) is True:
+            delete_entry(path)
+            summary["reconciled"] += 1
+            consecutive_failures = 0
+            last_error_class = None
+            continue
+
         try:
             _retry_one(entry, timeout=effective_timeout)
         except Exception as e:
@@ -397,14 +417,28 @@ def _reconcile_phase(config: dict, summary: dict, dry_run: bool) -> None:
     )
 
 
-def _wait_for_upstream(config: dict, backoff_ms: int) -> None:
-    """Block while the operator-supplied p95 probe says upstream is slow."""
+def _wait_for_upstream(backoff_ms: int, started: float, budget: float) -> bool:
+    """Block while the p95 probe says upstream is slow. False ⇒ give up.
+
+    The wait is bounded by the SAME wall-clock budget as the drain itself.
+    An unbounded ``while True: sleep(120)`` would let a persistently
+    degraded upstream block ``drain_backlog()`` indefinitely, long past the
+    budget the operator set — the one guarantee this mode makes about how
+    long it will run.
+    """
     if backoff_ms <= 0:
-        return
+        return True
     while True:
         p95 = _p95_probe_ms()
         if p95 < 0 or p95 <= backoff_ms:
-            return
+            return True
+        if time.monotonic() - started + 120 > budget:
+            _blog(
+                f"upstream still slow (p95={p95}ms > {backoff_ms}ms) and the "
+                f"budget is exhausted — stopping rather than waiting past it. "
+                f"Remaining entries stay queued; re-run when upstream recovers."
+            )
+            return False
         _blog(
             f"BACKOFF: upstream p95={p95}ms > {backoff_ms}ms — pausing 120s so "
             f"the replay never becomes the cause of a latency alarm"
@@ -448,13 +482,24 @@ def _drain_backlog_impl(
     consecutive_failures = 0
     last_error_class: str | None = None
 
+    # BUDGET GRANULARITY: checked between waves, not mid-wave, so a run can
+    # overshoot `budget` by at most one wave — up to HINDSIGHT_DRAIN_BACKLOG_
+    # TIMEOUT (180s default) plus the confirming GETs. That is deliberate:
+    # abandoning an in-flight wave would leave entries whose POST the server
+    # is still committing, and the whole point of commit-before-delete is not
+    # to guess about those. Unlike the in-hook drain (whose overshoot is
+    # clamped to ~1s because a SessionStart hook has a hard deadline), this
+    # mode has no deadline to miss — so a bounded overshoot is the cheaper
+    # trade.
     for start in range(0, len(entries), width):
         if time.monotonic() - started > budget:
             summary["budget_exceeded"] = True
             _blog("budget exhausted, stopping. Remaining entries stay queued — re-run to continue.")
             break
 
-        _wait_for_upstream(config, backoff_ms)
+        if not _wait_for_upstream(backoff_ms, started, budget):
+            summary["budget_exceeded"] = True
+            break
 
         wave = entries[start : start + width]
         # Results are collected in SUBMISSION order (not completion order)

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -112,6 +112,20 @@ def _clamp(timeout: int, budget: float, started: float) -> int:
     Floor at 1s so a near-exhausted budget still gets one bounded shot
     rather than a 0s (instant-fail) request. That floor is the entire
     overshoot: at most ~1s per request, ~2s for a GET+POST entry.
+
+    The 1s floor is expressed TWICE and the two are mutually redundant:
+    the early ``remaining < 1`` return and the ``max(1, ...)`` below each
+    enforce it alone (``int(0.5)`` → 0 → 1; ``int(-5)`` → -5 → 1). That
+    redundancy — not a coverage hole — is why single mutations here
+    survive: ``<`` → ``<=``, ``max(1`` → ``max(0``, and deleting either
+    guard are all EQUIVALENT mutants, verified by exhaustive comparison
+    over the boundary plus 200k random remainders (#3599 review R3-L4,
+    which reported it as unpinned). What matters is the floor's OUTCOME,
+    and that IS pinned: removing both guards fails
+    ``ClampAndEnvKnobBoundaryTest.test_clamp_floors_at_one_second_never_zero``
+    and ``test_session_start_reconcile_respects_the_hook_budget``. Left as
+    two lines deliberately — the shortcut states the intent where a reader
+    looks for it, and no mutation of it can change behaviour.
     """
     remaining = budget - (time.monotonic() - started)
     if remaining < 1:
@@ -332,6 +346,12 @@ def _new_summary() -> dict:
         "dead": 0,
         "reconciled": 0,
         "unknown": 0,
+        # Presence WAS established, but the entry could not be moved into
+        # the archive (ENOSPC, EACCES, read-only mount). It is still queued
+        # — archiving never falls back to a delete (#3599 review R3-M1) —
+        # so it must not be counted as drained/reconciled, which would
+        # report a retire that did not happen.
+        "archive_failed": 0,
         "stalled": False,
         "budget_exceeded": False,
     }
@@ -365,6 +385,8 @@ def drain(
          "dead":    int,   # entries promoted to .dead this run
          "reconciled": int,# already durable, archived without a POST
          "unknown": int,   # presence unknown, left queued
+         "archive_failed": int,  # durable, but the archive was unwritable
+                                 # so the entry is STILL QUEUED
          "stalled": bool,  # stall guard tripped
          "budget_exceeded": bool}
     """
@@ -418,8 +440,12 @@ def drain(
         # them durable.
         if _reconcilable_on_presence(entry):
             if _document_state(entry, timeout=_clamp(timeout, budget, started)) is True:
-                archive_reconciled(path)
-                summary["reconciled"] += 1
+                if archive_reconciled(path):
+                    summary["reconciled"] += 1
+                else:
+                    # Archive unwritable: the entry is STILL QUEUED (it is
+                    # never deleted), so calling it reconciled would be a lie.
+                    summary["archive_failed"] += 1
                 consecutive_failures = 0
                 last_error_class = None
                 continue
@@ -454,8 +480,10 @@ def drain(
         # nothing on the drain path is ever irreversibly removed, so the
         # in-hook path's weaker evidence costs at most a recoverable file
         # in ``pending-reconciled/`` instead of a lost turn.
-        archive_reconciled(path)
-        summary["drained"] += 1
+        if archive_reconciled(path):
+            summary["drained"] += 1
+        else:
+            summary["archive_failed"] += 1
         consecutive_failures = 0
         last_error_class = None
 
@@ -492,9 +520,10 @@ def _reconcile_phase(config: dict, summary: dict, dry_run: bool) -> None:
             continue
         state = _document_state(entry)
         if state is True:
-            summary["reconciled"] += 1
-            if not dry_run:
-                archive_reconciled(path)
+            if dry_run or archive_reconciled(path):
+                summary["reconciled"] += 1
+            else:
+                summary["archive_failed"] += 1
         elif state is None:
             summary["unknown"] += 1
     if skipped:
@@ -506,6 +535,12 @@ def _reconcile_phase(config: dict, summary: dict, dry_run: bool) -> None:
     _blog(
         f"phase 1 done: {summary['reconciled']} already durable "
         f"(no POST issued), {summary['unknown']} unknown (left queued)"
+        + (
+            f", {summary['archive_failed']} confirmed durable but NOT retired "
+            f"(archive unwritable — still queued)"
+            if summary["archive_failed"]
+            else ""
+        )
     )
 
 
@@ -620,8 +655,10 @@ def _drain_backlog_impl(
                 # synchronous POST of THIS entry's content that just
                 # returned 200. And the entry is archived, not deleted.
                 if _document_state(entry) is True:
-                    archive_reconciled(path)
-                    summary["drained"] += 1
+                    if archive_reconciled(path):
+                        summary["drained"] += 1
+                    else:
+                        summary["archive_failed"] += 1
                 else:
                     summary["unknown"] += 1
                     _blog(
@@ -709,13 +746,22 @@ def main(argv: list[str] | None = None) -> int:
         config, backlog=args.backlog, phase=args.phase, dry_run=args.dry_run
     )
     if any(
-        summary[k] for k in ("drained", "retried", "dead", "reconciled", "unknown")
+        summary[k]
+        for k in (
+            "drained",
+            "retried",
+            "dead",
+            "reconciled",
+            "unknown",
+            "archive_failed",
+        )
     ):
         print(
             f"[Hindsight] drain_pending{'(backlog)' if args.backlog else ''}: "
             f"drained={summary['drained']} reconciled={summary['reconciled']} "
             f"retried={summary['retried']} dead={summary['dead']} "
             f"unknown={summary['unknown']} "
+            f"archive_failed={summary['archive_failed']} "
             f"stalled={summary['stalled']} budget_exceeded={summary['budget_exceeded']}",
             file=sys.stderr,
         )

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -58,6 +58,11 @@ documents**, 3,815 of them with facts extracted.
 "Retire" never means ``os.remove``: an entry leaves the queue by MOVING
 into the bounded ``pending-reconciled/`` archive (``pending.
 archive_reconciled``), because every retire decision here rests on a 200.
+That holds unconditionally for THIS module. It does not make the queue
+immortal: if the archive cannot be written the entry stays queued, and a
+disk that stays full eventually drives ``pending._evict_to_fit`` to shed the
+OLDEST live entries on the ENQUEUE path (ledgered, and a ``switchroom
+doctor`` failure). Nothing the drain does deletes a turn; a full disk does.
 
 Pacing is not optional. The local model group backing retain has a small,
 fixed number of lanes shared with live retains, reflect and consolidation,
@@ -126,6 +131,21 @@ def _clamp(timeout: int, budget: float, started: float) -> int:
     and ``test_session_start_reconcile_respects_the_hook_budget``. Left as
     two lines deliberately — the shortcut states the intent where a reader
     looks for it, and no mutation of it can change behaviour.
+
+    THE EQUIVALENCE HAS A PRECONDITION, and it is not this function's
+    (#3599 review R4-Lb — the paragraph above used to claim it
+    unconditionally). ``max(1, min(timeout, int(remaining)))`` collapses to
+    ``max(0, ...)`` only while ``timeout >= 1``. With ``timeout == 0`` a
+    healthy budget takes the ``max`` branch and the ``max(0`` mutant returns
+    **0** — the instant-fail request the floor exists to prevent, on every
+    entry. The only callsite invariant that rules this out is
+    ``_per_entry_timeout()``'s own ``max(1, v)``, which is what turns
+    ``HINDSIGHT_DRAIN_TIMEOUT=0`` into 1. Both callers below take their
+    ``timeout`` from it (``drain``'s local, line ~396). So the honest
+    statement is: equivalent FOR EVERY REACHABLE INPUT, because
+    ``_per_entry_timeout`` floors first — a fact pinned by
+    ``ClampAndEnvKnobBoundaryTest.test_the_per_entry_timeout_is_floored_at_one_second``,
+    not by anything here. Change that floor and this proof dies with it.
     """
     remaining = budget - (time.monotonic() - started)
     if remaining < 1:
@@ -473,13 +493,22 @@ def drain(
                 break
             continue
 
-        # Success — retire the entry. ARCHIVED, not deleted: this path
-        # retires on a bare 200 (the hook has no budget for a confirming
-        # GET, which the backlog drain does issue because a 200 is an ack
-        # and not proof — #3244). One durability rule covers both paths:
-        # nothing on the drain path is ever irreversibly removed, so the
-        # in-hook path's weaker evidence costs at most a recoverable file
-        # in ``pending-reconciled/`` instead of a lost turn.
+        # Success — retire the entry. ARCHIVED, not deleted.
+        #
+        # The evidence here is the POST's own 200 and nothing else: a 5s
+        # hook budget has no room for the confirming re-GET the backlog
+        # drain issues. Not a BARE 200 though (#3599 review R4-B3 corrects
+        # this comment, which used to say so): ``_retry_one`` posts
+        # ``async_processing=False``, so the 200 is a commit-before-ack
+        # (#3244 §1.1) — the daemon's statement that it durably committed,
+        # not merely that it received. Weaker than an independent read,
+        # much stronger than an async ack.
+        #
+        # The residual risk is a daemon that does not honour ``async=false``.
+        # Archiving rather than deleting keeps a recoverable copy for that
+        # case — bounded by ``pending-reconciled/``'s caps, so recoverable
+        # has a horizon; ``pending._trim_dir`` documents exactly what that
+        # horizon costs.
         if archive_reconciled(path):
             summary["drained"] += 1
         else:

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -10,16 +10,19 @@ the queue no longer drains it but the operator can still inspect via
 Boundaries
 ----------
 * Per-entry HTTP timeout: ``HINDSIGHT_DRAIN_TIMEOUT`` (default 5s), but
-  clamped per entry to the budget still remaining (see below) so a
-  single slow entry can never overshoot the wall-clock cap. The default
-  timeout (5s) intentionally exceeds the default budget (4s): the clamp,
-  not the raw timeout, is what bounds a slow entry.
+  clamped to the budget still remaining (see below) so a single slow
+  entry can never overshoot the wall-clock cap. The default timeout (5s)
+  intentionally exceeds the default budget (4s): the clamp, not the raw
+  timeout, is what bounds a slow entry.
 * Total wall-clock cap: ``HINDSIGHT_DRAIN_BUDGET_S`` (default 4s) so
   drain never blocks SessionStart longer than the upstream hook timeout
-  permits. This is the authoritative bound; the per-entry timeout is
-  clamped down to ``max(1, remaining budget)`` before each request, so
-  even one slow upstream entry overshoots the budget by at most the
-  clamp floor (~1s), not by ``HINDSIGHT_DRAIN_TIMEOUT - budget``.
+  permits. This is the authoritative bound. The clamp is recomputed
+  **before every request** — the presence GET and, if it falls through,
+  the POST — against the budget remaining *at that moment*, not once per
+  entry. Clamping once per entry spends the same allowance twice (a 9s
+  budget with an 8s timeout measured 16.0s), so the overshoot is bounded
+  by the clamp floor (~1s) only if each request re-reads the remaining
+  budget.
 * Stall guard: if ``STALL_THRESHOLD`` (3) consecutive entries fail with
   the same error class, we stop draining for this session — that's a
   systemic outage, not a transient flake, and continuing would only
@@ -42,12 +45,19 @@ documents**, 3,815 of them with facts extracted.
 ``--backlog`` is therefore a two-phase, out-of-hook replay:
 
 * **Phase 1 — reconcile (free).** GET the document. If it exists, the
-  memory is already durable; drop the queue entry without a POST. No LLM
-  work, no cost, idempotent, resumable at any point.
+  memory is already durable; retire the queue entry without a POST. No
+  LLM work, no cost, idempotent, resumable at any point. Only for
+  post-#3244 CONTENT-derived ``document_id``s — a pre-#3244 bare session
+  id is answered 200 by any retain in that session, so its 200 says
+  nothing about this entry (see ``_reconcilable_on_presence``).
 * **Phase 2 — drain (real work).** Only for genuinely absent documents:
   POST with a realistic timeout, then **re-GET to confirm the document
-  exists before deleting the entry**. A 200 is an ack, not proof
+  exists before retiring the entry**. A 200 is an ack, not proof
   (switchroom #3244).
+
+"Retire" never means ``os.remove``: an entry leaves the queue by MOVING
+into the bounded ``pending-reconciled/`` archive (``pending.
+archive_reconciled``), because every retire decision here rests on a 200.
 
 Pacing is not optional. The local model group backing retain has a small,
 fixed number of lanes shared with live retains, reflect and consolidation,
@@ -78,7 +88,8 @@ from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.pending import (
     MAX_ATTEMPTS,
-    delete_entry,
+    archive_reconciled,
+    is_content_derived_document_id,
     iter_entries,
     mark_dead,
     update_attempt,
@@ -86,6 +97,36 @@ from lib.pending import (
 
 
 STALL_THRESHOLD = 3
+
+
+def _clamp(timeout: int, budget: float, started: float) -> int:
+    """Per-REQUEST HTTP timeout: ``timeout`` capped by the budget LEFT NOW.
+
+    Called immediately before each request — the presence GET and the POST
+    — not once per entry. Computing it once and spending it twice makes the
+    per-entry cost additive: with the fleet's own settings (budget 9s,
+    timeout 8s) a single slow entry measured 16.0s against a 9s budget,
+    while the module docstring promised an overshoot of at most the clamp
+    floor.
+
+    Floor at 1s so a near-exhausted budget still gets one bounded shot
+    rather than a 0s (instant-fail) request. That floor is the entire
+    overshoot: at most ~1s per request, ~2s for a GET+POST entry.
+    """
+    remaining = budget - (time.monotonic() - started)
+    if remaining < 1:
+        return 1
+    return max(1, min(timeout, int(remaining)))
+
+
+def _reconcilable_on_presence(entry: dict) -> bool:
+    """May a bare presence GET retire this entry? See ``pending.py``.
+
+    Only for post-#3244 content-derived ``document_id``s. A pre-#3244
+    entry's id is a bare session id, so a 200 reflects *some* retain in
+    that session, not this entry's content.
+    """
+    return is_content_derived_document_id(entry.get("document_id"))
 
 
 def _per_entry_timeout() -> int:
@@ -167,6 +208,15 @@ def _p95_probe_ms() -> int:
     log in postgres, which an agent container cannot reach — inventing a
     weaker in-container proxy for it would be a worse signal that looks
     like a better one. Unset ⇒ no backoff, and ``--backlog`` says so.
+
+    A CONFIGURED-BUT-BROKEN probe is not the same as an unset one, and
+    used to be indistinguishable: ``out.returncode`` was ignored, so a
+    typo'd or unauthorized command produced empty stdout, ``int()`` raised,
+    and the bare ``except`` returned ``-1`` — silently disabling the very
+    backoff the operator had asked for. It still returns ``-1`` (a replay
+    that halts because its probe is broken is worse than one that runs
+    unpaced), but it now says so loudly on stderr, naming the exit status
+    and stderr tail, so the gap is visible in the drain log.
     """
     cmd = os.environ.get("HINDSIGHT_DRAIN_P95_CMD")
     if not cmd:
@@ -175,8 +225,26 @@ def _p95_probe_ms() -> int:
         out = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=45
         )
+    except Exception as e:
+        _blog(
+            f"p95 probe FAILED to run ({type(e).__name__}: {e}) — backoff is "
+            f"DISABLED for this run. Fix HINDSIGHT_DRAIN_P95_CMD."
+        )
+        return -1
+    if out.returncode != 0:
+        _blog(
+            f"p95 probe exited {out.returncode} — backoff is DISABLED for this "
+            f"run. Fix HINDSIGHT_DRAIN_P95_CMD. stderr: "
+            f"{(out.stderr or '').strip()[:200]}"
+        )
+        return -1
+    try:
         return int(out.stdout.strip().splitlines()[-1])
-    except Exception:
+    except (ValueError, IndexError):
+        _blog(
+            f"p95 probe exited 0 but printed no millisecond figure — backoff is "
+            f"DISABLED for this run. stdout: {(out.stdout or '').strip()[:200]!r}"
+        )
         return -1
 
 
@@ -184,9 +252,9 @@ def _retry_one(entry: dict, timeout: int) -> None:
     """POST a single queued retain. Raises on failure.
 
     Posts ``async_processing=False`` (commit-before-ack, switchroom #3244 §1.1):
-    the drain is a DURABILITY path — it deletes the pending entry on a 200, so
+    the drain is a DURABILITY path — it retires the pending entry on a 200, so
     the 200 must prove durable persistence, not merely ack-of-receipt. A bare
-    async 200 followed by a dropped extraction would delete the queue entry
+    async 200 followed by a dropped extraction would retire the queue entry
     while the content never lands, and (for boot-reconcile remainders whose
     watermark already advanced) there is no reconcile backstop — silent loss
     (the #3244 bug). All drained entries — Stop-hook A2 failures, SessionEnd
@@ -292,10 +360,10 @@ def drain(
 
     Returns a summary dict::
 
-        {"drained": int,   # successful retries (entries deleted)
+        {"drained": int,   # successful retries (entries archived)
          "retried": int,   # failures kept for next session
          "dead":    int,   # entries promoted to .dead this run
-         "reconciled": int,# already durable, dropped without a POST
+         "reconciled": int,# already durable, archived without a POST
          "unknown": int,   # presence unknown, left queued
          "stalled": bool,  # stall guard tripped
          "budget_exceeded": bool}
@@ -326,36 +394,40 @@ def drain(
             debug_log(config, "drain_pending: total budget exceeded, stopping")
             break
 
-        # Clamp the per-entry HTTP timeout to the budget still remaining
-        # (#1094 item 2). Without this, a single slow entry using the full
-        # HINDSIGHT_DRAIN_TIMEOUT (default 5s) overshoots the total budget
-        # (default 4s). Floor at 1s so we still give a near-exhausted
-        # budget one bounded shot rather than a 0s (instant-fail) request.
-        remaining = budget - elapsed
-        effective_timeout = max(1, min(timeout, int(remaining) if remaining >= 1 else 1))
-
         # RECONCILE BEFORE RETRY — this is the fix for the re-post loop in
         # the path that actually runs on every boot, not just in --backlog.
         # 70.4% of the measured fleet backlog already existed as documents;
         # re-POSTing those inside the hook is a guaranteed client timeout
-        # (the clamp above is far below a 30-90s synchronous retain), 30-90s
-        # of wasted server-side extraction, and one more step toward .dead
-        # for a memory that was never actually lost.
+        # (the clamp is far below a 30-90s synchronous retain), 30-90s of
+        # wasted server-side extraction, and one more step toward .dead for
+        # a memory that was never actually lost.
         #
         # A GET is sub-second and it REPLACES that doomed POST, so this
         # strictly reduces both hook latency and upstream load. Only a
-        # definite True drops the entry: False and None (unknown) fall
-        # through to the retry, because guessing "present" would delete the
+        # definite True retires the entry: False and None (unknown) fall
+        # through to the retry, because guessing "present" would retire the
         # last on-disk copy of a turn.
-        if _document_state(entry, timeout=effective_timeout) is True:
-            delete_entry(path)
-            summary["reconciled"] += 1
-            consecutive_failures = 0
-            last_error_class = None
-            continue
+        #
+        # GATED ON THE ID SHAPE. A presence GET only proves *this* entry's
+        # content was committed when the document_id is content-derived
+        # (post-#3244 `retain.slice_document_id`). A pre-#3244 entry carries
+        # a bare session id, for which the bank answers 200 after ANY
+        # successful retain in that session — reconciling on that deletes a
+        # turn that was never committed. Such entries skip the free pass and
+        # go straight to the POST, which is the only thing that can make
+        # them durable.
+        if _reconcilable_on_presence(entry):
+            if _document_state(entry, timeout=_clamp(timeout, budget, started)) is True:
+                archive_reconciled(path)
+                summary["reconciled"] += 1
+                consecutive_failures = 0
+                last_error_class = None
+                continue
 
         try:
-            _retry_one(entry, timeout=effective_timeout)
+            # Re-clamp: the GET above spent part of the budget, and the same
+            # allowance must not be handed out twice (#3599 review F2).
+            _retry_one(entry, timeout=_clamp(timeout, budget, started))
         except Exception as e:
             err_class = _record_failure(config, path, entry, e, summary)
             if err_class == last_error_class:
@@ -375,8 +447,14 @@ def drain(
                 break
             continue
 
-        # Success — delete the entry.
-        delete_entry(path)
+        # Success — retire the entry. ARCHIVED, not deleted: this path
+        # retires on a bare 200 (the hook has no budget for a confirming
+        # GET, which the backlog drain does issue because a 200 is an ack
+        # and not proof — #3244). One durability rule covers both paths:
+        # nothing on the drain path is ever irreversibly removed, so the
+        # in-hook path's weaker evidence costs at most a recoverable file
+        # in ``pending-reconciled/`` instead of a lost turn.
+        archive_reconciled(path)
         summary["drained"] += 1
         consecutive_failures = 0
         last_error_class = None
@@ -396,21 +474,35 @@ def _reconcile_phase(config: dict, summary: dict, dry_run: bool) -> None:
     is duplicated LLM extraction for zero new memory. A GET costs nothing
     on the model pool.
 
-    Only a definite ``True`` drops an entry. ``False`` leaves it for phase
-    2; ``None`` (unknown) leaves it queued and is counted — never guessed.
+    Only a definite ``True`` retires an entry, and only for a post-#3244
+    content-derived ``document_id`` (see ``_reconcilable_on_presence``) —
+    a bare session id's 200 says nothing about *this* entry's content.
+    ``False`` leaves it for phase 2; ``None`` (unknown) leaves it queued
+    and is counted — never guessed. Retiring MOVES the entry into
+    ``pending-reconciled/``; it is never ``os.remove``d.
     """
     entries = iter_entries()
     if not entries:
         return
     _blog(f"phase 1 reconcile: checking {len(entries)} entries (no LLM cost)")
+    skipped = 0
     for path, entry in entries:
+        if not _reconcilable_on_presence(entry):
+            skipped += 1
+            continue
         state = _document_state(entry)
         if state is True:
             summary["reconciled"] += 1
             if not dry_run:
-                delete_entry(path)
+                archive_reconciled(path)
         elif state is None:
             summary["unknown"] += 1
+    if skipped:
+        _blog(
+            f"phase 1: {skipped} entries have a pre-#3244 (bare session) "
+            f"document_id — a presence GET cannot prove THEIR content was "
+            f"committed, so they go to phase 2 rather than the free pass"
+        )
     _blog(
         f"phase 1 done: {summary['reconciled']} already durable "
         f"(no POST issued), {summary['unknown']} unknown (left queued)"
@@ -519,12 +611,16 @@ def _drain_backlog_impl(
 
         for (path, entry), err in zip(wave, outcomes):
             if err is None:
-                # COMMIT-BEFORE-DELETE. A 200 is an ack, not proof the
+                # COMMIT-BEFORE-RETIRE. A 200 is an ack, not proof the
                 # document is durable (switchroom #3244), so re-GET before
-                # dropping the last on-disk copy. Anything other than a
-                # definite True keeps the entry.
+                # retiring the last on-disk copy. Anything other than a
+                # definite True keeps the entry. This confirming GET is
+                # meaningful even for a pre-#3244 bare-session id: unlike
+                # the free reconcile pass, it is corroborated by the
+                # synchronous POST of THIS entry's content that just
+                # returned 200. And the entry is archived, not deleted.
                 if _document_state(entry) is True:
-                    delete_entry(path)
+                    archive_reconciled(path)
                     summary["drained"] += 1
                 else:
                     summary["unknown"] += 1

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -26,16 +26,51 @@ Boundaries
   burn the SessionStart timeout budget. The remaining entries stay
   queued for the next session.
 
+Backlog mode (switchroom #3596)
+-------------------------------
+The bounds above are sized for the SessionStart hook and CANNOT clear an
+accumulated backlog. Worse, they CREATE one: the per-entry timeout is
+clamped to the remaining hook budget (1-8s) while ``_retry_one`` posts
+synchronously and a real retain takes 30-90s, so **the server commits the
+document and the client always gives up before the ack**. The entry is
+never deleted and is re-posted on every session start, forever, until it
+hits ``MAX_ATTEMPTS`` and goes ``.dead``. The queue depth was a symptom
+of that loop, not of lost memory: a full sweep of 5,751 queued entries on
+this fleet (2026-07-25) found **4,048 (70.4%) already existed as
+documents**, 3,815 of them with facts extracted.
+
+``--backlog`` is therefore a two-phase, out-of-hook replay:
+
+* **Phase 1 — reconcile (free).** GET the document. If it exists, the
+  memory is already durable; drop the queue entry without a POST. No LLM
+  work, no cost, idempotent, resumable at any point.
+* **Phase 2 — drain (real work).** Only for genuinely absent documents:
+  POST with a realistic timeout, then **re-GET to confirm the document
+  exists before deleting the entry**. A 200 is an ack, not proof
+  (switchroom #3244).
+
+Pacing is not optional. The local model group backing retain has a small,
+fixed number of lanes shared with live retains, reflect and consolidation,
+so backlog replay defaults to **concurrency 1** with a sleep between
+entries, and will pause entirely while an operator-supplied p95 probe
+reports the upstream is already slow.
+
 Standalone usage::
 
-    python3 drain_pending.py        # one-shot drain, prints summary
+    python3 drain_pending.py               # bounded in-hook drain
+    python3 drain_pending.py --backlog     # two-phase backlog replay
+    python3 drain_pending.py --backlog --phase reconcile   # free pass only
+    python3 drain_pending.py --backlog --dry-run
 """
 
 from __future__ import annotations
 
+import argparse
 import os
+import subprocess
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -71,6 +106,80 @@ def _budget_seconds() -> float:
         return 4.0
 
 
+def _env_num(name: str, default, cast=float, lo=None, hi=None):
+    """Read a numeric env knob, falling back to ``default`` on garbage."""
+    try:
+        v = cast(os.environ.get(name) or default)
+    except (TypeError, ValueError):
+        v = cast(default)
+    if lo is not None:
+        v = max(lo, v)
+    if hi is not None:
+        v = min(hi, v)
+    return v
+
+
+def _backlog_timeout() -> int:
+    """Per-entry HTTP timeout in backlog mode.
+
+    A synchronous retain takes 30-90s on this fleet, so the SessionStart
+    default (5-8s, further clamped by the hook budget) guarantees a
+    client-side timeout on a request the server then commits anyway.
+    """
+    return _env_num("HINDSIGHT_DRAIN_BACKLOG_TIMEOUT", 180, int, lo=1)
+
+
+def _backlog_budget_seconds() -> float:
+    """Total wall-clock cap in backlog mode (default 1h)."""
+    return _env_num("HINDSIGHT_DRAIN_BACKLOG_BUDGET_S", 3600, float, lo=1.0)
+
+
+def _backlog_concurrency() -> int:
+    """Entries retried in parallel in backlog mode.
+
+    **Defaults to 1, deliberately.** The local model group serving retain
+    has a small fixed number of lanes (4 on this fleet: 2 boxes x 2 slots)
+    SHARED with live retains, reflect and consolidation. A drain at width
+    4 consumes the whole pool; run per-agent across 11 agents and it is
+    44 lanes of demand against 4, which trips the latency watchdog. One
+    lane leaves the rest for live work. Raise it only if you know the
+    pool is idle.
+    """
+    return _env_num("HINDSIGHT_DRAIN_CONCURRENCY", 1, int, lo=1, hi=16)
+
+
+def _backlog_sleep_seconds() -> float:
+    """Pause between phase-2 retains, so replay never runs flat out."""
+    return _env_num("HINDSIGHT_DRAIN_SLEEP_S", 2.0, float, lo=0.0)
+
+
+def _p95_backoff_ms() -> int:
+    """Pause phase 2 while the upstream p95 exceeds this."""
+    return _env_num("HINDSIGHT_DRAIN_P95_BACKOFF_MS", 38000, int, lo=0)
+
+
+def _p95_probe_ms() -> int:
+    """Current upstream p95 in ms, or ``-1`` when unknown.
+
+    The probe is an operator-supplied command (``HINDSIGHT_DRAIN_P95_CMD``)
+    that prints a millisecond figure on stdout. It is NOT built in: the
+    authoritative latency figure on this fleet lives in LiteLLM's spend
+    log in postgres, which an agent container cannot reach — inventing a
+    weaker in-container proxy for it would be a worse signal that looks
+    like a better one. Unset ⇒ no backoff, and ``--backlog`` says so.
+    """
+    cmd = os.environ.get("HINDSIGHT_DRAIN_P95_CMD")
+    if not cmd:
+        return -1
+    try:
+        out = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=45
+        )
+        return int(out.stdout.strip().splitlines()[-1])
+    except Exception:
+        return -1
+
+
 def _retry_one(entry: dict, timeout: int) -> None:
     """POST a single queued retain. Raises on failure.
 
@@ -97,29 +206,108 @@ def _retry_one(entry: dict, timeout: int) -> None:
     )
 
 
-def drain(config: dict | None = None) -> dict:
+def _document_state(entry: dict, timeout: int = 30):
+    """Tri-state presence of this entry's document. See ``document_exists``.
+
+    ``True`` present / ``False`` absent / ``None`` unknown. Never raises —
+    an unknown must never be mistaken for an absence (which would re-POST
+    a durable document) nor for a presence (which would delete the last
+    on-disk copy of a turn).
+    """
+    did = entry.get("document_id")
+    bank = entry.get("bank_id")
+    if not did or not bank:
+        return None
+    try:
+        client = HindsightClient(entry["api_url"], entry.get("api_token"))
+        return client.document_exists(bank, did, timeout=timeout)
+    except Exception:
+        return None
+
+
+def _record_failure(
+    config: dict,
+    path: str,
+    entry: dict,
+    e: Exception,
+    summary: dict,
+) -> str:
+    """Apply the per-entry failure policy. Returns the error class name.
+
+    Shared by the sequential (SessionStart) and backlog drains so both age
+    entries toward ``.dead`` on exactly the same schedule.
+    """
+    err_class = type(e).__name__
+    attempts = int(entry.get("attempt_count", 1))
+    if attempts >= MAX_ATTEMPTS:
+        marker = mark_dead(path, entry)
+        summary["dead"] += 1
+        print(
+            f"[Hindsight] drain_pending: entry exceeded {MAX_ATTEMPTS} "
+            f"attempts, marking dead at {marker} (last error: {err_class}: {e})",
+            file=sys.stderr,
+        )
+    else:
+        update_attempt(path, entry, e)
+        summary["retried"] += 1
+        debug_log(
+            config,
+            f"drain_pending: retry {attempts}/{MAX_ATTEMPTS} failed for {path} ({err_class}: {e})",
+        )
+    return err_class
+
+
+def _new_summary() -> dict:
+    return {
+        "drained": 0,
+        "retried": 0,
+        "dead": 0,
+        "reconciled": 0,
+        "unknown": 0,
+        "stalled": False,
+        "budget_exceeded": False,
+    }
+
+
+def drain_backlog(config: dict | None = None, **kw) -> dict:
+    """Two-phase backlog replay, off the SessionStart budget entirely.
+
+    See the module docstring. Summary shape is ``drain()``'s plus
+    ``reconciled`` (already durable — no POST issued) and ``unknown``
+    (presence could not be established; left queued).
+    """
+    return drain(config, backlog=True, **kw)
+
+
+def drain(
+    config: dict | None = None,
+    backlog: bool = False,
+    phase: str = "both",
+    dry_run: bool = False,
+) -> dict:
     """Walk the pending-retains directory and retry each entry.
+
+    ``backlog=False`` (default) is the bounded in-hook drain.
+    ``backlog=True`` is the operator backlog replay — see ``drain_backlog()``.
 
     Returns a summary dict::
 
         {"drained": int,   # successful retries (entries deleted)
          "retried": int,   # failures kept for next session
          "dead":    int,   # entries promoted to .dead this run
+         "reconciled": int,# already durable, dropped without a POST
+         "unknown": int,   # presence unknown, left queued
          "stalled": bool,  # stall guard tripped
          "budget_exceeded": bool}
     """
     config = config or load_config()
+    if backlog:
+        return _drain_backlog_impl(config, phase=phase, dry_run=dry_run)
     timeout = _per_entry_timeout()
     budget = _budget_seconds()
     started = time.monotonic()
 
-    summary = {
-        "drained": 0,
-        "retried": 0,
-        "dead": 0,
-        "stalled": False,
-        "budget_exceeded": False,
-    }
+    summary = _new_summary()
 
     entries = iter_entries()
     if not entries:
@@ -149,29 +337,12 @@ def drain(config: dict | None = None) -> dict:
         try:
             _retry_one(entry, timeout=effective_timeout)
         except Exception as e:
-            err_class = type(e).__name__
+            err_class = _record_failure(config, path, entry, e, summary)
             if err_class == last_error_class:
                 consecutive_failures += 1
             else:
                 consecutive_failures = 1
                 last_error_class = err_class
-
-            attempts = int(entry.get("attempt_count", 1))
-            if attempts >= MAX_ATTEMPTS:
-                marker = mark_dead(path, entry)
-                summary["dead"] += 1
-                print(
-                    f"[Hindsight] drain_pending: entry exceeded {MAX_ATTEMPTS} "
-                    f"attempts, marking dead at {marker} (last error: {err_class}: {e})",
-                    file=sys.stderr,
-                )
-            else:
-                update_attempt(path, entry, e)
-                summary["retried"] += 1
-                debug_log(
-                    config,
-                    f"drain_pending: retry {attempts}/{MAX_ATTEMPTS} failed for {path} ({err_class}: {e})",
-                )
 
             if consecutive_failures >= STALL_THRESHOLD:
                 summary["stalled"] = True
@@ -193,14 +364,217 @@ def drain(config: dict | None = None) -> dict:
     return summary
 
 
-def main() -> int:
-    config = load_config()
-    summary = drain(config)
-    if summary["drained"] or summary["retried"] or summary["dead"]:
+def _blog(msg: str) -> None:
+    print(f"[Hindsight] drain_pending(backlog): {msg}", file=sys.stderr)
+
+
+def _reconcile_phase(config: dict, summary: dict, dry_run: bool) -> None:
+    """PHASE 1 — free pass: drop entries whose document already exists.
+
+    This is the phase that makes backlog replay affordable. 70.4% of a
+    measured 5,751-entry fleet backlog was already durable; POSTing those
+    is duplicated LLM extraction for zero new memory. A GET costs nothing
+    on the model pool.
+
+    Only a definite ``True`` drops an entry. ``False`` leaves it for phase
+    2; ``None`` (unknown) leaves it queued and is counted — never guessed.
+    """
+    entries = iter_entries()
+    if not entries:
+        return
+    _blog(f"phase 1 reconcile: checking {len(entries)} entries (no LLM cost)")
+    for path, entry in entries:
+        state = _document_state(entry)
+        if state is True:
+            summary["reconciled"] += 1
+            if not dry_run:
+                delete_entry(path)
+        elif state is None:
+            summary["unknown"] += 1
+    _blog(
+        f"phase 1 done: {summary['reconciled']} already durable "
+        f"(no POST issued), {summary['unknown']} unknown (left queued)"
+    )
+
+
+def _wait_for_upstream(config: dict, backoff_ms: int) -> None:
+    """Block while the operator-supplied p95 probe says upstream is slow."""
+    if backoff_ms <= 0:
+        return
+    while True:
+        p95 = _p95_probe_ms()
+        if p95 < 0 or p95 <= backoff_ms:
+            return
+        _blog(
+            f"BACKOFF: upstream p95={p95}ms > {backoff_ms}ms — pausing 120s so "
+            f"the replay never becomes the cause of a latency alarm"
+        )
+        time.sleep(120)
+
+
+def _drain_backlog_impl(
+    config: dict, phase: str = "both", dry_run: bool = False
+) -> dict:
+    """Concurrent-capable, long-budget, two-phase backlog replay."""
+    summary = _new_summary()
+
+    if phase in ("reconcile", "both"):
+        _reconcile_phase(config, summary, dry_run)
+    if phase == "reconcile":
+        return summary
+
+    timeout = _backlog_timeout()
+    budget = _backlog_budget_seconds()
+    width = _backlog_concurrency()
+    sleep_s = _backlog_sleep_seconds()
+    backoff_ms = _p95_backoff_ms()
+    started = time.monotonic()
+
+    entries = iter_entries()
+    if not entries:
+        _blog("phase 2: nothing left to retain")
+        return summary
+
+    _blog(
+        f"phase 2 drain: {len(entries)} entries genuinely need retaining "
+        f"(concurrency={width} timeout={timeout}s budget={budget:.0f}s "
+        f"sleep={sleep_s}s p95_probe="
+        f"{'on' if os.environ.get('HINDSIGHT_DRAIN_P95_CMD') else 'unset'})"
+    )
+    if dry_run:
+        _blog("dry run — no retains issued")
+        return summary
+
+    consecutive_failures = 0
+    last_error_class: str | None = None
+
+    for start in range(0, len(entries), width):
+        if time.monotonic() - started > budget:
+            summary["budget_exceeded"] = True
+            _blog("budget exhausted, stopping. Remaining entries stay queued — re-run to continue.")
+            break
+
+        _wait_for_upstream(config, backoff_ms)
+
+        wave = entries[start : start + width]
+        # Results are collected in SUBMISSION order (not completion order)
+        # so the stall guard sees a deterministic sequence and behaves
+        # identically to the sequential drain.
+        with ThreadPoolExecutor(max_workers=width) as pool:
+            futures = [
+                pool.submit(_retry_one, entry, timeout) for _path, entry in wave
+            ]
+            outcomes = []
+            for fut in futures:
+                try:
+                    fut.result()
+                    outcomes.append(None)
+                except Exception as e:  # noqa: BLE001 — per-entry policy below
+                    outcomes.append(e)
+
+        for (path, entry), err in zip(wave, outcomes):
+            if err is None:
+                # COMMIT-BEFORE-DELETE. A 200 is an ack, not proof the
+                # document is durable (switchroom #3244), so re-GET before
+                # dropping the last on-disk copy. Anything other than a
+                # definite True keeps the entry.
+                if _document_state(entry) is True:
+                    delete_entry(path)
+                    summary["drained"] += 1
+                else:
+                    summary["unknown"] += 1
+                    _blog(
+                        f"posted but document not confirmed, keeping entry: "
+                        f"{os.path.basename(path)}"
+                    )
+                consecutive_failures = 0
+                last_error_class = None
+                continue
+
+            # STALL GUARD, evaluated BEFORE the failure is recorded for the
+            # rest of the wave. Recording first would let a wave of `width`
+            # identical timeouts bump attempt_count on all of them before
+            # the loop breaks — aging entries toward .dead FASTER than the
+            # sequential drain, the opposite of the point. Counting first
+            # and breaking immediately after the tripping entry makes the
+            # two paths bump exactly the same number of entries.
+            err_class = type(err).__name__
+            if err_class == last_error_class:
+                consecutive_failures += 1
+            else:
+                consecutive_failures = 1
+                last_error_class = err_class
+
+            _record_failure(config, path, entry, err, summary)
+
+            if consecutive_failures >= STALL_THRESHOLD:
+                summary["stalled"] = True
+                _blog(
+                    f"{consecutive_failures} consecutive failures with "
+                    f"{err_class}, stalling. Fix the upstream, then re-run. "
+                    f"Remaining entries stay queued."
+                )
+                break
+
+        if summary["stalled"]:
+            break
+        if sleep_s:
+            time.sleep(sleep_s)
+
+    return summary
+
+
+def _parse_args(argv: list[str] | None):
+    """Real argument parsing.
+
+    Was a bare ``"--backlog" in argv`` membership test, which silently ran
+    the 4-second in-hook drain on a typo like ``--backlogg`` while the
+    operator believed they had started a backlog replay.
+    """
+    ap = argparse.ArgumentParser(
+        prog="drain_pending.py",
+        description="Drain the hindsight pending-retains queue.",
+    )
+    ap.add_argument(
+        "--backlog",
+        action="store_true",
+        help="two-phase backlog replay, off the SessionStart budget",
+    )
+    ap.add_argument(
+        "--phase",
+        choices=["reconcile", "drain", "both"],
+        default="both",
+        help="with --backlog: run only the free reconcile pass, only the "
+        "retain pass, or both (default)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="with --backlog: report what would happen, issue no writes",
+    )
+    return ap.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    if (args.phase != "both" or args.dry_run) and not args.backlog:
         print(
-            f"[Hindsight] drain_pending: "
-            f"drained={summary['drained']} retried={summary['retried']} "
-            f"dead={summary['dead']} "
+            "[Hindsight] drain_pending: --phase/--dry-run require --backlog",
+            file=sys.stderr,
+        )
+        return 2
+    config = load_config()
+    summary = drain(
+        config, backlog=args.backlog, phase=args.phase, dry_run=args.dry_run
+    )
+    if any(
+        summary[k] for k in ("drained", "retried", "dead", "reconciled", "unknown")
+    ):
+        print(
+            f"[Hindsight] drain_pending{'(backlog)' if args.backlog else ''}: "
+            f"drained={summary['drained']} reconciled={summary['reconciled']} "
+            f"retried={summary['retried']} dead={summary['dead']} "
+            f"unknown={summary['unknown']} "
             f"stalled={summary['stalled']} budget_exceeded={summary['budget_exceeded']}",
             file=sys.stderr,
         )

--- a/vendor/hindsight-memory/scripts/lib/client.py
+++ b/vendor/hindsight-memory/scripts/lib/client.py
@@ -206,6 +206,49 @@ class HindsightClient:
         }
         return self._request("POST", path, body, timeout=timeout)
 
+    def document_exists(
+        self,
+        bank_id: str,
+        document_id: str,
+        timeout: int = 30,
+    ) -> Optional[bool]:
+        """TRI-STATE presence check for one document (switchroom #3596).
+
+        ``True`` — the document is there. ``False`` — the server said 404.
+        ``None`` — **unknown** (transport error, 5xx, timeout).
+
+        The tri-state is load-bearing and must not be collapsed to a bool.
+        Two callers depend on it:
+
+        * the backlog drain's reconcile phase, which SKIPS a retain when the
+          memory already exists. Treating "unknown" as ``False`` there would
+          re-POST a document that is already durable — the duplicated-LLM-cost
+          bug this check exists to avoid (70.4% of one measured 5,751-entry
+          fleet backlog already existed as documents).
+        * commit-before-delete, which only deletes a queue entry once presence
+          is CONFIRMED. Treating "unknown" as ``True`` there would delete the
+          last on-disk copy of a turn on a flaky GET — the #3244 silent-loss
+          shape, reintroduced from the other direction.
+
+        Deliberately does NOT reuse ``_request()``: that wraps every
+        ``HTTPError`` into a ``RuntimeError``, which would make a 404
+        indistinguishable from a 503 without string-matching the message.
+        """
+        bank = urllib.parse.quote(bank_id, safe="")
+        did = urllib.parse.quote(document_id, safe="")
+        url = f"{self.api_url}/v1/default/banks/{bank}/documents/{did}"
+        req = urllib.request.Request(url, headers=self._headers(), method="GET")
+        try:
+            with urllib.request.urlopen(
+                req, timeout=self._resolve_timeout(timeout)
+            ) as resp:
+                resp.read()
+                return True
+        except urllib.error.HTTPError as e:
+            return False if e.code == 404 else None
+        except Exception:
+            return None
+
     def list_session_document_ids(
         self,
         bank_id: str,

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -6,8 +6,9 @@ persisted. To prevent silent data loss (#1071), session_end.py
 serializes the *exact retain payload* it would have POSTed into
 ``~/.hindsight/pending-retains/<unix-ms>-<short-uuid>.json``. The next
 SessionStart drains the directory: oldest first, success RETIRES the
-entry into the bounded ``pending-reconciled/`` archive (it is never
-deleted — see "Retiring an entry" below), failure bumps an attempt
+entry into the bounded ``pending-reconciled/`` archive (the drain never
+deletes — see "Retiring an entry" below for that promise and its one
+bound, a full disk), failure bumps an attempt
 counter (up to MAX_ATTEMPTS) and leaves the entry for the run after
 that.
 
@@ -105,6 +106,18 @@ disappears. ``is_content_derived_document_id()`` is the second half of that
 guard: a *presence-only* reconcile is sound only for post-#3244
 content-derived ids, because a pre-#3244 bare session id answers 200 for any
 retain in that session.
+
+The heading says "never delete" about the DRAIN path, and that is exact. The
+ENQUEUE path is different and the difference is the bound on this promise
+(#3599 review R4-M1): if ``archive_reconciled`` cannot write (ENOSPC), it
+keeps the entry queued; entries then accumulate until the queue hits its cap;
+``_evict_to_fit`` fires; its own archive move fails for the same reason; and
+it removes the OLDEST live entries to keep accepting the newest. So under a
+sustained full disk "keep it queued" degrades to "keep the newest, drop the
+oldest". Bounded, deliberate and loud — stderr, a ``+archive-failed`` line in
+``pending-evictions.log``, and a ``switchroom doctor`` row that fails on any
+eviction in the window — but it is loss, so no document here may claim
+otherwise. Full statement in ``_evict_to_fit``'s docstring.
 
 Oversized entries
 -----------------
@@ -340,13 +353,43 @@ def _trim_dir(a: str, max_entries: int, max_bytes: int) -> int:
     64 MB vs 2000 / 256 MB) (#3599 review R3-L1). Sizing them to match
     would put three full-queue copies on a container filesystem (queue +
     ``pending-evicted/`` + ``pending-reconciled/`` = 768 MB), which is the
-    disk problem the caps exist to bound. What that costs is bounded and
-    NOT the "last on-disk copy of a turn": an entry only reaches
-    ``pending-reconciled/`` once its document was CONFIRMED present
-    upstream, and only reaches ``pending-evicted/`` through the ledgered
-    eviction path. So the trim sheds a redundant copy — but it must not do
-    so silently, hence the log line: "reversible" has a horizon and the
-    operator is entitled to know when it passed.
+    disk problem the caps exist to bound.
+
+    WHAT THE TRIM COSTS, honestly (#3599 review R4-B3). An earlier revision
+    of this docstring justified the small caps by claiming an entry "only
+    reaches ``pending-reconciled/`` once its document was CONFIRMED present
+    upstream", so the trim "sheds a redundant copy". That is false for the
+    commonest path. Three of the four ways in are corroborated by a GET:
+
+      * in-hook reconcile (``drain_pending.drain``'s presence pass) — a GET
+        answered 200 for this entry's content-derived id;
+      * backlog phase 1 (``_reconcile_phase``) — the same, out of hook;
+      * backlog phase 2 — synchronous POST, then a CONFIRMING re-GET.
+
+    The fourth is not:
+
+      * ``drain``'s in-hook SUCCESS path retires on the POST's own 200 with
+        no confirming GET, because a 5s hook budget has no room for one.
+        That 200 is NOT a bare async ack — ``_retry_one`` posts
+        ``async_processing=False``, so it is a commit-before-ack (#3244
+        §1.1) and real upstream evidence of persistence. But it is the
+        daemon's word about itself, not an independent read, and this is
+        the path that runs on every boot: the common case.
+
+    So for that population the archived copy CAN be the last on-disk copy
+    of a turn — precisely when the daemon did not honour ``async=false``.
+    Trimming it is a real, if narrow, loss, and the caps stay small anyway:
+    this archive is the horizon of a recovery CONVENIENCE, not a durability
+    guarantee. The durability guarantee is commit-before-ack. Raising these
+    caps 4x would only move the horizon while tripling the disk cost, and a
+    daemon that ignores ``async=false`` is a precondition violation to fix
+    upstream, not to paper over with 768 MB of container disk. Hence the
+    log line: "reversible" has a horizon and the operator is entitled to
+    know when it passed.
+
+    ``pending-evicted/`` is a different story again — see ``_evict_to_fit``:
+    an entry only reaches it through the ledgered eviction path, and under
+    sustained ENOSPC it may not reach it at all.
     """
     try:
         names = sorted(n for n in os.listdir(a) if n.endswith(".json"))
@@ -407,6 +450,15 @@ def archive_reconciled(path: str) -> Optional[str]:
     retire that did not happen. The failure is also logged to stderr,
     because the one thing worse than a full disk is a full disk nobody
     hears about.
+
+    "STAYS QUEUED" IS BOUNDED, and the bound is worth stating here because
+    this is where the promise is made (#3599 review R4-M1). If the disk
+    stays full, entries pile up, the queue hits its cap, and ``enqueue()``
+    calls ``_evict_to_fit``, whose own archive move fails for the same
+    reason and which then removes the OLDEST live entries outright. So the
+    honest full statement is: this function never deletes, and under
+    sustained ENOSPC "keep it queued" degrades to "keep the newest, drop
+    the oldest" — loudly, via the eviction ledger and a failing doctor row.
     """
     dest_dir = reconciled_dir()
     try:
@@ -464,6 +516,24 @@ def _evict_to_fit(d: str, incoming_bytes: int) -> int:
 
     Returns the number of entries evicted. FIFO: oldest filename first,
     which is oldest by wall-clock because names are ``<unix-ms>-<uuid>.json``.
+
+    THE ONE PLACE A LIVE QUEUE ENTRY CAN BE REMOVED (#3599 review R4-M1),
+    and it must be read together with ``archive_reconciled``'s "the entry
+    STAYS QUEUED" promise, because it is the bound on that promise. Normally
+    an eviction is a MOVE into ``pending-evicted/`` and the payload survives.
+    Under sustained ENOSPC it is not: ``archive_reconciled`` keeps entries
+    queued, the queue fills, this function fires, its own archive move fails
+    for the same reason, and the fallback below ``os.remove``s the oldest
+    live entries to make room for the newest.
+
+    That is deliberate and it is the accepted behaviour, not an oversight:
+    the queue has to be bounded by something, and shedding the OLDEST turns
+    to keep accepting new ones is the least-bad bound. It is never silent —
+    stderr, a ``+archive-failed`` line in ``pending-evictions.log``, and a
+    ``switchroom doctor`` row that fails on any eviction in the window. So
+    "keep it queued" degrades to "keep the newest, drop the oldest" when the
+    disk stays full, and every document that says "keep it queued" is
+    qualified by this paragraph.
     """
     names = _list_entries(d)
     nbytes = _dir_bytes(d, names)
@@ -484,7 +554,13 @@ def _evict_to_fit(d: str, incoming_bytes: int) -> int:
             shutil.move(vpath, os.path.join(archive, victim))
         except OSError:
             # Archiving failed (disk full / perms). Still evict — keeping the
-            # newest memory is the priority — but say so loudly.
+            # newest memory is the priority — but say so loudly. This is the
+            # ONE ``os.remove`` in this module that can touch a LIVE entry,
+            # and with the archive move already failed there is no copy left:
+            # this line is the bound on "an entry is never deleted". The
+            # ``+archive-failed`` reason is what tells the operator (via the
+            # ledger and the doctor row) that the payload is gone, not merely
+            # moved.
             try:
                 os.remove(vpath)
             except OSError:
@@ -767,19 +843,38 @@ def iter_entries() -> list[tuple[str, dict]]:
     return out
 
 
-# There is deliberately NO ``delete_entry``/``os.remove`` primitive for a
-# live queue entry (#3599 review R3-M1). Its last caller was
-# ``archive_reconciled``'s OSError fallback, and while it existed the
-# "never irreversibly removed" claim in this module's docstring, in
-# ``drain_pending``'s, in ``switchroom doctor``'s backlog fix text and in
-# the CHANGELOG was one ``except OSError:`` away from being false. Making
-# the invariant structural — the function does not exist, so no branch can
-# reach it — is stronger than asserting it in prose. An entry leaves the
-# queue by MOVING: ``archive_reconciled`` (retired), ``_evict_to_fit``
-# (evicted, ledgered), ``quarantine_corrupt`` (unparsable), or the
-# ``.dead`` rename. Bounded archives are trimmed by ``_trim_dir``; that is
-# the only ``os.remove`` on this path and it acts on an already-retired
-# copy, never on a live entry.
+# There is deliberately NO ``delete_entry`` primitive callable on the DRAIN
+# path (#3599 review R3-M1). Its last caller was ``archive_reconciled``'s
+# OSError fallback, and while it existed the "never irreversibly removed"
+# claim in this module's docstring, in ``drain_pending``'s, in ``switchroom
+# doctor``'s backlog fix text and in the CHANGELOG was one ``except
+# OSError:`` away from being false. Making that invariant structural — the
+# function does not exist, so no drain branch can reach it — is stronger
+# than asserting it in prose. On the drain path an entry leaves the queue
+# only by MOVING: ``archive_reconciled`` (retired), ``quarantine_corrupt``
+# (unparsable), or the ``.dead`` rename.
+#
+# ONE ``os.remove`` in this module CAN touch a live entry, and an earlier
+# revision of this comment wrongly said none could (#3599 review R4-M1):
+# ``_evict_to_fit``'s ``OSError`` fallback. It is on the ENQUEUE path, not
+# the drain path, and it fires only when the eviction archive move ALSO
+# failed — sustained ENOSPC. Read the whole degradation in one line:
+#
+#   archive_reconciled keeps the entry queued → the queue fills →
+#   _evict_to_fit runs → its archive move fails too → the OLDEST live
+#   entries are removed to keep accepting the newest.
+#
+# So the queue IS bounded under a full disk, and it is bounded by dropping
+# the oldest turns. That is accepted behaviour (a queue must be bounded by
+# something, and the newest turn is the one most likely to still matter),
+# and it is loud: stderr, a ``+archive-failed`` ledger line, and a doctor
+# row that fails on any eviction in the window. It is NOT invisible and it
+# is NOT the drain deleting anything. Every "the entry is never deleted"
+# sentence in this repo means "not by the drain, and not while there is
+# disk"; ``_evict_to_fit``'s docstring carries the full statement.
+#
+# ``_trim_dir``'s ``os.remove`` is the third and mildest: it acts on an
+# already-retired copy in a bounded archive, never on a live entry.
 
 
 def update_attempt(path: str, entry: dict, error: BaseException) -> bool:

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -5,9 +5,11 @@ memory is the just-closed transcript — and the agent thinks it was
 persisted. To prevent silent data loss (#1071), session_end.py
 serializes the *exact retain payload* it would have POSTed into
 ``~/.hindsight/pending-retains/<unix-ms>-<short-uuid>.json``. The next
-SessionStart drains the directory: oldest first, success deletes,
-failure bumps an attempt counter (up to MAX_ATTEMPTS) and leaves the
-entry for the run after that.
+SessionStart drains the directory: oldest first, success RETIRES the
+entry into the bounded ``pending-reconciled/`` archive (it is never
+deleted — see "Retiring an entry" below), failure bumps an attempt
+counter (up to MAX_ATTEMPTS) and leaves the entry for the run after
+that.
 
 Layout
 ------
@@ -321,18 +323,36 @@ def _dir_bytes(d: str, names) -> int:
     return total
 
 
-def _trim_dir(a: str, max_entries: int, max_bytes: int) -> None:
+def _trim_dir(a: str, max_entries: int, max_bytes: int) -> int:
     """Keep ``a`` under its count/byte caps, deleting OLDEST first.
+
+    Returns the number of archived copies dropped.
 
     Oldest-first is load-bearing: ``names[0]`` is the lexicographically
     smallest name, and names lead with a fixed-width millisecond stamp, so
     it is the oldest archived entry. Trimming from the other end would keep
     the stale tail and discard what was just shed.
+
+    Both caps are ``>`` — a directory sitting exactly ON a cap is within
+    it, and trimming there would shed one entry per call forever.
+
+    The archive caps are deliberately 4x SMALLER than the queue caps (500 /
+    64 MB vs 2000 / 256 MB) (#3599 review R3-L1). Sizing them to match
+    would put three full-queue copies on a container filesystem (queue +
+    ``pending-evicted/`` + ``pending-reconciled/`` = 768 MB), which is the
+    disk problem the caps exist to bound. What that costs is bounded and
+    NOT the "last on-disk copy of a turn": an entry only reaches
+    ``pending-reconciled/`` once its document was CONFIRMED present
+    upstream, and only reaches ``pending-evicted/`` through the ledgered
+    eviction path. So the trim sheds a redundant copy — but it must not do
+    so silently, hence the log line: "reversible" has a horizon and the
+    operator is entitled to know when it passed.
     """
     try:
         names = sorted(n for n in os.listdir(a) if n.endswith(".json"))
     except OSError:
-        return
+        return 0
+    dropped = []
     while names and (
         len(names) > max_entries or _dir_bytes(a, names) > max_bytes
     ):
@@ -340,7 +360,19 @@ def _trim_dir(a: str, max_entries: int, max_bytes: int) -> None:
             os.remove(os.path.join(a, names[0]))
         except OSError:
             pass
-        names.pop(0)
+        dropped.append(names.pop(0))
+    if dropped:
+        shown = ", ".join(dropped[:10])
+        if len(dropped) > 10:
+            shown += f", +{len(dropped) - 10} more"
+        print(
+            f"[Hindsight] pending: trimmed {len(dropped)} archived "
+            f"cop{'y' if len(dropped) == 1 else 'ies'} from "
+            f"{os.path.basename(a.rstrip('/'))} to stay under its caps "
+            f"({max_entries} entries / {max_bytes} bytes): {shown}",
+            file=sys.stderr,
+        )
+    return len(dropped)
 
 
 def _trim_archive() -> None:
@@ -362,17 +394,32 @@ def archive_reconciled(path: str) -> Optional[str]:
     ``RECONCILED_MAX_BYTES``), so it can never become an unbounded disk
     problem of its own.
 
-    Falls back to ``delete_entry`` when the archive cannot be written (disk
-    full, permissions): a queue that cannot retire entries would re-POST
-    them forever, which is the very loop this change exists to break.
+    Returns the destination path, or ``None`` when the entry could NOT be
+    retired — in which case the entry is still queued and untouched.
+
+    A failure to archive (ENOSPC, EACCES, a read-only mount) is NOT a
+    licence to delete (#3599 review R3-M1). An earlier revision fell back
+    to ``delete_entry`` on ``OSError``, reasoning that a queue which cannot
+    retire would re-POST forever; the cost of that loop is duplicated LLM
+    extraction, while the cost of the delete is the last on-disk copy of a
+    turn, silently and irreversibly. The cheaper failure wins, and the
+    caller is told so it can count the entry honestly rather than report a
+    retire that did not happen. The failure is also logged to stderr,
+    because the one thing worse than a full disk is a full disk nobody
+    hears about.
     """
     dest_dir = reconciled_dir()
     try:
         os.makedirs(dest_dir, mode=0o700, exist_ok=True)
         dest = os.path.join(dest_dir, os.path.basename(path))
         shutil.move(path, dest)
-    except OSError:
-        delete_entry(path)
+    except OSError as e:
+        print(
+            f"[Hindsight] pending: could not archive {os.path.basename(path)} "
+            f"into {dest_dir} ({e}) — entry STAYS QUEUED (never deleted); "
+            f"free disk space or fix permissions, then re-run the drain",
+            file=sys.stderr,
+        )
         return None
     _trim_dir(dest_dir, RECONCILED_MAX_ENTRIES, RECONCILED_MAX_BYTES)
     return dest
@@ -720,13 +767,19 @@ def iter_entries() -> list[tuple[str, dict]]:
     return out
 
 
-def delete_entry(path: str) -> bool:
-    """Remove a queue entry. Returns True on success, False otherwise."""
-    try:
-        os.remove(path)
-        return True
-    except OSError:
-        return False
+# There is deliberately NO ``delete_entry``/``os.remove`` primitive for a
+# live queue entry (#3599 review R3-M1). Its last caller was
+# ``archive_reconciled``'s OSError fallback, and while it existed the
+# "never irreversibly removed" claim in this module's docstring, in
+# ``drain_pending``'s, in ``switchroom doctor``'s backlog fix text and in
+# the CHANGELOG was one ``except OSError:`` away from being false. Making
+# the invariant structural — the function does not exist, so no branch can
+# reach it — is stronger than asserting it in prose. An entry leaves the
+# queue by MOVING: ``archive_reconciled`` (retired), ``_evict_to_fit``
+# (evicted, ledgered), ``quarantine_corrupt`` (unparsable), or the
+# ``.dead`` rename. Bounded archives are trimmed by ``_trim_dir``; that is
+# the only ``os.remove`` on this path and it acts on an already-retired
+# copy, never on a live entry.
 
 
 def update_attempt(path: str, entry: dict, error: BaseException) -> bool:

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -68,11 +68,38 @@ Deduplication
 -------------
 ``reconcile_tail`` re-enqueues the same transcript slice on every boot
 until its watermark is confirmed, so a stalled upstream multiplied one
-memory into dozens of identical files (measured: 63% of the fleet queue,
-84.7 MB). Same bank + same content-derived ``document_id`` + same content
-is the same memory — the daemon would upsert them onto one document
-anyway — so ``enqueue()`` returns the existing path instead of writing a
-copy.
+memory into dozens of identical files. (The measured 63% / 84.7 MB
+collapse on this fleet was achieved by ``dedupe_queue.py``, a one-shot
+out-of-band sweep keyed on ``(bank, document_id, sha256(content))`` with
+no size index. What follows is the *preventive* guard that stops the
+duplicates accumulating in the first place — a different mechanism, and
+it does not get the credit for that number.)
+
+Same bank + same content-derived ``document_id`` + same content is the
+same memory — the daemon would upsert them onto one document anyway — so
+``enqueue()`` returns the existing path instead of writing a copy.
+
+The dedupe key is carried IN THE FILENAME
+(``<unix-ms>-<key>-<uuid>.json``), so a lookup is a prefix match over the
+directory listing with ZERO file reads. It deliberately is not inferred
+from the serialized bytes: an entry's JSON also carries ``failed_at``,
+``error_message``, ``attempt_count`` and — after any drain attempt —
+``last_attempt_at``, none of which are part of the memory's identity. An
+earlier revision pre-filtered candidates on ``os.path.getsize()``, which
+made the guard a no-op in exactly the scenario it was written for: the
+queued copy is ALWAYS post-``update_attempt`` by the time
+``reconcile_tail`` re-enqueues (the SessionStart drain attempts every
+entry on every boot), so its size had already drifted, and a
+one-character difference in the error string defeated it too.
+
+Oversized entries
+-----------------
+An entry larger than ``MAX_BYTES`` can never fit, and the eviction loop
+would otherwise evict the ENTIRE queue trying to make room for it and
+then write it anyway — trading every queued memory for one. ``enqueue()``
+refuses that single entry instead (recorded as a residual drop). Not
+reachable at the 256 MB default, but ``HINDSIGHT_PENDING_MAX_BYTES`` is
+operator-tunable.
 
 Residual drops
 --------------
@@ -120,6 +147,11 @@ DROPS_FILE = "pending-drops.json"
 #: errors can carry a full HTTP body; an unbounded copy per entry inflates
 #: the queue against MAX_BYTES for no diagnostic gain.
 MAX_ERROR_MESSAGE_CHARS = 500
+
+#: The eviction ledger is append-only; these bound it so it cannot grow
+#: without limit on a queue that evicts steadily.
+EVICTIONS_LOG_MAX_BYTES = 1024 * 1024
+EVICTIONS_LOG_KEEP_LINES = 2000
 
 
 def _clip_error(e: BaseException) -> str:
@@ -240,9 +272,21 @@ def _log_eviction(name: str, size: int, reason: str, depth: int, nbytes: int) ->
         depth,
         nbytes,
     )
+    log = evictions_log_path()
     try:
-        with open(evictions_log_path(), "a", encoding="utf-8") as f:
+        with open(log, "a", encoding="utf-8") as f:
             print(line, file=f)
+        # Bounded, not append-forever. `switchroom doctor` windows this by
+        # timestamp so a single legitimate eviction can't turn the row red
+        # permanently, but the FILE still needs a ceiling of its own.
+        if os.path.getsize(log) > EVICTIONS_LOG_MAX_BYTES:
+            with open(log, encoding="utf-8") as f:
+                kept = f.readlines()[-(EVICTIONS_LOG_KEEP_LINES):]
+            tmp = log + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.writelines(kept)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, log)
     except OSError:
         pass
     print(
@@ -292,51 +336,75 @@ def _evict_to_fit(d: str, incoming_bytes: int) -> int:
     return evicted
 
 
-def _dupe_key(entry: dict) -> tuple:
-    """Identity of a queued retain: (bank, document, content-hash).
+def _dupe_key(entry: dict) -> Optional[str]:
+    """Stable 16-hex identity of a queued retain, or ``None``.
 
+    Derived from ``(bank_id, document_id, sha256(content))``.
     ``document_id`` is already content-derived, so two entries sharing
     this key are the same memory and the daemon would upsert them onto
     the same document.
+
+    ``None`` when there is no ``document_id``: identity cannot be
+    established, so the entry must always be kept rather than merged.
     """
+    did = entry.get("document_id")
+    if did is None:
+        return None
     content = entry.get("content")
     if not isinstance(content, str):
         content = json.dumps(content, ensure_ascii=False, sort_keys=True)
-    return (
-        entry.get("bank_id"),
-        entry.get("document_id"),
-        hashlib.sha256(content.encode("utf-8")).hexdigest(),
-    )
+    h = hashlib.sha256()
+    # Length-prefixed so ("ab", "c") and ("a", "bc") cannot collide.
+    for part in (str(entry.get("bank_id")), str(did)):
+        h.update(b"%d:" % len(part))
+        h.update(part.encode("utf-8"))
+    h.update(hashlib.sha256(content.encode("utf-8")).digest())
+    return h.hexdigest()[:16]
 
 
-def _find_duplicate(d: str, entry: dict, blob_bytes: int) -> Optional[str]:
+def _find_duplicate(d: str, key: Optional[str]) -> Optional[str]:
     """Return the path of an already-queued identical entry, or ``None``.
 
-    Size-indexed: ``os.stat()`` is cheap, and only files of EXACTLY the
-    incoming size are opened and hashed — normally zero or one — so this
-    stays O(dir listing) even at a 2000-entry queue.
+    A pure filename prefix match — no file is opened, no payload is
+    hashed — because ``enqueue()`` stamps the key into the name. Entries
+    written by an older plugin build have no key segment and simply never
+    match, which is the safe direction: a missed dedupe costs a duplicate
+    file, a false one would discard a distinct memory.
     """
-    try:
-        key = _dupe_key(entry)
-    except Exception:
+    if not key:
         return None
-    if key[1] is None:
-        return None  # no document_id -> cannot establish identity, keep it
+    needle = f"-{key}-"
     for name in _list_entries(d):
-        p = os.path.join(d, name)
-        try:
-            if os.path.getsize(p) != blob_bytes:
-                continue
-            with open(p, encoding="utf-8") as f:
-                other = json.load(f)
-        except (OSError, ValueError):
-            continue
-        try:
-            if _dupe_key(other) == key:
-                return p
-        except Exception:
-            continue
+        if needle in name:
+            return os.path.join(d, name)
     return None
+
+
+def quarantine_corrupt(path: str) -> Optional[str]:
+    """Move an unparsable entry into the ``pending-corrupt/`` sibling.
+
+    Without this a corrupt entry is IMMORTAL: ``iter_entries()`` skips it,
+    so it is never reconciled, never drained and never aged to ``.dead``,
+    yet it still occupies a queue slot and still counts toward the depth
+    that ``switchroom doctor`` reports — inflating the warning forever
+    with eviction as its only exit. Mirrors the out-of-band drainer, which
+    moves unparsable entries to ``pending-corrupt`` rather than skipping.
+
+    Returns the new path, or ``None`` if the move failed.
+    """
+    dest_dir = _sibling("pending-corrupt")
+    try:
+        os.makedirs(dest_dir, mode=0o700, exist_ok=True)
+        dest = os.path.join(dest_dir, os.path.basename(path))
+        shutil.move(path, dest)
+    except OSError:
+        return None
+    print(
+        f"[Hindsight] pending-retains: entry is unparsable, quarantined to "
+        f"{dest} (it can no longer block the queue; inspect or delete it).",
+        file=sys.stderr,
+    )
+    return dest
 
 
 def read_drops() -> dict:
@@ -444,22 +512,37 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     entry["error_message"] = _clip_error(error)
     entry.setdefault("attempt_count", 1)
 
-    ts_ms = int(time.time() * 1000)
-    short_uuid = uuid.uuid4().hex[:12]
-    name = f"{ts_ms}-{short_uuid}.json"
-    final = os.path.join(d, name)
-    tmp = final + ".tmp"
-
     blob = json.dumps(entry, ensure_ascii=False)
     blob_bytes = len(blob.encode("utf-8"))
 
+    key = _dupe_key(entry)
+    ts_ms = int(time.time() * 1000)
+    short_uuid = uuid.uuid4().hex[:12]
+    # The key goes in the NAME so dedupe is a listing prefix match with no
+    # file reads. `_list_entries` still sorts oldest-first: the fixed-width
+    # millisecond timestamp remains the leading segment.
+    name = f"{ts_ms}-{key}-{short_uuid}.json" if key else f"{ts_ms}-{short_uuid}.json"
+    final = os.path.join(d, name)
+    tmp = final + ".tmp"
+
     # DEDUPE first: reconcile_tail re-enqueues the same transcript slice on
-    # every boot until its watermark is confirmed, so a stalled upstream used
-    # to multiply one memory into dozens of identical queue files. Returning
-    # the existing path keeps every caller's "queued" contract intact.
-    dup = _find_duplicate(d, entry, blob_bytes)
+    # every boot until its watermark is confirmed, so a stalled upstream would
+    # otherwise multiply one memory into dozens of queue files. Returning the
+    # existing path keeps every caller's "queued" contract intact.
+    dup = _find_duplicate(d, key)
     if dup is not None:
         return dup
+
+    # An entry bigger than the whole byte cap can never fit. Without this
+    # guard the eviction loop below evicts the ENTIRE queue trying to make
+    # room and then writes it anyway — trading every queued memory for one.
+    if blob_bytes > MAX_BYTES:
+        record_drop(payload, ValueError(
+            f"entry is {blob_bytes} bytes, larger than the whole "
+            f"HINDSIGHT_PENDING_MAX_BYTES cap ({MAX_BYTES}); refusing this "
+            f"entry rather than evicting the entire queue for it"
+        ))
+        return None
 
     # Then make room by evicting the OLDEST entries rather than refusing
     # this (newest, most valuable) one.
@@ -487,9 +570,12 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
 def iter_entries() -> list[tuple[str, dict]]:
     """Return ``[(path, entry_dict), ...]`` oldest first.
 
-    Unreadable / malformed files are skipped silently — the drainer
-    handles its own logging. We never crash the SessionStart hook on
-    a corrupt entry.
+    A malformed entry is QUARANTINED, not skipped. Skipping made it
+    immortal — never reconciled, never drained, never aged to ``.dead``,
+    but still holding a queue slot and still counted in the depth doctor
+    reports. Transient read errors (``OSError``) are still just skipped;
+    only unparsable content is moved aside. We never crash the
+    SessionStart hook on a corrupt entry either way.
     """
     d = pending_dir()
     out: list[tuple[str, dict]] = []
@@ -498,8 +584,13 @@ def iter_entries() -> list[tuple[str, dict]]:
         try:
             with open(p, encoding="utf-8") as f:
                 out.append((p, json.load(f)))
-        except (OSError, json.JSONDecodeError):
+        except OSError:
             continue
+        except ValueError:
+            # ValueError, not JSONDecodeError: a non-UTF-8 entry raises
+            # UnicodeDecodeError, which is a ValueError but NOT a
+            # JSONDecodeError, and is exactly as unparsable.
+            quarantine_corrupt(p)
     return out
 
 

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -44,26 +44,90 @@ Each entry is a JSON file ``<unix-ms>-<short-uuid>.json`` containing::
 The file is written via ``write tmp + rename`` so concurrent agents
 sharing ``$HOME`` (legacy installs) never observe a half-written entry.
 
-Bounded directory
------------------
-``MAX_ENTRIES`` (1000) caps the queue. When full, ``enqueue()`` refuses
-the entry and returns ``None`` — the caller logs loudly and the operator
-is expected to drain manually. A chronically full queue means upstream
-is broken for a long time; piling on more entries doesn't help.
+Bounded directory (switchroom #3596 — evict oldest, never refuse newest)
+-----------------------------------------------------------------------
+``MAX_ENTRIES`` and ``MAX_BYTES`` bound the queue, both env-overridable.
+When either binds, ``enqueue()`` evicts the OLDEST entries into a bounded
+archive (``pending-evicted/``) to make room, rather than refusing the
+incoming — newest, most likely to matter — memory.
+
+This is a PORT of the design validated out of band on the live fleet and
+already in force there via env in ``switchroom.yaml`` (the file patches
+themselves do not survive ``switchroom apply``, which is precisely why
+this belongs in-repo). Refusing the newest entry was the wrong end to
+shed from; the cap size was never the real bug.
+
+Sizing rationale (measured 2026-07-25 on this fleet, carried over from
+the validated patch): 5,751 queued entries occupied 432 MB — ~75 KB mean,
+but content spans 499 B .. 744 KB (p50 21 KB), so a count cap alone
+bounds disk only to within ~1500x; hence ``MAX_BYTES``. Retain fires
+every 3rd turn and the busiest agent queues ~100 entries/day, so 2000
+entries is ~3 weeks of total upstream outage headroom.
+
+Deduplication
+-------------
+``reconcile_tail`` re-enqueues the same transcript slice on every boot
+until its watermark is confirmed, so a stalled upstream multiplied one
+memory into dozens of identical files (measured: 63% of the fleet queue,
+84.7 MB). Same bank + same content-derived ``document_id`` + same content
+is the same memory — the daemon would upsert them onto one document
+anyway — so ``enqueue()`` returns the existing path instead of writing a
+copy.
+
+Residual drops
+--------------
+With eviction in place a *drop* is now rare: it means the entry could not
+be written at all (disk full, permissions) even after making room. That
+residual case still must not be silent, so it is recorded in the
+``pending-drops.json`` ledger — a sibling of the queue dir, like the
+eviction log, so it can never be mistaken for a queue entry.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import shutil
+import sys
 import time
 import uuid
 from typing import Optional
 
 
 SCHEMA = 1
-MAX_ENTRIES = 1000
+
+# Queue bounds. BOTH are enforced; whichever binds first triggers eviction.
+# Env-driven so the operator can retune without a plugin redeploy — and so
+# the values already set fleet-wide in switchroom.yaml keep working.
+MAX_ENTRIES = int(os.environ.get("HINDSIGHT_PENDING_MAX_ENTRIES") or 2000)
+MAX_BYTES = int(os.environ.get("HINDSIGHT_PENDING_MAX_BYTES") or (256 * 1024 * 1024))
+# The archive is bounded too, else eviction just relocates the disk problem.
+ARCHIVE_MAX_ENTRIES = int(
+    os.environ.get("HINDSIGHT_PENDING_ARCHIVE_MAX_ENTRIES") or 500
+)
+ARCHIVE_MAX_BYTES = int(
+    os.environ.get("HINDSIGHT_PENDING_ARCHIVE_MAX_BYTES") or (64 * 1024 * 1024)
+)
 MAX_ATTEMPTS = 5
+
+#: Residual-drop ledger. A SIBLING of the queue directory (like the
+#: eviction log), never inside it — so it can never be listed as an entry,
+#: drained, or counted against the caps.
+DROPS_FILE = "pending-drops.json"
+
+#: Cap on the stored ``error_message`` / ``last_error_message``. Upstream
+#: errors can carry a full HTTP body; an unbounded copy per entry inflates
+#: the queue against MAX_BYTES for no diagnostic gain.
+MAX_ERROR_MESSAGE_CHARS = 500
+
+
+def _clip_error(e: BaseException) -> str:
+    """``str(e)`` truncated to ``MAX_ERROR_MESSAGE_CHARS``."""
+    s = str(e)
+    if len(s) <= MAX_ERROR_MESSAGE_CHARS:
+        return s
+    return s[:MAX_ERROR_MESSAGE_CHARS] + "…[truncated]"
 
 
 def pending_dir() -> str:
@@ -112,6 +176,248 @@ def count() -> int:
     return len(_list_entries(d))
 
 
+def _sibling(name: str) -> str:
+    """Path to ``name`` as a sibling of the queue directory."""
+    return os.path.join(os.path.dirname(pending_dir().rstrip("/")), name)
+
+
+def evicted_dir() -> str:
+    """Archive directory for FIFO-evicted entries (sibling of the queue)."""
+    return os.environ.get("HINDSIGHT_PENDING_EVICTED_DIR") or _sibling(
+        "pending-evicted"
+    )
+
+
+def evictions_log_path() -> str:
+    """Append-only eviction ledger.
+
+    This is the deterministic, machine-readable signal that memories are
+    being shed — ``switchroom doctor`` reads it. Eviction is not silent
+    data loss, but it IS loss, so it must never be inferable only from a
+    depth reading.
+    """
+    return _sibling("pending-evictions.log")
+
+
+def drops_path() -> str:
+    """Path of the residual-drop ledger (sibling of the queue dir)."""
+    return _sibling(DROPS_FILE)
+
+
+def _dir_bytes(d: str, names) -> int:
+    total = 0
+    for n in names:
+        try:
+            total += os.path.getsize(os.path.join(d, n))
+        except OSError:
+            pass
+    return total
+
+
+def _trim_archive() -> None:
+    """Keep the archive under its own count/byte caps, oldest-first."""
+    a = evicted_dir()
+    try:
+        names = sorted(n for n in os.listdir(a) if n.endswith(".json"))
+    except OSError:
+        return
+    while names and (
+        len(names) > ARCHIVE_MAX_ENTRIES or _dir_bytes(a, names) > ARCHIVE_MAX_BYTES
+    ):
+        try:
+            os.remove(os.path.join(a, names[0]))
+        except OSError:
+            pass
+        names.pop(0)
+
+
+def _log_eviction(name: str, size: int, reason: str, depth: int, nbytes: int) -> None:
+    line = "%s evicted=%s bytes=%d reason=%s queue_depth=%d queue_bytes=%d" % (
+        time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        name,
+        size,
+        reason,
+        depth,
+        nbytes,
+    )
+    try:
+        with open(evictions_log_path(), "a", encoding="utf-8") as f:
+            print(line, file=f)
+    except OSError:
+        pass
+    print(
+        "[Hindsight] pending-retains FULL - evicted OLDEST entry to keep the "
+        "newest memory: %s (%d bytes, %s; queue now %d entries / %d bytes). "
+        "Archived under %s." % (name, size, reason, depth, nbytes, evicted_dir()),
+        file=sys.stderr,
+    )
+
+
+def _evict_to_fit(d: str, incoming_bytes: int) -> int:
+    """Evict oldest entries until the incoming entry fits under BOTH caps.
+
+    Returns the number of entries evicted. FIFO: oldest filename first,
+    which is oldest by wall-clock because names are ``<unix-ms>-<uuid>.json``.
+    """
+    names = _list_entries(d)
+    nbytes = _dir_bytes(d, names)
+    evicted = 0
+    archive = evicted_dir()
+    while names and (
+        len(names) + 1 > MAX_ENTRIES or nbytes + incoming_bytes > MAX_BYTES
+    ):
+        reason = "count" if len(names) + 1 > MAX_ENTRIES else "bytes"
+        victim = names.pop(0)
+        vpath = os.path.join(d, victim)
+        try:
+            vsize = os.path.getsize(vpath)
+        except OSError:
+            vsize = 0
+        try:
+            os.makedirs(archive, mode=0o700, exist_ok=True)
+            shutil.move(vpath, os.path.join(archive, victim))
+        except OSError:
+            # Archiving failed (disk full / perms). Still evict — keeping the
+            # newest memory is the priority — but say so loudly.
+            try:
+                os.remove(vpath)
+            except OSError:
+                break
+            reason += "+archive-failed"
+        nbytes -= vsize
+        evicted += 1
+        _log_eviction(victim, vsize, reason, len(names), nbytes)
+    if evicted:
+        _trim_archive()
+    return evicted
+
+
+def _dupe_key(entry: dict) -> tuple:
+    """Identity of a queued retain: (bank, document, content-hash).
+
+    ``document_id`` is already content-derived, so two entries sharing
+    this key are the same memory and the daemon would upsert them onto
+    the same document.
+    """
+    content = entry.get("content")
+    if not isinstance(content, str):
+        content = json.dumps(content, ensure_ascii=False, sort_keys=True)
+    return (
+        entry.get("bank_id"),
+        entry.get("document_id"),
+        hashlib.sha256(content.encode("utf-8")).hexdigest(),
+    )
+
+
+def _find_duplicate(d: str, entry: dict, blob_bytes: int) -> Optional[str]:
+    """Return the path of an already-queued identical entry, or ``None``.
+
+    Size-indexed: ``os.stat()`` is cheap, and only files of EXACTLY the
+    incoming size are opened and hashed — normally zero or one — so this
+    stays O(dir listing) even at a 2000-entry queue.
+    """
+    try:
+        key = _dupe_key(entry)
+    except Exception:
+        return None
+    if key[1] is None:
+        return None  # no document_id -> cannot establish identity, keep it
+    for name in _list_entries(d):
+        p = os.path.join(d, name)
+        try:
+            if os.path.getsize(p) != blob_bytes:
+                continue
+            with open(p, encoding="utf-8") as f:
+                other = json.load(f)
+        except (OSError, ValueError):
+            continue
+        try:
+            if _dupe_key(other) == key:
+                return p
+        except Exception:
+            continue
+    return None
+
+
+def read_drops() -> dict:
+    """Return the residual-drop ledger, or ``{}`` when nothing was dropped.
+
+    Never raises. Catching ``ValueError`` (not ``json.JSONDecodeError``)
+    is deliberate: ``open(..., encoding="utf-8")`` raises
+    ``UnicodeDecodeError`` — a ``ValueError`` subclass, NOT a
+    ``JSONDecodeError`` — on a non-UTF-8 ledger. A narrower catch would
+    let a corrupt ledger turn ``enqueue()`` from "returns ``None``" into
+    a raiser at exactly the moment the queue is under stress, breaking
+    ``session_end.py`` / ``subagent_retain.py``, which handle ``None``.
+    """
+    try:
+        with open(drops_path(), encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def record_drop(payload: dict, error: BaseException) -> int:
+    """Record one permanently-dropped retain. Returns the new total.
+
+    A drop is the residual case: the payload could not be written even
+    after eviction made room (disk full, permissions). Rare, but the one
+    outcome where a turn's memory is genuinely gone, so it gets a loud
+    stderr line plus a durable ledger entry.
+
+    NOTE (accepted, not a silent bug): the ``count`` bump is a
+    read-modify-write with no lock. Two hooks dropping concurrently in
+    the same ``$HOME`` can lose an increment, so ``count`` is a floor,
+    not an exact tally. That is acceptable — the ledger's job is to make
+    loss *visible*, and any non-zero count already fails the doctor row.
+    Locking here would mean taking a lock on the disk-full path, which is
+    exactly where it is most likely to wedge.
+    """
+    ledger = read_drops()
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    try:
+        prev = int(ledger.get("count", 0))
+    except (TypeError, ValueError):
+        prev = 0
+    count_now = prev + 1
+    ledger.update(
+        {
+            "schema": SCHEMA,
+            "count": count_now,
+            "last_dropped_at": now,
+            "last_error_class": type(error).__name__,
+            "last_error_message": _clip_error(error),
+            "last_bank_id": payload.get("bank_id"),
+        }
+    )
+    ledger.setdefault("first_dropped_at", now)
+
+    p = drops_path()
+    tmp = p + ".tmp"
+    try:
+        os.makedirs(os.path.dirname(p), mode=0o700, exist_ok=True)
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(ledger, f, ensure_ascii=False)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, p)
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+    print(
+        f"[Hindsight] pending-retains: DROPPED a failed retain for bank "
+        f"{payload.get('bank_id')!r} — could not write the queue entry even "
+        f"after eviction, so this turn's memory is permanently lost "
+        f"({type(error).__name__}: {_clip_error(error)}). "
+        f"Total dropped so far: {count_now}.",
+        file=sys.stderr,
+    )
+    return count_now
+
+
 def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     """Persist a failed retain payload.
 
@@ -119,19 +425,23 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     ``client.retain()`` plus connection info (``api_url``, ``api_token``)
     so the drainer can rebuild the client without re-resolving config.
 
-    Returns the absolute path of the written entry, or ``None`` if the
-    queue is full (``MAX_ENTRIES`` reached). Atomic: writes ``<name>.tmp``
-    then renames to ``<name>``.
+    Returns the absolute path of the entry — which may be an EXISTING
+    identical entry (dedupe) — or ``None`` in the residual case where the
+    entry could not be written at all. Atomic: writes ``<name>.tmp`` then
+    renames to ``<name>``.
+
+    A full queue no longer refuses the incoming entry: ``_evict_to_fit()``
+    sheds the OLDEST entries into ``pending-evicted/`` instead. Refusing
+    the newest memory was the wrong end to shed from — it is the turn most
+    likely to still matter.
     """
     d = _ensure_dir()
-    if len(_list_entries(d)) >= MAX_ENTRIES:
-        return None
 
     entry = dict(payload)
     entry["schema"] = SCHEMA
     entry["failed_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     entry["error_class"] = type(error).__name__
-    entry["error_message"] = str(error)
+    entry["error_message"] = _clip_error(error)
     entry.setdefault("attempt_count", 1)
 
     ts_ms = int(time.time() * 1000)
@@ -140,10 +450,37 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     final = os.path.join(d, name)
     tmp = final + ".tmp"
 
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(entry, f, ensure_ascii=False)
-    os.chmod(tmp, 0o600)
-    os.rename(tmp, final)
+    blob = json.dumps(entry, ensure_ascii=False)
+    blob_bytes = len(blob.encode("utf-8"))
+
+    # DEDUPE first: reconcile_tail re-enqueues the same transcript slice on
+    # every boot until its watermark is confirmed, so a stalled upstream used
+    # to multiply one memory into dozens of identical queue files. Returning
+    # the existing path keeps every caller's "queued" contract intact.
+    dup = _find_duplicate(d, entry, blob_bytes)
+    if dup is not None:
+        return dup
+
+    # Then make room by evicting the OLDEST entries rather than refusing
+    # this (newest, most valuable) one.
+    _evict_to_fit(d, blob_bytes)
+
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(blob)
+        os.chmod(tmp, 0o600)
+        os.rename(tmp, final)
+    except OSError as write_err:
+        # Residual drop: room was made and the write STILL failed (disk
+        # full, permissions). This is the only path that now loses a turn,
+        # and it is recorded rather than returned bare — callers handle
+        # ``None``, but none of them can see *why* without the ledger.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        record_drop(payload, write_err)
+        return None
     return final
 
 
@@ -183,7 +520,7 @@ def update_attempt(path: str, entry: dict, error: BaseException) -> bool:
     entry["attempt_count"] = int(entry.get("attempt_count", 1)) + 1
     entry["last_attempt_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     entry["error_class"] = type(error).__name__
-    entry["error_message"] = str(error)
+    entry["error_message"] = _clip_error(error)
     try:
         tmp = path + ".tmp"
         with open(tmp, "w", encoding="utf-8") as f:

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -92,6 +92,18 @@ queued copy is ALWAYS post-``update_attempt`` by the time
 entry on every boot), so its size had already drifted, and a
 one-character difference in the error string defeated it too.
 
+Retiring an entry — archive, never delete
+-----------------------------------------
+The drain retires an entry through ``archive_reconciled()``, which MOVES it
+into a bounded ``pending-reconciled/`` sibling. It never ``os.remove``s one.
+Every retire decision on that path rests on an HTTP 200 — a presence GET or a
+synchronous retain ack — and a 200 is evidence, not proof (#3244); an
+irreversible delete on evidence is how the last on-disk copy of a turn
+disappears. ``is_content_derived_document_id()`` is the second half of that
+guard: a *presence-only* reconcile is sound only for post-#3244
+content-derived ids, because a pre-#3244 bare session id answers 200 for any
+retain in that session.
+
 Oversized entries
 -----------------
 An entry larger than ``MAX_BYTES`` can never fit, and the eviction loop
@@ -115,6 +127,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shutil
 import sys
 import time
@@ -136,6 +149,15 @@ ARCHIVE_MAX_ENTRIES = int(
 ARCHIVE_MAX_BYTES = int(
     os.environ.get("HINDSIGHT_PENDING_ARCHIVE_MAX_BYTES") or (64 * 1024 * 1024)
 )
+# The reconciled archive (see ``archive_reconciled``) is bounded on exactly the
+# same terms as ``pending-evicted/`` — an archive that grows without limit is
+# just a slower disk problem.
+RECONCILED_MAX_ENTRIES = int(
+    os.environ.get("HINDSIGHT_PENDING_RECONCILED_MAX_ENTRIES") or 500
+)
+RECONCILED_MAX_BYTES = int(
+    os.environ.get("HINDSIGHT_PENDING_RECONCILED_MAX_BYTES") or (64 * 1024 * 1024)
+)
 MAX_ATTEMPTS = 5
 
 #: Residual-drop ledger. A SIBLING of the queue directory (like the
@@ -152,6 +174,41 @@ MAX_ERROR_MESSAGE_CHARS = 500
 #: without limit on a queue that evicts steadily.
 EVICTIONS_LOG_MAX_BYTES = 1024 * 1024
 EVICTIONS_LOG_KEEP_LINES = 2000
+
+
+#: Post-#3244 ``document_id`` shape (``retain.slice_document_id``):
+#: ``{session_id}-r{start_uuid}-{end_uuid}``, or the legacy-transcript fallback
+#: ``{session_id}-r{sha256[:32]}``. ``subagent_retain.py`` uses the same recipe
+#: over a ``{session}-sub-{agent}`` composite key, so it matches too.
+_UUID_RE = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+_CONTENT_DERIVED_ID_RE = re.compile(
+    r"-r(?:%s-%s|[0-9a-fA-F]{32})$" % (_UUID_RE, _UUID_RE)
+)
+
+
+def is_content_derived_document_id(document_id) -> bool:
+    """True iff ``document_id`` is a post-#3244 CONTENT-derived id.
+
+    This is the gate on any *presence-only* reconcile (a GET that returns
+    200 ⇒ drop the queue entry). It is only sound when the id identifies
+    the entry's own content:
+
+    * **Post-#3244** the id is ``{session_id}-r{start_uuid}-{end_uuid}``
+      (``retain.slice_document_id``), a pure function of *which turns* the
+      entry carries. A 200 on that id proves *this* content was committed.
+    * **Pre-#3244** entries carry a BARE SESSION ID. The bank answers 200
+      for that id after ANY successful retain in that session, so a 200
+      proves nothing about the queued entry's own content. Reconciling on
+      it deletes a turn that was never committed — confirmed against a
+      live entry on this fleet (525 KB of content, ``document_id`` a bare
+      UUID, GET 200).
+
+    Anything unrecognised is False: the safe direction is to keep the
+    entry and let the POST path decide.
+    """
+    if not isinstance(document_id, str):
+        return False
+    return bool(_CONTENT_DERIVED_ID_RE.search(document_id))
 
 
 def _clip_error(e: BaseException) -> str:
@@ -191,8 +248,13 @@ def _ensure_dir() -> str:
 
 
 def _list_entries(d: str) -> list[str]:
-    """Return sorted filenames (oldest first by lexicographic order on
-    the ``<unix-ms>-<uuid>.json`` filename pattern).
+    """Return sorted filenames, oldest first.
+
+    Order is the lexicographic sort of ``<unix-ms>-[<key>-]<uuid>.json``.
+    The millisecond stamp is fixed-width and leading, so this is true
+    enqueue order down to the millisecond; entries sharing a millisecond
+    tie-break on the remaining segments (stable and total, but arbitrary —
+    the name carries no finer age information).
     """
     try:
         names = [n for n in os.listdir(d) if n.endswith(".json")]
@@ -217,6 +279,19 @@ def evicted_dir() -> str:
     """Archive directory for FIFO-evicted entries (sibling of the queue)."""
     return os.environ.get("HINDSIGHT_PENDING_EVICTED_DIR") or _sibling(
         "pending-evicted"
+    )
+
+
+def reconciled_dir() -> str:
+    """Archive directory for reconciled/drained entries (sibling of the queue).
+
+    The out-of-band drainer this design was ported from ARCHIVES an entry it
+    stops draining; it never ``os.remove``s one. That is the difference
+    between "we believe this is durable upstream" and "the last on-disk copy
+    of this turn is gone", and only the second is irreversible.
+    """
+    return os.environ.get("HINDSIGHT_PENDING_RECONCILED_DIR") or _sibling(
+        "pending-reconciled"
     )
 
 
@@ -246,21 +321,61 @@ def _dir_bytes(d: str, names) -> int:
     return total
 
 
-def _trim_archive() -> None:
-    """Keep the archive under its own count/byte caps, oldest-first."""
-    a = evicted_dir()
+def _trim_dir(a: str, max_entries: int, max_bytes: int) -> None:
+    """Keep ``a`` under its count/byte caps, deleting OLDEST first.
+
+    Oldest-first is load-bearing: ``names[0]`` is the lexicographically
+    smallest name, and names lead with a fixed-width millisecond stamp, so
+    it is the oldest archived entry. Trimming from the other end would keep
+    the stale tail and discard what was just shed.
+    """
     try:
         names = sorted(n for n in os.listdir(a) if n.endswith(".json"))
     except OSError:
         return
     while names and (
-        len(names) > ARCHIVE_MAX_ENTRIES or _dir_bytes(a, names) > ARCHIVE_MAX_BYTES
+        len(names) > max_entries or _dir_bytes(a, names) > max_bytes
     ):
         try:
             os.remove(os.path.join(a, names[0]))
         except OSError:
             pass
         names.pop(0)
+
+
+def _trim_archive() -> None:
+    """Keep the eviction archive under its own count/byte caps."""
+    _trim_dir(evicted_dir(), ARCHIVE_MAX_ENTRIES, ARCHIVE_MAX_BYTES)
+
+
+def archive_reconciled(path: str) -> Optional[str]:
+    """Retire a queue entry into ``pending-reconciled/``. Returns the dest.
+
+    THE ONLY WAY the drain retires an entry. Every "we no longer need to
+    keep this queued" decision on the drain path rests on an HTTP 200 —
+    either a presence GET or a synchronous retain ack — and a 200 is
+    evidence, not proof (switchroom #3244). ``os.remove`` on that evidence
+    is irreversible; a bounded archive is not, and the archive is what the
+    out-of-band tooling this design was ported from always did.
+
+    Bounded exactly like ``pending-evicted/`` (``RECONCILED_MAX_ENTRIES`` /
+    ``RECONCILED_MAX_BYTES``), so it can never become an unbounded disk
+    problem of its own.
+
+    Falls back to ``delete_entry`` when the archive cannot be written (disk
+    full, permissions): a queue that cannot retire entries would re-POST
+    them forever, which is the very loop this change exists to break.
+    """
+    dest_dir = reconciled_dir()
+    try:
+        os.makedirs(dest_dir, mode=0o700, exist_ok=True)
+        dest = os.path.join(dest_dir, os.path.basename(path))
+        shutil.move(path, dest)
+    except OSError:
+        delete_entry(path)
+        return None
+    _trim_dir(dest_dir, RECONCILED_MAX_ENTRIES, RECONCILED_MAX_BYTES)
+    return dest
 
 
 def _log_eviction(name: str, size: int, reason: str, depth: int, nbytes: int) -> None:
@@ -339,10 +454,17 @@ def _evict_to_fit(d: str, incoming_bytes: int) -> int:
 def _dupe_key(entry: dict) -> Optional[str]:
     """Stable 16-hex identity of a queued retain, or ``None``.
 
-    Derived from ``(bank_id, document_id, sha256(content))``.
-    ``document_id`` is already content-derived, so two entries sharing
-    this key are the same memory and the daemon would upsert them onto
-    the same document.
+    Derived from ``(bank_id, document_id, sha256(content))``. The CONTENT
+    hash is what makes the key an identity: two entries sharing it carry
+    byte-identical content for the same bank and document, so they are the
+    same memory and the daemon would upsert them onto the same document.
+
+    Do NOT read this as "``document_id`` is content-derived, therefore a
+    matching id means matching content" — that only holds post-#3244
+    (``retain.slice_document_id``); pre-#3244 entries carry a bare session
+    id shared by every retain in that session. Dedupe is safe on either
+    because it hashes the content itself; a *presence GET* is not, which is
+    why that path is gated on ``is_content_derived_document_id``.
 
     ``None`` when there is no ``document_id``: identity cannot be
     established, so the entry must always be kept rather than merged.
@@ -519,8 +641,12 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     ts_ms = int(time.time() * 1000)
     short_uuid = uuid.uuid4().hex[:12]
     # The key goes in the NAME so dedupe is a listing prefix match with no
-    # file reads. `_list_entries` still sorts oldest-first: the fixed-width
-    # millisecond timestamp remains the leading segment.
+    # file reads. The fixed-width millisecond timestamp remains the LEADING
+    # segment, so `_list_entries`' lexicographic sort orders entries by
+    # enqueue millisecond. Entries written inside the SAME millisecond tie-
+    # break on the dupe key (then the random uuid) — arbitrary, but stable
+    # and total; the filename carries no finer age information than the
+    # millisecond, so no ordering could do better.
     name = f"{ts_ms}-{key}-{short_uuid}.json" if key else f"{ts_ms}-{short_uuid}.json"
     final = os.path.join(d, name)
     tmp = final + ".tmp"

--- a/vendor/hindsight-memory/scripts/session_start.py
+++ b/vendor/hindsight-memory/scripts/session_start.py
@@ -20,6 +20,48 @@ from lib.config import debug_log, load_config
 from lib.daemon import get_api_url, prestart_daemon_background
 
 
+#: Marker every version-skew warning carries, so log scrapers and tests
+#: match one stable string rather than the prose around it.
+SKEW_MARKER = "PARTIAL PLUGIN ROLLOUT"
+
+
+def _warn_version_skew(module: str, err: BaseException, config: dict, cost: str) -> None:
+    """Report an import-level version skew LOUDLY, on stderr (#3599 R4-Lc).
+
+    The plugin tree deploys as loose files under ``scripts/``, and this repo
+    removes symbols across versions — ``pending.delete_entry``, whose last
+    importer was ``drain_pending``, was removed in #3599 itself. A PARTIAL
+    rollout (new ``lib/pending.py`` beside an old ``drain_pending.py``)
+    therefore raises ``ImportError`` at the hook's import line.
+
+    Before this guard that landed in a bare ``except Exception`` and went to
+    ``debug_log``, which is off by default: the durability machinery would
+    stop and nothing would say so. A backlog then grows until ``switchroom
+    doctor`` notices it — and doctor names the QUEUE, not the cause. This
+    turns a silent deploy fault into an every-boot stderr line naming the
+    module, the missing symbol and the fix.
+
+    Deliberately not keyed to ``delete_entry`` or to a version number: any
+    import-level skew in this tree has the same cause and the same fix, so
+    the check generalises to removals that have not happened yet. A version
+    stamp would need bumping to stay true; this cannot go stale.
+
+    Never raises and never re-raises — a skew must not take SessionStart
+    down on top of everything else.
+    """
+    print(
+        f"[Hindsight] SessionStart: cannot import {module} ({err}). "
+        f"{SKEW_MARKER} — the files under the plugin's scripts/ are from "
+        f"different versions. {cost} until this is fixed. Re-deploy the "
+        f"plugin tree WHOLE (all of scripts/, never individual files).",
+        file=sys.stderr,
+    )
+    try:
+        debug_log(config, f"{module} import failed (version skew): {err}")
+    except Exception:
+        pass
+
+
 def main():
     config = load_config()
 
@@ -83,6 +125,8 @@ def main():
         from drain_pending import drain as drain_pending_retains
 
         drain_pending_retains(config)
+    except ImportError as e:
+        _warn_version_skew("drain_pending", e, config, "Queued retains will NOT be replayed")
     except Exception as e:
         # Never let the drain break session start. Issue sink picks
         # this up via run-hook.sh — see exit-code path in __main__.
@@ -99,6 +143,10 @@ def main():
         from reconcile_tail import reconcile as reconcile_tail
 
         reconcile_tail(config, hook_input=hook_input)
+    except ImportError as e:
+        _warn_version_skew(
+            "reconcile_tail", e, config, "Un-committed turns will NOT be recovered"
+        )
     except Exception as e:
         debug_log(config, f"reconcile_tail unexpected error (ignored): {e}")
 

--- a/vendor/hindsight-memory/scripts/tests/test_client_document_exists.py
+++ b/vendor/hindsight-memory/scripts/tests/test_client_document_exists.py
@@ -306,5 +306,74 @@ class HealthCheckRetryBoundaryTest(unittest.TestCase):
         self.assertEqual(slept, [])
 
 
+class SessionDocumentIdsPagingTest(unittest.TestCase):
+    """``session_document_ids`` must page until the server runs out.
+
+    The loop stops on a SHORT page (``len(items) < page``). With ``<=`` it
+    stops on a FULL one too, so a session with exactly one page of
+    documents reports only that page — and the #3244 recovery caller reads
+    a truncated set as "these turns were never retained" and restores
+    duplicates. A sweep found this uncovered: no test ever served more
+    than one page.
+    """
+
+    def _serve(self, pages):
+        """Serve ``pages`` (a list of lists of ids) by offset."""
+        seen = []
+
+        def handler(h):
+            import urllib.parse as up
+
+            q = up.parse_qs(up.urlparse(h.path).query)
+            offset = int(q.get("offset", ["0"])[0])
+            limit = int(q.get("limit", ["200"])[0])
+            seen.append((offset, limit))
+            idx = offset // limit
+            items = pages[idx] if idx < len(pages) else []
+            body = (
+                '{"items": ['
+                + ", ".join('{"id": "%s"}' % i for i in items)
+                + "]}"
+            ).encode()
+            h.send_response(200)
+            h.send_header("Content-Type", "application/json")
+            h.send_header("Content-Length", str(len(body)))
+            h.end_headers()
+            h.wfile.write(body)
+
+        srv = _Server(("127.0.0.1", 0), _Handler)
+        srv.behaviour = handler
+        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t.start()
+        self.addCleanup(t.join, 5)
+        self.addCleanup(srv.server_close)
+        self.addCleanup(srv.shutdown)
+        return HindsightClient(f"http://127.0.0.1:{srv.server_address[1]}"), seen
+
+    def test_a_full_page_is_followed_by_another_request(self):
+        c, seen = self._serve([["a", "b"], ["c"]])
+        got = c.list_session_document_ids(BANK, "sess-1", page=2, timeout=5)
+        self.assertEqual(got, {"a", "b", "c"}, "a full page must not end the walk")
+        self.assertEqual([o for o, _ in seen], [0, 2])
+
+    def test_a_short_page_ends_the_walk(self):
+        c, seen = self._serve([["a"], ["never-fetched"]])
+        got = c.list_session_document_ids(BANK, "sess-1", page=2, timeout=5)
+        self.assertEqual(got, {"a"})
+        self.assertEqual(len(seen), 1, "a short page means the server is done")
+
+    def test_an_exactly_full_last_page_costs_one_empty_confirmation(self):
+        """The walk cannot know a full page was the last one without asking."""
+        c, seen = self._serve([["a", "b"], []])
+        got = c.list_session_document_ids(BANK, "sess-1", page=2, timeout=5)
+        self.assertEqual(got, {"a", "b"})
+        self.assertEqual(len(seen), 2)
+
+    def test_max_pages_bounds_the_walk(self):
+        c, seen = self._serve([["a", "b"]] * 10)
+        c.list_session_document_ids(BANK, "sess-1", page=2, max_pages=3, timeout=5)
+        self.assertEqual(len(seen), 3, "max_pages is a hard bound")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_client_document_exists.py
+++ b/vendor/hindsight-memory/scripts/tests/test_client_document_exists.py
@@ -1,0 +1,310 @@
+"""Direct coverage of ``HindsightClient.document_exists`` (#3599 review R3-B2).
+
+Every drain test patches ``drain_pending._document_state``, so before this
+file the tri-state itself — the thing the docstring calls "load-bearing and
+must not be collapsed to a bool" — had ZERO executed lines and was asserted
+only in prose. ``return False if e.code == 404 else None`` could be mutated
+to a bare ``return True`` and both suites stayed green.
+
+These run against a REAL local HTTP server rather than a mocked ``urllib``:
+the branch under test is precisely the exception taxonomy urllib raises
+(``HTTPError`` with a code vs ``URLError``/``socket.timeout``), and a mock
+that hand-raises those proves the handler, not that urllib produces them.
+
+The tri-state contract:
+  * ``True``  — 200, the document is there;
+  * ``False`` — 404, and ONLY 404. It is the sole answer that lets a caller
+    re-POST (reconcile) or keep an entry queued for phase 2;
+  * ``None``  — unknown: any 5xx, any transport error, any timeout.
+    Collapsing this to ``True`` retires the last on-disk copy of a turn on
+    a flaky GET (#3244 silent loss); collapsing it to ``False`` re-POSTs an
+    already-durable document at full LLM extraction cost.
+"""
+
+import http.server
+import os
+import socket
+import sys
+import threading
+import unittest
+import unittest.mock
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.client import HindsightClient  # noqa: E402
+
+BANK = "bank-a"
+DOC = "sess-1-rdoc-1"
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    #: set per-server instance; a callable (handler) -> None, or an int status
+    behaviour = 200
+
+    def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler API
+        b = self.server.behaviour
+        if callable(b):
+            b(self)
+            return
+        self.send_response(b)
+        self.send_header("Content-Type", "application/json")
+        body = b'{"id": "%s"}' % DOC.encode() if b == 200 else b"{}"
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_a):  # silence the stderr access log
+        pass
+
+
+class _Server(http.server.HTTPServer):
+    behaviour = 200
+
+
+class DocumentExistsTriStateTest(unittest.TestCase):
+    """200 → True, 404 → False, everything else → None."""
+
+    def _serve(self, behaviour):
+        srv = _Server(("127.0.0.1", 0), _Handler)
+        srv.behaviour = behaviour
+        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t.start()
+        self.addCleanup(t.join, 5)
+        self.addCleanup(srv.server_close)
+        self.addCleanup(srv.shutdown)
+        return HindsightClient(f"http://127.0.0.1:{srv.server_address[1]}")
+
+    def test_200_is_true(self):
+        c = self._serve(200)
+        self.assertIs(c.document_exists(BANK, DOC, timeout=5), True)
+
+    def test_404_is_false(self):
+        """The ONLY negative. A 404 is the server stating the document is
+        absent, which is the one answer that authorises a re-POST."""
+        c = self._serve(404)
+        self.assertIs(c.document_exists(BANK, DOC, timeout=5), False)
+
+    def test_500_is_unknown(self):
+        c = self._serve(500)
+        self.assertIsNone(c.document_exists(BANK, DOC, timeout=5))
+
+    def test_503_is_unknown(self):
+        """The reviewer's live repro: a degraded upstream answering 503 must
+        leave the entry queued, not retire it."""
+        c = self._serve(503)
+        self.assertIsNone(c.document_exists(BANK, DOC, timeout=5))
+
+    def test_429_is_unknown(self):
+        """Not every non-404 error is a 5xx; rate limiting says nothing
+        about presence either."""
+        c = self._serve(429)
+        self.assertIsNone(c.document_exists(BANK, DOC, timeout=5))
+
+    def test_timeout_is_unknown(self):
+        """A hung server: urllib raises ``socket.timeout``/``URLError``,
+        which is neither presence nor absence."""
+        import time
+
+        def hang(handler):
+            time.sleep(3)
+            try:
+                handler.send_response(200)
+                handler.end_headers()
+            except OSError:
+                pass
+
+        c = self._serve(hang)
+        self.assertIsNone(c.document_exists(BANK, DOC, timeout=1))
+
+    def test_connection_refused_is_unknown(self):
+        """Nothing listening at all — the daemon is down, not the document."""
+        s = socket.socket()
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        s.close()
+        c = HindsightClient(f"http://127.0.0.1:{port}")
+        self.assertIsNone(c.document_exists(BANK, DOC, timeout=2))
+
+    def test_malformed_body_on_200_is_still_true(self):
+        """Presence is decided by the STATUS, not by parsing the body: a
+        proxy that mangles the payload must not read as an absence."""
+
+        def garbage(handler):
+            handler.send_response(200)
+            handler.send_header("Content-Length", "9")
+            handler.end_headers()
+            handler.wfile.write(b"not-json!")
+
+        c = self._serve(garbage)
+        self.assertIs(c.document_exists(BANK, DOC, timeout=5), True)
+
+
+class DocumentExistsRequestShapeTest(unittest.TestCase):
+    """The URL/method/auth the tri-state is derived from."""
+
+    def test_gets_the_document_path_with_both_ids_url_encoded(self):
+        seen = {}
+
+        def capture(handler):
+            seen["path"] = handler.path
+            seen["auth"] = handler.headers.get("Authorization")
+            seen["method"] = handler.command
+            handler.send_response(200)
+            handler.send_header("Content-Length", "2")
+            handler.end_headers()
+            handler.wfile.write(b"{}")
+
+        srv = _Server(("127.0.0.1", 0), _Handler)
+        srv.behaviour = capture
+        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t.start()
+        self.addCleanup(t.join, 5)
+        self.addCleanup(srv.server_close)
+        self.addCleanup(srv.shutdown)
+
+        c = HindsightClient(f"http://127.0.0.1:{srv.server_address[1]}", "tok")
+        self.assertIs(c.document_exists("bank/with slash", "doc id", timeout=5), True)
+        self.assertEqual(seen["method"], "GET")
+        self.assertEqual(
+            seen["path"],
+            "/v1/default/banks/bank%2Fwith%20slash/documents/doc%20id",
+            "both ids must be fully quoted — an unescaped '/' would GET a "
+            "different resource and the answer would be about that one",
+        )
+        self.assertEqual(seen["auth"], "Bearer tok")
+
+
+class DocumentStateWrapperTest(unittest.TestCase):
+    """``drain_pending._document_state`` — the wrapper every drain test
+    patches away, and which was therefore never itself executed.
+
+    It must preserve the tri-state end to end and swallow every exception
+    into ``None``: it is called on the retire path, where a raised
+    exception escaping into ``drain()``'s per-entry handler would be
+    recorded as a POST failure and age the entry toward ``.dead``.
+    """
+
+    def _entry(self, **kw):
+        e = {
+            "api_url": "http://127.0.0.1:1/none",
+            "api_token": None,
+            "bank_id": BANK,
+            "document_id": DOC,
+        }
+        e.update(kw)
+        return e
+
+    def test_forwards_the_client_tri_state_unchanged(self):
+        import drain_pending
+
+        for state in (True, False, None):
+            with self.subTest(state=state):
+                with unittest.mock.patch.object(
+                    drain_pending.HindsightClient,
+                    "document_exists",
+                    lambda self, b, d, timeout=30: state,
+                ):
+                    self.assertIs(
+                        drain_pending._document_state(self._entry()), state
+                    )
+
+    def test_missing_ids_are_unknown_not_absent(self):
+        """No document_id / bank_id means we cannot ask. That is unknown —
+        returning ``False`` would re-POST, ``True`` would retire blind."""
+        import drain_pending
+
+        self.assertIsNone(drain_pending._document_state(self._entry(document_id="")))
+        self.assertIsNone(drain_pending._document_state(self._entry(bank_id=None)))
+
+    def test_a_raising_client_is_unknown_not_a_crash(self):
+        import drain_pending
+
+        def boom(self, b, d, timeout=30):
+            raise RuntimeError("upstream on fire")
+
+        with unittest.mock.patch.object(
+            drain_pending.HindsightClient, "document_exists", boom
+        ):
+            self.assertIsNone(drain_pending._document_state(self._entry()))
+
+    def test_a_bad_api_url_is_unknown_not_a_crash(self):
+        """``HindsightClient.__init__`` raises on a non-http scheme; an old
+        queue entry with a junk url must not take the drain down."""
+        import drain_pending
+
+        self.assertIsNone(
+            drain_pending._document_state(self._entry(api_url="ftp://nope/x"))
+        )
+
+
+class HealthCheckRetryBoundaryTest(unittest.TestCase):
+    """``client.py``'s ``if attempt < retries`` sleep guard (#3599 R3-L3).
+
+    Mutating it to ``<=`` survived the whole sweep: it costs one extra
+    ``HEALTH_CHECK_DELAY`` sleep after the LAST attempt, for a result that
+    is already decided. The SessionStart drain gate passes ``retries=1``
+    precisely so a hung server costs ~one timeout and no delay at all; the
+    mutant makes that path sleep 2s inside a 4s hook budget.
+    """
+
+    def _client(self, attempts_log, ok_after=None):
+        c = HindsightClient("http://127.0.0.1:1/none")
+
+        def fake_urlopen(req, timeout=None):
+            attempts_log.append(timeout)
+            if ok_after is not None and len(attempts_log) >= ok_after:
+                class _R:
+                    status = 200
+
+                    def __enter__(self_inner):
+                        return self_inner
+
+                    def __exit__(self_inner, *a):
+                        return False
+
+                return _R()
+            raise OSError("refused")
+
+        return c, fake_urlopen
+
+    def _run(self, retries, ok_after=None):
+        attempts, slept = [], []
+        c, fake = self._client(attempts, ok_after)
+        import time as _t
+
+        with unittest.mock.patch("urllib.request.urlopen", fake):
+            with unittest.mock.patch.object(_t, "sleep", slept.append):
+                result = c.health_check(timeout=1, retries=retries)
+        return result, attempts, slept
+
+    def test_a_single_retry_never_sleeps(self):
+        """retries=1 is the hook-budget contract: one shot, no delay."""
+        ok, attempts, slept = self._run(retries=1)
+        self.assertFalse(ok)
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(slept, [], "no sleep after the final attempt")
+
+    def test_n_attempts_sleep_exactly_n_minus_one_times(self):
+        ok, attempts, slept = self._run(retries=3)
+        self.assertFalse(ok)
+        self.assertEqual(len(attempts), 3)
+        self.assertEqual(
+            len(slept), 2, "a sleep BETWEEN attempts, never after the last"
+        )
+
+    def test_success_short_circuits_the_remaining_attempts(self):
+        ok, attempts, slept = self._run(retries=3, ok_after=2)
+        self.assertTrue(ok)
+        self.assertEqual(len(attempts), 2)
+        self.assertEqual(len(slept), 1)
+
+    def test_retries_is_floored_at_one(self):
+        ok, attempts, slept = self._run(retries=0)
+        self.assertEqual(len(attempts), 1, "0 retries still makes one attempt")
+        self.assertEqual(slept, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_client_document_exists.py
+++ b/vendor/hindsight-memory/scripts/tests/test_client_document_exists.py
@@ -186,9 +186,47 @@ class DocumentStateWrapperTest(unittest.TestCase):
     recorded as a POST failure and age the entry toward ``.dead``.
     """
 
+    def setUp(self):
+        """Point the fixture at a LIVE server that answers 200 to anything.
+
+        The previous fixture used an unreachable ``http://127.0.0.1:1/none``,
+        which made ``test_missing_ids_are_unknown_not_absent`` unable to fail
+        (#3599 review R4-B1): with the ``if not did or not bank`` guard
+        deleted outright, control reached ``document_exists``, the connection
+        was refused, and the bare ``except`` returned ``None`` — exactly what
+        the test asserts. Both ``or`` → ``and`` AND deleting the guard
+        survived the whole suite.
+
+        A live 200-serving loopback models the real hazard. An entry with an
+        empty ``document_id`` quotes to ``""``, so the GET hits the
+        COLLECTION endpoint ``/v1/default/banks/<bank>/documents/`` — which a
+        real daemon answers **200** — and ``document_exists`` returns
+        ``True``. ``drain()`` would then retire a turn whose document was
+        never confirmed: the #3244 silent-loss path this PR exists to close.
+        """
+        self.requests: list[str] = []
+
+        def count(handler):
+            self.requests.append(handler.path)
+            body = b'{"id": "whatever"}'
+            handler.send_response(200)
+            handler.send_header("Content-Type", "application/json")
+            handler.send_header("Content-Length", str(len(body)))
+            handler.end_headers()
+            handler.wfile.write(body)
+
+        srv = _Server(("127.0.0.1", 0), _Handler)
+        srv.behaviour = count
+        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t.start()
+        self.addCleanup(t.join, 5)
+        self.addCleanup(srv.server_close)
+        self.addCleanup(srv.shutdown)
+        self.api_url = f"http://127.0.0.1:{srv.server_address[1]}"
+
     def _entry(self, **kw):
         e = {
-            "api_url": "http://127.0.0.1:1/none",
+            "api_url": self.api_url,
             "api_token": None,
             "bank_id": BANK,
             "document_id": DOC,
@@ -212,11 +250,44 @@ class DocumentStateWrapperTest(unittest.TestCase):
 
     def test_missing_ids_are_unknown_not_absent(self):
         """No document_id / bank_id means we cannot ask. That is unknown —
-        returning ``False`` would re-POST, ``True`` would retire blind."""
+        returning ``False`` would re-POST, ``True`` would retire blind.
+
+        Two assertions, and the SECOND is the one with teeth: the guard must
+        return ``None`` *without asking*. Against this test's live 200 server
+        an unguarded empty ``document_id`` GETs the collection endpoint and
+        reads back ``True``, so "answered None" alone cannot tell "guarded
+        early" from "asked and got a refusal".
+        """
         import drain_pending
 
-        self.assertIsNone(drain_pending._document_state(self._entry(document_id="")))
-        self.assertIsNone(drain_pending._document_state(self._entry(bank_id=None)))
+        for kw in ({"document_id": ""}, {"document_id": None}, {"bank_id": ""},
+                   {"bank_id": None}):
+            with self.subTest(**kw):
+                self.requests.clear()
+                self.assertIsNone(
+                    drain_pending._document_state(self._entry(**kw))
+                )
+                self.assertEqual(
+                    self.requests,
+                    [],
+                    "an entry with no usable ids must not reach the daemon at "
+                    "all: the collection endpoint answers 200 and would read "
+                    "back as a confirmed presence",
+                )
+
+    def test_an_empty_document_id_would_confirm_the_collection_endpoint(self):
+        """Why the guard exists, stated as an executable fact rather than a
+        comment: with the ids blank the URL degrades to the collection
+        endpoint, and that answers 200. This is the failure the guard
+        prevents, demonstrated one layer down at the client.
+        """
+        c = HindsightClient(self.api_url)
+        self.assertIs(c.document_exists(BANK, "", timeout=5), True)
+        self.assertEqual(
+            self.requests,
+            [f"/v1/default/banks/{BANK}/documents/"],
+            "an empty document_id quotes to '' and GETs the COLLECTION",
+        )
 
     def test_a_raising_client_is_unknown_not_a_crash(self):
         import drain_pending
@@ -373,6 +444,26 @@ class SessionDocumentIdsPagingTest(unittest.TestCase):
         c, seen = self._serve([["a", "b"]] * 10)
         c.list_session_document_ids(BANK, "sess-1", page=2, max_pages=3, timeout=5)
         self.assertEqual(len(seen), 3, "max_pages is a hard bound")
+
+    def test_max_pages_is_floored_at_one(self):
+        """``max(1, max_pages)`` — found by the R4-B1 sibling sweep, which
+        looked for guards whose only test reaches the same answer by a
+        second path. Every existing test passed ``max_pages >= 3``, so
+        ``max(1, ...)`` → ``max(0, ...)`` survived: nothing ever asked for
+        zero pages. It is not equivalent. ``max_pages=0`` under the mutant
+        makes ZERO requests and returns an empty set, and the #3244
+        recovery caller reads an empty set as "this session was never
+        retained" and restores the whole thing — duplicate restore from a
+        config value, with no error anywhere. One page is the floor for the
+        same reason ``retries`` is floored in ``health_check``: a bound of
+        zero is a typo, not a request to do nothing.
+        """
+        c, seen = self._serve([["a"], ["never-fetched"]])
+        got = c.list_session_document_ids(
+            BANK, "sess-1", page=2, max_pages=0, timeout=5
+        )
+        self.assertEqual(len(seen), 1, "0 pages still makes one request")
+        self.assertEqual(got, {"a"})
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -36,8 +36,28 @@ import lib.pending as pending  # noqa: E402
 
 CONFIG = {"debug": False}
 
+#: A session id of the shape ``retain.py`` sees (a plain uuid).
+SESSION = "11111111-2222-4333-8444-555555555555"
 
-def _payload(bank="bank-a", content="hello", doc="doc-1"):
+
+def _uuid(n: int) -> str:
+    h = f"{n:032x}"
+    return f"{h[:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:]}"
+
+
+def _cd_doc(i: int = 1) -> str:
+    """A POST-#3244 content-derived document_id.
+
+    ``retain.slice_document_id`` → ``{session}-r{start_uuid}-{end_uuid}``.
+    Presence-only reconcile is gated on this shape, so the drain tests must
+    use it rather than a stand-in like ``doc-1``.
+    """
+    return f"{SESSION}-r{_uuid(i)}-{_uuid(i + 1000)}"
+
+
+def _payload(bank="bank-a", content="hello", doc=None):
+    if doc is None:
+        doc = _cd_doc(1)
     return {
         "api_url": "http://127.0.0.1:9/none",
         "api_token": None,
@@ -55,6 +75,10 @@ class _QueueTempDirMixin:
     ENV_KEYS = (
         "HINDSIGHT_PENDING_DIR",
         "HINDSIGHT_PENDING_EVICTED_DIR",
+        "HINDSIGHT_PENDING_RECONCILED_DIR",
+        # Absent from this tuple the budget/clamp cases ran against whatever
+        # the ambient env said — vacuously green in CI, where nothing sets it.
+        "HINDSIGHT_DRAIN_TIMEOUT",
         "HINDSIGHT_DRAIN_BUDGET_S",
         "HINDSIGHT_DRAIN_BACKLOG_BUDGET_S",
         "HINDSIGHT_DRAIN_BACKLOG_TIMEOUT",
@@ -71,6 +95,10 @@ class _QueueTempDirMixin:
         os.environ["HINDSIGHT_PENDING_DIR"] = self._dir
         # Backlog replay paces itself by default; tests must not sleep.
         os.environ["HINDSIGHT_DRAIN_SLEEP_S"] = "0"
+        # Hermeticity: a case that cares about the clamp sets this itself;
+        # nothing may inherit an ambient value from the caller's shell.
+        os.environ.pop("HINDSIGHT_DRAIN_TIMEOUT", None)
+        os.environ.pop("HINDSIGHT_DRAIN_BUDGET_S", None)
         self._caps_prev = (pending.MAX_ENTRIES, pending.MAX_BYTES)
 
     def tearDown(self):
@@ -88,6 +116,12 @@ class _QueueTempDirMixin:
     def _archive_names(self):
         try:
             return sorted(os.listdir(pending.evicted_dir()))
+        except OSError:
+            return []
+
+    def _reconciled_names(self):
+        try:
+            return sorted(os.listdir(pending.reconciled_dir()))
         except OSError:
             return []
 
@@ -173,6 +207,98 @@ class EvictionTest(_QueueTempDirMixin, unittest.TestCase):
         finally:
             pending.ARCHIVE_MAX_ENTRIES = prev
 
+    def test_archive_trim_keeps_the_newest_evictions(self):
+        """Direction matters: trimming the wrong end keeps the stale tail.
+
+        ``test_archive_is_itself_bounded`` only pins the COUNT, so reversing
+        the trim direction leaves it green while the archive discards
+        exactly what was just shed.
+        """
+        pending.MAX_ENTRIES = 1
+        prev = pending.ARCHIVE_MAX_ENTRIES
+        pending.ARCHIVE_MAX_ENTRIES = 2
+        try:
+            clock = iter(1000.0 + i for i in range(20))
+            with unittest.mock.patch.object(pending.time, "time", lambda: next(clock)):
+                with redirect_stderr(io.StringIO()):
+                    paths = [
+                        pending.enqueue(_payload(doc=f"d{i}"), RuntimeError("x"))
+                        for i in range(5)
+                    ]
+            evicted_names = [os.path.basename(p) for p in paths[:-1]]
+            self.assertEqual(
+                self._archive_names(),
+                sorted(evicted_names[-2:]),
+                "the archive must keep the most recently evicted entries",
+            )
+        finally:
+            pending.ARCHIVE_MAX_ENTRIES = prev
+
+    def test_eviction_ledger_trim_keeps_the_NEWEST_lines(self):
+        """The ledger is the operator's record of what was shed.
+
+        Trimming the head off (keeping the oldest lines) would leave doctor
+        reading a frozen prefix while every recent eviction fell out — and
+        the existing ledger test only greps for one line, so it stays green
+        either way.
+        """
+        pending.MAX_ENTRIES = 1
+        log = pending.evictions_log_path()
+        os.makedirs(os.path.dirname(log), exist_ok=True)
+        with open(log, "w", encoding="utf-8") as f:
+            for i in range(500):
+                f.write(f"ANCIENT-{i:03d} evicted=old bytes=0 reason=count\n")
+
+        prev = (pending.EVICTIONS_LOG_MAX_BYTES, pending.EVICTIONS_LOG_KEEP_LINES)
+        pending.EVICTIONS_LOG_MAX_BYTES, pending.EVICTIONS_LOG_KEEP_LINES = 1, 3
+        try:
+            pending.enqueue(_payload(doc="d0"), RuntimeError("x"))
+            with redirect_stderr(io.StringIO()):
+                pending.enqueue(_payload(doc="d1"), RuntimeError("x"))
+        finally:
+            pending.EVICTIONS_LOG_MAX_BYTES, pending.EVICTIONS_LOG_KEEP_LINES = prev
+
+        with open(log, encoding="utf-8") as f:
+            kept = [ln.rstrip("\n") for ln in f]
+        self.assertEqual(len(kept), 3, "trimmed to KEEP_LINES")
+        self.assertIn("evicted=", kept[-1], "the newest line is the real eviction")
+        self.assertEqual(
+            [ln for ln in kept if ln.startswith("ANCIENT-000")],
+            [],
+            "the OLDEST lines must be the ones dropped",
+        )
+        self.assertTrue(
+            kept[0].startswith("ANCIENT-498"),
+            f"kept the wrong end of the ledger: {kept[0]!r}",
+        )
+
+    def test_the_byte_cap_is_a_boundary_not_an_approximation(self):
+        """`nbytes + incoming > MAX_BYTES` evicts; `== MAX_BYTES` does not.
+
+        Off-by-one here is silent: it either sheds a memory that fit, or
+        overshoots the cap the operator set.
+        """
+        pending.MAX_ENTRIES = 1000
+        first = pending.enqueue(_payload(content="x" * 100, doc="d0"), RuntimeError("x"))
+        second = pending.enqueue(_payload(content="y" * 100, doc="d1"), RuntimeError("x"))
+        exact = os.path.getsize(first) + os.path.getsize(second)
+        os.remove(second)
+
+        # Exactly at the cap: the incoming entry fits, nothing may be evicted.
+        pending.MAX_BYTES = exact
+        with redirect_stderr(io.StringIO()):
+            pending.enqueue(_payload(content="y" * 100, doc="d1"), RuntimeError("x"))
+        self.assertEqual(len(self._names()), 2, "an entry that fits exactly must fit")
+        self.assertEqual(self._archive_names(), [], "nothing was over the cap")
+
+        # One byte tighter: the same pair no longer fits, so the oldest sheds.
+        os.remove(sorted(os.path.join(self._dir, n) for n in self._names())[-1])
+        pending.MAX_BYTES = exact - 1
+        with redirect_stderr(io.StringIO()):
+            pending.enqueue(_payload(content="y" * 100, doc="d1"), RuntimeError("x"))
+        self.assertEqual(len(self._archive_names()), 1, "one byte over must evict")
+        self.assertEqual(len(self._names()), 1)
+
     def test_ledgers_live_outside_the_queue_dir(self):
         """So they can never be listed as an entry, drained, or counted."""
         pending.MAX_ENTRIES = 1
@@ -182,6 +308,38 @@ class EvictionTest(_QueueTempDirMixin, unittest.TestCase):
         for p in (pending.evictions_log_path(), pending.drops_path()):
             self.assertNotEqual(os.path.dirname(p), self._dir.rstrip("/"))
         self.assertEqual(pending.count(), 1)
+
+
+class QueueOrderTest(_QueueTempDirMixin, unittest.TestCase):
+    """What the filename ordering does and does not promise.
+
+    FIFO is what eviction and the drain both rely on, and it is exact only
+    down to the millisecond: the name carries no finer age information, so
+    entries sharing a millisecond tie-break on the dupe key — stable and
+    total, but arbitrary. The comment used to claim plain oldest-first.
+    """
+
+    def _enqueue_at(self, ms, content):
+        with unittest.mock.patch.object(pending.time, "time", lambda: ms / 1000.0):
+            return pending.enqueue(_payload(content=content, doc=f"d-{content}"),
+                                   RuntimeError("x"))
+
+    def test_entries_are_ordered_by_enqueue_millisecond(self):
+        newest = self._enqueue_at(1_700_000_002_000, "third")
+        oldest = self._enqueue_at(1_700_000_000_000, "first")
+        middle = self._enqueue_at(1_700_000_001_000, "second")
+        self.assertEqual(
+            [p for p, _ in pending.iter_entries()],
+            [oldest, middle, newest],
+            "write order must not matter; the millisecond stamp orders them",
+        )
+
+    def test_same_millisecond_entries_are_ordered_stably_but_arbitrarily(self):
+        paths = [self._enqueue_at(1_700_000_000_000, f"c{i}") for i in range(4)]
+        got = [p for p, _ in pending.iter_entries()]
+        self.assertEqual(sorted(got), sorted(paths), "every entry is listed once")
+        self.assertEqual(got, sorted(got), "the order is the name sort, not enqueue order")
+        self.assertEqual(got, [p for p, _ in pending.iter_entries()], "and it is stable")
 
 
 class DedupeTest(_QueueTempDirMixin, unittest.TestCase):
@@ -390,9 +548,10 @@ class DropLedgerTest(_QueueTempDirMixin, unittest.TestCase):
 
 class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
     def _queue(self, n):
+        """Queue ``n`` entries with POST-#3244 content-derived document_ids."""
         for i in range(n):
             pending.enqueue(
-                _payload(content=f"turn-{i}", doc=f"doc-{i}"), RuntimeError("boom")
+                _payload(content=f"turn-{i}", doc=_cd_doc(i)), RuntimeError("boom")
             )
         self.assertEqual(pending.count(), n)
 
@@ -428,7 +587,7 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
     def test_session_start_drain_reconciles_before_re_posting(self):
         self._queue(6)
         posted = []
-        durable = {"doc-0", "doc-1", "doc-2", "doc-3"}
+        durable = {_cd_doc(i) for i in range(4)}
 
         def exists(entry, timeout=30):
             return entry["document_id"] in durable
@@ -442,7 +601,7 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(summary["reconciled"], 4)
         self.assertEqual(
             sorted(posted),
-            ["doc-4", "doc-5"],
+            sorted([_cd_doc(4), _cd_doc(5)]),
             "already-durable entries must not be re-POSTed inside the hook",
         )
         self.assertEqual(pending.count(), 0)
@@ -461,24 +620,96 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(summary["reconciled"], 0)
         self.assertEqual(len(posted), 3, "unknown falls through to the retry")
 
+    def _stalled_upstream(self, budget, timeout):
+        """Simulate an upstream that never answers, on a virtual clock.
+
+        Every request consumes exactly the timeout it was given — the shape
+        of a hung upstream, and the shape that made the fleet's 9s budget
+        take 16.0s. The clock is virtual so the assertion is about the
+        drain's arithmetic, not about how fast the test box happens to be.
+
+        Returns ``(seen_get, seen_post, elapsed_fn, patch_contexts)``.
+        """
+        os.environ["HINDSIGHT_DRAIN_BUDGET_S"] = str(budget)
+        os.environ["HINDSIGHT_DRAIN_TIMEOUT"] = str(timeout)
+        clock = {"t": 1000.0}
+        start = clock["t"]
+        seen_get, seen_post = [], []
+
+        def fake_get(entry, timeout=30):
+            seen_get.append(timeout)
+            clock["t"] += timeout
+            return False  # absent -> falls through to the POST
+
+        def fake_post(entry, timeout):
+            seen_post.append(timeout)
+            clock["t"] += timeout
+            raise TimeoutError("upstream never answered")
+
+        ctx = (
+            unittest.mock.patch.object(
+                drain_pending.time, "monotonic", lambda: clock["t"]
+            ),
+            unittest.mock.patch.object(drain_pending, "_document_state", fake_get),
+            unittest.mock.patch.object(drain_pending, "_retry_one", fake_post),
+        )
+        return seen_get, seen_post, (lambda: clock["t"] - start), ctx
+
+    def test_the_per_entry_timeout_is_not_spent_twice(self):
+        """One entry = one budget, not one per request.
+
+        The clamp used to be computed ONCE per entry and then spent on the
+        presence GET *and* the POST. With the fleet's own settings (budget
+        9s, timeout 8s) that is 8 + 8 = 16.0s against a 9s hook budget,
+        while the docstring promised an overshoot of at most the 1s clamp
+        floor. The POST's timeout must be recomputed against what is left.
+        """
+        self._queue(1)
+        seen_get, seen_post, elapsed, ctx = self._stalled_upstream(budget=9, timeout=8)
+        with ctx[0], ctx[1], ctx[2]:
+            drain_pending.drain(CONFIG)
+
+        self.assertEqual(seen_get, [8], "the GET gets the full budgeted clamp")
+        self.assertEqual(
+            seen_post, [1], "the POST must re-clamp against the budget LEFT"
+        )
+        self.assertLessEqual(
+            elapsed(),
+            9,
+            f"one entry outspent the whole 9s budget "
+            f"(gets={seen_get} posts={seen_post})",
+        )
+        self.assertEqual(pending.count(), 1, "the failed entry stays queued")
+
     def test_session_start_reconcile_respects_the_hook_budget(self):
-        """The GET replaces the POST; it must not be an extra unbounded call."""
+        """The GET must not be an extra call bolted onto an unchanged POST.
+
+        Asserts against the BUDGET, with ``HINDSIGHT_DRAIN_TIMEOUT`` set
+        explicitly high — the previous form asserted ``t <= 5`` while
+        ``_per_entry_timeout()`` defaults to 5, so it held whether or not
+        the clamp existed at all, and it never patched ``_retry_one``, so
+        the GET+POST path it is named for never ran.
+        """
         self._queue(10)
-        os.environ["HINDSIGHT_DRAIN_BUDGET_S"] = "2"
-        seen = []
-
-        def slow_get(entry, timeout=30):
-            import time as _t
-
-            seen.append(timeout)
-            _t.sleep(0.5)
-            return True
-
-        with unittest.mock.patch.object(drain_pending, "_document_state", slow_get):
+        budget = 9
+        seen_get, seen_post, elapsed, ctx = self._stalled_upstream(
+            budget=budget, timeout=300
+        )
+        with ctx[0], ctx[1], ctx[2]:
             summary = drain_pending.drain(CONFIG)
 
+        self.assertTrue(seen_get and seen_post, "the GET+POST path must run")
+        self.assertTrue(
+            all(t <= budget for t in seen_get + seen_post),
+            f"a single request outlived the whole budget: {seen_get} {seen_post}",
+        )
+        self.assertLessEqual(
+            elapsed(),
+            budget + 2,
+            f"drain overshot the {budget}s hook budget by more than one "
+            f"floored GET+POST (gets={seen_get} posts={seen_post})",
+        )
         self.assertTrue(summary["budget_exceeded"])
-        self.assertTrue(all(t <= 5 for t in seen), f"timeout not clamped: {seen}")
         self.assertGreater(pending.count(), 0)
 
     def test_reconcile_phase_skips_already_durable_entries_without_posting(self):
@@ -487,7 +718,7 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
         memory; a GET costs nothing on the model pool."""
         self._queue(6)
         posted = []
-        durable = {"doc-0", "doc-1", "doc-2"}
+        durable = {_cd_doc(i) for i in range(3)}
 
         def exists(entry, timeout=30):
             return entry["document_id"] in durable
@@ -676,6 +907,201 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
                 )
         self.assertEqual(summary["reconciled"], 3)
         self.assertEqual(pending.count(), 3, "a dry run must not delete anything")
+
+
+class PresenceReconcileGateTest(_QueueTempDirMixin, unittest.TestCase):
+    """A presence GET may only retire an entry whose id proves ITS content.
+
+    Post-#3244 (`retain.slice_document_id`) the id is
+    ``{session}-r{start_uuid}-{end_uuid}`` — a function of which turns the
+    entry carries, so a 200 proves this content was committed. A pre-#3244
+    entry carries a BARE SESSION ID, for which the bank answers 200 after
+    ANY successful retain in that session. Reconciling on that deletes a
+    turn that was never committed. Confirmed against a live 525 KB entry on
+    this fleet whose ``document_id`` is a bare uuid and whose GET returns
+    200.
+    """
+
+    BARE_SESSION_ID = "d52ae253-2d26-42e5-a86b-9a354cc0ace5"
+
+    def test_the_id_shape_predicate_separates_the_two_generations(self):
+        self.assertTrue(pending.is_content_derived_document_id(_cd_doc(1)))
+        # sha256 fallback for uuid-less legacy transcripts
+        self.assertTrue(
+            pending.is_content_derived_document_id(f"{SESSION}-r" + "a1" * 16)
+        )
+        # sub-agent namespace reuses the same recipe
+        self.assertTrue(
+            pending.is_content_derived_document_id(
+                f"{SESSION}-sub-worker7-r{_uuid(1)}-{_uuid(2)}"
+            )
+        )
+        for bad in (
+            self.BARE_SESSION_ID,
+            "conversation",
+            "",
+            None,
+            123,
+            f"{SESSION}-r{_uuid(1)}",  # only one uuid: not the slice shape
+        ):
+            self.assertFalse(
+                pending.is_content_derived_document_id(bad), f"must not accept {bad!r}"
+            )
+
+    def _queue_bare(self, n=2):
+        for i in range(n):
+            pending.enqueue(
+                _payload(content=f"turn-{i}", doc=self.BARE_SESSION_ID),
+                RuntimeError("boom"),
+            )
+
+    def test_a_bare_session_id_is_never_reconciled_on_presence_alone(self):
+        """The bug: a 200 for the session deletes an uncommitted turn."""
+        self._queue_bare(2)
+        posted = []
+
+        def post_fails(entry, timeout):
+            posted.append(entry)
+            raise TimeoutError("upstream slow")
+
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: True
+        ):
+            with unittest.mock.patch.object(drain_pending, "_retry_one", post_fails):
+                summary = drain_pending.drain(CONFIG)
+
+        self.assertEqual(summary["reconciled"], 0, "presence alone proves nothing here")
+        self.assertEqual(len(posted), 2, "such entries must go to the POST instead")
+        self.assertEqual(pending.count(), 2, "and stay queued when the POST fails")
+        self.assertEqual(
+            self._reconciled_names(),
+            [],
+            "nothing may be retired by the reconcile path on a bare session id",
+        )
+
+    def test_backlog_reconcile_phase_also_refuses_a_bare_session_id(self):
+        self._queue_bare(2)
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: True
+        ):
+            with redirect_stderr(io.StringIO()) as err:
+                summary = drain_pending.drain_backlog(CONFIG, phase="reconcile")
+
+        self.assertEqual(summary["reconciled"], 0)
+        self.assertEqual(pending.count(), 2, "left for phase 2, which can make them durable")
+        self.assertIn("pre-#3244", err.getvalue())
+
+    def test_reconciled_entries_are_archived_not_deleted(self):
+        """The out-of-band tooling this design was ported from ARCHIVES.
+
+        Every retire decision rests on a 200, and a 200 is evidence, not
+        proof (#3244). An irreversible ``os.remove`` on evidence is how the
+        last on-disk copy of a turn disappears; ``pending-reconciled/`` is
+        recoverable and bounded.
+        """
+        pending.enqueue(_payload(doc=_cd_doc(7)), RuntimeError("x"))
+        name = self._names()[0]
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: True
+        ):
+            summary = drain_pending.drain(CONFIG)
+
+        self.assertEqual(summary["reconciled"], 1)
+        self.assertEqual(pending.count(), 0, "no longer queued")
+        self.assertEqual(self._reconciled_names(), [name], "payload is recoverable")
+
+    def test_a_successful_in_hook_retain_also_archives_rather_than_deletes(self):
+        """One durability rule on one path.
+
+        The in-hook success path retires on a bare 200 while the backlog
+        path insists a 200 is not proof. Archiving both makes the weaker
+        evidence cost a recoverable file rather than a lost turn.
+        """
+        pending.enqueue(_payload(doc=self.BARE_SESSION_ID), RuntimeError("x"))
+        name = self._names()[0]
+        with unittest.mock.patch.object(
+            drain_pending, "_retry_one", lambda e, timeout: None
+        ):
+            summary = drain_pending.drain(CONFIG)
+
+        self.assertEqual(summary["drained"], 1)
+        self.assertEqual(pending.count(), 0)
+        self.assertEqual(self._reconciled_names(), [name])
+
+    def test_the_backlog_confirmed_drain_archives_too(self):
+        pending.enqueue(_payload(doc=_cd_doc(3)), RuntimeError("x"))
+        name = self._names()[0]
+        with unittest.mock.patch.object(
+            drain_pending, "_retry_one", lambda e, timeout: None
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: True
+            ):
+                with redirect_stderr(io.StringIO()):
+                    summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+        self.assertEqual(summary["drained"], 1)
+        self.assertEqual(self._reconciled_names(), [name])
+
+    def test_the_reconciled_archive_is_bounded_and_sheds_oldest_first(self):
+        """An unbounded archive is just a slower disk problem."""
+        prev = pending.RECONCILED_MAX_ENTRIES
+        pending.RECONCILED_MAX_ENTRIES = 2
+        try:
+            clock = iter(1000.0 + i for i in range(20))
+            with unittest.mock.patch.object(pending.time, "time", lambda: next(clock)):
+                for i in range(5):
+                    pending.enqueue(
+                        _payload(content=f"c{i}", doc=_cd_doc(i)), RuntimeError("x")
+                    )
+            queued = self._names()
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: True
+            ):
+                drain_pending.drain(CONFIG)
+            self.assertEqual(
+                self._reconciled_names(),
+                queued[-2:],
+                "the archive keeps the NEWEST retirements, trimming oldest-first",
+            )
+        finally:
+            pending.RECONCILED_MAX_ENTRIES = prev
+
+    def test_an_unwritable_archive_still_retires_the_entry(self):
+        """A queue that cannot retire entries re-POSTs them forever."""
+        pending.enqueue(_payload(doc=_cd_doc(9)), RuntimeError("x"))
+        with unittest.mock.patch.object(
+            pending.shutil, "move", side_effect=OSError(28, "No space left")
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: True
+            ):
+                summary = drain_pending.drain(CONFIG)
+        self.assertEqual(summary["reconciled"], 1)
+        self.assertEqual(pending.count(), 0, "the entry must not stay queued")
+
+
+class P95ProbeTest(_QueueTempDirMixin, unittest.TestCase):
+    """A configured-but-broken probe is not the same as an unset one."""
+
+    def test_a_failing_probe_is_not_read_as_a_latency_figure(self):
+        """Exit status was ignored, so a typo'd probe's stdout was trusted."""
+        os.environ["HINDSIGHT_DRAIN_P95_CMD"] = "echo 12345; exit 3"
+        with redirect_stderr(io.StringIO()) as err:
+            self.assertEqual(drain_pending._p95_probe_ms(), -1)
+        self.assertIn("exited 3", err.getvalue())
+        self.assertIn("DISABLED", err.getvalue())
+
+    def test_a_probe_that_prints_nothing_says_so(self):
+        os.environ["HINDSIGHT_DRAIN_P95_CMD"] = "true"
+        with redirect_stderr(io.StringIO()) as err:
+            self.assertEqual(drain_pending._p95_probe_ms(), -1)
+        self.assertIn("DISABLED", err.getvalue())
+
+    def test_a_healthy_probe_is_read_silently(self):
+        os.environ["HINDSIGHT_DRAIN_P95_CMD"] = "echo 41000"
+        with redirect_stderr(io.StringIO()) as err:
+            self.assertEqual(drain_pending._p95_probe_ms(), 41000)
+        self.assertEqual(err.getvalue(), "")
 
 
 class CliTest(unittest.TestCase):

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -1297,6 +1297,29 @@ class TrimDirBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertIn(f"{1000:013d}-x.json", msg, "names the oldest dropped")
         self.assertIn("arch", msg, "names the directory")
 
+    def test_exactly_ten_dropped_names_are_all_listed(self):
+        """The name list truncates ABOVE ten, not at ten.
+
+        ``len(dropped) > 10`` vs ``>=`` differ only on a trim of exactly
+        ten, where the mutant appends a nonsense "+0 more".
+        """
+        d = self._archive([1] * 12)
+        with redirect_stderr(io.StringIO()) as err:
+            pending._trim_dir(d, max_entries=2, max_bytes=10**9)
+        msg = err.getvalue()
+        self.assertIn("trimmed 10 archived copies", msg)
+        self.assertNotIn("more", msg, "ten names fit; there is no remainder")
+        self.assertEqual(msg.count("-x.json"), 10)
+
+    def test_eleven_dropped_names_truncate_to_ten_plus_a_remainder(self):
+        d = self._archive([1] * 13)
+        with redirect_stderr(io.StringIO()) as err:
+            pending._trim_dir(d, max_entries=2, max_bytes=10**9)
+        msg = err.getvalue()
+        self.assertIn("trimmed 11 archived copies", msg)
+        self.assertIn("+1 more", msg)
+        self.assertEqual(msg.count("-x.json"), 10)
+
     def test_a_large_trim_caps_the_name_list(self):
         """A 1500-entry trim must not emit a 1500-name line."""
         d = self._archive([1] * 20)
@@ -1668,6 +1691,89 @@ class WaitForUpstreamBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
         got, slept, _ = self._wait(38000, [0])
         self.assertTrue(got)
         self.assertEqual(slept, [])
+
+
+class ClipErrorBoundaryTest(unittest.TestCase):
+    """``_clip_error`` clips ABOVE the cap and leaves the cap itself alone.
+
+    The ledger and every queued entry carry this string; the cap exists so
+    one pathological upstream message cannot bloat the queue. ``<=`` vs
+    ``<`` is invisible unless a message lands exactly on the cap, so that
+    is the case pinned here.
+    """
+
+    CAP = pending.MAX_ERROR_MESSAGE_CHARS
+
+    def test_a_message_exactly_at_the_cap_is_untouched(self):
+        msg = "x" * self.CAP
+        out = pending._clip_error(RuntimeError(msg))
+        self.assertEqual(out, msg)
+        self.assertNotIn("truncated", out)
+
+    def test_one_character_over_the_cap_is_clipped(self):
+        out = pending._clip_error(RuntimeError("x" * (self.CAP + 1)))
+        self.assertTrue(out.endswith("…[truncated]"))
+        self.assertEqual(out[: self.CAP], "x" * self.CAP)
+
+    def test_a_short_message_is_untouched(self):
+        self.assertEqual(pending._clip_error(RuntimeError("boom")), "boom")
+
+
+class EvictionsLogRotationBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
+    """The eviction ledger rotates ABOVE its cap, not AT it.
+
+    ``switchroom doctor`` reads this file, and rotation drops all but
+    ``EVICTIONS_LOG_KEEP_LINES``. ``>`` vs ``>=`` costs a whole ledger's
+    history on a file that is exactly at its ceiling — invisible to the
+    existing rotation test, which sets the cap to 1 byte and so can never
+    land on the boundary.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._prev = (
+            pending.EVICTIONS_LOG_MAX_BYTES,
+            pending.EVICTIONS_LOG_KEEP_LINES,
+        )
+        self.addCleanup(self._restore)
+        log = pending.evictions_log_path()
+        os.makedirs(os.path.dirname(log), exist_ok=True)
+        self.log = log
+
+    def _restore(self):
+        (
+            pending.EVICTIONS_LOG_MAX_BYTES,
+            pending.EVICTIONS_LOG_KEEP_LINES,
+        ) = self._prev
+
+    def _one_line_bytes(self):
+        """Write one ledger line with rotation effectively off; return its size."""
+        pending.EVICTIONS_LOG_MAX_BYTES = 10**9
+        pending.EVICTIONS_LOG_KEEP_LINES = 1
+        with redirect_stderr(io.StringIO()):
+            pending._log_eviction("aaaa.json", 10, "count", 1, 10)
+        return os.path.getsize(self.log)
+
+    def _lines(self):
+        with open(self.log, encoding="utf-8") as f:
+            return [ln for ln in f.read().splitlines() if ln]
+
+    def test_a_ledger_exactly_at_the_cap_is_not_rotated(self):
+        one = self._one_line_bytes()
+        # Both lines are the same fixed-width shape, so two of them land
+        # exactly on a 2*one cap.
+        pending.EVICTIONS_LOG_MAX_BYTES = 2 * one
+        with redirect_stderr(io.StringIO()):
+            pending._log_eviction("aaaa.json", 10, "count", 1, 10)
+        self.assertEqual(os.path.getsize(self.log), 2 * one, "fixture assumption")
+        self.assertEqual(len(self._lines()), 2, "a ledger AT the cap is within it")
+
+    def test_one_byte_over_the_cap_rotates_to_the_keep_window(self):
+        one = self._one_line_bytes()
+        pending.EVICTIONS_LOG_MAX_BYTES = 2 * one - 1
+        with redirect_stderr(io.StringIO()):
+            pending._log_eviction("aaaa.json", 10, "count", 1, 10)
+        self.assertEqual(len(self._lines()), 1, "over the cap, rotation runs")
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -172,6 +172,65 @@ class EvictionTest(_QueueTempDirMixin, unittest.TestCase):
             pending.enqueue(_payload(content="c", doc="d2"), RuntimeError("x"))
         self.assertEqual(len(self._archive_names()), 1)
 
+    def test_a_full_disk_evicts_the_oldest_live_entry_outright_and_says_so(self):
+        """The bound on "the entry is never deleted" (#3599 review R4-M1).
+
+        Three documents in this PR asserted a structural invariant the code
+        does not have — that no ``os.remove`` in ``pending.py`` can touch a
+        LIVE queue entry. ``_evict_to_fit``'s ``OSError`` fallback can, and
+        under sustained ENOSPC it does: ``archive_reconciled`` keeps entries
+        queued, the queue fills, this fires, its own archive move fails for
+        the same reason, and the oldest live entries are removed to keep
+        accepting the newest.
+
+        That behaviour is ACCEPTED — a queue must be bounded by something,
+        and the newest turn is the one most likely to still matter — but it
+        is loss, so what is pinned here is that it is loud and correctly
+        labelled, not that it doesn't happen. The ``+archive-failed`` reason
+        is the operator's only signal that the payload is GONE rather than
+        merely shed, so it is asserted, not just the eviction.
+        """
+        pending.MAX_ENTRIES = 3
+        for i in range(3):
+            pending.enqueue(_payload(content=f"c{i}", doc=f"d{i}"), RuntimeError("x"))
+        before = self._names()
+        self.assertEqual(len(before), 3)
+
+        with unittest.mock.patch.object(
+            pending.shutil, "move", side_effect=OSError(28, "No space left on device")
+        ):
+            with redirect_stderr(io.StringIO()) as err:
+                got = pending.enqueue(
+                    _payload(content="newest", doc="d-new"), RuntimeError("x")
+                )
+
+        self.assertIsNotNone(got, "the newest memory is still accepted")
+        names = self._names()
+        self.assertEqual(len(names), 3, "the queue stayed bounded")
+        self.assertNotIn(before[0], names, "the OLDEST live entry was removed")
+        # Set comparison, not slice: these are enqueued inside one
+        # millisecond, so their relative order tie-breaks on the dupe key
+        # (arbitrary but total — see enqueue()).
+        self.assertEqual(
+            set(names),
+            set(before[1:]) | {os.path.basename(got)},
+            "only the oldest went, and the newest arrived",
+        )
+        self.assertEqual(
+            self._archive_names(), [], "the archive move failed, so no copy was kept"
+        )
+        self.assertIn("evicted OLDEST entry", err.getvalue())
+
+        with open(pending.evictions_log_path(), encoding="utf-8") as f:
+            line = f.read().strip()
+        self.assertIn(f"evicted={before[0]}", line)
+        self.assertIn(
+            "+archive-failed",
+            line,
+            "the ledger must distinguish 'shed into the archive' from "
+            "'removed outright' — they are different categories of loss",
+        )
+
     def test_byte_cap_also_triggers_eviction(self):
         """Content spans 499 B .. 744 KB, so a count cap alone bounds disk
         only to within ~1500x. Both caps are load-bearing."""
@@ -504,6 +563,48 @@ class DropLedgerTest(_QueueTempDirMixin, unittest.TestCase):
 
         self.assertIsNone(got, "the oversized entry is refused")
         self.assertEqual(pending.count(), 20, "every other entry survived")
+        self.assertIn("larger than the whole", err.getvalue())
+        self.assertEqual(pending.read_drops()["count"], 1)
+
+    def test_an_entry_exactly_at_the_byte_cap_is_enqueued_not_dropped(self):
+        """``blob_bytes > MAX_BYTES``, not ``>=`` (#3599 review R4-La).
+
+        The boundary was pinned in ``_trim_dir``, ``_evict_to_fit``,
+        ``_clamp`` and ``_env_num`` and missed here, so ``>`` → ``>=``
+        survived the suite. It is not equivalent and it is not cosmetic: an
+        entry whose serialised size lands exactly ON the cap DOES fit —
+        ``_evict_to_fit``'s own condition is ``nbytes + incoming >
+        MAX_BYTES``, which an empty queue satisfies — so under the mutant a
+        writable, storable turn becomes a permanent RESIDUAL DROP. That is
+        the one outcome in this module that loses a memory outright, and it
+        would be reached by an entry the queue could have held.
+        """
+        payload = _payload(content="q" * 500, doc="exact-fit")
+        probe = pending.enqueue(payload, RuntimeError("x"))
+        exact = os.path.getsize(probe)
+        os.remove(probe)
+
+        pending.MAX_BYTES = exact
+        with redirect_stderr(io.StringIO()) as err:
+            got = pending.enqueue(payload, RuntimeError("x"))
+
+        self.assertIsNotNone(got, "an entry exactly at the cap fits within it")
+        self.assertEqual(os.path.getsize(got), exact)
+        self.assertEqual(pending.count(), 1)
+        self.assertNotIn("larger than the whole", err.getvalue())
+        self.assertEqual(pending.read_drops(), {}, "nothing was dropped")
+
+    def test_one_byte_over_the_byte_cap_is_refused(self):
+        """The other side of the same boundary, so no single comparison
+        satisfies both cases."""
+        payload = _payload(content="q" * 500, doc="one-over")
+        probe = pending.enqueue(payload, RuntimeError("x"))
+        exact = os.path.getsize(probe)
+        os.remove(probe)
+
+        pending.MAX_BYTES = exact - 1
+        with redirect_stderr(io.StringIO()) as err:
+            self.assertIsNone(pending.enqueue(payload, RuntimeError("x")))
         self.assertIn("larger than the whole", err.getvalue())
         self.assertEqual(pending.read_drops()["count"], 1)
 
@@ -1155,9 +1256,11 @@ class PresenceReconcileGateTest(_QueueTempDirMixin, unittest.TestCase):
     def test_a_successful_in_hook_retain_also_archives_rather_than_deletes(self):
         """One durability rule on one path.
 
-        The in-hook success path retires on a bare 200 while the backlog
-        path insists a 200 is not proof. Archiving both makes the weaker
-        evidence cost a recoverable file rather than a lost turn.
+        The in-hook success path retires on its POST's own 200 (a
+        commit-before-ack, see the test below — NOT a bare async ack, as
+        this docstring used to say) while the backlog path additionally
+        re-GETs. Archiving both makes the weaker evidence cost a
+        recoverable file rather than a lost turn.
         """
         pending.enqueue(_payload(doc=self.BARE_SESSION_ID), RuntimeError("x"))
         name = self._names()[0]
@@ -1169,6 +1272,53 @@ class PresenceReconcileGateTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(summary["drained"], 1)
         self.assertEqual(pending.count(), 0)
         self.assertEqual(self._reconciled_names(), [name])
+
+    def test_the_in_hook_success_path_commits_synchronously_and_never_re_gets(
+        self,
+    ):
+        """The evidence the in-hook retire ACTUALLY rests on (#3599 R4-B3).
+
+        ``pending._trim_dir``'s cap justification names this population by
+        hand — "retires on the POST's own 200 with no confirming GET, and
+        that 200 is a commit-before-ack" — so both halves are pinned here
+        rather than left as prose. Nothing else in the suite fails if the
+        in-hook path goes back to ``async_processing=True`` (making the 200
+        a bare ack, which is what the old comment claimed it already was)
+        or starts issuing a confirming re-GET it has no hook budget for.
+
+        The event log is ordered on purpose: ONE presence GET *before* the
+        POST is the reconcile free pass; the assertion is that nothing
+        follows the POST.
+        """
+        pending.enqueue(_payload(doc=_cd_doc(42)), RuntimeError("x"))
+        events = []
+
+        def fake_state(entry, timeout=30):
+            events.append("GET")
+            return False  # absent → fall through to the POST
+
+        class _Client:
+            def __init__(self, *_a, **_kw):
+                pass
+
+            def retain(self, **kw):
+                events.append(("POST", kw.get("async_processing")))
+                return {}
+
+        with unittest.mock.patch.object(drain_pending, "HindsightClient", _Client):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", fake_state
+            ):
+                summary = drain_pending.drain(CONFIG)
+
+        self.assertEqual(summary["drained"], 1)
+        self.assertEqual(
+            events,
+            ["GET", ("POST", False)],
+            "one presence GET before the POST, a SYNCHRONOUS post, and no "
+            "confirming GET after it",
+        )
+        self.assertEqual(len(self._reconciled_names()), 1)
 
     def test_the_backlog_confirmed_drain_archives_too(self):
         pending.enqueue(_payload(doc=_cd_doc(3)), RuntimeError("x"))
@@ -1342,6 +1492,48 @@ class ClampAndEnvKnobBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(drain_pending._clamp(8, budget=0.0, started=started), 1)
         # Remaining just under the floor.
         self.assertEqual(drain_pending._clamp(8, budget=0.9, started=started), 1)
+
+    def test_the_per_entry_timeout_is_floored_at_one_second(self):
+        """The invariant ``_clamp``'s equivalence proof rests on (R4-Lb).
+
+        ``_clamp``'s docstring argues its own ``max(1, ...)`` mutants are
+        equivalent. They are — but only while ``timeout >= 1``: with
+        ``timeout == 0`` and a healthy budget, ``max(0, min(0, n))`` returns
+        0, an instant-fail request on every entry. Nothing in ``_clamp``
+        rules that input out; ``_per_entry_timeout``'s floor does, and it is
+        the ONLY thing that does, because ``drain`` takes its ``timeout``
+        from here and passes it to both ``_clamp`` callsites. So the proof
+        lives in one function and its precondition lives in another — pin
+        the precondition, or the proof rots the day someone "simplifies"
+        this ``max``.
+        """
+        os.environ["HINDSIGHT_DRAIN_TIMEOUT"] = "0"
+        self.assertEqual(drain_pending._per_entry_timeout(), 1)
+        os.environ["HINDSIGHT_DRAIN_TIMEOUT"] = "-30"
+        self.assertEqual(drain_pending._per_entry_timeout(), 1)
+        os.environ["HINDSIGHT_DRAIN_TIMEOUT"] = "garbage"
+        self.assertEqual(drain_pending._per_entry_timeout(), 5, "default on junk")
+        os.environ["HINDSIGHT_DRAIN_TIMEOUT"] = "9"
+        self.assertEqual(drain_pending._per_entry_timeout(), 9, "a real value passes")
+
+        # And the consequence the floor buys, stated at the clamp: the
+        # smallest timeout _clamp can ever be handed still yields a
+        # non-zero, bounded request.
+        started = time.monotonic()
+        self.assertEqual(
+            drain_pending._clamp(
+                drain_pending._per_entry_timeout(), budget=100.0, started=started
+            ),
+            9,
+        )
+        os.environ["HINDSIGHT_DRAIN_TIMEOUT"] = "0"
+        self.assertEqual(
+            drain_pending._clamp(
+                drain_pending._per_entry_timeout(), budget=100.0, started=started
+            ),
+            1,
+            "a 0s knob must not reach urlopen as a 0s timeout",
+        )
 
     def test_clamp_hands_out_the_remaining_budget_once_past_the_floor(self):
         started = time.monotonic()

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -1132,8 +1132,10 @@ class ArchiveFailureNeverDeletesTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(pending.count(), 3)
 
     def test_in_hook_drain_keeps_an_unarchivable_entry(self):
-        """The bounded SessionStart path retires on a bare 200 and is the
-        one most likely to run on a nearly-full container filesystem."""
+        """The bounded SessionStart path retires on its POST's own
+        commit-before-ack 200 (``async_processing=False``, no confirming
+        GET) and is the one most likely to run on a nearly-full container
+        filesystem."""
         self._queue(2)
         with unittest.mock.patch.object(
             drain_pending, "_retry_one", lambda e, timeout: None

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -199,6 +199,57 @@ class DedupeTest(_QueueTempDirMixin, unittest.TestCase):
         pending.enqueue(_payload(content="two", doc="d1"), RuntimeError("x"))
         self.assertEqual(pending.count(), 2)
 
+    def test_dedupe_survives_an_attempted_entry(self):
+        """The scenario the guard exists for, and the one it used to miss.
+
+        The queued copy is ALWAYS post-``update_attempt`` by the time
+        ``reconcile_tail`` re-enqueues, because the SessionStart drain
+        attempts every entry on every boot. A size-indexed dedupe therefore
+        matched nothing in steady state and the queue grew by one duplicate
+        per boot.
+        """
+        first = pending.enqueue(_payload(content="same", doc="d1"), RuntimeError("x"))
+        _, entry = pending.iter_entries()[0]
+        pending.update_attempt(first, entry, TimeoutError("upstream timed out"))
+        self.assertNotEqual(
+            os.path.getsize(first),
+            len(json.dumps(entry, ensure_ascii=False).encode("utf-8")) - 1,
+        )
+
+        again = pending.enqueue(_payload(content="same", doc="d1"), RuntimeError("x"))
+        self.assertEqual(again, first, "attempted entry must still dedupe")
+        self.assertEqual(pending.count(), 1)
+
+    def test_dedupe_survives_a_different_error_message(self):
+        """The error string is not part of the memory's identity."""
+        a = pending.enqueue(_payload(content="same", doc="d1"), RuntimeError("short"))
+        b = pending.enqueue(
+            _payload(content="same", doc="d1"), ConnectionError("a much longer error")
+        )
+        self.assertEqual(a, b)
+        self.assertEqual(pending.count(), 1)
+
+    def test_dedupe_reads_no_files(self):
+        """The key is in the filename, so a lookup is a listing scan only."""
+        pending.enqueue(_payload(content="same", doc="d1"), RuntimeError("x"))
+        real_open = open
+        queue_dir = self._dir.rstrip("/")
+
+        def no_entry_reads(path, *a, **kw):
+            if os.path.dirname(str(path)) == queue_dir:
+                raise AssertionError(f"dedupe opened a queue entry: {path}")
+            return real_open(path, *a, **kw)
+
+        with unittest.mock.patch("builtins.open", no_entry_reads):
+            self.assertIsNotNone(pending._find_duplicate(self._dir, pending._dupe_key(
+                {"bank_id": "bank-a", "document_id": "d1", "content": "same"}
+            )))
+
+    def test_different_banks_do_not_collide(self):
+        pending.enqueue(_payload(bank="bank-a", content="same"), RuntimeError("x"))
+        pending.enqueue(_payload(bank="bank-b", content="same"), RuntimeError("x"))
+        self.assertEqual(pending.count(), 2)
+
     def test_entry_without_document_id_is_always_kept(self):
         """No document_id => identity cannot be established => never merge."""
         p = _payload()
@@ -275,6 +326,62 @@ class DropLedgerTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertLessEqual(len(stored), pending.MAX_ERROR_MESSAGE_CHARS + 20)
         self.assertTrue(stored.endswith("[truncated]"))
 
+    def test_oversized_entry_is_refused_without_wiping_the_queue(self):
+        """One entry must never cost the whole queue.
+
+        With no guard the eviction loop can never satisfy its condition, so
+        it evicts EVERY entry and writes the oversized one anyway -- and
+        the bounded archive then discards most of what it just shed.
+        """
+        pending.MAX_BYTES = 100_000
+        for i in range(20):
+            pending.enqueue(_payload(content=f"turn-{i}", doc=f"d{i}"), RuntimeError("x"))
+        self.assertEqual(pending.count(), 20)
+
+        with redirect_stderr(io.StringIO()) as err:
+            got = pending.enqueue(
+                _payload(content="z" * 200_000, doc="huge"), RuntimeError("x")
+            )
+
+        self.assertIsNone(got, "the oversized entry is refused")
+        self.assertEqual(pending.count(), 20, "every other entry survived")
+        self.assertIn("larger than the whole", err.getvalue())
+        self.assertEqual(pending.read_drops()["count"], 1)
+
+    def test_corrupt_entry_is_quarantined_not_skipped_forever(self):
+        """A skipped corrupt entry is immortal: never reconciled, never
+        drained, never aged to .dead, but still counted in the depth."""
+        good = pending.enqueue(_payload(), RuntimeError("x"))
+        bad = os.path.join(self._dir, "1700000000000-deadbeefdead.json")
+        with open(bad, "w", encoding="utf-8") as f:
+            f.write("{ not json at all")
+
+        with redirect_stderr(io.StringIO()) as err:
+            entries = pending.iter_entries()
+
+        self.assertEqual([p for p, _ in entries], [good])
+        self.assertFalse(os.path.exists(bad), "no longer occupying a queue slot")
+        self.assertEqual(pending.count(), 1, "no longer inflating the depth")
+        self.assertIn("quarantined", err.getvalue())
+        quarantined = os.path.join(
+            os.path.dirname(self._dir.rstrip("/")), "pending-corrupt"
+        )
+        self.assertEqual(os.listdir(quarantined), [os.path.basename(bad)])
+
+    def test_transient_read_error_is_skipped_not_quarantined(self):
+        """An OSError is not evidence the payload is bad."""
+        pending.enqueue(_payload(), RuntimeError("x"))
+        real_open = open
+
+        def flaky(path, *a, **kw):
+            if str(path).endswith(".json"):
+                raise OSError(11, "Resource temporarily unavailable")
+            return real_open(path, *a, **kw)
+
+        with unittest.mock.patch("builtins.open", flaky):
+            self.assertEqual(pending.iter_entries(), [])
+        self.assertEqual(pending.count(), 1, "entry left intact for the next pass")
+
     def test_healthy_enqueue_writes_no_drop_ledger(self):
         self.assertIsNotNone(pending.enqueue(_payload(), RuntimeError("x")))
         self.assertEqual(pending.read_drops(), {})
@@ -305,10 +412,73 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
             _t.sleep(0.5)
 
         with unittest.mock.patch.object(drain_pending, "_retry_one", slow_ok):
-            summary = drain_pending.drain(CONFIG)
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: False
+            ):
+                summary = drain_pending.drain(CONFIG)
 
         self.assertTrue(summary["budget_exceeded"])
         self.assertLess(summary["drained"], 20)
+        self.assertGreater(pending.count(), 0)
+
+    # The path that ACTUALLY runs on every boot is the sequential drain, not
+    # --backlog. Fixing the re-post loop only in the operator-invoked mode
+    # would change nothing operationally: every agent boot would go on
+    # re-POSTing its already-durable backlog exactly as before.
+    def test_session_start_drain_reconciles_before_re_posting(self):
+        self._queue(6)
+        posted = []
+        durable = {"doc-0", "doc-1", "doc-2", "doc-3"}
+
+        def exists(entry, timeout=30):
+            return entry["document_id"] in durable
+
+        with unittest.mock.patch.object(drain_pending, "_document_state", exists):
+            with unittest.mock.patch.object(
+                drain_pending, "_retry_one", lambda e, timeout: posted.append(e["document_id"])
+            ):
+                summary = drain_pending.drain(CONFIG)
+
+        self.assertEqual(summary["reconciled"], 4)
+        self.assertEqual(
+            sorted(posted),
+            ["doc-4", "doc-5"],
+            "already-durable entries must not be re-POSTed inside the hook",
+        )
+        self.assertEqual(pending.count(), 0)
+
+    def test_session_start_reconcile_never_deletes_on_an_unknown_result(self):
+        """Unknown must fall through to the retry, never to a delete."""
+        self._queue(3)
+        posted = []
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: None
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_retry_one", lambda e, timeout: posted.append(e)
+            ):
+                summary = drain_pending.drain(CONFIG)
+        self.assertEqual(summary["reconciled"], 0)
+        self.assertEqual(len(posted), 3, "unknown falls through to the retry")
+
+    def test_session_start_reconcile_respects_the_hook_budget(self):
+        """The GET replaces the POST; it must not be an extra unbounded call."""
+        self._queue(10)
+        os.environ["HINDSIGHT_DRAIN_BUDGET_S"] = "2"
+        seen = []
+
+        def slow_get(entry, timeout=30):
+            import time as _t
+
+            seen.append(timeout)
+            _t.sleep(0.5)
+            return True
+
+        with unittest.mock.patch.object(drain_pending, "_document_state", slow_get):
+            summary = drain_pending.drain(CONFIG)
+
+        self.assertTrue(summary["budget_exceeded"])
+        self.assertTrue(all(t <= 5 for t in seen), f"timeout not clamped: {seen}")
         self.assertGreater(pending.count(), 0)
 
     def test_reconcile_phase_skips_already_durable_entries_without_posting(self):
@@ -324,7 +494,7 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
 
         with unittest.mock.patch.object(drain_pending, "_document_state", exists):
             with unittest.mock.patch.object(
-                drain_pending, "_retry_one", lambda e, t: posted.append(e)
+                drain_pending, "_retry_one", lambda e, timeout: posted.append(e)
             ):
                 with redirect_stderr(io.StringIO()):
                     summary = drain_pending.drain_backlog(CONFIG, phase="reconcile")
@@ -348,7 +518,7 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
     def test_drain_confirms_the_document_before_deleting_the_entry(self):
         """Commit-before-delete: a 200 is an ack, not proof (#3244)."""
         self._queue(2)
-        with unittest.mock.patch.object(drain_pending, "_retry_one", lambda e, t: None):
+        with unittest.mock.patch.object(drain_pending, "_retry_one", lambda e, timeout: None):
             # POST succeeds, but the document is still not there.
             with unittest.mock.patch.object(
                 drain_pending, "_document_state", lambda e, timeout=30: False
@@ -362,7 +532,7 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
 
     def test_drain_deletes_once_the_document_is_confirmed(self):
         self._queue(5)
-        with unittest.mock.patch.object(drain_pending, "_retry_one", lambda e, t: None):
+        with unittest.mock.patch.object(drain_pending, "_retry_one", lambda e, timeout: None):
             with unittest.mock.patch.object(
                 drain_pending, "_document_state", lambda e, timeout=30: True
             ):
@@ -389,7 +559,7 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
         os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = "90"
         seen = []
         with unittest.mock.patch.object(
-            drain_pending, "_retry_one", lambda e, t: seen.append(t)
+            drain_pending, "_retry_one", lambda e, timeout: seen.append(timeout)
         ):
             with unittest.mock.patch.object(
                 drain_pending, "_document_state", lambda e, timeout=30: True
@@ -410,7 +580,7 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
         ):
             with unittest.mock.patch.object(drain_pending.time, "sleep", slept.append):
                 with unittest.mock.patch.object(
-                    drain_pending, "_retry_one", lambda e, t: None
+                    drain_pending, "_retry_one", lambda e, timeout: None
                 ):
                     with unittest.mock.patch.object(
                         drain_pending, "_document_state", lambda e, timeout=30: True
@@ -421,6 +591,31 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(slept.count(120), 2, "backed off until p95 recovered")
         self.assertIn("BACKOFF", err.getvalue())
         self.assertEqual(summary["drained"], 1)
+
+    def test_p95_backoff_is_bounded_by_the_drain_budget(self):
+        """A persistently slow upstream must not block past the budget.
+
+        An unbounded `while True: sleep(120)` would run indefinitely, past
+        the one guarantee this mode makes about how long it will run.
+        """
+        self._queue(2)
+        os.environ["HINDSIGHT_DRAIN_BACKLOG_BUDGET_S"] = "60"
+        slept = []
+
+        with unittest.mock.patch.object(
+            drain_pending, "_p95_probe_ms", lambda: 99000
+        ):
+            with unittest.mock.patch.object(drain_pending.time, "sleep", slept.append):
+                with unittest.mock.patch.object(
+                    drain_pending, "_retry_one", lambda e, timeout: None
+                ):
+                    with redirect_stderr(io.StringIO()) as err:
+                        summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+
+        self.assertEqual(slept, [], "60s budget cannot absorb a 120s pause")
+        self.assertTrue(summary["budget_exceeded"])
+        self.assertIn("budget is exhausted", err.getvalue())
+        self.assertEqual(pending.count(), 2, "entries stay queued")
 
     def test_absent_p95_probe_does_not_block(self):
         os.environ.pop("HINDSIGHT_DRAIN_P95_CMD", None)

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -23,6 +23,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 import unittest
 import unittest.mock
 from contextlib import redirect_stderr
@@ -761,6 +762,31 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(summary["unknown"], 2)
         self.assertEqual(pending.count(), 2, "unconfirmed entries stay queued")
 
+    def test_drain_never_retires_an_entry_on_an_unknown_result(self):
+        """Unknown != confirmed, on the PHASE-2 path too (#3599 review R3-B1).
+
+        The realistic shape: the POST returns 200, the confirming GET hits a
+        503 or times out, so ``_document_state`` is ``None``. Counting that
+        as durable archives the entry and it is never retried — a degraded
+        upstream is exactly the condition this PR exists for. Mirrors
+        ``test_reconcile_never_drops_an_entry_on_an_unknown_result``; its
+        absence left ``is True`` at the phase-2 site mutable to
+        ``is not False`` with both suites green.
+        """
+        self._queue(4)
+        with unittest.mock.patch.object(
+            drain_pending, "_retry_one", lambda e, timeout: None
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: None
+            ):
+                with redirect_stderr(io.StringIO()):
+                    summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+
+        self.assertEqual(summary["drained"], 0, "unknown is not a drain")
+        self.assertEqual(summary["unknown"], 4)
+        self.assertEqual(pending.count(), 4, "unconfirmed entries stay queued")
+
     def test_drain_deletes_once_the_document_is_confirmed(self):
         self._queue(5)
         with unittest.mock.patch.object(drain_pending, "_retry_one", lambda e, timeout: None):
@@ -907,6 +933,122 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
                 )
         self.assertEqual(summary["reconciled"], 3)
         self.assertEqual(pending.count(), 3, "a dry run must not delete anything")
+
+
+class ArchiveFailureNeverDeletesTest(_QueueTempDirMixin, unittest.TestCase):
+    """A failure to ARCHIVE is not a licence to DELETE (#3599 review R3-M1).
+
+    The previous ``archive_reconciled`` fell back to ``delete_entry`` on
+    ``OSError``. Reproduced: ENOSPC from ``os.makedirs`` removed the entry,
+    left ``pending-reconciled/`` empty, and emitted nothing at all — silent,
+    unrecorded, irreversible loss of the last on-disk copy of a turn. That
+    falsified, verbatim, four separate claims (``drain_pending``'s module
+    docstring, ``switchroom doctor``'s backlog fix text, the CHANGELOG, and
+    the PR body). The claims are now true because the code is.
+    """
+
+    def _queue(self, n):
+        for i in range(n):
+            pending.enqueue(
+                _payload(content=f"turn-{i}", doc=_cd_doc(i)), RuntimeError("boom")
+            )
+        self.assertEqual(pending.count(), n)
+
+    @staticmethod
+    def _enospc(*_a, **_kw):
+        raise OSError(28, "No space left on device")
+
+    def test_archive_reconciled_keeps_the_entry_when_the_archive_is_unwritable(self):
+        self._queue(1)
+        path = os.path.join(self._dir, self._names()[0])
+        err = io.StringIO()
+        with unittest.mock.patch.object(pending.os, "makedirs", self._enospc):
+            with redirect_stderr(err):
+                dest = pending.archive_reconciled(path)
+
+        self.assertIsNone(dest, "a failed archive reports failure, not a dest")
+        self.assertTrue(
+            os.path.exists(path),
+            "the entry is the ONLY on-disk copy of the turn; a full disk "
+            "must not destroy it",
+        )
+        self.assertEqual(pending.count(), 1)
+        self.assertEqual(self._reconciled_names(), [])
+
+    def test_archive_failure_is_loud_on_stderr(self):
+        """Silent loss was the worst part of the old behaviour. Even now
+        that nothing is lost, an unwritable archive must be visible."""
+        self._queue(1)
+        path = os.path.join(self._dir, self._names()[0])
+        err = io.StringIO()
+        with unittest.mock.patch.object(pending.os, "makedirs", self._enospc):
+            with redirect_stderr(err):
+                pending.archive_reconciled(path)
+        msg = err.getvalue()
+        self.assertIn(os.path.basename(path), msg)
+        self.assertIn("No space left on device", msg)
+        self.assertRegex(msg, r"STAYS QUEUED")
+
+    def test_the_queue_module_exposes_no_delete_primitive(self):
+        """Structural, not aspirational: with no ``delete_entry`` there is
+        no branch by which the drain path can ``os.remove`` a live entry."""
+        self.assertFalse(
+            hasattr(pending, "delete_entry"),
+            "re-adding a delete primitive re-opens the silent-loss path",
+        )
+
+    def test_backlog_drain_counts_an_unarchivable_entry_as_not_retired(self):
+        """The summary must not claim a retire that did not happen: the
+        entry is still queued, so ``drained`` would be a lie."""
+        self._queue(3)
+        with unittest.mock.patch.object(
+            drain_pending, "_retry_one", lambda e, timeout: None
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: True
+            ):
+                with unittest.mock.patch.object(
+                    pending.os, "makedirs", self._enospc
+                ):
+                    with redirect_stderr(io.StringIO()):
+                        summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+
+        self.assertEqual(summary["drained"], 0)
+        self.assertEqual(summary["archive_failed"], 3)
+        self.assertEqual(pending.count(), 3, "every entry survives a full disk")
+
+    def test_reconcile_phase_counts_an_unarchivable_entry_as_not_retired(self):
+        self._queue(3)
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: True
+        ):
+            with unittest.mock.patch.object(pending.os, "makedirs", self._enospc):
+                with redirect_stderr(io.StringIO()):
+                    summary = drain_pending.drain_backlog(CONFIG, phase="reconcile")
+
+        self.assertEqual(summary["reconciled"], 0)
+        self.assertEqual(summary["archive_failed"], 3)
+        self.assertEqual(pending.count(), 3)
+
+    def test_in_hook_drain_keeps_an_unarchivable_entry(self):
+        """The bounded SessionStart path retires on a bare 200 and is the
+        one most likely to run on a nearly-full container filesystem."""
+        self._queue(2)
+        with unittest.mock.patch.object(
+            drain_pending, "_retry_one", lambda e, timeout: None
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: False
+            ):
+                with unittest.mock.patch.object(
+                    pending.os, "makedirs", self._enospc
+                ):
+                    with redirect_stderr(io.StringIO()):
+                        summary = drain_pending.drain(CONFIG)
+
+        self.assertEqual(summary["drained"], 0)
+        self.assertEqual(summary["archive_failed"], 2)
+        self.assertEqual(pending.count(), 2)
 
 
 class PresenceReconcileGateTest(_QueueTempDirMixin, unittest.TestCase):
@@ -1066,8 +1208,17 @@ class PresenceReconcileGateTest(_QueueTempDirMixin, unittest.TestCase):
         finally:
             pending.RECONCILED_MAX_ENTRIES = prev
 
-    def test_an_unwritable_archive_still_retires_the_entry(self):
-        """A queue that cannot retire entries re-POSTs them forever."""
+    def test_an_unwritable_archive_keeps_the_entry_rather_than_deleting_it(self):
+        """REVERSED from the original assertion, deliberately (#3599 R3-M1).
+
+        This case used to assert ``pending.count() == 0`` — i.e. that a
+        failed archive deleted the entry — on the reasoning that a queue
+        which cannot retire re-POSTs forever. That trade is backwards: the
+        re-POST loop costs duplicated LLM extraction on a disk-full box,
+        and the delete costs the last on-disk copy of the turn, silently.
+        Sheds the cheaper failure; ``archive_failed`` keeps the summary
+        honest about the entry still being queued.
+        """
         pending.enqueue(_payload(doc=_cd_doc(9)), RuntimeError("x"))
         with unittest.mock.patch.object(
             pending.shutil, "move", side_effect=OSError(28, "No space left")
@@ -1075,9 +1226,147 @@ class PresenceReconcileGateTest(_QueueTempDirMixin, unittest.TestCase):
             with unittest.mock.patch.object(
                 drain_pending, "_document_state", lambda e, timeout=30: True
             ):
-                summary = drain_pending.drain(CONFIG)
-        self.assertEqual(summary["reconciled"], 1)
-        self.assertEqual(pending.count(), 0, "the entry must not stay queued")
+                with redirect_stderr(io.StringIO()) as err:
+                    summary = drain_pending.drain(CONFIG)
+        self.assertEqual(summary["reconciled"], 0, "nothing was retired")
+        self.assertEqual(summary["archive_failed"], 1)
+        self.assertEqual(pending.count(), 1, "the only copy of the turn survives")
+        self.assertIn("No space left", err.getvalue())
+
+
+class TrimDirBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
+    """``_trim_dir``'s caps, at the boundary (#3599 review R3-L2).
+
+    A separate site from the enqueue cap in ``_evict_to_fit`` (pinned by
+    ``EvictionTest``): ``>`` → ``>=`` here survived the whole sweep. Off by
+    one in this direction sheds one archived copy on every call forever,
+    including on a directory that is exactly at its cap.
+    """
+
+    def _archive(self, sizes):
+        """Write ``len(sizes)`` archive files of the given byte sizes."""
+        d = os.path.join(self._tmp, "arch")
+        os.makedirs(d, exist_ok=True)
+        for i, n in enumerate(sizes):
+            with open(os.path.join(d, f"{1000 + i:013d}-x.json"), "w") as f:
+                f.write("x" * n)
+        return d
+
+    def _names_in(self, d):
+        return sorted(n for n in os.listdir(d) if n.endswith(".json"))
+
+    def test_exactly_at_the_byte_cap_is_within_it(self):
+        d = self._archive([10, 10, 10])
+        with redirect_stderr(io.StringIO()) as err:
+            dropped = pending._trim_dir(d, max_entries=99, max_bytes=30)
+        self.assertEqual(dropped, 0, "30 bytes under a 30-byte cap fits")
+        self.assertEqual(len(self._names_in(d)), 3)
+        self.assertEqual(err.getvalue(), "", "nothing dropped, nothing logged")
+
+    def test_one_byte_over_the_cap_sheds_the_oldest_only(self):
+        d = self._archive([10, 10, 11])
+        with redirect_stderr(io.StringIO()):
+            dropped = pending._trim_dir(d, max_entries=99, max_bytes=30)
+        self.assertEqual(dropped, 1)
+        self.assertEqual(
+            self._names_in(d),
+            [f"{1001:013d}-x.json", f"{1002:013d}-x.json"],
+            "oldest first — the newest archived copy is the one worth keeping",
+        )
+
+    def test_exactly_at_the_count_cap_is_within_it(self):
+        d = self._archive([1, 1, 1])
+        self.assertEqual(pending._trim_dir(d, max_entries=3, max_bytes=10**9), 0)
+        self.assertEqual(len(self._names_in(d)), 3)
+
+    def test_one_over_the_count_cap_sheds_exactly_one(self):
+        d = self._archive([1, 1, 1, 1])
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending._trim_dir(d, max_entries=3, max_bytes=10**9), 1)
+        self.assertEqual(len(self._names_in(d)), 3)
+
+    def test_a_trim_names_what_it_dropped_on_stderr(self):
+        """The archive caps are 4x smaller than the queue caps, so a
+        full-queue drain trims. Silent trimming makes "archived, never
+        deleted" a half-truth; the log line is the other half."""
+        d = self._archive([1] * 6)
+        with redirect_stderr(io.StringIO()) as err:
+            pending._trim_dir(d, max_entries=2, max_bytes=10**9)
+        msg = err.getvalue()
+        self.assertIn("trimmed 4 archived copies", msg)
+        self.assertIn(f"{1000:013d}-x.json", msg, "names the oldest dropped")
+        self.assertIn("arch", msg, "names the directory")
+
+    def test_a_large_trim_caps_the_name_list(self):
+        """A 1500-entry trim must not emit a 1500-name line."""
+        d = self._archive([1] * 20)
+        with redirect_stderr(io.StringIO()) as err:
+            pending._trim_dir(d, max_entries=2, max_bytes=10**9)
+        msg = err.getvalue()
+        self.assertIn("trimmed 18 archived copies", msg)
+        self.assertIn("+8 more", msg)
+        self.assertLessEqual(msg.count("-x.json"), 10)
+
+
+class ClampAndEnvKnobBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
+    """``_clamp``'s floor and ``_env_num``'s clamps (#3599 review R3-L4)."""
+
+    def test_clamp_floors_at_one_second_never_zero(self):
+        """A 0s timeout fails instantly, turning a near-exhausted budget
+        into a guaranteed failure rather than one last bounded shot."""
+        started = time.monotonic()
+        # Budget already fully spent: remaining <= 0.
+        self.assertEqual(drain_pending._clamp(8, budget=0.0, started=started), 1)
+        # Remaining just under the floor.
+        self.assertEqual(drain_pending._clamp(8, budget=0.9, started=started), 1)
+
+    def test_clamp_hands_out_the_remaining_budget_once_past_the_floor(self):
+        started = time.monotonic()
+        self.assertEqual(drain_pending._clamp(8, budget=3.9, started=started), 3)
+        self.assertEqual(
+            drain_pending._clamp(2, budget=100.0, started=started),
+            2,
+            "the caller's timeout still wins when the budget is ample",
+        )
+
+    def test_env_num_lo_clamp_raises_a_too_small_value(self):
+        os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = "0"
+        self.assertEqual(
+            drain_pending._backlog_timeout(), 1, "lo=1 must raise 0 to 1"
+        )
+        os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = "-5"
+        self.assertEqual(drain_pending._backlog_timeout(), 1)
+
+    def test_env_num_lo_is_inclusive_and_leaves_larger_values_alone(self):
+        os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = "1"
+        self.assertEqual(drain_pending._backlog_timeout(), 1)
+        os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = "45"
+        self.assertEqual(drain_pending._backlog_timeout(), 45)
+
+    def test_env_num_hi_clamp_lowers_a_too_large_value(self):
+        os.environ["HINDSIGHT_DRAIN_CONCURRENCY"] = "17"
+        self.assertEqual(drain_pending._backlog_concurrency(), 16)
+        os.environ["HINDSIGHT_DRAIN_CONCURRENCY"] = "16"
+        self.assertEqual(drain_pending._backlog_concurrency(), 16)
+
+    def test_env_num_falls_back_to_the_default_on_garbage(self):
+        os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = "not-a-number"
+        self.assertEqual(drain_pending._backlog_timeout(), 180)
+        os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = ""
+        self.assertEqual(
+            drain_pending._backlog_timeout(), 180, "empty is unset, not 0"
+        )
+
+    def test_no_clamp_is_applied_when_lo_and_hi_are_absent(self):
+        """``lo``/``hi`` default to ``None``; that branch must be a no-op,
+        not an accidental floor at 0."""
+        os.environ["X_TEST_KNOB"] = "-42"
+        try:
+            self.assertEqual(
+                drain_pending._env_num("X_TEST_KNOB", 1, int), -42
+            )
+        finally:
+            os.environ.pop("X_TEST_KNOB", None)
 
 
 class P95ProbeTest(_QueueTempDirMixin, unittest.TestCase):
@@ -1140,6 +1429,245 @@ class CliTest(unittest.TestCase):
         with redirect_stderr(io.StringIO()):
             rc, _ = self._run(["--phase", "reconcile"])
         self.assertEqual(rc, 2)
+
+
+class StallGuardBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
+    """The stall guard counts CONSECUTIVE failures of the SAME class.
+
+    Every prior stall test drove a homogeneous error stream, which cannot
+    tell ``err_class == last_error_class`` from ``!=``: with one class the
+    mutant takes the increment branch every time and the reset branch is
+    never reached, so the drain stalls identically. Distinguishing them
+    needs an ALTERNATING stream, where the real guard resets and the
+    mutant stalls. Same false-green shape as Blocker 1 — the assertion
+    exercised the code without pinning the invariant.
+    """
+
+    def _queue(self, n):
+        for i in range(n):
+            pending.enqueue(
+                _payload(content=f"turn-{i}", doc=_cd_doc(i)), RuntimeError("boom")
+            )
+        self.assertEqual(pending.count(), n)
+
+    def _alternating(self):
+        """A failure stream whose error CLASS changes every entry."""
+        classes = [ConnectionError, TimeoutError]
+        n = {"i": 0}
+
+        def fail(entry, timeout):
+            cls = classes[n["i"] % 2]
+            n["i"] += 1
+            raise cls("upstream flapping")
+
+        return fail
+
+    def test_alternating_error_classes_never_stall_the_drain(self):
+        self._queue(6)
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: False
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_retry_one", self._alternating()
+            ):
+                with redirect_stderr(io.StringIO()):
+                    summary = drain_pending.drain(CONFIG)
+
+        self.assertFalse(
+            summary["stalled"],
+            "a flapping upstream is not a stall — the counter must RESET "
+            "when the error class changes",
+        )
+        self.assertEqual(summary["retried"], 6, "every entry got its attempt")
+        self.assertEqual(pending.count(), 6, "failed entries stay queued")
+
+    def test_alternating_error_classes_never_stall_the_backlog_drain(self):
+        self._queue(6)
+        os.environ["HINDSIGHT_DRAIN_CONCURRENCY"] = "1"
+        with unittest.mock.patch.object(
+            drain_pending, "_retry_one", self._alternating()
+        ):
+            with redirect_stderr(io.StringIO()):
+                summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+
+        self.assertFalse(summary["stalled"])
+        self.assertEqual(summary["retried"], 6)
+        self.assertEqual(pending.count(), 6)
+
+    def test_the_drain_stalls_at_exactly_stall_threshold(self):
+        """AT the threshold, not one past it.
+
+        Queueing exactly ``STALL_THRESHOLD`` entries is what separates
+        ``>=`` from ``>``: with ``>`` the run ends by exhausting the queue
+        and reports no stall at all.
+        """
+        self._queue(drain_pending.STALL_THRESHOLD)
+
+        def always_fail(entry, timeout):
+            raise ConnectionError("upstream down")
+
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: False
+        ):
+            with unittest.mock.patch.object(drain_pending, "_retry_one", always_fail):
+                with redirect_stderr(io.StringIO()) as err:
+                    summary = drain_pending.drain(CONFIG)
+
+        self.assertTrue(summary["stalled"])
+        self.assertIn("stalling drain", err.getvalue())
+        self.assertEqual(pending.count(), drain_pending.STALL_THRESHOLD)
+
+
+class BudgetBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
+    """The budget is spent DOWN TO the tick, not one tick short.
+
+    ``elapsed > budget`` vs ``>=`` is invisible to every wall-clock test
+    (real elapsed never lands exactly on the budget), so both loops are
+    driven here on a virtual clock that lands on it exactly.
+    """
+
+    def _queue(self, n):
+        for i in range(n):
+            pending.enqueue(
+                _payload(content=f"turn-{i}", doc=_cd_doc(i)), RuntimeError("boom")
+            )
+
+    def test_the_sequential_drain_uses_the_last_tick_of_its_budget(self):
+        self._queue(2)
+        os.environ["HINDSIGHT_DRAIN_BUDGET_S"] = "10"
+        os.environ["HINDSIGHT_DRAIN_TIMEOUT"] = "10"
+        start = 1000.0
+        clock = {"t": start}
+        gets = []
+
+        def fake_get(entry, timeout=30):
+            gets.append(timeout)
+            clock["t"] = start + 10.0  # entry 1 consumes the budget EXACTLY
+            return True
+
+        with unittest.mock.patch.object(
+            drain_pending.time, "monotonic", lambda: clock["t"]
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", fake_get
+            ):
+                summary = drain_pending.drain(CONFIG)
+
+        self.assertEqual(len(gets), 2, "entry 2 is still inside the budget at t==B")
+        self.assertEqual(summary["reconciled"], 2)
+        self.assertFalse(summary["budget_exceeded"])
+        self.assertEqual(pending.count(), 0)
+
+    def test_the_backlog_wave_loop_uses_the_last_tick_of_its_budget(self):
+        self._queue(2)
+        os.environ["HINDSIGHT_DRAIN_BACKLOG_BUDGET_S"] = "10"
+        os.environ["HINDSIGHT_DRAIN_CONCURRENCY"] = "1"
+        # Keep _wait_for_upstream off the clock; its own boundary is pinned
+        # by WaitForUpstreamBoundaryTest.
+        os.environ["HINDSIGHT_DRAIN_P95_BACKOFF_MS"] = "0"
+        start = 1000.0
+        clock = {"t": start}
+
+        def fake_post(entry, timeout):
+            clock["t"] = start + 10.0  # wave 1 consumes the budget EXACTLY
+
+        with unittest.mock.patch.object(
+            drain_pending.time, "monotonic", lambda: clock["t"]
+        ):
+            with unittest.mock.patch.object(drain_pending, "_retry_one", fake_post):
+                with unittest.mock.patch.object(
+                    drain_pending, "_document_state", lambda e, timeout=30: True
+                ):
+                    with redirect_stderr(io.StringIO()):
+                        summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+
+        self.assertEqual(summary["drained"], 2, "wave 2 starts at exactly t==B")
+        self.assertFalse(summary["budget_exceeded"])
+        self.assertEqual(pending.count(), 0)
+
+
+class WaitForUpstreamBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
+    """``_wait_for_upstream`` called directly — its three comparisons.
+
+    Driving it through ``drain_backlog`` only ever exercised the
+    disabled/slow/recovered cases; the boundaries below all survived a
+    mutation sweep because no test pinned them.
+    """
+
+    def _wait(self, backoff_ms, probes, now=1000.0, started=1000.0, budget=3600.0):
+        slept = []
+        seq = list(probes)
+        with unittest.mock.patch.object(
+            drain_pending.time, "monotonic", lambda: now
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_p95_probe_ms", lambda: seq.pop(0)
+            ):
+                with unittest.mock.patch.object(
+                    drain_pending.time, "sleep", slept.append
+                ):
+                    with redirect_stderr(io.StringIO()) as err:
+                        got = drain_pending._wait_for_upstream(
+                            backoff_ms, started, budget
+                        )
+        return got, slept, err.getvalue()
+
+    def test_backoff_disabled_never_pauses_even_when_the_probe_says_slow(self):
+        """``backoff_ms <= 0`` means OFF — the probe is not consulted.
+
+        With ``<`` instead of ``<=``, a 0 (explicitly disabled) falls into
+        the wait loop and a configured probe reporting 99s of p95 pauses
+        the drain for two minutes a wave. Disabled must mean disabled.
+        """
+        got, slept, _ = self._wait(0, [99000, 99000, 99000])
+        self.assertTrue(got)
+        self.assertEqual(slept, [], "a disabled backoff must never sleep")
+
+    def test_a_p95_exactly_at_the_threshold_is_not_slow(self):
+        """The knob is the tolerated ceiling, inclusive."""
+        got, slept, out = self._wait(38000, [38000])
+        self.assertTrue(got)
+        self.assertEqual(slept, [])
+        self.assertNotIn("BACKOFF", out)
+
+    def test_one_ms_over_the_threshold_is_slow(self):
+        got, slept, out = self._wait(38000, [38001, 38000])
+        self.assertTrue(got)
+        self.assertEqual(slept, [120], "paused once, then p95 came back in")
+        self.assertIn("BACKOFF", out)
+
+    def test_it_still_waits_when_the_pause_exactly_fits_the_budget(self):
+        """120s of pause with exactly 120s left is affordable, not a give-up.
+
+        ``elapsed + 120 > budget`` vs ``>=``: only a clock that lands
+        exactly on the budget separates them, so this one is virtual.
+        """
+        got, slept, out = self._wait(
+            38000, [99000, 1000], now=1120.0, started=1000.0, budget=240.0
+        )
+        self.assertTrue(got, "the wait fit the budget, so it must be taken")
+        self.assertEqual(slept, [120])
+        self.assertNotIn("budget is exhausted", out)
+
+    def test_it_gives_up_when_the_pause_would_overrun_the_budget(self):
+        got, slept, out = self._wait(
+            38000, [99000], now=1121.0, started=1000.0, budget=240.0
+        )
+        self.assertFalse(got)
+        self.assertEqual(slept, [])
+        self.assertIn("budget is exhausted", out)
+
+    def test_a_zero_p95_is_fast_not_unknown(self):
+        """``p95 < 0`` is the UNKNOWN sentinel; 0 is a real, fast reading.
+
+        (``< 0`` vs ``<= 0`` is an equivalent mutant here — a 0 reading
+        returns True down either branch, since it is also ``<= backoff_ms``
+        for any enabled backoff. Pinned anyway: the OUTCOME is what the
+        drain depends on, and it must not become a pause.)
+        """
+        got, slept, _ = self._wait(38000, [0])
+        self.assertTrue(got)
+        self.assertEqual(slept, [])
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -1,0 +1,525 @@
+"""Queue eviction/dedupe + two-phase backlog drain (switchroom #3596).
+
+These live under ``scripts/tests/`` deliberately: that is the ONLY python
+test directory CI discovers (``ci-tests-python.yml:63`` and
+``ci-full.yml:140`` both run ``python3 -m unittest discover tests/`` with
+``working-directory: vendor/hindsight-memory/scripts``). The sibling suite
+at ``vendor/hindsight-memory/tests/`` is never executed by CI, so a
+regression test placed there would gate nothing.
+
+The behaviours pinned here are the ones a well-meaning refactor would
+otherwise undo:
+  * eviction sheds the OLDEST entry, never the incoming newest one;
+  * reconcile-before-retain, so an already-durable document is not
+    re-extracted at LLM cost;
+  * commit-before-delete -- a 200 is an ack, not proof;
+  * backlog concurrency defaults to 1 (the model pool is fleet-shared);
+  * the stall guard does not overshoot under concurrency.
+"""
+
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import unittest.mock
+from contextlib import redirect_stderr
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import drain_pending  # noqa: E402
+import lib.pending as pending  # noqa: E402
+
+CONFIG = {"debug": False}
+
+
+def _payload(bank="bank-a", content="hello", doc="doc-1"):
+    return {
+        "api_url": "http://127.0.0.1:9/none",
+        "api_token": None,
+        "bank_id": bank,
+        "document_id": doc,
+        "content": content,
+        "context": None,
+        "metadata": {},
+        "tags": None,
+    }
+
+
+class _QueueTempDirMixin:
+    #: env knobs a case may set; restored in tearDown so none can leak.
+    ENV_KEYS = (
+        "HINDSIGHT_PENDING_DIR",
+        "HINDSIGHT_PENDING_EVICTED_DIR",
+        "HINDSIGHT_DRAIN_BUDGET_S",
+        "HINDSIGHT_DRAIN_BACKLOG_BUDGET_S",
+        "HINDSIGHT_DRAIN_BACKLOG_TIMEOUT",
+        "HINDSIGHT_DRAIN_CONCURRENCY",
+        "HINDSIGHT_DRAIN_SLEEP_S",
+        "HINDSIGHT_DRAIN_P95_CMD",
+        "HINDSIGHT_DRAIN_P95_BACKOFF_MS",
+    )
+
+    def setUp(self):
+        self._env_prev = {k: os.environ.get(k) for k in self.ENV_KEYS}
+        self._tmp = tempfile.mkdtemp(prefix="hindsight-pending-test-")
+        self._dir = os.path.join(self._tmp, "pending-retains")
+        os.environ["HINDSIGHT_PENDING_DIR"] = self._dir
+        # Backlog replay paces itself by default; tests must not sleep.
+        os.environ["HINDSIGHT_DRAIN_SLEEP_S"] = "0"
+        self._caps_prev = (pending.MAX_ENTRIES, pending.MAX_BYTES)
+
+    def tearDown(self):
+        pending.MAX_ENTRIES, pending.MAX_BYTES = self._caps_prev
+        for k, v in self._env_prev.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _names(self):
+        return sorted(n for n in os.listdir(self._dir) if n.endswith(".json"))
+
+    def _archive_names(self):
+        try:
+            return sorted(os.listdir(pending.evicted_dir()))
+        except OSError:
+            return []
+
+
+class EvictionTest(_QueueTempDirMixin, unittest.TestCase):
+    """A full queue must shed the OLDEST entry, not refuse the newest.
+
+    The pre-fix behaviour returned ``None`` at the cap, i.e. it threw away
+    the turn that had just happened -- the one most likely to still matter
+    -- and kept a queue full of stale entries instead.
+    """
+
+    def test_full_queue_evicts_oldest_and_keeps_the_newest(self):
+        pending.MAX_ENTRIES = 3
+        # Entry filenames are `<unix-ms>-<uuid>.json` and FIFO order is the
+        # lexicographic sort of that name. Real entries are milliseconds
+        # apart; a test that enqueues four inside one millisecond would
+        # tie-break on the random uuid instead, so pin the clock.
+        clock = iter(1000.0 + i for i in range(10))
+        with unittest.mock.patch.object(pending.time, "time", lambda: next(clock)):
+            first = pending.enqueue(
+                _payload(content="oldest", doc="d0"), RuntimeError("x")
+            )
+            for i in range(1, 3):
+                pending.enqueue(
+                    _payload(content=f"mid-{i}", doc=f"d{i}"), RuntimeError("x")
+                )
+            self.assertEqual(len(self._names()), 3)
+
+            with redirect_stderr(io.StringIO()) as err:
+                newest = pending.enqueue(
+                    _payload(content="NEWEST", doc="d9"), RuntimeError("x")
+                )
+
+        self.assertIsNotNone(newest, "the incoming entry must never be refused")
+        self.assertEqual(len(self._names()), 3, "cap still honoured")
+        self.assertFalse(os.path.exists(first), "the OLDEST entry was evicted")
+        with open(newest, encoding="utf-8") as f:
+            self.assertEqual(json.load(f)["content"], "NEWEST")
+        self.assertIn("evicted OLDEST", err.getvalue())
+
+    def test_eviction_archives_rather_than_deletes(self):
+        pending.MAX_ENTRIES = 2
+        pending.enqueue(_payload(content="a", doc="d0"), RuntimeError("x"))
+        pending.enqueue(_payload(content="b", doc="d1"), RuntimeError("x"))
+        with redirect_stderr(io.StringIO()):
+            pending.enqueue(_payload(content="c", doc="d2"), RuntimeError("x"))
+        self.assertEqual(len(self._archive_names()), 1)
+
+    def test_byte_cap_also_triggers_eviction(self):
+        """Content spans 499 B .. 744 KB, so a count cap alone bounds disk
+        only to within ~1500x. Both caps are load-bearing."""
+        pending.MAX_ENTRIES = 1000
+        pending.enqueue(_payload(content="x" * 4000, doc="d0"), RuntimeError("x"))
+        pending.MAX_BYTES = 5000
+        with redirect_stderr(io.StringIO()):
+            pending.enqueue(_payload(content="y" * 4000, doc="d1"), RuntimeError("x"))
+        self.assertEqual(len(self._names()), 1)
+        self.assertEqual(len(self._archive_names()), 1)
+
+    def test_eviction_is_logged_to_the_ledger(self):
+        """Eviction is not silent loss, but it IS loss -- doctor reads this."""
+        pending.MAX_ENTRIES = 1
+        pending.enqueue(_payload(doc="d0"), RuntimeError("x"))
+        with redirect_stderr(io.StringIO()):
+            pending.enqueue(_payload(doc="d1"), RuntimeError("x"))
+        with open(pending.evictions_log_path(), encoding="utf-8") as f:
+            line = f.read().strip()
+        self.assertIn("evicted=", line)
+        self.assertIn("reason=count", line)
+        self.assertIn("queue_depth=", line)
+
+    def test_archive_is_itself_bounded(self):
+        """Eviction must not merely relocate the disk problem."""
+        pending.MAX_ENTRIES = 1
+        prev = pending.ARCHIVE_MAX_ENTRIES
+        pending.ARCHIVE_MAX_ENTRIES = 2
+        try:
+            with redirect_stderr(io.StringIO()):
+                for i in range(6):
+                    pending.enqueue(_payload(doc=f"d{i}"), RuntimeError("x"))
+            self.assertLessEqual(len(self._archive_names()), 2)
+        finally:
+            pending.ARCHIVE_MAX_ENTRIES = prev
+
+    def test_ledgers_live_outside_the_queue_dir(self):
+        """So they can never be listed as an entry, drained, or counted."""
+        pending.MAX_ENTRIES = 1
+        pending.enqueue(_payload(doc="d0"), RuntimeError("x"))
+        with redirect_stderr(io.StringIO()):
+            pending.enqueue(_payload(doc="d1"), RuntimeError("x"))
+        for p in (pending.evictions_log_path(), pending.drops_path()):
+            self.assertNotEqual(os.path.dirname(p), self._dir.rstrip("/"))
+        self.assertEqual(pending.count(), 1)
+
+
+class DedupeTest(_QueueTempDirMixin, unittest.TestCase):
+    """``reconcile_tail`` re-enqueues the same slice on every boot until its
+    watermark is confirmed -- 63% of one measured fleet queue was dupes."""
+
+    def test_identical_entry_returns_the_existing_path(self):
+        a = pending.enqueue(_payload(content="same", doc="d1"), RuntimeError("x"))
+        b = pending.enqueue(_payload(content="same", doc="d1"), RuntimeError("x"))
+        self.assertEqual(a, b)
+        self.assertEqual(pending.count(), 1)
+
+    def test_different_content_is_not_deduped(self):
+        pending.enqueue(_payload(content="one", doc="d1"), RuntimeError("x"))
+        pending.enqueue(_payload(content="two", doc="d1"), RuntimeError("x"))
+        self.assertEqual(pending.count(), 2)
+
+    def test_entry_without_document_id_is_always_kept(self):
+        """No document_id => identity cannot be established => never merge."""
+        p = _payload()
+        p.pop("document_id")
+        pending.enqueue(dict(p), RuntimeError("x"))
+        pending.enqueue(dict(p), RuntimeError("x"))
+        self.assertEqual(pending.count(), 2)
+
+
+class DropLedgerTest(_QueueTempDirMixin, unittest.TestCase):
+    """Residual drops -- the entry could not be written even after eviction."""
+
+    def _fail_queue_writes(self):
+        real_open = open
+        queue_dir = self._dir.rstrip("/")
+
+        def boom(path, *a, **kw):
+            p = str(path)
+            if p.endswith(".tmp") and os.path.dirname(p) == queue_dir:
+                raise OSError(28, "No space left on device")
+            return real_open(path, *a, **kw)
+
+        return unittest.mock.patch("builtins.open", boom)
+
+    def test_unwritable_queue_records_a_drop_and_returns_none(self):
+        with self._fail_queue_writes():
+            with redirect_stderr(io.StringIO()) as err:
+                got = pending.enqueue(_payload(), RuntimeError("upstream down"))
+
+        self.assertIsNone(got, "callers handle None; they must still get it")
+        self.assertIn("permanently lost", err.getvalue())
+        ledger = pending.read_drops()
+        self.assertEqual(ledger["count"], 1)
+        self.assertEqual(ledger["last_error_class"], "OSError")
+        self.assertEqual(ledger["last_bank_id"], "bank-a")
+
+    def test_first_dropped_at_is_not_overwritten_by_later_drops(self):
+        with self._fail_queue_writes():
+            with redirect_stderr(io.StringIO()):
+                pending.enqueue(_payload(content="a"), RuntimeError("x"))
+                first = pending.read_drops()["first_dropped_at"]
+                pending.enqueue(_payload(content="b"), RuntimeError("x"))
+                ledger = pending.read_drops()
+        self.assertEqual(ledger["count"], 2)
+        self.assertEqual(ledger["first_dropped_at"], first)
+
+    def test_read_drops_survives_a_non_utf8_ledger(self):
+        """The narrow-catch bug: UnicodeDecodeError is NOT a JSONDecodeError.
+
+        ``record_drop()`` reads the ledger first, so a corrupt ledger used
+        to turn ``enqueue()`` from documented-returns-None into a raiser at
+        exactly the moment the queue is under stress -- breaking
+        session_end.py / subagent_retain.py, which handle None.
+        """
+        os.makedirs(os.path.dirname(pending.drops_path()), exist_ok=True)
+        with open(pending.drops_path(), "wb") as f:
+            f.write(b"\xff\xfe\x00not utf-8 at all")
+        self.assertEqual(pending.read_drops(), {})
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending.record_drop(_payload(), RuntimeError("x")), 1)
+
+    def test_read_drops_survives_malformed_json(self):
+        os.makedirs(os.path.dirname(pending.drops_path()), exist_ok=True)
+        with open(pending.drops_path(), "w", encoding="utf-8") as f:
+            f.write("{not json")
+        self.assertEqual(pending.read_drops(), {})
+
+    def test_error_messages_are_truncated(self):
+        """An unbounded upstream error body inflates the queue against
+        MAX_BYTES for no diagnostic gain."""
+        path = pending.enqueue(_payload(), RuntimeError("E" * 5000))
+        with open(path, encoding="utf-8") as f:
+            stored = json.load(f)["error_message"]
+        self.assertLessEqual(len(stored), pending.MAX_ERROR_MESSAGE_CHARS + 20)
+        self.assertTrue(stored.endswith("[truncated]"))
+
+    def test_healthy_enqueue_writes_no_drop_ledger(self):
+        self.assertIsNotNone(pending.enqueue(_payload(), RuntimeError("x")))
+        self.assertEqual(pending.read_drops(), {})
+        self.assertFalse(os.path.exists(pending.drops_path()))
+
+
+class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
+    def _queue(self, n):
+        for i in range(n):
+            pending.enqueue(
+                _payload(content=f"turn-{i}", doc=f"doc-{i}"), RuntimeError("boom")
+            )
+        self.assertEqual(pending.count(), n)
+
+    def test_session_start_drain_cannot_clear_a_backlog(self):
+        """Regression witness for the BUG, not just for the fix.
+
+        The in-hook drain clamps each entry to the remaining hook budget
+        while the retain is synchronous, so the queue barely moves. That
+        loop is what produced the backlog in the first place.
+        """
+        self._queue(20)
+        os.environ["HINDSIGHT_DRAIN_BUDGET_S"] = "2"
+
+        def slow_ok(entry, timeout):
+            import time as _t
+
+            _t.sleep(0.5)
+
+        with unittest.mock.patch.object(drain_pending, "_retry_one", slow_ok):
+            summary = drain_pending.drain(CONFIG)
+
+        self.assertTrue(summary["budget_exceeded"])
+        self.assertLess(summary["drained"], 20)
+        self.assertGreater(pending.count(), 0)
+
+    def test_reconcile_phase_skips_already_durable_entries_without_posting(self):
+        """The free pass: 70.4% of a measured fleet backlog was already
+        durable. Re-POSTing those is duplicated LLM extraction for zero new
+        memory; a GET costs nothing on the model pool."""
+        self._queue(6)
+        posted = []
+        durable = {"doc-0", "doc-1", "doc-2"}
+
+        def exists(entry, timeout=30):
+            return entry["document_id"] in durable
+
+        with unittest.mock.patch.object(drain_pending, "_document_state", exists):
+            with unittest.mock.patch.object(
+                drain_pending, "_retry_one", lambda e, t: posted.append(e)
+            ):
+                with redirect_stderr(io.StringIO()):
+                    summary = drain_pending.drain_backlog(CONFIG, phase="reconcile")
+
+        self.assertEqual(summary["reconciled"], 3)
+        self.assertEqual(posted, [], "reconcile must issue no retains at all")
+        self.assertEqual(pending.count(), 3, "only absent documents remain queued")
+
+    def test_reconcile_never_drops_an_entry_on_an_unknown_result(self):
+        """Unknown != present. Guessing here deletes the last copy of a turn."""
+        self._queue(3)
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: None
+        ):
+            with redirect_stderr(io.StringIO()):
+                summary = drain_pending.drain_backlog(CONFIG, phase="reconcile")
+        self.assertEqual(summary["reconciled"], 0)
+        self.assertEqual(summary["unknown"], 3)
+        self.assertEqual(pending.count(), 3)
+
+    def test_drain_confirms_the_document_before_deleting_the_entry(self):
+        """Commit-before-delete: a 200 is an ack, not proof (#3244)."""
+        self._queue(2)
+        with unittest.mock.patch.object(drain_pending, "_retry_one", lambda e, t: None):
+            # POST succeeds, but the document is still not there.
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: False
+            ):
+                with redirect_stderr(io.StringIO()):
+                    summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+
+        self.assertEqual(summary["drained"], 0)
+        self.assertEqual(summary["unknown"], 2)
+        self.assertEqual(pending.count(), 2, "unconfirmed entries stay queued")
+
+    def test_drain_deletes_once_the_document_is_confirmed(self):
+        self._queue(5)
+        with unittest.mock.patch.object(drain_pending, "_retry_one", lambda e, t: None):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: True
+            ):
+                with redirect_stderr(io.StringIO()):
+                    summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+        self.assertEqual(summary["drained"], 5)
+        self.assertEqual(pending.count(), 0)
+
+    def test_backlog_concurrency_defaults_to_one_lane(self):
+        """The model pool is small and fleet-shared; width 4 consumes all
+        of it, and 11 agents at width 4 is 44 lanes of demand against 4."""
+        os.environ.pop("HINDSIGHT_DRAIN_CONCURRENCY", None)
+        self.assertEqual(drain_pending._backlog_concurrency(), 1)
+        os.environ["HINDSIGHT_DRAIN_CONCURRENCY"] = "999"
+        self.assertEqual(drain_pending._backlog_concurrency(), 16, "clamped")
+
+    def test_backlog_uses_a_realistic_per_entry_timeout(self):
+        """A 1-8s clamp guarantees a client timeout on a 30-90s sync retain
+        that the server then commits anyway -- the root cause."""
+        os.environ.pop("HINDSIGHT_DRAIN_BACKLOG_TIMEOUT", None)
+        self.assertGreaterEqual(drain_pending._backlog_timeout(), 120)
+
+        self._queue(2)
+        os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = "90"
+        seen = []
+        with unittest.mock.patch.object(
+            drain_pending, "_retry_one", lambda e, t: seen.append(t)
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_document_state", lambda e, timeout=30: True
+            ):
+                with redirect_stderr(io.StringIO()):
+                    drain_pending.drain_backlog(CONFIG, phase="drain")
+        self.assertEqual(seen, [90, 90])
+
+    def test_p95_backoff_pauses_the_drain(self):
+        """Replay must never be the thing that trips the latency alarm."""
+        self._queue(1)
+        os.environ["HINDSIGHT_DRAIN_P95_BACKOFF_MS"] = "38000"
+        probes = [90000, 90000, 10000]
+        slept = []
+
+        with unittest.mock.patch.object(
+            drain_pending, "_p95_probe_ms", lambda: probes.pop(0)
+        ):
+            with unittest.mock.patch.object(drain_pending.time, "sleep", slept.append):
+                with unittest.mock.patch.object(
+                    drain_pending, "_retry_one", lambda e, t: None
+                ):
+                    with unittest.mock.patch.object(
+                        drain_pending, "_document_state", lambda e, timeout=30: True
+                    ):
+                        with redirect_stderr(io.StringIO()) as err:
+                            summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+
+        self.assertEqual(slept.count(120), 2, "backed off until p95 recovered")
+        self.assertIn("BACKOFF", err.getvalue())
+        self.assertEqual(summary["drained"], 1)
+
+    def test_absent_p95_probe_does_not_block(self):
+        os.environ.pop("HINDSIGHT_DRAIN_P95_CMD", None)
+        self.assertEqual(drain_pending._p95_probe_ms(), -1)
+
+    def test_stall_guard_does_not_overshoot_under_concurrency(self):
+        """A wave of `width` identical timeouts must not age `width` entries.
+
+        Recording failures for the whole wave before breaking would bump
+        attempt_count on up to `width - 1` extra entries per wave, pushing
+        them toward .dead FASTER than the sequential drain -- the opposite
+        of this change's purpose.
+        """
+        self._queue(12)
+        os.environ["HINDSIGHT_DRAIN_CONCURRENCY"] = "4"
+
+        def always_fail(entry, timeout):
+            raise ConnectionError("upstream down")
+
+        with unittest.mock.patch.object(drain_pending, "_retry_one", always_fail):
+            with redirect_stderr(io.StringIO()):
+                summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+
+        self.assertTrue(summary["stalled"])
+        self.assertEqual(
+            summary["retried"],
+            drain_pending.STALL_THRESHOLD,
+            "exactly STALL_THRESHOLD entries aged, same as the sequential drain",
+        )
+        self.assertEqual(pending.count(), 12, "stalled entries stay queued")
+
+    def test_backlog_ages_entries_toward_dead_like_the_sequential_drain(self):
+        self._queue(1)
+        path, entry = pending.iter_entries()[0]
+        entry["attempt_count"] = pending.MAX_ATTEMPTS
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(entry, f)
+
+        def always_fail(entry, timeout):
+            raise ConnectionError("upstream down")
+
+        with unittest.mock.patch.object(drain_pending, "_retry_one", always_fail):
+            with redirect_stderr(io.StringIO()):
+                summary = drain_pending.drain_backlog(CONFIG, phase="drain")
+
+        self.assertEqual(summary["dead"], 1)
+        self.assertTrue(os.path.exists(path + ".dead"))
+        self.assertFalse(os.path.exists(path))
+
+    def test_dry_run_issues_no_writes(self):
+        self._queue(3)
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: True
+        ):
+            with redirect_stderr(io.StringIO()):
+                summary = drain_pending.drain_backlog(
+                    CONFIG, phase="reconcile", dry_run=True
+                )
+        self.assertEqual(summary["reconciled"], 3)
+        self.assertEqual(pending.count(), 3, "a dry run must not delete anything")
+
+
+class CliTest(unittest.TestCase):
+    """A membership test on argv silently ran the WRONG drain on a typo."""
+
+    def _run(self, argv):
+        seen = {}
+
+        def fake_drain(config=None, backlog=False, phase="both", dry_run=False):
+            seen.update(backlog=backlog, phase=phase, dry_run=dry_run)
+            return drain_pending._new_summary()
+
+        with unittest.mock.patch.object(drain_pending, "drain", fake_drain):
+            with unittest.mock.patch.object(drain_pending, "load_config", lambda: {}):
+                rc = drain_pending.main(argv)
+        return rc, seen
+
+    def test_backlog_flag_selects_backlog_mode(self):
+        _, seen = self._run(["--backlog"])
+        self.assertTrue(seen["backlog"])
+        _, seen = self._run([])
+        self.assertFalse(seen["backlog"])
+
+    def test_typo_is_rejected_rather_than_silently_running_the_hook_drain(self):
+        with redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as cm:
+                self._run(["--backlogg"])
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_phase_and_dry_run_are_plumbed(self):
+        _, seen = self._run(["--backlog", "--phase", "reconcile", "--dry-run"])
+        self.assertEqual(seen["phase"], "reconcile")
+        self.assertTrue(seen["dry_run"])
+
+    def test_phase_without_backlog_is_refused(self):
+        with redirect_stderr(io.StringIO()):
+            rc, _ = self._run(["--phase", "reconcile"])
+        self.assertEqual(rc, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_session_start_version_skew.py
+++ b/vendor/hindsight-memory/scripts/tests/test_session_start_version_skew.py
@@ -1,0 +1,204 @@
+"""A partial plugin rollout must fail LOUDLY, not silently (#3599 R4-Lc).
+
+The deploy hazard this pins is not a bug in any one file. The plugin tree
+ships as loose files under ``scripts/``, and #3599 REMOVED a symbol
+(``lib.pending.delete_entry``) whose only importer was ``drain_pending``.
+So a rollout that lands the new ``lib/pending.py`` beside an old
+``drain_pending.py`` — an interrupted copy, a hand-patched file, a
+``.bak`` restored over one half — makes ``session_start.py``'s
+
+    from drain_pending import drain
+
+raise ``ImportError``. That used to be caught by a bare ``except
+Exception`` and written to ``debug_log``, which is OFF by default: the
+whole pending-retains drain would stop, on every boot, and say nothing.
+Turns queue up forever, and the only downstream signal is ``switchroom
+doctor`` reporting a growing backlog — which names the queue, not the
+cause.
+
+These tests live under ``scripts/tests/`` because that is the ONLY python
+test directory CI discovers (``ci-tests-python.yml:63-64`` runs
+``python3 -m unittest discover tests/`` from ``vendor/hindsight-memory/
+scripts``).
+"""
+
+import io
+import os
+import sys
+import types
+import unittest
+import unittest.mock
+from contextlib import redirect_stderr
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import session_start  # noqa: E402
+
+
+class _Client:
+    """Stand-in for HindsightClient — reachable, no network."""
+
+    def __init__(self, *_a, **_kw):
+        pass
+
+    def health_check(self, timeout=5, retries=3):
+        return True
+
+
+class VersionSkewIsLoudTest(unittest.TestCase):
+    """Every import-level skew in the tree reaches stderr."""
+
+    CONFIG = {"autoRetain": True, "autoRecall": True}
+
+    def _run_main(self, broken: str):
+        """Run ``session_start.main()`` with ``broken`` importable but
+        missing the name the hook imports from it — exactly the shape a
+        half-rolled-out tree produces."""
+        stub = types.ModuleType(broken)  # module exists, symbol does not
+        with unittest.mock.patch.dict(sys.modules, {broken: stub}):
+            with unittest.mock.patch.object(
+                session_start, "load_config", lambda: dict(self.CONFIG)
+            ):
+                with unittest.mock.patch.object(
+                    session_start,
+                    "get_api_url",
+                    lambda cfg, debug_fn=None, allow_daemon_start=True: (
+                        "http://127.0.0.1:9/none"
+                    ),
+                ):
+                    with unittest.mock.patch.object(
+                        session_start, "HindsightClient", _Client
+                    ):
+                        with unittest.mock.patch.object(
+                            sys, "stdin", io.StringIO("{}")
+                        ):
+                            with redirect_stderr(io.StringIO()) as err:
+                                session_start.main()
+        return err.getvalue()
+
+    def test_a_half_rolled_out_tree_says_the_drain_is_disabled(self):
+        out = self._run_main("drain_pending")
+        self.assertIn(session_start.SKEW_MARKER, out)
+        self.assertIn("drain_pending", out)
+        self.assertIn(
+            "Queued retains will NOT be replayed",
+            out,
+            "the operator must be told what the skew COSTS, not just that "
+            "an import failed",
+        )
+        self.assertIn("Re-deploy the plugin tree WHOLE", out, "and how to fix it")
+
+    def test_the_same_guard_covers_boot_reconciliation(self):
+        """``reconcile_tail`` is the other half of the #3244 durability
+        machinery and is imported the same way, so it fails the same way."""
+        out = self._run_main("reconcile_tail")
+        self.assertIn(session_start.SKEW_MARKER, out)
+        self.assertIn("reconcile_tail", out)
+        self.assertIn("Un-committed turns will NOT be recovered", out)
+
+    def test_a_skew_does_not_take_session_start_down(self):
+        """Loud, but never fatal: SessionStart still completes. A hook that
+        crashes on a skew trades a silent drain outage for a broken boot."""
+        self._run_main("drain_pending")  # no exception escapes _run_main
+
+    def test_a_healthy_tree_prints_no_skew_warning(self):
+        """The control case. Without it the assertions above are satisfied
+        by a warning that fires unconditionally."""
+        with unittest.mock.patch.object(
+            session_start, "load_config", lambda: dict(self.CONFIG)
+        ):
+            with unittest.mock.patch.object(
+                session_start,
+                "get_api_url",
+                lambda cfg, debug_fn=None, allow_daemon_start=True: (
+                    "http://127.0.0.1:9/none"
+                ),
+            ):
+                with unittest.mock.patch.object(
+                    session_start, "HindsightClient", _Client
+                ):
+                    with unittest.mock.patch.object(sys, "stdin", io.StringIO("{}")):
+                        with redirect_stderr(io.StringIO()) as err:
+                            session_start.main()
+        self.assertNotIn(session_start.SKEW_MARKER, err.getvalue())
+
+    def test_a_runtime_error_is_still_swallowed_quietly(self):
+        """Only SKEW is loud. A transient drain failure stays best-effort —
+        making every upstream hiccup print would train operators to ignore
+        the line that matters.
+        """
+        import drain_pending
+
+        def boom(_config):
+            raise RuntimeError("upstream on fire")
+
+        with unittest.mock.patch.object(drain_pending, "drain", boom):
+            with unittest.mock.patch.object(
+                session_start, "load_config", lambda: dict(self.CONFIG)
+            ):
+                with unittest.mock.patch.object(
+                    session_start,
+                    "get_api_url",
+                    lambda cfg, debug_fn=None, allow_daemon_start=True: (
+                        "http://127.0.0.1:9/none"
+                    ),
+                ):
+                    with unittest.mock.patch.object(
+                        session_start, "HindsightClient", _Client
+                    ):
+                        with unittest.mock.patch.object(
+                            sys, "stdin", io.StringIO("{}")
+                        ):
+                            with redirect_stderr(io.StringIO()) as err:
+                                session_start.main()
+        self.assertNotIn(session_start.SKEW_MARKER, err.getvalue())
+
+
+class RemovedSymbolIsNotImportedTest(unittest.TestCase):
+    """The skew guard is the safety net; this is the thing it nets.
+
+    ``delete_entry`` is gone from ``lib.pending`` (#3599 R3-M1). If any
+    module in this tree imports it again, every agent running a mixed tree
+    loses its drain — so the absence is asserted from the importer side too,
+    not only from the module side.
+    """
+
+    def test_no_script_in_the_tree_imports_delete_entry(self):
+        # Parsed, not grepped: several docstrings discuss the removal by
+        # name, and a substring match would fail on the prose that explains
+        # why the symbol is gone.
+        import ast
+
+        offenders = []
+        for root, _dirs, files in os.walk(SCRIPTS_DIR):
+            if os.path.basename(root) in ("tests", "__pycache__"):
+                continue
+            for f in files:
+                if not f.endswith(".py"):
+                    continue
+                p = os.path.join(root, f)
+                with open(p, encoding="utf-8") as fh:
+                    tree = ast.parse(fh.read(), filename=p)
+                rel = os.path.relpath(p, SCRIPTS_DIR)
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.ImportFrom) and any(
+                        a.name == "delete_entry" for a in node.names
+                    ):
+                        offenders.append(rel)
+                    elif (
+                        isinstance(node, ast.Attribute)
+                        and node.attr == "delete_entry"
+                    ):
+                        offenders.append(rel)
+        self.assertEqual(
+            offenders,
+            [],
+            "delete_entry was removed; re-introducing an import of it "
+            "breaks every partially-rolled-out agent",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/tests/test_drain_pending.py
+++ b/vendor/hindsight-memory/tests/test_drain_pending.py
@@ -174,8 +174,10 @@ class DrainPendingTest(unittest.TestCase):
         """A genuinely absent document is POSTed and the entry RETIRED.
 
         Retired means moved into ``pending-reconciled/``, not ``os.remove``d:
-        this path retires on a bare 200, and a 200 is an ack, not proof
-        (#3244), so the removal must stay recoverable.
+        this in-hook path retires on the POST's own commit-before-ack 200
+        (``async_processing=False``, no confirming GET) — the daemon's word
+        about itself, not an independent read (#3244) — so the removal must
+        stay recoverable.
         """
         path = _seed_entry(self._pending)
         import drain_pending

--- a/vendor/hindsight-memory/tests/test_drain_pending.py
+++ b/vendor/hindsight-memory/tests/test_drain_pending.py
@@ -94,13 +94,45 @@ class DrainPendingTest(unittest.TestCase):
         self.assertFalse(summary["stalled"])
         self.assertFalse(summary["budget_exceeded"])
 
-    def test_drain_success_deletes_entry(self):
+    def test_drain_reconciles_an_already_durable_entry_without_posting(self):
+        """switchroom #3596: GET before POST, in the SessionStart path too.
+
+        This test used to assert `drained == 1` against a mock that answered
+        200 to EVERYTHING, including the presence GET — i.e. it asserted
+        that an already-durable document gets re-POSTed anyway. That is the
+        re-post loop: the hook's clamped timeout guarantees the client gives
+        up, so the entry survives and is re-posted on every boot forever
+        while the memory was never actually lost.
+        """
         path = _seed_entry(self._pending)
         import drain_pending
 
-        with patch("urllib.request.urlopen", return_value=FakeOk()):
+        posts = []
+
+        def record(req, *a, **kw):
+            posts.append(getattr(req, "method", None) or req.get_method())
+            return FakeOk()
+
+        with patch("urllib.request.urlopen", side_effect=record):
             summary = drain_pending.drain({})
+        self.assertEqual(summary["reconciled"], 1)
+        self.assertEqual(summary["drained"], 0)
+        self.assertEqual(summary["retried"], 0)
+        self.assertFalse(os.path.exists(path))
+        self.assertEqual(posts, ["GET"], "no retain POST for a durable document")
+
+    def test_drain_success_deletes_entry(self):
+        """A genuinely absent document is POSTed and the entry deleted."""
+        path = _seed_entry(self._pending)
+        import drain_pending
+
+        with patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: False
+        ):
+            with patch("urllib.request.urlopen", return_value=FakeOk()):
+                summary = drain_pending.drain({})
         self.assertEqual(summary["drained"], 1)
+        self.assertEqual(summary["reconciled"], 0)
         self.assertEqual(summary["retried"], 0)
         self.assertFalse(os.path.exists(path))
 
@@ -249,11 +281,18 @@ class DrainPendingTest(unittest.TestCase):
 
         import drain_pending
 
-        with patch("urllib.request.urlopen", side_effect=maybe_ok):
-            summary = drain_pending.drain({})
+        # All three documents are genuinely absent, so every entry takes the
+        # POST path — otherwise the presence GET would consume call slots
+        # and this would be testing the reconcile phase by accident.
+        with patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: False
+        ):
+            with patch("urllib.request.urlopen", side_effect=maybe_ok):
+                summary = drain_pending.drain({})
 
         self.assertEqual(summary["drained"], 2)
         self.assertEqual(summary["retried"], 1)
+        self.assertEqual(summary["reconciled"], 0)
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/tests/test_drain_pending.py
+++ b/vendor/hindsight-memory/tests/test_drain_pending.py
@@ -32,10 +32,23 @@ class FakeOk:
         return False
 
 
-def _seed_entry(pending_dir: str, document_id: str = "doc-x", attempt: int = 1) -> str:
+#: A POST-#3244 content-derived document_id (``retain.slice_document_id``):
+#: ``{session}-r{start_uuid}-{end_uuid}``. The presence-GET reconcile is gated
+#: on this shape — a pre-#3244 bare session id is answered 200 by ANY retain in
+#: that session — so the id shape is load-bearing in every drain fixture here.
+CONTENT_DERIVED_DOC_ID = (
+    "11111111-2222-4333-8444-555555555555"
+    "-r00000000-0000-4000-8000-000000000001"
+    "-00000000-0000-4000-8000-000000000002"
+)
+
+
+def _seed_entry(
+    pending_dir: str, document_id: str = CONTENT_DERIVED_DOC_ID, attempt: int = 1
+) -> str:
     os.makedirs(pending_dir, mode=0o700, exist_ok=True)
     ts_ms = int(time.time() * 1000)
-    name = f"{ts_ms}-{document_id}.json"
+    name = f"{ts_ms}-{document_id[:24]}.json"
     path = os.path.join(pending_dir, name)
     payload = {
         "schema": 1,
@@ -84,6 +97,15 @@ class DrainPendingTest(unittest.TestCase):
         for n in ("drain_pending", "lib.pending"):
             sys.modules.pop(n, None)
 
+    def _reconciled(self):
+        """Basenames archived under ``pending-reconciled/`` (sibling dir)."""
+        import lib.pending as pending
+
+        try:
+            return sorted(os.listdir(pending.reconciled_dir()))
+        except OSError:
+            return []
+
     def test_drain_empty_queue_is_noop(self):
         import drain_pending
 
@@ -119,10 +141,42 @@ class DrainPendingTest(unittest.TestCase):
         self.assertEqual(summary["drained"], 0)
         self.assertEqual(summary["retried"], 0)
         self.assertFalse(os.path.exists(path))
+        self.assertEqual(self._reconciled(), [os.path.basename(path)])
         self.assertEqual(posts, ["GET"], "no retain POST for a durable document")
 
-    def test_drain_success_deletes_entry(self):
-        """A genuinely absent document is POSTed and the entry deleted."""
+    def test_drain_refuses_to_reconcile_a_pre_3244_bare_session_id(self):
+        """A bare session id's 200 is not evidence about THIS entry.
+
+        The bank answers 200 for a bare session id after any successful
+        retain in that session, so reconciling on presence would retire an
+        entry whose own content was never committed.
+        """
+        path = _seed_entry(
+            self._pending, document_id="d52ae253-2d26-42e5-a86b-9a354cc0ace5"
+        )
+        import drain_pending
+
+        methods = []
+
+        def record(req, *a, **kw):
+            methods.append(getattr(req, "method", None) or req.get_method())
+            raise urllib.error.URLError("upstream down")
+
+        with patch("urllib.request.urlopen", side_effect=record):
+            summary = drain_pending.drain({})
+
+        self.assertEqual(summary["reconciled"], 0)
+        self.assertEqual(methods, ["POST"], "no free-pass GET for a bare session id")
+        self.assertTrue(os.path.exists(path), "entry stays queued")
+        self.assertEqual(self._reconciled(), [])
+
+    def test_drain_success_archives_the_entry(self):
+        """A genuinely absent document is POSTed and the entry RETIRED.
+
+        Retired means moved into ``pending-reconciled/``, not ``os.remove``d:
+        this path retires on a bare 200, and a 200 is an ack, not proof
+        (#3244), so the removal must stay recoverable.
+        """
         path = _seed_entry(self._pending)
         import drain_pending
 
@@ -135,6 +189,7 @@ class DrainPendingTest(unittest.TestCase):
         self.assertEqual(summary["reconciled"], 0)
         self.assertEqual(summary["retried"], 0)
         self.assertFalse(os.path.exists(path))
+        self.assertEqual(self._reconciled(), [os.path.basename(path)])
 
     def test_drain_failure_bumps_attempt_count(self):
         path = _seed_entry(self._pending, attempt=1)

--- a/vendor/hindsight-memory/tests/test_pending.py
+++ b/vendor/hindsight-memory/tests/test_pending.py
@@ -67,17 +67,26 @@ class PendingQueueTest(unittest.TestCase):
         self.assertIn("failed_at", entry)
         self.assertEqual(entry["schema"], pending_mod.SCHEMA)
 
-    def test_enqueue_filename_is_unix_ms_uuid(self):
+    def test_enqueue_filename_is_unix_ms_key_uuid(self):
+        """``<unix-ms>-<dupe-key>-<uuid>.json`` (switchroom #3596).
+
+        The dedupe key moved INTO the name so a duplicate lookup is a
+        listing prefix match with zero file reads. The leading millisecond
+        timestamp is unchanged, so the lexicographic sort in
+        ``_list_entries`` is still oldest-first.
+        """
         path = pending_mod.enqueue(self._sample_payload(), RuntimeError("boom"))
         name = os.path.basename(path)
         self.assertTrue(name.endswith(".json"))
         head = name[: -len(".json")]
-        ts_part, uuid_part = head.split("-", 1)
+        ts_part, key_part, uuid_part = head.split("-")
         self.assertTrue(ts_part.isdigit())
         # Filename ts should be within 10 s of now
         now_ms = int(time.time() * 1000)
         self.assertLess(abs(now_ms - int(ts_part)), 10_000)
         self.assertEqual(len(uuid_part), 12)
+        self.assertEqual(len(key_part), 16)
+        self.assertRegex(key_part, r"^[0-9a-f]{16}$")
 
     def test_enqueue_atomic_no_tmp_left_behind(self):
         pending_mod.enqueue(self._sample_payload(), RuntimeError("boom"))

--- a/vendor/hindsight-memory/tests/test_pending.py
+++ b/vendor/hindsight-memory/tests/test_pending.py
@@ -1,5 +1,7 @@
 """Tests for the pending-retains persistent queue (#1071)."""
 
+import contextlib
+import io
 import json
 import os
 import sys
@@ -83,16 +85,30 @@ class PendingQueueTest(unittest.TestCase):
         self.assertEqual(len(names), 1)
         self.assertFalse(any(n.endswith(".tmp") for n in names))
 
-    def test_enqueue_returns_none_when_full(self):
-        # Pre-populate with MAX_ENTRIES dummy files.
+    def test_enqueue_evicts_oldest_when_full_instead_of_refusing(self):
+        """switchroom #3596: a full queue sheds the OLDEST entry.
+
+        This test previously asserted the opposite -- that ``enqueue()``
+        returns ``None`` at ``MAX_ENTRIES`` -- which meant throwing away the
+        turn that had just happened, the one most likely to still matter,
+        while keeping a queue full of stale ones.
+        """
         os.makedirs(self._dir, mode=0o700)
+        oldest = os.path.join(self._dir, f"{0:013d}-aaaaaaaaaaaa.json")
         for i in range(pending_mod.MAX_ENTRIES):
             with open(os.path.join(self._dir, f"{i:013d}-aaaaaaaaaaaa.json"), "w") as f:
                 json.dump({"placeholder": True}, f)
-        result = pending_mod.enqueue(self._sample_payload(), RuntimeError("boom"))
-        self.assertIsNone(result)
-        # Count unchanged
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            result = pending_mod.enqueue(self._sample_payload(), RuntimeError("boom"))
+
+        self.assertIsNotNone(result, "the incoming entry must never be refused")
+        self.assertTrue(os.path.exists(result))
+        self.assertFalse(os.path.exists(oldest), "the oldest entry was evicted")
+        # Cap still honoured: one in, one out.
         self.assertEqual(pending_mod.count(), pending_mod.MAX_ENTRIES)
+        self.assertIn("evicted OLDEST", stderr.getvalue())
 
     def test_iter_entries_ordered_oldest_first(self):
         p1 = pending_mod.enqueue(self._sample_payload("doc-1"), RuntimeError("e1"))


### PR DESCRIPTION
## ⚠️ Do not merge yet — a drain is running against these queues right now

An out-of-band drainer is actively replaying the live pending-retains queues
(most recent `drain.log` entries at the time of writing: 17:38:56, backing off
on p95 56087–89019ms). Landing a plugin change that `switchroom apply` pushes
into the agent containers **mid-drain** is its own hazard. Sequencing is a
separate decision for the operator; this PR is ready but parked.

## What this actually is

The first revision of this PR was built on a premise the ground truth
contradicts, and it has been reworked. Recording that plainly because the wrong
story is the more intuitive one:

**The backlog was not lost memory. It was a re-post loop.**

A full sweep of all 5,751 queued entries (2026-07-25) found:

| | entries | share |
|---|---|---|
| already exist as documents in their bank | **4,048** | **70.4%** |
| …of those, with facts extracted | 3,815 | 66.3% |
| genuinely absent | 1,703 | 29.6% |

### Root cause (`drain_pending.py`)

The SessionStart drain **built** the backlog it was supposed to clear. It runs
inside the hook and clamps each entry's HTTP timeout to the remaining hook
budget — 1–8s (`drain_pending.py:334-335`) — while `_retry_one` posts
`async_processing=False`, a synchronous retain that takes 30–90s on this fleet.
So the server committed the document and the client **always** gave up before
the ack. The entry was never deleted, was re-posted on every session start
forever, and aged toward `.dead` while the memory it carried was already
durable.

(The flat `attempt_count == 1` visible across the queue is not evidence the
drain is vestigial — it is an artefact of the dedupe pass carrying over the
lowest `attempt_count` per duplicate group.)

## The change

### 1. `--backlog` is a two-phase, out-of-hook replay

* **Phase 1 — reconcile (free).** GET the document; if it exists the memory is
  already durable, so retire the entry (moved to `pending-reconciled/`, never
  deleted) with no POST. No LLM work, no cost, idempotent, resumable. On the
  measured fleet that is 70% of the queue for nothing. `drain_pending.py:483-511`
  **Only entries whose `document_id` is content-derived** (post-#3244) are
  eligible — see round 2 below.

**The reconcile also runs in the automatic path.** `session_start.py:83-85`
calls `drain(config)` with `backlog=False`, so fixing the loop only in the
operator-invoked mode would have changed nothing operationally — every agent
boot would go on re-POSTing its durable backlog exactly as before. The
sequential drain now GETs before it POSTs, with the same tri-state rule
(`True` drops the entry; `False` and unknown fall through to the retry). A
sub-second GET replaces a doomed 30-90s server-side extraction **for entries
that are already durable**. For an entry that is genuinely absent the GET is an
*extra* call on top of the POST, so the per-entry timeout is re-clamped against
the remaining budget before each request rather than granted twice — see F2 in
round 2 below.
* **Phase 2 — drain (real work).** Only genuinely-absent documents, at a
  realistic timeout (`HINDSIGHT_DRAIN_BACKLOG_TIMEOUT`, default 180s), then
  **re-GET to confirm the document before retiring the entry**.
  `drain_pending.py:606-630`

**`async_processing=False` is kept deliberately.** The drain is a durability
path: it retires the pending entry on a 200, so the 200 must prove durable
persistence, not ack-of-receipt. Deleting on an async ack is precisely the
switchroom #3244 silent-loss bug. Throughput comes from a long budget and a
free reconcile phase, never from async. `drain_pending.py:183-206`

### 2. Replay is paced, because the model pool is fleet-shared

`HINDSIGHT_DRAIN_CONCURRENCY` defaults to **1**, not 4
(`drain_pending.py:137-148`). The group serving retain has 4 lanes (2 boxes ×
2 slots) shared with live retains, reflect and consolidation; 11 agents at
width 4 is 44 lanes of demand against 4. Phase 2 also sleeps between entries
(`HINDSIGHT_DRAIN_SLEEP_S`) and pauses entirely while a p95 probe reports the
upstream is already slow (`HINDSIGHT_DRAIN_P95_BACKOFF_MS`, default 38000 —
below the watchdog's 45000 alarm). `drain_pending.py:400-412`

### 3. A full queue evicts the OLDEST, never refuses the newest

`lib/pending.py` previously returned `None` at `MAX_ENTRIES`, discarding the
turn that had just happened, and three of six call sites dropped that return —
so it was silent. It now sheds oldest-first into a bounded `pending-evicted/`
archive with an append-only `pending-evictions.log`
(`lib/pending.py:256-292`), and dedupes on
`(bank_id, document_id, sha256(content))` — `reconcile_tail` re-enqueues the
same slice every boot until its watermark is confirmed. Both caps are
env-driven: a count cap alone bounds disk only to within ~1500× at the
measured content spread (499 B .. 744 KB).

**The dedupe key lives in the filename** (`<unix-ms>-<key>-<uuid>.json`), so a
lookup is a prefix match over the directory listing with **zero file reads**.
An earlier revision pre-filtered candidates on `os.path.getsize()`, which made
the guard a no-op in exactly the scenario it was written for: the serialized
blob also carries `failed_at`, `error_message`, `attempt_count` and — after any
drain attempt — `last_attempt_at`, none of which are part of the memory's
identity, and the queued copy is **always** post-`update_attempt` by the time
`reconcile_tail` re-enqueues, because the SessionStart drain attempts every
entry on every boot. In steady state the queue therefore grew by one duplicate
per boot. Reproduced against the fix:

```
1st: 1784967192474-50d05913f524caf7-4bb6420b7c2a.json count 1
2nd after update_attempt: 1784967192474-50d05913f524caf7-4bb6420b7c2a.json count 1
3rd different error msg: count 1
*** DEDUPE HELD ***
```

**Attribution corrected:** the measured 63% / 84.7 MB collapse on the fleet was
achieved by `dedupe_queue.py`, a one-shot out-of-band sweep keyed on
`(bank, doc, sha256(content))` with no size index. This is the *preventive*
guard that stops duplicates accumulating — a different mechanism, and it does
not get the credit for that number.

**An oversized entry no longer costs the whole queue.** If a payload exceeds
`MAX_BYTES` the eviction loop could never satisfy its condition, so it evicted
**every** entry and wrote the incoming one anyway — and the bounded archive
then discarded most of what it had just shed (reproduced: queue 20 → 1, with
only 5 of the 20 evicted payloads retained). That single entry is now refused
and recorded as a drop. Not reachable at the 256 MB default, but
`HINDSIGHT_PENDING_MAX_BYTES` is operator-tunable.

**Corrupt entries are quarantined, not skipped.** A malformed entry was
immortal — `iter_entries()` skipped it, so it was never reconciled, never
drained and never aged to `.dead`, yet it still held a queue slot and still
counted toward the depth doctor reports, with eviction as its only exit. It now
moves to `pending-corrupt/`, matching the out-of-band drainer. Transient
`OSError`s are still just skipped: an I/O error is not evidence the payload is
bad.

**This is a port of the design already validated and running out of band on
this fleet**, currently in force via env in `switchroom.yaml`. The file patches
themselves do not survive `switchroom apply` — which is exactly why the design
belongs in-repo. The earlier revision of this PR kept refuse-newest and would
have silently reverted the fleet to the weaker policy on the next `apply`.

### 4. Residual drops are still recorded

With eviction in place a *drop* now means the entry could not be written at all
(disk full, permissions). It gets a loud stderr line plus a durable
`pending-drops.json` ledger — a **sibling** of the queue dir, so it can never be
listed as an entry, drained, or counted against the caps
(`lib/pending.py:361-418`). `read_drops()` catches `ValueError`, not
`json.JSONDecodeError`: `UnicodeDecodeError` is a `ValueError` subclass and a
non-UTF-8 ledger used to turn `enqueue()` from documented-returns-`None` into a
raiser at exactly the moment the queue was under stress
(`lib/pending.py:342-358`). Stored error messages are truncated to 500 chars
(`lib/pending.py:125-130`).

The `count` bump is an unlocked read-modify-write, so it is a **floor**, not an
exact tally — documented in place (`lib/pending.py:369-375`). Taking a lock on
the disk-full path is where it would be most likely to wedge, and any non-zero
count already fails the doctor row.

### 5. `switchroom doctor` was telling the operator two false things

* It claimed a live backlog "drains automatically on the agent's next
  SessionStart". It cannot — that drain is what built it.
* It hardcoded `PENDING_RETAINS_MAX_ENTRIES = 1000` while the live cap is
  env-driven at 2000, so it reported "at cap of 1000 (dropping new failures)"
  against containers that were happily accepting entries.

The probe now reads the agent's **live** `HINDSIGHT_PENDING_MAX_ENTRIES` out of
the container (`src/cli/doctor.ts:1508-1551`, `buildPendingRetainsProbeScript`), plus the relocated
`pending-drops.json` and the new `pending-evictions.log`. Verdicts are honest:

* `warn` — a backlog, including one at the eviction threshold. Depth alone is
  **not** loss now that a full queue evicts rather than refuses.
* `fail` — actual loss only: `.dead` markers, residual drops, or evictions
  **within the last 7 days**.

The eviction count is **windowed, not cumulative**. Eviction is deliberate
policy under this design and `pending-evictions.log` is append-only, so a
cumulative `grep -c` would pin the row to `fail` forever after one legitimate
eviction — and a check that trains operators to ignore it is worse than no
check. The row now clears on its own once evictions stop, and the remediation
says so instead of telling the operator to delete the record of what was shed.
The ledger is size-bounded too.

The remediation names `--phase reconcile` first (it is free and usually clears
most of the queue), spells out the pacing (one agent at a time, at the default
concurrency of 1, with `HINDSIGHT_DRAIN_SLEEP_S` set), and **ships the actual
p95 query** — the same `LiteLLM_SpendLogs` `percentile_cont(0.95)` figure the
watchdog alarms on — rather than naming `HINDSIGHT_DRAIN_P95_CMD` and leaving
the operator to go find a command.

### 6. `argparse` replaces a membership test

`"--backlog" in argv` silently ran the 4-second in-hook drain on a typo like
`--backlogg` while the operator believed a backlog replay had started.

### 7. Stall guard no longer overshoots under concurrency

The failure counter is evaluated **before** the failure is recorded for the
rest of the wave. Recording first would let a wave of `width` identical
timeouts bump `attempt_count` on all of them before the loop breaks — aging
entries toward `.dead` *faster* than the sequential drain, the exact opposite of
the point. `drain_pending.py:494-517`

### 8. Backoff is bounded by the budget

`_wait_for_upstream` looped `sleep(120)` with no budget check and no iteration
cap, so with the p95 probe set and a persistently degraded upstream
`drain_backlog()` would block indefinitely — past the one guarantee this mode
makes about how long it runs. It is now bounded by the same wall-clock budget
as the drain, and stops rather than waiting past it. The unused `config`
parameter is gone. The per-wave budget granularity (an overshoot of at most one
wave) is now documented at `drain_pending.py:451-459`, the way the in-hook
clamp already was.

## Deliberately NOT ported from the live design

1. **The p95 probe is operator-supplied (`HINDSIGHT_DRAIN_P95_CMD`), not
   built-in.** The reference drainer queries LiteLLM's spend log in postgres
   via `docker exec` — the same source the watchdog alarms on. An agent
   container cannot reach that, and inventing a weaker in-container proxy would
   be a worse signal that *looks* like a better one. Unset ⇒ no backoff, and
   the startup line says `p95_probe=unset`. `drain_pending.py:161-180`
The second gap flagged in review — reconciled/drained entries being deleted
rather than moved — is **no longer a deferral**: `pending-reconciled/` is ported
(round 2, F1 below), bounded the same way `pending-evicted/` is, so it cannot
grow unbounded on disk. The third — corrupt entries being skipped rather than
quarantined — is likewise ported: `pending-corrupt/` (above).

## Round 2 review findings (all fixed, `c2c28a44`)

**F1 (high) — a presence GET could not prove the content was committed.** The
justification for deleting on a 200 was that `document_id` is content-derived,
which only holds post-#3244 (`retain.py:174 slice_document_id`). A pre-#3244
entry carries a bare session id, so the bank answers 200 for *any* successful
retain in that session and the queued slice would be deleted unread. Confirmed
read-only against live data: a 525 KB entry on this host whose
`document_id` is a bare uuid returns 200. Both halves of the reviewer's
prescription are implemented:

* the reconcile is **gated on the post-#3244 id grammar** —
  `lib/pending.py:184-199 is_content_derived_document_id`, applied at
  `drain_pending.py:122 _reconcilable_on_presence`. Unrecognised ⇒ not
  eligible ⇒ the entry is kept and re-POSTed, which is the safe direction. The
  backlog reconcile phase counts and logs the skips
  (`drain_pending.py:490-505`).
* **nothing on the drain path is deleted any more.** Retired entries move to a
  bounded `pending-reconciled/` (`lib/pending.py:285`, `:351
  archive_reconciled`, caps `HINDSIGHT_PENDING_RECONCILED_MAX_ENTRIES` = 500 /
  `..._MAX_BYTES` = 64 MB, shed oldest-first). This also resolves **F4**: the
  in-hook success path retired on a bare 200 while the backlog path insisted a
  200 is not proof. There is now one rule — a 200 retires an entry, and
  retiring is reversible.

**F2 (medium) — the per-entry timeout was spent twice.** `effective_timeout`
was clamped once and then granted in full to both the GET and the POST, so with
the fleet's settings (`BUDGET_S=9`, `TIMEOUT=8`) a stalled upstream burned a
measured **16.0s against a 9s budget**. The clamp is now recomputed immediately
before each request (`drain_pending.py:102 _clamp`, called at `:419` and
`:429`). All four claim sites corrected: the module docstring, the in-hook
comment, `CHANGELOG.md`, and this PR body.

**F3 (medium) — a sixth false-green test.** `test_pending_drops.py` asserted
`all(t <= 5 …)` while the default per-entry timeout *is* 5, with
`HINDSIGHT_DRAIN_TIMEOUT` missing from `_QueueTempDirMixin.ENV_KEYS` and
`_retry_one` never patched — it could not have failed on the bug. The env var
is now in `ENV_KEYS` and popped in `setUp`, the timeout is set explicitly high,
and the assertions run against the real GET+POST path on a virtual
`time.monotonic` clock where each faked request consumes exactly its granted
timeout.

**F5 (low) — a broken p95 probe silently disabled backoff.** `_p95_probe_ms`
ignored `out.returncode`, so a typo'd command returned -1 exactly like "no
probe configured". It now warns distinctly on a failed run, on a non-zero exit
(`drain_pending.py:236`), and on unparsable stdout (`:245`).

**F6 (low) — trim direction and the `MAX_BYTES` boundary had zero coverage.**
Tests added for the archive trim direction, the eviction-ledger trim direction,
and the `>` vs `>=` boundary; each fails on the corresponding mutation.

**F7 (low) — the ordering comment overstated the guarantee.** `_list_entries`
is oldest-first to the millisecond; same-millisecond ties break on the dupe key
— stable and total, but arbitrary. Comment corrected and both properties
pinned by tests.

### Mutation evidence

Every behaviour change was reverted one at a time and both python suites re-run.
All eight mutations were caught:

| mutation | failing tests |
|---|---|
| M1 F1 id-shape gate removed | 2 (`…bare_session_id_is_never_reconciled…`, `…backlog_reconcile_phase_also_refuses…`) + 1 in `vendor/…/tests/` |
| M2 archive → `os.remove` | 4 + 2 |
| M3 clamp computed once, spent twice | 2 |
| M4 probe returncode ignored | 1 |
| M5 archive trim direction reversed | 2 |
| M6 `>` → `>=` on `MAX_BYTES` | 1 |
| M7 eviction ledger keeps the wrong end | 1 |
| M8 queue ordering reversed | 3 + 2 |

## Round 3 review response

Three blockers, one medium and five lows. Every fix below was demonstrated by
mutation: apply the mutation, watch the new test fail, revert, watch it pass.

**B1 (high) — phase-2 commit-before-retire was not pinned.** `is True` →
`is not False` at `drain_pending.py:657` survived both suites, because
`test_pending_drops.py:749` patched `_document_state` to `False` only, with no
`None` counterpart. Added
`test_drain_never_retires_an_entry_on_an_unknown_result` (asserts
`drained == 0`, `unknown == N`, `pending.count() == N`). The mutation now fails
it.

**B2 (high) — `lib/client.py:document_exists` had zero coverage.** `return True`
survived. New `scripts/tests/test_client_document_exists.py` drives a real
loopback `http.server` (not a urllib mock — the branch under test *is* urllib's
exception taxonomy) and pins 200 → `True`, 404 → `False`, and
500 / 503 / 429 / timeout / connection-refused / malformed-body → `None`, plus
URL quoting, method and auth header, and the `_document_state` wrapper.

**B3 (medium) — the doctor eviction window was asserted only by message
wording.** Deleting `$1 >= c` from the awk clause left all 21 doctor tests
green. The probe shell is now built by an exported
`buildPendingRetainsProbeScript(base, now)`, and the tests run it under `sh`
against real ledger fixtures spanning inside/outside the window, asserting the
NUMERIC count. `doctor-pending-retains.test.ts` goes 21 → 33 tests.

**M1 (medium) — `archive_reconciled`'s `except OSError: delete_entry(path)` was
silent, unrecorded, irreversible loss**, and falsified four claims this PR
makes about never deleting. Fixed the code, not the docs: the fallback now
leaves the entry QUEUED and says so loudly on stderr, the four call sites honour
the return value, and a new `archive_failed` counter distinguishes "confirmed
durable but not retired" from "drained". `delete_entry()` is **deleted
outright** — with no delete primitive in the module the invariant is structural,
not a matter of every future branch remembering it. The pre-existing
`test_an_unwritable_archive_still_retires_the_entry`, which positively asserted
the old silent-delete behaviour, is reversed accordingly.

**L1 — archive caps 4x smaller than the queue caps.** Kept the caps and made the
trim name what it dropped (count + filenames + which cap tripped). Justification
in the `_trim_dir` docstring: matching the queue caps would put three full-queue
copies (~768 MB) on a container filesystem, and a trimmed archive entry is a
redundant copy of a document already CONFIRMED durable upstream — never the last
on-disk copy of a turn, which is what the queue caps exist to protect.

**L2 / L3 / L4 — untested boundaries.** Added `_trim_dir` byte-boundary tests
(exact-at-cap vs one-over, both caps), `client.py:120` retry-boundary tests, and
`_env_num` lo/hi clamp tests.

**L5 — numeric drift in this description.** Corrected above.

### Contradiction with the review (evidence)

The review's L4 also asks for a test pinning `_clamp`'s floor at
`drain_pending.py:117`. That mutant is **equivalent and cannot be killed**:
`if remaining < 1: return 1` and `return max(1, min(timeout, int(remaining)))`
are mutually redundant, so `<` → `<=`, `max(1` → `max(0`, and deleting *either*
guard alone all produce identical output for every input. Verified exhaustively
over the boundary values plus 200,000 random remainders — zero counterexamples.
Deleting **both** guards IS killed (2 failures). The analysis is recorded in the
`_clamp` docstring rather than papered over with a test that cannot fail.

A second, smaller one: `_wait_for_upstream`'s `p95 < 0` → `p95 <= 0` is likewise
equivalent (a 0 reading returns `True` down either branch). Noted in the test
that pins the outcome.

### Post-fix mutation sweep

The operator sweep was re-run over every prod file touched. It found six further
survivors in code this PR introduced — the stall guard's
`err_class == last_error_class` in **both** drains (a homogeneous error stream
cannot distinguish `==` from `!=`; only an ALTERNATING one can), the sequential
stall threshold's `>=`, both budget-loop `>` comparisons, and two
`_wait_for_upstream` boundaries. A second pass over the whole set (67 mutants
across the three prod python files) found four more: the document-paging walk's
`len(items) < page` (a full page would end the walk and silently truncate the
#3244 recovery set), `_clip_error`'s cap, the trim log's ten-name truncation,
and the eviction ledger's rotation cap. All ten now have tests and all ten
mutations fail them.

The survivors that REMAIN are accounted for, not ignored: two equivalent mutants
(above), four sweep artifacts that mutate text inside f-string log messages
rather than code, and three in pre-existing code this PR does not touch
(`client.py:163` `prefer_observations`, `pending.py:245` the queue-dir mode
tighten).

## Verification

```
$ cd vendor/hindsight-memory/scripts && python3 -m unittest discover tests/
...........................................................................
----------------------------------------------------------------------
Ran 557 tests in 10.5s

OK
```

```
$ npx vitest run src/cli/doctor
 ✓ src/cli/doctor-pending-retains.test.ts (33 tests) 9ms
 Test Files  18 passed (18)
      Tests  209 passed (209)
```

```
$ npm run lint
plugin-references: clean (no tsc errors in plugin source — strict since #623).
check-bot-api-wrapping: clean (no raw bot.api.* calls outside the retry policy)
check-bun-test-imports: clean (1262 test files scanned)
check-no-pii-secrets: clean (2918 tracked files scanned)
check-vault-test-hermeticity: clean (50 vault test files scanned)
check-no-broadcast-delivery: clean (376 files scanned)
check-stale-tool-descriptions: clean
check-mcp-instructions-budget: OK (1 measured) MCP_INSTRUCTIONS=1898/1950 (limit 2048)
check-web-subscription-honest: clean (20 dashboard sources scanned)
check-no-unpinned-npx-playwright: OK
check-gateway-line-ratchet: clean
check-litellm-config-guard: OK
```

```
$ python3 -m pytest vendor/hindsight-memory/tests/ -q     # the suite CI never runs
236 passed in 7.7s
```

Failures found and fixed during these runs rather than papered over:

* `test_full_queue_evicts_oldest_and_keeps_the_newest` — entry filenames lead
  with a millisecond timestamp, so four enqueues inside one millisecond
  tie-break on the random uuid, not on age. Real entries are milliseconds
  apart; the test now pins the clock.
* Two test doubles used `lambda e, t:` while the sequential drain calls
  `_retry_one(entry, timeout=…)` by keyword, so the `TypeError` was being
  swallowed as a retry failure and the assertions passed for the wrong reason.
* Three more in `vendor/hindsight-memory/tests/` — the suite CI never runs.
  `test_drain_success_deletes_entry` asserted `drained == 1` against a mock
  that answered 200 to *everything*, including the presence GET: it was
  asserting that an already-durable document gets re-POSTed anyway, i.e. it
  pinned the bug. Split into a reconcile case and an absent-document case.
  `test_drain_mixed_success_failure` counted `urlopen` calls that the presence
  GET now shifts, and `test_enqueue_filename_is_unix_ms_uuid` asserted the old
  two-segment filename. All three fixed, not loosened.
* Round 2: `test_pending_drops.py:464-482` asserted `all(t <= 5 …)` against a
  default of 5 with `_retry_one` unpatched — a sixth false green. Rewritten
  (F3 above). Five further fixtures queued `doc-N` ids that the new F1 gate
  correctly refuses; they now carry post-#3244 content-derived ids rather than
  having the gate loosened to accommodate them.

The new tests live in `vendor/hindsight-memory/scripts/tests/` because that is
the **only** python test directory CI discovers — see the note below.

## Separately filed

CI never runs `vendor/hindsight-memory/tests/`. Both python jobs use
`working-directory: vendor/hindsight-memory/scripts` with
`python3 -m unittest discover tests/`, so the 236 tests in the sibling
directory — which directly cover this code — gate nothing. Filed as
**#3606**; five stale assertions in that suite were caught by hand across the
two revisions of this PR, every one of which CI would have reported green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


