### PR TITLE
fix(logs): bound three unbounded logs — webhook events, hostd audit, rotated sidecar .1

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -210,6 +210,16 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
     #   * compress on rotate (gzip typically takes a text log to <10%), and
     #   * an AGE bound — a `.1`/`.1.gz` older than this is deleted on the
     #     next check even if no rotation happens.
+    # Be honest about what the age bound COSTS (#3600 review): right after
+    # a rotation the `.1` holds everything and the live log is empty, so
+    # if the agent then goes quiet for 14 days that history is DELETED
+    # while the near-empty live log survives. This is deliberate for a
+    # debug trace log — bounding shared host disk beats retaining stale
+    # traces — but it is deletion of the only copy, not merely eviction of
+    # a superseded backup. Raise SWITCHROOM_SIDECAR_LOG_ROTATE_MAX_AGE_SEC
+    # (or set it to 0 to disable the reaper) where that matters. Agent
+    # AUDIT trails are not affected: those are the hostd/vault logs, which
+    # rotate by count, never by age.
     local _max_age_sec="${SWITCHROOM_SIDECAR_LOG_ROTATE_MAX_AGE_SEC:-1209600}"  # 14 days
     local _compress="${SWITCHROOM_SIDECAR_LOG_COMPRESS:-1}"
     # Validate BOTH env overrides up front; garbage falls back to the

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -195,11 +195,23 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   # the child keeps appending to the same (now-empty) inode. Worst-case
   # race is a few log lines written between the cp and the truncate being
   # lost; acceptable for a debug trace log. Keeps at most ~2×cap on disk
-  # (live + one .1 generation). Cap + interval are env-overridable.
+  # (live + one .1 generation), and since #3596 that .1 is compressed on
+  # rotate and age-reaped, so it can't outlive its usefulness. Cap,
+  # interval, max-age and compression are all env-overridable.
   _switchroom_log_rotator() {
     local _logfile="$1"
     local _max="${SWITCHROOM_SIDECAR_LOG_MAX_BYTES:-52428800}"   # 50 MiB default
     local _interval="${SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC:-300}"  # 5 min
+    # #3596: the `.1` generation was written once and then NEVER reaped.
+    # A log that grows fast during an incident and slowly afterwards keeps
+    # its giant `.1` forever — on the live host clerk/gateway-supervisor.log.1
+    # was 582 MB (dated Jul 11) while the live log sat at ~5 MB, i.e. months
+    # away from ever being overwritten by the next rotation. Two bounds:
+    #   * compress on rotate (gzip typically takes a text log to <10%), and
+    #   * an AGE bound — a `.1`/`.1.gz` older than this is deleted on the
+    #     next check even if no rotation happens.
+    local _max_age_sec="${SWITCHROOM_SIDECAR_LOG_ROTATE_MAX_AGE_SEC:-1209600}"  # 14 days
+    local _compress="${SWITCHROOM_SIDECAR_LOG_COMPRESS:-1}"
     # Validate BOTH env overrides up front; garbage falls back to the
     # default. Unvalidated, a non-numeric interval makes `sleep` fail
     # instantly and the `while true` loop hot-spins a CPU core for the
@@ -208,12 +220,28 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
     # interval would also hot-spin, so it falls back too.
     case "$_max" in ''|*[!0-9]*) _max=52428800;; esac
     case "$_interval" in ''|0|*[!0-9]*) _interval=300;; esac
+    # Same garbage guard for the age bound; 0 disables the age reaper
+    # (the size-triggered overwrite still applies).
+    case "$_max_age_sec" in ''|*[!0-9]*) _max_age_sec=1209600;; esac
+    # `find -mmin` takes MINUTES; round up so a sub-minute age still reaps.
+    local _max_age_min=$(( (_max_age_sec + 59) / 60 ))
     # A cap of 0 disables rotation entirely (operator escape hatch).
     # (Negative values contain '-' → non-numeric per the guard above →
     # default cap, i.e. rotation stays on.)
     [ "$_max" -eq 0 ] && return 0
+    local _dir _base
+    _dir=$(dirname "$_logfile")
+    _base=$(basename "$_logfile")
     while true; do
       sleep "$_interval"
+      # Age-reap the retained generation first — this runs every cycle,
+      # INDEPENDENT of whether the live log is over cap, which is exactly
+      # the case the old code never handled (#3596).
+      if [ "$_max_age_min" -gt 0 ]; then
+        find "$_dir" -maxdepth 1 -type f \
+          \( -name "$_base.1" -o -name "$_base.1.gz" \) \
+          -mmin "+$_max_age_min" -exec rm -f {} + 2>/dev/null || true
+      fi
       [ -f "$_logfile" ] || continue
       local _size
       _size=$(wc -c < "$_logfile" 2>/dev/null || echo 0)
@@ -222,6 +250,13 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
       if [ "$_size" -gt "$_max" ]; then
         if cp "$_logfile" "$_logfile.1" 2>/dev/null; then
           : > "$_logfile"
+          # Drop any stale compressed generation, then (best-effort)
+          # compress the fresh one. gzip failing (missing binary, ENOSPC)
+          # just leaves the plain `.1` — never fatal.
+          rm -f "$_logfile.1.gz" 2>/dev/null || true
+          if [ "$_compress" != "0" ] && command -v gzip >/dev/null 2>&1; then
+            gzip -f "$_logfile.1" 2>/dev/null || true
+          fi
           echo "[supervise] rotated $_logfile (${_size} bytes > ${_max} cap) → ${_logfile}.1" >> "$_logfile"
         else
           # cp failed (e.g. ENOSPC — exactly when rotation matters most).

--- a/src/cli/doctor-audit-integrity.test.ts
+++ b/src/cli/doctor-audit-integrity.test.ts
@@ -43,7 +43,11 @@ function legacyRow(o: Record<string, unknown>): string {
 /** A reader that serves `files[path]`; absent path → throw (ENOENT). */
 function reader(files: Record<string, string>) {
   return (p: string) => {
-    if (!(p in files)) throw new Error("ENOENT");
+    if (!(p in files)) {
+      throw Object.assign(new Error(`ENOENT: no such file, open '${p}'`), {
+        code: "ENOENT",
+      });
+    }
     return files[p];
   };
 }
@@ -268,6 +272,87 @@ describe("runAuditIntegrityChecks across a rotation seam (#3600)", () => {
     });
     expect(
       r.find((c) => c.name.includes("hostd audit log present")),
+    ).toBeUndefined();
+    expect(r.find((c) => c.name.includes("hostd audit chain"))?.status).toBe("ok");
+  });
+});
+
+// ── #3600 re-review, finding 2 — unreadable is NOT absent ───────────────
+//
+// `readRetainedHistory` skips generations the reader throws on. If that
+// skip cannot tell ENOENT from EACCES, an attacker doctors `.1`, chmods
+// it 000, and doctor prints "chain valid ... tamper-evidence active" —
+// a false attestation, on the surface whose entire job is attestation.
+
+describe("runAuditIntegrityChecks — unreadable generations (#3600 re-review)", () => {
+  /** Serves `files[path]`; `errors[path]` throws that errno instead. */
+  function readerWithErrors(
+    files: Record<string, string>,
+    errors: Record<string, string>,
+  ) {
+    return (p: string) => {
+      if (p in errors) {
+        throw Object.assign(new Error(`${errors[p]}: ${p}`), {
+          code: errors[p],
+        });
+      }
+      if (!(p in files)) {
+        throw Object.assign(new Error(`ENOENT: no such file, open '${p}'`), {
+          code: "ENOENT",
+        });
+      }
+      return files[p];
+    };
+  }
+
+  it("FAILS instead of attesting when a rotated generation cannot be read", () => {
+    const r = runAuditIntegrityChecks({
+      homeDir: HOME,
+      readFileSync: readerWithErrors(
+        {
+          [VAULT]: chainedLog([{ ts: "t", op: "get" }]),
+          [HOSTD]: chainedLog([{ ts: "c", op: "agent_restart" }]),
+        },
+        { [`${HOSTD}.1`]: "EACCES" },
+      ),
+    });
+    const readable = r.find((c) => c.name.includes("hostd audit chain readable"));
+    expect(readable?.status).toBe("fail");
+    expect(readable?.detail).toContain(`${HOSTD}.1`);
+    expect(readable?.detail).toContain("EACCES");
+    // and it must NOT also print a clean chain verdict for this log
+    expect(r.find((c) => c.name === "hostd audit chain")).toBeUndefined();
+  });
+
+  it("fails the same way when the ACTIVE file is unreadable", () => {
+    const r = runAuditIntegrityChecks({
+      homeDir: HOME,
+      readFileSync: readerWithErrors(
+        {
+          [VAULT]: chainedLog([{ ts: "t", op: "get" }]),
+          [`${HOSTD}.1`]: chainedLog([{ ts: "b", op: "agent_restart" }]),
+        },
+        { [HOSTD]: "EIO" },
+      ),
+    });
+    expect(
+      r.find((c) => c.name.includes("hostd audit chain readable"))?.status,
+    ).toBe("fail");
+  });
+
+  it("ENOENT is still plain absence, not a failure", () => {
+    const r = runAuditIntegrityChecks({
+      homeDir: HOME,
+      readFileSync: readerWithErrors(
+        {
+          [VAULT]: chainedLog([{ ts: "t", op: "get" }]),
+          [HOSTD]: chainedLog([{ ts: "c", op: "agent_restart" }]),
+        },
+        {},
+      ),
+    });
+    expect(
+      r.find((c) => c.name.includes("hostd audit chain readable")),
     ).toBeUndefined();
     expect(r.find((c) => c.name.includes("hostd audit chain"))?.status).toBe("ok");
   });

--- a/src/cli/doctor-audit-integrity.test.ts
+++ b/src/cli/doctor-audit-integrity.test.ts
@@ -184,3 +184,91 @@ describe("runAuditIntegrityChecks", () => {
     expect(c?.status).toBe("ok");
   });
 });
+
+// ── #3600 review, finding 2 — rotation must not shrink the tamper check ──
+//
+// Both root-written logs are size-rotated now. Verifying only the active
+// file would mean that after the first rotation `doctor` reports "ok"
+// while attesting nothing about the ~96 MiB of history in `.1`-`.3`, and
+// that the momentarily-empty active file trips the "audit-blinding" warn.
+
+describe("runAuditIntegrityChecks across a rotation seam (#3600)", () => {
+  it("VERIFIES the rotated generations, not just the active file", () => {
+    // Tamper lives ONLY in `.1`; the active file is pristine. Pre-fix this
+    // reported ok — the whole point of the finding.
+    const good = chainedLog([{ ts: "t1", op: "agent_restart" }]);
+    const tamperedGen = good.replace('"agent_restart"', '"agent_stop"');
+    const r = runAuditIntegrityChecks({
+      homeDir: HOME,
+      readFileSync: reader({
+        [VAULT]: chainedLog([{ ts: "t", op: "get" }]),
+        [`${HOSTD}.1`]: tamperedGen,
+        [HOSTD]: chainedLog([{ ts: "t2", op: "agent_restart" }]),
+      }),
+    });
+    const hostd = r.find((c) => c.name.includes("hostd audit chain"));
+    expect(hostd?.status).toBe("fail");
+  });
+
+  it("still reports ok when the whole retained history verifies", () => {
+    const r = runAuditIntegrityChecks({
+      homeDir: HOME,
+      readFileSync: reader({
+        [VAULT]: chainedLog([{ ts: "t", op: "get" }]),
+        [`${HOSTD}.2`]: chainedLog([{ ts: "a", op: "agent_restart" }]),
+        [`${HOSTD}.1`]: chainedLog([{ ts: "b", op: "agent_restart" }]),
+        [HOSTD]: chainedLog([{ ts: "c", op: "agent_restart" }]),
+      }),
+    });
+    const hostd = r.find((c) => c.name.includes("hostd audit chain"));
+    expect(hostd?.status).toBe("ok");
+  });
+
+  it("an EMPTY active file with a populated .1 is NOT the fail-open symptom", () => {
+    // Rotation produces exactly this for a few ms — and permanently if the
+    // triggering append then fails.
+    const r = runAuditIntegrityChecks({
+      homeDir: HOME,
+      readFileSync: reader({
+        [VAULT]: chainedLog([{ ts: "t", op: "get" }]),
+        [`${HOSTD}.1`]: chainedLog([{ ts: "b", op: "agent_restart" }]),
+        [HOSTD]: "",
+      }),
+    });
+    expect(
+      r.find((c) => c.name.includes("hostd audit log non-empty")),
+    ).toBeUndefined();
+    expect(
+      r.find((c) => c.name.includes("hostd audit log present")),
+    ).toBeUndefined();
+    expect(r.find((c) => c.name.includes("hostd audit chain"))?.status).toBe("ok");
+  });
+
+  it("EVERY generation empty still warns (the real audit-blinding signal)", () => {
+    const r = runAuditIntegrityChecks({
+      homeDir: HOME,
+      readFileSync: reader({
+        [VAULT]: chainedLog([{ ts: "t", op: "get" }]),
+        [`${HOSTD}.1`]: "",
+        [HOSTD]: "",
+      }),
+    });
+    expect(
+      r.find((c) => c.name.includes("hostd audit log non-empty"))?.status,
+    ).toBe("warn");
+  });
+
+  it("a log present ONLY as a rotated generation is not reported missing", () => {
+    const r = runAuditIntegrityChecks({
+      homeDir: HOME,
+      readFileSync: reader({
+        [VAULT]: chainedLog([{ ts: "t", op: "get" }]),
+        [`${HOSTD}.1`]: chainedLog([{ ts: "b", op: "agent_restart" }]),
+      }),
+    });
+    expect(
+      r.find((c) => c.name.includes("hostd audit log present")),
+    ).toBeUndefined();
+    expect(r.find((c) => c.name.includes("hostd audit chain"))?.status).toBe("ok");
+  });
+});

--- a/src/cli/doctor-audit-integrity.ts
+++ b/src/cli/doctor-audit-integrity.ts
@@ -102,39 +102,45 @@ function rootWrittenLogs(home: string): LogTarget[] {
 
 /**
  * Concatenate the log's retained history OLDEST-first: `<path>.N` … `.1`
- * then the active file. An absent generation is skipped rather than
+ * then the active file. An ABSENT generation is skipped rather than
  * ending the walk, so a gap (a crashed rotation, an operator deleting one
  * file) still gets the surviving generations verified.
  *
- * Returns the combined text plus the paths that actually contributed —
- * an empty `sources` means "nothing on disk at all", which is the
- * genuinely missing case.
+ * An UNREADABLE generation is NOT absence and must never be skipped
+ * quietly (#3600 re-review, finding 2): this is the tamper-detection
+ * surface, so `chmod 000` on a doctored `.1` would otherwise buy an
+ * attacker a clean "chain valid — tamper-evidence active" verdict. Those
+ * paths come back in `unreadable` and the caller fails the check.
+ *
+ * Returns the combined text, the paths that actually contributed — an
+ * empty `sources` means "nothing on disk at all", the genuinely missing
+ * case — and the paths that exist but could not be read.
  */
 function readRetainedHistory(
   read: (p: string) => string,
   path: string,
   maxFiles: number,
-): { text: string; sources: string[] } {
+): { text: string; sources: string[]; unreadable: { path: string; error: string }[] } {
   const parts: { path: string; text: string }[] = [];
-  for (let n = maxFiles; n >= 1; n--) {
-    const gen = `${path}.${n}`;
-    let t: string;
+  const unreadable: { path: string; error: string }[] = [];
+  const attempt = (p: string) => {
     try {
-      t = read(gen);
-    } catch {
-      continue; // absent generation — older ones may still exist
+      parts.push({ path: p, text: read(p) });
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      // ENOENT is the only "it is not there" errno. Everything else
+      // (EACCES, EIO, EISDIR, ELOOP, a vanished network mount) means the
+      // file exists and we could not see it.
+      if (e.code === "ENOENT") return;
+      unreadable.push({ path: p, error: e.code ?? e.message ?? String(err) });
     }
-    parts.push({ path: gen, text: t });
-  }
-  try {
-    parts.push({ path, text: read(path) });
-  } catch {
-    /* active file absent — rotated generations (if any) still count */
-  }
+  };
+  for (let n = maxFiles; n >= 1; n--) attempt(`${path}.${n}`);
+  attempt(path);
   const text = parts
     .map((p) => (p.text.endsWith("\n") || p.text.length === 0 ? p.text : p.text + "\n"))
     .join("");
-  return { text, sources: parts.map((p) => p.path) };
+  return { text, sources: parts.map((p) => p.path), unreadable };
 }
 
 export function runAuditIntegrityChecks(
@@ -178,7 +184,21 @@ export function runAuditIntegrityChecks(
     // doctor would report "ok" while attesting nothing about the ~96 MiB
     // sitting in `.1`-`.3`. Verify the whole RETAINED history,
     // oldest-first, so the chain is checked exactly as it was written.
-    const { text, sources } = readRetainedHistory(read, path, maxFiles);
+    const { text, sources, unreadable } = readRetainedHistory(read, path, maxFiles);
+
+    if (unreadable.length > 0) {
+      // Cannot attest what we cannot read. Fail rather than verify the
+      // remainder and print "tamper-evidence active" (#3600 re-review,
+      // finding 2) — hiding a doctored generation behind a chmod must
+      // never be cheaper than tampering with a readable one.
+      results.push({
+        name: `${label} audit chain readable`,
+        status: "fail",
+        detail: `${unreadable.map((u) => `${u.path} (${u.error})`).join(", ")} exist(s) but could not be read — the ${label} audit chain CANNOT be verified over the full retained history, so no tamper-evidence claim can be made about ${sources.length > 0 ? "the remaining generation(s)" : "this log"}`,
+        fix: `Restore read access (root-owned, mode 0600 is expected — run doctor as the operator/root) and re-run; if the file is not a regular file or the volume is failing, investigate immediately: an unreadable audit generation is an audit-blinding signal (WS10-F3/F4).`,
+      });
+      continue;
+    }
 
     if (sources.length === 0) {
       results.push({

--- a/src/cli/doctor-audit-integrity.ts
+++ b/src/cli/doctor-audit-integrity.ts
@@ -30,9 +30,16 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { verifyAuditLog } from "../util/audit-hashchain.js";
+import { resolveRotationConfig } from "../util/log-rotation.js";
+import {
+  DEFAULT_HOSTD_AUDIT_MAX_BYTES,
+  DEFAULT_HOSTD_AUDIT_MAX_FILES,
+} from "../host-control/audit-rotation-config.js";
 import {
   failOpenStatePath,
   readFailOpenState,
+  DEFAULT_AUDIT_MAX_BYTES,
+  DEFAULT_AUDIT_MAX_FILES,
   type FailOpenState,
 } from "../vault/broker/audit-log.js";
 
@@ -62,16 +69,72 @@ export interface AuditIntegrityDeps {
 interface LogTarget {
   label: string;
   path: string;
+  /** Rotated generations (`<path>.1` … `.N`) this log retains — resolved
+   *  from the writer's own config so a raised retention is still fully
+   *  verified (#3600). */
+  maxFiles: number;
 }
 
 function rootWrittenLogs(home: string): LogTarget[] {
   return [
-    { label: "vault-broker", path: join(home, ".switchroom", "vault-audit.log") },
+    {
+      label: "vault-broker",
+      path: join(home, ".switchroom", "vault-audit.log"),
+      maxFiles: resolveRotationConfig({
+        envBytesVar: "SWITCHROOM_VAULT_AUDIT_MAX_BYTES",
+        envFilesVar: "SWITCHROOM_VAULT_AUDIT_MAX_FILES",
+        defaultBytes: DEFAULT_AUDIT_MAX_BYTES,
+        defaultFiles: DEFAULT_AUDIT_MAX_FILES,
+      }).maxFiles,
+    },
     {
       label: "hostd",
       path: join(home, ".switchroom", "host-control-audit.log"),
+      maxFiles: resolveRotationConfig({
+        envBytesVar: "SWITCHROOM_HOSTD_AUDIT_MAX_BYTES",
+        envFilesVar: "SWITCHROOM_HOSTD_AUDIT_MAX_FILES",
+        defaultBytes: DEFAULT_HOSTD_AUDIT_MAX_BYTES,
+        defaultFiles: DEFAULT_HOSTD_AUDIT_MAX_FILES,
+      }).maxFiles,
     },
   ];
+}
+
+/**
+ * Concatenate the log's retained history OLDEST-first: `<path>.N` … `.1`
+ * then the active file. An absent generation is skipped rather than
+ * ending the walk, so a gap (a crashed rotation, an operator deleting one
+ * file) still gets the surviving generations verified.
+ *
+ * Returns the combined text plus the paths that actually contributed —
+ * an empty `sources` means "nothing on disk at all", which is the
+ * genuinely missing case.
+ */
+function readRetainedHistory(
+  read: (p: string) => string,
+  path: string,
+  maxFiles: number,
+): { text: string; sources: string[] } {
+  const parts: { path: string; text: string }[] = [];
+  for (let n = maxFiles; n >= 1; n--) {
+    const gen = `${path}.${n}`;
+    let t: string;
+    try {
+      t = read(gen);
+    } catch {
+      continue; // absent generation — older ones may still exist
+    }
+    parts.push({ path: gen, text: t });
+  }
+  try {
+    parts.push({ path, text: read(path) });
+  } catch {
+    /* active file absent — rotated generations (if any) still count */
+  }
+  const text = parts
+    .map((p) => (p.text.endsWith("\n") || p.text.length === 0 ? p.text : p.text + "\n"))
+    .join("");
+  return { text, sources: parts.map((p) => p.path) };
 }
 
 export function runAuditIntegrityChecks(
@@ -108,25 +171,34 @@ export function runAuditIntegrityChecks(
     });
   }
 
-  for (const { label, path } of rootWrittenLogs(home)) {
-    let text: string;
-    try {
-      text = read(path);
-    } catch {
+  for (const { label, path, maxFiles } of rootWrittenLogs(home)) {
+    // #3600 review, finding 2 — BOTH root-written logs are size-rotated
+    // now, so verifying only the active file would silently shrink this
+    // tamper check to the current generation: after the first rotation
+    // doctor would report "ok" while attesting nothing about the ~96 MiB
+    // sitting in `.1`-`.3`. Verify the whole RETAINED history,
+    // oldest-first, so the chain is checked exactly as it was written.
+    const { text, sources } = readRetainedHistory(read, path, maxFiles);
+
+    if (sources.length === 0) {
       results.push({
         name: `${label} audit log present`,
         status: "warn",
-        detail: `no audit log at ${path} — the ${label} may never have written one, or it was removed (audit-blinding is a cheap pre-attack step; WS10-F3/F4)`,
+        detail: `no audit log at ${path} (nor any rotated generation) — the ${label} may never have written one, or it was removed (audit-blinding is a cheap pre-attack step; WS10-F3/F4)`,
         fix: `Confirm the ${label} is running and its audit volume is mounted; investigate if the file vanished.`,
       });
       continue;
     }
 
     if (text.trim().length === 0) {
+      // An empty ACTIVE file is normal for a few ms after a rotation (and
+      // persists if the triggering append then fails), so this only fires
+      // when every retained generation is empty too — which really is the
+      // fail-open / audit-blinding symptom.
       results.push({
         name: `${label} audit log non-empty`,
         status: "warn",
-        detail: `${path} exists but is empty — expected at least boot/activity rows; an emptied audit trail is the WS10-F3 fail-open symptom`,
+        detail: `${sources.join(", ")} exist but are empty — expected at least boot/activity rows; an emptied audit trail is the WS10-F3 fail-open symptom`,
         fix: `Investigate whether audit writes are failing (check ${label} stderr) and whether the file was truncated.`,
       });
       continue;

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -44,6 +44,7 @@ import { checkDowngrade } from "./deploy-version-guard.js";
 import { removeStaleContainerIfNeeded } from "./singleton-stale-cleanup.js";
 import {
   defaultAuditLogPath,
+  readAuditRaw,
   formatForCli,
   readAndFilter,
 } from "../host-control/audit-reader.js";
@@ -864,7 +865,9 @@ export function registerHostdCommand(program: Command): void {
         );
         return;
       }
-      const raw = readFileSync(logPath, "utf-8");
+      // Seam-aware: back-fills from `<log>.1` right after a rotation so
+      // `hostd audit` never looks like it lost history (#3596).
+      const raw = readAuditRaw(logPath);
       const limit = Math.max(1, parseInt(opts.tail ?? "50", 10) || 50);
       const filters = {
         agent: opts.agent,

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -52,7 +52,7 @@ import { resolveOperatorUid } from "./operator-uid.js";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { compareReleaseTags } from "../config/release-resolve.js";
 import { SWITCHROOM_VERSION } from "./resolve-version.js";
-import { readAndFilter, defaultAuditLogPath } from "../host-control/audit-reader.js";
+import { readAndFilter, defaultAuditLogPath, readAuditRaw } from "../host-control/audit-reader.js";
 import { isHindsightContainerExists } from "../setup/hindsight.js";
 import { deployedImageTag } from "./deploy-version-guard.js";
 import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
@@ -858,7 +858,7 @@ export function resolveRollbackTarget(auditLogPath?: string): string | null {
   const logPath = auditLogPath ?? defaultAuditLogPath(homedir());
   let raw: string;
   try {
-    raw = readFileSync(logPath, "utf8");
+    raw = readAuditRaw(logPath);
   } catch {
     return null;
   }

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -52,7 +52,12 @@ import { resolveOperatorUid } from "./operator-uid.js";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { compareReleaseTags } from "../config/release-resolve.js";
 import { SWITCHROOM_VERSION } from "./resolve-version.js";
-import { readAndFilter, defaultAuditLogPath, readAuditRaw } from "../host-control/audit-reader.js";
+import {
+  readAndFilter,
+  defaultAuditLogPath,
+  readAuditRaw,
+  AUDIT_READ_FULL_WINDOW_BYTES,
+} from "../host-control/audit-reader.js";
 import { isHindsightContainerExists } from "../setup/hindsight.js";
 import { deployedImageTag } from "./deploy-version-guard.js";
 import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
@@ -858,8 +863,24 @@ export function resolveRollbackTarget(auditLogPath?: string): string | null {
   const logPath = auditLogPath ?? defaultAuditLogPath(homedir());
   let raw: string;
   try {
-    raw = readAuditRaw(logPath);
-  } catch {
+    // Full window + strict (#3600 review, findings 3 & 4): this resolves
+    // the rollback TARGET, so a rollout row missed because it fell
+    // outside a 4 MiB tail — `agent_smoke` rows dominate the log — would
+    // silently degrade to "no prior rollout found" on exactly the busy
+    // hosts that need it. And a read error must not masquerade as
+    // absence; the caller then requires an explicit `--pin`.
+    raw = readAuditRaw(logPath, {
+      windowBytes: AUDIT_READ_FULL_WINDOW_BYTES,
+      strict: true,
+    });
+  } catch (err) {
+    // A missing log yields "" (not a throw), so reaching here means a REAL
+    // I/O failure. Say so — otherwise the caller's "no prior rollout
+    // found; pass --pin" reads as a fact about history rather than as
+    // "I could not look" (#3600 review, finding 4).
+    process.stderr.write(
+      `rollout: could not read the hostd audit log at ${logPath}: ${(err as Error).message} — cannot resolve a rollback target from history; pass --pin explicitly.\n`,
+    );
     return null;
   }
   // Read all rollout terminal completed rows (most-recent at the end).

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -56,7 +56,7 @@ import {
   readAndFilter,
   defaultAuditLogPath,
   readAuditRaw,
-  AUDIT_READ_FULL_WINDOW_BYTES,
+  auditReadFullWindowBytes,
 } from "../host-control/audit-reader.js";
 import { isHindsightContainerExists } from "../setup/hindsight.js";
 import { deployedImageTag } from "./deploy-version-guard.js";
@@ -870,7 +870,7 @@ export function resolveRollbackTarget(auditLogPath?: string): string | null {
     // hosts that need it. And a read error must not masquerade as
     // absence; the caller then requires an explicit `--pin`.
     raw = readAuditRaw(logPath, {
-      windowBytes: AUDIT_READ_FULL_WINDOW_BYTES,
+      windowBytes: auditReadFullWindowBytes(),
       strict: true,
     });
   } catch (err) {

--- a/src/host-control/audit-reader-seam.test.ts
+++ b/src/host-control/audit-reader-seam.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #3600 review — findings 4, 5, 6 on the seam-aware reader.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  readAuditRaw,
+  auditReadMaxGenerations,
+  AUDIT_READ_FULL_WINDOW_BYTES,
+} from "./audit-reader.js";
+import { DEFAULT_HOSTD_AUDIT_MAX_FILES } from "./audit-rotation-config.js";
+
+let dir: string;
+let log: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "audit-seam-"));
+  log = path.join(dir, "host-control-audit.log");
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  delete process.env.SWITCHROOM_HOSTD_AUDIT_MAX_FILES;
+});
+
+describe("readAuditRaw — I/O errors vs absence (finding 4)", () => {
+  it("returns '' for a MISSING log in both modes (absence is not an error)", () => {
+    expect(readAuditRaw(log)).toBe("");
+    expect(readAuditRaw(log, { strict: true })).toBe("");
+  });
+
+  it("strict THROWS on a real I/O failure instead of reporting emptiness", () => {
+    // A directory at the log path fails open(2) with EISDIR — a real I/O
+    // error that is not ENOENT, and (unlike chmod 000) it still fails for
+    // uid 0, so this holds in root containers too.
+    fs.mkdirSync(log);
+    expect(() => readAuditRaw(log, { strict: true })).toThrow();
+    // Non-strict keeps the old best-effort behaviour.
+    expect(readAuditRaw(log)).toBe("");
+  });
+});
+
+describe("readAuditRaw — generation walk (finding 5)", () => {
+  it("an EMPTY .1 does not stop the walk to .2 / .3", () => {
+    fs.writeFileSync(`${log}.3`, "row-oldest\n");
+    fs.writeFileSync(`${log}.2`, "row-older\n");
+    fs.writeFileSync(`${log}.1`, ""); // crashed/raced rotation
+    fs.writeFileSync(log, "row-newest\n");
+
+    const raw = readAuditRaw(log);
+    expect(raw).toContain("row-oldest");
+    expect(raw).toContain("row-older");
+    expect(raw).toContain("row-newest");
+    // Oldest-first ordering preserved.
+    expect(raw.indexOf("row-oldest")).toBeLessThan(raw.indexOf("row-older"));
+    expect(raw.indexOf("row-older")).toBeLessThan(raw.indexOf("row-newest"));
+  });
+
+  it("an ABSENT generation ends the walk (rotation shifts contiguously)", () => {
+    fs.writeFileSync(`${log}.3`, "unreachable\n");
+    // no .2 → nothing older than .1 is claimed to exist
+    fs.writeFileSync(`${log}.1`, "row-1\n");
+    fs.writeFileSync(log, "row-active\n");
+    const raw = readAuditRaw(log);
+    expect(raw).toContain("row-1");
+    expect(raw).toContain("row-active");
+    expect(raw).not.toContain("unreachable");
+  });
+});
+
+describe("auditReadMaxGenerations — no hand-mirrored constant (finding 6)", () => {
+  it("defaults to the writer's retention", () => {
+    expect(auditReadMaxGenerations()).toBe(DEFAULT_HOSTD_AUDIT_MAX_FILES);
+  });
+
+  it("follows SWITCHROOM_HOSTD_AUDIT_MAX_FILES so the reader can't lag the writer", () => {
+    process.env.SWITCHROOM_HOSTD_AUDIT_MAX_FILES = "6";
+    expect(auditReadMaxGenerations()).toBe(6);
+    // A 6th generation written under that setting is actually read.
+    for (let n = 1; n <= 6; n++) fs.writeFileSync(`${log}.${n}`, `gen-${n}\n`);
+    fs.writeFileSync(log, "active\n");
+    const raw = readAuditRaw(log);
+    expect(raw).toContain("gen-6");
+    expect(raw).toContain("active");
+  });
+});
+
+describe("AUDIT_READ_FULL_WINDOW_BYTES (finding 3)", () => {
+  it("reaches rows the default 4 MiB tail window would drop", () => {
+    const marker = '{"marker":"oldest"}\n';
+    // 5 MiB of noise after the marker pushes it out of the default window.
+    fs.writeFileSync(log, marker + "n".repeat(5 * 1024 * 1024) + "\n");
+    expect(readAuditRaw(log)).not.toContain("oldest");
+    expect(
+      readAuditRaw(log, { windowBytes: AUDIT_READ_FULL_WINDOW_BYTES }),
+    ).toContain("oldest");
+  });
+});

--- a/src/host-control/audit-reader-seam.test.ts
+++ b/src/host-control/audit-reader-seam.test.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 import {
   readAuditRaw,
   auditReadMaxGenerations,
-  AUDIT_READ_FULL_WINDOW_BYTES,
+  auditReadFullWindowBytes,
 } from "./audit-reader.js";
 import { DEFAULT_HOSTD_AUDIT_MAX_FILES } from "./audit-rotation-config.js";
 
@@ -86,14 +86,38 @@ describe("auditReadMaxGenerations — no hand-mirrored constant (finding 6)", ()
   });
 });
 
-describe("AUDIT_READ_FULL_WINDOW_BYTES (finding 3)", () => {
+describe("auditReadFullWindowBytes (finding 3)", () => {
   it("reaches rows the default 4 MiB tail window would drop", () => {
     const marker = '{"marker":"oldest"}\n';
     // 5 MiB of noise after the marker pushes it out of the default window.
     fs.writeFileSync(log, marker + "n".repeat(5 * 1024 * 1024) + "\n");
     expect(readAuditRaw(log)).not.toContain("oldest");
     expect(
-      readAuditRaw(log, { windowBytes: AUDIT_READ_FULL_WINDOW_BYTES }),
+      readAuditRaw(log, { windowBytes: auditReadFullWindowBytes() }),
     ).toContain("oldest");
+  });
+
+  it("scales with the WRITER's retention, so the window never reads less than the writer keeps (re-review, finding 3)", () => {
+    // A hardcoded 128 MiB is correct only at the default maxFiles=3.
+    // Raise retention and the window must grow with it, or
+    // resolveRollbackTarget silently truncates the extra generations
+    // auditReadMaxGenerations() faithfully walks.
+    const base = auditReadFullWindowBytes();
+    process.env.SWITCHROOM_HOSTD_AUDIT_MAX_FILES = "6";
+    try {
+      expect(auditReadMaxGenerations()).toBe(6);
+      expect(auditReadFullWindowBytes()).toBe((6 + 1) * 32 * 1024 * 1024);
+      expect(auditReadFullWindowBytes()).toBeGreaterThan(base);
+    } finally {
+      delete process.env.SWITCHROOM_HOSTD_AUDIT_MAX_FILES;
+    }
+    expect(auditReadFullWindowBytes()).toBe(base);
+
+    process.env.SWITCHROOM_HOSTD_AUDIT_MAX_BYTES = String(64 * 1024 * 1024);
+    try {
+      expect(auditReadFullWindowBytes()).toBe((3 + 1) * 64 * 1024 * 1024);
+    } finally {
+      delete process.env.SWITCHROOM_HOSTD_AUDIT_MAX_BYTES;
+    }
   });
 });

--- a/src/host-control/audit-reader.ts
+++ b/src/host-control/audit-reader.ts
@@ -13,6 +13,7 @@
  * module to share parsing + filtering semantics.
  */
 
+import { closeSync, openSync, readSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -78,6 +79,93 @@ export interface AuditFilters {
 
 export function defaultAuditLogPath(home: string = homedir()): string {
   return join(home, ".switchroom", "host-control-audit.log");
+}
+
+/**
+ * How many bytes of audit history a seam-aware read aims to return.
+ * Sized so `--tail 50` (and the dashboard's 1000-row window) still has
+ * material to work with immediately after a rotation.
+ */
+export const AUDIT_READ_WINDOW_BYTES = 4 * 1024 * 1024;
+
+/** How many rotated generations a seam-aware read will walk back through
+ *  (mirrors `DEFAULT_HOSTD_AUDIT_MAX_FILES`). The byte window above is the
+ *  real bound — this just stops the `existsSync` walk. */
+export const AUDIT_READ_MAX_GENERATIONS = 3;
+
+/** Read the last `n` bytes of `path`, dropping a leading partial line.
+ *  Returns "" if the file is missing/unreadable. */
+function tailBytes(path: string, n: number): string {
+  if (n <= 0) return "";
+  let fd: number;
+  let size: number;
+  try {
+    size = statSync(path).size;
+    fd = openSync(path, "r");
+  } catch {
+    return "";
+  }
+  try {
+    const len = Math.min(n, size);
+    const start = size - len;
+    const buf = Buffer.alloc(len);
+    let read = 0;
+    while (read < len) {
+      const got = readSync(fd, buf, read, len - read, start + read);
+      if (got <= 0) break;
+      read += got;
+    }
+    let text = buf.subarray(0, read).toString("utf-8");
+    // Dropped a leading partial line? Cut to the first newline. (Not
+    // needed when we started at byte 0 — that line is whole.)
+    if (start > 0) {
+      const nl = text.indexOf("\n");
+      text = nl === -1 ? "" : text.slice(nl + 1);
+    }
+    return text;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Seam-aware raw read of the hostd audit log (#3596).
+ *
+ * The active log is size-rotated (`server.ts` → `maybeRotateAuditLog`),
+ * so reading ONLY `<path>` shows an almost-empty file for a while right
+ * after a rotation — `switchroom hostd audit`, the dashboard panel and
+ * `get_status` would all appear to have lost history. This reads the
+ * active file and, when it is smaller than the read window, back-fills
+ * from `<path>.1` (oldest-first) so the seam is invisible to consumers.
+ *
+ * Bounded by construction: at most `windowBytes` of `.1` is read, and a
+ * partial first line is dropped (`parseAuditLine` would return null for
+ * it anyway).
+ */
+export function readAuditRaw(
+  logPath: string,
+  windowBytes: number = AUDIT_READ_WINDOW_BYTES,
+  maxFiles: number = AUDIT_READ_MAX_GENERATIONS,
+): string {
+  // Newest-first: active, then `.1`, `.2`, … stopping as soon as the
+  // window is full or a generation is absent.
+  const chunks: string[] = [];
+  let budget = windowBytes;
+  const active = tailBytes(logPath, budget);
+  chunks.push(active);
+  budget -= Buffer.byteLength(active, "utf-8");
+  for (let n = 1; n <= maxFiles && budget > 0; n++) {
+    const chunk = tailBytes(`${logPath}.${n}`, budget);
+    if (chunk.length === 0) break;
+    chunks.push(chunk);
+    budget -= Buffer.byteLength(chunk, "utf-8");
+  }
+  // Emit oldest-first so consumers keep their chronological contract.
+  return chunks
+    .reverse()
+    .filter((c) => c.length > 0)
+    .map((c) => (c.endsWith("\n") ? c : c + "\n"))
+    .join("");
 }
 
 /** Parse a single JSONL line. Returns null on malformed input — the log

--- a/src/host-control/audit-reader.ts
+++ b/src/host-control/audit-reader.ts
@@ -94,12 +94,32 @@ export function defaultAuditLogPath(home: string = homedir()): string {
 export const AUDIT_READ_WINDOW_BYTES = 4 * 1024 * 1024;
 
 /**
- * Whole-history window for callers that must not miss an old row
- * (`resolveRollbackTarget` — #3600 review, finding 3). 128 MiB is the
- * writer-side ceiling at the default 32 MiB × (3+1) generations, so this
- * is "everything that exists" without being unbounded.
+ * Resolve the hostd audit rotation config the WRITER will use. Single
+ * source of truth for both the generation count and the byte window
+ * (#3600 review, finding 6 / re-review, finding 3) — a hand-mirrored
+ * constant here silently truncates history the moment an operator raises
+ * `SWITCHROOM_HOSTD_AUDIT_MAX_FILES`/`_MAX_BYTES`.
  */
-export const AUDIT_READ_FULL_WINDOW_BYTES = 128 * 1024 * 1024;
+function auditRotation(): { maxBytes: number; maxFiles: number } {
+  return resolveRotationConfig({
+    envBytesVar: "SWITCHROOM_HOSTD_AUDIT_MAX_BYTES",
+    envFilesVar: "SWITCHROOM_HOSTD_AUDIT_MAX_FILES",
+    defaultBytes: DEFAULT_HOSTD_AUDIT_MAX_BYTES,
+    defaultFiles: DEFAULT_HOSTD_AUDIT_MAX_FILES,
+  });
+}
+
+/**
+ * Whole-history window for callers that must not miss an old row
+ * (`resolveRollbackTarget` — #3600 review, finding 3). Derived as
+ * `(maxFiles + 1) x maxBytes`: the writer-side ceiling on everything that
+ * can exist on disk, so this is "all of it" without being unbounded.
+ * 128 MiB at the defaults (32 MiB x (3+1)).
+ */
+export function auditReadFullWindowBytes(): number {
+  const { maxBytes, maxFiles } = auditRotation();
+  return (maxFiles + 1) * maxBytes;
+}
 
 /**
  * How many rotated generations a seam-aware read walks back through.
@@ -109,12 +129,7 @@ export const AUDIT_READ_FULL_WINDOW_BYTES = 128 * 1024 * 1024;
  * The byte window remains the real bound.
  */
 export function auditReadMaxGenerations(): number {
-  return resolveRotationConfig({
-    envBytesVar: "SWITCHROOM_HOSTD_AUDIT_MAX_BYTES",
-    envFilesVar: "SWITCHROOM_HOSTD_AUDIT_MAX_FILES",
-    defaultBytes: DEFAULT_HOSTD_AUDIT_MAX_BYTES,
-    defaultFiles: DEFAULT_HOSTD_AUDIT_MAX_FILES,
-  }).maxFiles;
+  return auditRotation().maxFiles;
 }
 
 export interface AuditReadOptions {

--- a/src/host-control/audit-reader.ts
+++ b/src/host-control/audit-reader.ts
@@ -13,9 +13,14 @@
  * module to share parsing + filtering semantics.
  */
 
-import { closeSync, openSync, readSync, statSync } from "node:fs";
+import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { resolveRotationConfig } from "../util/log-rotation.js";
+import {
+  DEFAULT_HOSTD_AUDIT_MAX_BYTES,
+  DEFAULT_HOSTD_AUDIT_MAX_FILES,
+} from "./audit-rotation-config.js";
 
 export interface AuditEntry {
   ts: string;
@@ -88,21 +93,60 @@ export function defaultAuditLogPath(home: string = homedir()): string {
  */
 export const AUDIT_READ_WINDOW_BYTES = 4 * 1024 * 1024;
 
-/** How many rotated generations a seam-aware read will walk back through
- *  (mirrors `DEFAULT_HOSTD_AUDIT_MAX_FILES`). The byte window above is the
- *  real bound — this just stops the `existsSync` walk. */
-export const AUDIT_READ_MAX_GENERATIONS = 3;
+/**
+ * Whole-history window for callers that must not miss an old row
+ * (`resolveRollbackTarget` — #3600 review, finding 3). 128 MiB is the
+ * writer-side ceiling at the default 32 MiB × (3+1) generations, so this
+ * is "everything that exists" without being unbounded.
+ */
+export const AUDIT_READ_FULL_WINDOW_BYTES = 128 * 1024 * 1024;
+
+/**
+ * How many rotated generations a seam-aware read walks back through.
+ * Derived from the SAME resolver the writer uses (honouring
+ * `SWITCHROOM_HOSTD_AUDIT_MAX_FILES`), so a raised retention can never
+ * write more generations than the reader reads (#3600 review, finding 6).
+ * The byte window remains the real bound.
+ */
+export function auditReadMaxGenerations(): number {
+  return resolveRotationConfig({
+    envBytesVar: "SWITCHROOM_HOSTD_AUDIT_MAX_BYTES",
+    envFilesVar: "SWITCHROOM_HOSTD_AUDIT_MAX_FILES",
+    defaultBytes: DEFAULT_HOSTD_AUDIT_MAX_BYTES,
+    defaultFiles: DEFAULT_HOSTD_AUDIT_MAX_FILES,
+  }).maxFiles;
+}
+
+export interface AuditReadOptions {
+  /** Byte ceiling on the returned text. Default {@link AUDIT_READ_WINDOW_BYTES}. */
+  windowBytes?: number;
+  /** Generations to walk. Default {@link auditReadMaxGenerations}. */
+  maxFiles?: number;
+  /**
+   * Surface real I/O failures (EACCES, EIO, …) as a thrown error rather
+   * than an empty read. A MISSING file is never an error either way.
+   *
+   * Callers that report ABSENCE — `get_status` ("no update_apply row
+   * found"), `resolveRollbackTarget` (null → operator must pass an
+   * explicit `--pin`) — MUST set this: on a privileged-verb surface,
+   * silently reporting "it never happened" because the log was
+   * unreadable is the wrong default (#3600 review, finding 4).
+   */
+  strict?: boolean;
+}
 
 /** Read the last `n` bytes of `path`, dropping a leading partial line.
- *  Returns "" if the file is missing/unreadable. */
-function tailBytes(path: string, n: number): string {
+ *  A missing file yields "". Other I/O errors yield "" unless `strict`,
+ *  in which case they throw. */
+function tailBytes(path: string, n: number, strict = false): string {
   if (n <= 0) return "";
   let fd: number;
   let size: number;
   try {
     size = statSync(path).size;
     fd = openSync(path, "r");
-  } catch {
+  } catch (err) {
+    if (strict && (err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
     return "";
   }
   try {
@@ -110,10 +154,18 @@ function tailBytes(path: string, n: number): string {
     const start = size - len;
     const buf = Buffer.alloc(len);
     let read = 0;
-    while (read < len) {
-      const got = readSync(fd, buf, read, len - read, start + read);
-      if (got <= 0) break;
-      read += got;
+    try {
+      while (read < len) {
+        const got = readSync(fd, buf, read, len - read, start + read);
+        if (got <= 0) break;
+        read += got;
+      }
+    } catch (err) {
+      // open(2) can succeed where read(2) fails (EISDIR, EIO, a vanished
+      // network mount). Same policy as the open failure above: loud under
+      // `strict`, best-effort otherwise.
+      if (strict) throw err;
+      return "";
     }
     let text = buf.subarray(0, read).toString("utf-8");
     // Dropped a leading partial line? Cut to the first newline. (Not
@@ -144,19 +196,28 @@ function tailBytes(path: string, n: number): string {
  */
 export function readAuditRaw(
   logPath: string,
-  windowBytes: number = AUDIT_READ_WINDOW_BYTES,
-  maxFiles: number = AUDIT_READ_MAX_GENERATIONS,
+  opts: AuditReadOptions = {},
 ): string {
-  // Newest-first: active, then `.1`, `.2`, … stopping as soon as the
-  // window is full or a generation is absent.
+  const windowBytes = opts.windowBytes ?? AUDIT_READ_WINDOW_BYTES;
+  const maxFiles = opts.maxFiles ?? auditReadMaxGenerations();
+  const strict = opts.strict ?? false;
+  // Newest-first: active, then `.1`, `.2`, … stopping once the window is
+  // full or every generation has been considered.
   const chunks: string[] = [];
   let budget = windowBytes;
-  const active = tailBytes(logPath, budget);
+  const active = tailBytes(logPath, budget, strict);
   chunks.push(active);
   budget -= Buffer.byteLength(active, "utf-8");
   for (let n = 1; n <= maxFiles && budget > 0; n++) {
-    const chunk = tailBytes(`${logPath}.${n}`, budget);
-    if (chunk.length === 0) break;
+    const gen = `${logPath}.${n}`;
+    // An EXISTING-but-empty generation must not stop the walk — a
+    // crashed/raced rotation can leave a zero-byte `.1` while `.2`/`.3`
+    // still hold real history (#3600 review, finding 5). Only a genuinely
+    // ABSENT generation ends it: rotation shifts contiguously, so there is
+    // nothing older beyond the first gap.
+    if (!existsSync(gen)) break;
+    const chunk = tailBytes(gen, budget, strict);
+    if (chunk.length === 0) continue;
     chunks.push(chunk);
     budget -= Buffer.byteLength(chunk, "utf-8");
   }

--- a/src/host-control/audit-rotation-config.ts
+++ b/src/host-control/audit-rotation-config.ts
@@ -1,0 +1,27 @@
+/**
+ * Rotation constants for `~/.switchroom/host-control-audit.log`.
+ *
+ * Their own module (not `server.ts`) so the pure reader — `audit-reader.ts`,
+ * imported by the CLI, the web API and the MCP server — can derive its
+ * generation walk from the SAME values the writer uses without pulling the
+ * hostd daemon into those bundles. #3600 review, finding 6: the reader
+ * previously hand-mirrored `3`, so `SWITCHROOM_HOSTD_AUDIT_MAX_FILES=6`
+ * wrote six generations and read three.
+ */
+
+/**
+ * Rotation cap: 32 MiB, the same threshold the vault broker's audit log
+ * uses (`DEFAULT_AUDIT_MAX_BYTES`). Rows here are fatter than the
+ * broker's (~4 KiB with redacted terminal tails vs ~300 B), so this is
+ * ~8k rows per generation. The live host reached 44,325,086 bytes
+ * unrotated before this existed. Env: `SWITCHROOM_HOSTD_AUDIT_MAX_BYTES`
+ * (negative disables rotation).
+ */
+export const DEFAULT_HOSTD_AUDIT_MAX_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Rotated generations retained: `.1` … `.3`. Total on-disk hostd audit
+ * history is bounded at ~(3 + 1) × 32 MiB = 128 MiB. Env:
+ * `SWITCHROOM_HOSTD_AUDIT_MAX_FILES`.
+ */
+export const DEFAULT_HOSTD_AUDIT_MAX_FILES = 3;

--- a/src/host-control/audit-rotation.test.ts
+++ b/src/host-control/audit-rotation.test.ts
@@ -1,0 +1,159 @@
+/**
+ * #3596 — `~/.switchroom/host-control-audit.log` grew without bound
+ * (44,325,086 bytes on the live host, rows ~4 KiB each because they carry
+ * redacted terminal tails). These tests assert the OUTCOMES an unbounded
+ * log fails:
+ *
+ *   1. writing far past the cap leaves a bounded active file,
+ *   2. the old rows survive in `.1` (nothing is silently discarded),
+ *   3. the hash chain across the rotation seam is NOT scored as tampering
+ *      and every row stays self-consistent,
+ *   4. the reader still returns pre-rotation history after a rotation.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { HostdServer } from "./server.js";
+import { readAuditRaw, readAndFilter, parseAuditLine } from "./audit-reader.js";
+import { verifyAuditLog } from "../util/audit-hashchain.js";
+
+let dir: string;
+let logPath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "hostd-audit-rot-"));
+  logPath = path.join(dir, "host-control-audit.log");
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function makeServer(maxBytes: number, maxFiles = 2): HostdServer {
+  return new HostdServer({
+    homeDir: dir,
+    auditLogPath: logPath,
+    auditMaxBytes: maxBytes,
+    auditMaxFiles: maxFiles,
+    agents: [],
+  } as unknown as ConstructorParameters<typeof HostdServer>[0]);
+}
+
+/** Write N audit rows through the real (private) append path. */
+async function writeRows(
+  server: HostdServer,
+  n: number,
+  pad = 2000,
+): Promise<void> {
+  const append = (
+    server as unknown as {
+      appendAuditRow: (r: Record<string, unknown>) => Promise<void>;
+    }
+  ).appendAuditRow.bind(server);
+  for (let i = 0; i < n; i++) {
+    await append({
+      ts: new Date(1_700_000_000_000 + i).toISOString(),
+      op: "agent_restart",
+      caller: { kind: "agent", name: "reggie" },
+      request_id: `req-${i}`,
+      result: "ok",
+      exit_code: 0,
+      duration_ms: 1,
+      stdout_tail: "z".repeat(pad),
+    });
+  }
+}
+
+describe("hostd audit log rotation (#3596)", () => {
+  it("bounds the active log instead of growing to 44 MB", async () => {
+    const cap = 32 * 1024;
+    const server = makeServer(cap);
+    await writeRows(server, 60); // ≈ 130 KB of rows, 4x the cap
+    const active = fs.statSync(logPath).size;
+    // One row can push past the cap before the NEXT check rotates, so
+    // allow one row of slack — but nothing like the unbounded total.
+    expect(active).toBeLessThan(cap + 8 * 1024);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+    const total = fs
+      .readdirSync(dir)
+      .filter((f) => f.startsWith("host-control-audit.log"))
+      .reduce((n, f) => n + fs.statSync(path.join(dir, f)).size, 0);
+    expect(total).toBeLessThan((2 + 1) * (cap + 8 * 1024));
+  });
+
+  it("retains at most maxFiles generations", async () => {
+    const server = makeServer(8 * 1024, 2);
+    await writeRows(server, 60);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+    expect(fs.existsSync(`${logPath}.2`)).toBe(true);
+    expect(fs.existsSync(`${logPath}.3`)).toBe(false);
+  });
+
+  it("keeps the hash chain valid across the rotation seam", async () => {
+    const server = makeServer(16 * 1024);
+    await writeRows(server, 40);
+    // Rows written after the seam live in the active file and continue
+    // the in-process chain (no re-seed) — every row must still be
+    // self-consistent, and the verdict must be "ok", never "tampered".
+    for (const p of [`${logPath}.1`, logPath]) {
+      const verdict = verifyAuditLog(fs.readFileSync(p, "utf-8"));
+      expect(verdict.state, `${p}: ${verdict.reason ?? ""}`).toBe("ok");
+      expect(verdict.chainedRows).toBeGreaterThan(0);
+    }
+    // Concatenated (rotated + active) the sequence is continuous — the
+    // rotation itself introduced no segment break.
+    const joined = verifyAuditLog(
+      fs.readFileSync(`${logPath}.1`, "utf-8") +
+        fs.readFileSync(logPath, "utf-8"),
+    );
+    expect(joined.state).toBe("ok");
+    expect(joined.segments).toBe(1);
+  });
+
+  it("the reader still surfaces pre-rotation rows after a rotation", async () => {
+    // Cap small enough to force a rotation, retention deep enough that the
+    // first row is still ON DISK (retention-dropped rows are gone by
+    // design — that's the "retains at most maxFiles" test above).
+    const server = makeServer(64 * 1024, 3);
+    await writeRows(server, 40);
+    // The active file alone holds only the tail; the seam-aware reader
+    // back-fills from `.1`, so early request ids are still visible.
+    const activeOnly = readAndFilter(
+      fs.readFileSync(logPath, "utf-8"),
+      {},
+      1000,
+    ).map((e) => e.request_id);
+    const seamAware = readAndFilter(readAuditRaw(logPath), {}, 1000).map(
+      (e) => e.request_id,
+    );
+    expect(activeOnly).not.toContain("req-0");
+    expect(seamAware).toContain("req-0");
+    expect(seamAware).toContain("req-39");
+    expect(seamAware.length).toBeGreaterThan(activeOnly.length);
+    // Chronological order is preserved across the seam.
+    expect(seamAware.indexOf("req-0")).toBeLessThan(
+      seamAware.indexOf("req-39"),
+    );
+  });
+
+  it("readAuditRaw drops a torn leading line rather than emitting garbage", async () => {
+    const server = makeServer(16 * 1024);
+    await writeRows(server, 40);
+    // Simulate a rotated file whose first line is torn (crash mid-append)
+    // by reading with a window smaller than the file, forcing a mid-line
+    // start inside `.1`.
+    const raw = readAuditRaw(logPath, 4 * 1024);
+    for (const line of raw.split("\n")) {
+      if (line.length === 0) continue;
+      // Every emitted line must be parseable — the torn one was dropped.
+      expect(parseAuditLine(line)).not.toBeNull();
+    }
+  });
+
+  it("a negative cap disables rotation entirely", async () => {
+    const server = makeServer(-1);
+    await writeRows(server, 20);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(false);
+    expect(fs.statSync(logPath).size).toBeGreaterThan(20 * 2000);
+  });
+});

--- a/src/host-control/audit-rotation.test.ts
+++ b/src/host-control/audit-rotation.test.ts
@@ -142,7 +142,7 @@ describe("hostd audit log rotation (#3596)", () => {
     // Simulate a rotated file whose first line is torn (crash mid-append)
     // by reading with a window smaller than the file, forcing a mid-line
     // start inside `.1`.
-    const raw = readAuditRaw(logPath, 4 * 1024);
+    const raw = readAuditRaw(logPath, { windowBytes: 4 * 1024 });
     for (const line of raw.split("\n")) {
       if (line.length === 0) continue;
       // Every emitted line must be parseable — the torn one was dropped.

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -59,6 +59,10 @@ import {
   maybeRotateLogFile,
   resolveRotationConfig,
 } from "../util/log-rotation.js";
+import {
+  DEFAULT_HOSTD_AUDIT_MAX_BYTES,
+  DEFAULT_HOSTD_AUDIT_MAX_FILES,
+} from "./audit-rotation-config.js";
 import { socketPathToIdentity, type SocketIdentity } from "./peercred.js";
 import { redact } from "../secret-detect/redact.js";
 import { detectInstallType, type InstallType } from "../cli/install-detect.js";
@@ -160,21 +164,13 @@ export const DEFAULT_OPERATOR_ATTEST_VERBS: readonly string[] = [
  *  mirroring the vault broker's `method: "passphrase"` attribution. */
 export const ATTEST_AUDIT_METHOD = "passphrase-attest";
 
-/**
- * Rotation cap for `~/.switchroom/host-control-audit.log`: 32 MiB, the
- * same threshold the vault broker's audit log uses
- * (`DEFAULT_AUDIT_MAX_BYTES`). Rows here are fatter than the broker's
- * (~4 KiB with redacted terminal tails vs ~300 B), so this is ~8k rows
- * per generation. The live host reached 44 MB unrotated before this
- * existed. Env override: `SWITCHROOM_HOSTD_AUDIT_MAX_BYTES`.
- */
-export const DEFAULT_HOSTD_AUDIT_MAX_BYTES = 32 * 1024 * 1024;
-/**
- * Rotated generations retained: `.1` … `.3`. Total on-disk hostd audit
- * history is bounded at ~(3 + 1) × 32 MiB = 128 MiB. Env override:
- * `SWITCHROOM_HOSTD_AUDIT_MAX_FILES`.
- */
-export const DEFAULT_HOSTD_AUDIT_MAX_FILES = 3;
+// Rotation constants live in their own module so the pure reader can share
+// them without importing the daemon — re-exported here for callers that
+// already import from `server.ts`.
+export {
+  DEFAULT_HOSTD_AUDIT_MAX_BYTES,
+  DEFAULT_HOSTD_AUDIT_MAX_FILES,
+} from "./audit-rotation-config.js";
 
 export interface ServerOptions {
   /** Operator HOME — daemon binds sockets under `<homeDir>/.switchroom/hostd/<agent>/sock`. */

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -55,6 +55,10 @@ import {
 } from "./protocol.js";
 import { err } from "./error-builder.js";
 import { chainRow, seedChain, type ChainState } from "../util/audit-hashchain.js";
+import {
+  maybeRotateLogFile,
+  resolveRotationConfig,
+} from "../util/log-rotation.js";
 import { socketPathToIdentity, type SocketIdentity } from "./peercred.js";
 import { redact } from "../secret-detect/redact.js";
 import { detectInstallType, type InstallType } from "../cli/install-detect.js";
@@ -156,6 +160,22 @@ export const DEFAULT_OPERATOR_ATTEST_VERBS: readonly string[] = [
  *  mirroring the vault broker's `method: "passphrase"` attribution. */
 export const ATTEST_AUDIT_METHOD = "passphrase-attest";
 
+/**
+ * Rotation cap for `~/.switchroom/host-control-audit.log`: 32 MiB, the
+ * same threshold the vault broker's audit log uses
+ * (`DEFAULT_AUDIT_MAX_BYTES`). Rows here are fatter than the broker's
+ * (~4 KiB with redacted terminal tails vs ~300 B), so this is ~8k rows
+ * per generation. The live host reached 44 MB unrotated before this
+ * existed. Env override: `SWITCHROOM_HOSTD_AUDIT_MAX_BYTES`.
+ */
+export const DEFAULT_HOSTD_AUDIT_MAX_BYTES = 32 * 1024 * 1024;
+/**
+ * Rotated generations retained: `.1` … `.3`. Total on-disk hostd audit
+ * history is bounded at ~(3 + 1) × 32 MiB = 128 MiB. Env override:
+ * `SWITCHROOM_HOSTD_AUDIT_MAX_FILES`.
+ */
+export const DEFAULT_HOSTD_AUDIT_MAX_FILES = 3;
+
 export interface ServerOptions {
   /** Operator HOME — daemon binds sockets under `<homeDir>/.switchroom/hostd/<agent>/sock`. */
   homeDir: string;
@@ -175,6 +195,13 @@ export interface ServerOptions {
   dockerBin?: string;
   /** Audit-log path. Default: `<homeDir>/.switchroom/host-control-audit.log`. */
   auditLogPath?: string;
+  /** Rotate the audit log once it reaches this many bytes. `0`/undefined →
+   *  env `SWITCHROOM_HOSTD_AUDIT_MAX_BYTES` → {@link DEFAULT_HOSTD_AUDIT_MAX_BYTES}.
+   *  A negative value disables rotation (operator escape hatch). */
+  auditMaxBytes?: number;
+  /** How many rotated generations (`.1` … `.N`) to retain. `0`/undefined →
+   *  env `SWITCHROOM_HOSTD_AUDIT_MAX_FILES` → {@link DEFAULT_HOSTD_AUDIT_MAX_FILES}. */
+  auditMaxFiles?: number;
   /** Allow non-Linux dev mode (skips chown). */
   allowNonLinux?: boolean;
   /**
@@ -4372,6 +4399,21 @@ export class HostdServer {
     );
   }
 
+  /** Rotate `<audit>.log` → `<audit>.log.1` when it reaches the cap.
+   *  Best-effort and never throws — housekeeping must not break the
+   *  privileged-verb request path it guards. */
+  private maybeRotateAuditLog(path: string): void {
+    const { maxBytes, maxFiles } = resolveRotationConfig({
+      maxBytes: this.opts.auditMaxBytes,
+      maxFiles: this.opts.auditMaxFiles,
+      envBytesVar: "SWITCHROOM_HOSTD_AUDIT_MAX_BYTES",
+      envFilesVar: "SWITCHROOM_HOSTD_AUDIT_MAX_FILES",
+      defaultBytes: DEFAULT_HOSTD_AUDIT_MAX_BYTES,
+      defaultFiles: DEFAULT_HOSTD_AUDIT_MAX_FILES,
+    });
+    maybeRotateLogFile(path, { maxBytes, maxFiles, tag: "hostd-audit" });
+  }
+
   /** Append one JSONL row. Best-effort: a failed append logs to
    *  stderr but never throws into the request path. Serialized via
    *  `auditAppendChain` so large rows can't interleave. */
@@ -4386,6 +4428,20 @@ export class HostdServer {
       if (this.auditChainState === undefined) {
         this.auditChainState = seedChain(path);
       }
+      // Size-based rotation, INSIDE the serialized section so it can never
+      // interleave with an in-flight append (#3596). Rows carry redacted
+      // terminal output (~4 KiB each) so this file grew to 44 MB unbounded
+      // on a live host before this bound existed.
+      //
+      // The hash chain is deliberately NOT re-seeded across the rotation:
+      // `this.auditChainState` keeps advancing, so the first row written
+      // into the freshly-truncated file links back to the last row now
+      // living in `<path>.1` and cross-file tamper-evidence continuity
+      // holds. `verifyAuditLog` scores per-row self-consistency and merely
+      // COUNTS linkage breaks as segments, so a rotation seam is never
+      // reported as tampering; `parseAuditLine` returns null on a torn
+      // line, so the reader is unaffected either way.
+      this.maybeRotateAuditLog(path);
       const { line, next } = chainRow(this.auditChainState, row);
       try {
         await appendFile(path, line);

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -36,6 +36,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { hostdRequest } from "../../host-control/client.js";
 import {
   defaultAuditLogPath,
+  readAuditRaw,
   parseAuditLine,
   type AuditEntry,
 } from "../../host-control/audit-reader.js";
@@ -981,7 +982,7 @@ export function getLastUpdateApplyStatus(): {
   }
   let raw: string;
   try {
-    raw = readFileSync(path, "utf-8");
+    raw = readAuditRaw(path);
   } catch (err) {
     return errorText(
       `get_status: failed to read audit log at ${path}: ${(err as Error).message}`,

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -982,7 +982,10 @@ export function getLastUpdateApplyStatus(): {
   }
   let raw: string;
   try {
-    raw = readAuditRaw(path);
+    // strict: an EACCES/EIO on a privileged-verb status surface must
+    // surface as a read FAILURE, never as "no update_apply row found" —
+    // those two answers are operationally opposite (#3600 review).
+    raw = readAuditRaw(path, { strict: true });
   } catch (err) {
     return errorText(
       `get_status: failed to read audit log at ${path}: ${(err as Error).message}`,

--- a/src/util/log-rotation-lock.test.ts
+++ b/src/util/log-rotation-lock.test.ts
@@ -1,0 +1,110 @@
+/**
+ * #3600 review, finding 1 — the webhook event log has TWO writer
+ * processes (`handleWebhookIngest` in the web container,
+ * `recordWebhookEvent` in the agent's gateway) and no shared promise
+ * chain. Unlocked, both can stat an over-cap file, A rotates, then B
+ * rotates the now-EMPTY active file: `.1` gets zero bytes copied over it
+ * and a full generation of events is destroyed.
+ *
+ * These tests assert that outcome cannot happen: the loser of the race
+ * declines (size re-checked under the lock) and a full `.1` survives.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { maybeRotateLogFile } from "./log-rotation.js";
+
+let dir: string;
+let log: string;
+const OPTS = { maxBytes: 1000, maxFiles: 2, tag: "t", lock: true };
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "rotlock-"));
+  log = path.join(dir, "events.jsonl");
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("cross-process rotation lock", () => {
+  it("THE BUG: a second rotator must not copy an empty active file over a full .1", () => {
+    // Exactly process B's world after process A rotated: `.1` holds a
+    // generation of events, the active file is back to (nearly) empty.
+    // B is still holding its stale "over cap" belief and calls rotate.
+    fs.writeFileSync(`${log}.1`, "REAL EVENTS\n".repeat(200));
+    const generationBytes = fs.statSync(`${log}.1`).size;
+    fs.writeFileSync(log, ""); // truncated by A
+
+    const rotated = maybeRotateLogFile(log, OPTS);
+
+    expect(rotated).toBe(false);
+    // The generation survived, unshifted and unemptied.
+    expect(fs.statSync(`${log}.1`).size).toBe(generationBytes);
+    expect(fs.readFileSync(`${log}.1`, "utf-8")).toContain("REAL EVENTS");
+    expect(fs.existsSync(`${log}.2`)).toBe(false);
+  });
+
+  it("declines while another process holds the lock, leaving .1 intact", () => {
+    fs.writeFileSync(`${log}.1`, "PREVIOUS GENERATION\n");
+    fs.writeFileSync(log, "x".repeat(5000)); // genuinely over cap
+    // Simulate the other process mid-rotation.
+    fs.writeFileSync(`${log}.rotate.lock`, "");
+
+    const rotated = maybeRotateLogFile(log, OPTS);
+
+    expect(rotated).toBe(false);
+    expect(fs.readFileSync(`${log}.1`, "utf-8")).toBe("PREVIOUS GENERATION\n");
+    // Live file untouched — we grow rather than race.
+    expect(fs.statSync(log).size).toBe(5000);
+  });
+
+  it("rotates normally when the lock is free, and releases it", () => {
+    fs.writeFileSync(log, "y".repeat(5000));
+    expect(maybeRotateLogFile(log, OPTS)).toBe(true);
+    expect(fs.statSync(log).size).toBe(0);
+    expect(fs.statSync(`${log}.1`).size).toBe(5000);
+    expect(fs.existsSync(`${log}.rotate.lock`)).toBe(false);
+  });
+
+  it("reclaims a stale lock left by a killed process", () => {
+    fs.writeFileSync(log, "z".repeat(5000));
+    fs.writeFileSync(`${log}.rotate.lock`, "");
+    const old = new Date(Date.now() - 5 * 60 * 1000); // 5 min
+    fs.utimesSync(`${log}.rotate.lock`, old, old);
+
+    expect(maybeRotateLogFile(log, OPTS)).toBe(true);
+    expect(fs.statSync(`${log}.1`).size).toBe(5000);
+    expect(fs.existsSync(`${log}.rotate.lock`)).toBe(false);
+  });
+
+  it("single-writer logs skip the lock entirely (no lockfile left behind)", () => {
+    fs.writeFileSync(log, "w".repeat(5000));
+    expect(
+      maybeRotateLogFile(log, { maxBytes: 1000, maxFiles: 2, tag: "t" }),
+    ).toBe(true);
+    expect(fs.existsSync(`${log}.rotate.lock`)).toBe(false);
+  });
+
+  it("interleaved rotate attempts preserve every event across generations", () => {
+    // Two writers appending to the same log, each rotating before its
+    // append. Every event must be recoverable from active + .1 + .2.
+    const seen: string[] = [];
+    for (let i = 0; i < 60; i++) {
+      // Writer A and writer B alternate; both check + rotate + append.
+      maybeRotateLogFile(log, OPTS);
+      const line = `event-${i}\n`.padEnd(120, "-") + "\n";
+      fs.appendFileSync(log, line);
+      seen.push(`event-${i}`);
+    }
+    const all = [`${log}.2`, `${log}.1`, log]
+      .filter((p) => fs.existsSync(p))
+      .map((p) => fs.readFileSync(p, "utf-8"))
+      .join("");
+    // With maxFiles=2 the oldest events legitimately age out, but no
+    // generation may be EMPTY while a newer one holds data (the
+    // destroyed-generation signature).
+    expect(fs.statSync(`${log}.1`).size).toBeGreaterThan(0);
+    expect(all).toContain(seen[seen.length - 1]);
+  });
+});

--- a/src/util/log-rotation-race.test.ts
+++ b/src/util/log-rotation-race.test.ts
@@ -580,6 +580,95 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
     expect(realFs.statSync(path.join(dir, debris[0])).ino).toBe(peerIno);
   });
 
+  it("release touches nothing when its opening stat cannot see our lock (round-10, the filter's ENOENT arm)", () => {
+    // Step 0's ENOENT arm is what BOUNDS the missed-release residual, and
+    // until round 10 nothing tested it: `catch { looksOurs = true }` and
+    // `let looksOurs = true` each survived all 46 scoped tests (#3600
+    // round-10, F1). Neither is equivalent. Under either, the release goes
+    // on to `rename(lockPath, <park>)`, and when what sits at `lockPath` is
+    // a peer's brand-new LIVE lock that park is exactly the round-8 M1
+    // damage, reached through the arm that exists to prevent it.
+    //
+    // The interleaving: a peer judged us stale and reclaimed us — park,
+    // unlink, `open(wx)` — so `lockPath` carries ITS live lock by the time
+    // we release, and our step-0 stat nonetheless reads ENOENT, as it does
+    // whenever it lands inside somebody's park window (the missed-release
+    // residual, documented at step 0 in `log-rotation.ts`).
+    //
+    // Those are two different instants and there is no hook between the
+    // step-0 stat and the rename it guards, so the reclaim is driven at a
+    // real syscall (the post-truncate `stillHeld()`) and the ENOENT is
+    // INJECTED into the next stat of `lockPath`, which IS step 0. The
+    // injection is what makes this differential rather than a path
+    // observation: the filesystem is byte-identical in both arms, so the
+    // only thing that can move the outcome is the value of `looksOurs`. A
+    // hook that instead really removed the lock would make the mutant's
+    // rename ENOENT too and hide the defect.
+    //
+    // `linkThrows` is on for the same reason the M1 residual test above
+    // needs it: with hardlinks available the mutant's restore puts the
+    // peer's lock back and the damage leaves no trace in the end state.
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    hooks.linkThrows = true;
+
+    let truncated = false;
+    hooks.beforeTruncate = () => {
+      truncated = true;
+    };
+    let peerIno = -1;
+    let injected = false;
+    let firing = false;
+    hooks.beforeStat = (p) => {
+      // `firing` keeps the peer's own stat — which re-enters this mocked
+      // module — from recursing into the hook.
+      if (p !== lock || !truncated || firing) return;
+      if (peerIno === -1) {
+        // The FIRST stat of `lockPath` after the truncate is
+        // `rotateLogFile`'s post-truncate `stillHeld()`, not the release.
+        // That is where the peer lands: it judges us stale and reclaims —
+        // park, unlink, `open(wx)` — so from here on `lockPath` carries ITS
+        // live lock. Our rotation is already complete, so all that costs is
+        // the "rows another rotator wrote … are LOST" diagnostic.
+        firing = true;
+        try {
+          realFs.rmSync(lock, { force: true });
+          realFs.closeSync(realFs.openSync(lock, "wx", 0o600));
+          peerIno = realFs.statSync(lock).ino;
+        } finally {
+          firing = false;
+        }
+        return;
+      }
+      if (injected) return; // the assertions below stat it too
+      injected = true;
+      // The NEXT stat of `lockPath` is the release's step 0 — and this is
+      // the ENOENT it reads.
+      const e: NodeJS.ErrnoException = new Error(
+        "ENOENT: no such file or directory, stat",
+      );
+      e.code = "ENOENT";
+      throw e;
+    };
+
+    maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "t",
+      lock: true,
+    });
+
+    expect(peerIno).not.toBe(-1); // the peer really reclaimed
+    expect(injected).toBe(true); // and the release really read the ENOENT
+    // The claim: an ENOENT at step 0 ENDS the release. The peer's live lock
+    // is still at the path, still its own inode …
+    expect(realFs.existsSync(lock)).toBe(true);
+    expect(realFs.statSync(lock).ino).toBe(peerIno);
+    // … and we parked nothing, so there is no debris to reap either.
+    expect(
+      realFs.readdirSync(dir).filter((f) => f.includes(".stale.")),
+    ).toEqual([]);
+  });
+
   it("a RECLAIM whose restore fails does not destroy the peer's lock inode (round-8 M1, sibling)", () => {
     // The reclaim's mismatch branch is the same code as the release's, one
     // branch away, and carried the same defect: swallow the failed `link`,
@@ -1486,15 +1575,29 @@ describe("the doc block's citations are checkable", () => {
       .map((l) => l.replace(/^\s*(\*|\/\/)\s?/, ""))
       .join(" ")
       .replace(/\s+/g, " ");
+    // The exclusion set is CODE punctuation only. An em-dash used to be in
+    // it and had no business there: test titles contain em-dashes, and
+    // exactly one citation did — "does not shift the peer's fresh .1 off the
+    // end — but the unlink gap destroys its shifted history". That citation
+    // was therefore invisible to the very mechanism built to catch renamed
+    // citations, and renaming its test kept the check green (#3600 round-10,
+    // F2). Anything the wider net now sweeps in that is genuinely prose goes
+    // in the allowlist below, deliberately and one at a time.
     const candidates = [...comments.matchAll(/"([^"]{20,120})"/g)]
       .map((m) => m[1])
-      .filter((s) => !/[`#{}—[\]]/.test(s) && /^[a-z]/.test(s));
+      .filter((s) => !/[`#{}[\]]/.test(s) && /^[a-z]/.test(s));
 
     // Quoted PROSE that is not a citation. Explicit, so that a new quote in
     // title shape fails this test until someone decides which it is —
     // that decision is the point, and it is cheap.
     const notCitations = new Set([
+      // The three round-10 additions are quotations of sentences the source
+      // used to assert and now retracts, kept verbatim so that the
+      // retraction names what it retracts (#3600 round-10, F3/F4).
+      "a cycle versus a generation",
+      "a spurious decline costs a rotation cycle",
       "between two adjacent syscalls",
+      "nothing destructive runs on a match",
       "our lock was destroyed",
       "rename works fine on the host",
       "rows another rotator wrote … are LOST",
@@ -1514,5 +1617,20 @@ describe("the doc block's citations are checkable", () => {
     // And the allowlist itself must not rot: every entry has to still be
     // present in the source, or it is a stale exemption hiding a real one.
     expect([...notCitations].filter((c) => !comments.includes(c))).toEqual([]);
+    // Nor may it ABSORB drift. "Still present in the source" is satisfied by
+    // a real citation too, so on its own that guard let a live citation be
+    // moved into the allowlist and its test renamed with the check still
+    // green (#3600 round-10, F2). An entry that names a real test is
+    // misfiled by construction — a non-citation cannot be one — so the
+    // laundering step is what gets rejected, at the moment it is made.
+    expect(
+      [...notCitations].filter((c) =>
+        titles.some((t) => t === c || t.startsWith(c)),
+      ),
+    ).toEqual([]);
+    // What this pair still cannot separate: allowlisting a citation AND
+    // renaming its test in the same change leaves a string that names no
+    // test, which is indistinguishable from genuine prose. The guard is a
+    // ratchet on the cheap move, not a proof.
   });
 });

--- a/src/util/log-rotation-race.test.ts
+++ b/src/util/log-rotation-race.test.ts
@@ -44,6 +44,8 @@ const hooks = vi.hoisted(() => ({
   beforeUnlink: undefined as ((p: string) => void) | undefined,
   beforeStat: undefined as ((p: string) => void) | undefined,
   afterStat: undefined as ((p: string) => void) | undefined,
+  /** Throwing from here simulates an `fstat` failure on that fd (L1). */
+  beforeFstat: undefined as ((fd: number) => void) | undefined,
   beforeCopy: undefined as ((from: string, to: string) => void) | undefined,
   beforeTruncate: undefined as ((p: string) => void) | undefined,
   beforeClose: undefined as ((fd: number) => void) | undefined,
@@ -80,6 +82,10 @@ vi.mock("node:fs", async (importOriginal) => {
       hooks.beforeClose?.(fd);
       return actual.closeSync(fd);
     },
+    fstatSync: ((fd: number, o?: realFs.StatOptions) => {
+      hooks.beforeFstat?.(fd);
+      return actual.fstatSync(fd, o);
+    }) as unknown as typeof realFs.fstatSync,
     statSync: ((p: realFs.PathLike, o?: realFs.StatSyncOptions) => {
       hooks.beforeStat?.(String(p));
       const s = actual.statSync(p, o);
@@ -105,6 +111,7 @@ function clearHooks(): void {
   hooks.beforeUnlink = undefined;
   hooks.beforeStat = undefined;
   hooks.afterStat = undefined;
+  hooks.beforeFstat = undefined;
   hooks.beforeCopy = undefined;
   hooks.beforeTruncate = undefined;
   hooks.beforeClose = undefined;
@@ -357,6 +364,64 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
     expect(realFs.existsSync(lock)).toBe(true);
     expect(realFs.statSync(lock).ino).toBe(peerIno);
   });
+
+  it("release does not delete a peer's lock that arrived after our identity check (H2)", () => {
+    // The test above lands the peer BEFORE the release guard reads the
+    // lock, where an inode comparison is enough. This one lands it INSIDE
+    // the release's own check→syscall gap, which the comparison never
+    // covered: `statSync(lockPath).ino === ourIno` and
+    // `unlinkSync(lockPath)` are two syscalls, so a peer that parks and
+    // claims between them is deleted on our verdict about a file that is
+    // no longer there. The log ends up with NO lock while the peer
+    // believes it holds one — the same observable failure the round-6 H3
+    // ordering fix addressed, still live afterwards because ordering makes
+    // the inode NUMBER meaningful and cannot make two syscalls atomic
+    // (#3600 round-7, H2).
+    //
+    // Fire on whichever syscall the implementation first points at
+    // `lockPath` during release — `rename` with park-verify, `unlink` in
+    // the pre-fix code — so this bites both shapes. Pre-fix the hook lands
+    // after the guard's stat and our unlink then removes the peer's LIVE
+    // lock; with park-verify the rename takes the file first, the parked
+    // inode fails the comparison, and it is linked back untouched.
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+
+    let truncated = false;
+    let peerIno = -1;
+    hooks.beforeTruncate = () => {
+      truncated = true;
+    };
+    const peerReclaims = (p: string) => {
+      // Only at release: our own rotation has finished (the truncate ran)
+      // and the next thing to touch `lockPath` is the release itself.
+      if (p !== lock || !truncated || peerIno !== -1) return;
+      realFs.rmSync(lock, { force: true });
+      realFs.closeSync(realFs.openSync(lock, "wx", 0o600));
+      peerIno = realFs.statSync(lock).ino;
+    };
+    hooks.beforeRename = peerReclaims;
+    hooks.beforeUnlink = peerReclaims;
+
+    expect(
+      maybeRotateLogFile(log, {
+        maxBytes: CAP,
+        maxFiles: 2,
+        tag: "t",
+        lock: true,
+      }),
+    ).toBe(true);
+
+    expect(peerIno).not.toBe(-1); // the interleaving really happened
+    expect(realFs.statSync(`${log}.1`).size).toBe(CAP * 4); // we did rotate
+    // The damage that must NOT happen: the peer's brand-new live lock
+    // survives release, same inode, so the log is still locked.
+    expect(realFs.existsSync(lock)).toBe(true);
+    expect(realFs.statSync(lock).ino).toBe(peerIno);
+    // And the park we took to decide that was put back, not left as debris.
+    expect(
+      realFs.readdirSync(dir).filter((f) => f.includes(".stale.")),
+    ).toEqual([]);
+  });
 });
 
 /**
@@ -377,15 +442,24 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
  *     reclaimer's `.1`, the shifted history at `.2` and the rows its
  *     writers appended all survive ("declines outright…").
  *   - the unlink gap — the peer's freshly shifted history at `.2` is
- *     deleted ("…but the unlink gap destroys its shifted history").
+ *     deleted ("…but the unlink gap destroys its shifted history"). Since
+ *     round 7 this gap carries the same shrank-since-entry gate as the
+ *     copy, so a landing before the GATE's stat costs nothing ("declines
+ *     the oldest-generation drop when the peer rotated after our lock
+ *     check"); the destructive test above lands after it.
  *   - the shift gap — `.1` ABSENT, `.2` the peer's snapshot: our
  *     unserialized `rename` moved its fresh `.1` to `.2` over the history
- *     that was there ("does not copy over the peer's .1").
+ *     that was there ("does not copy over the peer's .1"). Gated the same
+ *     way ("declines the shift when the peer rotated after our lock
+ *     check"), with the same post-gate-stat residual.
  *   - the copy gap — worst of the four, and how bad depends on the PEER:
  *     with a busy peer, `.1` is a duplicate of the live file and the
  *     prior generation is gone ("loses a generation…"); with a QUIET peer
  *     we copy its freshly-truncated zero bytes and the log loses
- *     everything it has ("loses EVERY byte…", round-6 H1).
+ *     everything it has ("loses EVERY byte…", round-6 H1). Both are the
+ *     residual PAST the round-7 gate's own stat; a landing before that
+ *     stat now costs nothing ("declines the copy when the peer rotated
+ *     after our lock check" and its quiet twin).
  *   - the truncate gap — the only one where WE destroy rows in the ACTIVE
  *     file (the quiet copy gap costs the same rows via the snapshot they
  *     had moved to), and the only one with no next checkpoint behind it.
@@ -541,12 +615,177 @@ describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
     expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY);
   });
 
+  /**
+   * Land the peer at the START of the check→`copyFileSync` gap: the
+   * instant AFTER the pre-copy `held()` stat of the lockfile, so the lock
+   * guard cannot see it, and before the data gate's own stat of the active
+   * file (#3600 round-7, M1). The two residual tests below inject at
+   * `beforeCopy` instead — the LAST instant of the same gap, past the gate
+   * — which is why they pass identically against the gated and the ungated
+   * code and cannot demonstrate this fix.
+   *
+   * The pre-copy `held()` stat is the first stat of the lockfile after our
+   * shift rename, so `shifted` identifies it without counting syscalls.
+   */
+  function firePeerAtCopyGapStart(run: () => void): () => boolean {
+    let shifted = false;
+    let fired = false;
+    hooks.beforeRename = (from) => {
+      if (from === `${log}.1`) shifted = true;
+    };
+    hooks.afterStat = (p) => {
+      if (p !== lock || !shifted || fired) return;
+      fired = true;
+      hooks.afterStat = undefined;
+      run();
+    };
+    return () => fired;
+  }
+
+  /**
+   * Land the peer at the START of a gap by firing just after the Nth stat
+   * of the LOCKFILE, which is the `held()` check for the Nth destructive
+   * syscall (nothing else in `withRotateLock` stats the lock path on this
+   * route). Same idea as `firePeerAtCopyGapStart`, for the gaps that come
+   * before the shift.
+   */
+  function firePeerAfterLockStat(n: number, run: () => void): () => boolean {
+    let seen = 0;
+    let fired = false;
+    hooks.afterStat = (p) => {
+      if (p !== lock || fired) return;
+      if (++seen !== n) return;
+      fired = true;
+      hooks.afterStat = undefined;
+      run();
+    };
+    return () => fired;
+  }
+
+  it("declines the oldest-generation drop when the peer rotated after our lock check (H1 sweep)", () => {
+    // The unlink gap, gate side. `held()`'s stat cannot see a peer that
+    // reclaims immediately after it, and what our unlink then destroys is
+    // the history the peer's own rotation just shifted into `<log>.2` —
+    // asserted as LOST in "does not shift the peer's fresh .1 off the end
+    // — but the unlink gap destroys its shifted history", which lands the
+    // peer one syscall later. The same evidence that gates the copy gates
+    // this too: the active file shrank, so these generations are the
+    // peer's (#3600 round-7, H1 sibling sweep). Nothing is destroyed.
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+    realFs.writeFileSync(`${log}.2`, "OLDEST\n");
+
+    // Lock stat #1 is `held("drop <log>.2")` — `.2` exists, so the drop is
+    // the first destructive syscall and its check is the first lock stat.
+    const fired = firePeerAfterLockStat(1, () => peerReclaimsAndRotates(2, NEW));
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(fired()).toBe(true);
+    expect(rotated).toBe(false);
+    expect(realFs.readFileSync(`${log}.2`, "utf8")).toBe(HISTORY); // NOT dropped
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY); // peer's snapshot
+    expect(realFs.readFileSync(log, "utf8")).toBe(NEW); // peer's live rows
+  });
+
+  it("declines the shift when the peer rotated after our lock check (H1 sweep)", () => {
+    // The shift gap, gate side. One syscall later ("does not copy over the
+    // peer's .1") our rename moves the peer's fresh `.1` onto `.2`, over
+    // the history sitting there. Gated, both survive where they are.
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    // No `<log>.2`, so there is no oldest-generation drop and lock stat #1
+    // is `held("shift <log>.1 → <log>.2")`.
+    const fired = firePeerAfterLockStat(1, () => peerReclaimsAndRotates(2, NEW));
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(fired()).toBe(true);
+    expect(rotated).toBe(false);
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY); // peer's snapshot
+    expect(realFs.readFileSync(`${log}.2`, "utf8")).toBe(HISTORY); // its shifted history
+    expect(realFs.readFileSync(log, "utf8")).toBe(NEW);
+  });
+
+  it("declines the copy when the peer rotated after our lock check (H1 gate)", () => {
+    // A peer that rotated under us leaves `.1` holding ITS fresh snapshot.
+    // Copying now overwrites that snapshot with whatever the peer's own
+    // truncate left in the active file. The data gate catches it the same
+    // way the truncate's does: our baseline is the active file's size on
+    // ENTRY, an append-only log only grows, so a shrink is someone else's
+    // truncate. Remove the gate and this fails with `.1` holding NEW —
+    // the peer's snapshot gone, one generation lost (#3600 round-7, H1).
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    const fired = firePeerAtCopyGapStart(() => peerReclaimsAndRotates(2, NEW));
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(fired()).toBe(true);
+    expect(rotated).toBe(false);
+    // Nothing of the peer's cycle is damaged: its snapshot is still at
+    // `.1` and the rows it appended after rotating are still live.
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY);
+    expect(realFs.readFileSync(log, "utf8")).toBe(NEW);
+  });
+
+  it("declines the copy when the peer rotated after our lock check and is quiet (H1 gate)", () => {
+    // Same gap, quiet peer — the shape round 6 declined to fix, arguing a
+    // code change "recovers no data because the peer's snapshot was
+    // already overwritten by our copy". The copy is the thing being
+    // skipped, so it recovers all of it: with the gate the log's live rows
+    // survive whole in `.1`; without it, `.1` is zero bytes, `.2` is gone
+    // and the active file is empty — every byte of the log lost (the
+    // residual test two below shows exactly that outcome, one injection
+    // point later). Total loss → zero loss (#3600 round-7, H1).
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    const fired = firePeerAtCopyGapStart(() => peerReclaimsAndRotates(2, ""));
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(fired()).toBe(true);
+    expect(rotated).toBe(false);
+    // The peer's full snapshot — every live row the log had — is intact.
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY);
+    expect(realFs.statSync(`${log}.1`).size).toBe(CAP * 4);
+    // The active file is the peer's freshly-truncated zero bytes, which is
+    // correct: those rows are the ones now sitting in `.1`.
+    expect(realFs.statSync(log).size).toBe(0);
+  });
+
   it("loses a generation when the reclaim lands in the copy gap (residual)", () => {
     // The documented worst case (#3600 round-5, M2), asserted so the
-    // residual cannot quietly become untrue. The peer lands between the
-    // pre-copy `held()` check and `copyFileSync` itself, so that ONE
-    // syscall proceeds unserialized: by then `.1` is the peer's fresh
-    // snapshot, and we overwrite it with a copy of the LIVE file.
+    // residual cannot quietly become untrue. The peer lands at the LAST
+    // instant of the check→`copyFileSync` gap — after the data gate's own
+    // stat of the active file, which is the window round-7's gate cannot
+    // close (it is a stat followed by a separate syscall, like every other
+    // check here). That ONE syscall proceeds unserialized: by then `.1` is
+    // the peer's fresh snapshot, and we overwrite it with a copy of the
+    // LIVE file.
     realFs.writeFileSync(log, BODY);
     realFs.writeFileSync(`${log}.1`, HISTORY);
 
@@ -580,11 +819,14 @@ describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
   });
 
   it("loses EVERY byte when the reclaim lands in the copy gap and the peer is quiet", () => {
-    // Same gap as the test above, one variable changed: the peer does not
-    // append after rotating. That is the ordinary state of a low-traffic
-    // log, and it is the real worst case (#3600 round-6, H1) — the test
-    // above masks it, because the rows its peer appends are what make the
-    // unguarded `copyFileSync` copy anything at all.
+    // Same residual window as the test above (after the data gate's stat,
+    // before the copy), one variable changed: the peer does not append
+    // after rotating. That is the ordinary state of a low-traffic log, and
+    // it is the real worst case (#3600 round-6, H1) — the test above masks
+    // it, because the rows its peer appends are what make the unguarded
+    // `copyFileSync` copy anything at all. Compare the gate test of the
+    // same shape above: one injection point earlier, the gate turns this
+    // outcome into no loss at all.
     //
     // With a quiet peer the active file it leaves is ZERO bytes, so our
     // one unserialized copy writes zero bytes over the peer's fresh `.1`,
@@ -707,6 +949,152 @@ describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
     expect(errs.join("")).toContain("rows another rotator wrote");
   });
 
+  it("the truncate gate is blind to a peer that re-appends exactly what we snapshotted (L2)", () => {
+    // The gate is `liveBytes < snapshotBytes` — STRICT, because in the
+    // ordinary rotation the two are equal and `<=` would decline every
+    // rotation this module performs. The documented residual therefore
+    // covers a peer that re-appends AT LEAST `snapshotBytes`, not "more
+    // than" it: landing on exactly that size passes the gate too (#3600
+    // round-7, L2). The peer here rotates and re-appends precisely as many
+    // bytes as we snapshotted, at the START of the truncate gap where the
+    // gate is what has to catch it — and does not.
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    const errs: string[] = [];
+    const spy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: unknown) => {
+        errs.push(String(chunk));
+        return true;
+      });
+
+    let copied = false;
+    let fired = false;
+    hooks.beforeCopy = () => {
+      copied = true;
+    };
+    hooks.afterStat = (p) => {
+      if (p !== lock || !copied || fired) return;
+      fired = true;
+      hooks.afterStat = undefined;
+      // EXACTLY the snapshot's size, not one byte more.
+      peerReclaimsAndRotates(2, "y".repeat(BODY.length));
+    };
+
+    let rotated: boolean;
+    try {
+      rotated = maybeRotateLogFile(log, {
+        maxBytes: CAP,
+        maxFiles: 2,
+        tag: "victim",
+        lock: true,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(fired).toBe(true);
+    expect(realFs.statSync(`${log}.1`).size).toBe(BODY.length); // snapshot size
+    // The gate did not fire: the sizes are equal, not shrunk.
+    expect(errs.join("")).not.toContain("shrank from");
+    // So we truncated, and the peer's rows are gone.
+    expect(rotated).toBe(true);
+    expect(realFs.statSync(log).size).toBe(0);
+    expect(errs.join("")).toContain("rows another rotator wrote");
+  });
+
+  it("an unverifiable lock fd drops every lock checkpoint (L1)", () => {
+    // `stillHeld()` returns a constant `true` when the `fstat` on our own
+    // lock fd failed — we cannot verify identity, and never rotating is
+    // the worse failure. The cost is not "one more gap": it is that none
+    // of the four checkpoints fires at all, so a peer that rotated before
+    // we touched anything does not stop us anywhere (#3600 round-7, L1).
+    //
+    // Compare "declines outright when the peer rotated before we touched
+    // anything", which is this exact interleaving with a verifiable fd and
+    // asserts that we touch NOTHING. Here the whole rotation runs: we drop
+    // the generation the peer just shifted its history into, shift its
+    // fresh snapshot off `.1`, copy, and truncate its live rows. The data
+    // gates cannot help — our baseline is measured after the peer's
+    // truncate, so nothing looks shrunk.
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+    realFs.writeFileSync(`${log}.2`, "OLDEST\n");
+
+    let lockFd = -1;
+    hooks.afterOpen = (p, flags, fd) => {
+      if (p === lock && flags === "wx" && lockFd === -1) lockFd = fd;
+    };
+    hooks.beforeFstat = (fd) => {
+      // Only OUR lock fd: the snapshot's fstat must still work.
+      if (fd === lockFd) throw new Error("EBADF: simulated fstat failure");
+    };
+
+    let stats = 0;
+    hooks.beforeStat = (p) => {
+      if (p !== log) return;
+      if (++stats !== 2) return; // the under-lock size re-check
+      hooks.beforeStat = undefined;
+      peerReclaimsAndRotates(2, NEW);
+    };
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(lockFd).not.toBe(-1);
+    expect(stats).toBeGreaterThanOrEqual(2); // the interleaving happened
+    // Every destructive syscall went through, unserialized:
+    expect(rotated).toBe(true);
+    expect(realFs.readFileSync(`${log}.2`, "utf8")).toBe(BODY); // peer's `.1`, shifted
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(NEW); // over its snapshot
+    expect(realFs.statSync(log).size).toBe(0); // and its live rows truncated
+    expect(realFs.existsSync(`${log}.3`)).toBe(false);
+  });
+
+  it("names the step that failed when the snapshot cannot be measured (L3)", () => {
+    // `open`, `fsync` and `fstat` on the snapshot fail for three different
+    // reasons and used to share one diagnostic — "could not fsync
+    // snapshot" — so an `fstat` failure sent the operator after durability
+    // when the problem was measurement (#3600 round-7, L3). The size is a
+    // precondition for the truncate gate, so a failure here still declines
+    // the rotation; what changed is that the line says which step it was.
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    let snapFd = -1;
+    hooks.afterOpen = (p, flags, fd) => {
+      if (p === `${log}.1` && flags === "r" && snapFd === -1) snapFd = fd;
+    };
+    hooks.beforeFstat = (fd) => {
+      if (fd === snapFd) throw new Error("EBADF: simulated fstat failure");
+    };
+
+    const errs: string[] = [];
+    const spy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: unknown) => {
+        errs.push(String(chunk));
+        return true;
+      });
+    let rotated: boolean;
+    try {
+      rotated = rotateLogFile(log, 2, "t");
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(snapFd).not.toBe(-1); // we really did hit the snapshot's fstat
+    expect(rotated).toBe(false);
+    expect(realFs.readFileSync(log, "utf8")).toBe(BODY); // active intact
+    expect(errs.join("")).toContain("could not measure snapshot");
+    expect(errs.join("")).not.toContain("could not fsync snapshot");
+  });
+
   it("a rotator that lost the lock touches nothing at all", () => {
     // Unit-level: the predicate is false from the first call, so every
     // generation and the active file must be byte-identical afterwards.
@@ -797,12 +1185,15 @@ describe("inode identity's premise: the lock fd stays open (M3)", () => {
     // the list is what let that survive round 5 (#3600 round-6, H3), so it
     // is included now and the ordering fix is what makes it pass.
     const isGeneration = (p: string) => /^\.\d+$/.test(p.slice(log.length));
+    const isLockPark = (p: string) => p.startsWith(`${lock}.stale.`);
     hooks.beforeUnlink = (p) => {
       if (isGeneration(p)) note(`unlink ${gen(p)}`);
       else if (p === lock) note("unlink <lock>");
+      else if (isLockPark(p)) note("unlink <lock park>");
     };
     hooks.beforeRename = (from) => {
       if (isGeneration(from)) note(`rename ${gen(from)}`);
+      else if (from === lock) note("rename <lock> → park");
     };
     hooks.beforeCopy = (from, to) => {
       if (from === log) note(`copy <log> → ${gen(to)}`);
@@ -826,7 +1217,14 @@ describe("inode identity's premise: the lock fd stays open (M3)", () => {
       "rename <log>.1 [fd open]",
       "copy <log> → <log>.1 [fd open]",
       "truncate <log> [fd open]",
-      "unlink <lock> [fd open]",
+      // Release is park-verify-unlink now (#3600 round-7, H2), so it is
+      // TWO syscalls at the lock path and both need the premise: the
+      // rename decides which file we are judging, and the comparison that
+      // follows is `parked.ino === ourIno` — which only means "our lock"
+      // while `fd` still pins that number. Close early and a peer's fresh
+      // lock can carry it, we park that, match, and delete it.
+      "rename <lock> → park [fd open]",
+      "unlink <lock park> [fd open]",
     ]);
     // And it IS closed by the end — otherwise the tags above would be
     // vacuously "fd open" and this test would prove nothing.

--- a/src/util/log-rotation-race.test.ts
+++ b/src/util/log-rotation-race.test.ts
@@ -11,7 +11,9 @@
  * INSIDE `withRotateLock`, at the precise syscall where the peer's action
  * must land. What the hook does is what a second process really does.
  *
- * Both tests fail against the pre-fix code:
+ * The file has grown past those two interleavings (H1 in round 4, the fd
+ * premise in round 5), but the first two describes are still the
+ * originals, and both fail against the pre-fix code:
  *  - drop the under-lock size re-check and the first one clobbers `.1`;
  *  - restore `unlink` + `open(wx)` as the stale reclaim and the second
  *    one enters the critical section while a peer holds the lock.
@@ -22,12 +24,22 @@ import * as realFs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-/** Fires immediately before the named syscall inside log-rotation.ts. */
+/**
+ * Fires immediately before the named syscall inside log-rotation.ts.
+ * `afterOpen` fires just after, because it needs the resulting fd — that
+ * is how the M3 test learns which fd is the lock's.
+ */
 const hooks = vi.hoisted(() => ({
   beforeRename: undefined as ((from: string) => void) | undefined,
   beforeOpen: undefined as ((p: string, flags: string) => void) | undefined,
+  afterOpen: undefined as
+    | ((p: string, flags: string, fd: number) => void)
+    | undefined,
   beforeUnlink: undefined as ((p: string) => void) | undefined,
   beforeStat: undefined as ((p: string) => void) | undefined,
+  beforeCopy: undefined as ((from: string, to: string) => void) | undefined,
+  beforeTruncate: undefined as ((p: string) => void) | undefined,
+  beforeClose: undefined as ((fd: number) => void) | undefined,
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -45,7 +57,21 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     openSync: (p: realFs.PathLike, flags: string, mode?: number) => {
       hooks.beforeOpen?.(String(p), flags);
-      return actual.openSync(p, flags, mode);
+      const fd = actual.openSync(p, flags, mode);
+      hooks.afterOpen?.(String(p), flags, fd);
+      return fd;
+    },
+    copyFileSync: (from: realFs.PathLike, to: realFs.PathLike) => {
+      hooks.beforeCopy?.(String(from), String(to));
+      return actual.copyFileSync(from, to);
+    },
+    truncateSync: (p: realFs.PathLike, len?: number) => {
+      hooks.beforeTruncate?.(String(p));
+      return actual.truncateSync(p, len);
+    },
+    closeSync: (fd: number) => {
+      hooks.beforeClose?.(fd);
+      return actual.closeSync(fd);
     },
     statSync: ((p: realFs.PathLike, o?: realFs.StatSyncOptions) => {
       hooks.beforeStat?.(String(p));
@@ -63,21 +89,26 @@ let lock: string;
 const HISTORY = "REAL HISTORY — must survive\n";
 const CAP = 1024;
 
+function clearHooks(): void {
+  hooks.beforeRename = undefined;
+  hooks.beforeOpen = undefined;
+  hooks.afterOpen = undefined;
+  hooks.beforeUnlink = undefined;
+  hooks.beforeStat = undefined;
+  hooks.beforeCopy = undefined;
+  hooks.beforeTruncate = undefined;
+  hooks.beforeClose = undefined;
+}
+
 beforeEach(() => {
   dir = realFs.mkdtempSync(path.join(os.tmpdir(), "rotrace-"));
   log = path.join(dir, "events.jsonl");
   lock = `${log}.rotate.lock`;
-  hooks.beforeRename = undefined;
-  hooks.beforeOpen = undefined;
-  hooks.beforeUnlink = undefined;
-  hooks.beforeStat = undefined;
+  clearHooks();
 });
 
 afterEach(() => {
-  hooks.beforeRename = undefined;
-  hooks.beforeOpen = undefined;
-  hooks.beforeUnlink = undefined;
-  hooks.beforeStat = undefined;
+  clearHooks();
   realFs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -319,8 +350,26 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
  * destructive syscall in `rotateLogFile` re-asserts the lock inode.
  *
  * Each test lands the peer at a different point in the victim's rotation
- * and asserts the OUTCOME: the reclaimer's snapshot, the shifted history,
- * and the rows the reclaimer's writers appended all survive.
+ * and asserts the OUTCOME. What survives is NOT uniform, and these tests
+ * pin the difference (#3600 round-5, M1):
+ *
+ *   - reclaim before our first destructive syscall — nothing of ours ran,
+ *     so the reclaimer's `.1`, the shifted history at `.2` and the rows
+ *     its writers appended all survive ("declines outright…").
+ *   - reclaim inside a check→syscall gap — that one syscall goes through
+ *     before the next checkpoint stops us, and it costs a generation.
+ *     "does not copy over the peer's .1" asserts exactly that: `.1` is
+ *     ABSENT and `.2` holds the reclaimer's snapshot, i.e. our
+ *     unserialized shift `rename` moved its fresh `.1` to `.2` and the
+ *     shifted HISTORY that was there is gone.
+ *
+ * So what these tests pin is narrower than "all survive". The rows the
+ * reclaimer's writers appended after its rotation survive every
+ * interleaving here; the reclaimer's snapshot survives all but one; and a
+ * generation of DEPTH is lost whenever the reclaim lands in a gap. The
+ * worst case, the check→`copyFileSync` gap, loses the reclaimer's
+ * snapshot too, and is asserted below rather than only described, so the
+ * residual in `log-rotation.ts` cannot drift away from the behaviour.
  */
 describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
   const BODY = "x".repeat(CAP * 4);
@@ -442,6 +491,44 @@ describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
     expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY);
   });
 
+  it("loses a generation when the reclaim lands in the copy gap (residual)", () => {
+    // The documented worst case (#3600 round-5, M2), asserted so the
+    // residual cannot quietly become untrue. The peer lands between the
+    // pre-copy `held()` check and `copyFileSync` itself, so that ONE
+    // syscall proceeds unserialized: by then `.1` is the peer's fresh
+    // snapshot, and we overwrite it with a copy of the LIVE file.
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    let fired = false;
+    hooks.beforeCopy = (from) => {
+      if (from !== log || fired) return;
+      fired = true;
+      hooks.beforeCopy = undefined;
+      peerReclaimsAndRotates(2, NEW);
+    };
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(fired).toBe(true);
+    // The NEXT checkpoint still stops us — the active file is not
+    // truncated, so the rows written after the peer's rotation survive.
+    expect(rotated).toBe(false);
+    expect(realFs.readFileSync(log, "utf8")).toBe(NEW);
+    // But the damage is real and this is what it looks like: `.1` is now
+    // a useless duplicate of the live file, and BOTH the peer's snapshot
+    // (which was at `.1`) and the shifted HISTORY (which our own earlier
+    // rename had put at `.2`, and the peer's rotation then dropped) are
+    // gone. One unguarded syscall costs a full generation.
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(NEW);
+    expect(realFs.existsSync(`${log}.2`)).toBe(false);
+  });
+
   it("a rotator that lost the lock touches nothing at all", () => {
     // Unit-level: the predicate is false from the first call, so every
     // generation and the active file must be byte-identical afterwards.
@@ -463,5 +550,87 @@ describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
     expect(rotateLogFile(log, 2, "t", () => true)).toBe(true);
     expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY);
     expect(realFs.statSync(log).size).toBe(0);
+  });
+});
+
+/**
+ * M3 (#3600 round-5). Everything above rests on inode identity:
+ * `stillHeld()` and the release guard both compare `statSync(lock).ino`
+ * against the number captured by `fstat` at `open(wx)`. That comparison
+ * only means "the same lock" because the lock `fd` stays OPEN for the
+ * whole critical section — an open fd is a reference, and a filesystem
+ * only recycles an inode number once nothing references it.
+ *
+ * This is not testable by outcome here. Measured over 200
+ * park→unlink→recreate cycles (the exact shape of a peer's reclaim):
+ *
+ *     fd closed  ext4  200/200 collisions      fd closed  tmpfs  0/200
+ *     fd open    ext4    0/200 collisions      fd open    tmpfs  0/200
+ *
+ * The suite's files live under `os.tmpdir()` — tmpfs, which never reuses
+ * — so a race test cannot see an early close, while the real logs live
+ * under `~/.switchroom/**` on ext4, which always does. Re-running the
+ * race suite with `TMPDIR` on ext4 does not help either (verified: still
+ * 14/14) — on the shipped code the fd is never closed early, so there is
+ * nothing for the reused inode number to collide with.
+ *
+ * So assert the MECHANISM, on any filesystem: the fd must still be open
+ * at each destructive syscall. Close it before `fn()` and this fails.
+ */
+describe("inode identity's premise: the lock fd stays open (M3)", () => {
+  it("holds the lock fd open through every destructive syscall", () => {
+    const BODY = "x".repeat(CAP * 4);
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+    realFs.writeFileSync(`${log}.2`, "OLDEST\n");
+
+    let lockFd = -1;
+    let lockFdClosed = false;
+    const seen: string[] = [];
+    const note = (what: string) =>
+      seen.push(`${what} [${lockFdClosed ? "FD CLOSED" : "fd open"}]`);
+    const gen = (p: string) => `<log>${p.slice(log.length)}`;
+
+    hooks.afterOpen = (p, flags, fd) => {
+      if (p === lock && flags === "wx" && lockFd === -1) lockFd = fd;
+    };
+    hooks.beforeClose = (fd) => {
+      if (lockFd !== -1 && fd === lockFd) lockFdClosed = true;
+    };
+    // Only the four log-data mutations; the lockfile's own unlink at
+    // release is deliberately not one of them.
+    const isGeneration = (p: string) => /^\.\d+$/.test(p.slice(log.length));
+    hooks.beforeUnlink = (p) => {
+      if (isGeneration(p)) note(`unlink ${gen(p)}`);
+    };
+    hooks.beforeRename = (from) => {
+      if (isGeneration(from)) note(`rename ${gen(from)}`);
+    };
+    hooks.beforeCopy = (from, to) => {
+      if (from === log) note(`copy <log> → ${gen(to)}`);
+    };
+    hooks.beforeTruncate = (p) => {
+      if (p === log) note("truncate <log>");
+    };
+
+    expect(
+      maybeRotateLogFile(log, {
+        maxBytes: CAP,
+        maxFiles: 2,
+        tag: "t",
+        lock: true,
+      }),
+    ).toBe(true);
+
+    expect(lockFd).not.toBe(-1); // we really did identify the lock fd
+    expect(seen).toEqual([
+      "unlink <log>.2 [fd open]",
+      "rename <log>.1 [fd open]",
+      "copy <log> → <log>.1 [fd open]",
+      "truncate <log> [fd open]",
+    ]);
+    // And it IS closed by the end — otherwise the tags above would be
+    // vacuously "fd open" and this test would prove nothing.
+    expect(lockFdClosed).toBe(true);
   });
 });

--- a/src/util/log-rotation-race.test.ts
+++ b/src/util/log-rotation-race.test.ts
@@ -27,6 +27,7 @@ const hooks = vi.hoisted(() => ({
   beforeRename: undefined as ((from: string) => void) | undefined,
   beforeOpen: undefined as ((p: string, flags: string) => void) | undefined,
   beforeUnlink: undefined as ((p: string) => void) | undefined,
+  beforeStat: undefined as ((p: string) => void) | undefined,
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -46,10 +47,14 @@ vi.mock("node:fs", async (importOriginal) => {
       hooks.beforeOpen?.(String(p), flags);
       return actual.openSync(p, flags, mode);
     },
+    statSync: ((p: realFs.PathLike, o?: realFs.StatSyncOptions) => {
+      hooks.beforeStat?.(String(p));
+      return actual.statSync(p, o);
+    }) as unknown as typeof realFs.statSync,
   };
 });
 
-const { maybeRotateLogFile } = await import("./log-rotation.js");
+const { maybeRotateLogFile, rotateLogFile } = await import("./log-rotation.js");
 
 let dir: string;
 let log: string;
@@ -65,14 +70,29 @@ beforeEach(() => {
   hooks.beforeRename = undefined;
   hooks.beforeOpen = undefined;
   hooks.beforeUnlink = undefined;
+  hooks.beforeStat = undefined;
 });
 
 afterEach(() => {
   hooks.beforeRename = undefined;
   hooks.beforeOpen = undefined;
   hooks.beforeUnlink = undefined;
+  hooks.beforeStat = undefined;
   realFs.rmSync(dir, { recursive: true, force: true });
 });
+
+/**
+ * Age our LIVE lock past the stale threshold (i.e. our rotation overran),
+ * then run a second process end to end: it EEXISTs, judges the lock
+ * stale, park-verify-claims it, rotates, and appends fresh rows
+ * afterwards. This is the whole of H1 — it needs no third process.
+ */
+function peerReclaimsAndRotates(maxFiles: number, appended: string): void {
+  const old = Date.now() / 1000 - 300;
+  realFs.utimesSync(lock, old, old);
+  maybeRotateLogFile(log, { maxBytes: CAP, maxFiles, tag: "peer", lock: true });
+  realFs.appendFileSync(log, appended);
+}
 
 describe("the under-lock size re-check (finding 4)", () => {
   it("declines to rotate a file a peer rotated while we waited for the lock", () => {
@@ -189,11 +209,20 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
       realFs.utimesSync(f, old, old);
     }
     // A park younger than the threshold — a peer may be mid-reclaim with
-    // it, so it must survive; and an unrelated neighbour must too.
+    // it, so it must survive.
     const fresh = `${lock}.stale.997.cccccccc`;
     realFs.writeFileSync(fresh, "");
+    // Neighbours that do NOT carry the park prefix. Both are older than
+    // the threshold, which is the whole point: the sweep's eligibility
+    // test is age, so the ONLY thing keeping them alive is the prefix
+    // guard. `<log>.1` is the previous generation and `webhook.sock` is
+    // the gateway's socket — both really do sit in this directory.
     const neighbour = `${log}.1`;
     realFs.writeFileSync(neighbour, HISTORY);
+    realFs.utimesSync(neighbour, old, old);
+    const sock = path.join(dir, "webhook.sock");
+    realFs.writeFileSync(sock, "");
+    realFs.utimesSync(sock, old, old);
 
     expect(
       maybeRotateLogFile(log, {
@@ -206,7 +235,14 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
 
     for (const f of leaked) expect(realFs.existsSync(f)).toBe(false);
     expect(realFs.existsSync(fresh)).toBe(true);
-    expect(realFs.existsSync(neighbour)).toBe(true);
+    expect(realFs.existsSync(sock)).toBe(true);
+    // `<log>.1` was SHIFTED to `.2`, not destroyed. Asserting the bytes at
+    // `.2` is what makes this bite: rotation recreates `.1` unconditionally
+    // (log-rotation.ts, `copyFileSync(logPath, snapshotPath)`), so
+    // `existsSync(<log>.1)` is true whether or not the sweep ate the
+    // original (#3600 round-4, L2).
+    expect(realFs.readFileSync(`${log}.2`, "utf8")).toBe(HISTORY);
+    expect(realFs.statSync(`${log}.1`).size).toBe(CAP * 4);
     // And our own park did not survive either.
     expect(
       realFs.readdirSync(dir).filter((f) => f.includes(".stale.")),
@@ -256,6 +292,9 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
       peerIno = realFs.statSync(lock).ino;
     };
 
+    // We now DECLINE as well as release safely (#3600 round-4, H1): once
+    // the lock is the peer's, finishing the rotation is the clobber. The
+    // release guard is what this test is about, and it still holds.
     expect(
       maybeRotateLogFile(log, {
         maxBytes: CAP,
@@ -263,10 +302,166 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
         tag: "t",
         lock: true,
       }),
-    ).toBe(true);
+    ).toBe(false);
 
     expect(peerIno).not.toBe(-1);
     expect(realFs.existsSync(lock)).toBe(true);
     expect(realFs.statSync(lock).ino).toBe(peerIno);
+  });
+});
+
+/**
+ * H1 (#3600 round-4). The reclaim cannot tell "stale because the holder
+ * died" from "stale because the holder is slow": the lock mtime is
+ * stamped once by `open(wx)` and never refreshed, so a LIVE holder that
+ * overruns the threshold is reclaimable by a peer, at TWO writers. The
+ * close is not to prevent that but to make the loser harmless — every
+ * destructive syscall in `rotateLogFile` re-asserts the lock inode.
+ *
+ * Each test lands the peer at a different point in the victim's rotation
+ * and asserts the OUTCOME: the reclaimer's snapshot, the shifted history,
+ * and the rows the reclaimer's writers appended all survive.
+ */
+describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
+  const BODY = "x".repeat(CAP * 4);
+  const NEW = "ROWS WRITTEN AFTER THE PEER ROTATED\n".repeat(64);
+
+  it("declines outright when the peer rotated before we touched anything", () => {
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    // Fire on the UNDER-LOCK size re-check — we hold the lock, we have
+    // destroyed nothing yet. The peer rotates and its writers append
+    // enough to put us back over cap, so the re-check passes and the
+    // inode guard is what has to stop us.
+    let stats = 0;
+    hooks.beforeStat = (p) => {
+      if (p !== log) return;
+      if (++stats !== 2) return;
+      hooks.beforeStat = undefined;
+      peerReclaimsAndRotates(2, NEW);
+    };
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(stats).toBeGreaterThanOrEqual(2); // the interleaving happened
+    expect(rotated).toBe(false);
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY); // peer's snapshot
+    expect(realFs.readFileSync(`${log}.2`, "utf8")).toBe(HISTORY); // shifted, not dropped
+    expect(realFs.readFileSync(log, "utf8")).toBe(NEW); // not re-truncated
+  });
+
+  it("does not shift the peer's fresh .1 off the end of the window", () => {
+    // `.1` absent, `.2` present: our first destructive syscall is the
+    // oldest-generation unlink, and the peer lands on it. By the time we
+    // reach the shift loop, `.1` is the peer's brand-new snapshot.
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.2`, "OLDEST\n");
+
+    let fired = false;
+    hooks.beforeUnlink = (p) => {
+      if (p !== `${log}.2` || fired) return;
+      fired = true;
+      hooks.beforeUnlink = undefined;
+      peerReclaimsAndRotates(2, NEW);
+    };
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(fired).toBe(true);
+    expect(rotated).toBe(false);
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY); // still `.1`
+    expect(realFs.readFileSync(log, "utf8")).toBe(NEW);
+  });
+
+  it("does not copy over the peer's .1", () => {
+    // The peer lands inside our shift rename — i.e. in the documented
+    // check→syscall gap, so that ONE rename proceeds unserialized and
+    // moves the peer's `.1` to `.2`. The next checkpoint must catch it:
+    // no zero-byte `.1` may be created over the peer's snapshot, and the
+    // rows its writers appended must survive.
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    let fired = false;
+    hooks.beforeRename = (from) => {
+      if (from !== `${log}.1` || fired) return;
+      fired = true;
+      hooks.beforeRename = undefined;
+      peerReclaimsAndRotates(2, NEW);
+    };
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(fired).toBe(true);
+    expect(rotated).toBe(false);
+    expect(realFs.existsSync(`${log}.1`)).toBe(false); // no copy happened
+    expect(realFs.readFileSync(`${log}.2`, "utf8")).toBe(BODY); // peer's snapshot
+    expect(realFs.readFileSync(log, "utf8")).toBe(NEW);
+  });
+
+  it("does not truncate rows written after the peer's rotation", () => {
+    // The peer lands on the snapshot fsync — after our copy, before our
+    // truncate. Truncating now would destroy rows that belong to the
+    // peer's already-completed cycle, not ours.
+    realFs.writeFileSync(log, BODY);
+
+    let fired = false;
+    hooks.beforeOpen = (p, flags) => {
+      if (p !== `${log}.1` || flags !== "r" || fired) return;
+      fired = true;
+      hooks.beforeOpen = undefined;
+      peerReclaimsAndRotates(2, NEW);
+    };
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(fired).toBe(true);
+    expect(rotated).toBe(false);
+    expect(realFs.readFileSync(log, "utf8")).toBe(NEW); // rows intact
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY);
+  });
+
+  it("a rotator that lost the lock touches nothing at all", () => {
+    // Unit-level: the predicate is false from the first call, so every
+    // generation and the active file must be byte-identical afterwards.
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+    realFs.writeFileSync(`${log}.2`, "OLDEST\n");
+
+    expect(rotateLogFile(log, 2, "victim", () => false)).toBe(false);
+
+    expect(realFs.readFileSync(log, "utf8")).toBe(BODY);
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(HISTORY);
+    expect(realFs.readFileSync(`${log}.2`, "utf8")).toBe("OLDEST\n");
+  });
+
+  it("rotates normally when the lock is still ours", () => {
+    // The guard must not be a blanket refusal: the ordinary path still
+    // rotates, and an absent predicate (unlocked callers) is unaffected.
+    realFs.writeFileSync(log, BODY);
+    expect(rotateLogFile(log, 2, "t", () => true)).toBe(true);
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY);
+    expect(realFs.statSync(log).size).toBe(0);
   });
 });

--- a/src/util/log-rotation-race.test.ts
+++ b/src/util/log-rotation-race.test.ts
@@ -1,0 +1,204 @@
+/**
+ * log-rotation — the two interleavings the lock exists for (#3600
+ * re-review, findings 1 and 4).
+ *
+ * `log-rotation-lock.test.ts` asserts the right OUTCOMES but never
+ * reaches the mechanisms it credits: with the active file at 0 bytes the
+ * top-level `overCap` guard returns before the lock is taken, and its
+ * "interleaved" case is sequential and single-process. Real concurrency
+ * in a test is either flaky or slow, so instead we drive the exact
+ * interleaving deterministically: `node:fs` is mocked so a hook fires
+ * INSIDE `withRotateLock`, at the precise syscall where the peer's action
+ * must land. What the hook does is what a second process really does.
+ *
+ * Both tests fail against the pre-fix code:
+ *  - drop the under-lock size re-check and the first one clobbers `.1`;
+ *  - restore `unlink` + `open(wx)` as the stale reclaim and the second
+ *    one enters the critical section while a peer holds the lock.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as realFs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/** Fires immediately before the named syscall inside log-rotation.ts. */
+const hooks = vi.hoisted(() => ({
+  beforeRename: undefined as ((from: string) => void) | undefined,
+  beforeOpen: undefined as ((p: string, flags: string) => void) | undefined,
+  beforeUnlink: undefined as ((p: string) => void) | undefined,
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    default: actual,
+    renameSync: (from: realFs.PathLike, to: realFs.PathLike) => {
+      hooks.beforeRename?.(String(from));
+      return actual.renameSync(from, to);
+    },
+    unlinkSync: (p: realFs.PathLike) => {
+      hooks.beforeUnlink?.(String(p));
+      return actual.unlinkSync(p);
+    },
+    openSync: (p: realFs.PathLike, flags: string, mode?: number) => {
+      hooks.beforeOpen?.(String(p), flags);
+      return actual.openSync(p, flags, mode);
+    },
+  };
+});
+
+const { maybeRotateLogFile } = await import("./log-rotation.js");
+
+let dir: string;
+let log: string;
+let lock: string;
+
+const HISTORY = "REAL HISTORY — must survive\n";
+const CAP = 1024;
+
+beforeEach(() => {
+  dir = realFs.mkdtempSync(path.join(os.tmpdir(), "rotrace-"));
+  log = path.join(dir, "events.jsonl");
+  lock = `${log}.rotate.lock`;
+  hooks.beforeRename = undefined;
+  hooks.beforeOpen = undefined;
+  hooks.beforeUnlink = undefined;
+});
+
+afterEach(() => {
+  hooks.beforeRename = undefined;
+  hooks.beforeOpen = undefined;
+  hooks.beforeUnlink = undefined;
+  realFs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("the under-lock size re-check (finding 4)", () => {
+  it("declines to rotate a file a peer rotated while we waited for the lock", () => {
+    // Real shape: over cap at our first stat, EMPTY by the time we hold
+    // the lock. Without the re-check we copy those zero bytes over `.1`
+    // and shift a full generation of events off the end of the window.
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    let peerRan = false;
+    hooks.beforeOpen = (p, flags) => {
+      // The instant we are about to take the lock, the peer finishes its
+      // own rotation: `.1` becomes the peer's snapshot, active truncated.
+      if (p !== lock || flags !== "wx" || peerRan) return;
+      peerRan = true;
+      realFs.writeFileSync(`${log}.1`, HISTORY);
+      realFs.truncateSync(log, 0);
+    };
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "t",
+      lock: true,
+    });
+
+    expect(peerRan).toBe(true); // the interleaving really happened
+    expect(rotated).toBe(false);
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(HISTORY);
+    expect(realFs.existsSync(`${log}.2`)).toBe(false); // no shift happened
+  });
+});
+
+describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
+  it("does NOT enter the critical section when a peer reclaimed first", () => {
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    // A lock left by a killed rotator, well past the stale threshold.
+    realFs.writeFileSync(lock, "");
+    const old = Date.now() / 1000 - 300;
+    realFs.utimesSync(lock, old, old);
+
+    // Fire on whichever syscall the implementation uses to get the stale
+    // lock out of the way — `rename` now, `unlink` in the pre-fix code —
+    // so this test is version-agnostic and really does bite both.
+    let peerLockIno = -1;
+    const peerReclaims = (p: string) => {
+      if (p !== lock || peerLockIno !== -1) return;
+      // Between our staleness decision and that syscall, a peer completes
+      // the same reclaim and is now HOLDING a fresh lock. Pre-fix, our
+      // unlink removed exactly this file and our create then succeeded —
+      // two rotators, which is the failure the lock exists to prevent.
+      realFs.rmSync(lock, { force: true });
+      realFs.closeSync(realFs.openSync(lock, "wx", 0o600));
+      peerLockIno = realFs.statSync(lock).ino;
+    };
+    hooks.beforeRename = peerReclaims;
+    hooks.beforeUnlink = peerReclaims;
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "t",
+      lock: true,
+    });
+
+    expect(peerLockIno).not.toBe(-1); // the interleaving really happened
+    expect(rotated).toBe(false); // we did NOT run alongside the peer
+    // The peer's lock is intact — same inode, still held.
+    expect(realFs.existsSync(lock)).toBe(true);
+    expect(realFs.statSync(lock).ino).toBe(peerLockIno);
+    // And nothing rotated behind the peer's back.
+    expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(HISTORY);
+    expect(realFs.statSync(log).size).toBe(CAP * 4);
+    // No parked debris left behind.
+    expect(
+      realFs.readdirSync(dir).filter((f) => f.includes(".stale.")),
+    ).toEqual([]);
+  });
+
+  it("still reclaims a genuinely stale lock when no peer intervenes", () => {
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    realFs.writeFileSync(lock, "");
+    const old = Date.now() / 1000 - 300;
+    realFs.utimesSync(lock, old, old);
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "t",
+      lock: true,
+    });
+
+    expect(rotated).toBe(true);
+    expect(realFs.statSync(`${log}.1`).size).toBe(CAP * 4);
+    expect(realFs.statSync(log).size).toBe(0);
+    expect(realFs.existsSync(lock)).toBe(false); // released
+  });
+
+  it("release does not delete a lock that is no longer ours", () => {
+    // We overran the stale threshold and a peer reclaimed while we were
+    // inside; the identity-guarded release must not unlink the peer's
+    // lock on the way out (that would leave the log with NO lock).
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    let peerIno = -1;
+    hooks.beforeRename = (from) => {
+      if (from !== `${log}.1` || peerIno !== -1) return;
+      realFs.unlinkSync(lock);
+      realFs.closeSync(realFs.openSync(lock, "wx", 0o600));
+      peerIno = realFs.statSync(lock).ino;
+    };
+
+    expect(
+      maybeRotateLogFile(log, {
+        maxBytes: CAP,
+        maxFiles: 2,
+        tag: "t",
+        lock: true,
+      }),
+    ).toBe(true);
+
+    expect(peerIno).not.toBe(-1);
+    expect(realFs.existsSync(lock)).toBe(true);
+    expect(realFs.statSync(lock).ino).toBe(peerIno);
+  });
+});

--- a/src/util/log-rotation-race.test.ts
+++ b/src/util/log-rotation-race.test.ts
@@ -12,9 +12,14 @@
  * must land. What the hook does is what a second process really does.
  *
  * The file has grown past those two interleavings (H1 in round 4, the fd
- * premise in round 5, the four check→syscall gaps in round 6). Describe 1
- * is still the original single test; describe 2 has kept its original
- * first test and accumulated four more (the reclaim/sweep/release cases).
+ * premise in round 5, the four check→syscall gaps in round 6, the release
+ * guard in round 7, the release PARK's own absence window in round 8).
+ * Describe 1 is still the original single test; describe 2 has kept its
+ * original first test and grown a family of reclaim, sweep and release
+ * cases around it. No count is stated here on purpose: round 7 added a
+ * test to that group and left the tally reading "four more", which is the
+ * whole failure mode this file exists to catch, one level up (#3600
+ * round-8, L2). Read the `it` titles, they are the record.
  * The two originals still fail against the pre-fix code:
  *  - drop the under-lock size re-check and "declines to rotate a file a
  *    peer rotated while we waited for the lock" clobbers `.1`;
@@ -42,6 +47,11 @@ const hooks = vi.hoisted(() => ({
     | ((p: string, flags: string, fd: number) => void)
     | undefined,
   beforeUnlink: undefined as ((p: string) => void) | undefined,
+  /** Fires before `link(2)`; `linkThrows` simulates a filesystem with no
+   *  hardlinks (EPERM/ENOSYS), which is one of the restore's three failure
+   *  modes and the one round 8 M1 was reproduced with. */
+  beforeLink: undefined as ((from: string, to: string) => void) | undefined,
+  linkThrows: false,
   beforeStat: undefined as ((p: string) => void) | undefined,
   afterStat: undefined as ((p: string) => void) | undefined,
   /** Throwing from here simulates an `fstat` failure on that fd (L1). */
@@ -63,6 +73,17 @@ vi.mock("node:fs", async (importOriginal) => {
     unlinkSync: (p: realFs.PathLike) => {
       hooks.beforeUnlink?.(String(p));
       return actual.unlinkSync(p);
+    },
+    linkSync: (from: realFs.PathLike, to: realFs.PathLike) => {
+      hooks.beforeLink?.(String(from), String(to));
+      if (hooks.linkThrows) {
+        const e: NodeJS.ErrnoException = new Error(
+          "EPERM: operation not permitted, link",
+        );
+        e.code = "EPERM";
+        throw e;
+      }
+      return actual.linkSync(from, to);
     },
     openSync: (p: realFs.PathLike, flags: string, mode?: number) => {
       hooks.beforeOpen?.(String(p), flags);
@@ -109,6 +130,8 @@ function clearHooks(): void {
   hooks.beforeOpen = undefined;
   hooks.afterOpen = undefined;
   hooks.beforeUnlink = undefined;
+  hooks.beforeLink = undefined;
+  hooks.linkThrows = false;
   hooks.beforeStat = undefined;
   hooks.afterStat = undefined;
   hooks.beforeFstat = undefined;
@@ -421,6 +444,203 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
     expect(
       realFs.readdirSync(dir).filter((f) => f.includes(".stale.")),
     ).toEqual([]);
+  });
+
+  it("a mismatched release does not park a peer's live lock (round-8 H2)", () => {
+    // The park's absence window is NOT private to the parking process: a
+    // legitimate holder that checkpoints while `lockPath` is renamed away
+    // reads ENOENT and aborts its rotation. Round 7 put that window on the
+    // MISMATCHED release path — the ordinary outcome after our lock was
+    // reclaimed — so a victim could lose a generation with no third party
+    // and no contention: our drop of `.2` runs, a peer's release parks our
+    // live lock, our next `held()` reads ENOENT, we abandon the rotation.
+    //
+    // This test is the victim's side, measured continuously: from the
+    // instant the peer's lock exists, EVERY syscall the releasing process
+    // makes is followed by the exact predicate `stillHeld()` would evaluate
+    // for that peer. It must never once report a loss.
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    let peerIno = -1;
+    let victimSawLoss = false;
+    const victimStillHolds = (): boolean => {
+      try {
+        return realFs.statSync(lock).ino === peerIno;
+      } catch {
+        return false; // ENOENT — exactly what stillHeld() reports as a loss
+      }
+    };
+    // `realFs` is the MOCKED module here, so the probe's own stat would
+    // re-enter this hook; the flag keeps one probe per syscall.
+    let probing = false;
+    const probe = (): void => {
+      if (probing || peerIno === -1) return;
+      probing = true;
+      try {
+        if (!victimStillHolds()) victimSawLoss = true;
+      } finally {
+        probing = false;
+      }
+    };
+    // The peer reclaims mid-rotation, as in the test above; everything from
+    // there on — including our whole release — is watched.
+    hooks.beforeRename = (from) => {
+      if (from === `${log}.1` && peerIno === -1) {
+        realFs.unlinkSync(lock);
+        realFs.closeSync(realFs.openSync(lock, "wx", 0o600));
+        peerIno = realFs.statSync(lock).ino;
+      }
+      probe();
+    };
+    hooks.beforeUnlink = probe;
+    hooks.beforeLink = probe;
+    hooks.beforeStat = probe;
+    hooks.beforeClose = probe;
+
+    expect(
+      maybeRotateLogFile(log, {
+        maxBytes: CAP,
+        maxFiles: 2,
+        tag: "t",
+        lock: true,
+      }),
+    ).toBe(false);
+
+    expect(peerIno).not.toBe(-1); // the interleaving really happened
+    // The claim: the peer holding the lock is never told it lost it.
+    expect(victimSawLoss).toBe(false);
+    expect(realFs.statSync(lock).ino).toBe(peerIno);
+    expect(
+      realFs.readdirSync(dir).filter((f) => f.includes(".stale.")),
+    ).toEqual([]);
+  });
+
+  it("release leaves the peer's lock alone even where the restore would fail (round-8 M1)", () => {
+    // Same interleaving, on a filesystem with no hardlinks. Before round 8
+    // the release parked the peer's live lock, the restoring `link` threw
+    // EPERM, and the cleanup `unlink` — which ran unconditionally — deleted
+    // the peer's inode: `existsSync(lock) === false`, the log unlocked
+    // while the peer believed it held it, i.e. the failure park-verify
+    // exists to prevent, reached through park-verify itself.
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+    hooks.linkThrows = true;
+
+    let peerIno = -1;
+    hooks.beforeRename = (from) => {
+      if (from !== `${log}.1` || peerIno !== -1) return;
+      realFs.unlinkSync(lock);
+      realFs.closeSync(realFs.openSync(lock, "wx", 0o600));
+      peerIno = realFs.statSync(lock).ino;
+    };
+
+    maybeRotateLogFile(log, { maxBytes: CAP, maxFiles: 2, tag: "t", lock: true });
+
+    expect(peerIno).not.toBe(-1);
+    expect(realFs.existsSync(lock)).toBe(true);
+    expect(realFs.statSync(lock).ino).toBe(peerIno);
+  });
+
+  it("a restore that fails does not destroy the peer's lock inode (round-8 M1, residual)", () => {
+    // The narrow case the filter cannot cover: the release's opening stat
+    // sees our OWN inode, and the peer reclaims in the one syscall between
+    // that stat and the `rename`. We then really do park the peer's live
+    // lock, and with `link` unavailable it cannot be put back.
+    //
+    // This test pins BOTH halves, the fix and its cost. The cost, asserted
+    // below and not papered over: `lockPath` is left absent, so the peer
+    // declines at its next checkpoint and a later arrival can take the lock
+    // — no atomic create-if-absent restore exists on a filesystem without
+    // hardlinks, and `rename`-ing it back would clobber whatever arrived
+    // meanwhile, which is the one thing this whole design refuses to do.
+    // What the fix buys is that the peer's lock INODE is not unlinked out
+    // from under its open fd: it survives as a named park the sweep reaps.
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    hooks.linkThrows = true;
+
+    let peerIno = -1;
+    hooks.beforeRename = (from) => {
+      // The release park is the only rename whose source is `lockPath`.
+      if (from !== lock || peerIno !== -1) return;
+      realFs.rmSync(lock, { force: true });
+      realFs.closeSync(realFs.openSync(lock, "wx", 0o600));
+      peerIno = realFs.statSync(lock).ino;
+    };
+
+    maybeRotateLogFile(log, { maxBytes: CAP, maxFiles: 2, tag: "t", lock: true });
+
+    expect(peerIno).not.toBe(-1); // we parked the peer's live lock
+    // The residual, stated as an assertion: the path IS left unlocked.
+    expect(realFs.existsSync(lock)).toBe(false);
+    const debris = realFs
+      .readdirSync(dir)
+      .filter((f) => f.includes(".stale."));
+    expect(debris).toHaveLength(1);
+    expect(realFs.statSync(path.join(dir, debris[0])).ino).toBe(peerIno);
+  });
+
+  it("a RECLAIM whose restore fails does not destroy the peer's lock inode (round-8 M1, sibling)", () => {
+    // The reclaim's mismatch branch is the same code as the release's, one
+    // branch away, and carried the same defect: swallow the failed `link`,
+    // then unlink the park unconditionally. Here the park holds a peer's
+    // brand-new LIVE lock, so that unlink deletes it.
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    realFs.closeSync(realFs.openSync(lock, "wx", 0o600));
+    const old = Date.now() / 1000 - 300;
+    realFs.utimesSync(lock, old, old); // stale: we will try to reclaim it
+    hooks.linkThrows = true;
+
+    let peerIno = -1;
+    hooks.beforeRename = (from) => {
+      // Between our staleness stat and our park `rename`, a peer reclaims.
+      if (from !== lock || peerIno !== -1) return;
+      realFs.rmSync(lock, { force: true });
+      realFs.closeSync(realFs.openSync(lock, "wx", 0o600));
+      peerIno = realFs.statSync(lock).ino;
+    };
+
+    // We must DECLINE — the lock we parked was not the stale one we judged.
+    expect(
+      maybeRotateLogFile(log, {
+        maxBytes: CAP,
+        maxFiles: 2,
+        tag: "t",
+        lock: true,
+      }),
+    ).toBe(false);
+
+    expect(peerIno).not.toBe(-1);
+    const debris = realFs
+      .readdirSync(dir)
+      .filter((f) => f.includes(".stale."));
+    expect(debris).toHaveLength(1);
+    expect(realFs.statSync(path.join(dir, debris[0])).ino).toBe(peerIno);
+  });
+
+  it("reaps a release park stranded by a crash, from an UNCONTENDED acquisition (round-8 L1)", () => {
+    // A crash between the release `rename` and its cleanup `unlink` leaves
+    // NOTHING at `lockPath`. So the next arrival's `open(wx)` succeeds and
+    // it never enters the EEXIST reclaim branch — which is where the sweep
+    // used to live, making the "release parks are reaped the same way"
+    // claim false and the leak unbounded.
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    const stranded = `${lock}.stale.999999.deadbeef`;
+    realFs.writeFileSync(stranded, "");
+    const old = Date.now() / 1000 - 300;
+    realFs.utimesSync(stranded, old, old);
+    expect(realFs.existsSync(lock)).toBe(false); // no lock: uncontended path
+
+    expect(
+      maybeRotateLogFile(log, {
+        maxBytes: CAP,
+        maxFiles: 2,
+        tag: "t",
+        lock: true,
+      }),
+    ).toBe(true);
+
+    expect(realFs.existsSync(stranded)).toBe(false);
   });
 });
 
@@ -1229,5 +1449,70 @@ describe("inode identity's premise: the lock fd stays open (M3)", () => {
     // And it IS closed by the end — otherwise the tags above would be
     // vacuously "fd open" and this test would prove nothing.
     expect(lockFdClosed).toBe(true);
+  });
+});
+
+/**
+ * Rounds 3 through 8 of the #3600 review each found a claim in
+ * `log-rotation.ts` that no longer matched the code, and twice the claim
+ * was a NAME: a doc citation pointing at a test that had been renamed, or
+ * a tally of tests that had gone stale. Prose cannot be type-checked, but
+ * a citation CAN be, so it is — mechanically, here, rather than by asking
+ * the next reviewer to grep (#3600 round-8, L2).
+ */
+describe("the doc block's citations are checkable", () => {
+  it("every test name this file cites exists", () => {
+    const here = path.dirname(new URL(import.meta.url).pathname);
+    const source = realFs.readFileSync(
+      path.join(here, "log-rotation.ts"),
+      "utf8",
+    );
+    const self = realFs.readFileSync(
+      path.join(here, "log-rotation-race.test.ts"),
+      "utf8",
+    );
+
+    const titles = [...self.matchAll(/^ {2}it\(\s*\n?\s*"([^"]+)"/gm)].map(
+      (m) => m[1],
+    );
+    expect(titles.length).toBeGreaterThan(20); // the extractor still works
+
+    // Comment lines only, flattened, so a citation wrapped across lines is
+    // still one string. A candidate is a quoted phrase in the shape of a
+    // test title: prose, lower-case, no code punctuation.
+    const comments = source
+      .split("\n")
+      .filter((l) => /^\s*(\*|\/\/|\/\*)/.test(l))
+      .map((l) => l.replace(/^\s*(\*|\/\/)\s?/, ""))
+      .join(" ")
+      .replace(/\s+/g, " ");
+    const candidates = [...comments.matchAll(/"([^"]{20,120})"/g)]
+      .map((m) => m[1])
+      .filter((s) => !/[`#{}—[\]]/.test(s) && /^[a-z]/.test(s));
+
+    // Quoted PROSE that is not a citation. Explicit, so that a new quote in
+    // title shape fails this test until someone decides which it is —
+    // that decision is the point, and it is cheap.
+    const notCitations = new Set([
+      "between two adjacent syscalls",
+      "our lock was destroyed",
+      "rename works fine on the host",
+      "rows another rotator wrote … are LOST",
+      "some file that got our number",
+      "someone else handled it",
+      "stale because the holder died",
+      "stale because the holder is slow",
+      "the rotation did not happen and the active file is exactly as it was",
+      "we cannot delete the new holder's lock on the way out",
+    ]);
+
+    const dangling = candidates.filter(
+      (c) =>
+        !notCitations.has(c) && !titles.some((t) => t === c || t.startsWith(c)),
+    );
+    expect(dangling).toEqual([]);
+    // And the allowlist itself must not rot: every entry has to still be
+    // present in the source, or it is a stale exemption hiding a real one.
+    expect([...notCitations].filter((c) => !comments.includes(c))).toEqual([]);
   });
 });

--- a/src/util/log-rotation-race.test.ts
+++ b/src/util/log-rotation-race.test.ts
@@ -386,8 +386,10 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
  *     prior generation is gone ("loses a generation…"); with a QUIET peer
  *     we copy its freshly-truncated zero bytes and the log loses
  *     everything it has ("loses EVERY byte…", round-6 H1).
- *   - the truncate gap — the only one that destroys LIVE rows and the
- *     only one with no next checkpoint. Caught by a data-based gate for
+ *   - the truncate gap — the only one where WE destroy rows in the ACTIVE
+ *     file (the quiet copy gap costs the same rows via the snapshot they
+ *     had moved to), and the only one with no next checkpoint behind it.
+ *     Caught by a data-based gate for
  *     every landing before its stat ("declines the truncate when the peer
  *     rotated after our lock check"); the surviving window after that
  *     stat destroys the peer's rows and returns `true` ("destroys the
@@ -620,7 +622,7 @@ describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
     // The peer lands in the check→`truncateSync` gap: AFTER `held()`'s
     // stat of the lockfile, so the lock guard cannot see it. This is the
     // one gap with no next checkpoint — the truncate is the last one — and
-    // the only gap that destroys LIVE rows rather than history depth.
+    // the only one where WE destroy rows in the active file itself.
     //
     // The data-based gate is what catches it: the active file is now
     // SHORTER than the snapshot we just wrote to `.1`, which only happens

--- a/src/util/log-rotation-race.test.ts
+++ b/src/util/log-rotation-race.test.ts
@@ -12,11 +12,15 @@
  * must land. What the hook does is what a second process really does.
  *
  * The file has grown past those two interleavings (H1 in round 4, the fd
- * premise in round 5), but the first two describes are still the
- * originals, and both fail against the pre-fix code:
- *  - drop the under-lock size re-check and the first one clobbers `.1`;
- *  - restore `unlink` + `open(wx)` as the stale reclaim and the second
- *    one enters the critical section while a peer holds the lock.
+ * premise in round 5, the four check→syscall gaps in round 6). Describe 1
+ * is still the original single test; describe 2 has kept its original
+ * first test and accumulated four more (the reclaim/sweep/release cases).
+ * The two originals still fail against the pre-fix code:
+ *  - drop the under-lock size re-check and "declines to rotate a file a
+ *    peer rotated while we waited for the lock" clobbers `.1`;
+ *  - restore `unlink` + `open(wx)` as the stale reclaim and "does NOT
+ *    enter the critical section when a peer reclaimed first" enters the
+ *    critical section while a peer holds the lock.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
@@ -27,7 +31,9 @@ import * as path from "node:path";
 /**
  * Fires immediately before the named syscall inside log-rotation.ts.
  * `afterOpen` fires just after, because it needs the resulting fd — that
- * is how the M3 test learns which fd is the lock's.
+ * is how the M3 test learns which fd is the lock's. `afterStat` fires just
+ * after, which is the only way to land a peer INSIDE a check→syscall gap
+ * rather than before the check (round-6, H2).
  */
 const hooks = vi.hoisted(() => ({
   beforeRename: undefined as ((from: string) => void) | undefined,
@@ -37,6 +43,7 @@ const hooks = vi.hoisted(() => ({
     | undefined,
   beforeUnlink: undefined as ((p: string) => void) | undefined,
   beforeStat: undefined as ((p: string) => void) | undefined,
+  afterStat: undefined as ((p: string) => void) | undefined,
   beforeCopy: undefined as ((from: string, to: string) => void) | undefined,
   beforeTruncate: undefined as ((p: string) => void) | undefined,
   beforeClose: undefined as ((fd: number) => void) | undefined,
@@ -75,7 +82,9 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     statSync: ((p: realFs.PathLike, o?: realFs.StatSyncOptions) => {
       hooks.beforeStat?.(String(p));
-      return actual.statSync(p, o);
+      const s = actual.statSync(p, o);
+      hooks.afterStat?.(String(p));
+      return s;
     }) as unknown as typeof realFs.statSync,
   };
 });
@@ -95,6 +104,7 @@ function clearHooks(): void {
   hooks.afterOpen = undefined;
   hooks.beforeUnlink = undefined;
   hooks.beforeStat = undefined;
+  hooks.afterStat = undefined;
   hooks.beforeCopy = undefined;
   hooks.beforeTruncate = undefined;
   hooks.beforeClose = undefined;
@@ -117,12 +127,20 @@ afterEach(() => {
  * then run a second process end to end: it EEXISTs, judges the lock
  * stale, park-verify-claims it, rotates, and appends fresh rows
  * afterwards. This is the whole of H1 — it needs no third process.
+ *
+ * `appended === ""` is the QUIET peer: it rotates and then writes nothing
+ * for the moment we are looking at. That is the ordinary state of a
+ * low-traffic log (the webhook event log goes minutes between events), and
+ * it is a strictly worse victim for us than a busy peer — the active file
+ * it leaves behind is zero bytes, so anything of ours that copies it
+ * copies nothing (round-6, H1). Passing rows here is the EASY case; tests
+ * that only pass rows mask the worst outcome.
  */
 function peerReclaimsAndRotates(maxFiles: number, appended: string): void {
   const old = Date.now() / 1000 - 300;
   realFs.utimesSync(lock, old, old);
   maybeRotateLogFile(log, { maxBytes: CAP, maxFiles, tag: "peer", lock: true });
-  realFs.appendFileSync(log, appended);
+  if (appended) realFs.appendFileSync(log, appended);
 }
 
 describe("the under-lock size re-check (finding 4)", () => {
@@ -351,25 +369,35 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
  *
  * Each test lands the peer at a different point in the victim's rotation
  * and asserts the OUTCOME. What survives is NOT uniform, and these tests
- * pin the difference (#3600 round-5, M1):
+ * pin the difference (#3600 round-5, M1; extended round-6). Read as a
+ * table, the peer lands either before our first destructive syscall or in
+ * one of the FOUR check→syscall gaps, and the four are not equivalent:
  *
- *   - reclaim before our first destructive syscall — nothing of ours ran,
- *     so the reclaimer's `.1`, the shifted history at `.2` and the rows
- *     its writers appended all survive ("declines outright…").
- *   - reclaim inside a check→syscall gap — that one syscall goes through
- *     before the next checkpoint stops us, and it costs a generation.
- *     "does not copy over the peer's .1" asserts exactly that: `.1` is
- *     ABSENT and `.2` holds the reclaimer's snapshot, i.e. our
- *     unserialized shift `rename` moved its fresh `.1` to `.2` and the
- *     shifted HISTORY that was there is gone.
+ *   - before our first destructive syscall — nothing of ours ran, so the
+ *     reclaimer's `.1`, the shifted history at `.2` and the rows its
+ *     writers appended all survive ("declines outright…").
+ *   - the unlink gap — the peer's freshly shifted history at `.2` is
+ *     deleted ("…but the unlink gap destroys its shifted history").
+ *   - the shift gap — `.1` ABSENT, `.2` the peer's snapshot: our
+ *     unserialized `rename` moved its fresh `.1` to `.2` over the history
+ *     that was there ("does not copy over the peer's .1").
+ *   - the copy gap — worst of the four, and how bad depends on the PEER:
+ *     with a busy peer, `.1` is a duplicate of the live file and the
+ *     prior generation is gone ("loses a generation…"); with a QUIET peer
+ *     we copy its freshly-truncated zero bytes and the log loses
+ *     everything it has ("loses EVERY byte…", round-6 H1).
+ *   - the truncate gap — the only one that destroys LIVE rows and the
+ *     only one with no next checkpoint. Caught by a data-based gate for
+ *     every landing before its stat ("declines the truncate when the peer
+ *     rotated after our lock check"); the surviving window after that
+ *     stat destroys the peer's rows and returns `true` ("destroys the
+ *     peer's rows…", round-6 H2).
  *
- * So what these tests pin is narrower than "all survive". The rows the
- * reclaimer's writers appended after its rotation survive every
- * interleaving here; the reclaimer's snapshot survives all but one; and a
- * generation of DEPTH is lost whenever the reclaim lands in a gap. The
- * worst case, the check→`copyFileSync` gap, loses the reclaimer's
- * snapshot too, and is asserted below rather than only described, so the
- * residual in `log-rotation.ts` cannot drift away from the behaviour.
+ * So what these tests pin is much narrower than "all survive", and
+ * narrower than round 5's "at worst one generation". They are asserted
+ * rather than described so the residual in `log-rotation.ts` cannot drift
+ * away from the behaviour — which is what rounds 3, 4, 5 and 6 each
+ * caught it doing.
  */
 describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
   const BODY = "x".repeat(CAP * 4);
@@ -405,19 +433,34 @@ describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
     expect(realFs.readFileSync(log, "utf8")).toBe(NEW); // not re-truncated
   });
 
-  it("does not shift the peer's fresh .1 off the end of the window", () => {
-    // `.1` absent, `.2` present: our first destructive syscall is the
-    // oldest-generation unlink, and the peer lands on it. By the time we
-    // reach the shift loop, `.1` is the peer's brand-new snapshot.
+  it("does not shift the peer's fresh .1 off the end — but the unlink gap destroys its shifted history", () => {
+    // The peer lands in the check→`unlinkSync` gap, our FIRST destructive
+    // syscall. Two things to pin, and the second one is why this test's
+    // fixture changed in round 6:
+    //
+    //   - the shift loop that runs after must NOT move the peer's fresh
+    //     `.1` off the end of the window (the next checkpoint stops us);
+    //   - the unlink itself already went through unserialized, and it is
+    //     NOT harmless. Until round 6 this test seeded `.2` and NO `.1`,
+    //     so the peer's own rotation had already removed `.2` by the time
+    //     our unlink ran: it failed ENOENT and the test passed on an
+    //     error path, asserting nothing about the gap. Seeding `.1` too
+    //     means the peer's shift puts real history at `.2`, and our
+    //     unguarded unlink deletes it — which is what actually happens.
     realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
     realFs.writeFileSync(`${log}.2`, "OLDEST\n");
 
     let fired = false;
+    let doomed = "";
     hooks.beforeUnlink = (p) => {
       if (p !== `${log}.2` || fired) return;
       fired = true;
       hooks.beforeUnlink = undefined;
       peerReclaimsAndRotates(2, NEW);
+      // What sits at `.2` at the instant our unlink executes. The peer's
+      // rotation shifted HISTORY there; we are about to delete it.
+      doomed = realFs.readFileSync(`${log}.2`, "utf8");
     };
 
     const rotated = maybeRotateLogFile(log, {
@@ -431,6 +474,11 @@ describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
     expect(rotated).toBe(false);
     expect(realFs.readFileSync(`${log}.1`, "utf8")).toBe(BODY); // still `.1`
     expect(realFs.readFileSync(log, "utf8")).toBe(NEW);
+    // The damage. Our unlink had a LIVE target — the peer's freshly
+    // shifted history — and removed it. `.2` is gone, not merely absent
+    // because nothing was ever there.
+    expect(doomed).toBe(HISTORY);
+    expect(realFs.existsSync(`${log}.2`)).toBe(false);
   });
 
   it("does not copy over the peer's .1", () => {
@@ -529,6 +577,134 @@ describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
     expect(realFs.existsSync(`${log}.2`)).toBe(false);
   });
 
+  it("loses EVERY byte when the reclaim lands in the copy gap and the peer is quiet", () => {
+    // Same gap as the test above, one variable changed: the peer does not
+    // append after rotating. That is the ordinary state of a low-traffic
+    // log, and it is the real worst case (#3600 round-6, H1) — the test
+    // above masks it, because the rows its peer appends are what make the
+    // unguarded `copyFileSync` copy anything at all.
+    //
+    // With a quiet peer the active file it leaves is ZERO bytes, so our
+    // one unserialized copy writes zero bytes over the peer's fresh `.1`,
+    // and the peer's own rotation already dropped the `.2` our earlier
+    // shift had put there. `.1` empty, `.2` gone, active empty: every byte
+    // of this log's history and of its live rows is gone. That is the
+    // outcome `RotateOptions.lock` calls strictly worse than the ordinary
+    // copy/truncate race window, produced WITH the lock held.
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    let fired = false;
+    hooks.beforeCopy = (from) => {
+      if (from !== log || fired) return;
+      fired = true;
+      hooks.beforeCopy = undefined;
+      peerReclaimsAndRotates(2, "");
+    };
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(fired).toBe(true);
+    expect(rotated).toBe(false); // the next checkpoint does stop us
+    expect(realFs.statSync(`${log}.1`).size).toBe(0); // zero-byte snapshot
+    expect(realFs.existsSync(`${log}.2`)).toBe(false); // prior generation gone
+    expect(realFs.statSync(log).size).toBe(0); // and nothing live to recover
+  });
+
+  it("declines the truncate when the peer rotated after our lock check (H2 gate)", () => {
+    // The peer lands in the check→`truncateSync` gap: AFTER `held()`'s
+    // stat of the lockfile, so the lock guard cannot see it. This is the
+    // one gap with no next checkpoint — the truncate is the last one — and
+    // the only gap that destroys LIVE rows rather than history depth.
+    //
+    // The data-based gate is what catches it: the active file is now
+    // SHORTER than the snapshot we just wrote to `.1`, which only happens
+    // when someone else truncated it under us. Remove that gate from
+    // `rotateLogFile` and this test fails with `rotated === true` and an
+    // empty active file — the peer's rows destroyed (#3600 round-6, H2).
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    let copied = false;
+    let fired = false;
+    hooks.beforeCopy = () => {
+      copied = true;
+    };
+    hooks.afterStat = (p) => {
+      // The first stat of the lockfile after our copy IS `held()`'s check
+      // for the truncate; firing after it lands us inside the gap.
+      if (p !== lock || !copied || fired) return;
+      fired = true;
+      hooks.afterStat = undefined;
+      peerReclaimsAndRotates(2, NEW);
+    };
+
+    const rotated = maybeRotateLogFile(log, {
+      maxBytes: CAP,
+      maxFiles: 2,
+      tag: "victim",
+      lock: true,
+    });
+
+    expect(fired).toBe(true);
+    expect(rotated).toBe(false);
+    expect(realFs.readFileSync(log, "utf8")).toBe(NEW); // rows survive
+  });
+
+  it("destroys the peer's rows when the reclaim lands in the truncate gap (residual, returns true)", () => {
+    // The residual the gate above cannot close: the gate is itself a stat
+    // followed by a separate `truncateSync`, and the peer lands between
+    // those two. Nothing catches this — there is no later checkpoint.
+    //
+    // Asserted rather than described, INCLUDING the return value: we
+    // report `rotated === true` while having destroyed rows that belong
+    // to the peer's completed cycle. `true` is deliberate — a rotation
+    // did happen, and `false` in this module means "nothing happened and
+    // the active file is exactly as it was", which would be a worse lie.
+    // The honest channel is the stderr line asserted below; both live
+    // callers discard the boolean (#3600 round-6, H2).
+    realFs.writeFileSync(log, BODY);
+    realFs.writeFileSync(`${log}.1`, HISTORY);
+
+    const errs: string[] = [];
+    const spy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: unknown) => {
+        errs.push(String(chunk));
+        return true;
+      });
+
+    let fired = false;
+    hooks.beforeTruncate = (p) => {
+      if (p !== log || fired) return;
+      fired = true;
+      hooks.beforeTruncate = undefined;
+      peerReclaimsAndRotates(2, NEW);
+    };
+
+    let rotated: boolean;
+    try {
+      rotated = maybeRotateLogFile(log, {
+        maxBytes: CAP,
+        maxFiles: 2,
+        tag: "victim",
+        lock: true,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(fired).toBe(true);
+    expect(rotated).toBe(true); // and it is not a rotation the caller can trust
+    expect(realFs.statSync(log).size).toBe(0); // the peer's rows are gone
+    expect(errs.join("")).toContain("rows another rotator wrote");
+  });
+
   it("a rotator that lost the lock touches nothing at all", () => {
     // Unit-level: the predicate is false from the first call, so every
     // generation and the active file must be byte-identical afterwards.
@@ -570,12 +746,24 @@ describe("a reclaimed holder does not clobber the reclaimer (H1)", () => {
  * The suite's files live under `os.tmpdir()` — tmpfs, which never reuses
  * — so a race test cannot see an early close, while the real logs live
  * under `~/.switchroom/**` on ext4, which always does. Re-running the
- * race suite with `TMPDIR` on ext4 does not help either (verified: still
- * 14/14) — on the shipped code the fd is never closed early, so there is
- * nothing for the reused inode number to collide with.
+ * whole race suite with `TMPDIR` on ext4 passes either way, which is
+ * exactly why this test has to assert the mechanism instead: none of the
+ * outcome tests lands a peer's reclaim in a window where an inode number
+ * has been freed, so there is nothing for a reused number to collide
+ * with even on the reusing filesystem.
+ *
+ * Round 5 wrote that list of sites and left the release unlink OFF it,
+ * and the release unlink was the one site that violated the premise —
+ * `closeSync` ran first, so the guard compared a freed number. Driven
+ * directly on ext4 (round-6 H3, peer reclaiming inside the
+ * close→stat window) that guard matched a peer's brand-new LIVE lock and
+ * deleted it. The list below therefore covers the release unlink too, and
+ * a carve-out is the thing to be suspicious of if this ever fails.
  *
  * So assert the MECHANISM, on any filesystem: the fd must still be open
- * at each destructive syscall. Close it before `fn()` and this fails.
+ * at every inode-guarded destructive syscall, the release unlink
+ * included. Close it before `fn()`, or move the close back ahead of the
+ * release guard, and this fails.
  */
 describe("inode identity's premise: the lock fd stays open (M3)", () => {
   it("holds the lock fd open through every destructive syscall", () => {
@@ -597,11 +785,19 @@ describe("inode identity's premise: the lock fd stays open (M3)", () => {
     hooks.beforeClose = (fd) => {
       if (lockFd !== -1 && fd === lockFd) lockFdClosed = true;
     };
-    // Only the four log-data mutations; the lockfile's own unlink at
-    // release is deliberately not one of them.
+    // The four log-data mutations AND the lockfile's own unlink at
+    // release. That last one is not decoration: the release guard is an
+    // inode comparison exactly like `stillHeld()`, so it needs the fd open
+    // for the same reason, and until round 6 it did not have it — the
+    // close ran first and the guard compared a number nothing was holding.
+    // On ext4 a peer's park→unlink→`open(wx)` in that window got our
+    // number back and we deleted its LIVE lock. Excluding this site from
+    // the list is what let that survive round 5 (#3600 round-6, H3), so it
+    // is included now and the ordering fix is what makes it pass.
     const isGeneration = (p: string) => /^\.\d+$/.test(p.slice(log.length));
     hooks.beforeUnlink = (p) => {
       if (isGeneration(p)) note(`unlink ${gen(p)}`);
+      else if (p === lock) note("unlink <lock>");
     };
     hooks.beforeRename = (from) => {
       if (isGeneration(from)) note(`rename ${gen(from)}`);
@@ -628,6 +824,7 @@ describe("inode identity's premise: the lock fd stays open (M3)", () => {
       "rename <log>.1 [fd open]",
       "copy <log> → <log>.1 [fd open]",
       "truncate <log> [fd open]",
+      "unlink <lock> [fd open]",
     ]);
     // And it IS closed by the end — otherwise the tags above would be
     // vacuously "fd open" and this test would prove nothing.

--- a/src/util/log-rotation-race.test.ts
+++ b/src/util/log-rotation-race.test.ts
@@ -173,6 +173,74 @@ describe("stale-lock reclaim is mutually exclusive (finding 1)", () => {
     expect(realFs.existsSync(lock)).toBe(false); // released
   });
 
+  it("sweeps park files a crashed reclaim stranded (L2)", () => {
+    // A crash between the reclaim's `rename` and its cleanup `unlink`
+    // leaves `<lock>.stale.<pid>.<rand>` behind forever — nothing else
+    // globs that name. A successful reclaim must collect the aged ones.
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    realFs.writeFileSync(lock, "");
+    const old = Date.now() / 1000 - 300;
+    realFs.utimesSync(lock, old, old);
+
+    // Two leaked parks from earlier crashes, both past the threshold.
+    const leaked = [`${lock}.stale.999.aaaaaaaa`, `${lock}.stale.998.bbbbbbbb`];
+    for (const f of leaked) {
+      realFs.writeFileSync(f, "");
+      realFs.utimesSync(f, old, old);
+    }
+    // A park younger than the threshold — a peer may be mid-reclaim with
+    // it, so it must survive; and an unrelated neighbour must too.
+    const fresh = `${lock}.stale.997.cccccccc`;
+    realFs.writeFileSync(fresh, "");
+    const neighbour = `${log}.1`;
+    realFs.writeFileSync(neighbour, HISTORY);
+
+    expect(
+      maybeRotateLogFile(log, {
+        maxBytes: CAP,
+        maxFiles: 3,
+        tag: "t",
+        lock: true,
+      }),
+    ).toBe(true);
+
+    for (const f of leaked) expect(realFs.existsSync(f)).toBe(false);
+    expect(realFs.existsSync(fresh)).toBe(true);
+    expect(realFs.existsSync(neighbour)).toBe(true);
+    // And our own park did not survive either.
+    expect(
+      realFs.readdirSync(dir).filter((f) => f.includes(".stale.")),
+    ).toEqual([path.basename(fresh)]);
+  });
+
+  it("a failing sweep never breaks the reclaim (L2)", () => {
+    realFs.writeFileSync(log, "x".repeat(CAP * 4));
+    realFs.writeFileSync(lock, "");
+    const old = Date.now() / 1000 - 300;
+    realFs.utimesSync(lock, old, old);
+
+    const leaked = `${lock}.stale.999.aaaaaaaa`;
+    realFs.writeFileSync(leaked, "");
+    realFs.utimesSync(leaked, old, old);
+
+    // The park vanishes under the sweep (a peer reaped it first): the
+    // unlink throws ENOENT and must be swallowed, not escape the reclaim.
+    hooks.beforeUnlink = (p) => {
+      if (p === leaked) realFs.rmSync(leaked, { force: true });
+    };
+
+    expect(
+      maybeRotateLogFile(log, {
+        maxBytes: CAP,
+        maxFiles: 2,
+        tag: "t",
+        lock: true,
+      }),
+    ).toBe(true);
+    expect(realFs.statSync(`${log}.1`).size).toBe(CAP * 4);
+    expect(realFs.statSync(log).size).toBe(0);
+  });
+
   it("release does not delete a lock that is no longer ours", () => {
     // We overran the stale threshold and a peer reclaimed while we were
     // inside; the identity-guarded release must not unlink the peer's

--- a/src/util/log-rotation.test.ts
+++ b/src/util/log-rotation.test.ts
@@ -1,0 +1,142 @@
+/**
+ * #3596 — the shared size-based rotation primitive.
+ *
+ * These assert OUTCOMES an unbounded log would fail: after enough bytes
+ * the active file is small, the old bytes survive in `.1`, retention
+ * caps total on-disk history, and the active inode is preserved (the
+ * bind-mount / open-fd constraint that rules out rename).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  maybeRotateLogFile,
+  rotateLogFile,
+  resolveRotationConfig,
+} from "./log-rotation.js";
+
+let dir: string;
+let log: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "logrot-"));
+  log = path.join(dir, "test.log");
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("maybeRotateLogFile", () => {
+  it("bounds an otherwise-unbounded log: repeated appends never exceed ~cap", () => {
+    const cap = 4096;
+    // Append 200 KiB in 1 KiB rows with a rotation check before each —
+    // exactly the writer-path shape. Unbounded, the file ends at 200 KiB.
+    let maxSeen = 0;
+    for (let i = 0; i < 200; i++) {
+      maybeRotateLogFile(log, { maxBytes: cap, maxFiles: 2, tag: "t" });
+      fs.appendFileSync(log, "x".repeat(1023) + "\n");
+      maxSeen = Math.max(maxSeen, fs.statSync(log).size);
+    }
+    expect(fs.statSync(log).size).toBeLessThanOrEqual(cap + 1024);
+    expect(maxSeen).toBeLessThanOrEqual(cap + 1024);
+    // And the whole directory is bounded by (maxFiles + 1) * cap-ish.
+    const total = fs
+      .readdirSync(dir)
+      .reduce((n, f) => n + fs.statSync(path.join(dir, f)).size, 0);
+    expect(total).toBeLessThan((2 + 1) * (cap + 1024));
+    expect(total).toBeLessThan(200 * 1024); // ≪ the unbounded 200 KiB
+  });
+
+  it("enforces retention: only maxFiles generations survive", () => {
+    for (let i = 0; i < 10; i++) {
+      fs.writeFileSync(log, `gen${i}\n`.padEnd(200, "."));
+      const rotated = maybeRotateLogFile(log, {
+        maxBytes: 100,
+        maxFiles: 2,
+        tag: "t",
+      });
+      expect(rotated).toBe(true);
+    }
+    expect(fs.existsSync(`${log}.1`)).toBe(true);
+    expect(fs.existsSync(`${log}.2`)).toBe(true);
+    expect(fs.existsSync(`${log}.3`)).toBe(false);
+    // Newest generation first: .1 holds gen9, .2 holds gen8.
+    expect(fs.readFileSync(`${log}.1`, "utf-8")).toContain("gen9");
+    expect(fs.readFileSync(`${log}.2`, "utf-8")).toContain("gen8");
+  });
+
+  it("does not rotate below the cap, and no-ops on a missing file", () => {
+    expect(
+      maybeRotateLogFile(log, { maxBytes: 100, maxFiles: 2, tag: "t" }),
+    ).toBe(false);
+    fs.writeFileSync(log, "small\n");
+    expect(
+      maybeRotateLogFile(log, { maxBytes: 100, maxFiles: 2, tag: "t" }),
+    ).toBe(false);
+    expect(fs.existsSync(`${log}.1`)).toBe(false);
+  });
+
+  it("a non-positive maxBytes disables rotation (operator escape hatch)", () => {
+    fs.writeFileSync(log, "x".repeat(10_000));
+    expect(
+      maybeRotateLogFile(log, { maxBytes: -1, maxFiles: 2, tag: "t" }),
+    ).toBe(false);
+    expect(fs.statSync(log).size).toBe(10_000);
+    expect(fs.existsSync(`${log}.1`)).toBe(false);
+  });
+
+  it("preserves the active inode (rename would EBUSY a single-file bind mount)", () => {
+    fs.writeFileSync(log, "x".repeat(1000));
+    const before = fs.statSync(log).ino;
+    rotateLogFile(log, 2, "t");
+    expect(fs.statSync(log).ino).toBe(before);
+    expect(fs.statSync(log).size).toBe(0);
+    expect(fs.statSync(`${log}.1`).size).toBe(1000);
+  });
+
+  it("an fd already open in O_APPEND keeps writing to the live file", () => {
+    fs.writeFileSync(log, "x".repeat(1000));
+    const fd = fs.openSync(log, "a");
+    try {
+      rotateLogFile(log, 2, "t");
+      fs.writeSync(fd, "AFTER\n");
+    } finally {
+      fs.closeSync(fd);
+    }
+    expect(fs.readFileSync(log, "utf-8")).toContain("AFTER");
+  });
+});
+
+describe("resolveRotationConfig", () => {
+  const base = {
+    envBytesVar: "X_BYTES",
+    envFilesVar: "X_FILES",
+    defaultBytes: 1000,
+    defaultFiles: 3,
+  };
+
+  it("falls back to defaults with no options and no env", () => {
+    expect(resolveRotationConfig({ ...base, env: {} })).toEqual({
+      maxBytes: 1000,
+      maxFiles: 3,
+    });
+  });
+
+  it("env overrides defaults; explicit options override env", () => {
+    const env = { X_BYTES: "500", X_FILES: "7" };
+    expect(resolveRotationConfig({ ...base, env })).toEqual({
+      maxBytes: 500,
+      maxFiles: 7,
+    });
+    expect(
+      resolveRotationConfig({ ...base, env, maxBytes: 42, maxFiles: 1 }),
+    ).toEqual({ maxBytes: 42, maxFiles: 1 });
+  });
+
+  it("a negative env value disables rotation (maxBytes < 0)", () => {
+    expect(
+      resolveRotationConfig({ ...base, env: { X_BYTES: "-1" } }).maxBytes,
+    ).toBe(-1);
+  });
+});

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -85,21 +85,26 @@ export interface RotateOptions {
    * that discards a whole generation of events; the empty-copy is
    * strictly worse than the ordinary copy/truncate race window.
    *
-   * The lock closes it twice over: only one rotator runs at a time, AND
-   * the size is re-checked while holding the lock, so the loser sees the
-   * freshly-truncated file and declines.
+   * The lock closes THAT interleaving twice over: only one rotator runs
+   * at a time, AND the size is re-checked while holding the lock, so the
+   * loser sees the freshly-truncated file and declines.
    *
-   * NOT unconditional mutual exclusion, at any writer count. A holder
-   * that overruns {@link ROTATE_LOCK_STALE_MS} is indistinguishable from
-   * a dead one, so a peer can legitimately reclaim a LIVE lock and enter
-   * `fn()` alongside it — reproduced at two writers (#3600 round-4, H1).
-   * What bounds the damage is the in-critical-section inode guard: a
-   * rotator whose lock was reclaimed aborts at the next checkpoint
-   * instead of running the rest of the rotation. It is a bound, not
-   * immunity — a reclaim landing between a checkpoint and the syscall it
-   * guards still gets that one syscall through, which is enough to lose
-   * a generation (see {@link withRotateLock}'s residual, which states
-   * the damage).
+   * It is NOT unconditional mutual exclusion, at any writer count. A
+   * holder that overruns {@link ROTATE_LOCK_STALE_MS} is indistinguishable
+   * from a dead one, so a peer can legitimately reclaim a LIVE lock and
+   * enter `fn()` alongside it — reproduced at two writers (#3600 round-4,
+   * H1). The in-critical-section inode guard bounds how much of the
+   * rotation such a rotator can still run: it aborts at the next
+   * checkpoint, so at most ONE destructive syscall proceeds unserialized.
+   *
+   * That bounds the COUNT, not the damage, and the distinction is not
+   * academic — the syscall that gets through can be the `copyFileSync`,
+   * and if the peer has not appended since rotating (a low-traffic log,
+   * most of the time) the bytes it copies over the peer's snapshot are
+   * zero. `.1` empty, prior generation gone, active file empty: the
+   * empty-copy outcome named two paragraphs up, reached WITH the lock
+   * held. See {@link withRotateLock}'s residual, which enumerates all four
+   * gaps and what each destroys (#3600 round-6, H1/H2).
    *
    * Single-writer logs (vault audit, hostd audit — both serialized
    * in-process, see `audit-hashchain.ts` single-writer-process contract)
@@ -147,11 +152,22 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * cannot delete the new holder's lock on the way out.
  *
  * That guard and `stillHeld()` both rest on a PREMISE the type system
- * cannot state: the lock `fd` stays open from the `open(wx)` that took it
- * until the `finally` below. An open fd pins the inode, which is the only
- * reason "same inode number" means "same lock" — see the comment at the
- * `ourIno` capture for the measurement and for the test that fails if a
- * refactor closes it early.
+ * cannot state: the lock `fd` is still open when the inode comparison
+ * happens. An open fd pins the inode, which is the only reason "same
+ * inode number" means "same lock" — see the comment at the `ourIno`
+ * capture for the measurement and for the test that fails if a refactor
+ * closes it early.
+ *
+ * For `stillHeld()` the premise holds by position — every call is inside
+ * `fn()`. For the RELEASE guard it holds only because the `finally` below
+ * unlinks BEFORE it closes, and until round 6 it did not: the close came
+ * first, and the guard then compared a number nothing was holding.
+ * Reproduced on ext4 (#3600 round-6, H3) — a peer's park→unlink→`open(wx)`
+ * landing in that window was handed our inode number, our guard matched,
+ * and we deleted the peer's LIVE lock, leaving the log unlocked in exactly
+ * the scenario the lock exists for. That is why the ordering in the
+ * `finally` is annotated rather than left to look arbitrary, and why the
+ * release unlink is one of the sites the round-5 mechanism test now tags.
  *
  * ── Residual, stated honestly ────────────────────────────────────────
  * The breach is at the STALENESS TEST. Step 2 can prove the parked file
@@ -172,57 +188,92 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *
  * The close is therefore NOT to prevent the double entry — POSIX has no
  * identity-checked reclaim and Node exposes no `flock`/`fcntl` lease —
- * but to make the loser CHEAP rather than catastrophic. `fn` receives a
+ * but to make the loser cheaper in the COMMON case. `fn` receives a
  * `stillHeld()` predicate that re-asserts the same inode identity the
  * release guard uses, and {@link rotateLogFile} calls it immediately
- * before every destructive syscall (four call sites; the shift one fires
- * once per loop iteration). An overrun rotator that lost its lock stops
- * at the next checkpoint instead of running the rotation to completion,
- * so it cannot produce the zero-byte `.1` above.
+ * before every destructive syscall (four `held()` sites; the shift one
+ * fires once per loop iteration), plus a data-based gate on the truncate
+ * and one further `stillHeld()` read AFTER the truncate that guards
+ * nothing and only decides whether to log that we destroyed the peer's
+ * rows. An overrun rotator that lost its lock stops at the next
+ * checkpoint instead of running the rotation to completion.
  *
- * What that does NOT buy is an untouched filesystem. Precisely what
- * survives depends on where the reclaim lands, and the tests say so:
- * when it lands before our first destructive syscall we touch nothing
- * (`log-rotation-race.test.ts`, "declines outright when the peer rotated
- * before we touched anything" — `.1` the peer's snapshot, `.2` the
- * shifted history, active untouched). When it lands in a check→syscall
- * gap, that one syscall goes through first and a generation is gone —
- * the same file asserts exactly that in "does not copy over the peer's
- * .1": `existsSync(<log>.1) === false` and `.2` holding the peer's
- * snapshot, i.e. our unserialized shift `rename` moved the reclaimer's
- * fresh `.1` onto `.2` and destroyed the shifted history that was there.
- * Preserved in every interleaving are the rows written after the
- * reclaimer's rotation — the truncate is the last checkpoint and it is
- * never reached. Its snapshot survives every gap but the copy one; a
- * generation of depth does not.
+ * ── What that does and does NOT buy ──────────────────────────────────
+ * It buys ONE thing, stated exactly: at most one destructive syscall
+ * proceeds unserialized, instead of the whole rotation. It does not
+ * bound the DAMAGE of that one syscall, and specifically it does not
+ * bound it to "one generation" — the copy gap below loses everything.
+ * Rounds 3-6 of the #3600 review each caught a sentence here claiming
+ * otherwise; every claim in this block is pinned by a named test in
+ * `log-rotation-race.test.ts`, and the tests, not the prose, are the
+ * record.
  *
- * What still remains, precisely — this is a narrowing, not a proof of
- * safety:
+ * When the reclaim lands BEFORE our first destructive syscall we touch
+ * nothing ("declines outright when the peer rotated before we touched
+ * anything" — `.1` the peer's snapshot, `.2` the shifted history, active
+ * untouched). A landing anywhere else is caught by the NEXT checkpoint
+ * and costs nothing either — except in the FOUR check→syscall gaps, one
+ * per destructive syscall, where that syscall is already committed. Those
+ * four are not equivalent; each destroys something different:
  *
- *   - `stillHeld()` is a `stat` and the destructive call after it is a
- *     separate syscall. A reclaim landing in that instruction-scale gap
- *     is not caught for the syscall it guards — the NEXT checkpoint does
- *     catch it, so at most ONE syscall proceeds unserialized, but one is
- *     enough to destroy a full generation. Both gaps are reproduced in
- *     `log-rotation-race.test.ts` at `maxFiles=2` (#3600 round-5, M2):
- *       · check→`copyFileSync` ("loses a generation when the reclaim
- *         lands in the copy gap"): `.1` becomes a byte-copy of the LIVE
- *         file and `.2` is absent — the reclaimer's snapshot and the
- *         prior generation are both gone. That is the outcome
- *         {@link RotateOptions.lock} calls strictly worse than the
- *         unlocked window.
- *       · check→shift-`rename` ("does not copy over the peer's .1"):
- *         `.1` absent, `.2` the reclaimer's snapshot — one generation
- *         irrecoverably lost.
- *     So the window shrinks from "the whole rotation" to "between two
- *     adjacent syscalls" and the worst case shrinks from "all history"
- *     to "one generation"; neither is zero. Reaching it needs a rotation
- *     that overruns {@link ROTATE_LOCK_STALE_MS} AND a peer completing a
- *     full reclaim-and-rotate inside a sub-microsecond inter-syscall
- *     gap, which is why this is documented rather than closed.
- *   - If `fstat` on our own lock fd failed, `ourIno` is null and
- *     `stillHeld()` returns true — we cannot verify, and refusing to
- *     ever rotate is the worse failure.
+ *   1. check→`unlinkSync(<log>.<keep>)` — the oldest-generation drop.
+ *      The peer's rotation has just shifted real history into that slot;
+ *      our unlink deletes it. `.1` the peer's snapshot, `.2` GONE.
+ *      ("does not shift the peer's fresh .1 off the end — but the unlink
+ *      gap destroys its shifted history". Before round 6 the in-tree
+ *      test seeded no `.1`, so the peer's own rotation had already
+ *      removed `.2` and our unlink merely failed ENOENT — it passed on
+ *      an error path and asserted nothing about this gap.)
+ *   2. check→shift-`rename` — our rename moves the peer's fresh `.1`
+ *      onto `.2`, over the history that was there. `.1` absent, `.2` the
+ *      peer's snapshot. ("does not copy over the peer's .1")
+ *   3. check→`copyFileSync` — the worst of the four, and its severity
+ *      depends on the peer, not on us:
+ *        · peer appended after rotating → `.1` becomes a byte-copy of
+ *          the live file, `.2` absent: the peer's snapshot and the prior
+ *          generation are both gone, the live rows survive. ("loses a
+ *          generation when the reclaim lands in the copy gap")
+ *        · peer QUIET after rotating — the ordinary state of a
+ *          low-traffic log — the file we copy is the peer's
+ *          freshly-truncated ZERO bytes. `.1` empty, `.2` gone, active
+ *          empty: EVERY byte, history and live rows alike, is lost.
+ *          ("loses EVERY byte when the reclaim lands in the copy gap and
+ *          the peer is quiet", #3600 round-6, H1.) This is verbatim the
+ *          outcome {@link RotateOptions.lock} calls strictly worse than
+ *          the ordinary copy/truncate race window, reached WITH the lock
+ *          held. The worst case does not shrink from "all history" to
+ *          "one generation": it is still total loss. What shrinks is how
+ *          much has to go wrong to reach it, not what it costs.
+ *   4. check→`truncateSync` — the only gap that destroys LIVE rows
+ *      rather than history depth, and the only one with no next
+ *      checkpoint behind it, because the truncate IS the last one. The
+ *      peer rotates and appends; we truncate its rows away and return
+ *      `true`, telling the caller the rotation succeeded. This is the
+ *      one gap that got a code change rather than a paragraph (#3600
+ *      round-6, H2): {@link rotateLogFile} now re-stats the active file
+ *      immediately before the truncate and declines if it SHRANK below
+ *      the snapshot we just wrote ("declines the truncate when the peer
+ *      rotated after our lock check"). Two things it does not do, both
+ *      deliberate. It does not catch a landing between its own stat and
+ *      the `truncateSync` — that check is itself a stat followed by a
+ *      separate syscall, so the gap moves, it does not close; the
+ *      surviving window is asserted, return value and all, in "destroys
+ *      the peer's rows when the reclaim lands in the truncate gap". And
+ *      it is a LENGTH test, so a peer that rotates and then re-appends
+ *      more bytes than we snapshotted is invisible to it. What it does
+ *      cover is the ordinary shape of the landing: a peer that rotated
+ *      leaves the active file shorter than our snapshot.
+ *
+ * So: the window shrinks from "the whole rotation" to "between two
+ * adjacent syscalls", and reaching it needs a rotation that overruns
+ * {@link ROTATE_LOCK_STALE_MS} AND a peer completing a full
+ * reclaim-and-rotate inside a sub-microsecond inter-syscall gap. That is
+ * why this is documented rather than closed. It is a narrowing of
+ * PROBABILITY, not of consequence.
+ *
+ * One more residual, unrelated to the gaps: if `fstat` on our own lock fd
+ * failed, `ourIno` is null and `stillHeld()` returns true — we cannot
+ * verify, and refusing to ever rotate is the worse failure.
  *
  * Refreshing the mtime from inside `fn()` was considered as a complement
  * and NOT taken. It cannot be periodic: rotation is entirely synchronous
@@ -365,17 +416,31 @@ function withRotateLock<T>(
   try {
     return fn(stillHeld);
   } finally {
-    try {
-      fs.closeSync(fd);
-    } catch {
-      /* best-effort */
-    }
+    // ORDER IS LOAD-BEARING: unlink under the guard FIRST, close after
+    // (#3600 round-6, H3). The guard's whole content is "the inode number
+    // at `lockPath` is still ours", and that only means "still our lock"
+    // while `fd` pins the inode. Closing first frees it, and a peer's
+    // reclaim — park (`rename`), unlink, `open(wx)` — is exactly the
+    // sequence that gets the number handed straight back on a reusing
+    // filesystem. Reproduced on ext4 with the close first: the peer's
+    // brand-new LIVE lock carried our inode number, the guard matched,
+    // and we unlinked it, leaving the log with no lock at all — the
+    // failure this guard exists to prevent. Same reproduction with the
+    // close last: different inode, guard declines, peer's lock intact.
+    // `log-rotation-race.test.ts`, "holds the lock fd open through every
+    // destructive syscall", pins the ordering on any filesystem by
+    // tagging the release unlink itself with the fd's open/closed state.
     try {
       if (ourIno !== null && fs.statSync(lockPath).ino === ourIno) {
         fs.unlinkSync(lockPath);
       }
     } catch {
       /* gone already, or someone else's — either way not ours to remove */
+    }
+    try {
+      fs.closeSync(fd);
+    } catch {
+      /* best-effort */
     }
   }
 }
@@ -429,32 +494,45 @@ function sweepStaleParks(lockPath: string): void {
  * `<path>` in place.
  *
  * Best-effort: returns `false` (and writes a diagnostic to stderr) if the
- * rotation could not complete, in which case the active file is left
- * exactly as it was. Never throws.
+ * rotation could not complete. `false` says the ACTIVE file is exactly as
+ * we found it — that holds on every return path here, and it is the whole
+ * of what it says. It does NOT say the generations are untouched: a
+ * mid-rotation decline can already have dropped `<path>.<maxFiles>` or
+ * shifted a generation. Never throws.
+ *
+ * The converse is worth stating too, because one interleaving makes it
+ * bite: `true` says we snapshotted and truncated, NOT that the result is
+ * coherent. If a peer reclaimed the lock in the gap between the pre-truncate
+ * size check and the `truncateSync`, we return `true` having destroyed the
+ * peer's rows. There is no return value that describes that honestly —
+ * `false` would assert the active file is untouched, which is worse — so
+ * the case is reported on stderr instead ("rows another rotator wrote …
+ * are LOST") and asserted in `log-rotation-race.test.ts`, "destroys the
+ * peer's rows when the reclaim lands in the truncate gap" (#3600 round-6,
+ * H2). Neither live caller (`src/host-control/server.ts`,
+ * `src/web/webhook-handler.ts`) reads the boolean.
  *
  * `stillHeld`, when supplied by {@link withRotateLock}, is re-asserted
  * immediately before EVERY destructive syscall — the oldest-generation
  * unlink, each shift rename, the `copyFileSync` that overwrites `.1`, and
- * the `truncate` that destroys live rows (#3600 round-4, H1). A holder
- * that overran the stale threshold can have its live lock legitimately
- * reclaimed by a peer; if that happened we are no longer serialized
- * against that peer, and continuing would rename its fresh `.1` off the
- * end of the window, copy a truncated active file over it, and truncate
- * rows written after its rotation. Declining costs one rotation cycle;
- * continuing costs a generation of events.
+ * the `truncate` that destroys live rows (#3600 round-4, H1) — and the
+ * truncate carries a second, data-based gate on top (round-6, H2). A
+ * holder that overran the stale threshold can have its live lock
+ * legitimately reclaimed by a peer; if that happened we are no longer
+ * serialized against that peer, and continuing would rename its fresh
+ * `.1` off the end of the window, copy a truncated active file over it,
+ * and truncate rows written after its rotation.
  *
  * Per-syscall rather than once at the top because a reclaim can land at
  * any point inside the rotation, and each check is one `stat` against a
  * handful of syscalls. It is a narrowing, not a proof — a reclaim landing
- * between a check and the syscall it guards is still uncaught, and while
- * the next check catches it, so that at most ONE syscall proceeds
- * unserialized, that one syscall is enough to destroy a full generation:
- * an unserialized shift `rename` moves the reclaimer's fresh `.1` onto
- * `.2` (history gone, asserted in `log-rotation-race.test.ts`, "does not
- * copy over the peer's .1"), and an unserialized `copyFileSync` overwrites
- * `.1` with a copy of the live file (reclaimer's snapshot AND the prior
- * generation gone). "At most one syscall" bounds the count, not the cost.
- * See {@link withRotateLock}'s residual for both reproductions.
+ * between a check and the syscall it guards is uncaught for that syscall,
+ * so at most ONE proceeds unserialized. "At most one syscall" bounds the
+ * COUNT and nothing else: depending on which of the four gaps it lands
+ * in, that one syscall costs a generation of history, the peer's live
+ * rows, or — the copy gap with a quiet peer — every byte the log has.
+ * {@link withRotateLock} enumerates all four with the test that asserts
+ * each.
  */
 export function rotateLogFile(
   logPath: string,
@@ -511,10 +589,12 @@ export function rotateLogFile(
     return false;
   }
   // Durably persist the snapshot before destroying the source.
+  let snapshotBytes = -1;
   try {
     const fd = fs.openSync(snapshotPath, "r");
     try {
       fs.fsyncSync(fd);
+      snapshotBytes = fs.fstatSync(fd).size;
     } finally {
       fs.closeSync(fd);
     }
@@ -541,6 +621,51 @@ export function rotateLogFile(
   // never ours to destroy. Leaving the active file intact is this
   // module's standing preference over losing rows.
   if (!held(`truncate ${logPath}`)) return false;
+  // A SECOND, DATA-BASED checkpoint on the one irreversible step (#3600
+  // round-6, H2). It narrows the truncate gap; it does not close it —
+  // nothing here can, and the tests pin both halves of that.
+  //
+  // Why a second one at all: the truncate gap is the only gap with no
+  // NEXT checkpoint to catch what slipped through, because this is the
+  // last one, and it is the only gap that destroys LIVE rows rather than
+  // history depth. A peer that reclaims after `held()`'s stat, rotates,
+  // and appends leaves us truncating rows that belong entirely to its
+  // completed cycle (reproduced, #3600 round-6).
+  //
+  // What it tests is the DATA, not the lock: a truncate is only correct
+  // if the active file still begins with the bytes now sitting in `.1`,
+  // and the one observable that changes when someone else rotates under
+  // us is that the active file got SHORTER than that snapshot. Appends
+  // only grow it, so this cannot false-positive on the ordinary
+  // copy-then-truncate window (rows appended between our copy and our
+  // truncate are lost either way — the technique's baseline race,
+  // documented at the top of this file, and NOT what this guards).
+  //
+  // Residual, precisely — two ways past it, and both are real:
+  //   · this check is itself a `stat` followed by a separate
+  //     `truncateSync`, so a reclaim landing in THAT gap is caught by
+  //     nothing. The window shrinks from [`held()` stat → truncate] to
+  //     [this stat → truncate]; it does not vanish. Asserted, with the
+  //     honest outcome including the `true` return, in
+  //     `log-rotation-race.test.ts`, "destroys the peer's rows when the
+  //     reclaim lands in the truncate gap".
+  //   · a peer that rotates AND re-appends more than `snapshotBytes`
+  //     before we stat is invisible to a length test.
+  let liveBytes: number;
+  try {
+    liveBytes = fs.statSync(logPath).size;
+  } catch (err) {
+    process.stderr.write(
+      `[${tag}] ERROR: could not re-stat active log ${logPath} before truncating; leaving it intact to avoid data loss: ${(err as Error).message}\n`,
+    );
+    return false;
+  }
+  if (snapshotBytes >= 0 && liveBytes < snapshotBytes) {
+    process.stderr.write(
+      `[${tag}] WARN: active log ${logPath} shrank from ${snapshotBytes} to ${liveBytes} bytes after we snapshotted it; another rotator truncated it and these rows are its, not ours — declining to truncate\n`,
+    );
+    return false;
+  }
   try {
     fs.truncateSync(logPath, 0);
   } catch (err) {
@@ -548,6 +673,24 @@ export function rotateLogFile(
       `[${tag}] ERROR: could not truncate active log ${logPath}: ${(err as Error).message}\n`,
     );
     return false;
+  }
+  // The truncate succeeded. If the lock is no longer ours, the reclaim
+  // landed in the one gap nothing above can cover — and we have just
+  // destroyed rows written after the reclaimer's own rotation. There is
+  // no undo, so the only thing left is to SAY SO (#3600 round-6, H2).
+  //
+  // The return value deliberately stays `true`: this function's `false`
+  // means "the rotation did not happen and the active file is exactly as
+  // it was" (every other decline path, and the tests on them, depend on
+  // that reading), and neither half is true here — we did snapshot and we
+  // did truncate. Returning `false` would trade one wrong answer for a
+  // worse one. Both live callers discard the value
+  // (`src/host-control/server.ts`, `src/web/webhook-handler.ts`), so this
+  // stderr line, not the boolean, is the operator-visible channel.
+  if (stillHeld && !stillHeld()) {
+    process.stderr.write(
+      `[${tag}] ERROR: truncated ${logPath} after our rotation lock was reclaimed; rows another rotator wrote between our size check and our truncate are LOST\n`,
+    );
   }
   return true;
 }

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -122,8 +122,9 @@ export interface RotateOptions {
    * empty, i.e. the empty-copy outcome named two paragraphs up reached
    * WITH the lock held — from every landing up to each gate's own stat.
    * What it does not remove is that gate's own stat→syscall gap. See
-   * {@link withRotateLock}'s residual, which enumerates all four gaps and
-   * what each still destroys (#3600 round-6 H1/H2, round-7 H1).
+   * {@link withRotateLock}'s residual, which enumerates all five gaps —
+   * these four plus the release's own — and what each still destroys
+   * (#3600 round-6 H1/H2, round-7 H1, round-10 F3).
    *
    * Single-writer logs (vault audit, hostd audit — both serialized
    * in-process, see `audit-hashchain.ts` single-writer-process contract)
@@ -251,8 +252,18 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * park its brand-new live lock. Then the absence window is real and the
  * cost above is real — but reaching it now requires the peer to have
  * judged us stale and to land inside a single syscall, not merely to have
- * reclaimed us at some point. The lock survives it (step 3), the peer
- * declines at its next checkpoint, and nothing is deleted.
+ * reclaimed us at some point. The peer's lock INODE survives it (step 3)
+ * and nothing of the peer's is ever unlinked — but be exact about what
+ * "survives" means, because it is not always at `lockPath`: where `link`
+ * works the file is restored there, and where it cannot (a filesystem
+ * without hardlinks, or a third arrival already holding the path) the
+ * inode survives only as the named park, `lockPath` is left ABSENT, and a
+ * later arrival can take the lock. Both halves are asserted — "release
+ * leaves the peer's lock alone even where the restore would fail" and "a
+ * restore that fails does not destroy the peer's lock inode", which
+ * asserts `existsSync(lockPath) === false` outright. Either way the peer
+ * declines at its next checkpoint. This is gap 5 of the five enumerated
+ * further down.
  *
  * The other new residual is a MISSED release: if a peer's release parked
  * our live lock and is mid-restore when our step 0 stats, we read ENOENT,
@@ -260,6 +271,22 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * restored with nobody holding it, and rotations skip until it ages past
  * {@link ROTATE_LOCK_STALE_MS} and is reclaimed. Bounded, non-destructive,
  * and it trades a delayed rotation for the destroyed generation above.
+ * That ENOENT arm is what bounds it, so it is pinned rather than asserted
+ * in prose: "release touches nothing when its opening stat cannot see our
+ * lock" (#3600 round-10, F1).
+ *
+ * Two things about that bound, since "30 seconds" is the wrong answer in
+ * both directions. The AGING part is ≤ {@link ROTATE_LOCK_STALE_MS}, not
+ * that value flat: the lockfile's mtime is stamped once, by the `open(wx)`
+ * that created it, and nothing in this file ever refreshes it (mtime
+ * refresh was considered and declined — see the end of this block), so an
+ * orphaned lock is already as old as the rotation that abandoned it at the
+ * instant it is abandoned, and has that much less to age. The RECLAIM part
+ * is unbounded above: nothing sweeps on a schedule, so the wedge does not
+ * end when the lock reads stale, it ends at the next over-cap write
+ * attempt after that. Honest statement: up to 30s of aging, plus however
+ * long until the next attempt. No rows are lost either way — the log keeps
+ * being written, it simply is not rotated.
  *
  * Teaching `stillHeld()` to tolerate the absence — ENOENT plus
  * `fstat(fd).nlink > 0` means our inode still has SOME name, i.e. we are
@@ -276,9 +303,12 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * H2), "release leaves the peer's lock alone even where the restore would
  * fail" and "a restore that fails does not destroy the peer's lock inode"
  * (#3600 round-8, M1) — plus its reclaim-side twin, "a RECLAIM whose
- * restore fails does not destroy the peer's lock inode". Those names are
- * checked mechanically, not by eye: "every test name this file cites
- * exists" fails if a citation here names no test (#3600 round-8, L2).
+ * restore fails does not destroy the peer's lock inode", and step 0's own
+ * ENOENT arm, "release touches nothing when its opening stat cannot see our
+ * lock" (#3600 round-10, F1). Those names are checked mechanically, not by
+ * eye: "every test name this file cites exists" fails if a citation here
+ * names no test (#3600 round-8, L2) — and, since round 10, if a citation is
+ * quietly moved into that check's own allowlist (F2).
  *
  * Note precisely what step 0 is and is not. It is NOT a `stillHeld()`-style
  * re-check that the release then trusts: a stat saying "ours" is exactly
@@ -357,24 +387,33 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * They do not bound the DAMAGE of the syscall that gets through, and
  * specifically they do not bound it to "one generation". Rounds 3-7 of the
  * #3600 review each caught a sentence here claiming more than the code
- * does; every claim in this block is pinned by a named test in
- * `log-rotation-race.test.ts`, and the tests, not the prose, are the
- * record.
+ * does.
+ *
+ * The obvious defence — "every claim in this block is pinned by a named
+ * test, and the tests, not the prose, are the record" — stood here until
+ * round 10 and was itself one of those sentences (#3600 round-10, F5).
+ * Mutation testing falsified it: the release filter's ENOENT arm had no
+ * test at all, and the citation checker that is supposed to keep these
+ * names honest had two holes of its own. What is true, and is all that is
+ * claimed now: every OUTCOME this block describes as prevented, and every
+ * residual it describes as reachable, is asserted by a named test in
+ * `log-rotation-race.test.ts`, and those names are checked mechanically by
+ * "every test name this file cites exists". Where something is NOT pinned
+ * this file now says so where it is written. There are three: the release's
+ * `vanished` branch (inert — no outcome to assert), the acquire
+ * park-verify's inode clause (defence in depth the age clause plausibly
+ * subsumes), and the DURATION bound on the missed release, which is an
+ * argument from the code — the lock's mtime is stamped once and never
+ * refreshed — rather than a test.
  *
  * When the reclaim lands BEFORE our first destructive syscall we touch
  * nothing ("declines outright when the peer rotated before we touched
  * anything" — `.1` the peer's snapshot, `.2` the shifted history, active
  * untouched). A landing anywhere else is caught by the NEXT checkpoint
- * and costs nothing either — except in the FOUR check→syscall gaps, one
- * per destructive syscall in {@link rotateLogFile}, where that syscall is
- * already committed. (The lockfile's own release unlink was a FIFTH site
- * of the same shape and is NOT in this list because it no longer has the
- * shape: the unlink now names a park nobody else can reach, and identity
- * is decided by the atomic `rename` that produced that name, not by a
- * stat of `lockPath`. Release does open with a stat, but a mismatch there
- * only ever STOPS us — no destructive syscall runs on its say-so — so it
- * is not a check→syscall gap. #3600 round-7 H2, round-8 H2, above.) Those
- * four are not equivalent; each destroys something different:
+ * and costs nothing either — except in the FIVE check→syscall gaps, where
+ * that syscall is already committed: one per destructive syscall in
+ * {@link rotateLogFile}, and one in the release below. They are not
+ * equivalent; each destroys something different:
  *
  *   1. check→`unlinkSync(<log>.<keep>)` — the oldest-generation drop.
  *      The peer's rotation has just shifted real history into that slot;
@@ -397,7 +436,8 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *      same way and for the same reason, once per loop iteration
  *      ("declines the shift when the peer rotated after our lock
  *      check"); residual likewise the gate's own stat→`rename` window.
- *   3. check→`copyFileSync` — the gap that WAS the worst of the four, and
+ *   3. check→`copyFileSync` — the gap that WAS the worst of the log's
+ *      four, and
  *      the one round 7 closed for every landing up to the gate's own stat
  *      (#3600 round-7, H1). The copy now carries a data-based gate
  *      symmetric to the truncate's: {@link rotateLogFile} measures the
@@ -461,6 +501,33 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *      sentence is. What the gate does cover is the ordinary shape of the
  *      landing: a peer that rotated leaves the active file shorter than
  *      our snapshot.
+ *   5. check→`renameSync(lockPath, <park>)` in the RELEASE below — the
+ *      only one of the five that destroys nothing in the LOG and instead
+ *      costs a peer its lock. It is here because for two rounds this list
+ *      said the release no longer had the shape, which was wrong (#3600
+ *      round-10, F3). What round 7 removed was the release's
+ *      stat→`unlink(lockPath)` pair: the unlink now names a park nobody
+ *      else can reach, and identity is decided by the atomic `rename` that
+ *      produced that name. What round 8 then ADDED, in front of it, is
+ *      step 0's `stat(lockPath)` — and on a MATCH the very next syscall is
+ *      that `rename`. A peer that reclaims in between has its brand-new
+ *      LIVE lock parked on the strength of our stat, which is the shape
+ *      exactly. Cost when it lands: `lockPath` goes absent for at least the
+ *      rename→`link` window, which is enough for the peer's next
+ *      `stillHeld()` to read ENOENT and abandon a rotation that may already
+ *      have dropped its oldest generation; and where `link` CANNOT restore
+ *      it, `lockPath` stays absent and the peer's lock inode survives only
+ *      as a park for the sweep. Asserted end to end, `existsSync(lockPath)
+ *      === false` and all, in "a restore that fails does not destroy the
+ *      peer's lock inode". Nothing of the peer's is ever unlinked.
+ *
+ *      What step 0 buys is the MISMATCH direction, which is final,
+ *      unfalsifiable while `fd` is open, and opens no window at all; what
+ *      it costs is this gap plus the missed release in the release
+ *      residual. It narrows the release's exposure from every mismatched
+ *      release to a reclaim landing inside one syscall; it does not change
+ *      its shape. Its ENOENT arm is pinned by "release touches nothing when
+ *      its opening stat cannot see our lock".
  *
  * So: the window shrinks from "the whole rotation" to "between two
  * adjacent syscalls", and reaching it needs a rotation that overruns
@@ -545,12 +612,22 @@ function withRotateLock<T>(
     let vanished = false;
     try {
       const p = fs.statSync(parked);
+      // The AGE clause is what the tests bite on; the inode clause is
+      // defence in depth and is NOT independently pinned — dropping
+      // `p.ino === observed.ino` survives the scoped suites, plausibly
+      // because a lock that arrived after our staleness stat is by
+      // construction fresh and so fails the age clause anyway (#3600
+      // round-10, recorded). Kept because "plausibly" is not "provably":
+      // the age clause rests on a clock, the inode clause does not.
       mine =
         p.ino === observed.ino &&
         Date.now() - p.mtimeMs >= ROTATE_LOCK_STALE_MS;
     } catch {
       vanished = true; // a peer's sweep reaped our park — nothing to put back
     }
+    // Unlike the release's `vanished` (which is inert), this one IS an
+    // outcome: it returns null instead of falling into the mismatch
+    // restore, i.e. we decline without taking the lock.
     if (vanished) return null;
     if (!mine) {
       // We parked a LIVE lock (a peer reclaimed between our stat and our
@@ -653,8 +730,26 @@ function withRotateLock<T>(
       // nlink > 0` ⇒ "parked, not deleted") returns true for a holder a
       // stale reclaim is about to displace legitimately, which would let a
       // destructive syscall through in exactly the H1 interleaving these
-      // checkpoints exist to stop. A spurious decline costs a rotation
-      // cycle; a spurious proceed costs a generation.
+      // checkpoints exist to stop.
+      //
+      // Be exact about the price of that choice, because the obvious
+      // sentence for it — "a spurious decline costs a rotation cycle" — is
+      // true only at the FIRST checkpoint and can be false at every one
+      // after it (#3600 round-10, F4). A decline costs whatever
+      // {@link rotateLogFile} has already done, and by control flow that
+      // grows along the rotation: at the first checkpoint it really is just
+      // the cycle, but a decline at the truncate checkpoint lands after the
+      // oldest-generation unlink, the shifts and the copy, so it costs the
+      // oldest generation and leaves the window shifted — exactly what that
+      // function's `false` contract spells out ("a mid-rotation decline can
+      // already have dropped `<path>.<maxFiles>` or shifted a generation").
+      //
+      // The trade still runs this way, on the OTHER side of the ledger, not
+      // this one: a spurious decline never destroys rows in the ACTIVE file
+      // and never overwrites a peer's snapshot, while a spurious proceed
+      // does both — up to the quiet-peer copy where every byte the log has
+      // is lost. Bounded damage to the generations beats unbounded damage
+      // to the live rows; it is not "a cycle versus a generation".
       return false;
     }
   };
@@ -683,9 +778,18 @@ function withRotateLock<T>(
     // observable failure H3 was fixed for. Ordering could not close it;
     // only deciding identity about a file NOBODY ELSE CAN NAME does.
     // `rename` gives us that atomically, so we take the file first and
-    // judge it second, exactly as the stale reclaim above does. (The stat
-    // in step 0 below does not walk that back: nothing destructive runs on
-    // a match there — a match only means we go on to park and judge.)
+    // judge it second, exactly as the stale reclaim above does.
+    //
+    // What step 0 below does and does not walk back, exactly (#3600
+    // round-10, F3): it does not restore the old stat→`unlink` shape — no
+    // unlink is ever taken on its verdict — but it is NOT true that
+    // "nothing destructive runs on a match". A match runs
+    // `renameSync(lockPath, parked)` one syscall later, and if a peer
+    // reclaimed in that syscall the file that gets parked is the peer's
+    // LIVE lock. That is gap 5 in the doc block's list, its cost is stated
+    // there, and it is asserted in "a restore that fails does not destroy
+    // the peer's lock inode". Step 0 is load-bearing on the MISMATCH side
+    // only.
     if (ourIno !== null) {
       // STEP 0 — a stat that can only rule the release OUT (#3600 round-8,
       // H2). A stat cannot prove the lock is still ours (that is the whole
@@ -704,7 +808,13 @@ function withRotateLock<T>(
       try {
         looksOurs = fs.statSync(lockPath).ino === ourIno;
       } catch {
-        /* nothing at the path — nothing of ours left to release */
+        /* Nothing of ours left to release — and this arm is load-bearing,
+           not defensive tidying: setting `looksOurs = true` here (or
+           initialising it true) makes the release go on to `rename` a path
+           that may by then hold a peer's LIVE lock. Both mutations survived
+           all 46 scoped tests until round 10; "release touches nothing when
+           its opening stat cannot see our lock" kills them (#3600 round-10,
+           F1). */
       }
       if (looksOurs) {
         const parked = `${lockPath}.stale.${process.pid}.${Math.random().toString(36).slice(2, 10)}`;
@@ -726,6 +836,24 @@ function withRotateLock<T>(
           if (vanished) {
             // Nothing to restore and nothing to unlink: the sweep that
             // reaped it performed exactly the release we came here to do.
+            //
+            // This branch is a READABILITY SPLIT, not a guard, and saying
+            // otherwise was the last unearned claim in this function (#3600
+            // round-10, F6). It has no outcome of its own: two independent
+            // mutations — collapsing it into the mismatch path below, and
+            // making it `unlink(parked)` — each survive all 47 scoped
+            // tests, and they are genuinely equivalent, because once the
+            // park is gone the mismatch path's `link` ENOENTs, `restored`
+            // stays false, and no unlink runs either way. It is therefore
+            // deliberately untested; a test written for it would assert a
+            // difference that does not exist.
+            //
+            // The load-bearing half of the round-8 M1 fix is the
+            // CONDITIONAL unlink below, and that is pinned: making it
+            // unconditional here fails "a restore that fails does not
+            // destroy the peer's lock inode", and doing the same at the
+            // acquire-side twin fails its sibling — one test each, two in
+            // total across the two sites.
           } else if (mine) {
             try {
               fs.unlinkSync(parked);
@@ -804,9 +932,11 @@ function withRotateLock<T>(
  * Reaping a LIVE release park is harmless in a second way: that park IS
  * the releasing process's own lock inode, so unlinking it is precisely the
  * release that process was about to perform. Its `statSync(parked)` then
- * throws, which it reads as "vanished" — a case distinct from a mismatch,
- * so it attempts no restore and no unlink — and both agree the lock is
- * released. (The release's OTHER park — a peer's live lock, mismatched —
+ * throws and it does nothing further — by the `vanished` label, or, if that
+ * label were removed, by the mismatch path whose `link` would ENOENT and
+ * whose unlink is conditional on a restore that cannot happen. The label is
+ * for the reader; the harmlessness comes from the code either way, and both
+ * ends agree the lock is released. (The release's OTHER park — a peer's live lock, mismatched —
  * can also be reaped here, from the branch where its restore failed and it
  * deliberately left the file. That is the leak this sweep is for.)
  *
@@ -938,8 +1068,9 @@ function fsyncAndMeasure(
  * syscall" bounds the COUNT and nothing else: depending on which of the
  * four gaps it lands in, that one syscall costs a generation of history,
  * the peer's live rows, or — the residual copy gap with a quiet peer —
- * every byte the log has. {@link withRotateLock} enumerates all four with
- * the test that asserts each.
+ * every byte the log has. {@link withRotateLock} enumerates these four,
+ * plus a fifth of the same shape in its own release, with the test that
+ * asserts each.
  */
 export function rotateLogFile(
   logPath: string,

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -252,8 +252,10 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * park its brand-new live lock. Then the absence window is real and the
  * cost above is real — but reaching it now requires the peer to have
  * judged us stale and to land inside a single syscall, not merely to have
- * reclaimed us at some point. The peer's lock INODE survives it (step 3)
- * and nothing of the peer's is ever unlinked — but be exact about what
+ * reclaimed us at some point. The peer's lock INODE survives it (step 3):
+ * the only name of the peer's we ever unlink is the park, and only once
+ * `link` has already put that inode back at `lockPath`, so no unlink of
+ * ours can cost the peer its lock — but be exact about what
  * "survives" means, because it is not always at `lockPath`: where `link`
  * works the file is restored there, and where it cannot (a filesystem
  * without hardlinks, or a third arrival already holding the path) the
@@ -399,10 +401,12 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * residual it describes as reachable, is asserted by a named test in
  * `log-rotation-race.test.ts`, and those names are checked mechanically by
  * "every test name this file cites exists". Where something is NOT pinned
- * this file now says so where it is written. There are three: the release's
- * `vanished` branch (inert — no outcome to assert), the acquire
- * park-verify's inode clause (defence in depth the age clause plausibly
- * subsumes), and the DURATION bound on the missed release, which is an
+ * this file now says so where it is written. There are four: the release's
+ * `vanished` branch (inert — no outcome to assert), the acquire reclaim's
+ * `vanished` branch (inert for the identical reason; claiming otherwise was
+ * itself a false claim — #3600 round-11, F7), the acquire park-verify's
+ * inode clause (defence in depth the age clause plausibly subsumes), and
+ * the DURATION bound on the missed release, which is an
  * argument from the code — the lock's mtime is stamped once and never
  * refreshed — rather than a test.
  *
@@ -625,9 +629,23 @@ function withRotateLock<T>(
     } catch {
       vanished = true; // a peer's sweep reaped our park — nothing to put back
     }
-    // Unlike the release's `vanished` (which is inert), this one IS an
-    // outcome: it returns null instead of falling into the mismatch
-    // restore, i.e. we decline without taking the lock.
+    // This is the SAME READABILITY SPLIT as the release's `vanished`, not a
+    // guard. Round 10 claimed the opposite here — that unlike the release's
+    // this one "IS an outcome" — and that was the mirror image of the false
+    // claim it fixed in the same commit (#3600 round-11, F7). The release's
+    // own argument applies verbatim: `mine` is still false, so falling
+    // through enters the mismatch path below; `statSync(parked)` has just
+    // ENOENTed, so `linkSync(parked, lockPath)` must ENOENT too, `restored`
+    // stays false, no unlink runs, and that path `return null`s as well.
+    // Same value, same filesystem state, one extra failing syscall.
+    // Verified by mutation: `if (false) return null;` here survives all 47
+    // scoped tests. It is therefore deliberately untested, exactly like its
+    // release-side twin.
+    //
+    // Both inertness arguments assume `vanished` means what the `catch`
+    // above calls it — ENOENT, a peer's sweep reaped our park. A stat
+    // failing for another reason (EACCES, EIO) would leave `parked` present
+    // and the `link` able to succeed, and then neither branch is inert.
     if (vanished) return null;
     if (!mine) {
       // We parked a LIVE lock (a peer reclaimed between our stat and our
@@ -846,7 +864,17 @@ function withRotateLock<T>(
             // park is gone the mismatch path's `link` ENOENTs, `restored`
             // stays false, and no unlink runs either way. It is therefore
             // deliberately untested; a test written for it would assert a
-            // difference that does not exist.
+            // difference that does not exist. The acquire reclaim's
+            // `vanished` is the same split for the same reason — round 10
+            // claimed it was an outcome and round 11 falsified that the same
+            // way (#3600 round-11, F7).
+            //
+            // This argument assumes `vanished` is the ENOENT the `catch`
+            // above names. A stat failing for another reason (EACCES, EIO)
+            // would leave `parked` present and the mismatch path's `link`
+            // able to succeed — the branch is inert under the file's stated
+            // reading, not under every possible stat failure. Same caveat,
+            // stated the same way, at the acquire twin.
             //
             // The load-bearing half of the round-8 M1 fix is the
             // CONDITIONAL unlink below, and that is pinned: making it

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -160,10 +160,13 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *      us parks as step 1 too — but what it parked is that racer's LIVE
  *      lock, which fails this check.
  *   3. on mismatch, put it back with `link(2)` (atomic create-if-absent, so
- *      it cannot clobber a lock taken meanwhile) and decline. Only on a
- *      match do we unlink the stale file and take the lock normally, which
- *      can still lose EEXIST to a fresh arrival — correct, that arrival
- *      holds it.
+ *      it cannot clobber a lock taken meanwhile) and decline — unlinking
+ *      the park only if that restore SUCCEEDED, for the reason spelled out
+ *      under the release's step 3 below (#3600 round-8, M1): a failed
+ *      restore leaves `parked` as the peer's only name for a LIVE lock.
+ *      Only on a match do we unlink the stale file and take the lock
+ *      normally, which can still lose EEXIST to a fresh arrival —
+ *      correct, that arrival holds it.
  *
  * Release is identity-guarded for the same reason, and by the SAME
  * primitive, for the same reason again: `statSync(lockPath).ino ===
@@ -176,33 +179,116 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * round-6 H3 ordering fix made the inode NUMBER meaningful, it did not
  * make stat+unlink atomic, and no ordering can.
  *
- * So release is park-verify-unlink:
+ * So release is filter-park-verify-unlink:
  *
+ *   0. `stat(lockPath).ino === ourIno`, and RETURN TOUCHING NOTHING if it
+ *      is not (#3600 round-8, H2). This stat cannot prove the lock is
+ *      ours — that is the entire reason steps 1-3 exist — but it can prove
+ *      it is NOT, and that direction has no race in it: `fd` is still open,
+ *      so our inode cannot be freed or reissued, and nothing ever puts our
+ *      inode back at `lockPath` once ANOTHER FILE is there (the only
+ *      restore in this file is `link(2)`, which fails EEXIST against it).
+ *      A different inode is therefore a final answer. ENOENT is not — our
+ *      lock may be parked mid-restore by a peer's release — and it is read
+ *      as "not ours" anyway; the cost of that reading is the MISSED
+ *      RELEASE in the residual below, and it is bounded. This is a filter,
+ *      not a guard, and it exists because the park below has a cost that
+ *      is NOT private to us — see the residual.
  *   1. `rename(lockPath -> lockPath.stale.<pid>.<rand>)` — atomic, and the
  *      park name is unique to us, so the file we are about to judge is
  *      unambiguously the one we took. This is the step that closes the
  *      gap: identity is decided about a file nobody else can name.
- *   2. compare the parked inode against `ourIno`; unlink it only on a
- *      match. A peer's lock, reclaimed at any instant before the rename,
- *      fails the comparison and is never unlinked.
+ *   2. compare the parked inode against `ourIno`. A match means the park
+ *      IS our lock and unlinking it is the release, so we unlink it and
+ *      stop. A peer's lock, reclaimed at any instant before the rename,
+ *      fails the comparison and is never unlinked as a release — step 3
+ *      restores it, and drops the park name only once the restore has put
+ *      the inode back at `lockPath`. If the stat itself fails, a peer's
+ *      sweep already reaped the park — which IS our release — and we touch
+ *      nothing further.
  *   3. on mismatch, `link(2)` it back (create-if-absent, so it cannot
- *      clobber a lock taken meanwhile) and touch nothing else.
+ *      clobber a lock taken meanwhile). The cleanup unlink then runs ONLY
+ *      if that restore SUCCEEDED, i.e. only while `parked` is a second
+ *      name for an inode that is also back at `lockPath`. The restore has
+ *      three failure modes, not one — EEXIST (a third arrival holds the
+ *      path), EPERM/ENOSYS (a filesystem without hardlinks), ENOENT (our
+ *      park reaped under us) — and after the first two `parked` is the
+ *      peer's ONLY remaining name for its LIVE lock. Unlinking there
+ *      destroys the lock of a process that believes it holds it, which is
+ *      not "conservative" and is strictly worse than the unconditional
+ *      delete this replaced; reproduced with `link` throwing EPERM (#3600
+ *      round-8, M1). So we leave the park and let `sweepStaleParks` reap
+ *      it: a named file of debris instead of a destroyed lock.
  *
- * Its residual is different in kind, and smaller: between the park
- * `rename` and the restoring `link` the lock path does not exist, so a
- * third arrival can take the lock there. The restore then fails EEXIST and
- * our cleanup unlink drops the reclaimer's inode — but that arrival really
- * does hold the lock, and the reclaimer's own `stillHeld()` reads the
- * arrival's inode and declines at its next checkpoint. Two syscalls of
- * exposure with a conservative outcome, in place of an unconditional
- * delete on every occurrence. Pinned by `log-rotation-race.test.ts`,
- * "release does not delete a peer's lock that arrived after our identity
- * check", which lands the peer in exactly the old gap.
+ *      Be exact about what that does and does not recover. It saves the
+ *      peer's INODE, not the peer's lock: `lockPath` stays absent, the
+ *      peer declines at its next checkpoint, and a later arrival may take
+ *      the lock. On a filesystem with no hardlinks there is no atomic
+ *      create-if-absent to restore with, and `rename`-ing the park back
+ *      would clobber whatever arrived meanwhile — deleting a live lock,
+ *      the one outcome every guard in this file exists to prevent — so it
+ *      is NOT done. Asserted, both halves, in "a restore that fails does
+ *      not destroy the peer's lock inode".
  *
- * Also note what park-verify does NOT need: a `stillHeld()`-style
- * re-check. The rename decides ownership, not a preceding stat.
+ * ── Release residual, stated honestly ────────────────────────────────
+ * Between the park `rename` and the restoring `link` the lock path does
+ * not exist. That absence is NOT private: `stillHeld()` reads a missing
+ * `lockPath` as "we lost the lock" (it cannot do otherwise — see below),
+ * so any legitimate holder that checkpoints inside it declines the rest of
+ * its rotation. Step 0 is what makes that window rare instead of routine.
+ * Without it, EVERY mismatched release opened one, and the damaging case
+ * needed no third party and no contention at all (#3600 round-8, H2,
+ * reproduced): A releases after its lock was reclaimed by V, parks V's
+ * LIVE lock, V's next `held()` reads ENOENT and aborts a rotation it was
+ * legitimately performing — after its oldest-generation unlink has already
+ * run. Cost: one full generation of history destroyed and zero rotation
+ * performed. That was a REGRESSION introduced with park-verify (round 7):
+ * before it, a mismatched release did nothing, so no peer's release ever
+ * made `lockPath` transiently absent.
  *
- * That guard and `stillHeld()` both rest on a PREMISE the type system
+ * What step 0 leaves is a one-syscall gap: we stat and see our own inode,
+ * a peer reclaims us as stale between that stat and our `rename`, and we
+ * park its brand-new live lock. Then the absence window is real and the
+ * cost above is real — but reaching it now requires the peer to have
+ * judged us stale and to land inside a single syscall, not merely to have
+ * reclaimed us at some point. The lock survives it (step 3), the peer
+ * declines at its next checkpoint, and nothing is deleted.
+ *
+ * The other new residual is a MISSED release: if a peer's release parked
+ * our live lock and is mid-restore when our step 0 stats, we read ENOENT,
+ * conclude "not ours" and leave without unlinking. The lockfile is then
+ * restored with nobody holding it, and rotations skip until it ages past
+ * {@link ROTATE_LOCK_STALE_MS} and is reclaimed. Bounded, non-destructive,
+ * and it trades a delayed rotation for the destroyed generation above.
+ *
+ * Teaching `stillHeld()` to tolerate the absence — ENOENT plus
+ * `fstat(fd).nlink > 0` means our inode still has SOME name, i.e. we are
+ * parked rather than deleted — was considered and NOT taken: the stale
+ * RECLAIM parks the same way and then unlinks, so that predicate returns
+ * true for a holder that is about to be legitimately displaced, and would
+ * let a destructive syscall through in exactly the H1 interleaving the
+ * checkpoints exist to stop. Trading a rare spurious decline for a rare
+ * spurious proceed is the wrong direction.
+ *
+ * Pinned by `log-rotation-race.test.ts`: "release does not delete a peer's
+ * lock that arrived after our identity check" (the step-0-to-rename gap),
+ * "a mismatched release does not park a peer's live lock" (#3600 round-8,
+ * H2), "release leaves the peer's lock alone even where the restore would
+ * fail" and "a restore that fails does not destroy the peer's lock inode"
+ * (#3600 round-8, M1) — plus its reclaim-side twin, "a RECLAIM whose
+ * restore fails does not destroy the peer's lock inode". Those names are
+ * checked mechanically, not by eye: "every test name this file cites
+ * exists" fails if a citation here names no test (#3600 round-8, L2).
+ *
+ * Note precisely what step 0 is and is not. It is NOT a `stillHeld()`-style
+ * re-check that the release then trusts: a stat saying "ours" is exactly
+ * the claim rounds 6 and 7 proved unusable, and nothing below relies on it.
+ * The rename still decides ownership. Step 0 is a one-directional filter —
+ * its only load-bearing verdict is "NOT ours", which is unfalsifiable while
+ * `fd` is open — and its only job is to keep us from parking at all in the
+ * case where we already know the answer.
+ *
+ * The release guard and `stillHeld()` both rest on a PREMISE the type system
  * cannot state: the lock `fd` is still open when the inode comparison
  * happens. An open fd pins the inode, which is the only reason "same
  * inode number" means "same lock" — see the comment at the `ourIno`
@@ -283,8 +369,11 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * per destructive syscall in {@link rotateLogFile}, where that syscall is
  * already committed. (The lockfile's own release unlink was a FIFTH site
  * of the same shape and is NOT in this list because it no longer has the
- * shape: park-verify-unlink decides identity with an atomic `rename`
- * rather than with a preceding stat — #3600 round-7, H2, above.) Those
+ * shape: the unlink now names a park nobody else can reach, and identity
+ * is decided by the atomic `rename` that produced that name, not by a
+ * stat of `lockPath`. Release does open with a stat, but a mismatch there
+ * only ever STOPS us — no destructive syscall runs on its say-so — so it
+ * is not a check→syscall gap. #3600 round-7 H2, round-8 H2, above.) Those
  * four are not equivalent; each destroys something different:
  *
  *   1. check→`unlinkSync(<log>.<keep>)` — the oldest-generation drop.
@@ -453,26 +542,41 @@ function withRotateLock<T>(
       return null; // a peer parked it first
     }
     let mine = false;
+    let vanished = false;
     try {
       const p = fs.statSync(parked);
       mine =
         p.ino === observed.ino &&
         Date.now() - p.mtimeMs >= ROTATE_LOCK_STALE_MS;
     } catch {
-      mine = false;
+      vanished = true; // a peer's sweep reaped our park — nothing to put back
     }
+    if (vanished) return null;
     if (!mine) {
       // We parked a LIVE lock (a peer reclaimed between our stat and our
-      // rename). Put it back without clobbering whatever is there now.
+      // rename). Put it back without clobbering whatever is there now —
+      // and unlink the park ONLY if that restore actually succeeded. The
+      // release below carries the identical branch for the identical
+      // reason (#3600 round-8, M1, swept here): `link` has three failure
+      // modes, not one — EEXIST, EPERM/ENOSYS (a filesystem with no
+      // hardlinks), ENOENT — and after the first two `parked` is the
+      // peer's ONLY remaining name for its LIVE lock, so unlinking it
+      // deletes a lock its holder still believes in. Leaving it is a named
+      // file `sweepStaleParks` reaps.
+      let restored = false;
       try {
         fs.linkSync(parked, lockPath);
+        restored = true;
       } catch {
-        /* a lock already exists at the path — the holder is covered */
+        /* EEXIST: a lock already exists at the path — that holder is
+           covered. EPERM/ENOSYS: no hardlinks here. ENOENT: reaped. */
       }
-      try {
-        fs.unlinkSync(parked);
-      } catch {
-        /* best-effort */
+      if (restored) {
+        try {
+          fs.unlinkSync(parked);
+        } catch {
+          /* best-effort */
+        }
       }
       return null;
     }
@@ -486,13 +590,22 @@ function withRotateLock<T>(
     } catch {
       return null; // a fresh arrival took the lock between our rename and this
     }
-    // Sweep only once the claim has SUCCEEDED (#3600 round-4, L1). Before
-    // the `open(wx)` above we hold nothing — `lockPath` does not exist —
-    // and a readdir plus N stat/unlink there would widen the rename→claim
-    // interval this comment names as the breach, from ~2 syscalls to
-    // 2 + O(parks). Here the path is locked and the sweep is free.
-    sweepStaleParks(lockPath);
   }
+  // Sweep only once the lock is HELD (#3600 round-4, L1) — but on EVERY
+  // path that holds it, not just the reclaim (#3600 round-8, L1). Before
+  // the reclaim's `open(wx)` we hold nothing — `lockPath` does not exist —
+  // and a readdir plus N stat/unlink there would widen the rename→claim
+  // interval the doc comment names as the breach, from ~2 syscalls to
+  // 2 + O(parks). Here the path is locked either way and the sweep is free.
+  //
+  // It sits AFTER the whole acquire, not inside the EEXIST branch, because
+  // the RELEASE park leaks a different shape: a crash between the release
+  // `rename` and its cleanup `unlink` leaves NOTHING at `lockPath`, so the
+  // next arrival's `open(wx)` SUCCEEDS and never enters the reclaim branch.
+  // With the sweep reachable only from that branch, a release park could
+  // survive every subsequent acquisition — an unbounded leak, which is
+  // exactly what this function exists to rule out.
+  sweepStaleParks(lockPath);
   // Identify the lock we hold, so release — and the critical section
   // itself — can prove it is still ours.
   //
@@ -532,7 +645,17 @@ function withRotateLock<T>(
     try {
       return fs.statSync(lockPath).ino === ourIno;
     } catch {
-      return false; // lock gone — we are certainly not holding it
+      // ENOENT. NOT the same as "our lock was destroyed": a park — ours,
+      // a reclaimer's, or a releaser's — makes `lockPath` absent for a
+      // syscall or two while our inode is alive and named elsewhere, so
+      // this can be a SPURIOUS loss (#3600 round-8, H2). It is reported as
+      // a loss anyway, deliberately: the alternative test (`fstat(fd).
+      // nlink > 0` ⇒ "parked, not deleted") returns true for a holder a
+      // stale reclaim is about to displace legitimately, which would let a
+      // destructive syscall through in exactly the H1 interleaving these
+      // checkpoints exist to stop. A spurious decline costs a rotation
+      // cycle; a spurious proceed costs a generation.
+      return false;
     }
   };
   try {
@@ -560,36 +683,83 @@ function withRotateLock<T>(
     // observable failure H3 was fixed for. Ordering could not close it;
     // only deciding identity about a file NOBODY ELSE CAN NAME does.
     // `rename` gives us that atomically, so we take the file first and
-    // judge it second, exactly as the stale reclaim above does.
+    // judge it second, exactly as the stale reclaim above does. (The stat
+    // in step 0 below does not walk that back: nothing destructive runs on
+    // a match there — a match only means we go on to park and judge.)
     if (ourIno !== null) {
-      const parked = `${lockPath}.stale.${process.pid}.${Math.random().toString(36).slice(2, 10)}`;
-      let took = false;
+      // STEP 0 — a stat that can only rule the release OUT (#3600 round-8,
+      // H2). A stat cannot prove the lock is still ours (that is the whole
+      // reason for the park), but it CAN prove it is not: our own `fd` is
+      // still open, so our inode cannot be freed and cannot be handed to
+      // anything else, and nothing puts our inode back at `lockPath` once
+      // something else is there. A mismatch here is therefore final, and we
+      // return having touched NOTHING — no rename, so no window in which
+      // `lockPath` is absent. That matters because the park's absence window
+      // is not private to us: a legitimate holder's `stillHeld()` reads
+      // ENOENT there and declines mid-rotation, and before this stat every
+      // mismatched release — the ordinary outcome after our lock was
+      // reclaimed, needing no third party at all — opened one under a peer
+      // that was doing nothing wrong.
+      let looksOurs = false;
       try {
-        fs.renameSync(lockPath, parked);
-        took = true;
+        looksOurs = fs.statSync(lockPath).ino === ourIno;
       } catch {
-        /* nothing at the path, or a peer parked it first — not ours */
+        /* nothing at the path — nothing of ours left to release */
       }
-      if (took) {
-        let mine = false;
+      if (looksOurs) {
+        const parked = `${lockPath}.stale.${process.pid}.${Math.random().toString(36).slice(2, 10)}`;
+        let took = false;
         try {
-          mine = fs.statSync(parked).ino === ourIno;
+          fs.renameSync(lockPath, parked);
+          took = true;
         } catch {
-          /* a peer's sweep reaped our park — it is already gone */
+          /* nothing at the path, or a peer parked it first — not ours */
         }
-        if (!mine) {
-          // We parked someone ELSE's live lock. Put it back, without
-          // clobbering whatever may have been created at the path since.
+        if (took) {
+          let mine = false;
+          let vanished = false;
           try {
-            fs.linkSync(parked, lockPath);
+            mine = fs.statSync(parked).ino === ourIno;
           } catch {
-            /* a lock already exists there — that holder is covered */
+            vanished = true; // a peer's sweep reaped our park — already gone
           }
-        }
-        try {
-          fs.unlinkSync(parked);
-        } catch {
-          /* best-effort — the park name is unique to us */
+          if (vanished) {
+            // Nothing to restore and nothing to unlink: the sweep that
+            // reaped it performed exactly the release we came here to do.
+          } else if (mine) {
+            try {
+              fs.unlinkSync(parked);
+            } catch {
+              /* best-effort — the park name is unique to us */
+            }
+          } else {
+            // We parked someone ELSE's live lock (a peer reclaimed in the
+            // one-syscall gap above). Put it back without clobbering
+            // whatever may have been created at the path since.
+            let restored = false;
+            try {
+              fs.linkSync(parked, lockPath);
+              restored = true;
+            } catch {
+              /* EEXIST: a lock already exists there — that holder is
+                 covered. EPERM/ENOSYS: no hardlinks on this filesystem.
+                 ENOENT: our park was reaped under us. */
+            }
+            if (restored) {
+              // `parked` is now a second name for the peer's inode; drop it.
+              try {
+                fs.unlinkSync(parked);
+              } catch {
+                /* best-effort — the park name is unique to us */
+              }
+            }
+            // NOT restored: `parked` is the peer's ONLY remaining name for
+            // its live lock inode, so unlinking it here would destroy the
+            // lock of a process that believes it holds it — the exact
+            // damage park-verify exists to prevent, and worse than the
+            // unconditional delete it replaced (#3600 round-8, M1). We
+            // leave the park; `sweepStaleParks` reaps it.
+          }
         }
       }
     }
@@ -608,10 +778,10 @@ function withRotateLock<T>(
  * crash-in-window, forever, in the agent's telegram dir.
  *
  * Only parks whose mtime is already past {@link ROTATE_LOCK_STALE_MS} are
- * taken. There is no "keep ours" exemption: the sole caller runs this
- * AFTER unlinking its own park and after taking the lock, so our park is
- * gone — and in the one case it is not (that unlink failed), it IS a leak
- * and reaping it is correct. A peer mid-reclaim WILL hold an eligible
+ * taken. There is no "keep ours" exemption: the caller runs this AFTER
+ * unlinking its own park and after taking the lock, so our park is gone —
+ * and in the one case it is not (that unlink failed), it IS a leak and
+ * reaping it is correct. A peer mid-reclaim WILL hold an eligible
  * park, not merely can: `rename(2)` does not touch the file's mtime (it
  * modifies the directory, not the inode), so a park always carries the
  * mtime of the ancient lock it was made from and is therefore always
@@ -622,14 +792,26 @@ function withRotateLock<T>(
  * at worst; it cannot wedge the path or produce two rotators.
  *
  * The RELEASE park (#3600 round-7, H2) carries the same name shape on
- * purpose — it leaks the same way on a crash and must be reaped the same
- * way. Reaping a live one is harmless in a second way: that park IS the
- * releasing process's own lock inode, so unlinking it is precisely the
- * release that process was about to perform. It then finds its park gone,
- * declines to unlink, and both agree the lock is released.
+ * purpose and leaks the same way on a crash — but it is NOT reached by the
+ * same acquisition path, and for one round the reaping claim here was
+ * simply false (#3600 round-8, L1). A crash between the release `rename`
+ * and its cleanup `unlink` leaves NOTHING at `lockPath`, so the next
+ * arrival's `open(wx)` SUCCEEDS and never takes the EEXIST reclaim branch
+ * this sweep used to be nested in — the park survived every subsequent
+ * acquisition, unbounded. The call site is therefore after the whole
+ * acquire, on both paths, which is what makes "reaped the same way" true.
+ *
+ * Reaping a LIVE release park is harmless in a second way: that park IS
+ * the releasing process's own lock inode, so unlinking it is precisely the
+ * release that process was about to perform. Its `statSync(parked)` then
+ * throws, which it reads as "vanished" — a case distinct from a mismatch,
+ * so it attempts no restore and no unlink — and both agree the lock is
+ * released. (The release's OTHER park — a peer's live lock, mismatched —
+ * can also be reaped here, from the branch where its restore failed and it
+ * deliberately left the file. That is the leak this sweep is for.)
  *
  * Entirely best-effort: every failure is swallowed, so this can never
- * throw out of the reclaim it runs inside.
+ * throw out of the acquisition it runs inside.
  */
 function sweepStaleParks(lockPath: string): void {
   try {

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -3,14 +3,21 @@
  * log this codebase owns.
  *
  * Extracted from `src/vault/broker/audit-log.ts` (issue #2792 item B /
- * #2953 / #2955), which had the only correct implementation. Three other
- * logs were appending without ANY bound:
+ * #2953 / #2955), which had the only correct implementation. Two other
+ * TypeScript logs were appending without ANY bound:
  *
  *   - `<agent>/telegram/webhook-events.jsonl` (src/web/webhook-gateway-record.ts)
  *   - `~/.switchroom/host-control-audit.log` (src/host-control/server.ts)
  *
- * Rather than grow a third and fourth copy of the copy/fsync/truncate
+ * Rather than grow a second and third copy of the copy/fsync/truncate
  * dance, both now call into here, and the vault broker delegates to it.
+ *
+ * The sidecar supervisor log is bounded as well, but NOT by this module:
+ * it is rotated in shell by the container entrypoint
+ * (`profiles/_base/start.sh.hbs`, the `cp` + `: >` copytruncate block),
+ * because no TypeScript runs on that path. It appears in the rename
+ * rationale below because it constrains the technique, not because it
+ * calls in here.
  *
  * ── Why copy-then-truncate rather than rename ────────────────────────
  * `rename` is wrong for every log this module serves — but for a
@@ -87,8 +94,12 @@ export interface RotateOptions {
    * a dead one, so a peer can legitimately reclaim a LIVE lock and enter
    * `fn()` alongside it — reproduced at two writers (#3600 round-4, H1).
    * What bounds the damage is the in-critical-section inode guard: a
-   * rotator whose lock was reclaimed aborts before it destroys anything
-   * (see {@link withRotateLock}'s residual for what remains).
+   * rotator whose lock was reclaimed aborts at the next checkpoint
+   * instead of running the rest of the rotation. It is a bound, not
+   * immunity — a reclaim landing between a checkpoint and the syscall it
+   * guards still gets that one syscall through, which is enough to lose
+   * a generation (see {@link withRotateLock}'s residual, which states
+   * the damage).
    *
    * Single-writer logs (vault audit, hostd audit — both serialized
    * in-process, see `audit-hashchain.ts` single-writer-process contract)
@@ -135,6 +146,13 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * own lock was reclaimed out from under us (we overran the threshold) we
  * cannot delete the new holder's lock on the way out.
  *
+ * That guard and `stillHeld()` both rest on a PREMISE the type system
+ * cannot state: the lock `fd` stays open from the `open(wx)` that took it
+ * until the `finally` below. An open fd pins the inode, which is the only
+ * reason "same inode number" means "same lock" — see the comment at the
+ * `ourIno` capture for the measurement and for the test that fails if a
+ * refactor closes it early.
+ *
  * ── Residual, stated honestly ────────────────────────────────────────
  * The breach is at the STALENESS TEST. Step 2 can prove the parked file
  * is the same inode we judged stale and is still past the threshold; it
@@ -154,22 +172,54 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *
  * The close is therefore NOT to prevent the double entry — POSIX has no
  * identity-checked reclaim and Node exposes no `flock`/`fcntl` lease —
- * but to make the loser HARMLESS. `fn` receives a `stillHeld()`
- * predicate that re-asserts the same inode identity the release guard
- * uses, and {@link rotateLogFile} calls it at the head of each of its
- * three destructive phases. An overrun rotator that lost its lock
- * declines instead of clobbering, so H1 leaves the reclaimer's `.1` and
- * the shifted history intact.
+ * but to make the loser CHEAP rather than catastrophic. `fn` receives a
+ * `stillHeld()` predicate that re-asserts the same inode identity the
+ * release guard uses, and {@link rotateLogFile} calls it immediately
+ * before every destructive syscall (four call sites; the shift one fires
+ * once per loop iteration). An overrun rotator that lost its lock stops
+ * at the next checkpoint instead of running the rotation to completion,
+ * so it cannot produce the zero-byte `.1` above.
+ *
+ * What that does NOT buy is an untouched filesystem. Precisely what
+ * survives depends on where the reclaim lands, and the tests say so:
+ * when it lands before our first destructive syscall we touch nothing
+ * (`log-rotation-race.test.ts`, "declines outright when the peer rotated
+ * before we touched anything" — `.1` the peer's snapshot, `.2` the
+ * shifted history, active untouched). When it lands in a check→syscall
+ * gap, that one syscall goes through first and a generation is gone —
+ * the same file asserts exactly that in "does not copy over the peer's
+ * .1": `existsSync(<log>.1) === false` and `.2` holding the peer's
+ * snapshot, i.e. our unserialized shift `rename` moved the reclaimer's
+ * fresh `.1` onto `.2` and destroyed the shifted history that was there.
+ * Preserved in every interleaving are the rows written after the
+ * reclaimer's rotation — the truncate is the last checkpoint and it is
+ * never reached. Its snapshot survives every gap but the copy one; a
+ * generation of depth does not.
  *
  * What still remains, precisely — this is a narrowing, not a proof of
  * safety:
  *
  *   - `stillHeld()` is a `stat` and the destructive call after it is a
  *     separate syscall. A reclaim landing in that instruction-scale gap
- *     is not caught for the phase it guards — though the NEXT checkpoint
- *     does catch it, so at most one phase proceeds unserialized. The
- *     window shrinks from "the whole rotation" to "between two adjacent
- *     syscalls", but it is not zero.
+ *     is not caught for the syscall it guards — the NEXT checkpoint does
+ *     catch it, so at most ONE syscall proceeds unserialized, but one is
+ *     enough to destroy a full generation. Both gaps are reproduced in
+ *     `log-rotation-race.test.ts` at `maxFiles=2` (#3600 round-5, M2):
+ *       · check→`copyFileSync` ("loses a generation when the reclaim
+ *         lands in the copy gap"): `.1` becomes a byte-copy of the LIVE
+ *         file and `.2` is absent — the reclaimer's snapshot and the
+ *         prior generation are both gone. That is the outcome
+ *         {@link RotateOptions.lock} calls strictly worse than the
+ *         unlocked window.
+ *       · check→shift-`rename` ("does not copy over the peer's .1"):
+ *         `.1` absent, `.2` the reclaimer's snapshot — one generation
+ *         irrecoverably lost.
+ *     So the window shrinks from "the whole rotation" to "between two
+ *     adjacent syscalls" and the worst case shrinks from "all history"
+ *     to "one generation"; neither is zero. Reaching it needs a rotation
+ *     that overruns {@link ROTATE_LOCK_STALE_MS} AND a peer completing a
+ *     full reclaim-and-rotate inside a sub-microsecond inter-syscall
+ *     gap, which is why this is documented rather than closed.
  *   - If `fstat` on our own lock fd failed, `ourIno` is null and
  *     `stillHeld()` returns true — we cannot verify, and refusing to
  *     ever rotate is the worse failure.
@@ -272,6 +322,32 @@ function withRotateLock<T>(
   }
   // Identify the lock we hold, so release — and the critical section
   // itself — can prove it is still ours.
+  //
+  // LOAD-BEARING PREMISE: `fd` must stay OPEN for the whole critical
+  // section — from the `open(wx)` above through the `finally` below
+  // (#3600 round-5, M3). Inode numbers are only unique among LIVE inodes;
+  // a filesystem is free to hand our number straight back to the next
+  // create once nothing references it. An open fd is a reference, so
+  // holding `fd` is what makes `ino === ourIno` mean "the same lock"
+  // rather than "some file that got our number". Close it early and the
+  // reclaim sequence a peer actually performs — park (`rename`), unlink,
+  // `open(wx)` — hands the peer's brand-new lock our exact inode, at
+  // which point `stillHeld()` returns true against a lock we do not hold
+  // and the whole H1 guard silently inverts.
+  //
+  // Measured on Linux/Node 22, 200 park→unlink→recreate cycles per cell:
+  //
+  //     fd closed  ext4  200/200 collisions      fd closed  tmpfs  0/200
+  //     fd open    ext4    0/200 collisions      fd open    tmpfs  0/200
+  //
+  // Note the tmpfs column: the race suite runs under `os.tmpdir()`, which
+  // is tmpfs on these machines and never reuses — so no outcome-level
+  // race test can detect an early close. The real logs live on ext4
+  // (`~/.switchroom/**`), i.e. on the reusing side. The guard is
+  // therefore mechanical, not observational: `log-rotation-race.test.ts`,
+  // "holds the lock fd open through every destructive syscall", watches
+  // `closeSync` and fails if `fd` is closed before the last destructive
+  // syscall — on any filesystem.
   let ourIno: number | null = null;
   try {
     ourIno = fs.fstatSync(fd).ino;
@@ -314,10 +390,15 @@ function withRotateLock<T>(
  * taken. There is no "keep ours" exemption: the sole caller runs this
  * AFTER unlinking its own park and after taking the lock, so our park is
  * gone — and in the one case it is not (that unlink failed), it IS a leak
- * and reaping it is correct. A peer mid-reclaim can hold an eligible park
- * — reaping it makes that peer's step-2 stat fail, so it declines and
- * takes no lock. That is a missed rotation cycle at worst; it cannot
- * wedge the path or produce two rotators.
+ * and reaping it is correct. A peer mid-reclaim WILL hold an eligible
+ * park, not merely can: `rename(2)` does not touch the file's mtime (it
+ * modifies the directory, not the inode), so a park always carries the
+ * mtime of the ancient lock it was made from and is therefore always
+ * already past the cutoff. Reaping a concurrent reclaimer's park is the
+ * common case, not an edge — the consequences below are what make that
+ * acceptable, not its rarity. Reaping it makes that peer's step-2 stat
+ * fail, so it declines and takes no lock. That is a missed rotation cycle
+ * at worst; it cannot wedge the path or produce two rotators.
  *
  * Entirely best-effort: every failure is swallowed, so this can never
  * throw out of the reclaim it runs inside.
@@ -365,9 +446,15 @@ function sweepStaleParks(lockPath: string): void {
  * Per-syscall rather than once at the top because a reclaim can land at
  * any point inside the rotation, and each check is one `stat` against a
  * handful of syscalls. It is a narrowing, not a proof — a reclaim landing
- * between a check and the syscall it guards is still uncaught (the next
- * check catches it, so at most one syscall proceeds unserialized). See
- * {@link withRotateLock}'s residual.
+ * between a check and the syscall it guards is still uncaught, and while
+ * the next check catches it, so that at most ONE syscall proceeds
+ * unserialized, that one syscall is enough to destroy a full generation:
+ * an unserialized shift `rename` moves the reclaimer's fresh `.1` onto
+ * `.2` (history gone, asserted in `log-rotation-race.test.ts`, "does not
+ * copy over the peer's .1"), and an unserialized `copyFileSync` overwrites
+ * `.1` with a copy of the live file (reclaimer's snapshot AND the prior
+ * generation gone). "At most one syscall" bounds the count, not the cost.
+ * See {@link withRotateLock}'s residual for both reproductions.
  */
 export function rotateLogFile(
   logPath: string,

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -82,6 +82,12 @@ export interface RotateOptions {
    * the size is re-checked while holding the lock, so the loser sees the
    * freshly-truncated file and declines.
    *
+   * BOUND, not merely documented convention: the lock is proven mutually
+   * exclusive for at most TWO concurrent rotators per path. At three the
+   * stale-lock reclaim has a real window (see {@link withRotateLock}'s
+   * residual). Adding a third writer process to a locked log is a design
+   * change, not a config change, and must revisit that analysis first.
+   *
    * Single-writer logs (vault audit, hostd audit — both serialized
    * in-process, see `audit-hashchain.ts` single-writer-process contract)
    * do not need it and leave this false.
@@ -128,16 +134,75 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * cannot delete the new holder's lock on the way out.
  *
  * Residual, stated honestly rather than papered over with an invariant
- * that is not true: three-plus processes interleaving inside the
- * sub-millisecond window of step 3 can still restore a lock over a
- * just-taken one. It needs a crashed holder, a >30s-idle log, and
- * microsecond-precise arrival of a third racer; the failure mode is one
- * lost rotation cycle, not a lost generation. Everything shorter than
- * that — the ordinary two-reclaimer race the reviewer reproduced — is
- * closed here, and the under-lock size re-check in
- * {@link maybeRotateLogFile} is the second, independent guard against
+ * that is not true. The breach is at step 1, not step 3: `rename` moves
+ * the lock off `lockPath`, so for the whole rename→claim interval the
+ * path is genuinely UNLOCKED and any arrival can legitimately
+ * `open(wx)` it. With three processes that is reachable — A parks a
+ * stale lock and reclaims; C arrives in A's interval and takes the path;
+ * B, which parked a live lock and is unwinding its step-3 mismatch, then
+ * runs its cleanup `unlinkSync(parked)` on what is now A's only link.
+ * A and C are both inside `fn()`, and `linkSync` is not what does the
+ * damage — it EEXISTs and cannot clobber. The cost is NOT one lost
+ * cycle: both rotators re-check `overCap` before either truncates, so
+ * both proceed, and at maxFiles=2 the second `unlinkSync(<log>.2)`
+ * destroys real history while its zero-byte copy lands on the first's
+ * fresh `.1`. Prior generation gone AND current snapshot zeroed — the
+ * exact outcome {@link RotateOptions.lock} calls strictly worse than the
+ * unlocked copy/truncate window.
+ *
+ * It is UNREACHABLE for the only `lock: true` log. That is
+ * `rotateWebhookLogIfNeeded` (`src/web/webhook-handler.ts:196`), which
+ * has exactly two writer processes per path — `handleWebhookIngest` in
+ * the web container and `recordWebhookEvent` in the agent gateway — and
+ * the interleaving needs a third. Raising any locked log to three
+ * concurrent writers is therefore a DESIGN change, not a config change:
+ * it re-opens this window and must revisit this comment. Closing it in
+ * code would need an identity-checked rename (POSIX has none) or a
+ * kernel `flock`/`fcntl` lease (not in Node's stdlib), so it is
+ * documented rather than fixed.
+ *
+ * Everything at two contenders — the ordinary two-reclaimer race the
+ * reviewer reproduced — is closed here, and the under-lock size re-check
+ * in {@link maybeRotateLogFile} is the second, independent guard against
  * copying an already-rotated (empty) file over a good `.1`.
  */
+/**
+ * Reap `<lockPath>.stale.<pid>.<rand>` files stranded by a crash between
+ * the reclaim's `rename` and its cleanup `unlink` (#3600 round-3, L2).
+ * Nothing else globs these names, so without this they accumulate one per
+ * crash-in-window, forever, in the agent's telegram dir.
+ *
+ * Only parks whose mtime is already past {@link ROTATE_LOCK_STALE_MS} are
+ * taken, and `keep` (our own, this reclaim) is always skipped. A peer
+ * mid-reclaim can hold an eligible park — reaping it makes that peer's
+ * step-2 stat fail, so it declines and takes no lock. That is a missed
+ * rotation cycle at worst; it cannot wedge the path or produce two
+ * rotators.
+ *
+ * Entirely best-effort: every failure is swallowed, so this can never
+ * throw out of the reclaim it runs inside.
+ */
+function sweepStaleParks(lockPath: string, keep: string): void {
+  try {
+    const dir = path.dirname(lockPath);
+    const prefix = `${path.basename(lockPath)}.stale.`;
+    const cutoff = Date.now() - ROTATE_LOCK_STALE_MS;
+    for (const name of fs.readdirSync(dir)) {
+      if (!name.startsWith(prefix)) continue;
+      const full = path.join(dir, name);
+      if (full === keep) continue;
+      try {
+        if (fs.statSync(full).mtimeMs > cutoff) continue;
+        fs.unlinkSync(full);
+      } catch {
+        /* raced with a peer's reclaim or another sweeper — leave it */
+      }
+    }
+  } catch {
+    /* unreadable dir — sweeping is housekeeping, never fatal */
+  }
+}
+
 function withRotateLock<T>(
   logPath: string,
   tag: string,
@@ -208,6 +273,9 @@ function withRotateLock<T>(
     } catch {
       /* best-effort — the park name is unique to us */
     }
+    // We are the one process known to be reclaiming this path right now:
+    // the cheapest safe moment to collect parks other crashes stranded.
+    sweepStaleParks(lockPath, parked);
     try {
       fd = fs.openSync(lockPath, "wx", 0o600);
     } catch {

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -244,9 +244,11 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *          held. The worst case does not shrink from "all history" to
  *          "one generation": it is still total loss. What shrinks is how
  *          much has to go wrong to reach it, not what it costs.
- *   4. check→`truncateSync` — the only gap that destroys LIVE rows
- *      rather than history depth, and the only one with no next
- *      checkpoint behind it, because the truncate IS the last one. The
+ *   4. check→`truncateSync` — the only gap where WE destroy rows in the
+ *      ACTIVE file (the quiet copy gap costs the same rows, but by
+ *      overwriting the snapshot they had been moved to), and the only
+ *      one with no next checkpoint behind it, because the truncate IS
+ *      the last one. The
  *      peer rotates and appends; we truncate its rows away and return
  *      `true`, telling the caller the rotation succeeded. This is the
  *      one gap that got a code change rather than a paragraph (#3600
@@ -627,8 +629,8 @@ export function rotateLogFile(
   //
   // Why a second one at all: the truncate gap is the only gap with no
   // NEXT checkpoint to catch what slipped through, because this is the
-  // last one, and it is the only gap that destroys LIVE rows rather than
-  // history depth. A peer that reclaims after `held()`'s stat, rotates,
+  // last one, and the only one where WE destroy rows in the active file
+  // itself. A peer that reclaims after `held()`'s stat, rotates,
   // and appends leaves us truncating rows that belong entirely to its
   // completed cycle (reproduced, #3600 round-6).
   //

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -26,8 +26,9 @@
  *   - hostd audit log: hostd is the source-side writer, so EBUSY is NOT
  *     the operative constraint (rename would succeed on the host). The
  *     decisive reason is the READERS: every admin agent bind-mounts this
- *     file `:ro` as a single file (`src/cli/apply.ts:1107-1116` pre-creates
- *     it precisely so that `:ro` mount source exists), and hostd writes it
+ *     file `:ro` as a single file — the mount is emitted at
+ *     `src/agents/compose.ts:2529-2531` (`src/cli/apply.ts:1107-1116` only
+ *     pre-creates the file so that mount source exists) — and hostd writes it
  *     through its own `/host-home` mount. A bind mount pins an INODE, not
  *     a path — renaming the active file would leave every one of those
  *     mounts permanently attached to the old, rotated inode. `/audit
@@ -97,9 +98,45 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * Returns `null` if the lock could not be taken (another process is
  * mid-rotation) — the caller treats that as "someone else handled it".
  *
- * A lock left behind by a killed process is reclaimed after
- * {@link ROTATE_LOCK_STALE_MS}; the reclaim is itself racy-safe because
- * the reclaimer re-attempts the same `O_EXCL` create and only one can win.
+ * A lock left behind by a killed process (container stop, OOM kill) is
+ * reclaimed after {@link ROTATE_LOCK_STALE_MS}. The reclaim must itself be
+ * mutually exclusive, and `unlink` + `open(O_EXCL)` is NOT (#3600
+ * re-review, finding 1): two reclaimers can interleave so that the
+ * second's `unlink` removes the FIRST's freshly created lockfile, after
+ * which its own exclusive create succeeds and both run. One stale lock
+ * would degrade the lock to no lock, in exactly the crash scenario the
+ * lock exists for.
+ *
+ * POSIX gives us no identity-checked `unlink`, so the reclaim is done as
+ * park-verify-claim:
+ *
+ *   1. `rename(lockPath -> lockPath.stale.<pid>.<rand>)` — atomic, and the
+ *      park name is unique to us, so the file we now hold is unambiguous.
+ *   2. verify the parked file IS the stale lock we observed (same inode,
+ *      still older than the threshold). A racer that reclaimed just before
+ *      us parks as step 1 too — but what it parked is that racer's LIVE
+ *      lock, which fails this check.
+ *   3. on mismatch, put it back with `link(2)` (atomic create-if-absent, so
+ *      it cannot clobber a lock taken meanwhile) and decline. Only on a
+ *      match do we unlink the stale file and take the lock normally, which
+ *      can still lose EEXIST to a fresh arrival — correct, that arrival
+ *      holds it.
+ *
+ * Release is inode-guarded for the same reason: we only unlink the
+ * lockfile if the path still resolves to the inode we created, so if our
+ * own lock was reclaimed out from under us (we overran the threshold) we
+ * cannot delete the new holder's lock on the way out.
+ *
+ * Residual, stated honestly rather than papered over with an invariant
+ * that is not true: three-plus processes interleaving inside the
+ * sub-millisecond window of step 3 can still restore a lock over a
+ * just-taken one. It needs a crashed holder, a >30s-idle log, and
+ * microsecond-precise arrival of a third racer; the failure mode is one
+ * lost rotation cycle, not a lost generation. Everything shorter than
+ * that — the ordinary two-reclaimer race the reviewer reproduced — is
+ * closed here, and the under-lock size re-check in
+ * {@link maybeRotateLogFile} is the second, independent guard against
+ * copying an already-rotated (empty) file over a good `.1`.
  */
 function withRotateLock<T>(
   logPath: string,
@@ -128,12 +165,61 @@ function withRotateLock<T>(
     process.stderr.write(
       `[${tag}] WARN: reclaiming stale rotation lock ${lockPath} (${Math.round(age / 1000)}s old)\n`,
     );
+    // Park-verify-claim (see the doc comment). `observed` is the identity
+    // we judged stale; anything else at that path is someone's live lock.
+    let observed: fs.Stats;
     try {
-      fs.unlinkSync(lockPath);
+      observed = fs.statSync(lockPath);
+    } catch {
+      return null; // gone — a peer is mid-reclaim
+    }
+    const parked = `${lockPath}.stale.${process.pid}.${Math.random().toString(36).slice(2, 10)}`;
+    try {
+      fs.renameSync(lockPath, parked);
+    } catch {
+      return null; // a peer parked it first
+    }
+    let mine = false;
+    try {
+      const p = fs.statSync(parked);
+      mine =
+        p.ino === observed.ino &&
+        Date.now() - p.mtimeMs >= ROTATE_LOCK_STALE_MS;
+    } catch {
+      mine = false;
+    }
+    if (!mine) {
+      // We parked a LIVE lock (a peer reclaimed between our stat and our
+      // rename). Put it back without clobbering whatever is there now.
+      try {
+        fs.linkSync(parked, lockPath);
+      } catch {
+        /* a lock already exists at the path — the holder is covered */
+      }
+      try {
+        fs.unlinkSync(parked);
+      } catch {
+        /* best-effort */
+      }
+      return null;
+    }
+    try {
+      fs.unlinkSync(parked);
+    } catch {
+      /* best-effort — the park name is unique to us */
+    }
+    try {
       fd = fs.openSync(lockPath, "wx", 0o600);
     } catch {
-      return null; // someone else won the reclaim
+      return null; // a fresh arrival took the lock between our rename and this
     }
+  }
+  // Identify the lock we hold, so release can prove it is still ours.
+  let ourIno: number | null = null;
+  try {
+    ourIno = fs.fstatSync(fd).ino;
+  } catch {
+    /* leave null — release then falls back to not unlinking */
   }
   try {
     return fn();
@@ -144,9 +230,11 @@ function withRotateLock<T>(
       /* best-effort */
     }
     try {
-      fs.unlinkSync(lockPath);
+      if (ourIno !== null && fs.statSync(lockPath).ino === ourIno) {
+        fs.unlinkSync(lockPath);
+      }
     } catch {
-      /* best-effort */
+      /* gone already, or someone else's — either way not ours to remove */
     }
   }
 }

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -95,16 +95,35 @@ export interface RotateOptions {
    * enter `fn()` alongside it — reproduced at two writers (#3600 round-4,
    * H1). The in-critical-section inode guard bounds how much of the
    * rotation such a rotator can still run: it aborts at the next
-   * checkpoint, so at most ONE destructive syscall proceeds unserialized.
+   * checkpoint, so at most ONE destructive syscall proceeds unserialized —
+   * WHENEVER THE GUARD CAN VERIFY ANYTHING AT ALL. If the `fstat` on our
+   * own lock fd failed, `ourIno` is null, `stillHeld()` returns true
+   * forever, and NO lock checkpoint fires at any of the four sites: the
+   * oldest-generation unlink and every shift rename then run unserialized,
+   * and only the data-based gates named below still bite — and those are
+   * silent too whenever the peer finished before our entry stat, which is
+   * exactly the interleaving that test drives. That
+   * carve-out is not a footnote to the "at most one" claim, it is an
+   * exception to it, and it is asserted in `log-rotation-race.test.ts`,
+   * "an unverifiable lock fd drops every lock checkpoint" (#3600 round-7,
+   * L1).
    *
-   * That bounds the COUNT, not the damage, and the distinction is not
-   * academic — the syscall that gets through can be the `copyFileSync`,
-   * and if the peer has not appended since rotating (a low-traffic log,
-   * most of the time) the bytes it copies over the peer's snapshot are
-   * zero. `.1` empty, prior generation gone, active file empty: the
-   * empty-copy outcome named two paragraphs up, reached WITH the lock
-   * held. See {@link withRotateLock}'s residual, which enumerates all four
-   * gaps and what each destroys (#3600 round-6, H1/H2).
+   * That bounds the COUNT, not the damage. Every destructive step —
+   * the oldest-generation unlink, each shift rename, the `copyFileSync`
+   * that overwrites `.1`, and the `truncateSync` that empties the active
+   * file — therefore carries a SECOND gate that
+   * depends on no lock at all: an append-only log only grows, so an active
+   * file that SHRANK below the size we measured is positive evidence that
+   * a peer rotated under us, and all of them decline on it (#3600 round-6
+   * H2 for the truncate, round-7 H1 for the copy and, by the sibling
+   * sweep that finding required, for the unlink and the shifts). That is what removes
+   * the worst outcome — a quiet peer's freshly-truncated zero bytes copied
+   * over its own fresh snapshot, `.1` empty, prior generation gone, active
+   * empty, i.e. the empty-copy outcome named two paragraphs up reached
+   * WITH the lock held — from every landing up to each gate's own stat.
+   * What it does not remove is that gate's own stat→syscall gap. See
+   * {@link withRotateLock}'s residual, which enumerates all four gaps and
+   * what each still destroys (#3600 round-6 H1/H2, round-7 H1).
    *
    * Single-writer logs (vault audit, hostd audit — both serialized
    * in-process, see `audit-hashchain.ts` single-writer-process contract)
@@ -146,10 +165,42 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *      can still lose EEXIST to a fresh arrival — correct, that arrival
  *      holds it.
  *
- * Release is inode-guarded for the same reason: we only unlink the
- * lockfile if the path still resolves to the inode we created, so if our
- * own lock was reclaimed out from under us (we overran the threshold) we
- * cannot delete the new holder's lock on the way out.
+ * Release is identity-guarded for the same reason, and by the SAME
+ * primitive, for the same reason again: `statSync(lockPath).ino ===
+ * ourIno` followed by a separate `unlinkSync(lockPath)` is two syscalls,
+ * so a peer that reclaims BETWEEN them is handed a verdict about a file it
+ * no longer owns and has its brand-new LIVE lock deleted unconditionally —
+ * the log left unlocked while the peer believes it holds it. That claim
+ * ("we cannot delete the new holder's lock on the way out") stood here
+ * false for five rounds and was reproduced in round 7 (#3600, H2); the
+ * round-6 H3 ordering fix made the inode NUMBER meaningful, it did not
+ * make stat+unlink atomic, and no ordering can.
+ *
+ * So release is park-verify-unlink:
+ *
+ *   1. `rename(lockPath -> lockPath.stale.<pid>.<rand>)` — atomic, and the
+ *      park name is unique to us, so the file we are about to judge is
+ *      unambiguously the one we took. This is the step that closes the
+ *      gap: identity is decided about a file nobody else can name.
+ *   2. compare the parked inode against `ourIno`; unlink it only on a
+ *      match. A peer's lock, reclaimed at any instant before the rename,
+ *      fails the comparison and is never unlinked.
+ *   3. on mismatch, `link(2)` it back (create-if-absent, so it cannot
+ *      clobber a lock taken meanwhile) and touch nothing else.
+ *
+ * Its residual is different in kind, and smaller: between the park
+ * `rename` and the restoring `link` the lock path does not exist, so a
+ * third arrival can take the lock there. The restore then fails EEXIST and
+ * our cleanup unlink drops the reclaimer's inode — but that arrival really
+ * does hold the lock, and the reclaimer's own `stillHeld()` reads the
+ * arrival's inode and declines at its next checkpoint. Two syscalls of
+ * exposure with a conservative outcome, in place of an unconditional
+ * delete on every occurrence. Pinned by `log-rotation-race.test.ts`,
+ * "release does not delete a peer's lock that arrived after our identity
+ * check", which lands the peer in exactly the old gap.
+ *
+ * Also note what park-verify does NOT need: a `stillHeld()`-style
+ * re-check. The rename decides ownership, not a preceding stat.
  *
  * That guard and `stillHeld()` both rest on a PREMISE the type system
  * cannot state: the lock `fd` is still open when the inode comparison
@@ -160,14 +211,17 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *
  * For `stillHeld()` the premise holds by position — every call is inside
  * `fn()`. For the RELEASE guard it holds only because the `finally` below
- * unlinks BEFORE it closes, and until round 6 it did not: the close came
- * first, and the guard then compared a number nothing was holding.
- * Reproduced on ext4 (#3600 round-6, H3) — a peer's park→unlink→`open(wx)`
- * landing in that window was handed our inode number, our guard matched,
- * and we deleted the peer's LIVE lock, leaving the log unlocked in exactly
- * the scenario the lock exists for. That is why the ordering in the
- * `finally` is annotated rather than left to look arbitrary, and why the
- * release unlink is one of the sites the round-5 mechanism test now tags.
+ * runs the whole park-verify-unlink BEFORE it closes, and until round 6 it
+ * did not: the close came first, and the guard then compared a number
+ * nothing was holding. Reproduced on ext4 (#3600 round-6, H3) — a peer's
+ * park→unlink→`open(wx)` landing in that window was handed our inode
+ * number, our guard matched, and we deleted the peer's LIVE lock, leaving
+ * the log unlocked in exactly the scenario the lock exists for. Park-verify
+ * does not retire that requirement, it inherits it: if `fd` were closed,
+ * the peer's new lock could carry `ourIno`, we would park it, match, and
+ * unlink it. That is why the ordering in the `finally` is annotated rather
+ * than left to look arbitrary, and why the release is one of the sites the
+ * round-5 mechanism test tags.
  *
  * ── Residual, stated honestly ────────────────────────────────────────
  * The breach is at the STALENESS TEST. Step 2 can prove the parked file
@@ -192,19 +246,32 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * `stillHeld()` predicate that re-asserts the same inode identity the
  * release guard uses, and {@link rotateLogFile} calls it immediately
  * before every destructive syscall (four `held()` sites; the shift one
- * fires once per loop iteration), plus a data-based gate on the truncate
- * and one further `stillHeld()` read AFTER the truncate that guards
- * nothing and only decides whether to log that we destroyed the peer's
- * rows. An overrun rotator that lost its lock stops at the next
- * checkpoint instead of running the rotation to completion.
+ * fires once per loop iteration), each paired with a data-based gate —
+ * the shrank-under-us predicate on the drop, the shifts and the copy,
+ * and the snapshot-relative one on the truncate — plus one further
+ * `stillHeld()` read AFTER the
+ * truncate that guards nothing and only decides whether to log that we
+ * destroyed the peer's rows. An overrun rotator that lost its lock stops
+ * at the next checkpoint instead of running the rotation to completion.
  *
  * ── What that does and does NOT buy ──────────────────────────────────
- * It buys ONE thing, stated exactly: at most one destructive syscall
- * proceeds unserialized, instead of the whole rotation. It does not
- * bound the DAMAGE of that one syscall, and specifically it does not
- * bound it to "one generation" — the copy gap below loses everything.
- * Rounds 3-6 of the #3600 review each caught a sentence here claiming
- * otherwise; every claim in this block is pinned by a named test in
+ * The lock checkpoints buy ONE thing, stated exactly: at most one
+ * destructive syscall proceeds unserialized, instead of the whole
+ * rotation — and even that holds only while `ourIno !== null`. With a
+ * null `ourIno` (an `fstat` that failed on our own lock fd) `stillHeld()`
+ * is a constant `true`, every one of the four checkpoints is a no-op, and
+ * the unlink and the shifts run unserialized together; the data-based
+ * gates are then the only thing between us and the peer's bytes — and
+ * they are silent whenever the peer finished BEFORE our entry stat, since
+ * `entryBytes` then already records the peer's truncated file and nothing
+ * shrinks relative to it. That
+ * exception is asserted, not merely mentioned, in "an unverifiable lock fd
+ * drops every lock checkpoint" (#3600 round-7, L1).
+ *
+ * They do not bound the DAMAGE of the syscall that gets through, and
+ * specifically they do not bound it to "one generation". Rounds 3-7 of the
+ * #3600 review each caught a sentence here claiming more than the code
+ * does; every claim in this block is pinned by a named test in
  * `log-rotation-race.test.ts`, and the tests, not the prose, are the
  * record.
  *
@@ -213,7 +280,11 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * anything" — `.1` the peer's snapshot, `.2` the shifted history, active
  * untouched). A landing anywhere else is caught by the NEXT checkpoint
  * and costs nothing either — except in the FOUR check→syscall gaps, one
- * per destructive syscall, where that syscall is already committed. Those
+ * per destructive syscall in {@link rotateLogFile}, where that syscall is
+ * already committed. (The lockfile's own release unlink was a FIFTH site
+ * of the same shape and is NOT in this list because it no longer has the
+ * shape: park-verify-unlink decides identity with an atomic `rename`
+ * rather than with a preceding stat — #3600 round-7, H2, above.) Those
  * four are not equivalent; each destroys something different:
  *
  *   1. check→`unlinkSync(<log>.<keep>)` — the oldest-generation drop.
@@ -223,12 +294,37 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *      gap destroys its shifted history". Before round 6 the in-tree
  *      test seeded no `.1`, so the peer's own rotation had already
  *      removed `.2` and our unlink merely failed ENOENT — it passed on
- *      an error path and asserted nothing about this gap.)
+ *      an error path and asserted nothing about this gap.) Round 7's
+ *      copy-gate fix was swept onto this syscall too rather than
+ *      point-fixed at the copy: the shrank-under-us evidence is the
+ *      same evidence here, so a landing anywhere from the `held()` stat
+ *      up to the GATE's stat now costs nothing ("declines the
+ *      oldest-generation drop when the peer rotated after our lock
+ *      check"). The residual is the gate's own stat→`unlink` window,
+ *      with the outcome above.
  *   2. check→shift-`rename` — our rename moves the peer's fresh `.1`
  *      onto `.2`, over the history that was there. `.1` absent, `.2` the
- *      peer's snapshot. ("does not copy over the peer's .1")
- *   3. check→`copyFileSync` — the worst of the four, and its severity
- *      depends on the peer, not on us:
+ *      peer's snapshot. ("does not copy over the peer's .1") Gated the
+ *      same way and for the same reason, once per loop iteration
+ *      ("declines the shift when the peer rotated after our lock
+ *      check"); residual likewise the gate's own stat→`rename` window.
+ *   3. check→`copyFileSync` — the gap that WAS the worst of the four, and
+ *      the one round 7 closed for every landing up to the gate's own stat
+ *      (#3600 round-7, H1). The copy now carries a data-based gate
+ *      symmetric to the truncate's: {@link rotateLogFile} measures the
+ *      active file on ENTRY, re-stats it immediately before the copy, and
+ *      declines if it SHRANK below that ("declines the copy when the peer
+ *      rotated after our lock check"). Appends only grow an append-only
+ *      log, so a shrink is someone else's truncate and nothing else.
+ *      Round 6 declined this fix arguing it recovers no data because the
+ *      peer's snapshot has already been overwritten by our copy; that is
+ *      circular — the copy is the thing the gate skips. Driven at the
+ *      START of the gap with a quiet peer, the gate turns `.1` empty /
+ *      `.2` absent / active empty into `.1` carrying the peer's full
+ *      snapshot: total loss → zero loss.
+ *
+ *      What survives is the gate's own stat→`copyFileSync` gap, where the
+ *      severity still depends on the peer, not on us:
  *        · peer appended after rotating → `.1` becomes a byte-copy of
  *          the live file, `.2` absent: the peer's snapshot and the prior
  *          generation are both gone, the live rows survive. ("loses a
@@ -241,9 +337,11 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *          the peer is quiet", #3600 round-6, H1.) This is verbatim the
  *          outcome {@link RotateOptions.lock} calls strictly worse than
  *          the ordinary copy/truncate race window, reached WITH the lock
- *          held. The worst case does not shrink from "all history" to
- *          "one generation": it is still total loss. What shrinks is how
- *          much has to go wrong to reach it, not what it costs.
+ *          held. The worst case inside this residual window does not
+ *          shrink from "all history" to "one generation": it is still
+ *          total loss. What the gate shrank is the window that reaches
+ *          it — from [`held()` stat → copy] to [gate stat → copy] — not
+ *          what it costs when it is reached.
  *   4. check→`truncateSync` — the only gap where WE destroy rows in the
  *      ACTIVE file (the quiet copy gap costs the same rows, but by
  *      overwriting the snapshot they had been moved to), and the only
@@ -261,10 +359,19 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  *      separate syscall, so the gap moves, it does not close; the
  *      surviving window is asserted, return value and all, in "destroys
  *      the peer's rows when the reclaim lands in the truncate gap". And
- *      it is a LENGTH test, so a peer that rotates and then re-appends
- *      more bytes than we snapshotted is invisible to it. What it does
- *      cover is the ordinary shape of the landing: a peer that rotated
- *      leaves the active file shorter than our snapshot.
+ *      it is a LENGTH test with a STRICT comparison (`liveBytes <
+ *      snapshotBytes`), so a peer that rotates and then re-appends AT
+ *      LEAST as many bytes as we snapshotted — exactly as many is enough,
+ *      not merely more — is invisible to it. The boundary is deliberate:
+ *      `<=` would decline the ordinary rotation, where nothing was
+ *      appended between our copy and our truncate and the two sizes are
+ *      equal by construction. It is asserted from both sides: "rotates
+ *      normally when the lock is still ours" fails if the comparison is
+ *      loosened, and "the truncate gate is blind to a peer that re-appends
+ *      exactly what we snapshotted" (#3600 round-7, L2) fails if this
+ *      sentence is. What the gate does cover is the ordinary shape of the
+ *      landing: a peer that rotated leaves the active file shorter than
+ *      our snapshot.
  *
  * So: the window shrinks from "the whole rotation" to "between two
  * adjacent syscalls", and reaching it needs a rotation that overruns
@@ -273,9 +380,22 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * why this is documented rather than closed. It is a narrowing of
  * PROBABILITY, not of consequence.
  *
- * One more residual, unrelated to the gaps: if `fstat` on our own lock fd
- * failed, `ourIno` is null and `stillHeld()` returns true — we cannot
- * verify, and refusing to ever rotate is the worse failure.
+ * One more residual, unrelated to the gaps and BROADER than them: if
+ * `fstat` on our own lock fd failed, `ourIno` is null and `stillHeld()`
+ * returns true unconditionally — we cannot verify, and refusing to ever
+ * rotate is the worse failure. Note what that costs, because it is not
+ * "one more gap": with a null `ourIno` there are no gaps because there
+ * are no checks. All four `held()` sites pass, so the oldest-generation
+ * unlink and every shift rename proceed unserialized in the same
+ * rotation, and only the data-based gates can decline anything — and in
+ * the interleaving that test drives, where the peer's rotation completes
+ * before our entry stat, they see nothing shrink and decline nothing, so
+ * the whole rotation runs unserialized. Release is affected too — it takes no park and
+ * unlinks nothing, so our lock is left behind for the next arrival to
+ * reclaim as stale. "At most ONE destructive syscall proceeds
+ * unserialized", stated anywhere in this file, is a claim about the
+ * `ourIno !== null` path only. Asserted in "an unverifiable lock fd drops
+ * every lock checkpoint" (#3600 round-7, L1).
  *
  * Refreshing the mtime from inside `fn()` was considered as a complement
  * and NOT taken. It cannot be periodic: rotation is entirely synchronous
@@ -418,26 +538,60 @@ function withRotateLock<T>(
   try {
     return fn(stillHeld);
   } finally {
-    // ORDER IS LOAD-BEARING: unlink under the guard FIRST, close after
-    // (#3600 round-6, H3). The guard's whole content is "the inode number
-    // at `lockPath` is still ours", and that only means "still our lock"
-    // while `fd` pins the inode. Closing first frees it, and a peer's
-    // reclaim — park (`rename`), unlink, `open(wx)` — is exactly the
-    // sequence that gets the number handed straight back on a reusing
-    // filesystem. Reproduced on ext4 with the close first: the peer's
-    // brand-new LIVE lock carried our inode number, the guard matched,
-    // and we unlinked it, leaving the log with no lock at all — the
-    // failure this guard exists to prevent. Same reproduction with the
-    // close last: different inode, guard declines, peer's lock intact.
-    // `log-rotation-race.test.ts`, "holds the lock fd open through every
-    // destructive syscall", pins the ordering on any filesystem by
-    // tagging the release unlink itself with the fd's open/closed state.
-    try {
-      if (ourIno !== null && fs.statSync(lockPath).ino === ourIno) {
-        fs.unlinkSync(lockPath);
+    // ORDER IS LOAD-BEARING: release under the guard FIRST, close after
+    // (#3600 round-6, H3). The guard's whole content is "this inode is
+    // ours", and that only means "our lock" while `fd` pins the inode.
+    // Closing first frees it, and a peer's reclaim — park (`rename`),
+    // unlink, `open(wx)` — is exactly the sequence that gets the number
+    // handed straight back on a reusing filesystem. Reproduced on ext4
+    // with the close first: the peer's brand-new LIVE lock carried our
+    // inode number, the guard matched, and we unlinked it, leaving the log
+    // with no lock at all. `log-rotation-race.test.ts`, "holds the lock fd
+    // open through every destructive syscall", pins the ordering on any
+    // filesystem by tagging the release syscalls with the fd's state.
+    //
+    // AND THE GUARD IS A PARK, NOT A STAT (#3600 round-7, H2). It used to
+    // be `statSync(lockPath).ino === ourIno` followed by a separate
+    // `unlinkSync(lockPath)` — two syscalls, so a peer reclaiming between
+    // them had its brand-new LIVE lock deleted on our verdict about a file
+    // that was no longer there. Reproduced on ext4 by firing the peer's
+    // park→claim right after that stat: `existsSync(lock) === false`, the
+    // log unlocked while the peer believed it held it — the same
+    // observable failure H3 was fixed for. Ordering could not close it;
+    // only deciding identity about a file NOBODY ELSE CAN NAME does.
+    // `rename` gives us that atomically, so we take the file first and
+    // judge it second, exactly as the stale reclaim above does.
+    if (ourIno !== null) {
+      const parked = `${lockPath}.stale.${process.pid}.${Math.random().toString(36).slice(2, 10)}`;
+      let took = false;
+      try {
+        fs.renameSync(lockPath, parked);
+        took = true;
+      } catch {
+        /* nothing at the path, or a peer parked it first — not ours */
       }
-    } catch {
-      /* gone already, or someone else's — either way not ours to remove */
+      if (took) {
+        let mine = false;
+        try {
+          mine = fs.statSync(parked).ino === ourIno;
+        } catch {
+          /* a peer's sweep reaped our park — it is already gone */
+        }
+        if (!mine) {
+          // We parked someone ELSE's live lock. Put it back, without
+          // clobbering whatever may have been created at the path since.
+          try {
+            fs.linkSync(parked, lockPath);
+          } catch {
+            /* a lock already exists there — that holder is covered */
+          }
+        }
+        try {
+          fs.unlinkSync(parked);
+        } catch {
+          /* best-effort — the park name is unique to us */
+        }
+      }
     }
     try {
       fs.closeSync(fd);
@@ -467,6 +621,13 @@ function withRotateLock<T>(
  * fail, so it declines and takes no lock. That is a missed rotation cycle
  * at worst; it cannot wedge the path or produce two rotators.
  *
+ * The RELEASE park (#3600 round-7, H2) carries the same name shape on
+ * purpose — it leaks the same way on a crash and must be reaped the same
+ * way. Reaping a live one is harmless in a second way: that park IS the
+ * releasing process's own lock inode, so unlinking it is precisely the
+ * release that process was about to perform. It then finds its park gone,
+ * declines to unlink, and both agree the lock is released.
+ *
  * Entirely best-effort: every failure is swallowed, so this can never
  * throw out of the reclaim it runs inside.
  */
@@ -491,6 +652,45 @@ function sweepStaleParks(lockPath: string): void {
 }
 
 /**
+ * `fsync` the freshly written snapshot and return its size, or `null` if
+ * any step failed — in which case the caller must leave the active log
+ * intact (#3600 round-7, L3).
+ *
+ * The `step` label is what makes the diagnostic honest: `open`, `fsync`
+ * and `fstat` fail for different reasons (a vanished snapshot, a
+ * filesystem that cannot flush, a bad fd), and reporting all three as
+ * "could not fsync" sends the operator after the wrong one.
+ */
+function fsyncAndMeasure(
+  snapshotPath: string,
+  logPath: string,
+  tag: string,
+): number | null {
+  let step = "open";
+  try {
+    const fd = fs.openSync(snapshotPath, "r");
+    try {
+      step = "fsync";
+      fs.fsyncSync(fd);
+      step = "measure";
+      const size = fs.fstatSync(fd).size;
+      // Reached only if both steps above succeeded, so if the `closeSync`
+      // in the `finally` throws it replaces this return and "close" is the
+      // right label. A throw from above skips this line and keeps its own.
+      step = "close";
+      return size;
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch (err) {
+    process.stderr.write(
+      `[${tag}] ERROR: could not ${step} snapshot ${snapshotPath}; leaving active log ${logPath} intact to avoid data loss: ${(err as Error).message}\n`,
+    );
+    return null;
+  }
+}
+
+/**
  * Rotate `<path>` unconditionally: drop `<path>.<maxFiles>`, shift
  * `<path>.(n-1)` → `<path>.n`, snapshot `<path>` → `<path>.1`, truncate
  * `<path>` in place.
@@ -511,30 +711,53 @@ function sweepStaleParks(lockPath: string): void {
  * the case is reported on stderr instead ("rows another rotator wrote …
  * are LOST") and asserted in `log-rotation-race.test.ts`, "destroys the
  * peer's rows when the reclaim lands in the truncate gap" (#3600 round-6,
- * H2). Neither live caller (`src/host-control/server.ts`,
- * `src/web/webhook-handler.ts`) reads the boolean.
+ * H2).
+ *
+ * That is survivable ONLY because nothing acts on the boolean, so the
+ * callers are enumerated here rather than gestured at (#3600 round-7, L4).
+ * Three call sites reach this function and all three discard the result:
+ * `src/host-control/server.ts` (`maybeRotateAuditLog`),
+ * `src/web/webhook-gateway-record.ts` and `src/web/webhook-handler.ts`
+ * (both via `rotateWebhookLogIfNeeded`). Two module-level wrappers sit in
+ * between, and NEITHER propagates the value any more:
+ * `rotateAuditLog` in `src/vault/broker/audit-log.ts` — a fourth caller,
+ * missing from this list until round 7, and the only one that calls
+ * `rotateLogFile` directly rather than through {@link maybeRotateLogFile},
+ * i.e. on the unlocked path — has always returned `void`, and
+ * `rotateWebhookLogIfNeeded` was changed to return `void` in round 7 for
+ * the same reason. A wrapper that returns the boolean is an invitation for
+ * some future `if (rotated)` to inherit a value this doc block spends a
+ * paragraph explaining you cannot trust; making the type `void` stops that
+ * deterministically instead of asking a later reader to re-derive it.
  *
  * `stillHeld`, when supplied by {@link withRotateLock}, is re-asserted
  * immediately before EVERY destructive syscall — the oldest-generation
  * unlink, each shift rename, the `copyFileSync` that overwrites `.1`, and
- * the `truncate` that destroys live rows (#3600 round-4, H1) — and the
- * truncate carries a second, data-based gate on top (round-6, H2). A
- * holder that overran the stale threshold can have its live lock
- * legitimately reclaimed by a peer; if that happened we are no longer
- * serialized against that peer, and continuing would rename its fresh
- * `.1` off the end of the window, copy a truncated active file over it,
- * and truncate rows written after its rotation.
+ * the `truncate` that destroys live rows (#3600 round-4, H1) — and EVERY
+ * one of those four carries a second, data-based gate on top: the shared
+ * `notRotatedUnderUs` shrank-since-entry check on the unlink, the shifts
+ * and the copy (round-7 H1 and its sibling sweep), and the tighter
+ * shrank-since-the-snapshot check on the truncate (round-6 H2).
+ * A holder that overran the stale threshold can
+ * have its live lock legitimately reclaimed by a peer; if that happened we
+ * are no longer serialized against that peer, and continuing would rename
+ * its fresh `.1` off the end of the window, copy a truncated active file
+ * over it, and truncate rows written after its rotation.
  *
  * Per-syscall rather than once at the top because a reclaim can land at
  * any point inside the rotation, and each check is one `stat` against a
  * handful of syscalls. It is a narrowing, not a proof — a reclaim landing
  * between a check and the syscall it guards is uncaught for that syscall,
- * so at most ONE proceeds unserialized. "At most one syscall" bounds the
- * COUNT and nothing else: depending on which of the four gaps it lands
- * in, that one syscall costs a generation of history, the peer's live
- * rows, or — the copy gap with a quiet peer — every byte the log has.
- * {@link withRotateLock} enumerates all four with the test that asserts
- * each.
+ * so at most ONE proceeds unserialized, WHEN `stillHeld` can verify
+ * anything: {@link withRotateLock} hands us a predicate that is a constant
+ * `true` if the `fstat` on its lock fd failed, and then all four checks
+ * are no-ops and the count is unbounded (#3600 round-7, L1 — asserted in
+ * "an unverifiable lock fd drops every lock checkpoint"). "At most one
+ * syscall" bounds the COUNT and nothing else: depending on which of the
+ * four gaps it lands in, that one syscall costs a generation of history,
+ * the peer's live rows, or — the residual copy gap with a quiet peer —
+ * every byte the log has. {@link withRotateLock} enumerates all four with
+ * the test that asserts each.
  */
 export function rotateLogFile(
   logPath: string,
@@ -551,10 +774,70 @@ export function rotateLogFile(
     );
     return false;
   };
+  // The size of the active file as we FOUND it, measured before we touch
+  // anything. This is the baseline for the data gate below (#3600 round-7,
+  // H1) and it has to be taken here, on entry: by the time we reach the
+  // copy we have already spent the whole unlink-and-shift sequence, which
+  // is exactly the interval a peer's rotation lands in.
+  //
+  // A stat that fails here means we cannot read the file we are about to
+  // snapshot; the copy would fail anyway, and declining now keeps the
+  // guarantee `false` carries — the active file is exactly as we found it —
+  // while touching no generation at all.
+  let entryBytes: number;
+  try {
+    entryBytes = fs.statSync(logPath).size;
+  } catch (err) {
+    process.stderr.write(
+      `[${tag}] ERROR: could not stat active log ${logPath} before rotating it: ${(err as Error).message}\n`,
+    );
+    return false;
+  }
+  /**
+   * True iff the active file has not SHRUNK since we entered — i.e. no
+   * peer has rotated it under us (#3600 round-7, H1 and its sibling
+   * sweep). Warns once per refusal.
+   *
+   * This is the data-based half of every checkpoint, and it is deliberately
+   * NOT limited to the copy the review asked for: the unlink, the shifts
+   * and the copy each destroy something a peer's completed rotation just
+   * put there, and one observable — an append-only log that got shorter —
+   * is evidence of exactly that for all three. Applying it at one site and
+   * not the other two would leave the same class of loss (the peer's
+   * shifted history at `<log>.<keep>`, the peer's fresh `.1`) behind a
+   * lock check that provably does not cover it.
+   *
+   * It is evidence, not proof, and it fails in one direction only: a peer
+   * that rotated and then re-appended at least `entryBytes` is invisible,
+   * and a file that shrank for any other reason (an operator truncating
+   * the log by hand) makes us decline a rotation, which costs nothing but
+   * a cycle. The truncate has its own, TIGHTER version of this gate below,
+   * comparing against the snapshot we actually wrote rather than against
+   * the entry size.
+   */
+  const notRotatedUnderUs = (what: string): boolean => {
+    let live: number;
+    try {
+      live = fs.statSync(logPath).size;
+    } catch (err) {
+      process.stderr.write(
+        `[${tag}] ERROR: could not re-stat active log ${logPath}; declining to ${what}: ${(err as Error).message}\n`,
+      );
+      return false;
+    }
+    if (live < entryBytes) {
+      process.stderr.write(
+        `[${tag}] WARN: active log ${logPath} shrank from ${entryBytes} to ${live} bytes while we were rotating it; another rotator snapshotted it and these generations are its, not ours — declining to ${what}\n`,
+      );
+      return false;
+    }
+    return true;
+  };
   // Delete the oldest retained generation — it falls off the window.
   const oldest = `${logPath}.${keep}`;
   if (fs.existsSync(oldest)) {
     if (!held(`drop ${oldest}`)) return false;
+    if (!notRotatedUnderUs(`drop ${oldest}`)) return false;
     try {
       fs.unlinkSync(oldest);
     } catch (err) {
@@ -569,6 +852,7 @@ export function rotateLogFile(
     const to = `${logPath}.${n + 1}`;
     if (!fs.existsSync(from)) continue;
     if (!held(`shift ${from} → ${to}`)) return false;
+    if (!notRotatedUnderUs(`shift ${from} → ${to}`)) return false;
     try {
       fs.renameSync(from, to);
     } catch (err) {
@@ -582,6 +866,30 @@ export function rotateLogFile(
   // The copy OVERWRITES `.1` — if a peer reclaimed during the shift above,
   // that `.1` is the peer's fresh snapshot, not ours to replace.
   if (!held(`overwrite ${snapshotPath}`)) return false;
+  // A SECOND, DATA-BASED checkpoint on the copy (#3600 round-7, H1),
+  // exactly symmetric to the one on the truncate below and justified the
+  // same way: an append-only log only GROWS, so an active file that has
+  // shrunk since we entered is not our file getting shorter, it is a peer
+  // having rotated it under us. Its `.1` is that peer's snapshot and its
+  // active file is that peer's freshly-truncated zero bytes; copying now
+  // writes those zero bytes over the snapshot and loses every byte the log
+  // has ("loses EVERY byte…", round-6 H1).
+  //
+  // Round 6 rejected a fix here on the reasoning that it recovers no data
+  // because the peer's snapshot is already overwritten by our copy. That
+  // reasoning is circular — the copy is the thing this declines — and it
+  // only ever refuted the shape it considered (snapshot to a temp name and
+  // rename it into place, which still lands zero bytes on `.1`). Skipping
+  // the copy leaves `.1` holding the peer's full snapshot: total loss
+  // becomes zero loss, asserted in "declines the copy when the peer
+  // rotated after our lock check" and its quiet-peer twin.
+  //
+  // Same two residuals as the truncate gate, for the same two reasons: it
+  // is a stat followed by a separate `copyFileSync`, so a landing in THAT
+  // gap is caught by nothing ("loses a generation…" / "loses EVERY
+  // byte…"), and it is a strict length comparison, so a peer that rotates
+  // and re-appends at least `entryBytes` is invisible to it.
+  if (!notRotatedUnderUs(`overwrite ${snapshotPath}`)) return false;
   try {
     fs.copyFileSync(logPath, snapshotPath);
   } catch (err) {
@@ -590,22 +898,20 @@ export function rotateLogFile(
     );
     return false;
   }
-  // Durably persist the snapshot before destroying the source.
-  let snapshotBytes = -1;
-  try {
-    const fd = fs.openSync(snapshotPath, "r");
-    try {
-      fs.fsyncSync(fd);
-      snapshotBytes = fs.fstatSync(fd).size;
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch (err) {
-    process.stderr.write(
-      `[${tag}] ERROR: could not fsync snapshot ${snapshotPath}; leaving active log intact to avoid data loss: ${(err as Error).message}\n`,
-    );
-    return false;
-  }
+  // Durably persist the snapshot before destroying the source, and measure
+  // it — the truncate gate below needs its size.
+  //
+  // Three syscalls, three different causes, ONE diagnostic, so the
+  // diagnostic names which one failed (#3600 round-7, L3: an `fstat`
+  // failure used to be reported as "could not fsync", pointing an operator
+  // at durability when the problem was measurement). Returning `null`
+  // rather than a sentinel size is the other half of that finding: a
+  // `-1` that every failure path skips over is a degraded mode that cannot
+  // occur, and a `snapshotBytes >= 0` test downstream reads as a guard
+  // against something reachable. It is not, so there is no such test and
+  // no such value — a failure returns here.
+  const snapshotBytes = fsyncAndMeasure(snapshotPath, logPath, tag);
+  if (snapshotBytes === null) return false;
   // Best-effort dirent persist — non-fatal, rotation is idempotent.
   try {
     const dirFd = fs.openSync(path.dirname(snapshotPath), "r");
@@ -624,8 +930,9 @@ export function rotateLogFile(
   // module's standing preference over losing rows.
   if (!held(`truncate ${logPath}`)) return false;
   // A SECOND, DATA-BASED checkpoint on the one irreversible step (#3600
-  // round-6, H2). It narrows the truncate gap; it does not close it —
-  // nothing here can, and the tests pin both halves of that.
+  // round-6, H2), the twin of the pre-copy gate above. It narrows the
+  // truncate gap; it does not close it — nothing here can, and the tests
+  // pin both halves of that.
   //
   // Why a second one at all: the truncate gap is the only gap with no
   // NEXT checkpoint to catch what slipped through, because this is the
@@ -651,8 +958,17 @@ export function rotateLogFile(
   //     honest outcome including the `true` return, in
   //     `log-rotation-race.test.ts`, "destroys the peer's rows when the
   //     reclaim lands in the truncate gap".
-  //   · a peer that rotates AND re-appends more than `snapshotBytes`
-  //     before we stat is invisible to a length test.
+  //   · a peer that rotates AND re-appends AT LEAST `snapshotBytes` before
+  //     we stat is invisible to a length test — the comparison below is
+  //     strict, so landing on exactly `snapshotBytes` passes too, not only
+  //     overshooting it (#3600 round-7, L2). Strict is the correct
+  //     comparison, not an oversight: in the ordinary rotation nothing is
+  //     appended between the copy and here and the two sizes are EQUAL, so
+  //     `<=` would decline every rotation this module performs. Both sides
+  //     are asserted — "rotates normally when the lock is still ours"
+  //     fails if this becomes `<=`, and "the truncate gate is blind to a
+  //     peer that re-appends exactly what we snapshotted" fails if this
+  //     bullet is written as "more than".
   let liveBytes: number;
   try {
     liveBytes = fs.statSync(logPath).size;
@@ -662,7 +978,7 @@ export function rotateLogFile(
     );
     return false;
   }
-  if (snapshotBytes >= 0 && liveBytes < snapshotBytes) {
+  if (liveBytes < snapshotBytes) {
     process.stderr.write(
       `[${tag}] WARN: active log ${logPath} shrank from ${snapshotBytes} to ${liveBytes} bytes after we snapshotted it; another rotator truncated it and these rows are its, not ours — declining to truncate\n`,
     );
@@ -686,9 +1002,10 @@ export function rotateLogFile(
   // it was" (every other decline path, and the tests on them, depend on
   // that reading), and neither half is true here — we did snapshot and we
   // did truncate. Returning `false` would trade one wrong answer for a
-  // worse one. Both live callers discard the value
-  // (`src/host-control/server.ts`, `src/web/webhook-handler.ts`), so this
-  // stderr line, not the boolean, is the operator-visible channel.
+  // worse one. Every caller discards the value and no wrapper propagates
+  // it any more (enumerated in this function's doc block, #3600 round-7,
+  // L4), so this stderr line, not the boolean, is the operator-visible
+  // channel.
   if (stillHeld && !stillHeld()) {
     process.stderr.write(
       `[${tag}] ERROR: truncated ${logPath} after our rotation lock was reclaimed; rows another rotator wrote between our size check and our truncate are LOST\n`,

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -1,0 +1,188 @@
+/**
+ * log-rotation — one size-based rotation primitive for every append-only
+ * log this codebase owns.
+ *
+ * Extracted from `src/vault/broker/audit-log.ts` (issue #2792 item B /
+ * #2953 / #2955), which had the only correct implementation. Three other
+ * logs were appending without ANY bound:
+ *
+ *   - `<agent>/telegram/webhook-events.jsonl` (src/web/webhook-gateway-record.ts)
+ *   - `~/.switchroom/host-control-audit.log` (src/host-control/server.ts)
+ *
+ * Rather than grow a third and fourth copy of the copy/fsync/truncate
+ * dance, both now call into here, and the vault broker delegates to it.
+ *
+ * ── Why copy-then-truncate rather than rename ────────────────────────
+ * In the deployed topology these logs are bind-mounted into containers as
+ * SINGLE FILES (not their parent directory) — e.g. the hostd audit log is
+ * visible to admin agents at `/host-home/.switchroom/host-control-audit.log`,
+ * and the vault audit log is mounted file-wise into the broker container.
+ * A single-file bind mount makes the path a mount point inside that
+ * container's mount namespace, and `rename(2)` cannot replace an active
+ * mount point: it fails EBUSY on every attempt and the log grows forever
+ * (issue #2953). Copying the bytes out to `<path>.1` and then
+ * `ftruncate`-ing the original back to zero keeps the active inode (and
+ * therefore the mount, mode, and any open O_APPEND fd) in place, so it
+ * works whether the operator mounts the file or its parent directory.
+ *
+ * The `.1 … .maxFiles` generations are ordinary files created by this
+ * module, never mount points, so shifting THOSE with `rename` is fine.
+ *
+ * ── Durability ───────────────────────────────────────────────────────
+ * `copyFileSync` returning does not mean the bytes are on stable storage.
+ * Truncate is an explicitly data-destroying op, so the snapshot is
+ * fsync'd (and its parent dir best-effort fsync'd) BEFORE the active file
+ * is truncated. Every failure path leaves the active file intact — we
+ * would rather keep growing than lose rows.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface RotateOptions {
+  /** Rotate when the active file is >= this many bytes. <= 0 disables. */
+  maxBytes: number;
+  /** How many `<path>.N` generations to retain. Minimum 1. */
+  maxFiles: number;
+  /** Prefix for stderr diagnostics, e.g. "vault-audit". */
+  tag: string;
+}
+
+/**
+ * Rotate `<path>` unconditionally: drop `<path>.<maxFiles>`, shift
+ * `<path>.(n-1)` → `<path>.n`, snapshot `<path>` → `<path>.1`, truncate
+ * `<path>` in place.
+ *
+ * Best-effort: returns `false` (and writes a diagnostic to stderr) if the
+ * rotation could not complete, in which case the active file is left
+ * exactly as it was. Never throws.
+ */
+export function rotateLogFile(
+  logPath: string,
+  maxFiles: number,
+  tag: string,
+): boolean {
+  const keep = Math.max(1, Math.floor(maxFiles));
+  // Delete the oldest retained generation — it falls off the window.
+  const oldest = `${logPath}.${keep}`;
+  if (fs.existsSync(oldest)) {
+    try {
+      fs.unlinkSync(oldest);
+    } catch (err) {
+      process.stderr.write(
+        `[${tag}] ERROR: could not drop oldest rotation ${oldest}: ${(err as Error).message}\n`,
+      );
+    }
+  }
+  // Shift .(n-1) → .n. Ordinary files; rename is safe.
+  for (let n = keep - 1; n >= 1; n--) {
+    const from = `${logPath}.${n}`;
+    const to = `${logPath}.${n + 1}`;
+    if (!fs.existsSync(from)) continue;
+    try {
+      fs.renameSync(from, to);
+    } catch (err) {
+      process.stderr.write(
+        `[${tag}] ERROR: could not rotate ${from} → ${to}: ${(err as Error).message}\n`,
+      );
+      return false;
+    }
+  }
+  const snapshotPath = `${logPath}.1`;
+  try {
+    fs.copyFileSync(logPath, snapshotPath);
+  } catch (err) {
+    process.stderr.write(
+      `[${tag}] ERROR: could not snapshot active log ${logPath} → ${snapshotPath}: ${(err as Error).message}\n`,
+    );
+    return false;
+  }
+  // Durably persist the snapshot before destroying the source.
+  try {
+    const fd = fs.openSync(snapshotPath, "r");
+    try {
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch (err) {
+    process.stderr.write(
+      `[${tag}] ERROR: could not fsync snapshot ${snapshotPath}; leaving active log intact to avoid data loss: ${(err as Error).message}\n`,
+    );
+    return false;
+  }
+  // Best-effort dirent persist — non-fatal, rotation is idempotent.
+  try {
+    const dirFd = fs.openSync(path.dirname(snapshotPath), "r");
+    try {
+      fs.fsyncSync(dirFd);
+    } finally {
+      fs.closeSync(dirFd);
+    }
+  } catch {
+    /* some filesystems refuse fsync on directories */
+  }
+  try {
+    fs.truncateSync(logPath, 0);
+  } catch (err) {
+    process.stderr.write(
+      `[${tag}] ERROR: could not truncate active log ${logPath}: ${(err as Error).message}\n`,
+    );
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Stat `<path>` and rotate it if it has reached `maxBytes`. Returns true
+ * iff a rotation actually happened. A missing file, a stat failure, or a
+ * non-positive `maxBytes` are all no-ops (never throws) — rotation is a
+ * housekeeping concern and must never break the write path it guards.
+ */
+export function maybeRotateLogFile(
+  logPath: string,
+  opts: RotateOptions,
+): boolean {
+  if (!(opts.maxBytes > 0)) return false;
+  let size: number;
+  try {
+    size = fs.statSync(logPath).size;
+  } catch {
+    return false; // not created yet (or unreadable) — nothing to rotate
+  }
+  if (size < opts.maxBytes) return false;
+  return rotateLogFile(logPath, opts.maxFiles, opts.tag);
+}
+
+/**
+ * Resolve a `{maxBytes, maxFiles}` pair from explicit options, then env
+ * overrides, then defaults. `maxBytes === 0` means "unset" (fall through);
+ * a NEGATIVE explicit/env value disables rotation entirely — the operator
+ * escape hatch, matching the vault broker's long-standing semantics.
+ */
+export function resolveRotationConfig(args: {
+  maxBytes?: number;
+  maxFiles?: number;
+  envBytesVar: string;
+  envFilesVar: string;
+  defaultBytes: number;
+  defaultFiles: number;
+  env?: NodeJS.ProcessEnv;
+}): { maxBytes: number; maxFiles: number } {
+  const env = args.env ?? process.env;
+  const envBytes = Number(env[args.envBytesVar]);
+  const envFiles = Number(env[args.envFilesVar]);
+  const maxBytes =
+    args.maxBytes !== undefined && args.maxBytes !== 0
+      ? args.maxBytes
+      : Number.isFinite(envBytes) && envBytes !== 0
+        ? envBytes
+        : args.defaultBytes;
+  const maxFiles =
+    args.maxFiles !== undefined && args.maxFiles > 0
+      ? args.maxFiles
+      : Number.isFinite(envFiles) && envFiles > 0
+        ? envFiles
+        : args.defaultFiles;
+  return { maxBytes, maxFiles };
+}

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -82,11 +82,13 @@ export interface RotateOptions {
    * the size is re-checked while holding the lock, so the loser sees the
    * freshly-truncated file and declines.
    *
-   * BOUND, not merely documented convention: the lock is proven mutually
-   * exclusive for at most TWO concurrent rotators per path. At three the
-   * stale-lock reclaim has a real window (see {@link withRotateLock}'s
-   * residual). Adding a third writer process to a locked log is a design
-   * change, not a config change, and must revisit that analysis first.
+   * NOT unconditional mutual exclusion, at any writer count. A holder
+   * that overruns {@link ROTATE_LOCK_STALE_MS} is indistinguishable from
+   * a dead one, so a peer can legitimately reclaim a LIVE lock and enter
+   * `fn()` alongside it — reproduced at two writers (#3600 round-4, H1).
+   * What bounds the damage is the in-critical-section inode guard: a
+   * rotator whose lock was reclaimed aborts before it destroys anything
+   * (see {@link withRotateLock}'s residual for what remains).
    *
    * Single-writer logs (vault audit, hostd audit — both serialized
    * in-process, see `audit-hashchain.ts` single-writer-process contract)
@@ -133,80 +135,63 @@ const ROTATE_LOCK_STALE_MS = 30_000;
  * own lock was reclaimed out from under us (we overran the threshold) we
  * cannot delete the new holder's lock on the way out.
  *
- * Residual, stated honestly rather than papered over with an invariant
- * that is not true. The breach is at step 1, not step 3: `rename` moves
- * the lock off `lockPath`, so for the whole rename→claim interval the
- * path is genuinely UNLOCKED and any arrival can legitimately
- * `open(wx)` it. With three processes that is reachable — A parks a
- * stale lock and reclaims; C arrives in A's interval and takes the path;
- * B, which parked a live lock and is unwinding its step-3 mismatch, then
- * runs its cleanup `unlinkSync(parked)` on what is now A's only link.
- * A and C are both inside `fn()`, and `linkSync` is not what does the
- * damage — it EEXISTs and cannot clobber. The cost is NOT one lost
- * cycle: both rotators re-check `overCap` before either truncates, so
- * both proceed, and at maxFiles=2 the second `unlinkSync(<log>.2)`
- * destroys real history while its zero-byte copy lands on the first's
- * fresh `.1`. Prior generation gone AND current snapshot zeroed — the
- * exact outcome {@link RotateOptions.lock} calls strictly worse than the
- * unlocked copy/truncate window.
+ * ── Residual, stated honestly ────────────────────────────────────────
+ * The breach is at the STALENESS TEST. Step 2 can prove the parked file
+ * is the same inode we judged stale and is still past the threshold; it
+ * CANNOT distinguish "stale because the holder died" from "stale because
+ * the holder is slow". The lock mtime is stamped once, by `open(wx)`,
+ * and never refreshed, so a live holder whose rotation overruns
+ * {@link ROTATE_LOCK_STALE_MS} ages into reclaimable. That needs only
+ * TWO processes (#3600 round-4, H1, reproduced): A holds and overruns; D
+ * EEXISTs, judges stale, parks, verifies `mine === true` — both clauses
+ * are true of A's LIVE lock — claims, and is inside `fn()` alongside A.
  *
- * It is UNREACHABLE for the only `lock: true` log. That is
- * `rotateWebhookLogIfNeeded` (`src/web/webhook-handler.ts:196`), which
- * has exactly two writer processes per path — `handleWebhookIngest` in
- * the web container and `recordWebhookEvent` in the agent gateway — and
- * the interleaving needs a third. Raising any locked log to three
- * concurrent writers is therefore a DESIGN change, not a config change:
- * it re-opens this window and must revisit this comment. Closing it in
- * code would need an identity-checked rename (POSIX has none) or a
- * kernel `flock`/`fcntl` lease (not in Node's stdlib), so it is
- * documented rather than fixed.
+ * Left unguarded the outcome is the one {@link RotateOptions.lock} calls
+ * strictly worse than the unlocked window: D rotates to completion, then
+ * A's shift renames D's fresh `.1` over `.2` and A copies the
+ * now-truncated active file over `.1`. `.1` zero bytes, prior generation
+ * gone.
  *
- * Everything at two contenders — the ordinary two-reclaimer race the
- * reviewer reproduced — is closed here, and the under-lock size re-check
- * in {@link maybeRotateLogFile} is the second, independent guard against
- * copying an already-rotated (empty) file over a good `.1`.
+ * The close is therefore NOT to prevent the double entry — POSIX has no
+ * identity-checked reclaim and Node exposes no `flock`/`fcntl` lease —
+ * but to make the loser HARMLESS. `fn` receives a `stillHeld()`
+ * predicate that re-asserts the same inode identity the release guard
+ * uses, and {@link rotateLogFile} calls it at the head of each of its
+ * three destructive phases. An overrun rotator that lost its lock
+ * declines instead of clobbering, so H1 leaves the reclaimer's `.1` and
+ * the shifted history intact.
+ *
+ * What still remains, precisely — this is a narrowing, not a proof of
+ * safety:
+ *
+ *   - `stillHeld()` is a `stat` and the destructive call after it is a
+ *     separate syscall. A reclaim landing in that instruction-scale gap
+ *     is not caught for the phase it guards — though the NEXT checkpoint
+ *     does catch it, so at most one phase proceeds unserialized. The
+ *     window shrinks from "the whole rotation" to "between two adjacent
+ *     syscalls", but it is not zero.
+ *   - If `fstat` on our own lock fd failed, `ourIno` is null and
+ *     `stillHeld()` returns true — we cannot verify, and refusing to
+ *     ever rotate is the worse failure.
+ *
+ * Refreshing the mtime from inside `fn()` was considered as a complement
+ * and NOT taken. It cannot be periodic: rotation is entirely synchronous
+ * `fs.*Sync` and blocks the loop, so no timer fires inside it. It would
+ * be one or two fixed stamps, which narrows the aging window without
+ * closing it (a copy slower than the threshold still ages past the last
+ * stamp), while every second it defers staleness is a second a genuinely
+ * crashed holder wedges the log. A heuristic layered on a deterministic
+ * guard, buying nothing the guard does not already hold and costing a
+ * `utimes` per rotation plus a worse crash-recovery bound.
+ *
+ * The under-lock size re-check in {@link maybeRotateLogFile} is the
+ * second, independent guard against copying an already-rotated (empty)
+ * file over a good `.1`.
  */
-/**
- * Reap `<lockPath>.stale.<pid>.<rand>` files stranded by a crash between
- * the reclaim's `rename` and its cleanup `unlink` (#3600 round-3, L2).
- * Nothing else globs these names, so without this they accumulate one per
- * crash-in-window, forever, in the agent's telegram dir.
- *
- * Only parks whose mtime is already past {@link ROTATE_LOCK_STALE_MS} are
- * taken, and `keep` (our own, this reclaim) is always skipped. A peer
- * mid-reclaim can hold an eligible park — reaping it makes that peer's
- * step-2 stat fail, so it declines and takes no lock. That is a missed
- * rotation cycle at worst; it cannot wedge the path or produce two
- * rotators.
- *
- * Entirely best-effort: every failure is swallowed, so this can never
- * throw out of the reclaim it runs inside.
- */
-function sweepStaleParks(lockPath: string, keep: string): void {
-  try {
-    const dir = path.dirname(lockPath);
-    const prefix = `${path.basename(lockPath)}.stale.`;
-    const cutoff = Date.now() - ROTATE_LOCK_STALE_MS;
-    for (const name of fs.readdirSync(dir)) {
-      if (!name.startsWith(prefix)) continue;
-      const full = path.join(dir, name);
-      if (full === keep) continue;
-      try {
-        if (fs.statSync(full).mtimeMs > cutoff) continue;
-        fs.unlinkSync(full);
-      } catch {
-        /* raced with a peer's reclaim or another sweeper — leave it */
-      }
-    }
-  } catch {
-    /* unreadable dir — sweeping is housekeeping, never fatal */
-  }
-}
-
 function withRotateLock<T>(
   logPath: string,
   tag: string,
-  fn: () => T,
+  fn: (stillHeld: () => boolean) => T,
 ): T | null {
   const lockPath = `${logPath}.rotate.lock`;
   let fd: number;
@@ -273,24 +258,36 @@ function withRotateLock<T>(
     } catch {
       /* best-effort — the park name is unique to us */
     }
-    // We are the one process known to be reclaiming this path right now:
-    // the cheapest safe moment to collect parks other crashes stranded.
-    sweepStaleParks(lockPath, parked);
     try {
       fd = fs.openSync(lockPath, "wx", 0o600);
     } catch {
       return null; // a fresh arrival took the lock between our rename and this
     }
+    // Sweep only once the claim has SUCCEEDED (#3600 round-4, L1). Before
+    // the `open(wx)` above we hold nothing — `lockPath` does not exist —
+    // and a readdir plus N stat/unlink there would widen the rename→claim
+    // interval this comment names as the breach, from ~2 syscalls to
+    // 2 + O(parks). Here the path is locked and the sweep is free.
+    sweepStaleParks(lockPath);
   }
-  // Identify the lock we hold, so release can prove it is still ours.
+  // Identify the lock we hold, so release — and the critical section
+  // itself — can prove it is still ours.
   let ourIno: number | null = null;
   try {
     ourIno = fs.fstatSync(fd).ino;
   } catch {
     /* leave null — release then falls back to not unlinking */
   }
+  const stillHeld = (): boolean => {
+    if (ourIno === null) return true; // unverifiable; see the residual
+    try {
+      return fs.statSync(lockPath).ino === ourIno;
+    } catch {
+      return false; // lock gone — we are certainly not holding it
+    }
+  };
   try {
-    return fn();
+    return fn(stillHeld);
   } finally {
     try {
       fs.closeSync(fd);
@@ -308,6 +305,44 @@ function withRotateLock<T>(
 }
 
 /**
+ * Reap `<lockPath>.stale.<pid>.<rand>` files stranded by a crash between
+ * the reclaim's `rename` and its cleanup `unlink` (#3600 round-3, L2).
+ * Nothing else globs these names, so without this they accumulate one per
+ * crash-in-window, forever, in the agent's telegram dir.
+ *
+ * Only parks whose mtime is already past {@link ROTATE_LOCK_STALE_MS} are
+ * taken. There is no "keep ours" exemption: the sole caller runs this
+ * AFTER unlinking its own park and after taking the lock, so our park is
+ * gone — and in the one case it is not (that unlink failed), it IS a leak
+ * and reaping it is correct. A peer mid-reclaim can hold an eligible park
+ * — reaping it makes that peer's step-2 stat fail, so it declines and
+ * takes no lock. That is a missed rotation cycle at worst; it cannot
+ * wedge the path or produce two rotators.
+ *
+ * Entirely best-effort: every failure is swallowed, so this can never
+ * throw out of the reclaim it runs inside.
+ */
+function sweepStaleParks(lockPath: string): void {
+  try {
+    const dir = path.dirname(lockPath);
+    const prefix = `${path.basename(lockPath)}.stale.`;
+    const cutoff = Date.now() - ROTATE_LOCK_STALE_MS;
+    for (const name of fs.readdirSync(dir)) {
+      if (!name.startsWith(prefix)) continue;
+      const full = path.join(dir, name);
+      try {
+        if (fs.statSync(full).mtimeMs > cutoff) continue;
+        fs.unlinkSync(full);
+      } catch {
+        /* raced with a peer's reclaim or another sweeper — leave it */
+      }
+    }
+  } catch {
+    /* unreadable dir — sweeping is housekeeping, never fatal */
+  }
+}
+
+/**
  * Rotate `<path>` unconditionally: drop `<path>.<maxFiles>`, shift
  * `<path>.(n-1)` → `<path>.n`, snapshot `<path>` → `<path>.1`, truncate
  * `<path>` in place.
@@ -315,16 +350,44 @@ function withRotateLock<T>(
  * Best-effort: returns `false` (and writes a diagnostic to stderr) if the
  * rotation could not complete, in which case the active file is left
  * exactly as it was. Never throws.
+ *
+ * `stillHeld`, when supplied by {@link withRotateLock}, is re-asserted
+ * immediately before EVERY destructive syscall — the oldest-generation
+ * unlink, each shift rename, the `copyFileSync` that overwrites `.1`, and
+ * the `truncate` that destroys live rows (#3600 round-4, H1). A holder
+ * that overran the stale threshold can have its live lock legitimately
+ * reclaimed by a peer; if that happened we are no longer serialized
+ * against that peer, and continuing would rename its fresh `.1` off the
+ * end of the window, copy a truncated active file over it, and truncate
+ * rows written after its rotation. Declining costs one rotation cycle;
+ * continuing costs a generation of events.
+ *
+ * Per-syscall rather than once at the top because a reclaim can land at
+ * any point inside the rotation, and each check is one `stat` against a
+ * handful of syscalls. It is a narrowing, not a proof — a reclaim landing
+ * between a check and the syscall it guards is still uncaught (the next
+ * check catches it, so at most one syscall proceeds unserialized). See
+ * {@link withRotateLock}'s residual.
  */
 export function rotateLogFile(
   logPath: string,
   maxFiles: number,
   tag: string,
+  stillHeld?: () => boolean,
 ): boolean {
   const keep = Math.max(1, Math.floor(maxFiles));
+  /** True iff we may still destroy things; warns once per refusal. */
+  const held = (what: string): boolean => {
+    if (!stillHeld || stillHeld()) return true;
+    process.stderr.write(
+      `[${tag}] WARN: rotation lock for ${logPath} was reclaimed while we were inside it; declining to ${what}\n`,
+    );
+    return false;
+  };
   // Delete the oldest retained generation — it falls off the window.
   const oldest = `${logPath}.${keep}`;
   if (fs.existsSync(oldest)) {
+    if (!held(`drop ${oldest}`)) return false;
     try {
       fs.unlinkSync(oldest);
     } catch (err) {
@@ -338,6 +401,7 @@ export function rotateLogFile(
     const from = `${logPath}.${n}`;
     const to = `${logPath}.${n + 1}`;
     if (!fs.existsSync(from)) continue;
+    if (!held(`shift ${from} → ${to}`)) return false;
     try {
       fs.renameSync(from, to);
     } catch (err) {
@@ -348,6 +412,9 @@ export function rotateLogFile(
     }
   }
   const snapshotPath = `${logPath}.1`;
+  // The copy OVERWRITES `.1` — if a peer reclaimed during the shift above,
+  // that `.1` is the peer's fresh snapshot, not ours to replace.
+  if (!held(`overwrite ${snapshotPath}`)) return false;
   try {
     fs.copyFileSync(logPath, snapshotPath);
   } catch (err) {
@@ -381,6 +448,12 @@ export function rotateLogFile(
   } catch {
     /* some filesystems refuse fsync on directories */
   }
+  // Re-assert identity before the one irreversible step. A reclaim that
+  // landed during the copy/fsync above means a peer already snapshotted
+  // and truncated, and the rows here now are rows written AFTER that —
+  // never ours to destroy. Leaving the active file intact is this
+  // module's standing preference over losing rows.
+  if (!held(`truncate ${logPath}`)) return false;
   try {
     fs.truncateSync(logPath, 0);
   } catch (err) {
@@ -412,9 +485,9 @@ export function maybeRotateLogFile(
   // have rotated between our stat above and our acquiring the lock, and
   // rotating the now-empty active file would copy zero bytes over a good
   // `.1` and shift the real history off the end of the window.
-  const rotated = withRotateLock(logPath, opts.tag, () => {
+  const rotated = withRotateLock(logPath, opts.tag, (stillHeld) => {
     if (!overCap(logPath, opts.maxBytes)) return false;
-    return rotateLogFile(logPath, opts.maxFiles, opts.tag);
+    return rotateLogFile(logPath, opts.maxFiles, opts.tag, stillHeld);
   });
   return rotated === true;
 }

--- a/src/util/log-rotation.ts
+++ b/src/util/log-rotation.ts
@@ -13,17 +13,34 @@
  * dance, both now call into here, and the vault broker delegates to it.
  *
  * ── Why copy-then-truncate rather than rename ────────────────────────
- * In the deployed topology these logs are bind-mounted into containers as
- * SINGLE FILES (not their parent directory) — e.g. the hostd audit log is
- * visible to admin agents at `/host-home/.switchroom/host-control-audit.log`,
- * and the vault audit log is mounted file-wise into the broker container.
- * A single-file bind mount makes the path a mount point inside that
- * container's mount namespace, and `rename(2)` cannot replace an active
- * mount point: it fails EBUSY on every attempt and the log grows forever
- * (issue #2953). Copying the bytes out to `<path>.1` and then
- * `ftruncate`-ing the original back to zero keeps the active inode (and
- * therefore the mount, mode, and any open O_APPEND fd) in place, so it
- * works whether the operator mounts the file or its parent directory.
+ * `rename` is wrong for every log this module serves — but for a
+ * DIFFERENT reason per log. State them precisely, because "rename works
+ * fine on the host" is true for the hostd log and will otherwise invite
+ * an "optimisation" back to rename (#3600 review):
+ *
+ *   - Vault broker audit log: the active file is bind-mounted into the
+ *     broker container as a SINGLE FILE, making the path a mount point in
+ *     that namespace. `rename(2)` cannot replace an active mount point —
+ *     it fails EBUSY on every attempt and the log grows forever (#2953).
+ *
+ *   - hostd audit log: hostd is the source-side writer, so EBUSY is NOT
+ *     the operative constraint (rename would succeed on the host). The
+ *     decisive reason is the READERS: every admin agent bind-mounts this
+ *     file `:ro` as a single file (`src/cli/apply.ts:1107-1116` pre-creates
+ *     it precisely so that `:ro` mount source exists), and hostd writes it
+ *     through its own `/host-home` mount. A bind mount pins an INODE, not
+ *     a path — renaming the active file would leave every one of those
+ *     mounts permanently attached to the old, rotated inode. `/audit
+ *     hostd` in each agent would silently freeze at the rotation instant,
+ *     forever, with no error surfaced anywhere.
+ *
+ *   - Sidecar supervisor logs: the supervised child holds an open
+ *     `O_APPEND` fd on the path; rename orphans that fd and the live file
+ *     stops growing (the copytruncate rationale in start.sh.hbs).
+ *
+ * Copying the bytes out to `<path>.1` and then `ftruncate`-ing the
+ * original back to zero keeps the active INODE — and therefore every
+ * mount, every open fd, and the mode — in place, satisfying all three.
  *
  * The `.1 … .maxFiles` generations are ordinary files created by this
  * module, never mount points, so shifting THOSE with `rename` is fine.
@@ -46,6 +63,92 @@ export interface RotateOptions {
   maxFiles: number;
   /** Prefix for stderr diagnostics, e.g. "vault-audit". */
   tag: string;
+  /**
+   * Serialize rotation against OTHER PROCESSES via an `O_CREAT|O_EXCL`
+   * lockfile at `<path>.rotate.lock` (#3600 review, finding 1).
+   *
+   * Required whenever two processes can append to the same log. The
+   * webhook event log is exactly that: `handleWebhookIngest` runs in the
+   * web container and `recordWebhookEvent` in the agent's gateway, both
+   * writing `<agent>/telegram/webhook-events.jsonl`. Without a lock they
+   * can both stat an over-cap file, A rotates (`.1` ← copy, active
+   * truncated), then B rotates the NOW-EMPTY active file — shifting the
+   * real `.1` to `.2` and copying zero bytes over `.1`. With maxFiles=2
+   * that discards a whole generation of events; the empty-copy is
+   * strictly worse than the ordinary copy/truncate race window.
+   *
+   * The lock closes it twice over: only one rotator runs at a time, AND
+   * the size is re-checked while holding the lock, so the loser sees the
+   * freshly-truncated file and declines.
+   *
+   * Single-writer logs (vault audit, hostd audit — both serialized
+   * in-process, see `audit-hashchain.ts` single-writer-process contract)
+   * do not need it and leave this false.
+   */
+  lock?: boolean;
+}
+
+/** Stale-lock threshold: a rotation is a copy + fsync + truncate, tens of
+ *  ms even for 32 MiB. A lock older than this is a crashed holder. */
+const ROTATE_LOCK_STALE_MS = 30_000;
+
+/**
+ * Run `fn` while holding an `O_CREAT|O_EXCL` lockfile beside the log.
+ * Returns `null` if the lock could not be taken (another process is
+ * mid-rotation) — the caller treats that as "someone else handled it".
+ *
+ * A lock left behind by a killed process is reclaimed after
+ * {@link ROTATE_LOCK_STALE_MS}; the reclaim is itself racy-safe because
+ * the reclaimer re-attempts the same `O_EXCL` create and only one can win.
+ */
+function withRotateLock<T>(
+  logPath: string,
+  tag: string,
+  fn: () => T,
+): T | null {
+  const lockPath = `${logPath}.rotate.lock`;
+  let fd: number;
+  try {
+    fd = fs.openSync(lockPath, "wx", 0o600);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+      process.stderr.write(
+        `[${tag}] ERROR: could not take rotation lock ${lockPath}: ${(err as Error).message}\n`,
+      );
+      return null;
+    }
+    // Held. Reclaim only if it is stale (holder died mid-rotation).
+    let age = 0;
+    try {
+      age = Date.now() - fs.statSync(lockPath).mtimeMs;
+    } catch {
+      return null; // vanished under us — the holder just finished
+    }
+    if (age < ROTATE_LOCK_STALE_MS) return null;
+    process.stderr.write(
+      `[${tag}] WARN: reclaiming stale rotation lock ${lockPath} (${Math.round(age / 1000)}s old)\n`,
+    );
+    try {
+      fs.unlinkSync(lockPath);
+      fd = fs.openSync(lockPath, "wx", 0o600);
+    } catch {
+      return null; // someone else won the reclaim
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      fs.closeSync(fd);
+    } catch {
+      /* best-effort */
+    }
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {
+      /* best-effort */
+    }
+  }
 }
 
 /**
@@ -144,14 +247,29 @@ export function maybeRotateLogFile(
   opts: RotateOptions,
 ): boolean {
   if (!(opts.maxBytes > 0)) return false;
-  let size: number;
+  if (!overCap(logPath, opts.maxBytes)) return false;
+  if (!opts.lock) {
+    return rotateLogFile(logPath, opts.maxFiles, opts.tag);
+  }
+  // Multi-writer log: take the cross-process lock and RE-CHECK the size
+  // under it. The recheck is the part that matters — a racing process may
+  // have rotated between our stat above and our acquiring the lock, and
+  // rotating the now-empty active file would copy zero bytes over a good
+  // `.1` and shift the real history off the end of the window.
+  const rotated = withRotateLock(logPath, opts.tag, () => {
+    if (!overCap(logPath, opts.maxBytes)) return false;
+    return rotateLogFile(logPath, opts.maxFiles, opts.tag);
+  });
+  return rotated === true;
+}
+
+/** True iff `logPath` exists and is at least `maxBytes` long. Never throws. */
+function overCap(logPath: string, maxBytes: number): boolean {
   try {
-    size = fs.statSync(logPath).size;
+    return fs.statSync(logPath).size >= maxBytes;
   } catch {
     return false; // not created yet (or unreadable) — nothing to rotate
   }
-  if (size < opts.maxBytes) return false;
-  return rotateLogFile(logPath, opts.maxFiles, opts.tag);
 }
 
 /**

--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -28,6 +28,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { chainRow, seedChain, type ChainState } from "../../util/audit-hashchain.js";
 import { safeAuditLogPath } from "./test-isolation-guard.js";
+import {
+  resolveRotationConfig,
+  rotateLogFile,
+} from "../../util/log-rotation.js";
 
 /** Operations the broker can perform. (PR-6: `approval_consume_record`
  *  and `approval_lookup_by_request` are additive members of the shared
@@ -214,21 +218,14 @@ function resolveRotation(opts: AuditLoggerOptions): {
   maxBytes: number;
   maxFiles: number;
 } {
-  const envBytes = Number(process.env.SWITCHROOM_VAULT_AUDIT_MAX_BYTES);
-  const envFiles = Number(process.env.SWITCHROOM_VAULT_AUDIT_MAX_FILES);
-  const maxBytes =
-    opts.maxBytes !== undefined && opts.maxBytes !== 0
-      ? opts.maxBytes
-      : Number.isFinite(envBytes) && envBytes !== 0
-        ? envBytes
-        : DEFAULT_AUDIT_MAX_BYTES;
-  const maxFiles =
-    opts.maxFiles !== undefined && opts.maxFiles > 0
-      ? opts.maxFiles
-      : Number.isFinite(envFiles) && envFiles > 0
-        ? envFiles
-        : DEFAULT_AUDIT_MAX_FILES;
-  return { maxBytes, maxFiles };
+  return resolveRotationConfig({
+    maxBytes: opts.maxBytes,
+    maxFiles: opts.maxFiles,
+    envBytesVar: "SWITCHROOM_VAULT_AUDIT_MAX_BYTES",
+    envFilesVar: "SWITCHROOM_VAULT_AUDIT_MAX_FILES",
+    defaultBytes: DEFAULT_AUDIT_MAX_BYTES,
+    defaultFiles: DEFAULT_AUDIT_MAX_FILES,
+  });
 }
 
 /**
@@ -236,119 +233,18 @@ function resolveRotation(opts: AuditLoggerOptions): {
  * past `maxFiles`, then snapshot `<path>` → `<path>.1` and truncate the
  * active file back to zero bytes IN PLACE.
  *
- * Why copy-then-truncate rather than rename (issue #2953): in the deployed
- * topology the active log is bind-mounted into the broker container as a
- * SINGLE FILE (not its parent directory), which makes `<path>` a mount
- * point inside the container's mount namespace. `rename(2)` cannot replace
- * an active mount point, so `rename(<path>, <path>.1)` fails with EBUSY on
- * every attempt and the log grows unbounded. Copying the bytes out to
- * `<path>.1` and then `ftruncate`-ing the original to length 0 keeps the
- * active inode/mount point in place, so it works regardless of whether the
- * operator mounts the file or its parent directory.
+ * The mechanism (copy → fsync → ftruncate, never rename, because the
+ * active log is a single-file bind mount inside the broker container —
+ * issue #2953/#2955) now lives in `src/util/log-rotation.ts` so the hostd
+ * audit log and the per-agent webhook event log share it rather than
+ * growing their own copies. This wrapper only pins the diagnostic tag.
  *
- * The active file is truncated (not deleted/recreated), so its inode, mode,
- * and — critically — its bind mount survive. The in-process hash chain is
- * intentionally NOT reset, so the first row appended after truncation links
- * back to the last row now living in `<path>.1` and cross-file continuity
- * holds. Best-effort: any failure is reported and rotation is skipped (the
- * current file keeps growing rather than losing data).
- *
- * NOTE: the `.1 … .maxFiles` rotated files are ordinary files created by
- * this function inside the log's directory, so shifting them with `rename`
- * is safe — only the active `<path>` is (potentially) a mount point.
+ * The in-process hash chain is intentionally NOT reset, so the first row
+ * appended after truncation links back to the last row now living in
+ * `<path>.1` and cross-file tamper-evidence continuity holds.
  */
 function rotateAuditLog(logPath: string, maxFiles: number): void {
-  // Delete the oldest retained file if it exists — it would fall off the
-  // window after the shift.
-  const oldest = `${logPath}.${maxFiles}`;
-  if (fs.existsSync(oldest)) {
-    try {
-      fs.unlinkSync(oldest);
-    } catch (err) {
-      process.stderr.write(
-        `[vault-audit] ERROR: could not drop oldest rotation ${oldest}: ${(err as Error).message}\n`,
-      );
-    }
-  }
-  // Shift .(n-1) → .n for n = maxFiles down to 2. These are ordinary files
-  // (never mount points), so rename is fine.
-  for (let n = maxFiles - 1; n >= 1; n--) {
-    const from = `${logPath}.${n}`;
-    const to = `${logPath}.${n + 1}`;
-    if (!fs.existsSync(from)) continue;
-    try {
-      fs.renameSync(from, to);
-    } catch (err) {
-      process.stderr.write(
-        `[vault-audit] ERROR: could not rotate ${from} → ${to}: ${(err as Error).message}\n`,
-      );
-      return;
-    }
-  }
-  // Finally, snapshot active → .1 by COPYING the bytes, then truncate the
-  // active file in place. Copy first: if the copy fails we leave the active
-  // file untouched (grow rather than lose rows). Only after the snapshot is
-  // durably on stable storage do we truncate the live file back to zero
-  // length.
-  //
-  // DURABILITY (#2955 review): `copyFileSync` returning does NOT mean the
-  // bytes are on stable storage — they may sit in the page cache. Truncate
-  // is an explicit data-destroying op, so without an fsync of the snapshot
-  // between copy and truncate, a host-crash window loses rows AND leaves
-  // the active file zeroed. fsync the `.1` snapshot (and best-effort the
-  // parent dir) before truncating — matches `vault.ts`'s durability
-  // discipline and makes the "safely on disk" claim below literally true.
-  const snapshotPath = `${logPath}.1`;
-  try {
-    fs.copyFileSync(logPath, snapshotPath);
-  } catch (err) {
-    process.stderr.write(
-      `[vault-audit] ERROR: could not snapshot active audit log ${logPath} → ${snapshotPath}: ${(err as Error).message}\n`,
-    );
-    return;
-  }
-  // Durably persist the snapshot before destroying the source. Best-effort:
-  // some filesystems reject fsync, but a failed fsync here is still safer
-  // than skipping it — we proceed to truncate only when the snapshot has
-  // been open + flushed. If the fsync throws, leave the active file intact
-  // (grow rather than risk losing rows to a truncate on an unflushed copy).
-  try {
-    const fd = fs.openSync(snapshotPath, "r");
-    try {
-      fs.fsyncSync(fd);
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch (err) {
-    process.stderr.write(
-      `[vault-audit] ERROR: could not fsync audit snapshot ${snapshotPath}; leaving active log intact to avoid data loss: ${(err as Error).message}\n`,
-    );
-    return;
-  }
-  // Best-effort fsync of the parent dir so the snapshot's dirent update is
-  // persisted (POSIX permits a post-copy crash to lose the dirent otherwise).
-  // A failure here is non-fatal — the data is flushed; only the directory
-  // entry update is at risk, and re-running rotation is idempotent.
-  try {
-    const dirFd = fs.openSync(path.dirname(snapshotPath), "r");
-    try {
-      fs.fsyncSync(dirFd);
-    } finally {
-      fs.closeSync(dirFd);
-    }
-  } catch {
-    /* best-effort: some filesystems refuse fsync on directories */
-  }
-  try {
-    // truncate(2) resets length to 0 while preserving the inode, mode, and
-    // any bind mount at this path — unlike rename, which would fail EBUSY on
-    // a single-file bind mount (issue #2953).
-    fs.truncateSync(logPath, 0);
-  } catch (err) {
-    process.stderr.write(
-      `[vault-audit] ERROR: could not truncate active audit log ${logPath}: ${(err as Error).message}\n`,
-    );
-  }
+  rotateLogFile(logPath, maxFiles, "vault-audit");
 }
 
 /**

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -39,6 +39,7 @@ import {
 } from "./blocked-approvals-read.js";
 import {
   defaultAuditLogPath,
+  readAuditRaw,
   readAndFilter,
   type AuditEntry,
 } from "../host-control/audit-reader.js";
@@ -1024,7 +1025,7 @@ export async function handleGetSystemHealth(
     const logPath = defaultAuditLogPath(home);
     if (existsSync(logPath)) {
       hostd.auditLogPresent = true;
-      const raw = readFileSync(logPath, "utf-8");
+      const raw = readAuditRaw(logPath);
       // Drop read-only/health-probe verbs — agent_smoke alone is the large
       // majority of rows and buries the actual privileged mutations this
       // panel exists to surface. Read a wide window, filter, then take 10.

--- a/src/web/webhook-gateway-record.ts
+++ b/src/web/webhook-gateway-record.ts
@@ -26,6 +26,7 @@ import { join } from 'path'
 import { homedir } from 'os'
 import {
   createFileDedupStore,
+  rotateWebhookLogIfNeeded,
   type DedupStore,
 } from './webhook-handler.js'
 import {
@@ -150,6 +151,10 @@ export function recordWebhookEvent(
   const logPath = join(telegramDir, 'webhook-events.jsonl')
   try {
     mkdirSync(telegramDir, { recursive: true })
+    // Bound the log BEFORE appending (#3596). This writer had no size
+    // check and nothing ever reaped the file: on the live host it reached
+    // 121,772,086 bytes for one agent against 328 KB for the next.
+    rotateWebhookLogIfNeeded(logPath)
     const record = {
       ts: now,
       source: rec.source,

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -182,7 +182,19 @@ export function resolveWebhookLogRotation(): {
  */
 export function rotateWebhookLogIfNeeded(logPath: string): boolean {
   const { maxBytes, maxFiles } = resolveWebhookLogRotation()
-  return maybeRotateLogFile(logPath, { maxBytes, maxFiles, tag: 'webhook-log' })
+  return maybeRotateLogFile(logPath, {
+    maxBytes,
+    maxFiles,
+    tag: 'webhook-log',
+    // TWO PROCESSES write this file (#3600 review, finding 1):
+    // `handleWebhookIngest` runs in the web container and
+    // `recordWebhookEvent` in the agent's gateway. Unlike the audit logs
+    // there is no promise chain serializing them, so rotation takes a
+    // cross-process lockfile and re-checks the size while holding it —
+    // otherwise the loser of the race rotates the already-truncated file,
+    // copying 0 bytes over a `.1` that holds a full generation of events.
+    lock: true,
+  })
 }
 
 function jsonReply(

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -53,6 +53,10 @@ import {
   type WebhookSource,
 } from './webhook-verify.js'
 import type { WebhookDispatchConfig } from './webhook-dispatch.js'
+import {
+  maybeRotateLogFile,
+  resolveRotationConfig,
+} from '../util/log-rotation.js'
 import { forwardToGateway, type WebhookForwardResponse } from './webhook-ingest-client.js'
 import { EDGE_HEADER, verifyEdgeHeader } from './webhook-edge.js'
 
@@ -141,6 +145,45 @@ export interface WebhookHandlerResult {
 }
 
 const KNOWN_SOURCES: WebhookSource[] = ['github', 'generic', 'linear']
+
+/**
+ * Rotation cap for `<agent>/telegram/webhook-events.jsonl` (#3596).
+ *
+ * This file had NO bound and NO reaper: on the live host one busy agent's
+ * log reached 121,772,086 bytes while the next-busiest sat at 328 KB —
+ * ~370x, all of it on the shared, bind-mounted host disk. 8 MiB is a
+ * generous window for a log whose consumer is "the agent reads the recent
+ * tail on demand" (schema.ts:1554). Env: `SWITCHROOM_WEBHOOK_LOG_MAX_BYTES`
+ * (negative disables rotation).
+ */
+export const DEFAULT_WEBHOOK_LOG_MAX_BYTES = 8 * 1024 * 1024
+/** Rotated generations retained → total bounded at ~(2+1) × 8 MiB = 24 MiB
+ *  per agent. Env: `SWITCHROOM_WEBHOOK_LOG_MAX_FILES`. */
+export const DEFAULT_WEBHOOK_LOG_MAX_FILES = 2
+
+/** Effective webhook-log rotation config (env-overridable). */
+export function resolveWebhookLogRotation(): {
+  maxBytes: number
+  maxFiles: number
+} {
+  return resolveRotationConfig({
+    envBytesVar: 'SWITCHROOM_WEBHOOK_LOG_MAX_BYTES',
+    envFilesVar: 'SWITCHROOM_WEBHOOK_LOG_MAX_FILES',
+    defaultBytes: DEFAULT_WEBHOOK_LOG_MAX_BYTES,
+    defaultFiles: DEFAULT_WEBHOOK_LOG_MAX_FILES,
+  })
+}
+
+/**
+ * Rotate `webhook-events.jsonl` if it has hit the cap. Call immediately
+ * BEFORE each append (both writer paths: the gateway-side recorder and
+ * the legacy host-runtime handler). Best-effort — never throws, so a
+ * rotation problem can never turn a verified webhook into a 500.
+ */
+export function rotateWebhookLogIfNeeded(logPath: string): boolean {
+  const { maxBytes, maxFiles } = resolveWebhookLogRotation()
+  return maybeRotateLogFile(logPath, { maxBytes, maxFiles, tag: 'webhook-log' })
+}
 
 function jsonReply(
   status: number,
@@ -522,6 +565,9 @@ export async function handleWebhookIngest(
   const logPath = join(telegramDir, 'webhook-events.jsonl')
   try {
     mkdirSync(telegramDir, { recursive: true })
+    // Bound the log BEFORE appending (#3596) — unbounded, this file hit
+    // 121 MB on a live agent.
+    rotateWebhookLogIfNeeded(logPath)
     const record = {
       ts: now,
       source,
@@ -542,6 +588,11 @@ export async function handleWebhookIngest(
 /**
  * Read the agent's webhook event log. Used by tests; agents can also
  * call this via Bash (`cat <path>`) as documented in CLAUDE.md.
+ *
+ * Seam-aware (#3596): the log is size-rotated on write, so history lives
+ * in `<log>.1 … .N` after a rotation. Rotated generations are read
+ * oldest-first ahead of the active file, which keeps this consumer's
+ * chronological contract intact across a rotation.
  */
 export function readWebhookLog(
   agent: string,
@@ -549,7 +600,23 @@ export function readWebhookLog(
 ): Array<Record<string, unknown>> {
   const dir = (resolveAgentDir ?? ((a) => join(homedir(), '.switchroom', 'agents', a)))(agent)
   const logPath = join(dir, 'telegram', 'webhook-events.jsonl')
-  if (!existsSync(logPath)) return []
-  const lines = readFileSync(logPath, 'utf-8').split('\n').filter(Boolean)
-  return lines.map((l) => JSON.parse(l) as Record<string, unknown>)
+  const { maxFiles } = resolveWebhookLogRotation()
+  const out: Array<Record<string, unknown>> = []
+  const paths: string[] = []
+  for (let n = maxFiles; n >= 1; n--) paths.push(`${logPath}.${n}`)
+  paths.push(logPath)
+  for (const p of paths) {
+    if (!existsSync(p)) continue
+    for (const line of readFileSync(p, 'utf-8').split('\n')) {
+      if (line.length === 0) continue
+      // A rotated generation can end in a torn line if the process died
+      // mid-append; skip it rather than throwing at the consumer.
+      try {
+        out.push(JSON.parse(line) as Record<string, unknown>)
+      } catch {
+        continue
+      }
+    }
+  }
+  return out
 }

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -179,10 +179,21 @@ export function resolveWebhookLogRotation(): {
  * BEFORE each append (both writer paths: the gateway-side recorder and
  * the legacy host-runtime handler). Best-effort — never throws, so a
  * rotation problem can never turn a verified webhook into a 500.
+ *
+ * Returns nothing ON PURPOSE (#3600 round-7, L4). `maybeRotateLogFile`'s
+ * boolean is not trustworthy in one interleaving — it reports `true` for a
+ * rotation that destroyed a concurrent rotator's rows, because the other
+ * reading of `false` ("the active file is untouched") would be a worse
+ * lie; the honest channel is its stderr line. Both of this wrapper's call
+ * sites already discard the value, but a wrapper that hands it out is an
+ * open invitation for a future `if (rotated)` to inherit the lie with
+ * nothing to stop it. `void` stops it in the type system instead of in a
+ * comment someone has to go and find. `rotateAuditLog` in
+ * `src/vault/broker/audit-log.ts` is the same shape for the same reason.
  */
-export function rotateWebhookLogIfNeeded(logPath: string): boolean {
+export function rotateWebhookLogIfNeeded(logPath: string): void {
   const { maxBytes, maxFiles } = resolveWebhookLogRotation()
-  return maybeRotateLogFile(logPath, {
+  maybeRotateLogFile(logPath, {
     maxBytes,
     maxFiles,
     tag: 'webhook-log',

--- a/src/web/webhook-log-rotation.test.ts
+++ b/src/web/webhook-log-rotation.test.ts
@@ -1,0 +1,135 @@
+/**
+ * #3596 — `<agent>/telegram/webhook-events.jsonl` had NO size check and
+ * NO reaper. On the live host one agent's log reached 121,772,086 bytes
+ * (vs 328 KB for the next-busiest) on shared, bind-mounted host disk.
+ *
+ * These tests assert outcomes an unbounded writer fails: the file stays
+ * bounded across many events, retention caps total on-disk history, and
+ * the documented consumer (`readWebhookLog`, schema.ts:1554 — "for the
+ * agent to read on demand") still sees events written before a rotation.
+ *
+ * All I/O is pinned to an isolated tmpdir — never `~/.switchroom`.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, readdirSync, statSync, existsSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  recordWebhookEvent,
+  type WebhookGatewayRecord,
+  type RecordDeps,
+} from './webhook-gateway-record.js'
+import { readWebhookLog, type DedupStore } from './webhook-handler.js'
+
+const NOW = 1_700_000_000_000
+const roots: string[] = []
+
+afterEach(() => {
+  for (const r of roots.splice(0)) rmSync(r, { recursive: true, force: true })
+  delete process.env.SWITCHROOM_WEBHOOK_LOG_MAX_BYTES
+  delete process.env.SWITCHROOM_WEBHOOK_LOG_MAX_FILES
+})
+
+function makeTmpResolveAgentDir(): {
+  resolveAgentDir: (a: string) => string
+  root: string
+} {
+  const root = mkdtempSync(join(tmpdir(), 'webhook-rot-'))
+  roots.push(root)
+  return { root, resolveAgentDir: (agent: string) => join(root, agent) }
+}
+
+/** Never dedups — every record is a fresh delivery. */
+function noDedup(): DedupStore {
+  return { check: () => undefined }
+}
+
+function record(i: number): WebhookGatewayRecord {
+  return {
+    agent: 'reggie',
+    source: 'github',
+    event_type: 'push',
+    ts: NOW + i,
+    rendered_text: `event ${i}`,
+    payload: { seq: i, filler: 'p'.repeat(1000) },
+    delivery_id: `d-${i}`,
+  }
+}
+
+function deps(resolveAgentDir: (a: string) => string): RecordDeps {
+  return {
+    resolveAgentDir,
+    dedupStore: noDedup(),
+    log: () => {},
+    loadConfig: () => ({}) as unknown as ReturnType<NonNullable<RecordDeps['loadConfig']>>,
+  }
+}
+
+function logDir(root: string): string {
+  return join(root, 'reggie', 'telegram')
+}
+
+function totalLogBytes(root: string): number {
+  const d = logDir(root)
+  return readdirSync(d)
+    .filter((f) => f.startsWith('webhook-events.jsonl'))
+    .reduce((n, f) => n + statSync(join(d, f)).size, 0)
+}
+
+describe('webhook-events.jsonl rotation (#3596)', () => {
+  it('bounds the log across many events instead of growing unbounded', () => {
+    process.env.SWITCHROOM_WEBHOOK_LOG_MAX_BYTES = String(16 * 1024)
+    process.env.SWITCHROOM_WEBHOOK_LOG_MAX_FILES = '2'
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const d = deps(resolveAgentDir)
+    // 200 events × ~1 KB ≈ 200 KB unbounded.
+    for (let i = 0; i < 200; i++) {
+      expect(recordWebhookEvent(record(i), d).status).toBe('ok')
+    }
+    const active = statSync(join(logDir(root), 'webhook-events.jsonl')).size
+    expect(active).toBeLessThan(16 * 1024 + 4 * 1024)
+    expect(totalLogBytes(root)).toBeLessThan(3 * (16 * 1024 + 4 * 1024))
+    expect(totalLogBytes(root)).toBeLessThan(180 * 1024) // ≪ unbounded
+  })
+
+  it('enforces retention — no generation beyond maxFiles survives', () => {
+    process.env.SWITCHROOM_WEBHOOK_LOG_MAX_BYTES = String(8 * 1024)
+    process.env.SWITCHROOM_WEBHOOK_LOG_MAX_FILES = '2'
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const d = deps(resolveAgentDir)
+    for (let i = 0; i < 200; i++) recordWebhookEvent(record(i), d)
+    const base = join(logDir(root), 'webhook-events.jsonl')
+    expect(existsSync(`${base}.1`)).toBe(true)
+    expect(existsSync(`${base}.2`)).toBe(true)
+    expect(existsSync(`${base}.3`)).toBe(false)
+  })
+
+  it('the documented consumer still reads pre-rotation events, in order', () => {
+    process.env.SWITCHROOM_WEBHOOK_LOG_MAX_BYTES = String(16 * 1024)
+    process.env.SWITCHROOM_WEBHOOK_LOG_MAX_FILES = '2'
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const d = deps(resolveAgentDir)
+    for (let i = 0; i < 40; i++) recordWebhookEvent(record(i), d)
+    const base = join(logDir(root), 'webhook-events.jsonl')
+    expect(existsSync(`${base}.1`)).toBe(true) // a seam exists
+
+    const events = readWebhookLog('reggie', resolveAgentDir)
+    const seqs = events.map((e) => (e.payload as { seq: number }).seq)
+    // Events from before the rotation are still visible…
+    expect(seqs).toContain(0)
+    expect(seqs).toContain(39)
+    // …and chronological order survives the seam.
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b))
+  })
+
+  it('a negative cap disables rotation (operator escape hatch)', () => {
+    process.env.SWITCHROOM_WEBHOOK_LOG_MAX_BYTES = '-1'
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const d = deps(resolveAgentDir)
+    for (let i = 0; i < 40; i++) recordWebhookEvent(record(i), d)
+    const base = join(logDir(root), 'webhook-events.jsonl')
+    expect(existsSync(`${base}.1`)).toBe(false)
+    expect(statSync(base).size).toBeGreaterThan(30 * 1000)
+  })
+})

--- a/tests/gateway-supervisor-log-rotation.test.ts
+++ b/tests/gateway-supervisor-log-rotation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, writeFileSync, existsSync, statSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, statSync, rmSync, utimesSync } from "node:fs";
+import { gunzipSync } from "node:zlib";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -40,6 +41,26 @@ function extractRotator(): string {
 let dir: string;
 let fnPath: string;
 
+/** The retained generation, whichever form it took (#3596 compresses on
+ *  rotate when gzip is available, so it may be `.1` or `.1.gz`). */
+function rotatedPath(log: string): string | null {
+  if (existsSync(log + ".1.gz")) return log + ".1.gz";
+  if (existsSync(log + ".1")) return log + ".1";
+  return null;
+}
+function rotatedExists(log: string): boolean {
+  return rotatedPath(log) !== null;
+}
+/** Uncompressed byte count of the retained generation. */
+function rotatedRawSize(log: string): number {
+  const p = rotatedPath(log);
+  if (p === null) return 0;
+  if (p.endsWith(".gz")) {
+    return gunzipSync(readFileSync(p)).length;
+  }
+  return statSync(p).size;
+}
+
 beforeAll(() => {
   dir = mkdtempSync(join(tmpdir(), "rot-test-"));
   fnPath = join(dir, "rot.fn");
@@ -75,8 +96,8 @@ describe("_switchroom_log_rotator — #3025 size-based copytruncate", () => {
       15_000,
     );
     // .1 generation captured the old (over-cap) content.
-    expect(existsSync(log + ".1"), "expected rotated .1 generation").toBe(true);
-    expect(statSync(log + ".1").size).toBeGreaterThanOrEqual(2000);
+    expect(rotatedExists(log), "expected rotated .1 generation").toBe(true);
+    expect(rotatedRawSize(log)).toBeGreaterThanOrEqual(2000);
     // Live file was truncated (only the small rotation-notice line remains).
     expect(statSync(log).size).toBeLessThan(1000);
     expect(readFileSync(log, "utf-8")).toContain("rotated");
@@ -94,7 +115,7 @@ describe("_switchroom_log_rotator — #3025 size-based copytruncate", () => {
       },
       15_000,
     );
-    expect(existsSync(log + ".1")).toBe(false);
+    expect(rotatedExists(log)).toBe(false);
     expect(readFileSync(log, "utf-8")).not.toContain("rotated");
   }, 15_000);
 
@@ -125,7 +146,7 @@ describe("_switchroom_log_rotator — #3025 size-based copytruncate", () => {
       },
       15_000,
     );
-    expect(existsSync(log + ".1")).toBe(true);
+    expect(rotatedExists(log)).toBe(true);
     expect(readFileSync(log, "utf-8")).toContain("SENTINEL_AFTER_ROTATE");
   }, 15_000);
 
@@ -151,7 +172,7 @@ describe("_switchroom_log_rotator — #3025 size-based copytruncate", () => {
       },
       15_000,
     );
-    expect(existsSync(log + ".1")).toBe(false);
+    expect(rotatedExists(log)).toBe(false);
     expect(statSync(log).size).toBeGreaterThanOrEqual(2000);
     // No sleep/test shell errors — the loop slept cleanly on the default.
     expect(readFileSync(stderrFile, "utf-8")).toBe("");
@@ -174,7 +195,7 @@ describe("_switchroom_log_rotator — #3025 size-based copytruncate", () => {
       },
       15_000,
     );
-    expect(existsSync(log + ".1")).toBe(false);
+    expect(rotatedExists(log)).toBe(false);
     expect(statSync(log).size).toBeGreaterThanOrEqual(2000);
     expect(readFileSync(stderrFile, "utf-8")).toBe("");
   }, 15_000);
@@ -191,7 +212,138 @@ describe("_switchroom_log_rotator — #3025 size-based copytruncate", () => {
       },
       15_000,
     );
-    expect(existsSync(log + ".1")).toBe(false);
+    expect(rotatedExists(log)).toBe(false);
     expect(statSync(log).size).toBeGreaterThanOrEqual(5000);
+  }, 15_000);
+});
+
+describe("_switchroom_log_rotator — #3596 the .1 generation is bounded", () => {
+  // Before #3596 the `.1` file was written once and NEVER reaped: on the
+  // live host clerk/gateway-supervisor.log.1 sat at 582 MB (dated Jul 11)
+  // while the live log was ~5 MB, i.e. months from being overwritten by
+  // the next rotation. Two bounds now apply — compress on rotate, and an
+  // age reaper that runs every cycle whether or not a rotation happens.
+
+  it("compresses the rotated generation (the 582 MB .1 case)", () => {
+    const log = join(dir, "gz.log");
+    // Highly compressible 200 KB — gzip must shrink it dramatically.
+    writeFileSync(log, "a".repeat(200_000) + "\n");
+    runBash(
+      `_switchroom_log_rotator ${JSON.stringify(log)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+      },
+      15_000,
+    );
+    expect(existsSync(log + ".1.gz"), "expected a compressed .1.gz").toBe(true);
+    expect(existsSync(log + ".1"), "plain .1 should be gone").toBe(false);
+    // Content preserved, on-disk footprint slashed.
+    expect(gunzipSync(readFileSync(log + ".1.gz")).length).toBeGreaterThanOrEqual(200_000);
+    expect(statSync(log + ".1.gz").size).toBeLessThan(20_000);
+  }, 15_000);
+
+  it("SWITCHROOM_SIDECAR_LOG_COMPRESS=0 keeps the plain .1", () => {
+    const log = join(dir, "nogz.log");
+    writeFileSync(log, "b".repeat(2000) + "\n");
+    runBash(
+      `_switchroom_log_rotator ${JSON.stringify(log)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+        SWITCHROOM_SIDECAR_LOG_COMPRESS: "0",
+      },
+      15_000,
+    );
+    expect(existsSync(log + ".1")).toBe(true);
+    expect(existsSync(log + ".1.gz")).toBe(false);
+  }, 15_000);
+
+  it("reaps an aged .1 even when the live log never crosses the cap", () => {
+    // THE regression this exists for: a small live log means no rotation
+    // ever fires, so pre-#3596 nothing would ever touch the stale .1.
+    const log = join(dir, "aged.log");
+    writeFileSync(log, "small\n");
+    const stale = log + ".1";
+    writeFileSync(stale, "c".repeat(50_000));
+    // Backdate 30 days.
+    const old = new Date(Date.now() - 30 * 24 * 3600 * 1000);
+    utimesSync(stale, old, old);
+    runBash(
+      `_switchroom_log_rotator ${JSON.stringify(log)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000000",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_MAX_AGE_SEC: "86400", // 1 day
+      },
+      15_000,
+    );
+    expect(existsSync(stale), "aged .1 should have been reaped").toBe(false);
+    // The live log is untouched (no rotation was warranted).
+    expect(readFileSync(log, "utf-8")).toContain("small");
+  }, 15_000);
+
+  it("reaps an aged .1.gz too", () => {
+    const log = join(dir, "aged-gz.log");
+    writeFileSync(log, "small\n");
+    const stale = log + ".1.gz";
+    writeFileSync(stale, "not-really-gzip-but-name-matches");
+    const old = new Date(Date.now() - 30 * 24 * 3600 * 1000);
+    utimesSync(stale, old, old);
+    runBash(
+      `_switchroom_log_rotator ${JSON.stringify(log)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000000",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_MAX_AGE_SEC: "86400",
+      },
+      15_000,
+    );
+    expect(existsSync(stale)).toBe(false);
+  }, 15_000);
+
+  it("does NOT reap a fresh .1", () => {
+    const log = join(dir, "fresh.log");
+    writeFileSync(log, "small\n");
+    const fresh = log + ".1";
+    writeFileSync(fresh, "d".repeat(5000));
+    runBash(
+      `_switchroom_log_rotator ${JSON.stringify(log)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000000",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_MAX_AGE_SEC: "86400",
+      },
+      15_000,
+    );
+    expect(existsSync(fresh)).toBe(true);
+    expect(statSync(fresh).size).toBe(5000);
+  }, 15_000);
+
+  it("a garbage max-age falls back to the 14d default (no shell errors)", () => {
+    const log = join(dir, "garbage-age.log");
+    writeFileSync(log, "small\n");
+    const stale = log + ".1";
+    writeFileSync(stale, "e".repeat(5000));
+    const old = new Date(Date.now() - 3 * 24 * 3600 * 1000); // 3d — under 14d
+    utimesSync(stale, old, old);
+    const stderrFile = join(dir, "garbage-age.stderr");
+    runBash(
+      `_switchroom_log_rotator ${JSON.stringify(log)} 2> ${JSON.stringify(stderrFile)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000000",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_MAX_AGE_SEC: "bogus",
+      },
+      15_000,
+    );
+    expect(existsSync(stale), "3d-old .1 is under the 14d default").toBe(true);
+    expect(readFileSync(stderrFile, "utf-8")).toBe("");
   }, 15_000);
 });


### PR DESCRIPTION
Three append-only logs on the live host grow without bound. The host is at **93% (34G free)**; these are a meaningful part of why. All sizes below were read off the live host.

## 1. `<agent>/telegram/webhook-events.jsonl` — no rotation, no reaper

`src/web/webhook-gateway-record.ts:150` was a bare `appendFileSync` with no size check; the legacy host-runtime writer at `src/web/webhook-handler.ts:522` did the same. Grepping `webhook-events` across `src/`, `telegram-plugin/` and `skills/` finds only the writers and a schema doc string — nothing ever reaped it.

Live: `reggie` **121,772,086 bytes** vs `clerk` 328 KB and `finn` 402 B — one busy agent at ~370x the next, on shared bind-mounted host disk.

Fix: rotate before each append at **8 MiB**, keeping **2** generations (~24 MiB per agent ceiling). Env: `SWITCHROOM_WEBHOOK_LOG_MAX_BYTES` / `_MAX_FILES` (negative disables). The documented consumer — "for the agent to read on demand" (`src/config/schema.ts:1554`) — is preserved: `readWebhookLog` now reads `.N … .1` then the active file, oldest-first, skipping a torn line rather than throwing.

## 2. `~/.switchroom/host-control-audit.log` — no rotation

`appendAuditRow` (`src/host-control/server.ts:4378-4399`) appends via an in-process promise chain; there was no `maxBytes` anywhere on the path. Live: **44,325,086 bytes**, rows ~4 KiB each because they carry redacted terminal output — already past the 32 MiB threshold its sibling rotates at.

Fix: check + rotate **inside** the existing serialized append section (so it can never interleave with an in-flight write), at **32 MiB** / **3** generations. Env: `SWITCHROOM_HOSTD_AUDIT_MAX_BYTES` / `_MAX_FILES`.

### The hash-chain seam — reasoning

The chain state (`seedChain`/`chainRow`, `src/host-control/audit-reader.ts:83-95`, `src/util/audit-hashchain.ts`) is deliberately **not** re-seeded on rotation. Two consequences, both wanted:

- **No process restart across the seam:** `this.auditChainState` keeps advancing, so the first row written into the freshly-truncated file links back (`_prev`, `_seq+1`) to the last row now living in `.1` — cross-file tamper-evidence continuity holds. The new test asserts `verifyAuditLog(".1" + active).segments === 1`.
- **Restart after a rotation:** `seedChain` re-anchors off the (near-empty) active file — exactly the same benign re-anchor a hostd restart has always produced. `verifyAuditLog` (`src/util/audit-hashchain.ts:272`) scores **per-row self-consistency** and only *counts* linkage breaks as segments, so a seam is never reported as `tampered`. `parseAuditLine` already returns `null` on a torn line, so the reader is unaffected either way.

### Reader across the seam

Reading only the active file would make `switchroom hostd audit`, the dashboard panel and `get_status` look like they had lost history for a while after each rotation. New `readAuditRaw` (`src/host-control/audit-reader.ts`) reads the active file and back-fills from rotated generations up to a bounded **4 MiB** window, dropping the partial first line. Wired into `src/cli/hostd.ts`, `src/web/api.ts`, `src/mcp/hostd/server.ts`, `src/cli/rollout.ts`.

## 3. The rotated `.log.1` generation was never reaped

`profiles/_base/start.sh.hbs`, `_switchroom_log_rotator`: it only `cp`s the live file onto `$_logfile.1` when the live file crosses the 50 MiB cap. Nothing prunes `.1`, so it is only ever replaced by the *next* rotation. An agent that grows fast during an incident and slowly afterwards keeps a giant `.1` forever.

Live proof: `clerk/gateway-supervisor.log.1` was **582 MB** (dated Jul 11) while its live log sat at ~5 MB — at ~5 MB/2wk, months from ever being overwritten.

Fix, both bounds:
- **Compress on rotate** — `gzip` the fresh `.1` (best-effort; missing binary / ENOSPC just leaves the plain `.1`). Opt out with `SWITCHROOM_SIDECAR_LOG_COMPRESS=0`.
- **Age reap** — every cycle, independent of whether a rotation fires, `find` deletes a `.1`/`.1.gz` older than `SWITCHROOM_SIDECAR_LOG_ROTATE_MAX_AGE_SEC` (default 14d). This is the branch the old code never had: with a small live log, no rotation ever fires and the stale `.1` was untouchable.

The ENOSPC truncate-without-backup fallback is unchanged (it is the right call). Garbage env values fall back to defaults, matching the existing guards.

## Shared primitive, not a third implementation

`src/vault/broker/audit-log.ts:193-300` already had the correct implementation, so it is extracted to **`src/util/log-rotation.ts`** and the broker now delegates to it (`rotateAuditLog` is a 1-line wrapper; `resolveRotation` delegates to `resolveRotationConfig`). Its 26 existing tests still pass unchanged.

It keeps **copy → fsync → ftruncate, never rename**, and the same constraint does apply here: the hostd audit log is bind-mounted into admin agents as a single file (`/host-home/.switchroom/host-control-audit.log`, `src/mcp/hostd/server.ts:957`), where `rename(2)` on a mount point fails `EBUSY` (#2953); the sidecar log additionally has a live `O_APPEND` fd that `mv` would orphan. Tests assert both the preserved inode and that an already-open fd keeps landing in the live file.

## Tests (assert outcomes, not code paths)

New: `src/util/log-rotation.test.ts`, `src/host-control/audit-rotation.test.ts`, `src/web/webhook-log-rotation.test.ts`, plus 6 new cases in `tests/gateway-supervisor-log-rotation.test.ts`. Each is written so it would FAIL on unbounded growth:

- writing 200 KB / 60 fat audit rows through the **real writer path** leaves an active file ≤ cap+slack and a whole-directory total far below the unbounded total;
- retention: `.1`/`.2` exist, `.3` never does;
- the reader returns `req-0` (pre-rotation) *and* `req-39`, in chronological order, where reading the active file alone does not;
- `verifyAuditLog` is `ok` on both generations and `segments === 1` when concatenated;
- gzip case asserts round-trip content (≥200 KB uncompressed) with <20 KB on disk;
- **the aged-`.1` reap fires with a live log that never crosses the cap** — the exact 582 MB scenario;
- a fresh `.1` is left alone; garbage max-age falls back to 14d with empty stderr.

## Verbatim output

```
$ npx vitest run src/util/log-rotation.test.ts src/host-control/audit-rotation.test.ts src/web/webhook-log-rotation.test.ts
 Test Files  3 passed (3)
      Tests  19 passed (19)

$ npx vitest run tests/gateway-supervisor-log-rotation.test.ts tests/gateway-supervisor-backoff.test.ts
 Test Files  2 passed (2)
      Tests  18 passed (18)

$ npx vitest run src/web/webhook-handler.test.ts src/web/webhook-gateway-record.test.ts src/vault/broker/ src/host-control/ src/cli/rollout
 Test Files  28 passed (28)
      Tests  468 passed (468)

$ npx tsc --noEmit
MAIN_TSC_CLEAN
```

`npm run lint` in the dev container fails only at `check-plugin-references` because the borrowed `node_modules` lacks the plugin's own deps (`mdast-util-from-markdown`, `@mtcute/node` — `ls node_modules/@mtcute` → No such file or directory). No plugin source is touched by this PR; `tsc --noEmit` over the main tree is clean and all 11 other lint scripts pass individually. CI is the authority.

Also pre-existing and unrelated: `src/web/blocked-approvals.test.ts` has 2 failures in this container (chmod-based unreadable-file assertions, defeated by running as uid 0). Verified pre-existing by stashing the diff and re-running on clean `main`.

## Round-5 corrections (bb9d0e3cf)

Doc-only diff plus one test. Every claim below was re-verified against the code or a test in this branch.

- **M1/M2** — three comments claimed the reclaimed rotator "leaves the reclaimer's `.1` and the shifted history intact" / "aborts before it destroys anything"; the PR's own test `does not copy over the peer's .1` asserts `.1` ABSENT and `.2` = the peer's snapshot, i.e. the shifted HISTORY is destroyed. Corrected in `src/util/log-rotation.ts` (`RotateOptions.lock` doc, `withRotateLock` residual, `rotateLogFile` doc) and in the H1 describe header. The residual now states the DAMAGE, not just the window: one unguarded syscall costs a full generation, with both gaps (check→`copyFileSync`, check→shift-`rename`) reproduced, and the copy gap is now an asserted test rather than prose.
- **M3** — documented and closed the load-bearing premise that the lock `fd` stays open across the whole critical section (an open fd is what pins the inode that `stillHeld()` and the release guard compare). Measured 200 park→unlink→recreate cycles per cell: fd closed ext4 **200/200** collisions, fd closed tmpfs 0/200, fd open ext4 **0/200**, fd open tmpfs 0/200. The suite runs under `os.tmpdir()` (tmpfs, never reuses) while the real logs live on ext4, so no outcome test can see an early close — new test `holds the lock fd open through every destructive syscall` asserts the mechanism on any filesystem. Mutation: closing `fd` before `fn()` fails exactly that test (all four mutations tagged `[FD CLOSED]`) and nothing else.
- **L1** — header said "Three other logs" and listed two; the third (sidecar supervisor) rotates in shell via `profiles/_base/start.sh.hbs` and does not call into this module. Now says two, with that distinction.
- **L2** — "three destructive phases" corrected to every destructive syscall, four call sites, the shift one per loop iteration (matching `rotateLogFile`'s own doc).
- **L3 — correcting the record.** `6ad945483`'s message claims `stillHeld always true -> 6 fail`. That is wrong: on that commit's 12-test suite the mutation kills **5** — `release does not delete a lock that is no longer ours` plus the four H1 interleaving tests. On this commit's 14-test suite the same mutation kills 6, the extra one being the new copy-gap test.
- **L4** — `sweepStaleParks`: a peer mid-reclaim "can" → **"will"** hold an eligible park; `rename(2)` preserves the file mtime (verified), so a park always carries the ancient lock's mtime and is always past the cutoff. Consequences stay benign as documented.

```
$ npx vitest run src/util/log-rotation src/web/webhook
 Test Files  9 passed (9)
      Tests  138 passed (138)          # was 136; +2 new

$ npx tsc --noEmit
MAIN_TSC_CLEAN
```

### CI note on `bb9d0e3cf` — the three non-green entries are GHA queue strandings, not test failures

27 pass / 11 skip. The `ci-tests-plugin` **pull_request** runs (`30152172939`, and `30153208716` from a close/reopen re-trigger) both sat in `queued` with zero jobs scheduled for 40+ min — the hosted-runner scheduling-window failure this workflow's own header documents (`#1336`). `gh run rerun` refuses on them ("already running"), and the `changes fail` / `bun-test-run fail` entries are artifacts of cancelling them to try to unstick the queue.

The workflow itself is **green on this exact sha** via the documented recovery lever, `workflow_dispatch`: run [`30153494090`](https://github.com/switchroom/switchroom/actions/runs/30153494090) on `bb9d0e3cfdbcf98beeb0f64f8b4f3aff7b12d9eb` — `changes` ✓ 7s, `bun-test-run` ✓ 1m12s, `bun-test` ✓ 4s. This diff touches no `telegram-plugin/` path anyway, so the path filter skips the suite.

## Deferred

- No migration of the currently-oversized live files — this PR is code only. The 121 MB `webhook-events.jsonl` will rotate on its next event; the 44 MB hostd log on its next privileged verb.
- Compression is applied to the sidecar `.1` only; the two JSONL logs keep plain rotated generations so agents/operators can `cat`/`grep` them directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

