### PR TITLE
fix(webkite): make the shared cloakbrowser Chromium mount actually work

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -135,9 +135,12 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
 # `webkite mcp` MCP server to fetch bot-gated sites. The webkite binary
 # itself is mounted from the operator's host (private beta — not
 # baked or committed); cloakbrowser is public OSS so we bake the
-# Python tool here. The 700MB chromium binary it spawns is shared
-# across the fleet via a host bind mount of `~/.cloakbrowser/` (see
-# compose.ts), NOT baked into the image.
+# Python tool here. The ~700MB chromium binary it spawns is shared
+# across the fleet via a host bind mount of `~/.switchroom/cloakbrowser/`
+# onto CLOAKBROWSER_CACHE_DIR (see compose.ts), NOT baked into the
+# image: the binary is licence-gated (cloakbrowser's download.py gates
+# the current build behind a login/key + concurrency tier) and would add
+# ~700MB to every image pull.
 #
 # Why bake instead of per-agent install: a pipx venv has shebang lines
 # pointing at the venv's own python interpreter. If we mounted the
@@ -157,6 +160,26 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && PIPX_HOME=${CLOAKBROWSER_PIPX_HOME} PIPX_BIN_DIR=/usr/local/bin \
     pipx install cloakbrowser
+
+# Shared stealth-Chromium cache path (#TBD). cloakbrowser's
+# `get_cache_dir()` honours CLOAKBROWSER_CACHE_DIR and only falls back to
+# `~/.cloakbrowser` when it is unset — so we pin it to a fixed NON-HOME
+# image path and bind-mount the operator's one shared copy onto it RO
+# (compose.ts). Prior to this the fleet relied on path-shadowing the
+# per-agent HOME, which silently produced N private 697MB downloads when
+# the mount didn't materialise.
+#
+# The directory is created here root-owned and left EMPTY on purpose:
+# agents run as a non-root per-agent UID (image default 10001), so when
+# the shared RO mount is absent an agent cannot silently re-download its
+# own private 697MB copy — cloakbrowser aborts with `[Errno 13]
+# Permission denied` (verified live) and start.sh warns loudly at boot.
+# ORDERING NOTE for the rollout: once this ENV ships, any pre-existing
+# per-agent `$HOME/.cloakbrowser` copy is ignored, so the shared cache
+# must be populated (see `switchroom doctor`) at or before the rebuild or
+# agents temporarily lose local render (cloud render is unaffected).
+ENV CLOAKBROWSER_CACHE_DIR=/opt/switchroom/cloakbrowser-cache
+RUN mkdir -p ${CLOAKBROWSER_CACHE_DIR} && chmod 0755 ${CLOAKBROWSER_CACHE_DIR}
 
 # Fleet-wide webkite render config (#2805). Baked here at a NON-HOME image
 # path so it survives container rebuilds and is identical across the fleet;

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1104,6 +1104,21 @@ if [ -f /opt/switchroom/webkite/config.toml ]; then
   unset sr_wk_target
 fi
 
