### PR TITLE
fix(ci): bind EXPECT_TAG in release.yml publish job so the completeness gate can run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -512,14 +512,22 @@ jobs:
       - name: Attach binaries + checksums to the GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          # `EXPECT_TAG`, not a step-local `TAG`: the same variable names the
+          # tag for `gh release upload` AND is the required input of
+          # assert-release-assets-complete.mjs below. v0.19.20 shipped this
+          # step with `TAG` while the assertion read `EXPECT_TAG`, so the
+          # assertion exited 1 ("EXPECT_TAG is required") on a release whose
+          # assets had all uploaded fine — failing `publish`, skipping `npm`
+          # and `finalize`, and stranding the release as a draft. One name is
+          # the fix; R10 in tests/release-pipeline-gating.test.ts is the guard.
+          EXPECT_TAG: ${{ github.ref_name }}
         shell: bash
         run: |
           files=""
           for asset in $RELEASE_ASSETS; do files="$files dist-bins/$asset"; done
           files="$files dist-bins/$CHECKSUMS_FILE"
           # shellcheck disable=SC2086
-          gh release upload "$TAG" $files --repo "$GITHUB_REPOSITORY" --clobber
+          gh release upload "$EXPECT_TAG" $files --repo "$GITHUB_REPOSITORY" --clobber
 
           # Close the loop: the failure this whole workflow exists to prevent
           # is a release page with zero assets. Assert every expected asset is
@@ -530,10 +538,10 @@ jobs:
           rc=$?
           set -e
           if [ "$rc" -ne 0 ]; then
-            echo "::error::assets are still missing from $TAG after upload (exit $rc). The upload reported success, so suspect a rename: scripts/check-release-asset-names.mjs is the static half of this contract."
+            echo "::error::assets are still missing from $EXPECT_TAG after upload (exit $rc). The upload reported success, so suspect a rename: scripts/check-release-asset-names.mjs is the static half of this contract."
             exit 1
           fi
-          echo "All release assets attached to $TAG (still a draft until finalize)."
+          echo "All release assets attached to $EXPECT_TAG (still a draft until finalize)."
 
   # The irreversible leg, and the reason the whole pipeline exists. `needs`
   # is the plain all-must-succeed form on purpose: no `always()`, no

