### PR TITLE
fix(hindsight): isolate foreground recall from background consolidation

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -109,6 +109,7 @@ jobs:
             hindsight:
               - 'docker/Dockerfile.hindsight'
               - 'tests/docker/hindsight-search-patches.test.ts'
+              - 'tests/docker/hindsight-recall-isolation-patches.test.ts'
               - 'tests/docker/dockerfile-hindsight-bakes.test.ts'
               - '.github/workflows/docker-e2e.yml'
 
@@ -240,10 +241,12 @@ jobs:
           done
 
   # ─── Hindsight patch probe (F5: this must NEVER silently skip) ────
-  # tests/docker/hindsight-search-patches.test.ts is the only behavioural
-  # evidence that the patches baked into docker/Dockerfile.hindsight actually
-  # change tokenization/error behaviour — a change that reaches every live
-  # agent's recall. It previously used
+  # tests/docker/hindsight-search-patches.test.ts and
+  # tests/docker/hindsight-recall-isolation-patches.test.ts are the only
+  # behavioural evidence that the patches baked into docker/Dockerfile.hindsight
+  # actually change tokenization/error behaviour and recall admission/worker
+  # scheduling — changes that reach every live agent's recall. The first
+  # previously used
   # `describe.skipIf(!imageOk)` with a deliberate no-pull policy, so on a
   # hosted runner (where the 6.4GB upstream image is never present) it
   # reported green without executing a single assertion.
@@ -295,11 +298,22 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-search-patches.test.ts
 
+      - name: Run the hindsight recall-isolation probe (RED/GREEN, must not skip)
+        # Same contract as the step above, for the admission-split /
+        # worker-slot-ceiling / sem-logging patches. A separate step so a
+        # failure names which patch family broke, and so the pulled image is
+        # reused rather than pulled twice.
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-recall-isolation-patches.test.ts
+
       - name: Label-scoped teardown
         if: always()
         run: |
-          ids=$(docker ps -aq --filter label=switchroom.test=hindsight-search-patches 2>/dev/null || true)
-          if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches; do
+            ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
+            if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
+          done
 
   # ─── Sentinel ─────────────────────────────────────────────────────
   # Branch-protection-required context (see ci-lint.yml header for the

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -881,6 +881,903 @@ assert t.count(") from e\n") >= 2, "switchroom hindsight timeout-message patch: 
 print("switchroom hindsight timeout-message patch: LiteLLM timeout re-raises now carry timeout/attempts/scope instead of an empty message")
 PYEOF
 
