### PR TITLE
fix(litellm): derive paired timeout budgets from the routing chain, and detect drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,100 @@
 
 ## Unreleased
 
+### LiteLLM paired timeout budgets are now DERIVED, and drift is detected
+
+A hindsight LLM call crosses three stacked deadlines, and LiteLLM's router
+fallback runs *inside* one client request. So the invariant is not
+`local < client`, it is `local + fallback + margin <= client`. It was
+maintained by hand, in a config comment, and broke twice in two days in
+opposite directions:
+
+- retain (#3611) moved the client budget to a derived `ceil(16384/80.6) = 204s`
+  without moving the litellm halves (`200 + 90 = 290`), so the retain
+  OpenRouter fallback had 4s of headroom and could never complete;
+- interactive raised its fallback hop `25s -> 60s` on 2026-07-26, giving
+  `90 + 60 = 150` against hindsight's 120s `DEFAULT_LLM_TIMEOUT`.
+
+- **`src/litellm/timeout-budget.ts` is the single declaration.** Per-lane tiers
+  (primary group + fallback group + each one's per-deployment timeout) live
+  there with the measurements that justify them. Every client budget is
+  computed from that declaration, so the halves are one number by construction.
+- **#3611's derivation is preserved as a FLOOR, not replaced.**
+  `clientBudgetSeconds(tier, floor)` is `max(floor, local + fallback + margin)`,
+  so the token-budget-derived lower bound and the chain lower bound must both
+  be satisfied. Taking the max does not reopen the runaway #3611 fixed — that
+  is cut by the output-token cap and by litellm's own per-deployment timeout,
+  both upstream of the client.
+- **`assertClientBudget` runs on the hindsight env emit paths**, so an
+  inconsistent budget cannot reach a container.
+- **All four hindsight timeouts are now emitted, not defaulted**:
+  `HINDSIGHT_API_LLM_TIMEOUT=160`, `HINDSIGHT_API_REFLECT_LLM_TIMEOUT=160`
+  (Ken's 160s interactive budget, derived as `90 + 60 + 10`, not typed),
+  `HINDSIGHT_API_RETAIN_LLM_TIMEOUT=300` and
+  `HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT=300` (`200 + 90 + 10`). The retain
+  lane previously shipped 204s; interactive and consolidation shipped nothing
+  and silently took the vendor's 120s.
+- **The plugin's retain client deadline moves `280s -> 310s`** in lockstep
+  (`retain_split.py`), because `290 <= RETAIN_LLM_TIMEOUT < 280` is
+  unsatisfiable at any derivation. The derived content bound follows it,
+  `45,000 -> 48,000` chars.
+- **This also explains, and fixes, the ~280.1s per-entry give-up in the
+  backlog-recovery logs.** It was never a third hand-set number: the backlog
+  drainer's `_backlog_timeout()` defaults to `int(retain_client_deadline())`
+  (`vendor/hindsight-memory/scripts/drain_pending.py:220`), i.e. the same
+  280.0 constant. It is the OUTERMOST deadline in the family and it did not
+  cover the 300s routing chain, so every drained entry whose retain fell
+  through to the OpenRouter fallback was abandoned client-side while the
+  server was still inside a legitimate budget — the entry stayed queued and
+  burned another attempt toward `.dead`. Moving the base to 310 fixes the
+  in-hook and out-of-hook lanes with one number, and
+  `tests/setup/hindsight.test.ts` now asserts the drain deadline stays both
+  derived and above the chain.
+- **Drift is now loud, three ways.** `src/litellm/repo-config.test.ts` fails CI
+  when the shipped `docker/litellm-proxy/litellm-config.yaml` disagrees with
+  the declaration, omits a per-deployment timeout on a budgeted group, or adds
+  a fallback edge the tiers do not know about. On-host, the fleet-health
+  litellm-config sensor emits a `litellm-timeout-budget-drift` finding
+  (`drift` / severity 3 / `fleet-stays-healthy`) against the LIVE proxy config,
+  which the ledger escalates like any other L0.
+- **`gpt-oss-20b-openrouter` gains `timeout: 60`** in the repo-managed config.
+  It carried none, so it inherited `request_timeout: 600` — 4x the whole
+  client budget for its lane.
+- **The 10s margin no longer claims to cover a pacer hold, and a test enforces
+  why it does not have to.** `LITELLM_ROUTER_MARGIN_S` justified itself partly
+  by "the pacer's admission delay", which is not true of any lane it budgets:
+  `docker/litellm-pacer/custom_pacing.py` paces only groups matching
+  `PACE_MODEL_GROUPS` (default `claude-*,sonnet,fable`) and no `gpt-oss-20b*`
+  group matches. That mattered rather than being pedantic — `PACE_MAX_WAIT_S`
+  alone defaults to 20s, twice the margin, and the hard backstop is clamped as
+  high as 280s, so a margin that genuinely had to cover a pacer hold would be
+  far too small. `src/litellm/repo-config.test.ts` now fails if any budgeted
+  group is ever added to the pacer's allowlist.
+- **The emit-time assertions are documented as defence in depth, not as the
+  mechanism.** All three `assertClientBudget` calls in `hindsightLlmBudgetEnv`
+  compare a value produced by `clientBudgetSeconds` (`max(floor, chain)`)
+  against that same `chain`, so they cannot fire as written — and neither can
+  `assertHindsightRetainBudget`'s `server < client` half now that the client
+  deadline is derived from the server one. They are kept because they catch the
+  NEXT edit (any hand-set or config-sourced budget), but the checks that can
+  actually FAIL today are the tests over files nothing derives, and the
+  docstring now says so instead of implying the opposite.
+- **Deadline literals in comments and assertions that went stale with the
+  280 -> 310 move are now derived or dated**: the drain-bound part-count
+  assertion in `test_retain_split.py` (was a literal `16`, now
+  `ceil(len / retain_content_limit())`), and the `45,000` / `280s` citations in
+  `src/hindsight-watch/evaluate.test.ts` and `src/litellm/timeout-budget.test.ts`
+  — including two that claimed `gpt-oss-20b-openrouter` still carries no
+  timeout, which this very change fixes.
+- **Unrelated but caught here and not worth leaving on main: #3676's
+  `tests/source-files-are-text.test.ts` was a coin flip on a cold cache.** It
+  reads ~2,600 files under vitest's default 5s per-test timeout. Measured on
+  the fleet host immediately after that PR landed: 10.1s on the first run after
+  a fresh checkout, 71ms on every run after — same work, page cache the only
+  difference, and a CI runner is always the cold case. It now carries an
+  explicit 60s timeout sized for the I/O rather than scanning less. The NUL
+  detection itself is unchanged and still fails on a planted raw NUL.
+
 ### A `v*` tag can no longer half-ship — release.yml is now the orchestrator (#3654)
 
 Three workflows fired independently on a `v*` tag with nothing cross-gating

--- a/docker/litellm-proxy/litellm-config.yaml
+++ b/docker/litellm-proxy/litellm-config.yaml
@@ -392,8 +392,16 @@ model_list:
       # extraction-timeout cluster (two retains lost). 90s < 120s makes the
       # SERVER give up first, so litellm returns a real error hindsight can retry
       # on instead of the client walking away from a still-running request.
-      # DO NOT RAISE past ~110s without first raising hindsight's client timeout
-      # — the invariant is server timeout < client timeout.
+      # 2026-07-26: DO NOT edit this number here alone. It is one half of a
+      # PAIR — switchroom derives hindsight's client budget for this lane from
+      # it, in `src/litellm/timeout-budget.ts` (LITELLM_TIMEOUT_TIERS.interactive).
+      # And the invariant is NOT "server < client": the router's fallback hop
+      # runs inside the SAME client request, so it is
+      #     local + fallback + margin  <=  client
+      # i.e. 90 + 60 + 10 = 160 <= HINDSIGHT_API_LLM_TIMEOUT (160, emitted by
+      # src/setup/hindsight.ts). Change this value in timeout-budget.ts and
+      # here together; the fleet-health litellm-config sensor reports it loudly
+      # when they drift apart.
       timeout: 90
       extra_body:
         reasoning_effort: low
@@ -410,12 +418,20 @@ model_list:
   # adds latency without adding availability. It only differed meaningfully while
   # the primary was a LOCAL box. Deliberately NOT changed by the reconciliation —
   # routing is Ken's call.
-  # Note: this entry has no per-model `timeout`, so a fallback hop still inherits
-  # request_timeout (600s). Only relevant once this tier is made distinct.
   - model_name: gpt-oss-20b-openrouter
     litellm_params:
       model: openrouter/openai/gpt-oss-20b
       api_key: os.environ/OPENROUTER_API_KEY
+      # 2026-07-26: this entry previously carried NO per-model `timeout`, so a
+      # fallback hop inherited request_timeout (600s) — 4x hindsight's whole
+      # client budget for the lane, which means the client always hung up
+      # mid-fallback and the failover path effectively did not exist. 60s is
+      # the value the live proxy runs (raised there from a useless 25s on
+      # 2026-07-26, at which the tier NEVER completed: 5,184 read timeouts in
+      # 24h). It is the OTHER half of the pair described on the gpt-oss-20b
+      # entry above: 90 + 60 + 10 = 160 <= HINDSIGHT_API_LLM_TIMEOUT.
+      # Declared in src/litellm/timeout-budget.ts; edit both together.
+      timeout: 60
       # Pin an explicit allowlist of providers that honor structured-output
       # (json_schema/response_format) — all verified structured:True on
       # OpenRouter 2026-07-14. The earlier blanket `require_parameters: true`

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -75,7 +75,9 @@ export type GatewaySignal =
  *  agent's turns.jsonl or gateway log. Each sensor reads a hard artifact
  *  (an operator-maintained config file, etc.) and emits a finding when the
  *  invariant it guards is violated. */
-export type SensorSignal = "litellm-header-passthrough-misconfig";
+export type SensorSignal =
+  | "litellm-header-passthrough-misconfig"
+  | "litellm-timeout-budget-drift";
 
 export type L0Signal = TurnSignal | GatewaySignal | SensorSignal;
 

--- a/src/fleet-health/litellm-config-sensor.test.ts
+++ b/src/fleet-health/litellm-config-sensor.test.ts
@@ -237,3 +237,86 @@ model_group_settings:
     expect(res.status).toBe("skipped");
   });
 });
+
+describe("scanLitellmConfig — paired-timeout-budget drift (Fix B guard)", () => {
+  it("live timeouts matching the declaration → ok, no findings", () => {
+    const res = withYaml(`
+model_list:
+  - model_name: gpt-oss-20b
+    litellm_params: { model: a, timeout: 90 }
+  - model_name: gpt-oss-20b-openrouter
+    litellm_params: { model: b, timeout: 60 }
+  - model_name: gpt-oss-20b-retain
+    litellm_params: { model: c, timeout: 200 }
+  - model_name: gpt-oss-20b-retain-openrouter
+    litellm_params: { model: d, timeout: 90 }
+`);
+    expect(res.status).toBe("ok");
+    expect(res.findings).toEqual([]);
+  });
+
+  it("a half that moved alone → violation the ledger can escalate", () => {
+    // The 2026-07-25/26 defect class, made loud: the operator edits one
+    // per-deployment timeout on the host and nothing else changes. Before this
+    // guard, every client budget on the lane was silently wrong.
+    const res = withYaml(`
+model_list:
+  - model_name: gpt-oss-20b-retain
+    litellm_params: { model: c, timeout: 200 }
+  - model_name: gpt-oss-20b-retain-openrouter
+    litellm_params: { model: d, timeout: 150 }
+`);
+    expect(res.status).toBe("violation");
+    expect(res.findings).toHaveLength(1);
+    const f = res.findings[0];
+    expect(f.signal).toBe("litellm-timeout-budget-drift");
+    expect(f.agent).toBe(LITELLM_PROXY_PSEUDO_AGENT);
+    expect(f.turn_id).toBe("litellm-timeout:retain:gpt-oss-20b-retain-openrouter");
+    expect(f.log_pointer).toContain(PATH);
+    expect(f.log_pointer).toContain("150s");
+    expect(f.log_pointer).toContain("90s");
+    const m = mapSignal(f.signal);
+    expect(m.job_spec).toBe("fleet-stays-healthy");
+    expect(m.failure_mode).toBe("drift");
+    expect(m.severity).toBe(3);
+  });
+
+  it("a group with no timeout at all → violation (it inherits request_timeout)", () => {
+    const res = withYaml(`
+model_list:
+  - model_name: gpt-oss-20b-openrouter
+    litellm_params: { model: b }
+`);
+    expect(res.status).toBe("violation");
+    expect(res.findings).toHaveLength(1);
+    expect(res.findings[0].log_pointer).toContain("carries NO per-deployment timeout");
+  });
+
+  it("reports BOTH invariants from one file read, without either masking the other", () => {
+    const res = withYaml(`
+litellm_settings:
+  forward_client_headers_to_llm_api: true
+model_list:
+  - model_name: gpt-oss-20b
+    litellm_params: { model: a, timeout: 45 }
+`);
+    expect(res.status).toBe("violation");
+    expect(res.findings.map((f) => f.signal).sort()).toEqual([
+      "litellm-header-passthrough-misconfig",
+      "litellm-timeout-budget-drift",
+    ]);
+  });
+
+  it("logs the drift violation so it is visible in the scan output", () => {
+    const logs: string[] = [];
+    withYaml(
+      `
+model_list:
+  - model_name: gpt-oss-20b
+    litellm_params: { model: a, timeout: 45 }
+`,
+      (m) => logs.push(m),
+    );
+    expect(logs.some((l) => /VIOLATION.*gpt-oss-20b/.test(l))).toBe(true);
+  });
+});

