### PR TITLE
ci: run the required checks on merge_group so the queue can drain

### DIFF
--- a/.github/MERGE-QUEUE.md
+++ b/.github/MERGE-QUEUE.md
@@ -1,0 +1,138 @@
+# Merge queue — how CI reports on `gh-readonly-queue/...` refs
+
+Ruleset **16470166** (`main branch protection`) enables a GitHub merge
+queue with `merge_method: SQUASH`, `grouping_strategy: ALLGREEN`,
+`max_entries_to_build: 5` and `check_response_timeout_minutes: 60`. Its
+required status checks are exactly:
+
+| context | workflow | job |
+|---|---|---|
+| `lint` | `ci-lint.yml` | `lint` |
+| `vitest` | `ci-tests-core.yml` | `vitest` |
+| `bun-test` | `ci-tests-plugin.yml` | `bun-test` |
+| `python-ok` | `ci-tests-python.yml` | `python-ok` |
+| `uat-gate` | `ci-uat.yml` | `uat-gate` |
+| `e2e-ok` | `docker-e2e.yml` | `e2e-ok` |
+| `images-ok` | `docker-images.yml` | `images-ok` |
+
+When a PR is enqueued, GitHub pushes a temporary
+`refs/heads/gh-readonly-queue/main/pr-<n>-<sha>` branch and emits a
+**`merge_group`** event. It then waits for those seven contexts to report
+**on that ref**. A workflow that only triggers on `pull_request` + `push`
+never runs there, so the contexts are never produced and the entry sits in
+`AWAITING_CHECKS` until the 60-minute timeout **ejects** it.
+
+Every workflow producing a required context therefore carries a
+`merge_group:` trigger. `tests/ci-merge-queue-triggers.test.ts` enforces
+this and the invariants below — none of which are observable on a PR.
+
+## The three rules
+
+### 1. A required check must never come back `skipped`
+
+A skipped required check is **not** success to the merge queue (same
+hard-block behaviour as classic branch protection — #1343, #2237). Every
+one of the seven is an `if: always()` sentinel for that reason, so the
+context is always *produced*; the risk is the sentinel becoming a rubber
+stamp that reports success having run nothing.
+
+So on `merge_group` the real work jobs are force-run rather than
+path-gated. **There is no path filtering on a queue ref**, deliberately:
+
+- A queue ref has no PR base. The only defensible base is
+  `github.event.merge_group.base_sha`, which needs a deepened fetch and
+  gives `dorny/paths-filter` a new way to *fail* — and a failed `changes`
+  job hard-fails the sentinel by design, recreating the exact outage this
+  file exists to prevent.
+- With `ALLGREEN` + `max_entries_to_merge: 5`, one queue ref can carry
+  several PRs. "Changed paths" is a fuzzier question for a batch than for
+  a PR.
+- The repo's existing policy for `push: main` is already "always run,
+  don't gamble on main". A queue ref **is** candidate main.
+
+Mechanically: the `changes` job still runs (so it reports `success`, which
+the sentinels require) but its checkout + filter steps are `if:`-skipped,
+and each work job's gate gained `|| github.event_name == 'merge_group'`.
+
+Two deliberate exceptions, neither of which lowers the bar:
+
+- **`ci-uat.yml`'s `uat-gate-run`** — already skipped on every PR and main
+  push (`UAT_GATE_ENABLED` has been `false` since 2026-07-04), so the
+  queue gets the identical `uat-gate` verdict a PR gets. Running it would
+  burn live subscription quota on the single `uat-host` self-hosted runner
+  per queue entry, and a busy/unregistered runner would stall the entry
+  until the 60-min timeout ejected it.
+- **`docker-images.yml`'s `build-hindsight` / `build-voice`** — the 6.4GB
+  hindsight pull and the CUDA voice build are the heaviest in the repo.
+  The hindsight image's behavioural gate (`hindsight-probe` in
+  `docker-e2e.yml`) *does* run on `merge_group`, and both images are still
+  built and published by the push to main immediately after the merge.
+
+### 2. A `merge_group` run must never be cancelled
+
+`cancel-in-progress` is disabled for `merge_group` in all seven
+workflows. Two reasons:
+
+- A cancelled required context is not success — the queue ejects the entry.
+- Cancelling a workflow whose sentinel is `if: always()` is the **#3614**
+  orphan-wedge shape: the sentinel can survive the cancel stuck in
+  `queued`, never reaching a terminal state, pinning the concurrency group
+  and starving the ref. On a queue ref that would burn the whole 60-minute
+  window with no self-service recovery.
+
+The group **key** needed no change: every one of the seven already keys on
+`github.ref`, which on a `merge_group` run is the queue's own
+`refs/heads/gh-readonly-queue/...` branch — never the PR's
+`refs/pull/<n>/merge` and never `refs/heads/main`. The queue's checks
+therefore cannot collide with, or be cancelled by, the PR's own run.
+
+### 3. A `merge_group` run must never publish
+
+`docker-images.yml` spelled "is this a publishing event?" as
+`github.event_name != 'pull_request'`, which is **true** on `merge_group`.
+Left alone, a queue run would have logged in to GHCR, pushed images,
+written registry build cache, and moved `:latest` / `:sha-<short>` from a
+ref that had not been merged.
+
+`merge_group` is therefore a **validation** event here, exactly like
+`pull_request`: build only, `push: false`, no `cache-to`, no GHCR login,
+amd64 only. Publication stays on the real push to `main`. The
+`merge-base` / `merge-dependents` manifest jobs are excluded outright.
+
+Image tags also can't reuse the PR shape: `github.event.pull_request.number`
+is **empty** on `merge_group`, so `${IMAGE}:pr-${{ ... }}` would render
+the invalid reference `${IMAGE}:pr-` and fail the build — the same class
+of bug as the #2816 non-main-dispatch follow-up. Queue builds tag
+`${IMAGE}:mq-<sha7>` instead.
+
+## Things that are NOT `merge_group`-triggered, on purpose
+
+- **`ci-infra-watchdog.yml`** is the only `workflow_run`-triggered
+  workflow in the repo. It produces no required context, and it is gated
+  on `workflow_run.event == 'push'` on `main` — it alerts on *post-merge*
+  red. A queue-ref failure is pre-merge and is reported by the queue
+  itself. **No required check is `workflow_run`-downstream**: each of the
+  seven is produced directly by a job in its own workflow on the
+  triggering event.
+- `ci-evals.yml`, `ci-full.yml`, `ci-tests-race-long.yml`,
+  `ci-claude-latest-canary.yml`, `npm-publish.yml`, `promote.yml` produce
+  no required context.
+
+## Diagnosing a stuck queue
+
+```bash
+# Is anything listening for merge_group at all?
+gh run list --event merge_group --limit 10
+
+# Queue state for a PR
+gh api graphql -f query='
+  { repository(owner:"switchroom", name:"switchroom") {
+      pullRequest(number: NNNN) {
+        isInMergeQueue
+        mergeQueueEntry { state position enqueuedAt }
+      } } }'
+```
+
+`state: AWAITING_CHECKS` with **zero** `merge_group` runs ever recorded is
+the signature of this bug: GitHub is dispatching the event and nothing is
+listening.

--- a/.github/MERGE-QUEUE.md
+++ b/.github/MERGE-QUEUE.md
@@ -1,9 +1,19 @@
 # Merge queue — how CI reports on `gh-readonly-queue/...` refs
 
-Ruleset **16470166** (`main branch protection`) enables a GitHub merge
-queue with `merge_method: SQUASH`, `grouping_strategy: ALLGREEN`,
-`max_entries_to_build: 5` and `check_response_timeout_minutes: 60`. Its
-required status checks are exactly:
+> **Current state (verified 2026-07-26 13:20 AEST):** the merge queue is
+> **OFF**. Ruleset **16470166** (`main branch protection`) carries only
+> `deletion`, `non_fast_forward` and `required_status_checks` — there is
+> no `merge_queue` rule, and `repository.mergeQueue(branch:"main")` is
+> `null`. It was enabled earlier that day, wedged `main` for the reason
+> below, and was switched back off to unblock merging. **This document
+> and the `merge_group:` triggers it describes are the prerequisite for
+> turning it back on safely** — they are inert while it is off, and they
+> are what stops the outage recurring when it is turned on.
+
+Ruleset **16470166** (`main branch protection`) requires exactly these
+status checks (verified live against the ruleset — if this table and the
+ruleset ever disagree, the ruleset wins and
+`tests/ci-merge-queue-triggers.test.ts` must be updated to match):
 
 | context | workflow | job |
 |---|---|---|
