### PR TITLE
fix(hindsight): split oversized retains so long transcripts can persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 ## Unreleased
 
+### Hindsight — bound retain content so oversized memories can persist at all (#3610)
+
+The sibling of #3599, not a duplicate of it. #3599 showed that 70.4% of the
+queue was already durable and being re-posted forever; this is about the
+remainder. A retain POST is not one model call — the daemon chunks content at
+`retain_chunk_size` (3000) and runs ONE sequential extraction call per chunk,
+so server wall time is linear in `len(content)` while the client holds a
+single deadline for the whole POST. Past the derived bound a retain cannot
+complete at ANY client deadline: it fails every attempt, burns `MAX_ATTEMPTS`
+and goes `.dead`. On the 2026-07-25 fleet backlog that was 154 of 629 entries
+(median content 26,112 chars, p90 150,224, max 744,546 — ~249 sequential
+extraction calls). A presence GET retires such an entry for free when the
+document IS already durable, which is #3599's fix; splitting is what makes it
+persist when it is NOT.
+
+- **The bound is enforced at `HindsightClient.retain()`** — the one function
+  every retain POST in the plugin goes through — and is derived, not chosen:
+  `retain_chunk_size × floor(client_deadline / chunk_latency)` =
+  `3000 × floor(280 / 18.4)` = 45,000 chars. All three inputs are
+  env-overridable. Splits are taken on transcript structure (JSON message
+  boundaries / `[role: …]…[…:end]` blocks), never a byte offset, and a split
+  message keeps its role envelope on every fragment.
+- **`timeout` is now the caller's TOTAL wall budget**, not a per-request read
+  deadline. Splitting must never turn one bounded POST into N of them: the
+  Stop hook's `timeout=15` would otherwise become `15 × N`.
+- **`pending.enqueue()` splits too**, into one entry PER PART, so no entry is
+  ever queued that the drainer cannot finish inside one deadline. Part
+  `document_id`s are deterministic (`{base}-p{i}of{n}`), so a part already
+  committed by the failed POST is upserted on drain, never duplicated. This
+  does raise queue DEPTH for oversized memories (one memory becomes N
+  entries) — that is the intended trade against entries that could never
+  drain, and both caps still bound the queue.
+- **`HINDSIGHT_DRAIN_BACKLOG_TIMEOUT` now defaults to the derived retain
+  client deadline (280s) instead of the `180` literal #3599 shipped.** Those
+  had to become one number: a maximally-sized part is ~276s of sequential
+  extraction, and #3611's DERIVED server per-call timeout is 204s — so under
+  180s the drain client abandoned requests the server was still legitimately
+  working on, which is the re-post loop #3599 fixed, one size class up.
+  `src/setup/hindsight.ts` already declared `HINDSIGHT_RETAIN_CLIENT_DEADLINE_S`
+  a mirror of the plugin constant; a test now enforces that rather than
+  trusting the comment.
+- **`enqueue()` refuses a memory whose PARTS TOGETHER exceed either cap**
+  (`HINDSIGHT_PENDING_MAX_BYTES` or `HINDSIGHT_PENDING_MAX_ENTRIES`). #3599's
+  guard measured one entry against one cap; after splitting, every part fits
+  individually, so the eviction loop becomes satisfiable and the later parts
+  evict the earlier parts *and* every unrelated queued memory — leaving a
+  tail fragment of one memory and nothing else. Worse than #3599's outcome,
+  so the guard is hoisted to the whole logical memory and given a count-cap
+  sibling.
+- **Split part ids stay inside #3599's free reconcile.**
+  `is_content_derived_document_id()` is anchored at the end of the id, so
+  `-p{i}of{n}` would have pushed every split part — by construction the
+  largest, most expensive entries in the queue — outside the presence-only
+  reconcile and into a full re-POST on every drain. The suffix is a pure
+  function of the same content the core id derives from, so it inherits the
+  core's verdict; a part suffix on a pre-#3244 bare session id still proves
+  nothing and is still refused.
+
 ### Hindsight — the pending-retains backlog was a re-post loop, not lost memory (#3596)
 
 The queue on this fleet grew to 5,751 entries. The cause was **not** that
@@ -21,7 +79,8 @@ extracted. Only 1,703 (29.6%) were genuinely absent.
   GETs the document and drops the entry if it already exists: no POST, no LLM
   work, no cost, resumable at any point — on the measured fleet that is 70% of
   the queue for free. Phase 2 posts only genuinely-absent entries with a
