### PR TITLE
perf(hindsight): seed graph expansion from the semantic arm, not a second ANN scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,38 @@ Embeddings come along for free. They run on the same torch, and make the same
 device probe, so they move to the GPU with no extra work — a smaller win
 (tens of milliseconds a call, not seconds), but a free one.
 
+### Recall no longer runs the same vector scan twice
+
+`retrieve_all_fact_types_parallel` ran the ANN scan
+(`ORDER BY embedding <=> $1::vector`) once for the semantic arm, discarded it,
+and then let the graph retriever issue its own — one per fact type, serialized
+behind the semantic stage's connection block. A three-fact-type recall did
+three vector scans where one is enough.
+
+Step 2's semantic rows are now threaded through as `semantic_seeds`. The
+parameter already existed and was already honoured by
+`link_expansion_retrieval`; nothing downstream changes shape. The derivation
+**declines** and lets upstream's own query run whenever the two sets are not
+provably identical — a per-request `min_scores.semantic` floor above the 0.3
+seed threshold, or a `thinking_budget` below the 20-seed cap — because a
+silently narrowed seed set is a quieter recall, and that is worse than a
+slower one.
+
+Verified, not assumed. The probe in
+`tests/docker/hindsight-search-patches.test.ts` counts the vector scans a whole
+recall issues (3 unpatched, 1 patched) and diffs the delivered seed ids against
+the output of upstream's own `_find_semantic_seeds`, called with the same
+parameters as the real call site — not against a hardcoded model. On the live
+`overlord` bank (67k `world` units), the two queries returned identical top-20
+seed sets across all 25 sampled query vectors.
+
+Honest scope: on that bank the removed scan measures ~10ms per fact type
+server-side (world 10.07ms / experience 11.33ms / observation 9.56ms, 10 warm
+samples each). Live graph timings are n=31 mean 0.258s p90 1.412s, so the
+graph tail is expansion-CTE work, not this scan. This removes real duplicated
+work; it is not the fix for the tail, and no end-to-end before/after was taken
+because the change is not deployed.
+
 ## v0.19.22 — release binaries attached and the pipeline gated end-to-end, derived LiteLLM timeout budgets, context7 by default
 
 ### LiteLLM paired timeout budgets are now DERIVED, and drift is detected

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -878,6 +878,229 @@ assert '        return " | ".join(tokens)' in pg, "switchroom hindsight BM25 com
 print("switchroom hindsight BM25 compound-token patch: intact compound tokens appended (strict superset of upstream tokens); native tsquery left as a plain OR join")
 PYEOF
 
