### PR TITLE
perf(hindsight): capability-gated performance defaults

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -730,6 +730,10 @@ export function registerMemoryCommand(program: Command): void {
           effectiveTag,
           hindsightConfig.hindsight?.llm,
           hindsightConsumerMirrorDir(hindsightConfig),
+          // gpu: omitted ⇒ hindsightGpuEnabled() reads the persisted verdict.
+          undefined,
+          // Operator overrides for the capability-gated performance defaults.
+          { env: hindsightConfig.hindsight?.env },
         );
         if (litellmCfg) {
           console.log(chalk.gray("  LiteLLM routing enabled for hindsight (--network host)."));
@@ -774,6 +778,10 @@ export function registerMemoryCommand(program: Command): void {
           generateHindsightComposeSnippet(
             snippetConfig.hindsight?.llm,
             hindsightConsumerMirrorDir(snippetConfig),
+            // litellm / gpu: omitted ⇒ same defaults the docker-run path uses.
+            undefined,
+            undefined,
+            { env: snippetConfig.hindsight?.env },
           ),
         );
       }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2058,6 +2058,23 @@ export const HindsightConfigSchema = z.object({
       "`consolidation` blocks override individual ops. All fields optional; " +
       "unset fields fall back to the hard-coded defaults.",
     ),
+  env: z
+    .record(z.union([z.string(), z.number(), z.boolean()]))
+    .optional()
+    .describe(
+      "Operator overrides for switchroom's capability-gated Hindsight " +
+      "performance defaults. Only the keys switchroom actually manages are " +
+      "honoured (`HINDSIGHT_PERF_ENV_KEYS` in " +
+      "src/setup/hindsight-perf-defaults.ts: RERANKER_LOCAL_FP16, " +
+      "LLM_MAX_CONCURRENT, RETAIN/CONSOLIDATION_LLM_MAX_CONCURRENT, " +
+      "RECALL_MAX_CANDIDATES_PER_SOURCE, LINK_EXPANSION_PER_ENTITY_LIMIT, " +
+      "LINK_EXPANSION_TIMEOUT, LLM_REASONING_EFFORT). A value set here " +
+      "REPLACES switchroom's default and is emitted even when the gating " +
+      "capability is absent, so an operator can always force a knob. Other " +
+      "`HINDSIGHT_API_*` keys are deliberately IGNORED — a blanket " +
+      "passthrough would collide with the vars startHindsight() derives " +
+      "itself (HINDSIGHT_API_PORT, the retain token/deadline budget).",
+    ),
 });
 
 /**

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Capability-gated Hindsight performance defaults.
+ *
+ * What these tests protect, in order of how badly a regression would hurt:
+ *
+ *   1. **Fail-safe gating.** A knob whose benefit needs hardware is emitted
+ *      ONLY when the host proves it has that hardware. FP16 reranking on a
+ *      CPU without native FP16 support is upstream's own stated reason for
+ *      defaulting it off; throttling a cloud LLM endpoint to 4 concurrent
+ *      requests is a throughput regression for nothing.
+ *   2. **Operator override wins.** A value in `hindsight.env` (or exported in
+ *      switchroom's environment) must reach the container — including when
+ *      the gating capability is ABSENT, otherwise "override" quietly means
+ *      "override, unless you have the wrong hardware".
+ *   3. **Run ⇄ compose parity.** Two launch paths, one resolver. The
+ *      assertions compare the OUTCOME of both generators for the same inputs,
+ *      not that both happened to call a shared function.
+ *   4. **Derivation coherence.** The per-source candidate cap exists to stop
+ *      ONE source filling the reranker budget without stopping ALL FOUR from
+ *      filling it. Both halves are asserted against the real reranker
+ *      constant, so raising the budget can't silently invert the property.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: execFileSyncMock };
+});
+
+import {
+  HINDSIGHT_DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT,
+  HINDSIGHT_DEFAULT_LINK_EXPANSION_TIMEOUT_S,
+  HINDSIGHT_DEFAULT_RECALL_MAX_CANDIDATES_PER_SOURCE,
+  HINDSIGHT_PERF_DEFAULTS_GPU,
+  HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+  HINDSIGHT_PERF_DEFAULTS_UNGATED,
+  HINDSIGHT_PERF_ENV_KEYS,
+  HINDSIGHT_RECALL_SOURCE_COUNT,
+  HINDSIGHT_RERANKER_MAX_CANDIDATES_FOR_DERIVATION,
+  hindsightPerfEnv,
+  resolveHindsightPerfOverrides,
+} from "./hindsight-perf-defaults.js";
+import {
+  HINDSIGHT_DEFAULT_RERANKER_MAX_CANDIDATES,
+  generateHindsightComposeSnippet,
+  hindsightLocalLlmEnabled,
+  hindsightNeedsHostNetwork,
+  hindsightPerfEnvPairs,
+  isLoopbackHttpUrl,
+  isSelfHostedHttpUrl,
+  startHindsight,
+} from "./hindsight.js";
+
+beforeEach(() => {
+  execFileSyncMock.mockReset();
+  execFileSyncMock.mockReturnValue(Buffer.from(""));
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+/** The `docker run` argv for the hindsight container itself (not the chown helper). */
+function runArgs(): string[] {
+  const call = execFileSyncMock.mock.calls.find(
+    (c) =>
+      c[0] === "docker" &&
+      Array.isArray(c[1]) &&
+      (c[1] as string[])[0] === "run" &&
+      (c[1] as string[]).includes("switchroom-hindsight"),
+  );
+  expect(call, "startHindsight must have issued a `docker run`").toBeDefined();
+  return call![1] as string[];
+}
+
+/** `KEY=VALUE` pairs following a `-e` flag in a docker-run argv. */
+function runEnv(args: string[]): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] !== "-e") continue;
+    const eq = args[i + 1].indexOf("=");
+    if (eq < 0) continue;
+    const key = args[i + 1].slice(0, eq);
+    const value = args[i + 1].slice(eq + 1);
+    out.set(key, [...(out.get(key) ?? []), value]);
+  }
+  return out;
+}
+
+/** `      - KEY=VALUE` environment lines from a compose snippet. */
+function composeEnv(snippet: string): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const line of snippet.split("\n")) {
+    const m = line.match(/^ {6}- ([A-Z0-9_]+)=(.*)$/);
+    if (!m) continue;
+    out.set(m[1], [...(out.get(m[1]) ?? []), m[2]]);
+  }
+  return out;
+}
+
+/** A LiteLLM config pointed at host loopback — this fleet's real shape. */
+const LOOPBACK_LITELLM = { baseUrl: "http://127.0.0.1:4010", apiKey: "sk-" + "test" };
+/** A hosted LiteLLM endpoint — the "not self-hosted" control. */
+const CLOUD_LITELLM = { baseUrl: "https://litellm.example.com", apiKey: "sk-" + "test" };
+
+// ── the derivation ────────────────────────────────────────────────────────
+describe("per-source candidate cap derivation", () => {
+  it("is pinned to the real reranker budget constant", () => {
+    // hindsight-perf-defaults.ts holds a literal to avoid an import cycle with
+    // hindsight.ts. If they drift, the two invariants below are computed
+    // against a number the engine never sees.
+    expect(HINDSIGHT_RERANKER_MAX_CANDIDATES_FOR_DERIVATION).toBe(
+      HINDSIGHT_DEFAULT_RERANKER_MAX_CANDIDATES,
+    );
+  });
+
+  it("stops ONE source filling the reranker budget on its own", () => {
+    // Upstream's stated purpose for the knob, verbatim: "Prevents one
+    // over-expanding backend from filling the reranker budget on its own."
+    expect(HINDSIGHT_DEFAULT_RECALL_MAX_CANDIDATES_PER_SOURCE).toBeLessThan(
+      HINDSIGHT_DEFAULT_RERANKER_MAX_CANDIDATES,
+    );
+  });
+
+  it("still lets ALL sources together fill the reranker budget", () => {
+    // The other half, and the one a naive "just make it small" tuning breaks:
+    // if sources * perSource < rerankerMax, the cap silently shrinks the pool
+    // that reaches the cross-encoder and costs recall quality even when no
+    // single source is misbehaving.
+    expect(
+      HINDSIGHT_DEFAULT_RECALL_MAX_CANDIDATES_PER_SOURCE * HINDSIGHT_RECALL_SOURCE_COUNT,
+    ).toBeGreaterThanOrEqual(HINDSIGHT_DEFAULT_RERANKER_MAX_CANDIDATES);
+  });
+
+  it("bounds the graph timeout below the client's per-bank recall timeout", () => {
+    // At upstream's 10s default the knob is dead code: the auto-recall client
+    // abandons the bank at 8s (vendor scripts/recall.py), so a graph stall
+    // kills the WHOLE recall — including the semantic and BM25 results that
+    // already returned — and writes no telemetry row. A bound strictly under
+    // the client timeout is what converts that into graceful degradation.
+    const PER_BANK_CLIENT_TIMEOUT_S = 8;
+    expect(HINDSIGHT_DEFAULT_LINK_EXPANSION_TIMEOUT_S).toBeLessThan(PER_BANK_CLIENT_TIMEOUT_S);
+  });
+
+  it("caps graph fan-out strictly below upstream's default", () => {
+    const UPSTREAM_DEFAULT = 200;
+    expect(HINDSIGHT_DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT).toBeLessThan(UPSTREAM_DEFAULT);
+    // ...and at or above the measured mean links-per-unit (16,604,592 links /
+    // 559,316 units = 29.7), so the cap only ever bites hub entities.
+    expect(HINDSIGHT_DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT).toBeGreaterThanOrEqual(30);
+  });
+});
+
+// ── the gate ──────────────────────────────────────────────────────────────
+describe("hindsightPerfEnv — capability gating", () => {
+  const keys = (caps: { gpu: boolean; localLlm: boolean }) =>
+    new Set(hindsightPerfEnv(caps).map(([k]) => k));
+
+  it("emits the ungated defaults on every host", () => {
+    // Spelled out, NOT derived from HINDSIGHT_PERF_DEFAULTS_UNGATED. Iterating
+    // the array under test makes the assertion vacuous: deleting an entry
+    // would delete the thing being checked and the test would still pass
+    // (verified — mutation M23 stayed green until this was written out).
+    const UNGATED = [
+      "HINDSIGHT_API_RECALL_MAX_CANDIDATES_PER_SOURCE",
+      "HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT",
+      "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT",
+      "HINDSIGHT_API_LLM_REASONING_EFFORT",
+    ];
+    expect(HINDSIGHT_PERF_DEFAULTS_UNGATED.map(([k]) => k)).toEqual(UNGATED);
+    for (const caps of [
+      { gpu: false, localLlm: false },
+      { gpu: true, localLlm: true },
+    ]) {
+      const got = keys(caps);
+      for (const k of UNGATED) {
+        expect(got, `${k} must be emitted for caps ${JSON.stringify(caps)}`).toContain(k);
+      }
+    }
+  });
+
+  it("declares exactly the gated knobs this PR ships, by name", () => {
+    // Same anti-vacuity discipline for the two gated groups: the GPU group
+    // must be FP16 and nothing else, and the local-LLM group must be the
+    // three concurrency caps and nothing else. Without this, quietly moving a
+    // knob between groups (or dropping one) passes every other test here.
+    expect(HINDSIGHT_PERF_DEFAULTS_GPU.map(([k]) => k)).toEqual([
+      "HINDSIGHT_API_RERANKER_LOCAL_FP16",
+    ]);
+    expect(HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM.map(([k]) => k)).toEqual([
+      "HINDSIGHT_API_LLM_MAX_CONCURRENT",
+      "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
+      "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT",
+    ]);
+  });
+
+  it("withholds FP16 reranking from a host with no GPU", () => {
+    // Upstream disables FP16 by default because "some CPUs lack native FP16
+    // support". Emitting it CPU-side is the regression the gate exists for.
+    const got = keys({ gpu: false, localLlm: true });
+    for (const [k] of HINDSIGHT_PERF_DEFAULTS_GPU) expect(got).not.toContain(k);
+  });
+
+  it("emits FP16 reranking only when the container can reach a GPU", () => {
+    const got = keys({ gpu: true, localLlm: false });
+    for (const [k, v] of HINDSIGHT_PERF_DEFAULTS_GPU) {
+      expect(got).toContain(k);
+      expect(new Map(hindsightPerfEnv({ gpu: true, localLlm: false })).get(k)).toBe(v);
+    }
+  });
+
+  it("withholds the LLM concurrency caps from a hosted endpoint", () => {
+    // Upstream's 32 is sized for a cloud provider. Throttling one to 4 is a
+    // pure throughput loss, so the absent-capability direction must be "leave
+    // upstream's default alone".
+    const got = keys({ gpu: true, localLlm: false });
+    for (const [k] of HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM) expect(got).not.toContain(k);
+  });
+
+  it("emits the LLM concurrency caps only for a self-hosted endpoint", () => {
+    const got = new Map(hindsightPerfEnv({ gpu: false, localLlm: true }));
+    expect(got.get("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toBe("4");
+    expect(got.get("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT")).toBe("1");
+    expect(got.get("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT")).toBe("1");
+  });
+
+  it("treats a non-boolean-true capability as NOT proven", () => {
+    // Mirrors hindsightGpuEnabled's `=== true` discipline: a coerced verdict
+    // (`"false"` is truthy) must not switch a group on.
+    for (const bogus of ["false", "true", 1, "yes", {}]) {
+      const caps = { gpu: bogus, localLlm: bogus } as unknown as {
+        gpu: boolean;
+        localLlm: boolean;
+      };
+      const got = keys(caps);
+      for (const [k] of [...HINDSIGHT_PERF_DEFAULTS_GPU, ...HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM]) {
+        expect(got, `capability ${JSON.stringify(bogus)} must not enable ${k}`).not.toContain(k);
+      }
+    }
+  });
+
+  it("never emits a managed key twice", () => {
+    const pairs = hindsightPerfEnv({ gpu: true, localLlm: true });
+    expect(new Set(pairs.map(([k]) => k)).size).toBe(pairs.length);
+  });
+});
+
+// ── operator override ─────────────────────────────────────────────────────
+describe("operator override wins", () => {
+  it("replaces a default rather than appending after it", () => {
+    const pairs = hindsightPerfEnv(
+      { gpu: true, localLlm: true },
+      new Map([["HINDSIGHT_API_LLM_MAX_CONCURRENT", "16"]]),
+    );
+    const hits = pairs.filter(([k]) => k === "HINDSIGHT_API_LLM_MAX_CONCURRENT");
+    // Exactly one, so the winner never depends on docker's argv last-wins.
+    expect(hits).toEqual([["HINDSIGHT_API_LLM_MAX_CONCURRENT", "16"]]);
+  });
+
+  it("still emits an override whose capability group is OFF", () => {
+    // The nasty case: an operator forces FP16 on a box whose GPU verdict is
+    // absent. Dropping it here would make "override" mean "override, unless".
+    const pairs = hindsightPerfEnv(
+      { gpu: false, localLlm: false },
+      new Map([["HINDSIGHT_API_RERANKER_LOCAL_FP16", "true"]]),
+    );
+    expect(new Map(pairs).get("HINDSIGHT_API_RERANKER_LOCAL_FP16")).toBe("true");
+  });
+
+  it("prefers switchroom.yaml over the process environment", () => {
+    const got = resolveHindsightPerfOverrides(
+      { HINDSIGHT_API_LLM_MAX_CONCURRENT: 8 },
+      { HINDSIGHT_API_LLM_MAX_CONCURRENT: "2" },
+    );
+    expect(got.get("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toBe("8");
+  });
+
+  it("honours a bare process-environment export", () => {
+    const got = resolveHindsightPerfOverrides(undefined, {
+      HINDSIGHT_API_LINK_EXPANSION_TIMEOUT: "5",
+    });
+    expect(got.get("HINDSIGHT_API_LINK_EXPANSION_TIMEOUT")).toBe("5");
+  });
+
+  it("ignores unmanaged keys from BOTH sources", () => {
+    // A blanket HINDSIGHT_API_* passthrough would let an operator's stale
+    // export collide with the port / retain-budget vars startHindsight derives.
+    const got = resolveHindsightPerfOverrides(
+      { HINDSIGHT_API_PORT: "9999", NOT_HINDSIGHT: "x" },
+      { HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS: "1" },
+    );
+    expect(got.size).toBe(0);
+  });
+
+  it("ignores an empty or whitespace-only value", () => {
+    const got = resolveHindsightPerfOverrides(
+      { HINDSIGHT_API_LLM_REASONING_EFFORT: "  " },
+      { HINDSIGHT_API_LINK_EXPANSION_TIMEOUT: "" },
+    );
+    expect(got.size).toBe(0);
+  });
+
+  it("covers every managed key and nothing else", () => {
+    const declared = new Set(
+      [
+        ...HINDSIGHT_PERF_DEFAULTS_UNGATED,
+        ...HINDSIGHT_PERF_DEFAULTS_GPU,
+        ...HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+      ].map(([k]) => k),
+    );
+    expect([...HINDSIGHT_PERF_ENV_KEYS].sort()).toEqual([...declared].sort());
+  });
+});
+
+// ── the self-hosted-endpoint probe ────────────────────────────────────────
+describe("isSelfHostedHttpUrl", () => {
+  it.each([
+    "http://127.0.0.1:4010",
+    "http://localhost:4010",
+    "http://[::1]:4010",
+    "http://10.1.2.3:8000",
+    "http://192.168.1.10:11434",
+    "http://172.16.0.5:4010",
+    "http://172.31.255.254:4010",
+    "http://169.254.10.1:4010",
+    "http://host.docker.internal:4010",
+    "http://ollama.local:11434",
+  ])("treats %s as self-hosted", (url) => {
+    expect(isSelfHostedHttpUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "https://api.openai.com/v1",
+    "https://openrouter.ai/api/v1",
+    "https://litellm.example.com",
+    // 172.15 and 172.32 bracket the RFC1918 /12 — the classic off-by-one.
+    "http://172.15.0.1:4010",
+    "http://172.32.0.1:4010",
+    // 11.x is NOT private, however much it looks like 10.x.
+    "http://11.0.0.1:4010",
+    "not a url",
+    "",
+  ])("treats %s as NOT self-hosted", (url) => {
+    expect(isSelfHostedHttpUrl(url)).toBe(false);
+  });
+});
+
+describe("isLoopbackHttpUrl — IPv6 bracket handling", () => {
+  it("recognises the bracketed IPv6 loopback form", () => {
+    // `new URL("http://[::1]:4010").hostname` is "[::1]", so the pre-existing
+    // `h === "::1"` comparison never fired: an IPv6-loopback LiteLLM base read
+    // as remote and hindsightNeedsHostNetwork() left hindsight on the bridge
+    // network, where 127.0.0.1:4010 is unreachable — the silent-retain outage.
+    expect(isLoopbackHttpUrl("http://[::1]:4010")).toBe(true);
+    expect(hindsightNeedsHostNetwork({ retain: { base_url: "http://[::1]:4010" } })).toBe(true);
+  });
+
+  it("does not treat a non-loopback IPv6 literal as loopback", () => {
+    expect(isLoopbackHttpUrl("http://[2001:db8::1]:4010")).toBe(false);
+  });
+});
+
+describe("hindsightLocalLlmEnabled", () => {
+  it("is FALSE with no LLM endpoint configured at all", () => {
+    // Fail-safe: unknown ⇒ upstream's 32 stands, no throughput regression.
+    expect(hindsightLocalLlmEnabled()).toBe(false);
+  });
+
+  it("is TRUE for this fleet's loopback LiteLLM", () => {
+    expect(hindsightLocalLlmEnabled(undefined, LOOPBACK_LITELLM)).toBe(true);
+  });
+
+  it("is FALSE for a hosted LiteLLM", () => {
+    expect(hindsightLocalLlmEnabled(undefined, CLOUD_LITELLM)).toBe(false);
+  });
+
+  it("is TRUE when any per-op base URL is self-hosted", () => {
+    expect(
+      hindsightLocalLlmEnabled(
+        { retain: { base_url: "http://192.168.1.50:11434/v1" } },
+        CLOUD_LITELLM,
+      ),
+    ).toBe(true);
+  });
+
+  it("honours an explicit override in both directions", () => {
+    expect(hindsightLocalLlmEnabled(undefined, LOOPBACK_LITELLM, false)).toBe(false);
+    expect(hindsightLocalLlmEnabled(undefined, CLOUD_LITELLM, true)).toBe(true);
+  });
+});
+
+// ── the launch paths ──────────────────────────────────────────────────────
+describe("startHindsight — performance defaults reach the container", () => {
+  it("emits every gated knob on a GPU host with a local LLM", () => {
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, true);
+    const env = runEnv(runArgs());
+    expect(env.get("HINDSIGHT_API_RERANKER_LOCAL_FP16")).toEqual(["true"]);
+    expect(env.get("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toEqual(["4"]);
+    expect(env.get("HINDSIGHT_API_RECALL_MAX_CANDIDATES_PER_SOURCE")).toEqual(["60"]);
+  });
+
+  it("emits NO GPU/local-LLM knob on a CPU host with a hosted endpoint", () => {
+    startHindsight(undefined, CLOUD_LITELLM, undefined, undefined, undefined, false);
+    const env = runEnv(runArgs());
+    expect(env.has("HINDSIGHT_API_RERANKER_LOCAL_FP16")).toBe(false);
+    expect(env.has("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toBe(false);
+    // ...while the ungated ones still land.
+    expect(env.get("HINDSIGHT_API_LINK_EXPANSION_TIMEOUT")).toEqual(["2"]);
+  });
+
+  it("does NOT emit HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER", () => {
+    // Deliberate omission. Upstream scopes it to "every pool connection of
+    // THIS process", and switchroom runs a single process (start-all.sh starts
+    // only hindsight-api; HINDSIGHT_API_WORKER_ENABLED defaults true = worker
+    // inside the API process). Setting it to 0 would serialise the recall path
+    // this PR is speeding up, not just background consolidation.
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, true);
+    expect(runEnv(runArgs()).has("HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER")).toBe(false);
+    expect(
+      composeEnv(
+        generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, true),
+      ).has("HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER"),
+    ).toBe(false);
+  });
+
+  it("leaves the reranker candidate budget at 150 (documented follow-up)", () => {
+    // src/setup/hindsight-reranker-budget.test.ts:111-118 records why cutting
+    // this needs an answer-quality A/B first. This PR must not move it.
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, true);
+    expect(runEnv(runArgs()).get("HINDSIGHT_API_RERANKER_MAX_CANDIDATES")).toEqual(["150"]);
+  });
+
+  it("emits an operator override once, with the operator's value", () => {
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, true, {
+      env: { HINDSIGHT_API_LLM_MAX_CONCURRENT: 12 },
+      processEnv: {},
+    });
+    expect(runEnv(runArgs()).get("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toEqual(["12"]);
+  });
+
+  it("never emits a managed key twice in the final argv", () => {
+    // Guards against a future edit that appends the perf block alongside a
+    // hard-coded literal elsewhere in envArgs — where docker's last-wins would
+    // decide the value silently.
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, true, {
+      env: { HINDSIGHT_API_LINK_EXPANSION_TIMEOUT: 3 },
+      processEnv: {},
+    });
+    const env = runEnv(runArgs());
+    for (const key of HINDSIGHT_PERF_ENV_KEYS) {
+      expect(env.get(key)?.length ?? 0, `${key} must appear at most once`).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("run ⇄ compose parity for the performance defaults", () => {
+  for (const gpu of [true, false]) {
+    for (const litellm of [LOOPBACK_LITELLM, CLOUD_LITELLM]) {
+      it(`agree for gpu=${gpu} litellm=${litellm.baseUrl}`, () => {
+        startHindsight(undefined, litellm, undefined, undefined, undefined, gpu);
+        const fromRun = runEnv(runArgs());
+        const fromCompose = composeEnv(
+          generateHindsightComposeSnippet(undefined, undefined, litellm, gpu),
+        );
+        // Compare the OUTCOME of both generators, key by key, for every knob
+        // this module manages — not merely that both called the resolver.
+        for (const key of HINDSIGHT_PERF_ENV_KEYS) {
+          expect(fromCompose.get(key) ?? null, `${key} must match across paths`).toEqual(
+            fromRun.get(key) ?? null,
+          );
+        }
+        // ...and at least one gated knob genuinely differs across the matrix,
+        // so a resolver that returned {} for everything wouldn't pass.
+        expect(fromRun.has("HINDSIGHT_API_RERANKER_LOCAL_FP16")).toBe(gpu);
+        expect(fromRun.has("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toBe(
+          litellm === LOOPBACK_LITELLM,
+        );
+      });
+    }
+  }
+
+  it("both paths derive from hindsightPerfEnvPairs for the same inputs", () => {
+    const expected = new Map(hindsightPerfEnvPairs(undefined, LOOPBACK_LITELLM, true));
+    startHindsight(undefined, LOOPBACK_LITELLM, undefined, undefined, undefined, true);
+    const fromRun = runEnv(runArgs());
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(undefined, undefined, LOOPBACK_LITELLM, true),
+    );
+    expect(expected.size).toBeGreaterThan(0);
+    for (const [key, value] of expected) {
+      expect(fromRun.get(key)).toEqual([value]);
+      expect(fromCompose.get(key)).toEqual([value]);
+    }
+  });
+});

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -33,6 +33,7 @@ import {
   HINDSIGHT_DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT,
   HINDSIGHT_DEFAULT_LINK_EXPANSION_TIMEOUT_S,
   HINDSIGHT_DEFAULT_RECALL_MAX_CANDIDATES_PER_SOURCE,
+  HINDSIGHT_DEFAULT_RETAIN_LLM_MAX_CONCURRENT,
   HINDSIGHT_PERF_DEFAULTS_GPU,
   HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
   HINDSIGHT_PERF_DEFAULTS_UNGATED,
@@ -558,6 +559,17 @@ describe("run ⇄ compose parity for the performance defaults", () => {
         }
         // Parity alone is symmetric — two paths that BOTH dropped `perf` would
         // still agree. Pin the operator's values on the compose side directly.
+        // Guard first: the pins below only prove the override travelled if the
+        // override value DIFFERS from the default it replaces. Should either
+        // default ever drift onto the override literal, the pin would pass
+        // against a generator that ignored `perf` entirely — so fail loudly
+        // here instead of going quietly vacuous (same guard as mutation M28).
+        expect(String(HINDSIGHT_DEFAULT_LINK_EXPANSION_TIMEOUT_S)).not.toBe(
+          String(OPERATOR_PERF.env.HINDSIGHT_API_LINK_EXPANSION_TIMEOUT),
+        );
+        expect(String(HINDSIGHT_DEFAULT_RETAIN_LLM_MAX_CONCURRENT)).not.toBe(
+          String(OPERATOR_PERF.env.HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT),
+        );
         expect(fromCompose.get("HINDSIGHT_API_LINK_EXPANSION_TIMEOUT")).toEqual(["7"]);
         expect(fromCompose.get("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT")).toEqual(["3"]);
         // ...and at least one gated knob genuinely differs across the matrix,

--- a/src/setup/hindsight-perf-defaults.test.ts
+++ b/src/setup/hindsight-perf-defaults.test.ts
@@ -139,7 +139,10 @@ describe("per-source candidate cap derivation", () => {
     // abandons the bank at 8s (vendor scripts/recall.py), so a graph stall
     // kills the WHOLE recall — including the semantic and BM25 results that
     // already returned — and writes no telemetry row. A bound strictly under
-    // the client timeout is what converts that into graceful degradation.
+    // the client timeout is what lets the engine shed the stalling stage
+    // before the client walks away. It is NOT a ceiling on recall: the knob
+    // wraps only the entity-expansion query, and its fallback is untimed —
+    // see the constant's doc comment for what the engine actually does.
     const PER_BANK_CLIENT_TIMEOUT_S = 8;
     expect(HINDSIGHT_DEFAULT_LINK_EXPANSION_TIMEOUT_S).toBeLessThan(PER_BANK_CLIENT_TIMEOUT_S);
   });
@@ -302,15 +305,23 @@ describe("operator override wins", () => {
     expect(got.size).toBe(0);
   });
 
-  it("covers every managed key and nothing else", () => {
-    const declared = new Set(
-      [
-        ...HINDSIGHT_PERF_DEFAULTS_UNGATED,
-        ...HINDSIGHT_PERF_DEFAULTS_GPU,
-        ...HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
-      ].map(([k]) => k),
-    );
-    expect([...HINDSIGHT_PERF_ENV_KEYS].sort()).toEqual([...declared].sort());
+  it("is overridable on exactly these eight keys, by name", () => {
+    // Spelled out, NOT derived from the three group arrays. HINDSIGHT_PERF_ENV_KEYS
+    // is DEFINED as the union of those arrays, so asserting it equals that union
+    // is a tautology — it passes no matter which keys are in the arrays. The
+    // override surface is a documented contract (src/config/schema.ts's
+    // `hindsight.env` description names these keys), so pin the literal list:
+    // adding or dropping a managed key must fail here and force the doc update.
+    expect([...HINDSIGHT_PERF_ENV_KEYS].sort()).toEqual([
+      "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT",
+      "HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT",
+      "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT",
+      "HINDSIGHT_API_LLM_MAX_CONCURRENT",
+      "HINDSIGHT_API_LLM_REASONING_EFFORT",
+      "HINDSIGHT_API_RECALL_MAX_CANDIDATES_PER_SOURCE",
+      "HINDSIGHT_API_RERANKER_LOCAL_FP16",
+      "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
+    ]);
   });
 });
 
@@ -320,6 +331,13 @@ describe("isSelfHostedHttpUrl", () => {
     "http://127.0.0.1:4010",
     "http://localhost:4010",
     "http://[::1]:4010",
+    // IPv6 unique-local (fc00::/7) and link-local (fe80::/10) literals — the
+    // two regexes in isSelfHostedHttpUrl. Without these cases both regexes can
+    // be deleted with the whole suite still green (mutation M1).
+    "http://[fd00::1]:4010",
+    "http://[fc00:abcd::5]:4010",
+    "http://[fe80::1]:4010",
+    "http://[feba::1]:4010",
     "http://10.1.2.3:8000",
     "http://192.168.1.10:11434",
     "http://172.16.0.5:4010",
@@ -340,6 +358,11 @@ describe("isSelfHostedHttpUrl", () => {
     "http://172.32.0.1:4010",
     // 11.x is NOT private, however much it looks like 10.x.
     "http://11.0.0.1:4010",
+    // Bracket the two IPv6 ranges the same way: fb00 is one nibble below
+    // fc00::/7, and fec0::/10 (deprecated site-local) is outside fe80::/10.
+    "http://[fb00::1]:4010",
+    "http://[fec0::1]:4010",
+    "http://[2001:db8::1]:4010",
     "not a url",
     "",
   ])("treats %s as NOT self-hosted", (url) => {
@@ -449,20 +472,82 @@ describe("startHindsight — performance defaults reach the container", () => {
       processEnv: {},
     });
     const env = runEnv(runArgs());
+    // The value FIRST: "at most once" alone cannot tell "emitted once with the
+    // operator's 3" from "silently dropped", so a resolver that ignored
+    // overrides for the ungated group passed this test (mutation M28).
+    expect(env.get("HINDSIGHT_API_LINK_EXPANSION_TIMEOUT")).toEqual(["3"]);
+    expect(String(HINDSIGHT_DEFAULT_LINK_EXPANSION_TIMEOUT_S)).not.toBe("3");
     for (const key of HINDSIGHT_PERF_ENV_KEYS) {
       expect(env.get(key)?.length ?? 0, `${key} must appear at most once`).toBeLessThanOrEqual(1);
     }
   });
+
+  it("reads a self-hosted per-op LLM base URL when there is no litellm block", () => {
+    // The `llm` argument's wiring into hindsightLocalLlmEnabled. Every other
+    // launch-path case configures the endpoint through `litellm`, so dropping
+    // `llm` from hindsightPerfEnvPairs left the suite green (mutation M29).
+    // Here `llm` carries the ONLY base URL and it is LAN-private, so the
+    // local-LLM group must switch on from that argument alone.
+    const llm = { retain: { base_url: "http://192.168.1.50:11434" } };
+    startHindsight(undefined, undefined, undefined, llm, undefined, false);
+    const fromRun = runEnv(runArgs());
+    expect(fromRun.get("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toEqual(["4"]);
+    expect(fromRun.get("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT")).toEqual(["1"]);
+    expect(fromRun.get("HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT")).toEqual(["1"]);
+    // ...and the compose twin reads the same argument the same way.
+    const fromCompose = composeEnv(
+      generateHindsightComposeSnippet(llm, undefined, undefined, false),
+    );
+    expect(fromCompose.get("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toEqual(["4"]);
+  });
+
+  it("leaves the LLM concurrency caps alone when the only per-op base URL is cloud", () => {
+    // The control for the case above: same argument position, hosted URL, so a
+    // predicate that just returned `true` whenever `llm` was present would fail.
+    startHindsight(
+      undefined,
+      undefined,
+      undefined,
+      { retain: { base_url: "https://api.openai.com/v1" } },
+      undefined,
+      false,
+    );
+    expect(runEnv(runArgs()).has("HINDSIGHT_API_LLM_MAX_CONCURRENT")).toBe(false);
+  });
 });
 
 describe("run ⇄ compose parity for the performance defaults", () => {
+  /**
+   * An operator override carried through EVERY parity cell.
+   *
+   * Without it both generators were called with `perf` undefined, so the
+   * compose path could ignore its `perf` argument entirely and still agree
+   * with the run path (mutation M17 — dropping `perf` from the
+   * hindsightPerfEnvPairs call inside generateHindsightComposeSnippet left the
+   * suite green). Two keys on purpose:
+   *   • LINK_EXPANSION_TIMEOUT is ungated, so it exercises the REPLACE path in
+   *     every cell.
+   *   • RETAIN_LLM_MAX_CONCURRENT is in the local-LLM group, so with
+   *     CLOUD_LITELLM it exercises the "group OFF, override still emitted"
+   *     append path across both generators too.
+   * Neither key is one of the two the matrix assertions below probe, so the
+   * gated-knob divergence check is unaffected.
+   */
+  const OPERATOR_PERF = {
+    env: {
+      HINDSIGHT_API_LINK_EXPANSION_TIMEOUT: 7,
+      HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT: 3,
+    },
+    processEnv: {},
+  };
+
   for (const gpu of [true, false]) {
     for (const litellm of [LOOPBACK_LITELLM, CLOUD_LITELLM]) {
       it(`agree for gpu=${gpu} litellm=${litellm.baseUrl}`, () => {
-        startHindsight(undefined, litellm, undefined, undefined, undefined, gpu);
+        startHindsight(undefined, litellm, undefined, undefined, undefined, gpu, OPERATOR_PERF);
         const fromRun = runEnv(runArgs());
         const fromCompose = composeEnv(
-          generateHindsightComposeSnippet(undefined, undefined, litellm, gpu),
+          generateHindsightComposeSnippet(undefined, undefined, litellm, gpu, OPERATOR_PERF),
         );
         // Compare the OUTCOME of both generators, key by key, for every knob
         // this module manages — not merely that both called the resolver.
@@ -471,6 +556,10 @@ describe("run ⇄ compose parity for the performance defaults", () => {
             fromRun.get(key) ?? null,
           );
         }
+        // Parity alone is symmetric — two paths that BOTH dropped `perf` would
+        // still agree. Pin the operator's values on the compose side directly.
+        expect(fromCompose.get("HINDSIGHT_API_LINK_EXPANSION_TIMEOUT")).toEqual(["7"]);
+        expect(fromCompose.get("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT")).toEqual(["3"]);
         // ...and at least one gated knob genuinely differs across the matrix,
         // so a resolver that returned {} for everything wouldn't pass.
         expect(fromRun.has("HINDSIGHT_API_RERANKER_LOCAL_FP16")).toBe(gpu);

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -1,0 +1,328 @@
+/**
+ * Capability-gated Hindsight performance defaults.
+ *
+ * ## Why this file exists
+ *
+ * Upstream Hindsight publishes 100–600ms recall and 800–3000ms reflect. The
+ * 2026-07-26 fleet measurement on this host class found **recall p90 5.83s**
+ * and **reflect p90 122s** — 10–58x off. Several of upstream's own documented
+ * knobs are left at defaults that are actively wrong for a single-host,
+ * one-local-GPU, 12GB-bank deployment. This module makes the right values the
+ * out-of-the-box defaults, so a fresh `switchroom memory setup` lands close to
+ * upstream's published numbers without operator tuning.
+ *
+ * Measured evidence behind the specific values (2026-07-26, live fleet):
+ *
+ *   • `memory_links` 16,604,592 rows / 7,242 MB; `memory_units` 559,316 rows /
+ *     3,443 MB; DB total 12 GB. Mean links-per-unit ≈ 29.7.
+ *   • graph/link_expansion p50 0.024s vs p90 1.412s — a bimodal hot/cold page
+ *     distribution, i.e. I/O bound rather than algorithmic. Upstream's
+ *     documented target for this stage is <100ms.
+ *   • rerank ≈ 3.98s of the 5.83s recall p90, on CPU.
+ *   • 99.7% of recall load is background consolidation (8,800 of 8,830 calls
+ *     in 24h) — so bounding background work protects interactive latency.
+ *
+ * ## Two rules this module exists to enforce
+ *
+ * 1. **Every default falls back safely.** A knob whose benefit depends on a
+ *    host capability is emitted ONLY when the persisted capability verdict
+ *    proves that capability. A box with no GPU, or one pointed at a hosted
+ *    LLM, gets upstream's default — never a value tuned for hardware it does
+ *    not have. The gating shape deliberately mirrors {@link
+ *    import("./hindsight.js").hindsightGpuEnabled} (src/setup/hindsight.ts):
+ *    one predicate, both launch paths, `=== true` comparisons, absent verdict
+ *    ⇒ off. There is exactly one gating mechanism in this codebase.
+ *
+ * 2. **An operator override always wins.** If a key is set in
+ *    `hindsight.env` in switchroom.yaml, or exported in switchroom's own
+ *    environment, that value is emitted and our default is suppressed. This
+ *    is scoped to {@link HINDSIGHT_PERF_ENV_KEYS} on purpose — a blanket
+ *    `HINDSIGHT_API_*` passthrough would collide with the vars
+ *    `startHindsight()` derives itself (`HINDSIGHT_API_PORT`, the retain
+ *    budget), which is a worse failure than a missing override.
+ *
+ * ## Not shipped here, and why
+ *
+ * `HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER=0` was proposed for the
+ * background worker. It is NOT emitted: upstream scopes it to "every pool
+ * connection of **this process**" (configuration reference), and switchroom's
+ * container runs a SINGLE process — `/app/start-all.sh` starts only
+ * `hindsight-api`, and `HINDSIGHT_API_WORKER_ENABLED` defaults to `true`
+ * ("Enable internal worker in API process"), so consolidation shares the API's
+ * connection pool. Setting it to 0 here would serialise the latency-sensitive
+ * recall path — including the exact `link_expansion` scan this PR is trying to
+ * speed up — rather than only the background work. It needs a separate
+ * worker process first; see the PR body.
+ *
+ * `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` is deliberately untouched (150).
+ * The rejection rationale is recorded at
+ * src/setup/hindsight-reranker-budget.test.ts:111-118.
+ */
+
+/**
+ * Host capabilities that gate a performance default.
+ *
+ * Both fields are plain booleans resolved by the caller from the persisted
+ * host-capabilities verdict / the effective LLM config — this module never
+ * probes anything itself, so it stays pure and trivially testable.
+ */
+export interface HindsightPerfCapabilities {
+  /**
+   * The container can actually reach a GPU — i.e. `hindsightGpuEnabled()`.
+   * Gates FP16 reranking (see {@link HINDSIGHT_PERF_DEFAULTS_GPU}).
+   */
+  gpu: boolean;
+  /**
+   * The LLM endpoint is on this host or this LAN, i.e. a finite fixed slot
+   * pool rather than a cloud provider that absorbs dozens of parallel
+   * requests. Gates the LLM concurrency caps
+   * (see {@link HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM}).
+   */
+  localLlm: boolean;
+}
+
+/**
+ * Reranker candidate budget this module derives its per-source cap from.
+ *
+ * Imported as a literal rather than from `hindsight.ts` to keep this module
+ * free of a cycle (`hindsight.ts` imports THIS file). The two are pinned
+ * equal by a test, so they cannot drift.
+ */
+export const HINDSIGHT_RERANKER_MAX_CANDIDATES_FOR_DERIVATION = 150;
+
+/**
+ * Retrieval sources whose candidates are fused by RRF before reranking:
+ * semantic, BM25, graph, temporal (upstream configuration reference,
+ * `HINDSIGHT_API_RECALL_MAX_CANDIDATES_PER_SOURCE`).
+ */
+export const HINDSIGHT_RECALL_SOURCE_COUNT = 4;
+
+/**
+ * Per-source candidate cap (upstream default `0` = uncapped).
+ *
+ * Upstream states this knob's purpose verbatim: "Prevents one over-expanding
+ * backend from filling the reranker budget on its own." That is precisely our
+ * symptom — the graph source expands over 16.6M links and crowds the RRF pool,
+ * and reranking is 3.98s of a 5.83s p90.
+ *
+ * Derived, not picked: 40% of the reranker budget. That satisfies BOTH halves
+ * of the invariant the knob exists for —
+ *
+ *   • one source alone can no longer fill the reranker budget
+ *     (`perSource < rerankerMax`), and
+ *   • the four sources together can still fill it, so the cap costs no
+ *     recall quality when the pool is healthy
+ *     (`perSource * sources >= rerankerMax`).
+ *
+ * Both are asserted in hindsight-perf-defaults.test.ts; raising the reranker
+ * budget moves this automatically.
+ */
+export const HINDSIGHT_DEFAULT_RECALL_MAX_CANDIDATES_PER_SOURCE = Math.ceil(
+  HINDSIGHT_RERANKER_MAX_CANDIDATES_FOR_DERIVATION * 0.4,
+);
+
+/**
+ * Per-entity graph fan-out cap (upstream default `200`).
+ *
+ * The LATERAL fan-out is unbounded in practice at 200 against 16.6M links:
+ * the mean is 29.7 links per unit, so 200 only ever binds on hub entities —
+ * exactly the entities that produce the cold-page p90 (0.024s p50 vs 1.412s
+ * p90 is an I/O distribution, not an algorithmic one). 50 is ~1.7x the
+ * measured mean: typical entities expand whole, hub entities stop at 4x less
+ * work than before.
+ */
+export const HINDSIGHT_DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT = 50;
+
+/**
+ * Per-entity graph expansion timeout in seconds (upstream default `10`).
+ *
+ * At 10s this is not a guard at all: the auto-recall client gives up on a bank
+ * long before it fires (`vendor/hindsight-memory/scripts/recall.py` passes an
+ * 8s per-bank socket timeout, itself inside a 10s shared fan-out deadline
+ * inside a 12s hook ceiling — see hindsight-reranker-budget.test.ts). So a
+ * graph stall today kills the WHOLE recall, losing the semantic and BM25
+ * results that had already returned, and leaves no telemetry row.
+ *
+ * A bound BELOW the client's per-bank timeout inverts that: the graph source
+ * degrades, recall still returns with the other three sources, and the turn
+ * keeps its memories. 2s is 20x upstream's documented <100ms target for this
+ * stage and above the measured 1.412s p90, so it should not fire on a healthy
+ * query at all — it only converts a tail stall into graceful degradation.
+ */
+export const HINDSIGHT_DEFAULT_LINK_EXPANSION_TIMEOUT_S = 2;
+
+/**
+ * Reasoning effort for internal LLM ops (upstream default is ALSO `low`).
+ *
+ * Pinned rather than inherited. Upstream's low-resource guide says extra
+ * reasoning tokens are "pure latency for the extraction and consolidation
+ * paths", and reflect p90 is 122s here — but the value is already upstream's
+ * default, so this pin buys no behaviour change today. It exists so an
+ * upstream default flip cannot silently add reasoning latency to every retain
+ * and consolidation call on this fleet, and so the value is legible in
+ * `docker inspect`. Deliberately NOT presented as a speed-up.
+ */
+export const HINDSIGHT_DEFAULT_LLM_REASONING_EFFORT = "low";
+
+/**
+ * Global LLM concurrency when the endpoint is local (upstream default `32`).
+ *
+ * Upstream's top low-resource warning: a default of 32 "assumes a cloud
+ * provider that can absorb dozens of parallel requests. A local server with a
+ * handful of slots cannot — Hindsight will fill every slot and **starve any
+ * other client sharing the endpoint**." This fleet is one RTX 5070 Ti behind
+ * LiteLLM, shared with every agent. 4/1/1 is upstream's own worked example for
+ * a shared endpoint ("global=4, with retain/consolidation capped low so
+ * reflect always has headroom"), and it matches our load shape: 99.7% of
+ * recall traffic is background consolidation, which must never crowd out an
+ * interactive reflect.
+ */
+export const HINDSIGHT_DEFAULT_LLM_MAX_CONCURRENT = 4;
+export const HINDSIGHT_DEFAULT_RETAIN_LLM_MAX_CONCURRENT = 1;
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_MAX_CONCURRENT = 1;
+
+/**
+ * Half-precision local reranking. Upstream default `false`, and upstream is
+ * explicit about WHY: "27–36% faster on MPS; quality-identical. Disabled by
+ * default to avoid regressions on non-MPS deployments — **some CPUs lack
+ * native FP16 support**."
+ *
+ * The caveat is about hosts with no fast FP16 path, which is exactly what the
+ * GPU gate excludes. Note honestly that the published 27–36% is an MPS number;
+ * on CUDA FP16 is a well-established win but we have not measured it on this
+ * host class, so the gate is about SAFETY (never emit it CPU-side), not about
+ * promising that figure.
+ */
+export const HINDSIGHT_DEFAULT_RERANKER_LOCAL_FP16 = "true";
+
+/** Emitted on every host — bounded work, no hardware assumption. */
+export const HINDSIGHT_PERF_DEFAULTS_UNGATED: ReadonlyArray<readonly [string, string]> = [
+  [
+    "HINDSIGHT_API_RECALL_MAX_CANDIDATES_PER_SOURCE",
+    String(HINDSIGHT_DEFAULT_RECALL_MAX_CANDIDATES_PER_SOURCE),
+  ],
+  [
+    "HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT",
+    String(HINDSIGHT_DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT),
+  ],
+  [
+    "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT",
+    String(HINDSIGHT_DEFAULT_LINK_EXPANSION_TIMEOUT_S),
+  ],
+  ["HINDSIGHT_API_LLM_REASONING_EFFORT", HINDSIGHT_DEFAULT_LLM_REASONING_EFFORT],
+];
+
+/** Emitted only when the container can reach a GPU. */
+export const HINDSIGHT_PERF_DEFAULTS_GPU: ReadonlyArray<readonly [string, string]> = [
+  ["HINDSIGHT_API_RERANKER_LOCAL_FP16", HINDSIGHT_DEFAULT_RERANKER_LOCAL_FP16],
+];
+
+/** Emitted only when the LLM endpoint is local/self-hosted. */
+export const HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM: ReadonlyArray<readonly [string, string]> = [
+  ["HINDSIGHT_API_LLM_MAX_CONCURRENT", String(HINDSIGHT_DEFAULT_LLM_MAX_CONCURRENT)],
+  [
+    "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
+    String(HINDSIGHT_DEFAULT_RETAIN_LLM_MAX_CONCURRENT),
+  ],
+  [
+    "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT",
+    String(HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_MAX_CONCURRENT),
+  ],
+];
+
+/**
+ * Every key this module manages — and therefore the exact set an operator may
+ * override through `hindsight.env` / the process environment.
+ *
+ * Scoped on purpose: see the "operator override always wins" note at the top
+ * of this file for why a blanket `HINDSIGHT_API_*` passthrough is worse.
+ */
+export const HINDSIGHT_PERF_ENV_KEYS: ReadonlySet<string> = new Set(
+  [
+    ...HINDSIGHT_PERF_DEFAULTS_UNGATED,
+    ...HINDSIGHT_PERF_DEFAULTS_GPU,
+    ...HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM,
+  ].map(([k]) => k),
+);
+
+/**
+ * Resolve the operator's overrides for the managed keys.
+ *
+ * Precedence, highest first:
+ *   1. `hindsight.env` in switchroom.yaml (explicit, version-controlled)
+ *   2. switchroom's own process environment (an operator `export`)
+ *
+ * Keys outside {@link HINDSIGHT_PERF_ENV_KEYS} are ignored, as are empty /
+ * whitespace-only values (an empty env var is an accident, not an override —
+ * forwarding it would hand the container a value upstream's config parser
+ * rejects).
+ *
+ * @param configEnv `config.hindsight?.env`, if any.
+ * @param processEnv Injected for tests; defaults to `process.env`.
+ */
+export function resolveHindsightPerfOverrides(
+  configEnv?: Record<string, string | number | boolean> | undefined,
+  processEnv: NodeJS.ProcessEnv = process.env,
+): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const key of HINDSIGHT_PERF_ENV_KEYS) {
+    const fromProcess = processEnv[key];
+    if (typeof fromProcess === "string" && fromProcess.trim() !== "") {
+      out.set(key, fromProcess.trim());
+    }
+  }
+  for (const [key, raw] of Object.entries(configEnv ?? {})) {
+    if (!HINDSIGHT_PERF_ENV_KEYS.has(key)) continue;
+    const value = String(raw).trim();
+    if (value === "") continue;
+    out.set(key, value);
+  }
+  return out;
+}
+
+/**
+ * The performance env pairs to hand the hindsight container.
+ *
+ * Ordering is stable (ungated, then GPU, then local-LLM, each in declaration
+ * order) so the docker-run argv and the compose snippet are byte-comparable
+ * and a parity test can assert they agree.
+ *
+ * Every managed key appears at most once in the result — the override
+ * REPLACES the default rather than being appended after it, so there is never
+ * an `-e K=a -e K=b` pair whose winner depends on docker's argv semantics.
+ *
+ * @param caps Resolved host capabilities. Anything not proven ⇒ that group is
+ *   omitted entirely ⇒ the container keeps upstream's default.
+ * @param overrides Result of {@link resolveHindsightPerfOverrides}.
+ */
+export function hindsightPerfEnv(
+  caps: HindsightPerfCapabilities,
+  overrides: ReadonlyMap<string, string> = new Map(),
+): Array<[string, string]> {
+  const groups: ReadonlyArray<readonly [string, string]>[] = [
+    HINDSIGHT_PERF_DEFAULTS_UNGATED,
+  ];
+  if (caps.gpu === true) groups.push(HINDSIGHT_PERF_DEFAULTS_GPU);
+  if (caps.localLlm === true) groups.push(HINDSIGHT_PERF_DEFAULTS_LOCAL_LLM);
+
+  const out: Array<[string, string]> = [];
+  const emitted = new Set<string>();
+  for (const group of groups) {
+    for (const [key, value] of group) {
+      if (emitted.has(key)) continue;
+      emitted.add(key);
+      out.push([key, overrides.get(key) ?? value]);
+    }
+  }
+
+  // An operator override for a key whose capability group is OFF still has to
+  // reach the container — otherwise "operator override wins" would silently
+  // mean "operator override is dropped on a GPU-less box". Append those in
+  // key order for determinism.
+  for (const key of [...overrides.keys()].sort()) {
+    if (emitted.has(key)) continue;
+    emitted.add(key);
+    out.push([key, overrides.get(key)!]);
+  }
+  return out;
+}

--- a/src/setup/hindsight-perf-defaults.ts
+++ b/src/setup/hindsight-perf-defaults.ts
@@ -110,12 +110,32 @@ export const HINDSIGHT_RECALL_SOURCE_COUNT = 4;
  *
  *   • one source alone can no longer fill the reranker budget
  *     (`perSource < rerankerMax`), and
- *   • the four sources together can still fill it, so the cap costs no
- *     recall quality when the pool is healthy
- *     (`perSource * sources >= rerankerMax`).
+ *   • the four sources together can still fill it
+ *     (`perSource * sources >= rerankerMax`), so the cap costs little recall
+ *     quality when the pool is healthy.
  *
- * Both are asserted in hindsight-perf-defaults.test.ts; raising the reranker
- * budget moves this automatically.
+ * "Little", not "nothing", and the difference is worth being precise about.
+ * The engine applies the cap per source, after each arm's own sort and BEFORE
+ * fusion (memory_engine.py, `per_source_cap` / `cap_per_source` on the
+ * semantic, bm25, graph and temporal lists). So the second half proves the
+ * fused pool can still be FILLED to the reranker budget — not that the same
+ * items reach it. An item ranked, say, #80 in both the semantic and the BM25
+ * arm has strong RRF consensus today and would be dropped from both arms
+ * before fusion under a 60 cap, so consensus-but-mid-ranked items are the
+ * class this trades away. In practice that is small — final k is ~10, and the
+ * items that survive fusion are overwhelmingly top-of-arm — but it is a real
+ * trade, not a free one.
+ *
+ * Both halves are asserted in hindsight-perf-defaults.test.ts; raising the
+ * reranker budget moves this automatically.
+ *
+ * NOTE the anchor: 150 is SWITCHROOM's reranker budget, not upstream's.
+ * Upstream's `DEFAULT_RERANKER_MAX_CANDIDATES` is 300; the 150 here is a
+ * prior switchroom tightening (src/setup/hindsight.ts). The 40% ratio is
+ * therefore derived against a switchroom value and would want revisiting if
+ * switchroom ever moves back toward upstream's 300 — at which point 40%
+ * yields 120 per source, still satisfying both halves, but the absolute
+ * per-arm truncation point moves with it.
  */
 export const HINDSIGHT_DEFAULT_RECALL_MAX_CANDIDATES_PER_SOURCE = Math.ceil(
   HINDSIGHT_RERANKER_MAX_CANDIDATES_FOR_DERIVATION * 0.4,
@@ -143,11 +163,33 @@ export const HINDSIGHT_DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT = 50;
  * graph stall today kills the WHOLE recall, losing the semantic and BM25
  * results that had already returned, and leaves no telemetry row.
  *
- * A bound BELOW the client's per-bank timeout inverts that: the graph source
- * degrades, recall still returns with the other three sources, and the turn
- * keeps its memories. 2s is 20x upstream's documented <100ms target for this
- * stage and above the measured 1.412s p90, so it should not fire on a healthy
- * query at all — it only converts a tail stall into graceful degradation.
+ * A bound BELOW the client's per-bank timeout gives the engine a chance to
+ * shed the expensive part instead. Be precise about what it actually sheds —
+ * read from the engine source, `engine/search/link_expansion_retrieval.py`:
+ *
+ *   • The timeout wraps ONE query: the entity-expansion CTE inside
+ *     `_expand_combined` (`asyncio.wait_for(conn.fetch(full_query, ...),
+ *     timeout=config.link_expansion_timeout)`). On fire it degrades WITHIN the
+ *     graph source — it drops entity expansion and re-runs a semantic+causal
+ *     query — it does NOT drop the graph source in favour of the other three.
+ *   • That fallback `conn.fetch` carries NO timeout of its own. Neither does
+ *     the seed lookup (`_find_semantic_seeds`) that runs before it. So this
+ *     knob bounds one stage, not the graph source and certainly not recall.
+ *   • The whole block runs once per fact_type — three by default
+ *     (`world`, `experience`, `observation`), dispatched concurrently by
+ *     `retrieve_all_fact_types_parallel` via `asyncio.gather`. Concurrent, so
+ *     the waits overlap rather than summing to 6s; but each has its own
+ *     unbounded fallback afterwards, and they contend for the same pool.
+ *
+ * So this is NOT a 2s ceiling on recall, and nothing here makes the 8s client
+ * timeout unreachable. What it buys is real but narrower: the single stage
+ * most responsible for the cold-page tail stops being allowed to burn 10s per
+ * fact_type before it gives up, which leaves the rest of the pipeline enough
+ * of the client's 8s to return something.
+ *
+ * The value: 2s is 20x upstream's documented <100ms target for this stage and
+ * above the measured 1.412s p90, so it should not fire on a healthy query at
+ * all — it only bites the tail.
  */
 export const HINDSIGHT_DEFAULT_LINK_EXPANSION_TIMEOUT_S = 2;
 

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -8,6 +8,10 @@ import {
   clientBudgetSeconds,
 } from "../litellm/timeout-budget.js";
 import { loadHostCapabilities } from "./host-capabilities.js";
+import {
+  hindsightPerfEnv,
+  resolveHindsightPerfOverrides,
+} from "./hindsight-perf-defaults.js";
 
 /**
  * Default Hindsight host ports.
@@ -1133,7 +1137,12 @@ export function resolveHindsightLlm(
 export function isLoopbackHttpUrl(url: string): boolean {
   try {
     const u = new URL(url.includes("://") ? url : `http://${url}`);
-    const h = (u.hostname || "").toLowerCase();
+    // `new URL("http://[::1]:4010").hostname` is "[::1]" — WITH the brackets.
+    // Comparing the raw hostname against "::1" therefore never matched, so an
+    // IPv6-loopback LiteLLM base was silently classified as remote and
+    // hindsightNeedsHostNetwork() left the container on the bridge network
+    // (the silent-retain outage class). Strip the brackets first.
+    const h = (u.hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
     return h === "localhost" || h === "127.0.0.1" || h === "::1";
   } catch {
     return false;
@@ -1179,6 +1188,67 @@ export function hindsightNeedsHostNetwork(
 ): boolean {
   if (litellm?.baseUrl?.trim()) return true;
   return collectHindsightLlmBaseUrls(llm).some(isLoopbackHttpUrl);
+}
+
+/**
+ * True when `url` names an endpoint on this host or this LAN — loopback,
+ * RFC1918 private space, link-local, `.local` mDNS, or Docker's
+ * `host.docker.internal` bridge alias.
+ *
+ * This is the "finite slot pool" test, not the "reachable" test: what makes a
+ * self-hosted LLM different from a cloud provider is that it serves a handful
+ * of fixed slots, so filling them starves every other client on the box.
+ * A hostname that is not provably private reads as cloud — the fail-safe
+ * direction, since being wrong there just leaves upstream's default in place.
+ */
+export function isSelfHostedHttpUrl(url: string): boolean {
+  let host: string;
+  try {
+    const u = new URL(url.includes("://") ? url : `http://${url}`);
+    host = (u.hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
+  } catch {
+    return false;
+  }
+  if (!host) return false;
+  if (isLoopbackHttpUrl(url)) return true;
+  if (host === "host.docker.internal" || host === "gateway.docker.internal") return true;
+  if (host.endsWith(".local") || host.endsWith(".internal")) return true;
+  // IPv6 unique-local (fc00::/7) and link-local (fe80::/10).
+  if (/^f[cd][0-9a-f]{2}:/.test(host) || /^fe[89ab][0-9a-f]:/.test(host)) return true;
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!v4) return false;
+  const [a, b] = [Number(v4[1]), Number(v4[2])];
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 127) return true; // 127.0.0.0/8 (bare-IP form isLoopbackHttpUrl misses)
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local
+  return false;
+}
+
+/**
+ * Whether hindsight's LLM traffic terminates on a self-hosted endpoint.
+ *
+ * The capability gate for the LLM concurrency caps (see
+ * `hindsight-perf-defaults.ts`): upstream's default of 32 concurrent requests
+ * assumes a cloud provider, and on a local endpoint it starves every other
+ * client sharing the box. Reads the SAME inputs the launch paths already take,
+ * via {@link collectHindsightLlmBaseUrls}, so it can never disagree with the
+ * host-network / health-probe decisions made from those URLs.
+ *
+ * No configured base URL at all ⇒ `false` ⇒ upstream's default stands. That is
+ * the fail-safe reading: a hosted provider throttled to 4 would be a
+ * throughput regression for no reason.
+ *
+ * @param override Test/caller seam, mirroring `hindsightGpuEnabled(override?)`.
+ */
+export function hindsightLocalLlmEnabled(
+  llm?: HindsightLlmConfig,
+  litellm?: LiteLLMHindsightConfig,
+  override?: boolean,
+): boolean {
+  if (override !== undefined) return override;
+  return collectHindsightLlmBaseUrls(llm, litellm).some(isSelfHostedHttpUrl);
 }
 
 /**
@@ -1274,6 +1344,53 @@ export function hindsightGpuEnabled(override?: boolean): boolean {
   return caps?.voice?.gpuPresent === true && caps?.voice?.containerToolkit === true;
 }
 
+/**
+ * Inputs for the capability-gated performance defaults, threaded through both
+ * launch paths as ONE trailing options object so the two generators keep
+ * identical shapes (the positional-parameter list is already long enough to
+ * make a silent argument-order mismatch between them plausible).
+ */
+export interface HindsightPerfOptions {
+  /**
+   * The operator's `hindsight.env` block from switchroom.yaml. Any key in
+   * `HINDSIGHT_PERF_ENV_KEYS` set here REPLACES switchroom's default for that
+   * key; other keys are ignored (see hindsight-perf-defaults.ts).
+   */
+  env?: Record<string, string | number | boolean>;
+  /**
+   * Local-LLM verdict override. Omit in production —
+   * {@link hindsightLocalLlmEnabled} derives it from the configured LLM base
+   * URLs. Tests pass an explicit boolean.
+   */
+  localLlm?: boolean;
+  /** Process-environment seam for tests; defaults to `process.env`. */
+  processEnv?: NodeJS.ProcessEnv;
+}
+
+/**
+ * The single derivation of the performance env pairs, shared by
+ * {@link startHindsight} and {@link generateHindsightComposeSnippet}.
+ *
+ * Exists so the two launch paths cannot drift: exactly like
+ * {@link hindsightGpuEnabled}, there is ONE place that decides, and both
+ * consumers route through it. The run ⇄ compose parity test asserts the
+ * outcome of both generators for the same inputs, not just that both call it.
+ */
+export function hindsightPerfEnvPairs(
+  llm?: HindsightLlmConfig,
+  litellm?: LiteLLMHindsightConfig,
+  gpu?: boolean,
+  perf?: HindsightPerfOptions,
+): Array<[string, string]> {
+  return hindsightPerfEnv(
+    {
+      gpu: hindsightGpuEnabled(gpu),
+      localLlm: hindsightLocalLlmEnabled(llm, litellm, perf?.localLlm),
+    },
+    resolveHindsightPerfOverrides(perf?.env, perf?.processEnv),
+  );
+}
+
 export function startHindsight(
   ports?: { apiPort: number; uiPort: number },
   litellm?: LiteLLMHindsightConfig,
@@ -1294,6 +1411,11 @@ export function startHindsight(
    * boolean so the suite never depends on the runner having (or lacking) a GPU.
    */
   gpu?: boolean,
+  /**
+   * Capability-gated performance defaults + the operator's `hindsight.env`
+   * overrides. See {@link HindsightPerfOptions}.
+   */
+  perf?: HindsightPerfOptions,
 ): void {
   const apiPort = ports?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT;
   const uiPort = ports?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT;
@@ -1353,6 +1475,13 @@ export function startHindsight(
     // `docker inspect` and survives operators who wrap start without the
     // entrypoint default.
     "-e", `HINDSIGHT_API_WORKER_ID=${HINDSIGHT_DEFAULT_WORKER_ID}`,
+    // Capability-gated performance defaults (recall p90 5.83s / reflect p90
+    // 122s vs upstream's published 100-600ms / 800-3000ms). Emitted through
+    // ONE resolver shared with the compose path; every gated group is omitted
+    // on a host that cannot prove the capability, and an operator value in
+    // `hindsight.env` replaces the default rather than being appended after
+    // it. See src/setup/hindsight-perf-defaults.ts.
+    ...hindsightPerfEnvPairs(llm, litellm, gpu, perf).flatMap(([k, v]) => ["-e", `${k}=${v}`]),
   ];
 
   // The `claude-code` provider drives an underlying claude subprocess; pin
@@ -1770,6 +1899,11 @@ export function generateHindsightComposeSnippet(
    * host-capabilities verdict.
    */
   gpu?: boolean,
+  /**
+   * Capability-gated performance defaults + operator `hindsight.env`
+   * overrides, mirroring {@link startHindsight}'s `perf` param.
+   */
+  perf?: HindsightPerfOptions,
 ): string {
   const { provider: llmProvider, model: llmModel } = resolveHindsightLlm(llm, litellm);
   const perOpLlm = resolveHindsightPerOpLlm(llm);
@@ -1886,6 +2020,10 @@ export function generateHindsightComposeSnippet(
     `      - HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
     `      - HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,
     `      - HINDSIGHT_API_WORKER_ID=${HINDSIGHT_DEFAULT_WORKER_ID}`,
+    // Capability-gated performance defaults — the compose twin of the
+    // docker-run path's block, from the SAME resolver so the two can never
+    // disagree about which knobs a host gets (see hindsightPerfEnvPairs).
+    ...hindsightPerfEnvPairs(llm, litellm, gpu, perf).map(([k, v]) => `      - ${k}=${v}`),
     `    mem_limit: ${HINDSIGHT_DEFAULT_MEM_LIMIT}`,
     `    mem_reservation: ${HINDSIGHT_DEFAULT_MEM_RESERVATION}`,
     `    pids_limit: ${HINDSIGHT_DEFAULT_PIDS_LIMIT}`,


### PR DESCRIPTION
## Goal

**Recall p90 under 1s and reflect p90 under 10s on this class of host.**

Today: recall p90 **5.83s**, reflect p90 **122s**. Upstream publishes 100–600ms recall and 800–3000ms reflect — we are **10–58x off**.

This PR ships the subset of that gap switchroom can close *durably and safely*: capability-gated defaults in code, with tests, rather than a tuning doc someone has to remember.

## Evidence base

Measured on this host (not re-derived here):

| Signal | Value |
|---|---|
| `memory_links` | 16,604,592 rows / 7,242 MB |
| `memory_units` | 559,316 rows / 3,443 MB |
| DB total | 12 GB |
| embedded pg0 | `shared_buffers=256MB`, `effective_cache_size=1GB`, in an 8 GB container |
| `graph/link_expansion` | p50 **0.024s** vs p90 **1.412s** (upstream target <100ms) |
| rerank | ~3.98s of the 5.83s recall p90, on CPU |
| recall load mix | 99.7% background consolidation (8,800 of 8,830 calls / 24h) |

The p50/p90 spread is the tell: the work is **I/O bound, not algorithmic** — 12 GB of hot data against 256 MB of shared buffers, so the p90 is buffer misses.

## What ships

New `src/setup/hindsight-perf-defaults.ts` — pure, testable, no I/O:

**Ungated (every host)**
- `HINDSIGHT_API_RECALL_MAX_CANDIDATES_PER_SOURCE=60` — derived, not magic: `ceil(150 × 0.4)`, pinned to the real reranker budget constant so the two can't drift. Big enough that all four recall sources together can still fill the 150-candidate budget; small enough that no single source can monopolise it.
- `HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT=50` (upstream 200) — caps graph fan-out over a 16.6M-row link table.
- `HINDSIGHT_API_LINK_EXPANSION_TIMEOUT=2` (upstream 10) — must sit **below** the client's per-bank recall timeout, or a slow graph leg burns the whole recall budget instead of degrading.
- `HINDSIGHT_API_LLM_REASONING_EFFORT=low` — see corrections below; this is a defensive pin, not a change.

**Gated on GPU** (`hindsightGpuEnabled()` — the existing verdict, `gpuPresent === true && containerToolkit === true`)
- `HINDSIGHT_API_RERANKER_LOCAL_FP16=true`

**Gated on a self-hosted LLM endpoint** (new `hindsightLocalLlmEnabled()`)
- `HINDSIGHT_API_LLM_MAX_CONCURRENT=4` (upstream 32)
- `HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT=1`
- `HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT=1`

32-way concurrency is right for a cloud API and wrong for a local model server, where it just deepens the queue and inflates every latency percentile. Detection classifies the configured base URL: loopback (v4 + v6), `host.docker.internal`, `.local`/`.internal`, RFC1918, link-local, IPv6 ULA. **No configured endpoint ⇒ false** (fail-safe).

## Design

- **Existing gating mechanism, not a second one.** `hindsightGpuEnabled()` is reused as-is; `hindsightLocalLlmEnabled()` mirrors its shape (same override seam, same `=== true` discipline, same absent-verdict-means-off default).
- **One resolver, both launch paths.** `startHindsight()` (docker-run argv) and `generateHindsightComposeSnippet()` (compose YAML) both call `hindsightPerfEnvPairs()`, so they are in parity *by construction*. A test asserts the two emit the same key/value set.
- **Operator override wins.** New `hindsight.env` in `switchroom.yaml`, plus the process environment. `switchroom.yaml` outranks the environment; an override **replaces** the default rather than being appended after it (append-after would work in docker-run and *lose* in compose); and an override is emitted **even when its capability group is OFF**, so an operator can force FP16 on a host whose GPU we haven't proven.
- **Allowlisted, not passthrough.** Only the keys switchroom actually manages are honoured. A blanket `HINDSIGHT_API_*` passthrough would collide with the vars `startHindsight()` derives itself (`HINDSIGHT_API_PORT`, the retain token/deadline budget).

## Drive-by bug fix

`isLoopbackHttpUrl` was broken for IPv6. `new URL("http://[::1]:4010").hostname` is `"[::1]"` — **with** the brackets — so `h === "::1"` never matched. An IPv6-loopback LiteLLM base was therefore classified as *remote*, and `hindsightNeedsHostNetwork()` left the container on the bridge network: the silent-retain outage class. Fixed by stripping the brackets; two regression tests cover it.

## Deliberately NOT shipped

**`HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER=0` — rejected on evidence.** Upstream scopes it to "every pool connection of **this process**", to be set on *background-worker processes*. This container runs a **single** process: `/app/start-all.sh` starts only `hindsight-api`, `ps` confirms one python process, and `HINDSIGHT_API_WORKER_ENABLED` defaults to `true` ("Enable internal worker in API process"). Setting it to 0 here would serialise the **latency-sensitive recall path** — including the very `link_expansion` scan this PR speeds up — not just consolidation. A test asserts neither launch path emits it.

**`HINDSIGHT_API_RERANKER_MAX_CANDIDATES` stays at 150.** This is the deliberate CPU-era compromise with the rejection rationale documented at `src/setup/hindsight-reranker-budget.test.ts:111-118`. Revisiting it toward 300 is **follow-up work once GPU reranking is actually measured** — not something to change blind in the same PR that enables FP16. A test pins it at 150 so this PR can't drift it.

## The pg0 finding (investigated, not shipped)

The dispatch flagged `shared_buffers`/`effective_cache_size` as the single highest-leverage fix for the graph p90. It is. Here is where it actually lives:

- The `-c shared_buffers=256MB -c effective_cache_size=1GB` flags are **baked into the pg0 Rust binary's own defaults** (`/app/api/.venv/lib/python3.11/site-packages/pg0/bin/pg0`). hindsight_api passes no config at all — `memory_engine.py:2686-2692` constructs `EmbeddedPostgres(name, port)` only, and `hindsight_api/pg0.py` forwards a `config` argument only if one is given.
- Postgres argv `-c` **outranks both** `postgresql.conf` (still says `shared_buffers = 128MB`) and `postgresql.auto.conf` — so `ALTER SYSTEM SET` cannot fix this. That is why it looks immovable.
- **But a switchroom-side mechanism does exist.** pg0's CLI documents `-c KEY=VALUE` ("can be used multiple times"), and `EmbeddedPostgres.ensure_running()` short-circuits when pg0 is *already* running. So switchroom's own `docker/hindsight-entrypoint.sh` could pre-start pg0 with tuned flags, and hindsight_api would adopt the running instance.
- **Sizing.** The container is `--memory=8g` / `--shm-size=2g` (`HINDSIGHT_DEFAULT_MEM_LIMIT`, `HINDSIGHT_DEFAULT_SHM_SIZE`). That same 8 GB also hosts the API python process, the embedding + cross-encoder models, and the Next.js control plane. `shared_buffers` consumes POSIX shm, so raising it toward 1.5–2 GB requires raising `shm_size` (e.g. to 3g) **in lockstep** — raising one without the other fails at startup.

Not shipped here on purpose: it touches first-boot ordering and the data volume, and deserves its own change with its own tests rather than riding along on an env-var PR.

## Corrections to the stated evidence base

Two premises did not survive checking against the upstream docs:

1. **`HINDSIGHT_API_LLM_REASONING_EFFORT` already defaults to `low` upstream** — it was not unset. The tuning guide literally says "keep it low (the default)". Shipped anyway as an explicit defensive pin; it buys **no behaviour change today** and only stops a future upstream default flip from silently adding reasoning latency. Documented honestly as such rather than claimed as a win.
2. **`HINDSIGHT_API_RERANKER_LOCAL_FP16`'s published 27–36% speedup is MPS-specific.** The CUDA figure is unmeasured on this host class. The GPU gate is therefore justified as **safety** — never emit FP16 CPU-side, because some CPUs lack native FP16 support and it can be *slower* or unstable — not as a promise of that number.

## Testing

56 new tests. Scoped run: `vitest run src/setup/ tests/setup/hindsight.test.ts tests/memory.test.ts src/config/` → **31 files, 648 tests, all green**.

Every test was **mutation-verified**: 27 mutations, each breaking exactly one invariant, all **RED**, each caught by the test whose name claims that invariant. Baseline green before, green again after restore.

This campaign paid for itself immediately: **M23 (deleting an entry from `HINDSIGHT_PERF_DEFAULTS_UNGATED`) stayed GREEN** — the test claiming to pin the ungated set was iterating the very array under test, so it could not fail. Fixed by spelling the expected keys out literally and adding a test that pins both gated groups by name; M23/M24/M25 are now RED.

Selected mutations and the test that caught each:

| Mutation | Caught by |
|---|---|
| M1 un-gate FP16 | `withholds FP16 reranking from a host with no GPU` |
| M3 `=== true` → truthy | `treats a non-boolean-true capability as NOT proven` |
| M4 override appended instead of replacing | `replaces a default rather than appending after it` |
| M5 drop OFF-group overrides | `still emits an override whose capability group is OFF` |
| M6 invert yaml/env precedence | `prefers switchroom.yaml over the process environment` |
| M7 blanket `HINDSIGHT_API_*` passthrough | `ignores unmanaged keys from BOTH sources` |
| M10 derivation constant drift | `is pinned to the real reranker budget constant` |
| M11 graph timeout back to 10s | `bounds the graph timeout below the client's per-bank recall timeout` |
| M13/M14 remove compose/run emission | the run ⇄ compose parity tests |
| M15 ship the rejected DB knob | `does NOT emit HINDSIGHT_API_DB_MAX_PARALLEL_WORKERS_PER_GATHER` |
| M16/M17 RFC1918 boundary errors | the `isSelfHostedHttpUrl` table |
| M18 no-endpoint defaults to local | `is FALSE with no LLM endpoint configured at all` |
| M19 revert the IPv6 fix | both bracket regression tests |
| M20 reranker budget moved off 150 | `leaves the reranker candidate budget at 150` |
| M21 double-emit a managed key | `never emits a managed key twice in the final argv` |
| M23 drop an ungated default | `emits the ungated defaults on every host` (after the fix) |

`npm run lint` clean.

---

## Review round 2 — punch list cleared (3d20c3c)

Adversarial review returned MERGEABLE with no shipped-behaviour defects; everything below is test coverage and comment accuracy. The reviewer's own mutation pass found four survivors the original 27 missed. All four are now RED:

| Mutation | Was | Now caught by |
|---|---|---|
| **M17** `generateHindsightComposeSnippet` passes `undefined` for `perf` | 56/56 green — every parity case called the compose generator with 4 positional args, so `perf` was `undefined` on both sides and the divergence was invisible | the 4 parity cases now thread an operator override through BOTH generators and pin the operator's values on the compose side directly (parity alone is symmetric) |
| **M28** `hindsightPerfEnv` ignores overrides for the ungated group | 56/56 green — the test set `LINK_EXPANSION_TIMEOUT: 3` then asserted only `length <= 1`, which cannot tell "emitted with 3" from "dropped" | `never emits a managed key twice in the final argv` now asserts the value is `["3"]` first |
| **M1** delete the IPv6 ULA (`fc00::/7`) + link-local (`fe80::/10`) regexes | 56/56 green — the table covered `[::1]` but no `fd00::`/`fe80::` literal | four self-hosted cases (`fd00::1`, `fc00:abcd::5`, `fe80::1`, `feba::1`) plus `fb00::`/`fec0::` near-misses on the negative side |
| **M29** `hindsightPerfEnvPairs` drops its `llm` argument | 56/56 green — every launch-path case configured the endpoint via `litellm` | new launch-path case where `llm` carries the ONLY base URL (`192.168.1.50:11434`, no litellm block), with a cloud-URL control in the same argument position |

Also in this round:

- **A tautology removed.** `covers every managed key and nothing else` asserted `HINDSIGHT_PERF_ENV_KEYS` equals the union of the three group arrays — but it is *defined* as that union, so it passed for any contents. Replaced with the literal eight-key list, which is the contract the `hindsight.env` schema description documents.
- **`LINK_EXPANSION_TIMEOUT` rationale corrected** against the engine source. The old comment claimed a fire means "the graph source degrades, recall still returns with the other three sources". Verified in `engine/search/link_expansion_retrieval.py`: the timeout wraps exactly one query (the entity-expansion CTE in `_expand_combined`), and on fire it degrades *within* the graph source — dropping entity expansion, keeping semantic+causal. That fallback `conn.fetch` carries **no timeout**, nor does the preceding `_find_semantic_seeds`. And the block runs **once per `fact_type`** — three by default (`world`, `experience`, `observation`; `VALID_RECALL_FACT_TYPES`), dispatched concurrently by `retrieve_all_fact_types_parallel` via `asyncio.gather`, so the waits overlap rather than summing, but each has its own unbounded fallback. It is not a 2s ceiling on recall. **The value 2 is unchanged and still defensible** — only the rationale was wrong.
- **Per-source cap claim softened** from "costs no recall quality when the pool is healthy" to "costs little", with the actual trade stated. The engine applies the cap per source, post-sort, pre-fusion (`memory_engine.py`, `per_source_cap` → `cap_per_source`), so `perSource * sources >= rerankerMax` proves the fused pool can be *filled*, not that the same items survive: an item ranked ~#80 in both the semantic and BM25 arms has strong RRF consensus today and would be dropped from both arms before fusion under a 60 cap. Small in practice (final k ~10) but real.

### The 40% ratio is anchored to a switchroom value, not upstream's

Worth stating explicitly since it is easy to misread. Upstream's `DEFAULT_RERANKER_MAX_CANDIDATES` is **300** (verified in the running container's `hindsight_api/config.py`). The **150** this PR derives from is switchroom's own prior tightening (`src/setup/hindsight.ts`). So `ceil(150 x 0.4) = 60` is derived against a switchroom number: if switchroom ever moves back toward upstream's 300, 40% yields 120 per source — still satisfying both halves of the invariant, but the absolute per-arm truncation point moves with it. The pin test (`is pinned to the real reranker budget constant`) already ties the two together mechanically; this note makes the dependency explicit in prose. **No code change** — flagging the coupling only.

### Filed, not implemented

- #3704 — `hindsight.env` silently discards out-of-allowlist keys (`z.record` with no key validation). The scoping is correct; the silence is the problem.
- #3705 — an override cannot *unset* a default; `resolveHindsightPerfOverrides` treats empty/whitespace as "no override". Defensible, but undocumented in the schema description.
- #3706 — `effective_cache_size=1GB` against a 12GB database (deferred pg0 PR). A planner hint, not an allocation, so it needs no `shm_size` change — likely the cheapest remaining graph win.

Scoped vitest: 65/65 in `hindsight-perf-defaults.test.ts`, 286/286 across it plus `hindsight-reranker-budget.test.ts` and `tests/docker/compose-generator.test.ts`. `npm run lint` clean. Frozen constants untouched: `src/setup/hindsight.ts:343` still `150`, `vendor/hindsight-memory/scripts/recall.py:1706` still `timeout=8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

