### PR TITLE
test(hindsight): make a silent revert of the perturbed-JSON-retry patch fail CI

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -110,6 +110,7 @@ jobs:
               - 'docker/Dockerfile.hindsight'
               - 'tests/docker/hindsight-search-patches.test.ts'
               - 'tests/docker/hindsight-recall-isolation-patches.test.ts'
+              - 'tests/docker/hindsight-retry-perturbation-patches.test.ts'
               - 'tests/docker/dockerfile-hindsight-bakes.test.ts'
               - '.github/workflows/docker-e2e.yml'
 
@@ -307,10 +308,21 @@ jobs:
           SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
         run: npx vitest run tests/docker/hindsight-recall-isolation-patches.test.ts
 
+      - name: Run the hindsight retry-perturbation probe (RED/GREEN, must not skip)
+        # Same contract again, for the perturbed-JSON-retry patch (#3669).
+        # This is the layer the bakes test structurally CANNOT provide:
+        # its assertions are unanchored substring matches, so indenting the
+        # perturbation under a falsy guard leaves all 24 of them green while
+        # the behaviour is gone (measured 2026-07-26 — bakes 24/24 pass,
+        # this probe goes red on TEMPERATURES/DISTINCT_RETRY_REQUESTS).
+        env:
+          SWITCHROOM_REQUIRE_HINDSIGHT_PROBE: "1"
+        run: npx vitest run tests/docker/hindsight-retry-perturbation-patches.test.ts
+
       - name: Label-scoped teardown
         if: always()
         run: |
-          for phase in hindsight-search-patches hindsight-recall-isolation-patches; do
+          for phase in hindsight-search-patches hindsight-recall-isolation-patches hindsight-retry-perturbation-patches; do
             ids=$(docker ps -aq --filter "label=switchroom.test=$phase" 2>/dev/null || true)
             if [ -n "$ids" ]; then docker rm -f $ids 2>/dev/null || true; fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 ## Unreleased
 
+### A runtime probe for the perturbed-JSON-retry patch, so a silent revert fails CI
+
+#3669 shipped the perturbed-JSON-retry patch with two of the three layers the
+#3660 review established for a build-time source patch: a build-level assert
+and a `dockerfile-hindsight-bakes.test.ts` mention. The missing layer was the
+one that checks BEHAVIOUR, and it is the layer that matters — the bakes
+assertions are unanchored substring matches, so they cannot distinguish
+"this code runs" from "this code is present".
+
+Measured on 2026-07-26, indenting the whole perturbation body under a falsy
+`if os.environ.get(...)` guard (`os` is already imported at
+`litellm_llm.py:18`, so the revert raises nothing) left every asserted literal
+in the file and **all 24 bakes tests passed** while the fix was inert.
+
+`tests/docker/hindsight-retry-perturbation-patches.test.ts` closes that. It
+extracts the real `RUN python3` heredoc from the Dockerfile, applies it to the
+digest-pinned upstream image, and drives `LiteLLMLLM.call()` against a body
+that never parses — asserting the retry is a DIFFERENT request each time:
+
+- RED (unpatched): `EXTRA_BODY [null, null, null, null]`, `TEMPERATURES
+  [0.1, 0.1, 0.1, 0.1]`, `DISTINCT_RETRY_REQUESTS 1 of 4`.
+- GREEN (patched): `TEMPERATURES [0.1, 0.4, 0.7, 0.7]`,
+  `DISTINCT_RETRY_REQUESTS 3 of 4`.
+
+The revert above turns it red. It runs in the `hindsight-probe` job under
+`SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1` (an unavailable docker/image is a hard
+failure, never a skip), and the file is in the `hindsight` paths filter so a
+change to the probe alone still runs it.
+
+### The permanence gate, asserted over the real client wrapping
+
+`pending.is_permanent_failure` decides whether a failed retain is retired to
+`.dead`, and its input is produced by `lib/client.py:91-97` — which catches
+only `HTTPError` and re-raises it as `RuntimeError("HTTP {code} from …")`,
+letting a bare `URLError` through untouched. Every existing permanence test
+injected a synthetic exception at `drain_pending._retry_one`, i.e. ABOVE that
+wrapping, so the shape the gate actually receives in production was asserted
+nowhere.
+
+`TransportFailureEndToEndTest` patches `urllib.request.urlopen` instead and
+drives the real drain: an outage (`URLError`) and a rate limit (`429`) past
+`MAX_ATTEMPTS` keep the memory queued, and a `400` rejection still retires it
+— the second half being what stops "never retire" from trading a data-loss
+bug for an unbounded queue.
+
+#3669 added an equivalent outage case, but to `vendor/hindsight-memory/tests/`,
+which no workflow discovers (`ci-tests-python.yml` runs `unittest discover
+tests/` from `vendor/hindsight-memory/scripts`) — so it never ran. The new
+tests live in the discovered suite and were mutation-checked: dropping the
+gate fails 2 of 3, dropping `429` from `_RETRYABLE_4XX` fails 1, and making
+`is_permanent_failure` always-false fails 1.
+
+Also corrects two comments on the #3669 patch: the class is `LiteLLMLLM`
+(`litellm_llm.py:50`), not `LiteLLMProvider`; and the 0.7 cap's rationale
+cited `call()`'s `max_retries=10` signature default (`litellm_llm.py:223`)
+while the retain path passes `max_retries=llm_max_retries`
+(`fact_extraction.py:1327`, `DEFAULT_LLM_MAX_RETRIES = 3` at `config.py:730`)
+— 4 attempts, contradicting the same comment's own measurement. The cap is
+unchanged and still right; the reason now states both budgets.
+
 ### context7 as a fleet-default MCP — server AND the prompt trigger that makes it get used
 
 Adds Upstash's **context7** (live library/framework documentation lookup) as a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -2161,10 +2161,11 @@ print(
 PYEOF
 
 # Perturbed JSON retry: upstream's `except json.JSONDecodeError` handler in