@@ -20,7 +30,8 @@ When a PR is enqueued, GitHub pushes a temporary
 **`merge_group`** event. It then waits for those seven contexts to report
 **on that ref**. A workflow that only triggers on `pull_request` + `push`
 never runs there, so the contexts are never produced and the entry sits in
-`AWAITING_CHECKS` until the 60-minute timeout **ejects** it.
+`AWAITING_CHECKS` until `check_response_timeout_minutes` **ejects** it
+(60 minutes as the queue was configured on 2026-07-26).
 
 Every workflow producing a required context therefore carries a
 `merge_group:` trigger. `tests/ci-merge-queue-triggers.test.ts` enforces
@@ -44,9 +55,9 @@ path-gated. **There is no path filtering on a queue ref**, deliberately:
   gives `dorny/paths-filter` a new way to *fail* — and a failed `changes`
   job hard-fails the sentinel by design, recreating the exact outage this
   file exists to prevent.
-- With `ALLGREEN` + `max_entries_to_merge: 5`, one queue ref can carry
-  several PRs. "Changed paths" is a fuzzier question for a batch than for
-  a PR.
+- Under the `ALLGREEN` grouping strategy a single queue ref can carry
+  several PRs at once. "Which paths changed" is a fuzzier question for a
+  batch than it is for one PR.
 - The repo's existing policy for `push: main` is already "always run,
   don't gamble on main". A queue ref **is** candidate main.
 
@@ -59,9 +70,9 @@ Two deliberate exceptions, neither of which lowers the bar:
 - **`ci-uat.yml`'s `uat-gate-run`** — the only required-context ancestor
   bound to `[self-hosted, uat-host]`, a single machine. A queue entry has
   no "it'll pick up in a minute": a busy or unregistered runner stalls the
-  entry until the 60-min timeout ejects it, taking the train with it, and
-  each entry would burn live subscription quota on a real Telegram
-  round-trip. Independently of that policy call, its gate reads
+  entry until the check-response timeout ejects it, taking the train with
+  it, and each entry would burn live subscription quota on a real
+  Telegram round-trip. Independently of that policy call, its gate reads
   `needs.changes.outputs.relevant`, which is **empty** on a queue ref, so
   it skips on its own merits no matter how `UAT_GATE_ENABLED` is set —
   don't rest this exception on the variable's current value.
@@ -84,8 +95,8 @@ workflows. Two reasons:
 - Cancelling a workflow whose sentinel is `if: always()` is the **#3614**
   orphan-wedge shape: the sentinel can survive the cancel stuck in
   `queued`, never reaching a terminal state, pinning the concurrency group
-  and starving the ref. On a queue ref that would burn the whole 60-minute
-  window with no self-service recovery.
+  and starving the ref. On a queue ref that would burn the entire
+  check-response window with no self-service recovery.
 
 The group **key** needed no change: every one of the seven already keys on
 `github.ref`, which on a `merge_group` run is the queue's own
@@ -122,12 +133,25 @@ of bug as the #2816 non-main-dispatch follow-up. Queue builds tag
   seven is produced directly by a job in its own workflow on the
   triggering event.
 - `ci-evals.yml`, `ci-full.yml`, `ci-tests-race-long.yml`,
