### PR TITLE
perf(hindsight): rerank recall on the GPU when the host has one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,12 @@ generated compose file.
 
 Both are gated on the host-capabilities verdict switchroom already probes for
 voice (NVIDIA GPU present AND the nvidia-container-toolkit wired), so a host
-without a usable GPU is untouched. If CUDA turns out to be unreachable at
-runtime the reranker falls back to CPU on its own, which is exactly the
-behaviour it has today.
+without a usable GPU is untouched — if CUDA is unreachable when the reranker
+starts, it selects CPU on its own and behaves exactly as it does today.
+
+Embeddings come along for free. They run on the same torch, and make the same
+device probe, so they move to the GPU with no extra work — a smaller win
+(tens of milliseconds a call, not seconds), but a free one.
 
 ## v0.19.22 — release binaries attached and the pipeline gated end-to-end, derived LiteLLM timeout budgets, context7 by default
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### Memory recall reranks on the GPU when the host has one
+
+Reranking was the single largest slice of every recall: 2.5-4.0s of a 5.83s
+total on this fleet's host, and the `overlord` bank timed out against its 8s
+per-bank budget almost every time. It ran on the CPU for one reason — the
+hindsight image's venv shipped `torch==2.12.1+cpu`. The reranker's own
+provider (`cross_encoder.py`) already asks for `cuda` when torch offers it.
+
+The image now installs the same torch version from the cu130 wheel index on
+amd64, with a build-time assert that the wheel really is a CUDA build, and
+`switchroom memory setup` passes the GPU through — `--gpus all` on the
+docker-run path, a `deploy.resources.reservations.devices` reservation in the
+generated compose file.
+
+Both are gated on the host-capabilities verdict switchroom already probes for
+voice (NVIDIA GPU present AND the nvidia-container-toolkit wired), so a host
+without a usable GPU is untouched. If CUDA turns out to be unreachable at
+runtime the reranker falls back to CPU on its own, which is exactly the
+behaviour it has today.
+
 ## v0.19.22 — release binaries attached and the pipeline gated end-to-end, derived LiteLLM timeout budgets, context7 by default
 
 ### LiteLLM paired timeout budgets are now DERIVED, and drift is detected

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -104,9 +104,14 @@ RUN VIRTUAL_ENV=/app/api/.venv uv pip install --no-cache-dir 'claude-agent-sdk==
 # silently-broken wheel would make the API fail to boot, autoheal would
 # restart-loop it, and fleet memory would be down until a manual rollback — so
 # the wheel is proven at BUILD time. Where that assert runs, precisely: the
-# multi-arch `build-hindsight` job (path-gated, QEMU) — NOT the four required
-# PR checks, which never build this image. So the guarantee is "no CUDA-broken
-# image can be published", not "no CUDA-broken commit can be merged".
+# `build-hindsight` job, which DOES run on pull_request when this path changes,
+# and whose result is consumed by the required `images-ok` check — so for a PR
+# touching this path, a CUDA-broken commit is genuinely blocked from merge.
+# Two real edges remain: on PRs the build is pinned to `platforms:
+# linux/amd64` with the QEMU step skipped, so the non-amd64 branch below is
+# never executed by CI at all (the arm64 leg is built only on main/tags); and
+# `build-hindsight` skips on merge_group, where docker-e2e's `hindsight-probe`
+# is the gate instead.
 #
 # Safety property, and its limit. AT INIT the fallback is total: device
 # selection happens once when the provider is constructed, so if CUDA is

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -72,6 +72,47 @@ RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
 RUN VIRTUAL_ENV=/app/api/.venv uv pip install --no-cache-dir 'claude-agent-sdk==0.2.87' \
  && /app/api/.venv/bin/python -c "from claude_agent_sdk import query; print('claude-agent-sdk ok')" >&2
 
+# ── CUDA-enabled torch for the local reranker ────────────────────────────
+# The recall reranker is sentence-transformers + PyTorch (provider `local` →
+# LocalSTCrossEncoder, model cross-encoder/ms-marco-MiniLM-L-6-v2), NOT ONNX
+# Runtime. hindsight_api/engine/reranker/cross_encoder.py ALREADY selects
+# `cuda` when `torch.cuda.is_available()` — so the ONLY thing standing between
+# this image and GPU reranking is that upstream's venv ships `torch==2.12.1+cpu`
+# (`torch.version.cuda is None`). Reinstall the SAME torch version from the
+# cu130 wheel index; no application code change is needed.
+#
+# cu130 matches the fleet GPU host's driver (580.x, reports CUDA 13.0)
+# natively, and the wheel vendors its own nvidia-* runtime libs, so this needs
+# no CUDA base image and no host CUDA toolkit — only the
+# nvidia-container-toolkit, which `src/setup/gpu-detect.ts` already probes and
+# which `src/setup/hindsight.ts` gates the `--gpus` flag on.
+#
+# amd64 ONLY, deliberately — the same call docker/Dockerfile.voice makes. The
+# cu130 index does publish aarch64 wheels, but the fleet's GPU hosts are x86_64
+# and the CUDA payload is multiple GB per arch; baking it into the (already
+# 6.4GB) arm64 leg costs real registry + pull weight for something that can
+# never be used there. arm64 keeps upstream's CPU torch and reranks on CPU.
+#
+# FAIL-LOUD: on amd64 the build asserts `torch.version.cuda` is non-None. A
+# silently-broken wheel would make the API fail to boot, autoheal would
+# restart-loop it, and fleet memory would be down until a manual rollback — so
+# the wheel is proven at BUILD time, where a failure is just a red CI job.
+#
+# Runtime safety property: this raises the CEILING, never the floor. If CUDA is
+# unreachable at runtime (no --gpus, no toolkit, GPU otherwise unusable),
+# cross_encoder.py falls back to CPU — worst case is exactly today's behaviour.
+ARG TARGETARCH
+RUN set -eu; \
+    if [ "${TARGETARCH:-amd64}" = "amd64" ]; then \
+      VIRTUAL_ENV=/app/api/.venv uv pip install --no-cache-dir \
+        --index-url https://download.pytorch.org/whl/cu130 \
+        'torch==2.12.1+cu130'; \
+      /app/api/.venv/bin/python -c "import torch; assert torch.version.cuda, f'switchroom hindsight CUDA-torch install: torch {torch.__version__} is not a CUDA build (torch.version.cuda={torch.version.cuda!r}) — the reranker would silently stay on CPU'; print(f'torch-cuda ok: {torch.__version__} (cuda {torch.version.cuda})')" >&2; \
+    else \
+      echo "torch-cuda skipped on non-amd64 arch: ${TARGETARCH}" >&2; \
+      /app/api/.venv/bin/python -c "import torch; print(f'torch ok (cpu build): {torch.__version__}')" >&2; \
+    fi
+
 # #2392: neutralize the upstream claude_code-provider env isolation, which is
 # incompatible with our file-based creds. Upstream PR #1825 (for #1751, a
 # plugin-recursion retain loop) made `_get_isolated_claude_env()` set, for

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -98,9 +98,16 @@ RUN VIRTUAL_ENV=/app/api/.venv uv pip install --no-cache-dir 'claude-agent-sdk==
 # restart-loop it, and fleet memory would be down until a manual rollback — so
 # the wheel is proven at BUILD time, where a failure is just a red CI job.
 #