--- a/src/fleet-health/litellm-config-sensor.ts
+++ b/src/fleet-health/litellm-config-sensor.ts
@@ -1,6 +1,11 @@
 /**
- * Fleet Health — LiteLLM config sensor (I2 OAuth-leak guard, the load-bearing
- * enforcement point for PR4a).
+ * Fleet Health — LiteLLM config sensor. Two invariants, one file read:
+ *   1. the I2 OAuth-leak guard (header passthrough scoping) — the load-bearing
+ *      enforcement point for PR4a;
+ *   2. paired-timeout-budget drift — the live per-deployment `timeout` values
+ *      vs the tiers `src/litellm/timeout-budget.ts` derives every hindsight
+ *      client budget from. A half that moves alone breaks the router's fallback
+ *      hop silently; this is what makes it loud.
  *
  * The `scripts/check-litellm-config-guard.mjs` lint step covers the
  * repo-managed config (`docker/litellm-proxy/litellm-config.yaml`, KEN-125) but
@@ -25,6 +30,10 @@ import {
   discoverLiveLitellmConfigPath,
   parseLitellmConfig,
 } from "../litellm/header-passthrough-guard.js";
+import {
+  detectLitellmTimeoutDrift,
+  extractGroupTimeouts,
+} from "../litellm/timeout-budget.js";
 
 /** The pseudo-agent the litellm misconfig finding is attributed to. It is not a
  *  real switchroom agent — it names the shared LiteLLM proxy so the ledger's
@@ -126,22 +135,47 @@ export function scanLitellmConfig(
     return { status: "skipped", path, findings: [] };
   }
 
+  const findings: Finding[] = [];
+
   const violations = detectHeaderMisconfig(parsed);
   if (violations.length === 0) {
     log(`fleet-health: litellm-config sensor OK — header passthrough correctly scoped (${path})`);
-    return { status: "ok", path, findings: [] };
   }
-
-  const findings: Finding[] = violations.map((v, i) => {
+  for (const v of violations) {
     const where = v.scope === "global" ? "litellm_settings (global)" : `group '${v.group}'`;
-    return {
+    findings.push({
       signal: "litellm-header-passthrough-misconfig",
       agent: LITELLM_PROXY_PSEUDO_AGENT,
       turn_id: `litellm-config:${v.scope}:${v.group ?? "global"}`,
       log_pointer: `${path}: ${where} — ${v.detail}`,
       ts: nowIso,
-    };
-  });
+    });
+  }
+
+  // Paired-timeout-budget drift: the live per-deployment timeouts vs the tiers
+  // switchroom derives every hindsight client budget from
+  // (`src/litellm/timeout-budget.ts`). The in-repo vitest asserts the invariant
+  // over the DECLARATION and is fully deterministic in CI; only this sensor can
+  // see whether the live proxy still agrees with that declaration. Same division
+  // of labour as the I2 guard above.
+  const drifts = detectLitellmTimeoutDrift(extractGroupTimeouts(parsed));
+  if (drifts.length === 0) {
+    log(
+      `fleet-health: litellm-config sensor OK — per-deployment timeouts match the declared ` +
+        `tiers in src/litellm/timeout-budget.ts (${path})`,
+    );
+  }
+  for (const d of drifts) {
+    findings.push({
+      signal: "litellm-timeout-budget-drift",
+      agent: LITELLM_PROXY_PSEUDO_AGENT,
+      turn_id: `litellm-timeout:${d.role}:${d.group}`,
+      log_pointer: `${path}: group '${d.group}' — ${d.detail}`,
+      ts: nowIso,
+    });
+  }
+
+  if (findings.length === 0) return { status: "ok", path, findings: [] };
   for (const f of findings) {
     log(`fleet-health: litellm-config sensor VIOLATION — ${f.log_pointer}`);
   }

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -104,6 +104,20 @@ export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
     job_spec: "keep-my-subscription-honest",
     signature: "litellm-header-passthrough:oauth-leak-scope",
   },
+  "litellm-timeout-budget-drift": {
+    // A per-deployment `timeout` in the live LiteLLM config no longer matches
+    // the tier switchroom derived its client budgets from
+    // (`src/litellm/timeout-budget.ts`). Classic `drift`: nothing errors at
+    // apply time, but every client budget on that lane is now computed from a
+    // stale number, so the router's fallback hop can be cut off mid-flight.
+    // severity 3 — this exact defect class ran undetected on the retain lane
+    // (client 204s vs a 290s chain) and turned every failover into a
+    // guaranteed error, i.e. dropped memories, for as long as nobody noticed.
+    failure_mode: "drift",
+    severity: 3,
+    job_spec: "fleet-stays-healthy",
+    signature: "litellm-timeout-budget:tier-drift",
+  },
 };
 
 /** The full set of 23 job-spec slugs the ledger carries a record for. Kept

--- a/src/hindsight-watch/evaluate.test.ts
+++ b/src/hindsight-watch/evaluate.test.ts
@@ -121,10 +121,15 @@ describe("evaluateQueueGrowth — rising vs draining", () => {
 
 describe("evaluateQueueGrowth — recalibrated for #3610's split (parts, not memories)", () => {
   it("does NOT fire on five worst-case memories splitting into 85 parts", () => {
-    // #3610 caps retain content at 45,000 chars; the largest entry measured
-    // on this fleet (744,546 chars) becomes 17 parts. Five such memories
-    // failing once is +85 entries with only five memories behind them, and
-    // must not read as "the spool turned around".
+    // #3610 caps retain content at `retain_content_limit()` — 45,000 chars
+    // when this case was measured, 48,000 since the client deadline became
+    // derived from the litellm routing chain (see B7a in ./thresholds.ts).
+    // At the 45,000 of the measurement the largest entry on this fleet
+    // (744,546 chars) becomes 17 parts. Five such memories failing once is
+    // +85 entries with only five memories behind them, and must not read as
+    // "the spool turned around". The scenario is kept at the measured
+    // numbers; the bound moving to 48,000 lowers it to 16 parts and makes
+    // this case strictly easier to pass, so it is still the worst case.
     //
     // The pre-#3610 thresholds WOULD have fired here: floor 100 (< 440) and
     // growth need max(20, 10%×440 = 44) = 44, which +85 clears. That is
@@ -264,7 +269,8 @@ describe("evaluateAll", () => {
     // backend already runs 19.4% of retains past it (measured 2026-07-25:
     // 52/268, with a 1.1% failure rate). Any threshold this instrument can
     // express fires permanently, so the signal was removed rather than
-    // retuned. Restoring it needs `le` edges above the 280s client deadline.
+    // retuned. Restoring it needs `le` edges above the retain client deadline
+    // (280s when this was measured, 310s since — see B7a in ./thresholds.ts).
     const verdicts = evaluateAll([sample(0), sample(1)]);
     expect(verdicts.some((v) => v.signal.includes("latency"))).toBe(false);
   });

--- a/src/hindsight-watch/thresholds.ts
+++ b/src/hindsight-watch/thresholds.ts
@@ -66,6 +66,21 @@
  *      ~276 s of server work is now WITHIN the design envelope rather than
  *      pathological. B5 is superseded.
  *
+ *  B7a REVISION: #3611's 204 s was derived from the token budget ALONE and
+ *      did not cover the litellm routing chain underneath it
+ *      (`gpt-oss-20b-retain` 200 s + `gpt-oss-20b-retain-openrouter` 90 s =
+ *      290 s), so the retain fallback hop had 4 s of headroom and could never
+ *      complete. Both budgets are now derived from
+ *      `src/litellm/timeout-budget.ts` as `max(token-derived floor, local +
+ *      fallback + margin)`: `HINDSIGHT_API_RETAIN_LLM_TIMEOUT = 300` and
+ *      `HINDSIGHT_RETAIN_CLIENT_DEADLINE_S = 310`, which moves
+ *      `retain_content_limit()` 45,000 → 48,000 chars
+ *      (3000 × floor(310 / 18.4) = 3000 × 16). The B6 part-count figures
+ *      above are stated against 45,000 and are left as the measured record;
+ *      re-derived at 48,000 they shift by ~6 %, inside the noise
+ *      {@link PARTS_PER_MEMORY} is calibrated against, and move no threshold
+ *      in this file.
+ *
  *  B8  Live `/metrics`, 2026-07-25 16:44 UTC, container up since
  *      2026-07-25T14:01:35Z (2.7 h), health `healthy`, RestartCount 0:
  *        retain operations   265 success / 3 failure  ⇒  1.1 % failure rate

--- a/src/hindsight-watch/types.ts
+++ b/src/hindsight-watch/types.ts
@@ -40,8 +40,11 @@ export interface Sample {
    * Live spooled retains across the fleet (`*.json`).
    *
    * Post-#3610 this counts memory PARTS, not memories: one oversized
-   * transcript enqueues one entry per 45,000-char part. Every threshold
-   * compared against it is scaled by `PARTS_PER_MEMORY`.
+   * transcript enqueues one entry per part, where the part size is derived
+   * from the retain client deadline (`retain_content_limit()`; 45,000 chars at
+   * the 280s deadline #3610 shipped, 48,000 at the 310s it is now — see B7a in
+   * `thresholds.ts`). Every threshold compared against it is scaled by
+   * `PARTS_PER_MEMORY`.
    */
   pending: number;
   /** permanently-failed spooled retains across the fleet (`*.json.dead`) */

--- a/src/litellm/repo-config.test.ts
+++ b/src/litellm/repo-config.test.ts
@@ -19,6 +19,12 @@ import {
   isClaudeAllowlistedGroup,
   parseLitellmConfig,
 } from "./header-passthrough-guard.js";
+import {
+  LITELLM_ROUTER_MARGIN_S,
+  LITELLM_TIMEOUT_TIERS,
+  detectLitellmTimeoutDrift,
+  extractGroupTimeouts,
+} from "./timeout-budget.js";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const configPath = join(repoRoot, "docker", "litellm-proxy", "litellm-config.yaml");
@@ -273,6 +279,110 @@ describe("repo-managed litellm-config.yaml (KEN-125)", () => {
       ).toBe(false);
       // A real pin must be immutable-ish: a digest, or a tag with a version.
       expect(imagePinLines[0]).toMatch(/(@sha256:[0-9a-f]{64}|:\S*\d)/);
+    }
+  });
+});
+
+describe("repo-managed litellm-config.yaml — paired timeout budgets (Fix B)", () => {
+  const actual = extractGroupTimeouts(parsed);
+
+  it("declares a per-deployment timeout on every group switchroom budgets for", () => {
+    // A group with no `timeout` inherits litellm_settings.request_timeout
+    // (600s here) — 4x the interactive lane's whole client budget, so the
+    // client always hangs up mid-fallback and the failover path does not
+    // exist. `gpt-oss-20b-openrouter` shipped in exactly that state until
+    // 2026-07-26; this test is what stops it recurring.
+    for (const tier of Object.values(LITELLM_TIMEOUT_TIERS)) {
+      for (const group of [tier.group, tier.fallbackGroup]) {
+        if (group === null || !actual.has(group)) continue; // absent lane: #3407's signal
+        expect(actual.get(group), `${configPath}: group '${group}' has no per-model timeout`).not.toBeNull();
+      }
+    }
+  });
+
+  it("matches the tiers switchroom derives its client budgets from", () => {
+    // The shipped config and src/litellm/timeout-budget.ts are two halves of
+    // one number. If this fails, one half was edited alone — which is the
+    // 2026-07-25/26 defect class, caught here at review time instead of by an
+    // operator noticing a lane has silently produced nothing for a week.
+    const drifts = detectLitellmTimeoutDrift(actual);
+    expect(
+      drifts.map((d) => `${d.group}: config ${d.actualS ?? "none"}s vs declared ${d.declaredS}s`),
+    ).toEqual([]);
+  });
+
+  it("keeps every router fallback edge represented in the declared tiers", () => {
+    // A fallback edge switchroom does not know about is an unbudgeted hop: the
+    // chain arithmetic silently omits it and the client budget is too small.
+    const fallbacks = (parsed.router_settings as Record<string, unknown> | undefined)?.fallbacks;
+    const declared = new Map(
+      Object.values(LITELLM_TIMEOUT_TIERS).map(
+        (t) => [t.group, t.fallbackGroup] as [string, string | null],
+      ),
+    );
+    for (const edge of Array.isArray(fallbacks) ? fallbacks : []) {
+      if (!edge || typeof edge !== "object") continue;
+      for (const [from, to] of Object.entries(edge as Record<string, unknown>)) {
+        if (!declared.has(from)) continue; // a lane switchroom does not budget
+        const targets = Array.isArray(to) ? to : [to];
+        expect(
+          targets,
+          `${configPath}: '${from}' falls back to ${JSON.stringify(targets)}, but ` +
+            `LITELLM_TIMEOUT_TIERS declares '${declared.get(from)}'`,
+        ).toContain(declared.get(from));
+      }
+    }
+  });
+
+  it("keeps every budgeted group OUT of the fleet pacer's allowlist", () => {
+    // LITELLM_ROUTER_MARGIN_S (10s) covers only litellm's own in-request work.
+    // It does NOT cover a pacer hold, and it could not: PACE_MAX_WAIT_S alone
+    // defaults to 20s and the hard backstop is clamped as high as 280s. The
+    // margin is sound today ONLY because no group these tiers budget matches
+    // PACE_MODEL_GROUPS. Adding e.g. `gpt-oss-*` to that allowlist would make
+    // every derived client budget too small again — silently, and in exactly
+    // the paired-drift shape this module exists to prevent. So it is checked
+    // rather than commented.
+    const pacerPath = join(repoRoot, "docker", "litellm-pacer", "custom_pacing.py");
+    const src = readFileSync(pacerPath, "utf8");
+
+    const read = (name: string): string[] => {
+      const m = new RegExp(`${name}\\s*=\\s*_csv_env\\(\\s*"${name}"\\s*,\\s*"([^"]*)"`).exec(src);
+      // An unreadable guard is not a guard. If the pacer's declaration shape
+      // changes, fail here instead of silently asserting over an empty list.
+      expect(m, `${pacerPath}: could not read the ${name} default`).not.toBeNull();
+      return m![1]
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    };
+
+    const globMatches = (pattern: string, value: string): boolean =>
+      new RegExp(
+        `^${pattern
+          .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+          .replace(/\*/g, ".*")
+          .replace(/\?/g, ".")}$`,
+      ).test(value);
+
+    const paced = read("PACE_MODEL_GROUPS");
+    const excluded = read("PACE_MODEL_GROUPS_EXCLUDE");
+    expect(paced.length).toBeGreaterThan(0);
+
+    for (const tier of Object.values(LITELLM_TIMEOUT_TIERS)) {
+      for (const group of [tier.group, tier.fallbackGroup]) {
+        if (group === null) continue;
+        // Same precedence as _group_is_paced(): exclusion wins.
+        const isPaced =
+          !excluded.some((p) => globMatches(p, group)) && paced.some((p) => globMatches(p, group));
+        expect(
+          isPaced,
+          `${pacerPath}: PACE_MODEL_GROUPS ${JSON.stringify(paced)} paces '${group}', which ` +
+            `LITELLM_TIMEOUT_TIERS budgets with only a ${LITELLM_ROUTER_MARGIN_S}s margin. A ` +
+            `pacer hold (PACE_MAX_WAIT_S defaults to 20s) does not fit in that margin — raise ` +
+            `the tier's timeouts to cover it, or keep the group unpaced.`,
+        ).toBe(false);
+      }
     }
   });
 });

