### PR TITLE
feat(protocol): bound adversarial review with a severity gate + round cap

### DIFF
--- a/.github/MERGE-QUEUE.md
+++ b/.github/MERGE-QUEUE.md
@@ -133,9 +133,13 @@ of bug as the #2816 non-main-dispatch follow-up. Queue builds tag
   seven is produced directly by a job in its own workflow on the
   triggering event.
 - `ci-evals.yml`, `ci-full.yml`, `ci-tests-race-long.yml`,
-  `ci-claude-latest-canary.yml`, `npm-publish.yml`, `promote.yml` and
-  `release.yml` produce no required context. That is the complete
-  remainder: the seven workflows above plus these seven are all 14.
+  `ci-claude-latest-canary.yml`, `npm-publish.yml`, `promote.yml`,
+  `release.yml` and `ci-review-rounds.yml` produce no required context.
+  That is the complete remainder: the seven workflows above plus these
+  eight are all 15. `ci-review-rounds.yml` is built ruleset-ready — its
+  `review-rounds` sentinel always reports, including on `merge_group` —
+  but until an operator adds that context to ruleset 16470166 it is
+  advisory, because `--auto --squash` merges past a non-required check.
 
 ## Diagnosing a stuck queue
 

--- a/.github/workflows/ci-review-rounds.yml
+++ b/.github/workflows/ci-review-rounds.yml
@@ -1,0 +1,89 @@
+name: ci-review-rounds
+
+# The deterministic cap on adversarial review rounds (Ken 2026-07-26).
+#
+# The protocol change that goes with it: blockers and mediums block the
+# merge, lows are FILED not fixed-now, and a re-review is earned only by a
+# behavioural fix. This workflow is the mechanism behind that prose, because
+# "deterministic mechanisms over model-dependent behavior" applies to this
+# rule too — a PR that has taken more than two review-fix rounds fails here
+# and the only way past is the durable `review-cap-override` label.
+#
+# Rounds are counted from git history: commits subject-prefixed
+# `review-fix:` (or carrying a `Review-Round:` trailer) on the PR branch.
+# Logic + tests live in scripts/check-review-rounds.mjs and
+# tests/review-rounds-gate.test.ts.
+#
+# Sentinel pattern (same shape as ci-lint.yml): the heavy job may skip on
+# non-PR events, and the `review-rounds` context always reports so it is
+# safe to add to Ruleset 16470166's required list.
+#
+# OPERATOR STEP — until `review-rounds` is in that ruleset it is advisory:
+# `gh pr merge --auto --squash` merges the moment the REQUIRED checks go
+# green and does not wait on a non-required one. To make the cap block,
+# append it to the ruleset's required_status_checks (verified shape as of
+# 2026-07-26: 7 contexts, all `integration_id: 15368` = GitHub Actions):
+#   gh api repos/switchroom/switchroom/rulesets/16470166   # read current
+#   # then PUT it back with {"context":"review-rounds","integration_id":15368}
+#   # appended to that rule's parameters.required_status_checks.
+
+on:
+  pull_request:
+    branches: [main]
+    # `labeled` / `unlabeled` so adding the override label re-runs the gate
+    # instead of needing an empty push.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-review-rounds-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
+jobs:
+  review-rounds-run:
+    # PRs only: a merge_group ref has no PR labels to read, and by then the
+    # gate has already had its say on the PR itself.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          # Full history so the base..head range is resolvable.
+          fetch-depth: 0
+
+      - name: Count review rounds
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Label names as comma-separated text, kept in `env:` rather than
+          # interpolated into the `run:` body (release-workflow rule).
+          REVIEW_ROUNDS_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        # The script runs `git log -z` itself. Do NOT hoist that into a shell
+        # variable here: command substitution drops NUL bytes, every commit
+        # would collapse into one message, and the gate would silently score
+        # any PR as a single round.
+        run: node scripts/check-review-rounds.mjs
+
+  # ─── Sentinel ─────────────────────────────────────────────────────
+  # Always reports, so this context can be made ruleset-required without
+  # blocking merge_group / dispatch runs where the heavy job skips.
+  review-rounds:
+    needs: [review-rounds-run]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verdict
+        run: |
+          r='${{ needs.review-rounds-run.result }}'
+          if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+            echo "::error::review-rounds-run=$r — review-round cap exceeded (or the check broke); see the job log"
+            exit 1
+          fi
+          echo "review-rounds-run=$r → pass (ran=success, or skipped on a non-PR event)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,10 @@ obligation:
 `check-no-broadcast-delivery`, `check-stale-tool-descriptions`,
 `check-web-subscription-honest`, `check-litellm-config-guard`.
 