-# Runtime safety property: this raises the CEILING, never the floor. If CUDA is
-# unreachable at runtime (no --gpus, no toolkit, GPU otherwise unusable),
-# cross_encoder.py falls back to CPU — worst case is exactly today's behaviour.
+# Safety property, and its limit. AT INIT the fallback is total: device
+# selection happens once when the provider is constructed, so if CUDA is
+# unreachable then (no --gpus, no toolkit, no driver) cross_encoder.py — and
+# embeddings.py, which rides this same wheel and makes the same probe — select
+# CPU and behave exactly as they do today. AT REQUEST TIME it is NOT: because
+# the device is already chosen, a CUDA OOM mid-recall surfaces as a 500 on that
+# recall, not an automatic CPU retry. Steady-state VRAM is comfortable (~1.2-
+# 1.8GB of models against ~5.3GB free), so that is a tail risk, not the
+# expected path — but it is a real one, tracked as a follow-up rather than
+# papered over here.
 ARG TARGETARCH
 RUN set -eu; \
     if [ "${TARGETARCH:-amd64}" = "amd64" ]; then \

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -93,10 +93,20 @@ RUN VIRTUAL_ENV=/app/api/.venv uv pip install --no-cache-dir 'claude-agent-sdk==
 # 6.4GB) arm64 leg costs real registry + pull weight for something that can
 # never be used there. arm64 keeps upstream's CPU torch and reranks on CPU.
 #
+# Size, stated honestly: this is a REINSTALL in a layer above the base, so the
+# amd64 image carries BOTH copies — upstream's `torch==2.12.1+cpu` stays in the
+# lower layer and the cu130 build plus its vendored nvidia-* libs are added on
+# top. `--no-cache-dir` only suppresses uv's download cache; it does not
+# reclaim the superseded CPU wheel. Genuinely shrinking this needs a
+# multi-stage rebuild of upstream's venv, which is out of scope here.
+#
 # FAIL-LOUD: on amd64 the build asserts `torch.version.cuda` is non-None. A
 # silently-broken wheel would make the API fail to boot, autoheal would
 # restart-loop it, and fleet memory would be down until a manual rollback — so
-# the wheel is proven at BUILD time, where a failure is just a red CI job.
+# the wheel is proven at BUILD time. Where that assert runs, precisely: the
+# multi-arch `build-hindsight` job (path-gated, QEMU) — NOT the four required
+# PR checks, which never build this image. So the guarantee is "no CUDA-broken
+# image can be published", not "no CUDA-broken commit can be merged".
 #
 # Safety property, and its limit. AT INIT the fallback is total: device
 # selection happens once when the provider is constructed, so if CUDA is

