### PR TITLE
chore: release v0.19.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.19.20 — release binaries attached and the pipeline gated end-to-end, derived LiteLLM timeout budgets, context7 by default
+
 ### LiteLLM paired timeout budgets are now DERIVED, and drift is detected
 
 A hindsight LLM call crosses three stacked deadlines, and LiteLLM's router
@@ -486,6 +488,29 @@ deployment. Not unused: **unreachable**, for weeks, with no error anywhere.
   binary on `main` unnoticed (`src/util/audit-hashchain.ts`,
   `telegram-plugin/tests/boot-version-string.test.ts`); all are now escaped,
   byte-identical in behaviour and readable again.
+
+### Also in this release
+
+Merged since v0.19.19 and not covered by a section above:
+
+- **Telegram — activity and status cards.** The edit-flood fuse is now
+  bypass-proof at the grammY transformer seam (#3631) and activity-card edits
+  are keyed through the send gate (#3628), so a card storm cannot route around
+  either. Worker steps indent under their header on the combined card (#3662),
+  using U+2800 rather than U+00A0, which Telegram renders flat (#3684). Live
+  sub-agent rows are no longer terminalized by the async-launch ACK (#3677).
+  Pinned status cards stay readable when Telegram collapses them (#3679), and
+  status pins get unpinned again — the boot sweep is gated on bot-ready and
+  unconfirmed unpins are retained for retry (#3675).
+- **Hindsight.** Foreground recall is isolated from background consolidation
+  (#3660), so a consolidation pass can no longer stall an interactive recall.
+  Degraded auto-recall is now visible to both the agent and `doctor` (#3626)
+  instead of failing quietly.
+- **Setup & vault.** The setup wizard's verification step actually verifies
+  (#3661). The vault passphrase card is louder, card-edit failures are no
+  longer silent, and entry gets a 3-attempt retry (#3627, #3632).
+- **CI.** Required checks now run on `merge_group`, so the merge queue can
+  drain (#3683).
 
 ## v0.19.19 — hindsight retain durability, approval-kernel fail-open fixes, bounded rollout & logs
 


### PR DESCRIPTION
Consolidate the CHANGELOG for **v0.19.20**: convert the staged `## Unreleased` section to a `v0.19.20` heading, keeping an empty `## Unreleased` above it per the established convention (same shape as the v0.19.19 release commit, 0bdb34ecf).

## Why this release matters

v0.19.19 published with **zero assets**, so both URLs `install.sh` constructs return 404 — `curl | sh` has been dead in production on every platform since. Two changes in this release are the fix:

- **#3665 (#3633/#3634)** builds and attaches the four static binaries plus `switchroom-checksums.txt`.
- **#3686 (#3654)** makes `release.yml` the orchestrator, so a `v*` tag can no longer half-ship — the GitHub Release is held as a **draft** until images, binaries and npm are all green.

The #3686 gating protects the *next* release; it does nothing for v0.19.19. This tag is what actually repairs the installer.

## Changelog coverage

Also adds an **"Also in this release"** section covering the 12 commits merged since v0.19.19 that no staged section described — 7 Telegram card fixes (#3631, #3628, #3662, #3684, #3677, #3679, #3675), 2 hindsight fixes (#3660, #3626), the setup-wizard verification fix (#3661), the vault passphrase card (#3627/#3632), and the `merge_group` CI fix (#3683). This matches what the v0.19.19 release commit did for its own unlogged merges. All 19 commits in `v0.19.19..main` are now represented.

## Discipline

- **CHANGELOG.md only** — 1 file, +25/-0.
- `package.json` `version` **not** bumped; it remains the stale `0.18.0` placeholder by design. The git tag is the version source of truth (`scripts/build.mjs:resolveVersion()`).
- Base is `63182ce51`, verified green on `main` (0 failing check-runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)