-  `ci-claude-latest-canary.yml`, `npm-publish.yml`, `promote.yml` produce
-  no required context.
+  `ci-claude-latest-canary.yml`, `npm-publish.yml`, `promote.yml` and
+  `release.yml` produce no required context. That is the complete
+  remainder: the seven workflows above plus these seven are all 14.
 
 ## Diagnosing a stuck queue
 
 ```bash
+# Is the queue even enabled? null == off (it is off as of 2026-07-26).
+gh api graphql -f query='
+  { repository(owner:"switchroom", name:"switchroom") {
+      mergeQueue(branch:"main") { id configuration {
+        mergeMethod mergingStrategy checkResponseTimeout
+      } } } }'
+
+# Do the ruleset's required contexts still match MERGE-QUEUE.md + the test?
+gh api repos/switchroom/switchroom/rulesets/16470166 \
+  --jq '.rules[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks[].context'
+
 # Is anything listening for merge_group at all?
 gh run list --event merge_group --limit 10
 

--- a/.github/MERGE-QUEUE.md
+++ b/.github/MERGE-QUEUE.md
@@ -56,12 +56,19 @@ and each work job's gate gained `|| github.event_name == 'merge_group'`.
 
 Two deliberate exceptions, neither of which lowers the bar:
 
-- **`ci-uat.yml`'s `uat-gate-run`** — already skipped on every PR and main
-  push (`UAT_GATE_ENABLED` has been `false` since 2026-07-04), so the
-  queue gets the identical `uat-gate` verdict a PR gets. Running it would
-  burn live subscription quota on the single `uat-host` self-hosted runner
-  per queue entry, and a busy/unregistered runner would stall the entry
-  until the 60-min timeout ejected it.
+- **`ci-uat.yml`'s `uat-gate-run`** — the only required-context ancestor
+  bound to `[self-hosted, uat-host]`, a single machine. A queue entry has
+  no "it'll pick up in a minute": a busy or unregistered runner stalls the
+  entry until the 60-min timeout ejects it, taking the train with it, and
+  each entry would burn live subscription quota on a real Telegram
+  round-trip. Independently of that policy call, its gate reads
+  `needs.changes.outputs.relevant`, which is **empty** on a queue ref, so
+  it skips on its own merits no matter how `UAT_GATE_ENABLED` is set —
+  don't rest this exception on the variable's current value.
+  (Corroborating but contingent: `UAT_GATE_ENABLED` has been `false`
+  since 2026-07-04, so the job is already skipped on every PR and main
+  push, and the queue therefore gets the identical `uat-gate` verdict a
+  PR gets.)
 - **`docker-images.yml`'s `build-hindsight` / `build-voice`** — the 6.4GB
   hindsight pull and the CUDA voice build are the heaviest in the repo.
   The hindsight image's behavioural gate (`hindsight-probe` in

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,6 +17,13 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Merge queue. GitHub pushes a temporary `gh-readonly-queue/main/...`
+  # ref and waits for the ruleset's required contexts to report ON THAT
+  # REF via `merge_group`. Without this trigger the workflow never runs
+  # there, `lint` is never produced, and the entry sits in
+  # AWAITING_CHECKS until `check_response_timeout_minutes` ejects it.
+  # See .github/MERGE-QUEUE.md.
+  merge_group:
   # Manual recovery lever. GHA marks a run failed (no auto-retry) when
   # its jobs sit queued past the hosted-runner scheduling window during
   # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
@@ -29,8 +36,17 @@ permissions:
   contents: read
 
 concurrency:
+  # `github.ref` on a merge_group run is the queue's own
+  # `refs/heads/gh-readonly-queue/main/pr-<n>-<sha>` — distinct from the
+  # PR's `refs/pull/<n>/merge` and from `refs/heads/main`, so the queue
+  # run can never share a group with (and be cancelled by) the PR run.
   group: ci-lint-${{ github.ref }}
-  cancel-in-progress: true
+  # NEVER cancel a merge-queue check. A cancelled required context is
+  # not success — the queue would eject the entry — and cancelling an
+  # `if: always()` sentinel mid-flight is the exact #3614 orphan-wedge
+  # shape, which on a queue ref would pin the group for the whole
+  # 60-min timeout window.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   changes:
@@ -39,9 +55,16 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.lint }}
     steps:
+      # merge_group: NO path filtering — see .github/MERGE-QUEUE.md.
+      # The job itself still runs (so it reports `success`, not
+      # `skipped`, to the sentinel); only the diff is skipped, because a
+      # queue ref has no PR base to diff against and a dorny failure
+      # here would hard-fail the sentinel and block the queue.
       - name: Checkout
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Filter changed paths
+        if: github.event_name != 'merge_group'
         id: filter
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         with:
@@ -54,8 +77,11 @@ jobs:
   lint-run:
     needs: changes
     # Push to main: always run (don't gamble on main).
+    # merge_group: always run — the queue ref IS candidate main, and a
+    #   path-skipped job would leave the required `lint` context resting
+    #   on nothing.
     # PR: gate on changed paths.
-    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ci-tests-core.yml
+++ b/.github/workflows/ci-tests-core.yml
@@ -34,6 +34,9 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Merge queue — required contexts must report on the temporary
+  # `gh-readonly-queue/main/...` ref. See .github/MERGE-QUEUE.md.
+  merge_group:
   # Manual recovery lever. GHA marks a run failed (no auto-retry) when
   # its jobs sit queued past the hosted-runner scheduling window during
   # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
@@ -46,8 +49,11 @@ permissions:
   contents: read
 
 concurrency:
+  # Queue refs get their own group for free — `github.ref` is the
+  # `gh-readonly-queue/...` branch, never the PR's `refs/pull/<n>/merge`.
   group: ci-tests-core-${{ github.ref }}
-  cancel-in-progress: true
+  # NEVER cancel a merge-queue check (ejects the entry; #3614 wedge shape).
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   # ─── Path-change filter (sentinel pattern) ────────────────────────
@@ -64,9 +70,14 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.core }}
     steps:
+      # merge_group: no diff base exists on a queue ref, so skip the
+      # filter (the job still reports `success`) and run everything.
+      # See .github/MERGE-QUEUE.md.
       - name: Checkout
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Filter changed paths
+        if: github.event_name != 'merge_group'
         id: filter
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         with:
@@ -79,7 +90,8 @@ jobs:
   # ─── Build dist/ once, share with all shards ──────────────────────
   build-dist:
     needs: changes
-    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+    # push / merge_group: always run — both are (candidate) main.
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -108,7 +120,8 @@ jobs:
   # contexts `vitest (1..4)` (those blocked docs-only PRs, #1343).
   vitest-shard:
     needs: [changes, build-dist]
-    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+    # push / merge_group: always run — both are (candidate) main.
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -167,8 +180,16 @@ jobs:
             --changed origin/${{ github.base_ref }} \
             --passWithNoTests
 
-      - name: Vitest shard ${{ matrix.shard }}/4 (push to main — full suite)
-        if: github.event_name == 'push'
+      # CRITICAL: this arm must cover EVERY non-pull_request event that
+      # reaches this job, or the job runs zero tests and still reports
+      # success — a silent false green under the required `vitest`
+      # context. `merge_group` is here for exactly that reason: the
+      # `--changed` arm above is `pull_request`-only (it needs
+      # `github.base_ref`, which a queue ref does not have), so without
+      # this the queue would "pass" vitest without executing a test.
+      # Guarded by tests/ci-merge-queue-triggers.test.ts.
+      - name: Vitest shard ${{ matrix.shard }}/4 (push to main / merge queue — full suite)
+        if: github.event_name == 'push' || github.event_name == 'merge_group'
         run: bunx vitest run --shard ${{ matrix.shard }}/4
 
       - name: Upload coverage (if produced)

--- a/.github/workflows/ci-tests-plugin.yml
+++ b/.github/workflows/ci-tests-plugin.yml
@@ -18,6 +18,9 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Merge queue — required contexts must report on the temporary
+  # `gh-readonly-queue/main/...` ref. See .github/MERGE-QUEUE.md.
+  merge_group:
   # Manual recovery lever. GHA marks a run failed (no auto-retry) when
   # its jobs sit queued past the hosted-runner scheduling window during
   # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
@@ -30,8 +33,11 @@ permissions:
   contents: read
 
 concurrency:
+  # Queue refs get their own group for free — `github.ref` is the
+  # `gh-readonly-queue/...` branch, never the PR's `refs/pull/<n>/merge`.
   group: ci-tests-plugin-${{ github.ref }}
-  cancel-in-progress: true
+  # NEVER cancel a merge-queue check (ejects the entry; #3614 wedge shape).
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   changes:
@@ -40,9 +46,14 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.plugin }}
     steps:
+      # merge_group: no diff base exists on a queue ref, so skip the
+      # filter (the job still reports `success`) and run everything.
+      # See .github/MERGE-QUEUE.md.
       - name: Checkout
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Filter changed paths
+        if: github.event_name != 'merge_group'
         id: filter
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         with:
@@ -54,7 +65,8 @@ jobs:
 
   bun-test-run:
     needs: changes
-    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+    # push / merge_group: always run — both are (candidate) main.
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     # Was 8 (single attempt). The hang-watchdog wrapper (scripts/bun-test-ci.sh)
     # retries a wedged run up to BUN_TEST_MAX_ATTEMPTS times; a healthy run is

--- a/.github/workflows/ci-tests-python.yml
+++ b/.github/workflows/ci-tests-python.yml
@@ -15,6 +15,9 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Merge queue — required contexts must report on the temporary
+  # `gh-readonly-queue/main/...` ref. See .github/MERGE-QUEUE.md.
+  merge_group:
   # Manual recovery lever. GHA marks a run failed (no auto-retry) when
   # its jobs sit queued past the hosted-runner scheduling window during
   # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
@@ -27,8 +30,13 @@ permissions:
   contents: read
 
 concurrency:
+  # Queue refs get their own group for free — `github.ref` is the
+  # `gh-readonly-queue/...` branch, never the PR's `refs/pull/<n>/merge`.
   group: ci-tests-python-${{ github.ref }}
-  cancel-in-progress: true
+  # NEVER cancel a merge-queue check: a cancelled required context ejects
+  # the entry, and cancelling this workflow's `if: always()` sentinel is
+  # the #3614 orphan-wedge shape (first observed in THIS workflow).
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   changes:
@@ -37,9 +45,14 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
+      # merge_group: no diff base exists on a queue ref, so skip the
+      # filter (the job still reports `success`) and run everything.
+      # See .github/MERGE-QUEUE.md.
       - name: Checkout
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Filter changed paths
+        if: github.event_name != 'merge_group'
         id: filter
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         with:
@@ -52,7 +65,8 @@ jobs:
 
   unittest:
     needs: changes
-    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+    # push / merge_group: always run — both are (candidate) main.
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -54,6 +54,13 @@ on:
       - "telegram-plugin/uat/**"
       - "vitest.uat.config.ts"
       - ".github/workflows/ci-uat.yml"
+  # Merge queue — the required `uat-gate` SENTINEL must report on the
+  # temporary `gh-readonly-queue/main/...` ref or the entry is ejected.
+  # No paths filter, for the same reason the PR trigger has none: the
+  # sentinel must ALWAYS be produced. The HEAVY, runner-bound
+  # `uat-gate-run` stays gated and is NOT expected to run here — see the
+  # note on that job. See .github/MERGE-QUEUE.md.
+  merge_group:
   # No `schedule:` — the nightly fuzz cron was removed (2026-06-09): each fuzz
   # scenario is a real claude turn on the subscription, and an automatic nightly
   # pass burns quota that competes with the live fleet. The thorough fuzz pool is
@@ -66,7 +73,10 @@ permissions:
 # Sequential — Telegram's per-bot rate limits are global; two parallel
 # UAT runs interleave inbounds on the same chat. NOT cancel-in-progress
 # (a fresh push must let the running job complete to release the
-# test-harness singleton cleanly).
+# test-harness singleton cleanly). That already satisfies the merge-queue
+# rule "never cancel a queue check": `cancel-in-progress: false` here is
+# unconditional, and `github.ref` on a merge_group run is the queue's own
+# `gh-readonly-queue/...` branch, so it cannot share a group with the PR.
 concurrency:
   group: ci-uat-${{ github.ref }}
   cancel-in-progress: false
@@ -93,9 +103,15 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
+      # merge_group: no diff base exists on a queue ref, so skip the
+      # filter. The job still runs and reports `success`, which is what
+      # the `uat-gate` sentinel needs (it hard-fails on a `changes`
+      # failure). See .github/MERGE-QUEUE.md.
       - name: Checkout
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Filter changed paths
+        if: github.event_name != 'merge_group'
         id: filter
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         with:
@@ -121,6 +137,26 @@ jobs:
     # workflow_dispatch bypasses BOTH gates: a manual run is the operator
     # explicitly asking for the UAT (2026-07-04: UAT_GATE_ENABLED flipped to
     # false — per-commit live UAT burns subscription quota; on-demand only).
+    #
+    # merge_group is DELIBERATELY not added here, and this is not a
+    # weakening. The durable reason (true regardless of how
+    # UAT_GATE_ENABLED is set): this job is the ONLY required-context
+    # ancestor in the repo bound to `[self-hosted, uat-host]`, a single
+    # machine. A merge-queue entry cannot tolerate a runner that is busy
+    # or unregistered — there is no "it'll pick up in a minute", the
+    # entry just sits until the queue's 60-min check_response_timeout
+    # ejects it and the whole train stalls. Live Telegram round-trips
+    # also burn subscription quota per queue entry, and the queue
+    # re-runs entries on every re-form.
+    #
+    # The verdict is unchanged either way: on a queue ref the `changes`
+    # filter step is skipped (no diff base), so `needs.changes.outputs.
+    # relevant` is EMPTY and the second arm is false on its own merits —
+    # this job would skip on merge_group even if the gate var were
+    # flipped back on. (Corroborating but contingent: UAT_GATE_ENABLED
+    # has been false since 2026-07-04, so it is already skipped on every
+    # PR and every main push too.) The always-on `uat-gate` sentinel
+    # below is what reports the required context.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (vars.UAT_GATE_ENABLED == 'true' && needs.changes.outputs.relevant == 'true')

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -30,6 +30,9 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Merge queue — required contexts must report on the temporary
+  # `gh-readonly-queue/main/...` ref. See .github/MERGE-QUEUE.md.
+  merge_group:
   # Manual recovery lever. GHA marks a run failed (no auto-retry) when
   # its jobs sit queued past the hosted-runner scheduling window during
   # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
