### PR TITLE
fix(hindsight): key the pending queue on content, not document_id

### DIFF
--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -53,8 +53,15 @@ of that loop, not of lost memory: a full sweep of 5,751 queued entries on
 this fleet (2026-07-25) found **4,048 (70.4%) already existed as
 documents**, 3,815 of them with facts extracted.
 
-``--backlog`` is therefore a two-phase, out-of-hook replay:
+``--backlog`` is therefore a three-phase, out-of-hook replay:
 
+* **Phase 0 — collapse duplicates (free, no network).** Queued entries
+  sharing ``(bank_id, part_position, sha256(content))`` are the same
+  memory; the redundant copies are archived so the phases below never pay
+  for one memory twice. Measured 2026-07-26: 1,060 queued files across 11
+  agents fell into ~368 distinct groups — ~65% of the queue was duplicate,
+  with one group repeated 32 times. At ~168 s per phase-2 extraction that
+  one group alone was 90 minutes of LLM lane time for a single memory.
 * **Phase 1 — reconcile (free).** GET the document. If it exists, the
   memory is already durable; retire the queue entry without a POST. No
   LLM work, no cost, idempotent, resumable at any point. Only for
@@ -84,7 +91,7 @@ reports the upstream is already slow.
 Standalone usage::
 
     python3 drain_pending.py               # bounded in-hook drain
-    python3 drain_pending.py --backlog     # two-phase backlog replay
+    python3 drain_pending.py --backlog     # three-phase backlog replay
     python3 drain_pending.py --backlog --phase reconcile   # free pass only
     python3 drain_pending.py --backlog --dry-run
 """
@@ -105,6 +112,7 @@ from lib.config import debug_log, load_config
 from lib.pending import (
     MAX_ATTEMPTS,
     archive_reconciled,
+    collapse_duplicates,
     is_content_derived_document_id,
     is_permanent_failure,
     iter_entries,
@@ -531,17 +539,21 @@ def _new_summary() -> dict:
         # so it must not be counted as drained/reconciled, which would
         # report a retire that did not happen.
         "archive_failed": 0,
+        # Redundant copies retired by `pending.collapse_duplicates` before
+        # any network work. Backlog mode only — see `_drain_backlog_impl`.
+        "collapsed": 0,
         "stalled": False,
         "budget_exceeded": False,
     }
 
 
 def drain_backlog(config: dict | None = None, **kw) -> dict:
-    """Two-phase backlog replay, off the SessionStart budget entirely.
+    """Three-phase backlog replay, off the SessionStart budget entirely.
 
     See the module docstring. Summary shape is ``drain()``'s plus
-    ``reconciled`` (already durable — no POST issued) and ``unknown``
-    (presence could not be established; left queued).
+    ``reconciled`` (already durable — no POST issued), ``unknown``
+    (presence could not be established; left queued) and ``collapsed``
+    (redundant duplicate copies archived before any network work).
     """
     return drain(config, backlog=True, **kw)
 
@@ -566,6 +578,7 @@ def drain(
          "unknown": int,   # presence unknown, left queued
          "archive_failed": int,  # durable, but the archive was unwritable
                                  # so the entry is STILL QUEUED
+         "collapsed": int, # duplicate copies archived (backlog mode only)
          "stalled": bool,  # stall guard tripped
          "budget_exceeded": bool}
     """
@@ -784,8 +797,30 @@ def _wait_for_upstream(backoff_ms: int, started: float, budget: float) -> bool:
 def _drain_backlog_impl(
     config: dict, phase: str = "both", dry_run: bool = False
 ) -> dict:
-    """Concurrent-capable, long-budget, two-phase backlog replay."""
+    """Concurrent-capable, long-budget, three-phase backlog replay."""
     summary = _new_summary()
+
+    # PHASE 0 — collapse duplicates (local, free, no network at all).
+    #
+    # Runs FIRST because every later phase is per-entry: a GET in phase 1
+    # and, worse, a ~168 s LLM-backed extraction in phase 2. On the measured
+    # 2026-07-26 fleet backlog ~65% of queued files were byte-identical
+    # copies of another queued file (top group 32x), so skipping this pass
+    # means paying phase 2 up to 32 times over for one memory.
+    #
+    # DELIBERATELY NOT run by the in-hook drain. It reads every queued entry
+    # to recompute identity from content — bounded, but not instant — and
+    # the SessionStart drain's whole contract is a hard wall-clock ceiling
+    # on hook latency. New duplicates cannot accumulate there anyway:
+    # `pending.enqueue`'s filename-keyed guard stops those at the producer.
+    if not dry_run:
+        summary["collapsed"] = collapse_duplicates()
+        if summary["collapsed"]:
+            _blog(
+                f"phase 0: collapsed {summary['collapsed']} duplicate entries "
+                f"(byte-identical content already queued under another entry); "
+                f"archived, not deleted"
+            )
 
     if phase in ("reconcile", "both"):
         _reconcile_phase(config, summary, dry_run)
@@ -935,7 +970,7 @@ def _parse_args(argv: list[str] | None):
     ap.add_argument(
         "--backlog",
         action="store_true",
-        help="two-phase backlog replay, off the SessionStart budget",
+        help="three-phase backlog replay, off the SessionStart budget",
     )
     ap.add_argument(
         "--phase",
@@ -967,6 +1002,7 @@ def main(argv: list[str] | None = None) -> int:
     if any(
         summary[k]
         for k in (
+            "collapsed",
             "drained",
             "retried",
             "dead",
@@ -978,6 +1014,7 @@ def main(argv: list[str] | None = None) -> int:
         print(
             f"[Hindsight] drain_pending{'(backlog)' if args.backlog else ''}: "
             f"drained={summary['drained']} reconciled={summary['reconciled']} "
+            f"collapsed={summary['collapsed']} "
             f"retried={summary['retried']} dead={summary['dead']} "
             f"unknown={summary['unknown']} "
             f"archive_failed={summary['archive_failed']} "

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -83,7 +83,7 @@ it does not get the credit for that number.)
 
 **Same bank + same position in a split + byte-identical content is the
 same memory.** The key is ``(bank_id, part_position, sha256(content))``;
-the rest of ``document_id`` is deliberately NOT in it (switchroom #3691).
+the rest of ``document_id`` is deliberately NOT in it (switchroom #3688).
 Including the whole id made the guard a near-no-op against the producer
 that actually fills this queue: ``subagent_retain.py`` embeds the
 sub-agent's own session id in the document id
@@ -821,7 +821,7 @@ def _dupe_key(entry: dict) -> Optional[str]:
     each other while duplicate re-enqueues of the SAME position still do.
 
     The WHOLE ``document_id`` used to be the key's dominant term and is not
-    any more (switchroom #3691) — see the module docstring for the
+    any more (switchroom #3688) — see the module docstring for the
     measurement that forced it and for the exact cost. Short version: the
     id varies per enqueue for the producer that dominates this queue
     (``subagent_retain.py`` embeds the sub-agent session id), so an

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -70,8 +70,8 @@ bounds disk only to within ~1500x; hence ``MAX_BYTES``. Retain fires
 every 3rd turn and the busiest agent queues ~100 entries/day, so 2000
 entries is ~3 weeks of total upstream outage headroom.
 
-Deduplication
--------------
+Deduplication — the identity is (bank, part position, content)
+--------------------------------------------------------------
 ``reconcile_tail`` re-enqueues the same transcript slice on every boot
 until its watermark is confirmed, so a stalled upstream multiplied one
 memory into dozens of identical files. (The measured 63% / 84.7 MB
@@ -81,9 +81,47 @@ no size index. What follows is the *preventive* guard that stops the
 duplicates accumulating in the first place — a different mechanism, and
 it does not get the credit for that number.)
 
-Same bank + same content-derived ``document_id`` + same content is the
-same memory — the daemon would upsert them onto one document anyway — so
-``enqueue()`` returns the existing path instead of writing a copy.
+**Same bank + same position in a split + byte-identical content is the
+same memory.** The key is ``(bank_id, part_position, sha256(content))``;
+the rest of ``document_id`` is deliberately NOT in it (switchroom #3691).
+Including the whole id made the guard a near-no-op against the producer
+that actually fills this queue: ``subagent_retain.py`` embeds the
+sub-agent's own session id in the document id
+(``{parent}-sub-{agent_id}-r{start}-{end}``), so every SubagentStop
+re-queues a near-identical slice of the SAME parent transcript under a
+FRESH id. Measured on this fleet 2026-07-26: 1,060 queued files across 11
+agents collapsing to ~368 ``(bank_id, part_position, sha256(content))``
+groups (~65% duplicates, top group 32x — 32 distinct document ids over
+one byte-identical 45,000-char part). Keyed with the whole id, the guard
+matched none of them.
+
+The part position (the ``-p{i}of{n}`` index, total discarded) stays in
+the key because a split's parts are not guaranteed to differ from one
+another — repetitive content cut on a character bound yields identical
+parts — and merging those would leave the document missing positions
+upstream. That is content loss, not a redundant copy, so it is not part
+of the trade below. See :func:`_part_position`.
+
+WHAT THIS COSTS, stated exactly. Two *different* documents whose content
+happens to be byte-identical for one part now collapse onto one queue
+entry, so the loser's document can end up missing that part upstream.
+That is a real difference and it is the accepted trade, because the thing
+this queue exists to protect is the MEMORY, not the container: the
+surviving entry carries byte-identical content into the SAME bank, so no
+text and no extractable fact is lost — only the second copy of it. The
+alternative is the measured status quo, where identical text is extracted
+by the LLM 32 times over, at ~168 s a part, for one memory. Collapsing is
+also reversible: ``collapse_duplicates()`` MOVES the loser into the
+bounded ``pending-duplicate/`` archive rather than deleting it.
+
+The filename key only protects entries queued by THIS build. Entries
+already on disk carry the old id-bearing key, so a new enqueue of their
+content computes a different key and never matches them — the safe
+direction (a missed dedupe costs a file, a false one would cost a
+memory), but it leaves the accumulated backlog duplicated.
+``collapse_duplicates()`` closes that: it recomputes the key from CONTENT
+for every live entry, so it is generation-agnostic, and the drain runs it
+before doing any work.
 
 The dedupe key is carried IN THE FILENAME
 (``<unix-ms>-<key>-<uuid>.json``), so a lookup is a prefix match over the
@@ -203,6 +241,16 @@ RECONCILED_MAX_ENTRIES = int(
 )
 RECONCILED_MAX_BYTES = int(
     os.environ.get("HINDSIGHT_PENDING_RECONCILED_MAX_BYTES") or (64 * 1024 * 1024)
+)
+# ``collapse_duplicates`` retires the losing copies here, on the same terms
+# as the other two archives: a collapsed duplicate is byte-identical to an
+# entry that is STILL QUEUED, so this archive is the most redundant of the
+# three — but it is still a MOVE, never a delete.
+DUPLICATE_MAX_ENTRIES = int(
+    os.environ.get("HINDSIGHT_PENDING_DUPLICATE_MAX_ENTRIES") or 500
+)
+DUPLICATE_MAX_BYTES = int(
+    os.environ.get("HINDSIGHT_PENDING_DUPLICATE_MAX_BYTES") or (64 * 1024 * 1024)
 )
 MAX_ATTEMPTS = 5
 
@@ -360,6 +408,13 @@ def reconciled_dir() -> str:
     """
     return os.environ.get("HINDSIGHT_PENDING_RECONCILED_DIR") or _sibling(
         "pending-reconciled"
+    )
+
+
+def duplicate_dir() -> str:
+    """Archive directory for entries retired by ``collapse_duplicates``."""
+    return os.environ.get("HINDSIGHT_PENDING_DUPLICATE_DIR") or _sibling(
+        "pending-duplicate"
     )
 
 
