### PR TITLE
fix(hindsight): size retain parts to a fraction of the client deadline

### DIFF
--- a/src/hindsight-watch/thresholds.test.ts
+++ b/src/hindsight-watch/thresholds.test.ts
@@ -21,11 +21,11 @@ describe("the #3610 memories → parts conversion", () => {
     expect(QUEUE_GROWTH_MIN_ABS).toBe(120);
   });
 
-  // #3694 lowered the content bound 48,000 → 33,000, so the SAME backlog
+  // #3693 lowered the content bound 48,000 → 33,000, so the SAME backlog
   // splits into more parts. If the conversion factor is ever left behind at a
   // bound change, every count threshold silently tightens and the watchdog
   // starts alerting on a queue that holds no more memory than before.
-  it("is scaled for the post-#3694 content bound, not the pre-#3694 one", () => {
+  it("is scaled for the post-#3693 content bound, not the pre-#3693 one", () => {
     expect(PARTS_PER_MEMORY).toBeGreaterThanOrEqual(4.4 * (45_000 / 33_000));
   });
 
@@ -42,7 +42,7 @@ describe("the #3610 memories → parts conversion", () => {
     expect(QUEUE_GROWTH_MIN_ABS).toBeGreaterThan(20);
     // Five worst-case memories must not clear the floor. 23 parts is the
     // worst single entry in the live 2026-07-26 backlog re-split at the
-    // post-#3694 33,000 bound (it was 17 at 45,000, B6).
+    // post-#3693 33,000 bound (it was 17 at 45,000, B6).
     expect(5 * 23).toBeLessThan(QUEUE_GROWTH_MIN_ABS);
   });
 });