-# `LiteLLMProvider.call()` sleeps and then re-issues the SAME `call_kwargs` —
-# a byte-identical request. Behind a caching LiteLLM proxy that is not a retry
-# at all: the proxy replays the identical unparseable body from its response
-# cache, so all N attempts consume one bad completion and the retain fails.
+# `LiteLLMLLM.call()` (litellm_llm.py:50, :216) sleeps and then re-issues the
+# SAME `call_kwargs` — a byte-identical request. Behind a caching LiteLLM
+# proxy that is not a retry at all: the proxy replays the identical
+# unparseable body from its response cache, so all N attempts consume one bad
+# completion and the retain fails.
 #
 # Measured on this host 2026-07-26 (fleet backlog drain), against the proxy at
 # 127.0.0.1:4010 with a fresh random marker in the prompt:
@@ -2188,16 +2189,25 @@ PYEOF
 #  2. A capped temperature bump — only when the caller already set a
 #     temperature (so models that reject the parameter are untouched). Retain
 #     extraction runs at 0.1, i.e. near-greedy, so an uncached resample would
-#     otherwise reproduce the same malformed output. The cap is 0.7, not 1.0:
-#     `call()` takes max_retries=10 by default, so a +0.3 ramp would sit at
-#     1.0 for most attempts, and the requested json_schema is advisory rather
-#     than enforced (one measured bad body was prose emitted WITH a schema
-#     set). Ramping to 1.0 would make the late attempts the likeliest to
-#     produce invalid JSON — backwards for a retry.
+#     otherwise reproduce the same malformed output. The cap is 0.7, not 1.0,
+#     because the requested json_schema is advisory rather than enforced (one
+#     measured bad body was prose emitted WITH a schema set), so 1.0 makes
+#     malformed JSON MORE likely — and an uncapped +0.3 ramp always lands on
+#     1.0 at its LAST attempts, i.e. it makes a retry's final chances its
+#     worst ones. That holds at either retry budget: the retain path runs 4
+#     attempts (fact_extraction.py:1327 passes max_retries=llm_max_retries,
+#     config.py:730 DEFAULT_LLM_MAX_RETRIES=3), where uncapped would ramp
+#     0.1/0.4/0.7/1.0 and end at 1.0; a caller that takes the
+#     `call()` signature default of max_retries=10 (litellm_llm.py:223) would
+#     ramp to 1.0 by attempt 4 and spend the remaining seven there.
 # Both apply only on the retry path; the first attempt is byte-for-byte the
 # request upstream would have sent, so cache hit-rate for healthy calls is
-# unchanged. Self-verifying; guarded by
-# tests/docker/dockerfile-hindsight-bakes.test.ts.
+# unchanged. Self-verifying, and guarded on two layers, because the structural
+# one alone is not enough: tests/docker/dockerfile-hindsight-bakes.test.ts
+# matches literals (it stays green if this body is indented under a falsy
+# guard — measured), and
+# tests/docker/hindsight-retry-perturbation-patches.test.ts applies this block
+# to the pinned image and asserts the retry is a DIFFERENT request each time.
 RUN python3 - <<'PYEOF'
 import pathlib
 