@@ -530,6 +585,96 @@ def archive_reconciled(path: str) -> Optional[str]:
     return dest
 
 
+def archive_duplicate(path: str) -> Optional[str]:
+    """Retire a REDUNDANT queue entry into ``pending-duplicate/``.
+
+    Used only by ``collapse_duplicates()``, and only for an entry whose
+    ``(bank_id, part_position, sha256(content))`` twin is still queued. Like
+    ``archive_reconciled`` this MOVES rather than deletes — the survivor is
+    evidence, not proof, that the content will land, and this module never
+    turns evidence into an irreversible delete.
+
+    Returns the destination path, or ``None`` when the entry could NOT be
+    retired — in which case it is still queued and untouched, and the
+    caller must not count it as collapsed. A concurrent drain that retired
+    the same entry first lands here too (``shutil.move`` raises
+    ``FileNotFoundError``, an ``OSError``), which is why the failure path
+    is a no-op rather than a raise.
+    """
+    dest_dir = duplicate_dir()
+    try:
+        os.makedirs(dest_dir, mode=0o700, exist_ok=True)
+        dest = os.path.join(dest_dir, os.path.basename(path))
+        shutil.move(path, dest)
+    except OSError as e:
+        print(
+            f"[Hindsight] pending: could not archive duplicate "
+            f"{os.path.basename(path)} into {dest_dir} ({e}) — entry STAYS "
+            f"QUEUED (never deleted)",
+            file=sys.stderr,
+        )
+        return None
+    _trim_dir(dest_dir, DUPLICATE_MAX_ENTRIES, DUPLICATE_MAX_BYTES)
+    return dest
+
+
+def collapse_duplicates() -> int:
+    """Collapse entries sharing ``(bank_id, part_position, sha256(content))``.
+
+    Returns the number of redundant copies retired.
+
+    ``enqueue()``'s filename-keyed guard stops NEW duplicates. This is the
+    other half: it recomputes the key from the entry's own CONTENT, so it
+    also collapses entries written by an older build (whose filename key
+    still carries ``document_id`` and therefore never matches) and entries
+    whose duplicate arrived while a drain held them. Generation-agnostic by
+    construction — the filename is not consulted for identity at all.
+
+    SURVIVOR SELECTION is deterministic and durability-first: the copy with
+    the LOWEST ``attempt_count`` wins, ties broken by oldest filename. All
+    copies carry byte-identical content, so any of them delivers the same
+    memory; the one with the most attempts left is the one most likely to
+    get there before ``MAX_ATTEMPTS`` promotes it to ``.dead``. Picking the
+    oldest outright would systematically keep the most-attempted copy —
+    exactly backwards.
+
+    An entry whose key is ``None`` (no ``content``) is never grouped: its
+    identity cannot be established, so it is always kept.
+
+    A copy that cannot be archived stays queued and is NOT counted, so the
+    return value is a count of retires that actually happened.
+    """
+    groups: dict[str, list[tuple[int, str, dict]]] = {}
+    for order, (path, entry) in enumerate(iter_entries()):
+        key = _dupe_key(entry)
+        if not key:
+            continue
+        groups.setdefault(key, []).append((order, path, entry))
+
+    collapsed = 0
+    for key, members in groups.items():
+        if len(members) < 2:
+            continue
+        survivor = min(
+            members,
+            key=lambda m: (int(m[2].get("attempt_count", 1) or 1), m[0]),
+        )
+        for member in members:
+            if member is survivor:
+                continue
+            if archive_duplicate(member[1]) is not None:
+                collapsed += 1
+        print(
+            f"[Hindsight] pending: collapsed {len(members) - 1} duplicate "
+            f"cop{'y' if len(members) == 2 else 'ies'} of key {key} onto "
+            f"{os.path.basename(survivor[1])} (byte-identical content, same "
+            f"bank; the copies are archived under {duplicate_dir()}, not "
+            f"deleted)",
+            file=sys.stderr,
+        )
+    return collapsed
+
+
 def _log_eviction(name: str, size: int, reason: str, depth: int, nbytes: int) -> None:
     line = "%s evicted=%s bytes=%d reason=%s queue_depth=%d queue_bytes=%d" % (
         time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -627,35 +772,86 @@ def _evict_to_fit(d: str, incoming_bytes: int) -> int:
     return evicted
 
 
+_PART_SUFFIX_TAIL_RE = re.compile(r"-p(\d+)of\d+$")
+
+
+def _part_position(entry: dict) -> str:
+    """Where this entry sits inside a split retain, as ``"7"`` / ``"2.1"``.
+
+    ``""`` for an unsplit retain. Read off the ``-p{i}of{n}`` suffix chain
+    that :func:`lib.retain_split.part_document_id` appends, innermost split
+    last, so a re-split part reads ``"2.1"`` (part 1 of part 2).
+
+    Only the INDEX is taken; the total is deliberately discarded. That is
+    what lets the key still collapse the duplicates it exists for: the
+    32-way group measured on this fleet carried ``-p7of15``, ``-p7of16``
+    and ``-p7of18`` over byte-identical content, because the enclosing
+    transcript kept growing while the part itself did not. Keying on the
+    total would have split that group three ways and matched nothing.
+    """
+    doc = entry.get("document_id")
+    if not isinstance(doc, str):
+        return ""
+    indices = []
+    while True:
+        m = _PART_SUFFIX_TAIL_RE.search(doc)
+        if not m:
+            break
+        indices.append(m.group(1))
+        doc = doc[: m.start()]
+    return ".".join(reversed(indices))
+
+
 def _dupe_key(entry: dict) -> Optional[str]:
     """Stable 16-hex identity of a queued retain, or ``None``.
 
-    Derived from ``(bank_id, document_id, sha256(content))``. The CONTENT
-    hash is what makes the key an identity: two entries sharing it carry
-    byte-identical content for the same bank and document, so they are the
-    same memory and the daemon would upsert them onto the same document.
+    Derived from ``(bank_id, part_position, sha256(content))`` and NOTHING
+    ELSE. Two entries sharing this key carry byte-identical content, for
+    the same bank, at the same position inside a split — the same memory,
+    however it got queued and whatever document id the producer stamped on
+    it.
 
-    Do NOT read this as "``document_id`` is content-derived, therefore a
-    matching id means matching content" — that only holds post-#3244
-    (``retain.slice_document_id``); pre-#3244 entries carry a bare session
-    id shared by every retain in that session. Dedupe is safe on either
-    because it hashes the content itself; a *presence GET* is not, which is
-    why that path is gated on ``is_content_derived_document_id``.
+    The part position is in the key because a split's parts are NOT
+    guaranteed to differ from each other: ``split_retain_content`` cuts on
+    a character bound, so highly repetitive content (a long run of
+    identical log lines, a padded transcript) yields byte-identical parts.
+    Without the position, a 10-part memory collapses to a single queued
+    part and the other nine positions never reach the bank — real loss, not
+    a redundant copy. With it, parts of one memory can never merge into
+    each other while duplicate re-enqueues of the SAME position still do.
 
-    ``None`` when there is no ``document_id``: identity cannot be
-    established, so the entry must always be kept rather than merged.
+    The WHOLE ``document_id`` used to be the key's dominant term and is not
+    any more (switchroom #3691) — see the module docstring for the
+    measurement that forced it and for the exact cost. Short version: the
+    id varies per enqueue for the producer that dominates this queue
+    (``subagent_retain.py`` embeds the sub-agent session id), so an
+    id-bearing key never matched a re-enqueue and the queue refilled itself
+    faster than it drained. The part position is the one fragment of the id
+    that survives into the key, and only because dropping it would lose
+    content rather than duplicate it.
+
+    ``None`` when ``content`` is absent: identity cannot be established, so
+    the entry must always be kept rather than merged. An EMPTY string is
+    identity enough — degenerate, but two empty retains into one bank are
+    genuinely the same (non-)memory.
+
+    Nothing else in the entry may enter this key. ``failed_at``,
+    ``error_message``, ``attempt_count`` and ``last_attempt_at`` all drift
+    between the first enqueue and the re-enqueue this guard exists to
+    catch; keying on any of them re-creates the no-op the size pre-filter
+    once was.
     """
-    did = entry.get("document_id")
-    if did is None:
-        return None
     content = entry.get("content")
+    if content is None:
+        return None
     if not isinstance(content, str):
         content = json.dumps(content, ensure_ascii=False, sort_keys=True)
     h = hashlib.sha256()
-    # Length-prefixed so ("ab", "c") and ("a", "bc") cannot collide.
-    for part in (str(entry.get("bank_id")), str(did)):
-        h.update(b"%d:" % len(part))
-        h.update(part.encode("utf-8"))
+    # Length-prefixed so a bank id ending in digits cannot be confused with
+    # the part position that follows it.
+    for field in (str(entry.get("bank_id")), _part_position(entry)):
+        h.update(b"%d:" % len(field))
+        h.update(field.encode("utf-8"))
     h.update(hashlib.sha256(content.encode("utf-8")).digest())
     return h.hexdigest()[:16]
 

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -482,7 +482,7 @@ class DedupeTest(_QueueTempDirMixin, unittest.TestCase):
         """No content => identity cannot be established => never merge.
 
         This used to key off ``document_id``. It does not any more
-        (switchroom #3691): the id varies per enqueue for the producer that
+        (switchroom #3688): the id varies per enqueue for the producer that
         dominates this queue, so it was never a usable identity. Content is.
         """
         p = _payload()
@@ -501,7 +501,7 @@ class DedupeTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(pending.count(), 1)
 
     def test_same_content_under_a_fresh_document_id_is_ONE_entry(self):
-        """THE bug (switchroom #3691), pinned as an outcome.
+        """THE bug (switchroom #3688), pinned as an outcome.
 
         Measured on the live fleet 2026-07-26: 1,060 queued files, ~368
         distinct ``(bank_id, part_position, sha256(content))`` groups. The top

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -253,9 +253,9 @@ class EvictionTest(_QueueTempDirMixin, unittest.TestCase):
     def test_eviction_is_logged_to_the_ledger(self):
         """Eviction is not silent loss, but it IS loss -- doctor reads this."""
         pending.MAX_ENTRIES = 1
-        pending.enqueue(_payload(doc="d0"), RuntimeError("x"))
+        pending.enqueue(_payload(content="m0", doc="d0"), RuntimeError("x"))
         with redirect_stderr(io.StringIO()):
-            pending.enqueue(_payload(doc="d1"), RuntimeError("x"))
+            pending.enqueue(_payload(content="m1", doc="d1"), RuntimeError("x"))
         with open(pending.evictions_log_path(), encoding="utf-8") as f:
             line = f.read().strip()
         self.assertIn("evicted=", line)
@@ -290,7 +290,9 @@ class EvictionTest(_QueueTempDirMixin, unittest.TestCase):
             with unittest.mock.patch.object(pending.time, "time", lambda: next(clock)):
                 with redirect_stderr(io.StringIO()):
                     paths = [
-                        pending.enqueue(_payload(doc=f"d{i}"), RuntimeError("x"))
+                        pending.enqueue(
+                            _payload(content=f"m{i}", doc=f"d{i}"), RuntimeError("x")
+                        )
                         for i in range(5)
                     ]
             evicted_names = [os.path.basename(p) for p in paths[:-1]]
@@ -320,9 +322,9 @@ class EvictionTest(_QueueTempDirMixin, unittest.TestCase):
         prev = (pending.EVICTIONS_LOG_MAX_BYTES, pending.EVICTIONS_LOG_KEEP_LINES)
         pending.EVICTIONS_LOG_MAX_BYTES, pending.EVICTIONS_LOG_KEEP_LINES = 1, 3
         try:
-            pending.enqueue(_payload(doc="d0"), RuntimeError("x"))
+            pending.enqueue(_payload(content="m0", doc="d0"), RuntimeError("x"))
             with redirect_stderr(io.StringIO()):
-                pending.enqueue(_payload(doc="d1"), RuntimeError("x"))
+                pending.enqueue(_payload(content="m1", doc="d1"), RuntimeError("x"))
         finally:
             pending.EVICTIONS_LOG_MAX_BYTES, pending.EVICTIONS_LOG_KEEP_LINES = prev
 
@@ -476,13 +478,340 @@ class DedupeTest(_QueueTempDirMixin, unittest.TestCase):
         pending.enqueue(_payload(bank="bank-b", content="same"), RuntimeError("x"))
         self.assertEqual(pending.count(), 2)
 
-    def test_entry_without_document_id_is_always_kept(self):
-        """No document_id => identity cannot be established => never merge."""
+    def test_entry_without_content_is_always_kept(self):
+        """No content => identity cannot be established => never merge.
+
+        This used to key off ``document_id``. It does not any more
+        (switchroom #3691): the id varies per enqueue for the producer that
+        dominates this queue, so it was never a usable identity. Content is.
+        """
         p = _payload()
-        p.pop("document_id")
+        p.pop("content")
         pending.enqueue(dict(p), RuntimeError("x"))
         pending.enqueue(dict(p), RuntimeError("x"))
         self.assertEqual(pending.count(), 2)
+
+    def test_entry_without_document_id_still_dedupes_on_content(self):
+        """The id is not required for identity — the content carries it."""
+        p = _payload(content="same")
+        p.pop("document_id")
+        a = pending.enqueue(dict(p), RuntimeError("x"))
+        b = pending.enqueue(dict(p), RuntimeError("x"))
+        self.assertEqual(a, b)
+        self.assertEqual(pending.count(), 1)
+
+    def test_same_content_under_a_fresh_document_id_is_ONE_entry(self):
+        """THE bug (switchroom #3691), pinned as an outcome.
+
+        Measured on the live fleet 2026-07-26: 1,060 queued files, ~368
+        distinct ``(bank_id, part_position, sha256(content))`` groups. The top
+        group held
+        32 files carrying ONE byte-identical 45,000-char part under 32
+        DIFFERENT document ids, because ``subagent_retain.py`` stamps the
+        sub-agent's own session id into the id
+        (``{parent}-sub-{agent_id}-r{start}-{end}``) and every SubagentStop
+        mints a new one. With ``document_id`` in the dedupe key not one of
+        those 32 matched, so the queue refilled itself faster than it
+        drained and the same LLM extraction was paid for 32 times.
+
+        Restore ``document_id`` to ``_dupe_key`` and this goes red.
+        """
+        parent = "34c4bbeb-f805-4dd3-b085-46ac2eb57ae9"
+        slice_ids = f"r{_uuid(7)}-{_uuid(8)}"
+        content = "the same sub-agent work log, byte for byte" * 50
+        for agent_id in ("aa2170a03a351e0", "a8857997182e1e9", "a836dfc39b5eb94"):
+            pending.enqueue(
+                _payload(content=content, doc=f"{parent}-sub-{agent_id}-{slice_ids}"),
+                RuntimeError("timed out"),
+            )
+        self.assertEqual(
+            pending.count(),
+            1,
+            "re-enqueuing identical content under a fresh document_id must be "
+            "a no-op, not a new queue entry",
+        )
+
+    def test_the_surviving_entry_keeps_a_usable_document_id(self):
+        """Dedupe must not leave an entry the drain cannot act on."""
+        doc = _cd_doc(3)
+        pending.enqueue(_payload(content="c", doc=doc), RuntimeError("x"))
+        pending.enqueue(_payload(content="c", doc=_cd_doc(4)), RuntimeError("x"))
+        (_, entry), = pending.iter_entries()
+        self.assertEqual(entry["document_id"], doc, "the FIRST entry survives")
+        self.assertTrue(pending.is_content_derived_document_id(entry["document_id"]))
+
+    def test_identical_parts_of_ONE_split_are_never_merged(self):
+        """The parts of a split are positions, not copies.
+
+        ``split_retain_content`` cuts on a character bound, so repetitive
+        content yields byte-identical parts. Merging them would leave the
+        document missing every position but one — content loss, not a
+        redundant copy. Drop ``_part_position`` from the key and this goes
+        red: 10 parts collapse to 1.
+        """
+        pending.MAX_ENTRIES = 20
+        pending.MAX_BYTES = 10**9
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        try:
+            pending.enqueue(
+                _payload(content="z" * 30_000, doc=_cd_doc(5)), RuntimeError("x")
+            )
+        finally:
+            os.environ.pop("HINDSIGHT_RETAIN_MAX_CONTENT_CHARS", None)
+
+        entries = [e for _p, e in pending.iter_entries()]
+        self.assertEqual(len(entries), 10, "one queued entry per position")
+        self.assertEqual(
+            len({e["content"] for e in entries}),
+            1,
+            "fixture check: the parts really are byte-identical",
+        )
+
+    def test_the_same_position_under_a_GROWING_total_still_dedupes(self):
+        """The measured 32x group carried -p7of15, -p7of16 and -p7of18.
+
+        The enclosing transcript kept growing between SubagentStops while
+        part 7 itself did not change. Key on the total as well as the index
+        and that group splits three ways and collapses nothing.
+        """
+        base = _cd_doc(6)
+        for total in (15, 16, 18):
+            pending.enqueue(
+                _payload(content="part-seven", doc=f"{base}-p7of{total}"),
+                RuntimeError("x"),
+            )
+        self.assertEqual(pending.count(), 1, "one memory, one queue entry")
+
+    def test_a_part_position_is_read_off_the_id_not_the_metadata(self):
+        """Entries queued by older builds may carry no part metadata."""
+        self.assertEqual(pending._part_position({"document_id": "abc"}), "")
+        self.assertEqual(pending._part_position({"document_id": "abc-p7of16"}), "7")
+        self.assertEqual(
+            pending._part_position({"document_id": "abc-p2of5-p1of2"}),
+            "2.1",
+            "innermost split reads last",
+        )
+        self.assertEqual(pending._part_position({"document_id": None}), "")
+
+
+class CollapseDuplicatesTest(_QueueTempDirMixin, unittest.TestCase):
+    """``collapse_duplicates`` — the other half of content-keyed identity.
+
+    ``enqueue``'s filename key stops NEW duplicates. It cannot touch the
+    ones already on disk: those were written with the old id-bearing key, so
+    a fresh enqueue of their content computes a different key and never
+    matches them. This pass recomputes identity from CONTENT, which makes it
+    generation-agnostic, and the backlog drain runs it before spending a
+    single LLM call.
+    """
+
+    def _duplicate_names(self):
+        try:
+            return sorted(os.listdir(pending.duplicate_dir()))
+        except OSError:
+            return []
+
+    def _write_legacy(self, name, content, bank="bank-a", doc=None, attempts=1):
+        """Write an entry the way an OLDER build would have named it.
+
+        ``<unix-ms>-<uuid>.json`` with no key segment at all — the shape
+        that predates #3596 — so nothing about the filename can be doing
+        the identity work in these cases.
+        """
+        os.makedirs(self._dir, mode=0o700, exist_ok=True)
+        entry = dict(_payload(bank=bank, content=content, doc=doc or _cd_doc(1)))
+        entry["attempt_count"] = attempts
+        p = os.path.join(self._dir, name)
+        with open(p, "w", encoding="utf-8") as f:
+            json.dump(entry, f)
+        return p
+
+    def test_duplicates_collapse_to_one_live_entry(self):
+        for i in range(5):
+            self._write_legacy(f"{1000 + i:013d}-aaaaaaaaaaa{i}.json", "same-memory")
+        self.assertEqual(pending.count(), 5)
+
+        with redirect_stderr(io.StringIO()):
+            collapsed = pending.collapse_duplicates()
+
+        self.assertEqual(collapsed, 4)
+        self.assertEqual(pending.count(), 1)
+
+    def test_collapse_archives_the_losers_and_never_deletes_them(self):
+        for i in range(3):
+            self._write_legacy(f"{1000 + i:013d}-aaaaaaaaaaa{i}.json", "same-memory")
+
+        with redirect_stderr(io.StringIO()):
+            pending.collapse_duplicates()
+
+        archived = self._duplicate_names()
+        self.assertEqual(len(archived), 2, "losers are MOVED, not removed")
+        for name in archived:
+            with open(os.path.join(pending.duplicate_dir(), name)) as f:
+                self.assertEqual(json.load(f)["content"], "same-memory")
+
+    def test_the_copy_with_the_fewest_attempts_survives(self):
+        """Durability-first survivor selection.
+
+        Every copy carries identical content, so any of them delivers the
+        same memory — but only the one with attempts left can still get
+        there before MAX_ATTEMPTS. Keeping the OLDEST outright would
+        systematically keep the most-attempted copy, which is backwards.
+        """
+        self._write_legacy("0000000001000-aaaaaaaaaaa0.json", "same", attempts=4)
+        keep = self._write_legacy("0000000002000-aaaaaaaaaaa1.json", "same", attempts=1)
+        self._write_legacy("0000000003000-aaaaaaaaaaa2.json", "same", attempts=3)
+
+        with redirect_stderr(io.StringIO()):
+            pending.collapse_duplicates()
+
+        survivors = [p for p, _ in pending.iter_entries()]
+        self.assertEqual(survivors, [keep])
+
+    def test_distinct_memories_are_never_collapsed(self):
+        self._write_legacy("0000000001000-aaaaaaaaaaa0.json", "memory-one")
+        self._write_legacy("0000000002000-aaaaaaaaaaa1.json", "memory-two")
+        self._write_legacy("0000000003000-aaaaaaaaaaa2.json", "memory-three")
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending.collapse_duplicates(), 0)
+        self.assertEqual(pending.count(), 3)
+
+    def test_identical_parts_of_ONE_split_are_never_collapsed(self):
+        """The backlog is full of split parts; do not eat a document's tail.
+
+        A legacy 3-part entry whose parts happen to be byte-identical must
+        survive the sweep intact. Only the position keeps them apart.
+        """
+        base = _cd_doc(2)
+        for i in range(1, 4):
+            self._write_legacy(
+                f"000000000{i}000-aaaaaaaaaaa{i}.json",
+                "zzz",
+                doc=f"{base}-p{i}of3",
+            )
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending.collapse_duplicates(), 0)
+        self.assertEqual(pending.count(), 3, "every position kept")
+        self.assertEqual(self._duplicate_names(), [], "nothing archived")
+
+    def test_the_same_position_from_different_runs_IS_collapsed(self):
+        """The complement: same index, different totals and ids -> one entry."""
+        for i, total in enumerate((15, 16, 18), start=1):
+            self._write_legacy(
+                f"000000000{i}000-aaaaaaaaaaa{i}.json",
+                "zzz",
+                doc=f"{_cd_doc(i)}-p7of{total}",
+            )
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending.collapse_duplicates(), 2)
+        self.assertEqual(pending.count(), 1)
+
+    def test_same_content_in_different_banks_is_never_collapsed(self):
+        self._write_legacy("0000000001000-aaaaaaaaaaa0.json", "same", bank="bank-a")
+        self._write_legacy("0000000002000-aaaaaaaaaaa1.json", "same", bank="bank-b")
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending.collapse_duplicates(), 0)
+        self.assertEqual(pending.count(), 2)
+
+    def test_entries_without_content_are_never_grouped(self):
+        os.makedirs(self._dir, mode=0o700, exist_ok=True)
+        for i in range(2):
+            p = os.path.join(self._dir, f"{1000 + i:013d}-aaaaaaaaaaa{i}.json")
+            e = dict(_payload())
+            e.pop("content")
+            with open(p, "w", encoding="utf-8") as f:
+                json.dump(e, f)
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(pending.collapse_duplicates(), 0)
+        self.assertEqual(pending.count(), 2)
+
+    def test_an_unarchivable_duplicate_stays_queued_and_is_not_counted(self):
+        """Archiving never falls back to a delete, and never over-reports."""
+        for i in range(3):
+            self._write_legacy(f"{1000 + i:013d}-aaaaaaaaaaa{i}.json", "same")
+
+        with unittest.mock.patch.object(
+            pending.shutil, "move", side_effect=OSError("ENOSPC")
+        ):
+            with redirect_stderr(io.StringIO()) as err:
+                collapsed = pending.collapse_duplicates()
+
+        self.assertEqual(collapsed, 0, "a retire that did not happen is not counted")
+        self.assertEqual(pending.count(), 3, "the entries are STILL QUEUED")
+        self.assertIn("STAYS QUEUED", err.getvalue())
+
+    def test_the_duplicate_archive_is_itself_bounded(self):
+        prev = pending.DUPLICATE_MAX_ENTRIES
+        pending.DUPLICATE_MAX_ENTRIES = 2
+        try:
+            for i in range(6):
+                self._write_legacy(f"{1000 + i:013d}-aaaaaaaaaaa{i}.json", "same")
+            with redirect_stderr(io.StringIO()):
+                pending.collapse_duplicates()
+            self.assertLessEqual(len(self._duplicate_names()), 2)
+        finally:
+            pending.DUPLICATE_MAX_ENTRIES = prev
+
+    def test_the_backlog_drain_collapses_before_paying_for_extraction(self):
+        """The user-visible outcome: one memory costs ONE extraction.
+
+        Thirty-two byte-identical copies is what the live queue actually
+        held. At the measured ~168 s per phase-2 extraction, draining them
+        all is ~90 minutes of shared LLM lane time to persist one memory.
+        """
+        for i in range(32):
+            self._write_legacy(f"{1000 + i:013d}-aaaaaaaaaaa{i:02d}.json", "one-memory")
+
+        posted = []
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: bool(posted)
+        ):
+            with unittest.mock.patch.object(
+                drain_pending,
+                "_retry_one",
+                lambda e, timeout: posted.append(e["document_id"]),
+            ):
+                with redirect_stderr(io.StringIO()):
+                    summary = drain_pending.drain_backlog(CONFIG)
+
+        self.assertEqual(summary["collapsed"], 31)
+        self.assertEqual(len(posted), 1, "one memory must cost exactly one retain")
+        self.assertEqual(pending.count(), 0)
+
+    def test_the_in_hook_drain_does_not_collapse(self):
+        """The SessionStart drain's contract is a hard latency ceiling.
+
+        Collapsing reads every queued entry to recompute identity from
+        content; that belongs out of hook. New duplicates cannot accumulate
+        in-hook anyway — ``enqueue``'s filename key stops those.
+        """
+        for i in range(4):
+            self._write_legacy(f"{1000 + i:013d}-aaaaaaaaaaa{i}.json", "same")
+
+        with unittest.mock.patch.object(
+            drain_pending, "_document_state", lambda e, timeout=30: None
+        ):
+            with unittest.mock.patch.object(
+                drain_pending, "_retry_one", lambda e, timeout: None
+            ):
+                with redirect_stderr(io.StringIO()):
+                    summary = drain_pending.drain(CONFIG)
+
+        self.assertEqual(summary["collapsed"], 0)
+        self.assertEqual(len(self._duplicate_names()), 0)
+
+    def test_a_dry_run_collapses_nothing(self):
+        for i in range(3):
+            self._write_legacy(f"{1000 + i:013d}-aaaaaaaaaaa{i}.json", "same")
+        with redirect_stderr(io.StringIO()):
+            summary = drain_pending.drain_backlog(CONFIG, dry_run=True)
+        self.assertEqual(summary["collapsed"], 0)
+        self.assertEqual(pending.count(), 3)
 
 
 class DropLedgerTest(_QueueTempDirMixin, unittest.TestCase):

