### PR TITLE
fix(setup): make the wizard's verification step actually verify

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -247,6 +247,18 @@ agents, and MCP wireup, and prints actionable fixes.
   during setup — switchroom is trying to write to its own install dir.
   Tracked work; see the install-validation follow-up that moves profile
   rendering to a user-writable cache dir.
+- **`Memory backend setup failed: Docker is not available`** — the memory
+  backend (Hindsight) is a container, and so is every agent, so setup stops
+  instead of pretending it succeeded. Install Docker and re-run, or re-run
+  with `SWITCHROOM_MEMORY_BACKEND=none` to skip memory setup.
+- **`Setup did NOT complete: verification failed`** — the final step now
+  checks the real thing: docker is reachable, no switchroom container is
+  crash-looping or stuck, and an agent you asked it to start actually came
+  up and stayed up. Setup exits non-zero in that case (so scripted installs
+  stop). The rows above the message name what failed; `switchroom doctor`
+  and `docker logs switchroom-<agent> --tail 50` are the next steps.
+  A fleet that simply isn't up yet is reported as *pending*, not a failure —
+  that's the normal state right after Step 3.
 - **Telegram bot doesn't reply** — `switchroom agent logs assistant -f`
   and `switchroom doctor`. The most common cause is OAuth not yet
   completed (`switchroom auth list` — confirm an account is present

--- a/docs/install.md
+++ b/docs/install.md
@@ -117,8 +117,21 @@ Interactive wizard. You'll be prompted for:
 
 The wizard scaffolds your first agent (`assistant` by default) and
 writes `~/.switchroom/switchroom.yaml` and
-`~/.switchroom/agents/assistant/`. It does **not** start any docker
-containers — that's Step 5.
+`~/.switchroom/agents/assistant/`. It does **not** start any agent
+containers — that's Step 5. (It does start the Hindsight memory
+container, unless you picked `none`.)
+
+Because `setup` runs before `apply`, its final verification step reports
+the fleet as **pending**, not failed — that is the expected first-install
+outcome and it exits 0. It exits non-zero only when something it actually
+attempted is broken.
+
+**On a machine without Docker:** `SWITCHROOM_MEMORY_BACKEND=none` (or
+`memory.backend: none` in the yaml) is the supported way through the
+wizard — memory setup is skipped, and the unreachable Docker is then
+reported as pending rather than a hard failure, so config generation on a
+Docker-less CI runner works. Your agents still need Docker to actually
+run.
 
 ### Non-interactive setup (CI / scripting)
 
@@ -247,10 +260,20 @@ agents, and MCP wireup, and prints actionable fixes.
   during setup — switchroom is trying to write to its own install dir.
   Tracked work; see the install-validation follow-up that moves profile
   rendering to a user-writable cache dir.
-- **`Memory backend setup failed: Docker is not available`** — the memory
-  backend (Hindsight) is a container, and so is every agent, so setup stops
-  instead of pretending it succeeded. Install Docker and re-run, or re-run
-  with `SWITCHROOM_MEMORY_BACKEND=none` to skip memory setup.
+- **`Memory backend setup failed: Docker is not installed`** — no `docker`
+  on PATH. The memory backend (Hindsight) is a container, and so is every
+  agent, so setup stops instead of pretending it succeeded. Install Docker
+  and re-run, or re-run with `SWITCHROOM_MEMORY_BACKEND=none`.
+- **`Memory backend setup failed: Docker is installed but its daemon is not
+  responding`** — the CLI is there but nothing is listening (the usual macOS
+  case: Docker Desktop isn't running). Start Docker (`open -a Docker`, or
+  `sudo systemctl start docker`) and re-run. Don't reinstall.
+- **`Memory backend setup failed: …ports…` / `…did not stay running`** — the
+  Hindsight container could not be given a free port, or exited immediately
+  after start. These used to be silent (the wizard still said "Setup
+  complete!") — now they stop setup. `docker logs switchroom-hindsight
+  --tail 50` says why; `SWITCHROOM_MEMORY_BACKEND=none` skips memory if you
+  want to proceed without it.
 - **`Setup did NOT complete: verification failed`** — the final step now
   checks the real thing: docker is reachable, no switchroom container is
   crash-looping or stuck, and an agent you asked it to start actually came
@@ -258,7 +281,10 @@ agents, and MCP wireup, and prints actionable fixes.
   stop). The rows above the message name what failed; `switchroom doctor`
   and `docker logs switchroom-<agent> --tail 50` are the next steps.
   A fleet that simply isn't up yet is reported as *pending*, not a failure —
-  that's the normal state right after Step 3.
+  that's the normal state right after Step 3. A container that reads
+  `created` or `restarting` for a moment (a `docker restart`, or an `apply`
+  reconcile in flight) is re-sampled before any verdict, so re-running setup
+  during a bounce does not fail a healthy fleet.
 - **Telegram bot doesn't reply** — `switchroom agent logs assistant -f`
   and `switchroom doctor`. The most common cause is OAuth not yet
   completed (`switchroom auth list` — confirm an account is present

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1154,9 +1154,18 @@ export function registerAgentCommand(program: Command): void {
         const names =
           name === "all" ? Object.keys(config.agents) : [name];
 
+        // Setup-verification review H3: every realistic failure below
+        // (undefined agent, quarantined, preflight errors, startAgent throw)
+        // printed red and then exited 0, so `switchroom agent start x && ...`
+        // sailed on and `switchroom setup`'s start seam could only ever
+        // observe ENOENT. Keep the loop's continue-on-error behaviour for
+        // `all` — but report the truth in the exit code.
+        const failed: string[] = [];
+
         for (const n of names) {
           if (!config.agents[n]) {
             console.error(chalk.red(`Agent "${n}" is not defined in switchroom.yaml`));
+            failed.push(n);
             continue;
           }
 
@@ -1167,6 +1176,7 @@ export function registerAgentCommand(program: Command): void {
           // `switchroom agent unquarantine <name>`. --force bypasses
           // (matches the existing --force semantics for preflight).
           if (!opts.force && checkQuarantineRefusal(agentsDir, n)) {
+            failed.push(n);
             continue;
           }
 
@@ -1183,6 +1193,7 @@ export function registerAgentCommand(program: Command): void {
               console.error(
                 chalk.gray(`\n  Fix the issues above, or use --force to skip preflight.\n`)
               );
+              failed.push(n);
               continue;
             }
           }
@@ -1194,7 +1205,18 @@ export function registerAgentCommand(program: Command): void {
             console.error(
               chalk.red(`Failed to start ${n}: ${(err as Error).message}`)
             );
+            failed.push(n);
           }
+        }
+
+        if (failed.length > 0) {
+          console.error(
+            chalk.red(
+              `\n  Did not start: ${failed.join(", ")} — see the errors above.\n`,
+            ),
+          );
+          // exitCode (not process.exit) so buffered stdout still flushes.
+          process.exitCode = 1;
         }
       })
     );

--- a/src/cli/doctor-docker.ts
+++ b/src/cli/doctor-docker.ts
@@ -325,8 +325,14 @@ export type DockerPsDeps = {
   listContainers: () => ContainerRow[] | null;
 };
 
-/** Default (real) implementation — calls docker ps. */
-function defaultListContainers(): ContainerRow[] | null {
+/**
+ * Default (real) implementation — calls docker ps.
+ *
+ * Exported so other surfaces that need the SAME container-state snapshot
+ * (the setup wizard's verification step, `src/setup/verify.ts`) reuse this
+ * probe instead of shelling out to docker with slightly different flags.
+ */
+export function listSwitchroomContainers(): ContainerRow[] | null {
   const r = spawnSync(
     "docker",
     [
@@ -345,7 +351,7 @@ function defaultListContainers(): ContainerRow[] | null {
   });
 }
 
-const DEFAULT_DOCKER_PS_DEPS: DockerPsDeps = { listContainers: defaultListContainers };
+const DEFAULT_DOCKER_PS_DEPS: DockerPsDeps = { listContainers: listSwitchroomContainers };
 
 /**
  * Check runtime container health for the 2026-06-23 incident class.

--- a/src/cli/doctor-docker.ts
+++ b/src/cli/doctor-docker.ts
@@ -287,17 +287,30 @@ export interface ContainerRow {
  * Classify a container's status string into a coarse health bucket.
  *
  * Docker status strings look like:
- *   "Up 3 hours (healthy)"      → running/healthy
- *   "Up 2 minutes"               → running (no healthcheck)
- *   "Restarting (1) 30 seconds"  → crash-looping
- *   "Created"                    → stuck before first start
- *   "Exited (1) 5 minutes ago"   → stopped
+ *   "Up 3 hours (healthy)"             → running/healthy
+ *   "Up 2 minutes"                      → running (no healthcheck)
+ *   "Up 2 minutes (unhealthy)"          → running but its healthcheck FAILS
+ *   "Up 4 seconds (health: starting)"   → running, healthcheck not decided yet
+ *   "Restarting (1) 30 seconds"         → crash-looping
+ *   "Created"                           → stuck before first start
+ *   "Exited (1) 5 minutes ago"          → stopped
+ *
+ * `running-unhealthy` and `running-starting` are split out of
+ * `running-no-healthcheck` deliberately (setup-verification review M6): a
+ * wedged `switchroom-hindsight` reports "Up 2 minutes (unhealthy)" — that
+ * healthcheck exists precisely to make a wedged API visible — and folding it
+ * into plain "running" let a dead memory backend verify green. Callers that
+ * only match the stuck/crash-loop signature (doctor's
+ * `checkContainerRuntimeHealth`) are unaffected: they test `restarting` /
+ * `created` only, and neither new bucket collides with those.
  *
  * @internal exported for testing
  */
 export type ContainerHealth =
   | "running-healthy"
   | "running-no-healthcheck"
+  | "running-unhealthy"
+  | "running-starting"
   | "restarting"
   | "created"
   | "exited"
@@ -305,6 +318,9 @@ export type ContainerHealth =
 
 export function classifyContainerStatus(status: string): ContainerHealth {
   const s = status.toLowerCase().trim();
+  // Order matters: test the qualified forms before the bare "up ".
+  if (s.startsWith("up ") && s.includes("(unhealthy)")) return "running-unhealthy";
+  if (s.startsWith("up ") && s.includes("(health: starting)")) return "running-starting";
   if (s.startsWith("up ") && s.includes("(healthy)")) return "running-healthy";
   if (s.startsWith("up ")) return "running-no-healthcheck";
   if (s.startsWith("restarting")) return "restarting";

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import chalk from "chalk";
 import { existsSync, copyFileSync, readFileSync, mkdirSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { resolve, dirname } from "node:path";
 import { loadConfig, resolveAgentsDir, resolvePath, findConfigFile, ConfigError } from "../config/loader.js";
@@ -42,6 +43,7 @@ import {
   pickHindsightPorts,
   preflightHindsightPorts,
   type LiteLLMHindsightConfig,
+  type DockerProbe,
 } from "../setup/hindsight.js";
 import { getViaBrokerStructured } from "../vault/broker/client.js";
 import {
@@ -61,6 +63,14 @@ import {
   setAgentSupergroupChatId,
 } from "./supergroup-setup-yaml.js";
 import { setSwitchroomTimezone } from "./timezone-setup-yaml.js";
+import {
+  waitForAgentContainerUp,
+  verifyFleetContainers,
+  hasFatal,
+  SetupVerificationError,
+  type VerifyFinding,
+} from "../setup/verify.js";
+import type { ContainerRow } from "./doctor-docker.js";
 import { detectServerTimezone } from "../config/timezone.js";
 import { isValidTimezone } from "../config/schema.js";
 
@@ -69,7 +79,17 @@ const STEP_ACTIVE = chalk.blue("->");
 const STEP_DONE = chalk.green("OK");
 
 function stepHeader(num: number, title: string, status: string): void {
-  console.log(`\n${status} ${chalk.bold(`Step ${num}:`)} ${title}`);
+  stepHeaderTo((line) => console.log(line), num, title, status);
+}
+
+/** stepHeader with an injectable sink (tests capture output). */
+function stepHeaderTo(
+  log: (line: string) => void,
+  num: number,
+  title: string,
+  status: string,
+): void {
+  log(`\n${status} ${chalk.bold(`Step ${num}:`)} ${title}`);
 }
 
 /**
@@ -180,32 +200,67 @@ export function registerSetupCommand(program: Command): void {
         await stepGoogleWorkspace(config, nonInteractive);
 
         // ── Step 13: Verification ────────────────────────────────
-        await stepVerification(config, nonInteractive);
+        // Throws (→ exit 1) when the fleet is demonstrably broken.
+        const verdict = await stepVerification(config, nonInteractive);
 
         await captureEvent("setup_completed", {
           agent_count: Object.keys(config.agents).length,
           interactive: !nonInteractive,
+          verified: verdict === "verified",
         });
 
-        console.log(
-          chalk.bold.green("\n  Setup complete!") +
-            chalk.gray(" Your agents are ready.\n"),
-        );
+        // The closing line must not claim more than the verification step
+        // actually proved (install-path review H7).
+        if (verdict === "verified") {
+          console.log(
+            chalk.bold.green("\n  Setup complete!") +
+              chalk.gray(" Your agents are running.\n"),
+          );
+        } else {
+          console.log(
+            chalk.bold.yellow("\n  Setup finished — config written, fleet not started yet.") +
+              chalk.gray(" Follow the steps above to bring it up.\n"),
+          );
+        }
       } catch (err) {
         await captureException(err, { action: "setup" });
-        if (err instanceof ConfigError) {
-          console.error(chalk.red(`\nConfig error: ${err.message}`));
-          if (err.details) {
-            for (const d of err.details) {
-              console.error(chalk.gray(d));
-            }
-          }
-          process.exit(1);
-        }
-        console.error(chalk.red(`\nSetup failed: ${(err as Error).message}`));
-        process.exit(1);
+        process.exit(reportSetupFailure(err));
       }
     });
+}
+
+/**
+ * Print a setup failure and return the process exit code.
+ *
+ * Split out of the action so the exit contract is testable: EVERY failure
+ * path — including a failed verification — must return non-zero, so a
+ * scripted/CI install (`switchroom setup --non-interactive && ...`) stops
+ * instead of sailing past a dead fleet (install-path review H7).
+ */
+export function reportSetupFailure(
+  err: unknown,
+  log: (line: string) => void = (line) => console.error(line),
+): number {
+  if (err instanceof SetupVerificationError) {
+    // The per-check rows were already printed by the verification step;
+    // keep the exit message short and point at doctor.
+    log(
+      chalk.red(
+        "\nSetup did NOT complete: verification failed (see the rows above).",
+      ),
+    );
+    log(chalk.gray("Diagnose with: switchroom doctor"));
+    return 1;
+  }
+  if (err instanceof ConfigError) {
+    log(chalk.red(`\nConfig error: ${err.message}`));
+    if (err.details) {
+      for (const d of err.details) log(chalk.gray(d));
+    }
+    return 1;
+  }
+  log(chalk.red(`\nSetup failed: ${err instanceof Error ? err.message : String(err)}`));
+  return 1;
 }
 
 // ─── Step 1: Config File ─────────────────────────────────────────────────────
@@ -942,10 +997,17 @@ async function resolveLiteLLMForHindsight(
   };
 }
 
-async function stepMemoryBackend(
+/** Injectable seams for the memory-backend step (tests: no docker needed). */
+export interface MemoryBackendDeps {
+  /** Docker probe passed to `isDockerAvailable` / container checks. */
+  dockerProbe?: DockerProbe;
+}
+
+export async function stepMemoryBackend(
   config: SwitchroomConfig,
   nonInteractive: boolean,
   switchroomConfigPath: string,
+  deps: MemoryBackendDeps = {},
 ): Promise<void> {
   stepHeader(6, "Memory backend", STEP_ACTIVE);
 
@@ -1041,24 +1103,44 @@ async function stepMemoryBackend(
     }
   }
 
-  // Check Docker availability
-  if (!isDockerAvailable()) {
+  // Check Docker availability.
+  //
+  // Pre-H7 this printed a GREEN `OK Manual setup pending` and returned — so
+  // a host with no Docker (where nothing in the fleet can run) still saw a
+  // successful step and a "Setup complete!" at the end. Hindsight is the
+  // default memory backend and it is a container; if Docker is absent the
+  // step did not succeed, so say so and fail. (Compatible with the
+  // hindsight-default-on direction in
+  // docs/proposed/hindsight-litellm-integration-audit-2026-07-26.md item 5:
+  // "a hard, named failure with a resume instruction". The opt-out below is
+  // the documented escape hatch for a Docker-less machine.)
+  if (!isDockerAvailable(deps.dockerProbe)) {
+    console.log(chalk.red("  x Docker is not available on this system."));
     console.log(
-      chalk.yellow("  Docker is not available on this system."),
+      chalk.gray(
+        "  Hindsight memory runs as a Docker container (and so does every agent).",
+      ),
     );
-    console.log(chalk.gray("  Install Docker, then re-run `switchroom setup`."));
-    console.log(chalk.green(`  ${STEP_DONE} Manual setup pending`));
-    return;
+    console.log(
+      chalk.gray(
+        "  Install Docker, then re-run `switchroom setup` — or re-run with " +
+          "SWITCHROOM_MEMORY_BACKEND=none to skip memory setup.",
+      ),
+    );
+    throw new Error(
+      "Memory backend setup failed: Docker is not available. Install Docker and " +
+        "re-run `switchroom setup`, or set SWITCHROOM_MEMORY_BACKEND=none to skip it.",
+    );
   }
 
   // Check if already running
-  if (isHindsightRunning()) {
+  if (isHindsightRunning(deps.dockerProbe)) {
     console.log(chalk.green(`  ${STEP_DONE} Hindsight container already running (switchroom-hindsight)`));
     return;
   }
 
   // Check if container exists but is stopped
-  if (isHindsightContainerExists()) {
+  if (isHindsightContainerExists(deps.dockerProbe)) {
     console.log(chalk.gray("  Found stopped switchroom-hindsight container, removing..."));
     stopHindsight();
   }
@@ -1134,7 +1216,7 @@ async function stepMemoryBackend(
       console.log(chalk.gray("  LiteLLM routing enabled (--network host, ANTHROPIC_BASE_URL set)."));
     }
 
-    if (isHindsightRunning()) {
+    if (isHindsightRunning(deps.dockerProbe)) {
       spin.stop(chalk.green(`${STEP_DONE} Hindsight container started (switchroom-hindsight)`));
       console.log(chalk.gray(`  API: http://localhost:${ports.apiPort}/mcp`));
       console.log(chalk.gray(`  UI:  http://localhost:${ports.uiPort}`));
@@ -1885,48 +1967,161 @@ async function stepGoogleWorkspace(
   }
 }
 
