### PR TITLE
chore: release v0.19.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## v0.19.20 — release binaries attached and the pipeline gated end-to-end, derived LiteLLM timeout budgets, context7 by default
+## v0.19.21 — release binaries attached and the pipeline gated end-to-end, derived LiteLLM timeout budgets, context7 by default
 
 ### LiteLLM paired timeout budgets are now DERIVED, and drift is detected
 
@@ -189,6 +189,46 @@ retaggable (`promote.yml`) where npm and `/releases/latest` are not, and
 converting the workflow that also serves every PR and main push (and carries
 the `images-ok` required check) to gate the one *recoverable* leg is the
 inverse trade of the npm case. Tracked in #3685 with the candidate shapes.
+
+### The completeness gate's own tag binding — why this release is v0.19.21, not v0.19.20 (#3691)
+
+`v0.19.20` was tagged, built and **never shipped**. It is a dead tag: the
+GitHub Release is a permanent draft (with all five assets correctly attached)
+and nothing was ever published to npm. This is the release it was meant to be,
+cut fresh off a fixed `main`.
+
+The guard shipped above mis-wired itself. In `release.yml`'s `publish` job, the
+"attach binaries" step bound the tag as `TAG:`, while the assertion it invokes
+three lines later, `scripts/ci/assert-release-assets-complete.mjs:116`, reads
+`process.env.EXPECT_TAG` and exits 1 on empty. So on a completely healthy
+release — four binaries and a checksums file uploaded, `gh release upload`
+green — the gate exited 1 with `EXPECT_TAG is required`, and the step's own
+error handler misreported it as `assets are still missing from  after upload`
+(the tag interpolating to the empty string it never had). `publish` went red,
+`npm` and `finalize` never ran, and the release stayed a draft.
+
+That is the *designed* failure direction — nothing half-shipped, and
+`/releases/latest` kept serving the previous complete release — but it fired on
+a release that was whole. The blame is entirely inside this feature: the step
+was authored with `TAG` in #3665, and the assertion that reads `EXPECT_TAG` was
+added by #3686. The "a `v*` tag cannot half-ship" work shipped its own guard
+disconnected from the thing it guards.
+
+- **Every step in `release.yml` that invokes the gate now binds `EXPECT_TAG`** —
+  `guard`, `publish`, `images-gate` and `finalize`, one name across the file
+  (`npm-publish.yml` already bound it in both of its own gates).
+- **Rule R10 in `tests/release-pipeline-gating.test.ts` makes it structural.**
+  Any step in either workflow that runs `assert-release-assets-complete.mjs`
+  without a non-empty `EXPECT_TAG` in scope now fails CI. R7 already asserted
+  the gate is *called*, and called early enough; R10 asserts it is *wired*.
+  A binding inherited from the job's `env:` satisfies it; a blank value does
+  not. The v0.19.20 regression itself is one of the mutation cases.
+
+Worth stating plainly, because a re-dispatch was the obvious reflex and it
+cannot work: `workflow_dispatch` executes the workflow YAML **at the dispatched
+ref**, so `gh workflow run release.yml --ref v0.19.20` re-runs the broken file.
+When the defect lives in the tag's own tree, the only path is a fix on `main`
+and a fresh tag.
 
 ### A runtime probe for the perturbed-JSON-retry patch, so a silent revert fails CI
 

--- a/skills/switchroom-release/SKILL.md
+++ b/skills/switchroom-release/SKILL.md
@@ -88,7 +88,14 @@ The tag push triggers `docker-images` and `release`. `release` internally waits 
 
 ### Gate A — docker images (`docker-images.yml`)
 - `gh run list --workflow=docker-images.yml --limit 1` — wait for `completed` / `success`.
-- Verify all 6 images are published: `docker manifest inspect ghcr.io/switchroom/<image>:vX.Y.Z` for `agent`, `auth-broker`, `kernel`, `broker`, `web`, `hostd`. Each must resolve.
+- Verify all 6 images are published. The repository name is `switchroom-<name>`, **not** `<name>` — `.github/workflows/docker-images.yml` builds `${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image.name }}`, so `ghcr.io/switchroom/agent` does not exist and returns `manifest unknown`. Check each of:
+  ```bash
+  for n in agent auth-broker kernel broker web hostd; do
+    docker manifest inspect "ghcr.io/switchroom/switchroom-$n:vX.Y.Z" >/dev/null \
+      && echo "OK   switchroom-$n" || echo "MISS switchroom-$n"
+  done
+  ```
+  Each must resolve.
 - If any image is missing: do NOT roll — the rollout canary version-assert fails on an unpublished tag. Wait + re-check. `release` will block on this by itself, so a red image build means npm never publishes and the release never leaves draft. That is the design.
 
 ### Gate B — the release pipeline (`release.yml`)