--- a/vendor/hindsight-memory/tests/test_pending.py
+++ b/vendor/hindsight-memory/tests/test_pending.py
@@ -40,7 +40,7 @@ class PendingQueueTest(unittest.TestCase):
             "bank_id": "test-bank",
             # Distinct per document: the queue's dedupe key is
             # (bank_id, part_position, sha256(content)) since switchroom
-            # #3691, so a shared body would collapse these into one entry.
+            # #3688, so a shared body would collapse these into one entry.
             "content": f"user: hello\nassistant: hi ({document_id})",
             "document_id": document_id,
             "context": "claude-code",

--- a/vendor/hindsight-memory/tests/test_pending.py
+++ b/vendor/hindsight-memory/tests/test_pending.py
@@ -38,7 +38,10 @@ class PendingQueueTest(unittest.TestCase):
             "api_url": "http://fake:9077",
             "api_token": None,
             "bank_id": "test-bank",
-            "content": "user: hello\nassistant: hi",
+            # Distinct per document: the queue's dedupe key is
+            # (bank_id, part_position, sha256(content)) since switchroom
+            # #3691, so a shared body would collapse these into one entry.
+            "content": f"user: hello\nassistant: hi ({document_id})",
             "document_id": document_id,
             "context": "claude-code",
             "metadata": {"session_id": "sess-1"},