--- a/src/litellm/timeout-budget.test.ts
+++ b/src/litellm/timeout-budget.test.ts
@@ -1,0 +1,357 @@
+/**
+ * The invariant these tests exist to enforce:
+ *
+ *   localTimeoutS + fallbackTimeoutS + margin  <=  clientBudgetS
+ *
+ * Every test here is written so that it FAILS on the real historical bug, not
+ * merely exercises the code that produces the number. Two live violations
+ * motivated them, both of which these assertions catch:
+ *
+ *   - retain      (#3611): client 204s vs chain 200 + 90 = 290
+ *   - interactive (2026-07-26): client 120s (vendor default) vs chain 90 + 60 = 150
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  LITELLM_ROUTER_MARGIN_S,
+  LITELLM_TIMEOUT_TIERS,
+  assertClientBudget,
+  clientBudgetSeconds,
+  detectLitellmTimeoutDrift,
+  extractGroupTimeouts,
+  litellmChainSeconds,
+  minimumClientBudgetSeconds,
+  type LitellmTimeoutTier,
+} from "./timeout-budget.js";
+import { parseLitellmConfig } from "./header-passthrough-guard.js";
+
+const RETAIN = LITELLM_TIMEOUT_TIERS.retain;
+const INTERACTIVE = LITELLM_TIMEOUT_TIERS.interactive;
+const CONSOLIDATION = LITELLM_TIMEOUT_TIERS.consolidation;
+
+describe("litellm timeout budget — chain arithmetic", () => {
+  it("counts the FULL fallback hop, not just the primary timeout", () => {
+    // The whole defect class is treating `local < client` as the invariant.
+    // The router's fallback runs inside the same client request, so the chain
+    // is the sum.
+    expect(litellmChainSeconds(RETAIN)).toBe(290);
+    expect(litellmChainSeconds(INTERACTIVE)).toBe(150);
+    expect(litellmChainSeconds(CONSOLIDATION)).toBe(290);
+    // Not the primary alone — the bug's arithmetic.
+    expect(litellmChainSeconds(RETAIN)).not.toBe(RETAIN.localTimeoutS);
+  });
+
+  it("collapses to the primary timeout when a group has no fallback", () => {
+    const noFallback: LitellmTimeoutTier = {
+      group: "solo",
+      localTimeoutS: 45,
+      fallbackGroup: null,
+      fallbackTimeoutS: 0,
+    };
+    expect(litellmChainSeconds(noFallback)).toBe(45);
+    expect(minimumClientBudgetSeconds(noFallback)).toBe(45 + LITELLM_ROUTER_MARGIN_S);
+  });
+
+  it("rejects a non-positive or non-finite timeout rather than silently underbudgeting", () => {
+    expect(() =>
+      litellmChainSeconds({ ...RETAIN, localTimeoutS: 0 }),
+    ).toThrow(/must be a positive number/);
+    expect(() =>
+      litellmChainSeconds({ ...RETAIN, fallbackTimeoutS: -1 }),
+    ).toThrow(/must be a positive number/);
+    expect(() =>
+      litellmChainSeconds({ ...RETAIN, localTimeoutS: Number.NaN }),
+    ).toThrow(/must be a positive number/);
+  });
+});
+
+describe("litellm timeout budget — assertClientBudget FAILS on the shipped bugs", () => {
+  it("rejects #3611's live retain budget (204s under a 290s chain)", () => {
+    // This is the exact number `hindsightRetainLlmTimeoutSeconds()` produced
+    // and that `docker inspect switchroom-hindsight` showed live on
+    // 2026-07-26: HINDSIGHT_API_RETAIN_LLM_TIMEOUT=204. The retain OpenRouter
+    // fallback had 4s of headroom.
+    expect(() =>
+      assertClientBudget({ role: "retain", tier: RETAIN, clientBudgetS: 204 }),
+    ).toThrow(/client budget 204s is below the 300s the routing chain needs/);
+  });
+
+  it("rejects the interactive lane's 120s vendor default under the raised 60s fallback", () => {
+    // hindsight_api/config.py DEFAULT_LLM_TIMEOUT = 120.0, taken because
+    // HINDSIGHT_API_LLM_TIMEOUT was never emitted. Chain 90 + 60 = 150.
+    expect(() =>
+      assertClientBudget({ role: "interactive", tier: INTERACTIVE, clientBudgetS: 120 }),
+    ).toThrow(/client budget 120s is below the 160s the routing chain needs/);
+  });
+
+  it("rejects the consolidation lane's 120s vendor default under a 290s chain", () => {
+    expect(() =>
+      assertClientBudget({ role: "consolidation", tier: CONSOLIDATION, clientBudgetS: 120 }),
+    ).toThrow(/client budget 120s is below the 300s the routing chain needs/);
+  });
+
+  it("rejects a budget that covers the chain but not the margin", () => {
+    // Exactly the chain is NOT enough: litellm's own routing, connection setup
+    // on the fallback hop, and response assembly happen inside the same
+    // request. (Not the fleet pacer — it does not pace these groups; see
+    // LITELLM_ROUTER_MARGIN_S.)
+    expect(() =>
+      assertClientBudget({ role: "retain", tier: RETAIN, clientBudgetS: 290 }),
+    ).toThrow(/below the 300s/);
+    expect(() =>
+      assertClientBudget({ role: "retain", tier: RETAIN, clientBudgetS: 299 }),
+    ).toThrow(/below the 300s/);
+  });
+
+  it("accepts exactly the required budget and anything above it", () => {
+    expect(() =>
+      assertClientBudget({ role: "retain", tier: RETAIN, clientBudgetS: 300 }),
+    ).not.toThrow();
+    expect(() =>
+      assertClientBudget({ role: "retain", tier: RETAIN, clientBudgetS: 600 }),
+    ).not.toThrow();
+  });
+
+  it("names both halves and the file to edit, so the error is actionable", () => {
+    let msg = "";
+    try {
+      assertClientBudget({ role: "retain", tier: RETAIN, clientBudgetS: 204 });
+    } catch (err) {
+      msg = (err as Error).message;
+    }
+    expect(msg).toContain("200s (gpt-oss-20b-retain)");
+    expect(msg).toContain("90s (gpt-oss-20b-retain-openrouter)");
+    expect(msg).toContain("src/litellm/timeout-budget.ts");
+  });
+});
+
+describe("litellm timeout budget — derivation, not hand-set constants", () => {
+  it("derives the interactive budget to exactly the 160s Ken set", () => {
+    // 90 + 60 + 10. The point is that nobody typed 160.
+    expect(clientBudgetSeconds(INTERACTIVE)).toBe(160);
+  });
+
+  it("derives retain and consolidation to 300s from their 290s chains", () => {
+    expect(clientBudgetSeconds(RETAIN)).toBe(300);
+    expect(clientBudgetSeconds(CONSOLIDATION)).toBe(300);
+  });
+
+  it("PRESERVES #3611: the token-derived value is kept as a floor, not discarded", () => {
+    // A tier whose chain is tiny must still not go below the token-derived
+    // floor, or a legitimately full-length extraction is starved by its own
+    // deadline — the reasoning #3611 shipped.
+    const tinyChain: LitellmTimeoutTier = {
+      group: "tiny",
+      localTimeoutS: 10,
+      fallbackGroup: "tiny-fallback",
+      fallbackTimeoutS: 10,
+    };
+    expect(minimumClientBudgetSeconds(tinyChain)).toBe(30);
+    expect(clientBudgetSeconds(tinyChain, 204)).toBe(204); // floor wins
+    expect(clientBudgetSeconds(tinyChain, 5)).toBe(30); // chain wins
+    // And on the real retain tier the chain is the larger of the two.
+    expect(clientBudgetSeconds(RETAIN, 204)).toBe(300);
+  });
+
+  it("moves the budget when a tier moves — the drift this prevents", () => {
+    // Raise the fallback hop and the client budget follows, with no second
+    // edit. This is the mechanism; everything else is bookkeeping.
+    const raised: LitellmTimeoutTier = { ...INTERACTIVE, fallbackTimeoutS: 90 };
+    expect(clientBudgetSeconds(raised)).toBe(190);
+    expect(clientBudgetSeconds(raised)).not.toBe(clientBudgetSeconds(INTERACTIVE));
+  });
+
+  it("rounds a fractional floor UP, never down into a violation", () => {
+    const t: LitellmTimeoutTier = {
+      group: "t",
+      localTimeoutS: 5,
+      fallbackGroup: null,
+      fallbackTimeoutS: 0,
+    };
+    expect(clientBudgetSeconds(t, 203.2)).toBe(204);
+  });
+
+  it("every declared tier's derived budget satisfies its own assertion", () => {
+    for (const [role, tier] of Object.entries(LITELLM_TIMEOUT_TIERS)) {
+      const budget = clientBudgetSeconds(tier);
+      expect(() => assertClientBudget({ role, tier, clientBudgetS: budget })).not.toThrow();
+    }
+  });
+});
+
+describe("litellm timeout budget — drift detection against the live proxy config", () => {
+  const live = (entries: Array<[string, number | null]>) => new Map(entries);
+
+  it("reports NOTHING when the live config matches the declaration", () => {
+    expect(
+      detectLitellmTimeoutDrift(
+        live([
+          ["gpt-oss-20b", 90],
+          ["gpt-oss-20b-openrouter", 60],
+          ["gpt-oss-20b-retain", 200],
+          ["gpt-oss-20b-retain-openrouter", 90],
+          ["gpt-oss-20b-consolidation", 200],
+          ["gpt-oss-20b-consolidation-openrouter", 90],
+        ]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("catches the 2026-07-26 change: the fallback hop moved and nothing else did", () => {
+    // The operator raises the interactive fallback 60 → 90 on the host without
+    // touching the declaration. Every interactive budget switchroom emits is
+    // now 30s short, silently.
+    const drifts = detectLitellmTimeoutDrift(
+      live([
+        ["gpt-oss-20b", 90],
+        ["gpt-oss-20b-openrouter", 90],
+      ]),
+    );
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0]).toMatchObject({
+      role: "interactive",
+      group: "gpt-oss-20b-openrouter",
+      declaredS: 60,
+      actualS: 90,
+    });
+    expect(drifts[0]!.detail).toContain("drifted apart");
+  });
+
+  it("catches a group with NO timeout at all (inherits request_timeout: 600)", () => {
+    // The state `gpt-oss-20b-openrouter` shipped in until this change gave it
+    // `timeout: 60` — the most dangerous shape, because a group with no
+    // timeout inherits 600s and blows every client budget on the lane.
+    const drifts = detectLitellmTimeoutDrift(live([["gpt-oss-20b-openrouter", null]]));
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0]!.actualS).toBeNull();
+    expect(drifts[0]!.detail).toContain("carries NO per-deployment timeout");
+  });
+
+  it("stays silent about groups the live config does not define at all", () => {
+    // A missing model group is a DIFFERENT signal with a different owner
+    // (src/litellm/model-validation.ts, #3407). Reporting it here would make
+    // this check noisy on any partial config and train people to ignore it.
+    expect(detectLitellmTimeoutDrift(live([]))).toEqual([]);
+    expect(detectLitellmTimeoutDrift(live([["gpt-oss-20b", 90]]))).toEqual([]);
+  });
+
+  it("reports every drifted group, not just the first", () => {
+    const drifts = detectLitellmTimeoutDrift(
+      live([
+        ["gpt-oss-20b", 45],
+        ["gpt-oss-20b-openrouter", 25],
+        ["gpt-oss-20b-retain", 90],
+      ]),
+    );
+    expect(drifts.map((d) => d.group).sort()).toEqual([
+      "gpt-oss-20b",
+      "gpt-oss-20b-openrouter",
+      "gpt-oss-20b-retain",
+    ]);
+  });
+});
+
+describe("litellm timeout budget — extractGroupTimeouts over real config shapes", () => {
+  const yaml = (s: string) => extractGroupTimeouts(parseLitellmConfig(s));
+
+  it("reads the per-deployment timeout for each model group", () => {
+    const got = yaml(`
+model_list:
+  - model_name: gpt-oss-20b
+    litellm_params:
+      model: openai/gpt-oss-20b
+      timeout: 90
+  - model_name: gpt-oss-20b-retain
+    litellm_params:
+      model: openai/gpt-oss-20b
+      timeout: 200
+`);
+    expect(got.get("gpt-oss-20b")).toBe(90);
+    expect(got.get("gpt-oss-20b-retain")).toBe(200);
+  });
+
+  it("reports null for a group whose deployment carries NO timeout", () => {
+    // The shape docker/litellm-proxy/litellm-config.yaml shipped for
+    // `gpt-oss-20b-openrouter` before this change: no timeout ⇒ inherits
+    // request_timeout: 600.
+    const got = yaml(`
+model_list:
+  - model_name: gpt-oss-20b-openrouter
+    litellm_params:
+      model: openrouter/openai/gpt-oss-20b
+`);
+    expect(got.has("gpt-oss-20b-openrouter")).toBe(true);
+    expect(got.get("gpt-oss-20b-openrouter")).toBeNull();
+  });
+
+  it("takes the WORST case across a load-balanced group's deployments", () => {
+    // The router may pick either deployment, so the budget must survive the
+    // slower one. An unbounded sibling makes the whole group unbounded.
+    const balanced = yaml(`
+model_list:
+  - model_name: g
+    litellm_params: { model: a, timeout: 90 }
+  - model_name: g
+    litellm_params: { model: b, timeout: 200 }
+`);
+    expect(balanced.get("g")).toBe(200);
+
+    const oneUnbounded = yaml(`
+model_list:
+  - model_name: g
+    litellm_params: { model: a, timeout: 90 }
+  - model_name: g
+    litellm_params: { model: b }
+`);
+    expect(oneUnbounded.get("g")).toBeNull();
+  });
+
+  it("treats a non-positive or unparseable timeout as unbounded, not as a bound", () => {
+    const got = yaml(`
+model_list:
+  - model_name: zero
+    litellm_params: { model: a, timeout: 0 }
+  - model_name: junk
+    litellm_params: { model: a, timeout: "soon" }
+`);
+    expect(got.get("zero")).toBeNull();
+    expect(got.get("junk")).toBeNull();
+  });
+
+  it("accepts a numeric string timeout (YAML quoting is not a semantic change)", () => {
+    expect(yaml(`
+model_list:
+  - model_name: g
+    litellm_params: { model: a, timeout: "90" }
+`).get("g")).toBe(90);
+  });
+
+  it("returns empty (never throws) for configs with no model_list at all", () => {
+    expect(extractGroupTimeouts(null).size).toBe(0);
+    expect(extractGroupTimeouts(undefined).size).toBe(0);
+    expect(extractGroupTimeouts("not a config").size).toBe(0);
+    expect(yaml("litellm_settings: { request_timeout: 600 }").size).toBe(0);
+    expect(yaml("model_list: not-a-list").size).toBe(0);
+    expect(yaml("model_list: [null, 3, {}, {model_name: 1}]").size).toBe(0);
+  });
+
+  it("end to end: a config whose fallback hop drifted is caught", () => {
+    const drifts = detectLitellmTimeoutDrift(
+      yaml(`
+model_list:
+  - model_name: gpt-oss-20b
+    litellm_params: { model: a, timeout: 90 }
+  - model_name: gpt-oss-20b-openrouter
+    litellm_params: { model: b, timeout: 25 }
+`),
+    );
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0]).toMatchObject({
+      role: "interactive",
+      group: "gpt-oss-20b-openrouter",
+      declaredS: 60,
+      actualS: 25,
+    });
+  });
+});

--- a/src/litellm/timeout-budget.ts
+++ b/src/litellm/timeout-budget.ts
@@ -1,0 +1,384 @@
+/**
+ * Paired timeout budgets for the LiteLLM proxy chain — DERIVED, never hand-set.
+ *
+ * ── The bug this exists to make impossible ──────────────────────────────────
+ *
+ * A hindsight LLM call crosses three deadlines stacked inside each other:
+ *
+ *   plugin ──POST /retain──▶ hindsight ──chat/completions──▶ litellm ──▶ upstream
+ *          (client deadline)          (per-call LLM timeout)      (per-deployment
+ *                                                                  timeout, ×2:
+ *                                                                  local then
+ *                                                                  fallback)
+ *
+ * LiteLLM's router fallback is *inside* one client request: hindsight issues a
+ * single POST with a single timeout, and litellm may spend `localTimeoutS` on
+ * the primary group, fail, and then spend `fallbackTimeoutS` on the fallback
+ * group — all under that one client deadline. So the invariant is not
+ * `local < client`, it is:
+ *
+ *   localTimeoutS + fallbackTimeoutS + MARGIN  <=  clientBudgetS
+ *
+ * Violate it and the fallback hop can NEVER complete: the client hangs up
+ * mid-fallback, every failover becomes a guaranteed error, and litellm keeps
+ * the upstream slot (and, on a metered provider, the meter) running against a
+ * request nobody is waiting for.
+ *
+ * This has now happened twice, in both directions:
+ *
+ *  - **2026-07-25 (#3611)** moved the retain CLIENT budget to a derived value
+ *    (`ceil(16384 / 80.6) = 204s`) without moving the litellm-side halves,
+ *    which were `local 200 + fallback 90 = 290`. 290 > 204: the retain
+ *    OpenRouter fallback had 4s of headroom and could never finish.
+ *  - **2026-07-26** raised the interactive fallback hop 25s → 60s, giving
+ *    `local 90 + fallback 60 = 150` against hindsight's 120s default client
+ *    timeout (`DEFAULT_LLM_TIMEOUT`, `hindsight_api/config.py:733`). Same
+ *    defect, other lane.
+ *
+ * Both times the config carried a correct comment saying "both halves must
+ * move together" and both times a half moved alone. A comment is not a
+ * mechanism. {@link assertClientBudget} is.
+ *
+ * ── Source of truth ─────────────────────────────────────────────────────────
+ *
+ * The per-deployment timeouts live in the operator-maintained LiteLLM proxy
+ * config, which is OUTSIDE this repo at runtime
+ * (`/data/coolify/services/<id>/litellm-config.yaml`; the repo copy at
+ * `docker/litellm-proxy/litellm-config.yaml` is the reviewed upstream of it).
+ * Nothing in a container can read that file, so the derivation cannot read it
+ * either.
+ *
+ * Therefore: **switchroom declares the tiers here, and this declaration is
+ * authoritative.** Every client budget switchroom emits is computed from it, so
+ * the two halves are one number by construction. Drift between this declaration
+ * and the live proxy config is caught separately and loudly by
+ * {@link detectLitellmTimeoutDrift}, wired into the on-host fleet-health
+ * sensor — the same division of labour CLAUDE.md documents for the I2
+ * OAuth-leak guard (an in-repo check that is vacuous off-host, plus an on-host
+ * sensor that is load-bearing).
+ *
+ * Changing a timeout in the live proxy config WITHOUT changing the matching
+ * number here is a supported operation in the sense that it will not silently
+ * break: the sensor reports it. It is not supported in the sense that it should
+ * ever be left that way.
+ */
+
+/**
+ * Slack added on top of the litellm chain before the client may hang up.
+ *
+ * The chain arithmetic (`local + fallback`) accounts only for time spent
+ * waiting on upstreams. It does not account for litellm's own work inside the
+ * request: routing/deployment selection, connection setup on the fallback hop,
+ * response assembly, and logging callbacks. 10s covers that on the observed
+ * fleet and keeps the derived budgets at round, reviewable numbers.
+ *
+ * Corroboration that 10 is the right size, not a guess: it is the value that
+ * makes the interactive lane derive to exactly 160s (90 + 60 + 10), which is
+ * independently the budget Ken set for that lane on 2026-07-26.
+ *
+ * NOT covered, and deliberately so: the fleet pacer's admission delay. The
+ * pacer (`docker/litellm-pacer/custom_pacing.py`) holds a request only when its
+ * model group matches `PACE_MODEL_GROUPS` — default `claude-*,sonnet,fable` —
+ * and no `gpt-oss-20b*` group in {@link LITELLM_TIMEOUT_TIERS} matches it, so
+ * no tier declared here is ever paced. That is load-bearing rather than
+ * incidental: `PACE_MAX_WAIT_S` alone defaults to 20s, twice this margin, and
+ * the hard backstop is clamped as high as `_PACE_WATCHDOG_SAFE_CEILING_S`
+ * (280s). If a `gpt-oss-*` group is ever added to that allowlist, this margin
+ * is no longer sufficient and every tier below has to grow to cover the hold.
+ */
+export const LITELLM_ROUTER_MARGIN_S = 10;
+
+/**
+ * One role's litellm routing tier: the primary model group and the
+ * router-level fallback it hops to, with the per-deployment timeout on each.
+ *
+ * `localTimeoutS` is named for the common case (the primary group is the pair
+ * of local Ollama boxes) but is simply "the timeout on the primary group" — it
+ * is correct even when the primary is remote.
+ */
+export interface LitellmTimeoutTier {
+  /** Primary model group name, as it appears in `model_list[].model_name`. */
+  readonly group: string;
+  /** Per-deployment `timeout` on every deployment in {@link group}. */
+  readonly localTimeoutS: number;
+  /**
+   * Router-level fallback target for {@link group}, from
+   * `router_settings.fallbacks`. `null` when the group has no fallback — the
+   * chain is then just {@link localTimeoutS}.
+   */
+  readonly fallbackGroup: string | null;
+  /** Per-deployment `timeout` on the fallback group. 0 when there is none. */
+  readonly fallbackTimeoutS: number;
+}
+
+/**
+ * The declared tiers, vendored from the live LiteLLM config on 2026-07-26.
+ *
+ * Each number is cited to the reasoning that produced it. None of them is a
+ * value this module chose — they are the operator's routing decisions, recorded
+ * here so the client budgets can be derived from them.
+ */
+export const LITELLM_TIMEOUT_TIERS = {
+  /**
+   * Interactive lane — `recall`, `reflect`, and the default hindsight LLM
+   * config. A person is waiting, so it fails fast.
+   *
+   * local 90s: the largest value that is both above the observed local max
+   * (72.1s, n=77, 2026-07-25) and inside the fallback budget. 45s was tried on
+   * 2026-07-25 and reverted — it severed ~8% of calls that were succeeding.
+   *
+   * fallback 60s: raised from 25s on 2026-07-26. At 25s the tier NEVER
+   * completed (5,184 read timeouts in 24h). 60s was chosen over dropping the
+   * local half to 60 because measured interactive reflect durations (n=36 over
+   * 24h) are p95 82.9s / p99 95.5s / max 118.2s — 19.4% exceed 60s, so a 60s
+   * local half would break reflect for a fifth of calls.
+   */
+  interactive: {
+    group: "gpt-oss-20b",
+    localTimeoutS: 90,
+    fallbackGroup: "gpt-oss-20b-openrouter",
+    fallbackTimeoutS: 60,
+  },
+
+  /**
+   * Retain lane — background fact extraction over a session transcript. No
+   * person is waiting, and a full-length extraction legitimately needs ~190s
+   * at the measured local floor of 80.6 tok/s against the 16384-token cap.
+   *
+   * local 200s: ~1.05x that 190s worst case. Deliberately not larger — it must
+   * still cut a genuine runaway, and the token cap is what bounds the worst
+   * case.
+   *
+   * fallback 90s: this hop only runs after a local attempt has already burned
+   * up to 200s, and an extraction that needs 190s locally will not finish in
+   * the interactive lane's 25s anywhere. Measured retain-fallback durations
+   * (LiteLLM_SpendLogs, `gpt-oss-20b-retain-openrouter`, 7d, n=58 successes)
+   * are p50 28.1s / p95 132.4s, so this hop is not generous.
+   */
+  retain: {
+    group: "gpt-oss-20b-retain",
+    localTimeoutS: 200,
+    fallbackGroup: "gpt-oss-20b-retain-openrouter",
+    fallbackTimeoutS: 90,
+  },
+
+  /**
+   * Consolidation lane — same shape and same rationale as retain: a background
+   * batch job whose fallback hop only runs after 200s has already been spent
+   * locally.
+   */
+  consolidation: {
+    group: "gpt-oss-20b-consolidation",
+    localTimeoutS: 200,
+    fallbackGroup: "gpt-oss-20b-consolidation-openrouter",
+    fallbackTimeoutS: 90,
+  },
+} as const satisfies Record<string, LitellmTimeoutTier>;
+
+/** The role names {@link LITELLM_TIMEOUT_TIERS} declares a tier for. */
+export type LitellmTimeoutRole = keyof typeof LITELLM_TIMEOUT_TIERS;
+
+/**
+ * Worst-case wall time litellm may spend inside ONE client request for this
+ * tier: the full primary timeout, then the full fallback timeout.
+ *
+ * This is deliberately the worst case and not an expected case. The client
+ * budget has to cover the failover path or the failover path does not exist.
+ */
+export function litellmChainSeconds(tier: LitellmTimeoutTier): number {
+  assertPositive(tier.localTimeoutS, `${tier.group} localTimeoutS`);
+  if (tier.fallbackGroup === null) return tier.localTimeoutS;
+  assertPositive(tier.fallbackTimeoutS, `${tier.fallbackGroup} fallbackTimeoutS`);
+  return tier.localTimeoutS + tier.fallbackTimeoutS;
+}
+
+/**
+ * The minimum client budget this tier can be served under:
+ * `local + fallback + margin`. Below this the fallback hop cannot complete.
+ */
+export function minimumClientBudgetSeconds(
+  tier: LitellmTimeoutTier,
+  marginS: number = LITELLM_ROUTER_MARGIN_S,
+): number {
+  return litellmChainSeconds(tier) + marginS;
+}
+
+/**
+ * The client budget to emit for a tier.
+ *
+ * `max(floorS, local + fallback + margin)` — NOT a replacement for whatever
+ * derivation produced `floorS`.
+ *
+ * The `floorS` argument is how #3611's reasoning survives. That change derived
+ * the retain budget from the output-token cap and the measured generation rate
+ * (`ceil(16384 / 80.6) = 204s`) so a legitimately full-length extraction is
+ * never starved by its own deadline. That remains a real lower bound and is
+ * passed in here. The chain arithmetic is a second, independent lower bound.
+ * The budget has to satisfy both, so it is the larger.
+ *
+ * Note what taking the max does NOT do: it does not reopen the 767.6s runaway
+ * #3611 fixed. Runaway generation is cut by the output cap
+ * (`HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS`) and by litellm's own
+ * per-deployment `timeout` upstream of the client — a longer CLIENT budget
+ * cannot let an upstream call run past `localTimeoutS`, it only stops the
+ * client abandoning a fallback that is still legitimately in flight.
+ */
+export function clientBudgetSeconds(
+  tier: LitellmTimeoutTier,
+  floorS = 0,
+  marginS: number = LITELLM_ROUTER_MARGIN_S,
+): number {
+  return Math.max(Math.ceil(floorS), minimumClientBudgetSeconds(tier, marginS));
+}
+
+/**
+ * Fail loudly, at config-emit time, on a client budget that cannot cover its
+ * tier's fallback hop.
+ *
+ * Called from the hindsight env emit paths, so an inconsistent budget can never
+ * reach a container — the same "assert at emit time" precedent
+ * `assertHindsightRetainBudget` set in #3611.
+ */
+export function assertClientBudget(args: {
+  role: string;
+  tier: LitellmTimeoutTier;
+  clientBudgetS: number;
+  marginS?: number;
+}): void {
+  const { role, tier, clientBudgetS } = args;
+  const marginS = args.marginS ?? LITELLM_ROUTER_MARGIN_S;
+  const required = minimumClientBudgetSeconds(tier, marginS);
+  if (clientBudgetS < required) {
+    const chain =
+      tier.fallbackGroup === null
+        ? `${tier.localTimeoutS}s`
+        : `${tier.localTimeoutS}s (${tier.group}) + ${tier.fallbackTimeoutS}s (${tier.fallbackGroup})`;
+    throw new Error(
+      `litellm timeout budget [${role}]: client budget ${clientBudgetS}s is below the ` +
+        `${required}s the routing chain needs (${chain} + ${marginS}s margin = ${required}s). ` +
+        `The fallback hop can never complete under this budget: the client hangs up ` +
+        `mid-failover, every failover becomes a guaranteed error, and litellm keeps the ` +
+        `upstream slot held against a request nobody is waiting for. Raise the client ` +
+        `budget, or lower localTimeoutS/fallbackTimeoutS for '${tier.group}' in ` +
+        `src/litellm/timeout-budget.ts AND in the live litellm-config.yaml together.`,
+    );
+  }
+}
+
+/** A disagreement between a declared tier and the live proxy config. */
+export interface LitellmTimeoutDrift {
+  /** Role whose tier disagrees. */
+  role: string;
+  /** Model group the disagreement is on. */
+  group: string;
+  /** What `LITELLM_TIMEOUT_TIERS` says. */
+  declaredS: number;
+  /** What the live config says. `null` ⇒ the group carries no `timeout` at all. */
+  actualS: number | null;
+  /** Human-readable explanation, safe to put in an operator alert. */
+  detail: string;
+}
+
+/**
+ * Compare the declared tiers against per-group timeouts read out of a live
+ * LiteLLM config, and report every disagreement.
+ *
+ * Pure over its inputs: the caller supplies `actualTimeouts` (group name → the
+ * per-deployment `timeout`, or `null` when the group's deployments carry none
+ * and therefore inherit `litellm_settings.request_timeout`). Parsing the YAML
+ * and locating the file is the on-host sensor's job, not this module's.
+ *
+ * A group that is absent from `actualTimeouts` entirely is NOT reported: the
+ * proxy may legitimately be running a config where that lane does not exist
+ * yet, and "the lane is missing" is a different signal with a different owner
+ * (`src/litellm/model-validation.ts`, #3407). This function reports only
+ * `declared !== actual` for groups that DO exist — the drift that silently
+ * breaks the budget while everything appears configured.
+ */
+export function detectLitellmTimeoutDrift(
+  actualTimeouts: ReadonlyMap<string, number | null>,
+  tiers: Record<string, LitellmTimeoutTier> = LITELLM_TIMEOUT_TIERS,
+): LitellmTimeoutDrift[] {
+  const drifts: LitellmTimeoutDrift[] = [];
+  for (const [role, tier] of Object.entries(tiers)) {
+    const check = (group: string | null, declaredS: number) => {
+      if (group === null) return;
+      if (!actualTimeouts.has(group)) return;
+      const actualS = actualTimeouts.get(group) ?? null;
+      if (actualS === declaredS) return;
+      drifts.push({
+        role,
+        group,
+        declaredS,
+        actualS,
+        detail:
+          actualS === null
+            ? `litellm group '${group}' carries NO per-deployment timeout (it inherits ` +
+              `litellm_settings.request_timeout), but switchroom derives the ${role} client ` +
+              `budget assuming ${declaredS}s. Every client budget for this lane is wrong.`
+            : `litellm group '${group}' has timeout ${actualS}s but switchroom declares ` +
+              `${declaredS}s (src/litellm/timeout-budget.ts). The ${role} client budget was ` +
+              `derived from ${declaredS}s, so the paired budgets have drifted apart — this ` +
+              `is exactly the 2026-07-25/26 defect class. Update the declaration and re-apply, ` +
+              `or revert the proxy config.`,
+      });
+    };
+    check(tier.group, tier.localTimeoutS);
+    check(tier.fallbackGroup, tier.fallbackTimeoutS);
+  }
+  return drifts;
+}
+
+/**
+ * Read per-group `timeout` values out of a parsed LiteLLM config's `model_list`.
+ *
+ * Returns group name → the timeout the WORST-CASE deployment in that group
+ * carries. "Worst case" because a group is a load-balanced set and the router
+ * may pick any deployment in it, so the budget has to survive the slowest:
+ *
+ *  - any deployment missing `timeout` ⇒ `null` (that deployment inherits
+ *    `litellm_settings.request_timeout`, typically 600s, which blows every
+ *    budget on the lane — the single most dangerous shape, so it wins);
+ *  - otherwise the maximum of the deployments' timeouts.
+ *
+ * Groups present in `model_list` but with an unparseable/non-positive timeout
+ * are treated as `null` for the same reason: an unreadable bound is not a bound.
+ *
+ * Pure; never throws. Feed the result to {@link detectLitellmTimeoutDrift}.
+ */
+export function extractGroupTimeouts(parsed: unknown): Map<string, number | null> {
+  const out = new Map<string, number | null>();
+  if (!parsed || typeof parsed !== "object") return out;
+  const list = (parsed as Record<string, unknown>).model_list;
+  if (!Array.isArray(list)) return out;
+
+  for (const entry of list) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const name = e.model_name;
+    if (typeof name !== "string" || name.length === 0) continue;
+
+    const params = e.litellm_params;
+    const rawTimeout =
+      params && typeof params === "object"
+        ? (params as Record<string, unknown>).timeout
+        : undefined;
+    const n = typeof rawTimeout === "number" ? rawTimeout : Number(rawTimeout);
+    const timeout = Number.isFinite(n) && n > 0 ? n : null;
+
+    if (!out.has(name)) {
+      out.set(name, timeout);
+      continue;
+    }
+    const prev = out.get(name) ?? null;
+    // null (unbounded) always wins; otherwise keep the larger bound.
+    out.set(name, prev === null || timeout === null ? null : Math.max(prev, timeout));
+  }
+  return out;
+}
+
+function assertPositive(value: number, label: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`litellm timeout budget: ${label} must be a positive number, got ${value}`);
+  }
+}

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -1,6 +1,12 @@
 import { execFileSync } from "node:child_process";
 import { createServer } from "node:net";
 import { isClaudeModel } from "../../telegram-plugin/gateway/model-command.js";