@@ -140,6 +147,8 @@ gh workflow run release.yml -R switchroom/switchroom --ref vX.Y.Z -f dry_run=fal
 ```
 
 It re-runs every leg — including `finalize`, which is what actually takes the release out of draft. Re-running one leg on its own generally leaves the release stuck as a draft.
+
+**But a re-dispatch cannot fix a defect that lives in the tag's own tree.** `workflow_dispatch` executes the workflow YAML **at the dispatched ref**, so `--ref vX.Y.Z` re-runs the same broken file and fails identically, every time. This is not theoretical — it is how v0.19.20 died (#3691). Before reaching for the re-dispatch, root-cause the failure in the workflow source **at that tag** (`git show vX.Y.Z:.github/workflows/release.yml`) and compare it to `main`. If the bug is in the tag's tree, the only path is a fix merged to `main` plus a **fresh tag**; abandon the old tag as a permanent draft (do not delete it, do not hand-publish it) and burn a patch version. Re-dispatch is for *transient* failures — a flaky runner, an npm 5xx, a `docker-images` run that has since gone green.
 
 - **`release` failed at `guard` ("no GitHub Release exists"):** step 2b was skipped or the tag name is misspelled. Create the draft release, then re-dispatch as above.
 - **`release` failed at `images-gate`:** `docker-images` was not green for this tag+commit. Fix it, `gh workflow run docker-images.yml --ref vX.Y.Z`, wait for green, then re-dispatch `release.yml`. Nothing was published to npm and the release is still a draft — nothing to undo.


### PR DESCRIPTION
Release commit for **v0.19.21**. CHANGELOG-only apart from a correction to the release skill. `package.json` `version` is untouched by design (stale placeholder; the git tag is the source of truth).

## Why v0.19.21 and not v0.19.20

`v0.19.20` was tagged, built, and **never shipped**. It is a dead tag: its GitHub Release is a permanent draft (all five assets correctly attached) and nothing was ever published to npm. It is being left in place — not deleted, not hand-published.

Root cause, verified in the tag's own tree: at `v0.19.20`, `.github/workflows/release.yml:515` bound the publish step's tag as `TAG:`, while `scripts/ci/assert-release-assets-complete.mjs:116` reads `process.env.EXPECT_TAG` and exits 1 on empty. The completeness gate therefore failed closed on a *healthy* release — every asset had uploaded — and the step's error handler misreported it as `assets are still missing from  after upload`, with the tag interpolating to the empty string it never had. `publish` went red, `npm` and `finalize` never ran.

#3691 (`bb1781a1e`) fixed the binding and added structural rule R10 to `tests/release-pipeline-gating.test.ts`. A re-dispatch could never have rescued the old tag: `workflow_dispatch` executes the workflow YAML **at the dispatched ref**, so `--ref v0.19.20` re-runs the broken file. A fresh tag off fixed `main` is the only path.

## Changes

- **`CHANGELOG.md`** — the `## v0.19.20` header is renamed to `## v0.19.21` rather than left as a phantom section describing a release nobody can install, and a new section documents #3691 (the `EXPECT_TAG` binding + R10). Everything else in the section is unchanged: it still covers the 19 commits merged since v0.19.19.
- **`skills/switchroom-release/SKILL.md`** — two corrections the failed run established:
  - Gate A's image paths were **wrong**. `ghcr.io/switchroom/agent:*` does not exist and returns `manifest unknown`. `.github/workflows/docker-images.yml:442` builds `${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image.name }}`, so the check is `ghcr.io/switchroom/switchroom-<name>`. Confirmed empirically against `v0.19.19`: all six `switchroom-*` names resolve, the bare names do not.
  - The "single recovery command is a re-dispatch" guidance now carries the caveat above, so the next release does not burn a tag rediscovering it.