### PR TITLE
test: green main — stale Bash-label expectation + the auth-broker live-probe flake

### DIFF
--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -49,7 +49,54 @@ function makeHarness(): Harness {
   return h;
 }
 
+/* ─── Offline net guard (mandatory for this whole file) ──────────
+ *
+ * `mark-exhausted` awaits a LIVE quota probe INSIDE the request path:
+ *
+ *   markExhaustedAndRoll (server.ts) → nextHealthyAccountLive
+ *                                    → probeAndCacheOne → fetchQuota
+ *
+ * `nextHealthyAccountLive` force-probes every candidate whose eligibility is
+ * still `unknown`, and `fetchQuota`'s default abort is 10s
+ * (src/auth/quota.ts:364) — more than 3x the 3s deadline `rpc()` below
+ * enforces. Any broker in this file constructed WITHOUT a `_testFetchQuota`
+ * seam is therefore latency-bound on api.anthropic.com and fails with
+ * `Error: rpc timeout` whenever the runner's egress is slow. That is what went
+ * red on main: run 30160839499 / vitest-shard (1), and locally 1 failure in 15
+ * repeat runs of this one file.
+ *
+ * The live-probe path arrived in 839791d3e (#2565, tri-state eligibility);
+ * d8f73d59c (#3609) fixed the same class in
+ * src/auth/broker/server-consumer-follow-active.test.ts per-broker and
+ * explicitly deferred "13 tests in src/auth/broker/server.test.ts with the
+ * identical un-injected live probe" — these are those 13.
+ *
+ * Rather than thread `_testFetchQuota` through 99 broker constructions (and
+ * leave every FUTURE one free to re-flake), the guard is installed at the file
+ * level: `globalThis.fetch` is replaced for the duration of every test with a
+ * stub that rejects immediately. Semantics are unchanged — `fetchQuota` catches
+ * and returns `{ ok: false, reason: "quota probe network error: …" }`, i.e. the
+ * probe FAILURE a real probe could only ever produce here anyway (the seeded
+ * tokens are fakes), so the candidate stays `unknown` and the selector takes it
+ * as the roll target exactly as before. Tests that inject `_testFetchQuota`
+ * bypass `fetch` entirely and are untouched.
+ */
+const NET_GUARD_MARKER = "test: offline net guard (server.test.ts never calls the network)";
+let realFetch: typeof globalThis.fetch;
+let netGuardCalls = 0;
+
+beforeEach(() => {
+  netGuardCalls = 0;
+  realFetch = globalThis.fetch;
+  const guard = async (): Promise<never> => {
+    netGuardCalls += 1;
+    throw new Error(NET_GUARD_MARKER);
+  };
+  globalThis.fetch = guard as unknown as typeof globalThis.fetch;
+});
+
 afterEach(() => {
+  globalThis.fetch = realFetch;
   for (const h of harnesses) {
     try { rmSync(h.tmp, { recursive: true, force: true }); } catch { /* ignore */ }
   }
@@ -643,7 +690,18 @@ describe("AuthBroker — consumer failover on quota exhaustion", () => {
     const quota = JSON.parse(readFileSync(join(h.stateDir, "quota.json"), "utf-8"));
     expect((quota["default"]?.exhausted_until ?? 0) > Date.now()).toBe(false);
     expect(quota["secondary"].exhausted_until > Date.now()).toBe(true);
+    // mark-exhausted's roll DID force a live candidate probe, and it went
+    // through the offline net guard rather than the wire. A zero here means
+    // the guard was removed and this test is latency-bound on
+    // api.anthropic.com again — which is exactly how it went red on main.
+    expect(netGuardCalls).toBeGreaterThan(0);
     broker.stop();
+  });
+});
+
+describe("AuthBroker — offline net guard", () => {
+  it("no test in this file can reach the network: global fetch rejects immediately", async () => {
+    await expect(fetch("https://api.anthropic.com/v1/messages")).rejects.toThrow(NET_GUARD_MARKER);
   });
 });
 

