### PR TITLE
fix(telegram): make the boot pin sweep reachable and never lose a failed unpin

### DIFF
--- a/telegram-plugin/gateway/activity-card-boot-reaper-wiring.ts
+++ b/telegram-plugin/gateway/activity-card-boot-reaper-wiring.ts
@@ -1,0 +1,128 @@
+/**
+ * Gateway wiring for the boot-time orphaned activity-card reaper (Known Gap 1,
+ * `reference/rfcs/deterministic-turn-liveness.md`).
+ *
+ * Extracted from gateway.ts (#3634) — the pure routine already lived in
+ * activity-card-store.ts; this is the seam binding that used to sit inline
+ * under the gateway's line ratchet. Behaviour is unchanged; the only reason it
+ * moved is that gateway.ts may not grow.
+ *
+ * Finalizes ANY card left open by a prior (crashed/restarted) session with ONE
+ * honest edit — never a new message, so no ping. The guarantee is
+ * AT-MOST-ONCE: the pure routine deletes each record before attempting its
+ * edit and does not retry, so a failed edit forfeits that orphan rather than
+ * risk a double-finalize on a later boot (see activity-card-store.ts for the
+ * full tradeoff). A benign-400 (card already gone) is reported as `vanished`,
+ * not `finalized`.
+ *
+ * MUST run ONLY after this gateway wins the startup mutex (the store is a
+ * shared per-agent file; a losing double-boot would finalize a card the
+ * still-alive holder's in-flight turn still legitimately owns) — identical
+ * ordering constraint to `statusPinBootCleanup` — and, since #3634, only after
+ * `gatewayBotReady` resolves: every call below dereferences the gateway's
+ * late-assigned `lockedBot`, and firing this at module-eval time is exactly
+ * what made the boot sweep a no-op for months.
+ *
+ * Deliberately does NOT attempt to resume climbing the old card: the resumed
+ * turn (if any) opens its own fresh card. Honest finalization, not resumption.
+ *
+ * After the finalizing edit it also unpins the card, but ONLY for a record
+ * whose persisted `pinned` flag is true — i.e. the card was actually
+ * pin-eligible on open. That unpin is DEFENSE-IN-DEPTH, not the primary path:
+ * `statusPinBootCleanup` already unpins orphaned status pins from its own
+ * durable store. The record's `pinned` flag must therefore reflect the ACTUAL
+ * pin outcome, not an unconditional `true`, or this would attempt an unpin on
+ * a card that was never pinned.
+ */
+
+export interface OrphanCardRecord {
+  chatId: string
+  threadId?: number | null
+  activityMessageId: number
+  startedAt: number
+}
+
+export interface ActivityCardBootReaperWiring {
+  enabled: boolean
+  path: string
+  fs: unknown
+  /** The gateway's late-assigned wrapped bot. Read lazily, never captured. */
+  getBot: () => {
+    api: {
+      editMessageText: (
+        chatId: string,
+        messageId: number,
+        text: unknown,
+        opts: Record<string, unknown>,
+      ) => Promise<unknown>
+      unpinChatMessage: (chatId: string, messageId: number) => Promise<unknown>
+    }
+  }
+  /** The gateway's retry/send-gate wrapper. Named for the repo's
+   *  check-bot-api-wrapping guard: every Bot API call below is inside it. */
+  robustApiCall: (
+    fn: () => Promise<unknown>,
+    opts: Record<string, unknown>,
+  ) => Promise<unknown>
+  /** `richMessage(restartOrphanCardFinalizeText(startedAt))` */
+  finalizeBody: (startedAt: number) => unknown
+  run: (args: {
+    path: string
+    fs: unknown
+    finalizeCard: (r: OrphanCardRecord) => Promise<unknown>
+    unpinCard: (r: OrphanCardRecord) => Promise<unknown>
+  }) => Promise<{
+    finalized: number
+    vanished: number
+    unpinned: number
+    total: number
+  }>
+  log?: (line: string) => void
+}
+
+const threadOpt = (r: OrphanCardRecord) =>
+  r.threadId != null ? { threadId: r.threadId } : {}
+
+export async function runActivityCardBootReaperWiring(
+  w: ActivityCardBootReaperWiring,
+): Promise<void> {
+  if (!w.enabled) return
+  const log = w.log ?? ((l: string) => process.stderr.write(l))
+  const { finalized, vanished, unpinned, total } = await w.run({
+    path: w.path,
+    fs: w.fs,
+    finalizeCard: (record) =>
+      w.robustApiCall(
+        () =>
+          w
+            .getBot()
+            .api.editMessageText(
+              record.chatId,
+              record.activityMessageId,
+              w.finalizeBody(record.startedAt),
+              {},
+            ),
+        {
+          chat_id: record.chatId,
+          ...threadOpt(record),
+          verb: 'activity-card.boot-reap-finalize',
+        },
+      ),
+    unpinCard: (record) =>
+      w.robustApiCall(
+        () => w.getBot().api.unpinChatMessage(record.chatId, record.activityMessageId),
+        {
+          chat_id: record.chatId,
+          ...threadOpt(record),
+          verb: 'activity-card.boot-reap-unpin',
+        },
+      ),
+  })
+  if (total > 0) {
+    log(
+      `telegram gateway: activity-card: finalized ${finalized}/${total} ` +
+        `(vanished ${vanished}/${total}), unpinned ${unpinned}/${total} ` +
+        `orphaned card(s) from a prior session (at-most-once)\n`,
+    )
+  }
+}

--- a/telegram-plugin/gateway/boot-pin-sweep.ts
+++ b/telegram-plugin/gateway/boot-pin-sweep.ts
@@ -1,0 +1,131 @@
+/**
+ * Boot pin sweep — ordering contract for the orphan-pin cleanup that runs
+ * once this gateway wins the startup mutex.
+ *
+ * WHY THIS MODULE EXISTS (#3634). The sweep used to be an inline
+ * `void runBootPinCleanupAndDmSweep()` fired from the startup-mutex block in
+ * gateway.ts. That block runs at MODULE-EVALUATION time, ~13k lines and one
+ * `await initGatewayBot()` before `lockedBot` is assigned — so every unpin the
+ * sweep issued went through `statusPinApi()`, dereferenced an unset
+ * `lockedBot`, and threw:
+ *
+ *     status-pin-store: boot cleanup unpin failed
+ *       (chat=… msg=… attempt=1): undefined is not an object
+ *       (evaluating 'lockedBot.api')
+ *
+ * `let lockedBot!: Bot<Context>` carries a definite-assignment assertion, so
+ * tsc never saw it. The sweep therefore NEVER unpinned anything on any agent:
+ * boot cleanup retained each row with `attempts+1`, and after
+ * BOOT_UNPIN_MAX_ATTEMPTS boots the row was forfeited — leaving a finished
+ * activity card pinned in the chat forever. That is the whole "the progress
+ * card stays pinned after the turn completes" defect.
+ *
+ * THE CONTRACT this module enforces, deterministically and in one testable
+ * place: **no sweep step may issue a Bot API call before the bot is ready.**
+ * The caller passes a `botReady` promise (resolved right after `lockedBot` is
+ * assigned in `initGatewayBot()`); `runBootPinSweep` awaits it before the
+ * first API-issuing step. Ordering after that is unchanged from the inline
+ * version: status pins → activity cards → queued cards → enable + run the DM
+ * stale-pin sweep.
+ *
+ * The store scan is deliberately BEFORE the gate: it is pure fs, needs no bot,
+ * and doing it early means a bot that never becomes ready still leaves the
+ * stores untouched rather than half-swept.
+ *
+ * Every step is best-effort: a throwing step is logged and the sweep
+ * continues, because a permanently-stuck step must not strand the later ones
+ * (the pre-existing failure mode where a dead status-pin cleanup also killed
+ * the DM sweep behind it).
+ */
+
+export interface BootPinSweepDeps {
+  /** Resolves once `lockedBot` is assigned and the Bot API is usable.
+   *  MUST be awaited before any unpin is issued — see the module docblock. */
+  botReady: Promise<void>
+  /** Pure fs scan of the persisted stores for DM chat ids. Never issues API
+   *  calls, so it runs before the ready gate. */
+  scanDmChatIds: () => string[]
+  statusPinCleanup: () => Promise<unknown>
+  activityCardReaper: () => Promise<unknown>
+  queuedCardReaper: () => Promise<unknown>
+  /** Flips the "this gateway owns the shared pin state" flag that authorises
+   *  the DM unpin-all path (both this sweep and later lazy first-inbound
+   *  sweeps). */
+  enableDmSweep: () => void
+  sweepDm: (chatId: string) => Promise<unknown>
+  log?: (line: string) => void
+}
+
+async function step(
+  name: string,
+  fn: () => Promise<unknown>,
+  log: (line: string) => void,
+): Promise<void> {
+  try {
+    await fn()
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    log(`telegram gateway: boot pin sweep step '${name}' failed: ${msg}\n`)
+  }
+}
+
+/**
+ * Run the boot orphan-pin sweep. Resolves when every step has settled; never
+ * rejects (each step is individually absorbed). Callers fire-and-forget it —
+ * cleanup is best-effort and must not block boot.
+ */
+export async function runBootPinSweep(deps: BootPinSweepDeps): Promise<void> {
+  const log = deps.log ?? ((l: string) => process.stderr.write(l))
+
+  let dmChatIds: string[] = []
+  try {
+    dmChatIds = deps.scanDmChatIds()
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    log(`telegram gateway: dm-pin-sweep: store scan failed: ${msg}\n`)
+  }
+
+  // THE GATE. Everything below issues Bot API calls; none of it may run
+  // against an unset `lockedBot`. See the module docblock (#3634).
+  await deps.botReady
+
+  await step('status-pin-cleanup', deps.statusPinCleanup, log)
+  await step('activity-card-reaper', deps.activityCardReaper, log)
+  await step('queued-card-reaper', deps.queuedCardReaper, log)
+
+  // This gateway now owns the shared per-agent pin state — enable the DM
+  // unpin-all path.
+  deps.enableDmSweep()
+  for (const id of dmChatIds) {
+    await step(`dm-sweep:${id}`, () => deps.sweepDm(id), log)
+  }
+}
+
+/**
+ * A one-shot readiness latch. `ready` resolves the first time `markReady()` is
+ * called and stays resolved; `isReady()` reports the current state (used by
+ * the defensive guard in `statusPinApi()` so a future caller that skips the
+ * gate fails with a NAMED error instead of a bare TypeError).
+ */
+export interface BotReadyGate {
+  ready: Promise<void>
+  markReady: () => void
+  isReady: () => boolean
+}
+
+export function createBotReadyGate(): BotReadyGate {
+  let resolved = false
+  let resolve!: () => void
+  const ready = new Promise<void>((r) => {
+    resolve = r
+  })
+  return {
+    ready,
+    markReady: () => {
+      if (resolved) return
+      resolved = true
+      resolve()
+    },
+    isReady: () => resolved,
+  }
+}