+import {
+  LITELLM_ROUTER_MARGIN_S,
+  LITELLM_TIMEOUT_TIERS,
+  assertClientBudget,
+  clientBudgetSeconds,
+} from "../litellm/timeout-budget.js";
 
 /**
  * Default Hindsight host ports.
@@ -395,23 +401,18 @@ export const HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS = 16384;
 export const HINDSIGHT_RETAIN_MIN_TOKENS_PER_SECOND = 80.6;
 
 /**
- * The retain CLIENT deadline: how long a caller waits for one retain POST.
- * Mirrors `DEFAULT_RETAIN_CLIENT_DEADLINE_S` in the plugin's
- * `vendor/hindsight-memory/scripts/lib/retain_split.py`, which sizes its
- * content bound off the same number. Explicit constant so the assertion below
- * is a real check, not a comparison against a literal nobody maintains.
- */
-export const HINDSIGHT_RETAIN_CLIENT_DEADLINE_S = 280;
-
-/**
- * Server-side per-call deadline, DERIVED from the output cap:
+ * Token-budget-derived per-call deadline, from the output cap (#3611):
  *
  *   ceil(maxCompletionTokens / minTokensPerSecond)
  *   = ceil(16384 / 80.6) = 204s
  *
  * Exactly long enough for the model to emit its whole permitted output at the
- * slowest measured rate, and not a second longer. Raising the token cap moves
- * this automatically; the two can no longer drift apart.
+ * slowest measured rate. Raising the token cap moves this automatically; the
+ * two can no longer drift apart.
+ *
+ * This is now a FLOOR on the emitted retain deadline rather than the emitted
+ * value itself — see {@link hindsightRetainClientTimeoutSeconds} for why, and
+ * for the second lower bound it is taken against.
  */
 export function hindsightRetainLlmTimeoutSeconds(
   maxCompletionTokens: number = HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS,
@@ -425,6 +426,62 @@ export function hindsightRetainLlmTimeoutSeconds(
   }
   return Math.ceil(maxCompletionTokens / tokensPerSecond);
 }
