### PR TITLE
fix(gateway): an inconclusive backstop read-back is not a delivery failure

### DIFF
--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -159,3 +159,36 @@ describe("scanAgent escalation decision", () => {
     expect(res.findings).toHaveLength(0);
   });
 });
+
+/**
+ * #3702 — a backstop delivery whose read-back probe was inconclusive is counted
+ * `complete` on the Bot API's ack alone. `landed_unconfirmed` on the turn row is
+ * the measurement of how often that bet is made; the scan surfaces the count so
+ * it is visible in the digest WITHOUT becoming a failure signal (escalating it
+ * would recreate the phantom `send_failed` cluster it exists to explain).
+ */
+describe("scanAgent landed_unconfirmed accounting (#3702)", () => {
+  it("counts turns whose delivery was never corroborated", () => {
+    const text = [
+      turn(1, {}), // ordinary row — field absent
+      turn(2, { landed_unconfirmed: 2 }),
+      turn(3, { landed_unconfirmed: 1 }),
+      turn(4, { landed_unconfirmed: 0 }), // explicitly zero ⇒ not counted
+    ].join("\n");
+    const res = scanAgent("alpha", text, "");
+    expect(res.landed_unconfirmed_turns).toBe(2);
+  });
+
+  it("is NOT a failure signal — it neither escalates nor emits a finding", () => {
+    const res = scanAgent("alpha", turn(1, { landed_unconfirmed: 3 }), "");
+    expect(res.landed_unconfirmed_turns).toBe(1);
+    expect(res.escalate).toBe(false);
+    expect(res.findings).toHaveLength(0);
+    expect(res.status_mix).toEqual({ complete: 1 });
+  });
+
+  it("is zero on a fleet that never made the bet", () => {
+    const res = scanAgent("alpha", turn(1, {}) + "\n" + turn(2, {}), "");
+    expect(res.landed_unconfirmed_turns).toBe(0);
+  });
+});

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -51,6 +51,13 @@ export interface TurnRecord {
   tools?: number;
   status?: string;
   turn_id?: string;
+  /** #3702 — landed backstop message ids the read-back probe never
+   *  corroborated (absent on an ordinary row). A `complete` turn carrying this
+   *  was called delivered on the Bot API's ack alone. Counted, NOT escalated:
+   *  it measures how often that bet is made, and is not itself a failure mode
+   *  (escalating it would recreate the phantom `send_failed` cluster the
+   *  counter exists to explain). */
+  landed_unconfirmed?: number;
 }
 
 /** The L0 failure-mode signals emitted from `turns.jsonl`. Kept as stable
@@ -103,6 +110,14 @@ export interface AgentScanResult {
   findings: Finding[];
   /** Raw gateway signature hit counts (for the digest / escalate decision). */
   gw_hits: Record<GatewaySignal, number>;
+  /** #3702 — how many of this agent's turns delivered at least one landed
+   *  message id the read-back probe never corroborated (`landed_unconfirmed >
+   *  0`). Reported in the digest so the fleet can watch the rate at which a
+   *  delivery is called `complete` on the Bot API's ack alone. Deliberately NOT
+   *  part of `escalate` and NOT a `Finding` — an inconclusive probe is not a
+   *  failure; it is the measurement that tells us if that assumption ever
+   *  breaks. */
+  landed_unconfirmed_turns: number;
   escalate: boolean;
 }
 