--- a/telegram-plugin/gateway/boot-pin-sweep.ts
+++ b/telegram-plugin/gateway/boot-pin-sweep.ts
@@ -103,14 +103,20 @@ export async function runBootPinSweep(deps: BootPinSweepDeps): Promise<void> {
 
 /**
  * A one-shot readiness latch. `ready` resolves the first time `markReady()` is
- * called and stays resolved; `isReady()` reports the current state (used by
- * the defensive guard in `statusPinApi()` so a future caller that skips the
- * gate fails with a NAMED error instead of a bare TypeError).
+ * called and stays resolved; later calls are no-ops, so a re-entrant or
+ * repeated `initGatewayBot()` cannot re-arm the gate.
+ *
+ * There is deliberately NO `isReady()` synchronous peek. The gate exists to be
+ * AWAITED; a boolean invites `if (ready) …` call sites that skip the wait and
+ * reintroduce the exact race this module fixes. The backstop for a caller that
+ * skips the gate anyway is the null check in `status-pin-api.ts`
+ * (`STATUS_PIN_BOT_NOT_READY`), which reads the real signal — whether
+ * `lockedBot` is actually assigned — rather than a mirrored flag that could
+ * drift from it.
  */
 export interface BotReadyGate {
   ready: Promise<void>
   markReady: () => void
-  isReady: () => boolean
 }
 
 export function createBotReadyGate(): BotReadyGate {
@@ -126,6 +132,5 @@ export function createBotReadyGate(): BotReadyGate {
       resolved = true
       resolve()
     },
-    isReady: () => resolved,
   }
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9078,6 +9078,16 @@ async function reconcileStatusPin(
 // is the `orphanPinKey()` row boot cleanup retries. See status-pin-orphans.ts.
 const statusPinOrphans = createOrphanPinRegistry({
   unpin: (chatId, messageId) => statusPinApi().unpinChatMessage(chatId, messageId),
+  // A leaked id can be CLAIMED AGAIN (the group worker card is ONE long-lived
+  // message pinned/unpinned across turns), so retrying blind would tear down a
+  // card the user is watching. Any key currently claiming this exact
+  // chat+message means the orphan is superseded.
+  isLive: (chatId, messageId) => {
+    for (const [key, st] of statusPinState) {
+      if (st.messageId === messageId && statusPinChatIds.get(key) === chatId) return true
+    }
+    return false
+  },
   clearRow: (key) => {
     if (!statusPinPersistEnabled) return
     void mutateStatusPinRow(STATUS_PIN_STORE_PATH, statusPinStoreFs, key, null)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -636,6 +636,10 @@ import { formatUpdateStatusLine } from './update-status-line.js'
 import type { HostdRequest, HostdResponse } from '../../src/host-control/protocol.js'
 import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
+import { runBootPinSweep, createBotReadyGate } from './boot-pin-sweep.js'
+import { createOrphanPinRegistry } from './status-pin-orphans.js'
+import { createStatusPinApi, type PinCapableBot } from './status-pin-api.js'
+import { runActivityCardBootReaperWiring } from './activity-card-boot-reaper-wiring.js'
 import {
   createDmPinSweeper,
   collectDmChatIdsFromStores,
@@ -1439,7 +1443,11 @@ async function rawEditMessageChecklist(args: {
 
 const chatLock = createChatLock()
 // P0b (#2996): wrapped in initGatewayBot() once `bot` is constructed at boot.
+// The `!` is an ASSERTION, not a guarantee — module-eval-time readers get
+// `undefined`. Anything touching the Bot API from there (the boot pin sweep,
+// #3634) MUST await `gatewayBotReady.ready` first. See boot-pin-sweep.ts.
 let lockedBot!: Bot<Context>
+const gatewayBotReady = createBotReadyGate()
 let botUsername = ''
 
 // ─── Access control ───────────────────────────────────────────────────────
@@ -8661,21 +8669,18 @@ function persistBannerRow(row: PersistedStatusPin | null): void {
   )
 }
 
-// The Bot API surface the pin driver needs. `lockedBot` is defined later; wrap
-// lazily so this helper can be declared alongside the state it owns.
+// The Bot API surface the pin driver needs. `lockedBot` is assigned late (in
+// initGatewayBot) so it is read lazily; `createStatusPinApi` also asserts it is
+// there, turning the old opaque `undefined is not an object (evaluating
+// 'lockedBot.api')` boot failure into a named error (#3634).
 function statusPinApi(): PinBotApi {
-  return {
-    pinChatMessage: (chat_id, message_id, opts) =>
-      robustApiCall(
-        () => lockedBot.api.pinChatMessage(chat_id, message_id, opts),
-        { chat_id: String(chat_id), verb: 'status-pin.pin' },
-      ),
-    unpinChatMessage: (chat_id, message_id) =>
-      robustApiCall(
-        () => lockedBot.api.unpinChatMessage(chat_id, message_id),
-        { chat_id: String(chat_id), verb: 'status-pin.unpin' },
-      ),
-  }
+  return createStatusPinApi(
+    () => lockedBot as unknown as PinCapableBot | undefined,
+    robustApiCall as (
+      fn: () => Promise<unknown>,
+      opts: Record<string, unknown>,
+    ) => Promise<unknown>,
+  )
 }
 
 /**
@@ -8710,74 +8715,21 @@ async function statusPinBootCleanup(): Promise<void> {
     )
   }
 }
-/**
- * Boot-time orphan-card reaper (Known Gap 1,
- * `reference/rfcs/deterministic-turn-liveness.md`). Thin gateway wrapper over
- * the pure `runActivityCardBootReaper` — binds the live fs seam, a real
- * Telegram edit, and the gateway logger. Finalizes ANY card left open by a
- * prior (crashed/restarted) session with ONE honest edit — never a new
- * message, so no ping. Guarantee is AT-MOST-ONCE: the pure routine deletes each
- * record before attempting its edit and does not retry, so a failed edit
- * forfeits that orphan rather than risk a double-finalize on a later boot (see
- * the module doc in activity-card-store.ts for the full tradeoff). A benign-400
- * (card already gone) is reported as `vanished`, not `finalized`.
- *
- * MUST run ONLY after this gateway wins the startup mutex (the store is a
- * shared per-agent file; a losing double-boot would finalize a card the
- * still-alive holder's in-flight turn still legitimately owns) — identical
- * ordering constraint to `statusPinBootCleanup`.
- *
- * Deliberately does NOT attempt to resume climbing the old card: the resumed
- * turn (if any) opens its own fresh card. Honest finalization, not
- * resumption, is the goal (see the module doc in activity-card-store.ts).
- *
- * After the finalizing edit, also unpins the card, but ONLY for a record whose
- * persisted `pinned` flag is true — i.e. the card was actually pin-eligible on
- * open (`PIN_STATUS_WHILE_WORKING`). This unpin is DEFENSE-IN-DEPTH, not the
- * primary unpin path: `statusPinBootCleanup` already unpins orphaned status
- * pins from its own durable store on boot. The reaper's unpin is belt-and-
- * braces for the case where the two stores disagree; the record's `pinned`
- * flag must therefore reflect the ACTUAL pin outcome (see the open path), not
- * an unconditional `true`, or the reaper would attempt an unpin on a card that
- * was never pinned.
- */
+/** Boot-time orphan-card reaper. The seam binding lives in
+ *  activity-card-boot-reaper-wiring.ts (extracted from here under the gateway
+ *  line ratchet, #3634); that module's docblock carries the full contract —
+ *  at-most-once finalize, startup-mutex ordering, and the bot-ready ordering
+ *  this whole boot sweep now depends on. */
 async function activityCardBootReaper(): Promise<void> {
-  if (!activityCardPersistEnabled) return
-  const { finalized, vanished, unpinned, total } = await runActivityCardBootReaper({
+  await runActivityCardBootReaperWiring({
+    enabled: activityCardPersistEnabled,
     path: ACTIVITY_CARD_STORE_PATH,
     fs: activityCardStoreFs,
-    finalizeCard: (record) =>
-      robustApiCall(
-        () =>
-          lockedBot.api.editMessageText(
-            record.chatId,
-            record.activityMessageId,
-            richMessage(restartOrphanCardFinalizeText(record.startedAt)),
-            {},
-          ),
-        {
-          chat_id: record.chatId,
-          ...(record.threadId != null ? { threadId: record.threadId } : {}),
-          verb: 'activity-card.boot-reap-finalize',
-        },
-      ),
-    unpinCard: (record) =>
-      robustApiCall(
-        () => lockedBot.api.unpinChatMessage(record.chatId, record.activityMessageId),
-        {
-          chat_id: record.chatId,
-          ...(record.threadId != null ? { threadId: record.threadId } : {}),
-          verb: 'activity-card.boot-reap-unpin',
-        },
-      ),
+    getBot: () => lockedBot as never,
+    robustApiCall: robustApiCall as never,
+    finalizeBody: (startedAt) => richMessage(restartOrphanCardFinalizeText(startedAt)),
+    run: runActivityCardBootReaper as never,
   })
-  if (total > 0) {
-    process.stderr.write(
-      `telegram gateway: activity-card: finalized ${finalized}/${total} ` +
-        `(vanished ${vanished}/${total}), unpinned ${unpinned}/${total} ` +
-        `orphaned card(s) from a prior session (at-most-once)\n`,
-    )
-  }
 }
 
 /**
@@ -9109,6 +9061,10 @@ async function reconcileStatusPin(
     // in-memory claim map at its top, so overlapping same-key reconciles must
     // run one-at-a-time or a stale `prev` clears the disk row under a live pin.
     await withPinReconcileLock(pinKey, () => reconcileStatusPinInner(pinKey, chatId, desired))
+    // #3634: retry pins whose unpin never landed. Outside the per-key lock
+    // (orphan keys are chat+message scoped, so they never contend); absorbed
+    // by the surrounding catch. See status-pin-orphans.ts.
+    await statusPinOrphans.drain(chatId)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     process.stderr.write(
@@ -9117,6 +9073,16 @@ async function reconcileStatusPin(
     )
   }
 }
+
+// #3634: in-process retry for pins whose unpin did NOT land. The durable half
+// is the `orphanPinKey()` row boot cleanup retries. See status-pin-orphans.ts.
+const statusPinOrphans = createOrphanPinRegistry({
+  unpin: (chatId, messageId) => statusPinApi().unpinChatMessage(chatId, messageId),
+  clearRow: (key) => {
+    if (!statusPinPersistEnabled) return
+    void mutateStatusPinRow(STATUS_PIN_STORE_PATH, statusPinStoreFs, key, null)
+  },
+})
 
 async function reconcileStatusPinInner(
   pinKey: string,
@@ -9132,6 +9098,10 @@ async function reconcileStatusPinInner(
   // older duplicate-pin concern (two edits both reading prev=null).
   const prev = statusPinState.get(pinKey) ?? null
 
+  // #3634: read back by the persist layer so a pin whose unpin did NOT land is
+  // recorded instead of vanishing along with the dropped claim.
+  let unpinLeaked: number | null = null
+
   const runReconcile = () =>
     reconcilePin({
       api: statusPinApi(),
@@ -9139,6 +9109,11 @@ async function reconcileStatusPinInner(
       prevState: prev,
       desired,
       rightsCache: statusPinRightsCache,
+      onUnpinOutcome: (outcome, messageId) => {
+        if (outcome === 'ok') return
+        unpinLeaked = messageId
+        statusPinOrphans.register(chatId, messageId)
+      },
       onPinRightsDisabled: (chat) => {
         // Logged ONCE per chat per process (#3024). Every subsequent auto-pin
         // attempt in this chat is skipped silently until a restart clears the
@@ -9193,6 +9168,7 @@ async function reconcileStatusPinInner(
     chatId,
     op,
     applyPin: runReconcile,
+    unpinFailedMessageId: () => unpinLeaked,
   })
   if (next == null) {
     statusPinState.delete(pinKey)
@@ -9293,39 +9269,37 @@ const dmPinSweeper: DmPinSweeper = createDmPinSweeper({
 
 /**
  * Boot-time pin cleanup + DM stale-pin sweep, sequenced under the startup
- * mutex. Collects the DM chat IDs with a prior-session pin record BEFORE the
- * store reapers empty the stores, runs the three existing boot reapers, marks
- * the DM sweep eligible (this gateway now owns the shared state), then
- * unpin-alls each recorded DM chat. Fire-and-forget from the caller — never
- * blocks boot, never rejects unhandled.
+ * mutex. Thin binder over `runBootPinSweep` (boot-pin-sweep.ts), which owns
+ * the ordering contract: the DM store scan is pure fs and runs immediately,
+ * but every UNPIN waits on `gatewayBotReady` — without that gate the whole
+ * sweep ran at module-eval time and every unpin died on `undefined is not an
+ * object (evaluating 'lockedBot.api')` (#3634). Fire-and-forget from the
+ * caller — never blocks boot, never rejects unhandled.
  */
 async function runBootPinCleanupAndDmSweep(): Promise<void> {
-  let dmChatIds: string[] = []
-  try {
-    dmChatIds = collectDmChatIdsFromStores({
-      statusPins:
-        statusPinPersistEnabled || bannerPinPersistEnabled || toolPinPersistEnabled
-          ? loadStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs)
+  await runBootPinSweep({
+    botReady: gatewayBotReady.ready,
+    scanDmChatIds: () =>
+      collectDmChatIdsFromStores({
+        statusPins:
+          statusPinPersistEnabled || bannerPinPersistEnabled || toolPinPersistEnabled
+            ? loadStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs)
+            : [],
+        activityCards: activityCardPersistEnabled
+          ? loadActivityCards(ACTIVITY_CARD_STORE_PATH, activityCardStoreFs)
           : [],
-      activityCards: activityCardPersistEnabled
-        ? loadActivityCards(ACTIVITY_CARD_STORE_PATH, activityCardStoreFs)
-        : [],
-      queuedCards: queuedCardPersistEnabled
-        ? loadQueuedCards(QUEUED_CARD_STORE_PATH, queuedCardStoreFs)
-        : [],
-    })
-  } catch (err) {
-    process.stderr.write(
-      `telegram gateway: dm-pin-sweep: store scan failed: ${(err as Error).message}\n`,
-    )
-  }
-  await statusPinBootCleanup()
-  await activityCardBootReaper()
-  await queuedCardBootReaper()
-  // This gateway now owns the shared per-agent pin state — enable the DM
-  // unpin-all path (both the boot sweep below and lazy first-inbound sweeps).
-  dmPinSweepEligible = true
-  for (const id of dmChatIds) await dmPinSweeper.sweep(id)
+        queuedCards: queuedCardPersistEnabled
+          ? loadQueuedCards(QUEUED_CARD_STORE_PATH, queuedCardStoreFs)
+          : [],
+      }),
+    statusPinCleanup: () => statusPinBootCleanup(),
+    activityCardReaper: () => activityCardBootReaper(),
+    queuedCardReaper: () => queuedCardBootReaper(),
+    enableDmSweep: () => {
+      dmPinSweepEligible = true
+    },
+    sweepDm: (id) => dmPinSweeper.sweep(id),
+  })
 }
 
 // Activity feed. The gateway streams a live "what it's doing" tool-activity
@@ -22999,6 +22973,10 @@ async function initGatewayBot(): Promise<void> {
   }
 
   lockedBot = chatLock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+  // Release everything that parked on the Bot API being usable — in particular
+  // the boot orphan-pin sweep, which is fired from the startup-mutex block at
+  // module-eval time, thousands of lines before this assignment (#3634).
+  gatewayBotReady.markReady()
 
   // RFC B §9 (moved here by P0b): register /approvals against the approval
   // kernel. The kernel's IPC client round-trips through the vault broker; the

--- a/telegram-plugin/gateway/status-pin-api.ts
+++ b/telegram-plugin/gateway/status-pin-api.ts
@@ -17,6 +17,7 @@
  */
 
 import type { PinBotApi } from '../status-pin-driver.js'
+import { SEND_GATE_SHED } from '../send-gate.js'
 
 export class BotNotReadyError extends Error {
   constructor(what: string) {
@@ -31,6 +32,40 @@ export class BotNotReadyError extends Error {
 export function assertBotReady<T>(bot: T | undefined | null, what: string): T {
   if (bot == null) throw new BotNotReadyError(what)
   return bot
+}
+
+export class SendGateShedError extends Error {
+  constructor(verb: string) {
+    super(`STATUS_PIN_SEND_SHED: ${verb} was shed by the send gate and never reached Telegram`)
+    this.name = 'SendGateShedError'
+  }
+}
+
+/**
+ * The pin state machine reads "the call did not throw" as "the pin/unpin
+ * PAINTED": `reconcilePin` claims the message on a resolved pin and treats a
+ * resolved unpin as landed (no orphan row, no retry). So a send that was
+ * DROPPED but resolved success-shaped would corrupt that state — exactly the
+ * bug shape review caught on #3631, where a dropped edit resolving ok made the
+ * gate record a never-painted payload as on-screen and froze the card.
+ *
+ * Today that cannot happen: a pin/unpin is a SEND (no `messageId`/`editPayload`
+ * opts), and untagged sends admit as `UNTAGGED_SEND_CLASS = 'critical'`
+ * (send-gate.ts:119) — critical is never shed and never TTL-expired; it either
+ * runs or throws a structured `FLOOD_WAIT_ACTIVE`. But that safety rests on a
+ * DEFAULT in another module. This converts it into an enforced invariant: if a
+ * pin/unpin ever resolves the gate's `SEND_GATE_SHED` sentinel, it becomes a
+ * throw, so the driver reports `failed`, the store re-homes an orphan row and
+ * the boot sweep finishes the job.
+ *
+ * Sentinel ONLY — `undefined` is deliberately NOT treated as a failure: the
+ * gate also resolves `undefined` for a benign no-op drop, and conflating the
+ * two is the ambiguity the sentinel was introduced to remove
+ * (send-gate.ts:129-140).
+ */
+function assertLanded(result: unknown, verb: string): unknown {
+  if (result === SEND_GATE_SHED) throw new SendGateShedError(verb)
+  return result
 }
 
 /** Minimal shape of the wrapped bot this module needs. */
@@ -64,11 +99,11 @@ export function createStatusPinApi(
       robust(() => bot('status-pin.pin').api.pinChatMessage(chat_id, message_id, opts), {
         chat_id: String(chat_id),
         verb: 'status-pin.pin',
-      }),
+      }).then((r) => assertLanded(r, 'status-pin.pin')),
     unpinChatMessage: (chat_id, message_id) =>
       robust(() => bot('status-pin.unpin').api.unpinChatMessage(chat_id, message_id), {
         chat_id: String(chat_id),
         verb: 'status-pin.unpin',
-      }),
+      }).then((r) => assertLanded(r, 'status-pin.unpin')),
   }
 }

--- a/telegram-plugin/gateway/status-pin-api.ts
+++ b/telegram-plugin/gateway/status-pin-api.ts
@@ -1,0 +1,74 @@
+/**
+ * The Bot API surface the status-pin driver needs, bound to the gateway's
+ * retry policy (#3634 — extracted from gateway.ts, which is under a line
+ * ratchet).
+ *
+ * `lockedBot` in gateway.ts is declared `let lockedBot!: Bot<Context>`: the
+ * definite-assignment `!` is an ASSERTION, not a guarantee, and it hid from
+ * tsc that anything running at module-eval time dereferences `undefined`. The
+ * boot orphan-pin sweep did exactly that for months — every unpin it issued
+ * failed with the opaque `undefined is not an object (evaluating
+ * 'lockedBot.api')`, so no orphaned pin was ever cleaned up and finished
+ * activity cards stayed pinned forever.
+ *
+ * The ordering fix is the `gatewayBotReady` latch (see boot-pin-sweep.ts).
+ * `assertBotReady` is the backstop: any FUTURE pre-ready caller gets a NAMED,
+ * greppable error instead of something that reads like a Telegram failure.
+ */
+
+import type { PinBotApi } from '../status-pin-driver.js'
+
+export class BotNotReadyError extends Error {
+  constructor(what: string) {
+    super(
+      `STATUS_PIN_BOT_NOT_READY: ${what} used before initGatewayBot() assigned ` +
+        `lockedBot — await gatewayBotReady.ready first`,
+    )
+    this.name = 'BotNotReadyError'
+  }
+}
+
+export function assertBotReady<T>(bot: T | undefined | null, what: string): T {
+  if (bot == null) throw new BotNotReadyError(what)
+  return bot
+}
+
+/** Minimal shape of the wrapped bot this module needs. */
+export interface PinCapableBot {
+  api: {
+    pinChatMessage: (
+      chatId: string | number,
+      messageId: number,
+      opts?: Record<string, unknown>,
+    ) => Promise<unknown>
+    unpinChatMessage: (
+      chatId: string | number,
+      messageId: number,
+    ) => Promise<unknown>
+  }
+}
+
+/**
+ * Build the pin API. `getBot` is read LAZILY on every call (the gateway's
+ * `lockedBot` is assigned late), and `robust` is the gateway's
+ * `robustApiCall` so pins/unpins ride the send gate and retry policy exactly
+ * as before this extraction.
+ */
+export function createStatusPinApi(
+  getBot: () => PinCapableBot | undefined,
+  robust: (fn: () => Promise<unknown>, opts: Record<string, unknown>) => Promise<unknown>,
+): PinBotApi {
+  const bot = (what: string) => assertBotReady(getBot(), what)
+  return {
+    pinChatMessage: (chat_id, message_id, opts) =>
+      robust(() => bot('status-pin.pin').api.pinChatMessage(chat_id, message_id, opts), {
+        chat_id: String(chat_id),
+        verb: 'status-pin.pin',
+      }),
+    unpinChatMessage: (chat_id, message_id) =>
+      robust(() => bot('status-pin.unpin').api.unpinChatMessage(chat_id, message_id), {
+        chat_id: String(chat_id),
+        verb: 'status-pin.unpin',
+      }),
+  }
+}

--- a/telegram-plugin/gateway/status-pin-orphans.ts
+++ b/telegram-plugin/gateway/status-pin-orphans.ts
@@ -14,12 +14,28 @@
  *
  * Bounded: `maxAttempts` retries per orphan, then it is forfeited in-process
  * (the durable row is still there, so boot cleanup gets its own ladder). Keyed
- * by chat+message, so registering the same leaked pin twice is idempotent.
+ * by chat+message, so registering the same leaked pin twice is idempotent. The
+ * map is also capped (`MAX_TRACKED_ORPHANS`) so a pathological run of failed
+ * unpins cannot grow it without bound — an evicted orphan still has its durable
+ * row, so eviction defers cleanup to boot rather than losing it.
+ *
+ * NEVER UNPINS A LIVE PIN. A leaked message id can be CLAIMED AGAIN before the
+ * retry fires — the group worker card (`wk:group:<feedKey>`) is one long-lived
+ * message that is pinned, unpinned and re-pinned across turns, so a turn-end
+ * unpin that flood-failed can be followed by a re-pin of that very id. Draining
+ * blind would then unpin a card the user is actively watching. `isLive` is
+ * therefore consulted immediately before every retry, and a superseded orphan
+ * is DISCARDED (row and all): the live claim now owns that message and its own
+ * row governs it.
  */
 
 import { orphanPinKey } from './status-pin-store.js'
 
 export const ORPHAN_PIN_MAX_ATTEMPTS = 5
+
+/** Cap on tracked orphans. Well above any plausible real leak count; exists so
+ *  a pathological failure run cannot grow the map without bound. */
+export const MAX_TRACKED_ORPHANS = 100
 
 export interface OrphanPinRegistryDeps {
   /** Best-effort unpin. May throw; a throw counts as one failed attempt. */
@@ -27,6 +43,11 @@ export interface OrphanPinRegistryDeps {
   /** Drop the durable orphan row once the unpin finally lands (or is
    *  forfeited). Receives the `orphanPinKey()` value. */
   clearRow: (pinKey: string) => void
+  /** True when this chat+message is CURRENTLY claimed as a live status pin.
+   *  Consulted immediately before each retry — see the module docblock. When
+   *  omitted, every orphan is treated as stale (test convenience only; the
+   *  gateway always passes it). */
+  isLive?: (chatId: string, messageId: number) => boolean
   maxAttempts?: number
   log?: (line: string) => void
 }
@@ -58,6 +79,18 @@ export function createOrphanPinRegistry(
     register(chatId, messageId) {
       const key = orphanPinKey(chatId, messageId)
       if (orphans.has(key)) return
+      if (orphans.size >= MAX_TRACKED_ORPHANS) {
+        // Evict the oldest (Map preserves insertion order). Its durable row is
+        // untouched, so boot cleanup still finishes it.
+        const oldest = orphans.keys().next().value
+        if (oldest != null) {
+          orphans.delete(oldest)
+          log(
+            `telegram gateway: orphan pin registry full (${MAX_TRACKED_ORPHANS}) — ` +
+              `evicted ${oldest} from in-process retry; its durable row remains\n`,
+          )
+        }
+      }
       orphans.set(key, { chatId, messageId, attempts: 0 })
     },
 
@@ -67,6 +100,17 @@ export function createOrphanPinRegistry(
       try {
         for (const [key, o] of [...orphans]) {
           if (o.chatId !== chatId) continue
+          if (deps.isLive?.(o.chatId, o.messageId) === true) {
+            // Superseded: this message is pinned again and a live claim owns
+            // it. Unpinning here would tear down a card the user is watching.
+            orphans.delete(key)
+            deps.clearRow(key)
+            log(
+              `telegram gateway: orphan pin superseded — message is pinned again ` +
+                `(chat=${o.chatId} msg=${o.messageId}); dropped ${key}\n`,
+            )
+            continue
+          }
           try {
             await deps.unpin(o.chatId, o.messageId)
             orphans.delete(key)

--- a/telegram-plugin/gateway/status-pin-orphans.ts
+++ b/telegram-plugin/gateway/status-pin-orphans.ts
@@ -1,0 +1,98 @@
+/**
+ * In-process orphan-pin retry (#3634).
+ *
+ * The durable half of the fix (`orphanPinKey` in status-pin-store.ts) makes a
+ * failed unpin survive to the next boot. This is the other half: a gateway
+ * that stays up for days would otherwise leave the pin visible for days.
+ *
+ * Deliberately TIMER-FREE. A background interval is another surface to leak,
+ * to test, and to unref correctly; instead the registry is drained
+ * opportunistically from the status-pin reconcile itself — i.e. at the next
+ * turn boundary in that chat. The transient failures this exists for
+ * (FLOOD_WAIT_ACTIVE, 5xx) clear within minutes, and a chat that has no
+ * further turns has no further pins to confuse either.
+ *
+ * Bounded: `maxAttempts` retries per orphan, then it is forfeited in-process
+ * (the durable row is still there, so boot cleanup gets its own ladder). Keyed
+ * by chat+message, so registering the same leaked pin twice is idempotent.
+ */
+
+import { orphanPinKey } from './status-pin-store.js'
+
+export const ORPHAN_PIN_MAX_ATTEMPTS = 5
+
+export interface OrphanPinRegistryDeps {
+  /** Best-effort unpin. May throw; a throw counts as one failed attempt. */
+  unpin: (chatId: string, messageId: number) => Promise<unknown>
+  /** Drop the durable orphan row once the unpin finally lands (or is
+   *  forfeited). Receives the `orphanPinKey()` value. */
+  clearRow: (pinKey: string) => void
+  maxAttempts?: number
+  log?: (line: string) => void
+}
+
+export interface OrphanPinRegistry {
+  /** Record a pin whose unpin did not land. Idempotent per chat+message. */
+  register: (chatId: string, messageId: number) => void
+  /** Retry every orphan recorded for `chatId`. Never rejects. */
+  drain: (chatId: string) => Promise<void>
+  /** Outstanding orphan count (tests / diagnostics). */
+  size: () => number
+}
+
+export function createOrphanPinRegistry(
+  deps: OrphanPinRegistryDeps,
+): OrphanPinRegistry {
+  const maxAttempts = deps.maxAttempts ?? ORPHAN_PIN_MAX_ATTEMPTS
+  const log = deps.log ?? ((l: string) => process.stderr.write(l))
+  const orphans = new Map<
+    string,
+    { chatId: string; messageId: number; attempts: number }
+  >()
+  // Guards re-entrancy: `drain` is fired from the reconcile path, which can be
+  // re-entered while an unpin is in flight. Without this, one slow orphan is
+  // retried by every concurrent reconcile at once.
+  const draining = new Set<string>()
+
+  return {
+    register(chatId, messageId) {
+      const key = orphanPinKey(chatId, messageId)
+      if (orphans.has(key)) return
+      orphans.set(key, { chatId, messageId, attempts: 0 })
+    },
+
+    async drain(chatId) {
+      if (draining.has(chatId)) return
+      draining.add(chatId)
+      try {
+        for (const [key, o] of [...orphans]) {
+          if (o.chatId !== chatId) continue
+          try {
+            await deps.unpin(o.chatId, o.messageId)
+            orphans.delete(key)
+            deps.clearRow(key)
+            log(
+              `telegram gateway: orphan pin cleared on retry ` +
+                `(chat=${o.chatId} msg=${o.messageId} attempts=${o.attempts + 1})\n`,
+            )
+          } catch (err) {
+            o.attempts += 1
+            if (o.attempts >= maxAttempts) {
+              orphans.delete(key)
+              log(
+                `telegram gateway: orphan pin giving up in-process after ` +
+                  `${o.attempts} attempts (chat=${o.chatId} msg=${o.messageId}): ` +
+                  `${err instanceof Error ? err.message : String(err)} — ` +
+                  `durable row ${key} remains for boot cleanup\n`,
+              )
+            }
+          }
+        }
+      } finally {
+        draining.delete(chatId)
+      }
+    },
+
+    size: () => orphans.size,
+  }
+}

--- a/telegram-plugin/gateway/status-pin-store.ts
+++ b/telegram-plugin/gateway/status-pin-store.ts
@@ -79,6 +79,27 @@ export interface PersistedStatusPin {
  *  re-fail on every boot forever. */
 export const BOOT_UNPIN_MAX_ATTEMPTS = 5
 
+/**
+ * Durable key for a pin whose RUNTIME unpin failed (#3634).
+ *
+ * The driver's drop-on-unpin contract clears the in-memory claim even when
+ * `unpinChatMessage` throws — deliberately, so pin STATE can never wedge. But
+ * the persist layer used to delete the durable row on that same signal, so an
+ * unpin that failed with FLOOD_WAIT_ACTIVE / a 5xx left the message pinned in
+ * Telegram with NOTHING on disk naming it: boot cleanup had no row to retry,
+ * and the pin was permanent.
+ *
+ * Now a failed unpin re-homes the record under this key — chat+message scoped,
+ * so it can never collide with the live `fg:`/`wk:` row (which is cleared as
+ * before, letting a fresh pin claim that key immediately). It carries no
+ * `expiresAt`, so it is work-scoped: the next boot cleanup unpins it, with the
+ * existing `attempts` retry/forfeit ladder bounding a permanently-undeliverable
+ * one. Unpins are idempotent, so a redundant retry is harmless.
+ */
+export function orphanPinKey(chatId: string, messageId: number): string {
+  return `orphan:${chatId}:${messageId}`
+}
+
 /** Envelope version. v1 had no `pending` field; a v1 row loads as a confirmed
  *  pin (pending undefined). v2 adds the optional `pending` flag. Both load
  *  fail-open — an unknown/newer version yields []. */
@@ -427,6 +448,12 @@ export function reconcileAndPersistStatusPin(args: {
   /** Execute the real pin/unpin; returns the confirmed message id (pin) or
    *  null (cleared). Must never throw — API errors are swallowed inside. */
   applyPin: () => Promise<{ messageId: number } | null>
+  /** Read AFTER `applyPin` settles, on a `clear` op only: the message id whose
+   *  unpin did NOT land (threw, or was skipped for missing pin rights), or
+   *  null when the unpin succeeded. Non-null re-homes the record under
+   *  `orphanPinKey()` so boot cleanup retries it instead of the pin leaking
+   *  with no durable trace (#3634). */
+  unpinFailedMessageId?: () => number | null
   log?: (line: string) => void
 }): Promise<{ messageId: number } | null> {
   const { path, fs, pinKey, chatId, op } = args
@@ -487,6 +514,26 @@ export function reconcileAndPersistStatusPin(args: {
     const next = await args.applyPin()
     if (next == null) {
       applyStatusPinRow(path, fs, pinKey, null, log)
+      // #3634: the claim is gone, but did the UNPIN actually land? If it did
+      // not, the message is still pinned in Telegram — re-home it under an
+      // orphan row (same store, same lock, distinct key) so the next boot
+      // cleanup retries it. Dropping BOTH the claim and the row here is what
+      // made a flood-wait'd unpin a permanent pin.
+      const orphanId = args.unpinFailedMessageId?.() ?? null
+      if (orphanId != null) {
+        const oKey = orphanPinKey(chatId, orphanId)
+        applyStatusPinRow(
+          path,
+          fs,
+          oKey,
+          { pinKey: oKey, chatId, messageId: orphanId },
+          log,
+        )
+        log(
+          `status-pin-store: unpin did not land (key=${pinKey} chat=${chatId} ` +
+            `msg=${orphanId}) — retained orphan row ${oKey} for boot retry\n`,
+        )
+      }
     } else {
       applyStatusPinRow(
         path,

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -70,11 +70,18 @@ export interface RetryCallOpts {
    *     send waits for a short window but fails fast (structured
    *     `FLOOD_WAIT_ACTIVE`) when the remaining window is long.
    *   - `useful`    — progress-card creation, worker handbacks, checklists,
-   *     boot/config cards. Queued with a TTL; dropped when stale. DEFAULT
-   *     when unset.
+   *     boot/config cards. Queued with a TTL; dropped when stale.
    *   - `cosmetic`  — typing, reactions, all card EDITS, stream updates,
    *     heartbeats. Shed immediately when no token is free OR any flood
    *     window is open.
+   *
+   * DEFAULT when unset is NOT `useful`: an untagged SEND admits as
+   * `UNTAGGED_SEND_CLASS = 'critical'` (send-gate.ts:119, hardened in review of
+   * #3106 so no untagged call is silently droppable), and an untagged EDIT is
+   * recorded `useful` but coalesces rather than sheds (send-gate.ts:1101).
+   * Callers that reason about droppability — e.g. the status-pin state machine,
+   * which reads "did not throw" as "painted" — depend on that, so correcting
+   * this comment matters (#3634).
    */
   priorityClass?: 'critical' | 'useful' | 'cosmetic'
 }

--- a/telegram-plugin/status-pin-driver.ts
+++ b/telegram-plugin/status-pin-driver.ts
@@ -65,6 +65,24 @@ export interface ReconcilePinArgs {
    *  per-attempt `status-pin pin failed` spam. Only fires when `rightsCache`
    *  is supplied. */
   onPinRightsDisabled?: (chatId: string) => void
+  /** Reports whether the UNPIN actually landed (#3634). The claim is dropped
+   *  either way — that contract is load-bearing and unchanged — but the caller
+   *  needs to know the difference so a FAILED unpin (flood-wait, 5xx, rights
+   *  revoked) can be recorded as a durable orphan instead of vanishing.
+   *  Dropping the claim AND the durable row on a failed unpin is what left
+   *  finished cards pinned forever with nothing left to reconcile them.
+   *
+   *  - `ok`                 — Telegram accepted the unpin; the pin is gone.
+   *  - `failed`             — the unpin threw; the message is probably STILL
+   *                           pinned and must be retried.
+   *  - `skipped-no-rights`  — no API call was made because the chat is in the
+   *                           pin-rights negative cache; also still pinned.
+   *
+   *  Only ever called for an `unpin` action. Never for `pin` / `noop`. */
+  onUnpinOutcome?: (
+    outcome: 'ok' | 'failed' | 'skipped-no-rights',
+    messageId: number,
+  ) => void
 }
 
 /**
@@ -89,11 +107,16 @@ export async function reconcilePin(
   if (action.kind === 'unpin') {
     // Skip the unpin API call in a chat the bot can't manage pins in — the
     // call would fail with the same rights 400 and spam the log. The claim is
-    // dropped either way (below), so skipping is safe.
-    if (!args.rightsCache?.isBlocked(args.chatId)) {
+    // dropped either way (below), so skipping is safe — but the outcome is
+    // reported so the caller can still record the leaked pin (#3634).
+    if (args.rightsCache?.isBlocked(args.chatId)) {
+      args.onUnpinOutcome?.('skipped-no-rights', action.messageId)
+    } else {
       try {
         await args.api.unpinChatMessage(args.chatId, action.messageId)
+        args.onUnpinOutcome?.('ok', action.messageId)
       } catch (err) {
+        args.onUnpinOutcome?.('failed', action.messageId)
         // Symmetric with the pin path below: a permanent rights 400 on UNPIN
         // (rights revoked mid-session after we pinned) also enters the
         // negative cache and logs once via onPinRightsDisabled — otherwise

--- a/telegram-plugin/tests/activity-card-wiring.test.ts
+++ b/telegram-plugin/tests/activity-card-wiring.test.ts
@@ -25,6 +25,12 @@ const gatewaySrc = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'
 // narrative-lane.ts (bodies indented +2 inside the factory — multi-line
 // markers below use the lane spelling).
 const laneSrc = readFileSync(resolve(__dirname, '..', 'gateway', 'narrative-lane.ts'), 'utf-8')
+// #3634: the reaper's seam binding (the Telegram edit/unpin + the honest boot
+// log) moved out of gateway.ts into its own module under the line ratchet.
+const reaperSrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'activity-card-boot-reaper-wiring.ts'),
+  'utf-8',
+)
 
 function between(src: string, startMarker: string, endMarker: string): string {
   const after = src.split(startMarker)[1] ?? ''
@@ -128,7 +134,11 @@ describe('activity-card durability wiring', () => {
       'async function runBootPinCleanupAndDmSweep()',
       'dmPinSweepEligible = true',
     )
-    expect(orchestrator).toMatch(/await activityCardBootReaper\(\)/)
+    // #3634: the orchestrator delegates its sequencing to runBootPinSweep, so
+    // the reaper is handed over as a step rather than awaited inline. The
+    // invariant under test is unchanged — it is invoked from HERE and nowhere
+    // earlier — and runBootPinSweep awaits every step it is given.
+    expect(orchestrator).toMatch(/activityCardReaper: \(\) => activityCardBootReaper\(\)/)
     // (2) Both orchestrator invocation sites (mutex-won + mutex-fallback)
     // sit AFTER acquireStartupLock.
     const afterLock = between(gatewaySrc, 'await acquireStartupLock({', 'catch (err)')
@@ -142,12 +152,10 @@ describe('activity-card durability wiring', () => {
   })
 
   it('the reaper wrapper counts a benign-400 as vanished, not finalized (honest boot log)', () => {
-    const wrapper = between(
-      gatewaySrc,
-      'async function activityCardBootReaper()',
-      '\n// NOTE: statusPinBootCleanup()',
-    )
-    expect(wrapper).toMatch(/vanished/)
-    expect(wrapper).toMatch(/at-most-once/)
+    // #3634: the wrapper body (and its boot log) now lives in
+    // activity-card-boot-reaper-wiring.ts; gateway.ts only binds the seams.
+    expect(gatewaySrc).toMatch(/await runActivityCardBootReaperWiring\(\{/)
+    expect(reaperSrc).toMatch(/vanished/)
+    expect(reaperSrc).toMatch(/at-most-once/)
   })
 })

--- a/telegram-plugin/tests/status-pin-orphan-lifecycle.test.ts
+++ b/telegram-plugin/tests/status-pin-orphan-lifecycle.test.ts
@@ -1,0 +1,521 @@
+/**
+ * #3634 — "the progress card stays pinned after the turn completes."
+ *
+ * Two independent defects kept a finished activity card pinned forever. Both
+ * are asserted here as OUTCOMES ("is anything still pinned in Telegram?"), so
+ * each test fails against the pre-fix code:
+ *
+ *   D1 — the boot orphan-pin sweep ran at module-eval time, thousands of lines
+ *        before `lockedBot` was assigned, so every unpin it issued threw
+ *        `undefined is not an object (evaluating 'lockedBot.api')`. It never
+ *        cleaned up anything on any agent; after BOOT_UNPIN_MAX_ATTEMPTS boots
+ *        the row was forfeited and the pin became permanent.
+ *
+ *   D2 — a RUNTIME unpin that failed (FLOOD_WAIT_ACTIVE / 5xx / rights revoked)
+ *        dropped the in-memory claim AND deleted the durable row, so the still-
+ *        pinned message had nothing on disk naming it and boot cleanup could
+ *        never see it.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  loadStatusPins,
+  persistStatusPins,
+  reconcileAndPersistStatusPin,
+  runStatusPinBootCleanup,
+  orphanPinKey,
+  BOOT_UNPIN_MAX_ATTEMPTS,
+  type PersistedStatusPin,
+  type StatusPinStoreFsSeam,
+} from "../gateway/status-pin-store.js";
+import { reconcilePin, type PinBotApi } from "../status-pin-driver.js";
+import { PinRightsCache } from "../status-pin.js";
+import {
+  runBootPinSweep,
+  createBotReadyGate,
+} from "../gateway/boot-pin-sweep.js";
+import {
+  createOrphanPinRegistry,
+  ORPHAN_PIN_MAX_ATTEMPTS,
+} from "../gateway/status-pin-orphans.js";
+
+const PATH = "/state/agent/telegram/status-pins.json";
+
+function memFs(seed: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(seed));
+  const fs: StatusPinStoreFsSeam = {
+    readFileSync: (p) => {
+      if (!files.has(p)) throw new Error(`ENOENT ${p}`);
+      return files.get(p)!;
+    },
+    writeFileSync: (p, d) => {
+      files.set(p, d);
+    },
+    renameSync: (a, b) => {
+      if (!files.has(a)) throw new Error(`ENOENT ${a}`);
+      files.set(b, files.get(a)!);
+      files.delete(a);
+    },
+    existsSync: (p) => files.has(p),
+  };
+  return { fs, files };
+}
+
+/** A Telegram stand-in that tracks what is actually pinned in the chat, so a
+ *  test can assert the OUTCOME ("nothing is pinned") rather than the fact that
+ *  some unpin function was called. */
+function fakeChat() {
+  const pinned = new Set<number>();
+  const unpinCalls: number[] = [];
+  return {
+    pinned,
+    unpinCalls,
+    pin: (id: number) => pinned.add(id),
+    unpin: async (_chatId: string, messageId: number) => {
+      unpinCalls.push(messageId);
+      pinned.delete(messageId);
+      return {};
+    },
+  };
+}
+
+describe("#3634 D1: the boot pin sweep must not run before the bot exists", () => {
+  /**
+   * Models the real gateway shape: `lockedBot` is a `let … !: Bot` that is
+   * undefined until initGatewayBot() assigns it, and the pin API closes over
+   * it. Pre-fix the sweep was fired at module-eval time, so this deref threw.
+   */
+  function gatewayLike() {
+    const chat = fakeChat();
+    let lockedBot: { unpin: (c: string, m: number) => Promise<unknown> } | undefined;
+    const gate = createBotReadyGate();
+    const unpinViaBot = (chatId: string, messageId: number) =>
+      // The literal pre-fix failure: dereferencing an unset `lockedBot`.
+      lockedBot!.unpin(chatId, messageId);
+    return {
+      chat,
+      gate,
+      unpinViaBot,
+      initBot: () => {
+        lockedBot = { unpin: chat.unpin };
+        gate.markReady();
+      },
+    };
+  }
+
+  it("clears an orphaned pin from a prior session (fails if the sweep races initGatewayBot)", async () => {
+    const { fs } = memFs();
+    const g = gatewayLike();
+    g.chat.pin(715);
+    persistStatusPins(PATH, fs, [
+      { pinKey: "fg:-100123:_", chatId: "-100123", messageId: 715 },
+    ]);
+
+    // Boot order, faithfully: the sweep is fired (fire-and-forget) from the
+    // startup-mutex block, and initGatewayBot() only assigns the bot later.
+    const sweep = runBootPinSweep({
+      botReady: g.gate.ready,
+      scanDmChatIds: () => [],
+      statusPinCleanup: () =>
+        runStatusPinBootCleanup({
+          path: PATH,
+          fs,
+          unpin: g.unpinViaBot,
+          log: () => {},
+        }),
+      activityCardReaper: async () => {},
+      queuedCardReaper: async () => {},
+      enableDmSweep: () => {},
+      sweepDm: async () => {},
+      log: () => {},
+    });
+
+    // Nothing may have been attempted yet — the bot does not exist.
+    await Promise.resolve();
+    expect(g.chat.unpinCalls).toEqual([]);
+
+    g.initBot();
+    await sweep;
+
+    // OUTCOME: the orphaned pin is gone from the chat and from the store.
+    expect(g.chat.pinned.size).toBe(0);
+    expect(g.chat.unpinCalls).toEqual([715]);
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("runs the store scan before the gate and the API steps in order after it", async () => {
+    const g = gatewayLike();
+    const order: string[] = [];
+    const sweep = runBootPinSweep({
+      botReady: g.gate.ready,
+      scanDmChatIds: () => {
+        order.push("scan");
+        return ["8248703757"];
+      },
+      statusPinCleanup: async () => {
+        order.push("status-pins");
+      },
+      activityCardReaper: async () => {
+        order.push("activity-cards");
+      },
+      queuedCardReaper: async () => {
+        order.push("queued-cards");
+      },
+      enableDmSweep: () => order.push("enable-dm"),
+      sweepDm: async (id) => {
+        order.push(`dm:${id}`);
+      },
+      log: () => {},
+    });
+    await Promise.resolve();
+    expect(order).toEqual(["scan"]); // gate holds everything else
+
+    g.initBot();
+    await sweep;
+    expect(order).toEqual([
+      "scan",
+      "status-pins",
+      "activity-cards",
+      "queued-cards",
+      "enable-dm",
+      "dm:8248703757",
+    ]);
+  });
+
+  it("a throwing step does not strand the steps behind it", async () => {
+    const g = gatewayLike();
+    g.initBot();
+    const order: string[] = [];
+    await runBootPinSweep({
+      botReady: g.gate.ready,
+      scanDmChatIds: () => ["1"],
+      statusPinCleanup: async () => {
+        throw new Error("boom");
+      },
+      activityCardReaper: async () => {
+        order.push("activity-cards");
+      },
+      queuedCardReaper: async () => {
+        order.push("queued-cards");
+      },
+      enableDmSweep: () => order.push("enable-dm"),
+      sweepDm: async (id) => {
+        order.push(`dm:${id}`);
+      },
+      log: () => {},
+    });
+    expect(order).toEqual([
+      "activity-cards",
+      "queued-cards",
+      "enable-dm",
+      "dm:1",
+    ]);
+  });
+});
+
+describe("#3634 D2: a runtime unpin that does not land stays recorded", () => {
+  function floodingApi(): PinBotApi {
+    return {
+      pinChatMessage: async () => ({}),
+      unpinChatMessage: async () => {
+        throw new Error("FLOOD_WAIT_ACTIVE");
+      },
+    };
+  }
+
+  it("reports the unpin outcome while still dropping the claim", async () => {
+    const outcomes: Array<[string, number]> = [];
+    const next = await reconcilePin({
+      api: floodingApi(),
+      chatId: "-100123",
+      prevState: { messageId: 715 },
+      desired: { pinned: false },
+      onError: () => {},
+      onUnpinOutcome: (o, id) => outcomes.push([o, id]),
+    });
+    // Drop-on-unpin is unchanged: state must never wedge.
+    expect(next).toBeNull();
+    expect(outcomes).toEqual([["failed", 715]]);
+  });
+
+  it("reports 'ok' only when Telegram accepted the unpin", async () => {
+    const chat = fakeChat();
+    chat.pin(715);
+    const outcomes: Array<[string, number]> = [];
+    await reconcilePin({
+      api: {
+        pinChatMessage: async () => ({}),
+        unpinChatMessage: (c, m) => chat.unpin(String(c), m),
+      },
+      chatId: "-100123",
+      prevState: { messageId: 715 },
+      desired: { pinned: false },
+      onUnpinOutcome: (o, id) => outcomes.push([o, id]),
+    });
+    expect(outcomes).toEqual([["ok", 715]]);
+    expect(chat.pinned.size).toBe(0);
+  });
+
+  it("reports 'skipped-no-rights' when the rights cache suppresses the call", async () => {
+    const rightsCache = new PinRightsCache();
+    rightsCache.block("-100123");
+    const outcomes: Array<[string, number]> = [];
+    let called = 0;
+    await reconcilePin({
+      api: {
+        pinChatMessage: async () => ({}),
+        unpinChatMessage: async () => {
+          called++;
+          return {};
+        },
+      },
+      chatId: "-100123",
+      prevState: { messageId: 715 },
+      desired: { pinned: false },
+      rightsCache,
+      onUnpinOutcome: (o, id) => outcomes.push([o, id]),
+    });
+    expect(called).toBe(0);
+    expect(outcomes).toEqual([["skipped-no-rights", 715]]);
+  });
+
+  it("re-homes a failed unpin as a durable orphan row instead of deleting it", async () => {
+    const { fs } = memFs();
+    persistStatusPins(PATH, fs, [
+      { pinKey: "fg:-100123:_", chatId: "-100123", messageId: 715 },
+    ]);
+
+    const next = await reconcileAndPersistStatusPin({
+      path: PATH,
+      fs,
+      pinKey: "fg:-100123:_",
+      chatId: "-100123",
+      op: { kind: "clear" },
+      applyPin: async () => null,
+      unpinFailedMessageId: () => 715,
+      log: () => {},
+    });
+
+    expect(next).toBeNull();
+    const rows = loadStatusPins(PATH, fs);
+    // Live key released (a fresh turn may claim it immediately)…
+    expect(rows.find((r) => r.pinKey === "fg:-100123:_")).toBeUndefined();
+    // …but the leaked pin is still named on disk.
+    expect(rows).toEqual([
+      {
+        pinKey: orphanPinKey("-100123", 715),
+        chatId: "-100123",
+        messageId: 715,
+      },
+    ]);
+  });
+
+  it("a successful unpin still clears the row (no orphan is invented)", async () => {
+    const { fs } = memFs();
+    persistStatusPins(PATH, fs, [
+      { pinKey: "fg:-100123:_", chatId: "-100123", messageId: 715 },
+    ]);
+    await reconcileAndPersistStatusPin({
+      path: PATH,
+      fs,
+      pinKey: "fg:-100123:_",
+      chatId: "-100123",
+      op: { kind: "clear" },
+      applyPin: async () => null,
+      unpinFailedMessageId: () => null,
+      log: () => {},
+    });
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+});
+
+describe("#3634: no pin outlives its turn, across a restart", () => {
+  it("a flood-wait'd turn-end unpin is finished by the next boot's sweep", async () => {
+    const { fs } = memFs();
+    const chat = fakeChat();
+    chat.pin(715); // the activity card, pinned while working
+
+    // ── Turn end, mid flood ban: the unpin throws. ────────────────────────
+    let leaked: number | null = null;
+    await reconcileAndPersistStatusPin({
+      path: PATH,
+      fs,
+      pinKey: "fg:-100123:_",
+      chatId: "-100123",
+      op: { kind: "clear" },
+      applyPin: () =>
+        reconcilePin({
+          api: {
+            pinChatMessage: async () => ({}),
+            unpinChatMessage: async () => {
+              throw new Error("FLOOD_WAIT_ACTIVE");
+            },
+          },
+          chatId: "-100123",
+          prevState: { messageId: 715 },
+          desired: { pinned: false },
+          onError: () => {},
+          onUnpinOutcome: (o, id) => {
+            if (o !== "ok") leaked = id;
+          },
+        }),
+      unpinFailedMessageId: () => leaked,
+      log: () => {},
+    });
+    expect(chat.pinned.has(715)).toBe(true); // still pinned — the bug's symptom
+
+    // ── Restart. The boot sweep (with a bot that now exists) finishes it. ──
+    const gate = createBotReadyGate();
+    gate.markReady();
+    await runBootPinSweep({
+      botReady: gate.ready,
+      scanDmChatIds: () => [],
+      statusPinCleanup: () =>
+        runStatusPinBootCleanup({ path: PATH, fs, unpin: chat.unpin, log: () => {} }),
+      activityCardReaper: async () => {},
+      queuedCardReaper: async () => {},
+      enableDmSweep: () => {},
+      sweepDm: async () => {},
+      log: () => {},
+    });
+
+    expect(chat.pinned.size).toBe(0);
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("boot cleanup treats an orphan row as work-scoped (no expiresAt to survive)", async () => {
+    const { fs } = memFs();
+    const chat = fakeChat();
+    chat.pin(42);
+    const row: PersistedStatusPin = {
+      pinKey: orphanPinKey("-100123", 42),
+      chatId: "-100123",
+      messageId: 42,
+    };
+    persistStatusPins(PATH, fs, [row]);
+    const res = await runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: chat.unpin,
+      log: () => {},
+    });
+    expect(res.cleared).toBe(1);
+    expect(res.kept).toBe(0);
+    expect(chat.pinned.size).toBe(0);
+  });
+
+  it("a permanently undeliverable orphan is forfeited, not retried forever", async () => {
+    const { fs } = memFs();
+    persistStatusPins(PATH, fs, [
+      {
+        pinKey: orphanPinKey("-100123", 42),
+        chatId: "-100123",
+        messageId: 42,
+        attempts: BOOT_UNPIN_MAX_ATTEMPTS - 1,
+      },
+    ]);
+    const res = await runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: async () => {
+        throw new Error("chat not found");
+      },
+      log: () => {},
+    });
+    expect(res.retained).toBe(0);
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+});
+
+describe("#3634: in-process orphan retry", () => {
+  it("clears the leaked pin at the next reconcile in that chat", async () => {
+    const chat = fakeChat();
+    chat.pin(715);
+    const cleared: string[] = [];
+    const reg = createOrphanPinRegistry({
+      unpin: chat.unpin,
+      clearRow: (k) => cleared.push(k),
+      log: () => {},
+    });
+    reg.register("-100123", 715);
+    reg.register("-100123", 715); // idempotent
+    expect(reg.size()).toBe(1);
+
+    await reg.drain("-100123");
+
+    expect(chat.pinned.size).toBe(0);
+    expect(reg.size()).toBe(0);
+    expect(cleared).toEqual([orphanPinKey("-100123", 715)]);
+  });
+
+  it("only drains the chat it was asked for", async () => {
+    const chat = fakeChat();
+    const reg = createOrphanPinRegistry({
+      unpin: chat.unpin,
+      clearRow: () => {},
+      log: () => {},
+    });
+    reg.register("-100123", 1);
+    reg.register("-100999", 2);
+    await reg.drain("-100123");
+    expect(chat.unpinCalls).toEqual([1]);
+    expect(reg.size()).toBe(1);
+  });
+
+  it("keeps retrying a transient failure, then forfeits in-process to the durable row", async () => {
+    let fail = true;
+    const seen: number[] = [];
+    const cleared: string[] = [];
+    const reg = createOrphanPinRegistry({
+      unpin: async (_c, m) => {
+        seen.push(m);
+        if (fail) throw new Error("FLOOD_WAIT_ACTIVE");
+        return {};
+      },
+      clearRow: (k) => cleared.push(k),
+      log: () => {},
+    });
+    reg.register("-100123", 715);
+
+    await reg.drain("-100123");
+    expect(reg.size()).toBe(1); // retained for the next turn
+    fail = false;
+    await reg.drain("-100123");
+    expect(reg.size()).toBe(0);
+    expect(seen).toEqual([715, 715]);
+    expect(cleared).toEqual([orphanPinKey("-100123", 715)]);
+
+    // …and a permanently failing one is bounded.
+    const reg2 = createOrphanPinRegistry({
+      unpin: async () => {
+        throw new Error("nope");
+      },
+      clearRow: () => {},
+      log: () => {},
+    });
+    reg2.register("-100123", 9);
+    for (let i = 0; i < ORPHAN_PIN_MAX_ATTEMPTS; i++) await reg2.drain("-100123");
+    expect(reg2.size()).toBe(0);
+  });
+
+  it("does not stack concurrent drains of the same chat", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const reg = createOrphanPinRegistry({
+      unpin: async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight--;
+        return {};
+      },
+      clearRow: () => {},
+      log: () => {},
+    });
+    reg.register("-100123", 1);
+    reg.register("-100123", 2);
+    await Promise.all([reg.drain("-100123"), reg.drain("-100123")]);
+    expect(maxInFlight).toBe(1);
+    expect(reg.size()).toBe(0);
+  });
+});

--- a/telegram-plugin/tests/status-pin-orphan-lifecycle.test.ts
+++ b/telegram-plugin/tests/status-pin-orphan-lifecycle.test.ts
@@ -37,6 +37,7 @@ import {
 import {
   createOrphanPinRegistry,
   ORPHAN_PIN_MAX_ATTEMPTS,
+  MAX_TRACKED_ORPHANS,
 } from "../gateway/status-pin-orphans.js";
 import {
   createStatusPinApi,
@@ -585,5 +586,60 @@ describe("#3634: a shed send never looks like a painted pin", () => {
     // is the ambiguity SEND_GATE_SHED exists to remove.
     const api = createStatusPinApi(bot, async () => undefined);
     await expect(api.unpinChatMessage("-100123", 715)).resolves.toBeUndefined();
+  });
+});
+
+describe("#3634: the retry never tears down a live pin", () => {
+  it("discards an orphan whose message has been pinned again", async () => {
+    // The group worker card is ONE long-lived message pinned/unpinned across
+    // turns: a flood-failed turn-end unpin can be followed by a re-pin of that
+    // same id. Retrying blind would unpin the card the user is watching.
+    const chat = fakeChat();
+    const cleared: string[] = [];
+    const live = new Set<number>();
+    const reg = createOrphanPinRegistry({
+      unpin: chat.unpin,
+      clearRow: (k) => cleared.push(k),
+      isLive: (_c, id) => live.has(id),
+      log: () => {},
+    });
+    reg.register("-100123", 715);
+
+    // A new turn re-pins 715 and the gateway now holds a live claim on it.
+    chat.pin(715);
+    live.add(715);
+    await reg.drain("-100123");
+
+    // OUTCOME: the card is STILL PINNED, and the stale orphan is gone.
+    expect(chat.pinned.has(715)).toBe(true);
+    expect(chat.unpinCalls).toEqual([]);
+    expect(reg.size()).toBe(0);
+    expect(cleared).toEqual([orphanPinKey("-100123", 715)]);
+  });
+
+  it("still unpins an orphan that is not live", async () => {
+    const chat = fakeChat();
+    chat.pin(715);
+    const reg = createOrphanPinRegistry({
+      unpin: chat.unpin,
+      clearRow: () => {},
+      isLive: () => false,
+      log: () => {},
+    });
+    reg.register("-100123", 715);
+    await reg.drain("-100123");
+    expect(chat.pinned.size).toBe(0);
+  });
+
+  it("caps the tracked set so a failure run cannot grow it without bound", () => {
+    const reg = createOrphanPinRegistry({
+      unpin: async () => {
+        throw new Error("nope");
+      },
+      clearRow: () => {},
+      log: () => {},
+    });
+    for (let i = 0; i < MAX_TRACKED_ORPHANS + 25; i++) reg.register("-100123", i);
+    expect(reg.size()).toBe(MAX_TRACKED_ORPHANS);
   });
 });

--- a/telegram-plugin/tests/status-pin-orphan-lifecycle.test.ts
+++ b/telegram-plugin/tests/status-pin-orphan-lifecycle.test.ts
@@ -38,6 +38,11 @@ import {
   createOrphanPinRegistry,
   ORPHAN_PIN_MAX_ATTEMPTS,
 } from "../gateway/status-pin-orphans.js";
+import {
+  createStatusPinApi,
+  type PinCapableBot,
+} from "../gateway/status-pin-api.js";
+import { SEND_GATE_SHED } from "../send-gate.js";
 
 const PATH = "/state/agent/telegram/status-pins.json";
 
@@ -150,7 +155,7 @@ describe("#3634 D1: the boot pin sweep must not run before the bot exists", () =
       botReady: g.gate.ready,
       scanDmChatIds: () => {
         order.push("scan");
-        return ["8248703757"];
+        return ["12345"];
       },
       statusPinCleanup: async () => {
         order.push("status-pins");
@@ -178,7 +183,7 @@ describe("#3634 D1: the boot pin sweep must not run before the bot exists", () =
       "activity-cards",
       "queued-cards",
       "enable-dm",
-      "dm:8248703757",
+      "dm:12345",
     ]);
   });
 
@@ -517,5 +522,68 @@ describe("#3634: in-process orphan retry", () => {
     await Promise.all([reg.drain("-100123"), reg.drain("-100123")]);
     expect(maxInFlight).toBe(1);
     expect(reg.size()).toBe(0);
+  });
+});
+
+describe("#3634: a shed send never looks like a painted pin", () => {
+  // The bug shape review caught on #3631: a dropped call resolving
+  // success-shaped, so the state machine records a never-painted change as
+  // on-screen. `reconcilePin` reads "did not throw" as "landed", so the pin API
+  // must convert the send gate's SEND_GATE_SHED sentinel into a throw.
+  const shedRobust = async () => SEND_GATE_SHED as unknown;
+  const bot = () =>
+    ({
+      api: {
+        pinChatMessage: async () => true,
+        unpinChatMessage: async () => true,
+      },
+    }) as PinCapableBot;
+
+  it("a shed unpin is reported as failed and re-homed, not swallowed", async () => {
+    const api = createStatusPinApi(bot, shedRobust);
+    const outcomes: Array<[string, number]> = [];
+    const next = await reconcilePin({
+      api,
+      chatId: "-100123",
+      prevState: { messageId: 715 },
+      desired: { pinned: false },
+      onError: () => {},
+      onUnpinOutcome: (o, id) => outcomes.push([o, id]),
+    });
+    expect(next).toBeNull();
+    // NOT ['ok', 715] — the message is still pinned in Telegram.
+    expect(outcomes).toEqual([["failed", 715]]);
+  });
+
+  it("a shed pin does not claim the message", async () => {
+    const api = createStatusPinApi(bot, shedRobust);
+    const next = await reconcilePin({
+      api,
+      chatId: "-100123",
+      prevState: null,
+      desired: { pinned: true, messageId: 715 },
+      onError: () => {},
+    });
+    // Claiming it would leave the gateway believing a pin exists that never
+    // painted — and it would never retry.
+    expect(next).toBeNull();
+  });
+
+  it("a landed call is passed through untouched", async () => {
+    const seen: unknown[] = [];
+    const api = createStatusPinApi(bot, async (fn) => {
+      const r = await fn();
+      seen.push(r);
+      return r;
+    });
+    await expect(api.unpinChatMessage("-100123", 715)).resolves.toBe(true);
+    expect(seen).toEqual([true]);
+  });
+
+  it("does NOT treat a benign undefined as a shed", async () => {
+    // The gate resolves `undefined` for a no-op drop; conflating it with a shed
+    // is the ambiguity SEND_GATE_SHED exists to remove.
+    const api = createStatusPinApi(bot, async () => undefined);
+    await expect(api.unpinChatMessage("-100123", 715)).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

"The progress card stays pinned after the turn completes." Two independent defects, both proven in production logs across six agents. The unpin logic itself is fine — the *funnel* is correct and comprehensive (`purgeReactionTracking` is reached on every terminal path, with the pre-restart sweep and boot reapers behind it). What was broken is everything that was supposed to catch an unpin that **didn't land**.

### D1 — the boot orphan-pin sweep has never worked

`runBootPinCleanupAndDmSweep()` is fired from the startup-mutex block at **module-eval time**. `lockedBot` is only assigned inside `initGatewayBot()` — thousands of lines and one `await` later. Every unpin the sweep issued dereferenced an unset binding and threw:

```
status-pin-store: boot cleanup unpin failed (chat=8248703757 msg=21450 attempt=1):
  undefined is not an object (evaluating 'lockedBot.api')
```

Present in `carrie`, `clerk`, `finn`, `gymbro`, `klanker` and `overlord` gateway logs, including repeat `attempt=2` lines for the same message id. The row is retained, the next boot fails identically, and after `BOOT_UNPIN_MAX_ATTEMPTS` boots the orphan is **forfeited** — a permanently pinned, finished activity card. `let lockedBot!: Bot<Context>` carries a definite-assignment assertion, so `tsc` never saw it.

The same latent hazard applied to `activityCardBootReaper`, `queuedCardBootReaper` and the DM sweep, which all sit behind the same call.

**Fix:** `telegram-plugin/gateway/boot-pin-sweep.ts` owns the ordering contract in one testable place — the pure-fs store scan runs immediately; **every API-issuing step awaits a `gatewayBotReady` latch** resolved right after `lockedBot` is assigned. Steps are individually absorbed, so a throwing reaper no longer strands the ones behind it. `status-pin-api.ts` adds a named `STATUS_PIN_BOT_NOT_READY` error as the backstop, so a future pre-ready caller is diagnosable on sight instead of looking like a Telegram failure.

### D2 — a runtime unpin that fails is forgotten

`reconcilePin`'s drop-on-unpin contract clears the claim even when `unpinChatMessage` throws — correct and unchanged; pin state must never wedge. But `reconcileAndPersistStatusPin` deleted the **durable row** on the same `next == null` signal. So a `FLOOD_WAIT_ACTIVE` unpin left the message pinned in Telegram with nothing on disk naming it — boot cleanup could never see it even once D1 was fixed.

Observed: `finn` 2026-07-15T22:59:07 and `overlord` 2026-07-25T23:58:40 (`status-pin unpin failed (key=wk:group:… ): FLOOD_WAIT_ACTIVE`, 15 minutes into the flood ban from #3628/#3631).

Same shed-honesty shape as the drain fix in #3628: a call that did not land must not be recorded as done.

**Fix:** `reconcilePin` reports the unpin outcome (`ok` / `failed` / `skipped-no-rights`). A non-`ok` outcome:
- re-homes the record under `orphanPinKey(chatId, messageId)` — a distinct, chat+message-scoped key, so the live `fg:`/`wk:` row is still released immediately for a fresh claim, and the orphan row is work-scoped (no `expiresAt`) so the existing boot retry/forfeit ladder picks it up;
- registers it with an in-process, **timer-free** retry (`status-pin-orphans.ts`) drained at the next reconcile in that chat — so a long-lived gateway heals without waiting for a restart.

## Why

A pin that outlives its turn is a leak, and the deterministic mechanism the repo already had for it (persist the pinned message id, reconcile at boot) was unreachable. Fixing it by adding unpin calls to more exit paths would have been the "63 of 70 call sites forgot" pattern again; the guarantee is now enforced by ordering + a durable record, not by remembering to call something.

Job: `reference/jobs/know-what-my-agent-is-doing.md` (the sanctioned silent status pin) and `reference/jobs/survive-reboots-and-real-life.md` (restart = reset for work-scoped state).

## Test plan

`telegram-plugin/tests/status-pin-orphan-lifecycle.test.ts` — 15 tests, all asserting the **outcome** ("is anything still pinned in the chat?") against a fake chat that tracks real pin state, not that some function was called.

Each fails on the bug, verified by reverting the fix in place:
- removing the ready gate (`botReady: Promise.resolve()`) → *"clears an orphaned pin from a prior session"* fails;
- removing the orphan re-homing → *"re-homes a failed unpin as a durable orphan row"* and *"a flood-wait'd turn-end unpin is finished by the next boot's sweep"* both fail.

Covered: gate ordering + step sequence + step isolation; all three unpin outcomes from the driver; orphan row written on failure and **not** invented on success; the cross-restart path; orphan rows are work-scoped and are forfeited rather than retried forever; in-process retry incl. chat scoping, bounded attempts and no concurrent stacking.

Also updated `activity-card-wiring.test.ts` for the extraction (intent preserved: the reaper is still reachable only from the mutex-gated orchestrator, never at import).

Local: `npm run lint` clean (incl. the gateway line ratchet), `npx vitest run telegram-plugin` → **501 files / 8218 tests passed**.

## Risk

Low–moderate, in a hot area.

- The sweep now runs *later* in boot (after `initGatewayBot`) instead of never. That is the intended change; it is still gated behind the startup mutex, so a losing double-boot still cannot touch the shared store.
- `gateway.ts` is under a line ratchet, so the activity-card boot reaper's seam binding moved verbatim to `activity-card-boot-reaper-wiring.ts`. Behaviour unchanged.
- Orphan rows are additive and use a distinct key prefix; older gateways would simply unpin them as ordinary work-scoped rows.
- The in-process retry issues at most one extra `unpinChatMessage` per leaked pin per reconcile, bounded at 5 attempts, and rides the same send gate + flood fuse as every other call — it cannot amplify into the ceiling those exist to protect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
