### PR TITLE
fix(telegram): sub-agent progress feed + Bash label fixes

### DIFF
--- a/src/agents/sub-agent-telegram-prompt.test.ts
+++ b/src/agents/sub-agent-telegram-prompt.test.ts
@@ -49,18 +49,33 @@ describe('buildTelegramProgressGuidance', () => {
     expect(out).toContain('mcp__switchroom-telegram__progress_update')
   })
 
-  it('mentions the inflection points (start, blocker, chunk done)', () => {
+  it('names the inflection points worth spending a send on', () => {
     const out = buildTelegramProgressGuidance({ defaultChatId: '1' })
-    expect(out).toContain('Start of work')
-    expect(out).toContain('Blocker')
-    expect(out).toContain('chunk done')
+    expect(out).toContain('blocker or pivot')
+    expect(out).toContain('long silent stretch')
   })
 
-  it('explains that progress_update lands on the parent card, not as a separate message', () => {
+  // Truthfulness guard. The pinned progress card was deleted in #1122/#1126
+  // and the card-injection path in `executeProgressUpdate` went with it, but
+  // this prompt kept telling every sub-agent its updates land on a card row
+  // and cost the user nothing. A sub-agent that believes a send is free will
+  // spam the chat (exactly the #256 regression). The guidance must describe
+  // what the tool does TODAY: a real, rate-limited Telegram message.
+  it('does NOT claim a pinned card or a free/no-message send', () => {
+    const out = buildTelegramProgressGuidance({ defaultChatId: '1' }).toLowerCase()
+    expect(out).not.toContain('pinned card')
+    expect(out).not.toContain('pinned progress card')
+    expect(out).not.toContain('does not send a separate telegram message')
+    expect(out).not.toContain('call it freely')
+  })
+
+  it('states that it sends a real Telegram message, and its limits', () => {
     const out = buildTelegramProgressGuidance({ defaultChatId: '1' })
-    expect(out.toLowerCase()).toContain('pinned')
-    expect(out.toLowerCase()).toContain('card')
-    expect(out.toLowerCase()).toContain('does not send a separate telegram message')
+    expect(out.toLowerCase()).toContain('new plain telegram message')
+    expect(out.toLowerCase()).toContain('sparingly')
+    expect(out).toContain('20 seconds')
+    expect(out).toContain('5 per turn')
+    expect(out).toContain('300 chars')
   })
 })
 

--- a/src/agents/sub-agent-telegram-prompt.ts
+++ b/src/agents/sub-agent-telegram-prompt.ts
@@ -3,11 +3,19 @@
  *
  * Originally introduced in #32; disabled in #256 because each
  * `progress_update` call posted a fresh Telegram message and parallel
- * sub-agents spammed the chat. Re-enabled in #305 Option A (PR #413):
- * the gateway now routes sub-agent `progress_update` calls onto the
- * parent's pinned progress card row body instead of sending separate
- * messages, so the spam concern is gone and the JTBD (user sees what
- * the sub-agent is doing) is restored without attention cost.
+ * sub-agents spammed the chat. Re-enabled in #305 Option A (PR #413),
+ * which routed sub-agent calls onto the parent's PINNED PROGRESS CARD
+ * row body instead of sending messages.
+ *
+ * That card was deleted in #1122/#1126, and with it the card-injection
+ * path (`progressDriver` is permanently null; the dead inject block was
+ * removed from `executeProgressUpdate` in the truthful-telemetry pass).
+ * This text kept describing the #413 behaviour for ~14 months anyway —
+ * so every sub-agent was told its updates land on a card that no longer
+ * exists and cost the user nothing. It rewrites here to what the tool
+ * ACTUALLY does today: send a short, rate-limited plain message. The
+ * #256 spam concern is therefore live again, which is why the guidance
+ * now says "sparingly at real inflection points" rather than "freely".
  *
  * Cron guidance (originally issue #269) was REMOVED in #1798 along with
  * the `claude -p` cron-fold-in retirement. The cron-specific helpers
@@ -69,27 +77,31 @@ export function shouldAppendTelegramProgressGuidance(args: {
 
 /**
  * Markdown block appended to a sub-agent's prompt body when the parent
- * runs on Telegram. The sub-agent's `progress_update` calls land on the
- * parent's pinned progress card (PR #413, issue #305 Option A) — they
- * do NOT send separate Telegram messages, so this is cheap and safe to
- * call at every meaningful inflection point.
+ * runs on Telegram. A sub-agent's `progress_update` sends a real, plain
+ * Telegram message (the pinned-card injection path died with the card in
+ * #1122/#1126) — the gateway rate-limits it to one per 20s per chat+thread
+ * and 5 per turn, and the guidance below tells the sub-agent to spend those
+ * few sends on genuine inflection points rather than narrating.
  */
 export function buildTelegramProgressGuidance(args: {
   defaultChatId: string
 }): string {
   return `
 
-## Progress visibility on the parent's pinned card
+## Progress visibility for the user
 
-Your parent agent runs in a Telegram chat. The user reads on a phone, not in this terminal. Tool calls and intermediate output do not reach them — only what is posted to the parent's pinned progress card.
+Your parent agent runs in a Telegram chat. The user reads on a phone, not in this terminal — your tool calls and intermediate output never reach them. Two channels do:
 
-When you call \`mcp__switchroom-telegram__progress_update\` from inside this sub-agent, the gateway routes the text onto your row in the parent's pinned card (replace-on-write, capped at ~200 chars). It does NOT send a separate Telegram message, so call it freely at meaningful inflection points:
+1. **The worker activity card** (automatic, free). The parent's chat already shows a live \`🛠 Worker\` card with your task, elapsed time, and a running feed of the steps you take. You do not drive this and should not narrate it.
+2. **\`mcp__switchroom-telegram__progress_update\`** (manual, NOT free). This posts a **new plain Telegram message** into the chat — it pings the user's phone and costs their attention. It is not a card row and not an edit.
 
-- **Start of work** — "Analyzing 12 files in /src/auth"
-- **Blocker / pivot** — "First approach hit X, switching to Y"
-- **Major chunk done** — "Tests green, opening PR"
+So use \`progress_update\` **sparingly**, only when the user would genuinely want to know mid-task and could not infer it from the card:
 
-One short line per call. Skip for trivial one-shot tasks. Don't narrate every tool call — the parent card already shows your tool ring buffer.
+- **A blocker or pivot that changes the ETA** — "First approach hit X, switching to Y"
+- **A long silent stretch is starting** — "Running the full suite, ~10 min"
+- **A decision you are proceeding past** — "No staging creds, using the local fixture"
+
+Do NOT send one for starting work, for each file you read, or for "done" (your handback covers that). One short line per call. The gateway enforces at most one update per 20 seconds per chat and 5 per turn, and truncates at 300 chars — an over-limit call returns \`{ok:false, reason:"too_soon"|"turn_limit"}\` and sends nothing, which is not an error to retry around.
 
 Pass \`chat_id\` = \`${args.defaultChatId}\` unless the parent is handling a different chat in this turn, in which case use whatever chat_id the parent saw on its inbound message.
 

--- a/src/auth/broker/server-consumer-follow-active.test.ts
+++ b/src/auth/broker/server-consumer-follow-active.test.ts
@@ -21,6 +21,7 @@ import { AuthBroker } from "./server.js";
 import { decodeResponse, encodeRequest } from "./protocol.js";
 import type { SwitchroomConfig } from "../../config/schema.js";
 import { writeAccountCredentials } from "../account-store.js";
+import type { fetchQuota } from "../quota.js";
 
 interface Harness {
   tmp: string;
@@ -120,6 +121,32 @@ function seedAccount(h: Harness, label: string): void {
   );
 }
 
+/**
+ * Offline quota-probe seam — MANDATORY for every broker in this file.
+ *
+ * `mark-exhausted` awaits a LIVE quota probe inside the request path:
+ * `markExhaustedAndRoll` → `nextHealthyAccountLive` → `probeAndCacheOne` →
+ * `fetchQuota`, which force-probes every fallback candidate whose eligibility
+ * is still `unknown`. `fetchQuota`'s default abort is 10s (src/auth/quota.ts),
+ * i.e. more than 3x the `rpc()` deadline above, so an un-injected broker makes
+ * these tests latency-bound on api.anthropic.com — they fail with
+ * `Error: rpc timeout` whenever the runner's egress is slow (observed on CI:
+ * PR #3609 run 30152401449, vitest-shard 2).
+ *
+ * Returning a probe FAILURE keeps the exact selection semantics these tests
+ * have always exercised: the seeded tokens are fakes, so a real probe could
+ * only ever fail too — the candidate stays `unknown` and the selector takes it
+ * as the last-resort roll target.
+ */
+function offlineQuotaProbe(): { impl: typeof fetchQuota; calls: () => number } {
+  let calls = 0;
+  const impl: typeof fetchQuota = async () => {
+    calls += 1;
+    return { ok: false, reason: "test: offline quota probe (never calls api.anthropic.com)" };
+  };
+  return { impl, calls: () => calls };
+}
+
 describe("AuthBroker — unpinned consumer follows the fleet active", () => {
   it("get-credentials serves the fleet active when the consumer has no pin", async () => {
     const h = makeHarness();
@@ -129,6 +156,7 @@ describe("AuthBroker — unpinned consumer follows the fleet active", () => {
       consumers: [{ name: "hindsight" }],
     }), {
       home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: offlineQuotaProbe().impl,
     });
     await broker.start();
     const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {
@@ -151,6 +179,7 @@ describe("AuthBroker — unpinned consumer follows the fleet active", () => {
       consumers: [{ name: "hindsight", mirror_dir: mirrorDir }],
     }), {
       home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: offlineQuotaProbe().impl,
     });
     await broker.start();
     await rpc(join(h.socketRoot, "adm", "sock"), {
@@ -169,6 +198,7 @@ describe("AuthBroker — unpinned consumer follows the fleet active", () => {
     const h = makeHarness();
     seedAccount(h, "default");
     seedAccount(h, "secondary");
+    const probe = offlineQuotaProbe();
     const broker = new AuthBroker(makeConfig(h, {
       active: "default",
       fallback_order: ["default", "secondary"],
@@ -176,6 +206,7 @@ describe("AuthBroker — unpinned consumer follows the fleet active", () => {
       consumers: [{ name: "hindsight" }],
     }), {
       home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: probe.impl,
     });
     mkdirSync(join(h.agentsDir, "marker"), { recursive: true });
     await broker.start();
@@ -188,6 +219,10 @@ describe("AuthBroker — unpinned consumer follows the fleet active", () => {
       v: 1, id: "2", op: "get-credentials",
     }) as { ok: boolean; data: { account: string } };
     expect(resp.data.account).toBe("secondary");
+    // The roll's live candidate probe went through the injected seam, not the
+    // network. A zero here means someone dropped `_testFetchQuota` and this
+    // test is back to being latency-bound on api.anthropic.com.
+    expect(probe.calls()).toBeGreaterThan(0);
     broker.stop();
   });
 
@@ -195,12 +230,14 @@ describe("AuthBroker — unpinned consumer follows the fleet active", () => {
     const h = makeHarness();
     seedAccount(h, "default");
     seedAccount(h, "secondary");
+    const probe = offlineQuotaProbe();
     const broker = new AuthBroker(makeConfig(h, {
       active: "default",
       fallback_order: ["default", "secondary"],
       consumers: [{ name: "hindsight" }],
     }), {
       home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: probe.impl,
     });
     await broker.start();
     const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {
@@ -208,6 +245,8 @@ describe("AuthBroker — unpinned consumer follows the fleet active", () => {
     }) as { ok: boolean; data: { account: string } };
     expect(resp.ok).toBe(true);
     expect(resp.data.account).toBe("default");
+    // Same guard as above — the roll probed through the seam, never the wire.
+    expect(probe.calls()).toBeGreaterThan(0);
     broker.stop();
   });
 
@@ -219,6 +258,7 @@ describe("AuthBroker — unpinned consumer follows the fleet active", () => {
       consumers: [{ name: "hindsight" }],
     }), {
       home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: offlineQuotaProbe().impl,
     });
     await broker.start();
     const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {

--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -134,6 +134,20 @@ const TOOL_SCHEMAS = [
     },
   },
   {
+    name: 'progress_update',
+    description:
+      'Post a short interim progress line to Telegram mid-task ("still working through X"). Sends a NEW plain message to the chat — it is not an edit and not a card row, so use it sparingly and only when the user genuinely benefits from knowing where a long task stands. The gateway enforces its own limits: text is truncated at 300 chars, at most one update per 20s per chat+thread, and at most 5 per turn; over-limit calls return {ok:false, reason:"too_soon"|"turn_limit"} instead of sending. Prefer edit_message when you already own a message to update, and always deliver the actual answer with reply.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chat_id: { type: 'string', description: 'Chat to post the progress line in — pass chat_id from the inbound message.' },
+        text: { type: 'string', description: 'The progress line. One short sentence; truncated at 300 chars by the gateway.' },
+        message_thread_id: { type: 'string', description: 'Forum topic thread ID. Auto-applied from the last inbound message in the same chat if not specified.' },
+      },
+      required: ['chat_id', 'text'],
+    },
+  },
+  {
     name: 'react',
     description: 'Add an emoji reaction to a Telegram message. Telegram only accepts a fixed whitelist (👍 👎 ❤ 🔥 👀 🎉 etc) — non-whitelisted emoji will be rejected.',
     inputSchema: {

--- a/telegram-plugin/hooks/tool-label-pretool.mjs
+++ b/telegram-plugin/hooks/tool-label-pretool.mjs
@@ -97,6 +97,81 @@ function urlHostPath(u) {
 }
 
 /**
+ * ALLOWLIST-style summary of a Bash command, for when the model omitted the
+ * optional `description`.
+ *
+ * The failure this closes: `description` is optional, so a sub-agent that never
+ * writes one produced the constant label "Running a command" for EVERY Bash
+ * call. The worker feed's narrative dedup then dropped every repeat and the
+ * card froze on one line for the whole job — the user could not tell a running
+ * worker from a wedged one. The card must never depend on a model volunteering
+ * an optional field.
+ *
+ * SECURITY: a command line routinely carries tokens, passwords, URLs with
+ * credentials, and private paths, and this string is rendered into a Telegram
+ * message. So this is NOT a clip of the command — nothing is echoed unless it
+ * passes a strict allowlist:
+ *   - only the PROGRAM name (basename, no directory), and
+ *   - for a known multiplexer (git/docker/npm/…), at most one bare subcommand
+ *     of pure lowercase letters/hyphens.
+ * Anything with a slash, `=`, digit-mixed shape, quote, or any other character
+ * is refused and we fall back to the generic label. Arguments, flag VALUES,
+ * env assignments, redirections and heredocs are never considered at all.
+ *
+ * Returns '' when nothing safe can be derived (caller uses the generic label).
+ */
+export function summariseBashCommand(cmd) {
+  if (typeof cmd !== 'string') return ''
+  // First line only — a heredoc/multiline body must never be inspected.
+  const firstLine = cmd.split('\n', 1)[0]
+  if (!firstLine) return ''
+
+  // Split on shell separators and prefer the first segment that actually runs
+  // something (`cd /x && git status` should read as "git status", not "cd").
+  const NAV = new Set(['cd', 'pushd', 'popd', 'export', 'set', 'source', '.', 'unset'])
+  const PREFIXES = new Set(['sudo', 'env', 'nohup', 'time', 'exec', 'command', 'doas', 'runuser', 'nice', 'xargs'])
+  const segments = firstLine.split(/&&|\|\||[;|]/).map((s) => s.trim()).filter(Boolean)
+  if (segments.length === 0) return ''
+
+  const PROGRAM_RE = /^[A-Za-z][A-Za-z0-9._+-]{0,19}$/
+  const SUBCOMMAND_RE = /^[a-z][a-z-]{1,15}$/
+  const MULTIPLEXERS = new Set([
+    'git', 'docker', 'npm', 'npx', 'bun', 'yarn', 'pnpm', 'cargo', 'go', 'gh',
+    'kubectl', 'systemctl', 'apt', 'apt-get', 'brew', 'pip', 'pip3', 'poetry',
+    'uv', 'terraform', 'aws', 'gcloud', 'helm', 'switchroom', 'make', 'openssl',
+  ])
+
+  /** Program + optional subcommand for one segment, or null. */
+  function fromSegment(seg) {
+    let tokens = seg.split(/\s+/).filter(Boolean)
+    // Drop leading env assignments (FOO=bar) and wrapper prefixes.
+    while (tokens.length > 0 && (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0]) || PREFIXES.has(tokens[0]))) {
+      tokens = tokens.slice(1)
+    }
+    if (tokens.length === 0) return null
+    // Basename only: never surface a directory (paths leak layout, usernames).
+    const head = safeBasename(tokens[0])
+    if (!PROGRAM_RE.test(head)) return null
+    if (NAV.has(head)) return { program: head, nav: true }
+    if (!MULTIPLEXERS.has(head)) return { program: head, nav: false }
+    for (const t of tokens.slice(1)) {
+      if (t.startsWith('-')) continue
+      return SUBCOMMAND_RE.test(t) ? { program: `${head} ${t}`, nav: false } : { program: head, nav: false }
+    }
+    return { program: head, nav: false }
+  }
+
+  let firstAny = null
+  for (const seg of segments) {
+    const r = fromSegment(seg)
+    if (r == null) continue
+    if (firstAny == null) firstAny = r
+    if (!r.nav) return r.program
+  }
+  return firstAny != null ? firstAny.program : ''
+}
+
+/**
  * Compute a label for a (toolName, input) pair. Returns null when the
  * tool should NOT be labeled (suppress / fall through to existing
  * renderer precedence).
@@ -111,8 +186,15 @@ export function computeLabel(toolName, input) {
   // never reaches the live draft. Uses the model-authored `description`
   // for Bash/Task, matching the gateway's describeToolUse rendering.
   switch (toolName) {
-    case 'Bash':
-      return clip(asText(i.description), 70).trim() || 'Running a command'
+    case 'Bash': {
+      const described = clip(asText(i.description), 70).trim()
+      if (described) return described
+      // No model-authored description — derive a sanitised one from the
+      // command itself rather than emitting the constant "Running a command"
+      // that freezes the step feed. See summariseBashCommand.
+      const derived = summariseBashCommand(asText(i.command))
+      return derived ? `Running ${derived}` : 'Running a command'
+    }
     case 'Task':
     case 'Agent': {
       const d = clip(asText(i.description), 60).trim()

--- a/telegram-plugin/hooks/tool-label-pretool.mjs
+++ b/telegram-plugin/hooks/tool-label-pretool.mjs
@@ -154,11 +154,15 @@ export function summariseBashCommand(cmd) {
     if (!PROGRAM_RE.test(head)) return null
     if (NAV.has(head)) return { program: head, nav: true }
     if (!MULTIPLEXERS.has(head)) return { program: head, nav: false }
-    for (const t of tokens.slice(1)) {
-      if (t.startsWith('-')) continue
-      return SUBCOMMAND_RE.test(t) ? { program: `${head} ${t}`, nav: false } : { program: head, nav: false }
-    }
-    return { program: head, nav: false }
+    // ONLY the immediately-following token may be a subcommand. Scanning past
+    // flags would surface a flag VALUE (`docker --context prod-internal ps` →
+    // "prod-internal"), which is exactly the kind of private name this
+    // function exists to keep out of a chat message. `git -C /x status` losing
+    // its "status" is the correct trade.
+    const next = tokens[1]
+    return next != null && SUBCOMMAND_RE.test(next)
+      ? { program: `${head} ${next}`, nav: false }
+      : { program: head, nav: false }
   }
 
   let firstAny = null

--- a/telegram-plugin/tests/bridge-tool-parity.test.ts
+++ b/telegram-plugin/tests/bridge-tool-parity.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { buildEffectiveToolSchemas } from '../bridge/tool-filter.js'
+
+/**
+ * Half-wiring guard: every tool the gateway is willing to EXECUTE must be
+ * ADVERTISED by the bridge's MCP surface.
+ *
+ * The failure this pins (observed live 2026-07-25): `progress_update` was in
+ * the gateway's `ALLOWED_TOOLS` allowlist and had a full `executeProgressUpdate`
+ * implementation, but it was never carried over into `bridge/bridge.ts`'s
+ * `TOOL_SCHEMAS` when the legacy `server.ts` monolith was deleted (5496f792,
+ * Wave 3 F4). The monolith had registered it (7206817a); the bridge never did.
+ * Result: the tool was documented in every sub-agent's system prompt, executable
+ * by the gateway, and completely unreachable — a sub-agent calling it got
+ * "No such tool available". Nothing failed loudly; the capability just silently
+ * did not exist for ~14 months.
+ *
+ * Why structural (source text, not imports): `gateway.ts` has heavy import-time
+ * side effects (socket bind, bot construction) and `bridge.ts` exits the process
+ * at import when no gateway socket is present, so neither can be imported into a
+ * unit test. Both lists are plain string literals in source, so parsing them is
+ * exact and cheap. If either declaration is refactored out of the shape these
+ * regexes expect, the test FAILS (it never silently degrades to a no-op) —
+ * update the parser, don't delete the assertion.
+ */
+
+const PLUGIN_DIR = join(import.meta.dirname, '..')
+
+function readSource(rel: string): string {
+  return readFileSync(join(PLUGIN_DIR, rel), 'utf8')
+}
+
+/** Tool names in the gateway's IPC execution allowlist (`ALLOWED_TOOLS`). */
+function gatewayAllowedTools(): string[] {
+  const src = readSource('gateway/gateway.ts')
+  const m = src.match(/const ALLOWED_TOOLS = new Set\(\[([\s\S]*?)\]\)/)
+  if (m == null) throw new Error('could not locate ALLOWED_TOOLS in gateway/gateway.ts')
+  return [...m[1].matchAll(/'([a-z0-9_]+)'/g)].map((x) => x[1])
+}
+
+/** Tool names advertised by the bridge's MCP `tools/list` (`TOOL_SCHEMAS`). */
+function bridgeToolSchemaNames(): string[] {
+  const src = readSource('bridge/bridge.ts')
+  const m = src.match(/const TOOL_SCHEMAS = \[([\s\S]*?)\n\]\n/)
+  if (m == null) throw new Error('could not locate TOOL_SCHEMAS in bridge/bridge.ts')
+  return [...m[1].matchAll(/^ {4}name: '([a-z0-9_]+)',$/gm)].map((x) => x[1])
+}
+
+/**
+ * Tools deliberately executable-but-unadvertised. EMPTY on purpose.
+ *
+ * Adding a name here is a decision to make a capability unreachable by the
+ * model — it needs a comment naming the reason, not just an entry. The whole
+ * point of this file is that the omission is explicit and reviewed rather than
+ * an accident of a refactor.
+ */
+const INTENTIONALLY_UNADVERTISED: ReadonlySet<string> = new Set([])
+
+describe('bridge MCP tool surface ↔ gateway ALLOWED_TOOLS parity', () => {
+  it('parses both declarations (guards against a silently no-op test)', () => {
+    expect(gatewayAllowedTools().length).toBeGreaterThan(15)
+    expect(bridgeToolSchemaNames().length).toBeGreaterThan(15)
+  })
+
+  it('advertises every gateway-executable tool', () => {
+    const advertised = new Set(bridgeToolSchemaNames())
+    const missing = gatewayAllowedTools().filter(
+      (t) => !advertised.has(t) && !INTENTIONALLY_UNADVERTISED.has(t),
+    )
+    expect(missing).toEqual([])
+  })
+
+  it('advertises no tool the gateway would refuse to execute', () => {
+    const allowed = new Set(gatewayAllowedTools())
+    const orphans = bridgeToolSchemaNames().filter((t) => !allowed.has(t))
+    expect(orphans).toEqual([])
+  })
+
+  it('registers progress_update — the tool this guard was written for', () => {
+    expect(bridgeToolSchemaNames()).toContain('progress_update')
+    expect(gatewayAllowedTools()).toContain('progress_update')
+  })
+
+  it('keeps progress_update reachable through the tool-surface filter', () => {
+    // The Linear gate (tool-filter.ts) must not strip it, with or without a
+    // Linear connection: an unregistered-in-effect tool is the same outage.
+    const schemas = bridgeToolSchemaNames().map((name) => ({ name }))
+    for (const linearEnabled of [false, true]) {
+      const names = buildEffectiveToolSchemas(schemas, { linearEnabled }).map((t) => t.name)
+      expect(names).toContain('progress_update')
+    }
+  })
+})

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -21,8 +21,15 @@ describe("describeToolUse — friendly per-tool rendering (draft-mirror)", () =>
     expect(
       describeToolUse("Bash", { command: "ls -la /tmp", description: "List workspace" }),
     ).toBe("List workspace");
-    // No description → safe generic, still never the raw command.
-    expect(describeToolUse("Bash", { command: "grep -r foo ." })).toBe("Running a command");
+    // No description → sanitised PROGRAM-ONLY derivation, never the raw
+    // command (its args routinely carry tokens and private paths). The old
+    // behavior was a constant "Running a command" for every Bash call, which
+    // froze the sub-agent step feed on one line for a whole job.
+    expect(describeToolUse("Bash", { command: "grep -r foo ." })).toBe("Running grep");
+    // Nothing safe to derive → the generic label is still the floor.
+    expect(describeToolUse("Bash", { command: "$(cat /run/secrets/token) --x" })).toBe(
+      "Running a command",
+    );
   });
 
   it("Read/Edit/Write render the file basename, not the full path", () => {

--- a/telegram-plugin/tests/tool-label-pretool.test.ts
+++ b/telegram-plugin/tests/tool-label-pretool.test.ts
@@ -68,3 +68,77 @@ describe('computeLabel — surface-tool suppression is key-agnostic', () => {
     expect(computeLabel('mcp__clerk-telegram__get_recent_messages', {})).toBe('Reading chat history')
   })
 })
+
+// ─── Bash label without a model-authored description ─────────────────────
+//
+// `description` is OPTIONAL, so a sub-agent that never writes one used to
+// produce the constant "Running a command" for every Bash call — the worker
+// feed then deduped every repeat away and the card froze on one line for the
+// whole job. The fallback derives a label from the command, but ONLY through
+// an allowlist: program basename, plus one bare subcommand for known
+// multiplexers. Command lines carry tokens, passwords, credential URLs and
+// private paths, and this string is rendered into a Telegram message.
+describe('computeLabel — Bash fallback when description is omitted', () => {
+  it('prefers the model-authored description when present', () => {
+    expect(computeLabel('Bash', { command: 'git push origin main', description: 'Push branch' }))
+      .toBe('Push branch')
+  })
+
+  it('derives the program name when description is missing', () => {
+    expect(computeLabel('Bash', { command: 'grep -r foo .' })).toBe('Running grep')
+    expect(computeLabel('Bash', { command: 'ls -la /var/log' })).toBe('Running ls')
+  })
+
+  it('adds a bare subcommand for known multiplexers', () => {
+    expect(computeLabel('Bash', { command: 'git status --short' })).toBe('Running git status')
+    expect(computeLabel('Bash', { command: 'docker ps -a' })).toBe('Running docker ps')
+    expect(computeLabel('Bash', { command: 'npm run lint' })).toBe('Running npm run')
+  })
+
+  it('produces DISTINCT labels for distinct commands (the frozen-card fix)', () => {
+    const labels = [
+      'git status', 'npm test', 'ls /tmp', 'grep -n x y', 'docker logs c',
+    ].map((c) => computeLabel('Bash', { command: c }))
+    expect(new Set(labels).size).toBe(labels.length)
+  })
+
+  it('skips navigation prefixes and wrappers to the real program', () => {
+    expect(computeLabel('Bash', { command: 'cd /srv/app && git pull' })).toBe('Running git pull')
+    expect(computeLabel('Bash', { command: 'sudo systemctl restart nginx' }))
+      .toBe('Running systemctl restart')
+    expect(computeLabel('Bash', { command: 'FOO=bar deploy.sh' })).toBe('Running deploy.sh')
+  })
+
+  it('NEVER echoes arguments, flag values, URLs, or env assignments', () => {
+    const cases = [
+      'curl -H "Authorization: Bearer sk-live-abcdef123456" https://api.example.com/v1/x',
+      'psql postgres://user:hunter2@db.internal:5432/prod -c "select 1"',
+      'aws s3 cp s3://private-bucket/key.pem . --profile prod',
+      'export TOKEN=ghp_AAAABBBBCCCCDDDD && ./run',
+      'echo "sk-ant-oat01-SECRETVALUE" > /root/.creds',
+      'ssh deploy@10.0.0.7 -i /root/.ssh/id_ed25519',
+      'git clone https://x-access-token:ghs_SECRET@github.com/o/r.git',
+    ]
+    const forbidden = /sk-|ghp_|ghs_|hunter2|Bearer|SECRET|10\.0\.0\.7|@|:\/\/|=/
+    for (const command of cases) {
+      const label = computeLabel('Bash', { command })
+      expect(label).not.toBeNull()
+      expect(label).not.toMatch(forbidden)
+      // Whatever it says, it must be short and made of the allowlisted shape.
+      expect(label).toMatch(/^Running (a command|[A-Za-z][A-Za-z0-9._+-]{0,19}( [a-z][a-z-]{1,15})?)$/)
+    }
+  })
+
+  it('never inspects a heredoc / multiline body', () => {
+    const label = computeLabel('Bash', {
+      command: 'cat <<EOF > /tmp/x\nAPI_KEY=sk-live-shouldnotleak\nEOF',
+    })
+    expect(label).toBe('Running cat')
+  })
+
+  it('falls back to the generic label when nothing safe can be derived', () => {
+    expect(computeLabel('Bash', { command: '$(cat /run/secrets/token) --x' })).toBe('Running a command')
+    expect(computeLabel('Bash', {})).toBe('Running a command')
+    expect(computeLabel('Bash', { command: '   ' })).toBe('Running a command')
+  })
+})

--- a/telegram-plugin/tests/tool-label-pretool.test.ts
+++ b/telegram-plugin/tests/tool-label-pretool.test.ts
@@ -146,3 +146,19 @@ describe('computeLabel — Bash fallback when description is omitted', () => {
     expect(computeLabel('Bash', { command: '   ' })).toBe('Running a command')
   })
 })
+
+describe('computeLabel — Bash subcommand is never a flag value', () => {
+  it('only accepts the token IMMEDIATELY after a multiplexer', () => {
+    // A flag value (a private context/host/profile name) must never surface.
+    expect(computeLabel('Bash', { command: 'docker --context prod-internal ps' }))
+      .toBe('Running docker')
+    expect(computeLabel('Bash', { command: 'git -C /srv/private-app status' }))
+      .toBe('Running git')
+    expect(computeLabel('Bash', { command: 'aws --profile customer-acme s3 ls' }))
+      .toBe('Running aws')
+  })
+
+  it('still reads the plain subcommand form', () => {
+    expect(computeLabel('Bash', { command: 'git commit -m "wip"' })).toBe('Running git commit')
+  })
+})

--- a/telegram-plugin/tests/tool-label-pretool.test.ts
+++ b/telegram-plugin/tests/tool-label-pretool.test.ts
@@ -110,12 +110,16 @@ describe('computeLabel — Bash fallback when description is omitted', () => {
   })
 
   it('NEVER echoes arguments, flag values, URLs, or env assignments', () => {
+    // Token-shaped literals are assembled at runtime: GitHub Push Protection
+    // and check-no-pii-secrets both reject contiguous ones, fake or not
+    // (pattern from secret-detect-secretlint.test.ts).
+    const fakeAnthropic = 'sk-' + 'ant-oat01-FAKEVALUE'
     const cases = [
-      'curl -H "Authorization: Bearer sk-live-abcdef123456" https://api.example.com/v1/x',
+      'curl -H "Authorization: Bearer ' + 'sk-' + 'live-abcdef123456" https://api.example.com/v1/x',
       'psql postgres://user:hunter2@db.internal:5432/prod -c "select 1"',
       'aws s3 cp s3://private-bucket/key.pem . --profile prod',
       'export TOKEN=ghp_AAAABBBBCCCCDDDD && ./run',
-      'echo "sk-ant-oat01-SECRETVALUE" > /root/.creds',
+      `echo "${fakeAnthropic}" > /root/.creds`,
       'ssh deploy@10.0.0.7 -i /root/.ssh/id_ed25519',
       'git clone https://x-access-token:ghs_SECRET@github.com/o/r.git',
     ]

--- a/telegram-plugin/tests/worker-feed-repeat-steps.test.ts
+++ b/telegram-plugin/tests/worker-feed-repeat-steps.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createWorkerActivityFeed,
+  stripRepeatSuffix,
+  repeatCountOf,
+  type WorkerActivityView,
+  type BotApiForWorkerFeed,
+} from '../worker-activity-feed.js'
+
+/**
+ * A worker whose steps all carry the SAME label must still visibly advance.
+ *
+ * The bug (observed live 2026-07-25, klanker): `description` is optional on
+ * Bash, so a sub-agent that never wrote one produced the constant label
+ * "Running a command" for every call. `accumulateNarrative` dropped every
+ * repeat as a duplicate, and the card held ONE line at a constant byte length
+ * for the whole job — editMessageText kept succeeding, so the surface looked
+ * healthy while conveying nothing. A wedged worker and a busy worker rendered
+ * identically.
+ *
+ * The fix counts repeats (`·×N`) instead of discarding them, gated on
+ * `view.toolCount` so that a re-emitted UNCHANGED view (the watcher does this
+ * every tick) never inflates the count.
+ */
+
+function view(partial: Partial<WorkerActivityView> = {}): WorkerActivityView {
+  return {
+    description: 'fix the thing',
+    lastTool: { name: 'Bash', sanitisedArg: 'x' },
+    toolCount: 1,
+    latestSummary: 'Running a command',
+    elapsedMs: 10_000,
+    state: 'running',
+    ...partial,
+  }
+}
+
+interface FakeBot extends BotApiForWorkerFeed {
+  sent: Array<{ text: string }>
+  edits: Array<{ text: string }>
+}
+
+function makeFakeBot(): FakeBot {
+  let nextId = 1000
+  const fb: FakeBot = {
+    sent: [],
+    edits: [],
+    sendMessage: async (_chatId, text) => {
+      fb.sent.push({ text })
+      return { message_id: nextId++ }
+    },
+    editMessageText: async (_chatId, _messageId, text) => {
+      fb.edits.push({ text })
+      return {}
+    },
+  }
+  return fb
+}
+
+/** Latest rendered body for the group (last edit, else the first paint). */
+function latestBody(bot: FakeBot): string {
+  return bot.edits.length > 0 ? bot.edits[bot.edits.length - 1].text : bot.sent[0].text
+}
+
+describe('worker feed — repeated step labels', () => {
+  it('renders a climbing ·×N counter instead of freezing on one line', async () => {
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    for (let i = 1; i <= 5; i++) {
+      clock += 10_000
+      await feed.update('w1', 'chat', view({ toolCount: i, elapsedMs: clock }))
+    }
+
+    const body = latestBody(bot)
+    expect(body).toContain('Running a command ·×5')
+    // …and the frozen single-count line is gone from the newest render.
+    expect(body).not.toMatch(/Running a command\*{0,2}\s*$/m)
+  })
+
+  it('does NOT inflate the count when the watcher re-emits an unchanged view', async () => {
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    // Same toolCount across many ticks = the SAME tool call, re-observed.
+    for (let i = 0; i < 6; i++) {
+      clock += 5_000
+      await feed.update('w1', 'chat', view({ toolCount: 2, elapsedMs: clock }))
+    }
+
+    const body = latestBody(bot)
+    expect(body).toContain('Running a command')
+    expect(body).not.toContain('·×')
+  })
+
+  it('starts a NEW step (no counter) when the label actually changes', async () => {
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    clock += 10_000
+    await feed.update('w1', 'chat', view({ toolCount: 1, elapsedMs: clock }))
+    clock += 10_000
+    await feed.update('w1', 'chat', view({ toolCount: 2, elapsedMs: clock }))
+    clock += 10_000
+    await feed.update('w1', 'chat', view({ toolCount: 3, latestSummary: 'Running git status', elapsedMs: clock }))
+
+    const body = latestBody(bot)
+    expect(body).toContain('Running a command ·×2')
+    expect(body).toContain('Running git status')
+    expect(body).not.toContain('Running git status ·×')
+  })
+
+  it('keeps the non-adjacent A,B,A dedup (no duplicate step lines)', async () => {
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    const steps = ['Reading alpha.ts', 'Running grep', 'Reading alpha.ts']
+    for (const [i, summary] of steps.entries()) {
+      clock += 10_000
+      await feed.update('w1', 'chat', view({ toolCount: i + 1, latestSummary: summary, elapsedMs: clock }))
+    }
+
+    const body = latestBody(bot)
+    expect((body.match(/Reading alpha\.ts/g) ?? []).length).toBe(1)
+    // Non-adjacent repeats are dropped, not counted — the A,B,A duplication
+    // guard predates this change and stays intact.
+    expect(body).not.toContain('Reading alpha.ts ·×')
+  })
+})
+
+describe('repeat-suffix helpers', () => {
+  it('round-trips the marker', () => {
+    expect(stripRepeatSuffix('Running a command ·×12')).toBe('Running a command')
+    expect(stripRepeatSuffix('Running a command')).toBe('Running a command')
+    expect(repeatCountOf('Running a command')).toBe(1)
+    expect(repeatCountOf('Running a command ·×12')).toBe(12)
+  })
+
+  it('does not mistake ordinary text for a marker', () => {
+    expect(stripRepeatSuffix('Comparing 3 ×2 grids')).toBe('Comparing 3 ×2 grids')
+    expect(repeatCountOf('Comparing 3 ×2 grids')).toBe(1)
+  })
+})

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -143,6 +143,25 @@ export interface BotApiForWorkerFeed {
 const DESC_MAX = 80
 
 /**
+ * Repeat marker appended to a narrative step that fired more than once in a
+ * row (`Running a command ·×3`). Rendered inline on the step line so a worker
+ * whose every step carries the SAME label still visibly advances instead of
+ * freezing the card. `·` is already the card's separator glyph.
+ */
+const REPEAT_SUFFIX_RE = / ·×(\d+)$/
+
+/** The step text without its `·×N` marker (identity for dedup comparisons). */
+export function stripRepeatSuffix(line: string): string {
+  return line.replace(REPEAT_SUFFIX_RE, '')
+}
+
+/** How many times a step line has fired: 1 when it carries no marker. */
+export function repeatCountOf(line: string): number {
+  const m = REPEAT_SUFFIX_RE.exec(line)
+  return m == null ? 1 : Number(m[1])
+}
+
+/**
  * Thin adapter over the unified `renderStatusCard` primitive (emoji 🛠, label
  * 'Worker'): builds the header, passes raw narrative steps (the primitive runs
  * stripMarkdown → collapse ws → clip → escape per line), and on finish passes
@@ -428,6 +447,13 @@ interface WorkerRow {
    * live render so the feed reads like the main agent's answer.
    */
   narrative: string[]
+  /**
+   * `view.toolCount` observed when the newest narrative step was last recorded
+   * or counted. The repeat counter (`·×N`) increments only when toolCount has
+   * MOVED — the watcher re-emits an unchanged view every tick, so counting
+   * label-equality alone would inflate the number with no work behind it.
+   */
+  lastNarrativeToolCount: number | null
   /** Last view for this worker (drives the heartbeat re-render + combined row). */
   lastView: WorkerActivityView | null
   /** Latest state observed for this worker; excluded from the running set once
@@ -794,10 +820,33 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   function accumulateNarrative(row: WorkerRow, view: WorkerActivityView): void {
     const line = view.latestSummary.trim()
     if (line.length === 0) return
+
+    // A REPEAT of the current step is counted, not dropped. A worker whose
+    // steps all render the same label (e.g. Bash calls with no description →
+    // "Running a command") used to hit the dedup below on every tool call and
+    // the card held ONE frozen line for the whole job — indistinguishable from
+    // a wedged worker. `·×N` makes the repetition visible and, because a new
+    // count resets stepStartedAtMs, the climbing `· Ns` step timer restarts
+    // with each real call.
+    //
+    // Gated on `view.toolCount`, NOT on the label: the watcher re-emits an
+    // UNCHANGED view on every tick, so counting label-equality alone would
+    // inflate the number with no work behind it. One increment per observed
+    // tool call, deterministically.
+    const last = row.narrative.length > 0 ? row.narrative[row.narrative.length - 1] : null
+    if (last != null && stripRepeatSuffix(last) === line) {
+      if (view.toolCount === row.lastNarrativeToolCount) return
+      row.lastNarrativeToolCount = view.toolCount
+      row.narrative[row.narrative.length - 1] = `${line} ·×${repeatCountOf(last) + 1}`
+      row.stepStartedAtMs = nowFn()
+      return
+    }
+
     // Dedup within the whole rolling window (the watcher re-emits the same
     // narrative across ticks, and a preamble + its tool label can repeat
     // non-adjacently — the A,B,A duplication observed on live cards).
-    if (row.narrative.includes(line)) return
+    if (row.narrative.some((l) => stripRepeatSuffix(l) === line)) return
+    row.lastNarrativeToolCount = view.toolCount
     row.narrative.push(line)
     // The `→` current-step line just CHANGED — reset the per-step timer.
     row.stepStartedAtMs = nowFn()
@@ -1545,6 +1594,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           agentId,
           ordinal: ++g.workerOrdinalCounter,
           narrative: [],
+          lastNarrativeToolCount: null,
           lastView: null,
           state: 'running',
           finished: false,


### PR DESCRIPTION
## Summary

Five related fixes to the sub-agent progress feed and the Telegram plugin's Bash tool labelling. Branch predates today's work; pushing it so it can be reviewed rather than sitting unpushed on the host.

## Commits

- `fix(telegram)`: never take a flag VALUE as a Bash subcommand label
- `test(telegram)`: assemble token-shaped fixtures at runtime for `check-no-pii-secrets`
- `fix(agents)`: tell sub-agents what `progress_update` actually does
- `fix(telegram)`: stop the sub-agent step feed freezing on a repeated label
- `fix(telegram)`: register `progress_update` on the bridge MCP surface

## Test plan

CI is the authority. `telegram-plugin/tests/worker-feed-repeat-steps.test.ts` is new and covers the repeated-label freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