+# Shared cloakbrowser Chromium cache (#TBD). The image pins
+# CLOAKBROWSER_CACHE_DIR to /opt/switchroom/cloakbrowser-cache and
+# compose bind-mounts the operator's single ~/.switchroom/cloakbrowser/
+# copy RO onto it. If that mount didn't materialise the dir is empty and
+# root-owned, so cloakbrowser cannot silently re-download its own ~700MB
+# private copy (verified live: it aborts with `[Errno 13] Permission
+# denied` instead of extracting) — it only loses local render. Warn
+# loudly, never fatally: webkite still cloud-renders when the
+# Cloudflare/Firecrawl credentials are present.
+sr_cb_dir="${CLOAKBROWSER_CACHE_DIR:-/opt/switchroom/cloakbrowser-cache}"
+if ! ls -d "$sr_cb_dir"/chromium-*/ >/dev/null 2>&1; then
+  echo "WARNING (cloakbrowser shared cache): shared cloakbrowser Chromium missing at $sr_cb_dir — webkite local render unavailable (cloud render still works if Cloudflare/Firecrawl creds are set). On the host run: CLOAKBROWSER_CACHE_DIR=~/.switchroom/cloakbrowser cloakbrowser install && switchroom apply" >&2
+fi
+unset sr_cb_dir
+
 # LiteLLM routing (opt-in, #litellm). When SWITCHROOM_LITELLM is set (compose
 # env, gated on litellm.enabled && keyConfirmed), route the unmodified `claude`
 # CLI through the operator's LiteLLM proxy at ANTHROPIC_BASE_URL: fetch the

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -2784,21 +2784,40 @@ function emitAgentService(
   // any per-agent install. existsSync-guarded because dev installs
   // without webkite staged should not hard-fail compose `up`.
   //
-  // Cloakbrowser's stealth Chromium (~700MB extracted) lives at the
-  // operator's `~/.cloakbrowser/` (cloakbrowser hardcodes that path).
-  // Mounted RO at the per-agent HOME so cloakbrowser's runtime lookup
-  // (`$HOME/.cloakbrowser/chromium-*/chrome`) resolves to the shared
-  // operator install — one ~700MB copy on disk instead of N. The
-  // cloakbrowser pipx tool itself is baked into the agent image
+  // Cloakbrowser's stealth Chromium (~700MB extracted) is shared fleet-
+  // wide from `~/.switchroom/cloakbrowser/`, mounted RO onto the image's
+  // fixed CLOAKBROWSER_CACHE_DIR (`/opt/switchroom/cloakbrowser-cache`,
+  // set in Dockerfile.agent) — one ~700MB copy on disk instead of N.
+  //
+  // #TBD: this used to shadow `$HOME/.cloakbrowser` from the operator's
+  // stray `~/.cloakbrowser`, on the belief that cloakbrowser hardcodes
+  // that path. It does NOT — `cloakbrowser/config.py::get_cache_dir()`
+  // reads CLOAKBROWSER_CACHE_DIR and only defaults to `~/.cloakbrowser`.
+  // The old source also sat OUTSIDE `~/.switchroom/`, which is the only
+  // subtree hostd bind-mounts, so the existsSync guard was always false
+  // whenever compose was generated from hostd — the mount was silently
+  // never emitted and every agent downloaded its own private 697MB copy.
+  // Keeping the source under `~/.switchroom/` keeps the probe truthful in
+  // both the host-CLI and hostd generation contexts.
+  //
+  // The target sits under `/opt/switchroom`, which BIND_MOUNT_TARGET_DENYLIST
+  // reserves for switchroom-owned image paths — i.e. an operator cannot
+  // shadow or redirect this cache from yaml. That's the point.
+  //
+  // The `:ro` is load-bearing, not incidental: a shared WRITABLE browser
+  // cache would let any one agent rewrite a Chromium binary that every
+  // other agent then executes as itself. Do not relax it.
+  //
+  // The cloakbrowser pipx tool itself is baked into the agent image
   // (Dockerfile.agent) so the venv shebang lines resolve in-container.
   if (existsSync(`${probeHome}/.switchroom/bin/webkite`)) {
     lines.push(
       `      - ${homePrefix}/.switchroom/bin/webkite:/usr/local/bin/webkite:ro`,
     );
   }
-  if (existsSync(`${probeHome}/.cloakbrowser`)) {
+  if (existsSync(`${probeHome}/.switchroom/cloakbrowser`)) {
     lines.push(
-      `      - ${homePrefix}/.cloakbrowser:/state/agent/home/.cloakbrowser:ro`,
+      `      - ${homePrefix}/.switchroom/cloakbrowser:/opt/switchroom/cloakbrowser-cache:ro`,
     );
   }
   // Operator-authored shared webkite config (e.g. defaults.format,

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4059,8 +4059,10 @@ export function integrationRetractionKeys(
  *     repo or the agent image.
  *   - cloakbrowser Python tool: baked into the agent image at
  *     `/opt/cloakbrowser` (public OSS, no constraint violation).
- *   - cloakbrowser Chromium: operator-mounted from `~/.cloakbrowser/`
- *     so the whole fleet shares one ~700MB install.
+ *   - cloakbrowser Chromium: operator-mounted RO from
+ *     `~/.switchroom/cloakbrowser/` onto the image's
+ *     CLOAKBROWSER_CACHE_DIR (`/opt/switchroom/cloakbrowser-cache`) so
+ *     the whole fleet shares one ~700MB install (#TBD).
  *
  * Credential injection: CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN /
  * FIRECRAWL_API_KEY are fetched from the vault-broker by start.sh.hbs

--- a/src/cli/doctor-webkite.test.ts
+++ b/src/cli/doctor-webkite.test.ts
@@ -20,7 +20,10 @@ function cfg(partial: Partial<SwitchroomConfig>): SwitchroomConfig {
   return partial as unknown as SwitchroomConfig;
 }
 
-function byName(rs: { name: string; status: string; detail?: string }[], name: string) {
+function byName(
+  rs: { name: string; status: string; detail?: string; fix?: string }[],
+  name: string,
+) {
   return rs.find((r) => r.name === name);
 }
 
@@ -73,8 +76,12 @@ function deps(fs: FakeFs, extra: Partial<WebkiteProbeDeps> = {}): WebkiteProbeDe
 }
 
 const BIN = "/home/op/.switchroom/bin/webkite";
-const CLOAK = "/home/op/.cloakbrowser";
-const CHROME = "/home/op/.cloakbrowser/chromium-146/chrome";
+// #TBD: the shared cache the fleet actually mounts.
+const CLOAK = "/home/op/.switchroom/cloakbrowser";
+const CHROME = "/home/op/.switchroom/cloakbrowser/chromium-146/chrome";
+// Pre-fix per-operator location — no longer mounted anywhere.
+const LEGACY_CLOAK = "/home/op/.cloakbrowser";
+const LEGACY_CHROME = "/home/op/.cloakbrowser/chromium-146/chrome";
 
 describe("runWebkiteChecks", () => {
   it("returns [] when every agent opts out of webkite", () => {
@@ -116,13 +123,45 @@ describe("runWebkiteChecks", () => {
     expect(byName(r, "webkite: cloakbrowser")?.status).toBe("warn");
   });
 
-  it("passes cloakbrowser when chromium/chrome is present", () => {
+  it("passes cloakbrowser when chromium/chrome is present in the shared cache", () => {
     const config = cfg({ agents: { a: {} as never } });
     const r = runWebkiteChecks(
       config,
       deps({ heads: { [BIN]: ELF_X64 }, dirs: { [CLOAK]: ["chromium-146"] }, files: { [CHROME]: "" } }),
     );
     expect(byName(r, "webkite: cloakbrowser")?.status).toBe("ok");
+  });
+
+  // #TBD: chromium sitting ONLY at the legacy ~/.cloakbrowser is the exact
+  // state that produced 5 private 697MB copies — nothing mounts that path,
+  // so it must warn (with a migration fix), not pass.
+  it("warns with a migration hint when chromium is only at the legacy ~/.cloakbrowser (#TBD)", () => {
+    const config = cfg({ agents: { a: {} as never } });
+    const r = runWebkiteChecks(
+      config,
+      deps({
+        heads: { [BIN]: ELF_X64 },
+        dirs: { [LEGACY_CLOAK]: ["chromium-146"] },
+        files: { [LEGACY_CHROME]: "" },
+      }),
+    );
+    const c = byName(r, "webkite: cloakbrowser");
+    expect(c?.status).toBe("warn");
+    expect(c?.fix).toContain("~/.switchroom/cloakbrowser");
+  });
+
+  // A doctor that dispenses advice which doesn't work IS the bug: the old
+  // hint (`XDG_DATA_HOME=… webkite setup --yes cloakbrowser`) relocated pipx,
+  // never the Chromium cache. The working lever is CLOAKBROWSER_CACHE_DIR,
+  // which cloakbrowser's config.py::get_cache_dir() reads.
+  it("hints the cache-dir env var that actually populates the shared cache (#TBD)", () => {
+    const config = cfg({ agents: { a: {} as never } });
+    const r = runWebkiteChecks(config, deps({ heads: { [BIN]: ELF_X64 } }));
+    const c = byName(r, "webkite: cloakbrowser");
+    expect(c?.status).toBe("warn");
+    expect(c?.fix).toContain("CLOAKBROWSER_CACHE_DIR=~/.switchroom/cloakbrowser");
+    expect(c?.fix).toContain("cloakbrowser install");
+    expect(c?.fix).not.toContain("XDG_DATA_HOME");
   });
 
   it("OK per-agent scaffold when wired + pre-approved + WebFetch denied", () => {

--- a/src/cli/doctor-webkite.ts
+++ b/src/cli/doctor-webkite.ts
@@ -13,10 +13,11 @@
  *      build) won't run in-container — the agent silently loses web
  *      access. We read the ELF header on the host so the gross mistake
  *      is caught before a fleet roll, not after.
- *   2. cloakbrowser      — the local stealth Chromium render path lives
- *      at `~/.cloakbrowser/`. Absent → webkite can only cloud-render
- *      (Cloudflare/Firecrawl) and fails on bot-gated sites with no
- *      local fallback.
+ *   2. cloakbrowser      — the fleet-shared stealth Chromium lives at
+ *      `~/.switchroom/cloakbrowser/` and is bind-mounted RO onto the
+ *      image's CLOAKBROWSER_CACHE_DIR (#TBD). Absent → webkite can only
+ *      cloud-render (Cloudflare/Firecrawl) and fails on bot-gated sites
+ *      with no local fallback.
  *   3. scaffold wiring   — for each webkite-enabled agent that HAS been
  *      scaffolded: `.mcp.json` must carry the `webkite` entry,
  *      `settings.json` `permissions.allow` must pre-approve
@@ -179,26 +180,42 @@ export function runWebkiteChecks(
   }
 
   // ── 2. cloakbrowser local render ──────────────────────────────────
-  const cloakDir = join(d.homeDir, ".cloakbrowser");
-  let chromeFound = false;
-  if (d.existsSync(cloakDir)) {
+  // Probe the SHARED cache (`~/.switchroom/cloakbrowser/`) — the mount
+  // source compose.ts emits (#TBD). The legacy per-operator
+  // `~/.cloakbrowser/` is probed only to produce a migration hint: it is
+  // no longer mounted anywhere, so a fleet with only that is NOT healthy.
+  const sharedCloakDir = join(d.homeDir, ".switchroom", "cloakbrowser");
+  const legacyCloakDir = join(d.homeDir, ".cloakbrowser");
+  const hasChromium = (dir: string): boolean => {
+    if (!d.existsSync(dir)) return false;
     try {
-      for (const entry of d.readdirSync(cloakDir)) {
-        if (entry.startsWith("chromium-") && d.existsSync(join(cloakDir, entry, "chrome"))) {
-          chromeFound = true;
-          break;
+      for (const entry of d.readdirSync(dir)) {
+        if (entry.startsWith("chromium-") && d.existsSync(join(dir, entry, "chrome"))) {
+          return true;
         }
       }
-    } catch { /* unreadable dir — fall through to the not-found branch */ }
-  }
-  if (chromeFound) {
-    results.push({ name: "webkite: cloakbrowser", status: "ok", detail: "stealth Chromium present (local render available)" });
+    } catch { /* unreadable dir — treat as absent */ }
+    return false;
+  };
+  if (hasChromium(sharedCloakDir)) {
+    results.push({
+      name: "webkite: cloakbrowser",
+      status: "ok",
+      detail: "shared stealth Chromium present at ~/.switchroom/cloakbrowser (local render available; one copy mounted RO into every agent)",
+    });
+  } else if (hasChromium(legacyCloakDir)) {
+    results.push({
+      name: "webkite: cloakbrowser",
+      status: "warn",
+      detail: "stealth Chromium is at the legacy ~/.cloakbrowser but NOT at the shared ~/.switchroom/cloakbrowser — nothing mounts the legacy path, so every agent re-downloads its own ~700MB copy",
+      fix: "Move it to the shared path, then re-apply: mv ~/.cloakbrowser ~/.switchroom/cloakbrowser && chmod -R a+rX ~/.switchroom/cloakbrowser && switchroom apply",
+    });
   } else {
     results.push({
       name: "webkite: cloakbrowser",
       status: "warn",
-      detail: "no local stealth Chromium at ~/.cloakbrowser/chromium-*/chrome — webkite can only cloud-render (Cloudflare/Firecrawl) and will fail bot-gated sites with no local fallback",
-      fix: "Install once on the host: XDG_DATA_HOME=~/.switchroom/webkite-share webkite setup --yes cloakbrowser",
+      detail: "no shared stealth Chromium at ~/.switchroom/cloakbrowser/chromium-*/chrome — webkite can only cloud-render (Cloudflare/Firecrawl) and will fail bot-gated sites with no local fallback",
+      fix: "Populate once on the host, then re-apply: CLOAKBROWSER_CACHE_DIR=~/.switchroom/cloakbrowser cloakbrowser install && chmod -R a+rX ~/.switchroom/cloakbrowser && switchroom apply",
     });
   }
 

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -975,7 +975,7 @@ describe("generateCompose", () => {
     try {
       mkdirSync(join(tmp, ".switchroom", "bin"), { recursive: true });
       writeFileSync(join(tmp, ".switchroom", "bin", "webkite"), "#!/bin/sh\n");
-      mkdirSync(join(tmp, ".cloakbrowser", "chromium-1"), { recursive: true });
+      mkdirSync(join(tmp, ".switchroom", "cloakbrowser", "chromium-1"), { recursive: true });
       mkdirSync(join(tmp, ".switchroom", "webkite"), { recursive: true });
       writeFileSync(join(tmp, ".switchroom", "webkite", "config.toml"), "");
       const out = generateCompose({
@@ -986,7 +986,7 @@ describe("generateCompose", () => {
         `${tmp}/.switchroom/bin/webkite:/usr/local/bin/webkite:ro`,
       );
       expect(out).toContain(
-        `${tmp}/.cloakbrowser:/state/agent/home/.cloakbrowser:ro`,
+        `${tmp}/.switchroom/cloakbrowser:/opt/switchroom/cloakbrowser-cache:ro`,
       );
       expect(out).toContain(
         `${tmp}/.switchroom/webkite/config.toml:/state/agent/home/.config/webkite/config.toml:ro`,
@@ -1011,7 +1011,7 @@ describe("generateCompose", () => {
         homeDir: tmp,
       });
       expect(out).not.toContain(`/.switchroom/bin/webkite:`);
-      expect(out).not.toContain(`/.cloakbrowser:`);
+      expect(out).not.toContain(`/.switchroom/cloakbrowser:`);
       expect(out).not.toContain(`/.switchroom/webkite/config.toml:`);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
@@ -3210,6 +3210,47 @@ describe("conditional-mount probe home (in-hostd apply — marko meta_pages regr
     // existsSync(/home/op/.switchroom/mcp-launchers) is false → not mounted.
     // This is exactly the in-hostd failure mode the probeHomeDir split fixes.
     expect(yaml).not.toContain("/.switchroom/mcp-launchers:");
+  });
+
+  // #TBD: the cloakbrowser shared-Chromium mount used to probe (and bake)
+  // `~/.cloakbrowser`, which sits OUTSIDE the only subtree hostd bind-mounts
+  // (`~/.switchroom/`). So on every in-hostd generation the existsSync guard
+  // was false and the mount was silently never emitted — each agent then
+  // downloaded its own private ~697MB Chromium (5 agents ≈ 3.4GB observed).
+  // Moving the source under `~/.switchroom/` makes the probe truthful in the
+  // hostd context. This test fails on pristine main.
+  it("emits the shared cloakbrowser mount on an in-hostd apply (#TBD)", () => {
+    // Mirror hostd exactly: only ~/.switchroom is visible at probeHomeDir.
+    mkdirSync(join(tmpDir, ".switchroom", "cloakbrowser", "chromium-146.0"), {
+      recursive: true,
+    });
+    const yaml = generateCompose({
+      config: makeConfig({ klanker: {} }),
+      homeDir: "/home/op", // baked source — does NOT exist on this filesystem
+      probeHomeDir: tmpDir, // container-real home (mirrors /host-home in hostd)
+    });
+    expect(yaml).toContain(
+      "/home/op/.switchroom/cloakbrowser:/opt/switchroom/cloakbrowser-cache:ro",
+    );
+    // The legacy HOME-shadowing target must be gone: cloakbrowser resolves
+    // the cache via CLOAKBROWSER_CACHE_DIR, not via $HOME/.cloakbrowser.
+    expect(yaml).not.toContain("/state/agent/home/.cloakbrowser");
+  });
+
+  it("keeps the shared cloakbrowser mount read-only (#TBD)", () => {
+    // Load-bearing: a shared WRITABLE browser cache would let one agent
+    // rewrite a Chromium binary every other agent executes as itself.
+    mkdirSync(join(tmpDir, ".switchroom", "cloakbrowser", "chromium-146.0"), {
+      recursive: true,
+    });
+    const yaml = generateCompose({
+      config: makeConfig({ klanker: {} }),
+      homeDir: "/home/op",
+      probeHomeDir: tmpDir,
+    });
+    expect(yaml).not.toContain(
+      "/home/op/.switchroom/cloakbrowser:/opt/switchroom/cloakbrowser-cache:rw",
+    );
   });
 
   // #2387: a conditional dir that is a symlink to an ABSOLUTE host path

--- a/tests/docker/dockerfile-agent-bakes.test.ts
+++ b/tests/docker/dockerfile-agent-bakes.test.ts
@@ -169,9 +169,10 @@ describe("Dockerfile.agent Playwright provisioning", () => {
  * because (a) it's public OSS and (b) baking-in avoids a fragile
  * per-agent pipx install in the boot path.
  *
- * The 700MB Chromium binary cloakbrowser spawns is NOT baked — it's
- * shared across the fleet via a host bind mount of `~/.cloakbrowser/`
- * (see src/agents/compose.ts).
+ * The ~700MB Chromium binary cloakbrowser spawns is NOT baked (licence-
+ * gated + would bloat every image pull) — it's shared across the fleet
+ * via a host bind mount of `~/.switchroom/cloakbrowser/` onto the baked
+ * CLOAKBROWSER_CACHE_DIR (see src/agents/compose.ts).
  */
 describe("Dockerfile.agent webkite/cloakbrowser provisioning", () => {
   it("apt-installs pipx (the package manager cloakbrowser ships through)", () => {
@@ -190,5 +191,31 @@ describe("Dockerfile.agent webkite/cloakbrowser provisioning", () => {
 
   it("CLOAKBROWSER_PIPX_HOME is an absolute /opt path (not under HOME)", () => {
     expect(dockerfile).toMatch(/ENV\s+CLOAKBROWSER_PIPX_HOME=\/opt\//);
+  });
+
+  // #TBD regression. cloakbrowser's config.py::get_cache_dir() reads
+  // CLOAKBROWSER_CACHE_DIR and only falls back to ~/.cloakbrowser. Pinning
+  // it to a fixed NON-HOME image path is what makes the shared RO mount
+  // authoritative; without this ENV each agent silently downloaded its own
+  // private ~697MB Chromium into $HOME.
+  it("pins CLOAKBROWSER_CACHE_DIR to the shared-mount image path", () => {
+    expect(dockerfile).toMatch(
+      /ENV\s+CLOAKBROWSER_CACHE_DIR=\/opt\/switchroom\/cloakbrowser-cache/,
+    );
+  });
+
+  it("pre-creates the cache dir root-owned so a missing mount cannot self-heal into a private copy", () => {
+    // Agents run as UID 10001. An empty root-owned dir means cloakbrowser
+    // fails loudly (webkite still cloud-renders) instead of re-downloading.
+    expect(dockerfile).toMatch(
+      /RUN\s+mkdir\s+-p\s+\$\{CLOAKBROWSER_CACHE_DIR\}/,
+    );
+    expect(dockerfile).not.toMatch(
+      /chown[^\n]*\$\{CLOAKBROWSER_CACHE_DIR\}/,
+    );
+  });
+
+  it("does NOT bake the licence-gated Chromium binary into the image", () => {
+    expect(dockerfile).not.toMatch(/cloakbrowser\s+install/);
   });
 });

--- a/tests/scaffold.cloakbrowser-cache-warning.test.ts
+++ b/tests/scaffold.cloakbrowser-cache-warning.test.ts
@@ -1,0 +1,81 @@
+/**
+ * #TBD — the rendered start.sh must warn (non-fatally) when the shared
+ * cloakbrowser Chromium cache is missing.
+ *
+ * Background: switchroom intends every agent to share ONE ~700MB stealth
+ * Chromium via a read-only bind mount. Before this change the mount was
+ * silently inert (the probe pointed at `~/.cloakbrowser`, outside the only
+ * subtree hostd can see), and every agent quietly downloaded its own private
+ * copy — 5 agents × 697MB observed on the live host. Nothing anywhere said so.
+ *
+ * The image now pins CLOAKBROWSER_CACHE_DIR to a root-owned image path, so a
+ * missing mount can no longer self-heal into a private copy (cloakbrowser
+ * aborts with `[Errno 13] Permission denied`). That makes the boot warning the
+ * operator's only signal — so it is asserted here, not left to review.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+describe("start.sh: shared cloakbrowser cache boot warning (#TBD)", () => {
+  let tmpDir: string;
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-cloakbrowser-warn-"));
+    savedHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+  });
+
+  it("warns to stderr when no chromium-* is present in the cache dir", () => {
+    const name = "carrie";
+    const config = { extends: "default", topic_name: "T", schedule: [] } as unknown as AgentConfig;
+    const switchroomConfig = {
+      switchroom: { version: 1, agents_dir: "~/.switchroom/agents", skills_dir: "~/.switchroom/skills" },
+      telegram: telegramConfig,
+      agents: { [name]: config },
+    } as unknown as SwitchroomConfig;
+
+    const res = scaffoldAgent(
+      name,
+      config,
+      join(tmpDir, ".switchroom", "agents"),
+      telegramConfig,
+      switchroomConfig,
+    );
+    const startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+
+    // Probes the image-pinned cache dir (with the same default the Dockerfile
+    // bakes, so an older image without the ENV still gets a truthful probe).
+    expect(startSh).toContain(
+      'sr_cb_dir="${CLOAKBROWSER_CACHE_DIR:-/opt/switchroom/cloakbrowser-cache}"',
+    );
+    expect(startSh).toContain('ls -d "$sr_cb_dir"/chromium-*/');
+    // Warns, on stderr, with the working repair command.
+    expect(startSh).toMatch(/WARNING \(cloakbrowser shared cache\)[^\n]*cloakbrowser[^\n]*>&2/);
+    expect(startSh).toContain(
+      "CLOAKBROWSER_CACHE_DIR=~/.switchroom/cloakbrowser cloakbrowser install",
+    );
+    // Non-fatal: no exit/abort in the guard body.
+    const guard = startSh.slice(
+      startSh.indexOf('sr_cb_dir="${CLOAKBROWSER_CACHE_DIR'),
+      startSh.indexOf("unset sr_cb_dir"),
+    );
+    expect(guard).not.toMatch(/\bexit\s+[1-9]/);
+  });
+});


### PR DESCRIPTION
## Summary

switchroom intends to share ONE ~700MB cloakbrowser stealth Chromium across the fleet via a read-only bind mount. **The mount was silently inert**: 5 agents each held a byte-identical private 697MB copy (~3.4GB on the live host, ~2.8GB reclaimable).

## Why it was inert (verified against the live host, not assumed)

- `compose.ts` probed `${probeHome}/.cloakbrowser`, which sits **outside** `~/.switchroom/` — the only host subtree hostd bind-mounts (`docker inspect switchroom-hostd`: `/home/<op>/.switchroom -> /host-home/.switchroom` is the sole home mount). Every in-hostd compose generation evaluated the guard false and emitted no mount line at all. Live `docker-compose.yml`: 0 cloakbrowser matches; no container has a cloakbrowser bind.
- The existing comment claimed "cloakbrowser hardcodes that path". **It does not** — `cloakbrowser/config.py::get_cache_dir()` reads `CLOAKBROWSER_CACHE_DIR` and only falls back to `~/.cloakbrowser`. That false belief is why the original design used fragile HOME path-shadowing instead of the env var.
- doctor's fix hint (`XDG_DATA_HOME=… webkite setup --yes cloakbrowser`) relocates pipx, not the Chromium cache — it could never populate anything.

## Change

- **`docker/Dockerfile.agent`** — pin `CLOAKBROWSER_CACHE_DIR=/opt/switchroom/cloakbrowser-cache` and pre-create it root-owned and **empty**, so a missing mount cannot silently self-heal into another private 697MB copy. The binary itself stays unbaked (licence-gated, ~700MB per image pull).
- **`src/agents/compose.ts`** — mount source is now the switchroom-owned `~/.switchroom/cloakbrowser/` (visible to hostd) onto that image path, still `:ro`. A shared *writable* browser cache would let one agent rewrite a binary another agent executes as itself.
- **`src/cli/doctor-webkite.ts`** — probe the shared dir; emit a fix hint that actually works (`CLOAKBROWSER_CACHE_DIR=… cloakbrowser install`), plus a dedicated migration warning when Chromium is only at the legacy path.
- **`profiles/_base/start.sh.hbs`** — non-fatal boot warning when the shared cache is absent.

## Test plan

The new/updated assertions **fail on pristine main** (verified by reverting only the source files: 7 failures) and pass with the fix. The regression test reproduces the real mechanism (`probeHomeDir ≠ homeDir`) rather than the tmpdir shape that passed while production was broken.

## Operator steps (order matters)

1. `mv ~/.cloakbrowser ~/.switchroom/cloakbrowser && chmod -R a+rX ~/.switchroom/cloakbrowser` — **first**, and the `chmod` is required: `extensions/` is `root:root 0700`. The existing 697MB host copy is exactly what's needed, so there is no re-download.
2. Merge this PR, rebuild the agent image, `switchroom apply`, restart agents.
3. Reclaim the ~2.8GB of per-agent private copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
