### PR TITLE
fix(rollout): bound every subprocess on the rollout executor's path

### DIFF
--- a/src/cli/deploy-version-guard.ts
+++ b/src/cli/deploy-version-guard.ts
@@ -32,8 +32,31 @@ export type DockerRunner = (args: string[]) => {
   stderr: string;
 };
 
+/**
+ * Wall-clock budget for the `docker inspect` probe in {@link defaultRunner}.
+ *
+ * The docker CLI has NO client-side request timeout, so against an
+ * unresponsive dockerd an unbounded `spawnSync` blocks FOREVER. That is
+ * load-bearing on the rollout path: {@link deployedImageTag} is the
+ * `refresh-web` step's skew probe, called in-process by `executeRollout`, so
+ * a hang here strands hostd's `fleetMutationInFlight` latch — and does it
+ * AFTER every agent has already rolled. Kept in sync in spirit with
+ * `ROLLOUT_PROBE_TIMEOUT_MS` (`src/cli/rollout.ts`); a healthy daemon answers
+ * an inspect in milliseconds, and the rollout executor threads in its own
+ * bounded runner anyway (see `createRolloutDeps`). Duplicated rather than
+ * imported to keep this module free of a cycle back into rollout.ts.
+ *
+ * A timeout surfaces as a non-zero/`null` status → `ok: false` → the same
+ * "unknown tag" path an absent container already takes. Fails closed.
+ */
+export const DOCKER_INSPECT_TIMEOUT_MS = 60 * 1000;
+
 const defaultRunner: DockerRunner = (args) => {
-  const r = spawnSync("docker", args, { encoding: "utf8" });
+  const r = spawnSync("docker", args, {
+    encoding: "utf8",
+    timeout: DOCKER_INSPECT_TIMEOUT_MS,
+    killSignal: "SIGKILL",
+  });
   return { ok: r.status === 0, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 };
 

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -33,6 +33,11 @@ import {
   type RolloutPhase,
   type RolloutResult,
   type RolloutStep,
+  createRolloutDeps,
+  isSpawnTimeout,
+  ROLLOUT_RUN_TIMEOUT_MS,
+  ROLLOUT_PROBE_TIMEOUT_MS,
+  type RolloutSpawnSync,
 } from "./rollout.js";
 import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
 
@@ -1094,5 +1099,193 @@ describe("executeRollout — phase emission", () => {
       // no emitPhase
     };
     expect(() => executeRollout(steps, TARGET, deps)).not.toThrow();
+  });
+});
+
+// ── Timeouts: a wedged container must not hang the executor ──────────────
+//
+// `deps.run` (spawnSync of `switchroom <subcommand>`) and `deps.probeVersion`
+// (`docker exec … switchroom --version`) had NO timeout. A wedged container —
+// precisely the case a roll exists to fix — blocks spawnSync forever, which
+// blocks executeRollout forever, which holds hostd's `fleetMutationInFlight`
+// latch forever (cleared in a `.finally()` that never runs because the child
+// never exits). No self-clearing path short of restarting hostd.
+
+describe("createRolloutDeps — every subprocess is bounded", () => {
+  function spy(): { calls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }>; spawn: RolloutSpawnSync } {
+    const calls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
+    const spawn: RolloutSpawnSync = (cmd, args, opts) => {
+      calls.push({ cmd, args, opts: opts as unknown as Record<string, unknown> });
+      return { status: 0, stdout: "0.19.4\n" };
+    };
+    return { calls, spawn };
+  }
+
+  it("passes a positive timeout + SIGKILL to the subcommand spawn", () => {
+    const { calls, spawn } = spy();
+    const deps = createRolloutDeps({
+      configPath: "/nope/switchroom.yaml",
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      spawn,
+      warn: () => undefined,
+    });
+    deps.run(["apply"]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.opts.timeout).toBe(ROLLOUT_RUN_TIMEOUT_MS);
+    expect(ROLLOUT_RUN_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(calls[0]!.opts.killSignal).toBe("SIGKILL");
+  });
+
+  it("passes a positive timeout + SIGKILL to the docker version probe", () => {
+    const { calls, spawn } = spy();
+    const deps = createRolloutDeps({
+      configPath: "/nope/switchroom.yaml",
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      spawn,
+      warn: () => undefined,
+    });
+    expect(deps.probeVersion("clerk")).toBe("0.19.4");
+    expect(calls[0]!.cmd).toBe("docker");
+    expect(calls[0]!.opts.timeout).toBe(ROLLOUT_PROBE_TIMEOUT_MS);
+    expect(ROLLOUT_PROBE_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(calls[0]!.opts.killSignal).toBe("SIGKILL");
+  });
+
+  it("reports a timed-out subcommand as a clean non-zero failure, not a hang", () => {
+    const warns: string[] = [];
+    const deps = createRolloutDeps({
+      configPath: "/nope/switchroom.yaml",
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      // Node reports a timeout kill as status:null + the killSignal.
+      spawn: () => ({ status: null, signal: "SIGKILL" }),
+      warn: (l) => warns.push(l),
+    });
+    const r = deps.run(["agent", "restart", "clerk", "--wait", "--force"]);
+    expect(r.timedOut).toBe(true);
+    expect(r.status).not.toBe(0); // trips every caller's `status !== 0` gate
+    const warned = warns.join(" ");
+    expect(warned).toMatch(/did not finish within \d+ms and was SIGKILLed/);
+    // The warning must be honest about BOTH known imprecisions, so an
+    // operator reading it host-side knows what to check.
+    expect(warned).toMatch(/OOM killer/);
+    expect(warned).toMatch(/grandchildren are NOT killed/);
+  });
+
+  it("treats an ETIMEDOUT-flavoured timeout the same way", () => {
+    const deps = createRolloutDeps({
+      configPath: "/nope/switchroom.yaml",
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      spawn: () =>
+        ({ status: null, error: Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }) }) as ReturnType<RolloutSpawnSync>,
+      warn: () => undefined,
+    });
+    expect(deps.run(["apply"]).timedOut).toBe(true);
+  });
+
+  it("a wedged container's version probe returns null instead of blocking", () => {
+    const warns: string[] = [];
+    const deps = createRolloutDeps({
+      configPath: "/nope/switchroom.yaml",
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      spawn: () => ({ status: null, signal: "SIGKILL", stdout: "" }),
+      warn: (l) => warns.push(l),
+    });
+    expect(deps.probeVersion("clerk")).toBeNull();
+    expect(warns.join(" ")).toMatch(/wedged/);
+  });
+
+  it("isSpawnTimeout does NOT misread an ordinary non-zero exit as a timeout", () => {
+    expect(isSpawnTimeout({ status: 1, signal: null }, "SIGKILL")).toBe(false);
+    expect(isSpawnTimeout({ status: 0, signal: null }, "SIGKILL")).toBe(false);
+    // A DIFFERENT signal (e.g. an operator's SIGTERM) is not our timeout kill.
+    expect(isSpawnTimeout({ status: null, signal: "SIGTERM" }, "SIGKILL")).toBe(false);
+  });
+});
+
+describe("executeRollout — a timed-out step stops the roll cleanly", () => {
+  const TARGET = "v0.19.4";
+
+  it("returns ok:false with timedOut set (the executor never blocks)", () => {
+    // The whole point: the executor RETURNS. A returned failure is what lets
+    // hostd's `.finally()` run and release `fleetMutationInFlight` — the
+    // latch that a hung spawnSync stranded forever.
+    const { deps: base } = harness({ versions: { "test-harness": null } });
+    const deps: RolloutDeps = {
+      ...base,
+      run: (args) =>
+        args[0] === "agent" ? { status: 1, timedOut: true } : { status: 0 },
+    };
+    const steps = planRollout(["test-harness", "clerk"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(true);
+    expect(r.failedAgent).toBe("test-harness");
+    expect(r.warnings.join(" ")).toMatch(/timeout and was killed/);
+    expect(r.warnings.join(" ")).toMatch(/wedged/);
+  });
+
+  it("marks an apply timeout as timedOut and stops before any restart", () => {
+    const { deps: base } = harness({ versions: {} });
+    const deps: RolloutDeps = {
+      ...base,
+      run: (args) => (args[0] === "apply" ? { status: 1, timedOut: true } : { status: 0 }),
+    };
+    const runs: string[][] = [];
+    const r = executeRollout(planRollout(["clerk"]), TARGET, {
+      ...deps,
+      run: (args) => {
+        runs.push(args);
+        return args[0] === "apply" ? { status: 1, timedOut: true } : { status: 0 };
+      },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("apply");
+    expect(r.timedOut).toBe(true);
+    // Stopped BEFORE any restart — a timed-out apply must not roll agents.
+    expect(runs.map((a) => a[0])).toEqual(["apply"]);
+  });
+
+  it("carries timedOut across the hostd result sentinel", () => {
+    // The executor runs in a CHILD process on the hostd path; the only
+    // channel back to hostd is the stdout sentinel. If `timedOut` doesn't
+    // survive encode→parse, hostd records a bare "exit 1" and the operator
+    // never learns the step was killed mid-flight (with docker grandchildren
+    // possibly still running).
+    const { deps: base } = harness({ versions: { "test-harness": null } });
+    const deps: RolloutDeps = {
+      ...base,
+      run: (args) => (args[0] === "agent" ? { status: 1, timedOut: true } : { status: 0 }),
+    };
+    const steps = planRollout(["test-harness"], { pinToPersist: TARGET, hostdContext: true });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+
+    const round = parseRolloutResultLine(
+      "some noise\n" + encodeRolloutResultLine(r) + "\nmore noise\n",
+    );
+    expect(round?.timedOut).toBe(true);
+    expect(round?.ok).toBe(false);
+    expect(round?.failedAgent).toBe("test-harness");
+  });
+
+  it("omits timedOut from the sentinel for an ordinary (non-timeout) failure", () => {
+    const { deps: base } = harness({ versions: {} });
+    const r = executeRollout(planRollout(["clerk"]), TARGET, {
+      ...base,
+      run: (args) => (args[0] === "apply" ? { status: 1 } : { status: 0 }),
+    });
+    const round = parseRolloutResultLine(encodeRolloutResultLine(r));
+    expect(round?.ok).toBe(false);
+    // Absent, not `false` — hostd treats absence as "not a timeout".
+    expect(round?.timedOut).toBeUndefined();
   });
 });

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -1365,6 +1365,92 @@ describe("createRolloutDeps — the in-process docker probes are bounded too", (
     // Fails closed: refresh-hindsight no-ops instead of blocking forever.
     expect(deps.hindsightExists?.()).toBe(false);
   });
+
+  // LOW-3 — fail-closed parity with the probe default this runner replaces.
+  //
+  // `isHindsightContainerExists`'s module default (`defaultDockerProbe`,
+  // src/setup/hindsight.ts) wraps its `execFileSync` in try/catch, so ANY
+  // throw became a clean `false`. The injected `dockerRun` had no try/catch,
+  // so a throw would escape `executeRollout` mid-roll — AFTER every agent has
+  // already restarted. spawnSync reports failures on `r.error` rather than
+  // throwing (ENOENT included), so this is parity insurance, not a live bug.
+  it("a THROWING docker spawn still fails closed for hindsightExists", () => {
+    const deps = depsWith(() => {
+      throw new Error("spawnSync exploded");
+    });
+    expect(() => deps.hindsightExists?.()).not.toThrow();
+    expect(deps.hindsightExists?.()).toBe(false);
+  });
+
+  it("a THROWING docker spawn yields an unknown web tag rather than escaping", () => {
+    const deps = depsWith(() => {
+      throw new Error("spawnSync exploded");
+    });
+    expect(() => deps.webImageTag?.()).not.toThrow();
+    expect(deps.webImageTag?.()).toBeNull();
+  });
+});
+
+// ── LOW-2: a TIMED-OUT web/hostd refresh must say so ──────────────────────
+//
+// Both steps gate only on `r.status !== 0`, and `deps.run` reports a SIGKILLed
+// child as `status: 1`. So a timed-out `webd install` / `hostd install`
+// produced the generic non-fatal warning that tells the operator to re-run the
+// command IMMEDIATELY — while the killed CLI's `docker` grandchildren may
+// still be live and mutating the same container. That's the same
+// "grandchildren are NOT killed with it" hazard the restart-agent timeout
+// branch already surfaces; these steps must surface it too.
+describe("executeRollout — a timed-out web/hostd refresh names the timeout", () => {
+  const TARGET = "v0.19.4";
+
+  /** Deps whose `webd`/`hostd` spawns report a timeout kill. */
+  function timedOutRefreshDeps(which: "webd" | "hostd"): RolloutDeps {
+    const { deps: base } = harness({ versions: { clerk: "0.19.4" } });
+    return {
+      ...base,
+      run: (args, o) => {
+        const r = base.run(args, o);
+        return args[0] === which ? { status: 1, timedOut: true } : r;
+      },
+    };
+  }
+
+  it("refresh-web: the warning says TIMED OUT and to sweep strays BEFORE re-running", () => {
+    const deps = timedOutRefreshDeps("webd");
+    const r = executeRollout(planRollout(["clerk"]), TARGET, deps);
+    // Still non-fatal — agents already rolled.
+    expect(r.ok).toBe(true);
+    const w = r.warnings.find((x) => /web refresh/.test(x));
+    expect(w).toBeTruthy();
+    expect(w).toMatch(/TIMED OUT/);
+    expect(w).toMatch(/grandchildren are NOT killed with it/);
+    expect(w).toMatch(/BEFORE re-running/);
+    expect(w).toContain(`switchroom webd install --tag ${TARGET}`);
+  });
+
+  it("refresh-hostd: the warning says TIMED OUT and to sweep strays BEFORE re-running", () => {
+    const deps = timedOutRefreshDeps("hostd");
+    const r = executeRollout(planRollout(["clerk"]), TARGET, deps);
+    expect(r.ok).toBe(true);
+    const w = r.warnings.find((x) => /hostd refresh/.test(x));
+    expect(w).toBeTruthy();
+    expect(w).toMatch(/TIMED OUT/);
+    expect(w).toMatch(/grandchildren are NOT killed with it/);
+    expect(w).toMatch(/BEFORE re-running/);
+    expect(w).toContain(`switchroom hostd install --tag ${TARGET}`);
+  });
+
+  it("an ordinary non-zero refresh exit keeps the plain wording (shapes stay disjoint)", () => {
+    const { deps } = harness({
+      versions: { clerk: "0.19.4" },
+      runStatus: (args) => (args[0] === "webd" || args[0] === "hostd" ? 1 : 0),
+    });
+    const r = executeRollout(planRollout(["clerk"]), TARGET, deps);
+    expect(r.ok).toBe(true);
+    expect(r.warnings.join(" ")).not.toMatch(/TIMED OUT/);
+    expect(r.warnings.some((w) => /web refresh FAILED/.test(w))).toBe(true);
+    expect(r.warnings.some((w) => /hostd refresh failed \(non-fatal\)/.test(w))).toBe(true);
+  });
 });
 
 describe("createRolloutDeps — a timeout can never be reported as success", () => {

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -1289,3 +1289,184 @@ describe("executeRollout — a timed-out step stops the roll cleanly", () => {
     expect(round?.timedOut).toBeUndefined();
   });
 });
+
+// ── Review follow-ups: the subprocesses that were STILL unbounded ─────────
+//
+// `deps.run` and `deps.probeVersion` were not the only children spawned from
+// inside `executeRollout`. The `refresh-web` step calls `deployedImageTag`
+// (`spawnSync("docker", …)`) and `refresh-hindsight` calls
+// `isHindsightContainerExists` (`execFileSync("docker", …)`), both IN-PROCESS.
+// The docker CLI has no client-side request timeout, so an unresponsive
+// dockerd blocked either one forever — executeRollout never returns, hostd's
+// runSwitchroom promise never settles, and `fleetMutationInFlight` is stranded
+// permanently. Worse-shaped than the original bug: it strands the latch AFTER
+// every agent has already rolled.
+
+describe("createRolloutDeps — the in-process docker probes are bounded too", () => {
+  function depsWith(spawn: RolloutSpawnSync, warn: (l: string) => void = () => undefined) {
+    return createRolloutDeps({
+      configPath: "/nope/switchroom.yaml",
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      spawn,
+      warn,
+    });
+  }
+
+  it("webImageTag's docker inspect carries a positive timeout + SIGKILL", () => {
+    const calls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
+    const deps = depsWith((cmd, args, opts) => {
+      calls.push({ cmd, args, opts: opts as unknown as Record<string, unknown> });
+      return { status: 0, stdout: "ghcr.io/switchroom/switchroom-web:v0.19.4\n" };
+    });
+
+    expect(deps.webImageTag?.()).toBe("v0.19.4");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.cmd).toBe("docker");
+    expect(calls[0]!.args[0]).toBe("inspect");
+    // The regression this guards: `spawnSync("docker", args, {encoding})` with
+    // NO timeout key at all.
+    expect(typeof calls[0]!.opts.timeout).toBe("number");
+    expect(calls[0]!.opts.timeout as number).toBeGreaterThan(0);
+    expect(calls[0]!.opts.timeout).toBe(ROLLOUT_PROBE_TIMEOUT_MS);
+    expect(calls[0]!.opts.killSignal).toBe("SIGKILL");
+  });
+
+  it("hindsightExists' docker ps carries a positive timeout + SIGKILL", () => {
+    const calls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
+    const deps = depsWith((cmd, args, opts) => {
+      calls.push({ cmd, args, opts: opts as unknown as Record<string, unknown> });
+      return { status: 0, stdout: "switchroom-hindsight\n" };
+    });
+
+    expect(deps.hindsightExists?.()).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.cmd).toBe("docker");
+    expect(calls[0]!.args.slice(0, 2)).toEqual(["ps", "-a"]);
+    expect(typeof calls[0]!.opts.timeout).toBe("number");
+    expect(calls[0]!.opts.timeout as number).toBeGreaterThan(0);
+    expect(calls[0]!.opts.timeout).toBe(ROLLOUT_PROBE_TIMEOUT_MS);
+    expect(calls[0]!.opts.killSignal).toBe("SIGKILL");
+  });
+
+  it("a timed-out docker inspect yields an unknown tag (no throw, no hang)", () => {
+    const warns: string[] = [];
+    const deps = depsWith(() => ({ status: null, signal: "SIGKILL", stdout: "" }), (l) =>
+      warns.push(l),
+    );
+    // null == "unknown tag" — the refresh-web skew check already skips on
+    // null, so a wedged daemon degrades to "no skew assertion", not a hang.
+    expect(deps.webImageTag?.()).toBeNull();
+    expect(warns.join(" ")).toMatch(/did not answer within \d+ms and was killed/);
+  });
+
+  it("a timed-out docker ps reports hindsight as absent rather than hanging", () => {
+    const deps = depsWith(() => ({ status: null, signal: "SIGKILL", stdout: "" }));
+    // Fails closed: refresh-hindsight no-ops instead of blocking forever.
+    expect(deps.hindsightExists?.()).toBe(false);
+  });
+});
+
+describe("createRolloutDeps — a timeout can never be reported as success", () => {
+  // F5: isSpawnTimeout checks its ETIMEDOUT arm BEFORE status, so a
+  // `{status: 0, error: {code: "ETIMEDOUT"}}` shape would have returned
+  // `{status: 0, timedOut: true}` — and EVERY caller gates on
+  // `if (r.status !== 0)`, so the timeout would have been read as SUCCESS and
+  // the roll would have marched on. We could not produce that shape on node
+  // v22.23.1, but the JSDoc asserted it as an invariant the code did not
+  // enforce. Now it does.
+  it("forces a non-zero status when a zero-status result is flagged as a timeout", () => {
+    const deps = createRolloutDeps({
+      configPath: "/nope/switchroom.yaml",
+      scriptPath: "switchroom",
+      hostdCtx: false,
+      spawn: () =>
+        ({
+          status: 0,
+          error: Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }),
+        }) as ReturnType<RolloutSpawnSync>,
+      warn: () => undefined,
+    });
+    const r = deps.run(["agent", "restart", "clerk", "--wait", "--force"]);
+    expect(r.timedOut).toBe(true);
+    expect(r.status).not.toBe(0);
+    expect(r.status).toBe(1);
+  });
+});
+
+describe("executeRollout — a timed-out restart stops even when the probe PASSES", () => {
+  const TARGET = "v0.19.4";
+
+  // F2: the timeout branch used to push a warning and FALL THROUGH to the
+  // version probe. A SIGKILL reaps only the direct CLI, so its orphaned
+  // `docker compose up -d` grandchild can still bring the container up on the
+  // target tag — the probe then passes, `ok` stays true, `timedOut` is never
+  // set on the result, and the roll reports SUCCESS for an agent whose
+  // post-start reconcile + #3333 scoped ownership sweep were killed and never
+  // ran. The pre-existing timeout test could not catch this: it used
+  // `versions: { "test-harness": null }`, so the probe failed anyway and the
+  // stop was attributable to the null probe, not to the timeout.
+  function timedOutRestartDeps(probeVersionValue: string | null): {
+    deps: RolloutDeps;
+    runs: string[][];
+  } {
+    const { deps: base, runs } = harness({ versions: { "test-harness": probeVersionValue } });
+    return {
+      deps: {
+        ...base,
+        run: (args, o) => {
+          const r = base.run(args, o);
+          return args[0] === "agent" ? { status: 1, timedOut: true } : r;
+        },
+      },
+      runs,
+    };
+  }
+
+  it("returns ok:false + timedOut even though the agent reports the target version", () => {
+    const { deps, runs } = timedOutRestartDeps(TARGET);
+    const steps = planRollout(["test-harness", "clerk"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+
+    // The probe agrees the container is on the target …
+    expect(deps.probeVersion("test-harness")).toBe(TARGET);
+    // … and the roll STILL stops, flagged as a timeout.
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(true);
+    expect(r.failedStep).toBe("restart-agent");
+    expect(r.failedAgent).toBe("test-harness");
+    expect(r.got).toBe(TARGET);
+    // The second agent must never be restarted while the first roll's
+    // SIGKILLed grandchild may still be rewriting the compose file.
+    expect(runs.filter((a) => a[0] === "agent" && a[1] === "restart")).toHaveLength(1);
+    expect(r.rolled).not.toContain("test-harness");
+    // The operator is told the agent is half-applied, not rolled.
+    expect(r.warnings.join(" ")).toMatch(/timeout and was killed/);
+    expect(r.warnings.join(" ")).toMatch(/HALF-APPLIED/);
+  });
+
+  it("survives the hostd result sentinel so get_status shows the timeout", () => {
+    const { deps } = timedOutRestartDeps(TARGET);
+    const steps = planRollout(["test-harness"], { pinToPersist: TARGET, hostdContext: true });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    const round = parseRolloutResultLine(encodeRolloutResultLine(r));
+    expect(round?.ok).toBe(false);
+    expect(round?.timedOut).toBe(true);
+    expect(round?.failedAgent).toBe("test-harness");
+  });
+
+  it("does NOT flag timedOut when the restart exits on its own with a bad version", () => {
+    // The disjointness that makes `timedOut` meaningful to hostd: a plain
+    // version-assert failure must not look like a killed-mid-flight restart.
+    const { deps: base } = harness({ versions: { "test-harness": "v0.19.3" } });
+    const steps = planRollout(["test-harness"], { pinToPersist: TARGET, hostdContext: true });
+    const r = executeRollout(steps, TARGET, base, { hostdContext: true });
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("restart-agent");
+    expect(r.timedOut).toBeUndefined();
+  });
+});

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -371,9 +371,20 @@ export interface RolloutDeps {
    * ONLY the canary restart spawn — the reconcile ownership sweep runs
    * inside this spawned `switchroom agent restart` process, so an env set
    * here (and nowhere else) gates exactly one agent, never the whole fleet.
+   *
+   * `timedOut` is set when the subprocess exceeded
+   * {@link ROLLOUT_RUN_TIMEOUT_MS} and was killed. A timeout is a CLEAN,
+   * REPORTED failure — never a hang. See the timeout note on
+   * {@link createRolloutDeps}.
    */
-  run(args: string[], opts?: { env?: Record<string, string> }): { status: number };
-  /** Probe the in-container `switchroom --version` for an agent. */
+  run(args: string[], opts?: { env?: Record<string, string> }): { status: number; timedOut?: boolean };
+  /**
+   * Probe the in-container `switchroom --version` for an agent. Returns null
+   * when the agent is unreachable — INCLUDING when the probe timed out
+   * against a wedged container (the exact case a roll exists to fix). The
+   * executor treats null as a version mismatch and stops the roll, so a
+   * wedged container produces a reported failure instead of a hang.
+   */
   probeVersion(agent: string): string | null;
   /** Emit a progress line. */
   log(line: string): void;
@@ -419,6 +430,11 @@ export interface RolloutResult {
   failedStep?: string;
   failedAgent?: string;
   got?: string | null;
+  /**
+   * True when the roll stopped because a subprocess exceeded its timeout and
+   * was killed. Distinguishes "the build is bad" from "the fleet is wedged".
+   */
+  timedOut?: boolean;
   /** Non-fatal warnings (e.g. web/hostd refresh failures). */
   warnings: string[];
 }
@@ -523,6 +539,7 @@ export function encodeRolloutResultLine(result: RolloutResult): string {
       ...(result.failedStep ? { failedStep: result.failedStep } : {}),
       ...(result.failedAgent ? { failedAgent: result.failedAgent } : {}),
       ...(result.got !== undefined ? { got: result.got } : {}),
+      ...(result.timedOut ? { timedOut: true } : {}),
       warnings: result.warnings,
     })
   );
@@ -539,6 +556,7 @@ export function parseRolloutResultLine(
   failedStep?: string;
   failedAgent?: string;
   got?: string | null;
+  timedOut?: boolean;
   warnings: string[];
 } | null {
   const lines = stdout.split("\n");
@@ -637,7 +655,20 @@ export function executeRollout(
           : ["apply"];
         const r = deps.run(applyArgs);
         if (r.status !== 0) {
-          return { ok: false, rolled, failedStep: "apply", warnings };
+          if (r.timedOut) {
+            deps.log(`  ✗ apply TIMED OUT after ${ROLLOUT_RUN_TIMEOUT_MS}ms — STOPPING`);
+            warnings.push(
+              `apply exceeded its ${ROLLOUT_RUN_TIMEOUT_MS}ms timeout and was ` +
+                `killed. The roll stopped cleanly rather than hanging.`,
+            );
+          }
+          return {
+            ok: false,
+            rolled,
+            failedStep: "apply",
+            ...(r.timedOut ? { timedOut: true } : {}),
+            warnings,
+          };
         }
         if (execOpts.hostdContext) {
           // SURFACED (not hidden): --compose-only skipped the host-side
@@ -698,10 +729,21 @@ export function executeRollout(
         // Verify on the roll: the canary's restart-time collapse (scope=scoped
         // in its `[ownership-sweep] #3333` log) with no approval-card storm,
         // before the default is flipped ON (stage 5).
-        deps.run(
+        const restartRes = deps.run(
           restartArgs,
           isCanary ? { env: { [SCOPED_SWEEP_ENV]: "1" } } : undefined,
         );
+        if (restartRes.timedOut) {
+          // A wedged container is precisely the case a roll exists to fix.
+          // Report it as a bounded, structural failure instead of letting the
+          // executor (and hostd's fleet-mutation latch) hang forever.
+          warnings.push(
+            `\`agent restart ${step.agent}\` exceeded its ` +
+              `${ROLLOUT_RUN_TIMEOUT_MS}ms timeout and was killed — the ` +
+              `container is likely wedged. The roll stopped cleanly rather ` +
+              `than hanging.`,
+          );
+        }
         const got = deps.probeVersion(step.agent);
         if (got === null || normalizeVersion(got) !== targetNorm) {
           deps.log(`  ✗ ${step.agent} → ${got ?? "<unreachable>"} (expected ${target}) — STOPPING`);
@@ -718,6 +760,7 @@ export function executeRollout(
             failedStep: "restart-agent",
             failedAgent: step.agent,
             got,
+            ...(restartRes.timedOut ? { timedOut: true } : {}),
             warnings,
           };
         }
@@ -823,6 +866,7 @@ export function executeRollout(
             ok: false,
             rolled,
             failedStep: "refresh-hindsight",
+            ...(r.timedOut ? { timedOut: true } : {}),
             warnings,
           };
         }
@@ -873,6 +917,272 @@ export function resolveRollbackTarget(auditLogPath?: string): string | null {
     }
   }
   return null;
+}
+
+/**
+ * Read a positive-integer millisecond budget from an env var, falling back to
+ * `fallback` when unset/garbage. Escape hatch for a genuinely slow host —
+ * never a way to reintroduce "no timeout" (0/negative/NaN are rejected).
+ */
+function envMs(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Wall-clock budget for a spawned `switchroom <subcommand>` inside a roll.
+ *
+ * Why a timeout is load-bearing (not defensive polish): `agent restart
+ * --wait` and `apply` are `spawnSync`ed. With no `timeout` a wedged container
+ * — PRECISELY the case a roll exists to fix — blocks `spawnSync` forever,
+ * which blocks `executeRollout` forever, which holds hostd's
+ * `fleetMutationInFlight` latch forever (it is cleared in a `.finally()` that
+ * never runs because the child never exits). Every subsequent fleet mutation
+ * is then refused and the auto-update latch stays `"attempting"`, with no
+ * self-clearing path short of restarting hostd.
+ *
+ * 20 minutes is deliberately generous: `agent restart --wait --force` pulls
+ * an image and waits for a health gate, and killing a legitimately-slow pull
+ * would itself strand the fleet. Override with
+ * `SWITCHROOM_ROLLOUT_RUN_TIMEOUT_MS`.
+ */
+export const ROLLOUT_RUN_TIMEOUT_MS = envMs(
+  "SWITCHROOM_ROLLOUT_RUN_TIMEOUT_MS",
+  20 * 60 * 1000,
+);
+
+/**
+ * Wall-clock budget for the `docker exec … switchroom --version` probe.
+ *
+ * Much tighter than {@link ROLLOUT_RUN_TIMEOUT_MS} because a healthy
+ * container answers in well under a second; anything past this IS the wedge
+ * we're detecting. A timed-out probe returns null — which the executor
+ * already treats as "not on the target version" and stops the roll on.
+ * Override with `SWITCHROOM_ROLLOUT_PROBE_TIMEOUT_MS`.
+ */
+export const ROLLOUT_PROBE_TIMEOUT_MS = envMs(
+  "SWITCHROOM_ROLLOUT_PROBE_TIMEOUT_MS",
+  60 * 1000,
+);
+
+/** Minimal `spawnSync` shape the deps factory needs — injectable for tests. */
+export type RolloutSpawnSync = (
+  cmd: string,
+  args: string[],
+  opts: {
+    stdio?: "inherit";
+    encoding?: "utf8";
+    env?: NodeJS.ProcessEnv;
+    timeout: number;
+    killSignal: NodeJS.Signals;
+  },
+) => {
+  status: number | null;
+  signal?: NodeJS.Signals | null;
+  stdout?: string | null;
+  error?: (Error & { code?: string }) | undefined;
+};
+
+/**
+ * True when a `spawnSync` result represents a TIMEOUT kill rather than a
+ * normal non-zero exit.
+ *
+ * Node reports a timeout two ways depending on version/platform: an `error`
+ * with `code === "ETIMEDOUT"`, and/or `status === null` with `signal` equal to
+ * the `killSignal` we passed. Match both — treating a timeout as an ordinary
+ * failure would still stop the roll safely, but the operator would lose the
+ * "your container is wedged" signal.
+ *
+ * KNOWN IMPRECISION (diagnostics only). The signal arm cannot distinguish OUR
+ * timeout kill from a FOREIGN SIGKILL — the host OOM killer reaping the child,
+ * or an operator's `kill -9`. Both surface as `status:null, signal:"SIGKILL"`,
+ * so an OOM-killed restart is reported as "wedged / timed out".
+ *
+ * This is deliberately accepted rather than papered over:
+ *   - it CANNOT false-positive on success. A successful child has a numeric
+ *     `status` (0), so the safety-critical path — "did this step pass?" — is
+ *     never affected. Both cases are genuine failures that must stop the roll;
+ *     only the LABEL differs.
+ *   - the alternative (timing the call and inferring "did we reach the
+ *     budget?") trades a wrong label for a flaky one on a loaded host.
+ *
+ * The cost is an operator chasing a "wedged container" that was actually
+ * OOM-killed, so the emitted warning names both possibilities explicitly
+ * rather than asserting the wedge. If this bites, the durable fix is to move
+ * off `spawnSync` to an async spawn where the timeout is ours to observe
+ * directly.
+ */
+export function isSpawnTimeout(
+  r: { status: number | null; signal?: NodeJS.Signals | null; error?: (Error & { code?: string }) | undefined },
+  killSignal: NodeJS.Signals,
+): boolean {
+  if (r.error && r.error.code === "ETIMEDOUT") return true;
+  return r.status === null && r.signal === killSignal;
+}
+
+/**
+ * Signal used to kill a timed-out rollout subprocess.
+ *
+ * ## Known limitation: GRANDCHILDREN ARE NOT KILLED
+ *
+ * `spawnSync`'s `timeout`/`killSignal` signal the DIRECT child only — there is
+ * no process-group kill available through `spawnSync` (no `detached`, no
+ * negative-pid kill hook). Our direct child is `node switchroom <subcommand>`,
+ * and the thing that actually wedges is its own grandchild: the `docker
+ * compose up -d` / `docker exec` the subcommand spawned.
+ *
+ * So on a timeout we reap the CLI but can leave a live `docker` process still
+ * mutating containers and, on the restart path, still holding/rewriting the
+ * compose file. Meanwhile the roll proceeds to its failure handling. Anything
+ * that touches the same compose file during that window (a rollback, a
+ * compose restore) races the orphan.
+ *
+ * This is NOT fixed here — the honest scope of this change is "bound the
+ * subprocess so the executor and hostd's fleet-mutation latch cannot hang
+ * forever", which it does. Killing the whole tree needs a move off `spawnSync`
+ * to `spawn` with `detached: true` + `process.kill(-pid)`, which changes the
+ * stdio-inherit and exit-code semantics every caller here depends on, and is
+ * its own change with its own tests.
+ *
+ * Operationally: after a reported rollout timeout, check for stray `docker`
+ * processes host-side before re-running the roll. The timeout warning says so.
+ */
+const ROLLOUT_KILL_SIGNAL: NodeJS.Signals = "SIGKILL";
+
+/**
+ * Build the production {@link RolloutDeps}.
+ *
+ * Extracted from the command action (and `spawnSync` injected) so the timeout
+ * contract — every subprocess bounded, a timeout reported cleanly rather than
+ * hung — is unit-testable without docker or a real 20-minute wait.
+ */
+export function createRolloutDeps(params: {
+  configPath: string;
+  scriptPath: string;
+  hostdCtx: boolean;
+  /** Injected in tests; defaults to node's `spawnSync`. */
+  spawn?: RolloutSpawnSync;
+  /** Injected in tests; defaults to process.stderr. */
+  warn?: (line: string) => void;
+}): RolloutDeps {
+  const { configPath, scriptPath, hostdCtx } = params;
+  const spawn = (params.spawn ?? (spawnSync as unknown as RolloutSpawnSync));
+  const warn = params.warn ?? ((line: string) => process.stderr.write(line));
+
+  /**
+   * Write `text` over the config, then chown back to the operator.
+   * Shared by persistPin and revertPin so a revert can never leave the
+   * config root-owned when the forward write wouldn't have.
+   *
+   * chown-back rationale differs by path:
+   *   host-shell: rollout self-elevates via sudo; a root write would leave
+   *     the operator-owned config root-owned and EACCES-lock other yaml verbs.
+   *   hostd: we're euid 0 inside the hostd container's mount namespace (NOT
+   *     via sudo). resolveOperatorUid() must resolve the operator's uid for
+   *     the chown to be meaningful; if it can't, SKIP the chown rather than
+   *     chown to a wrong/garbage uid (#2487 item 8).
+   */
+  const writeConfigPreservingOwnership = (
+    path: string,
+    text: string,
+    mode: number,
+  ): void => {
+    // Tries atomic rename(2) first; falls back to in-place rewrite on
+    // EBUSY/EXDEV/EINVAL (single-file bind mount inside the hostd container
+    // rejects rename over the mount point).
+    writeConfigFileSync(path, text, mode);
+    try {
+      if (typeof process.geteuid === "function" && process.geteuid() === 0) {
+        const uid = resolveOperatorUid();
+        if (uid !== undefined) {
+          chownSync(path, uid, uid);
+        } else if (hostdCtx) {
+          warn(
+            "⚠️  rollout (hostd path): could not resolve operator uid; " +
+              "skipping config chown-back to avoid leaving switchroom.yaml " +
+              "root-owned. Verify ownership host-side if other yaml verbs " +
+              "EACCES.\n",
+          );
+        }
+      }
+    } catch {
+      /* dev hosts may lack CAP_CHOWN — best-effort */
+    }
+  };
+
+  return {
+    run: (args, opts) => {
+      const r = spawn(process.execPath, [scriptPath, ...args], {
+        stdio: "inherit",
+        // #3333 amendment C: layer the per-invocation env (the scoped-sweep
+        // flag on the canary spawn) onto the inherited environment.
+        env: opts?.env ? { ...process.env, ...opts.env } : process.env,
+        // Bounded by contract — see ROLLOUT_RUN_TIMEOUT_MS.
+        timeout: ROLLOUT_RUN_TIMEOUT_MS,
+        killSignal: ROLLOUT_KILL_SIGNAL,
+      });
+      const timedOut = isSpawnTimeout(r, ROLLOUT_KILL_SIGNAL);
+      if (timedOut) {
+        warn(
+          `⚠️  rollout: \`switchroom ${args.join(" ")}\` did not finish within ` +
+            `${ROLLOUT_RUN_TIMEOUT_MS}ms and was ${ROLLOUT_KILL_SIGNAL}ed ` +
+            `(or was killed from outside — the OOM killer looks identical here; ` +
+            `see isSpawnTimeout). Its \`docker\` grandchildren are NOT killed ` +
+            `with it: check for stray docker processes host-side before ` +
+            `re-running the roll.\n`,
+        );
+      }
+      // A killed child has status null; report a non-zero status so every
+      // caller's `status !== 0` check trips.
+      return { status: r.status ?? 1, ...(timedOut ? { timedOut: true } : {}) };
+    },
+    probeVersion: (agent) => {
+      const r = spawn(
+        "docker",
+        ["exec", `switchroom-${agent}`, "sh", "-lc", "switchroom --version"],
+        {
+          encoding: "utf8",
+          timeout: ROLLOUT_PROBE_TIMEOUT_MS,
+          killSignal: ROLLOUT_KILL_SIGNAL,
+        },
+      );
+      if (isSpawnTimeout(r, ROLLOUT_KILL_SIGNAL)) {
+        warn(
+          `⚠️  rollout: version probe for ${agent} did not answer within ` +
+            `${ROLLOUT_PROBE_TIMEOUT_MS}ms and was killed — most likely a ` +
+            `wedged container (\`docker exec\` never returned), though an ` +
+            `externally-killed probe is indistinguishable here. Treating as ` +
+            `unreachable. The \`docker exec\` itself may still be running.\n`,
+        );
+        return null;
+      }
+      if (r.status !== 0) return null;
+      return (r.stdout ?? "").trim().split("\n").pop()?.trim() ?? null;
+    },
+    log: (line) => process.stdout.write(line + "\n"),
+    // #2726 — emit each phase transition as a stdout sentinel line hostd
+    // parses into a durable, hash-chained audit row. Harmless on the
+    // host-shell path (no hostd tailing stdout there); load-bearing on the
+    // hostd path where it drives durable observability + the narration
+    // surface. NEVER writes the audit log directly — hostd is the sole
+    // writer, preserving the single-writer hash-chain contract.
+    emitPhase: (phase) => process.stdout.write(encodeRolloutPhaseLine(phase) + "\n"),
+    // Belt-and-braces skew probe for the refresh-web step (webd install
+    // exits 0 on a downgrade-guard skip — see deploy-version-guard.ts).
+    webImageTag: () => deployedImageTag("switchroom-web"),
+    persistPin: (pin) => {
+      const before = readFileSync(configPath, "utf8");
+      const after = setReleasePinInConfig(before, pin);
+      if (after === before) return; // idempotent no-op
+      writeConfigPreservingOwnership(
+        configPath,
+        after,
+        statSync(configPath).mode & 0o777,
+      );
+    },
+  };
 }
 
 export function registerRolloutCommand(program: Command): void {
@@ -1044,76 +1354,7 @@ export function registerRolloutCommand(program: Command): void {
 
       const configPath = getConfigPath(program);
       const scriptPath = process.argv[1] ?? "switchroom";
-      const deps: RolloutDeps = {
-        run: (args, opts) => {
-          const r = spawnSync(process.execPath, [scriptPath, ...args], {
-            stdio: "inherit",
-            // #3333 amendment C: layer the per-invocation env (the scoped-sweep
-            // flag on the canary spawn) onto the inherited environment.
-            env: opts?.env ? { ...process.env, ...opts.env } : process.env,
-          });
-          return { status: r.status ?? 1 };
-        },
-        probeVersion: (agent) => {
-          const r = spawnSync(
-            "docker",
-            ["exec", `switchroom-${agent}`, "sh", "-lc", "switchroom --version"],
-            { encoding: "utf8" },
-          );
-          if (r.status !== 0) return null;
-          return (r.stdout ?? "").trim().split("\n").pop()?.trim() ?? null;
-        },
-        log: (line) => process.stdout.write(line + "\n"),
-        // #2726 — emit each phase transition as a stdout sentinel line hostd
-        // parses into a durable, hash-chained audit row. Harmless on the
-        // host-shell path (no hostd tailing stdout there); load-bearing on the
-        // hostd path where it drives durable observability + the narration
-        // surface. NEVER writes the audit log directly — hostd is the sole
-        // writer, preserving the single-writer hash-chain contract.
-        emitPhase: (phase) =>
-          process.stdout.write(encodeRolloutPhaseLine(phase) + "\n"),
-        // Belt-and-braces skew probe for the refresh-web step (webd install
-        // exits 0 on a downgrade-guard skip — see deploy-version-guard.ts).
-        webImageTag: () => deployedImageTag("switchroom-web"),
-        persistPin: (pin) => {
-          const before = readFileSync(configPath, "utf8");
-          const after = setReleasePinInConfig(before, pin);
-          if (after === before) return; // idempotent no-op
-          // Config-file write: tries atomic rename(2) first; falls back to
-          // in-place rewrite on EBUSY/EXDEV/EINVAL (single-file bind mount
-          // inside the hostd container rejects rename over the mount point).
-          writeConfigFileSync(configPath, after, statSync(configPath).mode & 0o777);
-          // chown-back rationale differs by path:
-          //   host-shell: rollout self-elevates via sudo; a root write
-          //     would leave the operator-owned config root-owned and
-          //     EACCES-lock other yaml verbs. chown back to the operator.
-          //   hostd: we're euid 0 inside the hostd container's mount
-          //     namespace (NOT via sudo). The config is a bind-mounted
-          //     single file at /state/config/switchroom.yaml whose
-          //     on-disk owner is the operator on the host. resolveOperatorUid()
-          //     must resolve the operator's uid for the chown to be
-          //     meaningful; if it can't, we SKIP the chown rather than
-          //     chown to a wrong/garbage uid — leaving the host's existing
-          //     ownership intact is safer than corrupting it (#2487 item 8).
-          try {
-            if (typeof process.geteuid === "function" && process.geteuid() === 0) {
-              const uid = resolveOperatorUid();
-              if (uid !== undefined) {
-                chownSync(configPath, uid, uid);
-              } else if (hostdCtx) {
-                process.stderr.write(
-                  "⚠️  rollout (hostd path): could not resolve operator uid; " +
-                    "skipping config chown-back to avoid leaving switchroom.yaml " +
-                    "root-owned. Verify ownership host-side if other yaml verbs " +
-                    "EACCES.\n",
-                );
-              }
-            }
-          } catch {
-            /* dev hosts may lack CAP_CHOWN — best-effort */
-          }
-        },
-      };
+      const deps = createRolloutDeps({ configPath, scriptPath, hostdCtx });
 
       process.stdout.write(
         `${opts.allowDowngrade ? "Rolling back" : "Rolling"} ${requested.length} agent(s) to ${target}…\n`,

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -843,10 +843,26 @@ export function executeRollout(
         emit({ phase: "web-refresh", target });
         const r = deps.run(["webd", "install", "--tag", target, ...downgradeArgs]);
         if (r.status !== 0) {
+          // A TIMED-OUT refresh is not the same failure as a non-zero exit,
+          // and the difference is operationally load-bearing. `deps.run`
+          // reports both as `status !== 0`, so without this branch a killed
+          // `webd install` produces the generic warning that tells the
+          // operator to re-run it IMMEDIATELY — while the killed CLI's
+          // `docker` grandchildren may still be live and mutating the same
+          // container. That is the same "grandchildren are NOT killed with
+          // it" signal the restart-agent timeout branch surfaces; surface it
+          // here too rather than losing it.
           warnings.push(
-            `web refresh FAILED (non-fatal — agents already rolled) so ` +
-              `switchroom-web is still on the PRIOR version. Finish it ` +
-              `host-side: \`switchroom webd install --tag ${target}\`.`,
+            r.timedOut
+              ? `web refresh TIMED OUT after ${ROLLOUT_RUN_TIMEOUT_MS}ms and was ` +
+                  `killed (non-fatal — agents already rolled) so switchroom-web ` +
+                  `is still on the PRIOR version. Its \`docker\` grandchildren ` +
+                  `are NOT killed with it: check for stray docker processes ` +
+                  `host-side BEFORE re-running, then finish it host-side: ` +
+                  `\`switchroom webd install --tag ${target}\`.`
+              : `web refresh FAILED (non-fatal — agents already rolled) so ` +
+                  `switchroom-web is still on the PRIOR version. Finish it ` +
+                  `host-side: \`switchroom webd install --tag ${target}\`.`,
           );
           break;
         }
@@ -880,7 +896,19 @@ export function executeRollout(
             (execOpts.allowDowngrade ? " --allow-downgrade" : ""),
         );
         const r = deps.run(["hostd", "install", "--tag", target, ...downgradeArgs]);
-        if (r.status !== 0) warnings.push(`hostd refresh failed (non-fatal); agents already rolled`);
+        // Same timeout-vs-exit distinction as refresh-web above: a killed
+        // `hostd install` leaves live `docker` grandchildren, so the operator
+        // must sweep for strays before re-running it.
+        if (r.status !== 0)
+          warnings.push(
+            r.timedOut
+              ? `hostd refresh TIMED OUT after ${ROLLOUT_RUN_TIMEOUT_MS}ms and ` +
+                  `was killed (non-fatal; agents already rolled). Its \`docker\` ` +
+                  `grandchildren are NOT killed with it: check for stray docker ` +
+                  `processes host-side BEFORE re-running \`switchroom hostd ` +
+                  `install --tag ${target}\`.`
+              : `hostd refresh failed (non-fatal); agents already rolled`,
+          );
         break;
       }
       case "refresh-hindsight": {
@@ -1179,13 +1207,28 @@ export function createRolloutDeps(params: {
    * belt-and-braces — see DOCKER_INSPECT_TIMEOUT_MS / DOCKER_PROBE_TIMEOUT_MS).
    * Threading through the injected `spawn` is also what makes the bound
    * unit-assertable without docker.
+   *
+   * Fails CLOSED on a throw. `isHindsightContainerExists`'s module default
+   * (`defaultDockerProbe`, `src/setup/hindsight.ts`) wraps its `execFileSync`
+   * in try/catch, so before this runner was threaded in, ANY throw from the
+   * probe became a clean `false` (→ "no hindsight container → skip"). Node's
+   * `spawnSync` reports failures on `r.error` rather than throwing —
+   * ENOENT included — so a throw here is theoretical, but "theoretical" is
+   * not a contract: swallowing it keeps the injected runner's failure shape
+   * identical to the default it replaces, instead of letting an unexpected
+   * throw escape `executeRollout` mid-roll after every agent has restarted.
    */
   const dockerRun: DockerRunner = (args) => {
-    const r = spawn("docker", args, {
-      encoding: "utf8",
-      timeout: ROLLOUT_PROBE_TIMEOUT_MS,
-      killSignal: ROLLOUT_KILL_SIGNAL,
-    });
+    let r: ReturnType<RolloutSpawnSync>;
+    try {
+      r = spawn("docker", args, {
+        encoding: "utf8",
+        timeout: ROLLOUT_PROBE_TIMEOUT_MS,
+        killSignal: ROLLOUT_KILL_SIGNAL,
+      });
+    } catch {
+      return { ok: false, stdout: "", stderr: "" };
+    }
     if (isSpawnTimeout(r, ROLLOUT_KILL_SIGNAL)) {
       warn(
         `⚠️  rollout: \`docker ${args.join(" ")}\` did not answer within ` +

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -54,7 +54,7 @@ import { compareReleaseTags } from "../config/release-resolve.js";
 import { SWITCHROOM_VERSION } from "./resolve-version.js";
 import { readAndFilter, defaultAuditLogPath } from "../host-control/audit-reader.js";
 import { isHindsightContainerExists } from "../setup/hindsight.js";
-import { deployedImageTag } from "./deploy-version-guard.js";
+import { deployedImageTag, type DockerRunner } from "./deploy-version-guard.js";
 import { SCOPED_SWEEP_ENV } from "../agents/agent-owned-tree.js";
 
 /** One ordered step of a rollout plan. Pure data so it unit-tests. */
@@ -737,12 +737,64 @@ export function executeRollout(
           // A wedged container is precisely the case a roll exists to fix.
           // Report it as a bounded, structural failure instead of letting the
           // executor (and hostd's fleet-mutation latch) hang forever.
+          //
+          // STOP THE ROLL — do NOT fall through to the version probe. A
+          // timeout here means the `switchroom agent restart` CLI was
+          // SIGKILLed mid-flight, and a SIGKILL reaps only the direct child
+          // (see ROLLOUT_KILL_SIGNAL): its `docker compose up -d` grandchild
+          // can still be live, still rewriting the compose file. Two things
+          // follow, and both are silent if we continue:
+          //   1. the orphan may well have brought the container up on the
+          //      target tag, so the probe PASSES (`got === targetNorm`) and
+          //      the roll reports success — while everything the CLI does
+          //      AFTER the container starts (the post-start reconcile and the
+          //      #3333 scoped ownership sweep injected via SCOPED_SWEEP_ENV
+          //      on the canary) was killed and never ran. A half-applied
+          //      agent reported as fully rolled.
+          //   2. proceeding restarts the NEXT agent while that orphan is
+          //      still mutating containers and the shared compose file — the
+          //      exact race ROLLOUT_KILL_SIGNAL's note names.
+          // A passing probe is evidence the container came up; it is NOT
+          // evidence the restart COMPLETED. Fail closed: the operator is told
+          // to check for stray docker processes before re-running, which is
+          // only coherent if the roll actually stopped.
           warnings.push(
             `\`agent restart ${step.agent}\` exceeded its ` +
               `${ROLLOUT_RUN_TIMEOUT_MS}ms timeout and was killed — the ` +
               `container is likely wedged. The roll stopped cleanly rather ` +
               `than hanging.`,
           );
+          const gotAfterKill = deps.probeVersion(step.agent);
+          if (gotAfterKill !== null && normalizeVersion(gotAfterKill) === targetNorm) {
+            warnings.push(
+              `${step.agent} is reporting ${gotAfterKill} (the roll target) ` +
+                `despite the killed restart — its orphaned \`docker compose\` ` +
+                `grandchild most likely finished the container start. The ` +
+                `restart's POST-start work (reconcile / ownership sweep) was ` +
+                `killed with the CLI and did NOT run, so this agent is ` +
+                `HALF-APPLIED, not rolled. Check for stray docker processes ` +
+                `host-side, then re-run.`,
+            );
+          }
+          deps.log(
+            `  ✗ ${step.agent} → restart TIMED OUT (killed after ` +
+              `${ROLLOUT_RUN_TIMEOUT_MS}ms; probe says ` +
+              `${gotAfterKill ?? "<unreachable>"}) — STOPPING`,
+          );
+          emit(
+            isCanary
+              ? { phase: "canary-fail", target, agent: step.agent, n: agentIndex, m: totalAgents }
+              : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
+          );
+          return {
+            ok: false,
+            rolled,
+            failedStep: "restart-agent",
+            failedAgent: step.agent,
+            got: gotAfterKill,
+            timedOut: true,
+            warnings,
+          };
         }
         const got = deps.probeVersion(step.agent);
         if (got === null || normalizeVersion(got) !== targetNorm) {
@@ -760,7 +812,13 @@ export function executeRollout(
             failedStep: "restart-agent",
             failedAgent: step.agent,
             got,
-            ...(restartRes.timedOut ? { timedOut: true } : {}),
+            // No `timedOut` here by construction: the timeout branch above
+            // returns unconditionally, so reaching this point means the
+            // restart exited on its own and the VERSION ASSERT is what
+            // failed. Keeping the two failure shapes disjoint is what lets
+            // hostd (and `get_status`) distinguish "killed mid-flight,
+            // grandchildren may be live" from "ran to completion, wrong
+            // version" — they need different operator recovery.
             warnings,
           };
         }
@@ -923,6 +981,15 @@ export function resolveRollbackTarget(auditLogPath?: string): string | null {
  * Read a positive-integer millisecond budget from an env var, falling back to
  * `fallback` when unset/garbage. Escape hatch for a genuinely slow host —
  * never a way to reintroduce "no timeout" (0/negative/NaN are rejected).
+ *
+ * SCOPE OF THE OVERRIDE (do not over-read it): the two constants below are
+ * evaluated at MODULE LOAD, so `SWITCHROOM_ROLLOUT_*_TIMEOUT_MS` only takes
+ * effect when it is set BEFORE this module is imported. That is true of the
+ * production entrypoint — the CLI process inherits its environment, and the
+ * rollout is a fresh `switchroom rollout` process — so the override works
+ * where operators actually use it. It is NOT a general runtime knob: setting
+ * `process.env.*` from inside an already-loaded process (or between tests in
+ * one vitest worker) will NOT change these values.
  */
 function envMs(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -982,6 +1049,7 @@ export type RolloutSpawnSync = (
   status: number | null;
   signal?: NodeJS.Signals | null;
   stdout?: string | null;
+  stderr?: string | null;
   error?: (Error & { code?: string }) | undefined;
 };
 
@@ -1048,6 +1116,26 @@ export function isSpawnTimeout(
  *
  * Operationally: after a reported rollout timeout, check for stray `docker`
  * processes host-side before re-running the roll. The timeout warning says so.
+ *
+ * ## That operator instruction does NOT cover the unattended path
+ *
+ * "Check host-side before re-running" presumes a human between the timeout
+ * and the next mutation. On the auto-rollout path there isn't one:
+ * `finishFailedAutoRollout` → `recoverFailedAutoRollout` (`server.ts`) re-runs
+ * `apply --pin … --compose-only` and, when `failed_step === "restart-agent"`,
+ * `agent restart <agent> --wait --force --pin …` immediately — zero delay, no
+ * orphan check — possibly CONCURRENT with the SIGKILLed child's still-live
+ * `docker compose up -d` on the same compose file. So on the path that
+ * matters most (nobody watching), the grandchild-orphan race above is not
+ * merely unmitigated, it is actively raced into.
+ *
+ * Not fixed here — the honest scope of this change is bounding the
+ * subprocesses. The durable fix is for `finishFailedAutoRollout` to SKIP
+ * auto-recovery when the executor reported `timed_out` and alert instead of
+ * re-mutating; that is a hostd-side behaviour change with its own tests and
+ * its own blast radius, tracked as a follow-up. Stated here rather than left
+ * implicit so the deferral is not read as "the operator instruction covers
+ * it".
  */
 const ROLLOUT_KILL_SIGNAL: NodeJS.Signals = "SIGKILL";
 
@@ -1070,6 +1158,45 @@ export function createRolloutDeps(params: {
   const { configPath, scriptPath, hostdCtx } = params;
   const spawn = (params.spawn ?? (spawnSync as unknown as RolloutSpawnSync));
   const warn = params.warn ?? ((line: string) => process.stderr.write(line));
+
+  /**
+   * One-shot `docker …` bounded by {@link ROLLOUT_PROBE_TIMEOUT_MS}.
+   *
+   * `deps.run` and `deps.probeVersion` were not the only subprocesses inside
+   * `executeRollout`'s own path: the `refresh-web` step calls
+   * {@link deployedImageTag} and the `refresh-hindsight` step calls
+   * {@link isHindsightContainerExists}, both of which shell out to `docker`
+   * IN-PROCESS. The docker CLI has no client-side request timeout, so with an
+   * unresponsive dockerd either call blocked forever — `executeRollout` never
+   * returns, hostd's `runSwitchroom` promise never settles (it resolves only
+   * on the child's `close`), its `.finally()` never runs, and
+   * `fleetMutationInFlight` is stranded permanently. Same bug this whole
+   * change exists to close, and worse-shaped: it strands the latch AFTER
+   * every agent has already rolled.
+   *
+   * Both helpers take an injectable runner, so we thread this bounded one in
+   * rather than relying on their module defaults (which are also bounded now,
+   * belt-and-braces — see DOCKER_INSPECT_TIMEOUT_MS / DOCKER_PROBE_TIMEOUT_MS).
+   * Threading through the injected `spawn` is also what makes the bound
+   * unit-assertable without docker.
+   */
+  const dockerRun: DockerRunner = (args) => {
+    const r = spawn("docker", args, {
+      encoding: "utf8",
+      timeout: ROLLOUT_PROBE_TIMEOUT_MS,
+      killSignal: ROLLOUT_KILL_SIGNAL,
+    });
+    if (isSpawnTimeout(r, ROLLOUT_KILL_SIGNAL)) {
+      warn(
+        `⚠️  rollout: \`docker ${args.join(" ")}\` did not answer within ` +
+          `${ROLLOUT_PROBE_TIMEOUT_MS}ms and was killed — most likely an ` +
+          `unresponsive docker daemon (though an externally-killed probe is ` +
+          `indistinguishable here). Treating as unknown.\n`,
+      );
+      return { ok: false, stdout: "", stderr: "" };
+    }
+    return { ok: r.status === 0, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+  };
 
   /**
    * Write `text` over the config, then chown back to the operator.
@@ -1136,7 +1263,17 @@ export function createRolloutDeps(params: {
       }
       // A killed child has status null; report a non-zero status so every
       // caller's `status !== 0` check trips.
-      return { status: r.status ?? 1, ...(timedOut ? { timedOut: true } : {}) };
+      //
+      // The `timedOut ? 1` arm is not redundant defensiveness — it ENFORCES
+      // the invariant isSpawnTimeout's contract asserts. isSpawnTimeout's
+      // ETIMEDOUT arm is checked BEFORE status, so a hypothetical
+      // `{status: 0, error: {code: "ETIMEDOUT"}}` shape would otherwise
+      // return `status: 0, timedOut: true` and every caller's
+      // `if (r.status !== 0)` gate would read the timeout as SUCCESS. We
+      // could not reproduce that shape on node v22.23.1, but "the runtime
+      // happens not to emit it" is not a guarantee — a timeout is never a
+      // success, so encode that in the code rather than only in the doc.
+      return { status: timedOut ? 1 : (r.status ?? 1), ...(timedOut ? { timedOut: true } : {}) };
     },
     probeVersion: (agent) => {
       const r = spawn(
@@ -1171,7 +1308,15 @@ export function createRolloutDeps(params: {
     emitPhase: (phase) => process.stdout.write(encodeRolloutPhaseLine(phase) + "\n"),
     // Belt-and-braces skew probe for the refresh-web step (webd install
     // exits 0 on a downgrade-guard skip — see deploy-version-guard.ts).
-    webImageTag: () => deployedImageTag("switchroom-web"),
+    // Bounded: this `docker inspect` runs IN-PROCESS inside executeRollout.
+    webImageTag: () => deployedImageTag("switchroom-web", dockerRun),
+    // Bounded for the same reason: the refresh-hindsight step's `docker ps`
+    // also runs in-process inside executeRollout.
+    hindsightExists: () =>
+      isHindsightContainerExists((args) => {
+        const r = dockerRun(args);
+        return r.ok ? r.stdout : null;
+      }),
     persistPin: (pin) => {
       const before = readFileSync(configPath, "utf8");
       const after = setReleasePinInConfig(before, pin);

--- a/src/host-control/rollout-timeout-latch.test.ts
+++ b/src/host-control/rollout-timeout-latch.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The POINT of bounding the rollout's subprocesses: hostd's fleet-mutation
+ * latch must actually get released when a roll dies on a timeout.
+ *
+ * `fleetMutationInFlight` is cleared in the `.finally()` of the promise chain
+ * in `spawnRollout` (server.ts:3980-3985). That `.finally()` only runs when
+ * the child EXITS. Pre-fix, `executeRollout` used `spawnSync` with no
+ * `timeout`, so a wedged container blocked the child forever, the promise
+ * never settled, the latch was never cleared, and every subsequent fleet
+ * mutation was refused with no self-clearing path short of restarting hostd.
+ *
+ * The claim "a timeout releases the latch" was previously only argued
+ * structurally. This asserts it end-to-end against a REAL child process: a
+ * `node -e` stub standing in for the rollout child, emitting the
+ * timeout-flavoured result sentinel and exiting non-zero exactly as
+ * `executeRollout` does after `ROLLOUT_RUN_TIMEOUT_MS` fires.
+ *
+ * (`process.execPath` is used as the injected `switchroomBin` rather than a
+ * shell script in a temp dir: `/tmp` is mounted `noexec` in the container
+ * this runs in, so an exec-bit stub is not portable.)
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HostdServer, type ServerOptions } from "./server.js";
+import { encodeRolloutResultLine, type RolloutResult } from "../cli/rollout.js";
+
+type Entry = {
+  request_id: string;
+  op: string;
+  result?: string;
+  exit_code?: number | null;
+  timed_out?: boolean;
+  failed_agent?: string;
+  failed_step?: string;
+  rolled?: string[];
+};
+
+type Internals = {
+  fleetMutationInFlight: { request_id: string } | null;
+  spawnRollout(args: string[], entry: Entry): void;
+  writeTerminalAudit(entry: Entry): Promise<void>;
+  pushRolloutTerminal(entry: Entry): void;
+};
+
+/** `node -e` argv that prints `stdout` verbatim then exits `code`. */
+function childArgs(stdout: string, code: number): string[] {
+  return [
+    "-e",
+    `process.stdout.write(${JSON.stringify(stdout)});process.exit(${code});`,
+  ];
+}
+
+function makeServer(): Internals {
+  const server = new HostdServer({
+    homeDir: mkdtempSync(join(tmpdir(), "hostd-latch-")),
+    switchroomBin: process.execPath,
+  } as unknown as ServerOptions);
+  const internals = server as unknown as Internals;
+  // Neutralise the durable-audit and chat side-effects — this test is about
+  // the latch, and those paths need a real state dir / relay.
+  internals.writeTerminalAudit = async () => undefined;
+  internals.pushRolloutTerminal = () => undefined;
+  return internals;
+}
+
+/** Wait until `predicate()` holds, or the budget expires (no fixed sleeps). */
+async function until(predicate: () => boolean, budgetMs = 5000): Promise<void> {
+  const deadline = Date.now() + budgetMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for condition");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+/** Drive one roll to termination and hand back the mutated status entry. */
+async function runRoll(stdout: string, code: number): Promise<{ entry: Entry; latch: unknown }> {
+  const internals = makeServer();
+  const entry: Entry = { request_id: `req-${code}-${Math.random()}`, op: "rollout" };
+  // Mirror launchRollout (server.ts:2137-2144): take the latch, then spawn.
+  internals.fleetMutationInFlight = { request_id: entry.request_id };
+  internals.spawnRollout(childArgs(stdout, code), entry);
+  expect(internals.fleetMutationInFlight).not.toBeNull();
+  await until(() => internals.fleetMutationInFlight === null);
+  return { entry, latch: internals.fleetMutationInFlight };
+}
+
+describe("fleetMutationInFlight is released when a roll ends on a timeout", () => {
+  it("clears the latch and records the timeout as a structured outcome", async () => {
+    const sentinel = encodeRolloutResultLine({
+      ok: false,
+      rolled: ["test-harness"],
+      failedStep: "restart-agent",
+      failedAgent: "clerk",
+      got: null,
+      timedOut: true,
+      warnings: ["agent restart clerk exceeded its timeout and was killed"],
+    } as RolloutResult);
+
+    const { entry, latch } = await runRoll(sentinel + "\n", 1);
+
+    // THE outcome: the next fleet mutation is admissible again with no hostd
+    // restart. Pre-fix this never happened — the child never exited at all.
+    expect(latch).toBeNull();
+    // And the timeout is legible to a get_status reader, not just a tail.
+    expect(entry.result).toBe("error");
+    expect(entry.timed_out).toBe(true);
+    expect(entry.failed_agent).toBe("clerk");
+    expect(entry.failed_step).toBe("restart-agent");
+  });
+
+  it("does not mark a non-timeout failure as timed_out", async () => {
+    const sentinel = encodeRolloutResultLine({
+      ok: false,
+      rolled: [],
+      failedStep: "apply",
+      warnings: [],
+    } as RolloutResult);
+
+    const { entry, latch } = await runRoll(sentinel + "\n", 1);
+
+    expect(latch).toBeNull();
+    expect(entry.result).toBe("error");
+    expect(entry.timed_out).toBeUndefined();
+  });
+
+  it("clears the latch on a successful roll too (no regression)", async () => {
+    const sentinel = encodeRolloutResultLine({
+      ok: true,
+      rolled: ["test-harness", "clerk"],
+      warnings: [],
+    } as RolloutResult);
+
+    const { entry, latch } = await runRoll(sentinel + "\n", 0);
+
+    expect(latch).toBeNull();
+    expect(entry.result).toBe("completed");
+    expect(entry.timed_out).toBeUndefined();
+  });
+
+  it("clears the latch even when the child dies with NO sentinel", async () => {
+    // The pathological shape: the rollout child is itself SIGKILLed, so no
+    // structured result is ever emitted. The `.finally()` must still run.
+    const { entry, latch } = await runRoll("", 137);
+
+    expect(latch).toBeNull();
+    expect(entry.result).toBe("error");
+    expect(entry.timed_out).toBeUndefined();
+  });
+});

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -342,6 +342,16 @@ export interface StatusEntry {
   failed_agent?: string;
   /** Actual version detected on failed_agent (null = unreachable). BONUS #2458 got-field gap. */
   got?: string | null;
+  /**
+   * True when the roll stopped because a bounded subprocess exceeded its
+   * timeout and was killed (see ROLLOUT_RUN_TIMEOUT_MS / ROLLOUT_PROBE_TIMEOUT_MS
+   * in cli/rollout.ts). A timeout is operationally distinct from a plain
+   * non-zero exit — the step may have left work half-done and docker
+   * grandchildren may still be running — so it is surfaced as its own field
+   * rather than being flattened into the stderr tail. Absent (not `false`)
+   * on rolls that did not time out.
+   */
+  timed_out?: boolean;
   // ─── Update-apply deferral result (#2458) ──────────────────────────
   // Steps that were deferred because the update ran in hostd-context
   // (SWITCHROOM_HOSTD_CONTEXT=1). Populated by parsing the
@@ -3909,6 +3919,10 @@ export class HostdServer {
           // unreachable). Preserve it so get_status readers can surface the
           // mismatch without scraping stdout.
           if (parsed.got !== undefined) entry.got = parsed.got;
+          // A timeout is its own outcome class: preserve it so get_status /
+          // the terminal audit row can say "killed on timeout" rather than
+          // just "exit 1". Only set when true — absence means "not a timeout".
+          if (parsed.timedOut) entry.timed_out = true;
           // Structured `ok` is the authority; exit code corroborates.
           entry.result = parsed.ok ? "completed" : "error";
         } else {

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -579,47 +579,74 @@ export async function pickHindsightPorts(): Promise<{
 }
 
 /**
+ * Wall-clock budget for the one-shot `docker ps` / `docker --version` probes
+ * below.
+ *
+ * The docker CLI has NO client-side request timeout: against an unresponsive
+ * dockerd these calls block FOREVER, and an unbounded `execFileSync` here
+ * hangs whatever called it. That is load-bearing on the rollout path —
+ * {@link isHindsightContainerExists} is reached from `executeRollout`'s
+ * `refresh-hindsight` step, so a hang here strands hostd's
+ * `fleetMutationInFlight` latch exactly the way the unbounded subcommand
+ * spawns did (see `ROLLOUT_PROBE_TIMEOUT_MS` in `src/cli/rollout.ts`).
+ *
+ * A healthy daemon answers these in milliseconds, so anything past this
+ * budget IS the wedge. All three probes already fail closed on any throw, and
+ * a timeout throws — so bounding them changes nothing on a healthy host and
+ * converts an infinite hang into a clean `false` on a wedged one.
+ */
+export const DOCKER_PROBE_TIMEOUT_MS = 60 * 1000;
+
+/**
+ * Minimal one-shot docker runner: stdout on success, `null` on ANY failure
+ * (non-zero exit, docker absent, or a timeout kill against a wedged daemon).
+ *
+ * Injectable so the rollout executor can supply a runner bounded by its own
+ * budget, and so tests can exercise these probes without docker.
+ */
+export type DockerProbe = (args: string[]) => string | null;
+
+const defaultDockerProbe: DockerProbe = (args) => {
+  try {
+    return execFileSync("docker", args, {
+      stdio: "pipe",
+      encoding: "utf-8",
+      timeout: DOCKER_PROBE_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    });
+  } catch {
+    return null;
+  }
+};
+
+/**
  * Check if Docker is available on the system.
  */
-export function isDockerAvailable(): boolean {
-  try {
-    execFileSync("docker", ["--version"], { stdio: "pipe" });
-    return true;
-  } catch {
-    return false;
-  }
+export function isDockerAvailable(probe: DockerProbe = defaultDockerProbe): boolean {
+  return probe(["--version"]) !== null;
 }
 
 /**
  * Check if the switchroom-hindsight container is currently running.
  */
-export function isHindsightRunning(): boolean {
-  try {
-    const output = execFileSync(
-      "docker",
-      ["ps", "--filter", "name=switchroom-hindsight", "--format", "{{.Status}}"],
-      { stdio: "pipe", encoding: "utf-8" },
-    );
-    return output.trim().length > 0;
-  } catch {
-    return false;
-  }
+export function isHindsightRunning(probe: DockerProbe = defaultDockerProbe): boolean {
+  const out = probe(["ps", "--filter", "name=switchroom-hindsight", "--format", "{{.Status}}"]);
+  return (out ?? "").trim().length > 0;
 }
 
 /**
  * Check if the switchroom-hindsight container exists (running or stopped).
  */
-export function isHindsightContainerExists(): boolean {
-  try {
-    const output = execFileSync(
-      "docker",
-      ["ps", "-a", "--filter", "name=switchroom-hindsight", "--format", "{{.Names}}"],
-      { stdio: "pipe", encoding: "utf-8" },
-    );
-    return output.trim().length > 0;
-  } catch {
-    return false;
-  }
+export function isHindsightContainerExists(probe: DockerProbe = defaultDockerProbe): boolean {
+  const out = probe([
+    "ps",
+    "-a",
+    "--filter",
+    "name=switchroom-hindsight",
+    "--format",
+    "{{.Names}}",
+  ]);
+  return (out ?? "").trim().length > 0;
 }
 
 /**


### PR DESCRIPTION
Carved out of #3601 so the independently-correct half can ship on its own. The pin-journal + compose-backup work stays on `fix/rollout-guard` and will be re-proposed separately once its review blockers are fixed.

## Scope, stated precisely

This PR bounds **every subprocess spawned from inside `executeRollout`'s own path** — the CLI-side rollout executor. It does **not** bound hostd's *recovery* spawns, so the hang class is **not** closed on the unattended auto-rollout path. See "What this does NOT close" below. The earlier framing of this PR ("every rollout subprocess") over-claimed; this is the honest boundary.

## The bug

The staggered fleet rollout executor had **zero timeouts** — `grep -c timeout src/cli/rollout.ts` on `main` returns 0. Every step ran through a bare `spawnSync` with no `timeout`, so one wedged container (hung `docker restart`, unresponsive `docker exec … switchroom --version`) blocks the rollout child forever.

On the hostd path that is worse than a slow roll:

- `launchRollout` (`src/host-control/server.ts:2090`) takes `fleetMutationInFlight` (`server.ts:2148-2152`) and calls `spawnRollout` (`server.ts:2153`).
- The latch is released **only** inside `spawnRollout`'s `.finally()` (`src/host-control/server.ts:3949`; the release itself is `server.ts:3994-3999`), which cannot run until the child exits.
- So a hung `spawnSync` strands the latch permanently. Every subsequent fleet mutation is refused, with no self-clearing path short of restarting hostd.

## The fix

- **`src/cli/rollout.ts`** — `createRolloutDeps()` extracted from the command action (making the spawn seam injectable) and every spawn given `timeout` + `killSignal: "SIGKILL"`. Two env-tunable budgets: `ROLLOUT_RUN_TIMEOUT_MS` (20 min, `SWITCHROOM_ROLLOUT_RUN_TIMEOUT_MS`) for subcommands; `ROLLOUT_PROBE_TIMEOUT_MS` (60 s, `SWITCHROOM_ROLLOUT_PROBE_TIMEOUT_MS`) for version probes.
- **`isSpawnTimeout()`** classifies the kill (`error.code === "ETIMEDOUT"`, or `status === null` with our kill signal). A timeout becomes a clean non-zero return carrying `timedOut: true` — the executor **always returns**, so hostd's `.finally()` always runs.
- **`RolloutResult.timedOut`** rides the stdout result sentinel (`encodeRolloutResultLine` / `parseRolloutResultLine`), and `src/host-control/server.ts` maps it onto a new `StatusEntry.timed_out` so `get_status` shows "killed on timeout" rather than a bare `exit 1`.

## Review round 2 — three findings fixed (`2bcb512`)

### F1 (HIGH) — two `docker` spawns were still unbounded *inside* `executeRollout`

`deps.run` and `deps.probeVersion` were not the only children. Two in-process `docker` calls on the executor's own path had no timeout:

- `src/cli/deploy-version-guard.ts:36` **on `main`** — `spawnSync("docker", args, { encoding: "utf8" })` — reached via `webImageTag: () => deployedImageTag("switchroom-web")` (`rollout.ts:1355` at HEAD) on the `refresh-web` step (`rollout.ts:834` at HEAD).
- `src/setup/hindsight.ts:614` **on `main`** — `execFileSync("docker", […], { stdio: "pipe", encoding: "utf-8" })` — reached on `refresh-hindsight` (`rollout.ts:914` at HEAD).

The docker CLI has **no client-side request timeout**, so against an unresponsive dockerd either call blocks forever — `executeRollout` never returns, `runSwitchroom`'s promise never settles (`server.ts:4589-4658`; it resolves only on the child's `close`, `server.ts:4653-4655`), `spawnRollout`'s `.finally()` (`server.ts:3949`) never runs, and `fleetMutationInFlight` is stranded permanently. Verbatim the bug this PR exists to close, and **worse-shaped**: it strands the latch *after* every agent has already rolled.

Fixed at both levels:

- `createRolloutDeps` (`rollout.ts:1177`) threads a bounded `dockerRun` (`rollout.ts:1221`, built from the **injected** `spawn`, `ROLLOUT_PROBE_TIMEOUT_MS` + SIGKILL) into both `deployedImageTag` and `isHindsightContainerExists`. Going through the injected spawn is what makes the bound unit-assertable without docker.
- The module defaults are bounded too (`DOCKER_INSPECT_TIMEOUT_MS`, `DOCKER_PROBE_TIMEOUT_MS`), closing the hazard for every caller rather than one call site. `isHindsightContainerExists` / `isHindsightRunning` / `isDockerAvailable` gain an injectable `DockerProbe`. All three already failed closed on a throw and a timeout throws, so behaviour on a healthy host is unchanged.

### F2 (MEDIUM) — a timed-out restart fell through and could report success

The timeout branch pushed a warning and **fell through** to the version probe. A SIGKILL reaps only the direct child, so its orphaned `docker compose up -d` grandchild could still bring the container up on the target tag; the probe then passed, the loop continued with `ok: true`, and `timedOut` was never set on the result. The roll reported **success** for an agent whose post-start reconcile and #3333 scoped ownership sweep (`SCOPED_SWEEP_ENV`, `rollout.ts:734`) were killed and never ran — and then restarted the *next* agent while the orphan was still rewriting the shared compose file.

**Chosen: return `ok: false` (with `timedOut: true`), not merely carrying `timedOut` onto a successful result.** A passing probe is evidence the container *came up*; it is **not** evidence the restart *completed*. Half-applied is a failure, and continuing the roll also means mutating the next agent while an orphan is live — the exact race `ROLLOUT_KILL_SIGNAL`'s note names. The warning already tells the operator to check for stray docker processes before re-running, which is only coherent if the roll actually stopped. Fail closed.

The existing executor timeout test could not catch this — it used `versions: { "test-harness": null }`, so the probe failed anyway and the stop was attributable to the null probe, not the timeout. The **probe-passes-after-timeout** case is now covered.

### F5 (LOW) — a timeout could have been read as success

`isSpawnTimeout` checks its `ETIMEDOUT` arm before status, so a `{status: 0, error: {code: "ETIMEDOUT"}}` shape would have returned `status: 0` with `timedOut: true` — and every caller gates on `if (r.status !== 0)`, so the timeout would have been read as **success**. That shape was not reproducible on node v22.23.1 (probed three ways), but the JSDoc asserted an invariant the code did not enforce. Now it does: `status: timedOut ? 1 : (r.status ?? 1)`.

## Review round 3 — two non-blocking lows + a citation audit (`5bf03a2`)

Round-2 re-review returned MERGEABLE and flagged these as optional-on-top. Landed.

### LOW-2 — a timed-out `refresh-web` / `refresh-hostd` was bounded but not *surfaced*

Both steps gate only on `r.status !== 0` (`rollout.ts:845`, `:902`), and `deps.run` reports a SIGKILLed child as `status: 1`. So a **timed-out** `webd install` / `hostd install` produced the generic non-fatal warning — which tells the operator to re-run the command *immediately*, while the killed CLI's `docker` grandchildren may still be live and mutating the same container. The "grandchildren are NOT killed with it" signal that the `restart-agent` timeout branch already surfaces was simply lost here.

Both warnings now branch on `r.timedOut` (`rollout.ts:845-867` web, `rollout.ts:902-911` hostd): they name the timeout, the budget, and "check for stray docker processes host-side **BEFORE** re-running". Non-timeout wording is byte-identical to before, so the two failure shapes stay disjoint — and a test pins that.

Deliberately **not** changed: the step stays non-fatal (`ok: true`). Agents have already rolled by then; escalating a stale web/hostd to a failed roll is a behaviour change well beyond the finding.

### LOW-3 — the injected docker probe no longer failed closed on a throw

`isHindsightContainerExists`'s module default (`defaultDockerProbe`, `src/setup/hindsight.ts:609-619`) wraps its `execFileSync` in try/catch, so ANY throw became a clean `false`. The bounded `dockerRun` that `createRolloutDeps` threads in its place had none (`rollout.ts:1221`), so a throw would escape `executeRollout` mid-roll — *after* every agent has already restarted.

`spawnSync` reports failures on `r.error` rather than throwing (ENOENT included), so this is **parity insurance, not a live bug** — stated plainly rather than dressed up. Parity is the point: the injected runner must fail closed exactly like the default it replaces. `dockerRun` now returns `{ok: false, stdout: "", stderr: ""}` on a throw.

### DOC-1 — every code citation in this body re-verified

Several `file:line` refs in this description had drifted (CLAUDE.md § "Line anchors drift fast"). Every citation was re-checked against the actual files; the wrong ones are corrected above and the anchor for each is now explicit. **All `rollout.ts` / `server.ts` line refs in this body are anchored at `5bf03a2`; the `deploy-version-guard.ts:36` and `hindsight.ts:614` refs describe the pre-fix code and are anchored on `main`.**

| Cited | Claim | Verdict |
|---|---|---|
| `deploy-version-guard.ts:36` | unbounded `spawnSync("docker", …)` | ✅ accurate on `main` |
| `hindsight.ts:614` | unbounded `execFileSync("docker", …)` | ✅ accurate on `main` |
| `server.ts:4149-4155` | `finishFailedAutoRollout`'s `finally` | ❌ that range is `pushRolloutTerminal`'s relay routing → **`server.ts:4029-4044`** |
| `server.ts:2137-2144` | latch taken + `spawnRollout` called | ❌ that range is the `StatusEntry` object literal's fields → **`:2148-2152`** (latch) / **`:2153`** (spawn); `launchRollout` starts at `:2090` |
| `server.ts:3980-3985` | the latch-releasing `.finally()` | ❌ that range is `clearAutoRolloutLatch()` + a comment → `.finally()` opens at **`:3949`**, the release is **`:3994-3999`** |
| `server.ts:3986` | same `.finally()` | ❌ → **`:3949`** (`:3986` is the `pushRolloutTerminal` call inside it) |
| `server.ts:4702-4768` | `runSwitchroom` resolves only on `close` | ❌ that range is `slimScheduleEntry` / the scheduler-fire trim, a different subsystem → **`:4589-4658`**, resolve at **`:4653-4655`** |
| `rollout.ts:1174` | `webImageTag` → `deployedImageTag` | ❌ → **`:1355`** |
| `rollout.ts:799` | the `refresh-web` step | ❌ → **`:834`** |
| `rollout.ts:839` | the `refresh-hindsight` step | ❌ → **`:914`** |
| `rollout.ts:729-731` | `SCOPED_SWEEP_ENV` injection | ❌ → **`:734`** (single line; import at `:58`) |
| `rollout.ts:951`, `:963` | the two timeout budgets | ❌ → **`:1046`** and **`:1060`** |

## What this does NOT close — documented limits

Stated here rather than left implicit, because each one is a place where the guarantee stops.

1. **Hostd-side auto-recovery spawns are unbounded (F3) — filed as #3607.** `recoverFailedAutoRollout`'s two `runSwitchroom` calls (`apply --pin … --compose-only`, and on `failed_step === "restart-agent"` an `agent restart <agent> --wait --force --pin …`) have no timeout, and are awaited inside `finishFailedAutoRollout`'s `try` with the latch released only in its `finally` (`server.ts:4029-4044`; the two recovery spawns are `server.ts:4099-4102` and `server.ts:4111-4119`). Either one reproduces this PR's exact hang. **Pre-existing on `main`, not a regression here — but it means the hang class is NOT closed on the unattended path, which is where it matters most.**

2. **Grandchildren are not killed, and the deferral rationale does not cover the unattended path (F4).** `spawnSync` offers no process-group kill, so the `docker` processes spawned by a killed `switchroom agent restart` survive. The deferral was justified by an operator instruction — "check for stray docker processes host-side before re-running" — which presumes a human between the timeout and the next mutation. On the auto-rollout path there is none: hostd immediately re-runs `apply --compose-only` and `agent restart --force`, zero delay, no orphan check, possibly **concurrent** with the SIGKILLed child's still-live `docker compose up -d`. `ROLLOUT_KILL_SIGNAL`'s JSDoc now says this explicitly. The recommended durable fix — make `finishFailedAutoRollout` skip auto-recovery when `timed_out` is set and alert instead of re-mutating — is a hostd-side behaviour change with its own blast radius, tracked in #3607.

3. **A foreign SIGKILL is indistinguishable from ours.** If the OOM killer (or an operator) SIGKILLs the child, `isSpawnTimeout` reports a timeout. It cannot false-positive on *success* — `status === 0` is never a timeout, and F5 now enforces that — so this is a diagnostics-only imprecision. Called out in JSDoc, in the operator-facing warning, and asserted by tests.

4. **The env overrides are module-load-time only (F6).** `ROLLOUT_RUN_TIMEOUT_MS` / `ROLLOUT_PROBE_TIMEOUT_MS` are evaluated at module load (`rollout.ts:1046`, `:1060`), so `SWITCHROOM_ROLLOUT_*_TIMEOUT_MS` takes effect only when set **before** the module is imported. That holds for the production CLI entrypoint (a rollout is a fresh `switchroom rollout` process inheriting its environment), so the override works where operators actually use it — but it is **not** a general runtime knob. Documented on `envMs`, whose own validation (reject 0/negative/NaN) is unchanged and correct.

5. **No test proves a *real* process exceeding a *real* timeout gets reaped (F7).** The latch test's child is a `node -e` stub emitting a pre-baked sentinel; `rollout.test.ts` injects `spawn`. What the tests prove is that (a) every spawn site passes a positive `timeout` + SIGKILL, and (b) every timeout-shaped result is classified and propagated correctly end-to-end. The kernel-level reap itself is node's contract, not ours — but don't read the coverage as an integration proof that it fires.

## Tests

`src/host-control/rollout-timeout-latch.test.ts` (new) drives a **real child process** through hostd's actual `spawnRollout` promise chain and asserts `fleetMutationInFlight` returns to `null` — the outcome an earlier review flagged as claimed-but-untested. Four cases: timeout failure, ordinary failure, success, and a child that dies with no sentinel at all. No docker is invoked and no rollout is performed; the child is a `node -e` stub injected via `ServerOptions.switchroomBin`.

Mutation-verified (round 1):

- Disabling the latch release (`if (false && this.fleetMutationInFlight …)`) → **4 failed**.
- Dropping the `timed_out` mapping (`if (false) entry.timed_out = true`) → **1 failed**.

Mutation-verified (round 2, 12 new tests in `src/cli/rollout.test.ts`):

- `webImageTag: () => deployedImageTag("switchroom-web", dockerRun)` → drop `dockerRun` (revert F1 web) → **2 failed**.
- `hindsightExists` → revert to the bare `isHindsightContainerExists()` (revert F1 hindsight) → **2 failed**.
- `status: timedOut ? 1 : (r.status ?? 1)` → `status: r.status ?? 1` (revert F5) → **1 failed**.
- Restore the F2 fall-through (warn, then probe) → **2 failed**, including the probe-passes-after-timeout case.

Mutation-verified (round 3, 5 new tests in `src/cli/rollout.test.ts`):

- Revert both LOW-2 warning branches to the plain wording → **2 failed | 105 passed (107)**.
- Revert LOW-3's `try/catch` in `dockerRun` → **2 failed | 105 passed (107)**.
- Restored → **107 passed (107)**. The 5th test pins the *non-timeout* wording, so the two failure shapes cannot silently converge.

## Verbatim output

`npx tsc --noEmit` — clean, no output.

Scoped tests (superset of the round-1 suite — adds the deploy-version-guard, hindsight, and rollout-observability/narrator files the F1 fix touches):

Re-run at `5bf03a2` (round 3 adds 5 tests to `rollout.test.ts`: 102 → 107, total 172 → 177):

```
 ✓ src/setup/hindsight-mirror-dir.test.ts (8 tests) 81ms
 ✓ src/host-control/rollout-narrator.test.ts (14 tests) 38ms
 ✓ src/cli/rollout.test.ts (107 tests) 216ms
 ✓ src/host-control/rollout-observability.test.ts (19 tests) 26ms
 ✓ src/host-control/rollout-agent-validation.test.ts (6 tests) 23ms
 ✓ src/host-control/rollout-timeout-latch.test.ts (4 tests) 222ms
 ✓ src/setup/hindsight-pin-tag.test.ts (8 tests) 7ms
 ✓ src/cli/deploy-version-guard.test.ts (11 tests) 8ms

 Test Files  8 passed (8)
      Tests  177 passed (177)
```

`npm run lint` fails in this worktree at gate 2 of 13, and the failure is **pre-existing and environmental**, not caused by this PR: this worktree has no `node_modules` of its own (disk pressure) and borrows a sibling checkout's, which lacks the plugin-only deps (`mdast-util-from-markdown`, `@mtcute/node`, …). The other **12 of 13** gates were run individually and all pass:

```
tsc OK
check-bot-api-wrapping.sh OK
check-bun-test-imports OK
check-no-pii-secrets OK
check-vault-test-hermeticity OK
check-no-broadcast-delivery OK
check-stale-tool-descriptions OK
check-mcp-instructions-budget OK
check-web-subscription-honest OK
check-no-unpinned-npx-playwright OK
check-gateway-line-ratchet OK
check-litellm-config-guard OK
```

CI is the authority on the full suite.