--- a/src/setup/hindsight-gpu.test.ts
+++ b/src/setup/hindsight-gpu.test.ts
@@ -139,16 +139,31 @@ describe("hindsightGpuEnabled — fail-safe host-capabilities gate", () => {
     // would emit `--gpus all` on a host that cannot honour it — arriving at the
     // exact container-create failure this gate exists to prevent, through the
     // gate. Anything not literally `true` must read as "not proven".
+    //
+    // The two fields are varied INDEPENDENTLY, and that is the point. Writing
+    // the same bogus value into both would leave a HALF-revert alive: relaxing
+    // only `containerToolkit` back to a truthy test still rejects a
+    // both-fields-bogus verdict, while restoring the exact original bug —
+    // `gpuPresent: true` with `containerToolkit: "false"` emitting `--gpus all`
+    // on a toolkit-less host, where container-create hard-fails. Pin each half.
     mkdirSync(join(home, ".switchroom"), { recursive: true });
-    for (const bogus of ['"false"', '"true"', "1", '"yes"', "{}"]) {
+    const bogus = ['"false"', '"true"', "1", '"yes"', "{}"];
+    const cases: Array<[string, string]> = [
+      // one field genuinely true, the other corrupt ⇒ catches a half-revert
+      ...bogus.map((b): [string, string] => ["true", b]),
+      ...bogus.map((b): [string, string] => [b, "true"]),
+      // both corrupt ⇒ catches a full revert
+      ...bogus.map((b): [string, string] => [b, b]),
+    ];
+    for (const [gpuPresent, containerToolkit] of cases) {
       writeFileSync(
         join(home, ".switchroom", "host-capabilities.json"),
-        `{"version":1,"voice":{"gpuPresent":${bogus},"containerToolkit":${bogus},` +
+        `{"version":1,"voice":{"gpuPresent":${gpuPresent},"containerToolkit":${containerToolkit},` +
           `"engine":"local","detectedAt":"2026-07-26T00:00:00.000Z"}}\n`,
       );
       expect(
         hindsightGpuEnabled(),
-        `non-boolean probe ${bogus} must not enable GPU`,
+        `verdict {gpuPresent: ${gpuPresent}, containerToolkit: ${containerToolkit}} must not enable GPU`,
       ).toBe(false);
     }
   });

--- a/src/setup/hindsight-gpu.test.ts
+++ b/src/setup/hindsight-gpu.test.ts
@@ -1,0 +1,239 @@
+/**
+ * GPU passthrough for the hindsight recall reranker.
+ *
+ * The reranker is sentence-transformers + PyTorch (provider `local` →
+ * LocalSTCrossEncoder), and upstream's `cross_encoder.py` already picks `cuda`
+ * when `torch.cuda.is_available()`. Two things have to hold for that to fire:
+ *
+ *   1. the image ships a CUDA-flavoured torch — pinned in
+ *      tests/docker/dockerfile-hindsight-bakes.test.ts; and
+ *   2. the container can SEE the device — `--gpus all` on the docker-run path,
+ *      `deploy.resources.reservations.devices` on the compose path.
+ *
+ * (2) is what this file pins, including the property that MATTERS most: the
+ * two launch paths are driven by ONE gate, so a host that gets GPU from
+ * `switchroom memory setup` also gets it from the emitted compose file, and a
+ * host without the nvidia-container-toolkit gets it from NEITHER (docker
+ * refuses `--gpus` outright there — "could not select device driver").
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: execFileSyncMock };
+});
+
+import {
+  startHindsight,
+  generateHindsightComposeSnippet,
+  hindsightGpuEnabled,
+} from "./hindsight.js";
+
+beforeEach(() => {
+  execFileSyncMock.mockReset();
+  execFileSyncMock.mockReturnValue(Buffer.from(""));
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+/**
+ * The `docker run` argv that launches the hindsight container itself.
+ *
+ * Selected by `--name switchroom-hindsight`, NOT by "first run call": mirror
+ * mode (#2578) issues a throwaway `docker run --rm` chown helper first, and
+ * matching that one would silently test the wrong argv.
+ */
+function runArgs(): string[] {
+  const call = execFileSyncMock.mock.calls.find(
+    (c) =>
+      c[0] === "docker" &&
+      Array.isArray(c[1]) &&
+      (c[1] as string[])[0] === "run" &&
+      (c[1] as string[]).includes("switchroom-hindsight"),
+  );
+  expect(call, "startHindsight must have issued a `docker run` for switchroom-hindsight").toBeDefined();
+  return call![1] as string[];
+}
+
+/** True iff argv carries the `--gpus all` pair (flag AND value, adjacent). */
+function hasGpusAll(args: string[]): boolean {
+  const i = args.indexOf("--gpus");
+  return i >= 0 && args[i + 1] === "all";
+}
+
+/** The compose GPU reservation stanza, exactly as the voice sidecar emits it. */
+const COMPOSE_GPU_STANZA = [
+  "    deploy:",
+  "      resources:",
+  "        reservations:",
+  "          devices:",
+  "            - driver: nvidia",
+  "              count: 1",
+  '              capabilities: ["gpu"]',
+].join("\n");
+
+// ── the gate itself ───────────────────────────────────────────────────────
+describe("hindsightGpuEnabled — fail-safe host-capabilities gate", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "switchroom-hs-gpu-"));
+    // resolveStatePath() reads HOME. Point it at a tmpdir so the suite never
+    // reads (or depends on) the real ~/.switchroom/host-capabilities.json.
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("USERPROFILE", home);
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeCaps(gpuPresent: boolean, containerToolkit: boolean): void {
+    mkdirSync(join(home, ".switchroom"), { recursive: true });
+    writeFileSync(
+      join(home, ".switchroom", "host-capabilities.json"),
+      JSON.stringify({
+        version: 1,
+        voice: {
+          gpuPresent,
+          containerToolkit,
+          engine: gpuPresent && containerToolkit ? "local" : "cloud",
+          detectedAt: "2026-07-26T00:00:00.000Z",
+        },
+      }) + "\n",
+    );
+  }
+
+  it("is FALSE with no persisted verdict (fresh install ⇒ today's CPU behaviour)", () => {
+    // The load-bearing default. `docker run --gpus all` HARD-FAILS on a host
+    // without the nvidia-container-toolkit, so an unknown host must never get
+    // the flag — that would turn `switchroom memory setup` into an error.
+    expect(hindsightGpuEnabled()).toBe(false);
+  });
+
+  it("is FALSE when a GPU exists but Docker cannot reach it (no toolkit)", () => {
+    writeCaps(true, false);
+    expect(hindsightGpuEnabled()).toBe(false);
+  });
+
+  it("is FALSE when the toolkit is present but there is no GPU", () => {
+    writeCaps(false, true);
+    expect(hindsightGpuEnabled()).toBe(false);
+  });
+
+  it("is TRUE only when a GPU is present AND the container toolkit is wired", () => {
+    writeCaps(true, true);
+    expect(hindsightGpuEnabled()).toBe(true);
+  });
+
+  it("honours an explicit override without touching the persisted verdict", () => {
+    writeCaps(true, true);
+    expect(hindsightGpuEnabled(false)).toBe(false);
+    writeCaps(false, false);
+    expect(hindsightGpuEnabled(true)).toBe(true);
+  });
+});
+
+// ── docker-run path ───────────────────────────────────────────────────────
+describe("startHindsight — GPU passthrough", () => {
+  it("passes `--gpus all` when the host can reach a GPU", () => {
+    startHindsight(undefined, undefined, undefined, undefined, undefined, true);
+    expect(hasGpusAll(runArgs())).toBe(true);
+  });
+
+  it("emits NO --gpus flag when the host cannot (docker would refuse to start)", () => {
+    startHindsight(undefined, undefined, undefined, undefined, undefined, false);
+    expect(runArgs()).not.toContain("--gpus");
+  });
+
+  it("keeps GPU orthogonal to the other run knobs (mirror mode still applies)", () => {
+    // Guards against the flag being spliced in a branch that swallows the
+    // creds-mirror mount — both must survive together.
+    startHindsight(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "/run/consumer-creds/hindsight",
+      true,
+    );
+    const args = runArgs();
+    expect(hasGpusAll(args)).toBe(true);
+    expect(args.join(" ")).toContain("consumer-creds-hindsight");
+  });
+});
+
+// ── compose path ──────────────────────────────────────────────────────────
+describe("generateHindsightComposeSnippet — GPU passthrough", () => {
+  it("emits the nvidia device reservation when the host can reach a GPU", () => {
+    const snippet = generateHindsightComposeSnippet(
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    expect(snippet).toContain(COMPOSE_GPU_STANZA);
+  });
+
+  it("emits NO deploy/devices stanza when the host cannot", () => {
+    const snippet = generateHindsightComposeSnippet(
+      undefined,
+      undefined,
+      undefined,
+      false,
+    );
+    expect(snippet).not.toContain("driver: nvidia");
+    expect(snippet).not.toContain("    deploy:");
+  });
+
+  it("nests the stanza under the hindsight service, not at the compose root", () => {
+    // 4-space `deploy:` = a key of the single service in this snippet. A
+    // top-level (2-space) `deploy:` would be silently ignored by compose.
+    const snippet = generateHindsightComposeSnippet(
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    expect(snippet).toMatch(/^ {4}deploy:$/m);
+    expect(snippet).not.toMatch(/^ {0,2}deploy:$/m);
+  });
+});
+
+// ── run ⇄ compose parity ──────────────────────────────────────────────────
+describe("run ⇄ compose GPU parity", () => {
+  // The two launch paths must never disagree: whichever one an operator uses,
+  // the container either sees the GPU or it doesn't. Assert the OUTCOME of
+  // both generators for the same gate value rather than just calling them.
+  for (const gpu of [true, false]) {
+    it(`agree for gpu=${gpu}`, () => {
+      startHindsight(undefined, undefined, undefined, undefined, undefined, gpu);
+      const runHasGpu = hasGpusAll(runArgs());
+      const composeHasGpu = generateHindsightComposeSnippet(
+        undefined,
+        undefined,
+        undefined,
+        gpu,
+      ).includes("driver: nvidia");
+
+      expect(runHasGpu).toBe(gpu);
+      expect(composeHasGpu).toBe(gpu);
+      expect(runHasGpu).toBe(composeHasGpu);
+    });
+  }
+
+  it("both paths default to the SAME persisted verdict when no override is passed", () => {
+    // Not a tautology: this is what stops one path from being wired to
+    // hindsightGpuEnabled() and the other to a hard-coded literal.
+    const expected = hindsightGpuEnabled();
+    startHindsight();
+    expect(hasGpusAll(runArgs())).toBe(expected);
+    expect(generateHindsightComposeSnippet().includes("driver: nvidia")).toBe(expected);
+  });
+});

--- a/src/setup/hindsight-gpu.test.ts
+++ b/src/setup/hindsight-gpu.test.ts
@@ -132,6 +132,27 @@ describe("hindsightGpuEnabled — fail-safe host-capabilities gate", () => {
     expect(hindsightGpuEnabled()).toBe(true);
   });
 
+  it("does NOT accept non-boolean truthy probes (a corrupt verdict fails safe)", () => {
+    // loadHostCapabilities() shape-checks the document but does NOT type-check
+    // these two fields, so a hand-edited or corrupted verdict can hold anything.
+    // The STRING "false" is the nasty one: it is truthy, so a COERCING gate
+    // would emit `--gpus all` on a host that cannot honour it — arriving at the
+    // exact container-create failure this gate exists to prevent, through the
+    // gate. Anything not literally `true` must read as "not proven".
+    mkdirSync(join(home, ".switchroom"), { recursive: true });
+    for (const bogus of ['"false"', '"true"', "1", '"yes"', "{}"]) {
+      writeFileSync(
+        join(home, ".switchroom", "host-capabilities.json"),
+        `{"version":1,"voice":{"gpuPresent":${bogus},"containerToolkit":${bogus},` +
+          `"engine":"local","detectedAt":"2026-07-26T00:00:00.000Z"}}\n`,
+      );
+      expect(
+        hindsightGpuEnabled(),
+        `non-boolean probe ${bogus} must not enable GPU`,
+      ).toBe(false);
+    }
+  });
+
   it("honours an explicit override without touching the persisted verdict", () => {
     writeCaps(true, true);
     expect(hindsightGpuEnabled(false)).toBe(false);

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -7,6 +7,7 @@ import {
   assertClientBudget,
   clientBudgetSeconds,
 } from "../litellm/timeout-budget.js";
+import { loadHostCapabilities } from "./host-capabilities.js";
 
 /**
  * Default Hindsight host ports.
@@ -1228,6 +1229,44 @@ export function buildLiteLlmAwareHealthCmd(apiPort: number, litellmBaseUrl: stri
   return `python3 -c "${buildLiteLlmAwareHealthPy(apiPort, litellmBaseUrl)}"`;
 }
 
+/**
+ * Should hindsight be launched with GPU passthrough?
+ *
+ * The recall reranker is sentence-transformers + PyTorch, and
+ * `hindsight_api/engine/reranker/cross_encoder.py` already selects `cuda`
+ * whenever `torch.cuda.is_available()`. docker/Dockerfile.hindsight installs a
+ * CUDA-flavoured torch on amd64 (see the `torch-cuda ok` build assert), so the
+ * only remaining requirement is that the container actually SEES the device —
+ * `--gpus all` on the run path, the `deploy.resources.reservations.devices`
+ * stanza on the compose path.
+ *
+ * This is GATED, not unconditional. `docker run --gpus all` FAILS outright on
+ * a host without the nvidia-container-toolkit ("could not select device
+ * driver"), which would turn a GPU-less install's `switchroom memory setup`
+ * into a hard error. So we reuse exactly the fail-safe rule the voice sidecar
+ * uses (`src/agents/compose.ts`, PR-B2): pass the GPU through only when the
+ * persisted host-capabilities verdict says a GPU is present AND Docker can
+ * reach it. No verdict file (fresh install, never ran `switchroom setup`) ⇒
+ * false ⇒ today's CPU behaviour.
+ *
+ * The booleans live under the `voice` key purely because that feature wrote
+ * the schema first (`src/setup/host-capabilities.ts` v1) — they are host
+ * hardware facts, not voice settings.
+ *
+ * Degrading to `false` on a GPU host is safe (CPU reranking, i.e. today);
+ * degrading to CPU inside a GPU-enabled container is also safe
+ * (cross_encoder.py's own `torch.cuda.is_available()` fallback). The only
+ * genuinely bad outcome is emitting `--gpus` where Docker can't honour it,
+ * which is precisely what this gate prevents.
+ *
+ * @param override Test/caller seam. When omitted the persisted verdict is read.
+ */
+export function hindsightGpuEnabled(override?: boolean): boolean {
+  if (override !== undefined) return override;
+  const caps = loadHostCapabilities();
+  return Boolean(caps?.voice?.gpuPresent && caps?.voice?.containerToolkit);
+}
+
 export function startHindsight(
   ports?: { apiPort: number; uiPort: number },
   litellm?: LiteLLMHindsightConfig,
@@ -1242,6 +1281,12 @@ export function startHindsight(
    * path; the consumer-side mount path is always HINDSIGHT_CRED_DIR.
    */
   mirrorDir?: string,
+  /**
+   * GPU-passthrough override. Omit in production — {@link hindsightGpuEnabled}
+   * reads the persisted host-capabilities verdict. Tests pass an explicit
+   * boolean so the suite never depends on the runner having (or lacking) a GPU.
+   */
+  gpu?: boolean,
 ): void {
   const apiPort = ports?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT;
   const uiPort = ports?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT;
@@ -1360,6 +1405,13 @@ export function startHindsight(
     // HINDSIGHT_DEFAULT_SHM_SIZE) or all writes/queries fail with
     // "No space left on device". Keep in sync with the compose snippet.
     `--shm-size=${HINDSIGHT_DEFAULT_SHM_SIZE}`,
+    // GPU passthrough for the local cross-encoder reranker. Gated on the
+    // persisted host-capabilities verdict — see hindsightGpuEnabled() for why
+    // this must never be unconditional. Kept in sync with the compose snippet
+    // (generateHindsightComposeSnippet emits the equivalent
+    // deploy.resources.reservations.devices stanza); the run/compose parity
+    // test pins that both paths move together.
+    ...(hindsightGpuEnabled(gpu) ? ["--gpus", "all"] : []),
     // Liveness signal for a wedged API: docker had no health probe for
     // hindsight, so an unresponsive server (or a never-booting one) stayed
     // "up" forever. This marks the container "unhealthy" in `docker inspect`
@@ -1675,7 +1727,10 @@ export function getHindsightMcpUrl(): {
  * container chowns and binds the per-consumer socket inside it). The
  * hindsight compose project is separate; it consumes the volume.
  *
- * Networking + healthcheck track {@link startHindsight}: when an explicit
+ * Networking, healthcheck and GPU passthrough track {@link startHindsight}:
+ * the `deploy.resources.reservations.devices` stanza here is the compose twin
+ * of that path's `--gpus all`, gated on the same {@link hindsightGpuEnabled}
+ * verdict so the two generators can never disagree about GPU. When an explicit
  * LiteLLM config is passed, OR any configured per-op `*_LLM_BASE_URL`
  * points at host loopback, the snippet emits `network_mode: host` (ports
  * are published on the host stack directly — no `ports:` mapping) and pairs
@@ -1702,10 +1757,17 @@ export function generateHindsightComposeSnippet(
    * so compose never silently diverges from the docker-run path.
    */
   litellm?: LiteLLMHindsightConfig,
+  /**
+   * GPU-passthrough override, mirroring {@link startHindsight}'s `gpu` param.
+   * Omit in production — {@link hindsightGpuEnabled} reads the persisted
+   * host-capabilities verdict.
+   */
+  gpu?: boolean,
 ): string {
   const { provider: llmProvider, model: llmModel } = resolveHindsightLlm(llm, litellm);
   const perOpLlm = resolveHindsightPerOpLlm(llm);
   const hostNetwork = hindsightNeedsHostNetwork(llm, litellm);
+  const gpuEnabled = hindsightGpuEnabled(gpu);
   const apiPort = HINDSIGHT_DEFAULT_API_PORT;
   // Bridge compose keeps the image-default internal bind (8888) and maps the
   // host port onto it. Host-network binds HINDSIGHT_API_PORT on the host
@@ -1823,6 +1885,23 @@ export function generateHindsightComposeSnippet(
     // PostgreSQL shm — see HINDSIGHT_DEFAULT_SHM_SIZE. Without this the
     // container gets Docker's 64MB default and all writes/queries fail.
     `    shm_size: ${HINDSIGHT_DEFAULT_SHM_SIZE}`,
+    // GPU passthrough for the local cross-encoder reranker — the compose twin
+    // of the docker-run path's `--gpus all`. Same shape as the voice sidecar
+    // (src/agents/compose.ts), same fail-safe gate (hindsightGpuEnabled): a
+    // host with no nvidia-container-toolkit gets no stanza at all, because
+    // compose would refuse to start the service ("could not select device
+    // driver") exactly like `docker run --gpus` does.
+    ...(gpuEnabled
+      ? [
+          "    deploy:",
+          "      resources:",
+          "        reservations:",
+          "          devices:",
+          "            - driver: nvidia",
+          "              count: 1",
+          '              capabilities: ["gpu"]',
+        ]
+      : []),
     // Liveness — restart a wedged/never-booted API (see the docker-run path).
     // When host-network + LiteLLM base is known, pair /health with a TCP
     // probe of the proxy so docker health reflects LLM reachability too.

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -1259,12 +1259,19 @@ export function buildLiteLlmAwareHealthCmd(apiPort: number, litellmBaseUrl: stri
  * genuinely bad outcome is emitting `--gpus` where Docker can't honour it,
  * which is precisely what this gate prevents.
  *
+ * Both probes are compared with `=== true`, NOT coerced. `loadHostCapabilities`
+ * does a shape check but no per-field type check, so a hand-edited or corrupt
+ * verdict holding the STRING `"false"` would satisfy a truthiness test and emit
+ * `--gpus all` on a host that cannot honour it — the precise failure this gate
+ * exists to prevent, arrived at through the gate. Anything that is not
+ * literally `true` is treated as "not proven", which is the fail-safe reading.
+ *
  * @param override Test/caller seam. When omitted the persisted verdict is read.
  */
 export function hindsightGpuEnabled(override?: boolean): boolean {
   if (override !== undefined) return override;
   const caps = loadHostCapabilities();
-  return Boolean(caps?.voice?.gpuPresent && caps?.voice?.containerToolkit);
+  return caps?.voice?.gpuPresent === true && caps?.voice?.containerToolkit === true;
 }
 
 export function startHindsight(

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -57,6 +57,58 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("reinstalls torch from a CUDA wheel index (the reranker runs on GPU)", () => {
+    // The recall reranker is sentence-transformers + PyTorch, and upstream's
+    // cross_encoder.py already selects `cuda` when torch.cuda.is_available().
+    // Upstream's venv ships `torch==2.12.1+cpu` (torch.version.cuda is None),
+    // which is the ONLY reason reranking is CPU-bound. Pin the CUDA reinstall.
+    expect(dockerfile).toMatch(
+      /--index-url\s+https:\/\/download\.pytorch\.org\/whl\/cu\d+/,
+    );
+    // CUDA local-version tag on an explicit version pin. A `+cpu` (or
+    // untagged) requirement would resolve straight back to the CPU build and
+    // silently undo the whole change while every other assertion here passed.
+    const torchReq = dockerfile.match(/'torch==([^']+)'/);
+    expect(torchReq, "the Dockerfile must pin an explicit torch requirement").not.toBeNull();
+    expect(torchReq![1]).toMatch(/^\d+\.\d+\.\d+\+cu\d+$/);
+    expect(torchReq![1]).not.toContain("+cpu");
+    // uv against the existing venv — same rule as the SDK install above
+    // (upstream's uv-managed venv ships no `pip` binary).
+    expect(dockerfile).toMatch(
+      /VIRTUAL_ENV=\/app\/api\/\.venv\s+uv\s+pip\s+install[\s\S]{0,120}?--index-url\s+https:\/\/download\.pytorch\.org/,
+    );
+  });
+
+  it("asserts at BUILD time that torch is really a CUDA build (fail-loud guard)", () => {
+    // The dangerous failure mode is a wheel that installs but resolves back to
+    // CPU (or imports broken): the reranker silently stays slow, or the API
+    // fails to boot, autoheal restart-loops the container, and fleet memory is
+    // down until someone rolls the image tag back. Prove it at BUILD time,
+    // where a failure is just a red CI job.
+    expect(dockerfile).toMatch(/import torch;\s*assert torch\.version\.cuda,/);
+    expect(dockerfile).toContain(
+      "switchroom hindsight CUDA-torch install: torch {torch.__version__} is not a CUDA build",
+    );
+    // The assert must FOLLOW the install — one that precedes it proves nothing.
+    const installIdx = dockerfile.search(/--index-url\s+https:\/\/download\.pytorch\.org/);
+    const assertIdx = dockerfile.search(/assert torch\.version\.cuda,/);
+    expect(installIdx).toBeGreaterThanOrEqual(0);
+    expect(assertIdx).toBeGreaterThan(installIdx);
+  });
+
+  it("restricts the CUDA torch payload to amd64 (fleet GPU hosts are x86_64)", () => {
+    // Multiple GB of vendored nvidia-* libs per arch, on an image already
+    // ~6.4GB, for an arch with no GPU host behind it. Dockerfile.voice makes
+    // the same call. arm64 keeps upstream's CPU torch and reranks on CPU.
+    expect(dockerfile).toMatch(/^ARG TARGETARCH$/m);
+    expect(dockerfile).toMatch(/if \[ "\$\{TARGETARCH:-amd64\}" = "amd64" \]; then/);
+    // ARG must be declared after the FROM it applies to, or the shell sees an
+    // empty value and the build silently takes the non-amd64 branch on amd64.
+    const fromIdx = dockerfile.search(/^FROM\s+ghcr\.io\/vectorize-io\/hindsight/m);
+    const argIdx = dockerfile.search(/^ARG TARGETARCH$/m);
+    expect(argIdx).toBeGreaterThan(fromIdx);
+  });
+
   it("installs the @anthropic-ai/claude-code CLI globally", () => {
     // Allow the install to be quoted + version-pinned, e.g.
     // `npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"`.

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -30,6 +30,45 @@ const dockerfile = readFileSync(
   "utf8",
 );
 
+/**
+ * Every `RUN` instruction, as its own array of physical lines (continuations
+ * folded in).
+ *
+ * Assertions about the CUDA stanza are scoped through this rather than through
+ * a file-wide `dockerfile.search()`. A file-wide search is positional and
+ * therefore fragile in a way that FAILS OPEN: the else-branch used to be
+ * sliced between the first `else \` and the first `fi` anywhere in the file,
+ * so adding an unrelated `if/else` earlier in the Dockerfile would silently
+ * re-point the slice at foreign text and every assertion inside it would go
+ * vacuous while staying green. Scoping to the instruction that actually
+ * contains the CUDA install cannot drift that way.
+ */
+function runInstructions(): string[][] {
+  const lines = dockerfile.split("\n");
+  const out: string[][] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^RUN\b/.test(lines[i])) continue;
+    const block = [lines[i]];
+    while (/\\\s*$/.test(block[block.length - 1]) && i + 1 < lines.length) {
+      block.push(lines[++i]);
+    }
+    out.push(block);
+  }
+  return out;
+}
+
+/** The single RUN instruction carrying the arch-gated CUDA torch install. */
+function cudaTorchRun(): string[] {
+  const matches = runInstructions().filter((b) =>
+    b.join("\n").includes("TARGETARCH:-amd64"),
+  );
+  expect(
+    matches,
+    "exactly one RUN instruction must carry the arch-gated CUDA torch install",
+  ).toHaveLength(1);
+  return matches[0];
+}
+
 describe("Dockerfile.hindsight shape", () => {
   it("extends the canonical upstream image", () => {
     expect(dockerfile).toMatch(
@@ -91,20 +130,32 @@ describe("Dockerfile.hindsight shape", () => {
     // which has its own (or no) torch. Verifying there would green-light a
     // build whose venv torch is still `+cpu` — the guard would pass while the
     // thing it guards is broken. Pin the interpreter path.
-    expect(dockerfile).toMatch(
-      /\/app\/api\/\.venv\/bin\/python\s+-c\s+"import torch;\s*assert torch\.version\.cuda,/,
+    const block = cudaTorchRun();
+    expect(block.join("\n")).toMatch(
+      /\/app\/api\/\.venv\/bin\/python\s+-c\s+["']import torch;\s*assert torch\.version\.cuda,/,
     );
     expect(dockerfile).toContain(
       "switchroom hindsight CUDA-torch install: torch {torch.__version__} is not a CUDA build",
     );
     // The assert must FOLLOW the install — one that precedes it proves nothing.
-    const installIdx = dockerfile.search(/--index-url\s+https:\/\/download\.pytorch\.org/);
-    const assertIdx = dockerfile.search(/assert torch\.version\.cuda,/);
-    expect(installIdx).toBeGreaterThanOrEqual(0);
+    // Both indices are taken over the EXECUTABLE lines of this instruction, not
+    // over the whole file: a file-wide search can be satisfied by a decoy in a
+    // comment, which would let a real assert sit above a real install and still
+    // read as ordered.
+    const code = block.filter((l) => !/^\s*#/.test(l));
+    const installIdx = code.findIndex((l) =>
+      /--index-url\s+https:\/\/download\.pytorch\.org/.test(l),
+    );
+    const assertIdx = code.findIndex((l) => /assert torch\.version\.cuda,/.test(l));
+    expect(installIdx, "the CUDA install line must exist").toBeGreaterThanOrEqual(0);
     expect(assertIdx).toBeGreaterThan(installIdx);
-    // Every torch probe in this stage — including the non-amd64 branch's
+    // Every torch probe in this instruction — including the non-amd64 branch's
     // informational one — must use the venv interpreter, for the same reason.
-    for (const probe of dockerfile.match(/^.*-c "import torch;.*$/gm) ?? []) {
+    // Quote-agnostic: `-c 'import torch;` is the same command as `-c "import
+    // torch;` to the shell, and a double-quote-only pattern would not see it.
+    const probes = block.filter((l) => /-c\s+["']import torch;/.test(l));
+    expect(probes.length, "the instruction must contain torch probes").toBeGreaterThan(0);
+    for (const probe of probes) {
       expect(probe, "torch probes must run under the venv interpreter").toContain(
         "/app/api/.venv/bin/python",
       );
@@ -128,17 +179,43 @@ describe("Dockerfile.hindsight shape", () => {
     const argIdx = dockerfile.search(/^ARG TARGETARCH$/m);
     expect(argIdx).toBeGreaterThan(fromIdx);
 
-    // The non-amd64 branch is NOT exercised by PR CI (the multi-arch
-    // build-hindsight job is path-gated and does not run on pull_request), so
-    // nothing but this assertion stands between it and an untested regression.
-    // Pin it to its trivial shape: echo + an import probe, no package install.
-    const elseBranch = dockerfile.slice(
-      dockerfile.search(/^\s*else \\$/m),
-      dockerfile.search(/^\s*fi$/m),
-    );
-    expect(elseBranch, "the non-amd64 branch must exist").not.toBe("");
-    expect(elseBranch).not.toMatch(/pip\s+install/);
-    expect(elseBranch).not.toContain("--index-url");
+    // The non-amd64 branch is never EXECUTED by PR CI. Not because the job is
+    // skipped — `build-hindsight` does run on pull_request and passes — but
+    // because PR builds pin `platforms: linux/amd64` and skip the QEMU setup
+    // step (`if: github.event_name != 'pull_request'`), so only the amd64 leg
+    // is ever built there. This assertion is therefore the only thing standing
+    // between that branch and an untested regression, and it has to be
+    // airtight rather than indicative.
+    //
+    // Hence an ALLOWLIST, not a blocklist. Enumerating forbidden spellings
+    // cannot hold: `pip3 install`, `uv add`, `apt-get install
+    // nvidia-cuda-toolkit` and `sh /opt/install-torch.sh` all install things
+    // while matching no plausible blocklist. Requiring each line to BE one of
+    // the two known statements rejects every one of them by construction.
+    const block = cudaTorchRun();
+    const elseIdx = block.findIndex((l) => /^\s*else\s*\\?\s*$/.test(l));
+    const fiIdx = block.findIndex((l) => /^\s*fi\s*;?\s*\\?\s*$/.test(l));
+    expect(elseIdx, "the non-amd64 branch must exist").toBeGreaterThanOrEqual(0);
+    expect(fiIdx).toBeGreaterThan(elseIdx);
+
+    const ELSE_BRANCH_ALLOWED = [
+      /^\s*echo "torch-cuda skipped on non-amd64 arch: \$\{TARGETARCH\}" >&2; \\$/,
+      /^\s*\/app\/api\/\.venv\/bin\/python -c "import torch; print\(f'torch ok \(cpu build\): \{torch\.__version__\}'\)" >&2; \\$/,
+    ];
+    const elseLines = block
+      .slice(elseIdx + 1, fiIdx)
+      .filter((l) => l.trim() !== "" && !/^\s*#/.test(l));
+    expect(
+      elseLines.length,
+      "the non-amd64 branch must contain exactly its two known statements",
+    ).toBe(ELSE_BRANCH_ALLOWED.length);
+    for (const [i, pattern] of ELSE_BRANCH_ALLOWED.entries()) {
+      expect(
+        elseLines[i],
+        `non-amd64 branch line ${i + 1} is not the expected statement — ` +
+          "this branch is unbuilt by PR CI, so anything new here ships unverified",
+      ).toMatch(pattern);
+    }
   });
 
   it("installs the @anthropic-ai/claude-code CLI globally", () => {

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -85,7 +85,15 @@ describe("Dockerfile.hindsight shape", () => {
     // fails to boot, autoheal restart-loops the container, and fleet memory is
     // down until someone rolls the image tag back. Prove it at BUILD time,
     // where a failure is just a red CI job.
-    expect(dockerfile).toMatch(/import torch;\s*assert torch\.version\.cuda,/);
+    //
+    // The interpreter is part of the assertion, not incidental: the API runs
+    // out of /app/api/.venv, and a bare `python3` is the image's SYSTEM python,
+    // which has its own (or no) torch. Verifying there would green-light a
+    // build whose venv torch is still `+cpu` — the guard would pass while the
+    // thing it guards is broken. Pin the interpreter path.
+    expect(dockerfile).toMatch(
+      /\/app\/api\/\.venv\/bin\/python\s+-c\s+"import torch;\s*assert torch\.version\.cuda,/,
+    );
     expect(dockerfile).toContain(
       "switchroom hindsight CUDA-torch install: torch {torch.__version__} is not a CUDA build",
     );
@@ -94,6 +102,13 @@ describe("Dockerfile.hindsight shape", () => {
     const assertIdx = dockerfile.search(/assert torch\.version\.cuda,/);
     expect(installIdx).toBeGreaterThanOrEqual(0);
     expect(assertIdx).toBeGreaterThan(installIdx);
+    // Every torch probe in this stage — including the non-amd64 branch's
+    // informational one — must use the venv interpreter, for the same reason.
+    for (const probe of dockerfile.match(/^.*-c "import torch;.*$/gm) ?? []) {
+      expect(probe, "torch probes must run under the venv interpreter").toContain(
+        "/app/api/.venv/bin/python",
+      );
+    }
   });
 
   it("restricts the CUDA torch payload to amd64 (fleet GPU hosts are x86_64)", () => {
@@ -102,11 +117,28 @@ describe("Dockerfile.hindsight shape", () => {
     // the same call. arm64 keeps upstream's CPU torch and reranks on CPU.
     expect(dockerfile).toMatch(/^ARG TARGETARCH$/m);
     expect(dockerfile).toMatch(/if \[ "\$\{TARGETARCH:-amd64\}" = "amd64" \]; then/);
-    // ARG must be declared after the FROM it applies to, or the shell sees an
-    // empty value and the build silently takes the non-amd64 branch on amd64.
+    // ARG must be re-declared inside the stage it is used in: BuildKit's
+    // built-in TARGETARCH is only bound to stages that declare it, and a
+    // declaration above the FROM does not carry into the stage. Note which way
+    // that fails — `${TARGETARCH:-amd64}` defaults an EMPTY value to amd64, so
+    // a missing declaration takes the CUDA branch, not the CPU one. The
+    // resulting hazard is an arm64 build attempting the x86_64 CUDA install
+    // (a hard failure), never a silent CPU fallback on amd64.
     const fromIdx = dockerfile.search(/^FROM\s+ghcr\.io\/vectorize-io\/hindsight/m);
     const argIdx = dockerfile.search(/^ARG TARGETARCH$/m);
     expect(argIdx).toBeGreaterThan(fromIdx);
+
+    // The non-amd64 branch is NOT exercised by PR CI (the multi-arch
+    // build-hindsight job is path-gated and does not run on pull_request), so
+    // nothing but this assertion stands between it and an untested regression.
+    // Pin it to its trivial shape: echo + an import probe, no package install.
+    const elseBranch = dockerfile.slice(
+      dockerfile.search(/^\s*else \\$/m),
+      dockerfile.search(/^\s*fi$/m),
+    );
+    expect(elseBranch, "the non-amd64 branch must exist").not.toBe("");
+    expect(elseBranch).not.toMatch(/pip\s+install/);
+    expect(elseBranch).not.toContain("--index-url");
   });
 
   it("installs the @anthropic-ai/claude-code CLI globally", () => {


### PR DESCRIPTION
## Summary

Move hindsight's recall reranker from CPU to GPU on hosts that have one. No
application code changes — the image ships a CUDA torch and the container is
given the device. Embeddings come along for free (see below).

- `docker/Dockerfile.hindsight` reinstalls the **same** torch version from the
  cu130 wheel index on amd64, with a **build-time assert** that
  `torch.version.cuda` is non-None.
- `startHindsight()` passes `--gpus all`; `generateHindsightComposeSnippet()`
  emits the matching `deploy.resources.reservations.devices` reservation
  (shape copied verbatim from the voice sidecar in `src/agents/compose.ts`).
- Both are gated on `hindsightGpuEnabled()` → the persisted
  host-capabilities verdict from `src/setup/gpu-detect.ts`.

## Why

Reranking is the largest slice of every recall. Measured on this host from the
live container's own logs:

```
[4] Reranking [cross-encoder]: 150 candidates scored in 3.984s (pre-filtered 1513)
[RECALL overlord-58818-fe1550] Complete: 28 facts ... | 5.831s
```

3.98s of a 5.83s recall — 68%. Across the sample, reranking ran 2.5-4.0s
(mean 3.31s over 23 calls) against 5.20-5.83s recall totals. The per-bank
recall timeout is 8s (`vendor/hindsight-memory/scripts/recall.py`), inside a
10s shared deadline (`vendor/hindsight-memory/scripts/lib/config.py`), and the
`overlord` bank regularly fails to land inside it — the log shows repeated
`[RECALL overlord] Starting recall` lines with no matching `Complete`.

**A large part of that is contention, not model cost.** A clean in-container
bench of the same reranker ran **1152ms**, against 2.5-4.0s in production —
14 agent containers share 16 vCPUs on this host. The GPU removes the
contention as well as the compute, which is why the expected win is bigger
than the raw model speedup alone.

The cause is one line of packaging, not architecture. The reranker is
**sentence-transformers + PyTorch** (provider `local` → `LocalSTCrossEncoder`,
`cross-encoder/ms-marco-MiniLM-L-6-v2`), not ONNX Runtime, and upstream's
`hindsight_api/engine/reranker/cross_encoder.py` **already** selects `cuda`
when `torch.cuda.is_available()`. The image just ships `torch==2.12.1+cpu`
(`torch.version.cuda is None`), verified on the live container:

```
$ docker exec switchroom-hindsight /app/api/.venv/bin/python \
    -c "import torch; print(torch.__version__, torch.version.cuda)"
2.12.1+cpu None
```

`HINDSIGHT_DEFAULT_RERANKER_MAX_CANDIDATES` stays at **150**. Cutting it to 50
was proposed and rejected in review on measured answer-quality evidence (the
NOTE at the foot of `src/setup/hindsight-reranker-budget.test.ts`). Affording
150 is the point of the GPU.

## Embeddings come along for free

Embeddings ride the **same torch wheel**. The live deployment runs
`LocalEmbeddingsProvider` on sentence-transformers, not the ONNX path:

```
hindsight_api.config      - Embeddings: provider=local
hindsight_api.engine.embeddings - Embeddings: initializing local provider with model BAAI/bge-small-en-v1.5
```

`embeddings.py:183-205` does the same `torch.cuda.is_available()` auto-probe
that `cross_encoder.py:203-227` does, so it flips to GPU with this change and
no extra work. The win there is real but marginal next to the reranker —
measured 1493 calls at a **57ms mean**, versus the reranker's 3.31s mean over
23 calls. Worth stating so nobody files a phantom follow-up: the
`providers=["CPUExecutionProvider"]` line further down `embeddings.py` belongs
to the ONNX provider, which this deployment does not use, so there is no
`onnxruntime-gpu` task hiding behind it.

## Design notes

**The `--gpus` flag is gated, not unconditional.** `docker run --gpus all`
hard-fails with "could not select device driver" on a host without the
nvidia-container-toolkit, which would turn `switchroom memory setup` into an
error for most installs. `hindsightGpuEnabled()` reuses the exact fail-safe
rule the voice sidecar uses: pass the device through only when the persisted
`host-capabilities.json` verdict says a GPU is present **and** Docker
advertises the `nvidia` runtime. Both probe halves matter — a GPU with no
toolkit still fails at container-create. No verdict file (fresh install) ⇒
false ⇒ today's behaviour.

**cu130, and no CUDA base image.** cu130 matches this host's driver (580.159.03,
reports CUDA 13.0) natively, and the wheel vendors its own `nvidia-*` runtime
libs, so the image needs no CUDA base and the host needs no CUDA toolkit. Wheel
existence verified before pinning:
`torch-2.12.1+cu130-cp311-cp311-manylinux_2_28_x86_64.whl` (the container runs
Python 3.11.15).

**amd64 only**, deliberately, the same call `docker/Dockerfile.voice` makes and
documents. The cu130 index does publish aarch64 wheels, but the fleet's GPU
hosts are x86_64 and the CUDA payload is multiple GB per arch on an image
already ~6.4GB. arm64 keeps upstream's CPU torch.

**Why the build-time assert.** The one genuinely dangerous failure mode is a
wheel that installs but is broken or resolves back to CPU: the API fails to
boot, the autoheal sidecar restart-loops the container, and fleet memory is
down until someone rolls the image tag back. Asserting `torch.version.cuda` at
build time turns that into a red build — and CI's `build-hindsight` job has
now built this image green, so the wheel and the assert are proven, not
assumed.

**Scope that guarantee precisely.** `build-hindsight` **does** run on
`pull_request` when this path changes, and the required `images-ok` check
`needs:` it and hard-fails on its failure — so for a PR touching the hindsight
path, a CUDA-broken commit genuinely is blocked from merge. Two real edges
remain, and neither is widened here:

- **The non-amd64 branch is never built by PR CI.** Not because the job is
  skipped, but because PR builds pin `platforms: linux/amd64` and skip the
  QEMU setup step (`if: github.event_name != 'pull_request'`). The arm64 leg
  is built only on main/tags. That branch's sole PR-time cover is a static
  allowlist assertion on its text — see the test plan.
- **`build-hindsight` skips on `merge_group`** (deliberate: the 6.4GB
  multi-arch build would blow the queue's timeout). docker-e2e's
  `hindsight-probe` is the gate there.

## Safety property, and its limit

**At init, the fallback is total.** Device selection happens once, when the
provider is constructed. If CUDA is unreachable then — no `--gpus`, no
toolkit, no driver — `cross_encoder.py` and `embeddings.py` both select CPU
and behave exactly as they do today.

**At request time, it is not.** Because the device is chosen once, a CUDA OOM
during a recall surfaces as a **500 on that recall**, not an automatic CPU
retry. Steady-state VRAM is comfortable — the two models are roughly 1.2-1.8GB
against 5.3GB free — so this is a tail risk, driven mainly by the voice
sidecar swapping to a larger whisper model and squeezing what's left. Stating
it plainly rather than claiming a blanket "worst case is today's behaviour",
which would be false. **Known gap, candidate follow-up** (a request-scoped
CPU retry, or a VRAM headroom check at init); deliberately not fixed here.

## Rollback

Repoint the image tag and re-run `startHindsight()` (`switchroom memory setup`)
— roughly 60 seconds. No data migration, no schema change, nothing persisted.

## Test plan

New/extended, all asserting outcomes rather than exercising code paths:

- `src/setup/hindsight-gpu.test.ts` (new, 15 tests) — the gate's full truth
  table against a tmpdir `$HOME` (no verdict / GPU-no-toolkit /
  toolkit-no-GPU / both ⇒ only the last is true); `--gpus all` present exactly
  when the gate says so; the compose reservation likewise, nested under the
  service (a 2-space `deploy:` would be silently ignored by compose); and
  **run ⇄ compose parity** — both generators asserted for the same gate value,
  plus a no-override case that catches one path being wired to a literal.
- `tests/docker/dockerfile-hindsight-bakes.test.ts` — the torch requirement
  must carry a `+cuNNN` local version and must not be `+cpu` (a `+cpu`
  requirement would silently undo the whole change while every other assertion
  passed); the CUDA index URL; the build-time assert, and that it *follows* the
  install, **and that it runs under `/app/api/.venv/bin/python`** — a bare
  `python3` is the image's system interpreter, with its own (or no) torch, so
  the guard would pass while the venv torch it guards stayed `+cpu`; every
  `import torch` probe in the stage is held to the same rule. Plus
  `ARG TARGETARCH` declared inside the stage that uses it (BuildKit only binds
  its built-in to declaring stages) — note the direction: `${TARGETARCH:-amd64}`
  defaults an **empty** value to amd64, so a missing declaration takes the CUDA
  branch, and the hazard is an arm64 build attempting an x86_64 install, never
  a silent CPU fallback on amd64. Finally the non-amd64 branch is pinned to its
  trivial shape via an **allowlist** — every non-empty line must BE one of its
  two known statements. A blocklist provably could not hold: `pip3 install
  --extra-index-url`, `uv add`, `apt-get install nvidia-cuda-toolkit` and
  `sh /opt/install-torch.sh` all install things while matching no plausible
  forbidden-spelling pattern. All four now go RED. These assertions are scoped
  to the RUN instruction carrying the CUDA install rather than to a file-wide
  `search()`, so an unrelated `if/else` added elsewhere in the Dockerfile
  cannot silently re-point the slice and make them vacuous while green.

```
vitest run src/setup/hindsight-gpu.test.ts \
  tests/docker/dockerfile-hindsight-bakes.test.ts \
  src/setup/hindsight-mirror-dir.test.ts tests/setup/hindsight.test.ts \
  src/setup/hindsight-reranker-budget.test.ts tests/memory.test.ts \
  tests/docker/compose-generator.test.ts
→ Test Files 7 passed (7)   Tests 364 passed (364)

npm run lint → clean (tsc + all 15 guard scripts)
```

**Mutation testing** (each applied to the source, suite re-run, then reverted):

| mutation | result |
| --- | --- |
| `/app/api/.venv/bin/python` → `python3` on the CUDA assert | **RED** — `dockerfile-hindsight-bakes` 1/26 |
| same, but single-quoted (`-c 'import torch;`) | **RED** — 1/26 |
| sneak `uv pip install --index-url .../cu130` into the non-amd64 branch | **RED** — 1/26 |
| `pip3 install … --extra-index-url …` into that branch | **RED** — 1/26 |
| `uv add torch==2.12.1+cu130` into that branch | **RED** — 1/26 |
| `apt-get install -y nvidia-cuda-toolkit` into that branch | **RED** — 1/26 |
| `sh /opt/install-torch.sh` into that branch | **RED** — 1/26 |
| gate `=== true` → `Boolean(a && b)` (full revert) | **RED** — `hindsight-gpu` 1/14 |
| gate: relax **only** `containerToolkit` (half-revert) | **RED** — `hindsight-gpu` 1/14 |

The first row is the mutation that SURVIVED the original review; it is now
dead, as is every follow-up attempt to route around it. Rows 4-7 are installs
that survived the first-pass blocklist and drove the switch to an allowlist.

CI `build-hindsight`: **success** — the real end-to-end proof that
`torch==2.12.1+cu130` installs into upstream's uv venv and passes the
`torch.version.cuda` assert.

Not deployed. No live image rebuilt, no container restarted. Rollout is a
separate step.

## Risk

- **Image size — stated fully.** The cu130 wheel plus vendored `nvidia-*` libs
  adds several GB to the amd64 leg, and this is a **reinstall in a layer above
  the base**, so the amd64 image carries **both** torch copies: upstream's
  `2.12.1+cpu` stays in the lower layer and cannot be reclaimed from here.
  `--no-cache-dir` only suppresses uv's download cache — it does not remove the
  superseded wheel, so it is a smaller mitigation than it sounds. The only real
  mitigation applied is keeping arm64 off CUDA entirely. Genuinely shrinking
  the amd64 leg would need a multi-stage rebuild of upstream's venv, which is
  out of scope for this PR.
- **Build time.** `build-hindsight` is path-gated and rarely fires; this adds
  one download+unpack layer to the amd64 leg only.
- **Runtime.** Bounded by the init-time fallback above, with the request-time
  OOM caveat called out as a known gap.

## Follow-ups (deliberately out of scope)

1. **Reranker batch-size / fp16 tuning** (`RERANKER_LOCAL_BATCH_SIZE`,
   `..._FP16`). Worth doing once GPU is confirmed live in production, so the
   tuning has a real baseline to measure against.
2. **Request-time CUDA OOM handling** — see the safety section. Today an OOM
   mid-recall is a 500, not a CPU retry.

## Verdict rule

- **Advances a vision outcome:** standing-team — memory that actually returns
  inside its budget is what makes an agent feel like it remembers.
- **Job spec:** `reference/jobs/remember-across-sessions.md` — "brings back
  relevant facts ... in the right moment". A recall that times out brings back
  nothing.
- **Principle checks:** docs (the flag is documented in-place and in the
  CHANGELOG), defaults (GPU-less hosts are byte-identical to today), and
  consistency (the run and compose paths share one gate and are parity-tested)
  all pass.
- **Invariants:** none crossed. No model routing, no auth, no `claude -p`.