@@ -59,7 +62,7 @@ class PendingQueueTest(unittest.TestCase):
         with open(path) as f:
             entry = json.load(f)
         self.assertEqual(entry["bank_id"], "test-bank")
-        self.assertEqual(entry["content"], "user: hello\nassistant: hi")
+        self.assertEqual(entry["content"], self._sample_payload()["content"])
         self.assertEqual(entry["document_id"], "doc-1")
         self.assertEqual(entry["error_class"], "ValueError")
         self.assertEqual(entry["error_message"], "nope")


### PR DESCRIPTION
## Summary

The pending-retains queue was refilling itself faster than it drained. Its dedupe key was `(bank_id, document_id, sha256(content))` — and `document_id` is **not stable across re-enqueues of the same memory**. `subagent_retain.py` stamps the sub-agent's own session id into it (`{parent}-sub-{agent_id}-r{start}-{end}`), so every SubagentStop re-queued a near-identical slice of the *same parent transcript* under a fresh id. The guard matched nothing.

This PR makes queue identity **content-derived and stable**: `(bank_id, part_position, sha256(content))`. A second enqueue of identical content is now a genuine no-op, and a new `collapse_duplicates()` pass cleans up the backlog that accumulated under the old key.

**Job spec:** `reference/jobs/remember-across-sessions.md` — "The agent brings back relevant facts… without the user reminding it." A queue that grows faster than it drains means the memories at the back never become recallable. Advances the **standing-team** vision outcome; crosses no invariant (local, no new egress, no new surface).