@@ -46,9 +49,15 @@ permissions:
 # recovery run — dispatch is the recovery lever advertised above, so
 # it must not be cancellable by the very traffic it recovers from
 # (same pattern as docker-images.yml, #1336).
+#
+# merge_group runs keep the plain `github.ref` group (the queue's own
+# `gh-readonly-queue/...` branch — never shared with the PR's
+# `refs/pull/<n>/merge`), but are NOT cancellable: a cancelled required
+# context ejects the queue entry, and cancelling the `e2e-ok`
+# `if: always()` sentinel is the #3614 orphan-wedge shape.
 concurrency:
   group: docker-e2e-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' }}
 
 jobs:
   # ─── Path-change filter (sentinel pattern; see ci-lint.yml header) ─
@@ -73,9 +82,14 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
       hindsight: ${{ steps.filter.outputs.hindsight }}
     steps:
+      # merge_group: no diff base exists on a queue ref, so skip the
+      # filter (the job still reports `success`, which `e2e-ok` requires)
+      # and run everything below. See .github/MERGE-QUEUE.md.
       - name: Checkout
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Filter changed paths
+        if: github.event_name != 'merge_group'
         id: filter
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         with:
@@ -116,7 +130,10 @@ jobs:
 
   e2e:
     needs: changes
-    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+    # push / merge_group: always run — both are (candidate) main. On the
+    # queue ref this is the job that actually catches a semantic conflict
+    # between two individually-green PRs, so it must not be skippable.
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -259,7 +276,12 @@ jobs:
   # and because it must not share that job's disk budget.
   hindsight-probe:
     needs: changes
-    if: github.event_name == 'push' || needs.changes.outputs.hindsight == 'true'
+    # merge_group is included alongside push for the reason stated above:
+    # this job exists so the patch probe can NEVER silently skip, and the
+    # queue ref is the last gate before those patches reach main. Letting
+    # it path-skip on the new candidate-main path would contradict the
+    # job's entire purpose.
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || needs.changes.outputs.hindsight == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -49,6 +49,19 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
+  # Merge queue — the required `images-ok` sentinel must report on the
+  # temporary `gh-readonly-queue/main/...` ref or the entry is ejected.
+  #
+  # merge_group is a VALIDATION event here, exactly like pull_request:
+  # build only, never push, never write registry cache, never log in to
+  # GHCR, amd64 only. Publication stays on the real push to `main` that
+  # follows the merge. This matters because this workflow's "is this a
+  # publishing event?" test was historically spelled
+  # `github.event_name != 'pull_request'` — which is TRUE on merge_group
+  # — so every such site now excludes merge_group explicitly. That
+  # invariant is enforced by tests/ci-merge-queue-triggers.test.ts,
+  # because none of it is observable on a PR. See .github/MERGE-QUEUE.md.
+  merge_group:
   # Manual re-trigger. GHA marks a run failed (no auto-retry) when its
   # jobs sit queued past the hosted-runner scheduling window during a
   # capacity blip; `gh run rerun` then refuses ("cannot be retried")
@@ -69,9 +82,15 @@ permissions:
 # path-gated image (e.g. hindsight) gets rebuilt (#1336, and observed
 # live on 2026-07-05: three successive merges cancelled both the push
 # run carrying a hindsight pin bump and the recovery dispatch).
+#
+# merge_group runs keep the plain `github.ref` group (the queue's own
+# `gh-readonly-queue/...` branch — never shared with the PR's
+# `refs/pull/<n>/merge`), but are NOT cancellable: a cancelled required
+# context ejects the queue entry, and cancelling the `images-ok`
+# `if: always()` sentinel is the #3614 orphan-wedge shape.
 concurrency:
   group: docker-images-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' }}
 
 env:
   REGISTRY: ghcr.io
@@ -113,6 +132,12 @@ jobs:
   # per-arch job renames in this rework don't touch branch protection;
   # keep the sentinel's `needs` list complete when adding jobs.
   changes:
+    # merge_group is deliberately absent: a queue ref has no diff base,
+    # so this job is SKIPPED there. That is safe — the `images-ok`
+    # sentinel treats a skipped `changes` as fine (only failure/cancel is
+    # infra breakage), and every downstream `if:` uses `!cancelled()` so a
+    # skipped `changes` does not auto-skip them (the same path tag pushes
+    # and workflow_dispatch already take).
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -131,10 +156,16 @@ jobs:
 
   build-base:
     needs: changes
-    # Non-PR events (main push / tag / dispatch): always build.
-    # PRs: only when image inputs changed. `!cancelled()` because
-    # `changes` is skipped on tag/dispatch and a skipped need would
-    # otherwise auto-skip this job.
+    # Non-PR events (main push / tag / dispatch / merge_group): always
+    # build. PRs: only when image inputs changed. `!cancelled()` because
+    # `changes` is skipped on tag/dispatch/merge_group and a skipped need
+    # would otherwise auto-skip this job.
+    #
+    # merge_group DOES build here — deliberately. `images-ok` is a
+    # required context, and if every build job skipped on the queue ref
+    # the sentinel would be a rubber stamp that green-lights a merge
+    # having compiled nothing. It builds amd64-only and pushes nothing
+    # (see the `merge_group` note in the `on:` block).
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.images == 'true') }}
     strategy:
       fail-fast: false
@@ -143,7 +174,10 @@ jobs:
         # green anyway, and the arm64 artifact is only consumed from
         # main/tag pushes. Non-PR: both arches, each on a NATIVE
         # runner (no QEMU).
-        arch: ${{ github.event_name == 'pull_request' && fromJSON('["amd64"]') || fromJSON('["amd64","arm64"]') }}
+        # merge_group is amd64-only for the same reason PRs are: the
+        # queue validates buildability and pushes nothing, and the arm64
+        # artifact is only ever consumed from a main/tag push.
+        arch: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && fromJSON('["amd64"]') || fromJSON('["amd64","arm64"]') }}
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
@@ -173,7 +207,9 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Log in to GHCR (push only on main / tags)
-        if: github.event_name != 'pull_request'
+        # merge_group excluded: a queue run is validation-only and pushes
+        # nothing, so it needs no registry credential.
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -185,7 +221,13 @@ jobs:
         run: |
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-base"
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            # Merge-queue validation: build-only, never pushed. Keyed on
+            # the queue ref's sha because `github.event.pull_request.number`
+            # is EMPTY on merge_group — interpolating it would emit the
+            # invalid reference `${IMAGE}:pr-` and fail the build.
+            echo "tags=${IMAGE}:mq-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # PR builds: synthesize a non-pushed tag for build-only mode.
             echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
@@ -205,7 +247,7 @@ jobs:
           file: docker/Dockerfile.base
           platforms: linux/${{ matrix.arch }}
           tags: ${{ steps.tags.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
           # Cache via GHCR registry, not type=gha (#1965). The GHA
           # Azure-blob backend restores each layer behind a short-lived
           # SAS token; on the heavy images' large layers that token
@@ -224,7 +266,7 @@ jobs:
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-base:buildcache-${{ matrix.arch }}
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-base:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-base:buildcache-{1},mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner, matrix.arch) || '' }}
+          cache-to: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' && format('type=registry,ref=ghcr.io/{0}/switchroom-base:buildcache-{1},mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner, matrix.arch) || '' }}
           # sec WS9-F3 (#1418, relaxed per header): signed provenance +
           # SBOM only on tag pushes — release artifacts are what
           # `switchroom update` verifies; attestation on every main/PR