--- a/tests/tool-label-pretool.test.ts
+++ b/tests/tool-label-pretool.test.ts
@@ -255,7 +255,18 @@ describe("tool-label-pretool.mjs", () => {
     // labelled here too. Bash/Task use the model-authored description.
     const cases: Array<[string, Record<string, unknown>, string]> = [
       ["Bash", { command: "ls -la", description: "List workspace" }, "List workspace"],
-      ["Bash", { command: "ls" }, "Running a command"], // no description → safe fallback
+      // No model-authored description → the label is DERIVED from the command
+      // through the allowlist added in d8f73d59c (#3609): program basename
+      // only (plus one bare subcommand for known multiplexers). This replaced
+      // the constant "Running a command", which froze the worker step feed on
+      // one line for any sub-agent that never wrote a description. Canonical
+      // coverage for the allowlist itself lives in
+      // telegram-plugin/tests/tool-label-pretool.test.ts.
+      ["Bash", { command: "ls" }, "Running ls"],
+      ["Bash", { command: "git status --short" }, "Running git status"],
+      // Nothing safe to derive → the generic fallback is still reachable.
+      ["Bash", { command: "$(cat /run/secrets/token) --x" }, "Running a command"],
+      ["Bash", {}, "Running a command"],
       ["Task", { description: "Review the migration", prompt: "y" }, "Delegating: Review the migration"],
       ["Agent", { description: "Audit deps", prompt: "y" }, "Delegating: Audit deps"],
       ["TodoWrite", { todos: [] }, "Updating the plan"],


### PR DESCRIPTION
`main` is red on run [30160839499](https://github.com/switchroom/switchroom/actions/runs/30160839499) (`780a095e1`) with two failures in different shards. **Neither is a regression from the three PRs merged immediately before it** (#3599 `4e6388862`, #3600 `3248cb7e7`, #3601 `780a095e1`) — none touches either subject area.

The run before them ([30160759496](https://github.com/switchroom/switchroom/actions/runs/30160759496), `52142dfeb`) shows `vitest = failure` with no failing shard because it was **cancelled**, not failed — superseded by the next push. It is not evidence of a pre-existing break.

---

## 1. `tests/tool-label-pretool.test.ts` — the TEST was stale

**Culprit:** `d8f73d59c` (#3609).

**Root cause:** `telegram-plugin/hooks/tool-label-pretool.mjs:193` — that commit deliberately replaced the constant `"Running a command"` for a description-less `Bash` call with an allowlist-derived label (`summariseBashCommand`), because the constant froze the sub-agent step feed on one line for a whole job. It updated the plugin-local test (`telegram-plugin/tests/tool-label-pretool.test.ts:89` asserts `ls -la /var/log` → `"Running ls"`) but **not** this root vitest copy, whose `tests/tool-label-pretool.test.ts:258` still expected `"Running a command"` for `{ command: "ls" }`.

**Verdict: code is right, test is stale.** The new behaviour is the intended one, with its own dedicated coverage, so the expectation moves.

**The assertion is not weakened.** The case now pins the derived label, adds the multiplexer form (`git status --short` → `Running git status`), and keeps **two** cases that still land on the generic fallback (`$(cat …)` — nothing safely derivable; and an input with no `command` at all), so the fallback stays asserted rather than becoming quietly unreachable.

## 2. `src/auth/broker/server.test.ts` — a real flake, now deterministic

**Not a regression.** `a consumer's mark-exhausted attributes to its PINNED account` is latency-bound on `api.anthropic.com`. `mark-exhausted` awaits a **live** quota probe inside the request path:

```
markExhaustedAndRoll → nextHealthyAccountLive → probeAndCacheOne → fetchQuota
```

`fetchQuota`'s default abort is 10s (`src/auth/quota.ts:364`) — over **3x** the 3s deadline the file's own `rpc()` helper enforces (`src/auth/broker/server.test.ts:122`). The live-probe path arrived in `839791d3e` (#2565). `d8f73d59c` fixed this exact class in `server-consumer-follow-active.test.ts` and explicitly deferred *"13 tests in `src/auth/broker/server.test.ts` with the identical un-injected live probe"*. **These are those 13.**

**Flake evidence:** 1 failure in 15 repeat runs of the file at `780a095e1`, with the CI signature `Error: rpc timeout` at `server.test.ts:122`. Preloading a `fetch` that hangs 8s makes it deterministic: **exactly 13 tests fail**, including both named in shard 1 of the red run.

**Fix:** the guard is installed at **file level** rather than threading `_testFetchQuota` through 99 broker constructions — so no future test in this file can silently re-flake. A `beforeEach` swaps `globalThis.fetch` for a stub that rejects immediately; `fetchQuota` catches it and returns `{ ok: false, reason: "quota probe network error: …" }` — the same probe **failure** a real probe could only ever produce here, since the seeded tokens are fakes. Selection semantics unchanged. Tests already injecting `_testFetchQuota` bypass `fetch` and are untouched.

Two **outcome** assertions back it: the previously-failing test now asserts the roll's live probe actually went through the guard (a zero means someone removed it and it is back on the wire), and a dedicated test asserts global `fetch` rejects.

---

## Verification

| Check | Result |
|---|---|
| Both files | **130 passed, 0 failed** (were 2 failed) |
| Broker file under hung-fetch harness | **13 failed → 95 passed**; test time `5.37s → 0.80s` (no fetch attempted) |
| 25 consecutive runs of broker file | **0 failures** (was 1 in 15) |
| All of `src/auth` under hung-fetch harness | **45 files / 615 tests pass** — no sibling still latency-bound |
| `npx tsc --noEmit` | clean |
| All `scripts/check-*.mjs` | pass, except `check-plugin-references`, which fails **only** on `Cannot find module '@mtcute/node'` in `telegram-plugin/uat/{login,driver}.ts` — a pre-existing worktree environment gap, untouched here |

**Test-only change.** No production code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