## Why — the measurement

Measured across the live fleet on 2026-07-26:

- **1,060 queued files across 11 agents → ~368 distinct `(bank, position, content)` groups.** ~65% of the queue was duplicate.
- **Top group: 32x** — 32 distinct `document_id`s over one byte-identical 45,000-char part (`-p7of15`, `-p7of16`, `-p7of18`; the enclosing transcript kept growing while part 7 did not).
- Phase-2 extraction measured at **~168s per part**, independent of payload size (197-char and 30,000-char parts both ~168s — it is lane wait, not compute). That one 32x group was **90 minutes of saturated LLM lane time for a single memory.**

## What changed

- **`lib/pending.py` — `_dupe_key` is now `(bank_id, part_position, sha256(content))`.** `document_id` is out of the key except for its part index. The two non-hash fields are **length-prefixed** into the digest, so a bank id ending in a digit cannot be confused with the position that follows it.
- **New `_part_position()`** — reads the `-p{i}of{n}` suffix chain off the document id, keeping the **index and discarding the total**. Both halves are load-bearing:
  - *Keeping the index* — `split_retain_content` cuts on a character bound, so repetitive content yields byte-identical parts. Without the position a 10-part memory collapses to one queued part and the other nine positions never reach the bank. That is **content loss**, not a redundant copy. (This was caught by an existing test going red, not by design foresight — see "contradicting evidence" below.)
  - *Discarding the total* — the measured 32x group carried three different totals over identical bytes. Keying on the total splits it three ways and collapses nothing.
