### PR TITLE
fix(hindsight): no recoverable memory can be destroyed by a janitor

### DIFF
--- a/src/cli/doctor-pending-retains.test.ts
+++ b/src/cli/doctor-pending-retains.test.ts
@@ -447,6 +447,28 @@ describe("buildPendingRetainsProbeScript — eviction window arithmetic", () => 
     expect(r.D).toBe(2);
   });
 
+  it("counts dead markers in the pending-dead/ sibling too", () => {
+    // Markers moved OUT of the live queue directory so no janitor glob can
+    // match a memory. If the probe only counted the in-queue form, that
+    // relocation would read as "0 dead" and silently retire the operator's
+    // only view of permanently-failed retains.
+    const dd = join(base, "pending-dead");
+    mkdirSync(dd, { recursive: true });
+    for (const n of ["1-a.json.dead", "2-b.json.dead"])
+      writeFileSync(join(dd, n), "{}");
+    const r = runProbe();
+    expect(r.D).toBe(2);
+    expect(r.P).toBe(0); // and never as queue depth
+  });
+
+  it("sums dead across BOTH locations during a mid-migration fleet", () => {
+    writeFileSync(join(base, "pending-retains", "legacy.json.dead"), "{}");
+    const dd = join(base, "pending-dead");
+    mkdirSync(dd, { recursive: true });
+    writeFileSync(join(dd, "moved.json.dead"), "{}");
+    expect(runProbe().D).toBe(2);
+  });
+
   it("reads the residual-drop count from the sibling ledger", () => {
     writeFileSync(
       join(base, "pending-drops.json"),

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1551,6 +1551,15 @@ export function buildPendingRetainsProbeScript(
     `P=$(ls -1 '${dir}' 2>/dev/null | grep -c '\\.json$' || true); ` +
     `D=$(ls -1 '${dir}' 2>/dev/null | grep -c '\\.json\\.dead$' || true); ` +
     `fi; ` +
+    // `.dead` markers are now retired into the `pending-dead/` SIBLING rather
+    // than left among the live entries (a marker is the only remaining copy of
+    // its memory, and the queue directory is what janitors sweep). Both
+    // locations are summed: counting only the in-queue form would make the
+    // relocation read as "0 dead", i.e. silently retire the operator's only
+    // view of permanently-failed retains.
+    `if [ -d '${base}/pending-dead' ]; then ` +
+    `D=$((D + $(ls -1 '${base}/pending-dead' 2>/dev/null | grep -c '\\.dead$' || true))); ` +
+    `fi; ` +
     `for L in '${base}/pending-drops.json' '${dir}/.drops.json'; do ` +
     `if [ "$X" = 0 ] && [ -f "$L" ]; then ` +
     `X=$(grep -o '"count"[^0-9]*[0-9][0-9]*' "$L" 2>/dev/null ` +

--- a/src/hindsight-watch/probe.test.ts
+++ b/src/hindsight-watch/probe.test.ts
@@ -66,6 +66,27 @@ describe("probeSpool — #3599's loss channels are siblings, not queue entries",
     expect(s.pending).toBe(1); // NOT 3
   });
 
+  it("counts pending-dead/ so relocating markers cannot zero the loss signal", () => {
+    queue("alpha", { "a.json": "{}" });
+    const dd = join(hindsight("alpha"), "pending-dead");
+    mkdirSync(dd, { recursive: true });
+    writeFileSync(join(dd, "d1.json.dead"), "{}");
+    writeFileSync(join(dd, "d2.json.dead"), "{}");
+    const s = probeSpool(dir);
+    expect(s.dead).toBe(2);
+    expect(s.pending).toBe(1); // NOT 3
+  });
+
+  it("counts dead in BOTH locations while legacy in-queue markers survive", () => {
+    // A fleet mid-migration has markers in the old and the new place at once.
+    // Counting only one would under-report the loss channel.
+    queue("alpha", { "a.json": "{}", "legacy.json.dead": "{}" });
+    const dd = join(hindsight("alpha"), "pending-dead");
+    mkdirSync(dd, { recursive: true });
+    writeFileSync(join(dd, "moved.json.dead"), "{}");
+    expect(probeSpool(dir).dead).toBe(2);
+  });
+
   it("sums the record_drop ledger count", () => {
     queue("alpha", {});
     writeFileSync(

--- a/src/hindsight-watch/probe.ts
+++ b/src/hindsight-watch/probe.ts
@@ -224,6 +224,18 @@ export function probeSpool(
     } catch {
       // Nothing has ever been evicted for this agent. Not a fault.
     }
+    // `.dead` markers used to be written INSIDE `pending-retains`; they are
+    // now retired into the `pending-dead/` sibling so that no janitor glob
+    // over the live queue can match a memory. Both locations are counted:
+    // if only the in-queue form were counted, the relocation would read as
+    // `dead` dropping to zero, i.e. a silent loss of the loss signal.
+    try {
+      for (const f of readdirSync(resolve(hindsightDir, "pending-dead"))) {
+        if (f.endsWith(".dead")) dead++;
+      }
+    } catch {
+      // Nothing has ever been retired for this agent. Not a fault.
+    }
     drops += readDropCount(hindsightDir);
   }
   return { pending, dead, evicted, drops, agents };

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -5,8 +5,12 @@ SessionStart calls into ``drain()`` to retry any retain payloads that
 ``session_end.py`` queued on failure (#1071). Each entry is retried up
 to ``MAX_ATTEMPTS`` (5) times; after that a **permanently** failing entry
 (a 4xx that a re-POST cannot fix — see ``pending.is_permanent_failure``)
-is renamed to ``.dead`` so the queue no longer drains it but the operator
-can still inspect via ``switchroom doctor``. An entry failing on anything
+is retired into the ``pending-dead/`` archive so the queue no longer
+drains it but the operator can still inspect via ``switchroom doctor``.
+The marker deliberately does NOT stay in the live queue directory: it is
+the only remaining copy of that memory, and leaving it among the live
+entries put it in the path of every janitor that sweeps that
+directory. An entry failing on anything
 else — a 5xx, a timeout, a connection error — stays queued past the
 attempt budget: a transient upstream is never evidence that the memory
 is unsaveable, and retiring it would lose content the user believes was
@@ -62,6 +66,15 @@ documents**, 3,815 of them with facts extracted.
   agents fell into ~368 distinct groups — ~65% of the queue was duplicate,
   with one group repeated 32 times. At ~168 s per phase-2 extraction that
   one group alone was 90 minutes of LLM lane time for a single memory.
+* **Phase 0b — relocate legacy ``.dead`` markers (free, no network).**
+  Markers written by an older build into the live queue directory are moved
+  into ``pending-dead/``, so the live queue holds only live entries and no
+  janitor glob over it can match a memory.
+* **Phase 0c — re-split over-bound entries (free, no network).** An entry
+  whose content exceeds ``retain_content_limit()`` needs more sequential
+  extraction calls than fit the client deadline, so it can never be drained
+  as-is; splitting it makes every part drainable. Measured 2026-07-26: 18 of
+  211 queued entries exceeded 100,000 chars, the largest 744,546.
 * **Phase 1 — reconcile (free).** GET the document. If it exists, the
   memory is already durable; retire the queue entry without a POST. No
   LLM work, no cost, idempotent, resumable at any point. Only for
@@ -117,9 +130,11 @@ from lib.pending import (
     is_permanent_failure,
     iter_entries,
     mark_dead,
+    resplit_over_bound_entries,
+    sweep_legacy_dead_markers,
     update_attempt,
 )
-from lib.retain_split import retain_client_deadline
+from lib.retain_split import retain_client_deadline, retain_content_limit
 
 
 STALL_THRESHOLD = 3
@@ -542,6 +557,9 @@ def _new_summary() -> dict:
         # Redundant copies retired by `pending.collapse_duplicates` before
         # any network work. Backlog mode only — see `_drain_backlog_impl`.
         "collapsed": 0,
+        "dead_relocated": 0,
+        "resplit": 0,
+        "resplit_parts": 0,
         "stalled": False,
         "budget_exceeded": False,
     }
@@ -579,6 +597,9 @@ def drain(
          "archive_failed": int,  # durable, but the archive was unwritable
                                  # so the entry is STILL QUEUED
          "collapsed": int, # duplicate copies archived (backlog mode only)
+         "dead_relocated": int,  # legacy .dead markers moved out of the queue dir
+         "resplit":   int, # over-bound entries split into drainable parts
+         "resplit_parts": int,  # parts those entries became
          "stalled": bool,  # stall guard tripped
          "budget_exceeded": bool}
     """
@@ -822,6 +843,40 @@ def _drain_backlog_impl(
                 f"archived, not deleted"
             )
 
+        # PHASE 0b — relocate any legacy `.dead` markers out of the live
+        # queue directory. Free, local, and an UPGRADE step: markers written
+        # by an older build sit in the directory external janitors sweep, and
+        # a marker is the only remaining copy of its memory.
+        moved = sweep_legacy_dead_markers()
+        if moved:
+            summary["dead_relocated"] = moved
+            _blog(
+                f"phase 0b: relocated {moved} legacy .dead marker(s) out of "
+                f"the live queue directory; the queue now holds only live "
+                f"entries, so no janitor glob over it can match a memory"
+            )
+
+        # PHASE 0c — re-split entries the drain provably CANNOT retain.
+        #
+        # An entry over `retain_content_limit()` needs more sequential
+        # extraction calls than fit the deadline, so every POST is guaranteed
+        # waste; if the server rejects the body as a 4xx it is classified
+        # permanent and the memory goes `.dead`. Splitting it makes every
+        # part drainable, which is the difference between a lost memory and a
+        # slow one. Runs after the duplicate collapse so a duplicated
+        # over-bound entry is split ONCE, not once per copy.
+        entries_split, parts_written = resplit_over_bound_entries()
+        if entries_split:
+            summary["resplit"] = entries_split
+            summary["resplit_parts"] = parts_written
+            _blog(
+                f"phase 0c: re-split {entries_split} entr"
+                f"{'y' if entries_split == 1 else 'ies'} over the "
+                f"{retain_content_limit()}-char retain bound into "
+                f"{parts_written} drainable part(s); the originals are "
+                f"archived, not deleted"
+            )
+
     if phase in ("reconcile", "both"):
         _reconcile_phase(config, summary, dry_run)
     if phase == "reconcile":
@@ -1003,6 +1058,8 @@ def main(argv: list[str] | None = None) -> int:
         summary[k]
         for k in (
             "collapsed",
+            "dead_relocated",
+            "resplit",
             "drained",
             "retried",
             "dead",
@@ -1015,6 +1072,8 @@ def main(argv: list[str] | None = None) -> int:
             f"[Hindsight] drain_pending{'(backlog)' if args.backlog else ''}: "
             f"drained={summary['drained']} reconciled={summary['reconciled']} "
             f"collapsed={summary['collapsed']} "
+            f"dead_relocated={summary['dead_relocated']} "
+            f"resplit={summary['resplit']}(+{summary['resplit_parts']} parts) "
             f"retried={summary['retried']} dead={summary['dead']} "
             f"unknown={summary['unknown']} "
             f"archive_failed={summary['archive_failed']} "

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -68,13 +68,19 @@ documents**, 3,815 of them with facts extracted.
   one group alone was 90 minutes of LLM lane time for a single memory.
 * **Phase 0b — relocate legacy ``.dead`` markers (free, no network).**
   Markers written by an older build into the live queue directory are moved
-  into ``pending-dead/``, so the live queue holds only live entries and no
-  janitor glob over it can match a memory.
+  into ``pending-dead/``. ``mark_dead`` no longer produces such a marker, so
+  after this phase has run once the live queue holds only live entries and no
+  janitor glob over it can match a memory. Note the CONDITION: phases 0b and
+  0c run in BACKLOG mode only (``drain_backlog``, and not under
+  ``--dry-run``). The SessionStart ``drain()`` never calls them, so on a host
+  where the backlog drain has not run, legacy markers are still sitting in
+  the queue directory.
 * **Phase 0c — re-split over-bound entries (free, no network).** An entry
   whose content exceeds ``retain_content_limit()`` needs more sequential
   extraction calls than fit the client deadline, so it can never be drained
   as-is; splitting it makes every part drainable. Measured 2026-07-26: 18 of
-  211 queued entries exceeded 100,000 chars, the largest 744,546.
+  211 queued entries exceeded 100,000 chars, the largest 744,546. Backlog
+  mode only, same as 0b.
 * **Phase 1 — reconcile (free).** GET the document. If it exists, the
   memory is already durable; retire the queue entry without a POST. No
   LLM work, no cost, idempotent, resumable at any point. Only for

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -271,11 +271,28 @@ RESPLIT_MAX_ENTRIES = int(
 RESPLIT_MAX_BYTES = int(
     os.environ.get("HINDSIGHT_PENDING_RESPLIT_MAX_BYTES") or (64 * 1024 * 1024)
 )
-# Fields `_build_entry` adds on top of the caller's payload. `enqueue()`
-# takes a PAYLOAD, so an entry read back off disk has to be stripped of them
-# before it can be re-enqueued (see `resplit_over_bound_entries`); leaving
-# them in would round-trip a stale `failed_at`/`attempt_count` into the new
-# entries and mis-order the queue.
+# Fields that belong to a queue ENTRY rather than to the caller's PAYLOAD.
+# `enqueue()` takes a payload, so an entry read back off disk has to be
+# stripped of them before it can be re-enqueued (see
+# `resplit_over_bound_entries`).
+#
+# Which members are load-bearing, checked against `_build_entry` (it is the
+# only writer of the first four):
+#
+#   - `attempt_count`, `last_attempt_at`, `dead_at` are LOAD-BEARING.
+#     `_build_entry` uses `setdefault` for `attempt_count` and never touches
+#     the other two, so leaving them in really does round-trip an exhausted
+#     retry budget — and a `last_attempt_at` from days ago paired with a
+#     fresh `attempt_count: 1` — straight into the new parts, sending a
+#     re-split part back toward `.dead` on its first failure.
+#   - `schema`, `failed_at`, `error_class`, `error_message` are
+#     DEFENCE-IN-DEPTH. `_build_entry` assigns all four unconditionally, so
+#     they cannot round-trip today. They are stripped anyway to keep the
+#     contract "what goes into `enqueue()` is a payload, not an entry" true
+#     of the dict itself, so no future `setdefault` here (as `attempt_count`
+#     already is) silently starts inheriting them. The strip is asserted on
+#     the payload, not only on the resulting entries — see
+#     `test_the_parts_carry_no_stale_attempt_metadata`.
 _ENTRY_ONLY_FIELDS = frozenset(
     {
         "schema",
@@ -283,9 +300,6 @@ _ENTRY_ONLY_FIELDS = frozenset(
         "error_class",
         "error_message",
         "attempt_count",
-        # `update_attempt` stamps this on every retry. It describes the OLD
-        # entry's attempt history, so carrying it into a fresh part would
-        # pair a `last_attempt_at` from days ago with `attempt_count: 1`.
         "last_attempt_at",
         "dead_at",
     }
@@ -802,7 +816,12 @@ def resplit_over_bound_entries() -> tuple[int, int]:
     A refusal here does NOT stamp the drop ledger
     (``record_refusal_as_drop=False``): the ledger means permanently lost and
     `switchroom doctor` fails on it, but the original is still queued and is
-    retried on every backlog drain, so stamping it would climb forever.
+    retried on every backlog drain, so stamping it would climb forever. The
+    same reasoning applies one level down, to a PER-PART failure — an
+    over-cap part, or a part whose write hit ENOSPC — which is why the drops
+    are collected on ``deferred_drops`` and only stamped
+    (``record_deferred_drops``) on the branches below where the original has
+    actually left the live queue.
 
     WHAT THIS COSTS, honestly. One entry becomes N, so the queue gets DEEPER
     (measured worst case on this fleet: 744,546 chars -> 23 parts). On a
@@ -823,6 +842,7 @@ def resplit_over_bound_entries() -> tuple[int, int]:
         payload = {k: v for k, v in entry.items() if k not in _ENTRY_ONLY_FIELDS}
         d = _ensure_dir()
         before = set(_list_entries(d))
+        deferred: list = []
         _first, returned = enqueue_parts(
             payload,
             RuntimeError(
@@ -830,6 +850,7 @@ def resplit_over_bound_entries() -> tuple[int, int]:
                 f"{limit}-char retain bound"
             ),
             record_refusal_as_drop=False,
+            deferred_drops=deferred,
         )
         # New FILES only. A queue-depth delta would be wrong in both
         # directions: 0 when a part deduped onto an existing entry (the
@@ -850,27 +871,56 @@ def resplit_over_bound_entries() -> tuple[int, int]:
             os.makedirs(dest_dir, mode=0o700, exist_ok=True)
             shutil.move(path, os.path.join(dest_dir, os.path.basename(path)))
         except OSError as e:
-            # The parts are already queued; leaving the original queued too
-            # means the memory is retained twice, which the upsert on
-            # document_id makes harmless. Losing it would not be.
+            if os.path.exists(path):
+                # The parts are already queued; leaving the original queued
+                # too means the memory is retained twice, which the upsert on
+                # document_id makes harmless. Losing it would not be.
+                print(
+                    f"[Hindsight] pending: re-split {os.path.basename(path)} "
+                    f"into {written} part(s) but could not archive the original "
+                    f"into {dest_dir} ({e}) — it STAYS QUEUED (never deleted)",
+                    file=sys.stderr,
+                )
+                continue
+            # The move failed because the original is NO LONGER IN THE QUEUE:
+            # writing the parts filled it and `_evict_to_fit` FIFO-shed the
+            # very entry being re-split (it is the oldest — the parts are all
+            # newer than it). Saying "STAYS QUEUED" here is simply false, and
+            # this is the line an operator reads under exactly that pressure.
+            # Nothing is lost — the parts carry the whole memory and the
+            # original is under `evicted_dir()` — but the entry IS retired
+            # from the live queue, so it counts like an archived one below.
             print(
                 f"[Hindsight] pending: re-split {os.path.basename(path)} into "
-                f"{written} part(s) but could not archive the original into "
-                f"{dest_dir} ({e}) — it STAYS QUEUED (never deleted)",
+                f"{written} queued part(s); the original could not be archived "
+                f"into {dest_dir} ({e}) because writing the parts filled the "
+                f"queue and it was itself evicted — it is NOT queued, it is "
+                f"under {evicted_dir()} (the parts carry the whole memory)",
                 file=sys.stderr,
             )
-            continue
+        else:
+            _trim_dir(dest_dir, RESPLIT_MAX_ENTRIES, RESPLIT_MAX_BYTES)
+            print(
+                f"[Hindsight] pending: re-split {os.path.basename(path)} "
+                f"({len(content)} chars, over the {limit}-char bound) into "
+                f"{written} queued part(s); the original is archived under "
+                f"{dest_dir}, not deleted",
+                file=sys.stderr,
+            )
 
-        _trim_dir(dest_dir, RESPLIT_MAX_ENTRIES, RESPLIT_MAX_BYTES)
+        # Reached only on the branches where the original has LEFT the live
+        # queue (archived, or evicted out from under the archive). Both are
+        # a completed re-split, so both count — the `continue` above used to
+        # skip the accounting on the evicted branch, returning (0, 0) after
+        # genuinely writing N parts, which silenced phase 0c's `_blog` line
+        # and under-reported `summary["resplit"]`.
         resplit += 1
         parts += written
-        print(
-            f"[Hindsight] pending: re-split {os.path.basename(path)} "
-            f"({len(content)} chars, over the {limit}-char bound) into "
-            f"{written} queued part(s); the original is archived under "
-            f"{dest_dir}, not deleted",
-            file=sys.stderr,
-        )
+        # And only now can a per-part failure be called a loss: the original
+        # is gone from the queue, so nothing will retry the parts that never
+        # got written. While it was still queued, stamping these would have
+        # failed `switchroom doctor` for a memory that was never lost.
+        record_deferred_drops(deferred)
     return resplit, parts
 
 
@@ -1179,6 +1229,21 @@ def record_drop(payload: dict, error: BaseException) -> int:
     return count_now
 
 
+def record_deferred_drops(drops: list) -> int:
+    """Stamp the ledger for drops ``enqueue_parts`` handed back deferred.
+
+    Call this ONLY once the caller's own copy of the memory has left the
+    live queue — that is the moment a per-part failure stops being a
+    retryable "nothing was written, the original stays queued" and becomes
+    the permanent loss ``record_drop`` claims. Returns how many were
+    recorded, so a caller can assert it stamped nothing on the keep-queued
+    branches.
+    """
+    for payload, error in drops:
+        record_drop(payload, error)
+    return len(drops)
+
+
 def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     """Persist a failed retain payload.
 
@@ -1210,6 +1275,7 @@ def enqueue_parts(
     error: BaseException,
     *,
     record_refusal_as_drop: bool = True,
+    deferred_drops: Optional[list] = None,
 ) -> tuple[Optional[str], list[str]]:
     """``enqueue()``, plus EVERY path ``_enqueue_one`` handed back.
 
@@ -1229,9 +1295,20 @@ def enqueue_parts(
     two whole-memory refusals below. ``record_drop`` means "this memory is
     PERMANENTLY LOST" — `switchroom doctor` fails on a non-zero ledger — so
     a caller that keeps the memory queued when the refusal comes back must
-    not stamp it. Only the whole-memory refusals are suppressed; a per-part
-    failure inside ``_enqueue_one`` still records, because by then the other
-    parts are queued and the caller will retire its copy.
+    not stamp it.
+
+    ``deferred_drops`` closes the same hole on the PER-PART door. A per-part
+    failure inside ``_enqueue_one`` (its own ``MAX_BYTES`` refusal, or a
+    write that fails after eviction made room) is NOT self-evidently a loss:
+    when every part fails, ``enqueue_parts`` hands back nothing, the caller
+    keeps its copy queued, and phase 0c retries the whole thing on the next
+    backlog drain — so stamping there makes the ledger climb by one part per
+    part per drain while describing zero lost memories, and it never resets
+    once the disk is fixed. Pass a list and those drops are collected onto it
+    instead; call :func:`record_deferred_drops` only on the branch where the
+    caller's copy actually leaves the live queue. With ``deferred_drops=None``
+    (the producers: ``session_end`` / ``retain``, who hold no other copy) the
+    ledger is stamped immediately, exactly as before.
     """
     d = _ensure_dir()
 
@@ -1239,7 +1316,7 @@ def enqueue_parts(
     parts = split_retain_content(content) if isinstance(content, str) else [content]
     total = len(parts)
     if total <= 1:
-        one = _enqueue_one(d, payload, error)
+        one = _enqueue_one(d, payload, error, deferred_drops=deferred_drops)
         return one, ([] if one is None else [one])
 
     base_doc = payload.get("document_id", "conversation")
@@ -1287,16 +1364,19 @@ def enqueue_parts(
         # MAX_BYTES refusal, eviction, the drop ledger — because each part
         # is an independently drainable memory, not a fragment that only
         # means something alongside its siblings. A part that cannot be
-        # written is recorded as a drop and the remaining parts still go in;
-        # returning ``None`` for the whole memory because part 7 of 9 hit
-        # ENOSPC would discard eight recoverable turns.
+        # written is recorded as a drop (or collected onto ``deferred_drops``
+        # for the caller to decide, see above) and the remaining parts still
+        # go in; returning ``None`` for the whole memory because part 7 of 9
+        # hit ENOSPC would discard eight recoverable turns.
         #
         # A part CAN evict an earlier part of the same memory when the queue
         # is already at its cap (eviction is FIFO and earlier parts are
         # older). That is the same trade `_evict_to_fit` documents — the
         # evicted part MOVES to ``pending-evicted/``, so it is shed, not
         # destroyed, except under the sustained-ENOSPC case named there.
-        written = _enqueue_one(d, part_payload, error)
+        written = _enqueue_one(
+            d, part_payload, error, deferred_drops=deferred_drops
+        )
         if written is not None:
             returned.append(written)
             if first is None:
@@ -1326,8 +1406,28 @@ def _entry_blob_bytes(payload: dict, error: BaseException) -> int:
     return len(json.dumps(_build_entry(payload, error), ensure_ascii=False).encode("utf-8"))
 
 
-def _enqueue_one(d: str, payload: dict, error: BaseException) -> Optional[str]:
-    """Write exactly ONE queue entry for ``payload``. See ``enqueue()``."""
+def _enqueue_one(
+    d: str,
+    payload: dict,
+    error: BaseException,
+    *,
+    deferred_drops: Optional[list] = None,
+) -> Optional[str]:
+    """Write exactly ONE queue entry for ``payload``. See ``enqueue()``.
+
+    ``deferred_drops``, when a list is passed, DEFERS both ``record_drop``
+    calls below: the ``(payload, error)`` pair is appended to the list
+    instead of being stamped on the ledger straight away. The caller then
+    owns the decision and must call :func:`record_deferred_drops` if — and
+    only if — it stops keeping its own copy of the memory. See
+    ``enqueue_parts`` for why that decision cannot be made here.
+    """
+    def _drop(err: BaseException) -> None:
+        if deferred_drops is None:
+            record_drop(payload, err)
+        else:
+            deferred_drops.append((payload, err))
+
     entry = _build_entry(payload, error)
 
     blob = json.dumps(entry, ensure_ascii=False)
@@ -1359,7 +1459,7 @@ def _enqueue_one(d: str, payload: dict, error: BaseException) -> Optional[str]:
     # guard the eviction loop below evicts the ENTIRE queue trying to make
     # room and then writes it anyway — trading every queued memory for one.
     if blob_bytes > MAX_BYTES:
-        record_drop(payload, ValueError(
+        _drop(ValueError(
             f"entry is {blob_bytes} bytes, larger than the whole "
             f"HINDSIGHT_PENDING_MAX_BYTES cap ({MAX_BYTES}); refusing this "
             f"entry rather than evicting the entire queue for it"
@@ -1380,11 +1480,12 @@ def _enqueue_one(d: str, payload: dict, error: BaseException) -> Optional[str]:
         # full, permissions). This is the only path that now loses a turn,
         # and it is recorded rather than returned bare — callers handle
         # ``None``, but none of them can see *why* without the ledger.
+        # ``_drop`` defers it for a caller that still holds the memory.
         try:
             os.unlink(tmp)
         except OSError:
             pass
-        record_drop(payload, write_err)
+        _drop(write_err)
         return None
     return final
 

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -500,6 +500,36 @@ def dead_dir() -> str:
     return os.environ.get("HINDSIGHT_PENDING_DEAD_DIR") or _sibling("pending-dead")
 
 
+def _retired_under(name: str) -> Optional[str]:
+    """Which archive sibling holds the retired queue entry ``name``, or ``None``.
+
+    An entry that vanished from the live queue mid-drain did NOT necessarily
+    get evicted. There is no mutex around the queue directory —
+    ``lib/pacing.py``'s ``retain-inflight.lock`` is a per-POST storm guard and
+    ``drain_pending.py`` takes no lock at all — so an in-hook ``drain()`` in
+    another process can retire the very entry this one is working on into
+    ``pending-reconciled/`` (memory confirmed durable upstream) between two
+    syscalls here. "Gone from the queue" therefore has to be RESOLVED, not
+    assumed: the difference between reconciled and evicted is the difference
+    between a memory that reached the bank and one that was shed, and callers
+    stamp the permanent-loss ledger off that distinction.
+
+    Search order is the archives that can hold a whole entry. ``mark_dead``
+    appends ``.dead`` to the name, so that spelling is checked too.
+    """
+    for d in (
+        evicted_dir(),
+        reconciled_dir(),
+        duplicate_dir(),
+        dead_dir(),
+        _sibling("pending-corrupt"),
+    ):
+        for candidate in (name, name + ".dead"):
+            if os.path.exists(os.path.join(d, candidate)):
+                return d
+    return None
+
+
 def evictions_log_path() -> str:
     """Append-only eviction ledger.
 
@@ -813,6 +843,24 @@ def resplit_over_bound_entries() -> tuple[int, int]:
     original. Counting that as a part archived a live memory into a capped
     archive while logging "into 0 queued part(s)".
 
+    NEW, and STILL LIVE, for the same reason. A part written early in the
+    loop can be FIFO-shed by a later part once the queue is at its cap, and
+    ``pending-evicted/`` is not re-drained by anything, so a shed part is a
+    slice of the memory that will not reach the bank. It is counted as shed
+    (named on its own stderr line) rather than as a queued part: the
+    ``(entries, parts)`` tuple feeds phase 0c's summary, and a summary that
+    counts evicted parts as drainable work is the same lie one level down.
+
+    WHERE THE ORIGINAL WENT is resolved, never assumed. The archive move
+    failing with the original already gone from the queue is usually
+    ``_evict_to_fit`` shedding it, but an unsynchronised in-hook ``drain()``
+    can equally have reconciled it away in the same window — see
+    ``_retired_under``. The two mean opposite things for the deferred
+    per-part drops (shed: the missing part is genuinely lost; reconciled:
+    the whole memory is already durable upstream and the missing part is a
+    copy that was not made), so the ledger is stamped off the resolved
+    destination rather than off the failure alone.
+
     A refusal here does NOT stamp the drop ledger
     (``record_refusal_as_drop=False``): the ledger means permanently lost and
     `switchroom doctor` fails on it, but the original is still queued and is
@@ -841,6 +889,7 @@ def resplit_over_bound_entries() -> tuple[int, int]:
 
         payload = {k: v for k, v in entry.items() if k not in _ENTRY_ONLY_FIELDS}
         d = _ensure_dir()
+        name = os.path.basename(path)
         before = set(_list_entries(d))
         deferred: list = []
         _first, returned = enqueue_parts(
@@ -852,58 +901,110 @@ def resplit_over_bound_entries() -> tuple[int, int]:
             record_refusal_as_drop=False,
             deferred_drops=deferred,
         )
+        after = set(_list_entries(d))
         # New FILES only. A queue-depth delta would be wrong in both
         # directions: 0 when a part deduped onto an existing entry (the
         # single-part case dedupes onto the original itself), and understated
         # whenever `_evict_to_fit` shed an entry to make room for a part.
-        written = len([p for p in returned if os.path.basename(p) not in before])
-        if written == 0:
+        fresh = [
+            os.path.basename(p) for p in returned if os.path.basename(p) not in before
+        ]
+        # ...and of those, only the ones STILL LIVE. A part written early in
+        # the loop can be FIFO-shed by a LATER part of the same memory when
+        # the queue is at its cap — `enqueue_parts` documents that trade — and
+        # the shed part lands in `pending-evicted/`, which nothing re-drains
+        # (every consumer only counts or trims it). Calling it a "queued part"
+        # is the same class of log-lie as the "STAYS QUEUED" line below: the
+        # operator reads N parts queued when N-1 are.
+        shed = sorted(n for n in fresh if n not in after)
+        queued = len(fresh) - len(shed)
+        # `queued == 0 while fresh` cannot arise through `_evict_to_fit` (it
+        # evicts to make room FOR the incoming part, so the last part written
+        # always survives), but the guard is on the LIVE count regardless:
+        # archiving the original is only safe once something of it is
+        # actually in the queue.
+        if queued == 0:
             print(
                 f"[Hindsight] pending: could not re-split "
-                f"{os.path.basename(path)} ({len(content)} chars, bound "
+                f"{name} ({len(content)} chars, bound "
                 f"{limit}) — entry STAYS QUEUED (never deleted)",
                 file=sys.stderr,
             )
             continue
+        if shed:
+            print(
+                f"[Hindsight] pending: re-split {name} wrote {len(fresh)} "
+                f"part(s) but the queue was at its cap, so {len(shed)} of "
+                f"them ({', '.join(shed)}) were themselves FIFO-evicted into "
+                f"{evicted_dir()} — nothing re-drains that directory, so only "
+                f"{queued} part(s) of this memory are live",
+                file=sys.stderr,
+            )
 
         dest_dir = resplit_dir()
+        durable_upstream = False
         try:
             os.makedirs(dest_dir, mode=0o700, exist_ok=True)
-            shutil.move(path, os.path.join(dest_dir, os.path.basename(path)))
+            shutil.move(path, os.path.join(dest_dir, name))
         except OSError as e:
             if os.path.exists(path):
                 # The parts are already queued; leaving the original queued
                 # too means the memory is retained twice, which the upsert on
                 # document_id makes harmless. Losing it would not be.
                 print(
-                    f"[Hindsight] pending: re-split {os.path.basename(path)} "
-                    f"into {written} part(s) but could not archive the original "
+                    f"[Hindsight] pending: re-split {name} "
+                    f"into {queued} part(s) but could not archive the original "
                     f"into {dest_dir} ({e}) — it STAYS QUEUED (never deleted)",
                     file=sys.stderr,
                 )
                 continue
-            # The move failed because the original is NO LONGER IN THE QUEUE:
-            # writing the parts filled it and `_evict_to_fit` FIFO-shed the
-            # very entry being re-split (it is the oldest — the parts are all
-            # newer than it). Saying "STAYS QUEUED" here is simply false, and
-            # this is the line an operator reads under exactly that pressure.
-            # Nothing is lost — the parts carry the whole memory and the
-            # original is under `evicted_dir()` — but the entry IS retired
-            # from the live queue, so it counts like an archived one below.
+            # The move failed because the original is NO LONGER IN THE QUEUE.
+            # Saying "STAYS QUEUED" here is simply false, and this is the line
+            # an operator reads under exactly that pressure. WHERE it went is
+            # not assumable, though: the usual cause is `_evict_to_fit`
+            # FIFO-shedding the very entry being re-split (it is the oldest —
+            # the parts are all newer than it), but an unsynchronised in-hook
+            # `drain()` can equally have RECONCILED it away inside the same
+            # window. Those two mean opposite things for the deferred drops,
+            # so resolve the destination instead of naming one.
+            gone_to = _retired_under(name)
+            durable_upstream = gone_to is not None and gone_to == reconciled_dir()
+            if durable_upstream:
+                where = (
+                    f"it is NOT queued: a concurrent drain reconciled it into "
+                    f"{gone_to} while the parts were being written, so the "
+                    f"whole memory is already durable upstream"
+                )
+            elif gone_to is not None:
+                # Only NOW may the reassuring clause be printed. A non-empty
+                # `deferred` is exactly the case where the parts do NOT carry
+                # the whole memory (one never got written), and a non-empty
+                # `shed` the case where one of them is no longer queued.
+                carries = not deferred and not shed
+                where = (
+                    f"it is NOT queued, it is under {gone_to} because writing "
+                    f"the parts filled the queue and it was itself evicted"
+                    + (" (the parts carry the whole memory)" if carries else "")
+                )
+            else:
+                where = (
+                    f"it is NOT queued and no archive sibling holds it either "
+                    f"— it left the live queue by a path this drain cannot "
+                    f"see, so treat the {queued} queued part(s) as the only "
+                    f"copy"
+                )
             print(
-                f"[Hindsight] pending: re-split {os.path.basename(path)} into "
-                f"{written} queued part(s); the original could not be archived "
-                f"into {dest_dir} ({e}) because writing the parts filled the "
-                f"queue and it was itself evicted — it is NOT queued, it is "
-                f"under {evicted_dir()} (the parts carry the whole memory)",
+                f"[Hindsight] pending: re-split {name} into "
+                f"{queued} queued part(s); the original could not be archived "
+                f"into {dest_dir} ({e}) — {where}",
                 file=sys.stderr,
             )
         else:
             _trim_dir(dest_dir, RESPLIT_MAX_ENTRIES, RESPLIT_MAX_BYTES)
             print(
-                f"[Hindsight] pending: re-split {os.path.basename(path)} "
+                f"[Hindsight] pending: re-split {name} "
                 f"({len(content)} chars, over the {limit}-char bound) into "
-                f"{written} queued part(s); the original is archived under "
+                f"{queued} queued part(s); the original is archived under "
                 f"{dest_dir}, not deleted",
                 file=sys.stderr,
             )
@@ -915,12 +1016,25 @@ def resplit_over_bound_entries() -> tuple[int, int]:
         # genuinely writing N parts, which silenced phase 0c's `_blog` line
         # and under-reported `summary["resplit"]`.
         resplit += 1
-        parts += written
+        parts += queued
         # And only now can a per-part failure be called a loss: the original
         # is gone from the queue, so nothing will retry the parts that never
         # got written. While it was still queued, stamping these would have
         # failed `switchroom doctor` for a memory that was never lost.
-        record_deferred_drops(deferred)
+        if durable_upstream:
+            # ...unless the original left by being RECONCILED. The whole
+            # memory reached the bank, so a part that never got written is a
+            # redundant copy that was not made, not a lost turn.
+            if deferred:
+                print(
+                    f"[Hindsight] pending: {len(deferred)} part(s) of {name} "
+                    f"could not be written, but the original was reconciled "
+                    f"upstream, so nothing was lost and the drop ledger is "
+                    f"not stamped",
+                    file=sys.stderr,
+                )
+        else:
+            record_deferred_drops(deferred)
     return resplit, parts
 
 
@@ -1298,8 +1412,8 @@ def enqueue_parts(
     not stamp it.
 
     ``deferred_drops`` closes the same hole on the PER-PART door. A per-part
-    failure inside ``_enqueue_one`` (its own ``MAX_BYTES`` refusal, or a
-    write that fails after eviction made room) is NOT self-evidently a loss:
+    failure inside ``_enqueue_one`` — in practice a write that fails after
+    eviction made room — is NOT self-evidently a loss:
     when every part fails, ``enqueue_parts`` hands back nothing, the caller
     keeps its copy queued, and phase 0c retries the whole thing on the next
     backlog drain — so stamping there makes the ledger climb by one part per
@@ -1309,6 +1423,21 @@ def enqueue_parts(
     caller's copy actually leaves the live queue. With ``deferred_drops=None``
     (the producers: ``session_end`` / ``retain``, who hold no other copy) the
     ledger is stamped immediately, exactly as before.
+
+    "In practice a write failure" is exact, and the deferral of
+    ``_enqueue_one``'s OWN ``MAX_BYTES`` refusal is defence-in-depth rather
+    than covered behaviour: no deferring caller can reach it today. On the
+    multi-part path the ``total_bytes > MAX_BYTES`` guard above short-circuits
+    first, and ``sum(part_bytes) <= MAX_BYTES`` implies every individual part
+    is under it (both sides measure the same ``_build_entry`` blob). On the
+    ``total <= 1`` path the payload is re-enqueued UNCHANGED, so its dupe key
+    is the key of the very entry ``resplit_over_bound_entries`` is re-splitting
+    and ``_find_duplicate`` — which runs BEFORE the guard — returns that entry.
+    The one residual crack is an original queued by a pre-#3688 build, whose
+    filename carries no key segment for the prefix match to hit; the guard is
+    kept deferral-aware for that case rather than assumed unreachable.
+    Verified 2026-07-26 by making the branch raise when ``deferred_drops`` is
+    not None: the whole python suite stayed green, i.e. no test reaches it.
     """
     d = _ensure_dir()
 

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -216,7 +216,12 @@ import time
 import uuid
 from typing import Optional
 
-from .retain_split import part_document_id, part_metadata, split_retain_content
+from .retain_split import (
+    part_document_id,
+    part_metadata,
+    retain_content_limit,
+    split_retain_content,
+)
 
 
 SCHEMA = 1
@@ -252,6 +257,27 @@ DUPLICATE_MAX_ENTRIES = int(
 DUPLICATE_MAX_BYTES = int(
     os.environ.get("HINDSIGHT_PENDING_DUPLICATE_MAX_BYTES") or (64 * 1024 * 1024)
 )
+# ``resplit_over_bound_entries`` retires the pre-split original here. Like
+# the duplicate archive, this copy is REDUNDANT by construction: it is only
+# moved after its parts are queued, and the parts carry the whole memory. So
+# it is bounded on the same terms — a MOVE into a capped archive, never a
+# delete of a memory that has nowhere else to live. (``pending-dead/`` is the
+# deliberate exception: see :func:`dead_dir`.)
+RESPLIT_MAX_ENTRIES = int(
+    os.environ.get("HINDSIGHT_PENDING_RESPLIT_MAX_ENTRIES") or 500
+)
+RESPLIT_MAX_BYTES = int(
+    os.environ.get("HINDSIGHT_PENDING_RESPLIT_MAX_BYTES") or (64 * 1024 * 1024)
+)
+# Fields `_build_entry` adds on top of the caller's payload. `enqueue()`
+# takes a PAYLOAD, so an entry read back off disk has to be stripped of them
+# before it can be re-enqueued (see `resplit_over_bound_entries`); leaving
+# them in would round-trip a stale `failed_at`/`attempt_count` into the new
+# entries and mis-order the queue.
+_ENTRY_ONLY_FIELDS = frozenset(
+    {"schema", "failed_at", "error_class", "error_message", "attempt_count", "dead_at"}
+)
+
 MAX_ATTEMPTS = 5
 
 #: Residual-drop ledger. A SIBLING of the queue directory (like the
@@ -418,6 +444,35 @@ def duplicate_dir() -> str:
     )
 
 
+def dead_dir() -> str:
+    """Archive directory for ``MAX_ATTEMPTS`` failures (sibling of the queue).
+
+    ``.dead`` markers used to be written INSIDE the queue directory, as
+    ``<entry>.json.dead``. A ``.dead`` marker is the ONLY remaining copy of
+    that memory — ``mark_dead`` unlinks the live entry once the marker is
+    durable — so leaving it in the live queue directory put the last copy of
+    a memory in the one directory that external janitorial tooling has every
+    reason to sweep. On this fleet exactly that happened: a host cron ran
+    ``find <queue> -name '*.dead' -mtime +14 | xargs rm -f``. Measured on
+    2026-07-26, 6 such markers were live in the queue directory, each one on
+    a countdown to permanent deletion.
+
+    Fixing the janitor is not a fix — the next one has the same shape. The
+    product-level fix is that the live queue directory contains ONLY live
+    entries, so no glob over it can ever match a memory. Dead markers move
+    out to this sibling, alongside ``pending-evicted``/``pending-reconciled``
+    /``pending-corrupt``, and ``sweep_legacy_dead_markers`` migrates any that
+    a previous version left behind.
+
+    NOT TTL-pruned, deliberately, and NOT trimmed to a cap: a dead entry is
+    an unrecovered memory, and dropping it is the loss this whole subsystem
+    exists to prevent. It is bounded instead by making it hard to REACH --
+    ``resplit_over_bound_entries`` recovers the entries that used to arrive
+    here, so the steady-state population is the genuinely unrecoverable ones.
+    """
+    return os.environ.get("HINDSIGHT_PENDING_DEAD_DIR") or _sibling("pending-dead")
+
+
 def evictions_log_path() -> str:
     """Append-only eviction ledger.
 
@@ -499,6 +554,12 @@ def _trim_dir(a: str, max_entries: int, max_bytes: int) -> int:
     an entry only reaches it through the ledgered eviction path, and under
     sustained ENOSPC it may not reach it at all.
     """
+    # `.json` ONLY, and that is load-bearing beyond "skip stray files": a
+    # `.dead` marker is named `<entry>.json.dead`, so it can never be
+    # selected here even if a future caller points a trim at `pending-dead/`.
+    # That archive holds the only remaining copy of an unrecovered memory and
+    # must stay uncapped; making it structurally unreachable is stronger than
+    # relying on nobody wiring up the call. See :func:`dead_dir`.
     try:
         names = sorted(n for n in os.listdir(a) if n.endswith(".json"))
     except OSError:
@@ -673,6 +734,105 @@ def collapse_duplicates() -> int:
             file=sys.stderr,
         )
     return collapsed
+
+
+def resplit_dir() -> str:
+    """Archive directory for entries retired by ``resplit_over_bound_entries``."""
+    return os.environ.get("HINDSIGHT_PENDING_RESPLIT_DIR") or _sibling(
+        "pending-resplit"
+    )
+
+
+def resplit_over_bound_entries() -> tuple[int, int]:
+    """Re-split queued entries whose content exceeds the current bound.
+
+    Returns ``(entries_resplit, parts_written)``.
+
+    THE ENTRY THIS EXISTS FOR is one whose ``content`` is larger than
+    ``retain_content_limit()``. Such an entry is not slow, it is IMPOSSIBLE:
+    the server runs one sequential extraction call per chunk, so the POST
+    cannot finish inside the deadline the drain waits, and re-POSTing it is
+    guaranteed waste. Today it either churns forever at the back of the drain
+    order or — if the server rejects the body as a 4xx, which
+    ``is_permanent_failure`` correctly classifies as permanent — goes
+    ``.dead``. Both outcomes are wrong for a memory that is perfectly
+    recoverable: ``enqueue()`` already knows how to split it.
+
+    Two ways an over-bound entry gets into a queue, and both are live here:
+      * it was enqueued by a build older than the split-on-enqueue path;
+      * the bound MOVED under it. It does that whenever the client deadline
+        or the deadline-safety fraction changes, so this is not a one-off
+        migration — it is the queue's standing response to a bound change.
+    Measured on this fleet 2026-07-26: 18 of 211 queued entries exceeded
+    100,000 chars, the largest 744,546 — i.e. 15x the bound.
+
+    Ordering matters. The original is archived into ``pending-resplit/`` only
+    AFTER at least one part is durably written, so a crash mid-way leaves the
+    original queued (worst case: the parts are written twice, and a re-split
+    is deterministic, so the second write dedupes onto the first). If NOT ONE
+    part could be written — ``enqueue`` refused the whole memory as larger
+    than the queue cap, or the disk is full — the original is left queued
+    untouched and is not counted. Nothing is deleted on any path.
+
+    WHAT THIS COSTS, honestly. One entry becomes N, so the queue gets DEEPER
+    (measured worst case on this fleet: 744,546 chars -> 23 parts). On a
+    queue already at its cap that means ``enqueue``'s eviction path sheds
+    the oldest entries into ``pending-evicted/`` — shed, not destroyed,
+    except under the sustained-ENOSPC case ``_evict_to_fit`` documents. The
+    trade is deliberate: depth is recoverable, and an over-bound entry is
+    not drainable at any depth.
+    """
+    limit = retain_content_limit()
+    resplit = 0
+    parts = 0
+    for path, entry in iter_entries():
+        content = entry.get("content")
+        if not isinstance(content, str) or len(content) <= limit:
+            continue
+
+        payload = {k: v for k, v in entry.items() if k not in _ENTRY_ONLY_FIELDS}
+        before = count()
+        first = enqueue(payload, RuntimeError(
+            f"re-split: content was {len(content)} chars, over the current "
+            f"{limit}-char retain bound"
+        ))
+        written = max(0, count() - before)
+        if first is None and written == 0:
+            print(
+                f"[Hindsight] pending: could not re-split "
+                f"{os.path.basename(path)} ({len(content)} chars, bound "
+                f"{limit}) — entry STAYS QUEUED (never deleted)",
+                file=sys.stderr,
+            )
+            continue
+
+        dest_dir = resplit_dir()
+        try:
+            os.makedirs(dest_dir, mode=0o700, exist_ok=True)
+            shutil.move(path, os.path.join(dest_dir, os.path.basename(path)))
+        except OSError as e:
+            # The parts are already queued; leaving the original queued too
+            # means the memory is retained twice, which the upsert on
+            # document_id makes harmless. Losing it would not be.
+            print(
+                f"[Hindsight] pending: re-split {os.path.basename(path)} into "
+                f"{written} part(s) but could not archive the original into "
+                f"{dest_dir} ({e}) — it STAYS QUEUED (never deleted)",
+                file=sys.stderr,
+            )
+            continue
+
+        _trim_dir(dest_dir, RESPLIT_MAX_ENTRIES, RESPLIT_MAX_BYTES)
+        resplit += 1
+        parts += written
+        print(
+            f"[Hindsight] pending: re-split {os.path.basename(path)} "
+            f"({len(content)} chars, over the {limit}-char bound) into "
+            f"{written} queued part(s); the original is archived under "
+            f"{dest_dir}, not deleted",
+            file=sys.stderr,
+        )
+    return resplit, parts
 
 
 def _log_eviction(name: str, size: int, reason: str, depth: int, nbytes: int) -> None:
@@ -1303,11 +1463,27 @@ def is_permanent_failure(error: BaseException) -> bool:
 
 
 def mark_dead(path: str, entry: dict) -> Optional[str]:
-    """Convert an entry that exceeded ``MAX_ATTEMPTS`` into a permanent
-    failure marker at ``<path>.dead`` so the queue no longer drains it
-    but operators can still inspect.
+    """Retire an entry that exceeded ``MAX_ATTEMPTS`` into ``dead_dir()``.
 
     Returns the marker path, or ``None`` if it failed.
+
+    WHERE THE MARKER GOES, AND WHY IT MOVED. This used to write
+    ``<path>.dead`` — i.e. INSIDE the live queue directory. Since the marker
+    is the only remaining copy of the memory (the live entry is unlinked once
+    it is durable), that put the last copy of a memory in the directory
+    external janitors sweep. It is not hypothetical: a host cron on this
+    fleet ran ``find <queue> -name '*.dead' -mtime +14 -delete``. Measured
+    2026-07-26, 6 such markers were live in the queue directory, each on a
+    countdown to permanent deletion. The marker now lands in the
+    ``pending-dead/`` sibling, so the live queue directory holds ONLY live
+    entries and no glob over it can match a memory. See :func:`dead_dir`.
+
+    FAILURE IS NOT DELETION. If the marker cannot be written at all, this
+    returns ``None`` and **leaves the live entry exactly where it is**. The
+    drain then re-attempts it on the next run, which is wasteful and visible;
+    the alternative — falling back to a marker inside the queue directory —
+    would quietly restore the loss channel this function exists to close.
+    Queued-and-retrying beats destroyed, every time.
 
     Crash-window invariant (#1094 item 3): **a live ``<path>.json`` entry
     must never carry a ``dead_at`` stamp.** The old two-step form violated
@@ -1316,21 +1492,25 @@ def mark_dead(path: str, entry: dict) -> Optional[str]:
     crash between the two renames left a live entry with ``dead_at`` set
     that the drainer would re-enter and re-bump. Here we instead:
 
-      1. write the dead_at-stamped payload to ``<path>.tmp``
-      2. ``os.replace(tmp, dead_path)``  — the .dead marker appears in one
-         atomic step (never drained: the drainer only lists ``*.json``)
+      1. write the dead_at-stamped payload to a ``.tmp`` inside ``dead_dir()``
+      2. ``os.replace(tmp, dead_path)``  — the marker appears in one atomic
+         step, in a directory the drainer never lists at all
       3. ``os.unlink(path)``            — drop the original live entry
 
-    At every crash point the invariant holds: the ``dead_at`` stamp only
-    ever lands on ``<path>.dead``. A crash after step 2 leaves both the
-    (stale, no-dead_at) live entry and the .dead marker; the next drain
-    re-marks it dead (os.replace overwrites the marker idempotently),
-    never observing a live entry with dead_at.
+    At every crash point the invariant holds: the ``dead_at`` stamp only ever
+    lands in ``dead_dir()``. A crash after step 2 leaves both the (stale, no-
+    dead_at) live entry and the marker; the next drain re-marks it dead
+    (``os.replace`` overwrites the marker idempotently), never observing a
+    live entry with dead_at. Step 1 writes the tmp in the DESTINATION
+    directory so step 2 is a same-directory rename and cannot fail on a
+    cross-filesystem boundary halfway through.
     """
     entry["dead_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-    dead_path = path + ".dead"
-    tmp = path + ".tmp"
+    dest_dir = dead_dir()
+    dead_path = os.path.join(dest_dir, os.path.basename(path) + ".dead")
+    tmp = dead_path + ".tmp"
     try:
+        os.makedirs(dest_dir, mode=0o700, exist_ok=True)
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(entry, f, ensure_ascii=False)
         os.chmod(tmp, 0o600)
@@ -1344,9 +1524,64 @@ def mark_dead(path: str, entry: dict) -> Optional[str]:
             pass
         return dead_path
     except OSError:
-        # Clean up a possibly-orphaned tmp so it doesn't linger.
+        # Clean up a possibly-orphaned tmp so it doesn't linger. The live
+        # entry is deliberately left alone — see "FAILURE IS NOT DELETION".
         try:
             os.unlink(tmp)
         except OSError:
             pass
         return None
+
+
+def sweep_legacy_dead_markers() -> int:
+    """Move ``*.dead`` markers left inside the queue dir into ``dead_dir()``.
+
+    Versions before this one wrote the marker as ``<entry>.json.dead``, next
+    to the live entries. Those markers are the only copy of their memory and
+    are sitting in the directory a janitor sweeps, so an upgrade has to
+    RELOCATE them, not just stop producing new ones. Returns the number moved.
+
+    Idempotent and safe to run on every drain: a queue with no legacy markers
+    does no work and returns 0. A marker whose name already exists in
+    ``dead_dir()`` is left where it is rather than overwritten — the two are
+    the same entry by construction (the name carries the queue's unique
+    suffix), but "leave both copies" is the answer that cannot lose one.
+    """
+    d = pending_dir()
+    try:
+        names = sorted(n for n in os.listdir(d) if n.endswith(".dead"))
+    except OSError:
+        return 0
+    if not names:
+        return 0
+
+    dest_dir = dead_dir()
+    try:
+        os.makedirs(dest_dir, mode=0o700, exist_ok=True)
+    except OSError as e:
+        print(
+            f"[Hindsight] pending: cannot create {dest_dir} ({e}); "
+            f"{len(names)} legacy .dead marker(s) STAY in the live queue "
+            f"directory (they are not deleted)",
+            file=sys.stderr,
+        )
+        return 0
+
+    moved = 0
+    for name in names:
+        dest = os.path.join(dest_dir, name)
+        if os.path.exists(dest):
+            continue
+        try:
+            shutil.move(os.path.join(d, name), dest)
+        except OSError:
+            continue
+        moved += 1
+    if moved:
+        print(
+            f"[Hindsight] pending: relocated {moved} legacy .dead marker(s) "
+            f"out of the live queue directory into {dest_dir} — the live "
+            f"queue now holds only live entries",
+            file=sys.stderr,
+        )
+    return moved

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -259,7 +259,9 @@ DUPLICATE_MAX_BYTES = int(
 )
 # ``resplit_over_bound_entries`` retires the pre-split original here. Like
 # the duplicate archive, this copy is REDUNDANT by construction: it is only
-# moved after its parts are queued, and the parts carry the whole memory. So
+# moved once at least one NEW queue file exists for it (a dedupe hit is not a
+# new file — see ``resplit_over_bound_entries``), and the parts carry the
+# whole memory. So
 # it is bounded on the same terms — a MOVE into a capped archive, never a
 # delete of a memory that has nowhere else to live. (``pending-dead/`` is the
 # deliberate exception: see :func:`dead_dir`.)
@@ -275,7 +277,18 @@ RESPLIT_MAX_BYTES = int(
 # them in would round-trip a stale `failed_at`/`attempt_count` into the new
 # entries and mis-order the queue.
 _ENTRY_ONLY_FIELDS = frozenset(
-    {"schema", "failed_at", "error_class", "error_message", "attempt_count", "dead_at"}
+    {
+        "schema",
+        "failed_at",
+        "error_class",
+        "error_message",
+        "attempt_count",
+        # `update_attempt` stamps this on every retry. It describes the OLD
+        # entry's attempt history, so carrying it into a fresh part would
+        # pair a `last_attempt_at` from days ago with `attempt_count: 1`.
+        "last_attempt_at",
+        "dead_at",
+    }
 )
 
 MAX_ATTEMPTS = 5
@@ -767,12 +780,29 @@ def resplit_over_bound_entries() -> tuple[int, int]:
     100,000 chars, the largest 744,546 — i.e. 15x the bound.
 
     Ordering matters. The original is archived into ``pending-resplit/`` only
-    AFTER at least one part is durably written, so a crash mid-way leaves the
-    original queued (worst case: the parts are written twice, and a re-split
-    is deterministic, so the second write dedupes onto the first). If NOT ONE
-    part could be written — ``enqueue`` refused the whole memory as larger
-    than the queue cap, or the disk is full — the original is left queued
-    untouched and is not counted. Nothing is deleted on any path.
+    AFTER at least one NEW queue file exists for it, so a crash mid-way leaves
+    the original queued (worst case: the parts are written twice, and a
+    re-split is deterministic, so the second write dedupes onto the first). If
+    NOT ONE new part file appeared — ``enqueue_parts`` refused the whole memory
+    as larger than the queue cap, the disk is full, or every part deduped onto
+    something already queued — the original is left queued untouched and is
+    not counted. Nothing is deleted on any path.
+
+    "NEW file", not "``_enqueue_one`` returned a path", is the load-bearing
+    distinction, and it is why the count is a set difference against the
+    queue listing taken just before the call. ``_enqueue_one`` returns the
+    path of an ALREADY-QUEUED identical entry on a dedupe hit. When the
+    splitter yields a SINGLE part for this content — which it does whenever
+    the entry is over the bound but still one part's worth under the CURRENT
+    bound — ``enqueue_parts`` re-enqueues the payload unchanged, so the dupe
+    key matches the very entry being re-split and the "written" path IS the
+    original. Counting that as a part archived a live memory into a capped
+    archive while logging "into 0 queued part(s)".
+
+    A refusal here does NOT stamp the drop ledger
+    (``record_refusal_as_drop=False``): the ledger means permanently lost and
+    `switchroom doctor` fails on it, but the original is still queued and is
+    retried on every backlog drain, so stamping it would climb forever.
 
     WHAT THIS COSTS, honestly. One entry becomes N, so the queue gets DEEPER
     (measured worst case on this fleet: 744,546 chars -> 23 parts). On a
@@ -791,13 +821,22 @@ def resplit_over_bound_entries() -> tuple[int, int]:
             continue
 
         payload = {k: v for k, v in entry.items() if k not in _ENTRY_ONLY_FIELDS}
-        before = count()
-        first = enqueue(payload, RuntimeError(
-            f"re-split: content was {len(content)} chars, over the current "
-            f"{limit}-char retain bound"
-        ))
-        written = max(0, count() - before)
-        if first is None and written == 0:
+        d = _ensure_dir()
+        before = set(_list_entries(d))
+        _first, returned = enqueue_parts(
+            payload,
+            RuntimeError(
+                f"re-split: content was {len(content)} chars, over the current "
+                f"{limit}-char retain bound"
+            ),
+            record_refusal_as_drop=False,
+        )
+        # New FILES only. A queue-depth delta would be wrong in both
+        # directions: 0 when a part deduped onto an existing entry (the
+        # single-part case dedupes onto the original itself), and understated
+        # whenever `_evict_to_fit` shed an entry to make room for a part.
+        written = len([p for p in returned if os.path.basename(p) not in before])
+        if written == 0:
             print(
                 f"[Hindsight] pending: could not re-split "
                 f"{os.path.basename(path)} ({len(content)} chars, bound "
@@ -1163,13 +1202,45 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     the newest memory was the wrong end to shed from — it is the turn most
     likely to still matter.
     """
+    return enqueue_parts(payload, error)[0]
+
+
+def enqueue_parts(
+    payload: dict,
+    error: BaseException,
+    *,
+    record_refusal_as_drop: bool = True,
+) -> tuple[Optional[str], list[str]]:
+    """``enqueue()``, plus EVERY path ``_enqueue_one`` handed back.
+
+    ``enqueue()`` returns only the first path, which cannot tell a caller
+    how many entries the call actually put in the queue. Callers that own a
+    copy of the memory (``resplit_over_bound_entries`` holds the original)
+    need that: they may only retire their copy once the parts are down.
+
+    The returned list is the paths ``_enqueue_one`` RETURNED, which is not
+    the same as the paths it CREATED — a dedupe hit returns the path of an
+    already-queued identical entry. The caller decides what that means for
+    it; :func:`resplit_over_bound_entries` subtracts the paths that were
+    already queued before the call, which is what makes a re-split that
+    deduped straight back onto its own original count as zero parts.
+
+    ``record_refusal_as_drop=False`` suppresses the drop-ledger entry on the
+    two whole-memory refusals below. ``record_drop`` means "this memory is
+    PERMANENTLY LOST" — `switchroom doctor` fails on a non-zero ledger — so
+    a caller that keeps the memory queued when the refusal comes back must
+    not stamp it. Only the whole-memory refusals are suppressed; a per-part
+    failure inside ``_enqueue_one`` still records, because by then the other
+    parts are queued and the caller will retire its copy.
+    """
     d = _ensure_dir()
 
     content = payload.get("content")
     parts = split_retain_content(content) if isinstance(content, str) else [content]
     total = len(parts)
     if total <= 1:
-        return _enqueue_one(d, payload, error)
+        one = _enqueue_one(d, payload, error)
+        return one, ([] if one is None else [one])
 
     base_doc = payload.get("document_id", "conversation")
     base_meta = payload.get("metadata")
@@ -1193,21 +1264,24 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
     # memory that cannot fit, so refuse it here too.
     total_bytes = sum(_entry_blob_bytes(p, error) for p in part_payloads)
     if total_bytes > MAX_BYTES:
-        record_drop(payload, ValueError(
-            f"entry is {total_bytes} bytes across {total} parts, larger than "
-            f"the whole HINDSIGHT_PENDING_MAX_BYTES cap ({MAX_BYTES}); "
-            f"refusing this entry rather than evicting the entire queue for it"
-        ))
-        return None
+        if record_refusal_as_drop:
+            record_drop(payload, ValueError(
+                f"entry is {total_bytes} bytes across {total} parts, larger than "
+                f"the whole HINDSIGHT_PENDING_MAX_BYTES cap ({MAX_BYTES}); "
+                f"refusing this entry rather than evicting the entire queue for it"
+            ))
+        return None, []
     if total > MAX_ENTRIES:
-        record_drop(payload, ValueError(
-            f"entry splits into {total} parts, more than the whole "
-            f"HINDSIGHT_PENDING_MAX_ENTRIES cap ({MAX_ENTRIES}); refusing "
-            f"this entry rather than evicting the entire queue for it"
-        ))
-        return None
+        if record_refusal_as_drop:
+            record_drop(payload, ValueError(
+                f"entry splits into {total} parts, more than the whole "
+                f"HINDSIGHT_PENDING_MAX_ENTRIES cap ({MAX_ENTRIES}); refusing "
+                f"this entry rather than evicting the entire queue for it"
+            ))
+        return None, []
 
     first: Optional[str] = None
+    returned: list[str] = []
     for part_payload in part_payloads:
         # Each part goes through the FULL enqueue pipeline — dedupe, the
         # MAX_BYTES refusal, eviction, the drop ledger — because each part
@@ -1223,9 +1297,11 @@ def enqueue(payload: dict, error: BaseException) -> Optional[str]:
         # evicted part MOVES to ``pending-evicted/``, so it is shed, not
         # destroyed, except under the sustained-ENOSPC case named there.
         written = _enqueue_one(d, part_payload, error)
-        if written is not None and first is None:
-            first = written
-    return first
+        if written is not None:
+            returned.append(written)
+            if first is None:
+                first = written
+    return first, returned
 
 
 def _build_entry(payload: dict, error: BaseException) -> dict:

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -17,6 +17,7 @@ otherwise undo:
   * the stall guard does not overshoot under concurrency.
 """
 
+import errno
 import io
 import json
 import os
@@ -2907,6 +2908,48 @@ class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertTrue(os.path.exists(path), "never deleted on failure")
         self.assertEqual(self._resplit_names(), [])
 
+    #: The exact membership of `pending._ENTRY_ONLY_FIELDS`, spelled out
+    #: here rather than read off the module under test.
+    #:
+    #: This literal is deliberate, and it is what makes the strip testable at
+    #: all. Only THREE members are observable in the resulting parts:
+    #: `attempt_count` (`_build_entry` uses `setdefault`), `last_attempt_at`
+    #: and `dead_at` (`_build_entry` never writes them). The other four --
+    #: `schema`, `failed_at`, `error_class`, `error_message` -- are assigned
+    #: UNCONDITIONALLY by `_build_entry`, so deleting any of them from the
+    #: frozenset changes no entry on disk and no outcome assertion can see
+    #: it. They are in the set as defence-in-depth (see the comment on
+    #: `_ENTRY_ONLY_FIELDS`), and defence-in-depth that is asserted against
+    #: the module's own value is asserted against nothing.
+    ENTRY_ONLY_FIELDS = frozenset(
+        {
+            "schema",
+            "failed_at",
+            "error_class",
+            "error_message",
+            "attempt_count",
+            "last_attempt_at",
+            "dead_at",
+        }
+    )
+
+    def test_entry_only_fields_is_every_field_build_entry_adds(self):
+        """Pin the membership itself; the strip's outcome cannot.
+
+        `_build_entry` is the only writer of the first four, and it writes
+        them unconditionally -- so a member dropped from the frozenset is
+        invisible in every part on disk. Asserting it here is the only
+        thing that fails when one goes missing.
+        """
+        self.assertEqual(pending._ENTRY_ONLY_FIELDS, self.ENTRY_ONLY_FIELDS)
+        built = pending._build_entry(_payload(), RuntimeError("x"))
+        self.assertEqual(
+            self.ENTRY_ONLY_FIELDS - set(_payload()) - {"last_attempt_at", "dead_at"},
+            set(built) - set(_payload()),
+            "the set drifted from what `_build_entry` actually stamps; "
+            "`last_attempt_at`/`dead_at` come from `update_attempt`/`mark_dead`",
+        )
+
     def test_the_parts_carry_no_stale_attempt_metadata(self):
         os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
         path = pending.enqueue(_payload(content="u" * 40_000), RuntimeError("x"))
@@ -2914,33 +2957,67 @@ class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
             with open(path, encoding="utf-8") as f:
                 entry = json.load(f)
             pending.update_attempt(path, entry, RuntimeError("again"))
-        # Age the queue stamp explicitly rather than relying on the clock:
-        # `failed_at` is second-resolution, so a same-second test could not
-        # tell a fresh stamp from a round-tripped one.
-        stale_failed_at = "2020-01-01T00:00:00Z"
+        stale_stamp = "2020-01-01T00:00:00Z"
         with open(path, encoding="utf-8") as f:
             stale = json.load(f)
-        stale["failed_at"] = stale_failed_at
+        stale["failed_at"] = stale_stamp
+        stale["dead_at"] = stale_stamp
         with open(path, "w", encoding="utf-8") as f:
             json.dump(stale, f)
         # Guard the fixture: the assertions below are vacuous unless the
-        # original really is carrying every field a retried entry accumulates.
+        # original really is carrying EVERY entry-only field, since what is
+        # under test is that all of them are stripped off the payload.
         self.assertEqual(stale["attempt_count"], 5)
         self.assertIn("last_attempt_at", stale)
         self.assertEqual(stale["error_class"], "RuntimeError")
         self.assertEqual(stale["error_message"], "again")
+        self.assertEqual(
+            self.ENTRY_ONLY_FIELDS - set(stale), frozenset(),
+            "the fixture must carry every entry-only field",
+        )
+
+        # The load-bearing assertion for the four fields `_build_entry`
+        # overwrites: catch the payload ON THE WAY IN. "The entry on disk has
+        # a fresh `failed_at`" is true whether or not `failed_at` was ever
+        # stripped; "the dict handed to `enqueue_parts` has no `failed_at`"
+        # is not.
+        seen: list[dict] = []
+        real_enqueue_parts = pending.enqueue_parts
+
+        def spy(payload, error, **kwargs):
+            seen.append(dict(payload))
+            return real_enqueue_parts(payload, error, **kwargs)
 
         os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
-        pending.resplit_over_bound_entries()
+        with unittest.mock.patch.object(pending, "enqueue_parts", spy):
+            with redirect_stderr(io.StringIO()):
+                pending.resplit_over_bound_entries()
+
+        self.assertEqual(len(seen), 1, "the over-bound entry was re-enqueued")
+        self.assertEqual(
+            sorted(set(seen[0]) & self.ENTRY_ONLY_FIELDS), [],
+            "`enqueue()` takes a PAYLOAD, not an entry read off disk -- every "
+            "entry-only field must be stripped before it goes back in",
+        )
+        self.assertEqual(
+            seen[0]["content"], "u" * 40_000,
+            "and the payload still carries the memory it is stripping around",
+        )
+
         entries = pending.iter_entries()
         self.assertGreaterEqual(len(entries), 13, "the entry really was split")
         for _p, entry in entries:
+            # These three are the ones the strip alone decides: `_build_entry`
+            # `setdefault`s `attempt_count` and never writes the other two.
             self.assertEqual(
                 entry["attempt_count"], 1,
                 "a re-split part starts its own budget -- inheriting an "
                 "exhausted one would send it straight back toward .dead",
             )
-            self.assertNotIn("dead_at", entry)
+            self.assertNotIn(
+                "dead_at", entry,
+                "a fresh part is not born already dead",
+            )
             # `update_attempt` stamps `last_attempt_at`, so it is entry-only
             # metadata too. Round-tripping it pairs a timestamp from the old
             # entry's last retry with a fresh `attempt_count: 1` -- an entry
@@ -2949,16 +3026,13 @@ class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
                 "last_attempt_at", entry,
                 "a fresh part has never been attempted",
             )
-            self.assertEqual(
-                entry["error_class"], "RuntimeError",
-                "the part records why IT was queued (the re-split), not the "
-                "error the original last failed with",
-            )
+            # The rest are `_build_entry` guarantees, not strip guarantees:
+            # they hold even if the field were left on the payload. Kept as
+            # a check on `_build_entry`, labelled so no one reads them as
+            # coverage of `_ENTRY_ONLY_FIELDS`.
+            self.assertEqual(entry["error_class"], "RuntimeError")
             self.assertIn("re-split", entry["error_message"])
-            self.assertNotEqual(
-                entry["failed_at"], stale_failed_at,
-                "a stale failed_at mis-orders the part in the drain queue",
-            )
+            self.assertNotEqual(entry["failed_at"], stale_stamp)
             self.assertEqual(entry["schema"], pending.SCHEMA)
 
     # --- The archive is only earned by a NEW file -------------------------
@@ -3105,6 +3179,187 @@ class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
             )
         self.assertEqual(pending.read_drops().get("count"), 1)
         self.assertEqual(pending.count(), 0)
+
+    # --- ... and neither is a PER-PART failure the caller absorbs ---------
+    #
+    # The cap refusals above are the whole-memory door. `_enqueue_one` has a
+    # second one: its own MAX_BYTES guard and the post-eviction write failure
+    # both `record_drop`. When EVERY part fails there, `enqueue_parts` hands
+    # back nothing, `written == 0`, and the original correctly STAYS QUEUED --
+    # so those drops describe a memory that was not lost, on an entry phase 0c
+    # retries every backlog drain (10 min on this fleet), climbing forever and
+    # never resetting once the disk is fixed. Same failure mode, same fix.
+
+    @staticmethod
+    def _enospc_on_every_rename():
+        """A full disk, at the exact syscall `_enqueue_one` fails on."""
+        return unittest.mock.patch.object(
+            pending.os, "rename",
+            side_effect=OSError(errno.ENOSPC, "No space left on device"),
+        )
+
+    def test_a_resplit_whose_every_part_fails_to_write_stamps_no_drop(self):
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="p" * 40_000), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+
+        with self._enospc_on_every_rename():
+            with redirect_stderr(io.StringIO()):
+                for _ in range(3):  # every backlog drain retries this entry
+                    self.assertEqual(pending.resplit_over_bound_entries(), (0, 0))
+
+        self.assertEqual(
+            pending.read_drops(), {},
+            "nothing was lost -- not one part was written, so the original "
+            "is still queued and the next drain retries the whole re-split",
+        )
+        self.assertTrue(os.path.exists(path), "the original never left")
+        self.assertEqual(pending.count(), 1)
+        self.assertEqual(self._resplit_names(), [])
+
+    def test_a_part_that_fails_is_stamped_once_the_original_is_retired(self):
+        """The deferral is not a suppression.
+
+        One part of fourteen hits ENOSPC, thirteen land, so the original IS
+        archived -- nothing will ever retry part five again. That IS the
+        permanent loss `record_drop` exists to make visible.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="q" * 40_000), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+
+        real_rename = os.rename
+        seen = {"n": 0}
+
+        def flaky(src, dst):
+            seen["n"] += 1
+            if seen["n"] == 5:  # part five of fourteen
+                raise OSError(errno.ENOSPC, "No space left on device")
+            return real_rename(src, dst)
+
+        with unittest.mock.patch.object(pending.os, "rename", flaky):
+            with redirect_stderr(io.StringIO()):
+                entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual((entries, parts), (1, 13), "thirteen of fourteen")
+        self.assertFalse(os.path.exists(path), "the original was archived")
+        self.assertEqual(
+            pending.read_drops().get("count"), 1,
+            "the part that never landed is gone for good and must be visible",
+        )
+        self.assertEqual(
+            pending.read_drops().get("last_error_class"), "OSError",
+        )
+
+    def test_the_producer_path_still_stamps_a_failed_part_as_dropped(self):
+        """The per-part deferral is scoped to the re-split caller too.
+
+        `session_end` / `retain` hold no other copy, so every part that
+        cannot be written really is a lost slice of the turn.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        with self._enospc_on_every_rename():
+            with redirect_stderr(io.StringIO()):
+                self.assertIsNone(
+                    pending.enqueue(_payload(content="f" * 40_000), RuntimeError("x"))
+                )
+        self.assertEqual(pending.count(), 0, "not one part landed")
+        self.assertGreaterEqual(
+            pending.read_drops().get("count", 0), 14,
+            "one drop per part the producer could not write",
+        )
+
+    # --- An original evicted out from under its own re-split --------------
+
+    def test_a_resplit_that_evicts_its_own_original_says_so(self):
+        """The parts fill the queue and FIFO-shed the entry being re-split.
+
+        `total > MAX_ENTRIES` is false at exactly 14 parts and a cap of 14,
+        so there is no refusal: part fourteen calls `_evict_to_fit`, which
+        sheds the OLDEST entry -- the original. `shutil.move` then raises
+        `FileNotFoundError`. Nothing is lost (fourteen parts plus the evicted
+        copy), but the old line told the operator the original "STAYS QUEUED"
+        when it is in `pending-evicted/`, and returned (0, 0) after writing
+        fourteen parts.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="z" * 40_000), RuntimeError("x"))
+        name = os.path.basename(path)
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        pending.MAX_ENTRIES = 14
+
+        err = io.StringIO()
+        with redirect_stderr(err):
+            entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual(len(retain_split.split_retain_content("z" * 40_000)), 14)
+        self.assertFalse(os.path.exists(path), "the original was evicted")
+        self.assertIn(name, self._archive_names(), "...into pending-evicted/")
+        self.assertEqual(self._resplit_names(), [], "it was never archived")
+        self.assertEqual(pending.count(), 14, "fourteen parts, at the cap")
+
+        log = err.getvalue()
+        self.assertNotIn(
+            "STAYS QUEUED", log,
+            "it is NOT queued -- that is the line an operator reads under "
+            "exactly this pressure",
+        )
+        self.assertIn(pending.evicted_dir(), log, "say where it actually is")
+        self.assertEqual(
+            (entries, parts), (1, 14),
+            "fourteen parts were genuinely written, so phase 0c's summary "
+            "and `_blog` line must report them",
+        )
+
+    def test_an_archive_failure_that_leaves_the_original_queued_still_says_so(self):
+        """The other branch: the move fails but the entry is still there."""
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="a" * 40_000), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+
+        err = io.StringIO()
+        with unittest.mock.patch.object(
+            pending.shutil, "move",
+            side_effect=OSError(errno.EACCES, "Permission denied"),
+        ):
+            with redirect_stderr(err):
+                entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual((entries, parts), (0, 0), "the original is still queued")
+        self.assertTrue(os.path.exists(path))
+        self.assertIn("STAYS QUEUED", err.getvalue())
+
+    # --- The (first, paths) contract at total <= 1 ------------------------
+
+    def test_a_single_part_enqueue_returns_the_path_it_wrote(self):
+        """`enqueue_parts` exists so a caller holding a copy can decide when
+        to retire it. That decision reads the LIST, so the list must carry
+        the single-part write too -- returning `(path, [])` would tell every
+        such caller "nothing was queued" for the commonest payload there is.
+        """
+        first, paths = pending.enqueue_parts(
+            _payload(content="under the bound"), RuntimeError("x")
+        )
+        self.assertIsNotNone(first)
+        self.assertEqual(
+            len(retain_split.split_retain_content("under the bound")), 1,
+            "the single-part branch is the one under test",
+        )
+        self.assertEqual(
+            paths, [first],
+            "one part written is one path handed back",
+        )
+        self.assertEqual(pending.count(), 1)
+
+    def test_a_single_part_that_could_not_be_written_returns_no_paths(self):
+        """The other half of the contract: `None` means nothing to retire."""
+        with self._enospc_on_every_rename():
+            with redirect_stderr(io.StringIO()):
+                first, paths = pending.enqueue_parts(
+                    _payload(content="under the bound"), RuntimeError("x")
+                )
+        self.assertIsNone(first)
+        self.assertEqual(paths, [])
 
     def test_the_backlog_drain_resplits_before_paying_for_extraction(self):
         os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -95,6 +95,9 @@ class _QueueTempDirMixin:
         "HINDSIGHT_RETAIN_CLIENT_DEADLINE_S",
         # The retain content bound, which decides whether `enqueue` splits.
         "HINDSIGHT_RETAIN_MAX_CONTENT_CHARS",
+        "HINDSIGHT_PENDING_DUPLICATE_DIR",
+        "HINDSIGHT_PENDING_DEAD_DIR",
+        "HINDSIGHT_PENDING_RESPLIT_DIR",
     )
 
     def setUp(self):
@@ -1420,8 +1423,12 @@ class BacklogDrainTest(_QueueTempDirMixin, unittest.TestCase):
         )
 
         self.assertEqual(summary["dead"], 1)
-        self.assertTrue(os.path.exists(path + ".dead"))
+        # The marker lands in the pending-dead/ archive, NOT beside the live
+        # entries -- see `pending.dead_dir`.
+        self.assertTrue(os.path.exists(
+            os.path.join(pending.dead_dir(), os.path.basename(path) + ".dead")))
         self.assertFalse(os.path.exists(path))
+        self.assertFalse(os.path.exists(path + ".dead"))
 
     def test_extraction_500_past_max_attempts_never_kills_the_memory(self):
         """The regression this gate exists for.
@@ -1566,8 +1573,10 @@ class TransportFailureEndToEndTest(_QueueTempDirMixin, unittest.TestCase):
         path = self._exhaust_attempts()
         summary = self._drain_with_urlopen(self._http_error(400))
         self.assertEqual(summary["dead"], 1, "a 4xx rejection must still retire")
-        self.assertTrue(os.path.exists(path + ".dead"))
+        self.assertTrue(os.path.exists(
+            os.path.join(pending.dead_dir(), os.path.basename(path) + ".dead")))
         self.assertFalse(os.path.exists(path))
+        self.assertFalse(os.path.exists(path + ".dead"))
 
 
 class ArchiveFailureNeverDeletesTest(_QueueTempDirMixin, unittest.TestCase):
@@ -2601,6 +2610,308 @@ class EvictionsLogRotationBoundaryTest(_QueueTempDirMixin, unittest.TestCase):
         with redirect_stderr(io.StringIO()):
             pending._log_eviction("aaaa.json", 10, "count", 1, 10)
         self.assertEqual(len(self._lines()), 1, "over the cap, rotation runs")
+
+
+class DeadMarkersLeaveTheLiveQueueTest(_QueueTempDirMixin, unittest.TestCase):
+    """A `.dead` marker is the ONLY copy of its memory, so it must not sit
+    in the directory external janitors sweep.
+
+    Live evidence: a host cron on this fleet ran
+    ``find <queue> -name '*.dead' -mtime +14 -delete`` (6 markers were live
+    in the queue when this was measured on 2026-07-26, each on a countdown
+    to permanent deletion). Fixing that one cron is
+    not a fix -- the next janitor has the same shape. These tests pin the
+    product-level invariant instead: THE LIVE QUEUE DIRECTORY CONTAINS ONLY
+    LIVE ENTRIES.
+    """
+
+    def _dead_names(self):
+        try:
+            return sorted(os.listdir(pending.dead_dir()))
+        except OSError:
+            return []
+
+    def test_a_janitor_globbing_the_live_queue_cannot_match_a_memory(self):
+        path = pending.enqueue(_payload(content="doomed"), RuntimeError("x"))
+        pending.mark_dead(path, dict(_payload(content="doomed")))
+
+        # This is literally what the host cron matched on.
+        leftovers = [n for n in os.listdir(self._dir) if n.endswith(".dead")]
+        self.assertEqual(leftovers, [], "no .dead file may remain in the queue dir")
+        self.assertEqual(len(self._dead_names()), 1, "and the memory still exists")
+
+    def test_the_marker_still_carries_the_whole_memory(self):
+        path = pending.enqueue(_payload(content="precious"), RuntimeError("x"))
+        marker = pending.mark_dead(path, dict(_payload(content="precious")))
+        with open(marker, encoding="utf-8") as f:
+            self.assertEqual(json.load(f)["content"], "precious")
+        self.assertTrue(marker.startswith(pending.dead_dir()))
+
+    def test_an_unwritable_dead_archive_leaves_the_entry_QUEUED(self):
+        """Failure to archive is never a licence to delete."""
+        path = pending.enqueue(_payload(content="stays"), RuntimeError("x"))
+        blocker = os.path.join(self._tmp, "blocked")
+        with open(blocker, "w", encoding="utf-8") as f:
+            f.write("not a directory")
+        os.environ["HINDSIGHT_PENDING_DEAD_DIR"] = os.path.join(blocker, "dead")
+
+        self.assertIsNone(pending.mark_dead(path, dict(_payload(content="stays"))))
+        self.assertTrue(os.path.exists(path), "the live entry must survive")
+        self.assertEqual(pending.count(), 1)
+
+    def test_legacy_markers_in_the_queue_dir_are_relocated_not_deleted(self):
+        os.makedirs(self._dir, mode=0o700, exist_ok=True)
+        legacy = []
+        for i in range(3):
+            name = os.path.join(self._dir, f"100{i}000-abc-{i}.json.dead")
+            with open(name, "w", encoding="utf-8") as f:
+                json.dump(_payload(content=f"old-{i}"), f)
+            legacy.append(name)
+
+        self.assertEqual(pending.sweep_legacy_dead_markers(), 3)
+        self.assertEqual(
+            [n for n in os.listdir(self._dir) if n.endswith(".dead")], []
+        )
+        self.assertEqual(len(self._dead_names()), 3)
+        for name in legacy:
+            self.assertFalse(os.path.exists(name))
+        # Content survived the move -- this is the whole point.
+        moved = os.path.join(pending.dead_dir(), self._dead_names()[0])
+        with open(moved, encoding="utf-8") as f:
+            self.assertEqual(json.load(f)["content"], "old-0")
+
+    def test_the_sweep_is_idempotent_and_never_overwrites(self):
+        os.makedirs(self._dir, mode=0o700, exist_ok=True)
+        name = os.path.join(self._dir, "1000000-abc-0.json.dead")
+        with open(name, "w", encoding="utf-8") as f:
+            json.dump(_payload(content="first"), f)
+        self.assertEqual(pending.sweep_legacy_dead_markers(), 1)
+        self.assertEqual(pending.sweep_legacy_dead_markers(), 0)
+
+        # A same-named marker reappearing must not clobber the archived one.
+        with open(name, "w", encoding="utf-8") as f:
+            json.dump(_payload(content="second"), f)
+        self.assertEqual(pending.sweep_legacy_dead_markers(), 0)
+        with open(os.path.join(pending.dead_dir(), os.path.basename(name)),
+                  encoding="utf-8") as f:
+            self.assertEqual(json.load(f)["content"], "first")
+
+    def test_the_sweep_leaves_live_entries_alone(self):
+        pending.enqueue(_payload(content="alive"), RuntimeError("x"))
+        self.assertEqual(pending.sweep_legacy_dead_markers(), 0)
+        self.assertEqual(pending.count(), 1)
+
+    def test_a_dead_marker_is_STRUCTURALLY_UNTRIMMABLE(self):
+        """The deliberate exception: a dead marker is the only copy left.
+
+        Every other archive holds a redundant copy and is capped. This one
+        holds unrecovered memories, so a cap would be a delete by another
+        name -- exactly the loss channel this change closes. The guarantee
+        is not "we remember not to call the trim": `_trim_dir` selects
+        `*.json` and a marker is `<entry>.json.dead`, so pointing a trim
+        straight at the dead archive with a zero cap still removes nothing.
+        """
+        for i in range(40):
+            path = pending.enqueue(_payload(content=f"dead-{i}"), RuntimeError("x"))
+            pending.mark_dead(path, dict(_payload(content=f"dead-{i}")))
+        self.assertEqual(len(self._dead_names()), 40)
+
+        with redirect_stderr(io.StringIO()):
+            dropped = pending._trim_dir(pending.dead_dir(), 0, 0)
+        self.assertEqual(dropped, 0)
+        self.assertEqual(len(self._dead_names()), 40, "a memory was trimmed away")
+
+    def test_the_backlog_drain_relocates_legacy_markers(self):
+        """The migration only happens if the drain actually calls it.
+
+        Nothing else on the fleet runs `sweep_legacy_dead_markers`, so an
+        unwired phase 0b leaves every existing marker sitting in the janitor's
+        path -- the exact condition this change exists to end. Asserting the
+        function works in isolation does not catch that; this does.
+        """
+        path = pending.enqueue(_payload(content="legacy"), RuntimeError("x"))
+        legacy = path + ".dead"
+        os.replace(path, legacy)
+
+        summary = drain_pending.drain_backlog(CONFIG, phase="reconcile")
+
+        self.assertEqual(summary["dead_relocated"], 1)
+        self.assertFalse(os.path.exists(legacy), "marker left in the live queue dir")
+        self.assertEqual(self._dead_names(), [os.path.basename(legacy)])
+
+    def test_a_dry_run_relocates_nothing(self):
+        path = pending.enqueue(_payload(content="legacy"), RuntimeError("x"))
+        legacy = path + ".dead"
+        os.replace(path, legacy)
+
+        summary = drain_pending.drain_backlog(CONFIG, phase="reconcile", dry_run=True)
+
+        self.assertEqual(summary["dead_relocated"], 0)
+        self.assertTrue(os.path.exists(legacy))
+
+
+class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
+    """An entry over the retain bound is RECOVERABLE, so it must never die.
+
+    Such an entry needs more sequential extraction calls than fit the client
+    deadline, so every POST is guaranteed waste; if the server rejects the
+    body as a 4xx it is (correctly) classified permanent and the memory goes
+    `.dead`. Splitting it is the difference between a lost memory and a slow
+    one. Two ways one gets into a queue and both are live on this fleet: an
+    older build enqueued it unsplit, or the BOUND MOVED under it.
+    """
+
+    def _resplit_names(self):
+        try:
+            return sorted(os.listdir(pending.resplit_dir()))
+        except OSError:
+            return []
+
+    def test_an_over_bound_entry_becomes_drainable_parts(self):
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="z" * 90_000), RuntimeError("x"))
+        self.assertEqual(pending.count(), 1, "queued unsplit under the old bound")
+
+        # The bound MOVES -- exactly what a deadline or safety-factor change
+        # does. The entry is now unretainable as-is.
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual(entries, 1)
+        self.assertGreaterEqual(parts, 30)
+        self.assertFalse(os.path.exists(path), "the original left the queue")
+        self.assertEqual(len(self._resplit_names()), 1, "archived, not deleted")
+        for _p, entry in pending.iter_entries():
+            self.assertLessEqual(len(entry["content"]), 3000)
+
+    def test_no_line_of_the_memory_is_lost_across_the_resplit(self):
+        """Every line survives -- that is the guarantee that matters.
+
+        `split_retain_content` promises to lose no MESSAGE, not to be
+        byte-exact: it splits on line boundaries and the boundary newline
+        itself is not carried into either part (measured: 29 newlines lost
+        over a 30-way split). That is a pre-existing property of the splitter
+        that the LIVE enqueue path already has; this test pins the property a
+        re-split must not go beyond -- no line of the memory may vanish.
+
+        Order is deliberately not asserted: the parts are independent queue
+        entries whose filenames carry a random suffix, so `iter_entries()`
+        returns them in filename order, not part order. Reassembly is by the
+        part metadata, not by queue position.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        body = "".join(f"line {i}\n" for i in range(9000))
+        pending.enqueue(_payload(content=body), RuntimeError("x"))
+
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        pending.resplit_over_bound_entries()
+        rejoined = "\n".join(e["content"] for _p, e in pending.iter_entries())
+        surviving = [ln for ln in rejoined.split("\n") if ln]
+        expected = [f"line {i}" for i in range(9000)]
+        # Cheap, readable failure first: name the lines that went missing
+        # rather than dumping a 9000-element list diff.
+        missing = sorted(set(expected) - set(surviving))
+        self.assertEqual(missing[:10], [], f"{len(missing)} line(s) lost in the re-split")
+        self.assertEqual(len(surviving), len(expected), "a line was duplicated or dropped")
+
+    def test_the_resplit_archive_is_itself_bounded(self):
+        """The archived original is redundant, so it must not eat the disk.
+
+        It is only moved AFTER its parts are queued, so unlike
+        `pending-dead/` (which holds the only copy of an unrecovered memory
+        and is deliberately uncapped) this archive can be trimmed on the
+        same terms as `pending-duplicate/`.
+        """
+        prev = pending.RESPLIT_MAX_ENTRIES
+        pending.RESPLIT_MAX_ENTRIES = 2
+        try:
+            os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+            for i in range(5):
+                pending.enqueue(_payload(content=f"{i}" * 40_000), RuntimeError("x"))
+            os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+            with redirect_stderr(io.StringIO()):
+                resplit, _parts = pending.resplit_over_bound_entries()
+            self.assertEqual(resplit, 5)
+            self.assertLessEqual(len(self._resplit_names()), 2)
+        finally:
+            pending.RESPLIT_MAX_ENTRIES = prev
+
+    def test_the_archived_original_is_still_readable(self):
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        pending.enqueue(_payload(content="q" * 50_000), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        pending.resplit_over_bound_entries()
+
+        archived = os.path.join(pending.resplit_dir(), self._resplit_names()[0])
+        with open(archived, encoding="utf-8") as f:
+            self.assertEqual(len(json.load(f)["content"]), 50_000)
+
+    def test_an_entry_within_the_bound_is_untouched(self):
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="small"), RuntimeError("x"))
+        self.assertEqual(pending.resplit_over_bound_entries(), (0, 0))
+        self.assertTrue(os.path.exists(path))
+        self.assertEqual(self._resplit_names(), [])
+
+    def test_resplitting_is_idempotent(self):
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        pending.enqueue(_payload(content="w" * 40_000), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        pending.resplit_over_bound_entries()
+        depth = pending.count()
+        self.assertEqual(pending.resplit_over_bound_entries(), (0, 0))
+        self.assertEqual(pending.count(), depth, "a second pass is a no-op")
+
+    def test_an_entry_that_cannot_be_split_STAYS_QUEUED(self):
+        """No part written => the original is left exactly where it was."""
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="v" * 40_000), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+
+        with unittest.mock.patch.object(pending, "_enqueue_one", return_value=None):
+            entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual((entries, parts), (0, 0))
+        self.assertTrue(os.path.exists(path), "never deleted on failure")
+        self.assertEqual(self._resplit_names(), [])
+
+    def test_the_parts_carry_no_stale_attempt_metadata(self):
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="u" * 40_000), RuntimeError("x"))
+        for _ in range(4):
+            with open(path, encoding="utf-8") as f:
+                entry = json.load(f)
+            pending.update_attempt(path, entry, RuntimeError("again"))
+
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        pending.resplit_over_bound_entries()
+        for _p, entry in pending.iter_entries():
+            self.assertEqual(
+                entry["attempt_count"], 1,
+                "a re-split part starts its own budget -- inheriting an "
+                "exhausted one would send it straight back toward .dead",
+            )
+            self.assertNotIn("dead_at", entry)
+
+    def test_the_backlog_drain_resplits_before_paying_for_extraction(self):
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        pending.enqueue(_payload(content="t" * 40_000), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+
+        summary = drain_pending.drain_backlog(CONFIG, phase="reconcile")
+        self.assertEqual(summary["resplit"], 1)
+        self.assertGreaterEqual(summary["resplit_parts"], 14)
+
+    def test_a_dry_run_resplits_nothing(self):
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="s" * 40_000), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+
+        summary = drain_pending.drain_backlog(
+            CONFIG, phase="reconcile", dry_run=True
+        )
+        self.assertEqual(summary["resplit"], 0)
+        self.assertTrue(os.path.exists(path))
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -2659,6 +2659,38 @@ class DeadMarkersLeaveTheLiveQueueTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertTrue(os.path.exists(path), "the live entry must survive")
         self.assertEqual(pending.count(), 1)
 
+    def test_a_failed_REPLACE_also_leaves_the_entry_QUEUED(self):
+        """The other half of "FAILURE IS NOT DELETION".
+
+        `test_an_unwritable_dead_archive_leaves_the_entry_QUEUED` fails at
+        `os.makedirs`, so the tmp never exists and the cleanup block's
+        `os.unlink(tmp)` raises before anything else in it can run -- which
+        shields a stray `os.unlink(path)` placed AFTER it from ever being
+        observed. Here the tmp write SUCCEEDS and only `os.replace` fails, so
+        every statement in the cleanup block executes.
+        """
+        path = pending.enqueue(_payload(content="stays"), RuntimeError("x"))
+        real_replace = os.replace
+
+        def _fail_replace(src, dst, *a, **kw):
+            if str(dst).endswith(".dead"):
+                raise OSError("replace refused")
+            return real_replace(src, dst, *a, **kw)
+
+        with unittest.mock.patch("os.replace", side_effect=_fail_replace):
+            self.assertIsNone(
+                pending.mark_dead(path, dict(_payload(content="stays")))
+            )
+
+        self.assertTrue(os.path.exists(path), "the live entry must survive")
+        self.assertEqual(pending.count(), 1)
+        self.assertEqual(self._dead_names(), [], "no marker, so no copy exists")
+        # And the orphaned tmp really was cleaned up -- that is what the
+        # `os.unlink(tmp)` in the cleanup block is FOR.
+        self.assertEqual(
+            [n for n in os.listdir(pending.dead_dir()) if n.endswith(".tmp")], []
+        )
+
     def test_legacy_markers_in_the_queue_dir_are_relocated_not_deleted(self):
         os.makedirs(self._dir, mode=0o700, exist_ok=True)
         legacy = []
@@ -2882,16 +2914,197 @@ class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
             with open(path, encoding="utf-8") as f:
                 entry = json.load(f)
             pending.update_attempt(path, entry, RuntimeError("again"))
+        # Age the queue stamp explicitly rather than relying on the clock:
+        # `failed_at` is second-resolution, so a same-second test could not
+        # tell a fresh stamp from a round-tripped one.
+        stale_failed_at = "2020-01-01T00:00:00Z"
+        with open(path, encoding="utf-8") as f:
+            stale = json.load(f)
+        stale["failed_at"] = stale_failed_at
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(stale, f)
+        # Guard the fixture: the assertions below are vacuous unless the
+        # original really is carrying every field a retried entry accumulates.
+        self.assertEqual(stale["attempt_count"], 5)
+        self.assertIn("last_attempt_at", stale)
+        self.assertEqual(stale["error_class"], "RuntimeError")
+        self.assertEqual(stale["error_message"], "again")
 
         os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
         pending.resplit_over_bound_entries()
-        for _p, entry in pending.iter_entries():
+        entries = pending.iter_entries()
+        self.assertGreaterEqual(len(entries), 13, "the entry really was split")
+        for _p, entry in entries:
             self.assertEqual(
                 entry["attempt_count"], 1,
                 "a re-split part starts its own budget -- inheriting an "
                 "exhausted one would send it straight back toward .dead",
             )
             self.assertNotIn("dead_at", entry)
+            # `update_attempt` stamps `last_attempt_at`, so it is entry-only
+            # metadata too. Round-tripping it pairs a timestamp from the old
+            # entry's last retry with a fresh `attempt_count: 1` -- an entry
+            # that claims it was last attempted before it was ever queued.
+            self.assertNotIn(
+                "last_attempt_at", entry,
+                "a fresh part has never been attempted",
+            )
+            self.assertEqual(
+                entry["error_class"], "RuntimeError",
+                "the part records why IT was queued (the re-split), not the "
+                "error the original last failed with",
+            )
+            self.assertIn("re-split", entry["error_message"])
+            self.assertNotEqual(
+                entry["failed_at"], stale_failed_at,
+                "a stale failed_at mis-orders the part in the drain queue",
+            )
+            self.assertEqual(entry["schema"], pending.SCHEMA)
+
+    # --- The archive is only earned by a NEW file -------------------------
+    #
+    # `_enqueue_one` returns the path of an ALREADY-QUEUED identical entry on
+    # a dedupe hit, so "enqueue handed back a path" is not "a part was
+    # written". Both cases below are the same bug from two angles: a re-split
+    # that wrote nothing must not archive the original, because the archive
+    # is capped (`_trim_dir`) and the original is then the only copy.
+
+    def test_a_resplit_that_dedupes_onto_its_own_original_STAYS_QUEUED(self):
+        """The real repro, no patching: ONE part, so `enqueue` re-enqueues
+        the payload unchanged, the dupe key matches the entry being re-split,
+        and the "written" path IS the original.
+
+        A JSON transcript is re-serialised compactly by the splitter, so a
+        pretty-printed one over the bound can compact to a single part under
+        it. That is not exotic -- it is any indented transcript whose
+        whitespace is most of its size.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        blocks = [{"type": "text", "text": f"line {i}"} for i in range(60)]
+        content = json.dumps([{"role": "user", "content": blocks}], indent=8)
+        path = pending.enqueue(_payload(content=content), RuntimeError("x"))
+        self.assertEqual(pending.count(), 1)
+
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        self.assertGreater(len(content), 3000, "the entry is over the bound")
+        self.assertEqual(
+            len(retain_split.split_retain_content(content)), 1,
+            "the splitter yields a SINGLE part -- the condition under test",
+        )
+
+        with redirect_stderr(io.StringIO()):
+            entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual((entries, parts), (0, 0))
+        self.assertTrue(os.path.exists(path), "the ONLY copy was archived away")
+        self.assertEqual(pending.count(), 1)
+        self.assertEqual(self._resplit_names(), [], "nothing was earned")
+
+    def test_a_deduped_part_is_not_counted_as_a_written_part(self):
+        """`_enqueue_one` returns an EXISTING path and writes no new file.
+
+        Distinct from `test_an_entry_that_cannot_be_split_STAYS_QUEUED`,
+        which returns None and so makes "no path came back" and "no file
+        appeared" true at once -- it cannot tell the two guards apart.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="d" * 40_000), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+
+        # Non-None, already on disk, and no new file is created.
+        with unittest.mock.patch.object(pending, "_enqueue_one", return_value=path):
+            with redirect_stderr(io.StringIO()):
+                entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual((entries, parts), (0, 0))
+        self.assertTrue(os.path.exists(path), "never deleted on a no-op split")
+        self.assertEqual(pending.count(), 1)
+        self.assertEqual(self._resplit_names(), [])
+
+    def test_the_part_count_is_not_a_queue_depth_delta(self):
+        """Parts WRITTEN, not queue growth.
+
+        When the queue is near its cap, `_evict_to_fit` sheds an older entry
+        for each part it makes room for, so the depth barely moves while N
+        parts are genuinely written. A depth delta under-reports that (and at
+        the extreme reads 0, which is the "stays queued" signal) -- so the
+        count is taken from what `_enqueue_one` handed back.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        for i in range(10):
+            pending.enqueue(
+                _payload(content=f"filler-{i}", doc=_cd_doc(i + 50)),
+                RuntimeError("x"),
+            )
+        path = pending.enqueue(_payload(content="y" * 40_000), RuntimeError("x"))
+        self.assertEqual(pending.count(), 11)
+
+        # 11 queued + 14 parts does not fit, so writing the parts evicts.
+        pending.MAX_ENTRIES = 20
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        with redirect_stderr(io.StringIO()):
+            entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual(entries, 1)
+        # 20 at the cap, less the original once it is archived out.
+        self.assertEqual(pending.count(), 19, "the cap held, so eviction fired")
+        self.assertLess(
+            19 - 11, 14, "the depth grew by less than the parts written"
+        )
+        self.assertEqual(
+            parts, 14,
+            "every part written is counted, even the ones whose room was "
+            "made by evicting an older entry",
+        )
+        self.assertFalse(os.path.exists(path), "the original was archived")
+
+    # --- A refusal the caller absorbs is not a permanent loss -------------
+
+    def _refused_resplit_leaves_the_ledger_clean(self, cap: str, value: int):
+        """`record_drop` means the memory is GONE; here it is still queued.
+
+        `switchroom doctor` FAILS on a non-zero drop ledger, and phase 0c
+        retries on every backlog drain (10 min on this fleet), so stamping a
+        refusal turns a safely-queued memory into a permanent, monotonically
+        climbing doctor failure.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="r" * 40_000), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        setattr(pending, cap, value)
+
+        with redirect_stderr(io.StringIO()):
+            for _ in range(3):  # every drain retries the same entry
+                self.assertEqual(pending.resplit_over_bound_entries(), (0, 0))
+
+        self.assertEqual(
+            pending.read_drops(), {},
+            "nothing was lost -- the original is still queued and retryable",
+        )
+        self.assertTrue(os.path.exists(path))
+        self.assertEqual(self._resplit_names(), [])
+
+    def test_a_resplit_refused_on_the_entry_cap_stamps_no_drop(self):
+        self._refused_resplit_leaves_the_ledger_clean("MAX_ENTRIES", 2)
+
+    def test_a_resplit_refused_on_the_byte_cap_stamps_no_drop(self):
+        self._refused_resplit_leaves_the_ledger_clean("MAX_BYTES", 4096)
+
+    def test_the_producer_path_still_stamps_a_refused_memory_as_dropped(self):
+        """The suppression is scoped to the re-split caller, not global.
+
+        `session_end` / `retain` have no other copy of the memory, so when
+        `enqueue` refuses one the turn really is lost and the ledger is the
+        only record of it.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        pending.MAX_BYTES = 4096  # smaller than the split memory as a whole
+        with redirect_stderr(io.StringIO()):
+            self.assertIsNone(
+                pending.enqueue(_payload(content="e" * 40_000), RuntimeError("x"))
+            )
+        self.assertEqual(pending.read_drops().get("count"), 1)
+        self.assertEqual(pending.count(), 0)
 
     def test_the_backlog_drain_resplits_before_paying_for_extraction(self):
         os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"

--- a/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
+++ b/vendor/hindsight-memory/scripts/tests/test_pending_drops.py
@@ -2754,6 +2754,75 @@ class DeadMarkersLeaveTheLiveQueueTest(_QueueTempDirMixin, unittest.TestCase):
         self.assertEqual(dropped, 0)
         self.assertEqual(len(self._dead_names()), 40, "a memory was trimmed away")
 
+    def _write_legacy_markers(self, n: int) -> list:
+        os.makedirs(self._dir, mode=0o700, exist_ok=True)
+        names = []
+        for i in range(n):
+            name = f"100{i}000-abc-{i}.json.dead"
+            with open(os.path.join(self._dir, name), "w", encoding="utf-8") as f:
+                json.dump(_payload(content=f"old-{i}"), f)
+            names.append(name)
+        return names
+
+    def _legacy_leftovers(self):
+        return sorted(n for n in os.listdir(self._dir) if n.endswith(".dead"))
+
+    def test_an_uncreatable_dead_archive_reports_ZERO_relocated(self):
+        """The count is a claim about the LIVE QUEUE, not an intention.
+
+        Phase 0b turns it straight into `summary["dead_relocated"]` and the
+        line "the queue now holds only live entries, so no janitor glob over
+        it can match a memory". When `dead_dir()` cannot be created not one
+        marker moved, so returning `len(names)` would print that sentence
+        over a queue directory still holding every marker -- the exact
+        condition this change exists to end, now with an operator told it was
+        fixed.
+        """
+        self._write_legacy_markers(3)
+
+        with unittest.mock.patch.object(
+            pending.os, "makedirs",
+            side_effect=OSError(errno.EACCES, "Permission denied"),
+        ):
+            with redirect_stderr(io.StringIO()) as err:
+                moved = pending.sweep_legacy_dead_markers()
+
+        self.assertEqual(moved, 0, "nothing moved, so nothing may be claimed")
+        self.assertEqual(
+            len(self._legacy_leftovers()), 3,
+            "and every marker is still in the janitor's path",
+        )
+        self.assertEqual(self._dead_names(), [])
+        self.assertIn("STAY in the live queue", err.getvalue())
+
+    def test_a_marker_that_could_not_be_MOVED_is_not_counted(self):
+        """One marker per `except OSError`, and a `pass` there counts a lie.
+
+        The loop swallows a per-marker failure deliberately -- one unwritable
+        marker must not abandon the other nine -- but swallowing it is not
+        the same as having moved it. Dropping the `continue` leaves the
+        marker in the live queue directory AND reports it relocated.
+        """
+        names = self._write_legacy_markers(2)
+        real_move = shutil.move
+
+        def refuse_the_second(src, dst):
+            if str(src).endswith(names[1]):
+                raise OSError(errno.EACCES, "Permission denied")
+            return real_move(src, dst)
+
+        with unittest.mock.patch.object(pending.shutil, "move", refuse_the_second):
+            with redirect_stderr(io.StringIO()) as err:
+                moved = pending.sweep_legacy_dead_markers()
+
+        self.assertEqual(moved, 1, "only the marker that actually moved counts")
+        self.assertEqual(
+            self._legacy_leftovers(), [names[1]],
+            "the refused one is still in the live queue directory",
+        )
+        self.assertEqual(self._dead_names(), [names[0]])
+        self.assertIn("relocated 1 legacy .dead marker(s)", err.getvalue())
+
     def test_the_backlog_drain_relocates_legacy_markers(self):
         """The migration only happens if the drain actually calls it.
 
@@ -3271,6 +3340,54 @@ class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
 
     # --- An original evicted out from under its own re-split --------------
 
+    @staticmethod
+    def _clock_frozen_at(when: float):
+        """Freeze the millisecond `_enqueue_one` stamps into entry names.
+
+        Entry names are `<unix-ms>-<dupe-key>-<uuid>.json` and FIFO order is
+        their lexicographic sort, so entries written inside ONE millisecond
+        tie-break on the CONTENT-DERIVED dupe key -- stable and total, but
+        arbitrary. Production never hits that on the re-split path: the
+        original was queued by an EARLIER process, milliseconds to days
+        before its parts. A test that enqueues both inside one tick does hit
+        it, and then `_evict_to_fit` sheds whichever name happens to sort
+        first -- measured 6 failures in 40 isolated runs of the case below
+        before this pin. So pin the age relationship the product guarantees
+        instead of racing the clock for it.
+        """
+        return unittest.mock.patch.object(pending.time, "time", lambda: when)
+
+    def _nth_part_write_fails(self, n: int):
+        """ENOSPC on the `n`-th part write, and on nothing else.
+
+        Counting every `os.rename` would be wrong: `shutil.move` renames too
+        when source and destination share a filesystem, so an eviction inside
+        the same loop shifts the count. Only the tmp -> `<entry>.json` rename
+        inside the LIVE QUEUE dir is a part landing.
+        """
+        real_rename = os.rename
+        seen = {"n": 0}
+
+        def flaky(src, dst):
+            landing = str(dst).endswith(".json") and os.path.dirname(
+                os.path.abspath(str(dst))
+            ) == os.path.abspath(self._dir)
+            if landing:
+                seen["n"] += 1
+                if seen["n"] == n:
+                    raise OSError(errno.ENOSPC, "No space left on device")
+            return real_rename(src, dst)
+
+        return unittest.mock.patch.object(pending.os, "rename", flaky)
+
+    def _an_original_older_than_its_parts(self, content: str) -> str:
+        """Enqueue `content` stamped an hour ago; return its queue path."""
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        with self._clock_frozen_at(time.time() - 3600):
+            path = pending.enqueue(_payload(content=content), RuntimeError("x"))
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        return path
+
     def test_a_resplit_that_evicts_its_own_original_says_so(self):
         """The parts fill the queue and FIFO-shed the entry being re-split.
 
@@ -3282,10 +3399,8 @@ class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
         when it is in `pending-evicted/`, and returned (0, 0) after writing
         fourteen parts.
         """
-        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
-        path = pending.enqueue(_payload(content="z" * 40_000), RuntimeError("x"))
+        path = self._an_original_older_than_its_parts("z" * 40_000)
         name = os.path.basename(path)
-        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
         pending.MAX_ENTRIES = 14
 
         err = io.StringIO()
@@ -3305,10 +3420,218 @@ class ResplitOverBoundEntriesTest(_QueueTempDirMixin, unittest.TestCase):
             "exactly this pressure",
         )
         self.assertIn(pending.evicted_dir(), log, "say where it actually is")