@@ -248,7 +290,11 @@ jobs:
   # Manifest-only (`imagetools create`): no rebuild, no layer re-export.
   merge-base:
     needs: build-base
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.build-base.result == 'success' }}
+    # merge_group excluded: this job PUBLISHES (:latest / :sha-<short> /
+    # :vX.Y.Z) from the per-arch scratch tags. A queue run pushes no
+    # scratch tags and must never move a user-facing tag — publication
+    # happens on the real push to main after the merge lands.
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.event_name != 'merge_group' && needs.build-base.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -332,12 +378,15 @@ jobs:
     # Same gate as build-base, plus an explicit success check on the
     # base build — `!cancelled()` alone would let dependents run past
     # a FAILED base (unlike the default all-needs-succeeded semantics
-    # it replaces).
+    # it replaces). merge_group builds here too; see build-base.
     if: ${{ !cancelled() && needs.build-base.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.images == 'true') }}
     strategy:
       fail-fast: false
       matrix:
-        arch: ${{ github.event_name == 'pull_request' && fromJSON('["amd64"]') || fromJSON('["amd64","arm64"]') }}
+        # merge_group is amd64-only for the same reason PRs are: the
+        # queue validates buildability and pushes nothing, and the arm64
+        # artifact is only ever consumed from a main/tag push.
+        arch: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && fromJSON('["amd64"]') || fromJSON('["amd64","arm64"]') }}
         image:
           - { name: agent,        file: docker/Dockerfile.agent }
           - { name: broker,       file: docker/Dockerfile.broker }
@@ -378,7 +427,9 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Log in to GHCR (push only on main / tags)
-        if: github.event_name != 'pull_request'
+        # merge_group excluded: a queue run is validation-only and pushes
+        # nothing, so it needs no registry credential.
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -391,7 +442,14 @@ jobs:
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image.name }}"
           BASE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-base"
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            # Merge-queue validation — see build-base for why the PR
+            # number can't be used here. Like a PR, the queue's base
+            # build pushed no scratch tag, so build FROM published
+            # :latest.
+            echo "tags=${IMAGE}:mq-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+            echo "base=${BASE}:latest" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             # On PRs the base wasn't pushed, so depend on the published
             # :latest (multi-arch; buildx resolves the amd64 leg).
@@ -410,7 +468,7 @@ jobs:
           file: ${{ matrix.image.file }}
           platforms: linux/${{ matrix.arch }}
           tags: ${{ steps.tags.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
           build-args: |
             BASE_IMAGE=${{ steps.tags.outputs.base }}
           # GHCR registry cache, not type=gha — #1965. `agent` (Chromium/
@@ -425,7 +483,7 @@ jobs:
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:buildcache-${{ matrix.arch }}
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-{1}:buildcache-{2},mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner, matrix.image.name, matrix.arch) || '' }}
+          cache-to: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' && format('type=registry,ref=ghcr.io/{0}/switchroom-{1}:buildcache-{2},mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner, matrix.image.name, matrix.arch) || '' }}
           # sec WS9-F3 (#1418, relaxed per header): attestation on tag
           # pushes only.
           provenance: ${{ startsWith(github.ref, 'refs/tags/v') && 'mode=max' || 'false' }}
@@ -435,7 +493,9 @@ jobs:
   # manifests. Same pattern as merge-base.
   merge-dependents:
     needs: build-dependents
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.build-dependents.result == 'success' }}
+    # merge_group excluded — see merge-base. Publication is a push-to-main
+    # concern, never a queue-validation concern.
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.event_name != 'merge_group' && needs.build-dependents.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
@@ -495,6 +555,14 @@ jobs:
     # Still single-job multi-arch via QEMU (NOT split per-arch like
     # base/dependents): this job is skipped on almost every main push,
     # so doubling its job count buys nothing on the common path.
+    #
+    # On merge_group this SKIPS (`changes` doesn't run there, so the
+    # `hindsight` output is empty). That is not a hole: the hindsight
+    # image's real gate is docker-e2e's `hindsight-probe`, which DOES run
+    # on merge_group, and the path-aware build + publish still happens on
+    # the push to main straight after the merge. Forcing the 6.4GB
+    # multi-arch build onto every queue entry would push the queue past
+    # its 60-min check_response_timeout for no added signal.
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.hindsight == 'true') }}
     runs-on: ubuntu-latest
@@ -503,14 +571,18 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up QEMU (only when arm64 build runs)
-        if: github.event_name != 'pull_request'
+        # merge_group excluded: a queue run is validation-only and pushes
+        # nothing, so it needs no registry credential.
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Log in to GHCR (push only on main / tags)
-        if: github.event_name != 'pull_request'
+        # merge_group excluded: a queue run is validation-only and pushes
+        # nothing, so it needs no registry credential.
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -536,6 +608,10 @@ jobs:
             echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.ref }}" == "refs/heads/main" && "$PUSH_LATEST" == "true" ]]; then
             echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            # Merge-queue validation: build-only, never pushed. Same
+            # empty-`pull_request.number` hazard as #2816 below.
+            echo "tags=${IMAGE}:mq-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
@@ -552,12 +628,12 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.hindsight
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           tags: ${{ steps.tags.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
           # GHCR registry cache, not type=gha — #1965 (see build-base).
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-hindsight:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-hindsight:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner) || '' }}
+          cache-to: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' && format('type=registry,ref=ghcr.io/{0}/switchroom-hindsight:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner) || '' }}
           # sec WS9-F3 (#1418, relaxed per header): attestation on tag
           # pushes only.
           provenance: ${{ startsWith(github.ref, 'refs/tags/v') && 'mode=max' || 'false' }}
@@ -588,6 +664,11 @@ jobs:
     # `changes` header): the CUDA layers make voice the heaviest build
     # and its context almost never changes; retag-unchanged covers the
     # skipped-on-main-push case. Tags + dispatch always build.
+    #
+    # Skips on merge_group for the same reason as build-hindsight — this
+    # is the single heaviest build in the repo and running it per queue
+    # entry would blow the queue's 60-min check_response_timeout. The
+    # build + publish still runs on the push to main after the merge.
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.voice == 'true') }}
     runs-on: ubuntu-latest
@@ -599,7 +680,9 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Log in to GHCR (push only on main / tags)
-        if: github.event_name != 'pull_request'
+        # merge_group excluded: a queue run is validation-only and pushes
+        # nothing, so it needs no registry credential.
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -625,6 +708,10 @@ jobs:
             echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.ref }}" == "refs/heads/main" && "$PUSH_LATEST" == "true" ]]; then
             echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            # Merge-queue validation: build-only, never pushed (see
+            # build-hindsight's twin branch).
+            echo "tags=${IMAGE}:mq-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
@@ -642,14 +729,14 @@ jobs:
           # job-level comment). No QEMU/arm64 leg on any event.
           platforms: linux/amd64
           tags: ${{ steps.tags.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
           # GHCR registry cache, not type=gha — #1965 (see build-base). The
           # CUDA base + faster-whisper pip layer are heavy, so the registry
           # cache materially shortens warm builds. cache-to gated to non-PR
           # (fork PRs have no GHCR write token; an export failure would break
           # the required build check).
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-voice:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-voice:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner) || '' }}
+          cache-to: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' && format('type=registry,ref=ghcr.io/{0}/switchroom-voice:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner) || '' }}
           # sec WS9-F3 (#1418, relaxed per header): attestation on tag
           # pushes only.
           provenance: ${{ startsWith(github.ref, 'refs/tags/v') && 'mode=max' || 'false' }}
@@ -885,8 +972,8 @@ jobs:
         run: |
           c='${{ needs.changes.result }}'
           # `changes` is intentionally skipped on tag pushes /
-          # workflow_dispatch (no diff base) — skipped is fine; only a
-          # failure/cancel is infra breakage.
+          # workflow_dispatch / merge_group (no diff base) — skipped is
+          # fine; only a failure/cancel is infra breakage.
           if [ "$c" = "failure" ] || [ "$c" = "cancelled" ]; then
             echo "::error::changes=$c — path-filter infra failed; can't trust skip"
             exit 1

--- a/tests/ci-merge-queue-triggers.test.ts
+++ b/tests/ci-merge-queue-triggers.test.ts
@@ -10,6 +10,13 @@
  * ever produced, and every enqueued PR sat in `AWAITING_CHECKS` until
  * `check_response_timeout_minutes: 60` ejected it. Nothing could merge.
  *
