### PR TITLE
feat(hindsight): drain the retain queue on a schedule, serialised per agent

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -458,6 +458,86 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   fi
 {{/if}}
 
+{{#if hindsightEnabled}}
+  # 5) hindsight backlog drain — the memory queue's only real consumer.
+  #
+  #    WHY THIS EXISTS. `pending-retains` is written whenever a retain
+  #    fails, but before this the ONLY automatic thing that drained it was
+  #    the SessionStart hook (`session_start.py`), which runs once per
+  #    session boot under a hard ~9s latency budget against work measured
+  #    at 85-280s per entry. So an agent that simply stays up never drained
+  #    at all: on this fleet 8 of 11 agents had not drained a single entry
+  #    and the queue reached 1,060 files. A memory sitting in that queue is
+  #    a memory the agent cannot recall — the job this feature exists for.
+  #
+  #    A sidecar, not a cron entry: cron fires cost a model turn and depend
+  #    on the agent remembering to keep the entry. This is a deterministic
+  #    mechanism — it runs because the container is up, needs no LLM turn of
+  #    its own, and cannot be prompted away.
+  #
+  #    SERIALISED. `flock -n` on a per-agent lockfile makes overlapping runs
+  #    impossible: a run that overshoots the interval causes the next tick to
+  #    SKIP, never to stack. The lock path is deliberately the one the
+  #    out-of-band recovery tooling also takes, so a manual sweep and this
+  #    loop mutually exclude instead of double-processing an entry.
+  #
+  #    LANE-RESPECTING. Retain extraction is served by a small fixed pool of
+  #    LLM lanes (4 on this fleet, 2 boxes x 2 slots) SHARED with live
+  #    retains, reflect and consolidation, already near saturation. So:
+  #    `HINDSIGHT_DRAIN_CONCURRENCY` is left at its default of 1 (one
+  #    in-flight POST per agent — do not raise it here), `drain_pending`'s
+  #    own inter-retain sleep and p95 backoff still apply, and the first
+  #    tick is delayed by a per-agent offset derived from the agent NAME so
+  #    the fleet does not all wake together. The offset is a `cksum` of the
+  #    name modulo the interval: deterministic (same agent, same offset,
+  #    every boot) and evenly spread, with no shared coordinator.
+  #    HONEST LIMIT: N agents x 1 lane still exceeds 4 lanes when every
+  #    agent has a backlog. The offset spreads the START times; it does not
+  #    cap fleet-wide demand. Sustained oversubscription is absorbed by the
+  #    p95 backoff, and the real fix is more lanes.
+  #
+  #    Failure is never terminal: the drain exits non-zero only when it
+  #    promoted entries to `.dead`, and the loop below ignores the status
+  #    and waits for the next tick. `--backlog` reads api_url/token/bank
+  #    from each queue ENTRY, so this sidecar needs no HINDSIGHT_* env
+  #    (those are exported later, in the inner pass) — only $HOME, to find
+  #    the queue.
+  #
+  #    Kill switch: SWITCHROOM_HINDSIGHT_DRAIN=0 at the container level.
+  #    Interval: SWITCHROOM_HINDSIGHT_DRAIN_INTERVAL_S (default 900s).
+  _hs_drain_script="{{agentDir}}/.claude/plugins/hindsight-memory/scripts/drain_pending.py"
+  if [ "$SWITCHROOM_HINDSIGHT_DRAIN" != "0" ] \
+     && [ -f "$_hs_drain_script" ] \
+     && command -v python3 >/dev/null 2>&1 \
+     && command -v flock >/dev/null 2>&1; then
+    _switchroom_hindsight_drain_loop() {
+      local _script="$1"
+      local _interval="${SWITCHROOM_HINDSIGHT_DRAIN_INTERVAL_S:-900}"
+      # Reject a non-numeric or too-eager interval rather than busy-looping
+      # against the LLM lane. 60s is the floor.
+      case "$_interval" in ''|*[!0-9]*) _interval=900 ;; esac
+      [ "$_interval" -lt 60 ] && _interval=60
+      local _lock="$HOME/.hindsight/drain.lock"
+      mkdir -p "$HOME/.hindsight" 2>/dev/null || true
+      # Deterministic per-agent phase offset (see the note above).
+      local _offset=0
+      if command -v cksum >/dev/null 2>&1; then
+        _offset=$(( $(printf '%s' "{{name}}" | cksum | cut -d' ' -f1) % _interval ))
+      fi
+      echo "[hindsight-drain] starting: interval=${_interval}s offset=${_offset}s lock=${_lock}"
+      sleep "$_offset"
+      while true; do
+        # -n: if a drain (ours or an operator sweep) already holds the
+        # lock, skip this tick entirely instead of queueing behind it.
+        flock -n "$_lock" python3 "$_script" --backlog || true
+        sleep "$_interval"
+      done
+    }
+    _switchroom_supervise hindsight-drain /var/log/switchroom/hindsight-drain.log \
+      _switchroom_hindsight_drain_loop "$_hs_drain_script" &
+  fi
+{{/if}}
+
   export SWITCHROOM_DOCKER_TMUX_INNER=1
   exec tmux -L "switchroom-{{name}}" \
     new-session -A -s "{{name}}" -x 400 -y 50 \

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -496,6 +496,27 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   #    cap fleet-wide demand. Sustained oversubscription is absorbed by the
   #    p95 backoff, and the real fix is more lanes.
   #
+  #    WHY NO `HINDSIGHT_DRAIN_BACKLOG_TIMEOUT` HERE, given the measurement.
+  #    A host-side stopgap measured, on the SHIPPED defaults:
+  #      timeout=310 conc=1, busy lane  ->  drained 0 of 2
+  #      timeout=310 conc=3, FREE lane  ->  drained 0 of 3, stalled
+  #      timeout=900 conc=1, free lane  ->  drained 5 of 5
+  #    It failed on an IDLE lane, so scheduling and contention were never the
+  #    whole story. The reading that matters is the third row's concurrency,
+  #    not its timeout: raising concurrency made it WORSE, which is why 1 is
+  #    the value above and is not a knob this sidecar exposes.
+  #    The timeout is deliberately left DERIVED rather than pinned at 900.
+  #    `_backlog_timeout()` defaults to `retain_client_deadline()` and the
+  #    content bound is sized against that same number — they must stay one
+  #    number, and hard-coding 900 here would silently unpick that. What
+  #    those runs actually measured was the bound consuming ~100% of the
+  #    deadline, so a maximally-sized part could never finish; that is fixed
+  #    at its root in #3693 (the bound is now a FRACTION of the deadline),
+  #    which brings a max part to 202s inside a 310s deadline. Entries
+  #    already queued ABOVE the current bound are recovered by re-splitting
+  #    them, not by waiting longer. An operator who still wants a longer
+  #    deadline moves HINDSIGHT_RETAIN_CLIENT_DEADLINE_S, which moves both.
+  #
   #    Failure is never terminal: the drain exits non-zero only when it
   #    promoted entries to `.dead`, and the loop below ignores the status
   #    and waits for the next tick. `--backlog` reads api_url/token/bank

--- a/tests/hindsight-drain-sidecar.test.ts
+++ b/tests/hindsight-drain-sidecar.test.ts
@@ -1,0 +1,293 @@
+/**
+ * The hindsight backlog drain sidecar (start.sh.hbs block 5).
+ *
+ * WHY: `pending-retains` had exactly one automatic consumer — the
+ * SessionStart hook, once per session boot, under a ~9s latency budget
+ * against work measured at 85-280s per entry. An agent that simply stays up
+ * never drained. Measured on the fleet 2026-07-26: 8 of 11 agents had
+ * drained nothing and the queue reached 1,060 files. A memory stuck in that
+ * queue is a memory the agent cannot recall
+ * (reference/jobs/remember-across-sessions.md).
+ *
+ * These tests execute the REAL shell function lifted out of the template
+ * against real `flock`, and assert OUTCOMES: that a run cannot be
+ * overlapped, that a failing run does not end the drain for the container's
+ * life, and that the fleet does not wake in lockstep against a 4-slot LLM
+ * lane.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+const TEMPLATE = join(__dirname, "..", "profiles", "_base", "start.sh.hbs");
+const SRC = readFileSync(TEMPLATE, "utf-8");
+
+/**
+ * Lift the pure-shell loop out of the template and bind the one handlebars
+ * token in its body ({{name}}) to a caller-supplied agent name. Asserting
+ * that {{name}} is the ONLY token keeps this harness representative of what
+ * actually renders — a second token appearing would make these tests lie.
+ */
+function extractLoop(agentName: string): string {
+  const lines = SRC.split("\n");
+  const start = lines.findIndex((l) =>
+    l.includes("_switchroom_hindsight_drain_loop() {"),
+  );
+  expect(
+    start,
+    "_switchroom_hindsight_drain_loop() not found in start.sh.hbs",
+  ).toBeGreaterThanOrEqual(0);
+  let end = -1;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i] === "    }") {
+      end = i;
+      break;
+    }
+  }
+  expect(end, "closing brace of the drain loop not found").toBeGreaterThan(start);
+  const fn = lines
+    .slice(start, end + 1)
+    .map((l) => l.replace(/^ {4}/, ""))
+    .join("\n");
+  expect(fn.match(/\{\{[^}]+\}\}/g) ?? []).toEqual(["{{name}}"]);
+  return fn.replaceAll("{{name}}", agentName);
+}
+
+// Sandbox under the repo, NOT os.tmpdir(): these tests exec a stub `python3`
+// off PATH, and /tmp is mounted `noexec` in the agent container (and on some
+// CI images). A noexec sandbox silently falls through to the REAL python3,
+// which makes the loop tests pass for the wrong reason. `.test-tmp/` is
+// already gitignored.
+let root: string;
+
+beforeAll(() => {
+  const base = join(__dirname, "..", ".test-tmp");
+  mkdirSync(base, { recursive: true });
+  root = mkdtempSync(join(base, "hs-drain-sidecar-"));
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+interface Scenario {
+  agentName?: string;
+  interval?: string;
+  /** exit status of the stub drain */
+  exitCode?: number;
+  /** hold the drain lock for the whole run, as a concurrent sweep would */
+  holdLock?: boolean;
+  /** shell prologue injected after the loop is defined (e.g. a sleep stub) */
+  prologue?: string;
+  /** how long the loop is allowed to run, in seconds */
+  runFor?: number;
+}
+
+/** Run the real loop in a sandbox and report what it did. */
+function run(s: Scenario): { runs: number; stdout: string; argv: string[] } {
+  const home = mkdtempSync(join(root, "home-"));
+  mkdirSync(join(home, ".hindsight"), { recursive: true });
+  const runsDir = join(home, "runs");
+  mkdirSync(runsDir);
+  writeFileSync(join(home, "drain_pending.py"), "# stub\n");
+
+  // Stand in for python3 on PATH: records every invocation, then exits.
+  const py = join(home, "python3");
+  writeFileSync(
+    py,
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" > "$RUNS_DIR/$(date +%s%N)"\nexit ${s.exitCode ?? 0}\n`,
+  );
+  chmodSync(py, 0o755);
+
+  const lockHold = s.holdLock
+    ? `exec 9>"$HOME/.hindsight/drain.lock"\nflock -n 9 || { echo "harness could not take the lock"; exit 99; }\n`
+    : "";
+
+  const harness = join(home, "harness.sh");
+  writeFileSync(
+    harness,
+    `#!/usr/bin/env bash
+set -u
+export PATH="${home}:$PATH"
+${extractLoop(s.agentName ?? "klanker")}
+${s.prologue ?? ""}
+${lockHold}
+_switchroom_hindsight_drain_loop "${join(home, "drain_pending.py")}" &
+_loop=$!
+command sleep ${s.runFor ?? 1}
+kill -9 $_loop 2>/dev/null
+exit 0
+`,
+  );
+  chmodSync(harness, 0o755);
+
+  const stdout = execFileSync("bash", [harness], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      HOME: home,
+      RUNS_DIR: runsDir,
+      SWITCHROOM_HINDSIGHT_DRAIN_INTERVAL_S: s.interval ?? "",
+    },
+    timeout: 20_000,
+  });
+  const names = readdirSync(runsDir);
+  return {
+    runs: names.length,
+    stdout,
+    argv: names.map((n) => readFileSync(join(runsDir, n), "utf-8").trim()),
+  };
+}
+
+/** Collapse the loop's own waits so a 15-minute cadence is testable in ~1s. */
+const FAST = "sleep() { command sleep 0.05; }";
+/** Stop the loop at its very first wait — enough to read the announced config. */
+const HALT_AT_FIRST_SLEEP = "sleep() { exit 0; }";
+
+describe("hindsight drain sidecar — structure", () => {
+  it("the whole block sits inside {{#if hindsightEnabled}}, so a memory-less agent's start.sh is unchanged", () => {
+    const lines = SRC.split("\n");
+    const marker = lines.findIndex((l) => l.includes("5) hindsight backlog drain"));
+    expect(marker, "block 5 not found").toBeGreaterThan(0);
+    let open = -1;
+    for (let i = marker; i >= 0; i--) {
+      if (lines[i].includes("{{#if")) {
+        open = i;
+        break;
+      }
+    }
+    expect(lines[open]).toBe("{{#if hindsightEnabled}}");
+    let close = -1;
+    for (let i = marker; i < lines.length; i++) {
+      if (lines[i] === "{{/if}}") {
+        close = i;
+        break;
+      }
+    }
+    expect(close, "guard not closed").toBeGreaterThan(marker);
+    const outside = lines.slice(0, open).concat(lines.slice(close + 1)).join("\n");
+    expect(outside).not.toContain("hindsight-drain");
+    expect(outside).not.toContain("_switchroom_hindsight_drain_loop");
+    expect(outside).not.toContain("drain_pending.py");
+  });
+
+  it("is supervised WITHOUT --oneshot-ok, so a crash self-heals and a clean exit still restarts", () => {
+    const line = SRC.split("\n").find((l) =>
+      l.includes("_switchroom_supervise hindsight-drain"),
+    );
+    expect(line, "the drain is not supervised").toBeTruthy();
+    expect(line!).toContain("/var/log/switchroom/hindsight-drain.log");
+    expect(line!).not.toContain("--oneshot-ok");
+  });
+
+  it("does not raise drain concurrency — the 4-slot LLM lane is shared and near-saturated", () => {
+    const block = SRC.slice(
+      SRC.indexOf("5) hindsight backlog drain"),
+      SRC.indexOf("SWITCHROOM_DOCKER_TMUX_INNER=1"),
+    );
+    expect(block).not.toMatch(/HINDSIGHT_DRAIN_CONCURRENCY=/);
+  });
+
+  it("the sidecar region is valid bash", () => {
+    const from = SRC.indexOf("  _hs_drain_script=");
+    const to = SRC.indexOf("{{/if}}", from);
+    expect(from).toBeGreaterThan(0);
+    const block = SRC.slice(from, to)
+      .replaceAll("{{agentDir}}", "/state/agent")
+      .replaceAll("{{name}}", "klanker");
+    expect(block).not.toContain("{{");
+    const f = join(root, "syntax.sh");
+    writeFileSync(f, `#!/usr/bin/env bash\n_switchroom_supervise() { :; }\n${block}\n`);
+    expect(() => execFileSync("bash", ["-n", f])).not.toThrow();
+  });
+});
+
+describe("hindsight drain sidecar — behaviour", () => {
+  it("drains again and again — a single boot-time pass is what left 8 of 11 agents at zero", () => {
+    const { runs } = run({ prologue: FAST, runFor: 1 });
+    expect(runs, "the loop must keep ticking").toBeGreaterThan(2);
+  });
+
+  it("invokes the drain in --backlog mode, not the 4-second in-hook mode", () => {
+    // Without --backlog the script runs the SessionStart drain: a ~4s total
+    // budget against ~168s per entry, i.e. the do-nothing path this sidecar
+    // exists to replace.
+    const { argv } = run({ prologue: FAST, runFor: 1 });
+    expect(argv.length).toBeGreaterThan(0);
+    for (const line of argv) {
+      expect(line).toMatch(/drain_pending\.py --backlog$/);
+    }
+  });
+
+  it("CANNOT overlap a drain that is already running — the tick skips instead of stacking", () => {
+    // Same outcome as a long run overshooting the interval: the lock is
+    // held, so no second drain may start. Without `flock -n` in the loop
+    // this window would see a dozen concurrent drains.
+    const { runs } = run({ prologue: FAST, holdLock: true, runFor: 1 });
+    expect(runs, "no drain may start while the lock is held").toBe(0);
+  });
+
+  it("keeps draining after a non-zero exit — `dead` entries are an outcome, not a reason to stop", () => {
+    // drain_pending exits 1 when it promoted entries to `.dead`. Treating
+    // that as fatal would silently end the drain for the container's life.
+    const { runs } = run({ prologue: FAST, exitCode: 1, runFor: 1 });
+    expect(runs).toBeGreaterThan(2);
+  });
+
+  it("staggers the fleet with a deterministic per-agent offset", () => {
+    const offsets = new Map<string, number>();
+    for (const name of ["klanker", "reggie", "marko", "overlord", "fable"]) {
+      const first = run({
+        agentName: name,
+        interval: "900",
+        prologue: HALT_AT_FIRST_SLEEP,
+        runFor: 1,
+      });
+      const m = first.stdout.match(/offset=(\d+)s/);
+      expect(m, `no offset announced for ${name}: ${first.stdout}`).not.toBeNull();
+      const again = run({
+        agentName: name,
+        interval: "900",
+        prologue: HALT_AT_FIRST_SLEEP,
+        runFor: 1,
+      });
+      expect(
+        again.stdout.match(/offset=(\d+)s/)![1],
+        "the same agent must get the same offset on every boot",
+      ).toBe(m![1]);
+      offsets.set(name, Number(m![1]));
+      expect(Number(m![1])).toBeLessThan(900);
+    }
+    expect(
+      new Set(offsets.values()).size,
+      `offsets collapsed, the fleet would stampede: ${JSON.stringify([...offsets])}`,
+    ).toBeGreaterThan(3);
+  });
+
+  it("clamps a bogus or too-eager interval instead of hammering the lane", () => {
+    const cases: Array<[string, number]> = [
+      ["", 900],
+      ["abc", 900],
+      ["0", 60],
+      ["5", 60],
+      ["1200", 1200],
+    ];
+    for (const [given, want] of cases) {
+      const { stdout } = run({
+        interval: given,
+        prologue: HALT_AT_FIRST_SLEEP,
+        runFor: 1,
+      });
+      expect(stdout, `interval ${JSON.stringify(given)}`).toContain(`interval=${want}s`);
+    }
+  });
+}, 60_000);

