### PR TITLE
fix(hindsight): derive the retain LLM timeout from the token budget

### DIFF
--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -352,6 +352,149 @@ export const HINDSIGHT_DEFAULT_RECALL_MAX_CONCURRENT = 8;
 export const HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S = 600;
 
 /**
+ * Retain LLM budget — output cap and the deadline that must bracket it.
+ *
+ * These numbers used to live in unrelated places (a vendor default inside the
+ * image, a client timeout in the plugin, a deployment timeout in the LiteLLM
+ * config) with nothing tying them together, which is exactly how the
+ * 2026-07-25 incident happened: a ~190s job under a 90s deadline, and a single
+ * request that ran 767.6s. Emitting them from one derivation, behind an
+ * assertion, makes an inconsistent budget impossible to ship.
+ *
+ * `HINDSIGHT_RETAIN_CHUNK_SIZE` mirrors the vendor default we do NOT override
+ * (`hindsight_api/config.py` `DEFAULT_RETAIN_CHUNK_SIZE = 3000`). It appears
+ * here only because the daemon refuses to boot unless
+ * `retain_max_completion_tokens > retain_chunk_size`, and that precondition
+ * must be checked before we hand the container an env it will die on.
+ */
+export const HINDSIGHT_RETAIN_CHUNK_SIZE = 3000;
+
+/**
+ * Max output tokens for a retain fact-extraction call.
+ *
+ * The vendor default is 64000 (`config.py DEFAULT_RETAIN_MAX_COMPLETION_TOKENS`),
+ * which is less a cap than permission to run away: at the measured local
+ * generation rate (87.1 and 80.6 tok/s across the two Ollama boxes,
+ * 2026-07-25) 64000 tokens is a ~12 minute call. It was observed doing exactly
+ * that — one request generated the full 64000 tokens over 767.6s, and every
+ * call exceeding 8192 completion tokens (n=17 in a 110-minute window) blew
+ * hindsight's own client timeout. Each runaway also tripped the per-deployment
+ * timeout on both local boxes, cooling them and dumping fleet traffic onto the
+ * metered OpenRouter fallback.
+ *
+ * 16384 is ~3.4 minutes at the slower measured rate: headroom for a
+ * legitimately verbose extraction, far too little for a reasoning loop.
+ */
+export const HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS = 16384;
+
+/**
+ * Slowest measured local generation rate, tokens/second (2026-07-25: 87.1 and
+ * 80.6 tok/s across the two Ollama boxes). Take the slower — a budget that
+ * only holds on the faster box is not a budget.
+ */
+export const HINDSIGHT_RETAIN_MIN_TOKENS_PER_SECOND = 80.6;
+
+/**
+ * The retain CLIENT deadline: how long a caller waits for one retain POST.
+ * Mirrors `DEFAULT_RETAIN_CLIENT_DEADLINE_S` in the plugin's
+ * `vendor/hindsight-memory/scripts/lib/retain_split.py`, which sizes its
+ * content bound off the same number. Explicit constant so the assertion below
+ * is a real check, not a comparison against a literal nobody maintains.
+ */
+export const HINDSIGHT_RETAIN_CLIENT_DEADLINE_S = 280;
+
+/**
+ * Server-side per-call deadline, DERIVED from the output cap:
+ *
+ *   ceil(maxCompletionTokens / minTokensPerSecond)
+ *   = ceil(16384 / 80.6) = 204s
+ *
+ * Exactly long enough for the model to emit its whole permitted output at the
+ * slowest measured rate, and not a second longer. Raising the token cap moves
+ * this automatically; the two can no longer drift apart.
+ */
+export function hindsightRetainLlmTimeoutSeconds(
+  maxCompletionTokens: number = HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS,
+  tokensPerSecond: number = HINDSIGHT_RETAIN_MIN_TOKENS_PER_SECOND,
+): number {
+  if (!(maxCompletionTokens > 0) || !(tokensPerSecond > 0)) {
+    throw new Error(
+      `hindsight retain budget: maxCompletionTokens (${maxCompletionTokens}) and ` +
+        `tokensPerSecond (${tokensPerSecond}) must both be positive`,
+    );
+  }
+  return Math.ceil(maxCompletionTokens / tokensPerSecond);
+}
+
+/**
+ * Fail loudly on an inconsistent retain budget, at config-emit time, before a
+ * container is ever handed it. Precedent: the daemon's own
+ * `retain_max_completion_tokens > retain_chunk_size` boot check.
+ *
+ * 1. **`maxCompletionTokens > chunkSize`** — the daemon refuses to boot
+ *    otherwise, and a crash-looping hindsight is no memory backend for the
+ *    entire fleet.
+ * 2. **server per-call timeout < client POST deadline** — a hung LLM call must
+ *    die server-side and surface as a real error rather than the client
+ *    abandoning first. When the client gives up first the server keeps
+ *    generating (and, on a metered fallback, keeps billing) against a request
+ *    nobody is waiting for. That is the 767.6s call.
+ *
+ * What this deliberately does NOT promise: the server deadline is per
+ * extraction call and one retain runs many calls sequentially, so satisfying
+ * it does not mean a whole POST fits inside the client deadline. Bounding
+ * total content is the plugin's job (`lib/retain_split.py`); the two are
+ * complementary halves of the same guarantee.
+ */
+export function assertHindsightRetainBudget(budget: {
+  maxCompletionTokens: number;
+  chunkSize: number;
+  serverTimeoutS: number;
+  clientDeadlineS: number;
+}): void {
+  const { maxCompletionTokens, chunkSize, serverTimeoutS, clientDeadlineS } = budget;
+  if (maxCompletionTokens <= chunkSize) {
+    throw new Error(
+      `hindsight retain budget: HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS ` +
+        `(${maxCompletionTokens}) must exceed retain_chunk_size (${chunkSize}) or the ` +
+        `hindsight container refuses to boot (config.py validate_retain_*).`,
+    );
+  }
+  if (serverTimeoutS >= clientDeadlineS) {
+    throw new Error(
+      `hindsight retain budget: server per-call timeout (${serverTimeoutS}s) must be ` +
+        `strictly less than the retain client deadline (${clientDeadlineS}s), or the ` +
+        `client abandons first and the server keeps generating against a request ` +
+        `nobody is waiting for. Lower HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS, ` +
+        `or raise HINDSIGHT_RETAIN_CLIENT_DEADLINE_S and ` +
+        `DEFAULT_RETAIN_CLIENT_DEADLINE_S in ` +
+        `vendor/hindsight-memory/scripts/lib/retain_split.py together.`,
+    );
+  }
+}
+
+/**
+ * The retain budget env vars as `[key, value]` pairs. Asserted before it
+ * returns, so both emit paths ({@link startHindsight} and
+ * {@link generateHindsightComposeSnippet}) fail loudly on a violation and can
+ * never drift from each other.
+ */
+export function hindsightRetainBudgetEnv(): Array<[string, string]> {
+  const maxCompletionTokens = HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS;
+  const serverTimeoutS = hindsightRetainLlmTimeoutSeconds(maxCompletionTokens);
+  assertHindsightRetainBudget({
+    maxCompletionTokens,
+    chunkSize: HINDSIGHT_RETAIN_CHUNK_SIZE,
+    serverTimeoutS,
+    clientDeadlineS: HINDSIGHT_RETAIN_CLIENT_DEADLINE_S,
+  });
+  return [
+    ["HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS", String(maxCompletionTokens)],
+    ["HINDSIGHT_API_RETAIN_LLM_TIMEOUT", String(serverTimeoutS)],
+  ];
+}
+
+/**
  * Consolidation throughput knobs — throttled HARD for shared-quota safety.
  * Consolidation is LLM-bound via the claude-code provider (observed
  * ~510s/op), and every concurrent op is a live claude (Sonnet) subprocess
@@ -923,6 +1066,10 @@ export function startHindsight(
     // Reflect wall timeout — let large-bank mental-model refreshes finish
     // (vendor 300s times out on 12k+ obs banks → stale user-profile models).
     "-e", `HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S}`,
+    // Retain output cap + its derived per-call deadline. Asserted consistent
+    // by hindsightRetainBudgetEnv() before it returns — see the constants
+    // above for the 767.6s runaway this replaces.
+    ...hindsightRetainBudgetEnv().flatMap(([k, v]) => ["-e", `${k}=${v}`]),
     // Consolidation concurrency: throttled by #2894 to a hard ceiling of
     // MAX_SLOTS 1 × LLM_PARALLELISM 2 = 2 concurrent model calls (was 18), so
     // consolidation can never exhaust the shared failover quota. Batch size 12
@@ -1446,6 +1593,8 @@ export function generateHindsightComposeSnippet(
     `      - HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT=${HINDSIGHT_DEFAULT_RERANKER_LOCAL_MAX_CONCURRENT}`,
     `      - HINDSIGHT_API_RECALL_MAX_CONCURRENT=${HINDSIGHT_DEFAULT_RECALL_MAX_CONCURRENT}`,
     `      - HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S}`,
+    // Retain budget — same derivation + assertion as the docker-run path.
+    ...hindsightRetainBudgetEnv().map(([k, v]) => `      - ${k}=${v}`),
     `      - HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`,
     `      - HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
     `      - HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -336,6 +336,87 @@ describe("hindsight broker-fed mode (#1245)", () => {
     expect(generateHindsightComposeSnippet()).toContain(`HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${t}`);
   });
 
+  it("caps retain output tokens well below the vendor 64000 runaway default", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    // 64000 tokens at the measured 80.6 tok/s is a ~13 minute call; one such
+    // request was observed running 767.6s on 2026-07-25.
+    expect(h.HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS).toBe(16384);
+    expect(h.HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS).toBeLessThan(64000);
+
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const envPairs = envPairsFromArgs(findRunArgs());
+    expect(envPairs).toContain(
+      `HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS=${h.HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS}`,
+    );
+    expect(h.generateHindsightComposeSnippet()).toContain(
+      `HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS=${h.HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS}`,
+    );
+  });
+
+  it("derives the retain server timeout from the token cap rather than hardcoding it", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    // ceil(16384 / 80.6) = 204
+    expect(h.hindsightRetainLlmTimeoutSeconds()).toBe(204);
+    // Derived, not constant: double the cap and the deadline follows.
+    expect(h.hindsightRetainLlmTimeoutSeconds(32768)).toBe(407);
+    expect(h.hindsightRetainLlmTimeoutSeconds(16384, 40)).toBe(410);
+
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const envPairs = envPairsFromArgs(findRunArgs());
+    expect(envPairs).toContain(
+      `HINDSIGHT_API_RETAIN_LLM_TIMEOUT=${h.hindsightRetainLlmTimeoutSeconds()}`,
+    );
+    expect(h.generateHindsightComposeSnippet()).toContain(
+      `HINDSIGHT_API_RETAIN_LLM_TIMEOUT=${h.hindsightRetainLlmTimeoutSeconds()}`,
+    );
+  });
+
+  it("holds the shipped budget: server per-call timeout < retain client deadline", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    expect(h.hindsightRetainLlmTimeoutSeconds()).toBeLessThan(
+      h.HINDSIGHT_RETAIN_CLIENT_DEADLINE_S,
+    );
+    expect(() => h.hindsightRetainBudgetEnv()).not.toThrow();
+  });
+
+  it("refuses to emit a budget where the server outlives the client deadline", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    // The 2026-07-25 shape: a ~190s job under a 90s deadline.
+    expect(() =>
+      h.assertHindsightRetainBudget({
+        maxCompletionTokens: 16384,
+        chunkSize: 3000,
+        serverTimeoutS: 190,
+        clientDeadlineS: 90,
+      }),
+    ).toThrow(/strictly less than the retain client deadline/);
+    // Equality is a violation too — it must be strictly less.
+    expect(() =>
+      h.assertHindsightRetainBudget({
+        maxCompletionTokens: 16384,
+        chunkSize: 3000,
+        serverTimeoutS: 280,
+        clientDeadlineS: 280,
+      }),
+    ).toThrow(/strictly less than the retain client deadline/);
+  });
+
+  it("refuses to emit a token cap the hindsight container would refuse to boot on", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    // config.py validate_retain_*: max_completion_tokens must exceed chunk_size.
+    expect(() =>
+      h.assertHindsightRetainBudget({
+        maxCompletionTokens: 3000,
+        chunkSize: 3000,
+        serverTimeoutS: 40,
+        clientDeadlineS: 280,
+      }),
+    ).toThrow(/must exceed retain_chunk_size/);
+    expect(h.HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS).toBeGreaterThan(
+      h.HINDSIGHT_RETAIN_CHUNK_SIZE,
+    );
+  });
+
   it("sets modest consolidation throughput knobs (batch size + slots) on both emit paths", async () => {
     const h = await import("../../src/setup/hindsight.js");
     startHindsight({ apiPort: 8888, uiPort: 9999 });


### PR DESCRIPTION
## Problem

Two numbers govern how long a retain may take, and nothing tied them together:

- `RETAIN_MAX_COMPLETION_TOKENS` — how much the model may generate (upstream default **64000**)
- `RETAIN_LLM_TIMEOUT` — how long we wait for it

At 64000 tokens and the measured local throughput floor of 80.6 tok/s, a single legitimate extraction needs ~13 minutes. Nothing enforced that the timeout could accommodate the cap, so a runaway generation blew the per-deployment deadline on both local Ollama boxes, tripped the router cooldown, and dumped all fleet memory traffic onto OpenRouter — where the runaway completed uncut and billed.

**The live config currently violates the invariant in the other direction:** `HINDSIGHT_API_RETAIN_LLM_TIMEOUT=300` exceeds the 280s durability client deadline, so the server can outlive the client that is waiting on it. That leaves an orphaned upstream slot.

## Fix

Make the timeout a derived value and assert the invariant at emit time.

- `HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS = 16384` — high enough for a looping extraction to finish, low enough that the worst case is ~2 min rather than ~13.
- `hindsightRetainLlmTimeoutSeconds()` derives **204s** = `ceil(16384 / 80.6)` from the cap and the measured throughput floor.
- `assertHindsightRetainBudget()` fails loudly on `tokens <= chunk_size` (which the upstream container refuses to boot on anyway) or `server >= client`.

Wired into both env emit paths (`docker run` and compose), so the value survives a deploy rather than living only in a hand-run container's baked env.

`src/setup/hindsight.ts` is the durable home for this because the hindsight API image is third-party upstream and its source is not in any repo we own — this is the code that decides what env the container actually gets.

## Tests

- vitest: `Test Files 12 passed (12) / Tests 213 passed (213)`
- Pre-fix proof: `Tests 5 failed | 60 passed (65)`
- `npm run lint`: all 13 gates clean

## Operator note

Applying this changes the live retain timeout from 300 to 204 at the next hindsight restart. That is the point — 300 is currently above the client deadline.

## Follow-up

The Python splitter's bound and this TypeScript budget agree by convention, not by construction. Worth making the plugin read the deadline from the emitted env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)