+# Duplicate-ANN-scan fix: `retrieve_all_fact_types_parallel` in
+# engine/search/retrieval.py runs the vector-similarity scan TWICE per recall,
+# the second one serialized behind the first.
+#
+#   Step 2 opens one pooled connection and runs the combined semantic + BM25
+#   CTE. The semantic arm is `ORDER BY embedding <=> $1::vector LIMIT n` per
+#   fact_type — the ANN scan.
+#   Step 3 then gathers the per-fact-type graph tasks, and passes
+#   `semantic_seeds=None` into `retriever.retrieve(...)` even though Step 2
+#   just computed exactly those rows. link_expansion_retrieval.py's
+#   `retrieve()` reads
+#       if semantic_seeds: all_seeds = list(semantic_seeds)
+#       else:              all_seeds = await _find_semantic_seeds(...)
+#   and `_find_semantic_seeds` issues its own
+#   `ORDER BY embedding <=> $1::vector LIMIT $5`.
+#
+# So the pipeline does an ANN scan, throws it away for seeding purposes, and
+# then does a second one on a fresh connection AFTER Step 2's `async with`
+# block has exited. Measured on this deployment (foreground recall, n=30):
+# mean 4.218s / p50 4.364s / p90 5.831s end to end, of which the retrieval
+# residual is ~1.73s and graph is ~1.45s of that (84%).
+#
+# Fix: thread Step 2's semantic results through as `semantic_seeds`. The
+# parameter already exists and is already honoured by the receiving code —
+# nothing downstream changes shape.
+#
+# EQUIVALENCE, which is the whole safety argument. `retrieve()` uses the seeds
+# for their IDs ONLY (`seed_ids = list({s.id for s in all_seeds})`), so the
+# seed set is equivalent iff it contains the same unit ids. The two queries are
+# the same query:
+#   * same table, same `bank_id = $2`, same `fact_type`, same
+#     `embedding IS NOT NULL`, same `ORDER BY embedding <=> $1::vector`;
+#   * the same tags / tag_groups / created_after / created_before values, built
+#     by the same helpers — Step 3 forwards the identical arguments Step 2 got;
+#   * the seed query's `threshold=0.3` equals the shipped
+#     DEFAULT_SEMANTIC_MIN_SIMILARITY the arm uses, and `limit=20` is far below
+#     the arm's per-fact-type fetch (max(budget*5, 100) >= 100).
+# The helper therefore re-derives the seed set from the arm's rows: sort by
+# similarity descending, keep >= 0.3, take 20.
+#
+# It returns None (= keep upstream's own query) in the two cases where that
+# derivation is NOT provably the same set:
+#   1. `min_scores.semantic` raised the arm's floor above 0.3. The arm's
+#      candidate pool is then NARROWER than the seed query's, so rows the seed
+#      query would have returned were never fetched. Falling back here is the
+#      difference between a faster recall and a quieter one.
+#   2. The arm's Python trim bit (`len(rows) >= budget`) and every retained row
+#      still cleared 0.3 while fewer than 20 rows exist. Only reachable with a
+#      thinking_budget below 20 (the shipped fixed budgets are 100/300/1000),
+#      but it is the one shape where rows the seed query would have seen could
+#      have been trimmed away.
+# In every other case the trimmed-away rows are provably all below 0.3 (the
+# retained rows are the highest-similarity ones), so they could never have been
+# seeds.
+#
+# The helper sorts explicitly rather than trusting the row order the UNION ALL
+# happened to return, so it introduces NO new ordering assumption of its own —
+# it is at worst exactly as order-dependent as upstream's existing trim, which
+# already decides which semantic rows the user gets.
+#
+# `temporal_seeds` is deliberately left None. Step 2's temporal results come
+# from `retrieve_temporal_combined`, which applies time-bucket coverage
+# selection — a different set with different semantics, and upstream currently
+# passes NO temporal seeds at all, so threading them would ADD seeds and change
+# graph output rather than reproduce it. Out of scope here.
+#
+# Also out of scope, deliberately: the Step2/Step3 serialization itself and the
+# connection budget. This patch removes the duplicate scan only.
+#
+# Self-verifying: the build FAILS LOUDLY if upstream reformats either anchor or
+# retunes `_find_semantic_seeds`' limit/threshold call-site defaults out from
+# under the mirrored constants. Guarded behaviourally by
+# tests/docker/hindsight-search-patches.test.ts and structurally by
+# tests/docker/dockerfile-hindsight-bakes.test.ts.
+RUN python3 - <<'PYEOF'
+import pathlib
+
+f = pathlib.Path("/app/api/hindsight_api/engine/search/retrieval.py")
+s = f.read_text()
+
+# The mirrored constants must still match link_expansion_retrieval's call site,
+# or the derived seed set is not the set upstream would have produced.
+le = pathlib.Path("/app/api/hindsight_api/engine/search/link_expansion_retrieval.py").read_text()
+assert "all_seeds = await _find_semantic_seeds(" in le, "switchroom hindsight duplicate-ANN-scan patch: _find_semantic_seeds call site not found in link_expansion_retrieval.py — upstream restructured the seeding path; re-author this patch"
+assert "                    limit=20,\n                    threshold=0.3,\n" in le, "switchroom hindsight duplicate-ANN-scan patch: _find_semantic_seeds is no longer called with limit=20/threshold=0.3 — the mirrored _GRAPH_SEED_* constants would derive the WRONG seed set; re-author this patch"
+assert "            if semantic_seeds:\n                all_seeds = list(semantic_seeds)\n" in le, "switchroom hindsight duplicate-ANN-scan patch: retrieve() no longer honours semantic_seeds — threading them would be a no-op; re-author this patch"
+assert "seed_ids = list({s.id for s in all_seeds})" in le, "switchroom hindsight duplicate-ANN-scan patch: seeds are no longer consumed by id alone — the equivalence argument (id-set equality) no longer holds; re-author this patch"
+
+# --- 1. the seed-derivation helper -----------------------------------------
+DEF_ANCHOR = "async def retrieve_all_fact_types_parallel(\n"
+
+HELPER = '''# switchroom: mirrors link_expansion_retrieval._find_semantic_seeds' call-site
+# defaults. The build asserts they still match upstream, so a retune fails the
+# image build instead of silently deriving a different seed set.
+_GRAPH_SEED_LIMIT = 20
+_GRAPH_SEED_MIN_SIMILARITY = 0.3
+
+
+def _graph_semantic_seeds(
+    semantic_results: list[RetrievalResult],
+    arm_limit: int,
+    arm_min_similarity: float,
+) -> list[RetrievalResult] | None:
+    """switchroom: re-derive the graph seed set from the semantic arm's rows.
+
+    Returns the seeds LinkExpansionRetriever would have found for itself, so the
+    pipeline stops issuing a second ANN scan (`ORDER BY embedding <=> ...`)
+    serialized behind the one the semantic arm already ran.
+
+    The seeds are consumed by id alone, and both queries are the same query over
+    the same table with the same bank/fact_type/tag/created filters and the same
+    ordering, so the id set is reproducible from the arm's rows: take the rows at
+    or above the seed threshold, best-first, up to the seed limit.
+
+    Returns None (meaning: let upstream run its own query) whenever that is not
+    provably the same set:
+
+    * ``arm_min_similarity`` above the seed threshold. A per-request
+      ``min_scores.semantic`` floor makes the arm's candidate pool NARROWER than
+      the seed query's, so qualifying rows were never fetched.
+    * The arm's trim bit while every retained row still cleared the seed
+      threshold and fewer than the seed limit survived, i.e. rows the seed query
+      would have returned may have been trimmed away.
+
+    An empty list is returned when the arm genuinely found nothing at or above
+    the threshold; upstream treats that as falsy and re-queries, which is
+    harmless because that query returns nothing either.
+    """
+    if arm_min_similarity > _GRAPH_SEED_MIN_SIMILARITY:
+        return None
+    if any(r.similarity is None for r in semantic_results):
+        return None
+
+    # Sorted explicitly: never depend on the row order the UNION ALL returned.
+    ranked = sorted(semantic_results, key=lambda r: r.similarity, reverse=True)
+    seeds = [r for r in ranked if r.similarity >= _GRAPH_SEED_MIN_SIMILARITY][:_GRAPH_SEED_LIMIT]
+
+    if len(seeds) < _GRAPH_SEED_LIMIT and len(seeds) == len(ranked) and len(ranked) >= arm_limit:
+        return None
+    return seeds
+
+
+'''
+
+n = s.count(DEF_ANCHOR)
+assert n == 1, (
+    f"switchroom hindsight duplicate-ANN-scan patch: retrieve_all_fact_types_parallel anchor found {n}x "
+    "(expected 1) in search/retrieval.py — upstream reformatted the signature; re-author this patch "
+    "in docker/Dockerfile.hindsight"
+)
+s = s.replace(DEF_ANCHOR, HELPER + DEF_ANCHOR, 1)
+
+# --- 2. the arm's effective similarity floor, hoisted for the helper --------
+OLD_FLOOR = (
+    "    semantic_bm25_start = time.time()\n"
+    "    temporal_results_by_ft: dict[str, list[RetrievalResult]] = {}\n"
+    "    temporal_time = 0.0\n"
+)
+NEW_FLOOR = (
+    "    semantic_bm25_start = time.time()\n"
+    "    temporal_results_by_ft: dict[str, list[RetrievalResult]] = {}\n"
+    "    temporal_time = 0.0\n"
+    "    # switchroom: the floor retrieve_semantic_bm25_combined will apply to the\n"
+    "    # semantic arm, recomputed here so _graph_semantic_seeds can tell whether\n"
+    "    # the arm's candidate pool covers the graph seed query's.\n"
+    "    _arm_min_similarity = min_semantic if min_semantic is not None else get_config().semantic_min_similarity\n"
+)
+n = s.count(OLD_FLOOR)
+assert n == 1, (
+    f"switchroom hindsight duplicate-ANN-scan patch: Step 2 preamble anchor found {n}x (expected 1) "
+    "in search/retrieval.py — upstream reformatted retrieve_all_fact_types_parallel's Step 2; "
+    "re-author this patch in docker/Dockerfile.hindsight"
+)
+s = s.replace(OLD_FLOOR, NEW_FLOOR, 1)
+
+# The hoisted expression must stay byte-identical to the one inside the arm.
+assert (
+    "    sem_min = min_semantic if min_semantic is not None else config.semantic_min_similarity\n" in s
+), "switchroom hindsight duplicate-ANN-scan patch: retrieve_semantic_bm25_combined no longer derives sem_min as `min_semantic if min_semantic is not None else config.semantic_min_similarity` — the hoisted _arm_min_similarity would no longer describe the arm; re-author this patch"
+
+# --- 3. the call site -------------------------------------------------------
+OLD_CALL = (
+    "            query_text=query_text,\n"
+    "            semantic_seeds=None,\n"
+    "            temporal_seeds=None,\n"
+)
+NEW_CALL = (
+    "            query_text=query_text,\n"
+    "            # switchroom: Step 2 already ran this exact ANN scan. Passing its rows\n"
+    "            # through removes a second, serialized `ORDER BY embedding <=> ...`\n"
+    "            # per fact type. None here means the derivation was not provably\n"
+    "            # equivalent, so upstream runs its own query (correctness first).\n"
+    "            semantic_seeds=_graph_semantic_seeds(\n"
+    "                semantic_bm25_results.get(ft, ([], []))[0],\n"
+    "                thinking_budget,\n"
+    "                _arm_min_similarity,\n"
+    "            ),\n"
+    "            # switchroom: deliberately still None. Step 2's temporal rows come from\n"
+    "            # coverage selection, not from this query, so threading them would ADD\n"
+    "            # seeds rather than reproduce upstream's (which passes none).\n"
+    "            temporal_seeds=None,\n"
+)
+n = s.count(OLD_CALL)
+assert n == 1, (
+    f"switchroom hindsight duplicate-ANN-scan patch: Step 3 retriever.retrieve call site anchor found {n}x "
+    "(expected 1) in search/retrieval.py — upstream reformatted run_graph_for_fact_type; re-author this "
+    "patch in docker/Dockerfile.hindsight"
+)
+s = s.replace(OLD_CALL, NEW_CALL, 1)
+
+f.write_text(s)
+
+t = f.read_text()
+assert "def _graph_semantic_seeds(" in t, "switchroom hindsight duplicate-ANN-scan patch: helper missing after patch"
+assert "_GRAPH_SEED_LIMIT = 20" in t and "_GRAPH_SEED_MIN_SIMILARITY = 0.3" in t, "switchroom hindsight duplicate-ANN-scan patch: mirrored seed constants missing after patch"
+assert "semantic_seeds=_graph_semantic_seeds(" in t, "switchroom hindsight duplicate-ANN-scan patch: call site still passes something other than the derived seeds"
+assert "            semantic_seeds=None,\n" not in t, "switchroom hindsight duplicate-ANN-scan patch: a semantic_seeds=None call site survives — the duplicate ANN scan is still reachable"
+assert t.count("temporal_seeds=None,") == 1, "switchroom hindsight duplicate-ANN-scan patch: temporal_seeds must stay None exactly once (out of scope for this patch)"
+assert "_arm_min_similarity = min_semantic if min_semantic is not None else get_config().semantic_min_similarity" in t, "switchroom hindsight duplicate-ANN-scan patch: hoisted arm floor missing after patch"
+compile(t, str(f), "exec")
+print("switchroom hindsight duplicate-ANN-scan patch: graph expansion now seeds off Step 2's semantic arm (one ANN scan per fact type instead of two); falls back to upstream's own query whenever the derived seed set is not provably identical")
+PYEOF
+
 # Empty-TimeoutError-message fix: both retry loops in
 # engine/providers/litellm_llm.py end their timeout handler with a bare
 # `raise`, which re-raises the asyncio.TimeoutError produced by

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -531,6 +531,76 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the duplicate-ANN-scan fix (assert-guarded, fail-loud)", () => {
+    // retrieve_all_fact_types_parallel ran the vector-similarity scan twice per
+    // recall: Step 2's semantic arm, then `semantic_seeds=None` into the graph
+    // retriever, whose _find_semantic_seeds issues its own
+    // `ORDER BY embedding <=> $1::vector LIMIT $5` per fact type — serialized
+    // behind Step 2's connection block. The patch threads Step 2's rows through
+    // as the seeds. Outcome coverage lives in hindsight-search-patches.test.ts.
+
+    // The exact-once anchor guards (fail-loud on upstream drift), one per site.
+    expect(dockerfile).toMatch(
+      /switchroom hindsight duplicate-ANN-scan patch: retrieve_all_fact_types_parallel anchor found \{n\}x/,
+    );
+    expect(dockerfile).toMatch(
+      /switchroom hindsight duplicate-ANN-scan patch: Step 2 preamble anchor found \{n\}x/,
+    );
+    expect(dockerfile).toMatch(
+      /switchroom hindsight duplicate-ANN-scan patch: Step 3 retriever\.retrieve call site anchor found \{n\}x/,
+    );
+
+    // The mirrored seed constants are only correct while link_expansion still
+    // calls _find_semantic_seeds with them — asserted against that file at
+    // build time, so an upstream retune fails the build rather than silently
+    // deriving a different seed set.
+    expect(dockerfile).toMatch(/_GRAPH_SEED_LIMIT = 20/);
+    expect(dockerfile).toMatch(/_GRAPH_SEED_MIN_SIMILARITY = 0\.3/);
+    expect(dockerfile).toContain(
+      String.raw`assert "                    limit=20,\n                    threshold=0.3,\n" in le,`,
+    );
+    // …and only correct while the seeds are still consumed by id alone, which
+    // is what makes "same id set" the right equivalence relation.
+    expect(dockerfile).toMatch(
+      /assert "seed_ids = list\(\{s\.id for s in all_seeds\}\)" in le,/,
+    );
+    // …and while the receiving branch still honours the parameter at all.
+    expect(dockerfile).toMatch(
+      /assert "            if semantic_seeds:\\n                all_seeds = list\(semantic_seeds\)\\n" in le,/,
+    );
+
+    // Correctness-first fallbacks: decline to derive whenever the arm's pool is
+    // narrower than the seed query's, or the arm's trim may have cut seeds.
+    expect(dockerfile).toMatch(
+      /if arm_min_similarity > _GRAPH_SEED_MIN_SIMILARITY:\n +return None/,
+    );
+    expect(dockerfile).toMatch(
+      /if len\(seeds\) < _GRAPH_SEED_LIMIT and len\(seeds\) == len\(ranked\) and len\(ranked\) >= arm_limit:/,
+    );
+    // Sorted explicitly: no new dependence on UNION ALL row order.
+    expect(dockerfile).toMatch(
+      /ranked = sorted\(semantic_results, key=lambda r: r\.similarity, reverse=True\)/,
+    );
+
+    // Scope guard: this patch does NOT thread temporal seeds. Step 2's temporal
+    // rows are coverage-selected and upstream passes none, so threading them
+    // would ADD seeds rather than reproduce upstream's graph output.
+    expect(dockerfile).toMatch(
+      /assert t\.count\("temporal_seeds=None,"\) == 1,/,
+    );
+
+    // Post-replace re-assertions (verification-on-build), including that no
+    // `semantic_seeds=None` call site survives and that the result still parses.
+    expect(dockerfile).toMatch(/assert "def _graph_semantic_seeds\(" in t,/);
+    expect(dockerfile).toMatch(
+      /assert "            semantic_seeds=None,\\n" not in t,/,
+    );
+    expect(dockerfile).toMatch(/compile\(t, str\(f\), "exec"\)/);
+    expect(dockerfile).toMatch(
+      /switchroom hindsight duplicate-ANN-scan patch: graph expansion now seeds off Step 2's semantic arm/,
+    );
+  });
+
   it("keeps the LiteLLM empty-TimeoutError-message fix (assert-guarded, fail-loud)", () => {
     // Both retry loops ended their timeout handler with a bare `raise`,
     // re-raising an asyncio.TimeoutError with no args — so operators saw

--- a/tests/docker/hindsight-search-patches.test.ts
+++ b/tests/docker/hindsight-search-patches.test.ts
@@ -1,12 +1,12 @@
 /**
- * Behavioural proof for the three search/provider patches
+ * Behavioural proof for the four search/provider patches
  * `docker/Dockerfile.hindsight` bakes into the pinned upstream Hindsight
  * image. `dockerfile-hindsight-bakes.test.ts` pins the *shape* of those patch
  * blocks (grep-on-file, runs everywhere). This file proves the *outcome*: it
  * runs the same probe against unpatched upstream (must be RED on every bug)
  * and against upstream + the patch blocks applied (must be GREEN).
  *
- * The three defects, all reproduced live on bank `overlord` before the fix:
+ * The four defects, all reproduced live on bank `overlord` before the fix:
  *
  *  1. Cross-encoder saturation. `apply_combined_scoring` makes
  *     `CE * recency_boost * temporal_boost * proof_count_boost` the only final
@@ -21,6 +21,11 @@
  *  3. Both LiteLLM timeout handlers ended in a bare `raise`, re-raising an
  *     `asyncio.TimeoutError` whose `str()` is empty → an operator-facing
  *     "TimeoutError:" with no cause.
+ *  4. `retrieve_all_fact_types_parallel` ran the vector-similarity scan TWICE
+ *     per recall. Step 2's semantic arm is an ANN scan; Step 3 then passed
+ *     `semantic_seeds=None` into the graph retriever, whose `_find_semantic_seeds`
+ *     issues its own `ORDER BY embedding <=> $1::vector LIMIT $5` per fact type,
+ *     serialized behind Step 2's connection block.
  *
  * Beyond proving those three fixes, the probe pins the properties that make
  * the fixes SAFE, because each was violated by an earlier revision of this
@@ -39,6 +44,13 @@
  *    additive levels and `min_scores.final` are calibrated against.
  *  - `tokenize_query` stays a STRICT SUPERSET of upstream's token list, so the
  *    OR-joined query can only match more documents than upstream, never fewer.
+ *  - The seeds the graph expansion is handed are the SAME SET, in the same
+ *    order, that upstream's own seed query returns — asserted by calling that
+ *    upstream query and diffing, not by trusting the derivation. Where the two
+ *    are not provably identical (a `min_scores.semantic` floor above the seed
+ *    threshold, or a thinking_budget below the seed cap) the derivation must
+ *    decline and let upstream re-query. A faster wrong seed set is a
+ *    regression, not a win.
  *
  * The patch blocks are extracted from the Dockerfile itself rather than
  * duplicated here, so this test cannot drift from what actually ships. It
@@ -96,6 +108,7 @@ function patchBlocks(): string[] {
     "CE-saturation patch",
     "BM25 compound-token patch",
     "timeout-message patch",
+    "duplicate-ANN-scan patch",
   ];
   return wanted.map((name) => {
     const b = blocks.find((x) => x.includes(name));
@@ -129,7 +142,11 @@ function patchBlocks(): string[] {
  *    to upstream;
  *  - two REAL driven timeouts — a hanging completion forced through both
  *    LiteLLM retry loops — checked for the timeout/scope facts in the message
- *    and for still being caught by an upstack `except asyncio.TimeoutError`.
+ *    and for still being caught by an upstack `except asyncio.TimeoutError`;
+ *  - the NUMBER of vector-similarity scans a whole recall issues, counted at
+ *    the connection by driving the real `retrieve_all_fact_types_parallel` and
+ *    the real `LinkExpansionRetriever` over an in-memory corpus, plus the ids
+ *    of the seed set that reaches the graph expansion.
  *
  * The test below enforces that the rank-order line above stays true in both
  * directions — this header went stale once already when the ranking patch was
@@ -461,6 +478,187 @@ for label, (how, msg) in sorted(timeouts.items()):
     elif "timed out after" not in msg or "scope=" not in msg:
         failures.append("%s timeout message lost the timeout/scope facts: %r" % (label, msg))
 
+# ------------------------------------------------------------------ fix 4
+# Drive the REAL retrieve_all_fact_types_parallel and the REAL
+# LinkExpansionRetriever over an in-memory corpus, and COUNT the
+# vector-similarity scans at the connection. Upstream issues one per fact type
+# on top of Step 2's arm; patched must issue exactly one for the whole recall.
+from hindsight_api.engine.db.ops_postgresql import PostgreSQLOps
+from hindsight_api.engine.search import link_expansion_retrieval as LE
+from hindsight_api.engine.search import retrieval as R
+
+SEED_LIMIT = 20
+SEED_THRESHOLD = 0.3
+
+
+def urow(ft, i, sim):
+    return {
+        "id": "%s-%02d" % (ft, i), "text": "fact %d" % i, "context": None,
+        "event_date": None, "occurred_start": None, "occurred_end": None,
+        "mentioned_at": None, "fact_type": ft, "document_id": None,
+        "chunk_id": None, "tags": None, "metadata": None, "proof_count": 1,
+        "similarity": sim, "bm25_score": None,
+    }
+
+
+# 40 world rows spanning the seed threshold (33 clear 0.3, so BOTH the 20-cap
+# and the threshold bite) plus 5 experience rows that all clear it (under the
+# cap, so the whole set is the seed set).
+CORPUS = [urow("world", i, round(0.95 - 0.02 * i, 4)) for i in range(40)]
+CORPUS += [urow("experience", i, round(0.90 - 0.10 * i, 4)) for i in range(5)]
+
+
+class FakeConn:
+    """Serves the real SQL the engine builds, from the corpus above.
+
+    Discriminates the three query shapes a recall issues so the probe can COUNT
+    ANN scans rather than infer them: the Step 2 combined arm, link_expansion's
+    standalone seed scan, and the graph expansion CTE.
+    """
+
+    backend_type = "postgresql"
+
+    def __init__(self, log):
+        self.log = log
+
+    async def fetch(self, query, *params):
+        if "'semantic' AS source" in query:
+            self.log.append("arm")
+            floor = float(re.search(r"<=> \$1::vector\)\) >= ([0-9.]+)", query).group(1))
+            return [dict(r, source="semantic") for r in CORPUS if r["similarity"] >= floor]
+        if "embedding <=>" in query:
+            # The duplicate scan this patch exists to remove.
+            self.log.append("seed")
+            _emb, _bank, ft, threshold, limit = params[:5]
+            hits = [r for r in CORPUS if r["fact_type"] == ft and r["similarity"] >= threshold]
+            hits.sort(key=lambda r: r["similarity"], reverse=True)
+            return hits[:limit]
+        self.log.append("expand")
+        return []
+
+
+class FakePool:
+    def __init__(self, conn):
+        self.conn = conn
+        self.ops = PostgreSQLOps()
+
+    async def acquire(self):
+        return self.conn
+
+    async def release(self, conn):
+        pass
+
+    def get_size(self):
+        return 1
+
+    def get_idle_size(self):
+        return 1
+
+
+class RecordingRetriever(LE.LinkExpansionRetriever):
+    """The REAL retriever, wrapped only to capture what it was handed."""
+
+    def __init__(self):
+        super().__init__()
+        self.seen = {}
+
+    async def retrieve(self, **kw):
+        self.seen[kw["fact_type"]] = kw["semantic_seeds"]
+        return await super().retrieve(**kw)
+
+
+async def _drive(fact_types, budget=300, min_semantic=None):
+    log = []
+    retriever = RecordingRetriever()
+    await R.retrieve_all_fact_types_parallel(
+        FakePool(FakeConn(log)), "alpha beta", "[0.1,0.2]", "bank-probe",
+        list(fact_types), budget, None, None,
+        graph_retriever=retriever, min_semantic=min_semantic,
+    )
+    return log, retriever.seen
+
+
+def seed_ids(seeds):
+    return None if seeds is None else [s.id for s in seeds]
+
+
+async def _reference(ft):
+    """The seed set upstream's OWN query returns, obtained by calling it."""
+    rows = await LE._find_semantic_seeds(
+        FakeConn([]), "[0.1,0.2]", "bank-probe", ft,
+        limit=SEED_LIMIT, threshold=SEED_THRESHOLD,
+    )
+    return [r.id for r in rows]
+
+
+# The mirrored seed constants are only right while the call site still passes
+# them; upstream retuning either one silently changes which set is equivalent.
+le_src = inspect.getsource(LE.LinkExpansionRetriever.retrieve)
+print("SEED_CALL_SITE_DEFAULTS", "limit=20" in le_src, "threshold=0.3" in le_src)
+if "limit=20" not in le_src or "threshold=0.3" not in le_src:
+    failures.append("link_expansion no longer seeds with limit=20/threshold=0.3 - the derived seed set is calibrated against those")
+
+FT = ["world", "experience"]
+scan_log, delivered = asyncio.run(_drive(FT))
+ref = {ft: asyncio.run(_reference(ft)) for ft in FT}
+
+ann = scan_log.count("arm") + scan_log.count("seed")
+print("ANN_SCANS", ann, "ARM", scan_log.count("arm"), "SEED_QUERIES", scan_log.count("seed"))
+print("REFERENCE_world", len(ref["world"]))
+print("REFERENCE_experience", len(ref["experience"]))
+for ft in FT:
+    print("DELIVERED_%s" % ft, seed_ids(delivered[ft]))
+
+if scan_log.count("seed") != 0:
+    failures.append(
+        "graph expansion still issued %d standalone ANN seed scan(s) after Step 2 already ran one"
+        % scan_log.count("seed")
+    )
+if ann != 1:
+    failures.append("recall issued %d vector-similarity scans (expected exactly 1)" % ann)
+
+# EQUIVALENCE. Same ids, same order, as upstream's own seed query - the whole
+# safety argument, since a narrowed seed set silently narrows recall.
+for ft in FT:
+    got = seed_ids(delivered[ft])
+    if got is None:
+        failures.append("%s: semantic_seeds was None - the graph path re-ran the ANN scan" % ft)
+    elif got != ref[ft]:
+        failures.append("%s: derived seeds %r != upstream seed query %r" % (ft, got, ref[ft]))
+
+# The corpus must keep exercising both bounds, or the equivalence check above
+# degenerates into a tautology.
+if len(ref["world"]) != SEED_LIMIT:
+    failures.append("probe corpus no longer exercises the %d-seed cap (%d)" % (SEED_LIMIT, len(ref["world"])))
+if len(ref["experience"]) >= SEED_LIMIT:
+    failures.append("probe corpus no longer exercises the under-cap case")
+
+# FALLBACK 1: a per-request min_scores.semantic floor ABOVE the seed threshold
+# makes the arm's pool narrower than the seed query's, so rows the seed query
+# would have returned were never fetched. Must decline and let upstream query.
+log_hi, seen_hi = asyncio.run(_drive(["world"], min_semantic=0.5))
+print("HIGH_FLOOR_SEEDS", seed_ids(seen_hi["world"]), "SEED_QUERIES", log_hi.count("seed"))
+if seen_hi["world"] is not None:
+    failures.append("min_scores.semantic=0.5 (above the 0.3 seed threshold) still derived seeds from the narrowed arm")
+if log_hi.count("seed") != 1:
+    failures.append("min_scores.semantic=0.5 did not fall back to upstream's own seed query")
+
+# FALLBACK 2: a thinking_budget below the seed cap can trim away rows the seed
+# query would have returned.
+log_lo, seen_lo = asyncio.run(_drive(["world"], budget=5))
+print("TINY_BUDGET_SEEDS", seed_ids(seen_lo["world"]), "SEED_QUERIES", log_lo.count("seed"))
+if seen_lo["world"] is not None:
+    failures.append("thinking_budget=5 (below the seed cap) still derived seeds from a trimmed arm")
+if log_lo.count("seed") != 1:
+    failures.append("thinking_budget=5 did not fall back to upstream's own seed query")
+
+# temporal_seeds stays out of scope: upstream passes none, and Step 2's temporal
+# rows are a coverage-selected set with different semantics, so threading them
+# would ADD seeds rather than reproduce upstream's behaviour.
+print("TEMPORAL_SEEDS_STILL_NONE", "temporal_seeds=None" in inspect.getsource(R.retrieve_all_fact_types_parallel))
+if "temporal_seeds=None" not in inspect.getsource(R.retrieve_all_fact_types_parallel):
+    failures.append("temporal_seeds is no longer None - that is a separate change with different semantics")
+
 print("FAILURES", failures)
 # Sentinel: proves the probe ran to completion. The harness asserts this, so a
 # probe that dies early or short-circuits can never be mistaken for a pass.
@@ -632,7 +830,7 @@ describe.skipIf(!dockerOk || !imageOk)(
       }
     });
 
-    it("unpatched upstream is RED on all three defects (proves the probe bites)", () => {
+    it("unpatched upstream is RED on all four defects (proves the probe bites)", () => {
       const { status, stdout } = runProbe(false);
       expect(stdout, "probe did not run to completion").toContain(
         "PROBE_EXECUTED"
@@ -670,6 +868,15 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toMatch(
         /TIMEOUT call_with_tools CAUGHT_BY_ASYNCIO_TIMEOUTERROR ''/
       );
+
+      // Defect 4 — the duplicate ANN scan, counted at the connection: Step 2's
+      // arm plus one standalone seed scan per fact type.
+      expect(stdout).toContain("ANN_SCANS 3 ARM 1 SEED_QUERIES 2");
+      expect(stdout).toContain(
+        "graph expansion still issued 2 standalone ANN seed scan(s) after Step 2 already ran one"
+      );
+      expect(stdout).toContain("DELIVERED_world None");
+      expect(stdout).toContain("DELIVERED_experience None");
     }, 240_000);
 
     it("upstream + the baked patch blocks is GREEN, including every safety property", () => {
@@ -749,6 +956,40 @@ describe.skipIf(!dockerOk || !imageOk)(
       expect(stdout).toMatch(
         /TIMEOUT call_with_tools CAUGHT_BY_ASYNCIO_TIMEOUTERROR 'LiteLLM tool call timed out after 0\.05s on 1 attempts \(TimeoutError, scope=tools\)'/
       );
+
+      // Fix 4: exactly ONE vector-similarity scan for the whole recall — the
+      // arm — and zero standalone seed scans, no matter how many fact types.
+      expect(stdout).toContain("ANN_SCANS 1 ARM 1 SEED_QUERIES 0");
+
+      // … and the seeds the graph expansion actually received are the SAME SET,
+      // in the same order, that upstream's own seed query returns. Diffed
+      // against that query's real output, with both of its bounds biting: the
+      // 20-seed cap on `world` (40 rows, 33 above the 0.3 threshold) and the
+      // under-cap case on `experience` (5 rows).
+      expect(stdout).toContain("SEED_CALL_SITE_DEFAULTS True True");
+      expect(stdout).toContain("REFERENCE_world 20");
+      expect(stdout).toContain("REFERENCE_experience 5");
+      expect(stdout).toContain(
+        "DELIVERED_world ['world-00', 'world-01', 'world-02', 'world-03', " +
+          "'world-04', 'world-05', 'world-06', 'world-07', 'world-08', " +
+          "'world-09', 'world-10', 'world-11', 'world-12', 'world-13', " +
+          "'world-14', 'world-15', 'world-16', 'world-17', 'world-18', " +
+          "'world-19']"
+      );
+      expect(stdout).toContain(
+        "DELIVERED_experience ['experience-00', 'experience-01', " +
+          "'experience-02', 'experience-03', 'experience-04']"
+      );
+
+      // … and it DECLINES rather than guessing wherever the derived set is not
+      // provably the upstream set. Correctness first: a narrowed seed set is a
+      // silently quieter recall, which is worse than a slower one.
+      expect(stdout).toContain("HIGH_FLOOR_SEEDS None SEED_QUERIES 1");
+      expect(stdout).toContain("TINY_BUDGET_SEEDS None SEED_QUERIES 1");
+
+      // … while temporal seeds stay out of scope (upstream passes none, and
+      // Step 2's temporal rows are a differently-selected set).
+      expect(stdout).toContain("TEMPORAL_SEEDS_STILL_NONE True");
     }, 240_000);
   }
 );


### PR DESCRIPTION
## Summary

Recall's `retrieve_all_fact_types_parallel` ran the ANN scan
(`ORDER BY embedding <=> $1::vector`) in Step 2 for the semantic arm, then passed
`semantic_seeds=None` into Step 3. `link_expansion_retrieval.retrieve` therefore
fell back to `_find_semantic_seeds` and issued its *own* ANN scan — once per fact
type, serialized behind the connection block Step 2 had just closed. A
three-fact-type recall did **three** vector scans where one is enough.

This threads Step 2's semantic rows through as `semantic_seeds`. The parameter
already existed and was already honoured by the receiving code; nothing
downstream changes shape.

Delivered as a Dockerfile patch block, because `hindsight_api` is upstream
`vectorize-io/hindsight` pinned by digest — there is no source checkout of it on
this host, and the self-verifying `RUN python3` block in
`docker/Dockerfile.hindsight` is this repo's sanctioned mechanism for engine
changes (same pattern as the BM25 compound-token block above it).

## Why this is safe

`LinkExpansionRetriever` consumes seeds **by id only**
(`seed_ids = list({s.id for s in all_seeds})`), so the equivalence relation that
has to hold is "same id set" — and it does. Both queries hit the same table with
the same bank / fact-type / tag / date filters, the same
`(1 - (embedding <=> $1::vector)) >= threshold` floor, and the same ordering.

The derivation **declines** — falling back to upstream's own query — in the two
cases where the sets are *not* provably identical:

- a per-request `min_scores.semantic` above the 0.3 seed threshold narrows the
  arm's pool below the seed query's;
- a `thinking_budget` below the 20-seed cap lets the arm's Python trim cut rows
  the seed query would have returned.

A silently narrowed seed set is a quieter recall, and that is worse than a slower
one. `temporal_seeds` stays `None`: Step 2's temporal rows are a
coverage-selected set with different semantics, and threading them is a separate
change with a separate argument.

The helper sorts explicitly rather than trusting the UNION ALL's row order, so
this adds no new ordering dependence.

## Test plan

- `tests/docker/hindsight-search-patches.test.ts` — behavioural. The probe
  **counts vector scans at the connection**: 3 unpatched, 1 patched. It diffs the
  delivered seeds against the output of the REAL `_find_semantic_seeds` invoked
  with the call site's own `limit=20` / `threshold=0.3` (not a hardcoded model),
  asserts the corpus still exercises both the 20-cap and the under-cap case, and
  asserts both fallbacks re-issue the standalone scan. RED on unpatched upstream,
  GREEN on the baked image — so it would fail if the seeds went back to `None`.
- `tests/docker/dockerfile-hindsight-bakes.test.ts` — structural. Pins the exact-
  once anchors, the mirrored constants, the cross-file assertions against
  `link_expansion_retrieval.py`, both decline conditions, and the post-replace
  re-assertions incl. `compile()`. A retune upstream fails the image build loudly
  instead of silently deriving a different seed set.
- Live correctness on the `overlord` bank (67k `world` units), 25 sampled query
  vectors, read-only: `seed_set_mismatches=0`. The seed-query top-20 and the
  arm-derived top-20 are identical id sets in every sample.

```
 ✓ tests/docker/dockerfile-hindsight-bakes.test.ts (25 tests)
 ✓ tests/docker/hindsight-search-patches.test.ts (5 tests)
 Test Files  2 passed (2)   Tests  30 passed (30)
```
`npm run lint` green (16 gates).

## Risk / honest scope

**This does not fix the graph tail, and the PR does not claim it does.** Measured
on the live bank, the removed scan is ~10ms per fact type server-side (world
10.07ms, experience 11.33ms, observation 9.56ms; 10 warm samples each), while
live graph timings are n=31 mean 0.258s p50 0.024s p90 1.412s — that p90 is
expansion-CTE work, not the duplicate scan. So this removes genuine duplicated
work and DB CPU contention, but the "graph is 84% of the retrieval residual"
figure stands unexplained by it.

No end-to-end before/after latency is available: this is not deployed, no image
was rebuilt and no container restarted.

Untouched by design: `HINDSIGHT_DEFAULT_RERANKER_MAX_CANDIDATES`, the
`recall.py` timeout, the admission semaphore, the connection budget, and the
Step 2 / Step 3 serialization.

Job: `reference/jobs/remember-across-sessions.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