+ * The queue was switched back OFF the same day to unblock `main` (as of
+ * 2026-07-26 the ruleset has no `merge_queue` rule). These assertions are
+ * therefore a PRECONDITION, not a description of live behaviour: they are
+ * what makes it safe to turn the queue on again. Do not delete them
+ * because "we don't use a merge queue" — that is exactly the state in
+ * which the next person turns it on and wedges `main` a second time.
+ *
  * Why this test has to exist: EVERY invariant below is invisible on a
  * pull request. A PR run exercises the `pull_request` paths only; the
  * `merge_group` paths are exercised for the first time when the PR is

--- a/tests/ci-merge-queue-triggers.test.ts
+++ b/tests/ci-merge-queue-triggers.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Guard: the merge queue's required checks must actually run, must not
+ * be cancellable, and must not publish.
+ *
+ * Ruleset 16470166 turned on a GitHub merge queue for `main`. A queue
+ * pushes a temporary `gh-readonly-queue/main/pr-<n>-<sha>` ref and waits
+ * for its seven required contexts to report ON THAT REF via the
+ * `merge_group` event. On 2026-07-26 not one of the 14 workflows carried
+ * a `merge_group:` trigger, so nothing ever ran there, no context was
+ * ever produced, and every enqueued PR sat in `AWAITING_CHECKS` until
+ * `check_response_timeout_minutes: 60` ejected it. Nothing could merge.
+ *
+ * Why this test has to exist: EVERY invariant below is invisible on a
+ * pull request. A PR run exercises the `pull_request` paths only; the
+ * `merge_group` paths are exercised for the first time when the PR is
+ * enqueued — i.e. after review, when getting it wrong wedges the queue
+ * for everyone. Same reasoning as
+ * tests/docker/manifest-jobs-no-buildx.test.ts, which guards the
+ * push-only paths of docker-images.yml.
+ *
+ * See .github/MERGE-QUEUE.md for the full rationale.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { parse } from 'yaml'
+
+const REPO = resolve(import.meta.dirname, '..')
+
+/**
+ * workflow file -> the required status-check context it produces.
+ * Mirrors ruleset 16470166's `required_status_checks`. If a context is
+ * added to or removed from the ruleset, this map must follow.
+ */
+const REQUIRED_CONTEXTS: Record<string, string> = {
+  'ci-lint.yml': 'lint',
+  'ci-tests-core.yml': 'vitest',
+  'ci-tests-plugin.yml': 'bun-test',
+  'ci-tests-python.yml': 'python-ok',
+  'ci-uat.yml': 'uat-gate',
+  'docker-e2e.yml': 'e2e-ok',
+  'docker-images.yml': 'images-ok',
+}
+
+const WORKFLOWS = Object.keys(REQUIRED_CONTEXTS)
+
+interface Step {
+  name?: string
+  uses?: string
+  run?: string
+  if?: unknown
+  with?: Record<string, unknown>
+}
+interface Job {
+  if?: unknown
+  needs?: string | string[]
+  steps?: Step[]
+  strategy?: unknown
+}
+interface Workflow {
+  on?: Record<string, unknown>
+  concurrency?: { group?: string; 'cancel-in-progress'?: unknown }
+  jobs?: Record<string, Job>
+}
+
+function load(file: string): Workflow {
+  return parse(readFileSync(join(REPO, '.github/workflows', file), 'utf8')) as Workflow
+}
+
+function jobsOf(wf: Workflow): Array<[string, Job]> {
+  return Object.entries(wf.jobs ?? {})
+}
+
+function stepsOf(job: Job): Step[] {
+  return Array.isArray(job.steps) ? job.steps : []
+}
+
+/** Everything a step can carry, flattened, so we can scan for expressions. */
+function textOf(value: unknown): string {
+  return value === undefined || value === null ? '' : JSON.stringify(value)
+}
+
+/**
+ * True when an `if:` expression provably cannot be satisfied on a
+ * `merge_group` event. Only two unambiguous shapes are recognised —
+ * anything else is treated as REACHABLE, so the guard fails closed:
+ *
+ *   1. the expression mentions `merge_group` at all — the author
+ *      considered the event explicitly (in this repo always as
+ *      `github.event_name != 'merge_group'`);
+ *   2. the expression is a positive event allowlist: it contains at
+ *      least one `github.event_name == '<x>'` term, contains no
+ *      `github.event_name !=` term, and no term names merge_group.
+ *      Reachable events are then a subset of the allowlist.
+ */
+function excludesMergeGroup(gate: unknown): boolean {
+  const expr = String(gate ?? '')
+  if (expr === '') return false
+  if (expr.includes('merge_group')) return true
+  const allowlisted = [...expr.matchAll(/github\.event_name\s*==\s*'([^']+)'/g)]
+  if (allowlisted.length === 0) return false
+  if (/github\.event_name\s*!=/.test(expr)) return false
+  return true
+}
+
+describe('merge queue — required checks run on the gh-readonly-queue ref', () => {
+  it('the guarded set matches the workflows that own a required context', () => {
+    // Sanity floor: if a workflow is renamed, every it.each below would
+    // silently guard nothing. Pin the job names too, so a sentinel rename
+    // that detaches the context from the ruleset is loud here.
+    for (const [file, context] of Object.entries(REQUIRED_CONTEXTS)) {
+      const jobs = load(file).jobs ?? {}
+      expect(
+        Object.keys(jobs),
+        `${file} must still define the job named '${context}' — that job name IS the ` +
+          `required status-check context in ruleset 16470166.`,
+      ).toContain(context)
+    }
+  })
+
+  it.each(WORKFLOWS)('%s has a merge_group trigger', (file) => {
+    const on = load(file).on ?? {}
+    expect(
+      Object.keys(on),
+      `${file} produces the required context '${REQUIRED_CONTEXTS[file]}', but has no ` +
+        `merge_group trigger. GitHub will never run it on the queue's ` +
+        `gh-readonly-queue/main/... ref, the context is never reported, and every ` +
+        `enqueued PR is ejected after check_response_timeout_minutes (60). ` +
+        `This is the exact 2026-07-26 outage.`,
+    ).toContain('merge_group')
+  })
+
+  it.each(WORKFLOWS)('%s — the required job always reports (if: always())', (file) => {
+    const context = REQUIRED_CONTEXTS[file]
+    const job = (load(file).jobs ?? {})[context]
+    expect(
+      String(job?.if ?? ''),
+      `${file}: job '${context}' is a REQUIRED context, so it must run unconditionally ` +
+        `(if: always()). A skipped required check is not success — it blocks the queue.`,
+    ).toContain('always()')
+  })
+
+  it.each(WORKFLOWS)('%s — a merge_group run can never be cancelled', (file) => {
+    const wf = load(file)
+    const cip = wf.concurrency?.['cancel-in-progress']
+    // Literal false is fine (nothing is ever cancelled). Anything else
+    // must be an expression that excludes merge_group.
+    if (cip === false) return
+    expect(
+      String(cip ?? ''),
+      `${file}: cancel-in-progress must exclude merge_group. Cancelling a queue check ` +
+        `reports a non-success required context (the entry is ejected), and cancelling ` +
+        `an 'if: always()' sentinel is the #3614 orphan-wedge shape — the sentinel can ` +
+        `survive stuck in 'queued', pinning the concurrency group for the whole 60-min ` +
+        `window with no self-service recovery.`,
+    ).toContain('merge_group')
+  })
+
+  it.each(WORKFLOWS)('%s — concurrency is keyed so the queue ref cannot collide', (file) => {
+    const group = String(load(file).concurrency?.group ?? '')
+    // github.ref on merge_group is refs/heads/gh-readonly-queue/... —
+    // distinct from the PR's refs/pull/<n>/merge and from refs/heads/main.
+    // Keying on head_ref / the PR number instead would collide.
+    expect(group, `${file}: concurrency.group must exist`).not.toBe('')
+    expect(
+      group,
+      `${file}: concurrency.group must key on github.ref. github.head_ref is EMPTY on ` +
+        `merge_group (every queue run would share one group and cancel its siblings), ` +
+        `and a PR-number key would put the queue run in the PR's group.`,
+    ).toContain('github.ref')
+    expect(
+      group,
+      `${file}: concurrency.group must not key on github.head_ref — empty on merge_group.`,
+    ).not.toContain('github.head_ref')
+  })
+
+  it.each(WORKFLOWS)('%s — the path filter is skipped on merge_group', (file) => {
+    // A queue ref has no diff base. dorny/paths-filter must not run
+    // there: if it FAILED, every sentinel hard-fails on
+    // `changes=failure` by design and the queue is blocked — the exact
+    // outage this change fixes, reintroduced one layer down.
+    const offenders: string[] = []
+    for (const [name, job] of jobsOf(load(file))) {
+      // Unreachable either way: the step is if:-skipped, or the whole
+      // job is (docker-images.yml gates `changes` at job level).
+      if (excludesMergeGroup(job.if)) continue
+      for (const step of stepsOf(job)) {
+        if (!(step.uses ?? '').includes('dorny/paths-filter')) continue
+        if (!excludesMergeGroup(step.if)) offenders.push(`${name}`)
+      }
+    }
+    expect(
+      offenders,
+      `${file}: paths-filter step(s) in job(s) [${offenders.join(', ')}] are not skipped on ` +
+        `merge_group. A queue ref has no PR base to diff against; a filter failure there ` +
+        `hard-fails the sentinel and blocks the queue.`,
+    ).toEqual([])
+  })
+
+  it.each(WORKFLOWS)('%s — no step reads PR-only context unguarded', (file) => {
+    // `github.event.pull_request.*` and `github.base_ref` are EMPTY on
+    // merge_group. A step that interpolates them there either renders a
+    // broken value (e.g. the invalid image reference `IMAGE:pr-`) or
+    // silently selects nothing (e.g. `vitest --changed origin/`). Each
+    // such step must either be gated to pull_request, or handle
+    // merge_group explicitly in its own body.
+    const offenders: string[] = []
+    for (const [name, job] of jobsOf(load(file))) {
+      for (const step of stepsOf(job)) {
+        const body = textOf(step)
+        if (!body.includes('github.event.pull_request.') && !body.includes('github.base_ref')) {
+          continue
+        }
+        const gatedToPr = String(step.if ?? '').includes("== 'pull_request'")
+        if (!gatedToPr && !body.includes('merge_group')) {
+          offenders.push(`${name}/${step.name ?? step.uses ?? '<step>'}`)
+        }
+      }
+    }
+    expect(
+      offenders,
+      `${file}: step(s) [${offenders.join(', ')}] interpolate pull-request-only context ` +
+        `that is EMPTY on merge_group, without gating to pull_request or handling ` +
+        `merge_group. Renders a broken value or silently selects nothing on a queue ref.`,
+    ).toEqual([])
+  })
+})
+
+describe('merge queue — ci-tests-core actually runs vitest on a queue ref', () => {
+  // The subtlest failure mode found while fixing the outage: adding the
+  // merge_group trigger alone is NOT enough here. Both vitest steps were
+  // `if:`-gated (`pull_request` for the --changed arm, `push` for the
+  // full-suite arm), so on merge_group the shard job would check out,
+  // install, download dist/ — and run ZERO tests, then report success
+  // under the required `vitest` context. A silent false green on the one
+  // check that gates the whole test suite.
+  const wf = load('ci-tests-core.yml')
+  const shard = (wf.jobs ?? {})['vitest-shard']
+
+  it('the vitest-shard job runs on merge_group', () => {
+    expect(String(shard?.if ?? ''), 'vitest-shard must not skip on merge_group').toContain(
+      'merge_group',
+    )
+  })
+
+  it('at least one vitest step executes on merge_group', () => {
+    const vitestSteps = stepsOf(shard).filter((s) => (s.run ?? '').includes('vitest run'))
+    expect(vitestSteps.length, 'expected vitest run steps in vitest-shard').toBeGreaterThan(0)
+
+    const runsOnMergeGroup = vitestSteps.filter((s) => {
+      const gate = String(s.if ?? '')
+      // An ungated step runs on every event; a gated one must name merge_group.
+      return gate === '' || gate.includes('merge_group')
+    })
+
+    expect(
+      runsOnMergeGroup.map((s) => s.name ?? '<step>'),
+      `ci-tests-core.yml: no vitest step is reachable on merge_group. The job would run ` +
+        `checkout + install + artifact download, execute NO tests, and still report ` +
+        `success under the REQUIRED 'vitest' context — a silent false green that would ` +
+        `let the merge queue land anything.`,
+    ).not.toEqual([])
+  })
+})
+
+describe('merge queue — docker-images never publishes from an unmerged ref', () => {
+  // docker-images.yml spelled "is this a publishing event?" as
+  // `github.event_name != 'pull_request'`, which is TRUE on merge_group.
+  // Left alone, a queue run would log in to GHCR, push images, write
+  // registry build cache, and move :latest / :sha-<short> — from a ref
+  // that has NOT been merged and may never be. None of this is
+  // observable on a PR.
+  const wf = load('docker-images.yml')
+  const jobs = jobsOf(wf)
+
+  it('no GHCR login step is reachable on merge_group', () => {
+    const offenders: string[] = []
+    for (const [name, job] of jobs) {
+      if (excludesMergeGroup(job.if)) continue
+      for (const step of stepsOf(job)) {
+        if (!(step.uses ?? '').includes('docker/login-action')) continue
+        if (!excludesMergeGroup(step.if)) offenders.push(`${name}/${step.name ?? '<login>'}`)
+      }
+    }
+    expect(
+      offenders,
+      `docker-images.yml: GHCR login reachable on merge_group in [${offenders.join(', ')}]. ` +
+        `A queue run publishes nothing and must not take a registry credential.`,
+    ).toEqual([])
+  })
+
+  it('no image build pushes or writes registry cache on merge_group', () => {
+    const pushOffenders: string[] = []
+    const cacheOffenders: string[] = []
+    for (const [name, job] of jobs) {
+      for (const step of stepsOf(job)) {
+        if (!(step.uses ?? '').includes('docker/build-push-action')) continue
+        const push = String(step.with?.push ?? '')
+        const cacheTo = String(step.with?.['cache-to'] ?? '')
+        if (push !== 'false' && !push.includes('merge_group')) pushOffenders.push(name)
+        if (cacheTo !== '' && !cacheTo.includes('merge_group')) cacheOffenders.push(name)
+      }
+    }
+    expect(
+      pushOffenders,
+      `docker-images.yml: build step(s) in [${pushOffenders.join(', ')}] would PUSH on ` +
+        `merge_group. \`push: github.event_name != 'pull_request'\` is TRUE on a queue ` +
+        `ref — images from an unmerged commit would land in GHCR.`,
+    ).toEqual([])
+    expect(
+      cacheOffenders,
+      `docker-images.yml: build step(s) in [${cacheOffenders.join(', ')}] would write ` +
+        `registry build cache on merge_group.`,
+    ).toEqual([])
+  })
+
+  it('no manifest job moves a user-facing tag on merge_group', () => {
+    // merge-base / merge-dependents / promote-to-dev / retag-unchanged
+    // assign :latest / :sha-<short> / :dev with `imagetools create`.
+    const manifestJobs = jobs.filter(([, job]) =>
+      stepsOf(job).some((s) => (s.run ?? '').includes('imagetools create')),
+    )
+    expect(
+      manifestJobs.map(([n]) => n).sort(),
+      'the rule must still match the publishing jobs it guards',
+    ).toEqual(['merge-base', 'merge-dependents', 'promote-to-dev', 'retag-unchanged'])
+
+    const offenders = manifestJobs.filter(([, job]) => !excludesMergeGroup(job.if)).map(([n]) => n)
+
+    expect(
+      offenders,
+      `docker-images.yml: manifest job(s) [${offenders.join(', ')}] are reachable on ` +
+        `merge_group. They move user-facing tags (:latest / :sha-<short> / :dev) and must ` +
+        `only ever run on a real push to main — publication follows the merge, it does ` +
+        `not precede it.`,
+    ).toEqual([])
+  })
+
+  it("every `!= 'pull_request'` publish gate also excludes merge_group", () => {
+    // The GENERAL form of the three rules above, so a NEW publish step
+    // can't reintroduce the bug those rules were written for. This file
+    // uses `github.event_name != 'pull_request'` as shorthand for "this
+    // is a publishing event" — a shorthand that is silently WRONG on a
+    // queue ref. Every occurrence must therefore also exclude
+    // merge_group, except the two deliberate JOB-LEVEL gates below,
+    // which mean "actually compile the images" and MUST run on
+    // merge_group or `images-ok` becomes a rubber stamp.
+    //
+    // The exemption is deliberately narrow: it is keyed on the job-level
+    // `if:` (4-space indent) and NOT on the job as a whole, because both
+    // exempt jobs also contain `push:` / `cache-to:` / step-level `if:`
+    // occurrences of the same shorthand that must still be caught. A
+    // job-wide exemption would wave those through — which is exactly the
+    // bug this file exists to prevent.
+    const ALLOWED_JOB_LEVEL_GATES = ['build-base', 'build-dependents']
+
+    const lines = readFileSync(join(REPO, '.github/workflows/docker-images.yml'), 'utf8').split('\n')
+    let job = '<workflow-level>'
+    const offenders: string[] = []
+    let seenAllowed = 0
+    lines.forEach((line, i) => {
+      const header = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line)
+      if (header) job = header[1]
+      if (line.trimStart().startsWith('#')) return
+      if (!line.includes("!= 'pull_request'")) return
+      if (line.includes('merge_group')) return
+      if (/^ {4}if:/.test(line) && ALLOWED_JOB_LEVEL_GATES.includes(job)) {
+        seenAllowed += 1
+        return
+      }
+      offenders.push(`${job} (line ${i + 1}): ${line.trim()}`)
+    })
+
+    expect(
+      seenAllowed,
+      'expected the two deliberate build gates to still be present — if this drops to 0 the ' +
+        'rule below is passing vacuously and no longer guards anything',
+    ).toBe(ALLOWED_JOB_LEVEL_GATES.length)
+
+    expect(
+      offenders,
+      `docker-images.yml treats \`github.event_name != 'pull_request'\` as "this is a publish", ` +
+        `but that expression is TRUE on a merge_group ref. These occurrences do not exclude ` +
+        `merge_group, so a queue run would perform them against an UNMERGED commit:\n  ` +
+        `${offenders.join('\n  ')}\nAdd \`&& github.event_name != 'merge_group'\`, or — if the ` +
+        `step genuinely must run on the queue ref — add the job to ` +
+        `ALLOWED_JOB_LEVEL_GATES in this test with the reason why.`,
+    ).toEqual([])
+  })
+
+  it('per-arch matrices stay amd64-only on merge_group', () => {
+    const matrices = jobs
+      .map(([name, job]) => [name, textOf(job.strategy)] as const)
+      .filter(([, s]) => s.includes('arm64') && s.includes("event_name == 'pull_request'"))
+    expect(matrices.length, 'expected the PR-gated per-arch matrices').toBeGreaterThan(0)
+    for (const [name, s] of matrices) {
+      expect(
+        s,
+        `docker-images.yml: job '${name}' would build the arm64 leg on merge_group. A ` +
+          `queue run validates buildability and pushes nothing; the arm64 artifact is ` +
+          `only ever consumed from a main/tag push.`,
+      ).toContain('merge_group')
+    }
+  })
+})