- **New `collapse_duplicates()` + `archive_duplicate()`** — recomputes identity from **content**, so it is generation-agnostic and also collapses entries written by older builds (whose filename key still carries the id and can never match). Survivor is the copy with the **lowest `attempt_count`** (ties → oldest), i.e. the one with the most retries left before `MAX_ATTEMPTS`. Losers **MOVE** into a bounded `pending-duplicate/` archive. An unarchivable copy stays queued and is not counted.
- **`drain_pending.py` — new PHASE 0** of `--backlog`, before any network work, because every later phase is per-entry (a GET in phase 1, a ~168s extraction in phase 2). Deliberately **not** run by the in-hook SessionStart drain, which has a hard latency ceiling; new duplicates cannot accumulate there anyway since `enqueue`'s filename guard stops them at the producer.

## The accepted trade, stated exactly

Two *different* documents whose content is byte-identical for one part now collapse onto one queue entry, so the loser's document can end up missing that part upstream. Accepted, because what this queue protects is the **memory**, not the container: the survivor carries byte-identical content into the **same bank**, so no text and no extractable fact is lost — only the second copy of it.

Parts of one split are explicitly **excluded** from this trade by `_part_position` — that case would be real loss.

**On reversibility — corrected from the first draft of this PR (review finding 3).** The original wording said flatly "it is reversible: collapse is a MOVE into `pending-duplicate/`". That overstates it, and materially so at the measured volume. A collapse is reversible **until the archive rolls**, which is not long:

- 1,060 queued files → ~368 groups → **~692 losers archived by a single first run**.
- `DUPLICATE_MAX_ENTRIES` is 500, so `_trim_dir` **deletes ~192 of them inside that same run.**

What *is* guaranteed unconditionally is the part that matters: the survivor of every group **stays queued** and still carries the identical bytes into the identical bank. The archive is a debugging affordance with a short, bounded half-life — not a backup. The docstrings in `lib/pending.py` now say exactly that, with the arithmetic.

## Rollout

This change ships in the **vendored plugin**, not the daemon.

