### PR TITLE
ci: gate the release pipeline so a v* tag cannot half-ship (#3654)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,20 +1,44 @@
 name: npm-publish
 
-# Publish the `switchroom` CLI to npm on every release tag. This is the
+# Publish the `switchroom` CLI to npm for a release tag. This is the
 # step that was historically silently skipped — v0.18.4 and v0.18.5 were
 # tagged, image-built, and rolled to the fleet but NEVER published to npm,
 # because the publish step lived only in CLAUDE.md prose and wasn't gated
-# before rollout. Automating it on tag push makes it unmissable: every
-# `vX.Y.Z` tag publishes, and the rollout skill gates on this workflow
-# going green + `npm view switchroom` showing the new version.
+# before rollout. Automating it made it unmissable.
 #
-# Trigger: tag push matching `v*` (the release-cut signal). Not fired on
-# main pushes or PRs — only on a real release tag.
+# ─── #3654: THIS WORKFLOW NO LONGER FIRES ON A TAG PUSH ────────────────
+#
+# npm is the one leg of a release that CANNOT BE UNDONE. Images can be
+# retagged, release assets can be re-uploaded, a GitHub Release can be
+# re-drafted — a published npm version is permanent. So publishing must be
+# the LAST thing a release does, and only once every other leg is green.
+#
+# It used to fire on `push: tags: v*`, in parallel with `docker-images` and
+# `release`, with nothing cross-gating the three. A tag could therefore put
+# `switchroom@X.Y.Z` on npm while the binary build was red — leaving a
+# permanent npm version whose advertised `curl | sh` install path points at
+# release assets that do not exist, with no way to take it back.
+#
+# TWO INDEPENDENT MECHANISMS now prevent that, because ordering alone is a
+# convention and conventions get bypassed:
+#
+#   1. TRIGGER. There is no `push` trigger. The only ways in are
+#      `workflow_call` (release.yml invokes this as its last job, after the
+#      binaries are attached AND docker-images is confirmed green) and
+#      `workflow_dispatch` (the operator's recovery lever).
+#
+#   2. SELF-GATE. Before anything irreversible, this workflow re-proves the
+#      preconditions FROM ITS OWN RUN — the GitHub Release for the tag
+#      carries every asset install.sh will ask for, and the docker-images
+#      run for that exact tag+commit concluded `success`. This holds on the
+#      `workflow_dispatch` path too, so a hand-dispatched publish cannot
+#      half-ship either. Mechanism 1 gives ordering; mechanism 2 gives the
+#      guarantee.
 #
 # Auth: the `NPM_TOKEN` repo secret (automation-scoped npm access token,
 # publish access on the `switchroom` package). The operator sets this once
 # in repo settings → Secrets and variables → Actions. Without it this
-# workflow fails loudly at the publish step rather than silently skipping.
+# workflow fails loudly at the auth step rather than silently skipping.
 #
 # Version source of truth: the git tag. `package.json` `version` is an
 # intentional stale placeholder (see its `//version` comment + CLAUDE.md >
@@ -22,26 +46,44 @@ name: npm-publish
 # npm tarball needs the SAME version in its package.json, so we bump it
 # UNCOMMITTED at pack time (never committed — that's the #2733 discipline).
 #
-# Ordering vs the docker-images workflow: both fire on the same tag push
-# and run in parallel. The rollout skill must wait for BOTH this workflow
-# (npm publish verified) AND docker-images (6 ghcr images verified) before
-# any fleet roll — neither alone is sufficient.
+# Script-injection discipline: every `${{ }}` is passed through `env:`
+# rather than pasted into a `run:` body — GitHub's own guidance, and it
+# matters doubly here because this workflow holds `NPM_TOKEN`. An
+# interpolated secret is rendered into the script file on the runner;
+# log masking does not undo that. Enforced by
+# tests/release-pipeline-gating.test.ts.
 
 on:
-  push:
-    tags:
-      - "v*"
-  # Manual re-trigger for a retry (e.g. a transient npm 5xx on publish).
-  # Rerun will not work for a tag-ref workflow the same way it does for
-  # branch workflows, so this lever exists.
+  # Invoked by release.yml as the FINAL job of the release pipeline. See the
+  # header: this is the ordering half of the guarantee.
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v0.19.20)"
+        required: true
+        type: string
+    secrets:
+      NPM_TOKEN:
+        description: "Automation-scoped npm token with publish rights on `switchroom`"
+        required: true
+  # Manual recovery lever: the release pipeline went green everywhere except
+  # npm (e.g. a transient npm 5xx). Dispatch on the tag ref, or pass the tag
+  # explicitly. The self-gate below still applies — this lever re-runs the
+  # publish, it does not bypass the preconditions.
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish. Defaults to the dispatch ref when that ref is a v* tag."
+        required: false
+        type: string
 
 permissions:
   contents: read
-  id-token: write  # npm provenance (sigstore) — requires npm provenance enabled on the package; harmless if not.
+  actions: read     # read docker-images run conclusions for the self-gate
+  id-token: write   # npm provenance (sigstore) — requires npm provenance enabled on the package; harmless if not.
 
 concurrency:
-  group: npm-publish-${{ github.ref }}
+  group: npm-publish-${{ inputs.tag || github.ref }}
   cancel-in-progress: false  # a publish in flight must not be cancelled mid-PUT
 
 jobs:
@@ -49,34 +91,123 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Checkout (full history for resolveVersion git describe)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          fetch-depth: 0  # resolveVersion() uses `git describe --tags --exact-match HEAD`; needs tags + history
-
-      - name: Set up Bun + install workspace deps
-        uses: ./.github/actions/setup-switchroom
-
-      - name: Resolve release version from the git tag
+      # Runs BEFORE checkout on purpose: it reads only inputs/env, and its
+      # output is what we check out. Resolving the ref explicitly (rather
+      # than leaning on whatever `github.ref` happens to be) means this
+      # behaves identically whether it was called by release.yml or
+      # dispatched by hand.
+      - name: Resolve release tag + version
         id: ver
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
         shell: bash
         run: |
           # Mirror scripts/build.mjs:resolveVersion() Layer 1-3 — the tag is
           # the source of truth. Strip the leading 'v'.
