### PR TITLE
fix(rollout): make the durable pin provisional; make the compose backup real

### DIFF
--- a/src/cli/release-yaml.test.ts
+++ b/src/cli/release-yaml.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { parse } from "yaml";
-import { setReleasePinInConfig } from "./release-yaml.js";
+import { setReleasePinInConfig, deleteReleasePinInConfig } from "./release-yaml.js";
+import { RootReleaseBlock } from "../config/schema.js";
 
 const DATE = "2026-06-14";
 
@@ -52,5 +53,74 @@ describe("setReleasePinInConfig", () => {
     const after = setReleasePinInConfig(before, "v0.15.18", DATE);
     expect(parse(after).release.channel).toBeUndefined();
     expect(parse(after).release.pin).toBe("v0.15.18");
+  });
+});
+
+describe("deleteReleasePinInConfig", () => {
+  const commentLines = (s: string) => s.split("\n").filter((l) => l.trim().startsWith("#"));
+
+  it("is a byte-identical no-op when there is no pin to delete", () => {
+    const text = ["# header", "telegram:", "  bot_token: x", ""].join("\n");
+    expect(deleteReleasePinInConfig(text)).toBe(text);
+  });
+
+  it("drops a husk the roll SYNTHESIZED, restoring the file byte-for-byte", () => {
+    // The `release:` block did not exist before the roll, so nothing is
+    // commented onto it and removing it entirely is the correct revert.
+    const before = ["# header", "telegram:", "  bot_token: x # keep me", ""].join("\n");
+    const pinned = setReleasePinInConfig(before, "v0.15.18", DATE);
+    expect(parse(pinned).release.pin).toBe("v0.15.18");
+    expect(deleteReleasePinInConfig(pinned)).toBe(before);
+  });
+
+  it("KEEPS the husk rather than destroying the block's comment header", () => {
+    // THE bug: `yaml` attaches a key's preceding comment block to the key node
+    // as `commentBefore`, so `doc.delete("release")` silently took the whole
+    // documented header with it. On the production config that is 15 lines.
+    const before = [
+      "telegram:",
+      "  bot_token: x",
+      "",
+      "# Release channel / pin.",
+      "# `channel` and `pin` are mutually exclusive.",
+      "# Set by `switchroom rollout --pin`; reverted if the roll fails.",
+      "release:",
+      "  pin: v0.15.18 # 2026-06-14: rolled by switchroom rollout",
+      "",
+      "agents:",
+      "  clerk: {}",
+      "",
+    ].join("\n");
+
+    const after = deleteReleasePinInConfig(before);
+
+    // The pin is gone…
+    expect(parse(after).release?.pin).toBeUndefined();
+    // …the documentation is NOT (every `#` line survives, in order)…
+    expect(commentLines(after)).toEqual([
+      "# Release channel / pin.",
+      "# `channel` and `pin` are mutually exclusive.",
+      "# Set by `switchroom rollout --pin`; reverted if the roll fails.",
+    ]);
+    // …and every other key is untouched.
+    expect(parse(after).telegram.bot_token).toBe("x");
+    expect(parse(after).agents.clerk).toEqual({});
+  });
+
+  it("the kept husk is schema-VALID (an empty release block passes)", () => {
+    // The husk removal was justified by "`release: {}` is invalid per the
+    // schema refine". It is not: every field is optional and the refine only
+    // rejects channel+pin together. Asserted against the real schema so the
+    // justification can't silently rot back in.
+    const before = ["# docs", "release:", "  pin: v0.15.18", ""].join("\n");
+    const after = deleteReleasePinInConfig(before);
+    expect(after).toMatch(/release:/);
+    expect(RootReleaseBlock.safeParse(parse(after).release).success).toBe(true);
+  });
+
+  it("leaves a non-empty release block alone apart from the pin", () => {
+    const before = ["release:", "  pin: v0.15.18", "  auto_update: true", ""].join("\n");
+    const after = deleteReleasePinInConfig(before);
+    expect(parse(after).release).toEqual({ auto_update: true });
   });
 });

--- a/src/cli/release-yaml.ts
+++ b/src/cli/release-yaml.ts
@@ -18,7 +18,7 @@
  * would fail validation.
  */
 
-import { parseDocument, isScalar, isMap } from "yaml";
+import { parseDocument, isScalar, isMap, isPair, type Document } from "yaml";
 
 /**
  * Read the current `release.pin` out of a config's raw text, or undefined
@@ -88,17 +88,65 @@ export function setReleasePinInConfig(
  * all of it. A targeted edit touches exactly the key the rollout wrote and
  * leaves every other change intact.
  *
- * Deleting an absent pin is a no-op, and an empty `release` block left behind
- * is removed too (an empty mapping fails the ReleaseBlock refine). Returns
- * `yamlText` unchanged when there is nothing to delete, so callers can call it
- * unconditionally without churning the file's mtime.
+ * Deleting an absent pin is a no-op. Returns `yamlText` unchanged when there is
+ * nothing to delete, so callers can call it unconditionally without churning
+ * the file's mtime.
+ *
+ * ## The empty `release` husk
+ *
+ * When `pin` was the block's only key, deleting it leaves `release: {}`. That
+ * husk is dropped — but ONLY when nothing is commented onto it.
+ *
+ * The `yaml` Document attaches a key's preceding comment block to the key node
+ * as `commentBefore`, so `doc.delete("release")` takes the block's entire
+ * documentation with it. On the production config that is a 15-line header. The
+ * two cases the journal actually hits pull in opposite directions:
+ *
+ *   - the roll SYNTHESIZED the block (the config was unpinned and had no
+ *     `release:` key at all) — no comments exist, so dropping the husk makes
+ *     the revert byte-identical to the pre-roll file. That is the case the
+ *     husk removal was written for;
+ *   - the block PRE-EXISTED with operator documentation and the roll only wrote
+ *     `pin` into it (or an operator added a documented `release:` during the
+ *     roll window, which the targeted-edit contract above exists to respect) —
+ *     dropping the husk would silently delete that documentation.
+ *
+ * So a commented husk is kept as `release: {}`. That is schema-VALID: every
+ * field in `ReleaseBlock` is optional and the refine only rejects
+ * `channel` + `pin` together, so `{}` passes (an earlier comment here claimed
+ * the opposite — it was wrong). Keeping a tidy config is not worth destroying
+ * an operator's comments.
  */
 export function deleteReleasePinInConfig(yamlText: string): string {
   const doc = parseDocument(yamlText);
   if (!doc.hasIn(["release", "pin"])) return yamlText;
   doc.deleteIn(["release", "pin"]);
   const rel = doc.getIn(["release"]);
-  // `release: {}` is invalid per the schema refine — drop the husk.
-  if (isMap(rel) && rel.items.length === 0) doc.delete("release");
+  if (isMap(rel) && rel.items.length === 0 && !releaseBlockIsCommented(doc)) {
+    doc.delete("release");
+  }
   return String(doc);
+}
+
+/**
+ * Does the top-level `release` pair carry any comment that would be destroyed
+ * by deleting it? Checks the key node (where a preceding `# …` block lands)
+ * and the value node (trailing / inner comments).
+ */
+function releaseBlockIsCommented(doc: Document): boolean {
+  const contents = doc.contents;
+  if (!isMap(contents)) return false;
+  for (const item of contents.items) {
+    if (!isPair(item)) continue;
+    const key = item.key;
+    if (!isScalar(key) || key.value !== "release") continue;
+    const nodes = [key, item.value];
+    return nodes.some(
+      (n) =>
+        !!n &&
+        typeof n === "object" &&
+        (("commentBefore" in n && !!n.commentBefore) || ("comment" in n && !!n.comment)),
+    );
+  }
+  return false;
 }

--- a/src/cli/release-yaml.ts
+++ b/src/cli/release-yaml.ts
@@ -18,7 +18,23 @@
  * would fail validation.
  */
 
-import { parseDocument, isScalar } from "yaml";
+import { parseDocument, isScalar, isMap } from "yaml";
+
+/**
+ * Read the current `release.pin` out of a config's raw text, or undefined
+ * when unpinned / unparseable. Read-only companion to
+ * {@link setReleasePinInConfig}; used by the rollout pin journal to record
+ * which pin a provisional write is replacing.
+ */
+export function getReleasePinFromConfig(yamlText: string): string | undefined {
+  let v: unknown;
+  try {
+    v = parseDocument(yamlText).getIn(["release", "pin"]);
+  } catch {
+    return undefined;
+  }
+  return typeof v === "string" ? v : undefined;
+}
 
 /**
  * Return `yamlText` with `release.pin` set to `pin` (creating the `release`
@@ -56,5 +72,33 @@ export function setReleasePinInConfig(
     node.comment = ` ${now}: rolled by switchroom rollout`;
   }
 
+  return String(doc);
+}
+
+/**
+ * Return `yamlText` with `release.pin` REMOVED — the inverse of
+ * {@link setReleasePinInConfig}, used by the rollout pin journal to revert a
+ * provisional pin that was written for a roll that never proved out.
+ *
+ * Why this exists rather than restoring a saved copy of the whole file: the
+ * revert can run minutes (or, after a crash, hours) after the provisional
+ * write, and anything else may legitimately have edited the config in between
+ * — an operator adding an agent, a `config_propose_edit` landing, a vault
+ * reference changing. Restoring a byte-exact snapshot would silently discard
+ * all of it. A targeted edit touches exactly the key the rollout wrote and
+ * leaves every other change intact.
+ *
+ * Deleting an absent pin is a no-op, and an empty `release` block left behind
+ * is removed too (an empty mapping fails the ReleaseBlock refine). Returns
+ * `yamlText` unchanged when there is nothing to delete, so callers can call it
+ * unconditionally without churning the file's mtime.
+ */
+export function deleteReleasePinInConfig(yamlText: string): string {
+  const doc = parseDocument(yamlText);
+  if (!doc.hasIn(["release", "pin"])) return yamlText;
+  doc.deleteIn(["release", "pin"]);
+  const rel = doc.getIn(["release"]);
+  // `release: {}` is invalid per the schema refine — drop the husk.
+  if (isMap(rel) && rel.items.length === 0) doc.delete("release");
   return String(doc);
 }

--- a/src/cli/rollout-pin-journal.test.ts
+++ b/src/cli/rollout-pin-journal.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Rollout pin journal — the two-phase commit that keeps a durable
+ * `release.pin` from outliving a roll that failed.
+ *
+ * These assert OUTCOMES on a real (tmpdir) config file: after each scenario,
+ * what does `release.pin` actually say, and what ELSE in the config survived?
+ * A test that only checked "the journal function was called" would not have
+ * failed on the original bug.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  chmodSync,
+  statSync,
+  mkdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  pinJournalPath,
+  hasPinJournal,
+  readPinJournal,
+  beginPinPersist,
+  commitPinPersist,
+  rollbackPinPersist,
+  recoverPinJournal,
+  isPidAlive,
+  isJournalFresh,
+  PIN_JOURNAL_MAX_AGE_MS,
+  type RolloutPinJournal,
+} from "./rollout-pin-journal.js";
+import { setReleasePinInConfig, getReleasePinFromConfig } from "./release-yaml.js";
+
+const CONFIG = `telegram:
+  bot_token: x
+release:
+  pin: v0.19.3 # 2026-07-01: rolled by switchroom rollout
+agents:
+  clerk:
+    extends: default
+`;
+
+function mkConfig(text = CONFIG): string {
+  const dir = mkdtempSync(join(tmpdir(), "pin-journal-"));
+  const p = join(dir, "switchroom.yaml");
+  writeFileSync(p, text, "utf8");
+  return p;
+}
+
+/** Simulate the production persistPin: journal, then write the new pin. */
+function provisionallyPersist(configPath: string, pin: string): void {
+  const before = readFileSync(configPath, "utf8");
+  beginPinPersist(configPath, pin);
+  writeFileSync(configPath, setReleasePinInConfig(before, pin), "utf8");
+}
+
+function pinOf(configPath: string): string | undefined {
+  return getReleasePinFromConfig(readFileSync(configPath, "utf8"));
+}
+
+/** A clock far enough past the journal's `at` that it reads as abandoned. */
+function afterTimeout(): number {
+  return Date.now() + PIN_JOURNAL_MAX_AGE_MS + 1;
+}
+
+describe("pin journal — two-phase commit", () => {
+  it("a provisional write changes the pin but leaves a journal", () => {
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    expect(pinOf(cfg)).toBe("v0.19.4");
+    expect(hasPinJournal(cfg)).toBe(true);
+    const j = readPinJournal(cfg);
+    expect(j?.pin).toBe("v0.19.4");
+    expect(j?.priorPin).toBe("v0.19.3");
+    // Liveness marker, so recovery can tell "died" from "still running".
+    expect(j?.pid).toBe(process.pid);
+    // The journal records pin VALUES only — never a config snapshot, whose
+    // restore would silently discard unrelated edits made in the meantime.
+    expect(JSON.stringify(j)).not.toContain("bot_token");
+  });
+
+  it("commit makes the pin durable and clears the journal", () => {
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    expect(commitPinPersist(cfg)).toBeNull();
+    expect(pinOf(cfg)).toBe("v0.19.4");
+    expect(hasPinJournal(cfg)).toBe(false);
+    // A later recovery pass must NOT undo a committed roll.
+    expect(recoverPinJournal(cfg, { now: afterTimeout() })).toBeNull();
+    expect(pinOf(cfg)).toBe("v0.19.4");
+  });
+
+  it("rollback restores the prior pin and touches NOTHING else", () => {
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    const out = rollbackPinPersist(cfg);
+    expect(out.reverted).toBe(true);
+    expect(out.pin).toBe("v0.19.4");
+    expect(out.priorPin).toBe("v0.19.3");
+    expect(pinOf(cfg)).toBe("v0.19.3");
+    // Every other key and its comments survive the targeted edit.
+    const text = readFileSync(cfg, "utf8");
+    expect(text).toContain("bot_token: x");
+    expect(text).toContain("clerk:");
+    expect(hasPinJournal(cfg)).toBe(false);
+  });
+
+  it("does NOT discard config edits made after the provisional write", () => {
+    // THE mirror-image bug a whole-file snapshot restore would have: on the
+    // hostd path the pin lands right after the canary and the remaining
+    // agents take minutes. Anything that edits the config in that window —
+    // an operator adding an agent, an approved config_propose_edit — must
+    // survive the rollback.
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    writeFileSync(
+      cfg,
+      readFileSync(cfg, "utf8") + "  archivist:\n    extends: default\n",
+      "utf8",
+    );
+
+    expect(rollbackPinPersist(cfg).reverted).toBe(true);
+
+    const text = readFileSync(cfg, "utf8");
+    expect(pinOf(cfg)).toBe("v0.19.3"); // pin reverted…
+    expect(text).toContain("archivist:"); // …and the unrelated edit kept.
+  });
+
+  it("rollback DELETES the pin when the config was unpinned before the roll", () => {
+    const unpinned = `telegram:\n  bot_token: x\nagents:\n  clerk:\n    extends: default\n`;
+    const cfg = mkConfig(unpinned);
+    provisionallyPersist(cfg, "v0.19.4");
+    expect(pinOf(cfg)).toBe("v0.19.4");
+    const out = rollbackPinPersist(cfg);
+    expect(out.reverted).toBe(true);
+    expect(out.priorPin).toBeUndefined();
+    expect(pinOf(cfg)).toBeUndefined();
+    // No `release: {}` husk left behind — that fails the schema refine.
+    expect(readFileSync(cfg, "utf8")).not.toMatch(/release:/);
+  });
+
+  it("commit and rollback are both idempotent", () => {
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    expect(rollbackPinPersist(cfg).reverted).toBe(true);
+    // Second rollback is a no-op — it must NOT re-revert over a later,
+    // legitimate pin write.
+    provisionallyPersist(cfg, "v0.19.5");
+    expect(commitPinPersist(cfg)).toBeNull();
+    expect(commitPinPersist(cfg)).toBeNull();
+    expect(rollbackPinPersist(cfg).reverted).toBe(false);
+    expect(pinOf(cfg)).toBe("v0.19.5");
+  });
+
+  it("writes the journal atomically and owner-only", () => {
+    const cfg = mkConfig();
+    chmodSync(cfg, 0o600);
+    provisionallyPersist(cfg, "v0.19.4");
+    expect(statSync(pinJournalPath(cfg)).mode & 0o077).toBe(0);
+    // tmp+rename leaves no debris beside the journal.
+    expect(existsSync(`${pinJournalPath(cfg)}.${process.pid}.tmp`)).toBe(false);
+  });
+});
+
+describe("pin journal — liveness gate (a live roll must not be reverted)", () => {
+  it("leaves the pin alone while the writing process is alive and the journal is young", () => {
+    // THE regression this gate exists for: hostd restarts MID-ROLL (the
+    // host-shell path refreshes hostd as its last step; a self-bump recreates
+    // it outright). Boot recovery must not revert the pin of a roll that is
+    // still running — or one that already succeeded and is about to commit.
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4"); // pid = this live process
+    const note = recoverPinJournal(cfg);
+    expect(note).toMatch(/still looks live/);
+    expect(pinOf(cfg)).toBe("v0.19.4"); // NOT reverted
+    expect(hasPinJournal(cfg)).toBe(true); // journal preserved for later
+  });
+
+  it("reverts once the journal ages past the cutoff, even if the pid still resolves", () => {
+    // Pids are recycled and a recreated hostd can land on the recorded one,
+    // so age is the backstop that guarantees eventual recovery.
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    const note = recoverPinJournal(cfg, { now: afterTimeout() });
+    expect(note).toMatch(/reverted an UNCOMMITTED release.pin=v0\.19\.4/);
+    expect(pinOf(cfg)).toBe("v0.19.3");
+  });
+
+  it("the rollout's own failure path reverts immediately, without the gate", () => {
+    // requireStale defaults to false: that caller IS the writer and knows the
+    // roll failed, so waiting out a 15-minute cutoff would be absurd.
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    expect(rollbackPinPersist(cfg).reverted).toBe(true);
+    expect(pinOf(cfg)).toBe("v0.19.3");
+  });
+
+  it("isPidAlive / isJournalFresh behave at their edges", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(-1)).toBe(false);
+    // A pid far above the kernel's pid_max cannot exist.
+    expect(isPidAlive(0x3fffffff)).toBe(false);
+
+    const base = { v: 1 as const, configPath: "/c", pin: "v1", pid: 1 };
+    const now = Date.now();
+    expect(isJournalFresh({ ...base, at: new Date(now).toISOString() }, now)).toBe(true);
+    expect(
+      isJournalFresh(
+        { ...base, at: new Date(now - PIN_JOURNAL_MAX_AGE_MS - 1).toISOString() },
+        now,
+      ),
+    ).toBe(false);
+    // An undateable journal is NOT fresh — we cannot claim it is in flight.
+    expect(isJournalFresh({ ...base, at: "not-a-date" } as RolloutPinJournal, now)).toBe(
+      false,
+    );
+  });
+});
+
+describe("pin journal — crash recovery", () => {
+  it("reverts an uncommitted pin left by a rollout that was killed mid-roll", () => {
+    const cfg = mkConfig();
+    // The roll persisted the pin after a green canary, then the process was
+    // SIGKILLed before it could commit OR revert. Nothing in-process runs.
+    provisionallyPersist(cfg, "v0.19.4");
+    expect(pinOf(cfg)).toBe("v0.19.4");
+
+    // A fresh hostd boots and runs recovery, long enough after the fact that
+    // the journal reads as abandoned.
+    const note = recoverPinJournal(cfg, { now: afterTimeout() });
+    expect(note).toMatch(/reverted an UNCOMMITTED release.pin=v0\.19\.4/);
+    // THE outcome: the durable pin names the last PROVEN version, so a later
+    // reconcile / `compose up -d` cannot converge the fleet onto v0.19.4.
+    expect(pinOf(cfg)).toBe("v0.19.3");
+    expect(existsSync(pinJournalPath(cfg))).toBe(false);
+  });
+
+  it("is a no-op when no roll was in flight", () => {
+    const cfg = mkConfig();
+    expect(recoverPinJournal(cfg)).toBeNull();
+    expect(readFileSync(cfg, "utf8")).toBe(CONFIG);
+  });
+
+  it("WARNS LOUDLY about a malformed journal instead of failing silently", () => {
+    // A journal we cannot parse means a pin write may be uncommitted with no
+    // way to know what to revert to. Silence there is the worst outcome: the
+    // operator never learns the fleet may be pinned to an unproven build.
+    const cfg = mkConfig();
+    writeFileSync(pinJournalPath(cfg), '{"v":1,"configPath":', "utf8");
+    const warnings: string[] = [];
+    expect(recoverPinJournal(cfg, { warn: (m) => warnings.push(m) })).toBeNull();
+    // Config untouched — a malformed journal must never clobber it.
+    expect(readFileSync(cfg, "utf8")).toBe(CONFIG);
+    const w = warnings.join("");
+    expect(w).toMatch(/rollout pin journal/);
+    expect(w).toMatch(/not valid JSON/);
+    expect(w).toMatch(/check it host-side/i);
+  });
+
+  it("warns and refuses when the journal names a different config", () => {
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    const j = JSON.parse(readFileSync(pinJournalPath(cfg), "utf8")) as RolloutPinJournal;
+    writeFileSync(
+      pinJournalPath(cfg),
+      JSON.stringify({ ...j, configPath: "/elsewhere/switchroom.yaml" }),
+      "utf8",
+    );
+    const warnings: string[] = [];
+    const out = rollbackPinPersist(cfg, { warn: (m) => warnings.push(m) });
+    expect(out.reverted).toBe(false);
+    expect(out.error).toBe("configPath mismatch");
+    expect(warnings.join("")).toMatch(/Refusing to revert/);
+    expect(pinOf(cfg)).toBe("v0.19.4"); // untouched
+  });
+
+  it("surfaces a commit that could not clear the journal", () => {
+    // A commit whose unlink fails is the input that makes the NEXT boot
+    // revert a proven pin — so it must be reported, not swallowed.
+    const cfg = mkConfig();
+    // A DIRECTORY at the journal path makes unlink fail (EISDIR/EPERM) for
+    // every uid including root, so this asserts deterministically rather than
+    // depending on the test runner's privileges.
+    mkdirSync(pinJournalPath(cfg));
+    const err = commitPinPersist(cfg);
+    expect(err).toMatch(/FAILED to clear/);
+    expect(err).toMatch(/may revert a proven/);
+  });
+
+  it("reports (never throws) when the restore write fails", () => {
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    const note = recoverPinJournal(cfg, {
+      now: afterTimeout(),
+      writeConfig: () => {
+        throw new Error("EROFS: read-only file system");
+      },
+    });
+    expect(note).toMatch(/FAILED to revert/);
+    expect(note).toMatch(/EROFS/);
+    // Journal is preserved so a later, working recovery can still act.
+    expect(hasPinJournal(cfg)).toBe(true);
+    expect(pinOf(cfg)).toBe("v0.19.4");
+  });
+});

--- a/src/cli/rollout-pin-journal.test.ts
+++ b/src/cli/rollout-pin-journal.test.ts
@@ -8,7 +8,7 @@
  * failed on the original bug.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   mkdtempSync,
   writeFileSync,