### PR DESCRIPTION
## The outage

Ruleset `16470166` enabled a GitHub merge queue on `main`. Its seven required contexts are `lint`, `bun-test`, `vitest`, `images-ok`, `uat-gate`, `e2e-ok`, `python-ok`.

**Not one of the 14 workflows carried a `merge_group:` trigger.** The queue pushes a temporary `gh-readonly-queue/main/pr-<n>-<sha>` ref and waits for those seven contexts to report *on that ref* via the `merge_group` event. With nothing listening, no context was ever produced, and every enqueued PR sat in `AWAITING_CHECKS` until `check_response_timeout_minutes: 60` ejected it. Nothing could merge.

## What this does

Adds `merge_group:` to exactly the seven workflows that own a required context. Verified 1:1 — no other workflow defines a job with any of those names, and the other seven workflows produce no required context, so they are correctly untouched. No required check is `workflow_run`-downstream (`ci-infra-watchdog.yml` is the only `workflow_run` workflow; its job is not a required context and is gated on `workflow_run.event == 'push'`).

Making the trigger fire is necessary but **not sufficient**. Three latent traps had to be fixed with it.

### 1. Silent false green on `vitest`

`ci-tests-core`'s `--changed` arm is `pull_request`-only (it needs `github.base_ref`, which is empty on a queue ref) and the full-suite arm was `push`-only. On `merge_group` **neither arm would execute** — the job would run checkout/install/artifact-download and report success having run zero tests, under a required context. The full-suite arm now covers `merge_group`.