--- a/tests/release-pipeline-gating.test.ts
+++ b/tests/release-pipeline-gating.test.ts
@@ -36,17 +36,20 @@ interface Step {
   name?: string;
   uses?: string;
   run?: string;
+  env?: Record<string, unknown>;
 }
 interface Job {
   needs?: string | string[];
   if?: unknown;
   uses?: string;
   steps?: Step[];
+  env?: Record<string, unknown>;
   "continue-on-error"?: unknown;
 }
 interface Workflow {
   on?: Record<string, unknown>;
   jobs?: Record<string, Job>;
+  env?: Record<string, unknown>;
 }
 
 function load(file: string): Workflow {
@@ -65,6 +68,19 @@ function stepsOf(job: Job): Step[] {
 /** First job whose steps contain `needle` in a `run:` body. */
 function jobDoing(wf: Workflow, needle: string): [string, Job] | undefined {
   return Object.entries(wf.jobs ?? {}).find(([, j]) => stepsOf(j).some((s) => (s.run ?? "").includes(needle)));
+}
+/**
+ * Is `name` bound to a non-empty value for this step? GitHub layers env as
+ * workflow < job < step, so a step inherits whatever the outer scopes set.
+ * An empty binding is NOT a binding — the gate scripts read `?? ""` and
+ * treat blank as absent, so `EXPECT_TAG: ""` fails exactly like omitting it.
+ */
+function envBound(wf: Workflow, job: Job, step: Step, name: string): boolean {
+  for (const scope of [step.env, job.env, wf.env]) {
+    const v = scope?.[name];
+    if (v !== undefined && v !== null && String(v).trim() !== "") return true;
+  }
+  return false;
 }
 
 /**
@@ -215,6 +231,37 @@ export function auditGating(release: Workflow, npmPublish: Workflow): string[] {
         if ((s.run ?? "").includes("${{")) {
           problems.push(
             `R8: ${file} job ${id} step "${s.name ?? "?"}" interpolates \`\${{ }}\` inside \`run:\` — pass it via \`env:\`.`,
+          );
+        }
+      }
+    }
+  }
+
+  // R10 — every caller of the completeness gate must bind `EXPECT_TAG`.
+  // The script reads the tag to check from that variable and exits 1
+  // ("EXPECT_TAG is required") when it is blank. Crucially that exit is
+  // INDISTINGUISHABLE, to the shell wrapping it, from "assets are missing":
+  // both callers branch on `rc -ne 0`. So forgetting the variable does not
+  // skip the gate, it fails the gate — on every release, forever, with a
+  // message blaming the assets. v0.19.20 shipped exactly this: the upload
+  // step bound a step-local `TAG` while the assertion read `EXPECT_TAG`, so
+  // `publish` went red with all five assets already correctly attached,
+  // `npm` and `finalize` were skipped, and the release stranded as a draft
+  // while `/releases/latest` kept serving the asset-less v0.19.19.
+  //
+  // R7 asserts the gate is CALLED and called early enough; R10 asserts the
+  // call can actually run. Neither implies the other.
+  for (const [file, wf] of [
+    ["release.yml", release],
+    ["npm-publish.yml", npmPublish],
+  ] as const) {
+    for (const [id, job] of Object.entries(wf.jobs ?? {})) {
+      for (const s of stepsOf(job)) {
+        if (!(s.run ?? "").includes("assert-release-assets-complete.mjs")) continue;
+        if (!envBound(wf, job, s, "EXPECT_TAG")) {
+          problems.push(
+            `R10: ${file} job ${id} step "${s.name ?? "?"}" runs assert-release-assets-complete.mjs without ` +
+              "binding a non-empty `EXPECT_TAG` — the script exits 1 and the caller misreports it as missing assets.",
           );
         }
       }
@@ -417,5 +464,50 @@ describe("release pipeline gating — every rule is proved by mutation", () => {
       stepsOf(job)[0]!.run = 'echo "${{ secrets.NPM_TOKEN }}" > /tmp/x';
     });
     expect(p.join("\n")).toMatch(/R8:.*interpolates/);
+  });
+
+  // The exact v0.19.20 regression: `publish` bound `TAG`, the assertion read
+  // `EXPECT_TAG`. Reproduced as a mutation so it can never come back.
+  it("R10: the v0.19.20 regression — the upload step binding `TAG` instead of `EXPECT_TAG` — is caught", () => {
+    const p = mutate((r) => {
+      const [, upload] = jobDoing(r, "gh release upload")!;
+      const step = stepsOf(upload).find((s) => (s.run ?? "").includes("assert-release-assets-complete.mjs"))!;
+      const tag = step.env!.EXPECT_TAG;
+      delete step.env!.EXPECT_TAG;
+      step.env!.TAG = tag;
+    });
+    expect(p.join("\n")).toMatch(/R10:.*release\.yml.*EXPECT_TAG/);
+  });
+
+  it("R10: binding EXPECT_TAG to an empty value is caught (blank is not a binding)", () => {
+    const p = mutate((r) => {
+      const [, upload] = jobDoing(r, "gh release upload")!;
+      const step = stepsOf(upload).find((s) => (s.run ?? "").includes("assert-release-assets-complete.mjs"))!;
+      step.env!.EXPECT_TAG = "";
+    });
+    expect(p.join("\n")).toMatch(/R10:.*EXPECT_TAG/);
+  });
+
+  it("R10: dropping EXPECT_TAG from npm-publish's own completeness gate is caught", () => {
+    const p = mutate((_r, n) => {
+      for (const job of Object.values(n.jobs!)) {
+        for (const s of stepsOf(job)) {
+          if ((s.run ?? "").includes("assert-release-assets-complete.mjs")) delete s.env?.EXPECT_TAG;
+        }
+      }
+    });
+    expect(p.join("\n")).toMatch(/R10:.*npm-publish\.yml.*EXPECT_TAG/);
+  });
+
+  // Guards the rule against over-firing: GitHub really does inherit env from
+  // the job and workflow scopes, so a valid outer binding must stay clean.
+  it("R10: an EXPECT_TAG inherited from the job scope satisfies the rule", () => {
+    const p = mutate((r) => {
+      const [, upload] = jobDoing(r, "gh release upload")!;
+      const step = stepsOf(upload).find((s) => (s.run ?? "").includes("assert-release-assets-complete.mjs"))!;
+      delete step.env!.EXPECT_TAG;
+      upload.env = { EXPECT_TAG: "${{ github.ref_name }}" };
+    });
+    expect(p.join("\n")).not.toMatch(/R10:/);
   });
 });


### PR DESCRIPTION
## What broke

v0.19.20's `release` run (30188339561) failed at **`attach assets to the release`**:

```
##[error]assert-release-assets-complete: EXPECT_TAG is required
##[error]assets are still missing from v0.19.20 after upload (exit 1). The upload reported success, so suspect a rename: ...
```

**The second line is false and the first explains why.** All five assets *had* uploaded — the release object carried `switchroom-linux-amd64`, `switchroom-linux-arm64`, `switchroom-macos-amd64`, `switchroom-macos-arm64` and `switchroom-checksums.txt` at the moment the job went red.

## Root cause

- #3665 authored the *Attach binaries + checksums* step with a step-local `TAG: ${{ github.ref_name }}` (`release.yml:515`).
- #3686 then added the post-upload completeness assertion **into that same step** (`release.yml:527-529`) without adding `EXPECT_TAG` — the variable `scripts/ci/assert-release-assets-complete.mjs:116` actually reads.

The script exits `1` (`badInput`) when that variable is blank, and the wrapping shell branches on `rc -ne 0`. So **a missing env var is indistinguishable from missing assets.** The gate wasn't skipped — it failed closed, on a perfectly healthy release, blaming the wrong thing.

The runner log confirms the step's entire env was `RELEASE_ASSETS`, `CHECKSUMS_FILE`, `GH_TOKEN`, `TAG: v0.19.20` — no `EXPECT_TAG` at any scope.

## Blast radius

`publish` red → `npm` and `finalize` skipped (plain `needs:`, by design) → nothing on npm, and the GitHub Release stranded as a **draft**. `/releases/latest` therefore kept resolving **v0.19.19**, which has `assets: []`, so `curl | sh` stayed broken — the exact production breakage #3654/#3686 exist to prevent.

Worth stating plainly: the draft-until-green invariant worked correctly. The problem is that the gate could never report green, so no release can complete until this is fixed.

## The fix

The publish step was the **only one of four call sites** using a second name for the tag — `images-gate` (364), `guard` (434) and `finalize` (592) all bind `EXPECT_TAG`. This removes the divergence rather than adding a second binding: one variable, used by both `gh release upload` and the assertion.

## The guard (R10)

`tests/release-pipeline-gating.test.ts` gains **R10**: every step in `release.yml` or `npm-publish.yml` that runs `assert-release-assets-complete.mjs` must bind a non-empty `EXPECT_TAG`, resolved across GitHub's `workflow < job < step` env layering.

Verified R10 fails against the **actual shipped v0.19.20 workflow**, not just a synthetic mutation:

```
R10: release.yml job publish step "Attach binaries + checksums to the GitHub Release" runs
assert-release-assets-complete.mjs without binding a non-empty `EXPECT_TAG` — the script
exits 1 and the caller misreports it as missing assets.
```

R7 already asserted the gate is *called*, and called before the irreversible step. It could not see that the call was **unable to run**. Four mutations prove R10: the v0.19.20 regression itself, an empty-string binding, dropping it from npm-publish's own gate, and a negative case so an `EXPECT_TAG` inherited from the job scope stays clean.

## Tests

```
tests/release-pipeline-gating.test.ts   26 passed  (22 before)
tests/release-gate-scripts.test.ts      35 passed
tests/release-asset-contract.test.ts    22 passed
tsc --noEmit                            exit 0
scripts/check-release-asset-names.mjs   exit 0
```

## Important: this does NOT unblock the existing v0.19.20 tag

`workflow_dispatch` runs the workflow file **at the ref it is dispatched on**, and the `v0.19.20` tree still contains the defect — so `gh workflow run release.yml --ref v0.19.20` would fail identically. This fix takes effect on the **next tag cut after it lands**. Completing the installer repair needs a follow-up release cut by the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)