-          ref="${GITHUB_REF#refs/tags/}"
-          case "$ref" in
-            v*) ver="${ref#v}" ;;
-            *)  ver="$ref" ;;
+          tag="$TAG_INPUT"
+          if [ -z "$tag" ]; then
+            case "$GITHUB_REF" in
+              refs/tags/*) tag="${GITHUB_REF#refs/tags/}" ;;
+            esac
+          fi
+          if [ -z "$tag" ]; then
+            echo "::error::no release tag: pass the \`tag\` input, or dispatch this workflow on a v* tag ref (got GITHUB_REF=$GITHUB_REF)"
+            exit 1
+          fi
+          case "$tag" in
+            v*) ver="${tag#v}" ;;
+            *)  ver="$tag" ;;
           esac
           # Guard: a tag that doesn't look like a version is a misfire.
           if ! echo "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-.+].+)?$'; then
-            echo "::error::tag '$ref' is not a version tag (got '$ver'); refusing to publish"
+            echo "::error::tag '$tag' is not a version tag (got '$ver'); refusing to publish"
             exit 1
           fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$ver" >> "$GITHUB_OUTPUT"
-          echo "Publishing switchroom@$ver (from tag $ref)"
+          echo "Publishing switchroom@$ver (from tag $tag)"
+
+      - name: Checkout the tag (full history for resolveVersion git describe)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          # Explicit ref, not the ambient one: a reusable workflow inherits
+          # the caller's `github` context, and a hand dispatch can be on any
+          # ref. The tarball must be built from the tagged tree, full stop.
+          ref: ${{ steps.ver.outputs.tag }}
+          fetch-depth: 0  # resolveVersion() uses `git describe --tags --exact-match HEAD`; needs tags + history
+
+      # ─── SELF-GATE (#3654) ────────────────────────────────────────────
+      # Everything below this line moves toward an irreversible npm publish.
+      # These two steps are the last point at which we can still refuse.
+      # They run on a bare checkout (no node_modules yet) — both scripts are
+      # node-stdlib only, deliberately.
+
+      - name: Gate — the GitHub Release for this tag must carry every install.sh asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECT_TAG: ${{ steps.ver.outputs.tag }}
+        shell: bash
+        run: |
+          # WHY: npm is permanent and the npm package advertises the
+          # `curl | sh` install path. Publishing switchroom@X.Y.Z for a tag
+          # whose release page has no binaries mints a version that is broken
+          # forever. The expected asset list is DERIVED from install.sh by
+          # scripts/release-assets.mjs, so it cannot drift from what the
+          # installer actually downloads.
+          #
+          # The LIST endpoint, not `releases/tags/<tag>`: the release is
+          # normally still a DRAFT at this point (release.yml un-drafts it
+          # only after this publish succeeds), and the by-tag endpoint does
+          # not return drafts.
+          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" > /tmp/releases.json
+          set +e
+          node scripts/ci/assert-release-assets-complete.mjs < /tmp/releases.json > /tmp/release-summary.json
+          rc=$?
+          set -e
+          cat /tmp/release-summary.json
+          # The script is a classifier and reports an incomplete release as a
+          # ::notice::. Turning that into an actionable ::error:: is the
+          # CALLER's job, because "incomplete" is fatal here but merely
+          # informational in release.yml's `guard`.
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::the GitHub Release for $EXPECT_TAG is missing assets install.sh needs (exit $rc; see the summary above). Refusing to publish to npm — npm cannot be un-published. Let release.yml attach them, or re-run it: gh workflow run release.yml --ref $EXPECT_TAG -f dry_run=false"
+            exit 1
+          fi
+
+      - name: Gate — docker-images must be green for this exact tag + commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECT_TAG: ${{ steps.ver.outputs.tag }}
+        shell: bash
+        run: |
+          # Single shot, no polling: when release.yml calls us it has already
+          # waited for this run, and a hand dispatch should fail immediately
+          # with an actionable message rather than hang for an hour.
+          #
+          # head_sha alone is ambiguous — the tagged commit was also pushed to
+          # main, so the main-push run shares it. classify-workflow-run.mjs
+          # additionally requires head_branch == the tag. See its header.
+          EXPECT_SHA="$(git rev-parse HEAD)"
+          export EXPECT_SHA
+          gh api "repos/$GITHUB_REPOSITORY/actions/workflows/docker-images.yml/runs?head_sha=$EXPECT_SHA&per_page=100" \
+            > /tmp/image-runs.json
+          set +e
+          node scripts/ci/classify-workflow-run.mjs < /tmp/image-runs.json
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::docker-images is not green for $EXPECT_TAG ($EXPECT_SHA). Refusing to publish to npm — npm cannot be un-published. Fix or re-run docker-images (gh workflow run docker-images.yml --ref $EXPECT_TAG), then re-run the release pipeline."
+            exit 1
+          fi
+
+      # ─── END SELF-GATE ────────────────────────────────────────────────
+
+      - name: Set up Bun + install workspace deps
+        uses: ./.github/actions/setup-switchroom
 
       - name: Bump package.json version UNCOMMITTED (pack-time only)
+        env:
+          RELEASE_VERSION: ${{ steps.ver.outputs.version }}
         shell: bash
         run: |
           # Never commit this bump — the placeholder is stale by design
@@ -87,10 +218,10 @@ jobs:
             const p = JSON.parse(fs.readFileSync("package.json", "utf-8"));
             p.version = process.argv[1];
             fs.writeFileSync("package.json", JSON.stringify(p, null, 2) + "\n");
-          ' "${{ steps.ver.outputs.version }}"
+          ' "$RELEASE_VERSION"
           # Sanity: confirm the bump landed and the //version comment survived
           # (JSON.parse drops comments, so re-add it as a guard below).
-          grep -q "\"version\": \"${{ steps.ver.outputs.version }}\"" package.json || {
+          grep -q "\"version\": \"$RELEASE_VERSION\"" package.json || {
             echo "::error::pack-time version bump did not land in package.json"
             exit 1
           }
@@ -146,6 +277,8 @@ jobs:
           echo "Packed $tarball ($(wc -c < "$tarball") bytes)"
 
       - name: Verify dist/cli/switchroom.js IS in the tarball
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
         shell: bash
         run: |
           # The whole point: confirm the CLI entrypoint ships in the
@@ -163,7 +296,7 @@ jobs:
           #     the pipeline return 141 — so the guard fired even when the
           #     file WAS present. Dump the listing to a temp file first, then
           #     grep it (no pipe, no pipefail trap).
-          tar tf "${{ steps.pack.outputs.tarball }}" > /tmp/tarball-list.txt
+          tar tf "$TARBALL" > /tmp/tarball-list.txt
           if grep -q '^package/dist/cli/switchroom\.js$' /tmp/tarball-list.txt; then
             echo "dist/cli/switchroom.js confirmed in the tarball"
           else
@@ -173,25 +306,37 @@ jobs:
           fi
 
       - name: Set up npm auth (NPM_TOKEN)
+        env:
+          # Via env, never interpolated into the script body: `${{ secrets.X }}`
+          # inside a `run:` is materialised into the shell script written to
+          # the runner's disk. Log masking does not cover that file.
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash
         run: |
-          # .npmjsrc in $HOME so `npm publish` + `npm view` pick up the
+          # Guard first: a missing/empty token fails loudly here, not at
+          # publish, and before we write a useless .npmrc.
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is empty or unset — set it in repo settings → Secrets → Actions"
+            exit 1
+          fi
+          # .npmrc in $HOME so `npm publish` + `npm view` pick up the
           # automation token. Using the //registry/ auth line (not
           # _authToken in a published file) keeps the token out of the
           # repo + the tarball.
           mkdir -p "$HOME"
-          printf '//registry.npmjs.org/:_authToken=%s\n' "${{ secrets.NPM_TOKEN }}" > "$HOME/.npmrc"
+          umask 077
+          printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" > "$HOME/.npmrc"
           chmod 600 "$HOME/.npmrc"
-          # Guard: a missing/empty token fails loudly here, not at publish.
-          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
-            echo "::error::NPM_TOKEN secret is empty or unset — set it in repo settings → Secrets → Actions"
-            rm -f "$HOME/.npmrc"
-            exit 1
-          fi
 
       - name: Publish to npm (provenance-first, fallback to plain)
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
         shell: bash
         run: |
+          # THE IRREVERSIBLE STEP. Everything above — the two self-gates, the
+          # empty-build guard, the tarball content check — exists so that by
+          # the time we get here, publishing is safe.
+          #
           # --ignore-scripts: do not run the package's prepublishOnly
           # (build+lint+test) on the npm side — we already built + verified
           # locally. --access public: the package is public.
@@ -207,7 +352,7 @@ jobs:
           # lands is strictly better than a provenanced publish that
           # never happens.
           set +e
-          npm publish "${{ steps.pack.outputs.tarball }}" \
+          npm publish "$TARBALL" \
             --ignore-scripts --access public --provenance > /tmp/publish.out 2>&1
           rc=$?
           set -e
@@ -222,7 +367,7 @@ jobs:
               exit 0
             fi
             set +e
-            npm publish "${{ steps.pack.outputs.tarball }}" \
+            npm publish "$TARBALL" \
               --ignore-scripts --access public > /tmp/publish-plain.out 2>&1
             rc=$?
             set -e
@@ -236,6 +381,8 @@ jobs:
           fi
 
       - name: Verify the new version is live on npm
+        env:
+          RELEASE_VERSION: ${{ steps.ver.outputs.version }}
         shell: bash
         run: |
           # The gate the rollout skill checks: `npm view switchroom version`
@@ -244,13 +391,13 @@ jobs:
           set +e
           for i in 1 2 3 4 5; do
             published=$(npm view switchroom version 2>/dev/null)
-            if [ "$published" = "${{ steps.ver.outputs.version }}" ]; then
+            if [ "$published" = "$RELEASE_VERSION" ]; then
               echo "npm view switchroom version = $published — published and live"
               exit 0
             fi
-            echo "attempt $i: npm view returned '$published', expected '${{ steps.ver.outputs.version }}' — retrying in 6s"
+            echo "attempt $i: npm view returned '$published', expected '$RELEASE_VERSION' — retrying in 6s"
             sleep 6
           done
           set -e
-          echo "::error::npm view switchroom version did not reach ${{ steps.ver.outputs.version }} after publish + retries — publish may have silently failed"
+          echo "::error::npm view switchroom version did not reach $RELEASE_VERSION after publish + retries — publish may have silently failed"
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,49 @@ name: release
 #     Security (macOS 15 removed the right-click → Open bypass).
 #     docs/operators/install.md tells macOS users to use the installer.
 #
-# Ordering vs npm-publish.yml / docker-images.yml: all three fire independently
-# on the same `v*` tag. Nothing cross-gates them at the workflow level — the
-# `switchroom-release` skill is the gate that requires all three green before a
-# fleet rollout.
+# ─── THIS IS THE RELEASE ORCHESTRATOR (#3654) ─────────────────────────
+#
+# It used to be one of three workflows firing independently on the same `v*`
+# tag with nothing cross-gating them, so a tag could half-ship: npm published
+# while the binaries were red, or binaries attached while npm never ran. npm
+# is the leg that CANNOT BE UNDONE, so it is now last and conditional.
+#
+# The pipeline this file runs on a tag:
+#
+#   guard ──┐                                    (~1 min: fail fast, and pull
+#           │                                     an incomplete PUBLISHED
+#   build ──┴─▶ bundle ──▶ publish ──┐            release back to draft)
+#                       (attach assets)│
+#   images-gate ─────────────────────┬┴─▶ npm (workflow_call → npm-publish.yml)
+#   (waits for docker-images)        │            │
+#                                    └────────────┴──▶ finalize (un-draft)
+#
+# Two invariants, both mechanical rather than procedural:
+#
+#   1. NOTHING IRREVERSIBLE UNTIL EVERYTHING IS GREEN. `npm` needs BOTH the
+#      assets being attached AND docker-images concluding success for this
+#      exact tag+commit. npm-publish.yml additionally re-proves both from
+#      inside its own run, so even a hand dispatch cannot bypass this.
+#
+#   2. NOTHING PUBLIC UNTIL EVERYTHING IS GREEN. install.sh resolves the
+#      version it installs from `/releases/latest`, which EXCLUDES DRAFTS.
+#      The operator creates the release as a draft (switchroom-release skill
+#      step 2); `finalize` is the only thing that publishes it. So a failed
+#      release leaves the PREVIOUS complete release serving `curl | sh`
+#      installs, instead of a v0.19.19-style empty release 404ing every user.
+#      `guard` forcibly re-drafts an incomplete release that was created
+#      published, so the invariant does not depend on the operator
+#      remembering `--draft` — and it runs FIRST, with no `needs:`, so that
+#      window is ~1 minute rather than the ~25 the native build legs take.
+#      (That failure is not hypothetical: at the time this was written
+#      `/releases/latest` was v0.19.19, `draft: false`, `assets: []` — every
+#      `curl | sh` install on every platform was 404ing on the download.)
+#
+# NOT closed by this: docker-images still moves the `:latest` IMAGE tag on a
+# tag push regardless of the other legs. That is deliberate scope — image
+# tags are retaggable (promote.yml) where npm and `/releases/latest` are not,
+# and folding docker-images into this pipeline would mean restructuring the
+# workflow that also serves every PR and main push. Tracked in #3685.
 
 on:
   push:
@@ -289,9 +328,166 @@ jobs:
           if-no-files-found: error
           retention-days: 5
 
+  # Wait for the OTHER tag-triggered workflow. docker-images.yml keeps its own
+  # `tags: ["v*"]` trigger and runs in parallel with the build above — this
+  # job is what makes its result BINDING on everything downstream.
+  #
+  # Deliberately not folded into this workflow via `workflow_call`:
+  # docker-images.yml also serves every PR and main push and carries the
+  # `images-ok` required check, so converting it would put the whole image
+  # pipeline at risk to gate a leg that is retaggable anyway. More decisively,
+  # a reusable-workflow conversion could only be proven correct by cutting a
+  # real tag; this gate's failure mode if anything about it is wrong is
+  # FAIL-CLOSED (no matching run found ⇒ the gate blocks), which is the mode
+  # you want on a release path you cannot rehearse.
+  images-gate:
+    name: gate on docker-images for this tag
+    # No `needs:` — runs from the start so a red image build surfaces early
+    # instead of after ~25 minutes of native macOS build legs.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.dry_run == false &&
+       startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 95
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout (for the classifier script)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Wait for docker-images to conclude for this tag + commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECT_TAG: ${{ github.ref_name }}
+          EXPECT_SHA: ${{ github.sha }}
+          # docker-images on a tag builds base + 6 dependents on two native
+          # arches plus the QEMU hindsight and CUDA voice images. 90 minutes
+          # is generous headroom over its observed worst case; the job
+          # timeout above is the hard stop.
+          WAIT_SECONDS: "5400"
+          POLL_SECONDS: "60"
+        shell: bash
+        run: |
+          # classify-workflow-run.mjs owns every decision (see its header for
+          # why head_sha alone is ambiguous — the tagged commit is also on
+          # main, so the main-push run shares it). This loop only owns time.
+          #   exit 0 → green, proceed
+          #   exit 2 → pending, keep waiting
+          #   exit 1 → concluded non-success, stop now (a re-run of
+          #            docker-images plus a re-dispatch of this workflow is
+          #            the recovery, and it is cheaper than a job that hangs)
+          deadline=$(( $(date +%s) + WAIT_SECONDS ))
+          while :; do
+            gh api "repos/$GITHUB_REPOSITORY/actions/workflows/docker-images.yml/runs?head_sha=$EXPECT_SHA&per_page=100" \
+              > /tmp/image-runs.json || : > /tmp/image-runs.json
+            set +e
+            node scripts/ci/classify-workflow-run.mjs < /tmp/image-runs.json
+            rc=$?
+            set -e
+            case "$rc" in
+              0) echo "docker-images is green for $EXPECT_TAG — release may proceed."; exit 0 ;;
+              2) : ;;
+              *)
+                echo "::error::docker-images did not succeed for $EXPECT_TAG ($EXPECT_SHA). Nothing has been published to npm and the GitHub Release stays a draft. Fix and re-run docker-images (gh workflow run docker-images.yml --ref $EXPECT_TAG), then re-run this workflow (gh workflow run release.yml --ref $EXPECT_TAG -f dry_run=false)."
+                exit 1
+                ;;
+            esac
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::timed out after ${WAIT_SECONDS}s waiting for a docker-images run on $EXPECT_TAG ($EXPECT_SHA). Refusing to proceed — an unverifiable image build is treated as a failed one."
+              exit 1
+            fi
+            sleep "$POLL_SECONDS"
+          done
+
+  # Runs IMMEDIATELY — deliberately no `needs:`. Two jobs' worth of value in
+  # about a minute:
+  #
+  #   1. It shrinks the window in which a release created WITHOUT `--draft`
+  #      sits on `/releases/latest` with no binaries, breaking every
+  #      `curl | sh` install, from ~25 minutes (the native macOS build legs)
+  #      to ~1. The operator is supposed to pass `--draft`; this is what
+  #      makes the invariant hold when they don't.
+  #   2. It fails the whole pipeline in ~3 minutes, not ~25, when no release
+  #      exists for the tag at all — the single most common release-run
+  #      failure before this (#3633).
+  guard:
+    name: hold an incomplete release out of `latest`
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.dry_run == false &&
+       startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout (for the release-completeness script)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Locate the release, and hold an incomplete one back from `latest`
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECT_TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          # The release object is created by the operator with
+          # `gh release create vX.Y.Z --draft` (switchroom-release skill,
+          # step 2) BEFORE the tag is pushed, so it normally already exists.
+          # Poll briefly for the API to catch up, then FAIL LOUDLY rather
+          # than inventing a release with auto-notes that would collide with
+          # the operator's CHANGELOG notes.
+          #
+          # The LIST endpoint, not `gh release view`: a draft has no
+          # published-release representation to view, and the draft is the
+          # state that matters here. Page 1 is sufficient and does not need
+          # `--paginate`: GitHub returns drafts first, then published
+          # releases newest-first, so the release for the tag being built
+          # (created minutes ago) is always at the top. If it somehow were
+          # not, the script reports notFound and this job FAILS — the error
+          # is a blocked release, never a silent pass.
+          found=""
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" > /tmp/releases.json || : > /tmp/releases.json
+            set +e
+            node scripts/ci/assert-release-assets-complete.mjs < /tmp/releases.json > /tmp/release-summary.json
+            rc=$?
+            set -e
+            case "$rc" in
+              0|3) found=1; break ;;
+              4)   echo "attempt $i: release $EXPECT_TAG not visible yet — retrying in 15s" ;;
+              *)   echo "::error::release completeness check failed to run (exit $rc)"; exit 1 ;;
+            esac
+            sleep 15
+          done
+          if [ -z "$found" ]; then
+            echo "::error::no GitHub Release exists for $EXPECT_TAG after ~150s. Create it as a DRAFT (gh release create $EXPECT_TAG --draft --notes-file …) then re-run this workflow via workflow_dispatch on the tag with dry_run=false."
+            exit 1
+          fi
+          cat /tmp/release-summary.json
+
+          # THE HALF-SHIP GUARD (#3654). install.sh reads
+          # `/releases/latest`, which excludes drafts. A release that is
+          # already PUBLISHED but missing assets is therefore actively
+          # breaking every `curl | sh` install right now — pull it back to
+          # draft so the previous complete release serves installs until
+          # `finalize` re-publishes this one. A complete published release
+          # (a re-run over an already-shipped tag) is left alone.
+          draft=$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).draft===true?"true":"false"))' < /tmp/release-summary.json)
+          nmissing=$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).missing.length))' < /tmp/release-summary.json)
+          if [ "$nmissing" -gt 0 ] && [ "$draft" != "true" ]; then
+            echo "::warning title=holding release back::$EXPECT_TAG is published but missing $nmissing asset(s) — re-drafting it so /releases/latest keeps serving the previous complete release until this one is whole."
+            gh release edit "$EXPECT_TAG" --repo "$GITHUB_REPOSITORY" --draft=true
+          fi
+
   publish:
     name: attach assets to the release
-    needs: bundle
+    # `guard` as well as `bundle`: the release must exist and be held out of
+    # `latest` before anything is attached to it.
+    needs: [bundle, guard]
     # Tag pushes publish. A workflow_dispatch publishes only when explicitly
     # asked (dry_run=false) AND the dispatch ref is a tag.
     if: >-
@@ -304,6 +500,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout (for the release-completeness script)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Download the assembled bundle
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -316,25 +515,6 @@ jobs:
           TAG: ${{ github.ref_name }}
         shell: bash
         run: |
-          # The release object is created by the operator with
-          # `gh release create vX.Y.Z` (switchroom-release skill, step 2),
-          # which creates the tag and the release together — so it normally
-          # exists before this job runs. Poll briefly for the API to catch up,
-          # then FAIL LOUDLY rather than inventing a release with auto-notes
-          # that would collide with the operator's CHANGELOG notes.
-          found=""
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-              found=1; break
-            fi
-            echo "attempt $i: release $TAG not visible yet — retrying in 15s"
-            sleep 15
-          done
-          if [ -z "$found" ]; then
-            echo "::error::no GitHub Release exists for $TAG after ~150s. Create it (gh release create $TAG --notes-file …) then re-run this workflow via workflow_dispatch on the tag with dry_run=false."
-            exit 1
-          fi
-
           files=""
           for asset in $RELEASE_ASSETS; do files="$files dist-bins/$asset"; done
           files="$files dist-bins/$CHECKSUMS_FILE"
@@ -344,15 +524,90 @@ jobs:
           # Close the loop: the failure this whole workflow exists to prevent
           # is a release page with zero assets. Assert every expected asset is
           # actually attached before calling the job green.
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
-            --jq '.assets[].name' > /tmp/attached.txt
-          cat /tmp/attached.txt
-          missing=""
-          for asset in $RELEASE_ASSETS "$CHECKSUMS_FILE"; do
-            grep -Fxq "$asset" /tmp/attached.txt || missing="$missing $asset"
-          done
-          if [ -n "$missing" ]; then
-            echo "::error::upload reported success but these assets are not on the release:$missing"
+          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" > /tmp/releases.json
+          set +e
+          node scripts/ci/assert-release-assets-complete.mjs < /tmp/releases.json
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::assets are still missing from $TAG after upload (exit $rc). The upload reported success, so suspect a rename: scripts/check-release-asset-names.mjs is the static half of this contract."
             exit 1
           fi
-          echo "All release assets attached to $TAG."
+          echo "All release assets attached to $TAG (still a draft until finalize)."
+
+  # The irreversible leg, and the reason the whole pipeline exists. `needs`
+  # is the plain all-must-succeed form on purpose: no `always()`, no
+  # `!cancelled()`, no `continue-on-error` anywhere on this chain, because
+  # every one of those turns an upstream failure into a green publish.
+  npm:
+    name: publish to npm
+    needs: [publish, images-gate]
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.dry_run == false &&
+       startsWith(github.ref, 'refs/tags/v'))
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets:
+      # Passed explicitly rather than `secrets: inherit` — the called
+      # workflow gets exactly the one secret it needs and nothing else.
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # The ONLY step that makes this release visible to `install.sh`. Runs last,
+  # after every other leg, so `/releases/latest` can never point at a release
+  # that is missing binaries or that npm never received.
+  finalize:
+    name: publish the GitHub Release
+    needs: [publish, images-gate, npm]
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.dry_run == false &&
+       startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout (for the release-completeness script)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Re-verify the bundle, then take the release out of draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECT_TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          # Re-derive completeness from install.sh rather than trusting the
+          # upstream job's verdict: this is the last gate before the release
+          # becomes `/releases/latest` for every `curl | sh` user, and an
+          # asset deleted between jobs would otherwise slip through.
+          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" > /tmp/releases.json
+          set +e
+          node scripts/ci/assert-release-assets-complete.mjs < /tmp/releases.json
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::refusing to publish $EXPECT_TAG out of draft — it is missing assets install.sh needs (exit $rc). It stays a draft, so /releases/latest keeps serving the previous complete release; re-run this workflow once the assets are attached."
+            exit 1
+          fi
+
+          gh release edit "$EXPECT_TAG" --repo "$GITHUB_REPOSITORY" --draft=false
+
+          # Confirm the flip actually landed — `gh release edit` reporting
+          # success while the release stays a draft would silently leave the
+          # installer on the previous version.
+          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" > /tmp/releases-after.json
+          node scripts/ci/assert-release-assets-complete.mjs < /tmp/releases-after.json > /tmp/after.json
+          still_draft=$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).draft===true?"true":"false"))' < /tmp/after.json)
+          if [ "$still_draft" = "true" ]; then
+            echo "::error::$EXPECT_TAG is still a draft after \`gh release edit --draft=false\`; install.sh will keep resolving the previous release."
+            exit 1
+          fi
+          echo "Release $EXPECT_TAG is published with a complete asset bundle."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,97 @@
 
 ## Unreleased
 
+### A `v*` tag can no longer half-ship — release.yml is now the orchestrator (#3654)
+
+Three workflows fired independently on a `v*` tag with nothing cross-gating
+them: `docker-images`, `release` (added by #3665) and `npm-publish`. Any one
+could go red while the others shipped. The worst ordering was routine, not
+exotic — **npm publishes in ~2 minutes; the four native binary legs take
+~25** — so the default outcome of a broken build was `switchroom@X.Y.Z`
+permanently on npm, advertising a `curl | sh` install path pointing at
+release assets that do not exist. npm has no undo.
+
+The second half was live in production while this was written:
+`/releases/latest` was **v0.19.19, `draft: false`, `assets: []`**. That is the
+exact object `install.sh` resolves (`install.sh:76`), so every `curl | sh`
+install on every platform was 404ing on the asset download — and it had been
+since the moment `gh release create` ran, ~25 minutes before the binaries
+would even have been ready.
+
+**`npm-publish.yml` no longer has a `push` trigger.** It is reachable only via
+`workflow_call` from `release.yml` (as the last job, after the assets are
+attached *and* `docker-images` is confirmed green for that exact tag+commit)
+and via `workflow_dispatch` for recovery.
+
+**`release.yml` sequences the pipeline:** `guard` → `build` ×4 → `bundle` →
+`publish` → `images-gate` → `npm` → `finalize`. Plain `needs:` throughout —
+no `always()`, no `!cancelled()`, no `continue-on-error` anywhere on the
+chain, since each of those turns an upstream failure into a green publish.
+
+**The GitHub Release is held as a draft until every leg is green.**
+`/releases/latest` excludes drafts, so an in-flight or failed release leaves
+the *previous complete* release serving installs instead of breaking them.
+`finalize` is the only thing that un-drafts, and it re-derives the expected
+asset set from `install.sh` immediately before flipping the flag rather than
+trusting the upstream job. The `guard` job runs with **no `needs:`** so that a
+release created without `--draft` is pulled back within ~1 minute instead of
+sitting broken on `latest` for the whole build — and so a missing release
+fails the run in ~3 minutes rather than after ~25 minutes of macOS runner
+time.
+
+**Ordering is a convention; the self-gate is the guarantee.** `npm-publish.yml`
+re-proves both preconditions *from inside its own run* before anything
+irreversible: the release for the tag carries every asset `install.sh` asks
+for, and `docker-images` concluded `success` for that tag+commit. So a hand
+dispatch cannot bypass the ordering either.
+
+Two small pure scripts own every decision, so the shell owns only time:
+- `scripts/ci/classify-workflow-run.mjs` — success / failed / pending for a
+  workflow run. `head_sha` alone is **ambiguous**, verified against the live
+  API: commit `0bdb34ec` (v0.19.19) has two `docker-images` runs, one with
+  `head_branch: "v0.19.19"` and one with `head_branch: "main"`. Matching also
+  on `head_branch` is what separates them. Verdict is an allow-list on
+  `conclusion === "success"`, and no-match is **pending, never success**, so
+  a wrong assumption fails closed.
+- `scripts/ci/assert-release-assets-complete.mjs` — expected assets derived
+  from `install.sh` via the existing `scripts/release-assets.mjs`, never
+  hard-coded, so adding a platform to the installer automatically makes it
+  required at the gate. Uses the *list* endpoint because
+  `/releases/tags/{tag}` hides drafts — the one state that matters here.
+
+`docker-images.yml` was deliberately **not** converted to a reusable workflow.
+It also serves every PR and main push and carries the `images-ok` required
+check, and more decisively: a `workflow_call` conversion could only be proven
+correct by cutting a real tag, and if any assumption in it were wrong it would
+fail **open** (images mis-tagged). The polling gate's failure mode is closed
+(no matching run ⇒ blocked). On a path that cannot be rehearsed, that
+asymmetry decides it.
+
+**Tested by mutation, because neither workflow runs on a pull request.**
+A dropped `needs:`, a re-added `push` trigger or a stray `if: always()` would
+otherwise be invisible until the next real release, when the damage is an
+unpublishable npm version. `tests/release-pipeline-gating.test.ts` expresses
+nine rules over the parsed workflows and proves each one by weakening a clone
+until it goes red; `tests/release-gate-scripts.test.ts` covers the two scripts
+including the main-push-run rejection and the eight non-success conclusions.
+Rule R8 also pins the script-injection discipline: **no `${{ }}` inside any
+`run:` body** in either workflow — these hold `contents: write` and
+`NPM_TOKEN`, and an interpolated expression is written into the script file on
+the runner where log masking cannot reach it. `npm-publish.yml` had five, two
+of them `${{ secrets.NPM_TOKEN }}`; all now pass through `env:`.
+
+`skills/switchroom-release/SKILL.md` now **pins an explicit SHA**
+(`gh release create --target "$SHA"`, then `git push origin
+"$SHA:refs/tags/vX.Y.Z"`) instead of `--target main`, which resolves
+server-side — with agents merging PRs in parallel, a PR landing between the
+pre-flight check and the create call was silently swallowed into the release.
+
+Not closed by this: `docker-images` still moves the `:latest` **image** tag on
+a tag push regardless of the other legs. Deliberate scope — image tags are
+retaggable (`promote.yml`) where npm and `/releases/latest` are not, and
+converting the workflow that also serves every PR and main push (and carries
+the `images-ok` required check) to gate the one *recoverable* leg is the
+inverse trade of the npm case. Tracked in #3685 with the candidate shapes.
 ### A runtime probe for the perturbed-JSON-retry patch, so a silent revert fails CI
 
 #3669 shipped the perturbed-JSON-retry patch with two of the three layers the
@@ -201,7 +292,8 @@ this change, which already applied to `docker-images` + `npm-publish`; this
 adds a third leg to it). The `switchroom-release` skill's Gate C is the
 process-side mitigation until #3654 lands a mechanism: a release is not done
 until `gh release view vX.Y.Z --json assets` lists all four binaries plus the
-checksums file.
+checksums file. *(Closed in Unreleased — see "A `v*` tag can no longer
+half-ship".)*
 
 ### The LiteLLM virtual-key model allowlist now has a declarative home, and unreachable lanes FAIL doctor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ retaggable (`promote.yml`) where npm and `/releases/latest` are not, and
 converting the workflow that also serves every PR and main push (and carries
 the `images-ok` required check) to gate the one *recoverable* leg is the
 inverse trade of the npm case. Tracked in #3685 with the candidate shapes.
+
 ### A runtime probe for the perturbed-JSON-retry patch, so a silent revert fails CI
 
 #3669 shipped the perturbed-JSON-retry patch with two of the three layers the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,24 +373,47 @@ published to npm because publish wasn't gated. Don't let that recur.
   `scripts/build.mjs:resolveVersion()`. The committed `package.json`
   `version` is a stale placeholder by design (see its `//version` comment) —
   never bump it in a commit. Release = CHANGELOG consolidation PR → merge →
-  tag `vX.Y.Z` on the merge commit → push tag (triggers `docker-images`
-  AND `npm-publish` in parallel).
-- **npm publish is automated by `.github/workflows/npm-publish.yml`** on
-  tag push: it does the uncommitted pack-time `package.json` bump, builds,
-  verifies `dist/cli/switchroom.js` is non-empty AND in the tarball (the
-  v0.12.6→7 empty-build guard), `npm publish --ignore-scripts
-  --provenance`, and verifies `npm view switchroom version` shows the new
-  version. Needs the `NPM_TOKEN` repo secret (set once). **Do NOT roll
-  the fleet until this workflow is green AND `npm view switchroom version`
-  returns the tag version.** Never run `npm publish` by hand from an
-  agent container (no npm auth there); fix the workflow, don't side-step
+  **pin `SHA=$(git rev-parse origin/main)`** → `gh release create vX.Y.Z
+  --draft --target "$SHA"` → `git push origin "$SHA:refs/tags/vX.Y.Z"`.
+  Never `--target main`: it resolves server-side and agents merge in
+  parallel, so an unrelated PR can be swallowed into the release.
+- **`.github/workflows/release.yml` is the release ORCHESTRATOR (#3654).**
+  A tag push starts exactly two workflows — `docker-images` and `release` —
+  and `release` sequences everything else: attach the four static binaries →
+  wait for `docker-images` to conclude `success` for that exact tag+commit →
+  `workflow_call` into `npm-publish.yml` → un-draft the GitHub Release.
+  **`npm-publish.yml` has NO tag trigger.** npm is the only irreversible leg,
+  so it runs last, and it re-proves both preconditions from inside its own
+  run — a hand `workflow_dispatch` cannot half-ship either. Any red leg
+  leaves the release a draft with npm unpublished, which is recoverable;
+  re-dispatch `release.yml --ref vX.Y.Z -f dry_run=false` to resume.
+- **The GitHub Release is created as a DRAFT and only `finalize` publishes
+  it.** `install.sh` resolves the version from `/releases/latest`, which
+  excludes drafts — so an in-flight or failed release leaves the previous
+  complete release serving `curl | sh` installs. Creating it published is
+  the v0.19.19 failure (published, zero assets, `latest`, installer 404 on
+  every platform); `release.yml`'s `guard` job re-drafts an incomplete
+  published release within ~1 minute as the safety net.
+- **npm publish (`.github/workflows/npm-publish.yml`)** does the uncommitted
+  pack-time `package.json` bump, builds, verifies `dist/cli/switchroom.js`
+  is non-empty AND in the tarball (the v0.12.6→7 empty-build guard),
+  `npm publish --ignore-scripts --provenance`, and verifies `npm view
+  switchroom version` shows the new version. Needs the `NPM_TOKEN` repo
+  secret (set once). **Do NOT roll the fleet until `npm view switchroom
+  version` returns the tag version.** Never run `npm publish` by hand from
+  an agent container (no npm auth there); fix the workflow, don't side-step
   it. Release builds need a **real `node_modules`**, not a worktree
   symlink — a symlinked one made `bun build` silently emit an empty
   `dist/cli/` (broke v0.12.6→7); the workflow's setup-switchroom action
   avoids this and the empty-build guard catches it.
-- Create the GitHub Release (`gh release create`) — historically silently
-  dropped. The naive `awk '/^## vX/,/^## v/'` CHANGELOG range collapses to
-  one line; use a start-flag awk instead.
+- **Both release workflows keep every `${{ }}` out of `run:` bodies** — they
+  hold `contents: write` and `NPM_TOKEN`, and an interpolated expression is
+  materialised into the script file on the runner where log masking cannot
+  reach it. `tests/release-pipeline-gating.test.ts` fails the build if one
+  reappears, and mutation-tests every gating rule (neither workflow runs on
+  a PR, so a broken gate would otherwise only surface at the next release).
+- The naive `awk '/^## vX/,/^## v/'` CHANGELOG notes range collapses to one
+  line; use a start-flag awk instead.
 - The web container is a separate compose project
   (`~/.switchroom/web/docker-compose.yml`) — `switchroom update` doesn't
   touch it; pull + up manually.

--- a/scripts/ci/assert-release-assets-complete.mjs
+++ b/scripts/ci/assert-release-assets-complete.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Half-ship gate, leg 2: "does the GitHub Release for this tag actually carry
+ * every file `install.sh` will ask for?" (#3654)
+ *
+ * WHY THIS IS THE HIGH-VALUE GATE. `install.sh` resolves the version it
+ * installs from `https://api.github.com/repos/<repo>/releases/latest`, and
+ * that endpoint EXCLUDES drafts. So the moment a release is created
+ * published, it becomes `latest` for every `curl | sh` user on earth — even
+ * though the binaries take ~20 minutes to build and attach, and even if they
+ * never attach at all. install.sh then dies on the asset download ("does this
+ * release ship static binaries?"). Holding the release as a DRAFT until every
+ * asset is attached keeps the PREVIOUS complete release serving installs, so
+ * a failed build is invisible to users instead of breaking them.
+ *
+ * This script is the mechanical answer to "is it complete?", used by:
+ *
+ *   - `.github/workflows/release.yml`     → hold an incomplete PUBLISHED
+ *     release back to draft before uploading; re-verify before un-drafting
+ *   - `.github/workflows/npm-publish.yml` → refuse to publish the
+ *     IRREVERSIBLE npm artifact for a tag whose release is incomplete
+ *
+ * SHAPE: pure comparison, no network. The caller pipes in the JSON from
+ * `gh api repos/{repo}/releases` (the LIST endpoint, deliberately — see
+ * below) and reads the exit code plus a JSON summary on stdout.
+ *
+ * WHY THE LIST ENDPOINT, NOT `/releases/tags/{tag}`: "Get a release by tag
+ * name" returns PUBLISHED releases. A draft is exactly the state this gate
+ * has to inspect, so looking it up by tag would 404 on the one case that
+ * matters. The list endpoint includes drafts for any token with push access.
+ *
+ * WHY ONE PAGE IS ENOUGH (this repo passed 100 releases): the list endpoint
+ * returns DRAFTS FIRST, then published releases newest-first — verified
+ * against the live API, where a May draft sorts ahead of the July releases.
+ * The release this gate inspects was created minutes earlier, so it is at
+ * the top of page 1 either way. And the failure mode if that ever stopped
+ * holding is exit 4 (not found) → the caller BLOCKS the release. Never a
+ * silent pass, which is the only property that has to be guaranteed.
+ *
+ * WHY THE EXPECTED SET IS DERIVED, NOT LISTED: the required asset names come
+ * from parsing `install.sh` via scripts/release-assets.mjs — the same module
+ * `npm run lint` uses. Hard-coding them here would let the installer and the
+ * gate drift apart, which is the whole failure class #3633 was about. Adding
+ * a platform to install.sh automatically makes it required here.
+ * (`loadInstallerContract` is node-stdlib only — no `yaml` import — so this
+ * runs on a bare checkout with no node_modules.)
+ *
+ * Exit codes:
+ *   0 — release found and every expected asset is attached
+ *   3 — release found but assets are MISSING (summary lists which)
+ *   4 — no release exists for this tag at all
+ *   1 — bad input / bad configuration (never treated as "fine")
+ *
+ * stdout is always a one-object JSON summary so callers can branch on
+ * `.draft` without re-parsing the API payload.
+ */
+
+import { loadInstallerContract } from "../release-assets.mjs";
+
+export const EXIT = { complete: 0, badInput: 1, incomplete: 3, notFound: 4 };
+
+/**
+ * The files a release MUST carry, derived from install.sh.
+ *
+ * @param {{installShPath?: string}} [opts]
+ * @returns {string[]}
+ */
+export function expectedAssets(opts = {}) {
+  const { installer } = loadInstallerContract(opts);
+  return [...installer.assets, installer.checksumsFile];
+}
+
+/**
+ * Find the release for a tag in a `GET /repos/{repo}/releases` payload.
+ *
+ * Matches on `tag_name`, NOT on `name`/title: the title is free text an
+ * operator can typo, the tag name is the identity the workflows and
+ * install.sh both key on.
+ *
+ * @param {unknown} payload array of releases (or a single release object)
+ * @param {string} tag
+ * @returns {Record<string, any> | null}
+ */
+export function selectRelease(payload, tag) {
+  const releases = Array.isArray(payload) ? payload : payload ? [payload] : [];
+  const matches = releases.filter((r) => r && typeof r === "object" && r.tag_name === tag);
+  if (matches.length === 0) return null;
+  // A tag maps to at most one release in GitHub's model; if the payload
+  // somehow carries duplicates, prefer the PUBLISHED one — reporting the
+  // draft as authoritative would understate what users can already see.
+  return matches.find((r) => r.draft === false) ?? matches[0];
+}
+
+/**
+ * Which expected assets are absent from the release.
+ *
+ * Only assets GitHub reports as `uploaded` count. An asset stuck in
+ * `starting`/`new` state is a half-finished upload; treating it as present
+ * would let the gate pass on a release whose download 404s.
+ *
+ * @param {string[]} expected
+ * @param {Record<string, any>} release
+ * @returns {string[]}
+ */
+export function missingAssets(expected, release) {
+  const uploaded = new Set(
+    (Array.isArray(release?.assets) ? release.assets : [])
+      .filter((a) => a && (a.state === undefined || a.state === "uploaded"))
+      .map((a) => a.name),
+  );
+  return expected.filter((name) => !uploaded.has(name));
+}
+
+/* c8 ignore start — CLI wiring, covered end-to-end by spawnSync tests. */
+async function main() {
+  const tag = process.env.EXPECT_TAG ?? "";
+  if (!tag) {
+    console.error("::error::assert-release-assets-complete: EXPECT_TAG is required");
+    process.exit(EXIT.badInput);
+  }
+
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf-8").trim();
+
+  let payload;
+  try {
+    payload = raw.length > 0 ? JSON.parse(raw) : [];
+  } catch {
+    console.error("::error::assert-release-assets-complete: stdin was not JSON");
+    process.exit(EXIT.badInput);
+  }
+
+  let expected;
+  try {
+    expected = expectedAssets();
+  } catch (err) {
+    // A parse failure in release-assets.mjs means the install.sh contract is
+    // unreadable. Refuse rather than guess — an empty expected set would make
+    // every release trivially "complete".
+    console.error(`::error::assert-release-assets-complete: ${err.message}`);
+    process.exit(EXIT.badInput);
+  }
+
+  const release = selectRelease(payload, tag);
+  if (!release) {
+    console.log(JSON.stringify({ tag, found: false, draft: null, expected, missing: expected }));
+    console.error(
+      `::error::no GitHub Release exists for ${tag}. Create it (draft) before the release pipeline runs — see skills/switchroom-release/SKILL.md step 2.`,
+    );
+    process.exit(EXIT.notFound);
+  }
+
+  const missing = missingAssets(expected, release);
+  const summary = {
+    tag,
+    found: true,
+    draft: release.draft === true,
+    id: release.id ?? null,
+    expected,
+    missing,
+  };
+  console.log(JSON.stringify(summary));
+
+  if (missing.length > 0) {
+    console.error(
+      `::notice::release ${tag} is INCOMPLETE — missing: ${missing.join(", ")} (draft=${summary.draft})`,
+    );
+    process.exit(EXIT.incomplete);
+  }
+  console.error(`::notice::release ${tag} carries all ${expected.length} expected assets`);
+  process.exit(EXIT.complete);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}
+/* c8 ignore stop */