### 2. Publishing from an unmerged commit

`docker-images` spelled *"is this a publishing event?"* as `github.event_name != 'pull_request'` — which is **TRUE on `merge_group`**. Left alone, a queue run would have logged in to GHCR, pushed images, written registry build cache, and moved the user-facing `:latest` / `:sha-<short>` / `:dev` tags **from a commit that has not merged and may never merge**.

Every such gate now also excludes `merge_group`, except the two job-level gates on `build-base` / `build-dependents`, which *must* run there or `images-ok` becomes a rubber stamp. Net effect: **a queue run behaves exactly like a PR run** — build amd64 only, push nothing, tag `:mq-<sha7>`. (The PR arm interpolates `github.event.pull_request.number`, empty on `merge_group`, which would emit the invalid reference `:pr-` and fail the build.)

### 3. Cancellation

A cancelled required context is not success — it ejects the entry — and cancelling an `if: always()` sentinel is the #3614 orphan-wedge shape, which on a queue ref would pin the concurrency group for the full 60-minute window with no self-service recovery. `cancel-in-progress` now excludes `merge_group` in all seven.

The concurrency **group keys were already safe** and needed no change: all seven key on `github.ref`, which differs between `refs/pull/<n>/merge`, `refs/heads/main`, and `refs/heads/gh-readonly-queue/...`. No collision existed.

## Path filters

The filters are **skipped** on `merge_group`, not run. A queue ref has no diff base, and a *failed* filter job makes every sentinel hard-fail by design — that would reintroduce the outage one layer down. The work jobs gate on the event instead (`push || merge_group || relevant == 'true'`), so the queue runs everything. This is the safe direction: **a skipped required check blocks a merge queue exactly as hard as a failed one.**

## Deliberately not run on the queue ref

Both documented in place, both with a sentinel that tolerates the skip and still reports:

- **`uat-gate-run`** — the only required-context ancestor bound to `[self-hosted, uat-host]`, a single machine. A busy or unregistered runner has no "it'll pick up in a minute" in a queue; the entry stalls to the 60-min eject and the whole train with it. Independently, its gate reads `needs.changes.outputs.relevant`, which is empty on a queue ref, so it would skip on its own merits regardless of `UAT_GATE_ENABLED`.
- **`build-hindsight` / `build-voice`** — a 6.4GB pull and a CUDA build would blow the same timeout. The hindsight behavioural gate runs in `docker-e2e` regardless, and both images are still built and published on the push to `main`.

**No existing check is weakened, disabled, or removed**, and the `workflow_dispatch` manual recovery lever is intact in all seven workflows.

## Guard

`tests/ci-merge-queue-triggers.test.ts` (50 assertions) pins every invariant above. This test has to exist because **every one of those invariants is invisible on a pull request** — the `merge_group` paths are exercised for the first time when a PR is enqueued, i.e. after review, when getting it wrong wedges the queue for everyone. Same reasoning as `tests/docker/manifest-jobs-no-buildx.test.ts`.

It asserts outcomes, not code paths: **against the pre-fix tree, 26 of its assertions fail**, including the outage itself, the `vitest` false green, and all four `docker-images` publish assertions. Mutation-tested — reverting a single `push:` gate produces `build-base (line 250): push: ${{ github.event_name != 'pull_request' }}`.

`.github/MERGE-QUEUE.md` documents the required-context table, the three rules (never skipped, never cancelled, never publish), the two exceptions, and the diagnostic commands.

## Validation

- `npm run lint` — clean (tsc + 14 check scripts)
- `actionlint` 1.7.7 — **zero new findings** (the 2 reported are the pre-existing unknown-`uat-host`-label warnings, proven pre-existing by stashing the diff)
- scoped tests — 66/66 (`ci-merge-queue-triggers` 50, `manifest-jobs-no-buildx` 4, `ci-image-matrix` 5, `ci-infra-watchdog` 7)

## Note for the ruleset owner (not changed here)

With `e2e` and `hindsight-probe` (30 min each) plus the image builds now running per queue entry, worst-case wall clock is roughly 35-40 min against `check_response_timeout_minutes: 60`. That is tight but workable; it may be worth tuning. This PR does not touch the ruleset, the required-check list, or any repo setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)