@@ -2227,9 +2237,11 @@ REPL = (
     '                    call_kwargs["extra_body"] = _extra\n'
     "                    # Only nudge a temperature the caller actually set, so\n"
     "                    # models that reject the parameter keep their kwargs clean.\n"
-    "                    # Capped at 0.7, NOT 1.0: `call()` defaults to\n"
-    "                    # max_retries=10, so an uncapped +0.3 ramp from 0.1 hits\n"
-    "                    # 1.0 by attempt 4 and spends the remaining seven there.\n"
+    "                    # Capped at 0.7, NOT 1.0: an uncapped +0.3 ramp from\n"
+    "                    # 0.1 always ENDS on 1.0 — the retain path runs 4\n"
+    "                    # attempts (0.1/0.4/0.7/1.0), and a caller taking the\n"
+    "                    # max_retries=10 signature default hits 1.0 by attempt\n"
+    "                    # 4 and spends the remaining seven there.\n"
     "                    # The json_schema response_format is advisory, not\n"
     "                    # enforced — one of the two measured bad bodies was a\n"
     "                    # numbered prose list emitted WHILE a schema was set — so\n"

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -631,6 +631,14 @@ describe("Dockerfile.hindsight shape", () => {
     // response id on the repeat, vs 37.66s and a new id once the cache was
     // bypassed). That is how a transient bad completion burned all attempts
     // and failed a retain — which in turn aged a queued memory toward .dead.
+    //
+    // SCOPE: this test is structural, not behavioural. Every assertion below
+    // is an unanchored substring match, so it proves the patch is PRESENT,
+    // never that it RUNS — indenting the perturbation body under a falsy
+    // guard keeps all of them green (measured 2026-07-26). The behavioural
+    // gate is tests/docker/hindsight-retry-perturbation-patches.test.ts,
+    // which applies this block to the pinned image and asserts the retry is
+    // actually a different request. Do not treat this file as sufficient.
 
     // The exact-once anchor guard (fail-loud on upstream drift).
     expect(dockerfile).toMatch(
@@ -646,12 +654,14 @@ describe("Dockerfile.hindsight shape", () => {
     expect(dockerfile).toMatch(
       /if call_kwargs\.get\("temperature"\) is not None:/,
     );
-    // And it is capped at 0.7, not 1.0. `call()` defaults to max_retries=10,
-    // so a +0.3 ramp from 0.1 saturates by attempt 4 and spends the rest at
-    // the cap. The json_schema response_format is advisory (one of the two
-    // measured bad bodies was prose emitted while a schema was set), so a cap
-    // of 1.0 would make the LATE attempts the likeliest to emit invalid JSON
-    // — a retry strategy that degrades as it goes.
+    // And it is capped at 0.7, not 1.0. The json_schema response_format is
+    // advisory (one of the two measured bad bodies was prose emitted while a
+    // schema was set), so a cap of 1.0 would make the LATE attempts the
+    // likeliest to emit invalid JSON — a retry strategy that degrades as it
+    // goes. An uncapped +0.3 ramp from 0.1 always ENDS on 1.0: the retain
+    // path runs 4 attempts (0.1/0.4/0.7/1.0 — fact_extraction.py passes
+    // max_retries=llm_max_retries, DEFAULT_LLM_MAX_RETRIES=3), and a caller
+    // taking `call()`'s own max_retries=10 default saturates by attempt 4.
     expect(dockerfile).toMatch(
       /0\.7, float\(call_kwargs\["temperature"\]\) \+ 0\.3/,
     );

--- a/tests/docker/hindsight-retry-perturbation-patches.test.ts
+++ b/tests/docker/hindsight-retry-perturbation-patches.test.ts
@@ -11,16 +11,23 @@
  * Dockerfile behaviour change whose revert nothing caught; the remedy that
  * landed was a THREE-layer gate (a build-time assert, a runtime probe, and a
  * bakes-test mention). #3669 shipped layers 1 and 3 only, and the hole is
- * demonstrable: inserting one inert line ahead of the perturbation —
+ * demonstrable: indent the whole perturbation body under a falsy guard —
  *
  *     if os.environ.get("HINDSIGHT_PERTURB"):
- *         pass
- *     _extra = dict(call_kwargs.get("extra_body") or {})
+ *         _extra = dict(call_kwargs.get("extra_body") or {})
+ *         ...
+ *         call_kwargs["extra_body"] = _extra
  *
- * — leaves every literal the bakes test greps for present, still parses under
- * the patch's own `ast.parse`, still satisfies its post-replace text asserts,
- * and reverts the fix. That mutation was measured green on all 24 bakes cases.
+ * — and the fix is inert while every literal the bakes test greps for is still
+ * present. `os` is already imported (`litellm_llm.py:18`), so nothing raises;
+ * the block still parses under the patch's own `ast.parse` and still satisfies
+ * its post-replace text asserts, because those assert on COUNTS of substrings,
+ * not on column. Measured 2026-07-26: all 24 bakes cases green, fix disabled.
  * Only running the patched module catches it, which is what this file does.
+ *
+ * (The weaker mutation of merely INSERTING `if ...: pass` above the body is a
+ * no-op — the perturbation still executes at its original indentation — so it
+ * proves nothing. The indent is what makes it a genuine revert.)
  *
  * THE DEFECT, in the real shipping source. `LiteLLMLLM.call()`
  * (`/app/api/hindsight_api/engine/providers/litellm_llm.py:216`) builds

--- a/tests/docker/hindsight-retry-perturbation-patches.test.ts
+++ b/tests/docker/hindsight-retry-perturbation-patches.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Behavioural proof for the perturbed-JSON-retry patch `docker/Dockerfile.hindsight`
+ * bakes into the pinned upstream Hindsight image (#3669).
+ *
+ * `dockerfile-hindsight-bakes.test.ts` pins the *shape* of that patch block
+ * (grep-on-file, runs everywhere). This file proves the *outcome*: it runs the
+ * same probe against unpatched upstream (must be RED) and against upstream +
+ * the patch block applied (must be GREEN).
+ *
+ * WHY THE SHAPE TEST IS NOT ENOUGH — the gap this file closes. #3660 shipped a
+ * Dockerfile behaviour change whose revert nothing caught; the remedy that
+ * landed was a THREE-layer gate (a build-time assert, a runtime probe, and a
+ * bakes-test mention). #3669 shipped layers 1 and 3 only, and the hole is
+ * demonstrable: inserting one inert line ahead of the perturbation —
+ *
+ *     if os.environ.get("HINDSIGHT_PERTURB"):
+ *         pass
+ *     _extra = dict(call_kwargs.get("extra_body") or {})
+ *
+ * — leaves every literal the bakes test greps for present, still parses under
+ * the patch's own `ast.parse`, still satisfies its post-replace text asserts,
+ * and reverts the fix. That mutation was measured green on all 24 bakes cases.
+ * Only running the patched module catches it, which is what this file does.
+ *
+ * THE DEFECT, in the real shipping source. `LiteLLMLLM.call()`
+ * (`/app/api/hindsight_api/engine/providers/litellm_llm.py:216`) builds
+ * `call_kwargs` ONCE, above the retry loop, and its
+ * `except json.JSONDecodeError` handler sleeps and re-issues that same dict
+ * unchanged. Behind a caching LiteLLM proxy that is not a retry: the proxy
+ * replays the identical unparseable body, so every attempt consumes one bad
+ * completion and the retain fails. Measured on this host 2026-07-26 against the
+ * proxy at 127.0.0.1:4010 — cold 41.29s id=chatcmpl-112, identical repeat 0.02s
+ * id=chatcmpl-112 (a cache replay), `extra_body` no-cache 37.66s id=chatcmpl-101
+ * (genuinely bypassed).
+ *
+ * The four properties this probe drives, none of which the patch TEXT can show:
+ *
+ *  1. Attempt 1 is byte-for-byte what upstream would have sent — no
+ *     `extra_body`, the caller's temperature untouched. That is what keeps the
+ *     healthy-call cache hit-rate unchanged, and it is the property most easily
+ *     lost by "simplifying" the patch to set the kwargs before the loop.
+ *  2. Every RETRY carries `extra_body={"cache": {"no-cache": True}}`, so the
+ *     proxy is actually bypassed. It must travel in `extra_body`: litellm's
+ *     top-level `cache=` kwarg is consumed by the SDK and never reaches the
+ *     wire (measured, same run).
+ *  3. The temperature ramp is +0.3 CAPPED AT 0.7, and the cap binds. The
+ *     requested json_schema is advisory rather than enforced (one of the two
+ *     measured bad bodies was a numbered prose list emitted WHILE a schema was
+ *     set), so a ramp to 1.0 would make the late attempts the likeliest to emit
+ *     invalid JSON — backwards for a retry.
+ *  4. A caller that set NO temperature never acquires one, so models that
+ *     reject the parameter keep clean kwargs.
+ *
+ * The probe drives the REAL `LiteLLMLLM.call()` from the image — only
+ * `_acompletion` is stubbed, because the point is to observe the kwargs the
+ * loop hands it on each attempt — rather than re-implementing the loop here.
+ * `max_retries=3` is not arbitrary: it is what the retain path actually passes
+ * (`engine/retain/fact_extraction.py:1327` forwards `llm_max_retries`, whose
+ * default is `config.py:730 DEFAULT_LLM_MAX_RETRIES = 3`), and `temperature=0.1`
+ * is `DEFAULT_LLM_TEMPERATURE_RETAIN` (`config.py:184`).
+ *
+ * The patch block is extracted from the Dockerfile itself rather than
+ * duplicated here, so this test cannot drift from what actually ships. It
+ * applies it by `docker exec` (not `docker build`) so it runs on daemons
+ * without buildx, and it never touches the production `switchroom-hindsight`
+ * container.
+ *
+ * SKIP DISCIPLINE: identical to `hindsight-recall-isolation-patches.test.ts`.
+ * Locally, with no docker or no cached image, this skips (never pull a 6.4GB
+ * third-party image onto a dev box). In CI the `hindsight-probe` job pulls the
+ * pinned digest and sets SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1, under which an
+ * unavailable docker/image is a HARD FAILURE, never a green skip. Both runs
+ * assert a `PROBE_EXECUTED` sentinel so a probe that dies early can never be
+ * mistaken for a pass.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(
+  resolve(root, "docker/Dockerfile.hindsight"),
+  "utf8",
+);
+
+const RUN_ID = randomUUID();
+const TEST_PHASE = "hindsight-retry-perturbation-patches";
+
+/** The pinned upstream image, read from the Dockerfile so it can never drift. */
+const UPSTREAM_IMAGE = (() => {
+  const m = dockerfile.match(/^FROM\s+(\S+)/m);
+  if (!m) throw new Error("Dockerfile.hindsight has no FROM line");
+  return m[1];
+})();
+
+/** The patch this file proves, named by its unique in-block marker. */
+const PATCH_NAME = "perturbed-JSON-retry patch";
+
+/**
+ * The patch block under test, pulled out of the Dockerfile's
+ * `RUN python3 - <<'PYEOF' ... PYEOF` heredocs by its unique patch name.
+ */
+function patchBlocks(): string[] {
+  const blocks = [
+    ...dockerfile.matchAll(/^RUN python3 - <<'PYEOF'\n([\s\S]*?)^PYEOF$/gm),
+  ].map((m) => m[1]);
+  const hits = blocks.filter((b) => b.includes(PATCH_NAME));
+  if (hits.length !== 1) {
+    throw new Error(
+      `Dockerfile.hindsight contains ${hits.length} "${PATCH_NAME}" RUN blocks ` +
+        `(expected exactly 1) — if the patch was deliberately removed, delete ` +
+        `this test with it.`,
+    );
+  }
+  return hits;
+}
+
+/**
+ * Python probe. Exits 0 only when all four properties above hold; prints the
+ * offending assertions otherwise.
+ *
+ * Deliberately asserts OUTCOMES: it runs the real retry loop to exhaustion and
+ * records the exact kwargs dict handed to the completion call on every attempt.
+ * Nothing here greps the patched source.
+ */
+const PROBE = String.raw`
+import asyncio
+import json
+import sys
+
+failures = []
+
+
+def fail(msg):
+    failures.append(msg)
+
+
+from hindsight_api.engine.providers.litellm_llm import LiteLLMLLM
+
+
+# ── the smallest response object call() actually reads ────────────────────
+class _Msg:
+    def __init__(self, content):
+        self.content = content
+
+
+class _Choice:
+    def __init__(self, content):
+        self.message = _Msg(content)
+        self.finish_reason = "stop"
+
+
+class _Resp:
+    def __init__(self, content):
+        self.choices = [_Choice(content)]
+        self.usage = None
+        self.model = "probe-model"
+
+
+class _Schema:
+    """A response_format stand-in: call() only needs the schema + a name."""
+
+    __name__ = "ProbeSchema"
+
+    @staticmethod
+    def model_json_schema():
+        return {"type": "object", "properties": {"facts": {"type": "array"}}}
+
+
+def _make():
+    """A real LiteLLMLLM with only the completion call stubbed.
+
+    __init__ wants a live config, so the instance is built directly and given
+    exactly the attributes _build_common_kwargs / call() read. Everything that
+    decides the retry behaviour is the shipping code.
+    """
+    llm = object.__new__(LiteLLMLLM)
+    llm.model = "openai/probe"
+    llm.timeout = 30
+    llm.api_key = "probe-key"
+    llm.base_url = "http://127.0.0.1:4010"
+    llm._extra_body = {}
+    llm._default_headers = {}
+    llm.bedrock_service_tier = None
+    llm.provider = "litellm"
+
+    seen = []
+
+    async def _acompletion(**kwargs):
+        # Snapshot, not alias: call() MUTATES call_kwargs in place between
+        # attempts, so keeping the reference would make every entry equal.
+        seen.append(json.loads(json.dumps(kwargs, default=str)))
+        # Never parseable, so every attempt takes the JSONDecodeError path.
+        return _Resp("1. not json at all")
+
+    llm._acompletion = _acompletion
+    llm._resolve_completion_model = lambda response: "probe-model"
+    return llm, seen
+
+
+async def _drive(temperature, max_retries=3):
+    llm, seen = _make()
+    try:
+        await llm.call(
+            messages=[{"role": "user", "content": "probe"}],
+            response_format=_Schema,
+            temperature=temperature,
+            scope="retain_extract_facts",
+            max_retries=max_retries,
+            # Zero backoff: this probe measures kwargs, not sleeping.
+            initial_backoff=0.0,
+            max_backoff=0.0,
+            skip_validation=True,
+        )
+    except json.JSONDecodeError:
+        pass  # expected — the loop exhausts and re-raises
+    except Exception as e:
+        fail("unexpected exception from call(): " + type(e).__name__ + ": " + str(e))
+    return seen
+
+
+NO_CACHE = {"cache": {"no-cache": True}}
+
+# ── the retain shape: max_retries=3, temperature=0.1 ──────────────────────
+seen = asyncio.run(_drive(0.1))
+print("ATTEMPTS", len(seen))
+if len(seen) != 4:
+    fail("expected 4 attempts (max_retries=3), got " + str(len(seen)))
+
+extras = [k.get("extra_body") for k in seen]
+temps = [k.get("temperature") for k in seen]
+print("EXTRA_BODY", json.dumps(extras, sort_keys=True))
+print("TEMPERATURES", json.dumps(temps))
+
+# 1. attempt 1 is byte-for-byte upstream's request
+if extras[:1] != [None]:
+    fail("attempt 1 carried extra_body " + repr(extras[0]) + " — it must be untouched")
+if temps[:1] != [0.1]:
+    fail("attempt 1 temperature was " + repr(temps[0]) + ", expected the caller's 0.1")
+
+# 2. every RETRY bypasses the proxy response cache
+retry_extras = extras[1:]
+if not retry_extras:
+    fail("no retry was issued at all")
+elif any(e != NO_CACHE for e in retry_extras):
+    fail(
+        "a retry replayed an un-perturbed request: extra_body="
+        + json.dumps(retry_extras, sort_keys=True)
+    )
+    print("CACHE_REPLAYED_IDENTICAL_REQUEST True")
+
+# 3. the ramp is +0.3 capped at 0.7, and the cap BINDS on this path
+if temps != [0.1, 0.4, 0.7, 0.7]:
+    fail("temperature ramp was " + json.dumps(temps) + ", expected [0.1, 0.4, 0.7, 0.7]")
+if any(t is not None and t > 0.7 for t in temps):
+    fail("temperature exceeded the 0.7 cap: " + json.dumps(temps))
+
+# 4. a caller that set no temperature never acquires one
+seen_none = asyncio.run(_drive(None))
+temps_none = ["<absent>" if "temperature" not in k else k["temperature"] for k in seen_none]
+extras_none = [k.get("extra_body") for k in seen_none]
+print("TEMPERATURES_UNSET", json.dumps(temps_none))
+print("EXTRA_BODY_UNSET", json.dumps(extras_none, sort_keys=True))
+if any(t != "<absent>" for t in temps_none):
+    fail("a caller that set no temperature acquired one: " + json.dumps(temps_none))
+# …but it still gets the load-bearing perturbation.
+if extras_none[1:] and any(e != NO_CACHE for e in extras_none[1:]):
+    fail(
+        "the cache bypass was skipped when no temperature was set: "
+        + json.dumps(extras_none, sort_keys=True)
+    )
+
+# The whole point, stated as one line the RED run also emits.
+print(
+    "DISTINCT_RETRY_REQUESTS",
+    len({json.dumps(k, sort_keys=True) for k in seen}),
+    "of",
+    len(seen),
+)
+
+print("FAILURES", failures)
+print("PROBE_EXECUTED")
+sys.exit(1 if failures else 0)
+`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * CI marker. When set, this suite MUST really execute — an absent docker or
+ * an absent upstream image becomes a hard failure instead of a green skip.
+ * `.github/workflows/docker-e2e.yml` sets it after pulling the pinned digest.
+ */
+const REQUIRED = process.env.SWITCHROOM_REQUIRE_HINDSIGHT_PROBE === "1";
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(UPSTREAM_IMAGE);
+
+type ProbeResult = { status: number; stdout: string };
+
+/** Run the probe in a throwaway container, optionally patching first. */
+function runProbe(patched: boolean): ProbeResult {
+  const name = `sr-hs-retry-${patched ? "patched" : "upstream"}-${RUN_ID.slice(
+    0,
+    8,
+  )}`;
+  try {
+    execFileSync(
+      "docker",
+      [
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        `switchroom.test=${TEST_PHASE}`,
+        "--label",
+        `switchroom.test.run=${RUN_ID}`,
+        "--user",
+        "root",
+        "--network",
+        "none",
+        UPSTREAM_IMAGE,
+        "sleep",
+        "300",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+
+    if (patched) {
+      for (const block of patchBlocks()) {
+        // The block is self-verifying: it asserts its upstream anchor exists
+        // exactly once and re-asserts the result, so a non-zero exit here means
+        // upstream drifted and the patch must be re-authored.
+        execFileSync("docker", ["exec", "-i", name, "python3", "-"], {
+          input: block,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      }
+    }
+
+    const res = execFileSync(
+      "docker",
+      ["exec", "-i", "-w", "/app/api", name, "/app/api/.venv/bin/python", "-"],
+      { input: PROBE, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+    );
+    return { status: 0, stdout: res };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? -1,
+      stdout: (err.stdout ?? "").toString(),
+    };
+  } finally {
+    try {
+      execFileSync("docker", ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe("Dockerfile.hindsight retry-perturbation probe is real, not a silent skip", () => {
+  it("pins the upstream image by digest so the probe tests the exact shipping bytes", () => {
+    expect(UPSTREAM_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("extracts exactly the one patch block it claims to prove", () => {
+    expect(patchBlocks()).toHaveLength(1);
+  });
+
+  it("hard-fails rather than skipping when CI demands a real run", () => {
+    if (!REQUIRED) {
+      // Local/dev path: skipping is legitimate (never pull a 6.4GB image onto
+      // a dev box), but it must be visible rather than silent.
+      expect(
+        REQUIRED,
+        "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE is unset — the behavioural probe " +
+          "is advisory here. CI's hindsight-probe job sets it after pulling " +
+          `${UPSTREAM_IMAGE}.`,
+      ).toBe(false);
+      return;
+    }
+    expect(
+      dockerOk,
+      "SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but the docker daemon is unreachable",
+    ).toBe(true);
+    expect(
+      imageOk,
+      `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1 but ${UPSTREAM_IMAGE} is not present ` +
+        "locally — the workflow must pull the pinned digest before running this suite",
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "Dockerfile.hindsight perturbed-JSON-retry patch changes real behaviour",
+  () => {
+    afterAll(() => {
+      // Label-scoped teardown belt (never an unlabelled bulk removal).
+      try {
+        const ids = execSync(
+          `docker ps -aq --filter label=switchroom.test.run=${RUN_ID}`,
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .filter(Boolean);
+        if (ids.length) {
+          execFileSync("docker", ["rm", "-f", ...ids], { stdio: "ignore" });
+        }
+      } catch {
+        /* nothing to clean */
+      }
+    });
+
+    it("unpatched upstream is RED — all four attempts are the identical request", () => {
+      const { status, stdout } = runProbe(false);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe unexpectedly passed:\n${stdout}`).not.toBe(0);
+
+      // The defect, driven: the retry loop hands the completion call the very
+      // same dict every time, so behind a caching proxy all four attempts
+      // consume one cached bad completion.
+      expect(stdout).toContain("ATTEMPTS 4");
+      expect(stdout).toContain("EXTRA_BODY [null, null, null, null]");
+      expect(stdout).toContain("TEMPERATURES [0.1, 0.1, 0.1, 0.1]");
+      expect(stdout).toContain("DISTINCT_RETRY_REQUESTS 1 of 4");
+      expect(stdout).toContain("CACHE_REPLAYED_IDENTICAL_REQUEST True");
+    }, 240_000);
+
+    it("upstream + the baked patch block is GREEN on all four properties", () => {
+      const { status, stdout } = runProbe(true);
+      expect(stdout, "probe did not run to completion").toContain(
+        "PROBE_EXECUTED",
+      );
+      expect(status, `probe failed:\n${stdout}`).toBe(0);
+      expect(stdout).toContain("FAILURES []");
+
+      // 1. attempt 1 is untouched (healthy-call cache hit-rate preserved) and
+      // 2. every retry carries the proxy cache bypass, in `extra_body`.
+      expect(stdout).toContain(
+        'EXTRA_BODY [null, {"cache": {"no-cache": true}}, ' +
+          '{"cache": {"no-cache": true}}, {"cache": {"no-cache": true}}]',
+      );
+      // 3. +0.3 per retry, capped at 0.7 — and on the retain path (max_retries=3,
+      // temperature=0.1) the cap BINDS, so a regression to a 1.0 cap changes
+      // this line rather than being invisible.
+      expect(stdout).toContain("TEMPERATURES [0.1, 0.4, 0.7, 0.7]");
+      // 4. a caller that set no temperature still gets the load-bearing
+      // perturbation but never acquires a temperature.
+      expect(stdout).toContain(
+        'TEMPERATURES_UNSET ["<absent>", "<absent>", "<absent>", "<absent>"]',
+      );
+      expect(stdout).toContain(
+        'EXTRA_BODY_UNSET [null, {"cache": {"no-cache": true}}, ' +
+          '{"cache": {"no-cache": true}}, {"cache": {"no-cache": true}}]',
+      );
+      // The headline: the retries are genuinely different requests now.
+      expect(stdout).toContain("DISTINCT_RETRY_REQUESTS 3 of 4");
+      expect(stdout).not.toContain("CACHE_REPLAYED_IDENTICAL_REQUEST");
+    }, 240_000);
+  },
+);

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -26,6 +26,8 @@ import tempfile
 import time
 import unittest
 import unittest.mock
+import urllib.error
+import urllib.request
 from contextlib import redirect_stderr
 
 SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -1147,6 +1149,96 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
                 )
         self.assertEqual(summary["reconciled"], 3)
         self.assertEqual(pending.count(), 3, "a dry run must not delete anything")
+
+
+class TransportFailureEndToEndTest(_QueueTempDirMixin, unittest.TestCase):
+    """The permanence gate over the REAL client wrapping (#3669 follow-up).
+
+    Every other permanence test injects a synthetic exception at
+    ``drain_pending._retry_one`` — i.e. ABOVE ``lib/client.py``. That skips
+    the layer which actually decides what a fault LOOKS like to
+    ``pending.is_permanent_failure``: ``client._request`` catches only
+    ``HTTPError`` and re-raises it as ``RuntimeError("HTTP {code} from …")``
+    (lib/client.py:91-97), while a bare ``URLError`` propagates untouched.
+    So the gate's input shape is produced there and asserted nowhere.
+
+    These tests patch ``urllib.request.urlopen`` instead and drive the real
+    drain, keeping that wrapping in the loop. #3669 added an equivalent
+    end-to-end case, but to ``vendor/hindsight-memory/tests/`` — which no
+    workflow discovers (ci-tests-python.yml runs ``unittest discover
+    tests/`` from ``vendor/hindsight-memory/scripts``), so it never ran.
+    """
+
+    def _queue_one(self):
+        pending.enqueue(_payload(content="turn-0", doc=_cd_doc(0)), RuntimeError("boom"))
+        self.assertEqual(pending.count(), 1)
+
+    def _exhaust_attempts(self):
+        """One entry sitting on the MAX_ATTEMPTS boundary."""
+        self._queue_one()
+        path, entry = pending.iter_entries()[0]
+        entry["attempt_count"] = pending.MAX_ATTEMPTS
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(entry, f)
+        return path
+
+    @staticmethod
+    def _http_error(code):
+        def raise_it(*_a, **_kw):
+            raise urllib.error.HTTPError(
+                "http://127.0.0.1:9/none/v1/retain",
+                code,
+                "rejected",
+                {},
+                io.BytesIO(b'{"detail":"rejected"}'),
+            )
+
+        return raise_it
+
+    def _drain_with_urlopen(self, side_effect):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=side_effect):
+            with redirect_stderr(io.StringIO()):
+                return drain_pending.drain_backlog(CONFIG, phase="drain")
+
+    def test_outage_past_max_attempts_keeps_the_memory(self):
+        """A dead daemon raises bare ``URLError`` — no ``.code``, so transient.
+
+        Before the gate this retired the entry at MAX_ATTEMPTS: an outage
+        destroyed memory that was perfectly saveable.
+        """
+        path = self._exhaust_attempts()
+
+        def down(*_a, **_kw):
+            raise urllib.error.URLError("still down")
+
+        summary = self._drain_with_urlopen(down)
+        self.assertEqual(summary["dead"], 0, "an outage must never retire a memory")
+        self.assertTrue(os.path.exists(path), "the queued memory survives")
+        self.assertFalse(os.path.exists(path + ".dead"))
+
+    def test_rate_limit_past_max_attempts_keeps_the_memory(self):
+        """429 wears a 4xx code but is the most transient fault there is.
+
+        This is the case the raw ``400 <= code < 500`` rule would get
+        wrong, asserted through the real ``HTTP {code} from …`` wrapping.
+        """
+        path = self._exhaust_attempts()
+        summary = self._drain_with_urlopen(self._http_error(429))
+        self.assertEqual(summary["dead"], 0, "a rate limit must never retire a memory")
+        self.assertTrue(os.path.exists(path))
+        self.assertFalse(os.path.exists(path + ".dead"))
+
+    def test_server_rejection_past_max_attempts_still_retires(self):
+        """The other half of the gate: a fix that never retires is a leak.
+
+        A positively-rejected payload must still age to ``.dead``, or the
+        queue grows without bound.
+        """
+        path = self._exhaust_attempts()
+        summary = self._drain_with_urlopen(self._http_error(400))
+        self.assertEqual(summary["dead"], 1, "a 4xx rejection must still retire")
+        self.assertTrue(os.path.exists(path + ".dead"))
+        self.assertFalse(os.path.exists(path))
 
 
 class ArchiveFailureNeverDeletesTest(_QueueTempDirMixin, unittest.TestCase):


### PR DESCRIPTION
Follow-up to #3669 (merged as `15dd7b4c2`), from an adversarial review of that PR.

The review's central question was the #3660 one: **if someone silently reverted the behavioural change, would anything fail?** For the Dockerfile patch, the answer was no.

## The gap, measured

#3669 shipped two of the three layers #3660 established for a build-time source patch — a build-level assert and a bakes-test mention — but not the behavioural probe.

That matters because every bakes assertion is an unanchored substring match. Indenting the whole perturbation body under a falsy `if os.environ.get(...)` guard (`os` is already imported at `litellm_llm.py:18`, so the revert raises nothing) leaves every asserted literal in the file:

| | bakes test | new probe |
|---|---|---|
| patch intact | 24/24 pass | 5/5 pass |
| patch silently reverted | **24/24 still pass** | **RED** |

## What this adds

**`tests/docker/hindsight-retry-perturbation-patches.test.ts`** — extracts the real `RUN python3` heredoc from the Dockerfile, applies it to the digest-pinned upstream image, and drives `LiteLLMLLM.call()` against a body that never parses, snapshotting kwargs per attempt:

- RED (unpatched): `EXTRA_BODY [null, null, null, null]`, `TEMPERATURES [0.1, 0.1, 0.1, 0.1]`, `DISTINCT_RETRY_REQUESTS 1 of 4`
- GREEN (patched): `TEMPERATURES [0.1, 0.4, 0.7, 0.7]`, `DISTINCT_RETRY_REQUESTS 3 of 4`

Runs in the `hindsight-probe` job under `SWITCHROOM_REQUIRE_HINDSIGHT_PROBE=1` (unavailable docker/image is a hard failure, never a skip), added to the `hindsight` paths filter and the label-scoped teardown loop.

**`TransportFailureEndToEndTest`** — the permanence gate over the real client wrapping. `is_permanent_failure`'s input is produced by `lib/client.py:91-97` (catches only `HTTPError`, re-raises as `RuntimeError("HTTP {code} from …")`; a bare `URLError` passes through untouched), but every existing test injected a synthetic exception at `drain_pending._retry_one` — *above* that wrapping. These patch `urllib.request.urlopen` and drive the real drain:

- outage (`URLError`) past `MAX_ATTEMPTS` → stays queued
- rate limit (`429`) past `MAX_ATTEMPTS` → stays queued
- rejection (`400`) past `MAX_ATTEMPTS` → **still retires**, so "never retire" doesn't trade a data-loss bug for an unbounded queue

Mutation-checked: dropping the gate fails 2 of 3, dropping `429` from `_RETRYABLE_4XX` fails 1, making `is_permanent_failure` always-false fails 1.

#3669 added an equivalent outage case, but to `vendor/hindsight-memory/tests/` — which no workflow discovers (`ci-tests-python.yml` runs `unittest discover tests/` from `vendor/hindsight-memory/scripts`), so it never ran. That directory also has 4 pre-existing `ModuleNotFoundError`s, untouched here. The new tests live in the discovered suite.

## Comment corrections on the #3669 patch

- The class is `LiteLLMLLM` (`litellm_llm.py:50`), not `LiteLLMProvider`.
- The 0.7-cap rationale cited `call()`'s `max_retries=10` signature default (`litellm_llm.py:223`), but the retain path passes `max_retries=llm_max_retries` (`fact_extraction.py:1327`, `DEFAULT_LLM_MAX_RETRIES = 3` at `config.py:730`) — 4 attempts, which contradicts the same comment's own "burned its 4 attempts" measurement. **The cap is unchanged and still correct**; the reason now states both budgets and leads with the argument that holds for either.
- Both the Dockerfile and the bakes test now say in-line that the structural test is not the behavioural gate.

## Verification

- `dockerfile-hindsight-bakes.test.ts` — 24/24
- `hindsight-retry-perturbation-patches.test.ts` — 5/5 (RED + GREEN against the pinned image)
- `unittest discover tests/` from `vendor/hindsight-memory/scripts` — **657 OK** (654 before, +3)
- `npm run lint` — clean

No source behaviour changes: the only non-test, non-comment edits are the CI workflow wiring.

Checked and found *not* to overlap #3678 (reflect/refresh foreground admission) — that path is `memory_engine.py` / `engine/reflect/tools.py`, untouched here.