-// ─── Step 12: Verification ───────────────────────────────────────────────────
+// ─── Step 13: Verification ───────────────────────────────────────────────────
 
-async function stepVerification(
+/**
+ * Injectable seams for the verification step. Tests drive the whole step
+ * without docker, without a `switchroom` binary on PATH, and without
+ * wall-clock waits.
+ */
+export interface VerificationDeps {
+  /** `docker ps -a` rows; null when docker is unreachable. */
+  listContainers?: () => ContainerRow[] | null;
+  /** Poll sleep — no-op in tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Runs `switchroom agent start <name>`; throws on failure. */
+  startAgent?: (name: string) => void;
+  /** Interactive "start it now?" prompt. */
+  confirmStart?: (name: string) => Promise<boolean>;
+  /** Output sink (defaults to console.log). */
+  log?: (line: string) => void;
+  timeoutMs?: number;
+  intervalMs?: number;
+  stableSamples?: number;
+}
+
+function defaultStartAgent(name: string): void {
+  // Keep shelling out to the `switchroom` CLI (not lifecycle.startAgent
+  // directly) so the operator gets the same reconcile-then-start path
+  // `switchroom agent start` performs. Errors propagate: a missing binary
+  // (ENOENT) or a non-zero exit is a real verification failure now, not a
+  // yellow shrug.
+  execFileSync("switchroom", ["agent", "start", name], { stdio: "inherit" });
+}
+
+/**
+ * Final step: prove something, or fail loudly.
+ *
+ * Pre-H7 this printed four manual instructions and an unconditional green
+ * `OK Verification steps ready`, and swallowed an `agent start` failure in a
+ * bare `catch {}` — so the wizard reported success on a host where nothing
+ * was running. Now:
+ *
+ *   - a start we attempted must produce a container that comes up AND stays
+ *     up (`waitForAgentContainerUp`), otherwise the step fails;
+ *   - the fleet's container runtime is checked with doctor's own
+ *     `checkContainerRuntimeHealth` (crash-loop / stuck-Created signature);
+ *   - docker being unreachable is a failure, not a footnote;
+ *   - "not up yet" (the normal state on a first install, where `setup` runs
+ *     before `apply`) is reported as PENDING in yellow — never as a green OK.
+ *
+ * Throws `SetupVerificationError` on any fatal finding; the wizard's action
+ * handler turns that into a non-zero exit so scripted installs stop here.
+ */
+export async function stepVerification(
   config: SwitchroomConfig,
   nonInteractive: boolean,
-): Promise<void> {
-  stepHeader(13, "Verification", STEP_ACTIVE);
+  deps: VerificationDeps = {},
+): Promise<"verified" | "pending"> {
+  const log = deps.log ?? ((line: string) => console.log(line));
+  stepHeaderTo(log, 13, "Verification", STEP_ACTIVE);
 
   const agentNames = Object.keys(config.agents);
   const firstName = agentNames[0];
-  const firstAgent = config.agents[firstName];
+  const firstAgent = firstName ? config.agents[firstName] : undefined;
 
-  console.log(chalk.gray("  To verify your setup:"));
-  console.log(chalk.gray(`    1. Start an agent:  switchroom agent start ${firstName}`));
-  console.log(chalk.gray(`    2. Check status:    switchroom agent list`));
-  console.log(
-    chalk.gray(
-      `    3. Send a message in the "${firstAgent.topic_name}" topic`,
-    ),
-  );
-  console.log(chalk.gray("    4. Check auth:      switchroom auth list"));
+  const findings: VerifyFinding[] = [];
 
-  if (!nonInteractive) {
-    const startNow = await askYesNo(
-      `\n  Start ${chalk.cyan(firstName)} now?`,
-      false,
-    );
+  // ── Optionally start the first agent, and hold that start to account ──
+  if (!nonInteractive && firstName) {
+    const confirm =
+      deps.confirmStart ??
+      ((name: string) => askYesNo(`\n  Start ${chalk.cyan(name)} now?`, false));
+    const startNow = await confirm(firstName);
     if (startNow) {
+      const start = deps.startAgent ?? defaultStartAgent;
+      let started = true;
       try {
-        const { execFileSync } = await import("node:child_process");
-        console.log(chalk.gray(`  Starting ${firstName}...`));
-        execFileSync("switchroom", ["agent", "start", firstName], { stdio: "inherit" });
-        console.log(chalk.green(`  ${STEP_DONE} Agent started`));
-      } catch {
-        console.log(
-          chalk.yellow(
-            `  Could not start automatically. Run: switchroom agent start ${firstName}`,
-          ),
+        log(chalk.gray(`  Starting ${firstName}...`));
+        start(firstName);
+      } catch (err) {
+        started = false;
+        findings.push({
+          name: `${firstName}: agent start`,
+          status: "fail",
+          detail: `\`switchroom agent start ${firstName}\` failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          fix:
+            "If the compose file does not exist yet, run `switchroom apply` " +
+            `first, then \`switchroom agent start ${firstName}\`.`,
+        });
+      }
+      if (started) {
+        log(chalk.gray(`  Waiting for ${firstName} to come up...`));
+        findings.push(
+          await waitForAgentContainerUp(firstName, deps, {
+            timeoutMs: deps.timeoutMs,
+            intervalMs: deps.intervalMs,
+            stableSamples: deps.stableSamples,
+          }),
         );
       }
     }
   }
 
-  console.log(chalk.green(`  ${STEP_DONE} Verification steps ready`));
+  // ── Fleet runtime health (doctor's own check) ──────────────────────────
+  findings.push(...verifyFleetContainers(config, deps));
+
+  for (const f of findings) {
+    if (f.status === "ok") {
+      log(chalk.green(`  ${STEP_DONE} ${f.name}: ${f.detail}`));
+    } else if (f.status === "pending") {
+      log(chalk.yellow(`  .. ${f.name}: ${f.detail}`));
+    } else {
+      log(chalk.red(`  x  ${f.name}: ${f.detail}`));
+    }
+    if (f.fix && f.status !== "ok") log(chalk.gray(`     ${f.fix}`));
+  }
+
+  if (hasFatal(findings)) {
+    log(chalk.red("\n  Verification FAILED — your fleet is not healthy."));
+    throw new SetupVerificationError(findings);
+  }
+
+  // Only reached when nothing is broken. Still honest about what was NOT
+  // proven: a pending fleet gets the checklist, not a success claim.
+  if (findings.some((f) => f.status === "pending")) {
+    log(chalk.yellow("\n  Setup wrote your config, but the fleet is not verified yet."));
+    log(chalk.gray("  Finish with:"));
+    log(chalk.gray("    1. switchroom apply"));
+    log(
+      chalk.gray(
+        "    2. docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d",
+      ),
+    );
+    if (firstName) {
+      log(chalk.gray(`    3. switchroom agent list   # ${firstName} should be running`));
+      if (firstAgent) {
+        log(
+          chalk.gray(
+            `    4. Send a message in the "${firstAgent.topic_name}" topic`,
+          ),
+        );
+      }
+    }
+    log(chalk.gray("    5. switchroom doctor"));
+    return "pending";
+  }
+
+  log(chalk.green(`  ${STEP_DONE} Verified: the fleet is running`));
+  if (firstAgent) {
+    log(
+      chalk.gray(
+        `  Try it: send a message in the "${firstAgent.topic_name}" topic ` +
+          "(auth: `switchroom auth list`, health: `switchroom doctor`).",
+      ),
+    );
+  }
+  return "verified";
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -31,7 +31,7 @@ import {
 import { detectGpuCapabilities } from "../setup/gpu-detect.js";
 import { saveVoiceCapability } from "../setup/host-capabilities.js";
 import {
-  isDockerAvailable,
+  probeDockerAvailability,
   isHindsightRunning,
   isHindsightContainerExists,
   startHindsight,
@@ -66,11 +66,13 @@ import { setSwitchroomTimezone } from "./timezone-setup-yaml.js";
 import {
   waitForAgentContainerUp,
   verifyFleetContainers,
+  dedupeFindings,
   hasFatal,
   SetupVerificationError,
   type VerifyFinding,
 } from "../setup/verify.js";
 import type { ContainerRow } from "./doctor-docker.js";
+import { composeFilePath } from "../agents/lifecycle.js";
 import { detectServerTimezone } from "../config/timezone.js";
 import { isValidTimezone } from "../config/schema.js";
 
@@ -173,7 +175,13 @@ export function registerSetupCommand(program: Command): void {
         await stepCreateTopics(config, botToken, nonInteractive);
 
         // ── Step 6: Memory backend ───────────────────────────────
-        await stepMemoryBackend(config, nonInteractive, switchroomConfigPath);
+        // The outcome is carried into step 13: what this run believes it
+        // started is what step 13 holds it to (review H1/H2).
+        const memoryOutcome = await stepMemoryBackend(
+          config,
+          nonInteractive,
+          switchroomConfigPath,
+        );
 
         // ── Step 7: Voice engine (GPU detection + verdict) ───────
         stepVoiceEngine();
@@ -201,11 +209,34 @@ export function registerSetupCommand(program: Command): void {
 
         // ── Step 13: Verification ────────────────────────────────
         // Throws (→ exit 1) when the fleet is demonstrably broken.
-        const verdict = await stepVerification(config, nonInteractive);
-
-        await captureEvent("setup_completed", {
+        const setupCompletedProps = {
           agent_count: Object.keys(config.agents).length,
           interactive: !nonInteractive,
+        };
+        let verdict: "verified" | "pending";
+        try {
+          verdict = await stepVerification(
+            config,
+            nonInteractive,
+            {},
+            {
+              hindsightExpected: memoryOutcome.hindsightExpected,
+              memoryOptedOut: memoryOutcome.optedOut,
+            },
+          );
+        } catch (verifyErr) {
+          // L12: `setup_completed` used to be skipped entirely when
+          // verification threw, so `verified: false` never recorded the one
+          // population it exists to measure — the failed installs.
+          await captureEvent("setup_completed", {
+            ...setupCompletedProps,
+            verified: false,
+          });
+          throw verifyErr;
+        }
+
+        await captureEvent("setup_completed", {
+          ...setupCompletedProps,
           verified: verdict === "verified",
         });
 
@@ -1001,6 +1032,37 @@ async function resolveLiteLLMForHindsight(
 export interface MemoryBackendDeps {
   /** Docker probe passed to `isDockerAvailable` / container checks. */
   dockerProbe?: DockerProbe;
+  /** Poll sleep while waiting for the container to report running. */
+  sleep?: (ms: number) => Promise<void>;
+  /** How many times to re-check `docker ps` after `startHindsight`. */
+  readyRetries?: number;
+  /**
+   * The `docker run` seam. Injected so tests can exercise the
+   * "start returned but the container is not there" path (review H2)
+   * without docker.
+   */
+  startContainer?: typeof startHindsight;
+}
+
+/**
+ * What step 6 actually left behind, so step 13 can hold it to account.
+ *
+ * `hindsightExpected` is true ONLY when this run believes a working
+ * `switchroom-hindsight` container exists. Step 13 turns that into a hard
+ * requirement (review H2): without it, every path where step 6 gave up
+ * silently produced a wizard that ended with "Setup complete! Your agents
+ * are running." over a dead memory backend.
+ */
+export interface MemoryBackendOutcome {
+  hindsightExpected: boolean;
+  /** True when the operator took the `none` opt-out (config or env). */
+  optedOut: boolean;
+}
+
+/** True when memory is switched off by env or config — the H1 opt-out. */
+export function isMemoryBackendDisabled(config: SwitchroomConfig): boolean {
+  const memoryBackend = config.memory?.backend ?? "hindsight";
+  return process.env.SWITCHROOM_MEMORY_BACKEND === "none" || memoryBackend === "none";
 }
 
 export async function stepMemoryBackend(
@@ -1008,17 +1070,16 @@ export async function stepMemoryBackend(
   nonInteractive: boolean,
   switchroomConfigPath: string,
   deps: MemoryBackendDeps = {},
-): Promise<void> {
+): Promise<MemoryBackendOutcome> {
   stepHeader(6, "Memory backend", STEP_ACTIVE);
 
-  // Check if memory backend is configured and is hindsight
-  const memoryBackend = config.memory?.backend ?? "hindsight";
-  const envBackend = process.env.SWITCHROOM_MEMORY_BACKEND;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
 
-  if (envBackend === "none" || memoryBackend === "none") {
+  // Check if memory backend is configured and is hindsight
+  if (isMemoryBackendDisabled(config)) {
     console.log(chalk.gray("  Memory backend disabled (set to 'none')."));
     console.log(chalk.green(`  ${STEP_DONE} Skipped`));
-    return;
+    return { hindsightExpected: false, optedOut: true };
   }
 
   // In non-interactive mode, default to hindsight unless env says otherwise
@@ -1043,7 +1104,7 @@ export async function stepMemoryBackend(
   if (!setupHindsight) {
     console.log(chalk.gray("  Skipping Hindsight setup."));
     console.log(chalk.green(`  ${STEP_DONE} Skipped`));
-    return;
+    return { hindsightExpected: false, optedOut: false };
   }
 
   // Surface a one-liner if the legacy OpenAI key still exists in vault or env.
@@ -1114,29 +1175,38 @@ export async function stepMemoryBackend(
   // docs/proposed/hindsight-litellm-integration-audit-2026-07-26.md item 5:
   // "a hard, named failure with a resume instruction". The opt-out below is
   // the documented escape hatch for a Docker-less machine.)
-  if (!isDockerAvailable(deps.dockerProbe)) {
-    console.log(chalk.red("  x Docker is not available on this system."));
+  // Review L8: `docker --version` only proves the CLI is on PATH. The far
+  // more common macOS case is "installed but Docker Desktop isn't running",
+  // where "Install Docker" is the wrong instruction. Name which one it is.
+  const dockerState = probeDockerAvailability(deps.dockerProbe);
+  if (dockerState !== "ok") {
+    const noCli = dockerState === "no-cli";
+    const headline = noCli
+      ? "Docker is not installed (no `docker` command on PATH)."
+      : "Docker is installed but its daemon is not responding.";
+    const remedy = noCli
+      ? "Install Docker (https://docs.docker.com/get-docker/), then re-run `switchroom setup`"
+      : "Start Docker (on macOS: open Docker Desktop; on Linux: `sudo systemctl start docker`), " +
+        "then re-run `switchroom setup`";
+    console.log(chalk.red(`  x ${headline}`));
     console.log(
       chalk.gray(
         "  Hindsight memory runs as a Docker container (and so does every agent).",
       ),
     );
     console.log(
-      chalk.gray(
-        "  Install Docker, then re-run `switchroom setup` — or re-run with " +
-          "SWITCHROOM_MEMORY_BACKEND=none to skip memory setup.",
-      ),
+      chalk.gray(`  ${remedy} — or re-run with SWITCHROOM_MEMORY_BACKEND=none to skip memory setup.`),
     );
     throw new Error(
-      "Memory backend setup failed: Docker is not available. Install Docker and " +
-        "re-run `switchroom setup`, or set SWITCHROOM_MEMORY_BACKEND=none to skip it.",
+      `Memory backend setup failed: ${headline} ${remedy}, or set ` +
+        "SWITCHROOM_MEMORY_BACKEND=none to skip it.",
     );
   }
 
   // Check if already running
   if (isHindsightRunning(deps.dockerProbe)) {
     console.log(chalk.green(`  ${STEP_DONE} Hindsight container already running (switchroom-hindsight)`));
-    return;
+    return { hindsightExpected: true, optedOut: false };
   }
 
   // Check if container exists but is stopped
@@ -1150,12 +1220,23 @@ export async function stepMemoryBackend(
   // `docker run` (the 2026-07 crash-loop: hindsight died on `[Errno 98]
   // address already in use` while fleet memory was silently down). Upstream
   // default 18888/19999 first, fall back to a free pair if occupied.
+  //
+  // Review H2: each `return` below used to leave the step "successful" with
+  // no memory backend running — and step 13 had nothing to catch it, so the
+  // wizard still printed "Setup complete! Your agents are running." They are
+  // throws now, in the same shape as the Docker-absent failure above:
+  // a named error with a resume instruction.
   let ports: { apiPort: number; uiPort: number };
   try {
     ports = await pickHindsightPorts();
   } catch (err) {
     console.log(chalk.red(`  ${(err as Error).message}`));
-    return;
+    throw new Error(
+      `Memory backend setup failed: could not allocate Hindsight ports: ${
+        (err as Error).message
+      }. Free a port and re-run \`switchroom setup\`, or set ` +
+        "SWITCHROOM_MEMORY_BACKEND=none to skip it.",
+    );
   }
   if (ports.apiPort !== HINDSIGHT_DEFAULT_API_PORT) {
     console.log(
@@ -1182,19 +1263,23 @@ export async function stepMemoryBackend(
       ports = await pickHindsightPorts();
     } catch (err) {
       console.log(chalk.red(`  ${(err as Error).message}`));
-      return;
+      throw new Error(
+        `Memory backend setup failed: could not allocate Hindsight ports after ` +
+          `reassignment: ${(err as Error).message}. Free a port and re-run ` +
+          "`switchroom setup`, or set SWITCHROOM_MEMORY_BACKEND=none to skip it.",
+      );
     }
     conflict = await preflightHindsightPorts(ports);
     if (conflict) {
       const stillHeldBy = conflict.holder ? ` (held by ${conflict.holder})` : "";
-      console.log(
-        chalk.red(
-          `  Refusing to start Hindsight: port ${conflict.port} is still ` +
-            `occupied${stillHeldBy} after reassignment. Free it and re-run ` +
-            "`switchroom setup`.",
-        ),
+      const msg =
+        `Refusing to start Hindsight: port ${conflict.port} is still ` +
+        `occupied${stillHeldBy} after reassignment.`;
+      console.log(chalk.red(`  ${msg}`));
+      throw new Error(
+        `Memory backend setup failed: ${msg} Free it and re-run ` +
+          "`switchroom setup`, or set SWITCHROOM_MEMORY_BACKEND=none to skip it.",
       );
-      return;
     }
     console.log(
       chalk.green(`  Reassigned Hindsight to port ${ports.apiPort}/${ports.uiPort}.`),
@@ -1205,7 +1290,8 @@ export async function stepMemoryBackend(
   const spin = spinner("Starting Hindsight Docker container...");
   try {
     const litellmCfg = await resolveLiteLLMForHindsight(config);
-    startHindsight(
+    const startContainer = deps.startContainer ?? startHindsight;
+    startContainer(
       ports,
       litellmCfg,
       undefined,
@@ -1215,14 +1301,6 @@ export async function stepMemoryBackend(
     if (litellmCfg) {
       console.log(chalk.gray("  LiteLLM routing enabled (--network host, ANTHROPIC_BASE_URL set)."));
     }
-
-    if (isHindsightRunning(deps.dockerProbe)) {
-      spin.stop(chalk.green(`${STEP_DONE} Hindsight container started (switchroom-hindsight)`));
-      console.log(chalk.gray(`  API: http://localhost:${ports.apiPort}/mcp`));
-      console.log(chalk.gray(`  UI:  http://localhost:${ports.uiPort}`));
-    } else {
-      spin.stop(chalk.yellow("Container started but may still be initializing"));
-    }
   } catch (err) {
     spin.stop(chalk.red(`Failed to start Hindsight: ${(err as Error).message}`));
     console.log(
@@ -1231,8 +1309,45 @@ export async function stepMemoryBackend(
           `consumer socket volume (auth-broker-${HINDSIGHT_CONSUMER_NAME}-sock) exists.`,
       ),
     );
+    throw new Error(
+      `Memory backend setup failed: ${(err as Error).message}. Fix the cause and ` +
+        "re-run `switchroom setup`, or set SWITCHROOM_MEMORY_BACKEND=none to skip it.",
+    );
   }
+
+  // `docker run -d` returning is not evidence the container survived. Re-check
+  // a few times before deciding (a container that dies during startup drops
+  // out of `docker ps` within a second or two). Deliberately OUTSIDE the try
+  // above so this verdict is not re-wrapped as a start error.
+  let running = isHindsightRunning(deps.dockerProbe);
+  const retries = deps.readyRetries ?? HINDSIGHT_READY_RETRIES;
+  for (let i = 0; !running && i < retries; i++) {
+    await sleep(HINDSIGHT_READY_INTERVAL_MS);
+    running = isHindsightRunning(deps.dockerProbe);
+  }
+
+  if (!running) {
+    // H2: this was a yellow "Container started but may still be
+    // initializing" that the wizard then reported as overall success.
+    spin.stop(chalk.red("Hindsight container did not stay running after start"));
+    throw new Error(
+      "Memory backend setup failed: switchroom-hindsight did not stay running " +
+        "after start. Check `docker logs switchroom-hindsight --tail 50`, then " +
+        "re-run `switchroom setup`, or set SWITCHROOM_MEMORY_BACKEND=none to skip it.",
+    );
+  }
+
+  spin.stop(chalk.green(`${STEP_DONE} Hindsight container started (switchroom-hindsight)`));
+  console.log(chalk.gray(`  API: http://localhost:${ports.apiPort}/mcp`));
+  console.log(chalk.gray(`  UI:  http://localhost:${ports.uiPort}`));
+
+  return { hindsightExpected: true, optedOut: false };
 }
+
+/** Re-checks of `docker ps` after `startHindsight` before calling it dead. */
+const HINDSIGHT_READY_RETRIES = 5;
+/** Gap between those re-checks. */
+const HINDSIGHT_READY_INTERVAL_MS = 1_000;
 
 // ─── Step 7: Voice engine (GPU detection + verdict) ──────────────────────────
 
@@ -1982,21 +2097,67 @@ export interface VerificationDeps {
   /** Runs `switchroom agent start <name>`; throws on failure. */
   startAgent?: (name: string) => void;
   /** Interactive "start it now?" prompt. */
-  confirmStart?: (name: string) => Promise<boolean>;
+  confirmStart?: (names: string[]) => Promise<boolean>;
+  /**
+   * Whether `switchroom apply` has generated the compose file yet. When it
+   * has not, there is nothing to start and we must not offer to (H3c).
+   */
+  composeFileExists?: () => boolean;
   /** Output sink (defaults to console.log). */
   log?: (line: string) => void;
   timeoutMs?: number;
   intervalMs?: number;
   stableSamples?: number;
+  /** Forwarded to `verifyFleetContainers` (M4). */
+  confirmSamples?: number;
+  confirmIntervalMs?: number;
 }
+
+/** What step 6 left behind; step 13 holds the run to it (H1/H2). */
+export interface VerificationExpectations {
+  hindsightExpected?: boolean;
+  /** Memory opted out ⇒ this run did not require docker (H1). */
+  memoryOptedOut?: boolean;
+}
+
+/** Lines of captured child output to quote back on a failed start. */
+const START_OUTPUT_TAIL_LINES = 12;
 
 function defaultStartAgent(name: string): void {
   // Keep shelling out to the `switchroom` CLI (not lifecycle.startAgent
   // directly) so the operator gets the same reconcile-then-start path
-  // `switchroom agent start` performs. Errors propagate: a missing binary
-  // (ENOENT) or a non-zero exit is a real verification failure now, not a
-  // yellow shrug.
-  execFileSync("switchroom", ["agent", "start", name], { stdio: "inherit" });
+  // `switchroom agent start` performs.
+  //
+  // Review H3(b): with `stdio: "inherit"` the only failure this could ever
+  // observe was ENOENT, and the child's own diagnosis was not available to
+  // put in the finding. Capture it instead, echo it, and quote the tail in
+  // the thrown error so the verification row names the REAL reason (missing
+  // compose file, quarantined agent, preflight error, docker error) rather
+  // than degrading into a 45s "did not come up" timeout.
+  let out = "";
+  try {
+    out = execFileSync("switchroom", ["agent", "start", name], {
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    if (out.trim()) process.stdout.write(out);
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & {
+      stdout?: Buffer | string;
+      stderr?: Buffer | string;
+    };
+    const combined = [e.stdout?.toString() ?? "", e.stderr?.toString() ?? ""]
+      .join("\n")
+      .trim();
+    if (combined) process.stderr.write(`${combined}\n`);
+    const tail = combined
+      .split("\n")
+      .filter((l) => l.trim().length > 0)
+      .slice(-START_OUTPUT_TAIL_LINES)
+      .join(" / ");
+    const base = e.message ?? String(err);
+    throw new Error(tail ? `${base}: ${tail}` : base);
+  }
 }
 
 /**
@@ -2010,10 +2171,18 @@ function defaultStartAgent(name: string): void {
  *   - a start we attempted must produce a container that comes up AND stays
  *     up (`waitForAgentContainerUp`), otherwise the step fails;
  *   - the fleet's container runtime is checked with doctor's own
- *     `checkContainerRuntimeHealth` (crash-loop / stuck-Created signature);
- *   - docker being unreachable is a failure, not a footnote;
+ *     `checkContainerRuntimeHealth` (crash-loop / stuck-Created signature),
+ *     confirmed across samples so a `restart: always` bounce is not a FAIL;
+ *   - docker being unreachable is a failure — unless this run took the
+ *     documented `SWITCHROOM_MEMORY_BACKEND=none` opt-out and therefore
+ *     never needed docker, in which case it is honest PENDING (review H1);
  *   - "not up yet" (the normal state on a first install, where `setup` runs
  *     before `apply`) is reported as PENDING in yellow — never as a green OK.
+ *
+ * Ordering constraint (review H3c): `setup` runs BEFORE `apply`, so on a
+ * first install there is no compose file and NOTHING can be started. We
+ * detect that up front and skip the "start it now?" offer entirely rather
+ * than starting, timing out, and turning a first install into exit 1.
  *
  * Throws `SetupVerificationError` on any fatal finding; the wizard's action
  * handler turns that into a non-zero exit so scripted installs stop here.
@@ -2022,6 +2191,7 @@ export async function stepVerification(
   config: SwitchroomConfig,
   nonInteractive: boolean,
   deps: VerificationDeps = {},
+  expect: VerificationExpectations = {},
 ): Promise<"verified" | "pending"> {
   const log = deps.log ?? ((line: string) => console.log(line));
   stepHeaderTo(log, 13, "Verification", STEP_ACTIVE);
@@ -2031,49 +2201,99 @@ export async function stepVerification(
   const firstAgent = firstName ? config.agents[firstName] : undefined;
 
   const findings: VerifyFinding[] = [];
+  let applyPending = false;
 
-  // ── Optionally start the first agent, and hold that start to account ──
-  if (!nonInteractive && firstName) {
-    const confirm =
-      deps.confirmStart ??
-      ((name: string) => askYesNo(`\n  Start ${chalk.cyan(name)} now?`, false));
-    const startNow = await confirm(firstName);
-    if (startNow) {
-      const start = deps.startAgent ?? defaultStartAgent;
-      let started = true;
-      try {
-        log(chalk.gray(`  Starting ${firstName}...`));
-        start(firstName);
-      } catch (err) {
-        started = false;
-        findings.push({
-          name: `${firstName}: agent start`,
-          status: "fail",
-          detail: `\`switchroom agent start ${firstName}\` failed: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-          fix:
-            "If the compose file does not exist yet, run `switchroom apply` " +
-            `first, then \`switchroom agent start ${firstName}\`.`,
-        });
-      }
-      if (started) {
-        log(chalk.gray(`  Waiting for ${firstName} to come up...`));
-        findings.push(
-          await waitForAgentContainerUp(firstName, deps, {
-            timeoutMs: deps.timeoutMs,
-            intervalMs: deps.intervalMs,
-            stableSamples: deps.stableSamples,
-          }),
-        );
+  // ── Optionally start the agents, and hold that start to account ────────
+  if (!nonInteractive && agentNames.length > 0) {
+    const composeExists =
+      (deps.composeFileExists ?? (() => existsSync(composeFilePath())))();
+
+    if (!composeExists) {
+      // H3c — FRESH-INSTALL PATH. No compose file means `switchroom apply`
+      // has not run, so `agent start` cannot possibly work. Offering to
+      // start here (and then failing) turned a normal first install into a
+      // 45s wait and a false FAIL. Say what is missing and move on; the
+      // fleet check below reports PENDING and the checklist tells them to
+      // run `apply`.
+      applyPending = true;
+      log(
+        chalk.gray(
+          "  Not started: `switchroom apply` has not generated the compose file yet.",
+        ),
+      );
+    } else {
+      // L11: verification requires ALL configured agents to be up before it
+      // says "verified", so offer to start all of them — starting only the
+      // first guaranteed a pending verdict (and a false `verified: false`
+      // telemetry row) on any 2+ agent config.
+      const confirm =
+        deps.confirmStart ??
+        ((names: string[]) =>
+          askYesNo(
+            names.length === 1
+              ? `\n  Start ${chalk.cyan(names[0])} now?`
+              : `\n  Start ${chalk.cyan(names.join(", "))} now?`,
+            false,
+          ));
+      const startNow = await confirm(agentNames);
+      if (startNow) {
+        const start = deps.startAgent ?? defaultStartAgent;
+        const awaiting: string[] = [];
+        for (const name of agentNames) {
+          try {
+            log(chalk.gray(`  Starting ${name}...`));
+            start(name);
+            awaiting.push(name);
+          } catch (err) {
+            findings.push({
+              name: `${name}: agent start`,
+              status: "fail",
+              detail: `\`switchroom agent start ${name}\` failed: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+              fix: `Fix the cause above, then \`switchroom agent start ${name}\`.`,
+            });
+          }
+        }
+        if (awaiting.length > 0) {
+          log(chalk.gray(`  Waiting for ${awaiting.join(", ")} to come up...`));
+          // Concurrently: the stability window is wall-clock, so waiting on
+          // N agents in series would multiply the wizard's wait by N. They
+          // all read the same `docker ps`.
+          findings.push(
+            ...(await Promise.all(
+              awaiting.map((name) =>
+                waitForAgentContainerUp(name, deps, {
+                  timeoutMs: deps.timeoutMs,
+                  intervalMs: deps.intervalMs,
+                  stableSamples: deps.stableSamples,
+                }),
+              ),
+            )),
+          );
+        }
       }
     }
   }
 
   // ── Fleet runtime health (doctor's own check) ──────────────────────────
-  findings.push(...verifyFleetContainers(config, deps));
+  findings.push(
+    ...(await verifyFleetContainers(config, deps, {
+      // H1: honour the documented Docker-less escape hatch end to end. Step
+      // 6 short-circuits on it; step 13 used to call this unconditionally
+      // and exit 1 on the very path the docs call the way through.
+      dockerRequired: !expect.memoryOptedOut,
+      hindsightExpected: expect.hindsightExpected ?? false,
+      confirmSamples: deps.confirmSamples,
+      confirmIntervalMs: deps.confirmIntervalMs,
+    })),
+  );
 
-  for (const f of findings) {
+  // L9: one row per underlying fact — the agent poller and the fleet check
+  // both report a docker-less host.
+  const shown = dedupeFindings(findings);
+
+  for (const f of shown) {
     if (f.status === "ok") {
       log(chalk.green(`  ${STEP_DONE} ${f.name}: ${f.detail}`));
     } else if (f.status === "pending") {
@@ -2084,33 +2304,37 @@ export async function stepVerification(
     if (f.fix && f.status !== "ok") log(chalk.gray(`     ${f.fix}`));
   }
 
-  if (hasFatal(findings)) {
+  if (hasFatal(shown)) {
     log(chalk.red("\n  Verification FAILED — your fleet is not healthy."));
-    throw new SetupVerificationError(findings);
+    throw new SetupVerificationError(shown);
   }
 
   // Only reached when nothing is broken. Still honest about what was NOT
   // proven: a pending fleet gets the checklist, not a success claim.
-  if (findings.some((f) => f.status === "pending")) {
+  if (shown.some((f) => f.status === "pending")) {
     log(chalk.yellow("\n  Setup wrote your config, but the fleet is not verified yet."));
     log(chalk.gray("  Finish with:"));
-    log(chalk.gray("    1. switchroom apply"));
-    log(
-      chalk.gray(
-        "    2. docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d",
-      ),
-    );
+    // L10: build the list, then number it — the old hard-coded "1. 2. 5."
+    // printed a gap on a zero-agent config.
+    const steps = [
+      "switchroom apply",
+      "docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d",
+    ];
     if (firstName) {
-      log(chalk.gray(`    3. switchroom agent list   # ${firstName} should be running`));
+      steps.push(`switchroom agent list   # ${firstName} should be running`);
       if (firstAgent) {
-        log(
-          chalk.gray(
-            `    4. Send a message in the "${firstAgent.topic_name}" topic`,
-          ),
-        );
+        steps.push(`Send a message in the "${firstAgent.topic_name}" topic`);
       }
     }
-    log(chalk.gray("    5. switchroom doctor"));
+    steps.push("switchroom doctor");
+    steps.forEach((s, i) => log(chalk.gray(`    ${i + 1}. ${s}`)));
+    if (applyPending) {
+      log(
+        chalk.gray(
+          "  (Nothing was started: setup runs before `apply` by design.)",
+        ),
+      );
+    }
     return "pending";
   }
 

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -763,10 +763,33 @@ const defaultDockerProbe: DockerProbe = (args) => {
 };
 
 /**
- * Check if Docker is available on the system.
+ * Why docker can't be used, when it can't.
+ *
+ * `docker --version` succeeding only proves the CLI is on PATH. On macOS
+ * (Docker Desktop ships the CLI but the VM is frequently stopped) that is
+ * the far more common failure, and telling the operator to "install Docker"
+ * when it is already installed sends them down the wrong road — review L8.
+ * `docker ps` is the cheapest probe that actually reaches the daemon.
+ */
+export type DockerAvailability = "ok" | "no-cli" | "daemon-unreachable";
+
+/**
+ * Distinguish "no docker CLI on PATH" from "CLI present, daemon not
+ * answering", so callers can print the right next step.
+ */
+export function probeDockerAvailability(
+  probe: DockerProbe = defaultDockerProbe,
+): DockerAvailability {
+  if (probe(["--version"]) === null) return "no-cli";
+  if (probe(["ps", "--quiet"]) === null) return "daemon-unreachable";
+  return "ok";
+}
+
+/**
+ * Check if Docker is usable — CLI present AND daemon reachable.
  */
 export function isDockerAvailable(probe: DockerProbe = defaultDockerProbe): boolean {
-  return probe(["--version"]) !== null;
+  return probeDockerAvailability(probe) === "ok";
 }
 
 /**

--- a/src/setup/verify.ts
+++ b/src/setup/verify.ts
@@ -10,12 +10,19 @@
  *
  *   - `waitForAgentContainerUp` — after we asked docker to start an agent,
  *     poll `docker ps` until the container is genuinely up AND has *stayed*
- *     up across consecutive samples (a crash-looping container is "Up" for
- *     a moment, then "Restarting"). Any terminal state (exited / restarting)
+ *     up across a stability WINDOW (a crash-looping container is "Up" for a
+ *     moment, then "Restarting"). Any terminal state (exited / restarting)
  *     fails immediately; a timeout fails with the last observed state.
  *   - `verifyFleetContainers` — reuse doctor's `checkContainerRuntimeHealth`
  *     (the 2026-06-23 stuck/crash-loop signature) rather than inventing a
  *     parallel health surface, and translate its rows into setup findings.
+ *
+ * Both verdicts are sampled over time, and SYMMETRICALLY so (review M4/M5):
+ * a single `docker ps` snapshot is evidence neither of health nor of
+ * breakage. Every switchroom container is generated with `restart: always`
+ * (`src/agents/compose.ts`), so a fleet seconds into a `docker restart` or
+ * an `apply` reconcile legitimately reads `created`/`restarting` for a
+ * moment — failing on the first frame would exit 1 on a healthy fleet.
  *
  * Design constraints that shaped the statuses:
  *
@@ -54,7 +61,16 @@ export interface VerifyFinding {
   detail: string;
   /** Operator-actionable next step; printed under a pending/fail row. */
   fix?: string;
+  /**
+   * Stable identifier for findings that several probes can independently
+   * produce. The wizard de-duplicates on it so a docker-less host gets ONE
+   * "docker is not reachable" row instead of one per probe (review L9).
+   */
+  code?: string;
 }
+
+/** De-dup key for the "docker itself is not reachable" verdict (L9). */
+export const DOCKER_UNAVAILABLE_CODE = "docker-unavailable";
 
 export interface VerifyDeps {
   /**
@@ -67,19 +83,40 @@ export interface VerifyDeps {
 }
 
 /** How long we wait for a just-started agent container to settle. */
-export const AGENT_UP_TIMEOUT_MS = 30_000;
+export const AGENT_UP_TIMEOUT_MS = 45_000;
 /**
- * Gap between `docker ps` samples while waiting. Wide enough that
- * AGENT_STABLE_SAMPLES spans several seconds — a container that restarts
- * every second cannot fake stability across the window.
+ * Gap between `docker ps` samples while waiting.
  */
 export const AGENT_POLL_INTERVAL_MS = 2_000;
 /**
- * Consecutive "Up" samples required before we call a start verified. A
- * crash-looping container shows "Up 1 second" between restarts, so a single
- * sample is not evidence that it *stayed* up.
+ * How long a container must stay continuously up before we call the start
+ * verified — the real guarantee this check offers.
+ *
+ * Review M5: the previous "3 consecutive samples" spanned only ~4s of wall
+ * clock, so the docstring's crash-loop claim held only for sub-4-second
+ * loops. An agent whose `start.sh` dies 8-10s in (a documented failure mode
+ * here — npm install / broker socket waits happen in that window) sailed
+ * through. 15s covers that class with margin and still fits inside the
+ * 45s timeout.
  */
-export const AGENT_STABLE_SAMPLES = 3;
+export const AGENT_STABLE_WINDOW_MS = 15_000;
+/**
+ * Consecutive "Up" samples required, derived from the window so the two can
+ * never drift: N samples span (N-1) intervals of wall clock, so we need
+ * ceil(window / interval) + 1.
+ */
+export const AGENT_STABLE_SAMPLES =
+  Math.ceil(AGENT_STABLE_WINDOW_MS / AGENT_POLL_INTERVAL_MS) + 1;
+
+/**
+ * How many consecutive samples must ALL show a broken fleet before
+ * `verifyFleetContainers` returns `fail` (review M4). Symmetric with the
+ * `ok` path: `restart: always` means a healthy fleet reads `created` /
+ * `restarting` for a beat after `docker restart` or an `apply` reconcile.
+ */
+export const FLEET_FAIL_CONFIRM_SAMPLES = 3;
+/** Gap between the confirmation samples above. */
+export const FLEET_FAIL_CONFIRM_INTERVAL_MS = 2_000;
 
 const defaultSleep = (ms: number): Promise<void> =>
   new Promise((r) => setTimeout(r, ms));
@@ -103,6 +140,14 @@ export function agentContainerHealth(
   return classifyContainerStatus(row.status);
 }
 
+/**
+ * "Demonstrably up." Deliberately excludes `running-unhealthy` (review M6):
+ * `switchroom-hindsight` carries a healthcheck added specifically to make a
+ * wedged API visible, so "Up 2 minutes (unhealthy)" is a container that is
+ * running and NOT working. `running-starting` is also excluded — it is not
+ * yet evidence either way, so the poller keeps looking rather than crediting
+ * stability.
+ */
 function isUp(h: ContainerHealth | "absent"): boolean {
   return h === "running-healthy" || h === "running-no-healthcheck";
 }
@@ -110,11 +155,31 @@ function isUp(h: ContainerHealth | "absent"): boolean {
 const DOCKER_UNAVAILABLE_FIX =
   "Install/start Docker (the fleet runs as containers), then re-run `switchroom setup`.";
 
+/** Human-readable rendering of a docker health bucket for finding text. */
+function describeHealth(h: ContainerHealth | "absent"): string {
+  switch (h) {
+    case "absent":
+      return "no such container";
+    case "running-unhealthy":
+      return "running but its healthcheck is failing";
+    case "running-starting":
+      return "running, healthcheck still starting";
+    default:
+      return h;
+  }
+}
+
 /**
- * Poll until the agent container is up and has stayed up.
+ * Poll until the agent container is up and has stayed up for
+ * {@link AGENT_STABLE_WINDOW_MS}.
  *
  * Called ONLY after a start was actually attempted, so every non-up
  * outcome here is a real failure — including "container never appeared".
+ *
+ * The guarantee: an `ok` verdict means the container was observed up in
+ * every sample across a window of at least `(stableSamples - 1) *
+ * intervalMs` milliseconds. A container that dies inside that window fails,
+ * whatever it looked like on the first frame.
  */
 export async function waitForAgentContainerUp(
   agent: string,
@@ -148,6 +213,7 @@ export async function waitForAgentContainerUp(
         status: "fail",
         detail: `docker ps is unavailable, so ${container} cannot be verified`,
         fix: DOCKER_UNAVAILABLE_FIX,
+        code: DOCKER_UNAVAILABLE_CODE,
       };
     }
     const health = agentContainerHealth(agent, rows);
@@ -172,57 +238,142 @@ export async function waitForAgentContainerUp(
     if (isUp(health)) {
       stable++;
       if (stable >= stableSamples) {
+        const windowSec = Math.round(((stable - 1) * intervalMs) / 1000);
         return {
           name,
           status: "ok",
           detail:
-            `${container} is up and stayed up across ${stable} checks` +
+            `${container} is up and stayed up for ${windowSec}s ` +
+            `(${stable} consecutive checks)` +
             (health === "running-healthy" ? " (healthcheck: healthy)" : ""),
         };
       }
     } else {
-      // absent / created / other — still coming up; don't credit stability.
+      // absent / created / starting / unhealthy / other — not evidence of a
+      // healthy start; reset the window rather than crediting stability.
       stable = 0;
     }
 
     if (i < maxSamples - 1) await sleep(intervalMs);
   }
 
-  const lastDesc = last === "absent" ? "no such container" : last;
   return {
     name,
     status: "fail",
     detail:
       `${container} did not reach a stable running state within ` +
-      `${Math.round(timeoutMs / 1000)}s (last docker state: ${lastDesc})`,
-    fix: `docker logs ${container} --tail 50`,
+      `${Math.round(timeoutMs / 1000)}s (last docker state: ${describeHealth(last)})`,
+    // Review H3(b): `docker logs` on a container that never existed prints
+    // "No such container" — useless guidance exactly when the operator is
+    // most lost. Name the state we actually observed.
+    fix:
+      last === "absent"
+        ? `No ${container} container was created. Check that \`switchroom apply\` ` +
+          "has generated the compose file, then " +
+          `\`switchroom agent start ${agent}\` and read its output.`
+        : `docker logs ${container} --tail 50`,
   };
+}
+
+/** Knobs for {@link verifyFleetContainers}. */
+export interface FleetVerifyOptions {
+  /**
+   * Whether this run *depends* on docker. False when the operator took the
+   * documented `SWITCHROOM_MEMORY_BACKEND=none` / `memory.backend: none`
+   * opt-out and nothing container-backed was attempted — then an absent
+   * docker is `pending` (honest, exit 0), not a hard fail.
+   *
+   * Review H1: step 6 honours that opt-out but step 13 did not, so the
+   * documented Docker-less path still exited 1. Defaults to true.
+   */
+  dockerRequired?: boolean;
+  /**
+   * True when step 6 started (or found already running) the hindsight
+   * container in THIS run. Then a missing / dead `switchroom-hindsight` is
+   * a failure this wizard owns, rather than "absent is fine" (review H2).
+   */
+  hindsightExpected?: boolean;
+  /** Samples that must all show breakage before returning `fail` (M4). */
+  confirmSamples?: number;
+  /** Gap between those samples. */
+  confirmIntervalMs?: number;
 }
 
 /**
  * Fleet-level runtime verification, reusing doctor's runtime health check.
  *
  * Returns:
- *   - a `fail` when docker is unreachable (nothing in the fleet can run),
- *   - a `fail` for doctor's stuck/crash-loop signature,
+ *   - a `fail` when docker is unreachable and this run needed it,
+ *   - a `fail` for doctor's stuck/crash-loop signature — CONFIRMED across
+ *     `confirmSamples` snapshots, symmetric with the `ok` path (review M4),
+ *   - a `fail` when memory was set up this run but its container is not
+ *     usable (review H2/M6),
  *   - a `pending` when no agent container exists yet (the normal state
  *     right after a first-install `setup`, which runs before `apply`),
  *   - `ok` otherwise.
  */
-export function verifyFleetContainers(
+export async function verifyFleetContainers(
   config: SwitchroomConfig,
   deps: VerifyDeps = {},
-): VerifyFinding[] {
+  opts: FleetVerifyOptions = {},
+): Promise<VerifyFinding[]> {
   const listContainers = deps.listContainers ?? listSwitchroomContainers;
-  const rows = listContainers();
+  const sleep = deps.sleep ?? defaultSleep;
+  const confirmSamples = Math.max(1, opts.confirmSamples ?? FLEET_FAIL_CONFIRM_SAMPLES);
+  const confirmIntervalMs = opts.confirmIntervalMs ?? FLEET_FAIL_CONFIRM_INTERVAL_MS;
+
+  // Sample until either the verdict is non-fatal or every confirmation
+  // sample agreed that it is broken. A transient `created`/`restarting`
+  // frame during a `restart: always` bounce therefore clears instead of
+  // exiting 1 on a healthy fleet.
+  let findings = evaluateFleetSnapshot(config, listContainers(), opts);
+  const sawFatal = hasFatal(findings);
+  for (let i = 1; i < confirmSamples && hasFatal(findings); i++) {
+    await sleep(confirmIntervalMs);
+    findings = evaluateFleetSnapshot(config, listContainers(), opts);
+  }
+
+  if (!hasFatal(findings) && sawFatal) {
+    // A crash-looping container reads "Up 1 second" between restarts, so
+    // "a later sample was clean" is NOT evidence of health — it is exactly
+    // what a flap looks like. Don't hard-fail (that's the M4 false
+    // positive), but never print green over it either: downgrade to
+    // pending and say what we saw.
+    findings = findings.map((f) =>
+      f.status === "ok" ? { ...f, status: "pending" as VerifyStatus } : f,
+    );
+    findings.push({
+      name: "runtime stability",
+      status: "pending",
+      detail:
+        "at least one switchroom container was restarting or stuck during " +
+        "this check, then recovered — not treated as a failure (containers " +
+        "run with `restart: always`), but not verified either",
+      fix: "Confirm with `switchroom doctor` once the fleet has settled.",
+    });
+  }
+  return findings;
+}
+
+/** One `docker ps` snapshot → findings. Pure; no clock, no I/O. */
+function evaluateFleetSnapshot(
+  config: SwitchroomConfig,
+  rows: ContainerRow[] | null,
+  opts: FleetVerifyOptions,
+): VerifyFinding[] {
+  const dockerRequired = opts.dockerRequired ?? true;
 
   if (rows === null) {
     return [
       {
         name: "docker runtime",
-        status: "fail",
-        detail: "docker is not reachable — `docker ps` failed",
+        status: dockerRequired ? "fail" : "pending",
+        detail: dockerRequired
+          ? "docker is not reachable — `docker ps` failed"
+          : "docker is not reachable — nothing container-backed was verified " +
+            "(memory backend is disabled, so setup did not need it)",
         fix: DOCKER_UNAVAILABLE_FIX,
+        code: DOCKER_UNAVAILABLE_CODE,
       },
     ];
   }
@@ -245,23 +396,62 @@ export function verifyFleetContainers(
   }
 
   // Hindsight is started by step 6 of this same wizard, so a crash-looping
-  // memory container is something setup itself caused and must own. Absent
-  // is fine (memory backend `none`, or an older install).
+  // memory container is something setup itself caused and must own.
+  //
+  // Review H2: "absent is fine" unconditionally meant that when step 6's
+  // silent-return paths (port preflight, `startHindsight` throw) left NO
+  // container behind, step 13 saw nothing to complain about and the wizard
+  // still printed "Setup complete! Your agents are running." — the exact
+  // lie this PR exists to remove. Those returns are now throws, and when
+  // step 6 reports it started/found hindsight, step 13 holds it to that.
+  const hindsightExpected = opts.hindsightExpected ?? false;
   const hindsight = rows.find((r) => r.name === "switchroom-hindsight");
-  if (hindsight) {
+  const HINDSIGHT_LOGS_FIX = "docker logs switchroom-hindsight --tail 50";
+  if (!hindsight) {
+    if (hindsightExpected) {
+      out.push({
+        name: "hindsight memory",
+        status: "fail",
+        detail:
+          "memory setup reported success but there is no switchroom-hindsight container",
+        fix: "Re-run `switchroom memory setup` and read its output.",
+      });
+    }
+    // Not expected + absent: nothing to say (backend `none`, opted out, or
+    // an older install).
+  } else {
     const h = classifyContainerStatus(hindsight.status);
     if (h === "restarting" || h === "created") {
       out.push({
         name: "hindsight memory",
         status: "fail",
         detail: `switchroom-hindsight is ${h === "restarting" ? "crash-looping" : "stuck in Created"}`,
-        fix: "docker logs switchroom-hindsight --tail 50",
+        fix: HINDSIGHT_LOGS_FIX,
       });
-    } else if (h === "exited") {
+    } else if (h === "running-unhealthy") {
+      // M6: the hindsight healthcheck exists to make a wedged API visible.
+      // Treating "Up (unhealthy)" as running verified a dead backend green.
+      out.push({
+        name: "hindsight memory",
+        status: "fail",
+        detail:
+          "switchroom-hindsight is running but its healthcheck is failing " +
+          "(the memory API is not answering)",
+        fix: HINDSIGHT_LOGS_FIX,
+      });
+    } else if (h === "running-starting") {
+      // Normal for the first ~60s after start (--health-start-period 60s).
       out.push({
         name: "hindsight memory",
         status: "pending",
-        detail: "switchroom-hindsight is not running",
+        detail: "switchroom-hindsight is still starting (healthcheck not settled)",
+        fix: "Re-check with `switchroom doctor` in a minute.",
+      });
+    } else if (!isUp(h)) {
+      out.push({
+        name: "hindsight memory",
+        status: hindsightExpected ? "fail" : "pending",
+        detail: `switchroom-hindsight is not running (docker state: ${describeHealth(h)})`,
         fix: "Restart it with `switchroom memory setup`, or `docker start switchroom-hindsight`.",
       });
     }
@@ -297,11 +487,34 @@ export function verifyFleetContainers(
     status: "pending",
     detail:
       `${running.length}/${agents.length} agent container(s) running — ` +
-      `not up: ${notUp.join(", ")}`,
+      `not up: ${notUp
+        .map((a) => `${a} (${describeHealth(agentContainerHealth(a, rows))})`)
+        .join(", ")}`,
     fix:
       "The fleet is not running yet. Next: `switchroom apply` then " +
       "`docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d`",
   });
+  return out;
+}
+
+/**
+ * Collapse findings that several probes produced for the same underlying
+ * fact, keyed on {@link VerifyFinding.code} (review L9: a docker-less host
+ * got the same "docker is not reachable" row twice — once from the agent
+ * poller, once from the fleet check). Findings without a `code` are always
+ * kept; the first occurrence wins so the earliest, most specific wording
+ * survives.
+ */
+export function dedupeFindings(findings: VerifyFinding[]): VerifyFinding[] {
+  const seen = new Set<string>();
+  const out: VerifyFinding[] = [];
+  for (const f of findings) {
+    if (f.code) {
+      if (seen.has(f.code)) continue;
+      seen.add(f.code);
+    }
+    out.push(f);
+  }
   return out;
 }
 

--- a/src/setup/verify.ts
+++ b/src/setup/verify.ts
@@ -1,0 +1,326 @@
+/**
+ * Setup-wizard verification primitives (install-path review H7).
+ *
+ * The wizard's final step used to print `OK Verification steps ready`
+ * unconditionally, and swallowed the optional `agent start` failure in a
+ * bare `catch {}`. On a host where nothing could possibly run, setup still
+ * reported success — which made every other install failure silent.
+ *
+ * These helpers give that step something real to assert:
+ *
+ *   - `waitForAgentContainerUp` — after we asked docker to start an agent,
+ *     poll `docker ps` until the container is genuinely up AND has *stayed*
+ *     up across consecutive samples (a crash-looping container is "Up" for
+ *     a moment, then "Restarting"). Any terminal state (exited / restarting)
+ *     fails immediately; a timeout fails with the last observed state.
+ *   - `verifyFleetContainers` — reuse doctor's `checkContainerRuntimeHealth`
+ *     (the 2026-06-23 stuck/crash-loop signature) rather than inventing a
+ *     parallel health surface, and translate its rows into setup findings.
+ *
+ * Design constraints that shaped the statuses:
+ *
+ *   - `switchroom setup` runs BEFORE `switchroom apply` and before the
+ *     fleet is brought up (docs/install.md Step 3 vs Step 5). So "no agent
+ *     containers exist yet" is the normal first-install state — it reports
+ *     `pending` (honest, no green claim, exit 0), never a fake OK.
+ *   - Anything we actually *attempted* in this run and that did not work is
+ *     `fail`, which the wizard turns into a non-zero exit.
+ *   - A pre-existing container that the operator deliberately stopped is
+ *     `pending`, not `fail` — matching doctor, which only flags
+ *     created/restarting as broken.
+ *
+ * Everything is dependency-injected (docker probe + sleep) so tests assert
+ * the failure paths without docker and without wall-clock waits.
+ */
+
+import {
+  classifyContainerStatus,
+  checkContainerRuntimeHealth,
+  listSwitchroomContainers,
+  type ContainerHealth,
+  type ContainerRow,
+} from "../cli/doctor-docker.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+/**
+ * `fail` is fatal (wizard exits non-zero). `pending` is an honest "not
+ * verified / not up yet" — printed in yellow, never as a green OK.
+ */
+export type VerifyStatus = "ok" | "pending" | "fail";
+
+export interface VerifyFinding {
+  name: string;
+  status: VerifyStatus;
+  detail: string;
+  /** Operator-actionable next step; printed under a pending/fail row. */
+  fix?: string;
+}
+
+export interface VerifyDeps {
+  /**
+   * `docker ps -a --filter name=switchroom-` rows, or null when docker is
+   * unavailable / errored. Defaults to the real docker probe doctor uses.
+   */
+  listContainers?: () => ContainerRow[] | null;
+  /** Injected in tests so polling costs no wall-clock time. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** How long we wait for a just-started agent container to settle. */
+export const AGENT_UP_TIMEOUT_MS = 30_000;
+/**
+ * Gap between `docker ps` samples while waiting. Wide enough that
+ * AGENT_STABLE_SAMPLES spans several seconds — a container that restarts
+ * every second cannot fake stability across the window.
+ */
+export const AGENT_POLL_INTERVAL_MS = 2_000;
+/**
+ * Consecutive "Up" samples required before we call a start verified. A
+ * crash-looping container shows "Up 1 second" between restarts, so a single
+ * sample is not evidence that it *stayed* up.
+ */
+export const AGENT_STABLE_SAMPLES = 3;
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/** Container name for an agent — mirrors compose's `container_name:`. */
+export function agentContainerName(agent: string): string {
+  return `switchroom-${agent}`;
+}
+
+/**
+ * Health of one agent's container from a `docker ps -a` row set.
+ * `absent` = no container with that name at all.
+ */
+export function agentContainerHealth(
+  agent: string,
+  rows: ContainerRow[],
+): ContainerHealth | "absent" {
+  const want = agentContainerName(agent);
+  const row = rows.find((r) => r.name === want);
+  if (!row) return "absent";
+  return classifyContainerStatus(row.status);
+}
+
+function isUp(h: ContainerHealth | "absent"): boolean {
+  return h === "running-healthy" || h === "running-no-healthcheck";
+}
+
+const DOCKER_UNAVAILABLE_FIX =
+  "Install/start Docker (the fleet runs as containers), then re-run `switchroom setup`.";
+
+/**
+ * Poll until the agent container is up and has stayed up.
+ *
+ * Called ONLY after a start was actually attempted, so every non-up
+ * outcome here is a real failure — including "container never appeared".
+ */
+export async function waitForAgentContainerUp(
+  agent: string,
+  deps: VerifyDeps = {},
+  opts: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    stableSamples?: number;
+  } = {},
+): Promise<VerifyFinding> {
+  const listContainers = deps.listContainers ?? listSwitchroomContainers;
+  const sleep = deps.sleep ?? defaultSleep;
+  const timeoutMs = opts.timeoutMs ?? AGENT_UP_TIMEOUT_MS;
+  const intervalMs = opts.intervalMs ?? AGENT_POLL_INTERVAL_MS;
+  const stableSamples = opts.stableSamples ?? AGENT_STABLE_SAMPLES;
+
+  const name = `${agent}: container up`;
+  const container = agentContainerName(agent);
+  // Poll-count rather than wall-clock so the loop is deterministic under
+  // an injected no-op sleep.
+  const maxSamples = Math.max(1, Math.ceil(timeoutMs / Math.max(1, intervalMs)));
+
+  let stable = 0;
+  let last: ContainerHealth | "absent" | "docker-unavailable" = "absent";
+
+  for (let i = 0; i < maxSamples; i++) {
+    const rows = listContainers();
+    if (rows === null) {
+      return {
+        name,
+        status: "fail",
+        detail: `docker ps is unavailable, so ${container} cannot be verified`,
+        fix: DOCKER_UNAVAILABLE_FIX,
+      };
+    }
+    const health = agentContainerHealth(agent, rows);
+    last = health;
+
+    if (health === "restarting") {
+      return {
+        name,
+        status: "fail",
+        detail: `${container} is crash-looping (docker status: Restarting)`,
+        fix: `docker logs ${container} --tail 50`,
+      };
+    }
+    if (health === "exited") {
+      return {
+        name,
+        status: "fail",
+        detail: `${container} started and then exited`,
+        fix: `docker logs ${container} --tail 50`,
+      };
+    }
+    if (isUp(health)) {
+      stable++;
+      if (stable >= stableSamples) {
+        return {
+          name,
+          status: "ok",
+          detail:
+            `${container} is up and stayed up across ${stable} checks` +
+            (health === "running-healthy" ? " (healthcheck: healthy)" : ""),
+        };
+      }
+    } else {
+      // absent / created / other — still coming up; don't credit stability.
+      stable = 0;
+    }
+
+    if (i < maxSamples - 1) await sleep(intervalMs);
+  }
+
+  const lastDesc = last === "absent" ? "no such container" : last;
+  return {
+    name,
+    status: "fail",
+    detail:
+      `${container} did not reach a stable running state within ` +
+      `${Math.round(timeoutMs / 1000)}s (last docker state: ${lastDesc})`,
+    fix: `docker logs ${container} --tail 50`,
+  };
+}
+
+/**
+ * Fleet-level runtime verification, reusing doctor's runtime health check.
+ *
+ * Returns:
+ *   - a `fail` when docker is unreachable (nothing in the fleet can run),
+ *   - a `fail` for doctor's stuck/crash-loop signature,
+ *   - a `pending` when no agent container exists yet (the normal state
+ *     right after a first-install `setup`, which runs before `apply`),
+ *   - `ok` otherwise.
+ */
+export function verifyFleetContainers(
+  config: SwitchroomConfig,
+  deps: VerifyDeps = {},
+): VerifyFinding[] {
+  const listContainers = deps.listContainers ?? listSwitchroomContainers;
+  const rows = listContainers();
+
+  if (rows === null) {
+    return [
+      {
+        name: "docker runtime",
+        status: "fail",
+        detail: "docker is not reachable — `docker ps` failed",
+        fix: DOCKER_UNAVAILABLE_FIX,
+      },
+    ];
+  }
+
+  const out: VerifyFinding[] = [];
+
+  // Reuse doctor's check verbatim so setup and `switchroom doctor` can
+  // never disagree about what "the fleet is stuck" means.
+  for (const row of checkContainerRuntimeHealth(config, {
+    listContainers: () => rows,
+  })) {
+    if (row.status === "fail") {
+      out.push({
+        name: row.name,
+        status: "fail",
+        detail: row.detail ?? "container runtime health check failed",
+        fix: row.fix,
+      });
+    }
+  }
+
+  // Hindsight is started by step 6 of this same wizard, so a crash-looping
+  // memory container is something setup itself caused and must own. Absent
+  // is fine (memory backend `none`, or an older install).
+  const hindsight = rows.find((r) => r.name === "switchroom-hindsight");
+  if (hindsight) {
+    const h = classifyContainerStatus(hindsight.status);
+    if (h === "restarting" || h === "created") {
+      out.push({
+        name: "hindsight memory",
+        status: "fail",
+        detail: `switchroom-hindsight is ${h === "restarting" ? "crash-looping" : "stuck in Created"}`,
+        fix: "docker logs switchroom-hindsight --tail 50",
+      });
+    } else if (h === "exited") {
+      out.push({
+        name: "hindsight memory",
+        status: "pending",
+        detail: "switchroom-hindsight is not running",
+        fix: "Restart it with `switchroom memory setup`, or `docker start switchroom-hindsight`.",
+      });
+    }
+  }
+
+  const agents = Object.keys(config.agents ?? {});
+  if (agents.length === 0) {
+    out.push({
+      name: "agent containers",
+      status: "pending",
+      detail: "no agents configured yet — nothing to verify",
+      fix: "Add an agent to switchroom.yaml, then `switchroom apply`.",
+    });
+    return out;
+  }
+
+  const running = agents.filter((a) => isUp(agentContainerHealth(a, rows)));
+  // Everything not demonstrably up, whatever its docker state — so an
+  // unexpected state (paused/dead) is named rather than silently dropped.
+  const notUp = agents.filter((a) => !isUp(agentContainerHealth(a, rows)));
+
+  if (running.length === agents.length) {
+    out.push({
+      name: "agent containers",
+      status: "ok",
+      detail: `${running.length}/${agents.length} agent container(s) running`,
+    });
+    return out;
+  }
+
+  out.push({
+    name: "agent containers",
+    status: "pending",
+    detail:
+      `${running.length}/${agents.length} agent container(s) running — ` +
+      `not up: ${notUp.join(", ")}`,
+    fix:
+      "The fleet is not running yet. Next: `switchroom apply` then " +
+      "`docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d`",
+  });
+  return out;
+}
+
+/** True when any finding is fatal. */
+export function hasFatal(findings: VerifyFinding[]): boolean {
+  return findings.some((f) => f.status === "fail");
+}
+
+/** Error thrown by the wizard when verification finds a fatal problem. */
+export class SetupVerificationError extends Error {
+  readonly findings: VerifyFinding[];
+  constructor(findings: VerifyFinding[]) {
+    const failed = findings.filter((f) => f.status === "fail");
+    super(
+      `verification failed: ${failed
+        .map((f) => `${f.name} — ${f.detail}`)
+        .join("; ")}`,
+    );
+    this.name = "SetupVerificationError";
+    this.findings = findings;
+  }
+}

--- a/tests/cli.agent-start-exit-code.test.ts
+++ b/tests/cli.agent-start-exit-code.test.ts
@@ -1,0 +1,136 @@
+/**
+ * `switchroom agent start <name>` must report failure in its EXIT CODE.
+ *
+ * Setup-verification review H3: every realistic failure in this command —
+ * an agent not defined in switchroom.yaml, a quarantined agent, preflight
+ * errors, a `startAgent()` throw — printed red and then exited 0. Two
+ * consequences:
+ *
+ *   1. `switchroom agent start x && <next step>` sailed on over a dead agent.
+ *   2. `switchroom setup`'s start seam shells out to this command, so the
+ *      only failure it could ever observe was ENOENT (no binary). Every
+ *      real failure degraded into a container-never-came-up timeout with
+ *      misleading `docker logs` guidance.
+ *
+ * These tests assert the OUTCOME (exit code), not that the code path ran.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const mocks = vi.hoisted(() => ({
+  startAgent: vi.fn(),
+}));
+
+// The success path polls the agent's readiness for up to 30s against a
+// container that does not exist here. Short-circuit it.
+vi.mock("../src/agents/status.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agents/status.js")>();
+  return {
+    ...actual,
+    waitForAgentReady: vi.fn(async () => ({
+      ready: true,
+      elapsedMs: 0,
+      notReady: [],
+    })),
+  };
+});
+
+// The lifecycle layer shells out to docker; stub the one verb we drive.
+vi.mock("../src/agents/lifecycle.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agents/lifecycle.js")>();
+  return { ...actual, startAgent: mocks.startAgent };
+});
+
+vi.mock("../src/analytics/posthog.js", () => ({
+  captureEvent: vi.fn(),
+  installGlobalErrorHandlers: vi.fn(),
+}));
+
+import { Command } from "commander";
+import { registerAgentCommand } from "../src/cli/agent.js";
+
+function buildProgram(configPath: string): Command {
+  const program = new Command()
+    .name("switchroom")
+    .option("-c, --config <path>", "Path to switchroom.yaml");
+  registerAgentCommand(program);
+  program.setOptionValue("config", configPath);
+  return program;
+}
+
+describe("switchroom agent start — exit code (review H3)", () => {
+  let tmpDir: string;
+  let configPath: string;
+  let priorExitCode: number | string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "sr-agent-start-"));
+    mkdirSync(join(tmpDir, "agents"), { recursive: true });
+    configPath = join(tmpDir, "switchroom.yaml");
+    writeFileSync(
+      configPath,
+      [
+        "switchroom:",
+        "  version: 1",
+        `  agents_dir: ${join(tmpDir, "agents")}`,
+        "telegram:",
+        '  bot_token: "test:token"',
+        '  forum_chat_id: "0"',
+        "agents:",
+        "  alpha:",
+        "    topic_name: alpha",
+        "",
+      ].join("\n"),
+    );
+    priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    mocks.startAgent.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = priorExitCode;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("exits NON-ZERO for an agent that is not in switchroom.yaml", async () => {
+    await buildProgram(configPath).parseAsync(["agent", "start", "ghost"], {
+      from: "user",
+    });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("exits NON-ZERO when preflight fails (unscaffolded agent dir)", async () => {
+    // `agents/alpha` has no scaffold at all, so preflightCheck reports
+    // errors and the command `continue`s — previously exit 0.
+    await buildProgram(configPath).parseAsync(["agent", "start", "alpha"], {
+      from: "user",
+    });
+    expect(process.exitCode).toBe(1);
+    expect(mocks.startAgent).not.toHaveBeenCalled();
+  });
+
+  it("exits NON-ZERO when startAgent() throws", async () => {
+    mocks.startAgent.mockImplementation(() => {
+      throw new Error("no configuration file provided: not found");
+    });
+    await buildProgram(configPath).parseAsync(
+      ["agent", "start", "alpha", "--force"],
+      { from: "user" },
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("leaves the exit code alone on a successful start", async () => {
+    mocks.startAgent.mockImplementation(() => {});
+    await buildProgram(configPath).parseAsync(
+      ["agent", "start", "alpha", "--force"],
+      { from: "user" },
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/tests/setup-verification.test.ts
+++ b/tests/setup-verification.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Setup-wizard verification tests (install-path review H7).
+ *
+ * The bug these pin: the wizard's final step printed a green
+ * `OK Verification steps ready` unconditionally and swallowed the
+ * `agent start` failure in a bare `catch {}`, so `switchroom setup`
+ * reported success with nothing running. A happy-path test would not
+ * have caught that — every assertion here is about a FAILURE producing a
+ * failure (thrown error / non-zero exit / no green claim).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// setup.ts statically imports vault-broker.js → broker/server.ts →
+// grants-db.ts → bun:sqlite, which vitest cannot resolve. Same mocks as
+// tests/setup.test.ts.
+vi.mock("../src/vault/vault.js", () => ({
+  openVault: vi.fn(),
+  createVault: vi.fn(),
+  setStringSecret: vi.fn(),
+  getStringSecret: vi.fn(() => null),
+}));
+vi.mock("../src/vault/grants-db.ts", () => ({}));
+vi.mock("../src/vault/broker/server.js", () => ({
+  VaultBroker: vi.fn(),
+  registerShutdownHandlers: vi.fn(),
+}));
+
+import {
+  waitForAgentContainerUp,
+  verifyFleetContainers,
+  agentContainerHealth,
+  hasFatal,
+  SetupVerificationError,
+} from "../src/setup/verify.js";
+import {
+  stepVerification,
+  stepMemoryBackend,
+  reportSetupFailure,
+} from "../src/cli/setup.js";
+import type { ContainerRow } from "../src/cli/doctor-docker.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+const noSleep = async (): Promise<void> => {};
+
+/** Minimal config with one agent named `alpha`. */
+function configWithAgent(name = "alpha"): SwitchroomConfig {
+  return {
+    agents: {
+      [name]: { topic_name: `${name}-topic` },
+    },
+  } as unknown as SwitchroomConfig;
+}
+
+/** A `docker ps` stub that plays a scripted sequence, repeating the last. */
+function scripted(frames: (ContainerRow[] | null)[]): () => ContainerRow[] | null {
+  let i = 0;
+  return () => {
+    const frame = frames[Math.min(i, frames.length - 1)];
+    i++;
+    return frame;
+  };
+}
+
+const up = (name: string): ContainerRow[] => [
+  { name: `switchroom-${name}`, status: "Up 5 seconds" },
+];
+
+// ─── waitForAgentContainerUp ─────────────────────────────────────────────────
+
+describe("waitForAgentContainerUp", () => {
+  const opts = { timeoutMs: 5000, intervalMs: 1000, stableSamples: 3 };
+
+  it("FAILS when the container died right after start", async () => {
+    const f = await waitForAgentContainerUp(
+      "alpha",
+      { listContainers: scripted([[{ name: "switchroom-alpha", status: "Exited (1) 2 seconds ago" }]]), sleep: noSleep },
+      opts,
+    );
+    expect(f.status).toBe("fail");
+    expect(f.detail).toContain("switchroom-alpha");
+    expect(f.detail).toMatch(/exited/i);
+    expect(f.fix).toContain("docker logs switchroom-alpha");
+  });
+
+  it("FAILS on a crash-looping container even after one healthy-looking sample", async () => {
+    const f = await waitForAgentContainerUp(
+      "alpha",
+      {
+        listContainers: scripted([
+          up("alpha"),
+          up("alpha"),
+          [{ name: "switchroom-alpha", status: "Restarting (1) 3 seconds ago" }],
+        ]),
+        sleep: noSleep,
+      },
+      opts,
+    );
+    expect(f.status).toBe("fail");
+    expect(f.detail).toMatch(/crash-looping/i);
+  });
+
+  it("FAILS when the container never appears within the timeout", async () => {
+    const f = await waitForAgentContainerUp(
+      "alpha",
+      { listContainers: scripted([[]]), sleep: noSleep },
+      opts,
+    );
+    expect(f.status).toBe("fail");
+    expect(f.detail).toMatch(/did not reach a stable running state/);
+    expect(f.detail).toContain("no such container");
+  });
+
+  it("FAILS when docker itself is unreachable", async () => {
+    const f = await waitForAgentContainerUp(
+      "alpha",
+      { listContainers: () => null, sleep: noSleep },
+      opts,
+    );
+    expect(f.status).toBe("fail");
+    expect(f.detail).toMatch(/docker ps is unavailable/);
+  });
+
+  it("FAILS when the container is stuck in Created for the whole window", async () => {
+    const f = await waitForAgentContainerUp(
+      "alpha",
+      { listContainers: scripted([[{ name: "switchroom-alpha", status: "Created" }]]), sleep: noSleep },
+      opts,
+    );
+    expect(f.status).toBe("fail");
+    expect(f.detail).toContain("created");
+  });
+
+  it("passes only after the container has STAYED up across samples", async () => {
+    let calls = 0;
+    const f = await waitForAgentContainerUp(
+      "alpha",
+      {
+        listContainers: () => {
+          calls++;
+          return up("alpha");
+        },
+        sleep: noSleep,
+      },
+      opts,
+    );
+    expect(f.status).toBe("ok");
+    expect(calls).toBe(3); // stableSamples, not a single lucky read
+  });
+
+  it("reports the healthcheck when one exists", async () => {
+    const f = await waitForAgentContainerUp(
+      "alpha",
+      {
+        listContainers: () => [
+          { name: "switchroom-alpha", status: "Up 2 minutes (healthy)" },
+        ],
+        sleep: noSleep,
+      },
+      { ...opts, stableSamples: 1 },
+    );
+    expect(f.status).toBe("ok");
+    expect(f.detail).toContain("healthcheck: healthy");
+  });
+});
+
+// ─── agentContainerHealth ────────────────────────────────────────────────────
+
+describe("agentContainerHealth", () => {
+  it("reports absent when no container matches", () => {
+    expect(agentContainerHealth("alpha", [{ name: "switchroom-beta", status: "Up 1 hour" }]))
+      .toBe("absent");
+  });
+
+  it("does not match on a name prefix collision", () => {
+    expect(
+      agentContainerHealth("alpha", [
+        { name: "switchroom-alpha-sidecar", status: "Up 1 hour" },
+      ]),
+    ).toBe("absent");
+  });
+});
+
+// ─── verifyFleetContainers ───────────────────────────────────────────────────
+
+describe("verifyFleetContainers", () => {
+  it("FAILS when docker is unreachable", () => {
+    const findings = verifyFleetContainers(configWithAgent(), {
+      listContainers: () => null,
+    });
+    expect(hasFatal(findings)).toBe(true);
+    expect(findings[0].detail).toMatch(/docker is not reachable/);
+  });
+
+  it("FAILS on doctor's stuck/crash-loop signature", () => {
+    const findings = verifyFleetContainers(configWithAgent(), {
+      listContainers: () => [
+        { name: "switchroom-alpha", status: "Created" },
+        { name: "switchroom-vault-broker", status: "Restarting (1) 2 seconds ago" },
+      ],
+    });
+    expect(hasFatal(findings)).toBe(true);
+    expect(findings.map((f) => f.detail).join(" ")).toMatch(/stuck\/crash-looping/);
+  });
+
+  it("reports PENDING (never ok) when no agent container exists yet", () => {
+    const findings = verifyFleetContainers(configWithAgent(), {
+      listContainers: () => [],
+    });
+    expect(hasFatal(findings)).toBe(false);
+    const agentRow = findings.find((f) => f.name === "agent containers");
+    expect(agentRow?.status).toBe("pending");
+    expect(agentRow?.detail).toContain("0/1");
+  });
+
+  it("reports PENDING for a stopped (deliberately) agent, not a hard fail", () => {
+    const findings = verifyFleetContainers(configWithAgent(), {
+      listContainers: () => [
+        { name: "switchroom-alpha", status: "Exited (0) 3 hours ago" },
+      ],
+    });
+    expect(hasFatal(findings)).toBe(false);
+    expect(findings.find((f) => f.name === "agent containers")?.status).toBe("pending");
+  });
+
+  it("FAILS when the hindsight container setup just started is crash-looping", () => {
+    const findings = verifyFleetContainers(configWithAgent(), {
+      listContainers: () => [
+        ...up("alpha"),
+        { name: "switchroom-hindsight", status: "Restarting (1) 4 seconds ago" },
+      ],
+    });
+    expect(hasFatal(findings)).toBe(true);
+    expect(findings.find((f) => f.name === "hindsight memory")?.detail).toMatch(
+      /crash-looping/,
+    );
+  });
+
+  it("does not invent a hindsight row when there is no hindsight container", () => {
+    const findings = verifyFleetContainers(configWithAgent(), {
+      listContainers: () => up("alpha"),
+    });
+    expect(findings.find((f) => f.name === "hindsight memory")).toBeUndefined();
+  });
+
+  it("names an agent in an unexpected docker state instead of dropping it", () => {
+    const findings = verifyFleetContainers(configWithAgent(), {
+      listContainers: () => [{ name: "switchroom-alpha", status: "Paused" }],
+    });
+    const row = findings.find((f) => f.name === "agent containers");
+    expect(row?.status).toBe("pending");
+    expect(row?.detail).toContain("not up: alpha");
+  });
+
+  it("reports ok when every configured agent is up", () => {
+    const findings = verifyFleetContainers(configWithAgent(), {
+      listContainers: () => up("alpha"),
+    });
+    expect(findings.find((f) => f.name === "agent containers")?.status).toBe("ok");
+    expect(hasFatal(findings)).toBe(false);
+  });
+});
+
+// ─── stepVerification ────────────────────────────────────────────────────────
+
+describe("stepVerification", () => {
+  function capture(): { lines: string[]; log: (l: string) => void; text: () => string } {
+    const lines: string[] = [];
+    return {
+      lines,
+      log: (l: string) => lines.push(l),
+      text: () => lines.join("\n"),
+    };
+  }
+
+  it("THROWS with the real error when `agent start` fails (was a bare catch {})", async () => {
+    const out = capture();
+    await expect(
+      stepVerification(configWithAgent(), false, {
+        log: out.log,
+        sleep: noSleep,
+        confirmStart: async () => true,
+        startAgent: () => {
+          throw new Error("spawn switchroom ENOENT");
+        },
+        listContainers: () => [],
+      }),
+    ).rejects.toBeInstanceOf(SetupVerificationError);
+    expect(out.text()).toContain("spawn switchroom ENOENT");
+    expect(out.text()).toContain("Verification FAILED");
+    expect(out.text()).not.toContain("Verification steps ready");
+  });
+
+  it("THROWS when the agent was started but never came up", async () => {
+    const out = capture();
+    await expect(
+      stepVerification(configWithAgent(), false, {
+        log: out.log,
+        sleep: noSleep,
+        timeoutMs: 3000,
+        intervalMs: 1000,
+        confirmStart: async () => true,
+        startAgent: () => {},
+        // start "succeeded" but the container is nowhere — the exact shape
+        // of the bug: a green success over a dead agent.
+        listContainers: () => [],
+      }),
+    ).rejects.toBeInstanceOf(SetupVerificationError);
+    expect(out.text()).toMatch(/did not reach a stable running state/);
+  });
+
+  it("THROWS when the started agent crash-loops", async () => {
+    const out = capture();
+    await expect(
+      stepVerification(configWithAgent(), false, {
+        log: out.log,
+        sleep: noSleep,
+        confirmStart: async () => true,
+        startAgent: () => {},
+        listContainers: () => [
+          { name: "switchroom-alpha", status: "Restarting (1) 1 second ago" },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(SetupVerificationError);
+  });
+
+  it("THROWS when docker is unreachable, even with nothing started", async () => {
+    const out = capture();
+    await expect(
+      stepVerification(configWithAgent(), true, {
+        log: out.log,
+        sleep: noSleep,
+        listContainers: () => null,
+      }),
+    ).rejects.toBeInstanceOf(SetupVerificationError);
+    expect(out.text()).toMatch(/docker is not reachable/);
+  });
+
+  it("returns PENDING (not a green claim) on a fresh install with no containers", async () => {
+    const out = capture();
+    const verdict = await stepVerification(configWithAgent(), true, {
+      log: out.log,
+      sleep: noSleep,
+      listContainers: () => [],
+    });
+    expect(verdict).toBe("pending");
+    expect(out.text()).not.toContain("Verified: the fleet is running");
+    expect(out.text()).toContain("switchroom apply");
+  });
+
+  it("returns verified only when the started container stays up", async () => {
+    const out = capture();
+    const verdict = await stepVerification(configWithAgent(), false, {
+      log: out.log,
+      sleep: noSleep,
+      stableSamples: 2,
+      confirmStart: async () => true,
+      startAgent: () => {},
+      listContainers: () => up("alpha"),
+    });
+    expect(verdict).toBe("verified");
+    expect(out.text()).toContain("Verified: the fleet is running");
+  });
+
+  it("never starts anything (and never claims to) in non-interactive mode", async () => {
+    const out = capture();
+    const startAgent = vi.fn();
+    await stepVerification(configWithAgent(), true, {
+      log: out.log,
+      sleep: noSleep,
+      startAgent,
+      listContainers: () => [],
+    });
+    expect(startAgent).not.toHaveBeenCalled();
+  });
+});
+
+// ─── exit contract ───────────────────────────────────────────────────────────
+
+describe("reportSetupFailure", () => {
+  it("returns a NON-ZERO exit code for a verification failure", () => {
+    const lines: string[] = [];
+    const code = reportSetupFailure(
+      new SetupVerificationError([
+        { name: "alpha: container up", status: "fail", detail: "died" },
+      ]),
+      (l) => lines.push(l),
+    );
+    expect(code).not.toBe(0);
+    expect(lines.join("\n")).toMatch(/Setup did NOT complete/);
+  });
+
+  it("returns a NON-ZERO exit code for any other setup error", () => {
+    expect(reportSetupFailure(new Error("boom"), () => {})).not.toBe(0);
+  });
+});
+
+// ─── stepMemoryBackend: Docker absent ────────────────────────────────────────
+
+describe("stepMemoryBackend (Docker absent)", () => {
+  let dir: string;
+  let cfgPath: string;
+  let logs: string[];
+  let origLog: typeof console.log;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-setup-mem-"));
+    cfgPath = join(dir, "switchroom.yaml");
+    writeFileSync(
+      cfgPath,
+      ["telegram:", '  forum_chat_id: "0"', "agents:", "  alpha:", "    topic_name: alpha", ""].join("\n"),
+    );
+    for (const k of ["SWITCHROOM_MEMORY_BACKEND", "SWITCHROOM_VAULT_PASSPHRASE", "HINDSIGHT_API_LLM_API_KEY"]) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    logs = [];
+    origLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("THROWS instead of printing a green OK when Docker is missing", async () => {
+    // Probe returns null for every docker invocation → docker absent.
+    await expect(
+      stepMemoryBackend(configWithAgent(), true, cfgPath, {
+        dockerProbe: () => null,
+      }),
+    ).rejects.toThrow(/Docker is not available/);
+
+    const text = logs.join("\n");
+    expect(text).not.toContain("Manual setup pending");
+    // The old code printed a green OK on this exact path.
+    expect(text).toMatch(/Docker is not available/);
+    expect(text).toMatch(/SWITCHROOM_MEMORY_BACKEND=none/);
+  });
+
+  it("still honours the documented opt-out without touching Docker", async () => {
+    process.env.SWITCHROOM_MEMORY_BACKEND = "none";
+    const probe = vi.fn(() => null);
+    await expect(
+      stepMemoryBackend(configWithAgent(), true, cfgPath, { dockerProbe: probe }),
+    ).resolves.toBeUndefined();
+    expect(probe).not.toHaveBeenCalled();
+  });
+});

--- a/tests/setup-verification.test.ts
+++ b/tests/setup-verification.test.ts
@@ -33,7 +33,11 @@ import {
   waitForAgentContainerUp,
   verifyFleetContainers,
   agentContainerHealth,
+  dedupeFindings,
   hasFatal,
+  AGENT_STABLE_SAMPLES,
+  AGENT_STABLE_WINDOW_MS,
+  AGENT_POLL_INTERVAL_MS,
   SetupVerificationError,
 } from "../src/setup/verify.js";
 import {
@@ -41,6 +45,7 @@ import {
   stepMemoryBackend,
   reportSetupFailure,
 } from "../src/cli/setup.js";
+import { classifyContainerStatus } from "../src/cli/doctor-docker.js";
 import type { ContainerRow } from "../src/cli/doctor-docker.js";
 import type { SwitchroomConfig } from "../src/config/schema.js";
 
@@ -134,21 +139,79 @@ describe("waitForAgentContainerUp", () => {
     expect(f.detail).toContain("created");
   });
 
-  it("passes only after the container has STAYED up across samples", async () => {
-    let calls = 0;
+  it("only says ok after watching for at least the stability WINDOW", async () => {
+    // PROPERTY, not a call count (review M5): an `ok` verdict must mean the
+    // container was observed up across a window of wall-clock time, so a
+    // container that dies inside that window cannot pass.
+    let elapsedMs = 0;
     const f = await waitForAgentContainerUp(
       "alpha",
       {
-        listContainers: () => {
-          calls++;
-          return up("alpha");
+        listContainers: () => up("alpha"),
+        sleep: async (ms: number) => {
+          elapsedMs += ms;
         },
+      },
+      // defaults: real window/interval/samples
+      {},
+    );
+    expect(f.status).toBe("ok");
+    expect(elapsedMs).toBeGreaterThanOrEqual(AGENT_STABLE_WINDOW_MS);
+  });
+
+  it("the default sample count really spans the documented window", () => {
+    // Guards the constants against drifting apart: N samples span
+    // (N-1) intervals.
+    expect((AGENT_STABLE_SAMPLES - 1) * AGENT_POLL_INTERVAL_MS)
+      .toBeGreaterThanOrEqual(AGENT_STABLE_WINDOW_MS);
+  });
+
+  it("FAILS on an agent whose start.sh dies ~9s in (the real failure mode)", async () => {
+    // The bug M5 pins: with a ~4s window this container passed. It must not.
+    let virtualMs = 0;
+    const f = await waitForAgentContainerUp(
+      "alpha",
+      {
+        listContainers: () =>
+          virtualMs < 9_000
+            ? up("alpha")
+            : [{ name: "switchroom-alpha", status: "Exited (1) 1 second ago" }],
+        sleep: async (ms: number) => {
+          virtualMs += ms;
+        },
+      },
+      {},
+    );
+    expect(f.status).toBe("fail");
+    expect(f.detail).toMatch(/exited/i);
+  });
+
+  it("does not count `Up (unhealthy)` as up (review M6)", async () => {
+    const f = await waitForAgentContainerUp(
+      "alpha",
+      {
+        listContainers: () => [
+          { name: "switchroom-alpha", status: "Up 2 minutes (unhealthy)" },
+        ],
         sleep: noSleep,
       },
       opts,
     );
-    expect(f.status).toBe("ok");
-    expect(calls).toBe(3); // stableSamples, not a single lucky read
+    expect(f.status).toBe("fail");
+    expect(f.detail).toMatch(/healthcheck is failing/);
+  });
+
+  it("gives useful guidance (not `docker logs`) when no container was made", async () => {
+    // Review H3(b): `docker logs switchroom-alpha` errors "No such container"
+    // in exactly this case.
+    const f = await waitForAgentContainerUp(
+      "alpha",
+      { listContainers: () => [], sleep: noSleep },
+      opts,
+    );
+    expect(f.status).toBe("fail");
+    expect(f.fix).not.toContain("docker logs");
+    expect(f.fix).toContain("switchroom apply");
   });
 
   it("reports the healthcheck when one exists", async () => {
@@ -187,16 +250,18 @@ describe("agentContainerHealth", () => {
 // ─── verifyFleetContainers ───────────────────────────────────────────────────
 
 describe("verifyFleetContainers", () => {
-  it("FAILS when docker is unreachable", () => {
-    const findings = verifyFleetContainers(configWithAgent(), {
+  it("FAILS when docker is unreachable", async () => {
+    const findings = await verifyFleetContainers(configWithAgent(), {
+      sleep: noSleep,
       listContainers: () => null,
     });
     expect(hasFatal(findings)).toBe(true);
     expect(findings[0].detail).toMatch(/docker is not reachable/);
   });
 
-  it("FAILS on doctor's stuck/crash-loop signature", () => {
-    const findings = verifyFleetContainers(configWithAgent(), {
+  it("FAILS on doctor's stuck/crash-loop signature", async () => {
+    const findings = await verifyFleetContainers(configWithAgent(), {
+      sleep: noSleep,
       listContainers: () => [
         { name: "switchroom-alpha", status: "Created" },
         { name: "switchroom-vault-broker", status: "Restarting (1) 2 seconds ago" },
@@ -206,8 +271,9 @@ describe("verifyFleetContainers", () => {
     expect(findings.map((f) => f.detail).join(" ")).toMatch(/stuck\/crash-looping/);
   });
 
-  it("reports PENDING (never ok) when no agent container exists yet", () => {
-    const findings = verifyFleetContainers(configWithAgent(), {
+  it("reports PENDING (never ok) when no agent container exists yet", async () => {
+    const findings = await verifyFleetContainers(configWithAgent(), {
+      sleep: noSleep,
       listContainers: () => [],
     });
     expect(hasFatal(findings)).toBe(false);
@@ -216,8 +282,9 @@ describe("verifyFleetContainers", () => {
     expect(agentRow?.detail).toContain("0/1");
   });
 
-  it("reports PENDING for a stopped (deliberately) agent, not a hard fail", () => {
-    const findings = verifyFleetContainers(configWithAgent(), {
+  it("reports PENDING for a stopped (deliberately) agent, not a hard fail", async () => {
+    const findings = await verifyFleetContainers(configWithAgent(), {
+      sleep: noSleep,
       listContainers: () => [
         { name: "switchroom-alpha", status: "Exited (0) 3 hours ago" },
       ],
@@ -226,8 +293,9 @@ describe("verifyFleetContainers", () => {
     expect(findings.find((f) => f.name === "agent containers")?.status).toBe("pending");
   });
 
-  it("FAILS when the hindsight container setup just started is crash-looping", () => {
-    const findings = verifyFleetContainers(configWithAgent(), {
+  it("FAILS when the hindsight container setup just started is crash-looping", async () => {
+    const findings = await verifyFleetContainers(configWithAgent(), {
+      sleep: noSleep,
       listContainers: () => [
         ...up("alpha"),
         { name: "switchroom-hindsight", status: "Restarting (1) 4 seconds ago" },
@@ -239,15 +307,17 @@ describe("verifyFleetContainers", () => {
     );
   });
 
-  it("does not invent a hindsight row when there is no hindsight container", () => {
-    const findings = verifyFleetContainers(configWithAgent(), {
+  it("does not invent a hindsight row when there is no hindsight container", async () => {
+    const findings = await verifyFleetContainers(configWithAgent(), {
+      sleep: noSleep,
       listContainers: () => up("alpha"),
     });
     expect(findings.find((f) => f.name === "hindsight memory")).toBeUndefined();
   });
 
-  it("names an agent in an unexpected docker state instead of dropping it", () => {
-    const findings = verifyFleetContainers(configWithAgent(), {
+  it("names an agent in an unexpected docker state instead of dropping it", async () => {
+    const findings = await verifyFleetContainers(configWithAgent(), {
+      sleep: noSleep,
       listContainers: () => [{ name: "switchroom-alpha", status: "Paused" }],
     });
     const row = findings.find((f) => f.name === "agent containers");
@@ -255,8 +325,9 @@ describe("verifyFleetContainers", () => {
     expect(row?.detail).toContain("not up: alpha");
   });
 
-  it("reports ok when every configured agent is up", () => {
-    const findings = verifyFleetContainers(configWithAgent(), {
+  it("reports ok when every configured agent is up", async () => {
+    const findings = await verifyFleetContainers(configWithAgent(), {
+      sleep: noSleep,
       listContainers: () => up("alpha"),
     });
     expect(findings.find((f) => f.name === "agent containers")?.status).toBe("ok");
@@ -283,6 +354,7 @@ describe("stepVerification", () => {
         log: out.log,
         sleep: noSleep,
         confirmStart: async () => true,
+        composeFileExists: () => true,
         startAgent: () => {
           throw new Error("spawn switchroom ENOENT");
         },
@@ -303,6 +375,7 @@ describe("stepVerification", () => {
         timeoutMs: 3000,
         intervalMs: 1000,
         confirmStart: async () => true,
+        composeFileExists: () => true,
         startAgent: () => {},
         // start "succeeded" but the container is nowhere — the exact shape
         // of the bug: a green success over a dead agent.
@@ -319,6 +392,7 @@ describe("stepVerification", () => {
         log: out.log,
         sleep: noSleep,
         confirmStart: async () => true,
+        composeFileExists: () => true,
         startAgent: () => {},
         listContainers: () => [
           { name: "switchroom-alpha", status: "Restarting (1) 1 second ago" },
@@ -358,6 +432,7 @@ describe("stepVerification", () => {
       sleep: noSleep,
       stableSamples: 2,
       confirmStart: async () => true,
+        composeFileExists: () => true,
       startAgent: () => {},
       listContainers: () => up("alpha"),
     });
@@ -440,21 +515,354 @@ describe("stepMemoryBackend (Docker absent)", () => {
       stepMemoryBackend(configWithAgent(), true, cfgPath, {
         dockerProbe: () => null,
       }),
-    ).rejects.toThrow(/Docker is not available/);
+    ).rejects.toThrow(/Memory backend setup failed/);
 
     const text = logs.join("\n");
     expect(text).not.toContain("Manual setup pending");
     // The old code printed a green OK on this exact path.
-    expect(text).toMatch(/Docker is not available/);
+    expect(text).toMatch(/Docker is not installed/);
     expect(text).toMatch(/SWITCHROOM_MEMORY_BACKEND=none/);
   });
 
   it("still honours the documented opt-out without touching Docker", async () => {
     process.env.SWITCHROOM_MEMORY_BACKEND = "none";
     const probe = vi.fn(() => null);
+    const outcome = await stepMemoryBackend(configWithAgent(), true, cfgPath, {
+      dockerProbe: probe,
+    });
+    expect(outcome).toEqual({ hindsightExpected: false, optedOut: true });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("says INSTALL Docker only when the CLI is genuinely missing (review L8)", async () => {
+    await expect(
+      stepMemoryBackend(configWithAgent(), true, cfgPath, { dockerProbe: () => null }),
+    ).rejects.toThrow(/not installed/);
+    expect(logs.join("\n")).toMatch(/no `docker` command on PATH/);
+  });
+
+  it("says START Docker when the CLI is present but the daemon is down (L8)", async () => {
+    // The common macOS case: Docker Desktop ships the CLI, VM is stopped.
+    // "Install Docker" here sends the operator down the wrong road.
+    const probe = (args: string[]) =>
+      args[0] === "--version" ? "Docker version 27.0.0\n" : null;
     await expect(
       stepMemoryBackend(configWithAgent(), true, cfgPath, { dockerProbe: probe }),
-    ).resolves.toBeUndefined();
-    expect(probe).not.toHaveBeenCalled();
+    ).rejects.toThrow(/daemon is not responding/);
+    const text = logs.join("\n");
+    expect(text).toMatch(/daemon is not responding/);
+    expect(text).not.toMatch(/Docker is not installed/);
+  });
+
+  it("THROWS when the container is started but does not stay running (H2)", async () => {
+    // The PR's remaining silent-success: this printed a yellow "may still be
+    // initializing" and the wizard finished with "Setup complete! Your agents
+    // are running." over a dead memory backend.
+    const probe = (args: string[]) => {
+      if (args[0] === "--version") return "Docker version 27.0.0\n";
+      if (args[0] === "ps" && args[1] === "--quiet") return "";
+      return ""; // `docker ps --filter name=switchroom-hindsight` → no rows
+    };
+    const startContainer = vi.fn();
+    await expect(
+      stepMemoryBackend(configWithAgent(), true, cfgPath, {
+        dockerProbe: probe,
+        startContainer: startContainer as never,
+        sleep: async () => {},
+        readyRetries: 2,
+      }),
+    ).rejects.toThrow(/did not stay running/);
+    expect(startContainer).toHaveBeenCalled();
+    expect(logs.join("\n")).not.toMatch(/may still be initializing/);
+  });
+});
+
+// ─── review M4: a FAIL verdict is sampled, like the OK verdict ───────────────
+
+describe("verifyFleetContainers stability (review M4)", () => {
+  it("does NOT fail on a transient created/restarting frame during a bounce", async () => {
+    // Every switchroom container is generated with `restart: always`, so a
+    // fleet seconds into `docker restart` legitimately reads like this on
+    // the first snapshot. One snapshot used to be an unconditional exit 1.
+    const findings = await verifyFleetContainers(
+      configWithAgent(),
+      {
+        listContainers: scripted([
+          [{ name: "switchroom-alpha", status: "Restarting (0) 1 second ago" }],
+          up("alpha"),
+        ]),
+        sleep: noSleep,
+      },
+      { confirmIntervalMs: 1 },
+    );
+    expect(hasFatal(findings)).toBe(false);
+  });
+
+  it("downgrades a flap to PENDING rather than printing green over it", async () => {
+    // A crash-looping container reads "Up 1 second" between restarts, so a
+    // later clean sample is NOT evidence of health — it is what a flap looks
+    // like. Not a hard fail (M4), but never an unqualified ok either.
+    const findings = await verifyFleetContainers(
+      configWithAgent(),
+      {
+        listContainers: scripted([
+          [{ name: "switchroom-alpha", status: "Restarting (0) 1 second ago" }],
+          up("alpha"),
+        ]),
+        sleep: noSleep,
+      },
+      { confirmIntervalMs: 1 },
+    );
+    expect(hasFatal(findings)).toBe(false);
+    expect(findings.some((f) => f.status === "ok")).toBe(false);
+    expect(findings.find((f) => f.name === "agent containers")?.status).toBe(
+      "pending",
+    );
+    expect(findings.find((f) => f.name === "runtime stability")?.status).toBe(
+      "pending",
+    );
+  });
+
+  it("reports a clean fleet as ok with no stability caveat", async () => {
+    const findings = await verifyFleetContainers(
+      configWithAgent(),
+      { listContainers: () => up("alpha"), sleep: noSleep },
+      { confirmIntervalMs: 1 },
+    );
+    expect(findings.find((f) => f.name === "agent containers")?.status).toBe("ok");
+    expect(findings.some((f) => f.name === "runtime stability")).toBe(false);
+  });
+
+  it("still FAILS when the breakage persists across every sample", async () => {
+    let samples = 0;
+    const findings = await verifyFleetContainers(
+      configWithAgent(),
+      {
+        listContainers: () => {
+          samples++;
+          return [{ name: "switchroom-alpha", status: "Restarting (1) 2 seconds ago" }];
+        },
+        sleep: noSleep,
+      },
+      { confirmIntervalMs: 1 },
+    );
+    expect(hasFatal(findings)).toBe(true);
+    expect(samples).toBeGreaterThan(1); // confirmed, not a single read
+  });
+});
+
+// ─── review H1: the documented Docker-less opt-out, END TO END ──────────────
+
+describe("SWITCHROOM_MEMORY_BACKEND=none on a Docker-less host (review H1)", () => {
+  it("step 13 does NOT exit 1 when memory was opted out and docker is absent", async () => {
+    // The whole point of the escape hatch docs/install.md advertises. The
+    // isolated stepMemoryBackend test missed this because step 13 called
+    // verifyFleetContainers unconditionally.
+    const out: string[] = [];
+    const verdict = await stepVerification(
+      configWithAgent(),
+      true,
+      { log: (l) => out.push(l), sleep: noSleep, listContainers: () => null },
+      { memoryOptedOut: true, hindsightExpected: false },
+    );
+    expect(verdict).toBe("pending");
+    expect(out.join("\n")).toMatch(/docker is not reachable/);
+    expect(out.join("\n")).not.toMatch(/Verification FAILED/);
+  });
+
+  it("still FAILS on an absent docker when memory was NOT opted out", async () => {
+    await expect(
+      stepVerification(
+        configWithAgent(),
+        true,
+        { log: () => {}, sleep: noSleep, listContainers: () => null },
+        { memoryOptedOut: false },
+      ),
+    ).rejects.toBeInstanceOf(SetupVerificationError);
+  });
+});
+
+// ─── review H2: step 6 said it started memory; step 13 holds it to that ─────
+
+describe("hindsight accountability (review H2/M6)", () => {
+  it("FAILS when memory setup claimed success but no container exists", async () => {
+    const findings = await verifyFleetContainers(
+      configWithAgent(),
+      { listContainers: () => up("alpha"), sleep: noSleep },
+      { hindsightExpected: true, confirmIntervalMs: 1 },
+    );
+    expect(hasFatal(findings)).toBe(true);
+    expect(findings.find((f) => f.name === "hindsight memory")?.detail).toMatch(
+      /no switchroom-hindsight container/,
+    );
+  });
+
+  it("FAILS on a wedged hindsight reporting `Up (unhealthy)`", async () => {
+    // M6: the healthcheck exists to make a wedged API visible; treating
+    // "Up (unhealthy)" as running verified a dead memory backend green.
+    const findings = await verifyFleetContainers(
+      configWithAgent(),
+      {
+        listContainers: () => [
+          ...up("alpha"),
+          { name: "switchroom-hindsight", status: "Up 2 minutes (unhealthy)" },
+        ],
+        sleep: noSleep,
+      },
+      { hindsightExpected: true, confirmIntervalMs: 1 },
+    );
+    expect(hasFatal(findings)).toBe(true);
+    expect(findings.find((f) => f.name === "hindsight memory")?.detail).toMatch(
+      /healthcheck is failing/,
+    );
+  });
+
+  it("treats `health: starting` as pending, not a failure", async () => {
+    const findings = await verifyFleetContainers(
+      configWithAgent(),
+      {
+        listContainers: () => [
+          ...up("alpha"),
+          { name: "switchroom-hindsight", status: "Up 4 seconds (health: starting)" },
+        ],
+        sleep: noSleep,
+      },
+      { hindsightExpected: true, confirmIntervalMs: 1 },
+    );
+    expect(hasFatal(findings)).toBe(false);
+    expect(findings.find((f) => f.name === "hindsight memory")?.status).toBe("pending");
+  });
+
+  it("classifies the docker status strings the verdicts rest on", () => {
+    expect(classifyContainerStatus("Up 2 minutes (unhealthy)")).toBe("running-unhealthy");
+    expect(classifyContainerStatus("Up 4 seconds (health: starting)")).toBe("running-starting");
+    expect(classifyContainerStatus("Up 3 hours (healthy)")).toBe("running-healthy");
+    expect(classifyContainerStatus("Up 3 hours")).toBe("running-no-healthcheck");
+  });
+});
+
+// ─── review H3c: a first-install "yes" must not become a false FAIL ─────────
+
+describe("fresh install, before `switchroom apply` (review H3c)", () => {
+  it("does not offer to start (nor fail) when the compose file does not exist", async () => {
+    const out: string[] = [];
+    const startAgent = vi.fn();
+    const confirmStart = vi.fn(async () => true);
+    const verdict = await stepVerification(configWithAgent(), false, {
+      log: (l) => out.push(l),
+      sleep: noSleep,
+      composeFileExists: () => false,
+      startAgent,
+      confirmStart,
+      listContainers: () => [],
+    });
+    expect(verdict).toBe("pending");
+    expect(confirmStart).not.toHaveBeenCalled();
+    expect(startAgent).not.toHaveBeenCalled();
+    expect(out.join("\n")).toMatch(/has not generated the compose file yet/);
+  });
+
+  it("surfaces the child's real error when a start does fail", async () => {
+    const out: string[] = [];
+    await expect(
+      stepVerification(configWithAgent(), false, {
+        log: (l) => out.push(l),
+        sleep: noSleep,
+        composeFileExists: () => true,
+        confirmStart: async () => true,
+        startAgent: () => {
+          throw new Error(
+            "Command failed: Preflight failed for alpha / .oauth-token missing",
+          );
+        },
+        listContainers: () => [],
+      }),
+    ).rejects.toBeInstanceOf(SetupVerificationError);
+    expect(out.join("\n")).toMatch(/Preflight failed for alpha/);
+    // NOT the misleading "run `switchroom apply` first" on a fleet that has
+    // already been applied.
+    expect(out.join("\n")).not.toMatch(/did not reach a stable running state/);
+  });
+});
+
+// ─── review L11: every configured agent is offered, not just the first ──────
+
+describe("multi-agent start offer (review L11)", () => {
+  function twoAgents(): SwitchroomConfig {
+    return {
+      agents: { alpha: { topic_name: "a" }, beta: { topic_name: "b" } },
+    } as unknown as SwitchroomConfig;
+  }
+
+  it("starts every agent, so `verified` is reachable on a 2-agent config", async () => {
+    const started: string[] = [];
+    const verdict = await stepVerification(twoAgents(), false, {
+      log: () => {},
+      sleep: noSleep,
+      stableSamples: 2,
+      composeFileExists: () => true,
+      confirmStart: async () => true,
+      startAgent: (n) => started.push(n),
+      listContainers: () => [...up("alpha"), ...up("beta")],
+    });
+    expect(started).toEqual(["alpha", "beta"]);
+    expect(verdict).toBe("verified");
+  });
+
+  it("waits on the agents CONCURRENTLY, not N × the stability window", async () => {
+    // The stability window is wall-clock. Waiting in series would make the
+    // wizard's worst case N × AGENT_UP_TIMEOUT_MS. Virtual clock: sum the
+    // sleeps the waits ask for.
+    let virtualMs = 0;
+    let pending = 0;
+    const sleep = async (ms: number) => {
+      // Concurrent waiters overlap: only advance the clock for the sleep
+      // that is not already covered by another in-flight waiter.
+      pending++;
+      if (pending === 1) virtualMs += ms;
+      await Promise.resolve();
+      pending--;
+    };
+    await stepVerification(twoAgents(), false, {
+      log: () => {},
+      sleep,
+      composeFileExists: () => true,
+      confirmStart: async () => true,
+      startAgent: () => {},
+      listContainers: () => [...up("alpha"), ...up("beta")],
+    });
+    // One window's worth of sleeping covered both agents.
+    expect(virtualMs).toBeLessThan(AGENT_STABLE_WINDOW_MS * 2);
+    expect(virtualMs).toBeGreaterThanOrEqual(AGENT_STABLE_WINDOW_MS);
+  });
+});
+
+// ─── review L9 / L10: output hygiene ────────────────────────────────────────
+
+describe("finding output hygiene", () => {
+  it("de-duplicates the docker-unavailable row (review L9)", () => {
+    const deduped = dedupeFindings([
+      { name: "alpha: container up", status: "fail", detail: "a", code: "docker-unavailable" },
+      { name: "docker runtime", status: "fail", detail: "b", code: "docker-unavailable" },
+      { name: "agent containers", status: "pending", detail: "c" },
+    ]);
+    expect(deduped).toHaveLength(2);
+    expect(deduped[0].name).toBe("alpha: container up");
+  });
+
+  it("numbers the pending checklist contiguously with zero agents (review L10)", async () => {
+    const out: string[] = [];
+    const verdict = await stepVerification(
+      { agents: {} } as unknown as SwitchroomConfig,
+      true,
+      { log: (l) => out.push(l), sleep: noSleep, listContainers: () => [] },
+    );
+    expect(verdict).toBe("pending");
+    const numbers = out
+      .map((l) => l.match(/^\s+(\d+)\. /)?.[1])
+      .filter((n): n is string => Boolean(n))
+      .map(Number);
+    expect(numbers.length).toBeGreaterThan(0);
+    expect(numbers).toEqual(numbers.map((_, i) => i + 1)); // 1,2,3… no gap
   });
 });

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -647,10 +647,15 @@ describe("Hindsight port-collision regression", () => {
     // the call site may be formatted multi-line (#2578 added trailing args).
     expect(src).not.toMatch(/startHindsight\(\s*undefined/);
     // Must use the shared guard helpers (not a parallel implementation) and
-    // hand the chosen ports to startHindsight (first argument = `ports`).
+    // hand the chosen ports to the launch (first argument = `ports`).
     expect(src).toContain("pickHindsightPorts");
     expect(src).toContain("preflightHindsightPorts");
-    expect(src).toMatch(/startHindsight\(\s*ports\b/);
+    // The launch now goes through an injectable seam (setup-verification
+    // review H2 needed a docker-free test of "started but did not stay
+    // running"), so accept either name at the call site — and pin that the
+    // seam's DEFAULT is still the real `startHindsight`.
+    expect(src).toMatch(/(?:startHindsight|startContainer)\(\s*ports\b/);
+    expect(src).toMatch(/deps\.startContainer \?\? startHindsight/);
   });
 
   it("setup's port guard selects a free port instead of binding the occupied default", async () => {


### PR DESCRIPTION
## Summary

`switchroom setup`'s final "Verification" step verified nothing: it printed four manual instructions and then an unconditional green `OK Verification steps ready`, and the optional `switchroom agent start` was wrapped in a bare `catch {}` (install-path review H7, `src/cli/setup.ts:1900-1932`). The same lie-green appeared in the memory step, where Docker being absent still printed `OK Manual setup pending` (`:1044-1052`).

Net effect: on a host where nothing could run, the wizard reported success — which made every other install failure silent.

**Every lie-green path in `src/cli/setup.ts` is fixed.** The first pass claimed "three instances"; adversarial review found four more same-shaped silent-success returns inside `stepMemoryBackend` (a `pickHindsightPorts` throw, a port still occupied after reassignment, a `startHindsight` throw, and started-but-not-running printing only a yellow warning). All four now throw `Memory backend setup failed: …`, and step 13 holds step 6 to its claim rather than treating an absent `switchroom-hindsight` row as fine. The file's three remaining `catch {}` blocks — `:87` statSync mode default, `:234` findConfigFile fallback, `:848` statSync mode default — are documented fallbacks that do not claim success, and were left alone.

### What verification now actually checks

New `src/setup/verify.ts`, fully dependency-injected (docker probe + sleep):

- **docker reachable** — `docker ps` failing is a `fail`, not a footnote.
- **fleet runtime health** — reuses doctor's own `checkContainerRuntimeHealth` (the 2026-06-23 stuck-`Created` / crash-loop signature) instead of inventing a parallel check; `listSwitchroomContainers` is now exported from `doctor-docker.ts` so both surfaces share one probe.
- **the hindsight container this wizard started** — crash-looping / stuck-Created is a `fail`.
- **an agent we were asked to start** — must appear AND stay up for `AGENT_STABLE_WINDOW_MS` (15s of consecutive `docker ps` samples, timeout 45s; the sample count is derived from the window so the two cannot drift). A crash-looping container reads "Up 1 second" between restarts, so one sample is not evidence. A start that throws reports the real error, including the tail of the command's own output.
- **health, not just presence** — `Up (unhealthy)` is no longer counted as up. `switchroom-hindsight` carries a healthcheck precisely so a wedged memory API is visible; it now fails verification instead of verifying green. `(health: starting)` is `pending` (the container has a 60s health-start-period).
- **a FAIL is sampled like an OK** — every switchroom container runs with `restart: always`, so re-running setup seconds into a bounce used to exit 1 on a healthy fleet off one snapshot. A fatal verdict is now confirmed across samples. A fleet seen broken-then-clean is *not* reported green either (that is exactly what a flap looks like): it downgrades to `pending` with a `runtime stability` row.

### Honesty about what was *not* proven

`setup` runs **before** `apply` and before the fleet is up (docs/install.md Step 3 vs Step 5), so "no containers yet" is normal. That is reported as **pending** in yellow with the finish-up checklist and exit 0 — never as a green OK. The closing banner is now conditional: `Setup complete! Your agents are running.` only when verification passed, otherwise `Setup finished — config written, fleet not started yet.`

### `switchroom agent start` reports failure

Setup's start seam shells out to `switchroom agent start`, which swallowed every realistic failure and exited 0 — an undefined agent, a quarantined agent, preflight errors and a `startAgent()` throw were all `continue`/caught. So the only failure setup could observe was ENOENT, and every real one degraded into a 28s timeout whose suggested `docker logs switchroom-<agent> --tail 50` itself errored "No such container". The command now sets `process.exitCode = 1` when any named agent did not start, and `defaultStartAgent` captures the command's output so the thrown message says *why*.

**Fresh-install regression fixed:** setup runs before `apply`, so on a first install there is no compose file and nothing can start. The wizard now checks for the compose file *before* offering "Start alpha now?" — a first-install "yes" can no longer become a 45s wait ending in a false FAIL. And when a timeout does happen with no container ever created, the fix text points at `switchroom apply`, not at `docker logs` for a container that does not exist.

### Exit code

Verification failure throws `SetupVerificationError`; the action handler calls the new exported `reportSetupFailure(err)` and `process.exit()`s with its non-zero return, so `switchroom setup --non-interactive && ...` stops instead of sailing past a dead fleet.

## Why

Install-path review H7: "This is the amplifier for every other finding: on Mac, where H5/H6 mean the fleet genuinely won't work, the wizard still says it succeeded." Docker-absent hard-fail also matches item 5 of the hindsight/LiteLLM audit ("a hard, named failure with a resume instruction"); the documented `SWITCHROOM_MEMORY_BACKEND=none` opt-out is the escape hatch for a Docker-less box — and that opt-out is now honoured *end to end* (step 13 no longer hard-fails on absent docker when memory was opted out; docs/install.md's own non-interactive CI example depends on this). This PR deliberately does **not** implement hindsight default-on — that is separate work.

## Test plan

`tests/setup-verification.test.ts` — 51 tests, plus a new `tests/cli.agent-start-exit-code.test.ts` (4 tests). Failure-first by design (a happy-path-only suite would have passed on the original bug):

- `agent start` throws ⇒ step throws `SetupVerificationError`, output contains the real error (`spawn switchroom ENOENT`) and never `Verification steps ready`
- started but container never appears / exits / crash-loops / stuck in `Created` ⇒ throw
- docker unreachable ⇒ throw, even with nothing started
- fresh install with no containers ⇒ `pending`, no "Verified" claim
- verified only when the container stays up for the whole stability *window* — the test asserts the property (elapsed >= `AGENT_STABLE_WINDOW_MS`) plus a constants-drift guard, not `calls === 3`, and a virtual-clock case fails an agent whose `start.sh` dies ~9s in
- `SWITCHROOM_MEMORY_BACKEND=none` + absent docker, driven end to end **through step 13** ⇒ `pending`, exit 0 (the isolated step-6 test missed this)
- memory setup claimed success but no `switchroom-hindsight` row ⇒ fail; `Up (unhealthy)` hindsight ⇒ fail
- `agent start` exit code is 1 for an undefined agent, a preflight failure and a `startAgent()` throw, and untouched on success
- fresh install with no compose file ⇒ no start offer, `pending`, no FAIL
- a two-agent config starts *both* and waits on them concurrently (asserted on a virtual clock: total wait < 2 x window)
- a fleet observed restarting-then-clean is `pending`, never `ok` and never `fail`
- `reportSetupFailure` returns non-zero for verification failures and for any other setup error
- `stepMemoryBackend` with a Docker-absent probe ⇒ **throws**, prints no `Manual setup pending`; `SWITCHROOM_MEMORY_BACKEND=none` still skips without touching Docker

Negative control: mutating `waitForAgentContainerUp` to always return `ok` (the original bug shape) reds 8 of these tests.

```
vitest run tests/setup-verification.test.ts tests/setup.test.ts \
  tests/cli.agent-start-exit-code.test.ts tests/doctor.test.ts \
  tests/memory.test.ts tests/cli.doctor.memory*.test.ts \
  tests/cli.agent-quarantine.test.ts tests/agent.status.test.ts
                                       283 passed | 2 skipped
npm run lint                                            clean
```

## Risk

- **Behaviour change:** on a Docker-less host the wizard now aborts at step 6 instead of continuing to scaffold. Intentional (every agent is a container); `SWITCHROOM_MEMORY_BACKEND=none` is the documented way through, and docs/install.md gained a troubleshooting entry for both new failure messages.
- **New non-zero exits** are all cases that were previously silent successes. A deliberately-stopped agent stays `pending`, not `fail`, matching doctor — so re-running setup on a host with a stopped agent does not newly exit 1.
- No runtime/behaviour change to `doctor`; `listSwitchroomContainers` is a rename-and-export of the existing private probe, and the two new `classifyContainerStatus` buckets (`running-unhealthy`, `running-starting`) are inert for doctor's consumers, which only match `restarting` / `created`.
- **Partial-write on a step 6 abort (review M7):** `ensureHindsightConsumer` writes `auth.consumers[hindsight]` into `switchroom.yaml` *before* step 6 can throw, so an aborted run leaves that stanza behind. A re-run is safe — the `result.added` guard makes it idempotent — but the config on disk is not identical to a never-run state. Not reverted here: the consumer entry is inert without a hindsight container and rolling it back would be a second failure mode on the error path.
- **`isDockerAvailable` is now stricter** — it requires a responding daemon, not just the CLI on PATH. Its three other callers in `src/cli/memory.ts` all genuinely need a live daemon, so this is a correctness improvement rather than a regression; their message text is unchanged.
- **`switchroom agent start` now exits non-zero on failure.** Any script relying on its unconditional exit 0 will start failing — which is the point, but it is a user-visible change beyond setup.

Job spec: `reference/jobs/get-from-zero-to-a-working-fleet.md` — "When something is wrong it says so, with a next step, instead of reporting success on a broken state."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