+
+    def test_the_evicted_branch_counts_the_parts_it_actually_wrote(self):
+        """The return tuple alone, pinned on its own.
+
+        This is the assertion that keeps the `continue` off the evicted
+        branch: with it restored the drain writes fourteen parts and reports
+        (0, 0), so phase 0c's `_blog` line and `summary["resplit"]` both go
+        silent on a re-split that happened. It is deliberately free of log
+        wording and of every archive-location assertion, so no rewording of
+        the operator line can retire the guard by accident.
+        """
+        self._an_original_older_than_its_parts("z" * 40_000)
+        pending.MAX_ENTRIES = 14
+
+        with redirect_stderr(io.StringIO()):
+            entries, parts = pending.resplit_over_bound_entries()
+
         self.assertEqual(
             (entries, parts), (1, 14),
-            "fourteen parts were genuinely written, so phase 0c's summary "
-            "and `_blog` line must report them",
+            "fourteen parts were genuinely written and are queued, so phase "
+            "0c's summary and `_blog` line must report them",
+        )
+        self.assertEqual(pending.count(), 14, "and all fourteen really are live")
+
+    def test_a_part_shed_to_make_room_is_not_counted_as_queued(self):
+        """The other side of the eviction race, and an accounting lie.
+
+        FIFO sheds the OLDEST name, which is the original only while the
+        original IS the oldest. Freeze the parts into an older millisecond
+        and part fourteen evicts a PART instead: `shutil.move` then SUCCEEDS,
+        the original is archived under `pending-resplit/`, and the drain used
+        to report "into 14 queued part(s)" with thirteen queued and one
+        sitting in `pending-evicted/`. Nothing re-drains that directory (see
+        `drain_pending`, `probe.ts`, `doctor.ts` -- all of them only count or
+        trim it), so the shed part is a slice of the memory that will not
+        reach the bank, and the operator line must not paper over it.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="y" * 40_000), RuntimeError("x"))
+        name = os.path.basename(path)
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        pending.MAX_ENTRIES = 14
+
+        err = io.StringIO()
+        # The parts land an hour "before" the original, so the oldest name in
+        # the queue when part fourteen needs room is a part, not the original.
+        with self._clock_frozen_at(time.time() - 3600):
+            with redirect_stderr(err):
+                entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual(pending.count(), 13, "thirteen parts survived")
+        self.assertEqual(
+            self._resplit_names(), [name], "the original WAS archived here"
+        )
+        shed = self._archive_names()
+        self.assertEqual(len(shed), 1, "one part was shed to make room")
+        self.assertNotIn(name, shed, "and it was a part, not the original")
+
+        self.assertEqual(
+            (entries, parts), (1, 13),
+            "a part in pending-evicted/ is not a queued part -- nothing "
+            "re-drains that directory",
+        )
+        log = err.getvalue()
+        self.assertIn("into 13 queued part(s)", log)
+        self.assertNotIn("into 14 queued part(s)", log)
+        # The eviction itself already logs "evicted OLDEST ... into <dir>", so
+        # asserting on `evicted_dir()` alone here passes with no re-split line
+        # at all -- vacuous. Pin the re-split's OWN line: the operator reading
+        # "the original is archived" has to be told, in the same breath, that
+        # a part went the other way.
+        self.assertRegex(
+            log,
+            r"re-split \S+ wrote 14 part\(s\).*13 part\(s\) of this memory "
+            r"are live",
+            "the re-split must reconcile 14 written against 13 live",
+        )
+        self.assertIn(
+            f"FIFO-evicted into {pending.evicted_dir()}", log,
+            "and say where the shed part went",
+        )
+        self.assertIn(shed[0], log, "named, so it can be found")
+
+    def _resplit_with_the_last_part_failing(self):
+        """Original evicted AND one part unwritten, the two together.
+
+        Part fourteen is the one that triggers `_evict_to_fit` (the queue is
+        at its cap of fourteen), so failing THAT part's write is the only
+        arrangement where the original leaves the queue and a part is
+        genuinely lost in the same drain. Returns `(entries, parts, log)`.
+        """
+        path = self._an_original_older_than_its_parts("w" * 40_000)
+        pending.MAX_ENTRIES = 14
+
+        err = io.StringIO()
+        with self._nth_part_write_fails(14):
+            with redirect_stderr(err):
+                entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertFalse(os.path.exists(path), "the original left the queue")
+        self.assertIn(
+            os.path.basename(path), self._archive_names(),
+            "by eviction -- pending-resplit/ never got it",
+        )
+        self.assertEqual(self._resplit_names(), [])
+        self.assertEqual((entries, parts), (1, 13), "thirteen of fourteen")
+        return entries, parts, err.getvalue()
+
+    def test_a_part_that_fails_is_stamped_when_the_original_is_EVICTED(self):
+        """The archived branch is not the only one that retires the original.
+
+        `record_deferred_drops` is reached on BOTH branches below the move,
+        and only the archived one was covered: gating the stamp on the
+        original having reached `pending-resplit/` left this drain silent
+        about part fourteen, which nothing will ever retry -- the original is
+        in `pending-evicted/` and no consumer re-drains that directory.
+        """
+        self._resplit_with_the_last_part_failing()
+
+        self.assertEqual(
+            pending.read_drops().get("count"), 1,
+            "the part that never landed is gone for good and must be visible",
+        )
+        self.assertEqual(pending.read_drops().get("last_error_class"), "OSError")
+
+    def test_the_evicted_branch_does_not_reassure_when_a_part_was_lost(self):
+        """Two contradictory lines in one drain is a log-lie, not a nuance.
+
+        The evicted branch printed "(the parts carry the whole memory)"
+        unconditionally and `record_deferred_drops` then printed "permanently
+        lost" for the same entry, in the same drain. A non-empty `deferred`
+        is EXACTLY the case where the parts do not carry the whole memory.
+        """
+        _entries, _parts, log = self._resplit_with_the_last_part_failing()
+
+        self.assertNotIn(
+            "carry the whole memory", log,
+            "one part never got written, so they demonstrably do not",
+        )
+        self.assertIn("permanently lost", log, "and the loss is still said")
+        self.assertIn(pending.evicted_dir(), log, "with the original's location")
+
+    def test_a_concurrent_reconcile_is_not_reported_as_an_eviction(self):
+        """"Gone from the queue" is resolved, not assumed.
+
+        Nothing serialises this drain against an in-hook `drain()` --
+        `lib/pacing.py`'s `retain-inflight.lock` is a per-POST storm guard and
+        `drain_pending` takes no lock -- so the original can be RECONCILED out
+        from under the archive move. Attributing that to eviction told the
+        operator the memory was shed when it had just been confirmed durable
+        upstream, and stamped a permanent DROP for a part of a memory that
+        reached the bank whole.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "100000"
+        path = pending.enqueue(_payload(content="v" * 40_000), RuntimeError("x"))
+        name = os.path.basename(path)
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+
+        real_move = shutil.move
+
+        def reconcile_first(src, dst):
+            """The other process wins the race, between two syscalls here."""
+            if os.path.abspath(src) == os.path.abspath(path):
+                # Exactly what `archive_reconciled` does in the other
+                # process, minus the recursion back through this patch.
+                os.makedirs(pending.reconciled_dir(), mode=0o700, exist_ok=True)
+                real_move(src, os.path.join(pending.reconciled_dir(), name))
+                raise OSError(errno.ENOENT, "No such file or directory")
+            return real_move(src, dst)
+
+        err = io.StringIO()
+        with self._nth_part_write_fails(5):  # part five never lands
+            with unittest.mock.patch.object(pending.shutil, "move", reconcile_first):
+                with redirect_stderr(err):
+                    entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual(self._reconciled_names(), [name], "that is where it went")
+        self.assertEqual(self._archive_names(), [], "it was never evicted")
+        self.assertEqual((entries, parts), (1, 13))
+
+        log = err.getvalue()
+        self.assertIn(pending.reconciled_dir(), log, "say where it actually is")
+        self.assertNotIn("it was itself evicted", log)
+        self.assertEqual(
+            pending.read_drops(), {},
+            "the whole memory is durable upstream, so the part that never "
+            "got written is a redundant copy, not a lost turn",
+        )
+
+    def test_content_exactly_at_the_bound_is_not_re_split(self):
+        """`<= limit` is the bound, and the equal case is the whole point.
+
+        `split_retain_content` passes content of exactly `limit` chars
+        through unsplit, so re-splitting it here is pure churn: the payload
+        dedupes straight back onto the original and the drain prints "could
+        not re-split" about an entry that never needed splitting. At `<`
+        every drain does that for every at-the-bound entry.
+        """
+        os.environ["HINDSIGHT_RETAIN_MAX_CONTENT_CHARS"] = "3000"
+        path = pending.enqueue(_payload(content="b" * 3000), RuntimeError("x"))
+        self.assertEqual(pending.count(), 1, "it was queued whole, not split")
+
+        err = io.StringIO()
+        with redirect_stderr(err):
+            entries, parts = pending.resplit_over_bound_entries()
+
+        self.assertEqual((entries, parts), (0, 0))
+        self.assertTrue(os.path.exists(path), "untouched")
+        self.assertEqual(
+            err.getvalue(), "",
+            "an entry AT the bound is not even considered -- one char over "
+            "is over, one char at is not",
         )
 
     def test_an_archive_failure_that_leaves_the_original_queued_still_says_so(self):