@@ -301,5 +316,17 @@ export function scanAgent(
     gw_hits["duplicate-delivery-represent"] > 0 ||
     gw_hits["reply-delivery-failure"] > 0;
 
-  return { agent, turns: turns.length, status_mix, findings, gw_hits, escalate };
+  const landed_unconfirmed_turns = turns.filter(
+    (t) => (t.landed_unconfirmed ?? 0) > 0,
+  ).length;
+
+  return {
+    agent,
+    turns: turns.length,
+    status_mix,
+    findings,
+    gw_hits,
+    landed_unconfirmed_turns,
+    escalate,
+  };
 }

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -112,8 +112,11 @@ export interface AgentScanResult {
   gw_hits: Record<GatewaySignal, number>;
   /** #3702 — how many of this agent's turns delivered at least one landed
    *  message id the read-back probe never corroborated (`landed_unconfirmed >
-   *  0`). Reported in the digest so the fleet can watch the rate at which a
-   *  delivery is called `complete` on the Bot API's ack alone. Deliberately NOT
+   *  0`). Available on the scan result for a future digest — no consumer reads
+   *  `ScanResult.perAgent` yet, so the durable per-turn `landed_unconfirmed`
+   *  field on `turns.jsonl` is currently the only way to watch the rate at
+   *  which a delivery is called `complete` on the Bot API's ack alone
+   *  (surfacing the aggregate is filed as follow-up). Deliberately NOT
    *  part of `escalate` and NOT a `Finding` — an inconclusive probe is not a
    *  failure; it is the measurement that tells us if that assumption ever
    *  breaks. */

--- a/telegram-plugin/gateway/backstop-delivery.ts
+++ b/telegram-plugin/gateway/backstop-delivery.ts
@@ -114,8 +114,10 @@ export class BackstopDeliveryLedger {
 
   /**
    * #3278 — transition a landed-unconfirmed chunk to `landed-confirmed` after a
-   * read-back probe proved the message exists in the chat. Only a confirmed
-   * chunk counts toward delivery / `complete`.
+   * read-back probe proved the message exists in the chat. Confirmation is the
+   * STRONGER of the two delivery states; the weaker `landed-unconfirmed` also
+   * counts as delivered (an inconclusive probe is not a failure — see
+   * `runBackstopDelivery`). Only a POSITIVE absence (`demoteChunk`) un-delivers.
    */
   confirmChunk(turnId: string, index: number): void {
     let set = this.confirmed.get(turnId)
@@ -164,8 +166,10 @@ export class BackstopDeliveryLedger {
     return true
   }
 
-  /** Landed message ids of CONFIRMED chunks only, in chunk-index order — the set
-   *  the delivery predicate counts (fresh non-card ids that are proven-present). */
+  /** Landed message ids of CONFIRMED chunks only, in chunk-index order — the
+   *  read-back view of the ledger (ids proven present in the chat). The delivery
+   *  predicate counts LANDED ids (`sentIds`), not these; this is the stronger
+   *  proven-present subset, kept as the natural pair to `hasConfirmedChunk`. */
   confirmedIds(turnId: string): number[] {
     const m = this.chunks.get(turnId)
     const set = this.confirmed.get(turnId)
@@ -226,9 +230,11 @@ export class BackstopDeliveryLedger {
  *                  `landed-confirmed` (counts toward delivery).
  *  - `absent`    — Telegram `400 message to edit not found` ⇒ positive absence
  *                  ⇒ demote to `unsent` (safe to re-send — it never landed).
- *  - `ambiguous` — 429 / 5xx / network / gate-shed / anything else ⇒ leave
- *                  `landed-unconfirmed`; NEVER re-send (a re-send would risk a
- *                  duplicate, and duplicate-risk beats missing-risk here).
+ *  - `ambiguous` — 429 / 5xx / network / gate-shed / gate no-op / anything else
+ *                  ⇒ leave `landed-unconfirmed`; NEVER re-send (a re-send would
+ *                  risk a duplicate, and duplicate-risk beats missing-risk
+ *                  here) and NEVER count it as a delivery failure either — the
+ *                  probe established nothing, so the landed-id evidence stands.
  *
  * NOTE (honest limitation, #3278 §1.4): a passing probe proves only that the
  * message EXISTS at that chat_id. It does NOT prove the human's client rendered
@@ -322,8 +328,24 @@ export interface BackstopDeliveryResult {
   sentIds: number[]
   /** Number of input chunks the answer was split into. */
   chunkCount: number
-  /** True IFF every chunk landed at least one fresh non-card id. */
+  /**
+   * True IFF every chunk landed at least one message id AND at least one of
+   * them is a fresh non-card chat id. This is the DELIVERY verdict the turn
+   * record, the obligation ledger and the status reaction key on.
+   *
+   * A read-back probe can only ever LOWER it, and only on POSITIVE absence: an
+   * `absent` verdict demotes the chunk back to `unsent`, so it stops counting as
+   * landed. An `ambiguous` probe carries no information and therefore does not
+   * move this flag — see {@link confirmed}.
+   */
   delivered: boolean
+  /**
+   * True IFF every chunk was read-back CONFIRMED (`exists`). Strictly stronger
+   * than {@link delivered} and purely observational — nothing keys a failure on
+   * it. `delivered && !confirmed` is the `landed-unconfirmed` state: the Bot API
+   * returned fresh ids for every chunk but the probe could not corroborate them.
+   */
+  confirmed: boolean
   /** How many attempts ran (1..maxAttempts). */
   attempts: number
   /** True when retries were exhausted without full delivery (terminal fail). */
@@ -345,9 +367,10 @@ export interface BackstopDeliveryResult {
  * is read-back-probed via `deps.readBack` (when provided): `exists` confirms it,
  * `absent` demotes it to `unsent` so the NEXT attempt re-sends only that chunk,
  * and `ambiguous` leaves it `landed-unconfirmed` — never re-sent (duplicate-risk
- * beats missing-risk). `delivered` now requires every chunk `landed-confirmed`,
- * so an API-ack'd-but-silently-dropped send (fresh id, absent on read-back) is
- * reported `delivered:false` and the caller leaves the obligation OPEN.
+ * beats missing-risk). An API-ack'd-but-silently-dropped send (fresh id, absent
+ * on read-back) is therefore reported `delivered:false` and the caller leaves
+ * the obligation OPEN. An INCONCLUSIVE probe is not a failure: it leaves
+ * `delivered` alone and only clears `confirmed` (see `BackstopDeliveryResult`).
  *
  * `recordOutbound` (when provided) fires ONCE at the end with the full landed
  * set and a `texts` array ALIGNED to the actual sent ids (via `ledger.entries`).
@@ -449,12 +472,36 @@ export async function runBackstopDelivery(
   }
 
   const sentIds = ledger.sentIds(turnId)
-  // #3278 — delivered IFF every chunk is `landed-confirmed` AND at least one
-  // confirmed id is a fresh non-card chat id (the receipt gate, guard 7).
+  const confirmed = ledger.allConfirmed(turnId, chunkCount)
+  // The delivery verdict is EVIDENCE-BASED, not confirmation-gated.
+  //
+  // #3278 originally required every chunk to be `landed-confirmed`, so an
+  // `ambiguous` probe — which by definition establishes nothing — produced
+  // `delivered:false`. That inverted the guard it was meant to be: the turn was
+  // recorded `send_failed`, the status reaction painted error, and the delivery
+  // obligation was left OPEN for a re-present, all for an answer the user had
+  // demonstrably received. In production the probe is ambiguous essentially
+  // always (it is issued at cosmetic priority in the same millisecond as the
+  // send it probes, so the per-chat token bucket sheds it), so this turned a
+  // successful backstop delivery into a logged failure ~146 times in two weeks.
+  //
+  // Absence of evidence is not evidence of absence. The verdict is therefore:
+  // every chunk LANDED (guard 6) and at least one landed id is a fresh non-card
+  // chat id (the receipt gate, guard 7). A probe can still lower it — an
+  // `absent` verdict demotes the chunk to `unsent` above, so it is no longer
+  // landed — which keeps #3278's real contribution (a positive absence is
+  // caught and re-sent) while an inconclusive probe changes nothing.
+  const allLanded = chunkCount > 0 && ledger.unsentIndices(turnId, chunkCount).length === 0
   const delivered =
-    ledger.allConfirmed(turnId, chunkCount) &&
-    backstopReceiptIds(ledger.confirmedIds(turnId), cardMessageId).length > 0
+    allLanded && backstopReceiptIds(sentIds, cardMessageId).length > 0
   const exhausted = !delivered
+  if (delivered && !confirmed) {
+    stderr(
+      `telegram gateway: backstop delivery landed-unconfirmed for turn ${turnId} — ` +
+      `every chunk returned a fresh message id but the read-back probe was ` +
+      `inconclusive; counting it delivered (an ambiguous probe is not a failure)\n`,
+    )
+  }
 
   if (deps.recordOutbound && sentIds.length > 0) {
     const texts: string[] = []
@@ -468,5 +515,5 @@ export async function runBackstopDelivery(
     deps.recordOutbound(ids, texts)
   }
 
-  return { sentIds, chunkCount, delivered, attempts, exhausted }
+  return { sentIds, chunkCount, delivered, confirmed, attempts, exhausted }
 }

--- a/telegram-plugin/gateway/backstop-delivery.ts
+++ b/telegram-plugin/gateway/backstop-delivery.ts
@@ -169,7 +169,11 @@ export class BackstopDeliveryLedger {
   /** Landed message ids of CONFIRMED chunks only, in chunk-index order — the
    *  read-back view of the ledger (ids proven present in the chat). The delivery
    *  predicate counts LANDED ids (`sentIds`), not these; this is the stronger
-   *  proven-present subset, kept as the natural pair to `hasConfirmedChunk`. */
+   *  proven-present subset. Its production consumer is
+   *  {@link BackstopDeliveryResult.landedUnconfirmedIds} — `sentIds` minus these
+   *  is the landed-but-uncorroborated set that reaches `turns.jsonl` as
+   *  `landed_unconfirmed`, the counter that measures whether this module's
+   *  optimism about an inconclusive probe is ever wrong. */
   confirmedIds(turnId: string): number[] {
     const m = this.chunks.get(turnId)
     const set = this.confirmed.get(turnId)
@@ -346,6 +350,18 @@ export interface BackstopDeliveryResult {
    * returned fresh ids for every chunk but the probe could not corroborate them.
    */
   confirmed: boolean
+  /**
+   * The landed message ids NO read-back corroborated — `sentIds` minus the
+   * confirmed subset, in chunk-index order. Empty when {@link confirmed}.
+   *
+   * This is the MEASURABLE form of this module's central bet: a landed id whose
+   * probe came back inconclusive is counted as delivered. Its count is stamped
+   * onto the turn record as `landed_unconfirmed` (see `buildTurnRecord`) so the
+   * fleet can tell how often that bet is being made — and, if a
+   * `landed_unconfirmed` turn is ever followed by a "you never answered me",
+   * that the bet was wrong. Purely observational: nothing keys a failure on it.
+   */
+  landedUnconfirmedIds: number[]
   /** How many attempts ran (1..maxAttempts). */
   attempts: number
   /** True when retries were exhausted without full delivery (terminal fail). */
@@ -369,8 +385,10 @@ export interface BackstopDeliveryResult {
  * and `ambiguous` leaves it `landed-unconfirmed` — never re-sent (duplicate-risk
  * beats missing-risk). An API-ack'd-but-silently-dropped send (fresh id, absent
  * on read-back) is therefore reported `delivered:false` and the caller leaves
- * the obligation OPEN. An INCONCLUSIVE probe is not a failure: it leaves
- * `delivered` alone and only clears `confirmed` (see `BackstopDeliveryResult`).
+ * the obligation OPEN — a correct mechanism that is INERT UNTIL #3703, because
+ * the probe is 100% shed in production and never resolves `absent`. An
+ * INCONCLUSIVE probe is not a failure: it leaves `delivered` alone and only
+ * clears `confirmed` (see `BackstopDeliveryResult`).
  *
  * `recordOutbound` (when provided) fires ONCE at the end with the full landed
  * set and a `texts` array ALIGNED to the actual sent ids (via `ledger.entries`).
@@ -491,15 +509,31 @@ export async function runBackstopDelivery(
   // `absent` verdict demotes the chunk to `unsent` above, so it is no longer
   // landed — which keeps #3278's real contribution (a positive absence is
   // caught and re-sent) while an inconclusive probe changes nothing.
+  //
+  // Honesty about what that contribution is worth TODAY: it is INERT UNTIL
+  // #3703. The probe is issued at cosmetic priority in the same millisecond as
+  // the send it probes, so the per-chat token bucket sheds it 100% of the time
+  // (146 `ambiguous` / 0 `absent` across the live fleet) and the `absent` branch
+  // is structurally unreachable in production. The demote-and-re-send path below
+  // is a correct mechanism with no live trigger; #3703 is the change that wakes
+  // the probe (and must first fix its resplit-overwrite hazard). Do not read
+  // this block as "absence is still caught in production" — it is not, yet.
   const allLanded = chunkCount > 0 && ledger.unsentIndices(turnId, chunkCount).length === 0
   const delivered =
     allLanded && backstopReceiptIds(sentIds, cardMessageId).length > 0
   const exhausted = !delivered
+  // The landed-but-uncorroborated set (L2/L5): `sentIds` minus the read-back
+  // confirmed subset. Surfaced on the result so the caller can stamp
+  // `landed_unconfirmed` on the turn record — the only way to measure whether
+  // counting an inconclusive probe as delivered is ever wrong.
+  const confirmedSet = new Set(ledger.confirmedIds(turnId))
+  const landedUnconfirmedIds = sentIds.filter(id => !confirmedSet.has(id))
   if (delivered && !confirmed) {
     stderr(
       `telegram gateway: backstop delivery landed-unconfirmed for turn ${turnId} — ` +
       `every chunk returned a fresh message id but the read-back probe was ` +
-      `inconclusive; counting it delivered (an ambiguous probe is not a failure)\n`,
+      `inconclusive for ${landedUnconfirmedIds.length} of ${sentIds.length} landed ` +
+      `id(s); counting it delivered (an ambiguous probe is not a failure)\n`,
     )
   }
 
@@ -515,5 +549,5 @@ export async function runBackstopDelivery(
     deps.recordOutbound(ids, texts)
   }
 
-  return { sentIds, chunkCount, delivered, confirmed, attempts, exhausted }
+  return { sentIds, chunkCount, delivered, confirmed, landedUnconfirmedIds, attempts, exhausted }
 }

--- a/telegram-plugin/gateway/captured-answer-resume.ts
+++ b/telegram-plugin/gateway/captured-answer-resume.ts
@@ -14,8 +14,8 @@
  *
  * ── The fix (design-of-record §2.2) ─────────────────────────────────────────
  * Make the re-present a *byte-identical captured-answer resume* of ONLY the
- * not-yet-`landed-confirmed` tail — never a regeneration — so a chunk that
- * already reached the chat is provably never re-posted:
+ * not-yet-LANDED tail — never a regeneration — so a chunk that already reached
+ * the chat is provably never re-posted:
  *
  *   1. On a partial (`!delivered`) turn-flush, persist a {@link
  *      CapturedDeliverySnapshot} (the split chunks + each landed chunk's ids and
@@ -25,9 +25,9 @@
  *   2. The obligation sweep's `represent` branch becomes source-aware: when the
  *      obligation carries a captured-delivery snapshot it drives THIS resume
  *      (re-run `runBackstopDelivery` for the SAME `turnId` and the SAME captured
- *      chunks, resuming at the first non-`landed-confirmed` index) instead of
- *      pushing a fresh-generation inbound. No snapshot ⇒ the genuine "model wrote
- *      nothing / never fired a backstop" case falls through to fresh generation
+ *      chunks, resuming at the first UNSENT index) instead of pushing a
+ *      fresh-generation inbound. No snapshot ⇒ the genuine "model wrote nothing
+ *      / never fired a backstop" case falls through to fresh generation
  *      unchanged.
  *   3. The in-memory ledger is rehydrated from the snapshot AND reconciled against
  *      the durable outbound-text oracle (`hasOutboundWithText`), so a chunk that
@@ -39,8 +39,28 @@
  * chunks (not a regenerated answer). #3278's per-chunk state machine
  * (`unsent → pending → landed-unconfirmed → {landed-confirmed | unsent}`) binds
  * here too: the resume re-PROBES `landed-unconfirmed` chunks (never re-sends
- * them) and re-SENDS only `unsent` ones, so a confirmed chunk is never duplicated
+ * them) and re-SENDS only `unsent` ones, so a landed chunk is never duplicated
  * by either the in-fire retry OR the cross-represent resume.
+ *
+ * ── The CLOSE condition is LANDED, not confirmed (#3702) ────────────────────
+ * `runBackstopDelivery`'s verdict is evidence-based: every chunk landed a
+ * message id and at least one is a fresh non-card id. An inconclusive read-back
+ * does not lower it (only a POSITIVE `absent`, which demotes the chunk back to
+ * `unsent`, does). So a resume over a snapshot whose chunks ALL landed but were
+ * never corroborated closes the obligation having sent NOTHING — the re-probe
+ * ran, resolved nothing, and the landed-id evidence stood.
+ *
+ * That is deliberate, not an oversight. The alternative — keep the obligation
+ * OPEN because nothing corroborated the ids — has no corrective action
+ * available: the resume never re-sends a LANDED chunk, so every subsequent
+ * represent would re-run the same shed probe, send zero messages, and burn
+ * represent budget until the cap escalates a false "the agent never answered
+ * you" nudge to the operator. Representing cannot deliver anything the first
+ * delivery did not; the only thing it can produce is noise. When the durable
+ * outbound-text oracle CAN corroborate (history enabled + the row present) it
+ * confirms the chunk at hydration and the same close happens by the older
+ * `hasOutboundWithText` route — this path is the same decision when that oracle
+ * is unavailable.
  *
  * This module is PURE state + orchestration over injected effects — no Telegram,
  * no SQLite, no gateway module state — so the resume decision is unit-testable
@@ -55,10 +75,10 @@ import type { CapturedDeliverySnapshot, Obligation } from './obligation-ledger.j
 /**
  * Build the durable {@link CapturedDeliverySnapshot} from the live per-chunk
  * ledger after a partial `runBackstopDelivery`. Captures every LANDED chunk's
- * message ids + confirmed flag so the resume can (a) never re-send a confirmed
- * chunk and (b) re-PROBE a landed-unconfirmed chunk instead of blindly re-sending
- * it. Chunks that never landed (send threw) are simply absent → the resume treats
- * them as `unsent` and re-sends them. Pure.
+ * message ids + confirmed flag so the resume can (a) never re-send a chunk that
+ * already landed and (b) re-PROBE a landed-unconfirmed chunk instead of blindly
+ * re-sending it. Chunks that never landed (send threw) are simply absent → the
+ * resume treats them as `unsent` and re-sends them. Pure.
  */
 export function buildCapturedDeliverySnapshot(
   ledger: BackstopDeliveryLedger,
@@ -165,9 +185,13 @@ export interface CapturedResumeDispatcher {
  * The obligation-sweep's captured-answer resume driver. Owns the in-flight guard
  * + the deliver→close/leave-open orchestration so the gateway sweep stays a
  * two-line dispatch. On each dispatch it consumes one represent-budget unit
- * (bounding the ladder → escalate), re-delivers only the non-confirmed tail, and:
+ * (bounding the ladder → escalate), re-delivers only the UNSENT tail (a landed
+ * chunk is re-probed, never re-sent), and:
  *   - fully delivered ⇒ record the supersede tail, close the obligation, GC the
- *     ledger (the represent ladder stops);
+ *     ledger (the represent ladder stops). Since #3702 "delivered" means every
+ *     chunk LANDED — so a snapshot that is already fully landed closes here
+ *     having sent nothing (see the module header for why that is the right
+ *     call, and why leaving it OPEN would only manufacture a false escalation);
  *   - still partial / error ⇒ leave the obligation OPEN so the next eligible
  *     sweep (after the per-represent grace) retries, until the represent cap
  *     escalates it to the operator nudge — no infinite loop.
@@ -176,7 +200,7 @@ export function createCapturedResumeDispatcher(ports: CapturedResumePorts): Capt
   const stderr = ports.stderr ?? (() => {})
   const inFlight = new Set<string>()
 
-  /** Re-deliver the non-confirmed tail of `o`'s captured answer, byte-identical,
+  /** Re-deliver the UNSENT tail of `o`'s captured answer, byte-identical,
    *  by rehydrating the per-chunk ledger from the snapshot reconciled against the
    *  durable text oracle. Never regenerates. */
   function deliver(o: Obligation, snapshot: CapturedDeliverySnapshot): Promise<{ delivered: boolean; sentIds: number[] }> {
@@ -221,16 +245,21 @@ export function createCapturedResumeDispatcher(ports: CapturedResumePorts): Capt
       if (delivered) {
         ports.obligationLedger.close(o.originTurnId)
         ports.backstopDeliveryLedger.clear(o.originTurnId)
+        // `sentIds` is `ledger.sentIds()` — every LANDED id, which since #3702
+        // routinely includes ids no read-back corroborated. Say "landed", not
+        // "confirmed": claiming confirmation for an uncorroborated id is exactly
+        // the overstatement this PR removed from the delivery verdict.
         stderr(
           `telegram gateway: captured-answer resume delivered — origin=${o.originTurnId} ` +
-            `${sentIds.length} chunk(s) confirmed; obligation closed\n`,
+            `${sentIds.length} message id(s) landed; obligation closed\n`,
         )
       } else {
-        // Tail still not confirmed — leave the obligation OPEN for the next paced
-        // sweep / escalation (bounded by the represent cap).
+        // Not fully landed (a chunk never got an id, or a positive `absent`
+        // demoted one) — leave the obligation OPEN for the next paced sweep /
+        // escalation (bounded by the represent cap).
         stderr(
           `telegram gateway: captured-answer resume partial — origin=${o.originTurnId} ` +
-            `tail still not confirmed; left OPEN for retry\n`,
+            `tail still not landed; left OPEN for retry\n`,
         )
       }
     } catch (err) {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2456,9 +2456,9 @@ async function deliverAnswer(args: {
    *  the send alive if the user deleted their message. Null for synthesized
    *  turns (cron/handback) — those send bare, as before. */
   replyToMessageId: number | null
-  /** #3282 captured-answer RESUME (see captured-answer-resume.ts): re-deliver the SAME byte-identical chunks + pre-hydrate the ledger (non-confirmed tail only). */
+  /** #3282 captured-answer RESUME (see captured-answer-resume.ts): re-deliver the SAME byte-identical chunks + pre-hydrate the ledger (unsent tail only; a landed chunk is re-probed, never re-sent). */
   resume?: { snapshot: CapturedDeliverySnapshot; hydrate: (ledger: BackstopDeliveryLedger, turnId: string) => void }
-}): Promise<{ sentIds: number[]; chunkCount: number; delivered: boolean; exhausted: boolean }> {
+}): Promise<{ sentIds: number[]; chunkCount: number; delivered: boolean; exhausted: boolean; landedUnconfirmed: number }> {
   const { chatId, turnId } = args
   // Spacers into `\n\n` gaps then split (as executeReply); a resume re-delivers the EXACT captured chunks (byte-stable, no re-split).
   const chunks = args.resume
@@ -2594,6 +2594,7 @@ async function deliverAnswer(args: {
     chunkCount: result.chunkCount,
     delivered: result.delivered,
     exhausted: result.exhausted,
+    landedUnconfirmed: result.landedUnconfirmedIds.length, // #3702 — the caller stamps this on the turn record
   }
 }
 
@@ -3427,6 +3428,7 @@ export type CurrentTurn = {
   // turn-end paths (reply-tool tail, silent-marker, genuine no-reply), where
   // the legacy `finalAnswerDelivered` reading still applies unchanged.
   deliveryOutcome?: DeliveryOutcome
+  landedUnconfirmed?: number // #3702 — landed ids no read-back corroborated; emitted as `landed_unconfirmed` (rationale: turn-record-status.ts)
   // Feed-reopen-after-ack refinement — whether the reply that set
   // `finalAnswerDelivered` was a *substantive* final answer (stream
   // `done`, or ≥200 chars) as opposed to a short pinging interim ACK.
@@ -5033,7 +5035,7 @@ function emitTurnRecord(turn: CurrentTurn, endedAt: number): void {
             toolCallCount: turn.toolCallCount ?? 0,
             turnId: turn.turnId,
             finalAnswerDelivered: turn.finalAnswerDelivered,
-            deliveryOutcome: turn.deliveryOutcome,
+            deliveryOutcome: turn.deliveryOutcome, landedUnconfirmed: turn.landedUnconfirmed,
           },
           endedAt,
         ),

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -611,7 +611,14 @@ export function createBackstopReadBack(
     }
     try {
       const r = await w.gate(() => w.editMessageText(messageId, body, editApiOpts), gateOpts)
-      return w.isShed(r) ? 'ambiguous' : 'exists'
+      // A shed resolves the SEND_GATE_SHED sentinel; a gate no-op drop (the
+      // identical payload is already the last one sent for this message id) or
+      // an expired queue entry resolves `undefined`. In BOTH cases the edit
+      // never reached Telegram, so there is no evidence of existence —
+      // `ambiguous`, never a fabricated `exists`. Only a real API result
+      // (grammy resolves `true` or the edited Message) proves presence.
+      if (w.isShed(r) || r === undefined) return 'ambiguous'
+      return 'exists'
     } catch (err) {
       return classifyReadBackError(err)
     }

--- a/telegram-plugin/gateway/stream-render.ts
+++ b/telegram-plugin/gateway/stream-render.ts
@@ -1856,6 +1856,12 @@ export function handleSessionEvent(deps: StreamRenderDeps, ev: SessionEvent): vo
             sentIds = delivery.sentIds
             chunkCount = delivery.chunkCount
             delivered = delivery.delivered
+            // #3702 — how many landed ids the read-back never corroborated.
+            // Stamped on the turn so `emitTurnRecord` writes `landed_unconfirmed`
+            // (omitted when 0): the fleet-visible counter for deliveries we call
+            // `complete` on the Bot API's ack alone, because the probe is
+            // inconclusive. Observational only — it never changes the status.
+            turn.landedUnconfirmed = delivery.landedUnconfirmed
 
             // #546 dedup: record what turn-flush just sent so a late-arriving
             // reply / stream_reply with the same content gets suppressed.

--- a/telegram-plugin/gateway/turn-record-status.ts
+++ b/telegram-plugin/gateway/turn-record-status.ts
@@ -148,6 +148,20 @@ export interface TurnRecordRow {
   tools: number
   status: TurnStatus
   turn_id: string
+  /**
+   * How many landed message ids of this turn's backstop delivery the read-back
+   * probe never corroborated (`sentIds` minus the confirmed subset). OMITTED
+   * when zero, so an ordinary row is byte-identical to before.
+   *
+   * This is the measurable counterpart of the delivery verdict: since an
+   * inconclusive probe counts as delivered, a `complete` row carrying
+   * `landed_unconfirmed > 0` is a turn we called delivered on the Bot API's
+   * ack alone. Counting those is how the fleet can tell whether that optimism
+   * is ever wrong (a `landed_unconfirmed` turn followed by a "you never
+   * answered me" is the falsifying observation). It is NOT a failure signal and
+   * nothing escalates on it.
+   */
+  landed_unconfirmed?: number
 }
 
 /**
@@ -165,6 +179,7 @@ export function buildTurnRecord(
     turnId: string
     finalAnswerDelivered: boolean
     deliveryOutcome?: DeliveryOutcome
+    landedUnconfirmed?: number
   },
   endedAt: number,
 ): TurnRecordRow {
@@ -175,5 +190,9 @@ export function buildTurnRecord(
     tools: turn.toolCallCount ?? 0,
     status: computeTurnStatus(turn),
     turn_id: turn.turnId,
+    // Emitted ONLY when non-zero (see `TurnRecordRow.landed_unconfirmed`).
+    ...(turn.landedUnconfirmed != null && turn.landedUnconfirmed > 0
+      ? { landed_unconfirmed: turn.landedUnconfirmed }
+      : {}),
   }
 }

--- a/telegram-plugin/tests/backstop-delivery.test.ts
+++ b/telegram-plugin/tests/backstop-delivery.test.ts
@@ -348,25 +348,29 @@ describe('#3278 runBackstopDelivery — read-back drives the delivery outcome', 
     expect(ledger.hasConfirmedChunk('#drop', 0)).toBe(true)
   })
 
-  it('429/ambiguous probe ⇒ NOT re-sent, stays landed-unconfirmed, delivered=false', async () => {
+  it('429/ambiguous probe ⇒ NOT re-sent, stays landed-unconfirmed, still DELIVERED', async () => {
     const ledger = new BackstopDeliveryLedger()
     const sendChunk = vi.fn(async () => [950])
     const readBack = vi.fn(async (): Promise<ReadBackResult> => 'ambiguous')
     const res = await runBackstopDelivery(ledger, '#amb', ['answer'], null, { sendChunk, readBack }, 3)
     expect(sendChunk).toHaveBeenCalledTimes(1) // never re-sent on ambiguous
-    expect(res.delivered).toBe(false)
-    expect(res.exhausted).toBe(true)
+    // An inconclusive probe establishes nothing, so the landed-id evidence
+    // stands: the answer IS in the chat and the turn is not a failure.
+    expect(res.delivered).toBe(true)
+    expect(res.confirmed).toBe(false) // landed-unconfirmed, honestly reported
+    expect(res.exhausted).toBe(false)
     expect(ledger.hasConfirmedChunk('#amb', 0)).toBe(false)
     expect(ledger.landedUnconfirmedIndices('#amb', 1)).toEqual([0]) // still landed-unconfirmed
   })
 
-  it('a read-back adapter THAT THROWS is treated as ambiguous — never re-sent', async () => {
+  it('a read-back adapter THAT THROWS is ambiguous — never re-sent, never a failure', async () => {
     const ledger = new BackstopDeliveryLedger()
     const sendChunk = vi.fn(async () => [951])
     const readBack = vi.fn(async () => { throw new Error('boom') })
     const res = await runBackstopDelivery(ledger, '#throw', ['answer'], null, { sendChunk, readBack }, 3)
     expect(sendChunk).toHaveBeenCalledTimes(1)
-    expect(res.delivered).toBe(false)
+    expect(res.delivered).toBe(true)
+    expect(res.confirmed).toBe(false)
   })
 
   it('#3278 CORE: API-ack fresh id but read-back ABSENT ⇒ send_failed, NOT complete', async () => {
@@ -403,15 +407,70 @@ describe('#3278 runBackstopDelivery — read-back drives the delivery outcome', 
     expect(ledger.hasConfirmedChunk('#noprobe', 0)).toBe(true)
   })
 
-  it('partial: chunk 0 confirmed, chunk 1 ambiguous ⇒ delivered=false, chunk 0 not re-sent', async () => {
+  it('partial: chunk 0 confirmed, chunk 1 ambiguous ⇒ both landed ⇒ delivered, chunk 0 not re-sent', async () => {
     const ledger = new BackstopDeliveryLedger()
     const calls: number[] = []
     const sendChunk = vi.fn(async (i: number) => { calls.push(i); return [700 + i] })
     const readBack = vi.fn(async (i: number): Promise<ReadBackResult> => (i === 0 ? 'exists' : 'ambiguous'))
     const res = await runBackstopDelivery(ledger, '#part', ['c0', 'c1'], null, { sendChunk, readBack }, 3)
-    expect(res.delivered).toBe(false)
+    expect(res.delivered).toBe(true) // every chunk landed a fresh id
+    expect(res.confirmed).toBe(false) // ...but chunk 1 was never corroborated
     expect(calls.filter(i => i === 0)).toHaveLength(1) // confirmed chunk never re-sent
     expect(ledger.hasConfirmedChunk('#part', 0)).toBe(true)
     expect(ledger.hasConfirmedChunk('#part', 1)).toBe(false)
+  })
+
+  // ── The measurement bug this PR fixes ────────────────────────────────────
+  //
+  // The probe is issued at cosmetic priority in the same millisecond as the
+  // send it probes, so the per-chat token bucket (1/sec, just consumed by that
+  // very send) sheds it: in production it resolved `ambiguous` 146 times in two
+  // weeks and `absent` ZERO times. Under the old confirmation-gated verdict each
+  // of those became `delivered:false` → `send_failed` on a turn whose answer the
+  // user had received, plus an error reaction and a still-OPEN obligation.
+  it('AMBIGUOUS probe ⇒ turn record `complete`, NOT send_failed (the fixed bug)', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const cardId = 500
+    const sendChunk = vi.fn(async () => [971]) // a fresh, non-card chat id
+    const readBack = vi.fn(async (): Promise<ReadBackResult> => 'ambiguous')
+    const res = await runBackstopDelivery(ledger, '#shed', ['answer'], cardId, { sendChunk, readBack }, 3)
+    const turn: { finalAnswerDelivered: boolean; deliveryOutcome?: 'delivered' | 'failed' | 'suppressed' } = {
+      finalAnswerDelivered: true,
+    }
+    finalizeBackstopSendGated(turn, {
+      threw: !res.delivered, sentIds: res.sentIds, chunkCount: res.chunkCount, cardMessageId: cardId,
+    })
+    expect(computeTurnStatus(turn)).toBe('complete')
+  })
+
+  it('an ambiguous probe on a CARD-ONLY delivery is still send_failed (guard 7 holds)', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const cardId = 501
+    // The only id that landed IS the progress card — swept ~60-90s later, so
+    // the user receives nothing. Ambiguity must not rescue this.
+    const sendChunk = vi.fn(async () => [cardId])
+    const readBack = vi.fn(async (): Promise<ReadBackResult> => 'ambiguous')
+    const res = await runBackstopDelivery(ledger, '#cardonly', ['answer'], cardId, { sendChunk, readBack }, 3)
+    expect(res.delivered).toBe(false)
+    const turn: { finalAnswerDelivered: boolean; deliveryOutcome?: 'delivered' | 'failed' | 'suppressed' } = {
+      finalAnswerDelivered: true,
+    }
+    finalizeBackstopSendGated(turn, {
+      threw: !res.delivered, sentIds: res.sentIds, chunkCount: res.chunkCount, cardMessageId: cardId,
+    })
+    expect(computeTurnStatus(turn)).toBe('send_failed')
+  })
+
+  it('an ambiguous probe on a chunk that never landed is still NOT delivered', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    // chunk 0 lands; chunk 1 throws on every attempt → never landed.
+    const sendChunk = vi.fn(async (i: number) => {
+      if (i === 1) throw new Error('flood')
+      return [800 + i]
+    })
+    const readBack = vi.fn(async (): Promise<ReadBackResult> => 'ambiguous')
+    const res = await runBackstopDelivery(ledger, '#gap', ['c0', 'c1'], null, { sendChunk, readBack }, 2)
+    expect(res.delivered).toBe(false)
+    expect(res.exhausted).toBe(true)
   })
 })

--- a/telegram-plugin/tests/backstop-delivery.test.ts
+++ b/telegram-plugin/tests/backstop-delivery.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../gateway/backstop-delivery.js'
 import {
   backstopSendOutcomeGated,
+  buildTurnRecord,
   finalizeBackstopSendGated,
   computeTurnStatus,
 } from '../gateway/turn-record-status.js'
@@ -472,5 +473,142 @@ describe('#3278 runBackstopDelivery — read-back drives the delivery outcome', 
     const res = await runBackstopDelivery(ledger, '#gap', ['c0', 'c1'], null, { sendChunk, readBack }, 2)
     expect(res.delivered).toBe(false)
     expect(res.exhausted).toBe(true)
+  })
+
+  // Mixed sequence: the two probe states that MOVE the verdict, composed in one
+  // run. Chunk 0's first send is silently discarded (`absent` ⇒ demote ⇒
+  // re-send) and the probe on the RE-SEND is shed (`ambiguous`). Under the old
+  // confirmation-gated verdict the re-sent chunk was never `landed-confirmed`,
+  // so the whole turn came out `delivered:false` — a `send_failed` for an answer
+  // that had just been successfully re-sent. Demote-and-re-send and
+  // ambiguity-is-not-failure must compose.
+  it('absent ⇒ demote ⇒ re-send, then AMBIGUOUS on the re-send ⇒ delivered, sent exactly twice', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    let sends = 0
+    const sendChunk = vi.fn(async () => { sends++; return [990 + sends] })
+    let probes = 0
+    const readBack = vi.fn(async (): Promise<ReadBackResult> => {
+      probes++
+      return probes === 1 ? 'absent' : 'ambiguous'
+    })
+    const res = await runBackstopDelivery(ledger, '#mixed', ['answer'], null, { sendChunk, readBack }, 3)
+    expect(sendChunk).toHaveBeenCalledTimes(2) // initial + exactly one re-send
+    expect(readBack).toHaveBeenCalledTimes(2) // probed once per landing
+    expect(res.delivered).toBe(true) // the re-send landed a fresh id; ambiguity proves nothing
+    expect(res.confirmed).toBe(false) // ...and is honestly reported as uncorroborated
+    expect(res.sentIds).toEqual([992]) // the demoted first id is gone; the re-send's id stands
+    expect(res.landedUnconfirmedIds).toEqual([992])
+    // The outcome the user actually experiences: a `complete` turn record.
+    const turn: { finalAnswerDelivered: boolean; deliveryOutcome?: 'delivered' | 'failed' | 'suppressed' } = {
+      finalAnswerDelivered: true,
+    }
+    finalizeBackstopSendGated(turn, {
+      threw: !res.delivered, sentIds: res.sentIds, chunkCount: res.chunkCount, cardMessageId: null,
+    })
+    expect(computeTurnStatus(turn)).toBe('complete')
+  })
+})
+
+// ── The observability of the new optimism (#3702 L2/L5/L6a) ─────────────────
+//
+// Counting an inconclusive probe as delivered is a BET. These pin the two
+// artifacts that let the fleet find out if it is ever wrong: the per-delivery
+// stderr line, and the `landed_unconfirmed` field on the turns.jsonl row.
+describe('#3702 landed-unconfirmed is MEASURED, not silently assumed', () => {
+  it('a delivered-but-unconfirmed turn writes the diagnostic stderr line', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const lines: string[] = []
+    const res = await runBackstopDelivery(
+      ledger, '#obs', ['answer'], null,
+      {
+        sendChunk: async () => [1001],
+        readBack: async (): Promise<ReadBackResult> => 'ambiguous',
+        stderr: (s) => lines.push(s),
+      },
+      3,
+    )
+    expect(res.delivered).toBe(true)
+    expect(res.confirmed).toBe(false)
+    const diag = lines.filter(l => l.includes('backstop delivery landed-unconfirmed'))
+    expect(diag).toHaveLength(1)
+    expect(diag[0]).toContain('#obs')
+    expect(diag[0]).toContain('1 of 1 landed id(s)') // the measured quantity, not just a warning
+  })
+
+  it('a fully CONFIRMED delivery writes NO landed-unconfirmed line (no false alarm)', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const lines: string[] = []
+    const res = await runBackstopDelivery(
+      ledger, '#conf', ['answer'], null,
+      {
+        sendChunk: async () => [1002],
+        readBack: async (): Promise<ReadBackResult> => 'exists',
+        stderr: (s) => lines.push(s),
+      },
+      3,
+    )
+    expect(res.confirmed).toBe(true)
+    expect(res.landedUnconfirmedIds).toEqual([])
+    expect(lines.filter(l => l.includes('backstop delivery landed-unconfirmed'))).toHaveLength(0)
+  })
+
+  it('landedUnconfirmedIds is exactly the uncorroborated subset of sentIds', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    // chunk 0 confirmed, chunk 1 landed-unconfirmed (shed probe).
+    const res = await runBackstopDelivery(
+      ledger, '#subset', ['c0', 'c1'], null,
+      {
+        sendChunk: async (i: number) => [1100 + i],
+        readBack: async (i: number): Promise<ReadBackResult> => (i === 0 ? 'exists' : 'ambiguous'),
+      },
+      3,
+    )
+    expect(res.sentIds).toEqual([1100, 1101])
+    expect(res.landedUnconfirmedIds).toEqual([1101]) // c0 is corroborated; c1 is the bet
+    expect(res.delivered).toBe(true)
+    expect(res.confirmed).toBe(false)
+  })
+
+  it('the count reaches turns.jsonl: a complete turn carries `landed_unconfirmed`', async () => {
+    const ledger = new BackstopDeliveryLedger()
+    const res = await runBackstopDelivery(
+      ledger, '#row', ['c0', 'c1'], null,
+      {
+        sendChunk: async (i: number) => [1200 + i],
+        readBack: async (): Promise<ReadBackResult> => 'ambiguous',
+      },
+      3,
+    )
+    const turn = {
+      agent: 'test-agent',
+      startedAt: 1_000_000,
+      toolCallCount: 0,
+      turnId: '#row',
+      finalAnswerDelivered: true,
+      deliveryOutcome: 'delivered' as const,
+      landedUnconfirmed: res.landedUnconfirmedIds.length,
+    }
+    const row = buildTurnRecord(turn, 1_002_000)
+    // The status is honest AND the bet is visible on the same row — that pairing
+    // is the point: a `complete` we could not corroborate is countable.
+    expect(row.status).toBe('complete')
+    expect(row.landed_unconfirmed).toBe(2)
+  })
+
+  it('an ordinary confirmed turn omits the field entirely (row shape unchanged)', () => {
+    const row = buildTurnRecord(
+      {
+        agent: 'test-agent',
+        startedAt: 1_000_000,
+        toolCallCount: 0,
+        turnId: '#plain',
+        finalAnswerDelivered: true,
+        deliveryOutcome: 'delivered',
+        landedUnconfirmed: 0,
+      },
+      1_002_000,
+    )
+    expect(row.status).toBe('complete')
+    expect('landed_unconfirmed' in row).toBe(false)
   })
 })

--- a/telegram-plugin/tests/backstop-readback-probe.test.ts
+++ b/telegram-plugin/tests/backstop-readback-probe.test.ts
@@ -141,4 +141,16 @@ describe('#3278 createBackstopReadBack — full gate+edit+classify wiring', () =
     const readBack = createBackstopReadBack(wiring({ gate, editMessageText }))
     expect(await readBack(0, [55], 'answer')).toBe('ambiguous')
   })
+
+  test('gate NO-OP drop (resolves undefined) ⇒ ambiguous, NOT a false exists', async () => {
+    // The gate's edit path drops a repeat of the last payload it actually sent
+    // (`counters.dropped`) and drops an expired queue entry, resolving
+    // `undefined` in both cases. Nothing reached Telegram, so nothing was
+    // proven — classifying it `exists` would fabricate a confirmation from a
+    // call that never happened.
+    const gate = vi.fn(async () => undefined)
+    const editMessageText = vi.fn(async () => true)
+    const readBack = createBackstopReadBack(wiring({ gate, editMessageText }))
+    expect(await readBack(0, [55], 'answer')).toBe('ambiguous')
+  })
 })

--- a/telegram-plugin/tests/captured-answer-resume.test.ts
+++ b/telegram-plugin/tests/captured-answer-resume.test.ts
@@ -271,6 +271,110 @@ describe('#3282 createCapturedResumeDispatcher — the represent RESUME outcome'
     expect(oblLedger.isOpen('#t1')).toBe(false)
   })
 
+  // #3702 L3 — the close condition is LANDED, not confirmed. A snapshot whose
+  // chunks all landed but were NEVER corroborated (the read-back is 100% shed in
+  // production, #3703) is resolved on HYDRATION alone: the resume re-probes,
+  // resolves nothing again, sends zero messages, and closes.
+  //
+  // This is the case the durable outbound-text oracle CANNOT reach — history
+  // disabled here, so `hasOutboundWithText` never fires and the old
+  // confirmation-gated verdict would have kept the obligation OPEN, re-running
+  // the same shed probe on every sweep with no send available to it, until the
+  // represent cap escalated a false "never answered you" to the operator.
+  it('fully-landed-but-UNCONFIRMED snapshot, no oracle ⇒ ZERO sends and the obligation CLOSES', async () => {
+    const chunks = ['c0', 'c1']
+    const snapshot = {
+      chunks,
+      chunkStates: [
+        { index: 0, messageIds: [5000], confirmed: false },
+        { index: 1, messageIds: [5001], confirmed: false },
+      ],
+    }
+    const resumeLedger = new BackstopDeliveryLedger()
+    const sentIdx: number[] = []
+    const oblLedger = new ObligationLedger(2)
+    oblLedger.openIfAbsent(obligation({ capturedDelivery: snapshot }))
+    oblLedger.noteCapturedDelivery('#t1', snapshot)
+
+    // No durable corroboration is available from EITHER source: the snapshot
+    // flags are false, history is off, and the re-probe sheds (ambiguous).
+    mockOracle = () => false
+
+    const lines: string[] = []
+    const dispatcher = createCapturedResumeDispatcher({
+      deliverAnswer: async (a) => {
+        a.resume.hydrate(resumeLedger, a.turnId)
+        const res = await runBackstopDelivery(
+          resumeLedger, a.turnId, a.resume.snapshot.chunks, a.cardMessageId,
+          {
+            sendChunk: async (i: number) => { sentIdx.push(i); return [7000 + i] },
+            readBack: async (): Promise<ReadBackResult> => 'ambiguous',
+          },
+          3,
+        )
+        expect(res.confirmed).toBe(false) // nothing corroborated it, at any point
+        expect(res.landedUnconfirmedIds).toEqual([5000, 5001]) // ...and it is counted
+        return { delivered: res.delivered, sentIds: res.sentIds }
+      },
+      obligationLedger: oblLedger,
+      backstopDeliveryLedger: resumeLedger,
+      flushedTurnSupersede: { record: () => {} },
+      historyEnabled: false,
+      stderr: (s) => lines.push(s),
+    })
+    dispatcher.dispatch(oblLedger.list()[0])
+    await flush(dispatcher)
+
+    expect(sentIdx).toEqual([]) // nothing re-posted — the user never sees a duplicate
+    expect(oblLedger.isOpen('#t1')).toBe(false) // closed on the landed-id evidence
+    // ...and the log must say what actually happened. These ids are LANDED, not
+    // confirmed: calling them "confirmed" is the overstatement #3702 removed from
+    // the verdict, and a log that reintroduces it re-lies to the next debugger.
+    const closed = lines.find((l) => l.includes('resume delivered'))
+    expect(closed).toBeDefined()
+    expect(closed).toContain('2 message id(s) landed')
+    expect(closed).not.toContain('confirmed')
+  })
+
+  // The other half of that decision: a positive ABSENCE still re-opens the send
+  // path, so "landed" is not a rubber stamp. (Inert in production until #3703
+  // wakes the probe, but the mechanism must remain correct.)
+  it('a landed chunk the re-probe finds ABSENT is demoted and RE-SENT, not closed on the stale id', async () => {
+    const chunks = ['c0']
+    const snapshot = { chunks, chunkStates: [{ index: 0, messageIds: [5000], confirmed: false }] }
+    const resumeLedger = new BackstopDeliveryLedger()
+    const sentIdx: number[] = []
+    const oblLedger = new ObligationLedger(2)
+    oblLedger.openIfAbsent(obligation({ capturedDelivery: snapshot }))
+    oblLedger.noteCapturedDelivery('#t1', snapshot)
+    mockOracle = () => false
+
+    let probes = 0
+    const dispatcher = createCapturedResumeDispatcher({
+      deliverAnswer: async (a) => {
+        a.resume.hydrate(resumeLedger, a.turnId)
+        const res = await runBackstopDelivery(
+          resumeLedger, a.turnId, a.resume.snapshot.chunks, a.cardMessageId,
+          {
+            sendChunk: async (i: number) => { sentIdx.push(i); return [7000 + i] },
+            readBack: async (): Promise<ReadBackResult> => (++probes === 1 ? 'absent' : 'exists'),
+          },
+          3,
+        )
+        return { delivered: res.delivered, sentIds: res.sentIds }
+      },
+      obligationLedger: oblLedger,
+      backstopDeliveryLedger: resumeLedger,
+      flushedTurnSupersede: { record: () => {} },
+      historyEnabled: false,
+    })
+    dispatcher.dispatch(oblLedger.list()[0])
+    await flush(dispatcher)
+
+    expect(sentIdx).toEqual([0]) // the silently-dropped chunk IS re-sent
+    expect(oblLedger.isOpen('#t1')).toBe(false)
+  })
+
   it('a partial RESUME (tail still fails) leaves the obligation OPEN + consumes represent budget', async () => {
     const chunks = ['c0', 'c1']
     const snapshot = {


### PR DESCRIPTION
## Summary

The backstop delivery path recorded successful deliveries as failures. #3278 made the verdict **confirmation-gated** — `delivered` required every chunk to be `landed-confirmed` by the read-back probe — but the probe is tri-state, and its third state `ambiguous` (429 / 5xx / network / gate shed) establishes *nothing*. Counting it as not-delivered inverted the guard it was meant to be:

`delivered:false` ⇒ `finalizeBackstopSendGated({ threw: true })` ⇒ turn record `send_failed`, 😱 error reaction, `answerDelivered = false`, and the delivery obligation left **OPEN** for a re-present — on turns the user demonstrably received (duplicate-send risk on top of a false metric).

This is not a rare edge. Across the live fleet the probe resolved `ambiguous` **146** times, `absent` **0** times, threw **0** times. It never reaches Telegram at all: `createBackstopReadBack` issues it at `cosmetic` priority in the same millisecond as the send it is probing, so the per-chat 1/sec token bucket sheds it every single time. `~/.switchroom/logs/klanker/gateway-supervisor.log` shows the send `msg_id=22115` ok at `22:17:05.513`, the probe `ambiguous` at `22:17:05.513`, and no probe `editMessageText` posted at all — followed by the 🤔→😱 reaction flip. Those turns are the `send_failed` cluster the fleet-health ledger ranks second (priority 47.00, 172 occurrences in `turns.jsonl`).

The verdict is now **evidence-based**, not confirmation-gated: every chunk LANDED (guard 6) and at least one landed id is a fresh non-card chat id (the receipt gate, guard 7). A probe can still *lower* it — an `absent` verdict demotes the chunk to `unsent` above, so it stops counting as landed — which preserves #3278's real contribution (an API-ack'd-but-silently-dropped send is caught and re-sent) while an inconclusive probe changes nothing. `confirmed` is exposed as a separate, strictly-stronger observational field; nothing keys a failure on it. A `landed-unconfirmed` delivery logs one diagnostic line.

Also fixed: `createBackstopReadBack` classified *any* non-shed gate result as `exists`, but a gate no-op drop (identical payload already last-sent for that id) or an expired queue entry resolves `undefined` without ever reaching Telegram. That is `ambiguous`, not proof of presence — a latent false-`exists` that would have masked a genuine absence.

## Why

Job spec: `reference/jobs/know-what-my-agent-is-doing.md` — outcome "the user can see what the agent is up to and why", invariant `chat-is-the-single-source-of-truth`. A delivered answer painted 😱 and logged `send_failed` breaks that invariant in the direction that costs the most trust: the chat says failure, reality says delivered. It also poisons the fleet-health ledger (`fleet-stays-healthy.md`) with a 172-occurrence phantom cluster.

"Absence of evidence is not evidence of absence" is the whole fix. A threshold tweak (retry the probe, wait longer) would not be durable: the probe is *structurally* shed, not flaky.

## Test plan

- `telegram-plugin/tests/backstop-delivery.test.ts` — 3 existing tests re-pinned to the new contract (ambiguous ⇒ `delivered:true, confirmed:false, exhausted:false`), plus 3 new outcome tests: **"AMBIGUOUS probe ⇒ turn record `complete`, NOT send_failed (the fixed bug)"** (drives `finalizeBackstopSendGated`/`computeTurnStatus`, not just the verdict), "an ambiguous probe on a CARD-ONLY delivery is still `send_failed` (guard 7 holds)", and "an ambiguous probe on a chunk that never landed is still NOT delivered" (guard 6 holds).
- `telegram-plugin/tests/backstop-readback-probe.test.ts` — new "gate NO-OP drop (resolves undefined) ⇒ ambiguous, NOT a false exists".
- **Mutation-checked:** restoring the old confirmation-gated verdict and the old `isShed ? … : 'exists'` classifier fails 5 tests, including the headline one. They assert outcomes, not code paths.
- Review follow-up commit: `landedUnconfirmedIds` result field + `landed_unconfirmed` turn row + `landed_unconfirmed_turns` scan field, the previously-untested `delivered && !confirmed` diagnostic branch, the mixed `absent` ⇒ demote ⇒ re-send ⇒ `ambiguous` sequence, and the resume-hydration verdict path (a fully-landed-but-unconfirmed snapshot closes with ZERO sends — pinned deliberately, with its converse: an `absent` re-probe still demotes and re-sends).
- **Mutation-checked (follow-up):** restoring the confirmation-gated verdict fails 8; deleting the diagnostic line fails 1; dropping `landed_unconfirmed` from the row fails 1; stubbing the fleet-health counter fails 2; restoring the lying "confirmed" resume log fails 1.
- Local: scoped vitest 170/170 green, `npm run lint` clean.

## Risk

Low-moderate, and asymmetric in the safe direction. The change can only move a verdict from `false` to `true`, and only when every chunk returned a fresh message id — i.e. when the Bot API already ack'd the send. The two genuine failure modes are untouched: a chunk that never landed still fails guard 6, and a positive `absent` read-back still demotes the chunk so it fails guard 6 too. A card-only delivery still fails the receipt gate.

**Blast radius — `delivered:true` closes THREE nets, not one.** Worth stating plainly, because the safety argument has to hold for all three:

1. **The delivery obligation** — `answerDelivered = true` resolves it, so no represent.
2. **The captured-answer resume** — the durable `CapturedDeliverySnapshot` records the chunks as LANDED, so a resume over that snapshot closes the obligation without re-sending (by design: the resume only ever sends an *unsent* tail, so leaving it open has no corrective action available — see the `captured-answer-resume.ts` header).
3. **The out-of-process backstop** — `delivered` also arms the **durable cross-process suppression key** via `journalExternalDelivery({ deliverySource: 'flush' })` (`stream-render.ts:1948-1962`), which `backstopAlreadyDelivered` (`outbox.ts:345`) reads from `stream-render.ts:1805`, `stream-render.ts:2131` and `gateway/outbox-sweep.ts:397`. So the Stop-hook bridge and the outbox sweep are suppressed too — across processes, and past this turn's lifetime.

All three closures are *correct when the answer really did land*, which is exactly what guards 6+7 establish (a fresh non-card message id per chunk from the Bot API). But the failure mode if that inference is ever wrong is silence, not a duplicate — so the follow-up commit **measures** it rather than assuming: the count of landed ids no read-back corroborated is stamped on the turn record as `landed_unconfirmed` (omitted when 0) and surfaced by `scanAgent` as `landed_unconfirmed_turns`. Counted, deliberately **not** escalated — making an inconclusive probe a failure signal is precisely the bug this PR removes.

**Known-not-fixed (follow-up issue to file):** because the probe is 100% shed, #3278's absence detection is effectively dead code in production — this PR makes the system honest about that rather than pretending an unrun probe is a verdict. Waking the probe is not a one-liner: the `useful` priority class carries a 120s TTL (which would block post-turn bookkeeping under flood), and `readBack(i, ids, chunks[i])` edits *every* id of a length-resplit chunk to the FULL chunk text, so enabling it as-is would visibly corrupt already-delivered messages. That deserves its own change with its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