--- a/scripts/ci/classify-workflow-run.mjs
+++ b/scripts/ci/classify-workflow-run.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Half-ship gate, leg 1: "did the OTHER tag-triggered workflow succeed for
+ * THIS exact tag and commit?" (#3654)
+ *
+ * A `v*` tag fires `docker-images`, `release` and (historically)
+ * `npm-publish` as independent workflows with nothing cross-gating them, so
+ * a tag could publish to npm — the one IRREVERSIBLE leg — while the image
+ * build or the binary build went red. This script is the deterministic
+ * answer to "is docker-images green for this tag?", used by:
+ *
+ *   - `.github/workflows/release.yml`   → the `images-gate` job (polls)
+ *   - `.github/workflows/npm-publish.yml` → its own preflight (single shot)
+ *
+ * SHAPE: pure classification, no network. The caller fetches
+ * `GET /repos/{repo}/actions/workflows/{file}/runs?head_sha=<sha>` with
+ * `gh api` (which owns auth + retries) and pipes the JSON in on stdin. That
+ * keeps every decision in this file unit-testable against fixtures
+ * (tests/release-gate-scripts.test.ts) instead of behind an HTTP mock.
+ *
+ * WHY head_branch MATTERS AND head_sha ALONE IS NOT ENOUGH: a release tag
+ * points at a commit that was ALSO pushed to main, so the main-push run and
+ * the tag run share `head_sha`. Only `head_branch` separates them — on a tag
+ * push GitHub sets `head_branch` to the tag name. Matching on sha alone would
+ * happily accept the main-push run (which does not publish `:vX.Y.Z` images)
+ * as proof the tag build succeeded. That is the exact false-green this gate
+ * exists to prevent.
+ *
+ * WHY event IS NOT FILTERED: a `workflow_dispatch` re-run of docker-images on
+ * the tag ref (`gh workflow run docker-images.yml --ref vX.Y.Z`) is the
+ * documented recovery lever, and it produces a legitimately green run with
+ * `head_branch` = the tag. Requiring `event == 'push'` would reject a real
+ * recovery and force a pointless re-tag.
+ *
+ * FAIL-CLOSED BY CONSTRUCTION: "no matching run" is PENDING, never success.
+ * An empty/garbled payload (transient API trouble) is PENDING too, so the
+ * caller retries; the caller's deadline is what converts sustained pending
+ * into a hard failure. Nothing here can turn "I could not tell" into "green".
+ *
+ * Exit codes (the caller's control flow depends on all three):
+ *   0 — a matching run completed with conclusion `success`
+ *   2 — pending: no matching run yet, or it is still running, or input was
+ *       unusable. Caller should retry until its own deadline.
+ *   1 — definitive failure: a matching run completed with any other
+ *       conclusion. Caller should stop; retrying cannot change it.
+ */
+
+/**
+ * Pick the run that belongs to this tag at this commit.
+ *
+ * @param {unknown} payload parsed `…/runs` response (or an array of runs)
+ * @param {{tag: string, sha: string}} want
+ * @returns {Record<string, any> | null} newest matching run, or null
+ */
+export function selectRun(payload, { tag, sha }) {
+  const runs = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.workflow_runs)
+      ? payload.workflow_runs
+      : null;
+  if (!runs) return null;
+
+  const matches = runs.filter(
+    (r) => r && typeof r === "object" && r.head_branch === tag && r.head_sha === sha,
+  );
+  if (matches.length === 0) return null;
+
+  // Multiple matches are possible if a tag was deleted and re-pushed. Take
+  // the most recently STARTED one: an older green run must never vouch for a
+  // newer red one. `id` is monotonic and is the tie-break when timestamps are
+  // absent or equal.
+  const startedAt = (r) => Date.parse(r.run_started_at ?? r.created_at ?? "") || 0;
+  return matches.reduce((best, r) => {
+    const d = startedAt(r) - startedAt(best);
+    if (d !== 0) return d > 0 ? r : best;
+    return Number(r.id ?? 0) > Number(best.id ?? 0) ? r : best;
+  });
+}
+
+/**
+ * Reduce a run to the gate's verdict.
+ *
+ * Deliberately an allow-list on `conclusion === 'success'`, not a deny-list
+ * on `'failure'`. GitHub emits `cancelled`, `timed_out`, `action_required`,
+ * `neutral`, `skipped` and `startup_failure` too; a deny-list would wave all
+ * of those through as green.
+ *
+ * @param {Record<string, any> | null} run
+ * @returns {{state: 'pending'|'success'|'failed', detail: string}}
+ */
+export function classify(run) {
+  if (!run) return { state: "pending", detail: "no matching run yet" };
+  if (run.status !== "completed") {
+    return { state: "pending", detail: `run ${run.id} status=${run.status}` };
+  }
+  if (run.conclusion === "success") {
+    return { state: "success", detail: `run ${run.id} concluded success` };
+  }
+  return { state: "failed", detail: `run ${run.id} concluded ${String(run.conclusion)}` };
+}
+
+/** Map a verdict to this script's documented exit code. */
+export const EXIT = { success: 0, failed: 1, pending: 2 };
+
+/* c8 ignore start — CLI wiring, covered end-to-end by spawnSync tests. */
+async function main() {
+  const tag = process.env.EXPECT_TAG ?? "";
+  const sha = process.env.EXPECT_SHA ?? "";
+  if (!tag || !sha) {
+    console.error("::error::classify-workflow-run: EXPECT_TAG and EXPECT_SHA are both required");
+    // Missing configuration is a HARD failure, not pending: retrying an
+    // unconfigured gate would spin until the deadline and hide the real bug.
+    process.exit(1);
+  }
+
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf-8").trim();
+
+  let payload = null;
+  if (raw.length > 0) {
+    try {
+      payload = JSON.parse(raw);
+    } catch {
+      console.error("::notice::classify-workflow-run: unparseable payload — treating as pending");
+      process.exit(EXIT.pending);
+    }
+  }
+
+  const run = selectRun(payload, { tag, sha });
+  const { state, detail } = classify(run);
+  const where = `${tag} @ ${sha.slice(0, 7)}`;
+  if (state === "success") console.log(`gate: ${where} — ${detail}`);
+  else if (state === "failed") console.error(`::error::gate: ${where} — ${detail}`);
+  else console.log(`gate: ${where} — pending (${detail})`);
+  if (run?.html_url) console.log(run.html_url);
+  process.exit(EXIT[state]);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}
+/* c8 ignore stop */