-  realistic timeout (`HINDSIGHT_DRAIN_BACKLOG_TIMEOUT`, 180s) and then
+  realistic timeout (`HINDSIGHT_DRAIN_BACKLOG_TIMEOUT`, which since #3610
+  defaults to the derived retain client deadline of 280s) and then
   **re-GETs to confirm the document before deleting the entry** —
   commit-before-delete, because a 200 is an ack and not proof (#3244). It is
   still `async_processing=False` for exactly that reason: deleting the queue

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -379,6 +379,25 @@ describe("hindsight broker-fed mode (#1245)", () => {
     expect(() => h.hindsightRetainBudgetEnv()).not.toThrow();
   });
 
+  it("keeps HINDSIGHT_RETAIN_CLIENT_DEADLINE_S equal to the plugin's own constant", async () => {
+    // #3611 declares this constant "mirrors DEFAULT_RETAIN_CLIENT_DEADLINE_S
+    // in vendor/hindsight-memory/scripts/lib/retain_split.py", and its budget
+    // assertion is only meaningful if that is TRUE. Two literals in two
+    // languages with a doc comment between them is not a mirror, it is a
+    // promise; this is the check that makes it one. The python side derives
+    // BOTH its content bound and the backlog drain's per-entry deadline from
+    // its copy (#3610), so a silent drift here reintroduces the re-post loop
+    // #3599 fixed, one size class up.
+    const h = await import("../../src/setup/hindsight.js");
+    const src = readFileSync(
+      join(process.cwd(), "vendor/hindsight-memory/scripts/lib/retain_split.py"),
+      "utf8",
+    );
+    const m = src.match(/^DEFAULT_RETAIN_CLIENT_DEADLINE_S\s*=\s*([0-9.]+)\s*$/m);
+    expect(m, "retain_split.py must define DEFAULT_RETAIN_CLIENT_DEADLINE_S").not.toBeNull();
+    expect(Number(m![1])).toBe(h.HINDSIGHT_RETAIN_CLIENT_DEADLINE_S);
+  });
+
   it("refuses to emit a budget where the server outlives the client deadline", async () => {
     const h = await import("../../src/setup/hindsight.js");
     // The 2026-07-25 shape: a ~190s job under a 90s deadline.

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -99,6 +99,7 @@ from lib.pending import (
     mark_dead,
     update_attempt,
 )
+from lib.retain_split import retain_client_deadline
 
 
 STALL_THRESHOLD = 3
@@ -200,8 +201,28 @@ def _backlog_timeout() -> int:
     A synchronous retain takes 30-90s on this fleet, so the SessionStart
     default (5-8s, further clamped by the hook budget) guarantees a
     client-side timeout on a request the server then commits anyway.
+
+    The default is DERIVED, not a literal: it is
+    ``retain_split.retain_client_deadline()`` (280s), the same deadline the
+    retain content bound is sized against. Those two must be ONE number.
+    This function shipped as a bare ``180`` (#3599), and against a 180s
+    deadline both halves of the retain budget break: a maximally-sized part
+    is ~276s of sequential extraction, and the SERVER per-call timeout
+    derived in ``src/setup/hindsight.ts`` (#3611) is 204s — so the drain
+    client would abandon a request the server is still legitimately working
+    on, leave the entry queued, and rebuild the re-post loop #3599 exists to
+    kill, one size class up.
+
+    ``HINDSIGHT_DRAIN_BACKLOG_TIMEOUT`` still overrides it outright;
+    ``HINDSIGHT_RETAIN_CLIENT_DEADLINE_S`` moves the derivation and the
+    content bound together.
     """
-    return _env_num("HINDSIGHT_DRAIN_BACKLOG_TIMEOUT", 180, int, lo=1)
+    return _env_num(
+        "HINDSIGHT_DRAIN_BACKLOG_TIMEOUT",
+        int(retain_client_deadline()),
+        int,
+        lo=1,
+    )
 
 
 def _backlog_budget_seconds() -> float:
@@ -640,7 +661,8 @@ def _drain_backlog_impl(
 
     # BUDGET GRANULARITY: checked between waves, not mid-wave, so a run can
     # overshoot `budget` by at most one wave — up to HINDSIGHT_DRAIN_BACKLOG_
-    # TIMEOUT (180s default) plus the confirming GETs. That is deliberate:
+    # TIMEOUT (280s default, `_backlog_timeout`) plus the confirming GETs.
+    # That is deliberate:
     # abandoning an in-flight wave would leave entries whose POST the server
     # is still committing, and the whole point of commit-before-delete is not
     # to guess about those. Unlike the in-hook drain (whose overshoot is

--- a/vendor/hindsight-memory/scripts/lib/client.py
+++ b/vendor/hindsight-memory/scripts/lib/client.py
@@ -11,6 +11,8 @@ import urllib.request
 from pathlib import Path
 from typing import Optional
 
+from .retain_split import part_document_id, part_metadata, split_retain_content
+
 DEFAULT_TIMEOUT = 15  # seconds
 HEALTH_CHECK_RETRIES = 3
 HEALTH_CHECK_DELAY = 2  # seconds
@@ -189,7 +191,56 @@ class HindsightClient:
         reconciliation) MUST use this so a bare async 200 can never falsely mark
         unpersisted work as committed. (Merge precondition: the daemon honours
         ``async=false`` as commit-before-ack — verified by the §1.1 probe.)
+
+        **Oversized content is split before it is posted** (``lib/retain_split``).
+        The daemon runs one sequential extraction LLM call per
+        ``retain_chunk_size`` (3000) chars, so server wall time is linear in
+        ``len(content)`` while the client has a single deadline for the whole
+        POST — past ~45,000 chars a retain cannot complete at ANY client
+        timeout and the memory is permanently unsaveable (measured: 154 of the
+        629 entries in the 2026-07-25 fleet backlog). This is the enforcement
+        point precisely because every retain POST in the plugin goes through
+        it, so the bound is code-enforced rather than left to each producer.
+
+        Parts are posted SEQUENTIALLY, each with the caller's ``timeout`` (the
+        timeout is a per-HTTP-request read deadline, and each part is its own
+        request) and each with the caller's ``async_processing`` — so a
+        durability caller still gets commit-before-ack per part. Any part
+        failing raises, exactly as an unsplit failure does, so the caller's
+        existing enqueue/retry handling is unchanged; already-committed parts
+        carry deterministic ids and are upserted, not duplicated, on retry.
         """
+        parts = split_retain_content(content)
+        total = len(parts)
+        response = None
+        for index, part in enumerate(parts):
+            response = self._retain_one(
+                bank_id=bank_id,
+                content=part,
+                document_id=part_document_id(document_id, index, total),
+                context=context,
+                metadata=part_metadata(metadata, index, total),
+                tags=tags,
+                timeout=timeout,
+                async_processing=async_processing,
+            )
+        if total > 1 and isinstance(response, dict):
+            response = dict(response)
+            response["split_parts"] = total
+        return response
+
+    def _retain_one(
+        self,
+        bank_id: str,
+        content: str,
+        document_id: str,
+        context: Optional[str],
+        metadata: Optional[dict],
+        tags: Optional[list],
+        timeout: int,
+        async_processing: bool,
+    ) -> dict:
+        """POST exactly one retain item. Raises on any HTTP/transport error."""
         path = f"/v1/default/banks/{urllib.parse.quote(bank_id, safe='')}/memories"
         item = {
             "content": content,

--- a/vendor/hindsight-memory/scripts/lib/client.py
+++ b/vendor/hindsight-memory/scripts/lib/client.py
@@ -5,6 +5,7 @@ Openclaw HindsightClient (client.js), adapted for Python stdlib.
 """
 
 import json
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -209,11 +210,33 @@ class HindsightClient:
         failing raises, exactly as an unsplit failure does, so the caller's
         existing enqueue/retry handling is unchanged; already-committed parts
         carry deterministic ids and are upserted, not duplicated, on retry.
+
+        ``timeout`` bounds the CALLER'S TOTAL WALL TIME, not just each HTTP
+        request. Splitting must never turn one bounded POST into N of them:
+        the Stop hook passes ``timeout=15`` because it has a hook budget to
+        respect, and ``15 × N`` would stall the session. Once the budget is
+        spent no further part is started and the call raises, so the caller's
+        existing enqueue path runs — and ``pending.enqueue`` queues the
+        remainder as bounded per-part entries the drainer can finish. The
+        parts already committed are upserted on that drain, not duplicated.
         """
         parts = split_retain_content(content)
         total = len(parts)
         response = None
+        deadline = time.monotonic() + timeout
+        part_timeout = timeout
         for index, part in enumerate(parts):
+            if index > 0:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"retain wall budget of {timeout}s exhausted after "
+                        f"{index}/{total} parts; remainder is enqueued for the "
+                        f"drainer"
+                    )
+                # Clamp the request deadline to what is left of the budget so
+                # the final part cannot overrun it either.
+                part_timeout = max(1, int(remaining))
             response = self._retain_one(
                 bank_id=bank_id,
                 content=part,
@@ -221,7 +244,7 @@ class HindsightClient:
                 context=context,
                 metadata=part_metadata(metadata, index, total),
                 tags=tags,
-                timeout=timeout,
+                timeout=part_timeout,
                 async_processing=async_processing,
             )
         if total > 1 and isinstance(response, dict):

--- a/vendor/hindsight-memory/scripts/lib/client.py
+++ b/vendor/hindsight-memory/scripts/lib/client.py
@@ -215,10 +215,14 @@ class HindsightClient:
         request. Splitting must never turn one bounded POST into N of them:
         the Stop hook passes ``timeout=15`` because it has a hook budget to
         respect, and ``15 × N`` would stall the session. Once the budget is
-        spent no further part is started and the call raises, so the caller's
-        existing enqueue path runs — and ``pending.enqueue`` queues the
-        remainder as bounded per-part entries the drainer can finish. The
-        parts already committed are upserted on that drain, not duplicated.
+        spent no further part is started and the call raises, exactly as an
+        unsplit failure does, so each caller's EXISTING failure path handles
+        the remainder: the hook paths (``retain.py``, ``subagent_retain.py``,
+        ``reconcile_tail.py``) enqueue, and ``pending.enqueue`` queues the
+        remainder as bounded per-part entries the drainer can finish; the
+        drain paths count an attempt and keep the entry;
+        ``backfill_transcripts.py`` logs and backs off. The parts already
+        committed are upserted on the next attempt, not duplicated.
         """
         parts = split_retain_content(content)
         total = len(parts)
@@ -231,8 +235,11 @@ class HindsightClient:
                 if remaining <= 0:
                     raise TimeoutError(
                         f"retain wall budget of {timeout}s exhausted after "
-                        f"{index}/{total} parts; remainder is enqueued for the "
-                        f"drainer"
+                        f"{index}/{total} parts; no further part was started. "
+                        f"The caller's own failure path decides the remainder: "
+                        f"the hook paths enqueue it (as bounded per-part "
+                        f"entries), the drain paths count an attempt and keep "
+                        f"the entry queued."
                     )
                 # Clamp the request deadline to what is left of the budget so
                 # the final part cannot overrun it either.

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -135,6 +135,24 @@ be written at all (disk full, permissions) even after making room. That
 residual case still must not be silent, so it is recorded in the
 ``pending-drops.json`` ledger — a sibling of the queue dir, like the
 eviction log, so it can never be mistaken for a queue entry.
+
+Bounded entries
+---------------
+``MAX_BYTES`` is about the QUEUE's capacity. A second, much smaller bound
+is about whether an entry can ever be DRAINED: ``enqueue()`` splits an
+oversized payload into one entry PER PART (``lib/retain_split``) instead
+of writing a single giant entry. This is load-bearing, not tidiness. The
+daemon runs one sequential extraction LLM call per ``retain_chunk_size``
+chars, so an entry above the derived content bound cannot complete inside
+ANY client deadline — including the 280s out-of-hook backlog deadline that
+``drain_pending._backlog_timeout()`` now takes from the same derivation.
+Such an entry fails every drain, burns its ``MAX_ATTEMPTS``, and is
+renamed ``.dead``: the mechanism that stranded 154 of the 629 entries in
+the 2026-07-25 fleet backlog. Note this is orthogonal to the re-post loop
+#3599 fixed — a presence GET retires an oversized entry for free when the
+document IS already durable; splitting is what makes the entry drainable
+when it is NOT. Part document_ids are deterministic, so a part already
+committed by the failed POST is upserted on drain, not duplicated.
 """
 
 from __future__ import annotations
@@ -148,6 +166,8 @@ import sys
 import time
 import uuid
 from typing import Optional
+
+from .retain_split import part_document_id, part_metadata, split_retain_content
 
 
 SCHEMA = 1
@@ -738,10 +758,16 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     ``client.retain()`` plus connection info (``api_url``, ``api_token``)
     so the drainer can rebuild the client without re-resolving config.
 
-    Returns the absolute path of the entry — which may be an EXISTING
-    identical entry (dedupe) — or ``None`` in the residual case where the
-    entry could not be written at all. Atomic: writes ``<name>.tmp`` then
-    renames to ``<name>``.
+    Oversized content is SPLIT into one entry PER PART before anything is
+    written, so no entry is ever queued that the drainer cannot finish
+    inside one client deadline (see "Bounded entries" above). Content at or
+    under the bound is written as a single entry exactly as before, with
+    the document_id and metadata untouched.
+
+    Returns the absolute path of the (first) written entry — which may be
+    an EXISTING identical entry (dedupe) — or ``None`` in the residual case
+    where NO part could be written at all. Atomic per entry: writes
+    ``<name>.tmp`` then renames to ``<name>``.
 
     A full queue no longer refuses the incoming entry: ``_evict_to_fit()``
     sheds the OLDEST entries into ``pending-evicted/`` instead. Refusing
@@ -750,6 +776,42 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     """
     d = _ensure_dir()
 
+    content = payload.get("content")
+    parts = split_retain_content(content) if isinstance(content, str) else [content]
+    total = len(parts)
+    if total <= 1:
+        return _enqueue_one(d, payload, error)
+
+    base_doc = payload.get("document_id", "conversation")
+    base_meta = payload.get("metadata")
+
+    first: Optional[str] = None
+    for index, part in enumerate(parts):
+        part_payload = dict(payload)
+        part_payload["content"] = part
+        part_payload["document_id"] = part_document_id(base_doc, index, total)
+        part_payload["metadata"] = part_metadata(base_meta, index, total)
+        # Each part goes through the FULL enqueue pipeline — dedupe, the
+        # MAX_BYTES refusal, eviction, the drop ledger — because each part
+        # is an independently drainable memory, not a fragment that only
+        # means something alongside its siblings. A part that cannot be
+        # written is recorded as a drop and the remaining parts still go in;
+        # returning ``None`` for the whole memory because part 7 of 9 hit
+        # ENOSPC would discard eight recoverable turns.
+        #
+        # A part CAN evict an earlier part of the same memory when the queue
+        # is already at its cap (eviction is FIFO and earlier parts are
+        # older). That is the same trade `_evict_to_fit` documents — the
+        # evicted part MOVES to ``pending-evicted/``, so it is shed, not
+        # destroyed, except under the sustained-ENOSPC case named there.
+        written = _enqueue_one(d, part_payload, error)
+        if written is not None and first is None:
+            first = written
+    return first
+
+
+def _enqueue_one(d: str, payload: dict, error: BaseException) -> Optional[str]:
+    """Write exactly ONE queue entry for ``payload``. See ``enqueue()``."""
     entry = dict(payload)
     entry["schema"] = SCHEMA
     entry["failed_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -215,9 +215,25 @@ EVICTIONS_LOG_KEEP_LINES = 2000
 #: ``{session_id}-r{start_uuid}-{end_uuid}``, or the legacy-transcript fallback
 #: ``{session_id}-r{sha256[:32]}``. ``subagent_retain.py`` uses the same recipe
 #: over a ``{session}-sub-{agent}`` composite key, so it matches too.
+#: A split retain appends ``-p{i}of{n}`` (``retain_split.part_document_id``).
+#: That suffix is a pure function of the SAME content the core id derives
+#: from — the split is deterministic in (content, bound) — so a part id is
+#: content-derived exactly when its core is, and must be reconcilable on
+#: presence for the same reason. Without this the split entries introduced by
+#: #3610 would be the ONLY entries excluded from #3599's free phase-1
+#: reconcile: every one would take a full re-POST forever, which is the
+#: re-post loop #3599 exists to kill, aimed at the largest entries in the
+#: queue. It does NOT loosen the pre-#3244 guard: a bare session id with a
+#: part suffix (``{session}-p2of5``) still has no content-derived core and
+#: still returns False.
 _UUID_RE = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+#: ``*``, not ``?``: a part queued under one bound and drained under a smaller
+#: one (an operator lowers ``HINDSIGHT_RETAIN_CLIENT_DEADLINE_S``) is re-split
+#: at POST time into ``{core}-p2of5-p1of2``. Still a pure function of content,
+#: still reconcilable; ``?`` would silently exclude it.
+_PART_SUFFIX_RE = r"(?:-p[0-9]+of[0-9]+)*"
 _CONTENT_DERIVED_ID_RE = re.compile(
-    r"-r(?:%s-%s|[0-9a-fA-F]{32})$" % (_UUID_RE, _UUID_RE)
+    r"-r(?:%s-%s|[0-9a-fA-F]{32})%s$" % (_UUID_RE, _UUID_RE, _PART_SUFFIX_RE)
 )
 
 
@@ -237,6 +253,12 @@ def is_content_derived_document_id(document_id) -> bool:
       it deletes a turn that was never committed — confirmed against a
       live entry on this fleet (525 KB of content, ``document_id`` a bare
       UUID, GET 200).
+
+    * **Split parts** (``{core}-p{i}of{n}``, #3610) inherit the verdict of
+      their core: the part suffix is derived from the same content, so a 200
+      on ``…-r{uuid}-{uuid}-p2of5`` proves that part's own content was
+      committed. A part suffix on a bare session id proves nothing and is
+      still False.
 
     Anything unrecognised is False: the safe direction is to keep the
     entry and let the POST path decide.
@@ -785,12 +807,41 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     base_doc = payload.get("document_id", "conversation")
     base_meta = payload.get("metadata")
 
-    first: Optional[str] = None
+    part_payloads = []
     for index, part in enumerate(parts):
         part_payload = dict(payload)
         part_payload["content"] = part
         part_payload["document_id"] = part_document_id(base_doc, index, total)
         part_payload["metadata"] = part_metadata(base_meta, index, total)
+        part_payloads.append(part_payload)
+
+    # #3599's "an entry larger than the whole cap can never fit" guard,
+    # applied to the whole LOGICAL memory rather than to one part, against
+    # BOTH caps. Splitting would otherwise defeat it: each part fits, so the
+    # eviction loop becomes satisfiable and every part gets written — but the
+    # parts together still exceed the cap, so the later parts evict the
+    # earlier parts of the same memory AND every unrelated memory already
+    # queued. The queue is left holding a tail fragment of one memory and
+    # nothing else: strictly worse than #3599's outcome of refusing the one
+    # memory that cannot fit, so refuse it here too.
+    total_bytes = sum(_entry_blob_bytes(p, error) for p in part_payloads)
+    if total_bytes > MAX_BYTES:
+        record_drop(payload, ValueError(
+            f"entry is {total_bytes} bytes across {total} parts, larger than "
+            f"the whole HINDSIGHT_PENDING_MAX_BYTES cap ({MAX_BYTES}); "
+            f"refusing this entry rather than evicting the entire queue for it"
+        ))
+        return None
+    if total > MAX_ENTRIES:
+        record_drop(payload, ValueError(
+            f"entry splits into {total} parts, more than the whole "
+            f"HINDSIGHT_PENDING_MAX_ENTRIES cap ({MAX_ENTRIES}); refusing "
+            f"this entry rather than evicting the entire queue for it"
+        ))
+        return None
+
+    first: Optional[str] = None
+    for part_payload in part_payloads:
         # Each part goes through the FULL enqueue pipeline — dedupe, the
         # MAX_BYTES refusal, eviction, the drop ledger — because each part
         # is an independently drainable memory, not a fragment that only
@@ -810,14 +861,31 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     return first
 
 
-def _enqueue_one(d: str, payload: dict, error: BaseException) -> Optional[str]:
-    """Write exactly ONE queue entry for ``payload``. See ``enqueue()``."""
+def _build_entry(payload: dict, error: BaseException) -> dict:
+    """The on-disk entry dict for ``payload``, exactly as it will be written."""
     entry = dict(payload)
     entry["schema"] = SCHEMA
     entry["failed_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     entry["error_class"] = type(error).__name__
     entry["error_message"] = _clip_error(error)
     entry.setdefault("attempt_count", 1)
+    return entry
+
+
+def _entry_blob_bytes(payload: dict, error: BaseException) -> int:
+    """Serialised size of the entry ``payload`` would be written as.
+
+    Shares ``_build_entry`` with ``_enqueue_one`` so the pre-split total-size
+    guard measures the same bytes the per-entry ``MAX_BYTES`` guard does; the
+    only field that varies between the two calls is ``failed_at``, whose
+    encoding is fixed-width.
+    """
+    return len(json.dumps(_build_entry(payload, error), ensure_ascii=False).encode("utf-8"))
+
+
+def _enqueue_one(d: str, payload: dict, error: BaseException) -> Optional[str]:
+    """Write exactly ONE queue entry for ``payload``. See ``enqueue()``."""
+    entry = _build_entry(payload, error)
 
     blob = json.dumps(entry, ensure_ascii=False)
     blob_bytes = len(blob.encode("utf-8"))

--- a/vendor/hindsight-memory/scripts/lib/retain_split.py
+++ b/vendor/hindsight-memory/scripts/lib/retain_split.py
@@ -1,0 +1,426 @@
+"""Deterministic size bound for retain content, with structure-preserving split.
+
+Why this exists
+---------------
+A retain POST is *not* one model call. The Hindsight daemon chunks the
+submitted content at ``retain_chunk_size`` chars and runs fact extraction as
+one **sequential** LLM call per chunk
+(``hindsight_api/config.py`` ``DEFAULT_RETAIN_CHUNK_SIZE = 3000``). So the
+server-side wall time of a retain is linear in ``len(content)``, while the
+client only ever gets ONE deadline for the whole POST. Past some content
+length, no client timeout can cover the work and the retain can never succeed
+— not on the live Stop hook, not on the SessionStart drain, not ever. Those
+memories are permanently unsaveable.
+
+Measured on the 2026-07-25 fleet backlog (629 queued entries): median content
+26,112 chars, p90 150,224, max 744,546. 154 entries exceeded 60,000 chars and
+burned the full client deadline on every attempt. A 744,546-char entry is
+~249 sequential extraction calls.
+
+Why the bound is enforced here and not server-side
+--------------------------------------------------
+The daemon *does* have an auto-splitter — ``retain_batch_tokens``
+(``DEFAULT_RETAIN_BATCH_TOKENS = 10_000``, "Max chars per sub-batch for async
+retain auto-splitting") — but it only applies on the ``async=True`` path.
+Every durability retain in this plugin posts ``async=False`` on purpose
+(commit-before-ack, switchroom #3244 §1.1): the 200 must prove durable
+persistence because a 200 is what lets the caller delete the queue entry and
+advance the watermark. So the one server-side mechanism that would help is
+structurally unavailable to us. It is also the wrong layer: the server
+receives an opaque string and could only cut it at a byte offset, whereas the
+plugin still knows the transcript's message structure and can cut on a
+message boundary.
+
+The bound is applied at ``HindsightClient.retain()`` — the single function
+every retain POST in this plugin goes through (Stop hook, SessionEnd,
+drain_pending, reconcile_tail, backfill_transcripts, subagent_retain) — so it
+is code-enforced for every present and future caller rather than something a
+producer has to remember.
+
+Splitting rules
+---------------
+Splits are taken on transcript structure, never on a raw byte offset, so a
+part is always a syntactically complete transcript with role attribution
+intact:
+
+* JSON transcript (``retainToolCalls`` default, a JSON array of
+  ``{role, content:[blocks]}``): split the array into groups; each part
+  re-serializes as a valid JSON array.
+* Text transcript (``[role: x]\\n…\\n[x:end]`` blocks joined by a blank
+  line): split on block boundaries; each part is a whole number of blocks.
+* An atom (one message / one block) larger than the bound is split at line
+  boundaries and each fragment is re-wrapped in the SAME role envelope, so
+  context is still attributed rather than stranded.
+* Last resort, only if the structural passes cannot get a part under the
+  bound (e.g. one unbroken 100k-char line): a hard character slice. The size
+  invariant wins over structure at that extreme, because a part over the
+  bound is a part that never persists at all.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# The bound — derived, not chosen
+# ---------------------------------------------------------------------------
+#
+#   max_content_chars = retain_chunk_size × floor(client_deadline / chunk_latency)
+#
+# Each input is a measured or read property of the deployment, not a taste
+# call, and each is env-overridable so the bound tracks the deployment:
+#
+#   retain_chunk_size  3000 s  — server-side chars per extraction chunk.
+#                               `hindsight_api/config.py`
+#                               DEFAULT_RETAIN_CHUNK_SIZE = 3000. One chunk =
+#                               one sequential LLM call.
+#   chunk_latency      18.4 s  — measured mean wall time of a healthy retain
+#                               extraction call, n=752, LiteLLM SpendLogs
+#                               2026-07-25 07:00–08:05 UTC (the 0–7,941
+#                               completion-token bucket; the runaway bucket is
+#                               a separate defect, fixed by capping
+#                               HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS).
+#   client_deadline     280 s  — the deadline of the DURABILITY path (the
+#                               supervised backlog drain), deliberately not
+#                               the live Stop hook's 15s. The live path is
+#                               allowed to miss its deadline: it enqueues to
+#                               pending-retains and the drain retries. Sizing
+#                               to 15s would cut content to a single chunk and
+#                               shred every transcript for no gain.
+#
+#   floor(280 / 18.4) = 15 chunks  →  15 × 3000 = 45,000 chars
+#
+# Sanity check against the same backlog: every entry at or below 60,000 chars
+# drained successfully inside the 280s deadline (observed per-entry times
+# 0.3s–153.4s at concurrency 3), so 45,000 sits inside demonstrated-good
+# territory with margin for a slower model or a busier box.
+DEFAULT_RETAIN_CHUNK_SIZE = 3000
+DEFAULT_RETAIN_CHUNK_LATENCY_S = 18.4
+DEFAULT_RETAIN_CLIENT_DEADLINE_S = 280.0
+
+# Absolute floor: one chunk. A bound below one chunk would split every
+# transcript into extraction-sized confetti and is never the right answer.
+MIN_RETAIN_CONTENT_CHARS = DEFAULT_RETAIN_CHUNK_SIZE
+
+
+def _env_number(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def retain_content_limit() -> int:
+    """Max chars of retain content that can complete inside the client deadline.
+
+    Recomputed per call (cheap) so a test or an operator can move an input via
+    the environment without reimporting the module.
+    """
+    override = os.environ.get("HINDSIGHT_RETAIN_MAX_CONTENT_CHARS")
+    if override:
+        try:
+            forced = int(override)
+            if forced > 0:
+                return max(MIN_RETAIN_CONTENT_CHARS, forced)
+        except (TypeError, ValueError):
+            pass
+
+    chunk_size = int(_env_number("HINDSIGHT_RETAIN_CHUNK_SIZE", DEFAULT_RETAIN_CHUNK_SIZE))
+    latency = _env_number("HINDSIGHT_RETAIN_CHUNK_LATENCY_S", DEFAULT_RETAIN_CHUNK_LATENCY_S)
+    deadline = _env_number("HINDSIGHT_RETAIN_CLIENT_DEADLINE_S", DEFAULT_RETAIN_CLIENT_DEADLINE_S)
+
+    chunks = int(deadline // latency)
+    if chunks < 1:
+        chunks = 1
+    return max(MIN_RETAIN_CONTENT_CHARS, chunk_size * chunks)
+
+
+# ---------------------------------------------------------------------------
+# Part identity
+# ---------------------------------------------------------------------------
+
+def part_document_id(document_id: str, index: int, total: int) -> str:
+    """Document id for part ``index`` (0-based) of ``total``.
+
+    ``total <= 1`` returns the id unchanged, so an unsplit retain keeps EXACTLY
+    the id it has today and its upsert convergence (retain.py
+    ``slice_document_id``) is untouched.
+
+    For a split, ``{base}-p{i}of{n}``: deterministic (same content + same bound
+    ⇒ same parts ⇒ same ids, so a retry upserts rather than duplicates), unique
+    per part (parts must never overwrite each other — that would be silent
+    loss), and prefix-preserving, so the ``{session_id}`` prefix probe in
+    ``client.list_session_document_ids`` still finds them.
+    """
+    if total <= 1:
+        return document_id
+    return f"{document_id}-p{index + 1}of{total}"
+
+
+def part_metadata(metadata: Optional[dict], index: int, total: int) -> dict:
+    """Metadata for part ``index`` of ``total``, carrying provenance.
+
+    Unsplit retains are returned untouched (a copy). A split stamps the part
+    position, so any one part says where it sits in the logical retain and the
+    base document id is recoverable from the part id's ``-p{i}of{n}`` suffix.
+    Values are strings to match the existing metadata convention
+    (``retain.py`` writes ``message_count`` as a string).
+    """
+    base = dict(metadata or {})
+    if total <= 1:
+        return base
+    base["retain_part_index"] = str(index + 1)
+    base["retain_part_count"] = str(total)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Splitting
+# ---------------------------------------------------------------------------
+
+_TEXT_BLOCK_SEP = "\n\n"
+
+
+def split_retain_content(content: str, max_chars: Optional[int] = None) -> list:
+    """Split ``content`` into parts each at most ``max_chars`` long.
+
+    Returns ``[content]`` unchanged when it already fits — the overwhelmingly
+    common case, and the one where behaviour must not change at all.
+
+    Guarantees, all asserted by the test suite:
+      * every part is non-empty and ``<= max_chars``
+      * concatenating the parts loses no *message*; only the pathological
+        single-unbreakable-line case cuts inside text
+      * the split is a pure function of (content, max_chars) — no clock, no
+        randomness — so retries converge on identical parts and identical ids
+    """
+    limit = max_chars if (max_chars and max_chars > 0) else retain_content_limit()
+    # Non-string / empty content is passed straight through: the retain path's
+    # existing behaviour for it is not this module's business to change.
+    if not isinstance(content, str) or len(content) <= limit:
+        return [content]
+
+    parts = _split_json(content, limit)
+    if parts is None:
+        parts = _split_text(content, limit)
+
+    # Normalisation: structure-preserving passes are best-effort; the size
+    # bound is not. Anything still over the limit gets hard-sliced, because a
+    # part over the limit is a part that never persists.
+    normalised: list = []
+    for part in parts:
+        if len(part) <= limit:
+            if part:
+                normalised.append(part)
+        else:
+            normalised.extend(_hard_split(part, limit))
+    return normalised or [content[:limit]]
+
+
+def _hard_split(text: str, limit: int) -> list:
+    """Last-resort fixed-width slice. Always satisfies the bound."""
+    return [text[i : i + limit] for i in range(0, len(text), limit)] or [""]
+
+
+def _json_dump(value) -> str:
+    # Must match _prepare_json_transcript in lib/content.py exactly, or a part
+    # would measure differently here than it serialises there.
+    return json.dumps(value, indent=None, ensure_ascii=False)
+
+
+def _split_json(content: str, limit: int) -> Optional[list]:
+    """Split a JSON-array transcript on message boundaries.
+
+    Returns ``None`` (not a partial result) when ``content`` is not the JSON
+    transcript shape, so the caller falls through to the text splitter.
+    """
+    stripped = content.lstrip()
+    if not stripped.startswith("["):
+        return None
+    try:
+        messages = json.loads(content)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(messages, list) or not messages:
+        return None
+
+    # Expand any single message that cannot fit on its own, so the grouping
+    # pass below only ever sees messages that individually fit.
+    expanded: list = []
+    for message in messages:
+        serialised = _json_dump([message])
+        if len(serialised) <= limit:
+            expanded.append(message)
+        else:
+            expanded.extend(_split_json_message(message, limit))
+
+    parts: list = []
+    group: list = []
+    for message in expanded:
+        candidate = group + [message]
+        if group and len(_json_dump(candidate)) > limit:
+            parts.append(_json_dump(group))
+            group = [message]
+        else:
+            group = candidate
+    if group:
+        parts.append(_json_dump(group))
+    return parts
+
+
+def _split_json_message(message, limit: int) -> list:
+    """Split ONE oversized JSON message into several same-role messages.
+
+    Preserves the role envelope on every fragment: the model still sees who
+    said what, which is the context that a naive byte cut strands.
+    """
+    if not isinstance(message, dict):
+        return [message]
+    role = message.get("role", "unknown")
+    blocks = message.get("content")
+    if not isinstance(blocks, list) or not blocks:
+        return [message]
+
+    # Envelope cost of a one-message array with no blocks — the budget that
+    # blocks have to fit inside.
+    envelope = len(_json_dump([{"role": role, "content": []}]))
+    budget = limit - envelope
+    if budget <= 0:
+        return [message]
+
+    # Expand oversized individual blocks first (a single giant tool_result).
+    atoms: list = []
+    for block in blocks:
+        if len(_json_dump(block)) <= budget:
+            atoms.append(block)
+        else:
+            atoms.extend(_split_json_block(block, budget))
+
+    out: list = []
+    group: list = []
+    for atom in atoms:
+        candidate = group + [atom]
+        if group and len(_json_dump(candidate)) > budget:
+            out.append({"role": role, "content": group})
+            group = [atom]
+        else:
+            group = candidate
+    if group:
+        out.append({"role": role, "content": group})
+    return out or [message]
+
+
+def _split_json_block(block, budget: int) -> list:
+    """Split one oversized content block by slicing its longest text field."""
+    if not isinstance(block, dict):
+        return [block]
+    field = None
+    for candidate in ("text", "content", "input", "output"):
+        if isinstance(block.get(candidate), str) and block[candidate]:
+            field = candidate
+            break
+    if field is None:
+        return [block]
+
+    # Room the text has once the rest of the block is serialised.
+    skeleton = dict(block)
+    skeleton[field] = ""
+    room = budget - len(_json_dump(skeleton))
+    if room <= 0:
+        return [block]
+
+    out = []
+    for fragment in _split_text_by_lines(block[field], room):
+        clone = dict(block)
+        clone[field] = fragment
+        out.append(clone)
+    return out or [block]
+
+
+def _split_text(content: str, limit: int) -> list:
+    """Split a ``[role: x]…[x:end]`` transcript on block boundaries."""
+    blocks = content.split(_TEXT_BLOCK_SEP)
+
+    expanded: list = []
+    for block in blocks:
+        if len(block) <= limit:
+            expanded.append(block)
+        else:
+            expanded.extend(_split_text_block(block, limit))
+
+    parts: list = []
+    group: list = []
+    group_len = 0
+    sep_len = len(_TEXT_BLOCK_SEP)
+    for block in expanded:
+        added = len(block) + (sep_len if group else 0)
+        if group and group_len + added > limit:
+            parts.append(_TEXT_BLOCK_SEP.join(group))
+            group, group_len = [block], len(block)
+        else:
+            group.append(block)
+            group_len += added
+    if group:
+        parts.append(_TEXT_BLOCK_SEP.join(group))
+    return parts
+
+
+def _split_text_block(block: str, limit: int) -> list:
+    """Split one oversized ``[role: x]…[x:end]`` block, re-wrapping each part.
+
+    Falls back to a plain line split when the block is not in the marker form
+    (e.g. a legacy flat transcript), which the caller's normalisation pass
+    then hard-slices if any fragment is still over the bound.
+    """
+    lines = block.split("\n")
+    if len(lines) < 3 or not lines[0].startswith("[role: ") or not lines[-1].endswith(":end]"):
+        return _split_text_by_lines(block, limit)
+
+    header, footer = lines[0], lines[-1]
+    body = "\n".join(lines[1:-1])
+    # +2 for the two newlines that rejoin header/body/footer.
+    room = limit - len(header) - len(footer) - 2
+    if room <= 0:
+        return _split_text_by_lines(block, limit)
+    return [f"{header}\n{fragment}\n{footer}" for fragment in _split_text_by_lines(body, room)]
+
+
+def _split_text_by_lines(text: str, limit: int) -> list:
+    """Group whole lines into fragments of at most ``limit`` chars.
+
+    A single line longer than ``limit`` is hard-sliced — the only place this
+    module cuts inside a line, and unavoidable: an unbroken 100k-char line has
+    no structural boundary to cut on.
+    """
+    if limit <= 0:
+        return [text]
+    if len(text) <= limit:
+        return [text]
+
+    out: list = []
+    buf: list = []
+    buf_len = 0
+    for line in text.split("\n"):
+        if len(line) > limit:
+            if buf:
+                out.append("\n".join(buf))
+                buf, buf_len = [], 0
+            out.extend(_hard_split(line, limit))
+            continue
+        added = len(line) + (1 if buf else 0)
+        if buf and buf_len + added > limit:
+            out.append("\n".join(buf))
+            buf, buf_len = [line], len(line)
+        else:
+            buf.append(line)
+            buf_len += added
+    if buf:
+        out.append("\n".join(buf))
+    return out or [text]

--- a/vendor/hindsight-memory/scripts/lib/retain_split.py
+++ b/vendor/hindsight-memory/scripts/lib/retain_split.py
@@ -84,12 +84,22 @@ from typing import Optional
 #                               a separate defect, fixed by capping
 #                               HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS).
 #   client_deadline     280 s  — the deadline of the DURABILITY path (the
-#                               supervised backlog drain), deliberately not
-#                               the live Stop hook's 15s. The live path is
+#                               out-of-hook backlog drain, #3599), deliberately
+#                               not the live Stop hook's 15s. The live path is
 #                               allowed to miss its deadline: it enqueues to
 #                               pending-retains and the drain retries. Sizing
 #                               to 15s would cut content to a single chunk and
 #                               shred every transcript for no gain.
+#                               This is the ONE definition of that deadline:
+#                               `drain_pending._backlog_timeout()` defaults to
+#                               `retain_client_deadline()` rather than a second
+#                               literal, and `src/setup/hindsight.ts`
+#                               (`HINDSIGHT_RETAIN_CLIENT_DEADLINE_S`, #3611)
+#                               mirrors it as the client half of that PR's
+#                               `server per-call timeout < client deadline`
+#                               assertion — which its derived 204s server
+#                               timeout satisfies against 280 and would NOT
+#                               against #3599's original 180s literal.
 #
 #   floor(280 / 18.4) = 15 chunks  →  15 × 3000 = 45,000 chars
 #
@@ -117,6 +127,19 @@ def _env_number(name: str, default: float) -> float:
     return value if value > 0 else default
 
 
+def retain_client_deadline() -> float:
+    """Seconds a DURABILITY caller waits for one retain POST.
+
+    The single definition of that deadline. ``retain_content_limit()`` sizes
+    content so a whole POST fits inside it, and
+    ``drain_pending._backlog_timeout()`` takes it as its default so the drainer
+    actually waits that long — a shorter drain deadline would abandon a
+    correctly-sized part mid-extraction and rebuild the very re-post loop #3599
+    fixed, one size class up.
+    """
+    return _env_number("HINDSIGHT_RETAIN_CLIENT_DEADLINE_S", DEFAULT_RETAIN_CLIENT_DEADLINE_S)
+
+
 def retain_content_limit() -> int:
     """Max chars of retain content that can complete inside the client deadline.
 
@@ -134,7 +157,7 @@ def retain_content_limit() -> int:
 
     chunk_size = int(_env_number("HINDSIGHT_RETAIN_CHUNK_SIZE", DEFAULT_RETAIN_CHUNK_SIZE))
     latency = _env_number("HINDSIGHT_RETAIN_CHUNK_LATENCY_S", DEFAULT_RETAIN_CHUNK_LATENCY_S)
-    deadline = _env_number("HINDSIGHT_RETAIN_CLIENT_DEADLINE_S", DEFAULT_RETAIN_CLIENT_DEADLINE_S)
+    deadline = retain_client_deadline()
 
     chunks = int(deadline // latency)
     if chunks < 1:

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -34,6 +34,7 @@ if SCRIPTS_DIR not in sys.path:
 
 import drain_pending  # noqa: E402
 import lib.pending as pending  # noqa: E402
+import lib.retain_split as retain_split  # noqa: E402
 
 CONFIG = {"debug": False}
 
@@ -87,6 +88,11 @@ class _QueueTempDirMixin:
         "HINDSIGHT_DRAIN_SLEEP_S",
         "HINDSIGHT_DRAIN_P95_CMD",
         "HINDSIGHT_DRAIN_P95_BACKOFF_MS",
+        # `_backlog_timeout` derives its default from this (#3610), so an
+        # ambient value would silently move the assertions below.
+        "HINDSIGHT_RETAIN_CLIENT_DEADLINE_S",
+        # The retain content bound, which decides whether `enqueue` splits.
+        "HINDSIGHT_RETAIN_MAX_CONTENT_CHARS",
     )
 
     def setUp(self):
@@ -565,6 +571,59 @@ class DropLedgerTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(pending.count(), 20, "every other entry survived")
         self.assertIn("larger than the whole", err.getvalue())
         self.assertEqual(pending.read_drops()["count"], 1)
+
+    def test_a_memory_with_more_parts_than_the_count_cap_is_refused(self):
+        """The count-cap sibling of the byte-cap guard (#3610).
+
+        Splitting turns one memory into N entries, so the count cap can be
+        blown the same way the byte cap can — and with a satisfiable eviction
+        loop the later parts shed the earlier ones plus everything already
+        queued, leaving a tail fragment and nothing else. Refuse instead.
+        """
+        pending.MAX_ENTRIES = 4
+        pending.MAX_BYTES = 10**9  # only the COUNT cap may fire here
+        for i in range(3):
+            pending.enqueue(_payload(content=f"turn-{i}", doc=f"d{i}"), RuntimeError("x"))
+        self.assertEqual(pending.count(), 3)
+
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        try:
+            with redirect_stderr(io.StringIO()) as err:
+                got = pending.enqueue(
+                    _payload(content="z" * 30_000, doc=_cd_doc(9)), RuntimeError("x")
+                )
+        finally:
+            os.environ.pop("HINDSIGHT_RETAIN_MAX_CONTENT_CHARS", None)
+
+        self.assertIsNone(got, "a 10-part memory under a 4-entry cap is refused")
+        self.assertEqual(pending.count(), 3, "every other entry survived")
+        self.assertIn("more than the whole", err.getvalue())
+        self.assertEqual(pending.read_drops()["count"], 1)
+
+    def test_a_split_that_fits_the_count_cap_is_still_queued_per_part(self):
+        """The other side of that boundary: refusal must not swallow a
+        memory the queue can actually hold."""
+        pending.MAX_ENTRIES = 20
+        pending.MAX_BYTES = 10**9
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        try:
+            got = pending.enqueue(
+                _payload(content="z" * 30_000, doc=_cd_doc(9)), RuntimeError("x")
+            )
+        finally:
+            os.environ.pop("HINDSIGHT_RETAIN_MAX_CONTENT_CHARS", None)
+
+        self.assertIsNotNone(got)
+        self.assertEqual(pending.count(), 10, "one entry per part")
+        self.assertEqual(pending.read_drops(), {}, "nothing was dropped")
+        docs = sorted(e["document_id"] for _p, e in pending.iter_entries())
+        self.assertEqual(docs[0], f"{_cd_doc(9)}-p10of10")
+        for _p, entry in pending.iter_entries():
+            self.assertLessEqual(len(entry["content"]), 3000)
+            self.assertTrue(
+                pending.is_content_derived_document_id(entry["document_id"]),
+                "every queued part stays inside the free presence reconcile",
+            )
 
     def test_an_entry_exactly_at_the_byte_cap_is_enqueued_not_dropped(self):
         """``blob_bytes > MAX_BYTES``, not ``>=`` (#3599 review R4-La).
@@ -1193,6 +1252,56 @@ class PresenceReconcileGateTest(_QueueTempDirMixin, unittest.TestCase):
                 pending.is_content_derived_document_id(bad), f"must not accept {bad!r}"
             )
 
+    def test_a_split_part_inherits_the_verdict_of_its_core_id(self):
+        """#3610's part ids must stay inside #3599's free reconcile.
+
+        The gate is anchored at the end of the id, so ``-p{i}of{n}`` would
+        otherwise push EVERY split part outside it — and split parts are, by
+        construction, the largest and most expensive entries in the queue.
+        Each would take a full re-POST on every drain instead of a sub-second
+        presence GET: the re-post loop #3599 fixed, aimed at the worst case.
+
+        The suffix must not rescue a pre-#3244 id, which is the whole point
+        of the gate, so both directions are asserted here.
+        """
+        core = _cd_doc(1)
+        for total in (2, 5, 12, 249):
+            for index in range(min(total, 3)):
+                part = retain_split.part_document_id(core, index, total)
+                self.assertTrue(
+                    pending.is_content_derived_document_id(part),
+                    f"a split part of a content-derived id is content-derived: {part!r}",
+                )
+        # sha256 fallback core, and the sub-agent namespace, split too
+        self.assertTrue(
+            pending.is_content_derived_document_id(f"{SESSION}-r" + "a1" * 16 + "-p1of3")
+        )
+        self.assertTrue(
+            pending.is_content_derived_document_id(
+                f"{SESSION}-sub-worker7-r{_uuid(1)}-{_uuid(2)}-p2of4"
+            )
+        )
+        # A part re-split under a lowered bound nests its suffix, and is still
+        # a pure function of content.
+        self.assertTrue(
+            pending.is_content_derived_document_id(
+                retain_split.part_document_id(
+                    retain_split.part_document_id(core, 1, 5), 0, 2
+                )
+            )
+        )
+        # A part suffix on a PRE-#3244 id still proves nothing.
+        for bad in (
+            f"{self.BARE_SESSION_ID}-p1of3",
+            "conversation-p2of2",
+            f"{SESSION}-r{_uuid(1)}-p1of2",  # only one uuid: not the slice shape
+            f"{core}-pXofY",  # not the emitted suffix shape
+            f"{core}-p1of2-trailing",  # suffix must be terminal
+        ):
+            self.assertFalse(
+                pending.is_content_derived_document_id(bad), f"must not accept {bad!r}"
+            )
+
     def _queue_bare(self, n=2):
         for i in range(n):
             pending.enqueue(
@@ -1567,12 +1676,50 @@ class ClampAndEnvKnobBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(drain_pending._backlog_concurrency(), 16)
 
     def test_env_num_falls_back_to_the_default_on_garbage(self):
+        default = int(retain_split.retain_client_deadline())
         os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = "not-a-number"
-        self.assertEqual(drain_pending._backlog_timeout(), 180)
+        self.assertEqual(drain_pending._backlog_timeout(), default)
         os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = ""
         self.assertEqual(
-            drain_pending._backlog_timeout(), 180, "empty is unset, not 0"
+            drain_pending._backlog_timeout(), default, "empty is unset, not 0"
         )
+
+    def test_the_backlog_timeout_defaults_to_the_retain_client_deadline(self):
+        """The drain deadline and the content bound are ONE number (#3610).
+
+        A maximally-sized part is sized to just fit inside
+        ``retain_client_deadline()``. If the drainer's own deadline were
+        shorter — as the ``180`` literal #3599 shipped was — it would abandon a
+        correctly-sized part mid-extraction, leave the entry queued, and
+        rebuild the re-post loop #3599 fixed. Moving the deadline must move
+        both, so this asserts the derivation, not the number.
+        """
+        os.environ.pop("HINDSIGHT_DRAIN_BACKLOG_TIMEOUT", None)
+        os.environ.pop("HINDSIGHT_RETAIN_CLIENT_DEADLINE_S", None)
+        self.assertEqual(drain_pending._backlog_timeout(), 280)
+
+        os.environ["HINDSIGHT_RETAIN_CLIENT_DEADLINE_S"] = "600"
+        try:
+            self.assertEqual(
+                drain_pending._backlog_timeout(),
+                600,
+                "moving the client deadline must move the drain deadline",
+            )
+            self.assertEqual(
+                retain_split.retain_content_limit(),
+                3000 * int(600 // 18.4),
+                "and the content bound, from the same input",
+            )
+        finally:
+            os.environ.pop("HINDSIGHT_RETAIN_CLIENT_DEADLINE_S", None)
+
+    def test_an_explicit_backlog_timeout_still_overrides_the_derivation(self):
+        os.environ["HINDSIGHT_RETAIN_CLIENT_DEADLINE_S"] = "600"
+        os.environ["HINDSIGHT_DRAIN_BACKLOG_TIMEOUT"] = "42"
+        try:
+            self.assertEqual(drain_pending._backlog_timeout(), 42)
+        finally:
+            os.environ.pop("HINDSIGHT_RETAIN_CLIENT_DEADLINE_S", None)
 
     def test_no_clamp_is_applied_when_lo_and_hi_are_absent(self):
         """``lo``/``hi`` default to ``None``; that branch must be a no-op,

--- a/vendor/hindsight-memory/scripts/tests/test_retain_split.py
+++ b/vendor/hindsight-memory/scripts/tests/test_retain_split.py
@@ -1,0 +1,304 @@
+"""Oversized retain content must be bounded and split before it is POSTed.
+
+These tests assert the OUTCOME of the fix, not that a function runs: each one
+fails against the pre-fix code, where ``client.retain()`` posted a single item
+of unbounded length. The bug being fixed is that the daemon runs one
+sequential extraction LLM call per 3000 chars, so a 744k-char retain is ~249
+sequential calls and can never complete inside any client deadline — the
+memory is permanently unsaveable.
+"""
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lib import retain_split  # noqa: E402
+from lib.client import HindsightClient  # noqa: E402
+from lib.retain_split import (  # noqa: E402
+    part_document_id,
+    part_metadata,
+    retain_content_limit,
+    split_retain_content,
+)
+
+
+def _json_transcript(n_messages: int, chars_each: int) -> str:
+    return json.dumps(
+        [
+            {"role": "user" if i % 2 == 0 else "assistant",
+             "content": [{"type": "text", "text": "x" * chars_each}]}
+            for i in range(n_messages)
+        ],
+        indent=None,
+        ensure_ascii=False,
+    )
+
+
+def _text_transcript(n_blocks: int, chars_each: int) -> str:
+    return "\n\n".join(
+        f"[role: user]\n{'y' * chars_each}\n[user:end]" for _ in range(n_blocks)
+    )
+
+
+class TestDerivedLimit(unittest.TestCase):
+    def tearDown(self):
+        for key in (
+            "HINDSIGHT_RETAIN_MAX_CONTENT_CHARS",
+            "HINDSIGHT_RETAIN_CHUNK_SIZE",
+            "HINDSIGHT_RETAIN_CHUNK_LATENCY_S",
+            "HINDSIGHT_RETAIN_CLIENT_DEADLINE_S",
+        ):
+            os.environ.pop(key, None)
+
+    def test_limit_is_chunk_size_times_chunks_that_fit_the_deadline(self):
+        # chunk_size * floor(deadline / latency) = 3000 * floor(280/18.4) = 45000
+        self.assertEqual(retain_content_limit(), 45000)
+
+    def test_limit_is_derived_from_chunk_size_not_a_constant(self):
+        os.environ["HINDSIGHT_RETAIN_CHUNK_SIZE"] = "1000"
+        self.assertEqual(retain_content_limit(), 15000)
+
+    def test_limit_tracks_the_client_deadline(self):
+        os.environ["HINDSIGHT_RETAIN_CLIENT_DEADLINE_S"] = "92"
+        # floor(92 / 18.4) = 5 chunks
+        self.assertEqual(retain_content_limit(), 15000)
+
+    def test_limit_never_falls_below_one_chunk(self):
+        os.environ["HINDSIGHT_RETAIN_CLIENT_DEADLINE_S"] = "1"
+        self.assertEqual(retain_content_limit(), 3000)
+
+    def test_garbage_env_falls_back_to_the_derived_default(self):
+        os.environ["HINDSIGHT_RETAIN_CHUNK_LATENCY_S"] = "not-a-number"
+        self.assertEqual(retain_content_limit(), 45000)
+
+
+class TestSplitBounds(unittest.TestCase):
+    def test_content_within_the_limit_is_untouched(self):
+        content = _json_transcript(3, 100)
+        self.assertEqual(split_retain_content(content), [content])
+
+    def test_every_part_of_an_oversized_json_transcript_is_within_the_limit(self):
+        content = _json_transcript(40, 5000)  # ~200k chars
+        self.assertGreater(len(content), 45000)
+        parts = split_retain_content(content)
+        self.assertGreater(len(parts), 1)
+        for part in parts:
+            self.assertLessEqual(len(part), 45000)
+
+    def test_every_part_of_an_oversized_text_transcript_is_within_the_limit(self):
+        content = _text_transcript(60, 4000)  # ~240k chars
+        parts = split_retain_content(content, 45000)
+        self.assertGreater(len(parts), 1)
+        for part in parts:
+            self.assertLessEqual(len(part), 45000)
+
+    def test_worst_case_backlog_entry_is_bounded(self):
+        # The largest entry measured in the 2026-07-25 fleet backlog.
+        content = _json_transcript(200, 3700)
+        self.assertGreater(len(content), 744000)
+        parts = split_retain_content(content)
+        self.assertTrue(all(len(p) <= 45000 for p in parts))
+        # ~249 sequential extraction calls become bounded batches of <=15.
+        self.assertGreaterEqual(len(parts), 16)
+
+    def test_single_oversized_message_is_split_not_dropped(self):
+        content = _json_transcript(1, 300000)
+        parts = split_retain_content(content)
+        self.assertGreater(len(parts), 1)
+        for part in parts:
+            self.assertLessEqual(len(part), 45000)
+
+    def test_single_unbreakable_line_still_respects_the_bound(self):
+        # No structural boundary anywhere: the bound must still hold.
+        parts = split_retain_content("z" * 500000, 45000)
+        self.assertTrue(all(len(p) <= 45000 for p in parts))
+        self.assertEqual("".join(parts), "z" * 500000)
+
+
+class TestSplitPreservesStructure(unittest.TestCase):
+    def test_json_parts_are_each_a_valid_json_transcript(self):
+        content = _json_transcript(40, 5000)
+        for part in split_retain_content(content):
+            decoded = json.loads(part)
+            self.assertIsInstance(decoded, list)
+            self.assertTrue(decoded)
+            for message in decoded:
+                self.assertIn("role", message)
+                self.assertIn("content", message)
+
+    def test_json_split_loses_no_message_and_keeps_order(self):
+        content = _json_transcript(40, 5000)
+        original = json.loads(content)
+        rejoined = []
+        for part in split_retain_content(content):
+            rejoined.extend(json.loads(part))
+        self.assertEqual([m["role"] for m in rejoined], [m["role"] for m in original])
+        self.assertEqual(
+            "".join(b["text"] for m in rejoined for b in m["content"]),
+            "".join(b["text"] for m in original for b in m["content"]),
+        )
+
+    def test_a_split_message_keeps_its_role_on_every_fragment(self):
+        content = json.dumps(
+            [{"role": "assistant", "content": [{"type": "text", "text": "q" * 300000}]}],
+            indent=None,
+            ensure_ascii=False,
+        )
+        for part in split_retain_content(content):
+            for message in json.loads(part):
+                self.assertEqual(message["role"], "assistant")
+
+    def test_text_parts_keep_whole_role_blocks(self):
+        content = _text_transcript(60, 4000)
+        for part in split_retain_content(content, 45000):
+            self.assertTrue(part.startswith("[role: user]"))
+            self.assertTrue(part.endswith("[user:end]"))
+            self.assertEqual(part.count("[role: user]"), part.count("[user:end]"))
+
+    def test_an_oversized_text_block_is_rewrapped_with_its_role_markers(self):
+        content = _text_transcript(1, 200000)
+        parts = split_retain_content(content, 45000)
+        self.assertGreater(len(parts), 1)
+        for part in parts:
+            self.assertTrue(part.startswith("[role: user]\n"))
+            self.assertTrue(part.endswith("\n[user:end]"))
+
+    def test_split_is_deterministic(self):
+        content = _json_transcript(40, 5000)
+        self.assertEqual(split_retain_content(content), split_retain_content(content))
+
+
+class TestPartIdentity(unittest.TestCase):
+    def test_unsplit_document_id_and_metadata_are_unchanged(self):
+        self.assertEqual(part_document_id("sess-rA-B", 0, 1), "sess-rA-B")
+        self.assertEqual(part_metadata({"session_id": "s"}, 0, 1), {"session_id": "s"})
+
+    def test_part_ids_are_unique_so_parts_cannot_overwrite_each_other(self):
+        ids = [part_document_id("sess-rA-B", i, 5) for i in range(5)]
+        self.assertEqual(len(set(ids)), 5)
+
+    def test_part_ids_keep_the_session_prefix(self):
+        self.assertTrue(part_document_id("sess123-rA-B", 2, 5).startswith("sess123"))
+
+    def test_part_metadata_records_provenance_without_mutating_the_input(self):
+        original = {"session_id": "s"}
+        meta = part_metadata(original, 2, 5)
+        self.assertEqual(meta["retain_part_index"], "3")
+        self.assertEqual(meta["retain_part_count"], "5")
+        self.assertEqual(original, {"session_id": "s"})
+
+
+class _RecordingClient(HindsightClient):
+    """Client that records POSTs instead of issuing them."""
+
+    def __init__(self, *a, fail_on=None, **kw):
+        super().__init__(*a, **kw)
+        self.posts = []
+        self.fail_on = fail_on
+
+    def _request(self, method, path, body=None, timeout=None):
+        if self.fail_on is not None and len(self.posts) == self.fail_on:
+            self.posts.append((path, body, timeout))
+            raise RuntimeError("upstream boom")
+        self.posts.append((path, body, timeout))
+        return {"ok": True}
+
+
+class TestClientEnforcesTheBound(unittest.TestCase):
+    def setUp(self):
+        self.client = _RecordingClient("http://hindsight.invalid")
+
+    def test_oversized_retain_is_never_posted_as_one_item(self):
+        # The bug: pre-fix this was a single POST of 200k chars, which the
+        # daemon turns into ~67 sequential LLM calls and no deadline covers.
+        self.client.retain("bank", _json_transcript(40, 5000), document_id="doc")
+        self.assertGreater(len(self.client.posts), 1)
+        for _path, body, _timeout in self.client.posts:
+            self.assertEqual(len(body["items"]), 1)
+            self.assertLessEqual(len(body["items"][0]["content"]), 45000)
+
+    def test_small_retain_still_posts_exactly_once_with_the_original_id(self):
+        self.client.retain("bank", "small transcript", document_id="doc")
+        self.assertEqual(len(self.client.posts), 1)
+        self.assertEqual(self.client.posts[0][1]["items"][0]["document_id"], "doc")
+        self.assertNotIn("retain_part_index", self.client.posts[0][1]["items"][0]["metadata"])
+
+    def test_each_part_gets_a_distinct_document_id(self):
+        self.client.retain("bank", _json_transcript(40, 5000), document_id="doc")
+        ids = [b["items"][0]["document_id"] for _p, b, _t in self.client.posts]
+        self.assertEqual(len(set(ids)), len(ids))
+        self.assertTrue(all(i.startswith("doc-p") for i in ids))
+
+    def test_every_part_carries_the_callers_commit_before_ack_and_context(self):
+        self.client.retain(
+            "bank",
+            _json_transcript(40, 5000),
+            document_id="doc",
+            context="claude-code",
+            tags=["t"],
+            async_processing=False,
+            timeout=280,
+        )
+        for _path, body, timeout in self.client.posts:
+            self.assertIs(body["async"], False)
+            self.assertEqual(body["items"][0]["context"], "claude-code")
+            self.assertEqual(body["items"][0]["tags"], ["t"])
+            self.assertEqual(timeout, 280)
+
+    def test_a_failing_part_raises_so_the_caller_still_enqueues_and_retries(self):
+        client = _RecordingClient("http://hindsight.invalid", fail_on=2)
+        with self.assertRaises(RuntimeError):
+            client.retain("bank", _json_transcript(40, 5000), document_id="doc")
+        self.assertEqual(len(client.posts), 3)  # stops at the failure
+
+    def test_retry_after_partial_failure_reposts_identical_part_ids(self):
+        content = _json_transcript(40, 5000)
+        first = _RecordingClient("http://hindsight.invalid", fail_on=2)
+        with self.assertRaises(RuntimeError):
+            first.retain("bank", content, document_id="doc")
+        second = _RecordingClient("http://hindsight.invalid")
+        second.retain("bank", content, document_id="doc")
+        committed = [b["items"][0]["document_id"] for _p, b, _t in first.posts[:2]]
+        retried = [b["items"][0]["document_id"] for _p, b, _t in second.posts[:2]]
+        # Identical ids ⇒ the daemon upserts the already-committed parts
+        # instead of double-storing them.
+        self.assertEqual(committed, retried)
+
+    def test_split_count_is_reported_on_the_response(self):
+        response = self.client.retain("bank", _json_transcript(40, 5000), document_id="doc")
+        self.assertEqual(response["split_parts"], len(self.client.posts))
+
+    def test_limit_is_read_at_call_time_from_the_environment(self):
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "6000"
+        try:
+            self.client.retain("bank", _json_transcript(10, 1000), document_id="doc")
+        finally:
+            os.environ.pop("HINDSIGHT_RETAIN_MAX_CONTENT_CHARS", None)
+        self.assertGreater(len(self.client.posts), 1)
+        for _p, body, _t in self.client.posts:
+            self.assertLessEqual(len(body["items"][0]["content"]), 6000)
+
+
+class TestModuleIsPure(unittest.TestCase):
+    def test_splitter_imports_nothing_nondeterministic_or_networked(self):
+        # The split must be a pure function of (content, limit): a clock or an
+        # RNG in here would make retry ids diverge and turn every retry into a
+        # duplicate document instead of an upsert.
+        import ast
+
+        with open(retain_split.__file__, encoding="utf-8") as fh:
+            tree = ast.parse(fh.read())
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+        self.assertEqual(imported, {"__future__", "json", "os", "typing"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_retain_split.py
+++ b/vendor/hindsight-memory/scripts/tests/test_retain_split.py
@@ -10,11 +10,15 @@ memory is permanently unsaveable.
 
 import json
 import os
+import shutil
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from lib import client as client_mod  # noqa: E402
+from lib import pending  # noqa: E402
 from lib import retain_split  # noqa: E402
 from lib.client import HindsightClient  # noqa: E402
 from lib.retain_split import (  # noqa: E402
@@ -246,7 +250,10 @@ class TestClientEnforcesTheBound(unittest.TestCase):
             self.assertIs(body["async"], False)
             self.assertEqual(body["items"][0]["context"], "claude-code")
             self.assertEqual(body["items"][0]["tags"], ["t"])
-            self.assertEqual(timeout, 280)
+            # Each part gets a positive request deadline, clamped to what is
+            # left of the caller's 280s wall budget (never more than it).
+            self.assertGreater(timeout, 0)
+            self.assertLessEqual(timeout, 280)
 
     def test_a_failing_part_raises_so_the_caller_still_enqueues_and_retries(self):
         client = _RecordingClient("http://hindsight.invalid", fail_on=2)
@@ -280,6 +287,110 @@ class TestClientEnforcesTheBound(unittest.TestCase):
         self.assertGreater(len(self.client.posts), 1)
         for _p, body, _t in self.client.posts:
             self.assertLessEqual(len(body["items"][0]["content"]), 6000)
+
+
+class TestRetainRespectsTheCallersWallBudget(unittest.TestCase):
+    """Splitting must not turn one bounded POST into N of them.
+
+    The Stop hook passes ``timeout=15`` because it has a hook budget. Posting
+    17 parts at 15s each would stall the session for over four minutes — a
+    worse bug than the one being fixed. Fails against the first cut of the fix,
+    which passed the caller's timeout to every part with no overall bound.
+    """
+
+    def test_total_wall_time_is_bounded_by_the_callers_timeout(self):
+        class _SlowClient(_RecordingClient):
+            def _request(self, method, path, body=None, timeout=None):
+                self.clock[0] += 9.0  # each part burns 9s
+                return super()._request(method, path, body, timeout)
+
+        client = _SlowClient("http://hindsight.invalid")
+        client.clock = [0.0]
+        real_monotonic = client_mod.time.monotonic
+        client_mod.time.monotonic = lambda: client.clock[0]
+        try:
+            with self.assertRaises(TimeoutError):
+                client.retain("bank", _json_transcript(40, 20000), timeout=15)
+        finally:
+            client_mod.time.monotonic = real_monotonic
+        # 15s budget, 9s per part: part 1 runs, part 2 starts (6s left), part 3
+        # must not. Bounded — not all 40-message-worth of parts.
+        self.assertEqual(len(client.posts), 2)
+
+    def test_parts_that_fit_the_budget_all_post(self):
+        client = _RecordingClient("http://hindsight.invalid")
+        content = _json_transcript(40, 20000)
+        result = client.retain("bank", content, timeout=280)
+        self.assertGreater(len(client.posts), 1)
+        self.assertEqual(result["split_parts"], len(client.posts))
+
+
+class TestEnqueueQueuesBoundedEntries(unittest.TestCase):
+    """An oversized entry can never be drained, so it must never be queued.
+
+    drain_pending marks an entry ``.dead`` after MAX_ATTEMPTS failures. A
+    queued 744k-char payload fails every attempt by construction, so queuing it
+    whole is a scheduled data loss. Fails against pre-fix pending.enqueue,
+    which wrote one entry of whatever size it was handed.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._prev = os.environ.get("HOME")
+        os.environ["HOME"] = self.tmp
+
+    def tearDown(self):
+        if self._prev is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._prev
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _payload(self, content):
+        return {
+            "api_url": "http://hindsight.invalid",
+            "bank_id": "bank",
+            "document_id": "sess-r1-2",
+            "content": content,
+            "metadata": {"source": "test"},
+        }
+
+    def test_small_payload_still_queues_exactly_one_unchanged_entry(self):
+        pending.enqueue(self._payload("short content"), RuntimeError("boom"))
+        entries = pending.iter_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0][1]["content"], "short content")
+        self.assertEqual(entries[0][1]["document_id"], "sess-r1-2")
+
+    def test_oversized_payload_is_queued_as_multiple_bounded_entries(self):
+        content = _json_transcript(40, 20000)
+        pending.enqueue(self._payload(content), RuntimeError("boom"))
+        entries = pending.iter_entries()
+        limit = retain_content_limit()
+        self.assertGreater(len(entries), 1)
+        for _path, entry in entries:
+            self.assertLessEqual(len(entry["content"]), limit)
+
+    def test_queued_parts_have_distinct_deterministic_ids(self):
+        content = _json_transcript(40, 20000)
+        pending.enqueue(self._payload(content), RuntimeError("boom"))
+        ids = [e["document_id"] for _p, e in pending.iter_entries()]
+        self.assertEqual(len(ids), len(set(ids)))
+        total = len(ids)
+        self.assertEqual(
+            sorted(ids),
+            sorted(part_document_id("sess-r1-2", i, total) for i in range(total)),
+        )
+
+    def test_queue_cap_is_still_respected_when_splitting(self):
+        content = _json_transcript(40, 20000)
+        original = pending.MAX_ENTRIES
+        pending.MAX_ENTRIES = 2
+        try:
+            pending.enqueue(self._payload(content), RuntimeError("boom"))
+        finally:
+            pending.MAX_ENTRIES = original
+        self.assertEqual(len(pending.iter_entries()), 2)
 
 
 class TestModuleIsPure(unittest.TestCase):

--- a/vendor/hindsight-memory/scripts/tests/test_retain_split.py
+++ b/vendor/hindsight-memory/scripts/tests/test_retain_split.py
@@ -8,12 +8,14 @@ sequential calls and can never complete inside any client deadline — the
 memory is permanently unsaveable.
 """
 
+import io
 import json
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -383,14 +385,27 @@ class TestEnqueueQueuesBoundedEntries(unittest.TestCase):
         )
 
     def test_queue_cap_is_still_respected_when_splitting(self):
+        """A memory needing more parts than the cap is REFUSED, not partly kept.
+
+        This asserted "queue the 2 parts that fit" before the rebase onto
+        #3599. That answer stopped being available: #3599 replaced the
+        "refuse at MAX_ENTRIES" branch with ``_evict_to_fit``, so writing
+        part 20 of 20 under a 2-entry cap now sheds parts 1-18 of the SAME
+        memory along with everything else already queued, and leaves a
+        meaningless tail fragment behind. Refusing matches #3599's own
+        byte-cap guard: one memory must never cost the whole queue.
+        """
         content = _json_transcript(40, 20000)
         original = pending.MAX_ENTRIES
         pending.MAX_ENTRIES = 2
         try:
-            pending.enqueue(self._payload(content), RuntimeError("boom"))
+            with redirect_stderr(io.StringIO()) as err:
+                got = pending.enqueue(self._payload(content), RuntimeError("boom"))
         finally:
             pending.MAX_ENTRIES = original
-        self.assertEqual(len(pending.iter_entries()), 2)
+        self.assertIsNone(got)
+        self.assertEqual(len(pending.iter_entries()), 0)
+        self.assertIn("more than the whole", err.getvalue())
 
 
 class TestModuleIsPure(unittest.TestCase):


### PR DESCRIPTION
## Problem

Long conversation transcripts can never be saved to memory. Fact extraction chunks content at ~3000 chars and issues one LLM call per chunk sequentially, so a 744k-char transcript is ~250 serial calls — it cannot finish inside any sane client deadline. Measured on the 2026-07-25 fleet backlog: median content 26,112 chars, p90 150,224, max 744,546; 154 entries over 60,000 chars burned the full client deadline on every attempt, failed all 5 drain attempts, and were marked `.dead`. That is scheduled data loss, not a transient failure.

## Relationship to #3599 — complementary, not duplicate

#3599 (`the pending-retains backlog was a re-post loop, not lost memory`) landed on main while this was in review, and its title asserts a different root cause. Both claims are true, of disjoint parts of the same queue, and #3599 says so itself: 4,048 of 5,751 entries (70.4%) were already durable and being re-posted forever — that is #3599's — and **1,703 were genuinely absent**, which is what this PR is about. #3599 fixes the *drain*; a presence GET retires an oversized entry for free when its document IS already durable. This fixes the *write path*; splitting is what makes the memory persist when it is NOT. Neither subsumes the other: with #3599 alone, a fresh 744k-char retain still fails every attempt and goes `.dead`.

Independent evidence that this is still expected to land: **#3611 is already on main carrying three references to `vendor/hindsight-memory/scripts/lib/retain_split.py`** — a file that only exists on this branch — and pins `HINDSIGHT_RETAIN_CLIENT_DEADLINE_S = 280` as "a mirror" of a python constant main does not yet have.

## Fix

Split at the plugin, at both the POST path and the queue path.

- `retain()` splits oversized content before posting, and treats `timeout` as a **total wall budget** across parts (not per-part, which would have multiplied a Stop hook's 15s into 15s x N).
- `enqueue()` writes one queue entry **per part**, so a failed retain can no longer re-form a giant unsaveable entry.
- Splits on JSON message boundaries / `[role:]...[:end]` blocks, never a byte offset; every fragment keeps its role envelope. Deterministic part ids (`<base>-p<i>of<n>`) make a re-post an upsert, so the drain is resumable.

Bound is derived, not picked: `chunk_size x floor(client_deadline / chunk_latency)` = `3000 x floor(280 / 18.4)` = **45,000 chars**. All three inputs are env-overridable.

### Why plugin-side rather than server-side

The hindsight API image is third-party upstream (`ghcr.io/vectorize-io/hindsight`, pinned by digest) and its source is not on this host. Its own auto-splitter is gated on `async=True`, but every durability retain posts `async=False` by contract (#3244 s1.1) — so the one server mechanism that would help is structurally unavailable. The server also sees an opaque string, while the plugin still has message structure. `client.retain()` is the single function all six retain callers pass through, so one change covers all of them, including the drainer.

## Rebase onto #3599 + #3611 — four defects that exist only in the COMBINATION

Resolved on the merits, not by picking a side. Each fix fails a named test when reverted.

1. **HIGH — split part ids fell outside #3599's free reconcile.** `is_content_derived_document_id` is anchored at the end of the id, so `{core}-p{i}of{n}` did not match. Every split part — by construction the largest, most expensive entries in the queue — would have taken a full re-POST on every drain instead of a sub-second presence GET: exactly the loop #3599 exists to kill, aimed at the worst case. A part suffix is a pure function of the same content the core derives from, so a part inherits its core's verdict; `*` not `?`, because a part queued under one bound and re-split under a smaller one nests its suffix. A part suffix on a pre-#3244 bare session id is still refused.
2. **MED — the drain deadline contradicted the bound it must satisfy.** `HINDSIGHT_DRAIN_BACKLOG_TIMEOUT` shipped as a bare `180` (#3599) while the bound is sized against a 280s client deadline and #3611's *derived* server per-call timeout is 204s under a stated `server < client` invariant. Under 180s the drain abandons requests the server is still legitimately working on. `_backlog_timeout()` now derives its default from `retain_split.retain_client_deadline()`, so the drain deadline and the content bound are one number, and a test enforces the TS↔python mirror #3611 only asserted in a comment.
3. **MED — splitting defeated #3599's "larger than the whole cap can never fit" guard.** Each part fits, so the eviction loop becomes satisfiable and every part is written — but the parts together still exceed the cap, so the later parts evict the earlier parts of the same memory *plus* every unrelated queued memory, leaving a tail fragment and nothing else. The guard is hoisted to the whole logical memory, against **both** caps (bytes and count). This restores #3599's `test_oversized_entry_is_refused_without_wiping_the_queue` verbatim.
4. **LOW — the wall-budget `TimeoutError` claimed "remainder is enqueued for the drainer".** Two of the six callers do not enqueue. Message and docstring now name what each caller actually does.

## Tests

- `vendor/hindsight-memory/scripts/tests` (the only python dir CI discovers): **611 passed, 180 subtests passed**
- `vendor/hindsight-memory/tests`: **236 passed**
- `vitest tests/setup/hindsight.test.ts src/cli/doctor-pending-retains.test.ts`: **114 passed**
- `npm run lint`: all 13 gates clean

Mutation-verified: reverting the part-suffix gate, the derived backlog timeout, the byte/count total guards, and the TS↔python mirror each fails a named test.

## Follow-up (not in this PR)

A supervised recovery script for the existing backlog exists off-repo and is dry-run-by-default. It deletes an entry only when every part is confirmed persisted, and never writes `.dead`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