--- a/vendor/hindsight-memory/tests/test_drain_pending.py
+++ b/vendor/hindsight-memory/tests/test_drain_pending.py
@@ -15,6 +15,21 @@ if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
 
+def _dead_marker(path: str) -> str:
+    """Where `mark_dead` puts the marker for the queue entry at `path`.
+
+    NOT `<path>.dead` any more: a marker is the only remaining copy of its
+    memory, so it leaves the live queue directory for the `pending-dead/`
+    sibling rather than sitting in the directory external janitors glob
+    (switchroom #3697). Asserting the old spelling made this suite red on a
+    deliberate change -- invisibly, because CI discovers only
+    `scripts/tests/`.
+    """
+    from lib.pending import dead_dir
+
+    return os.path.join(dead_dir(), os.path.basename(path) + ".dead")
+
+
 class FakeOk:
     """Minimal urlopen() context-manager stand-in for a 200 OK."""
 
@@ -229,7 +244,7 @@ class DrainPendingTest(unittest.TestCase):
             summary = drain_pending.drain({})
         self.assertEqual(summary["dead"], 1)
         self.assertFalse(os.path.exists(path))
-        self.assertTrue(os.path.exists(path + ".dead"))
+        self.assertTrue(os.path.exists(_dead_marker(path)))
 
     def test_drain_max_attempts_keeps_the_memory_on_a_transient_failure(self):
         """A dead upstream must never retire a memory, however many attempts.
@@ -251,7 +266,7 @@ class DrainPendingTest(unittest.TestCase):
         self.assertEqual(summary["dead"], 0)
         self.assertEqual(summary["retried"], 1)
         self.assertTrue(os.path.exists(path))
-        self.assertFalse(os.path.exists(path + ".dead"))
+        self.assertFalse(os.path.exists(_dead_marker(path)))
 
     def test_drain_stall_guard_stops_after_threshold(self):
         # Seed 10 entries; with a same-error-class stream, the stall

--- a/vendor/hindsight-memory/tests/test_pending.py
+++ b/vendor/hindsight-memory/tests/test_pending.py
@@ -203,8 +203,13 @@ class PendingQueueTest(unittest.TestCase):
             self.assertNotIn(
                 "dead_at", e, "a live queue entry must never carry dead_at"
             )
-        # The .dead marker exists and carries dead_at.
-        dead = path + ".dead"
+        # The .dead marker exists and carries dead_at. It lives in the
+        # `pending-dead/` SIBLING, not in the live queue directory: a marker
+        # is the only remaining copy of its memory, and the queue dir is the
+        # one external janitors glob (switchroom #3697).
+        dead = os.path.join(
+            pending_mod.dead_dir(), os.path.basename(path) + ".dead"
+        )
         self.assertTrue(os.path.isfile(dead))
         with open(dead) as f:
             self.assertIn("dead_at", json.load(f))


### PR DESCRIPTION
## User outcome

A memory the user was told was saved can no longer be destroyed by disk hygiene, and an oversized one is no longer unretainable.

## The problem

A `.dead` marker is the **only remaining copy** of its memory — `mark_dead` unlinks the live entry once the marker is durable. It was written *inside* `pending-retains/`, which is the one directory external janitorial tooling has every reason to sweep. On this fleet a host cron did exactly that:

```
find "$base/pending-retains" -name '*.dead' -mtime +14 -print0 | xargs -0 rm -f --
```

Measured 2026-07-26: 6 such markers were live in the queue directory, each on a countdown to permanent deletion. Fixing that one cron is not a fix — the next janitor has the same shape.

The second half is upstream of it: an entry whose content exceeds `retain_content_limit()` needs more sequential extraction calls than fit the client deadline, so it is not *slow*, it is **impossible**. It churns forever at the back of the drain order, or the server rejects the oversized body as a 4xx, `is_permanent_failure` (correctly) calls that permanent, and the memory goes `.dead` — manufacturing exactly the markers the janitor then deletes. Measured on this fleet: 18 of 211 queued entries exceed 100,000 chars, the largest 744,546 (15x the bound).

## What changed

**1. Dead markers leave the live queue.**

- `mark_dead` retires into a new `pending-dead/` sibling. The live queue directory holds only live entries, so **no glob over it can match a memory**.
- `sweep_legacy_dead_markers` (drain **phase 0b**) relocates markers an older build left behind. An upgrade has to MOVE the existing ones, not just stop producing new ones. Idempotent; never overwrites an existing destination name.
- **Failure is not deletion.** If the marker cannot be written, `mark_dead` returns `None` and leaves the live entry exactly where it is. Falling back to an in-queue marker would quietly restore the loss channel.
- `pending-dead/` is deliberately **uncapped**, and that is structural rather than a convention: `_trim_dir` selects `*.json`, and a marker is `<entry>.json.dead`, so pointing a trim straight at the dead archive with a zero cap still removes nothing. A test asserts that outcome.

**2. Over-bound entries are re-split, not retired.**

- `resplit_over_bound_entries` (drain **phase 0c**) splits an entry over the bound into drainable parts via the existing `enqueue` splitter. Stale `attempt_count` / `failed_at` metadata is stripped so the parts do not inherit a spent retry budget.
- The original is archived into `pending-resplit/` **only after** at least one part is written. On every failure path — nothing splittable, unwritable archive — the original **stays queued**. Nothing is deleted on any path.
- `pending-resplit/` *is* capped (500 / 64 MB, same terms as `pending-duplicate/`): that copy is redundant by construction once the parts are queued.
- Runs after the duplicate collapse, so a duplicated over-bound entry is split once, not once per copy.
- This is also the queue's standing response to the bound MOVING, which #3693 makes routine.

**3. Both observability paths sum the new location.** `probeSpool` (hindsight-watch) and the doctor's per-container probe script now count `pending-dead/` as well as legacy in-queue markers. Counting only the in-queue form would make the relocation read as "0 dead" — silently retiring the operator's only view of permanently-failed retains.

## Honest costs

- One entry becomes N, so the queue gets **deeper** (worst case measured: 744,546 chars -> 23 parts). On a queue at its cap, `enqueue`'s eviction path sheds the oldest into `pending-evicted/` — shed, not destroyed, except under the sustained-ENOSPC case `_evict_to_fit` documents. Depth is recoverable; an over-bound entry is not drainable at any depth.
- `split_retain_content` drops the boundary newline at each part join (measured: 29 over a 30-way split). That is **pre-existing** and equally true of the live enqueue path; its contract is "loses no *message*", not byte-exactness. The re-split test asserts the real invariant (no line vanishes) and does not paper over the gap. Filing separately rather than folding a splitter change into this PR.

## Mutation testing

`PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared before every run. Revert each mechanism, confirm the suite goes red:

| # | Mutation | Result |
|---|---|---|
| M1 | `mark_dead` writes back inside the live queue dir | KILLED (5 failures) |
| M2 | `sweep_legacy_dead_markers` returns 0 | KILLED (2) |
| M3 | sweep overwrites an existing marker | KILLED (1) |
| M4 | `resplit_over_bound_entries` returns (0,0) | KILLED (4) |
| M5 | `_ENTRY_ONLY_FIELDS` emptied (stale attempt metadata kept) | KILLED (1) |
| M6 | `mark_dead` falls back to an in-queue marker on failure | KILLED (1) |
| M7 | resplit archives the original even when no part was written | KILLED (1) |
| M8 | phase 0b unwired from the drain | **SURVIVED on the first pass** — a test was missing; now KILLED (1) |
| M9 | phase 0c unwired from the drain | KILLED (1) |
| M10 | resplit archive left unbounded | KILLED (1) |
| M11 | `_trim_dir` also selects `.dead` markers | KILLED (1) |
| M12 | `probeSpool` stops counting `pending-dead/` | KILLED (2 vitest) |

M8 is the reason this table exists: every mechanism worked in isolation and the migration would still never have run.

## Verification

- `python3 -m unittest discover tests` in `vendor/hindsight-memory/scripts` — **695 tests, OK** (the CI-gated suite).
- `npx vitest run src/hindsight-watch src/cli/doctor-pending-retains.test.ts` — **132 passed**.
- `npm run lint` — clean.

## Operator note: the host stopgap and the prune script

The interim host stopgap is live at `/etc/cron.d/hindsight-drain-backlog` plus `~/.switchroom/agents/klanker/scripts/hindsight-drain-backlog.sh` — every 10 minutes under `flock`, and it IS draining (five agents fully cleared, ~25 entries/hr). It stays until this stack ships. To remove it afterwards: `rm /etc/cron.d/hindsight-drain-backlog`, `rm ~/.switchroom/agents/klanker/scripts/hindsight-drain-backlog.sh`, and un-park anything the script parked (see the script header).

Two things the host-side `hindsight-archive-prune.sh` needs when this lands:

1. `pending-dead/` must **NOT** be added to its `ARCHIVE_DIRS`. It is the one archive that holds unrecovered memories; a TTL there is the same delete this PR closes, one directory over.
2. Its `ARCHIVE_DIRS` lists `pending-dupes`, but #3688 creates `pending-duplicate/`. That naming divergence means the duplicate archive is currently unpruned — worth reconciling, in the host script, not here.

## Verdict

`reference/jobs/remember-across-sessions.md` — "a memory the user was told was saved is still there next session". Disk hygiene deleting the last copy of a queued memory is the sharpest possible violation of that job, and an entry that is structurally undrainable is the same violation on a slower clock.

## Stack

Stacked on #3688 (`fix/hindsight-content-keyed-queue`). Related: #3689 (scheduled drain), #3693 (deadline margin — this PR's phase 0c is what recovers the entries that bound change strands).