@@ -23,6 +23,38 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+
+/**
+ * `pinJournalDir` has THREE precedence rules and rule 1
+ * (`SWITCHROOM_PIN_JOURNAL_DIR`) short-circuits the other two. Most tests here
+ * are about journal SEMANTICS, not about where the directory came from, so
+ * they take rule 1 via the `beforeEach` below.
+ *
+ * The tests that are specifically about *where the journal lives* — the ones
+ * that assert "never beside the config", which is THE production defect — must
+ * NOT take rule 1, or they assert nothing: with the env var set they pass
+ * verbatim against the pre-fix `dirname(resolve(configPath))` implementation.
+ * They delete the env var and drive rule 3 instead, which needs `homedir()`
+ * pointed somewhere hermetic. Hence this mock: `fakeHome` is null for every
+ * test that doesn't opt in, so the real `homedir()` is used and nothing else
+ * changes shape.
+ */
+let fakeHome: string | null = null;
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: () => fakeHome ?? actual.homedir() };
+});
+
+/**
+ * Opt a test out of rule 1 and into rules 2/3: clear the override and give
+ * `homedir()` a tmpdir. Returns the durable state dir rule 3 will land on.
+ */
+function useFakeHomeStateDir(): string {
+  delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+  fakeHome = mkdtempSync(join(tmpdir(), "pin-journal-home-"));
+  return join(fakeHome, ".switchroom");
+}
 import {
   pinJournalDir,
   pinJournalPath,
@@ -64,6 +96,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+  fakeHome = null;
 });
 
 function mkConfig(text = CONFIG): string {
@@ -73,7 +106,14 @@ function mkConfig(text = CONFIG): string {
   return p;
 }
 
-/** Simulate the production persistPin: journal, then write the new pin. */
+/**
+ * ARRANGE a config into the mid-persist state: journal on disk, new pin
+ * written. This is a fixture, NOT a stand-in for production `persistPin` —
+ * nothing here asserts that `rollout.ts` wires the two calls in this order, and
+ * a test that read it that way would be a false green. That wiring is asserted
+ * against the real `createRolloutDeps` in rollout.test.ts ("createRolloutDeps'
+ * persistPin JOURNALS to disk before it writes the pin").
+ */
 function provisionallyPersist(configPath: string, pin: string): void {
   const before = readFileSync(configPath, "utf8");
   beginPinPersist(configPath, pin);
@@ -103,15 +143,43 @@ describe("pin journal — the journal must outlive the container that wrote it",
     // journal landed somewhere that exists nowhere on the host and dies with
     // the container — making hostd-boot crash recovery dead code on exactly
     // the path this module targets.
-    const cfg = mkConfig();
+    //
+    // Rule 1 (`SWITCHROOM_PIN_JOURNAL_DIR`) is deliberately NOT used here: it
+    // short-circuits `pinJournalDir` before the rules that ARE the fix, so
+    // with it set this test passes verbatim against the pre-fix
+    // `dirname(resolve(configPath))`. Rule 3 (`<homedir()>/.switchroom`) is
+    // what hostd actually takes, so that is what is exercised.
+    const durable = useFakeHomeStateDir();
+    const cfg = mkConfig(); // a plain tmpdir — NOT named `.switchroom`, so rule 2 misses
     provisionallyPersist(cfg, "v0.19.4");
 
     const p = pinJournalPath(cfg);
-    expect(dirname(p)).toBe(stateDir); // the durable, directory-bind-mounted dir
+    expect(dirname(p)).toBe(durable); // the durable, directory-bind-mounted dir
     expect(dirname(p)).not.toBe(dirname(cfg)); // NOT the config's (ephemeral) dir
     expect(existsSync(p)).toBe(true);
     // Nothing at all was dropped next to the config.
     expect(readdirSync(dirname(cfg))).toEqual(["switchroom.yaml"]);
+  });
+
+  it("takes the config's own dir ONLY when it is itself a .switchroom dir", () => {
+    // Rule 2, the host-shell case. `~/.switchroom/switchroom.yaml` — here the
+    // config's directory IS the durable state dir, so co-locating is correct
+    // and sudo's `HOME` policy stops mattering. This is the one case where
+    // "beside the config" is the right answer, and pinning it is what stops a
+    // future rewrite from collapsing rules 2 and 3 into "always homedir".
+    const durable = useFakeHomeStateDir();
+    const opHome = mkdtempSync(join(tmpdir(), "pin-journal-ophome-"));
+    const opState = join(opHome, ".switchroom");
+    mkdirSync(opState);
+    const cfg = join(opState, "switchroom.yaml");
+    writeFileSync(cfg, CONFIG, "utf8");
+
+    provisionallyPersist(cfg, "v0.19.4");
+
+    expect(dirname(pinJournalPath(cfg))).toBe(opState);
+    // …and NOT the `homedir()` fallback, which is a different directory here.
+    expect(dirname(pinJournalPath(cfg))).not.toBe(durable);
+    expect(existsSync(pinJournalPath(cfg))).toBe(true);
   });
 
   it("recovery still finds the journal after a container recreate wipes the config's directory", () => {
@@ -120,6 +188,12 @@ describe("pin journal — the journal must outlive the container that wrote it",
     // `/state/config` the DIRECTORY is a fresh overlay: the file is remounted,
     // anything else written there is gone. Modelled with a symlink into a
     // separate "container view" directory that gets emptied.
+    //
+    // Rule 1 is cleared for the same reason as the test above: with the env
+    // override in place the journal lands in a tmpdir that the simulated
+    // recreate never touches, so the scenario passes against the very bug it
+    // is written to catch. Rule 3 is the one hostd takes.
+    useFakeHomeStateDir();
     const real = mkConfig();
     const viewDir = mkdtempSync(join(tmpdir(), "pin-journal-view-"));
     const viewPath = join(viewDir, "switchroom.yaml");
@@ -214,6 +288,31 @@ describe("pin journal — two writers must not share one journal", () => {
     // The first roll's journal is intact, so ITS revert still works.
     expect(readPinJournal(cfg)?.pin).toBe("v0.19.4");
     expect(readPinJournal(cfg)?.priorPin).toBe("v0.19.3");
+  });
+
+  it("does NOT exclude the hostd/host-shell pair — that is the fleet lock's job", () => {
+    // The limitation, pinned so the module header cannot drift back into
+    // claiming "two rolls against the same config path cannot interleave".
+    // The gate is keyed by journal path, i.e. by config-path STRING. The only
+    // two contending writers in this system reach the SAME physical file
+    // through two different strings (`cli/hostd.ts` bind-mounts
+    // `~/.switchroom/switchroom.yaml` onto `/state/config/switchroom.yaml`), so
+    // both begins succeed and the gate never fires between them.
+    const dir = mkdtempSync(join(tmpdir(), "pin-journal-pair-"));
+    const asShell = join(dir, "switchroom.yaml");
+    writeFileSync(asShell, CONFIG, "utf8");
+    const asHostd = join(dir, "state-config.yaml");
+    symlinkSync(asShell, asHostd);
+
+    const a = beginPinPersist(asShell, "v0.19.4"); // live writer: this process
+    // Same file, other path. If exclusivity spanned the pair this would throw.
+    expect(() => beginPinPersist(asHostd, "v0.19.5")).not.toThrow();
+    // Two live journals against one file, each intact and each correct about
+    // its OWN write — which is what keeps the dangerous failure (a cross-roll
+    // revert) impossible even though the benign one is not prevented here.
+    expect(readPinJournal(asShell)?.pin).toBe(a.pin);
+    expect(readPinJournal(asHostd)?.pin).toBe("v0.19.5");
+    expect(pinJournalPath(asShell)).not.toBe(pinJournalPath(asHostd));
   });
 
   it("overwrites (with a warning) a journal whose writer is gone", () => {

--- a/src/cli/rollout-pin-journal.test.ts
+++ b/src/cli/rollout-pin-journal.test.ts
@@ -8,19 +8,23 @@
  * failed on the original bug.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   mkdtempSync,
   writeFileSync,
   readFileSync,
+  readdirSync,
   existsSync,
   chmodSync,
   statSync,
   mkdirSync,
+  symlinkSync,
+  rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
+  pinJournalDir,
   pinJournalPath,
   hasPinJournal,
   readPinJournal,
@@ -29,6 +33,7 @@ import {
   rollbackPinPersist,
   recoverPinJournal,
   isPidAlive,
+  isJournalWriterAlive,
   isJournalFresh,
   PIN_JOURNAL_MAX_AGE_MS,
   type RolloutPinJournal,
@@ -36,13 +41,30 @@ import {
 import { setReleasePinInConfig, getReleasePinFromConfig } from "./release-yaml.js";
 
 const CONFIG = `telegram:
-  bot_token: x
+  bot_token: x # the fleet's bot credential
 release:
   pin: v0.19.3 # 2026-07-01: rolled by switchroom rollout
 agents:
   clerk:
     extends: default
 `;
+
+/**
+ * Stand-in for the DURABLE switchroom state dir (`~/.switchroom` on the host
+ * shell, the `/host-home/.switchroom` bind inside hostd). Every test points the
+ * journal at a tmpdir so the suite can never touch a real state dir — and so
+ * the "journal does NOT live beside the config" property is assertable.
+ */
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "pin-journal-state-"));
+  process.env.SWITCHROOM_PIN_JOURNAL_DIR = stateDir;
+});
+
+afterEach(() => {
+  delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+});
 
 function mkConfig(text = CONFIG): string {
   const dir = mkdtempSync(join(tmpdir(), "pin-journal-"));
@@ -58,6 +80,11 @@ function provisionallyPersist(configPath: string, pin: string): void {
   writeFileSync(configPath, setReleasePinInConfig(before, pin), "utf8");
 }
 
+/** A start-time probe reporting a process that began AFTER `journal.at`. */
+function startedAfterJournal(journal: RolloutPinJournal): () => number {
+  return () => Date.parse(journal.at) + 60_000;
+}
+
 function pinOf(configPath: string): string | undefined {
   return getReleasePinFromConfig(readFileSync(configPath, "utf8"));
 }
@@ -66,6 +93,144 @@ function pinOf(configPath: string): string | undefined {
 function afterTimeout(): number {
   return Date.now() + PIN_JOURNAL_MAX_AGE_MS + 1;
 }
+
+describe("pin journal — the journal must outlive the container that wrote it", () => {
+  it("writes the journal into the DURABLE state dir, never beside the config", () => {
+    // THE production defect: the journal used to be `dirname(configPath)`.
+    // Inside hostd the config is a SINGLE-FILE bind mount
+    // (`~/.switchroom/switchroom.yaml` → `/state/config/switchroom.yaml`), so
+    // `/state/config` the directory is the container's writable overlay. The
+    // journal landed somewhere that exists nowhere on the host and dies with
+    // the container — making hostd-boot crash recovery dead code on exactly
+    // the path this module targets.
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+
+    const p = pinJournalPath(cfg);
+    expect(dirname(p)).toBe(stateDir); // the durable, directory-bind-mounted dir
+    expect(dirname(p)).not.toBe(dirname(cfg)); // NOT the config's (ephemeral) dir
+    expect(existsSync(p)).toBe(true);
+    // Nothing at all was dropped next to the config.
+    expect(readdirSync(dirname(cfg))).toEqual(["switchroom.yaml"]);
+  });
+
+  it("recovery still finds the journal after a container recreate wipes the config's directory", () => {
+    // The failure end-to-end. Inside hostd the config is a SINGLE-FILE bind
+    // mount, so `/state/config/switchroom.yaml` survives a recreate but
+    // `/state/config` the DIRECTORY is a fresh overlay: the file is remounted,
+    // anything else written there is gone. Modelled with a symlink into a
+    // separate "container view" directory that gets emptied.
+    const real = mkConfig();
+    const viewDir = mkdtempSync(join(tmpdir(), "pin-journal-view-"));
+    const viewPath = join(viewDir, "switchroom.yaml");
+    symlinkSync(real, viewPath); // the bind-mounted file
+
+    provisionallyPersist(viewPath, "v0.19.4");
+    expect(pinOf(real)).toBe("v0.19.4");
+
+    // …the container is recreated: the overlay is discarded, only the
+    // bind-mounted file is remounted.
+    for (const entry of readdirSync(viewDir)) {
+      if (entry !== "switchroom.yaml") rmSync(join(viewDir, entry), { recursive: true });
+    }
+    expect(existsSync(viewPath)).toBe(true);
+
+    // A fresh hostd boots and runs recovery against the same config path.
+    const note = recoverPinJournal(viewPath, { now: afterTimeout() });
+
+    expect(note).toMatch(/reverted an UNCOMMITTED release.pin=v0\.19\.4/);
+    // THE outcome: the durable pin names the last PROVEN build, so no later
+    // reconcile can converge the fleet onto the one that never proved out.
+    expect(pinOf(real)).toBe("v0.19.3");
+  });
+
+  it("creates the state dir when it does not exist yet", () => {
+    const fresh = join(stateDir, "nested", "state");
+    process.env.SWITCHROOM_PIN_JOURNAL_DIR = fresh;
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    expect(existsSync(pinJournalPath(cfg))).toBe(true);
+  });
+
+  it("falls back to <home>/.switchroom when nothing overrides it", () => {
+    delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+    // Not `dirname(configPath)` — the whole point. `homedir()` is the operator
+    // home on the host shell and `/host-home` inside hostd (whose compose pins
+    // HOME), so both resolve onto the same durable directory bind mount.
+    expect(pinJournalDir().endsWith("/.switchroom")).toBe(true);
+    expect(dirname(pinJournalPath("/state/config/switchroom.yaml"))).toBe(pinJournalDir());
+  });
+});
+
+describe("pin journal — two writers must not share one journal", () => {
+  it("keys the journal by config path, so hostd and a host shell stay separate", () => {
+    // Moving BOTH writers into one durable directory is what creates this
+    // hazard: hostd rolls against `/state/config/switchroom.yaml` while an
+    // operator's `sudo switchroom rollout` rolls against
+    // `~/.switchroom/switchroom.yaml`. Same file, different paths.
+    const hostd = pinJournalPath("/state/config/switchroom.yaml");
+    const shell = pinJournalPath("/home/op/.switchroom/switchroom.yaml");
+    expect(dirname(hostd)).toBe(dirname(shell)); // same durable directory…
+    expect(hostd).not.toBe(shell); // …different journals.
+  });
+
+  it("a failing roll does NOT revert to the other roll's priorPin", () => {
+    // THE damage a shared journal would do, asserted as an outcome. Roll A
+    // (hostd view) writes v2 over v1; roll B (host-shell view of the SAME
+    // file) then writes v3 over v2. With one shared journal, A's failure
+    // reverts to B's recorded priorPin (v2) and deletes B's journal, so B
+    // commits a no-op and reports success on a pin nobody proved.
+    const dir = mkdtempSync(join(tmpdir(), "pin-journal-two-"));
+    const real = join(dir, "switchroom.yaml");
+    writeFileSync(real, CONFIG.replace("v0.19.3", "v1"), "utf8");
+    // A second path onto the SAME file — the symlink stands in for hostd's
+    // single-file bind mount of `~/.switchroom/switchroom.yaml` onto
+    // `/state/config/switchroom.yaml`.
+    const asShell = real;
+    const asHostd = join(dir, "state-config.yaml");
+    symlinkSync(real, asHostd);
+
+    beginPinPersist(asHostd, "v2");
+    writeFileSync(real, setReleasePinInConfig(readFileSync(real, "utf8"), "v2"), "utf8");
+    beginPinPersist(asShell, "v3");
+    writeFileSync(real, setReleasePinInConfig(readFileSync(real, "utf8"), "v3"), "utf8");
+
+    // Roll A fails and reverts. It must restore ITS OWN prior pin (v1)…
+    expect(rollbackPinPersist(asHostd).priorPin).toBe("v1");
+    // …and must not have destroyed roll B's journal.
+    expect(hasPinJournal(asShell)).toBe(true);
+    expect(readPinJournal(asShell)?.priorPin).toBe("v2");
+  });
+
+  it("REFUSES to open a second journal while the first writer is alive", () => {
+    // Per-writer keying separates hostd from a host shell, but two rolls
+    // against the SAME config path would still collide. This is the exclusive
+    // gate: the second begin throws, so the caller never writes an
+    // unjournalled (or mis-journalled) provisional pin.
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4"); // journal pid = this live process
+
+    expect(() => beginPinPersist(cfg, "v0.19.5")).toThrow(/held by a LIVE roll/);
+    // The first roll's journal is intact, so ITS revert still works.
+    expect(readPinJournal(cfg)?.pin).toBe("v0.19.4");
+    expect(readPinJournal(cfg)?.priorPin).toBe("v0.19.3");
+  });
+
+  it("overwrites (with a warning) a journal whose writer is gone", () => {
+    // The other half: a crashed predecessor must not block every future roll.
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    const warnings: string[] = [];
+    // Journal aged past the cutoff = abandoned.
+    const j = beginPinPersist(cfg, "v0.19.5", {
+      warn: (m) => warnings.push(m),
+      now: afterTimeout(),
+    });
+    expect(j.pin).toBe("v0.19.5");
+    expect(warnings.join("")).toMatch(/overwriting an ABANDONED journal/);
+    expect(readPinJournal(cfg)?.pin).toBe("v0.19.5");
+  });
+});
 
 describe("pin journal — two-phase commit", () => {
   it("a provisional write changes the pin but leaves a journal", () => {
@@ -102,10 +267,17 @@ describe("pin journal — two-phase commit", () => {
     expect(out.pin).toBe("v0.19.4");
     expect(out.priorPin).toBe("v0.19.3");
     expect(pinOf(cfg)).toBe("v0.19.3");
-    // Every other key and its comments survive the targeted edit.
+    // Every other key AND its comments survive the targeted edit. Asserting
+    // the keys alone would pass under a comment-stripping rewrite
+    // (`yaml.stringify(obj)`), which is the failure mode this module bans, so
+    // the unrelated comment is asserted byte-for-byte…
     const text = readFileSync(cfg, "utf8");
-    expect(text).toContain("bot_token: x");
+    expect(text).toContain("bot_token: x # the fleet's bot credential");
     expect(text).toContain("clerk:");
+    // …and nothing outside the `release:` block moved at all.
+    const untouched = (s: string) =>
+      s.split("\n").filter((l) => !/^\s*pin:/.test(l)).join("\n");
+    expect(untouched(text)).toBe(untouched(CONFIG));
     expect(hasPinJournal(cfg)).toBe(false);
   });
 
@@ -139,8 +311,44 @@ describe("pin journal — two-phase commit", () => {
     expect(out.reverted).toBe(true);
     expect(out.priorPin).toBeUndefined();
     expect(pinOf(cfg)).toBeUndefined();
-    // No `release: {}` husk left behind — that fails the schema refine.
+    // The roll SYNTHESIZED the whole `release:` block, so the revert removes
+    // it again and the file is byte-identical to the pre-roll one.
     expect(readFileSync(cfg, "utf8")).not.toMatch(/release:/);
+    expect(readFileSync(cfg, "utf8")).toBe(unpinned);
+  });
+
+  it("does NOT destroy a documented `release:` block added during the roll", () => {
+    // The window this whole module exists for: the pin lands after the canary
+    // and the remaining agents take minutes. If an operator (or an approved
+    // config_propose_edit) adds a DOCUMENTED `release:` block in that window,
+    // the revert deletes the `pin` key it wrote — and must leave their
+    // documentation alone. Dropping the now-empty husk would take the
+    // `commentBefore` block with it.
+    const unpinned = `telegram:\n  bot_token: x\nagents:\n  clerk:\n    extends: default\n`;
+    const cfg = mkConfig(unpinned);
+    provisionallyPersist(cfg, "v0.19.4");
+    // …the operator documents the block mid-roll.
+    writeFileSync(
+      cfg,
+      readFileSync(cfg, "utf8").replace(
+        /^release:$/m,
+        "# Release channel / pin.\n# `channel` and `pin` are mutually exclusive.\n# Set by `switchroom rollout --pin`.\nrelease:",
+      ),
+      "utf8",
+    );
+    const commentLines = (s: string) => s.split("\n").filter((l) => l.trim().startsWith("#"));
+    expect(commentLines(readFileSync(cfg, "utf8"))).toHaveLength(3);
+
+    expect(rollbackPinPersist(cfg).reverted).toBe(true);
+
+    const text = readFileSync(cfg, "utf8");
+    expect(pinOf(cfg)).toBeUndefined(); // the pin IS reverted…
+    // …and every comment line survives, byte for byte.
+    expect(commentLines(text)).toEqual([
+      "# Release channel / pin.",
+      "# `channel` and `pin` are mutually exclusive.",
+      "# Set by `switchroom rollout --pin`.",
+    ]);
   });
 
   it("commit and rollback are both idempotent", () => {
@@ -180,12 +388,38 @@ describe("pin journal — liveness gate (a live roll must not be reverted)", () 
     expect(hasPinJournal(cfg)).toBe(true); // journal preserved for later
   });
 
-  it("reverts once the journal ages past the cutoff, even if the pid still resolves", () => {
-    // Pids are recycled and a recreated hostd can land on the recorded one,
-    // so age is the backstop that guarantees eventual recovery.
+  it("reverts a journal whose pid was REUSED by a container recreate", () => {
+    // THE systematic false-alive. Container PID namespaces restart at 1, so a
+    // roll inside hostd records a small pid (tens); when hostd is recreated —
+    // the primary recovery trigger — the new process tree occupies the same
+    // low range, `kill(pid, 0)` succeeds against an unrelated process, and a
+    // bare liveness probe declines recovery essentially always. The start-time
+    // discriminator is what tells the two apart: a process that started AFTER
+    // the journal was written cannot be the journal's writer.
     const cfg = mkConfig();
     provisionallyPersist(cfg, "v0.19.4");
-    const note = recoverPinJournal(cfg, { now: afterTimeout() });
+    const journal = readPinJournal(cfg)!;
+    // pid IS alive (it's this process) — only the start time says otherwise.
+    expect(isPidAlive(journal.pid)).toBe(true);
+
+    const note = recoverPinJournal(cfg, { startTimeMs: startedAfterJournal(journal) });
+
+    // Reverted WITHOUT waiting out the 15-minute age backstop.
+    expect(note).toMatch(/reverted an UNCOMMITTED release.pin=v0\.19\.4/);
+    expect(pinOf(cfg)).toBe("v0.19.3");
+    expect(hasPinJournal(cfg)).toBe(false);
+  });
+
+  it("reverts once the journal ages past the cutoff, even if the writer looks alive", () => {
+    // The residual backstop, for the cases start time cannot resolve
+    // (non-Linux, unreadable /proc) — both of which are treated conservatively
+    // as alive, so age is the only thing left.
+    const cfg = mkConfig();
+    provisionallyPersist(cfg, "v0.19.4");
+    const note = recoverPinJournal(cfg, {
+      now: afterTimeout(),
+      startTimeMs: () => null, // "cannot tell" → conservatively alive
+    });
     expect(note).toMatch(/reverted an UNCOMMITTED release.pin=v0\.19\.4/);
     expect(pinOf(cfg)).toBe("v0.19.3");
   });
@@ -197,6 +431,28 @@ describe("pin journal — liveness gate (a live roll must not be reverted)", () 
     provisionallyPersist(cfg, "v0.19.4");
     expect(rollbackPinPersist(cfg).reverted).toBe(true);
     expect(pinOf(cfg)).toBe("v0.19.3");
+  });
+
+  it("isJournalWriterAlive is conservative when it cannot decide", () => {
+    const j: RolloutPinJournal = {
+      v: 1,
+      configPath: "/c",
+      pin: "v1",
+      pid: process.pid,
+      at: new Date().toISOString(),
+    };
+    // Started before the journal → the writer.
+    expect(isJournalWriterAlive(j, () => Date.parse(j.at) - 1000)).toBe(true);
+    // Started after → pid reuse / a recreated container's tree.
+    expect(isJournalWriterAlive(j, () => Date.parse(j.at) + 1000)).toBe(false);
+    // Unknown start time → conservatively alive (age is the backstop).
+    expect(isJournalWriterAlive(j, () => null)).toBe(true);
+    // Undateable journal → conservatively alive.
+    expect(
+      isJournalWriterAlive({ ...j, at: "not-a-date" }, () => Date.now()),
+    ).toBe(true);
+    // A dead pid short-circuits before start time is consulted.
+    expect(isJournalWriterAlive({ ...j, pid: 0x3fffffff }, () => 0)).toBe(false);
   });
 
   it("isPidAlive / isJournalFresh behave at their edges", () => {

--- a/src/cli/rollout-pin-journal.ts
+++ b/src/cli/rollout-pin-journal.ts
@@ -71,9 +71,35 @@
  * journal. That matters: a shared journal would let a failing roll revert to
  * the OTHER roll's `priorPin` and delete its journal, after which the other
  * roll commits a no-op and reports success while the durable pin names the
- * wrong version. {@link beginPinPersist} additionally refuses to open a second
- * journal for the same config while the first writer is demonstrably alive, so
- * two rolls against the same config path cannot interleave either.
+ * wrong version.
+ *
+ * **What that keying does NOT buy: mutual exclusion between the two writers.**
+ * {@link beginPinPersist} refuses to open a second journal while the first
+ * writer is demonstrably alive, but that gate is keyed by journal path, i.e. by
+ * config-path STRING. The only two contending writers in this system —
+ * hostd (`/state/config/switchroom.yaml`) and a host-shell roll
+ * (`~/.switchroom/switchroom.yaml`) — reach the SAME physical file through that
+ * pair of strings (`cli/hostd.ts` bind-mounts one onto the other), so they get
+ * different journals and the gate can never fire BETWEEN them. It fires only
+ * between two rolls that resolved the same string: two host-shell rolls, or
+ * hostd against itself. Concurrent hostd + host-shell rolls are prevented by
+ * the fleet lock, not by this module; if that lock is bypassed, this module
+ * degrades to "each writer correctly reverts its own uncommitted write" and
+ * offers no ordering guarantee between them.
+ *
+ * Unifying the two is not available: the container path is a bind mount, not a
+ * symlink, so `realpath` returns it unchanged from inside hostd; inode keying
+ * breaks commit/revert, because `writeConfigFileSync` prefers tmp+rename and
+ * REPLACES the inode between {@link beginPinPersist} and
+ * {@link commitPinPersist}; and basename/constant keying collides genuinely
+ * different configs that share a filename (a repo checkout's
+ * `$PWD/switchroom.yaml` journals into `~/.switchroom` under rule 3 of
+ * {@link pinJournalDir}, next to the operator's fleet journal), which
+ * {@link rollbackPinPersist}'s `configPath` mismatch guard cannot tell apart
+ * from the legitimate two-namespace case. Path-string keying keeps the
+ * dangerous failure (cross-revert) impossible and leaves the benign one
+ * (no cross-writer exclusion) to the fleet lock. Pinned by
+ * "does NOT exclude the hostd/host-shell pair" in the tests.
  *
  * ## Why liveness + freshness
  *
@@ -222,8 +248,10 @@ export function pinJournalDir(configPath?: string): string {
  * (`/state/config/switchroom.yaml`) and a host-shell writer
  * (`~/.switchroom/switchroom.yaml`) on separate journals now that they share
  * one directory — see the module header for the concurrent-roll damage a
- * shared journal would cause. The config's basename is kept in the name purely
- * so an operator listing the directory can tell what a journal belongs to.
+ * shared journal would cause, and for why that same keying means
+ * {@link beginPinPersist}'s exclusivity gate does not span those two writers.
+ * The config's basename is kept in the name purely so an operator listing the
+ * directory can tell what a journal belongs to.
  */
 export function pinJournalPath(configPath: string): string {
   const abs = resolve(configPath);
@@ -373,8 +401,12 @@ export function readPinJournal(
  * Written atomically (tmp + rename) so a crash mid-write can never leave a
  * truncated journal that recovery would have to guess about.
  *
- * **Exclusive.** If a journal for this config already exists and its writer is
- * demonstrably alive, this THROWS rather than overwriting it. Two rolls sharing
+ * **Exclusive per journal path — which is per config-path STRING, not per
+ * file.** If a journal for this config already exists and its writer is
+ * demonstrably alive, this THROWS rather than overwriting it. That covers two
+ * rolls that resolved the same string; it does NOT cover hostd vs. a host-shell
+ * roll, which reach the same file through two different strings and so hold two
+ * different journals (module header, "What that keying does NOT buy"). Two rolls sharing
  * one journal is not a benign race: the loser's revert restores the winner's
  * `priorPin` and deletes the journal, after which the winner commits a no-op
  * and reports `ok:true` while the durable pin names the wrong version — worse

--- a/src/cli/rollout-pin-journal.ts
+++ b/src/cli/rollout-pin-journal.ts
@@ -41,6 +41,40 @@
  * change) would be silently reverted. The journal therefore carries only the
  * pin values, and the revert touches only `release.pin`.
  *
+ * ## Where the journal lives — and why NOT beside the config
+ *
+ * The journal MUST outlive the container that wrote it, because "hostd was
+ * recreated mid-roll" is the primary case it exists for. It therefore lives in
+ * the switchroom state directory (`<homedir()>/.switchroom`), which is a
+ * **directory** bind mount on every path that runs a roll:
+ *
+ *   - host shell — `homedir()` is the operator's home, so this is literally
+ *     `~/.switchroom`, the same directory `findConfigFile` searches;
+ *   - inside hostd — `hostd.ts` pins `HOME: /host-home` in the compose it
+ *     generates, and `/host-home/.switchroom` is bind-mounted from the
+ *     operator's `~/.switchroom`. Durable by construction.
+ *
+ * An earlier draft put the journal beside the config (`dirname(configPath)`).
+ * That is correct on the host shell and **silently wrong inside hostd**: the
+ * config there is a SINGLE-FILE bind mount (`~/.switchroom/switchroom.yaml` →
+ * `/state/config/switchroom.yaml`), so `/state/config` the *directory* is the
+ * container's writable overlay. The journal landed at
+ * `/state/config/.switchroom.yaml.rollout-pin-journal.json`, existed nowhere on
+ * the host, and died with the container — making the hostd-boot recovery site
+ * below dead code on exactly the path this module is aimed at. (The same
+ * single-file mount is why `rollout.ts` carries an in-place-rewrite fallback
+ * for EBUSY/EXDEV/EINVAL on the config.)
+ *
+ * Because both writers now share ONE directory, the filename is keyed by a
+ * digest of the absolute config path the writer sees — `/state/config/…`
+ * inside hostd, `~/.switchroom/…` on the host shell — so the two never share a
+ * journal. That matters: a shared journal would let a failing roll revert to
+ * the OTHER roll's `priorPin` and delete its journal, after which the other
+ * roll commits a no-op and reports success while the durable pin names the
+ * wrong version. {@link beginPinPersist} additionally refuses to open a second
+ * journal for the same config while the first writer is demonstrably alive, so
+ * two rolls against the same config path cannot interleave either.
+ *
  * ## Why liveness + freshness
  *
  * A journal on disk means "a pin write is uncommitted", NOT "the writer is
@@ -49,14 +83,25 @@
  * recovery revert the pin of a roll that is still running, or that already
  * succeeded. So recovery reverts only when the journal is **stale**:
  *
- *   - the recording pid is no longer alive (`isPidAlive`), **or**
+ *   - the recording process is gone ({@link isJournalWriterAlive}), **or**
  *   - the journal is older than {@link PIN_JOURNAL_MAX_AGE_MS}.
  *
- * This mirrors the sibling self-bump marker mechanism
- * (`parsePendingRolloutMarker` / `isMarkerFresh` in `host-control/self-bump.ts`),
- * deliberately: the same "did the thing that wrote this survive?" question,
- * answered the same way. The pid check alone is not enough — a recreated
- * hostd's pid can collide with the recorded one — so age is the backstop.
+ * `isJournalWriterAlive` is deliberately NOT a bare `kill(pid, 0)`. The pid is
+ * recorded inside a container, PID namespaces restart at 1, so a recreated
+ * hostd's process tree occupies the same low pid range — a bare probe answers
+ * "alive" for an unrelated process essentially always, precisely in the
+ * recreate case that triggers recovery. It therefore pairs the liveness probe
+ * with the process's **start time** (`/proc/<pid>/stat` field 22 against
+ * `/proc/stat:btime`), the same PID-reuse defence `vault/flock.ts` uses for the
+ * vault writer lock: a process that started AFTER the journal was written is
+ * not the journal's writer, whatever its pid says.
+ *
+ * The age check is the backstop *within* a recovery pass, for the residual
+ * cases start time cannot resolve (non-Linux, unreadable /proc — both treated
+ * conservatively as alive). It is NOT a periodic sweep: all three sites below
+ * are one-shot, so "the journal will eventually age out" only means "the next
+ * time one of these sites runs, age alone is enough". Nothing re-checks on a
+ * timer, and this module does not claim otherwise.
  *
  * The crash case is the reason this is a *file* and not an in-memory
  * try/finally: if the rollout process is SIGKILLed (or hostd is recreated
@@ -79,17 +124,28 @@ import {
   renameSync,
   unlinkSync,
   statSync,
+  mkdirSync,
 } from "node:fs";
-import { dirname, join, basename } from "node:path";
+import { homedir } from "node:os";
+import { createHash } from "node:crypto";
+import { join, basename, resolve, dirname } from "node:path";
 import {
   getReleasePinFromConfig,
   setReleasePinInConfig,
   deleteReleasePinInConfig,
 } from "./release-yaml.js";
+import { pidStartTimeMs } from "../vault/flock.js";
 
 /**
- * Age past which a journal is considered abandoned even if its pid still
- * resolves (pids are recycled, and a recreated hostd can land on the old one).
+ * Age past which a journal is considered abandoned even if
+ * {@link isJournalWriterAlive} could not rule its writer out (a `/proc` we
+ * cannot read, a non-Linux host, an undateable journal — all treated
+ * conservatively as alive).
+ *
+ * This bounds how long a recovery pass will defer to an unresolvable writer.
+ * It is NOT a promise that an abandoned pin self-heals on a timer: every
+ * recovery site is one-shot (see the module header), so the age check only
+ * takes effect the next time one of them runs.
  *
  * 15 minutes, matching `SELF_BUMP_MARKER_MAX_AGE_MS` in
  * `host-control/self-bump.ts` — the same question about the same subsystem
@@ -107,19 +163,72 @@ export interface RolloutPinJournal {
   pin: string;
   /** The pin in effect before the write. Absent = the config was unpinned. */
   priorPin?: string;
-  /** pid of the process that wrote the provisional pin (liveness probe). */
+  /**
+   * pid of the process that wrote the provisional pin. Only meaningful when
+   * paired with {@link RolloutPinJournal.at} — see {@link isJournalWriterAlive}.
+   */
   pid: number;
-  /** ISO timestamp of the begin (freshness backstop). */
+  /**
+   * ISO timestamp of the begin. Doubles as the freshness backstop AND the
+   * reference point for the start-time / PID-reuse check.
+   */
   at: string;
 }
 
+/** Name of the switchroom state directory, under the operator's home. */
+const STATE_DIR_NAME = ".switchroom";
+
 /**
- * Journal path for a given config. Sits beside the config (same directory,
- * so the same mount/ownership rules apply) and is dot-prefixed so it is never
- * mistaken for a config variant by the `*.yaml` globs.
+ * Directory the journal is written into: the switchroom state dir.
+ *
+ * This is the DURABLE, bind-mounted directory on every path that runs a roll.
+ * See the module header for why it must NOT be `dirname(configPath)` in
+ * general: inside hostd the config is a single-file bind mount, so its parent
+ * directory is container-ephemeral and a journal written there cannot survive
+ * the recreate it exists to recover from.
+ *
+ * Precedence:
+ *
+ *   1. `SWITCHROOM_PIN_JOURNAL_DIR` — a test seam, and an operator escape
+ *      hatch for a host whose state dir is elsewhere.
+ *   2. the config's own directory when it IS a `.switchroom` dir. This is the
+ *      host-shell case (`~/.switchroom/switchroom.yaml`), and taking it from
+ *      the config rather than `homedir()` removes the one ambiguity here:
+ *      `switchroom rollout` is documented "run with sudo", and whether sudo
+ *      leaves `HOME` as the operator's or resets it to `/root` is sudoers
+ *      policy. It never matches inside hostd, whose config dir is
+ *      `/state/config`.
+ *   3. `<homedir()>/.switchroom` — the hostd case, where `hostd.ts` pins
+ *      `HOME: /host-home` in the compose it generates and
+ *      `/host-home/.switchroom` is bind-mounted from the operator's
+ *      `~/.switchroom`. Durable by construction.
+ */
+export function pinJournalDir(configPath?: string): string {
+  const override = process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+  if (override && override.trim().length > 0) return override.trim();
+  if (configPath) {
+    const dir = dirname(resolve(configPath));
+    if (basename(dir) === STATE_DIR_NAME) return dir;
+  }
+  return join(homedir(), STATE_DIR_NAME);
+}
+
+/**
+ * Journal path for a given config: `<state dir>/.rollout-pin-journal.<key>.json`.
+ *
+ * Dot-prefixed so it is never mistaken for a config variant by the state dir's
+ * `*.yaml` globs, and keyed by a digest of the ABSOLUTE config path rather than
+ * co-located with it. The key is what keeps the hostd writer
+ * (`/state/config/switchroom.yaml`) and a host-shell writer
+ * (`~/.switchroom/switchroom.yaml`) on separate journals now that they share
+ * one directory — see the module header for the concurrent-roll damage a
+ * shared journal would cause. The config's basename is kept in the name purely
+ * so an operator listing the directory can tell what a journal belongs to.
  */
 export function pinJournalPath(configPath: string): string {
-  return join(dirname(configPath), `.${basename(configPath)}.rollout-pin-journal.json`);
+  const abs = resolve(configPath);
+  const key = createHash("sha256").update(abs).digest("hex").slice(0, 12);
+  return join(pinJournalDir(abs), `.rollout-pin-journal.${basename(abs)}.${key}.json`);
 }
 
 /** True when an uncommitted provisional pin write is on disk. */
@@ -142,6 +251,50 @@ export function isPidAlive(pid: number): boolean {
   } catch (e) {
     return (e as NodeJS.ErrnoException).code !== "ESRCH";
   }
+}
+
+/**
+ * Slop for the start-time comparison. The journal's `at` is stamped after the
+ * writer process started (it reads the config first), so a genuine writer's
+ * start time is always <= `at`. 100ms absorbs the 1-tick (10ms at USER_HZ=100)
+ * granularity of `/proc/<pid>/stat` start times — same tolerance
+ * `vault/flock.ts` uses for the identical check.
+ */
+const START_TIME_SLOP_MS = 100;
+
+/**
+ * Is the process that WROTE this journal still running?
+ *
+ * A bare `kill(pid, 0)` is not an answer here. The pid is recorded inside a
+ * container; PID namespaces start at 1, so recorded pids are small (tens) and
+ * after a container recreate the new process tree occupies the same low range.
+ * `isPidAlive(37)` then hits an unrelated live process and recovery declines —
+ * systematically, in exactly the recreate case recovery exists for.
+ *
+ * So the pid probe is paired with a start-time discriminator: if the process
+ * currently at `journal.pid` started AFTER the journal was written, the pid was
+ * reused (or belongs to a different container's tree) and the writer is gone.
+ * This is `vault/flock.ts`'s `pidIsOriginalHolder` defence, reusing the same
+ * `pidStartTimeMs` implementation rather than a second copy of the /proc parse.
+ *
+ * Conservative on unknown, in both directions: an unreadable `/proc` or an
+ * undateable journal returns true (treat as alive). Refusing to revert leaves a
+ * stale pin an operator can fix by hand; reverting a LIVE roll's pin actively
+ * fights the roll. {@link isJournalFresh} is the backstop for those cases.
+ *
+ * `startTimeMs` is injectable so tests can assert the recreate case without
+ * needing a real recycled pid.
+ */
+export function isJournalWriterAlive(
+  journal: RolloutPinJournal,
+  startTimeMs: (pid: number) => number | null = pidStartTimeMs,
+): boolean {
+  if (!isPidAlive(journal.pid)) return false;
+  const started = startTimeMs(journal.pid);
+  if (started === null) return true; // cannot tell — conservative
+  const writtenAt = Date.parse(journal.at);
+  if (!Number.isFinite(writtenAt)) return true; // cannot tell — conservative
+  return started <= writtenAt + START_TIME_SLOP_MS;
 }
 
 /**
@@ -220,11 +373,49 @@ export function readPinJournal(
  * Written atomically (tmp + rename) so a crash mid-write can never leave a
  * truncated journal that recovery would have to guess about.
  *
- * Throws only if the config is unreadable or the journal cannot be written —
- * in which case the caller must NOT proceed with the pin write either, since
- * an unjournalled pin write is exactly the defect this module prevents.
+ * **Exclusive.** If a journal for this config already exists and its writer is
+ * demonstrably alive, this THROWS rather than overwriting it. Two rolls sharing
+ * one journal is not a benign race: the loser's revert restores the winner's
+ * `priorPin` and deletes the journal, after which the winner commits a no-op
+ * and reports `ok:true` while the durable pin names the wrong version — worse
+ * than having no journal at all. A journal whose writer is gone (or which has
+ * aged out) is overwritten with a warning; blocking every future roll on a
+ * crashed predecessor's file would be its own outage.
+ *
+ * Throws only if the config is unreadable, a live roll holds the journal, or
+ * the journal cannot be written — in each case the caller must NOT proceed
+ * with the pin write, since an unjournalled pin write is exactly the defect
+ * this module prevents.
  */
-export function beginPinPersist(configPath: string, pin: string): RolloutPinJournal {
+export function beginPinPersist(
+  configPath: string,
+  pin: string,
+  opts: { warn?: (msg: string) => void; now?: number } = {},
+): RolloutPinJournal {
+  const warn = opts.warn ?? ((m: string) => process.stderr.write(m));
+  const p = pinJournalPath(configPath);
+
+  const existing = readPinJournal(configPath, warn);
+  if (existing) {
+    const now = opts.now ?? Date.now();
+    if (isJournalWriterAlive(existing) && isJournalFresh(existing, now)) {
+      throw new Error(
+        `rollout pin journal: ${p} is held by a LIVE roll (pid ${existing.pid}, ` +
+          `provisional pin ${existing.pin}, started ${existing.at}). Refusing to ` +
+          `start a second provisional pin write against ${configPath} — two ` +
+          `concurrent rolls sharing one journal can leave the durable ` +
+          `\`release.pin\` naming the wrong version. Wait for that roll to ` +
+          `finish, or delete the journal host-side if you know it is dead.`,
+      );
+    }
+    warn(
+      `⚠️  rollout pin journal: overwriting an ABANDONED journal at ${p} ` +
+        `(pid ${existing.pid} recorded ${existing.at}, provisional pin ` +
+        `${existing.pin}). Its roll never committed or reverted; \`release.pin\` ` +
+        `in ${configPath} may still name that unproven build — verify it.\n`,
+    );
+  }
+
   const priorPin = getReleasePinFromConfig(readFileSync(configPath, "utf8"));
   const journal: RolloutPinJournal = {
     v: 1,
@@ -234,7 +425,9 @@ export function beginPinPersist(configPath: string, pin: string): RolloutPinJour
     pid: process.pid,
     at: new Date().toISOString(),
   };
-  const p = pinJournalPath(configPath);
+  // The state dir exists on every real host (it holds switchroom.yaml), but a
+  // journal write must never be the thing that fails a roll on a fresh box.
+  mkdirSync(dirname(p), { recursive: true });
   const tmp = `${p}.${process.pid}.tmp`;
   writeFileSync(tmp, JSON.stringify(journal), { encoding: "utf8", mode: 0o600 });
   renameSync(tmp, p);
@@ -303,6 +496,7 @@ export function rollbackPinPersist(
     writeConfig?: (path: string, text: string, mode: number) => void;
     warn?: (msg: string) => void;
     now?: number;
+    startTimeMs?: (pid: number) => number | null;
   } = {},
 ): PinRollbackOutcome {
   const warn = opts.warn ?? ((m: string) => process.stderr.write(m));
@@ -321,7 +515,10 @@ export function rollbackPinPersist(
 
   if (opts.requireStale) {
     const now = opts.now ?? Date.now();
-    if (isPidAlive(journal.pid) && isJournalFresh(journal, now)) {
+    if (
+      isJournalWriterAlive(journal, opts.startTimeMs ?? pidStartTimeMs) &&
+      isJournalFresh(journal, now)
+    ) {
       return { reverted: false, pin: journal.pin, skippedLive: true };
     }
   }
@@ -376,6 +573,7 @@ export function recoverPinJournal(
     writeConfig?: (path: string, text: string, mode: number) => void;
     warn?: (msg: string) => void;
     now?: number;
+    startTimeMs?: (pid: number) => number | null;
   } = {},
 ): string | null {
   let outcome: PinRollbackOutcome;
@@ -387,8 +585,9 @@ export function recoverPinJournal(
   if (outcome.skippedLive) {
     return (
       `rollout pin journal: left release.pin=${outcome.pin} alone — the roll ` +
-      `that wrote it still looks live (its process is running and the journal ` +
-      `is under ${PIN_JOURNAL_MAX_AGE_MS / 60000}min old).`
+      `that wrote it still looks live (its pid is running, its process start ` +
+      `time predates the journal, and the journal is under ` +
+      `${PIN_JOURNAL_MAX_AGE_MS / 60000}min old).`
     );
   }
   if (outcome.reverted) {

--- a/src/cli/rollout-pin-journal.ts
+++ b/src/cli/rollout-pin-journal.ts
@@ -1,0 +1,411 @@
+/**
+ * Durable pin journal — makes the rollout's `release.pin` write **provisional
+ * until the roll is proven**.
+ *
+ * ## The bug this closes
+ *
+ * `planRollout` emits a `persist-pin` step (first on the host-shell path,
+ * just-after-the-canary on the hostd path). Once that step ran, the durable
+ * pin in `switchroom.yaml` IS the target version — permanently, even if the
+ * roll then fails. `executeRollout` returns `ok:false` and nothing reverts it,
+ * and hostd's `recoverFailedAutoRollout` explicitly declines to act on
+ * past-canary failures ("Past-canary failures are NOT auto-rolled-back",
+ * `src/host-control/server.ts`). From that moment every later `agent restart`,
+ * crash-loop recreate, reconcile or `docker compose up -d` reads the broken
+ * pin and converges the *remaining* agents onto a build that demonstrably
+ * failed to boot: the fleet drifts toward broken instead of staying
+ * mixed-but-working.
+ *
+ * ## The mechanism
+ *
+ * Persisting the pin is a two-phase commit:
+ *
+ *   1. **begin** — before rewriting `switchroom.yaml`, write a journal file
+ *      next to it recording *which pin* is being written, *which pin it
+ *      replaces*, the writing process's **pid**, and the time. Then write the
+ *      new pin.
+ *   2. **commit** — only when the whole roll returned `ok:true`, delete the
+ *      journal. The pin is now durable.
+ *   3. **rollback** — on any failure return, make a **targeted** edit that
+ *      restores `release.pin` to `priorPin` (or deletes it when there was
+ *      none), then clear the journal.
+ *
+ * ## Why targeted, not a snapshot restore
+ *
+ * An earlier draft stored the byte-exact prior config and restored it
+ * wholesale. That is the mirror image of the bug it fixes: on the hostd path
+ * the provisional write lands right after the canary and the remaining agents
+ * take minutes, so a rollback commonly runs long after the write — and after a
+ * crash, arbitrarily later. Any config edit made in that window (an operator
+ * adding an agent, an approved `config_propose_edit`, a vault reference
+ * change) would be silently reverted. The journal therefore carries only the
+ * pin values, and the revert touches only `release.pin`.
+ *
+ * ## Why liveness + freshness
+ *
+ * A journal on disk means "a pin write is uncommitted", NOT "the writer is
+ * dead". A hostd restart mid-roll (the host-shell path refreshes hostd as its
+ * last step; a self-bump recreates it outright) would otherwise make boot
+ * recovery revert the pin of a roll that is still running, or that already
+ * succeeded. So recovery reverts only when the journal is **stale**:
+ *
+ *   - the recording pid is no longer alive (`isPidAlive`), **or**
+ *   - the journal is older than {@link PIN_JOURNAL_MAX_AGE_MS}.
+ *
+ * This mirrors the sibling self-bump marker mechanism
+ * (`parsePendingRolloutMarker` / `isMarkerFresh` in `host-control/self-bump.ts`),
+ * deliberately: the same "did the thing that wrote this survive?" question,
+ * answered the same way. The pid check alone is not enough — a recreated
+ * hostd's pid can collide with the recorded one — so age is the backstop.
+ *
+ * The crash case is the reason this is a *file* and not an in-memory
+ * try/finally: if the rollout process is SIGKILLed (or hostd is recreated
+ * under it) between step 1 and step 2, the journal survives on disk. Any of
+ * the three recovery sites then reverts it:
+ *
+ *   - hostd startup — covers "hostd died mid-roll";
+ *   - hostd's rollout terminal handler — covers "the roll child died mid-roll
+ *     while hostd survived" (no sentinel, so the outcome was never captured);
+ *   - the start of the next `switchroom rollout` — covers the host-shell path.
+ *
+ * A committed roll leaves no journal, so recovery is a no-op in the happy
+ * case. Recovery is idempotent and best-effort: it never throws into a caller.
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+  statSync,
+} from "node:fs";
+import { dirname, join, basename } from "node:path";
+import {
+  getReleasePinFromConfig,
+  setReleasePinInConfig,
+  deleteReleasePinInConfig,
+} from "./release-yaml.js";
+
+/**
+ * Age past which a journal is considered abandoned even if its pid still
+ * resolves (pids are recycled, and a recreated hostd can land on the old one).
+ *
+ * 15 minutes, matching `SELF_BUMP_MARKER_MAX_AGE_MS` in
+ * `host-control/self-bump.ts` — the same question about the same subsystem
+ * should not have two different answers. A staggered fleet roll is minutes,
+ * not tens of minutes; a journal older than this is not a roll in progress.
+ */
+export const PIN_JOURNAL_MAX_AGE_MS = 15 * 60 * 1000;
+
+/** Journal schema. Records pin VALUES only — never a config snapshot. */
+export interface RolloutPinJournal {
+  v: 1;
+  /** Absolute path of the config the pin was written into. */
+  configPath: string;
+  /** The pin that was provisionally written. */
+  pin: string;
+  /** The pin in effect before the write. Absent = the config was unpinned. */
+  priorPin?: string;
+  /** pid of the process that wrote the provisional pin (liveness probe). */
+  pid: number;
+  /** ISO timestamp of the begin (freshness backstop). */
+  at: string;
+}
+
+/**
+ * Journal path for a given config. Sits beside the config (same directory,
+ * so the same mount/ownership rules apply) and is dot-prefixed so it is never
+ * mistaken for a config variant by the `*.yaml` globs.
+ */
+export function pinJournalPath(configPath: string): string {
+  return join(dirname(configPath), `.${basename(configPath)}.rollout-pin-journal.json`);
+}
+
+/** True when an uncommitted provisional pin write is on disk. */
+export function hasPinJournal(configPath: string): boolean {
+  return existsSync(pinJournalPath(configPath));
+}
+
+/**
+ * Is `pid` a live process? `kill(pid, 0)` throws ESRCH when it is not, and
+ * EPERM when it exists but is owned by another user — EPERM therefore means
+ * ALIVE. Treats an unknown error as alive: refusing to revert is the safe
+ * default (a stale pin is recoverable by hand; a wrongly-reverted pin on a
+ * live roll actively fights the roll).
+ */
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+/**
+ * Is this journal still plausibly owned by a running roll? Mirrors
+ * `isMarkerFresh` (host-control/self-bump.ts). An unparseable timestamp is
+ * treated as NOT fresh — a journal we cannot date is a journal we cannot
+ * trust to be in-flight.
+ */
+export function isJournalFresh(journal: RolloutPinJournal, nowMs: number): boolean {
+  const created = Date.parse(journal.at);
+  if (!Number.isFinite(created)) return false;
+  return nowMs - created < PIN_JOURNAL_MAX_AGE_MS;
+}
+
+/**
+ * Read + validate the journal.
+ *
+ * Returns null when absent. A journal that EXISTS but is unreadable or
+ * malformed is a **loud** condition, not a silent no-op: it means a pin write
+ * may be uncommitted with no way to tell what to revert to, which an operator
+ * must know about. The `warn` sink is invoked in that case (and defaults to
+ * stderr) before null is returned.
+ */
+export function readPinJournal(
+  configPath: string,
+  warn: (msg: string) => void = (m) => process.stderr.write(m),
+): RolloutPinJournal | null {
+  const p = pinJournalPath(configPath);
+  let raw: string;
+  try {
+    raw = readFileSync(p, "utf8");
+  } catch (e) {
+    if (existsSync(p)) {
+      warn(
+        `⚠️  rollout pin journal: ${p} exists but could not be read ` +
+          `(${(e as Error).message}). A provisional \`release.pin\` may be ` +
+          `uncommitted — verify it host-side before the next reconcile.\n`,
+      );
+    }
+    return null;
+  }
+  const bad = (why: string): null => {
+    warn(
+      `⚠️  rollout pin journal: ${p} is unusable (${why}). A rollout may have ` +
+        `left an unproven \`release.pin\` in ${configPath} that CANNOT be ` +
+        `auto-reverted — check it host-side, then delete the journal file.\n`,
+    );
+    return null;
+  };
+  let obj: unknown;
+  try {
+    obj = JSON.parse(raw);
+  } catch (e) {
+    return bad(`not valid JSON: ${(e as Error).message}`);
+  }
+  if (typeof obj !== "object" || obj === null) return bad("not a JSON object");
+  const o = obj as Record<string, unknown>;
+  if (o.v !== 1) return bad(`unknown schema version ${JSON.stringify(o.v)}`);
+  if (typeof o.configPath !== "string") return bad("missing configPath");
+  if (typeof o.pin !== "string") return bad("missing pin");
+  if (typeof o.pid !== "number") return bad("missing pid");
+  if (typeof o.at !== "string") return bad("missing timestamp");
+  return {
+    v: 1,
+    configPath: o.configPath,
+    pin: o.pin,
+    ...(typeof o.priorPin === "string" ? { priorPin: o.priorPin } : {}),
+    pid: o.pid,
+    at: o.at,
+  };
+}
+
+/**
+ * Phase 1 — record the pin being provisionally written, and what it replaces.
+ *
+ * Written atomically (tmp + rename) so a crash mid-write can never leave a
+ * truncated journal that recovery would have to guess about.
+ *
+ * Throws only if the config is unreadable or the journal cannot be written —
+ * in which case the caller must NOT proceed with the pin write either, since
+ * an unjournalled pin write is exactly the defect this module prevents.
+ */
+export function beginPinPersist(configPath: string, pin: string): RolloutPinJournal {
+  const priorPin = getReleasePinFromConfig(readFileSync(configPath, "utf8"));
+  const journal: RolloutPinJournal = {
+    v: 1,
+    configPath,
+    pin,
+    ...(priorPin ? { priorPin } : {}),
+    pid: process.pid,
+    at: new Date().toISOString(),
+  };
+  const p = pinJournalPath(configPath);
+  const tmp = `${p}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(journal), { encoding: "utf8", mode: 0o600 });
+  renameSync(tmp, p);
+  return journal;
+}
+
+/**
+ * Phase 2 — the roll succeeded; the pin is durable.
+ *
+ * Returns an error message when the journal could NOT be removed and still
+ * exists. That is not cosmetic: a journal that survives a successful commit is
+ * exactly the input that makes the next boot revert a *proven* pin, so the
+ * caller must surface it. A journal that is simply already gone is a success
+ * (commit is idempotent).
+ */
+export function commitPinPersist(configPath: string): string | null {
+  const p = pinJournalPath(configPath);
+  try {
+    unlinkSync(p);
+    return null;
+  } catch (e) {
+    if (!existsSync(p)) return null; // already gone — idempotent success
+    return (
+      `rollout pin journal: FAILED to clear ${p} after a SUCCESSFUL roll ` +
+      `(${(e as Error).message}). Delete it host-side — while it exists, ` +
+      `recovery may revert a proven \`release.pin\`.`
+    );
+  }
+}
+
+/** Outcome of a rollback attempt, for operator-facing notes. */
+export interface PinRollbackOutcome {
+  /** True when a journal existed and `release.pin` was reverted. */
+  reverted: boolean;
+  /** The provisional pin that was rolled back (when reverted). */
+  pin?: string;
+  /** The pin restored — absent means the pin was deleted (was unpinned). */
+  priorPin?: string;
+  /** Set when the journal was left alone because its writer looks alive. */
+  skippedLive?: boolean;
+  /** Set when a journal existed but the revert failed. */
+  error?: string;
+}
+
+/**
+ * Phase 3 — revert the provisional pin with a targeted `release.pin` edit,
+ * then clear the journal.
+ *
+ * Never throws: a failed revert is reported in the outcome so the caller can
+ * surface it to the operator. Callable at any time — a no-op (and cheap) when
+ * no journal exists, which is what makes it safe to run unconditionally.
+ *
+ * `opts.requireStale` is what recovery sites pass: it declines to revert while
+ * the recording process is still alive AND the journal is young, so a hostd
+ * restart mid-roll cannot revert a roll that is still running (or has already
+ * succeeded but not yet committed). The rollout's OWN failure path leaves it
+ * false — that caller *is* the writer and knows the roll is over.
+ *
+ * `writeConfig` is injectable so the production caller can route through the
+ * hardened atomic/ownership-preserving writer while tests stay hermetic.
+ */
+export function rollbackPinPersist(
+  configPath: string,
+  opts: {
+    requireStale?: boolean;
+    writeConfig?: (path: string, text: string, mode: number) => void;
+    warn?: (msg: string) => void;
+    now?: number;
+  } = {},
+): PinRollbackOutcome {
+  const warn = opts.warn ?? ((m: string) => process.stderr.write(m));
+  const journal = readPinJournal(configPath, warn);
+  if (!journal) return { reverted: false };
+
+  // A journal written for a DIFFERENT config is not ours to act on. (Same
+  // directory, different file — e.g. a config path that moved between runs.)
+  if (journal.configPath !== configPath) {
+    warn(
+      `⚠️  rollout pin journal: journal records configPath=${journal.configPath} ` +
+        `but recovery is running against ${configPath}. Refusing to revert.\n`,
+    );
+    return { reverted: false, pin: journal.pin, error: "configPath mismatch" };
+  }
+
+  if (opts.requireStale) {
+    const now = opts.now ?? Date.now();
+    if (isPidAlive(journal.pid) && isJournalFresh(journal, now)) {
+      return { reverted: false, pin: journal.pin, skippedLive: true };
+    }
+  }
+
+  try {
+    const current = readFileSync(configPath, "utf8");
+    const next = journal.priorPin
+      ? setReleasePinInConfig(current, journal.priorPin)
+      : deleteReleasePinInConfig(current);
+    let mode = 0o600;
+    try {
+      mode = statSync(configPath).mode & 0o777;
+    } catch {
+      /* config missing/unreadable — fall back to owner-only */
+    }
+    if (opts.writeConfig) {
+      opts.writeConfig(configPath, next, mode);
+    } else {
+      writeFileSync(configPath, next, { encoding: "utf8", mode });
+    }
+  } catch (e) {
+    return {
+      reverted: false,
+      pin: journal.pin,
+      ...(journal.priorPin ? { priorPin: journal.priorPin } : {}),
+      error: (e as Error).message,
+    };
+  }
+  const commitErr = commitPinPersist(configPath);
+  if (commitErr) warn(`⚠️  ${commitErr}\n`);
+  return {
+    reverted: true,
+    pin: journal.pin,
+    ...(journal.priorPin ? { priorPin: journal.priorPin } : {}),
+  };
+}
+
+/**
+ * Crash recovery entry point. Reverts an uncommitted provisional pin left by
+ * a rollout that died between the pin write and the roll's terminal, and
+ * returns a human-readable note (null when there was nothing to do).
+ *
+ * Always stale-gated — every caller of this is a recovery site that may be
+ * running *concurrently* with a live roll.
+ *
+ * Best-effort by contract — callers wire this into startup paths where a
+ * throw would be worse than a stale pin, so it swallows everything.
+ */
+export function recoverPinJournal(
+  configPath: string,
+  opts: {
+    writeConfig?: (path: string, text: string, mode: number) => void;
+    warn?: (msg: string) => void;
+    now?: number;
+  } = {},
+): string | null {
+  let outcome: PinRollbackOutcome;
+  try {
+    outcome = rollbackPinPersist(configPath, { ...opts, requireStale: true });
+  } catch (e) {
+    return `rollout pin journal: recovery threw (${(e as Error).message}) — verify \`release.pin\` in ${configPath} host-side.`;
+  }
+  if (outcome.skippedLive) {
+    return (
+      `rollout pin journal: left release.pin=${outcome.pin} alone — the roll ` +
+      `that wrote it still looks live (its process is running and the journal ` +
+      `is under ${PIN_JOURNAL_MAX_AGE_MS / 60000}min old).`
+    );
+  }
+  if (outcome.reverted) {
+    return (
+      `rollout pin journal: reverted an UNCOMMITTED release.pin=${outcome.pin} ` +
+      `left by a rollout that did not complete` +
+      (outcome.priorPin ? ` (restored ${outcome.priorPin})` : " (pin removed)") +
+      `. The fleet keeps the prior pin so reconciles cannot converge onto an ` +
+      `unproven build.`
+    );
+  }
+  if (outcome.error) {
+    return (
+      `rollout pin journal: FAILED to revert an uncommitted release.pin=` +
+      `${outcome.pin} (${outcome.error}). Check \`release.pin\` in ` +
+      `${configPath} host-side before the next reconcile.`
+    );
+  }
+  return null;
+}

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -2259,15 +2259,15 @@ describe("rollout CLI — the pre-roll crash net and its --dry-run gate", () => 
     }
 
     // It really did reach the plan print, so the gate above it ran. Anchored on
-    // `formatRolloutPlan`'s header, which nothing else in this command emits:
-    // an alternation including /rollout/i matches almost any stdout the verb
-    // can produce (its own usage text, an error, the command name itself), so
-    // it would assert far less than this comment claims. `persist-pin` is NOT
-    // the anchor — this invocation plans no such step (the pin already matches
-    // the config), so matching on it would fail for a reason unrelated to the
-    // gate.
+    // `formatRolloutPlan`'s own output, which nothing else in this command
+    // emits: an alternation including /rollout/i matches almost any stdout the
+    // verb can produce (its usage text, an error, the command name itself), so
+    // it would assert far less than this comment claims. Note the rendered
+    // literal is `persist release.pin=`, NOT the step KIND `persist-pin` — the
+    // renderer spells the step out, so matching the kind name would fail here
+    // for a reason that has nothing to do with the gate under test.
     expect(out.join("")).toMatch(/Rollout plan → v0\.0\.1:/);
-    expect(out.join("")).toMatch(/apply — regenerate compose/);
+    expect(out.join("")).toMatch(/persist release\.pin=v0\.0\.1 to switchroom\.yaml/);
     // …and NOTHING on disk moved.
     expect(getReleasePinFromConfig(readFileSync(configPath, "utf8"))).toBe("v0.19.3");
     expect(hasPinJournal(configPath)).toBe(true);

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -8,7 +8,15 @@
  * injected side-effects so this runs without docker.
  */
 
-import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  statSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, expect, afterEach } from "vitest";
@@ -41,14 +49,13 @@ import {
 } from "./rollout.js";
 import {
   beginPinPersist,
-  commitPinPersist,
-  rollbackPinPersist,
   hasPinJournal,
   pinJournalPath,
+  readPinJournal,
   recoverPinJournal,
   PIN_JOURNAL_MAX_AGE_MS,
 } from "./rollout-pin-journal.js";
-import { setReleasePinInConfig, getReleasePinFromConfig } from "./release-yaml.js";
+import { getReleasePinFromConfig } from "./release-yaml.js";
 import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
 
 describe("normalizeVersion", () => {
@@ -1125,8 +1132,22 @@ describe("executeRollout — phase emission", () => {
 // `release.pin` say after the roll? — not that a hook was invoked.
 
 /**
- * Deps wired to the REAL pin-journal implementation against a tmpdir config,
- * mirroring `createRolloutDeps`'s persist/commit/revert triple.
+ * Deps for the pin scenarios below, built from the REAL
+ * {@link createRolloutDeps} against a tmpdir config.
+ *
+ * It used to hand-roll its own persist/commit/revert triple that "mirrored"
+ * the production factory. That shape is a false-green generator: a harness
+ * that reimplements the thing under test asserts only that the COPY works.
+ * It hid three production lines completely — `beginPinPersist` inside
+ * `persistPin`, its ordering relative to the config write, and
+ * `revertPin`'s `writeConfig: writeConfigPreservingOwnership` — each of which
+ * could be deleted from `rollout.ts` with the whole suite still green.
+ *
+ * Only the four deps that genuinely need faking are overridden: `run` and
+ * `probeVersion` (which would otherwise spawn docker), `log` (noise), and
+ * `hindsightExists`. The `spawn` handed to the factory throws, so a leak of
+ * any un-overridden subprocess dep fails loudly instead of silently shelling
+ * out from a unit test.
  */
 function pinHarness(opts: {
   versions: Record<string, string | null>;
@@ -1151,21 +1172,21 @@ function pinHarness(opts: {
     "utf8",
   );
   const deps: RolloutDeps = {
+    // THE PRODUCTION persist/commit/revert triple — not a copy of it.
+    ...createRolloutDeps({
+      configPath,
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      spawn: (() => {
+        throw new Error("pinHarness: an un-overridden dep tried to spawn a subprocess");
+      }) as unknown as RolloutSpawnSync,
+      warn: () => undefined,
+    }),
     run: (args) => ({ status: opts.runStatus ? opts.runStatus(args) : 0 }),
     probeVersion: (agent) => opts.versions[agent] ?? null,
     log: () => undefined,
+    emitPhase: () => undefined,
     hindsightExists: () => false,
-    persistPin: (p) => {
-      const before = readFileSync(configPath, "utf8");
-      const after = setReleasePinInConfig(before, p);
-      if (after === before) return;
-      beginPinPersist(configPath, p);
-      writeFileSync(configPath, after, "utf8");
-    },
-    // Mirrors createRolloutDeps: the error is RETURNED so the executor can
-    // put it in RolloutResult.warnings, not just written to stderr.
-    commitPin: () => commitPinPersist(configPath),
-    revertPin: () => rollbackPinPersist(configPath).reverted,
   };
   return {
     deps,
@@ -1247,6 +1268,91 @@ describe("executeRollout — durable pin is provisional until the roll is proven
     expect(r.pinReverted).toBe(true);
     expect(h.journalled()).toBe(false);
     expect(r.warnings.join(" ")).toMatch(/REVERTED to the prior version/);
+  });
+
+  it("createRolloutDeps' persistPin JOURNALS to disk before it writes the pin", () => {
+    // The production wiring, exercised directly rather than through a harness
+    // that mirrors it. Three separate production lines live here and nothing
+    // else covers them: the `beginPinPersist` call itself, its ORDERING
+    // relative to the config write, and the state dir the journal lands in.
+    const stateDir = mkdtempSync(join(tmpdir(), "rollout-persist-state-"));
+    process.env.SWITCHROOM_PIN_JOURNAL_DIR = stateDir;
+    const dir = mkdtempSync(join(tmpdir(), "rollout-persist-"));
+    const configPath = join(dir, "switchroom.yaml");
+    writeFileSync(
+      configPath,
+      `telegram:\n  bot_token: x\nrelease:\n  pin: v0.19.3\nagents:\n  clerk:\n    extends: default\n`,
+      "utf8",
+    );
+    const deps = createRolloutDeps({
+      configPath,
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      spawn: (() => {
+        throw new Error("no subprocess expected");
+      }) as unknown as RolloutSpawnSync,
+      warn: () => undefined,
+    });
+
+    deps.persistPin?.(TARGET);
+
+    // A journal EXISTS on disk, in the durable state dir — delete the
+    // `beginPinPersist(configPath, pin)` line from production `persistPin` and
+    // this is the assertion that notices.
+    const journalPath = pinJournalPath(configPath);
+    expect(journalPath.startsWith(stateDir + "/")).toBe(true);
+    expect(existsSync(journalPath)).toBe(true);
+    // …and it was written BEFORE the config, so it records the pin being
+    // REPLACED. Move `beginPinPersist` after `writeConfigPreservingOwnership`
+    // and priorPin becomes the new pin — two-phase commit silently defeated,
+    // with the journal still present to make it look wired.
+    const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+      pin: string;
+      priorPin?: string;
+    };
+    expect(journal.pin).toBe(TARGET);
+    expect(journal.priorPin).toBe("v0.19.3");
+    expect(getReleasePinFromConfig(readFileSync(configPath, "utf8"))).toBe(TARGET);
+    delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+  });
+
+  it("createRolloutDeps' revertPin restores the pin through the ownership-preserving writer", () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "rollout-revert-state-"));
+    process.env.SWITCHROOM_PIN_JOURNAL_DIR = stateDir;
+    const dir = mkdtempSync(join(tmpdir(), "rollout-revert-"));
+    const configPath = join(dir, "switchroom.yaml");
+    writeFileSync(
+      configPath,
+      `telegram:\n  bot_token: x # keep me\nrelease:\n  pin: v0.19.3\nagents:\n  clerk:\n    extends: default\n`,
+      "utf8",
+    );
+    const deps = createRolloutDeps({
+      configPath,
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      spawn: (() => {
+        throw new Error("no subprocess expected");
+      }) as unknown as RolloutSpawnSync,
+      warn: () => undefined,
+    });
+    deps.persistPin?.(TARGET);
+    const inodeAfterPersist = statSync(configPath).ino;
+
+    expect(deps.revertPin?.()).toBe(true);
+
+    expect(getReleasePinFromConfig(readFileSync(configPath, "utf8"))).toBe("v0.19.3");
+    expect(hasPinJournal(configPath)).toBe(false);
+    expect(readFileSync(configPath, "utf8")).toContain("bot_token: x # keep me");
+    // Routed through `writeConfigPreservingOwnership` — NOT a bare
+    // `writeFileSync`. The observable signature is the atomic tmp+rename:
+    // it REPLACES the inode (which is precisely why that writer has to chown
+    // back afterwards — CLAUDE.md's "tmp+rename re-owns the file to the
+    // writer's euid" rule). A bare `writeFileSync` truncates in place and
+    // keeps the inode, so dropping
+    // `writeConfig: writeConfigPreservingOwnership` from production
+    // `revertPin` flips this.
+    expect(statSync(configPath).ino).not.toBe(inodeAfterPersist);
+    delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
   });
 
   it("createRolloutDeps' commitPin RETURNS the error, not just warns it", () => {
@@ -1412,6 +1518,30 @@ describe("executeRollout — durable pin is provisional until the roll is proven
     expect(h.pin()).toBe(TARGET);
   });
 
+  it("does NOT commit a journal it never wrote", () => {
+    // `commitPin` unlinks the journal for this config. A roll that persisted
+    // NOTHING (target came from `config.release.pin`) must therefore leave it
+    // alone: the journal on disk belongs to an earlier roll that crashed
+    // mid-persist, and it is the only record that `release.pin` names an
+    // unproven build. Deleting it on this roll's success destroys the
+    // crash-recovery evidence permanently — every recovery site keys off the
+    // file's existence — and the bad pin becomes undetectable.
+    const h = pinHarness({
+      versions: { "test-harness": "0.19.4" },
+      initialPin: TARGET,
+    });
+    beginPinPersist(h.configPath, TARGET); // the crashed roll's journal
+    const steps = planRollout(["test-harness"], { hostdContext: true });
+    expect(steps.some((s) => s.kind === "persist-pin")).toBe(false);
+
+    const r = executeRollout(steps, TARGET, h.deps, { hostdContext: true });
+
+    expect(r.ok).toBe(true);
+    expect(h.journalled()).toBe(true);
+    // …and it still names the earlier roll's write, so recovery can act on it.
+    expect(readPinJournal(h.configPath)?.priorPin).toBe(TARGET);
+  });
+
   it("warns loudly when the pin was persisted but no revert hook is wired", () => {
     const deps: RolloutDeps = {
       run: () => ({ status: 0 }),
@@ -1423,6 +1553,72 @@ describe("executeRollout — durable pin is provisional until the roll is proven
     const r = executeRollout(steps, TARGET, deps);
     expect(r.ok).toBe(false);
     expect(r.warnings.join(" ")).toMatch(/no revert hook was wired/);
+  });
+
+  it("REPORTS a step that THREW instead of dying without a result", () => {
+    // `beginPinPersist` THROWS by contract when a live roll already holds the
+    // journal, and nothing between it and the commander caught that. The
+    // exception escaped `executeRollout`, so `encodeRolloutResultLine` never
+    // ran and hostd took its no-sentinel branch: `result` inferred from the
+    // exit code, no `rolled`, no `failedStep`. `fail()`'s docstring called
+    // itself "the single exit point for every stop-the-roll failure" while
+    // this path bypassed it entirely.
+    const h = pinHarness({ versions: {} });
+    const deps: RolloutDeps = {
+      ...h.deps,
+      persistPin: () => {
+        throw new Error("rollout pin journal: … is held by a LIVE roll (pid 41 …)");
+      },
+    };
+    const steps = planRollout(["clerk"], { pinToPersist: TARGET });
+    expect(steps[0]).toEqual({ kind: "persist-pin", pin: TARGET });
+
+    let r: RolloutResult | undefined;
+    expect(() => {
+      r = executeRollout(steps, TARGET, deps);
+    }).not.toThrow();
+
+    // A structured result exists, so the sentinel gets emitted and the status
+    // row names the step instead of reading "error, no detail".
+    expect(r?.ok).toBe(false);
+    expect(r?.failedStep).toBe("persist-pin");
+    expect(r?.warnings.join(" ")).toMatch(/held by a LIVE roll/);
+    // And the config is untouched: the throw came from the exclusivity gate,
+    // so the journal on disk belongs to the OTHER roll. Reverting here would
+    // clobber exactly what that gate exists to protect.
+    expect(r?.pinReverted).toBeUndefined();
+    expect(h.pin()).toBe("v0.19.3");
+  });
+
+  it("names the AGENT when a restart step throws past a persisted pin", () => {
+    // The same catch must preserve the two fields the terminal row and the
+    // operator narration key off — and, unlike the `persist-pin` throw above,
+    // this one IS past the provisional write, so it must revert.
+    const h = pinHarness({
+      versions: Object.fromEntries(FLEET.map((a) => [a, "0.19.4"])),
+    });
+    const deps: RolloutDeps = {
+      ...h.deps,
+      probeVersion: (agent) => {
+        if (agent === "nadia") throw new Error("docker daemon vanished");
+        return "0.19.4";
+      },
+    };
+    const steps = planRollout(FLEET, { pinToPersist: TARGET, hostdContext: true });
+
+    let r: RolloutResult | undefined;
+    expect(() => {
+      r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    }).not.toThrow();
+
+    expect(r?.ok).toBe(false);
+    expect(r?.failedStep).toBe("restart-agent");
+    expect(r?.failedAgent).toBe("nadia");
+    expect(r?.warnings.join(" ")).toMatch(/docker daemon vanished/);
+    // THE outcome: the durable pin does not name the build the roll abandoned.
+    expect(r?.pinReverted).toBe(true);
+    expect(h.pin()).toBe("v0.19.3");
+    expect(h.journalled()).toBe(false);
   });
 
   it("carries pinReverted + timedOut across the hostd result sentinel", () => {

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -16,10 +16,12 @@ import {
   rmSync,
   existsSync,
   statSync,
+  chmodSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, expect, afterEach } from "vitest";
+import { Command } from "commander";
 import {
   normalizeVersion,
   isVersionAssertable,
@@ -46,6 +48,7 @@ import {
   ROLLOUT_RUN_TIMEOUT_MS,
   ROLLOUT_PROBE_TIMEOUT_MS,
   type RolloutSpawnSync,
+  registerRolloutCommand,
 } from "./rollout.js";
 import {
   beginPinPersist,
@@ -173,7 +176,10 @@ function harness(opts: {
     probeVersion: (agent) => opts.versions[agent] ?? null,
     log: (line) => logs.push(line),
     emitPhase: (p) => phases.push(p),
-    persistPin: (pin) => persisted.push(pin),
+    persistPin: (pin) => {
+      persisted.push(pin);
+      return true; // this fake ALWAYS writes — see RolloutDeps.persistPin
+    },
     hindsightExists: () => opts.hindsightExists ?? false,
     webImageTag: () => opts.webImageTag ?? null,
   };
@@ -1316,6 +1322,45 @@ describe("executeRollout — durable pin is provisional until the roll is proven
     delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
   });
 
+  it("createRolloutDeps' persistPin PRESERVES the config's permission bits", () => {
+    // `writeConfigPreservingOwnership` takes the mode as an ARGUMENT, and both
+    // supply sites read it off the file being replaced — `persistPin` here
+    // (`statSync(configPath).mode & 0o777`) and `rollbackPinPersist`, which
+    // does its own stat before calling the injected writer. Hand either one a
+    // constant instead and a tmp+rename write silently re-modes
+    // switchroom.yaml — the same class of damage as the ownership rule in
+    // CLAUDE.md ("tmp+rename re-owns the file to the writer's euid"), and
+    // 0600-ing the config is exactly what strands the non-root verbs that read
+    // it. Nothing else in the suite looked at the mode at all.
+    const dir = mkdtempSync(join(tmpdir(), "rollout-mode-"));
+    process.env.SWITCHROOM_PIN_JOURNAL_DIR = mkdtempSync(join(tmpdir(), "rollout-mode-state-"));
+    const configPath = join(dir, "switchroom.yaml");
+    writeFileSync(
+      configPath,
+      `telegram:\n  bot_token: x\nrelease:\n  pin: v0.19.3\nagents:\n  clerk:\n    extends: default\n`,
+      "utf8",
+    );
+    chmodSync(configPath, 0o640);
+    const deps = createRolloutDeps({
+      configPath,
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      spawn: (() => {
+        throw new Error("no subprocess expected");
+      }) as unknown as RolloutSpawnSync,
+      warn: () => undefined,
+    });
+
+    expect(deps.persistPin?.(TARGET)).toBe(true);
+
+    expect(getReleasePinFromConfig(readFileSync(configPath, "utf8"))).toBe(TARGET);
+    expect(statSync(configPath).mode & 0o777).toBe(0o640);
+    // …and the revert half must not re-mode it either.
+    expect(deps.revertPin?.()).toBe(true);
+    expect(statSync(configPath).mode & 0o777).toBe(0o640);
+    delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+  });
+
   it("createRolloutDeps' revertPin restores the pin through the ownership-preserving writer", () => {
     const stateDir = mkdtempSync(join(tmpdir(), "rollout-revert-state-"));
     process.env.SWITCHROOM_PIN_JOURNAL_DIR = stateDir;
@@ -1343,14 +1388,22 @@ describe("executeRollout — durable pin is provisional until the roll is proven
     expect(getReleasePinFromConfig(readFileSync(configPath, "utf8"))).toBe("v0.19.3");
     expect(hasPinJournal(configPath)).toBe(false);
     expect(readFileSync(configPath, "utf8")).toContain("bot_token: x # keep me");
-    // Routed through `writeConfigPreservingOwnership` — NOT a bare
-    // `writeFileSync`. The observable signature is the atomic tmp+rename:
-    // it REPLACES the inode (which is precisely why that writer has to chown
-    // back afterwards — CLAUDE.md's "tmp+rename re-owns the file to the
-    // writer's euid" rule). A bare `writeFileSync` truncates in place and
-    // keeps the inode, so dropping
+    // Routed through an ATOMIC tmp+rename writer, not a bare `writeFileSync`.
+    // That — and only that — is what the inode proves: tmp+rename REPLACES the
+    // inode, an in-place `writeFileSync` truncates and keeps it. Dropping
     // `writeConfig: writeConfigPreservingOwnership` from production
-    // `revertPin` flips this.
+    // `revertPin` falls back to `rollbackPinPersist`'s default writer, which
+    // IS a bare in-place `writeFileSync` (rollout-pin-journal.ts), so this
+    // assertion flips.
+    //
+    // What it does NOT prove is the ownership half of that writer's name.
+    // Disabling the chown-back branch inside `writeConfigPreservingOwnership`
+    // leaves this green — any tmp+rename writer passes. Pinning the chown from
+    // a unit test is not available here: `resolveOperatorUid`
+    // (src/cli/operator-uid.ts) returns undefined for root-without-`SUDO_UID`,
+    // and non-root CI skips the chown outright, so the branch is unreachable
+    // in both environments the suite runs in. Accepted limitation, named
+    // rather than papered over.
     expect(statSync(configPath).ino).not.toBe(inodeAfterPersist);
     delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
   });
@@ -1461,9 +1514,10 @@ describe("executeRollout — durable pin is provisional until the roll is proven
     const deps: RolloutDeps = {
       ...h.deps,
       persistPin: (p) => {
-        h.deps.persistPin?.(p);
+        const wrote = h.deps.persistPin?.(p) ?? false;
         rmSync(pinJournalPath(h.configPath));
         mkdirSync(pinJournalPath(h.configPath));
+        return wrote;
       },
     };
 
@@ -1542,12 +1596,47 @@ describe("executeRollout — durable pin is provisional until the roll is proven
     expect(readPinJournal(h.configPath)?.priorPin).toBe(TARGET);
   });
 
+  it("does NOT commit a journal it never wrote when persist-pin NO-OPS", () => {
+    // The narrower — and far likelier — shape of the same defect. Here the
+    // plan DOES carry a `persist-pin` step (`--pin` was passed, which hostd
+    // always does), but production `persistPin` returns early without
+    // journalling because the config already names that pin. The sibling test
+    // above only covers the shape where the step is ABSENT, so
+    // `pinPersisted = true` set as a side effect of "a persistPin hook exists"
+    // survived it: the roll commits, `commitPin` unlinks the journal path for
+    // this config, and an EARLIER crashed roll's journal — the only record
+    // that `release.pin` names an unproven build — is destroyed on success.
+    //
+    // Reachable straight through hostd: `spawnRollout` always passes `--pin`
+    // and may pass `--agents`, so a SUBSET roll proves three of twelve agents
+    // while wiping the evidence for the other nine.
+    const h = pinHarness({
+      versions: { clerk: "0.19.4" },
+      initialPin: TARGET, // config ALREADY at the target → persistPin no-ops
+    });
+    beginPinPersist(h.configPath, TARGET); // the crashed predecessor's journal
+    const steps = planRollout(["clerk"], { hostdContext: true, pinToPersist: TARGET });
+    // The step IS present — this is the distinguishing precondition.
+    expect(steps.some((s) => s.kind === "persist-pin")).toBe(true);
+    // …and production really does report the no-op.
+    expect(h.deps.persistPin?.(TARGET)).toBe(false);
+
+    const r = executeRollout(steps, TARGET, h.deps, { hostdContext: true });
+
+    expect(r.ok).toBe(true);
+    expect(h.pin()).toBe(TARGET);
+    // The predecessor's journal SURVIVES: this roll wrote nothing, so it has
+    // nothing to commit.
+    expect(h.journalled()).toBe(true);
+    expect(readPinJournal(h.configPath)?.pin).toBe(TARGET);
+  });
+
   it("warns loudly when the pin was persisted but no revert hook is wired", () => {
     const deps: RolloutDeps = {
       run: () => ({ status: 0 }),
       probeVersion: () => "0.0.1",
       log: () => undefined,
-      persistPin: () => undefined,
+      persistPin: () => true,
     };
     const steps = planRollout(["clerk"], { pinToPersist: TARGET });
     const r = executeRollout(steps, TARGET, deps);
@@ -2104,5 +2193,75 @@ describe("executeRollout — a timed-out restart stops even when the probe PASSE
     expect(r.ok).toBe(false);
     expect(r.failedStep).toBe("restart-agent");
     expect(r.timedOut).toBeUndefined();
+  });
+});
+
+describe("rollout CLI — --dry-run changes NOTHING, including the crash net", () => {
+  afterEach(() => {
+    delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+    process.exitCode = 0;
+  });
+
+  it("does NOT run pin-journal recovery under --dry-run", async () => {
+    // The action's pre-roll `recoverPinJournal` is gated on `!opts.dryRun`,
+    // and `--dry-run`'s documented contract is "print the plan and exit
+    // without changing anything". Nothing exercised that gate: flip it to
+    // `if (true)` and the whole scoped suite stayed green while a dry run
+    // silently REVERTED `release.pin` on disk. The command action is also the
+    // only place this call site exists — testing `recoverPinJournal` directly
+    // (which the journal suite does thoroughly) cannot see it.
+    const dir = mkdtempSync(join(tmpdir(), "rollout-dryrun-"));
+    process.env.SWITCHROOM_PIN_JOURNAL_DIR = mkdtempSync(
+      join(tmpdir(), "rollout-dryrun-state-"),
+    );
+    const configPath = join(dir, "switchroom.yaml");
+    writeFileSync(
+      configPath,
+      `switchroom:\n  version: 1\ntelegram:\n  bot_token: x\n  forum_chat_id: "1"\n` +
+        `release:\n  pin: v0.19.3\nagents:\n  clerk:\n    topic_name: clerk\n`,
+      "utf8",
+    );
+    // A STALE journal a crashed predecessor left: dead pid, aged well past
+    // PIN_JOURNAL_MAX_AGE_MS, so the liveness gate would NOT stop a revert.
+    writeFileSync(
+      pinJournalPath(configPath),
+      JSON.stringify({
+        v: 1,
+        configPath,
+        pin: "v0.19.3",
+        priorPin: "v0.0.9",
+        pid: 0x3fffffff,
+        at: new Date(Date.now() - PIN_JOURNAL_MAX_AGE_MS * 4).toISOString(),
+      }),
+      "utf8",
+    );
+
+    const program = new Command();
+    program.exitOverride();
+    program.option("-c, --config <path>", "Path to switchroom.yaml config file");
+    registerRolloutCommand(program);
+    const out: string[] = [];
+    const write = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((s: string) => {
+      out.push(String(s));
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      // A target OLDER than this CLI, so neither the stale-CLI guard nor (on
+      // the host-shell path) the downgrade guard short-circuits before the
+      // dry-run print.
+      await program.parseAsync(
+        ["--config", configPath, "rollout", "--pin", "v0.0.1", "--dry-run"],
+        { from: "user" },
+      );
+    } finally {
+      process.stdout.write = write;
+    }
+
+    // It really did reach the plan print, so the gate above it ran.
+    expect(out.join("")).toMatch(/persist-pin|Plan|rollout/i);
+    // …and NOTHING on disk moved.
+    expect(getReleasePinFromConfig(readFileSync(configPath, "utf8"))).toBe("v0.19.3");
+    expect(hasPinJournal(configPath)).toBe(true);
   });
 });

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -1213,6 +1213,81 @@ describe("executeRollout — durable pin is provisional until the roll is proven
     expect(r.warnings.join(" ")).toMatch(/REVERTED to the prior version/);
   });
 
+  it("REVERTS the pin when a non-canary restart TIMES OUT past a green canary", () => {
+    // The timed-out-restart branch (#3605) is a stop-the-roll failure that did
+    // not exist when the provisional-pin design was written, and it returned
+    // its own result literal rather than going through `fail()`. That made the
+    // pin guarantee false on exactly the path it matters most: a wedged
+    // container is the failure most likely to leave the durable pin naming a
+    // build that cannot boot, which every later reconcile then converges the
+    // rest of the fleet onto.
+    const h = pinHarness({
+      versions: Object.fromEntries(FLEET.map((a) => [a, "0.19.4"])),
+    });
+    const steps = planRollout(FLEET, { pinToPersist: TARGET, hostdContext: true });
+    // Sanity: the pin really is persisted BEFORE nadia is restarted.
+    expect(steps.findIndex((s) => s.kind === "persist-pin")).toBeLessThan(
+      steps.findIndex((s) => s.kind === "restart-agent" && s.agent === "nadia"),
+    );
+    const deps: RolloutDeps = {
+      ...h.deps,
+      run: (args, opts) =>
+        args[0] === "agent" && args[1] === "restart" && args[2] === "nadia"
+          ? { status: 1, timedOut: true }
+          : h.deps.run(args, opts),
+    };
+
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(true);
+    expect(r.failedAgent).toBe("nadia");
+    // THE outcome: the durable pin does NOT name the build that wedged.
+    expect(h.pin()).toBe("v0.19.3");
+    expect(r.pinReverted).toBe(true);
+    expect(h.journalled()).toBe(false);
+    expect(r.warnings.join(" ")).toMatch(/REVERTED to the prior version/);
+  });
+
+  it("createRolloutDeps' commitPin RETURNS the error, not just warns it", () => {
+    // The executor can only promote a failed commit into RolloutResult.warnings
+    // if the real deps factory hands the error back. The suite's own harness
+    // only MIRRORS that wiring, so without this the production line is covered
+    // by nothing and a rebase could drop the `return` in silence.
+    const dir = mkdtempSync(join(tmpdir(), "rollout-commitpin-"));
+    process.env.SWITCHROOM_PIN_JOURNAL_DIR = mkdtempSync(
+      join(tmpdir(), "rollout-commitpin-state-"),
+    );
+    const configPath = join(dir, "switchroom.yaml");
+    writeFileSync(
+      configPath,
+      `telegram:\n  bot_token: x\nrelease:\n  pin: v0.19.3\nagents:\n  clerk:\n    extends: default\n`,
+      "utf8",
+    );
+    beginPinPersist(configPath, TARGET);
+    // A DIRECTORY at the journal path makes unlink fail for every uid, root
+    // included — deterministic rather than privilege-dependent.
+    rmSync(pinJournalPath(configPath));
+    mkdirSync(pinJournalPath(configPath));
+    const warned: string[] = [];
+    const deps = createRolloutDeps({
+      configPath,
+      scriptPath: "switchroom",
+      hostdCtx: true,
+      spawn: (() => ({ status: 0, stdout: "", stderr: "" })) as unknown as RolloutSpawnSync,
+      warn: (line) => {
+        warned.push(line);
+      },
+    });
+
+    const err = deps.commitPin?.();
+
+    expect(typeof err).toBe("string");
+    expect(err as string).toMatch(/FAILED to clear/);
+    // Still warned to stderr as well — the two surfaces are complementary.
+    expect(warned.join(" ")).toMatch(/FAILED to clear/);
+  });
+
   it("REVERTS the pin when the host-shell path (persist FIRST) fails at apply", () => {
     // Worst case called out in the bug report: persist-pin is step 1, so a
     // failed apply used to leave a broken pin with ZERO agents rolled.

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -2196,7 +2196,7 @@ describe("executeRollout — a timed-out restart stops even when the probe PASSE
   });
 });
 
-describe("rollout CLI — --dry-run changes NOTHING, including the crash net", () => {
+describe("rollout CLI — the pre-roll crash net and its --dry-run gate", () => {
   afterEach(() => {
     delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
     process.exitCode = 0;
@@ -2258,10 +2258,86 @@ describe("rollout CLI — --dry-run changes NOTHING, including the crash net", (
       process.stdout.write = write;
     }
 
-    // It really did reach the plan print, so the gate above it ran.
-    expect(out.join("")).toMatch(/persist-pin|Plan|rollout/i);
+    // It really did reach the plan print, so the gate above it ran. Anchored on
+    // `formatRolloutPlan`'s header, which nothing else in this command emits:
+    // an alternation including /rollout/i matches almost any stdout the verb
+    // can produce (its own usage text, an error, the command name itself), so
+    // it would assert far less than this comment claims. `persist-pin` is NOT
+    // the anchor — this invocation plans no such step (the pin already matches
+    // the config), so matching on it would fail for a reason unrelated to the
+    // gate.
+    expect(out.join("")).toMatch(/Rollout plan → v0\.0\.1:/);
+    expect(out.join("")).toMatch(/apply — regenerate compose/);
     // …and NOTHING on disk moved.
     expect(getReleasePinFromConfig(readFileSync(configPath, "utf8"))).toBe("v0.19.3");
     expect(hasPinJournal(configPath)).toBe(true);
+  });
+
+  it("DOES run pin-journal recovery on a real (non-dry-run) invocation", async () => {
+    // The other half of the gate, and the one that carries the crash net. The
+    // dry-run test above pins "recovery did NOT run"; deleting the whole
+    // `if (!opts.dryRun) { recoverPinJournal(...) }` block satisfies it just as
+    // well, so on its own it cannot tell the net from its absence.
+    //
+    // Reaching the real path without spawning a roll uses the action's own
+    // ordering: recovery runs BEFORE `getConfig(program)` and before every
+    // guard, so a target that is not version-assertable (`nightly` — a
+    // floating channel) lets recovery execute and then bails at the
+    // `isVersionAssertable` refusal with exitCode 2. No child process, no
+    // compose write, no apply — but the crash net has already run for real.
+    const dir = mkdtempSync(join(tmpdir(), "rollout-realrun-"));
+    process.env.SWITCHROOM_PIN_JOURNAL_DIR = mkdtempSync(
+      join(tmpdir(), "rollout-realrun-state-"),
+    );
+    const configPath = join(dir, "switchroom.yaml");
+    writeFileSync(
+      configPath,
+      `switchroom:\n  version: 1\ntelegram:\n  bot_token: x\n  forum_chat_id: "1"\n` +
+        `release:\n  pin: v0.19.3\nagents:\n  clerk:\n    topic_name: clerk\n`,
+      "utf8",
+    );
+    // Same stale journal as above: a crashed predecessor wrote v0.19.3
+    // provisionally over v0.0.9 and never committed it.
+    writeFileSync(
+      pinJournalPath(configPath),
+      JSON.stringify({
+        v: 1,
+        configPath,
+        pin: "v0.19.3",
+        priorPin: "v0.0.9",
+        pid: 0x3fffffff,
+        at: new Date(Date.now() - PIN_JOURNAL_MAX_AGE_MS * 4).toISOString(),
+      }),
+      "utf8",
+    );
+
+    const program = new Command();
+    program.exitOverride();
+    program.option("-c, --config <path>", "Path to switchroom.yaml config file");
+    registerRolloutCommand(program);
+    const err: string[] = [];
+    const writeErr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((s: string) => {
+      err.push(String(s));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await program.parseAsync(
+        ["--config", configPath, "rollout", "--pin", "nightly"],
+        { from: "user" },
+      );
+    } finally {
+      process.stderr.write = writeErr;
+    }
+
+    // It bailed at the version-assertable guard — so nothing was rolled…
+    expect(process.exitCode).toBe(2);
+    expect(err.join("")).toMatch(/isn't version-assertable/);
+    // …and yet the crash net had ALREADY run: the unproven pin is reverted to
+    // the last PROVEN one and the journal is gone. Delete the `if
+    // (!opts.dryRun)` recovery block and both of these fail.
+    expect(getReleasePinFromConfig(readFileSync(configPath, "utf8"))).toBe("v0.0.9");
+    expect(hasPinJournal(configPath)).toBe(false);
+    expect(err.join("")).toMatch(/reverted an UNCOMMITTED release\.pin/);
   });
 });

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -8,7 +8,7 @@
  * injected side-effects so this runs without docker.
  */
 
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, expect } from "vitest";
@@ -39,6 +39,15 @@ import {
   ROLLOUT_PROBE_TIMEOUT_MS,
   type RolloutSpawnSync,
 } from "./rollout.js";
+import {
+  beginPinPersist,
+  commitPinPersist,
+  rollbackPinPersist,
+  hasPinJournal,
+  recoverPinJournal,
+  PIN_JOURNAL_MAX_AGE_MS,
+} from "./rollout-pin-journal.js";
+import { setReleasePinInConfig, getReleasePinFromConfig } from "./release-yaml.js";
 import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
 
 describe("normalizeVersion", () => {
@@ -1102,6 +1111,219 @@ describe("executeRollout — phase emission", () => {
   });
 });
 
+// ── The durable pin must not outlive a roll that failed ──────────────────
+//
+// Before this, `planRollout` ordered `persist-pin` right after the canary
+// (hostd path) / first (host-shell path) and NOTHING reverted it when the
+// roll then failed at agent 5 of 12. From that moment the durable pin WAS
+// the broken version, so every later restart / crash-loop recreate /
+// reconcile / `docker compose up -d` converged the remaining agents onto a
+// build that demonstrably failed to boot.
+//
+// These tests assert the OUTCOME on a real config file — what does
+// `release.pin` say after the roll? — not that a hook was invoked.
+
+/**
+ * Deps wired to the REAL pin-journal implementation against a tmpdir config,
+ * mirroring `createRolloutDeps`'s persist/commit/revert triple.
+ */
+function pinHarness(opts: {
+  versions: Record<string, string | null>;
+  runStatus?: (args: string[]) => number;
+  initialPin?: string;
+}): {
+  deps: RolloutDeps;
+  configPath: string;
+  pin: () => string | undefined;
+  journalled: () => boolean;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "rollout-pin-"));
+  const configPath = join(dir, "switchroom.yaml");
+  writeFileSync(
+    configPath,
+    `telegram:\n  bot_token: x\nrelease:\n  pin: ${opts.initialPin ?? "v0.19.3"}\nagents:\n  clerk:\n    extends: default\n`,
+    "utf8",
+  );
+  const deps: RolloutDeps = {
+    run: (args) => ({ status: opts.runStatus ? opts.runStatus(args) : 0 }),
+    probeVersion: (agent) => opts.versions[agent] ?? null,
+    log: () => undefined,
+    hindsightExists: () => false,
+    persistPin: (p) => {
+      const before = readFileSync(configPath, "utf8");
+      const after = setReleasePinInConfig(before, p);
+      if (after === before) return;
+      beginPinPersist(configPath, p);
+      writeFileSync(configPath, after, "utf8");
+    },
+    commitPin: () => {
+      commitPinPersist(configPath);
+    },
+    revertPin: () => rollbackPinPersist(configPath).reverted,
+  };
+  return {
+    deps,
+    configPath,
+    pin: () => getReleasePinFromConfig(readFileSync(configPath, "utf8")),
+    journalled: () => hasPinJournal(configPath),
+  };
+}
+
+describe("executeRollout — durable pin is provisional until the roll is proven", () => {
+  const TARGET = "v0.19.4";
+  const FLEET = ["test-harness", "clerk", "marko", "nadia", "opal"];
+
+  it("REVERTS the pin when a non-canary agent fails past a green canary (hostd path)", () => {
+    // Canary + 2 agents green, then agent 4 comes back on the OLD version.
+    const h = pinHarness({
+      versions: {
+        "test-harness": "0.19.4",
+        clerk: "0.19.4",
+        marko: "0.19.4",
+        nadia: "0.19.3", // failed to boot the new build
+        opal: "0.19.4",
+      },
+    });
+    const steps = planRollout(FLEET, { pinToPersist: TARGET, hostdContext: true });
+    // Sanity: the plan really does persist the pin BEFORE nadia is restarted.
+    expect(steps.findIndex((s) => s.kind === "persist-pin")).toBeLessThan(
+      steps.findIndex((s) => s.kind === "restart-agent" && s.agent === "nadia"),
+    );
+
+    const r = executeRollout(steps, TARGET, h.deps, { hostdContext: true });
+
+    expect(r.ok).toBe(false);
+    expect(r.failedAgent).toBe("nadia");
+    expect(r.rolled).toEqual(["test-harness", "clerk", "marko"]);
+    // THE outcome: the durable pin does NOT name the failed build, so a later
+    // reconcile cannot pull opal (and the rest) onto it.
+    expect(h.pin()).toBe("v0.19.3");
+    expect(r.pinReverted).toBe(true);
+    expect(h.journalled()).toBe(false);
+    expect(r.warnings.join(" ")).toMatch(/REVERTED to the prior version/);
+  });
+
+  it("REVERTS the pin when the host-shell path (persist FIRST) fails at apply", () => {
+    // Worst case called out in the bug report: persist-pin is step 1, so a
+    // failed apply used to leave a broken pin with ZERO agents rolled.
+    const h = pinHarness({
+      versions: {},
+      runStatus: (args) => (args[0] === "apply" ? 1 : 0),
+    });
+    const steps = planRollout(FLEET, { pinToPersist: TARGET });
+    expect(steps[0]).toEqual({ kind: "persist-pin", pin: TARGET });
+
+    const r = executeRollout(steps, TARGET, h.deps);
+
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("apply");
+    expect(r.rolled).toEqual([]);
+    expect(h.pin()).toBe("v0.19.3");
+    expect(r.pinReverted).toBe(true);
+  });
+
+  it("REVERTS the pin when the hindsight refresh fails after every agent rolled", () => {
+    const h = pinHarness({
+      versions: Object.fromEntries(FLEET.map((a) => [a, "0.19.4"])),
+      runStatus: (args) => (args[0] === "memory" ? 1 : 0),
+    });
+    const deps: RolloutDeps = { ...h.deps, hindsightExists: () => true };
+    const steps = planRollout(FLEET, { pinToPersist: TARGET, hostdContext: true });
+
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("refresh-hindsight");
+    expect(h.pin()).toBe("v0.19.3");
+    expect(r.pinReverted).toBe(true);
+  });
+
+  it("COMMITS the pin (and clears the journal) only when the whole roll succeeds", () => {
+    const h = pinHarness({
+      versions: Object.fromEntries(FLEET.map((a) => [a, "0.19.4"])),
+    });
+    const steps = planRollout(FLEET, { pinToPersist: TARGET, hostdContext: true });
+
+    const r = executeRollout(steps, TARGET, h.deps, { hostdContext: true });
+
+    expect(r.ok).toBe(true);
+    expect(r.rolled).toEqual(FLEET);
+    expect(h.pin()).toBe(TARGET);
+    expect(r.pinReverted).toBeUndefined();
+    // No journal left behind — a later hostd boot must NOT revert a proven roll.
+    expect(h.journalled()).toBe(false);
+  });
+
+  it("leaves the journal in place when a crash beats both commit and revert", () => {
+    // Model the SIGKILL case: the pin was persisted, then the process died —
+    // executeRollout never returned, so neither commit nor revert ran.
+    const h = pinHarness({ versions: {} });
+    h.deps.persistPin?.(TARGET);
+    expect(h.pin()).toBe(TARGET);
+    expect(h.journalled()).toBe(true);
+
+    // The crash-recovery net (hostd boot / next rollout) is stale-gated, so
+    // while the writer still looks live it deliberately declines — that gate
+    // is what stops a hostd restart mid-roll from reverting a running roll.
+    expect(recoverPinJournal(h.configPath)).toMatch(/still looks live/);
+    expect(h.pin()).toBe(TARGET);
+
+    // Once the journal ages out (the writer is gone / the roll is long over),
+    // the same net reverts it.
+    const note = recoverPinJournal(h.configPath, {
+      now: Date.now() + PIN_JOURNAL_MAX_AGE_MS + 1,
+    });
+    expect(note).toMatch(/reverted an UNCOMMITTED/);
+    expect(h.pin()).toBe("v0.19.3");
+  });
+
+  it("does not touch the pin when the roll never persisted one", () => {
+    // Target came from config.release.pin — nothing to persist, nothing to
+    // revert. A failure must not spuriously rewrite the config.
+    const h = pinHarness({
+      versions: { "test-harness": "0.19.3" },
+      initialPin: TARGET,
+    });
+    const steps = planRollout(["test-harness"], { hostdContext: true });
+    expect(steps.some((s) => s.kind === "persist-pin")).toBe(false);
+
+    const r = executeRollout(steps, TARGET, h.deps, { hostdContext: true });
+
+    expect(r.ok).toBe(false);
+    expect(r.pinReverted).toBeUndefined();
+    expect(h.pin()).toBe(TARGET);
+  });
+
+  it("warns loudly when the pin was persisted but no revert hook is wired", () => {
+    const deps: RolloutDeps = {
+      run: () => ({ status: 0 }),
+      probeVersion: () => "0.0.1",
+      log: () => undefined,
+      persistPin: () => undefined,
+    };
+    const steps = planRollout(["clerk"], { pinToPersist: TARGET });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(false);
+    expect(r.warnings.join(" ")).toMatch(/no revert hook was wired/);
+  });
+
+  it("carries pinReverted + timedOut across the hostd result sentinel", () => {
+    const line = encodeRolloutResultLine({
+      ok: false,
+      rolled: ["clerk"],
+      failedStep: "restart-agent",
+      failedAgent: "marko",
+      got: null,
+      timedOut: true,
+      pinReverted: true,
+      warnings: [],
+    });
+    const parsed = parseRolloutResultLine(line);
+    expect(parsed?.timedOut).toBe(true);
+    expect(parsed?.pinReverted).toBe(true);
+  });
+});
+
 // ── Timeouts: a wedged container must not hang the executor ──────────────
 //
 // `deps.run` (spawnSync of `switchroom <subcommand>`) and `deps.probeVersion`
@@ -1214,9 +1436,12 @@ describe("executeRollout — a timed-out step stops the roll cleanly", () => {
     // The whole point: the executor RETURNS. A returned failure is what lets
     // hostd's `.finally()` run and release `fleetMutationInFlight` — the
     // latch that a hung spawnSync stranded forever.
-    const { deps: base } = harness({ versions: { "test-harness": null } });
+    const h = pinHarness({
+      versions: { "test-harness": null },
+      runStatus: () => 0,
+    });
     const deps: RolloutDeps = {
-      ...base,
+      ...h.deps,
       run: (args) =>
         args[0] === "agent" ? { status: 1, timedOut: true } : { status: 0 },
     };
@@ -1235,11 +1460,22 @@ describe("executeRollout — a timed-out step stops the roll cleanly", () => {
   });
 
   it("marks an apply timeout as timedOut and stops before any restart", () => {
-    const { deps: base } = harness({ versions: {} });
+    const h = pinHarness({ versions: {} });
     const deps: RolloutDeps = {
-      ...base,
+      ...h.deps,
       run: (args) => (args[0] === "apply" ? { status: 1, timedOut: true } : { status: 0 }),
     };
+    const steps = planRollout(["clerk"], { pinToPersist: TARGET });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("apply");
+    expect(r.timedOut).toBe(true);
+    // And the provisional pin still got reverted.
+    expect(h.pin()).toBe("v0.19.3");
+  });
+
+  it("a timed-out apply stops the roll BEFORE any agent is restarted", () => {
+    const { deps } = harness({ versions: {} });
     const runs: string[][] = [];
     const r = executeRollout(planRollout(["clerk"]), TARGET, {
       ...deps,

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -8,10 +8,10 @@
  * injected side-effects so this runs without docker.
  */
 
-import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   normalizeVersion,
   isVersionAssertable,
@@ -44,6 +44,7 @@ import {
   commitPinPersist,
   rollbackPinPersist,
   hasPinJournal,
+  pinJournalPath,
   recoverPinJournal,
   PIN_JOURNAL_MAX_AGE_MS,
 } from "./rollout-pin-journal.js";
@@ -1138,6 +1139,11 @@ function pinHarness(opts: {
   journalled: () => boolean;
 } {
   const dir = mkdtempSync(join(tmpdir(), "rollout-pin-"));
+  // The journal lives in the DURABLE switchroom state dir, NOT beside the
+  // config (rollout-pin-journal.ts — inside hostd the config's directory is a
+  // container-ephemeral overlay). Point it at a tmpdir so the suite never
+  // writes into a real `~/.switchroom`.
+  process.env.SWITCHROOM_PIN_JOURNAL_DIR = mkdtempSync(join(tmpdir(), "rollout-pin-state-"));
   const configPath = join(dir, "switchroom.yaml");
   writeFileSync(
     configPath,
@@ -1156,9 +1162,9 @@ function pinHarness(opts: {
       beginPinPersist(configPath, p);
       writeFileSync(configPath, after, "utf8");
     },
-    commitPin: () => {
-      commitPinPersist(configPath);
-    },
+    // Mirrors createRolloutDeps: the error is RETURNED so the executor can
+    // put it in RolloutResult.warnings, not just written to stderr.
+    commitPin: () => commitPinPersist(configPath),
     revertPin: () => rollbackPinPersist(configPath).reverted,
   };
   return {
@@ -1172,6 +1178,10 @@ function pinHarness(opts: {
 describe("executeRollout — durable pin is provisional until the roll is proven", () => {
   const TARGET = "v0.19.4";
   const FLEET = ["test-harness", "clerk", "marko", "nadia", "opal"];
+
+  afterEach(() => {
+    delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+  });
 
   it("REVERTS the pin when a non-canary agent fails past a green canary (hostd path)", () => {
     // Canary + 2 agents green, then agent 4 comes back on the OLD version.
@@ -1252,6 +1262,39 @@ describe("executeRollout — durable pin is provisional until the roll is proven
     expect(r.pinReverted).toBeUndefined();
     // No journal left behind — a later hostd boot must NOT revert a proven roll.
     expect(h.journalled()).toBe(false);
+  });
+
+  it("surfaces a commit that could NOT clear the journal in the structured warnings", () => {
+    // A journal surviving a SUCCESSFUL commit is the exact input that makes a
+    // later recovery pass revert a PROVEN pin. It used to go only to the
+    // `warn` sink (child stderr), which is invisible on the hostd path — the
+    // roll's outcome there is consumed as a result object, and the analogous
+    // revert failure already lands in `warnings`.
+    const h = pinHarness({
+      versions: Object.fromEntries(FLEET.map((a) => [a, "0.19.4"])),
+    });
+    const steps = planRollout(FLEET, { pinToPersist: TARGET, hostdContext: true });
+    // A DIRECTORY at the journal path makes unlink fail for every uid,
+    // including the root the suite may run as — deterministic, not
+    // privilege-dependent. Created after persist so it replaces the journal.
+    const deps: RolloutDeps = {
+      ...h.deps,
+      persistPin: (p) => {
+        h.deps.persistPin?.(p);
+        rmSync(pinJournalPath(h.configPath));
+        mkdirSync(pinJournalPath(h.configPath));
+      },
+    };
+
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+
+    // The roll itself SUCCEEDED and the pin is correct…
+    expect(r.ok).toBe(true);
+    expect(h.pin()).toBe(TARGET);
+    // …but the operator is told, through the structured surface.
+    expect(r.warnings.join(" ")).toMatch(/FAILED to clear/);
+    expect(r.warnings.join(" ")).toMatch(/may revert a proven/);
+    expect(r.warnings.join(" ")).toMatch(/The roll SUCCEEDED/);
   });
 
   it("leaves the journal in place when a crash beats both commit and revert", () => {

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -666,6 +666,16 @@ export function executeRollout(
    * Single exit point for every stop-the-roll failure. Reverting the pin
    * here (rather than at each `return`) is what makes the guarantee
    * structural: a future failure branch cannot forget to revert.
+   *
+   * "Every" is load-bearing and was once false. A step that THREW — the
+   * documented behaviour of `beginPinPersist` when a live roll already holds
+   * the journal — bypassed this entirely: the exception escaped the executor
+   * and the commander action, so `encodeRolloutResultLine` never ran and hostd
+   * fell to its no-sentinel branch (`result: "error"`, no `rolled`, no
+   * `failedStep`) on a path where the canary and every earlier agent had
+   * already restarted. The step loop below is therefore wrapped in a try/catch
+   * that routes a throw through here; see that catch for which throws do and
+   * do NOT revert.
    */
   const fail = (partial: Omit<RolloutResult, "ok" | "rolled" | "warnings">): RolloutResult => {
     let pinReverted = false;
@@ -708,354 +718,398 @@ export function executeRollout(
     };
   };
 
-  for (const step of steps) {
-    switch (step.kind) {
-      case "persist-pin": {
-        // On the hostd path this runs AFTER the canary is green; on the
-        // host-shell path it runs FIRST. Either way: durably persist so
-        // subsequent reconciles read the same pin.
-        deps.log(`ROLL_STEP persist-pin — release.pin=${step.pin} to switchroom.yaml`);
-        if (deps.persistPin) {
-          deps.persistPin(step.pin);
-          // Provisional from here on: `fail()` reverts it, and the success
-          // path below commits it. Set AFTER the call so a throwing
-          // persistPin doesn't leave us claiming a write that never landed.
-          pinPersisted = true;
-        } else {
-          warnings.push(`persist-pin requested but no persist hook wired; pin NOT durable`);
-        }
-        emit({ phase: "persist-pin", target });
-        break;
-      }
-      case "apply": {
-        // hostd path: pin not yet persisted (it follows the canary), so
-        // pass the one-shot --pin so compose regenerates on the target.
-        // host-shell path: pin already persisted → bare apply reads it.
-        //
-        // On the hostd path we ALSO pass `--compose-only --non-interactive`.
-        // A version roll only needs the compose regenerated with the new
-        // image tags plus compose-level env (SWITCHROOM_VOICE_ENGINE) and the
-        // sidecar healthcheck — all emitted by generateCompose(), which
-        // `--compose-only` still runs. What `--compose-only` skips is the
-        // per-agent SCAFFOLD loop (start.sh / .mcp.json / settings.json).
-        // Under docker mode (v0.7+) per-agent state dirs are mode 0700 owned
-        // by per-agent UIDs; hostd runs unprivileged and cannot write into
-        // them, so a FULL apply fails scaffold for every agent, returns
-        // non-zero, and aborts the whole roll having rolled nothing (every
-        // historical hostd rollout in the audit log: failedStep "apply",
-        // rolled []). Skipping scaffold lets the roll actually complete.
-        deps.log(`ROLL_STEP apply — regenerating compose for ${target}`);
-        emit({ phase: "apply", target });
-        const applyArgs = execOpts.hostdContext
-          ? ["apply", "--pin", target, "--compose-only", "--non-interactive"]
-          : ["apply"];
-        const r = deps.run(applyArgs);
-        if (r.status !== 0) {
-          if (r.timedOut) {
-            deps.log(`  ✗ apply TIMED OUT after ${ROLLOUT_RUN_TIMEOUT_MS}ms — STOPPING`);
-            warnings.push(
-              `apply exceeded its ${ROLLOUT_RUN_TIMEOUT_MS}ms timeout and was ` +
-                `killed. The roll stopped cleanly rather than hanging.`,
-            );
+  /**
+   * The step currently executing, for the catch below. A throw carries no
+   * step context of its own, and `failedStep` is the field hostd's status row
+   * and the operator narration key off.
+   */
+  let currentStep: RolloutStep | undefined;
+
+  try {
+    for (const step of steps) {
+      currentStep = step;
+      switch (step.kind) {
+        case "persist-pin": {
+          // On the hostd path this runs AFTER the canary is green; on the
+          // host-shell path it runs FIRST. Either way: durably persist so
+          // subsequent reconciles read the same pin.
+          deps.log(`ROLL_STEP persist-pin — release.pin=${step.pin} to switchroom.yaml`);
+          if (deps.persistPin) {
+            deps.persistPin(step.pin);
+            // Provisional from here on: `fail()` reverts it, and the success
+            // path below commits it. Set AFTER the call so a throwing
+            // persistPin doesn't leave us claiming a write that never landed.
+            pinPersisted = true;
+          } else {
+            warnings.push(`persist-pin requested but no persist hook wired; pin NOT durable`);
           }
-          return fail({ failedStep: "apply", ...(r.timedOut ? { timedOut: true } : {}) });
+          emit({ phase: "persist-pin", target });
+          break;
         }
-        if (execOpts.hostdContext) {
-          // SURFACED (not hidden): --compose-only skipped the host-side
-          // per-agent scaffold loop (hostd is unprivileged and cannot write
-          // per-agent state dirs). This is NOT left stale: the per-agent
-          // restart-reconcile that follows for every agent in this roll
-          // refreshes each agent's own templates (start.sh / .mcp.json /
-          // settings.json) from inside its own container on restart. So a
-          // version roll picks up template changes automatically — no
-          // agent-run apply, and no manual host apply, is required here.
-          // A host-side `sudo switchroom apply` is only for STRUCTURAL
-          // changes (new-agent scaffolding / compose regeneration), not for
-          // per-agent template refresh on a roll.
-          warnings.push(
-            `apply ran --compose-only (hostd is unprivileged and cannot ` +
-              `write per-agent state dirs). Compose + compose-level env/` +
-              `healthcheck are up to date; per-agent template changes ` +
-              `(start.sh / .mcp.json / settings.json) are refreshed ` +
-              `automatically by each agent's restart-reconcile in this roll. ` +
-              `A host-side \`sudo switchroom apply\` is only needed for ` +
-              `structural changes (new agents / compose regeneration).`,
-          );
-        }
-        break;
-      }
-      case "restart-agent": {
-        deps.log(`ROLL_STEP restart-agent — ${step.agent} (--wait --force)`);
-        agentIndex += 1;
-        const isCanary = agentIndex === 1;
-        // The first agent restarted is the sanctioned canary gate
-        // (stop-on-first-mismatch). Narrate its start/pass/fail distinctly so
-        // the operator sees the canary decision, not just "agent 1/N".
-        emit(
-          isCanary
-            ? { phase: "canary-start", target, agent: step.agent, n: agentIndex, m: totalAgents }
-            : { phase: "agent-start", target, agent: step.agent, n: agentIndex, m: totalAgents },
-        );
-        // `agent restart` can exit 0 while still "polling" on boot — do
-        // NOT trust its status; the version assert is the real gate.
-        //
-        // hostd path: pass --pin <target> so the compose regeneration step
-        // inside `agent restart` uses the target image tag. Without this,
-        // `reconcileAndRestartAgent` re-reads the stale `release.pin` from
-        // config and overwrites the correct compose that `apply --pin` just
-        // wrote — putting the canary/agent on the old image (#2558). On the
-        // host-shell path the pin is already persisted before `apply` runs,
-        // so bare restart reads the correct pin from config; passing --pin
-        // there is harmless but unnecessary.
-        const restartArgs = execOpts.hostdContext
-          ? ["agent", "restart", step.agent, "--wait", "--force", "--pin", target]
-          : ["agent", "restart", step.agent, "--wait", "--force"];
-        // #3333 amendment C — staged canary rollout of the scoped ownership
-        // sweep. The reconcile sweep runs INSIDE this spawned `switchroom
-        // agent restart` process, so injecting the scoped-sweep env into the
-        // canary spawn ONLY (and reading it at the sweep site) flips exactly
-        // one agent per roll — the first-restarted canary. A global/container
-        // boot env would flip every agent at once and defeat the canary gate.
-        // Verify on the roll: the canary's restart-time collapse (scope=scoped
-        // in its `[ownership-sweep] #3333` log) with no approval-card storm,
-        // before the default is flipped ON (stage 5).
-        const restartRes = deps.run(
-          restartArgs,
-          isCanary ? { env: { [SCOPED_SWEEP_ENV]: "1" } } : undefined,
-        );
-        if (restartRes.timedOut) {
-          // A wedged container is precisely the case a roll exists to fix.
-          // Report it as a bounded, structural failure instead of letting the
-          // executor (and hostd's fleet-mutation latch) hang forever.
+        case "apply": {
+          // hostd path: pin not yet persisted (it follows the canary), so
+          // pass the one-shot --pin so compose regenerates on the target.
+          // host-shell path: pin already persisted → bare apply reads it.
           //
-          // STOP THE ROLL — do NOT fall through to the version probe. A
-          // timeout here means the `switchroom agent restart` CLI was
-          // SIGKILLed mid-flight, and a SIGKILL reaps only the direct child
-          // (see ROLLOUT_KILL_SIGNAL): its `docker compose up -d` grandchild
-          // can still be live, still rewriting the compose file. Two things
-          // follow, and both are silent if we continue:
-          //   1. the orphan may well have brought the container up on the
-          //      target tag, so the probe PASSES (`got === targetNorm`) and
-          //      the roll reports success — while everything the CLI does
-          //      AFTER the container starts (the post-start reconcile and the
-          //      #3333 scoped ownership sweep injected via SCOPED_SWEEP_ENV
-          //      on the canary) was killed and never ran. A half-applied
-          //      agent reported as fully rolled.
-          //   2. proceeding restarts the NEXT agent while that orphan is
-          //      still mutating containers and the shared compose file — the
-          //      exact race ROLLOUT_KILL_SIGNAL's note names.
-          // A passing probe is evidence the container came up; it is NOT
-          // evidence the restart COMPLETED. Fail closed: the operator is told
-          // to check for stray docker processes before re-running, which is
-          // only coherent if the roll actually stopped.
-          warnings.push(
-            `\`agent restart ${step.agent}\` exceeded its ` +
-              `${ROLLOUT_RUN_TIMEOUT_MS}ms timeout and was killed — the ` +
-              `container is likely wedged. The roll stopped cleanly rather ` +
-              `than hanging.`,
-          );
-          const gotAfterKill = deps.probeVersion(step.agent);
-          if (gotAfterKill !== null && normalizeVersion(gotAfterKill) === targetNorm) {
+          // On the hostd path we ALSO pass `--compose-only --non-interactive`.
+          // A version roll only needs the compose regenerated with the new
+          // image tags plus compose-level env (SWITCHROOM_VOICE_ENGINE) and the
+          // sidecar healthcheck — all emitted by generateCompose(), which
+          // `--compose-only` still runs. What `--compose-only` skips is the
+          // per-agent SCAFFOLD loop (start.sh / .mcp.json / settings.json).
+          // Under docker mode (v0.7+) per-agent state dirs are mode 0700 owned
+          // by per-agent UIDs; hostd runs unprivileged and cannot write into
+          // them, so a FULL apply fails scaffold for every agent, returns
+          // non-zero, and aborts the whole roll having rolled nothing (every
+          // historical hostd rollout in the audit log: failedStep "apply",
+          // rolled []). Skipping scaffold lets the roll actually complete.
+          deps.log(`ROLL_STEP apply — regenerating compose for ${target}`);
+          emit({ phase: "apply", target });
+          const applyArgs = execOpts.hostdContext
+            ? ["apply", "--pin", target, "--compose-only", "--non-interactive"]
+            : ["apply"];
+          const r = deps.run(applyArgs);
+          if (r.status !== 0) {
+            if (r.timedOut) {
+              deps.log(`  ✗ apply TIMED OUT after ${ROLLOUT_RUN_TIMEOUT_MS}ms — STOPPING`);
+              warnings.push(
+                `apply exceeded its ${ROLLOUT_RUN_TIMEOUT_MS}ms timeout and was ` +
+                  `killed. The roll stopped cleanly rather than hanging.`,
+              );
+            }
+            return fail({ failedStep: "apply", ...(r.timedOut ? { timedOut: true } : {}) });
+          }
+          if (execOpts.hostdContext) {
+            // SURFACED (not hidden): --compose-only skipped the host-side
+            // per-agent scaffold loop (hostd is unprivileged and cannot write
+            // per-agent state dirs). This is NOT left stale: the per-agent
+            // restart-reconcile that follows for every agent in this roll
+            // refreshes each agent's own templates (start.sh / .mcp.json /
+            // settings.json) from inside its own container on restart. So a
+            // version roll picks up template changes automatically — no
+            // agent-run apply, and no manual host apply, is required here.
+            // A host-side `sudo switchroom apply` is only for STRUCTURAL
+            // changes (new-agent scaffolding / compose regeneration), not for
+            // per-agent template refresh on a roll.
             warnings.push(
-              `${step.agent} is reporting ${gotAfterKill} (the roll target) ` +
-                `despite the killed restart — its orphaned \`docker compose\` ` +
-                `grandchild most likely finished the container start. The ` +
-                `restart's POST-start work (reconcile / ownership sweep) was ` +
-                `killed with the CLI and did NOT run, so this agent is ` +
-                `HALF-APPLIED, not rolled. Check for stray docker processes ` +
-                `host-side, then re-run.`,
+              `apply ran --compose-only (hostd is unprivileged and cannot ` +
+                `write per-agent state dirs). Compose + compose-level env/` +
+                `healthcheck are up to date; per-agent template changes ` +
+                `(start.sh / .mcp.json / settings.json) are refreshed ` +
+                `automatically by each agent's restart-reconcile in this roll. ` +
+                `A host-side \`sudo switchroom apply\` is only needed for ` +
+                `structural changes (new agents / compose regeneration).`,
             );
           }
-          deps.log(
-            `  ✗ ${step.agent} → restart TIMED OUT (killed after ` +
-              `${ROLLOUT_RUN_TIMEOUT_MS}ms; probe says ` +
-              `${gotAfterKill ?? "<unreachable>"}) — STOPPING`,
-          );
+          break;
+        }
+        case "restart-agent": {
+          deps.log(`ROLL_STEP restart-agent — ${step.agent} (--wait --force)`);
+          agentIndex += 1;
+          const isCanary = agentIndex === 1;
+          // The first agent restarted is the sanctioned canary gate
+          // (stop-on-first-mismatch). Narrate its start/pass/fail distinctly so
+          // the operator sees the canary decision, not just "agent 1/N".
           emit(
             isCanary
-              ? { phase: "canary-fail", target, agent: step.agent, n: agentIndex, m: totalAgents }
-              : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
+              ? { phase: "canary-start", target, agent: step.agent, n: agentIndex, m: totalAgents }
+              : { phase: "agent-start", target, agent: step.agent, n: agentIndex, m: totalAgents },
           );
-          // Through `fail()`, not a bare literal: this branch is a
-          // stop-the-roll failure like any other, and by the time a restart
-          // can time out the `persist-pin` step has already written the
-          // provisional durable pin. Returning directly would leave
-          // `release.pin` naming the build that just wedged a container —
-          // which every later restart/reconcile/`compose up` would then
-          // converge the rest of the fleet onto. The single exit point is
-          // what makes that guarantee structural rather than remembered.
-          return fail({
-            failedStep: "restart-agent",
-            failedAgent: step.agent,
-            got: gotAfterKill,
-            timedOut: true,
-          });
-        }
-        const got = deps.probeVersion(step.agent);
-        if (got === null || normalizeVersion(got) !== targetNorm) {
-          deps.log(`  ✗ ${step.agent} → ${got ?? "<unreachable>"} (expected ${target}) — STOPPING`);
-          // A failed canary is the gate that stops the whole roll; a
-          // failed non-canary is a per-agent stop. Narrate both distinctly.
+          // `agent restart` can exit 0 while still "polling" on boot — do
+          // NOT trust its status; the version assert is the real gate.
+          //
+          // hostd path: pass --pin <target> so the compose regeneration step
+          // inside `agent restart` uses the target image tag. Without this,
+          // `reconcileAndRestartAgent` re-reads the stale `release.pin` from
+          // config and overwrites the correct compose that `apply --pin` just
+          // wrote — putting the canary/agent on the old image (#2558). On the
+          // host-shell path the pin is already persisted before `apply` runs,
+          // so bare restart reads the correct pin from config; passing --pin
+          // there is harmless but unnecessary.
+          const restartArgs = execOpts.hostdContext
+            ? ["agent", "restart", step.agent, "--wait", "--force", "--pin", target]
+            : ["agent", "restart", step.agent, "--wait", "--force"];
+          // #3333 amendment C — staged canary rollout of the scoped ownership
+          // sweep. The reconcile sweep runs INSIDE this spawned `switchroom
+          // agent restart` process, so injecting the scoped-sweep env into the
+          // canary spawn ONLY (and reading it at the sweep site) flips exactly
+          // one agent per roll — the first-restarted canary. A global/container
+          // boot env would flip every agent at once and defeat the canary gate.
+          // Verify on the roll: the canary's restart-time collapse (scope=scoped
+          // in its `[ownership-sweep] #3333` log) with no approval-card storm,
+          // before the default is flipped ON (stage 5).
+          const restartRes = deps.run(
+            restartArgs,
+            isCanary ? { env: { [SCOPED_SWEEP_ENV]: "1" } } : undefined,
+          );
+          if (restartRes.timedOut) {
+            // A wedged container is precisely the case a roll exists to fix.
+            // Report it as a bounded, structural failure instead of letting the
+            // executor (and hostd's fleet-mutation latch) hang forever.
+            //
+            // STOP THE ROLL — do NOT fall through to the version probe. A
+            // timeout here means the `switchroom agent restart` CLI was
+            // SIGKILLed mid-flight, and a SIGKILL reaps only the direct child
+            // (see ROLLOUT_KILL_SIGNAL): its `docker compose up -d` grandchild
+            // can still be live, still rewriting the compose file. Two things
+            // follow, and both are silent if we continue:
+            //   1. the orphan may well have brought the container up on the
+            //      target tag, so the probe PASSES (`got === targetNorm`) and
+            //      the roll reports success — while everything the CLI does
+            //      AFTER the container starts (the post-start reconcile and the
+            //      #3333 scoped ownership sweep injected via SCOPED_SWEEP_ENV
+            //      on the canary) was killed and never ran. A half-applied
+            //      agent reported as fully rolled.
+            //   2. proceeding restarts the NEXT agent while that orphan is
+            //      still mutating containers and the shared compose file — the
+            //      exact race ROLLOUT_KILL_SIGNAL's note names.
+            // A passing probe is evidence the container came up; it is NOT
+            // evidence the restart COMPLETED. Fail closed: the operator is told
+            // to check for stray docker processes before re-running, which is
+            // only coherent if the roll actually stopped.
+            warnings.push(
+              `\`agent restart ${step.agent}\` exceeded its ` +
+                `${ROLLOUT_RUN_TIMEOUT_MS}ms timeout and was killed — the ` +
+                `container is likely wedged. The roll stopped cleanly rather ` +
+                `than hanging.`,
+            );
+            const gotAfterKill = deps.probeVersion(step.agent);
+            if (gotAfterKill !== null && normalizeVersion(gotAfterKill) === targetNorm) {
+              warnings.push(
+                `${step.agent} is reporting ${gotAfterKill} (the roll target) ` +
+                  `despite the killed restart — its orphaned \`docker compose\` ` +
+                  `grandchild most likely finished the container start. The ` +
+                  `restart's POST-start work (reconcile / ownership sweep) was ` +
+                  `killed with the CLI and did NOT run, so this agent is ` +
+                  `HALF-APPLIED, not rolled. Check for stray docker processes ` +
+                  `host-side, then re-run.`,
+              );
+            }
+            deps.log(
+              `  ✗ ${step.agent} → restart TIMED OUT (killed after ` +
+                `${ROLLOUT_RUN_TIMEOUT_MS}ms; probe says ` +
+                `${gotAfterKill ?? "<unreachable>"}) — STOPPING`,
+            );
+            emit(
+              isCanary
+                ? { phase: "canary-fail", target, agent: step.agent, n: agentIndex, m: totalAgents }
+                : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
+            );
+            // Through `fail()`, not a bare literal: this branch is a
+            // stop-the-roll failure like any other, and by the time a restart
+            // can time out the `persist-pin` step has already written the
+            // provisional durable pin. Returning directly would leave
+            // `release.pin` naming the build that just wedged a container —
+            // which every later restart/reconcile/`compose up` would then
+            // converge the rest of the fleet onto. The single exit point is
+            // what makes that guarantee structural rather than remembered.
+            return fail({
+              failedStep: "restart-agent",
+              failedAgent: step.agent,
+              got: gotAfterKill,
+              timedOut: true,
+            });
+          }
+          const got = deps.probeVersion(step.agent);
+          if (got === null || normalizeVersion(got) !== targetNorm) {
+            deps.log(`  ✗ ${step.agent} → ${got ?? "<unreachable>"} (expected ${target}) — STOPPING`);
+            // A failed canary is the gate that stops the whole roll; a
+            // failed non-canary is a per-agent stop. Narrate both distinctly.
+            emit(
+              isCanary
+                ? { phase: "canary-fail", target, agent: step.agent, n: agentIndex, m: totalAgents }
+                : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
+            );
+            return fail({
+              failedStep: "restart-agent",
+              failedAgent: step.agent,
+              got,
+              // No `timedOut` here by construction: the timeout branch above
+              // returns unconditionally, so reaching this point means the
+              // restart exited on its own and the VERSION ASSERT is what
+              // failed. Keeping the two failure shapes disjoint is what lets
+              // hostd (and `get_status`) distinguish "killed mid-flight,
+              // grandchildren may be live" from "ran to completion, wrong
+              // version" — they need different operator recovery.
+            });
+          }
+          rolled.push(step.agent);
+          deps.log(`  ✓ ${step.agent} → ${got}`);
           emit(
             isCanary
-              ? { phase: "canary-fail", target, agent: step.agent, n: agentIndex, m: totalAgents }
+              ? { phase: "canary-pass", target, agent: step.agent, n: agentIndex, m: totalAgents }
               : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
-          );
-          return fail({
-            failedStep: "restart-agent",
-            failedAgent: step.agent,
-            got,
-            // No `timedOut` here by construction: the timeout branch above
-            // returns unconditionally, so reaching this point means the
-            // restart exited on its own and the VERSION ASSERT is what
-            // failed. Keeping the two failure shapes disjoint is what lets
-            // hostd (and `get_status`) distinguish "killed mid-flight,
-            // grandchildren may be live" from "ran to completion, wrong
-            // version" — they need different operator recovery.
-          });
-        }
-        rolled.push(step.agent);
-        deps.log(`  ✓ ${step.agent} → ${got}`);
-        emit(
-          isCanary
-            ? { phase: "canary-pass", target, agent: step.agent, n: agentIndex, m: totalAgents }
-            : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
-        );
-        break;
-      }
-      case "refresh-web": {
-        // Forward --allow-downgrade on a rollback roll: webd install's
-        // downgrade guard would otherwise guard.skip with exit 0 — agents
-        // roll back but web silently stays on the NEWER tag, no warning.
-        const downgradeArgs = execOpts.allowDowngrade ? ["--allow-downgrade"] : [];
-        deps.log(
-          `ROLL_STEP refresh-web — webd install --tag ${target}` +
-            (execOpts.allowDowngrade ? " --allow-downgrade" : ""),
-        );
-        emit({ phase: "web-refresh", target });
-        const r = deps.run(["webd", "install", "--tag", target, ...downgradeArgs]);
-        if (r.status !== 0) {
-          // A TIMED-OUT refresh is not the same failure as a non-zero exit,
-          // and the difference is operationally load-bearing. `deps.run`
-          // reports both as `status !== 0`, so without this branch a killed
-          // `webd install` produces the generic warning that tells the
-          // operator to re-run it IMMEDIATELY — while the killed CLI's
-          // `docker` grandchildren may still be live and mutating the same
-          // container. That is the same "grandchildren are NOT killed with
-          // it" signal the restart-agent timeout branch surfaces; surface it
-          // here too rather than losing it.
-          warnings.push(
-            r.timedOut
-              ? `web refresh TIMED OUT after ${ROLLOUT_RUN_TIMEOUT_MS}ms and was ` +
-                  `killed (non-fatal — agents already rolled) so switchroom-web ` +
-                  `is still on the PRIOR version. Its \`docker\` grandchildren ` +
-                  `are NOT killed with it: check for stray docker processes ` +
-                  `host-side BEFORE re-running, then finish it host-side: ` +
-                  `\`switchroom webd install --tag ${target}\`.`
-              : `web refresh FAILED (non-fatal — agents already rolled) so ` +
-                  `switchroom-web is still on the PRIOR version. Finish it ` +
-                  `host-side: \`switchroom webd install --tag ${target}\`.`,
           );
           break;
         }
-        // Belt-and-braces skew check: `webd install` exits 0 on a
-        // downgrade-guard skip (deliberate — deploy-version-guard.ts), so a
-        // zero exit does NOT prove web is on the target. Probe the running
-        // container's image tag and warn LOUDLY on any mismatch.
-        const webTag = deps.webImageTag?.();
-        if (
-          webTag !== undefined &&
-          webTag !== null &&
-          isVersionAssertable(webTag) &&
-          normalizeVersion(webTag) !== targetNorm
-        ) {
-          warnings.push(
-            `web refresh completed but switchroom-web is running ${webTag}, ` +
-              `NOT the roll target ${target} (most likely its downgrade guard ` +
-              `skipped the install). Finish it host-side: \`switchroom webd ` +
-              `install --tag ${target} --allow-downgrade\`.`,
+        case "refresh-web": {
+          // Forward --allow-downgrade on a rollback roll: webd install's
+          // downgrade guard would otherwise guard.skip with exit 0 — agents
+          // roll back but web silently stays on the NEWER tag, no warning.
+          const downgradeArgs = execOpts.allowDowngrade ? ["--allow-downgrade"] : [];
+          deps.log(
+            `ROLL_STEP refresh-web — webd install --tag ${target}` +
+              (execOpts.allowDowngrade ? " --allow-downgrade" : ""),
           );
-        }
-        break;
-      }
-      case "refresh-hostd": {
-        // Same downgrade-guard forwarding as refresh-web (hostd install
-        // shares deploy-version-guard.ts) — a host-shell rollback must not
-        // leave hostd silently on the newer tag.
-        const downgradeArgs = execOpts.allowDowngrade ? ["--allow-downgrade"] : [];
-        deps.log(
-          `ROLL_STEP refresh-hostd — hostd install --tag ${target}` +
-            (execOpts.allowDowngrade ? " --allow-downgrade" : ""),
-        );
-        const r = deps.run(["hostd", "install", "--tag", target, ...downgradeArgs]);
-        // Same timeout-vs-exit distinction as refresh-web above: a killed
-        // `hostd install` leaves live `docker` grandchildren, so the operator
-        // must sweep for strays before re-running it.
-        if (r.status !== 0)
-          warnings.push(
-            r.timedOut
-              ? `hostd refresh TIMED OUT after ${ROLLOUT_RUN_TIMEOUT_MS}ms and ` +
-                  `was killed (non-fatal; agents already rolled). Its \`docker\` ` +
-                  `grandchildren are NOT killed with it: check for stray docker ` +
-                  `processes host-side BEFORE re-running \`switchroom hostd ` +
-                  `install --tag ${target}\`.`
-              : `hostd refresh failed (non-fatal); agents already rolled`,
-          );
-        break;
-      }
-      case "refresh-hindsight": {
-        // hindsight is a STANDALONE `docker run` on the mutable `:latest`
-        // tag — it is NOT a compose service and does NOT self-heal on a pin
-        // bump, so a roll leaves it pinned to whatever `:latest` resolved to
-        // when it was last recreated (observed: hindsight stuck on claude
-        // 2.1.197 while the fleet moved to 2.1.199). `memory setup --recreate`
-        // pulls the latest hindsight image then recreates the container
-        // (pull → stop → start), reusing the running host ports so
-        // memory.config.url never drifts under the fleet. No-op cleanly when
-        // hindsight isn't installed on this host (guard below also returns
-        // false when docker is unavailable).
-        const hindsightExists = deps.hindsightExists ?? isHindsightContainerExists;
-        if (!hindsightExists()) {
-          deps.log(`ROLL_STEP refresh-hindsight — no hindsight container on this host; skipping`);
+          emit({ phase: "web-refresh", target });
+          const r = deps.run(["webd", "install", "--tag", target, ...downgradeArgs]);
+          if (r.status !== 0) {
+            // A TIMED-OUT refresh is not the same failure as a non-zero exit,
+            // and the difference is operationally load-bearing. `deps.run`
+            // reports both as `status !== 0`, so without this branch a killed
+            // `webd install` produces the generic warning that tells the
+            // operator to re-run it IMMEDIATELY — while the killed CLI's
+            // `docker` grandchildren may still be live and mutating the same
+            // container. That is the same "grandchildren are NOT killed with
+            // it" signal the restart-agent timeout branch surfaces; surface it
+            // here too rather than losing it.
+            warnings.push(
+              r.timedOut
+                ? `web refresh TIMED OUT after ${ROLLOUT_RUN_TIMEOUT_MS}ms and was ` +
+                    `killed (non-fatal — agents already rolled) so switchroom-web ` +
+                    `is still on the PRIOR version. Its \`docker\` grandchildren ` +
+                    `are NOT killed with it: check for stray docker processes ` +
+                    `host-side BEFORE re-running, then finish it host-side: ` +
+                    `\`switchroom webd install --tag ${target}\`.`
+                : `web refresh FAILED (non-fatal — agents already rolled) so ` +
+                    `switchroom-web is still on the PRIOR version. Finish it ` +
+                    `host-side: \`switchroom webd install --tag ${target}\`.`,
+            );
+            break;
+          }
+          // Belt-and-braces skew check: `webd install` exits 0 on a
+          // downgrade-guard skip (deliberate — deploy-version-guard.ts), so a
+          // zero exit does NOT prove web is on the target. Probe the running
+          // container's image tag and warn LOUDLY on any mismatch.
+          const webTag = deps.webImageTag?.();
+          if (
+            webTag !== undefined &&
+            webTag !== null &&
+            isVersionAssertable(webTag) &&
+            normalizeVersion(webTag) !== targetNorm
+          ) {
+            warnings.push(
+              `web refresh completed but switchroom-web is running ${webTag}, ` +
+                `NOT the roll target ${target} (most likely its downgrade guard ` +
+                `skipped the install). Finish it host-side: \`switchroom webd ` +
+                `install --tag ${target} --allow-downgrade\`.`,
+            );
+          }
           break;
         }
-        // Thread the pinned rollout target through as `--tag <target>` so the
-        // recreate pulls `…switchroom-hindsight:v<target>` — the SAME pinned
-        // image the rest of the fleet moved to — NOT floating `:latest`
-        // (which drifts hindsight off the roll's version; #2752 fix 1).
-        deps.log(
-          `ROLL_STEP refresh-hindsight — memory setup --recreate --tag ${target} (pull ${target} + recreate)`,
-        );
-        const r = deps.run(["memory", "setup", "--recreate", "--tag", target]);
-        if (r.status !== 0) {
-          // FATAL, not a soft warning (#2752 fix 2): `memory setup --recreate`
-          // already did `docker stop && docker rm` before the failing
-          // `startHindsight`, so a failed recreate leaves the fleet with NO
-          // memory backend. Folding that into the generic non-fatal web/hostd
-          // warning while returning ok:true reported success on a fleet whose
-          // memory is DOWN. Stop the roll (same stop-on-failure semantics as a
-          // failed agent restart) and name the manual recovery.
+        case "refresh-hostd": {
+          // Same downgrade-guard forwarding as refresh-web (hostd install
+          // shares deploy-version-guard.ts) — a host-shell rollback must not
+          // leave hostd silently on the newer tag.
+          const downgradeArgs = execOpts.allowDowngrade ? ["--allow-downgrade"] : [];
           deps.log(
-            `  ✗ hindsight recreate FAILED — the memory backend is DOWN (the ` +
-              `recreate stopped + removed the old container before the failed ` +
-              `start). Run \`switchroom memory setup\` to bring it back. — STOPPING`,
+            `ROLL_STEP refresh-hostd — hostd install --tag ${target}` +
+              (execOpts.allowDowngrade ? " --allow-downgrade" : ""),
           );
-          return fail({
-            failedStep: "refresh-hindsight",
-            ...(r.timedOut ? { timedOut: true } : {}),
-          });
+          const r = deps.run(["hostd", "install", "--tag", target, ...downgradeArgs]);
+          // Same timeout-vs-exit distinction as refresh-web above: a killed
+          // `hostd install` leaves live `docker` grandchildren, so the operator
+          // must sweep for strays before re-running it.
+          if (r.status !== 0)
+            warnings.push(
+              r.timedOut
+                ? `hostd refresh TIMED OUT after ${ROLLOUT_RUN_TIMEOUT_MS}ms and ` +
+                    `was killed (non-fatal; agents already rolled). Its \`docker\` ` +
+                    `grandchildren are NOT killed with it: check for stray docker ` +
+                    `processes host-side BEFORE re-running \`switchroom hostd ` +
+                    `install --tag ${target}\`.`
+                : `hostd refresh failed (non-fatal); agents already rolled`,
+            );
+          break;
         }
-        break;
-      }
-      case "sweep": {
-        deps.log(`ROLL_STEP sweep`);
-        for (const a of rolled) {
-          const v = deps.probeVersion(a);
-          deps.log(`  ${a}: ${v ?? "<unreachable>"}`);
+        case "refresh-hindsight": {
+          // hindsight is a STANDALONE `docker run` on the mutable `:latest`
+          // tag — it is NOT a compose service and does NOT self-heal on a pin
+          // bump, so a roll leaves it pinned to whatever `:latest` resolved to
+          // when it was last recreated (observed: hindsight stuck on claude
+          // 2.1.197 while the fleet moved to 2.1.199). `memory setup --recreate`
+          // pulls the latest hindsight image then recreates the container
+          // (pull → stop → start), reusing the running host ports so
+          // memory.config.url never drifts under the fleet. No-op cleanly when
+          // hindsight isn't installed on this host (guard below also returns
+          // false when docker is unavailable).
+          const hindsightExists = deps.hindsightExists ?? isHindsightContainerExists;
+          if (!hindsightExists()) {
+            deps.log(`ROLL_STEP refresh-hindsight — no hindsight container on this host; skipping`);
+            break;
+          }
+          // Thread the pinned rollout target through as `--tag <target>` so the
+          // recreate pulls `…switchroom-hindsight:v<target>` — the SAME pinned
+          // image the rest of the fleet moved to — NOT floating `:latest`
+          // (which drifts hindsight off the roll's version; #2752 fix 1).
+          deps.log(
+            `ROLL_STEP refresh-hindsight — memory setup --recreate --tag ${target} (pull ${target} + recreate)`,
+          );
+          const r = deps.run(["memory", "setup", "--recreate", "--tag", target]);
+          if (r.status !== 0) {
+            // FATAL, not a soft warning (#2752 fix 2): `memory setup --recreate`
+            // already did `docker stop && docker rm` before the failing
+            // `startHindsight`, so a failed recreate leaves the fleet with NO
+            // memory backend. Folding that into the generic non-fatal web/hostd
+            // warning while returning ok:true reported success on a fleet whose
+            // memory is DOWN. Stop the roll (same stop-on-failure semantics as a
+            // failed agent restart) and name the manual recovery.
+            deps.log(
+              `  ✗ hindsight recreate FAILED — the memory backend is DOWN (the ` +
+                `recreate stopped + removed the old container before the failed ` +
+                `start). Run \`switchroom memory setup\` to bring it back. — STOPPING`,
+            );
+            return fail({
+              failedStep: "refresh-hindsight",
+              ...(r.timedOut ? { timedOut: true } : {}),
+            });
+          }
+          break;
         }
-        break;
+        case "sweep": {
+          deps.log(`ROLL_STEP sweep`);
+          for (const a of rolled) {
+            const v = deps.probeVersion(a);
+            deps.log(`  ${a}: ${v ?? "<unreachable>"}`);
+          }
+          break;
+        }
       }
     }
+  } catch (e) {
+    // A step THREW rather than returning a status. Before this, the throw
+    // escaped `executeRollout`, escaped the commander action, and killed the
+    // process before `encodeRolloutResultLine` ran — so hostd took its
+    // no-sentinel branch and recorded `result: "error"` with no `rolled` /
+    // `failedStep` at all, on a path where (hostd ordering) every agent up to
+    // the failure has ALREADY restarted.
+    //
+    // The concrete source is `beginPinPersist`, which THROWS by contract when
+    // a live roll already holds the journal (rollout-pin-journal.ts). Routing
+    // it here keeps `fail()`'s promise structural: every stop-the-roll
+    // failure, thrown or returned, now RETURNS a RolloutResult and reverts a
+    // provisional pin exactly when one was written. The commander then does
+    // for it what it does for any failed result — the stdout sentinel on the
+    // hostd path, the `✗ Rollout STOPPED at …` narration and exit 1 on the
+    // host shell.
+    //
+    // Note which failures do NOT revert: a `persist-pin` step that threw never
+    // set `pinPersisted`, so `fail()` correctly leaves the journal alone —
+    // reverting on a throw from `beginPinPersist` would revert the OTHER
+    // roll's pin, which is precisely the damage the exclusivity gate exists to
+    // prevent. A throw from the config write AFTER `beginPinPersist` (the
+    // window where the journal exists but `pinPersisted` is still false) is
+    // likewise left to the stale-gated recovery sites, which is safe because
+    // the pin write is the thing that failed.
+    warnings.push(
+      `the ${currentStep?.kind ?? "rollout"} step THREW: ${(e as Error).message}. ` +
+        `The roll stopped and reported the failure instead of dying without a ` +
+        `result.`,
+    );
+    return fail({
+      ...(currentStep ? { failedStep: currentStep.kind } : {}),
+      ...(currentStep?.kind === "restart-agent" ? { failedAgent: currentStep.agent } : {}),
+    });
   }
   // The roll is PROVEN — every agent came back on the target and no fatal
   // step failed. Only now does the provisional pin become durable: commit

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -417,8 +417,15 @@ export interface RolloutDeps {
    * Mark the provisional pin write durable. Called EXACTLY ONCE, at the very
    * end of a fully successful roll. Optional (a caller with no persistPin
    * has nothing to commit).
+   *
+   * Returns an operator-facing message when the commit did NOT clear the
+   * journal, null/void otherwise. A surviving journal is the exact input that
+   * makes a later boot revert a PROVEN pin, so the executor promotes it into
+   * {@link RolloutResult.warnings} — the same structured surface the revert
+   * failure uses. A stderr-only warning would be invisible on the hostd path,
+   * where the roll's outcome is consumed as a result object.
    */
-  commitPin?(): void;
+  commitPin?(): string | null | void;
   /**
    * Revert a provisional pin write. Called on every failure return after a
    * `persist-pin` step ran, so a roll that fails at agent 5 of 12 cannot
@@ -1055,7 +1062,13 @@ export function executeRollout(
   // clears the crash-recovery journal, so a later hostd boot won't revert it.
   if (pinPersisted && deps.commitPin) {
     try {
-      deps.commitPin();
+      const commitErr = deps.commitPin();
+      if (typeof commitErr === "string" && commitErr.length > 0) {
+        warnings.push(
+          `${commitErr} (The roll SUCCEEDED and release.pin is correct — the ` +
+            `risk is a later recovery pass reverting it.)`,
+        );
+      }
     } catch (e) {
       warnings.push(
         `roll succeeded but committing the durable release.pin threw: ` +
@@ -1475,7 +1488,10 @@ export function createRolloutDeps(params: {
     },
     commitPin: () => {
       const err = commitPinPersist(configPath);
+      // Returned (not just warned) so the executor lands it in
+      // RolloutResult.warnings \u2014 see RolloutDeps.commitPin.
       if (err) warn(`\u26a0\ufe0f  ${err}\n`);
+      return err;
     },
     revertPin: () => {
       // requireStale is deliberately FALSE here: this caller IS the process

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -410,7 +410,10 @@ export interface RolloutDeps {
    * PROVISIONAL by contract: the production implementation journals the
    * prior config text first (see rollout-pin-journal.ts), so the write is
    * only durable once {@link RolloutDeps.commitPin} runs. The executor calls
-   * {@link RolloutDeps.revertPin} on every failure path after this ran.
+   * {@link RolloutDeps.revertPin} on every failure path after this returned
+   * **true** — and on none after it returned false, because a no-op persist
+   * wrote nothing and journalled nothing, so there is nothing of this roll's to
+   * revert (`fail()` gates on `pinPersisted`). See the return contract below.
    *
    * **Returns whether it actually WROTE** — true when a provisional pin write
    * was journalled, false when the call was a no-op because the config already

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -411,8 +411,21 @@ export interface RolloutDeps {
    * prior config text first (see rollout-pin-journal.ts), so the write is
    * only durable once {@link RolloutDeps.commitPin} runs. The executor calls
    * {@link RolloutDeps.revertPin} on every failure path after this ran.
+   *
+   * **Returns whether it actually WROTE** — true when a provisional pin write
+   * was journalled, false when the call was a no-op because the config already
+   * carried this pin. The distinction is load-bearing and NOT cosmetic: the
+   * executor's `commitPin` unlinks the journal for this config path, and a
+   * journal it did not write belongs to an EARLIER roll that crashed
+   * mid-persist. Committing that destroys the only record that `release.pin`
+   * names an unproven build (every recovery site keys off the file's
+   * existence), so a no-op persist must leave `pinPersisted` false.
+   *
+   * The return type is deliberately `boolean`, not `boolean | void`: tsc then
+   * forces every implementation — production and test alike — to state which
+   * it did, instead of the executor remembering to guess.
    */
-  persistPin?(pin: string): void;
+  persistPin?(pin: string): boolean;
   /**
    * Mark the provisional pin write durable. Called EXACTLY ONCE, at the very
    * end of a fully successful roll. Optional (a caller with no persistPin
@@ -735,11 +748,16 @@ export function executeRollout(
           // subsequent reconciles read the same pin.
           deps.log(`ROLL_STEP persist-pin — release.pin=${step.pin} to switchroom.yaml`);
           if (deps.persistPin) {
-            deps.persistPin(step.pin);
             // Provisional from here on: `fail()` reverts it, and the success
-            // path below commits it. Set AFTER the call so a throwing
-            // persistPin doesn't leave us claiming a write that never landed.
-            pinPersisted = true;
+            // path below commits it — but ONLY if a write actually landed.
+            // Taken from the return value, not set as a side effect, so the
+            // flag cannot outrun the write in either direction: a THROWING
+            // persistPin never assigns (the catch below sees false), and a
+            // no-op persistPin (config already at this pin — see
+            // `createRolloutDeps`' idempotent early return) reports false, so
+            // the success path does not commit — i.e. does not unlink — a
+            // journal some earlier crashed roll left at this config path.
+            pinPersisted = deps.persistPin(step.pin);
           } else {
             warnings.push(`persist-pin requested but no persist hook wired; pin NOT durable`);
           }
@@ -1526,7 +1544,11 @@ export function createRolloutDeps(params: {
     persistPin: (pin) => {
       const before = readFileSync(configPath, "utf8");
       const after = setReleasePinInConfig(before, pin);
-      if (after === before) return; // idempotent no-op
+      // Idempotent no-op: the config already names this pin, so there is
+      // nothing to journal, nothing to revert, and — critically — nothing to
+      // COMMIT. Reporting false keeps the executor from unlinking a journal
+      // this roll never wrote (see RolloutDeps.persistPin).
+      if (after === before) return false;
       // PROVISIONAL WRITE. Journal the pin (and the pin it replaces) FIRST so
       // it can be reverted both on a clean failure (revertPin below) and after
       // a crash (recoverPinJournal at hostd boot / next rollout). Without
@@ -1539,6 +1561,7 @@ export function createRolloutDeps(params: {
         after,
         statSync(configPath).mode & 0o777,
       );
+      return true;
     },
     commitPin: () => {
       const err = commitPinPersist(configPath);

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -48,6 +48,12 @@ import { homedir } from "node:os";
 import type { Command } from "commander";
 import { getConfig, getConfigPath } from "./helpers.js";
 import { setReleasePinInConfig } from "./release-yaml.js";
+import {
+  beginPinPersist,
+  commitPinPersist,
+  rollbackPinPersist,
+  recoverPinJournal,
+} from "./rollout-pin-journal.js";
 import { resolveOperatorUid } from "./operator-uid.js";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { compareReleaseTags } from "../config/release-resolve.js";
@@ -400,8 +406,26 @@ export interface RolloutDeps {
    * preserving, atomic, ownership-restoring). Only invoked for a
    * `persist-pin` step. Optional so callers that never persist (and tests)
    * can omit it.
+   *
+   * PROVISIONAL by contract: the production implementation journals the
+   * prior config text first (see rollout-pin-journal.ts), so the write is
+   * only durable once {@link RolloutDeps.commitPin} runs. The executor calls
+   * {@link RolloutDeps.revertPin} on every failure path after this ran.
    */
   persistPin?(pin: string): void;
+  /**
+   * Mark the provisional pin write durable. Called EXACTLY ONCE, at the very
+   * end of a fully successful roll. Optional (a caller with no persistPin
+   * has nothing to commit).
+   */
+  commitPin?(): void;
+  /**
+   * Revert a provisional pin write. Called on every failure return after a
+   * `persist-pin` step ran, so a roll that fails at agent 5 of 12 cannot
+   * leave the durable pin naming a build that failed to boot. Returns true
+   * when a pin was actually reverted (for the operator-facing warning).
+   */
+  revertPin?(): boolean;
   /**
    * Probe whether the standalone `switchroom-hindsight` container exists on
    * this host (the `refresh-hindsight` step no-ops cleanly when it doesn't).
@@ -435,6 +459,12 @@ export interface RolloutResult {
    * was killed. Distinguishes "the build is bad" from "the fleet is wedged".
    */
   timedOut?: boolean;
+  /**
+   * True when a provisional `release.pin` write was rolled back because this
+   * roll failed. Surfaced so the operator knows the durable pin still names
+   * the PRIOR (working) version.
+   */
+  pinReverted?: boolean;
   /** Non-fatal warnings (e.g. web/hostd refresh failures). */
   warnings: string[];
 }
@@ -540,6 +570,7 @@ export function encodeRolloutResultLine(result: RolloutResult): string {
       ...(result.failedAgent ? { failedAgent: result.failedAgent } : {}),
       ...(result.got !== undefined ? { got: result.got } : {}),
       ...(result.timedOut ? { timedOut: true } : {}),
+      ...(result.pinReverted ? { pinReverted: true } : {}),
       warnings: result.warnings,
     })
   );
@@ -557,6 +588,7 @@ export function parseRolloutResultLine(
   failedAgent?: string;
   got?: string | null;
   timedOut?: boolean;
+  pinReverted?: boolean;
   warnings: string[];
 } | null {
   const lines = stdout.split("\n");
@@ -616,6 +648,59 @@ export function executeRollout(
   const totalAgents = steps.filter((s) => s.kind === "restart-agent").length;
   let agentIndex = 0;
 
+  // Set once the `persist-pin` step ran. Every failure return below goes
+  // through `fail()`, which reverts that provisional write — a roll that dies
+  // at agent 5 of 12 must NOT leave the durable pin naming the build that
+  // just failed to boot, because every later restart/reconcile/`compose up`
+  // reads that pin and converges the rest of the fleet onto it.
+  let pinPersisted = false;
+
+  /**
+   * Single exit point for every stop-the-roll failure. Reverting the pin
+   * here (rather than at each `return`) is what makes the guarantee
+   * structural: a future failure branch cannot forget to revert.
+   */
+  const fail = (partial: Omit<RolloutResult, "ok" | "rolled" | "warnings">): RolloutResult => {
+    let pinReverted = false;
+    if (pinPersisted && deps.revertPin) {
+      try {
+        pinReverted = deps.revertPin();
+      } catch (e) {
+        warnings.push(
+          `FAILED to revert the provisional release.pin after a failed roll: ` +
+            `${(e as Error).message}. Check \`release.pin\` in switchroom.yaml ` +
+            `host-side BEFORE the next reconcile — it may name a build that ` +
+            `failed to boot.`,
+        );
+      }
+      if (pinReverted) {
+        deps.log(
+          `  ↩ reverted the provisional release.pin — the durable pin still ` +
+            `names the prior version`,
+        );
+        warnings.push(
+          `The roll failed after the durable pin had been written, so the ` +
+            `provisional \`release.pin\` was REVERTED to the prior version. ` +
+            `Agents already rolled stay on the target until they next restart; ` +
+            `the rest of the fleet will not converge onto the failed build.`,
+        );
+      }
+    } else if (pinPersisted && !deps.revertPin) {
+      warnings.push(
+        `The roll failed after \`release.pin\` was persisted but no revert ` +
+          `hook was wired — the durable pin may still name the failed build. ` +
+          `Verify switchroom.yaml host-side.`,
+      );
+    }
+    return {
+      ok: false,
+      rolled,
+      warnings,
+      ...partial,
+      ...(pinReverted ? { pinReverted: true } : {}),
+    };
+  };
+
   for (const step of steps) {
     switch (step.kind) {
       case "persist-pin": {
@@ -625,6 +710,10 @@ export function executeRollout(
         deps.log(`ROLL_STEP persist-pin — release.pin=${step.pin} to switchroom.yaml`);
         if (deps.persistPin) {
           deps.persistPin(step.pin);
+          // Provisional from here on: `fail()` reverts it, and the success
+          // path below commits it. Set AFTER the call so a throwing
+          // persistPin doesn't leave us claiming a write that never landed.
+          pinPersisted = true;
         } else {
           warnings.push(`persist-pin requested but no persist hook wired; pin NOT durable`);
         }
@@ -662,13 +751,7 @@ export function executeRollout(
                 `killed. The roll stopped cleanly rather than hanging.`,
             );
           }
-          return {
-            ok: false,
-            rolled,
-            failedStep: "apply",
-            ...(r.timedOut ? { timedOut: true } : {}),
-            warnings,
-          };
+          return fail({ failedStep: "apply", ...(r.timedOut ? { timedOut: true } : {}) });
         }
         if (execOpts.hostdContext) {
           // SURFACED (not hidden): --compose-only skipped the host-side
@@ -786,15 +869,20 @@ export function executeRollout(
               ? { phase: "canary-fail", target, agent: step.agent, n: agentIndex, m: totalAgents }
               : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
           );
-          return {
-            ok: false,
-            rolled,
+          // Through `fail()`, not a bare literal: this branch is a
+          // stop-the-roll failure like any other, and by the time a restart
+          // can time out the `persist-pin` step has already written the
+          // provisional durable pin. Returning directly would leave
+          // `release.pin` naming the build that just wedged a container —
+          // which every later restart/reconcile/`compose up` would then
+          // converge the rest of the fleet onto. The single exit point is
+          // what makes that guarantee structural rather than remembered.
+          return fail({
             failedStep: "restart-agent",
             failedAgent: step.agent,
             got: gotAfterKill,
             timedOut: true,
-            warnings,
-          };
+          });
         }
         const got = deps.probeVersion(step.agent);
         if (got === null || normalizeVersion(got) !== targetNorm) {
@@ -806,9 +894,7 @@ export function executeRollout(
               ? { phase: "canary-fail", target, agent: step.agent, n: agentIndex, m: totalAgents }
               : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
           );
-          return {
-            ok: false,
-            rolled,
+          return fail({
             failedStep: "restart-agent",
             failedAgent: step.agent,
             got,
@@ -819,8 +905,7 @@ export function executeRollout(
             // hostd (and `get_status`) distinguish "killed mid-flight,
             // grandchildren may be live" from "ran to completion, wrong
             // version" — they need different operator recovery.
-            warnings,
-          };
+          });
         }
         rolled.push(step.agent);
         deps.log(`  ✓ ${step.agent} → ${got}`);
@@ -948,13 +1033,10 @@ export function executeRollout(
               `recreate stopped + removed the old container before the failed ` +
               `start). Run \`switchroom memory setup\` to bring it back. — STOPPING`,
           );
-          return {
-            ok: false,
-            rolled,
+          return fail({
             failedStep: "refresh-hindsight",
             ...(r.timedOut ? { timedOut: true } : {}),
-            warnings,
-          };
+          });
         }
         break;
       }
@@ -966,6 +1048,20 @@ export function executeRollout(
         }
         break;
       }
+    }
+  }
+  // The roll is PROVEN — every agent came back on the target and no fatal
+  // step failed. Only now does the provisional pin become durable: commit
+  // clears the crash-recovery journal, so a later hostd boot won't revert it.
+  if (pinPersisted && deps.commitPin) {
+    try {
+      deps.commitPin();
+    } catch (e) {
+      warnings.push(
+        `roll succeeded but committing the durable release.pin threw: ` +
+          `${(e as Error).message}. The pin IS written; a stale rollout ` +
+          `journal may cause a later boot to revert it — verify host-side.`,
+      );
     }
   }
   return { ok: true, rolled, warnings };
@@ -1364,11 +1460,39 @@ export function createRolloutDeps(params: {
       const before = readFileSync(configPath, "utf8");
       const after = setReleasePinInConfig(before, pin);
       if (after === before) return; // idempotent no-op
+      // PROVISIONAL WRITE. Journal the pin (and the pin it replaces) FIRST so
+      // it can be reverted both on a clean failure (revertPin below) and after
+      // a crash (recoverPinJournal at hostd boot / next rollout). Without
+      // this, a roll that fails at agent 5 of 12 leaves the durable pin naming
+      // the failed build and every later reconcile converges the rest of the
+      // fleet onto it.
+      beginPinPersist(configPath, pin);
       writeConfigPreservingOwnership(
         configPath,
         after,
         statSync(configPath).mode & 0o777,
       );
+    },
+    commitPin: () => {
+      const err = commitPinPersist(configPath);
+      if (err) warn(`\u26a0\ufe0f  ${err}\n`);
+    },
+    revertPin: () => {
+      // requireStale is deliberately FALSE here: this caller IS the process
+      // that wrote the provisional pin and it knows the roll has failed, so
+      // the liveness gate (which exists for concurrent recovery sites) would
+      // only ever refuse a revert we are certain about.
+      const outcome = rollbackPinPersist(configPath, {
+        writeConfig: writeConfigPreservingOwnership,
+        warn,
+      });
+      if (outcome.error) {
+        warn(
+          `⚠️  rollout: FAILED to revert the provisional release.pin=` +
+            `${outcome.pin}: ${outcome.error}\n`,
+        );
+      }
+      return outcome.reverted;
     },
   };
 }
@@ -1404,6 +1528,16 @@ export function registerRolloutCommand(program: Command): void {
     )
     .option("--dry-run", "Print the plan and exit without changing anything.")
     .action(async (opts: { pin?: string; agents?: string; skipWeb?: boolean; allowDowngrade?: boolean; dryRun?: boolean }) => {
+      // Crash recovery (host-shell path). A previous roll that was SIGKILLed
+      // between the provisional `release.pin` write and its commit leaves a
+      // journal on disk; revert it BEFORE reading the config, so this roll
+      // (and the downgrade guard's "current pin" comparison) sees the last
+      // PROVEN pin rather than an unproven one. No-op when no journal exists.
+      // Skipped under --dry-run, which changes nothing by contract.
+      if (!opts.dryRun) {
+        const note = recoverPinJournal(getConfigPath(program));
+        if (note) process.stderr.write(`⚠️  ${note}\n`);
+      }
       const config = getConfig(program);
       // #2492 — when --allow-downgrade is set but no --pin was given, default
       // the target to the last completed rollout's prior_pin (the version that

--- a/src/cli/write-compose.test.ts
+++ b/src/cli/write-compose.test.ts
@@ -9,7 +9,14 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SwitchroomConfig } from "../config/schema.js";
-import { writeComposeFile, resolveHostSwitchroomConfigPath } from "./write-compose.js";
+import {
+  writeComposeFile,
+  resolveHostSwitchroomConfigPath,
+  shouldBackupCompose,
+  restoreComposeBackup,
+  composeImageTag,
+  composeServiceNames,
+} from "./write-compose.js";
 
 function mkConfig(pin?: string): SwitchroomConfig {
   return {
@@ -185,5 +192,197 @@ describe("resolveHostSwitchroomConfigPath", () => {
     expect(content).toContain("/home/testop/.switchroom/switchroom.yaml:/state/config/switchroom.yaml:ro");
     // Must NOT have the container path as source — that's the bug.
     expect(content).not.toContain("/state/config/switchroom.yaml:/state/config/switchroom.yaml:ro");
+  });
+});
+
+// ── The compose backup must survive a roll ───────────────────────────────
+//
+// The old rule backed up on EVERY write. But `writeComposeFile` runs on every
+// `agent restart` too (src/cli/agent.ts — the restart reconcile regenerates
+// the WHOLE-fleet compose), so during a staggered roll the FIRST agent's
+// restart backed up the pre-roll compose and the SECOND agent's restart
+// immediately overwrote that backup with the post-bump file. Verified on the
+// production host: `cmp docker-compose.yml docker-compose.yml.bak` matched,
+// 58803 bytes each, same mtime — zero recovery value. The write-side comment
+// also claimed src/cli/update.ts could roll back to it; no such code existed
+// (`grep -n '\.bak\|rollback\|revert' src/cli/update.ts` → nothing).
+
+describe("shouldBackupCompose", () => {
+  const at = (tag: string) => `services:\n  x:\n    image: ghcr.io/o/switchroom-agent:${tag}\n`;
+
+  it("skips the first-ever write (nothing to back up)", () => {
+    expect(shouldBackupCompose(null, at("v1.0.0"), null)).toBe(false);
+  });
+
+  it("backs up when the image tag is genuinely moving", () => {
+    expect(shouldBackupCompose(at("v1.0.0"), at("v1.0.1"), null)).toBe(true);
+    expect(shouldBackupCompose(at("v1.0.0"), at("v1.0.1"), "v0.9.0")).toBe(true);
+  });
+
+  it("does NOT clobber the backup on a no-op regeneration", () => {
+    // Agents 2..N of a roll all rewrite the same already-bumped compose.
+    expect(shouldBackupCompose(at("v1.0.1"), at("v1.0.1"), "v1.0.0")).toBe(false);
+  });
+
+  it("does NOT clobber a pre-bump backup with a same-version write", () => {
+    const prev = at("v1.0.1") + "# unrelated edit\n";
+    expect(shouldBackupCompose(prev, at("v1.0.1"), "v1.0.0")).toBe(false);
+  });
+
+  it("still creates a first backup for a tag-neutral edit when none exists", () => {
+    const prev = at("v1.0.1") + "# unrelated edit\n";
+    expect(shouldBackupCompose(prev, at("v1.0.1"), null)).toBe(true);
+  });
+});
+
+describe("compose backup across a simulated staggered roll", () => {
+  it("keeps .bak on the PRE-ROLL version after every agent restarts", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-bak-"));
+    const composePath = join(dir, "docker-compose.yml");
+    const bak = composePath + ".bak";
+
+    // Fleet settled on v0.19.3 (an apply, then some restarts).
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+
+    // The roll: `apply --pin v0.19.4`, then one whole-fleet compose
+    // regeneration per agent restart (12 agents).
+    await writeComposeFile({ config: mkConfig("v0.19.4"), composePath, switchroomConfigPath: undefined });
+    for (let i = 0; i < 12; i++) {
+      await writeComposeFile({ config: mkConfig("v0.19.4"), composePath, switchroomConfigPath: undefined });
+    }
+
+    expect(readFileSync(composePath, "utf8")).toContain("switchroom-agent:v0.19.4");
+    // THE outcome the old code got wrong: the backup is the PRE-ROLL compose,
+    // not a copy of the live one.
+    const bakContent = readFileSync(bak, "utf8");
+    expect(bakContent).toContain("switchroom-agent:v0.19.3");
+    expect(bakContent).not.toContain("switchroom-agent:v0.19.4");
+    expect(bakContent).not.toBe(readFileSync(composePath, "utf8"));
+    expect(composeImageTag(bakContent)).toBe("v0.19.3");
+  });
+
+  it("restoreComposeBackup actually puts the fleet back on the prior compose", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-restore-"));
+    const composePath = join(dir, "docker-compose.yml");
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    await writeComposeFile({ config: mkConfig("v0.19.4"), composePath, switchroomConfigPath: undefined });
+
+    const res = await restoreComposeBackup(composePath);
+
+    expect(res.restored).toBe(true);
+    expect(res.imageTag).toBe("v0.19.3");
+    expect(readFileSync(composePath, "utf8")).toContain("switchroom-agent:v0.19.3");
+    expect(readFileSync(composePath, "utf8")).not.toContain("switchroom-agent:v0.19.4");
+  });
+
+  it("restoreComposeBackup reports (never throws) when there is no backup", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-nobak-"));
+    const composePath = join(dir, "docker-compose.yml");
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    const res = await restoreComposeBackup(composePath);
+    expect(res.restored).toBe(false);
+    expect(res.reason).toMatch(/no usable compose backup/);
+    // The live compose is untouched.
+    expect(readFileSync(composePath, "utf8")).toContain("switchroom-agent:v0.19.3");
+  });
+
+  it("refuses to restore an empty/truncated backup over a good compose", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-emptybak-"));
+    const composePath = join(dir, "docker-compose.yml");
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    writeFileSync(composePath + ".bak", "   \n", "utf8");
+    const res = await restoreComposeBackup(composePath);
+    expect(res.restored).toBe(false);
+    expect(res.reason).toMatch(/empty/);
+    expect(readFileSync(composePath, "utf8")).toContain("switchroom-agent:v0.19.3");
+  });
+
+  it("REFUSES a backup that predates an agent being added", async () => {
+    // The backup is deliberately preserved across many writes, so it can be
+    // arbitrarily old. Restoring one generated before `archivist` existed
+    // would silently delete a live agent's service — worse than the bad
+    // compose it is replacing.
+    const dir = mkdtempSync(join(tmpdir(), "wc-drift-add-"));
+    const composePath = join(dir, "docker-compose.yml");
+    const twoAgents = {
+      telegram: { bot_token: "x", forum_chat_id: "-100" },
+      release: { pin: "v0.19.4" },
+      agents: { clerk: { extends: "default" }, archivist: { extends: "default" } },
+    } as unknown as SwitchroomConfig;
+
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    await writeComposeFile({ config: twoAgents, composePath, switchroomConfigPath: undefined });
+
+    const live = readFileSync(composePath, "utf8");
+    expect(composeServiceNames(live)).toContain("agent-archivist");
+
+    const res = await restoreComposeBackup(composePath);
+
+    expect(res.restored).toBe(false);
+    expect(res.reason).toMatch(/does not match the current fleet/);
+    expect(res.reason).toMatch(/missing: agent-archivist/);
+    // THE outcome: the live compose is untouched, so no agent is dropped.
+    expect(readFileSync(composePath, "utf8")).toBe(live);
+  });
+
+  it("refuses a backup carrying a service the fleet no longer has", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-drift-rm-"));
+    const composePath = join(dir, "docker-compose.yml");
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    // Backup names a retired agent.
+    writeFileSync(
+      composePath + ".bak",
+      readFileSync(composePath, "utf8").replace(/^services:$/m, "services:\n  retired:\n    image: x"),
+      "utf8",
+    );
+    const res = await restoreComposeBackup(composePath);
+    expect(res.restored).toBe(false);
+    expect(res.reason).toMatch(/unknown: retired/);
+  });
+
+  it("force bypasses the coherence gate for a deliberate operator restore", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-force-"));
+    const composePath = join(dir, "docker-compose.yml");
+    const twoAgents = {
+      telegram: { bot_token: "x", forum_chat_id: "-100" },
+      release: { pin: "v0.19.4" },
+      agents: { clerk: { extends: "default" }, archivist: { extends: "default" } },
+    } as unknown as SwitchroomConfig;
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    await writeComposeFile({ config: twoAgents, composePath, switchroomConfigPath: undefined });
+
+    const res = await restoreComposeBackup(composePath, { force: true });
+
+    expect(res.restored).toBe(true);
+    expect(res.imageTag).toBe("v0.19.3");
+  });
+
+  it("still restores when the fleet is unchanged (the gate is not a blanket refusal)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-same-"));
+    const composePath = join(dir, "docker-compose.yml");
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    await writeComposeFile({ config: mkConfig("v0.19.4"), composePath, switchroomConfigPath: undefined });
+    const res = await restoreComposeBackup(composePath);
+    expect(res.restored).toBe(true);
+    expect(res.imageTag).toBe("v0.19.3");
+  });
+
+  it("composeServiceNames reads only top-level service keys", () => {
+    const text = [
+      "version: '3'",
+      "services:",
+      "  clerk:",
+      "    image: x",
+      "    environment:",
+      "      foo: bar",
+      "  # a comment",
+      "  archivist:",
+      "    image: y",
+      "volumes:",
+      "  data:",
+    ].join("\n");
+    expect(composeServiceNames(text)).toEqual(["clerk", "archivist"]);
+    expect(composeServiceNames("garbage")).toEqual([]);
   });
 });

--- a/src/cli/write-compose.test.ts
+++ b/src/cli/write-compose.test.ts
@@ -5,7 +5,7 @@
  * are correct. Writes to an isolated tmpdir — never ~/.switchroom.
  */
 import { describe, expect, it, afterEach, beforeEach } from "vitest";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SwitchroomConfig } from "../config/schema.js";
@@ -341,18 +341,72 @@ describe("compose backup across a simulated staggered roll", () => {
     expect(res.reason).toMatch(/unknown: retired/);
   });
 
-  it("force bypasses the coherence gate for a deliberate operator restore", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "wc-force-"));
+  it("REFUSES when the live compose is unreadable — the gate must not disable itself", async () => {
+    // THE bug this asserts: the gate used to run only `if (expected &&
+    // expected.length > 0)`, so a missing live compose left `expected`
+    // undefined and the check was SKIPPED — restoring blind. A missing or
+    // broken live compose is exactly the state the sole caller (hostd's
+    // failed-auto-roll recovery, reached only after `apply --pin` exited
+    // non-zero) invokes this in, so the gate switched itself off precisely
+    // when it mattered.
+    const dir = mkdtempSync(join(tmpdir(), "wc-nolive-"));
     const composePath = join(dir, "docker-compose.yml");
-    const twoAgents = {
-      telegram: { bot_token: "x", forum_chat_id: "-100" },
-      release: { pin: "v0.19.4" },
-      agents: { clerk: { extends: "default" }, archivist: { extends: "default" } },
-    } as unknown as SwitchroomConfig;
     await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
-    await writeComposeFile({ config: twoAgents, composePath, switchroomConfigPath: undefined });
+    await writeComposeFile({ config: mkConfig("v0.19.4"), composePath, switchroomConfigPath: undefined });
+    const backup = readFileSync(composePath + ".bak", "utf8");
+    rmSync(composePath);
 
-    const res = await restoreComposeBackup(composePath, { force: true });
+    const res = await restoreComposeBackup(composePath);
+
+    expect(res.restored).toBe(false);
+    expect(res.reason).toMatch(/cannot verify the compose backup/);
+    expect(res.reason).toMatch(/no service set to check it against/);
+    // THE outcome: nothing was written, so an unverifiable backup cannot
+    // drop or resurrect services behind the operator's back…
+    expect(existsSync(composePath)).toBe(false);
+    // …and the backup is left intact for a deliberate host-side recovery.
+    expect(readFileSync(composePath + ".bak", "utf8")).toBe(backup);
+  });
+
+  it("REFUSES when the live compose declares no services (truncated/corrupt)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-emptylive-"));
+    const composePath = join(dir, "docker-compose.yml");
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    await writeComposeFile({ config: mkConfig("v0.19.4"), composePath, switchroomConfigPath: undefined });
+    // A half-written compose: plausible prefix, no service keys at all.
+    const corrupt = "# switchroom\nversion: '3'\n";
+    writeFileSync(composePath, corrupt, "utf8");
+
+    const res = await restoreComposeBackup(composePath);
+
+    expect(res.restored).toBe(false);
+    expect(res.reason).toMatch(/declares no services/);
+    expect(readFileSync(composePath, "utf8")).toBe(corrupt);
+  });
+
+  it("an empty caller-supplied expectation is a refusal too, not a bypass", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-emptyexp-"));
+    const composePath = join(dir, "docker-compose.yml");
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    await writeComposeFile({ config: mkConfig("v0.19.4"), composePath, switchroomConfigPath: undefined });
+    const live = readFileSync(composePath, "utf8");
+
+    const res = await restoreComposeBackup(composePath, { expectedServices: [] });
+
+    expect(res.restored).toBe(false);
+    expect(res.reason).toMatch(/declares no services/);
+    expect(readFileSync(composePath, "utf8")).toBe(live);
+  });
+
+  it("a caller-supplied expectation is honoured over the live compose", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-exp-"));
+    const composePath = join(dir, "docker-compose.yml");
+    await writeComposeFile({ config: mkConfig("v0.19.3"), composePath, switchroomConfigPath: undefined });
+    await writeComposeFile({ config: mkConfig("v0.19.4"), composePath, switchroomConfigPath: undefined });
+    const expected = composeServiceNames(readFileSync(composePath + ".bak", "utf8"));
+    expect(expected.length).toBeGreaterThan(0);
+
+    const res = await restoreComposeBackup(composePath, { expectedServices: expected });
 
     expect(res.restored).toBe(true);
     expect(res.imageTag).toBe("v0.19.3");

--- a/src/cli/write-compose.ts
+++ b/src/cli/write-compose.ts
@@ -389,20 +389,246 @@ export async function computeComposeContent(
   return { content, imageTag, previous, previousImageTag };
 }
 
+/** Suffix of the compose backup file. */
+export const BACKUP_SUFFIX = ".bak";
+
+/** Absolute path of the compose backup for a given compose path. */
+export function composeBackupPath(composePath: string): string {
+  return composePath + BACKUP_SUFFIX;
+}
+
+/** Extract the agent image tag from compose text (null when absent). */
+export function composeImageTag(content: string | null): string | null {
+  if (!content) return null;
+  return AGENT_IMAGE_TAG_RE.exec(content)?.[1] ?? null;
+}
+
+/** Read the agent image tag currently recorded in the backup, or null. */
+async function readBackupImageTag(composePath: string): Promise<string | null> {
+  try {
+    return composeImageTag(await readFile(composeBackupPath(composePath), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Should this compose write refresh `<composePath>.bak`?
+ *
+ * ## Why this is not "always"
+ *
+ * The old rule was "copy the previous file every time", which produced a
+ * backup with ZERO recovery value:
+ *
+ *   - `writeComposeFile` runs on EVERY `agent restart`, not just `apply`
+ *     (`src/cli/agent.ts` — the restart reconcile regenerates the WHOLE-fleet
+ *     compose). A staggered roll restarts agents one at a time, so the FIRST
+ *     agent's restart backed up the pre-roll compose and the SECOND agent's
+ *     restart immediately overwrote that backup with the new (post-bump)
+ *     file. By agent 3 of 12 the "backup" was byte-identical to the live
+ *     compose — verified on the production host: `cmp docker-compose.yml
+ *     docker-compose.yml.bak` matched, same size, same mtime.
+ *   - Which is why the operator ended up hand-rolling 27 `docker-compose.yml
+ *     .bak-*` files: the built-in backup never held anything they could go
+ *     back to.
+ *
+ * ## The rule
+ *
+ * `.bak` is defined as *the last compose generated on a different agent image
+ * tag than the current one* — i.e. the pre-version-bump compose, which is the
+ * only thing worth rolling back to when a roll produces a bad compose.
+ *
+ * 1. No previous file (first-ever write) → nothing to back up.
+ * 2. Previous === next (a no-op regeneration, e.g. agents 2..N of a roll all
+ *    rewriting the same already-bumped whole-fleet compose) → keep the older
+ *    backup. This alone kills the mid-roll clobber.
+ * 3. Previous is ALREADY on the tag we're about to write, and a backup
+ *    already exists → the version bump happened on an earlier write; keep
+ *    that pre-bump backup rather than replacing it with a same-version one.
+ * 4. Otherwise (the tag is genuinely changing, or there is no backup yet) →
+ *    take the backup.
+ *
+ * ## What `.bak` is NOT
+ *
+ * It is **"the last compose on a different agent image tag"**, which is not
+ * the same claim as **"a compose known to work"**. Nothing here health-checks
+ * the previous file. Two cases where the distinction bites:
+ *
+ *   - roll v1 → v2 fails, leaving `.bak` = v1 (good). A second roll v2 → v3
+ *     then backs up the v2 compose, so `.bak` now holds the compose of the
+ *     build that just failed. The pre-bump copy from the FIRST roll is gone.
+ *   - an operator hand-edits a broken compose and applies; the tag moved, so
+ *     the broken file becomes the backup on the next bump.
+ *
+ * This is why {@link restoreComposeBackup} is a best-effort FALLBACK behind
+ * `apply --pin <priorPin>` (which regenerates from config and is authoritative)
+ * rather than a primary rollback, and why it refuses a backup whose service
+ * set no longer matches the fleet. Making `.bak` mean "known good" needs a
+ * post-roll health signal to gate the backup on — a separate change, filed
+ * rather than half-implemented here.
+ *
+ * Pure + exported so the clobber case is asserted in tests without docker.
+ */
+export function shouldBackupCompose(
+  previous: string | null,
+  next: string,
+  existingBackupTag: string | null,
+): boolean {
+  if (previous === null) return false; // (1)
+  if (previous === next) return false; // (2)
+  const prevTag = composeImageTag(previous);
+  const nextTag = composeImageTag(next);
+  // (3) — only skip when we actually HAVE a backup to protect and the tag
+  // isn't moving; otherwise a tag-neutral edit on a fresh host would never
+  // create a backup at all.
+  if (existingBackupTag !== null && prevTag !== null && prevTag === nextTag) return false;
+  return true; // (4)
+}
+
+/**
+ * Top-level service names declared in compose text, in file order.
+ *
+ * Deliberately a shallow scan rather than a YAML parse: this runs on recovery
+ * paths where a partially-corrupt file must degrade to "no services found"
+ * (→ refuse the restore) instead of throwing. Service keys are emitted by the
+ * generator at exactly one indent level under `services:`.
+ */
+export function composeServiceNames(content: string): string[] {
+  const names: string[] = [];
+  let inServices = false;
+  let indent: number | null = null;
+  for (const raw of content.split("\n")) {
+    if (/^\s*(#|$)/.test(raw)) continue;
+    const lead = raw.length - raw.trimStart().length;
+    if (!inServices) {
+      if (/^services:\s*$/.test(raw)) inServices = true;
+      continue;
+    }
+    if (lead === 0) break; // left the services block
+    if (indent === null) indent = lead;
+    if (lead !== indent) continue; // nested key, not a service
+    const m = /^([A-Za-z0-9_.-]+):\s*$/.exec(raw.trim());
+    if (m) names.push(m[1]!);
+  }
+  return names;
+}
+
+/** Outcome of a {@link restoreComposeBackup} attempt. */
+export interface ComposeRestoreResult {
+  restored: boolean;
+  /** The agent image tag the restored compose carries (when restored). */
+  imageTag?: string | null;
+  /** Why the restore did not happen / failed. */
+  reason?: string;
+}
+
+/**
+ * Restore `<composePath>.bak` over `<composePath>`.
+ *
+ * This is the consumer the backup existed for. Before this, the write-side
+ * comment claimed "the health-gated recreate (src/cli/update.ts) can roll
+ * back to" the `.bak` — but no such rollback existed anywhere in
+ * `src/cli/update.ts` (`grep -n '\.bak\|rollback\|revert'` → nothing). The
+ * comment described a mechanism that was never built; this function is that
+ * mechanism.
+ *
+ * ## Coherence gate
+ *
+ * A backup is only "last known good" for the fleet it was generated FOR. It
+ * can be arbitrarily old (rule 3 in {@link shouldBackupCompose} deliberately
+ * preserves the pre-bump copy across many writes), so the config may have
+ * gained or lost agents since. Restoring it then would silently remove a live
+ * agent's service — a far worse outcome than the bad compose it's replacing.
+ *
+ * So the restore refuses when the backup's service set differs from the
+ * service set in the compose currently on disk (which the last write generated
+ * from the live config). `opts.expectedServices` overrides that source when
+ * the caller has the config's own view; `opts.force` bypasses the gate for an
+ * operator who has looked at the diff and wants it anyway.
+ *
+ * Uses the same tmp+rename swap as the forward write so a crash mid-restore
+ * can't leave a truncated compose. Never throws — callers are recovery paths
+ * where a throw is worse than a reported failure.
+ */
+export async function restoreComposeBackup(
+  composePath: string,
+  opts: { expectedServices?: string[]; force?: boolean } = {},
+): Promise<ComposeRestoreResult> {
+  const bak = composeBackupPath(composePath);
+  let content: string;
+  try {
+    content = await readFile(bak, "utf8");
+  } catch (e) {
+    return { restored: false, reason: `no usable compose backup at ${bak} (${(e as Error).message})` };
+  }
+  if (content.trim() === "") {
+    return { restored: false, reason: `compose backup at ${bak} is empty` };
+  }
+
+  if (!opts.force) {
+    let expected = opts.expectedServices;
+    if (!expected) {
+      try {
+        expected = composeServiceNames(await readFile(composePath, "utf8"));
+      } catch {
+        expected = undefined; // nothing live to compare against
+      }
+    }
+    if (expected && expected.length > 0) {
+      const have = composeServiceNames(content);
+      const missing = expected.filter((s) => !have.includes(s));
+      const extra = have.filter((s) => !expected.includes(s));
+      if (missing.length > 0 || extra.length > 0) {
+        return {
+          restored: false,
+          reason:
+            `compose backup at ${bak} does not match the current fleet ` +
+            `(missing: ${missing.join(", ") || "none"}; ` +
+            `unknown: ${extra.join(", ") || "none"}). Refusing to restore — it ` +
+            `predates a config change and would drop or resurrect services. ` +
+            `Re-run \`switchroom apply\` against the intended release instead.`,
+        };
+      }
+    }
+  }
+
+  try {
+    const tmpPath = composePath + ".restore.tmp";
+    await writeFile(tmpPath, content, { encoding: "utf8", mode: 0o600 });
+    await rename(tmpPath, composePath);
+  } catch (e) {
+    return { restored: false, reason: `restore write failed: ${(e as Error).message}` };
+  }
+  const operatorUid = resolveOperatorUid();
+  if (operatorUid !== undefined && process.geteuid?.() === 0) {
+    try {
+      chownSync(composePath, operatorUid, operatorUid);
+    } catch {
+      /* best-effort — matches the forward write's tolerance */
+    }
+  }
+  return { restored: true, imageTag: composeImageTag(content) };
+}
+
 /** Generate the compose content and write it (mode 0600). Always writes — same as apply. */
 export async function writeComposeFile(opts: WriteComposeOpts): Promise<WriteComposeResult> {
   const { content, imageTag, previous, previousImageTag } = await computeComposeContent(opts);
   const operatorUid = resolveOperatorUid();
 
   await mkdir(dirname(opts.composePath), { recursive: true });
-  // Last-known-good backup + atomic write. If a deploy regenerates a bad
-  // compose, `<composePath>.bak` is the prior file the health-gated recreate
-  // (src/cli/update.ts) can roll back to. tmp+rename makes the swap atomic so a
-  // crash mid-write never leaves a truncated compose. Backup only when the
-  // prior content actually parsed as a real file (skip first-ever-write).
-  if (previous !== null) {
+  // Pre-version backup + atomic write. `<composePath>.bak` holds the last
+  // compose generated on a DIFFERENT agent image tag than the one being
+  // written — see {@link shouldBackupCompose} for why the previous
+  // "always copy" rule made the backup worthless. NOTE it means exactly
+  // "last compose on a different tag", NOT "known good" — see the caveats on
+  // {@link shouldBackupCompose}. Restored by {@link restoreComposeBackup}
+  // (hostd's failed-auto-roll recovery falls back to it, service-set gated,
+  // only when regenerating compose on the prior pin fails).
+  // tmp+rename makes the swap atomic so a crash mid-write never leaves a
+  // truncated compose.
+  if (shouldBackupCompose(previous, content, await readBackupImageTag(opts.composePath))) {
     try {
-      await copyFile(opts.composePath, opts.composePath + ".bak");
+      await copyFile(opts.composePath, composeBackupPath(opts.composePath));
     } catch {
       /* best-effort backup — never block the write */
     }

--- a/src/cli/write-compose.ts
+++ b/src/cli/write-compose.ts
@@ -543,8 +543,22 @@ export interface ComposeRestoreResult {
  * So the restore refuses when the backup's service set differs from the
  * service set in the compose currently on disk (which the last write generated
  * from the live config). `opts.expectedServices` overrides that source when
- * the caller has the config's own view; `opts.force` bypasses the gate for an
- * operator who has looked at the diff and wants it anyway.
+ * the caller has the config's own view.
+ *
+ * **The gate cannot disable itself.** An earlier draft only ran the comparison
+ * `if (expected && expected.length > 0)`, i.e. it silently skipped the check
+ * whenever the live compose was missing, empty, or too corrupt to yield a
+ * service name — which is precisely the "`apply --pin` failed and left a broken
+ * compose" state the only caller invokes this from. The gate switched itself
+ * off exactly when it mattered and restored blind. An indeterminate expectation
+ * is now a REFUSAL: without a service set to compare against there is no way to
+ * know the backup still describes this fleet, and `switchroom apply` host-side
+ * is a strictly better recovery than a blind overwrite.
+ *
+ * There is deliberately no `force` bypass: this function has one caller
+ * (hostd's failed-auto-roll recovery), which is unattended, so a bypass would
+ * be dead code — and the operator's override already exists and is better
+ * (`switchroom apply`, or copying the `.bak` by hand after reading the diff).
  *
  * Uses the same tmp+rename swap as the forward write so a crash mid-restore
  * can't leave a truncated compose. Never throws — callers are recovery paths
@@ -552,7 +566,7 @@ export interface ComposeRestoreResult {
  */
 export async function restoreComposeBackup(
   composePath: string,
-  opts: { expectedServices?: string[]; force?: boolean } = {},
+  opts: { expectedServices?: string[] } = {},
 ): Promise<ComposeRestoreResult> {
   const bak = composeBackupPath(composePath);
   let content: string;
@@ -565,30 +579,50 @@ export async function restoreComposeBackup(
     return { restored: false, reason: `compose backup at ${bak} is empty` };
   }
 
-  if (!opts.force) {
-    let expected = opts.expectedServices;
-    if (!expected) {
-      try {
-        expected = composeServiceNames(await readFile(composePath, "utf8"));
-      } catch {
-        expected = undefined; // nothing live to compare against
-      }
+  let expected = opts.expectedServices;
+  let expectationSource = "the caller's expected service set";
+  if (!expected) {
+    expectationSource = `the compose currently at ${composePath}`;
+    try {
+      expected = composeServiceNames(await readFile(composePath, "utf8"));
+    } catch (e) {
+      return {
+        restored: false,
+        reason:
+          `cannot verify the compose backup at ${bak}: ${composePath} is ` +
+          `unreadable (${(e as Error).message}), so there is no service set to ` +
+          `check it against. Refusing to restore — a backup can predate a ` +
+          `config change and would then drop or resurrect services. Run ` +
+          `\`switchroom apply\` host-side against the intended release.`,
+      };
     }
-    if (expected && expected.length > 0) {
-      const have = composeServiceNames(content);
-      const missing = expected.filter((s) => !have.includes(s));
-      const extra = have.filter((s) => !expected.includes(s));
-      if (missing.length > 0 || extra.length > 0) {
-        return {
-          restored: false,
-          reason:
-            `compose backup at ${bak} does not match the current fleet ` +
-            `(missing: ${missing.join(", ") || "none"}; ` +
-            `unknown: ${extra.join(", ") || "none"}). Refusing to restore — it ` +
-            `predates a config change and would drop or resurrect services. ` +
-            `Re-run \`switchroom apply\` against the intended release instead.`,
-        };
-      }
+  }
+  if (expected.length === 0) {
+    return {
+      restored: false,
+      reason:
+        `cannot verify the compose backup at ${bak}: ${expectationSource} ` +
+        `declares no services (empty, truncated, or unparseable), so there is ` +
+        `no service set to check it against. Refusing to restore — a backup ` +
+        `can predate a config change and would then drop or resurrect ` +
+        `services. Run \`switchroom apply\` host-side against the intended ` +
+        `release.`,
+    };
+  }
+  {
+    const have = composeServiceNames(content);
+    const missing = expected.filter((s) => !have.includes(s));
+    const extra = have.filter((s) => !expected.includes(s));
+    if (missing.length > 0 || extra.length > 0) {
+      return {
+        restored: false,
+        reason:
+          `compose backup at ${bak} does not match the current fleet ` +
+          `(missing: ${missing.join(", ") || "none"}; ` +
+          `unknown: ${extra.join(", ") || "none"}). Refusing to restore — it ` +
+          `predates a config change and would drop or resurrect services. ` +
+          `Re-run \`switchroom apply\` against the intended release instead.`,
+      };
     }
   }
 

--- a/src/host-control/rollout-narrator.test.ts
+++ b/src/host-control/rollout-narrator.test.ts
@@ -418,7 +418,10 @@ describe("LogTailRolloutNarrator", () => {
       log: () => {},
       // Bridge the executor's phase emissions into the real narrator.
       emitPhase: (p) => n.onPhase(entry, p),
-      persistPin: (pin) => persisted.push(pin),
+      persistPin: (pin) => {
+        persisted.push(pin);
+        return true;
+      },
     };
 
     const result = executeRollout(steps, TARGET, deps, { hostdContext: true });

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -64,6 +64,8 @@ import {
   isVersionAssertable,
   type RolloutPhase,
 } from "../cli/rollout.js";
+import { recoverPinJournal } from "../cli/rollout-pin-journal.js";
+import { restoreComposeBackup } from "../cli/write-compose.js";
 import { SWITCHROOM_VERSION } from "../cli/resolve-version.js";
 import {
   needsSelfBump,
@@ -787,6 +789,51 @@ export class HostdServer {
 
   constructor(private opts: ServerOptions) {}
 
+  /**
+   * The live `switchroom.yaml` this daemon reads/writes. Mirrors the default
+   * pinned by the config-edit wire schema.
+   */
+  private hostdConfigPath(): string {
+    return this.opts.configPath ?? "/state/config/switchroom.yaml";
+  }
+
+  /**
+   * The FLEET compose file (not hostd's own). Same resolution as
+   * {@link imageRefsForDigestCapture} uses.
+   */
+  private fleetComposePath(): string {
+    return join(
+      this.opts.bindRoot ?? this.opts.homeDir,
+      ".switchroom",
+      "compose",
+      "docker-compose.yml",
+    );
+  }
+
+  /**
+   * Revert an UNCOMMITTED provisional `release.pin` left behind by a rollout
+   * that died before it could commit or revert its own write.
+   *
+   * The rollout child normally handles both outcomes itself (commit on
+   * success, revert on a clean failure), so this is purely the crash net:
+   * SIGKILL / OOM / hostd recreate between the pin write and the terminal.
+   * It is a no-op when no journal exists, which is why it's safe to call
+   * unconditionally at boot and on every rollout terminal.
+   *
+   * Never throws — a stranded lock or a failed boot would be worse than the
+   * stale pin it's fixing, so failures are reported and swallowed.
+   */
+  private recoverRolloutPinJournal(context: string): string | null {
+    let note: string | null = null;
+    try {
+      note = recoverPinJournal(this.hostdConfigPath());
+    } catch (e) {
+      note = `rollout pin journal recovery threw: ${(e as Error).message}`;
+    }
+    if (note) process.stderr.write(`hostd (${context}): ${note}\n`);
+    return note;
+  }
+
   /** Start listening on every configured agent's socket. */
   async start(): Promise<void> {
     const hostdDir = join(this.opts.homeDir, ".switchroom", "hostd");
@@ -813,6 +860,39 @@ export class HostdServer {
         `hostd: self-bump resume failed (non-fatal): ${(e as Error).message}\n`,
       );
     });
+
+    // Rollout pin-journal crash recovery. A roll that was SIGKILLed between
+    // its provisional `release.pin` write and the commit leaves a journal on
+    // disk; without this, the durable pin names a build that was never proven
+    // and EVERY later restart / crash-loop recreate / reconcile / `compose up
+    // -d` converges the rest of the fleet onto it. No-op when nothing is
+    // journalled.
+    //
+    // ORDERING, precisely: awaiting `resumePendingSelfBumpRollout()` above does
+    // NOT mean a resumed roll has finished. That path ends at `launchRollout`,
+    // which takes the fleet-mutation latch, calls `spawnRollout`, and returns
+    // SYNCHRONOUSLY — the roll then runs for minutes in a child process. So a
+    // journal seen here may well belong to a roll that is still running, and
+    // reverting it would fight a live roll (and could revert the pin of one
+    // that is about to succeed).
+    //
+    // Two independent guards, deliberately belt-and-braces:
+    //   1. the latch check below — if a resume is in flight, boot recovery is
+    //      skipped outright and that roll's own terminal handler runs recovery
+    //      when it finishes (see the rollout terminal `.finally()`);
+    //   2. `recoverPinJournal` is stale-gated regardless: it reverts only when
+    //      the journal's recorded pid is gone OR the journal has aged past
+    //      PIN_JOURNAL_MAX_AGE_MS, so even a journal from a roll hostd doesn't
+    //      know about (a host-shell `switchroom rollout`) is left alone while
+    //      it is plausibly live.
+    if (this.fleetMutationInFlight) {
+      process.stderr.write(
+        `hostd (boot): a rollout resumed at boot is still in flight — ` +
+          `deferring pin-journal recovery to its terminal handler.\n`,
+      );
+    } else {
+      this.recoverRolloutPinJournal("boot");
+    }
 
     const agentNames = Object.keys(this.opts.agentUids).sort();
     if (agentNames.length === 0) {
@@ -3947,6 +4027,18 @@ export class HostdServer {
         delete entry.prior_pin;
       })
       .finally(() => {
+        // Crash net for the durable pin. The rollout child commits its own
+        // provisional `release.pin` on success and reverts it on a clean
+        // failure, so a journal surviving to the TERMINAL means the child
+        // died in between (SIGKILL / OOM — the `result: "error"` rows with no
+        // sentinel). Reverting here, before the lock is released and before
+        // any other mutation can run, stops the next reconcile from
+        // converging the fleet onto a pin that was never proven. No-op in the
+        // normal case.
+        const pinNote = this.recoverRolloutPinJournal(
+          `rollout terminal ${entry.request_id}`,
+        );
+        if (pinNote) entry.stderr_tail = `${entry.stderr_tail ?? ""}\n${pinNote}`.trim();
         void this.writeTerminalAudit(entry);
         // KEN-131 — unattended (auto-update) roll that FAILED: no operator
         // is watching, so the hardened no-operator path runs instead of the
@@ -4100,13 +4192,34 @@ export class HostdServer {
       ["apply", "--pin", priorPin, "--compose-only", "--non-interactive"],
       { SWITCHROOM_HOSTD_CONTEXT: "1" },
     );
-    notes.push(
-      applyRes.exit_code === 0
-        ? `Rollback: compose restored to ${priorPin}.`
-        : `Rollback FAILED: compose restore to ${priorPin} exited ` +
-            `${applyRes.exit_code} — run \`switchroom apply\` host-side ` +
-            `(${tail(applyRes.stderr).trim().slice(-300) || "no stderr"}).`,
-    );
+    if (applyRes.exit_code === 0) {
+      notes.push(`Rollback: compose restored to ${priorPin}.`);
+    } else {
+      // Regeneration failed — fall back to the pre-version-bump compose
+      // backup. This is the FIRST real consumer of `<compose>.bak`; the
+      // write-side comment used to claim src/cli/update.ts rolled back to it,
+      // but no such code existed. With the backup rule fixed
+      // (shouldBackupCompose — a roll's per-agent restarts can no longer
+      // clobber it), the file genuinely holds the pre-roll compose.
+      //
+      // Strictly a FALLBACK behind `apply --pin`, and not "known good": the
+      // backup means "the last compose on a different image tag", which can
+      // predate config changes or hold a previously-failed build. It is
+      // service-set gated inside restoreComposeBackup — a backup that would
+      // drop or resurrect an agent is refused rather than applied blind.
+      const restore = await restoreComposeBackup(this.fleetComposePath());
+      notes.push(
+        `Rollback: compose regeneration to ${priorPin} exited ` +
+          `${applyRes.exit_code} ` +
+          `(${tail(applyRes.stderr).trim().slice(-300) || "no stderr"}). ` +
+          (restore.restored
+            ? `Fell back to the pre-bump compose backup (image tag ` +
+              `${restore.imageTag ?? "unknown"}). Verify host-side with ` +
+              `\`switchroom apply\`.`
+            : `Backup fallback ALSO failed (${restore.reason ?? "unknown"}) — ` +
+              `run \`switchroom apply\` host-side.`),
+      );
+    }
     if (entry.failed_step === "restart-agent" && entry.failed_agent) {
       const restartRes = await this.runSwitchroom(
         [

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -68,6 +68,7 @@ import {
   recoverPinJournal,
   commitPinPersist,
   hasPinJournal,
+  readPinJournal,
 } from "../cli/rollout-pin-journal.js";
 import { restoreComposeBackup } from "../cli/write-compose.js";
 import { SWITCHROOM_VERSION } from "../cli/resolve-version.js";
@@ -680,19 +681,29 @@ export const HOSTD_FALLBACK_CONFIG_PATH = "/state/config/switchroom.yaml";
  *
  * Order:
  *   1. an explicit `opts.configPath` (tests, and any future embedder);
- *   2. `$SWITCHROOM_CONFIG` — what `hostd install` exports into the container
- *      and what the child's `findConfigFile` consults first;
- *   3. `findConfigFile()` — cwd / `~/.switchroom`, same as the child;
- *   4. {@link HOSTD_FALLBACK_CONFIG_PATH}, only when 2 and 3 both come up
- *      empty (a hostd whose config has been deleted out from under it —
+ *   2. {@link findConfigFile} — **the child's own resolver, called directly**.
+ *      It consults `$SWITCHROOM_CONFIG` first (what `hostd install` exports
+ *      into the container), then cwd, then `~/.switchroom`;
+ *   3. {@link HOSTD_FALLBACK_CONFIG_PATH}, only when 2 comes up empty (a
+ *      hostd whose config has been deleted out from under it —
  *      `findConfigFile` THROWS there, and a throw out of a boot path or a
  *      rollout `.finally()` would be worse than a wrong-but-conventional
  *      guess).
+ *
+ * Arm 2 deliberately DELEGATES rather than re-deriving. An earlier shape read
+ * `$SWITCHROOM_CONFIG` here itself and returned it unconditionally, one arm
+ * ahead of `findConfigFile`. That looked equivalent — `findConfigFile` checks
+ * the same variable first — but it is not: the child takes `$SWITCHROOM_CONFIG`
+ * only `if (existsSync(envPath))` and otherwise falls through to cwd /
+ * `~/.switchroom`. With the variable pointing at a path that does not exist,
+ * hostd returned the dangling path while the child resolved a real file, the
+ * two hashed to different journal names, and the divergence this function
+ * exists to prevent reappeared — invisibly. Calling the child's resolver makes
+ * the agreement structural instead of a claim two code paths have to keep
+ * honouring independently.
  */
 export function resolveHostdConfigPath(explicit?: string): string {
   if (explicit) return explicit;
-  const env = process.env.SWITCHROOM_CONFIG;
-  if (env && env.trim().length > 0) return resolve(env.trim());
   try {
     return findConfigFile();
   } catch {
@@ -906,19 +917,52 @@ export class HostdServer {
    * BOOT recovery (which has no sentinel to consult) will eventually revert
    * that proven pin.
    *
+   * **Only deletes a journal it can ATTRIBUTE to this roll.** "A journal
+   * exists and this roll succeeded" does not imply the journal is this roll's
+   * debris: the child journals only when it actually writes the pin, and it
+   * no-ops when the config already names the target (`createRolloutDeps`'
+   * `persistPin`). So a journal can equally be an ORPHAN a predecessor left
+   * behind — and on a subset roll (`--agents`, which hostd passes alongside
+   * `--pin`) that orphan is the only record that `release.pin` names a build
+   * still unproven for every agent this roll did not touch. Deleting it
+   * because some other roll went green destroys that record permanently.
+   *
+   * The discriminator is already in the record: the journal carries the `at`
+   * the child wrote it, and `entry.started_at` is when this roll's child was
+   * spawned. `journal.at < started_at` means the journal predates this roll,
+   * so this roll did not write it — leave it, and say so.
+   *
    * Never throws — same contract as the recovery path it replaces.
    */
-  private clearProvenRolloutPinJournal(context: string): string | null {
+  private clearProvenRolloutPinJournal(
+    context: string,
+    startedAt: number,
+  ): string | null {
     let note: string | null = null;
     try {
       const configPath = this.hostdConfigPath();
       if (!hasPinJournal(configPath)) return null;
-      const err = commitPinPersist(configPath);
-      note =
-        err ??
-        `rollout pin journal: cleared a journal that outlived a SUCCESSFUL ` +
-          `roll (the child's own commit did not remove it). release.pin is ` +
-          `correct and was NOT reverted.`;
+      const journal = readPinJournal(configPath, () => undefined);
+      const at = journal ? Date.parse(journal.at) : Number.NaN;
+      // An unreadable/malformed journal (readPinJournal returns null) or an
+      // unparseable timestamp cannot be attributed either — same verdict.
+      if (!Number.isFinite(at) || at < startedAt) {
+        note =
+          `rollout pin journal: LEFT IN PLACE a journal this roll did not ` +
+          `write (journal at=${journal?.at ?? "unreadable"}, this roll started ` +
+          `${new Date(startedAt).toISOString()}). It belongs to an earlier ` +
+          `roll whose provisional \`release.pin\` was never committed, and it ` +
+          `is the only record that the pin may name an unproven build — a ` +
+          `subset roll going green does not prove it for the rest of the ` +
+          `fleet. Verify \`release.pin\` host-side, then delete the journal.`;
+      } else {
+        const err = commitPinPersist(configPath);
+        note =
+          err ??
+          `rollout pin journal: cleared a journal that outlived a SUCCESSFUL ` +
+            `roll (the child's own commit did not remove it). release.pin is ` +
+            `correct and was NOT reverted.`;
+      }
     } catch (e) {
       note = `rollout pin journal: clearing a proven roll's journal threw: ${(e as Error).message}`;
     }
@@ -4141,14 +4185,20 @@ export class HostdServer {
         // priorPin while telling the operator the roll succeeded, and every
         // later reconcile would drag the fleet back to the prior version.
         //
-        // So: a sentinel that says ok:true means the pin is proven. The
-        // surviving journal is then debris to DELETE, never input to act on.
+        // So: a sentinel that says ok:true means the pin is proven, and the
+        // surviving journal is never input to REVERT. It is only debris to
+        // delete when it is also attributable to THIS roll — the child no-ops
+        // its journal write when the config already names the target, so a
+        // journal can equally be a predecessor's orphan, and on a subset roll
+        // that orphan is the only record the pin is unproven elsewhere.
+        // `clearProvenRolloutPinJournal` makes that call from `started_at`.
         // Everything else (ok:false, no sentinel at all, a rejected promise)
         // goes through the stale-gated revert. Both run before the lock is
         // released and before any other mutation can start.
         const pinNote = sentinelProvenOk
           ? this.clearProvenRolloutPinJournal(
               `rollout terminal ${entry.request_id}`,
+              entry.started_at,
             )
           : this.recoverRolloutPinJournal(
               `rollout terminal ${entry.request_id}`,

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -64,7 +64,11 @@ import {
   isVersionAssertable,
   type RolloutPhase,
 } from "../cli/rollout.js";
-import { recoverPinJournal } from "../cli/rollout-pin-journal.js";
+import {
+  recoverPinJournal,
+  commitPinPersist,
+  hasPinJournal,
+} from "../cli/rollout-pin-journal.js";
 import { restoreComposeBackup } from "../cli/write-compose.js";
 import { SWITCHROOM_VERSION } from "../cli/resolve-version.js";
 import {
@@ -89,7 +93,7 @@ import { classifyBlastRadius } from "./config-blast-radius.js";
 import type { ApprovalGateway } from "./approval-gateway.js";
 import type { RolloutRelay } from "./rollout-relay.js";
 import { renderRolloutStatus } from "./render-rollout-status.js";
-import { loadConfig, resolveAgentsDir } from "../config/loader.js";
+import { loadConfig, resolveAgentsDir, findConfigFile } from "../config/loader.js";
 import { getAllAgentStatuses } from "../agents/lifecycle.js";
 import {
   collectScheduleEntries,
@@ -650,6 +654,52 @@ interface AutoRolloutLatch {
   reason?: string;
 }
 
+/**
+ * Last-resort config path when neither an explicit `opts.configPath`, nor
+ * `$SWITCHROOM_CONFIG`, nor {@link findConfigFile} can name one. This is the
+ * container path `hostd install` bind-mounts `~/.switchroom/switchroom.yaml`
+ * onto (`src/cli/hostd.ts` — the `:/state/config/switchroom.yaml:rw` mount and
+ * the `SWITCHROOM_CONFIG` it exports alongside it).
+ *
+ * Exported so a test can assert the fallback is the LAST arm, not the first.
+ */
+export const HOSTD_FALLBACK_CONFIG_PATH = "/state/config/switchroom.yaml";
+
+/**
+ * Resolve the live `switchroom.yaml` this daemon reads/writes.
+ *
+ * This MUST agree, string-for-string, with what the rollout child resolves —
+ * the child goes `getConfigPath` → {@link findConfigFile} → `$SWITCHROOM_CONFIG`
+ * (`src/cli/rollout.ts`). It is not merely cosmetic agreement: the pin
+ * journal's FILENAME is a digest of the absolute config path
+ * (`pinJournalPath`, `src/cli/rollout-pin-journal.ts`), so a daemon that
+ * resolves a different string than its child looks for a journal that does not
+ * exist and silently recovers nothing — at boot and on every rollout terminal.
+ * The older `dirname(configPath)` journal scheme degraded to "same directory,
+ * wrong name"; digest keying degrades to "invisible".
+ *
+ * Order:
+ *   1. an explicit `opts.configPath` (tests, and any future embedder);
+ *   2. `$SWITCHROOM_CONFIG` — what `hostd install` exports into the container
+ *      and what the child's `findConfigFile` consults first;
+ *   3. `findConfigFile()` — cwd / `~/.switchroom`, same as the child;
+ *   4. {@link HOSTD_FALLBACK_CONFIG_PATH}, only when 2 and 3 both come up
+ *      empty (a hostd whose config has been deleted out from under it —
+ *      `findConfigFile` THROWS there, and a throw out of a boot path or a
+ *      rollout `.finally()` would be worse than a wrong-but-conventional
+ *      guess).
+ */
+export function resolveHostdConfigPath(explicit?: string): string {
+  if (explicit) return explicit;
+  const env = process.env.SWITCHROOM_CONFIG;
+  if (env && env.trim().length > 0) return resolve(env.trim());
+  try {
+    return findConfigFile();
+  } catch {
+    return HOSTD_FALLBACK_CONFIG_PATH;
+  }
+}
+
 export class HostdServer {
   // One Server per bound socket path. `node:net.Server.listen` can
   // only be called once per instance — to bind N agent sockets we
@@ -790,11 +840,13 @@ export class HostdServer {
   constructor(private opts: ServerOptions) {}
 
   /**
-   * The live `switchroom.yaml` this daemon reads/writes. Mirrors the default
-   * pinned by the config-edit wire schema.
+   * The live `switchroom.yaml` this daemon reads/writes.
+   *
+   * See {@link resolveHostdConfigPath} for why this is NOT a hardcoded
+   * container path.
    */
   private hostdConfigPath(): string {
-    return this.opts.configPath ?? "/state/config/switchroom.yaml";
+    return resolveHostdConfigPath(this.opts.configPath);
   }
 
   /**
@@ -818,7 +870,15 @@ export class HostdServer {
    * success, revert on a clean failure), so this is purely the crash net:
    * SIGKILL / OOM / hostd recreate between the pin write and the terminal.
    * It is a no-op when no journal exists, which is why it's safe to call
-   * unconditionally at boot and on every rollout terminal.
+   * unconditionally at boot.
+   *
+   * NOT safe on every rollout terminal: a roll can succeed and still leave a
+   * journal behind when the child's own commit-unlink fails, and reverting
+   * THERE would roll back a proven pin. The terminal handler therefore routes
+   * a structurally-successful roll to {@link clearProvenRolloutPinJournal}
+   * instead. At BOOT there is no sentinel to consult, so the stale gate
+   * (writer dead / journal aged out) is all we have — which is why a journal
+   * that survives a successful commit must be reported loudly.
    *
    * Never throws — a stranded lock or a failed boot would be worse than the
    * stale pin it's fixing, so failures are reported and swallowed.
@@ -829,6 +889,38 @@ export class HostdServer {
       note = recoverPinJournal(this.hostdConfigPath());
     } catch (e) {
       note = `rollout pin journal recovery threw: ${(e as Error).message}`;
+    }
+    if (note) process.stderr.write(`hostd (${context}): ${note}\n`);
+    return note;
+  }
+
+  /**
+   * The PROVEN-roll counterpart of {@link recoverRolloutPinJournal}: delete a
+   * journal that outlived a roll the child structurally reported as `ok:true`.
+   *
+   * The child already tried this (`commitPin`) and surfaced its failure in the
+   * roll's warnings; this is the second attempt, from a different process,
+   * after the child's file handles are gone. It must NEVER revert: the pin it
+   * would revert is the one the roll just proved. A journal we cannot clear is
+   * reported so the operator can delete it host-side — while it exists, hostd's
+   * BOOT recovery (which has no sentinel to consult) will eventually revert
+   * that proven pin.
+   *
+   * Never throws — same contract as the recovery path it replaces.
+   */
+  private clearProvenRolloutPinJournal(context: string): string | null {
+    let note: string | null = null;
+    try {
+      const configPath = this.hostdConfigPath();
+      if (!hasPinJournal(configPath)) return null;
+      const err = commitPinPersist(configPath);
+      note =
+        err ??
+        `rollout pin journal: cleared a journal that outlived a SUCCESSFUL ` +
+          `roll (the child's own commit did not remove it). release.pin is ` +
+          `correct and was NOT reverted.`;
+    } catch (e) {
+      note = `rollout pin journal: clearing a proven roll's journal threw: ${(e as Error).message}`;
     }
     if (note) process.stderr.write(`hostd (${context}): ${note}\n`);
     return note;
@@ -3983,6 +4075,13 @@ export class HostdServer {
       const phase = parseRolloutPhaseLine(line);
       if (phase) this.onRolloutPhase(entry, phase);
     };
+    // Set ONLY when the child emitted a structured sentinel saying the roll
+    // completed. `entry.result === "completed"` is NOT the same test: the
+    // no-sentinel branch below infers "completed" from a zero exit code, which
+    // is exactly the case where we cannot tell a proven roll from a child that
+    // died quietly. See the `.finally()` below for why the distinction decides
+    // whether a surviving journal is DELETED or ACTED ON.
+    let sentinelProvenOk = false;
     this.runSwitchroom(args, { SWITCHROOM_HOSTD_CONTEXT: "1" }, onLine)
       .then((res) => {
         entry.exit_code = res.exit_code;
@@ -4005,6 +4104,7 @@ export class HostdServer {
           if (parsed.timedOut) entry.timed_out = true;
           // Structured `ok` is the authority; exit code corroborates.
           entry.result = parsed.ok ? "completed" : "error";
+          sentinelProvenOk = parsed.ok === true;
         } else {
           // No sentinel — the child died before finishing (e.g. SIGKILL).
           // Fall back to the exit code; structured fields stay unset so a
@@ -4027,17 +4127,32 @@ export class HostdServer {
         delete entry.prior_pin;
       })
       .finally(() => {
-        // Crash net for the durable pin. The rollout child commits its own
-        // provisional `release.pin` on success and reverts it on a clean
-        // failure, so a journal surviving to the TERMINAL means the child
-        // died in between (SIGKILL / OOM — the `result: "error"` rows with no
-        // sentinel). Reverting here, before the lock is released and before
-        // any other mutation can run, stops the next reconcile from
-        // converging the fleet onto a pin that was never proven. No-op in the
-        // normal case.
-        const pinNote = this.recoverRolloutPinJournal(
-          `rollout terminal ${entry.request_id}`,
-        );
+        // Crash net for the durable pin, GATED ON THE OUTCOME.
+        //
+        // The rollout child commits its own provisional `release.pin` on
+        // success and reverts it on a clean failure, so a journal surviving to
+        // the TERMINAL usually means the child died in between (SIGKILL / OOM).
+        // "Usually" is not "always", and the exception is the dangerous one:
+        // `commitPinPersist` can FAIL to unlink the journal (EIO, a read-only
+        // state dir, or a directory sitting at the journal path) on a roll that
+        // otherwise SUCCEEDED. The child returns ok:true with a warning and
+        // exits 0. Running recovery on that journal — with the child now dead,
+        // so `isJournalWriterAlive` is false — would revert a PROVEN pin to
+        // priorPin while telling the operator the roll succeeded, and every
+        // later reconcile would drag the fleet back to the prior version.
+        //
+        // So: a sentinel that says ok:true means the pin is proven. The
+        // surviving journal is then debris to DELETE, never input to act on.
+        // Everything else (ok:false, no sentinel at all, a rejected promise)
+        // goes through the stale-gated revert. Both run before the lock is
+        // released and before any other mutation can start.
+        const pinNote = sentinelProvenOk
+          ? this.clearProvenRolloutPinJournal(
+              `rollout terminal ${entry.request_id}`,
+            )
+          : this.recoverRolloutPinJournal(
+              `rollout terminal ${entry.request_id}`,
+            );
         if (pinNote) entry.stderr_tail = `${entry.stderr_tail ?? ""}\n${pinNote}`.trim();
         void this.writeTerminalAudit(entry);
         // KEN-131 — unattended (auto-update) roll that FAILED: no operator

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -946,6 +946,13 @@ export class HostdServer {
       const at = journal ? Date.parse(journal.at) : Number.NaN;
       // An unreadable/malformed journal (readPinJournal returns null) or an
       // unparseable timestamp cannot be attributed either — same verdict.
+      //
+      // `<` vs `<=` is a genuine 1 ms tie (a journal stamped in the same
+      // millisecond the child was spawned) and is deliberately left untested:
+      // the two verdicts differ only for that single millisecond, both are
+      // defensible there, and the safe one is reachable either way. Don't read
+      // a surviving `<=` mutant here as a coverage gap — the discriminating
+      // input shape does not exist in production.
       if (!Number.isFinite(at) || at < startedAt) {
         note =
           `rollout pin journal: LEFT IN PLACE a journal this roll did not ` +

--- a/src/vault/flock.ts
+++ b/src/vault/flock.ts
@@ -191,7 +191,19 @@ export function parseProcStartTimeMs(
   return Math.floor(startEpochMs);
 }
 
-function pidStartTimeMs(pid: number): number | null {
+/**
+ * Wall-clock ms at which the process at `pid` started, or null when it cannot
+ * be determined (non-Linux, no such pid, unparseable /proc).
+ *
+ * Exported because it is the repo's ONE correct answer to "is the process at
+ * this pid still the process I recorded?" — `kill(pid, 0)` alone cannot tell a
+ * surviving holder from an unrelated process that inherited the pid. Also used
+ * by the rollout pin journal (`src/cli/rollout-pin-journal.ts`), where the pid
+ * is recorded inside a container: PID namespaces restart at 1, so after a
+ * container recreate the recorded pid is very likely occupied by an unrelated
+ * live process and a bare liveness probe answers "alive" essentially always.
+ */
+export function pidStartTimeMs(pid: number): number | null {
   if (process.platform !== "linux") return null;
   try {
     const statLine = readFileSync(`/proc/${pid}/stat`, "utf8");

--- a/tests/host-control/rollout-pin-terminal.test.ts
+++ b/tests/host-control/rollout-pin-terminal.test.ts
@@ -48,6 +48,26 @@ const TARGET = "v2.0.0";
  */
 const DEAD_PID = 0x3fffffff;
 
+/**
+ * How long before "now" this roll's child was spawned, in the fixture.
+ *
+ * Load-bearing, not decoration. The terminal attributes a journal by comparing
+ * its `at` against `entry.started_at`, and the production shape is
+ * `started_at < at < now`: no child can write a journal AFTER the terminal
+ * that reads it has run. If the fixture stamped `started_at` at `Date.now()`,
+ * {@link afterStart} would have to put `at` in the FUTURE — on the far side of
+ * BOTH candidate discriminators — and the delete-path test could no longer
+ * tell `entry.started_at` from `Date.now()` at the
+ * `clearProvenRolloutPinJournal` call site: swap the argument there and the
+ * suite would stay green with the regression fully live. Backdating the roll
+ * puts `afterStart` strictly between the two, which is the only positioning
+ * that discriminates.
+ */
+const ROLL_STARTED_AGO_MS = 60_000;
+
+/** Where {@link afterStart} sits in that window: after the start, before now. */
+const JOURNAL_WRITTEN_AGO_MS = 30_000;
+
 function config(pin: string): string {
   return `telegram:\n  bot_token: x\nrelease:\n  pin: ${pin}\nagents:\n  clerk:\n    extends: default\n`;
 }
@@ -102,7 +122,10 @@ function makeServer(child: { stdout: string; exit_code: number }): Harness {
     verb: "rollout",
     caller: { kind: "agent", name: "overlord" },
     result: "started",
-    started_at: Date.now(),
+    // Backdated on purpose — see ROLL_STARTED_AGO_MS. The terminal adjudicates
+    // within milliseconds of this call, so a `Date.now()` stamp here would
+    // collapse the `started_at` / `now` window that attribution is tested on.
+    started_at: Date.now() - ROLL_STARTED_AGO_MS,
     pin: TARGET,
     prior_pin: PRIOR_PIN,
   };
@@ -124,9 +147,12 @@ const started: Array<{ stop(): Promise<void> }> = [];
  * Plant the journal a dead child left behind: pin written, never committed.
  *
  * `at` is an EXPLICIT parameter because it is the attribution discriminator
- * the terminal uses. A journal written AFTER this roll started is this roll's
- * own child's — its `commitPin` failed to unlink it, so the terminal may clear
- * it. A journal written BEFORE is a PREDECESSOR's orphan: this roll's child
+ * the terminal uses. A journal written BETWEEN this roll's start and now is
+ * this roll's own child's — its `commitPin` failed to unlink it, so the
+ * terminal may clear it. (Both bounds matter: the child cannot have written it
+ * before the child existed, and it cannot have written it after the terminal
+ * reading it ran.) A journal written BEFORE the start is a PREDECESSOR's
+ * orphan: this roll's child
  * journalled nothing (production `persistPin` no-ops when the config already
  * names the target), and clearing it destroys the only record that
  * `release.pin` names a build this roll never proved for the agents it did not
@@ -147,9 +173,21 @@ function plantOrphanJournal(configPath: string, at: Date): void {
   );
 }
 
-/** A journal timestamp that unambiguously belongs to THIS roll's child. */
+/**
+ * A journal timestamp that unambiguously belongs to THIS roll's child: strictly
+ * after `started_at` AND strictly before now, which is the only window a real
+ * child could have written in. See {@link ROLL_STARTED_AGO_MS} for why landing
+ * inside the window (rather than past its far edge) is what makes the
+ * delete-path test discriminate.
+ */
 function afterStart(h: Harness): Date {
-  return new Date((h.entry.started_at as number) + 1_000);
+  const at = new Date(
+    (h.entry.started_at as number) + (ROLL_STARTED_AGO_MS - JOURNAL_WRITTEN_AGO_MS),
+  );
+  // Guard the fixture itself: the production shape is started_at < at < now.
+  expect(at.getTime()).toBeGreaterThan(h.entry.started_at as number);
+  expect(at.getTime()).toBeLessThan(Date.now());
+  return at;
 }
 
 /** A journal timestamp that unambiguously predates this roll. */
@@ -204,10 +242,15 @@ describe("rollout terminal — a PROVEN pin is never reverted", () => {
     // …and the debris is gone, so hostd's next BOOT recovery — which has no
     // sentinel to consult and only the stale gate — can't revert it later.
     // Deleting is correct HERE, and only here, because the journal is
-    // attributable to this roll: `afterStart` puts its `at` past the roll's
-    // `started_at`, which is the production shape (this roll's own child wrote
-    // it and then failed to unlink it). The sibling test below pins the
-    // opposite verdict for a journal that predates the roll.
+    // attributable to this roll: `afterStart` puts its `at` INSIDE the roll's
+    // own window — after `started_at`, before the terminal that is reading it
+    // — which is the production shape (this roll's own child wrote it and then
+    // failed to unlink it). That positioning is what makes this assertion
+    // discriminating rather than decorative: `at` is on the near side of both
+    // `started_at` and `now`, so passing `Date.now()` instead of
+    // `entry.started_at` at the call site flips this journal to LEFT IN PLACE
+    // and fails the expectation below. The sibling test pins the opposite
+    // verdict for a journal that predates the roll.
     expect(h.journalExists()).toBe(false);
     expect(h.entry.result).toBe("completed");
     expect(String(h.entry.stderr_tail ?? "")).toMatch(/outlived a SUCCESSFUL roll/);

--- a/tests/host-control/rollout-pin-terminal.test.ts
+++ b/tests/host-control/rollout-pin-terminal.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -59,6 +59,8 @@ interface Harness {
   pin: () => string | undefined;
   journalExists: () => boolean;
   spawnRollout: (args: string[]) => void;
+  /** Run hostd's real boot path (registered for teardown). */
+  start: () => Promise<void>;
 }
 
 /**
@@ -85,6 +87,7 @@ function makeServer(child: { stdout: string; exit_code: number }): Harness {
       },
     },
   } as unknown as ServerOptions);
+  started.push(server);
   const s = server as unknown as {
     runSwitchroom: (
       args: string[],
@@ -110,11 +113,26 @@ function makeServer(child: { stdout: string; exit_code: number }): Harness {
     pin: () => getReleasePinFromConfig(readFileSync(configPath, "utf8")),
     journalExists: () => existsSync(pinJournalPath(configPath)),
     spawnRollout: (args) => s.spawnRollout(args, entry),
+    start: () => server.start(),
   };
 }
 
-/** Plant the journal a dead child left behind: pin written, never committed. */
-function plantOrphanJournal(configPath: string): void {
+/** Every server built in this file, stopped in afterEach. */
+const started: Array<{ stop(): Promise<void> }> = [];
+
+/**
+ * Plant the journal a dead child left behind: pin written, never committed.
+ *
+ * `at` is an EXPLICIT parameter because it is the attribution discriminator
+ * the terminal uses. A journal written AFTER this roll started is this roll's
+ * own child's — its `commitPin` failed to unlink it, so the terminal may clear
+ * it. A journal written BEFORE is a PREDECESSOR's orphan: this roll's child
+ * journalled nothing (production `persistPin` no-ops when the config already
+ * names the target), and clearing it destroys the only record that
+ * `release.pin` names a build this roll never proved for the agents it did not
+ * touch.
+ */
+function plantOrphanJournal(configPath: string, at: Date): void {
   writeFileSync(
     pinJournalPath(configPath),
     JSON.stringify({
@@ -123,10 +141,20 @@ function plantOrphanJournal(configPath: string): void {
       pin: TARGET,
       priorPin: PRIOR_PIN,
       pid: DEAD_PID,
-      at: new Date().toISOString(),
+      at: at.toISOString(),
     }),
     "utf8",
   );
+}
+
+/** A journal timestamp that unambiguously belongs to THIS roll's child. */
+function afterStart(h: Harness): Date {
+  return new Date((h.entry.started_at as number) + 1_000);
+}
+
+/** A journal timestamp that unambiguously predates this roll. */
+function beforeStart(h: Harness): Date {
+  return new Date((h.entry.started_at as number) - 60_000);
 }
 
 beforeEach(() => {
@@ -140,8 +168,11 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
+afterEach(async () => {
   delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+  // Only servers that actually bound sockets need stopping; stop() is a no-op
+  // otherwise. Draining here keeps a boot test from leaking listeners.
+  while (started.length) await started.pop()!.stop().catch(() => undefined);
 });
 
 describe("rollout terminal — a PROVEN pin is never reverted", () => {
@@ -161,7 +192,7 @@ describe("rollout terminal — a PROVEN pin is never reverted", () => {
           warnings: ["rollout pin journal: FAILED to clear …"],
         }) + "\n",
     });
-    plantOrphanJournal(h.configPath);
+    plantOrphanJournal(h.configPath, afterStart(h));
 
     h.spawnRollout(["rollout", "--pin", TARGET]);
     await vi.waitFor(() => expect(h.posted.length).toBeGreaterThan(0));
@@ -172,9 +203,71 @@ describe("rollout terminal — a PROVEN pin is never reverted", () => {
     expect(h.pin()).toBe(TARGET);
     // …and the debris is gone, so hostd's next BOOT recovery — which has no
     // sentinel to consult and only the stale gate — can't revert it later.
+    // Deleting is correct HERE, and only here, because the journal is
+    // attributable to this roll: `afterStart` puts its `at` past the roll's
+    // `started_at`, which is the production shape (this roll's own child wrote
+    // it and then failed to unlink it). The sibling test below pins the
+    // opposite verdict for a journal that predates the roll.
     expect(h.journalExists()).toBe(false);
     expect(h.entry.result).toBe("completed");
     expect(String(h.entry.stderr_tail ?? "")).toMatch(/outlived a SUCCESSFUL roll/);
+  });
+
+  it("LEAVES a predecessor's orphan journal alone on a successful roll", async () => {
+    // The undiscriminated delete: `hasPinJournal` → `commitPinPersist` with no
+    // check that the journal belongs to this roll. A journal is NOT proof this
+    // roll wrote one — the child journals only when it actually writes the pin
+    // and no-ops when the config already names the target, which is precisely
+    // the state a repeat/subset roll of an already-pinned version is in.
+    //
+    // hostd always passes `--pin` and may pass `--agents`, so this is the
+    // subset roll: three of twelve agents proved, and the orphan journal is
+    // the only record that `release.pin` names a build still unproven for the
+    // other nine. Deleting it makes that permanently undetectable — the exact
+    // damage the guard exists to prevent, arrived at from the other side.
+    const h = makeServer({
+      exit_code: 0,
+      stdout:
+        encodeRolloutResultLine({
+          ok: true,
+          rolled: ["test-harness"],
+          warnings: [],
+        }) + "\n",
+    });
+    plantOrphanJournal(h.configPath, beforeStart(h));
+
+    h.spawnRollout(["rollout", "--pin", TARGET, "--agents", "test-harness"]);
+    await vi.waitFor(() => expect(h.posted.length).toBeGreaterThan(0));
+
+    // Never reverted — this roll succeeded, so the pin stands…
+    expect(h.pin()).toBe(TARGET);
+    // …but the evidence survives, and the operator is TOLD, through the same
+    // structured surface the clear-path uses.
+    expect(h.journalExists()).toBe(true);
+    expect(h.entry.result).toBe("completed");
+    expect(String(h.entry.stderr_tail ?? "")).toMatch(/LEFT IN PLACE/);
+    expect(String(h.entry.stderr_tail ?? "")).not.toMatch(/outlived a SUCCESSFUL roll/);
+  });
+
+  it("LEAVES an UNREADABLE journal alone on a successful roll", async () => {
+    // Attribution needs a parseable `at`. A journal that is corrupt (or whose
+    // timestamp is garbage) cannot be attributed to this roll either, and the
+    // safe verdict for "cannot attribute" must be LEAVE — deleting would turn
+    // a loud, recoverable corruption into silence.
+    const h = makeServer({
+      exit_code: 0,
+      stdout:
+        encodeRolloutResultLine({ ok: true, rolled: ["test-harness"], warnings: [] }) +
+        "\n",
+    });
+    writeFileSync(pinJournalPath(h.configPath), "{ not json", "utf8");
+
+    h.spawnRollout(["rollout", "--pin", TARGET]);
+    await vi.waitFor(() => expect(h.posted.length).toBeGreaterThan(0));
+
+    expect(h.pin()).toBe(TARGET);
+    expect(h.journalExists()).toBe(true);
+    expect(String(h.entry.stderr_tail ?? "")).toMatch(/LEFT IN PLACE/);
   });
 
   it("still REVERTS when the roll structurally failed", async () => {
@@ -190,7 +283,7 @@ describe("rollout terminal — a PROVEN pin is never reverted", () => {
           warnings: [],
         }) + "\n",
     });
-    plantOrphanJournal(h.configPath);
+    plantOrphanJournal(h.configPath, afterStart(h));
 
     h.spawnRollout(["rollout", "--pin", TARGET]);
     await vi.waitFor(() => expect(h.posted.length).toBeGreaterThan(0));
@@ -205,12 +298,33 @@ describe("rollout terminal — a PROVEN pin is never reverted", () => {
     // keyed on the SENTINEL, not on `entry.result`. Nothing proved this roll,
     // so the uncommitted pin must not stand.
     const h = makeServer({ exit_code: 0, stdout: "no sentinel here\n" });
-    plantOrphanJournal(h.configPath);
+    plantOrphanJournal(h.configPath, afterStart(h));
 
     h.spawnRollout(["rollout", "--pin", TARGET]);
     await vi.waitFor(() => expect(h.posted.length).toBeGreaterThan(0));
 
     expect(h.entry.result).toBe("completed");
+    expect(h.pin()).toBe(PRIOR_PIN);
+    expect(h.journalExists()).toBe(false);
+  });
+
+  it("recovers a stale journal at BOOT — the call site, not just the helper", async () => {
+    // `recoverPinJournal` itself is well covered in
+    // `src/cli/rollout-pin-journal.test.ts`, but nothing exercised hostd's
+    // BOOT call site: delete `this.recoverRolloutPinJournal("boot")` from
+    // `start()` and the whole scoped suite stayed green. That call is the
+    // crash net's only trigger after a SIGKILL/OOM/recreate killed the child
+    // between the provisional pin write and its commit — with it gone, the
+    // unproven pin stands and every later reconcile converges the fleet onto
+    // a build that never booted.
+    const h = makeServer({ exit_code: 0, stdout: "" });
+    // Aged well past PIN_JOURNAL_MAX_AGE_MS and owned by a dead pid, so the
+    // stale gate (which correctly protects a LIVE roll) opens.
+    plantOrphanJournal(h.configPath, new Date(Date.now() - 60 * 60 * 1000));
+    expect(h.pin()).toBe(TARGET);
+
+    await h.start();
+
     expect(h.pin()).toBe(PRIOR_PIN);
     expect(h.journalExists()).toBe(false);
   });
@@ -239,9 +353,88 @@ describe("rollout terminal — a PROVEN pin is never reverted", () => {
 
 describe("resolveHostdConfigPath — hostd and its rollout child must agree", () => {
   const saved = process.env.SWITCHROOM_CONFIG;
+  const savedHome = process.env.HOME;
   afterEach(() => {
     if (saved === undefined) delete process.env.SWITCHROOM_CONFIG;
     else process.env.SWITCHROOM_CONFIG = saved;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+  });
+
+  /**
+   * The PRODUCTION wiring, not the helper.
+   *
+   * `main.ts` constructs `HostdServer` with **no** `configPath`, so every
+   * recovery site inside the daemon reaches the resolver through the private
+   * `hostdConfigPath()`. Testing the exported helper alone leaves that wire
+   * unpinned: restore the pre-fix body
+   * `return this.opts.configPath ?? "/state/config/switchroom.yaml";` and a
+   * helper-only suite stays green with the defect fully back.
+   */
+  function serverConfigPath(configPath?: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "hostd-wiring-"));
+    const server = new HostdServer({
+      homeDir: dir,
+      ...(configPath ? { configPath } : {}),
+      agentUids: {},
+      config: { agents: { "test-harness": {} } },
+      auditLogPath: join(dir, "audit.log"),
+      selfVersion: "v99.0.0",
+      allowNonLinux: true,
+    } as unknown as ServerOptions);
+    return (
+      server as unknown as { hostdConfigPath(): string }
+    ).hostdConfigPath();
+  }
+
+  it("routes a HostdServer with NO configPath through the resolver", () => {
+    // Constructed the way production constructs it (`src/cli/main.ts` — no
+    // `configPath`), which is the only shape where arms 2+ are reachable. The
+    // whole rest of this suite passes an explicit path, so without this the
+    // hardcoded container literal is restorable with a green suite.
+    const dir = mkdtempSync(join(tmpdir(), "hostd-configpath-env-"));
+    const cfg = join(dir, "switchroom.yaml");
+    writeFileSync(cfg, config(PRIOR_PIN), "utf8");
+    process.env.SWITCHROOM_CONFIG = cfg;
+
+    expect(serverConfigPath()).toBe(cfg);
+    expect(serverConfigPath()).toBe(findConfigFile());
+    expect(serverConfigPath()).not.toBe(HOSTD_FALLBACK_CONFIG_PATH);
+    // …and an explicit path still wins, so the arm order survives too.
+    expect(serverConfigPath("/explicit/switchroom.yaml")).toBe(
+      "/explicit/switchroom.yaml",
+    );
+  });
+
+  it("DELEGATES to findConfigFile rather than reading $SWITCHROOM_CONFIG itself", () => {
+    // The divergence a re-derived env arm reintroduces. `findConfigFile` takes
+    // `$SWITCHROOM_CONFIG` only `if (existsSync(envPath))` and otherwise falls
+    // through to cwd / `~/.switchroom`. An arm that returns `resolve(env)`
+    // unconditionally — one arm ahead of `findConfigFile`, which is what this
+    // function used to do — hands back a dangling path while the child
+    // resolves a real file. The two hash to different journal names and the
+    // recovery goes silently blind, which is the exact failure mode the
+    // docstring's "MUST agree, string-for-string" claim asserts cannot happen.
+    const home = mkdtempSync(join(tmpdir(), "hostd-configpath-home-"));
+    mkdirSync(join(home, ".switchroom"));
+    const real = join(home, ".switchroom", "switchroom.yaml");
+    writeFileSync(real, config(PRIOR_PIN), "utf8");
+    process.env.HOME = home;
+    const dangling = join(
+      mkdtempSync(join(tmpdir(), "hostd-configpath-gone-")),
+      "nope",
+      "switchroom.yaml",
+    );
+    expect(existsSync(dangling)).toBe(false);
+    process.env.SWITCHROOM_CONFIG = dangling;
+    // Guard the fixture: nothing in cwd may shadow the home config, or this
+    // would pass for the wrong reason.
+    expect(existsSync(join(process.cwd(), "switchroom.yaml"))).toBe(false);
+
+    expect(findConfigFile()).toBe(real);
+    expect(serverConfigPath()).toBe(real);
+    expect(serverConfigPath()).not.toBe(dangling);
+    expect(pinJournalPath(serverConfigPath())).toBe(pinJournalPath(findConfigFile()));
   });
 
   it("computes the SAME journal path the rollout child does", () => {

--- a/tests/host-control/rollout-pin-terminal.test.ts
+++ b/tests/host-control/rollout-pin-terminal.test.ts
@@ -1,0 +1,289 @@
+/**
+ * hostd's rollout TERMINAL handler vs. the durable pin journal.
+ *
+ * The terminal handler runs a pin-journal recovery pass on every roll that
+ * finishes. Recovery REVERTS `release.pin` to the journal's `priorPin` — which
+ * is right for a child that died mid-roll and catastrophic for a child that
+ * SUCCEEDED and merely failed to unlink its journal afterwards (`commitPin`
+ * returns that error rather than throwing, so the roll still reports ok:true
+ * and exits 0).
+ *
+ * These assert the OUTCOME on a real config file: after the terminal, what does
+ * `release.pin` say, and is the journal still there? A test that only checked
+ * "recovery was called" would pass on the bug.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const loadConfigMock = vi.fn();
+vi.mock("../../src/config/loader.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/config/loader.js")
+  >("../../src/config/loader.js");
+  return {
+    ...actual,
+    loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+  };
+});
+
+const { HostdServer, resolveHostdConfigPath, HOSTD_FALLBACK_CONFIG_PATH } =
+  await import("../../src/host-control/server.js");
+import type { ServerOptions } from "../../src/host-control/server.js";
+import { encodeRolloutResultLine } from "../../src/cli/rollout.js";
+import { pinJournalPath } from "../../src/cli/rollout-pin-journal.js";
+import { findConfigFile } from "../../src/config/loader.js";
+import { getReleasePinFromConfig } from "../../src/cli/release-yaml.js";
+import type { RolloutTerminalNotice } from "../../src/host-control/rollout-relay.js";
+
+const PRIOR_PIN = "v1.0.0";
+const TARGET = "v2.0.0";
+
+/**
+ * A pid that cannot be alive, so the journal reads as ABANDONED and the
+ * stale gate does NOT protect us. That is the production shape at a terminal:
+ * the child that wrote the journal has exited.
+ */
+const DEAD_PID = 0x3fffffff;
+
+function config(pin: string): string {
+  return `telegram:\n  bot_token: x\nrelease:\n  pin: ${pin}\nagents:\n  clerk:\n    extends: default\n`;
+}
+
+interface Harness {
+  configPath: string;
+  posted: RolloutTerminalNotice[];
+  entry: Record<string, unknown>;
+  pin: () => string | undefined;
+  journalExists: () => boolean;
+  spawnRollout: (args: string[]) => void;
+}
+
+/**
+ * A server whose config is a tmpdir file and whose rollout child is stubbed to
+ * return `stdout` verbatim — the sentinel line is what the terminal handler
+ * parses, so that string IS the roll's outcome.
+ */
+function makeServer(child: { stdout: string; exit_code: number }): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pin-terminal-"));
+  const configPath = join(dir, "switchroom.yaml");
+  writeFileSync(configPath, config(TARGET), "utf8"); // the provisional write already landed
+  const posted: RolloutTerminalNotice[] = [];
+  const server = new HostdServer({
+    homeDir: dir,
+    configPath,
+    agentUids: {},
+    config: { agents: { "test-harness": {}, overlord: { admin: true } } },
+    auditLogPath: join(dir, "audit.log"),
+    selfVersion: "v99.0.0",
+    allowNonLinux: true,
+    rolloutRelay: {
+      postTerminal: (n) => {
+        posted.push(n);
+      },
+    },
+  } as unknown as ServerOptions);
+  const s = server as unknown as {
+    runSwitchroom: (
+      args: string[],
+      env?: Record<string, string>,
+      onLine?: (l: string) => void,
+    ) => Promise<{ exit_code: number; stdout: string; stderr: string }>;
+    spawnRollout: (args: string[], entry: Record<string, unknown>) => void;
+  };
+  s.runSwitchroom = async () => ({ ...child, stderr: "" });
+  const entry: Record<string, unknown> = {
+    request_id: "req-pin-terminal",
+    verb: "rollout",
+    caller: { kind: "agent", name: "overlord" },
+    result: "started",
+    started_at: Date.now(),
+    pin: TARGET,
+    prior_pin: PRIOR_PIN,
+  };
+  return {
+    configPath,
+    posted,
+    entry,
+    pin: () => getReleasePinFromConfig(readFileSync(configPath, "utf8")),
+    journalExists: () => existsSync(pinJournalPath(configPath)),
+    spawnRollout: (args) => s.spawnRollout(args, entry),
+  };
+}
+
+/** Plant the journal a dead child left behind: pin written, never committed. */
+function plantOrphanJournal(configPath: string): void {
+  writeFileSync(
+    pinJournalPath(configPath),
+    JSON.stringify({
+      v: 1,
+      configPath,
+      pin: TARGET,
+      priorPin: PRIOR_PIN,
+      pid: DEAD_PID,
+      at: new Date().toISOString(),
+    }),
+    "utf8",
+  );
+}
+
+beforeEach(() => {
+  process.env.SWITCHROOM_PIN_JOURNAL_DIR = mkdtempSync(
+    join(tmpdir(), "pin-terminal-state-"),
+  );
+  loadConfigMock.mockReset();
+  loadConfigMock.mockReturnValue({
+    agents: { "test-harness": {}, overlord: { admin: true } },
+    release: { pin: PRIOR_PIN },
+  });
+});
+
+afterEach(() => {
+  delete process.env.SWITCHROOM_PIN_JOURNAL_DIR;
+});
+
+describe("rollout terminal — a PROVEN pin is never reverted", () => {
+  it("deletes (does not act on) a journal that outlived a SUCCESSFUL roll", async () => {
+    // The production sequence: canary green, every agent rolled, the child's
+    // own `commitPinPersist` FAILED to unlink the journal (EIO / read-only
+    // state dir / a directory at the journal path — a state this repo's own
+    // suite constructs). `commitPin` RETURNS that as a warning rather than
+    // throwing, so the roll is ok:true and exits 0 with the journal still on
+    // disk. The child is now dead, so the stale gate offers no protection.
+    const h = makeServer({
+      exit_code: 0,
+      stdout:
+        encodeRolloutResultLine({
+          ok: true,
+          rolled: ["test-harness", "overlord"],
+          warnings: ["rollout pin journal: FAILED to clear …"],
+        }) + "\n",
+    });
+    plantOrphanJournal(h.configPath);
+
+    h.spawnRollout(["rollout", "--pin", TARGET]);
+    await vi.waitFor(() => expect(h.posted.length).toBeGreaterThan(0));
+
+    // THE outcome: the pin the roll PROVED survives. Reverting it here would
+    // tell the operator the roll succeeded while the durable pin named the
+    // prior version, and every later reconcile would drag the fleet back.
+    expect(h.pin()).toBe(TARGET);
+    // …and the debris is gone, so hostd's next BOOT recovery — which has no
+    // sentinel to consult and only the stale gate — can't revert it later.
+    expect(h.journalExists()).toBe(false);
+    expect(h.entry.result).toBe("completed");
+    expect(String(h.entry.stderr_tail ?? "")).toMatch(/outlived a SUCCESSFUL roll/);
+  });
+
+  it("still REVERTS when the roll structurally failed", async () => {
+    // The case the terminal recovery exists for, unchanged.
+    const h = makeServer({
+      exit_code: 1,
+      stdout:
+        encodeRolloutResultLine({
+          ok: false,
+          rolled: ["test-harness"],
+          failedStep: "restart-agent",
+          failedAgent: "overlord",
+          warnings: [],
+        }) + "\n",
+    });
+    plantOrphanJournal(h.configPath);
+
+    h.spawnRollout(["rollout", "--pin", TARGET]);
+    await vi.waitFor(() => expect(h.posted.length).toBeGreaterThan(0));
+
+    expect(h.pin()).toBe(PRIOR_PIN);
+    expect(h.journalExists()).toBe(false);
+  });
+
+  it("REVERTS when the child died with NO sentinel, even on exit 0", async () => {
+    // `entry.result` is inferred from the exit code when no sentinel was
+    // emitted, so it reads "completed" here — which is exactly why the gate is
+    // keyed on the SENTINEL, not on `entry.result`. Nothing proved this roll,
+    // so the uncommitted pin must not stand.
+    const h = makeServer({ exit_code: 0, stdout: "no sentinel here\n" });
+    plantOrphanJournal(h.configPath);
+
+    h.spawnRollout(["rollout", "--pin", TARGET]);
+    await vi.waitFor(() => expect(h.posted.length).toBeGreaterThan(0));
+
+    expect(h.entry.result).toBe("completed");
+    expect(h.pin()).toBe(PRIOR_PIN);
+    expect(h.journalExists()).toBe(false);
+  });
+
+  it("is a silent no-op on a successful roll that left NO journal", async () => {
+    // The normal case: the child committed its own pin. Nothing to clear, and
+    // nothing added to the operator-facing tail.
+    const h = makeServer({
+      exit_code: 0,
+      stdout:
+        encodeRolloutResultLine({
+          ok: true,
+          rolled: ["test-harness", "overlord"],
+          warnings: [],
+        }) + "\n",
+    });
+
+    h.spawnRollout(["rollout", "--pin", TARGET]);
+    await vi.waitFor(() => expect(h.posted.length).toBeGreaterThan(0));
+
+    expect(h.pin()).toBe(TARGET);
+    expect(h.journalExists()).toBe(false);
+    expect(String(h.entry.stderr_tail ?? "")).not.toMatch(/rollout pin journal/);
+  });
+});
+
+describe("resolveHostdConfigPath — hostd and its rollout child must agree", () => {
+  const saved = process.env.SWITCHROOM_CONFIG;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.SWITCHROOM_CONFIG;
+    else process.env.SWITCHROOM_CONFIG = saved;
+  });
+
+  it("computes the SAME journal path the rollout child does", () => {
+    // Not a cosmetic agreement. The journal FILENAME is a digest of the
+    // absolute config path, so a daemon that resolves a different string than
+    // its child looks for a journal that does not exist — at boot and at every
+    // rollout terminal — and silently recovers nothing. The old `dirname()`
+    // scheme degraded to "same directory, wrong name"; digest keying degrades
+    // to invisible.
+    //
+    // The child resolves via `getConfigPath` → `findConfigFile()` →
+    // `$SWITCHROOM_CONFIG`. A hardcoded `/state/config/switchroom.yaml` on the
+    // daemon side agrees with that only by coincidence of today's deployment.
+    const dir = mkdtempSync(join(tmpdir(), "hostd-configpath-"));
+    const cfg = join(dir, "switchroom.yaml");
+    writeFileSync(cfg, config(PRIOR_PIN), "utf8");
+    process.env.SWITCHROOM_CONFIG = cfg;
+
+    expect(resolveHostdConfigPath()).toBe(findConfigFile());
+    expect(pinJournalPath(resolveHostdConfigPath())).toBe(pinJournalPath(findConfigFile()));
+    expect(resolveHostdConfigPath()).not.toBe(HOSTD_FALLBACK_CONFIG_PATH);
+  });
+
+  it("prefers an explicit configPath over the environment", () => {
+    process.env.SWITCHROOM_CONFIG = "/somewhere/else/switchroom.yaml";
+    expect(resolveHostdConfigPath("/explicit/switchroom.yaml")).toBe(
+      "/explicit/switchroom.yaml",
+    );
+  });
+
+  it("falls back to the container path only when nothing else resolves", () => {
+    // `findConfigFile()` THROWS when it finds nothing, and a throw out of a
+    // boot path or a rollout `.finally()` would be worse than a
+    // wrong-but-conventional guess — so the literal survives as the LAST arm,
+    // never the first.
+    delete process.env.SWITCHROOM_CONFIG;
+    let expected: string;
+    try {
+      expected = findConfigFile();
+    } catch {
+      expected = HOSTD_FALLBACK_CONFIG_PATH;
+    }
+    expect(resolveHostdConfigPath()).toBe(expected);
+  });
+});


### PR DESCRIPTION
**Stacked on #3605** (`fix/rollout-subprocess-timeouts`) — review that one first; this PR's diff is only the pin-journal + compose-backup half. Rebased and rewritten after the do-not-merge review, then reworked again against the round-2 review (1 HIGH, 3 MEDIUM, 4 LOW — all fixed; see "Round-2 review, fixed" below).

## Defect 1 — the durable pin was persisted before the roll was proven

`planRollout` emits a `persist-pin` step (first on the host-shell path, just after the canary on the hostd path). Once it ran, `release.pin` was the target version **permanently**, even if the roll then failed: `executeRollout` returned `ok:false` and nothing reverted it, and hostd's `recoverFailedAutoRollout` explicitly declines past-canary failures ("Past-canary failures are NOT auto-rolled-back", `src/host-control/server.ts`). From that moment every later `agent restart`, crash-loop recreate, reconcile or `docker compose up -d` read the broken pin and converged the **remaining** agents onto a build that had demonstrably failed to boot. The fleet drifted toward broken instead of staying mixed-but-working.

**Fix** — `src/cli/rollout-pin-journal.ts` (new): a two-phase commit journalled in the durable switchroom state directory.

| phase | what happens |
|---|---|
| begin | refuse if a LIVE writer already holds this config's journal; else write `{pin, priorPin, pid, at}` to `<state-dir>/.rollout-pin-journal.<config>.<hash>.json` (0600, tmp+rename), then write the pin |
| commit | only on `ok:true` — delete the journal |
| rollback | targeted `release.pin` edit back to `priorPin` (or delete it), then clear the journal |

It is a *file* and not a try/finally because the crash case is the point: SIGKILL / OOM / hostd recreate between the write and the terminal. Three recovery sites cover it — hostd boot, hostd's rollout terminal handler, and the start of the next `switchroom rollout` (the host-shell path).

### Round-1 review blockers, fixed

1. **Targeted revert, not a whole-file restore.** The prior draft stored `priorText` (byte-exact config) and restored it wholesale. That is the mirror image of the bug it fixes, and — as the review noted — it is reachable *without any crash*: on the hostd path the pin lands right after the canary while the remaining agents take minutes, so a rollback commonly runs long after the write. Any config edit in that window (an operator adding an agent, an approved `config_propose_edit`, a vault reference change) would have been silently discarded. The journal now carries pin **values** only; `deleteReleasePinInConfig` (`src/cli/release-yaml.ts`) provides the comment-preserving targeted delete for the was-unpinned case, via the same `parseDocument` Document API (no `js-yaml`, no `stringify(obj)`). Asserted by *"does NOT discard config edits made after the provisional write"*.
2. **Liveness + freshness on the journal.** A journal on disk means "a pin write is uncommitted", NOT "the writer is dead" — which is why a hostd restart mid-roll could make boot recovery revert the pin of a **successful** roll. Recovery is stale-gated: it reverts only when the writer is gone (`isJournalWriterAlive`, see MEDIUM-2 below) **or** the journal is older than `PIN_JOURNAL_MAX_AGE_MS` — the same 15-minute cutoff `isMarkerFresh` / `SELF_BUMP_MARKER_MAX_AGE_MS` uses in `src/host-control/self-bump.ts` for the same question about the same subsystem. The rollout's OWN failure path passes `requireStale: false` — that caller *is* the writer and knows the roll is over.
3. **Atomic write; loud, not silent, on corruption.** The journal is written tmp+rename. A malformed journal now emits an explicit operator-facing warning naming the config and telling them to check `release.pin` host-side, instead of returning `null` in silence. `commitPinPersist` no longer swallows an `unlinkSync` failure — a journal that survives a successful commit is *precisely* the input that makes the next boot revert a proven pin, so it is returned as an error and surfaced. `journal.configPath` is compared on recovery and a mismatch refuses with a warning.
4. **The false boot-ordering comment.** The old comment claimed recovery ran after the self-bump resume "finishes (or fails) the pending roll first". That is false: `resumePendingSelfBumpRollout` → `launchRollout` takes the latch, calls `spawnRollout`, and **returns synchronously** while the roll runs for minutes in a child. Both the comment and the ordering are fixed: boot recovery is now skipped outright while `fleetMutationInFlight` is held, deferring to that roll's own terminal handler — with the stale gate as the second, independent guard.

### Round-2 review, fixed

**HIGH-1 — the journal died with the container it was meant to outlive.** `pinJournalPath` derived its directory from `dirname(configPath)`, under a docstring claiming it "sits beside the config (same directory, so the same mount/ownership rules apply)". That is false inside hostd: the config there is a **single-file** bind mount (`~/.switchroom/switchroom.yaml:/state/config/switchroom.yaml:rw`, hostd's generated compose), so `/state/config` the *directory* is the container's writable overlay. The child inherits `SWITCHROOM_CONFIG=/state/config/switchroom.yaml` and wrote a journal that existed nowhere on the host and died with the container — making the hostd-boot recovery site dead code on exactly the path this module is aimed at. (The same single-file mount is why `rollout.ts` already carries an in-place-rewrite fallback for EBUSY/EXDEV/EINVAL on the config.)

The journal now lives in the switchroom **state directory**, a real directory bind mount on both paths. `pinJournalDir(configPath)` resolves in three steps: `SWITCHROOM_PIN_JOURNAL_DIR` (test/operator seam) → the config's own directory when that directory *is* a `.switchroom` dir (the host-shell case; also removes the `sudo`-changes-`HOME` ambiguity, and never matches inside hostd whose config dir is `/state/config`) → `<homedir()>/.switchroom` (the hostd case — durable by construction, because `src/cli/hostd.ts` pins `HOME: /host-home` in the compose it generates and `/host-home/.switchroom` is bind-mounted from the operator's `~/.switchroom`). No hard-coded container path.

Moving both writers into one directory *creates* a hostd↔host-shell collision, so the fix carries both defences. The filename is keyed by a sha256 of the **absolute config path the writer sees** (`/state/config/…` vs `~/.switchroom/…`), and `beginPinPersist` is **exclusive**: it throws rather than open a second journal for the same config while the incumbent writer is demonstrably alive and the journal is fresh. Without both, roll A's failure would revert to roll B's `priorPin` and delete B's journal, after which B commits a no-op and reports `ok:true` while the durable pin names the wrong version.

**MEDIUM-2 — `isPidAlive` alone was systematically wrong across a container recreate.** PID namespaces are per-container and restart at 1, so after a recreate the recorded pid is very likely occupied by an unrelated live process: a bare `kill(pid, 0)` answers "alive" essentially always, precisely in the recreate case that triggers recovery. New `isJournalWriterAlive` pairs the liveness probe with the process's **start time** (`/proc/<pid>/stat` field 22 against `/proc/stat:btime`) — a process that started *after* the journal was written is not the journal's writer, whatever its pid says. It reuses `vault/flock.ts`'s existing `pidStartTimeMs` (now exported with a docstring explaining why it is the repo's one correct answer to this question) rather than duplicating the `/proc` parse. Unresolvable cases (non-Linux, unreadable `/proc`, an undateable journal) are treated conservatively as alive. Kept the pid probe rather than going freshness-only, as `isMarkerFresh` does, because freshness alone would make a crashed roll block new rolls for the full 15 minutes.

**MEDIUM-3 — dropped the "age is the backstop that guarantees eventual recovery" claim.** It was not delivered: all three recovery sites are one-shot (`server.ts` boot, `server.ts` terminal handler, `rollout.ts` start-of-run) and nothing re-checks on a timer. The docstring now says exactly that — the age check is the backstop *within* a recovery pass, for the residual cases start time cannot resolve. Scoped to honesty rather than adding a periodic hostd sweep: the MEDIUM-2 fix removes the false-alive that made the one-shot sites bite, and a timer sweep would add a new concurrency surface against live rolls.

**MEDIUM-4 — `deleteReleasePinInConfig` destroyed the `release:` block's comment header.** It dropped the empty `release: {}` husk unconditionally, and the `yaml` Document attaches a key's preceding comment block to the key node as `commentBefore` — so `doc.delete("release")` took the documentation with it. On the real host config that is a 15-line header. A commented husk is now kept; an uncommented one (the case the husk removal was written for — the roll synthesized the block, so the revert is byte-identical to the pre-roll file) is still dropped. Note the earlier justification for unconditional removal — *"`release: {}` is invalid per the schema refine"* — is **factually false**: every field in `ReleaseBlock` is optional and the refine only rejects `channel` + `pin` together, so `{}` validates. Verified empirically and pinned by a test that runs the kept husk through `RootReleaseBlock.safeParse`.

**L1 — the compose coherence gate could disable itself.** `if (expected && expected.length > 0)` silently skipped the check when the live compose was missing, empty or unparseable — exactly the state the fallback is invoked for. It is now a **refusal** with a specific, actionable reason (naming which side declared no services and pointing at `switchroom apply`), and the gate cannot disable itself.
**L2 — dropped the unused `force` bypass** rather than wiring it: `restoreComposeBackup`'s sole caller is unattended hostd recovery, so an operator-override parameter there is dead code. The operator's real override is `switchroom apply` or a manual `.bak` copy. This also left the `server.ts` call site byte-identical — no edit to `recoverFailedAutoRollout`, which belongs to #3605.
**L3 — the "every other key and its comments survive" test asserted only keys.** It now asserts the unrelated trailing comment byte-for-byte, so a comment-stripping rewrite (`yaml.stringify(obj)`, the pattern this module bans) fails it.
**L4 — a `commitPin` failure went only to the `warn` sink** while the analogous revert failure landed in `warnings`. `RolloutDeps.commitPin` now returns the error string and the executor pushes it into structured `RolloutResult.warnings`, with the operator context that the roll succeeded and the risk is a *later* recovery pass reverting a correct pin.

## Defect 2 — the compose "last known good" backup was fictional and self-destroying

`writeComposeFile` copied `<compose>.bak` on every write. But it runs on every `agent restart`, not just `apply`, and a restart regenerates the WHOLE-fleet compose — so during a staggered roll, agent 1's restart backed up the pre-roll compose and agent 2's restart immediately overwrote it with the post-bump file. By agent 3 of 12 the "backup" was byte-identical to the live compose. Meanwhile the write-side comment claimed the health-gated recreate in `src/cli/update.ts` could roll back to it; `grep -n '\.bak\|rollback\|revert' src/cli/update.ts` returns nothing. The mechanism described did not exist.

**Fix** — `shouldBackupCompose` redefines `.bak` as *the last compose generated on a different agent image tag*, which a roll's per-agent regenerations can no longer clobber; `restoreComposeBackup` is the consumer that was missing, wired as the fallback when hostd's `apply --pin <priorPin>` recovery exits non-zero.

### Round-1 review items, fixed

- **The doc no longer conflates "different tag" with "known to work".** Two concrete cases where that bites are spelled out (a second roll backing up the compose of the build that just failed; an operator's hand-edited broken compose becoming the backup on the next bump), the restore is documented as a best-effort fallback behind the authoritative `apply --pin`, and the real fix — gating the backup on a post-roll health signal — is filed rather than half-implemented.
- **Coherence gate.** `restoreComposeBackup` compares the backup's service set (`composeServiceNames`) against the live compose's and **refuses** on divergence, so a backup predating an added agent cannot silently drop that agent's service. Per L1/L2 above the gate is now un-disableable and has no `force` bypass.

## Tests

All assert outcomes on real tmpdir configs — *what does `release.pin` actually say afterwards, and what else in the file survived* — not that a function was called. Both journal suites pin `SWITCHROOM_PIN_JOURNAL_DIR` to a tmpdir, which is also what stops them leaking journal files into a real `~/.switchroom`.

```
 ✓ src/cli/rollout-pin-journal.test.ts (28 tests)
 ✓ src/cli/write-compose.test.ts (27 tests)
 ✓ src/cli/rollout.test.ts (104 tests)
 ✓ src/cli/release-yaml.test.ts (10 tests)
 ✓ src/host-control/rollout-timeout-latch.test.ts (4 tests)
 ✓ src/host-control/rollout-agent-validation.test.ts (6 tests)
 ✓ src/cli/update.test.ts (68 tests)

 Test Files  7 passed (7)
      Tests  247 passed (247)
```

**Mutation evidence** — every new/changed test was proven to fail on the defect it claims to cover, by re-introducing that defect against the final tree:

| # | mutation (the defect re-introduced) | killed |
|---|---|---|
| MUT-1 | journal path back to `dirname(configPath)` (HIGH-1) | 4 — *writes the journal into the DURABLE state dir, never beside the config*; *recovery still finds the journal after a container recreate wipes the config's directory*; *falls back to `<home>/.switchroom` when nothing overrides it*; *keys the journal by config path, so hostd and a host shell stay separate* |
| MUT-2 | collapse the filename to one shared `.rollout-pin-journal.json` | 2 — *keys the journal by config path…*; *a failing roll does NOT revert to the other roll's priorPin* |
| MUT-3 | drop `beginPinPersist`'s exclusivity throw | 1 — *REFUSES to open a second journal while the first writer is alive* |
| MUT-4 | bare `isPidAlive`, no start-time discriminator (MEDIUM-2) | 2 — *reverts a journal whose pid was REUSED by a container recreate*; *isJournalWriterAlive is conservative when it cannot decide* |
| MUT-5 | delete the `release: {}` husk unconditionally (MEDIUM-4) | 3 — *KEEPS the husk rather than destroying the block's comment header*; *the kept husk is schema-VALID*; *does NOT destroy a documented `release:` block added during the roll* |
| MUT-6 | restore the self-disabling `if (expected && expected.length > 0)` gate (L1) | 3 — *REFUSES when the live compose is unreadable — the gate must not disable itself*; *REFUSES when the live compose declares no services*; *an empty caller-supplied expectation is a refusal too, not a bypass* |
| MUT-7 | swallow the `commitPin` error instead of promoting it (L4) | 1 — *surfaces a commit that could NOT clear the journal in the structured warnings* |
| MUT-8 | `yaml.stringify(doc.toJS())` — the banned comment-stripping rewrite (L3) | 4 — *rollback restores the prior pin and touches NOTHING else*; *updates an existing pin, refreshes the dated comment, preserves OTHER comments*; *creates the release block when absent, preserving everything else*; *drops a husk the roll SYNTHESIZED, restoring the file byte-for-byte* |

Comment preservation was additionally re-verified against the **real production config** (2,347 lines, 874 comment lines, pinned): `set → revert` is byte-identical (874 → 874 → 874 comment lines); `delete` on the documented block keeps all 874 comment lines with `release:` kept and `pin` gone; the was-unpinned `set → delete` round trip is byte-identical.

`npm run lint` fails in this worktree at gate 2 of 13 with a **pre-existing, environmental** error (no local `node_modules`; a sibling checkout's is borrowed and lacks the plugin-only deps `mdast-util-from-markdown`, `micromark-extension-gfm`, `mdast-util-gfm`, `mdast`, `@mtcute/node`). Verified by stashing to pristine `main` and reproducing identically. The other 12 gates were run individually and all pass:

```
tsc OK
check-bot-api-wrapping.sh OK
check-bun-test-imports OK
check-no-pii-secrets OK
check-vault-test-hermeticity OK
check-no-broadcast-delivery OK
check-stale-tool-descriptions OK
check-mcp-instructions-budget OK
check-web-subscription-honest OK
check-no-unpinned-npx-playwright OK
check-gateway-line-ratchet OK
check-litellm-config-guard OK
```

CI is the authority on the full suite.

## Deferred, explicitly

- **`.bak` still does not mean "known good."** Making it so needs a post-roll health signal to gate the backup on. Documented in `shouldBackupCompose`, not silently implied. To be precise about the exposure: both the authoritative `apply --pin <priorPin>` recovery and this `.bak` fallback run `--compose-only`, so **neither recreates containers** — a restore is a file write that takes effect at the next reconcile, not a fleet that has already moved onto an unverified compose. The risk is a stale-but-coherent compose sitting on disk awaiting that reconcile, which the service-set gate bounds but does not eliminate.
- **Concurrent rolls against the *same* config.** Closed for the case that mattered — the hostd↔host-shell pair no longer shares a journal (per-config-path keying), and `beginPinPersist` refuses while a live writer holds the journal. What remains is that hostd's fleet lock still does not cover a host-shell `switchroom rollout`, so two rolls can still *run* concurrently against the same fleet and fight over `release.pin` itself; the journal now detects and refuses the overlap rather than silently mis-reverting, but a proper fix is a cross-process lock on the config, which is its own change.
- **Backup suppression after a failed roll** — considered, not implemented: it needs the same health signal as the first item, and a half-measure keyed on exit code would suppress backups for failures unrelated to compose validity.
- **Process-group kill and SIGKILL attribution** — deferred with the timeout PR (#3605).

## Rebase touchpoint with #3605

One line inside `createRolloutDeps` changed (`commitPin` now `return err;` so the executor can surface it — L4). That function belongs to #3605's area; the change is a single `return` on an existing statement and was made only because L4 is unimplementable without it. Flagged for the rebase onto the updated base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