--- a/skills/switchroom-release/SKILL.md
+++ b/skills/switchroom-release/SKILL.md
@@ -12,7 +12,9 @@ Cut a release of `switchroom/switchroom` and get it live on the fleet. This is a
 
 - A release = a `vX.Y.Z` **git tag** on `main` (the merge commit of the CHANGELOG PR).
 - The tag is the version source of truth (`scripts/build.mjs:resolveVersion()`). `package.json` `version` is a **stale placeholder by design** — never bump it in a commit (the `//version` comment + #2733 discipline). The uncommitted pack-time bump happens in CI now, not by hand.
-- Cutting the tag fires TWO workflows in parallel on tag push: `docker-images` (builds + pushes the 6 ghcr images) and `npm-publish` (builds, packs, verifies, publishes to npm). **Rollout is gated on BOTH going green.**
+- Cutting the tag fires **two** workflows: `docker-images` (builds + pushes the 6 ghcr images) and `release` (the **orchestrator** — builds the four static binaries, attaches them, waits for `docker-images`, then calls `npm-publish`, then takes the GitHub Release out of draft).
+- **`npm-publish.yml` no longer has a tag trigger (#3654).** It is reachable only via `workflow_call` from `release.yml` and via `workflow_dispatch`. npm is the one leg that cannot be undone, so it runs last and only once everything else is green. It also re-proves both preconditions from inside its own run, so a hand dispatch cannot bypass the ordering either.
+- **The GitHub Release is created as a DRAFT and stays one until every leg is green.** `install.sh` resolves the version to install from `/releases/latest`, and that endpoint excludes drafts — so a half-finished release is invisible to `curl | sh` users and the previous complete release keeps serving them. This is not theoretical: v0.19.19 shipped published-with-zero-assets and broke the installer on every platform.
 
 ## Before you start — pre-flight (verify, don't assume)
 
@@ -28,36 +30,75 @@ Cut a release of `switchroom/switchroom` and get it live on the fleet. This is a
 - The release commit touches **CHANGELOG.md only**. Do NOT bump `package.json` (placeholder discipline).
 - Branch protection blocks direct push to `main`, so: create a `release/vX.Y.Z` branch, push it, open a `chore: release vX.Y.Z` PR (base `main`), arm auto-merge (squash, delete-branch) on green CI.
 
-## Step 2 — Cut the tag (on the merge commit, not the PR branch)
+## Step 2 — Create the DRAFT release on a PINNED SHA, then push the tag
 
-Once the changelog PR is merged:
-- `git fetch origin && git checkout main && git pull --ff-only`
-- Tag the merge commit and create the GitHub Release:
-  - `gh release create vX.Y.Z -R switchroom/switchroom --target main --title 'vX.Y.Z — <summary>' --notes-file <notes-file>`
+Once the changelog PR is merged. **Order matters, and so does the pin.**
+
+### 2a — Resolve and PIN the commit
+
+```bash
+git fetch origin
+SHA="$(git rev-parse origin/main)"
+git --no-pager log -1 --oneline "$SHA"    # show the operator exactly what is being released
+```
+
+**Never pass `--target main`.** `main` is resolved server-side at the moment the API call lands, and agents merge PRs in parallel here — a PR that merged in the seconds between your pre-flight check and your `gh release create` would be silently swallowed into the release. Resolve `$SHA` once, confirm it is the commit you inspected in pre-flight, and use that literal SHA everywhere below.
+
+### 2b — Create the release as a DRAFT
+
+```bash
+gh release create "vX.Y.Z" -R switchroom/switchroom \
+  --draft \
+  --target "$SHA" \
+  --title 'vX.Y.Z — <summary>' \
+  --notes-file <notes-file>
+```
+
+- **`--draft` is mandatory.** A published release with no assets immediately becomes `/releases/latest` and 404s every `curl | sh` install for the entire ~25-minute build window. `release.yml` will forcibly re-draft an incomplete published release within about a minute, but do not rely on the safety net — it exists for the case where this step was done wrong.
+- A draft release does **not** create the tag ref. That is 2c's job, and it is why this ordering has no race: the release object exists before the workflows that need it start.
 - **Notes extraction gotcha (historical):** the naive `awk '/^## vX/,/^## v/' CHANGELOG` range collapses to a single line. Use a start-flag awk: `awk 'f{print} /^## vX\.Y\.Z/{print; f=1} f && /^## v/ && !/^## vX\.Y\.Z/{exit}'` — or extract the section to a temp file by line range.
-- **`gh release create` has been silently dropped in past runs.** After running it, verify: `gh release view vX.Y.Z` must return the release. If it didn't create, re-run.
+- **`gh release create` has been silently dropped in past runs.** Verify with `gh release list -R switchroom/switchroom --limit 5` (a draft does NOT show up under `gh release view` reliably; the list does show drafts). If it didn't create, re-run.
 
-## Step 3 — Wait for ALL THREE tag-push workflows (hard gates)
+### 2c — Push the tag at that same pinned SHA
 
-The tag push triggers `docker-images`, `npm-publish` AND `release` in parallel. **Do not proceed to rollout until all three are green AND verified.**
+```bash
+git push origin "$SHA:refs/tags/vX.Y.Z"
+```
 
-### Gate A — npm publish (`npm-publish.yml`)
-- `gh run list --workflow=npm-publish.yml --limit 1` — wait for it to reach `completed` / `success`.
-- Verify the publish is live: `npm view switchroom version` must return `X.Y.Z` (not the old version). Retry a few times — npm registry propagation can lag a few seconds.
-- If this workflow fails: **the release is not published.** Do NOT roll. Diagnose (NPM_TOKEN unset? npm 5xx? empty dist?). Re-run via `gh workflow run npm-publish.yml --ref vX.Y.Z` after fixing.
+This is what fires `docker-images` and `release`. Pushing the SHA-to-ref form rather than `git tag && git push --tags` guarantees the tag lands on the commit you pinned in 2a, not on whatever your local `main` happens to be.
 
-### Gate B — docker images (`docker-images.yml`)
+## Step 3 — Wait for the pipeline (two workflows, one of them orchestrated)
+
+The tag push triggers `docker-images` and `release`. `release` internally waits for `docker-images`, then publishes to npm, then un-drafts the GitHub Release. **Do not proceed to rollout until both are green AND verified.**
+
+### Gate A — docker images (`docker-images.yml`)
 - `gh run list --workflow=docker-images.yml --limit 1` — wait for `completed` / `success`.
 - Verify all 6 images are published: `docker manifest inspect ghcr.io/switchroom/<image>:vX.Y.Z` for `agent`, `auth-broker`, `kernel`, `broker`, `web`, `hostd`. Each must resolve.
-- If any image is missing: do NOT roll — the rollout canary version-assert fails on an unpublished tag. Wait + re-check.
+- If any image is missing: do NOT roll — the rollout canary version-assert fails on an unpublished tag. Wait + re-check. `release` will block on this by itself, so a red image build means npm never publishes and the release never leaves draft. That is the design.
 
-### Gate C — static binaries (`release.yml`)
-- `gh run list --workflow=release.yml --limit 1` — wait for `completed` / `success`.
-- Verify the release page actually has assets: `gh release view vX.Y.Z --json assets --jq '.assets[].name'` must list all four binaries (`switchroom-{linux,macos}-{amd64,arm64}`) **and** `switchroom-checksums.txt`. This is the gate that did not exist through v0.19.19 — every release up to then shipped **zero** assets and the advertised `curl | sh` installer (`install.sh`) was dead on every platform (#3633).
-- `release.yml` uploads to a release that must ALREADY EXIST — it deliberately does not invent one, so step 2's `gh release create` is a prerequisite, not optional. If the workflow failed with "no GitHub Release exists for …", create the release, then re-run: `gh workflow run release.yml --ref vX.Y.Z -f dry_run=false`.
-- To rehearse a change to this workflow without publishing anything: `gh workflow run release.yml --ref <branch>` (dry_run defaults to true — it builds, checksums and verifies the bundle, and attaches it as a workflow artifact only).
+### Gate B — the release pipeline (`release.yml`)
+- `gh run list --workflow=release.yml --limit 1` — wait for `completed` / `success`. Expect ~25-30 minutes: four native build legs plus the wait on `docker-images`.
+- Its jobs, in order: `guard` (release exists + held out of `latest`) → `build` ×4 → `bundle` → `publish` (attach) → `images-gate` (wait on docker-images) → `npm` → `finalize` (un-draft). A red job anywhere leaves the release a **draft** and npm **unpublished** — which is the correct, recoverable state.
+- Verify the release page actually has assets **and is no longer a draft**:
+  ```bash
+  gh release view vX.Y.Z -R switchroom/switchroom --json isDraft,assets \
+    --jq '{isDraft, assets: [.assets[].name]}'
+  ```
+  `isDraft` must be `false`, and `assets` must list all four binaries (`switchroom-{linux,macos}-{amd64,arm64}`) **and** `switchroom-checksums.txt`. This is the gate that did not exist through v0.19.19 — every release up to then shipped **zero** assets and the advertised `curl | sh` installer (`install.sh`) was dead on every platform (#3633).
+- Confirm the installer's own resolution path agrees:
+  ```bash
+  gh api repos/switchroom/switchroom/releases/latest --jq '{tag_name, assets: [.assets[].name]}'
+  ```
+  This is literally what `install.sh` calls. If it still reports the previous version, `finalize` did not run.
+
+### Gate C — npm publish
+- npm is published by the `npm` job **inside** the `release` run, not by a separate workflow run. `gh run list --workflow=npm-publish.yml` will show nothing new for a normal release — that is expected, not a failure.
+- Verify the publish is live: `npm view switchroom version` must return `X.Y.Z` (not the old version). Retry a few times — npm registry propagation can lag a few seconds.
 
 **Only when Gates A, B AND C are green + verified** do you proceed.
+
+### Rehearsing a workflow change without releasing anything
+`gh workflow run release.yml --ref <branch>` — `dry_run` defaults to `true`, so it builds, checksums and verifies the full bundle and attaches it as a workflow artifact, touching no GitHub Release, no npm, and no image tags. This is the only supported way to prove a change to the release pipeline before a real tag.
 
 ## Step 4 — Fleet rollout (operator-gated, canary-first)
 
@@ -69,14 +110,26 @@ The tag push triggers `docker-images`, `npm-publish` AND `release` in parallel. 
 
 - **Never bump `package.json` `version` in a commit.** It's a stale placeholder; the tag is the source of truth and `npm-publish.yml` does the uncommitted pack-time bump.
 - **Never run `npm publish` by hand from the agent container.** You can't reach the operator's npm auth, and the workflow is the reliable path. If the workflow is broken, fix the workflow — don't side-step it.
-- **Never roll the fleet before Gate A (npm) AND Gate B (images) are both green + verified.** A release that's on the fleet but not on npm is the exact regression this skill exists to prevent.
+- **Never create the GitHub Release without `--draft`,** and **never `gh release create --target main`.** Pin the SHA (step 2a).
+- **Never take the release out of draft by hand** while the pipeline is still running. `finalize` is the only thing that should publish it; un-drafting early puts an incomplete release on `/releases/latest` and breaks every installer.
+- **Never roll the fleet before Gates A, B AND C are green + verified.** A release that's on the fleet but not on npm is the exact regression this skill exists to prevent.
 - **Never push directly to `main`.** The CHANGELOG PR goes through auto-merge on green.
 - **Never force-push `main` or bypass hooks (`--no-verify`).**
 
 ## If something goes wrong
 
-- **npm-publish failed but the tag is already pushed:** fix + `gh workflow run npm-publish.yml --ref vX.Y.Z`. Do NOT roll until it's green + `npm view` confirms.
-- **Images failed but npm succeeded:** the npm package is live but the fleet can't roll yet. Fix the image workflow / re-run. (npm being ahead of images is fine — the CLI is published for npm consumers; the fleet waits on images.)
+**The single recovery command for almost everything is a re-dispatch of the orchestrator:**
+
+```bash
+gh workflow run release.yml -R switchroom/switchroom --ref vX.Y.Z -f dry_run=false
+```
+
+It re-runs every leg — including `finalize`, which is what actually takes the release out of draft. Re-running one leg on its own generally leaves the release stuck as a draft.
+
+- **`release` failed at `guard` ("no GitHub Release exists"):** step 2b was skipped or the tag name is misspelled. Create the draft release, then re-dispatch as above.
+- **`release` failed at `images-gate`:** `docker-images` was not green for this tag+commit. Fix it, `gh workflow run docker-images.yml --ref vX.Y.Z`, wait for green, then re-dispatch `release.yml`. Nothing was published to npm and the release is still a draft — nothing to undo.
+- **`release` failed at `npm` (e.g. a transient npm 5xx):** re-dispatch `release.yml` as above. `npm-publish` treats "already published" as success, so a re-run is safe and idempotent. Dispatching `npm-publish.yml --ref vX.Y.Z` directly also works and its own gates still apply, but it will NOT un-draft the release, so you would then have to re-dispatch `release.yml` anyway.
+- **Everything is green but the release is still a draft:** `finalize` did not run. Check `gh run view <run-id>` for a skipped job, then re-dispatch. Do not hand-publish — `finalize` re-verifies the asset set immediately before flipping the flag.
 - **Rollout started before publish verified (the old bug):** abort the rollout, publish, then re-roll. Do not let a half-published release sit on the fleet.
 
 ## Operator one-time setup (tell them once, not every release)

--- a/skills/switchroom-release/SKILL.md
+++ b/skills/switchroom-release/SKILL.md
@@ -55,17 +55,32 @@ gh release create "vX.Y.Z" -R switchroom/switchroom \
 ```
 
 - **`--draft` is mandatory.** A published release with no assets immediately becomes `/releases/latest` and 404s every `curl | sh` install for the entire ~25-minute build window. `release.yml` will forcibly re-draft an incomplete published release within about a minute, but do not rely on the safety net — it exists for the case where this step was done wrong.
-- A draft release does **not** create the tag ref. That is 2c's job, and it is why this ordering has no race: the release object exists before the workflows that need it start.
+- Creating the release object *before* the tag is what removes the race: `release.yml`'s `guard` job needs it to exist within ~150s of the tag push.
 - **Notes extraction gotcha (historical):** the naive `awk '/^## vX/,/^## v/' CHANGELOG` range collapses to a single line. Use a start-flag awk: `awk 'f{print} /^## vX\.Y\.Z/{print; f=1} f && /^## v/ && !/^## vX\.Y\.Z/{exit}'` — or extract the section to a temp file by line range.
-- **`gh release create` has been silently dropped in past runs.** Verify with `gh release list -R switchroom/switchroom --limit 5` (a draft does NOT show up under `gh release view` reliably; the list does show drafts). If it didn't create, re-run.
+- **`gh release create` has been silently dropped in past runs.** Verify it exists and is a draft:
+  ```bash
+  gh release view vX.Y.Z -R switchroom/switchroom --json tagName,isDraft
+  ```
+  `gh` resolves drafts by tag name (it falls back to scanning the release list). Note the raw REST `GET /releases/tags/{tag}` does **not** — it 404s on a draft. That difference is why the workflow scripts use the list endpoint; don't "fix" them to use the by-tag endpoint.
 
 ### 2c — Push the tag at that same pinned SHA
 
+GitHub does not create the tag ref for a *draft* release (it creates it on publish), so the tag push below is what actually starts the pipeline. Confirm that before pushing, because if the ref already existed at `$SHA` the push would be a silent no-op and **no workflow would fire**:
+
 ```bash
+git ls-remote --tags origin "refs/tags/vX.Y.Z"   # expect NO output
 git push origin "$SHA:refs/tags/vX.Y.Z"
 ```
 
-This is what fires `docker-images` and `release`. Pushing the SHA-to-ref form rather than `git tag && git push --tags` guarantees the tag lands on the commit you pinned in 2a, not on whatever your local `main` happens to be.
+Pushing the SHA-to-ref form rather than `git tag && git push --tags` guarantees the tag lands on the commit you pinned in 2a, not on whatever your local `main` happens to be. (If the ref *does* already exist at a different commit, the push is rejected — that is the safe direction. Do not force it; work out why first.)
+
+Then confirm both workflows actually started before you walk away:
+
+```bash
+gh run list -R switchroom/switchroom --branch vX.Y.Z --limit 5
+```
+
+You should see a `docker-images` run and a `release` run. If you see neither, the tag ref already existed and nothing fired.
 
 ## Step 3 — Wait for the pipeline (two workflows, one of them orchestrated)
 

--- a/tests/release-gate-scripts.test.ts
+++ b/tests/release-gate-scripts.test.ts
@@ -1,0 +1,314 @@
+/**
+ * The two half-ship gate scripts (#3654).
+ *
+ * A `v*` tag used to fire `docker-images`, `release` and `npm-publish` as
+ * three independent workflows with nothing cross-gating them, so a tag could
+ * publish `switchroom@X.Y.Z` to npm — which can never be un-published —
+ * while the binary build was red. These two scripts are the mechanical
+ * "is it actually safe to proceed?" checks that the release pipeline and
+ * npm-publish both run.
+ *
+ * Everything here asserts an OUTCOME (a verdict / an exit code), never that
+ * a code path executed. The negative cases are chosen so that the obvious
+ * weakenings of each script make them fail:
+ *
+ *   - deny-listing `failure` instead of allow-listing `success` → the
+ *     `cancelled` / `timed_out` / `skipped` / `null` cases go red
+ *   - matching runs on `head_sha` alone → the "main-push run shares the
+ *     tagged commit" case goes red
+ *   - treating "no matching run" or a bad payload as success → the
+ *     fail-closed cases go red
+ *   - hard-coding the expected asset list instead of deriving it from
+ *     install.sh → the "installer grew a platform" case goes red
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { selectRun, classify, EXIT as RUN_EXIT } from "../scripts/ci/classify-workflow-run.mjs";
+import {
+  selectRelease,
+  missingAssets,
+  expectedAssets,
+  EXIT as REL_EXIT,
+} from "../scripts/ci/assert-release-assets-complete.mjs";
+
+const REPO = resolve(import.meta.dirname, "..");
+const CLASSIFY = resolve(REPO, "scripts/ci/classify-workflow-run.mjs");
+const ASSERT_RELEASE = resolve(REPO, "scripts/ci/assert-release-assets-complete.mjs");
+
+const TAG = "v9.9.9";
+const SHA = "1111111111111111111111111111111111111111";
+
+const dirs: string[] = [];
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), "release-gate-"));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function run(script: string, stdin: string, env: Record<string, string>) {
+  const r = spawnSync("node", [script], {
+    cwd: REPO,
+    input: stdin,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+  return { code: r.status, out: `${r.stdout ?? ""}`, err: `${r.stderr ?? ""}` };
+}
+
+function mkRun(over: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    head_branch: TAG,
+    head_sha: SHA,
+    event: "push",
+    status: "completed",
+    conclusion: "success",
+    run_started_at: "2026-07-26T01:00:00Z",
+    html_url: "https://example.invalid/run/1",
+    ...over,
+  };
+}
+
+// ───────────────────────── classify-workflow-run ─────────────────────────
+
+describe("classify-workflow-run — which run counts", () => {
+  it("accepts the run whose head_branch is the tag and head_sha is the commit", () => {
+    const r = selectRun({ workflow_runs: [mkRun()] }, { tag: TAG, sha: SHA });
+    expect(r?.id).toBe(1);
+  });
+
+  it("REJECTS the main-push run that shares the tagged commit", () => {
+    // The regression this whole matcher exists for: a release tag points at
+    // a commit that was also pushed to main, so both runs carry the same
+    // head_sha. The main-push run never publishes `:vX.Y.Z` images, so
+    // accepting it would be a false green on the image gate.
+    const runs = [mkRun({ id: 7, head_branch: "main" })];
+    expect(selectRun({ workflow_runs: runs }, { tag: TAG, sha: SHA })).toBeNull();
+  });
+
+  it("rejects a run for the same tag at a different commit", () => {
+    const runs = [mkRun({ id: 8, head_sha: "2".repeat(40) })];
+    expect(selectRun({ workflow_runs: runs }, { tag: TAG, sha: SHA })).toBeNull();
+  });
+
+  it("accepts a workflow_dispatch recovery run on the tag ref", () => {
+    // `gh workflow run docker-images.yml --ref vX.Y.Z` is the documented
+    // recovery lever; filtering on event == 'push' would reject a genuine fix.
+    const runs = [mkRun({ id: 9, event: "workflow_dispatch" })];
+    expect(selectRun({ workflow_runs: runs }, { tag: TAG, sha: SHA })?.id).toBe(9);
+  });
+
+  it("prefers the most recently started run when a tag was re-pushed", () => {
+    const runs = [
+      mkRun({ id: 1, run_started_at: "2026-07-26T01:00:00Z", conclusion: "success" }),
+      mkRun({ id: 2, run_started_at: "2026-07-26T03:00:00Z", conclusion: "failure" }),
+    ];
+    // An older green run must never vouch for a newer red one.
+    expect(selectRun({ workflow_runs: runs }, { tag: TAG, sha: SHA })?.id).toBe(2);
+  });
+
+  it("falls back to the highest id when timestamps are absent", () => {
+    const runs = [
+      mkRun({ id: 3, run_started_at: undefined, created_at: undefined }),
+      mkRun({ id: 5, run_started_at: undefined, created_at: undefined }),
+    ];
+    expect(selectRun({ workflow_runs: runs }, { tag: TAG, sha: SHA })?.id).toBe(5);
+  });
+
+  it("returns null (never a run) for a malformed payload", () => {
+    expect(selectRun(null, { tag: TAG, sha: SHA })).toBeNull();
+    expect(selectRun({}, { tag: TAG, sha: SHA })).toBeNull();
+    expect(selectRun({ workflow_runs: "nope" }, { tag: TAG, sha: SHA })).toBeNull();
+  });
+});
+
+describe("classify-workflow-run — the verdict is an allow-list on success", () => {
+  it("is success ONLY for a completed run concluding success", () => {
+    expect(classify(mkRun()).state).toBe("success");
+  });
+
+  // Deny-listing `failure` (the tempting simplification) would wave every one
+  // of these through as green.
+  for (const conclusion of [
+    "failure",
+    "cancelled",
+    "timed_out",
+    "action_required",
+    "neutral",
+    "skipped",
+    "startup_failure",
+    null,
+  ]) {
+    it(`is FAILED for a completed run concluding ${String(conclusion)}`, () => {
+      expect(classify(mkRun({ conclusion })).state).toBe("failed");
+    });
+  }
+
+  it("is pending while the run is still going", () => {
+    expect(classify(mkRun({ status: "in_progress", conclusion: null })).state).toBe("pending");
+    expect(classify(mkRun({ status: "queued", conclusion: null })).state).toBe("pending");
+  });
+
+  it("is pending — NOT success — when no run matched at all", () => {
+    expect(classify(null).state).toBe("pending");
+  });
+});
+
+describe("classify-workflow-run — CLI exit codes drive the gate loop", () => {
+  const env = { EXPECT_TAG: TAG, EXPECT_SHA: SHA };
+
+  it("exits 0 on a green tag run", () => {
+    const r = run(CLASSIFY, JSON.stringify({ workflow_runs: [mkRun()] }), env);
+    expect(r.code).toBe(RUN_EXIT.success);
+    expect(r.code).toBe(0);
+  });
+
+  it("exits 1 on a red tag run so the caller stops instead of retrying", () => {
+    const r = run(CLASSIFY, JSON.stringify({ workflow_runs: [mkRun({ conclusion: "failure" })] }), env);
+    expect(r.code).toBe(RUN_EXIT.failed);
+    expect(r.err).toContain("::error::");
+  });
+
+  it("exits 2 (pending, keep waiting) when only the main-push run exists", () => {
+    const r = run(CLASSIFY, JSON.stringify({ workflow_runs: [mkRun({ head_branch: "main" })] }), env);
+    expect(r.code).toBe(RUN_EXIT.pending);
+    expect(r.code).not.toBe(0);
+  });
+
+  it("exits 2 (never 0) on an empty payload — a silent API failure must not read as green", () => {
+    expect(run(CLASSIFY, "", env).code).toBe(RUN_EXIT.pending);
+    expect(run(CLASSIFY, "not json at all", env).code).toBe(RUN_EXIT.pending);
+    expect(run(CLASSIFY, JSON.stringify({ workflow_runs: [] }), env).code).toBe(RUN_EXIT.pending);
+  });
+
+  it("exits 1 when misconfigured, rather than spinning until the deadline", () => {
+    const r = run(CLASSIFY, JSON.stringify({ workflow_runs: [mkRun()] }), { EXPECT_TAG: TAG, EXPECT_SHA: "" });
+    expect(r.code).toBe(1);
+  });
+});
+
+// ─────────────────── assert-release-assets-complete ───────────────────
+
+const REAL_EXPECTED = expectedAssets();
+
+function mkRelease(assets: string[], over: Record<string, unknown> = {}) {
+  return {
+    id: 42,
+    tag_name: TAG,
+    draft: true,
+    assets: assets.map((name) => ({ name, state: "uploaded" })),
+    ...over,
+  };
+}
+
+describe("assert-release-assets-complete — what a release must carry", () => {
+  it("derives the expected set from install.sh, not from a hard-coded list", () => {
+    // Same four binaries + checksums file the installer downloads. If
+    // install.sh grows a platform, this set grows with it (proved below).
+    expect(REAL_EXPECTED).toEqual([
+      "switchroom-linux-amd64",
+      "switchroom-linux-arm64",
+      "switchroom-macos-amd64",
+      "switchroom-macos-arm64",
+      "switchroom-checksums.txt",
+    ]);
+  });
+
+  it("grows the requirement when install.sh adds a platform", () => {
+    const d = tmp();
+    const p = join(d, "install.sh");
+    const original = readFileSync(resolve(REPO, "install.sh"), "utf-8");
+    const mutated = original.replace(
+      /^(\s*)Linux\)(\s*)platform=linux ;;$/m,
+      "$1Linux)$2platform=linux ;;\n$1FreeBSD)$2platform=freebsd ;;",
+    );
+    // Guard the mutation itself: if install.sh's case arm is ever reworded,
+    // a silent no-op replace would leave this test asserting nothing.
+    expect(mutated).not.toBe(original);
+    writeFileSync(p, mutated);
+    const grown = expectedAssets({ installShPath: p });
+    expect(grown).toContain("switchroom-freebsd-amd64");
+    expect(grown).toContain("switchroom-freebsd-arm64");
+    // …and the pre-existing ones are still required.
+    for (const a of REAL_EXPECTED) expect(grown).toContain(a);
+  });
+
+  it("finds a DRAFT release — the state the by-tag API endpoint hides", () => {
+    const rel = selectRelease([mkRelease(REAL_EXPECTED, { draft: true })], TAG);
+    expect(rel?.draft).toBe(true);
+  });
+
+  it("matches on tag_name, not on the human-editable title", () => {
+    const rel = selectRelease([mkRelease([], { name: "totally different title" })], TAG);
+    expect(rel?.id).toBe(42);
+    expect(selectRelease([mkRelease([], { tag_name: "v0.0.1" })], TAG)).toBeNull();
+  });
+
+  it("reports exactly which assets are absent", () => {
+    const rel = mkRelease(REAL_EXPECTED.filter((a) => a !== "switchroom-macos-arm64"));
+    expect(missingAssets(REAL_EXPECTED, rel)).toEqual(["switchroom-macos-arm64"]);
+  });
+
+  it("does NOT count an asset whose upload never finished", () => {
+    // A `state: "starting"` asset 404s on download. Counting it present
+    // would let the gate pass on a release users cannot install from.
+    const rel = {
+      ...mkRelease(REAL_EXPECTED),
+      assets: REAL_EXPECTED.map((name, i) => ({ name, state: i === 0 ? "starting" : "uploaded" })),
+    };
+    expect(missingAssets(REAL_EXPECTED, rel)).toEqual([REAL_EXPECTED[0]]);
+  });
+
+  it("treats a release with no assets array as missing everything", () => {
+    expect(missingAssets(REAL_EXPECTED, { tag_name: TAG } as never)).toEqual(REAL_EXPECTED);
+  });
+});
+
+describe("assert-release-assets-complete — CLI exit codes drive the draft gate", () => {
+  const env = { EXPECT_TAG: TAG };
+
+  it("exits 0 only when every expected asset is attached", () => {
+    const r = run(ASSERT_RELEASE, JSON.stringify([mkRelease(REAL_EXPECTED)]), env);
+    expect(r.code).toBe(REL_EXIT.complete);
+    expect(JSON.parse(r.out).missing).toEqual([]);
+  });
+
+  it("exits 3 and names the gap when an asset is missing", () => {
+    const short = REAL_EXPECTED.filter((a) => a !== "switchroom-checksums.txt");
+    const r = run(ASSERT_RELEASE, JSON.stringify([mkRelease(short)]), env);
+    expect(r.code).toBe(REL_EXIT.incomplete);
+    expect(r.code).not.toBe(0);
+    expect(JSON.parse(r.out).missing).toEqual(["switchroom-checksums.txt"]);
+  });
+
+  it("exits 4 when no release exists for the tag", () => {
+    const r = run(ASSERT_RELEASE, JSON.stringify([mkRelease(REAL_EXPECTED, { tag_name: "v0.0.1" })]), env);
+    expect(r.code).toBe(REL_EXIT.notFound);
+    expect(JSON.parse(r.out).found).toBe(false);
+  });
+
+  it("reports the draft flag so the caller can hold a published release back", () => {
+    const published = run(ASSERT_RELEASE, JSON.stringify([mkRelease([], { draft: false })]), env);
+    expect(JSON.parse(published.out).draft).toBe(false);
+    expect(published.code).toBe(REL_EXIT.incomplete);
+
+    const draft = run(ASSERT_RELEASE, JSON.stringify([mkRelease([], { draft: true })]), env);
+    expect(JSON.parse(draft.out).draft).toBe(true);
+  });
+
+  it("never exits 0 on unusable input", () => {
+    expect(run(ASSERT_RELEASE, "{{{", env).code).toBe(REL_EXIT.badInput);
+    expect(run(ASSERT_RELEASE, "[]", env).code).toBe(REL_EXIT.notFound);
+    expect(run(ASSERT_RELEASE, JSON.stringify([mkRelease(REAL_EXPECTED)]), { EXPECT_TAG: "" }).code).toBe(
+      REL_EXIT.badInput,
+    );
+  });
+});

--- a/tests/release-pipeline-gating.test.ts
+++ b/tests/release-pipeline-gating.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Structural guard: a `v*` tag cannot half-ship (#3654).
+ *
+ * Until this landed, `docker-images`, `release` and `npm-publish` all fired
+ * independently on the same tag push with nothing cross-gating them. A tag
+ * could therefore put `switchroom@X.Y.Z` on npm — permanently, npm has no
+ * undo — while the binary build was red, minting a version whose advertised
+ * `curl | sh` install path points at release assets that do not exist.
+ *
+ * WHY A TEST AND NOT A CODE REVIEW. None of these workflows run on a pull
+ * request: `release` and `npm-publish` are tag/dispatch-only. An edit that
+ * re-adds a `push:` trigger to npm-publish, or drops a `needs:`, or slips an
+ * `if: always()` onto the chain, is INVISIBLE until the next real release —
+ * at which point the damage is an unpublishable npm version. The same
+ * reasoning as tests/docker/manifest-jobs-no-buildx.test.ts.
+ *
+ * The rules are expressed as one pure `auditGating()` over the parsed
+ * workflows, and every rule is proved by MUTATION: the real files must be
+ * clean, and a copy weakened in the specific way a careless edit would
+ * weaken it must go red. A rule that only asserted the happy path would pass
+ * just as well with the gating deleted.
+ *
+ * Jobs are identified by what they DO (a step that uploads release assets, a
+ * step that runs the classifier, a step that un-drafts), not by job id, so a
+ * rename cannot silently disable a rule.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+
+const REPO = resolve(import.meta.dirname, "..");
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+}
+interface Job {
+  needs?: string | string[];
+  if?: unknown;
+  uses?: string;
+  steps?: Step[];
+  "continue-on-error"?: unknown;
+}
+interface Workflow {
+  on?: Record<string, unknown>;
+  jobs?: Record<string, Job>;
+}
+
+function load(file: string): Workflow {
+  return parse(readFileSync(resolve(REPO, ".github/workflows", file), "utf8")) as Workflow;
+}
+function clone<T>(x: T): T {
+  return JSON.parse(JSON.stringify(x)) as T;
+}
+function needsOf(job: Job): string[] {
+  const n = job.needs;
+  return Array.isArray(n) ? n : typeof n === "string" ? [n] : [];
+}
+function stepsOf(job: Job): Step[] {
+  return Array.isArray(job.steps) ? job.steps : [];
+}
+/** First job whose steps contain `needle` in a `run:` body. */
+function jobDoing(wf: Workflow, needle: string): [string, Job] | undefined {
+  return Object.entries(wf.jobs ?? {}).find(([, j]) => stepsOf(j).some((s) => (s.run ?? "").includes(needle)));
+}
+
+/**
+ * The whole rule set, as a list of human-readable problems. Empty = the
+ * pipeline cannot half-ship.
+ */
+export function auditGating(release: Workflow, npmPublish: Workflow): string[] {
+  const problems: string[] = [];
+  const releaseJobs = Object.entries(release.jobs ?? {});
+
+  // R1 — npm-publish must not be reachable from a tag push. This is the
+  // trigger half of the guarantee: ordering that depends on nobody adding a
+  // `push:` trigger back is not a guarantee.
+  if (npmPublish.on && Object.prototype.hasOwnProperty.call(npmPublish.on, "push")) {
+    problems.push(
+      "R1: npm-publish.yml has a `push` trigger — a tag push would publish to npm in parallel with the " +
+        "binary build again. npm cannot be un-published.",
+    );
+  }
+
+  // R2 — and it must still be callable by the orchestrator.
+  if (!npmPublish.on || !Object.prototype.hasOwnProperty.call(npmPublish.on, "workflow_call")) {
+    problems.push("R2: npm-publish.yml has no `workflow_call` trigger — release.yml cannot invoke it.");
+  }
+
+  // Locate the pipeline's jobs by behaviour.
+  const npmEntry = releaseJobs.find(([, j]) => (j.uses ?? "").endsWith("npm-publish.yml"));
+  const uploadEntry = jobDoing(release, "gh release upload");
+  const gateEntry = jobDoing(release, "classify-workflow-run.mjs");
+  const undraftEntry = jobDoing(release, "--draft=false");
+
+  if (!npmEntry) problems.push("R3: release.yml has no job that calls npm-publish.yml.");
+  if (!uploadEntry) problems.push("R3: release.yml has no job that uploads release assets.");
+  if (!gateEntry) problems.push("R3: release.yml has no job that gates on the docker-images run.");
+  if (!undraftEntry) problems.push("R3: release.yml has no job that publishes the release out of draft.");
+
+  // R4 — the irreversible leg waits for BOTH the assets and the image build.
+  if (npmEntry && uploadEntry && gateEntry) {
+    const n = needsOf(npmEntry[1]);
+    for (const [id] of [uploadEntry, gateEntry]) {
+      if (!n.includes(id)) {
+        problems.push(
+          `R4: the npm job (${npmEntry[0]}) does not \`needs: ${id}\` — npm could publish before that leg is green.`,
+        );
+      }
+    }
+  }
+
+  // R5 — the release becomes visible to install.sh (which resolves
+  // /releases/latest, and that endpoint skips drafts) only after every leg,
+  // npm included, has succeeded. Exactly one job may do it.
+  const undrafters = releaseJobs.filter(([, j]) => stepsOf(j).some((s) => (s.run ?? "").includes("--draft=false")));
+  if (undrafters.length > 1) {
+    problems.push(
+      `R5: ${undrafters.length} jobs take the release out of draft (${undrafters
+        .map(([id]) => id)
+        .join(", ")}) — only the final one may.`,
+    );
+  }
+  if (undraftEntry && npmEntry && !needsOf(undraftEntry[1]).includes(npmEntry[0])) {
+    problems.push(
+      `R5: the un-draft job (${undraftEntry[0]}) does not \`needs: ${npmEntry[0]}\` — the release could go ` +
+        "public for a version that never reached npm.",
+    );
+  }
+  // R9 — the job that pulls an incomplete PUBLISHED release back to draft
+  // must run immediately (no `needs:`), and the asset upload must wait for
+  // it. Give it a `needs:` on the build and the release sits on
+  // `/releases/latest` with no binaries for the ~25 minutes the native macOS
+  // legs take — which is the exact production breakage #3654 is about.
+  const redraftEntry = jobDoing(release, "--draft=true");
+  if (!redraftEntry) {
+    problems.push("R9: release.yml has no job that pulls an incomplete published release back to draft.");
+  } else {
+    if (needsOf(redraftEntry[1]).length > 0) {
+      problems.push(
+        `R9: the re-draft guard (${redraftEntry[0]}) has \`needs: ${needsOf(redraftEntry[1]).join(", ")}\` — it must ` +
+          "run immediately, or an incomplete release stays on /releases/latest for the whole build.",
+      );
+    }
+    if (uploadEntry && !needsOf(uploadEntry[1]).includes(redraftEntry[0])) {
+      problems.push(
+        `R9: the upload job (${uploadEntry[0]}) does not \`needs: ${redraftEntry[0]}\` — assets could be attached ` +
+          "to a release that was never checked for existence.",
+      );
+    }
+  }
+
+  if (undraftEntry && gateEntry && !needsOf(undraftEntry[1]).includes(gateEntry[0])) {
+    problems.push(`R5: the un-draft job (${undraftEntry[0]}) does not \`needs: ${gateEntry[0]}\`.`);
+  }
+
+  // R6 — nothing on the chain may swallow an upstream failure. `always()`
+  // and `cancelled()` override the default all-needs-succeeded semantics;
+  // `continue-on-error` turns a red step green.
+  for (const [file, wf] of [
+    ["release.yml", release],
+    ["npm-publish.yml", npmPublish],
+  ] as const) {
+    for (const [id, job] of Object.entries(wf.jobs ?? {})) {
+      const cond = String(job.if ?? "");
+      if (/\balways\s*\(/.test(cond) || /\bcancelled\s*\(/.test(cond)) {
+        problems.push(`R6: ${file} job ${id} has \`if: ${cond.trim()}\` — that runs it past a failed dependency.`);
+      }
+      if (job["continue-on-error"] === true) {
+        problems.push(`R6: ${file} job ${id} sets continue-on-error — a failed leg would report green.`);
+      }
+      for (const s of stepsOf(job)) {
+        if ((s as Record<string, unknown>)["continue-on-error"] === true) {
+          problems.push(`R6: ${file} job ${id} step "${s.name ?? "?"}" sets continue-on-error.`);
+        }
+      }
+    }
+  }
+
+  // R7 — npm-publish re-proves the preconditions from inside its OWN run,
+  // before the irreversible step, so a hand `workflow_dispatch` cannot
+  // bypass the orchestrator's ordering.
+  const publishJob = Object.values(npmPublish.jobs ?? {}).find((j) =>
+    stepsOf(j).some((s) => (s.run ?? "").includes("npm publish ")),
+  );
+  if (!publishJob) {
+    problems.push("R7: npm-publish.yml has no `npm publish` step to gate.");
+  } else {
+    const steps = stepsOf(publishJob);
+    const idxOf = (needle: string) => steps.findIndex((s) => (s.run ?? "").includes(needle));
+    const publishIdx = idxOf("npm publish ");
+    for (const gate of ["assert-release-assets-complete.mjs", "classify-workflow-run.mjs"]) {
+      const gi = idxOf(gate);
+      if (gi === -1) {
+        problems.push(`R7: npm-publish.yml never runs ${gate} — a direct dispatch could half-ship.`);
+      } else if (gi > publishIdx) {
+        problems.push(`R7: npm-publish.yml runs ${gate} AFTER \`npm publish\` — too late to refuse.`);
+      }
+    }
+  }
+
+  // R8 — no `${{ }}` inside a `run:` body. GitHub materialises expressions
+  // into the shell script written to the runner's disk; for `secrets.*` that
+  // defeats log masking, and for anything attacker-influenced it is script
+  // injection. Both of these workflows hold write-scoped credentials.
+  for (const [file, wf] of [
+    ["release.yml", release],
+    ["npm-publish.yml", npmPublish],
+  ] as const) {
+    for (const [id, job] of Object.entries(wf.jobs ?? {})) {
+      for (const s of stepsOf(job)) {
+        if ((s.run ?? "").includes("${{")) {
+          problems.push(
+            `R8: ${file} job ${id} step "${s.name ?? "?"}" interpolates \`\${{ }}\` inside \`run:\` — pass it via \`env:\`.`,
+          );
+        }
+      }
+    }
+  }
+
+  return problems;
+}
+
+const RELEASE = load("release.yml");
+const NPM = load("npm-publish.yml");
+const DOCKER = load("docker-images.yml");
+
+describe("release pipeline gating — the real workflows", () => {
+  it("has no gating problems", () => {
+    expect(auditGating(RELEASE, NPM)).toEqual([]);
+  });
+
+  it("keeps npm-publish unreachable from a tag push, and callable by release.yml", () => {
+    expect(Object.keys(NPM.on ?? {}).sort()).toEqual(["workflow_call", "workflow_dispatch"]);
+  });
+
+  it("still fires the orchestrator itself on a v* tag", () => {
+    // If release.yml stopped triggering on the tag, nothing would drive the
+    // pipeline and npm would simply never publish — a different half-ship.
+    const push = (RELEASE.on as { push?: { tags?: string[] } })?.push;
+    expect(push?.tags).toContain("v*");
+  });
+
+  it("still relies on docker-images firing on the same tag", () => {
+    // The images gate polls for that run. If docker-images stopped
+    // triggering on tags, the gate would (correctly) fail closed and block
+    // every release — so this asserts the assumption it is built on.
+    const push = (DOCKER.on as { push?: { tags?: string[] } })?.push;
+    expect(push?.tags).toContain("v*");
+  });
+
+  it("gates the images wait on the docker-images workflow specifically", () => {
+    const gate = jobDoing(RELEASE, "classify-workflow-run.mjs");
+    expect(gate).toBeDefined();
+    const body = stepsOf(gate![1])
+      .map((s) => s.run ?? "")
+      .join("\n");
+    expect(body).toContain("workflows/docker-images.yml/runs");
+    expect(body).toContain("head_sha=");
+  });
+
+  it("preserves the native-runner property release.yml exists for (#3634)", () => {
+    // The orchestration rework must not quietly move the macOS legs onto a
+    // Linux runner: a cross-compiled arm64 Mach-O ships unsigned and is
+    // SIGKILLed on exec, and the codesign step is `if:`-gated on the runner.
+    const targets = (RELEASE.jobs?.build as unknown as { strategy?: { matrix?: { target?: { asset: string; runner: string }[] } } })
+      ?.strategy?.matrix?.target;
+    expect(targets).toBeDefined();
+    for (const t of targets!) {
+      const wantMac = t.asset.includes("macos");
+      expect(t.runner.startsWith("macos-")).toBe(wantMac);
+    }
+  });
+});
+
+/** Deep-clone the real workflows and weaken them the way a careless edit would. */
+function mutate(fn: (r: Workflow, n: Workflow) => void): string[] {
+  const r = clone(RELEASE);
+  const n = clone(NPM);
+  fn(r, n);
+  return auditGating(r, n);
+}
+
+describe("release pipeline gating — every rule is proved by mutation", () => {
+  it("R1: re-adding a push trigger to npm-publish is caught", () => {
+    const p = mutate((_r, n) => {
+      (n.on as Record<string, unknown>).push = { tags: ["v*"] };
+    });
+    expect(p.join("\n")).toMatch(/R1:/);
+  });
+
+  it("R2: removing workflow_call from npm-publish is caught", () => {
+    const p = mutate((_r, n) => {
+      delete (n.on as Record<string, unknown>).workflow_call;
+    });
+    expect(p.join("\n")).toMatch(/R2:/);
+  });
+
+  it("R4: dropping the images gate from the npm job's needs is caught", () => {
+    const p = mutate((r) => {
+      const job = Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("npm-publish.yml"))!;
+      job.needs = needsOf(job).filter((x) => x !== "images-gate");
+    });
+    expect(p.join("\n")).toMatch(/R4:.*images-gate/);
+  });
+
+  it("R4: dropping the asset-upload job from the npm job's needs is caught", () => {
+    const p = mutate((r) => {
+      const job = Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("npm-publish.yml"))!;
+      job.needs = needsOf(job).filter((x) => x !== "publish");
+    });
+    expect(p.join("\n")).toMatch(/R4:.*publish/);
+  });
+
+  it("R5: un-drafting without waiting for npm is caught", () => {
+    const p = mutate((r) => {
+      const [, job] = jobDoing(r, "--draft=false")!;
+      job.needs = needsOf(job).filter((x) => x !== "npm");
+    });
+    expect(p.join("\n")).toMatch(/R5:.*npm/);
+  });
+
+  it("R5: un-drafting from a second, earlier job is caught", () => {
+    const p = mutate((r) => {
+      const [, upload] = jobDoing(r, "gh release upload")!;
+      stepsOf(upload).push({ name: "sneaky", run: 'gh release edit "$TAG" --draft=false' });
+    });
+    expect(p.join("\n")).toMatch(/R5: 2 jobs take the release out of draft/);
+  });
+
+  it("R6: `if: always()` anywhere on the chain is caught", () => {
+    const p = mutate((r) => {
+      const job = Object.values(r.jobs!).find((j) => (j.uses ?? "").endsWith("npm-publish.yml"))!;
+      job.if = "always()";
+    });
+    expect(p.join("\n")).toMatch(/R6:.*always/);
+  });
+
+  it("R6: `!cancelled()` — the idiom used elsewhere in this repo — is caught here", () => {
+    const p = mutate((r) => {
+      const [, gate] = jobDoing(r, "classify-workflow-run.mjs")!;
+      gate.if = "${{ !cancelled() }}";
+    });
+    expect(p.join("\n")).toMatch(/R6:.*cancelled/);
+  });
+
+  it("R6: continue-on-error on the gate job or its step is caught", () => {
+    expect(
+      mutate((r) => {
+        jobDoing(r, "classify-workflow-run.mjs")![1]["continue-on-error"] = true;
+      }).join("\n"),
+    ).toMatch(/R6:.*continue-on-error/);
+    expect(
+      mutate((r) => {
+        const s = stepsOf(jobDoing(r, "classify-workflow-run.mjs")![1])[1] as Record<string, unknown>;
+        s["continue-on-error"] = true;
+      }).join("\n"),
+    ).toMatch(/R6:.*continue-on-error/);
+  });
+
+  it("R7: removing npm-publish's own release-completeness gate is caught", () => {
+    const p = mutate((_r, n) => {
+      const job = Object.values(n.jobs!)[0];
+      job.steps = stepsOf(job).filter((s) => !(s.run ?? "").includes("assert-release-assets-complete.mjs"));
+    });
+    expect(p.join("\n")).toMatch(/R7: npm-publish\.yml never runs assert-release-assets-complete/);
+  });
+
+  it("R7: removing npm-publish's own docker-images gate is caught", () => {
+    const p = mutate((_r, n) => {
+      const job = Object.values(n.jobs!)[0];
+      job.steps = stepsOf(job).filter((s) => !(s.run ?? "").includes("classify-workflow-run.mjs"));
+    });
+    expect(p.join("\n")).toMatch(/R7: npm-publish\.yml never runs classify-workflow-run/);
+  });
+
+  it("R7: moving a gate after `npm publish` is caught", () => {
+    const p = mutate((_r, n) => {
+      const job = Object.values(n.jobs!)[0];
+      const steps = stepsOf(job);
+      const i = steps.findIndex((s) => (s.run ?? "").includes("classify-workflow-run.mjs"));
+      const [gate] = steps.splice(i, 1);
+      steps.push(gate);
+    });
+    expect(p.join("\n")).toMatch(/R7:.*AFTER `npm publish`/);
+  });
+
+  it("R9: making the re-draft guard wait on the build is caught", () => {
+    const p = mutate((r) => {
+      jobDoing(r, "--draft=true")![1].needs = ["bundle"];
+    });
+    expect(p.join("\n")).toMatch(/R9: the re-draft guard .* must\s+run immediately/s);
+  });
+
+  it("R9: uploading assets without waiting for the guard is caught", () => {
+    const p = mutate((r) => {
+      const [, upload] = jobDoing(r, "gh release upload")!;
+      upload.needs = needsOf(upload).filter((x) => x !== "guard");
+    });
+    expect(p.join("\n")).toMatch(/R9: the upload job/);
+  });
+
+  it("R9: deleting the re-draft guard entirely is caught", () => {
+    const p = mutate((r) => {
+      const [id] = jobDoing(r, "--draft=true")!;
+      delete r.jobs![id];
+    });
+    expect(p.join("\n")).toMatch(/R9: release\.yml has no job that pulls an incomplete published release back/);
+  });
+
+  it("R8: interpolating a secret into a run body is caught", () => {
+    const p = mutate((_r, n) => {
+      const job = Object.values(n.jobs!)[0];
+      stepsOf(job)[0]!.run = 'echo "${{ secrets.NPM_TOKEN }}" > /tmp/x';
+    });
+    expect(p.join("\n")).toMatch(/R8:.*interpolates/);
+  });
+});