+
+/**
+ * Hindsight's per-call LLM deadline for the RETAIN lane — the value emitted as
+ * `HINDSIGHT_API_RETAIN_LLM_TIMEOUT`.
+ *
+ * This one number sits between two deadlines and has to satisfy both, which is
+ * why it is derived rather than chosen:
+ *
+ *   litellm chain (200 + 90) + margin 10  <=  THIS  <  retain client deadline
+ *                          300            <=  300  <         310
+ *
+ * ── Lower bound (new, #3611's missing half) ─────────────────────────────────
+ * litellm's router fallback runs INSIDE this one request: up to 200s on the
+ * local `gpt-oss-20b-retain` group, then up to 90s on
+ * `gpt-oss-20b-retain-openrouter`. #3611 set this to the token-derived 204s
+ * while the chain below it was already 290s, so the retain fallback hop had 4s
+ * of headroom and could never complete. {@link clientBudgetSeconds} now takes
+ * the max of the two lower bounds, so the token derivation is preserved as a
+ * FLOOR (204s — never starve a legitimately full-length extraction) rather than
+ * being the whole answer.
+ *
+ * Raising this from 204 to 300 does not reopen the 767.6s runaway #3611 fixed.
+ * A runaway is cut by `HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS` at the
+ * source and by litellm's own 200s per-deployment timeout upstream of this
+ * client — a longer CLIENT deadline cannot make an upstream call run longer, it
+ * only stops the client abandoning a failover that is still in flight.
+ *
+ * ── Upper bound (#3611's assertion, unchanged) ──────────────────────────────
+ * Must stay strictly under the retain POST deadline the plugin holds, or the
+ * plugin walks away while hindsight is still working — see
+ * {@link assertHindsightRetainBudget}.
+ */
+export function hindsightRetainClientTimeoutSeconds(): number {
+  return clientBudgetSeconds(
+    LITELLM_TIMEOUT_TIERS.retain,
+    hindsightRetainLlmTimeoutSeconds(),
+  );
+}
+
+/**
+ * The retain CLIENT deadline: how long a caller waits for one retain POST.
+ *
+ * DERIVED, not hand-set: one margin above
+ * {@link hindsightRetainClientTimeoutSeconds}, so the plugin always outlives
+ * hindsight's own LLM deadline by construction. It was the literal `280` until
+ * the retain chain grew past it — a hand-set number in a chain of derived ones
+ * is the drift bug wearing a different hat.
+ *
+ * Mirrored by `DEFAULT_RETAIN_CLIENT_DEADLINE_S` in the plugin's
+ * `vendor/hindsight-memory/scripts/lib/retain_split.py`, which sizes its
+ * content bound and the backlog-drain timeout off the same number (#3610).
+ * `tests/setup/hindsight.test.ts` enforces that the two stay equal, so the
+ * mirror is a check rather than a comment.
+ */
+export const HINDSIGHT_RETAIN_CLIENT_DEADLINE_S =
+  hindsightRetainClientTimeoutSeconds() + LITELLM_ROUTER_MARGIN_S;
 
 /**
  * Fail loudly on an inconsistent retain budget, at config-emit time, before a
@@ -474,23 +531,131 @@ export function assertHindsightRetainBudget(budget: {
 }
 
 /**
- * The retain budget env vars as `[key, value]` pairs. Asserted before it
- * returns, so both emit paths ({@link startHindsight} and
- * {@link generateHindsightComposeSnippet}) fail loudly on a violation and can
- * never drift from each other.
+ * Hindsight's per-call LLM deadline for the INTERACTIVE lane — emitted as both
+ * `HINDSIGHT_API_LLM_TIMEOUT` (the global default, used by recall and the
+ * default LLM config) and `HINDSIGHT_API_REFLECT_LLM_TIMEOUT`, because both
+ * route to the `gpt-oss-20b` group.
+ *
+ * `90 (local) + 60 (openrouter fallback) + 10 (margin) = 160s`.
+ *
+ * Previously NOT EMITTED AT ALL, so it silently took hindsight's vendor default
+ * of 120s (`hindsight_api/config.py:733 DEFAULT_LLM_TIMEOUT`). When the
+ * interactive fallback hop was raised 25s → 60s on 2026-07-26 the chain became
+ * 150s against that unmoved 120s default, so the fallback could not complete —
+ * the same paired-drift defect as the retain lane, in the lane where a person
+ * is actually waiting. An unset knob is still half of a pair; it just has
+ * nobody's name on it. Emitting it explicitly is what makes it derivable.
+ *
+ * 160s is also the value Ken set for this lane on 2026-07-26, arrived at
+ * independently — the derivation reproduces it rather than replacing it.
+ *
+ * The measured interactive floor is comfortably under this: reflect durations
+ * over 24h (n=36) were max 118.2s, p99 95.5s, p95 82.9s, median 29.2s.
  */