--- a/tests/hindsight-drain-sidecar.test.ts
+++ b/tests/hindsight-drain-sidecar.test.ts
@@ -197,6 +197,21 @@ describe("hindsight drain sidecar — structure", () => {
     expect(block).not.toMatch(/HINDSIGHT_DRAIN_CONCURRENCY=/);
   });
 
+  // The measured `timeout=900 conc=1 -> drained 5 of 5` result is real, but
+  // the durable reading of it is that the CONTENT BOUND consumed the whole
+  // deadline (#3693), not that the drain should wait three times as long.
+  // `_backlog_timeout()` and `retain_content_limit()` are derived from ONE
+  // number on purpose; pinning a literal here would silently unpick that and
+  // size a max part against a deadline nothing else in the system knows about.
+  it("does not pin a drain timeout — it stays derived from the retain client deadline", () => {
+    const block = SRC.slice(
+      SRC.indexOf("5) hindsight backlog drain"),
+      SRC.indexOf("SWITCHROOM_DOCKER_TMUX_INNER=1"),
+    );
+    expect(block).not.toMatch(/HINDSIGHT_DRAIN_BACKLOG_TIMEOUT=/);
+    expect(block).not.toMatch(/HINDSIGHT_RETAIN_CLIENT_DEADLINE_S=/);
+  });
+
   it("the sidecar region is valid bash", () => {
     const from = SRC.indexOf("  _hs_drain_script=");
     const to = SRC.indexOf("{{/if}}", from);


### PR DESCRIPTION
## Summary

Nothing was draining the memory queue. `pending-retains` had exactly **one** automatic consumer — the SessionStart hook (`vendor/hindsight-memory/scripts/session_start.py:125-127`), which runs once per session boot under a hard ~9s latency budget, against work measured at **85-280s per entry**. An agent that simply stays up never drained at all.

Measured on this fleet 2026-07-26: **8 of 11 agents had drained nothing, and the queue reached 1,060 files.** A memory sitting in that queue is a memory the agent cannot recall.

This adds a fifth supervised sidecar to `start.sh` — `hindsight-drain` — that runs the backlog drain periodically, without spending a model turn, and moves the serialisation that makes concurrent drains safe **into `drain_pending.py`**, where every drain path inherits it.

**Job spec:** `reference/jobs/remember-across-sessions.md` — "The agent brings back relevant facts, preferences, decisions, and open threads from past conversations… without the user reminding it." Its stakes clause is exactly the failure here: memory that never lands means the relationship never compounds. Advances the **standing-team** vision outcome; crosses no invariant (no new egress, no new surface, no model call).

## What changed

- **`profiles/_base/start.sh.hbs`** — the `hindsight-drain` sidecar, entirely inside `{{#if hindsightEnabled}}`. An agent without memory renders byte-identically to before.
- **`vendor/hindsight-memory/scripts/drain_pending.py`** — the drain lock, and a per-entry circuit breaker.
- **`src/cli/doctor.ts`** — the backlog remediation now tells the operator the documented command is serialised, and how not to break that.

### The sidecar

- **Periodic, not boot-only.** Default 900s, floor 60s, `SWITCHROOM_HINDSIGHT_DRAIN_INTERVAL_S` to change it, `SWITCHROOM_HINDSIGHT_DRAIN=0` to disable.
- **The interval is a COOLDOWN BETWEEN RUNS, not a fixed period.** The loop is strictly sequential (`drain; sleep $interval`), so true tick-to-tick spacing is one drain's duration — up to the 3600s backlog budget — *plus* the interval. Deliberate: a fixed period would give a long, lane-heavy drain no cooldown at all. There is no "next tick" to stack or skip, because a tick cannot start while the previous one is running. (An earlier revision of this description claimed the next tick "skips, never stacks" — that described a `flock`-guarded fixed timer, which is not what this loop is.)
- **Lane-respecting.** Retain extraction is served by 4 shared LLM slots (2 boxes x 2), already ~100% saturated at ~1,450 calls/hr, and duration is independent of payload size (197-char parts averaged 168.1s; 30,000-char parts 166.5s — that is queue wait, not compute). So: `HINDSIGHT_DRAIN_CONCURRENCY` stays at its default of **1**, `drain_pending`'s own inter-retain sleep and p95 backoff still apply, and the first tick is delayed by a **deterministic per-agent offset** (`cksum` of the agent name mod the interval) so the fleet does not wake in lockstep. **Honest limit, documented at the call site:** N agents x 1 lane still exceeds 4 lanes when everyone has a backlog. The offset spreads start times; it does not cap fleet-wide demand.
- **Never silent.** If a precondition fails, an `else` branch names *which* one, on stdout and in `/var/log/switchroom/hindsight-drain.log`. Previously a failed precondition produced no line and no logfile, so "is the drain running?" was unanswerable from the logs and looked identical to "running, nothing to do".
- **`${SWITCHROOM_HINDSIGHT_DRAIN:-1}`**, not the bare variable — house style, and one `set -u` away from aborting boot for every hindsight agent otherwise.
- **Deterministic mechanism, not prompt discipline.** It runs because the container is up. No model turn, no cron entry to forget, nothing an agent can talk itself out of.
- **Supervised without `--oneshot-ok`** — a crash self-heals through the existing backoff, and a clean exit is abnormal and restarts.
- **Needs no `HINDSIGHT_*` env.** `--backlog` reads `api_url` / `api_token` / `bank_id` from each queue *entry*, which matters because the sidecar forks in the OUTER shell pass, before those vars are exported. Verified live: `env -i HOME=/state/agent/home PATH=/usr/bin:/bin python3 drain_pending.py --backlog --phase reconcile --dry-run` inside a real agent container returned `phase 1 done: 1 already durable`.
- **HONEST LIMIT — docker runtime only.** The block sits inside the `[ "$SWITCHROOM_RUNTIME" = "docker" ]` branch, so an agent on the legacy systemd path gets no drain sidecar and keeps the boot-only SessionStart behaviour. The fleet is entirely docker; if systemd ever comes back this needs an equivalent timer. Stated at the call site rather than left silently absent.

### Serialisation — now inside `drain_pending.py`

Two drains walking one queue is not a tidiness problem: it is the same ~168s of a 4-slot fleet-wide resource, spent twice, for one memory.

The queue has **three independent drain paths**, and a lock wrapped around only one of them serialises nothing:

1. `session_start.py` imports `drain` and calls it **in-process** at every session boot, with no lock of its own — and a session booting while the sidecar is mid-backlog is the ordinary case, not a corner;
2. this sidecar;
3. the out-of-band `docker exec … drain_pending.py --backlog` that `switchroom doctor` documents for operators.

So the lock is taken **inside `drain()`** — the one function all three go through. `_exclusive_drain()` holds an `fcntl.flock(LOCK_EX|LOCK_NB)` on `$HOME/.hindsight/drain-pending.lock` for the whole run; a drain that finds it held does nothing at all and returns a zero summary with `skipped_locked=True`. It never queues behind the holder: every caller has a next tick, none has time to wait. If the lock file cannot even be opened (read-only `.hindsight/`) the drain proceeds **without** serialisation and says so loudly on stderr — losing serialisation costs duplicated LLM work, losing the drain costs the memory itself.

Two deliberate consequences:

- **The sidecar does NOT wrap the call in `flock`, and must not.** An outer `flock` would hold the very lock the python then asks for, and the drain would skip every tick, silently, forever. `tests/hindsight-drain-sidecar.test.ts` fails if one reappears.
- **The lock file is `drain-pending.lock`, deliberately NOT the `drain.lock` the interim host stopgap wraps its `docker exec` in** — for exactly the same reason. With distinct names that wrapper stays merely redundant instead of starving the drain it just launched.

### Circuit breaker — unattended means bounded

`is_permanent_failure` keeps an entry queued past `MAX_ATTEMPTS` on anything but a 4xx, and `_over_budget`/`_drain_order` demote it so it cannot starve healthy entries. Both are right, and together they bound head-of-line blocking — but not *total* work: the entry was still retried in full on every run, forever.

That was affordable when every drain was supervised. This sidecar makes it unaffordable: a 3600s backlog budget against a 900s cooldown means a wedged agent spends ~80% of wall-clock draining, unattended, against 4 lanes shared with live retains, reflect and consolidation. The interim host stopgap recorded exactly that shape while it ran (`finn 280s drained=0 retried=3 STALLED`, `carrie 564s drained=0 retried=2 (lane busy)`).

An entry at or past `_attempt_ceiling()` — default `MAX_ATTEMPTS * 4` = 20, tunable via `HINDSIGHT_DRAIN_ATTEMPT_CEILING`, clamped up to never fire below `MAX_ATTEMPTS` — is now **parked**. Parking is not retirement: the entry stays on disk, is never promoted to `.dead`, is still swept for free by the reconcile pass, and comes back in full under the new `--force`. What it stops is paying ~168s of a shared lane, again, for a POST that has already failed 20 times.

## Test plan

`npm run lint`: clean. Full python suite: **681 tests, OK**. Scoped TS suites green: `hindsight-drain-sidecar` (19), `doctor-pending-retains` (50), `doctor`, `scaffold`, `gateway-supervisor-backoff`, `gateway-supervisor-log-rotation`, `reconcile.skip-profile-templates`, `docker/compose-generator`.

New/rewritten:

- **`tests/hindsight-drain-sidecar.test.ts` (19)** — rewritten to assert **outcomes**. The previous 10 tests asserted the sidecar's own announcement, so the stagger, the kill switch and the interval clamp could each be deleted outright with all 10 still green. Now the offset is asserted as a wall-clock wait *and* as the argument handed to `sleep`; the clamped interval is asserted as the measured spacing between ticks, with the announcement checked to match it; and the precondition guard is **executed** — under `set -u`, with a closed `PATH`, so "python3 is absent" is a real condition rather than one the ambient `/usr/bin` quietly contradicts.
- **`vendor/hindsight-memory/scripts/tests/test_drain_serialisation.py` (11, new)** — the lock holds for the in-process caller (what `session_start.py` does) and for a genuinely separate process running the CLI; the skip is the lock and not an unconditional refusal; the lock is released after a run; an unopenable lock still drains; the path is beside the queue and is *not* the stopgap's.
- **`vendor/hindsight-memory/scripts/tests/test_drain_circuit_breaker.py` (12, new)** — a wedged entry is not retried across 5 unattended runs, parking is not retirement, a parked entry is still reconciled for free, `--force` replays it, an entry one attempt below the ceiling still drains, and the ceiling is tunable/clamped/garbage-tolerant.
- **`src/cli/doctor-pending-retains.test.ts` (+2)** — the backlog remediation names the lock and warns against adding an `flock`, and names the attempt ceiling and `--force`.

**Mutation-tested — every mechanism broken one at a time, each confirmed to turn a named test red:**

| Mutation | Killed by |
|---|---|
| Delete `sleep "$_offset"` | `WAITS out the per-agent offset before the first drain`, `the offset it WAITS for is deterministic per agent and spreads the fleet` |
| Delete the `SWITCHROOM_HINDSIGHT_DRAIN` condition | `SWITCHROOM_HINDSIGHT_DRAIN=0 actually stops it` |
| `sleep "$_interval"` → `sleep 900` | `waits the CLAMPED interval between ticks, and announces the same number` |
| Re-add a `flock` wrapper around the python call | `leaves the drain lock free for drain_pending.py, which takes it itself` |
| Delete the `else` branch | `says WHY it did not start … when the script is missing`, `… when python3 is absent`, `names exactly one reason, and it is the true one` |
| Revert `${VAR:-1}` to the bare `$SWITCHROOM_HINDSIGHT_DRAIN` | `starts the sidecar when nothing objects, with SWITCHROOM_HINDSIGHT_DRAIN unset` |
| Remove `_exclusive_drain` from `drain()` | `test_the_in_hook_drain_does_nothing_while_another_drain_holds_it`, `…backlog_drain…`, `test_the_cli_a_separate_process_runs_also_skips`, `test_the_public_drain_is_what_takes_the_lock` |
| Remove both `_park_broken` calls | `test_the_unattended_backlog_drain_stops_retrying_a_wedged_entry`, `test_the_in_hook_drain_parks_too`, `test_repeated_unattended_runs_never_touch_the_wedged_entry_again`, `test_the_ceiling_is_operator_tunable` |
| Drop `force=args.force` from `main()` | `test_force_is_plumbed_and_defaults_off` |
| Delete the doctor serialisation note | `the remediation says the documented drain is serialised, and how not to break it` |
| Delete the doctor attempt-ceiling note | `the remediation names the attempt ceiling and the --force replay` |

**Live smoke inside `switchroom-klanker`**, with `python3` shadowed by a recorder so nothing was actually drained, confirmed the per-agent offset, the argv, and that `bash` / `cksum` / `python3` are all present in the agent image.

One test-harness note worth flagging for CI: the sandbox is created under the repo's gitignored `.test-tmp/`, **not** `os.tmpdir()`, because `/tmp` is mounted `noexec` in the agent container. On a noexec sandbox the stub `python3` is skipped and the REAL `python3` runs, which made the loop tests pass for the wrong reason until it was caught.

## Retiring the interim host cron

An interim host-level stopgap is running right now. Once this lands and agents have been restarted, the operator removes it with:

```bash
sudo rm /etc/cron.d/hindsight-drain-backlog
sudo rm /home/kenthompson/.switchroom/agents/klanker/scripts/hindsight-drain-backlog.sh
sudo rm -f /var/log/hindsight-drain-backlog.log /run/hindsight-drain-backlog.lock
# then un-park any held oversized entries — the one-liner is in that
# script's header comment
```

The transition is safe in either order, but **not** for the reason an earlier revision of this description gave. The stopgap wraps its `docker exec` in `flock -n $HOME/.hindsight/drain.lock`; this PR's lock is `drain-pending.lock`, a **different** file, precisely so the stopgap's outer `flock` cannot starve the `drain_pending.py` it launches. What makes the coexistence safe is that the stopgap's inner command *is* `drain_pending.py`, so it takes the new internal lock like every other caller. While both exist, the stopgap's own `drain.lock` is simply redundant.

## Rollout

`start.sh` is template-driven and regenerated by `switchroom apply`; the sidecar starts on the next **container restart**. No new scaffolded file, so no changes to the agent-owned-tree allowlist or the drift check.

## Risk

Low, and bounded by two switches. Worst realistic case is drain work competing with live retains for the shared lanes — mitigated by concurrency 1, the per-agent offset, the existing p95 backoff, the interval floor, and now the circuit breaker; and `SWITCHROOM_HINDSIGHT_DRAIN=0` turns it off at the container level without a code change.

**Pairs with #3688** (content-keyed queue identity). #3688 stops the queue refilling itself and adds a free phase-0 duplicate collapse; this PR is what actually consumes the queue. Landing only one leaves either a deduped queue nobody drains, or a drain paying up to 32x for the same memory. They are independent and can merge in either order.

---

### Known gap, tracked separately

Neither this PR nor #3688 cleans up the **unbounded** sibling directories the interim stopgap and the ad-hoc sweeps left behind. Measured 2026-07-26 by `docker exec … du -sh $HOME/.hindsight/*`:

| Directory | Managed by code? | overlord | klanker |
|---|---|---|---|
| `pending-reconciled` | **yes** — `RECONCILED_MAX_ENTRIES=500` / `MAX_BYTES=64M`, trimmed on write | 61M | 65M |
| `pending-corrupt` | **yes** — `lib/pending.py:682` | — | 4.0K |
| `pending-dupes` | no | 6.5M | 12M |
| `pending-dupes-archive-20260726` | no | 608K | 23M |
| `pending-oversized-hold-20260726` | no | 3.7M | 6.4M |
| `pending-dead-reconciled` | no | 1.9M | 2.4M |
| `pending-drained` | no | — | 680K |

`pending-reconciled` is *not* an orphan — it is sitting at its designed 64M cap and trimming correctly, so leaving it alone is the right call. The other five appear nowhere in the repo (`grep -rl` over the tree returns nothing), so nothing bounds them and nothing will ever reclaim them: ~13M on overlord and ~44M on klanker, growing only by hand. Also left behind: a zero-byte `$HOME/.hindsight/drain.lock` in every container, which after this PR is no longer taken by anything in the repo.

That is host state, not code, and it should be filed and fixed separately — as a scripted sweep that verifies each held entry is durable (or re-enqueues it) before removing anything, not a blanket `rm -rf`. Two of those directories hold entries that were *parked*, not proven landed.
