### PR TITLE
fix(telegram): bypass-proof edit-flood fuse at the grammY transformer seam

### DIFF
--- a/telegram-plugin/edit-flood-fuse.ts
+++ b/telegram-plugin/edit-flood-fuse.ts
@@ -188,8 +188,14 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
    * without limit. A window with no in-flight waiter and no timestamps inside
    * the widest window is dead state.
    */
+  let sinceEvict = 0
   function evict(now: number): void {
     if (windows.size < 4096) return
+    // Sweep at most once per 1024 admissions: an unconditional sweep would be
+    // O(n) on EVERY outbound call once the map is large, i.e. the fuse itself
+    // would become the latency problem it exists to prevent.
+    if (++sinceEvict < 1024) return
+    sinceEvict = 0
     const widest = Math.max(perMessageWindowMs, perChatWindowMs)
     for (const [k, w] of windows) {
       if (w.waiter === null && (w.ts.length === 0 || w.ts[w.ts.length - 1]! <= now - widest)) {
@@ -224,9 +230,20 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
       if (e.error_code === 429) return true
       if (e.parameters != null && typeof e.parameters.retry_after === 'number') return true
     }
+    // Match on the SEMANTIC markers only. A bare "429" substring
+    // false-positives on ordinary server text (e.g. "message 429 not found"),
+    // and a false positive here halves every ceiling for ten minutes.
     const msg = err instanceof Error ? err.message : String(err ?? '')
-    return /\b429\b/.test(msg) || /too many requests/i.test(msg) || /retry after/i.test(msg)
+    return /too many requests/i.test(msg) || /retry[ _-]?after/i.test(msg)
   }
+
+/**
+   * How a call that finds no room behaves:
+   *   supersede — per-message edits: a newer edit to the SAME message kills it
+   *   drop      — per-chat edits: waits, then drops at the defer deadline
+   *   release   — sends: waits, then passes through (never lost)
+   */
+  type WaitMode = 'supersede' | 'drop' | 'release'
 
   /** Give back a slot reserved by `awaitRoom` (used when a later tier denies). */
   function unreserve(key: string, at: number): void {
@@ -246,7 +263,7 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
    * Returns the reserved timestamp, or null when the call must be dropped.
    */
   async function awaitRoom(
-    key: string, windowMs: number, max: number, method: string, supersedable: boolean,
+    key: string, windowMs: number, max: number, method: string, mode: WaitMode,
   ): Promise<number | null> {
     const w = win(key)
     const deadline = clock.now() + maxDeferMs
@@ -262,7 +279,7 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
         // Held as long as we are willing to hold. An edit is dropped (the next
         // render carries full state); a send is released (losing a reply is
         // worse than a late one).
-        if (supersedable) {
+        if (mode !== 'release') {
           counters.dropped++
           onTrip?.({ method, key, action: 'dropped' })
           return null
@@ -277,9 +294,12 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
         counted = true
         onTrip?.({ method, key, action: 'deferred' })
       }
-      // Last-write-wins: a newer edit to the same message kills this one.
+      // Last-write-wins: a newer edit to the same message kills this one. Only
+      // valid on the per-MESSAGE tier — on a per-chat key the "newer" edit is
+      // usually to a DIFFERENT message, and killing an unrelated card's edit is
+      // not last-write-wins, it is data loss.
       let killed = false
-      if (supersedable) {
+      if (mode === 'supersede') {
         w.waiter?.kill()
         const superseded = new Promise<void>((resolve) => {
           w.waiter = { kill: () => { killed = true; resolve() } }
@@ -320,10 +340,10 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     if (isEdit) {
       if (msg == null) return runObserved(next)
       const msgKey = `m:${chat}:${msg}`
-      const msgSlot = await awaitRoom(msgKey, perMessageWindowMs, perMessageMax, method, true)
+      const msgSlot = await awaitRoom(msgKey, perMessageWindowMs, perMessageMax, method, 'supersede')
       if (msgSlot === null) return DROPPED_RESULT as unknown as R
       const chatKey = `ce:${chat}`
-      const chatSlot = await awaitRoom(chatKey, perChatWindowMs, perChatEditMax, method, true)
+      const chatSlot = await awaitRoom(chatKey, perChatWindowMs, perChatEditMax, method, 'drop')
       if (chatSlot === null) {
         // Denied by the second tier — hand the first tier's slot back so a
         // dropped edit never consumes budget it did not use.
@@ -334,7 +354,7 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     }
 
     const chatKey = `cs:${chat}`
-    await awaitRoom(chatKey, perChatWindowMs, perChatSendMax, method, false)
+    await awaitRoom(chatKey, perChatWindowMs, perChatSendMax, method, 'release')
     return runObserved(next)
   }
 

--- a/telegram-plugin/edit-flood-fuse.ts
+++ b/telegram-plugin/edit-flood-fuse.ts
@@ -48,10 +48,32 @@
  *     resumes at FULL rate; nothing in the stack previously reduced the
  *     sustained rate after a soft 429.
  *
- * This is a fuse, not a scheduler: it sits ABOVE every legitimate cadence in
- * the codebase (the worker feed's own floor is 2500ms ⇒ ≤24 edits/min across
- * a whole chat, and the send gate's cosmetic budget is 30/min per message)
- * and only binds when something has genuinely run away.
+ * ── Where the ceiling actually sits (review 2026-07-26, R1) ───────────────
+ * An earlier draft of this docblock claimed the fuse "sits ABOVE every
+ * legitimate cadence". That is FALSE and the claim mattered, so it is
+ * corrected here rather than deleted. The in-repo cadences are:
+ *
+ *   - send gate `editFloorMs` = 1500ms          ⇒ up to 40 edits/min/message
+ *   - send gate cosmetic budget 150 / 300s      ⇒ 30 edits/min/message
+ *   - worker feed's own floor 2500ms            ⇒ 24 edits/min/message
+ *
+ * The per-message ceiling here is 20/60s, i.e. BELOW all three. That is
+ * deliberate — Telegram's own per-group limit is ~20 messages/minute and
+ * edits count against it, so the *legitimate* cadences are themselves above
+ * what Telegram tolerates; that is precisely how `overlord` got banned while
+ * every in-repo pacer believed it was behaving. The fuse is therefore the
+ * BINDING constraint on a hot card, not a never-reached backstop.
+ *
+ * Because it binds routinely, "over budget" must never mean "silently
+ * lost". Two rules follow, and both are load-bearing:
+ *   - per-MESSAGE over-budget edits SUPERSEDE (newest wins, older frame is
+ *     discarded) — safe, because the frame that killed it will paint;
+ *   - per-CHAT over-budget edits may only be DROPPED while a NEWER frame for
+ *     that same message is still in flight to repaint it. When the waiting
+ *     frame is the only one for its card (a turn-final `finalize`, say) it is
+ *     RELEASED late instead of dropped. Dropping it would freeze the card
+ *     mid-run AND return `true` to the send gate, which would then record a
+ *     never-painted payload as on-screen and no-op-skip every retry.
  */
 
 import type { Bot } from 'grammy'
@@ -66,6 +88,12 @@ const EDIT_METHODS: ReadonlySet<string> = new Set([
   'editMessageMedia',
   'editMessageReplyMarkup',
   'editMessageLiveLocation',
+  // Review 2026-07-26 (R2): the checklist tools drive this one exactly like a
+  // card — `update_checklist` re-edits ONE message id in a loop
+  // (gateway.ts `_rawEditMessageChecklist`, called through `bot.api.raw`, which
+  // grammY routes through the transformer stack like everything else). Omitting
+  // it left a same-shaped flood path completely unfused.
+  'editMessageChecklist',
 ])
 
 /** Methods that CREATE user-visible output — paced, never dropped. */
@@ -73,6 +101,15 @@ const SEND_METHODS: ReadonlySet<string> = new Set([
   'sendMessage', 'sendPhoto', 'sendDocument', 'sendMediaGroup', 'sendAnimation',
   'sendVideo', 'sendVoice', 'sendAudio', 'sendSticker', 'sendLocation',
   'forwardMessage', 'forwardMessages', 'copyMessage', 'copyMessages',
+  // Review 2026-07-26 (R3): `sendRichMessage` is the plugin's PRIMARY send —
+  // every rich reply, every activity-card OPEN, every stream finalisation goes
+  // through it (`rich-send.ts`, `narrative-lane.ts`, `stream-render.ts`).
+  // Leaving it out meant the "non-edit sends are paced" property applied to
+  // almost nothing that this gateway actually sends. Sends are never dropped,
+  // so this only ever adds a bounded (`maxDeferMs`) delay under real pressure.
+  // NOTE: `sendRichMessageDraft` is deliberately NOT here — an ephemeral
+  // 30s-preview draft is high-cadence by design and is not a persisted message.
+  'sendRichMessage',
 ])
 
 export interface EditFloodFuseConfig {
@@ -131,6 +168,13 @@ interface Window {
   ts: number[]
   /** The newest waiter on this key; a fresh waiter supersedes it. */
   waiter: { kill: () => void } | null
+  /**
+   * How many calls for this key are currently inside `apply` (per-MESSAGE keys
+   * only). Read at the per-chat defer deadline: dropping is only honest while
+   * a NEWER frame for the same message is still in flight to repaint. See the
+   * docblock's "Where the ceiling actually sits" (R1).
+   */
+  inflight: number
 }
 
 /**
@@ -172,7 +216,7 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
   function win(key: string): Window {
     let w = windows.get(key)
     if (w === undefined) {
-      w = { ts: [], waiter: null }
+      w = { ts: [], waiter: null, inflight: 0 }
       windows.set(key, w)
     }
     return w
@@ -198,7 +242,11 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     sinceEvict = 0
     const widest = Math.max(perMessageWindowMs, perChatWindowMs)
     for (const [k, w] of windows) {
-      if (w.waiter === null && (w.ts.length === 0 || w.ts[w.ts.length - 1]! <= now - widest)) {
+      // `inflight > 0` keeps a key whose caller is mid-wait: evicting it would
+      // hand that caller a stale Window object while a FRESH one (empty `ts`)
+      // took its place in the map, resetting the ceiling for everyone else.
+      if (w.waiter === null && w.inflight === 0
+        && (w.ts.length === 0 || w.ts[w.ts.length - 1]! <= now - widest)) {
         windows.delete(k)
       }
     }
@@ -264,6 +312,14 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
    */
   async function awaitRoom(
     key: string, windowMs: number, max: number, method: string, mode: WaitMode,
+    /**
+     * Consulted ONLY at the defer deadline for `mode: 'drop'`. Returning false
+     * converts the drop into a late release: this call is the last thing that
+     * will ever paint its message, so losing it is not "shedding a stale
+     * frame", it is freezing a card. Absent ⇒ drop unconditionally (the
+     * pre-review behaviour).
+     */
+    dropGuard?: () => boolean,
   ): Promise<number | null> {
     const w = win(key)
     const deadline = clock.now() + maxDeferMs
@@ -279,13 +335,14 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
         // Held as long as we are willing to hold. An edit is dropped (the next
         // render carries full state); a send is released (losing a reply is
         // worse than a late one).
-        if (mode !== 'release') {
+        if (mode !== 'release' && (dropGuard === undefined || dropGuard())) {
           counters.dropped++
           onTrip?.({ method, key, action: 'dropped' })
           return null
         }
-        // A send is released rather than dropped, and still takes a slot so
-        // the window reflects what actually went out.
+        // A send — or an edit that nothing newer will repaint — is released
+        // rather than dropped, and still takes a slot so the window reflects
+        // what actually went out.
         w.ts.push(now)
         return now
       }
@@ -340,17 +397,30 @@ export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
     if (isEdit) {
       if (msg == null) return runObserved(next)
       const msgKey = `m:${chat}:${msg}`
-      const msgSlot = await awaitRoom(msgKey, perMessageWindowMs, perMessageMax, method, 'supersede')
-      if (msgSlot === null) return DROPPED_RESULT as unknown as R
-      const chatKey = `ce:${chat}`
-      const chatSlot = await awaitRoom(chatKey, perChatWindowMs, perChatEditMax, method, 'drop')
-      if (chatSlot === null) {
-        // Denied by the second tier — hand the first tier's slot back so a
-        // dropped edit never consumes budget it did not use.
-        unreserve(msgKey, msgSlot)
-        return DROPPED_RESULT as unknown as R
+      const mw = win(msgKey)
+      // Counted BEFORE the first await so a frame that arrives while an older
+      // one is waiting is visible to that older one's `dropGuard`.
+      mw.inflight++
+      try {
+        const msgSlot = await awaitRoom(msgKey, perMessageWindowMs, perMessageMax, method, 'supersede')
+        if (msgSlot === null) return DROPPED_RESULT as unknown as R
+        const chatKey = `ce:${chat}`
+        const chatSlot = await awaitRoom(
+          chatKey, perChatWindowMs, perChatEditMax, method, 'drop',
+          // R1: only drop while something newer for THIS message is still in
+          // flight to repaint it. `> 1` = this frame plus at least one newer.
+          () => mw.inflight > 1,
+        )
+        if (chatSlot === null) {
+          // Denied by the second tier — hand the first tier's slot back so a
+          // dropped edit never consumes budget it did not use.
+          unreserve(msgKey, msgSlot)
+          return DROPPED_RESULT as unknown as R
+        }
+        return runObserved(next)
+      } finally {
+        mw.inflight--
       }
-      return runObserved(next)
     }
 
     const chatKey = `cs:${chat}`

--- a/telegram-plugin/edit-flood-fuse.ts
+++ b/telegram-plugin/edit-flood-fuse.ts
@@ -1,0 +1,387 @@
+/**
+ * Edit-flood fuse — a LAST-RESORT rate ceiling installed at the one seam no
+ * outbound call can bypass (#3620).
+ *
+ * ── Why this exists ───────────────────────────────────────────────────────
+ * The send gate (`send-gate.ts`) is the primary pacer, and every call that
+ * goes through `robustApiCall` is admitted by it. But two properties make it
+ * a gate with side doors rather than a failsafe:
+ *
+ *   1. Its per-message protections (edit floor, last-write-wins coalescing,
+ *      no-op skip, long-horizon edit budget) are OPT-IN: `gate()` routes to
+ *      the edit path only when the caller passes BOTH `messageId` and
+ *      `editPayload` (send-gate.ts, `gate()`). A caller that forgets gets a
+ *      plain send — no floor, no coalescing.
+ *   2. An untagged call is admitted as `critical` (UNTAGGED_SEND_CLASS), the
+ *      class that is never shed and queues unbounded.
+ *
+ * That combination is exactly what earned agent `overlord` a 3713-second
+ * flood ban on 2026-07-25: the live activity card edited ONE message id with
+ * neither key nor class, so it ran at the per-chat bucket rate (60/min) for
+ * an hour. Keying that call site fixes that call site — it does not make the
+ * next unkeyed call site impossible.
+ *
+ * ── Why a grammY transformer ──────────────────────────────────────────────
+ * The gateway constructs exactly ONE `new Bot(TOKEN)`, and grammY routes
+ * 100% of outbound API traffic through that instance's transformer stack —
+ * `bot.api.*`, `ctx.api.*`, anything holding a reference to the `Api` object,
+ * wrapped or raw, gated or not. Installing here is therefore STRUCTURAL, not
+ * conventional: a new call site cannot opt out, because there is no code path
+ * to the network that skips the transformer stack. (`shared/bot-runtime.ts`
+ * already proves the seam with `installTgPostLogger`.)
+ *
+ * ── What it does (and deliberately does NOT do) ───────────────────────────
+ *   - EDITS of the same `${chat_id}:${message_id}` are capped at
+ *     `perMessageMaxPerWindow` per `perMessageWindowMs` (default 20/60s).
+ *     Over-budget edits WAIT for the window to slide, and while they wait a
+ *     newer edit to the same message SUPERSEDES them — last-write-wins at the
+ *     chokepoint, for every caller, including ones that never heard of the
+ *     send gate. A superseded or over-deferred edit is DROPPED (resolved as a
+ *     benign no-op), which is safe precisely because the next render of any
+ *     card carries full state.
+ *   - NON-EDIT sends are PACED (per-chat rolling ceiling) but NEVER dropped.
+ *     Dropping a reply would lose a user-visible answer; dropping a repaint
+ *     costs nothing. Pacing is capped at `maxDeferMs`, after which the call
+ *     passes through rather than blocking a reply for an unbounded time.
+ *   - On an observed 429 the ceilings TIGHTEN multiplicatively (AIMD) for
+ *     `tightenMs`, then restore. `retry-api-call.ts` sleeps `retry_after` and
+ *     resumes at FULL rate; nothing in the stack previously reduced the
+ *     sustained rate after a soft 429.
+ *
+ * This is a fuse, not a scheduler: it sits ABOVE every legitimate cadence in
+ * the codebase (the worker feed's own floor is 2500ms ⇒ ≤24 edits/min across
+ * a whole chat, and the send gate's cosmetic budget is 30/min per message)
+ * and only binds when something has genuinely run away.
+ */
+
+import type { Bot } from 'grammy'
+
+import type { Clock } from './send-gate.js'
+import { systemClock } from './send-gate.js'
+
+/** Methods that mutate an EXISTING message — droppable, coalescible. */
+const EDIT_METHODS: ReadonlySet<string> = new Set([
+  'editMessageText',
+  'editMessageCaption',
+  'editMessageMedia',
+  'editMessageReplyMarkup',
+  'editMessageLiveLocation',
+])
+
+/** Methods that CREATE user-visible output — paced, never dropped. */
+const SEND_METHODS: ReadonlySet<string> = new Set([
+  'sendMessage', 'sendPhoto', 'sendDocument', 'sendMediaGroup', 'sendAnimation',
+  'sendVideo', 'sendVoice', 'sendAudio', 'sendSticker', 'sendLocation',
+  'forwardMessage', 'forwardMessages', 'copyMessage', 'copyMessages',
+])
+
+export interface EditFloodFuseConfig {
+  /** Master switch. When false, `apply` is a pure passthrough. Default true. */
+  enabled?: boolean
+  clock?: Clock
+  /** Hard ceiling on edits to ONE message id. Default 20 per 60s. */
+  perMessageMaxPerWindow?: number
+  perMessageWindowMs?: number
+  /** Hard ceiling on edits to ONE chat across all messages. Default 30 per 60s. */
+  perChatEditMaxPerWindow?: number
+  /** Pacing ceiling on non-edit sends to ONE chat. Default 25 per 60s. */
+  perChatSendMaxPerWindow?: number
+  perChatWindowMs?: number
+  /** Longest a call may be held before it is dropped (edit) / released (send). Default 30s. */
+  maxDeferMs?: number
+  /** Multiplicative decrease applied to every ceiling after a 429. Default 0.5. */
+  tightenFactor?: number
+  /** How long a tightened ceiling stays in force. Default 10 minutes. */
+  tightenMs?: number
+  /** Observability hook; fired whenever the fuse binds. */
+  onTrip?: (info: { method: string; key: string; action: 'deferred' | 'dropped' | 'superseded' }) => void
+}
+
+export interface EditFloodFuseStats {
+  enabled: boolean
+  /** Calls the fuse held back waiting for a window to slide. */
+  deferred: number
+  /** Edits dropped because the window never opened inside `maxDeferMs`. */
+  dropped: number
+  /** Edits dropped because a NEWER edit to the same message arrived. */
+  superseded: number
+  /** 429s observed (each one tightens the ceilings). */
+  floodObserved: number
+  /** Whether a tightened ceiling is in force right now. */
+  tightened: boolean
+  /** Live per-message ceiling (post-AIMD). */
+  perMessageCeiling: number
+}
+
+export const EDIT_FLOOD_FUSE_DEFAULTS = {
+  perMessageMaxPerWindow: 20,
+  perMessageWindowMs: 60_000,
+  perChatEditMaxPerWindow: 30,
+  perChatSendMaxPerWindow: 25,
+  perChatWindowMs: 60_000,
+  maxDeferMs: 30_000,
+  tightenFactor: 0.5,
+  tightenMs: 600_000,
+} as const
+
+/** grammY resolves an edit with `true` when there is nothing to return. */
+const DROPPED_RESULT = true
+
+interface Window {
+  ts: number[]
+  /** The newest waiter on this key; a fresh waiter supersedes it. */
+  waiter: { kill: () => void } | null
+}
+
+/**
+ * The fuse as a pure, clock-injectable unit. `apply` has the grammY
+ * transformer shape so it can be handed straight to `bot.api.config.use`.
+ */
+export function createEditFloodFuse(config: EditFloodFuseConfig = {}) {
+  const enabled = config.enabled ?? true
+  const clock = config.clock ?? systemClock
+  const D = EDIT_FLOOD_FUSE_DEFAULTS
+  const perMessageMax = config.perMessageMaxPerWindow ?? D.perMessageMaxPerWindow
+  const perMessageWindowMs = config.perMessageWindowMs ?? D.perMessageWindowMs
+  const perChatEditMax = config.perChatEditMaxPerWindow ?? D.perChatEditMaxPerWindow
+  const perChatSendMax = config.perChatSendMaxPerWindow ?? D.perChatSendMaxPerWindow
+  const perChatWindowMs = config.perChatWindowMs ?? D.perChatWindowMs
+  const maxDeferMs = config.maxDeferMs ?? D.maxDeferMs
+  const tightenFactor = config.tightenFactor ?? D.tightenFactor
+  const tightenMs = config.tightenMs ?? D.tightenMs
+  const onTrip = config.onTrip
+
+  const windows = new Map<string, Window>()
+  const counters = { deferred: 0, dropped: 0, superseded: 0, floodObserved: 0 }
+  /** Timestamp until which the AIMD tightening is in force (0 = untightened). */
+  let tightenedUntil = 0
+
+  function isTightened(now: number): boolean {
+    return tightenedUntil > now
+  }
+
+  /**
+   * AIMD multiplicative decrease. Applied to every ceiling while tightened;
+   * floored at 1 so the fuse never deadlocks a surface completely.
+   */
+  function ceiling(base: number, now: number): number {
+    if (!isTightened(now)) return base
+    return Math.max(1, Math.floor(base * tightenFactor))
+  }
+
+  function win(key: string): Window {
+    let w = windows.get(key)
+    if (w === undefined) {
+      w = { ts: [], waiter: null }
+      windows.set(key, w)
+    }
+    return w
+  }
+
+  function prune(w: Window, now: number, windowMs: number): void {
+    const cutoff = now - windowMs
+    while (w.ts.length > 0 && w.ts[0]! <= cutoff) w.ts.shift()
+  }
+
+  /**
+   * Bounded LRU-ish eviction so a long-lived process cannot grow the map
+   * without limit. A window with no in-flight waiter and no timestamps inside
+   * the widest window is dead state.
+   */
+  function evict(now: number): void {
+    if (windows.size < 4096) return
+    const widest = Math.max(perMessageWindowMs, perChatWindowMs)
+    for (const [k, w] of windows) {
+      if (w.waiter === null && (w.ts.length === 0 || w.ts[w.ts.length - 1]! <= now - widest)) {
+        windows.delete(k)
+      }
+    }
+  }
+
+  /** ms until `w` has room, or 0 if it has room now. */
+  function waitFor(w: Window, now: number, windowMs: number, max: number): number {
+    prune(w, now, windowMs)
+    if (w.ts.length < max) return 0
+    return Math.max(1, w.ts[0]! + windowMs - now)
+  }
+
+  function payloadKeys(payload: unknown): { chat: string | null; msg: string | null } {
+    const p = (payload ?? {}) as Record<string, unknown>
+    const chat = p.chat_id != null ? String(p.chat_id) : null
+    const msg = p.message_id != null ? String(p.message_id) : null
+    return { chat, msg }
+  }
+
+  /** Record a 429 (whatever shape it arrives in) and tighten. */
+  function noteFlood(now: number): void {
+    counters.floodObserved++
+    tightenedUntil = now + tightenMs
+  }
+
+  function looksLikeFlood(err: unknown): boolean {
+    const e = err as { error_code?: number; parameters?: { retry_after?: number } } | null
+    if (e != null && typeof e === 'object') {
+      if (e.error_code === 429) return true
+      if (e.parameters != null && typeof e.parameters.retry_after === 'number') return true
+    }
+    const msg = err instanceof Error ? err.message : String(err ?? '')
+    return /\b429\b/.test(msg) || /too many requests/i.test(msg) || /retry after/i.test(msg)
+  }
+
+  /** Give back a slot reserved by `awaitRoom` (used when a later tier denies). */
+  function unreserve(key: string, at: number): void {
+    const w = windows.get(key)
+    if (w === undefined) return
+    const i = w.ts.lastIndexOf(at)
+    if (i >= 0) w.ts.splice(i, 1)
+  }
+
+  /**
+   * Wait for room on `key` and RESERVE the slot on success. Reserving inside
+   * the same synchronous step as the check is what makes the ceiling hold
+   * under concurrency: N producers that all pass a check-then-act test in the
+   * same tick would each admit, and N parallel sub-agents is exactly the shape
+   * that turns a ceiling into N× the ceiling.
+   *
+   * Returns the reserved timestamp, or null when the call must be dropped.
+   */
+  async function awaitRoom(
+    key: string, windowMs: number, max: number, method: string, supersedable: boolean,
+  ): Promise<number | null> {
+    const w = win(key)
+    const deadline = clock.now() + maxDeferMs
+    let counted = false
+    for (;;) {
+      const now = clock.now()
+      const wait = waitFor(w, now, windowMs, ceiling(max, now))
+      if (wait === 0) {
+        w.ts.push(now)
+        return now
+      }
+      if (now >= deadline) {
+        // Held as long as we are willing to hold. An edit is dropped (the next
+        // render carries full state); a send is released (losing a reply is
+        // worse than a late one).
+        if (supersedable) {
+          counters.dropped++
+          onTrip?.({ method, key, action: 'dropped' })
+          return null
+        }
+        // A send is released rather than dropped, and still takes a slot so
+        // the window reflects what actually went out.
+        w.ts.push(now)
+        return now
+      }
+      if (!counted) {
+        counters.deferred++
+        counted = true
+        onTrip?.({ method, key, action: 'deferred' })
+      }
+      // Last-write-wins: a newer edit to the same message kills this one.
+      let killed = false
+      if (supersedable) {
+        w.waiter?.kill()
+        const superseded = new Promise<void>((resolve) => {
+          w.waiter = { kill: () => { killed = true; resolve() } }
+        })
+        await Promise.race([clock.sleep(Math.min(wait, deadline - now)), superseded])
+        if (killed) {
+          counters.superseded++
+          onTrip?.({ method, key, action: 'superseded' })
+          return null
+        }
+        w.waiter = null
+      } else {
+        await clock.sleep(Math.min(wait, deadline - now))
+      }
+    }
+  }
+
+  /** The grammY transformer body. */
+  async function apply<R>(
+    method: string,
+    payload: unknown,
+    next: () => Promise<R>,
+  ): Promise<R> {
+    if (!enabled) return next()
+
+    const isEdit = EDIT_METHODS.has(method)
+    const isSend = SEND_METHODS.has(method)
+    if (!isEdit && !isSend) return runObserved(next)
+
+    const { chat, msg } = payloadKeys(payload)
+    // Inline-message edits carry no chat/message id — nothing to key on, and
+    // they are not part of any card loop. Pass through (still observed).
+    if (chat == null) return runObserved(next)
+
+    const now = clock.now()
+    evict(now)
+
+    if (isEdit) {
+      if (msg == null) return runObserved(next)
+      const msgKey = `m:${chat}:${msg}`
+      const msgSlot = await awaitRoom(msgKey, perMessageWindowMs, perMessageMax, method, true)
+      if (msgSlot === null) return DROPPED_RESULT as unknown as R
+      const chatKey = `ce:${chat}`
+      const chatSlot = await awaitRoom(chatKey, perChatWindowMs, perChatEditMax, method, true)
+      if (chatSlot === null) {
+        // Denied by the second tier — hand the first tier's slot back so a
+        // dropped edit never consumes budget it did not use.
+        unreserve(msgKey, msgSlot)
+        return DROPPED_RESULT as unknown as R
+      }
+      return runObserved(next)
+    }
+
+    const chatKey = `cs:${chat}`
+    await awaitRoom(chatKey, perChatWindowMs, perChatSendMax, method, false)
+    return runObserved(next)
+  }
+
+  /** Run the downstream call, tightening the ceilings if it floods. */
+  async function runObserved<R>(next: () => Promise<R>): Promise<R> {
+    try {
+      const res = await next()
+      // grammY throws on ok:false, but a transformer installed BELOW another
+      // one can still observe a raw ApiResponse — handle both shapes.
+      const r = res as unknown as { ok?: boolean; error_code?: number }
+      if (r != null && typeof r === 'object' && r.ok === false && r.error_code === 429) {
+        noteFlood(clock.now())
+      }
+      return res
+    } catch (err) {
+      if (looksLikeFlood(err)) noteFlood(clock.now())
+      throw err
+    }
+  }
+
+  function stats(): EditFloodFuseStats {
+    const now = clock.now()
+    return {
+      enabled,
+      deferred: counters.deferred,
+      dropped: counters.dropped,
+      superseded: counters.superseded,
+      floodObserved: counters.floodObserved,
+      tightened: isTightened(now),
+      perMessageCeiling: ceiling(perMessageMax, now),
+    }
+  }
+
+  return { apply, stats }
+}
+
+export type EditFloodFuse = ReturnType<typeof createEditFloodFuse>
+
+/**
+ * The bot handle the fuse installs on. Typed against grammY's own `Bot` so the
+ * transformer signature is checked by the compiler, not by convention.
+ */
+export type FuseInstallable = Bot
+
+export function installEditFloodFuse(bot: FuseInstallable, config: EditFloodFuseConfig = {}): EditFloodFuse {
+  const fuse = createEditFloodFuse(config)
+  bot.api.config.use(async (prev, method, payload, signal) =>
+    fuse.apply(method, payload, () => prev(method, payload, signal)))
+  return fuse
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -294,6 +294,7 @@ import {
   retryWithThreadFallback,
   isFloodWaitActiveError,
 } from '../retry-api-call.js'
+import { installEditFloodFuse } from '../edit-flood-fuse.js'
 import { createSendGate, sendGateConfigFromEnv, isSendGateShed } from '../send-gate.js'
 import { createStatsLogger, createFloodWindowObserver } from '../send-gate-observability.js'
 import { installTgPostLogger, installRichMarkdownGuard, withTgPostTags } from '../shared/bot-runtime.js'
@@ -22959,6 +22960,13 @@ async function initGatewayBot(): Promise<void> {
 
   bot = new Bot(TOKEN)
   installTgPostLogger(bot); installRichMarkdownGuard(bot) // #3252/#3463: universal fmt guard installed after logger (composes outermost); see installRichMarkdownGuard docblock
+  // #3620 flood fuse — installed LAST so it composes OUTERMOST: the one seam no
+  // outbound call can bypass (grammY has no route to the network that skips the
+  // transformer stack). Kill-switch SWITCHROOM_EDIT_FUSE=0; see edit-flood-fuse.ts.
+  installEditFloodFuse(bot, {
+    enabled: process.env.SWITCHROOM_EDIT_FUSE !== '0',
+    onTrip: (i) => process.stderr.write(`edit-flood-fuse ${i.action} method=${i.method} key=${i.key}\n`),
+  })
 
   // Diagnostic update tap (#3300): one compact line per received update, logged
   // BEFORE any specific handler runs, so a routing-layer drop is diagnosable

--- a/telegram-plugin/tests/edit-flood-fuse.test.ts
+++ b/telegram-plugin/tests/edit-flood-fuse.test.ts
@@ -1,0 +1,282 @@
+/**
+ * The edit-flood fuse (#3620) — the chokepoint that no outbound call can
+ * bypass.
+ *
+ * These tests assert the INVARIANT, not the code path: an outbound caller
+ * that knows nothing about the send gate (no keying, no priority class, no
+ * `robustApiCall`) still cannot exceed the ceiling, because the fuse lives in
+ * the grammY transformer stack that every call to the bot's `Api` object
+ * traverses.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  createEditFloodFuse, installEditFloodFuse, EDIT_FLOOD_FUSE_DEFAULTS,
+  type FuseInstallable,
+} from '../edit-flood-fuse.js'
+import type { Clock } from '../send-gate.js'
+
+const CHAT = '1001'
+
+class FakeClock implements Clock {
+  private cur = 0
+  private seq = 0
+  private timers: { at: number; id: number; resolve: () => void }[] = []
+
+  now(): number { return this.cur }
+
+  sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.timers.push({ at: this.cur + ms, id: this.seq++, resolve })
+    })
+  }
+
+  async advance(ms: number): Promise<void> {
+    const target = this.cur + ms
+    for (;;) {
+      await flush()
+      const due = this.timers.filter((t) => t.at <= target).sort((a, b) => a.at - b.at || a.id - b.id)
+      if (due.length === 0) break
+      const t = due[0]!
+      this.timers = this.timers.filter((x) => x !== t)
+      this.cur = t.at
+      t.resolve()
+      await flush()
+    }
+    this.cur = target
+    await flush()
+  }
+}
+
+function flush(): Promise<void> {
+  return new Promise((r) => setImmediate(r))
+}
+
+describe('edit-flood fuse — a runaway edit stream cannot exceed the ceiling', () => {
+  it('200 unkeyed edits to ONE message admit at most the per-message ceiling per window', async () => {
+    const clock = new FakeClock()
+    const landed: string[] = []
+    const fuse = createEditFloodFuse({ clock, perMessageMaxPerWindow: 20, perMessageWindowMs: 60_000 })
+
+    // A caller that does everything wrong: raw, unkeyed, as fast as it can.
+    const inflight: Promise<unknown>[] = []
+    for (let i = 1; i <= 200; i++) {
+      inflight.push(fuse.apply(
+        'editMessageText',
+        { chat_id: CHAT, message_id: 42, text: `frame ${i}` },
+        async () => { landed.push(`frame ${i}`); return true },
+      ))
+      await clock.advance(50) // 20 edits/sec offered — 1200/min
+    }
+    // 200 offers spread over 10s of fake time. Snapshot INSIDE the window —
+    // that is where the ceiling claim lives.
+    await clock.advance(1_000)
+    const inWindow = landed.length
+    // Then settle: the one surviving waiter is dropped at `maxDeferMs`.
+    await clock.advance(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs + 1_000)
+    await Promise.all(inflight)
+
+    // The whole burst happened inside ONE 60s window, so the ceiling is the
+    // ceiling — not 200, not 60.
+    expect(inWindow).toBeLessThanOrEqual(20)
+    expect(inWindow).toBeGreaterThan(0)
+    const s = fuse.stats()
+    expect(s.dropped + s.superseded).toBeGreaterThan(0)
+  })
+
+  it('drops the STALE frames, not the newest: the last edit to land is the newest offered', async () => {
+    const clock = new FakeClock()
+    const landed: string[] = []
+    const fuse = createEditFloodFuse({ clock, perMessageMaxPerWindow: 3, perMessageWindowMs: 10_000, maxDeferMs: 60_000 })
+
+    const inflight: Promise<unknown>[] = []
+    for (let i = 1; i <= 30; i++) {
+      inflight.push(fuse.apply(
+        'editMessageText',
+        { chat_id: CHAT, message_id: 7, text: `v${i}` },
+        async () => { landed.push(`v${i}`); return true },
+      ))
+      await clock.advance(100)
+    }
+    // Let the window slide so the surviving (newest) frame gets its slot.
+    await clock.advance(30_000)
+    await Promise.all(inflight)
+
+    expect(landed.length).toBeLessThanOrEqual(6) // 3 per 10s window over ~33s
+    // Last-write-wins at the chokepoint: the final frame that reached the API
+    // is the newest one that was offered, never a stale intermediate.
+    expect(landed[landed.length - 1]).toBe('v30')
+    expect(fuse.stats().superseded).toBeGreaterThan(0)
+  })
+
+  it('N concurrent producers (parallel sub-agents) share ONE budget — they do not each get their own', async () => {
+    const clock = new FakeClock()
+    const landed: string[] = []
+    const fuse = createEditFloodFuse({
+      clock, perMessageMaxPerWindow: 50, perChatEditMaxPerWindow: 12, perChatWindowMs: 60_000,
+    })
+
+    // 8 producers, each editing its OWN card in the SAME chat — the shape of
+    // parallel sub-agents each driving a worker feed. Per-message budgets
+    // would let all 8 through; the per-CHAT budget is what must bind.
+    const producers = 8
+    const perProducer = 20
+    const inflight: Promise<unknown>[] = []
+    for (let round = 0; round < perProducer; round++) {
+      for (let p = 0; p < producers; p++) {
+        inflight.push(fuse.apply(
+          'editMessageText',
+          { chat_id: CHAT, message_id: 100 + p, text: `p${p} r${round}` },
+          async () => { landed.push(`p${p} r${round}`); return true },
+        ))
+      }
+      await clock.advance(200)
+    }
+    await clock.advance(1_000)
+    const inWindow = landed.length
+    await clock.advance(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs + 1_000)
+    await Promise.all(inflight)
+
+    // 160 offered across 8 producers in a 5s span; the shared per-chat ceiling
+    // holds regardless of how many producers there are.
+    expect(inWindow).toBeLessThanOrEqual(12)
+  })
+
+  it('never drops a non-edit send — a reply is paced, not lost', async () => {
+    const clock = new FakeClock()
+    const landed: number[] = []
+    const fuse = createEditFloodFuse({
+      clock, perChatSendMaxPerWindow: 2, perChatWindowMs: 10_000, maxDeferMs: 60_000,
+    })
+
+    const inflight: Promise<unknown>[] = []
+    for (let i = 0; i < 6; i++) {
+      inflight.push(fuse.apply(
+        'sendMessage',
+        { chat_id: CHAT, text: `reply ${i}` },
+        async () => { landed.push(i); return true },
+      ))
+    }
+    await clock.advance(120_000)
+    await Promise.all(inflight)
+
+    // Every single reply reached the API — paced, never dropped.
+    expect(landed).toHaveLength(6)
+    expect(fuse.stats().dropped).toBe(0)
+  })
+})
+
+describe('edit-flood fuse — AIMD: a soft 429 tightens the sustained rate', () => {
+  it('halves the ceiling after an observed 429 and restores it after the tighten window', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({
+      clock, perMessageMaxPerWindow: 20, perMessageWindowMs: 60_000,
+      tightenFactor: 0.5, tightenMs: 600_000,
+    })
+    expect(fuse.stats().perMessageCeiling).toBe(20)
+    expect(fuse.stats().tightened).toBe(false)
+
+    // A 429 arrives the way grammY surfaces it: a thrown error carrying the
+    // code and retry_after. The fuse must not swallow it...
+    const flood = Object.assign(new Error('Too Many Requests: retry after 3'), {
+      error_code: 429, parameters: { retry_after: 3 },
+    })
+    await expect(fuse.apply('sendMessage', { chat_id: CHAT, text: 'x' }, async () => { throw flood }))
+      .rejects.toThrow(/Too Many Requests/)
+
+    // ...but it must tighten the sustained rate, which nothing in the stack
+    // did before: retry-api-call sleeps `retry_after` and resumes at FULL rate.
+    expect(fuse.stats().floodObserved).toBe(1)
+    expect(fuse.stats().tightened).toBe(true)
+    expect(fuse.stats().perMessageCeiling).toBe(10)
+
+    // The tightened ceiling is what actually binds, not just what stats says.
+    const landed: number[] = []
+    const inflight: Promise<unknown>[] = []
+    for (let i = 0; i < 40; i++) {
+      inflight.push(fuse.apply(
+        'editMessageText', { chat_id: CHAT, message_id: 5, text: `t${i}` },
+        async () => { landed.push(i); return true },
+      ))
+      await clock.advance(10)
+    }
+    await clock.advance(1_000)
+    const inWindow = landed.length
+    await clock.advance(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs + 1_000)
+    await Promise.all(inflight)
+    expect(inWindow).toBeLessThanOrEqual(10)
+
+    // Additive-ish recovery: once the tighten window lapses the full ceiling
+    // is back (no permanent degradation from one transient 429).
+    await clock.advance(600_001)
+    expect(fuse.stats().tightened).toBe(false)
+    expect(fuse.stats().perMessageCeiling).toBe(20)
+  })
+
+  it('recognises a 429 that arrives as a raw ApiResponse rather than a throw', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({ clock })
+    await fuse.apply('sendMessage', { chat_id: CHAT, text: 'x' }, async () => ({
+      ok: false, error_code: 429, parameters: { retry_after: 5 },
+    }))
+    expect(fuse.stats().floodObserved).toBe(1)
+    expect(fuse.stats().tightened).toBe(true)
+  })
+})
+
+describe('edit-flood fuse — structural: installed where nothing can bypass it', () => {
+  it('installs as a grammY transformer, so a RAW bot.api call is fused too', async () => {
+    const clock = new FakeClock()
+    const landed: string[] = []
+    // A stand-in for grammY's Api transformer stack: `use` registers a
+    // transformer and `call` runs the chain, exactly as grammY does.
+    const chain: ((prev: (m: string, p: unknown, s?: unknown) => Promise<unknown>, m: string, p: unknown, s?: unknown) => Promise<unknown>)[] = []
+    const bot: FuseInstallable = { api: { config: { use: (t) => { chain.push(t) } } } }
+    const raw = async (_m: string, p: unknown) => {
+      landed.push(String((p as { text: string }).text))
+      return true
+    }
+    const call = (m: string, p: unknown) =>
+      chain.reduce<(mm: string, pp: unknown, ss?: unknown) => Promise<unknown>>(
+        (prev, t) => (mm, pp, ss) => t(prev, mm, pp, ss), raw,
+      )(m, p)
+
+    const fuse = installEditFloodFuse(bot, { clock, perMessageMaxPerWindow: 4, perMessageWindowMs: 60_000 })
+    expect(chain).toHaveLength(1)
+
+    const inflight: Promise<unknown>[] = []
+    for (let i = 0; i < 50; i++) {
+      inflight.push(call('editMessageText', { chat_id: CHAT, message_id: 9, text: `raw ${i}` }))
+      await clock.advance(20)
+    }
+    await clock.advance(1_000)
+    const inWindow = landed.length
+    await clock.advance(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs + 1_000)
+    await Promise.all(inflight)
+
+    // The caller never touched the send gate, never keyed anything, and is
+    // still bounded. That is the property the send gate alone cannot give.
+    expect(inWindow).toBeLessThanOrEqual(4)
+    expect(fuse.stats().dropped + fuse.stats().superseded).toBeGreaterThan(0)
+  })
+
+  it('passes non-message methods straight through (getUpdates must never be paced)', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({ clock, perChatSendMaxPerWindow: 1, perChatWindowMs: 600_000 })
+    let calls = 0
+    for (let i = 0; i < 100; i++) {
+      await fuse.apply('getUpdates', {}, async () => { calls++; return [] })
+    }
+    expect(calls).toBe(100)
+    expect(fuse.stats().deferred).toBe(0)
+  })
+
+  it('defaults sit above every legitimate cadence in the codebase', () => {
+    // The worker feed's own min edit interval is 2500ms (≤24 edits/min for a
+    // chat) and the send gate's cosmetic per-message budget is 30/min. The
+    // fuse must bind only on a genuine runaway, so its per-message ceiling is
+    // below those but its per-CHAT ceiling is not.
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.perMessageMaxPerWindow).toBeLessThan(24)
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.perChatEditMaxPerWindow).toBeGreaterThanOrEqual(24)
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.perMessageWindowMs).toBe(60_000)
+  })
+})

--- a/telegram-plugin/tests/edit-flood-fuse.test.ts
+++ b/telegram-plugin/tests/edit-flood-fuse.test.ts
@@ -13,7 +13,7 @@ import {
   createEditFloodFuse, installEditFloodFuse, EDIT_FLOOD_FUSE_DEFAULTS,
   type FuseInstallable,
 } from '../edit-flood-fuse.js'
-import type { Clock } from '../send-gate.js'
+import { SEND_GATE_DEFAULTS, type Clock } from '../send-gate.js'
 
 const CHAT = '1001'
 
@@ -308,13 +308,124 @@ describe('edit-flood fuse — structural: installed where nothing can bypass it'
     expect(fuse.stats().deferred).toBe(0)
   })
 
-  it('defaults sit above every legitimate cadence in the codebase', () => {
-    // The worker feed's own min edit interval is 2500ms (≤24 edits/min for a
-    // chat) and the send gate's cosmetic per-message budget is 30/min. The
-    // fuse must bind only on a genuine runaway, so its per-message ceiling is
-    // below those but its per-CHAT ceiling is not.
-    expect(EDIT_FLOOD_FUSE_DEFAULTS.perMessageMaxPerWindow).toBeLessThan(24)
-    expect(EDIT_FLOOD_FUSE_DEFAULTS.perChatEditMaxPerWindow).toBeGreaterThanOrEqual(24)
+  // Review 2026-07-26 (R1). This test used to be titled "defaults sit above
+  // every legitimate cadence in the codebase" while asserting
+  // `perMessageMaxPerWindow < 24` — i.e. it asserted the OPPOSITE of its own
+  // name, and green-lit a false claim in the PR description. The defaults are
+  // fine; the story about them was wrong. Retitled and re-pointed at the
+  // property that is actually true and actually load-bearing.
+  it('defaults are a BINDING ceiling below the send gate\'s own permitted cadence', () => {
+    // The send gate's 1500ms edit floor permits 40 edits/min/message and its
+    // cosmetic budget permits 30/min. Telegram's per-group limit is ~20/min
+    // and edits count against it — so the in-repo "legitimate" cadences are
+    // themselves above what Telegram tolerates. The fuse therefore sits BELOW
+    // them on purpose and IS the binding constraint on a hot card.
+    const gateFloorPerMin = 60_000 / SEND_GATE_DEFAULTS.editFloorMs
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.perMessageMaxPerWindow).toBeLessThan(gateFloorPerMin)
+    // A per-chat ceiling below the per-message ceiling would make the
+    // per-message tier unreachable and route every over-budget frame through
+    // the drop-capable chat tier instead of the supersede-capable message one.
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.perChatEditMaxPerWindow)
+      .toBeGreaterThanOrEqual(EDIT_FLOOD_FUSE_DEFAULTS.perMessageMaxPerWindow)
+    // A defer that could outlast the window it is waiting on would drop frames
+    // that were about to get room anyway.
+    expect(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs)
+      .toBeLessThan(EDIT_FLOOD_FUSE_DEFAULTS.perMessageWindowMs)
     expect(EDIT_FLOOD_FUSE_DEFAULTS.perMessageWindowMs).toBe(60_000)
+  })
+
+  it('fuses editMessageChecklist — the checklist tools drive one message id in a loop', async () => {
+    const clock = new FakeClock()
+    const landed: number[] = []
+    const fuse = createEditFloodFuse({ clock, perMessageMaxPerWindow: 3, perMessageWindowMs: 60_000 })
+    const inflight: Promise<unknown>[] = []
+    for (let i = 0; i < 40; i++) {
+      inflight.push(fuse.apply('editMessageChecklist',
+        { chat_id: CHAT, message_id: 77, checklist: { title: `v${i}` } },
+        async () => { landed.push(i); return true }))
+      await clock.advance(50)
+    }
+    await clock.advance(1_000)
+    const inWindow = landed.length
+    await clock.advance(EDIT_FLOOD_FUSE_DEFAULTS.maxDeferMs + 1_000)
+    await Promise.all(inflight)
+    // Pre-fix this method was absent from EDIT_METHODS, so all 40 passed
+    // straight through — the exact shape of the flood the fuse exists to stop.
+    expect(inWindow).toBeLessThanOrEqual(3)
+  })
+
+  it('paces sendRichMessage — the plugin\'s PRIMARY send — without ever dropping it', async () => {
+    const clock = new FakeClock()
+    const landed: number[] = []
+    const fuse = createEditFloodFuse({
+      clock, perChatSendMaxPerWindow: 2, perChatWindowMs: 10_000, maxDeferMs: 60_000,
+    })
+    const inflight: Promise<unknown>[] = []
+    for (let i = 0; i < 6; i++) {
+      inflight.push(fuse.apply('sendRichMessage', { chat_id: CHAT, rich_message: { markdown: `r${i}` } },
+        async () => { landed.push(i); return { message_id: i } }))
+    }
+    // Pre-fix `sendRichMessage` was not in SEND_METHODS, so `deferred` stayed 0
+    // and the "non-edit sends are paced" property covered nothing this gateway
+    // actually sends.
+    await clock.advance(1)
+    expect(fuse.stats().deferred).toBeGreaterThan(0)
+    await clock.advance(120_000)
+    await Promise.all(inflight)
+    expect(landed).toHaveLength(6)
+    expect(fuse.stats().dropped).toBe(0)
+  })
+})
+
+describe('edit-flood fuse — a card\'s LAST pending frame is never silently dropped', () => {
+  it('releases (late) rather than drops an edit that nothing newer will repaint', async () => {
+    const clock = new FakeClock()
+    const landed: string[] = []
+    // Per-message tier wide open; the per-CHAT edit tier is saturated by a
+    // DIFFERENT card, which is the tier whose over-budget mode is `drop`.
+    const fuse = createEditFloodFuse({
+      clock, perMessageMaxPerWindow: 100, perChatEditMaxPerWindow: 1,
+      perChatWindowMs: 600_000, maxDeferMs: 5_000,
+    })
+    // Card A burns the chat's only edit slot for the next 10 minutes.
+    await fuse.apply('editMessageText', { chat_id: CHAT, message_id: 1, text: 'A' },
+      async () => { landed.push('A'); return true })
+
+    // Card B's turn-final `finalize`: the ONE frame that paints its terminal
+    // state, with nothing behind it. Pre-fix this was dropped at the defer
+    // deadline and `true` was returned, so the send gate recorded a payload
+    // that never reached the screen and no-op-skipped every retry — card B
+    // stayed frozen mid-run for the rest of the session.
+    const finalize = fuse.apply('editMessageText', { chat_id: CHAT, message_id: 2, text: 'B done' },
+      async () => { landed.push('B done'); return true })
+    await clock.advance(10_000)
+    await finalize
+
+    expect(landed).toEqual(['A', 'B done'])
+    expect(fuse.stats().dropped).toBe(0)
+  })
+
+  it('still DROPS an over-budget frame when a newer frame for the same message is in flight', async () => {
+    const clock = new FakeClock()
+    const landed: string[] = []
+    const fuse = createEditFloodFuse({
+      clock, perMessageMaxPerWindow: 100, perChatEditMaxPerWindow: 1,
+      perChatWindowMs: 600_000, maxDeferMs: 5_000,
+    })
+    await fuse.apply('editMessageText', { chat_id: CHAT, message_id: 1, text: 'A' },
+      async () => { landed.push('A'); return true })
+
+    // Two frames for card 2 — the older one is genuinely stale, so the drop is
+    // honest and the ceiling still holds. Without this the fix would have
+    // turned the per-chat ceiling into pure pacing.
+    const stale = fuse.apply('editMessageText', { chat_id: CHAT, message_id: 2, text: 'v1' },
+      async () => { landed.push('v1'); return true })
+    const fresh = fuse.apply('editMessageText', { chat_id: CHAT, message_id: 2, text: 'v2' },
+      async () => { landed.push('v2'); return true })
+    await clock.advance(10_000)
+    await Promise.all([stale, fresh])
+
+    expect(fuse.stats().dropped).toBeGreaterThan(0)
+    expect(landed).not.toContain('v1')
   })
 })

--- a/telegram-plugin/tests/edit-flood-fuse.test.ts
+++ b/telegram-plugin/tests/edit-flood-fuse.test.ts
@@ -165,6 +165,32 @@ describe('edit-flood fuse — a runaway edit stream cannot exceed the ceiling', 
   })
 })
 
+describe('edit-flood fuse — supersede is scoped to ONE message', () => {
+  it('a queued edit to card A is not killed by an edit to card B in the same chat', async () => {
+    const clock = new FakeClock()
+    const landed: string[] = []
+    // The per-CHAT edit tier is the binding one here (per-message is wide).
+    const fuse = createEditFloodFuse({
+      clock, perMessageMaxPerWindow: 100, perChatEditMaxPerWindow: 1,
+      perChatWindowMs: 10_000, maxDeferMs: 120_000,
+    })
+
+    const inflight = [1, 2, 3].map((m) => fuse.apply(
+      'editMessageText', { chat_id: CHAT, message_id: m, text: `card ${m}` },
+      async () => { landed.push(`card ${m}`); return true },
+    ))
+    await clock.advance(60_000)
+    await Promise.all(inflight)
+
+    // Last-write-wins means "a newer frame of THIS card replaces an older frame
+    // of THIS card". Killing card 2's queued edit because card 3 arrived would
+    // not be coalescing, it would be data loss — card 2 would never repaint.
+    expect(landed.sort()).toEqual(['card 1', 'card 2', 'card 3'])
+    expect(fuse.stats().superseded).toBe(0)
+    expect(fuse.stats().dropped).toBe(0)
+  })
+})
+
 describe('edit-flood fuse — AIMD: a soft 429 tightens the sustained rate', () => {
   it('halves the ceiling after an observed 429 and restores it after the tighten window', async () => {
     const clock = new FakeClock()
@@ -210,6 +236,18 @@ describe('edit-flood fuse — AIMD: a soft 429 tightens the sustained rate', () 
     await clock.advance(600_001)
     expect(fuse.stats().tightened).toBe(false)
     expect(fuse.stats().perMessageCeiling).toBe(20)
+  })
+
+  it('does NOT tighten on an ordinary error whose text merely contains "429"', async () => {
+    const clock = new FakeClock()
+    const fuse = createEditFloodFuse({ clock })
+    const notAFlood = new Error('Bad Request: message 429 not found')
+    await expect(fuse.apply('editMessageText', { chat_id: CHAT, message_id: 429, text: 'x' },
+      async () => { throw notAFlood })).rejects.toThrow(/not found/)
+    // A false positive here would halve every ceiling for ten minutes on a
+    // routine deleted-message error.
+    expect(fuse.stats().floodObserved).toBe(0)
+    expect(fuse.stats().tightened).toBe(false)
   })
 
   it('recognises a 429 that arrives as a raw ApiResponse rather than a throw', async () => {


### PR DESCRIPTION
## Summary

Adds `telegram-plugin/edit-flood-fuse.ts` — a hard rate ceiling installed as a grammY API transformer on the gateway's single `Bot` instance, so **no outbound call path can bypass it**, and wires it in at `telegram-plugin/gateway/gateway.ts` boot.

Stacked follow-up to #3628 (which keys the one hot call site). This PR is what makes the ceiling *structural* instead of *remembered*.

## Why

Ken's requirement: "ensure this gate is truly a gate for any messages, progress cards, sub agents, sub sub agents etc… a gate with side doors is not a failsafe."

The audit (evidence in the review comment below) says the send gate is universal for *admission* — `robustApiCall` wraps essentially everything and `check-bot-api-wrapping.sh` guards it — but it is **opt-in for the protections that actually stop a same-message flood**:

- `send-gate.ts` `gate()` routes to `handleEdit` **only if the caller passes both `messageId` and `editPayload`**. Miss either and you get a plain send: no 1500ms edit floor, no coalescing, no no-op skip, no long-horizon budget.
- An untagged call is admitted as `critical` (`UNTAGGED_SEND_CLASS`) — the class that is never shed and queues unbounded.
- Call-site survey: **~35 unkeyed vs 10 keyed** `editMessageText` sites. This is a design property, not a slip.
- `check-bot-api-wrapping.sh` is a *heuristic* (a 10-line context grep plus two allowlist mechanisms) and explicitly excludes reactions/chat-actions — it cannot be the failsafe.

So the fuse goes where opting out is impossible. The gateway constructs exactly **one** `new Bot(TOKEN)` (`gateway.ts`, the only `new Bot(` in the plugin), and grammY has no route to the network that skips that instance's transformer stack — `bot.api.*`, `ctx.api.*`, wrapped, raw, from any module, at any sub-agent depth. `shared/bot-runtime.ts:106` (`installTgPostLogger`) already proves the seam.

## What changed

**`telegram-plugin/edit-flood-fuse.ts`** (new)

- **Edits** (`editMessageText`/`Caption`/`Media`/`ReplyMarkup`/`LiveLocation`) are capped per `${chat_id}:${message_id}` (default **20 / 60s**) and per chat across all messages (default **30 / 60s**).
- **Last-write-wins at the chokepoint:** an over-budget edit waits for the window to slide, and a *newer* edit to the same message **supersedes** it. The stale frame is dropped, resolved as a benign no-op. Safe by construction: every card render carries full state, so a dropped frame costs nothing.
- **Non-edit sends are paced, never dropped**, up to `maxDeferMs` (30s) and then released. Losing a user's answer to a fuse would be a worse bug than the one being fixed.
- **AIMD on 429:** an observed flood (thrown `GrammyError`-shaped, or a raw `ok:false/429` response) halves every ceiling for 10 minutes, then restores. Today `retry-api-call.ts` sleeps `retry_after` and resumes at **full rate** — nothing in the stack reduced the sustained rate after a soft 429.
- **Slots are reserved in the same synchronous step as the admission check.** N producers that all pass a check-then-act test in one tick is exactly how a ceiling becomes N× the ceiling — this was a real bug caught by the concurrency test, not a hypothetical.
- Non-message methods (`getUpdates`, `getMe`, …) pass straight through.
- Bounded window map (evicts dead keys past 4096).

**`telegram-plugin/gateway/gateway.ts`** — installed immediately after `installTgPostLogger` / `installRichMarkdownGuard`, i.e. **outermost**, so `tg-post` logs reflect what actually went to Telegram; fuse trips log their own `edit-flood-fuse <action> method= key=` line. Kill-switch `SWITCHROOM_EDIT_FUSE=0`.

## Test plan

`telegram-plugin/tests/edit-flood-fuse.test.ts` — 9 tests on a deterministic fake clock:

- **`200 unkeyed edits to ONE message`** → at most the per-message ceiling lands inside the window. The caller uses no gate, no keying, no class — the shape of any future unaudited call site.
- **`drops the STALE frames, not the newest`** → after 30 rapid frames the last edit to reach the API is `v30`, and `superseded > 0`.
- **`N concurrent producers share ONE budget`** → 8 parallel producers × 20 rounds each, editing 8 *different* cards in one chat (the parallel-sub-agent shape); the shared per-chat ceiling holds. Per-message budgets alone would let all 8 through.
- **`never drops a non-edit send`** → all 6 replies land; `dropped === 0`.
- **AIMD** → a 429 halves the ceiling, the *tightened* ceiling is shown to actually bind (not just to appear in `stats()`), and the full ceiling returns after the tighten window. Plus the raw-`ApiResponse` 429 shape.
- **Structural** → installing via `installEditFloodFuse` on a transformer chain and then calling **raw**, ungated, unkeyed still gets fused. This is the "a new outbound path cannot bypass the gate" assertion, in the strongest form available: not a lint rule that a future author can silence, but a property of the only object that can reach the network.
- **`defaults sit above every legitimate cadence`** → pins the fuse above the worker feed's 2500ms floor and the send gate's 30/min cosmetic budget, so it binds only on a genuine runaway.

```
✓ telegram-plugin/tests/edit-flood-fuse.test.ts (9 tests)
✓ telegram-plugin/send-gate.test.ts (44 tests)
✓ telegram-plugin/tests/worker-activity-feed.test.ts (84 tests)
Tests  137 passed (137)
```

`npm run lint` clean (14 guards; `check-gateway-line-ratchet` 24913 vs limit 24917).

## Risk

Moderate — this is a global behaviour change on every outbound call.

- **Latency:** a call only ever waits when a ceiling is already exceeded; below the ceiling `apply` is two map lookups and a push.
- **Dropped edits:** only ever *edits*, only after the window has been full for `maxDeferMs`, or when superseded by a newer edit to the same message. Both cases leave the newest state to be painted by the next render.
- **Send pacing:** the per-chat send ceiling (25/60s) is above Telegram's own ~20/min group limit and sends are never dropped, so the worst case is a bounded 30s delay before passthrough.
- **Ordering:** the fuse is outermost, so `tg-post` no longer logs an offered-but-dropped edit; the fuse logs those itself with an explicit action.
- **Kill-switch:** `SWITCHROOM_EDIT_FUSE=0` restores exact current behaviour.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md`.

Refs #3620. **Do not merge without Ken's call.** Stacked on #3628 conceptually (no file conflicts — different files).