-export function hindsightRetainBudgetEnv(): Array<[string, string]> {
+export function hindsightInteractiveLlmTimeoutSeconds(): number {
+  return clientBudgetSeconds(LITELLM_TIMEOUT_TIERS.interactive);
+}
+
+/**
+ * Hindsight's per-call LLM deadline for the CONSOLIDATION lane — emitted as
+ * `HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT`.
+ *
+ * `200 (local) + 90 (openrouter fallback) + 10 (margin) = 300s`.
+ *
+ * Also previously unemitted, so it took the same 120s vendor default while its
+ * routing chain was 290s — the identical defect as the interactive lane. The
+ * live symptom was in the logs: 173 `exceeded timeout=120.0s` errors and
+ * 160/630 consolidation calls needing at least one retry.
+ */
+export function hindsightConsolidationLlmTimeoutSeconds(): number {
+  return clientBudgetSeconds(LITELLM_TIMEOUT_TIERS.consolidation);
+}
+
+/**
+ * Every LLM timeout budget hindsight is handed, as `[key, value]` pairs.
+ *
+ * Asserted before it returns, so both emit paths ({@link startHindsight} and
+ * {@link generateHindsightComposeSnippet}) fail loudly on a violation and can
+ * never drift from each other — or from the litellm routing chain each budget
+ * is derived from.
+ *
+ * Two independent assertions run per lane:
+ *   - {@link assertClientBudget}: the budget covers `local + fallback + margin`,
+ *     so the router's fallback hop can actually complete (the 2026-07-25/26
+ *     defect).
+ *   - {@link assertHindsightRetainBudget}: retain-specific — the token cap
+ *     exceeds the chunk size (or the container refuses to boot) and hindsight's
+ *     deadline stays strictly under the plugin's POST deadline (#3611).
+ *
+ * Honest caveat, and it applies to BOTH of them from this call site:
+ *
+ *  - The three {@link assertClientBudget} calls below cannot fail as written.
+ *    Each budget comes from {@link clientBudgetSeconds}, which returns
+ *    `max(floor, local + fallback + margin)`, and the assertion's threshold is
+ *    that same `local + fallback + margin`. Asserting a value against the
+ *    lower bound it was clamped to is a tautology.
+ *  - {@link assertHindsightRetainBudget}'s `server < client` half is tautological
+ *    for the same reason: {@link HINDSIGHT_RETAIN_CLIENT_DEADLINE_S} is now
+ *    derived from {@link hindsightRetainClientTimeoutSeconds} plus one margin.
+ *    Its `maxCompletionTokens > chunkSize` half is NOT — those two are
+ *    independent constants and it can still fire.
+ *
+ * They are kept deliberately, as the guard that catches the NEXT edit rather
+ * than this one: the moment any lane's budget is hand-set, or read from config,
+ * or `clientBudgetSeconds` is bypassed, these stop being tautologies and become
+ * the emit-time failure that keeps a broken budget out of a container. They are
+ * defence in depth, not the primary mechanism, and this comment exists so
+ * nobody mistakes them for it.
+ *
+ * The checks that can actually FAIL today, and are therefore the load-bearing
+ * ones, all live in tests over files nothing derives:
+ *   - `src/litellm/timeout-budget.test.ts` exercises {@link assertClientBudget}
+ *     directly against the shipped-bug values (204/120) and its boundaries.
+ *   - `src/litellm/repo-config.test.ts` compares the declared tiers against the
+ *     real `docker/litellm-proxy/litellm-config.yaml`.
+ *   - `tests/setup/hindsight.test.ts` asserts
+ *     {@link HINDSIGHT_RETAIN_CLIENT_DEADLINE_S} equals
+ *     `DEFAULT_RETAIN_CLIENT_DEADLINE_S` in the plugin's `retain_split.py`.
+ */
+export function hindsightLlmBudgetEnv(): Array<[string, string]> {
   const maxCompletionTokens = HINDSIGHT_DEFAULT_RETAIN_MAX_COMPLETION_TOKENS;
-  const serverTimeoutS = hindsightRetainLlmTimeoutSeconds(maxCompletionTokens);
+
+  const interactiveS = hindsightInteractiveLlmTimeoutSeconds();
+  const retainS = hindsightRetainClientTimeoutSeconds();
+  const consolidationS = hindsightConsolidationLlmTimeoutSeconds();
+
+  assertClientBudget({
+    role: "interactive",
+    tier: LITELLM_TIMEOUT_TIERS.interactive,
+    clientBudgetS: interactiveS,
+  });
+  assertClientBudget({
+    role: "retain",
+    tier: LITELLM_TIMEOUT_TIERS.retain,
+    clientBudgetS: retainS,
+  });
+  assertClientBudget({
+    role: "consolidation",
+    tier: LITELLM_TIMEOUT_TIERS.consolidation,
+    clientBudgetS: consolidationS,
+  });
+
   assertHindsightRetainBudget({
     maxCompletionTokens,
     chunkSize: HINDSIGHT_RETAIN_CHUNK_SIZE,
-    serverTimeoutS,
+    serverTimeoutS: retainS,
     clientDeadlineS: HINDSIGHT_RETAIN_CLIENT_DEADLINE_S,
   });
+
   return [
     ["HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS", String(maxCompletionTokens)],
-    ["HINDSIGHT_API_RETAIN_LLM_TIMEOUT", String(serverTimeoutS)],
+    // Interactive lane: recall + the default LLM config, and reflect, both of
+    // which route to `gpt-oss-20b`. Emitted explicitly so the 120s vendor
+    // default can never silently become half of a mismatched pair again.
+    ["HINDSIGHT_API_LLM_TIMEOUT", String(interactiveS)],
+    ["HINDSIGHT_API_REFLECT_LLM_TIMEOUT", String(interactiveS)],
+    ["HINDSIGHT_API_RETAIN_LLM_TIMEOUT", String(retainS)],
+    ["HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT", String(consolidationS)],
   ];
 }
 
@@ -1116,10 +1281,12 @@ export function startHindsight(
     // Reflect wall timeout — let large-bank mental-model refreshes finish
     // (vendor 300s times out on 12k+ obs banks → stale user-profile models).
     "-e", `HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S}`,
-    // Retain output cap + its derived per-call deadline. Asserted consistent
-    // by hindsightRetainBudgetEnv() before it returns — see the constants
-    // above for the 767.6s runaway this replaces.
-    ...hindsightRetainBudgetEnv().flatMap(([k, v]) => ["-e", `${k}=${v}`]),
+    // Retain output cap + the DERIVED per-call deadline for every lane
+    // (interactive / reflect / retain / consolidation). Asserted consistent by
+    // hindsightLlmBudgetEnv() before it returns — against the token budget
+    // (the 767.6s runaway, see the constants above) AND against each lane's
+    // litellm routing chain (src/litellm/timeout-budget.ts).
+    ...hindsightLlmBudgetEnv().flatMap(([k, v]) => ["-e", `${k}=${v}`]),
     // Consolidation concurrency: throttled by #2894 to a hard ceiling of
     // MAX_SLOTS 1 × LLM_PARALLELISM 2 = 2 concurrent model calls (was 18), so
     // consolidation can never exhaust the shared failover quota. Batch size 12
@@ -1644,7 +1811,7 @@ export function generateHindsightComposeSnippet(
     `      - HINDSIGHT_API_RECALL_MAX_CONCURRENT=${HINDSIGHT_DEFAULT_RECALL_MAX_CONCURRENT}`,
     `      - HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S}`,
     // Retain budget — same derivation + assertion as the docker-run path.
-    ...hindsightRetainBudgetEnv().map(([k, v]) => `      - ${k}=${v}`),
+    ...hindsightLlmBudgetEnv().map(([k, v]) => `      - ${k}=${v}`),
     `      - HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`,
     `      - HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
     `      - HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -353,30 +353,123 @@ describe("hindsight broker-fed mode (#1245)", () => {
     );
   });
 
-  it("derives the retain server timeout from the token cap rather than hardcoding it", async () => {
+  it("keeps #3611's token-derived value as a FLOOR on the retain deadline", async () => {
     const h = await import("../../src/setup/hindsight.js");
-    // ceil(16384 / 80.6) = 204
+    // ceil(16384 / 80.6) = 204. Unchanged, and still derived from the cap:
+    // double the cap and the floor follows.
     expect(h.hindsightRetainLlmTimeoutSeconds()).toBe(204);
-    // Derived, not constant: double the cap and the deadline follows.
     expect(h.hindsightRetainLlmTimeoutSeconds(32768)).toBe(407);
     expect(h.hindsightRetainLlmTimeoutSeconds(16384, 40)).toBe(410);
-
-    startHindsight({ apiPort: 8888, uiPort: 9999 });
-    const envPairs = envPairsFromArgs(findRunArgs());
-    expect(envPairs).toContain(
-      `HINDSIGHT_API_RETAIN_LLM_TIMEOUT=${h.hindsightRetainLlmTimeoutSeconds()}`,
-    );
-    expect(h.generateHindsightComposeSnippet()).toContain(
-      `HINDSIGHT_API_RETAIN_LLM_TIMEOUT=${h.hindsightRetainLlmTimeoutSeconds()}`,
+    // …but it is a floor, not the answer: the litellm retain chain
+    // (200 + 90 + 10 margin) is larger, so the emitted deadline is that.
+    expect(h.hindsightRetainClientTimeoutSeconds()).toBe(300);
+    expect(h.hindsightRetainClientTimeoutSeconds()).toBeGreaterThanOrEqual(
+      h.hindsightRetainLlmTimeoutSeconds(),
     );
   });
 
-  it("holds the shipped budget: server per-call timeout < retain client deadline", async () => {
+  it("emits a retain deadline that COVERS the litellm fallback hop (the #3611 gap)", async () => {
     const h = await import("../../src/setup/hindsight.js");
-    expect(h.hindsightRetainLlmTimeoutSeconds()).toBeLessThan(
+    const tb = await import("../../src/litellm/timeout-budget.js");
+    // The bug: #3611 shipped HINDSIGHT_API_RETAIN_LLM_TIMEOUT=204 (confirmed
+    // live on switchroom-hindsight 2026-07-26) while the litellm retain chain
+    // under it was 200 + 90 = 290. The fallback hop had 4s of headroom and
+    // could never complete. This asserts the emitted value covers the chain.
+    const emitted = h.hindsightRetainClientTimeoutSeconds();
+    expect(emitted).toBeGreaterThanOrEqual(
+      tb.minimumClientBudgetSeconds(tb.LITELLM_TIMEOUT_TIERS.retain),
+    );
+    expect(emitted).toBe(300);
+    expect(emitted).not.toBe(204); // the shipped bug
+
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const envPairs = envPairsFromArgs(findRunArgs());
+    expect(envPairs).toContain(`HINDSIGHT_API_RETAIN_LLM_TIMEOUT=${emitted}`);
+    expect(h.generateHindsightComposeSnippet()).toContain(
+      `HINDSIGHT_API_RETAIN_LLM_TIMEOUT=${emitted}`,
+    );
+  });
+
+  it("emits the INTERACTIVE budget (160s) rather than leaving the 120s vendor default", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    // Neither HINDSIGHT_API_LLM_TIMEOUT nor HINDSIGHT_API_REFLECT_LLM_TIMEOUT
+    // was emitted at all before this, so both silently took
+    // hindsight_api/config.py DEFAULT_LLM_TIMEOUT = 120.0 while the litellm
+    // interactive chain became 90 + 60 = 150. An unset knob is still half of a
+    // pair. 90 + 60 + 10 = 160 — the value Ken set for this lane, derived.
+    expect(h.hindsightInteractiveLlmTimeoutSeconds()).toBe(160);
+
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const envPairs = envPairsFromArgs(findRunArgs());
+    const snippet = h.generateHindsightComposeSnippet();
+    for (const key of ["HINDSIGHT_API_LLM_TIMEOUT", "HINDSIGHT_API_REFLECT_LLM_TIMEOUT"]) {
+      expect(envPairs).toContain(`${key}=160`);
+      expect(snippet).toContain(`${key}=160`);
+    }
+  });
+
+  it("emits the CONSOLIDATION budget (300s) rather than leaving the 120s vendor default", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    // Same defect, third lane: 173 `exceeded timeout=120.0s` errors observed
+    // against a 200 + 90 = 290s chain.
+    expect(h.hindsightConsolidationLlmTimeoutSeconds()).toBe(300);
+
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    expect(envPairsFromArgs(findRunArgs())).toContain(
+      "HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT=300",
+    );
+    expect(h.generateHindsightComposeSnippet()).toContain(
+      "HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT=300",
+    );
+  });
+
+  it("holds the shipped budget end to end: chain <= per-call timeout < client deadline", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    const tb = await import("../../src/litellm/timeout-budget.js");
+    // The whole three-deadline stack, asserted as one chain:
+    //   litellm 200+90 (+10 margin) = 300 <= 300 < 310
+    expect(tb.minimumClientBudgetSeconds(tb.LITELLM_TIMEOUT_TIERS.retain)).toBeLessThanOrEqual(
+      h.hindsightRetainClientTimeoutSeconds(),
+    );
+    expect(h.hindsightRetainClientTimeoutSeconds()).toBeLessThan(
       h.HINDSIGHT_RETAIN_CLIENT_DEADLINE_S,
     );
-    expect(() => h.hindsightRetainBudgetEnv()).not.toThrow();
+    expect(h.HINDSIGHT_RETAIN_CLIENT_DEADLINE_S).toBe(310);
+    expect(() => h.hindsightLlmBudgetEnv()).not.toThrow();
+  });
+
+  it("keeps the reflect WALL timeout above the reflect per-call timeout", async () => {
+    // Third deadline on the same lane: HINDSIGHT_API_REFLECT_WALL_TIMEOUT
+    // bounds the whole agentic reflect loop, which makes SEVERAL per-call LLM
+    // requests. If the per-call budget ever grew past the wall budget, reflect
+    // would be killed by its own wall clock before a single call could use its
+    // full deadline — the same paired-drift class, one level up.
+    const h = await import("../../src/setup/hindsight.js");
+    const perCall = Number(new Map(h.hindsightLlmBudgetEnv()).get("HINDSIGHT_API_REFLECT_LLM_TIMEOUT"));
+    expect(perCall).toBeGreaterThan(0);
+    expect(h.HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S).toBeGreaterThan(perCall);
+  });
+
+  it("every emitted LLM timeout covers its own litellm routing chain", async () => {
+    // The general form of the bug, asserted over whatever is emitted rather
+    // than over specific numbers: if any lane's budget ever drops below its
+    // chain again, this fails regardless of which lane or which half moved.
+    const h = await import("../../src/setup/hindsight.js");
+    const tb = await import("../../src/litellm/timeout-budget.js");
+    const env = new Map(h.hindsightLlmBudgetEnv());
+    const lanes: Array<[string, tb.LitellmTimeoutTier]> = [
+      ["HINDSIGHT_API_LLM_TIMEOUT", tb.LITELLM_TIMEOUT_TIERS.interactive],
+      ["HINDSIGHT_API_REFLECT_LLM_TIMEOUT", tb.LITELLM_TIMEOUT_TIERS.interactive],
+      ["HINDSIGHT_API_RETAIN_LLM_TIMEOUT", tb.LITELLM_TIMEOUT_TIERS.retain],
+      ["HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT", tb.LITELLM_TIMEOUT_TIERS.consolidation],
+    ];
+    for (const [key, tier] of lanes) {
+      const raw = env.get(key);
+      expect(raw, `${key} must be emitted, not left to the vendor default`).toBeDefined();
+      expect(() =>
+        tb.assertClientBudget({ role: key, tier, clientBudgetS: Number(raw) }),
+      ).not.toThrow();
+    }
   });
 
   it("keeps HINDSIGHT_RETAIN_CLIENT_DEADLINE_S equal to the plugin's own constant", async () => {
@@ -396,6 +489,39 @@ describe("hindsight broker-fed mode (#1245)", () => {
     const m = src.match(/^DEFAULT_RETAIN_CLIENT_DEADLINE_S\s*=\s*([0-9.]+)\s*$/m);
     expect(m, "retain_split.py must define DEFAULT_RETAIN_CLIENT_DEADLINE_S").not.toBeNull();
     expect(Number(m![1])).toBe(h.HINDSIGHT_RETAIN_CLIENT_DEADLINE_S);
+  });
+
+  it("keeps the backlog drain's per-entry deadline above the retain routing chain", async () => {
+    // The OUTERMOST member of the paired-budget family, and the one that
+    // produced the unexplained ~280.1s per-entry give-up in the 2026-07-26
+    // backlog-recovery logs. It is not a third hand-set number: the drainer's
+    // `_backlog_timeout()` defaults to `int(retain_client_deadline())`
+    // (vendor/hindsight-memory/scripts/drain_pending.py:220), which reads
+    // DEFAULT_RETAIN_CLIENT_DEADLINE_S — 280.0 at the time. 280 < 300, so
+    // every drained entry that fell through to the OpenRouter fallback was
+    // abandoned client-side while the server was still inside a legitimate
+    // budget, and the entry stayed queued to burn another attempt.
+    //
+    // This asserts the OUTCOME (the outer deadline covers the whole chain),
+    // not the number, so it fails on the 280 shape and on any future edit
+    // that lowers either side independently.
+    const h = await import("../../src/setup/hindsight.js");
+    const tb = await import("../../src/litellm/timeout-budget.js");
+
+    const drainSrc = readFileSync(
+      join(process.cwd(), "vendor/hindsight-memory/scripts/drain_pending.py"),
+      "utf8",
+    );
+    expect(
+      drainSrc,
+      "the drain deadline must stay DERIVED from retain_client_deadline(), not a literal",
+    ).toContain("int(retain_client_deadline())");
+
+    const chain = tb.minimumClientBudgetSeconds(tb.LITELLM_TIMEOUT_TIERS.retain);
+    expect(chain).toBe(300);
+    expect(h.HINDSIGHT_RETAIN_CLIENT_DEADLINE_S).toBeGreaterThan(chain);
+    // The exact regression: the shipped 280 must not satisfy this.
+    expect(280).toBeLessThan(chain);
   });
 
   it("refuses to emit a budget where the server outlives the client deadline", async () => {

--- a/tests/source-files-are-text.test.ts
+++ b/tests/source-files-are-text.test.ts
@@ -71,6 +71,17 @@ function candidateTextFiles(): string[] {
   return [...new Set(paths)];
 }
 
+/**
+ * Vitest's default per-test timeout is 5s, which is not enough here on a COLD
+ * page cache: this reads ~2,600 files, and measured on the fleet host the first
+ * run after a fresh checkout took 10.1s while every subsequent run took 71ms —
+ * same work, same files, cache the only difference. A CI runner is always the
+ * cold case, so the default would make this test a coin flip rather than a
+ * guard. It is I/O-bound by design (the whole point is to look at every file),
+ * so the right answer is a timeout sized for the I/O, not less scanning.
+ */
+const SCAN_TIMEOUT_MS = 60_000;
+
 describe("source files are text, not binary (PR #3676 regression)", () => {
   it("contains no raw NUL byte in any tracked or newly added text file", () => {
     const offenders: string[] = [];
@@ -86,5 +97,5 @@ describe("source files are text, not binary (PR #3676 regression)", () => {
     }
     // Named, not just counted — the whole point is that the diff can't tell you.
     expect(offenders).toEqual([]);
-  });
+  }, SCAN_TIMEOUT_MS);
 });

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -215,15 +215,29 @@ def _backlog_timeout() -> int:
     client-side timeout on a request the server then commits anyway.
 
     The default is DERIVED, not a literal: it is
-    ``retain_split.retain_client_deadline()`` (280s), the same deadline the
+    ``retain_split.retain_client_deadline()`` (310s), the same deadline the
     retain content bound is sized against. Those two must be ONE number.
     This function shipped as a bare ``180`` (#3599), and against a 180s
     deadline both halves of the retain budget break: a maximally-sized part
     is ~276s of sequential extraction, and the SERVER per-call timeout
-    derived in ``src/setup/hindsight.ts`` (#3611) is 204s — so the drain
+    derived in ``src/setup/hindsight.ts`` is larger still — so the drain
     client would abandon a request the server is still legitimately working
     on, leave the entry queued, and rebuild the re-post loop #3599 exists to
     kill, one size class up.
+
+    This is the OUTERMOST deadline of the paired-budget family, and it is the
+    one the 2026-07-26 backlog-recovery logs show as a fixed ~280.1s per-entry
+    give-up. That was not an unexplained third number: it is this default at
+    the then-current ``DEFAULT_RETAIN_CLIENT_DEADLINE_S = 280.0``, plus the
+    request's own setup overhead. It was WRONG for the same reason #3611's
+    204s was wrong — it did not cover hindsight's LiteLLM routing chain
+    (local 200s + OpenRouter fallback 90s + router margin 10s = 300s), so
+    every drained entry whose retain fell through to the fallback was
+    abandoned client-side at 280s while the server was still inside a
+    legitimate 300s budget. Raising the derivation's base to 310 fixes this
+    lane and the in-hook lane with the same number, by construction.
+    ``src/litellm/timeout-budget.ts`` is where the chain is declared, and
+    ``tests/setup/hindsight.test.ts`` fails if these drift apart again.
 
     ``HINDSIGHT_DRAIN_BACKLOG_TIMEOUT`` still overrides it outright;
     ``HINDSIGHT_RETAIN_CLIENT_DEADLINE_S`` moves the derivation and the

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -147,7 +147,7 @@ oversized payload into one entry PER PART (``lib/retain_split``) instead
 of writing a single giant entry. This is load-bearing, not tidiness. The
 daemon runs one sequential extraction LLM call per ``retain_chunk_size``
 chars, so an entry above the derived content bound cannot complete inside
-ANY client deadline — including the 280s out-of-hook backlog deadline that
+ANY client deadline — including the out-of-hook backlog deadline that
 ``drain_pending._backlog_timeout()`` now takes from the same derivation.
 Such an entry fails every drain and burns its ``MAX_ATTEMPTS``: the
 mechanism that stranded 154 of the 629 entries in the 2026-07-25 fleet

--- a/vendor/hindsight-memory/scripts/lib/retain_split.py
+++ b/vendor/hindsight-memory/scripts/lib/retain_split.py
@@ -83,7 +83,7 @@ from typing import Optional
 #                               completion-token bucket; the runaway bucket is
 #                               a separate defect, fixed by capping
 #                               HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS).
-#   client_deadline     280 s  — the deadline of the DURABILITY path (the
+#   client_deadline     310 s  — the deadline of the DURABILITY path (the
 #                               out-of-hook backlog drain, #3599), deliberately
 #                               not the live Stop hook's 15s. The live path is
 #                               allowed to miss its deadline: it enqueues to
@@ -96,20 +96,31 @@ from typing import Optional
 #                               literal, and `src/setup/hindsight.ts`
 #                               (`HINDSIGHT_RETAIN_CLIENT_DEADLINE_S`, #3611)
 #                               mirrors it as the client half of that PR's
-#                               `server per-call timeout < client deadline`
-#                               assertion — which its derived 204s server
-#                               timeout satisfies against 280 and would NOT
-#                               against #3599's original 180s literal.
+#                               `hindsight per-call timeout < client deadline`
+#                               assertion. A test in `tests/setup/hindsight.test.ts`
+#                               enforces that the two stay equal, so the mirror
+#                               is checked, not merely asserted in prose.
+#                               WAS 280.0. Raised to 310 when the retain
+#                               per-call timeout became derived from the litellm
+#                               routing chain (`local 200 + fallback 90 +
+#                               margin 10 = 300`) instead of from the token
+#                               budget alone: #3611's 204s could not cover that
+#                               chain, so the retain OpenRouter fallback hop had
+#                               4s of headroom and could never complete. 310 is
+#                               that 300 plus the same one margin, so the plugin
+#                               always outlives hindsight by construction. It is
+#                               NOT a hand-set number on either side — change
+#                               `src/litellm/timeout-budget.ts` and both move.
 #
-#   floor(280 / 18.4) = 15 chunks  →  15 × 3000 = 45,000 chars
+#   floor(310 / 18.4) = 16 chunks  →  16 × 3000 = 48,000 chars
 #
 # Sanity check against the same backlog: every entry at or below 60,000 chars
-# drained successfully inside the 280s deadline (observed per-entry times
-# 0.3s–153.4s at concurrency 3), so 45,000 sits inside demonstrated-good
-# territory with margin for a slower model or a busier box.
+# drained successfully inside the (then 280s) deadline (observed per-entry
+# times 0.3s–153.4s at concurrency 3), so 48,000 still sits inside
+# demonstrated-good territory with margin for a slower model or a busier box.
 DEFAULT_RETAIN_CHUNK_SIZE = 3000
 DEFAULT_RETAIN_CHUNK_LATENCY_S = 18.4
-DEFAULT_RETAIN_CLIENT_DEADLINE_S = 280.0
+DEFAULT_RETAIN_CLIENT_DEADLINE_S = 310.0
 
 # Absolute floor: one chunk. A bound below one chunk would split every
 # transcript into extraction-sized confetti and is never the right answer.

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -1842,7 +1842,15 @@ class ClampAndEnvKnobBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
         """
         os.environ.pop("HINDSIGHT_DRAIN_BACKLOG_TIMEOUT", None)
         os.environ.pop("HINDSIGHT_RETAIN_CLIENT_DEADLINE_S", None)
-        self.assertEqual(drain_pending._backlog_timeout(), 280)
+        # Assert the DERIVATION, per this test's own docstring: the drain
+        # deadline is retain_client_deadline(), whatever that currently is.
+        # It was pinned to the literal 280 here, which meant the test went
+        # stale the moment the deadline became derived from the litellm
+        # routing chain (280 -> 310) instead of being hand-set.
+        self.assertEqual(
+            drain_pending._backlog_timeout(),
+            int(retain_split.retain_client_deadline()),
+        )
 
         os.environ["HINDSIGHT_RETAIN_CLIENT_DEADLINE_S"] = "600"
         try:

--- a/vendor/hindsight-memory/scripts/tests/test_retain_split.py
+++ b/vendor/hindsight-memory/scripts/tests/test_retain_split.py
@@ -10,6 +10,7 @@ memory is permanently unsaveable.
 
 import io
 import json
+import math
 import os
 import shutil
 import sys
@@ -60,12 +61,13 @@ class TestDerivedLimit(unittest.TestCase):
             os.environ.pop(key, None)
 
     def test_limit_is_chunk_size_times_chunks_that_fit_the_deadline(self):
-        # chunk_size * floor(deadline / latency) = 3000 * floor(280/18.4) = 45000
-        self.assertEqual(retain_content_limit(), 45000)
+        # chunk_size * floor(deadline / latency) = 3000 * floor(310/18.4) = 48000
+        self.assertEqual(retain_content_limit(), 48000)
 
     def test_limit_is_derived_from_chunk_size_not_a_constant(self):
         os.environ["HINDSIGHT_RETAIN_CHUNK_SIZE"] = "1000"
-        self.assertEqual(retain_content_limit(), 15000)
+        # 1000 * floor(310 / 18.4) = 1000 * 16
+        self.assertEqual(retain_content_limit(), 16000)
 
     def test_limit_tracks_the_client_deadline(self):
         os.environ["HINDSIGHT_RETAIN_CLIENT_DEADLINE_S"] = "92"
@@ -78,7 +80,7 @@ class TestDerivedLimit(unittest.TestCase):
 
     def test_garbage_env_falls_back_to_the_derived_default(self):
         os.environ["HINDSIGHT_RETAIN_CHUNK_LATENCY_S"] = "not-a-number"
-        self.assertEqual(retain_content_limit(), 45000)
+        self.assertEqual(retain_content_limit(), 48000)
 
 
 class TestSplitBounds(unittest.TestCase):
@@ -88,11 +90,11 @@ class TestSplitBounds(unittest.TestCase):
 
     def test_every_part_of_an_oversized_json_transcript_is_within_the_limit(self):
         content = _json_transcript(40, 5000)  # ~200k chars
-        self.assertGreater(len(content), 45000)
+        self.assertGreater(len(content), retain_content_limit())
         parts = split_retain_content(content)
         self.assertGreater(len(parts), 1)
         for part in parts:
-            self.assertLessEqual(len(part), 45000)
+            self.assertLessEqual(len(part), retain_content_limit())
 
     def test_every_part_of_an_oversized_text_transcript_is_within_the_limit(self):
         content = _text_transcript(60, 4000)  # ~240k chars
@@ -106,16 +108,22 @@ class TestSplitBounds(unittest.TestCase):
         content = _json_transcript(200, 3700)
         self.assertGreater(len(content), 744000)
         parts = split_retain_content(content)
-        self.assertTrue(all(len(p) <= 45000 for p in parts))
-        # ~249 sequential extraction calls become bounded batches of <=15.
-        self.assertGreaterEqual(len(parts), 16)
+        self.assertTrue(all(len(p) <= retain_content_limit() for p in parts))
+        # ~249 sequential extraction calls become bounded batches of at most
+        # `retain_content_limit() / chunk_size` calls each. Both the bound and
+        # the expected part count are DERIVED here: the literal 16 this line
+        # carried was correct only at the 45,000-char bound and went stale the
+        # moment the client deadline moved 280 -> 310 (bound 48,000). A split
+        # must always produce at least ceil(len / bound) parts, whatever the
+        # bound currently is.
+        self.assertGreaterEqual(len(parts), math.ceil(len(content) / retain_content_limit()))
 
     def test_single_oversized_message_is_split_not_dropped(self):
         content = _json_transcript(1, 300000)
         parts = split_retain_content(content)
         self.assertGreater(len(parts), 1)
         for part in parts:
-            self.assertLessEqual(len(part), 45000)
+            self.assertLessEqual(len(part), retain_content_limit())
 
     def test_single_unbreakable_line_still_respects_the_bound(self):
         # No structural boundary anywhere: the bound must still hold.
@@ -224,7 +232,7 @@ class TestClientEnforcesTheBound(unittest.TestCase):
         self.assertGreater(len(self.client.posts), 1)
         for _path, body, _timeout in self.client.posts:
             self.assertEqual(len(body["items"]), 1)
-            self.assertLessEqual(len(body["items"][0]["content"]), 45000)
+            self.assertLessEqual(len(body["items"][0]["content"]), retain_content_limit())
 
     def test_small_retain_still_posts_exactly_once_with_the_original_id(self):
         self.client.retain("bank", "small transcript", document_id="doc")


### PR DESCRIPTION
## The bug

LiteLLM's router fallback runs **inside** one client request. So the invariant is not `local < client`, it is:

```
localTimeoutS + fallbackTimeoutS + margin  <=  clientBudgetS
```

It was maintained by hand, in a config comment, and broke twice in two days in opposite directions:

| lane | chain | client budget | result |
|---|---|---|---|
| retain (#3611) | 200 + 90 = 290 | `ceil(16384/80.6)` = **204** | fallback had 4s of headroom, could never complete |
| interactive (2026-07-26) | 90 + 60 = 150 | **120** (vendor `DEFAULT_LLM_TIMEOUT`, never emitted) | same defect, lane where a person is waiting |
| consolidation | 200 + 90 = 290 | **120** (same, never emitted) | 173 `exceeded timeout=120.0s` errors in the logs |

Both times the config carried a correct comment saying "both halves must move together", and both times a half moved alone. A comment is not a mechanism.

## The mechanism

`src/litellm/timeout-budget.ts` declares the per-lane tiers once — primary group, fallback group, and each one's per-deployment timeout — with the measurement that justifies every number. Every client budget is computed from that declaration, so the halves are one number by construction.

**#3611's derivation is preserved, not replaced.** `clientBudgetSeconds(tier, floor)` is `max(floor, chain + margin)`: the token-budget-derived floor (never starve a legitimately full-length extraction) and the chain bound (the fallback hop must be able to complete) are two independent lower bounds and the budget satisfies both. Taking the max does not reopen the 767.6s runaway #3611 fixed — a runaway is cut by `HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS` at the source and by litellm's own per-deployment `timeout`, both upstream of the client. A longer *client* deadline cannot make an upstream call run longer; it only stops the client abandoning a failover that is still in flight.

### Source of truth

The live per-deployment timeouts are in the operator-maintained proxy config at `/data/coolify/services/<id>/litellm-config.yaml`, which nothing in a container can read — so the derivation cannot read it either. Switchroom therefore **declares** the tiers, authoritatively, and divergence from the live proxy is a detected condition rather than an assumed impossibility. This is the same division of labour `CLAUDE.md` already documents for the I2 OAuth-leak guard: an in-repo check that is deterministic in CI, plus an on-host sensor that is load-bearing against the live file.

## What ships

- `HINDSIGHT_API_LLM_TIMEOUT=160`, `HINDSIGHT_API_REFLECT_LLM_TIMEOUT=160` — the interactive budget Ken set on 2026-07-26, arrived at here as `90 + 60 + 10`. Nobody typed 160.
- `HINDSIGHT_API_RETAIN_LLM_TIMEOUT=300`, `HINDSIGHT_API_CONSOLIDATION_LLM_TIMEOUT=300` (`200 + 90 + 10`). Retain previously shipped 204; the other two shipped nothing.
- `assertClientBudget` on both emit paths (`startHindsight` docker args and the compose snippet), so an inconsistent budget cannot reach a container.
- The plugin's retain client deadline `280 -> 310` in lockstep (`retain_split.py`). `290 <= RETAIN_LLM_TIMEOUT < 280` is unsatisfiable at any derivation, and the plugin deadline was the only hand-set number in a chain of derived ones. The derived content bound follows it: `3000 x floor(310/18.4)` = 45,000 -> 48,000 chars.
- `gpt-oss-20b-openrouter` gains `timeout: 60` in the repo-managed config. It carried none, so it inherited `request_timeout: 600` — 4x the whole client budget for its lane.

## The guard

Three layers, all deterministic:

1. **`src/litellm/timeout-budget.test.ts` (27 tests)** — asserts the invariant over the declaration. Every test fails on a real historical bug, not merely exercises the code: `204` on retain, `120` on interactive and on consolidation, and `290`/`299` on retain (the margin is load-bearing) all throw. The error names both halves and the file to edit.
2. **`src/litellm/repo-config.test.ts`** — reads the **actual shipped** `docker/litellm-proxy/litellm-config.yaml` and fails CI when it disagrees with the declaration, omits a per-deployment timeout on a budgeted group, or adds a fallback edge the tiers do not know about. Verified by mutation: reverting the openrouter hop to 25s fails with `"gpt-oss-20b-openrouter: config 25s vs declared 60s"`.
3. **The fleet-health litellm-config sensor** — emits a `litellm-timeout-budget-drift` finding (`drift` / severity 3 / `fleet-stays-healthy`) against the **LIVE** proxy config, escalated by the priority ledger like any other L0. Reported per drifted group, with the "no timeout at all" case called out separately because it is the most dangerous shape.

## Test evidence

```
vitest  tests/setup/hindsight.test.ts src/litellm/ src/fleet-health/   228 passed (12 files)
pytest  vendor/hindsight-memory/scripts/tests                          633 passed, 180 subtests
npm run lint                                                           clean
```

Python assertions that had pinned the literal `280` / `45000` were changed to assert the *derivation* (`retain_split.retain_client_deadline()`, `retain_content_limit()`) — one of them, `test_the_backlog_timeout_defaults_to_the_retain_client_deadline`, had a docstring claiming exactly that while pinning the number.

## Note for review

`vendor/hindsight-memory/scripts/lib/retain_split.py` is touched, but only the `DEFAULT_RETAIN_CLIENT_DEADLINE_S` constant and its derivation comment — no chunking or retry logic, which is another in-flight worker's territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)