### PR TITLE
fix(ci): give the npm job's token push access so the release gate can see the draft

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -78,7 +78,25 @@ on:
         type: string
 
 permissions:
-  contents: read
+  # `write` is required to READ, not to write. The self-gate below calls
+  # `GET /repos/{o}/{r}/releases`, and GitHub returns DRAFT releases from
+  # that endpoint only to a caller with PUSH ACCESS. The release is still a
+  # draft every time this workflow runs — release.yml's `finalize` un-drafts
+  # it only after this publish succeeds, which the gate's own comment (below)
+  # already says. Nothing here mutates a release.
+  #
+  # This did not bite before #3654 because releases were created PUBLISHED,
+  # and a published release is visible to anyone; the draft-until-finalize
+  # model made the existing `contents: read` insufficient. v0.19.21 is the
+  # regression: the gate reported found:false / draft:null for a tag whose
+  # draft carried all five assets.
+  #
+  # Both halves are needed. release.yml's `npm` job block caps this one, so
+  # this alone would still yield a read-only token on the workflow_call path.
+  # This block is what covers the `workflow_dispatch` recovery lever, which
+  # has no caller to inherit from — and which is used precisely when the
+  # release is stuck as a draft.
+  contents: write
   actions: read     # read docker-images run conclusions for the self-gate
   id-token: write   # npm provenance (sigstore) — requires npm provenance enabled on the package; harmless if not.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -556,7 +556,33 @@ jobs:
        inputs.dry_run == false &&
        startsWith(github.ref, 'refs/tags/v'))
     permissions:
-      contents: read
+      # `write`, not `read` — and this block is HALF the fix; npm-publish.yml's
+      # own `permissions:` is the other half. A caller job's block CAPS the
+      # token the called workflow gets, so raising either one alone is a
+      # silent no-op.
+      #
+      # WHY WRITE AT ALL: npm-publish.yml's self-gate reads
+      # `GET /repos/{o}/{r}/releases`, and that endpoint returns DRAFT
+      # releases ONLY to a caller with push access. At this point in the
+      # pipeline the release IS a draft — `finalize` un-drafts it only after
+      # npm succeeds — so a `contents: read` token sees no release for the
+      # tag at all and the gate exits 4 ("no release exists"), reported as
+      # "missing assets install.sh needs".
+      #
+      # v0.19.21 died exactly here, and the proof is a three-way control
+      # inside ONE run (30189755957): same script, same endpoint, same tag —
+      # `guard` (contents: write) got found:true, `publish` (contents: write)
+      # got found:true/missing:[] with all five assets attached, and `npm`
+      # (contents: read) got found:false/draft:null. The only variable was
+      # this permission. R11 in tests/release-pipeline-gating.test.ts is the
+      # guard against it coming back.
+      #
+      # The marginal risk is small: this job already carries `NPM_TOKEN`,
+      # which is a strictly bigger prize than repo write, and the alternative
+      # (trusting an upstream job's verdict instead of re-verifying) would
+      # remove the last independent check before an npm publish that cannot
+      # be undone.
+      contents: write
       actions: read
       id-token: write
     uses: ./.github/workflows/npm-publish.yml

--- a/tests/release-pipeline-gating.test.ts
+++ b/tests/release-pipeline-gating.test.ts
@@ -38,18 +38,21 @@ interface Step {
   run?: string;
   env?: Record<string, unknown>;
 }