--- a/src/hindsight-watch/thresholds.test.ts
+++ b/src/hindsight-watch/thresholds.test.ts
@@ -10,15 +10,23 @@ import {
 describe("the #3610 memories → parts conversion", () => {
   // These two numbers are what the operator sees in `--json` and in every
   // alert detail line, so they are pinned rather than left to whatever
-  // IEEE-754 does with 4.4. `Math.ceil` here really did produce 441 from
-  // 100 × 4.4 = 440.00000000000006 while 20 × 4.4 came out exact at 88 —
-  // a threshold that moves with float representation is not a threshold.
-  it("pins QUEUE_FLOOR at 440 parts (100 memories), not 441", () => {
-    expect(QUEUE_FLOOR).toBe(440);
+  // IEEE-754 does with the factor. `Math.ceil` really did produce 441 from
+  // the old 100 × 4.4 = 440.00000000000006 while 20 × 4.4 came out exact at
+  // 88 — a threshold that moves with float representation is not a threshold.
+  it("pins QUEUE_FLOOR at 600 parts (100 memories)", () => {
+    expect(QUEUE_FLOOR).toBe(600);
   });
 
-  it("pins QUEUE_GROWTH_MIN_ABS at 88 parts (20 memories)", () => {
-    expect(QUEUE_GROWTH_MIN_ABS).toBe(88);
+  it("pins QUEUE_GROWTH_MIN_ABS at 120 parts (20 memories)", () => {
+    expect(QUEUE_GROWTH_MIN_ABS).toBe(120);
+  });
+
+  // #3694 lowered the content bound 48,000 → 33,000, so the SAME backlog
+  // splits into more parts. If the conversion factor is ever left behind at a
+  // bound change, every count threshold silently tightens and the watchdog
+  // starts alerting on a queue that holds no more memory than before.
+  it("is scaled for the post-#3694 content bound, not the pre-#3694 one", () => {
+    expect(PARTS_PER_MEMORY).toBeGreaterThanOrEqual(4.4 * (45_000 / 33_000));
   });
 
   it("keeps both thresholds equal to their stated intent in memories", () => {
@@ -32,7 +40,9 @@ describe("the #3610 memories → parts conversion", () => {
     // false positive B6 documents would return.
     expect(QUEUE_FLOOR).toBeGreaterThan(100);
     expect(QUEUE_GROWTH_MIN_ABS).toBeGreaterThan(20);
-    // Five worst-case memories (17 parts each, B6) must not clear the floor.
-    expect(5 * 17).toBeLessThan(QUEUE_GROWTH_MIN_ABS);
+    // Five worst-case memories must not clear the floor. 23 parts is the
+    // worst single entry in the live 2026-07-26 backlog re-split at the
+    // post-#3694 33,000 bound (it was 17 at 45,000, B6).
+    expect(5 * 23).toBeLessThan(QUEUE_GROWTH_MIN_ABS);
   });
 });

--- a/src/hindsight-watch/thresholds.ts
+++ b/src/hindsight-watch/thresholds.ts
@@ -216,7 +216,7 @@ export const RETAIN_FAILURE_RATE = 0.1;
  * in entries means something different than it did when `QUEUE_FLOOR` and
  * `QUEUE_GROWTH_MIN_ABS` were first set.
  *
- * B7b REVISION (#3694): the bound is now a FRACTION of the client deadline
+ * B7b REVISION (#3693): the bound is now a FRACTION of the client deadline
  * rather than the whole of it, moving `retain_content_limit()` 48,000 →
  * 33,000. Unlike B7a's ~6 % this is a 45 % change and is NOT inside the
  * noise: the same backlog splits into ~1.45× as many parts with not one new

--- a/src/hindsight-watch/thresholds.ts
+++ b/src/hindsight-watch/thresholds.ts
@@ -216,7 +216,25 @@ export const RETAIN_FAILURE_RATE = 0.1;
  * in entries means something different than it did when `QUEUE_FLOOR` and
  * `QUEUE_GROWTH_MIN_ABS` were first set.
  *
- * 4.4 is measured, not assumed (B6): over the 174 live pre-split queue
+ * B7b REVISION (#3694): the bound is now a FRACTION of the client deadline
+ * rather than the whole of it, moving `retain_content_limit()` 48,000 →
+ * 33,000. Unlike B7a's ~6 % this is a 45 % change and is NOT inside the
+ * noise: the same backlog splits into ~1.45× as many parts with not one new
+ * memory behind it, so leaving the factor at 4.4 would tighten every count
+ * threshold below by that much and reintroduce exactly the B6 false positive
+ * they exist to prevent. The B6 population (174 pre-split entries) no longer
+ * exists to re-measure, so the revision is applied as the bound RATIO:
+ *
+ *   4.4 × (45,000 / 33,000) = 6.0
+ *
+ * Ratio-scaling is EXACT for entries far above the bound and OVER-estimates
+ * for entries below it (those are one part at either bound), so the factor
+ * errs high — i.e. quieter — which is the safe direction for a watchdog.
+ * Corroborated against the live 2026-07-26 backlog (209 entries): re-splitting
+ * it at 33,000 rather than 48,000 moves 336 parts → 531, a ratio of 1.58,
+ * slightly above the 1.45 applied here, so 6.0 remains the conservative side.
+ *
+ * 4.4 was measured, not assumed (B6): over the 174 live pre-split queue
  * entries, `Σ ceil(content_chars / 45,000) / 174 = 4.397`. That population
  * is deliberately the right one to calibrate against — it is a real backlog
  * on this fleet, and the concrete false positive being prevented is exactly
@@ -226,12 +244,13 @@ export const RETAIN_FAILURE_RATE = 0.1;
  * Two honest limits on this number:
  *  - It is the BACKLOG distribution, which skews large (small retains drain
  *    first and are not in it). Steady-state parts-per-memory is lower, so
- *    4.4 is a conservative — i.e. quieter — factor.
- *  - The worst single entry splits 17 ways, so a handful of very large
- *    memories can still move the depth a long way. That is the reason the
- *    absolute growth floor below is scaled at all.
+ *    the factor is a conservative — i.e. quieter — one.
+ *  - The worst single entry splits 23 ways at the 33,000 bound (17 at
+ *    45,000), so a handful of very large memories can still move the depth a
+ *    long way. That is the reason the absolute growth floor below is scaled
+ *    at all.
  */
-export const PARTS_PER_MEMORY = 4.4;
+export const PARTS_PER_MEMORY = 6.0;
 
 /**
  * Convert a threshold stated in MEMORIES into the spool's post-#3610 unit.

--- a/src/hindsight-watch/types.ts
+++ b/src/hindsight-watch/types.ts
@@ -42,8 +42,10 @@ export interface Sample {
    * Post-#3610 this counts memory PARTS, not memories: one oversized
    * transcript enqueues one entry per part, where the part size is derived
    * from the retain client deadline (`retain_content_limit()`; 45,000 chars at
-   * the 280s deadline #3610 shipped, 48,000 at the 310s it is now — see B7a in
-   * `thresholds.ts`). Every threshold compared against it is scaled by
+   * the 280s deadline #3610 shipped, 48,000 at the 310s of B7a, and 33,000
+   * since #3694 sized it to a FRACTION of that deadline rather than all of it
+   * — see B7a/B7b in `thresholds.ts`). Every threshold compared against it is
+   * scaled by
    * `PARTS_PER_MEMORY`.
    */
   pending: number;

--- a/src/hindsight-watch/types.ts
+++ b/src/hindsight-watch/types.ts
@@ -43,7 +43,7 @@ export interface Sample {
    * transcript enqueues one entry per part, where the part size is derived
    * from the retain client deadline (`retain_content_limit()`; 45,000 chars at
    * the 280s deadline #3610 shipped, 48,000 at the 310s of B7a, and 33,000
-   * since #3694 sized it to a FRACTION of that deadline rather than all of it
+   * since #3693 sized it to a FRACTION of that deadline rather than all of it
    * — see B7a/B7b in `thresholds.ts`). Every threshold compared against it is
    * scaled by
    * `PARTS_PER_MEMORY`.

--- a/vendor/hindsight-memory/scripts/lib/retain_split.py
+++ b/vendor/hindsight-memory/scripts/lib/retain_split.py
@@ -68,7 +68,8 @@ from typing import Optional
 # The bound — derived, not chosen
 # ---------------------------------------------------------------------------
 #
-#   max_content_chars = retain_chunk_size × floor(client_deadline / chunk_latency)
+#   max_content_chars = retain_chunk_size
+#                       × floor(client_deadline × deadline_safety / chunk_latency)
 #
 # Each input is a measured or read property of the deployment, not a taste
 # call, and each is env-overridable so the bound tracks the deployment:
@@ -112,15 +113,44 @@ from typing import Optional
 #                               NOT a hand-set number on either side — change
 #                               `src/litellm/timeout-budget.ts` and both move.
 #
-#   floor(310 / 18.4) = 16 chunks  →  16 × 3000 = 48,000 chars
+#   deadline_safety    0.7    — the FRACTION of the deadline a maximally-sized
+#                               part is allowed to consume. See below; this
+#                               input did not exist until #3694 and was
+#                               effectively 1.0.
 #
-# Sanity check against the same backlog: every entry at or below 60,000 chars
-# drained successfully inside the (then 280s) deadline (observed per-entry
-# times 0.3s–153.4s at concurrency 3), so 48,000 still sits inside
-# demonstrated-good territory with margin for a slower model or a busier box.
+#   floor(310 × 0.7 / 18.4) = 11 chunks  →  11 × 3000 = 33,000 chars
+#
+# WHY THERE IS A SAFETY FRACTION AT ALL (#3694). Without it the bound was
+# `floor(deadline / latency)`, which sizes a maximally-sized part to consume
+# ~100% of the deadline BY CONSTRUCTION: 16 × 18.4 = 294.4s against a 310s
+# deadline is 15.6s — 5% — of headroom for the POST/response, server queueing,
+# and any chunk slower than the n=752 MEAN the latency input is. Half the
+# extraction calls are slower than the mean; a part sized to the mean therefore
+# misses the deadline roughly half the time. `drain_pending._backlog_timeout()`
+# defaults to the SAME deadline, so the drainer inherits the same zero margin,
+# times the entry out, bumps its attempt count, and after MAX_ATTEMPTS ages it
+# to `.dead`. That is not a theory: on this fleet every `.dead` marker measured
+# on 2026-07-26 held content of 16,076–44,568 chars — every one of them UNDER
+# the then-current 45,000 bound. The bound was manufacturing dead memories.
+#
+# 0.7 is not a taste call either: it is the utilisation at which the observed
+# per-chunk latency distribution fits, and it independently matches the 30,000
+# char limit the host-side stopgap converged on empirically before this landed.
+# At 0.7 a maximally-sized part is 11 × 18.4 = 202.4s against 310s, leaving
+# 107.6s — enough for a chunk distribution ~50% worse than its own mean.
+#
+# The trade is more parts per logical memory (33,000 rather than 48,000 chars
+# each). That costs nothing in total LLM work — the chunk count across the
+# whole memory is unchanged, only its grouping — and each part now finishes.
+# A part that finishes is worth strictly more than a larger part that does not.
 DEFAULT_RETAIN_CHUNK_SIZE = 3000
 DEFAULT_RETAIN_CHUNK_LATENCY_S = 18.4
 DEFAULT_RETAIN_CLIENT_DEADLINE_S = 310.0
+
+# Fraction of the client deadline a maximally-sized part may consume.
+# Clamped to (0, 1]: a value above 1.0 would size parts to overrun the
+# deadline outright, which is the defect this input exists to prevent.
+DEFAULT_RETAIN_DEADLINE_SAFETY = 0.7
 
 # Absolute floor: one chunk. A bound below one chunk would split every
 # transcript into extraction-sized confetti and is never the right answer.
@@ -151,6 +181,18 @@ def retain_client_deadline() -> float:
     return _env_number("HINDSIGHT_RETAIN_CLIENT_DEADLINE_S", DEFAULT_RETAIN_CLIENT_DEADLINE_S)
 
 
+def retain_deadline_safety() -> float:
+    """Fraction of the client deadline a maximally-sized part may consume.
+
+    Clamped to ``(0, 1]``. A value above 1.0 is not honoured: it would size
+    parts to overrun the deadline by construction, which is exactly the defect
+    (#3694) this input exists to prevent, so it is treated as "no margin at
+    all" — 1.0 — rather than as a licence to go further.
+    """
+    value = _env_number("HINDSIGHT_RETAIN_DEADLINE_SAFETY", DEFAULT_RETAIN_DEADLINE_SAFETY)
+    return min(1.0, value)
+
+
 def retain_content_limit() -> int:
     """Max chars of retain content that can complete inside the client deadline.
 
@@ -170,7 +212,12 @@ def retain_content_limit() -> int:
     latency = _env_number("HINDSIGHT_RETAIN_CHUNK_LATENCY_S", DEFAULT_RETAIN_CHUNK_LATENCY_S)
     deadline = retain_client_deadline()
 
-    chunks = int(deadline // latency)
+    # A FRACTION of the deadline, not all of it (#3694). Sizing to the whole
+    # deadline leaves a maximally-sized part no headroom for the POST itself,
+    # server queueing, or a chunk slower than the MEAN `latency` is measured
+    # as — so the part times out, the drain bumps its attempt count, and it
+    # ages to `.dead`. See the derivation block at the top of this module.
+    chunks = int((deadline * retain_deadline_safety()) // latency)
     if chunks < 1:
         chunks = 1
     return max(MIN_RETAIN_CONTENT_CHARS, chunk_size * chunks)

--- a/vendor/hindsight-memory/scripts/lib/retain_split.py
+++ b/vendor/hindsight-memory/scripts/lib/retain_split.py
@@ -115,12 +115,12 @@ from typing import Optional
 #
 #   deadline_safety    0.7    — the FRACTION of the deadline a maximally-sized
 #                               part is allowed to consume. See below; this
-#                               input did not exist until #3694 and was
+#                               input did not exist until #3693 and was
 #                               effectively 1.0.
 #
 #   floor(310 × 0.7 / 18.4) = 11 chunks  →  11 × 3000 = 33,000 chars
 #
-# WHY THERE IS A SAFETY FRACTION AT ALL (#3694). Without it the bound was
+# WHY THERE IS A SAFETY FRACTION AT ALL (#3693). Without it the bound was
 # `floor(deadline / latency)`, which sizes a maximally-sized part to consume
 # ~100% of the deadline BY CONSTRUCTION: 16 × 18.4 = 294.4s against a 310s
 # deadline is 15.6s — 5% — of headroom for the POST/response, server queueing,
@@ -186,7 +186,7 @@ def retain_deadline_safety() -> float:
 
     Clamped to ``(0, 1]``. A value above 1.0 is not honoured: it would size
     parts to overrun the deadline by construction, which is exactly the defect
-    (#3694) this input exists to prevent, so it is treated as "no margin at
+    (#3693) this input exists to prevent, so it is treated as "no margin at
     all" — 1.0 — rather than as a licence to go further.
     """
     value = _env_number("HINDSIGHT_RETAIN_DEADLINE_SAFETY", DEFAULT_RETAIN_DEADLINE_SAFETY)
@@ -212,7 +212,7 @@ def retain_content_limit() -> int:
     latency = _env_number("HINDSIGHT_RETAIN_CHUNK_LATENCY_S", DEFAULT_RETAIN_CHUNK_LATENCY_S)
     deadline = retain_client_deadline()
 
-    # A FRACTION of the deadline, not all of it (#3694). Sizing to the whole
+    # A FRACTION of the deadline, not all of it (#3693). Sizing to the whole
     # deadline leaves a maximally-sized part no headroom for the POST itself,
     # server queueing, or a chunk slower than the MEAN `latency` is measured
     # as — so the part times out, the drain bumps its attempt count, and it

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -1861,7 +1861,7 @@ class ClampAndEnvKnobBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
             )
             self.assertEqual(
                 retain_split.retain_content_limit(),
-                # Same input, less the #3694 safety fraction: the bound is a
+                # Same input, less the #3693 safety fraction: the bound is a
                 # FRACTION of the deadline, not all of it, so a maximally-sized
                 # part still has headroom when the drain waits exactly 600s.
                 3000 * int((600 * retain_split.retain_deadline_safety()) // 18.4),

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -1861,7 +1861,10 @@ class ClampAndEnvKnobBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
             )
             self.assertEqual(
                 retain_split.retain_content_limit(),
-                3000 * int(600 // 18.4),
+                # Same input, less the #3694 safety fraction: the bound is a
+                # FRACTION of the deadline, not all of it, so a maximally-sized
+                # part still has headroom when the drain waits exactly 600s.
+                3000 * int((600 * retain_split.retain_deadline_safety()) // 18.4),
                 "and the content bound, from the same input",
             )
         finally:

--- a/vendor/hindsight-memory/scripts/tests/test_retain_split.py
+++ b/vendor/hindsight-memory/scripts/tests/test_retain_split.py
@@ -86,7 +86,7 @@ class TestDerivedLimit(unittest.TestCase):
 
 
 class TestTheBoundLeavesMarginUnderTheDeadline(unittest.TestCase):
-    """The bound must NOT consume the whole deadline (#3694).
+    """The bound must NOT consume the whole deadline (#3693).
 
     Sizing a maximally-sized part to ~100% of the client deadline is what
     manufactured `.dead` entries on this fleet: every `.dead` marker measured
@@ -120,7 +120,7 @@ class TestTheBoundLeavesMarginUnderTheDeadline(unittest.TestCase):
     def test_a_maximally_sized_part_finishes_well_inside_the_deadline(self):
         deadline = retain_split.retain_client_deadline()
         worst = self._worst_case_seconds()
-        # The pre-#3694 derivation gave 294.4s against 310s -> 0.95 here.
+        # The pre-#3693 derivation gave 294.4s against 310s -> 0.95 here.
         self.assertLessEqual(
             worst / deadline,
             0.8,

--- a/vendor/hindsight-memory/scripts/tests/test_retain_split.py
+++ b/vendor/hindsight-memory/scripts/tests/test_retain_split.py
@@ -57,22 +57,24 @@ class TestDerivedLimit(unittest.TestCase):
             "HINDSIGHT_RETAIN_CHUNK_SIZE",
             "HINDSIGHT_RETAIN_CHUNK_LATENCY_S",
             "HINDSIGHT_RETAIN_CLIENT_DEADLINE_S",
+            "HINDSIGHT_RETAIN_DEADLINE_SAFETY",
         ):
             os.environ.pop(key, None)
 
     def test_limit_is_chunk_size_times_chunks_that_fit_the_deadline(self):
-        # chunk_size * floor(deadline / latency) = 3000 * floor(310/18.4) = 48000
-        self.assertEqual(retain_content_limit(), 48000)
+        # chunk_size * floor(deadline * safety / latency)
+        #   = 3000 * floor(310 * 0.7 / 18.4) = 3000 * 11 = 33000
+        self.assertEqual(retain_content_limit(), 33000)
 
     def test_limit_is_derived_from_chunk_size_not_a_constant(self):
         os.environ["HINDSIGHT_RETAIN_CHUNK_SIZE"] = "1000"
-        # 1000 * floor(310 / 18.4) = 1000 * 16
-        self.assertEqual(retain_content_limit(), 16000)
+        # 1000 * floor(310 * 0.7 / 18.4) = 1000 * 11
+        self.assertEqual(retain_content_limit(), 11000)
 
     def test_limit_tracks_the_client_deadline(self):
         os.environ["HINDSIGHT_RETAIN_CLIENT_DEADLINE_S"] = "92"
-        # floor(92 / 18.4) = 5 chunks
-        self.assertEqual(retain_content_limit(), 15000)
+        # floor(92 * 0.7 / 18.4) = floor(3.5) = 3 chunks
+        self.assertEqual(retain_content_limit(), 9000)
 
     def test_limit_never_falls_below_one_chunk(self):
         os.environ["HINDSIGHT_RETAIN_CLIENT_DEADLINE_S"] = "1"
@@ -80,7 +82,77 @@ class TestDerivedLimit(unittest.TestCase):
 
     def test_garbage_env_falls_back_to_the_derived_default(self):
         os.environ["HINDSIGHT_RETAIN_CHUNK_LATENCY_S"] = "not-a-number"
+        self.assertEqual(retain_content_limit(), 33000)
+
+
+class TestTheBoundLeavesMarginUnderTheDeadline(unittest.TestCase):
+    """The bound must NOT consume the whole deadline (#3694).
+
+    Sizing a maximally-sized part to ~100% of the client deadline is what
+    manufactured `.dead` entries on this fleet: every `.dead` marker measured
+    on 2026-07-26 held 16,076-44,568 chars, i.e. every one of them sat UNDER
+    the then-current bound and still could not finish inside the deadline the
+    bound was derived from. `latency` is a MEAN (n=752), so half the
+    extraction calls are slower than it; a part sized to the mean misses its
+    deadline about half the time, the drain bumps its attempt count, and
+    MAX_ATTEMPTS later the memory is dead.
+
+    These assert the OUTCOME — real headroom — rather than the arithmetic, so
+    they fail on the zero-margin derivation regardless of how it is spelled.
+    """
+
+    def tearDown(self):
+        for key in (
+            "HINDSIGHT_RETAIN_MAX_CONTENT_CHARS",
+            "HINDSIGHT_RETAIN_CHUNK_SIZE",
+            "HINDSIGHT_RETAIN_CHUNK_LATENCY_S",
+            "HINDSIGHT_RETAIN_CLIENT_DEADLINE_S",
+            "HINDSIGHT_RETAIN_DEADLINE_SAFETY",
+        ):
+            os.environ.pop(key, None)
+
+    @staticmethod
+    def _worst_case_seconds() -> float:
+        """Sequential extraction time of a maximally-sized part."""
+        chunks = retain_content_limit() / retain_split.DEFAULT_RETAIN_CHUNK_SIZE
+        return chunks * retain_split.DEFAULT_RETAIN_CHUNK_LATENCY_S
+
+    def test_a_maximally_sized_part_finishes_well_inside_the_deadline(self):
+        deadline = retain_split.retain_client_deadline()
+        worst = self._worst_case_seconds()
+        # The pre-#3694 derivation gave 294.4s against 310s -> 0.95 here.
+        self.assertLessEqual(
+            worst / deadline,
+            0.8,
+            f"a maximally-sized part is {worst:.1f}s of extraction against a "
+            f"{deadline:.0f}s deadline: no room for the POST, server queueing, "
+            f"or a chunk slower than the mean",
+        )
+
+    def test_the_headroom_absorbs_a_chunk_distribution_worse_than_its_mean(self):
+        deadline = retain_split.retain_client_deadline()
+        # Every chunk running 25% slower than the measured mean must still fit.
+        self.assertLessEqual(self._worst_case_seconds() * 1.25, deadline)
+
+    def test_the_margin_holds_at_every_deadline_not_just_the_default(self):
+        for seconds in ("120", "200", "310", "600", "900"):
+            os.environ["HINDSIGHT_RETAIN_CLIENT_DEADLINE_S"] = seconds
+            worst = self._worst_case_seconds()
+            deadline = float(seconds)
+            with self.subTest(deadline=seconds):
+                self.assertLessEqual(worst / deadline, 0.8)
+
+    def test_the_safety_fraction_is_operator_tunable(self):
+        os.environ["HINDSIGHT_RETAIN_DEADLINE_SAFETY"] = "0.5"
+        # floor(310 * 0.5 / 18.4) = floor(8.42) = 8 chunks
+        self.assertEqual(retain_content_limit(), 24000)
+
+    def test_a_safety_fraction_above_one_cannot_reintroduce_the_overrun(self):
+        os.environ["HINDSIGHT_RETAIN_DEADLINE_SAFETY"] = "2.0"
+        # Clamped to 1.0, so the WORST an operator can do is the old
+        # zero-margin bound -- never a part sized to overrun outright.
         self.assertEqual(retain_content_limit(), 48000)
+        self.assertLessEqual(self._worst_case_seconds(), retain_split.retain_client_deadline())
 
 
 class TestSplitBounds(unittest.TestCase):


### PR DESCRIPTION
## Problem

`retain_content_limit()` derived the split bound as `chunk_size × floor(deadline / latency)`. That sizes a maximally-sized part to consume **~100% of the client deadline by construction**: `16 × 18.4 = 294.4s` against a `310s` deadline leaves `15.6s` — 5% — for the POST itself, server-side queueing, and any chunk slower than the **mean** the `latency` input is (n=752). Half of all extraction calls are slower than the mean, so a part sized to the mean misses its deadline roughly half the time.

`drain_pending._backlog_timeout()` defaults to that same deadline — deliberately, they must be one number — so the drainer inherits the same zero margin. It times the entry out, bumps `attempt_count`, and after `MAX_ATTEMPTS` ages the memory to `.dead`.

**This is measured, not theoretical.** Every `.dead` marker on this fleet on 2026-07-26 held content of **16,076–44,568 chars** — every one of them *under* the then-current 45,000 bound, and every one of them unable to finish inside the deadline that bound was derived from. The bound was manufacturing dead memories.

Corroborating measurement from the host-side stopgap: `timeout=280 conc=1` drained **0 of 2** with the LLM lane busy *and* **0 of 3** with the lane completely free; `timeout=900 conc=1` drained **5 of 5**. It failed on an idle lane, so this was never lane contention.

## Change

Add a deadline-safety fraction — `HINDSIGHT_RETAIN_DEADLINE_SAFETY`, default `0.7`, clamped to `(0, 1]`:

```
max_content_chars = chunk_size × floor(deadline × safety / latency)
                  = 3000 × floor(310 × 0.7 / 18.4) = 3000 × 11 = 33,000
```

A maximally-sized part is now `202.4s` against `310s` — `107.6s` of headroom, enough to absorb a chunk distribution ~50% worse than its own mean. The clamp at 1.0 means the *worst* an operator can do by misconfiguring it is the old zero-margin bound, never a part sized to overrun outright.

`0.7` is not a taste call: it independently matches the **30,000**-char limit the host-side stopgap converged on empirically before this landed.

Total LLM work is unchanged — the chunk count across a logical memory is identical, only its grouping into parts moves — so the whole cost is more parts, each of which now finishes. A part that finishes is worth strictly more than a larger part that does not.

### Also in this PR (same concern, would be a shipped bug if split out)

`hindsight-watch`'s `PARTS_PER_MEMORY` is the unit-conversion factor between "memories" and queue depth, and is explicitly calibrated against the content bound. B7a waved through a ~6% bound change as noise; this is a **45%** change. Leaving the factor at 4.4 would tighten `QUEUE_FLOOR` and `QUEUE_GROWTH_MIN_ABS` by that much and reintroduce exactly the B6 false positive they exist to prevent.

The B6 population (174 pre-split entries) no longer exists to re-measure, so the revision is applied as the bound ratio: `4.4 × (45,000 / 33,000) = 6.0`. Ratio-scaling is exact for entries far above the bound and over-estimates for entries below it, so the factor errs **high** — quieter — which is the safe direction for a watchdog. Corroborated against the live 2026-07-26 backlog (209 entries): re-splitting at 33,000 rather than 48,000 moves 336 parts → 531, a ratio of 1.58, slightly *above* the 1.45 applied here.

`QUEUE_FLOOR` 440 → 600, `QUEUE_GROWTH_MIN_ABS` 88 → 120.

## Tests assert the outcome, not the arithmetic

`TestTheBoundLeavesMarginUnderTheDeadline` computes the worst-case sequential extraction time of a maximally-sized part and asserts real headroom — so it fails on the zero-margin derivation regardless of how that derivation is spelled:

- a maximally-sized part consumes ≤ 80% of the deadline (the old derivation was 95%)
- the headroom absorbs every chunk running 25% slower than the measured mean
- the margin holds at deadlines of 120/200/310/600/900s, not just the default
- a safety fraction above 1.0 cannot reintroduce the overrun

### Mutation evidence (4/4 killed)

Run with `PYTHONDONTWRITEBYTECODE=1` and `__pycache__` cleared first.

| Mutant | Result |
|---|---|
| revert to `chunks = int(deadline // latency)` (zero margin) | **RED** — 13 failures |
| drop the `min(1.0, value)` clamp | **RED** — 1 failure |
| set the default safety to `0.95` (nominal margin, still too tight) | **RED** — 11 failures |
| leave `PARTS_PER_MEMORY` stale at 4.4 | **RED** — 4 failures |

Clean: `Ran 662 tests ... OK` (`vendor/hindsight-memory/scripts`), `81 passed` (`src/hindsight-watch/`), `npm run lint` clean.

## Relationship to the other open hindsight PRs

- #3688 (content-keyed queue) — independent; stops the queue refilling itself.
- #3689 (scheduled drain) — independent; makes the queue drain at all.
- the `.dead` loss-closure PR — **complementary**: this PR stops new memories being sized into the failure zone; it recovers the ones already there and makes `.dead` non-destructive.

None of the four subsumes another. This one is the upstream root cause: without it, inflow into the failure zone continues no matter how well the drain runs.

Verdict: `reference/jobs/remember-across-sessions.md`