1. **`switchroom apply`** is required. The hindsight plugin is scaffolded into each agent from `vendor/hindsight-memory/` (`src/agents/scaffold.ts:2952-2956`), so an updated binary alone changes nothing inside the containers.
2. **Restart each agent container** afterwards (`docker restart switchroom-<agent>`, or `switchroom agent restart <name>`). The hooks load the plugin at session start.
3. **No `switchroom-hindsight` restart.** Nothing here touches the daemon, its schema, or its HTTP contract — the queue, the archives and the drain are all client-side files under each agent's `~/.hindsight/`. No coordinated fleet restart, no maintenance window.

Host-side (`switchroom doctor`, `hindsight-watch`) picks the new `pending-duplicate/` counter up as soon as the CLI is updated, and reads **0** against agents still running the old plugin — see the forward/backward-compat tests below.

## Review fixes (second commit)

Eight findings, all fixed. No redesign.

| # | Sev | Finding | Fix | Pinned by |
|---|---|---|---|---|
| 1 | MED | Phase 0 unguarded in `_drain_backlog_impl`; one semantically-malformed entry killed the whole backlog drain | `try/except Exception` — log and fall through to the phases that drain | `test_a_failing_phase_0_never_blocks_the_phases_that_drain`, `test_a_malformed_attempt_count_cannot_make_the_backlog_immortal` |
| 2 | MED | `pending-duplicate/` invisible to every monitor; `_trim_dir` wrote no ledger line | doctor probe + `probeSpool` count it; reported as a note, never a verdict; `_trim_dir` ledgers via the new `_append_ledger` | 6 probe tests, 4 doctor tests, `ArchiveTrimLedgerTest` (3) |
| 3 | MED | "archive-never-delete" overstated; `_trim_dir` docstring budgeted a stale 768 MB | reworded to "reversible until the archive rolls" with the arithmetic; budget corrected to 448 MB/agent (was 384) | docs |
| 4 | LOW | doctor promised `--phase reconcile` "costs nothing" — false since phase 0 | **updated doctor's text** (see below) | `does not promise --phase reconcile is free…` |
| 5 | LOW | `_dupe_key` length-prefixing untested | test added (and the finding's own example corrected — see below) | `test_a_bank_id_ending_in_a_digit_never_collapses_into_another_bank`, `test_the_dupe_key_is_field_delimited_not_concatenated` |
| 6 | LOW | `int(... or 1)` untested and wrong for `attempt_count: 0` | extracted `_attempt_count()`: `0` stays `0`; unparseable sorts **last** instead of winning | `test_a_never_attempted_copy_beats_a_once_attempted_older_one`, `test_an_unparseable_attempt_count_is_never_preferred_as_survivor` |
| 7 | LOW | phase-0-before-phase-1 ordering unpinned (32 wasted GETs) | test added, asserting both halves | `test_the_backlog_drain_collapses_before_the_free_reconcile_pass_too` |
| 8 | LOW | CI never ran `vendor/hindsight-memory/tests/` | **widened CI** (see below) | the workflows themselves |

### Finding 4 — why the text changed and not the code

The two options were (a) gate phase 0 on `phase == "both"`, restoring doctor's "costs nothing" promise, or (b) tell the truth about what `--phase reconcile` now costs. **Chose (b).** Gating would:

- reintroduce exactly what phase 0 exists to prevent — a 32x group costs **32 presence GETs** in phase 1 and, worse, up to 32 extractions in phase 2 — for the operator who runs the reconcile pass first;
- mean an operator following **doctor's own remediation** (reconcile first, then drain) gets no collapse on the pass where collapsing pays the most;
- mean `--phase drain`-only operators never collapse at all.

The real cost of not gating is **one extra local queue scan per cycle** — file IO, no network, no LLM — and the second scan finds nothing left to move. Cheaper text beats a more expensive drain. doctor now says "costs no **model** time (presence GETs only, no extraction)… it is not free of local work, and deliberately so", and names phase 0 and `pending-duplicate/`. The test asserts the retired phrasing (`costs nothing`, `is free`) can never come back.

### Finding 5 — the finding's example does not actually collide

Reported rather than force-fitted. The review cited bank `agent-overlord-1` + position `2` vs bank `agent-overlord` + position `12`. Those concatenate to `agent-overlord-12` and `agent-overlord12` — **different strings, no collision.** The hazard is real but needs a bank id ending in a **digit**: `agent-overlord1` + `2` and `agent-overlord` + `12` both concatenate to `agent-overlord12`. The test uses the corrected pair (and says so inline), and it is mutation-verified against a `_dupe_key` with the length prefixes stripped.

### Finding 8 — widened CI rather than moving the assertions

**Chose to widen.** `vendor/hindsight-memory/tests/` was started by no check at all, and an unrun suite does not stay neutral — it rots into a liability. Moving assertions out of it would have papered over that; turning it on fixes the root cause, and it produced its own proof immediately:

- `test_hooks.py::TestRecallHook::test_graceful_on_api_error` was asserting the **pre-#3619** silent-degradation behaviour (`output.strip() == ""`) and had been red on `main`. Fixed here, in the same change, because the gate cannot go green otherwise.
- This PR itself edits a fixture in `tests/test_pending.py` that no gate covered.

Mechanically: the `dorny/paths-filter` list gains `vendor/hindsight-memory/tests/**`, and `ci-tests-python.yml` + `ci-full.yml` each gain a `pip install -q pytest` and a `python3 -m pytest tests/ -q` step. It is pytest and not `unittest discover` because `tests/conftest.py` is what puts `scripts/` on `sys.path`, the suite uses `monkeypatch`/`tmp_path`, and `tests/` has no `__init__.py`. pytest is the only added dependency — same unpinned `pip install -q` shape as `ci-evals.yml`'s `pyyaml`.

### Finding 2 — two hazards the fix had to avoid

- **doctor false-red.** `switchroom doctor` counts ledger lines with `awk '$1 >= c && /evicted=/ {n++}'` and **FAILs** the pending-retains row on any hit. A naive `evicted=` line for an archive trim would have turned every routine collapse into a red memory-loss row. The new line is keyed **`trimmed=`**, with `archive=<name> reason=archive-<count|bytes>`, and a test asserts no trim line can ever contain `evicted=`.
- **watchdog ring reset.** `hindsight-watch`'s `isSample()` rejects a persisted sample missing any **required** field, and `loadState` silently filters the rejects out. Making `Sample.duplicates` required would have discarded the entire persisted rolling window on upgrade — a watchdog with an empty ring reports `no-data` for its first cycles, i.e. goes blind to loss exactly when a change has just been deployed. The field is **optional**, read as `?? 0`, and pinned by `keeps a persisted pre-#3688 window that has no 'duplicates' field`.

### Self-review: a regression the finding-2 fix introduced, and its fix

Found by adversarially re-reading my own diff, not by the review. Ledgering `_trim_dir` puts a **benign, high-volume** channel into the same bounded file as the one channel that means memory is gone — and rotation was a plain tail.

Before #3688 every line in `pending-evictions.log` was an eviction, so "keep the newest `EVICTIONS_LOG_KEEP_LINES` lines" and "keep the newest 2,000 evictions" were the same sentence. Not any more: one `collapse_duplicates` run over the measured backlog writes ~192 `trimmed=` lines, so a tail-rotate lets collapse noise push real `evicted=` lines out of the 7-day window doctor reads. **Adding observability for the benign channel would have removed it for the real one.**

Rotation now fills its keep window **evictions-first**, then tops up with the newest remaining lines — deliberately inside the **same budget** (`EVICTIONS_LOG_KEEP_LINES` total, selected by index so timestamp order survives for doctor's `$1 >= cutoff` awk). A first attempt that re-admitted evictions *on top of* the tail raised the ceiling to 2x and was caught by two **existing** tests (`test_eviction_ledger_trim_keeps_the_NEWEST_lines`, `test_one_byte_over_the_cap_rotates_to_the_keep_window`) — trading a monitoring bug for the unbounded log #3599 bounded. A pure-eviction ledger now rotates exactly as it did before #3688.

`pending-duplicate/` is also deliberately **not** a fourth channel of the `retain-loss` signal. A copy lands there only when a byte-identical twin is *still queued*, so the memory did not leave the queue — its redundant second POST did. Counting it as loss would fire the loss alarm on the healthy outcome, on every collapse, at ~692 at a time. It rides in the totals line as "N collapsed-duplicate (not loss)" instead.

## Test plan

**CI-gated suite** (`vendor/hindsight-memory/scripts/tests/`, `unittest discover`): **688 tests, OK.**
**Sibling suite** (`vendor/hindsight-memory/tests/`, pytest — now gated): **237 passed.** The one pre-existing failure (`test_hooks.py::TestRecallHook::test_graceful_on_api_error`) is fixed here; it was red at merge-base `63182ce51` too.
**vitest** `src/cli/` + `src/hindsight-watch/`: 1,527 passed. The 10 failures in `src/cli/apply.test.ts` are **environmental, not from this PR** — `EROFS` writing to a read-only `~/.switchroom/fleet` mount in the dev container; identical 10 failures at merge-base `63182ce51`.
**`npm run lint`** (includes `tsc --noEmit`): clean.

### Mutation testing

Every load-bearing mechanism reverted one at a time, `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared between runs.

Original change:

| Mutation | Result |
|---|---|
| Restore `document_id` to the key | RED — `test_same_content_under_a_fresh_document_id_is_ONE_entry`, `test_the_same_position_under_a_GROWING_total_still_dedupes`, `test_the_same_position_from_different_runs_IS_collapsed`, +1 |
| Drop `part_position` from the key | RED — `test_identical_parts_of_ONE_split_are_never_merged`, `test_identical_parts_of_ONE_split_are_never_collapsed`, `test_a_split_that_fits_the_count_cap_is_still_queued_per_part` |
| Remove phase 0 from the backlog drain | RED — `test_the_backlog_drain_collapses_before_paying_for_extraction` |
| Invert survivor selection (keep most-attempted) | RED — `test_the_copy_with_the_fewest_attempts_survives` |
| Count a duplicate as collapsed when archiving failed | RED — `test_an_unarchivable_duplicate_stays_queued_and_is_not_counted` |
| Make the duplicate archive unbounded | RED — `test_the_duplicate_archive_is_itself_bounded` |

Review fixes — every new test verified red before its fix. Where the defect was "shipped but untested" rather than "shipped broken", the mutant is named explicitly:

| New test | Verified red against | Failure observed |
|---|---|---|
| `test_a_failing_phase_0_never_blocks_the_phases_that_drain` | parent `aefd3bb16` | `ValueError: invalid literal for int() with base 10: 'many'` |
| `test_a_malformed_attempt_count_cannot_make_the_backlog_immortal` | parent | same `ValueError` — the whole drain dies |
| `test_a_never_attempted_copy_beats_a_once_attempted_older_one` | parent | wrong survivor (`…1000-…0.json` vs `…2000-…1.json`) — `0 or 1` picked the older copy |
| `test_an_unparseable_attempt_count_is_never_preferred_as_survivor` | parent | `ValueError` |
| `test_every_bounded_archive_ledgers_the_copies_it_sheds` | parent | `0 != 9` — no ledger line at all |
| `test_a_trim_can_never_be_counted_as_an_eviction_by_doctor` | parent | `[] is not true` — the trim was never ledgered |
| `test_a_collapsed_duplicate_that_rolls_out_of_the_archive_is_traceable` | parent | `0 != 2` |
| `test_a_bank_id_ending_in_a_digit_never_collapses_into_another_bank` | mutant: length prefixes stripped from `_dupe_key` | `1 != 0` — two banks collapsed into one |
| `test_the_dupe_key_is_field_delimited_not_concatenated` | mutant: same | `'e09d3d3daa5c2e6c' == 'e09d3d3daa5c2e6c'` |
| `test_the_backlog_drain_collapses_before_the_free_reconcile_pass_too` | mutant A: phase 0 gated on `phase == "both"`; mutant B: phase 0 moved after phase 1 | `0 != 31` under both |
| 6 x `probeSpool — pending-duplicate/…` | parent | `duplicates` undefined / archive uncounted |
| 3 x `evaluateRetainLoss` collapsed-count tests | parent | totals line missing the collapsed count |
| `does NOT fire when only the duplicate archive grew` | mutant: `duplicates` promoted to a 4th loss channel | breach on the healthy outcome |
| 5 x `parsePendingRetainsProbeOutput` / 3 x probe-script / 4 x doctor-row tests | parent | `U=` unparsed, note absent |
| `keeps a persisted pre-#3688 window that has no 'duplicates' field` | mutant: `duplicates` made required in `isSample()` | whole ring discarded on load |
| `a fleet with zero duplicates says nothing about them at all` | mutant: `collapsedNote` emitted unconditionally | note leaks onto clean fleets |
| `does not promise --phase reconcile is free…` | parent | the retired "costs nothing" wording still present |
| `test_trim_noise_can_never_push_a_real_eviction_out_of_the_ledger` | mutant: plain tail-rotate | `0 != 5` — every eviction lost |
| ″ | mutant: rotation keeps everything | `2056 not <= 2000` — ledger unbounded |
| `test_the_rotate_still_sheds_trim_lines` | mutant: rotation keeps everything | `2501 != 2000` |

Four pre-existing tests were updated in the first commit, all for the same reason: their fixtures seeded **byte-identical content under different document ids** and relied on the old key to keep them apart (three `EvictionTest` cases could no longer trigger an eviction; `test_iter_entries_ordered_oldest_first` in the sibling suite). Each now seeds distinct content per entry, which is what the real producers do.

## Contradicting evidence, reported rather than force-fitted

The brief framed the duplicates as "a fresh random `document_id` per re-enqueue" and pointed at changing the id's derivation. Two corrections:

1. **The ids are legitimate, not random.** `subagent_retain.py` derives them deterministically; it is the *sub-agent session id inside them* that differs per SubagentStop while the transcript slice does not. Changing `slice_document_id` would break `is_content_derived_document_id`'s regex (and with it the free presence-GET reconcile) and orphan every already-durable document's id. So the fix is scoped to the **queue's identity key**, not to `document_id`. Nothing about document ids upstream changes.
2. **Pure content-keying is unsafe, and an existing test proved it.** `test_a_split_that_fits_the_count_cap_is_still_queued_per_part` went red at `1 != 10` with a content-only key: `"z" * 30_000` splits into ten byte-identical parts. That is why `_part_position` is in the key. The brief's "make identity content-derived" is right; "content alone" would have shipped silent content loss on repetitive transcripts.

A third, from the review round: **finding 5's collision example does not collide** (see above).

## Risk

Low. Local-only, no new network surface, no config change. The one behavioural change is fewer queue entries for identical content. Backwards-compatible in the safe direction: old-key entries simply never match a new enqueue (a missed dedupe costs a file; a false one would cost a memory), and `collapse_duplicates` cleans them up from content. Concurrent drains are safe — a lost `shutil.move` race raises `FileNotFoundError`, which is handled as a no-op, not a raise.

The host-side monitoring additions are strictly additive and version-skew-safe in both directions: an old CLI ignores the archive, and a new CLI reads a missing `pending-duplicate/` or an absent `U=` as **0** rather than as an error (a probe error would make the whole agent read `unreachable` and blind doctor to real backlogs). Both directions have tests.

**Does not** address the second half of the problem (nothing drains on a schedule) — that is a separate PR.