+type Permissions = string | Record<string, string> | undefined;
 interface Job {
   needs?: string | string[];
   if?: unknown;
   uses?: string;
   steps?: Step[];
   env?: Record<string, unknown>;
+  permissions?: Permissions;
   "continue-on-error"?: unknown;
 }
 interface Workflow {
   on?: Record<string, unknown>;
   jobs?: Record<string, Job>;
   env?: Record<string, unknown>;
+  permissions?: Permissions;
 }
 
 function load(file: string): Workflow {
@@ -81,6 +84,29 @@ function envBound(wf: Workflow, job: Job, step: Step, name: string): boolean {
     if (v !== undefined && v !== null && String(v).trim() !== "") return true;
   }
   return false;
+}
+
+/**
+ * The effective `contents:` scope of a job's GITHUB_TOKEN.
+ *
+ * Unlike `env:`, permissions do NOT layer: a job-level `permissions:` block
+ * REPLACES the workflow-level one outright, and every scope it omits becomes
+ * `none`. So this resolves job-first-or-workflow, never a merge of the two.
+ * An absent block anywhere means "whatever the repo default happens to be",
+ * which is not a guarantee — report it as `null` and let the caller fail
+ * closed rather than assume write.
+ */
+function contentsScope(wf: Workflow, job: Job): string | null {
+  const p: Permissions = job.permissions !== undefined ? job.permissions : wf.permissions;
+  if (p === undefined || p === null) return null;
+  if (typeof p === "string") {
+    // The shorthand forms: `write-all` / `read-all` / `{}` (= none).
+    if (p === "write-all") return "write";
+    if (p === "read-all") return "read";
+    return "none";
+  }
+  const v = p.contents;
+  return typeof v === "string" ? v : "none";
 }
 
 /**
@@ -264,6 +290,73 @@ export function auditGating(release: Workflow, npmPublish: Workflow): string[] {
               "binding a non-empty `EXPECT_TAG` — the script exits 1 and the caller misreports it as missing assets.",
           );
         }
+      }
+    }
+  }
+
+  // R11 — every job that runs the completeness gate must hold
+  // `contents: write`, because that is what lets it SEE A DRAFT.
+  //
+  // `GET /repos/{o}/{r}/releases` returns draft releases only to a caller
+  // with push access; to a `contents: read` token the drafts simply are not
+  // in the payload. The release is a DRAFT at every point this gate runs —
+  // `finalize` is the only thing that un-drafts it, and it runs last — so a
+  // read-scoped caller gets `found:false` for a release that exists and is
+  // complete, and exits 4 ("no release exists for this tag").
+  //
+  // That exit is INDISTINGUISHABLE, to every wrapper on this chain, from
+  // "the assets are missing": all of them branch on `rc -ne 0`. So the wrong
+  // permission does not skip the gate, it fails the gate — on every release,
+  // forever, blaming the assets. Exactly the shape of the R10 defect, one
+  // axis over: R10 is about the ENV a gate call needs, R11 is about the
+  // PERMISSION the same call needs. Neither implies the other.
+  //
+  // v0.19.21 shipped this. The proof is a three-way control inside one run
+  // (30189755957) — same script, same endpoint, same tag, differing only in
+  // this permission:
+  //     guard   (contents: write) → {"found":true,"draft":true,...}
+  //     publish (contents: write) → {"found":true,"draft":true,"missing":[]}
+  //     npm     (contents: read)  → {"found":false,"draft":null,...}
+  // All five assets were attached; npm refused to publish anyway and
+  // `finalize` was skipped, stranding the release as a draft while
+  // `/releases/latest` kept serving the asset-less v0.19.19.
+  //
+  // It stayed latent until then because before #3654 releases were created
+  // PUBLISHED, and a published release is visible to any token. The
+  // draft-until-finalize model is what made `contents: read` insufficient.
+  for (const [file, wf] of [
+    ["release.yml", release],
+    ["npm-publish.yml", npmPublish],
+  ] as const) {
+    for (const [id, job] of Object.entries(wf.jobs ?? {})) {
+      if (!stepsOf(job).some((s) => (s.run ?? "").includes("assert-release-assets-complete.mjs"))) continue;
+      const scope = contentsScope(wf, job);
+      if (scope !== "write") {
+        problems.push(
+          `R11: ${file} job ${id} runs assert-release-assets-complete.mjs with \`contents: ${scope ?? "(unset)"}\` — ` +
+            "the releases LIST endpoint hides DRAFTS from a token without push access, so the gate reports " +
+            "`found:false` for a complete release and blocks every release.",
+        );
+      }
+    }
+  }
+
+  // R11 (caller half) — a job that CALLS npm-publish.yml must itself grant
+  // `contents: write`. A caller job's `permissions:` block is a CAP on the
+  // token the reusable workflow receives, not a default it can exceed, so
+  // raising the permission inside npm-publish.yml alone is a silent no-op:
+  // the callee would still run read-scoped and the gate would still go red.
+  // Both halves or neither.
+  if (Object.values(npmPublish.jobs ?? {}).some((j) => stepsOf(j).some((s) => (s.run ?? "").includes("assert-release-assets-complete.mjs")))) {
+    for (const [id, job] of releaseJobs) {
+      if (!(job.uses ?? "").endsWith("npm-publish.yml")) continue;
+      const scope = contentsScope(release, job);
+      if (scope !== "write") {
+        problems.push(
+          `R11: release.yml job ${id} calls npm-publish.yml with \`contents: ${scope ?? "(unset)"}\` — a caller job's ` +
+            "permissions CAP the called workflow's token, so npm-publish.yml's own `contents: write` is neutered " +
+            "and its draft-visibility gate fails closed on every release.",
+        );
       }
     }
   }
@@ -497,6 +590,87 @@ describe("release pipeline gating — every rule is proved by mutation", () => {
       }
     });
     expect(p.join("\n")).toMatch(/R10:.*npm-publish\.yml.*EXPECT_TAG/);
+  });
+
+  // ── R11: the v0.19.21 regression ───────────────────────────────────────
+  //
+  // Reconstructing the tag's ACTUAL configuration is the proof that matters.
+  // `git show v0.19.21:.github/workflows/{release,npm-publish}.yml` differs
+  // from the fixed files in exactly these two lines, so setting them back
+  // reproduces the tree that died — and R11 is the only rule that fires on
+  // it, which is also how we know it went undetected before.
+  it("R11: the v0.19.21 tree — `contents: read` on both halves of the npm call — is caught", () => {
+    const p = mutate((r, n) => {
+      (r.jobs!.npm.permissions as Record<string, string>).contents = "read";
+      (n.permissions as Record<string, string>).contents = "read";
+    });
+    expect(p.join("\n")).toMatch(/R11: npm-publish\.yml job publish runs assert-release-assets-complete\.mjs with `contents: read`/);
+    expect(p.join("\n")).toMatch(/R11: release\.yml job npm calls npm-publish\.yml with `contents: read`/);
+    // …and nothing else. The pipeline was otherwise clean, which is exactly
+    // why two tags died before anyone could see this.
+    expect(p.filter((x) => !x.startsWith("R11:"))).toEqual([]);
+  });
+
+  it("R11: fixing only npm-publish.yml, leaving the caller capped at read, is caught", () => {
+    // The half-fix that looks right and does nothing: the callee asks for
+    // write, the caller's block never grants it.
+    const p = mutate((r) => {
+      (r.jobs!.npm.permissions as Record<string, string>).contents = "read";
+    });
+    expect(p.join("\n")).toMatch(/R11: release\.yml job npm calls npm-publish\.yml .*CAP/s);
+  });
+
+  it("R11: fixing only the caller, leaving npm-publish.yml at read, is caught", () => {
+    const p = mutate((_r, n) => {
+      (n.permissions as Record<string, string>).contents = "read";
+    });
+    expect(p.join("\n")).toMatch(/R11: npm-publish\.yml job publish runs assert-release-assets-complete/);
+  });
+
+  it("R11: downgrading the un-draft job so it can no longer see the draft is caught", () => {
+    // `finalize` has never executed in any release to date; it re-runs the
+    // same gate on the same draft and would fail the same way.
+    const p = mutate((r) => {
+      (jobDoing(r, "--draft=false")![1].permissions as Record<string, string>).contents = "read";
+    });
+    expect(p.join("\n")).toMatch(/R11: release\.yml job finalize/);
+  });
+
+  it("R11: dropping a gate job's permissions block entirely is caught (repo default is not a guarantee)", () => {
+    const p = mutate((r) => {
+      delete jobDoing(r, "gh release upload")![1].permissions;
+    });
+    // Falls back to release.yml's workflow-level `contents: read`.
+    expect(p.join("\n")).toMatch(/R11: release\.yml job publish .*`contents: read`/);
+  });
+
+  // Guards R11 against over-firing on the legal shorthand: `write-all` really
+  // does grant contents:write, and a rule that flagged it would push people
+  // toward silencing the rule rather than fixing the permission.
+  it("R11: the `write-all` shorthand satisfies the rule", () => {
+    const p = mutate((r) => {
+      jobDoing(r, "gh release upload")![1].permissions = "write-all";
+    });
+    expect(p.join("\n")).not.toMatch(/R11:/);
+  });
+
+  // Guards the rule against under-firing on the OTHER shorthand.
+  it("R11: the `read-all` shorthand is caught", () => {
+    const p = mutate((r) => {
+      jobDoing(r, "gh release upload")![1].permissions = "read-all";
+    });
+    expect(p.join("\n")).toMatch(/R11: release\.yml job publish .*`contents: read`/);
+  });
+
+  // Permissions do NOT layer the way env does: a job block REPLACES the
+  // workflow block, so a job that sets only `actions: read` silently drops
+  // contents to `none`. Pin that, because it is the subtle way this defect
+  // returns.
+  it("R11: a job block that omits `contents:` drops it to none, and is caught", () => {
+    const p = mutate((r) => {
+      jobDoing(r, "--draft=false")![1].permissions = { actions: "read" };
+    });
+    expect(p.join("\n")).toMatch(/R11: release\.yml job finalize .*`contents: none`/);
   });
 
   // Guards the rule against over-firing: GitHub really does inherit env from


### PR DESCRIPTION
## The defect

v0.19.21 reached the `npm` job with **all five assets already attached to the release**, and the self-gate then refused to publish, reporting the release as missing every asset it had just verified. `finalize` was skipped, the release stranded as a draft, and `/releases/latest` kept serving the asset-less **v0.19.19** — `curl | sh` has now been broken in production across two tags.

**Root cause.** `GET /repos/{o}/{r}/releases` returns **draft** releases only to a caller with **push access**. Since #3654 the release is a draft at every point the completeness gate runs (`finalize` un-drafts it last, on purpose), but `release.yml`'s `npm` job — and `npm-publish.yml` itself — declared `contents: read`. The gate saw *no release for the tag at all* and exited **4** (`no release exists`). Every wrapper on this chain branches on `rc -ne 0`, so that exit is indistinguishable from "the assets are missing", which is what the error message said.

The decisive evidence is a **three-way control inside a single run** ([30189755957](https://github.com/switchroom/switchroom/actions/runs/30189755957)) — same script, same endpoint, same tag, same commit; only the permission differs:

| job | `contents:` | `assert-release-assets-complete.mjs` stdout |
|---|---|---|
| `guard` | **write** | `{"found":true,"draft":true,...}` |
| `publish` | **write** | `{"found":true,"draft":true,"missing":[]}` |
| `npm` | **read** | `{"found":false,"draft":null,...}` ← |

It stayed latent because before #3654 releases were created **published**, and a published release is visible to any token. Draft-until-finalize is what made `contents: read` insufficient. v0.19.20 died in `publish` (#3691), so the `npm` job never ran and never exposed this.

## Why option (a), not (b)

Two options were on the table.

**(a) — chosen. Grant `contents: write` to the `npm` caller job and to `npm-publish.yml`.**

**(b) — rejected. Keep `npm` at `contents: read`; have `publish` (already write) emit its verdict as a job output that `npm` gates on.**

(b) is the better-looking choice on least-privilege grounds and it is still wrong here, for three reasons in increasing order of weight:

1. **It buys no ordering.** `npm` already has `needs: [publish, images-gate]`. A job output threaded through `with:` adds nothing to sequencing — `publish` failing already blocks `npm` today.
2. **It deletes the last independent check before an irreversible act.** `npm publish` cannot be undone; that is the entire stated reason the self-gate exists (`npm-publish.yml` header, "SELF-GATE (#3654)"). Replacing "re-prove it from inside my own run" with "trust the verdict an upstream job handed me" removes exactly the property the gate was built for, at exactly the step where it matters.
3. **It leaves the documented recovery lever permanently broken — this is decisive.** `npm-publish.yml` has a `workflow_dispatch` trigger described as the lever for "the release pipeline went green everywhere except npm". On that path there is no caller to inherit an output from, and the release is *by definition* still a draft. Under (b) the workflow-level `contents: read` stands, the gate still cannot see the draft, and the hand-dispatch recovery still fails — the exact situation you would be dispatching it in. (a) fixes that path too.

**The cost of (a), stated plainly:** the job holding `NPM_TOKEN` now also holds a repo-write `GITHUB_TOKEN`. That is a real widening. It is a small marginal one, because an automation token with publish rights on `switchroom` is a strictly larger prize than repo write, and it was already in that job. Note also that nothing here *writes*: `contents: write` is required purely to **read** a draft.

**Both halves are mandatory.** A caller job's `permissions:` block is a **cap** on the token a reusable workflow receives, not a floor it can raise. Raising only the caller leaves `npm-publish.yml` self-limited to read; raising only the callee is worse than a no-op — it **kills the whole run at startup**, because a called workflow may not request more than its caller grants. That is not a guess: it is what happened on the first attempt of the probe below ([30190529154](https://github.com/switchroom/switchroom/actions/runs/30190529154), `startup_failure`, zero jobs started).

## Proof — a live, read-only probe on the real API

`release.yml`'s `dry_run` **cannot** exercise this. `images-gate`, `guard`, `publish`, `npm` and `finalize` are each `if:`-gated on `inputs.dry_run == false`, so a dry run executes only `build` and `bundle`. The gating path is unreachable from a rehearsal, and the *fixed* permission combination had never run anywhere in this repo.

So it was proved directly, on the `probe/draft-visibility` branch (temporary, deleted, never merged): two legs invoking a reusable workflow through `uses:`, differing **only** in the `contents:` scope, each running the real `scripts/ci/assert-release-assets-complete.mjs` against the **existing v0.19.21 draft** (which carries all five assets). Every call is a GET; nothing was mutated.

[Run 30190629605](https://github.com/switchroom/switchroom/actions/runs/30190629605):

```
via-read   contents:READ on both halves — the exact v0.19.21 configuration
  PROBE-DRAFTS-VISIBLE: (none)
  PROBE-GATE-EXIT: 4
  PROBE-GATE-SUMMARY: {"tag":"v0.19.21","found":false,"draft":null,...}

via-write  contents:WRITE on both halves — the fix
  PROBE-DRAFTS-VISIBLE: v0.19.21,v0.19.20,v0.8.0
  PROBE-GATE-EXIT: 0
  PROBE-GATE-SUMMARY: {"tag":"v0.19.21","found":true,"draft":true,"id":359935708,"missing":[]}
```

Same script, same tag, same reusable-workflow path the `npm` job takes. One line of YAML flips it.

## The structural guard — R11

Analogous to R10, one axis over: **R10 is about the `env` a gate call needs; R11 is about the `permission` the same call needs.** Neither implies the other, and the pipeline passed R1–R10 clean while dying on this.

- **R11 (gate half)** — every job running `assert-release-assets-complete.mjs` must hold `contents: write`.
- **R11 (caller half)** — any job that `uses:` `npm-publish.yml` must itself grant `contents: write`, because the caller caps the callee.

`contentsScope()` models GitHub's real semantics rather than env-style layering: a job-level `permissions:` block **replaces** the workflow-level one outright, so a block that omits `contents:` silently drops it to `none`. An absent block resolves to `null` and fails closed.

**Proved against the real v0.19.21 tree**, not just a synthetic mutation. `git show v0.19.21:.github/workflows/{release,npm-publish}.yml` piped through the new `auditGating()`:

```
>>> auditGating(v0.19.21 tree) reported 2 problem(s):
    R11: npm-publish.yml job publish runs assert-release-assets-complete.mjs with `contents: read` — …
    R11: release.yml job npm calls npm-publish.yml with `contents: read` — …
```

Two problems, both R11, **and nothing else** — which is also precisely why this was invisible until a tag hit it. The committed test reconstructs that same configuration as a mutation (house pattern, no fixture to go stale) and additionally asserts `problems.filter(p => !p.startsWith("R11:")) === []`. Eight new mutation cases cover: the v0.19.21 tree, each half-fix alone, a downgraded `finalize`, a deleted `permissions:` block, `read-all`, a job block that omits `contents:`, and an over-fire guard proving `write-all` stays clean.

## Static audit of the rest of the path

Every job in both workflows was checked on the axis both failures shared — `permissions` vs `env` vs what each script actually reads from `process.env`:

| script | requires | callsites | verdict |
|---|---|---|---|
| `assert-release-assets-complete.mjs` | `EXPECT_TAG` | `guard`, `publish`, `finalize`, npm-publish gate 1 | env OK everywhere (R10/#3691); permission was the gap, now closed |
| `classify-workflow-run.mjs` | `EXPECT_TAG`, `EXPECT_SHA` | `images-gate`, npm-publish gate 2 | OK — npm-publish sets `EXPECT_SHA` in-shell and `export`s it (`npm-publish.yml:190-191`) |
| `verify-release-bundle.mjs` | — (argv only) | `bundle` | OK |
| `scripts/build.mjs` | `TAG_VERSION` (optional), `GITHUB_REF` | `build`, npm-publish | OK — npm-publish binds no `TAG_VERSION`, resolves via `GITHUB_REF` at Layer 2; the mis-stamp guard sees one consistent signal |

`gh` needs `GH_TOKEN`: bound in all six `gh`-using steps. `actions: read` is present in both jobs that read run conclusions. No further mismatch of this class remains.

Two things worth recording that are **not** defects:

- Everything in `npm-publish.yml` after the self-gate has **never executed on the `workflow_call` path** — its 12 prior successes were all on the pre-#3654 `push` trigger. `git diff v0.19.19..main -- .github/workflows/npm-publish.yml` shows those post-gate steps changed only by `${{ }}` → `env:` refactors (R8) and an added empty-token guard, so they are semantically the code that has shipped 12 releases — but the *context* (reusable workflow, explicit-ref checkout, caller-capped token) is new.
- `finalize` has **never run in any release**. Its `gh release edit "$EXPECT_TAG" --draft=false` resolves a release that is still a draft; verified that `gh` falls back to the draft-listing lookup when `/releases/tags/{tag}` 404s (`gh release view v0.19.21` returns the draft), and `finalize` holds `contents: write`, so the fallback has the access it needs.

## Testing

- `tests/release-pipeline-gating.test.ts` — 34 passing (was 26)
- `tests/release-asset-contract.test.ts`, `tests/ci-merge-queue-triggers.test.ts`, `tests/ci-infra-watchdog.test.ts`, `tests/docker/manifest-jobs-no-buildx.test.ts` — 117 passing together
- `npm run lint` — exit 0
- `actionlint` — clean on both changed workflows

CI is the full-suite authority.