### PR DESCRIPTION
Closes #3654.

## The problem, measured

Three workflows fired independently on a `v*` tag with nothing cross-gating them: `docker-images`, `release` (added by #3665) and `npm-publish`. Any one could go red while the others shipped.

The worst ordering was the **routine** one, not an exotic race: **npm publishes in ~2 minutes; the four native binary legs take ~25.** So the default outcome of a broken build was `switchroom@X.Y.Z` permanently on npm, advertising a `curl | sh` install path pointing at release assets that do not exist. npm has no undo.

The other half was **live in production while this was written**:

```
$ gh api repos/switchroom/switchroom/releases/latest --jq '{tag_name, assets: [.assets[].name]}'
{"assets":[],"tag_name":"v0.19.19"}
```

That is the exact object `install.sh:76` resolves. Every `curl | sh` install on every platform was 404ing on the asset download, and had been since `gh release create` ran — ~25 minutes before the binaries could have existed. The dispatcher's question ("does a partial failure leave a published release with missing assets?") has an empirical answer: yes, and it was the current state.

## The design

**`npm-publish.yml` loses its `push` trigger.** It is reachable only via `workflow_call` from `release.yml` — as the last job, after the assets are attached **and** `docker-images` is confirmed green for that exact tag+commit — and via `workflow_dispatch` for recovery.

**`release.yml` becomes the orchestrator:**

```
guard ──┐                                    (~1 min: fail fast, and pull an
        │                                     incomplete PUBLISHED release
build ──┴─▶ bundle ──▶ publish ──┐            back to draft)
                    (attach assets)│
images-gate ─────────────────────┬┴─▶ npm (workflow_call → npm-publish.yml)
(waits for docker-images)        │            │
                                 └────────────┴──▶ finalize (un-draft)
```

Plain `needs:` throughout — no `always()`, no `!cancelled()`, no `continue-on-error` anywhere on the chain, because each of those turns an upstream failure into a green publish.

**The GitHub Release is held as a DRAFT until every leg is green.** `/releases/latest` excludes drafts, so an in-flight or failed release leaves the *previous complete* release serving installs instead of breaking them. `finalize` is the only thing that un-drafts, and it re-derives the expected asset set from `install.sh` immediately before flipping the flag rather than trusting the upstream job's verdict. `guard` runs with **no `needs:`** so a release created without `--draft` is pulled back within ~1 minute instead of sitting broken on `latest` for the whole build — and so a missing release fails the run in ~3 minutes rather than after ~25 minutes of macOS runner time.

**Ordering is a convention; the self-gate is the guarantee.** `npm-publish.yml` re-proves both preconditions *from inside its own run* before anything irreversible, so a hand `workflow_dispatch` cannot half-ship either.

## Why not the alternatives

**`workflow_run`** fires regardless of the upstream conclusion and runs against the **default branch's** copy of the workflow file — so the version of the gate that runs is not the version in the tag being released. Rejected.

**Converting `docker-images.yml` to `workflow_call`** is the theoretically cleanest shape and was rejected on a **failure-mode asymmetry**: it also serves every PR and main push and carries the `images-ok` required check, and a reusable-workflow conversion could only be proven correct by cutting a real tag. If any assumption in it were wrong it fails **OPEN** (images mis-tagged, release proceeds). The polling gate's failure mode is **CLOSED** (no matching run ⇒ blocked). On a path that cannot be rehearsed, that decides it.

Note this PR's `uses: ./.github/workflows/npm-publish.yml` does *not* inherit the `workflow_run` hazard: a local `uses:` is resolved from the caller's own ref, so a tag run gets the tag's copy of the called workflow.

## Two pure scripts own every decision, so the shell owns only time

**`scripts/ci/classify-workflow-run.mjs`** — `head_sha` alone is **ambiguous**, verified against the live API rather than reasoned about:

```
$ gh api ".../docker-images.yml/runs?head_sha=0bdb34ec…" --jq '[.workflow_runs[]|{head_branch,conclusion}]'
[{"head_branch":"v0.19.19","conclusion":"success"},{"head_branch":"main","conclusion":"success"}]
```

The tagged commit is also on `main`, so the main-push run shares the SHA — and it does **not** publish `:vX.Y.Z` images. Matching on `head_branch` too is what separates them. The verdict is an **allow-list** on `conclusion === "success"` (GitHub also emits `cancelled`, `timed_out`, `action_required`, `neutral`, `skipped`, `startup_failure`, and `null`), and no-match is **pending, never success** — a wrong assumption fails closed.

**`scripts/ci/assert-release-assets-complete.mjs`** — the expected asset set is **derived from `install.sh`** via the existing `scripts/release-assets.mjs`, never hard-coded, so adding a platform to the installer automatically makes it required at the gate (that drift is the failure class #3633 was about). It uses the **list** endpoint because the by-tag endpoint 404s on drafts — the one state that matters here, also verified live:

```
$ gh api repos/switchroom/switchroom/releases/tags/v0.8.0      # an existing draft
{"message":"Not Found","status":"404"}
$ gh release view v0.8.0 --json tagName,isDraft
{"isDraft":true,"tagName":"v0.8.0"}                            # gh's list fallback does find it
```

Both scripts are node-stdlib only (`loadInstallerContract` imports `yaml` lazily and only on the workflow-parsing path), so they run on a bare checkout before `setup-switchroom`.

## Tested by mutation, because neither workflow runs on a PR

A dropped `needs:`, a re-added `push` trigger or a stray `if: always()` would be **invisible until the next real release**, when the damage is an unpublishable npm version. So the gating itself is asserted:

- **`tests/release-pipeline-gating.test.ts`** — nine rules over the parsed workflows, each proved by weakening a clone until it goes red (13 mutations). Jobs are identified by what they *do* (a step that uploads assets, a step that runs the classifier, a step that un-drafts), not by job id, so a rename cannot silently disable a rule. It also pins the assumptions the design rests on: `release.yml` and `docker-images.yml` both still trigger on `v*`, and the build matrix still uses **native** runners per target (`macos-*` for macOS assets — #3634).
- **`tests/release-gate-scripts.test.ts`** — 35 tests over both scripts, including the main-push-run rejection, the `workflow_dispatch` recovery-run acceptance, all eight non-success conclusions, and the CLI exit codes the gate loops branch on. Empty/garbled payloads exit 2 (pending), never 0.

**Rule R8 pins the script-injection discipline the brief asked to preserve, and extends it:** no `${{ }}` inside any `run:` body in **either** workflow. They hold `contents: write` and `NPM_TOKEN`, and an interpolated expression is materialised into the shell script file on the runner where log masking cannot reach it. `release.yml` already had zero; `npm-publish.yml` had **five, two of them `${{ secrets.NPM_TOKEN }}`** — all now pass through `env:`, with the empty-token guard moved ahead of the `.npmrc` write plus `umask 077` / `chmod 600`.

## Adversarial review

- **Can any leg still run alone?** `npm-publish` no longer can (no trigger; and the self-gate holds on the dispatch path). `docker-images` still can — deliberate, reasoned, and filed as #3685 (image tags are retaggable via `promote.yml`; npm and `/releases/latest` are not).
- **Can a failure be swallowed?** Every `set +e` region captures `$?` and branches explicitly; a `gh api` failure yields an empty payload which classifies as pending, never green. R6 fails the build on `always()` / `cancelled()` / `continue-on-error` anywhere on the chain.
- **Does a re-run of one leg do the right thing?** Re-dispatching `release.yml` is idempotent end-to-end (`--clobber` on upload; `npm-publish` treats "already published" as success; `finalize` re-verifies then un-drafts). Re-running `npm-publish` alone publishes but leaves the release a draft — so the skill now names `release.yml` re-dispatch as *the* recovery command.
- **Lows fixed:** three callers treated "incomplete release" as fatal but the script only emits a `::notice::`, so the failure was unactionable. Each policy caller now emits its own `::error::` with the recovery command (the script stays a classifier, since `guard` legitimately treats incomplete as informational).

## Also in this PR

- **`skills/switchroom-release/SKILL.md`** now **pins an explicit SHA**: `SHA=$(git rev-parse origin/main)` → `gh release create --draft --target "$SHA"` → `git push origin "$SHA:refs/tags/vX.Y.Z"`. `--target main` resolves server-side, and with agents merging PRs in parallel here, a PR landing between the pre-flight check and the create call was silently swallowed into the release. Draft-first also removes the release-doesn't-exist-yet race entirely.
- `CLAUDE.md` and `CHANGELOG.md` updated — including correcting the #3665 entry's now-stale "Known and unchanged by this" paragraph.

## Constraints honoured

No git tags created, no release run triggered, no npm publish, no repo settings or ruleset touched. `package.json`'s `0.18.0` placeholder untouched. `release.yml`'s native-runner property and the `scripts/release-assets.mjs` lint contract both still hold — `npm run lint` is green, including `check-release-asset-names.mjs`, which parses the restructured `release.yml`. `actionlint` clean on both workflows.