+# Recall admission split: background consolidation must not starve the
+# latency-critical per-turn recall hook.
+#
+# Consolidation reaches recall through the SAME entry point a user's turn does
+# (engine/consolidation/consolidator.py -> MemoryEngine.recall_async), so both
+# contend on the single `_search_semaphore` admission gate sized by
+# HINDSIGHT_API_RECALL_MAX_CONCURRENT (8 in this fleet). Measured on this host
+# before the fix: mean admission wait 5.43s, p90 15.7s, max 27.4s, against a
+# recall hook whose per-bank socket timeout is 8s — fleet p50 pinned at exactly
+# 8.02s and per-agent timeout rates of 97.5% / 95.8% / 73.9%.
+#
+# The fix is a strict RESERVATION, not a second budget: a background caller
+# takes a slot in a small background semaphore FIRST and only then the shared
+# one. Total concurrency against the database is therefore unchanged at
+# recall_max_concurrent, background can never hold more than
+# consolidation_recall_max_concurrent of those slots, and foreground always has
+# at least the remainder available to it. Deadlock-free by construction —
+# foreground never acquires the background semaphore, so the acquisition order
+# (background -> shared) is total and no cycle exists.
+#
+# Self-verifying; guarded structurally by
+# tests/docker/dockerfile-hindsight-bakes.test.ts and behaviourally (RED against
+# unpatched upstream / GREEN patched) by
+# tests/docker/hindsight-recall-isolation-patches.test.ts.
+RUN python3 - <<'PYEOF'
+import pathlib
+
+BASE = pathlib.Path("/app/api/hindsight_api")
+
+
+def apply(rel, edits):
+    f = BASE / rel
+    s = f.read_text()
+    for anchor, repl in edits:
+        n = s.count(anchor)
+        assert n == 1, (
+            f"switchroom hindsight recall-admission-split patch: anchor found {n}x "
+            f"(expected 1) in {rel} — upstream reformatted; re-author this patch in "
+            f"docker/Dockerfile.hindsight. Anchor head: {anchor.splitlines()[0]!r}"
+        )
+        s = s.replace(anchor, repl, 1)
+    f.write_text(s)
+    return s
+
+
+# ---- 1. config.py: the background-recall admission budget ----
+cfg_new = apply("config.py", [
+    (
+        'ENV_RECALL_MAX_CONCURRENT = "HINDSIGHT_API_RECALL_MAX_CONCURRENT"\n',
+        'ENV_RECALL_MAX_CONCURRENT = "HINDSIGHT_API_RECALL_MAX_CONCURRENT"\n'
+        'ENV_CONSOLIDATION_RECALL_MAX_CONCURRENT = "HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT"\n',
+    ),
+    (
+        "DEFAULT_RECALL_MAX_CONCURRENT = 32  # Max concurrent recall operations per worker\n",
+        "DEFAULT_RECALL_MAX_CONCURRENT = 32  # Max concurrent recall operations per worker\n"
+        "# switchroom: of the recall_max_concurrent admission slots, at most this many may\n"
+        "# be held by BACKGROUND (consolidation) recalls at once. It is a reservation for\n"
+        "# the foreground, not an extra budget: total concurrency stays\n"
+        "# recall_max_concurrent, and foreground per-turn recall always has at least\n"
+        "# (recall_max_concurrent - this) slots it cannot be denied.\n"
+        "DEFAULT_CONSOLIDATION_RECALL_MAX_CONCURRENT = 2\n"
+        "\n"
+        "\n"
+        "def _consolidation_recall_max_concurrent(getenv) -> int:\n"
+        '    """switchroom: resolve the background-recall reservation.\n'
+        "\n"
+        "    The DEFAULT is derived from recall_max_concurrent, not fixed, so lowering\n"
+        "    HINDSIGHT_API_RECALL_MAX_CONCURRENT can never turn a deployment that boots\n"
+        "    today into one that refuses to boot. An explicit value is taken verbatim and\n"
+        "    validated loudly in HindsightConfig.validate() — misconfiguration should fail,\n"
+        "    but a default never should.\n"
+        '    """\n'
+        "    raw = getenv(ENV_CONSOLIDATION_RECALL_MAX_CONCURRENT)\n"
+        "    if raw is not None and raw.strip():\n"
+        "        return int(raw)\n"
+        "    shared = int(getenv(ENV_RECALL_MAX_CONCURRENT, str(DEFAULT_RECALL_MAX_CONCURRENT)))\n"
+        "    return max(1, min(DEFAULT_CONSOLIDATION_RECALL_MAX_CONCURRENT, shared - 1))\n",
+    ),
+    (
+        "    recall_max_concurrent: int\n    recall_connection_budget: int\n",
+        "    recall_max_concurrent: int\n"
+        "    consolidation_recall_max_concurrent: int\n"
+        "    recall_connection_budget: int\n",
+    ),
+    (
+        "            recall_max_concurrent=int(os.getenv(ENV_RECALL_MAX_CONCURRENT, str(DEFAULT_RECALL_MAX_CONCURRENT))),\n",
+        "            recall_max_concurrent=int(os.getenv(ENV_RECALL_MAX_CONCURRENT, str(DEFAULT_RECALL_MAX_CONCURRENT))),\n"
+        "            consolidation_recall_max_concurrent=_consolidation_recall_max_concurrent(os.getenv),\n",
+    ),
+    (
+        '                f"Reduce reservations or increase HINDSIGHT_API_WORKER_MAX_SLOTS."\n'
+        "            )\n"
+        "\n"
+        "    @classmethod\n"
+        '    def from_env(cls) -> "HindsightConfig":\n',
+
+        '                f"Reduce reservations or increase HINDSIGHT_API_WORKER_MAX_SLOTS."\n'
+        "            )\n"
+        "\n"
+        "        # switchroom: the background-recall reservation must leave the foreground a\n"
+        "        # non-empty floor, otherwise consolidation can still occupy every admission\n"
+        "        # slot and the split buys nothing. Validated at boot for the same reason the\n"
+        "        # reservation sum above is: an incoherent admission policy must fail loudly\n"
+        "        # rather than silently reintroduce the starvation it exists to prevent.\n"
+        "        if self.consolidation_recall_max_concurrent < 1:\n"
+        "            raise ValueError(\n"
+        '                f"consolidation_recall_max_concurrent ({self.consolidation_recall_max_concurrent}) '
+        'must be >= 1. "\n'
+        '                f"Set HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT to a positive integer."\n'
+        "            )\n"
+        "        # The `> 1` guard is the degenerate single-slot deployment: with one\n"
+        "        # admission slot in total no split is possible, and refusing to boot a\n"
+        "        # configuration upstream accepts would be a worse failure than losing a\n"
+        "        # guarantee that cannot exist at that size.\n"
+        "        if (\n"
+        "            self.recall_max_concurrent > 1\n"
+        "            and self.consolidation_recall_max_concurrent >= self.recall_max_concurrent\n"
+        "        ):\n"
+        "            raise ValueError(\n"
+        '                f"consolidation_recall_max_concurrent ({self.consolidation_recall_max_concurrent}) '
+        'must be strictly less "\n'
+        '                f"than recall_max_concurrent ({self.recall_max_concurrent}), otherwise background '
+        'consolidation "\n'
+        '                f"can hold every recall admission slot and foreground per-turn recall has no '
+        'guaranteed floor. "\n'
+        '                f"Lower HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT or raise '
+        'HINDSIGHT_API_RECALL_MAX_CONCURRENT."\n'
+        "            )\n"
+        "\n"
+        "    @classmethod\n"
+        '    def from_env(cls) -> "HindsightConfig":\n',
+    ),
+])
+
+# ---- 2. memory_engine.py: split admission, foreground-first ----
+me_new = apply("engine/memory_engine.py", [
+    (
+        "import asyncio\nimport contextvars\n",
+        "import asyncio\nimport contextlib\nimport contextvars\n",
+    ),
+    (
+        "logger = logging.getLogger(__name__)\n",
+
+        "logger = logging.getLogger(__name__)\n"
+        "\n"
+        "\n"
+        "# switchroom recall-admission split. Background consolidation and the\n"
+        "# latency-critical per-turn foreground recall contended on ONE admission\n"
+        "# semaphore (MemoryEngine._search_semaphore), because consolidation reaches\n"
+        "# recall through the very same recall_async() entry point\n"
+        "# (engine/consolidation/consolidator.py). A consolidation burst could therefore\n"
+        "# hold every slot and starve the foreground hook.\n"
+        "#\n"
+        "# This is a strict RESERVATION, not a second independent budget. A background\n"
+        "# recall must take a slot in the small background semaphore FIRST and only then\n"
+        "# the shared one, so:\n"
+        "#   * total concurrency against the database is unchanged at\n"
+        "#     recall_max_concurrent (the shared semaphore is still the only gate on\n"
+        "#     entering the pipeline), and\n"
+        "#   * background can never hold more than consolidation_recall_max_concurrent of\n"
+        "#     those slots, so foreground always has at least\n"
+        "#     (recall_max_concurrent - consolidation_recall_max_concurrent) slots\n"
+        "#     available to it.\n"
+        "#\n"
+        "# Deadlock-free by construction: foreground NEVER acquires the background\n"
+        "# semaphore, so the acquisition order (background -> shared) is total and no\n"
+        "# cycle exists. A background caller blocked on the shared semaphore delays only\n"
+        "# other background callers.\n"
+        "@contextlib.asynccontextmanager\n"
+        "async def _recall_admission(shared, background_reservation, is_background):\n"
+        '    """Admit one recall; background callers pass the background cap first."""\n'
+        "    if is_background:\n"
+        "        async with background_reservation:\n"
+        "            async with shared:\n"
+        "                yield\n"
+        "    else:\n"
+        "        async with shared:\n"
+        "            yield\n",
+    ),
+    (
+        "        # Backpressure mechanism: limit concurrent searches to prevent overwhelming the database\n"
+        "        # Configurable via HINDSIGHT_API_RECALL_MAX_CONCURRENT (default: 50)\n"
+        "        self._search_semaphore = asyncio.Semaphore(get_config().recall_max_concurrent)\n",
+
+        "        # Backpressure mechanism: limit concurrent searches to prevent overwhelming the database\n"
+        "        # Configurable via HINDSIGHT_API_RECALL_MAX_CONCURRENT (switchroom: the code\n"
+        "        # default is DEFAULT_RECALL_MAX_CONCURRENT = 32; the '50' this comment used to\n"
+        "        # claim never existed in config.py)\n"
+        "        self._search_semaphore = asyncio.Semaphore(get_config().recall_max_concurrent)\n"
+        "\n"
+        "        # switchroom: background (consolidation) recalls must hold one of THESE before\n"
+        "        # they may take a _search_semaphore slot, which caps background at\n"
+        "        # consolidation_recall_max_concurrent of the shared budget and leaves the\n"
+        "        # remainder permanently available to foreground per-turn recall.\n"
+        "        # Configurable via HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT (default: 2).\n"
+        "        self._background_search_semaphore = asyncio.Semaphore(\n"
+        "            get_config().consolidation_recall_max_concurrent\n"
+        "        )\n",
+    ),
+    (
+        "        _quiet: bool = False,\n",
+        "        _quiet: bool = False,\n"
+        "        # switchroom: True for recalls issued by BACKGROUND work (consolidation).\n"
+        "        # Such callers are admitted through a small reservation semaphore first, so\n"
+        "        # they can never consume the admission slots foreground per-turn recall\n"
+        "        # depends on. Leave False for anything a user is waiting on.\n"
+        "        _background: bool = False,\n",
+    ),
+    (
+        "            async with self._search_semaphore:\n",
+        "            async with _recall_admission(\n"
+        "                self._search_semaphore, self._background_search_semaphore, _background\n"
+        "            ):\n",
+    ),
+])
+
+# ---- 3. consolidator.py: mark its internal recall as background ----
+cons_new = apply("engine/consolidation/consolidator.py", [
+    (
+        "        recall_result = await memory_engine.recall_async(\n"
+        "            bank_id=bank_id,\n"
+        "            query=query,\n",
+
+        "        recall_result = await memory_engine.recall_async(\n"
+        "            # switchroom: consolidation is background work with no user waiting on\n"
+        "            # it, so it is admitted through the background reservation and can never\n"
+        "            # starve the foreground per-turn recall hook.\n"
+        "            _background=True,\n"
+        "            bank_id=bank_id,\n"
+        "            query=query,\n",
+    ),
+])
+
+# ---- verification ----
+assert "consolidation_recall_max_concurrent: int" in cfg_new, (
+    "switchroom hindsight recall-admission-split patch: config field missing after patch"
+)
+assert "ENV_CONSOLIDATION_RECALL_MAX_CONCURRENT" in cfg_new, (
+    "switchroom hindsight recall-admission-split patch: env constant missing after patch"
+)
+assert "DEFAULT_CONSOLIDATION_RECALL_MAX_CONCURRENT = 2" in cfg_new, (
+    "switchroom hindsight recall-admission-split patch: default missing after patch"
+)
+assert "must be strictly less" in cfg_new, (
+    "switchroom hindsight recall-admission-split patch: boot validation missing after patch"
+)
+assert "async def _recall_admission(" in me_new, (
+    "switchroom hindsight recall-admission-split patch: admission helper missing after patch"
+)
+assert "self._background_search_semaphore = asyncio.Semaphore(" in me_new, (
+    "switchroom hindsight recall-admission-split patch: background semaphore missing after patch"
+)
+assert "_background: bool = False," in me_new, (
+    "switchroom hindsight recall-admission-split patch: _background parameter missing after patch"
+)
+assert "async with self._search_semaphore:" not in me_new, (
+    "switchroom hindsight recall-admission-split patch: a bare shared-semaphore acquisition "
+    "still remains — background recalls would bypass the reservation"
+)
+assert "_background=True," in cons_new, (
+    "switchroom hindsight recall-admission-split patch: consolidation still recalls as foreground"
+)
+print(
+    "switchroom hindsight recall-admission-split patch: background consolidation recalls now pass a "
+    "reservation semaphore before the shared one; foreground keeps a guaranteed floor of "
+    "(recall_max_concurrent - consolidation_recall_max_concurrent) slots"
+)
+PYEOF
+
+# A real per-operation-type worker slot CEILING.
+#
+# HINDSIGHT_API_WORKER_<TYPE>_MAX_SLOTS is a FLOOR despite the name: see
+# config.WORKER_SLOT_RESERVATION_TYPES and WorkerPoller._get_available_slots,
+# "when an operation type's in-flight count exceeds its reservation, the excess
+# tasks are considered to be using shared pool slots". So a worker log reading
+# `consolidation=6/1(avail=0)` is documented behaviour, not an overrun. The real
+# gap is that upstream has NO ceiling at all, so one operation type can occupy
+# all DEFAULT_WORKER_MAX_SLOTS = 10 slots and starve every other type.
+#
+# This adds `worker_slot_limits` — a hard per-type cap across the reserved and
+# shared pools, defaulting to consolidation<=4 and leaving every other type
+# uncapped (byte-for-byte upstream scheduling). It is validated at boot in
+# HindsightConfig.validate(), alongside the existing
+# `total_reserved <= worker_max_slots` check, and enforced in claim_tasks
+# immediately BEFORE the `UPDATE ... SET status='processing'` — the point that
+# actually claims a row. Surplus rows were selected FOR UPDATE SKIP LOCKED but
+# are never transitioned out of 'pending', so their locks drop with the
+# transaction and they are claimed on a later poll.
+#
+# The misleading ..._MAX_SLOTS name is deliberately NOT changed here (renaming a
+# shipped env var is a breaking config change); it is filed upstream instead.
+#
+# Self-verifying; guarded by tests/docker/dockerfile-hindsight-bakes.test.ts and
+# tests/docker/hindsight-recall-isolation-patches.test.ts.
+RUN python3 - <<'PYEOF'
+import pathlib
+
+BASE = pathlib.Path("/app/api/hindsight_api")
+
+
+def apply(rel, edits, expect=1):
+    f = BASE / rel
+    s = f.read_text()
+    for anchor, repl in edits:
+        n = s.count(anchor)
+        assert n == expect, (
+            f"switchroom hindsight worker-slot-ceiling patch: anchor found {n}x "
+            f"(expected {expect}) in {rel} — upstream reformatted; re-author this patch "
+            f"in docker/Dockerfile.hindsight. Anchor head: {anchor.splitlines()[0]!r}"
+        )
+        s = s.replace(anchor, repl, expect)
+    f.write_text(s)
+    return s
+
+
+# ---- 1. config.py: WORKER_SLOT_LIMIT_TYPES (a real CEILING) + boot validation ----
+cfg_new = apply("config.py", [
+    (
+        '    "import_documents": ("HINDSIGHT_API_WORKER_IMPORT_DOCUMENTS_MAX_SLOTS", 0),\n'
+        "}\n",
+
+        '    "import_documents": ("HINDSIGHT_API_WORKER_IMPORT_DOCUMENTS_MAX_SLOTS", 0),\n'
+        "}\n"
+        "\n"
+        "# switchroom: per-operation-type slot CEILINGS.\n"
+        "#\n"
+        "# WORKER_SLOT_RESERVATION_TYPES above is a FLOOR, despite the ..._MAX_SLOTS\n"
+        "# names. A reservation guarantees a type that much capacity but does NOT stop\n"
+        "# it from ALSO taking the shared pool: see WorkerPoller._get_available_slots,\n"
+        '# "when an operation type\'s in-flight count exceeds its reservation, the excess\n'
+        '# tasks are considered to be using shared pool slots". That is why the worker\n'
+        "# progress log can read `consolidation=6/1(avail=0)` — six consolidation tasks\n"
+        "# against a reservation of one. Documented behaviour, not a bug; but nothing in\n"
+        "# upstream stopped consolidation occupying all DEFAULT_WORKER_MAX_SLOTS and\n"
+        "# starving every other operation type.\n"
+        "#\n"
+        "# These entries are the missing ceiling: a hard cap on how many slots one\n"
+        "# operation type may hold at once, reserved and shared combined. Each maps an\n"
+        "# operation_type to its env var and default cap; None means uncapped (exact\n"
+        "# upstream behaviour). Adding a type here is the ONLY change needed to make it\n"
+        "# cappable — the config field, from_env() and the poller all derive from it.\n"
+        "#\n"
+        "# consolidation defaults to 4 of DEFAULT_WORKER_MAX_SLOTS = 10 because it is the\n"
+        "# only type observed saturating the worker; every other type stays uncapped so\n"
+        "# this patch cannot change their scheduling at all.\n"
+        "WORKER_SLOT_LIMIT_TYPES: dict[str, tuple[str, int | None]] = {\n"
+        '    "consolidation": ("HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT", 4),\n'
+        '    "retain": ("HINDSIGHT_API_WORKER_RETAIN_SLOT_LIMIT", None),\n'
+        '    "file_convert_retain": ("HINDSIGHT_API_WORKER_FILE_CONVERT_RETAIN_SLOT_LIMIT", None),\n'
+        '    "refresh_mental_model": ("HINDSIGHT_API_WORKER_REFRESH_MENTAL_MODEL_SLOT_LIMIT", None),\n'
+        '    "graph_maintenance": ("HINDSIGHT_API_WORKER_GRAPH_MAINTENANCE_SLOT_LIMIT", None),\n'
+        '    "import_documents": ("HINDSIGHT_API_WORKER_IMPORT_DOCUMENTS_SLOT_LIMIT", None),\n'
+        "}\n"
+        "\n"
+        "\n"
+        "def _parse_worker_slot_limits(getenv, max_slots: int) -> dict[str, int]:\n"
+        '    """switchroom: resolve WORKER_SLOT_LIMIT_TYPES against the environment.\n'
+        "\n"
+        '    An empty string means "no ceiling for this type" so an operator can switch a\n'
+        "    default cap off without editing the image.\n"
+        "\n"
+        "    A DEFAULT cap is clamped to max_slots, so lowering\n"
+        "    HINDSIGHT_API_WORKER_MAX_SLOTS can never turn a deployment that boots today\n"
+        "    into one that refuses to boot. An EXPLICIT cap is taken verbatim and\n"
+        "    validated loudly in HindsightConfig.validate().\n"
+        '    """\n'
+        "    limits: dict[str, int] = {}\n"
+        "    for op_type, (env_var, default) in WORKER_SLOT_LIMIT_TYPES.items():\n"
+        "        raw = getenv(env_var)\n"
+        "        if raw is None:\n"
+        "            if default is not None:\n"
+        "                limits[op_type] = max(1, min(int(default), max_slots))\n"
+        "            continue\n"
+        "        raw = raw.strip()\n"
+        "        if not raw:\n"
+        "            continue\n"
+        "        limits[op_type] = int(raw)\n"
+        "    return limits\n",
+    ),
+    (
+        "    worker_slot_reservations: dict[str, int]\n",
+        "    worker_slot_reservations: dict[str, int]\n"
+        "    # switchroom: per-type CEILINGS (see WORKER_SLOT_LIMIT_TYPES). Absent key =\n"
+        "    # uncapped. This is the cap the ..._MAX_SLOTS reservations above are NOT.\n"
+        "    worker_slot_limits: dict[str, int]\n",
+    ),
+    (
+        "            worker_slot_reservations={\n"
+        "                op_type: int(os.getenv(env_var, str(default)))\n"
+        "                for op_type, (env_var, default) in WORKER_SLOT_RESERVATION_TYPES.items()\n"
+        "                if int(os.getenv(env_var, str(default))) > 0\n"
+        "            },\n",
+
+        "            worker_slot_reservations={\n"
+        "                op_type: int(os.getenv(env_var, str(default)))\n"
+        "                for op_type, (env_var, default) in WORKER_SLOT_RESERVATION_TYPES.items()\n"
+        "                if int(os.getenv(env_var, str(default))) > 0\n"
+        "            },\n"
+        "            worker_slot_limits=_parse_worker_slot_limits(\n"
+        "                os.getenv, int(os.getenv(ENV_WORKER_MAX_SLOTS, str(DEFAULT_WORKER_MAX_SLOTS)))\n"
+        "            ),\n",
+    ),
+    (
+        '                f"Reduce reservations or increase HINDSIGHT_API_WORKER_MAX_SLOTS."\n'
+        "            )\n",
+
+        '                f"Reduce reservations or increase HINDSIGHT_API_WORKER_MAX_SLOTS."\n'
+        "            )\n"
+        "\n"
+        "        # switchroom: validate the per-type CEILINGS the same way, and at the same\n"
+        "        # point, as the reservation sum above — an incoherent slot policy must fail\n"
+        "        # at boot rather than silently mis-schedule for weeks.\n"
+        "        for op_type, limit in sorted(self.worker_slot_limits.items()):\n"
+        "            env_var = WORKER_SLOT_LIMIT_TYPES.get(op_type, (op_type, None))[0]\n"
+        "            if limit < 1:\n"
+        "                raise ValueError(\n"
+        '                    f"Per-operation slot limit for {op_type!r} ({limit}) must be >= 1. "\n'
+        '                    f"Unset {env_var} (or set it to an empty string) to leave the type uncapped."\n'
+        "                )\n"
+        "            if limit > self.worker_max_slots:\n"
+        "                raise ValueError(\n"
+        '                    f"Per-operation slot limit for {op_type!r} ({limit}) exceeds worker_max_slots "\n'
+        '                    f"({self.worker_max_slots}). Lower {env_var} or raise '
+        'HINDSIGHT_API_WORKER_MAX_SLOTS."\n'
+        "                )\n"
+        "            reserved = self.worker_slot_reservations.get(op_type, 0)\n"
+        "            if limit < reserved:\n"
+        "                raise ValueError(\n"
+        '                    f"Per-operation slot limit for {op_type!r} ({limit}) is below its own slot "\n'
+        '                    f"RESERVATION ({reserved}) — the reservation could never be filled. Raise '
+        '{env_var} "\n'
+        '                    f"or lower {WORKER_SLOT_RESERVATION_TYPES.get(op_type, (op_type, 0))[0]}."\n'
+        "                )\n",
+    ),
+])
+
+# ---- 2. poller.py: carry per-type headroom through claiming ----
+poller_new = apply("worker/poller.py", [
+    (
+        "    shared: int\n"
+        '    """Remaining shared pool capacity (usable by any operation type)."""\n',
+
+        "    shared: int\n"
+        '    """Remaining shared pool capacity (usable by any operation type)."""\n'
+        "\n"
+        "    ceilings: dict[str, int] | None = None\n"
+        '    """switchroom: per-operation-type headroom left under its CEILING\n'
+        "\n"
+        "    (``worker_slot_limits``), i.e. ``limit - in_flight``. Reservations are a\n"
+        "    floor and never stopped a type spilling into the shared pool; this is the\n"
+        "    cap that does. ``None`` means no type is capped (upstream behaviour); a key\n"
+        "    absent from a present dict means that type is uncapped.\n"
+        '    """\n',
+    ),
+    (
+        "        slot_reservations: dict[str, int] | None = None,\n"
+        "        consolidation_bank_priority: dict[str, int] | None = None,\n"
+        "    ):\n",
+
+        "        slot_reservations: dict[str, int] | None = None,\n"
+        "        slot_limits: dict[str, int] | None = None,\n"
+        "        consolidation_bank_priority: dict[str, int] | None = None,\n"
+        "    ):\n",
+    ),
+    (
+        "                by any operation type. Defaults to {\"consolidation\": 2} if None.\n",
+
+        "                by any operation type. Defaults to {\"consolidation\": 2} if None.\n"
+        "            slot_limits: switchroom — per-operation-type CEILINGS (e.g.\n"
+        '                {"consolidation": 4}). A hard cap on how many slots one type may hold\n'
+        "                at once, reserved and shared combined. This is NOT the same thing as\n"
+        "                ``slot_reservations``, which is a floor: a reserved type may still take\n"
+        "                the whole shared pool on top of its reservation, so without a ceiling a\n"
+        "                single type can occupy every slot. A type absent from this dict (or\n"
+        "                None/empty) is uncapped, which is exactly upstream behaviour.\n",
+    ),
+    (
+        "        self._slot_reservations: dict[str, int] = (\n"
+        "            slot_reservations if slot_reservations is not None else {\"consolidation\": 2}\n"
+        "        )\n",
+
+        "        self._slot_reservations: dict[str, int] = (\n"
+        "            slot_reservations if slot_reservations is not None else {\"consolidation\": 2}\n"
+        "        )\n"
+        "        # switchroom: per-type ceilings; empty dict = every type uncapped.\n"
+        "        self._slot_limits: dict[str, int] = dict(slot_limits) if slot_limits else {}\n",
+    ),
+    (
+        "        Each operation type can have reserved slots (via ``slot_reservations``).\n"
+        "        Reserved slots guarantee capacity for that type — they cannot be used by\n"
+        "        other types. The remaining slots (``max_slots - sum(reservations)``) form\n"
+        "        a shared pool usable by any operation type on a first-come basis.\n"
+        "\n"
+        "        When an operation type's in-flight count exceeds its reservation, the\n"
+        "        excess tasks are considered to be using shared pool slots.\n"
+        '        """\n',
+
+        "        Each operation type can have reserved slots (via ``slot_reservations``).\n"
+        "        Reserved slots guarantee capacity for that type — they cannot be used by\n"
+        "        other types. The remaining slots (``max_slots - sum(reservations)``) form\n"
+        "        a shared pool usable by any operation type on a first-come basis.\n"
+        "\n"
+        "        When an operation type's in-flight count exceeds its reservation, the\n"
+        "        excess tasks are considered to be using shared pool slots.\n"
+        "\n"
+        "        switchroom: a reservation is therefore a FLOOR, not a cap. ``slot_limits``\n"
+        "        supplies the missing CEILING — the returned ``SlotAvailability.ceilings``\n"
+        "        carries each capped type's remaining headroom, which claim_batch spends\n"
+        "        alongside the reserved/shared budgets and hands to ``claim_tasks`` so an\n"
+        "        over-ceiling row is never marked processing.\n"
+        '        """\n',
+    ),
+    (
+        "        # Per-type reserved availability\n"
+        "        reserved_available: dict[str, int] = {}\n"
+        "        tasks_in_reserved = 0\n"
+        "        for op_type, reserved in self._slot_reservations.items():\n"
+        "            in_flight = in_flight_snapshot.get(op_type, 0)\n"
+        "            reserved_available[op_type] = max(0, reserved - in_flight)\n"
+        "            tasks_in_reserved += min(reserved, in_flight)\n",
+
+        "        # switchroom: remaining headroom under each type's CEILING.\n"
+        "        ceilings: dict[str, int] = {\n"
+        "            op_type: max(0, limit - in_flight_snapshot.get(op_type, 0))\n"
+        "            for op_type, limit in self._slot_limits.items()\n"
+        "        }\n"
+        "\n"
+        "        # Per-type reserved availability\n"
+        "        reserved_available: dict[str, int] = {}\n"
+        "        tasks_in_reserved = 0\n"
+        "        for op_type, reserved in self._slot_reservations.items():\n"
+        "            in_flight = in_flight_snapshot.get(op_type, 0)\n"
+        "            available = max(0, reserved - in_flight)\n"
+        "            # switchroom: the ceiling binds the reserved pool too. Config validation\n"
+        "            # keeps limit >= reservation so this is normally a no-op, but clamping in\n"
+        "            # the mechanism means the guarantee does not rest on validation alone.\n"
+        "            if op_type in ceilings:\n"
+        "                available = min(available, ceilings[op_type])\n"
+        "            reserved_available[op_type] = available\n"
+        "            tasks_in_reserved += min(reserved, in_flight)\n",
+    ),
+    (
+        "        return SlotAvailability(reserved=reserved_available, shared=shared_available)\n",
+        "        return SlotAvailability(\n"
+        "            reserved=reserved_available, shared=shared_available, ceilings=ceilings or None\n"
+        "        )\n",
+    ),
+    (
+        "        all_tasks: list[ClaimedTask] = []\n"
+        "        remaining_reserved = dict(availability.reserved)\n"
+        "        remaining_shared = availability.shared\n",
+
+        "        all_tasks: list[ClaimedTask] = []\n"
+        "        remaining_reserved = dict(availability.reserved)\n"
+        "        remaining_shared = availability.shared\n"
+        "        # switchroom: per-type ceiling headroom, spent across BOTH passes below so a\n"
+        "        # single claim_batch cannot itself push a type past its cap.\n"
+        "        remaining_ceilings: dict[str, int] | None = (\n"
+        "            dict(availability.ceilings) if availability.ceilings is not None else None\n"
+        "        )\n",
+    ),
+    (
+        "        def _account_tasks(tasks: list[ClaimedTask]) -> None:\n"
+        "            nonlocal remaining_shared\n"
+        "            for task in tasks:\n"
+        "                op_type = task.task_dict.get(\"operation_type\", \"unknown\")\n"
+        "                if op_type in remaining_reserved and remaining_reserved[op_type] > 0:\n"
+        "                    remaining_reserved[op_type] -= 1\n"
+        "                else:\n"
+        "                    remaining_shared -= 1\n",
+
+        "        def _account_tasks(tasks: list[ClaimedTask]) -> None:\n"
+        "            nonlocal remaining_shared\n"
+        "            for task in tasks:\n"
+        "                op_type = task.task_dict.get(\"operation_type\", \"unknown\")\n"
+        "                # switchroom: spend the type's ceiling headroom first — it is\n"
+        "                # orthogonal to which pool the slot came from.\n"
+        "                if remaining_ceilings is not None and op_type in remaining_ceilings:\n"
+        "                    remaining_ceilings[op_type] = max(0, remaining_ceilings[op_type] - 1)\n"
+        "                if op_type in remaining_reserved and remaining_reserved[op_type] > 0:\n"
+        "                    remaining_reserved[op_type] -= 1\n"
+        "                else:\n"
+        "                    remaining_shared -= 1\n",
+    ),
+    (
+        "            tasks = await self._claim_batch_for_schema(schema, fair_reserved, fair_shared)\n",
+        "            tasks = await self._claim_batch_for_schema(\n"
+        "                schema, fair_reserved, fair_shared, remaining_ceilings\n"
+        "            )\n",
+    ),
+    (
+        "                tasks = await self._claim_batch_for_schema(\n"
+        "                    schema, {t: v for t, v in remaining_reserved.items() if v > 0}, remaining_shared\n"
+        "                )\n",
+
+        "                tasks = await self._claim_batch_for_schema(\n"
+        "                    schema,\n"
+        "                    {t: v for t, v in remaining_reserved.items() if v > 0},\n"
+        "                    remaining_shared,\n"
+        "                    remaining_ceilings,\n"
+        "                )\n",
+    ),
+    (
+        "    async def _claim_batch_for_schema(\n"
+        "        self, schema: str | None, reserved_limits: dict[str, int], shared_limit: int\n"
+        "    ) -> list[ClaimedTask]:\n"
+        '        """Claim tasks from a specific schema respecting per-type and shared slot limits."""\n'
+        "        try:\n"
+        "            return await self._claim_batch_for_schema_inner(schema, reserved_limits, shared_limit)\n",
+
+        "    async def _claim_batch_for_schema(\n"
+        "        self,\n"
+        "        schema: str | None,\n"
+        "        reserved_limits: dict[str, int],\n"
+        "        shared_limit: int,\n"
+        "        type_ceilings: dict[str, int] | None = None,\n"
+        "    ) -> list[ClaimedTask]:\n"
+        '        """Claim tasks from a specific schema respecting per-type and shared slot limits."""\n'
+        "        try:\n"
+        "            return await self._claim_batch_for_schema_inner(\n"
+        "                schema, reserved_limits, shared_limit, type_ceilings\n"
+        "            )\n",
+    ),
+    (
+        "    async def _claim_batch_for_schema_inner(\n"
+        "        self, schema: str | None, reserved_limits: dict[str, int], shared_limit: int\n"
+        "    ) -> list[ClaimedTask]:\n",
+
+        "    async def _claim_batch_for_schema_inner(\n"
+        "        self,\n"
+        "        schema: str | None,\n"
+        "        reserved_limits: dict[str, int],\n"
+        "        shared_limit: int,\n"
+        "        type_ceilings: dict[str, int] | None = None,\n"
+        "    ) -> list[ClaimedTask]:\n",
+    ),
+    (
+        "                    reserved_limits,\n"
+        "                    shared_limit,\n"
+        "                    consolidation_bank_priority=self._consolidation_bank_priority,\n"
+        "                )\n",
+
+        "                    reserved_limits,\n"
+        "                    shared_limit,\n"
+        "                    consolidation_bank_priority=self._consolidation_bank_priority,\n"
+        "                    type_ceilings=type_ceilings,\n"
+        "                )\n",
+    ),
+    (
+        "        shared_pool = max(0, self._max_slots - sum(self._slot_reservations.values()))\n"
+        "        logger.info(\n"
+        '            f"Worker {self._worker_id} starting polling loop "\n'
+        '            f"(max_slots={self._max_slots}, reservations=[{reservations_str}], shared_pool={shared_pool})"\n'
+        "        )\n",
+
+        "        shared_pool = max(0, self._max_slots - sum(self._slot_reservations.values()))\n"
+        "        # switchroom: log the CEILINGS next to the reservations. The reservation line\n"
+        "        # alone is what made `consolidation=6/1(avail=0)` read like a bug.\n"
+        "        limits_str = (\n"
+        '            ", ".join(f"{k}<={v}" for k, v in sorted(self._slot_limits.items()))\n'
+        "            if self._slot_limits\n"
+        '            else "none"\n'
+        "        )\n"
+        "        logger.info(\n"
+        '            f"Worker {self._worker_id} starting polling loop "\n'
+        '            f"(max_slots={self._max_slots}, reservations=[{reservations_str}], shared_pool={shared_pool}, "\n'
+        '            f"ceilings=[{limits_str}])"\n'
+        "        )\n",
+    ),
+    (
+        '                reserved_parts.append(f"{op_type}={type_in_flight}/{reserved}(avail={type_available})")\n',
+        "                # switchroom: `N/R` is in-flight over the RESERVATION (a floor), so\n"
+        "                # N > R is normal. Show the ceiling too, otherwise the line reads as\n"
+        "                # an overrun of a cap that never existed.\n"
+        "                cap = self._slot_limits.get(op_type)\n"
+        '                cap_str = f",cap={cap}" if cap is not None else ""\n'
+        "                reserved_parts.append(\n"
+        '                    f"{op_type}={type_in_flight}/{reserved}(avail={type_available}{cap_str})"\n'
+        "                )\n",
+    ),
+])
+
+# ---- 3. db ops: never mark an over-ceiling row as processing ----
+CLAIM_SIG_OLD = (
+    "        reserved_limits,\n"
+    "        shared_limit,\n"
+    "        *,\n"
+    "        consolidation_bank_priority=None,\n"
+    "    ):\n"
+)
+CLAIM_SIG_NEW = (
+    "        reserved_limits,\n"
+    "        shared_limit,\n"
+    "        *,\n"
+    "        consolidation_bank_priority=None,\n"
+    "        type_ceilings=None,\n"
+    "    ):\n"
+)
+
+CEILING_OLD = (
+    "        if not all_rows:\n"
+    "            return []\n"
+    "\n"
+    "        # Mark all claimed rows as processing\n"
+)
+CEILING_NEW = (
+    "        # switchroom: enforce the per-operation-type CEILING before anything is\n"
+    "        # marked processing. The shared pool claims by created_at across types, so\n"
+    "        # this is the only point that can bound one type's share of the worker;\n"
+    "        # `type_ceilings` is the remaining headroom the poller has not already spent\n"
+    "        # this batch. Rows dropped here were selected FOR UPDATE SKIP LOCKED but are\n"
+    "        # never transitioned out of 'pending', so the row lock is released with the\n"
+    "        # transaction and the task is simply claimed on a later poll. None/empty =\n"
+    "        # uncapped, i.e. byte-for-byte upstream behaviour.\n"
+    "        if type_ceilings:\n"
+    "            kept = []\n"
+    "            used: dict[str, int] = {}\n"
+    "            for row in all_rows:\n"
+    "                op_type = row[\"operation_type\"]\n"
+    "                cap = type_ceilings.get(op_type)\n"
+    "                if cap is not None:\n"
+    "                    if used.get(op_type, 0) >= cap:\n"
+    "                        continue\n"
+    "                    used[op_type] = used.get(op_type, 0) + 1\n"
+    "                kept.append(row)\n"
+    "            all_rows = kept\n"
+    "\n"
+    "        if not all_rows:\n"
+    "            return []\n"
+    "\n"
+    "        # Mark all claimed rows as processing\n"
+)
+
+for rel in ("engine/db/ops_postgresql.py", "engine/db/ops_oracle.py"):
+    apply(rel, [(CLAIM_SIG_OLD, CLAIM_SIG_NEW), (CEILING_OLD, CEILING_NEW)])
+
+ops_new = apply("engine/db/ops.py", [
+    (
+        "        reserved_limits: dict[str, int],\n"
+        "        shared_limit: int,\n"
+        "        *,\n"
+        "        consolidation_bank_priority: dict[str, int] | None = None,\n"
+        "    ) -> list[ResultRow]:\n",
+
+        "        reserved_limits: dict[str, int],\n"
+        "        shared_limit: int,\n"
+        "        *,\n"
+        "        consolidation_bank_priority: dict[str, int] | None = None,\n"
+        "        type_ceilings: dict[str, int] | None = None,\n"
+        "    ) -> list[ResultRow]:\n",
+    ),
+    (
+        "                None preserves current behavior (pure created_at ordering).\n",
+        "                None preserves current behavior (pure created_at ordering).\n"
+        "            type_ceilings: switchroom — per-operation-type CEILING headroom for THIS\n"
+        "                call. At most ``type_ceilings[t]`` rows of type ``t`` may be marked\n"
+        "                processing; the surplus is left pending (its FOR UPDATE lock is\n"
+        "                released with the transaction) and claimed on a later poll. Slot\n"
+        "                RESERVATIONS are a floor and never bounded a type's share of the\n"
+        "                shared pool; this is the cap that does. None/empty = uncapped.\n",
+    ),
+])
+
+# ---- 4. wire config -> poller at both construction sites ----
+http_new = apply("api/http.py", [
+    (
+        "                max_slots=config.worker_max_slots,\n"
+        "                slot_reservations=config.worker_slot_reservations,\n",
+
+        "                max_slots=config.worker_max_slots,\n"
+        "                slot_reservations=config.worker_slot_reservations,\n"
+        "                slot_limits=config.worker_slot_limits,\n",
+    ),
+])
+
+main_new = apply("worker/main.py", [
+    (
+        "            max_slots=config.worker_max_slots,\n"
+        "            slot_reservations=config.worker_slot_reservations,\n",
+
+        "            max_slots=config.worker_max_slots,\n"
+        "            slot_reservations=config.worker_slot_reservations,\n"
+        "            slot_limits=config.worker_slot_limits,\n",
+    ),
+    (
+        '    print(f"  Slot reservations: {reservations_str}")\n',
+        '    print(f"  Slot reservations (floor): {reservations_str}")\n'
+        "    limits = config.worker_slot_limits\n"
+        '    limits_str = ", ".join(f"{k}<={v}" for k, v in sorted(limits.items())) if limits else "none"\n'
+        '    print(f"  Slot ceilings (cap): {limits_str}")\n',
+    ),
+])
+
+# ---- verification ----
+assert "WORKER_SLOT_LIMIT_TYPES: dict[str, tuple[str, int | None]]" in cfg_new, (
+    "switchroom hindsight worker-slot-ceiling patch: WORKER_SLOT_LIMIT_TYPES missing after patch"
+)
+assert "worker_slot_limits: dict[str, int]" in cfg_new, (
+    "switchroom hindsight worker-slot-ceiling patch: config field missing after patch"
+)
+assert "worker_slot_limits=_parse_worker_slot_limits(" in cfg_new, (
+    "switchroom hindsight worker-slot-ceiling patch: from_env wiring missing after patch"
+)
+assert "is below its own slot " in cfg_new, (
+    "switchroom hindsight worker-slot-ceiling patch: boot validation missing after patch"
+)
+assert "self._slot_limits: dict[str, int]" in poller_new, (
+    "switchroom hindsight worker-slot-ceiling patch: poller ceiling state missing after patch"
+)
+assert "ceilings: dict[str, int] | None = None" in poller_new, (
+    "switchroom hindsight worker-slot-ceiling patch: SlotAvailability.ceilings missing after patch"
+)
+assert "type_ceilings=type_ceilings," in poller_new, (
+    "switchroom hindsight worker-slot-ceiling patch: ceilings not threaded into claim_tasks"
+)
+assert "type_ceilings: dict[str, int] | None = None," in ops_new, (
+    "switchroom hindsight worker-slot-ceiling patch: abstract claim_tasks signature not widened"
+)
+for rel in ("engine/db/ops_postgresql.py", "engine/db/ops_oracle.py"):
+    t = (BASE / rel).read_text()
+    assert "if type_ceilings:" in t, (
+        f"switchroom hindsight worker-slot-ceiling patch: ceiling enforcement missing in {rel}"
+    )
+    assert t.index("if type_ceilings:") < t.index("# Mark all claimed rows as processing"), (
+        f"switchroom hindsight worker-slot-ceiling patch: ceiling filter runs AFTER the "
+        f"processing UPDATE in {rel} — over-ceiling rows would already be claimed"
+    )
+assert "slot_limits=config.worker_slot_limits," in http_new, (
+    "switchroom hindsight worker-slot-ceiling patch: api/http.py poller not wired"
+)
+assert "slot_limits=config.worker_slot_limits," in main_new, (
+    "switchroom hindsight worker-slot-ceiling patch: worker/main.py poller not wired"
+)
+print(
+    "switchroom hindsight worker-slot-ceiling patch: worker_slot_limits is a real per-type CAP "
+    "(reservations remain a floor); consolidation defaults to 4 of 10 and is validated at boot"
+)
+PYEOF
+
+# Always emit `sem=` on the recall completion line.
+#
+# The wait was only logged when it exceeded 0.01s, so the recalls that did NOT
+# queue left no datum at all. Scraping the logs therefore could not distinguish
+# a fleet where 45% of recalls wait from one where none do, and averaging the
+# lines that DID appear silently biased the reported mean upwards — which is
+# exactly how the admission contention above was mis-sized on first measurement.
+# An unconditional `sem=0.000s` makes the distribution recoverable. Scoped to the
+# admission wait: the `conn=` threshold is deliberately left alone.
+#
+# Self-verifying; guarded by tests/docker/dockerfile-hindsight-bakes.test.ts and
+# tests/docker/hindsight-recall-isolation-patches.test.ts.
+RUN python3 - <<'PYEOF'
+import pathlib
+
+f = pathlib.Path("/app/api/hindsight_api/engine/memory_engine.py")
+s = f.read_text()
+
+OLD = (
+    "            wait_parts = []\n"
+    "            if semaphore_wait > 0.01:\n"
+    '                wait_parts.append(f"sem={semaphore_wait:.3f}s")\n'
+)
+NEW = (
+    "            wait_parts = []\n"
+    "            # switchroom: ALWAYS emit sem=. The old `> 0.01` gate meant the admission\n"
+    "            # wait only appeared on the recalls that queued, so a log scrape could not\n"
+    "            # tell a fleet where 45% of recalls wait from one where none do — and the\n"
+    "            # absent lines silently biased the measured mean upwards. An unconditional\n"
+    "            # sem=0.000s is the datum that makes the distribution recoverable.\n"
+    '            wait_parts.append(f"sem={semaphore_wait:.3f}s")\n'
+)
+n = s.count(OLD)
+assert n == 1, (
+    f"switchroom hindsight sem-wait-always-logged patch: anchor found {n}x (expected 1) in "
+    "engine/memory_engine.py — upstream reformatted the recall wait_parts block; re-author "
+    "this patch in docker/Dockerfile.hindsight"
+)
+s = s.replace(OLD, NEW, 1)
+f.write_text(s)
+
+t = f.read_text()
+assert "if semaphore_wait > 0.01:" not in t, (
+    "switchroom hindsight sem-wait-always-logged patch: the conditional survived the patch"
+)
+assert t.count('wait_parts.append(f"sem={semaphore_wait:.3f}s")') == 1, (
+    "switchroom hindsight sem-wait-always-logged patch: sem= is not emitted exactly once"
+)
+assert 'if max_conn_wait > 0.01:' in t, (
+    "switchroom hindsight sem-wait-always-logged patch: the conn= branch was altered — this "
+    "patch is scoped to the admission wait only"
+)
+print(
+    "switchroom hindsight sem-wait-always-logged patch: sem= now emitted on every recall, "
+    "including sem=0.000s"
+)
+PYEOF
+
 # Pin the upstream `hindsight` user to UID 11000 to match
 # `HINDSIGHT_DEFAULT_UID` in src/setup/hindsight.ts (and the
 # `auth.consumers[hindsight].uid` value the operator writes in

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -901,6 +901,18 @@ PYEOF
 # foreground never acquires the background semaphore, so the acquisition order
 # (background -> shared) is total and no cycle exists.
 #