+`scripts/check-review-rounds.mjs` is deliberately NOT in `npm run lint` — it
+needs a PR range and PR labels, so it runs only in `ci-review-rounds.yml`.
+Its logic is unit-tested in `tests/review-rounds-gate.test.ts`.
+
 Traps that bite repeatedly:
 
 - **`check-no-pii-secrets` fails on real operator PII** — real Telegram
@@ -324,9 +328,15 @@ repo too — the five parts, condensed:
    verdicts with evidence); stage delivery as focused single-concern PRs.
 4. **Pipeline.** Branch off fresh main. Scoped tests + `npm run lint`
    locally; CI is the full-suite authority. Adversarial review of the diff;
-   fix ALL findings including lows; re-review the fix; merge only on CI
-   green. Durable fixes over hack patches; deterministic mechanisms over
-   model-dependent behavior; tests assert outcomes, not just code paths.
+   fix every blocker and medium before merge; lows don't block — inline only
+   if a genuine one-liner, otherwise file a follow-up issue and merge.
+   Re-review only when the fix changed behaviour (docs/comment/log/test-only
+   fix commits don't earn another pass). **Prefix every commit answering a
+   review round `review-fix:`** — `scripts/check-review-rounds.mjs` counts
+   them and the `review-rounds` check fails past 2 rounds unless a
+   `review-cap-override` label is on the PR. Merge only on CI green. Durable
+   fixes over hack patches; deterministic mechanisms over model-dependent
+   behavior; tests assert outcomes, not just code paths.
 5. **Communicate.** Consolidated messages, always-visible progress, no
    foreground watches over 30s (background + notification), max 15 parallel
    sub-agents.

--- a/profiles/_shared/dev-protocol.md.hbs
+++ b/profiles/_shared/dev-protocol.md.hbs
@@ -21,20 +21,21 @@ How development work gets done here — orient, clarify, align, ship, communicat
 
 For tasks that are architecturally significant, cross-cutting, or ambiguous in approach:
 
-- **Design report before implementation.** Present an evidence-grounded design (what exists today with citations, what changes, why this approach) to the user and get alignment before writing the code.
+- **Design report before implementation.** Present an evidence-grounded design (what exists today with citations, what changes, why this approach) to the user and get alignment before coding.
 - **Red-team your own plan.** Adversarially review the design item by item — a per-item verdict backed by evidence, not a rubber stamp.
-- **Stage delivery.** Ship as focused, single-concern PRs rather than one omnibus change.
+- **Stage delivery.** Ship focused, single-concern PRs, not one omnibus change.
 
 ### Pipeline — how a change ships
 
 - **Branch off fresh main.** Always pull before branching.
-- **Scoped tests + lint locally; CI is the full-suite authority.** Run the tests that cover what you touched plus `npm run lint` before pushing — but the merge gate is CI green, not your local run.
-- **Adversarial review of the diff.** Every change gets reviewed as an adversary would read it: what breaks, what's untested, what's inconsistent.
-- **Fix ALL findings — including lows.** A "low" you skip is a bug you shipped. Then **re-review the fix** before calling it done.
+- **Scoped tests + lint locally; CI is the full-suite authority.** Run the tests covering what you touched plus `npm run lint` before pushing.
+- **Adversarial review of the diff.** Read every change as an adversary would: what breaks, what's untested, what's inconsistent.
+- **Blockers and mediums block the merge; lows don't** — fix a low inline if it's a one-liner, else file a follow-up issue and merge. Filing is mandatory.
+- **Re-review only a behavioural fix** — a docs/comment/log/test-only commit doesn't earn one. Prefix a fix commit `review-fix:`; two rounds is the cap, and CI enforces it.
 - **Merge only on CI green.** No exceptions, no "it's probably fine".
 - **Durable fixes over hack patches.** Fix the root cause; a workaround needs an explicit reason and a filed follow-up.
-- **Deterministic mechanisms over model-dependent behavior.** If a guarantee can be enforced by code (a check, a hook, a schema), don't leave it to prompt discipline.
-- **Tests assert outcomes, not just code paths.** A test that exercises the code but wouldn't fail on the bug is not a test.
+- **Deterministic mechanisms over model-dependent behavior.** If code can enforce a guarantee (a check, a hook, a schema), don't leave it to prompt discipline.
+- **Tests assert outcomes, not just code paths.** A test that wouldn't fail on the bug it guards is not a test.
 
 ### Communicate while you work
 

--- a/scripts/check-review-rounds.mjs
+++ b/scripts/check-review-rounds.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * check-review-rounds — the deterministic cap on adversarial review rounds.
+ *
+ * Why this exists (Ken 2026-07-26): the old protocol said "fix ALL findings
+ * including lows, then re-review the fix". That is a loop generator by
+ * construction — an adversarial reviewer always surfaces lows (that is its
+ * job), fixing lows produces a new diff, and a new diff earned another
+ * re-review. Observed: PRs going FOUR review rounds, the last round's only
+ * finding being an inaccurate doc comment. The severity gate in the protocol
+ * prose fixes the incentive; this script is the mechanism, because the repo's
+ * own rule is "deterministic mechanisms over model-dependent behavior" and
+ * prose that says "don't loop" is exactly model-dependent behavior.
+ *
+ * The artifact it counts: every commit that answers an adversarial review
+ * round is subject-prefixed `review-fix:` / `review-fix(scope):` (or carries a
+ * `Review-Round:` trailer). That prefix is mandated by the protocol in
+ * CLAUDE.md, `profiles/_shared/dev-protocol.md.hbs`, and the bundled
+ * `dev-protocol` skill. Rounds are counted from git history on the PR branch —
+ * no API call, no reviewer cooperation, no state file to drift.
+ *
+ * The cap: 2 rounds. A third fix round fails the `review-rounds` check, and
+ * the only way past it is the durable, PR-visible `review-cap-override` label
+ * (an operator action that leaves a trace), NOT a re-run and not a judgement
+ * call by the agent that wrote the commits.
+ *
+ * Honest limit: the input is a commit-message convention written by the agent
+ * under review, so an unprefixed fix commit undercounts. That is a protocol
+ * violation, not a supported bypass — the point of the gate is that once a
+ * round IS recorded, no amount of agent self-persuasion clears it.
+ */
+
+import { execFileSync } from "node:child_process";
+
+export const REVIEW_ROUND_CAP = 2;
+export const OVERRIDE_LABEL = "review-cap-override";
+
+/**
+ * A commit answers a review round when its subject is `review-fix`-prefixed
+ * (Conventional-Commits shaped, optional scope and `!`) or its body carries a
+ * `Review-Round:` trailer.
+ */
+const SUBJECT_RE = /^review-fix(\([^)]*\))?!?:/i;
+const TRAILER_RE = /^Review-Round:/im;
+
+/** Count the review-fix rounds recorded in a list of commit messages. */
+export function countReviewRounds(commitMessages) {
+  return commitMessages.filter((message) => {
+    const text = String(message ?? "");
+    const subject = text.split("\n", 1)[0].trim();
+    return SUBJECT_RE.test(subject) || TRAILER_RE.test(text);
+  }).length;
+}
+
+/**
+ * Evaluate the cap. Pure: no git, no network — so the tests assert the
+ * outcome (pass/fail + the message the developer sees), not a code path.
+ */
+export function evaluateReviewRounds({
+  commitMessages = [],
+  labels = [],
+  cap = REVIEW_ROUND_CAP,
+} = {}) {
+  const rounds = countReviewRounds(commitMessages);
+  const overridden = labels.some(
+    (l) => String(l ?? "").trim().toLowerCase() === OVERRIDE_LABEL,
+  );
+
+  if (rounds <= cap) {
+    return {
+      ok: true,
+      rounds,
+      cap,
+      overridden: false,
+      message: `check-review-rounds: OK — ${rounds}/${cap} adversarial review rounds recorded.`,
+    };
+  }
+
+  if (overridden) {
+    return {
+      ok: true,
+      rounds,
+      cap,
+      overridden: true,
+      message:
+        `check-review-rounds: OVERRIDDEN — ${rounds} rounds exceeds the cap of ${cap}, ` +
+        `allowed by the \`${OVERRIDE_LABEL}\` label on this PR.`,
+    };
+  }
+
+  return {
+    ok: false,
+    rounds,
+    cap,
+    overridden: false,
+    message:
+      `check-review-rounds: FAIL — ${rounds} adversarial review rounds on this PR; the cap is ${cap}.\n` +
+      `Review is bounded on purpose: blockers and mediums block the merge, lows do not.\n` +
+      `Do this instead of a third round: file the remaining findings as follow-up issues and merge.\n` +
+      `If a third round is genuinely warranted, an operator adds the \`${OVERRIDE_LABEL}\` label to this PR.`,
+  };
+}
+
+/** Split `git log -z --format=%B` output into individual commit messages. */
+export function parseGitLogZ(stdout) {
+  return String(stdout ?? "")
+    .split("\0")
+    .map((m) => m.trim())
+    .filter((m) => m.length > 0);
+}
+
+/**
+ * Read the PR's commit messages straight from git.
+ *
+ * This runs INSIDE the script on purpose. `git log -z` separates commits
+ * with NUL, and a shell `VAR="$(git log -z …)"` silently drops NUL bytes —
+ * every commit would collapse into one message and the gate would score any
+ * PR as a single round, i.e. it would never fire. Capturing the buffer in
+ * Node keeps the separators intact.
+ */
+export function readCommitMessages(baseRef, headRef, exec = execFileSync) {
+  const out = exec("git", ["log", "-z", "--format=%B", `${baseRef}..${headRef}`], {
+    encoding: "utf-8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return parseGitLogZ(out);
+}
+
+// ─── CLI ────────────────────────────────────────────────────────────────
+// Inputs come from the workflow env:
+//   BASE_SHA / HEAD_SHA   — the PR range (git is run here, see above)
+//   REVIEW_ROUNDS_LABELS  — newline- or comma-separated PR label names
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const base = process.env.BASE_SHA;
+  const head = process.env.HEAD_SHA ?? "HEAD";
+  if (!base) {
+    console.error("check-review-rounds: BASE_SHA is required (the PR base sha)");
+    process.exit(2);
+  }
+  const result = evaluateReviewRounds({
+    commitMessages: readCommitMessages(base, head),
+    labels: (process.env.REVIEW_ROUNDS_LABELS ?? "")
+      .split(/[\n,]/)
+      .map((l) => l.trim())
+      .filter(Boolean),
+  });
+  console.log(result.message);
+  process.exit(result.ok ? 0 : 1);
+}

--- a/skills/dev-protocol/SKILL.md
+++ b/skills/dev-protocol/SKILL.md
@@ -104,17 +104,38 @@ For larger tasks:
    - Charge: *find reasons this change is wrong* — correctness, missed edge
      cases, untested behavior, inconsistency with surrounding code, docs
      drift, security/data-loss risk.
-   - Output: a findings list, each with severity (high/medium/low), the
-     evidence (`file:line`), and a concrete fix.
-6. **Fix ALL findings — including lows.** A low you skip is a bug you
-   shipped. If a finding is genuinely invalid, rebut it with evidence in
-   writing; silence is not a rebuttal.
-7. **Re-review the fix.** The re-review verdict must contain, per original
-   finding: the finding ID, what changed (`file:line` of the fix), whether it
-   fully resolves the finding (`RESOLVED` / `PARTIAL` / `REBUTTED` with
-   evidence), and whether the fix introduced anything new. A bare "fixed" is
-   not a verdict.
-8. **Merge only on CI green.** No exceptions. A red or flaky CI run is a
+   - Output: a findings list, each carrying an explicit severity field —
+     `blocker` / `major` / `low`, one per finding, never omitted — plus the
+     evidence (`file:line`) and a concrete fix. The severity field is what
+     the merge gate reads, so an unlabelled finding is an invalid finding:
+     send it back for a severity rather than guessing one. A structured
+     findings tool (e.g. `ReportFindings`) already emits this shape; use it
+     rather than inventing a parallel format.
+6. **Severity gates the merge — mechanically.** Every `blocker` and `major`
+   finding is fixed before merge; those are the gate. **Lows do not block:**
+   fix a low inline only if it is a genuine one-liner, otherwise file it as a
+   follow-up issue and merge. Filing is mandatory — a low is tracked, never
+   waived. If a finding is genuinely invalid, rebut it with evidence in
+   writing; silence is not a rebuttal. Review terminates here: a reviewer
+   whose verdict is "mergeable, file the lows" is not talked into another
+   round, by you or by itself.
+7. **Re-review only a behavioural fix.** A fix commit confined to docs,
+   comments, log strings, or tests does not earn another adversarial pass —
+   read it and ship. When the fix changed behaviour, the re-review verdict
+   must contain, per original finding: the finding ID, what changed
+   (`file:line` of the fix), whether it fully resolves the finding
+   (`RESOLVED` / `PARTIAL` / `REBUTTED` with evidence), and whether the fix
+   introduced anything new. A bare "fixed" is not a verdict.
+8. **Two rounds is the cap, and it is enforced outside your judgement.**
+   Every commit answering a review round is subject-prefixed `review-fix:`
+   (or carries a `Review-Round:` trailer). `scripts/check-review-rounds.mjs`
+   counts them from git history and the `review-rounds` CI check fails a
+   third round. There is exactly one way past it: an operator adds the
+   `review-cap-override` label to the PR — a durable, visible artifact, not
+   a re-run and not a self-persuaded exception. When you hit the cap, the
+   correct move is the one the failure message names: file the remaining
+   findings as follow-up issues and merge.
+9. **Merge only on CI green.** No exceptions. A red or flaky CI run is a
    blocker to investigate, not to override.
 
 ## 5. Communicate while you work

--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -568,14 +568,43 @@ describe("renderDevProtocolFragment", () => {
     expect(fragment.toLowerCase()).toContain("single-concern pr");
   });
 
-  it("pins the pipeline: CI authority, fix all findings, merge on green", async () => {
+  it("pins the pipeline: CI authority, blocker/medium merge gate, merge on green", async () => {
     const { renderDevProtocolFragment } = await import("./profiles.js");
     const fragment = renderDevProtocolFragment();
     expect(fragment.toLowerCase()).toContain("ci is the full-suite authority");
-    expect(fragment).toContain("Fix ALL findings");
+    expect(fragment).toContain("Blockers and mediums block the merge");
     expect(fragment).toContain("Merge only on CI green");
     expect(fragment.toLowerCase()).toContain("durable fixes over hack patches");
     expect(fragment.toLowerCase()).toContain("outcomes, not just code paths");
+  });
+
+  // Ken 2026-07-26: the old rule ("fix ALL findings including lows, then
+  // re-review the fix") was a loop generator by construction — an
+  // adversarial reviewer always surfaces lows, fixing lows produces a new
+  // diff, and a new diff earned another re-review. These two tests pin the
+  // termination conditions that replaced it: a severity gate, and a
+  // behaviour-scoped re-review trigger.
+  it("bounds the review loop: lows are filed, not merge-blocking", async () => {
+    const { renderDevProtocolFragment } = await import("./profiles.js");
+    const fragment = renderDevProtocolFragment();
+    expect(fragment).toContain("lows don't");
+    expect(fragment.toLowerCase()).toContain("file a follow-up issue and merge");
+    // Tracked, not waived — filing stays mandatory.
+    expect(fragment.toLowerCase()).toContain("filing is mandatory");
+    // The unbounded phrasing must be gone, not merely reworded around it.
+    expect(fragment).not.toContain("Fix ALL findings");
+    expect(fragment).not.toContain("including lows");
+  });
+
+  it("bounds the review loop: re-review only on a behavioural fix", async () => {
+    const { renderDevProtocolFragment } = await import("./profiles.js");
+    const fragment = renderDevProtocolFragment();
+    expect(fragment).toContain("Re-review only a behavioural fix");
+    expect(fragment.toLowerCase()).toContain(
+      "docs/comment/log/test-only commit doesn't earn one",
+    );
+    // Adversarial review itself must survive the change.
+    expect(fragment).toContain("Adversarial review of the diff");
   });
 
   it("pins the communication rules: 30s watch cap and 15 sub-agent cap", async () => {

--- a/tests/review-rounds-gate.test.ts
+++ b/tests/review-rounds-gate.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+// @ts-expect-error — plain .mjs guard script, no types
+import {
+  countReviewRounds,
+  evaluateReviewRounds,
+  parseGitLogZ,
+  REVIEW_ROUND_CAP,
+  OVERRIDE_LABEL,
+} from "../scripts/check-review-rounds.mjs";
+
+/**
+ * The deterministic review-round cap (Ken 2026-07-26).
+ *
+ * The protocol prose now says blockers/mediums block the merge, lows get
+ * filed, and only a behavioural fix earns a re-review. These tests pin the
+ * MECHANISM behind it: a PR that has taken more than two `review-fix:` rounds
+ * fails the gate, and the only thing that clears it is a durable, PR-visible
+ * operator label. Every assertion is on the outcome an engineer sees
+ * (pass/fail + the message), not on a code path being reached.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, "..");
+
+const roundCommit = (n: number) => `review-fix: address review round ${n} findings`;
+
+describe("check-review-rounds — counting", () => {
+  it("counts only commits that answer a review round", () => {
+    const commits = [
+      "feat(review): add the round cap",
+      roundCommit(1),
+      "docs: unrelated tweak",
+      "review-fix(profiles): tighten the fragment",
+      "review-fixture: not a review round", // near-miss must NOT count
+    ];
+    expect(countReviewRounds(commits)).toBe(2);
+  });
+
+  it("counts a commit carrying a Review-Round trailer", () => {
+    expect(
+      countReviewRounds(["fix(gateway): drop the stale guard\n\nReview-Round: 2"]),
+    ).toBe(1);
+  });
+
+  it("does not double-count a commit that has both the prefix and the trailer", () => {
+    expect(countReviewRounds([`${roundCommit(1)}\n\nReview-Round: 1`])).toBe(1);
+  });
+
+  it("parses NUL-separated git log output into whole commit messages", () => {
+    const stdout = `${roundCommit(1)}\n\nbody line\n\0feat: something else\n\0`;
+    expect(parseGitLogZ(stdout)).toEqual([
+      `${roundCommit(1)}\n\nbody line`,
+      "feat: something else",
+    ]);
+  });
+});
+
+describe("check-review-rounds — the gate", () => {
+  it("passes a PR with zero review rounds", () => {
+    const r = evaluateReviewRounds({ commitMessages: ["feat: initial work"] });
+    expect(r.ok).toBe(true);
+    expect(r.rounds).toBe(0);
+  });
+
+  it("passes at the cap (two rounds is normal)", () => {
+    const r = evaluateReviewRounds({
+      commitMessages: ["feat: work", roundCommit(1), roundCommit(2)],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.rounds).toBe(REVIEW_ROUND_CAP);
+  });
+
+  it("FAILS the third round — the loop cannot happen silently", () => {
+    const r = evaluateReviewRounds({
+      commitMessages: [
+        "feat: work",
+        roundCommit(1),
+        roundCommit(2),
+        roundCommit(3),
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.rounds).toBe(3);
+  });
+
+  it("names the cap and the remedy in the failure message", () => {
+    const r = evaluateReviewRounds({
+      commitMessages: [roundCommit(1), roundCommit(2), roundCommit(3)],
+    });
+    expect(r.message).toContain(`the cap is ${REVIEW_ROUND_CAP}`);
+    // The remedy the protocol wants: file the rest, merge.
+    expect(r.message).toContain("file the remaining findings as follow-up issues and merge");
+    expect(r.message).toContain(OVERRIDE_LABEL);
+  });
+
+  it("clears only on the durable operator label, and says it was overridden", () => {
+    const commitMessages = [roundCommit(1), roundCommit(2), roundCommit(3)];
+    expect(evaluateReviewRounds({ commitMessages, labels: ["bug"] }).ok).toBe(false);
+    const overridden = evaluateReviewRounds({
+      commitMessages,
+      labels: ["bug", OVERRIDE_LABEL.toUpperCase()],
+    });
+    expect(overridden.ok).toBe(true);
+    expect(overridden.overridden).toBe(true);
+    expect(overridden.message).toContain("OVERRIDDEN");
+  });
+
+  it("an under-cap PR is never marked overridden even when the label is present", () => {
+    const r = evaluateReviewRounds({
+      commitMessages: [roundCommit(1)],
+      labels: [OVERRIDE_LABEL],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.overridden).toBe(false);
+  });
+});
+
+describe("ci-review-rounds workflow wiring", () => {
+  const wf = parseYaml(
+    readFileSync(join(REPO_ROOT, ".github/workflows/ci-review-rounds.yml"), "utf-8"),
+  ) as Record<string, any>;
+
+  it("runs the gate on PRs, including when a label is added or removed", () => {
+    // `on:` parses as the YAML boolean true — quote-free `on` key.
+    const on = wf.on ?? wf[true as unknown as string];
+    const types: string[] = on.pull_request.types;
+    expect(types).toContain("synchronize");
+    // Without these, adding the override label would need an empty push.
+    expect(types).toContain("labeled");
+    expect(types).toContain("unlabeled");
+  });
+
+  it("invokes the guard script rather than reimplementing the count inline", () => {
+    const run = wf.jobs["review-rounds-run"].steps
+      .map((s: Record<string, unknown>) => String(s.run ?? ""))
+      .join("\n");
+    expect(run).toContain("node scripts/check-review-rounds.mjs");
+  });
+
+  it("never hoists `git log -z` into a shell variable (NUL bytes are dropped there)", () => {
+    // Caught in this PR's own adversarial review: `VAR="$(git log -z …)"`
+    // silently strips the NUL separators, so every commit collapses into one
+    // message and the cap can never trip. The script runs git itself.
+    const run = wf.jobs["review-rounds-run"].steps
+      .map((s: Record<string, unknown>) => String(s.run ?? ""))
+      .join("\n");
+    expect(run).not.toMatch(/\$\(\s*git log/);
+  });
+
+  it("passes the PR range to the script via env, not argv interpolation", () => {
+    const step = wf.jobs["review-rounds-run"].steps.find(
+      (s: Record<string, unknown>) => String(s.run ?? "").includes("check-review-rounds"),
+    );
+    expect(Object.keys(step.env)).toEqual(
+      expect.arrayContaining(["BASE_SHA", "HEAD_SHA", "REVIEW_ROUNDS_LABELS"]),
+    );
+    // No `${{ }}` inside the run body — same rule the release workflows carry.
+    expect(String(step.run)).not.toContain("${{");
+  });
+
+  it("exposes an always-reporting `review-rounds` sentinel that fails on a real failure", () => {
+    const sentinel = wf.jobs["review-rounds"];
+    // `if: always()` so the context is ruleset-required-safe.
+    expect(String(sentinel.if)).toContain("always()");
+    const verdict = sentinel.steps.map((s: Record<string, unknown>) => String(s.run ?? "")).join("\n");
+    expect(verdict).toContain("failure");
+    expect(verdict).toContain("exit 1");
+  });
+});


### PR DESCRIPTION
## Summary

Adversarial review was generating unbounded fix/re-review loops. The rule
`Fix ALL findings — including lows. Then re-review the fix` is a loop
generator by construction: an adversarial reviewer always surfaces lows (that
is its job), fixing lows produces a new diff, and a new diff earned another
re-review. Nothing specified a termination condition, and the cost scaled UP
with reviewer thoroughness. Observed on #3702 (the reviewer's own verdict was
MERGEABLE with "ship and file the lows"; the rule overrode that into an extra
fix round plus a full re-review whose sole finding was an inaccurate doc
comment) and on PRs that ran four rounds.

Three changes:

1. **Severity gates the merge.** Blockers and mediums block; **lows do not**.
   A low is fixed inline only if it is a genuine one-liner, otherwise it is
   filed as a follow-up issue and the PR merges. Filing is mandatory — a low
   is tracked, never waived.
2. **Re-review only a behavioural fix.** A fix commit confined to docs,
   comments, log strings, or tests does not earn another adversarial pass.
3. **A deterministic round cap**, because "deterministic mechanisms over
   model-dependent behavior" applies to this rule too. Commits answering a
   review round are `review-fix:`-prefixed;
   `scripts/check-review-rounds.mjs` counts them straight from git history;
   `ci-review-rounds.yml` fails a third round. The only way past is the
   durable, PR-visible `review-cap-override` label — not a re-run, not a
   self-persuaded exception. The failure message names the cap and the
   remedy ("file the remaining findings as follow-up issues and merge").

Everything that was working is untouched: adversarial review still runs on
every diff, CI green is still the merge gate, tests still assert outcomes not
code paths, root-cause fixes still beat workarounds.

## Where the rule lived

| Location | Change |
|---|---|
| `profiles/_shared/dev-protocol.md.hbs:33-34` | rewritten (this generates every agent's `CLAUDE.md`) |
| `CLAUDE.md:325-332` (repo protocol summary) | rewritten + `review-fix:` convention |
| `skills/dev-protocol/SKILL.md` steps 5-8 | severity field now mandatory per finding; steps 6/7 rewritten; new step 8 = the cap |
| `src/agents/profiles.test.ts` | assertion on the old wording retargeted; 2 new tests pin both termination conditions |
| `.github/MERGE-QUEUE.md` | workflow inventory 14 → 15 |

`~/.switchroom/fleet/CLAUDE.md:47-48` carries the same rule but is **hand-
maintained host state** — `renderFleetDefaultsClaudeMd()`
(`src/agents/fleet-defaults.ts`) seeds that path via `writeIfMissing` and its
canonical text contains no Development Protocol section at all. Same for the
per-turn `<dev-protocol>` UserPromptSubmit hook, which comes from the
operator's `hooks:` block in `~/.switchroom/switchroom.yaml:408-419`, not from
any template here. Both are reported to the operator as manual edits rather
than touched from this PR.

## Test plan

- `tests/review-rounds-gate.test.ts` (15 tests) — counting incl. near-miss
  subjects (`review-fixture:` must not count), pass at 2 rounds, **fail at
  3**, override only via the label, the failure message naming cap + remedy,
  and workflow wiring (labeled/unlabeled triggers, always-reporting sentinel).
- `src/agents/profiles.test.ts` — new tests assert the fragment says lows
  don't block, that filing is mandatory, that re-review is behaviour-scoped,
  and that the unbounded phrasing is *gone* rather than reworded around.
- `tests/scaffold.persona.test.ts` byte ceiling held under 40000 by tightening
  prose, per that test's standing instruction not to paper over a breach with
  a ceiling bump.
- `npm run lint` green.

An adversarial pass on this diff caught one blocker in the mechanism itself:
`VAR="$(git log -z …)"` in the workflow silently drops NUL bytes, collapsing
every commit into one message so the cap could never trip. The script now runs
git itself, and a test pins that the workflow never reintroduces the pattern.

## Risk

Docs-shaped plus one new CI workflow. `ci-review-rounds.yml` is **advisory
until an operator adds `review-rounds` to ruleset 16470166** (exact command in
the workflow header; verified live that the 7 current contexts all use
`integration_id: 15368`) — `gh pr merge --auto --squash` does not wait on a
non-required check.

Honest limit: the count's input is a commit-message convention written by the
agent under review, so an unprefixed fix commit undercounts. That is a
protocol violation, not a supported bypass — once a round is recorded, no
amount of self-persuasion clears it.

Job spec: `reference/jobs/feel-like-a-colleague.md` — a colleague ships when
the work is done and files the nits instead of relitigating its own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