+# ORDER-COUPLED WITH THE worker-slot-ceiling BLOCK BELOW — DO NOT SWAP THEM.
+# Both append a validation clause to config.py at the same anchor, the tail of
+# HindsightConfig.validate():
+#     f"Reduce reservations or increase HINDSIGHT_API_WORKER_MAX_SLOTS."
+#         )
+# THIS block additionally requires `\n    @classmethod\n    def from_env` to
+# still follow that anchor, so it must run while the anchor is still the last
+# thing in validate(). The ceiling block below anchors on the shorter form and
+# is order-independent. Running them in the other order makes THIS block's
+# anchor match 0x and fails the build loudly (it does not mis-apply) — but the
+# failure would read as upstream drift, which it is not.
+#
 # Self-verifying; guarded structurally by
 # tests/docker/dockerfile-hindsight-bakes.test.ts and behaviourally (RED against
 # unpatched upstream / GREEN patched) by
@@ -1140,6 +1152,17 @@ assert "async with self._search_semaphore:" not in me_new, (
     "switchroom hindsight recall-admission-split patch: a bare shared-semaphore acquisition "
     "still remains — background recalls would bypass the reservation"
 )
+# The ARGUMENTS, not just the call. `_recall_admission(shared, background, False)`
+# reverts the entire split while leaving every other assertion in this block green
+# (`self._search_semaphore` survives as an argument, the helper is still defined,
+# the call is still made). The third argument MUST be the caller's `_background`.
+assert (
+    "                self._search_semaphore, self._background_search_semaphore, _background\n"
+) in me_new, (
+    "switchroom hindsight recall-admission-split patch: recall_async does not pass "
+    "(_search_semaphore, _background_search_semaphore, _background) to _recall_admission — "
+    "a hard-coded third argument silently reverts the admission split"
+)
 assert "_background=True," in cons_new, (
     "switchroom hindsight recall-admission-split patch: consolidation still recalls as foreground"
 )
@@ -1172,6 +1195,13 @@ PYEOF
 #
 # The misleading ..._MAX_SLOTS name is deliberately NOT changed here (renaming a
 # shipped env var is a breaking config change); it is filed upstream instead.
+#
+# ORDER-COUPLED WITH THE recall-admission-split BLOCK ABOVE — DO NOT SWAP THEM.
+# Both append a validation clause to config.py at the same
+# `Reduce reservations or increase HINDSIGHT_API_WORKER_MAX_SLOTS.` anchor. This
+# block's anchor is the shorter, order-independent form; the block above ALSO
+# requires `@classmethod / def from_env` to still follow it, so it has to go
+# first. See the note on that block.
 #
 # Self-verifying; guarded by tests/docker/dockerfile-hindsight-bakes.test.ts and
 # tests/docker/hindsight-recall-isolation-patches.test.ts.
@@ -1221,7 +1251,10 @@ cfg_new = apply("config.py", [
         "# operation type may hold at once, reserved and shared combined. Each maps an\n"
         "# operation_type to its env var and default cap; None means uncapped (exact\n"
         "# upstream behaviour). Adding a type here is the ONLY change needed to make it\n"
-        "# cappable — the config field, from_env() and the poller all derive from it.\n"
+        "# cappable — the config field, from_env() and the poller all derive from it, and\n"
+        "# claim_tasks bounds a capped type in the SELECT itself, so capping a type that\n"
+        "# phase 2a actually claims (everything except consolidation) does not cost the\n"
+        "# other types their share of the shared budget.\n"
         "#\n"
         "# consolidation defaults to 4 of DEFAULT_WORKER_MAX_SLOTS = 10 because it is the\n"
         "# only type observed saturating the worker; every other type stays uncapped so\n"
@@ -1563,7 +1596,19 @@ poller_new = apply("worker/poller.py", [
     ),
 ])
 
-# ---- 3. db ops: never mark an over-ceiling row as processing ----
+# ---- 3. db ops: enforce the per-type CEILING inside the claim itself ----
+#
+# NOT a post-selection filter. The shared pool is a single `ORDER BY created_at
+# LIMIT n` across every non-consolidation type, so dropping the surplus after
+# selection spends the shared budget on rows that are never claimed and starves
+# the types that were not over their cap. The ceiling is therefore pushed into
+# the WHERE clause (`operation_type != ALL(...)`) with a refill fetch for the
+# unspent remainder, and phase 2b is skipped outright when consolidation has no
+# headroom rather than taking FOR UPDATE locks on rows it must discard.
+#
+# The phase 1 + phase 2 body is byte-identical in ops_postgresql.py and
+# ops_oracle.py upstream (verified: the 4213-byte block matches exactly), so one
+# anchor covers both backends.
 CLAIM_SIG_OLD = (
     "        reserved_limits,\n"
     "        shared_limit,\n"
@@ -1580,42 +1625,290 @@ CLAIM_SIG_NEW = (
     "    ):\n"
 )
 
-CEILING_OLD = (
-    "        if not all_rows:\n"
-    "            return []\n"
-    "\n"
-    "        # Mark all claimed rows as processing\n"
-)
-CEILING_NEW = (
-    "        # switchroom: enforce the per-operation-type CEILING before anything is\n"
-    "        # marked processing. The shared pool claims by created_at across types, so\n"
-    "        # this is the only point that can bound one type's share of the worker;\n"
-    "        # `type_ceilings` is the remaining headroom the poller has not already spent\n"
-    "        # this batch. Rows dropped here were selected FOR UPDATE SKIP LOCKED but are\n"
-    "        # never transitioned out of 'pending', so the row lock is released with the\n"
-    "        # transaction and the task is simply claimed on a later poll. None/empty =\n"
-    "        # uncapped, i.e. byte-for-byte upstream behaviour.\n"
-    "        if type_ceilings:\n"
-    "            kept = []\n"
-    "            used: dict[str, int] = {}\n"
-    "            for row in all_rows:\n"
-    "                op_type = row[\"operation_type\"]\n"
-    "                cap = type_ceilings.get(op_type)\n"
-    "                if cap is not None:\n"
-    "                    if used.get(op_type, 0) >= cap:\n"
-    "                        continue\n"
-    "                    used[op_type] = used.get(op_type, 0) + 1\n"
-    "                kept.append(row)\n"
-    "            all_rows = kept\n"
-    "\n"
-    "        if not all_rows:\n"
-    "            return []\n"
-    "\n"
-    "        # Mark all claimed rows as processing\n"
-)
+# The exact upstream body, replaced wholesale. `apply()` asserts it appears
+# exactly once per file, so any upstream reformatting fails the build loudly
+# instead of silently leaving the ceiling unenforced.
+CLAIM_BODY_OLD = r'''        # --- Phase 1: claim from reserved pools ---
+        for op_type, limit in reserved_limits.items():
+            if limit <= 0:
+                continue
+
+            if op_type == "consolidation":
+                busy_banks = await conn.fetch(
+                    f"""
+                    SELECT DISTINCT bank_id FROM {table}
+                    WHERE operation_type = 'consolidation' AND status = 'processing'
+                    """,
+                )
+                busy_bank_ids = [r["bank_id"] for r in busy_banks]
+
+                rows = await self._claim_consolidation_tasks(
+                    conn,
+                    table,
+                    busy_bank_ids,
+                    claimed_ids,
+                    limit,
+                    consolidation_bank_priority,
+                )
+            else:
+                rows = await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type = $1
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                    ORDER BY created_at
+                    LIMIT $2
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    op_type,
+                    limit,
+                )
+
+            for row in rows:
+                claimed_ids.append(row["operation_id"])
+                all_rows.append(row)
+
+        # --- Phase 2: claim from shared pool ---
+        remaining_shared = shared_limit
+        if remaining_shared > 0:
+            # 2a. Non-consolidation tasks
+            if claimed_ids:
+                rows = await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type != 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                      AND operation_id != ALL($1::uuid[])
+                    ORDER BY created_at
+                    LIMIT $2
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    claimed_ids,
+                    remaining_shared,
+                )
+            else:
+                rows = await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type != 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                    ORDER BY created_at
+                    LIMIT $1
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    remaining_shared,
+                )
+
+            for row in rows:
+                claimed_ids.append(row["operation_id"])
+                all_rows.append(row)
+            remaining_shared -= len(rows)
+
+            # 2b. Consolidation tasks (with bank-serialization + optional priority)
+            if remaining_shared > 0:
+                busy_banks_2 = await conn.fetch(
+                    f"""
+                    SELECT DISTINCT bank_id FROM {table}
+                    WHERE operation_type = 'consolidation' AND status = 'processing'
+                    """,
+                )
+                busy_bank_ids_2 = [r["bank_id"] for r in busy_banks_2]
+
+                rows = await self._claim_consolidation_tasks(
+                    conn,
+                    table,
+                    busy_bank_ids_2,
+                    claimed_ids,
+                    remaining_shared,
+                    consolidation_bank_priority,
+                )
+
+                for row in rows:
+                    claimed_ids.append(row["operation_id"])
+                    all_rows.append(row)
+
+        if not all_rows:
+            return []
+
+        # Mark all claimed rows as processing
+'''
+
+CLAIM_BODY_NEW = r'''        # --- Phase 1: claim from reserved pools ---
+        # switchroom: `remaining_ceilings` is the per-operation-type CEILING headroom
+        # for THIS call - what the poller has not already spent this batch - and it is
+        # decremented as rows are accepted, so one claim_tasks call can never push a
+        # type past its cap across the phases below.
+        #
+        # A capped type is bounded BEFORE selection, never filtered after it. Phase 2a
+        # is a single `ORDER BY created_at LIMIT n` across every non-consolidation
+        # type, so discarding the surplus afterwards spends the shared budget on rows
+        # that are then thrown away: with ceilings {"retain": 2}, 12 pending retain
+        # (older) and 5 pending graph_maintenance, a post-filter claims 2 retain and 0
+        # graph_maintenance where upstream claims 9 tasks. Instead, a type with no
+        # headroom left is excluded in SQL (`operation_type != ALL(...)`) and the fetch
+        # is retried for the unspent remainder, so nothing is ever selected FOR UPDATE
+        # that this call cannot claim. None/empty ceilings = byte-for-byte upstream.
+        remaining_ceilings = dict(type_ceilings) if type_ceilings else {}
+
+        def _headroom(op_type, budget):
+            """switchroom: `budget` clamped to op_type's remaining ceiling headroom."""
+            cap = remaining_ceilings.get(op_type)
+            return budget if cap is None else min(budget, cap)
+
+        def _accept(rows):
+            """switchroom: record claimed rows and spend their ceiling headroom."""
+            for row in rows:
+                op_type = row["operation_type"]
+                if op_type in remaining_ceilings:
+                    remaining_ceilings[op_type] = max(0, remaining_ceilings[op_type] - 1)
+                claimed_ids.append(row["operation_id"])
+                all_rows.append(row)
+
+        for op_type, limit in reserved_limits.items():
+            # switchroom: the ceiling binds the reserved pool too, and it binds it here
+            # in the mechanism rather than resting on the poller's clamp alone.
+            limit = _headroom(op_type, limit)
+            if limit <= 0:
+                continue
+
+            if op_type == "consolidation":
+                busy_banks = await conn.fetch(
+                    f"""
+                    SELECT DISTINCT bank_id FROM {table}
+                    WHERE operation_type = 'consolidation' AND status = 'processing'
+                    """,
+                )
+                busy_bank_ids = [r["bank_id"] for r in busy_banks]
+
+                rows = await self._claim_consolidation_tasks(
+                    conn,
+                    table,
+                    busy_bank_ids,
+                    claimed_ids,
+                    limit,
+                    consolidation_bank_priority,
+                )
+            else:
+                rows = await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type = $1
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                    ORDER BY created_at
+                    LIMIT $2
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    op_type,
+                    limit,
+                )
+
+            _accept(rows)
+
+        # --- Phase 2: claim from shared pool ---
+        remaining_shared = shared_limit
+        if remaining_shared > 0:
+            # 2a. Non-consolidation tasks
+            # switchroom: refill loop. Types whose ceiling headroom is exhausted are
+            # excluded in SQL, so the LIMIT is only ever spent on rows this call can
+            # actually claim; when a type hits its cap part-way through a fetch, the
+            # unspent remainder is re-queried with that type excluded. The budget is
+            # decremented per ACCEPTED row, not per selected row, so rows a ceiling
+            # would drop no longer under-budget phase 2b.
+            #
+            # Terminates: a row can only be dropped if its type had headroom at fetch
+            # time and has none now, so every extra iteration adds at least one type to
+            # `exhausted`, which is bounded by len(type_ceilings). With no ceilings the
+            # loop runs exactly one query with exactly upstream's SQL.
+            while remaining_shared > 0:
+                exhausted = sorted(t for t, h in remaining_ceilings.items() if h <= 0)
+                conditions: list[str] = []
+                params: list = []
+                idx = 1
+                if claimed_ids:
+                    conditions.append(f"AND operation_id != ALL(${idx}::uuid[])")
+                    params.append(claimed_ids)
+                    idx += 1
+                if exhausted:
+                    conditions.append(f"AND operation_type != ALL(${idx}::text[])")
+                    params.append(exhausted)
+                    idx += 1
+                params.append(remaining_shared)
+                extra_clause = "".join("\n                      " + c for c in conditions)
+
+                rows = await conn.fetch(
+                    f"""
+                    SELECT operation_id, operation_type, task_payload, retry_count
+                    FROM {table}
+                    WHERE status = 'pending'
+                      AND task_payload IS NOT NULL
+                      AND operation_type != 'consolidation'
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW()){extra_clause}
+                    ORDER BY created_at
+                    LIMIT ${idx}
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    *params,
+                )
+                if not rows:
+                    break
+
+                dropped = 0
+                for row in rows:
+                    if _headroom(row["operation_type"], 1) <= 0:
+                        dropped += 1
+                        continue
+                    _accept([row])
+                    remaining_shared -= 1
+                if dropped == 0:
+                    break
+
+            # 2b. Consolidation tasks (with bank-serialization + optional priority)
+            # switchroom: clamped by consolidation's own ceiling headroom, and SKIPPED
+            # entirely at zero. Upstream still ran the busy-banks scan and took FOR
+            # UPDATE locks on rows this worker could not claim - per active schema, per
+            # poll. Multi-worker, those locks briefly hide the head consolidation rows
+            # from a worker that does have headroom.
+            consolidation_shared = _headroom("consolidation", remaining_shared)
+            if consolidation_shared > 0:
+                busy_banks_2 = await conn.fetch(
+                    f"""
+                    SELECT DISTINCT bank_id FROM {table}
+                    WHERE operation_type = 'consolidation' AND status = 'processing'
+                    """,
+                )
+                busy_bank_ids_2 = [r["bank_id"] for r in busy_banks_2]
+
+                rows = await self._claim_consolidation_tasks(
+                    conn,
+                    table,
+                    busy_bank_ids_2,
+                    claimed_ids,
+                    consolidation_shared,
+                    consolidation_bank_priority,
+                )
+
+                _accept(rows)
+
+        if not all_rows:
+            return []
+
+        # Mark all claimed rows as processing
+'''
 
 for rel in ("engine/db/ops_postgresql.py", "engine/db/ops_oracle.py"):
-    apply(rel, [(CLAIM_SIG_OLD, CLAIM_SIG_NEW), (CEILING_OLD, CEILING_NEW)])
+    apply(rel, [(CLAIM_SIG_OLD, CLAIM_SIG_NEW), (CLAIM_BODY_OLD, CLAIM_BODY_NEW)])
 
 ops_new = apply("engine/db/ops.py", [
     (
@@ -1701,12 +1994,29 @@ assert "type_ceilings: dict[str, int] | None = None," in ops_new, (
 )
 for rel in ("engine/db/ops_postgresql.py", "engine/db/ops_oracle.py"):
     t = (BASE / rel).read_text()
-    assert "if type_ceilings:" in t, (
+    assert "remaining_ceilings = dict(type_ceilings) if type_ceilings else {}" in t, (
         f"switchroom hindsight worker-slot-ceiling patch: ceiling enforcement missing in {rel}"
     )
-    assert t.index("if type_ceilings:") < t.index("# Mark all claimed rows as processing"), (
-        f"switchroom hindsight worker-slot-ceiling patch: ceiling filter runs AFTER the "
+    # The ceiling must bound SELECTION, not just what is returned. A post-selection
+    # filter still spends the single shared-pool LIMIT on rows it then discards, so
+    # a burst of one capped type starves every other type of the whole batch.
+    assert 'AND operation_type != ALL(${idx}::text[])' in t, (
+        f"switchroom hindsight worker-slot-ceiling patch: at-ceiling types are not excluded "
+        f"in the shared-pool WHERE clause in {rel} — the ceiling would be a post-selection "
+        f"filter and the shared budget would be spent on rows that are never claimed"
+    )
+    # …and the whole of it must precede the UPDATE that actually claims a row.
+    assert t.index("remaining_ceilings = dict(type_ceilings)") < t.index(
+        "# Mark all claimed rows as processing"
+    ), (
+        f"switchroom hindsight worker-slot-ceiling patch: ceiling enforcement runs AFTER the "
         f"processing UPDATE in {rel} — over-ceiling rows would already be claimed"
+    )
+    # L1: at zero headroom phase 2b must not run at all — no busy-banks scan and no
+    # FOR UPDATE locks on rows this worker cannot claim.
+    assert 'consolidation_shared = _headroom("consolidation", remaining_shared)' in t, (
+        f"switchroom hindsight worker-slot-ceiling patch: phase 2b is not clamped by "
+        f"consolidation's ceiling headroom in {rel}"
     )
 assert "slot_limits=config.worker_slot_limits," in http_new, (
     "switchroom hindsight worker-slot-ceiling patch: api/http.py poller not wired"
@@ -1720,15 +2030,31 @@ print(
 )
 PYEOF
 
-# Always emit `sem=` on the recall completion line.
+# Make the recall admission wait OBSERVABLE — on every recall, including the
+# background ones.
 #
-# The wait was only logged when it exceeded 0.01s, so the recalls that did NOT
-# queue left no datum at all. Scraping the logs therefore could not distinguish
-# a fleet where 45% of recalls wait from one where none do, and averaging the
-# lines that DID appear silently biased the reported mean upwards — which is
-# exactly how the admission contention above was mis-sized on first measurement.
-# An unconditional `sem=0.000s` makes the distribution recoverable. Scoped to the
-# admission wait: the `conn=` threshold is deliberately left alone.
+# Two gates hid it, and between them the exact population this image now caps
+# emitted nothing at all:
+#
+#  1. The wait was only logged when it exceeded 0.01s, so the recalls that did
+#     NOT queue left no datum. Scraping the logs therefore could not distinguish
+#     a fleet where 45% of recalls wait from one where none do, and averaging the
+#     lines that DID appear silently biased the reported mean upwards — exactly
+#     how the admission contention above was mis-sized on first measurement.
+#  2. The whole completion line is emitted under `if not quiet:`, and the
+#     consolidator recalls with `_quiet=True`. So BACKGROUND recalls — the
+#     population the reservation semaphore above pins at 2 — logged no `sem=`
+#     line whatsoever. A reservation you cannot see queueing is a reservation you
+#     will mis-size the same way twice: if consolidation starts backing up behind
+#     its own cap, nothing in the logs says so.
+#
+# Fix 1 is an unconditional `sem=0.000s`, which makes the distribution
+# recoverable. Fix 2 emits ONE compact line for a quiet recall rather than the
+# whole multi-line buffer, so the datum exists without restoring the noise
+# `_quiet` was introduced to suppress (and background is capped at 2 concurrent,
+# so the volume is bounded by construction).
+#
+# Scoped to the admission wait: the `conn=` threshold is deliberately left alone.
 #
 # Self-verifying; guarded by tests/docker/dockerfile-hindsight-bakes.test.ts and
 # tests/docker/hindsight-recall-isolation-patches.test.ts.
@@ -1738,10 +2064,31 @@ import pathlib
 f = pathlib.Path("/app/api/hindsight_api/engine/memory_engine.py")
 s = f.read_text()
 
+
+def apply(anchor, repl, source):
+    n = source.count(anchor)
+    assert n == 1, (
+        f"switchroom hindsight sem-wait-always-logged patch: anchor found {n}x (expected 1) "
+        f"in engine/memory_engine.py — upstream reformatted the recall completion block; "
+        f"re-author this patch in docker/Dockerfile.hindsight. Anchor head: "
+        f"{anchor.splitlines()[0]!r}"
+    )
+    return source.replace(anchor, repl, 1)
+
+
+# ---- 1. sem= on every recall, and wait_info unconditional with it ----
+#
+# The `if wait_parts else ""` tail went with the gate: wait_parts now always
+# carries sem=, so the conditional could never take its empty branch. Removing it
+# keeps the line honest rather than leaving a dead ternary that reads as though a
+# recall might still produce no wait information.
 OLD = (
     "            wait_parts = []\n"
     "            if semaphore_wait > 0.01:\n"
     '                wait_parts.append(f"sem={semaphore_wait:.3f}s")\n'
+    "            if max_conn_wait > 0.01:\n"
+    '                wait_parts.append(f"conn={max_conn_wait:.3f}s")\n'
+    "            wait_info = f\" | waits: {', '.join(wait_parts)}\" if wait_parts else \"\"\n"
 )
 NEW = (
     "            wait_parts = []\n"
@@ -1751,14 +2098,40 @@ NEW = (
     "            # absent lines silently biased the measured mean upwards. An unconditional\n"
     "            # sem=0.000s is the datum that makes the distribution recoverable.\n"
     '            wait_parts.append(f"sem={semaphore_wait:.3f}s")\n'
+    "            if max_conn_wait > 0.01:\n"
+    '                wait_parts.append(f"conn={max_conn_wait:.3f}s")\n'
+    "            # switchroom: unconditional — wait_parts always holds sem= now, so the\n"
+    "            # empty-string branch of the old ternary tail was unreachable.\n"
+    "            wait_info = f\" | waits: {', '.join(wait_parts)}\"\n"
 )
-n = s.count(OLD)
-assert n == 1, (
-    f"switchroom hindsight sem-wait-always-logged patch: anchor found {n}x (expected 1) in "
-    "engine/memory_engine.py — upstream reformatted the recall wait_parts block; re-author "
-    "this patch in docker/Dockerfile.hindsight"
+s = apply(OLD, NEW, s)
+
+# ---- 2. a quiet (BACKGROUND) recall still reports its admission wait ----
+QUIET_OLD = (
+    "            if not quiet:\n"
+    '                logger.info("\\n" + "\\n".join(log_buffer))\n'
+    "\n"
+    "            return RecallResultModel(\n"
 )
-s = s.replace(OLD, NEW, 1)
+QUIET_NEW = (
+    "            if not quiet:\n"
+    '                logger.info("\\n" + "\\n".join(log_buffer))\n'
+    "            else:\n"
+    "                # switchroom: a quiet recall is exactly the BACKGROUND population the\n"
+    "                # reservation semaphore caps (the consolidator recalls with\n"
+    "                # _quiet=True). Suppressing its wait entirely is what made the\n"
+    "                # original contention unmeasurable, and it would equally hide the\n"
+    "                # reservation itself backing consolidation up. Emit the ONE datum —\n"
+    "                # not the whole multi-line buffer _quiet exists to suppress.\n"
+    "                logger.info(\n"
+    '                    f"[RECALL {recall_id}] Complete (quiet): {len(top_scored)} facts, "\n'
+    '                    f"{total_time:.3f}s{wait_info}"\n'
+    "                )\n"
+    "\n"
+    "            return RecallResultModel(\n"
+)
+s = apply(QUIET_OLD, QUIET_NEW, s)
+
 f.write_text(s)
 
 t = f.read_text()
@@ -1768,13 +2141,22 @@ assert "if semaphore_wait > 0.01:" not in t, (
 assert t.count('wait_parts.append(f"sem={semaphore_wait:.3f}s")') == 1, (
     "switchroom hindsight sem-wait-always-logged patch: sem= is not emitted exactly once"
 )
+assert "join(wait_parts)}\" if wait_parts else \"\"" not in t, (
+    "switchroom hindsight sem-wait-always-logged patch: the dead conditional tail on "
+    "wait_info survived — wait_parts can no longer be empty, so its empty branch is "
+    "unreachable"
+)
 assert 'if max_conn_wait > 0.01:' in t, (
     "switchroom hindsight sem-wait-always-logged patch: the conn= branch was altered — this "
     "patch is scoped to the admission wait only"
 )
+assert "[RECALL {recall_id}] Complete (quiet):" in t, (
+    "switchroom hindsight sem-wait-always-logged patch: a quiet (background) recall still "
+    "emits no admission-wait line — the reservation is unobservable"
+)
 print(
     "switchroom hindsight sem-wait-always-logged patch: sem= now emitted on every recall, "
-    "including sem=0.000s"
+    "including sem=0.000s and including quiet/background recalls"
 )
 PYEOF
 

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -396,6 +396,158 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the recall-admission-split fix (assert-guarded, fail-loud)", () => {
+    // Background consolidation reaches recall through the SAME
+    // MemoryEngine.recall_async a user's turn does, so both contended on the
+    // single `_search_semaphore` admission gate. Measured on this host: mean
+    // admission wait 5.43s, p90 15.7s, max 27.4s against a recall hook whose
+    // per-bank socket timeout is 8s — fleet p50 pinned at 8.02s. The patch
+    // admits background callers through a small reservation semaphore FIRST,
+    // then the same shared one. Behaviour (including that total concurrency is
+    // unchanged) is proven against the pinned upstream image in
+    // tests/docker/hindsight-recall-isolation-patches.test.ts.
+
+    // The exact-once anchor guard (fail-loud on upstream drift).
+    expect(dockerfile).toMatch(
+      /switchroom hindsight recall-admission-split patch: anchor found \{n\}x/,
+    );
+    // The admission helper, and the nesting order that makes it a RESERVATION
+    // rather than a second budget: background takes its own semaphore and then
+    // the shared one, so the peak is still recall_max_concurrent.
+    expect(dockerfile).toMatch(
+      /"async def _recall_admission\(shared, background_reservation, is_background\):\\n"/,
+    );
+    expect(dockerfile).toMatch(/"    if is_background:\\n"/);
+    expect(dockerfile).toMatch(/"        async with background_reservation:\\n"/);
+    expect(dockerfile).toMatch(/"            async with shared:\\n"/);
+    // The two call sites: recall_async admits through the helper, and the
+    // consolidator flags its recall as background.
+    expect(dockerfile).toMatch(
+      /"            async with _recall_admission\(\\n"/,
+    );
+    expect(dockerfile).toMatch(/"            _background=True,\\n"/);
+    // The config knob + the boot validation that keeps a foreground floor.
+    expect(dockerfile).toMatch(
+      /ENV_CONSOLIDATION_RECALL_MAX_CONCURRENT = "HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT"/,
+    );
+    expect(dockerfile).toMatch(
+      /DEFAULT_CONSOLIDATION_RECALL_MAX_CONCURRENT = 2/,
+    );
+    expect(dockerfile).toMatch(
+      /and self\.consolidation_recall_max_concurrent >= self\.recall_max_concurrent/,
+    );
+    // The DEFAULT is derived from the shared budget rather than fixed, so
+    // lowering HINDSIGHT_API_RECALL_MAX_CONCURRENT cannot turn a deployment
+    // that boots today into one that refuses to boot. Only an EXPLICIT
+    // incoherent value fails validation.
+    expect(dockerfile).toMatch(
+      /def _consolidation_recall_max_concurrent\(getenv\)/,
+    );
+    expect(dockerfile).toMatch(
+      /return max\(1, min\(DEFAULT_CONSOLIDATION_RECALL_MAX_CONCURRENT, shared - 1\)\)/,
+    );
+    // Post-replace re-assertions (verification-on-build). The negative one is
+    // load-bearing: a surviving bare acquisition would let background bypass
+    // the reservation entirely.
+    expect(dockerfile).toMatch(
+      /assert "async def _recall_admission\(" in me_new,/,
+    );
+    expect(dockerfile).toMatch(
+      /assert "async with self\._search_semaphore:" not in me_new,/,
+    );
+    expect(dockerfile).toMatch(/assert "_background=True," in cons_new,/);
+    expect(dockerfile).toMatch(
+      /switchroom hindsight recall-admission-split patch: background consolidation recalls now pass a/,
+    );
+  });
+
+  it("keeps the worker-slot-ceiling fix (assert-guarded, fail-loud)", () => {
+    // HINDSIGHT_API_WORKER_<TYPE>_MAX_SLOTS is a reservation, i.e. a FLOOR:
+    // WorkerPoller._get_available_slots documents that in-flight beyond the
+    // reservation is served from the shared pool, so one type could hold all
+    // DEFAULT_WORKER_MAX_SLOTS = 10 slots. This patch adds the missing CEILING.
+    // Behaviour is proven against the pinned upstream image in
+    // tests/docker/hindsight-recall-isolation-patches.test.ts.
+
+    // The exact-once anchor guard (fail-loud on upstream drift).
+    expect(dockerfile).toMatch(
+      /switchroom hindsight worker-slot-ceiling patch: anchor found \{n\}x/,
+    );
+    // The mechanism: a per-type limit table with a consolidation default, an
+    // env parser whose empty string means "uncapped", and the config field.
+    expect(dockerfile).toMatch(
+      /WORKER_SLOT_LIMIT_TYPES: dict\[str, tuple\[str, int \| None\]\] = \{/,
+    );
+    expect(dockerfile).toMatch(
+      /"consolidation": \("HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT", 4\)/,
+    );
+    expect(dockerfile).toMatch(
+      /def _parse_worker_slot_limits\(getenv, max_slots: int\)/,
+    );
+    expect(dockerfile).toMatch(/worker_slot_limits=_parse_worker_slot_limits\(/);
+    // Same rule as the admission reservation: a DEFAULT cap is clamped to
+    // worker_max_slots so lowering that knob cannot break boot; an EXPLICIT
+    // over-large cap still fails validation below.
+    expect(dockerfile).toMatch(
+      /limits\[op_type\] = max\(1, min\(int\(default\), max_slots\)\)/,
+    );
+    // Boot validation, at the same point as the existing reservation-sum check.
+    expect(dockerfile).toMatch(/if limit > self\.worker_max_slots:/);
+    expect(dockerfile).toMatch(/if limit < reserved:/);
+    // Enforcement runs BEFORE the row is marked processing — that UPDATE is the
+    // actual claim, so filtering after it would leave rows half-claimed.
+    expect(dockerfile).toMatch(/"        if type_ceilings:\\n"/);
+    expect(dockerfile).toMatch(
+      /"        # Mark all claimed rows as processing\\n"/,
+    );
+    // Threaded from the poller through both DB backends.
+    expect(dockerfile).toMatch(/"        type_ceilings=None,\\n"/);
+    expect(dockerfile).toMatch(
+      /for rel in \("engine\/db\/ops_postgresql\.py", "engine\/db\/ops_oracle\.py"\):/,
+    );
+    expect(dockerfile).toMatch(/slot_limits=config\.worker_slot_limits,/);
+    // The reservations themselves must NOT be renamed here: renaming a shipped
+    // env var is a breaking config change, filed upstream instead.
+    expect(dockerfile).not.toMatch(
+      /HINDSIGHT_API_WORKER_CONSOLIDATION_MIN_SLOTS/,
+    );
+    // Post-replace re-assertions (verification-on-build), including the
+    // ORDERING guard that the filter precedes the claiming UPDATE.
+    expect(dockerfile).toMatch(
+      /assert t\.index\("if type_ceilings:"\) < t\.index\("# Mark all claimed rows as processing"\),/,
+    );
+    expect(dockerfile).toMatch(
+      /switchroom hindsight worker-slot-ceiling patch: worker_slot_limits is a real per-type CAP/,
+    );
+  });
+
+  it("keeps the sem-wait-always-logged fix (assert-guarded, fail-loud)", () => {
+    // The admission wait was only logged above 0.01s, so recalls that did NOT
+    // queue left no datum and the measured mean was biased upwards by the
+    // missing zeros. Emitting sem= unconditionally makes the distribution
+    // recoverable from the logs. Behaviour is proven against the pinned
+    // upstream image in tests/docker/hindsight-recall-isolation-patches.test.ts.
+
+    // The exact-once anchor guard (fail-loud on upstream drift).
+    expect(dockerfile).toMatch(
+      /switchroom hindsight sem-wait-always-logged patch: anchor found \{n\}x/,
+    );
+    // The conditional is the anchor being replaced, and the append is now
+    // unconditional.
+    expect(dockerfile).toMatch(/"            if semaphore_wait > 0\.01:\\n"/);
+    // Post-replace re-assertions (verification-on-build), including the SCOPE
+    // guard: the conn= threshold is deliberately untouched by this patch.
+    expect(dockerfile).toMatch(
+      /assert "if semaphore_wait > 0\.01:" not in t,/,
+    );
+    expect(dockerfile).toMatch(
+      /assert 'if max_conn_wait > 0\.01:' in t,/,
+    );
+    expect(dockerfile).toMatch(
+      /switchroom hindsight sem-wait-always-logged patch: sem= now emitted on every recall/,
+    );
+  });
+
   it("preserves upstream's start-all.sh as the post-shim CMD", () => {
     // The shim does broker auth, then `exec "$@"` which is whatever
     // CMD docker passes — must be upstream's start-all.sh so the

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -425,6 +425,13 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toMatch(
       /"            async with _recall_admission\(\\n"/,
     );
+    // The ARGUMENT LINE, pinned exactly. This is the load-bearing one: swapping
+    // the third argument for a literal `False` reverts the whole split while
+    // leaving the helper defined, the call site intact and `_search_semaphore`
+    // present as an argument — every other check here would still pass.
+    expect(dockerfile).toContain(
+      '"                self._search_semaphore, self._background_search_semaphore, _background\\n"',
+    );
     expect(dockerfile).toMatch(/"            _background=True,\\n"/);
     // The config knob + the boot validation that keeps a foreground floor.
     expect(dockerfile).toMatch(
@@ -456,8 +463,19 @@ describe("Dockerfile.hindsight shape", () => {
       /assert "async with self\._search_semaphore:" not in me_new,/,
     );
     expect(dockerfile).toMatch(/assert "_background=True," in cons_new,/);
+    // …and the build-time twin of the argument pin above.
+    expect(dockerfile).toMatch(
+      /a hard-coded third argument silently reverts the admission split/,
+    );
     expect(dockerfile).toMatch(
       /switchroom hindsight recall-admission-split patch: background consolidation recalls now pass a/,
+    );
+    // The two config.py patch blocks are ORDER-COUPLED on the same
+    // HindsightConfig.validate() anchor; this block additionally requires
+    // `@classmethod / def from_env` to still follow it, so it must run first.
+    // Swapping them fails the build loudly, but reads as upstream drift.
+    expect(dockerfile).toMatch(
+      /ORDER-COUPLED WITH THE worker-slot-ceiling BLOCK BELOW — DO NOT SWAP THEM/,
     );
   });
 
@@ -494,12 +512,46 @@ describe("Dockerfile.hindsight shape", () => {
     // Boot validation, at the same point as the existing reservation-sum check.
     expect(dockerfile).toMatch(/if limit > self\.worker_max_slots:/);
     expect(dockerfile).toMatch(/if limit < reserved:/);
-    // Enforcement runs BEFORE the row is marked processing — that UPDATE is the
-    // actual claim, so filtering after it would leave rows half-claimed.
-    expect(dockerfile).toMatch(/"        if type_ceilings:\\n"/);
-    expect(dockerfile).toMatch(
-      /"        # Mark all claimed rows as processing\\n"/,
+    // The ceiling bounds SELECTION, it is not a post-selection filter. Phase 2a
+    // is one `ORDER BY created_at LIMIT n` across every non-consolidation type,
+    // so discarding the surplus afterwards spends the shared budget on rows that
+    // are never claimed — one capped type then starves every other type of the
+    // whole batch. An at-ceiling type is excluded in the WHERE clause instead,
+    // with a refill fetch for the unspent remainder.
+    expect(dockerfile).toContain(
+      "AND operation_type != ALL(${idx}::text[])",
     );
+    expect(dockerfile).toMatch(
+      /exhausted = sorted\(t for t, h in remaining_ceilings\.items\(\) if h <= 0\)/,
+    );
+    // The budget is spent per ACCEPTED row, never per selected row (otherwise
+    // rows the ceiling drops under-budget phase 2b).
+    expect(dockerfile).toMatch(/_accept\(\[row\]\)\n\s+remaining_shared -= 1/);
+    // Scoped to the REPLACEMENT body. `remaining_shared -= len(rows)` is
+    // upstream's line and MUST still appear verbatim in CLAIM_BODY_OLD — it is
+    // part of the anchor being replaced. It must not survive into the new body.
+    const claimBodyOldIdx = dockerfile.indexOf("CLAIM_BODY_OLD = r'''");
+    const claimBodyNewIdx = dockerfile.indexOf("CLAIM_BODY_NEW = r'''");
+    expect(claimBodyOldIdx).toBeGreaterThan(-1);
+    expect(claimBodyNewIdx).toBeGreaterThan(claimBodyOldIdx);
+    expect(dockerfile.slice(claimBodyOldIdx, claimBodyNewIdx)).toMatch(
+      /remaining_shared -= len\(rows\)/,
+    );
+    expect(dockerfile.slice(claimBodyNewIdx)).not.toMatch(
+      /remaining_shared -= len\(rows\)/,
+    );
+    // At zero headroom phase 2b is skipped OUTRIGHT — no busy-banks scan, no
+    // FOR UPDATE locks on rows this worker must discard.
+    expect(dockerfile).toMatch(
+      /consolidation_shared = _headroom\("consolidation", remaining_shared\)/,
+    );
+    expect(dockerfile).toMatch(/if consolidation_shared > 0:/);
+    // Enforcement runs BEFORE the row is marked processing — that UPDATE is the
+    // actual claim, so enforcing after it would leave rows half-claimed.
+    expect(dockerfile).toMatch(
+      /remaining_ceilings = dict\(type_ceilings\) if type_ceilings else \{\}/,
+    );
+    expect(dockerfile).toMatch(/        # Mark all claimed rows as processing/);
     // Threaded from the poller through both DB backends.
     expect(dockerfile).toMatch(/"        type_ceilings=None,\\n"/);
     expect(dockerfile).toMatch(
@@ -512,9 +564,15 @@ describe("Dockerfile.hindsight shape", () => {
       /HINDSIGHT_API_WORKER_CONSOLIDATION_MIN_SLOTS/,
     );
     // Post-replace re-assertions (verification-on-build), including the
-    // ORDERING guard that the filter precedes the claiming UPDATE.
+    // ORDERING guard that enforcement precedes the claiming UPDATE.
     expect(dockerfile).toMatch(
-      /assert t\.index\("if type_ceilings:"\) < t\.index\("# Mark all claimed rows as processing"\),/,
+      /assert t\.index\("remaining_ceilings = dict\(type_ceilings\)"\) < t\.index\(/,
+    );
+    expect(dockerfile).toContain(
+      "at-ceiling types are not excluded ",
+    );
+    expect(dockerfile).toContain(
+      "phase 2b is not clamped by ",
     );
     expect(dockerfile).toMatch(
       /switchroom hindsight worker-slot-ceiling patch: worker_slot_limits is a real per-type CAP/,
@@ -522,11 +580,13 @@ describe("Dockerfile.hindsight shape", () => {
   });
 
   it("keeps the sem-wait-always-logged fix (assert-guarded, fail-loud)", () => {
-    // The admission wait was only logged above 0.01s, so recalls that did NOT
-    // queue left no datum and the measured mean was biased upwards by the
-    // missing zeros. Emitting sem= unconditionally makes the distribution
-    // recoverable from the logs. Behaviour is proven against the pinned
-    // upstream image in tests/docker/hindsight-recall-isolation-patches.test.ts.
+    // Two gates hid the admission wait. It was only logged above 0.01s, so
+    // recalls that did NOT queue left no datum and the measured mean was biased
+    // upwards by the missing zeros; and the whole completion line sits behind
+    // `if not quiet:` while the consolidator recalls with _quiet=True, so the
+    // BACKGROUND population this PR pins at 2 emitted nothing at all. Behaviour
+    // is proven against the pinned upstream image in
+    // tests/docker/hindsight-recall-isolation-patches.test.ts.
 
     // The exact-once anchor guard (fail-loud on upstream drift).
     expect(dockerfile).toMatch(
@@ -535,6 +595,19 @@ describe("Dockerfile.hindsight shape", () => {
     // The conditional is the anchor being replaced, and the append is now
     // unconditional.
     expect(dockerfile).toMatch(/"            if semaphore_wait > 0\.01:\\n"/);
+    // The dead ternary goes with the gate: wait_parts can no longer be empty, so
+    // the `else ""` branch was unreachable.
+    expect(dockerfile).toContain(
+      "wait_info = f\\\" | waits: {', '.join(wait_parts)}\\\"\\n",
+    );
+    // A quiet (background) recall still reports its admission wait — otherwise
+    // the reservation backing consolidation up is invisible, which is the exact
+    // "we mis-sized this from biased logs" failure the patch exists to prevent.
+    expect(dockerfile).toContain("[RECALL {recall_id}] Complete (quiet):");
+    // …as ONE line, not the multi-line buffer _quiet exists to suppress.
+    expect(dockerfile).not.toMatch(
+      /else:\n\s+logger\.info\("\\\\n" \+ "\\\\n"\.join\(log_buffer\)\)/,
+    );
     // Post-replace re-assertions (verification-on-build), including the SCOPE
     // guard: the conn= threshold is deliberately untouched by this patch.
     expect(dockerfile).toMatch(
@@ -542,6 +615,9 @@ describe("Dockerfile.hindsight shape", () => {
     );
     expect(dockerfile).toMatch(
       /assert 'if max_conn_wait > 0\.01:' in t,/,
+    );
+    expect(dockerfile).toContain(
+      "a quiet (background) recall still ",
     );
     expect(dockerfile).toMatch(
       /switchroom hindsight sem-wait-always-logged patch: sem= now emitted on every recall/,

--- a/tests/docker/hindsight-recall-isolation-patches.test.ts
+++ b/tests/docker/hindsight-recall-isolation-patches.test.ts
@@ -1,0 +1,946 @@
+/**
+ * Behavioural proof for the three recall-isolation patches
+ * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight image.
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of those patch blocks
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: it runs the
+ * same probe against unpatched upstream (must be RED on every defect) and
+ * against upstream + the patch blocks applied (must be GREEN).
+ *
+ * The three defects, all measured on this host before the fix:
+ *
+ *  1. Background consolidation and the latency-critical per-turn recall hook
+ *     contend on ONE admission semaphore. The consolidator calls the very same
+ *     `MemoryEngine.recall_async` a user's turn does, which acquires
+ *     `self._search_semaphore` sized by HINDSIGHT_API_RECALL_MAX_CONCURRENT
+ *     (8 in this fleet). Measured admission wait: mean 5.43s, p90 15.7s, max
+ *     27.4s, against a recall hook whose per-bank socket timeout is 8s — fleet
+ *     p50 pinned at exactly 8.02s, with per-agent timeout rates of 97.5%,
+ *     95.8% and 73.9%.
+ *  2. There is no per-operation-type worker slot CEILING. The
+ *     HINDSIGHT_API_WORKER_<TYPE>_MAX_SLOTS knobs are reservations, i.e. a
+ *     FLOOR: `WorkerPoller._get_available_slots` documents that "when an
+ *     operation type's in-flight count exceeds its reservation, the excess
+ *     tasks are considered to be using shared pool slots". So consolidation
+ *     could take every one of DEFAULT_WORKER_MAX_SLOTS = 10 slots, and the
+ *     `consolidation=6/1(avail=0)` seen in the worker log was documented
+ *     behaviour rather than the overrun it looked like.
+ *  3. The recall completion line only emitted `sem=` when the wait exceeded
+ *     0.01s, so the recalls that did NOT queue left no datum. That is how the
+ *     contention above was first mis-measured: averaging only the lines that
+ *     appeared biased the mean upwards and hid that just 45% of recalls wait
+ *     at all.
+ *
+ * Beyond proving the three fixes, the probe pins the properties that make them
+ * SAFE, none of which is visible from the patch text:
+ *
+ *  - The admission split does not RAISE database concurrency. Background takes
+ *    a small reservation semaphore and then the SAME shared one, so the peak is
+ *    still exactly recall_max_concurrent — it is a reservation, not a second
+ *    budget.
+ *  - It cannot deadlock: foreground never acquires the background semaphore, so
+ *    the acquisition order is total. Driven here rather than argued.
+ *  - A ceiling on one operation type never throttles another, and with no
+ *    ceilings configured `claim_tasks` returns byte-for-byte what upstream did.
+ *  - An over-ceiling row is dropped BEFORE the `UPDATE ... SET
+ *    status='processing'`, so it is left pending rather than half-claimed.
+ *  - The `conn=` wait threshold is untouched: fix 3 is scoped to `sem=`.
+ *
+ * Both slot mechanisms are driven through the REAL shipping code — the real
+ * `PostgreSQLOps.claim_tasks` against a fake connection, and the real
+ * `WorkerPoller._get_available_slots` — rather than a reimplementation, and the
+ * config validations are driven through the real `HindsightConfig.from_env()`.
+ *
+ * The patch blocks are extracted from the Dockerfile itself rather than
+ * duplicated here, so this test cannot drift from what actually ships. It
+ * applies them by `docker exec` (not `docker build`) so it runs on daemons
+ * without buildx, and it never touches the production `switchroom-hindsight`
+ * container.
+ *
+ * SKIP DISCIPLINE: identical to `hindsight-search-patches.test.ts`. Locally,
+ * with no docker or no cached image, this skips (never pull a 6.4GB
+ * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
+ * pinned digest and sets SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an
+ * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
+ * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
+ * mistaken for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8"
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-recall-isolation-patches";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/** The patch names this file proves, in the order they must be applied. */
+const PATCH_NAMES = [
+  "recall-admission-split patch",
+  "worker-slot-ceiling patch",
+  "sem-wait-always-logged patch",
+];
+
+/**
+ * The three patch blocks under test, pulled out of the Dockerfile's
+ * `RUN python3 - <<'PYEOF' ... PYEOF` heredocs by their unique patch names.
+ */
+function patchBlocks(): string[] {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  return PATCH_NAMES.map((name) => {
+    const b = blocks.find((x) => x.includes(name));
+    if (!b) {
+      throw new Error(
+        `Dockerfile.hindsight no longer contains the "${name}" RUN block — ` +
+          `if it was deliberately removed, delete this test with it.`
+      );
+    }
+    return b;
+  });
+}
+
+/**
+ * Python probe. Exits 0 only when all three fixes are in effect AND every
+ * safety property above holds; prints the offending assertions otherwise.
+ *
+ * Deliberately asserts OUTCOMES rather than merely calling the code: it starves
+ * a real asyncio admission gate and times a foreground acquire, drives the real
+ * `claim_tasks` and counts what it marks processing, and executes the real
+ * wait-line assembly lifted out of the shipping source. The only string-shaped
+ * assertions are AST checks on the two call sites a live database would be
+ * needed to reach.
+ */
+const PROBE = String.raw`
+import ast
+import asyncio
+import inspect
+import os
+import re
+import sys
+import textwrap
+import uuid
+
+failures = []
+
+
+def fail(msg):
+    failures.append(msg)
+
+
+# =====================================================================
+# fix 1 - recall admission split (foreground must not be starvable)
+# =====================================================================
+import hindsight_api.config as hs_config
+import hindsight_api.engine.memory_engine as me
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+_admission = getattr(me, "_recall_admission", None)
+print("HAS_ADMISSION_HELPER", _admission is not None)
+
+
+def admit(shared, background_reservation, is_background):
+    """Admission exactly as the SHIPPING module defines it.
+
+    Upstream has no split, so every caller takes the one shared semaphore -
+    that IS the defect. Running the identical scenario through whatever the
+    module actually provides is what makes this probe RED on upstream and
+    GREEN once patched.
+    """
+    if _admission is None:
+        return shared
+    return _admission(shared, background_reservation, is_background)
+
+
+SHARED = 8  # HINDSIGHT_API_RECALL_MAX_CONCURRENT in this deployment
+BG = 2  # DEFAULT_CONSOLIDATION_RECALL_MAX_CONCURRENT
+
+
+async def starvation_scenario(n_background):
+    """Saturate admission with background recalls, then time a foreground one."""
+    shared = asyncio.Semaphore(SHARED)
+    background = asyncio.Semaphore(BG)
+    release = asyncio.Event()
+    live_background = 0
+    peak_background = 0
+    lock = asyncio.Lock()
+
+    async def bg_recall():
+        nonlocal live_background, peak_background
+        async with admit(shared, background, True):
+            async with lock:
+                live_background += 1
+                peak_background = max(peak_background, live_background)
+            await release.wait()
+            async with lock:
+                live_background -= 1
+
+    tasks = [asyncio.create_task(bg_recall()) for _ in range(n_background)]
+    await asyncio.sleep(0.1)  # let everything that CAN be admitted be admitted
+
+    loop = asyncio.get_running_loop()
+    t0 = loop.time()
+    admitted = True
+    try:
+        async with asyncio.timeout(0.5):
+            async with admit(shared, background, False):
+                pass
+    except TimeoutError:
+        admitted = False
+    waited = loop.time() - t0
+
+    release.set()
+    await asyncio.gather(*tasks)
+    return admitted, waited, peak_background
+
+
+fg_ok, fg_wait, bg_in = asyncio.run(starvation_scenario(SHARED))
+print(f"STARVATION background={bg_in} foreground_admitted={fg_ok} wait={fg_wait:.3f}s")
+if not fg_ok:
+    fail(
+        f"foreground recall was STARVED: {bg_in} concurrent background (consolidation) "
+        f"recalls held every one of the {SHARED} admission slots"
+    )
+if _admission is not None and bg_in > BG:
+    fail(f"background held {bg_in} admission slots, above its reservation of {BG}")
+
+# The floor must be a guarantee, not luck: with far more background pressure
+# than there are slots, foreground must still be admitted immediately.
+fg_ok2, fg_wait2, bg_in2 = asyncio.run(starvation_scenario(SHARED * 4))
+print(f"STARVATION_HEAVY background={bg_in2} foreground_admitted={fg_ok2} wait={fg_wait2:.3f}s")
+if not fg_ok2:
+    fail("foreground recall was STARVED under heavy background load")
+if _admission is not None:
+    if bg_in2 != BG:
+        fail(f"{bg_in2} background recalls were admitted at once, expected exactly {BG}")
+    if fg_wait2 > 0.25:
+        fail(f"foreground recall queued {fg_wait2:.3f}s behind background work")
+
+
+async def total_concurrency_scenario():
+    """The split must not RAISE total DB concurrency above recall_max_concurrent."""
+    shared = asyncio.Semaphore(SHARED)
+    background = asyncio.Semaphore(BG)
+    release = asyncio.Event()
+    live = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def one(is_bg):
+        nonlocal live, peak
+        async with admit(shared, background, is_bg):
+            async with lock:
+                live += 1
+                peak = max(peak, live)
+            await release.wait()
+            async with lock:
+                live -= 1
+
+    tasks = [asyncio.create_task(one(i % 2 == 0)) for i in range(SHARED * 5)]
+    await asyncio.sleep(0.1)
+    observed = peak
+    release.set()
+    await asyncio.gather(*tasks)
+    return observed
+
+
+peak = asyncio.run(total_concurrency_scenario())
+print("TOTAL_CONCURRENCY_PEAK", peak)
+if peak > SHARED:
+    fail(f"admission let {peak} recalls run concurrently, above recall_max_concurrent={SHARED}")
+if peak < SHARED:
+    fail(f"admission only reached {peak} concurrent recalls, below recall_max_concurrent={SHARED}")
+
+
+async def no_deadlock_scenario():
+    """Driven, not argued: a blocked background caller must not wedge anyone."""
+    shared = asyncio.Semaphore(1)
+    background = asyncio.Semaphore(1)
+    held = asyncio.Event()
+    release = asyncio.Event()
+
+    async def holder():
+        async with admit(shared, background, False):
+            held.set()
+            await release.wait()
+
+    async def blocked_bg():
+        async with admit(shared, background, True):
+            pass
+
+    h = asyncio.create_task(holder())
+    await held.wait()
+    b = asyncio.create_task(blocked_bg())
+    await asyncio.sleep(0.05)
+    release.set()
+    try:
+        async with asyncio.timeout(1.0):
+            await asyncio.gather(h, b)
+        return True
+    except TimeoutError:
+        h.cancel()
+        b.cancel()
+        return False
+
+
+no_deadlock = asyncio.run(no_deadlock_scenario())
+print("NO_DEADLOCK", no_deadlock)
+if not no_deadlock:
+    fail("nested background admission deadlocked")
+
+# ---- the wiring the scenario above cannot reach without a live database ----
+# Structural (AST), not a string grep: these pin that the REAL recall entry
+# point and the REAL consolidation caller are what the split governs.
+params = inspect.signature(MemoryEngine.recall_async).parameters
+print("RECALL_HAS_BACKGROUND_PARAM", "_background" in params)
+if "_background" not in params:
+    fail("recall_async has no _background parameter - the admission split is not wired in")
+elif params["_background"].default is not False:
+    fail("recall_async _background must default to False so foreground stays the default")
+
+recall_src = textwrap.dedent(inspect.getsource(MemoryEngine.recall_async))
+tree = ast.parse(recall_src)
+admission_calls = [
+    item
+    for n in ast.walk(tree)
+    if isinstance(n, ast.AsyncWith)
+    for item in n.items
+    if isinstance(item.context_expr, ast.Call)
+    and isinstance(item.context_expr.func, ast.Name)
+    and item.context_expr.func.id == "_recall_admission"
+]
+bare_shared = [
+    item
+    for n in ast.walk(tree)
+    if isinstance(n, ast.AsyncWith)
+    for item in n.items
+    if isinstance(item.context_expr, ast.Attribute) and item.context_expr.attr == "_search_semaphore"
+]
+print("RECALL_ADMISSION_WIRED", len(admission_calls), "BARE_SHARED_ACQUIRES", len(bare_shared))
+if len(admission_calls) != 1:
+    fail("recall_async does not admit through _recall_admission exactly once")
+if bare_shared:
+    fail(
+        "recall_async still acquires _search_semaphore directly - background recalls "
+        "would bypass the reservation"
+    )
+
+import hindsight_api.engine.consolidation.consolidator as consolidator
+
+ctree = ast.parse(inspect.getsource(consolidator))
+recall_calls = [
+    n
+    for n in ast.walk(ctree)
+    if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr == "recall_async"
+]
+bg_flagged = [
+    c
+    for c in recall_calls
+    if any(
+        kw.arg == "_background" and isinstance(kw.value, ast.Constant) and kw.value.value is True
+        for kw in c.keywords
+    )
+]
+print("CONSOLIDATOR_RECALLS", len(recall_calls), "MARKED_BACKGROUND", len(bg_flagged))
+if not recall_calls:
+    fail("no recall_async call found in the consolidator - re-author this probe")
+if len(bg_flagged) != len(recall_calls):
+    fail(
+        f"{len(recall_calls) - len(bg_flagged)} consolidator recall_async call(s) are still "
+        "admitted as FOREGROUND and can starve the per-turn recall hook"
+    )
+
+
+def cfg_with(**env):
+    """Build a config from env, returning (config, error)."""
+    old = {k: os.environ.get(k) for k in env}
+    os.environ.update({k: str(v) for k, v in env.items()})
+    try:
+        return hs_config.HindsightConfig.from_env(), None
+    except ValueError as e:
+        return None, str(e)
+    finally:
+        for k, v in old.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+fields = getattr(hs_config.HindsightConfig, "__dataclass_fields__", {})
+has_bg_field = "consolidation_recall_max_concurrent" in fields
+print("CONFIG_HAS_BG_FIELD", has_bg_field)
+if not has_bg_field:
+    fail("HindsightConfig has no consolidation_recall_max_concurrent field")
+else:
+    good, err = cfg_with(
+        HINDSIGHT_API_RECALL_MAX_CONCURRENT=8, HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT=2
+    )
+    print("BG_CONFIG_OK", good is not None and good.consolidation_recall_max_concurrent == 2)
+    if good is None:
+        fail(f"a valid admission config was rejected: {err}")
+
+    no_floor, _ = cfg_with(
+        HINDSIGHT_API_RECALL_MAX_CONCURRENT=8, HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT=8
+    )
+    print("BG_CONFIG_REJECTS_NO_FLOOR", no_floor is None)
+    if no_floor is not None:
+        fail(
+            "a background reservation equal to recall_max_concurrent was accepted - "
+            "foreground would have no guaranteed floor"
+        )
+
+    zero, _ = cfg_with(HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT=0)
+    print("BG_CONFIG_REJECTS_ZERO", zero is None)
+    if zero is not None:
+        fail("a zero background reservation was accepted - consolidation could never recall")
+
+    # A DEFAULT must never turn a deployment that boots today into one that
+    # refuses to boot: the reservation default is derived from the shared budget.
+    tiny, err = cfg_with(HINDSIGHT_API_RECALL_MAX_CONCURRENT=2)
+    one, err_one = cfg_with(HINDSIGHT_API_RECALL_MAX_CONCURRENT=1)
+    print(
+        "BG_DEFAULT_DERIVED",
+        None if tiny is None else tiny.consolidation_recall_max_concurrent,
+        None if one is None else one.consolidation_recall_max_concurrent,
+    )
+    if tiny is None or tiny.consolidation_recall_max_concurrent != 1:
+        fail(f"recall_max_concurrent=2 did not derive a background reservation of 1: {err}")
+    if one is None or one.consolidation_recall_max_concurrent != 1:
+        fail(f"a single-slot deployment no longer boots: {err_one}")
+
+
+# =====================================================================
+# fix 2 - a real per-type worker slot CEILING
+# =====================================================================
+from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+from hindsight_api.worker.poller import WorkerPoller
+
+
+class FakeConn:
+    """Enough of asyncpg to drive the real claim_tasks end to end."""
+
+    def __init__(self, pending):
+        self.pending = list(pending)
+        self.claimed = []
+
+    async def fetch(self, sql, *params):
+        if "SELECT DISTINCT bank_id" in sql:
+            return []
+        limit = int(params[-1]) if params else len(self.pending)
+        rows = self.pending
+        if "operation_type = $1" in sql:
+            rows = [r for r in rows if r["operation_type"] == params[0]]
+        elif "operation_type = 'consolidation'" in sql:
+            rows = [r for r in rows if r["operation_type"] == "consolidation"]
+        elif "operation_type != 'consolidation'" in sql:
+            rows = [r for r in rows if r["operation_type"] != "consolidation"]
+        excluded = set()
+        for p in params[:-1]:
+            if isinstance(p, list) and p and isinstance(p[0], uuid.UUID):
+                excluded = {str(x) for x in p}
+        rows = [r for r in rows if str(r["operation_id"]) not in excluded]
+        return rows[:limit]
+
+    async def execute(self, sql, *params):
+        if "SET status = 'processing'" in sql:
+            self.claimed = [str(x) for x in params[1]]
+        return None
+
+
+def pending(n_consolidation, n_retain=0):
+    rows = []
+
+    def row(op_type):
+        return {
+            "operation_id": uuid.uuid4(),
+            "operation_type": op_type,
+            "task_payload": "{}",
+            "retry_count": 0,
+            "bank_id": f"bank-{len(rows)}",
+        }
+
+    for _ in range(n_consolidation):
+        rows.append(row("consolidation"))
+    for _ in range(n_retain):
+        rows.append(row("retain"))
+    return rows
+
+
+ops = PostgreSQLOps()
+supports_ceilings = "type_ceilings" in inspect.signature(ops.claim_tasks).parameters
+print("CLAIM_TASKS_SUPPORTS_CEILINGS", supports_ceilings)
+
+# THE BUG, driven through the real claim path: worker_max_slots=10 with a
+# consolidation RESERVATION of 1 and a 9-slot shared pool. A reservation is a
+# floor, so upstream lets consolidation take every slot.
+conn = FakeConn(pending(12))
+kwargs = {"consolidation_bank_priority": None}
+if supports_ceilings:
+    kwargs["type_ceilings"] = {"consolidation": 4}
+rows = asyncio.run(ops.claim_tasks(conn, "async_operations", "w1", {"consolidation": 1}, 9, **kwargs))
+n_consolidation = sum(1 for r in rows if r["operation_type"] == "consolidation")
+print("CEILING_CLAIMED", n_consolidation, "MARKED_PROCESSING", len(conn.claimed))
+if n_consolidation > 4:
+    fail(
+        f"consolidation claimed {n_consolidation} worker slots under a ceiling of 4 - no "
+        "per-type CEILING exists, only the ..._MAX_SLOTS reservation FLOOR"
+    )
+if len(conn.claimed) != len(rows):
+    fail("claim_tasks marked a different number of rows processing than it returned")
+if {str(r["operation_id"]) for r in rows} != set(conn.claimed):
+    fail("rows dropped by the ceiling were still marked processing (half-claimed)")
+
+if supports_ceilings:
+    # A ceiling on one type must not throttle another, and an uncapped type
+    # must be claimed in full.
+    conn3 = FakeConn(pending(12, n_retain=5))
+    rows3 = asyncio.run(
+        ops.claim_tasks(
+            conn3,
+            "async_operations",
+            "w1",
+            {},
+            9,
+            consolidation_bank_priority=None,
+            type_ceilings={"consolidation": 2},
+        )
+    )
+    by_type = {}
+    for r in rows3:
+        by_type[r["operation_type"]] = by_type.get(r["operation_type"], 0) + 1
+    print("MIXED_CLAIM", sorted(by_type.items()))
+    if by_type.get("consolidation", 0) > 2:
+        fail("the ceiling did not bound consolidation in a mixed batch")
+    if by_type.get("retain", 0) != 5:
+        fail("the uncapped retain type was throttled by another type's ceiling")
+
+    # No ceilings == upstream, byte for byte.
+    conn4 = FakeConn(pending(12))
+    rows4 = asyncio.run(
+        ops.claim_tasks(
+            conn4, "async_operations", "w1", {"consolidation": 1}, 9, consolidation_bank_priority=None
+        )
+    )
+    print("UNCAPPED_CLAIMED", len(rows4))
+    if len(rows4) != 10:
+        fail(f"with no ceilings claim_tasks returned {len(rows4)} rows, expected upstream's 10")
+
+# The poller must compute and expose the headroom the claim path spends.
+poller_kwargs = {
+    "backend": object(),
+    "worker_id": "w1",
+    "executor": lambda *_: None,
+    "tenant_extension": object(),
+    "max_slots": 10,
+    "slot_reservations": {"consolidation": 1},
+}
+if "slot_limits" in inspect.signature(WorkerPoller.__init__).parameters:
+    poller_kwargs["slot_limits"] = {"consolidation": 4}
+poller = WorkerPoller(**poller_kwargs)
+
+poller._in_flight_count = 4
+poller._in_flight_by_type = {"consolidation": 4}
+avail = asyncio.run(poller._get_available_slots())
+ceilings = getattr(avail, "ceilings", None)
+print("POLLER_CEILINGS", ceilings, "RESERVED", avail.reserved, "SHARED", avail.shared)
+if ceilings is None:
+    fail("SlotAvailability carries no per-type ceilings - the poller cannot enforce a cap")
+else:
+    if ceilings.get("consolidation") != 0:
+        fail(f"consolidation headroom is {ceilings.get('consolidation')} at 4 in-flight, cap 4")
+    if avail.shared > 0 and ceilings.get("consolidation") == 0:
+        pass  # shared stays open for OTHER types - that is correct
+
+poller._in_flight_count = 0
+poller._in_flight_by_type = {}
+avail0 = asyncio.run(poller._get_available_slots())
+idle_ceilings = getattr(avail0, "ceilings", None)
+print("POLLER_CEILINGS_IDLE", idle_ceilings)
+if idle_ceilings is not None and idle_ceilings.get("consolidation") != 4:
+    fail("idle consolidation headroom should equal the full ceiling")
+
+has_limits = "worker_slot_limits" in fields
+print("CONFIG_HAS_SLOT_LIMITS", has_limits)
+if not has_limits:
+    fail("HindsightConfig has no worker_slot_limits - there is no per-type ceiling mechanism")
+else:
+    c, err = cfg_with(HINDSIGHT_API_WORKER_MAX_SLOTS=10)
+    print("DEFAULT_CEILINGS", None if c is None else sorted(c.worker_slot_limits.items()))
+    if c is None or c.worker_slot_limits.get("consolidation") != 4:
+        fail(f"default consolidation ceiling is not 4: {err or c.worker_slot_limits}")
+
+    over, _ = cfg_with(
+        HINDSIGHT_API_WORKER_MAX_SLOTS=10, HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT=11
+    )
+    print("REJECTS_CEILING_ABOVE_MAX_SLOTS", over is None)
+    if over is not None:
+        fail("a ceiling above worker_max_slots was accepted")
+
+    under, _ = cfg_with(
+        HINDSIGHT_API_WORKER_MAX_SLOTS=10,
+        HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=5,
+        HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT=2,
+    )
+    print("REJECTS_CEILING_BELOW_RESERVATION", under is None)
+    if under is not None:
+        fail("a ceiling below the type's own reservation was accepted - the floor is unsatisfiable")
+
+    off, _ = cfg_with(HINDSIGHT_API_WORKER_MAX_SLOTS=10, HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT="")
+    print("CEILING_OPT_OUT", off is not None and not off.worker_slot_limits)
+    if off is None or off.worker_slot_limits:
+        fail("an empty ceiling env var did not switch the cap off")
+
+    zero_cap, _ = cfg_with(
+        HINDSIGHT_API_WORKER_MAX_SLOTS=10, HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT=0
+    )
+    print("REJECTS_ZERO_CEILING", zero_cap is None)
+    if zero_cap is not None:
+        fail("a zero ceiling was accepted - the type could never be scheduled")
+
+    # Same rule as the admission reservation: an EXPLICIT ceiling above
+    # worker_max_slots is rejected (above), but the DEFAULT is clamped so that
+    # lowering HINDSIGHT_API_WORKER_MAX_SLOTS cannot break boot.
+    small, err_small = cfg_with(HINDSIGHT_API_WORKER_MAX_SLOTS=2)
+    print(
+        "CEILING_DEFAULT_CLAMPED",
+        None if small is None else small.worker_slot_limits.get("consolidation"),
+    )
+    if small is None or small.worker_slot_limits.get("consolidation") != 2:
+        fail(f"worker_max_slots=2 did not clamp the default consolidation ceiling: {err_small}")
+
+
+# =====================================================================
+# fix 3 - sem= is emitted on EVERY recall
+# =====================================================================
+# Execute the REAL shipping wait-line assembly with a zero admission wait.
+# (It lives in MemoryEngine._search_with_retries, the recall search path.)
+engine_src = inspect.getsource(me)
+m = re.search(r"^( *)wait_parts = \[\]\n(?:.*?\n)??\1wait_info = [^\n]*", engine_src, re.S | re.M)
+if not m:
+    fail("could not locate the recall wait-line assembly - re-author this probe")
+else:
+    indent = m.group(1)
+    block = "\n".join(
+        line[len(indent) :] if line.startswith(indent) else line
+        for line in m.group(0).splitlines()
+    )
+    scope = {"semaphore_wait": 0.0, "max_conn_wait": 0.0}
+    exec(compile(block, "<recall-wait-line>", "exec"), scope)
+    print("WAIT_INFO_AT_ZERO %r" % scope["wait_info"])
+    if "sem=" not in scope["wait_info"]:
+        fail(
+            "sem= is absent when the admission wait is 0.000s - the >0.01s gate hides that a "
+            "recall did not queue, so no log scrape can recover the wait distribution"
+        )
+    elif "sem=0.000s" not in scope["wait_info"]:
+        fail(f"expected sem=0.000s in the zero-wait line, got {scope['wait_info']!r}")
+
+    scope2 = {"semaphore_wait": 5.43, "max_conn_wait": 0.0}
+    exec(compile(block, "<recall-wait-line>", "exec"), scope2)
+    print("WAIT_INFO_AT_MEASURED_MEAN %r" % scope2["wait_info"])
+    if "sem=5.430s" not in scope2["wait_info"]:
+        fail("a real 5.43s admission wait is no longer reported")
+
+    scope3 = {"semaphore_wait": 0.0, "max_conn_wait": 0.0053}
+    exec(compile(block, "<recall-wait-line>", "exec"), scope3)
+    print("WAIT_INFO_CONN_SUBTHRESHOLD %r" % scope3["wait_info"])
+    if "conn=" in scope3["wait_info"]:
+        fail("the connection-wait threshold was changed - this fix is scoped to sem= only")
+
+
+print("FAILURES", failures)
+print("PROBE_EXECUTED")
+sys.exit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-iso-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8
+  )}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "300",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] }
+    );
+
+    if (patched) {
+      for (const block of patchBlocks()) {
+        // Each block is self-verifying: it asserts its upstream anchors exist
+        // exactly once and re-asserts the result, so a non-zero exit here means
+        // upstream drifted and the patch must be re-authored.
+        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+          input: block,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      }
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" }
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight recall-isolation probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("extracts exactly the three patch blocks it claims to prove", () => {
+    const blocks = patchBlocks();
+    expect(blocks).toHaveLength(PATCH_NAMES.length);
+    // Distinct blocks: a duplicated name would silently apply one patch twice
+    // and leave another unproven.
+    expect(new Set(blocks).size).toBe(PATCH_NAMES.length);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate (never pull a 6.4GB image onto
+      // a dev box), but it must be visible rather than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable"
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite"
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight recall-isolation patches change real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" }
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED on all three defects (proves the probe bites)", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED"
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // Defect 1 — the starvation itself, driven: 8 concurrent background
+      // recalls hold all 8 admission slots and the foreground acquire never
+      // completes. Total concurrency is already correct upstream (8), which is
+      // why the fix must not change it.
+      expect(stdout).toContain("HAS_ADMISSION_HELPER False");
+      expect(stdout).toMatch(
+        /STARVATION background=8 foreground_admitted=False/
+      );
+      expect(stdout).toMatch(
+        /STARVATION_HEAVY background=8 foreground_admitted=False/
+      );
+      expect(stdout).toContain("TOTAL_CONCURRENCY_PEAK 8");
+      expect(stdout).toContain(
+        "foreground recall was STARVED: 8 concurrent background (consolidation) " +
+          "recalls held every one of the 8 admission slots"
+      );
+      // … and the wiring that causes it: the consolidator's recall is admitted
+      // as foreground, straight onto the shared semaphore.
+      expect(stdout).toContain("RECALL_ADMISSION_WIRED 0 BARE_SHARED_ACQUIRES 1");
+      expect(stdout).toContain("CONSOLIDATOR_RECALLS 1 MARKED_BACKGROUND 0");
+      expect(stdout).toContain("CONFIG_HAS_BG_FIELD False");
+
+      // Defect 2 — with a consolidation reservation of 1 and a 9-slot shared
+      // pool, consolidation claims all 10 worker slots.
+      expect(stdout).toContain("CLAIM_TASKS_SUPPORTS_CEILINGS False");
+      expect(stdout).toContain("CEILING_CLAIMED 10 MARKED_PROCESSING 10");
+      expect(stdout).toContain(
+        "consolidation claimed 10 worker slots under a ceiling of 4 - no " +
+          "per-type CEILING exists, only the ..._MAX_SLOTS reservation FLOOR"
+      );
+      expect(stdout).toContain("POLLER_CEILINGS None");
+      expect(stdout).toContain("CONFIG_HAS_SLOT_LIMITS False");
+
+      // Defect 3 — a recall that did not queue produces NO wait information at
+      // all, so the 0-wait population is unrecoverable from the logs.
+      expect(stdout).toContain("WAIT_INFO_AT_ZERO ''");
+      expect(stdout).toContain(
+        "sem= is absent when the admission wait is 0.000s"
+      );
+      // The >0.01s lines upstream DID emit are unchanged by the fix.
+      expect(stdout).toContain(
+        "WAIT_INFO_AT_MEASURED_MEAN ' | waits: sem=5.430s'"
+      );
+    }, 240_000);
+
+    it("upstream + the baked patch blocks is GREEN, including every safety property", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED"
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+
+      // Fix 1: background is pinned at its reservation of 2 even under 32
+      // concurrent background recalls, and foreground is admitted immediately …
+      expect(stdout).toMatch(
+        /STARVATION background=2 foreground_admitted=True wait=0\.00\d+s/
+      );
+      expect(stdout).toMatch(
+        /STARVATION_HEAVY background=2 foreground_admitted=True wait=0\.00\d+s/
+      );
+      // … without raising total database concurrency above recall_max_concurrent
+      // (a reservation, not a second budget) …
+      expect(stdout).toContain("TOTAL_CONCURRENCY_PEAK 8");
+      // … and the nested acquisition cannot deadlock.
+      expect(stdout).toContain("NO_DEADLOCK True");
+      // The wiring, checked structurally because reaching it needs a database:
+      // recall_async admits through the helper exactly once, never bare, and
+      // every consolidator recall is flagged background.
+      expect(stdout).toContain("RECALL_HAS_BACKGROUND_PARAM True");
+      expect(stdout).toContain("RECALL_ADMISSION_WIRED 1 BARE_SHARED_ACQUIRES 0");
+      expect(stdout).toContain("CONSOLIDATOR_RECALLS 1 MARKED_BACKGROUND 1");
+      // An incoherent admission policy fails at boot rather than silently
+      // reintroducing the starvation.
+      expect(stdout).toContain("BG_CONFIG_OK True");
+      expect(stdout).toContain("BG_CONFIG_REJECTS_NO_FLOOR True");
+      expect(stdout).toContain("BG_CONFIG_REJECTS_ZERO True");
+      // … but a DEFAULT must never break boot. The reservation default is
+      // derived from the shared budget, so lowering recall_max_concurrent —
+      // even to the degenerate 1, where no split is possible at all — still
+      // starts. Only an EXPLICIT incoherent value fails.
+      expect(stdout).toContain("BG_DEFAULT_DERIVED 1 1");
+
+      // Fix 2: the ceiling bounds what is marked processing …
+      expect(stdout).toContain("CEILING_CLAIMED 4 MARKED_PROCESSING 4");
+      // … it does not throttle an uncapped type sharing the batch …
+      expect(stdout).toContain(
+        "MIXED_CLAIM [('consolidation', 2), ('retain', 5)]"
+      );
+      // … and with no ceilings configured the claim path is upstream's.
+      expect(stdout).toContain("UNCAPPED_CLAIMED 10");
+      // The poller computes the headroom the claim path spends.
+      expect(stdout).toContain("POLLER_CEILINGS {'consolidation': 0}");
+      expect(stdout).toContain("POLLER_CEILINGS_IDLE {'consolidation': 4}");
+      // Defaults and boot validation, driven through the real from_env().
+      expect(stdout).toContain("DEFAULT_CEILINGS [('consolidation', 4)]");
+      expect(stdout).toContain("REJECTS_CEILING_ABOVE_MAX_SLOTS True");
+      expect(stdout).toContain("REJECTS_CEILING_BELOW_RESERVATION True");
+      expect(stdout).toContain("REJECTS_ZERO_CEILING True");
+      // An operator can switch the default cap off without rebuilding.
+      expect(stdout).toContain("CEILING_OPT_OUT True");
+      // Same rule as the admission reservation: the DEFAULT cap is clamped to
+      // worker_max_slots, so lowering that knob cannot break boot either.
+      expect(stdout).toContain("CEILING_DEFAULT_CLAMPED 2");
+
+      // Fix 3: a zero wait is now a datum, the real waits still read the same,
+      // and the conn= threshold is untouched (this fix is scoped to sem=).
+      expect(stdout).toContain("WAIT_INFO_AT_ZERO ' | waits: sem=0.000s'");
+      expect(stdout).toContain(
+        "WAIT_INFO_AT_MEASURED_MEAN ' | waits: sem=5.430s'"
+      );
+      expect(stdout).toContain(
+        "WAIT_INFO_CONN_SUBTHRESHOLD ' | waits: sem=0.000s'"
+      );
+    }, 240_000);
+  }
+);

--- a/tests/docker/hindsight-recall-isolation-patches.test.ts
+++ b/tests/docker/hindsight-recall-isolation-patches.test.ts
@@ -340,6 +340,45 @@ if bare_shared:
         "would bypass the reservation"
     )
 
+
+def _arg_repr(node):
+    """A stable, readable description of one call argument."""
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        return node.value.id + "." + node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Constant):
+        return "<literal %r>" % (node.value,)
+    return "<" + type(node).__name__ + ">"
+
+
+# The ARGUMENTS, not just the presence of the call. Asserting only that
+# _recall_admission is called leaves the whole split revertible by a one-token
+# edit: _recall_admission(shared, background, False) keeps the helper defined,
+# keeps the call site, keeps _search_semaphore as an argument, and admits every
+# background recall as foreground again. The third argument MUST be the caller's
+# _background parameter, and the first two must be the two real semaphores.
+ADMISSION_ARGS_EXPECTED = [
+    "self._search_semaphore",
+    "self._background_search_semaphore",
+    "_background",
+]
+if admission_calls:
+    _call = admission_calls[0].context_expr
+    admission_args = [_arg_repr(a) for a in _call.args] + [
+        (kw.arg or "**") + "=" + _arg_repr(kw.value) for kw in _call.keywords
+    ]
+else:
+    admission_args = []
+print("ADMISSION_ARGS", admission_args)
+if admission_args != ADMISSION_ARGS_EXPECTED:
+    fail(
+        "recall_async passes %r to _recall_admission, expected %r - the caller's "
+        "_background flag must reach the admission helper, otherwise the split is "
+        "hard-coded and background recalls take the foreground path"
+        % (admission_args, ADMISSION_ARGS_EXPECTED)
+    )
+
 import hindsight_api.engine.consolidation.consolidator as consolidator
 
 ctree = ast.parse(inspect.getsource(consolidator))
@@ -433,13 +472,21 @@ from hindsight_api.worker.poller import WorkerPoller
 
 
 class FakeConn:
-    """Enough of asyncpg to drive the real claim_tasks end to end."""
+    """Enough of asyncpg to drive the real claim_tasks end to end.
+
+    Row order is insertion order, which stands in for 'ORDER BY created_at'.
+    Placeholder indices are read out of the SQL rather than guessed positionally,
+    so the '!= ALL(...)' filters are applied to the parameter the real query
+    actually binds them to.
+    """
 
     def __init__(self, pending):
         self.pending = list(pending)
         self.claimed = []
+        self.fetches = []
 
     async def fetch(self, sql, *params):
+        self.fetches.append(sql)
         if "SELECT DISTINCT bank_id" in sql:
             return []
         limit = int(params[-1]) if params else len(self.pending)
@@ -450,11 +497,17 @@ class FakeConn:
             rows = [r for r in rows if r["operation_type"] == "consolidation"]
         elif "operation_type != 'consolidation'" in sql:
             rows = [r for r in rows if r["operation_type"] != "consolidation"]
-        excluded = set()
-        for p in params[:-1]:
-            if isinstance(p, list) and p and isinstance(p[0], uuid.UUID):
-                excluded = {str(x) for x in p}
-        rows = [r for r in rows if str(r["operation_id"]) not in excluded]
+
+        m = re.search(r"operation_id != ALL\(\$(\d+)", sql)
+        if m:
+            excluded = {str(x) for x in params[int(m.group(1)) - 1]}
+            rows = [r for r in rows if str(r["operation_id"]) not in excluded]
+
+        m = re.search(r"operation_type != ALL\(\$(\d+)", sql)
+        if m:
+            excluded_types = set(params[int(m.group(1)) - 1])
+            rows = [r for r in rows if r["operation_type"] not in excluded_types]
+
         return rows[:limit]
 
     async def execute(self, sql, *params):
@@ -463,23 +516,37 @@ class FakeConn:
         return None
 
 
-def pending(n_consolidation, n_retain=0):
+def rows_of(*spec):
+    """Pending rows in created_at order: rows_of(("retain", 12), ("consolidation", 3))."""
     rows = []
-
-    def row(op_type):
-        return {
-            "operation_id": uuid.uuid4(),
-            "operation_type": op_type,
-            "task_payload": "{}",
-            "retry_count": 0,
-            "bank_id": f"bank-{len(rows)}",
-        }
-
-    for _ in range(n_consolidation):
-        rows.append(row("consolidation"))
-    for _ in range(n_retain):
-        rows.append(row("retain"))
+    for op_type, n in spec:
+        for _ in range(n):
+            rows.append(
+                {
+                    "operation_id": uuid.uuid4(),
+                    "operation_type": op_type,
+                    "task_payload": "{}",
+                    "retry_count": 0,
+                    "bank_id": f"bank-{len(rows)}",
+                }
+            )
     return rows
+
+
+def pending(n_consolidation, n_retain=0):
+    return rows_of(("consolidation", n_consolidation), ("retain", n_retain))
+
+
+def claim(conn, reserved, shared, ceilings=None):
+    """Drive the real claim_tasks, passing ceilings only when it supports them."""
+    kwargs = {"consolidation_bank_priority": None}
+    if ceilings is not None and supports_ceilings:
+        kwargs["type_ceilings"] = ceilings
+    rows = asyncio.run(ops.claim_tasks(conn, "async_operations", "w1", reserved, shared, **kwargs))
+    counts = {}
+    for r in rows:
+        counts[r["operation_type"]] = counts.get(r["operation_type"], 0) + 1
+    return rows, counts
 
 
 ops = PostgreSQLOps()
@@ -509,26 +576,79 @@ if {str(r["operation_id"]) for r in rows} != set(conn.claimed):
 if supports_ceilings:
     # A ceiling on one type must not throttle another, and an uncapped type
     # must be claimed in full.
-    conn3 = FakeConn(pending(12, n_retain=5))
-    rows3 = asyncio.run(
-        ops.claim_tasks(
-            conn3,
-            "async_operations",
-            "w1",
-            {},
-            9,
-            consolidation_bank_priority=None,
-            type_ceilings={"consolidation": 2},
-        )
-    )
-    by_type = {}
-    for r in rows3:
-        by_type[r["operation_type"]] = by_type.get(r["operation_type"], 0) + 1
-    print("MIXED_CLAIM", sorted(by_type.items()))
+    #
+    # NOTE this configuration caps ONLY consolidation, which phase 2a excludes in
+    # SQL — so it exercises the one case where "filter after selection" and
+    # "bound before selection" agree. It is kept because it is the shipping
+    # default, but it proves nothing about a capped type phase 2a actually
+    # claims. MIXED_CLAIM_SHARED_BUDGET below is the assertion that does.
+    _, by_type = claim(FakeConn(pending(12, n_retain=5)), {}, 9, {"consolidation": 2})
+    print("MIXED_CLAIM_CONSOLIDATION_ONLY", sorted(by_type.items()))
     if by_type.get("consolidation", 0) > 2:
         fail("the ceiling did not bound consolidation in a mixed batch")
     if by_type.get("retain", 0) != 5:
         fail("the uncapped retain type was throttled by another type's ceiling")
+
+    # THE REGRESSION the ceiling must not introduce: a capped type that phase 2a
+    # DOES claim must not spend the shared budget on rows it cannot keep.
+    #
+    # 12 pending retain (older) + 5 graph_maintenance, shared_limit=9, retain
+    # capped at 2. Phase 2a is one 'ORDER BY created_at LIMIT 9' across both
+    # types, so a post-selection filter selects 9 retain rows, keeps 2, and
+    # claims ZERO graph_maintenance — against upstream's 9 claimed tasks. Bounded
+    # before selection, the at-ceiling type is excluded in SQL and the unspent
+    # budget refills: 2 retain + 5 graph_maintenance.
+    conn5 = FakeConn(rows_of(("retain", 12), ("graph_maintenance", 5)))
+    rows5, by_type5 = claim(conn5, {}, 9, {"retain": 2})
+    print("MIXED_CLAIM_SHARED_BUDGET", sorted(by_type5.items()), "TOTAL", len(rows5))
+    if by_type5.get("retain", 0) != 2:
+        fail(f"retain claimed {by_type5.get('retain', 0)} rows under a ceiling of 2")
+    if by_type5.get("graph_maintenance", 0) != 5:
+        fail(
+            "the shared budget was spent on retain rows the ceiling then discarded: "
+            f"{by_type5.get('graph_maintenance', 0)} of 5 pending graph_maintenance tasks "
+            "were claimed. A ceiling must bound SELECTION, not filter after it, or one "
+            "capped type starves every other type of the whole batch"
+        )
+    if set(conn5.claimed) != {str(r["operation_id"]) for r in rows5}:
+        fail("rows dropped by the ceiling were still marked processing (half-claimed)")
+
+    # L1/L2: with consolidation at its ceiling, phase 2b must not run AT ALL —
+    # no busy-banks scan, no FOR UPDATE locks on rows this worker must discard —
+    # and the budget phase 2a did not spend must still reach the rest of the batch.
+    #
+    # 9 retain (capped at 1) + 9 consolidation (capped at 0), shared_limit=9. A
+    # post-selection filter claims exactly ONE task here and leaves 8 slots idle
+    # against 17 pending, because phase 2a burned all 9 on retain rows it dropped.
+    conn6 = FakeConn(rows_of(("retain", 9), ("consolidation", 9)))
+    rows6, by_type6 = claim(conn6, {}, 9, {"retain": 1, "consolidation": 0})
+    busy_scans = sum(1 for s in conn6.fetches if "SELECT DISTINCT bank_id" in s)
+    print(
+        "AT_CEILING_BATCH", sorted(by_type6.items()), "TOTAL", len(rows6),
+        "BUSY_BANK_SCANS", busy_scans,
+    )
+    if by_type6.get("consolidation", 0) != 0:
+        fail("a type at zero ceiling headroom was still claimed")
+    if by_type6.get("retain", 0) != 1:
+        fail(f"retain claimed {by_type6.get('retain', 0)} rows under a ceiling of 1")
+    if busy_scans != 0:
+        fail(
+            f"phase 2b ran its busy-banks scan {busy_scans}x with consolidation at zero "
+            "ceiling headroom - it takes FOR UPDATE locks on rows it must discard, which "
+            "multi-worker briefly hides head consolidation rows from a worker that does "
+            "have headroom"
+        )
+
+    # …and the same batch with headroom restored proves the skip above is the
+    # ceiling talking, not the probe failing to reach phase 2b at all.
+    conn7 = FakeConn(rows_of(("retain", 9), ("consolidation", 9)))
+    _, by_type7 = claim(conn7, {}, 9, {"retain": 1, "consolidation": 4})
+    busy_scans7 = sum(1 for s in conn7.fetches if "SELECT DISTINCT bank_id" in s)
+    print("HEADROOM_BATCH", sorted(by_type7.items()), "BUSY_BANK_SCANS", busy_scans7)
+    if by_type7.get("consolidation", 0) != 4 or by_type7.get("retain", 0) != 1:
+        fail(f"with headroom the batch should claim 1 retain + 4 consolidation: {by_type7}")
+    if busy_scans7 != 1:
+        fail(f"phase 2b did not run with consolidation headroom left ({busy_scans7} scans)")
 
     # No ceilings == upstream, byte for byte.
     conn4 = FakeConn(pending(12))
@@ -626,42 +746,121 @@ else:
 
 
 # =====================================================================
-# fix 3 - sem= is emitted on EVERY recall
+# fix 3 - the admission wait is OBSERVABLE on every recall, background included
 # =====================================================================
-# Execute the REAL shipping wait-line assembly with a zero admission wait.
-# (It lives in MemoryEngine._search_with_retries, the recall search path.)
+# Executes the REAL shipping completion block: the wait-line assembly AND the
+# 'if not quiet:' emission gate that decides whether any of it reaches the log.
+# Both matter — an unconditional sem= that is then swallowed by _quiet leaves the
+# BACKGROUND population (the one this PR pins at 2 concurrent) emitting nothing,
+# which is the same blind spot that mis-sized the contention in the first place.
+
+
+class _CapturingLogger:
+    """Stands in for the module logger so the emission itself is observable."""
+
+    def __init__(self):
+        self.lines = []
+
+    def info(self, msg, *a, **k):
+        self.lines.append(str(msg))
+
+    error = warning = debug = info
+
+
+def run_completion_block(block, *, quiet, semaphore_wait, max_conn_wait):
+    """Execute the real completion block and return (wait_info, emitted lines)."""
+    log = _CapturingLogger()
+    scope = {
+        "semaphore_wait": semaphore_wait,
+        "max_conn_wait": max_conn_wait,
+        "quiet": quiet,
+        "logger": log,
+        "log_buffer": ["[RECALL r-1] Start"],
+        "recall_id": "r-1",
+        "recall_start": 0.0,
+        "total_time": 1.25,
+        "top_scored": [object()] * 3,
+        "total_tokens": 100,
+        "num_chunks": 1,
+        "total_chunk_tokens": 10,
+        "num_entities": 2,
+        "total_entity_tokens": 20,
+        "fact_type_summary": "world=3",
+    }
+    exec(compile(block, "<recall-completion>", "exec"), scope)
+    return scope["wait_info"], log.lines
+
+
 engine_src = inspect.getsource(me)
-m = re.search(r"^( *)wait_parts = \[\]\n(?:.*?\n)??\1wait_info = [^\n]*", engine_src, re.S | re.M)
+# From 'wait_parts = []' up to (not including) the 'return RecallResultModel('
+# that follows at the same indentation - i.e. the whole completion block.
+m = re.search(
+    r"^( *)wait_parts = \[\]\n(?P<body>(?:.*?\n)*?)\1return RecallResultModel\(",
+    engine_src,
+    re.M,
+)
 if not m:
-    fail("could not locate the recall wait-line assembly - re-author this probe")
+    fail("could not locate the recall completion block - re-author this probe")
 else:
     indent = m.group(1)
+    raw = indent + "wait_parts = []\n" + m.group("body")
     block = "\n".join(
         line[len(indent) :] if line.startswith(indent) else line
-        for line in m.group(0).splitlines()
+        for line in raw.splitlines()
     )
-    scope = {"semaphore_wait": 0.0, "max_conn_wait": 0.0}
-    exec(compile(block, "<recall-wait-line>", "exec"), scope)
-    print("WAIT_INFO_AT_ZERO %r" % scope["wait_info"])
-    if "sem=" not in scope["wait_info"]:
+    if "if not quiet:" not in block:
+        fail("the recall completion block no longer contains the quiet gate - re-author this probe")
+
+    wait_info, loud = run_completion_block(
+        block, quiet=False, semaphore_wait=0.0, max_conn_wait=0.0
+    )
+    print("WAIT_INFO_AT_ZERO %r" % wait_info)
+    if "sem=" not in wait_info:
         fail(
             "sem= is absent when the admission wait is 0.000s - the >0.01s gate hides that a "
             "recall did not queue, so no log scrape can recover the wait distribution"
         )
-    elif "sem=0.000s" not in scope["wait_info"]:
-        fail(f"expected sem=0.000s in the zero-wait line, got {scope['wait_info']!r}")
+    elif "sem=0.000s" not in wait_info:
+        fail(f"expected sem=0.000s in the zero-wait line, got {wait_info!r}")
+    print("FOREGROUND_EMITTED", len(loud))
+    if not any("sem=" in line for line in loud):
+        fail("a foreground recall emitted no sem= line at all")
 
-    scope2 = {"semaphore_wait": 5.43, "max_conn_wait": 0.0}
-    exec(compile(block, "<recall-wait-line>", "exec"), scope2)
-    print("WAIT_INFO_AT_MEASURED_MEAN %r" % scope2["wait_info"])
-    if "sem=5.430s" not in scope2["wait_info"]:
+    wait_info2, _ = run_completion_block(
+        block, quiet=False, semaphore_wait=5.43, max_conn_wait=0.0
+    )
+    print("WAIT_INFO_AT_MEASURED_MEAN %r" % wait_info2)
+    if "sem=5.430s" not in wait_info2:
         fail("a real 5.43s admission wait is no longer reported")
 
-    scope3 = {"semaphore_wait": 0.0, "max_conn_wait": 0.0053}
-    exec(compile(block, "<recall-wait-line>", "exec"), scope3)
-    print("WAIT_INFO_CONN_SUBTHRESHOLD %r" % scope3["wait_info"])
-    if "conn=" in scope3["wait_info"]:
+    wait_info3, _ = run_completion_block(
+        block, quiet=False, semaphore_wait=0.0, max_conn_wait=0.0053
+    )
+    print("WAIT_INFO_CONN_SUBTHRESHOLD %r" % wait_info3)
+    if "conn=" in wait_info3:
         fail("the connection-wait threshold was changed - this fix is scoped to sem= only")
+
+    # THE QUIET GATE. consolidator.py recalls with _quiet=True, so this is the
+    # exact population the background reservation caps. If it emits nothing, the
+    # reservation backing consolidation up is invisible in the logs - the very
+    # failure ("we mis-sized this from biased logs") the fix exists to prevent.
+    _, quiet_lines = run_completion_block(
+        block, quiet=True, semaphore_wait=5.43, max_conn_wait=0.0
+    )
+    quiet_sem = [line for line in quiet_lines if "sem=5.430s" in line]
+    print("QUIET_EMITTED", len(quiet_lines), "QUIET_SEM_LINES", len(quiet_sem))
+    if not quiet_sem:
+        fail(
+            "a quiet (BACKGROUND) recall emitted no sem= line - the whole completion line "
+            "is gated on 'if not quiet:' and the consolidator passes _quiet=True, so the "
+            "population this reservation caps is unobservable and cannot be re-measured"
+        )
+    # …and it stays ONE line: _quiet exists to suppress the multi-line buffer, and
+    # restoring that noise would be a different regression.
+    if len(quiet_lines) > 1:
+        fail(f"a quiet recall emitted {len(quiet_lines)} log records, expected exactly 1")
+    if quiet_sem and "\n" in quiet_sem[0]:
+        fail("the quiet recall line restored the full multi-line log buffer")
 
 
 print("FAILURES", failures)
@@ -846,6 +1045,7 @@ describe.skipIf(!dockerOk || !imageOk)(
       // … and the wiring that causes it: the consolidator's recall is admitted
       // as foreground, straight onto the shared semaphore.
       expect(stdout).toContain("RECALL_ADMISSION_WIRED 0 BARE_SHARED_ACQUIRES 1");
+      expect(stdout).toContain("ADMISSION_ARGS []");
       expect(stdout).toContain("CONSOLIDATOR_RECALLS 1 MARKED_BACKGROUND 0");
       expect(stdout).toContain("CONFIG_HAS_BG_FIELD False");
 
@@ -861,10 +1061,17 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("CONFIG_HAS_SLOT_LIMITS False");
 
       // Defect 3 — a recall that did not queue produces NO wait information at
-      // all, so the 0-wait population is unrecoverable from the logs.
+      // all, so the 0-wait population is unrecoverable from the logs …
       expect(stdout).toContain("WAIT_INFO_AT_ZERO ''");
       expect(stdout).toContain(
         "sem= is absent when the admission wait is 0.000s"
+      );
+      // … and a BACKGROUND (quiet) recall emits nothing whatsoever, even when it
+      // waited 5.43s, because the whole completion line sits behind
+      // `if not quiet:` and the consolidator passes _quiet=True.
+      expect(stdout).toContain("QUIET_EMITTED 0 QUIET_SEM_LINES 0");
+      expect(stdout).toContain(
+        "a quiet (BACKGROUND) recall emitted no sem= line"
       );
       // The >0.01s lines upstream DID emit are unchanged by the fix.
       expect(stdout).toContain(
@@ -898,6 +1105,14 @@ describe.skipIf(!dockerOk || !imageOk)(
       // every consolidator recall is flagged background.
       expect(stdout).toContain("RECALL_HAS_BACKGROUND_PARAM True");
       expect(stdout).toContain("RECALL_ADMISSION_WIRED 1 BARE_SHARED_ACQUIRES 0");
+      // The call's ARGUMENTS, pinned. Asserting only that _recall_admission is
+      // called leaves the split revertible by one token — hard-coding the third
+      // argument to False sends every background recall down the foreground path
+      // while every other assertion in this file stays green.
+      expect(stdout).toContain(
+        "ADMISSION_ARGS ['self._search_semaphore', " +
+          "'self._background_search_semaphore', '_background']"
+      );
       expect(stdout).toContain("CONSOLIDATOR_RECALLS 1 MARKED_BACKGROUND 1");
       // An incoherent admission policy fails at boot rather than silently
       // reintroducing the starvation.
@@ -914,7 +1129,26 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain("CEILING_CLAIMED 4 MARKED_PROCESSING 4");
       // … it does not throttle an uncapped type sharing the batch …
       expect(stdout).toContain(
-        "MIXED_CLAIM [('consolidation', 2), ('retain', 5)]"
+        "MIXED_CLAIM_CONSOLIDATION_ONLY [('consolidation', 2), ('retain', 5)]"
+      );
+      // … and — the property the line above cannot see, because phase 2a
+      // excludes consolidation in SQL anyway — a capped type that phase 2a DOES
+      // claim must not spend the shared budget on rows it then discards. 12
+      // older retain capped at 2, 5 graph_maintenance, shared_limit 9: a
+      // post-selection filter claims 2 and 0 here, against upstream's 9.
+      expect(stdout).toContain(
+        "MIXED_CLAIM_SHARED_BUDGET [('graph_maintenance', 5), ('retain', 2)] TOTAL 7"
+      );
+      // At zero headroom phase 2b is skipped outright — no busy-banks scan, no
+      // FOR UPDATE locks on rows this worker must discard — and the budget phase
+      // 2a did not spend is not lost.
+      expect(stdout).toContain(
+        "AT_CEILING_BATCH [('retain', 1)] TOTAL 1 BUSY_BANK_SCANS 0"
+      );
+      // The same batch WITH headroom still reaches phase 2b, so the skip above
+      // is the ceiling talking and not the probe missing the phase entirely.
+      expect(stdout).toContain(
+        "HEADROOM_BATCH [('consolidation', 4), ('retain', 1)] BUSY_BANK_SCANS 1"
       );
       // … and with no ceilings configured the claim path is upstream's.
       expect(stdout).toContain("UNCAPPED_CLAIMED 10");
@@ -941,6 +1175,10 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toContain(
         "WAIT_INFO_CONN_SUBTHRESHOLD ' | waits: sem=0.000s'"
       );
+      // …and the BACKGROUND population the reservation caps is observable: a
+      // quiet recall emits exactly one line, carrying its admission wait. One,
+      // not the whole buffer — _quiet still suppresses the noise it exists for.
+      expect(stdout).toContain("QUIET_EMITTED 1 QUIET_SEM_LINES 1");
     }, 240_000);
   }
 );


### PR DESCRIPTION
## Summary

Three engine patches baked into the pinned upstream Hindsight image
(`docker/Dockerfile.hindsight`), all driven by one measurement: **the per-turn
recall hook times out fleet-wide because background consolidation and
foreground recall share a single admission gate.**

1. **Recall admission split** — background (consolidation) recalls are admitted
   through a small reservation semaphore *before* the shared one, so they can
   never consume the slots foreground recall depends on.
2. **A real per-operation-type worker slot CEILING** (`worker_slot_limits`) —
   the existing `..._MAX_SLOTS` knobs are reservations, i.e. a *floor*; nothing
   upstream caps a type's total share of the worker.
3. **`sem=` emitted on every recall** — the `>0.01s` gate hid the 0-wait
   population and biased the measured mean.

Companion to #3626 (merged), which handled the switchroom-side rerank-candidate
reduction and degraded-recall visibility. This is the engine-side half. **No
overlap:** #3626 touched `src/cli/*` and `vendor/hindsight-memory/scripts/*`;
this PR touches only `docker/Dockerfile.hindsight`, its two test files, and the
CI job that runs them.

## Why

### The measurement

| Signal | Value |
| --- | --- |
| Recall admission wait (mean / p90 / max) | 5.43s / 15.7s / 27.4s |
| Recall hook per-bank socket timeout | 8s (`vendor/hindsight-memory/scripts/recall.py:1706`) |
| Fleet recall p50 | 8.02s — pinned *at* the timeout |
| Per-agent timeout rate | klanker 97.5%, overlord 95.8%, marko 73.9% |

### Fix 1 — admission split

`engine/consolidation/consolidator.py:2047` calls
`await memory_engine.recall_async(...)` — the **same** method a user's turn
calls, which acquires `self._search_semaphore` at `engine/memory_engine.py:4174`
(constructed at `:1270` from `recall_max_concurrent`, 8 in this fleet via
`src/setup/hindsight.ts:339`). A consolidation burst therefore holds every
admission slot and the hook queues behind it until its 8s socket timeout.

The fix is a **strict reservation, not a second budget**: a background caller
takes a slot in a small background semaphore *first*, then the shared one.

- Total concurrency against the database is unchanged at `recall_max_concurrent`
  (the shared semaphore is still the only gate into the pipeline).
- Background can never hold more than `consolidation_recall_max_concurrent`
  (default 2) of those slots.
- Foreground therefore always has at least the remainder available.
- **Deadlock-free by construction**: foreground never acquires the background
  semaphore, so the acquisition order (background → shared) is total and no
  cycle exists. Driven in the probe rather than argued.

### Fix 2 — the missing ceiling

The premise that `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS` is a cap does
**not** hold, and I verified it in the pinned image before building on it:
`config.py:604-607` (`WORKER_SLOT_RESERVATION_TYPES`) is a *reservation* table,
and `WorkerPoller._get_available_slots` (`poller.py:281-311` — the citation I
was given pointed at `:1020-1050`, which is the progress-log block, not this
function) documents:

> When an operation type's in-flight count exceeds its reservation, the excess
> tasks are considered to be using shared pool slots.

So `consolidation=6/1(avail=0)` in the worker log is **documented behaviour, not
a bug**. The real gap is that **no per-type ceiling exists at all**, so
consolidation can take all `DEFAULT_WORKER_MAX_SLOTS = 10` (`config.py:1052`)
and starve every other operation type.

This adds `worker_slot_limits`: a hard cap across the reserved and shared pools,
defaulting to `consolidation<=4` with every other type uncapped (byte-for-byte
upstream scheduling). It is validated at boot in `HindsightConfig.validate()`
— the same function and the same style as the existing
`total_reserved <= worker_max_slots` check at `config.py:2262-2268` — and
enforced in `claim_tasks` by **bounding selection**, not by filtering after it.
Phase 2a is a single `ORDER BY created_at LIMIT n` across every
non-consolidation type, so discarding the surplus afterwards would spend the
shared budget on rows that are then thrown away — with `{"retain": 2}`, 12
pending `retain` (older) and 5 `graph_maintenance`, a post-filter claims 2 and 0
where upstream claims 9. Instead a type with no headroom left is excluded in the
`WHERE` clause (`operation_type != ALL($n::text[])`) and the fetch is retried for
the unspent remainder (a loop bounded by `len(type_ceilings)`: a row can only be
dropped if its type had headroom at fetch time and has none now, so each extra
iteration retires at least one type). Nothing is ever selected `FOR UPDATE` that
the call cannot claim, so no half-claim is possible and a capped type cannot
starve an uncapped one. With no ceilings configured the loop issues exactly one
query with exactly upstream's SQL.

The misleading `..._MAX_SLOTS`-means-minimum **name is deliberately not changed
here** (renaming a shipped env var is a breaking config change); filed upstream
instead — see below.

### Fix 3 — always emit `sem=`

`memory_engine.py:5393` only appended `sem=` when the wait exceeded 0.01s. The
recalls that did *not* queue left no datum at all, so a log scrape could not
distinguish a fleet where 45% of recalls wait from one where none do, and
averaging the surviving lines biased the reported mean upwards — which is
exactly how this contention was mis-sized on first measurement. Now
unconditional. Scoped to the admission wait: the `conn=` threshold is untouched,
and the probe asserts that.

## Test plan

New `tests/docker/hindsight-recall-isolation-patches.test.ts` — a RED/GREEN
behavioural probe against the digest-pinned upstream image, in the same shape as
the existing `hindsight-search-patches.test.ts`. It **asserts outcomes**, not
code paths:

- **Fix 1** starves a real `asyncio` admission gate: 8 concurrent background
  recalls, then a timed foreground acquire. RED: `background=8
  foreground_admitted=False`. GREEN: `background=2 foreground_admitted=True
  wait=0.000s`, and under 32× background pressure background is still pinned at
  exactly 2. Safety: `TOTAL_CONCURRENCY_PEAK 8` on **both** sides (the split
  does not raise DB concurrency) and a driven no-deadlock scenario.
- **Fix 2** drives the **real** `PostgreSQLOps.claim_tasks` against a fake
  connection and counts what it marks processing. RED: `CEILING_CLAIMED 10
  MARKED_PROCESSING 10` with a reservation of 1 and a 9-slot shared pool. GREEN:
  `CEILING_CLAIMED 4 MARKED_PROCESSING 4`, an uncapped type in the same batch
  untouched (`MIXED_CLAIM_CONSOLIDATION_ONLY [('consolidation', 2),
  ('retain', 5)]`), a capped type not starving an uncapped one in the shared pool
  (`MIXED_CLAIM_SHARED_BUDGET [('graph_maintenance', 5), ('retain', 2)] TOTAL
  7` — a post-selection filter yields 2/0 here), the phase-2b skip at zero
  headroom (`AT_CEILING_BATCH ... BUSY_BANK_SCANS 0` vs `HEADROOM_BATCH ...
  BUSY_BANK_SCANS 1`, so the skip is the ceiling talking and not an unrelated
  short-circuit), and
  `UNCAPPED_CLAIMED 10` — with no ceilings configured the claim path is
  upstream's. The real `WorkerPoller._get_available_slots` supplies the headroom.
- **Fix 3** executes the **real** wait-line assembly lifted out of the shipping
  source with a zero wait. RED: `WAIT_INFO_AT_ZERO ''`. GREEN:
  `' | waits: sem=0.000s'`, with the 5.43s line unchanged and no `conn=` leak.
- Boot validation is driven through the real `HindsightConfig.from_env()`: an
  explicit zero / no-floor / above-`max_slots` / below-own-reservation value is
  rejected, and an empty string switches a default cap off.

Only two assertions are string-shaped (AST checks that `recall_async` admits
through the helper exactly once and never bare **and passes
`(self._search_semaphore, self._background_search_semaphore, _background)` — the
argument list, not merely the call**, and that every consolidator `recall_async`
call carries `_background=True`) — reaching those call sites for real needs a
live database.

**Fix 3** additionally drives the `if not quiet:` emission gate, executing the
real completion block with `quiet=True`: a background recall now emits exactly
one compact line carrying `sem=` (`QUIET_EMITTED 1 QUIET_SEM_LINES 1`), and the
probe asserts it does *not* restore the multi-line buffer `_quiet` exists to
suppress. RED on upstream is `QUIET_EMITTED 0 QUIET_SEM_LINES 0`.

Structural guards for all three patch blocks added to
`dockerfile-hindsight-bakes.test.ts` (exact-once anchors, the replacement text,
the post-replace re-assertions, and the ordering assert that the ceiling filter
precedes the claiming UPDATE).

CI: the new probe is added to the `hindsight:` path filter and gets its own step
in the `hindsight-probe` job under `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1`, so an
absent docker/image is a hard failure rather than a green skip. Teardown is
label-scoped over both phases.

Local runs (this host, docker + pinned image present):

```
✓ tests/docker/dockerfile-hindsight-bakes.test.ts (23 tests)
✓ tests/docker/hindsight-recall-isolation-patches.test.ts (5 tests)
✓ tests/docker/hindsight-search-patches.test.ts (5 tests)   # no regression
npm run lint  # clean
```

I also applied **all nine** `RUN python3` patch blocks in Dockerfile order to a
pristine pinned image and re-ran **both** probes green, so the new patches
compose with the existing ones (FK-race and CE/BM25/timeout) rather than merely
applying in isolation.

## Risk

- **Consolidation gets slower, deliberately.** Background recall is capped at 2
  concurrent and consolidation at 4 worker slots (it was observed at 6). That is
  the intended trade — foreground wins — and both are env knobs
  (`HINDSIGHT_API_CONSOLIDATION_RECALL_MAX_CONCURRENT`,
  `HINDSIGHT_API_WORKER_CONSOLIDATION_SLOT_LIMIT`; an empty string uncaps).
- **Defaults can never break boot.** Both defaults are derived, not fixed: the
  admission reservation from `recall_max_concurrent` (and a degenerate
  single-slot deployment, where no split is possible, still starts), the ceiling
  clamped to `worker_max_slots`. Only an *explicit* incoherent value fails
  validation. Asserted in the probe (`BG_DEFAULT_DERIVED 1 1`,
  `CEILING_DEFAULT_CLAMPED 2`).
- **The ceiling is per-worker**, like `worker_max_slots` and the reservations it
  sits beside — not a global cap.
- **At zero headroom the consolidation phase is skipped outright** — no
  busy-banks `SELECT DISTINCT` scan and no `FOR UPDATE` locks on rows the worker
  could not claim anyway (those locks briefly hide the head consolidation rows
  from a *different* worker that does have headroom). The residual cost of the
  ceiling is the phase-2a refill fetch, which only runs when a type actually
  hits its cap part-way through a batch.
- **`reflect`'s recalls are not flagged — `refresh_mental_model` is uncapped by
  BOTH mechanisms in this PR.** `engine/reflect/tools.py:206`
  (`tool_search_observations`) and `:283` (`tool_recall`) still enter through the
  foreground admission path, so a `refresh_mental_model` worker task competes
  with a user's turn for the shared semaphore, and `refresh_mental_model` has no
  default entry in `WORKER_SLOT_LIMIT_TYPES` (the env knob ships, the default
  cap does not). Deferred to **#3678**: threading `_background` needs ~8 anchors
  through `_handle_refresh_mental_model` → `refresh_mental_model` →
  `reflect_async` → the tool closures, and `reflect_async` is shared with real
  foreground callers (`api/http.py`, `mcp_tools.py`), so the flag must be
  threaded rather than hard-set — every anchor is a new upstream-drift point in a
  heredoc patch. (`extensions/context.py:71` was raised as a fourth site; it is a
  docstring example inside the abstract `get_memory_engine()`, not a live call
  site — it takes no semaphore.)
- Not applied to the live fleet by this PR — it lands on the next hindsight
  image build.

## Related

- Upstream naming defect (`..._MAX_SLOTS` is a minimum): filed separately, not
  renamed here.
- Job spec: `reference/jobs/remember-across-sessions.md` — recall that times out
  is recall that did not happen.

## Review round 2 (adversarial re-review, `7852a9c`)

Eight findings from an adversarial review of `cb5948e`, all fixed in this
branch except one deferred with reasons:

- **M2 (blocker) — the admission split was silently revertible.** The probe's
  AST check asserted the *call* to `_recall_admission`, not its arguments, and
  its fix-1 scenarios call the helper directly without traversing
  `recall_async`; the Dockerfile's own post-replace assert had the same blind
  spot. Mutating the third argument to a literal `False` reverted the entire
  split while the probe exited 0 with `FAILURES []`. Now pinned at three layers
  (build assert, probe AST, bakes grep). **Mutation-checked:** with the third
  argument hard-coded to `False` the build now aborts on its own assert
  (`EXIT=1`); with that assert additionally stripped, the probe reports
  `ADMISSION_ARGS [..., '<literal False>']` and fails (`EXIT=1`) where it
  previously passed.
- **M1 — post-selection filtering starved uncapped types.** Fixed by bounding
  at SELECT time; see the Fix 2 section above. The comment claiming a new entry
  in `WORKER_SLOT_LIMIT_TYPES` was "the ONLY change needed to make it cappable"
  was false and is corrected.
- **M3 — background admission waits were unobservable** (`if not quiet:` +
  `consolidator.py:2069` passing `_quiet=True`). Fixed; covered in the probe.
- **L1** — phase 2b skipped outright at zero headroom; Risk section corrected.
- **L2** — shared budget spent per *accepted* row, not per selected row.
- **L3** — removed the now-dead `if wait_parts else ""` tail.
- **L4** — the two `config.py` blocks share an anchor and are order-coupled;
  recorded in both block headers (swapping them fails the build loudly, but the
  failure would read as upstream drift, which it would not be).
- **L5 — deferred to #3678** with reasons. One correction to the finding:
  `extensions/context.py:71` is a docstring example, not a live call site.
